### PR TITLE
perf(reconcile): skip the policy re-parse for current chunks on the backlog gate

### DIFF
--- a/crates/rag-rat-core/src/index/ai/policy.rs
+++ b/crates/rag-rat-core/src/index/ai/policy.rs
@@ -7,14 +7,26 @@ pub(crate) fn needs_embedding(
     dim: usize,
     max_embedding_chars: usize,
 ) -> bool {
-    let input = build_embedding_input(chunk, max_embedding_chars);
-    let expected_input_hash = embedding_input_hash(model_id, model_version, &input.text);
-    chunk.embedding_status.as_deref() != Some("Current")
+    // Evaluate the CHEAP staleness signals first. The only clause that needs the (O(text))
+    // embedding input + its hash is the `input_hash` comparison, so defer building them until
+    // every cheaper signal has said "fresh" — a chunk that is missing (no embedding row →
+    // status != "Current"), re-hashed, model-/dim-/text-version-shifted is decided here without
+    // touching the text. This is a pure reordering of an OR chain (`build_embedding_input` is
+    // side-effect-free), so the boolean is byte-identical; it matters because
+    // `estimated_reconcile_jobs` runs this per candidate on the idle watcher/maintenance gate,
+    // where a repo full of policy-skipped chunks (all missing, so decided by the first clause)
+    // must not pay a build+hash each pass.
+    if chunk.embedding_status.as_deref() != Some("Current")
         || chunk.source_text_hash.as_deref() != Some(chunk.text_hash.as_str())
         || chunk.model_version.as_deref() != Some(model_version)
         || chunk.embedding_dim != Some(i64::try_from(dim).unwrap_or(i64::MAX))
-        || chunk.input_hash.as_deref() != Some(expected_input_hash.as_str())
         || chunk.embedding_text_version.as_deref() != Some(EMBEDDING_TEXT_VERSION)
+    {
+        return true;
+    }
+    let input = build_embedding_input(chunk, max_embedding_chars);
+    let expected_input_hash = embedding_input_hash(model_id, model_version, &input.text);
+    chunk.input_hash.as_deref() != Some(expected_input_hash.as_str())
 }
 
 /// How the `SkipLowSignal` gate classifies a chunk. Evaluated ONLY if the cheaper gates

