### PR TITLE
Wire op-log authoring into the live memory write path (phase B)

### DIFF
--- a/crates/rag-rat-core/src/lib.rs
+++ b/crates/rag-rat-core/src/lib.rs
@@ -10,9 +10,10 @@ pub mod index;
 pub mod language;
 pub mod locks;
 pub mod logging;
-// Phase B op-log primitive (#404/#489): a pure op model + deterministic projection fold, frozen in
-// isolation and NOT yet wired into the write path — so its surface is dead until a later increment
-// consumes it (the same posture as `content_hash`'s `#[allow(dead_code)]`).
+// Phase B op-log (#404). The authoring half is now wired into the memory write path (#532), but the
+// SYNC-TRANSPORT half — `append` (receiving a foreign signed entry), the fork quarantine,
+// `AppendOutcome` — is still unconsumed (a later increment), so the module keeps
+// `allow(dead_code)`.
 #[allow(dead_code)]
 pub(crate) mod oplog;
 pub mod output;

--- a/crates/rag-rat-core/src/oplog/mod.rs
+++ b/crates/rag-rat-core/src/oplog/mod.rs
@@ -46,13 +46,11 @@ mod stream;
 // private, so this curated re-export is the ONE seam `query::memory` reaches through — and the only
 // direction of the dependency (`oplog` never depends back on `query::memory`).
 pub(crate) use identity::local_device;
-pub(crate) use op::{EdgeSpec, MemoryOp, NodeContent, NodeId, NodeStatus};
-// The rest of the minting API completes the frozen surface but is unconsumed until the
-// live-wiring increment: `author_in_tx` / `author_op` mint ONE op (composed into a mutation
-// txn, or standalone), and `author_batch` is the standalone genesis-batch wrapper (the
-// backfill instead drives `author_genesis_in_tx` inside the txn it opens to snapshot memories
-// atomically).
+pub(crate) use op::{EdgeKey, EdgeSpec, MemoryOp, NodeContent, NodeId, NodeStatus};
+// `author_op` / `author_batch` are the standalone (own-txn) wrappers — still only test-used,
+// so their re-export stays `allow(unused_imports)`. The live write path uses the in-txn
+// primitives.
 #[allow(unused_imports)]
-pub(crate) use store::{author_batch, author_in_tx, author_op};
-pub(crate) use store::{author_genesis_in_tx, chain_tail};
-pub(crate) use stream::owner_stream;
+pub(crate) use store::{author_batch, author_op};
+pub(crate) use store::{author_genesis_in_tx, author_in_tx, chain_tail};
+pub(crate) use stream::{StreamId, owner_stream};

--- a/crates/rag-rat-core/src/query/memory/api.rs
+++ b/crates/rag-rat-core/src/query/memory/api.rs
@@ -1,4 +1,7 @@
+use rusqlite::{Transaction, TransactionBehavior};
+
 use super::*;
+use crate::query::memory::authoring;
 
 /// Max chars for a memory title (a one-line summary) and body. The body cap is generous on purpose:
 /// Invariant / Decision / BugPattern memories are meant to carry the *why* + *how to apply* in
