### PR TITLE
feat(index): realign logical-symbol references on key-derivation drift

### DIFF
--- a/crates/rag-rat-core/src/index/file_index.rs
+++ b/crates/rag-rat-core/src/index/file_index.rs
@@ -61,7 +61,9 @@ impl IndexDatabase {
             &text,
             &scope,
         )?;
-        self.rebuild_logical_symbols()?;
+        // Defer: a single-file heal must not stamp the logical-key version — every other file's
+        // drift is still in the future (#493).
+        self.rebuild_logical_symbols(graph_index::KeyVersionStamp::Defer)?;
         self.resolve_edges()
     }
 

--- a/crates/rag-rat-core/src/index/file_rows.rs
+++ b/crates/rag-rat-core/src/index/file_rows.rs
@@ -45,6 +45,11 @@ impl IndexDatabase {
         commit_sha: &str,
         worktree_id: &str,
     ) -> anyhow::Result<()> {
+        // #493: every live-scope file replacement funnels through here, so this is the seam that
+        // memoizes the drift-heal snapshot BEFORE the symbol deletes below destroy its
+        // member-signature evidence. A no-op unless the key-version stamp is stale, and paid at
+        // most once per pass.
+        self.capture_drift_snapshot_before_removal()?;
         let path = path_string(path);
         // Direct edges_data writes (#79): these statements touch up to every in-edge of a file's
         // symbols, so they must not pay the view triggers' per-row dictionary probes.

--- a/crates/rag-rat-core/src/index/graph_index.rs
+++ b/crates/rag-rat-core/src/index/graph_index.rs
@@ -141,12 +141,23 @@ pub(crate) fn realign_logical_symbol_ids(conn: &rusqlite::Connection) -> rusqlit
         }
     }
 
-    // Two-phase through negative temp ids: `stable_id` values are all >= 0 (`>> 1`), so a `-(i+1)`
-    // temp can never collide with a real id or with another temp. Phase 1 vacates every OLD id in
-    // the remap set; phase 2 lands the finals — so a new id equal to another remapped row's old
-    // id never trips the PK mid-pass. (A new id equal to an already-aligned row's id is a
-    // 63-bit hash collision — the same astronomically-unlikely case a plain rebuild already
-    // surfaces loudly.)
+    remap_logical_symbol_ids(conn, &remap)?;
+    Ok(remap.len())
+}
+
+/// Apply an old → new id remap across the PK row and every referencing table, two-phase through
+/// negative temp ids: `stable_id` values are all >= 0 (`>> 1`), so a `-(i+1)` temp can never
+/// collide with a real id or with another temp. Phase 1 vacates every OLD id in the remap set;
+/// phase 2 lands the finals — so a new id equal to another remapped row's old id never trips the
+/// PK mid-pass. (A new id equal to an already-aligned row's id is a 63-bit hash collision — the
+/// same astronomically-unlikely case a plain rebuild already surfaces loudly.) Shared by
+/// [`realign_logical_symbol_ids`] (`repo_id` changes: the PK row moves with its references) and
+/// the key-drift heal (#493: the re-derived rows already hold the new ids, so the
+/// `logical_symbols`/members updates no-op and the reference tables are the payload).
+fn remap_logical_symbol_ids(
+    conn: &rusqlite::Connection,
+    remap: &[(i64, i64)],
+) -> rusqlite::Result<()> {
     for (i, (old_id, _)) in remap.iter().enumerate() {
         let temp_id = -(i as i64 + 1);
         rewrite_logical_symbol_id(conn, *old_id, temp_id)?;
@@ -155,7 +166,7 @@ pub(crate) fn realign_logical_symbol_ids(conn: &rusqlite::Connection) -> rusqlit
         let temp_id = -(i as i64 + 1);
         rewrite_logical_symbol_id(conn, temp_id, *new_id)?;
     }
-    Ok(remap.len())
+    Ok(())
 }
 
 /// Move a single logical-symbol id from `from` to `to` across the PK row and every column that
