### PR TITLE
refactor(parser): iterative depth-safe tree walks for symbol and edge extraction

### DIFF
--- a/crates/rag-rat-core/src/index/edges/extract/mod.rs
+++ b/crates/rag-rat-core/src/index/edges/extract/mod.rs
@@ -140,29 +140,42 @@ pub(crate) fn syntactic_edges(
     collect_edges(language, text, tree.root_node(), symbols, path, &mut out);
     Ok(out)
 }
+/// Pre-order DFS over the named nodes of `root`, running the per-language edge extractor at each.
+///
+/// Iterative (#520): the old per-node recursion allocated a fresh `node.walk()` cursor each frame
+/// and recursed to full tree depth, overflowing the stack on a deeply-nested 512 KB file. An
+/// explicit heap stack keeps the call stack O(1); one reused cursor + one reused child buffer keep
+/// it single-allocation. The per-language extractors are unchanged. Error/missing subtrees are
+/// pruned and named children pop in document order — same visit set/order, so edges are emitted
+/// identically.
 pub(crate) fn collect_edges(
     language: Language,
     text: &str,
-    node: Node<'_>,
+    root: Node<'_>,
     symbols: &[IndexedSymbol],
     path: &Path,
     out: &mut Vec<EdgeCandidate>,
 ) {
-    if node.is_error() || node.is_missing() {
-        return;
-    }
-    match language {
-        Language::Rust => rust::rust_edges(text, node, symbols, path, out),
-        Language::TypeScript => typescript::typescript_edges(text, node, symbols, path, out),
-        Language::Kotlin => kotlin::kotlin_edges(text, node, symbols, path, out),
-        Language::C | Language::Cpp => c_like::c_like_edges(text, node, symbols, path, out),
-        Language::Python => python::python_edges(text, node, symbols, path, out),
-        Language::Markdown => {},
-    }
-
-    let mut cursor = node.walk();
-    for child in node.named_children(&mut cursor) {
-        collect_edges(language, text, child, symbols, path, out);
+    let mut stack = vec![root];
+    let mut cursor = root.walk();
+    let mut named_children = Vec::new();
+    while let Some(node) = stack.pop() {
+        if node.is_error() || node.is_missing() {
+            continue;
+        }
+        match language {
+            Language::Rust => rust::rust_edges(text, node, symbols, path, out),
+            Language::TypeScript => typescript::typescript_edges(text, node, symbols, path, out),
+            Language::Kotlin => kotlin::kotlin_edges(text, node, symbols, path, out),
+            Language::C | Language::Cpp => c_like::c_like_edges(text, node, symbols, path, out),
+            Language::Python => python::python_edges(text, node, symbols, path, out),
+            Language::Markdown => {},
+        }
+        named_children.clear();
+        named_children.extend(node.named_children(&mut cursor));
+        for &child in named_children.iter().rev() {
+            stack.push(child);
+        }
     }
 }
 
@@ -434,5 +447,31 @@ mod contains_edges_tests {
             sym(8, 130, 180),
         ];
         assert_equiv(&symbols);
+    }
+}
+
+#[cfg(test)]
+mod collect_edges_depth_tests {
+    use std::path::Path;
+
+    use crate::language::Language;
+
+    #[test]
+    fn deeply_nested_input_does_not_overflow_the_edge_walk() {
+        // The edge walk (collect_edges) recurses the whole tree just like the symbol walk, so it
+        // has the same stack-overflow exposure on deeply-nested input (#520). Small stack + a
+        // thousands-deep tree: a per-node recursive walk overflows here; the iterative one does
+        // not.
+        let depth = 8_000;
+        let src = format!("fn deep_edges_fn() {}{}\n", "{".repeat(depth), "}".repeat(depth));
+        std::thread::Builder::new()
+            .stack_size(256 * 1024)
+            .spawn(move || {
+                super::edge_candidates(Path::new("deep.rs"), Language::Rust, &src, &[])
+                    .expect("edge extraction")
+            })
+            .expect("spawn walk thread")
+            .join()
+            .expect("the edge walk must not overflow the stack on deeply-nested input");
     }
 }

--- a/crates/rag-rat-core/src/index/parser.rs
+++ b/crates/rag-rat-core/src/index/parser.rs
@@ -306,29 +306,44 @@ pub fn parse_error(path: &Path, language: Language, text: &str) -> anyhow::Resul
     }
 }
 
