### PR TITLE
feat(memory): two-observation downgrade hysteresis for anchor status

### DIFF
--- a/crates/rag-rat-cli/tests/multi_repo_e2e.rs
+++ b/crates/rag-rat-cli/tests/multi_repo_e2e.rs
@@ -526,6 +526,9 @@ fn memories_are_isolated_across_repos() {
         })
         .unwrap();
     let db_a = open_scoped(&repo_a, &data_dir);
+    // Twice: the #492 downgrade hysteresis defers the first gone observation, and doctor reads
+    // the PERSISTED status.
+    db_a.memory_validate().unwrap();
     db_a.memory_validate().unwrap();
     let a_doc = db_a.memory_doctor().unwrap();
     assert!(a_doc.iter().any(|e| e.anchor_status == "gone"), "doctor A flags A's gone anchor");

--- a/crates/rag-rat-core/src/index/oracle/tests/memory_bindings.rs
+++ b/crates/rag-rat-core/src/index/oracle/tests/memory_bindings.rs
@@ -31,6 +31,9 @@ fn path_binding_status_after_validate(h: &Harness, path: &str) -> String {
         bind: RepoMemoryBindTarget { path: Some(path.to_string()), ..Default::default() },
     })
     .unwrap();
+    // Twice: the #492 downgrade hysteresis defers a first gone observation, so the SETTLED
+    // status needs two passes (every other status is a fixpoint under repeated validation).
+    validate_memories(&h.conn, None).unwrap();
     validate_memories(&h.conn, None).unwrap();
     let memory = memory_by_id(&h.conn, &created.memory.memory_id).unwrap().unwrap();
     memory
@@ -259,6 +262,9 @@ fn moniker_binding_validation_statuses() {
     let memory_id = create_target_memory(&h, sym);
 
     let moniker_status = |h: &Harness| -> String {
+        // Twice: the #492 downgrade hysteresis defers a first gone observation, so the SETTLED
+        // status needs two passes (every other status is a fixpoint under repeated validation).
+        validate_memories(&h.conn, None).unwrap();
         validate_memories(&h.conn, None).unwrap();
         let memory = memory_by_id(&h.conn, &memory_id).unwrap().unwrap();
         memory
@@ -516,8 +522,10 @@ fn bare_path_binding_survives_file_edit_spanned_goes_stale() {
     );
     assert_eq!(status(&spanned), "stale", "spanned path binding still claims content");
 
-    // Deleting the file row sends both to gone.
+    // Deleting the file row sends both to gone — after TWO passes, per the #492 downgrade
+    // hysteresis (the first observation only arms the marker).
     h.conn.execute("DELETE FROM files WHERE id = ?1", [file]).unwrap();
+    validate_memories(&h.conn, None).unwrap();
     validate_memories(&h.conn, None).unwrap();
     assert_eq!(status(&bare), "gone");
     assert_eq!(status(&spanned), "gone");

--- a/crates/rag-rat-core/src/index/oracle/tests/monikers.rs
+++ b/crates/rag-rat-core/src/index/oracle/tests/monikers.rs
@@ -269,6 +269,11 @@ fn cross_version_moniker_match_requires_kind_corroboration() {
             .unwrap();
 
         validate_memories(&h.conn, None).unwrap();
+        if expect_status == "gone" {
+            // The #492 downgrade hysteresis defers the first gone observation; the relocated arm
+            // stays single-pass (a second pass would re-judge the freshly moved anchor).
+            validate_memories(&h.conn, None).unwrap();
+        }
         let memory = memory_by_id(&h.conn, &memory_id).unwrap().unwrap();
         let symbol_binding =
             memory.bindings.iter().find(|b| b.binding_kind == "symbol").expect("symbol binding");

--- a/crates/rag-rat-core/src/index/schema/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema/migrations.rs
@@ -1189,6 +1189,7 @@ pub(crate) fn known_version(migrations: &[AppliedMigration]) -> u32 {
             MIGRATION_052_ID => Some(52),
             MIGRATION_053_ID => Some(53),
             MIGRATION_054_ID => Some(54),
+            MIGRATION_055_ID => Some(55),
             _ => None,
         })
         .max()
@@ -1252,6 +1253,7 @@ pub(crate) fn known_migration(id: &str) -> bool {
             | MIGRATION_052_ID
             | MIGRATION_053_ID
             | MIGRATION_054_ID
+            | MIGRATION_055_ID
             | DIRTY_MIGRATION_ID
     )
 }
@@ -1312,6 +1314,7 @@ pub(crate) fn migration_checksum_mismatch(migration: &AppliedMigration) -> bool 
         MIGRATION_052_ID => migration.checksum != MIGRATION_052_CHECKSUM,
         MIGRATION_053_ID => migration.checksum != MIGRATION_053_CHECKSUM,
         MIGRATION_054_ID => migration.checksum != MIGRATION_054_CHECKSUM,
+        MIGRATION_055_ID => migration.checksum != MIGRATION_055_CHECKSUM,
         _ => false,
     }
 }
