### PR TITLE
perf(edges): linearize contains_edges and containing_symbol; dedup the grammar match

### DIFF
--- a/crates/rag-rat-core/src/index/edges/extract/mod.rs
+++ b/crates/rag-rat-core/src/index/edges/extract/mod.rs
@@ -61,32 +61,57 @@ pub(crate) fn edge_candidates_from_root(
 pub(crate) fn qn_tail(qualified_name: &str) -> &str {
     qualified_name.rsplit("::").next().unwrap_or(qualified_name)
 }
+/// `Contains` edges: each symbol → its immediate enclosing symbol (the smallest-span container).
+///
+/// Symbols come from the AST, so their byte ranges form a properly-nested forest — any two are
+/// either disjoint or one contains the other, never partially overlapping, and no two distinct
+/// symbols share an exact `(start, end)` span. Under that invariant the smallest-span container of
+/// a symbol IS its immediate parent in the nesting forest, so a single nesting-stack sweep finds
+/// every parent in O(S log S) instead of the old O(S²) per-child rescan (#519). Edges are still
+/// emitted in the input's original order, so the output is byte-identical.
 pub(crate) fn contains_edges(symbols: &[IndexedSymbol]) -> Vec<EdgeCandidate> {
-    let mut out = Vec::new();
-    for child in symbols {
-        let parent = symbols
-            .iter()
-            .filter(|candidate| {
-                candidate.id != child.id
-                    && candidate.start_byte <= child.start_byte
-                    && candidate.end_byte >= child.end_byte
-            })
-            .min_by_key(|candidate| candidate.end_byte.saturating_sub(candidate.start_byte));
-        if let Some(parent) = parent {
-            out.push(EdgeCandidate {
-                from_symbol_id: Some(parent.id),
-                from_name: Some(parent.qualified_name.clone()),
-                to_name: child.qualified_name.clone(),
-                target_qualified_name: Some(child.qualified_name.clone()),
-                evidence: Some(child.qualified_name.clone()),
-                receiver_hint: None,
-                source_span: child.span(),
-                callee_span: None,
-                import_scope: None,
-                edge_kind: EdgeKind::Contains,
-                confidence: EdgeConfidence::Exact,
-            });
+    // Visit outer symbols before the ones they enclose: `start` ascending puts a container first,
+    // and on an equal start `end` DESCENDING puts the larger (containing) span first.
+    let mut order = (0..symbols.len()).collect::<Vec<_>>();
+    order.sort_by(|&a, &b| {
+        symbols[a]
+            .start_byte
+            .cmp(&symbols[b].start_byte)
+            .then_with(|| symbols[b].end_byte.cmp(&symbols[a].end_byte))
+    });
+
+    // `stack` holds the currently-open enclosers, innermost on top. For each symbol we pop the
+    // enclosers whose span ends before it (they can't contain it); the remaining top is its
+    // immediate parent.
+    let mut parent = vec![None; symbols.len()];
+    let mut stack = Vec::<usize>::new();
+    for &index in &order {
+        let end = symbols[index].end_byte;
+        while stack.last().is_some_and(|&top| symbols[top].end_byte < end) {
+            stack.pop();
         }
+        parent[index] = stack.last().copied();
+        stack.push(index);
+    }
+
+    let mut out = Vec::new();
+    for (index, child) in symbols.iter().enumerate() {
+        let Some(parent) = parent[index].map(|parent_index| &symbols[parent_index]) else {
+            continue;
+        };
+        out.push(EdgeCandidate {
+            from_symbol_id: Some(parent.id),
+            from_name: Some(parent.qualified_name.clone()),
+            to_name: child.qualified_name.clone(),
+            target_qualified_name: Some(child.qualified_name.clone()),
+            evidence: Some(child.qualified_name.clone()),
+            receiver_hint: None,
+            source_span: child.span(),
+            callee_span: None,
+            import_scope: None,
+            edge_kind: EdgeKind::Contains,
+            confidence: EdgeConfidence::Exact,
+        });
     }
     out
 }
@@ -96,15 +121,10 @@ pub(crate) fn syntactic_edges(
     text: &str,
     symbols: &[IndexedSymbol],
 ) -> anyhow::Result<Vec<EdgeCandidate>> {
-    let grammar = match parser::parser_kind(path, language) {
-        ParserKind::Rust => tree_sitter_rust::LANGUAGE.into(),
-        ParserKind::TypeScript => tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into(),
-        ParserKind::Tsx => tree_sitter_typescript::LANGUAGE_TSX.into(),
-        ParserKind::Kotlin => tree_sitter_kotlin::LANGUAGE.into(),
-        ParserKind::C => tree_sitter_c::LANGUAGE.into(),
-        ParserKind::Cpp => tree_sitter_cpp::LANGUAGE.into(),
-        ParserKind::Python => tree_sitter_python::LANGUAGE.into(),
-        ParserKind::Markdown => return Ok(Vec::new()),
+    // Single source of truth for the grammar mapping (#519); `None` (Markdown / no grammar) yields
+    // no edges, same as the old `ParserKind::Markdown` arm.
+    let Some(grammar) = parser::grammar_for(parser::parser_kind(path, language)) else {
+        return Ok(Vec::new());
     };
     // Cancel/abandon a pathological parse (a grammar-ambiguity blowup, e.g. some Kotlin files)
     // rather than hang the indexer forever — a timed-out file yields no edges, same as a parse
@@ -293,5 +313,126 @@ pub(crate) fn symbol_edge_with_context(
         import_scope: None,
         edge_kind,
         confidence,
+    }
+}
+
+#[cfg(test)]
+mod contains_edges_tests {
+    use super::*;
+
+    fn sym(id: i64, start: usize, end: usize) -> IndexedSymbol {
+        IndexedSymbol {
+            id,
+            file_id: 0,
+            language: "rust".to_string(),
+            name: format!("s{id}"),
+            qualified_name: format!("s{id}"),
+            scope_path: String::new(),
+            kind: "function".to_string(),
+            start_byte: start,
+            end_byte: end,
+            start_line: 0,
+            end_line: 0,
+        }
+    }
+
+    /// The pre-#519 O(S²) implementation: for each child, scan ALL symbols for the smallest-span
+    /// symbol that encloses it. Kept verbatim so the nesting-sweep rewrite is proven to emit the
+    /// same (parent → child) edges in the same order.
+    fn reference(symbols: &[IndexedSymbol]) -> Vec<EdgeCandidate> {
+        let mut out = Vec::new();
+        for child in symbols {
+            let parent = symbols
+                .iter()
+                .filter(|candidate| {
+                    candidate.id != child.id
+                        && candidate.start_byte <= child.start_byte
+                        && candidate.end_byte >= child.end_byte
+                })
+                .min_by_key(|candidate| candidate.end_byte.saturating_sub(candidate.start_byte));
+            if let Some(parent) = parent {
+                out.push(EdgeCandidate {
+                    from_symbol_id: Some(parent.id),
+                    from_name: Some(parent.qualified_name.clone()),
+                    to_name: child.qualified_name.clone(),
+                    target_qualified_name: Some(child.qualified_name.clone()),
+                    evidence: Some(child.qualified_name.clone()),
+                    receiver_hint: None,
+                    source_span: child.span(),
+                    callee_span: None,
+                    import_scope: None,
+                    edge_kind: EdgeKind::Contains,
+                    confidence: EdgeConfidence::Exact,
+                });
+            }
+        }
+        out
+    }
+
+    /// (parent from_symbol_id, child to_name) in emission order — the identity of a Contains edge.
+    fn projection(edges: &[EdgeCandidate]) -> Vec<(Option<i64>, String)> {
+        edges.iter().map(|edge| (edge.from_symbol_id, edge.to_name.clone())).collect()
+    }
+
+    fn assert_equiv(symbols: &[IndexedSymbol]) {
+        assert_eq!(
+            projection(&contains_edges(symbols)),
+            projection(&reference(symbols)),
+            "contains_edges diverged from the O(S^2) reference",
+        );
+    }
+
+    #[test]
+    fn a_nested_chain_links_each_symbol_to_its_immediate_parent() {
+        // module(0..100) ⊃ function(10..90) ⊃ struct(40..60); each child's parent is the next
+        // enclosing span, and the outermost has none.
+        let symbols = [sym(1, 0, 100), sym(2, 10, 90), sym(3, 40, 60)];
+        let edges = contains_edges(&symbols);
+        // Emitted in original (child) array order: s2's parent (the module), then s3's parent
+        // (the function).
+        assert_eq!(projection(&edges), vec![
+            (Some(1), "s2".to_string()), // function's parent is the module
+            (Some(2), "s3".to_string()), // struct's parent is the function
+        ]);
+        assert_equiv(&symbols);
+    }
+
+    #[test]
+    fn siblings_share_a_parent_and_the_outermost_has_none() {
+        let symbols = [sym(1, 0, 100), sym(2, 10, 30), sym(3, 40, 60), sym(4, 70, 90)];
+        assert_equiv(&symbols);
+        assert_eq!(contains_edges(&symbols).len(), 3, "three children, one root");
+    }
+
+    #[test]
+    fn a_symbol_with_no_container_emits_no_edge() {
+        let symbols = [sym(1, 0, 10), sym(2, 20, 30)];
+        assert!(contains_edges(&symbols).is_empty());
+    }
+
+    #[test]
+    fn equal_start_container_is_the_parent() {
+        // A container sharing its child's start byte (e.g. `impl X { fn y }` where the grammar
+        // happened to align starts) must still be recognised as the enclosing parent.
+        let symbols = [sym(1, 0, 50), sym(2, 0, 20)];
+        assert_eq!(projection(&contains_edges(&symbols)), vec![(Some(1), "s2".to_string())]);
+        assert_equiv(&symbols);
+    }
+
+    #[test]
+    fn matches_the_reference_across_nested_and_sibling_shapes() {
+        // Deep nesting plus siblings at several depths, in the (start ASC, end ASC) order both real
+        // input paths produce — sweep the whole shape against the O(S²) reference.
+        let symbols = [
+            sym(1, 0, 200),
+            sym(2, 10, 90),
+            sym(3, 20, 40),
+            sym(4, 50, 80),
+            sym(5, 55, 60),
+            sym(6, 100, 190),
+            sym(7, 110, 120),
+            sym(8, 130, 180),
+        ];
+        assert_equiv(&symbols);
     }
 }

--- a/crates/rag-rat-core/src/index/edges/helpers.rs
+++ b/crates/rag-rat-core/src/index/edges/helpers.rs
@@ -45,25 +45,36 @@ pub(crate) fn dotted_qualified_name(identifiers: &[String]) -> Option<String> {
 pub(crate) fn c_like_qualified_name(identifiers: &[String]) -> Option<String> {
     (identifiers.len() > 1).then(|| identifiers.join("::"))
 }
+/// The smallest-span symbol whose byte range covers `byte` (a call/reference site's owner). When
+/// that smallest is a `const`/`property`/`static` — a value binding whose initializer is where the
+/// call actually lives, so the enclosing definition is the better owner — the smallest-span
+/// container that ISN'T one of those is preferred instead, falling back to the value binding when
+/// none exists.
+///
+/// One O(S) pass, no per-call allocation or sort (#519): the old filter-into-`Vec` + stable
+/// sort-by-span ran once per edge candidate (O(E·S) plus an alloc+sort each). Tracking the two
+/// running minima gives byte-identical selection — a strict `<` update keeps the FIRST symbol of an
+/// equal-span tie, exactly as the stable sort did.
 pub(crate) fn containing_symbol(symbols: &[IndexedSymbol], byte: usize) -> Option<&IndexedSymbol> {
-    let mut matches = symbols
-        .iter()
-        .filter(|symbol| symbol.start_byte <= byte && symbol.end_byte >= byte)
-        .collect::<Vec<_>>();
-    matches.sort_by_key(|symbol| symbol.end_byte.saturating_sub(symbol.start_byte));
-    let first = matches.first().copied()?;
-    if matches!(first.kind.as_str(), "const" | "property" | "static") {
-        matches
-            .iter()
-            .copied()
-            .find(|symbol| {
-                symbol.id != first.id
-                    && !matches!(symbol.kind.as_str(), "const" | "property" | "static")
-            })
-            .or(Some(first))
-    } else {
-        Some(first)
+    let span = |symbol: &IndexedSymbol| symbol.end_byte.saturating_sub(symbol.start_byte);
+    let is_special =
+        |symbol: &IndexedSymbol| matches!(symbol.kind.as_str(), "const" | "property" | "static");
+    let mut smallest: Option<&IndexedSymbol> = None;
+    let mut smallest_non_special: Option<&IndexedSymbol> = None;
+    for symbol in symbols {
+        if symbol.start_byte > byte || symbol.end_byte < byte {
+            continue;
+        }
+        if smallest.is_none_or(|best| span(symbol) < span(best)) {
+            smallest = Some(symbol);
+        }
+        if !is_special(symbol) && smallest_non_special.is_none_or(|best| span(symbol) < span(best))
+        {
+            smallest_non_special = Some(symbol);
+        }
     }
+    let smallest = smallest?;
+    if is_special(smallest) { smallest_non_special.or(Some(smallest)) } else { Some(smallest) }
 }
 /// A trailing turbofish (`f::<T>`) wraps the callee path in a `generic_function`; unwrap it so the
 /// type arguments' identifiers / byte ranges aren't mistaken for the callee.
@@ -471,4 +482,125 @@ pub(crate) fn collect_rows<T>(
         out.push(row?);
     }
     Ok(out)
+}
+
+#[cfg(test)]
+mod containing_symbol_tests {
+    use super::*;
+
+    fn sym(id: i64, kind: &str, start: usize, end: usize) -> IndexedSymbol {
+        IndexedSymbol {
+            id,
+            file_id: 0,
+            language: "rust".to_string(),
+            name: format!("s{id}"),
+            qualified_name: format!("s{id}"),
+            scope_path: String::new(),
+            kind: kind.to_string(),
+            start_byte: start,
+            end_byte: end,
+            start_line: 0,
+            end_line: 0,
+        }
+    }
+
+    /// The pre-#519 filter-into-`Vec` + stable-sort-by-span implementation, kept verbatim so the
+    /// single-pass rewrite can be proven byte-identical (same selected id, same tie-break) across a
+    /// battery of inputs — including degenerate equal-span sets a real parse can't produce.
+    fn reference(symbols: &[IndexedSymbol], byte: usize) -> Option<&IndexedSymbol> {
+        let mut matches = symbols
+            .iter()
+            .filter(|symbol| symbol.start_byte <= byte && symbol.end_byte >= byte)
+            .collect::<Vec<_>>();
+        matches.sort_by_key(|symbol| symbol.end_byte.saturating_sub(symbol.start_byte));
+        let first = matches.first().copied()?;
+        if matches!(first.kind.as_str(), "const" | "property" | "static") {
+            matches
+                .iter()
+                .copied()
+                .find(|symbol| {
+                    symbol.id != first.id
+                        && !matches!(symbol.kind.as_str(), "const" | "property" | "static")
+                })
+                .or(Some(first))
+        } else {
+            Some(first)
+        }
+    }
+
+    fn assert_equiv(symbols: &[IndexedSymbol], byte: usize) {
+        let got = containing_symbol(symbols, byte).map(|symbol| symbol.id);
+        let want = reference(symbols, byte).map(|symbol| symbol.id);
+        assert_eq!(got, want, "byte={byte}");
+    }
+
+    #[test]
+    fn smallest_enclosing_wins_over_a_nested_chain() {
+        let symbols =
+            [sym(1, "module", 0, 100), sym(2, "function", 10, 90), sym(3, "struct", 40, 60)];
+        assert_eq!(containing_symbol(&symbols, 50).map(|s| s.id), Some(3), "innermost");
+        assert_eq!(containing_symbol(&symbols, 20).map(|s| s.id), Some(2));
+        assert_eq!(containing_symbol(&symbols, 5).map(|s| s.id), Some(1));
+        assert!(containing_symbol(&symbols, 200).is_none(), "outside every span");
+    }
+
+    #[test]
+    fn boundary_bytes_are_inclusive() {
+        let symbols = [sym(1, "function", 10, 20)];
+        assert_eq!(containing_symbol(&symbols, 10).map(|s| s.id), Some(1), "start is inclusive");
+        assert_eq!(containing_symbol(&symbols, 20).map(|s| s.id), Some(1), "end is inclusive");
+        assert!(containing_symbol(&symbols, 9).is_none());
+        assert!(containing_symbol(&symbols, 21).is_none());
+    }
+
+    #[test]
+    fn const_property_static_reselects_the_smallest_non_special_container() {
+        // A `const` is the smallest span at the byte, but a non-special container exists → pick it.
+        let symbols = [sym(1, "function", 0, 100), sym(2, "const", 40, 60)];
+        assert_eq!(containing_symbol(&symbols, 50).map(|s| s.id), Some(1), "reselect the fn");
+        assert_equiv(&symbols, 50);
+    }
+
+    #[test]
+    fn a_const_with_no_non_special_container_stays_selected() {
+        let symbols = [sym(1, "const", 40, 60)];
+        assert_eq!(containing_symbol(&symbols, 50).map(|s| s.id), Some(1));
+        assert_equiv(&symbols, 50);
+    }
+
+    #[test]
+    fn reselection_prefers_the_smallest_non_special_container() {
+        // Two non-special containers wrap a `const`; the SMALLER-span one is chosen (not just any).
+        let symbols =
+            [sym(1, "module", 0, 200), sym(2, "function", 30, 70), sym(3, "property", 45, 55)];
+        assert_eq!(containing_symbol(&symbols, 50).map(|s| s.id), Some(2), "smallest non-special");
+        assert_equiv(&symbols, 50);
+    }
+
+    #[test]
+    fn equal_span_containers_keep_the_first_in_array_order() {
+        // Degenerate (unreachable from a real parse): two containers with an identical span at the
+        // byte. Both `containing_symbol` and the reference must pick the FIRST in array order.
+        let symbols = [sym(7, "function", 10, 20), sym(8, "function", 10, 20)];
+        assert_eq!(containing_symbol(&symbols, 15).map(|s| s.id), Some(7));
+        assert_equiv(&symbols, 15);
+    }
+
+    #[test]
+    fn matches_the_reference_across_a_swept_battery() {
+        // Overlapping/nested/sibling spans of mixed kinds; sweep every byte and every reordering-
+        // sensitive case to pin byte-identical selection against the old implementation.
+        let symbols = [
+            sym(1, "module", 0, 100),
+            sym(2, "const", 0, 100),
+            sym(3, "function", 20, 80),
+            sym(4, "static", 20, 80),
+            sym(5, "struct", 40, 60),
+            sym(6, "property", 40, 60),
+            sym(7, "function", 50, 50),
+        ];
+        for byte in 0..=110 {
+            assert_equiv(&symbols, byte);
+        }
+    }
 }

--- a/crates/rag-rat-core/src/index/edges/mod.rs
+++ b/crates/rag-rat-core/src/index/edges/mod.rs
@@ -16,7 +16,7 @@ use rusqlite::{Connection, params};
 use serde::Serialize;
 use tree_sitter::Node;
 
-use crate::index::parser::{self, ParserKind};
+use crate::index::parser;
 use crate::language::Language;
 
 pub const MAX_GRAPH_PARSE_BYTES: usize = 512_000;

--- a/crates/rag-rat-core/src/index/parser.rs
+++ b/crates/rag-rat-core/src/index/parser.rs
@@ -235,7 +235,10 @@ pub fn parser_kind(path: &Path, language: Language) -> ParserKind {
 const PARSE_ERROR_MESSAGE: &str =
     "tree-sitter parse produced error nodes; partial structural index was retained";
 
-fn grammar_for(kind: ParserKind) -> Option<tree_sitter::Language> {
+/// The tree-sitter grammar for a [`ParserKind`], or `None` for kinds with no structural grammar
+/// (Markdown). The single source of truth for the kind → grammar mapping — edge extraction routes
+/// through here rather than duplicating the match (#519).
+pub(crate) fn grammar_for(kind: ParserKind) -> Option<tree_sitter::Language> {
     Some(match kind {
         ParserKind::Rust => tree_sitter_rust::LANGUAGE.into(),
         ParserKind::TypeScript => tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into(),


### PR DESCRIPTION
Two per-file quadratic costs in edge extraction, plus a grammar-match dedup. Output is byte-identical — proven by reference-equivalence tests that keep each old implementation and assert the rewrite matches it.

Fixes #519.

## `containing_symbol`: O(S) single pass, no per-call alloc/sort

`containing_symbol` (the owner of a call/reference site) filtered all symbols into a fresh `Vec` and stable-sorted it by span, **once per edge candidate** — O(E·S) plus an allocation + sort each. It now makes one pass tracking two running minima: the smallest-span container, and the smallest-span container that isn't a `const`/`property`/`static` (the re-selection rule for value bindings whose initializer is where the call lives). A strict `<` update keeps the first symbol of an equal-span tie, so selection is byte-identical to the stable sort.

## `contains_edges`: O(S²) → O(S log S) nesting sweep

For each symbol, `contains_edges` scanned **all** symbols to find the smallest enclosing one (the `Contains` parent) — O(S²). Because symbols come from the AST their byte ranges form a properly-nested forest (any two are disjoint or nested, never partially overlapping, and no two distinct symbols share an exact span), so the smallest-span container is exactly the immediate nesting parent. A single stack sweep over indices sorted `(start ASC, end DESC)` finds every parent in O(S log S); edges are still emitted in the input's original order, so the output is identical.

## `syntactic_edges`: route through `parser::grammar_for`

`syntactic_edges` duplicated the `ParserKind → tree_sitter::Language` match verbatim. It now calls `parser::grammar_for(parser::parser_kind(..))` — the single source of truth — so a new language lands in one place. `None` (Markdown) yields no edges, same as the old `Markdown` arm.

## Tests

- `containing_symbol_tests` — nested chains, inclusive boundaries, the const/property/static re-selection (incl. smallest-non-special preference and the no-non-special fallback), the equal-span tie-break, and a full byte-sweep against the retained O(S²)+sort reference.
- `contains_edges_tests` — nested chain, siblings, no-container, equal-start containment, and a nested+sibling battery against the retained O(S²) reference (`(from_symbol_id, to_name)` projection, in emission order).
- Full workspace suite green; the per-language graph-edge integration tests (Rust/C/C++/Kotlin/TypeScript) are unchanged.
