### PR TITLE
Persisted local device identity: CSPRNG keygen + single-row store (phase B)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3447,6 +3447,7 @@ dependencies = [
  "criterion",
  "ed25519-dalek",
  "fastembed",
+ "getrandom 0.3.4",
  "gix",
  "iai-callgrind",
  "ignore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,10 @@ anyhow = "1.0"
 # `SigningKey::from_bytes`. Verification uses `verify_strict` (rejects malleable / small-order sigs).
 ed25519-dalek = "2"
 fastembed = { version = "5.17.2", default-features = false, features = ["hf-hub-rustls-tls", "ort-download-binaries-rustls-tls"] }
+# OS CSPRNG for the op-log device key: fills a 32-byte ed25519 seed at first use, which then flows
+# through the existing deterministic `SigningKey::from_bytes`. The lowest-level entropy source (no
+# `rand`/`rand_core` pulled in for this), keeping `from_seed` the sole key constructor.
+getrandom = "0.3"
 gix = { version = "0.85.0", default-features = false, features = ["status", "parallel", "sha1", "sha256", "revision", "blob-diff", "blame"] }
 libc = "0.2"
 # Separator-aware path→forward-slash conversion. Unlike a raw `\`→`/` replace, it only rewrites the

--- a/crates/rag-rat-core/Cargo.toml
+++ b/crates/rag-rat-core/Cargo.toml
@@ -15,6 +15,7 @@ categories.workspace = true
 anyhow.workspace = true
 ed25519-dalek.workspace = true
 fastembed = { workspace = true, optional = true }
+getrandom.workspace = true
 gix.workspace = true
 ignore = "0.4.26"
 model2vec-rs = { version = "0.2.1", default-features = false, features = ["hf-hub", "fancy-regex"], optional = true }

--- a/crates/rag-rat-core/src/index/schema/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema/migrations.rs
@@ -1188,6 +1188,7 @@ pub(crate) fn known_version(migrations: &[AppliedMigration]) -> u32 {
             MIGRATION_051_ID => Some(51),
             MIGRATION_052_ID => Some(52),
             MIGRATION_053_ID => Some(53),
+            MIGRATION_054_ID => Some(54),
             _ => None,
         })
         .max()
@@ -1250,6 +1251,7 @@ pub(crate) fn known_migration(id: &str) -> bool {
             | MIGRATION_051_ID
             | MIGRATION_052_ID
             | MIGRATION_053_ID
+            | MIGRATION_054_ID
             | DIRTY_MIGRATION_ID
     )
 }
@@ -1309,6 +1311,7 @@ pub(crate) fn migration_checksum_mismatch(migration: &AppliedMigration) -> bool 
         MIGRATION_051_ID => migration.checksum != MIGRATION_051_CHECKSUM,
         MIGRATION_052_ID => migration.checksum != MIGRATION_052_CHECKSUM,
         MIGRATION_053_ID => migration.checksum != MIGRATION_053_CHECKSUM,
+        MIGRATION_054_ID => migration.checksum != MIGRATION_054_CHECKSUM,
         _ => false,
     }
 }
@@ -3644,6 +3647,35 @@ pub(crate) fn apply_oplog_stream_scoping(conn: &Connection) -> rusqlite::Result<
              conflicting_entry_hash BLOB,
              observed_at_ms         INTEGER NOT NULL,
              PRIMARY KEY(stream_id, entry_hash)
