### PR TITLE
Op-authoring helper + full backfill of existing memories (phase B, unwired)

### DIFF
--- a/crates/rag-rat-core/src/oplog/identity.rs
+++ b/crates/rag-rat-core/src/oplog/identity.rs
@@ -29,17 +29,22 @@ pub(crate) struct LocalDevice {
 }
 
 impl LocalDevice {
-    /// The signing capability — the authoring seam signs entry bodies with this.
-    pub(crate) fn secret(&self) -> &DeviceSecret {
+    /// The signing capability — the authoring seam signs entry bodies with this. `pub(super)`: the
+    /// secret (and `DeviceSecret` itself) stay oplog-internal; the store's authoring path is the
+    /// only caller. Cross-module callers author under a whole `&LocalDevice`, never the raw secret.
+    pub(super) fn secret(&self) -> &DeviceSecret {
         &self.secret
     }
 
-    /// The verifying key (for a local self-verify or to hand a peer).
-    pub(crate) fn public(&self) -> DevicePublic {
+    /// The verifying key (for a local self-verify). `pub(super)` to match `DevicePublic`'s
+    /// oplog-internal visibility.
+    pub(super) fn public(&self) -> DevicePublic {
         self.public
     }
 
-    /// The opaque device fingerprint the op model + signed entry body carry.
+    /// The opaque device fingerprint the op model + signed entry body carry. `pub(crate)` — the
+    /// authoring seam in `query::memory` passes it to `chain_tail`; `DeviceFingerprint` is likewise
+    /// crate-visible.
     pub(crate) fn fingerprint(&self) -> DeviceFingerprint {
         self.fingerprint
     }

--- a/crates/rag-rat-core/src/oplog/mod.rs
+++ b/crates/rag-rat-core/src/oplog/mod.rs
@@ -40,3 +40,19 @@ mod op;
 mod project;
 mod store;
 mod stream;
+
+// The op-log's first crate-internal API surface (#524): the MINTING primitives + the op vocabulary
+// the memory subsystem needs to author + backfill entries. Every submodule above is otherwise
+// private, so this curated re-export is the ONE seam `query::memory` reaches through — and the only
+// direction of the dependency (`oplog` never depends back on `query::memory`).
+pub(crate) use identity::local_device;
+pub(crate) use op::{EdgeSpec, MemoryOp, NodeContent, NodeId, NodeStatus};
+// The rest of the minting API completes the frozen surface but is unconsumed until the
+// live-wiring increment: `author_in_tx` / `author_op` mint ONE op (composed into a mutation
+// txn, or standalone), and `author_batch` is the standalone genesis-batch wrapper (the
+// backfill instead drives `author_genesis_in_tx` inside the txn it opens to snapshot memories
+// atomically).
+#[allow(unused_imports)]
+pub(crate) use store::{author_batch, author_in_tx, author_op};
+pub(crate) use store::{author_genesis_in_tx, chain_tail};
+pub(crate) use stream::owner_stream;

--- a/crates/rag-rat-core/src/oplog/store.rs
+++ b/crates/rag-rat-core/src/oplog/store.rs
@@ -23,9 +23,10 @@ use serde::{Deserialize, Serialize};
 
 use super::device::DevicePublic;
 use super::entry::{self, VerifiedEntry};
+use super::identity::LocalDevice;
 use super::op::{
-    self, DecodedOp, DeviceFingerprint, EdgeKey, EdgeSpec, Entry, NodeContent, NodeId, NodeStatus,
-    OpMeta, ResolvedAnchor,
+    self, DecodedOp, DeviceFingerprint, EdgeKey, EdgeSpec, Entry, MemoryOp, NodeContent, NodeId,
+    NodeStatus, OpMeta, ResolvedAnchor,
 };
 use super::project::{self, ProjectedEdge, ProjectedNode, ProjectedState};
 use super::stream::StreamId;
@@ -150,17 +151,128 @@ pub(crate) fn append(
     }
 
     insert_entry(&tx, &verified, lamport, signed_bytes, now_ms)?;
-    match stored_projector_version(&tx)? {
-        // The projection is already current: only the appended stream's fold moved.
-        Some(version) if version == PROJECTOR_VERSION => reproject(&tx, stream)?,
-        // An older (or missing) stamp means every OTHER stream's fold is stale too, and the
-        // store-global stamp written below would mark them all current — so this append must
-        // sweep every stream, not just its own, or a quiet stream keeps its stale rows forever.
-        _ => reproject_all_streams(&tx)?,
-    }
+    reproject_after_write(&tx, stream)?;
     stamp_projector_version(&tx)?;
     tx.commit()?;
     Ok(AppendOutcome::Appended { entry_hash: verified.entry_hash })
+}
+
+/// Re-fold after a write, then the caller stamps: only the touched `stream` when the projector
+/// stamp is already current, else EVERY stream. An older (or missing) stamp means every OTHER
+/// stream's fold is stale too, and the store-global stamp written next would mark them all current
+/// — so the write must sweep every stream, not just its own, or a quiet stream keeps its stale rows
+/// forever. Shared by [`append`] and the authoring path.
+fn reproject_after_write(tx: &Transaction<'_>, stream: StreamId) -> anyhow::Result<()> {
+    match stored_projector_version(tx)? {
+        Some(version) if version == PROJECTOR_VERSION => reproject(tx, stream)?,
+        _ => reproject_all_streams(tx)?,
+    }
+    Ok(())
+}
+
+/// Author one NEW entry on `stream` WITHIN a caller-provided transaction: allocate the next Lamport
+/// from the local chain tail, sign, insert, and re-fold the projection — but neither open nor
+/// commit the txn. This is the seam a live memory mutation uses to make its row write and this
+/// op-append ONE atomic unit: it cannot call the self-transacting [`author_op`] from inside its own
+/// `IMMEDIATE` txn (SQLite has no nested transactions), and splitting them across two txns leaves a
+/// crash window where only one side commits. Genesis when the chain is empty. Unlike [`append`]
+/// (which accepts a foreign, pre-signed entry and may Fork), this MINTS a valid continuation from
+/// the tail it just read, so under the single local writer it is always continuous. Returns the new
+/// `entry_hash`.
+pub(crate) fn author_in_tx(
+    tx: &Transaction<'_>,
+    stream: StreamId,
+    device: &LocalDevice,
+    op: &MemoryOp,
+    now_ms: i64,
+) -> anyhow::Result<[u8; 32]> {
+    assert_projector_not_newer(tx)?;
+    let entry_hash = author_one(tx, stream, device, op, now_ms)?;
+    reproject_after_write(tx, stream)?;
+    stamp_projector_version(tx)?;
+    Ok(entry_hash)
+}
+
+/// Author one entry in its OWN `IMMEDIATE` txn — the standalone wrapper over [`author_in_tx`] for a
+/// caller that is NOT already inside a transaction (the op-append is the whole unit of work).
+pub(crate) fn author_op(
+    conn: &Connection,
+    stream: StreamId,
+    device: &LocalDevice,
+    op: &MemoryOp,
+    now_ms: i64,
+) -> anyhow::Result<[u8; 32]> {
+    let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
+    let entry_hash = author_in_tx(&tx, stream, device, op, now_ms)?;
+    tx.commit()?;
+    Ok(entry_hash)
+}
+
+/// Author `ops` as the GENESIS batch of `stream` WITHIN a caller-provided txn — gate on an empty
+/// chain, then chain every entry from genesis with a SINGLE projection re-fold at the end, but
+/// NEITHER open NOR commit. The empty-chain gate lives INSIDE the txn (the caller's), so two
+/// concurrent first-authoring callers converge: the winner authors genesis→N, and the loser —
+/// serialized behind the winner's write — sees a non-empty chain and no-ops. Returns whether it
+/// authored (`false` = a chain already existed). The backfill opens its OWN `IMMEDIATE` txn, reads
+/// the memory snapshot UNDER that write lock, and calls this so the snapshot read + gate + write
+/// are one atomic unit (no memory created between the read and the batch is lost from the history).
+pub(crate) fn author_genesis_in_tx(
+    tx: &Transaction<'_>,
+    stream: StreamId,
+    device: &LocalDevice,
+    ops: &[MemoryOp],
+    now_ms: i64,
+) -> anyhow::Result<bool> {
+    assert_projector_not_newer(tx)?;
+    if chain_tail(tx, stream, device.fingerprint())?.is_some() {
+        return Ok(false);
+    }
+    for op in ops {
+        // The tail read sees prior in-txn inserts, so each op chains off the one before it.
+        author_one(tx, stream, device, op, now_ms)?;
+    }
+    reproject_after_write(tx, stream)?;
+    stamp_projector_version(tx)?;
+    Ok(true)
+}
+
+/// [`author_genesis_in_tx`] in its OWN `IMMEDIATE` txn — the standalone wrapper for a caller that
+/// does not need to read a snapshot under the same write lock. Empty `ops` is a no-op.
+pub(crate) fn author_batch(
+    conn: &Connection,
+    stream: StreamId,
+    device: &LocalDevice,
+    ops: &[MemoryOp],
+    now_ms: i64,
+) -> anyhow::Result<bool> {
+    if ops.is_empty() {
+        return Ok(false);
+    }
+    let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
+    let authored = author_genesis_in_tx(&tx, stream, device, ops, now_ms)?;
+    tx.commit()?;
+    Ok(authored)
+}
+
+/// Read the `(stream, device)` tail, mint the next entry for `op` (genesis when the chain is
+/// empty), and INSERT it — no projection (the caller re-folds once). MUST run inside a txn so the
+/// tail read sees prior in-txn inserts, which is what lets [`author_batch`] chain a whole sequence.
+fn author_one(
+    tx: &Transaction<'_>,
+    stream: StreamId,
+    device: &LocalDevice,
+    op: &MemoryOp,
+    now_ms: i64,
+) -> anyhow::Result<[u8; 32]> {
+    let (lamport, prev_hash) = match chain_tail(tx, stream, device.fingerprint())? {
+        Some(tail) => (tail.lamport + 1, Some(tail.entry_hash)),
+        None => (0, None),
+    };
+    let signed = entry::sign_entry(device.secret(), stream, prev_hash, lamport, op);
+    let lamport = i64::try_from(lamport)
+        .map_err(|_| anyhow::anyhow!("op-log lamport {lamport} exceeds i64"))?;
+    insert_entry(tx, &signed.entry, lamport, &signed.signed_bytes, now_ms)?;
+    Ok(signed.entry.entry_hash)
 }
 
 /// Where an incoming entry sits relative to a device's stored chain.
@@ -820,6 +932,82 @@ mod tests {
         let projected = load_projection(&conn, stream_a()).unwrap();
         assert_eq!(projected.nodes.len(), 3);
         assert!(projected.nodes.contains_key(&NodeId::from("mem_a")));
+    }
+
+    #[test]
+    fn author_op_mints_a_genesis_chain_and_projects() {
+        let conn = db();
+        let device = crate::oplog::local_device(&conn, 0).unwrap();
+        // The FIRST authored op is genesis (lamport 0), each next advances by one — the allocator
+        // reads the tail, unlike `append` which is fed a caller-chosen lamport.
+        let h0 = author_op(&conn, stream_a(), &device, &create("mem_a", "first"), 1_000).unwrap();
+        let h1 = author_op(&conn, stream_a(), &device, &create("mem_b", "second"), 1_001).unwrap();
+        let h2 = author_op(&conn, stream_a(), &device, &create("mem_c", "third"), 1_002).unwrap();
+        assert_ne!(h0, h1, "each authored entry is distinct");
+        let tail = chain_tail(&conn, stream_a(), device.fingerprint()).unwrap().unwrap();
+        assert_eq!(tail.lamport, 2, "three authored ops occupy lamports 0,1,2");
+        assert_eq!(tail.entry_hash, h2);
+        assert_eq!(entry_count(&conn), 3);
+        let projected = load_projection(&conn, stream_a()).unwrap();
+        assert_eq!(projected.nodes.len(), 3);
+        assert!(projected.nodes.contains_key(&NodeId::from("mem_a")));
+    }
+
+    #[test]
+    fn author_in_tx_commits_atomically_with_a_caller_write() {
+        let conn = db();
+        let device = crate::oplog::local_device(&conn, 0).unwrap();
+        // A live mutation: a table write and the op-append share ONE caller-owned txn.
+        let tx = Transaction::new_unchecked(&conn, TransactionBehavior::Immediate).unwrap();
+        tx.execute("CREATE TABLE probe(x INTEGER)", []).unwrap();
+        tx.execute("INSERT INTO probe(x) VALUES (1)", []).unwrap();
+        author_in_tx(&tx, stream_a(), &device, &create("mem_a", "first"), 1_000).unwrap();
+        tx.commit().unwrap();
+        // Both sides landed under the one commit.
+        assert_eq!(entry_count(&conn), 1);
+        assert_eq!(load_projection(&conn, stream_a()).unwrap().nodes.len(), 1);
+    }
+
+    #[test]
+    fn author_in_tx_rolls_back_with_the_caller_transaction() {
+        let conn = db();
+        let device = crate::oplog::local_device(&conn, 0).unwrap();
+        let tx = Transaction::new_unchecked(&conn, TransactionBehavior::Immediate).unwrap();
+        author_in_tx(&tx, stream_a(), &device, &create("mem_a", "first"), 1_000).unwrap();
+        drop(tx); // roll back the caller's txn
+        assert_eq!(entry_count(&conn), 0, "the authored entry rolls back with the caller's txn");
+    }
+
+    #[test]
+    fn author_batch_writes_one_atomic_chain_and_an_empty_batch_is_a_noop() {
+        let conn = db();
+        let device = crate::oplog::local_device(&conn, 0).unwrap();
+        let authored = author_batch(&conn, stream_a(), &device, &[], 1_000).unwrap();
+        assert!(!authored, "an empty batch authors nothing");
+        assert_eq!(entry_count(&conn), 0);
+
+        let ops = [create("mem_a", "a"), create("mem_b", "b"), create("mem_c", "c")];
+        assert!(
+            author_batch(&conn, stream_a(), &device, &ops, 2_000).unwrap(),
+            "the genesis batch authored"
+        );
+        let tail = chain_tail(&conn, stream_a(), device.fingerprint()).unwrap().unwrap();
+        assert_eq!(tail.lamport, 2, "the batch chained lamports 0,1,2 in one txn");
+        assert_eq!(entry_count(&conn), 3);
+        assert_eq!(load_projection(&conn, stream_a()).unwrap().nodes.len(), 3);
+    }
+
+    #[test]
+    fn author_batch_no_ops_on_a_nonempty_chain() {
+        let conn = db();
+        let device = crate::oplog::local_device(&conn, 0).unwrap();
+        author_op(&conn, stream_a(), &device, &create("mem_a", "genesis"), 1_000).unwrap();
+        // author_batch is a GENESIS gate: on an already-non-empty chain it no-ops (returns false)
+        // rather than appending — that atomic gate is the backfill's idempotency guarantee.
+        let authored =
+            author_batch(&conn, stream_a(), &device, &[create("mem_b", "b")], 2_000).unwrap();
+        assert!(!authored, "a genesis batch no-ops on a non-empty chain");
+        assert_eq!(entry_count(&conn), 1, "the non-empty chain is left untouched");
     }
 
     #[test]

--- a/crates/rag-rat-core/src/query/memory/authoring.rs
+++ b/crates/rag-rat-core/src/query/memory/authoring.rs
@@ -1,0 +1,421 @@
+//! Translating persisted memories into signed op-log entries, and the one-time full backfill of a
+//! store's pre-existing memories into the log (#524).
+//!
+//! This bridges `repo_memories` / `repo_node_edges` (owned by this module) and the op-log MINTING
+//! primitives ([`crate::oplog`]) — a ONE-WAY dependency, so `oplog` never depends back on the
+//! memory subsystem (the next increment adds the reverse call, `create_memory` → author, and a
+//! cycle would break the build).
+//!
+//! NOT wired into the live write path yet: [`backfill_memory_oplog`] is exercised in isolation. The
+//! next increment calls it before the first live-authored mutation and reuses [`memory_to_ops`] for
+//! the mutations themselves.
+
+use rusqlite::{Connection, Transaction, TransactionBehavior, params};
+
+use super::hydrate::tags_for_memory;
+use super::{EdgeRelation, NodeEdge, all_edges_from, memory_repo_scope};
+use crate::oplog::{
+    EdgeSpec, MemoryOp, NodeContent, NodeId, NodeStatus, author_genesis_in_tx, chain_tail,
+    local_device, owner_stream,
+};
+
+/// One memory's projectable content — the columns the op model carries (NOT the identity / anchor /
+/// dedup bookkeeping). Read in bulk so the backfill makes one pass over `repo_memories`.
+struct MemoryRow {
+    memory_id: String,
+    kind: String,
+    title: String,
+    body: String,
+    confidence: String,
+    status: String,
+    source: String,
+    payload_json: Option<String>,
+    tags: Vec<String>,
+}
+
+/// Translate one memory into its op sequence: a `NodeCreate` for content, a `NodeStatus` ONLY when
+/// the status is not the fold's `active` create-time default, and an `EdgeAdd` per outgoing typed
+/// node-edge (in `edge_key` order, so the authored chain is reproducible). Code-anchor BINDINGS are
+/// excluded — they are per-device derived resolution state, re-validated locally, and never part of
+/// the shared node graph the projection models.
+fn memory_to_ops(
+    row: &MemoryRow,
+    owner_repo_id: &str,
+    edges: &[NodeEdge],
+) -> anyhow::Result<Vec<MemoryOp>> {
+    let node_id = NodeId::from(row.memory_id.as_str());
+    let mut ops = vec![MemoryOp::NodeCreate {
+        node_id: node_id.clone(),
+        content: NodeContent {
+            kind: row.kind.clone(),
+            title: row.title.clone(),
+            body: row.body.clone(),
+            confidence: row.confidence.clone(),
+            source: row.source.clone(),
+            tags: row.tags.clone(),
+            payload: row.payload_json.clone(),
+        },
+    }];
+    // `active` is the fold's create-time default, so it needs no op. A status token this binary
+    // does NOT recognize (a newer binary's future status) must NOT be silently dropped — that would
+    // permanently mint this row as `active` in the SIGNED history, and a signed op cannot be
+    // corrected later. FAIL the backfill instead, so a binary that understands the token authors
+    // it.
+    if row.status != NodeStatus::default().as_db_str() {
+        let status = NodeStatus::from_db_str(&row.status).ok_or_else(|| {
+            anyhow::anyhow!(
+                "cannot backfill memory `{}`: unknown status token `{}` (a newer binary must \
+                 author this history)",
+                row.memory_id,
+                row.status
+            )
+        })?;
+        ops.push(MemoryOp::NodeStatus { node_id: node_id.clone(), status });
+    }
+    // An `EdgeAdd` ONLY — deliberately NO `Rebind`. `EdgeAdd` carries the edge's presence and the
+    // DURABLE spec (incl. the `target_repo_id` `all_edges_from` re-resolved to current). The
+    // `Rebind` op's resolved dimension (`target_node_id`, `anchor_status`) is PER-DEVICE
+    // derived state: `anchor_status` (current/gone/unresolved — is the target present in THIS
+    // db) differs by device and is recomputed on every read by `reresolve_on_read`. Signing it
+    // into the immutable shared history would bake one device's view into the log — excluded
+    // for the same reason code-anchor BINDINGS are. The projection's `resolved` column stays
+    // NULL for a backfilled edge; the reader recomputes it locally, exactly as the live edge
+    // table does.
+    let mut edges = edges.to_vec();
+    edges.sort_by(|a, b| a.edge_key.cmp(&b.edge_key));
+    for edge in &edges {
+        ops.push(MemoryOp::EdgeAdd {
+            edge: EdgeSpec {
+                source_node_id: NodeId::from(edge.source_node_id.as_str()),
+                relation: EdgeRelation::from_db_str(&edge.relation)?,
+                target_repo_id: edge.target_repo_id.clone(),
+                target_kind: edge.target_kind.clone(),
+                target_anchor: edge.target_anchor.clone(),
+                owner_repo_id: owner_repo_id.to_string(),
+            },
+        });
+    }
+    Ok(ops)
+}
+
+/// Author every one of the active repo's pre-existing memories into its owner stream — the one-time
+/// full backfill that makes the op-log the complete signed history from genesis. Idempotent and
+/// scope-gated:
+/// - a NO-OP on an unscoped database (no active repo → no owner stream to root the log on);
+/// - a NO-OP once the owner chain is non-empty: because [`crate::oplog::author_batch`] is atomic, a
+///   non-empty chain is a COMPLETED backfill (no partial state to resume). The next increment's
+///   "backfill before the first live author" ordering keeps this gate correct once live ops share
+///   the chain.
+///
+/// Memories are ordered deterministically `(created_at_ms, memory_id)` — a reproducible Lamport
+/// assignment. Each contributes NodeCreate, then a NodeStatus when non-active, then its EdgeAdds.
+/// ALL statuses are backfilled (obsolete/rejected included): the log is the whole history.
+pub(crate) fn backfill_memory_oplog(conn: &Connection, now_ms: i64) -> anyhow::Result<()> {
+    let Some(repo_id) = memory_repo_scope(conn)? else {
+        return Ok(());
+    };
+    // Only a STABLE repo id may root an IMMUTABLE owner stream. Two ids get re-pointed later, which
+    // would strand a stream signed under the old id: the legacy `__unassigned__` placeholder (an
+    // unadopted DB, re-pointed on adoption) and a machine-local `local:` shallow-clone id (upgraded
+    // to a portable id when the clone is deepened). No-op until a stable id is active — as if
+    // unscoped.
+    if repo_id == crate::index::schema::LEGACY_REPO_ID
+        || repo_id.starts_with(crate::repo_identity::LOCAL_ONLY_ID_PREFIX)
+    {
+        return Ok(());
+    }
+    let stream = owner_stream(&repo_id)?;
+    let device = local_device(conn, now_ms)?;
+    // Cheap fast-path: skip opening the write txn when a chain already exists. NOT the correctness
+    // gate — `author_genesis_in_tx` re-checks emptiness inside the txn below.
+    if chain_tail(conn, stream, device.fingerprint())?.is_some() {
+        return Ok(());
+    }
+    // ATOMIC snapshot: open the write txn FIRST — the `IMMEDIATE` lock blocks concurrent memory
+    // writers — THEN read the memory/edge snapshot and author it, so a memory created between the
+    // read and the batch cannot be silently omitted from the complete history (after which the
+    // idempotency gate would hide it forever). The empty-chain gate is re-checked inside this txn.
+    let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
+    let mut ops = Vec::new();
+    for row in read_memory_rows(&tx, &repo_id)? {
+        // `all_edges_from`, not `edges_from`: a backfilled obsolete/rejected memory still carries
+        // its persisted edges into the complete-history log (the live reader hides them).
+        let edges = all_edges_from(&tx, &row.memory_id)?;
+        ops.extend(memory_to_ops(&row, &repo_id, &edges)?);
+    }
+    author_genesis_in_tx(&tx, stream, &device, &ops, now_ms)?;
+    tx.commit()?;
+    Ok(())
+}
+
+/// The active repo's memories in deterministic `(created_at_ms, memory_id)` order, tags attached.
+fn read_memory_rows(conn: &Connection, repo_id: &str) -> anyhow::Result<Vec<MemoryRow>> {
+    let mut stmt = conn.prepare(
+        "SELECT id, kind, title, body, confidence, status, source, payload_json
+         FROM repo_memories WHERE repo_id = ?1 ORDER BY created_at_ms, id",
+    )?;
+    let mut rows = stmt
+        .query_map(params![repo_id], |row| {
+            Ok(MemoryRow {
+                memory_id: row.get(0)?,
+                kind: row.get(1)?,
+                title: row.get(2)?,
+                body: row.get(3)?,
+                confidence: row.get(4)?,
+                status: row.get(5)?,
+                source: row.get(6)?,
+                payload_json: row.get(7)?,
+                tags: Vec::new(),
+            })
+        })?
+        .collect::<Result<Vec<_>, _>>()?;
+    for row in &mut rows {
+        // Reuse the memory subsystem's own tag reader (the op encoder sorts + dedupes anyway).
+        row.tags = tags_for_memory(conn, &row.memory_id)?;
+    }
+    Ok(rows)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const REPO: &str = "repo-a";
+
+    /// A DB with the memory schema, one registered repo, and the connection scoped to it — the
+    /// minimal setup `memory_repo_scope` needs to resolve an active repo.
+    fn scoped_conn() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("PRAGMA foreign_keys = ON;").unwrap();
+        crate::index::schema::apply(&conn).unwrap();
+        conn.execute(
+            "INSERT INTO repos(repo_id, display_name, registered_at_ms) VALUES (?1, ?1, 0)",
+            [REPO],
+        )
+        .unwrap();
+        conn.execute_batch(
+            "CREATE TEMP TABLE IF NOT EXISTS connection_context(key TEXT PRIMARY KEY, value TEXT);",
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT OR REPLACE INTO temp.connection_context(key, value) VALUES ('repo_id', ?1)",
+            [REPO],
+        )
+        .unwrap();
+        conn
+    }
+
+    fn insert_memory(conn: &Connection, id: &str, status: &str, created_at_ms: i64) {
+        conn.execute(
+            "INSERT INTO repo_memories(
+                 id, kind, title, body, confidence, status, created_by, created_at_ms,
+                 updated_at_ms, source, input_hash, memory_version, repo_id)
+             VALUES (?1, 'Invariant', ?1, 'body', 'high', ?2, 'agent', ?3, ?3, 'agent', 'h', 'v1',
+                 ?4)",
+            params![id, status, created_at_ms, REPO],
+        )
+        .unwrap();
+    }
+
+    fn entry_count(conn: &Connection) -> i64 {
+        conn.query_row("SELECT COUNT(*) FROM oplog_entries", [], |r| r.get(0)).unwrap()
+    }
+
+    fn projected_node_count(conn: &Connection) -> i64 {
+        conn.query_row("SELECT COUNT(*) FROM oplog_projected_nodes", [], |r| r.get(0)).unwrap()
+    }
+
+    #[test]
+    fn memory_to_ops_translates_content_status_and_edges() {
+        let row = MemoryRow {
+            memory_id: "mem_a".to_string(),
+            kind: "Invariant".to_string(),
+            title: "t".to_string(),
+            body: "b".to_string(),
+            confidence: "high".to_string(),
+            status: "obsolete".to_string(),
+            source: "agent".to_string(),
+            payload_json: None,
+            tags: vec!["x".to_string()],
+        };
+        let edge = NodeEdge {
+            edge_key: "k1".to_string(),
+            source_node_id: "mem_a".to_string(),
+            relation: "relates_to".to_string(),
+            target_repo_id: REPO.to_string(),
+            target_kind: "node".to_string(),
+            target_anchor: "mem_b".to_string(),
+            target_node_id: Some("mem_b".to_string()),
+            anchor_status: "current".to_string(),
+        };
+        let ops = memory_to_ops(&row, REPO, std::slice::from_ref(&edge)).unwrap();
+        // NodeCreate, then a NodeStatus (obsolete is not the active default), then the EdgeAdd.
+        assert_eq!(ops.len(), 3);
+        assert!(
+            matches!(&ops[0], MemoryOp::NodeCreate { node_id, .. } if node_id.as_str() == "mem_a")
+        );
+        assert!(
+            matches!(&ops[1], MemoryOp::NodeStatus { status, .. } if status.as_db_str() == "obsolete")
+        );
+        // An EdgeAdd, and DELIBERATELY no Rebind — the per-device resolved dimension
+        // (target_node_id / anchor_status) is recomputed on read, never signed into the log.
+        assert!(matches!(&ops[2], MemoryOp::EdgeAdd { .. }));
+        assert!(
+            !ops.iter().any(|op| matches!(op, MemoryOp::Rebind { .. })),
+            "the backfill omits the per-device resolved dimension"
+        );
+    }
+
+    #[test]
+    fn an_active_memory_emits_no_status_op() {
+        let row = MemoryRow {
+            memory_id: "mem_a".to_string(),
+            kind: "Invariant".to_string(),
+            title: "t".to_string(),
+            body: "b".to_string(),
+            confidence: "high".to_string(),
+            status: "active".to_string(),
+            source: "agent".to_string(),
+            payload_json: None,
+            tags: Vec::new(),
+        };
+        let ops = memory_to_ops(&row, REPO, &[]).unwrap();
+        assert_eq!(ops.len(), 1, "an active, edgeless memory is just its NodeCreate");
+    }
+
+    #[test]
+    fn memory_to_ops_fails_on_an_unknown_status() {
+        // A status token this binary can't map must FAIL the backfill, not silently default the
+        // signed history to `active`.
+        let row = MemoryRow {
+            memory_id: "mem_a".to_string(),
+            kind: "Invariant".to_string(),
+            title: "t".to_string(),
+            body: "b".to_string(),
+            confidence: "high".to_string(),
+            status: "future_status_from_a_newer_binary".to_string(),
+            source: "agent".to_string(),
+            payload_json: None,
+            tags: Vec::new(),
+        };
+        let err = memory_to_ops(&row, REPO, &[]).unwrap_err();
+        assert!(err.to_string().contains("unknown status"), "an unknown status fails the backfill");
+    }
+
+    #[test]
+    fn backfill_authors_every_memory_and_is_idempotent() {
+        let conn = scoped_conn();
+        insert_memory(&conn, "mem_a", "active", 100);
+        insert_memory(&conn, "mem_b", "active", 200);
+        insert_memory(&conn, "mem_c", "active", 300);
+        // Author a typed edge FROM mem_b (add_edge requires a live source), THEN mark mem_b
+        // obsolete. The persisted edge must still be backfilled — the P2 regression guard: the
+        // complete-history log keeps a non-live source's relationships (unlike the live reader).
+        crate::query::memory::add_edge(
+            &conn,
+            "mem_b",
+            EdgeRelation::RelatesTo,
+            &crate::query::memory::EdgeTarget::Node { repo_id: None, node_id: "mem_c".to_string() },
+        )
+        .unwrap();
+        conn.execute("UPDATE repo_memories SET status = 'obsolete' WHERE id = 'mem_b'", [])
+            .unwrap();
+
+        backfill_memory_oplog(&conn, 1_000).unwrap();
+        // 3 NodeCreate + 1 NodeStatus (mem_b obsolete) + 1 EdgeAdd (from obsolete mem_b) = 5
+        // entries; 3 projected nodes.
+        assert_eq!(entry_count(&conn), 5);
+        assert_eq!(projected_node_count(&conn), 3);
+        let status: String = conn
+            .query_row(
+                "SELECT status FROM oplog_projected_nodes WHERE node_id = 'mem_b'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(status, "obsolete");
+        let edges: i64 =
+            conn.query_row("SELECT COUNT(*) FROM oplog_projected_edges", [], |r| r.get(0)).unwrap();
+        assert_eq!(edges, 1);
+
+        // A second backfill is a no-op — the atomic batch already completed (chain non-empty).
+        backfill_memory_oplog(&conn, 2_000).unwrap();
+        assert_eq!(entry_count(&conn), 5, "re-running backfill authors nothing more");
+    }
+
+    #[test]
+    fn backfill_is_a_noop_on_the_placeholder_repo() {
+        // An unadopted DB scoped to the legacy `__unassigned__` placeholder: backfilling would sign
+        // an immutable owner stream that adoption can never re-point, so it must no-op even with
+        // memories present.
+        let conn = Connection::open_in_memory().unwrap();
+        crate::index::schema::apply(&conn).unwrap();
+        conn.execute_batch(
+            "CREATE TEMP TABLE IF NOT EXISTS connection_context(key TEXT PRIMARY KEY, value TEXT);",
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT OR REPLACE INTO temp.connection_context(key, value) VALUES ('repo_id', ?1)",
+            [crate::index::schema::LEGACY_REPO_ID],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO repo_memories(
+                 id, kind, title, body, confidence, status, created_by, created_at_ms,
+                 updated_at_ms, source, input_hash, memory_version, repo_id)
+             VALUES ('mem_a', 'Invariant', 'mem_a', 'body', 'high', 'active', 'agent', 1, 1,
+                 'agent', 'h', 'v1', ?1)",
+            [crate::index::schema::LEGACY_REPO_ID],
+        )
+        .unwrap();
+
+        backfill_memory_oplog(&conn, 1_000).unwrap();
+        assert_eq!(entry_count(&conn), 0, "the placeholder repo is not backfilled");
+    }
+
+    #[test]
+    fn backfill_is_a_noop_on_a_local_only_repo() {
+        // A machine-local `local:` shallow-clone id is upgraded to a portable id when the clone is
+        // deepened, re-pointing the rows — so an immutable owner stream must not be rooted on it.
+        let conn = Connection::open_in_memory().unwrap();
+        crate::index::schema::apply(&conn).unwrap();
+        let local_id = format!("{}deadbeef", crate::repo_identity::LOCAL_ONLY_ID_PREFIX);
+        conn.execute_batch(
+            "CREATE TEMP TABLE IF NOT EXISTS connection_context(key TEXT PRIMARY KEY, value TEXT);",
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT OR REPLACE INTO temp.connection_context(key, value) VALUES ('repo_id', ?1)",
+            [&local_id],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO repo_memories(
+                 id, kind, title, body, confidence, status, created_by, created_at_ms,
+                 updated_at_ms, source, input_hash, memory_version, repo_id)
+             VALUES ('mem_a', 'Invariant', 'mem_a', 'body', 'high', 'active', 'agent', 1, 1,
+                 'agent', 'h', 'v1', ?1)",
+            [&local_id],
+        )
+        .unwrap();
+
+        backfill_memory_oplog(&conn, 1_000).unwrap();
+        assert_eq!(entry_count(&conn), 0, "a local: repo is not backfilled");
+    }
+
+    #[test]
+    fn backfill_is_a_noop_on_an_unscoped_db() {
+        // No repos row, no connection scope → memory_repo_scope is None → nothing to root a stream.
+        let conn = Connection::open_in_memory().unwrap();
+        crate::index::schema::apply(&conn).unwrap();
+        backfill_memory_oplog(&conn, 1_000).unwrap();
+        assert_eq!(entry_count(&conn), 0);
+    }
+
+    #[test]
+    fn backfill_of_an_empty_repo_leaves_the_chain_empty() {
+        let conn = scoped_conn();
+        backfill_memory_oplog(&conn, 1_000).unwrap();
+        assert_eq!(entry_count(&conn), 0, "no memories ⇒ no entries; the first live op is genesis");
+    }
+}

--- a/crates/rag-rat-core/src/query/memory/edges.rs
+++ b/crates/rag-rat-core/src/query/memory/edges.rs
@@ -226,11 +226,47 @@ pub(crate) fn remove_edge(conn: &Connection, edge_key: &str) -> anyhow::Result<b
 
 /// Every edge OUT of `source_node_id` (its outgoing graph — deps, mind-map links, tracks).
 pub(crate) fn edges_from(conn: &Connection, source_node_id: &str) -> anyhow::Result<Vec<NodeEdge>> {
+    edges_from_source(conn, source_node_id, SourceScope::LiveOnly)
+}
+
+/// Every edge FROM `source_node_id`, INCLUDING those whose source memory is `obsolete`/`rejected` —
+/// the complete-history read the op-log backfill needs. It is exactly [`edges_from`] MINUS the
+/// `LIVE_SOURCE_PREDICATE` (a non-live source's edges stay visible); it KEEPS `reresolve_on_read`,
+/// so a node target's `target_repo_id` is repaired to CURRENT before it is signed into the op-log
+/// `EdgeSpec` (the stored column is only an add-time snapshot — stale after a repo-id re-point or
+/// if the target was `unresolved` at add time, and a signed op cannot be corrected later).
+/// `edge_key` itself folds node ids, not repo ids, so it is stable regardless.
+pub(crate) fn all_edges_from(
+    conn: &Connection,
+    source_node_id: &str,
+) -> anyhow::Result<Vec<NodeEdge>> {
+    edges_from_source(conn, source_node_id, SourceScope::All)
+}
+
+/// Whether an outgoing-edge read is filtered to a LIVE source (the recall surface) or spans EVERY
+/// source regardless of its memory's status (the complete-history backfill).
+enum SourceScope {
+    LiveOnly,
+    All,
+}
+
+/// Shared body of [`edges_from`] / [`all_edges_from`]: the only difference is whether the
+/// `LIVE_SOURCE_PREDICATE` is applied. Both are owner-scoped and both re-resolve node targets on
+/// read.
+fn edges_from_source(
+    conn: &Connection,
+    source_node_id: &str,
+    scope_kind: SourceScope,
+) -> anyhow::Result<Vec<NodeEdge>> {
     let scope = memory_repo_scope(conn)?;
     let repo_clause = periphery_edge_scope_clause(&scope);
+    let live_clause = match scope_kind {
+        SourceScope::LiveOnly => LIVE_SOURCE_PREDICATE,
+        SourceScope::All => "",
+    };
     let mut stmt = conn.prepare(&format!(
-        "{EDGE_SELECT} WHERE source_node_id = ?1{repo_clause}{LIVE_SOURCE_PREDICATE} ORDER BY \
-         relation, target_anchor"
+        "{EDGE_SELECT} WHERE source_node_id = ?1{repo_clause}{live_clause} ORDER BY relation, \
+         target_anchor"
     ))?;
     let rows = stmt.query_map([source_node_id], edge_row)?.collect::<rusqlite::Result<_>>()?;
     reresolve_on_read(conn, rows)

--- a/crates/rag-rat-core/src/query/memory/mod.rs
+++ b/crates/rag-rat-core/src/query/memory/mod.rs
@@ -1,4 +1,9 @@
 mod api;
+// The op-log authoring seam (#524): row→op translation + the one-time full backfill. Unwired to
+// the live write path this increment (only its tests drive it), so it is dead in a non-test build
+// — the next increment calls `backfill_memory_oplog` from `create_memory` and the allow drops.
+#[cfg_attr(not(test), allow(dead_code))]
+mod authoring;
 mod edges;
 mod hydrate;
 mod moniker;
@@ -11,7 +16,7 @@ pub(crate) use api::*;
 // The typed-edge public surface (#464): the boundary types cross the FFI/MCP/CLI edge, so they
 // are `pub`; the query fns stay crate-internal.
 pub use edges::{EdgeRelation, EdgeTarget, NodeEdge};
-pub(crate) use edges::{add_edge, edge_key, edges_from, edges_into, remove_edge};
+pub(crate) use edges::{add_edge, all_edges_from, edge_key, edges_from, edges_into, remove_edge};
 pub(crate) use hydrate::*;
 pub(crate) use moniker::*;
 pub(crate) use resolve::*;


### PR DESCRIPTION
Seventh phase-B op-log increment, after #480/#489/#495/#497/#500/#503/#504/#509/#511/#513/#523. Freezes the machinery that turns memories into signed log entries — the minting primitive, the row→op translation, and the one-time full backfill — WITHOUT touching the live memory write path.

## What landed

- **`store::author_op` / `store::author_batch`** — mint entries by allocating the next Lamport from the `(stream, device)` chain tail, signing, and inserting. `author_op` is one op in its own `IMMEDIATE` txn; `author_batch` is a whole sequence in ONE atomic txn (an interrupted backfill rolls back and re-runs clean) with a single projection re-fold at the end. `append`'s reproject branch is factored into a shared `reproject_after_write` helper. The primitives take a `&LocalDevice`, so `DeviceSecret` stays oplog-private.
- **oplog's first crate-internal API surface** — a curated `pub(crate)` re-export in `oplog/mod.rs` (the minting fns + the op vocabulary). Every submodule is otherwise private, so this is the ONE seam `query::memory` reaches through — and the only direction of the dependency (`oplog` never depends back on `query::memory`, which the next increment's reverse call would otherwise cycle).
- **`query::memory::authoring`** — translates a memory into `NodeCreate` [+ `NodeStatus` when non-active] [+ `EdgeAdd` per outgoing typed node-edge, in `edge_key` order]. Code-anchor **bindings** stay out of the log: they are per-device derived resolution state, re-validated locally, never part of the shared node graph. `backfill_memory_oplog` authors every one of the active repo's memories into its owner stream — **idempotent** (a completed atomic batch leaves a non-empty chain, so a re-run is a no-op), **scope-gated** (a no-op on an unscoped DB), deterministically ordered `(created_at_ms, id)`. The log becomes the complete signed history from genesis.

Still **not** wired to the live write path — `mod oplog` stays dead-code-allowed. The next increment calls `backfill_memory_oplog` + `author_op` inside each mutation's transaction (making `create_memory`/`update_memory` transactional), and reuses `memory_to_ops` for the mutations themselves.

## Tests / gates

- store: `author_op` mints a genesis→1→2 chain and projects; `author_batch` writes N ops in one txn with sequential lamports (empty batch is a no-op; continues a non-empty chain).
- authoring: `memory_to_ops` translates content + non-active status + edges in order; end-to-end backfill over a 3-memory fixture (one obsolete, one edge) yields 3 projected nodes + the right status + the edge, and a second backfill is a no-op; unscoped and empty-repo backfills are no-ops.
- Full workspace suite green (2040 tests), clippy clean on default and `--no-default-features`, nightly fmt clean.


Fixes #524
