### PR TITLE
docs: complete the MCP tool catalog, trim the README, make the skills MCP-native

### DIFF
--- a/.agents/skills/dream-review/SKILL.md
+++ b/.agents/skills/dream-review/SKILL.md
@@ -2,104 +2,106 @@
 name: dream-review
 description: >
   Use when asked to review, triage, or resolve rag-rat "dream" findings — the memory-maintenance
-  worklist `rag-rat dream` produces. Walks the pending (open) findings and, per kind, either fixes
-  the underlying memory / coverage gap (which resolves the finding at the root) or records an
-  accept / dismiss verdict. Triggers: "dream review", "resolve dream findings", "triage the dream
-  worklist", "go through pending dream findings".
+  worklist the `dream` tool produces. Walks the open findings and, per kind, either fixes the
+  underlying memory / coverage gap (which resolves the finding at the root) or records an
+  accept / dismiss verdict with `dream_review`. Triggers: "dream review", "resolve dream findings",
+  "triage the dream worklist", "go through pending dream findings".
 ---
 
 # dream-review — triage and resolve the rag-rat dream worklist
 
-`rag-rat dream` surfaces findings **about** the repo's memories and load-bearing code. It never
+The **`dream`** tool surfaces findings **about** the repo's memories and load-bearing code. It never
 mutates a memory — the deterministic passes and the optional model **propose**; a reviewer
 **decides**. This skill is that reviewer loop: for each open finding, investigate with the rag-rat
-tools, then resolve it — preferring a **root fix** (repair the memory / close the coverage gap, so
-the finding resolves on its own next run) over a bare verdict.
+MCP tools, then resolve it — preferring a **root fix** (repair the memory / close the coverage gap,
+so the finding resolves on its own next run) over a bare verdict.
 
-Run this from inside the rag-rat-indexed repo. Use the **rag-rat MCP tools** to investigate
-(`semantic_search`, `symbol_lookup`, `impact_surface`, `find_callers`, `git_history_for_symbol`,
-`memory_search`) — not `grep`. It is a batch chore meant to run a few times a day, not continuously.
+Drive the whole loop through the **rag-rat MCP tools** — `dream` and `dream_review` for the worklist,
+and `semantic_search` / `symbol_lookup` / `impact_surface` / `find_callers` / `git_history_for_symbol`
+/ `memory_search` / `read_chunk` to investigate — not `grep`, and not the `rag-rat` CLI (an agent has
+the MCP but may not have the binary on PATH). It is a batch chore meant to run a few times a day, not
+continuously.
 
 ## 1. Preflight
 
