### PR TITLE
perf(index): shared-parse low-signal classification + O(1) chunker line spans

### DIFF
--- a/crates/rag-rat-core/src/index/ai/policy.rs
+++ b/crates/rag-rat-core/src/index/ai/policy.rs
@@ -17,6 +17,35 @@ pub(crate) fn needs_embedding(
         || chunk.embedding_text_version.as_deref() != Some(EMBEDDING_TEXT_VERSION)
 }
 
+/// How the `SkipLowSignal` gate classifies a chunk. Evaluated ONLY if the cheaper gates
+/// (`SkipTooLarge`/`SkipGenerated`/`SkipTestFixture`/language/`SkipTooSmall`) don't short-circuit
+/// first — a sub-80-char chunk must pay neither a re-parse nor a tree walk.
+pub(crate) enum LowSignalCheck<'a> {
+    /// Re-parse the chunk text (`is_low_signal_chunk`) — for callers with no tree at hand:
+    /// generated / oversized / markdown / parse-failure files, the heal path, the reconcile paths.
+    FromText,
+    /// Classify the chunk's byte span against the file's shared parse (`is_low_signal_span`,
+    /// #516) — one tree-sitter parse per file instead of one per chunk.
+    FromSpan { language: Language, root: tree_sitter::Node<'a>, start_byte: usize, end_byte: usize },
+}
+
+impl LowSignalCheck<'_> {
+    fn is_low_signal(
+        &self,
+        language: &str,
+        chunk_kind: &str,
+        symbol_path: Option<&str>,
+        trimmed: &str,
+    ) -> bool {
+        match self {
+            Self::FromText => is_low_signal_chunk(language, chunk_kind, symbol_path, trimmed),
+            Self::FromSpan { language, root, start_byte, end_byte } =>
+                is_low_signal_span(*language, *root, *start_byte, *end_byte),
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn embedding_policy_for_chunk(
     path: &Path,
     language: &str,
@@ -25,6 +54,7 @@ pub(crate) fn embedding_policy_for_chunk(
     symbol_path: Option<&str>,
     text: &str,
     max_embedding_chars: usize,
+    low_signal: LowSignalCheck<'_>,
 ) -> EmbeddingPolicyDecision {
     let path_text = path.to_string_lossy();
     let trimmed = text.trim();
@@ -48,7 +78,7 @@ pub(crate) fn embedding_policy_for_chunk(
     if trimmed.chars().count() < MIN_EMBEDDING_CHARS {
         return policy("SkipTooSmall", 9, false);
     }
-    if is_low_signal_chunk(language, chunk_kind, symbol_path, trimmed) {
+    if low_signal.is_low_signal(language, chunk_kind, symbol_path, trimmed) {
         return policy("SkipLowSignal", 9, false);
     }
     policy("Embed", embedding_priority(&path_text, language, chunk_kind, symbol_path), true)
@@ -70,6 +100,7 @@ pub(crate) fn policy_for_job(
         chunk.symbol_path.as_deref(),
         &chunk.text,
         max_embedding_chars,
+        LowSignalCheck::FromText,
     )
 }
 
@@ -141,8 +172,9 @@ pub(crate) fn is_test_fixture_path(path: &str) -> bool {
 /// string heuristic mishandled. A symbol chunk is a definition node, so it's never low-signal.
 ///
 /// `chunk_kind` / `symbol_path` are unused now (the node kinds carry the signal) but kept on the
-/// signature for the call site. Re-parsing a small chunk is cheap relative to the embedding it
-/// gates; if it ever shows up hot, precompute the flag from the file's parse at index time.
+/// signature for the call site. This is the FALLBACK for callers with no tree at hand
+/// ([`LowSignalCheck::FromText`]); the prepare phase classifies against the file's shared parse
+/// instead ([`is_low_signal_span`], #516) so it never pays a per-chunk re-parse.
 pub(crate) fn is_low_signal_chunk(
     language: &str,
     _chunk_kind: &str,
@@ -166,6 +198,48 @@ pub(crate) fn is_low_signal_chunk(
     // chunk that parses to no statements). Any definition/expression/other node is signal.
     let mut cursor = root.walk();
     root.named_children(&mut cursor).all(|child| is_plumbing_node(lang, child))
+}
+
+/// Span-based twin of [`is_low_signal_chunk`] (#516): classify a chunk's byte span against the
+/// FILE's already-parsed tree, so the prepare phase pays one tree-sitter parse per file instead of
+/// one per chunk (each of those re-parses cost a worker-thread spawn + a full text copy in
+/// `parse_within_budget`). Low-signal iff every named node the span covers is plumbing, descending
+/// into container nodes that extend beyond the span (a `mod` / class / function body the chunk
+/// slices into) — so a `use`-only slice of a mod body classifies the way its standalone parse used
+/// to. Vacuously true for a span covering no named nodes (blank / `}`-only chunks), which the
+/// `SkipTooSmall` gate catches before low-signal is consulted anyway.
+pub(crate) fn is_low_signal_span(
+    language: Language,
+    root: tree_sitter::Node<'_>,
+    start_byte: usize,
+    end_byte: usize,
+) -> bool {
+    span_is_plumbing(language, root, start_byte, end_byte)
+}
+
+fn span_is_plumbing(
+    language: Language,
+    node: tree_sitter::Node<'_>,
+    start_byte: usize,
+    end_byte: usize,
+) -> bool {
+    let mut cursor = node.walk();
+    node.named_children(&mut cursor).all(|child| {
+        if child.end_byte() <= start_byte || child.start_byte() >= end_byte {
+            return true;
+        }
+        if is_plumbing_node(language, child) {
+            return true;
+        }
+        if start_byte <= child.start_byte() && child.end_byte() <= end_byte {
+            // A whole non-plumbing statement inside the chunk is signal.
+            return false;
+        }
+        // The child extends beyond the span — a container the chunk slices into. Classify the
+        // slice by the child's own children. A sliced leaf (e.g. one line inside a long string
+        // literal) has none and classifies as plumbing, consistent with docstring interiors.
+        span_is_plumbing(language, child, start_byte, end_byte)
+    })
 }
 
 /// A top-level node carrying no embed-worthy signal: a comment, or a per-language import/include /
@@ -262,5 +336,83 @@ mod low_signal_tests {
     #[test]
     fn rust_use_only_is_low_signal() {
         assert!(is_low_signal_chunk("rust", "code", Some("s"), "use a::b;\npub use c::d;"));
+    }
+}
+
+/// The span-based twin of `is_low_signal_chunk` (#516): classifies a chunk's byte span against the
+/// FILE's shared parse instead of re-parsing the chunk text, so the prepare phase pays one parse
+/// per file, not one per chunk. These pin parity with the text-based semantics on the same shapes
+/// the `low_signal_tests` above cover, plus the container-descent case the text parse could only
+/// approximate (plumbing nested inside a `mod`/function body the chunk slices into).
+#[cfg(test)]
+mod low_signal_span_tests {
+    use std::path::Path;
+
+    use super::is_low_signal_span;
+    use crate::index::parser;
+    use crate::language::Language;
+
+    fn parsed(path: &str, language: Language, src: &str) -> parser::ParsedFile {
+        parser::parse_file(Path::new(path), language, src).expect("fixture parses")
+    }
+
+    #[test]
+    fn rust_use_only_span_at_file_root_is_low_signal_and_a_fn_span_is_not() {
+        let src = "use a::b;\npub use c::d;\n\nfn real() {\n    let x = 1;\n}\n";
+        let file = parsed("s.rs", Language::Rust, src);
+        let uses_end = src.find("\nfn").expect("fn present") + 1;
+        assert!(is_low_signal_span(Language::Rust, file.root(), 0, uses_end), "use-only span");
+        assert!(
+            !is_low_signal_span(Language::Rust, file.root(), uses_end, src.len()),
+            "a definition span is signal"
+        );
+    }
+
+    #[test]
+    fn rust_use_lines_inside_a_mod_body_are_low_signal() {
+        // The chunk slices INTO the mod body (the mod node extends beyond the span), so the
+        // classifier must descend through the container instead of treating it as signal.
+        let src = "mod tests {\n    use super::*;\n    use std::fmt;\n\n    fn helper() {}\n}\n";
+        let file = parsed("s.rs", Language::Rust, src);
+        let start = src.find("    use super").expect("use present");
+        let end = src.find("\n\n").expect("blank line") + 1;
+        assert!(is_low_signal_span(Language::Rust, file.root(), start, end));
+    }
+
+    #[test]
+    fn whitespace_only_span_is_low_signal() {
+        let src = "use a::b;\n\n\nfn real() {}\n";
+        let file = parsed("s.rs", Language::Rust, src);
+        let start = src.find("\n\n").expect("gap") + 1;
+        assert!(is_low_signal_span(Language::Rust, file.root(), start, start + 1));
+    }
+
+    #[test]
+    fn python_docstring_and_import_spans_are_low_signal_but_a_def_is_not() {
+        let src = "\"\"\"Module doc.\nMore prose.\n\"\"\"\nimport os\nfrom a import b\n\ndef \
+                   real():\n    return 1\n";
+        let file = parsed("s.py", Language::Python, src);
+        let def_start = src.find("\ndef").expect("def present") + 1;
+        assert!(is_low_signal_span(Language::Python, file.root(), 0, def_start));
+        assert!(!is_low_signal_span(Language::Python, file.root(), def_start, src.len()));
+    }
+
+    #[test]
+    fn c_include_span_is_low_signal_but_a_define_is_not() {
+        // Regression twin of `c_macro_definition_is_not_low_signal`: `#define` is a macro SYMBOL.
+        let src = "#include <stdio.h>\n#include \"a.h\"\n#define DEVICE_API(x) (x)\nint f(void) \
+                   {\n    return 0;\n}\n";
+        let file = parsed("s.c", Language::C, src);
+        let define_start = src.find("#define").expect("define present");
+        let define_end = src.find("\nint").expect("fn present") + 1;
+        assert!(is_low_signal_span(Language::C, file.root(), 0, define_start));
+        assert!(!is_low_signal_span(Language::C, file.root(), define_start, define_end));
+    }
+
+    #[test]
+    fn mixed_span_with_any_definition_is_signal() {
+        let src = "use a::b;\nfn real() {}\n";
+        let file = parsed("s.rs", Language::Rust, src);
+        assert!(!is_low_signal_span(Language::Rust, file.root(), 0, src.len()));
     }
 }

--- a/crates/rag-rat-core/src/index/ai/reconcile/embed_loop.rs
+++ b/crates/rag-rat-core/src/index/ai/reconcile/embed_loop.rs
@@ -782,6 +782,7 @@ pub(crate) fn embedding_policy_skip_summary(
             symbol_path.as_deref(),
             &text,
             max_embedding_chars,
+            LowSignalCheck::FromText,
         );
         if !decision.eligible {
             *skipped_by_policy.entry(decision.policy).or_default() += 1;

--- a/crates/rag-rat-core/src/index/chunker.rs
+++ b/crates/rag-rat-core/src/index/chunker.rs
@@ -86,18 +86,21 @@ pub fn code_chunks_for_symbols(
     text: &str,
     symbols: &[parser::ParsedSymbol],
 ) -> Vec<Chunk> {
+    // One line-offset table per file: every symbol's line range becomes an O(1) byte-range lookup
+    // instead of a from-byte-0 rescan per symbol (#517).
+    let lines = LineOffsets::new(text);
     let mut chunks = Vec::new();
     for symbol in symbols {
-        let Some(symbol_span) = line_span(text, symbol.start_line, symbol.end_line) else {
+        let Some(range) = lines.byte_range(symbol.start_line, symbol.end_line) else {
             continue;
         };
-        if symbol_span.text.trim().is_empty() {
+        let span_start = range.start;
+        let span_text = &text[range];
+        if span_text.trim().is_empty() {
             continue;
         }
         for (part_idx, part) in
-            split_symbol(&symbol_span.text, symbol_span.start_byte, symbol.start_line, 120)
-                .into_iter()
-                .enumerate()
+            split_symbol(span_text, span_start, symbol.start_line, 120).into_iter().enumerate()
         {
             chunks.push(make_chunk(
                 "code",
@@ -114,13 +117,18 @@ pub fn code_chunks_for_symbols(
             ));
         }
     }
-    chunks.extend(uncovered_code_chunks(path, text, symbols));
+    chunks.extend(uncovered_code_chunks(path, text, symbols, &lines));
     chunks.sort_by_key(|chunk| (chunk.start_byte, chunk.end_byte));
     if chunks.is_empty() { whole_file_chunk(path, text) } else { chunks }
 }
 
-fn uncovered_code_chunks(path: &Path, text: &str, symbols: &[parser::ParsedSymbol]) -> Vec<Chunk> {
-    let line_count = text.lines().count().max(1);
+fn uncovered_code_chunks(
+    path: &Path,
+    text: &str,
+    symbols: &[parser::ParsedSymbol],
+    lines: &LineOffsets,
+) -> Vec<Chunk> {
+    let line_count = lines.line_count().max(1);
     let mut covered = vec![false; line_count + 1];
     for symbol in symbols {
         let start = symbol.start_line.max(1);
@@ -141,6 +149,7 @@ fn uncovered_code_chunks(path: &Path, text: &str, symbols: &[parser::ParsedSymbo
             push_uncovered_chunk(
                 path,
                 text,
+                lines,
                 start,
                 line.saturating_sub(1),
                 chunks.len(),
@@ -149,27 +158,31 @@ fn uncovered_code_chunks(path: &Path, text: &str, symbols: &[parser::ParsedSymbo
         }
     }
     if let Some(start) = start_line {
-        push_uncovered_chunk(path, text, start, line_count, chunks.len(), &mut chunks);
+        push_uncovered_chunk(path, text, lines, start, line_count, chunks.len(), &mut chunks);
     }
     chunks
 }
 
+#[allow(clippy::too_many_arguments)]
 fn push_uncovered_chunk(
     path: &Path,
     text: &str,
+    lines: &LineOffsets,
     start_line: usize,
     end_line: usize,
     context_index: usize,
     chunks: &mut Vec<Chunk>,
 ) {
-    let Some(span) = line_span(text, start_line, end_line) else {
+    let Some(range) = lines.byte_range(start_line, end_line) else {
         return;
     };
-    if span.text.trim().is_empty() {
+    let span_start = range.start;
+    let span_text = &text[range];
+    if span_text.trim().is_empty() {
         return;
     }
     for (part_idx, part) in
-        split_symbol(&span.text, span.start_byte, start_line, 80).into_iter().enumerate()
+        split_symbol(span_text, span_start, start_line, 80).into_iter().enumerate()
     {
         chunks.push(make_chunk(
             "code",
@@ -188,37 +201,51 @@ fn push_uncovered_chunk(
     }
 }
 
-struct LineSpan {
-    start_byte: usize,
-    text: String,
+/// Byte offsets of each line start, computed once per file so a line range becomes an O(1)
+/// byte-range lookup — replacing the per-symbol from-byte-0 rescan that made chunking
+/// O(symbols × file bytes) (#517). The range slices the raw on-disk bytes (incl. any CRLF), so a
+/// span's length equals its real byte length; `split_symbol` re-normalizes each line when it
+/// builds chunk text, and advances its byte cursor over these raw lengths so code-chunk offsets
+/// stay aligned with the tree-sitter symbol offsets `query::graph_meta` joins against.
+pub(crate) struct LineOffsets {
+    /// `starts[i]` is the byte offset where 1-based line `i + 1` begins. A trailing `\n` closes
+    /// the last line rather than opening a phantom one (`split_inclusive` line semantics).
+    starts: Vec<usize>,
+    text_len: usize,
 }
 
-fn line_span(text: &str, start_line: usize, end_line: usize) -> Option<LineSpan> {
-    if start_line == 0 || end_line < start_line {
-        return None;
+impl LineOffsets {
+    pub(crate) fn new(text: &str) -> Self {
+        let mut starts = Vec::new();
+        if !text.is_empty() {
+            starts.push(0);
+        }
+        for (idx, byte) in text.bytes().enumerate() {
+            if byte == b'\n' && idx + 1 < text.len() {
+                starts.push(idx + 1);
+            }
+        }
+        Self { starts, text_len: text.len() }
     }
-    let mut byte = 0;
-    let mut start_byte = None;
-    let mut out = String::new();
-    for (idx, raw) in text.split_inclusive('\n').enumerate() {
-        let line_no = idx + 1;
-        if line_no == start_line {
-            start_byte = Some(byte);
-        }
-        if line_no >= start_line && line_no <= end_line {
-            // Keep the raw on-disk bytes (incl. any CRLF) so the returned span's length equals its
-            // real byte length; `split_symbol` re-normalizes each line when it builds chunk text,
-            // and advances its byte cursor over these raw lengths so code-chunk offsets stay
-            // aligned with the tree-sitter symbol offsets `query::graph_meta` joins against.
-            out.push_str(raw);
-        }
-        byte += raw.len();
-        if line_no >= end_line {
-            break;
-        }
+
+    pub(crate) fn line_count(&self) -> usize {
+        self.starts.len()
     }
-    let start_byte = start_byte?;
-    (!out.trim().is_empty()).then_some(LineSpan { start_byte, text: out })
+
+    /// The byte range covering whole lines `start_line..=end_line` (1-based; `end_line` clamps to
+    /// EOF), or `None` when the range is empty or starts past the last line.
+    pub(crate) fn byte_range(
+        &self,
+        start_line: usize,
+        end_line: usize,
+    ) -> Option<std::ops::Range<usize>> {
+        if start_line == 0 || end_line < start_line || start_line > self.starts.len() {
+            return None;
+        }
+        let start = self.starts[start_line - 1];
+        let end = self.starts.get(end_line).copied().unwrap_or(self.text_len);
+        Some(start..end)
+    }
 }
 
 fn whole_file_chunk(path: &Path, text: &str) -> Vec<Chunk> {

--- a/crates/rag-rat-core/src/index/chunker_tests.rs
+++ b/crates/rag-rat-core/src/index/chunker_tests.rs
@@ -91,10 +91,11 @@ fn crlf_markdown_intermediate_boundary_is_on_disk_exact() {
 
 #[test]
 fn crlf_code_path_chunk_offsets_match_disk() {
-    // The tree-sitter code path (code_chunks_for_symbols -> line_span -> split_symbol) is the path
-    // whose offsets graph_meta joins against tree-sitter symbol byte offsets. line_span returns the
-    // on-disk span so split_symbol's end_byte stays byte-aligned with the raw file on CRLF input
-    // (the pre-#241-completion code computed end_byte in LF-normalized space and drifted short).
+    // The tree-sitter code path (code_chunks_for_symbols -> LineOffsets -> split_symbol) is the
+    // path whose offsets graph_meta joins against tree-sitter symbol byte offsets. The line-offset
+    // table yields the raw on-disk span so split_symbol's end_byte stays byte-aligned with the raw
+    // file on CRLF input (the pre-#241-completion code computed end_byte in LF-normalized space
+    // and drifted short).
     let crlf = "fn alpha() {\r\n    let x = 1;\r\n    let y = 2;\r\n}\r\n\r\nfn beta() {\r\n    \
                 alpha();\r\n}\r\n";
     let chunks = chunker::chunks_for_file(Path::new("x.rs"), Language::Rust, crlf);
@@ -131,4 +132,73 @@ fn lf_offsets_unchanged_regression() {
     let chunks = chunker::generated_chunks_for_file(Path::new("x.txt"), lf);
     assert_chunk_bytes_match_disk(&chunks, lf);
     assert_contiguous(&chunks, lf);
+}
+
+/// The per-file line-offset table replacing `line_span`'s from-byte-0 rescan (#517). These pin the
+/// exact contract the old scan had, so the O(1) lookups stay byte-identical: raw on-disk bytes
+/// (CRLF included), 1-based whole-line ranges, `None` on empty/invalid ranges, EOF clamping.
+mod line_offsets {
+    use crate::index::chunker::LineOffsets;
+
+    #[test]
+    fn middle_range_slices_whole_lines_including_terminators() {
+        let text = "one\ntwo\nthree\nfour\n";
+        let lines = LineOffsets::new(text);
+        let range = lines.byte_range(2, 3).expect("valid range");
+        assert_eq!(&text[range], "two\nthree\n");
+    }
+
+    #[test]
+    fn crlf_bytes_are_preserved_in_the_span() {
+        // The span must be the raw on-disk bytes — chunk offsets join against tree-sitter symbol
+        // offsets, which count CR bytes.
+        let text = "a\r\nb\r\nc\r\n";
+        let lines = LineOffsets::new(text);
+        let range = lines.byte_range(2, 2).expect("valid range");
+        assert_eq!(&text[range], "b\r\n");
+    }
+
+    #[test]
+    fn zero_start_line_and_inverted_range_are_none() {
+        let lines = LineOffsets::new("a\nb\n");
+        assert!(lines.byte_range(0, 1).is_none(), "lines are 1-based");
+        assert!(lines.byte_range(2, 1).is_none(), "end before start");
+    }
+
+    #[test]
+    fn start_line_past_eof_is_none() {
+        let lines = LineOffsets::new("a\nb");
+        assert!(lines.byte_range(3, 5).is_none());
+    }
+
+    #[test]
+    fn end_line_past_eof_clamps_to_text_end() {
+        let text = "a\nb\nc";
+        let lines = LineOffsets::new(text);
+        let range = lines.byte_range(2, 99).expect("valid range");
+        assert_eq!(&text[range], "b\nc");
+    }
+
+    #[test]
+    fn unterminated_last_line_ends_exactly_at_eof() {
+        let text = "a\nb\nc";
+        let lines = LineOffsets::new(text);
+        let range = lines.byte_range(3, 3).expect("valid range");
+        assert_eq!(&text[range], "c");
+        assert_eq!(lines.line_count(), 3);
+    }
+
+    #[test]
+    fn trailing_newline_does_not_create_a_phantom_line() {
+        let lines = LineOffsets::new("a\nb\n");
+        assert_eq!(lines.line_count(), 2, "split_inclusive semantics: no trailing empty line");
+        assert!(lines.byte_range(3, 3).is_none());
+    }
+
+    #[test]
+    fn empty_text_has_no_lines() {
+        let lines = LineOffsets::new("");
+        assert_eq!(lines.line_count(), 0);
+        assert!(lines.byte_range(1, 1).is_none());
+    }
 }

--- a/crates/rag-rat-core/src/index/file_index.rs
+++ b/crates/rag-rat-core/src/index/file_index.rs
@@ -90,7 +90,9 @@ impl IndexDatabase {
         } else {
             chunker::chunks_for_file(path, language, text)
         };
-        let chunks = prepare_chunks(path, language.as_str(), kind.as_str(), chunks, text);
+        // No shared tree on the heal path yet (it re-parses per derivation, #518), so the
+        // low-signal gate keeps its text-based fallback here.
+        let chunks = prepare_chunks(path, language.as_str(), kind.as_str(), chunks, text, None);
         // has_test_code from the SAME chunk-text marker set as insert_prepared_file + the V024
         // backfill, so a file healed through this path matches a fully-indexed one (#77). The heal
         // path is a second files-insert site; chunks are prepared up here (they don't need file_id)

--- a/crates/rag-rat-core/src/index/prep.rs
+++ b/crates/rag-rat-core/src/index/prep.rs
@@ -23,14 +23,21 @@ pub(crate) struct PreparedChunk {
 /// Compute the per-chunk hashes / anchor / embedding policy for a file's chunks. Splits the file's
 /// lines once (anchors only read a few boundary/context lines). Shared by the parallel prepare
 /// phase and the inline incremental path, so both keep this CPU work off the serial insert stage.
+///
+/// `parsed_root` is the file's shared tree-sitter parse when the caller holds one: the low-signal
+/// embedding gate then classifies each chunk's byte span against it instead of re-parsing every
+/// chunk's text (#516 — the re-parse cost a worker-thread spawn per chunk). `None` (generated /
+/// oversized / markdown / parse-failure files, and the heal path) keeps the text-based fallback.
 pub(crate) fn prepare_chunks(
     path: &Path,
     language: &str,
     file_kind: &str,
     chunks: Vec<Chunk>,
     full_text: &str,
+    parsed_root: Option<tree_sitter::Node<'_>>,
 ) -> Vec<PreparedChunk> {
     let full_lines = full_text.lines().collect::<Vec<_>>();
+    let language_kind = language.parse::<Language>().ok();
     chunks
         .into_iter()
         .map(|chunk| {
@@ -41,6 +48,17 @@ pub(crate) fn prepare_chunks(
                 chunk.end_line,
                 &full_lines,
             );
+            // Build the check lazily — the policy's cheaper gates (SkipTooSmall etc.) must keep
+            // short-circuiting before any tree walk or re-parse happens.
+            let low_signal = match parsed_root.zip(language_kind) {
+                Some((root, language)) => ai::LowSignalCheck::FromSpan {
+                    language,
+                    root,
+                    start_byte: chunk.start_byte,
+                    end_byte: chunk.end_byte,
+                },
+                None => ai::LowSignalCheck::FromText,
+            };
             let embedding = ai::embedding_policy_for_chunk(
                 path,
                 language,
@@ -49,6 +67,7 @@ pub(crate) fn prepare_chunks(
                 chunk.symbol_path.as_deref(),
                 &chunk.text,
                 ai::DEFAULT_MAX_EMBEDDING_CHARS,
+                low_signal,
             );
             PreparedChunk { chunk, text_hash, anchor, embedding }
         })
@@ -271,13 +290,15 @@ pub(crate) fn prepare_index_content(file: &IndexFile) -> anyhow::Result<Prepared
         // Markdown, oversized, or a hard parse failure: line-based chunking, no shared tree.
         chunker::chunks_for_file(&file.relative_path, file.language, &text)
     };
-    // Precompute per-chunk hashes / anchor / embedding policy here, in parallel.
+    // Precompute per-chunk hashes / anchor / embedding policy here, in parallel. The low-signal
+    // gate classifies chunk spans against the shared tree (one parse per file, #516).
     let chunks = prepare_chunks(
         &file.relative_path,
         file.language.as_str(),
         file.kind.as_str(),
         chunks,
         &text,
+        parsed.as_ref().map(|p| p.root()),
     );
 
     // Edge candidates walk the shared tree (no re-parse). from_symbol_id holds a local symbol
@@ -324,4 +345,56 @@ pub(crate) fn prepare_index_content(file: &IndexFile) -> anyhow::Result<Prepared
         symbol_fingerprints,
         parser_failure,
     })
+}
+
+#[cfg(test)]
+mod low_signal_wiring_tests {
+    use super::*;
+
+    /// The span-based low-signal gate (#516) must reach the same per-chunk policy decisions as the
+    /// text-based fallback it replaces on the shared-parse path — same chunks, tree present vs
+    /// absent. The fixture is sized so both outcomes occur (every block clears the 80-char
+    /// `SkipTooSmall` gate): a use/doc-comment block that must be SkipLowSignal and function
+    /// bodies that must Embed. If the wiring ever regresses to `None`, this still passes — the
+    /// companion assertions that BOTH policies occur keep the parity check non-vacuous.
+    #[test]
+    fn span_and_text_low_signal_paths_agree_on_prepared_chunk_policies() {
+        let src = "//! Module documentation explaining what this file is for.\n\nuse \
+                   std::collections::BTreeMap;\nuse std::collections::HashSet;\nuse \
+                   std::path::PathBuf;\n\nfn real_work(input: usize) -> usize {\n    let doubled \
+                   = input * 2;\n    let shifted = doubled + 7;\n    shifted * shifted\n}\n\nfn \
+                   more_work(count: usize) -> usize {\n    let mut total = 0;\n    for step in \
+                   0..count {\n        total += step;\n    }\n    total\n}\n";
+        let path = Path::new("src/lib.rs");
+        let parsed = parser::parse_file(path, Language::Rust, src).expect("fixture parses");
+        let chunks = chunker::code_chunks_for_symbols(path, src, &parsed.symbols);
+
+        let decisions = |prepared: &[PreparedChunk]| {
+            prepared
+                .iter()
+                .map(|pc| {
+                    (
+                        pc.chunk.symbol_path.clone(),
+                        pc.embedding.policy.clone(),
+                        pc.embedding.eligible,
+                    )
+                })
+                .collect::<Vec<_>>()
+        };
+        let with_tree =
+            prepare_chunks(path, "rust", "source", chunks.clone(), src, Some(parsed.root()));
+        let text_only = prepare_chunks(path, "rust", "source", chunks, src, None);
+
+        assert_eq!(decisions(&with_tree), decisions(&text_only), "span vs text policy parity");
+        assert!(
+            with_tree.iter().any(|pc| pc.embedding.policy == "SkipLowSignal"),
+            "fixture must exercise the low-signal outcome: {:?}",
+            decisions(&with_tree),
+        );
+        assert!(
+            with_tree.iter().any(|pc| pc.embedding.policy == "Embed"),
+            "fixture must exercise the embed outcome: {:?}",
+            decisions(&with_tree),
+        );
+    }
 }


### PR DESCRIPTION
Two prepare-phase wins from the parse-pipeline efficiency milestone.

Fixes #516. Fixes #517.

## Low-signal embedding gate: one parse per file, not per chunk (#516)

`is_low_signal_chunk` re-parsed **every chunk's text** with tree-sitter to decide the embedding policy — inside `prepare_chunks`, on every indexing path. Each re-parse went through `parse_within_budget`, paying a worker-thread spawn, a full text copy, a hash + global-mutex probe of the timeout memo, and a fresh `Parser` per chunk.

Now the prepare phase classifies each chunk's **byte span against the file's shared parse** (`is_low_signal_span`): low-signal iff every named node the span covers is plumbing, descending into container nodes that extend beyond the span — so a `use`-only slice of a `mod` body classifies the way its standalone parse used to. The text-based path stays as the documented fallback for callers with no tree (generated / oversized / markdown / parse-failure files, the heal path pending #518, and the reconcile paths pending #522).

- `embedding_policy_for_chunk` takes a `LowSignalCheck`: `FromSpan` carries the shared root + chunk span, `FromText` is the fallback. The check is evaluated only at the final gate, so the cheaper skips (`SkipTooSmall` etc.) still short-circuit before any tree walk or re-parse happens.
- `prepare_chunks` threads the shared root through; `prepare_index_content` passes it, heal/reconcile pass `FromText`.
- Tests: span-twin coverage of the existing `low_signal_tests` shapes (imports-only, definition, docstring, `#include` vs `#define`, mixed, whitespace) plus the container-descent case, and a prep-level parity test asserting span- and text-classification produce identical policy decisions on the same chunks (with assertions that both outcomes occur, so parity can't pass vacuously).

## Chunker: O(1) line spans via a per-file line-offset table (#517)

`line_span` rescanned the file **from byte 0** to convert a line range to a byte span, and was called once per symbol plus once per uncovered gap — O(symbols × file bytes); a symbol-dense 512 KB file rescanned ~1 GB of text during chunking.

`LineOffsets` is built once per file (one pass over the bytes) and answers every span in O(1). Call sites migrated, `line_span` deleted (no wrapper shim). Exact semantics pinned by tests before the swap: raw on-disk bytes (CRLF preserved, so chunk offsets stay aligned with the tree-sitter symbol offsets `query::graph_meta` joins against), `None` for 0/inverted/past-EOF starts, EOF clamping, `split_inclusive` line-count semantics (no phantom trailing line). The existing CRLF byte-offset pins (#241) all pass unchanged.

## Benchmarks

iai-callgrind (`benches/rag_pipeline.rs`, cargo-resolver corpus subtree), branch vs an `origin/main` baseline on the same machine — deterministic instruction counts, 0 regressions:

| bench | instructions | vs main |
|---|---|---|
| `index` (full rebuild) | 1,551,624,214 | **−5.52%** |
| `query_cold` | 146,843,690 | **−35.11%** |
| `query_warm` | 178,568,196 | **−18.04%** |

The query-side win is the chunker fix surfacing in hit validation, which re-derives a result file's chunks and previously paid the per-symbol rescan there too.
