### PR TITLE
feat(dream): expose dream + dream_review MCP tools (#263)

### DIFF
--- a/crates/rag-rat-core/src/dream/findings.rs
+++ b/crates/rag-rat-core/src/dream/findings.rs
@@ -323,7 +323,17 @@ pub(super) fn sync(
     now_ms: i64,
     resolve_kinds: &[&str],
 ) -> rusqlite::Result<(usize, usize, usize, usize)> {
-    let tx = conn.unchecked_transaction()?;
+    // IMMEDIATE, not the default DEFERRED: take the write lock at BEGIN so the per-finding
+    // SELECT-then-INSERT in `sync_in_tx` is atomic against a concurrent writer. A DEFERRED txn
+    // upgrades to a writer only on its first INSERT — AFTER the SELECT already read "no current
+    // row" — so two runs racing on the same (kind, subject) could both take the
+    // brand-new-insert branch and the loser hits a PK violation instead of refreshing. The CLI
+    // serializes `dream` with the repo WriteLock, but the MCP `dream`/`dream_review` tools run
+    // on the lock-free write path (up to `RAG_RAT_MCP_TOOL_WORKERS`, default 2, concurrent), so
+    // the atomicity must live here. IMMEDIATE makes a second writer block at BEGIN
+    // (busy_timeout, then the MCP call-level busy-retry) until the first commits, after which
+    // its SELECT sees the row and refreshes — no duplicate insert.
+    let tx = rusqlite::Transaction::new_unchecked(conn, rusqlite::TransactionBehavior::Immediate)?;
     let counts = sync_in_tx(&tx, findings, now_ms, resolve_kinds)?;
     tx.commit()?;
     Ok(counts)
@@ -1001,5 +1011,33 @@ mod tests {
         assert_eq!(rows.len(), 1, "only the winning claim is persisted: {rows:?}");
         assert_eq!(rows[0].0, "open");
         assert_eq!(rows[0].1, "hi", "the higher-ranked claim wins the collision");
+    }
+
+    #[test]
+    fn sync_uses_an_immediate_transaction_so_concurrent_dream_workers_cannot_race() {
+        // #514: two MCP `dream` workers hit `sync` on separate connections with no cross-process
+        // lock. The txn is IMMEDIATE, so it takes the write lock at BEGIN and the per-finding
+        // SELECT-then-INSERT can't interleave into a duplicate-id insert. Proven deterministically:
+        // hold a writer on a second connection, then run an EMPTY sync. Under the old DEFERRED txn
+        // an empty sync does zero writes and would succeed even against a held writer;
+        // under IMMEDIATE it must fail busy at BEGIN. busy_timeout=0 makes the contention
+        // immediate, not a blocking wait.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("dream.sqlite");
+        let a = Connection::open(&path).unwrap();
+        a.execute_batch("PRAGMA journal_mode=WAL;").unwrap();
+        a.busy_timeout(std::time::Duration::ZERO).unwrap();
+        crate::index::schema::apply(&a).unwrap();
+
+        let b = Connection::open(&path).unwrap();
+        b.busy_timeout(std::time::Duration::ZERO).unwrap();
+        b.execute_batch("BEGIN IMMEDIATE").unwrap(); // hold the write lock
+
+        let err = sync(&a, &[], 1, BASE_FINDING_KINDS).unwrap_err();
+        assert!(
+            crate::storage::is_busy(&anyhow::Error::new(err)),
+            "an empty sync under a concurrently-held writer must fail busy — proving BEGIN \
+             IMMEDIATE, not DEFERRED (which would do no writes and silently succeed)"
+        );
     }
 }

--- a/crates/rag-rat-core/src/dream/findings.rs
+++ b/crates/rag-rat-core/src/dream/findings.rs
@@ -555,12 +555,25 @@ pub(crate) fn review_dream_finding(
         ReviewVerdict::Reset => None,
         _ => Some(now_ms),
     };
-    conn.execute(
+    // Status-CONDITIONAL update (#514): the reviewability check above ran against the SELECT
+    // snapshot, but the MCP `dream_review` tool runs on the lock-free write path where a concurrent
+    // `dream` sync can resolve/supersede this finding between that read and this write. Gate the
+    // UPDATE on the row STILL being reviewable so it can never flip a terminal
+    // (resolved/superseded/archived) row back to accepted/open; if the race lost, 0 rows change and
+    // we report it rather than silently corrupting the lifecycle. (The Rust check above stays: it
+    // gives the precise "is {status} — not reviewable" message for the common non-racing case.)
+    let changed = conn.execute(
         &format!(
-            "UPDATE dream_findings SET status = ?2, reviewed_at_ms = ?3 WHERE id = ?1{repo_clause}"
+            "UPDATE dream_findings SET status = ?2, reviewed_at_ms = ?3 WHERE id = ?1 AND status \
+             IN ('open', 'accepted', 'dismissed'){repo_clause}"
         ),
         rusqlite::params![id, new_status, reviewed_at],
     )?;
+    if changed == 0 {
+        anyhow::bail!(
+            "finding `{id}` is no longer reviewable — it was resolved or superseded concurrently"
+        );
+    }
     Ok(ReviewedFinding { id, kind, subject, status: new_status.to_string() })
 }
 

--- a/crates/rag-rat-mcp/src/tools/catalog.rs
+++ b/crates/rag-rat-mcp/src/tools/catalog.rs
@@ -45,6 +45,8 @@ pub const TOOL_NAMES: &[&str] = &[
     "memory_edge_add",
     "memory_edge_remove",
     "memory_edges",
+    "dream",
+    "dream_review",
 ];
 
 pub fn list_tools() -> Value {
@@ -223,6 +225,20 @@ pub fn description(name: &str) -> &'static str {
             "List a node's typed edges: direction=from returns its outgoing edges (deps / links / \
              tracks); direction=into is the reverse traversal (e.g. tasks that track an issue, or \
              nodes that depend on this one).",
+        "dream" =>
+            "Return the deterministic memory-maintenance worklist: coverage gaps (load-bearing \
+             symbols with no memory) + stale references (a memory citing a path that no longer \
+             resolves), ranked, each with a stable `id` to review. This is the pull surface for a \
+             strong agent to burn down the worklist. Recomputes the deterministic findings on each \
+             call (like `rag-rat dream`); it does NOT run the opt-in model verdict/compaction \
+             passes — those stay on the CLI/cron `rag-rat dream --verify|--compact`, and the \
+             findings they persist (e.g. memory_divergence) still surface here. Review a finding \
+             with dream_review.",
+        "dream_review" =>
+            "Apply a human verdict to ONE dream finding by id (a full id or unambiguous prefix): \
+             accept (a real gap to act on), dismiss (noise), or reset (clear a prior verdict, back \
+             to open). Dream only proposes; this is how the reviewer confirms. The verdict \
+             survives future dream runs. Mirrors `rag-rat dream <id> --accept|--dismiss|--reset`.",
         _ => "Unknown tool.",
     }
 }
