### PR TITLE
Immutable stream identity: signed stream binding, stream-scoped op-log store, fork quarantine (phase B S2)

### DIFF
--- a/crates/rag-rat-core/src/index/schema/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema/migrations.rs
@@ -1187,6 +1187,7 @@ pub(crate) fn known_version(migrations: &[AppliedMigration]) -> u32 {
             MIGRATION_050_ID => Some(50),
             MIGRATION_051_ID => Some(51),
             MIGRATION_052_ID => Some(52),
+            MIGRATION_053_ID => Some(53),
             _ => None,
         })
         .max()
@@ -1248,6 +1249,7 @@ pub(crate) fn known_migration(id: &str) -> bool {
             | MIGRATION_050_ID
             | MIGRATION_051_ID
             | MIGRATION_052_ID
+            | MIGRATION_053_ID
             | DIRTY_MIGRATION_ID
     )
 }
@@ -1306,6 +1308,7 @@ pub(crate) fn migration_checksum_mismatch(migration: &AppliedMigration) -> bool 
         MIGRATION_050_ID => migration.checksum != MIGRATION_050_CHECKSUM,
         MIGRATION_051_ID => migration.checksum != MIGRATION_051_CHECKSUM,
         MIGRATION_052_ID => migration.checksum != MIGRATION_052_CHECKSUM,
+        MIGRATION_053_ID => migration.checksum != MIGRATION_053_CHECKSUM,
         _ => false,
     }
 }
@@ -3579,6 +3582,71 @@ pub(crate) fn apply_oplog_storage(conn: &Connection) -> rusqlite::Result<()> {
              key   TEXT PRIMARY KEY,
              value TEXT NOT NULL
          ) STRICT;",
+    )?;
+    Ok(())
+}
+
+/// V053 (#509): scope the op-log by immutable stream identity. One signed chain, watermark, and
+/// projection exists per `(stream_id, device)`, so the V052 tables gain a `stream_id` dimension:
+/// `UNIQUE(stream_id, device_fingerprint, lamport)` pins each device's chain as strictly linear
+/// PER STREAM, and the shadow-projection tables key on `(stream_id, node_id / edge_key)` so a
+/// re-fold of one stream never touches another's rows. `oplog_fork_evidence` is new — the
+/// quarantine that durably preserves BOTH heads of a detected equivocation (the store previously
+/// only RETURNED the colliding entry to the caller); `signed_bytes` is the rejected head verbatim,
+/// `conflicting_entry_hash` points at the stored entry it collided with.
+///
+/// INVARIANT: this is a DROP + CREATE rebuild, which is safe ONLY because nothing writes the
+/// op-log tables yet (the module is un-wired until the write-path increment, so every database's
+/// copies are empty — there is no data to preserve). Once the log is wired, a re-shape must use a
+/// data-preserving recipe instead. `oplog_meta` is left untouched (its projector-version stamp is
+/// not stream-scoped). Idempotent (a replay rebuilds the same empty tables); the self-wrapped
+/// IMMEDIATE transaction makes an interrupted rebuild reconverge on the next run.
+pub(crate) fn apply_oplog_stream_scoping(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "BEGIN IMMEDIATE;
+
+         DROP TABLE IF EXISTS oplog_entries;
+         CREATE TABLE oplog_entries(
+             entry_hash         BLOB PRIMARY KEY,
+             stream_id          BLOB NOT NULL,
+             device_fingerprint BLOB NOT NULL,
+             lamport            INTEGER NOT NULL,
+             prev_hash          BLOB,
+             signed_bytes       BLOB NOT NULL,
+             received_at_ms     INTEGER NOT NULL,
+             UNIQUE(stream_id, device_fingerprint, lamport)
+         ) STRICT;
+
+         DROP TABLE IF EXISTS oplog_projected_nodes;
+         CREATE TABLE oplog_projected_nodes(
+             stream_id    BLOB NOT NULL,
+             node_id      TEXT NOT NULL,
+             content_json TEXT NOT NULL,
+             status       TEXT NOT NULL,
+             PRIMARY KEY(stream_id, node_id)
+         ) STRICT;
+
+         DROP TABLE IF EXISTS oplog_projected_edges;
+         CREATE TABLE oplog_projected_edges(
+             stream_id     BLOB NOT NULL,
+             edge_key      TEXT NOT NULL,
+             spec_json     TEXT NOT NULL,
+             resolved_json TEXT,
+             PRIMARY KEY(stream_id, edge_key)
+         ) STRICT;
+
+         CREATE TABLE IF NOT EXISTS oplog_fork_evidence(
+             stream_id              BLOB NOT NULL,
+             entry_hash             BLOB NOT NULL,
+             device_fingerprint     BLOB NOT NULL,
+             lamport                INTEGER NOT NULL,
+             signed_bytes           BLOB NOT NULL,
+             conflicting_entry_hash BLOB,
+             observed_at_ms         INTEGER NOT NULL,
+             PRIMARY KEY(stream_id, entry_hash)
+         ) STRICT;
+
+         COMMIT;",
     )?;
     Ok(())
 }

--- a/crates/rag-rat-core/src/index/schema/mod.rs
+++ b/crates/rag-rat-core/src/index/schema/mod.rs
@@ -19,7 +19,7 @@ pub use registry::{LEGACY_REPO_ID, register_repo, register_repo_read_only};
 use rusqlite::{Connection, OptionalExtension, params};
 use serde::Serialize;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 52;
+pub const LATEST_SCHEMA_VERSION: u32 = 53;
 
 /// Every oracle-DERIVED persisted table — the outputs an `oracle run` writes that must OUTLIVE a
 /// reindex.
@@ -358,6 +358,14 @@ const MIGRATION_052_DESCRIPTION: &str =
      signed entry log, content-addressed on entry_hash, no FK; and the layer-2 shadow projection \
      (oplog_projected_nodes / oplog_projected_edges) plus oplog_meta, wholly rebuilt by the \
      full-replay fold. Fresh tables (no backfill); nothing is wired to the live write path yet";
+const MIGRATION_053_ID: &str = "053_oplog_stream_scoping";
+const MIGRATION_053_CHECKSUM: &str = "sha256:rag-rat-oplog-stream-scoping-v53";
+const MIGRATION_053_DESCRIPTION: &str =
+    "Scope the op-log by immutable stream identity (#509): rebuild the still-unwired (and \
+     therefore empty) V052 op-log tables with a stream_id dimension — one signed chain per \
+     (stream_id, device), UNIQUE(stream_id, device_fingerprint, lamport), projection keyed per \
+     stream — and add oplog_fork_evidence, the quarantine that durably preserves BOTH heads of a \
+     detected equivocation. Nothing is wired to the live write path yet";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -811,6 +819,12 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         checksum: MIGRATION_052_CHECKSUM,
         description: MIGRATION_052_DESCRIPTION,
         apply: apply_oplog_storage,
+    },
+    Migration {
+        id: MIGRATION_053_ID,
+        checksum: MIGRATION_053_CHECKSUM,
+        description: MIGRATION_053_DESCRIPTION,
+        apply: apply_oplog_stream_scoping,
     },
 ];
 

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
@@ -1372,10 +1372,13 @@ fn migration_052_adds_oplog_storage_tables() {
         ["oplog_entries", "oplog_projected_nodes", "oplog_projected_edges", "oplog_meta"];
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     schema::apply(&conn).unwrap();
-    // V052 is the schema tip — the absolute pin (migration_051's drops to the symbolic
-    // `current_version == LATEST` check when a V053 lands).
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 52, "V052 is the schema tip");
-    assert_eq!(schema::status(&conn).unwrap().current_version, 52, "schema at LATEST after apply");
+    // V053 now holds the absolute tip pin (migration_053's test); this drops to the symbolic
+    // `current_version == LATEST` freshness check.
+    assert_eq!(
+        schema::status(&conn).unwrap().current_version,
+        schema::LATEST_SCHEMA_VERSION,
+        "schema at LATEST after apply"
+    );
     for table in OPLOG_TABLES {
         assert!(conn_table_exists(&conn, table), "V052 creates {table}");
     }
@@ -1396,6 +1399,69 @@ fn migration_052_adds_oplog_storage_tables() {
     for table in OPLOG_TABLES {
         assert!(conn_table_exists(&conn, table), "the isolated applier recreates {table}");
     }
+}
+
+#[test]
+fn migration_053_scopes_the_oplog_by_stream_and_adds_fork_evidence() {
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn).unwrap();
+    // V053 is the schema tip — the absolute pin (migration_052's drops to the symbolic
+    // `current_version == LATEST` check when a V054 lands).
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 53, "V053 is the schema tip");
+    assert_eq!(schema::status(&conn).unwrap().current_version, 53, "schema at LATEST after apply");
+
+    // The rebuilt tables carry the stream dimension; the quarantine table exists.
+    for (table, column) in [
+        ("oplog_entries", "stream_id"),
+        ("oplog_projected_nodes", "stream_id"),
+        ("oplog_projected_edges", "stream_id"),
+        ("oplog_fork_evidence", "conflicting_entry_hash"),
+    ] {
+        assert!(
+            conn_table_columns(&conn, table).contains(&column.to_string()),
+            "V053 gives {table} its {column} column"
+        );
+    }
+
+    // One chain slot per (stream, device, lamport): the same (device, lamport) is legal on two
+    // DIFFERENT streams, and an equivocation within one stream trips the UNIQUE tripwire.
+    conn.execute_batch(
+        "INSERT INTO oplog_entries VALUES (x'01', x'aa', x'dd', 1, NULL, x'00', 0);
+         INSERT INTO oplog_entries VALUES (x'02', x'bb', x'dd', 1, NULL, x'00', 0);",
+    )
+    .expect("the same (device, lamport) slot on two streams is two distinct chains");
+    assert!(
+        conn.execute(
+            "INSERT INTO oplog_entries VALUES (x'03', x'aa', x'dd', 1, NULL, x'00', 0)",
+            [],
+        )
+        .is_err(),
+        "UNIQUE(stream_id, device_fingerprint, lamport) rejects a same-stream slot collision"
+    );
+
+    // Deferred-absence in ISOLATION: reduce the tables to the V052 shape (no stream_id, no
+    // quarantine) and re-run the applier alone — it rebuilds the stream-scoped shape, and a
+    // replay reconverges (the rebuild is safe precisely because the log is un-wired and empty;
+    // see the applier's invariant comment).
+    conn.execute_batch(
+        "DROP TABLE oplog_entries;
+         DROP TABLE oplog_projected_nodes;
+         DROP TABLE oplog_projected_edges;
+         DROP TABLE oplog_fork_evidence;
+         CREATE TABLE oplog_entries(entry_hash BLOB PRIMARY KEY) STRICT;",
+    )
+    .unwrap();
+    schema::apply_oplog_stream_scoping(&conn).unwrap();
+    schema::apply_oplog_stream_scoping(&conn).expect("replay reconverges");
+    for table in
+        ["oplog_entries", "oplog_projected_nodes", "oplog_projected_edges", "oplog_fork_evidence"]
+    {
+        assert!(
+            conn_table_columns(&conn, table).contains(&"stream_id".to_string()),
+            "the isolated applier rebuilds {table} stream-scoped"
+        );
+    }
+    assert!(conn_table_exists(&conn, "oplog_meta"), "oplog_meta is left untouched");
 }
 
 #[test]

--- a/crates/rag-rat-core/src/oplog/entry.rs
+++ b/crates/rag-rat-core/src/oplog/entry.rs
@@ -1,28 +1,34 @@
-//! The signed, hash-chained op-log entry envelope (phase B op-log, §C4 layer-1).
+//! The signed, hash-chained op-log entry envelope (phase B op-log, layer 1).
 //!
-//! Wraps an opaque op ([`super::op`]) in a per-device, append-only signed log. Two domain-tagged
-//! canonical CBOR objects, both DEFINITE-length + minimal-header (the same discipline `super::op`
-//! and `super::cbor` enforce):
+//! Wraps an opaque op ([`super::op`]) in a per-`(stream, device)`, append-only signed log. Two
+//! domain-tagged canonical CBOR objects, both DEFINITE-length + minimal-header (the same
+//! discipline `super::op` and `super::cbor` enforce):
 //!
 //! ```text
-//! body_bytes   = cbor([ "rag-rat/entry/1", prev_hash, lamport, device_fingerprint, op_bytes ])
+//! body_bytes   = cbor([ "rag-rat/entry/2", stream_id, prev_hash, lamport, device_fingerprint,
+//!                       op_bytes ])
 //! signed_bytes = cbor([ "rag-rat/signed-entry/1", body_bytes (bstr), signature (64-byte bstr) ])
 //! ```
 //!
+//! - `stream_id` is the immutable identity of the stream this entry belongs to (32-byte bstr,
+//!   [`super::stream`], #509). It lives INSIDE the signed body so stream membership is
+//!   signature-protected: a signed entry cannot be replayed from one stream into another (which
+//!   would let a peer/relay contaminate a filtered view with another view's chains).
 //! - `prev_hash` is the previous entry's `entry_hash` (32-byte bstr), or CBOR `null` for the
-//!   genesis (first) entry — the hash-chain link.
+//!   genesis (first) entry — the hash-chain link. Chains are per `(stream_id, device)`.
 //! - `op_bytes` = `op::encode(op)`, carried as an opaque bstr. Layer-1 forwards op bytes verbatim:
-//!   an UNKNOWN op still signs, verifies, and chains (§5.4) — verification NEVER requires
-//!   `op::decode` to succeed.
-//! - `entry_hash = sha256(body_bytes)` — the chain link + content address (§5.6 watermark `(seq,
-//!   entry_hash)`).
+//!   an UNKNOWN op still signs, verifies, and chains — verification NEVER requires `op::decode` to
+//!   succeed.
+//! - `entry_hash = sha256(body_bytes)` — the chain link + content address (the `(seq, entry_hash)`
+//!   watermark primitive). Because the body folds `stream_id`, entry hashes are globally unique
+//!   across streams.
 //!
 //! **The signature covers exactly `body_bytes`** — the canonical CBOR of
-//! `[domain, prev_hash, lamport, device_fingerprint, op_bytes]`, and nothing else. `signed_bytes`
-//! (the outer envelope) is NOT signed; it is the transport form bundling the signed body with its
-//! signature. This is the security boundary: a byte that is not inside `body_bytes` is not
-//! protected by the signature, and the canonical rule guarantees the SAME logical body has exactly
-//! one signed encoding.
+//! `[domain, stream_id, prev_hash, lamport, device_fingerprint, op_bytes]`, and nothing else.
+//! `signed_bytes` (the outer envelope) is NOT signed; it is the transport form bundling the signed
+//! body with its signature. This is the security boundary: a byte that is not inside `body_bytes`
+//! is not protected by the signature, and the canonical rule guarantees the SAME logical body has
+//! exactly one signed encoding.
 
 use anyhow::Context;
 use minicbor::Encoder;
@@ -33,11 +39,12 @@ use sha2::{Digest, Sha256};
 use super::cbor;
 use super::device::{DevicePublic, DeviceSecret};
 use super::op::{self, DeviceFingerprint, MemoryOp};
+use super::stream::StreamId;
 
 /// Domain tag + version for the signed BODY (the bytes the signature covers). Bump the version to
 /// evolve the entry wire deliberately — an old binary then rejects the new domain rather than