@@ -3680,6 +3683,16 @@ pub(crate) fn apply_oplog_device_identity(conn: &Connection) -> rusqlite::Result
 
          COMMIT;",
     )?;
+    Ok(())
+}
+
+/// V055 (#492): the anchor-status downgrade hysteresis marker. INVARIANT: NULL means "no gone
+/// observation is pending" — every persisted non-deferred stamp clears it, so a non-null marker
+/// only ever bridges two CONSECUTIVE gone observations of the same binding. Nullable and
+/// additive: existing rows start unarmed, and the pre-V055 behavior (immediate downgrade) simply
+/// becomes the two-pass rule from the next validate on.
+pub(crate) fn apply_binding_downgrade_marker(conn: &Connection) -> rusqlite::Result<()> {
+    add_column_if_missing(conn, "repo_memory_bindings", "downgrade_pending_at_ms", "INTEGER")?;
     Ok(())
 }
 

--- a/crates/rag-rat-core/src/index/schema/mod.rs
+++ b/crates/rag-rat-core/src/index/schema/mod.rs
@@ -19,7 +19,7 @@ pub use registry::{LEGACY_REPO_ID, register_repo, register_repo_read_only};
 use rusqlite::{Connection, OptionalExtension, params};
 use serde::Serialize;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 54;
+pub const LATEST_SCHEMA_VERSION: u32 = 55;
 
 /// Every oracle-DERIVED persisted table — the outputs an `oracle run` writes that must OUTLIVE a
 /// reindex.
@@ -374,6 +374,14 @@ const MIGRATION_054_DESCRIPTION: &str =
      the 32-byte seed, its derived public_key, and the sha256(public_key) fingerprint. \
      Store-global, not repo-scoped (a device is a machine identity). Purely additive; nothing is \
      wired to the live write path yet";
+const MIGRATION_055_ID: &str = "055_binding_downgrade_marker";
+const MIGRATION_055_CHECKSUM: &str = "sha256:rag-rat-binding-downgrade-marker-v55";
+const MIGRATION_055_DESCRIPTION: &str =
+    "Add repo_memory_bindings.downgrade_pending_at_ms (#492), the anchor-status downgrade \
+     hysteresis marker: a validate pass that observes a non-gone binding as gone arms the marker \
+     instead of stamping, and only a SECOND consecutive gone observation persists the downgrade — \
+     so a single torn observation (a validate racing a rebuild window, or a sweep from a narrower \
+     checkout) cannot flip a healthy anchor to gone and hand doctor destructive advice";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -839,6 +847,12 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         checksum: MIGRATION_054_CHECKSUM,
         description: MIGRATION_054_DESCRIPTION,
         apply: apply_oplog_device_identity,
