### PR TITLE
feat(clones): scip refine mode — moniker-collapse same-symbol callees to Type-2

### DIFF
--- a/crates/rag-rat-core/src/index/clones/refine/antiunify/classify.rs
+++ b/crates/rag-rat-core/src/index/clones/refine/antiunify/classify.rs
@@ -98,7 +98,51 @@ pub(super) fn matched_column_reopen(
     };
     // The erasure only matters when the recovered source values actually differ (C1 up front): a
     // same-callee / same-type / same-literal column stays fixed.
-    matched_source_values_differ(members, alignment, col).then_some(role)
+    if !matched_source_values_differ(members, alignment, col) {
+        return None;
+    }
+    // SCIP moniker collapse (#275, Plan 3): a callee column whose members SPELL the callee
+    // differently but all RESOLVE to one oracle moniker is the same function (moved / aliased /
+    // re-exported) — the Type-2 equivalence the baseline can't prove. The column stays FIXED
+    // (anchor's spelling renders), exactly like a consistently-renamed value local; no variation
+    // point, no `differing_callee`. Only fires when EVERY contributing member carries a moniker
+    // for its span (attached only in scip refine mode) — one missing resolution vetoes the
+    // collapse, so oracle staleness degrades to today's conservative reopen, never a wrong fix.
+    if role == ReopenRole::Callee && matched_callee_monikers_agree(members, alignment, col) {
+        return None;
+    }
+    Some(role)
+}
+
+/// `true` when EVERY aligned member contributing a token at matched column `col` carries a SCIP
+/// callee moniker for that token's span, and all those monikers name ONE symbol (#275, Plan 3).
+/// A contributing member WITHOUT a moniker returns `false` (no oracle evidence → no collapse);
+/// members that gapped the column contribute no opinion, mirroring
+/// [`matched_source_values_differ`]. `local N` monikers never reach here
+/// (`current_callee_monikers` drops them — document-scoped identity must not equate across
+/// files).
+fn matched_callee_monikers_agree(
+    members: &[RefineMember],
+    alignment: &ClassAlignment,
+    col: usize,
+) -> bool {
+    let mut seen: Option<&str> = None;
+    for (m_idx, member) in members.iter().enumerate() {
+        if !alignment.aligned[m_idx] {
+            continue;
+        }
+        let Some(j) = alignment.col_map[m_idx][col] else { continue };
+        let span = &member.node_spans[j];
+        let Some(moniker) = member.callee_monikers.get(&(span.start_byte, span.end_byte)) else {
+            return false;
+        };
+        match seen {
+            None => seen = Some(moniker),
+            Some(prev) if prev == moniker => {},
+            Some(_) => return false,
+        }
+    }
+    seen.is_some()
 }
 
 /// `true` when the anchor's spine leaf at column `col` is a callee / method-name identifier in