-/// misreading it.
-const ENTRY_DOMAIN: &str = "rag-rat/entry/1";
+/// misreading it. (`/2` added the in-body `stream_id`; `/1` never shipped and has no decoder.)
+const ENTRY_DOMAIN: &str = "rag-rat/entry/2";
 
 /// Domain tag + version for the outer transport envelope (body + signature).
 const SIGNED_DOMAIN: &str = "rag-rat/signed-entry/1";
@@ -51,6 +58,8 @@ const INFALLIBLE: &str = "encoding CBOR to a Vec is infallible";
 /// projection actually needs it.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct VerifiedEntry {
+    /// The stream this entry belongs to — signature-protected, so it cannot be re-homed.
+    pub(super) stream_id: StreamId,
     /// The previous entry's `entry_hash`, or `None` for the genesis entry.
     pub(super) prev_hash: Option<[u8; 32]>,
     pub(super) lamport: u64,
@@ -73,8 +82,9 @@ pub(super) struct SignedEntry {
 }
 
 /// The pieces of one entry body, grouped so the encoder takes a single named argument rather than a
-/// four-primitive train (two of which are 32-byte arrays that are easy to transpose).
+/// five-primitive train (three of which are 32-byte arrays that are easy to transpose).
 struct BodyParts<'a> {
+    stream_id: StreamId,
     prev_hash: Option<[u8; 32]>,
     lamport: u64,
     device_fingerprint: DeviceFingerprint,