+         ) STRICT;
+
+         COMMIT;",
+    )?;
+    Ok(())
+}
+
+/// V054 (#513): the op-log's persisted local device identity. ONE ed25519 keypair per store, so
+/// every entry this install authors — live or backfilled — signs under a stable fingerprint
+/// instead of a fresh per-process key. Store-global, NOT repo-scoped: a device is a machine
+/// identity, orthogonal to the per-repo owner streams it signs (and, later, doubles as the
+/// transport node key — a machine singleton). `id INTEGER PRIMARY KEY CHECK (id = 0)` is the
+/// single-row guard: a second identity cannot be inserted. `seed` is the 32-byte secret scalar
+/// seed; `public_key` (32 bytes) and `fingerprint` (= sha256(public_key)) are derivable from it but
+/// stored too so the row is legible and a load can assert they still agree.
+///
+/// Purely ADDITIVE (`CREATE TABLE IF NOT EXISTS` — a brand-new table, nothing to drop or backfill),
+/// unlike the V053 rebuild. Idempotent; the self-wrapped IMMEDIATE transaction reconverges an
+/// interrupted create on the next run.
+pub(crate) fn apply_oplog_device_identity(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "BEGIN IMMEDIATE;
+
+         CREATE TABLE IF NOT EXISTS oplog_device_identity(
+             id            INTEGER PRIMARY KEY CHECK (id = 0),
+             seed          BLOB NOT NULL,
+             public_key    BLOB NOT NULL,
+             fingerprint   BLOB NOT NULL,
+             created_at_ms INTEGER NOT NULL
          ) STRICT;
 
          COMMIT;",

--- a/crates/rag-rat-core/src/index/schema/mod.rs
+++ b/crates/rag-rat-core/src/index/schema/mod.rs
@@ -19,7 +19,7 @@ pub use registry::{LEGACY_REPO_ID, register_repo, register_repo_read_only};
 use rusqlite::{Connection, OptionalExtension, params};
 use serde::Serialize;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 53;
+pub const LATEST_SCHEMA_VERSION: u32 = 54;
 
 /// Every oracle-DERIVED persisted table — the outputs an `oracle run` writes that must OUTLIVE a
 /// reindex.
@@ -366,6 +366,14 @@ const MIGRATION_053_DESCRIPTION: &str =
      (stream_id, device), UNIQUE(stream_id, device_fingerprint, lamport), projection keyed per \
      stream — and add oplog_fork_evidence, the quarantine that durably preserves BOTH heads of a \
      detected equivocation. Nothing is wired to the live write path yet";
+const MIGRATION_054_ID: &str = "054_oplog_device_identity";
+const MIGRATION_054_CHECKSUM: &str = "sha256:rag-rat-oplog-device-identity-v54";
+const MIGRATION_054_DESCRIPTION: &str =
+    "Add oplog_device_identity (#513, phase B): the ONE persisted ed25519 keypair per store that \
+     the op-log write path signs every entry with — a single-row (id = 0) STRICT table holding \
+     the 32-byte seed, its derived public_key, and the sha256(public_key) fingerprint. \
+     Store-global, not repo-scoped (a device is a machine identity). Purely additive; nothing is \
+     wired to the live write path yet";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -825,6 +833,12 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         checksum: MIGRATION_053_CHECKSUM,
         description: MIGRATION_053_DESCRIPTION,
         apply: apply_oplog_stream_scoping,
+    },
+    Migration {
+        id: MIGRATION_054_ID,
+        checksum: MIGRATION_054_CHECKSUM,
+        description: MIGRATION_054_DESCRIPTION,
+        apply: apply_oplog_device_identity,
     },
 ];
 

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
@@ -1405,10 +1405,13 @@ fn migration_052_adds_oplog_storage_tables() {
 fn migration_053_scopes_the_oplog_by_stream_and_adds_fork_evidence() {
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     schema::apply(&conn).unwrap();
-    // V053 is the schema tip — the absolute pin (migration_052's drops to the symbolic
-    // `current_version == LATEST` check when a V054 lands).
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 53, "V053 is the schema tip");
-    assert_eq!(schema::status(&conn).unwrap().current_version, 53, "schema at LATEST after apply");
+    // V054 now holds the absolute tip pin (migration_054's test); this drops to the symbolic
+    // `current_version == LATEST` freshness check.
+    assert_eq!(
+        schema::status(&conn).unwrap().current_version,
+        schema::LATEST_SCHEMA_VERSION,
+        "schema at LATEST after apply"
+    );
 
     // The rebuilt tables carry the stream dimension; the quarantine table exists.
     for (table, column) in [
@@ -1462,6 +1465,54 @@ fn migration_053_scopes_the_oplog_by_stream_and_adds_fork_evidence() {
         );
     }
     assert!(conn_table_exists(&conn, "oplog_meta"), "oplog_meta is left untouched");
+}
+
+#[test]
+fn migration_054_adds_the_single_row_device_identity_table() {
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn).unwrap();
+    // V054 is the schema tip — this test carries the absolute pin (the older oplog tests dropped to
+    // the symbolic `current_version == LATEST` check).
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 54, "V054 is the schema tip");
+    assert_eq!(schema::status(&conn).unwrap().current_version, 54, "schema at LATEST after apply");
+
+    // The identity table exists with its full column set.
+    for column in ["seed", "public_key", "fingerprint", "created_at_ms"] {
+        assert!(
+            conn_table_columns(&conn, "oplog_device_identity").contains(&column.to_string()),
+            "V054 gives oplog_device_identity its {column} column"
+        );
+    }
+
+    // `CHECK (id = 0)` + the primary key make it a strict single-row table: id 0 inserts once; a
+    // non-zero id is refused by the CHECK; a second id-0 insert is refused by the PK.
+    conn.execute("INSERT INTO oplog_device_identity VALUES (0, x'00', x'11', x'22', 0)", [])
+        .expect("the sole id=0 identity row inserts");
+    assert!(
+        conn.execute("INSERT INTO oplog_device_identity VALUES (1, x'00', x'11', x'22', 0)", [])
+            .is_err(),
+        "CHECK (id = 0) rejects a second, non-zero identity"
+    );
+    assert!(
+        conn.execute("INSERT INTO oplog_device_identity VALUES (0, x'99', x'88', x'77', 1)", [])
+            .is_err(),
+        "the id=0 primary key rejects a second identity"
+    );
+
+    // Deferred-absence in ISOLATION: drop the table and re-run the applier alone (never against the
+    // full ladder's end state). It recreates the table, and a replay is a no-op (CREATE … IF NOT
+    // EXISTS).
+    conn.execute_batch("DROP TABLE oplog_device_identity;").unwrap();
+    assert!(
+        !conn_table_exists(&conn, "oplog_device_identity"),
+        "dropped before the isolated apply"
+    );
+    schema::apply_oplog_device_identity(&conn).unwrap();
+    schema::apply_oplog_device_identity(&conn).expect("replay is a no-op");
+    assert!(
+        conn_table_columns(&conn, "oplog_device_identity").contains(&"seed".to_string()),
+        "the isolated applier recreates the table"
+    );
 }
 
 #[test]