+    },
+    Migration {
+        id: MIGRATION_055_ID,
+        checksum: MIGRATION_055_CHECKSUM,
+        description: MIGRATION_055_DESCRIPTION,
+        apply: apply_binding_downgrade_marker,
     },
 ];
 

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_memory.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_memory.rs
@@ -419,6 +419,8 @@ fn repo_memory_validate_marks_changed_or_missing_anchors_non_current() {
     assert_eq!(stale[0].bindings[0].anchor_status, "stale");
 
     db.storage.connection().execute("DELETE FROM chunks WHERE id = ?1", [chunk_id]).unwrap();
+    // Twice: the #492 downgrade hysteresis defers the first gone observation.
+    db.memory_validate().unwrap();
     let report = db.memory_validate().unwrap();
     assert_eq!(report.gone, 1);
     let gone = db.memory_for_symbol(&symbol, 10, crate::config::MemorySurface::Full).unwrap();
@@ -580,6 +582,8 @@ fn a_deleted_at_head_file_makes_a_bare_path_binding_gone() {
             [],
         )
         .unwrap();
+    // Twice: the #492 downgrade hysteresis defers the first gone observation.
+    db.memory_validate().unwrap();
     let report = db.memory_validate().unwrap();
     assert_eq!(status(&db), "gone", "the deleted marker must not shadow the file's absence");
     assert_eq!(report.gone, 1);
@@ -645,16 +649,24 @@ fn a_path_alive_only_in_another_scope_validates_pending_not_gone() {
             .unwrap()
     };
 
-    // A SUPERSEDED generation's not-yet-GC'd row is NOT alive-elsewhere evidence (the review
-    // case: a full rebuild deleted the file; pre-sweep the dead generation still holds a source
-    // row) — only live-generation rows (worktree overlays ride the live generation) count.
+    // An ABANDONED staging's row (generation above live) is NOT alive-elsewhere evidence — only
+    // live-generation rows (worktree overlays ride the live generation) count. It IS, however, a
+    // torn window for the #492 downgrade hysteresis: while it exists, the observed gone neither
+    // arms nor confirms, so the persisted status holds.
     insert_row(live_generation + 7, "dead-gen-sha");
     let report = db.memory_validate().unwrap();
-    assert_eq!(
-        status(&db),
-        "gone",
-        "a superseded generation's leftover row must not report pending"
-    );
+    assert_eq!(report.pending, 0, "a staged generation's leftover row must not report pending");
+    assert_eq!(report.gone, 1, "the observation is gone, not pending");
+    assert_eq!(status(&db), "current", "a staged-window observation must not move the status");
+
+    // gc sweeps the abandoned staging: the two-pass downgrade proceeds.
+    db.storage
+        .connection()
+        .execute("DELETE FROM main.files WHERE sha256 = 'dead-gen-sha'", [])
+        .unwrap();
+    db.memory_validate().unwrap();
+    let report = db.memory_validate().unwrap();
+    assert_eq!(status(&db), "gone", "two trustworthy observations persist the downgrade");
     assert_eq!(report.pending, 0);
 
     // A retained old-commit BASE row (worktree_id = '') at the live generation is THIS context's
@@ -1010,9 +1022,11 @@ fn server_derived_call_path_hash_is_stable_and_validates_through_edge_churn() {
     db.memory_validate().unwrap();
     assert_eq!(call_path_status(&db), "relocated", "a moved call site relocates the path");
 
-    // Remove the call site → the edge is gone → the call path is gone.
+    // Remove the call site → the edge is gone → the call path is gone. Two passes: the #492
+    // downgrade hysteresis defers the first gone observation.
     fs::write(root.join("src/lib.rs"), "pub fn caller() {}\npub fn callee() {}\n").unwrap();
     let db = IndexDatabase::rebuild(&config).unwrap();
+    db.memory_validate().unwrap();
     db.memory_validate().unwrap();
     assert_eq!(call_path_status(&db), "gone", "deleting the call site makes the path gone");
 
@@ -2213,6 +2227,9 @@ fn memory_doctor_lists_gone_and_suggests_candidates() {
     fs::remove_file(root.join("src/a.rs")).unwrap();
     fs::write(root.join("src/b.rs"), "pub fn doctor_src() -> u32 {\n    99\n}\n").unwrap();
     let db = IndexDatabase::rebuild(&config).unwrap();
+    // Twice: the #492 downgrade hysteresis defers the first gone observation, and doctor reads
+    // the PERSISTED status.
+    db.memory_validate().unwrap();
     let validate_report = db.memory_validate().unwrap();
     assert_eq!(
         validate_report.gone, 1,
@@ -2333,6 +2350,9 @@ fn memory_doctor_dedupes_cfg_split_candidates() {
     )
     .unwrap();
     let db = IndexDatabase::rebuild(&config).unwrap();
+    // Twice: the #492 downgrade hysteresis defers the first gone observation, and doctor reads
+    // the PERSISTED status.
+    db.memory_validate().unwrap();
     assert_eq!(db.memory_validate().unwrap().gone, 1, "binding must be gone");
 
     let entries = db.memory_doctor().unwrap();
@@ -3375,6 +3395,261 @@ fn typed_edges_add_traverse_and_resolve() {
     // filter).
     let from_dead = db.memory_edge_add(&a, "depends_on", node(&b)).unwrap_err();
     assert!(from_dead.to_string().contains("not found or is obsolete"), "{from_dead}");
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+/// #492: a single `gone` observation must not persist a downgrade — a validate pass racing a
+/// rebuild window (or sweeping from a narrower checkout context) can produce a torn observation,
+/// and doctor then hands out destructive mark-obsolete advice for healthy anchors. The persisted
+/// `anchor_status` downgrades only on the SECOND consecutive gone observation; the validation
+/// report still counts what each pass actually saw.
+#[test]
+fn a_downgrade_to_gone_needs_two_consecutive_observations() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), "pub fn keeper() {}\n").unwrap();
+    fs::write(root.join("src/doomed.rs"), "pub fn doomed() {}\n").unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let created = db
+        .memory_create(crate::query::memory::RepoMemoryCreate {
+            kind: "Risk".to_string(),
+            title: "Anchored to a file a torn pass will misjudge".to_string(),
+            body: "One gone observation arms the marker; only the second downgrades.".to_string(),
+            confidence: "medium".to_string(),
+            created_by: Some("test-agent".to_string()),
+            source: Some("agent".to_string()),
+            tags: Vec::new(),
+            payload_json: None,
+            bind: crate::query::memory::RepoMemoryBindTarget {
+                path: Some("src/doomed.rs".to_string()),
+                ..Default::default()
+            },
+        })
+        .unwrap();
+    let memory_id = created.memory.memory_id;
+    let persisted = |db: &IndexDatabase| -> (String, Option<i64>) {
+        db.storage
+            .connection()
+            .query_row(
+                "SELECT anchor_status, downgrade_pending_at_ms FROM repo_memory_bindings
+                 WHERE memory_id = ?1",
+                params![memory_id],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap()
+    };
+    db.memory_validate().unwrap();
+    assert_eq!(persisted(&db), ("current".to_string(), None), "alive file → current, unarmed");
+
+    fs::remove_file(root.join("src/doomed.rs")).unwrap();
+    db.storage
+        .connection()
+        .execute(
+            "UPDATE main.files SET kind = 'deleted', sha256 = '' WHERE path = 'src/doomed.rs'",
+            [],
+        )
+        .unwrap();
+
+    // First gone observation: the report says what the pass saw, but the persisted status holds
+    // and the marker arms.
+    let report = db.memory_validate().unwrap();
+    assert_eq!(report.gone, 1, "the report counts the computed observation");
+    let (status, marker) = persisted(&db);
+    assert_eq!(status, "current", "one observation must not persist the downgrade");
+    assert!(marker.is_some(), "the first gone observation arms the marker");
+
+    // Second consecutive observation: the downgrade lands and the marker clears.
+    let report = db.memory_validate().unwrap();
+    assert_eq!(report.gone, 1);
+    assert_eq!(
+        persisted(&db),
+        ("gone".to_string(), None),
+        "the second consecutive observation persists the downgrade and clears the marker"
+    );
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+/// #492: a positive observation between two gone observations disarms the pending downgrade — the
+/// ping-pong a pair of checkout contexts produces (one sees the anchor, one does not) must never
+/// land a persisted `gone`.
+#[test]
+fn a_recovered_anchor_clears_the_pending_downgrade() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), "pub fn keeper() {}\n").unwrap();
+    fs::write(root.join("src/wobbling.rs"), "pub fn wobbling() {}\n").unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let created = db
+        .memory_create(crate::query::memory::RepoMemoryCreate {
+            kind: "Risk".to_string(),
+            title: "Anchored to a file that wobbles across contexts".to_string(),
+            body: "A recovery between gone observations must disarm the downgrade.".to_string(),
+            confidence: "medium".to_string(),
+            created_by: Some("test-agent".to_string()),
+            source: Some("agent".to_string()),
+            tags: Vec::new(),
+            payload_json: None,
+            bind: crate::query::memory::RepoMemoryBindTarget {
+                path: Some("src/wobbling.rs".to_string()),
+                ..Default::default()
+            },
+        })
+        .unwrap();
+    let memory_id = created.memory.memory_id;
+    let persisted = |db: &IndexDatabase| -> (String, Option<i64>) {
+        db.storage
+            .connection()
+            .query_row(
+                "SELECT anchor_status, downgrade_pending_at_ms FROM repo_memory_bindings
+                 WHERE memory_id = ?1",
+                params![memory_id],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap()
+    };
+
+    fs::remove_file(root.join("src/wobbling.rs")).unwrap();
+    db.storage
+        .connection()
+        .execute(
+            "UPDATE main.files SET kind = 'deleted', sha256 = '' WHERE path = 'src/wobbling.rs'",
+            [],
+        )
+        .unwrap();
+    db.memory_validate().unwrap();
+    let (status, marker) = persisted(&db);
+    assert_eq!(status, "current");
+    assert!(marker.is_some(), "the gone observation arms the marker");
+
+    // The anchor recovers (the other context's view): the next pass re-asserts it and disarms
+    // the half-armed downgrade.
+    fs::write(root.join("src/wobbling.rs"), "pub fn wobbling() {}\n").unwrap();
+    db.storage
+        .connection()
+        .execute(
+            "UPDATE main.files SET kind = 'source', sha256 = 'restored'
+              WHERE path = 'src/wobbling.rs'",
+            [],
+        )
+        .unwrap();
+    db.memory_validate().unwrap();
+    assert_eq!(
+        persisted(&db),
+        ("current".to_string(), None),
+        "a positive observation stamps current and clears the marker"
+    );
+
+    // A later gone observation starts the two-pass rule from scratch.
+    fs::remove_file(root.join("src/wobbling.rs")).unwrap();
+    db.storage
+        .connection()
+        .execute(
+            "UPDATE main.files SET kind = 'deleted', sha256 = '' WHERE path = 'src/wobbling.rs'",
+            [],
+        )
+        .unwrap();
+    db.memory_validate().unwrap();
+    let (status, marker) = persisted(&db);
+    assert_eq!(status, "current", "the disarmed marker means the count restarts at one");
+    assert!(marker.is_some());
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+/// #492: while a STAGED generation exists for the repo (a rebuild is mid-flight, or an abandoned
+/// staging awaits gc), a gone observation is untrustworthy — the pass may be reading a
+/// half-published world. It must neither ARM nor CONFIRM a downgrade; the two-pass rule resumes
+/// once the staging clears.
+#[test]
+fn a_staged_generation_freezes_the_downgrade_rule() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), "pub fn keeper() {}\n").unwrap();
+    fs::write(root.join("src/torn.rs"), "pub fn torn() {}\n").unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let created = db
+        .memory_create(crate::query::memory::RepoMemoryCreate {
+            kind: "Risk".to_string(),
+            title: "Anchored while a rebuild is mid-flight".to_string(),
+            body: "A torn window's gone observation must not move the downgrade rule.".to_string(),
+            confidence: "medium".to_string(),
+            created_by: Some("test-agent".to_string()),
+            source: Some("agent".to_string()),
+            tags: Vec::new(),
+            payload_json: None,
+            bind: crate::query::memory::RepoMemoryBindTarget {
+                path: Some("src/torn.rs".to_string()),
+                ..Default::default()
+            },
+        })
+        .unwrap();
+    let memory_id = created.memory.memory_id;
+    let persisted = |db: &IndexDatabase| -> (String, Option<i64>) {
+        db.storage
+            .connection()
+            .query_row(
+                "SELECT anchor_status, downgrade_pending_at_ms FROM repo_memory_bindings
+                 WHERE memory_id = ?1",
+                params![memory_id],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap()
+    };
+
+    fs::remove_file(root.join("src/torn.rs")).unwrap();
+    db.storage
+        .connection()
+        .execute(
+            "UPDATE main.files SET kind = 'deleted', sha256 = '' WHERE path = 'src/torn.rs'",
+            [],
+        )
+        .unwrap();
+    // A staged (higher-than-live) generation row: the mid-flight rebuild window.
+    let live_generation =
+        crate::index::schema::live_files_generation(db.storage.connection(), &db.active_repo_id)
+            .unwrap();
+    db.storage
+        .connection()
+        .execute(
+            "INSERT INTO main.files (path, language, kind, sha256, modified_at_ms, generated,
+                                indexed_at_ms, indexed_revision, commit_sha, worktree_id,
+                                has_test_code, repo_id, generation)
+             VALUES ('src/staged.rs', 'rust', 'source', 'staged', 0, 0, 0, '', '', '', 0, ?1, ?2)",
+            params![db.active_repo_id, live_generation + 1],
+        )
+        .unwrap();
+
+    // Repeated gone observations inside the torn window: nothing arms, nothing confirms.
+    db.memory_validate().unwrap();
+    db.memory_validate().unwrap();
+    assert_eq!(
+        persisted(&db),
+        ("current".to_string(), None),
+        "a torn window's observations neither arm nor confirm the downgrade"
+    );
+
+    // The staging clears (published or gc-swept): the two-pass rule proceeds.
+    db.storage
+        .connection()
+        .execute("DELETE FROM main.files WHERE path = 'src/staged.rs'", [])
+        .unwrap();
+    db.memory_validate().unwrap();
+    let (status, marker) = persisted(&db);
+    assert_eq!(status, "current");
+    assert!(marker.is_some(), "the first trustworthy gone observation arms the marker");
+    db.memory_validate().unwrap();
+    assert_eq!(persisted(&db), ("gone".to_string(), None), "the second confirms");
 
     let _ = fs::remove_dir_all(&root);
 }

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
@@ -1471,10 +1471,13 @@ fn migration_053_scopes_the_oplog_by_stream_and_adds_fork_evidence() {
 fn migration_054_adds_the_single_row_device_identity_table() {
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     schema::apply(&conn).unwrap();
-    // V054 is the schema tip — this test carries the absolute pin (the older oplog tests dropped to
-    // the symbolic `current_version == LATEST` check).
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 54, "V054 is the schema tip");
-    assert_eq!(schema::status(&conn).unwrap().current_version, 54, "schema at LATEST after apply");
+    // The absolute-tip pin moved to `migration_055_*` (V055 is the tip now); this drops to the
+    // symbolic check, per the ladder convention.
+    assert_eq!(
+        schema::status(&conn).unwrap().current_version,
+        schema::LATEST_SCHEMA_VERSION,
+        "schema at LATEST after apply"
+    );
 
     // The identity table exists with its full column set.
     for column in ["seed", "public_key", "fingerprint", "created_at_ms"] {
@@ -1512,6 +1515,37 @@ fn migration_054_adds_the_single_row_device_identity_table() {
     assert!(
         conn_table_columns(&conn, "oplog_device_identity").contains(&"seed".to_string()),
         "the isolated applier recreates the table"
+    );
+}
+
+#[test]
+fn migration_055_adds_the_binding_downgrade_marker_column() {
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn).unwrap();
+    // V055 is the schema tip — this test carries the absolute pin (the older tests dropped to
+    // the symbolic `current_version == LATEST` check).
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 55, "V055 is the schema tip");
+    assert_eq!(schema::status(&conn).unwrap().current_version, 55, "schema at LATEST after apply");
+    assert!(
+        conn_table_columns(&conn, "repo_memory_bindings")
+            .contains(&"downgrade_pending_at_ms".to_string()),
+        "repo_memory_bindings carries the downgrade hysteresis marker (#492)"
+    );
+    // Additive + nullable: a re-apply is idempotent and the column survives.
+    schema::apply(&conn).unwrap();
+    assert!(
+        conn_table_columns(&conn, "repo_memory_bindings")
+            .contains(&"downgrade_pending_at_ms".to_string()),
+        "downgrade_pending_at_ms survives a re-apply"
+    );
+    // A forward migrate over a ledger truncated below V055 replays the step and lands the
+    // column (the standard lagging-index path).
+    truncate_schema_to(&conn, 54);
+    schema::migrate_forward(&conn).unwrap();
+    assert_eq!(
+        schema::status(&conn).unwrap().current_version,
+        schema::LATEST_SCHEMA_VERSION,
+        "forward migrate reaches the tip"
     );
 }
 