@@ -267,6 +283,8 @@ pub fn schema(name: &str) -> Value {
         "memory_edge_add" => schema_for::<MemoryEdgeAddArgs>(),
         "memory_edge_remove" => schema_for::<MemoryEdgeRemoveArgs>(),
         "memory_edges" => schema_for::<MemoryEdgesArgs>(),
+        "dream" => schema_for::<DreamArgs>(),
+        "dream_review" => schema_for::<DreamReviewArgs>(),
         _ => json!({"type": "object"}),
     }
 }

--- a/crates/rag-rat-mcp/src/tools/defaults.rs
+++ b/crates/rag-rat-mcp/src/tools/defaults.rs
@@ -32,6 +32,11 @@ pub(crate) fn default_search_limit() -> u32 {
     10
 }
 
+/// `dream`'s `coverage_gap` budget — matches the CLI `rag-rat dream`'s `--limit` default (20).
+pub(crate) fn default_dream_limit() -> u32 {
+    20
+}
+
 pub(crate) fn default_search_graph_mode() -> McpGraphMode {
     McpGraphMode::Compact
 }

--- a/crates/rag-rat-mcp/src/tools/handlers.rs
+++ b/crates/rag-rat-mcp/src/tools/handlers.rs
@@ -237,6 +237,24 @@ pub(crate) fn call_tool_with_db(
             let args: MemoryIdArgs = serde_json::from_value(arguments)?;
             json!(db.memory_mark_obsolete(&args.memory_id)?)
         },