+/// Pre-order DFS over the named nodes of `root`, emitting a symbol for each declaration node.
+///
+/// Iterative (#520): a per-node recursion with a fresh `node.walk()` cursor each frame allocated a
+/// cursor per node AND recursed to full tree depth — a deeply-nested 512 KB file (thousands of
+/// nested blocks/expressions) overflows the stack on a worker thread even though the parse itself
+/// stays within budget. An explicit heap stack keeps the call stack O(1); one reused cursor + one
+/// reused child buffer keep it single-allocation. Error/missing subtrees are pruned (skipped, not
+/// descended) and named children are pushed in reverse so they pop in document order — the same
+/// visit set and order as the recursion, so the emitted symbols are byte-identical.
 fn collect_symbols(
     path: &Path,
     language: Language,
     text: &str,
-    node: Node<'_>,
+    root: Node<'_>,
     out: &mut Vec<ParsedSymbol>,
 ) {
-    if node.is_error() || node.is_missing() {
-        return;
-    }
-    if let Some((kind, name_node)) = symbol_node(language, node, text) {
-        let name = node_text(name_node, text).unwrap_or_default();
-        if !name.is_empty() {
-            // The span (chunk/embedding) is the matched `node`; the SIGNATURE is read from the
-            // declaration node, which differs for a decorated Python def (the span starts at the
-            // decorator, but the signature must be the `def`/`class` line).
-            let signature_node = signature_source_node(language, node);
-            out.push(make_symbol(path, language, text, node, signature_node, kind, name));
+    let mut stack = vec![root];
+    let mut cursor = root.walk();
+    let mut named_children = Vec::new();
+    while let Some(node) = stack.pop() {
+        if node.is_error() || node.is_missing() {
+            continue;
         }
-    }
-    let mut cursor = node.walk();
-    for child in node.named_children(&mut cursor) {
-        collect_symbols(path, language, text, child, out);
+        if let Some((kind, name_node)) = symbol_node(language, node, text) {
+            let name = node_text(name_node, text).unwrap_or_default();
+            if !name.is_empty() {
+                // The span (chunk/embedding) is the matched `node`; the SIGNATURE is read from the
+                // declaration node, which differs for a decorated Python def (the span starts at
+                // the decorator, but the signature must be the `def`/`class` line).
+                let signature_node = signature_source_node(language, node);
+                out.push(make_symbol(path, language, text, node, signature_node, kind, name));
+            }
+        }
+        named_children.clear();
+        named_children.extend(node.named_children(&mut cursor));
+        for &child in named_children.iter().rev() {
+            stack.push(child);
+        }
     }
 }
 

--- a/crates/rag-rat-core/src/index/parser_tests.rs
+++ b/crates/rag-rat-core/src/index/parser_tests.rs
@@ -339,3 +339,24 @@ fn assert_no_symbol_fact(
         symbol.facts
     );
 }
+
+#[test]
+fn deeply_nested_input_does_not_overflow_the_symbol_walk() {
+    // A pathological deeply-nested file (thousands of `{` blocks) parses fine, but the resulting
+    // tree is thousands of nodes deep. The symbol walk must not recurse per node — that overflows
+    // the stack on a real worker thread (#520). Run on a deliberately small stack so a per-node
+    // recursive walk would overflow HERE; the iterative walk uses O(1) stack and completes.
+    let depth = 8_000;
+    let src = format!("fn deep_marker_fn() {}{}\n", "{".repeat(depth), "}".repeat(depth));
+    let symbols = std::thread::Builder::new()
+        .stack_size(256 * 1024)
+        .spawn(move || parser::parse_symbols(Path::new("deep.rs"), Language::Rust, &src))
+        .expect("spawn walk thread")
+        .join()
+        .expect("the symbol walk must not overflow the stack on deeply-nested input")
+        .expect("parse");
+    assert!(
+        symbols.iter().any(|symbol| symbol.name == "deep_marker_fn"),
+        "the function symbol survives the deep walk",
+    );
+}


### PR DESCRIPTION
The two whole-tree walks in symbol/edge extraction recursed once per node, allocating a fresh `node.walk()` cursor each frame and recursing to full tree depth. On a deeply-nested file under the 512 KB parse cap (thousands of nested blocks/expressions) the parse itself stays within budget, but the *walk* overflows the stack on a worker thread. Byte-identical output.

**Scope:** this fixes the two whole-tree walks — the most *general* overflow path (any deeply-nested file hits it). It does **not** fully close #520: the name-finding helpers the extractors call still recurse to subtree depth and overflow on adversarial nested-expression subtrees. See "Not covered" below and the follow-up #543. Refs #520.

## Iterative walks

`parser.rs::collect_symbols` and `edges/extract/mod.rs::collect_edges` now drive a pre-order DFS from an explicit heap stack instead of the call stack:

- **Depth-safe:** the call stack stays O(1); nesting depth lives on the heap, so a deeply-nested file can't overflow *these walks*.
- **Single-allocation:** one `TreeCursor` reused for the whole tree (via `node.named_children(&mut cursor)`, which reseats it — the upstream-recommended reuse), plus one reused child buffer, instead of a fresh cursor per visited node.
- **Byte-identical:** error/missing subtrees are pruned (skipped, not descended) exactly as before, and named children are pushed in reverse so they pop in document order — the same visit set and order. Symbols are sorted after collection regardless; edges keep the same pre-order.

## Tests

- `deeply_nested_input_does_not_overflow_the_symbol_walk` and `deeply_nested_input_does_not_overflow_the_edge_walk` run the walk on a ~8000-deep tree on a deliberately small (256 KB) stack. Both **abort with a stack overflow on the old recursive code** (verified — SIGABRT, isolated per-test by nextest) and complete on the iterative walk.
- The existing per-language extraction tests (`parser_tests`, the Rust/C/C++/Kotlin/TypeScript graph-edge integration tests, and the partial/error-tree tests) pin byte-identical output and pass unchanged.

## Not covered (follow-up #543)

An adversarial review confirmed the stack-overflow *class* survives through the recursive name-finding helpers the extractors call (`collect_identifiers`, `first_identifier_node`, `first_descendant_node`, `last_descendant_node`, `kotlin_variable_declaration`, the `rust_dispatch` match-arm scanners). These recurse to *subtree* depth and overflow on real, in-cap inputs — e.g. a call whose callee is thousands of nested parens, or a thousands-deep generic type (reproduced). That's a pre-existing bug this PR doesn't regress; it's tracked in #543 (depth cap or `stacker`).
