### PR TITLE
refactor(init): print the MCP connect command instead of auto-registering

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,25 +75,26 @@ rag-rat init
 ```
 
 `init` scans the repo, prompts for languages and path bindings, writes `rag-rat.toml`, indexes,
-offers to install the local embedding model, and can register the MCP server and git hooks. Preview
-without writing anything with `rag-rat init --dry-run`; `--yes` runs the non-interactive defaults.
+offers to install the local embedding model, and can install git hooks; on completion it prints the
+one command to connect your agent. Preview without writing anything with `rag-rat init --dry-run`;
+`--yes` runs the non-interactive defaults.
 
 Manual setup and every config knob live in [`docs/config.md`](docs/config.md). For a large repo where
 the default local embedder is too slow, see [Embedding backends](#embedding-backends).
 
 ## Connect it to your agent (MCP)
 
-The MCP server is STDIO — the client launches `rag-rat` as a child process. **`rag-rat init` is the
-recommended path:** it registers the server **per project** (`claude mcp add --scope project` /
-`codex mcp add`), so each repo gets its own index.
-
-To wire it up by hand, register a **project-scoped** server that runs in the repo directory:
+The MCP server is STDIO — the client launches `rag-rat` as a child process. Registering it is **one
+command**, run from the repo directory so the server resolves that repo's `rag-rat.toml` and each
+repo gets its own index:
 
 ```bash
-claude mcp add --scope project rag-rat -- rag-rat mcp
+claude mcp add --scope project rag-rat -- rag-rat mcp     # Claude Code
+codex  mcp add rag-rat -- rag-rat mcp                     # Codex
 ```
 
-or a project `.mcp.json` / equivalent:
+`rag-rat init` prints this command on completion — it does not register the server for you. Or add a
+project `.mcp.json` / equivalent:
 
 ```json
 {

--- a/crates/rag-rat-cli/src/init/mod.rs
+++ b/crates/rag-rat-cli/src/init/mod.rs
@@ -4,7 +4,6 @@ mod scan;
 mod wizard;
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
-use std::process::Command;
 use std::{env, fs, io};
 
 use dialoguer::Confirm;

--- a/crates/rag-rat-cli/src/init/run.rs
+++ b/crates/rag-rat-cli/src/init/run.rs
@@ -76,9 +76,9 @@ fn run_non_interactive(
     apply_embedding_runtime_env(&config.llm.embedding.runtime);
     let db = setup_index(&config)?;
     setup_model_and_reconcile(&config, &db, options.yes)?;
-    offer_mcp_install(&config, &options.config_path, options.yes)?;
     offer_hooks_install(&config, options.yes)?;
     eprintln!("init: complete");
+    print_mcp_connect_hint();
     Ok(())
 }
 
@@ -117,10 +117,9 @@ fn run_interactive(options: &InitOptions) -> anyhow::Result<()> {
     apply_embedding_runtime_env(&config.llm.embedding.runtime);
     let db = setup_index(&config)?;
     setup_model_and_reconcile(&config, &db, false)?;
-    // `false` = prompt the user — the wizard didn't cover MCP install, so ask after completing.
-    offer_mcp_install(&config, &options.config_path, false)?;
     apply_wizard_hooks(&config, &result)?;
     eprintln!("init: complete");
+    print_mcp_connect_hint();
     Ok(())
 }
 
@@ -392,26 +391,14 @@ pub(crate) fn setup_model_and_reconcile(
     )?;
     Ok(())
 }