--- a/crates/rag-rat-core/src/oplog/device.rs
+++ b/crates/rag-rat-core/src/oplog/device.rs
@@ -37,6 +37,26 @@ impl DeviceSecret {
         Self(SigningKey::from_bytes(&seed))
     }
 
+    /// Generate a FRESH random device key from OS entropy — the production keygen path. The 32-byte
+    /// seed is filled by the system CSPRNG (`getrandom`) and flows through [`from_seed`], so
+    /// seeding stays the one construction point (deterministic tests keep their fixed seeds).
+    /// Fails only if the OS entropy source is unavailable.
+    pub(super) fn generate() -> anyhow::Result<Self> {
+        let mut seed = Zeroizing::new([0u8; 32]);
+        // `getrandom::Error` only implements `std::error::Error` behind getrandom's `std` feature
+        // (off under `--no-default-features`), so format it via `Display` rather than `.context`.
+        getrandom::fill(seed.as_mut_slice())
+            .map_err(|e| anyhow::anyhow!("OS CSPRNG failed to seed a device key: {e}"))?;
+        Ok(Self::from_seed(&seed))
+    }
+
+    /// The 32-byte secret seed, in a scrubbing buffer. The persistence layer stores this so a
+    /// reopened store re-derives the SAME key via [`from_seed`] — it is the only durable copy, so
+    /// the accessor deliberately exposes the secret (see the plaintext-at-rest decision).
+    pub(super) fn seed(&self) -> Zeroizing<[u8; 32]> {
+        Zeroizing::new(self.0.to_bytes())
+    }
+
     /// The matching public identity (for verification + fingerprint derivation).
     pub(super) fn public(&self) -> DevicePublic {
         DevicePublic(self.0.verifying_key())
@@ -107,6 +127,31 @@ mod tests {
         // A different seed is a different device.
         let b = DeviceSecret::from_seed(&seed_b());
         assert_ne!(a1.public().to_bytes(), b.public().to_bytes());
+    }
+
+    #[test]
+    fn generate_is_nondeterministic() {
+        // Two independent generations must not collide — the CSPRNG, not a fixed seed, is the
+        // source. (A collision here would mean the entropy source is broken.)
+        let a = DeviceSecret::generate().expect("OS CSPRNG available");
+        let b = DeviceSecret::generate().expect("OS CSPRNG available");
+        assert_ne!(a.public().to_bytes(), b.public().to_bytes(), "generate must not repeat a key");
+    }
+
+    #[test]
+    fn generated_key_seed_round_trips() {
+        // The persisted seed must reconstruct the IDENTICAL key: `generate` → `seed` → `from_seed`
+        // yields the same pubkey, fingerprint, and signatures. This is what makes a reopened store
+        // keep one stable identity.
+        let generated = DeviceSecret::generate().expect("OS CSPRNG available");
+        let reloaded = DeviceSecret::from_seed(&generated.seed());
+        assert_eq!(generated.public().to_bytes(), reloaded.public().to_bytes());
+        assert_eq!(
+            generated.public().fingerprint().to_bytes(),
+            reloaded.public().fingerprint().to_bytes()
+        );
+        let msg = b"canonical entry body bytes";
+        assert_eq!(generated.sign(msg), reloaded.sign(msg), "the reloaded key signs identically");
     }
 
     #[test]

--- a/crates/rag-rat-core/src/oplog/identity.rs
+++ b/crates/rag-rat-core/src/oplog/identity.rs
@@ -1,0 +1,221 @@
+//! The op-log's persisted local device identity (phase B, #513).
+//!
+//! Exactly ONE ed25519 keypair per store, minted from OS entropy on first use and persisted so it
+//! is stable for the life of the index — every entry this install authors (live or backfilled)
+//! signs under the same fingerprint instead of a fresh per-process key. Store-global, NOT
+//! repo-scoped: a device is a machine identity, orthogonal to the per-repo owner streams it signs.
+//!
+//! [`local_device`] is the single accessor: it returns the persisted identity, minting-and-storing
+//! it on the first call. The single-row `oplog_device_identity` table (`CHECK (id = 0)`) plus an
+//! `ON CONFLICT DO NOTHING` insert and a mandatory re-read make a concurrent first-open converge on
+//! one identity — the process that loses the insert race silently adopts the winner's key and
+//! discards its own. A load re-derives the key from the stored seed and asserts the stored
+//! `public_key` / `fingerprint` still agree, so a corrupted row is refused rather than signed
+//! under.
+
+use anyhow::Context;
+use rusqlite::{Connection, OptionalExtension, params};
+use zeroize::Zeroizing;
+
+use super::device::{DevicePublic, DeviceSecret};
+use super::op::DeviceFingerprint;
+
+/// The store's local signing identity: the secret (for signing), its verifying key, and the opaque
+/// op-model fingerprint. Owns the secret, so it is neither `Clone` nor `Debug`-printable.
+pub(crate) struct LocalDevice {
+    secret: DeviceSecret,
+    public: DevicePublic,
+    fingerprint: DeviceFingerprint,
+}
+
+impl LocalDevice {
+    /// The signing capability — the authoring seam signs entry bodies with this.
+    pub(crate) fn secret(&self) -> &DeviceSecret {
+        &self.secret
+    }
+
+    /// The verifying key (for a local self-verify or to hand a peer).
+    pub(crate) fn public(&self) -> DevicePublic {
+        self.public
+    }
+
+    /// The opaque device fingerprint the op model + signed entry body carry.
+    pub(crate) fn fingerprint(&self) -> DeviceFingerprint {
+        self.fingerprint
+    }
+}
+
+/// Return this store's persisted device identity, minting + persisting one on the first call.
+/// Idempotent: every later call returns the SAME identity (a stable fingerprint). `now_ms` stamps a
+/// freshly-minted row (injected, matching the op-log store convention); it is ignored once an
+/// identity already exists.
+pub(crate) fn local_device(conn: &Connection, now_ms: i64) -> anyhow::Result<LocalDevice> {
+    if let Some(device) = read_identity(conn)? {
+        return Ok(device);
+    }
+    // First use: mint from OS entropy and persist. Under a concurrent first open another process
+    // may win the insert; `ON CONFLICT DO NOTHING` makes our write a no-op and the mandatory
+    // re-read below returns whichever identity actually landed — so we adopt the incumbent and drop
+    // our own freshly-minted seed rather than ever holding a key the store didn't record.
+    let fresh = DeviceSecret::generate()?;
+    persist_identity(conn, &fresh, now_ms)?;
+    read_identity(conn)?
+        .context("device identity missing immediately after persist (single-row insert lost?)")
+}
+
+/// Insert the identity as the sole row (`id = 0`); a no-op if one already exists.
+fn persist_identity(conn: &Connection, secret: &DeviceSecret, now_ms: i64) -> anyhow::Result<()> {
+    let public = secret.public();
+    conn.execute(
+        "INSERT INTO oplog_device_identity(id, seed, public_key, fingerprint, created_at_ms)
+         VALUES (0, ?1, ?2, ?3, ?4)
+         ON CONFLICT(id) DO NOTHING",
+        params![
+            secret.seed().as_slice(),
+            public.to_bytes().as_slice(),
+            public.fingerprint().to_bytes().as_slice(),
+            now_ms
+        ],
+    )?;
+    Ok(())
+}
+
+/// Read the sole identity row, re-deriving the key from its seed and asserting the stored derived
+/// columns still agree. `None` when no identity has been minted yet.
+fn read_identity(conn: &Connection) -> anyhow::Result<Option<LocalDevice>> {
+    let row = conn
+        .query_row(
+            "SELECT seed, public_key, fingerprint FROM oplog_device_identity WHERE id = 0",
+            [],
+            |row| {
+                Ok((
+                    row.get::<_, Vec<u8>>(0)?,
+                    row.get::<_, Vec<u8>>(1)?,
+                    row.get::<_, Vec<u8>>(2)?,
+                ))
+            },
+        )
+        .optional()?;
+    let Some((seed, stored_public, stored_fingerprint)) = row else {
+        return Ok(None);
+    };
+
+    let seed: [u8; 32] =
+        seed.as_slice().try_into().context("stored device seed is not exactly 32 bytes")?;
+    let seed = Zeroizing::new(seed);
+    let secret = DeviceSecret::from_seed(&seed);
+    let public = secret.public();
+    // The seed is the source of truth; the derived columns are a legibility copy. If they disagree
+    // the row was corrupted or hand-edited — refuse it rather than sign under a mismatched
+    // identity.
+    anyhow::ensure!(
+        public.to_bytes().as_slice() == stored_public.as_slice(),
+        "stored device public_key does not match the key derived from its seed"
+    );
+    let fingerprint = public.fingerprint();
+    anyhow::ensure!(
+        fingerprint.to_bytes().as_slice() == stored_fingerprint.as_slice(),
+        "stored device fingerprint does not match sha256(public_key)"
+    );
+    Ok(Some(LocalDevice { secret, public, fingerprint }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::index::schema;
+
+    /// A migrated in-memory DB carrying the V054 identity table.
+    fn conn() -> Connection {
+        let conn = Connection::open_in_memory().expect("open in-memory db");
+        schema::apply(&conn).expect("apply schema");
+        conn
+    }
+
+    /// A fixed receipt time — the identity tests never assert on it.
+    fn now() -> i64 {
+        1_700_000_000_000
+    }
+
+    #[test]
+    fn first_call_mints_and_persists_exactly_one_identity() {
+        let conn = conn();
+        let device = local_device(&conn, now()).expect("mint identity");
+        // Exactly one row, and it is the identity we returned.
+        let rows: i64 = conn
+            .query_row("SELECT COUNT(*) FROM oplog_device_identity", [], |r| r.get(0))
+            .expect("count rows");
+        assert_eq!(rows, 1, "first call persists exactly one identity row");
+        // The returned fingerprint is sha256(pubkey) of the returned key.
+        assert_eq!(device.fingerprint().to_bytes(), device.public().fingerprint().to_bytes());
+    }
+
+    #[test]
+    fn second_call_returns_the_same_stable_identity() {
+        let conn = conn();
+        let first = local_device(&conn, now()).expect("mint identity");
+        // A later call (a different `now_ms`, as a reopen would have) returns the SAME identity and
+        // adds no second row — the fingerprint is stable for the life of the store.
+        let second = local_device(&conn, now() + 5_000).expect("re-read identity");
+        assert_eq!(first.fingerprint().to_bytes(), second.fingerprint().to_bytes());
+        assert_eq!(first.public().to_bytes(), second.public().to_bytes());
+        let rows: i64 = conn
+            .query_row("SELECT COUNT(*) FROM oplog_device_identity", [], |r| r.get(0))
+            .expect("count rows");
+        assert_eq!(rows, 1, "re-reading must not mint a second identity");
+    }
+
+    #[test]
+    fn stored_derived_columns_match_the_seed() {
+        let conn = conn();
+        local_device(&conn, now()).expect("mint identity");
+        // Independently re-derive the key from the stored seed and confirm the persisted
+        // public_key + fingerprint agree — the legibility copy is not allowed to drift from truth.
+        let (seed, public_key, fingerprint): (Vec<u8>, Vec<u8>, Vec<u8>) = conn
+            .query_row(
+                "SELECT seed, public_key, fingerprint FROM oplog_device_identity WHERE id = 0",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+            )
+            .expect("read row");
+        let seed: [u8; 32] = seed.as_slice().try_into().expect("32-byte seed");
+        let derived = DeviceSecret::from_seed(&seed).public();
+        assert_eq!(derived.to_bytes().as_slice(), public_key.as_slice());
+        assert_eq!(derived.fingerprint().to_bytes().as_slice(), fingerprint.as_slice());
+    }
+
+    #[test]
+    fn a_row_with_an_existing_identity_is_adopted_not_replaced() {
+        // Model the race outcome: a row already exists when the mint path's insert runs. The
+        // `ON CONFLICT DO NOTHING` + re-read must return the INCUMBENT, never overwrite it.
+        let conn = conn();
+        let incumbent = local_device(&conn, now()).expect("incumbent identity");
+        // A second `persist_identity` with a different key must be a no-op (the id=0 conflict).
+        let intruder = DeviceSecret::generate().expect("csprng");
+        assert_ne!(incumbent.public().to_bytes(), intruder.public().to_bytes());
+        persist_identity(&conn, &intruder, now() + 1).expect("conflicting insert is a no-op");
+        let after = local_device(&conn, now() + 2).expect("re-read");
+        assert_eq!(
+            incumbent.public().to_bytes(),
+            after.public().to_bytes(),
+            "the incumbent identity survives a conflicting insert"
+        );
+    }
+
+    #[test]
+    fn a_corrupted_public_key_column_is_refused() {
+        let conn = conn();
+        local_device(&conn, now()).expect("mint identity");
+        // Corrupt the derived public_key so it no longer matches the seed; a load must refuse it
+        // rather than sign under a mismatched identity.
+        conn.execute("UPDATE oplog_device_identity SET public_key = ?1 WHERE id = 0", params![
+            [0u8; 32].as_slice()
+        ])
+        .expect("corrupt row");
+        // `LocalDevice` is deliberately not `Debug` (it holds secret material), so drop the Ok
+        // value before `expect_err`.
+        let err =
+            local_device(&conn, now()).map(|_| ()).expect_err("corrupted identity must be refused");
+        assert!(err.to_string().contains("public_key"), "error names the mismatched column");
+    }
+}

--- a/crates/rag-rat-core/src/oplog/mod.rs
+++ b/crates/rag-rat-core/src/oplog/mod.rs
@@ -24,6 +24,9 @@
 //! - [`stream`]: the immutable, content-derived stream identity (#509) — one signed chain,
 //!   watermark, and projection exists PER [`stream::StreamId`]; the entry body binds it, so stream
 //!   membership is signature-protected.
+//! - [`identity`]: the store's ONE persisted ed25519 device identity (#513) —
+//!   [`identity::local_device`] mints it from OS entropy on first use and returns it stably
+//!   thereafter, so every authored entry signs under one machine fingerprint.
 //!
 //! Nothing here is wired into the live write path yet (later increments add the append-on-mutation
 //! seam, roster/epochs, and transport) — this mirrors the `content_hash` freeze: pin the semantic
@@ -32,6 +35,7 @@
 mod cbor;
 mod device;
 mod entry;
+mod identity;
 mod op;
 mod project;
 mod store;


### PR DESCRIPTION
Sixth phase-B op-log increment, after #480 (content_hash), #489/#495 (op model + fold), #497/#500 (signed entry envelope), #503/#504 (durable layer-1 store), #509/#511 (immutable stream identity + stream-scoped store).

The signed entry envelope and the store both take a device key, but until now that key was **deterministic-from-seed only** — no CSPRNG, no persistence ("production CSPRNG keygen is a later concern"). Every entry the write path will author (live or backfilled) must sign under ONE identity that is stable for the life of the index; generating a fresh key per process would fork the local chain on every restart. This freezes that primitive, in isolation, exactly as the earlier op-log primitives were frozen before wiring.

## What landed

- **`oplog_device_identity` (V054)** — a single-row (`id = 0`) STRICT table holding the 32-byte ed25519 seed, its derived `public_key`, and the `sha256(public_key)` fingerprint. **Store-global, not repo-scoped**: a device is a machine identity, orthogonal to the per-repo owner streams it signs. Purely additive (`CREATE TABLE IF NOT EXISTS`), full ladder wiring, tip pin moved 053 → 054.
- **`DeviceSecret::generate()`** — sources a 32-byte seed from the OS CSPRNG (`getrandom`) and flows it through the existing `from_seed`, so seeding stays the one key constructor (deterministic tests keep their fixed seeds). A `seed()` accessor round-trips the persisted seed back to the identical key.
- **`identity::local_device`** — mints + persists on first use and returns that identity on every later call (a stable fingerprint). A concurrent first open converges on one identity via `ON CONFLICT DO NOTHING` + a mandatory re-read (the insert-race loser adopts the incumbent), and a load re-derives the key from its seed and refuses a row whose derived `public_key` / `fingerprint` drifted.

The seed is stored in plaintext, deliberately: the index is an unencrypted local SQLite file, so an attacker with local read can already rewrite the log directly — plaintext storage does not widen the threat model. `Zeroizing` still scrubs in-memory copies.

Still **not** wired to the live write path — the authoring seam + the full backfill of pre-existing memories are the next increment.

## Tests / gates

- New device (CSPRNG non-determinism, seed round-trip) and identity (first-mint, stable re-read, derived-column agreement, incumbent-adoption, corrupted-row refusal) unit tests; V054 migration test (columns + `CHECK (id = 0)` single-row guard + deferred-absence in isolation) carrying the absolute tip pin.
- Full workspace suite green (2015 tests), clippy clean on default and `--no-default-features`, nightly fmt clean.

Fixes #513