@@ -170,6 +181,35 @@ fn rewrite_logical_symbol_id(
     conn.execute("UPDATE logical_symbols SET id = ?1 WHERE id = ?2", params![to, from])?;
     conn.execute(
         "UPDATE logical_symbol_members SET logical_symbol_id = ?1 WHERE logical_symbol_id = ?2",
+        params![to, from],
+    )?;
+    rewrite_logical_symbol_references(conn, from, to)
+}
+
+/// Move ONLY the durable references to a logical-symbol id — monikers, memory bindings,
+/// call-path endpoints — leaving the `logical_symbols` row and its members untouched. The drift
+/// heal (#493) must use this shape: after a key change, a snapshot row's OLD id can be OCCUPIED
+/// by a different symbol's re-derived row (a key swap, not a hash collision), and the full
+/// [`rewrite_logical_symbol_id`] would MOVE that innocent row along with the drifted reference.
+fn rewrite_logical_symbol_references(
+    conn: &rusqlite::Connection,
+    from: i64,
+    to: i64,
+) -> rusqlite::Result<()> {
+    // `logical_symbol_monikers` has no FK, so a DANGLING row (its logical row died in some
+    // earlier wholesale rebuild; the next oracle run sweeps it) can already occupy `to` for the
+    // same tool — and the plain UPDATE below would abort the whole rebuild on the PK. The moving
+    // row is the one bound to the symbol that now lives at `to`, so the stale occupant loses:
+    // displace exactly the colliding rows first. The correlate deliberately omits `repo_id`: a
+    // logical id is repo-UNIQUE by construction (`stable_id` folds `repo_id`), so same-id +
+    // same-tool is the full collision key — and the V040 migration runs this against the
+    // pre-V042 moniker shape, which has no `repo_id` column yet.
+    conn.execute(
+        "DELETE FROM logical_symbol_monikers
+          WHERE logical_symbol_id = ?1
+            AND EXISTS (SELECT 1 FROM logical_symbol_monikers src
+                         WHERE src.logical_symbol_id = ?2
+                           AND src.tool = logical_symbol_monikers.tool)",
         params![to, from],
     )?;
     conn.execute(
@@ -191,6 +231,239 @@ fn rewrite_logical_symbol_id(
         params![to, from],
     )?;
     Ok(())
+}
+
+/// NULL every CALL-PATH reference to a drifted id the heal could not realign (#493 review).
+/// Call-path references are the exception to the self-healing ladder: `validate_call_path_binding`
+/// re-checks only the stored EDGE fingerprints and NEVER consults or repairs the endpoint ids, so
+/// a stale (occupied-by-another OR vanished) endpoint would be a permanent bogus `sym_8000…`
+/// hydration surfaces and no validator ever fixes — no matter whether the id is sentineled or
+/// left on the dead value. NULL is the supported "no recorded endpoint" state every reader
+/// already guards for. Both the `repo_memory_call_paths` endpoint columns AND the
+/// `repo_memory_bindings` row for `binding_kind = 'call_path'` (whose `logical_symbol_id` is the
+/// start-or-end endpoint, equally ignored by the validator) are cleared. Called for EVERY
+/// no-winner id — occupied and vanished alike — unlike the sentinel/delete cleanup below which is
+/// occupied-only.
+fn null_call_path_references(conn: &rusqlite::Connection, from: i64) -> rusqlite::Result<()> {
+    conn.execute(
+        "UPDATE repo_memory_bindings SET logical_symbol_id = NULL
+          WHERE logical_symbol_id = ?1 AND binding_kind = 'call_path'",
+        params![from],
+    )?;
+    conn.execute(
+        "UPDATE repo_memory_call_paths SET start_logical_symbol_id = NULL
+          WHERE start_logical_symbol_id = ?1",
+        params![from],
+    )?;
+    conn.execute(
+        "UPDATE repo_memory_call_paths SET end_logical_symbol_id = NULL
+          WHERE end_logical_symbol_id = ?1",
+        params![from],
+    )?;
+    Ok(())
+}
+
+/// Move a drifted reference OFF an OCCUPIED id (a LIVE row now belonging to a DIFFERENT symbol)
+/// the heal could not realign (#493) — the vanished-id case needs no such move (a dead id already
+/// resolves to nothing). Call-path references are handled separately by
+/// [`null_call_path_references`]; this covers the two kinds that DO self-heal on an unresolvable
+/// id, so they must be pushed off the live-wrong id:
+/// - `repo_memory_bindings.logical_symbol_id` (every kind EXCEPT `call_path`) parks on
+///   [`VACATED_LOGICAL_SYMBOL_ID`]: an unresolvable id is exactly what makes the validate-time
+///   relocation ladder run, so the binding self-heals with a visible papertrail — where leaving it
+///   on the occupied LIVE id would validate as healthy and strand it silently.
+/// - `logical_symbol_monikers` rows are DELETED: their PK is `(repo_id, logical_symbol_id, tool)`,
+///   so two vacated ids carrying the same tool's moniker would collide on a shared sentinel and
+///   abort the rebuild — and a moniker pointing at a dead symbol is worthless anyway
+///   (oracle-derived, re-derived by the next `oracle run`).
+fn vacate_logical_symbol_references(
+    conn: &rusqlite::Connection,
+    from: i64,
+) -> rusqlite::Result<()> {
+    conn.execute("DELETE FROM logical_symbol_monikers WHERE logical_symbol_id = ?1", params![
+        from
+    ])?;
+    conn.execute(
+        "UPDATE repo_memory_bindings SET logical_symbol_id = ?1
+          WHERE logical_symbol_id = ?2 AND binding_kind != 'call_path'",
+        params![VACATED_LOGICAL_SYMBOL_ID, from],
+    )?;
+    Ok(())
+}
+
+/// The reference-only two-phase remap the drift heal applies (#493): same negative-temp-id
+/// discipline as [`remap_logical_symbol_ids`] — with occupied-id swaps in the set, a pair's
+/// SOURCE can equal another pair's TARGET, so the direct rewrite would collide mid-pass — but
+/// touching only the reference tables (see [`rewrite_logical_symbol_references`]).
+fn remap_logical_symbol_references(
+    conn: &rusqlite::Connection,
+    remap: &[(i64, i64)],
+) -> rusqlite::Result<()> {
+    for (i, (old_id, _)) in remap.iter().enumerate() {
+        let temp_id = -(i as i64 + 1);
+        rewrite_logical_symbol_references(conn, *old_id, temp_id)?;
+    }
+    for (i, (_, new_id)) in remap.iter().enumerate() {
+        let temp_id = -(i as i64 + 1);
+        rewrite_logical_symbol_references(conn, temp_id, *new_id)?;
+    }
+    Ok(())
+}
+
+/// One REFERENCED old-derivation logical row, snapshotted before a key-drift rebuild clears the
+/// table (#493): the key fields the heal matches on, plus the id the durable references still
+/// hold. `signature` is recovered from the surviving members when they UNANIMOUSLY carry the same
+/// non-null capture ([`UNANIMOUS_MEMBER_SIGNATURE_SQL`]); `None` when no member survives (an
+/// incremental pass already replaced the file's symbols) or the members disagree — signature
+/// evidence then simply cannot corroborate, and qualified-name agreement must carry the match
+/// alone.
+#[derive(Debug)]
+pub(super) struct LogicalKeyDriftRow {
+    pub(super) old_id: i64,
+    path: String,
+    name: String,
+    qualified_name: Option<String>,
+    kind: String,
+    pub(super) signature: Option<String>,
+}
+
+impl LogicalKeyDriftRow {
+    /// The identity fields a survivor probe compares against — everything in the logical key
+    /// except the id. A re-derived row still carrying this exact key is an UNCHANGED symbol; a
+    /// key-mismatched survivor is a key swap (a different symbol occupying the old id).
+    fn key(&self) -> DriftKey {
+        DriftKey {
+            path: self.path.clone(),
+            name: self.name.clone(),
+            qualified_name: self.qualified_name.clone(),
+            kind: self.kind.clone(),
+            signature: self.signature.clone(),
+        }
+    }
+}
+
+/// The comparable identity of a logical row (its key minus the id), shared by the snapshot row
+/// and the survivor probe so the equality check is one `==` rather than a five-field tuple that
+/// trips `clippy::type_complexity`.
+#[derive(Debug, PartialEq, Eq)]
+struct DriftKey {
+    path: String,
+    name: String,
+    qualified_name: Option<String>,
+    kind: String,
+    signature: Option<String>,
+}
+
+/// Where the drift heal parks a reference it had to move OFF an occupied id without an evidence
+/// winner (#493): resolves to nothing by construction (`stable_id` is >= 0 and this is far below
+/// the small negative `-(i+1)` temp range the two-phase remaps use, so no phase of any pass —
+/// this heal's or a later one's — can ever capture a vacated reference). A vacated binding walks
+/// the validate-time relocation ladder on the next pass, exactly like a vanished id.
+const VACATED_LOGICAL_SYMBOL_ID: i64 = i64::MIN;
+
+/// Whether a [`IndexDatabase::rebuild_logical_symbols`] pass may stamp
+/// `repo_meta["logical_key_version"]` (#493 review). Only a whole-corpus pass (the full rebuild,
+/// the fresh-index standalone pass) re-parses EVERY file, so only it proves the repo's symbols
+/// were all derived under the current key semantics. A partial pass (incremental edit sweep,
+/// single-file heal, worktree overlay refresh) re-derives a SUBSET: untouched files still carry
+/// old-derivation symbols whose logical ids only churn when those files are eventually
+/// re-parsed — stamping there would switch the drift heal off while most of the drift is still
+/// in the future, stranding those references permanently. Partial passes still RUN the heal
+/// (each pass realigns whatever drift is visible, and the heal is idempotent — exact-key
+/// survivors are skipped); they just must not declare the repo healed.
+pub(super) enum KeyVersionStamp {
+    /// The pass re-derived every file of the repo — stamp the key version after the heal.
+    FullRederive,
+    /// A partial pass — heal what is visible, leave the stamp for a whole-corpus pass.
+    Defer,
+}
+
+/// A re-derived logical row competing to inherit a drifted reference — see
+/// [`IndexDatabase::heal_logical_key_drift`]. Carries `kind` so the strict (kind-agreeing)
+/// subset is split in memory from one kind-relaxed fetch, keeping cross-kind contenders visible
+/// for the decoy veto ([`conflicting_drift_evidence`]).
+struct LogicalKeyDriftCandidate {
+    id: i64,
+    kind: String,
+    qualified_name: Option<String>,
+    signature: Option<String>,
+}
+
+/// The group-signature evidence subquery shared by the drift snapshot, the survivor probe, and
+/// the candidate scan (#493): a group's signature is evidence only when EVERY member carries the
+/// SAME non-null capture. The `COUNT(*) = COUNT(s.signature)` guard is load-bearing —
+/// `COUNT(DISTINCT)` alone ignores NULLs, so a partially captured group (one member recaptured,
+/// one signature-less) would read as unanimous on the sole non-null value and hand its references
+/// to whichever overload that member happened to match. Expects the enclosing query to alias
+/// `logical_symbols` as `ls`.
+const UNANIMOUS_MEMBER_SIGNATURE_SQL: &str = "
+    (SELECT CASE WHEN COUNT(*) = COUNT(s.signature) AND COUNT(DISTINCT s.signature) = 1
+                 THEN MIN(s.signature) END
+       FROM logical_symbol_members m
+       JOIN symbols s ON s.id = m.symbol_id
+      WHERE m.logical_symbol_id = ls.id)";
+
+/// Whether one evidence axis (qualified name / signature) corroborates a drift match: both sides
+/// present and equal. An unrecoverable side (`None`) is NO evidence, never a wildcard — matching
+/// on absence is how a heal would guess.
+fn drift_evidence_agrees(old: &Option<String>, new: &Option<String>) -> bool {
+    match (old, new) {
+        (Some(old), Some(new)) => old == new,
+        _ => false,
+    }
+}
+
+/// The unique realign target among EVIDENCE-ELIGIBLE candidates, or `None` for ambiguity: one
+/// eligible candidate wins outright; several narrow to those agreeing on BOTH axes and only a
+/// unique survivor wins — overload twins whose evidence drifted on both axes stay unmatched for
+/// the validate-time relocation ladder, because a confidently mis-anchored memory is worse than a
+/// flagged one.
+fn unique_drift_winner(
+    old: &LogicalKeyDriftRow,
+    eligible: &[&LogicalKeyDriftCandidate],
+) -> Option<i64> {
+    match eligible {
+        [only] => Some(only.id),
+        [] => None,
+        several => {
+            let both: Vec<&LogicalKeyDriftCandidate> = several
+                .iter()
+                .copied()
+                .filter(|candidate| {
+                    drift_evidence_agrees(&old.qualified_name, &candidate.qualified_name)
+                        && drift_evidence_agrees(&old.signature, &candidate.signature)
+                })
+                .collect();
+            match both.as_slice() {
+                [only] => Some(only.id),
+                _ => None,
+            }
+        },
+    }
+}
+
+/// Whether the kind-relaxed pool holds CONFLICTING evidence against a strict-pass winner (#493
+/// review): the winner is carried by ONE axis while some other pool member agrees on the axis
+/// the winner lacks. This is the kind-drift decoy shape — a kind-classification bump moves the
+/// true symbol OFF the old kind while a same-(path, name, qualified-name) twin stays on it; the
+/// twin wins the strict pass on qualified name alone and would silently inherit the reference,
+/// with the true row (agreeing on signature) never consulted. Split evidence is ambiguity, and
+/// ambiguity falls to the relocation ladder. A both-axes winner has no missing axis, so nothing
+/// can veto it.
+fn conflicting_drift_evidence(
+    old: &LogicalKeyDriftRow,
+    pool: &[LogicalKeyDriftCandidate],
+    winner_id: i64,
+) -> bool {
+    let Some(winner) = pool.iter().find(|candidate| candidate.id == winner_id) else {
+        return false;
+    };
+    let winner_qual = drift_evidence_agrees(&old.qualified_name, &winner.qualified_name);
+    let winner_sig = drift_evidence_agrees(&old.signature, &winner.signature);
+    pool.iter().filter(|candidate| candidate.id != winner_id).any(|candidate| {
+        (!winner_qual && drift_evidence_agrees(&old.qualified_name, &candidate.qualified_name))
+            || (!winner_sig && drift_evidence_agrees(&old.signature, &candidate.signature))
+    })
 }
 
 #[derive(Debug, Clone)]
@@ -220,7 +493,22 @@ impl IndexDatabase {
         edges::resolve_overlay_edges(self.storage.connection(), worktree_id)
     }
 
-    pub(super) fn rebuild_logical_symbols(&self) -> anyhow::Result<()> {
+    /// The #493 heal input is the drift snapshot memoized by the pass's FIRST
+    /// [`Self::remove_file_in_scope`] (see [`Self::capture_drift_snapshot_before_removal`]) —
+    /// a partial pass (single-file heal, incremental sweep, overlay refresh) deletes an edited
+    /// file's old symbols before this rebuild runs, and with them the snapshot's member-
+    /// signature evidence; a snapshot taken only here would then have nothing to corroborate a
+    /// qualified-name drift with, stranding the reference permanently (the old row is cleared
+    /// below, so no later pass could recover it either). When the pass removed nothing (a
+    /// HEAD-move carry, a package-roots refresh), the evidence is still intact and the snapshot
+    /// is captured fresh here. A leftover memo for a DIFFERENT repo (a consolidated-DB context
+    /// switch) is discarded, not consumed.
+    pub(super) fn rebuild_logical_symbols(&self, stamp: KeyVersionStamp) -> anyhow::Result<()> {
+        let memoized = self.drift_snapshot.lock().expect("drift snapshot lock").take();
+        let drift_snapshot = match memoized {
+            Some((repo, snapshot)) if repo == self.active_repo_id => snapshot,
+            _ => self.logical_key_drift_snapshot()?,
+        };
         // The insert below re-derives the COMPLETE logical-symbol table for the ACTIVE REPO from
         // its current symbols, so clear that repo's rows entirely first. A member-join
         // "rebuild set" misses logical_symbols whose members were cascade-deleted with
@@ -323,7 +611,360 @@ impl IndexDatabase {
         if let Some((key, members)) = current.take() {
             Self::insert_logical_group(conn, &self.active_repo_id, &key, &members)?;
         }
+        if let Some(snapshot) = drift_snapshot {
+            self.heal_logical_key_drift(&snapshot)?;
+            if matches!(stamp, KeyVersionStamp::FullRederive) {
+                self.set_repo_meta(LOGICAL_KEY_VERSION_KEY, LOGICAL_KEY_VERSION)?;
+            }
+        }
         Ok(())
+    }
+
+    /// Memoize the #493 drift snapshot BEFORE symbol rows are deleted, once per pass:
+    /// [`Self::remove_file_in_scope`] calls this first, so whichever file replacement happens
+    /// first in a pass captures the evidence while it is still complete — and every later
+    /// removal in the same pass sees the memo and pays nothing. Idle passes never remove a file
+    /// and never reach this, so the stale-stamp snapshot scan is paid only by passes that
+    /// actually mutate files (and once). Reads only `repo_meta` when the key version is
+    /// current. A memo left by a different repo's context (consolidated DB) is replaced.
+    pub(super) fn capture_drift_snapshot_before_removal(&self) -> anyhow::Result<()> {
+        let mut slot = self.drift_snapshot.lock().expect("drift snapshot lock");
+        let current = matches!(slot.as_ref(), Some((repo, _)) if repo == &self.active_repo_id);
+        if !current {
+            *slot = Some((self.active_repo_id.clone(), self.logical_key_drift_snapshot()?));
+        }
+        Ok(())
+    }
+
+    /// The #493 drift snapshot: `Some(referenced old rows)` when this repo's stamped
+    /// `logical_key_version` lags [`LOGICAL_KEY_VERSION`] (including the never-stamped first
+    /// rebuild under a stamping binary), `None` when the derivation is current. Captured via
+    /// [`Self::capture_drift_snapshot_before_removal`] before a pass's first file removal (the
+    /// member-signature evidence lives in the rows being deleted), or fresh at
+    /// [`Self::rebuild_logical_symbols`] when nothing was removed. Bounded by the
+    /// DURABLE references (memory bindings, call-path endpoints, oracle monikers) rather than the
+    /// whole table: unreferenced ids need no healing, and the reference set is dozens of rows
+    /// where the table is tens of thousands. The `logical_symbols` join keys the intersection to
+    /// the ACTIVE repo, so a sibling repo's references never enter a heal that queries this
+    /// repo's candidates.
+    pub(super) fn logical_key_drift_snapshot(
+        &self,
+    ) -> anyhow::Result<Option<Vec<LogicalKeyDriftRow>>> {
+        if self.repo_meta(LOGICAL_KEY_VERSION_KEY)?.as_deref() == Some(LOGICAL_KEY_VERSION) {
+            return Ok(None);
+        }
+        let conn = self.storage.connection();
+        let mut stmt = conn.prepare(&format!(
+            "
+            SELECT ls.id, ls.path, ls.logical_name,
+                   (SELECT value FROM name_strings WHERE id = ls.qualified_name_id),
+                   ls.kind,
+                   {UNANIMOUS_MEMBER_SIGNATURE_SQL}
+            FROM main.logical_symbols ls
+            WHERE ls.repo_id = ?1
+              AND ls.id IN (
+                  SELECT logical_symbol_id FROM repo_memory_bindings
+                   WHERE logical_symbol_id IS NOT NULL
+                  UNION
+                  SELECT start_logical_symbol_id FROM repo_memory_call_paths
+                   WHERE start_logical_symbol_id IS NOT NULL
+                  UNION
+                  SELECT end_logical_symbol_id FROM repo_memory_call_paths
+                   WHERE end_logical_symbol_id IS NOT NULL
+                  UNION
+                  SELECT logical_symbol_id FROM logical_symbol_monikers
+              )
+            "
+        ))?;
+        let rows = stmt
+            .query_map(params![self.active_repo_id], |row| {
+                Ok(LogicalKeyDriftRow {
+                    old_id: row.get(0)?,
+                    path: row.get(1)?,
+                    name: row.get(2)?,
+                    qualified_name: row.get(3)?,
+                    kind: row.get(4)?,
+                    signature: row.get(5)?,
+                })
+            })?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        Ok(Some(rows))
+    }
+
+    /// Realign drifted durable references onto the freshly re-derived logical ids (#493). A
+    /// snapshot row is drifted when its old id vanished from the rebuilt table OR survives with a
+    /// DIFFERENT key (another symbol's re-derived key occupying it — a key swap). Candidates are
+    /// the new rows sharing `(path, name, kind)` — falling back to `(path, name)` only when the
+    /// strict pass has NO eligible candidate, which is what a kind-classification drift looks
+    /// like; a strict winner carried by a single evidence axis is vetoed when a cross-kind row
+    /// agrees on the axis it lacks ([`conflicting_drift_evidence`]). The EVIDENCE rule mirrors
+    /// the #491/#494 relocation discriminators ([`drift_evidence_agrees`] /
+    /// [`unique_drift_winner`]): qualified-name or signature agreement makes a candidate
+    /// eligible, ambiguity matches nothing and falls to the validate-time relocation ladder.
+    /// Pairs are bijective (two old ids resolving to one new id drop both) and applied
+    /// REFERENCE-ONLY via [`remap_logical_symbol_references`] — the re-derived rows already own
+    /// the new ids, and an occupying row must stay put.
+    fn heal_logical_key_drift(&self, snapshot: &[LogicalKeyDriftRow]) -> anyhow::Result<usize> {
+        if snapshot.is_empty() {
+            return Ok(0);
+        }
+        let conn = self.storage.connection();
+        // The survivor and candidate probes hit (id) and (repo_id, path, logical_name) once per
+        // snapshot row — and a moniker-bearing repo can snapshot close to the whole table, so an
+        // unindexed candidate probe would go quadratic inside the rebuild transaction. The index
+        // is TRANSIENT: built for this pass, dropped before returning — a persistent index would
+        // tax every rebuild's wholesale DELETE + re-INSERT for an event that fires once per
+        // derivation bump. Inside a caller's transaction an error path rolls it back with
+        // everything else; outside one, the IF NOT EXISTS / IF EXISTS pair converges on the next
+        // heal.
+        conn.execute_batch(
+            "CREATE INDEX IF NOT EXISTS logical_symbols_drift_heal_idx
+                ON logical_symbols(repo_id, path, logical_name)",
+        )?;
+        let mut remap: Vec<(i64, i64)> = Vec::new();
+        // Target ids already OWNED by a snapshot row that keeps them — an unchanged survivor, or
+        // a drifted row whose evidence winner is its own (occupied) id. A remap pair landing on a
+        // claimed id competes with the owner's existing references (the MERGE shape: two old
+        // symbols collapsing into one surviving row), so it must drop to the relocation ladder,
+        // which relocates with a visible papertrail instead of a silent heal.
+        let mut survivor_claims: std::collections::HashSet<i64> = std::collections::HashSet::new();
+        // Old ids whose row survived with a DIFFERENT key — another symbol owns them now. If the
+        // evidence below cannot realign such a reference, it must still be VACATED off the
+        // occupied id (see the tail of this fn).
+        let mut occupied_old_ids: std::collections::HashSet<i64> = std::collections::HashSet::new();
+        // In-place winners (evidence winner == own old id): no remap, but their bind-time
+        // discriminators may still be stale under the new derivation — refresh them at the tail
+        // alongside the remap targets.
+        let mut in_place_winners: Vec<i64> = Vec::new();
+        for old in snapshot {
+            // A surviving id is proof of an unchanged symbol ONLY when the surviving row still
+            // carries the snapshotted key: after a key change, a DIFFERENT symbol's re-derived
+            // key can occupy the old id (a key swap — e.g. two same-path/name rows exchanging
+            // kind under a kind-classification fix). A key-mismatched survivor is drifted like a
+            // vanished id; its references realign by evidence while the occupying row stays put.
+            let survivor: Option<DriftKey> = conn
+                .query_row(
+                    &format!(
+                        "
+                        SELECT ls.path, ls.logical_name,
+                               (SELECT value FROM name_strings WHERE id = ls.qualified_name_id),
+                               ls.kind,
+                               {UNANIMOUS_MEMBER_SIGNATURE_SQL}
+                        FROM main.logical_symbols ls
+                        WHERE ls.id = ?1 AND ls.repo_id = ?2
+                        "
+                    ),
+                    params![old.old_id, self.active_repo_id],
+                    |row| {
+                        Ok(DriftKey {
+                            path: row.get(0)?,
+                            name: row.get(1)?,
+                            qualified_name: row.get(2)?,
+                            kind: row.get(3)?,
+                            signature: row.get(4)?,
+                        })
+                    },
+                )
+                .optional()?;
+            match survivor {
+                Some(key) if key == old.key() => {
+                    survivor_claims.insert(old.old_id);
+                    continue;
+                },
+                // The old id is OCCUPIED by a different symbol's row: whatever the evidence
+                // decides below, the references must not stay parked on it — a live wrong id
+                // validates as healthy and the ladder never runs.
+                Some(_) => {
+                    occupied_old_ids.insert(old.old_id);
+                },
+                None => {},
+            }
+            // Strict pass: candidates share (path, name, kind). When the KIND ITSELF drifted (a
+            // kind-classification bump — an advertised LOGICAL_KEY_VERSION reason), no strict
+            // candidate can agree; fall back to the kind-RELAXED pool so qualified-name /
+            // signature agreement can still carry the realign. Relaxation only ever widens an
+            // EMPTY eligible set: a strict pass that found agreeing-but-ambiguous candidates
+            // must not widen the pool (more candidates cannot disambiguate), and kind stays the
+            // primary discriminator wherever it survives — the #491 struct/impl twins are told
+            // apart by kind first. A strict winner is still checked against the FULL pool for
+            // conflicting cross-kind evidence ([`conflicting_drift_evidence`], the decoy veto).
+            let pool = self.drift_eligible_candidates(old)?;
+            let strict: Vec<&LogicalKeyDriftCandidate> =
+                pool.iter().filter(|candidate| candidate.kind == old.kind).collect();
+            let winner = if strict.is_empty() {
+                let relaxed: Vec<&LogicalKeyDriftCandidate> = pool.iter().collect();
+                unique_drift_winner(old, &relaxed)
+            } else {
+                unique_drift_winner(old, &strict)
+                    .filter(|id| !conflicting_drift_evidence(old, &pool, *id))
+            };
+            // A winner equal to the old id (the occupying row IS the evidence match) needs no
+            // remap — and must not enter the two-phase pass as a self-cycle — but it claims its
+            // id like any survivor.
+            match winner {
+                Some(new_id) if new_id != old.old_id => remap.push((old.old_id, new_id)),
+                Some(claimed) => {
+                    survivor_claims.insert(claimed);
+                    in_place_winners.push(claimed);
+                },
+                None => {},
+            }
+        }
+        // Bijectivity: a target claimed by more than one old id — including a survivor that
+        // keeps it — is ambiguous evidence; drop every contending pair rather than guess which
+        // reference inherits it.
+        let mut target_claims: std::collections::HashMap<i64, usize> =
+            std::collections::HashMap::new();
+        for (_, new_id) in &remap {
+            *target_claims.entry(*new_id).or_insert(0) += 1;
+        }
+        remap.retain(|(_, new_id)| target_claims[new_id] == 1 && !survivor_claims.contains(new_id));
+        // Clean up every snapshot id that found NO winner — neither remapped, nor an unchanged
+        // survivor, nor an in-place winner (`survivor_claims`; its references already belong where
+        // they are). Two DISTINCT cleanups by reference kind, because their validators differ:
+        //  - Call-path references (endpoints + the `call_path` binding row) have NO validate-time
+        //    re-resolution, so a stale endpoint id is permanent whether the old id is OCCUPIED
+        //    (live, another symbol) or VANISHED (dead) — NULL them in BOTH cases
+        //    (`null_call_path_references`, #493 review).
+        //  - Logical/symbol/moniker bindings SELF-HEAL on an unresolvable id (the relocation ladder
+        //    / gone status), so they only need pushing OFF an OCCUPIED id — a LIVE wrong id would
+        //    otherwise validate as healthy. A VANISHED id is already dead, so the ladder handles it
+        //    and no sentinel is needed (`vacate_logical_symbol_references`, occupied-only).
+        // MUST run BEFORE the remap: an occupied id can be another drifted reference's legitimate
+        // target, and a post-remap cleanup would wipe the freshly realigned references with the
+        // stale ones.
+        let remapped: std::collections::HashSet<i64> =
+            remap.iter().map(|(old_id, _)| *old_id).collect();
+        for old in snapshot {
+            let old_id = old.old_id;
+            if remapped.contains(&old_id) || survivor_claims.contains(&old_id) {
+                continue;
+            }
+            null_call_path_references(conn, old_id)?;
+            if occupied_old_ids.contains(&old_id) {
+                vacate_logical_symbol_references(conn, old_id)?;
+            }
+        }
+        remap_logical_symbol_references(conn, &remap)?;
+        // A realigned reference still carries its bind-time discriminators — `binding_id` (the
+        // qualified name), `symbol_kind`, `signature_hash` — from the OLD derivation. Validation
+        // treats a live id as current and never repairs those fields, so a LATER churn or
+        // relocation would search with stale evidence and miss (or mis-pick) the twin. Refresh
+        // them from the row each reference now points at — remap targets and in-place winners
+        // alike; exact-key survivors are skipped because an unchanged key implies unchanged
+        // discriminators.
+        for (_, new_id) in &remap {
+            self.refresh_logical_binding_discriminators(*new_id)?;
+        }
+        for id in in_place_winners {
+            self.refresh_logical_binding_discriminators(id)?;
+        }
+        conn.execute_batch("DROP INDEX IF EXISTS logical_symbols_drift_heal_idx")?;
+        Ok(remap.len())
+    }
+
+    /// Rewrite every logical binding at `logical_symbol_id` to the relocation discriminators of
+    /// the row it now points at (#493 review): `binding_id` = the live qualified name,
+    /// `symbol_kind` = the logical row's kind, `signature_hash` = the sha256 of the unanimous
+    /// member signature — the same values [`crate::query::memory::resolve_logical_symbol_binding`]
+    /// captures at bind time and the validate-time ladder writes on a relocation.
+    ///
+    /// `binding_id` is part of the `(memory_id, binding_kind, binding_id)` PK, so a rename can
+    /// collide with a SIBLING logical binding of the SAME memory that already holds the target
+    /// qualified name (a memory bound to the anchor under two derivations). The multi-row
+    /// `UPDATE OR IGNORE` would silently SKIP the colliding row, stranding it with stale
+    /// discriminators on a now-live id — validate then reads it as current and never repairs it.
+    /// So this walks the affected rows one by one and, on an ignored rename, DELETES the stale
+    /// duplicate — exactly the PK-collision cleanup `validate_memories` performs.
+    fn refresh_logical_binding_discriminators(&self, logical_symbol_id: i64) -> anyhow::Result<()> {
+        let conn = self.storage.connection();
+        let row: Option<(Option<String>, String, Option<String>)> = conn
+            .query_row(
+                &format!(
+                    "
+                    SELECT (SELECT value FROM name_strings WHERE id = ls.qualified_name_id),
+                           ls.kind,
+                           {UNANIMOUS_MEMBER_SIGNATURE_SQL}
+                    FROM main.logical_symbols ls
+                    WHERE ls.id = ?1 AND ls.repo_id = ?2
+                    "
+                ),
+                params![logical_symbol_id, self.active_repo_id],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .optional()?;
+        let Some((Some(qualified_name), kind, signature)) = row else {
+            return Ok(());
+        };
+        let signature_hash =
+            signature.map(|sig| crate::index::util::hex_sha256(sig.trim().as_bytes()));
+        // Snapshot the current binding_ids before mutating, so the rename loop is not walking a
+        // live cursor it is also writing to.
+        let stale_binding_ids: Vec<(String, String)> = {
+            let mut stmt = conn.prepare(
+                "SELECT memory_id, binding_id FROM repo_memory_bindings
+                  WHERE binding_kind = 'logical_symbol' AND logical_symbol_id = ?1",
+            )?;
+            stmt.query_map(params![logical_symbol_id], |row| Ok((row.get(0)?, row.get(1)?)))?
+                .collect::<rusqlite::Result<Vec<_>>>()?
+        };
+        for (memory_id, old_binding_id) in stale_binding_ids {
+            let updated = conn.execute(
+                "UPDATE OR IGNORE repo_memory_bindings
+                    SET binding_id = ?3, symbol_kind = ?4, signature_hash = ?5
+                  WHERE memory_id = ?1 AND binding_kind = 'logical_symbol' AND binding_id = ?2",
+                params![memory_id, old_binding_id, qualified_name, kind, signature_hash],
+            )?;
+            // The rename was ignored because a sibling binding of this memory already holds the
+            // target qualified name: drop the stale row instead of leaving it mis-labelled.
+            if updated == 0 && old_binding_id != qualified_name {
+                conn.execute(
+                    "DELETE FROM repo_memory_bindings
+                      WHERE memory_id = ?1 AND binding_kind = 'logical_symbol' AND binding_id = ?2",
+                    params![memory_id, old_binding_id],
+                )?;
+            }
+        }
+        Ok(())
+    }
+
+    /// The re-derived rows a drifted reference may realign onto, EVIDENCE-FILTERED: candidates
+    /// share the snapshot row's `(path, name)` and are eligible only when the qualified name
+    /// agrees OR the signature agrees (both sides present and equal; an unrecoverable side is no
+    /// evidence, never a wildcard). Fetched kind-RELAXED in one probe; the caller splits the
+    /// strict (kind-agreeing) subset in memory, so cross-kind contenders stay visible for the
+    /// decoy veto ([`conflicting_drift_evidence`]) without a second scan.
+    fn drift_eligible_candidates(
+        &self,
+        old: &LogicalKeyDriftRow,
+    ) -> anyhow::Result<Vec<LogicalKeyDriftCandidate>> {
+        let conn = self.storage.connection();
+        let mut stmt = conn.prepare(&format!(
+            "
+            SELECT ls.id, ls.kind,
+                   (SELECT value FROM name_strings WHERE id = ls.qualified_name_id),
+                   {UNANIMOUS_MEMBER_SIGNATURE_SQL}
+            FROM main.logical_symbols ls
+            WHERE ls.repo_id = ?1 AND ls.path = ?2 AND ls.logical_name = ?3
+            "
+        ))?;
+        let candidates = stmt
+            .query_map(params![self.active_repo_id, old.path, old.name], |row| {
+                Ok(LogicalKeyDriftCandidate {
+                    id: row.get(0)?,
+                    kind: row.get(1)?,
+                    qualified_name: row.get(2)?,
+                    signature: row.get(3)?,
+                })
+            })?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        Ok(candidates
+            .into_iter()
+            .filter(|candidate| {
+                drift_evidence_agrees(&old.qualified_name, &candidate.qualified_name)
+                    || drift_evidence_agrees(&old.signature, &candidate.signature)
+            })
+            .collect())
     }
 
     pub(super) fn graph_coverage(

--- a/crates/rag-rat-core/src/index/incremental.rs
+++ b/crates/rag-rat-core/src/index/incremental.rs
@@ -257,7 +257,9 @@ impl IndexDatabase {
             // the full-scope resolve every ordinary edit pass runs is what re-points it.
             if indexed > 0 || healed > 0 || carried > 0 || roots_changed {
                 progress(IndexProgress::RebuildingLogicalSymbols);
-                db.rebuild_logical_symbols()?;
+                // Defer: this pass re-parsed only the CHANGED files, so it must not stamp the
+                // logical-key version — untouched files' drift is still in the future (#493).
+                db.rebuild_logical_symbols(graph_index::KeyVersionStamp::Defer)?;
                 progress(IndexProgress::ResolvingGraph);
                 db.resolve_edges()?;
                 db.mark_graph_index_current()?;
@@ -328,7 +330,10 @@ impl IndexDatabase {
         let result = (|| -> anyhow::Result<()> {
             self.build_chunk_text_store()?;
             self.finalize_base_edges(config, graph)?;
-            self.rebuild_logical_symbols()?;
+            // FullRederive: the standalone pass indexed the whole corpus (a fresh index — no
+            // pre-existing rows, so the drift heal is empty), so it may stamp the logical-key
+            // version (#493).
+            self.rebuild_logical_symbols(graph_index::KeyVersionStamp::FullRederive)?;
             self.apply_staged_parser_failures(self.active_generation)?;
             self.refresh_clone_token_df()?;
             self.sync_fts()?;

--- a/crates/rag-rat-core/src/index/lifecycle.rs
+++ b/crates/rag-rat-core/src/index/lifecycle.rs
@@ -140,6 +140,7 @@ impl IndexDatabase {
             github: github::GitHubContext::default(),
             config: None,
             _identity_lock: None,
+            drift_snapshot: std::sync::Mutex::new(None),
         };
         if matches!(mode, BareOpenMode::ConfigLess) {
             db.ensure_graph_index_current()?;
@@ -161,6 +162,7 @@ impl IndexDatabase {
             github: github::GitHubContext::from_gh(),
             config: Some(config.clone()),
             _identity_lock: None,
+            drift_snapshot: std::sync::Mutex::new(None),
         };
         db.storage.set_source_root(config.root.clone());
         // Register/adopt BEFORE anything repo-scoped runs, then install the scope context so the
@@ -327,6 +329,7 @@ impl IndexDatabase {
             github: github::GitHubContext::from_gh(),
             config: Some(config.clone()),
             _identity_lock: None,
+            drift_snapshot: std::sync::Mutex::new(None),
         };
         // Install the scope context BEFORE the heal-owed gates: `set_context` mirrors the resolved
         // `repo_id` into `temp.connection_context` (writable even on a read-only main DB), so the
@@ -448,6 +451,7 @@ impl IndexDatabase {
             github: github::GitHubContext::default(),
             config: None,
             _identity_lock: None,
+            drift_snapshot: std::sync::Mutex::new(None),
         })
     }
 

--- a/crates/rag-rat-core/src/index/mod.rs
+++ b/crates/rag-rat-core/src/index/mod.rs
@@ -143,6 +143,15 @@ pub struct IndexDatabase {
     /// lock must match the repo id it writes under. `None` on the lockless open paths (they stay
     /// lockless by design) and whenever the entry lock already covers the resolved id.
     _identity_lock: Option<crate::locks::WriteLock>,
+    /// The lazily captured #493 drift-heal snapshot, tagged with the repo it was captured for.
+    /// Populated by the FIRST [`Self::remove_file_in_scope`] of a pass while the key-version
+    /// stamp is stale — the symbol rows about to be deleted carry the snapshot's signature
+    /// evidence, so it must be memoized before the first deletion — and consumed by the next
+    /// [`Self::rebuild_logical_symbols`] (which captures fresh when nothing was removed: the
+    /// evidence is still intact then). Idle passes never remove a file, never populate this, and
+    /// never pay the snapshot scan. Interior mutability because the deleters take `&self`.
+    drift_snapshot:
+        std::sync::Mutex<Option<(String, Option<Vec<graph_index::LogicalKeyDriftRow>>)>>,
 }
 
 #[derive(Debug, Clone)]
@@ -268,6 +277,20 @@ const GRAPH_INDEX_VERSION: &str = "11";
 // `is_generated_path` codegen living under a source target.
 const GENERATED_FLAGS_VERSION: &str = "1";
 const GENERATED_FLAGS_VERSION_KEY: &str = "generated_flags_version";
+
+// Bumped when [`graph_index::LogicalSymbolKey`]'s DERIVATION changes semantics — a
+// signature-capture fix, a kind-classification change, a qualified-name derivation change, or a
+// grammar bump that shifts any of them. The stable logical id hashes those fields, so a semantic
+// change churns EVERY logical id in a repo at its next rebuild at once, stranding every
+// logical-symbol memory binding (and moniker / call-path reference) simultaneously (#493). On a
+// mismatch the rebuild snapshots the referenced old rows and realigns them onto the re-derived
+// ids (`heal_logical_key_drift`); matching is evidence-gated, so bump this LIBERALLY on any doubt
+// — a no-drift heal is a cheap no-op, an unbumped drift is a whole-repo stranding healed one
+// validate at a time. Per-repo (`repo_meta`, like `graph_index_version`): a shared DB holds repos
+// rebuilt by different binaries.
+// 1: initial version (#493).
+const LOGICAL_KEY_VERSION: &str = "1";
+const LOGICAL_KEY_VERSION_KEY: &str = "logical_key_version";
 
 #[derive(Debug, Error)]
 pub enum IndexError {

--- a/crates/rag-rat-core/src/index/query_api/mod.rs
+++ b/crates/rag-rat-core/src/index/query_api/mod.rs
@@ -359,7 +359,9 @@ impl IndexDatabase {
         let result = (|| -> anyhow::Result<()> {
             self.apply_incremental_file_plan(files, changes.deleted.clone(), &mut |_| {})?;
             self.refresh_packages(&config.root)?;
-            self.rebuild_logical_symbols()?;
+            // Defer: this heal re-parsed only the STALE files, so it must not stamp the
+            // logical-key version — untouched files' drift is still in the future (#493).
+            self.rebuild_logical_symbols(graph_index::KeyVersionStamp::Defer)?;
             self.resolve_edges()?;
             self.sync_fts()?;
             Ok(())

--- a/crates/rag-rat-core/src/index/rebuild.rs
+++ b/crates/rag-rat-core/src/index/rebuild.rs
@@ -184,7 +184,7 @@ impl IndexDatabase {
             // Carry every live row OUTSIDE the base scope (linked-worktree overlays, other-commit
             // leftovers) forward onto `target` — the rebuild only re-emits the base scope, so
             // they must ride along to stay visible after the flip.
-            db.carry_forward_live_overlays(target, old_live)?;
+            let carried_rows = db.carry_forward_live_overlays(target, old_live)?;
             let carried_overlays = db.carried_overlay_worktrees(target)?;
             // Carry each carried overlay's PACKAGE ROOTS onto the new base scope (batch 6 #3): the
             // overlay FILE rows carried above are matched into the scope view by `worktree_id`
@@ -219,7 +219,23 @@ impl IndexDatabase {
             // already at `target` within this transaction, so the fold sees them (the A6 handoff
             // note, now satisfied PRE-flip inside the same atomic write).
             progress(IndexProgress::RebuildingLogicalSymbols);
-            db.rebuild_logical_symbols()?;
+            // FullRederive ONLY when the published set is EXACTLY what this rebuild re-parsed.
+            // Any row `carry_forward_live_overlays` moved forward — a linked-worktree overlay OR
+            // an other-commit committed leftover (`worktree_id = ''`, carried when this rebuild
+            // runs from a linked worktree) — rode along WITHOUT a reparse, so its symbols still
+            // carry the old derivation. Stamping over them would let a later heal of THOSE rows
+            // see a current key version, skip the drift snapshot, and strand their references.
+            // Gate on the carried-row COUNT, not `carried_overlays.is_empty()`:
+            // `carried_overlay_worktrees` returns only `worktree_id != ''` overlays, a NARROWER
+            // set than what was actually carried, so it would miss carried committed leftovers
+            // (#493 review). Carries are transient, so the stamp lands on the next carry-free
+            // rebuild while every pass keeps healing what it can see.
+            let stamp = if carried_rows == 0 {
+                graph_index::KeyVersionStamp::FullRederive
+            } else {
+                graph_index::KeyVersionStamp::Defer
+            };
+            db.rebuild_logical_symbols(stamp)?;
             // Publish the STAGED `parser_failures` state (upserts for paths that failed this
             // pass, clears for clean re-parses, an orphan sweep for paths removed from the tree)
             // atomically with the flip: the waves staged these mutations in a temp table instead
@@ -359,8 +375,12 @@ impl IndexDatabase {
     /// (base commit + base worktree both empty ⇒ every row IS in the base scope) and when there
     /// are no overlays. Runs INSIDE the terminal flip transaction so a reader sees overlays at
     /// exactly one generation.
-    fn carry_forward_live_overlays(&self, target: i64, old_live: i64) -> anyhow::Result<()> {
-        self.storage.connection().execute(
+    ///
+    /// Returns the number of `files` rows carried — the #493 logical-key-version stamp gate reads
+    /// it: any carried row was NOT re-parsed by this rebuild, so a non-zero count means the
+    /// published generation still holds old-derivation symbols and the stamp must defer.
+    fn carry_forward_live_overlays(&self, target: i64, old_live: i64) -> anyhow::Result<usize> {
+        let carried = self.storage.connection().execute(
             "UPDATE main.files SET generation = ?1
              WHERE repo_id = ?2 AND generation = ?3
                AND commit_sha != ?4 AND worktree_id != ?5",
@@ -372,7 +392,7 @@ impl IndexDatabase {
                 self.active_worktree_id
             ],
         )?;
-        Ok(())
+        Ok(carried)
     }
 
     /// Re-key each carried linked-worktree overlay's generation-less `packages` rows onto the

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_memory.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_memory.rs
@@ -3653,3 +3653,2979 @@ fn a_staged_generation_freezes_the_downgrade_rule() {
 
     let _ = fs::remove_dir_all(&root);
 }
+
+/// #493: a key-derivation change (grammar bump, signature-capture/kind/qualified-name fix) churns
+/// EVERY logical id at the next rebuild — the stored rows hold old-derivation field values, so
+/// `realign_logical_symbol_ids` (which recomputes from stored fields) reproduces the old ids and
+/// cannot help. On a `logical_key_version` mismatch the rebuild snapshots the REFERENCED old rows
+/// before the clear and realigns them onto the re-derived ids by (path, name, kind) + qualified-
+/// name/signature agreement — whole-repo stranding becomes an invisible in-place migration.
+#[test]
+fn key_derivation_drift_realigns_referenced_logical_bindings_at_rebuild() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), "pub fn drift_anchor() -> u32 { 7 }\n").unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let real_id: i64 = db
+        .storage
+        .connection()
+        .query_row("SELECT id FROM logical_symbols WHERE logical_name = 'drift_anchor'", [], |r| {
+            r.get(0)
+        })
+        .unwrap();
+    let created = db
+        .memory_create(crate::query::memory::RepoMemoryCreate {
+            kind: "Invariant".to_string(),
+            title: "Anchored across derivation drift".to_string(),
+            body: "The binding must follow the symbol through a logical-key version bump."
+                .to_string(),
+            confidence: "high".to_string(),
+            created_by: Some("test-agent".to_string()),
+            source: Some("agent".to_string()),
+            tags: Vec::new(),
+            payload_json: None,
+            bind: crate::query::memory::RepoMemoryBindTarget {
+                logical_symbol_id: Some(real_id),
+                symbol_id: None,
+                chunk_id: None,
+                edge_id: None,
+                path: None,
+                start_line: None,
+                end_line: None,
+                commit_hash: None,
+                github_owner: None,
+                github_repo: None,
+                github_number: None,
+                start_logical_symbol_id: None,
+                end_logical_symbol_id: None,
+                edge_sequence_hash: None,
+                path_summary: None,
+                edge_path: None,
+                dir: None,
+            },
+        })
+        .unwrap();
+    let memory_id = created.memory.memory_id;
+    drop(db);
+
+    // Simulate an old-derivation store: the persisted logical id (and every reference to it) was
+    // derived under PREVIOUS key rules — the re-derive will mint a different id. A raw connection
+    // (foreign keys off) rewrites parent + references consistently, and clearing the stamp is
+    // what arms the heal.
+    {
+        let conn = rusqlite::Connection::open(&config.database).unwrap();
+        conn.execute_batch("PRAGMA foreign_keys = OFF;").unwrap();
+        conn.execute("UPDATE logical_symbols SET id = 424242 WHERE id = ?1", params![real_id])
+            .unwrap();
+        conn.execute(
+            "UPDATE logical_symbol_members SET logical_symbol_id = 424242
+              WHERE logical_symbol_id = ?1",
+            params![real_id],
+        )
+        .unwrap();
+        conn.execute(
+            "UPDATE repo_memory_bindings SET logical_symbol_id = 424242
+              WHERE logical_symbol_id = ?1",
+            params![real_id],
+        )
+        .unwrap();
+        conn.execute("DELETE FROM repo_meta WHERE key = 'logical_key_version'", []).unwrap();
+    }
+
+    // A content change so the next rebuild runs a full pass (unchanged content short-circuits).
+    fs::write(
+        root.join("src/lib.rs"),
+        "pub fn drift_anchor() -> u32 { 7 }\n\npub fn drift_appendix() {}\n",
+    )
+    .unwrap();
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let fresh_id: i64 = db
+        .storage
+        .connection()
+        .query_row("SELECT id FROM logical_symbols WHERE logical_name = 'drift_anchor'", [], |r| {
+            r.get(0)
+        })
+        .unwrap();
+    let bound: i64 = db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT logical_symbol_id FROM repo_memory_bindings WHERE memory_id = ?1",
+            params![memory_id],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        bound, fresh_id,
+        "the drift heal must realign the binding onto the re-derived logical id"
+    );
+    let stamp: String = db
+        .storage
+        .connection()
+        .query_row("SELECT value FROM repo_meta WHERE key = 'logical_key_version'", [], |r| {
+            r.get(0)
+        })
+        .unwrap();
+    assert!(!stamp.is_empty(), "the rebuild stamps the healed logical-key version");
+
+    // End-to-end: validate resolves the realigned binding as current, not gone/relocated.
+    db.memory_validate().unwrap();
+    let status: String = db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT anchor_status FROM repo_memory_bindings WHERE memory_id = ?1",
+            params![memory_id],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(status, "current");
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+/// #493 version gate: a CURRENT `logical_key_version` stamp means the derivation did not change,
+/// so the rebuild must not run the drift snapshot/heal — a dangling reference then stays dangling
+/// for the validate-time relocation ladder (the pre-#493 behavior).
+#[test]
+fn a_current_logical_key_version_stamp_skips_the_drift_heal() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), "pub fn gated_anchor() -> u32 { 7 }\n").unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let real_id: i64 = db
+        .storage
+        .connection()
+        .query_row("SELECT id FROM logical_symbols WHERE logical_name = 'gated_anchor'", [], |r| {
+            r.get(0)
+        })
+        .unwrap();
+    let created = db
+        .memory_create(crate::query::memory::RepoMemoryCreate {
+            kind: "Invariant".to_string(),
+            title: "Gated by the version stamp".to_string(),
+            body: "No drift heal may run while the stamp is current.".to_string(),
+            confidence: "high".to_string(),
+            created_by: Some("test-agent".to_string()),
+            source: Some("agent".to_string()),
+            tags: Vec::new(),
+            payload_json: None,
+            bind: crate::query::memory::RepoMemoryBindTarget {
+                logical_symbol_id: Some(real_id),
+                symbol_id: None,
+                chunk_id: None,
+                edge_id: None,
+                path: None,
+                start_line: None,
+                end_line: None,
+                commit_hash: None,
+                github_owner: None,
+                github_repo: None,
+                github_number: None,
+                start_logical_symbol_id: None,
+                end_logical_symbol_id: None,
+                edge_sequence_hash: None,
+                path_summary: None,
+                edge_path: None,
+                dir: None,
+            },
+        })
+        .unwrap();
+    let memory_id = created.memory.memory_id;
+    drop(db);
+
+    {
+        let conn = rusqlite::Connection::open(&config.database).unwrap();
+        conn.execute_batch("PRAGMA foreign_keys = OFF;").unwrap();
+        conn.execute("UPDATE logical_symbols SET id = 424242 WHERE id = ?1", params![real_id])
+            .unwrap();
+        conn.execute(
+            "UPDATE logical_symbol_members SET logical_symbol_id = 424242
+              WHERE logical_symbol_id = ?1",
+            params![real_id],
+        )
+        .unwrap();
+        conn.execute(
+            "UPDATE repo_memory_bindings SET logical_symbol_id = 424242
+              WHERE logical_symbol_id = ?1",
+            params![real_id],
+        )
+        .unwrap();
+        // The stamp stays CURRENT (written by the first rebuild) — the heal must not arm.
+    }
+
+    fs::write(
+        root.join("src/lib.rs"),
+        "pub fn gated_anchor() -> u32 { 7 }\n\npub fn gated_appendix() {}\n",
+    )
+    .unwrap();
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let bound: i64 = db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT logical_symbol_id FROM repo_memory_bindings WHERE memory_id = ?1",
+            params![memory_id],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        bound, 424242,
+        "with a current stamp the heal must not run; the ladder owns this binding"
+    );
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+/// #493 ambiguity posture: overload twins (same path/name/kind, same qualified name, distinct
+/// signatures — cfg variants whose signatures differ) whose signature evidence ALSO drifted
+/// cannot be told apart; the heal must match NEITHER (a confidently mis-anchored memory is worse
+/// than a flagged one) and leave both to the relocation ladder.
+#[test]
+fn drifted_overload_twins_stay_unmatched_for_the_ladder() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(
+        root.join("src/lib.rs"),
+        "#[cfg(unix)]\npub fn drift_twin(a: u32) -> u32 { a }\n#[cfg(windows)]\npub fn \
+         drift_twin(b: i64) -> i64 { b }\n",
+    )
+    .unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let twin_ids: Vec<i64> = {
+        let conn = db.storage.connection();
+        let mut stmt = conn
+            .prepare("SELECT id FROM logical_symbols WHERE logical_name = 'drift_twin' ORDER BY id")
+            .unwrap();
+        stmt.query_map([], |r| r.get(0)).unwrap().map(Result::unwrap).collect()
+    };
+    assert_eq!(twin_ids.len(), 2, "the fixture must produce two signature-distinct twins");
+
+    let mut memory_ids = Vec::new();
+    for (i, twin) in twin_ids.iter().enumerate() {
+        let created = db
+            .memory_create(crate::query::memory::RepoMemoryCreate {
+                kind: "Invariant".to_string(),
+                title: format!("Bound to drift twin {i}"),
+                body: "Ambiguous drift must not guess a twin.".to_string(),
+                confidence: "high".to_string(),
+                created_by: Some("test-agent".to_string()),
+                source: Some("agent".to_string()),
+                tags: Vec::new(),
+                payload_json: None,
+                bind: crate::query::memory::RepoMemoryBindTarget {
+                    logical_symbol_id: Some(*twin),
+                    symbol_id: None,
+                    chunk_id: None,
+                    edge_id: None,
+                    path: None,
+                    start_line: None,
+                    end_line: None,
+                    commit_hash: None,
+                    github_owner: None,
+                    github_repo: None,
+                    github_number: None,
+                    start_logical_symbol_id: None,
+                    end_logical_symbol_id: None,
+                    edge_sequence_hash: None,
+                    path_summary: None,
+                    edge_path: None,
+                    dir: None,
+                },
+            })
+            .unwrap();
+        memory_ids.push(created.memory.memory_id);
+    }
+    drop(db);
+
+    {
+        let conn = rusqlite::Connection::open(&config.database).unwrap();
+        conn.execute_batch("PRAGMA foreign_keys = OFF;").unwrap();
+        for (i, twin) in twin_ids.iter().enumerate() {
+            let fake = 424242 + i as i64;
+            conn.execute("UPDATE logical_symbols SET id = ?1 WHERE id = ?2", params![fake, twin])
+                .unwrap();
+            conn.execute(
+                "UPDATE logical_symbol_members SET logical_symbol_id = ?1
+                  WHERE logical_symbol_id = ?2",
+                params![fake, twin],
+            )
+            .unwrap();
+            conn.execute(
+                "UPDATE repo_memory_bindings SET logical_symbol_id = ?1
+                  WHERE logical_symbol_id = ?2",
+                params![fake, twin],
+            )
+            .unwrap();
+        }
+        // Signature capture ALSO drifted: the stored member signatures no longer agree with the
+        // re-derived ones, so signature evidence cannot break the qualified-name tie.
+        conn.execute(
+            "UPDATE symbols SET signature = signature || ' /* drifted */'
+              WHERE id IN (SELECT symbol_id FROM logical_symbol_members
+                            WHERE logical_symbol_id IN (424242, 424243))",
+            [],
+        )
+        .unwrap();
+        conn.execute("DELETE FROM repo_meta WHERE key = 'logical_key_version'", []).unwrap();
+    }
+
+    fs::write(
+        root.join("src/lib.rs"),
+        "#[cfg(unix)]\npub fn drift_twin(a: u32) -> u32 { a }\n#[cfg(windows)]\npub fn \
+         drift_twin(b: i64) -> i64 { b }\n\npub fn twin_appendix() {}\n",
+    )
+    .unwrap();
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    for (i, memory_id) in memory_ids.iter().enumerate() {
+        let bound: i64 = db
+            .storage
+            .connection()
+            .query_row(
+                "SELECT logical_symbol_id FROM repo_memory_bindings WHERE memory_id = ?1",
+                params![memory_id],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            bound,
+            424242 + i as i64,
+            "ambiguous twins must stay unmatched (memory {i}); the ladder owns them"
+        );
+    }
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+/// #493: when the QUALIFIED-NAME derivation drifted (the stored qualified name no longer matches
+/// the re-derived one), signature agreement is the evidence that realigns the binding.
+#[test]
+fn qualified_name_drift_realigns_via_signature_agreement() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), "pub fn qual_drift_anchor(x: u8) -> u8 { x }\n").unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let real_id: i64 = db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT id FROM logical_symbols WHERE logical_name = 'qual_drift_anchor'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    let created = db
+        .memory_create(crate::query::memory::RepoMemoryCreate {
+            kind: "Invariant".to_string(),
+            title: "Anchored across qualified-name drift".to_string(),
+            body: "Signature agreement must carry the realign when the qual drifted.".to_string(),
+            confidence: "high".to_string(),
+            created_by: Some("test-agent".to_string()),
+            source: Some("agent".to_string()),
+            tags: Vec::new(),
+            payload_json: None,
+            bind: crate::query::memory::RepoMemoryBindTarget {
+                logical_symbol_id: Some(real_id),
+                symbol_id: None,
+                chunk_id: None,
+                edge_id: None,
+                path: None,
+                start_line: None,
+                end_line: None,
+                commit_hash: None,
+                github_owner: None,
+                github_repo: None,
+                github_number: None,
+                start_logical_symbol_id: None,
+                end_logical_symbol_id: None,
+                edge_sequence_hash: None,
+                path_summary: None,
+                edge_path: None,
+                dir: None,
+            },
+        })
+        .unwrap();
+    let memory_id = created.memory.memory_id;
+    drop(db);
+
+    {
+        let conn = rusqlite::Connection::open(&config.database).unwrap();
+        conn.execute_batch("PRAGMA foreign_keys = OFF;").unwrap();
+        // The stored row carries the OLD-derivation qualified name; the signature is unchanged.
+        conn.execute(
+            "INSERT OR IGNORE INTO name_strings(value) VALUES ('legacy::qual_drift_anchor')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "UPDATE logical_symbols
+                SET id = 424242,
+                    qualified_name_id =
+                        (SELECT id FROM name_strings WHERE value = 'legacy::qual_drift_anchor')
+              WHERE id = ?1",
+            params![real_id],
+        )
+        .unwrap();
+        conn.execute(
+            "UPDATE logical_symbol_members SET logical_symbol_id = 424242
+              WHERE logical_symbol_id = ?1",
+            params![real_id],
+        )
+        .unwrap();
+        conn.execute(
+            "UPDATE repo_memory_bindings SET logical_symbol_id = 424242
+              WHERE logical_symbol_id = ?1",
+            params![real_id],
+        )
+        .unwrap();
+        conn.execute("DELETE FROM repo_meta WHERE key = 'logical_key_version'", []).unwrap();
+    }
+
+    fs::write(
+        root.join("src/lib.rs"),
+        "pub fn qual_drift_anchor(x: u8) -> u8 { x }\n\npub fn qual_appendix() {}\n",
+    )
+    .unwrap();
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let fresh_id: i64 = db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT id FROM logical_symbols WHERE logical_name = 'qual_drift_anchor'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    let bound: i64 = db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT logical_symbol_id FROM repo_memory_bindings WHERE memory_id = ?1",
+            params![memory_id],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(bound, fresh_id, "signature agreement must realign a qual-drifted binding");
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+/// #493: when the strict pass yields MULTIPLE evidence-eligible candidates (same-qualified-name
+/// twins differing only by signature — cfg overloads with distinct signatures group into
+/// separate logical symbols), the winner is the UNIQUE one agreeing on BOTH axes. `old` shares
+/// its qualified name with both twins, so both are eligible; only the twin whose signature also
+/// matches is the both-axes winner, and the realign lands there rather than falling to the
+/// ladder. Exercises `unique_drift_winner`'s narrowing arm, not the single-candidate path.
+#[test]
+fn multiple_eligible_candidates_narrow_to_the_both_axes_winner() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    // Two cfg overloads with DIFFERENT signatures → two logical symbols sharing one qualified
+    // name. tree-sitter indexes both cfg branches, so both defs are present.
+    fs::write(
+        root.join("src/lib.rs"),
+        "#[cfg(unix)]\npub fn over_pick(a: u32) -> u32 { a }\n#[cfg(windows)]\npub fn \
+         over_pick(a: u64) -> u64 { a }\n",
+    )
+    .unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    // The u32 twin — the one whose signature the drifted snapshot will carry.
+    let u32_id: i64 = db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT ls.id FROM logical_symbols ls
+             JOIN logical_symbol_members m ON m.logical_symbol_id = ls.id
+             JOIN symbols s ON s.id = m.symbol_id
+             WHERE ls.logical_name = 'over_pick' AND s.signature LIKE '%u32%'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    let u64_id: i64 = db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT ls.id FROM logical_symbols ls
+             JOIN logical_symbol_members m ON m.logical_symbol_id = ls.id
+             JOIN symbols s ON s.id = m.symbol_id
+             WHERE ls.logical_name = 'over_pick' AND s.signature LIKE '%u64%'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_ne!(u32_id, u64_id, "the differing signatures must produce two logical symbols");
+    let created = db
+        .memory_create(crate::query::memory::RepoMemoryCreate {
+            kind: "Invariant".to_string(),
+            title: "Anchored to the u32 overload across drift".to_string(),
+            body: "Both twins agree on qual; only the u32 twin agrees on both axes.".to_string(),
+            confidence: "high".to_string(),
+            created_by: Some("test-agent".to_string()),
+            source: Some("agent".to_string()),
+            tags: Vec::new(),
+            payload_json: None,
+            bind: crate::query::memory::RepoMemoryBindTarget {
+                logical_symbol_id: Some(u32_id),
+                symbol_id: None,
+                chunk_id: None,
+                edge_id: None,
+                path: None,
+                start_line: None,
+                end_line: None,
+                commit_hash: None,
+                github_owner: None,
+                github_repo: None,
+                github_number: None,
+                start_logical_symbol_id: None,
+                end_logical_symbol_id: None,
+                edge_sequence_hash: None,
+                path_summary: None,
+                edge_path: None,
+                dir: None,
+            },
+        })
+        .unwrap();
+    let memory_id = created.memory.memory_id;
+    drop(db);
+
+    // Drift only the u32 twin's id to a fake (qual + signature stored unchanged): after the
+    // rebuild both twins re-derive fresh, both share `old`'s qualified name, and the u32 twin is
+    // the unique both-axes agreer.
+    {
+        let conn = rusqlite::Connection::open(&config.database).unwrap();
+        conn.execute_batch("PRAGMA foreign_keys = OFF;").unwrap();
+        conn.execute("UPDATE logical_symbols SET id = 424242 WHERE id = ?1", params![u32_id])
+            .unwrap();
+        conn.execute(
+            "UPDATE logical_symbol_members SET logical_symbol_id = 424242
+              WHERE logical_symbol_id = ?1",
+            params![u32_id],
+        )
+        .unwrap();
+        conn.execute(
+            "UPDATE repo_memory_bindings SET logical_symbol_id = 424242
+              WHERE logical_symbol_id = ?1",
+            params![u32_id],
+        )
+        .unwrap();
+        conn.execute("DELETE FROM repo_meta WHERE key = 'logical_key_version'", []).unwrap();
+    }
+
+    fs::write(
+        root.join("src/lib.rs"),
+        "#[cfg(unix)]\npub fn over_pick(a: u32) -> u32 { a }\n#[cfg(windows)]\npub fn \
+         over_pick(a: u64) -> u64 { a }\n\npub fn pick_appendix() {}\n",
+    )
+    .unwrap();
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let fresh_u32_id: i64 = db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT ls.id FROM logical_symbols ls
+             JOIN logical_symbol_members m ON m.logical_symbol_id = ls.id
+             JOIN symbols s ON s.id = m.symbol_id
+             WHERE ls.logical_name = 'over_pick' AND s.signature LIKE '%u32%'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    let bound: i64 = db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT logical_symbol_id FROM repo_memory_bindings WHERE memory_id = ?1",
+            params![memory_id],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        bound, fresh_u32_id,
+        "the both-axes winner (the signature-matching twin) inherits the drifted binding"
+    );
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+/// #493 review: a KIND-classification drift (an advertised bump reason) leaves the stored row
+/// with the old kind, so the strict (path, name, kind) candidate pass finds nothing — the heal
+/// must retry kind-relaxed and let qualified-name + signature agreement carry the realign,
+/// instead of stamping the repo healed with the reference still stranded.
+#[test]
+fn kind_classification_drift_realigns_via_the_relaxed_pass() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), "pub fn kind_drift_anchor(k: u8) -> u8 { k }\n").unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let real_id: i64 = db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT id FROM logical_symbols WHERE logical_name = 'kind_drift_anchor'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    let created = db
+        .memory_create(crate::query::memory::RepoMemoryCreate {
+            kind: "Invariant".to_string(),
+            title: "Anchored across kind drift".to_string(),
+            body: "Qualified-name and signature agreement must carry a kind reclassification."
+                .to_string(),
+            confidence: "high".to_string(),
+            created_by: Some("test-agent".to_string()),
+            source: Some("agent".to_string()),
+            tags: Vec::new(),
+            payload_json: None,
+            bind: crate::query::memory::RepoMemoryBindTarget {
+                logical_symbol_id: Some(real_id),
+                symbol_id: None,
+                chunk_id: None,
+                edge_id: None,
+                path: None,
+                start_line: None,
+                end_line: None,
+                commit_hash: None,
+                github_owner: None,
+                github_repo: None,
+                github_number: None,
+                start_logical_symbol_id: None,
+                end_logical_symbol_id: None,
+                edge_sequence_hash: None,
+                path_summary: None,
+                edge_path: None,
+                dir: None,
+            },
+        })
+        .unwrap();
+    let memory_id = created.memory.memory_id;
+    drop(db);
+
+    {
+        let conn = rusqlite::Connection::open(&config.database).unwrap();
+        conn.execute_batch("PRAGMA foreign_keys = OFF;").unwrap();
+        // The stored row carries the OLD kind classification; qualified name and signature are
+        // unchanged.
+        conn.execute(
+            "UPDATE logical_symbols SET id = 424242, kind = 'legacy_kind' WHERE id = ?1",
+            params![real_id],
+        )
+        .unwrap();
+        conn.execute(
+            "UPDATE logical_symbol_members SET logical_symbol_id = 424242
+              WHERE logical_symbol_id = ?1",
+            params![real_id],
+        )
+        .unwrap();
+        conn.execute(
+            "UPDATE repo_memory_bindings SET logical_symbol_id = 424242
+              WHERE logical_symbol_id = ?1",
+            params![real_id],
+        )
+        .unwrap();
+        conn.execute("DELETE FROM repo_meta WHERE key = 'logical_key_version'", []).unwrap();
+    }
+
+    fs::write(
+        root.join("src/lib.rs"),
+        "pub fn kind_drift_anchor(k: u8) -> u8 { k }\n\npub fn kind_appendix() {}\n",
+    )
+    .unwrap();
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let fresh_id: i64 = db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT id FROM logical_symbols WHERE logical_name = 'kind_drift_anchor'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    let bound: i64 = db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT logical_symbol_id FROM repo_memory_bindings WHERE memory_id = ?1",
+            params![memory_id],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(bound, fresh_id, "the kind-relaxed pass must realign a kind-drifted binding");
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+/// #493 review: a surviving OLD id is not proof of an unchanged symbol — after a key change a
+/// DIFFERENT symbol's re-derived key can occupy it (a key swap, not a hash collision). The heal
+/// must compare the survivor's key fields against the snapshot, realign the drifted reference by
+/// evidence, and leave the occupying row (and its members) untouched — a reference-only remap.
+#[test]
+fn an_old_id_occupied_by_another_symbol_still_realigns_by_evidence() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(
+        root.join("src/lib.rs"),
+        "pub fn alpha_occ(a: u8) -> u8 { a }\n\npub fn beta_occ(b: u16) -> u16 { b }\n",
+    )
+    .unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let id_of = |db: &IndexDatabase, name: &str| -> i64 {
+        db.storage
+            .connection()
+            .query_row("SELECT id FROM logical_symbols WHERE logical_name = ?1", [name], |r| {
+                r.get(0)
+            })
+            .unwrap()
+    };
+    let alpha_id = id_of(&db, "alpha_occ");
+    let beta_id = id_of(&db, "beta_occ");
+    let created = db
+        .memory_create(crate::query::memory::RepoMemoryCreate {
+            kind: "Invariant".to_string(),
+            title: "Anchored to alpha across an id swap".to_string(),
+            body: "A surviving id occupied by beta must not capture alpha's binding.".to_string(),
+            confidence: "high".to_string(),
+            created_by: Some("test-agent".to_string()),
+            source: Some("agent".to_string()),
+            tags: Vec::new(),
+            payload_json: None,
+            bind: crate::query::memory::RepoMemoryBindTarget {
+                logical_symbol_id: Some(alpha_id),
+                symbol_id: None,
+                chunk_id: None,
+                edge_id: None,
+                path: None,
+                start_line: None,
+                end_line: None,
+                commit_hash: None,
+                github_owner: None,
+                github_repo: None,
+                github_number: None,
+                start_logical_symbol_id: None,
+                end_logical_symbol_id: None,
+                edge_sequence_hash: None,
+                path_summary: None,
+                edge_path: None,
+                dir: None,
+            },
+        })
+        .unwrap();
+    let memory_id = created.memory.memory_id;
+    drop(db);
+
+    {
+        let conn = rusqlite::Connection::open(&config.database).unwrap();
+        conn.execute_batch("PRAGMA foreign_keys = OFF;").unwrap();
+        // Simulate the swap: under OLD derivation rules alpha's key hashed to what is beta's id
+        // under the NEW rules. Move beta's stored row aside and park alpha's row (and its
+        // references) on beta's id.
+        conn.execute(
+            "DELETE FROM logical_symbol_members
+              WHERE logical_symbol_id = ?1",
+            params![beta_id],
+        )
+        .unwrap();
+        conn.execute("DELETE FROM logical_symbols WHERE id = ?1", params![beta_id]).unwrap();
+        conn.execute("UPDATE logical_symbols SET id = ?1 WHERE id = ?2", params![
+            beta_id, alpha_id
+        ])
+        .unwrap();
+        conn.execute(
+            "UPDATE logical_symbol_members SET logical_symbol_id = ?1
+              WHERE logical_symbol_id = ?2",
+            params![beta_id, alpha_id],
+        )
+        .unwrap();
+        conn.execute(
+            "UPDATE repo_memory_bindings SET logical_symbol_id = ?1
+              WHERE logical_symbol_id = ?2",
+            params![beta_id, alpha_id],
+        )
+        .unwrap();
+        conn.execute("DELETE FROM repo_meta WHERE key = 'logical_key_version'", []).unwrap();
+    }
+
+    fs::write(
+        root.join("src/lib.rs"),
+        "pub fn alpha_occ(a: u8) -> u8 { a }\n\npub fn beta_occ(b: u16) -> u16 { b }\n\npub fn \
+         occ_appendix() {}\n",
+    )
+    .unwrap();
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let alpha_fresh = id_of(&db, "alpha_occ");
+    let beta_fresh = id_of(&db, "beta_occ");
+    assert_eq!(beta_fresh, beta_id, "beta re-derives its own id; the fixture swap is honest");
+    let bound: i64 = db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT logical_symbol_id FROM repo_memory_bindings WHERE memory_id = ?1",
+            params![memory_id],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        bound, alpha_fresh,
+        "the occupied old id must realign to alpha by evidence, not stay captured by beta"
+    );
+    // The occupying row is untouched by the reference-only remap: beta keeps its id and members.
+    let beta_members: i64 = db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT COUNT(*) FROM logical_symbol_members WHERE logical_symbol_id = ?1",
+            params![beta_id],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert!(beta_members > 0, "beta's rebuilt members must survive the drift remap");
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+/// #493 review: when a key change MERGES two old logical symbols into one surviving row (e.g. a
+/// signature normalization collapses sig-distinct cfg twins into one group under the survivor's
+/// id), the vanished twin's evidence match onto the survivor competes with the survivor's own
+/// existing references. The heal must not silently move it — survivors count as target claims,
+/// the pair drops, and the validate-time ladder relocates it with a visible papertrail.
+#[test]
+fn a_merge_into_a_surviving_id_is_left_for_the_ladder_not_silently_healed() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    // Two cfg variants with DISTINCT signatures — two logical rows sharing (path, name, qual).
+    fs::write(
+        root.join("src/lib.rs"),
+        "#[cfg(unix)]\npub fn merge_twin(a: u32) -> u32 { a }\n#[cfg(windows)]\npub fn \
+         merge_twin(b: i64) -> i64 { b }\n",
+    )
+    .unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let twin_ids: Vec<i64> = {
+        let conn = db.storage.connection();
+        let mut stmt = conn
+            .prepare("SELECT id FROM logical_symbols WHERE logical_name = 'merge_twin' ORDER BY id")
+            .unwrap();
+        stmt.query_map([], |r| r.get(0)).unwrap().map(Result::unwrap).collect()
+    };
+    assert_eq!(twin_ids.len(), 2, "the fixture must produce two signature-distinct twins");
+
+    let mut memory_ids = Vec::new();
+    for (i, twin) in twin_ids.iter().enumerate() {
+        let created = db
+            .memory_create(crate::query::memory::RepoMemoryCreate {
+                kind: "Invariant".to_string(),
+                title: format!("Bound to merge twin {i}"),
+                body: "A merge must not silently capture the vanished twin's reference."
+                    .to_string(),
+                confidence: "high".to_string(),
+                created_by: Some("test-agent".to_string()),
+                source: Some("agent".to_string()),
+                tags: Vec::new(),
+                payload_json: None,
+                bind: crate::query::memory::RepoMemoryBindTarget {
+                    logical_symbol_id: Some(*twin),
+                    symbol_id: None,
+                    chunk_id: None,
+                    edge_id: None,
+                    path: None,
+                    start_line: None,
+                    end_line: None,
+                    commit_hash: None,
+                    github_owner: None,
+                    github_repo: None,
+                    github_number: None,
+                    start_logical_symbol_id: None,
+                    end_logical_symbol_id: None,
+                    edge_sequence_hash: None,
+                    path_summary: None,
+                    edge_path: None,
+                    dir: None,
+                },
+            })
+            .unwrap();
+        memory_ids.push(created.memory.memory_id);
+    }
+    drop(db);
+
+    {
+        let conn = rusqlite::Connection::open(&config.database).unwrap();
+        conn.execute("DELETE FROM repo_meta WHERE key = 'logical_key_version'", []).unwrap();
+    }
+
+    // The "derivation change": both variants now carry ONE signature (byte-identical
+    // declarations — the canonical cfg-variant grouping), so the rebuild collapses the group
+    // under the surviving twin's key/id and the other id vanishes.
+    fs::write(
+        root.join("src/lib.rs"),
+        "#[cfg(unix)]\npub fn merge_twin(a: u32) -> u32 { a }\n#[cfg(windows)]\npub fn \
+         merge_twin(a: u32) -> u32 { a }\n",
+    )
+    .unwrap();
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let merged_ids: Vec<i64> = {
+        let conn = db.storage.connection();
+        let mut stmt = conn
+            .prepare("SELECT id FROM logical_symbols WHERE logical_name = 'merge_twin' ORDER BY id")
+            .unwrap();
+        stmt.query_map([], |r| r.get(0)).unwrap().map(Result::unwrap).collect()
+    };
+    assert_eq!(merged_ids.len(), 1, "the derivation change must merge the twins into one row");
+    let survivor = merged_ids[0];
+    let vanished_memory = memory_ids
+        .iter()
+        .zip(&twin_ids)
+        .find(|(_, twin)| **twin != survivor)
+        .map(|(memory_id, _)| memory_id.clone())
+        .expect("one twin id must vanish in the merge");
+    let vanished_old_id =
+        *twin_ids.iter().find(|twin| **twin != survivor).expect("the vanished twin id");
+
+    let bound: i64 = db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT logical_symbol_id FROM repo_memory_bindings WHERE memory_id = ?1",
+            params![vanished_memory],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        bound, vanished_old_id,
+        "the heal must not silently move a reference onto a claimed survivor id"
+    );
+
+    // The relocation ladder owns it — with a visible papertrail, not a silent heal.
+    db.memory_validate().unwrap();
+    let (relocated_to, status): (i64, String) = db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT logical_symbol_id, anchor_status FROM repo_memory_bindings
+             WHERE memory_id = ?1",
+            params![vanished_memory],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(status, "relocated", "the ladder relocates the merged-away reference visibly");
+    assert_eq!(relocated_to, survivor);
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+/// #493 review: a logical group's snapshot signature is EVIDENCE only when every member agrees —
+/// a `LIMIT 1` pick would hand a SPLIT group's references to whichever overload the arbitrary
+/// member happened to match (members can disagree when a scope's symbols were re-captured while
+/// a sibling scope's were not). Disagreement must yield no signature evidence at all.
+#[test]
+fn disagreeing_member_signatures_yield_no_drift_evidence() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(
+        root.join("src/lib.rs"),
+        "#[cfg(unix)]\npub fn split_twin(a: u32) -> u32 { a }\n#[cfg(windows)]\npub fn \
+         split_twin(a: u32) -> u32 { a }\n",
+    )
+    .unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let group_id: i64 = db
+        .storage
+        .connection()
+        .query_row("SELECT id FROM logical_symbols WHERE logical_name = 'split_twin'", [], |r| {
+            r.get(0)
+        })
+        .unwrap();
+    let created = db
+        .memory_create(crate::query::memory::RepoMemoryCreate {
+            kind: "Invariant".to_string(),
+            title: "Bound to the collapsed group".to_string(),
+            body: "A split group's members disagree; the snapshot must carry no signature."
+                .to_string(),
+            confidence: "high".to_string(),
+            created_by: Some("test-agent".to_string()),
+            source: Some("agent".to_string()),
+            tags: Vec::new(),
+            payload_json: None,
+            bind: crate::query::memory::RepoMemoryBindTarget {
+                logical_symbol_id: Some(group_id),
+                symbol_id: None,
+                chunk_id: None,
+                edge_id: None,
+                path: None,
+                start_line: None,
+                end_line: None,
+                commit_hash: None,
+                github_owner: None,
+                github_repo: None,
+                github_number: None,
+                start_logical_symbol_id: None,
+                end_logical_symbol_id: None,
+                edge_sequence_hash: None,
+                path_summary: None,
+                edge_path: None,
+                dir: None,
+            },
+        })
+        .unwrap();
+    assert!(!created.duplicate);
+
+    // Simulate the partially-re-captured store: the group's two members now carry DIFFERENT
+    // signature captures. Arm the drift snapshot and read it directly.
+    {
+        let conn = db.storage.connection();
+        let member_symbols: Vec<i64> = {
+            let mut stmt = conn
+                .prepare(
+                    "SELECT symbol_id FROM logical_symbol_members WHERE logical_symbol_id = ?1
+                     ORDER BY symbol_id",
+                )
+                .unwrap();
+            stmt.query_map(params![group_id], |r| r.get(0)).unwrap().map(Result::unwrap).collect()
+        };
+        assert_eq!(member_symbols.len(), 2, "the cfg twins must group into one two-member row");
+        conn.execute(
+            "UPDATE symbols SET signature = 'fn split_twin(recaptured: u32) -> u32'
+              WHERE id = ?1",
+            params![member_symbols[0]],
+        )
+        .unwrap();
+        conn.execute("DELETE FROM repo_meta WHERE key = 'logical_key_version'", []).unwrap();
+    }
+
+    let snapshot =
+        db.logical_key_drift_snapshot().unwrap().expect("a missing stamp arms the drift snapshot");
+    let row = snapshot
+        .iter()
+        .find(|row| row.old_id == group_id)
+        .expect("the referenced group is snapshotted");
+    assert!(
+        row.signature.is_none(),
+        "disagreeing member signatures must yield NO signature evidence, not an arbitrary pick"
+    );
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+/// #493 review: a group with one signature-less member and one captured member is DISAGREEMENT,
+/// not unanimity — `COUNT(DISTINCT)` alone ignores the NULLs and would crown the sole non-null
+/// capture as the group's evidence, silently realigning references by a signature only PART of
+/// the group carries. Mixed NULL/non-null must yield no signature evidence at all.
+#[test]
+fn a_mixed_null_signature_group_yields_no_drift_evidence() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(
+        root.join("src/lib.rs"),
+        "#[cfg(unix)]\npub fn split_twin(a: u32) -> u32 { a }\n#[cfg(windows)]\npub fn \
+         split_twin(a: u32) -> u32 { a }\n",
+    )
+    .unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let group_id: i64 = db
+        .storage
+        .connection()
+        .query_row("SELECT id FROM logical_symbols WHERE logical_name = 'split_twin'", [], |r| {
+            r.get(0)
+        })
+        .unwrap();
+    let created = db
+        .memory_create(crate::query::memory::RepoMemoryCreate {
+            kind: "Invariant".to_string(),
+            title: "Bound to the partially captured group".to_string(),
+            body: "One member lost its signature capture; the group must carry no evidence."
+                .to_string(),
+            confidence: "high".to_string(),
+            created_by: Some("test-agent".to_string()),
+            source: Some("agent".to_string()),
+            tags: Vec::new(),
+            payload_json: None,
+            bind: crate::query::memory::RepoMemoryBindTarget {
+                logical_symbol_id: Some(group_id),
+                symbol_id: None,
+                chunk_id: None,
+                edge_id: None,
+                path: None,
+                start_line: None,
+                end_line: None,
+                commit_hash: None,
+                github_owner: None,
+                github_repo: None,
+                github_number: None,
+                start_logical_symbol_id: None,
+                end_logical_symbol_id: None,
+                edge_sequence_hash: None,
+                path_summary: None,
+                edge_path: None,
+                dir: None,
+            },
+        })
+        .unwrap();
+    assert!(!created.duplicate);
+
+    // Simulate a partial re-capture: one member keeps its signature, the other loses it
+    // entirely. Arm the drift snapshot and read it directly.
+    {
+        let conn = db.storage.connection();
+        let member_symbols: Vec<i64> = {
+            let mut stmt = conn
+                .prepare(
+                    "SELECT symbol_id FROM logical_symbol_members WHERE logical_symbol_id = ?1
+                     ORDER BY symbol_id",
+                )
+                .unwrap();
+            stmt.query_map(params![group_id], |r| r.get(0)).unwrap().map(Result::unwrap).collect()
+        };
+        assert_eq!(member_symbols.len(), 2, "the cfg twins must group into one two-member row");
+        conn.execute("UPDATE symbols SET signature = NULL WHERE id = ?1", params![
+            member_symbols[0]
+        ])
+        .unwrap();
+        conn.execute("DELETE FROM repo_meta WHERE key = 'logical_key_version'", []).unwrap();
+    }
+
+    let snapshot =
+        db.logical_key_drift_snapshot().unwrap().expect("a missing stamp arms the drift snapshot");
+    let row = snapshot
+        .iter()
+        .find(|row| row.old_id == group_id)
+        .expect("the referenced group is snapshotted");
+    assert!(
+        row.signature.is_none(),
+        "a mixed NULL/non-null signature group must yield NO signature evidence — COUNT(DISTINCT) \
+         alone ignores the NULL member and crowns the sole capture"
+    );
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+/// #493 review: an occupied old id with NO evidence winner must be VACATED, not left in place —
+/// the occupying row is live, so `memory_validate` would resolve the binding as healthy and the
+/// relocation ladder would never run: a silent permanent mis-anchor. Vacated references point at
+/// a sentinel that resolves to nothing, so the ladder relocates them by qualified name with a
+/// visible papertrail.
+#[test]
+fn an_occupied_old_id_with_no_winner_is_vacated_for_the_ladder() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(
+        root.join("src/lib.rs"),
+        "pub fn vac_alpha(a: u8) -> u8 { a }\n\npub fn vac_beta(b: u16) -> u16 { b }\n",
+    )
+    .unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let id_of = |db: &IndexDatabase, name: &str| -> i64 {
+        db.storage
+            .connection()
+            .query_row("SELECT id FROM logical_symbols WHERE logical_name = ?1", [name], |r| {
+                r.get(0)
+            })
+            .unwrap()
+    };
+    let alpha_id = id_of(&db, "vac_alpha");
+    let beta_id = id_of(&db, "vac_beta");
+    let created = db
+        .memory_create(crate::query::memory::RepoMemoryCreate {
+            kind: "Invariant".to_string(),
+            title: "Anchored to alpha across an evidence-dead swap".to_string(),
+            body: "An occupied id without evidence must be vacated, never silently captured."
+                .to_string(),
+            confidence: "high".to_string(),
+            created_by: Some("test-agent".to_string()),
+            source: Some("agent".to_string()),
+            tags: Vec::new(),
+            payload_json: None,
+            bind: crate::query::memory::RepoMemoryBindTarget {
+                logical_symbol_id: Some(alpha_id),
+                symbol_id: None,
+                chunk_id: None,
+                edge_id: None,
+                path: None,
+                start_line: None,
+                end_line: None,
+                commit_hash: None,
+                github_owner: None,
+                github_repo: None,
+                github_number: None,
+                start_logical_symbol_id: None,
+                end_logical_symbol_id: None,
+                edge_sequence_hash: None,
+                path_summary: None,
+                edge_path: None,
+                dir: None,
+            },
+        })
+        .unwrap();
+    let memory_id = created.memory.memory_id;
+    drop(db);
+
+    {
+        let conn = rusqlite::Connection::open(&config.database).unwrap();
+        conn.execute_batch("PRAGMA foreign_keys = OFF;").unwrap();
+        // Park alpha's row on beta's id (the swap), and kill BOTH evidence axes: the stored
+        // qualified name AND the stored member signature no longer match anything re-derived.
+        conn.execute(
+            "DELETE FROM logical_symbol_members
+              WHERE logical_symbol_id = ?1",
+            params![beta_id],
+        )
+        .unwrap();
+        conn.execute("DELETE FROM logical_symbols WHERE id = ?1", params![beta_id]).unwrap();
+        conn.execute("INSERT OR IGNORE INTO name_strings(value) VALUES ('legacy::vac_alpha')", [])
+            .unwrap();
+        conn.execute(
+            "UPDATE logical_symbols
+                SET id = ?1,
+                    qualified_name_id =
+                        (SELECT id FROM name_strings WHERE value = 'legacy::vac_alpha')
+              WHERE id = ?2",
+            params![beta_id, alpha_id],
+        )
+        .unwrap();
+        conn.execute(
+            "UPDATE logical_symbol_members SET logical_symbol_id = ?1
+              WHERE logical_symbol_id = ?2",
+            params![beta_id, alpha_id],
+        )
+        .unwrap();
+        conn.execute(
+            "UPDATE symbols SET signature = 'fn vac_alpha(legacy_capture: u8) -> u8'
+              WHERE id IN (SELECT symbol_id FROM logical_symbol_members
+                            WHERE logical_symbol_id = ?1)",
+            params![beta_id],
+        )
+        .unwrap();
+        conn.execute(
+            "UPDATE repo_memory_bindings SET logical_symbol_id = ?1
+              WHERE logical_symbol_id = ?2",
+            params![beta_id, alpha_id],
+        )
+        .unwrap();
+        conn.execute("DELETE FROM repo_meta WHERE key = 'logical_key_version'", []).unwrap();
+    }
+
+    fs::write(
+        root.join("src/lib.rs"),
+        "pub fn vac_alpha(a: u8) -> u8 { a }\n\npub fn vac_beta(b: u16) -> u16 { b }\n\npub fn \
+         vac_appendix() {}\n",
+    )
+    .unwrap();
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let bound: i64 = db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT logical_symbol_id FROM repo_memory_bindings WHERE memory_id = ?1",
+            params![memory_id],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_ne!(
+        bound, beta_id,
+        "an occupied id without an evidence winner must be vacated, not silently captured by the \
+         occupying symbol"
+    );
+
+    // The ladder relocates the vacated reference by its stored qualified name, visibly.
+    db.memory_validate().unwrap();
+    let (relocated_to, status): (i64, String) = db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT logical_symbol_id, anchor_status FROM repo_memory_bindings
+             WHERE memory_id = ?1",
+            params![memory_id],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(status, "relocated", "the ladder owns the vacated reference, with a papertrail");
+    assert_eq!(relocated_to, id_of(&db, "vac_alpha"));
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+/// #493 review: a vacated CALL-PATH endpoint must be NULLED, not parked on
+/// `VACATED_LOGICAL_SYMBOL_ID`. `validate_call_path_binding` re-checks only the stored edge
+/// fingerprints — it never consults or repairs `start/end_logical_symbol_id` — so a sentinel
+/// there would leave a permanent bogus `sym_8000…` endpoint that hydration surfaces and no
+/// validator ever fixes. NULL is the supported "no recorded endpoint" state.
+#[test]
+fn a_vacated_call_path_endpoint_is_nulled_not_sentineled() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(
+        root.join("src/lib.rs"),
+        "pub fn cp_alpha(a: u8) -> u8 { a }\n\npub fn cp_beta(b: u16) -> u16 { b }\n",
+    )
+    .unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let id_of = |db: &IndexDatabase, name: &str| -> i64 {
+        db.storage
+            .connection()
+            .query_row("SELECT id FROM logical_symbols WHERE logical_name = ?1", [name], |r| {
+                r.get(0)
+            })
+            .unwrap()
+    };
+    let alpha_id = id_of(&db, "cp_alpha");
+    let beta_id = id_of(&db, "cp_beta");
+    // A parent memory (path-bound so it needs no logical symbol) plus a call-path row whose START
+    // endpoint references cp_alpha — the durable reference the drift snapshot will pick up.
+    let created = db
+        .memory_create(crate::query::memory::RepoMemoryCreate {
+            kind: "Decision".to_string(),
+            title: "Call-path memory with a drifting endpoint".to_string(),
+            body: "Its start endpoint must vacate to NULL, not a bogus sentinel.".to_string(),
+            confidence: "high".to_string(),
+            created_by: Some("test-agent".to_string()),
+            source: Some("agent".to_string()),
+            tags: Vec::new(),
+            payload_json: None,
+            bind: crate::query::memory::RepoMemoryBindTarget {
+                path: Some("src/lib.rs".to_string()),
+                ..Default::default()
+            },
+        })
+        .unwrap();
+    let memory_id = created.memory.memory_id;
+    db.storage
+        .connection()
+        .execute(
+            "INSERT INTO repo_memory_call_paths(memory_id, start_logical_symbol_id,
+                        end_logical_symbol_id, edge_sequence_hash, path_summary, created_at_ms)
+             VALUES (?1, ?2, NULL, 'cp-hash-1', 'alpha -> ...', 0)",
+            params![memory_id, alpha_id],
+        )
+        .unwrap();
+    // The matching `call_path` BINDING row also carries the endpoint in its `logical_symbol_id`
+    // (start-or-end at bind time). `validate_call_path_binding` ignores it too, so the vacate must
+    // NULL it — not the i64::MIN sentinel the generic binding update would leave (#493 review).
+    db.storage
+        .connection()
+        .execute(
+            "INSERT INTO repo_memory_bindings(memory_id, binding_kind, binding_id,
+                        logical_symbol_id, anchor_status, created_at_ms)
+             VALUES (?1, 'call_path', 'cp-hash-1', ?2, 'current', 0)",
+            params![memory_id, alpha_id],
+        )
+        .unwrap();
+    drop(db);
+
+    {
+        let conn = rusqlite::Connection::open(&config.database).unwrap();
+        conn.execute_batch("PRAGMA foreign_keys = OFF;").unwrap();
+        // Occupied-no-winner swap: cp_beta re-derives to its own (unchanged) id, so parking
+        // cp_alpha's row on beta_id and killing both evidence axes makes beta_id occupied by a
+        // key-mismatched survivor after the rebuild, with no candidate the endpoint can realign
+        // onto.
+        conn.execute("DELETE FROM logical_symbol_members WHERE logical_symbol_id = ?1", params![
+            beta_id
+        ])
+        .unwrap();
+        conn.execute("DELETE FROM logical_symbols WHERE id = ?1", params![beta_id]).unwrap();
+        conn.execute("INSERT OR IGNORE INTO name_strings(value) VALUES ('legacy::cp_alpha')", [])
+            .unwrap();
+        conn.execute(
+            "UPDATE logical_symbols
+                SET id = ?1,
+                    qualified_name_id =
+                        (SELECT id FROM name_strings WHERE value = 'legacy::cp_alpha')
+              WHERE id = ?2",
+            params![beta_id, alpha_id],
+        )
+        .unwrap();
+        conn.execute(
+            "UPDATE logical_symbol_members SET logical_symbol_id = ?1 WHERE logical_symbol_id = ?2",
+            params![beta_id, alpha_id],
+        )
+        .unwrap();
+        conn.execute(
+            "UPDATE symbols SET signature = 'fn cp_alpha(legacy_capture: u8) -> u8'
+              WHERE id IN (SELECT symbol_id FROM logical_symbol_members
+                            WHERE logical_symbol_id = ?1)",
+            params![beta_id],
+        )
+        .unwrap();
+        conn.execute(
+            "UPDATE repo_memory_call_paths SET start_logical_symbol_id = ?1
+              WHERE start_logical_symbol_id = ?2",
+            params![beta_id, alpha_id],
+        )
+        .unwrap();
+        conn.execute(
+            "UPDATE repo_memory_bindings SET logical_symbol_id = ?1
+              WHERE logical_symbol_id = ?2 AND binding_kind = 'call_path'",
+            params![beta_id, alpha_id],
+        )
+        .unwrap();
+        conn.execute("DELETE FROM repo_meta WHERE key = 'logical_key_version'", []).unwrap();
+    }
+
+    fs::write(
+        root.join("src/lib.rs"),
+        "pub fn cp_alpha(a: u8) -> u8 { a }\n\npub fn cp_beta(b: u16) -> u16 { b }\n\npub fn \
+         cp_appendix() {}\n",
+    )
+    .unwrap();
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let start_endpoint: Option<i64> = db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT start_logical_symbol_id FROM repo_memory_call_paths WHERE memory_id = ?1",
+            params![memory_id],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        start_endpoint, None,
+        "a vacated call-path endpoint must be NULL, never the i64::MIN sentinel that no validator \
+         handles"
+    );
+    let binding_endpoint: Option<i64> = db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT logical_symbol_id FROM repo_memory_bindings
+              WHERE memory_id = ?1 AND binding_kind = 'call_path'",
+            params![memory_id],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        binding_endpoint, None,
+        "the call_path BINDING row's endpoint must also be NULL, not the sentinel the generic \
+         binding update would leave"
+    );
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+/// #493 review: a drifted call-path id that VANISHES (re-derives nowhere and finds no evidence
+/// winner) never enters the occupied set, so the vacate loop used to skip it entirely — leaving
+/// the endpoints and the call_path binding pointing at a dead pre-rebuild id. `validate_call_path`
+/// never revisits those ids, and once a full rebuild stamps `logical_key_version` the heal won't
+/// run again, so the stale `sym_…` would be permanent. Vanished no-winner call-path references
+/// must be NULLed too, not only occupied ones.
+#[test]
+fn a_vanished_call_path_reference_with_no_winner_is_nulled() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), "pub fn cpv_fn(a: u8) -> u8 { a }\n").unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let real_id: i64 = db
+        .storage
+        .connection()
+        .query_row("SELECT id FROM logical_symbols WHERE logical_name = 'cpv_fn'", [], |r| r.get(0))
+        .unwrap();
+    let created = db
+        .memory_create(crate::query::memory::RepoMemoryCreate {
+            kind: "Decision".to_string(),
+            title: "Call-path memory whose endpoint vanishes".to_string(),
+            body: "A vanished no-winner endpoint must be NULLed, not left on a dead id."
+                .to_string(),
+            confidence: "high".to_string(),
+            created_by: Some("test-agent".to_string()),
+            source: Some("agent".to_string()),
+            tags: Vec::new(),
+            payload_json: None,
+            bind: crate::query::memory::RepoMemoryBindTarget {
+                path: Some("src/lib.rs".to_string()),
+                ..Default::default()
+            },
+        })
+        .unwrap();
+    let memory_id = created.memory.memory_id;
+    db.storage
+        .connection()
+        .execute(
+            "INSERT INTO repo_memory_call_paths(memory_id, start_logical_symbol_id,
+                        end_logical_symbol_id, edge_sequence_hash, path_summary, created_at_ms)
+             VALUES (?1, ?2, NULL, 'cpv-hash', 'cpv -> ...', 0)",
+            params![memory_id, real_id],
+        )
+        .unwrap();
+    db.storage
+        .connection()
+        .execute(
+            "INSERT INTO repo_memory_bindings(memory_id, binding_kind, binding_id,
+                        logical_symbol_id, anchor_status, created_at_ms)
+             VALUES (?1, 'call_path', 'cpv-hash', ?2, 'current', 0)",
+            params![memory_id, real_id],
+        )
+        .unwrap();
+    drop(db);
+
+    let fake_id: i64 = 424249;
+    {
+        let conn = rusqlite::Connection::open(&config.database).unwrap();
+        conn.execute_batch("PRAGMA foreign_keys = OFF;").unwrap();
+        // Drift the symbol onto a fake id AND kill both evidence axes (legacy qual + legacy
+        // signature), so after the rebuild the fake id VANISHES (cpv_fn re-derives to a different
+        // id) and the re-derived cpv_fn is not an evidence match — a vanished no-winner id, NOT an
+        // occupied one.
+        conn.execute("INSERT OR IGNORE INTO name_strings(value) VALUES ('legacy::cpv_fn')", [])
+            .unwrap();
+        conn.execute(
+            "UPDATE logical_symbols
+                SET id = ?1,
+                    qualified_name_id =
+                        (SELECT id FROM name_strings WHERE value = 'legacy::cpv_fn')
+              WHERE id = ?2",
+            params![fake_id, real_id],
+        )
+        .unwrap();
+        conn.execute(
+            "UPDATE logical_symbol_members SET logical_symbol_id = ?1 WHERE logical_symbol_id = ?2",
+            params![fake_id, real_id],
+        )
+        .unwrap();
+        conn.execute(
+            "UPDATE symbols SET signature = 'fn cpv_fn(legacy_capture: u8) -> u8'
+              WHERE id IN (SELECT symbol_id FROM logical_symbol_members
+                            WHERE logical_symbol_id = ?1)",
+            params![fake_id],
+        )
+        .unwrap();
+        conn.execute(
+            "UPDATE repo_memory_call_paths SET start_logical_symbol_id = ?1
+              WHERE start_logical_symbol_id = ?2",
+            params![fake_id, real_id],
+        )
+        .unwrap();
+        conn.execute(
+            "UPDATE repo_memory_bindings SET logical_symbol_id = ?1
+              WHERE logical_symbol_id = ?2 AND binding_kind = 'call_path'",
+            params![fake_id, real_id],
+        )
+        .unwrap();
+        conn.execute("DELETE FROM repo_meta WHERE key = 'logical_key_version'", []).unwrap();
+    }
+
+    fs::write(
+        root.join("src/lib.rs"),
+        "pub fn cpv_fn(a: u8) -> u8 { a }\n\npub fn cpv_extra() {}\n",
+    )
+    .unwrap();
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let (endpoint, binding_endpoint): (Option<i64>, Option<i64>) = {
+        let conn = db.storage.connection();
+        let endpoint = conn
+            .query_row(
+                "SELECT start_logical_symbol_id FROM repo_memory_call_paths WHERE memory_id = ?1",
+                params![memory_id],
+                |r| r.get(0),
+            )
+            .unwrap();
+        let binding_endpoint = conn
+            .query_row(
+                "SELECT logical_symbol_id FROM repo_memory_bindings
+                  WHERE memory_id = ?1 AND binding_kind = 'call_path'",
+                params![memory_id],
+                |r| r.get(0),
+            )
+            .unwrap();
+        (endpoint, binding_endpoint)
+    };
+    assert_eq!(endpoint, None, "a vanished no-winner call-path endpoint must be NULLed");
+    assert_eq!(
+        binding_endpoint, None,
+        "the vanished call_path binding endpoint must be NULLed too"
+    );
+    // The fake id is truly gone — the assertion above is not just masking a lingering row.
+    let fake_rows: i64 = db
+        .storage
+        .connection()
+        .query_row("SELECT COUNT(*) FROM logical_symbols WHERE id = ?1", params![fake_id], |r| {
+            r.get(0)
+        })
+        .unwrap();
+    assert_eq!(fake_rows, 0, "the drifted id vanished (this is the vanished, not occupied, case)");
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+/// #493 review: `refresh_logical_binding_discriminators` renames each realigned binding's
+/// `binding_id` to the live qualified name, but that column is part of the PK. When the SAME
+/// memory already carries a sibling logical binding at the target qualified name, the rename
+/// collides — a plain `UPDATE OR IGNORE` would silently SKIP the stale row, leaving it on a live
+/// id with stale discriminators that validate as current forever. The refresh must delete the
+/// stale duplicate, exactly as `validate_memories` does on the same collision shape.
+#[test]
+fn a_refresh_collision_deletes_the_stale_duplicate_binding() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), "pub fn dup_anchor(x: u8) -> u8 { x }\n").unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let real_id: i64 = db
+        .storage
+        .connection()
+        .query_row("SELECT id FROM logical_symbols WHERE logical_name = 'dup_anchor'", [], |r| {
+            r.get(0)
+        })
+        .unwrap();
+    // The live qualified name dup_anchor re-derives to (unchanged across the rebuild) — the
+    // target the rename collides on.
+    let live_qual: String = db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT value FROM name_strings
+              WHERE id = (SELECT qualified_name_id FROM logical_symbols WHERE id = ?1)",
+            params![real_id],
+            |r| r.get(0),
+        )
+        .unwrap();
+    let created = db
+        .memory_create(crate::query::memory::RepoMemoryCreate {
+            kind: "Invariant".to_string(),
+            title: "Bound to dup_anchor under two derivations".to_string(),
+            body: "The stale sibling binding must be dropped, not stranded mis-labelled."
+                .to_string(),
+            confidence: "high".to_string(),
+            created_by: Some("test-agent".to_string()),
+            source: Some("agent".to_string()),
+            tags: Vec::new(),
+            payload_json: None,
+            bind: crate::query::memory::RepoMemoryBindTarget {
+                logical_symbol_id: Some(real_id),
+                symbol_id: None,
+                chunk_id: None,
+                edge_id: None,
+                path: None,
+                start_line: None,
+                end_line: None,
+                commit_hash: None,
+                github_owner: None,
+                github_repo: None,
+                github_number: None,
+                start_logical_symbol_id: None,
+                end_logical_symbol_id: None,
+                edge_sequence_hash: None,
+                path_summary: None,
+                edge_path: None,
+                dir: None,
+            },
+        })
+        .unwrap();
+    let memory_id = created.memory.memory_id;
+    drop(db);
+
+    let fake_id: i64 = 424248;
+    {
+        let conn = rusqlite::Connection::open(&config.database).unwrap();
+        conn.execute_batch("PRAGMA foreign_keys = OFF;").unwrap();
+        // Drift the symbol onto a fake id (qual + signature stored unchanged, so it realigns by
+        // evidence onto the re-derived row).
+        conn.execute("UPDATE logical_symbols SET id = ?1 WHERE id = ?2", params![fake_id, real_id])
+            .unwrap();
+        conn.execute(
+            "UPDATE logical_symbol_members SET logical_symbol_id = ?1 WHERE logical_symbol_id = ?2",
+            params![fake_id, real_id],
+        )
+        .unwrap();
+        // The memory's created binding becomes the DRIFTED one: rename its binding_id to a legacy
+        // qual FIRST (freeing the live-qual PK slot), then point it at the fake id.
+        conn.execute(
+            "UPDATE repo_memory_bindings
+                SET binding_id = 'legacy::dup_anchor', logical_symbol_id = ?1
+              WHERE memory_id = ?2 AND binding_kind = 'logical_symbol'",
+            params![fake_id, memory_id],
+        )
+        .unwrap();
+        // The SIBLING binding already holding the live qualified name (the collision target),
+        // also drifted onto the fake id so the remap carries it to the same re-derived row.
+        conn.execute(
+            "INSERT INTO repo_memory_bindings(memory_id, binding_kind, binding_id,
+                        logical_symbol_id, anchor_status, created_at_ms)
+             VALUES (?1, 'logical_symbol', ?2, ?3, 'current', 0)",
+            params![memory_id, live_qual, fake_id],
+        )
+        .unwrap();
+        conn.execute("DELETE FROM repo_meta WHERE key = 'logical_key_version'", []).unwrap();
+    }
+
+    fs::write(
+        root.join("src/lib.rs"),
+        "pub fn dup_anchor(x: u8) -> u8 { x }\n\npub fn dup_appendix() {}\n",
+    )
+    .unwrap();
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let fresh_id: i64 = db
+        .storage
+        .connection()
+        .query_row("SELECT id FROM logical_symbols WHERE logical_name = 'dup_anchor'", [], |r| {
+            r.get(0)
+        })
+        .unwrap();
+    let rows: Vec<(String, i64)> = {
+        let conn = db.storage.connection();
+        let mut stmt = conn
+            .prepare(
+                "SELECT binding_id, logical_symbol_id FROM repo_memory_bindings
+                  WHERE memory_id = ?1 AND binding_kind = 'logical_symbol'
+                  ORDER BY binding_id",
+            )
+            .unwrap();
+        stmt.query_map(params![memory_id], |r| Ok((r.get(0)?, r.get(1)?)))
+            .unwrap()
+            .map(Result::unwrap)
+            .collect()
+    };
+    assert_eq!(
+        rows,
+        vec![(live_qual.clone(), fresh_id)],
+        "the stale 'legacy::dup_anchor' duplicate must be deleted, leaving one binding at the \
+         live qualified name and re-derived id"
+    );
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+/// #493 review: vacating must run BEFORE the remap — an occupied id with no winner can itself be
+/// another drifted reference's legitimate target, and a post-remap vacate would wipe the freshly
+/// realigned references along with the stale ones.
+#[test]
+fn vacating_an_occupied_id_does_not_undo_a_remap_landing_on_it() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), "pub fn undo_alpha(a: u8) -> u8 { a }\n").unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let alpha_id: i64 = db
+        .storage
+        .connection()
+        .query_row("SELECT id FROM logical_symbols WHERE logical_name = 'undo_alpha'", [], |r| {
+            r.get(0)
+        })
+        .unwrap();
+    let bind_target = |logical: i64| crate::query::memory::RepoMemoryBindTarget {
+        logical_symbol_id: Some(logical),
+        symbol_id: None,
+        chunk_id: None,
+        edge_id: None,
+        path: None,
+        start_line: None,
+        end_line: None,
+        commit_hash: None,
+        github_owner: None,
+        github_repo: None,
+        github_number: None,
+        start_logical_symbol_id: None,
+        end_logical_symbol_id: None,
+        edge_sequence_hash: None,
+        path_summary: None,
+        edge_path: None,
+        dir: None,
+    };
+    let alpha_memory = db
+        .memory_create(crate::query::memory::RepoMemoryCreate {
+            kind: "Invariant".to_string(),
+            title: "Realigns onto its occupied id".to_string(),
+            body: "The vacate of the ghost must not wipe this freshly realigned binding."
+                .to_string(),
+            confidence: "high".to_string(),
+            created_by: Some("test-agent".to_string()),
+            source: Some("agent".to_string()),
+            tags: Vec::new(),
+            payload_json: None,
+            bind: bind_target(alpha_id),
+        })
+        .unwrap()
+        .memory
+        .memory_id;
+    // The ghost's memory rides the API too (a hand-rolled repo_memories row would fight the
+    // full column contract); its binding is re-pointed at the occupied id below.
+    let ghost_memory = db
+        .memory_create(crate::query::memory::RepoMemoryCreate {
+            kind: "Invariant".to_string(),
+            title: "The evidence-dead ghost".to_string(),
+            body: "Occupies alpha's re-derived id with a foreign key.".to_string(),
+            confidence: "low".to_string(),
+            created_by: Some("test-agent".to_string()),
+            source: Some("agent".to_string()),
+            tags: Vec::new(),
+            payload_json: None,
+            bind: bind_target(alpha_id),
+        })
+        .unwrap()
+        .memory
+        .memory_id;
+    drop(db);
+
+    {
+        let conn = rusqlite::Connection::open(&config.database).unwrap();
+        conn.execute_batch("PRAGMA foreign_keys = OFF;").unwrap();
+        // Park alpha's row (key intact) on a fake old-derivation id...
+        conn.execute("UPDATE logical_symbols SET id = 424242 WHERE id = ?1", params![alpha_id])
+            .unwrap();
+        conn.execute(
+            "UPDATE logical_symbol_members SET logical_symbol_id = 424242
+              WHERE logical_symbol_id = ?1",
+            params![alpha_id],
+        )
+        .unwrap();
+        conn.execute(
+            "UPDATE repo_memory_bindings SET logical_symbol_id = 424242
+              WHERE logical_symbol_id = ?1",
+            params![alpha_id],
+        )
+        .unwrap();
+        // ...fabricate a GHOST row occupying alpha's real id with evidence-dead key fields (a
+        // foreign name — no candidate will ever agree), and point the ghost memory's binding at
+        // it so it enters the snapshot.
+        conn.execute("INSERT OR IGNORE INTO name_strings(value) VALUES ('legacy::undo_ghost')", [])
+            .unwrap();
+        conn.execute(
+            "INSERT INTO logical_symbols(id, repo_id, language, path, logical_name,
+                                         qualified_name_id, kind, variant_count, group_reason)
+             SELECT ?1, repo_id, language, path, 'undo_ghost',
+                    (SELECT id FROM name_strings WHERE value = 'legacy::undo_ghost'),
+                    kind, 1, 'single'
+             FROM logical_symbols WHERE id = 424242",
+            params![alpha_id],
+        )
+        .unwrap();
+        conn.execute(
+            "UPDATE repo_memory_bindings SET logical_symbol_id = ?1, binding_id = \
+             'legacy::undo_ghost'
+              WHERE memory_id = ?2",
+            params![alpha_id, ghost_memory],
+        )
+        .unwrap();
+        conn.execute("DELETE FROM repo_meta WHERE key = 'logical_key_version'", []).unwrap();
+    }
+
+    fs::write(
+        root.join("src/lib.rs"),
+        "pub fn undo_alpha(a: u8) -> u8 { a }\n\npub fn undo_appendix() {}\n",
+    )
+    .unwrap();
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let bound: i64 = db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT logical_symbol_id FROM repo_memory_bindings WHERE memory_id = ?1",
+            params![alpha_memory],
+            |r| r.get(0),
+        )
+        .unwrap();
+    let alpha_fresh: i64 = db
+        .storage
+        .connection()
+        .query_row("SELECT id FROM logical_symbols WHERE logical_name = 'undo_alpha'", [], |r| {
+            r.get(0)
+        })
+        .unwrap();
+    assert_eq!(
+        bound, alpha_fresh,
+        "vacating the ghost's stale references must not wipe the remap that landed on the id"
+    );
+    let ghost_bound: i64 = db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT logical_symbol_id FROM repo_memory_bindings WHERE memory_id = ?1",
+            params![ghost_memory],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_ne!(ghost_bound, alpha_fresh, "the ghost's stale reference is off the occupied id");
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+/// #493 review: two evidence-dead occupied ids carrying `logical_symbol_monikers` rows for the
+/// SAME tool must not collide on the moniker PK when vacated — monikers are oracle-derived and
+/// re-derivable, so a vacated id's moniker rows are deleted, never collapsed onto one sentinel.
+#[test]
+fn vacating_two_moniker_bearing_ids_does_not_abort_on_the_moniker_pk() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(
+        root.join("src/lib.rs"),
+        "pub fn pk_alpha(a: u8) -> u8 { a }\n\npub fn pk_beta(b: u16) -> u16 { b }\n",
+    )
+    .unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let id_of = |db: &IndexDatabase, name: &str| -> i64 {
+        db.storage
+            .connection()
+            .query_row(
+                "SELECT id FROM logical_symbols WHERE path = 'src/lib.rs' AND logical_name = ?1",
+                [name],
+                |r| r.get(0),
+            )
+            .unwrap()
+    };
+    let alpha_id = id_of(&db, "pk_alpha");
+    let beta_id = id_of(&db, "pk_beta");
+    drop(db);
+
+    {
+        let conn = rusqlite::Connection::open(&config.database).unwrap();
+        conn.execute_batch("PRAGMA foreign_keys = OFF;").unwrap();
+        // Both rows become evidence-dead occupied ids: legacy quals + legacy member captures, ids
+        // swapped so each survives holding the OTHER symbol's re-derived id.
+        conn.execute(
+            "INSERT OR IGNORE INTO name_strings(value)
+             VALUES ('legacy::pk_alpha'), ('legacy::pk_beta')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "UPDATE logical_symbols
+                SET id = -9001,
+                    qualified_name_id = (SELECT id FROM name_strings
+                                          WHERE value = 'legacy::pk_alpha')
+              WHERE id = ?1",
+            params![alpha_id],
+        )
+        .unwrap();
+        conn.execute(
+            "UPDATE logical_symbols
+                SET id = ?1,
+                    qualified_name_id = (SELECT id FROM name_strings
+                                          WHERE value = 'legacy::pk_beta')
+              WHERE id = ?2",
+            params![alpha_id, beta_id],
+        )
+        .unwrap();
+        conn.execute("UPDATE logical_symbols SET id = ?1 WHERE id = -9001", params![beta_id])
+            .unwrap();
+        conn.execute(
+            "UPDATE symbols SET signature = 'fn legacy_capture()'
+              WHERE id IN (SELECT symbol_id FROM logical_symbol_members)",
+            [],
+        )
+        .unwrap();
+        // A moniker row for the SAME tool on each occupied id — the PK-collision shape.
+        conn.execute(
+            "INSERT INTO logical_symbol_monikers(repo_id, logical_symbol_id, tool,
+                                                 tool_version, moniker, computed_at)
+             SELECT repo_id, ?1, 'scip-rust', '1', 'legacy::pk_alpha#m', 1
+             FROM logical_symbols WHERE id = ?1",
+            params![alpha_id],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO logical_symbol_monikers(repo_id, logical_symbol_id, tool,
+                                                 tool_version, moniker, computed_at)
+             SELECT repo_id, ?1, 'scip-rust', '1', 'legacy::pk_beta#m', 1
+             FROM logical_symbols WHERE id = ?1",
+            params![beta_id],
+        )
+        .unwrap();
+        conn.execute("DELETE FROM repo_meta WHERE key = 'logical_key_version'", []).unwrap();
+    }
+
+    fs::write(
+        root.join("src/lib.rs"),
+        "pub fn pk_alpha(a: u8) -> u8 { a }\n\npub fn pk_beta(b: u16) -> u16 { b }\n\npub fn \
+         pk_appendix() {}\n",
+    )
+    .unwrap();
+    // Pre-fix this rebuild ABORTS: both vacates collapse their moniker rows onto one sentinel id
+    // and the second UPDATE violates the (repo_id, logical_symbol_id, tool) PK.
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let leftover: i64 = db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT COUNT(*) FROM logical_symbol_monikers WHERE logical_symbol_id IN (?1, ?2)",
+            params![alpha_id, beta_id],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(leftover, 0, "vacated ids' moniker rows are deleted, not collapsed or stranded");
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+/// #493 review: a snapshot row whose members were already replaced (an incremental pass deleted
+/// them) carries NO signature, so the freshly re-derived row — SAME id, agreeing qualified name —
+/// fails the exact-key survivor probe and lands in the occupied set. The evidence pass then names
+/// the old id itself as the winner (an IN-PLACE winner, no remap pair), and the vacate sweep must
+/// honor that claim: vacating it would rewrite perfectly valid references to the sentinel and
+/// delete live monikers on every incremental rebuild that follows a version bump.
+#[test]
+fn an_in_place_winner_with_dead_snapshot_members_is_not_vacated() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), "pub fn keeper_fn(a: u8) -> u8 { a }\n").unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let keeper_id: i64 = db
+        .storage
+        .connection()
+        .query_row("SELECT id FROM logical_symbols WHERE logical_name = 'keeper_fn'", [], |r| {
+            r.get(0)
+        })
+        .unwrap();
+    let created = db
+        .memory_create(crate::query::memory::RepoMemoryCreate {
+            kind: "Invariant".to_string(),
+            title: "Anchored across a members-dead snapshot".to_string(),
+            body: "An in-place evidence winner keeps its references; the vacate sweep must not \
+                   wipe them."
+                .to_string(),
+            confidence: "high".to_string(),
+            created_by: Some("test-agent".to_string()),
+            source: Some("agent".to_string()),
+            tags: Vec::new(),
+            payload_json: None,
+            bind: crate::query::memory::RepoMemoryBindTarget {
+                logical_symbol_id: Some(keeper_id),
+                symbol_id: None,
+                chunk_id: None,
+                edge_id: None,
+                path: None,
+                start_line: None,
+                end_line: None,
+                commit_hash: None,
+                github_owner: None,
+                github_repo: None,
+                github_number: None,
+                start_logical_symbol_id: None,
+                end_logical_symbol_id: None,
+                edge_sequence_hash: None,
+                path_summary: None,
+                edge_path: None,
+                dir: None,
+            },
+        })
+        .unwrap();
+    let memory_id = created.memory.memory_id;
+    drop(db);
+
+    {
+        let conn = rusqlite::Connection::open(&config.database).unwrap();
+        conn.execute_batch("PRAGMA foreign_keys = OFF;").unwrap();
+        conn.execute(
+            "INSERT INTO logical_symbol_monikers(repo_id, logical_symbol_id, tool,
+                                                 tool_version, moniker, computed_at)
+             SELECT repo_id, ?1, 'scip-rust', '1', 'keeper::keeper_fn#m', 1
+             FROM logical_symbols WHERE id = ?1",
+            params![keeper_id],
+        )
+        .unwrap();
+        // The members-dead snapshot shape: the group row survives with its references, but its
+        // member rows are gone, so the snapshot recovers NO signature for it.
+        conn.execute("DELETE FROM logical_symbol_members WHERE logical_symbol_id = ?1", params![
+            keeper_id
+        ])
+        .unwrap();
+        conn.execute("DELETE FROM repo_meta WHERE key = 'logical_key_version'", []).unwrap();
+    }
+
+    // keeper_fn's own content is untouched, so it re-derives to the SAME id; the appendix only
+    // defeats the unchanged-content short-circuit.
+    fs::write(
+        root.join("src/lib.rs"),
+        "pub fn keeper_fn(a: u8) -> u8 { a }\n\npub fn keeper_appendix() {}\n",
+    )
+    .unwrap();
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let bound: i64 = db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT logical_symbol_id FROM repo_memory_bindings WHERE memory_id = ?1",
+            params![memory_id],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        bound, keeper_id,
+        "an in-place winner's binding must stay on its id, not be vacated to the sentinel"
+    );
+    let monikers: i64 = db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT COUNT(*) FROM logical_symbol_monikers WHERE logical_symbol_id = ?1",
+            params![keeper_id],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(monikers, 1, "an in-place winner's monikers survive the vacate sweep");
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+/// #493 review: a kind-classification bump can leave a DECOY — a same-(path, name,
+/// qualified-name) twin still carrying the snapshot row's OLD kind — while the true symbol
+/// re-derives under a NEW kind. The strict pass sees only the decoy (its qualified name agrees),
+/// but the cross-kind twin agreeing on the axis the decoy lacks (signature) is CONFLICTING
+/// evidence: the heal must match nothing and leave the reference for the relocation ladder,
+/// never hand it to the decoy.
+#[test]
+fn a_kind_drift_decoy_with_conflicting_evidence_falls_to_the_ladder() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(
+        root.join("src/twin.rs"),
+        "pub struct TwinAnchor {\n    pub x: i64,\n}\n\nimpl TwinAnchor {\n    pub fn \
+         probe(&self) -> i64 {\n        self.x\n    }\n}\n",
+    )
+    .unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let twin_id = |kind: &str| -> i64 {
+        db.storage
+            .connection()
+            .query_row(
+                "SELECT ls.id FROM logical_symbols ls
+                 JOIN name_strings qn ON qn.id = ls.qualified_name_id
+                 WHERE qn.value LIKE '%::TwinAnchor' AND ls.kind = ?1",
+                [kind],
+                |r| r.get(0),
+            )
+            .unwrap()
+    };
+    let struct_id = twin_id("struct");
+    let impl_id = twin_id("impl");
+    assert_ne!(struct_id, impl_id, "the fixture must produce both twins");
+    let group_sig = |db: &IndexDatabase, id: i64| -> Option<String> {
+        db.storage
+            .connection()
+            .query_row(
+                "SELECT CASE WHEN COUNT(*) = COUNT(s.signature)
+                              AND COUNT(DISTINCT s.signature) = 1
+                             THEN MIN(s.signature) END
+                   FROM logical_symbol_members m
+                   JOIN symbols s ON s.id = m.symbol_id
+                  WHERE m.logical_symbol_id = ?1",
+                params![id],
+                |r| r.get(0),
+            )
+            .unwrap()
+    };
+    let struct_sig = group_sig(&db, struct_id);
+    assert!(struct_sig.is_some(), "fixture: the struct twin must carry a signature capture");
+    assert_ne!(
+        struct_sig,
+        group_sig(&db, impl_id),
+        "fixture: the twins' signature evidence must differ"
+    );
+
+    let created = db
+        .memory_create(crate::query::memory::RepoMemoryCreate {
+            kind: "Invariant".to_string(),
+            title: "Anchored to the struct across a kind bump".to_string(),
+            body: "The old-kind decoy must not inherit this binding by qualified name alone."
+                .to_string(),
+            confidence: "high".to_string(),
+            created_by: Some("test-agent".to_string()),
+            source: Some("agent".to_string()),
+            tags: Vec::new(),
+            payload_json: None,
+            bind: crate::query::memory::RepoMemoryBindTarget {
+                logical_symbol_id: Some(struct_id),
+                symbol_id: None,
+                chunk_id: None,
+                edge_id: None,
+                path: None,
+                start_line: None,
+                end_line: None,
+                commit_hash: None,
+                github_owner: None,
+                github_repo: None,
+                github_number: None,
+                start_logical_symbol_id: None,
+                end_logical_symbol_id: None,
+                edge_sequence_hash: None,
+                path_summary: None,
+                edge_path: None,
+                dir: None,
+            },
+        })
+        .unwrap();
+    let memory_id = created.memory.memory_id;
+    drop(db);
+
+    // Simulate the kind-drift decoy shape: under the OLD derivation the struct's row carried the
+    // kind the impl twin still holds today ('impl'), and a fake id models the whole-key churn.
+    // After the rebuild, the strict (old-kind) pass sees ONLY the impl decoy, while the true
+    // struct row agrees on qualified name AND signature.
+    let fake_id: i64 = 424243;
+    {
+        let conn = rusqlite::Connection::open(&config.database).unwrap();
+        conn.execute_batch("PRAGMA foreign_keys = OFF;").unwrap();
+        conn.execute("UPDATE logical_symbols SET id = ?1, kind = 'impl' WHERE id = ?2", params![
+            fake_id, struct_id
+        ])
+        .unwrap();
+        conn.execute(
+            "UPDATE logical_symbol_members SET logical_symbol_id = ?1
+              WHERE logical_symbol_id = ?2",
+            params![fake_id, struct_id],
+        )
+        .unwrap();
+        conn.execute(
+            "UPDATE repo_memory_bindings SET logical_symbol_id = ?1 WHERE memory_id = ?2",
+            params![fake_id, memory_id],
+        )
+        .unwrap();
+        conn.execute("DELETE FROM repo_meta WHERE key = 'logical_key_version'", []).unwrap();
+    }
+
+    fs::write(
+        root.join("src/twin.rs"),
+        "pub struct TwinAnchor {\n    pub x: i64,\n}\n\nimpl TwinAnchor {\n    pub fn \
+         probe(&self) -> i64 {\n        self.x\n    }\n}\n\npub fn twin_appendix() {}\n",
+    )
+    .unwrap();
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let bound: i64 = db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT logical_symbol_id FROM repo_memory_bindings WHERE memory_id = ?1",
+            params![memory_id],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_ne!(bound, impl_id, "the heal must not hand the binding to the old-kind decoy");
+    assert_eq!(
+        bound, fake_id,
+        "conflicting cross-kind evidence must match nothing and leave the reference in place"
+    );
+
+    // The relocation ladder — not a heal-time guess — resolves it, preferring the twin whose
+    // stored discriminators (symbol kind + signature hash) agree.
+    db.memory_validate().unwrap();
+    let (relocated_id, status): (i64, String) = db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT logical_symbol_id, anchor_status FROM repo_memory_bindings
+             WHERE memory_id = ?1",
+            params![memory_id],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(status, "relocated", "the ladder owns the conflicted reference");
+    assert_eq!(relocated_id, struct_id, "the ladder's discriminators pick the struct twin");
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+/// #493 review: the heal's `(repo_id, path, logical_name)` candidate probe runs behind a
+/// TRANSIENT index — created for the pass, dropped before it returns — so a moniker-bearing repo
+/// (snapshot ≈ whole table) doesn't go quadratic, and ordinary rebuilds don't pay index
+/// maintenance on their wholesale DELETE + re-INSERT. This pins the cleanup: a heal-armed
+/// rebuild must leave no `logical_symbols_drift_heal_idx` behind.
+#[test]
+fn the_drift_heal_leaves_no_transient_index_behind() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), "pub fn tidy_fn(a: u8) -> u8 { a }\n").unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let tidy_id: i64 = db
+        .storage
+        .connection()
+        .query_row("SELECT id FROM logical_symbols WHERE logical_name = 'tidy_fn'", [], |r| {
+            r.get(0)
+        })
+        .unwrap();
+    // A referenced binding keeps the snapshot non-empty, so the heal actually builds the index.
+    db.memory_create(crate::query::memory::RepoMemoryCreate {
+        kind: "Invariant".to_string(),
+        title: "Keeps the drift snapshot non-empty".to_string(),
+        body: "The heal must build AND drop its transient candidate index.".to_string(),
+        confidence: "high".to_string(),
+        created_by: Some("test-agent".to_string()),
+        source: Some("agent".to_string()),
+        tags: Vec::new(),
+        payload_json: None,
+        bind: crate::query::memory::RepoMemoryBindTarget {
+            logical_symbol_id: Some(tidy_id),
+            symbol_id: None,
+            chunk_id: None,
+            edge_id: None,
+            path: None,
+            start_line: None,
+            end_line: None,
+            commit_hash: None,
+            github_owner: None,
+            github_repo: None,
+            github_number: None,
+            start_logical_symbol_id: None,
+            end_logical_symbol_id: None,
+            edge_sequence_hash: None,
+            path_summary: None,
+            edge_path: None,
+            dir: None,
+        },
+    })
+    .unwrap();
+    db.storage
+        .connection()
+        .execute("DELETE FROM repo_meta WHERE key = 'logical_key_version'", [])
+        .unwrap();
+    drop(db);
+
+    fs::write(
+        root.join("src/lib.rs"),
+        "pub fn tidy_fn(a: u8) -> u8 { a }\n\npub fn tidy_appendix() {}\n",
+    )
+    .unwrap();
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let stamp: String = db
+        .storage
+        .connection()
+        .query_row("SELECT value FROM repo_meta WHERE key = 'logical_key_version'", [], |r| {
+            r.get(0)
+        })
+        .unwrap();
+    assert!(!stamp.is_empty(), "the heal-armed rebuild must stamp the key version");
+    let leftover: i64 = db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT COUNT(*) FROM sqlite_master
+              WHERE type = 'index' AND name = 'logical_symbols_drift_heal_idx'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(leftover, 0, "the transient heal index must not outlive the heal pass");
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+/// #493 review: a PARTIAL pass (incremental edit sweep) re-parses only the changed files, so it
+/// must not stamp `logical_key_version` — untouched files still carry old-derivation symbols
+/// whose ids churn only when they are eventually re-parsed, and an early stamp would switch the
+/// drift heal off with most of the drift still in the future. The pass still RUNS the heal for
+/// whatever drift is visible; only the stamp defers to a whole-corpus pass.
+#[test]
+fn a_partial_pass_heals_without_stamping_the_key_version() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), "pub fn part_fn(a: u8) -> u8 { a }\n").unwrap();
+    // `index_changed` (the incremental entry) needs a git repo to compute the change set.
+    run_git(&root, &["init"]);
+    run_git(&root, &["config", "user.name", "Rag Rat"]);
+    run_git(&root, &["config", "user.email", "rag@example.com"]);
+    run_git(&root, &["add", "."]);
+    run_git(&root, &["commit", "-m", "seed"]);
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let part_id: i64 = db
+        .storage
+        .connection()
+        .query_row("SELECT id FROM logical_symbols WHERE logical_name = 'part_fn'", [], |r| {
+            r.get(0)
+        })
+        .unwrap();
+    let created = db
+        .memory_create(crate::query::memory::RepoMemoryCreate {
+            kind: "Invariant".to_string(),
+            title: "Healed by the partial pass".to_string(),
+            body: "The incremental sweep realigns visible drift but must not stamp.".to_string(),
+            confidence: "high".to_string(),
+            created_by: Some("test-agent".to_string()),
+            source: Some("agent".to_string()),
+            tags: Vec::new(),
+            payload_json: None,
+            bind: crate::query::memory::RepoMemoryBindTarget {
+                logical_symbol_id: Some(part_id),
+                symbol_id: None,
+                chunk_id: None,
+                edge_id: None,
+                path: None,
+                start_line: None,
+                end_line: None,
+                commit_hash: None,
+                github_owner: None,
+                github_repo: None,
+                github_number: None,
+                start_logical_symbol_id: None,
+                end_logical_symbol_id: None,
+                edge_sequence_hash: None,
+                path_summary: None,
+                edge_path: None,
+                dir: None,
+            },
+        })
+        .unwrap();
+    let memory_id = created.memory.memory_id;
+    drop(db);
+
+    let fake_id: i64 = 424244;
+    {
+        let conn = rusqlite::Connection::open(&config.database).unwrap();
+        conn.execute_batch("PRAGMA foreign_keys = OFF;").unwrap();
+        conn.execute("UPDATE logical_symbols SET id = ?1 WHERE id = ?2", params![fake_id, part_id])
+            .unwrap();
+        conn.execute(
+            "UPDATE logical_symbol_members SET logical_symbol_id = ?1
+              WHERE logical_symbol_id = ?2",
+            params![fake_id, part_id],
+        )
+        .unwrap();
+        conn.execute(
+            "UPDATE repo_memory_bindings SET logical_symbol_id = ?1 WHERE memory_id = ?2",
+            params![fake_id, memory_id],
+        )
+        .unwrap();
+        conn.execute("DELETE FROM repo_meta WHERE key = 'logical_key_version'", []).unwrap();
+    }
+
+    // The PARTIAL pass: an incremental sweep over the edited file, not a full rebuild.
+    fs::write(
+        root.join("src/lib.rs"),
+        "pub fn part_fn(a: u8) -> u8 { a }\n\npub fn part_appendix() {}\n",
+    )
+    .unwrap();
+    let db = IndexDatabase::index_changed(&config).unwrap();
+
+    let bound: i64 = db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT logical_symbol_id FROM repo_memory_bindings WHERE memory_id = ?1",
+            params![memory_id],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(bound, part_id, "the partial pass still heals the drift it can see");
+    let stamp: Option<String> = db
+        .storage
+        .connection()
+        .query_row("SELECT value FROM repo_meta WHERE key = 'logical_key_version'", [], |r| {
+            r.get(0)
+        })
+        .optional()
+        .unwrap();
+    assert_eq!(
+        stamp, None,
+        "a partial pass must not stamp the key version — untouched files' drift is still ahead"
+    );
+    drop(db);
+
+    // The whole-corpus pass is what stamps.
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let stamp: Option<String> = db
+        .storage
+        .connection()
+        .query_row("SELECT value FROM repo_meta WHERE key = 'logical_key_version'", [], |r| {
+            r.get(0)
+        })
+        .optional()
+        .unwrap();
+    assert!(stamp.is_some(), "the full rebuild re-derives every file and stamps");
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+/// #493 review: a realigned reference keeps its bind-time relocation discriminators —
+/// `binding_id` (the qualified name), `symbol_kind`, `signature_hash` — unless the heal rewrites
+/// them. Validation treats the live id as current and never repairs those fields, so a LATER
+/// churn or relocation would search with stale evidence and miss (or mis-pick) the twin. The
+/// heal must refresh them from the row the reference now points at.
+#[test]
+fn a_drift_heal_refreshes_the_binding_discriminators() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), "pub fn disc_fn(a: u8) -> u8 { a }\n").unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let disc_id: i64 = db
+        .storage
+        .connection()
+        .query_row("SELECT id FROM logical_symbols WHERE logical_name = 'disc_fn'", [], |r| {
+            r.get(0)
+        })
+        .unwrap();
+    let created = db
+        .memory_create(crate::query::memory::RepoMemoryCreate {
+            kind: "Invariant".to_string(),
+            title: "Discriminators refreshed by the heal".to_string(),
+            body: "A realigned binding must carry current relocation evidence.".to_string(),
+            confidence: "high".to_string(),
+            created_by: Some("test-agent".to_string()),
+            source: Some("agent".to_string()),
+            tags: Vec::new(),
+            payload_json: None,
+            bind: crate::query::memory::RepoMemoryBindTarget {
+                logical_symbol_id: Some(disc_id),
+                symbol_id: None,
+                chunk_id: None,
+                edge_id: None,
+                path: None,
+                start_line: None,
+                end_line: None,
+                commit_hash: None,
+                github_owner: None,
+                github_repo: None,
+                github_number: None,
+                start_logical_symbol_id: None,
+                end_logical_symbol_id: None,
+                edge_sequence_hash: None,
+                path_summary: None,
+                edge_path: None,
+                dir: None,
+            },
+        })
+        .unwrap();
+    let memory_id = created.memory.memory_id;
+    drop(db);
+
+    // Old-derivation storage: the id is fake, and the binding's discriminators are the OLD
+    // derivation's captures — a legacy qualified name, a legacy kind label, a stale signature
+    // hash.
+    let fake_id: i64 = 424245;
+    {
+        let conn = rusqlite::Connection::open(&config.database).unwrap();
+        conn.execute_batch("PRAGMA foreign_keys = OFF;").unwrap();
+        conn.execute("UPDATE logical_symbols SET id = ?1 WHERE id = ?2", params![fake_id, disc_id])
+            .unwrap();
+        conn.execute(
+            "UPDATE logical_symbol_members SET logical_symbol_id = ?1
+              WHERE logical_symbol_id = ?2",
+            params![fake_id, disc_id],
+        )
+        .unwrap();
+        conn.execute(
+            "UPDATE repo_memory_bindings
+                SET logical_symbol_id = ?1, binding_id = 'legacy::disc_fn',
+                    symbol_kind = 'legacy_kind', signature_hash = 'stale-hash'
+              WHERE memory_id = ?2",
+            params![fake_id, memory_id],
+        )
+        .unwrap();
+        conn.execute("DELETE FROM repo_meta WHERE key = 'logical_key_version'", []).unwrap();
+    }
+
+    fs::write(
+        root.join("src/lib.rs"),
+        "pub fn disc_fn(a: u8) -> u8 { a }\n\npub fn disc_appendix() {}\n",
+    )
+    .unwrap();
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let (bound, binding_id, symbol_kind, signature_hash): (i64, String, String, String) = db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT logical_symbol_id, binding_id, symbol_kind, signature_hash
+               FROM repo_memory_bindings WHERE memory_id = ?1",
+            params![memory_id],
+            |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?)),
+        )
+        .unwrap();
+    assert_eq!(bound, disc_id, "the heal realigns the reference onto the re-derived id");
+    let (live_qual, live_kind, live_sig): (String, String, String) = db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT (SELECT value FROM name_strings WHERE id = ls.qualified_name_id),
+                    ls.kind,
+                    (SELECT s.signature FROM logical_symbol_members m
+                       JOIN symbols s ON s.id = m.symbol_id
+                      WHERE m.logical_symbol_id = ls.id LIMIT 1)
+               FROM logical_symbols ls WHERE ls.id = ?1",
+            params![disc_id],
+            |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+        )
+        .unwrap();
+    assert_eq!(binding_id, live_qual, "binding_id must be refreshed to the live qualified name");
+    assert_eq!(symbol_kind, live_kind, "symbol_kind must be refreshed to the live kind");
+    assert_eq!(
+        signature_hash,
+        crate::index::util::hex_sha256(live_sig.trim().as_bytes()),
+        "signature_hash must be refreshed to the live capture's hash"
+    );
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+/// #493 review: `logical_symbol_monikers` has no FK, so a dangling row can sit at ANY id —
+/// including one a drift remap is about to land on (the moniker table survives the wholesale
+/// logical rebuild that killed its row). The phase-2 reference move must displace the stale
+/// occupant, not abort the whole rebuild transaction on the
+/// `(repo_id, logical_symbol_id, tool)` PK.
+#[test]
+fn a_dangling_moniker_at_the_remap_target_does_not_abort_the_heal() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), "pub fn mon_fn(a: u8) -> u8 { a }\n").unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let mon_id: i64 = db
+        .storage
+        .connection()
+        .query_row("SELECT id FROM logical_symbols WHERE logical_name = 'mon_fn'", [], |r| r.get(0))
+        .unwrap();
+    drop(db);
+
+    // Old-derivation storage: the row (with its oracle moniker — the durable reference that
+    // snapshots it) sits on a fake id, while a DANGLING moniker row for the same tool already
+    // occupies the id the heal will realign onto.
+    let fake_id: i64 = 424246;
+    {
+        let conn = rusqlite::Connection::open(&config.database).unwrap();
+        conn.execute_batch("PRAGMA foreign_keys = OFF;").unwrap();
+        conn.execute("UPDATE logical_symbols SET id = ?1 WHERE id = ?2", params![fake_id, mon_id])
+            .unwrap();
+        conn.execute(
+            "UPDATE logical_symbol_members SET logical_symbol_id = ?1
+              WHERE logical_symbol_id = ?2",
+            params![fake_id, mon_id],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO logical_symbol_monikers(repo_id, logical_symbol_id, tool,
+                                                 tool_version, moniker, computed_at)
+             SELECT repo_id, ?1, 'scip-rust', '1', 'live::mon_fn#m', 1
+             FROM logical_symbols WHERE id = ?1",
+            params![fake_id],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO logical_symbol_monikers(repo_id, logical_symbol_id, tool,
+                                                 tool_version, moniker, computed_at)
+             SELECT repo_id, ?1, 'scip-rust', '1', 'dangling::mon_fn#m', 1
+             FROM logical_symbols WHERE id = ?2",
+            params![mon_id, fake_id],
+        )
+        .unwrap();
+        conn.execute("DELETE FROM repo_meta WHERE key = 'logical_key_version'", []).unwrap();
+    }
+
+    fs::write(
+        root.join("src/lib.rs"),
+        "pub fn mon_fn(a: u8) -> u8 { a }\n\npub fn mon_appendix() {}\n",
+    )
+    .unwrap();
+    // Pre-fix this rebuild ABORTS: the phase-2 moniker move onto the re-derived id collides
+    // with the dangling occupant on the (repo_id, logical_symbol_id, tool) PK.
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let monikers: Vec<String> = {
+        let conn = db.storage.connection();
+        let mut stmt = conn
+            .prepare(
+                "SELECT moniker FROM logical_symbol_monikers WHERE logical_symbol_id = ?1
+                 ORDER BY moniker",
+            )
+            .unwrap();
+        stmt.query_map(params![mon_id], |r| r.get(0)).unwrap().map(Result::unwrap).collect()
+    };
+    assert_eq!(
+        monikers,
+        vec!["live::mon_fn#m".to_string()],
+        "the realigned moniker displaces the stale dangling occupant"
+    );
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+/// #493 review: a partial pass that REPLACES the bound file (the single-file heal, the
+/// incremental sweep) deletes its old symbols before the logical rebuild runs — and with them
+/// the snapshot's signature evidence. If the qualified name is what drifted, a late snapshot
+/// then has NO evidence at all and the reference is stranded forever (the old row is gone, so
+/// no later pass can heal it either). The drift snapshot must be captured at PASS ENTRY, before
+/// any file mutation.
+#[test]
+fn drift_evidence_survives_the_partial_pass_that_edits_the_bound_file() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), "pub fn edit_fn(a: u8) -> u8 { a }\n").unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let edit_id: i64 = db
+        .storage
+        .connection()
+        .query_row("SELECT id FROM logical_symbols WHERE logical_name = 'edit_fn'", [], |r| {
+            r.get(0)
+        })
+        .unwrap();
+    let created = db
+        .memory_create(crate::query::memory::RepoMemoryCreate {
+            kind: "Invariant".to_string(),
+            title: "Survives the edit-and-heal pass".to_string(),
+            body: "Evidence must be snapshotted before the pass replaces the file.".to_string(),
+            confidence: "high".to_string(),
+            created_by: Some("test-agent".to_string()),
+            source: Some("agent".to_string()),
+            tags: Vec::new(),
+            payload_json: None,
+            bind: crate::query::memory::RepoMemoryBindTarget {
+                logical_symbol_id: Some(edit_id),
+                symbol_id: None,
+                chunk_id: None,
+                edge_id: None,
+                path: None,
+                start_line: None,
+                end_line: None,
+                commit_hash: None,
+                github_owner: None,
+                github_repo: None,
+                github_number: None,
+                start_logical_symbol_id: None,
+                end_logical_symbol_id: None,
+                edge_sequence_hash: None,
+                path_summary: None,
+                edge_path: None,
+                dir: None,
+            },
+        })
+        .unwrap();
+    let memory_id = created.memory.memory_id;
+
+    // Old-derivation storage with a DRIFTED qualified name: the heal must lean on the member
+    // signature — evidence that lives in the very symbol rows the file replacement deletes.
+    {
+        let conn = db.storage.connection();
+        conn.execute_batch("PRAGMA foreign_keys = OFF;").unwrap();
+        let fake_id: i64 = 424247;
+        conn.execute("INSERT OR IGNORE INTO name_strings(value) VALUES ('legacy::edit_fn')", [])
+            .unwrap();
+        conn.execute(
+            "UPDATE logical_symbols
+                SET id = ?1,
+                    qualified_name_id =
+                        (SELECT id FROM name_strings WHERE value = 'legacy::edit_fn')
+              WHERE id = ?2",
+            params![fake_id, edit_id],
+        )
+        .unwrap();
+        conn.execute(
+            "UPDATE logical_symbol_members SET logical_symbol_id = ?1
+              WHERE logical_symbol_id = ?2",
+            params![fake_id, edit_id],
+        )
+        .unwrap();
+        conn.execute(
+            "UPDATE repo_memory_bindings SET logical_symbol_id = ?1 WHERE memory_id = ?2",
+            params![fake_id, memory_id],
+        )
+        .unwrap();
+        conn.execute("DELETE FROM repo_meta WHERE key = 'logical_key_version'", []).unwrap();
+        conn.execute_batch("PRAGMA foreign_keys = ON;").unwrap();
+    }
+
+    // The PARTIAL pass: heal_file replaces the file in place (remove + reindex) and then runs
+    // the logical rebuild — the old symbols die mid-pass.
+    fs::write(
+        root.join("src/lib.rs"),
+        "pub fn edit_fn(a: u8) -> u8 { a }\n\npub fn edit_appendix() {}\n",
+    )
+    .unwrap();
+    db.heal_file(Path::new("src/lib.rs")).unwrap();
+
+    let bound: i64 = db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT logical_symbol_id FROM repo_memory_bindings WHERE memory_id = ?1",
+            params![memory_id],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        bound, edit_id,
+        "the heal must realign via the signature evidence captured BEFORE the file replacement"
+    );
+    let stamp: Option<String> = db
+        .storage
+        .connection()
+        .query_row("SELECT value FROM repo_meta WHERE key = 'logical_key_version'", [], |r| {
+            r.get(0)
+        })
+        .optional()
+        .unwrap();
+    assert_eq!(stamp, None, "the single-file heal is a partial pass and must not stamp");
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+/// #493 review: a full rebuild that CARRIES live linked-worktree overlay rows forward re-parses
+/// the base scope only — the carried symbols keep their old derivation. Stamping the key
+/// version over them would let the next overlay refresh see a current stamp, skip the drift
+/// snapshot, and strand the overlay's references. With overlays carried, the stamp must defer;
+/// a rebuild with none stamps as usual.
+#[test]
+fn a_rebuild_carrying_overlays_defers_the_key_version_stamp() {
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(main.join("src/lib.rs"), "pub fn carry_fn(a: u8) -> u8 { a }\n").unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let config = source_config(main.clone(), Language::Rust);
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+    let stamp = |db: &IndexDatabase| -> Option<String> {
+        db.storage
+            .connection()
+            .query_row("SELECT value FROM repo_meta WHERE key = 'logical_key_version'", [], |r| {
+                r.get(0)
+            })
+            .optional()
+            .unwrap()
+    };
+    assert!(stamp(&db).is_some(), "the overlay-free rebuild stamps");
+
+    // A live linked-worktree overlay whose rows the next full rebuild will carry forward.
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat-carry", linked.to_str().unwrap()]);
+    fs::write(linked.join("src/lib.rs"), "pub fn carry_fn(a: u8) -> u8 { a + 1 }\n").unwrap();
+    let report = db.index_worktree_overlay(&config, &linked, &mut |_| {}).unwrap();
+    assert!(report.indexed >= 1, "the branch edit is indexed as an overlay row");
+    // The derivation bump arrives while the overlay is live.
+    db.storage
+        .connection()
+        .execute("DELETE FROM repo_meta WHERE key = 'logical_key_version'", [])
+        .unwrap();
+    drop(db);
+
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    assert_eq!(
+        stamp(&db),
+        None,
+        "a rebuild that carried overlay rows must defer the stamp — their symbols were not \
+         re-derived"
+    );
+    drop(db);
+
+    // Once the overlay rows are gone, the next rebuild's corpus is exactly what it re-parses.
+    {
+        let conn = rusqlite::Connection::open(&config.database).unwrap();
+        conn.execute_batch("PRAGMA foreign_keys = OFF;").unwrap();
+        conn.execute("DELETE FROM files WHERE commit_sha = ''", []).unwrap();
+    }
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    assert!(stamp(&db).is_some(), "an overlay-free rebuild stamps again");
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}
+
+/// #493 review: the stamp gate must count ALL rows `carry_forward_live_overlays` moves forward,
+/// not just linked-worktree overlays. An OTHER-COMMIT committed leftover (`worktree_id = ''`, a
+/// prior HEAD's retained rows) is carried un-reparsed — its `worktree_id = ''` differs from the
+/// active checkout's `worktree_id` (the canonical path), and its commit differs from the active
+/// HEAD — yet `carried_overlay_worktrees` (which returns only `worktree_id != ''`) excludes it.
+/// Gating on `carried_overlays.is_empty()` would stamp a stale key version over those carried
+/// rows; gating on the carried-row COUNT defers correctly.
+#[test]
+fn a_rebuild_carrying_a_committed_leftover_defers_the_stamp() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), "pub fn leftover_fn(a: u8) -> u8 { a }\n").unwrap();
+    init_git_repo(&root);
+    run_git(&root, &["add", "."]);
+    run_git(&root, &["commit", "-q", "-m", "commit A"]);
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let stamp = |db: &IndexDatabase| -> Option<String> {
+        db.storage
+            .connection()
+            .query_row("SELECT value FROM repo_meta WHERE key = 'logical_key_version'", [], |r| {
+                r.get(0)
+            })
+            .optional()
+            .unwrap()
+    };
+    assert!(stamp(&db).is_some(), "the clean rebuild stamps");
+    let repo_id = db.active_repo_id.clone();
+    let live =
+        crate::index::schema::live_files_generation(db.storage.connection(), &repo_id).unwrap();
+    // Seed an other-commit committed leftover (worktree_id = '') at the live generation — the
+    // #502 HEAD-move retention shape. Not a worktree overlay, so carried_overlay_worktrees skips
+    // it, but carry_forward_live_overlays carries it (its commit differs from the active HEAD and
+    // its '' worktree_id differs from the active checkout path).
+    db.storage
+        .connection()
+        .execute(
+            "INSERT INTO main.files (path, language, kind, sha256, modified_at_ms, generated,
+                                indexed_at_ms, indexed_revision, commit_sha, worktree_id,
+                                has_test_code, repo_id, generation)
+             VALUES ('src/leftover_extra.rs', 'rust', 'source', 'stale', 0, 0, 0, '',
+                     'stalecommit0000', '', 0, ?1, ?2)",
+            params![repo_id, live],
+        )
+        .unwrap();
+    db.storage
+        .connection()
+        .execute("DELETE FROM repo_meta WHERE key = 'logical_key_version'", [])
+        .unwrap();
+    drop(db);
+
+    // Rebuild (HEAD unchanged): the seeded leftover is carried un-reparsed, so — even though there
+    // are NO worktree overlays — the stamp must defer.
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    assert_eq!(
+        stamp(&db),
+        None,
+        "a rebuild carrying an other-commit committed leftover must defer the stamp, not stamp \
+         over its un-reparsed rows"
+    );
+
+    let _ = fs::remove_dir_all(&root);
+}