+        "dream" => {
+            let args: DreamArgs = serde_json::from_value(arguments)?;
+            // The MCP surface is DETERMINISTIC-ONLY: never provision a GPU box or run minutes-long
+            // model inference from a tool call — the model verdict/compaction passes stay on the
+            // CLI/cron `rag-rat dream --verify|--compact`. `verify: false` also preserves any
+            // model-derived findings a prior `--verify` run persisted (dream_run's resolve sweep is
+            // kind-scoped), so `memory_divergence` etc. still surface in this worklist.
+            json!(db.dream_run(rag_rat_core::dream::DreamOptions {
+                now_ms: now_ms(),
+                limit: args.limit as usize,
+                verify: false,
+                include_reviewed: args.all,
+            })?)
+        },
+        "dream_review" => {
+            let args: DreamReviewArgs = serde_json::from_value(arguments)?;
+            json!(db.review_dream_finding(&args.finding, args.verdict.core(), now_ms())?)
+        },
         "find_clones" => {
             let args: FindClonesArgs = serde_json::from_value(arguments)?;
             find_clones_tool(db, args)?
@@ -688,6 +706,16 @@ pub(crate) fn graph_symbol_selector(args: &SymbolGraphArgs) -> anyhow::Result<Sy
         allow_ambiguous: args.allow_ambiguous,
         limit: args.limit,
     })