--- a/crates/rag-rat-core/src/index/ai/reconcile/embed_loop.rs
+++ b/crates/rag-rat-core/src/index/ai/reconcile/embed_loop.rs
@@ -120,7 +120,7 @@ pub(crate) fn reconcile_with_options_progress(
     //    (`provision_remote=false`) whose local `query_endpoint` is absent or UNREACHABLE — defer
     //    incremental embedding to an explicit reconcile. (WITH a REACHABLE `query_endpoint`, that
     //    pass takes the light local-embed path → `Ready`, not here.) Returning here avoids paying
-    //    the O(repo) `embedding_policy_skip_summary` just to report a deferral.
+    //    the repo-wide `embedding_policy_skip_summary` scan just to report a deferral.
     //  - NoEphemeralWork: an explicit provisioning reconcile on an already-current ephemeral model
     //    (never cold-start a paid box for zero work, #330-6). `acquire_chunk_embedder` confirmed
     //    ZERO candidates, so the policy scan would likewise be wasted work.
@@ -186,7 +186,7 @@ pub(crate) fn reconcile_with_options_progress(
         other => other,
     };
 
-    // Ready / NotReady: BOTH report the per-policy skip counts, so run the O(repo) policy summary
+    // Ready / NotReady: BOTH report the per-policy skip counts, so run the repo-wide policy summary
     // now. (SkipEphemeral already returned above without paying it.)
     let skipped_by_policy = embedding_policy_skip_summary(conn, max_embedding_chars)?;
     let skipped_chunks = skipped_by_policy.values().sum();
@@ -739,17 +739,20 @@ pub(crate) fn embedding_policy_skip_summary(
     conn: &Connection,
     max_embedding_chars: usize,
 ) -> anyhow::Result<BTreeMap<String, u64>> {
-    let mut skipped_by_policy = BTreeMap::new();
-    // STREAM the chunks one row at a time, counting skips, instead of materializing every chunk.
-    // The previous `current_chunks(conn, None)` loaded ALL chunk rows — including each chunk's full
-    // `text` — into a `Vec` just to produce this count. On a kernel-sized index (~4.2M chunks) that
-    // is ~4 GB resident for a summary that keeps nothing per row, and it runs on every reconcile
-    // (and `reconcile_plan`), so it dominated `index --full` peak memory. The same
-    // `embedding_policy_for_chunk` runs over the same chunks, so the counts are identical.
+    // Re-derive each chunk's policy from its text and count the ineligible ones by category. This
+    // is DIAGNOSTIC-ONLY (reported in status/plan; nothing gates work on it). It deliberately does
+    // NOT read the persisted `chunks.embedding_policy`: that column is stamped at index time with
+    // DEFAULT_MAX_EMBEDDING_CHARS and (for chunks predating its migration) defaults to 'Embed'
+    // without a backfill, so aggregating it would under-report the skips the authoritative
+    // `select_reconcile_batch` (which recomputes with the runtime cap) actually makes — defeating
+    // the summary's whole job of explaining WHY nothing embedded. Recomputing keeps it exact for
+    // any cap and any index age. Streams one chunk at a time to bound memory (#379): the previous
+    // `current_chunks(conn, None)` materialized every chunk's decompressed text into a `Vec`.
     //
-    // Chunk text comes from the compressed `chunk_text` store (#77 Phase 2); the `chunks.text`
-    // column is gone, so INNER JOIN `chunk_text` (every live chunk has one blob). One dict decoder
-    // for the whole stream (versions loaded once, reused per row).
+    // The hotter watcher/maintenance gate (`estimated_reconcile_jobs`) avoids this scan entirely by
+    // ordering its freshness check before the policy check (#522), so the parse there fires only
+    // for genuinely stale chunks.
+    let mut skipped_by_policy = BTreeMap::new();
     let dicts = crate::query::chunk_text_dicts(conn)?;
     let mut decoder = crate::index::text_compression::ChunkTextDecoder::new(&dicts);
     let mut stmt = conn.prepare(

--- a/crates/rag-rat-core/src/index/ai/store.rs
+++ b/crates/rag-rat-core/src/index/ai/store.rs
@@ -53,8 +53,7 @@ pub(crate) fn current_chunk_row(
 /// on the fly and handing the owned [`CurrentChunk`] to `f` — WITHOUT collecting the whole set into
 /// a `Vec`. This bounds the resident memory of a full-index pass to one chunk's text at a time.
 /// `embedding_reconcile_plan` counts over it so a plan on a kernel-scale index never materializes
-/// every candidate's decompressed text at once (#379, mirroring the already-streamed
-/// `embedding_policy_skip_summary`). `limit == None` walks every candidate.
+/// every candidate's decompressed text at once (#379). `limit == None` walks every candidate.
 pub(crate) fn for_each_embedding_candidate(
     conn: &Connection,
     model_id: &str,
@@ -248,8 +247,9 @@ pub(crate) fn estimated_reconcile_jobs(
     // peak. The `force` branch queries with an empty model_id (no embedding rows join, so every
     // chunk is a candidate — matching the old `current_chunks`); otherwise use the active model
     // so `needs_embedding` sees each chunk's embedding row. Text is still decompressed per row
-    // (both `policy_for_job` and `needs_embedding` read it), but only ONE chunk is resident at
-    // a time now.
+    // (`needs_embedding`'s input hash reads it; `policy_for_job` reads it only for the stale
+    // chunks that reach the policy gate after the #522 reorder), but only ONE chunk is resident
+    // at a time now.
     let (model_id, model_version, dim, changed_first) = if options.force {
         ("", "", 0, false)
     } else {
@@ -264,15 +264,25 @@ pub(crate) fn estimated_reconcile_jobs(
         options.limit,
         changed_first,
         |candidate| {
-            let eligible = policy_for_job(&candidate, scan.max_embedding_chars).eligible
-                && (options.force
-                    || needs_embedding(
-                        &candidate,
-                        scan.model_id,
-                        scan.model_version,
-                        scan.dim,
-                        scan.max_embedding_chars,
-                    ));
+            // Freshness FIRST, policy second (#522). Both operands are pure, so `&&` commutes and
+            // the count is byte-identical to the old policy-first order — but in steady state most
+            // chunks are already `Current`, so `needs_embedding` returns false and short-circuits
+            // BEFORE `policy_for_job`, whose low-signal gate would otherwise re-parse the chunk
+            // with tree-sitter. The parse now runs only for genuinely stale chunks (about to be
+            // embedded anyway) or under `--force` (where `options.force` short-circuits
+            // `needs_embedding`). Policy-skipped chunks (generated/tiny/fixture) are always
+            // missing, so `needs_embedding` decides them on its first (cheap) clause
+            // without building or hashing the text — the idle gate does not pay an
+            // O(text) pass per skipped chunk.
+            let eligible = (options.force
+                || needs_embedding(
+                    &candidate,
+                    scan.model_id,
+                    scan.model_version,
+                    scan.dim,
+                    scan.max_embedding_chars,
+                ))
+                && policy_for_job(&candidate, scan.max_embedding_chars).eligible;
             if eligible {
                 count = count.saturating_add(1);
             }

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/reconcile_embeddings.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/reconcile_embeddings.rs
@@ -712,6 +712,135 @@ fn reconcile_policy_skips_tiny_chunks_before_embedding() {
 }
 
 #[test]
+fn policy_skip_summary_recomputes_exactly_for_a_non_default_char_cap() {
+    // #522: the skip summary recomputes each chunk's policy against the RUNTIME cap — it must not
+    // trust the persisted `chunks.embedding_policy` (stamped at index time with the default cap),
+    // so the diagnostic matches what the authoritative `select_reconcile_batch` will actually skip.
+    // A ~5 KB generated chunk is SkipGenerated at the default cap (5 KB < 16 KB) but SkipTooLarge
+    // at cap=1000 (5 KB > 4 KB); the summary bucket must track the cap actually used.
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("gen")).unwrap();
+    // ~5.3 KB across 80 lines (one generated chunk: split_text_chunks flushes every 160 lines).
+    let big =
+        "// generated data line with sufficient length to matter for the cap xxxxx\n".repeat(80);
+    fs::write(root.join("gen/bindings.rs"), &big).unwrap();
+    let config = Config {
+        repo_id_override: None,
+        database_key_pinned: true,
+        root: root.clone(),
+        database: root.join(".rag-rat/index.sqlite"),
+        targets: vec![ResolvedTarget {
+            name: "generated".to_string(),
+            language: Language::Rust,
+            directories: vec![PathBuf::from("gen")],
+            include: vec!["gen/".to_string()],
+            exclude: Vec::new(),
+            kind: TargetKind::Generated,
+        }],
+        llm: Default::default(),
+        watch: Default::default(),
+        version_check: Default::default(),
+        oracle: Default::default(),
+        search: Default::default(),
+        memory: Default::default(),
+        log: Default::default(),
+        source_root_reanchored_from: None,
+        allow_empty: false,
+    };
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    db.install_model(HASH_MODEL_ID, None).unwrap();
+
+    // Default cap: the persisted (default-stamped) policy is SkipGenerated; the fast path agrees.
+    let default_run = db
+        .reconcile_with_options_progress(
+            crate::index::ai::ReconcileOptions { batch_size: Some(8), ..Default::default() },
+            |_| {},
+        )
+        .unwrap();
+    assert!(
+        default_run.skipped_by_policy.get("SkipGenerated").copied().unwrap_or(0) >= 1,
+        "default cap: {:?}",
+        default_run.skipped_by_policy
+    );
+    assert_eq!(
+        default_run.skipped_by_policy.get("SkipTooLarge"),
+        None,
+        "default cap must not see SkipTooLarge: {:?}",
+        default_run.skipped_by_policy
+    );
+
+    // Non-default cap: the fallback recomputes and the same chunk is now SkipTooLarge — the report
+    // explains the skip that `select_reconcile_batch` (which also uses the runtime cap) will make.
+    let small_cap_run = db
+        .reconcile_with_options_progress(
+            crate::index::ai::ReconcileOptions {
+                batch_size: Some(8),
+                max_embedding_chars: 1_000,
+                ..Default::default()
+            },
+            |_| {},
+        )
+        .unwrap();
+    assert!(
+        small_cap_run.skipped_by_policy.get("SkipTooLarge").copied().unwrap_or(0) >= 1,
+        "cap=1000 must recompute SkipTooLarge: {:?}",
+        small_cap_run.skipped_by_policy
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn policy_skip_summary_buckets_ineligible_chunks_across_categories() {
+    // #522: the skip summary must bucket ineligible chunks by policy across distinct categories
+    // (SkipTooSmall, SkipGenerated), never count an eligible `Embed` chunk, and leave a supported
+    // language out of SkipLanguageUnsupported.
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src/generated")).unwrap();
+    // A real, embeddable function (>= MIN_EMBEDDING_CHARS, real body → Embed) plus a tiny one
+    // (< 80 chars → SkipTooSmall).
+    fs::write(
+        root.join("src/lib.rs"),
+        "pub fn real_function_with_a_meaningful_body(input: usize) -> usize {\n    let doubled = \
+         input * 2;\n    doubled + 7\n}\n\nfn x() {}\n",
+    )
+    .unwrap();
+    // Path-heuristic codegen under a Source target still gets symbols, but every chunk is
+    // SkipGenerated (looks_generated_path fires on `/generated/`).
+    fs::write(
+        root.join("src/generated/bindings.rs"),
+        "pub fn generated_alpha() -> u32 {\n    1\n}\n\npub fn generated_beta() -> u32 {\n    \
+         2\n}\n",
+    )
+    .unwrap();
+
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    db.install_model(HASH_MODEL_ID, None).unwrap();
+
+    let skipped = db.reconcile_plan().unwrap().embeddings.skipped_by_policy;
+
+    // The summary holds ONLY ineligible chunks — an eligible `Embed` chunk is never a bucket.
+    assert!(
+        !skipped.contains_key("Embed"),
+        "Embed must not appear in the skip summary: {skipped:?}"
+    );
+    // The tiny `fn x() {}` chunk.
+    assert_eq!(skipped.get("SkipTooSmall"), Some(&1), "summary: {skipped:?}");
+    // Both generated functions (plus any generated context chunk) — path-heuristic SkipGenerated.
+    assert!(
+        skipped.get("SkipGenerated").copied().unwrap_or(0) >= 2,
+        "expected >=2 SkipGenerated: {skipped:?}"
+    );
+    // Rust is a supported embedding language.
+    assert_eq!(skipped.get("SkipLanguageUnsupported"), None, "summary: {skipped:?}");
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
 fn reconcile_plan_reports_policy_skips_for_fastembed_model() {
     let (root, config) = markdown_config("tiny\n");
     let db = IndexDatabase::rebuild(&config).unwrap();


### PR DESCRIPTION
The reconcile paths recompute each chunk's embedding policy from text on hot loops, and the policy's low-signal gate parses the chunk with tree-sitter (a worker-thread spawn + text copy per call). Freshness is a cheaper gate than policy, so the hottest path can skip the parse for chunks that don't need embedding.

Fixes #522.

## Backlog estimator → freshness-first gate

`estimated_reconcile_jobs` is the watcher/maintenance backlog gate (`pending_embedding_jobs`) — the most frequent of these paths, firing on every file change. It ANDed policy eligibility with a `needs_embedding` freshness check, **policy first**. Both operands are pure, so the order is reordered to **freshness-first**: the count is byte-identical, but in steady state most chunks are already `Current`, so `needs_embedding` short-circuits before `policy_for_job` and its tree-sitter parse never runs. The parse now fires only for genuinely stale chunks (about to be embedded anyway) or under `--force`.

## `needs_embedding` made lazy (keeps the win symmetric)

`needs_embedding` built the embedding input + SHA256 **unconditionally**, but that hash feeds only one of its six OR-clauses. So a naive reorder would make the gate pay an O(text) build+hash for every *policy-skipped* chunk (generated/tiny/fixture — permanently missing, re-evaluated each idle pass). Fixed at the root: the `input_hash` clause moves last and the text is built only after every cheaper staleness signal has said "fresh". The boolean is byte-identical (`build_embedding_input` is side-effect-free), so a skipped chunk — decided by the first clause (`status != Current`) — costs no build+hash, and every `needs_embedding` caller (`select_reconcile_batch` too) gets faster for stale chunks. (Caught in review.)

## Diagnostic summary: recompute, deliberately

`embedding_policy_skip_summary` keeps re-deriving policy from text rather than aggregating the persisted `chunks.embedding_policy`. That column is stamped at index time with `DEFAULT_MAX_EMBEDDING_CHARS`, and (for chunks predating its migration, which had no backfill) defaults to `'Embed'`. Aggregating it would under-report the skips the authoritative `select_reconcile_batch` actually makes on a non-default `max_embedding_chars` or an older index — defeating a diagnostic whose whole job is explaining *why nothing embedded*. An earlier revision added a `GROUP BY` fast path; review surfaced exactly those divergences, so it was dropped. A correct fast path needs a full-rebuild version stamp (an incremental pass can't certify unchanged chunks are fresh) — filed as **#530**.

`embedding_reconcile_plan`'s classification loop is likewise left alone — it needs per-candidate eligibility for every chunk.

## Tests

- `policy_skip_summary_buckets_ineligible_chunks_across_categories` — the summary buckets ineligible chunks by category, never counts an eligible `Embed`, leaves a supported language out of `SkipLanguageUnsupported`.
- `policy_skip_summary_recomputes_exactly_for_a_non_default_char_cap` — a ~5 KB generated chunk is `SkipGenerated` at the default cap but `SkipTooLarge` at cap=1000; the summary tracks the runtime cap (what `select_reconcile_batch` skips).
- Full workspace suite green (2053 tests); clippy clean; existing count-pinning reconcile tests unchanged.
