### PR TITLE
feat(oracle): live LSP client substrate for the incremental resolution path

### DIFF
--- a/crates/rag-rat-core/src/index/oracle/lsp/client.rs
+++ b/crates/rag-rat-core/src/index/oracle/lsp/client.rs
@@ -1,0 +1,388 @@
+//! The resident LSP client: process lifecycle (spawn, `initialize` handshake with position-encoding
+//! negotiation, graceful `shutdown`, kill-on-drop) and synchronous JSON-RPC request/response over
+//! the [`super::protocol`] framing. Single-flight by design — slice 1 issues one request at a time
+//! from the maintenance-pass worker thread — so `request` reads until it sees the response for the
+//! id it just sent, skipping interleaved notifications and replying `MethodNotFound` to any
+//! server→client request so a server awaiting that reply can't deadlock the loop.
+//!
+//! The transport is injectable (`Box<dyn Write/BufRead>`): [`LspClient::spawn`] wires a child
+//! process, while tests wire an in-process fake server over `std::io::pipe`. That is what makes the
+//! whole client unit-testable without a real `rust-analyzer`.
+
+use std::io::{self, BufRead, BufReader, Write};
+use std::process::{Child, Command, Stdio};
+
+use serde_json::{Value, json};
+
+use super::position::LspEncoding;
+use super::protocol;
+
+/// The JSON-RPC `MethodNotFound` code — a server's answer for a method it doesn't implement (an
+/// optional request like `textDocument/moniker`), and the code we reply with to a server→client
+/// request we don't handle.
+const METHOD_NOT_FOUND: i64 = -32601;
+
+/// A JSON-RPC error object from a response (`code` + `message`), so callers can distinguish a
+/// `MethodNotFound` (optional-capability) from a real failure.
+struct LspRpcError {
+    code: i64,
+    message: String,
+}
+
+/// A live language-server session. Owns the transport and (for a spawned server) the child process,
+/// which it kills on drop so a crashed or abandoned pass never leaks a resident `rust-analyzer`.
+pub(crate) struct LspClient {
+    writer: Box<dyn Write + Send>,
+    reader: Box<dyn BufRead + Send>,
+    next_id: i64,
+    encoding: LspEncoding,
+    /// The child process for a spawned server; `None` for an injected (test) transport. Present so
+    /// [`Drop`] can hard-kill it.
+    child: Option<Child>,
+}
+
+impl LspClient {
+    /// Spawn `program args…` as a language server, piping its stdio into the JSON-RPC transport.
+    /// stderr is discarded (server diagnostics are not part of the protocol). The session starts at
+    /// the LSP default encoding (UTF-16) until [`initialize`](Self::initialize) negotiates one.
+    pub(crate) fn spawn(program: &str, args: &[&str]) -> io::Result<Self> {
+        let mut child = Command::new(program)
+            .args(args)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()?;
+        let stdin =
+            child.stdin.take().ok_or_else(|| io::Error::other("child stdin unavailable"))?;
+        let stdout =
+            child.stdout.take().ok_or_else(|| io::Error::other("child stdout unavailable"))?;
+        Ok(Self {
+            writer: Box::new(stdin),
+            reader: Box::new(BufReader::new(stdout)),
+            next_id: 1,
+            encoding: LspEncoding::Utf16,
+            child: Some(child),
+        })
+    }
+
+    /// Build a client over an injected transport (no child process). The fake-server test seam.
+    fn from_transport(reader: Box<dyn BufRead + Send>, writer: Box<dyn Write + Send>) -> Self {
+        Self { writer, reader, next_id: 1, encoding: LspEncoding::Utf16, child: None }
+    }
+
+    /// The position encoding negotiated during [`initialize`](Self::initialize) (UTF-16 until
+    /// then).
+    pub(crate) fn encoding(&self) -> LspEncoding {
+        self.encoding
+    }
+
+    /// Send a request and return its `result`, mapping a JSON-RPC `error` response to an `Err`.
+    pub(crate) fn request(&mut self, method: &str, params: Value) -> io::Result<Value> {
+        match self.request_raw(method, params)? {
+            Ok(result) => Ok(result),
+            Err(err) => Err(io::Error::other(format!("LSP error {}: {}", err.code, err.message))),
+        }
+    }
+
+    /// A request whose method the server may not support: a `MethodNotFound` (-32601) error becomes
+    /// `Ok(None)` (the server lacks the capability) rather than failing the caller; a resolved
+    /// response is `Ok(Some(result))`; any OTHER JSON-RPC error still propagates. Used for optional
+    /// requests like `textDocument/moniker`.
+    pub(crate) fn request_optional(
+        &mut self,
+        method: &str,
+        params: Value,
+    ) -> io::Result<Option<Value>> {
+        match self.request_raw(method, params)? {
+            Ok(result) => Ok(Some(result)),
+            Err(err) if err.code == METHOD_NOT_FOUND => Ok(None),
+            Err(err) => Err(io::Error::other(format!("LSP error {}: {}", err.code, err.message))),
+        }
+    }
+
+    /// Send a request and block until its response arrives, returning the `result` (`Ok(Ok)`) or
+    /// the JSON-RPC error object (`Ok(Err)`); the outer `io::Result` is the transport. While
+    /// waiting it skips notifications AND — crucially — REPLIES to any server→client request
+    /// with a `MethodNotFound` error, because a server that awaits that reply before answering
+    /// us would otherwise deadlock this single-flight loop (slice 3 can add real handlers for
+    /// `workspace/configuration` etc.).
+    fn request_raw(
+        &mut self,
+        method: &str,
+        params: Value,
+    ) -> io::Result<Result<Value, LspRpcError>> {
+        let id = self.next_id;
+        self.next_id += 1;
+        let request = json!({"jsonrpc": "2.0", "id": id, "method": method, "params": params});
+        protocol::write_message(&mut self.writer, &request)?;
+        loop {
+            let msg = protocol::read_message(&mut self.reader)?.ok_or_else(|| {
+                io::Error::new(io::ErrorKind::UnexpectedEof, "server closed before responding")
+            })?;
+            // A `method`-bearing message is server→client: a notification (no id) is ignored; a
+            // request (id present) MUST be answered so the server doesn't block waiting on us.
+            if msg.get("method").is_some() {
+                if let Some(peer_id) = msg.get("id") {
+                    let reply = json!({
+                        "jsonrpc": "2.0", "id": peer_id.clone(),
+                        "error": {"code": METHOD_NOT_FOUND,
+                                  "message": "not handled by the rag-rat live oracle"}
+                    });
+                    protocol::write_message(&mut self.writer, &reply)?;
+                }
+                continue;
+            }
+            // A response with no `method`: ours iff the id matches (single-flight; a stray id is
+            // skipped defensively).
+            if msg.get("id").and_then(Value::as_i64) != Some(id) {
+                continue;
+            }
+            if let Some(error) = msg.get("error") {
+                return Ok(Err(LspRpcError {
+                    code: error.get("code").and_then(Value::as_i64).unwrap_or(0),
+                    message: error
+                        .get("message")
+                        .and_then(Value::as_str)
+                        .unwrap_or_default()
+                        .to_string(),
+                }));
+            }
+            return Ok(Ok(msg.get("result").cloned().unwrap_or(Value::Null)));
+        }
+    }
+
+    /// Send a notification (no id, no response expected).
+    pub(crate) fn notify(&mut self, method: &str, params: Value) -> io::Result<()> {
+        let notification = json!({"jsonrpc": "2.0", "method": method, "params": params});
+        protocol::write_message(&mut self.writer, &notification)
+    }
+
+    /// The `initialize`/`initialized` handshake: advertise the byte-space-friendly encodings we
+    /// support, record the one the server negotiates (defaulting to the LSP protocol default,
+    /// UTF-16, when the server doesn't echo one), and confirm with `initialized`.
+    pub(crate) fn initialize(&mut self, root_uri: &str) -> io::Result<()> {
+        let params = json!({
+            "processId": null,
+            "rootUri": root_uri,
+            "capabilities": {
+                "general": {
+                    "positionEncodings": [
+                        LspEncoding::Utf8.as_lsp_str(),
+                        LspEncoding::Utf16.as_lsp_str(),
+                        LspEncoding::Utf32.as_lsp_str(),
+                    ],
+                },
+                "textDocument": {
+                    "definition": { "dynamicRegistration": false, "linkSupport": true },
+                },
+            },
+        });
+        let result = self.request("initialize", params)?;
+        // The server echoes the single encoding it chose under `capabilities.positionEncoding`;
+        // absent (or unrecognized) → the LSP protocol default, UTF-16.
+        self.encoding = result
+            .get("capabilities")
+            .and_then(|caps| caps.get("positionEncoding"))
+            .and_then(Value::as_str)
+            .and_then(LspEncoding::from_lsp_str)
+            .unwrap_or(LspEncoding::Utf16);
+        self.notify("initialized", json!({}))
+    }
+
+    /// The graceful `shutdown` request followed by the `exit` notification (the LSP teardown
+    /// sequence). Kill-on-drop is the fallback if this is skipped or the server wedges.
+    pub(crate) fn shutdown(&mut self) -> io::Result<()> {
+        self.request("shutdown", Value::Null)?;
+        self.notify("exit", Value::Null)
+    }
+}
+
+impl Drop for LspClient {
+    fn drop(&mut self) {
+        // Hard-kill a spawned server so an abandoned/crashed pass never leaks a resident process.
+        // Best-effort: a server that already exited (graceful shutdown) makes kill a no-op.
+        if let Some(child) = self.child.as_mut() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+    }
+}
+
+/// Fake-server test harness, shared by the `client` and `resolve` unit tests.
+#[cfg(test)]
+pub(crate) mod test_support {
+    use std::io::BufReader;
+    use std::thread;
+
+    use serde_json::Value;
+
+    use super::{LspClient, protocol};
+
+    /// Wire an [`LspClient`] to an in-process fake server run on a thread over two
+    /// `std::io::pipe`s. `handler(request)` returns `Some(messages_to_emit)` (notifications can
+    /// be interleaved before a response by ordering them first), or `None` to CLOSE the
+    /// connection without replying — modelling a crashed/exited server, so the client reads a
+    /// real EOF rather than blocking. The server thread also exits when the client drops (its
+    /// write end closes → the server reads EOF).
+    pub(crate) fn client_with_server<H>(handler: H) -> LspClient
+    where
+        H: FnMut(&Value) -> Option<Vec<Value>> + Send + 'static,
+    {
+        let (to_server_read, to_server_write) = std::io::pipe().unwrap();
+        let (from_server_read, from_server_write) = std::io::pipe().unwrap();
+        thread::spawn(move || {
+            let mut reader = BufReader::new(to_server_read);
+            let mut writer = from_server_write;
+            let mut handler = handler;
+            while let Ok(Some(msg)) = protocol::read_message(&mut reader) {
+                let Some(out) = handler(&msg) else {
+                    return; // close: drop the write end so the client sees EOF
+                };
+                for m in out {
+                    if protocol::write_message(&mut writer, &m).is_err() {
+                        return;
+                    }
+                }
+            }
+        });
+        LspClient::from_transport(
+            Box::new(BufReader::new(from_server_read)),
+            Box::new(to_server_write),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use serde_json::json;
+
+    use super::test_support::client_with_server;
+    use super::*;
+
+    #[test]
+    fn initialize_advertises_definition_link_support() {
+        // Advertising DefinitionClientCapabilities.linkSupport is what makes a compliant server
+        // return LocationLink (with targetSelectionRange = the identifier span) instead of a plain
+        // Location whose range can span the whole declaration — which would mis-map to an enclosing
+        // symbol. The selection-range preference in `parse_definition` is only reachable with this.
+        let captured = Arc::new(Mutex::new(Vec::new()));
+        let capture = Arc::clone(&captured);
+        let mut client = client_with_server(move |msg: &Value| {
+            capture.lock().unwrap().push(msg.clone());
+            respond(msg, Some("utf-16"))
+        });
+        client.initialize("file:///repo").unwrap();
+        let requests = captured.lock().unwrap();
+        let init = requests
+            .iter()
+            .find(|m| m.get("method").and_then(Value::as_str) == Some("initialize"))
+            .expect("an initialize request was sent");
+        assert_eq!(
+            init["params"]["capabilities"]["textDocument"]["definition"]["linkSupport"].as_bool(),
+            Some(true),
+        );
+    }
+
+    /// Build an `initialize` response echoing `encoding` (or none when `encoding` is `None`), and a
+    /// no-op ack (stay open) for every other request/notification.
+    fn respond(msg: &Value, encoding: Option<&str>) -> Option<Vec<Value>> {
+        let id = msg.get("id").cloned();
+        match msg.get("method").and_then(|m| m.as_str()) {
+            Some("initialize") => {
+                let mut caps = json!({});
+                if let Some(enc) = encoding {
+                    caps["positionEncoding"] = json!(enc);
+                }
+                Some(vec![json!({"jsonrpc": "2.0", "id": id, "result": {"capabilities": caps}})])
+            },
+            // Notifications (initialized/exit) have no id and need no reply; stay open.
+            _ if id.is_none() => Some(vec![]),
+            // Any other request → empty result.
+            _ => Some(vec![json!({"jsonrpc": "2.0", "id": id, "result": null})]),
+        }
+    }
+
+    #[test]
+    fn initialize_negotiates_the_servers_position_encoding() {
+        let mut client = client_with_server(|msg| respond(msg, Some("utf-8")));
+        client.initialize("file:///repo").unwrap();
+        assert_eq!(client.encoding(), LspEncoding::Utf8, "adopts the server's negotiated encoding");
+    }
+
+    #[test]
+    fn initialize_defaults_to_utf16_when_the_server_omits_encoding() {
+        let mut client = client_with_server(|msg| respond(msg, None));
+        client.initialize("file:///repo").unwrap();
+        assert_eq!(client.encoding(), LspEncoding::Utf16, "LSP protocol default when unset");
+    }
+
+    #[test]
+    fn request_skips_an_interleaved_notification_before_the_response() {
+        // The server emits a window/logMessage notification BEFORE the response to the same id;
+        // request must skip the notification and return the response's result.
+        let mut client = client_with_server(|msg| {
+            let id = msg.get("id").cloned();
+            Some(vec![
+                json!({"jsonrpc": "2.0", "method": "window/logMessage", "params": {"message": "hi"}}),
+                json!({"jsonrpc": "2.0", "id": id, "result": {"ok": true}}),
+            ])
+        });
+        let result = client.request("custom/thing", json!({})).unwrap();
+        assert_eq!(result, json!({"ok": true}));
+    }
+
+    #[test]
+    fn request_surfaces_a_server_error_as_err() {
+        let mut client = client_with_server(|msg| {
+            let id = msg.get("id").cloned();
+            Some(vec![
+                json!({"jsonrpc": "2.0", "id": id, "error": {"code": -32603, "message": "boom"}}),
+            ])
+        });
+        let err = client.request("custom/thing", json!({})).unwrap_err();
+        assert!(err.to_string().contains("boom"), "surfaces the server's error message: {err}");
+    }
+
+    #[test]
+    fn request_replies_to_a_server_initiated_request_so_it_does_not_deadlock() {
+        // The server sends a server→client request (workspace/configuration) BEFORE answering ours,
+        // and withholds its own response until it receives our reply to that request. If `request`
+        // dropped the server request, the server would block forever (the run's terminate-after
+        // would kill it). A returned result proves the client replied.
+        let mut pending_id: Option<Value> = None;
+        let mut client = client_with_server(move |msg: &Value| {
+            match msg.get("method").and_then(Value::as_str) {
+                Some("custom/thing") => {
+                    pending_id = msg.get("id").cloned();
+                    Some(vec![json!({
+                        "jsonrpc": "2.0", "id": 4242,
+                        "method": "workspace/configuration", "params": {"items": []}
+                    })])
+                },
+                // Our reply to the server's request (id 4242, no method) → now answer the original.
+                None if msg.get("id") == Some(&json!(4242)) => Some(vec![
+                    json!({"jsonrpc": "2.0", "id": pending_id.take(), "result": {"ok": true}}),
+                ]),
+                _ => Some(vec![]),
+            }
+        });
+        let result = client.request("custom/thing", json!({})).unwrap();
+        assert_eq!(result, json!({"ok": true}), "the original request completed after we replied");
+    }
+
+    #[test]
+    fn request_errors_when_the_server_closes_before_responding() {
+        // The server reads the request then CLOSES its connection without replying (a crash) →
+        // request sees EOF, not a hang.
+        let mut client = client_with_server(|_msg| None);
+        let err = client.request("custom/thing", json!({})).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
+    }
+
+    #[test]
+    fn spawn_of_a_missing_program_errors() {
+        assert!(LspClient::spawn("rag-rat-no-such-lsp-xyzzy", &[]).is_err());
+    }
+}

--- a/crates/rag-rat-core/src/index/oracle/lsp/mod.rs
+++ b/crates/rag-rat-core/src/index/oracle/lsp/mod.rs
@@ -1,0 +1,23 @@
+//! Live LSP oracle (#74): a resident language-server client that produces the SAME `edge_oracle`
+//! resolution shape the batch SCIP pass produces, but for dirty/overlay files at watcher cadence
+//! rather than a whole-checkout SCIP build.
+//!
+//! Slice 1 (this module) is the CLIENT SUBSTRATE only — process lifecycle + JSON-RPC framing +
+//! per-document `textDocument/definition` resolution + the position-encoding conversion the LSP
+//! spec demands — with NO watcher wiring, NO DB access, and NO persistence. It is exercised end to
+//! end against a fake in-process LSP server (a thread over `std::io::pipe`), so it is fully
+//! unit-testable without a real `rust-analyzer`. The DB mapping (definition → symbol id via
+//! `join::map_definition_to_symbol`, moniker synthesis, `EdgeOracleRow` assembly + write) and the
+//! maintenance-pass wiring land in slice 2.
+//!
+//! Layout mirrors the batch reader's split (`scip.rs` / `join.rs`):
+//! - `position.rs` — LSP `(line, character)` ↔ absolute byte conversion, per the negotiated
+//!   position encoding. The batch analog is `scip::LineColumnToByte`; LSP defaults to UTF-16 and
+//!   negotiates via `initialize`, and unlike SCIP we need BOTH directions (byte → position to ASK
+//!   for a definition, position → byte to READ one back).
+#![allow(dead_code)] // Slice-1 substrate: the maintenance pass wires this in slice 2 (#74).
+
+mod client;
+mod position;
+mod protocol;
+mod resolve;

--- a/crates/rag-rat-core/src/index/oracle/lsp/position.rs
+++ b/crates/rag-rat-core/src/index/oracle/lsp/position.rs
@@ -1,0 +1,237 @@
+//! LSP `(line, character)` ↔ absolute byte conversion, honoring the server's negotiated position
+//! encoding. This is the ONE place the encoding matters (everything else is byte space) — and the
+//! exact class of silent mis-join the batch reader's `scip.rs` invariant memory documents: every
+//! encoding agrees on ASCII, so a UTF-8-assuming shortcut passes every ASCII test and then
+//! mis-locates an identifier the moment a multibyte character precedes it on the line.
+//!
+//! Unlike the batch SCIP reader (which only ever converts occurrence ranges INTO byte space), the
+//! live client needs BOTH directions: byte → position to point `textDocument/definition` at a
+//! callee, and position → byte to read the returned definition range back. The scalar-walk +
+//! code-unit accounting is the same algorithm as `scip::LineColumnToByte`, kept separate here
+//! because LSP negotiates its own encoding enum (`utf-8` / `utf-16` / `utf-32`) rather than SCIP's.
+
+/// The position encoding an LSP session resolved during `initialize`. LSP's protocol default is
+/// UTF-16; a server may advertise `utf-8` / `utf-32` support and the client picks one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum LspEncoding {
+    Utf8,
+    Utf16,
+    Utf32,
+}
+
+impl LspEncoding {
+    /// The LSP `PositionEncodingKind` wire string this encoding advertises / is negotiated as.
+    pub(crate) fn as_lsp_str(self) -> &'static str {
+        match self {
+            LspEncoding::Utf8 => "utf-8",
+            LspEncoding::Utf16 => "utf-16",
+            LspEncoding::Utf32 => "utf-32",
+        }
+    }
+
+    /// Parse a server's negotiated `PositionEncodingKind`. `None` for an unrecognized value (the
+    /// caller falls back to the LSP protocol default, UTF-16).
+    pub(crate) fn from_lsp_str(value: &str) -> Option<Self> {
+        match value {
+            "utf-8" => Some(LspEncoding::Utf8),
+            "utf-16" => Some(LspEncoding::Utf16),
+            "utf-32" => Some(LspEncoding::Utf32),
+            _ => None,
+        }
+    }
+}
+
+/// A zero-based LSP text position: `line` and `character`, the latter counted in code units of the
+/// session's [`LspEncoding`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct LspPosition {
+    pub(crate) line: u32,
+    pub(crate) character: u32,
+}
+
+/// Precomputes per-line byte starts over a document so `(line, character)` ↔ byte lookups are a
+/// single walk from the line start in the declared encoding.
+pub(crate) struct LineIndex<'a> {
+    source: &'a [u8],
+    encoding: LspEncoding,
+    /// Byte offset of the first byte of each 0-based line.
+    line_starts: Vec<usize>,
+}
+
+impl<'a> LineIndex<'a> {
+    pub(crate) fn new(source: &'a [u8], encoding: LspEncoding) -> Self {
+        let mut line_starts = vec![0usize];
+        for (idx, byte) in source.iter().enumerate() {
+            if *byte == b'\n' {
+                line_starts.push(idx + 1);
+            }
+        }
+        Self { source, encoding, line_starts }
+    }
+
+    /// The LSP position of an absolute byte offset: its line, and the code-unit count from that
+    /// line's start to the offset. `byte` past EOF clamps to the last line's end.
+    pub(crate) fn position_at_byte(&self, byte: usize) -> LspPosition {
+        let byte = byte.min(self.source.len());
+        // The line is the last line start at or before `byte`: `partition_point` gives the count of
+        // starts `<= byte`, which is `line + 1` (there is always the line-0 start at 0).
+        let line = self.line_starts.partition_point(|&start| start <= byte).saturating_sub(1);
+        let line_start = self.line_starts[line];
+        // Count code units walking scalars from the line start to `byte`.
+        let mut units = 0usize;
+        let mut cursor = line_start;
+        while cursor < byte {
+            let ch_len = utf8_char_len(self.source[cursor]);
+            let end = (cursor + ch_len).min(byte);
+            units += code_units_for(&self.source[cursor..end], self.encoding);
+            cursor = end;
+        }
+        LspPosition {
+            line: u32::try_from(line).unwrap_or(u32::MAX),
+            character: u32::try_from(units).unwrap_or(u32::MAX),
+        }
+    }
+
+    /// The absolute byte offset of an LSP position, where `character` counts code units in the
+    /// session encoding. `None` when the line is out of range; a `character` past the line's end
+    /// clamps to the line end (LSP end positions commonly sit at the trailing column).
+    pub(crate) fn byte_at_position(&self, pos: LspPosition) -> Option<usize> {
+        let line = usize::try_from(pos.line).ok()?;
+        let target_units = usize::try_from(pos.character).ok()?;
+        let line_start = *self.line_starts.get(line)?;
+        // Bound the walk at the next line start (or EOF) so a column overrun can't spill onto the
+        // following line.
+        let line_end = self.line_starts.get(line + 1).copied().unwrap_or(self.source.len());
+        let mut byte = line_start;
+        let mut units = 0usize;
+        while units < target_units {
+            if byte >= line_end {
+                return Some(line_end.min(self.source.len()));
+            }
+            let ch_len = utf8_char_len(self.source[byte]);
+            let ch_bytes = self.source.get(byte..byte + ch_len)?;
+            units += code_units_for(ch_bytes, self.encoding);
+            byte += ch_len;
+        }
+        Some(byte)
+    }
+}
+
+/// How many code units a single Unicode scalar (given as its UTF-8 bytes) occupies in `encoding`:
+/// UTF-8 → its UTF-8 byte length; UTF-16 → 2 for astral scalars (UTF-8 length 4) else 1; UTF-32 →
+/// always 1 (one scalar, one unit).
+fn code_units_for(utf8_bytes: &[u8], encoding: LspEncoding) -> usize {
+    match encoding {
+        LspEncoding::Utf8 => utf8_bytes.len(),
+        LspEncoding::Utf16 =>
+            if utf8_bytes.len() == 4 {
+                2
+            } else {
+                1
+            },
+        LspEncoding::Utf32 => 1,
+    }
+}
+
+/// Byte length of the UTF-8 sequence whose lead byte is `lead`; a continuation/invalid byte counts
+/// as 1 so the walk always advances.
+fn utf8_char_len(lead: u8) -> usize {
+    if lead < 0x80 {
+        1
+    } else if lead >> 5 == 0b110 {
+        2
+    } else if lead >> 4 == 0b1110 {
+        3
+    } else if lead >> 3 == 0b11110 {
+        4
+    } else {
+        1
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ascii_position_round_trips_both_directions() {
+        // "fn main() {}\n": the callee-ish token `main` starts at byte 3 → (line 0, char 3) under
+        // any encoding (ASCII agrees), and back.
+        let src = b"fn main() {}\n";
+        for enc in [LspEncoding::Utf8, LspEncoding::Utf16, LspEncoding::Utf32] {
+            let idx = LineIndex::new(src, enc);
+            let pos = idx.position_at_byte(3);
+            assert_eq!(pos, LspPosition { line: 0, character: 3 }, "{enc:?}");
+            assert_eq!(idx.byte_at_position(pos), Some(3), "{enc:?} round-trip");
+        }
+    }
+
+    #[test]
+    fn utf16_counts_astral_char_as_two_units_before_the_callee() {
+        // A 😀 (U+1F600, 4 UTF-8 bytes, 2 UTF-16 units) precedes `foo` on the line. Under UTF-16
+        // the callee's character offset must count the emoji as 2 units, not 1 or 4.
+        let src = "let s = \"😀\"; foo();\n".as_bytes();
+        let foo_byte = find(src, "foo");
+        let idx = LineIndex::new(src, LspEncoding::Utf16);
+        let pos = idx.position_at_byte(foo_byte);
+        // bytes before foo: `let s = "` (9) + 😀 (4) + `"; ` (3) = 16 bytes; UTF-16 units:
+        // 9 + 2 + 3 = 14.
+        assert_eq!(pos, LspPosition { line: 0, character: 14 });
+        assert_eq!(idx.byte_at_position(pos), Some(foo_byte), "utf-16 round-trip lands on foo");
+    }
+
+    #[test]
+    fn utf8_counts_astral_char_as_four_units() {
+        // Same source under UTF-8: the character offset is the BYTE offset within the line, so the
+        // emoji counts as its 4 UTF-8 bytes.
+        let src = "let s = \"😀\"; foo();\n".as_bytes();
+        let foo_byte = find(src, "foo");
+        let idx = LineIndex::new(src, LspEncoding::Utf8);
+        let pos = idx.position_at_byte(foo_byte);
+        assert_eq!(pos, LspPosition { line: 0, character: 16 });
+        assert_eq!(idx.byte_at_position(pos), Some(foo_byte));
+    }
+
+    #[test]
+    fn utf32_counts_astral_char_as_one_unit() {
+        let src = "let s = \"😀\"; foo();\n".as_bytes();
+        let foo_byte = find(src, "foo");
+        let idx = LineIndex::new(src, LspEncoding::Utf32);
+        let pos = idx.position_at_byte(foo_byte);
+        // 9 + 1 (one scalar) + 3 = 13.
+        assert_eq!(pos, LspPosition { line: 0, character: 13 });
+        assert_eq!(idx.byte_at_position(pos), Some(foo_byte));
+    }
+
+    #[test]
+    fn multi_line_positions_map_to_the_right_line() {
+        let src = b"a();\nlet x = 1;\nbar();\n";
+        let bar_byte = find(src, "bar");
+        let idx = LineIndex::new(src, LspEncoding::Utf16);
+        let pos = idx.position_at_byte(bar_byte);
+        assert_eq!(pos, LspPosition { line: 2, character: 0 });
+        assert_eq!(idx.byte_at_position(pos), Some(bar_byte));
+    }
+
+    #[test]
+    fn character_past_line_end_clamps_to_line_end() {
+        // "ab\ncd\n": (line 0, char 99) clamps to line 0's end — byte 3, the start of line 1, an
+        // EXCLUSIVE upper bound that includes line 0's trailing newline but nothing of line 1's
+        // content. This is the batch reader's clamp semantics (never spills into the next line's
+        // text); a real LSP range never overruns, so this only guards a malformed position.
+        let src = b"ab\ncd\n";
+        let idx = LineIndex::new(src, LspEncoding::Utf16);
+        assert_eq!(idx.byte_at_position(LspPosition { line: 0, character: 99 }), Some(3));
+    }
+
+    #[test]
+    fn line_out_of_range_is_none() {
+        let src = b"only();\n";
+        let idx = LineIndex::new(src, LspEncoding::Utf16);
+        assert_eq!(idx.byte_at_position(LspPosition { line: 9, character: 0 }), None);
+    }
+
+    fn find(src: &[u8], needle: &str) -> usize {
+        std::str::from_utf8(src).unwrap().find(needle).unwrap()
+    }
+}

--- a/crates/rag-rat-core/src/index/oracle/lsp/protocol.rs
+++ b/crates/rag-rat-core/src/index/oracle/lsp/protocol.rs
@@ -1,0 +1,108 @@
+//! LSP base-protocol framing: `Content-Length: N\r\n\r\n<N bytes of UTF-8 JSON>` (the JSON-RPC 2.0
+//! envelope the Language Server Protocol wraps every message in). Generic over `Write`/`BufRead` so
+//! the client can be driven by a real child process OR, in tests, by an in-process fake server over
+//! `std::io::pipe`.
+
+use std::io::{self, BufRead, Write};
+
+use serde_json::Value;
+
+/// Frame and write one message: the `Content-Length` header (byte length of the JSON body), the
+/// blank-line separator, then the UTF-8 JSON body. Flushes so the peer sees it immediately.
+pub(crate) fn write_message<W: Write>(w: &mut W, msg: &Value) -> io::Result<()> {
+    let body = serde_json::to_vec(msg)?;
+    write!(w, "Content-Length: {}\r\n\r\n", body.len())?;
+    w.write_all(&body)?;
+    w.flush()
+}
+
+/// Read one framed message: parse headers up to the blank line (honoring `Content-Length`, ignoring
+/// any others such as `Content-Type`), then read exactly that many body bytes and parse them as
+/// JSON. `Ok(None)` on a clean EOF at a message boundary (the server closed its stdout).
+pub(crate) fn read_message<R: BufRead>(r: &mut R) -> io::Result<Option<Value>> {
+    let mut content_length: Option<usize> = None;
+    let mut first_line = true;
+    loop {
+        let mut line = String::new();
+        if r.read_line(&mut line)? == 0 {
+            // EOF. At a message boundary (before any header) it is clean; part-way through the
+            // headers it is a truncated frame.
+            if first_line {
+                return Ok(None);
+            }
+            return Err(io::Error::new(io::ErrorKind::UnexpectedEof, "EOF within LSP headers"));
+        }
+        first_line = false;
+        let header = line.trim_end_matches(['\r', '\n']);
+        if header.is_empty() {
+            break; // blank line ends the headers
+        }
+        if let Some(rest) = header.strip_prefix("Content-Length:") {
+            content_length = rest.trim().parse::<usize>().ok();
+        }
+        // Any other header (e.g. Content-Type) is ignored.
+    }
+    let len = content_length.ok_or_else(|| {
+        io::Error::new(io::ErrorKind::InvalidData, "LSP frame missing Content-Length")
+    })?;
+    let mut body = vec![0u8; len];
+    r.read_exact(&mut body)?;
+    let value = serde_json::from_slice(&body).map_err(io::Error::other)?;
+    Ok(Some(value))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn write_then_read_round_trips_a_message() {
+        let msg = json!({"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {"x": 3}});
+        let mut buf = Vec::new();
+        write_message(&mut buf, &msg).unwrap();
+        // The framed bytes carry a Content-Length header and the exact JSON body.
+        let text = String::from_utf8(buf.clone()).unwrap();
+        assert!(text.starts_with("Content-Length: "), "framed with a length header: {text:?}");
+        let mut cursor = Cursor::new(buf);
+        let read = read_message(&mut cursor).unwrap().expect("one message");
+        assert_eq!(read, msg);
+    }
+
+    #[test]
+    fn read_ignores_extra_headers_and_crlf() {
+        // A server may send additional headers (Content-Type) before the blank line; the reader
+        // keys only on Content-Length and reads exactly that many body bytes.
+        let body = r#"{"jsonrpc":"2.0","id":7,"result":null}"#;
+        let framed = format!(
+            "Content-Length: {}\r\nContent-Type: application/vscode-jsonrpc; \
+             charset=utf-8\r\n\r\n{body}",
+            body.len()
+        );
+        let mut cursor = Cursor::new(framed.into_bytes());
+        let read = read_message(&mut cursor).unwrap().expect("one message");
+        assert_eq!(read, json!({"jsonrpc": "2.0", "id": 7, "result": null}));
+    }
+
+    #[test]
+    fn read_two_messages_from_one_stream() {
+        // Back-to-back frames read as two independent messages (the body length delimits them, so
+        // the reader never over-reads into the next frame).
+        let mut buf = Vec::new();
+        write_message(&mut buf, &json!({"id": 1})).unwrap();
+        write_message(&mut buf, &json!({"id": 2})).unwrap();
+        let mut cursor = Cursor::new(buf);
+        assert_eq!(read_message(&mut cursor).unwrap(), Some(json!({"id": 1})));
+        assert_eq!(read_message(&mut cursor).unwrap(), Some(json!({"id": 2})));
+        assert_eq!(read_message(&mut cursor).unwrap(), None, "clean EOF after the last frame");
+    }
+
+    #[test]
+    fn read_returns_none_on_immediate_eof() {
+        let mut cursor = Cursor::new(Vec::new());
+        assert_eq!(read_message(&mut cursor).unwrap(), None);
+    }
+}

--- a/crates/rag-rat-core/src/index/oracle/lsp/resolve.rs
+++ b/crates/rag-rat-core/src/index/oracle/lsp/resolve.rs
@@ -1,0 +1,428 @@
+//! The per-file resolution routine: open a document's DIRTY bytes, then ask the server to resolve
+//! each callee identifier via `textDocument/definition` (and, where supported,
+//! `textDocument/moniker`). The output is a raw [`LiveDefinition`] per callee — the target document
+//! URI, the definition RANGE in LSP position space, and any moniker — deliberately stopping short
+//! of the DB: converting a target range to a byte span needs the target file's content, and mapping
+//! it to a symbol id needs the index, both of which the slice-2 write path owns (it reuses
+//! `join::map_definition_to_symbol`). Slice 1 is the language-server half, unit-tested against the
+//! fake server.
+
+use std::io;
+
+use serde_json::{Value, json};
+
+use super::client::LspClient;
+use super::position::{LineIndex, LspPosition};
+
+/// An LSP text range (a definition's span in the target document, in that document's position
+/// encoding — NOT yet byte space).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct LspRange {
+    pub(crate) start: LspPosition,
+    pub(crate) end: LspPosition,
+}
+
+/// One callee's resolved definition as the server reported it: the target document URI, the
+/// definition range (LSP positions), and the moniker the server minted for the callee, if any.
+/// Byte-span conversion + symbol mapping happen in slice 2 (they need the target file + the index).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct LiveDefinition {
+    pub(crate) target_uri: String,
+    pub(crate) target_range: LspRange,
+    pub(crate) moniker: Option<String>,
+}
+
+impl LspClient {
+    /// Open a document with its DIRTY bytes (`textDocument/didOpen`) — the exact bytes whose sha
+    /// the slice-2 write stamps into `file_sha`, so the resolution is against the same content.
+    pub(crate) fn did_open(&mut self, uri: &str, language_id: &str, text: &str) -> io::Result<()> {
+        self.notify(
+            "textDocument/didOpen",
+            json!({
+                "textDocument": {
+                    "uri": uri,
+                    "languageId": language_id,
+                    "version": 1,
+                    "text": text,
+                }
+            }),
+        )
+    }
+
+    /// Ask for the definition at a position; `None` when the server returns `null` (unresolved).
+    pub(crate) fn definition_at(
+        &mut self,
+        uri: &str,
+        position: LspPosition,
+    ) -> io::Result<Option<(String, LspRange)>> {
+        let result = self.request(
+            "textDocument/definition",
+            json!({
+                "textDocument": { "uri": uri },
+                "position": { "line": position.line, "character": position.character },
+            }),
+        )?;
+        Ok(parse_definition(&result))
+    }
+
+    /// Ask for the moniker at a position (`textDocument/moniker`, LSP 3.16+); `None` when the
+    /// server has no moniker or does not support the request.
+    pub(crate) fn moniker_at(
+        &mut self,
+        uri: &str,
+        position: LspPosition,
+    ) -> io::Result<Option<String>> {
+        // `request_optional`: a server without moniker support answers `MethodNotFound`, which must
+        // degrade to `None`, not fail the file. A supported-but-empty result (`null`) also parses
+        // to `None`.
+        let Some(result) = self.request_optional(
+            "textDocument/moniker",
+            json!({
+                "textDocument": { "uri": uri },
+                "position": { "line": position.line, "character": position.character },
+            }),
+        )?
+        else {
+            return Ok(None);
+        };
+        Ok(parse_moniker(&result))
+    }
+
+    /// Close a document (`textDocument/didClose`), ending the `didOpen` lifecycle.
+    pub(crate) fn did_close(&mut self, uri: &str) -> io::Result<()> {
+        self.notify("textDocument/didClose", json!({ "textDocument": { "uri": uri } }))
+    }
+
+    /// Resolve every callee in one dirty file as a clean open→resolve→close cycle: `didOpen` the
+    /// bytes, resolve each callee, then `didClose`. The open/close pairing is what lets a RESIDENT
+    /// client (reused across maintenance passes) reopen the same URI on a later pass without a
+    /// double-`didOpen` — an LSP protocol violation that makes servers ignore the update and
+    /// resolve stale text. The close is best-effort so it never masks the resolution result.
+    ///
+    /// For each callee-identifier START byte offset it issues a `textDocument/definition` (position
+    /// computed in the session's negotiated encoding) and — only when the definition resolved — a
+    /// `textDocument/moniker`. The result is aligned index-for-index with `callee_starts`; an
+    /// unresolved callee is `None`.
+    pub(crate) fn resolve_callees(
+        &mut self,
+        uri: &str,
+        language_id: &str,
+        text: &str,
+        callee_starts: &[usize],
+    ) -> io::Result<Vec<Option<LiveDefinition>>> {
+        self.did_open(uri, language_id, text)?;
+        let resolved = self.resolve_open_callees(uri, text, callee_starts);
+        let _ = self.did_close(uri);
+        resolved
+    }
+
+    /// The resolution loop over an ALREADY-OPEN document (the interior of [`resolve_callees`],
+    /// split out so the enclosing `didOpen`/`didClose` always pair even when a request errors).
+    fn resolve_open_callees(
+        &mut self,
+        uri: &str,
+        text: &str,
+        callee_starts: &[usize],
+    ) -> io::Result<Vec<Option<LiveDefinition>>> {
+        let index = LineIndex::new(text.as_bytes(), self.encoding());
+        let mut out = Vec::with_capacity(callee_starts.len());
+        for &start in callee_starts {
+            let position = index.position_at_byte(start);
+            let Some((target_uri, target_range)) = self.definition_at(uri, position)? else {
+                out.push(None);
+                continue;
+            };
+            // Only spend a moniker request on a resolved callee (the per-request fan-out the plan
+            // caps in slice 2's budget).
+            let moniker = self.moniker_at(uri, position)?;
+            out.push(Some(LiveDefinition { target_uri, target_range, moniker }));
+        }
+        Ok(out)
+    }
+}
+
+/// Parse a `textDocument/definition` result: `Location`, `Location[]`, `LocationLink`,
+/// `LocationLink[]`, or `null`. Returns the FIRST target's `(uri, range)`.
+fn parse_definition(value: &Value) -> Option<(String, LspRange)> {
+    match value {
+        Value::Null => None,
+        Value::Array(items) => items.first().and_then(parse_one_location),
+        object => parse_one_location(object),
+    }
+}
+
+/// A single `Location` (`uri`/`range`) or `LocationLink` (`targetUri` + `targetSelectionRange` /
+/// `targetRange`). For a LocationLink, prefer `targetSelectionRange` (the identifier span) over
+/// `targetRange` (the whole declaration, which can wrap doc comments + body): the narrower span is
+/// what the slice-2 containment mapper resolves to a symbol; the wider one can hit an enclosing
+/// symbol or miss entirely for a documented definition. `targetRange` is the fallback.
+fn parse_one_location(value: &Value) -> Option<(String, LspRange)> {
+    let uri = value.get("uri").or_else(|| value.get("targetUri")).and_then(Value::as_str)?;
+    let range = value
+        .get("range")
+        .or_else(|| value.get("targetSelectionRange"))
+        .or_else(|| value.get("targetRange"))?;
+    let start = parse_position(range.get("start")?)?;
+    let end = parse_position(range.get("end")?)?;
+    Some((uri.to_string(), LspRange { start, end }))
+}
+
+fn parse_position(value: &Value) -> Option<LspPosition> {
+    let line = u32::try_from(value.get("line")?.as_u64()?).ok()?;
+    let character = u32::try_from(value.get("character")?.as_u64()?).ok()?;
+    Some(LspPosition { line, character })
+}
+
+/// Parse a `textDocument/moniker` result (`Moniker[]` or `null`), returning the first moniker's
+/// `scheme:identifier` (or bare `identifier` when the scheme is absent).
+fn parse_moniker(value: &Value) -> Option<String> {
+    let first = match value {
+        Value::Array(items) => items.first()?,
+        object if object.is_object() => object,
+        _ => return None,
+    };
+    let identifier = first.get("identifier").and_then(Value::as_str)?;
+    match first.get("scheme").and_then(Value::as_str) {
+        Some(scheme) => Some(format!("{scheme}:{identifier}")),
+        None => Some(identifier.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use super::*;
+    use crate::index::oracle::lsp::client::test_support::client_with_server;
+    use crate::index::oracle::lsp::position::LspEncoding;
+
+    /// A canned definition the fake server returns: `(target_uri, start (line, char), end)`.
+    type FakeDef = (&'static str, (u32, u32), (u32, u32));
+
+    /// An `initialize` response advertising `encoding`, plus a definition/moniker responder driven
+    /// by `def` (the target to return, or `None` for an unresolved `null`) and `moniker`.
+    fn responder(
+        encoding: &'static str,
+        def: Option<FakeDef>,
+        moniker: Option<&'static str>,
+        captured: Arc<Mutex<Vec<Value>>>,
+    ) -> impl FnMut(&Value) -> Option<Vec<Value>> + Send + 'static {
+        move |msg: &Value| {
+            captured.lock().unwrap().push(msg.clone());
+            let id = msg.get("id").cloned();
+            match msg.get("method").and_then(Value::as_str) {
+                Some("initialize") => Some(vec![json!({
+                    "jsonrpc": "2.0", "id": id,
+                    "result": {"capabilities": {"positionEncoding": encoding}}
+                })]),
+                Some("textDocument/definition") => {
+                    let result = match def {
+                        Some((uri, (sl, sc), (el, ec))) => json!({
+                            "uri": uri,
+                            "range": {"start": {"line": sl, "character": sc},
+                                      "end": {"line": el, "character": ec}}
+                        }),
+                        None => Value::Null,
+                    };
+                    Some(vec![json!({"jsonrpc": "2.0", "id": id, "result": result})])
+                },
+                Some("textDocument/moniker") => {
+                    let result = match moniker {
+                        Some(ident) => json!([{"scheme": "rust-analyzer", "identifier": ident,
+                                               "unique": "scheme"}]),
+                        None => Value::Null,
+                    };
+                    Some(vec![json!({"jsonrpc": "2.0", "id": id, "result": result})])
+                },
+                // Notifications (initialized / didOpen) need no reply; stay open.
+                _ if id.is_none() => Some(vec![]),
+                _ => Some(vec![json!({"jsonrpc": "2.0", "id": id, "result": null})]),
+            }
+        }
+    }
+
+    #[test]
+    fn resolve_callees_returns_the_definition_and_moniker_per_callee() {
+        let captured = Arc::new(Mutex::new(Vec::new()));
+        let mut client = client_with_server(responder(
+            "utf-16",
+            Some(("file:///defs.rs", (5, 3), (5, 9))),
+            Some("cargo std foo"),
+            Arc::clone(&captured),
+        ));
+        client.initialize("file:///repo").unwrap();
+        let src = "fn caller() { foo(); }\n";
+        let foo = src.find("foo").unwrap();
+        let out = client.resolve_callees("file:///src.rs", "rust", src, &[foo]).unwrap();
+        assert_eq!(out, vec![Some(LiveDefinition {
+            target_uri: "file:///defs.rs".to_string(),
+            target_range: LspRange {
+                start: LspPosition { line: 5, character: 3 },
+                end: LspPosition { line: 5, character: 9 },
+            },
+            moniker: Some("rust-analyzer:cargo std foo".to_string()),
+        })]);
+    }
+
+    #[test]
+    fn resolve_callees_returns_none_moniker_when_the_server_lacks_moniker_support() {
+        // A server that resolves definitions but does NOT support textDocument/moniker replies to
+        // the moniker request with MethodNotFound (-32601). That must degrade to `moniker: None`,
+        // not fail the whole file's resolution.
+        let mut client = client_with_server(|msg: &Value| {
+            let id = msg.get("id").cloned();
+            match msg.get("method").and_then(Value::as_str) {
+                Some("initialize") => Some(vec![json!({
+                    "jsonrpc": "2.0", "id": id,
+                    "result": {"capabilities": {"positionEncoding": "utf-16"}}
+                })]),
+                Some("textDocument/definition") => Some(vec![json!({
+                    "jsonrpc": "2.0", "id": id,
+                    "result": {"uri": "file:///d.rs",
+                               "range": {"start": {"line": 0, "character": 0},
+                                         "end": {"line": 0, "character": 1}}}
+                })]),
+                Some("textDocument/moniker") => Some(vec![json!({
+                    "jsonrpc": "2.0", "id": id,
+                    "error": {"code": -32601, "message": "method not found"}
+                })]),
+                _ if id.is_none() => Some(vec![]),
+                _ => Some(vec![json!({"jsonrpc": "2.0", "id": id, "result": null})]),
+            }
+        });
+        client.initialize("file:///repo").unwrap();
+        let out =
+            client.resolve_callees("file:///s.rs", "rust", "fn a() { b(); }\n", &[9]).unwrap();
+        assert_eq!(out, vec![Some(LiveDefinition {
+            target_uri: "file:///d.rs".to_string(),
+            target_range: LspRange {
+                start: LspPosition { line: 0, character: 0 },
+                end: LspPosition { line: 0, character: 1 },
+            },
+            moniker: None,
+        })]);
+    }
+
+    #[test]
+    fn resolve_callees_maps_an_unresolved_null_definition_to_none() {
+        let captured = Arc::new(Mutex::new(Vec::new()));
+        let mut client = client_with_server(responder("utf-16", None, None, Arc::clone(&captured)));
+        client.initialize("file:///repo").unwrap();
+        let out = client.resolve_callees("file:///s.rs", "rust", "x();\n", &[0]).unwrap();
+        assert_eq!(out, vec![None]);
+    }
+
+    #[test]
+    fn definition_request_position_is_in_the_negotiated_encoding() {
+        // The source has an astral char before the callee. Under UTF-16 the requested position must
+        // count the emoji as 2 units — proving the request side honors the negotiated encoding, not
+        // raw bytes. This is the exact silent-mis-join the position invariant guards.
+        let captured = Arc::new(Mutex::new(Vec::new()));
+        let mut client = client_with_server(responder(
+            "utf-16",
+            Some(("file:///d.rs", (0, 0), (0, 1))),
+            None,
+            Arc::clone(&captured),
+        ));
+        client.initialize("file:///repo").unwrap();
+        let src = "let s = \"😀\"; foo();\n";
+        let foo = src.find("foo").unwrap();
+        client.resolve_callees("file:///s.rs", "rust", src, &[foo]).unwrap();
+
+        let requests = captured.lock().unwrap();
+        let def_req = requests
+            .iter()
+            .find(|m| m.get("method").and_then(Value::as_str) == Some("textDocument/definition"))
+            .expect("a definition request was sent");
+        let character = def_req["params"]["position"]["character"].as_u64().unwrap();
+        // `let s = "` (9) + 😀 (2 UTF-16 units) + `"; ` (3) = 14.
+        assert_eq!(character, 14, "position counts the emoji as 2 UTF-16 units, not 4 bytes");
+    }
+
+    #[test]
+    fn resolve_callees_opens_the_document_with_the_dirty_text() {
+        let captured = Arc::new(Mutex::new(Vec::new()));
+        let mut client = client_with_server(responder(
+            "utf-16",
+            Some(("file:///d.rs", (0, 0), (0, 1))),
+            None,
+            Arc::clone(&captured),
+        ));
+        client.initialize("file:///repo").unwrap();
+        let src = "fn a() { b(); }\n";
+        client.resolve_callees("file:///s.rs", "rust", src, &[src.find('b').unwrap()]).unwrap();
+
+        let requests = captured.lock().unwrap();
+        let did_open = requests
+            .iter()
+            .find(|m| m.get("method").and_then(Value::as_str) == Some("textDocument/didOpen"))
+            .expect("a didOpen notification was sent");
+        assert_eq!(did_open["params"]["textDocument"]["text"].as_str(), Some(src));
+        assert_eq!(did_open["params"]["textDocument"]["languageId"].as_str(), Some("rust"));
+    }
+
+    #[test]
+    fn resolve_callees_closes_the_document_after_resolving() {
+        // Each call is a clean open→resolve→close cycle so a resident client reused across passes
+        // never double-opens a URI (an LSP protocol violation that makes servers resolve stale
+        // text). A didClose must follow the resolution.
+        let captured = Arc::new(Mutex::new(Vec::new()));
+        let mut client = client_with_server(responder(
+            "utf-16",
+            Some(("file:///d.rs", (0, 0), (0, 1))),
+            None,
+            Arc::clone(&captured),
+        ));
+        client.initialize("file:///repo").unwrap();
+        let src = "fn a() { b(); }\n";
+        client.resolve_callees("file:///s.rs", "rust", src, &[src.find('b').unwrap()]).unwrap();
+        // didClose is a fire-and-forget notification, so resolve_callees returns before the server
+        // thread has necessarily recorded it. Issue a synchronous barrier request: the pipe is
+        // FIFO, so when its response arrives the server has provably processed the earlier
+        // didClose.
+        client.request("$/barrier", Value::Null).unwrap();
+
+        let requests = captured.lock().unwrap();
+        let open_at = requests
+            .iter()
+            .position(|m| m.get("method").and_then(Value::as_str) == Some("textDocument/didOpen"));
+        let close_at = requests
+            .iter()
+            .position(|m| m.get("method").and_then(Value::as_str) == Some("textDocument/didClose"));
+        assert!(open_at.is_some(), "opened the document");
+        assert!(
+            close_at.is_some() && close_at > open_at,
+            "closed the document after opening + resolving: {requests:?}"
+        );
+        assert_eq!(
+            requests[close_at.unwrap()]["params"]["textDocument"]["uri"].as_str(),
+            Some("file:///s.rs"),
+        );
+    }
+
+    #[test]
+    fn parse_definition_prefers_the_location_link_selection_range() {
+        // rust-analyzer returns LocationLink[] when linkSupport is advertised. `targetRange` spans
+        // the whole declaration (here lines 0–5, incl. a doc comment + body);
+        // `targetSelectionRange` is the identifier span. The narrower selection range is
+        // what maps to a symbol, so it wins.
+        let value = json!([{
+            "targetUri": "file:///t.rs",
+            "targetRange": {"start": {"line": 0, "character": 0}, "end": {"line": 5, "character": 1}},
+            "targetSelectionRange": {"start": {"line": 2, "character": 3}, "end": {"line": 2, "character": 9}}
+        }]);
+        assert_eq!(
+            parse_definition(&value),
+            Some(("file:///t.rs".to_string(), LspRange {
+                start: LspPosition { line: 2, character: 3 },
+                end: LspPosition { line: 2, character: 9 },
+            }))
+        );
+    }
+
+    #[test]
+    fn encoding_is_reachable() {
+        // Guard: the resolve routine must use the client's negotiated encoding (compile-time link).
+        assert_eq!(LspEncoding::Utf16.as_lsp_str(), "utf-16");
+    }
+}

--- a/crates/rag-rat-core/src/index/oracle/mod.rs
+++ b/crates/rag-rat-core/src/index/oracle/mod.rs
@@ -21,6 +21,7 @@
 mod auto_run;
 mod corpus;
 mod join;
+mod lsp;
 mod manifest;
 mod report;
 mod run;


### PR DESCRIPTION
The batch SCIP oracle resolves edges for the whole checkout at minutes-scale cadence, so dirty/overlay files during an editing session never carry current verdicts. This lands the client half of a resident language-server oracle that will produce the same `edge_oracle` resolution shape for changed files at watcher cadence (#74).

**Substrate only** — no watcher wiring, no DB access, no persistence. The whole module is driven end to end by an in-process fake LSP server over `std::io::pipe`, so it is unit-tested without a real `rust-analyzer` (27 tests).

- **position** — LSP `(line, character)` ↔ absolute byte conversion for utf-8/16/32, both directions, honoring the encoding negotiated at `initialize`. The one place the encoding matters and the exact class of silent mis-join the batch reader guards; covered for astral characters under each encoding.
- **protocol** — `Content-Length` JSON-RPC framing, generic over the transport so a child process or a fake server drive it identically.
- **client** — process lifecycle (spawn, `initialize` handshake with position-encoding negotiation, graceful `shutdown`, kill-on-drop) and single-flight request/response that skips notifications, replies `MethodNotFound` to server-initiated requests (so a server awaiting the reply can't deadlock), and advertises `definition.linkSupport`.
- **resolve** — the per-file routine as a clean open→resolve→close cycle (`didOpen` dirty bytes → per-callee `textDocument/definition` at the negotiated-encoding position → optional `textDocument/moniker`), yielding a raw `LiveDefinition` per callee. Unsupported `moniker` degrades to `None`; `LocationLink` prefers `targetSelectionRange`. Converting the target range to a byte span and mapping it to a symbol id stay in the write path.

### Not in this slice
Watcher-pass wiring, per-pass budget, the `edge_oracle` write (tool identity / `oracle_runs` recording), and the definition→symbol mapping (which reuses `join::map_definition_to_symbol`). Those, plus rust-analyzer hardening and additional backends, are the remaining slices.