@@ -212,7 +256,16 @@ pub(super) fn classify_run(
     // DIFFERS across members is closure_param Medium/Low, NEVER a high-confidence value_param.
     // Baseline cannot prove two differing callees resolve to the same symbol. `differing_callee` is
     // set true ONLY here, so downstream scoring keys off the real seam, not the band (Fix 5).
-    if run_callees_differ(per_member_values) {
+    //
+    // SCIP moniker collapse (#275, Plan 3): when the oracle CAN prove it — every member realises
+    // the run as one callee leaf whose attached moniker is the SAME symbol — the guard is skipped
+    // and the run classifies through the normal ladder (a single `ID` leaf lands at rule (2)
+    // value_param, like any consistently-equivalent rename), never `differing_callee`. Scope is
+    // deliberately same-call-syntax only (finding 2): a multi-token or cross-syntax run
+    // (`a::b::foo()` vs `foo()`) fails the single-leaf gate and keeps today's verdict.
+    if run_callees_differ(per_member_values)
+        && !run_callee_monikers_agree(members, alignment, lo, hi)
+    {
         if opens_call_head(anchor_kind) {
             // The run snapped to the call node itself — generic differing call subtree, Low.
             return RunClass {
@@ -557,6 +610,59 @@ fn uniform_literal_bucket(
         }
     }
     bucket.map(|b| b.to_string())
+}
+
+/// `true` when EVERY aligned member realises the run `[lo..=hi]` as exactly ONE leaf token whose
+/// span carries a SCIP callee moniker, and all those monikers name ONE symbol (#275, Plan 3) —
+/// the oracle-proven "same function, different spelling" case the differing-callee guard exists
+/// to be conservative about. Any member realising the run as a multi-token subtree, a non-leaf,
+/// or a leaf WITHOUT a moniker returns `false` (finding 2's same-call-syntax scope + the
+/// no-evidence veto); a member that gapped the run contributes no opinion, mirroring
+/// [`run_callees_differ`]'s empty-value skip. Token indices are gathered the same way as
+/// [`every_member_single_leaf`] (col_map slots + inserts keyed in the run).
+fn run_callee_monikers_agree(
+    members: &[RefineMember],
+    alignment: &ClassAlignment,
+    lo: usize,
+    hi: usize,
+) -> bool {
+    let mut seen: Option<&str> = None;
+    for (m_idx, member) in members.iter().enumerate() {
+        if !alignment.aligned[m_idx] {
+            continue;
+        }
+        let cm = &alignment.col_map[m_idx];
+        let inserts = &alignment.member_inserts[m_idx];
+        let mut idxs: Vec<usize> = Vec::new();
+        for &slot in &cm[lo..=hi] {
+            if let Some(j) = slot {
+                idxs.push(j);
+            }
+        }
+        for (_key, ins) in inserts.range(lo..=hi) {
+            idxs.extend(ins.iter().copied());
+        }
+        if idxs.is_empty() {
+            // A gap / cost-skipped member has no callee to compare — no opinion.
+            continue;
+        }
+        if idxs.len() != 1 {
+            return false;
+        }
+        let span = &member.node_spans[idxs[0]];
+        if !span.is_leaf {
+            return false;
+        }
+        let Some(moniker) = member.callee_monikers.get(&(span.start_byte, span.end_byte)) else {
+            return false;
+        };
+        match seen {
+            None => seen = Some(moniker),
+            Some(prev) if prev == moniker => {},
+            Some(_) => return false,
+        }
+    }
+    seen.is_some()
 }
 
 /// `true` when the run's per-member values (the call/method subtree source) differ across members —

--- a/crates/rag-rat-core/src/index/clones/refine/antiunify/statement.rs
+++ b/crates/rag-rat-core/src/index/clones/refine/antiunify/statement.rs
@@ -481,6 +481,9 @@ fn emit_matched_statement_redescent(
             seq: member.seq[start..end].to_vec(),
             node_spans: member.node_spans[start..end].to_vec(),
             text: member.text.clone(),
+            // Same ABSOLUTE offsets as the parent, so the moniker map carries over verbatim —
+            // the #275 callee collapse works inside a re-descended statement too.
+            callee_monikers: member.callee_monikers.clone(),
         });
         sub_to_full.push(m_idx);
     }
@@ -624,6 +627,7 @@ mod coverage_tests {
         node_spans: Vec<NodeSpan>,
     ) -> RefineMember {
         RefineMember {
+            callee_monikers: Default::default(),
             symbol_id,
             lang: Language::Rust,
             struct_hash: seq.join("\u{1}"),

--- a/crates/rag-rat-core/src/index/clones/refine/antiunify/tests.rs
+++ b/crates/rag-rat-core/src/index/clones/refine/antiunify/tests.rs
@@ -17,7 +17,15 @@ fn member(symbol_id: i64, src: &str) -> RefineMember {
         parsed.root().descendant_for_byte_range(func.start_byte, func.end_byte).expect("node");
     let (seq, node_spans) = normalize_baseline_spanned(node, &text, Language::Rust);
     let struct_hash = tokens::struct_hash(&seq);
-    RefineMember { symbol_id, lang: Language::Rust, struct_hash, seq, node_spans, text }
+    RefineMember {
+        callee_monikers: Default::default(),
+        symbol_id,
+        lang: Language::Rust,
+        struct_hash,
+        seq,
+        node_spans,
+        text,
+    }
 }
 
 /// Build a `RefineMember` from a TypeScript snippet — the TS analogue of [`member`]. Picks the
@@ -39,7 +47,15 @@ fn member_ts(symbol_id: i64, src: &str) -> RefineMember {
         .expect("a body symbol");
     let (seq, node_spans) = normalize_baseline_spanned(node, &text, Language::TypeScript);
     let struct_hash = tokens::struct_hash(&seq);
-    RefineMember { symbol_id, lang: Language::TypeScript, struct_hash, seq, node_spans, text }
+    RefineMember {
+        callee_monikers: Default::default(),
+        symbol_id,
+        lang: Language::TypeScript,
+        struct_hash,
+        seq,
+        node_spans,
+        text,
+    }
 }
 
 /// Sort members into the canonical order the loader guarantees. Production keys on the
@@ -913,6 +929,145 @@ fn differing_free_callee_at_matched_column_is_closure_param() {
     );
 }
 
+/// Attach a SCIP callee moniker for the `nth` (0-based) occurrence of `name` in the member's
+/// source — the span-exact map `current_callee_monikers` would build in scip refine mode (#275).
+fn with_callee_moniker(
+    mut member: RefineMember,
+    name: &str,
+    nth: usize,
+    moniker: &str,
+) -> RefineMember {
+    let mut from = 0;
+    let mut start = None;
+    for _ in 0..=nth {
+        let at = member.text[from..].find(name).expect("callee occurrence present") + from;
+        start = Some(at);
+        from = at + name.len();
+    }
+    let start = start.expect("nth occurrence");
+    member.callee_monikers.insert((start, start + name.len()), moniker.to_string());
+    member
+}
+
+#[test]
+fn same_moniker_callee_at_matched_column_stays_fixed() {
+    // #275 (Plan 3): the SAME fixture as `differing_free_callee_at_matched_column_is_closure_param`
+    // — `foo()` vs `bar()` at an LCS-matched callee column — but the oracle proves both spellings
+    // resolve to ONE moniker (a moved / aliased / re-exported same function). The reopen must NOT
+    // fire: the column stays FIXED (the anchor's spelling renders as template text — finding 4's
+    // "a collapsed callee becomes fixed template text"), there is NO variation point, NO
+    // `differing_callee`, and coverage stays 1.0 — the Type-2 lift.
+    let a = with_callee_moniker(member(1, "fn a(){ foo(); }"), "foo", 0, "rust cr 1.0 m/foo().");
+    let b = with_callee_moniker(member(2, "fn b(){ bar(); }"), "bar", 0, "rust cr 1.0 m/foo().");
+    let (_members, template) = run(vec![a, b]);
+
+    assert!(
+        template.variation_points.is_empty(),
+        "a moniker-proven same-symbol callee must not open a variation point, got {:?}",
+        template.variation_points
+    );
+    assert!(
+        (template.anti_unify_coverage - 1.0).abs() < 1e-12,
+        "a collapsed callee keeps coverage 1.0, got {}",
+        template.anti_unify_coverage
+    );
+    assert!(
+        template.text.contains("foo"),
+        "the collapsed column renders the anchor's spelling as fixed text, got {:?}",
+        template.text
+    );
+}
+
+#[test]
+fn differing_moniker_callee_still_reopens_as_closure_param() {
+    // #275: monikers attached but DIFFERENT — genuinely different functions. The collapse must
+    // not fire; the reopen routes through the differing-callee guard exactly as with no oracle.
+    let a = with_callee_moniker(member(1, "fn a(){ foo(); }"), "foo", 0, "rust cr 1.0 m/foo().");
+    let b = with_callee_moniker(member(2, "fn b(){ bar(); }"), "bar", 0, "rust cr 1.0 m/bar().");
+    let (_members, template) = run(vec![a, b]);
+
+    assert_eq!(template.variation_points.len(), 1, "got {:?}", template.variation_points);
+    let vp = &template.variation_points[0];
+    assert_eq!(vp.kind, MetavarKind::ClosureParam);
+    assert!(vp.differing_callee, "different monikers keep the differing-callee verdict");
+}
+
+#[test]
+fn missing_moniker_on_one_member_vetoes_the_collapse() {
+    // #275: only ONE member carries oracle evidence (stale coverage for the other file, a drifted
+    // member, an unresolved callee). No proof ⇒ no collapse — the conservative reopen stands.
+    let a = with_callee_moniker(member(1, "fn a(){ foo(); }"), "foo", 0, "rust cr 1.0 m/foo().");
+    let b = member(2, "fn b(){ bar(); }");
+    let (_members, template) = run(vec![a, b]);
+
+    assert_eq!(template.variation_points.len(), 1, "got {:?}", template.variation_points);
+    let vp = &template.variation_points[0];
+    assert_eq!(vp.kind, MetavarKind::ClosureParam);
+    assert!(vp.differing_callee, "a member without a moniker must veto the collapse");
+}
+
+#[test]
+fn same_moniker_callee_in_matched_statement_redescent_is_not_differing() {
+    // #275, the VARIATION-RUN site (`run_callees_differ` guard): the
+    // `matched_statement_differing_callee_after_indel_is_closure_param` fixture — the matched
+    // second statement's callee genuinely differs in token space (reused `a` = ID0 vs fresh `b` =
+    // ID1, so LCS makes it a variation run, not a matched column) — but the oracle proves both
+    // resolve to ONE moniker. The guard is skipped: the run classifies through the normal ladder
+    // (a single `ID` leaf ⇒ value_param), NEVER `differing_callee`. This also pins that the
+    // moniker map survives the statement re-descent (the sub-members share the parent's absolute
+    // offsets).
+    let a = with_callee_moniker(
+        member(1, "fn f(){ a(); a(); let z = 0; }"),
+        "a",
+        // Occurrences of "a" in the source: the fn param list has none; `fn f(){ a(); a(); …` —
+        // occurrence 0 is the first callee, 1 the second (the compared statement's callee).
+        // Attach BOTH so whichever statement the alignment compares carries evidence.
+        0,
+        "rust cr 1.0 m/same().",
+    );
+    let a = with_callee_moniker(a, "a", 1, "rust cr 1.0 m/same().");
+    let b = with_callee_moniker(
+        member(2, "fn f(){ a(); b(); let z = 0; w(); }"),
+        "b",
+        0,
+        "rust cr 1.0 m/same().",
+    );
+    // Member b's FIRST callee `a` matches member a's — equal values never reopen, but attach the
+    // moniker anyway (the production map covers every resolved call site).
+    let b = with_callee_moniker(b, "a", 0, "rust cr 1.0 m/same().");
+    let (_members, template) = run(vec![a, b]);
+
+    // The a/b callee variation must NOT be a differing callee any more…
+    assert!(
+        template.variation_points.iter().all(|vp| !vp.differing_callee),
+        "a moniker-proven same-symbol callee must not be flagged differing_callee, got {:?}",
+        template.variation_points
+    );
+    // …it classifies through the ladder as a plain single-leaf value hole instead.
+    let collapsed_vp = template
+        .variation_points
+        .iter()
+        .find(|vp| {
+            let mut vals = vp.per_member_values.clone();
+            vals.retain(|v| !v.is_empty());
+            vals.sort();
+            vals == vec!["a".to_string(), "b".to_string()]
+        })
+        .expect("the a/b callee column still surfaces as a variation point");
+    assert_eq!(
+        collapsed_vp.kind,
+        MetavarKind::ValueParam,
+        "the guard-skipped single-leaf run falls through to value_param, got {:?}",
+        collapsed_vp
+    );
+    // The inserted `w();` stays gapped — the collapse never touches indel handling.
+    assert!(
+        template.variation_points.iter().any(|vp| vp.kind == MetavarKind::Gapped),
+        "the inserted w(); must stay a gapped metavar, got {:?}",
+        template.variation_points
+    );
+}
+
 #[test]
 fn differing_scoped_path_callee_tail_at_matched_column_is_closure_param() {
     // #235 item 18: `m::foo()` vs `m::bar()` differ only in the FINAL path segment. Both
@@ -1318,6 +1473,7 @@ fn synthetic_method_call() -> RefineMember {
         "ID2".to_string(),
     ];
     RefineMember {
+        callee_monikers: Default::default(),
         symbol_id: 1,
         lang: Language::Rust,
         struct_hash: "synthetic".to_string(),
@@ -1690,6 +1846,7 @@ fn synthetic_member(symbol_id: i64, struct_hash: &str, token_count: usize) -> Re
         })
         .collect();
     RefineMember {
+        callee_monikers: Default::default(),
         symbol_id,
         lang: Language::Rust,
         struct_hash: struct_hash.to_string(),
@@ -1980,6 +2137,7 @@ fn zero_width_insert_sharing_column_is_rendered() {
     // non-deterministic to force): a 3-leaf anchor, a consuming gapped VP over cols
     // [1..=2], and a zero-width gapped VP also attached at col 1.
     let anchor = RefineMember {
+        callee_monikers: Default::default(),
         symbol_id: 1,
         lang: Language::Rust,
         struct_hash: "synthetic".to_string(),
@@ -2753,6 +2911,7 @@ fn defensive_member_sample_cap_marks_tail_members_unaligned() {
 fn call_node_differing_callee_classifies_low_with_flag() {
     let members = vec![
         RefineMember {
+            callee_monikers: Default::default(),
             symbol_id: 1,
             lang: Language::Rust,
             struct_hash: "call".to_string(),
@@ -2766,6 +2925,7 @@ fn call_node_differing_callee_classifies_low_with_flag() {
             text: Arc::from("foo()"),
         },
         RefineMember {
+            callee_monikers: Default::default(),
             symbol_id: 2,
             lang: Language::Rust,
             struct_hash: "call".to_string(),
@@ -2831,6 +2991,7 @@ fn split_helper_defensive_paths_are_covered() {
     assert_eq!(classified.hi(), 8);
 
     let invalid_utf8_slice = RefineMember {
+        callee_monikers: Default::default(),
         symbol_id: 1,
         lang: Language::Rust,
         struct_hash: "utf8".to_string(),
@@ -2848,6 +3009,7 @@ fn split_helper_defensive_paths_are_covered() {
     ]);
 
     let empty_anchor = RefineMember {
+        callee_monikers: Default::default(),
         symbol_id: 2,
         lang: Language::Rust,
         struct_hash: "empty".to_string(),
@@ -2858,6 +3020,7 @@ fn split_helper_defensive_paths_are_covered() {
     assert_eq!(annotation_type_context(&empty_anchor, 0), None);
 
     let invalid_type_slice = RefineMember {
+        callee_monikers: Default::default(),
         symbol_id: 3,
         lang: Language::Rust,
         struct_hash: "bad-type".to_string(),
@@ -2871,6 +3034,7 @@ fn split_helper_defensive_paths_are_covered() {
     assert_eq!(annotation_type_context(&invalid_type_slice, 1), None);
 
     let colon_without_type = RefineMember {
+        callee_monikers: Default::default(),
         symbol_id: 4,
         lang: Language::Rust,
         struct_hash: "no-type".to_string(),
@@ -2884,6 +3048,7 @@ fn split_helper_defensive_paths_are_covered() {
     assert_eq!(annotation_type_context(&colon_without_type, 1), None);
 
     let interpolated_template = RefineMember {
+        callee_monikers: Default::default(),
         symbol_id: 5,
         lang: Language::TypeScript,
         struct_hash: "template".to_string(),
@@ -2906,6 +3071,7 @@ fn split_helper_defensive_paths_are_covered() {
     assert_eq!(widen_string_content_run(&interpolated_template, 2, 2), (2, 2));
 
     let duplicate_string_candidates = RefineMember {
+        callee_monikers: Default::default(),
         symbol_id: 6,
         lang: Language::Rust,
         struct_hash: "duplicate-strings".to_string(),

--- a/crates/rag-rat-core/src/index/clones/refine/cache.rs
+++ b/crates/rag-rat-core/src/index/clones/refine/cache.rs
@@ -23,8 +23,38 @@ use super::signature::propose_signature;
 use crate::index::clones::refine::RefineMember;
 use crate::index::clones::{ALIGNMENT_VERSION, NORM_VERSION};
 
-/// The 4a refine mode. Baseline token space only; the SCIP-aware mode is Plan 3/4b.
-const REFINE_MODE: &str = "baseline";
+/// The refine mode: which evidence the anti-unification classifier was allowed to consult.
+///
+/// `Baseline` is the 4a token-space-only mode. `Scip` (#275, Plan 3) additionally consults the
+/// SCIP-oracle callee monikers attached to each [`RefineMember`] — a same-named-different-spelling
+/// callee whose members all resolve to ONE moniker collapses back into the fixed spine instead of
+/// reopening as a `closure_param`/`differing_callee` variation. The mode is folded into
+/// [`refinement_key`], so the two modes address DISJOINT cache rows: an oracle run can invalidate
+/// every scip-mode row ([`invalidate_scip_refinements`]) without touching baseline rows, and a
+/// baseline row can never serve a scip-mode read.
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    serde::Serialize,
+    serde::Deserialize,
+    strum::EnumString,
+    strum::IntoStaticStr,
+)]
+#[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
+pub(crate) enum RefineMode {
+    Baseline,
+    Scip,
+}
+
+impl RefineMode {
+    pub(crate) fn as_db_str(&self) -> &'static str {
+        (*self).into()
+    }
+}
 
 /// A computed (or cache-hit) refinement for one clone class.
 ///
@@ -38,7 +68,7 @@ pub(crate) struct CachedRefinement {
     pub(crate) lcs_ratio: f64,
     pub(crate) confidence: Confidence,
     pub(crate) refactorability: f64,
-    pub(crate) refine_mode: &'static str,
+    pub(crate) refine_mode: RefineMode,
     /// The rendered anti-unification template (`clone_refinements.template`): fixed runs verbatim,
     /// variation runs as `⟨m0⟩`, gapped runs as `⟨m2?⟩`.
     pub(crate) template: String,
@@ -89,6 +119,7 @@ pub(crate) struct CachedRefinement {
 /// duplicates is preserved; structurally-identical-but-source-different classes get distinct keys.
 pub(crate) fn refinement_key(
     language: &str,
+    mode: RefineMode,
     struct_hashes: &[String],
     source_discriminators: &[String],
 ) -> String {
@@ -100,7 +131,7 @@ pub(crate) fn refinement_key(
     let mut material = String::new();
     material.push_str(language);
     material.push('\0');
-    material.push_str(REFINE_MODE);
+    material.push_str(mode.as_db_str());
     material.push('\0');
     material.push_str(&NORM_VERSION.to_string());
     material.push('\0');
@@ -129,6 +160,7 @@ pub(crate) fn refinement_key(
 pub(crate) fn refine_lookup(
     conn: &Connection,
     refinement_key: &str,
+    mode: RefineMode,
 ) -> anyhow::Result<Option<CachedRefinement>> {
     // The full content payload (4b): the rendered template + the serialized variation_points /
     // proposed_signature + the REAL anti_unify_coverage round-trip alongside the scoring outputs,
@@ -147,9 +179,10 @@ pub(crate) fn refine_lookup(
                 "SELECT lcs_ratio, confidence, refactorability, lcs_sampled,
                     template, variation_points_json, proposed_signature_json, anti_unify_coverage
              FROM clone_refinements
-             WHERE class_key = ?1 AND norm_version = ?2 AND alignment_version = ?3{repo_clause}"
+             WHERE class_key = ?1 AND norm_version = ?2 AND alignment_version = ?3
+               AND refine_mode = ?4{repo_clause}"
             ),
-            rusqlite::params![refinement_key, NORM_VERSION, ALIGNMENT_VERSION],
+            rusqlite::params![refinement_key, NORM_VERSION, ALIGNMENT_VERSION, mode.as_db_str()],
             |row| {
                 Ok((
                     row.get(0)?,
@@ -178,7 +211,9 @@ pub(crate) fn refine_lookup(
             lcs_ratio,
             confidence: Confidence::from_db_str(&confidence),
             refactorability,
-            refine_mode: REFINE_MODE,
+            // The key folds the mode and the WHERE filters on it, so the row's mode IS the
+            // requested one — no re-parse needed.
+            refine_mode: mode,
             template,
             variation_points_json,
             proposed_signature_json,
@@ -211,6 +246,7 @@ pub(crate) fn refine_compute_and_store(
     conn: &Connection,
     refinement_key: &str,
     language: &str,
+    mode: RefineMode,
     members: &[RefineMember],
     similarity_min: f64,
     medoid_symbol_id: Option<i64>,
@@ -219,6 +255,7 @@ pub(crate) fn refine_compute_and_store(
         conn,
         refinement_key,
         language,
+        mode,
         members,
         similarity_min,
         medoid_symbol_id,
@@ -242,11 +279,20 @@ pub(crate) fn refine_compute_and_store_budgeted(
     conn: &Connection,
     refinement_key: &str,
     language: &str,
+    mode: RefineMode,
     members: &[RefineMember],
     similarity_min: f64,
     medoid_symbol_id: Option<i64>,
     mut global_remaining: Option<&mut u64>,
 ) -> anyhow::Result<CachedRefinement> {
+    // MODE COHERENCE (#275): a Baseline row must be oracle-independent — it survives
+    // `invalidate_scip_refinements`, so its payload may never depend on attached monikers. The
+    // driver only attaches monikers when it probed Scip; this assert keeps a future caller from
+    // silently computing an oracle-dependent payload under a baseline key.
+    debug_assert!(
+        mode == RefineMode::Scip || members.iter().all(|m| m.callee_monikers.is_empty()),
+        "baseline refine must not receive members with attached callee monikers"
+    );
     // `lcs_ratio` stays the NiCad class fidelity (min pairwise 2·LCS/(|a|+|b|)) + its sampling bit.
     let seqs: Vec<Vec<String>> = members.iter().map(|m| m.seq.clone()).collect();
     let (lcs_ratio, lcs_sampled) = match global_remaining.as_deref_mut() {
@@ -314,7 +360,7 @@ pub(crate) fn refine_compute_and_store_budgeted(
         rusqlite::params![
             refinement_key,
             language,
-            REFINE_MODE,
+            mode.as_db_str(),
             template.text,
             variation_points_json,
             proposed_signature_json,
@@ -333,7 +379,7 @@ pub(crate) fn refine_compute_and_store_budgeted(
         lcs_ratio,
         confidence,
         refactorability,
-        refine_mode: REFINE_MODE,
+        refine_mode: mode,
         template: template.text,
         variation_points_json,
         proposed_signature_json,
@@ -352,21 +398,45 @@ pub(crate) fn refine_class(
     conn: &Connection,
     refinement_key: &str,
     language: &str,
+    mode: RefineMode,
     members: &[RefineMember],
     similarity_min: f64,
     medoid_symbol_id: Option<i64>,
 ) -> anyhow::Result<CachedRefinement> {
-    if let Some(cached) = refine_lookup(conn, refinement_key)? {
+    if let Some(cached) = refine_lookup(conn, refinement_key, mode)? {
         return Ok(cached);
     }
     refine_compute_and_store(
         conn,
         refinement_key,
         language,
+        mode,
         members,
         similarity_min,
         medoid_symbol_id,
     )
+}
+
+/// Drop every NON-baseline refinement row (#275, finding 3): an `oracle run` rewrites the
+/// `edge_oracle` moniker evidence a scip-mode refinement consulted, and NOTHING in
+/// [`refinement_key`] changes when a moniker changes (the key folds struct_hashes + source
+/// discriminators, both oracle-blind) — so the rows must be invalidated wholesale. Baseline rows
+/// never consult oracle evidence (see the mode-coherence assert in
+/// [`refine_compute_and_store_budgeted`]) and are deliberately spared. Scoped to the active repo
+/// (`clone_refinements` is repo-scoped since A5); the dropped classes recompute lazily on the next
+/// `find_clones` refine pass.
+pub(crate) fn invalidate_scip_refinements(conn: &Connection) -> anyhow::Result<usize> {
+    let scope = crate::index::schema::periphery_repo_scope(conn, "clone_refinements")?;
+    let repo_clause =
+        crate::index::schema::periphery_repo_scope_clause(&scope, "clone_refinements");
+    let dropped = conn.execute(
+        &format!(
+            "DELETE FROM clone_refinements
+             WHERE refine_mode <> ?1{repo_clause}"
+        ),
+        rusqlite::params![RefineMode::Baseline.as_db_str()],
+    )?;
+    Ok(dropped)
 }
 
 #[cfg(test)]
@@ -393,7 +463,15 @@ mod tests {
             parsed.root().descendant_for_byte_range(func.start_byte, func.end_byte).expect("node");
         let (seq, node_spans) = normalize_baseline_spanned(node, &text, Language::Rust);
         let struct_hash = tokens::struct_hash(&seq);
-        RefineMember { symbol_id, lang: Language::Rust, struct_hash, seq, node_spans, text }
+        RefineMember {
+            callee_monikers: Default::default(),
+            symbol_id,
+            lang: Language::Rust,
+            struct_hash,
+            seq,
+            node_spans,
+            text,
+        }
     }
 
     /// Per-member source discriminator the way `load_source_discriminators` builds it in
@@ -413,28 +491,63 @@ mod tests {
 
     #[test]
     fn refinement_key_is_order_independent_over_struct_hashes() {
-        let k1 = refinement_key("rust", &["aaa".into(), "bbb".into(), "ccc".into()], &[]);
-        let k2 = refinement_key("rust", &["ccc".into(), "aaa".into(), "bbb".into()], &[]);
+        let k1 = refinement_key(
+            "rust",
+            RefineMode::Baseline,
+            &["aaa".into(), "bbb".into(), "ccc".into()],
+            &[],
+        );
+        let k2 = refinement_key(
+            "rust",
+            RefineMode::Baseline,
+            &["ccc".into(), "aaa".into(), "bbb".into()],
+            &[],
+        );
         assert_eq!(k1, k2, "the same struct_hash multiset must address the same refinement");
 
         // Source discriminators are ALSO order-independent (sorted before folding).
-        let d1 = refinement_key("rust", &["aaa".into()], &["s1".into(), "s2".into()]);
-        let d2 = refinement_key("rust", &["aaa".into()], &["s2".into(), "s1".into()]);
+        let d1 = refinement_key("rust", RefineMode::Baseline, &["aaa".into()], &[
+            "s1".into(),
+            "s2".into(),
+        ]);
+        let d2 = refinement_key("rust", RefineMode::Baseline, &["aaa".into()], &[
+            "s2".into(),
+            "s1".into(),
+        ]);
         assert_eq!(d1, d2, "source discriminators must be order-independent too");
     }
 
     #[test]
     fn refinement_key_distinguishes_language_and_multiset() {
-        let base = refinement_key("rust", &["aaa".into(), "bbb".into()], &[]);
+        let base = refinement_key("rust", RefineMode::Baseline, &["aaa".into(), "bbb".into()], &[]);
         // Different language → different key.
-        assert_ne!(base, refinement_key("typescript", &["aaa".into(), "bbb".into()], &[]));
+        assert_ne!(
+            base,
+            refinement_key("typescript", RefineMode::Baseline, &["aaa".into(), "bbb".into()], &[])
+        );
         // Different multiset → different key.
-        assert_ne!(base, refinement_key("rust", &["aaa".into(), "ccc".into()], &[]));
+        assert_ne!(
+            base,
+            refinement_key("rust", RefineMode::Baseline, &["aaa".into(), "ccc".into()], &[])
+        );
         // Duplicate-sensitive: a doubled hash is a different multiset.
-        assert_ne!(base, refinement_key("rust", &["aaa".into(), "aaa".into(), "bbb".into()], &[]));
+        assert_ne!(
+            base,
+            refinement_key(
+                "rust",
+                RefineMode::Baseline,
+                &["aaa".into(), "aaa".into(), "bbb".into()],
+                &[]
+            )
+        );
         // Same struct_hash multiset, DIFFERENT source discriminators → different key (the
         // cache-poisoning fix: structure-only is no longer sufficient).
-        assert_ne!(base, refinement_key("rust", &["aaa".into(), "bbb".into()], &["s1".into()]));
+        assert_ne!(
+            base,
+            refinement_key("rust", RefineMode::Baseline, &["aaa".into(), "bbb".into()], &[
+                "s1".into()
+            ])
+        );
     }
 
     /// Synthesize a long `RefineMember` with VALID parallel `node_spans` (one leaf span per token):
@@ -454,6 +567,7 @@ mod tests {
             })
             .collect();
         RefineMember {
+            callee_monikers: Default::default(),
             symbol_id,
             lang: Language::Rust,
             struct_hash: struct_hash.to_string(),
@@ -476,10 +590,18 @@ mod tests {
             long_member(1, "h1", LCS_MAX_SEQ_TOKENS + 1),
             long_member(2, "h2", LCS_MAX_SEQ_TOKENS + 1),
         ];
-        let key = refinement_key("rust", &["h1".into(), "h2".into()], &[]);
+        let key = refinement_key("rust", RefineMode::Baseline, &["h1".into(), "h2".into()], &[]);
 
-        let refinement =
-            refine_compute_and_store(&conn, &key, "rust", &members, 1.0, None).unwrap();
+        let refinement = refine_compute_and_store(
+            &conn,
+            &key,
+            "rust",
+            RefineMode::Baseline,
+            &members,
+            1.0,
+            None,
+        )
+        .unwrap();
         assert!(refinement.lcs_sampled, "long-member compute must set lcs_sampled (proxy path)");
         let rows: i64 =
             conn.query_row("SELECT COUNT(*) FROM clone_refinements", [], |r| r.get(0)).unwrap();
@@ -503,10 +625,19 @@ mod tests {
             long_member(1, "h1", LCS_MAX_SEQ_TOKENS + 1),
             long_member(2, "h2", LCS_MAX_SEQ_TOKENS + 1),
         ];
-        let key = refinement_key("rust", &["h1".into(), "h2".into()], &[]);
+        let key = refinement_key("rust", RefineMode::Baseline, &["h1".into(), "h2".into()], &[]);
 
         // COLD compute: the length proxy engages → lcs_sampled = true, and it is PERSISTED.
-        let cold = refine_compute_and_store(&conn, &key, "rust", &members, 1.0, None).unwrap();
+        let cold = refine_compute_and_store(
+            &conn,
+            &key,
+            "rust",
+            RefineMode::Baseline,
+            &members,
+            1.0,
+            None,
+        )
+        .unwrap();
         assert!(cold.lcs_sampled, "cold compute on long seqs must set lcs_sampled");
 
         // Confirm the bit landed in the row (1, not the DEFAULT 0).
@@ -520,7 +651,7 @@ mod tests {
         assert_eq!(persisted, 1, "lcs_sampled must be persisted as 1");
 
         // WARM hit: refine_lookup reads the bit back — it must NOT degrade to false.
-        let warm = refine_lookup(&conn, &key).unwrap().expect("warm hit");
+        let warm = refine_lookup(&conn, &key, RefineMode::Baseline).unwrap().expect("warm hit");
         assert!(warm.lcs_sampled, "warm cache hit must read lcs_sampled=true back from the row");
     }
 
@@ -547,8 +678,8 @@ mod tests {
         };
         assert_eq!(count_rows(&conn), 0, "table starts empty");
 
-        let key = refinement_key("rust", &["h1".into(), "h2".into()], &[]);
-        let hit = refine_lookup(&conn, &key).unwrap();
+        let key = refinement_key("rust", RefineMode::Baseline, &["h1".into(), "h2".into()], &[]);
+        let hit = refine_lookup(&conn, &key, RefineMode::Baseline).unwrap();
 
         assert!(hit.is_none(), "a miss must return None");
         assert_eq!(count_rows(&conn), 0, "refine_lookup must NOT write a row on a miss");
@@ -573,15 +704,22 @@ mod tests {
             member(2, "fn g() { let y = 20; sink(y); }"),
         ];
         let struct_hashes: Vec<String> = members.iter().map(|m| m.struct_hash.clone()).collect();
-        let key = refinement_key("rust", &struct_hashes, &discriminators_for(&members));
+        let key = refinement_key(
+            "rust",
+            RefineMode::Baseline,
+            &struct_hashes,
+            &discriminators_for(&members),
+        );
 
         // Miss: compute + persist one row.
-        let first = refine_class(&conn, &key, "rust", &members, 1.0, None).unwrap();
+        let first =
+            refine_class(&conn, &key, "rust", RefineMode::Baseline, &members, 1.0, None).unwrap();
         assert_eq!(count_rows(&conn), 1, "the miss persists exactly one row");
         assert!(first.lcs_ratio > 0.99, "identical sequences ⇒ near-perfect lcs_ratio");
 
         // Hit: same key serves the cache, no new row.
-        let second = refine_class(&conn, &key, "rust", &members, 1.0, None).unwrap();
+        let second =
+            refine_class(&conn, &key, "rust", RefineMode::Baseline, &members, 1.0, None).unwrap();
         assert_eq!(count_rows(&conn), 1, "the hit must NOT grow the row count");
         assert_eq!(
             first.confidence, second.confidence,
@@ -645,9 +783,23 @@ mod tests {
             member(2, "fn g() { let y: f32 = 2.5; sink(y); }"),
         ];
         let struct_hashes: Vec<String> = members.iter().map(|m| m.struct_hash.clone()).collect();
-        let key = refinement_key("rust", &struct_hashes, &discriminators_for(&members));
+        let key = refinement_key(
+            "rust",
+            RefineMode::Baseline,
+            &struct_hashes,
+            &discriminators_for(&members),
+        );
 
-        let computed = refine_compute_and_store(&conn, &key, "rust", &members, 1.0, None).unwrap();
+        let computed = refine_compute_and_store(
+            &conn,
+            &key,
+            "rust",
+            RefineMode::Baseline,
+            &members,
+            1.0,
+            None,
+        )
+        .unwrap();
         // The payload is non-trivial: a real template + a non-empty VP array + a non-stub
         // signature.
         assert!(!computed.template.is_empty(), "computed template must be non-empty");
@@ -660,7 +812,7 @@ mod tests {
         );
 
         // Warm lookup returns byte-identical payload — no recompute, no proxy.
-        let cached = refine_lookup(&conn, &key).unwrap().expect("warm hit");
+        let cached = refine_lookup(&conn, &key, RefineMode::Baseline).unwrap().expect("warm hit");
         assert_eq!(cached.template, computed.template, "template must round-trip");
         assert_eq!(
             cached.variation_points_json, computed.variation_points_json,
@@ -702,7 +854,12 @@ mod tests {
             member(2, "fn g() { let y = 2.5; sink(y); }"),
         ];
         let struct_hashes: Vec<String> = members.iter().map(|m| m.struct_hash.clone()).collect();
-        let key = refinement_key("rust", &struct_hashes, &discriminators_for(&members));
+        let key = refinement_key(
+            "rust",
+            RefineMode::Baseline,
+            &struct_hashes,
+            &discriminators_for(&members),
+        );
 
         // Plant a stale 4a-style row at alignment_version = 1 (placeholder payload) directly.
         conn.execute(
@@ -719,14 +876,22 @@ mod tests {
 
         // The lookup at the CURRENT version (2) must MISS the v1 row.
         assert!(
-            refine_lookup(&conn, &key).unwrap().is_none(),
+            refine_lookup(&conn, &key, RefineMode::Baseline).unwrap().is_none(),
             "an alignment_version=1 row must not serve at the current version"
         );
 
         // Recompute: writes the row at the current version with the REAL payload (INSERT OR REPLACE
         // over the same class_key PRIMARY KEY).
-        let recomputed =
-            refine_compute_and_store(&conn, &key, "rust", &members, 1.0, None).unwrap();
+        let recomputed = refine_compute_and_store(
+            &conn,
+            &key,
+            "rust",
+            RefineMode::Baseline,
+            &members,
+            1.0,
+            None,
+        )
+        .unwrap();
         assert_ne!(recomputed.template, "STALE 4A SKELETON", "must recompute the real template");
         assert_ne!(recomputed.variation_points_json, "[]", "recompute fills the real VP array");
 
@@ -743,7 +908,9 @@ mod tests {
             )
             .unwrap();
         assert_eq!(stored_version, ALIGNMENT_VERSION, "the recompute writes the current version");
-        let warm = refine_lookup(&conn, &key).unwrap().expect("warm hit after recompute");
+        let warm = refine_lookup(&conn, &key, RefineMode::Baseline)
+            .unwrap()
+            .expect("warm hit after recompute");
         assert_eq!(
             warm.template, recomputed.template,
             "the warm hit serves the recomputed payload"
@@ -764,15 +931,25 @@ mod tests {
         ];
         let hashes_a: Vec<String> = class_a.iter().map(|m| m.struct_hash.clone()).collect();
         let discs_a = discriminators_for(&class_a);
-        let key_a = refinement_key("rust", &hashes_a, &discs_a);
-        let computed_a =
-            refine_compute_and_store(&conn, &key_a, "rust", &class_a, 1.0, None).unwrap();
+        let key_a = refinement_key("rust", RefineMode::Baseline, &hashes_a, &discs_a);
+        let computed_a = refine_compute_and_store(
+            &conn,
+            &key_a,
+            "rust",
+            RefineMode::Baseline,
+            &class_a,
+            1.0,
+            None,
+        )
+        .unwrap();
 
         // Re-key the SAME content (same struct_hash multiset + same source bytes) → same key, same
         // template (cache hit).
-        let key_a2 = refinement_key("rust", &hashes_a, &discs_a);
+        let key_a2 = refinement_key("rust", RefineMode::Baseline, &hashes_a, &discs_a);
         assert_eq!(key_a, key_a2, "identical content must address the same refinement");
-        let cached = refine_lookup(&conn, &key_a2).unwrap().expect("hit for identical content");
+        let cached = refine_lookup(&conn, &key_a2, RefineMode::Baseline)
+            .unwrap()
+            .expect("hit for identical content");
         assert_eq!(cached.template, computed_a.template, "identical content → identical template");
 
         // A DIFFERENT class (a different body shape → a different struct_hash multiset) → a
@@ -782,10 +959,19 @@ mod tests {
             member(4, "fn q(c: i32, d: i32) -> i32 { let s = c + d + c; s * 2 }"),
         ];
         let hashes_b: Vec<String> = class_b.iter().map(|m| m.struct_hash.clone()).collect();
-        let key_b = refinement_key("rust", &hashes_b, &discriminators_for(&class_b));
+        let key_b =
+            refinement_key("rust", RefineMode::Baseline, &hashes_b, &discriminators_for(&class_b));
         assert_ne!(key_a, key_b, "different content must address a different refinement");
-        let computed_b =
-            refine_compute_and_store(&conn, &key_b, "rust", &class_b, 1.0, None).unwrap();
+        let computed_b = refine_compute_and_store(
+            &conn,
+            &key_b,
+            "rust",
+            RefineMode::Baseline,
+            &class_b,
+            1.0,
+            None,
+        )
+        .unwrap();
         assert_ne!(
             computed_a.template, computed_b.template,
             "structurally different classes must not share a template"
@@ -827,25 +1013,45 @@ mod tests {
         hb.sort();
         assert_eq!(ha, hb, "the two classes must share the struct_hash multiset (the bug premise)");
 
-        let key_a = refinement_key("rust", &hashes_a, &discriminators_for(&class_a));
-        let key_b = refinement_key("rust", &hashes_b, &discriminators_for(&class_b));
+        let key_a =
+            refinement_key("rust", RefineMode::Baseline, &hashes_a, &discriminators_for(&class_a));
+        let key_b =
+            refinement_key("rust", RefineMode::Baseline, &hashes_b, &discriminators_for(&class_b));
         assert_ne!(
             key_a, key_b,
             "same struct_hash multiset but different source MUST get distinct keys (no poisoning)"
         );
 
         // Compute A, then B. Two distinct keys → two distinct rows, each with its OWN payload.
-        let computed_a =
-            refine_compute_and_store(&conn, &key_a, "rust", &class_a, 1.0, None).unwrap();
-        let computed_b =
-            refine_compute_and_store(&conn, &key_b, "rust", &class_b, 1.0, None).unwrap();
+        let computed_a = refine_compute_and_store(
+            &conn,
+            &key_a,
+            "rust",
+            RefineMode::Baseline,
+            &class_a,
+            1.0,
+            None,
+        )
+        .unwrap();
+        let computed_b = refine_compute_and_store(
+            &conn,
+            &key_b,
+            "rust",
+            RefineMode::Baseline,
+            &class_b,
+            1.0,
+            None,
+        )
+        .unwrap();
         let rows: i64 =
             conn.query_row("SELECT COUNT(*) FROM clone_refinements", [], |r| r.get(0)).unwrap();
         assert_eq!(rows, 2, "two source-distinct classes persist two distinct rows");
 
         // B's WARM lookup serves B's OWN payload — NOT A's. The per_member_values carry the real
         // literals, so a poisoned cache would surface A's `10`/`2.5` for class B.
-        let warm_b = refine_lookup(&conn, &key_b).unwrap().expect("class B has its own warm row");
+        let warm_b = refine_lookup(&conn, &key_b, RefineMode::Baseline)
+            .unwrap()
+            .expect("class B has its own warm row");
         assert_eq!(warm_b.template, computed_b.template, "B must serve B's template, not A's");
         assert_ne!(
             warm_b.variation_points_json, computed_a.variation_points_json,
@@ -863,6 +1069,61 @@ mod tests {
                 && !warm_b.variation_points_json.contains("2.5"),
             "class B payload carries ITS real literal 3.5 (not A's 2.5): {}",
             warm_b.variation_points_json
+        );
+    }
+
+    /// #275: the refine MODE is folded into the content key, so baseline and scip refinements
+    /// of the SAME class occupy disjoint cache rows — an oracle run can drop every scip row
+    /// without touching baseline rows, and neither mode can serve the other's payload.
+    #[test]
+    fn refinement_key_distinguishes_refine_mode() {
+        let hashes = vec!["aaa".to_string(), "bbb".to_string()];
+        let discs = vec!["s1".to_string()];
+        assert_ne!(
+            refinement_key("rust", RefineMode::Baseline, &hashes, &discs),
+            refinement_key("rust", RefineMode::Scip, &hashes, &discs),
+            "the two refine modes must address disjoint cache namespaces"
+        );
+    }
+
+    /// #275 finding 3: an oracle run rewrites the moniker evidence a scip refinement consulted,
+    /// and nothing in its key changes — `invalidate_scip_refinements` must drop every scip-mode
+    /// row (they recompute lazily) while sparing the oracle-independent baseline rows.
+    #[test]
+    fn invalidate_scip_refinements_drops_scip_rows_and_spares_baseline() {
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        crate::index::schema::apply(&conn).unwrap();
+
+        let members = vec![
+            member(1, "fn f() { let x = 10; sink(x); }"),
+            member(2, "fn g() { let y = 20; sink(y); }"),
+        ];
+        let hashes: Vec<String> = members.iter().map(|m| m.struct_hash.clone()).collect();
+        let discs = discriminators_for(&members);
+        let base_key = refinement_key("rust", RefineMode::Baseline, &hashes, &discs);
+        let scip_key = refinement_key("rust", RefineMode::Scip, &hashes, &discs);
+        refine_compute_and_store(
+            &conn,
+            &base_key,
+            "rust",
+            RefineMode::Baseline,
+            &members,
+            1.0,
+            None,
+        )
+        .unwrap();
+        refine_compute_and_store(&conn, &scip_key, "rust", RefineMode::Scip, &members, 1.0, None)
+            .unwrap();
+
+        let dropped = invalidate_scip_refinements(&conn).unwrap();
+        assert_eq!(dropped, 1, "exactly the scip row is dropped");
+        assert!(
+            refine_lookup(&conn, &scip_key, RefineMode::Scip).unwrap().is_none(),
+            "the scip refinement must be gone after an oracle run"
+        );
+        assert!(
+            refine_lookup(&conn, &base_key, RefineMode::Baseline).unwrap().is_some(),
+            "the oracle-independent baseline refinement must survive"
         );
     }
 
@@ -889,19 +1150,32 @@ mod tests {
         ];
         let hashes1: Vec<String> = class1.iter().map(|m| m.struct_hash.clone()).collect();
         let hashes2: Vec<String> = class2.iter().map(|m| m.struct_hash.clone()).collect();
-        let key1 = refinement_key("rust", &hashes1, &discriminators_for(&class1));
-        let key2 = refinement_key("rust", &hashes2, &discriminators_for(&class2));
+        let key1 =
+            refinement_key("rust", RefineMode::Baseline, &hashes1, &discriminators_for(&class1));
+        let key2 =
+            refinement_key("rust", RefineMode::Baseline, &hashes2, &discriminators_for(&class2));
         assert_eq!(key1, key2, "byte-identical source → same content key (true dupe)");
 
         // Compute class 1 → persists one row.
-        let computed1 = refine_compute_and_store(&conn, &key1, "rust", &class1, 1.0, None).unwrap();
+        let computed1 = refine_compute_and_store(
+            &conn,
+            &key1,
+            "rust",
+            RefineMode::Baseline,
+            &class1,
+            1.0,
+            None,
+        )
+        .unwrap();
         let rows_after_1: i64 =
             conn.query_row("SELECT COUNT(*) FROM clone_refinements", [], |r| r.get(0)).unwrap();
         assert_eq!(rows_after_1, 1, "class 1 persists one row");
 
         // Class 2 (distinct class, byte-identical content) LOOKS UP the same key → cache hit, same
         // template, no new row.
-        let cached2 = refine_lookup(&conn, &key2).unwrap().expect("class 2 hits class 1's cache");
+        let cached2 = refine_lookup(&conn, &key2, RefineMode::Baseline)
+            .unwrap()
+            .expect("class 2 hits class 1's cache");
         assert_eq!(
             cached2.template, computed1.template,
             "byte-identical source must serve the same cached template"

--- a/crates/rag-rat-core/src/index/clones/refine/mod.rs
+++ b/crates/rag-rat-core/src/index/clones/refine/mod.rs
@@ -45,4 +45,13 @@ pub(crate) struct RefineMember {
     /// `text.get(span.start_byte..span.end_byte)` to recover real source for any `NodeSpan` in
     /// `node_spans`.
     pub(crate) text: std::sync::Arc<str>,
+    /// SCIP-oracle callee resolutions for this member's file (#275, Plan 3): the callee-identifier
+    /// byte range → the resolved SCIP moniker, from `edge_oracle` rows whose `file_sha` matches
+    /// the EXACT bytes `text` was read from (so the spans line up — see
+    /// `current_callee_monikers`). EMPTY unless the driver probed scip mode and current oracle
+    /// coverage exists; the anti-unify classifier consults it to collapse a
+    /// same-symbol-different-spelling callee back into the fixed spine instead of reopening it as
+    /// a `differing_callee` variation. Byte ranges use the same ABSOLUTE file offsets as
+    /// `node_spans`.
+    pub(crate) callee_monikers: std::collections::HashMap<(usize, usize), String>,
 }

--- a/crates/rag-rat-core/src/index/clones/refine/signature.rs
+++ b/crates/rag-rat-core/src/index/clones/refine/signature.rs
@@ -676,7 +676,15 @@ mod tests {
             parsed.root().descendant_for_byte_range(func.start_byte, func.end_byte).expect("node");
         let (seq, node_spans) = normalize_baseline_spanned(node, &text, Language::Rust);
         let struct_hash = tokens::struct_hash(&seq);
-        RefineMember { symbol_id, lang: Language::Rust, struct_hash, seq, node_spans, text }
+        RefineMember {
+            callee_monikers: Default::default(),
+            symbol_id,
+            lang: Language::Rust,
+            struct_hash,
+            seq,
+            node_spans,
+            text,
+        }
     }
 
     /// Canonical-order sort — matches the loader guarantee. Production keys on the REINDEX-STABLE
@@ -818,6 +826,7 @@ mod tests {
         // Synthetic anchor: `fn ...` header reduced to a single literal leaf at column 0 (all that
         // `anchor_leaf_is_literal` / `recover_param_type` inspect). seq[0] = a LIT_* token.
         let anchor = RefineMember {
+            callee_monikers: Default::default(),
             symbol_id: 1,
             lang: Language::Rust,
             struct_hash: "synthetic".to_string(),

--- a/crates/rag-rat-core/src/index/oracle/mod.rs
+++ b/crates/rag-rat-core/src/index/oracle/mod.rs
@@ -48,7 +48,9 @@ pub use run::{OracleEvalMetrics, RecallCalls};
 use rusqlite::Connection;
 use serde::Serialize;
 pub use status::OracleStatus;
-pub(crate) use store::{EdgeOracleComparison, EdgeOracleVerdict, current_callee_monikers};
+pub(crate) use store::{
+    EdgeOracleComparison, EdgeOracleVerdict, callee_moniker_current_clause, current_callee_monikers,
+};
 
 /// Run one oracle pass over the current edge candidates from a pre-built `.scip` and return its
 /// [`OracleReport`]. Phase-1 public entry point (consumed by `eval`); no CLI/MCP surface yet (#69).

--- a/crates/rag-rat-core/src/index/oracle/mod.rs
+++ b/crates/rag-rat-core/src/index/oracle/mod.rs
@@ -48,7 +48,7 @@ pub use run::{OracleEvalMetrics, RecallCalls};
 use rusqlite::Connection;
 use serde::Serialize;
 pub use status::OracleStatus;
-pub(crate) use store::{EdgeOracleComparison, EdgeOracleVerdict};
+pub(crate) use store::{EdgeOracleComparison, EdgeOracleVerdict, current_callee_monikers};
 
 /// Run one oracle pass over the current edge candidates from a pre-built `.scip` and return its
 /// [`OracleReport`]. Phase-1 public entry point (consumed by `eval`); no CLI/MCP surface yet (#69).

--- a/crates/rag-rat-core/src/index/oracle/run.rs
+++ b/crates/rag-rat-core/src/index/oracle/run.rs
@@ -437,6 +437,12 @@ pub(crate) fn run_in_tx(
         &serde_json::to_string(&report).unwrap_or_else(|_| "{}".to_string()),
     )?;
 
+    // The run rewrote the `edge_oracle` moniker evidence, and NOTHING in a scip-mode clone
+    // refinement's cache key changes when a moniker changes (#275 finding 3) — invalidate every
+    // scip-mode row so the next refine pass recomputes against the fresh verdicts. Baseline rows
+    // are oracle-independent and spared.
+    crate::index::clones::refine::cache::invalidate_scip_refinements(conn)?;
+
     Ok(report)
 }
 

--- a/crates/rag-rat-core/src/index/oracle/scip.rs
+++ b/crates/rag-rat-core/src/index/oracle/scip.rs
@@ -232,8 +232,9 @@ pub(crate) fn symbol_is_module(symbol: &str) -> bool {
 }
 
 /// A SCIP `local …` symbol is function-local. SCIP's own `is_local_symbol` checks the `local`
-/// scheme prefix; we mirror it so the dependency's exact rule applies.
-fn is_local_symbol(symbol: &str) -> bool {
+/// scheme prefix; we mirror it so the dependency's exact rule applies. `pub(crate)` since #275:
+/// the clone-refine moniker collapse must never treat two document-scoped locals as one identity.
+pub(crate) fn is_local_symbol(symbol: &str) -> bool {
     ::scip::symbol::is_local_symbol(symbol)
 }
 

--- a/crates/rag-rat-core/src/index/oracle/store.rs
+++ b/crates/rag-rat-core/src/index/oracle/store.rs
@@ -156,14 +156,72 @@ pub(crate) struct EdgeJoinCandidate {
 /// *call* and must be excluded from the recall numerator (the population-mismatch finding, #81).
 pub(crate) const CALL_EDGE_KIND: &str = "calls_name";
 
+/// The edge kinds whose callee byte range covers a CALL-HEAD identifier the clone-refine
+/// anti-unify classifier can treat as a callee position (#275): free-fn/method calls
+/// (`calls_name`) and macro invocations (`uses_macro` — `opens_call_head` treats a macro head
+/// exactly like a call head, and the Rust extractor stamps the callee range on the macro-name
+/// identifier). Spelled as a SQL list fragment for the two moniker-collapse reads.
+/// `references_type` / `constructs` / `implements` rows also join SCIP occurrences (they carry a
+/// callee range) but are never callee positions in the classifier, so they stay excluded.
+pub(crate) const CALL_HEAD_EDGE_KINDS_SQL: &str = "('calls_name', 'uses_macro')";
+
+/// The gating tail every clone-refine moniker read appends after its `edge_oracle` anchor match
+/// (`source_path` + `file_sha`): rows a collapse may trust are exactly those that are
+///
+/// 1. **call-HEAD kinds** ([`CALL_HEAD_EDGE_KINDS_SQL`]) — the only positions the classifier can
+///    reopen as a callee;
+/// 2. **from the LATEST completed run of their tool in the active checkout** — superseded
+///    `tool_version` rows are intentionally left behind by [`clear_edge_oracle_for_tool`] (it
+///    clears only the current `(tool, tool_version)` scope), and a run in a sibling checkout says
+///    nothing about this one. The correlated subquery is the SQL spelling of
+///    [`latest_run_tool_version`] (`id DESC` = completion order — see that fn for why `started_at`
+///    ordering is wrong); a tool with no run in this checkout matches nothing (`= NULL` is never
+///    true), so its rows drop;
+/// 3. **backed by a still-live resolved definition** ([`edge_oracle_def_current_predicate`]) — the
+///    same def-drift gate the surfacing reads apply: a callsite file can be unchanged while the
+///    resolved def was deleted/reindexed, and a moniker for a target the current index no longer
+///    contains must not prove two callees identical.
+/// 4. **still decorating a LIVE edge** ([`edge_oracle_live_edge_predicate`]) — the content-key join
+///    the surfacing path makes an INNER JOIN. A verdict whose content key no longer maps to a live
+///    edge (a row surviving a reindex after the extractor stopped emitting that call edge) is a
+///    dangling verdict; the surfacing reads exclude it via [`edge_oracle_scope_join`], so the
+///    collapse must too. This loses no real collapse: the classifier only ever looks up callee
+///    spans that are call-head tokens, which is exactly where the extractor emits an edge.
+///
+/// `commit_slot`/`worktree_slot` are the caller's bind-parameter names for the active checkout
+/// (e.g. `"?3"`, `"?4"`); they feed the runs subquery, the def-drift EXISTS, and the live-edge
+/// EXISTS. Shared by [`current_callee_monikers`] and the refine-mode probe
+/// (`oracle_callee_coverage_exists`) so the probe and the fetch express ONE currency discipline —
+/// a probe looser than the fetch would key baseline-identical refinements into the scip cache
+/// namespace (needless oracle-run churn).
+pub(crate) fn callee_moniker_current_clause(
+    conn: &Connection,
+    commit_slot: &str,
+    worktree_slot: &str,
+) -> anyhow::Result<String> {
+    let runs_repo_clause = oracle_repo_scope_clause(conn, "oracle_runs")?;
+    Ok(format!(
+        " AND edge_oracle.edge_kind IN {CALL_HEAD_EDGE_KINDS_SQL} AND edge_oracle.tool_version = \
+         (SELECT oracle_runs.tool_version FROM oracle_runs WHERE oracle_runs.tool = \
+         edge_oracle.tool AND oracle_runs.commit_sha = {commit_slot} AND oracle_runs.worktree_id \
+         = {worktree_slot}{runs_repo_clause} ORDER BY oracle_runs.id DESC LIMIT \
+         1){def_current}{live_edge}",
+        def_current = edge_oracle_def_current_predicate(commit_slot, worktree_slot),
+        live_edge = edge_oracle_live_edge_predicate(commit_slot, worktree_slot),
+    ))
+}
+
 /// The CURRENT SCIP callee resolutions for one file, keyed by the callee-identifier byte range —
 /// the clone-refine moniker-collapse input (#275, Plan 3). `file_sha` must be the sha256 of the
 /// EXACT bytes the caller's byte offsets were derived from: `edge_oracle` spans were computed
 /// against the content hashed into each row's `file_sha`, so filtering on it is what makes the
 /// span join sound (a drifted file simply matches nothing — the conservative no-collapse
-/// fallback). Uses `idx_edge_oracle_anchor` (source_path prefix).
+/// fallback). `commit_sha`/`worktree_id` scope the currency gate
+/// ([`callee_moniker_current_clause`]): only call-HEAD rows the LATEST run of each tool in the
+/// active checkout stands behind, whose resolved definition still exists, are returned. Uses
+/// `idx_edge_oracle_anchor` (source_path prefix).
 ///
-/// Two exclusions keep a false collapse impossible:
+/// Two further exclusions keep a false collapse impossible:
 /// - `local N` monikers are DOCUMENT-scoped (unique only within one file), so cross-file equality
 ///   would identify two different functions — never returned.
 /// - a span where two rows (different tools / tool versions) disagree on the moniker has no
@@ -172,14 +230,17 @@ pub(crate) fn current_callee_monikers(
     conn: &Connection,
     source_path: &str,
     file_sha: &str,
+    commit_sha: &str,
+    worktree_id: &str,
 ) -> anyhow::Result<HashMap<(usize, usize), String>> {
     let repo_clause = oracle_repo_scope_clause(conn, "edge_oracle")?;
+    let current_clause = callee_moniker_current_clause(conn, "?3", "?4")?;
     let mut stmt = conn.prepare(&format!(
         "SELECT callee_start_byte, callee_end_byte, scip_symbol
          FROM edge_oracle
-         WHERE source_path = ?1 AND file_sha = ?2 AND edge_kind = ?3{repo_clause}"
+         WHERE source_path = ?1 AND file_sha = ?2{repo_clause}{current_clause}"
     ))?;
-    let rows = stmt.query_map(params![source_path, file_sha, CALL_EDGE_KIND], |row| {
+    let rows = stmt.query_map(params![source_path, file_sha, commit_sha, worktree_id], |row| {
         Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?, row.get::<_, String>(2)?))
     })?;
     let mut monikers: HashMap<(usize, usize), String> = HashMap::new();
@@ -871,10 +932,48 @@ pub(crate) fn count_edge_oracle_scoped(
 /// cleanly after [`edge_oracle_scope_join`]'s trailing `WHERE`.
 pub(crate) fn edge_oracle_current_predicate() -> String {
     format!(
-        " AND edge_oracle.file_sha = files.sha256 AND (edge_oracle.resolved_symbol_id IS NULL OR \
-         EXISTS (SELECT 1 FROM symbols JOIN files ON files.id = symbols.file_id WHERE symbols.id \
-         = edge_oracle.resolved_symbol_id AND {scope}))",
-        scope = active_checkout_file_predicate("?3", "?4"),
+        " AND edge_oracle.file_sha = files.sha256{def_current}",
+        def_current = edge_oracle_def_current_predicate("?3", "?4"),
+    )
+}
+
+/// Gate (2) of [`edge_oracle_current_predicate`] on its own — the def-drift EXISTS, parameterized
+/// on the caller's bind-slot names for `(commit_sha, worktree_id)` so reads that don't use the
+/// `?1..?4` scope-join slot convention ([`callee_moniker_current_clause`]) still apply the ONE
+/// spelling of the gate rather than re-deriving it. The inner `symbols`/`files` names shadow any
+/// outer join of the same tables (SQLite resolves the subquery scope first), exactly as when
+/// appended after [`edge_oracle_scope_join`].
+pub(crate) fn edge_oracle_def_current_predicate(commit_slot: &str, worktree_slot: &str) -> String {
+    format!(
+        " AND (edge_oracle.resolved_symbol_id IS NULL OR EXISTS (SELECT 1 FROM symbols JOIN files \
+         ON files.id = symbols.file_id WHERE symbols.id = edge_oracle.resolved_symbol_id AND \
+         {scope}))",
+        scope = active_checkout_file_predicate(commit_slot, worktree_slot),
+    )
+}
+
+/// The EXISTS-form mirror of [`edge_oracle_scope_join`]'s content-key INNER JOIN: whether the
+/// correlated `edge_oracle` row still decorates a LIVE `edges` row in the active
+/// `(commit_sha, worktree_id)` checkout — the SAME six content-key columns (`source_path` →
+/// `files.path`, `file_sha` → `files.sha256`, the source + callee byte spans, and `edge_kind`)
+/// plus the active-checkout file predicate. The surfacing reads express this as an INNER JOIN
+/// because they DECORATE edges (they need a live edge to attach the `Compiler` tier to); the
+/// clone-refine moniker reads are `FROM edge_oracle` with no join and span multiple tools (to
+/// detect cross-tool conflicts), so they can't take the single-tool JOIN form and append this
+/// ` AND EXISTS(...)` instead. Same isolation model as `edge_oracle_scope_join`: repo isolation
+/// comes from the outer `edge_oracle.repo_id` predicate, so this EXISTS is intentionally not
+/// repo-scoped (a cross-repo path+sha+commit collision is identical content, benign for an
+/// existence check). Uses the `edges` VIEW (like the JOIN) so `edge_kind` resolves as text. The
+/// inner `files`/`edges` names are a fresh scope, shadowing any outer join of the same tables.
+pub(crate) fn edge_oracle_live_edge_predicate(commit_slot: &str, worktree_slot: &str) -> String {
+    format!(
+        " AND EXISTS (SELECT 1 FROM files JOIN edges ON edges.source_file_id = files.id AND \
+         edges.source_start_byte = edge_oracle.source_start_byte AND edges.source_end_byte = \
+         edge_oracle.source_end_byte AND edges.callee_start_byte = edge_oracle.callee_start_byte \
+         AND edges.callee_end_byte = edge_oracle.callee_end_byte AND edges.edge_kind = \
+         edge_oracle.edge_kind WHERE files.path = edge_oracle.source_path AND files.sha256 = \
+         edge_oracle.file_sha AND {scope})",
+        scope = active_checkout_file_predicate(commit_slot, worktree_slot),
     )
 }
 

--- a/crates/rag-rat-core/src/index/oracle/store.rs
+++ b/crates/rag-rat-core/src/index/oracle/store.rs
@@ -5,6 +5,9 @@
 //! The heuristic resolution stays on the `edges` row untouched; the oracle's verdict lives only in
 //! `edge_oracle`. This is what lets eval diff heuristic-vs-oracle. See `apply_oracle_tables`.
 
+use std::collections::hash_map::Entry;
+use std::collections::{HashMap, HashSet};
+
 use rusqlite::{Connection, params};
 
 use super::{OracleResolutionKind, OracleTool};
@@ -152,6 +155,60 @@ pub(crate) struct EdgeJoinCandidate {
 /// `constructs`) join against SCIP occurrences too, but a confirmation on them is not a covered
 /// *call* and must be excluded from the recall numerator (the population-mismatch finding, #81).
 pub(crate) const CALL_EDGE_KIND: &str = "calls_name";
+
+/// The CURRENT SCIP callee resolutions for one file, keyed by the callee-identifier byte range —
+/// the clone-refine moniker-collapse input (#275, Plan 3). `file_sha` must be the sha256 of the
+/// EXACT bytes the caller's byte offsets were derived from: `edge_oracle` spans were computed
+/// against the content hashed into each row's `file_sha`, so filtering on it is what makes the
+/// span join sound (a drifted file simply matches nothing — the conservative no-collapse
+/// fallback). Uses `idx_edge_oracle_anchor` (source_path prefix).
+///
+/// Two exclusions keep a false collapse impossible:
+/// - `local N` monikers are DOCUMENT-scoped (unique only within one file), so cross-file equality
+///   would identify two different functions — never returned.
+/// - a span where two rows (different tools / tool versions) disagree on the moniker has no
+///   trustworthy identity — dropped entirely.
+pub(crate) fn current_callee_monikers(
+    conn: &Connection,
+    source_path: &str,
+    file_sha: &str,
+) -> anyhow::Result<HashMap<(usize, usize), String>> {
+    let repo_clause = oracle_repo_scope_clause(conn, "edge_oracle")?;
+    let mut stmt = conn.prepare(&format!(
+        "SELECT callee_start_byte, callee_end_byte, scip_symbol
+         FROM edge_oracle
+         WHERE source_path = ?1 AND file_sha = ?2 AND edge_kind = ?3{repo_clause}"
+    ))?;
+    let rows = stmt.query_map(params![source_path, file_sha, CALL_EDGE_KIND], |row| {
+        Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?, row.get::<_, String>(2)?))
+    })?;
+    let mut monikers: HashMap<(usize, usize), String> = HashMap::new();
+    let mut conflicted: HashSet<(usize, usize)> = HashSet::new();
+    for row in rows {
+        let (start, end, symbol) = row?;
+        let (Ok(start), Ok(end)) = (usize::try_from(start), usize::try_from(end)) else {
+            continue;
+        };
+        if super::scip::is_local_symbol(&symbol) {
+            continue;
+        }
+        let span = (start, end);
+        if conflicted.contains(&span) {
+            continue;
+        }
+        match monikers.entry(span) {
+            Entry::Vacant(slot) => {
+                slot.insert(symbol);
+            },
+            Entry::Occupied(existing) if *existing.get() == symbol => {},
+            Entry::Occupied(existing) => {
+                existing.remove();
+                conflicted.insert(span);
+            },
+        }
+    }
+    Ok(monikers)
+}
 
 /// One symbol's identity + byte span within a file, for mapping a SCIP definition range back to our
 /// symbol table by containment overlap.

--- a/crates/rag-rat-core/src/index/oracle/tests/store_io.rs
+++ b/crates/rag-rat-core/src/index/oracle/tests/store_io.rs
@@ -249,6 +249,22 @@ fn current_callee_monikers_filters_sha_locals_and_conflicts() {
         let start = src.find(name).unwrap();
         (start, start + name.len())
     };
+    // The currency gate only trusts rows the LATEST run of their tool stands behind — record a
+    // completed run for BOTH tools so every row below is in play (the conflict drop must fire
+    // on trusted rows, not on rows the run gate already filtered).
+    store::record_oracle_run_at(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, 0, "Completed", "{}")
+        .unwrap();
+    store::record_oracle_run_at(
+        &h.conn,
+        OracleTool::ScipClang,
+        VERSION,
+        COMMIT,
+        WORKTREE,
+        0,
+        "Completed",
+        "{}",
+    )
+    .unwrap();
 
     let (keep_lo, keep_hi) = span("keep");
     let keep_edge = h.add_edge(file, "keep", keep_lo, keep_hi, "NameOnly", None);
@@ -292,10 +308,197 @@ fn current_callee_monikers_filters_sha_locals_and_conflicts() {
     let loc_edge = h.add_edge(file, "loc", loc_lo, loc_hi, "NameOnly", None);
     h.write_verdict(loc_edge, &sha, None, "local 5", OracleResolutionKind::Upgrade);
 
-    let monikers = store::current_callee_monikers(&h.conn, "m.rs", &sha).unwrap();
+    let monikers = store::current_callee_monikers(&h.conn, "m.rs", &sha, COMMIT, WORKTREE).unwrap();
     assert_eq!(
         monikers,
         std::collections::HashMap::from([((keep_lo, keep_hi), "rust cr 1.0 keep().".to_string())]),
         "only the sha-current, non-local, conflict-free span may be returned"
+    );
+}
+
+/// The run/def currency gates on `current_callee_monikers` (#275 Codex round-2): a row is trusted
+/// ONLY when (a) the LATEST completed run of its tool in the active checkout stands behind its
+/// `tool_version` — superseded-version rows linger by design (`clear_edge_oracle_for_tool` clears
+/// only the current scope) and must not lend identity — and (b) its resolved definition, if
+/// in-corpus, still exists in the active checkout (the same def-drift gate the surfacing reads
+/// apply: an unchanged callsite can point at a deleted/reindexed target).
+#[test]
+fn current_callee_monikers_drops_superseded_runs_and_dead_defs() {
+    let h = Harness::new();
+    let src = "fn caller() { old_ver(); no_run(); dead_def(); live_def(); }\n";
+    let file = h.add_file("m.rs", src);
+    let sha = h.file_sha("m.rs");
+    let span = |name: &str| {
+        let start = src.find(name).unwrap();
+        (start, start + name.len())
+    };
+    // The latest completed run for TOOL carries VERSION — rows under any other version of TOOL,
+    // or under a tool with NO run in this checkout, are not backed by it.
+    store::record_oracle_run_at(
+        &h.conn,
+        TOOL,
+        "superseded",
+        COMMIT,
+        WORKTREE,
+        0,
+        "Completed",
+        "{}",
+    )
+    .unwrap();
+    store::record_oracle_run_at(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, 1, "Completed", "{}")
+        .unwrap();
+
+    // (a) A row written under TOOL's SUPERSEDED version: the latest run no longer stands behind
+    // it, even though its file_sha is current.
+    let (old_lo, old_hi) = span("old_ver");
+    let old_edge = h.add_edge(file, "old_ver", old_lo, old_hi, "NameOnly", None);
+    let old_key = h.edge_content_key(old_edge);
+    store::write_edge_oracle(&h.conn, TOOL, "superseded", &EdgeOracleRow {
+        source_path: &old_key.source_path,
+        source_start_byte: old_key.source_start_byte,
+        source_end_byte: old_key.source_end_byte,
+        callee_start_byte: old_key.callee_start_byte,
+        callee_end_byte: old_key.callee_end_byte,
+        edge_kind: &old_key.edge_kind,
+        file_sha: &sha,
+        resolved_symbol_id: None,
+        scip_symbol: "rust cr 1.0 old().",
+        kind: OracleResolutionKind::Upgrade,
+    })
+    .unwrap();
+
+    // (a') A row under a tool with NO run in this checkout — nothing stands behind it here (a
+    // sibling checkout's run must not lend identity to this one).
+    let (norun_lo, norun_hi) = span("no_run");
+    let norun_edge = h.add_edge(file, "no_run", norun_lo, norun_hi, "NameOnly", None);
+    let norun_key = h.edge_content_key(norun_edge);
+    store::write_edge_oracle(&h.conn, OracleTool::ScipClang, VERSION, &EdgeOracleRow {
+        source_path: &norun_key.source_path,
+        source_start_byte: norun_key.source_start_byte,
+        source_end_byte: norun_key.source_end_byte,
+        callee_start_byte: norun_key.callee_start_byte,
+        callee_end_byte: norun_key.callee_end_byte,
+        edge_kind: &norun_key.edge_kind,
+        file_sha: &sha,
+        resolved_symbol_id: None,
+        scip_symbol: "cpp . . norun().",
+        kind: OracleResolutionKind::Upgrade,
+    })
+    .unwrap();
+
+    // (b) An in-corpus verdict whose resolved definition no longer exists — the callsite file is
+    // unchanged (sha matches) but the target is gone, so the moniker names nothing current.
+    let (dead_lo, dead_hi) = span("dead_def");
+    let dead_edge = h.add_edge(file, "dead_def", dead_lo, dead_hi, "NameOnly", None);
+    h.write_verdict(
+        dead_edge,
+        &sha,
+        Some(999_999),
+        "rust cr 1.0 dead().",
+        OracleResolutionKind::Upgrade,
+    );
+
+    // Control: a current-version verdict whose resolved definition IS live in the active
+    // checkout — the only row the collapse may trust.
+    let defs = h.add_file("defs.rs", "fn live_def() {}\n");
+    let live_sym = h.add_symbol(defs, "live_def", 3, 11);
+    let (live_lo, live_hi) = span("live_def");
+    let live_edge = h.add_edge(file, "live_def", live_lo, live_hi, "NameOnly", Some(live_sym));
+    h.write_verdict(
+        live_edge,
+        &sha,
+        Some(live_sym),
+        "rust cr 1.0 live().",
+        OracleResolutionKind::Upgrade,
+    );
+
+    let monikers = store::current_callee_monikers(&h.conn, "m.rs", &sha, COMMIT, WORKTREE).unwrap();
+    assert_eq!(
+        monikers,
+        std::collections::HashMap::from([((live_lo, live_hi), "rust cr 1.0 live().".to_string())]),
+        "superseded-version, run-less-tool, and dead-def rows must all be dropped"
+    );
+}
+
+/// The call-HEAD kind gate (#275 Codex round-2): `uses_macro` rows participate in the collapse —
+/// the classifier treats a macro head exactly like a call head, so a clone class differing only
+/// by macro name needs macro verdicts to reach scip mode — while `references_type` rows (which
+/// also carry a callee range and join SCIP occurrences) are never callee positions and stay out.
+#[test]
+fn current_callee_monikers_includes_macro_heads_and_excludes_non_call_kinds() {
+    let h = Harness::new();
+    let src = "fn caller() { emit!(1); let t: Widget = make(); }\n";
+    let file = h.add_file("m.rs", src);
+    let sha = h.file_sha("m.rs");
+    let span = |name: &str| {
+        let start = src.find(name).unwrap();
+        (start, start + name.len())
+    };
+    store::record_oracle_run_at(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, 0, "Completed", "{}")
+        .unwrap();
+
+    let (mac_lo, mac_hi) = span("emit");
+    let mac_edge =
+        h.add_edge_with_kind(file, "emit", mac_lo, mac_hi, "uses_macro", "NameOnly", None);
+    h.write_verdict(mac_edge, &sha, None, "rust cr 1.0 emit!.", OracleResolutionKind::Upgrade);
+
+    let (ty_lo, ty_hi) = span("Widget");
+    let ty_edge =
+        h.add_edge_with_kind(file, "Widget", ty_lo, ty_hi, "references_type", "NameOnly", None);
+    h.write_verdict(ty_edge, &sha, None, "rust cr 1.0 Widget#", OracleResolutionKind::Upgrade);
+
+    let monikers = store::current_callee_monikers(&h.conn, "m.rs", &sha, COMMIT, WORKTREE).unwrap();
+    assert_eq!(
+        monikers,
+        std::collections::HashMap::from([((mac_lo, mac_hi), "rust cr 1.0 emit!.".to_string())]),
+        "uses_macro is a call-HEAD kind (returned); references_type is not (excluded)"
+    );
+}
+
+/// The live-edge gate (#512 Codex round-3): a verdict whose content key no longer maps to a LIVE
+/// edge — a dangling row surviving a reindex after the extractor stopped emitting that call — is
+/// dropped, exactly as the surfacing reads drop it via `edge_oracle_scope_join`. A live-edge-backed
+/// verdict on the same file, current sha, and same run is still returned; only the missing edge
+/// distinguishes them.
+#[test]
+fn current_callee_monikers_drops_verdicts_without_a_live_edge() {
+    let h = Harness::new();
+    let src = "fn caller() { live(); dangling(); }\n";
+    let file = h.add_file("m.rs", src);
+    let sha = h.file_sha("m.rs");
+    let span = |name: &str| {
+        let start = src.find(name).unwrap();
+        (start, start + name.len())
+    };
+    store::record_oracle_run_at(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, 0, "Completed", "{}")
+        .unwrap();
+
+    // A live edge + its verdict, keyed off the real edge — returned.
+    let (live_lo, live_hi) = span("live");
+    let live_edge = h.add_edge(file, "live", live_lo, live_hi, "NameOnly", None);
+    h.write_verdict(live_edge, &sha, None, "rust cr 1.0 live().", OracleResolutionKind::Upgrade);
+
+    // A dangling verdict: a `calls_name` content key with NO backing edge (no `add_edge`), same
+    // file + current sha + same completed run — only the live-edge gate can exclude it.
+    let (dang_lo, dang_hi) = span("dangling");
+    store::write_edge_oracle(&h.conn, TOOL, VERSION, &EdgeOracleRow {
+        source_path: "m.rs",
+        source_start_byte: 0,
+        source_end_byte: 0,
+        callee_start_byte: dang_lo as i64,
+        callee_end_byte: dang_hi as i64,
+        edge_kind: "calls_name",
+        file_sha: &sha,
+        resolved_symbol_id: None,
+        scip_symbol: "rust cr 1.0 dangling().",
+        kind: OracleResolutionKind::Upgrade,
+    })
+    .unwrap();
+
+    let monikers = store::current_callee_monikers(&h.conn, "m.rs", &sha, COMMIT, WORKTREE).unwrap();
+    assert_eq!(
+        monikers,
+        std::collections::HashMap::from([((live_lo, live_hi), "rust cr 1.0 live().".to_string())]),
+        "a verdict with no live edge is dropped; the live-edge-backed one is returned"
     );
 }

--- a/crates/rag-rat-core/src/index/oracle/tests/store_io.rs
+++ b/crates/rag-rat-core/src/index/oracle/tests/store_io.rs
@@ -234,3 +234,68 @@ fn record_oracle_run_and_count_by_kind() {
         0
     );
 }
+
+/// `current_callee_monikers` (#275, Plan 3) returns only span→moniker entries a clone-refine
+/// collapse may trust: rows whose `file_sha` matches the requested content hash (a drifted file
+/// matches nothing), never a document-scoped `local N` symbol, and never a span two rows disagree
+/// on (a multi-tool conflict has no trustworthy identity).
+#[test]
+fn current_callee_monikers_filters_sha_locals_and_conflicts() {
+    let h = Harness::new();
+    let src = "fn caller() { keep(); conflicted(); stale(); loc(); }\n";
+    let file = h.add_file("m.rs", src);
+    let sha = h.file_sha("m.rs");
+    let span = |name: &str| {
+        let start = src.find(name).unwrap();
+        (start, start + name.len())
+    };
+
+    let (keep_lo, keep_hi) = span("keep");
+    let keep_edge = h.add_edge(file, "keep", keep_lo, keep_hi, "NameOnly", None);
+    h.write_verdict(keep_edge, &sha, None, "rust cr 1.0 keep().", OracleResolutionKind::Upgrade);
+
+    // A span two tools disagree on: the second verdict is written under a DIFFERENT tool with a
+    // different symbol → the span is dropped entirely.
+    let (con_lo, con_hi) = span("conflicted");
+    let con_edge = h.add_edge(file, "conflicted", con_lo, con_hi, "NameOnly", None);
+    h.write_verdict(con_edge, &sha, None, "rust cr 1.0 one().", OracleResolutionKind::Upgrade);
+    let key = h.edge_content_key(con_edge);
+    store::write_edge_oracle(&h.conn, OracleTool::ScipClang, VERSION, &EdgeOracleRow {
+        source_path: &key.source_path,
+        source_start_byte: key.source_start_byte,
+        source_end_byte: key.source_end_byte,
+        callee_start_byte: key.callee_start_byte,
+        callee_end_byte: key.callee_end_byte,
+        edge_kind: &key.edge_kind,
+        file_sha: &sha,
+        resolved_symbol_id: None,
+        scip_symbol: "rust cr 1.0 two().",
+        kind: OracleResolutionKind::Upgrade,
+    })
+    .unwrap();
+
+    // A verdict computed against DIFFERENT bytes (stale sha) — the spans can't be trusted to
+    // line up with the requested content, so it is excluded.
+    let (stale_lo, stale_hi) = span("stale");
+    let stale_edge = h.add_edge(file, "stale", stale_lo, stale_hi, "NameOnly", None);
+    h.write_verdict(
+        stale_edge,
+        "not-the-requested-sha",
+        None,
+        "rust cr 1.0 stale().",
+        OracleResolutionKind::Upgrade,
+    );
+
+    // A `local N` symbol is document-scoped — cross-file equality would identify two different
+    // functions, so it is never returned.
+    let (loc_lo, loc_hi) = span("loc");
+    let loc_edge = h.add_edge(file, "loc", loc_lo, loc_hi, "NameOnly", None);
+    h.write_verdict(loc_edge, &sha, None, "local 5", OracleResolutionKind::Upgrade);
+
+    let monikers = store::current_callee_monikers(&h.conn, "m.rs", &sha).unwrap();
+    assert_eq!(
+        monikers,
+        std::collections::HashMap::from([((keep_lo, keep_hi), "rust cr 1.0 keep().".to_string())]),
+        "only the sha-current, non-local, conflict-free span may be returned"
+    );
+}

--- a/crates/rag-rat-core/src/index/query_api/clones/mod.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/mod.rs
@@ -114,7 +114,9 @@ const _: () = assert!(
 pub(crate) const HYDRATION_CHUNK: usize = 900;
 
 use self::build::{build_class, count_stale_member_paths};
-use self::refine_load::{load_refine_rows, load_source_discriminators};
+use self::refine_load::{
+    load_refine_rows, load_source_discriminators, oracle_callee_coverage_exists,
+};
 use self::resolve::{classify_ineligibility_reason, resolve_selector_to_symbol_id};
 use self::scoring::{
     apply_refinement, build_completeness, canonical_member_order_key,
@@ -126,7 +128,7 @@ use self::substrate::{
 };
 use crate::index::IndexDatabase;
 use crate::index::clones::refine::cache::{
-    refine_compute_and_store_budgeted, refine_lookup, refinement_key,
+    RefineMode, refine_compute_and_store_budgeted, refine_lookup, refinement_key,
 };
 use crate::index::clones::refine::split::coherence_split;
 
@@ -491,6 +493,17 @@ impl IndexDatabase {
             return Ok(());
         };
 
+        // Refine mode (#275, Plan 3): scip when any member file has CURRENT oracle callee
+        // coverage, else baseline. Probed BEFORE the key because the mode is folded into it — the
+        // two modes address disjoint cache namespaces, so an oracle run can invalidate every
+        // scip-mode row (`invalidate_scip_refinements`) without touching baseline rows. Cheap
+        // (one EXISTS per hydration chunk), so the warm probe stays a probe.
+        let mode = if oracle_callee_coverage_exists(conn, class_ids)? {
+            RefineMode::Scip
+        } else {
+            RefineMode::Baseline
+        };
+
         // Content-addressed key over the member struct_hash multiset + the per-member source
         // discriminators — NOT the read-side `class.class_key` (location-derived). Two classes with
         // the same structural content AND the same exact source bodies share a refinement; the key
@@ -501,7 +514,7 @@ impl IndexDatabase {
         // `build_class`), while `key` spans the FULL struct_hash multiset. The gap is not a
         // determinism break — the sample is id-ASC stable — but Plan-4b should compute confidence
         // over the full set or fold the sample into the key.
-        let key = refinement_key(&class.language, &struct_hashes, &source_discriminators);
+        let key = refinement_key(&class.language, mode, &struct_hashes, &source_discriminators);
 
         // ── Phase 1 (PURE READ — warm path): probe the content-addressed cache. A SELECT is safe
         // on the MCP's read-only connection; a WARM cache hit never takes the write lock and never
@@ -515,7 +528,7 @@ impl IndexDatabase {
         // key → cache miss → cold path (re-parse + faithfulness check). Staleness is separately
         // surfaced to callers via `completeness.stale_members`. Skipping the re-validation on warm
         // hits is therefore not a regression; it is the designed behavior.
-        if let Some(refinement) = refine_lookup(conn, &key)? {
+        if let Some(refinement) = refine_lookup(conn, &key, mode)? {
             // WARM path: cache hit — apply the refinement without re-parsing any source files.
             apply_refinement(class, refinement);
             return Ok(());
@@ -546,7 +559,7 @@ impl IndexDatabase {
         // `load_refine_members` is the expensive step (file reads + tree-sitter parses).
         // `None` ⇒ refine unavailable (overlay scope, drifted source, parse failure, or a
         // vanished fingerprint row) — leave the class un-refined.
-        let Some(members) = self.load_refine_members(class_ids)? else {
+        let Some(members) = self.load_refine_members(class_ids, mode == RefineMode::Scip)? else {
             return Ok(());
         };
         // An empty or singleton member set (shouldn't happen for a ≥2 class) is not refinable.
@@ -560,6 +573,7 @@ impl IndexDatabase {
             conn,
             &key,
             &class.language,
+            mode,
             &members,
             class.similarity_min,
             class.medoid_symbol_id,
@@ -776,6 +790,11 @@ impl IndexDatabase {
     pub(crate) fn load_refine_members(
         &self,
         member_ids: &[i64],
+        // Attach per-member SCIP callee monikers (#275) — `true` ONLY when the driver probed
+        // `RefineMode::Scip`. A baseline refinement must stay oracle-independent (it survives the
+        // oracle-run invalidation), so the monikers that would let the classifier collapse a
+        // callee are simply never attached in baseline mode.
+        attach_callee_monikers: bool,
     ) -> anyhow::Result<Option<Vec<crate::index::clones::refine::RefineMember>>> {
         if member_ids.is_empty() {
             return Ok(Some(Vec::new()));
@@ -831,6 +850,14 @@ impl IndexDatabase {
         // whole-file buffer must be kept, not sliced to the symbol range.
         let mut file_cache: std::collections::HashMap<String, Arc<str>> =
             std::collections::HashMap::new();
+        // Per-path SCIP callee monikers (#275), fetched once per distinct file in scip mode.
+        // Keyed by the sha of the DISK bytes just read — `current_callee_monikers` only returns
+        // rows whose `file_sha` matches, so the spans are guaranteed to line up with the
+        // `node_spans` this very parse produces. A drifted file matches nothing (no collapse).
+        let mut moniker_cache: std::collections::HashMap<
+            String,
+            std::collections::HashMap<(usize, usize), String>,
+        > = std::collections::HashMap::new();
 
         let mut members: Vec<crate::index::clones::refine::RefineMember> =
             Vec::with_capacity(rows.len());
@@ -840,6 +867,13 @@ impl IndexDatabase {
                     // Source missing/unreadable on disk — can't reproduce the token sequence.
                     return Ok(None);
                 };
+                if attach_callee_monikers {
+                    let disk_sha = crate::index::hex_sha256(content.as_bytes());
+                    moniker_cache.insert(
+                        row.path.clone(),
+                        crate::index::oracle::current_callee_monikers(conn, &row.path, &disk_sha)?,
+                    );
+                }
                 file_cache.insert(row.path.clone(), Arc::from(content.as_str()));
             }
             let text: Arc<str> =
@@ -883,6 +917,7 @@ impl IndexDatabase {
                 struct_hash: row.struct_hash,
                 seq,
                 node_spans,
+                callee_monikers: moniker_cache.get(&row.path).cloned().unwrap_or_default(),
                 text,
             });
         }

--- a/crates/rag-rat-core/src/index/query_api/clones/mod.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/mod.rs
@@ -498,7 +498,12 @@ impl IndexDatabase {
         // two modes address disjoint cache namespaces, so an oracle run can invalidate every
         // scip-mode row (`invalidate_scip_refinements`) without touching baseline rows. Cheap
         // (one EXISTS per hydration chunk), so the warm probe stays a probe.
-        let mode = if oracle_callee_coverage_exists(conn, class_ids)? {
+        let mode = if oracle_callee_coverage_exists(
+            conn,
+            class_ids,
+            &self.active_commit_sha,
+            &self.active_worktree_id,
+        )? {
             RefineMode::Scip
         } else {
             RefineMode::Baseline
@@ -871,7 +876,13 @@ impl IndexDatabase {
                     let disk_sha = crate::index::hex_sha256(content.as_bytes());
                     moniker_cache.insert(
                         row.path.clone(),
-                        crate::index::oracle::current_callee_monikers(conn, &row.path, &disk_sha)?,
+                        crate::index::oracle::current_callee_monikers(
+                            conn,
+                            &row.path,
+                            &disk_sha,
+                            &self.active_commit_sha,
+                            &self.active_worktree_id,
+                        )?,
                     );
                 }
                 file_cache.insert(row.path.clone(), Arc::from(content.as_str()));

--- a/crates/rag-rat-core/src/index/query_api/clones/refine_load.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/refine_load.rs
@@ -94,6 +94,52 @@ pub(crate) fn load_refine_rows(
     Ok(Some(rows))
 }
 
+/// Whether ANY member's file has CURRENT SCIP-oracle callee coverage (#275, Plan 3): an
+/// `edge_oracle` call row whose `file_sha` matches the file's indexed `sha256`. This is the
+/// refine-MODE probe — `true` selects [`RefineMode::Scip`], which keys (and caches) the refinement
+/// in the scip-mode namespace and lets the loader attach callee monikers. CHEAP (one EXISTS per
+/// hydration chunk over `idx_edge_oracle_anchor`), and deterministic for a given (index, oracle)
+/// state, so the warm cache probe stays a probe.
+///
+/// ANY (not ALL) member coverage selects scip mode: a class spanning a covered and an uncovered
+/// file still benefits when the compared callee spans all carry monikers, and the collapse itself
+/// stays span-exact (a member without a moniker vetoes its own comparison, never the whole
+/// class). A class with NO covered file computes byte-identically to baseline, so it keeps the
+/// baseline key rather than duplicating rows into the scip namespace.
+///
+/// [`RefineMode::Scip`]: crate::index::clones::refine::cache::RefineMode
+pub(crate) fn oracle_callee_coverage_exists(
+    conn: &Connection,
+    member_ids: &[i64],
+) -> anyhow::Result<bool> {
+    let repo_clause = crate::index::schema::periphery_repo_scope_clause(
+        &crate::index::schema::periphery_repo_scope(conn, "edge_oracle")?,
+        "edge_oracle",
+    );
+    for chunk in member_ids.chunks(HYDRATION_CHUNK) {
+        let id_placeholders: Vec<String> = (1..=chunk.len()).map(|i| format!("?{i}")).collect();
+        let sql = format!(
+            "SELECT EXISTS(
+                 SELECT 1
+                 FROM symbols
+                 JOIN files ON files.id = symbols.file_id
+                 JOIN edge_oracle
+                   ON edge_oracle.source_path = files.path
+                   AND edge_oracle.file_sha = files.sha256
+                   AND edge_oracle.edge_kind = 'calls_name'{repo_clause}
+                 WHERE symbols.id IN ({})
+             )",
+            id_placeholders.join(", ")
+        );
+        let covered: bool =
+            conn.query_row(&sql, rusqlite::params_from_iter(chunk.iter()), |row| row.get(0))?;
+        if covered {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
 /// Fetch a per-member SOURCE DISCRIMINATOR — `"{file_sha256}:{start_byte}-{end_byte}"` — for the
 /// refinement cache key (#215 Plan 4b, cache-poisoning fix). `file_sha256` is the indexed file
 /// content hash; the body byte span pins the member's source range. Together they uniquely

--- a/crates/rag-rat-core/src/index/query_api/clones/refine_load.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/refine_load.rs
@@ -95,11 +95,14 @@ pub(crate) fn load_refine_rows(
 }
 
 /// Whether ANY member's file has CURRENT SCIP-oracle callee coverage (#275, Plan 3): an
-/// `edge_oracle` call row whose `file_sha` matches the file's indexed `sha256`. This is the
-/// refine-MODE probe — `true` selects [`RefineMode::Scip`], which keys (and caches) the refinement
-/// in the scip-mode namespace and lets the loader attach callee monikers. CHEAP (one EXISTS per
-/// hydration chunk over `idx_edge_oracle_anchor`), and deterministic for a given (index, oracle)
-/// state, so the warm cache probe stays a probe.
+/// `edge_oracle` call-HEAD row whose `file_sha` matches the file's indexed `sha256` and that
+/// passes the shared currency gate (`callee_moniker_current_clause`: call-HEAD edge kinds, the
+/// LATEST completed run per tool in the active `(commit_sha, worktree_id)` checkout, a still-live
+/// resolved definition) — the SAME discipline the moniker fetch applies, so mode and attachment
+/// can't diverge. This is the refine-MODE probe — `true` selects [`RefineMode::Scip`], which keys
+/// (and caches) the refinement in the scip-mode namespace and lets the loader attach callee
+/// monikers. CHEAP (one EXISTS per hydration chunk over `idx_edge_oracle_anchor`), and
+/// deterministic for a given (index, oracle) state, so the warm cache probe stays a probe.
 ///
 /// ANY (not ALL) member coverage selects scip mode: a class spanning a covered and an uncovered
 /// file still benefits when the compared callee spans all carry monikers, and the collapse itself
@@ -111,6 +114,8 @@ pub(crate) fn load_refine_rows(
 pub(crate) fn oracle_callee_coverage_exists(
     conn: &Connection,
     member_ids: &[i64],
+    commit_sha: &str,
+    worktree_id: &str,
 ) -> anyhow::Result<bool> {
     let repo_clause = crate::index::schema::periphery_repo_scope_clause(
         &crate::index::schema::periphery_repo_scope(conn, "edge_oracle")?,
@@ -118,6 +123,13 @@ pub(crate) fn oracle_callee_coverage_exists(
     );
     for chunk in member_ids.chunks(HYDRATION_CHUNK) {
         let id_placeholders: Vec<String> = (1..=chunk.len()).map(|i| format!("?{i}")).collect();
+        let commit_slot = format!("?{}", chunk.len() + 1);
+        let worktree_slot = format!("?{}", chunk.len() + 2);
+        let current_clause = crate::index::oracle::callee_moniker_current_clause(
+            conn,
+            &commit_slot,
+            &worktree_slot,
+        )?;
         let sql = format!(
             "SELECT EXISTS(
                  SELECT 1
@@ -125,14 +137,21 @@ pub(crate) fn oracle_callee_coverage_exists(
                  JOIN files ON files.id = symbols.file_id
                  JOIN edge_oracle
                    ON edge_oracle.source_path = files.path
-                   AND edge_oracle.file_sha = files.sha256
-                   AND edge_oracle.edge_kind = 'calls_name'{repo_clause}
+                   AND edge_oracle.file_sha = files.sha256{repo_clause}{current_clause}
                  WHERE symbols.id IN ({})
              )",
             id_placeholders.join(", ")
         );
+        let params: Vec<Box<dyn rusqlite::ToSql>> = chunk
+            .iter()
+            .map(|id| Box::new(*id) as Box<dyn rusqlite::ToSql>)
+            .chain([
+                Box::new(commit_sha.to_string()) as Box<dyn rusqlite::ToSql>,
+                Box::new(worktree_id.to_string()) as Box<dyn rusqlite::ToSql>,
+            ])
+            .collect();
         let covered: bool =
-            conn.query_row(&sql, rusqlite::params_from_iter(chunk.iter()), |row| row.get(0))?;
+            conn.query_row(&sql, rusqlite::params_from_iter(params.iter()), |row| row.get(0))?;
         if covered {
             return Ok(true);
         }

--- a/crates/rag-rat-core/src/index/query_api/clones/scoring.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/scoring.rs
@@ -206,7 +206,7 @@ pub(crate) fn apply_refinement(
     class.lcs_ratio = Some(refinement.lcs_ratio);
     class.confidence = Some(refinement.confidence.as_db_str().to_string());
     class.refactorability = Some(refinement.refactorability);
-    class.refine_mode = Some(refinement.refine_mode);
+    class.refine_mode = Some(refinement.refine_mode.as_db_str());
 
     // Plan 4b anti-unification payload — surfaced on BOTH the warm (cache-hit) and cold
     // (compute+store) paths because both flow through this helper. The two JSON columns are parsed

--- a/crates/rag-rat-core/src/index/query_api/clones/tests.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/tests.rs
@@ -706,7 +706,7 @@ fn unsampled_refinement() -> crate::index::clones::refine::cache::CachedRefineme
         lcs_ratio: 1.0,
         confidence: crate::index::clones::refine::score::Confidence::High,
         refactorability: 1.0,
-        refine_mode: "baseline",
+        refine_mode: crate::index::clones::refine::cache::RefineMode::Baseline,
         template: String::new(),
         variation_points_json: "[]".to_string(),
         proposed_signature_json: "{}".to_string(),

--- a/crates/rag-rat-core/src/index/query_api/clones/types.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/types.rs
@@ -91,7 +91,8 @@ pub struct CandidateCloneClass {
     /// only on classes the two-phase driver refined (`refined == true`). `lcs_ratio` is the NiCad
     /// class fidelity (min pairwise `2·LCS/(|a|+|b|)`); `confidence` is the persisted band
     /// (`"high"`/`"medium"`/`"low"`); `refactorability` is the `(0,1]`-clamped ROI multiplier;
-    /// `refine_mode` is `Some("baseline")` when refined.
+    /// `refine_mode` is `Some("baseline")` or — when the SCIP-oracle moniker evidence was
+    /// consulted (#275, Plan 3) — `Some("scip")` when refined.
     pub lcs_ratio: Option<f64>,
     pub confidence: Option<String>,
     pub refactorability: Option<f64>,

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/clones.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/clones.rs
@@ -3938,27 +3938,43 @@ fn scip_moniker_collapse_lifts_a_same_symbol_callee_class() {
     );
 
     // Seed CURRENT oracle verdicts: each member file's callee identifier span resolves to the
-    // SAME moniker. `file_sha` must equal the indexed (= on-disk) content hash for the rows to
-    // count as current.
+    // SAME moniker. `file_sha` must equal the indexed (= on-disk) content hash, a COMPLETED
+    // `oracle_runs` row in this checkout must stand behind their `(tool, tool_version)`, and each
+    // verdict's content key must match a LIVE `calls_name` edge — the three currency gates the
+    // collapse read applies. Deriving the verdict's content key from the real indexed edge (rather
+    // than a synthetic callee-only span) is what the production oracle does, so the live-edge gate
+    // sees a match.
     let conn = db.storage.connection();
+    conn.execute(
+        "INSERT INTO oracle_runs(repo_id, tool, tool_version, commit_sha, worktree_id, \
+         started_at, status, stats_json)
+         VALUES (?1, 'scip-rust', 'v1', ?2, ?3, 0, 'Completed', '{}')",
+        rusqlite::params![db.active_repo_id, db.active_commit_sha, db.active_worktree_id],
+    )
+    .unwrap();
     for (dir, name, _var, callee) in fixtures {
         let rel = format!("{dir}/{name}.rs");
         let src = fs::read_to_string(root.join(&rel)).unwrap();
         let sha = crate::index::hex_sha256(src.as_bytes());
-        let start = src.find(&format!("{callee}(")).unwrap();
+        // The real edge the extractor emitted for `callee(...)` — its source span is the whole
+        // call expression, its callee span the identifier. The verdict is keyed by BOTH.
+        let (src_lo, src_hi, cal_lo, cal_hi): (i64, i64, i64, i64) = conn
+            .query_row(
+                "SELECT edges.source_start_byte, edges.source_end_byte, edges.callee_start_byte, \
+                 edges.callee_end_byte
+                 FROM edges JOIN files ON files.id = edges.source_file_id
+                 WHERE files.path = ?1 AND edges.edge_kind = 'calls_name' AND edges.to_name = ?2",
+                rusqlite::params![rel, callee],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?)),
+            )
+            .unwrap();
         conn.execute(
             "INSERT INTO edge_oracle(repo_id, source_path, source_start_byte, source_end_byte, \
              callee_start_byte, callee_end_byte, edge_kind, file_sha, tool, tool_version, \
              scip_symbol, kind, computed_at)
-             VALUES (?1, ?2, ?3, ?4, ?3, ?4, 'calls_name', ?5, 'scip-rust', 'v1', 'rust cr 1.0 \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'calls_name', ?7, 'scip-rust', 'v1', 'rust cr 1.0 \
              validate().', 'resolved', 0)",
-            rusqlite::params![
-                db.active_repo_id,
-                rel,
-                start as i64,
-                (start + callee.len()) as i64,
-                sha,
-            ],
+            rusqlite::params![db.active_repo_id, rel, src_lo, src_hi, cal_lo, cal_hi, sha],
         )
         .unwrap();
     }

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/clones.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/clones.rs
@@ -1939,7 +1939,7 @@ fn clones_for_symbol_returns_refined_class() {
 /// same key; the two key families never collide for the same class.
 #[test]
 fn refinement_key_is_content_addressed_and_distinct_from_read_key() {
-    use crate::index::clones::refine::cache::refinement_key;
+    use crate::index::clones::refine::cache::{RefineMode, refinement_key};
 
     let hashes = vec!["h1".to_string(), "h2".to_string(), "h3".to_string()];
     let shuffled = vec!["h3".to_string(), "h1".to_string(), "h2".to_string()];
@@ -1948,8 +1948,8 @@ fn refinement_key_is_content_addressed_and_distinct_from_read_key() {
     // Same multiset, different order (struct_hashes AND source discriminators) → same
     // refinement_key (content-addressed, order-independent).
     assert_eq!(
-        refinement_key("rust", &hashes, &discs),
-        refinement_key("rust", &shuffled, &discs_shuffled),
+        refinement_key("rust", RefineMode::Baseline, &hashes, &discs),
+        refinement_key("rust", RefineMode::Baseline, &shuffled, &discs_shuffled),
         "the same struct_hash + source-discriminator multiset must address the same refinement"
     );
 
@@ -2398,7 +2398,7 @@ fn load_refine_members_returns_up_to_value_cap() {
 
     // load_refine_members must cap the re-parse to MEMBER_VALUE_CAP members.
     let members = db
-        .load_refine_members(&big)
+        .load_refine_members(&big, false)
         .expect("load_refine_members ok")
         .expect("refine inputs available for an in-scope class");
     assert_eq!(
@@ -2450,8 +2450,10 @@ fn refine_member_carries_spans_len_eq_seq() {
     let id_a = fingerprinted_symbol_id_for_ref(&db, "src/a.rs::load_user");
     let id_b = fingerprinted_symbol_id_for_ref(&db, "src/b.rs::load_order");
 
-    let members =
-        db.load_refine_members(&[id_a, id_b]).expect("load ok").expect("refine inputs available");
+    let members = db
+        .load_refine_members(&[id_a, id_b], false)
+        .expect("load ok")
+        .expect("refine inputs available");
     assert_eq!(members.len(), 2, "both members must be returned");
 
     for m in &members {
@@ -2515,7 +2517,7 @@ fn faithfulness_pin_still_drops_drifted_member() {
 
     // Sanity: before drift, refine inputs are available.
     assert!(
-        db.load_refine_members(&[id_a, id_b]).unwrap().is_some(),
+        db.load_refine_members(&[id_a, id_b], false).unwrap().is_some(),
         "before drift: refine inputs must be available"
     );
 
@@ -2529,7 +2531,7 @@ fn faithfulness_pin_still_drops_drifted_member() {
 
     // After drift: the re-parse of b.rs produces a different struct_hash → faithfulness pin fires
     // → load_refine_members returns Ok(None).
-    let result = db.load_refine_members(&[id_a, id_b]).unwrap();
+    let result = db.load_refine_members(&[id_a, id_b], false).unwrap();
     assert!(
         result.is_none(),
         "a drifted member (struct_hash mismatch) must cause load_refine_members to return Ok(None)"
@@ -3729,7 +3731,7 @@ fn load_refine_members_reparse_is_faithful_to_persisted_struct_hash() {
     let id_b = fingerprinted_symbol_id_for_ref(&db, "src/b.rs::load_order");
 
     let members = db
-        .load_refine_members(&[id_a, id_b])
+        .load_refine_members(&[id_a, id_b], false)
         .unwrap()
         .expect("refine inputs available for an unchanged, in-scope clone pair");
     assert_eq!(members.len(), 2, "both members loaded");
@@ -3792,7 +3794,8 @@ fn load_refine_members_empty_input_returns_empty() {
     fs::write(root.join("src/a.rs"), "pub fn f() -> i32 { 0 }\n").unwrap();
     let db = IndexDatabase::rebuild(&source_config(root.clone(), Language::Rust)).unwrap();
 
-    let members = db.load_refine_members(&[]).unwrap().expect("empty input is a valid empty set");
+    let members =
+        db.load_refine_members(&[], false).unwrap().expect("empty input is a valid empty set");
     assert!(members.is_empty(), "empty member_ids → empty members");
 
     let _ = fs::remove_dir_all(root);
@@ -3824,7 +3827,7 @@ fn load_refine_members_returns_none_when_source_missing() {
     // Delete one member's source file on disk; the fingerprint rows are unchanged in the index.
     fs::remove_file(root.join("src/b.rs")).unwrap();
 
-    let result = db.load_refine_members(&[id_a, id_b]).unwrap();
+    let result = db.load_refine_members(&[id_a, id_b], false).unwrap();
     assert!(
         result.is_none(),
         "a member with a deleted source file must yield Ok(None) for the whole class"
@@ -3876,7 +3879,7 @@ fn load_refine_members_returns_none_under_linked_overlay_scope() {
     let id_b = fingerprinted_symbol_id_for_ref(&db, "src/b.rs::load_order");
 
     // Even with valid member ids, refine is unavailable under an overlay scope.
-    let result = db.load_refine_members(&[id_a, id_b]).unwrap();
+    let result = db.load_refine_members(&[id_a, id_b], false).unwrap();
     assert!(
         result.is_none(),
         "refine must be unavailable (Ok(None)) under a linked-worktree overlay scope"
@@ -3884,4 +3887,120 @@ fn load_refine_members_returns_none_under_linked_overlay_scope() {
 
     let _ = fs::remove_dir_all(&main);
     let _ = fs::remove_dir_all(&linked);
+}
+
+/// #275 (Plan 3) end to end: a clone class whose ONLY difference is the callee SPELLING —
+/// baseline refines it with a `differing_callee` closure_param (it cannot prove `validate` /
+/// `check` / `verify` / `audit` are one function). Seeding CURRENT `edge_oracle` rows that
+/// resolve every member's callee to ONE moniker flips the next refine into scip mode: the callee
+/// column collapses back into the fixed spine (coverage 1.0, no variation point, no
+/// `differing_callee`) and the class carries `refine_mode = "scip"` provenance. The baseline and
+/// scip refinements coexist as separate cache rows (the mode is folded into the key).
+#[test]
+fn scip_moniker_collapse_lifts_a_same_symbol_callee_class() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("a")).unwrap();
+    fs::create_dir_all(root.join("b")).unwrap();
+    // The write_four_renamed_clones shape, but the CALLEE differs per member — the one variation
+    // baseline must flag as differing_callee and the oracle can collapse.
+    let fixtures = [
+        ("a", "load_user", "u", "validate"),
+        ("a", "load_order", "o", "check"),
+        ("b", "load_item", "i", "verify"),
+        ("b", "load_blob", "x", "audit"),
+    ];
+    for (dir, name, var, callee) in fixtures {
+        fs::write(
+            root.join(dir).join(format!("{name}.rs")),
+            format!(
+                "pub fn {name}(db: Db) -> i32 {{ let {var} = db.get(1); {callee}({var}); {var} + \
+                 1 }}\n"
+            ),
+        )
+        .unwrap();
+    }
+    let config = four_clone_config(&root);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    // Run 1 — NO oracle data: baseline mode, and the differing callee is a conservative
+    // closure_param/differing_callee variation point.
+    let r1 = db
+        .find_clones(FindClonesOptions { min_similarity: None, min_copies: None, limit: None })
+        .unwrap();
+    let class1 = &r1.classes[0];
+    assert!(class1.refined, "run 1 refines the class");
+    assert_eq!(class1.refine_mode, Some("baseline"), "no oracle coverage ⇒ baseline mode");
+    let vps1 = class1.variation_points.as_ref().expect("run 1 VPs").as_array().unwrap().clone();
+    assert!(
+        vps1.iter().any(|vp| vp["differing_callee"] == serde_json::Value::Bool(true)),
+        "baseline must flag the differing callee (non-vacuity guard), got {vps1:?}"
+    );
+
+    // Seed CURRENT oracle verdicts: each member file's callee identifier span resolves to the
+    // SAME moniker. `file_sha` must equal the indexed (= on-disk) content hash for the rows to
+    // count as current.
+    let conn = db.storage.connection();
+    for (dir, name, _var, callee) in fixtures {
+        let rel = format!("{dir}/{name}.rs");
+        let src = fs::read_to_string(root.join(&rel)).unwrap();
+        let sha = crate::index::hex_sha256(src.as_bytes());
+        let start = src.find(&format!("{callee}(")).unwrap();
+        conn.execute(
+            "INSERT INTO edge_oracle(repo_id, source_path, source_start_byte, source_end_byte, \
+             callee_start_byte, callee_end_byte, edge_kind, file_sha, tool, tool_version, \
+             scip_symbol, kind, computed_at)
+             VALUES (?1, ?2, ?3, ?4, ?3, ?4, 'calls_name', ?5, 'scip-rust', 'v1', 'rust cr 1.0 \
+             validate().', 'resolved', 0)",
+            rusqlite::params![
+                db.active_repo_id,
+                rel,
+                start as i64,
+                (start + callee.len()) as i64,
+                sha,
+            ],
+        )
+        .unwrap();
+    }
+
+    // Run 2 — oracle coverage exists: scip mode, the callee collapses into the fixed spine.
+    let r2 = db
+        .find_clones(FindClonesOptions { min_similarity: None, min_copies: None, limit: None })
+        .unwrap();
+    let class2 = &r2.classes[0];
+    assert!(class2.refined, "run 2 refines the class (scip-mode cold compute)");
+    assert_eq!(
+        class2.refine_mode,
+        Some("scip"),
+        "oracle coverage ⇒ scip mode provenance on the class"
+    );
+    let vps2 = class2.variation_points.as_ref().expect("run 2 VPs").as_array().unwrap().clone();
+    assert!(
+        vps2.iter().all(|vp| vp["differing_callee"] != serde_json::Value::Bool(true)),
+        "a moniker-proven same-symbol callee must not be differing_callee, got {vps2:?}"
+    );
+    assert!(
+        vps2.is_empty(),
+        "the callee was the ONLY variation — the collapsed class has no variation points, got \
+         {vps2:?}"
+    );
+    assert_eq!(
+        class2.anti_unify_coverage,
+        Some(1.0),
+        "the collapsed callee column is fixed spine — coverage returns to 1.0"
+    );
+
+    // Both modes' refinements coexist as distinct cache rows (disjoint key namespaces). Scoped
+    // to the active repo — the poison-sibling harness seeds its own refinement row.
+    let modes: Vec<String> = {
+        let mut stmt = conn
+            .prepare(
+                "SELECT refine_mode FROM clone_refinements WHERE repo_id = ?1 ORDER BY refine_mode",
+            )
+            .unwrap();
+        stmt.query_map([&db.active_repo_id], |r| r.get(0)).unwrap().map(Result::unwrap).collect()
+    };
+    assert_eq!(modes, vec!["baseline".to_string(), "scip".to_string()]);
+
+    let _ = fs::remove_dir_all(root);
 }

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/mod.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/mod.rs
@@ -828,10 +828,17 @@ fn write_four_renamed_clones(root: &PathBuf) -> IndexDatabase {
         )
         .unwrap();
     }
-    let config = Config {
+    IndexDatabase::rebuild(&four_clone_config(root)).unwrap()
+}
+
+/// The `write_four_renamed_clones` fixture's config — a rust target over the `a/` + `b/` dirs —
+/// shared with tests that write their own four-member variant (e.g. the #275 differing-callee
+/// fixture) before rebuilding.
+fn four_clone_config(root: &Path) -> Config {
+    Config {
         repo_id_override: None,
         database_key_pinned: true,
-        root: root.clone(),
+        root: root.to_path_buf(),
         database: root.join(".rag-rat/index.sqlite"),
         targets: vec![ResolvedTarget {
             name: "rust".to_string(),
@@ -850,8 +857,7 @@ fn write_four_renamed_clones(root: &PathBuf) -> IndexDatabase {
         log: Default::default(),
         source_root_reanchored_from: None,
         allow_empty: false,
-    };
-    IndexDatabase::rebuild(&config).unwrap()
+    }
 }
 
 /// Resolve the `symbols.id` of a fingerprinted function by its qualified-name `ref` (the

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/multi_repo_scope.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/multi_repo_scope.rs
@@ -1938,10 +1938,25 @@ fn incremental_open_resets_source_root_from_the_config_before_heals() {
 /// to the active repo. Both repos hold a row for the SAME `(source_path, file_sha, span)` with
 /// DIFFERENT monikers; an unscoped read would see both, treat the span as a multi-tool conflict,
 /// and drop it (or worse, serve the sibling's identity). The active repo must see exactly its own.
+/// The latest-run currency gate's `oracle_runs` subquery must be repo-scoped too: repo B holds a
+/// NEWER run under a DIFFERENT `tool_version` — unscoped, that run would be "latest" for the tool
+/// and filter repo A's current rows.
 #[test]
 fn current_callee_monikers_ignores_a_sibling_repos_rows() {
     let conn = a5_scoped_two_repo_conn();
 
+    // Repo A's latest run stands behind 'v1'; repo B's NEWER (higher-id) run is on 'v2'. Rows are
+    // only trusted when the LATEST run of their tool in the ACTIVE repo + checkout backs their
+    // version, so B's run must not supersede A's.
+    for (repo, version) in [(A5_REPO_A, "v1"), (A5_REPO_B, "v2")] {
+        conn.execute(
+            "INSERT INTO oracle_runs(repo_id, tool, tool_version, commit_sha, worktree_id, \
+             started_at, status, stats_json)
+             VALUES (?1, 'scip-rust', ?2, 'commit-x', '', 0, 'Completed', '{}')",
+            rusqlite::params![repo, version],
+        )
+        .unwrap();
+    }
     for (repo, symbol) in [(A5_REPO_A, "rust cr 1.0 a()."), (A5_REPO_B, "rust cr 1.0 b().")] {
         conn.execute(
             "INSERT INTO edge_oracle(repo_id, source_path, source_start_byte, source_end_byte, \
@@ -1954,13 +1969,48 @@ fn current_callee_monikers_ignores_a_sibling_repos_rows() {
         .unwrap();
     }
 
+    // A LIVE `calls_name` edge for the verdict's content key must exist in the active checkout —
+    // the collapse read gates on it. One file+edge in repo A's scope satisfies the (repo-agnostic,
+    // path+sha+commit-keyed) live-edge EXISTS; repo B's verdict is filtered by the repo predicate
+    // before that gate, so it needs none.
+    conn.execute(
+        "INSERT INTO files(repo_id, path, language, kind, sha256, modified_at_ms, indexed_at_ms, \
+         commit_sha, worktree_id)
+         VALUES (?1, 'src/x.rs', 'rust', 'source', 'sha-x', 0, 0, 'commit-x', '')",
+        [A5_REPO_A],
+    )
+    .unwrap();
+    let file_id = conn.last_insert_rowid();
+    conn.execute_batch(
+        "INSERT OR IGNORE INTO name_strings(value)
+             VALUES ('x_callee'), ('calls_name'), ('NameOnly'), ('unresolved');",
+    )
+    .unwrap();
+    let id_of = |v: &str| -> i64 {
+        conn.query_row("SELECT id FROM name_strings WHERE value = ?1", [v], |r| r.get(0)).unwrap()
+    };
+    conn.execute(
+        "INSERT INTO edges_data(source_file_id, to_name_id, edge_kind_id, confidence_id, \
+         resolution_id, source_start_byte, source_end_byte, callee_start_byte, callee_end_byte)
+         VALUES (?1, ?2, ?3, ?4, ?5, 0, 20, 5, 8)",
+        rusqlite::params![
+            file_id,
+            id_of("x_callee"),
+            id_of("calls_name"),
+            id_of("NameOnly"),
+            id_of("unresolved"),
+        ],
+    )
+    .unwrap();
+
     a5_set_active_repo(&conn, A5_REPO_A);
     let monikers =
-        crate::index::oracle::current_callee_monikers(&conn, "src/x.rs", "sha-x").unwrap();
+        crate::index::oracle::current_callee_monikers(&conn, "src/x.rs", "sha-x", "commit-x", "")
+            .unwrap();
     assert_eq!(
         monikers,
         std::collections::HashMap::from([((5, 8), "rust cr 1.0 a().".to_string())]),
         "the collapse read must serve the ACTIVE repo's moniker, never conflict against (or leak) \
-         the sibling's row"
+         the sibling's row — and the sibling's newer run must not supersede the active repo's"
     );
 }

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/multi_repo_scope.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/multi_repo_scope.rs
@@ -1933,3 +1933,34 @@ fn incremental_open_resets_source_root_from_the_config_before_heals() {
 
     let _ = fs::remove_dir_all(fx.root_a);
 }
+
+/// #275: `current_callee_monikers` — the clone-refine collapse's `edge_oracle` read — must scope
+/// to the active repo. Both repos hold a row for the SAME `(source_path, file_sha, span)` with
+/// DIFFERENT monikers; an unscoped read would see both, treat the span as a multi-tool conflict,
+/// and drop it (or worse, serve the sibling's identity). The active repo must see exactly its own.
+#[test]
+fn current_callee_monikers_ignores_a_sibling_repos_rows() {
+    let conn = a5_scoped_two_repo_conn();
+
+    for (repo, symbol) in [(A5_REPO_A, "rust cr 1.0 a()."), (A5_REPO_B, "rust cr 1.0 b().")] {
+        conn.execute(
+            "INSERT INTO edge_oracle(repo_id, source_path, source_start_byte, source_end_byte, \
+             callee_start_byte, callee_end_byte, edge_kind, file_sha, tool, tool_version, \
+             scip_symbol, kind, computed_at)
+             VALUES (?1, 'src/x.rs', 0, 20, 5, 8, 'calls_name', 'sha-x', 'scip-rust', 'v1', ?2, \
+             'resolved', 0)",
+            rusqlite::params![repo, symbol],
+        )
+        .unwrap();
+    }
+
+    a5_set_active_repo(&conn, A5_REPO_A);
+    let monikers =
+        crate::index::oracle::current_callee_monikers(&conn, "src/x.rs", "sha-x").unwrap();
+    assert_eq!(
+        monikers,
+        std::collections::HashMap::from([((5, 8), "rust cr 1.0 a().".to_string())]),
+        "the collapse read must serve the ACTIVE repo's moniker, never conflict against (or leak) \
+         the sibling's row"
+    );
+}


### PR DESCRIPTION
Fixes #275.

The differing-callee guard is deliberately conservative: baseline token space cannot prove `validate()` and `check()` are the same function, so a class whose members differ only in callee spelling refines as `closure_param`/`differing_callee` (confidence low). When the SCIP oracle (#61) has resolved every member's callee to ONE moniker, that conservatism is no longer necessary — this lifts the class to Type-2, addressing all four findings recorded on the issue.

## How it works

- **Finding 1 (moniker-aware comparisons):** `load_refine_members` attaches a per-member `callee span → scip_symbol` map (`current_callee_monikers`); `matched_column_reopen` and the `run_callees_differ` guard consult it. A matched callee column whose contributing members all resolve to one moniker stays **fixed spine** — the anchor's spelling renders as template text; a proven single-leaf variation run skips the guard and classifies through the normal ladder. One member without a moniker vetoes the collapse — oracle absence degrades to today's behavior, never a wrong fix.
- **Finding 2 (same-call-syntax scope):** the collapse only fires on LCS-matched columns and single-leaf runs; multi-token / cross-syntax runs (`a::b::foo()` vs `foo()`) keep today's verdict.
- **Finding 3 (cache staleness):** `RefineMode { baseline, scip }` is folded into `refinement_key`, so the modes occupy disjoint cache namespaces; the mode is probed per class before the warm lookup (any member file with **current** `edge_oracle` callee coverage, i.e. `file_sha = files.sha256`). `oracle run` completion deletes every scip-mode row (`invalidate_scip_refinements`) — nothing in the key changes when a moniker changes — while baseline rows, oracle-independent by construction (monikers are only attached in scip mode, with a debug assert), survive.
- **Finding 4 (no `Typedness::Resolved`):** provenance is class-level — `refine_mode: "scip"` on the refined class; a collapsed callee is fixed template text, not a param with a phantom referent.

Span-join soundness: moniker attach is gated on `edge_oracle.file_sha == sha256(disk bytes just parsed)`, so byte offsets always line up; `local N` symbols (document-scoped identity) and spans two tools disagree on are never attached. The new `edge_oracle` read is repo-scoped with a two-repo isolation test per the periphery-scoping discipline.

The seam is oracle-source-agnostic: it reads whatever `edge_oracle` rows exist, so the live-LSP incremental oracle (#74) will feed it without changes.

## Verification

- Unit: reopen collapse / differing-moniker / missing-moniker veto / re-descent variation-run collapse; `current_callee_monikers` sha-local-conflict filtering; mode-distinct keys; scip-only invalidation; two-repo isolation.
- End to end (library + real CLI): a four-member class differing only in callee spelling refines baseline as `closure_param`/`differing_callee` (confidence low, coverage 0.977); after same-moniker verdicts land, the same class refines as clean Type-2 — zero variation points, coverage 1.0, confidence high, `refine_mode: scip`, callee fixed in the template. Both refinements coexist as separate cache rows.
- Full workspace suite green (2003 tests); clippy clean.