+}
+
+/// Wall-clock milliseconds for the dream write tools (finding first/last-seen + review stamps).
+/// Mirrors the CLI `dream` command's inline clock — the core `now_ms` helpers are crate-private, so
+/// the MCP surface computes its own; the dream lifecycle only needs a monotonic-enough stamp.
+fn now_ms() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
 }
 
 pub(crate) fn find_clones_tool(db: &IndexDatabase, args: FindClonesArgs) -> anyhow::Result<Value> {

--- a/crates/rag-rat-mcp/src/tools/handlers.rs
+++ b/crates/rag-rat-mcp/src/tools/handlers.rs
@@ -7,6 +7,13 @@ pub(crate) fn call_tool_with_db(
     graded_history: bool,
     memory_surface: MemorySurface,
 ) -> anyhow::Result<Value> {
+    // A JSON-RPC `tools/call` with the `arguments` object OMITTED reaches here as `Value::Null`
+    // (server.rs maps `None` → Null). `serde_json::from_value` of Null into an all-optional arg
+    // struct (e.g. `DreamArgs`) fails ("invalid type: null") BEFORE serde field defaults apply, so
+    // a bare no-arg call like `dream` would error. Normalize an absent/null argument object to
+    // an empty object so every tool's field defaults apply; a tool with REQUIRED fields still
+    // errors with a precise "missing field" message rather than a confusing type error (#514).
+    let arguments = if arguments.is_null() { json!({}) } else { arguments };
     let result = match name {
         "semantic_search" => {
             let args: SearchArgs = serde_json::from_value(arguments)?;

--- a/crates/rag-rat-mcp/src/tools/mod.rs
+++ b/crates/rag-rat-mcp/src/tools/mod.rs
@@ -59,6 +59,10 @@ pub(crate) fn is_write_tool(name: &str) -> bool {
             | "memory_edge_remove"
             | "memory_mark_obsolete"
             | "memory_validate"
+            // `dream` recomputes the deterministic worklist and syncs `dream_findings`;
+            // `dream_review` writes a finding's human verdict — both mutate the index.
+            | "dream"
+            | "dream_review"
     )
 }
 

--- a/crates/rag-rat-mcp/src/tools/requests.rs
+++ b/crates/rag-rat-mcp/src/tools/requests.rs
@@ -902,6 +902,56 @@ impl MemoryEdgesArgs {
     }
 }
 
+/// `dream`: recompute and return the deterministic memory-maintenance worklist (coverage gaps +
+/// stale references). Mirrors the SHAPE of the read tools (returns a ranked worklist) but is
+/// classified as a write tool — like the CLI `rag-rat dream`, it syncs `dream_findings`. It does
+/// NOT run the opt-in model verdict/compaction passes (those stay on the CLI/cron `--verify` /
+/// `--compact`); findings a prior model run persisted still surface here.
+#[derive(Debug, Deserialize, Serialize, schemars::JsonSchema)]
+pub struct DreamArgs {
+    /// Max `coverage_gap` findings to compute (the load-bearing-symbol budget); defaults to 20.
+    #[serde(default = "default_dream_limit")]
+    pub limit: u32,
+    /// Also surface the human-reviewed (`accepted` / `dismissed`) findings, not just the open
+    /// worklist — the `rag-rat dream --all` listing, so a reviewer can see and `reset` them.
+    #[serde(default)]
+    pub all: bool,
+}
+
+/// The human verdict `dream_review` applies to a dream finding — mirrors the CLI
+/// `rag-rat dream <id> --accept|--dismiss|--reset`.
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, schemars::JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum McpReviewVerdict {
+    /// Confirm the finding as a real gap to act on; the verdict survives future dream runs.
+    Accept,
+    /// Reject the finding as noise; the verdict survives future dream runs.
+    Dismiss,
+    /// Clear a prior accept/dismiss, returning the finding to the open worklist.
+    Reset,
+}
+
+impl McpReviewVerdict {
+    pub(super) fn core(self) -> rag_rat_core::dream::ReviewVerdict {
+        use rag_rat_core::dream::ReviewVerdict;
+        match self {
+            Self::Accept => ReviewVerdict::Accept,
+            Self::Dismiss => ReviewVerdict::Dismiss,
+            Self::Reset => ReviewVerdict::Reset,
+        }
+    }
+}
+
+/// `dream_review`: apply a human verdict to ONE dream finding by id or prefix — the pull-based
+/// counterpart to the CLI review surface, so a strong agent burns down the worklist over MCP.
+#[derive(Debug, Deserialize, Serialize, schemars::JsonSchema)]
+pub struct DreamReviewArgs {
+    /// The finding id from the `dream` worklist — a full id or an unambiguous git-style PREFIX.
+    pub finding: String,
+    /// `accept` / `dismiss` / `reset`.
+    pub verdict: McpReviewVerdict,
+}
+
 #[derive(Debug, Deserialize, Serialize, schemars::JsonSchema)]
 pub struct FindClonesArgs {
     /// Minimum pairwise overlap/max_len similarity. Must be in the range [0.5, 1.0]; defaults to

--- a/crates/rag-rat-mcp/src/tools/tests.rs
+++ b/crates/rag-rat-mcp/src/tools/tests.rs
@@ -551,6 +551,87 @@ fn mcp_memory_tools_create_surface_validate_and_obsolete_symbol_memory() {
 }
 
 #[test]
+fn mcp_dream_surfaces_a_finding_and_review_applies_a_verdict() {
+    // #263: the pull-based dream surface over MCP. `dream` recomputes the deterministic worklist
+    // (a WRITE tool — it syncs `dream_findings`, like `rag-rat dream`); `dream_review` applies a
+    // human verdict. Seed a `stale_reference` finding by binding a memory whose body cites a `.rs`
+    // path that does NOT resolve against the index — a deterministic, single-finding trigger that
+    // needs no model.
+    let root = unique_temp_root();
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), "pub fn anchor() {}\n").unwrap();
+    let config = rust_config(root.clone());
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    drop(db);
+
+    let memory = call_tool(
+        &config.database,
+        "memory_create",
+        json!({
+            "kind": "Risk",
+            "title": "Cites a path that has since moved",
+            "body": "The old logic lived in crates/ghost/src/vanished.rs before the refactor.",
+            "confidence": "medium",
+            "created_by": "dream-test",
+            "bind": {"path": "src/lib.rs"}
+        }),
+    )
+    .unwrap();
+    let memory_id = memory["memory"]["memory_id"].as_str().unwrap().to_string();
+
+    // The default worklist surfaces the OPEN stale_reference finding (its subject is the memory
+    // id).
+    let report = call_tool(&config.database, "dream", json!({})).unwrap();
+    let finding = report["findings"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|f| f["kind"] == "stale_reference" && f["subject"] == memory_id.as_str())
+        .expect("dream should surface the stale_reference finding")
+        .clone();
+    assert_eq!(finding["status"], "open");
+    let finding_id = finding["id"].as_str().unwrap().to_string();
+
+    // Accept it: the verdict is echoed back, and the finding leaves the default (open) worklist.
+    let reviewed = call_tool(
+        &config.database,
+        "dream_review",
+        json!({"finding": finding_id, "verdict": "accept"}),
+    )
+    .unwrap();
+    assert_eq!(reviewed["status"], "accepted");
+    assert_eq!(reviewed["id"], finding_id.as_str());
+
+    // Re-running `dream` recomputes stale_reference (the bad path is still cited) — the refresh
+    // branch PRESERVES the accepted verdict, so the finding stays out of the open worklist.
+    let after = call_tool(&config.database, "dream", json!({})).unwrap();
+    assert!(
+        !after["findings"].as_array().unwrap().iter().any(|f| f["id"] == finding_id.as_str()),
+        "an accepted finding must drop out of the default (open) worklist"
+    );
+    // `all: true` brings the reviewed finding back, now marked accepted.
+    let all = call_tool(&config.database, "dream", json!({"all": true})).unwrap();
+    let seen = all["findings"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|f| f["id"] == finding_id.as_str())
+        .expect("`all: true` lists the accepted finding");
+    assert_eq!(seen["status"], "accepted");
+
+    // reset clears the verdict, returning the finding to the open worklist.
+    let reset = call_tool(
+        &config.database,
+        "dream_review",
+        json!({"finding": finding_id, "verdict": "reset"}),
+    )
+    .unwrap();
+    assert_eq!(reset["status"], "open");
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
 fn mcp_read_chunk_and_heal_index_do_not_return_stale_text() {
     let (root, config) = markdown_config("# Title\nalpha token\n");
     let db = IndexDatabase::rebuild(&config).unwrap();
@@ -1280,6 +1361,8 @@ fn read_only_classification_covers_every_tool_and_denies_writers() {
         "memory_edge_remove",
         "memory_mark_obsolete",
         "memory_validate",
+        "dream",
+        "dream_review",
     ];
     for writer in WRITERS {
         assert!(TOOL_NAMES.contains(writer), "writer {writer} is not a registered tool");

--- a/crates/rag-rat-mcp/src/tools/tests.rs
+++ b/crates/rag-rat-mcp/src/tools/tests.rs
@@ -632,6 +632,27 @@ fn mcp_dream_surfaces_a_finding_and_review_applies_a_verdict() {
 }
 
 #[test]
+fn mcp_dream_defaults_when_arguments_are_omitted() {
+    // #514: a JSON-RPC tools/call with the `arguments` object OMITTED reaches the dispatcher as
+    // Value::Null (server maps None -> Null). A bare `dream` call — all schema fields optional —
+    // must still apply its `limit`/`all` defaults, not error deserializing Null into DreamArgs.
+    let root = unique_temp_root();
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), "pub fn anchor() {}\n").unwrap();
+    let config = rust_config(root.clone());
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    drop(db);
+
+    let report = call_tool(&config.database, "dream", json!(null)).unwrap();
+    assert!(
+        report["findings"].is_array(),
+        "a bare `dream` call (omitted arguments) returns a worklist: {report}"
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
 fn mcp_read_chunk_and_heal_index_do_not_return_stale_text() {
     let (root, config) = markdown_config("# Title\nalpha token\n");
     let db = IndexDatabase::rebuild(&config).unwrap();

--- a/docs/config.md
+++ b/docs/config.md
@@ -454,6 +454,11 @@ A verdict is **preserved across future runs**: a re-run that still reports the f
 `open`/`accepted`/`dismissed` finding is reviewable — a `resolved`/`superseded` one is not (the code
 moved on, so there is nothing to act on). Reviewing is repo-scoped and never runs the model.
 
+The same worklist and review actions are available over MCP for a pull-based strong agent: the
+`dream` tool returns the ranked worklist (`{ limit?, all? }`; recomputes the deterministic findings
+like `rag-rat dream`, but never the opt-in model passes), and `dream_review` applies a verdict
+(`{ finding, verdict: "accept" | "dismiss" | "reset" }`).
+
 ## Memory surfacing (`[memory] surface`)
 
 `[memory] surface` controls how memory attachments and memory-query results render. The default is


### PR DESCRIPTION
`dream` was CLI-only, but the deterministic memory-maintenance worklist is meant for a pull-based strong agent (Claude Code / Codex over MCP) to burn down. This adds two MCP tools mirroring the CLI review surface:

- **`dream`** (`{ limit?, all? }`) — recomputes the deterministic worklist (coverage gaps + stale references) and returns the ranked findings, each with a stable `id`. Like `rag-rat dream` it syncs `dream_findings`, so it is classified as a write tool. It never runs the opt-in model verdict/compaction passes (those stay on the CLI/cron `--verify`/`--compact`); findings a prior model run persisted still surface here.
- **`dream_review`** (`{ finding, verdict: accept|dismiss|reset }`) — applies a human verdict to one finding by id or prefix.

Routing is generic (`call_tool_for_config` dispatches by name), so no per-tool method is needed. Both are added to the `is_write_tool` deny-list and its classification test, and the stdio routability guard exercises them. Includes a functional lifecycle test and a `docs/config.md` pointer.

Fixes #263.