--- a/crates/rag-rat-core/src/index/worktree_overlay.rs
+++ b/crates/rag-rat-core/src/index/worktree_overlay.rs
@@ -450,7 +450,10 @@ impl IndexDatabase {
         pruned: usize,
     ) -> anyhow::Result<()> {
         if indexed > 0 || tombstoned > 0 || pruned > 0 {
-            self.rebuild_logical_symbols()?;
+            // Defer: an overlay refresh re-parsed only the worktree's own files, so it must not
+            // stamp the logical-key version — the base scope's drift is still in the future
+            // (#493).
+            self.rebuild_logical_symbols(graph_index::KeyVersionStamp::Defer)?;
             self.refresh_packages(source_root)?;
             self.resolve_overlay_edges(worktree_id)?;
             self.sync_fts()?;


### PR DESCRIPTION
A logical symbol's stable id hashes `(repo_id, language, path, name, qualified_name, kind, signature)`. Three of those inputs are parser/normalizer artifacts: a grammar bump or a signature-capture / kind / qualified-name derivation change churns every logical id in a repo at its next rebuild, stranding all logical-symbol memory bindings, call-path endpoints, and oracle monikers at once. `realign_logical_symbol_ids` can't help — it recomputes ids from the *stored* (old-derivation) field values, so it reproduces the old ids.

## Design

- **`LOGICAL_KEY_VERSION`**, stamped per-repo in `repo_meta` (the `graph_index_version` pattern): bump it whenever `LogicalSymbolKey`'s derivation changes semantics. Only a whole-corpus pass stamps — the full rebuild (when it carried no overlay rows; carried symbols are not reparsed) and the fresh-index standalone pass. Partial passes (incremental sweep, single-file heal, worktree overlay refresh) heal what is visible but defer the stamp: untouched files' drift is still in the future, and an early stamp would strand it permanently.
- **Heal inside `rebuild_logical_symbols`**: on a stamp mismatch, snapshot the *referenced* old rows before the clear (bounded by durable references, never the whole table), then realign each drifted id onto the new row matching `(path, name, kind)` with qualified-name OR signature agreement — the same discriminator evidence as the #491/#494 relocation twins. Group signatures count only when every member carries the same non-null capture. Multiple eligibles narrow to both-axes agreement; a kind-relaxed pass covers kind-classification drift; a strict winner carried by a single axis is vetoed when a cross-kind twin agrees on the axis it lacks (the decoy shape). Ambiguity and target collisions match nothing and fall to the validate-time relocation ladder — a confidently mis-anchored memory is worse than a flagged one.
- **Evidence survives partial passes**: the snapshot is memoized by a pass's first `remove_file_in_scope` — a partial pass deletes an edited file's old symbols (the signature evidence) before the logical rebuild runs, and one unhealed rebuild destroys the old rows forever. Idle passes remove nothing and never pay the scan.
- **Occupied ids**: an old id occupied by a different symbol's re-derived row realigns by evidence like a vanished one; without a winner its references are vacated to a sentinel so the ladder relocates them visibly instead of validating a live wrong id as healthy. In-place winners keep their references.
- **Discriminator refresh**: realigned references get their bind-time `binding_id` / `symbol_kind` / `signature_hash` rewritten from the row they now point at, so a later churn or relocation searches with current evidence. A moniker moving onto an id already occupied by a stale dangling row for the same tool displaces it instead of aborting the rebuild on the moniker PK.
- **Scale**: the candidate probe runs behind a transient `(repo_id, path, logical_name)` index — built for the heal, dropped before it returns — so a moniker-bearing repo (snapshot close to the whole table) doesn't go quadratic, and ordinary rebuilds pay no index maintenance.

## Tests

18 new tests covering: end-to-end drift heal (full and partial passes), the version gate, overload-twin ambiguity, qualified-name drift via signature agreement, kind drift via the relaxed pass, the cross-kind decoy veto, mixed-NULL and disagreeing member signatures, occupied-id realign/vacate/bijectivity (incl. moniker PK collisions and the dangling-occupant displacement), in-place winners surviving the vacate sweep, discriminator refresh, partial-pass stamp deferral (incremental + single-file heal), carried-overlay stamp deferral, and transient-index cleanup.

Fixes #493