@@ -86,19 +96,32 @@ struct BodyParts<'a> {
 /// deterministic).
 pub(super) fn sign_entry(
     secret: &DeviceSecret,
+    stream_id: StreamId,
     prev_hash: Option<[u8; 32]>,
     lamport: u64,
     op: &MemoryOp,
 ) -> SignedEntry {
     let device_fingerprint = secret.public().fingerprint();
     let op_bytes = op::encode(op);
-    let body_bytes =
-        encode_body(&BodyParts { prev_hash, lamport, device_fingerprint, op_bytes: &op_bytes });
+    let body_bytes = encode_body(&BodyParts {
+        stream_id,
+        prev_hash,
+        lamport,
+        device_fingerprint,
+        op_bytes: &op_bytes,
+    });
     let entry_hash = sha256(&body_bytes);
     let signature = secret.sign(&body_bytes);
     let signed_bytes = encode_signed(&body_bytes, &signature);
     SignedEntry {
-        entry: VerifiedEntry { prev_hash, lamport, device_fingerprint, op_bytes, entry_hash },
+        entry: VerifiedEntry {
+            stream_id,
+            prev_hash,
+            lamport,
+            device_fingerprint,
+            op_bytes,
+            entry_hash,
+        },
         signature,
         body_bytes,
         signed_bytes,
@@ -112,18 +135,31 @@ pub(super) fn sign_entry(
 #[cfg(test)]
 pub(super) fn sign_entry_from_op_bytes(
     secret: &DeviceSecret,
+    stream_id: StreamId,
     prev_hash: Option<[u8; 32]>,
     lamport: u64,
     op_bytes: Vec<u8>,
 ) -> SignedEntry {
     let device_fingerprint = secret.public().fingerprint();
-    let body_bytes =
-        encode_body(&BodyParts { prev_hash, lamport, device_fingerprint, op_bytes: &op_bytes });
+    let body_bytes = encode_body(&BodyParts {
+        stream_id,
+        prev_hash,
+        lamport,
+        device_fingerprint,
+        op_bytes: &op_bytes,
+    });
     let entry_hash = sha256(&body_bytes);
     let signature = secret.sign(&body_bytes);
     let signed_bytes = encode_signed(&body_bytes, &signature);
     SignedEntry {
-        entry: VerifiedEntry { prev_hash, lamport, device_fingerprint, op_bytes, entry_hash },
+        entry: VerifiedEntry {
+            stream_id,
+            prev_hash,
+            lamport,
+            device_fingerprint,
+            op_bytes,
+            entry_hash,
+        },
         signature,
         body_bytes,
         signed_bytes,
@@ -152,10 +188,11 @@ pub(super) fn verify_signed(bytes: &[u8], pubkey: &DevicePublic) -> anyhow::Resu
     Ok(signed.entry)
 }
 
-/// Verify a SINGLE device's append-only chain under `pubkey`: genesis `prev_hash == None`, each
-/// subsequent `prev_hash == previous.entry_hash`, STRICTLY increasing `lamport`, and every
-/// signature valid (re-checked from `signed_bytes`, not trusted from the struct's cached fields).
-/// Cross-device merge is the fold (`super::project`), never here.
+/// Verify a SINGLE device's append-only chain under `pubkey`: one `stream_id` throughout (a chain
+/// is per `(stream, device)` — a spliced-in foreign-stream entry must not read as continuity),
+/// genesis `prev_hash == None`, each subsequent `prev_hash == previous.entry_hash`, STRICTLY
+/// increasing `lamport`, and every signature valid (re-checked from `signed_bytes`, not trusted
+/// from the struct's cached fields). Cross-device merge is the fold (`super::project`), never here.
 pub(super) fn verify_chain(entries: &[SignedEntry], pubkey: &DevicePublic) -> anyhow::Result<()> {
     let mut prev: Option<VerifiedEntry> = None;
     for (idx, signed) in entries.iter().enumerate() {
@@ -169,6 +206,9 @@ pub(super) fn verify_chain(entries: &[SignedEntry], pubkey: &DevicePublic) -> an
                     anyhow::bail!("genesis entry {idx} must have prev_hash == None");
                 },
             Some(previous) => {
+                if verified.stream_id != previous.stream_id {
+                    anyhow::bail!("entry {idx} belongs to a different stream than the chain");
+                }
                 if verified.prev_hash != Some(previous.entry_hash) {
                     anyhow::bail!("entry {idx} prev_hash does not link to the previous entry_hash");
                 }
@@ -186,14 +226,16 @@ pub(super) fn verify_chain(entries: &[SignedEntry], pubkey: &DevicePublic) -> an
     Ok(())
 }
 
-/// Encode the signed body: `[domain, prev_hash | null, lamport, device_fingerprint, op_bytes]`,
-/// definite lengths + minimal headers. THESE are the bytes the signature and `entry_hash` cover.
+/// Encode the signed body: `[domain, stream_id, prev_hash | null, lamport, device_fingerprint,
+/// op_bytes]`, definite lengths + minimal headers. THESE are the bytes the signature and
+/// `entry_hash` cover.
 fn encode_body(parts: &BodyParts<'_>) -> Vec<u8> {
-    let mut buf = Vec::with_capacity(96);
+    let mut buf = Vec::with_capacity(128);
     {
         let mut enc = Encoder::new(&mut buf);
-        enc.array(5).expect(INFALLIBLE);
+        enc.array(6).expect(INFALLIBLE);
         enc.str(ENTRY_DOMAIN).expect(INFALLIBLE);
+        enc.bytes(&parts.stream_id.to_bytes()).expect(INFALLIBLE);
         match parts.prev_hash {
             // A 32-byte bstr for a linked entry, CBOR null for the genesis — an unambiguous,
             // distinct "no predecessor" marker (not an all-zero hash).
@@ -239,15 +281,16 @@ fn decode_body(body_bytes: &[u8]) -> Result<VerifiedEntry, CborError> {
     // — layer-1 does NOT require the op to be a recognizable / canonical op here).
     cbor::require_canonical_cbor(body_bytes)?;
     let mut d = Decoder::new(body_bytes);
-    cbor::expect_array(&mut d, 5)?;
+    cbor::expect_array(&mut d, 6)?;
     expect_domain(&mut d, ENTRY_DOMAIN)?;
+    let stream_id = StreamId::from_bytes(fixed_bytes::<32>(d.bytes()?, "stream_id")?);
     let prev_hash = decode_prev_hash(&mut d)?;
     let lamport = d.u64()?;
     let device_fingerprint =
         DeviceFingerprint::from_bytes(fixed_bytes::<32>(d.bytes()?, "device fingerprint")?);
     let op_bytes = d.bytes()?.to_vec();
     let entry_hash = sha256(body_bytes);
-    Ok(VerifiedEntry { prev_hash, lamport, device_fingerprint, op_bytes, entry_hash })
+    Ok(VerifiedEntry { stream_id, prev_hash, lamport, device_fingerprint, op_bytes, entry_hash })
 }
 
 /// Read the leading domain string and assert it matches `want` — a wrong/absent tag is a foreign or
@@ -298,6 +341,11 @@ mod tests {
         DeviceSecret::from_seed(&[7u8; 32])
     }
 
+    /// A fixed stream identity for wire fixtures — deterministic and visually distinctive.
+    fn stream() -> StreamId {
+        StreamId::from_bytes([3u8; 32])
+    }
+
     /// A representative content op for round-trip / tamper tests.
     fn node_create() -> MemoryOp {
         MemoryOp::NodeCreate {
@@ -318,18 +366,18 @@ mod tests {
     fn golden_vectors_pin_the_entry_wire_format() {
         // The entry wire is a frozen primitive: the signature, `entry_hash`, and the chain all
         // build on these exact bytes. A canonical-rule change must break this test and
-        // force a deliberate `rag-rat/entry/1` / `rag-rat/signed-entry/1` domain bump.
-        // Fixture: genesis Snapshot, lamport 1, seed [7; 32] — fully deterministic (ed25519
-        // signing is deterministic).
-        let signed = sign_entry(&secret(), None, 1, &MemoryOp::Snapshot);
+        // force a deliberate domain bump (as adding `stream_id` bumped `/1` to `/2`).
+        // Fixture: genesis Snapshot on stream [3; 32], lamport 1, seed [7; 32] — fully
+        // deterministic (ed25519 signing is deterministic).
+        let signed = sign_entry(&secret(), stream(), None, 1, &MemoryOp::Snapshot);
         assert_eq!(
             hex(&signed.body_bytes),
-            "856f7261672d7261742f656e7472792f31f6015820fe812c12f3ab4ce6ac5db69ac352f906cb1b11ef43fb33e252ef7ff5522638895818836c7261672d7261742f6f702f3168736e617073686f74f6",
+            "866f7261672d7261742f656e7472792f3258200303030303030303030303030303030303030303030303030303030303030303f6015820fe812c12f3ab4ce6ac5db69ac352f906cb1b11ef43fb33e252ef7ff5522638895818836c7261672d7261742f6f702f3168736e617073686f74f6",
             "body_bytes golden",
         );
         assert_eq!(
             hex(&signed.signed_bytes),
-            "83767261672d7261742f7369676e65642d656e7472792f31584f856f7261672d7261742f656e7472792f31f6015820fe812c12f3ab4ce6ac5db69ac352f906cb1b11ef43fb33e252ef7ff5522638895818836c7261672d7261742f6f702f3168736e617073686f74f658402d6c805bb70968fdfb32ecf19fdbbbccdc2130dad9b067b25c9782824c1dceb0ec5c03c7090bc786bad56ad3e05f8b0ad0129ffb699cf2bcc4d56b63c5b24800",
+            "83767261672d7261742f7369676e65642d656e7472792f315871866f7261672d7261742f656e7472792f3258200303030303030303030303030303030303030303030303030303030303030303f6015820fe812c12f3ab4ce6ac5db69ac352f906cb1b11ef43fb33e252ef7ff5522638895818836c7261672d7261742f6f702f3168736e617073686f74f658400aab0cf060dd7eee539e0e84c48fdf5be81eaba1ece62324a513cd6adc5a29e508c275dd0b4a4d2030254375a62ee171527e562136102e702c40924d7488a504",
             "signed_bytes golden",
         );
     }
@@ -338,51 +386,54 @@ mod tests {
     fn body_bytes_has_the_expected_canonical_structure() {
         // Structure-level proof (independent of the opaque fingerprint / signature bytes) that the
         // encoder emits the frozen shape the golden vector pins.
-        let signed = sign_entry(&secret(), None, 1, &MemoryOp::Snapshot);
+        let signed = sign_entry(&secret(), stream(), None, 1, &MemoryOp::Snapshot);
         let body = &signed.body_bytes;
-        assert_eq!(body[0], 0x85, "5-element array header");
+        assert_eq!(body[0], 0x86, "6-element array header");
         assert_eq!(body[1], 0x6f, "text header, len 15");
-        assert_eq!(&body[2..17], b"rag-rat/entry/1");
-        assert_eq!(body[17], 0xf6, "genesis prev_hash is CBOR null");
-        assert_eq!(body[18], 0x01, "lamport 1, minimal uint");
-        assert_eq!(&body[19..21], &[0x58, 0x20], "device_fp bstr header, len 32");
+        assert_eq!(&body[2..17], b"rag-rat/entry/2");
+        assert_eq!(&body[17..19], &[0x58, 0x20], "stream_id bstr header, len 32");
+        assert_eq!(&body[19..51], &stream().to_bytes(), "stream_id bytes");
+        assert_eq!(body[51], 0xf6, "genesis prev_hash is CBOR null");
+        assert_eq!(body[52], 0x01, "lamport 1, minimal uint");
+        assert_eq!(&body[53..55], &[0x58, 0x20], "device_fp bstr header, len 32");
         assert_eq!(
-            &body[21..53],
+            &body[55..87],
             &secret().public().fingerprint().to_bytes(),
             "device_fp bytes == sha256(pubkey)",
         );
-        assert_eq!(&body[53..55], &[0x58, 0x18], "op_bytes bstr header, len 24");
-        assert_eq!(&body[55..], &op::encode(&MemoryOp::Snapshot), "op_bytes == op::encode");
-        assert_eq!(body.len(), 79);
+        assert_eq!(&body[87..89], &[0x58, 0x18], "op_bytes bstr header, len 24");
+        assert_eq!(&body[89..], &op::encode(&MemoryOp::Snapshot), "op_bytes == op::encode");
+        assert_eq!(body.len(), 113);
     }
 
     #[test]
     fn signed_bytes_has_the_expected_canonical_structure() {
-        let signed = sign_entry(&secret(), None, 1, &MemoryOp::Snapshot);
+        let signed = sign_entry(&secret(), stream(), None, 1, &MemoryOp::Snapshot);
         let wire = &signed.signed_bytes;
         assert_eq!(wire[0], 0x83, "3-element array header");
         assert_eq!(wire[1], 0x76, "text header, len 22");
         assert_eq!(&wire[2..24], b"rag-rat/signed-entry/1");
-        assert_eq!(&wire[24..26], &[0x58, 0x4f], "body bstr header, len 79");
-        assert_eq!(&wire[26..105], signed.body_bytes.as_slice());
-        assert_eq!(&wire[105..107], &[0x58, 0x40], "signature bstr header, len 64");
-        assert_eq!(&wire[107..171], &signed.signature);
-        assert_eq!(wire.len(), 171);
+        assert_eq!(&wire[24..26], &[0x58, 0x71], "body bstr header, len 113");
+        assert_eq!(&wire[26..139], signed.body_bytes.as_slice());
+        assert_eq!(&wire[139..141], &[0x58, 0x40], "signature bstr header, len 64");
+        assert_eq!(&wire[141..205], &signed.signature);
+        assert_eq!(wire.len(), 205);
     }
 
     #[test]
     fn entry_hash_is_sha256_of_the_body() {
-        let signed = sign_entry(&secret(), None, 1, &MemoryOp::Snapshot);
+        let signed = sign_entry(&secret(), stream(), None, 1, &MemoryOp::Snapshot);
         assert_eq!(signed.entry.entry_hash, sha256(&signed.body_bytes));
     }
 
     #[test]
     fn genesis_round_trips_through_verify() {
         let secret = secret();
-        let signed = sign_entry(&secret, None, 1, &node_create());
+        let signed = sign_entry(&secret, stream(), None, 1, &node_create());
         let verified = verify_signed(&signed.signed_bytes, &secret.public()).expect("verifies");
         assert_eq!(verified, signed.entry);
         assert_eq!(verified.prev_hash, None);
+        assert_eq!(verified.stream_id, stream());
         // decode_signed alone (no signature check) yields the same structure.
         assert_eq!(decode_signed(&signed.signed_bytes).unwrap().entry, signed.entry);
     }
@@ -390,8 +441,9 @@ mod tests {
     #[test]
     fn non_genesis_round_trips_through_verify() {
         let secret = secret();
-        let genesis = sign_entry(&secret, None, 1, &MemoryOp::Snapshot);
-        let second = sign_entry(&secret, Some(genesis.entry.entry_hash), 2, &node_create());
+        let genesis = sign_entry(&secret, stream(), None, 1, &MemoryOp::Snapshot);
+        let second =
+            sign_entry(&secret, stream(), Some(genesis.entry.entry_hash), 2, &node_create());
         let verified = verify_signed(&second.signed_bytes, &secret.public()).expect("verifies");
         assert_eq!(verified.prev_hash, Some(genesis.entry.entry_hash));
         assert_eq!(verified.lamport, 2);
@@ -399,7 +451,7 @@ mod tests {
 
     #[test]
     fn verify_rejects_the_wrong_key() {
-        let signed = sign_entry(&secret(), None, 1, &MemoryOp::Snapshot);
+        let signed = sign_entry(&secret(), stream(), None, 1, &MemoryOp::Snapshot);
         let wrong = DeviceSecret::from_seed(&[9u8; 32]).public();
         assert!(
             verify_signed(&signed.signed_bytes, &wrong).is_err(),
@@ -417,6 +469,7 @@ mod tests {
         let public_b = DeviceSecret::from_seed(&[9u8; 32]).public();
         let op_bytes = op::encode(&MemoryOp::Snapshot);
         let forged_body = encode_body(&BodyParts {
+            stream_id: stream(),
             prev_hash: None,
             lamport: 1,
             device_fingerprint: public_b.fingerprint(),
@@ -433,7 +486,7 @@ mod tests {
     /// Flip one byte at `index` of an otherwise-valid signed entry and assert verification fails.
     fn assert_tamper_rejected(index: usize, label: &str) {
         let secret = secret();
-        let signed = sign_entry(&secret, Some([0x11; 32]), 5, &node_create());
+        let signed = sign_entry(&secret, stream(), Some([0x11; 32]), 5, &node_create());
         let mut wire = signed.signed_bytes.clone();
         wire[index] ^= 0x01;
         assert!(
@@ -445,24 +498,26 @@ mod tests {
     #[test]
     fn tampering_any_signed_field_is_rejected() {
         // Locate each field inside the fixture's wire and flip a byte within it. Layout (a
-        // non-genesis node_create entry): outer [0x83, 0x76, 22-byte domain, 0x58 0x4f, body(79+),
-        // 0x58 0x40, sig(64)]; body [0x85, 0x6f, 15-byte domain, 0x58 0x20 prev_hash(32), lamport,
-        // 0x58 0x20 device_fp(32), 0x58 .. op_bytes(..)].
+        // non-genesis node_create entry): outer [0x83, 0x76, 22-byte domain, 0x58 len, body,
+        // 0x58 0x40, sig(64)]; body [0x86, 0x6f, 15-byte domain, 0x58 0x20 stream_id(32),
+        // 0x58 0x20 prev_hash(32), lamport, 0x58 0x20 device_fp(32), 0x58 .. op_bytes(..)].
         let secret = secret();
-        let signed = sign_entry(&secret, Some([0x11; 32]), 5, &node_create());
+        let signed = sign_entry(&secret, stream(), Some([0x11; 32]), 5, &node_create());
         let wire = &signed.signed_bytes;
         // Body starts after outer header [0x83, 0x76, 22 domain bytes, 0x58, len] = 2 + 22 + 2 =
         // 26.
         let body_start = 26;
-        // Within the body: [0]=array, [1..17)=domain(0x6f+15), [17]=0x58,[18]=0x20 prev_hash
-        // header, prev_hash = [19..51), lamport at 51 (5 → 0x05), device_fp header [52,53],
-        // fp [54..86), op header at 86, op_bytes after.
-        let prev_hash_byte = body_start + 19; // inside the 32-byte prev_hash
-        let lamport_byte = body_start + 51; // the lamport uint
-        let device_fp_byte = body_start + 54; // inside the 32-byte device_fp
-        let op_byte = body_start + 88; // inside op_bytes
+        // Within the body: [0]=array, [1..17)=domain(0x6f+15), stream_id header [17,18],
+        // stream_id = [19..51), prev_hash header [51,52], prev_hash = [53..85), lamport at 85
+        // (5 → 0x05), device_fp header [86,87], fp [88..120), op header at 120, op_bytes after.
+        let stream_byte = body_start + 19; // inside the 32-byte stream_id
+        let prev_hash_byte = body_start + 53; // inside the 32-byte prev_hash
+        let lamport_byte = body_start + 85; // the lamport uint
+        let device_fp_byte = body_start + 88; // inside the 32-byte device_fp
+        let op_byte = body_start + 122; // inside op_bytes
         let signature_byte = wire.len() - 1; // last signature byte
         for (index, label) in [
+            (stream_byte, "stream_id"),
             (prev_hash_byte, "prev_hash"),
             (lamport_byte, "lamport"),
             (device_fp_byte, "device_fingerprint"),
@@ -475,7 +530,7 @@ mod tests {
 
     #[test]
     fn trailing_bytes_are_rejected() {
-        let signed = sign_entry(&secret(), None, 1, &MemoryOp::Snapshot);
+        let signed = sign_entry(&secret(), stream(), None, 1, &MemoryOp::Snapshot);
         let mut wire = signed.signed_bytes.clone();
         wire.push(0x00);
         assert!(decode_signed(&wire).is_err(), "trailing bytes after the wire are rejected");
@@ -488,16 +543,17 @@ mod tests {
         let secret = secret();
         let op_bytes = op::encode(&MemoryOp::Snapshot);
         let good = encode_body(&BodyParts {
+            stream_id: stream(),
             prev_hash: None,
             lamport: 1,
             device_fingerprint: secret.public().fingerprint(),
             op_bytes: &op_bytes,
         });
-        // good[18] is the minimal lamport uint (0x01). Splice a non-minimal 8-byte header for 1.
-        assert_eq!(good[18], 0x01);
-        let mut overlong = good[..18].to_vec();
+        // good[52] is the minimal lamport uint (0x01). Splice a non-minimal 8-byte header for 1.
+        assert_eq!(good[52], 0x01);
+        let mut overlong = good[..52].to_vec();
         overlong.extend_from_slice(&[0x1b, 0, 0, 0, 0, 0, 0, 0, 1]); // uint 1, non-minimal 8-byte
-        overlong.extend_from_slice(&good[19..]);
+        overlong.extend_from_slice(&good[53..]);
         let signature = secret.sign(&overlong);
         let wire = encode_signed(&overlong, &signature);
         assert!(verify_signed(&wire, &secret.public()).is_err(), "non-canonical lamport rejected");
@@ -535,6 +591,7 @@ mod tests {
         // Sanity: op::decode keeps it opaque (Unknown), never errors.
         assert!(op::decode(&unknown_op).is_ok());
         let body = encode_body(&BodyParts {
+            stream_id: stream(),
             prev_hash: None,
             lamport: 1,
             device_fingerprint: secret.public().fingerprint(),
@@ -550,11 +607,12 @@ mod tests {
         verify_chain(&[genesis], &secret.public()).expect("unknown op chains");
     }
 
-    /// A good three-entry chain from one device: genesis + two links, strictly increasing lamport.
+    /// A good three-entry chain from one device on one stream: genesis + two links, strictly
+    /// increasing lamport.
     fn good_chain(secret: &DeviceSecret) -> Vec<SignedEntry> {
-        let e0 = sign_entry(secret, None, 1, &MemoryOp::Snapshot);
-        let e1 = sign_entry(secret, Some(e0.entry.entry_hash), 2, &node_create());
-        let e2 = sign_entry(secret, Some(e1.entry.entry_hash), 5, &MemoryOp::Snapshot);
+        let e0 = sign_entry(secret, stream(), None, 1, &MemoryOp::Snapshot);
+        let e1 = sign_entry(secret, stream(), Some(e0.entry.entry_hash), 2, &node_create());
+        let e2 = sign_entry(secret, stream(), Some(e1.entry.entry_hash), 5, &MemoryOp::Snapshot);
         vec![e0, e1, e2]
     }
 
@@ -577,16 +635,16 @@ mod tests {
         let secret = secret();
         let mut chain = good_chain(&secret);
         // Re-author entry 2 pointing at the WRONG predecessor hash (still a valid signature).
-        chain[2] = sign_entry(&secret, Some([0xaa; 32]), 5, &MemoryOp::Snapshot);
+        chain[2] = sign_entry(&secret, stream(), Some([0xaa; 32]), 5, &MemoryOp::Snapshot);
         assert!(verify_chain(&chain, &secret.public()).is_err(), "a broken link must fail");
     }
 
     #[test]
     fn a_non_monotonic_lamport_fails() {
         let secret = secret();
-        let e0 = sign_entry(&secret, None, 5, &MemoryOp::Snapshot);
+        let e0 = sign_entry(&secret, stream(), None, 5, &MemoryOp::Snapshot);
         // entry 1 links correctly but does NOT advance the lamport (5 is not > 5).
-        let e1 = sign_entry(&secret, Some(e0.entry.entry_hash), 5, &node_create());
+        let e1 = sign_entry(&secret, stream(), Some(e0.entry.entry_hash), 5, &node_create());
         assert!(
             verify_chain(&[e0, e1], &secret.public()).is_err(),
             "lamport must strictly increase",
@@ -597,10 +655,24 @@ mod tests {
     fn a_non_none_genesis_prev_hash_fails() {
         let secret = secret();
         // A genesis entry that claims a predecessor is not a valid chain head.
-        let genesis = sign_entry(&secret, Some([0x22; 32]), 1, &MemoryOp::Snapshot);
+        let genesis = sign_entry(&secret, stream(), Some([0x22; 32]), 1, &MemoryOp::Snapshot);
         assert!(
             verify_chain(&[genesis], &secret.public()).is_err(),
             "genesis prev_hash must be None",
+        );
+    }
+
+    #[test]
+    fn a_foreign_stream_entry_cannot_continue_a_chain() {
+        // A validly-signed entry that links the predecessor hash and advances the lamport, but
+        // belongs to a DIFFERENT stream, is not continuity: chains are per (stream, device).
+        let secret = secret();
+        let e0 = sign_entry(&secret, stream(), None, 1, &MemoryOp::Snapshot);
+        let other = StreamId::from_bytes([4u8; 32]);
+        let e1 = sign_entry(&secret, other, Some(e0.entry.entry_hash), 2, &node_create());
+        assert!(
+            verify_chain(&[e0, e1], &secret.public()).is_err(),
+            "a chain must carry exactly one stream_id",
         );
     }
 

--- a/crates/rag-rat-core/src/oplog/mod.rs
+++ b/crates/rag-rat-core/src/oplog/mod.rs
@@ -1,5 +1,5 @@
 //! Memory op-log: the op model, a deterministic projection fold, and the signed hash-chained entry
-//! envelope (phase B, §5.4 / §C4 layer-1).
+//! envelope (phase B, layer 1).
 //!
 //! A pure, in-memory primitive frozen in isolation — the op-log's ordering + integrity semantics
 //! without any transport or storage. Parts:
@@ -12,20 +12,22 @@
 //!   [`device::DevicePublic`] verifies (`verify_strict`) and derives the op model's opaque
 //!   `DeviceFingerprint` = `sha256(pubkey)`.
 //! - [`entry`]: the signed, hash-chained entry envelope over an OPAQUE op — sign / verify /
-//!   per-device chain-verify. The signature covers the canonical body `[domain, prev_hash, lamport,
-//!   device_fingerprint, op_bytes]`; `entry_hash = sha256(body)` links the chain, so an UNKNOWN op
-//!   still verifies + chains.
+//!   per-`(stream, device)` chain-verify. The signature covers the canonical body `[domain,
+//!   stream_id, prev_hash, lamport, device_fingerprint, op_bytes]`; `entry_hash = sha256(body)`
+//!   links the chain, so an UNKNOWN op still verifies + chains.
 //! - [`cbor`]: the shared canonical-CBOR discipline (definite lengths, minimal headers, sorted map
 //!   keys, no trailing) both wire layers enforce.
 //!
 //! - [`store`]: the durable SQLite seam — the layer-1 opaque signed entry log (verified,
 //!   chain-continuous, idempotent [`store::append`]) plus the layer-2 full-replay projection into
-//!   oplog-owned shadow tables, kept in sync atomically (§C4/§5.4).
+//!   oplog-owned shadow tables, kept in sync atomically.
+//! - [`stream`]: the immutable, content-derived stream identity (#509) — one signed chain,
+//!   watermark, and projection exists PER [`stream::StreamId`]; the entry body binds it, so stream
+//!   membership is signature-protected.
 //!
 //! Nothing here is wired into the live write path yet (later increments add the append-on-mutation
-//! seam, roster/epochs, immutable stream identity, and transport) — this mirrors the `content_hash`
-//! freeze: pin the semantic primitive first, in isolation-testable form. See `issue-489-plan.md` /
-//! `issue-497-plan.md` / `issue-503-plan.md`.
+//! seam, roster/epochs, and transport) — this mirrors the `content_hash` freeze: pin the semantic
+//! primitive first, in isolation-testable form.
 
 mod cbor;
 mod device;
@@ -33,3 +35,4 @@ mod entry;
 mod op;
 mod project;
 mod store;
+mod stream;

--- a/crates/rag-rat-core/src/oplog/store.rs
+++ b/crates/rag-rat-core/src/oplog/store.rs
@@ -1,20 +1,21 @@
-//! Durable SQLite storage for the memory op-log (phase B, §C4/§5.4).
+//! Durable SQLite storage for the memory op-log (phase B, layer 1 + shadow projection).
 //!
-//! Two layers, persisted by the V052 migration:
+//! Two layers, persisted by the V052/V053 migrations, both scoped by the immutable
+//! [`super::stream`] identity — one signed chain per `(stream_id, device)`:
 //! - **Layer 1** — `oplog_entries`, the opaque signed entry log. [`append`] verifies an entry
-//!   (signature + fingerprint binding), gates it on op-bytes decodability, checks per-device chain
-//!   continuity against the stored tail, and inserts — all in one `IMMEDIATE` transaction,
-//!   idempotent on `entry_hash`. `signed_bytes` is the sole source of truth; every header column
-//!   derives from it.
+//!   (signature + fingerprint binding + stream binding), gates it on op-bytes decodability, checks
+//!   per-`(stream, device)` chain continuity against the stored tail, and inserts — all in one
+//!   `IMMEDIATE` transaction, idempotent on `entry_hash`. `signed_bytes` is the sole source of
+//!   truth; every header column derives from it. A detected fork durably quarantines the rejected
+//!   head in `oplog_fork_evidence`, so BOTH heads of an equivocation survive.
 //! - **Layer 2** — the shadow projection (`oplog_projected_nodes` / `oplog_projected_edges`), a
-//!   pure full-replay fold of layer 1 via [`super::project::project`], rewritten wholesale inside
+//!   pure full-replay fold of layer 1 via [`super::project::project`], rewritten per stream inside
 //!   the same transaction so the materialized view never lags the log. Never a source of truth; a
-//!   `DELETE`-all
-//!   + reinsert is the whole update.
+//!   per-stream `DELETE` + reinsert is the whole update.
 //!
-//! Nothing here is wired to the live memory write path yet — roster/epochs, immutable stream
-//! identity, and transport are later increments; the module is exercised in isolation, mirroring
-//! the `content_hash` / op-model / entry-envelope freezes that preceded it.
+//! Nothing here is wired to the live memory write path yet — roster/epochs and transport are later
+//! increments; the module is exercised in isolation, mirroring the `content_hash` / op-model /
+//! entry-envelope / stream-identity freezes that preceded it.
 
 use anyhow::Context;
 use rusqlite::{Connection, OptionalExtension, Transaction, TransactionBehavior, params};
@@ -27,11 +28,12 @@ use super::op::{
     OpMeta, ResolvedAnchor,
 };
 use super::project::{self, ProjectedEdge, ProjectedNode, ProjectedState};
+use super::stream::StreamId;
 use crate::query::memory::EdgeRelation;
 
 /// Bump when the fold's projectable set or LWW semantics change (a new op kind becomes `Known`, a
 /// register is added). A shadow projection stamped with an older version is re-folded on demand
-/// ([`reproject_if_projector_stale`], the §5.4 upgrade re-fold), never trusted incrementally.
+/// ([`reproject_if_projector_stale`], the upgrade re-fold), never trusted incrementally.
 const PROJECTOR_VERSION: i64 = 1;
 
 /// The `oplog_meta` key holding the projector version the shadow tables were last folded by.
@@ -39,9 +41,9 @@ const PROJECTOR_VERSION_KEY: &str = "projector_version";
 
 /// The result of an [`append`] attempt. `Appended` / `AlreadyPresent` mean the log now contains the
 /// entry; `MissingPredecessor` / `Fork` mean it was rejected WITHOUT mutating the log or
-/// projection, so a caller (phase D) can discriminate a retry-after-backfill from an equivocation
-/// to quarantine. A cryptographic failure, an undecodable op, or a lamport overflow is an `Err`,
-/// not an outcome.
+/// projection, so a caller (phase D) can discriminate a retry-after-backfill from an equivocation.
+/// A cryptographic failure, a stream mismatch, an undecodable op, or a lamport overflow is an
+/// `Err`, not an outcome.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum AppendOutcome {
     /// Verified, chain-continuous, newly inserted; the projection was re-folded in the same txn.
@@ -53,25 +55,28 @@ pub(crate) enum AppendOutcome {
     /// after backfill.
     MissingPredecessor { entry_hash: [u8; 32] },
     /// The entry conflicts with the stored chain (a second genesis, or a `lamport` at/behind the
-    /// tail) — an equivocation. `conflicting` is the stored entry it collides with, kept as
-    /// evidence (richer fork forensics — a quarantine table — is a later S2 increment).
+    /// tail) — an equivocation. `conflicting` is the stored entry it collides with. The rejected
+    /// entry is durably quarantined in `oplog_fork_evidence` (BOTH heads must survive a process
+    /// exit — a cloned/restored device is exactly the case where forensics happen later); the
+    /// log and projection stay untouched.
     Fork { entry_hash: [u8; 32], conflicting: Vec<u8> },
 }
 
-/// The head of one device's chain — its highest-`lamport` entry.
+/// The head of one `(stream, device)` chain — its highest-`lamport` entry.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ChainTail {
     pub(crate) lamport: u64,
     pub(crate) entry_hash: [u8; 32],
 }
 
-/// Verify and durably append one signed entry under `pubkey`, keeping the shadow projection in sync
-/// atomically. `now_ms` is the injected local receipt time (not protocol ordering). See
-/// [`AppendOutcome`] for the accept/reject cases; a tampered/wrong-keyed entry, an undecodable op,
-/// a lamport that overflows `i64`, or a store whose projection a NEWER rag-rat already owns is an
-/// `Err`.
+/// Verify and durably append one signed entry under `pubkey` onto `expected_stream`, keeping the
+/// shadow projection in sync atomically. `now_ms` is the injected local receipt time (not protocol
+/// ordering). See [`AppendOutcome`] for the accept/reject cases; a tampered/wrong-keyed entry, an
+/// entry whose signed body names a DIFFERENT stream, an undecodable op, a lamport that overflows
+/// `i64`, or a store whose projection a NEWER rag-rat already owns is an `Err`.
 pub(crate) fn append(
     conn: &Connection,
+    expected_stream: StreamId,
     signed_bytes: &[u8],
     pubkey: &DevicePublic,
     now_ms: i64,
@@ -80,27 +85,36 @@ pub(crate) fn append(
     //    binding. A tampered body/header/signature or a wrong key is a hard error.
     let verified = entry::verify_signed(signed_bytes, pubkey)?;
 
-    // 2. Poison guard (§5.4): the op bytes must be DECODABLE before accepting an entry whose
-    //    projection will decode them. `Known` AND `Unknown` both pass — an unknown kind/relation/
-    //    status stays retained-but-unprojected. Only a HARD decode error (structural corruption, or
-    //    a deliberate `rag-rat/op/2` domain bump this binary can't read) is rejected here, so one
-    //    poison entry can never wedge every future reproject.
+    // 2. Stream binding: the signed body names the stream it belongs to; the caller names the
+    //    stream it is accepting for. A mismatch is the cross-stream replay the in-body stream_id
+    //    exists to stop (an entry re-homed onto another stream would contaminate that stream's
+    //    projection past any visibility filtering) — a hard error, never stored.
+    if verified.stream_id != expected_stream {
+        anyhow::bail!("op-log entry belongs to a different stream than it was offered for");
+    }
+
+    // 3. Poison guard: the op bytes must be DECODABLE before accepting an entry whose projection
+    //    will decode them. `Known` AND `Unknown` both pass — an unknown kind/relation/status stays
+    //    retained-but-unprojected. Only a HARD decode error (structural corruption, or a deliberate
+    //    `rag-rat/op/2` domain bump this binary can't read) is rejected here, so one poison entry
+    //    can never wedge every future reproject.
     op::decode(&verified.op_bytes)
         .context("op-log entry carries undecodable op bytes; refusing to append")?;
 
-    // 3. Lamport must fit SQLite's signed INTEGER; `as i64` would wrap a >= 2^63 value negative and
+    // 4. Lamport must fit SQLite's signed INTEGER; `as i64` would wrap a >= 2^63 value negative and
     //    silently corrupt the chain order. No realistic Lamport reaches this — reject, don't trust.
     let lamport = i64::try_from(verified.lamport)
         .map_err(|_| anyhow::anyhow!("op-log lamport {} exceeds i64", verified.lamport))?;
 
     let device = verified.device_fingerprint;
+    let stream = verified.stream_id;
     // IMMEDIATE so the tail read and the insert are one write transaction — no TOCTOU between the
     // continuity check and the append. Dropping the txn (an early return below) rolls back.
     let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
 
     // Refuse to touch a store whose projection a NEWER rag-rat already owns: reprojecting with this
-    // older decoder would drop ops the newer binary knows and stamp the version DOWN (§5.4
-    // projector monotonicity). Read inside the txn so the check and the write are atomic.
+    // older decoder would drop ops the newer binary knows and stamp the version DOWN (projector
+    // monotonicity). Read inside the txn so the check and the write are atomic.
     assert_projector_not_newer(&tx)?;
 
     // Idempotency BEFORE continuity (a re-delivered mid-chain entry must not read as a fork).
@@ -108,20 +122,42 @@ pub(crate) fn append(
         return Ok(AppendOutcome::AlreadyPresent { entry_hash: verified.entry_hash });
     }
 
-    let tail = chain_tail(&tx, device)?;
-    match classify_chain(&tx, device, &verified, tail.as_ref())? {
+    let tail = chain_tail(&tx, stream, device)?;
+    match classify_chain(&tx, stream, device, &verified, tail.as_ref())? {
         ChainVerdict::MissingPredecessor => {
             return Ok(AppendOutcome::MissingPredecessor { entry_hash: verified.entry_hash });
         },
         ChainVerdict::Fork => {
-            let conflicting = conflicting_entry(&tx, device, lamport)?;
-            return Ok(AppendOutcome::Fork { entry_hash: verified.entry_hash, conflicting });
+            let conflicting = conflicting_entry(&tx, stream, device, lamport)?;
+            // Quarantine the rejected head durably, then COMMIT only that: the log and projection
+            // stay unmutated, but the equivocation's second head survives a process exit for later
+            // forensics instead of living only in this return value.
+            record_fork_evidence(
+                &tx,
+                &verified,
+                lamport,
+                signed_bytes,
+                conflicting.as_ref().map(|c| c.entry_hash),
+                now_ms,
+            )?;
+            tx.commit()?;
+            return Ok(AppendOutcome::Fork {
+                entry_hash: verified.entry_hash,
+                conflicting: conflicting.map(|c| c.signed_bytes).unwrap_or_default(),
+            });
         },
         ChainVerdict::Continuous => {},
     }
 
     insert_entry(&tx, &verified, lamport, signed_bytes, now_ms)?;
-    reproject(&tx)?;
+    match stored_projector_version(&tx)? {
+        // The projection is already current: only the appended stream's fold moved.
+        Some(version) if version == PROJECTOR_VERSION => reproject(&tx, stream)?,
+        // An older (or missing) stamp means every OTHER stream's fold is stale too, and the
+        // store-global stamp written below would mark them all current — so this append must
+        // sweep every stream, not just its own, or a quiet stream keeps its stale rows forever.
+        _ => reproject_all_streams(&tx)?,
+    }
     stamp_projector_version(&tx)?;
     tx.commit()?;
     Ok(AppendOutcome::Appended { entry_hash: verified.entry_hash })
@@ -139,14 +175,15 @@ enum ChainVerdict {
     Fork,
 }
 
-/// Classify `verified` against the device's `tail`. The rule is [`super::entry::verify_chain`]'s
-/// per-device chain, applied one entry at a time: genesis has `prev_hash == None`; a follow-on
-/// points `prev_hash` at the head and strictly advances `lamport`. Only ONE rejection is a
-/// retryable gap — a `lamport` PAST the tail whose (absent) predecessor may still backfill;
-/// everything else that can never become a valid extension is a `Fork`. The present-vs-absent
-/// predecessor split needs a DB read.
+/// Classify `verified` against the `(stream, device)` chain's `tail`. The rule is
+/// [`super::entry::verify_chain`]'s per-`(stream, device)` chain, applied one entry at a time:
+/// genesis has `prev_hash == None`; a follow-on points `prev_hash` at the head and strictly
+/// advances `lamport`. Only ONE rejection is a retryable gap — a `lamport` PAST the tail whose
+/// (absent) predecessor may still backfill; everything else that can never become a valid
+/// extension is a `Fork`. The present-vs-absent predecessor split needs a DB read.
 fn classify_chain(
     conn: &Connection,
+    stream: StreamId,
     device: DeviceFingerprint,
     verified: &VerifiedEntry,
     tail: Option<&ChainTail>,
@@ -171,24 +208,27 @@ fn classify_chain(
     }
     Ok(if prev == tail.entry_hash {
         ChainVerdict::Continuous // extends the head
-    } else if predecessor_present(conn, device, &prev)? {
+    } else if predecessor_present(conn, stream, device, &prev)? {
         ChainVerdict::Fork // branches off a present non-head entry
     } else {
         ChainVerdict::MissingPredecessor // predecessor genuinely absent — a later entry may backfill
     })
 }
 
-/// Whether this device's log already holds the entry `prev_hash` points at.
+/// Whether this `(stream, device)` chain already holds the entry `prev_hash` points at.
 fn predecessor_present(
     conn: &Connection,
+    stream: StreamId,
     device: DeviceFingerprint,
     prev_hash: &[u8; 32],
 ) -> rusqlite::Result<bool> {
+    let stream_bytes = stream.to_bytes();
     let device_bytes = device.to_bytes();
     Ok(conn
         .query_row(
-            "SELECT 1 FROM oplog_entries WHERE device_fingerprint = ?1 AND entry_hash = ?2",
-            params![device_bytes.as_slice(), prev_hash.as_slice()],
+            "SELECT 1 FROM oplog_entries
+             WHERE stream_id = ?1 AND device_fingerprint = ?2 AND entry_hash = ?3",
+            params![stream_bytes.as_slice(), device_bytes.as_slice(), prev_hash.as_slice()],
             |_| Ok(()),
         )
         .optional()?
@@ -202,14 +242,17 @@ fn insert_entry(
     signed_bytes: &[u8],
     now_ms: i64,
 ) -> rusqlite::Result<()> {
+    let stream_bytes = verified.stream_id.to_bytes();
     let device_bytes = verified.device_fingerprint.to_bytes();
     let prev_hash: Option<Vec<u8>> = verified.prev_hash.map(|h| h.to_vec());
     tx.execute(
         "INSERT INTO oplog_entries(
-             entry_hash, device_fingerprint, lamport, prev_hash, signed_bytes, received_at_ms)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+             entry_hash, stream_id, device_fingerprint, lamport, prev_hash, signed_bytes,
+             received_at_ms)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
         params![
             verified.entry_hash.as_slice(),
+            stream_bytes.as_slice(),
             device_bytes.as_slice(),
             lamport,
             prev_hash,
@@ -220,17 +263,19 @@ fn insert_entry(
     Ok(())
 }
 
-/// The device's highest-`lamport` entry, or `None` for an empty chain.
+/// The `(stream, device)` chain's highest-`lamport` entry, or `None` for an empty chain.
 pub(crate) fn chain_tail(
     conn: &Connection,
+    stream: StreamId,
     device: DeviceFingerprint,
 ) -> anyhow::Result<Option<ChainTail>> {
+    let stream_bytes = stream.to_bytes();
     let device_bytes = device.to_bytes();
     let row = conn
         .query_row(
             "SELECT lamport, entry_hash FROM oplog_entries
-             WHERE device_fingerprint = ?1 ORDER BY lamport DESC LIMIT 1",
-            params![device_bytes.as_slice()],
+             WHERE stream_id = ?1 AND device_fingerprint = ?2 ORDER BY lamport DESC LIMIT 1",
+            params![stream_bytes.as_slice(), device_bytes.as_slice()],
             |row| Ok((row.get::<_, i64>(0)?, row.get::<_, Vec<u8>>(1)?)),
         )
         .optional()?;
@@ -254,53 +299,122 @@ fn entry_exists(conn: &Connection, entry_hash: &[u8; 32]) -> rusqlite::Result<bo
         .is_some())
 }
 
-/// The stored entry an incoming one collides with: prefer the entry in the same `(device, lamport)`
-/// slot (the direct equivocation), else the device's current head. Best-effort evidence.
-fn conflicting_entry(
-    conn: &Connection,
-    device: DeviceFingerprint,
-    lamport: i64,
-) -> anyhow::Result<Vec<u8>> {
-    let device_bytes = device.to_bytes();
-    let at_slot: Option<Vec<u8>> = conn
-        .query_row(
-            "SELECT signed_bytes FROM oplog_entries
-             WHERE device_fingerprint = ?1 AND lamport = ?2",
-            params![device_bytes.as_slice(), lamport],
-            |row| row.get(0),
-        )
-        .optional()?;
-    if let Some(bytes) = at_slot {
-        return Ok(bytes);
-    }
-    let head: Option<Vec<u8>> = conn
-        .query_row(
-            "SELECT signed_bytes FROM oplog_entries
-             WHERE device_fingerprint = ?1 ORDER BY lamport DESC LIMIT 1",
-            params![device_bytes.as_slice()],
-            |row| row.get(0),
-        )
-        .optional()?;
-    Ok(head.unwrap_or_default())
+/// The stored entry a rejected fork collides with — its wire bytes plus its `entry_hash` (the
+/// quarantine row points at it).
+struct ConflictingEntry {
+    signed_bytes: Vec<u8>,
+    entry_hash: [u8; 32],
 }
 
-/// Rebuild the shadow projection from the whole log in one `IMMEDIATE` txn, and stamp the projector
-/// version. The standalone entry point for the §5.4 upgrade re-fold and for a batch-append caller.
-/// Refuses (like [`append`]) if a NEWER projector already owns the projection.
+/// The stored entry an incoming one collides with: prefer the entry in the same `(stream, device,
+/// lamport)` slot (the direct equivocation), else the chain's current head. Best-effort evidence.
+fn conflicting_entry(
+    conn: &Connection,
+    stream: StreamId,
+    device: DeviceFingerprint,
+    lamport: i64,
+) -> anyhow::Result<Option<ConflictingEntry>> {
+    let stream_bytes = stream.to_bytes();
+    let device_bytes = device.to_bytes();
+    let at_slot: Option<(Vec<u8>, Vec<u8>)> = conn
+        .query_row(
+            "SELECT signed_bytes, entry_hash FROM oplog_entries
+             WHERE stream_id = ?1 AND device_fingerprint = ?2 AND lamport = ?3",
+            params![stream_bytes.as_slice(), device_bytes.as_slice(), lamport],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .optional()?;
+    let row = match at_slot {
+        Some(row) => Some(row),
+        None => conn
+            .query_row(
+                "SELECT signed_bytes, entry_hash FROM oplog_entries
+                 WHERE stream_id = ?1 AND device_fingerprint = ?2 ORDER BY lamport DESC LIMIT 1",
+                params![stream_bytes.as_slice(), device_bytes.as_slice()],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .optional()?,
+    };
+    row.map(|(signed_bytes, entry_hash)| {
+        Ok(ConflictingEntry { signed_bytes, entry_hash: hash_from_vec(entry_hash)? })
+    })
+    .transpose()
+}
+
+/// Durably quarantine the rejected head of a detected fork. Idempotent on `(stream, entry_hash)`
+/// (a redelivered fork re-reports, never duplicates); never touches the log or projection.
+fn record_fork_evidence(
+    tx: &Transaction<'_>,
+    verified: &VerifiedEntry,
+    lamport: i64,
+    signed_bytes: &[u8],
+    conflicting_entry_hash: Option<[u8; 32]>,
+    now_ms: i64,
+) -> rusqlite::Result<()> {
+    let stream_bytes = verified.stream_id.to_bytes();
+    let device_bytes = verified.device_fingerprint.to_bytes();
+    let conflicting: Option<Vec<u8>> = conflicting_entry_hash.map(|h| h.to_vec());
+    tx.execute(
+        "INSERT INTO oplog_fork_evidence(
+             stream_id, entry_hash, device_fingerprint, lamport, signed_bytes,
+             conflicting_entry_hash, observed_at_ms)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+         ON CONFLICT(stream_id, entry_hash) DO NOTHING",
+        params![
+            stream_bytes.as_slice(),
+            verified.entry_hash.as_slice(),
+            device_bytes.as_slice(),
+            lamport,
+            signed_bytes,
+            conflicting,
+            now_ms,
+        ],
+    )?;
+    Ok(())
+}
+
+/// Rebuild the whole shadow projection — every stream present in the log — in one `IMMEDIATE`
+/// txn, and stamp the projector version. The standalone entry point for the upgrade re-fold and
+/// for a batch-append caller; a re-fold must sweep EVERY stream, not just the one a write touched,
+/// or a quiet stream would serve a stale materialization after an upgrade. Refuses (like
+/// [`append`]) if a NEWER projector already owns the projection.
 pub(crate) fn rebuild_projection(conn: &Connection) -> anyhow::Result<()> {
     let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
     assert_projector_not_newer(&tx)?;
-    reproject(&tx)?;
+    reproject_all_streams(&tx)?;
     stamp_projector_version(&tx)?;
     tx.commit()?;
     Ok(())
 }
 
+/// Re-fold EVERY stream wholesale: clear BOTH tables first so a projection row whose stream no
+/// longer has entries cannot linger, then fold each present stream. The only projection write
+/// allowed to precede a projector-version stamp over a stale store.
+fn reproject_all_streams(tx: &Transaction<'_>) -> anyhow::Result<()> {
+    tx.execute("DELETE FROM oplog_projected_nodes", [])?;
+    tx.execute("DELETE FROM oplog_projected_edges", [])?;
+    for stream in streams_present(tx)? {
+        reproject(tx, stream)?;
+    }
+    Ok(())
+}
+
+/// Every distinct stream the log currently holds entries for.
+fn streams_present(conn: &Connection) -> anyhow::Result<Vec<StreamId>> {
+    let mut stmt = conn.prepare("SELECT DISTINCT stream_id FROM oplog_entries")?;
+    let rows = stmt.query_map([], |row| row.get::<_, Vec<u8>>(0))?;
+    let mut streams = Vec::new();
+    for row in rows {
+        streams.push(StreamId::from_bytes(hash_from_vec(row?)?));
+    }
+    Ok(streams)
+}
+
 /// Re-fold the shadow projection iff it was last folded by a STRICTLY OLDER (or missing) projector
-/// version (§5.4: a binary that learns a new op kind must re-fold WITHOUT waiting for a write).
-/// Returns whether it re-folded. A projection stamped by the current or a NEWER projector is left
-/// intact — never downgraded. (The mechanism; wiring this into the index open path lands when the
-/// store meets the live read path.)
+/// version (a binary that learns a new op kind must re-fold WITHOUT waiting for a write). Returns
+/// whether it re-folded. A projection stamped by the current or a NEWER projector is left intact —
+/// never downgraded. (The mechanism; wiring this into the index open path lands when the store
+/// meets the live read path.)
 pub(crate) fn reproject_if_projector_stale(conn: &Connection) -> anyhow::Result<bool> {
     match stored_projector_version(conn)? {
         Some(version) if version >= PROJECTOR_VERSION => Ok(false),
@@ -314,7 +428,8 @@ pub(crate) fn reproject_if_projector_stale(conn: &Connection) -> anyhow::Result<
 /// Error if a NEWER projector already folded this store's projection — an older binary must not
 /// reproject (it would drop ops the newer binary knows) or stamp the version down. Mirrors the
 /// schema ladder's "newer rag-rat" refusal, at the projection layer (a projector bump need not
-/// carry a schema bump, so the schema guard does not cover it).
+/// carry a schema bump, so the schema guard does not cover it). The stamp is store-global, not
+/// per stream: one binary folds every stream it holds.
 fn assert_projector_not_newer(conn: &Connection) -> anyhow::Result<()> {
     if let Some(stored) = stored_projector_version(conn)?
         && stored > PROJECTOR_VERSION
@@ -327,20 +442,32 @@ fn assert_projector_not_newer(conn: &Connection) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// The full-replay fold: decode the projectable entries, `project`, and rewrite BOTH shadow tables.
-/// Deterministic and side-effect-free beyond the two tables; the O(n) cost per call is bounded
-/// later by snapshot compaction (§5.6).
-fn reproject(tx: &Transaction<'_>) -> anyhow::Result<()> {
-    let entries = load_known_entries(tx)?;
+/// The full-replay fold for ONE stream: decode its projectable entries, `project`, and rewrite its
+/// rows in BOTH shadow tables — another stream's projection is never touched, so a busy stream's
+/// append cannot perturb a filtered view's materialization. Deterministic and side-effect-free
+/// beyond the two tables; the O(n) cost per call is bounded later by snapshot compaction.
+fn reproject(tx: &Transaction<'_>, stream: StreamId) -> anyhow::Result<()> {
+    let entries = load_known_entries(tx, stream)?;
     let state = project::project(&entries);
-    tx.execute("DELETE FROM oplog_projected_nodes", [])?;
-    tx.execute("DELETE FROM oplog_projected_edges", [])?;
+    let stream_bytes = stream.to_bytes();
+    tx.execute("DELETE FROM oplog_projected_nodes WHERE stream_id = ?1", params![
+        stream_bytes.as_slice()
+    ])?;
+    tx.execute("DELETE FROM oplog_projected_edges WHERE stream_id = ?1", params![
+        stream_bytes.as_slice()
+    ])?;
     for (node_id, node) in &state.nodes {
         let content_json = serde_json::to_string(&NodeContentRow::from(&node.content))
             .context("serialize projected node content")?;
         tx.execute(
-            "INSERT INTO oplog_projected_nodes(node_id, content_json, status) VALUES (?1, ?2, ?3)",
-            params![node_id.as_str(), content_json, node.status.as_db_str()],
+            "INSERT INTO oplog_projected_nodes(stream_id, node_id, content_json, status)
+             VALUES (?1, ?2, ?3, ?4)",
+            params![
+                stream_bytes.as_slice(),
+                node_id.as_str(),
+                content_json,
+                node.status.as_db_str()
+            ],
         )?;
     }
     for (edge_key, edge) in &state.edges {
@@ -353,22 +480,25 @@ fn reproject(tx: &Transaction<'_>) -> anyhow::Result<()> {
             .transpose()
             .context("serialize projected edge resolved anchor")?;
         tx.execute(
-            "INSERT INTO oplog_projected_edges(edge_key, spec_json, resolved_json)
-             VALUES (?1, ?2, ?3)",
-            params![edge_key.as_str(), spec_json, resolved_json],
+            "INSERT INTO oplog_projected_edges(stream_id, edge_key, spec_json, resolved_json)
+             VALUES (?1, ?2, ?3, ?4)",
+            params![stream_bytes.as_slice(), edge_key.as_str(), spec_json, resolved_json],
         )?;
     }
     Ok(())
 }
 
-/// Load the PROJECTABLE entries — every stored op decoded to `Known`. An `Unknown` op is retained
-/// in the log but skipped here (§5.4), so this is a strict subset of the full log (hence
+/// Load ONE stream's PROJECTABLE entries — every stored op decoded to `Known`. An `Unknown` op is
+/// retained in the log but skipped here, so this is a strict subset of the stream's log (hence
 /// `_known_`). A hard decode failure is unreachable given [`append`]'s accept-gate and surfaces as
 /// a loud error (corruption at rest), never a silent skip.
-fn load_known_entries(tx: &Transaction<'_>) -> anyhow::Result<Vec<Entry>> {
-    let mut stmt =
-        tx.prepare("SELECT device_fingerprint, lamport, signed_bytes FROM oplog_entries")?;
-    let rows = stmt.query_map([], |row| {
+fn load_known_entries(tx: &Transaction<'_>, stream: StreamId) -> anyhow::Result<Vec<Entry>> {
+    let stream_bytes = stream.to_bytes();
+    let mut stmt = tx.prepare(
+        "SELECT device_fingerprint, lamport, signed_bytes FROM oplog_entries
+         WHERE stream_id = ?1",
+    )?;
+    let rows = stmt.query_map(params![stream_bytes.as_slice()], |row| {
         Ok((row.get::<_, Vec<u8>>(0)?, row.get::<_, i64>(1)?, row.get::<_, Vec<u8>>(2)?))
     })?;
     let mut entries = Vec::new();
@@ -384,21 +514,27 @@ fn load_known_entries(tx: &Transaction<'_>) -> anyhow::Result<Vec<Entry>> {
             .op_bytes;
         match op::decode(&op_bytes).context("stored op bytes failed to decode")? {
             DecodedOp::Known(op) => entries.push(Entry { meta: OpMeta { lamport, device }, op }),
-            DecodedOp::Unknown { .. } => {}, // retained in the log, not projected (§5.4)
+            DecodedOp::Unknown { .. } => {}, // retained in the log, not projected
         }
     }
     Ok(entries)
 }
 
-/// Reconstruct the converged projection from the shadow tables — the read the eventual live path
-/// consumes, and the round-trip for idempotency tests (compare parsed `ProjectedState`, never JSON
-/// text, so serde_json key order is irrelevant).
-pub(crate) fn load_projection(conn: &Connection) -> anyhow::Result<ProjectedState> {
+/// Reconstruct ONE stream's converged projection from the shadow tables — the read the eventual
+/// live path consumes, and the round-trip for idempotency tests (compare parsed `ProjectedState`,
+/// never JSON text, so serde_json key order is irrelevant).
+pub(crate) fn load_projection(
+    conn: &Connection,
+    stream: StreamId,
+) -> anyhow::Result<ProjectedState> {
+    let stream_bytes = stream.to_bytes();
     let mut state = ProjectedState::default();
     {
-        let mut stmt =
-            conn.prepare("SELECT node_id, content_json, status FROM oplog_projected_nodes")?;
-        let rows = stmt.query_map([], |row| {
+        let mut stmt = conn.prepare(
+            "SELECT node_id, content_json, status FROM oplog_projected_nodes
+             WHERE stream_id = ?1",
+        )?;
+        let rows = stmt.query_map(params![stream_bytes.as_slice()], |row| {
             Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?, row.get::<_, String>(2)?))
         })?;
         for row in rows {
@@ -414,9 +550,11 @@ pub(crate) fn load_projection(conn: &Connection) -> anyhow::Result<ProjectedStat
         }
     }
     {
-        let mut stmt =
-            conn.prepare("SELECT edge_key, spec_json, resolved_json FROM oplog_projected_edges")?;
-        let rows = stmt.query_map([], |row| {
+        let mut stmt = conn.prepare(
+            "SELECT edge_key, spec_json, resolved_json FROM oplog_projected_edges
+             WHERE stream_id = ?1",
+        )?;
+        let rows = stmt.query_map(params![stream_bytes.as_slice()], |row| {
             Ok((
                 row.get::<_, String>(0)?,
                 row.get::<_, String>(1)?,
@@ -598,6 +736,15 @@ mod tests {
         DeviceSecret::from_seed(&[seed; 32])
     }
 
+    /// The stream the tests append onto, plus a second one for cross-stream isolation cases.
+    fn stream_a() -> StreamId {
+        StreamId::from_bytes([0xAA; 32])
+    }
+
+    fn stream_b() -> StreamId {
+        StreamId::from_bytes([0xBB; 32])
+    }
+
     fn content(title: &str) -> NodeContent {
         NodeContent {
             kind: "Invariant".to_string(),
@@ -623,25 +770,54 @@ mod tests {
         conn.query_row("SELECT COUNT(*) FROM oplog_entries", [], |row| row.get(0)).unwrap()
     }
 
+    /// Every quarantined fork head: `(entry_hash, signed_bytes, conflicting_entry_hash)`.
+    #[allow(clippy::type_complexity)]
+    fn fork_evidence(conn: &Connection) -> Vec<(Vec<u8>, Vec<u8>, Option<Vec<u8>>)> {
+        let mut stmt = conn
+            .prepare(
+                "SELECT entry_hash, signed_bytes, conflicting_entry_hash FROM oplog_fork_evidence
+                 ORDER BY lamport",
+            )
+            .unwrap();
+        stmt.query_map([], |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)))
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap()
+    }
+
     #[test]
     fn append_genesis_then_chain_roundtrips() {
         let conn = db();
         let s = secret(1);
-        let g = entry::sign_entry(&s, None, 1, &create("mem_a", "first"));
-        let out = append(&conn, &g.signed_bytes, &s.public(), 1_000).unwrap();
+        let g = entry::sign_entry(&s, stream_a(), None, 1, &create("mem_a", "first"));
+        let out = append(&conn, stream_a(), &g.signed_bytes, &s.public(), 1_000).unwrap();
         assert!(matches!(out, AppendOutcome::Appended { .. }));
 
-        let e2 = entry::sign_entry(&s, Some(g.entry.entry_hash), 4, &create("mem_b", "second"));
-        append(&conn, &e2.signed_bytes, &s.public(), 1_001).unwrap();
-        let e3 = entry::sign_entry(&s, Some(e2.entry.entry_hash), 9, &create("mem_c", "third"));
-        append(&conn, &e3.signed_bytes, &s.public(), 1_002).unwrap();
+        let e2 = entry::sign_entry(
+            &s,
+            stream_a(),
+            Some(g.entry.entry_hash),
+            4,
+            &create("mem_b", "second"),
+        );
+        append(&conn, stream_a(), &e2.signed_bytes, &s.public(), 1_001).unwrap();
+        let e3 = entry::sign_entry(
+            &s,
+            stream_a(),
+            Some(e2.entry.entry_hash),
+            9,
+            &create("mem_c", "third"),
+        );
+        append(&conn, stream_a(), &e3.signed_bytes, &s.public(), 1_002).unwrap();
 
-        let tail = chain_tail(&conn, s.public().fingerprint()).unwrap().expect("chain has a head");
+        let tail = chain_tail(&conn, stream_a(), s.public().fingerprint())
+            .unwrap()
+            .expect("chain has a head");
         assert_eq!(tail.lamport, 9);
         assert_eq!(tail.entry_hash, e3.entry.entry_hash);
         assert_eq!(entry_count(&conn), 3);
 
-        let projected = load_projection(&conn).unwrap();
+        let projected = load_projection(&conn, stream_a()).unwrap();
         assert_eq!(projected.nodes.len(), 3);
         assert!(projected.nodes.contains_key(&NodeId::from("mem_a")));
     }
@@ -650,9 +826,9 @@ mod tests {
     fn reappend_is_idempotent() {
         let conn = db();
         let s = secret(2);
-        let g = entry::sign_entry(&s, None, 1, &create("mem_a", "first"));
-        append(&conn, &g.signed_bytes, &s.public(), 1_000).unwrap();
-        let again = append(&conn, &g.signed_bytes, &s.public(), 1_005).unwrap();
+        let g = entry::sign_entry(&s, stream_a(), None, 1, &create("mem_a", "first"));
+        append(&conn, stream_a(), &g.signed_bytes, &s.public(), 1_000).unwrap();
+        let again = append(&conn, stream_a(), &g.signed_bytes, &s.public(), 1_005).unwrap();
         assert_eq!(again, AppendOutcome::AlreadyPresent { entry_hash: g.entry.entry_hash });
         assert_eq!(entry_count(&conn), 1);
     }
@@ -662,20 +838,21 @@ mod tests {
         let conn = db();
         let s = secret(3);
         // A follow-on that references a predecessor we don't hold (no genesis appended yet).
-        let orphan = entry::sign_entry(&s, Some([7u8; 32]), 2, &create("mem_a", "orphan"));
+        let orphan =
+            entry::sign_entry(&s, stream_a(), Some([7u8; 32]), 2, &create("mem_a", "orphan"));
         assert!(matches!(
-            append(&conn, &orphan.signed_bytes, &s.public(), 1_000).unwrap(),
+            append(&conn, stream_a(), &orphan.signed_bytes, &s.public(), 1_000).unwrap(),
             AppendOutcome::MissingPredecessor { .. }
         ));
         assert_eq!(entry_count(&conn), 0);
 
         // Genesis, then a follow-on that advances lamport but points prev at the wrong hash (a
         // gap).
-        let g = entry::sign_entry(&s, None, 1, &create("mem_a", "first"));
-        append(&conn, &g.signed_bytes, &s.public(), 1_001).unwrap();
-        let gap = entry::sign_entry(&s, Some([9u8; 32]), 5, &create("mem_b", "gap"));
+        let g = entry::sign_entry(&s, stream_a(), None, 1, &create("mem_a", "first"));
+        append(&conn, stream_a(), &g.signed_bytes, &s.public(), 1_001).unwrap();
+        let gap = entry::sign_entry(&s, stream_a(), Some([9u8; 32]), 5, &create("mem_b", "gap"));
         assert!(matches!(
-            append(&conn, &gap.signed_bytes, &s.public(), 1_002).unwrap(),
+            append(&conn, stream_a(), &gap.signed_bytes, &s.public(), 1_002).unwrap(),
             AppendOutcome::MissingPredecessor { .. }
         ));
         assert_eq!(entry_count(&conn), 1);
@@ -685,12 +862,14 @@ mod tests {
     fn fork_rejections_keep_evidence() {
         let conn = db();
         let s = secret(4);
-        let g = entry::sign_entry(&s, None, 5, &create("mem_a", "first"));
-        append(&conn, &g.signed_bytes, &s.public(), 1_000).unwrap();
+        let g = entry::sign_entry(&s, stream_a(), None, 5, &create("mem_a", "first"));
+        append(&conn, stream_a(), &g.signed_bytes, &s.public(), 1_000).unwrap();
 
         // A second genesis for the same device is an equivocation.
-        let second_genesis = entry::sign_entry(&s, None, 6, &create("mem_b", "genesis-2"));
-        let out = append(&conn, &second_genesis.signed_bytes, &s.public(), 1_001).unwrap();
+        let second_genesis =
+            entry::sign_entry(&s, stream_a(), None, 6, &create("mem_b", "genesis-2"));
+        let out =
+            append(&conn, stream_a(), &second_genesis.signed_bytes, &s.public(), 1_001).unwrap();
         match out {
             AppendOutcome::Fork { conflicting, .. } => {
                 assert_eq!(conflicting, g.signed_bytes, "the stored genesis is the evidence");
@@ -699,22 +878,48 @@ mod tests {
         }
 
         // A follow-on that chains onto the head but does not advance lamport rewrites history.
-        let stale = entry::sign_entry(&s, Some(g.entry.entry_hash), 5, &create("mem_c", "stale"));
+        let stale = entry::sign_entry(
+            &s,
+            stream_a(),
+            Some(g.entry.entry_hash),
+            5,
+            &create("mem_c", "stale"),
+        );
         assert!(matches!(
-            append(&conn, &stale.signed_bytes, &s.public(), 1_002).unwrap(),
+            append(&conn, stream_a(), &stale.signed_bytes, &s.public(), 1_002).unwrap(),
             AppendOutcome::Fork { .. }
         ));
 
         // A stale entry (lamport at/below the tail) whose predecessor we don't even hold can never
         // become a valid extension either — it is a permanent equivocation, NOT a retryable gap.
         let stale_absent =
-            entry::sign_entry(&s, Some([3u8; 32]), 4, &create("mem_d", "stale-absent"));
+            entry::sign_entry(&s, stream_a(), Some([3u8; 32]), 4, &create("mem_d", "stale-absent"));
         assert!(matches!(
-            append(&conn, &stale_absent.signed_bytes, &s.public(), 1_003).unwrap(),
+            append(&conn, stream_a(), &stale_absent.signed_bytes, &s.public(), 1_003).unwrap(),
             AppendOutcome::Fork { .. }
         ));
 
-        assert_eq!(entry_count(&conn), 1, "no fork was stored");
+        assert_eq!(entry_count(&conn), 1, "no fork entered the log");
+
+        // Every rejected head was durably quarantined — BOTH heads of each equivocation survive a
+        // process exit — and each row points at the stored entry it collided with.
+        let quarantined = fork_evidence(&conn);
+        assert_eq!(quarantined.len(), 3, "each fork left one evidence row");
+        assert!(
+            quarantined.iter().any(|(hash, signed, conflicting)| {
+                hash.as_slice() == second_genesis.entry.entry_hash
+                    && signed == &second_genesis.signed_bytes
+                    && conflicting.as_deref() == Some(g.entry.entry_hash.as_slice())
+            }),
+            "the second genesis is quarantined verbatim, pointing at the stored genesis"
+        );
+
+        // Redelivering a quarantined fork re-reports without duplicating the evidence row.
+        assert!(matches!(
+            append(&conn, stream_a(), &second_genesis.signed_bytes, &s.public(), 1_004).unwrap(),
+            AppendOutcome::Fork { .. }
+        ));
+        assert_eq!(fork_evidence(&conn).len(), 3, "redelivery does not duplicate evidence");
     }
 
     #[test]
@@ -722,15 +927,17 @@ mod tests {
         let conn = db();
         let s = secret(13);
         // Build a chain A -> B.
-        let a = entry::sign_entry(&s, None, 1, &create("mem_a", "a"));
-        append(&conn, &a.signed_bytes, &s.public(), 1).unwrap();
-        let b = entry::sign_entry(&s, Some(a.entry.entry_hash), 2, &create("mem_b", "b"));
-        append(&conn, &b.signed_bytes, &s.public(), 2).unwrap();
+        let a = entry::sign_entry(&s, stream_a(), None, 1, &create("mem_a", "a"));
+        append(&conn, stream_a(), &a.signed_bytes, &s.public(), 1).unwrap();
+        let b =
+            entry::sign_entry(&s, stream_a(), Some(a.entry.entry_hash), 2, &create("mem_b", "b"));
+        append(&conn, stream_a(), &b.signed_bytes, &s.public(), 2).unwrap();
 
         // C forks off A — a PRESENT predecessor that is not the head B — at a higher lamport. The
         // predecessor exists, so backfill can never resolve it: this is an equivocation, not a gap.
-        let c = entry::sign_entry(&s, Some(a.entry.entry_hash), 3, &create("mem_c", "c"));
-        match append(&conn, &c.signed_bytes, &s.public(), 3).unwrap() {
+        let c =
+            entry::sign_entry(&s, stream_a(), Some(a.entry.entry_hash), 3, &create("mem_c", "c"));
+        match append(&conn, stream_a(), &c.signed_bytes, &s.public(), 3).unwrap() {
             AppendOutcome::Fork { conflicting, .. } => {
                 assert!(!conflicting.is_empty(), "the colliding head is kept as evidence");
             },
@@ -743,16 +950,16 @@ mod tests {
     fn tamper_and_wrong_key_are_hard_errors() {
         let conn = db();
         let s = secret(5);
-        let g = entry::sign_entry(&s, None, 1, &create("mem_a", "first"));
+        let g = entry::sign_entry(&s, stream_a(), None, 1, &create("mem_a", "first"));
 
         let mut tampered = g.signed_bytes.clone();
         let last = tampered.len() - 1;
         tampered[last] ^= 0x01;
-        assert!(append(&conn, &tampered, &s.public(), 1_000).is_err());
+        assert!(append(&conn, stream_a(), &tampered, &s.public(), 1_000).is_err());
 
         // A valid entry verified under the wrong device key.
         let wrong = secret(6);
-        assert!(append(&conn, &g.signed_bytes, &wrong.public(), 1_000).is_err());
+        assert!(append(&conn, stream_a(), &g.signed_bytes, &wrong.public(), 1_000).is_err());
         assert_eq!(entry_count(&conn), 0);
     }
 
@@ -761,9 +968,9 @@ mod tests {
         let conn = db();
         let s = secret(7);
         // A validly-SIGNED entry whose op bytes are structurally undecodable.
-        let poison = entry::sign_entry_from_op_bytes(&s, None, 1, vec![0xFF]);
+        let poison = entry::sign_entry_from_op_bytes(&s, stream_a(), None, 1, vec![0xFF]);
         assert!(
-            append(&conn, &poison.signed_bytes, &s.public(), 1_000).is_err(),
+            append(&conn, stream_a(), &poison.signed_bytes, &s.public(), 1_000).is_err(),
             "an undecodable op must not enter the log (it would wedge every future reproject)"
         );
         assert_eq!(entry_count(&conn), 0);
@@ -774,7 +981,7 @@ mod tests {
         let conn = db();
         let s = secret(8);
         // A canonical `rag-rat/op/1` envelope with a kind tag this binary doesn't know → decodes to
-        // `Unknown`, so it passes the accept-gate, stores, and chains — but never projects (§5.4).
+        // `Unknown`, so it passes the accept-gate, stores, and chains — but never projects.
         let mut op_bytes = Vec::new();
         {
             let mut enc = Encoder::new(&mut op_bytes);
@@ -783,18 +990,23 @@ mod tests {
             enc.str("future_kind").unwrap();
             enc.null().unwrap();
         }
-        let unknown = entry::sign_entry_from_op_bytes(&s, None, 1, op_bytes);
+        let unknown = entry::sign_entry_from_op_bytes(&s, stream_a(), None, 1, op_bytes);
         assert!(matches!(
-            append(&conn, &unknown.signed_bytes, &s.public(), 1_000).unwrap(),
+            append(&conn, stream_a(), &unknown.signed_bytes, &s.public(), 1_000).unwrap(),
             AppendOutcome::Appended { .. }
         ));
         // It chains: a follow-on onto it is accepted.
-        let follow =
-            entry::sign_entry(&s, Some(unknown.entry.entry_hash), 2, &create("mem_a", "x"));
-        append(&conn, &follow.signed_bytes, &s.public(), 1_001).unwrap();
+        let follow = entry::sign_entry(
+            &s,
+            stream_a(),
+            Some(unknown.entry.entry_hash),
+            2,
+            &create("mem_a", "x"),
+        );
+        append(&conn, stream_a(), &follow.signed_bytes, &s.public(), 1_001).unwrap();
 
         assert_eq!(entry_count(&conn), 2, "both entries are in the log");
-        let projected = load_projection(&conn).unwrap();
+        let projected = load_projection(&conn, stream_a()).unwrap();
         assert_eq!(projected.nodes.len(), 1, "only the known op projected");
         assert!(projected.nodes.contains_key(&NodeId::from("mem_a")));
     }
@@ -807,30 +1019,31 @@ mod tests {
 
         // Two devices interleave; a non-null payload round-trips; a status flip is folded.
         let t = secret(10);
-        let g = entry::sign_entry(&s, None, 1, &{
+        let g = entry::sign_entry(&s, stream_a(), None, 1, &{
             let mut c = content("payload node");
             c.payload = Some(r#"{"schema_version":1,"n":42}"#.to_string());
             MemoryOp::NodeCreate { node_id: NodeId::from("mem_a"), content: c }
         });
-        let g_other = entry::sign_entry(&t, None, 2, &create("mem_b", "other-device"));
-        let status = entry::sign_entry(&s, Some(g.entry.entry_hash), 3, &MemoryOp::NodeStatus {
-            node_id: NodeId::from("mem_a"),
-            status: NodeStatus::Stale,
-        });
+        let g_other = entry::sign_entry(&t, stream_a(), None, 2, &create("mem_b", "other-device"));
+        let status =
+            entry::sign_entry(&s, stream_a(), Some(g.entry.entry_hash), 3, &MemoryOp::NodeStatus {
+                node_id: NodeId::from("mem_a"),
+                status: NodeStatus::Stale,
+            });
 
         let expected;
         {
             let conn = Connection::open(&path).unwrap();
             schema::apply(&conn).unwrap();
-            append(&conn, &g.signed_bytes, &s.public(), 1).unwrap();
-            append(&conn, &g_other.signed_bytes, &t.public(), 2).unwrap();
-            append(&conn, &status.signed_bytes, &s.public(), 3).unwrap();
-            expected = load_projection(&conn).unwrap();
+            append(&conn, stream_a(), &g.signed_bytes, &s.public(), 1).unwrap();
+            append(&conn, stream_a(), &g_other.signed_bytes, &t.public(), 2).unwrap();
+            append(&conn, stream_a(), &status.signed_bytes, &s.public(), 3).unwrap();
+            expected = load_projection(&conn, stream_a()).unwrap();
         }
 
         // Reopen a fresh connection to the same file: the projection persisted verbatim.
         let reopened = Connection::open(&path).unwrap();
-        let loaded = load_projection(&reopened).unwrap();
+        let loaded = load_projection(&reopened, stream_a()).unwrap();
         assert_eq!(loaded, expected);
 
         // …and it equals a from-scratch in-memory fold of the same ops.
@@ -859,9 +1072,9 @@ mod tests {
     fn upgrade_refold_rebuilds_a_stale_projection() {
         let conn = db();
         let s = secret(11);
-        let g = entry::sign_entry(&s, None, 1, &create("mem_a", "first"));
-        append(&conn, &g.signed_bytes, &s.public(), 1_000).unwrap();
-        assert_eq!(load_projection(&conn).unwrap().nodes.len(), 1);
+        let g = entry::sign_entry(&s, stream_a(), None, 1, &create("mem_a", "first"));
+        append(&conn, stream_a(), &g.signed_bytes, &s.public(), 1_000).unwrap();
+        assert_eq!(load_projection(&conn, stream_a()).unwrap().nodes.len(), 1);
 
         // Simulate an old binary that folded under an earlier projector version and left the shadow
         // tables stale (here: emptied).
@@ -872,7 +1085,7 @@ mod tests {
         .unwrap();
 
         assert!(reproject_if_projector_stale(&conn).unwrap(), "a stale stamp re-folds");
-        assert_eq!(load_projection(&conn).unwrap().nodes.len(), 1, "the node is back");
+        assert_eq!(load_projection(&conn, stream_a()).unwrap().nodes.len(), 1, "the node is back");
         assert!(!reproject_if_projector_stale(&conn).unwrap(), "current stamp is a no-op");
     }
 
@@ -880,8 +1093,8 @@ mod tests {
     fn append_refuses_to_downgrade_a_newer_projection() {
         let conn = db();
         let s = secret(14);
-        let g = entry::sign_entry(&s, None, 1, &create("mem_a", "first"));
-        append(&conn, &g.signed_bytes, &s.public(), 1).unwrap();
+        let g = entry::sign_entry(&s, stream_a(), None, 1, &create("mem_a", "first"));
+        append(&conn, stream_a(), &g.signed_bytes, &s.public(), 1).unwrap();
 
         // Simulate a NEWER binary having folded + stamped a higher projector version.
         conn.execute("UPDATE oplog_meta SET value = ?1 WHERE key = ?2", params![
@@ -892,9 +1105,15 @@ mod tests {
 
         // This older projector must refuse to append (it would drop newer-known ops and stamp
         // down).
-        let e2 = entry::sign_entry(&s, Some(g.entry.entry_hash), 2, &create("mem_b", "second"));
+        let e2 = entry::sign_entry(
+            &s,
+            stream_a(),
+            Some(g.entry.entry_hash),
+            2,
+            &create("mem_b", "second"),
+        );
         assert!(
-            append(&conn, &e2.signed_bytes, &s.public(), 2).is_err(),
+            append(&conn, stream_a(), &e2.signed_bytes, &s.public(), 2).is_err(),
             "an older projector must not write a newer-projected store"
         );
         assert_eq!(entry_count(&conn), 1, "the refused append wrote nothing");
@@ -918,22 +1137,161 @@ mod tests {
             owner_repo_id: "repo".to_string(),
         };
         let key = edge.edge_key();
-        let g = entry::sign_entry(&s, None, 1, &create("mem_a", "first"));
-        append(&conn, &g.signed_bytes, &s.public(), 1).unwrap();
-        let add = entry::sign_entry(&s, Some(g.entry.entry_hash), 2, &MemoryOp::EdgeAdd {
-            edge: edge.clone(),
-        });
+        let g = entry::sign_entry(&s, stream_a(), None, 1, &create("mem_a", "first"));
+        append(&conn, stream_a(), &g.signed_bytes, &s.public(), 1).unwrap();
+        let add =
+            entry::sign_entry(&s, stream_a(), Some(g.entry.entry_hash), 2, &MemoryOp::EdgeAdd {
+                edge: edge.clone(),
+            });
         let add_hash = add.entry.entry_hash;
-        append(&conn, &add.signed_bytes, &s.public(), 2).unwrap();
-        assert_eq!(load_projection(&conn).unwrap().edges.len(), 1);
+        append(&conn, stream_a(), &add.signed_bytes, &s.public(), 2).unwrap();
+        assert_eq!(load_projection(&conn, stream_a()).unwrap().edges.len(), 1);
 
-        let remove = entry::sign_entry(&s, Some(add_hash), 3, &MemoryOp::EdgeRemove {
+        let remove = entry::sign_entry(&s, stream_a(), Some(add_hash), 3, &MemoryOp::EdgeRemove {
             edge_key: key.clone(),
         });
-        append(&conn, &remove.signed_bytes, &s.public(), 3).unwrap();
+        append(&conn, stream_a(), &remove.signed_bytes, &s.public(), 3).unwrap();
         assert!(
-            load_projection(&conn).unwrap().edges.is_empty(),
-            "the DELETE-all reproject drops the tombstoned edge's row"
+            load_projection(&conn, stream_a()).unwrap().edges.is_empty(),
+            "the reproject drops the tombstoned edge's row"
+        );
+    }
+
+    #[test]
+    fn an_entry_offered_for_the_wrong_stream_is_refused() {
+        // The cross-stream replay case the in-body stream_id exists to stop: a validly-signed
+        // stream-B entry offered on stream A is a hard error — never stored, never quarantined
+        // (it is not an equivocation, it is mis-delivery).
+        let conn = db();
+        let s = secret(15);
+        let foreign = entry::sign_entry(&s, stream_b(), None, 1, &create("mem_a", "foreign"));
+        assert!(
+            append(&conn, stream_a(), &foreign.signed_bytes, &s.public(), 1).is_err(),
+            "a stream-B entry must not append onto stream A"
+        );
+        assert_eq!(entry_count(&conn), 0);
+        assert!(fork_evidence(&conn).is_empty(), "mis-delivery is not an equivocation");
+    }
+
+    #[test]
+    fn streams_are_isolated_chains_and_projections() {
+        let conn = db();
+        let s = secret(16);
+
+        // The SAME device opens a genesis at the SAME lamport on two streams: two independent
+        // chains, not a fork.
+        let on_a = entry::sign_entry(&s, stream_a(), None, 1, &create("mem_a", "on a"));
+        let on_b = entry::sign_entry(&s, stream_b(), None, 1, &create("mem_b", "on b"));
+        assert!(matches!(
+            append(&conn, stream_a(), &on_a.signed_bytes, &s.public(), 1).unwrap(),
+            AppendOutcome::Appended { .. }
+        ));
+        assert!(matches!(
+            append(&conn, stream_b(), &on_b.signed_bytes, &s.public(), 2).unwrap(),
+            AppendOutcome::Appended { .. }
+        ));
+
+        // Tails are per (stream, device).
+        let device = s.public().fingerprint();
+        assert_eq!(chain_tail(&conn, stream_a(), device).unwrap().unwrap().lamport, 1);
+        assert_eq!(
+            chain_tail(&conn, stream_a(), device).unwrap().unwrap().entry_hash,
+            on_a.entry.entry_hash
+        );
+        assert_eq!(
+            chain_tail(&conn, stream_b(), device).unwrap().unwrap().entry_hash,
+            on_b.entry.entry_hash
+        );
+
+        // Projections are per stream: each holds exactly its own node.
+        let projected_a = load_projection(&conn, stream_a()).unwrap();
+        let projected_b = load_projection(&conn, stream_b()).unwrap();
+        assert_eq!(projected_a.nodes.len(), 1);
+        assert!(projected_a.nodes.contains_key(&NodeId::from("mem_a")));
+        assert_eq!(projected_b.nodes.len(), 1);
+        assert!(projected_b.nodes.contains_key(&NodeId::from("mem_b")));
+
+        // A fork on stream B never perturbs stream A's chain or projection.
+        let fork_b = entry::sign_entry(&s, stream_b(), None, 2, &create("mem_c", "fork"));
+        assert!(matches!(
+            append(&conn, stream_b(), &fork_b.signed_bytes, &s.public(), 3).unwrap(),
+            AppendOutcome::Fork { .. }
+        ));
+        assert_eq!(load_projection(&conn, stream_a()).unwrap(), projected_a);
+        assert_eq!(load_projection(&conn, stream_b()).unwrap(), projected_b);
+
+        // A wholesale rebuild re-folds every stream and converges to the same state.
+        rebuild_projection(&conn).unwrap();
+        assert_eq!(load_projection(&conn, stream_a()).unwrap(), projected_a);
+        assert_eq!(load_projection(&conn, stream_b()).unwrap(), projected_b);
+    }
+
+    #[test]
+    fn upgrade_refold_rebuilds_every_stream() {
+        // The upgrade re-fold must sweep EVERY stream, not just the busiest: a stream nothing is
+        // writing to would otherwise serve a stale materialization forever after an upgrade.
+        let conn = db();
+        let s = secret(17);
+        let on_a = entry::sign_entry(&s, stream_a(), None, 1, &create("mem_a", "on a"));
+        let on_b = entry::sign_entry(&s, stream_b(), None, 1, &create("mem_b", "on b"));
+        append(&conn, stream_a(), &on_a.signed_bytes, &s.public(), 1).unwrap();
+        append(&conn, stream_b(), &on_b.signed_bytes, &s.public(), 2).unwrap();
+
+        conn.execute_batch(
+            "DELETE FROM oplog_projected_nodes;
+             DELETE FROM oplog_projected_edges;",
+        )
+        .unwrap();
+        conn.execute("UPDATE oplog_meta SET value = '0' WHERE key = ?1", params![
+            PROJECTOR_VERSION_KEY
+        ])
+        .unwrap();
+
+        assert!(reproject_if_projector_stale(&conn).unwrap(), "a stale stamp re-folds");
+        assert_eq!(load_projection(&conn, stream_a()).unwrap().nodes.len(), 1);
+        assert_eq!(load_projection(&conn, stream_b()).unwrap().nodes.len(), 1);
+    }
+
+    #[test]
+    fn append_over_a_stale_stamp_refolds_every_stream_before_stamping() {
+        // An append that finds an older/missing projector stamp writes the store-GLOBAL current
+        // stamp on commit — so it must re-fold every stream first, not just its own. If it swept
+        // only the appended stream, the now-current stamp would stop
+        // `reproject_if_projector_stale` from ever fixing the others' stale rows.
+        let conn = db();
+        let s = secret(18);
+        let on_a = entry::sign_entry(&s, stream_a(), None, 1, &create("mem_a", "on a"));
+        let on_b = entry::sign_entry(&s, stream_b(), None, 1, &create("mem_b", "on b"));
+        append(&conn, stream_a(), &on_a.signed_bytes, &s.public(), 1).unwrap();
+        append(&conn, stream_b(), &on_b.signed_bytes, &s.public(), 2).unwrap();
+
+        // Simulate an old binary's fold: stale shadow rows everywhere, an older stamp.
+        conn.execute_batch(
+            "DELETE FROM oplog_projected_nodes;
+             DELETE FROM oplog_projected_edges;",
+        )
+        .unwrap();
+        conn.execute("UPDATE oplog_meta SET value = '0' WHERE key = ?1", params![
+            PROJECTOR_VERSION_KEY
+        ])
+        .unwrap();
+
+        // Append lands on stream A only.
+        let second = entry::sign_entry(
+            &s,
+            stream_a(),
+            Some(on_a.entry.entry_hash),
+            2,
+            &create("mem_c", "second"),
+        );
+        append(&conn, stream_a(), &second.signed_bytes, &s.public(), 3).unwrap();
+
+        // Stream B's projection was rebuilt too, and the stamp is genuinely current.
+        assert_eq!(load_projection(&conn, stream_b()).unwrap().nodes.len(), 1);
+        assert_eq!(load_projection(&conn, stream_a()).unwrap().nodes.len(), 2);
+        assert!(
+            !reproject_if_projector_stale(&conn).unwrap(),
+            "nothing left for the upgrade re-fold to do"
         );
     }
 }

--- a/crates/rag-rat-core/src/oplog/stream.rs
+++ b/crates/rag-rat-core/src/oplog/stream.rs
@@ -1,0 +1,335 @@
+//! Immutable, content-derived stream identity (phase B, #509).
+//!
+//! A stream is the unit of replication: one signed, per-device hash chain and one watermark exist
+//! PER stream, and a filtered view is its own stream — never a lens over another one. The
+//! identity is derived from the visibility policy itself, so it is immutable by construction:
+//!
+//! ```text
+//! stream_id = sha256( cbor([ "rag-rat/stream/1",
+//!                            repo_set,                  -- byte-sorted, deduped, non-empty
+//!                            kind_allow_list | null,    -- null = UNFILTERED (see below)
+//!                            relation_policy | null,    -- null = ALL RELATIONS
+//!                            per_node_override_set ]))  -- [node_id, action] pairs, node_id-sorted
+//! ```
+//!
+//! Changing the policy (repo set, allow-list, overrides) cannot mutate a stream — it derives a NEW
+//! `stream_id` (a later increment announces the transition with a signed snapshot entry), so
+//! watermark/fork continuity is never claimed across different visibility rules.
+//!
+//! **`null` is NOT an empty list.** The unfiltered (owner) view is encoded as CBOR `null`, a
+//! distinguished marker — deliberately not "every kind known today" enumerated: adding a kind or
+//! relation must stay *data + a projector* (the unknown-op retention seam), and an enumerated full
+//! list would re-mint the owner stream on every vocabulary addition. An EMPTY list is the
+//! degenerate nothing-visible filter and hashes differently.
+//!
+//! Tokens (repo ids, kind/relation tokens, node ids) are machine identifiers and are encoded
+//! VERBATIM — no NFC/trim (the same "structural canonicity only" rule as [`super::op`]).
+
+use minicbor::Encoder;
+use sha2::{Digest, Sha256};
+
+/// Domain tag + version for the stream-identity derivation. Bump only when the canonical rule
+/// itself changes — never when a kind/relation token is added.
+const STREAM_DOMAIN: &str = "rag-rat/stream/1";
+
+/// Writing CBOR into a `Vec` cannot fail (its `Write` impl is infallible) — mirrors `super::op`.
+const INFALLIBLE: &str = "encoding CBOR to a Vec is infallible";
+
+/// A stream's immutable identity: `sha256` of the canonical policy tuple. The scoping key for
+/// chains, watermarks, fork detection, and the shadow projection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct StreamId([u8; 32]);
+
+impl StreamId {
+    pub(crate) fn from_bytes(bytes: [u8; 32]) -> Self {
+        Self(bytes)
+    }
+
+    /// By value — `StreamId` is `Copy` (clippy `wrong_self_convention` flags `to_*` on `&self`).
+    pub(crate) fn to_bytes(self) -> [u8; 32] {
+        self.0
+    }
+}
+
+/// Whether a per-node override pulls a node INTO the view or drops it OUT — the per-node
+/// refinement on top of the per-kind allow-list defaults.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum NodeOverrideAction {
+    Include,
+    Exclude,
+}
+
+impl NodeOverrideAction {
+    /// The frozen wire token — a rename is a format change.
+    fn as_wire_str(self) -> &'static str {
+        match self {
+            Self::Include => "include",
+            Self::Exclude => "exclude",
+        }
+    }
+}
+
+/// One per-node visibility override: `node_id` + the action applied to it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct NodeOverride {
+    pub(crate) node_id: String,
+    pub(crate) action: NodeOverrideAction,
+}
+
+/// The visibility policy a stream identity is derived from. Collections may arrive in any order
+/// with duplicates — [`derive`] canonicalizes (byte-sort + dedup) before encoding, so caller order
+/// never perturbs the identity.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct StreamSpec {
+    /// The repos this stream carries. Non-empty.
+    pub(crate) repo_set: Vec<String>,
+    /// `None` = the UNFILTERED view (every kind, present and future); `Some` = the enumerated
+    /// per-kind allow-list (`Some(vec![])` is the valid nothing-visible degenerate).
+    pub(crate) kind_allow_list: Option<Vec<String>>,
+    /// `None` = all relations; `Some` = the enumerated relation allow-list.
+    pub(crate) relation_policy: Option<Vec<String>>,
+    /// Per-node overrides on top of the kind defaults. One action per `node_id`.
+    pub(crate) node_overrides: Vec<NodeOverride>,
+}
+
+/// The default full-visibility stream a repo's own authored log lives on: one repo, no kind or
+/// relation filtering, no overrides. The only stream shape mintable this increment.
+pub(crate) fn owner_stream(repo_id: &str) -> anyhow::Result<StreamId> {
+    derive(&StreamSpec {
+        repo_set: vec![repo_id.to_string()],
+        kind_allow_list: None,
+        relation_policy: None,
+        node_overrides: Vec::new(),
+    })
+}
+
+/// Derive the immutable `stream_id` for a visibility policy. Canonicalizes the spec (sort + dedup)
+/// first; rejects a policy that has no coherent identity — an empty/blank `repo_set`, or two
+/// overrides that give one `node_id` conflicting actions.
+pub(crate) fn derive(spec: &StreamSpec) -> anyhow::Result<StreamId> {
+    let bytes = canonical_spec_bytes(spec)?;
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&Sha256::digest(&bytes));
+    Ok(StreamId(out))
+}
+
+/// The canonical CBOR tuple the identity hashes — `[domain, repo_set, kind_allow_list | null,
+/// relation_policy | null, override_pairs]`, definite lengths + minimal headers throughout.
+fn canonical_spec_bytes(spec: &StreamSpec) -> anyhow::Result<Vec<u8>> {
+    let repo_set = sorted_deduped(&spec.repo_set);
+    if repo_set.is_empty() {
+        anyhow::bail!("a stream must carry at least one repo");
+    }
+    if repo_set.iter().any(|repo| repo.is_empty()) {
+        anyhow::bail!("a stream repo id must be non-empty");
+    }
+    let kind_allow_list = spec.kind_allow_list.as_deref().map(sorted_deduped);
+    let relation_policy = spec.relation_policy.as_deref().map(sorted_deduped);
+    let overrides = canonical_overrides(&spec.node_overrides)?;
+
+    let mut buf = Vec::with_capacity(96);
+    {
+        let mut enc = Encoder::new(&mut buf);
+        enc.array(5).expect(INFALLIBLE);
+        enc.str(STREAM_DOMAIN).expect(INFALLIBLE);
+        encode_str_array(&mut enc, &repo_set);
+        encode_optional_str_array(&mut enc, kind_allow_list.as_deref());
+        encode_optional_str_array(&mut enc, relation_policy.as_deref());
+        enc.array(overrides.len() as u64).expect(INFALLIBLE);
+        for entry in &overrides {
+            enc.array(2).expect(INFALLIBLE);
+            enc.str(&entry.node_id).expect(INFALLIBLE);
+            enc.str(entry.action.as_wire_str()).expect(INFALLIBLE);
+        }
+    }
+    Ok(buf)
+}
+
+/// Byte-sort + dedup a token list into canonical SET order (the same rule as `NodeContent` tags).
+fn sorted_deduped(values: &[String]) -> Vec<String> {
+    let mut out = values.to_vec();
+    out.sort_unstable();
+    out.dedup();
+    out
+}
+
+/// Canonicalize the override set: sorted by `(node_id, action)`, exact duplicates collapsed, and a
+/// `node_id` carrying BOTH actions rejected — a node cannot be simultaneously included and
+/// excluded, and silently picking one would make two authors derive different "same" streams.
+fn canonical_overrides(overrides: &[NodeOverride]) -> anyhow::Result<Vec<NodeOverride>> {
+    let mut out = overrides.to_vec();
+    out.sort_unstable_by(|a, b| (&a.node_id, a.action).cmp(&(&b.node_id, b.action)));
+    out.dedup();
+    for pair in out.windows(2) {
+        if pair[0].node_id == pair[1].node_id {
+            anyhow::bail!("node `{}` has conflicting stream overrides", pair[0].node_id);
+        }
+    }
+    Ok(out)
+}
+
+fn encode_str_array(enc: &mut Encoder<&mut Vec<u8>>, values: &[String]) {
+    enc.array(values.len() as u64).expect(INFALLIBLE);
+    for value in values {
+        enc.str(value).expect(INFALLIBLE);
+    }
+}
+
+/// `None` → CBOR `null` (the distinguished UNFILTERED marker); `Some` → the enumerated list. The
+/// two must stay distinguishable on the wire — see the module docs.
+fn encode_optional_str_array(enc: &mut Encoder<&mut Vec<u8>>, values: Option<&[String]>) {
+    match values {
+        Some(values) => encode_str_array(enc, values),
+        None => {
+            enc.null().expect(INFALLIBLE);
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::oplog::cbor;
+
+    fn hex(bytes: &[u8]) -> String {
+        bytes.iter().map(|byte| format!("{byte:02x}")).collect()
+    }
+
+    fn filtered_spec() -> StreamSpec {
+        StreamSpec {
+            repo_set: vec!["repo-b".to_string(), "repo-a".to_string()],
+            kind_allow_list: Some(vec!["Invariant".to_string(), "Decision".to_string()]),
+            relation_policy: Some(vec!["tracks".to_string()]),
+            node_overrides: vec![NodeOverride {
+                node_id: "mem_1".to_string(),
+                action: NodeOverrideAction::Exclude,
+            }],
+        }
+    }
+
+    #[test]
+    fn golden_vectors_pin_the_stream_identity() {
+        // The derivation is a frozen primitive: signed entry bodies embed these 32 bytes, so a
+        // canonical-rule change must break this test and force a deliberate `rag-rat/stream/1`
+        // domain bump.
+        let owner = owner_stream("repo-a").unwrap();
+        assert_eq!(
+            hex(&owner.to_bytes()),
+            "4d011fdcf0fad7d9483f70a9bb797f75262758656fe8f3ce88ff8d17ed480c4f",
+            "owner stream golden",
+        );
+        let filtered = derive(&filtered_spec()).unwrap();
+        assert_eq!(
+            hex(&filtered.to_bytes()),
+            "4ae73564c5647cd84e7cc8ca8f8ff680e2c06cb85bbfcfc981c0f8a276d3db06",
+            "filtered stream golden",
+        );
+    }
+
+    #[test]
+    fn canonical_spec_bytes_have_the_expected_structure() {
+        // Structure-level proof of the frozen shape the golden vector pins.
+        let bytes = canonical_spec_bytes(&StreamSpec {
+            repo_set: vec!["repo-a".to_string()],
+            kind_allow_list: None,
+            relation_policy: None,
+            node_overrides: Vec::new(),
+        })
+        .unwrap();
+        assert_eq!(bytes[0], 0x85, "5-element array header");
+        assert_eq!(bytes[1], 0x70, "text header, len 16");
+        assert_eq!(&bytes[2..18], b"rag-rat/stream/1");
+        assert_eq!(bytes[18], 0x81, "repo_set: 1-element array");
+        assert_eq!(bytes[19], 0x66, "text header, len 6");
+        assert_eq!(&bytes[20..26], b"repo-a");
+        assert_eq!(bytes[26], 0xf6, "unfiltered kind_allow_list is CBOR null");
+        assert_eq!(bytes[27], 0xf6, "all-relations policy is CBOR null");
+        assert_eq!(bytes[28], 0x80, "empty override set");
+        assert_eq!(bytes.len(), 29);
+        // And the tuple obeys the module-wide canonical-CBOR floor.
+        cbor::require_canonical_cbor(&bytes).expect("spec tuple is canonical CBOR");
+    }
+
+    #[test]
+    fn caller_order_and_duplicates_never_perturb_the_identity() {
+        let baseline = derive(&filtered_spec()).unwrap();
+        let shuffled = StreamSpec {
+            repo_set: vec!["repo-a".to_string(), "repo-b".to_string(), "repo-a".to_string()],
+            kind_allow_list: Some(vec![
+                "Decision".to_string(),
+                "Invariant".to_string(),
+                "Decision".to_string(),
+            ]),
+            relation_policy: Some(vec!["tracks".to_string(), "tracks".to_string()]),
+            node_overrides: vec![
+                NodeOverride { node_id: "mem_1".to_string(), action: NodeOverrideAction::Exclude },
+                NodeOverride { node_id: "mem_1".to_string(), action: NodeOverrideAction::Exclude },
+            ],
+        };
+        assert_eq!(derive(&shuffled).unwrap(), baseline);
+    }
+
+    #[test]
+    fn unfiltered_null_is_distinct_from_an_empty_allow_list() {
+        // `None` (every kind, forever) and `Some(vec![])` (nothing visible) are different
+        // policies and MUST derive different identities.
+        let unfiltered = owner_stream("repo-a").unwrap();
+        let nothing_visible = derive(&StreamSpec {
+            repo_set: vec!["repo-a".to_string()],
+            kind_allow_list: Some(Vec::new()),
+            relation_policy: None,
+            node_overrides: Vec::new(),
+        })
+        .unwrap();
+        assert_ne!(unfiltered, nothing_visible);
+    }
+
+    #[test]
+    fn every_policy_dimension_feeds_the_identity() {
+        let base = filtered_spec();
+        let baseline = derive(&base).unwrap();
+        let repo_changed = StreamSpec { repo_set: vec!["repo-c".to_string()], ..base.clone() };
+        let kinds_changed =
+            StreamSpec { kind_allow_list: Some(vec!["Risk".to_string()]), ..base.clone() };
+        let relations_changed = StreamSpec { relation_policy: None, ..base.clone() };
+        let overrides_changed = StreamSpec {
+            node_overrides: vec![NodeOverride {
+                node_id: "mem_1".to_string(),
+                action: NodeOverrideAction::Include,
+            }],
+            ..base
+        };
+        for changed in [repo_changed, kinds_changed, relations_changed, overrides_changed] {
+            assert_ne!(derive(&changed).unwrap(), baseline, "changed policy, same id: {changed:?}");
+        }
+    }
+
+    #[test]
+    fn an_empty_or_blank_repo_set_is_rejected() {
+        assert!(
+            derive(&StreamSpec {
+                repo_set: Vec::new(),
+                kind_allow_list: None,
+                relation_policy: None,
+                node_overrides: Vec::new(),
+            })
+            .is_err(),
+            "empty repo_set",
+        );
+        assert!(owner_stream("").is_err(), "blank repo id");
+    }
+
+    #[test]
+    fn conflicting_node_overrides_are_rejected() {
+        let spec = StreamSpec {
+            repo_set: vec!["repo-a".to_string()],
+            kind_allow_list: None,
+            relation_policy: None,
+            node_overrides: vec![
+                NodeOverride { node_id: "mem_1".to_string(), action: NodeOverrideAction::Include },
+                NodeOverride { node_id: "mem_1".to_string(), action: NodeOverrideAction::Exclude },
+            ],
+        };
+        assert!(derive(&spec).is_err(), "one node cannot be both included and excluded");
+    }
+}


### PR DESCRIPTION
Fifth phase-B op-log increment, after #480 (content_hash), #495 (op model + fold), #500 (signed entry envelope), and #504 (durable layer-1 store). Gives the durable log the stream dimension the live write-path wiring needs — "one log per (repo stream, device)" — before any chain is signed against the un-scoped shape.

## What lands

**`oplog::stream`** — the frozen identity primitive: `stream_id = sha256(cbor(["rag-rat/stream/1", repo_set, kind_allow_list, relation_policy, per_node_override_set]))`, canonical CBOR, golden-vector-pinned. `kind_allow_list`/`relation_policy` encode the unfiltered view as CBOR `null` — a distinguished marker, deliberately not an enumerated list, so the default **owner stream** (`derive([repo_id], null, null, [])`) never re-mints when a kind/relation is added (that stays data + a projector). `Some(vec![])` is the distinct nothing-visible degenerate. Duplicate/order-insensitive; empty repo sets and conflicting per-node overrides are rejected.

**Entry body binds its stream** — `body_bytes = cbor([domain, stream_id, prev_hash, lamport, device_fingerprint, op_bytes])` under a bumped **`rag-rat/entry/2`** domain (`/1` never shipped and has no decoder; the bump keeps the bump-on-rule-change contract exception-free). Stream membership is now signature-protected: a signed entry cannot be replayed from one stream into another, and `entry_hash` becomes globally unique across streams. `verify_chain` additionally rejects a mixed-stream chain.

**V053** — rebuilds the (provably empty — the module is un-wired, so nothing has ever written them) V052 op-log tables stream-scoped: `oplog_entries` gains `stream_id` with `UNIQUE(stream_id, device_fingerprint, lamport)`; the projection tables key on `(stream_id, node_id / edge_key)`; new **`oplog_fork_evidence`** quarantine table. The DROP+CREATE recipe is documented as safe only pre-wiring.

**`oplog::store`** — `append` takes the expected stream and hard-errors on a body-stream mismatch; chain tail / predecessor / conflict queries scope by `(stream_id, device)` (the same device can hold independent chains at the same lamport on two streams); the projection re-folds per stream. A `Fork` rejection now durably quarantines the rejected head (with the conflicting entry's hash) instead of only returning it — both heads of an equivocation survive a process exit — while the log and projection stay untouched. An append that finds a stale/missing projector stamp re-folds **every** stream before writing the store-global stamp, so a quiet stream can never be marked current while stale.

## Scope

Still un-wired to the live write path — device-key persistence, per-stream lamport allocation, the authoring seam, roster/epochs, and transport are later increments. View-epoch/snapshot-transition entries wait until a second stream shape is mintable.

## Tests

Stream-identity golden vectors + canonicalization/rejection matrix; re-pinned entry goldens + byte-structure walks + a stream-tamper case + mixed-stream chain rejection; store cross-stream isolation (chains, forks, projections), wrong-stream replay refusal, fork-evidence persistence/idempotence, stale-stamp append re-folding every stream; V053 forward + deferred-absence-in-isolation, with the schema tip pin moved 052 → 053. Full workspace suite green (2002); clippy clean on both feature sets; nightly fmt clean.

Fixes #509