-- Confirm the index is fresh: `rag-rat index_status` (MCP) or `rag-rat doctor`. If findings look
-  stale/empty, `rag-rat index --discover` then `rag-rat reconcile`.
-- (Re)generate findings. Deterministic only:
-
-  ```bash
-  rag-rat dream
-  ```
-
-  With the model configured (`[llm.dream] enabled = true`) also run the verdict + compaction passes,
-  which add `memory_divergence` findings and summaries:
-
-  ```bash
-  rag-rat dream --verify --compact --max-memories 20
-  ```
+- Confirm the index is fresh: call **`index_status`**. If it reports drift, call **`heal_index`** to
+  repair already-indexed files. (Discovering brand-new files and re-embedding is a CLI/cron job —
+  `rag-rat index --discover` then `rag-rat reconcile` — outside this MCP loop; if findings look
+  empty, that's the thing to ask a human to run.)
+- **The `dream` tool is deterministic-only.** It recomputes `coverage_gap` + `stale_reference` on
+  every call and *surfaces* any `memory_divergence` / `memory_unverifiable` findings a prior model
+  run persisted — but it does **not** run the model itself. Generating *fresh* model findings is the
+  CLI/cron `rag-rat dream --verify --compact` pass (it provisions a GPU and takes minutes, so it
+  never runs from a tool call). If the divergence findings look stale, that CLI pass is what refreshes
+  them.
 
 ## 2. Pull the open worklist
 
-```bash
-rag-rat dream --json
-```
-
-`findings[]` carries `{ id, kind, subject, evidence, rank, status }`. Work **highest `rank`
+Call **`dream`** — no args needed (`limit` caps the number of `coverage_gap` findings, default 20).
+It returns `findings[]`, each `{ id, kind, subject, evidence, rank, status }`. Work **highest `rank`
 first** (rank decays with age). The `id` (a short hex; a unique prefix also works) is what you pass
-to the verdict commands. `rag-rat dream --all --json` additionally lists already-`accepted` /
-`dismissed` findings (use it to find one to `--reset`).
+to `dream_review`.
+
+Call `dream` with `{ "all": true }` to *additionally* list already-`accepted` / `dismissed` findings
+— use it to find one to reset.
 
 ## 3. Resolve each finding, by kind
 
-For every finding: **investigate first, then act.** Prefer the root fix; fall back to a verdict.
+For every finding: **investigate first, then act.** Prefer the root fix; fall back to a verdict. All
+verdicts go through **`dream_review`** with `{ "finding": "<id>", "verdict": "accept" | "dismiss" |
+"reset" }`.
 
 ### `coverage_gap` — `subject = "path::symbol"`
 A load-bearing symbol (many callers) with no memory binding.
 - Investigate: `impact_surface` / `important_symbols` (personalize on the symbol) /
   `git_history_for_symbol` — is there a durable, non-obvious invariant, decision, or footgun here?
-- **Root fix:** if yes, `memory_create` (MCP) an `Invariant`/`Decision`/`Risk` **bound to that
-  symbol** (`bind.id` = its `sym_…` handle, or `bind.path`). The gap closes automatically on the
-  next `rag-rat dream` (the binding now exists) — no verdict needed.
-- **Dismiss** if the symbol is self-explanatory / not memory-worthy: `rag-rat dream <id> --dismiss`.
+- **Root fix:** if yes, `memory_create` an `Invariant`/`Decision`/`Risk` **bound to that symbol**
+  (`bind.id` = its `sym_…` handle, or `bind.path`). The gap closes automatically on the next `dream`
+  call (the binding now exists) — no verdict needed.
+- **Dismiss** if the symbol is self-explanatory / not memory-worthy: `dream_review` with
+  `verdict: "dismiss"`.
 - Use **accept** only to mean "real gap, but I'm not writing the memory in this pass" (keeps it out
   of the open list without claiming it's a non-issue).
 
 ### `stale_reference` — `subject = <memory id>`, `evidence` lists the unresolved path(s)
 A memory body references a `.rs` path that no longer resolves against the index.
-- Read the memory: `rag-rat memory show <id>`. Locate where the path went: `semantic_search` /
+- Read the memory: `memory_show` with its id. Locate where the path went: `semantic_search` /
   `symbol_lookup` on the moved code.
-- **Root fix:** if the code moved, `memory_update` (MCP) the body to the new path, and/or
-  `memory_rebind` (MCP or `rag-rat memory rebind`) to re-anchor. The finding resolves once the
-  reference is valid again. If the memory is genuinely stale, `memory_mark_obsolete` (MCP).
-- **Dismiss** only for a true false positive (e.g. a deliberate historical reference the regex
-  can't tell apart): `rag-rat dream <id> --dismiss`.
+- **Root fix:** if the code moved, `memory_update` the body to the new path, and/or `memory_rebind`
+  to re-anchor. The finding resolves once the reference is valid again. If the memory is genuinely
+  stale, `memory_mark_obsolete`.
+- **Dismiss** only for a true false positive (e.g. a deliberate historical reference the regex can't
+  tell apart): `dream_review` with `verdict: "dismiss"`.
 
 ### `memory_unverifiable` — `subject = <memory id>`
-Decided deterministically: the memory's bindings are all gone/absent **and** none of its
-identifiers resolve anywhere in the whole-tree index.
-- Read it (`rag-rat memory show <id>`). Does the code it describes still exist under a new name?
-- **Root fix:** re-anchor with `memory_rebind`; or if it's obsolete, `memory_mark_obsolete` (MCP).
+Decided deterministically: the memory's bindings are all gone/absent **and** none of its identifiers
+resolve anywhere in the whole-tree index.
+- Read it (`memory_show`). Does the code it describes still exist under a new name?
+- **Root fix:** re-anchor with `memory_rebind`; or if it's obsolete, `memory_mark_obsolete`.
 - **Dismiss** if it's still-true prose that simply isn't code-anchorable (accept it as-is):
-  `rag-rat dream <id> --dismiss`.
+  `dream_review` with `verdict: "dismiss"`.
 
 ### `memory_divergence` — `subject = <memory id>`, `evidence` = the model's cited pack lines
 The model judged the memory to have drifted from current code. **The model is ~71–76% accurate —
 verify before acting.**
-- Read the memory and the cited lines yourself (`impact_surface`, `read_chunk`). Is the note
-  actually wrong about current code?
+- Read the memory and the cited lines yourself (`memory_show`, `impact_surface`, `read_chunk`). Is
+  the note actually wrong about current code?
 - **Root fix:** if genuinely stale, `memory_update` to correct it (or `memory_mark_obsolete`). The
   divergence finding drops once the stored verdict flips `current` on a re-check, or the body edit
   self-invalidates the old verdict.
-- **Accept** if the divergence is real but intentional — the note is deliberately *ahead* of
-  unmerged code (a "note-ahead" case): `rag-rat dream <id> --accept`.
-- **Dismiss** if the model is wrong (false positive): `rag-rat dream <id> --dismiss`.
+- **Accept** if the divergence is real but intentional — the note is deliberately *ahead* of unmerged
+  code (a "note-ahead" case): `dream_review` with `verdict: "accept"`.
+- **Dismiss** if the model is wrong (false positive): `dream_review` with `verdict: "dismiss"`.
 
 ## 4. Verdict semantics (quick reference)
 
-```bash
-rag-rat dream <id> --accept    # real, acknowledged (action pending) — leaves the open worklist
-rag-rat dream <id> --dismiss   # false positive / won't-fix — hidden from the worklist
-rag-rat dream <id> --reset     # undo a verdict, back to open
-```
+Each is a **`dream_review`** call, `{ "finding": "<id>", "verdict": … }`:
+
+| `verdict` | Meaning |
+|---|---|
+| `accept` | Real, acknowledged (action pending) — leaves the open worklist. |
+| `dismiss` | False positive / won't-fix — hidden from the worklist. |
+| `reset` | Undo a prior verdict, back to open. |
 
 - A verdict **survives future runs**: a re-run that still reports the finding keeps your
   accept/dismiss; a finding the code makes obsolete resolves on its own.
@@ -109,8 +111,8 @@ rag-rat dream <id> --reset     # undo a verdict, back to open
 
 ## 5. Loop until clear
 
-Re-run `rag-rat dream --json` and repeat until `findings[]` is empty (or only accepted/dismissed
-remain under `--all`). If your fixes created new memories, a fresh run may open follow-on findings —
+Call `dream` again and repeat until `findings[]` is empty (or only accepted/dismissed remain under
+`{ "all": true }`). If your fixes created new memories, a fresh call may open follow-on findings —
 one more pass usually converges.
 
 ## Guardrails
@@ -118,7 +120,7 @@ one more pass usually converges.
 - **Never edit, demote, or mark-obsolete a memory without verifying the claim yourself.** The passes
   propose; you decide. This is the invariant that keeps dream from silently corrupting the memory
   layer.
-- **Prefer the root fix over a bare `--dismiss`.** Dismissing a real issue just hides it.
+- **Prefer the root fix over a bare `dismiss`.** Dismissing a real issue just hides it.
 - **Capture what you learn.** If investigating a finding taught you a durable, non-obvious fact,
   `memory_create` it (that also closes `coverage_gap` findings).
 - Respect the voice/scope rules of whatever repo you're in when writing memory bodies.

--- a/.agents/skills/using-rag-rat/SKILL.md
+++ b/.agents/skills/using-rag-rat/SKILL.md
@@ -34,6 +34,32 @@ Prefer these over `grep`/`cat`/file sweeps when browsing or understanding code:
 - **`important_symbols`** — load-bearing symbols by (SCIP-aware) PageRank; pass `personalize` to bias
   toward what you're editing.
 
+That's the daily loop. The MCP exposes **46 tools** in all — reach past the core ones by the question
+you're actually asking (full schemas: `docs/mcp-tools.md`):
+
+| When you want to… | Reach for |
+|---|---|
+| Find where a concept/behavior lives | `semantic_search` |
+| Resolve a symbol by name (exact/fuzzy) | `symbol_lookup` |
+| See what calls X / what X calls | `find_callers` / `trace_callees` |
+| **Know the blast radius before editing** | **`impact_surface`** (callers, callees, tests, history, memories — the preflight) |
+| Read a chunk's exact current text | `read_chunk` |
+| Orient in an unfamiliar repo | `repo_brief` (spine / churn / god_modules / refactor_candidates), `repo_clusters` |
+| Find the load-bearing symbols | `important_symbols` |
+| Check if code duplicates what's already here | `find_clones`; the clone class of one symbol → `clones_for_symbol` |
+| Understand **why** code exists (rationale) | `papertrail_for_symbol` / `papertrail_for_chunk`, `rationale_search` |
+| Trace **when/why** something changed | `git_history_for_symbol` / `git_history_for_path`, `commit_search`, `commits_touching_query`, `git_blame_chunk` |
+| Pull a GitHub issue/PR or refs for a path | `github_issue_search`, `github_refs_for_path`, `papertrail_for_commit` |
+| Read docs / doc-comments for a symbol | `docs_for_symbol` |
+| Map the FFI / binding surface | `ffi_surface` |
+| Audit whether the graph is trustworthy here | `compare_graph_to_scip` (vs compiler), `compare_graph_to_text` (vs regex) |
+| Recall prior notes and their links | `memory_search`, `memory_for_symbol` / `memory_for_path` / `memory_for_call_path`, `memory_edges` |
+| Triage the memory-maintenance worklist | `dream` → `dream_review` (see the **dream-review** skill) |
+| Check index / embedding / GitHub-cache health | `index_status`, `llm_status`, `github_sync_status`; repair drift with `heal_index` |
+
+Reaching for the right tool is cheap and eager: prefer the specific one (`papertrail_for_symbol` for
+*why*, `find_clones` before writing a helper) over defaulting to `semantic_search` for everything.
+
 **Symbol handle:** symbol-returning tools emit `id`, an opaque `sym_<hex>` token — the stable handle
 to cache and pass back into graph/impact/memory tools as `id` (copy verbatim; never parse it as a
 number). Use `ref` (the `path::name` qualified name) for human-readable identity.
@@ -72,6 +98,11 @@ Do it well:
   `FFIBoundary`. Write a concrete title and a body with the **why** + **how to apply** — not just the
   what.
 - **`memory_update` / `memory_mark_obsolete`** when a memory is wrong or superseded — don't leave
-  stale guidance. After a large refactor, `rag-rat memory doctor` flags `gone` anchors to re-bind.
+  stale guidance. After a large refactor, **`memory_doctor`** flags `gone` anchors and
+  **`memory_rebind`** re-anchors them.
+
+The memory layer is kept honest by **`dream`** — a maintenance worklist of load-bearing code with no
+memory (coverage gaps) and memories that have drifted from the source. The **dream-review** skill is
+the loop for triaging it.
 
 The equivalents exist on the CLI too (`rag-rat memory …`) — use whichever your harness exposes.

--- a/README.md
+++ b/README.md
@@ -78,6 +78,18 @@ rag-rat init
 offers to install the local embedding model, and can register the MCP server and git hooks. Preview
 without writing anything with `rag-rat init --dry-run`; `--yes` runs the non-interactive defaults.
 
+**Install the agent skills.** `init` wires up the index and MCP server; a pair of skills teaches your
+agent to actually reach for them. Install into whatever agents you have (Claude Code, Codex, Cursor,
+and 70+ others, detected automatically):
+
+```bash
+npx @rag-rat/skills
+```
+
+That installs **`using-rag-rat`** (reach for the MCP tools before grep; record durable findings as
+memories) and **`dream-review`** (triage the memory-maintenance worklist). See
+[`skills/README.md`](skills/README.md) for `update` / `list` / `remove` and per-agent flags.
+
 Manual setup and every config knob live in [`docs/config.md`](docs/config.md). For a large repo where
 the default local embedder is too slow, see [Embedding backends](#embedding-backends).
 

--- a/README.md
+++ b/README.md
@@ -208,29 +208,30 @@ Prefer reusing the existing function(s) over duplicating — impact_surface / sy
 
 ## The tools
 
-The highest-leverage ones (full catalog + JSON schemas in [`docs/mcp-tools.md`](docs/mcp-tools.md)):
+rag-rat exposes **46 MCP tools** — the full catalog with JSON schemas lives in
+[`docs/mcp-tools.md`](docs/mcp-tools.md). The ones you'll reach for most:
 
 - **`impact_surface`** — the coding preflight from the loop above: callers, callees, tests, git
-  history, GitHub papertrail, and repo memories for a symbol in one call. `repo_memories` defaults to
-  a compact, scannable per-memory header (kind, title, confidence, anchor status, and where it's
-  bound); pass `full_memories: true` (or use `memory_for_symbol|path|call_path`) for full bodies +
-  bindings.
-- **`semantic_search`** — hybrid BM25 + vector recall over source/docs, validated against current
+  history, GitHub papertrail, and the repo memories crossing a symbol, in one call. Memories default
+  to compact, scannable headers; pass `full_memories: true` for full bodies + bindings.
+- **`semantic_search`** — hybrid BM25 + vector recall over source and docs, validated against current
   source. Every hit reports `retrieval_mode`; `explain=true` breaks down the score.
-- **`symbol_lookup`** — exact/fuzzy symbol resolution; cfg/overload duplicates grouped as one
-  logical symbol.
-- **`find_callers` / `trace_callees`** — reverse/forward graph traversal (low-signal std/macro noise
-  filtered by default).
-- **`important_symbols`** — load-bearing symbols by (SCIP-aware) PageRank; see
-  [`docs/oracle.md`](docs/oracle.md).
-- **`repo_brief` / `repo_clusters`** — orientation: spine / churn / god-modules / ownership clusters.
-- **`find_clones` / `clones_for_symbol`** — exact + near-miss duplicate functions ranked by refactor
-  ROI; the candidate graph is precomputed in the background so it scales to large repos.
-- **`read_chunk`** — current text for a chunk with anchor validation.
-- Git/GitHub: `commit_search`, `git_history_for_path|symbol`, `git_blame_chunk`,
-  `papertrail_for_*`, `rationale_search`.
-- Memories: `memory_create`, `memory_update`, `memory_search`, `memory_for_symbol|path|call_path`,
-  `memory_validate`, `memory_mark_obsolete`.
+- **`symbol_lookup`** — exact/fuzzy symbol resolution; cfg/overload variants grouped as one logical
+  symbol.
+- **`find_callers` / `trace_callees`** — reverse/forward call-graph traversal (low-signal std/macro
+  noise filtered by default).
+- **`important_symbols`** — the load-bearing symbols by (SCIP-aware) PageRank, seeded from your
+  current diff by default; see [`docs/oracle.md`](docs/oracle.md).
+- **`find_clones`** — exact + near-miss duplicate functions ranked by refactor ROI (the candidate
+  graph is precomputed in the background, so it scales to large repos).
+- **`memory_create`** — record a source-anchored repo memory; **`dream`** surfaces the maintenance
+  worklist that keeps them honest ([below](#self-maintaining-memories)).
+
+Beyond these: repo orientation (`repo_brief`, `repo_clusters`), git/GitHub rationale
+(`commit_search`, `git_history_for_*`, `papertrail_for_*`, `rationale_search`), the full memory
+graph (`memory_search`, `memory_edges`, `memory_rebind`, `memory_doctor`, …), graph-vs-compiler
+audit (`compare_graph_to_scip`), and index diagnostics (`index_status`, `llm_status`, `heal_index`)
+— all documented in [`docs/mcp-tools.md`](docs/mcp-tools.md).
 
 ## Repo memories
 
@@ -242,6 +243,32 @@ call-path, commit, or GitHub ref. rag-rat tracks each anchor as `current`, `relo
 `gone`, or `unverified`, and surfaces matching memories through the `memory_*` tools and inline in
 `read_chunk`, `symbol_lookup`, `find_callers`, `trace_callees`, and `impact_surface`. They're how
 hard-won context reaches the *next* agent in one call instead of evaporating.
+
+Memories are also a **typed graph**, not just a flat list: `memory_edge_add` / `memory_edges` connect
+them with relations (`depends_on`, `relates_to`, `supersedes`, `derived_from`, `tracks`) — a task DAG,
+a mind-map link between decisions, or a task that `tracks` a GitHub issue. Full tool list:
+[`docs/mcp-tools.md`](docs/mcp-tools.md#repo-memories).
+
+## Self-maintaining memories
+
+Memories rot: the code moves under them, an invariant gets superseded, a load-bearing function ships
+with no memory at all. **`dream`** is the maintenance loop that keeps the layer honest. It recomputes
+a ranked worklist of findings *about* the memories themselves — each with a stable id to review:
+
+- **coverage gaps** — load-bearing symbols (by the same PageRank as `important_symbols`) that carry no
+  memory, so the next agent editing them gets nothing.
+- **stale references** — a memory citing a path or anchor that no longer resolves.
+
+`dream` runs the deterministic findings on every call. Two opt-in **model passes** go deeper, running
+a small model on an ephemeral remote GPU (`[llm.dream.remote]`) only when work is pending:
+`rag-rat dream --verify` recomputes each memory's verdict against current source *reality* (has the
+code drifted from what the memory claims?), and `--compact` rewrites a verbose memory to a tighter
+summary. Findings those passes persist surface back through `dream`.
+
+Nothing is deleted automatically. A human — or a strong agent over MCP — burns the worklist down with
+**`dream_review`** (`accept` a real gap, `dismiss` noise, `reset` a prior verdict), and verdicts
+survive future runs so settled findings don't come back. It's the same surface as the CLI
+`rag-rat dream` / `rag-rat dream <id> --accept|--dismiss|--reset`.
 
 ## Compiler-grade resolution & ranking
 
@@ -380,6 +407,9 @@ rag-rat oracle run | status        # compiler-grade resolution (docs/oracle.md)
 rag-rat models list | install <model>
 rag-rat reconcile --changed-first --max-seconds 60 --batch-size 64
 rag-rat github sync --from-refs
+rag-rat memory list | show <id> | doctor | rebind <id>    # inspect / re-anchor repo memories
+rag-rat dream [--verify|--compact] [<id> --accept|--dismiss|--reset]   # memory-maintenance worklist
+rag-rat consolidate                # import a legacy per-repo index into the global store
 rag-rat hooks install              # git maintenance hooks
 rag-rat gc                         # prune rows for dead git contexts
 rag-rat eval [--json|--update-baseline]   # CI search-quality gate; requires a `--features eval` build (absent from the released binary)

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -53,15 +53,43 @@ To run from a checkout without installing, use a project-scoped server whose com
 
 ## Tools
 
+The MCP surface is **46 tools** in nine groups. The signatures are below; the prose sections that
+follow describe response shapes and per-tool behavior. Every symbol/search/read tool additionally
+accepts an optional `"worktree": string` — an absolute path to a linked git worktree, served as a
+branch overlay over the indexed checkout — omitted from the signatures below for brevity.
+
+**Search & symbols**
+
 - `semantic_search`: `{ "query": string, "limit"?: number, "include_graph"?: "none" | "compact" | "full", "graph_limit"?: number, "include"?: ("generated" | "git" | "papertrail" | "fallback")[], "explain"?: boolean }`
-- `symbol_lookup`: `{ "symbol"?: string, "ref"?: string, "id"?: string, "lang"?: string, "allow_ambiguous"?: boolean, "limit"?: number, "include"?: ("memories")[] }`
+- `symbol_lookup`: `{ "symbol"?: string, "ref"?: string, "id"?: string, "lang"?: string, "allow_ambiguous"?: boolean, "limit"?: number, "include"?: ("memories" | "generated")[] }`
+- `docs_for_symbol`: `{ "symbol"?: string, "ref"?: string, "id"?: string, "allow_ambiguous"?: boolean, "limit"?: number }`
+
+**Call graph & impact**
+
 - `find_callers`: `{ "symbol"?: string, "ref"?: string, "id"?: string, "resolution"?: "exact" | "syntactic" | "fuzzy", "allow_ambiguous"?: boolean, "limit"?: number, "include"?: ("references" | "unresolved" | "macros" | "common_methods" | "coverage" | "memories")[], "edge_kinds"?: string[] }`
 - `trace_callees`: `{ "symbol"?: string, "ref"?: string, "id"?: string, "resolution"?: "exact" | "syntactic" | "fuzzy", "allow_ambiguous"?: boolean, "limit"?: number, "include"?: ("references" | "unresolved" | "macros" | "common_methods" | "coverage" | "memories")[], "edge_kinds"?: string[] }`
-- `compare_graph_to_text`: `{ "symbol"?: string, "ref"?: string, "id"?: string, "pattern": string, "resolution"?: "exact" | "syntactic" | "fuzzy", "allow_ambiguous"?: boolean, "limit"?: number, "include"?: ("tests" | "references" | "unresolved" | "macros" | "common_methods")[], "edge_kinds"?: string[] }`
 - `impact_surface`: `{ "query"?: string, "symbol"?: string, "ref"?: string, "id"?: string, "resolution"?: "exact" | "syntactic" | "fuzzy", "allow_ambiguous"?: boolean, "limit"?: number, "include"?: ("tests" | "docs" | "git" | "papertrail" | "text_fallback" | "memories")[], "full_memories"?: boolean }`
+- `compare_graph_to_text`: `{ "symbol"?: string, "ref"?: string, "id"?: string, "pattern": string, "resolution"?: "exact" | "syntactic" | "fuzzy", "allow_ambiguous"?: boolean, "limit"?: number, "include"?: ("tests" | "references" | "unresolved" | "macros" | "common_methods")[], "edge_kinds"?: string[] }`
+- `compare_graph_to_scip`: `{}`
 - `ffi_surface`: `{ "limit"?: number }`
-- `docs_for_symbol`: `{ "symbol"?: string, "ref"?: string, "id"?: string, "allow_ambiguous"?: boolean, "limit"?: number }`
+
+**Orientation & ranking**
+
+- `repo_brief`: `{ "mode"?: "spine" | "churn" | "god_modules" | "refactor_candidates", "limit"?: number, "include"?: ("memories" | "generated")[] }`
+- `repo_clusters`: `{ "limit"?: number, "include"?: ("memories" | "generated")[], "min_cluster_size"?: number }`
+- `important_symbols`: `{ "limit"?: number, "personalize"?: string[] }`
+
+**Clones**
+
+- `find_clones`: `{ "min_similarity"?: number, "min_copies"?: number, "limit"?: number }`
+- `clones_for_symbol`: `{ "id"?: string, "ref"?: string, "path"?: string, "line"?: number }`
+
+**Read**
+
 - `read_chunk`: `{ "chunk_id": number, "include_graph"?: "none" | "compact" | "full", "graph_limit"?: number, "include"?: ("memories")[] }`
+
+**Git & GitHub history**
+
 - `commit_search`: `{ "query": string, "limit"?: number }`
 - `git_history_for_path`: `{ "path": string, "limit"?: number }`
 - `git_history_for_symbol`: `{ "symbol"?: string, "ref"?: string, "id"?: string, "lang"?: string, "allow_ambiguous"?: boolean, "limit"?: number }`
@@ -73,10 +101,40 @@ To run from a checkout without installing, use a project-scoped server whose com
 - `github_issue_search`: `{ "query": string, "limit"?: number }`
 - `github_refs_for_path`: `{ "path": string, "limit"?: number }`
 - `rationale_search`: `{ "query": string, "limit"?: number, "include"?: ("fallback")[] }`
+
+**Index health**
+
 - `llm_status`: `{}`
 - `heal_index`: `{ "limit"?: number }`
 - `github_sync_status`: `{}`
 - `index_status`: `{}`
+
+**Repo memories**
+
+- `memory_create`: `{ "kind": MemoryKind, "title": string, "body": string, "confidence": "high" | "medium" | "low", "created_by"?: string, "source"?: "agent" | "human" | "imported" | "generated", "tags"?: string[], "payload"?: object, "bind"?: BindTarget }`
+- `memory_rebind`: `{ "memory_id": string, "bind": BindTarget }`
+- `memory_update`: `{ "memory_id": string, "kind"?: MemoryKind, "title"?: string, "body"?: string, "confidence"?: "high" | "medium" | "low", "status"?: "active" | "stale" | "obsolete" | "rejected", "tags"?: string[], "payload"?: object }`
+- `memory_search`: `{ "query": string, "limit"?: number }`
+- `memory_for_symbol`: `{ "symbol"?: string, "ref"?: string, "id"?: string, "allow_ambiguous"?: boolean, "limit"?: number }`
+- `memory_for_path`: `{ "path": string, "limit"?: number }`
+- `memory_for_call_path`: `{ "edge_sequence_hash": string, "limit"?: number }`
+- `memory_show`: `{ "memory_id": string }`
+- `memory_validate`: `{}`
+- `memory_doctor`: `{}`
+- `memory_mark_obsolete`: `{ "memory_id": string }`
+- `memory_edge_add`: `{ "source_node_id": string, "relation": "depends_on" | "relates_to" | "supersedes" | "derived_from" | "tracks", "target_node_id"?: string, "target_repo_id"?: string, "github_owner"?: string, "github_repo"?: string, "github_number"?: number }`
+- `memory_edge_remove`: `{ "edge_key": string }`
+- `memory_edges`: `{ "direction": "from" | "into", "node_id"?: string, "github_owner"?: string, "github_repo"?: string, "github_number"?: number }`
+
+`MemoryKind` is one of `Invariant`, `Decision`, `RejectedAlternative`, `Risk`, `BugPattern`,
+`TestExpectation`, `PerformanceNote`, `SecurityNote`, `FFIBoundary`, `PlatformQuirk`, `FollowUp`,
+`OpenQuestion`, `Task`, `Concept`, `Obsolete`. `BindTarget` names **exactly one** anchor — see
+[Repo memories](#repo-memories) below for its shape.
+
+**Dream (memory maintenance)**
+
+- `dream`: `{ "limit"?: number, "all"?: boolean }`
+- `dream_review`: `{ "finding": string, "verdict": "accept" | "dismiss" | "reset" }`
 
 **The `include` array** replaces the former `include_*` boolean params (#149 follow-up — shorter,
 token-cheaper). Presence in the list turns a section on. **Omit `include` entirely to keep each
@@ -301,6 +359,14 @@ rows are also listed in `likely_false_positives`. The tool includes the same `co
 graph traversal envelopes so audit output can be checked for stale source and parser failures before
 treating the counts as authoritative.
 
+`compare_graph_to_scip` is the graph-vs-compiler audit bridge — where `compare_graph_to_text` diffs
+the tree-sitter graph against a regex, this diffs it against the **SCIP oracle**. It reports only the
+edges where the compiler and tree-sitter *disagree* on a callee's resolution (the compiler resolves a
+call the heuristic graph got wrong or missed). It takes no arguments (`{}`) and reports over the whole
+oracle-covered checkout; it requires `rag-rat oracle run` to have populated compiler verdicts first,
+and returns nothing when no oracle data exists. Use it to debug the resolver and to see where turning
+the oracle on would change the graph. See [`oracle.md`](oracle.md).
+
 `impact_surface` is the graph-backed rg replacement path for a selected symbol. For
 `id`, `ref`, or `symbol` requests it returns sections instead of a flat list:
 
@@ -382,3 +448,100 @@ short serialized transaction per batch.
 Parser failures are visible through `index_status.parser_failure_paths`, with path, language, and
 message for each failed source parse. Markdown files are chunked by headings instead of parsed with
 tree-sitter.
+
+### Orientation & ranking
+
+`repo_brief`, `repo_clusters`, and `important_symbols` answer "what is this repo, and what holds it
+together?" before you know a symbol to look up.
+
+`repo_brief` ranks files by `mode`: `spine` (central coupling — what the rest of the code depends on),
+`churn` (git change frequency), `god_modules` (oversized high-fan-in files), or `refactor_candidates`.
+Each row carries size/coupling/churn/memory signals and a suggested next tool. `repo_clusters` groups
+the repo into ownership clusters from path proximity, graph edges, and git co-touch, with a
+representative file per cluster (`min_cluster_size` sets the floor). Both accept the orientation
+`include` array (`memories` on by default, `generated` off).
+
+`important_symbols` ranks the most load-bearing symbols by weighted PageRank over the call/type/import
+edge graph — SCIP-aware once `rag-rat oracle run` has populated compiler edges. With **no**
+`personalize`, it auto-seeds from your current git diff and returns importance *relative to your
+current changes* (the random surfer teleports back to what you're editing, lifting the spine those
+symbols depend on). Pass `personalize` (a list of names, `path::name` refs, or `sym_<hex>` handles) to
+seed it explicitly, or a single `"global"` to force whole-repo PageRank. The result is labeled: `mode`
+(which scale), `seed_source` (seed provenance), and `symbols`. See [`oracle.md`](oracle.md) for how the
+oracle sharpens the ranking.
+
+### Clones
+
+`find_clones` returns candidate clone classes ranked by refactor ROI (cross-module spread × member
+count × token length × load-bearing factor × cohesion), each with a completeness provenance block.
+`min_similarity` (if set) must be in `[0.5, 1.0]` (θ default `0.7`); `min_copies` defaults to `2`. A
+**limited** query (`limit: N`) is capped at the refine budget (currently 50): it returns at most 50
+classes, all refined with anti-unification metrics; omit `limit` (or pass `null`) to retrieve every
+class with only the top 50 refined. `completeness.refine_budget_clamped` is true when a supplied limit
+hit that cap. The candidate graph is precomputed in the background, so the tool stays responsive on
+large repos.
+
+`clones_for_symbol` returns the one clone class containing a specific symbol — selected by **exactly
+one** of `id` (a `sym_<hex>` handle), `ref` (`path::name`), or `path` + `line` together. It returns
+the candidate class if the symbol is fingerprinted and has clone siblings, or `null` if it is unique
+or not fingerprinted. This is the same signal the Write/Edit clone-check hook uses at write time.
+
+### Repo memories
+
+Memory tools read and write the durable, source-anchored notes described in the
+[README](../README.md#repo-memories). `memory_create` records one (typed `kind`, `title`, `body`,
+`confidence`), `memory_search` finds them by keyword, and `memory_for_symbol` / `memory_for_path` /
+`memory_for_call_path` fetch the full memories bound to an anchor (the expanded form of the compact
+headers `impact_surface` attaches). `memory_show` expands one memory to its full body by
+`memory_id` — the expand path for a `[memory] surface = "summary"` compact attachment.
+
+`memory_update` edits text/status/confidence/kind/tags; `memory_mark_obsolete` retires a memory
+(kept for audit, hidden from active recall). `memory_validate` re-anchors every memory against current
+source and marks each `current` / `relocated` / `stale` / `gone` / `pending` (it also runs
+automatically after indexing); `memory_doctor` lists the stale/gone/pending ones with suggested
+re-anchor targets. Rebind a moved memory with `memory_rebind` rather than obsoleting and recreating it
+— a `pending` anchor is alive on an in-flight worktree branch and re-anchors itself when that branch
+lands, so leave those alone.
+
+**`BindTarget`** (the `bind` on `memory_create` / `memory_rebind`) names **exactly one** anchor form:
+a logical symbol (`id`), a concrete `chunk_id`, a graph `edge_id`, a `path` (optionally with
+`start_line` + `end_line`), a `commit_hash`, a GitHub ref (`github_owner` + `github_repo` +
+`github_number`), a call-path (`edge_path`: an ordered list of edge ids, from which the server derives
+the authoritative `edge_sequence_hash`), or a directory (`dir`, relative to the repo root; `""` anchors
+to the root). Omit `bind` entirely to create an **unanchored** node — a `Concept` or standalone `Task`
+that lives only as a graph node.
+
+**Memory graph edges.** Memories are not only a flat list — they form a typed graph.
+`memory_edge_add` connects a source node to another node or a GitHub issue with a relation:
+`depends_on` (a task DAG), `relates_to` (a mind-map link), `supersedes`, `derived_from`, or `tracks`
+(issue ← task). Give **exactly one** target: a `target_node_id` (with an optional `target_repo_id` for
+a cross-repo edge) or a full GitHub ref. `memory_edges` lists a node's edges — `direction: "from"` for
+its outgoing edges (dependencies / links / tracks), `direction: "into"` for the reverse traversal
+(e.g. the tasks that `tracks` an issue, or the nodes that depend on this one). `memory_edge_remove`
+deletes an edge by its stable `edge_key`.
+
+### Dream — memory maintenance
+
+`dream` is the pull surface for keeping the memory layer honest as the code moves under it. It
+recomputes a deterministic **maintenance worklist** on each call and returns it ranked, each finding
+with a stable `id`:
+
+- **coverage gaps** — load-bearing symbols (by the same PageRank as `important_symbols`) that carry no
+  memory, so the next agent editing them gets nothing.
+- **stale references** — a memory citing a path or anchor that no longer resolves.
+- **model-verdict findings** (e.g. `memory_divergence`) that a prior opt-in model pass persisted — see
+  below.
+
+`dream` is classified as a **write** tool (like `rag-rat dream`, it syncs the `dream_findings` table)
+even though it returns a worklist. It runs the **deterministic** findings only; it does **not** run the
+optional model passes — those stay on the CLI/cron `rag-rat dream --verify` (recompute each memory's
+verdict against current source reality) and `--compact` (rewrite a memory to a tighter summary), which
+run a small model on an ephemeral remote GPU (`[llm.dream.remote]`) only when work is pending. Findings
+those passes persist still surface through `dream`.
+
+`dream_review` applies a human (or strong-agent) verdict to **one** finding by `id` — a full id or an
+unambiguous git-style prefix — as `accept` (a real gap to act on), `dismiss` (noise), or `reset` (clear
+a prior verdict, back to the open worklist). Verdicts survive future dream runs, so the worklist burns
+down instead of re-proposing settled findings. Pass `all: true` to `dream` to also list the already
+`accepted` / `dismissed` findings (for a reviewer to see and `reset`). This mirrors the CLI
+`rag-rat dream <id> --accept|--dismiss|--reset`.

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -129,7 +129,8 @@ branch overlay over the indexed checkout — omitted from the signatures below f
 `MemoryKind` is one of `Invariant`, `Decision`, `RejectedAlternative`, `Risk`, `BugPattern`,
 `TestExpectation`, `PerformanceNote`, `SecurityNote`, `FFIBoundary`, `PlatformQuirk`, `FollowUp`,
 `OpenQuestion`, `Task`, `Concept`, `Obsolete`. `BindTarget` names **exactly one** anchor — see
-[Repo memories](#repo-memories) below for its shape.
+[Repo memories](#repo-memories) below for its shape. `payload` is accepted **only** for the
+polymorphic graph-node kinds `Task` and `Concept` (#465); passing it for any other kind is rejected.
 
 **Dream (memory maintenance)**
 
@@ -360,12 +361,14 @@ graph traversal envelopes so audit output can be checked for stale source and pa
 treating the counts as authoritative.
 
 `compare_graph_to_scip` is the graph-vs-compiler audit bridge — where `compare_graph_to_text` diffs
-the tree-sitter graph against a regex, this diffs it against the **SCIP oracle**. It reports only the
-edges where the compiler and tree-sitter *disagree* on a callee's resolution (the compiler resolves a
-call the heuristic graph got wrong or missed). It takes no arguments (`{}`) and reports over the whole
-oracle-covered checkout; it requires `rag-rat oracle run` to have populated compiler verdicts first,
-and returns nothing when no oracle data exists. Use it to debug the resolver and to see where turning
-the oracle on would change the graph. See [`oracle.md`](oracle.md).
+the tree-sitter graph against a regex, this diffs it against the **SCIP oracle**. It reports only
+**contradictions**: edges where the heuristic resolved a callee to one target and the compiler says
+it is actually another. Calls the heuristic merely *missed* or under-resolved are agreement-shaped
+(the oracle classifies them `Upgrade` / `ResolvedExternal`) and are **not** reported — so an empty
+result means "no contradictions," not "SCIP found no missed edges." It takes no arguments (`{}`) and
+reports over the whole oracle-covered checkout; it requires `rag-rat oracle run` to have populated
+compiler verdicts first, and returns nothing when no oracle data exists. Use it to debug the resolver
+where tree-sitter and the compiler actively disagree. See [`oracle.md`](oracle.md).
 
 `impact_surface` is the graph-backed rg replacement path for a selected symbol. For
 `id`, `ref`, or `symbol` requests it returns sections instead of a flat list:
@@ -508,8 +511,9 @@ a logical symbol (`id`), a concrete `chunk_id`, a graph `edge_id`, a `path` (opt
 `start_line` + `end_line`), a `commit_hash`, a GitHub ref (`github_owner` + `github_repo` +
 `github_number`), a call-path (`edge_path`: an ordered list of edge ids, from which the server derives
 the authoritative `edge_sequence_hash`), or a directory (`dir`, relative to the repo root; `""` anchors
-to the root). Omit `bind` entirely to create an **unanchored** node — a `Concept` or standalone `Task`
-that lives only as a graph node.
+to the root). On **`memory_create`** only, omit `bind` entirely to create an **unanchored** node — a
+`Concept` or standalone `Task` that lives only as a graph node. **`memory_rebind`** requires a real
+target: it rejects an empty `bind` (to unanchor an existing memory, delete and recreate it).
 
 **Memory graph edges.** Memories are not only a flat list — they form a typed graph.
 `memory_edge_add` connects a source node to another node or a GitHub issue with a relation:


### PR DESCRIPTION
## Why

The README's tool listing and `docs/mcp-tools.md` had fallen behind the tool surface. The MCP now
exposes **46 tools**, but `docs/mcp-tools.md` — which the README points to as "the full catalog" —
documented only 24, omitting every memory tool, every clone tool, the orientation/ranking tools, and
the entire `dream` subsystem. The README enumerated a stale subset inline.

## What

- **`docs/mcp-tools.md` — now the complete catalog.** All 46 tools listed and grouped
  (search/symbols · call-graph & impact · orientation · clones · read · git/GitHub · index health ·
  memories · dream), each with its signature. Added prose for the previously-undocumented groups:
  memories (including the typed edge graph and `BindTarget` anchor forms), clones, orientation &
  ranking, dream, and `compare_graph_to_scip`. Signatures are derived from the `*Args` request
  structs.
- **`README.md` — highlights, not a catalog.** "The tools" now lists the ~7 highest-impact tools and
  links out to `docs/mcp-tools.md` for the rest. Adds a **Self-maintaining memories** (dream)
  section, notes the typed memory graph in "Repo memories", and fills in the Commands block
  (`memory`, `dream`, `consolidate`).
- **`skills/dream-review` — MCP-native.** The review loop now runs through the `dream` / `dream_review`
  MCP tools instead of the `rag-rat` CLI (an agent has the MCP connected, but not necessarily the
  binary on PATH). The only CLI references left are the two operations with no MCP equivalent:
  file discovery/reconcile, and the GPU-backed `--verify` / `--compact` model passes.
- **`skills/using-rag-rat` — tool router.** Adds a compact "question → tool" map covering the full
  surface, so the long-tail tools (`find_clones`, `papertrail_for_symbol`, `compare_graph_to_scip`,
  `ffi_surface`, …) get reached for eagerly rather than defaulting to `semantic_search`.

Docs and skills only — no code changes. Tool signatures were verified against
`crates/rag-rat-mcp/src/tools/{catalog.rs,requests.rs}`; all 46 `TOOL_NAMES` are present in the
catalog.

## Follow-up

No CI gate enforces catalog↔doc parity today, so this can silently drift again. A small test counting
`TOOL_NAMES` against the `docs/mcp-tools.md` bullets would close the loop — happy to file/add it.