@@ -57,6 +60,11 @@ pub(crate) fn create_memory(
     // scope drives the repo stamp below.
     let scope = memory_repo_scope(conn)?;
     let id = memory_id(now, &input_hash, &scope);
+    // Backfill the pre-existing history BEFORE this live entry (idempotent; a cheap no-op once the
+    // chain exists), then do the table writes + the op-append in ONE transaction so they commit —
+    // or roll back — together (strict-atomic). Writes via `conn` participate in the open txn.
+    authoring::backfill_memory_oplog(conn, now)?;
+    let tx = conn.unchecked_transaction()?;
     conn.execute(
         "
         INSERT INTO repo_memories(
@@ -100,12 +108,21 @@ pub(crate) fn create_memory(
     upsert_memory_fts(conn, &id)?;
     let memory = memory_by_id(conn, &id)?
         .ok_or_else(|| anyhow::anyhow!("created memory `{id}` could not be read back"))?;
+    // Author the NodeCreate in the SAME txn; an authoring error drops `tx` → the INSERT rolls back.
+    authoring::author_create(&tx, &memory, now)?;
+    tx.commit()?;
     Ok(RepoMemoryCreateResult { memory, duplicate: false })
 }
 pub(crate) fn update_memory(
     conn: &Connection,
     update: RepoMemoryUpdate,
 ) -> anyhow::Result<RepoMemory> {
+    let now = now_ms();
+    // Backfill (idempotent) before opening our txn, then open an IMMEDIATE txn so the current-row
+    // READ and the UPDATE are ONE atomic unit — a racing writer cannot flip the status between the
+    // read and the write and desync the table from the op-log projection.
+    authoring::backfill_memory_oplog(conn, now)?;
+    let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
     let current = memory_by_id(conn, &update.memory_id)?
         .ok_or_else(|| anyhow::anyhow!("memory `{}` not found", update.memory_id))?;
     if let Some(kind) = update.kind.as_deref() {
@@ -144,7 +161,25 @@ pub(crate) fn update_memory(
     } else {
         None
     };
-    let now = now_ms();
+    // Detect what actually CHANGED before `current`'s fields are moved into the UPDATE params.
+    // Content and status are INDEPENDENT LWW registers: author a NodeUpdate ONLY on a real content
+    // change (else a status-only update would re-assert this device's content and could revert a
+    // concurrent edit under sync) and a NodeStatus ONLY on a real status change.
+    let new_title = update.title.as_deref().unwrap_or(current.title.as_str());
+    let new_body = update.body.as_deref().unwrap_or(current.body.as_str());
+    let new_confidence = update.confidence.as_deref().unwrap_or(current.confidence.as_str());
+    // Compare tags NORMALIZED — `current.tags` is trimmed / non-empty / deduped / sorted (how
+    // `replace_tags` stores and `tags_for_memory` reads them), so raw `update.tags` must be put in
+    // the same shape before comparing, or a whitespace/duplicate-only re-tag would look "changed"
+    // and mint a spurious NodeUpdate (the status-only-update hazard, re-reached through tags).
+    let tags_changed = update.tags.as_ref().is_some_and(|raw| normalize_tags(raw) != current.tags);
+    let content_changed = new_kind != current.kind
+        || new_title != current.title
+        || new_body != current.body
+        || new_confidence != current.confidence
+        || stored_payload != current.payload_json
+        || tags_changed;
+    let status_changed = update.status.as_deref().is_some_and(|s| s != current.status.as_str());
     conn.execute(
         "
         UPDATE repo_memories
@@ -172,9 +207,14 @@ pub(crate) fn update_memory(
         replace_tags(conn, &update.memory_id, &tags)?;
     }
     upsert_memory_fts(conn, &update.memory_id)?;
-    memory_by_id(conn, &update.memory_id)?.ok_or_else(|| {
+    let memory = memory_by_id(conn, &update.memory_id)?.ok_or_else(|| {
         anyhow::anyhow!("updated memory `{}` could not be read back", update.memory_id)
-    })
+    })?;
+    // Author NodeUpdate (+ NodeStatus on a status change) in the SAME txn; an authoring error drops
+    // `tx` → the UPDATE rolls back.
+    authoring::author_update(&tx, &memory, content_changed, status_changed, now)?;
+    tx.commit()?;
+    Ok(memory)
 }
 pub(crate) fn mark_obsolete(conn: &Connection, memory_id: &str) -> anyhow::Result<RepoMemory> {
     update_memory(conn, RepoMemoryUpdate {

--- a/crates/rag-rat-core/src/query/memory/authoring.rs
+++ b/crates/rag-rat-core/src/query/memory/authoring.rs
@@ -3,20 +3,20 @@
 //!
 //! This bridges `repo_memories` / `repo_node_edges` (owned by this module) and the op-log MINTING
 //! primitives ([`crate::oplog`]) — a ONE-WAY dependency, so `oplog` never depends back on the
-//! memory subsystem (the next increment adds the reverse call, `create_memory` → author, and a
-//! cycle would break the build).
+//! memory subsystem (a reverse call would cycle the build).
 //!
-//! NOT wired into the live write path yet: [`backfill_memory_oplog`] is exercised in isolation. The
-//! next increment calls it before the first live-authored mutation and reuses [`memory_to_ops`] for
-//! the mutations themselves.
+//! WIRED into the live write path (#532): the memory mutations call [`backfill_memory_oplog`] once
+//! (before the first live entry) and the `author_*` seams below INSIDE their own transaction, so
+//! the op-append and the table write commit — or roll back — together (strict-atomic). Authoring is
+//! a NO-OP under an unstable scope ([`stable_owner_stream`]), leaving scope-less callers untouched.
 
 use rusqlite::{Connection, Transaction, TransactionBehavior, params};
 
 use super::hydrate::tags_for_memory;
-use super::{EdgeRelation, NodeEdge, all_edges_from, memory_repo_scope};
+use super::{EdgeRelation, NodeEdge, RepoMemory, all_edges_from, memory_repo_scope};
 use crate::oplog::{
-    EdgeSpec, MemoryOp, NodeContent, NodeId, NodeStatus, author_genesis_in_tx, chain_tail,
-    local_device, owner_stream,
+    EdgeKey, EdgeSpec, MemoryOp, NodeContent, NodeId, NodeStatus, StreamId, author_genesis_in_tx,
+    author_in_tx, chain_tail, local_device, owner_stream,
 };
 
 /// One memory's projectable content — the columns the op model carries (NOT the identity / anchor /
@@ -33,11 +33,34 @@ struct MemoryRow {
     tags: Vec<String>,
 }
 
-/// Translate one memory into its op sequence: a `NodeCreate` for content, a `NodeStatus` ONLY when
-/// the status is not the fold's `active` create-time default, and an `EdgeAdd` per outgoing typed
-/// node-edge (in `edge_key` order, so the authored chain is reproducible). Code-anchor BINDINGS are
-/// excluded — they are per-device derived resolution state, re-validated locally, and never part of
-/// the shared node graph the projection models.
+/// Build the op model's content register from a memory's projectable columns — shared by the
+/// backfill ([`memory_to_ops`]) and the live create/update authors, so all three agree
+/// byte-for-byte.
+fn node_content(
+    kind: &str,
+    title: &str,
+    body: &str,
+    confidence: &str,
+    source: &str,
+    tags: &[String],
+    payload_json: Option<&str>,
+) -> NodeContent {
+    NodeContent {
+        kind: kind.to_string(),
+        title: title.to_string(),
+        body: body.to_string(),
+        confidence: confidence.to_string(),
+        source: source.to_string(),
+        tags: tags.to_vec(),
+        payload: payload_json.map(str::to_string),
+    }
+}
+
+/// Translate one memory into its BACKFILL op sequence: a `NodeCreate` for content, a `NodeStatus`
+/// ONLY when the status is not the fold's `active` create-time default, and an `EdgeAdd` per
+/// outgoing typed node-edge (in `edge_key` order, so the authored chain is reproducible).
+/// Code-anchor BINDINGS are excluded — per-device derived resolution state, never part of the
+/// shared node graph.
 fn memory_to_ops(
     row: &MemoryRow,
     owner_repo_id: &str,
@@ -46,15 +69,15 @@ fn memory_to_ops(
     let node_id = NodeId::from(row.memory_id.as_str());
     let mut ops = vec![MemoryOp::NodeCreate {
         node_id: node_id.clone(),
-        content: NodeContent {
-            kind: row.kind.clone(),
-            title: row.title.clone(),
-            body: row.body.clone(),
-            confidence: row.confidence.clone(),
-            source: row.source.clone(),
-            tags: row.tags.clone(),
-            payload: row.payload_json.clone(),
-        },
+        content: node_content(
+            &row.kind,
+            &row.title,
+            &row.body,
+            &row.confidence,
+            &row.source,
+            &row.tags,
+            row.payload_json.as_deref(),
+        ),
     }];
     // `active` is the fold's create-time default, so it needs no op. A status token this binary
     // does NOT recognize (a newer binary's future status) must NOT be silently dropped — that would
@@ -146,6 +169,140 @@ pub(crate) fn backfill_memory_oplog(conn: &Connection, now_ms: i64) -> anyhow::R
     author_genesis_in_tx(&tx, stream, &device, &ops, now_ms)?;
     tx.commit()?;
     Ok(())
+}
+
+/// The active repo's owner stream, but ONLY when the scope is a STABLE identity to root an
+/// IMMUTABLE stream on — the SAME gate the backfill uses: `Some`, not the `__unassigned__`
+/// placeholder, not a `local:` shallow-clone id (both get re-pointed later). `None` otherwise, and
+/// the `author_*` seams SKIP authoring on `None`, so a scope-less mutation (most tests) never
+/// touches the log.
+fn stable_owner_stream(conn: &Connection) -> anyhow::Result<Option<StreamId>> {
+    let Some(repo_id) = memory_repo_scope(conn)? else {
+        return Ok(None);
+    };
+    if repo_id == crate::index::schema::LEGACY_REPO_ID
+        || repo_id.starts_with(crate::repo_identity::LOCAL_ONLY_ID_PREFIX)
+    {
+        return Ok(None);
+    }
+    Ok(Some(owner_stream(&repo_id)?))
+}
+
+/// Author `ops` onto the active repo's owner stream WITHIN the caller's mutation txn — the strict-
+/// atomic live seam. Each op is minted + inserted + folded by `author_in_tx` (no open/commit), so
+/// an authoring error propagates via `?` and the caller's txn rolls the table write back with it. A
+/// NO-OP under an unstable scope. The caller MUST have run [`backfill_memory_oplog`] first (so the
+/// pre-existing history precedes this live entry).
+fn author_in_owner_stream(
+    tx: &Transaction<'_>,
+    ops: &[MemoryOp],
+    now_ms: i64,
+) -> anyhow::Result<()> {
+    let Some(stream) = stable_owner_stream(tx)? else {
+        return Ok(());
+    };
+    let device = local_device(tx, now_ms)?;
+    for op in ops {
+        author_in_tx(tx, stream, &device, op, now_ms)?;
+    }
+    Ok(())
+}
+
+/// Author a live memory CREATE (`NodeCreate`) inside the caller's mutation txn. A fresh memory has
+/// no node-edges yet, so this is a single op.
+pub(crate) fn author_create(
+    tx: &Transaction<'_>,
+    memory: &RepoMemory,
+    now_ms: i64,
+) -> anyhow::Result<()> {
+    let op = MemoryOp::NodeCreate {
+        node_id: NodeId::from(memory.memory_id.as_str()),
+        content: content_of(memory),
+    };
+    author_in_owner_stream(tx, &[op], now_ms)
+}
+
+/// Author a live memory UPDATE inside the caller's mutation txn: a `NodeUpdate` ONLY when the
+/// content actually changed, plus a `NodeStatus` ONLY when the status changed (even to `active`,
+/// since the fold needs an explicit op to override a prior non-active status). Content and status
+/// are INDEPENDENT LWW registers, so a status-only change must NOT emit a `NodeUpdate` — in a
+/// synced multi-writer stream that lifecycle op would re-assert this device's content snapshot at a
+/// new Lamport and could revert a concurrent body/title edit from another device. An unknown new
+/// status token errors (the write path validates status first, so this is defensive).
+pub(crate) fn author_update(
+    tx: &Transaction<'_>,
+    memory: &RepoMemory,
+    content_changed: bool,
+    status_changed: bool,
+    now_ms: i64,
+) -> anyhow::Result<()> {
+    let node_id = NodeId::from(memory.memory_id.as_str());
+    let mut ops = Vec::new();
+    if content_changed {
+        ops.push(MemoryOp::NodeUpdate { node_id: node_id.clone(), content: content_of(memory) });
+    }
+    if status_changed {
+        let status = NodeStatus::from_db_str(&memory.status).ok_or_else(|| {
+            anyhow::anyhow!(
+                "unknown status token `{}` (a newer binary must author this)",
+                memory.status
+            )
+        })?;
+        ops.push(MemoryOp::NodeStatus { node_id, status });
+    }
+    author_in_owner_stream(tx, &ops, now_ms)
+}
+
+/// Author a live edge ADD (`EdgeAdd`) inside the caller's mutation txn — presence + the durable
+/// spec only (no `Rebind`; edge resolution is per-device, recomputed on read).
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn author_edge_add(
+    tx: &Transaction<'_>,
+    source_node_id: &str,
+    relation: EdgeRelation,
+    target_repo_id: &str,
+    target_kind: &str,
+    target_anchor: &str,
+    owner_repo_id: &str,
+    now_ms: i64,
+) -> anyhow::Result<()> {
+    let op = MemoryOp::EdgeAdd {
+        edge: EdgeSpec {
+            source_node_id: NodeId::from(source_node_id),
+            relation,
+            target_repo_id: target_repo_id.to_string(),
+            target_kind: target_kind.to_string(),
+            target_anchor: target_anchor.to_string(),
+            owner_repo_id: owner_repo_id.to_string(),
+        },
+    };
+    author_in_owner_stream(tx, &[op], now_ms)
+}
+
+/// Author a live edge REMOVE (`EdgeRemove` tombstone) inside the caller's mutation txn.
+pub(crate) fn author_edge_remove(
+    tx: &Transaction<'_>,
+    edge_key: &str,
+    now_ms: i64,
+) -> anyhow::Result<()> {
+    author_in_owner_stream(
+        tx,
+        &[MemoryOp::EdgeRemove { edge_key: EdgeKey::from(edge_key) }],
+        now_ms,
+    )
+}
+
+/// The op-model content register for a persisted memory.
+fn content_of(memory: &RepoMemory) -> NodeContent {
+    node_content(
+        &memory.kind,
+        &memory.title,
+        &memory.body,
+        &memory.confidence,
+        &memory.source,
+        &memory.tags,
+        memory.payload_json.as_deref(),
+    )
 }
 
 /// The active repo's memories in deterministic `(created_at_ms, memory_id)` order, tags attached.
@@ -308,14 +465,17 @@ mod tests {
         insert_memory(&conn, "mem_a", "active", 100);
         insert_memory(&conn, "mem_b", "active", 200);
         insert_memory(&conn, "mem_c", "active", 300);
-        // Author a typed edge FROM mem_b (add_edge requires a live source), THEN mark mem_b
-        // obsolete. The persisted edge must still be backfilled — the P2 regression guard: the
-        // complete-history log keeps a non-live source's relationships (unlike the live reader).
-        crate::query::memory::add_edge(
-            &conn,
-            "mem_b",
-            EdgeRelation::RelatesTo,
-            &crate::query::memory::EdgeTarget::Node { repo_id: None, node_id: "mem_c".to_string() },
+        // Insert a typed edge FROM mem_b DIRECTLY (not via the now-live `add_edge`, which would
+        // author it eagerly and defeat this isolation test), THEN mark mem_b obsolete — so the
+        // explicit backfill below is the SOLE authoring path and must still capture the edge from a
+        // now-non-live source (the complete-history guard: the live reader hides it).
+        let ek = crate::query::memory::edge_key("mem_b", "relates_to", "node", "mem_c");
+        conn.execute(
+            "INSERT INTO repo_node_edges(
+                 edge_key, repo_id, source_node_id, relation, target_repo_id, target_kind,
+                 target_anchor, target_node_id, anchor_status, created_at_ms)
+             VALUES (?1, ?2, 'mem_b', 'relates_to', ?2, 'node', 'mem_c', 'mem_c', 'current', 0)",
+            params![ek, REPO],
         )
         .unwrap();
         conn.execute("UPDATE repo_memories SET status = 'obsolete' WHERE id = 'mem_b'", [])
@@ -417,5 +577,255 @@ mod tests {
         let conn = scoped_conn();
         backfill_memory_oplog(&conn, 1_000).unwrap();
         assert_eq!(entry_count(&conn), 0, "no memories ⇒ no entries; the first live op is genesis");
+    }
+
+    // --- live write-path wiring (#532) ---
+
+    fn projected_edge_count(conn: &Connection) -> i64 {
+        conn.query_row("SELECT COUNT(*) FROM oplog_projected_edges", [], |r| r.get(0)).unwrap()
+    }
+
+    /// Create an unanchored `Concept` (needs no code binding) through the LIVE `create_memory`.
+    fn create_concept(
+        conn: &Connection,
+        title: &str,
+    ) -> anyhow::Result<crate::query::memory::RepoMemoryCreateResult> {
+        crate::query::memory::create_memory(conn, crate::query::memory::RepoMemoryCreate {
+            kind: "Concept".to_string(),
+            title: title.to_string(),
+            body: "body".to_string(),
+            confidence: "high".to_string(),
+            created_by: None,
+            source: None,
+            tags: Vec::new(),
+            payload_json: None,
+            bind: crate::query::memory::RepoMemoryBindTarget::default(),
+        })
+    }
+
+    #[test]
+    fn create_memory_authors_a_projected_node() {
+        let conn = scoped_conn();
+        let r = create_concept(&conn, "t1").unwrap();
+        let n: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM oplog_projected_nodes WHERE node_id = ?1",
+                [&r.memory.memory_id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(n, 1, "the created memory is a projected node");
+        assert_eq!(projected_node_count(&conn), 1);
+    }
+
+    #[test]
+    fn a_scope_less_create_authors_nothing() {
+        // No repos row / no active-repo context → the scope gate skips authoring entirely.
+        let conn = Connection::open_in_memory().unwrap();
+        crate::index::schema::apply(&conn).unwrap();
+        create_concept(&conn, "t1").unwrap();
+        assert_eq!(entry_count(&conn), 0, "a scope-less create never touches the log");
+    }
+
+    #[test]
+    fn update_memory_authors_node_update_and_a_status_change() {
+        let conn = scoped_conn();
+        let id = create_concept(&conn, "t1").unwrap().memory.memory_id;
+        crate::query::memory::update_memory(&conn, crate::query::memory::RepoMemoryUpdate {
+            memory_id: id.clone(),
+            kind: None,
+            title: None,
+            body: Some("a new body".to_string()),
+            confidence: None,
+            status: Some("obsolete".to_string()),
+            tags: None,
+            payload_json: None,
+        })
+        .unwrap();
+        let (content_json, status): (String, String) = conn
+            .query_row(
+                "SELECT content_json, status FROM oplog_projected_nodes WHERE node_id = ?1",
+                [&id],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert!(content_json.contains("a new body"), "the NodeUpdate replaced the content");
+        assert_eq!(status, "obsolete", "the status change authored a NodeStatus");
+    }
+
+    #[test]
+    fn mark_obsolete_authors_only_a_status_op_no_node_update() {
+        let conn = scoped_conn();
+        let id = create_concept(&conn, "t1").unwrap().memory.memory_id;
+        // The NodeCreate is the sole entry so far.
+        assert_eq!(entry_count(&conn), 1);
+        crate::query::memory::mark_obsolete(&conn, &id).unwrap();
+        let status: String = conn
+            .query_row("SELECT status FROM oplog_projected_nodes WHERE node_id = ?1", [&id], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        assert_eq!(status, "obsolete");
+        // A status-only change authors EXACTLY ONE op (a NodeStatus) — NOT a NodeUpdate, which in a
+        // synced stream could revert a concurrent content edit (content/status are independent
+        // LWW).
+        assert_eq!(
+            entry_count(&conn),
+            2,
+            "status-only update authors one NodeStatus, no NodeUpdate"
+        );
+    }
+
+    #[test]
+    fn a_no_op_update_authors_nothing() {
+        let conn = scoped_conn();
+        let id = create_concept(&conn, "t1").unwrap().memory.memory_id;
+        assert_eq!(entry_count(&conn), 1);
+        // An update that changes neither content nor status is a complete no-op in the log.
+        crate::query::memory::update_memory(&conn, crate::query::memory::RepoMemoryUpdate {
+            memory_id: id,
+            kind: None,
+            title: None,
+            body: None,
+            confidence: None,
+            status: None,
+            tags: None,
+            payload_json: None,
+        })
+        .unwrap();
+        assert_eq!(entry_count(&conn), 1, "a change-free update authors no op");
+    }
+
+    #[test]
+    fn add_and_remove_edge_author_edge_presence() {
+        let conn = scoped_conn();
+        let a = create_concept(&conn, "a").unwrap().memory.memory_id;
+        let b = create_concept(&conn, "b").unwrap().memory.memory_id;
+        let edge = crate::query::memory::add_edge(&conn, &a, EdgeRelation::RelatesTo, &{
+            crate::query::memory::EdgeTarget::Node { repo_id: None, node_id: b }
+        })
+        .unwrap();
+        assert_eq!(projected_edge_count(&conn), 1, "add_edge authored an EdgeAdd");
+        assert!(crate::query::memory::remove_edge(&conn, &edge.edge_key).unwrap());
+        assert_eq!(projected_edge_count(&conn), 0, "remove_edge authored an EdgeRemove tombstone");
+    }
+
+    #[test]
+    fn a_failed_author_rolls_back_the_memory_write() {
+        let conn = scoped_conn();
+        // One good create so the owner chain is non-empty (the second create's backfill fast-paths,
+        // isolating the failure to the live author).
+        create_concept(&conn, "first").unwrap();
+        let before: i64 =
+            conn.query_row("SELECT COUNT(*) FROM repo_memories", [], |r| r.get(0)).unwrap();
+        // Poison: pretend a NEWER projector owns the store — `author_in_tx`'s
+        // `assert_projector_not_newer` now errors, so the second create's op-append fails.
+        conn.execute("UPDATE oplog_meta SET value = '999' WHERE key = 'projector_version'", [])
+            .unwrap();
+        assert!(create_concept(&conn, "second").is_err(), "the authoring failure fails the create");
+        let after: i64 =
+            conn.query_row("SELECT COUNT(*) FROM repo_memories", [], |r| r.get(0)).unwrap();
+        assert_eq!(after, before, "strict-atomic: the failed create's row rolled back with it");
+    }
+
+    #[test]
+    fn a_live_create_backfills_pre_existing_memories_first() {
+        let conn = scoped_conn();
+        // A memory inserted by RAW SQL (never authored) — the pre-existing history.
+        insert_memory(&conn, "old", "active", 100);
+        // The first LIVE create backfills `old` (a NodeCreate) BEFORE authoring the new memory.
+        let new_id = create_concept(&conn, "new").unwrap().memory.memory_id;
+        assert_eq!(
+            projected_node_count(&conn),
+            2,
+            "old (backfilled) + new (live) are both projected"
+        );
+        let old_present: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM oplog_projected_nodes WHERE node_id = 'old'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(old_present, 1, "the pre-existing memory was backfilled");
+        assert_ne!(new_id, "old");
+    }
+
+    /// Create an unanchored `Concept` with tags through the LIVE `create_memory`.
+    fn create_concept_tagged(conn: &Connection, title: &str, tags: Vec<String>) -> String {
+        crate::query::memory::create_memory(conn, crate::query::memory::RepoMemoryCreate {
+            kind: "Concept".to_string(),
+            title: title.to_string(),
+            body: "body".to_string(),
+            confidence: "high".to_string(),
+            created_by: None,
+            source: None,
+            tags,
+            payload_json: None,
+            bind: crate::query::memory::RepoMemoryBindTarget::default(),
+        })
+        .unwrap()
+        .memory
+        .memory_id
+    }
+
+    fn update_tags(conn: &Connection, id: &str, tags: Vec<String>) {
+        crate::query::memory::update_memory(conn, crate::query::memory::RepoMemoryUpdate {
+            memory_id: id.to_string(),
+            kind: None,
+            title: None,
+            body: None,
+            confidence: None,
+            status: None,
+            tags: Some(tags),
+            payload_json: None,
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn a_normalization_only_tag_change_authors_nothing() {
+        let conn = scoped_conn();
+        let id = create_concept_tagged(&conn, "t", vec!["x".to_string()]);
+        let before = entry_count(&conn);
+        // Tags that normalize to the SAME set: trailing space, duplicate, and an empty string.
+        update_tags(&conn, &id, vec!["x ".to_string(), "x".to_string(), String::new()]);
+        assert_eq!(
+            entry_count(&conn),
+            before,
+            "a whitespace/duplicate-only re-tag is not a content change → no NodeUpdate"
+        );
+    }
+
+    #[test]
+    fn a_real_tag_change_authors_a_node_update() {
+        let conn = scoped_conn();
+        let id = create_concept_tagged(&conn, "t", vec!["x".to_string()]);
+        let before = entry_count(&conn);
+        update_tags(&conn, &id, vec!["x".to_string(), "y".to_string()]);
+        assert_eq!(entry_count(&conn), before + 1, "adding a real tag authors a NodeUpdate");
+    }
+
+    #[test]
+    fn re_adding_an_edge_authors_no_duplicate() {
+        let conn = scoped_conn();
+        let a = create_concept(&conn, "a").unwrap().memory.memory_id;
+        let b = create_concept(&conn, "b").unwrap().memory.memory_id;
+        let target = |node: &str| crate::query::memory::EdgeTarget::Node {
+            repo_id: None,
+            node_id: node.to_string(),
+        };
+        crate::query::memory::add_edge(&conn, &a, EdgeRelation::RelatesTo, &target(&b)).unwrap();
+        let after_first = entry_count(&conn);
+        assert_eq!(projected_edge_count(&conn), 1);
+        // Re-adding the SAME edge is an idempotent resolution-refresh — it must NOT author a second
+        // EdgeAdd (which could resurrect a concurrent remove under sync).
+        crate::query::memory::add_edge(&conn, &a, EdgeRelation::RelatesTo, &target(&b)).unwrap();
+        assert_eq!(
+            entry_count(&conn),
+            after_first,
+            "an idempotent edge re-add authors no duplicate EdgeAdd"
+        );
+        assert_eq!(projected_edge_count(&conn), 1);
     }
 }

--- a/crates/rag-rat-core/src/query/memory/edges.rs
+++ b/crates/rag-rat-core/src/query/memory/edges.rs
@@ -12,6 +12,7 @@
 //! once its target repo is indexed and its `target_repo_id` self-heals across a repo-id re-point.
 
 use super::*;
+use crate::query::memory::authoring;
 
 /// The relation an edge expresses, from a source memory node to its target. Persisted in
 /// `repo_node_edges.relation`; the db tokens are the snake_case variant names.
@@ -185,6 +186,17 @@ pub(crate) fn add_edge(
         EdgeTarget::Github { .. } => (hint_repo_id.clone(), None, "current".to_string()),
     };
     let now = now_ms();
+    // Backfill the pre-existing history (idempotent) + the edge INSERT + the EdgeAdd op in ONE
+    // transaction (strict-atomic); the write via `conn` participates in the open txn.
+    authoring::backfill_memory_oplog(conn, now)?;
+    let tx = conn.unchecked_transaction()?;
+    // Whether this is a GENUINELY new edge vs an idempotent re-add: the INSERT below is
+    // `ON CONFLICT DO UPDATE` refreshing ONLY the per-device resolution columns
+    // (`target_repo_id`/`target_node_id`/`anchor_status`) — state the log deliberately excludes (no
+    // `Rebind`). A re-add therefore changes nothing log-relevant, so it must NOT author a second
+    // `EdgeAdd`: re-asserting presence at a fresh Lamport could resurrect a concurrent remove from
+    // another device under sync (the symmetric partner of `remove_edge`'s `n > 0` gate).
+    let edge_is_new = edge_by_key(conn, &key)?.is_none();
     conn.execute(
         "
         INSERT INTO repo_node_edges(
@@ -210,6 +222,19 @@ pub(crate) fn add_edge(
             now
         ],
     )?;
+    if edge_is_new {
+        authoring::author_edge_add(
+            &tx,
+            source_node_id,
+            relation,
+            &target_repo_id,
+            target_kind,
+            &target_anchor,
+            &owner_repo_id,
+            now,
+        )?;
+    }
+    tx.commit()?;
     edge_by_key(conn, &key)?.ok_or_else(|| anyhow::anyhow!("edge `{key}` disappeared after insert"))
 }
 
@@ -217,10 +242,18 @@ pub(crate) fn add_edge(
 pub(crate) fn remove_edge(conn: &Connection, edge_key: &str) -> anyhow::Result<bool> {
     let scope = memory_repo_scope(conn)?;
     let repo_clause = periphery_edge_scope_clause(&scope);
+    let now = now_ms();
+    authoring::backfill_memory_oplog(conn, now)?;
+    let tx = conn.unchecked_transaction()?;
     let n = conn
         .execute(&format!("DELETE FROM repo_node_edges WHERE edge_key = ?1{repo_clause}"), [
             edge_key,
         ])?;
+    if n > 0 {
+        // Author an EdgeRemove tombstone ONLY when a row was actually removed, in the same txn.
+        authoring::author_edge_remove(&tx, edge_key, now)?;
+    }
+    tx.commit()?;
     Ok(n > 0)
 }
 

--- a/crates/rag-rat-core/src/query/memory/hydrate.rs
+++ b/crates/rag-rat-core/src/query/memory/hydrate.rs
@@ -71,14 +71,26 @@ pub(crate) fn duplicate_memory_id(
     .optional()
     .map_err(Into::into)
 }
+/// The canonical tag-SET form — trimmed, empties dropped, deduped, sorted. [`replace_tags`] STORES
+/// this shape and [`tags_for_memory`] reads it back sorted, so comparing `normalize_tags(input)`
+/// against a stored set is a stable "did the tags actually change?" test (a whitespace- or
+/// duplicate-only difference is NOT a change — the op-log update-detection relies on this).
+pub(crate) fn normalize_tags(tags: &[String]) -> Vec<String> {
+    let mut out: Vec<String> =
+        tags.iter().map(|tag| tag.trim().to_string()).filter(|tag| !tag.is_empty()).collect();
+    out.sort();
+    out.dedup();
+    out
+}
+
 pub(crate) fn replace_tags(
     conn: &Connection,
     memory_id: &str,
     tags: &[String],
 ) -> anyhow::Result<()> {
     conn.execute("DELETE FROM repo_memory_tags WHERE memory_id = ?1", [memory_id])?;
-    for tag in tags.iter().map(|tag| tag.trim()).filter(|tag| !tag.is_empty()) {
-        validate_len("tag", tag, 64)?;
+    for tag in normalize_tags(tags) {
+        validate_len("tag", &tag, 64)?;
         conn.execute(
             "INSERT OR IGNORE INTO repo_memory_tags(memory_id, tag) VALUES (?1, ?2)",
             params![memory_id, tag],

--- a/crates/rag-rat-core/src/query/memory/mod.rs
+++ b/crates/rag-rat-core/src/query/memory/mod.rs
@@ -1,8 +1,6 @@
 mod api;
-// The op-log authoring seam (#524): row→op translation + the one-time full backfill. Unwired to
-// the live write path this increment (only its tests drive it), so it is dead in a non-test build
-// — the next increment calls `backfill_memory_oplog` from `create_memory` and the allow drops.
-#[cfg_attr(not(test), allow(dead_code))]
+// The op-log authoring seam: row→op translation, the one-time full backfill, and the live
+// `author_*` helpers the memory mutations call in-transaction (#532).
 mod authoring;
 mod edges;
 mod hydrate;


### PR DESCRIPTION
Eighth phase-B op-log increment, after #524/#526 (authoring + backfill machinery, unwired). **Turns the op-log ON**: the memory mutations author signed entries in the SAME transaction as the table write, with the one-time full backfill running before the first live entry.

## What landed

- **`create_memory` / `update_memory` become transactional** (via `unchecked_transaction` — the `rebind_memory` pattern, where writes through `conn` participate in the open txn); `add_edge` / `remove_edge` likewise. Each authors its op(s) IN that txn: create → `NodeCreate`, update → `NodeUpdate` (+ `NodeStatus` on a status change, even back to `active`), `mark_obsolete` → `NodeStatus`, `add_edge` → `EdgeAdd`, `remove_edge` → `EdgeRemove` (only when a row was removed).
- **Strict-atomic** (the chosen posture): an authoring error drops the txn → the table write rolls back with it, so the log is always the complete history and the tables are never half-written.
- **Backfill before the first live entry**: every mutation calls the idempotent `backfill_memory_oplog` first (its own txn; a cheap no-op once the chain exists), so the pre-existing history precedes the first live-authored op.
- **Scope-gated**: authoring is a no-op unless a STABLE owner scope is active (skip when unscoped / `__unassigned__` placeholder / `local:` id — the same guard the backfill uses), so the many scope-less callers (mostly tests) are untouched — the full suite stays green.
- New `authoring` seams (`author_create` / `author_update` / `author_edge_add` / `author_edge_remove` + `stable_owner_stream`) reuse the frozen `author_in_tx` minting primitive and a shared `node_content` builder. Bindings stay OUT of the log; `rebind_memory` authors nothing; edge RESOLUTION stays per-device (no `Rebind`).

`oplog`'s authoring half is now live; the SYNC-TRANSPORT half (`append`, the fork quarantine) stays `#[allow(dead_code)]` until a later increment. The projection remains a shadow — `repo_memories` is still the source of truth (reading FROM the projection is out of scope).

## Tests / gates

- New wiring tests: each mutation projects correctly (create/update/mark_obsolete node + status, add/remove edge presence); a scope-less create authors nothing; **strict-atomic** — a poisoned projector fails the create and the row rolls back; a live create backfills pre-existing memories first.
- Full workspace suite green (2125 tests), clippy clean on default and `--no-default-features`, nightly fmt clean, codex review 0 findings.

Fixes #532