-pub(crate) fn offer_mcp_install(
-    config: &Config,
-    config_path: &Path,
-    assume_yes: bool,
-) -> anyhow::Result<()> {
-    let absolute_config = absolute_config_path(config, config_path)?;
-    if assume_yes
-        || Confirm::new()
-            .with_prompt("Install rag-rat MCP for Claude Code?")
-            .default(false)
-            .interact()?
-    {
-        install_claude_mcp(&absolute_config)?;
-    }
-    if assume_yes
-        || Confirm::new().with_prompt("Install rag-rat MCP for Codex?").default(false).interact()?
-    {
-        install_codex_mcp(&absolute_config)?;
-    }
-    Ok(())
+/// `init` does not register the MCP server with the user's agent — that is one short command the
+/// user runs themselves (`init` shelling out to `claude`/`codex` was fragile and hid the command).
+/// Print the project-scoped one-liner instead, so the connection step stays discoverable. See the
+/// README "Connect it to your agent (MCP)" section.
+fn print_mcp_connect_hint() {
+    eprintln!("Next — connect your coding agent to rag-rat (run from this repo):");
+    eprintln!("    claude mcp add --scope project rag-rat -- rag-rat mcp   # Claude Code");
+    eprintln!("    codex  mcp add rag-rat -- rag-rat mcp                   # Codex");
 }
 pub(crate) fn offer_hooks_install(config: &Config, assume_yes: bool) -> anyhow::Result<()> {
     let install = assume_yes
@@ -430,71 +417,6 @@ pub(crate) fn offer_hooks_install(config: &Config, assume_yes: bool) -> anyhow::
     eprintln!("init: installed hooks in {}", git.hooks_dir.display());
     Ok(())
 }
-pub(crate) fn install_claude_mcp(config_path: &Path) -> anyhow::Result<()> {
-    let exe = current_exe_for_mcp()?;
-    let status = Command::new("claude")
-        .arg("mcp")
-        .arg("add")
-        .arg("--scope")
-        .arg("project")
-        .arg("rag-rat")
-        .arg("--")
-        .arg(&exe)
-        .arg("mcp")
-        .arg("--config")
-        .arg(config_path)
-        .status();
-    match status {
-        Ok(status) if status.success() => eprintln!("init: installed Claude Code MCP server"),
-        Ok(status) => eprintln!("init: claude mcp add exited with status {status}"),
-        Err(err) => eprintln!("init: could not run claude mcp add: {err}"),
-    }
-    Ok(())
-}
-pub(crate) fn install_codex_mcp(config_path: &Path) -> anyhow::Result<()> {
-    let exe = current_exe_for_mcp()?;
-    let status = Command::new("codex")
-        .arg("mcp")
-        .arg("add")
-        .arg("rag-rat")
-        .arg("--")
-        .arg(&exe)
-        .arg("mcp")
-        .arg("--config")
-        .arg(config_path)
-        .status();
-    match status {
-        Ok(status) if status.success() => eprintln!("init: installed Codex MCP server"),
-        Ok(status) => {
-            eprintln!("init: codex mcp add exited with status {status}");
-            print_codex_config_snippet(&exe, config_path);
-        },
-        Err(err) => {
-            eprintln!("init: could not run codex mcp add: {err}");
-            print_codex_config_snippet(&exe, config_path);
-        },
-    }
-    Ok(())
-}
-pub(crate) fn current_exe_for_mcp() -> anyhow::Result<PathBuf> {
-    env::current_exe().map_err(Into::into)
-}
-pub(crate) fn print_codex_config_snippet(exe: &Path, config_path: &Path) {
-    eprintln!(
-        "Add this to ~/.codex/config.toml if your Codex build does not support `codex mcp add`:"
-    );
-    eprintln!("[mcp_servers.rag-rat]");
-    eprintln!("command = {:?}", exe.display().to_string());
-    eprintln!("args = [\"mcp\", \"--config\", {:?}]", config_path.display().to_string());
-}
-pub(crate) fn absolute_config_path(config: &Config, config_path: &Path) -> anyhow::Result<PathBuf> {
-    if config_path.is_absolute() {
-        Ok(config_path.to_path_buf())
-    } else {
-        Ok(config.root.join(config_path).canonicalize()?)
-    }
-}
-
 #[cfg(test)]
 mod default_plan_tests {
     use std::path::Path;

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -8,8 +8,9 @@ plus dirty worktree overlay in the same way as CLI queries.
 ## Install
 
 The MCP server is launched by the MCP client over STDIO; it does not listen on a TCP port. The
-recommended setup is `rag-rat init` from the target repo, which indexes it and registers a
-**project-scoped** MCP server. The per-repo setup, by hand:
+recommended setup is `rag-rat init` from the target repo, which indexes it and prints the one command
+that registers a **project-scoped** MCP server (`init` does not register it for you). The per-repo
+setup, by hand:
 
 ```bash
 cd /path/to/your/repo


### PR DESCRIPTION
## Why

`rag-rat init` used to register the MCP server by shelling out to `claude mcp add` / `codex mcp add`.
That is fragile — it depends on those agent CLIs being installed and on their flags staying stable —
and it hides the fact that connecting the server is a single short command a user can run themselves.

## What

- **`init` no longer auto-registers the MCP server.** On completion it prints the project-scoped
  command for Claude Code and Codex, and leaves running it to the user. No more spawning `claude` /
  `codex`.
- Removes `offer_mcp_install` and the now-dead helpers (`install_claude_mcp`, `install_codex_mcp`,
  `current_exe_for_mcp`, `print_codex_config_snippet`, `absolute_config_path`) plus the
  `std::process::Command` import they needed — the whole cluster was only reachable from the two init
  flows.
- **Docs:** the README "Connect it to your agent (MCP)" section and the `docs/mcp-tools.md` install
  intro now lead with the one-line `claude mcp add --scope project rag-rat -- rag-rat mcp` command
  instead of "init registers it for you".

## Verification

`cargo clippy -p rag-rat --all-targets` clean; `cargo nextest run -p rag-rat` — 278 passed.

Separate from #539 (the docs-catalog refresh); this one is the CLI behavior change.