--- a/crates/rag-rat-core/src/query/memory/api.rs
+++ b/crates/rag-rat-core/src/query/memory/api.rs
@@ -964,17 +964,26 @@ pub(crate) fn validate_memories(
     let scope = memory_repo_scope(conn)?;
     let repo_clause =
         crate::index::schema::periphery_repo_scope_clause(&scope, "repo_memory_bindings");
+    // The downgrade-hysteresis torn-window guard (#492): while a STAGED (higher-than-live)
+    // generation exists for this repo — a rebuild is mid-flight, or an abandoned staging awaits
+    // gc — a `gone` observation may be reading a half-published world, so it must neither ARM
+    // nor CONFIRM a downgrade. Positive observations still stamp: evidence of presence is real
+    // in any window.
+    let staged_window = staged_generation_exists(conn, &scope)?;
     let mut stmt = conn.prepare(&format!(
         "
         SELECT memory_id, binding_kind, binding_id, path, start_line, end_line,
                logical_symbol_id, symbol_id, chunk_id, edge_id, commit_hash, github_owner,
                github_repo, github_number, symbol_kind, signature_hash, moniker_tool,
-               moniker_tool_version, relocation_reason, anchor_status, created_at_ms
+               moniker_tool_version, relocation_reason, anchor_status, created_at_ms,
+               downgrade_pending_at_ms
         FROM repo_memory_bindings
         WHERE 1=1{repo_clause}
         "
     ))?;
-    let rows = stmt.query_map([], binding_row)?;
+    let rows = stmt.query_map([], |row| {
+        Ok((binding_row(row)?, row.get::<_, Option<i64>>("downgrade_pending_at_ms")?))
+    })?;
     let tx = conn.unchecked_transaction()?;
     let mut report = RepoMemoryValidationReport {
         checked: 0,
@@ -986,47 +995,35 @@ pub(crate) fn validate_memories(
         unverified: 0,
     };
     for row in rows {
-        let mut binding = row?;
+        let (mut binding, downgrade_pending_at_ms) = row?;
         let original_binding_id = binding.binding_id.clone();
+        let stored_status = binding.anchor_status.clone();
         report.checked += 1;
         let status = validate_binding(conn, &mut binding, fs_root)?;
-        let updated = conn.execute(
-            "
-            UPDATE OR IGNORE repo_memory_bindings
-            SET anchor_status = ?3, logical_symbol_id = ?4, symbol_id = ?5, chunk_id = ?6,
-                edge_id = ?7, path = ?8, start_line = ?9, end_line = ?10,
-                binding_id = ?11, symbol_kind = ?12, signature_hash = ?13,
-                moniker_tool_version = ?15, relocation_reason = ?16
-            WHERE memory_id = ?1 AND binding_kind = ?2 AND binding_id = ?14
-            ",
-            params![
-                binding.memory_id,
-                binding.binding_kind,
-                status,
-                binding.logical_symbol_id,
-                binding.symbol_id,
-                binding.chunk_id,
-                binding.edge_id,
-                binding.path,
-                binding.start_line,
-                binding.end_line,
-                binding.binding_id,
-                binding.symbol_kind,
-                binding.signature_hash,
-                original_binding_id,
-                binding.moniker_tool_version,
-                binding.relocation_reason
-            ],
-        )?;
-        // UPDATE OR IGNORE: if a sibling binding already holds the new (memory_id, kind,
-        // binding_id) PK, the rewrite is a no-op rather than a crash. Drop the
-        // now-duplicate stale row.
-        if updated == 0 && binding.binding_id != original_binding_id {
-            conn.execute(
-                "DELETE FROM repo_memory_bindings
-                 WHERE memory_id = ?1 AND binding_kind = ?2 AND binding_id = ?3",
-                params![binding.memory_id, binding.binding_kind, original_binding_id],
-            )?;
+        // Downgrade hysteresis (#492): a single `gone` observation of a not-yet-gone binding is
+        // exactly what a torn pass produces (a validate racing a rebuild window, or a sweep from
+        // a checkout context that cannot see the anchor another context re-asserts), and a
+        // persisted `gone` is what doctor turns into destructive mark-obsolete advice. So a
+        // FIRST gone observation only ARMS `downgrade_pending_at_ms` — the stored row stays as
+        // it was — and only a SECOND consecutive one persists the downgrade. Any non-gone stamp
+        // clears the marker (the ping-pong never lands), and a staged-generation window freezes
+        // the rule entirely (see `staged_window` above). The REPORT keeps counting the computed
+        // observation: what this pass saw is honest; only what doctor reads is hysteresis-
+        // guarded.
+        if status == "gone" && stored_status != "gone" {
+            if staged_window {
+                // Untrustworthy observation: leave the row exactly as it was.
+            } else if downgrade_pending_at_ms.is_none() {
+                conn.execute(
+                    "UPDATE repo_memory_bindings SET downgrade_pending_at_ms = ?4
+                     WHERE memory_id = ?1 AND binding_kind = ?2 AND binding_id = ?3",
+                    params![binding.memory_id, binding.binding_kind, original_binding_id, now_ms()],
+                )?;
+            } else {
+                stamp_validated_binding(conn, &binding, &original_binding_id, &status)?;
+            }
+        } else {
+            stamp_validated_binding(conn, &binding, &original_binding_id, &status)?;
         }
         match status.as_str() {
             "current" => report.current += 1,
@@ -1039,4 +1036,72 @@ pub(crate) fn validate_memories(
     }
     tx.commit()?;
     Ok(report)
+}
+
+/// Persist one validated binding: the full field rewrite `validate_memories` stamps for every
+/// non-deferred observation. Clears `downgrade_pending_at_ms` — a persisted stamp is either an
+/// upgrade (the anchor is seen again; the pending downgrade is disarmed) or the confirmed
+/// downgrade itself (the marker's job is done).
+fn stamp_validated_binding(
+    conn: &Connection,
+    binding: &RepoMemoryBinding,
+    original_binding_id: &str,
+    status: &str,
+) -> anyhow::Result<()> {
+    let updated = conn.execute(
+        "
+        UPDATE OR IGNORE repo_memory_bindings
+        SET anchor_status = ?3, logical_symbol_id = ?4, symbol_id = ?5, chunk_id = ?6,
+            edge_id = ?7, path = ?8, start_line = ?9, end_line = ?10,
+            binding_id = ?11, symbol_kind = ?12, signature_hash = ?13,
+            moniker_tool_version = ?15, relocation_reason = ?16,
+            downgrade_pending_at_ms = NULL
+        WHERE memory_id = ?1 AND binding_kind = ?2 AND binding_id = ?14
+        ",
+        params![
+            binding.memory_id,
+            binding.binding_kind,
+            status,
+            binding.logical_symbol_id,
+            binding.symbol_id,
+            binding.chunk_id,
+            binding.edge_id,
+            binding.path,
+            binding.start_line,
+            binding.end_line,
+            binding.binding_id,
+            binding.symbol_kind,
+            binding.signature_hash,
+            original_binding_id,
+            binding.moniker_tool_version,
+            binding.relocation_reason
+        ],
+    )?;
+    // UPDATE OR IGNORE: if a sibling binding already holds the new (memory_id, kind,
+    // binding_id) PK, the rewrite is a no-op rather than a crash. Drop the
+    // now-duplicate stale row.
+    if updated == 0 && binding.binding_id != original_binding_id {
+        conn.execute(
+            "DELETE FROM repo_memory_bindings
+             WHERE memory_id = ?1 AND binding_kind = ?2 AND binding_id = ?3",
+            params![binding.memory_id, binding.binding_kind, original_binding_id],
+        )?;
+    }
+    Ok(())
+}
+
+/// Whether a STAGED (higher-than-live) `files` generation exists for the scoped repo (#492): a
+/// rebuild is mid-flight, or an abandoned staging awaits gc. Scope `None` (a pre-scoping ladder
+/// state) reads as no window — the guard is a refinement, never a gate on validation itself.
+fn staged_generation_exists(conn: &Connection, scope: &Option<String>) -> anyhow::Result<bool> {
+    let Some(repo_id) = scope.as_deref() else {
+        return Ok(false);
+    };
+    let live = crate::index::schema::live_files_generation(conn, repo_id)?;
+    let staged: bool = conn.query_row(
+        "SELECT EXISTS(SELECT 1 FROM main.files WHERE repo_id = ?1 AND generation > ?2)",
+        params![repo_id, live],
+        |row| row.get(0),
+    )?;
+    Ok(staged)
 }

--- a/crates/rag-rat-mcp/src/server.rs
+++ b/crates/rag-rat-mcp/src/server.rs
@@ -722,7 +722,9 @@ mod tests {
             }),
         )
         .unwrap();
-        // A path binding is created `current`; validation flips the absent path to `gone`.
+        // A path binding is created `current`; validation flips the absent path to `gone` —
+        // after TWO passes, per the #492 downgrade hysteresis (the first only arms the marker).
+        toon.call("memory_validate", json!({})).unwrap();
         toon.call("memory_validate", json!({})).unwrap();
 
         // TOON (default, LLM-facing): nudge present as a second block.


### PR DESCRIPTION
A validate pass racing a rebuild window — or sweeping from a checkout context that cannot see an anchor another context keeps re-asserting — produces a torn `gone` observation. A single such observation used to persist immediately, and doctor then read the downgraded status and handed out destructive mark-obsolete advice for healthy anchors. Observed live on the dogfood DB as a `current`/`gone` ping-pong between contexts.

## Design

- **V055** adds `repo_memory_bindings.downgrade_pending_at_ms` (nullable INTEGER). NULL means no gone observation is pending; a non-null marker only ever bridges two consecutive gone observations of the same binding.
- **Two-observation rule** in `validate_memories`: a `gone` observation of a not-yet-gone binding no longer stamps. The FIRST observation arms the marker and leaves the row untouched; only a SECOND consecutive one persists the downgrade (and clears the marker). Any non-gone stamp clears the marker, so the `current`/`gone` ping-pong between two contexts never lands a persisted downgrade.
- **Torn-window guard**: while a staged (higher-than-live) `files` generation exists for the repo — a rebuild is mid-flight, or an abandoned staging awaits gc — a gone observation neither arms nor confirms; the observation itself is untrustworthy. Positive observations still stamp in any window.
- The validation **report** keeps counting the computed observation (what this pass saw); only the persisted `anchor_status` — what doctor reads and remediation acts on — is hysteresis-guarded.

## Tests

Three red-first behavior tests (two-pass downgrade, recovery disarms the pending marker, staged-generation freeze) plus the V055 migration test. Nine existing tests that arranged a persisted `gone` in one pass now validate twice; the relocated arm of the cross-version moniker test stays single-pass (a second pass re-judges the freshly moved anchor).

Fixes #492