### PR TITLE
fix(parser): grow the stack for recursive tree-descent helpers (+ tripwire)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,6 +127,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ar_archive_writer"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4087686b4b0a3427190bae57a1d9a478dbb2d40c5dc1bd6e2b6d797913bdd348"
+dependencies = [
+ "object",
+]
+
+[[package]]
 name = "arc-swap"
 version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3066,6 +3075,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3338,6 +3356,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "psm"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645dbe486e346d9b5de3ef16ede18c26e6c70ad97418f4874b8b1889d6e761ea"
+dependencies = [
+ "ar_archive_writer",
+ "cc",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3464,6 +3492,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.11.0",
+ "stacker",
  "strum",
  "tempfile",
  "thiserror 2.0.18",
@@ -4239,6 +4268,19 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "stacker"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "640c8cdd92b6b12f5bcb1803ca3bbf5ab96e5e6b6b96b9ab77dabe9e880b3190"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "static_assertions"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,11 @@ schemars = { version = "1.2.1", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.11"
+# On-demand stack growth for the tree-sitter descent helpers. A hostile source file (a callee that
+# is thousands of nested parens, a thousands-deep generic type) parses within budget but recursing
+# its subtree to find a name/identifier would overflow the indexer's worker-thread stack; `stacker`
+# grows the stack instead of crashing (the same mechanism rustc uses). See index::grow_stack (#543).
+stacker = "0.1"
 strum = { version = "0.28.0", features = ["derive"] }
 thiserror = "2.0"
 tokio = { version = "1.52", features = ["rt-multi-thread", "macros", "io-std"] }

--- a/crates/rag-rat-core/Cargo.toml
+++ b/crates/rag-rat-core/Cargo.toml
@@ -32,6 +32,7 @@ scip = "0.8.1"
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
+stacker.workspace = true
 strum.workspace = true
 thiserror.workspace = true
 toml.workspace = true

--- a/crates/rag-rat-core/src/index/ai/policy.rs
+++ b/crates/rag-rat-core/src/index/ai/policy.rs
@@ -235,22 +235,26 @@ fn span_is_plumbing(
     start_byte: usize,
     end_byte: usize,
 ) -> bool {
-    let mut cursor = node.walk();
-    node.named_children(&mut cursor).all(|child| {
-        if child.end_byte() <= start_byte || child.start_byte() >= end_byte {
-            return true;
-        }
-        if is_plumbing_node(language, child) {
-            return true;
-        }
-        if start_byte <= child.start_byte() && child.end_byte() <= end_byte {
-            // A whole non-plumbing statement inside the chunk is signal.
-            return false;
-        }
-        // The child extends beyond the span — a container the chunk slices into. Classify the
-        // slice by the child's own children. A sliced leaf (e.g. one line inside a long string
-        // literal) has none and classifies as plumbing, consistent with docstring interiors.
-        span_is_plumbing(language, child, start_byte, end_byte)
+    // grow_stack: this recurses into container children to full subtree depth; a hostile
+    // deeply-nested chunk must grow the stack, not overflow it (#543).
+    crate::index::grow_stack(|| {
+        let mut cursor = node.walk();
+        node.named_children(&mut cursor).all(|child| {
+            if child.end_byte() <= start_byte || child.start_byte() >= end_byte {
+                return true;
+            }
+            if is_plumbing_node(language, child) {
+                return true;
+            }
+            if start_byte <= child.start_byte() && child.end_byte() <= end_byte {
+                // A whole non-plumbing statement inside the chunk is signal.
+                return false;
+            }
+            // The child extends beyond the span — a container the chunk slices into. Classify the
+            // slice by the child's own children. A sliced leaf (e.g. one line inside a long string
+            // literal) has none and classifies as plumbing, consistent with docstring interiors.
+            span_is_plumbing(language, child, start_byte, end_byte)
+        })
     })
 }
 

--- a/crates/rag-rat-core/src/index/clones/normalize.rs
+++ b/crates/rag-rat-core/src/index/clones/normalize.rs
@@ -208,10 +208,14 @@ fn walk_spanned(
     tokens.push(kind.to_string());
     spans.push(NodeSpan { start_byte, end_byte, kind, is_leaf: false });
 
-    let mut cursor = node.walk();
-    for child in node.children(&mut cursor) {
-        walk_spanned(child, src, lang, idents, tokens, spans);
-    }
+    // grow_stack: this recurses to full subtree depth; a hostile deeply-nested clone body must grow
+    // the stack, not overflow it (#543).
+    crate::index::grow_stack(|| {
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            walk_spanned(child, src, lang, idents, tokens, spans);
+        }
+    });
 }
 
 #[cfg(test)]

--- a/crates/rag-rat-core/src/index/edges/extract/mod.rs
+++ b/crates/rag-rat-core/src/index/edges/extract/mod.rs
@@ -475,3 +475,33 @@ mod collect_edges_depth_tests {
             .expect("the edge walk must not overflow the stack on deeply-nested input");
     }
 }
+
+#[cfg(test)]
+mod deep_expression_helper_tests {
+    use std::path::Path;
+
+    use crate::language::Language;
+
+    // The whole-tree walks (collect_edges/collect_symbols) are iterative (#520), but the extractors
+    // call name-finding helpers that recurse to full SUBTREE depth. A hostile file whose CALLEE is
+    // thousands of nested parens drives those helpers deep — grow_stack must grow the stack instead
+    // of overflowing it (#543). The input is far under the 512 KB parse cap and aborts with a stack
+    // overflow WITHOUT the grow_stack wraps.
+
+    #[test]
+    fn a_call_with_a_deeply_nested_paren_callee_does_not_overflow() {
+        // `((((…g…))))();` — the callee is 8000 nested parens (unambiguous, so the parse is fast),
+        // so call_target_name -> last_identifier_text -> collect_identifiers recurses 8000 deep.
+        let depth = 8_000;
+        let src = format!("fn f() {{ {}g{}(); }}\n", "(".repeat(depth), ")".repeat(depth));
+        std::thread::Builder::new()
+            .stack_size(512 * 1024)
+            .spawn(move || {
+                super::edge_candidates(Path::new("deep.rs"), Language::Rust, &src, &[])
+                    .expect("edge extraction");
+            })
+            .expect("spawn")
+            .join()
+            .expect("a deeply-nested paren callee must not overflow the stack");
+    }
+}

--- a/crates/rag-rat-core/src/index/edges/extract/python.rs
+++ b/crates/rag-rat-core/src/index/edges/extract/python.rs
@@ -222,10 +222,14 @@ fn emit_python_type_refs(
     match node.kind() {
         "type" | "generic_type" | "subscript" | "binary_operator" | "list" | "tuple"
         | "type_parameter" => {
-            let mut cursor = node.walk();
-            for child in node.named_children(&mut cursor) {
-                emit_python_type_refs(child, symbols, text, out);
-            }
+            // grow_stack: a deeply-nested annotation (a PEP 604 union `A|A|…`, nested generics)
+            // recurses to full subtree depth here — grow rather than overflow (#543).
+            crate::index::grow_stack(|| {
+                let mut cursor = node.walk();
+                for child in node.named_children(&mut cursor) {
+                    emit_python_type_refs(child, symbols, text, out);
+                }
+            });
         },
         "identifier" =>
             if let Some(name) = last_identifier_text(node, text) {
@@ -424,8 +428,10 @@ fn python_rebinding_effective_byte(node: Node<'_>, name: &str, text: &str) -> Op
             .and_then(|name_node| last_identifier_text(name_node, text))
             .filter(|defined| defined == name)
             .map(|_| node.start_byte()),
-        "expression_statement" =>
-            node.named_child(0).and_then(|inner| python_rebinding_effective_byte(inner, name, text)),
+        "expression_statement" => node.named_child(0).and_then(|inner| {
+            // grow_stack: uniform depth guard (#543); shallow today, no-op fast path.
+            crate::index::grow_stack(|| python_rebinding_effective_byte(inner, name, text))
+        }),
         "assignment"
             if node.child_by_field_name("right").is_some()
                 && node
@@ -455,12 +461,13 @@ fn python_assignment_target_binds(target: Node<'_>, name: &str, text: &str) -> b
     match target.kind() {
         "identifier" => node_text(target, text) == name,
         "pattern_list" | "tuple_pattern" | "list_pattern" | "splat_pattern"
-        | "list_splat_pattern" | "expression_list" => {
+        | "list_splat_pattern" | "expression_list" => crate::index::grow_stack(|| {
+            // grow_stack: nested unpacking (`a, (b, (c, …))`) recurses to full depth (#543).
             let mut cursor = target.walk();
             target
                 .named_children(&mut cursor)
                 .any(|element| python_assignment_target_binds(element, name, text))
-        },
+        }),
         _ => false,
     }
 }
@@ -472,24 +479,30 @@ fn python_assignment_target_binds(target: Node<'_>, name: &str, text: &str) -> b
 fn python_import_binds_name(node: Node<'_>, name: &str, text: &str) -> bool {
     let from_import = node.kind() == "import_from_statement";
     let module_id = node.child_by_field_name("module_name").map(|module| module.id());
-    let mut cursor = node.walk();
-    node.named_children(&mut cursor).any(|child| {
-        if Some(child.id()) == module_id {
-            return false;
-        }
-        match child.kind() {
-            "aliased_import" => child
-                .child_by_field_name("alias")
-                .and_then(|alias| last_identifier_text(alias, text))
-                .is_some_and(|alias| alias == name),
-            // from-import: the imported leaf (`from m import Account`). plain import: the top-level
-            // segment of the dotted module path (`import other.Account` binds `other`).
-            "dotted_name" if from_import =>
-                last_identifier_text(child, text).is_some_and(|leaf| leaf == name),
-            "dotted_name" => first_identifier_text(child, text).is_some_and(|root| root == name),
-            "import_list" => python_import_binds_name(child, name, text),
-            _ => false,
-        }
+    // grow_stack: uniform depth guard for a tree descender (#543); `import_list` doesn't nest
+    // deeply today, so this is a no-op fast path.
+    crate::index::grow_stack(|| {
+        let mut cursor = node.walk();
+        node.named_children(&mut cursor).any(|child| {
+            if Some(child.id()) == module_id {
+                return false;
+            }
+            match child.kind() {
+                "aliased_import" => child
+                    .child_by_field_name("alias")
+                    .and_then(|alias| last_identifier_text(alias, text))
+                    .is_some_and(|alias| alias == name),
+                // from-import: the imported leaf (`from m import Account`). plain import: the
+                // top-level segment of the dotted module path (`import other.Account` binds
+                // `other`).
+                "dotted_name" if from_import =>
+                    last_identifier_text(child, text).is_some_and(|leaf| leaf == name),
+                "dotted_name" =>
+                    first_identifier_text(child, text).is_some_and(|root| root == name),
+                "import_list" => python_import_binds_name(child, name, text),
+                _ => false,
+            }
+        })
     })
 }
 
@@ -503,10 +516,22 @@ fn python_import_target(
     out: &mut Vec<EdgeCandidate>,
 ) {
     if child.kind() == "import_list" {
-        let mut cursor = child.walk();
-        for clause in child.named_children(&mut cursor) {
-            python_import_target(clause, text, path, record_alias, import_start, module_root, out);
-        }
+        // grow_stack: uniform depth guard for a tree descender (#543); `import_list` doesn't nest
+        // deeply today, so this is a no-op fast path, but the invariant stays uniform.
+        crate::index::grow_stack(|| {
+            let mut cursor = child.walk();
+            for clause in child.named_children(&mut cursor) {
+                python_import_target(
+                    clause,
+                    text,
+                    path,
+                    record_alias,
+                    import_start,
+                    module_root,
+                    out,
+                );
+            }
+        });
         return;
     }
     // `from <module> import <target> as <alias>` — a SYMBOL alias (#174). Emit the Imports edge to
@@ -1134,5 +1159,43 @@ mod python_edge_tests {
             "scope starts at the import"
         );
         assert_eq!(scope.scope_end, src.len(), "a redef before the import does not shrink scope");
+    }
+
+    #[test]
+    fn nested_type_annotations_emit_type_refs_via_the_recursive_walk() {
+        // Exercises emit_python_type_refs recursing through generic/subscript/union nodes (#543
+        // grow_stack-wrapped) on NORMAL input.
+        let e = edges("def f(x: dict[str, list[int]]) -> Account | Other:\n    pass\n");
+        assert!(has(&e, EdgeKind::ReferencesType, "dict"), "generic type ref: {e:?}");
+        assert!(has(&e, EdgeKind::ReferencesType, "int"), "nested subscript type ref: {e:?}");
+        assert!(has(&e, EdgeKind::ReferencesType, "Account"), "union member type ref: {e:?}");
+        assert!(has(&e, EdgeKind::ReferencesType, "Other"), "union member type ref: {e:?}");
+    }
+
+    #[test]
+    fn parenthesized_import_list_records_each_target() {
+        // Exercises python_import_target recursing into `import_list` (#543 grow_stack-wrapped).
+        let e = edges("from pkg import (Alpha, Beta as B, Gamma)\n");
+        assert!(has(&e, EdgeKind::Imports, "Alpha"), "first list member: {e:?}");
+        assert!(has(&e, EdgeKind::Imports, "Beta"), "aliased list member target: {e:?}");
+        assert!(has(&e, EdgeKind::Imports, "Gamma"), "third list member: {e:?}");
+        assert!(!has(&e, EdgeKind::Imports, "B"), "alias must not be an import target: {e:?}");
+    }
+
+    #[test]
+    fn alias_scope_scan_walks_unpacking_and_expression_statements() {
+        // The aliased import triggers the module-scope rebinding scan (python_next_module_binding →
+        // python_rebinding_effective_byte over statements → python_assignment_target_binds on a
+        // nested unpacking target). All #543 grow_stack-wrapped; this runs them on normal input.
+        // The plain dotted `import Acct.deep` makes the scan's dotted-name arm run
+        // `first_identifier_text` (checking whether the root `Acct` rebinds the alias).
+        let e = edges(
+            "from mod import Account as Acct\n(a, (b, c)) = g()\nresult\nimport Acct.deep\nAcct = \
+             5\n",
+        );
+        // Running the scan is the point (it walks the wrapped helpers on normal input); the import
+        // target is still recorded, and the local `as` alias is never itself an import.
+        assert!(has(&e, EdgeKind::Imports, "Account"), "aliased import target: {e:?}");
+        assert!(!has(&e, EdgeKind::Imports, "Acct"), "alias is not an import target: {e:?}");
     }
 }

--- a/crates/rag-rat-core/src/index/edges/extract/rust_dispatch.rs
+++ b/crates/rag-rat-core/src/index/edges/extract/rust_dispatch.rs
@@ -149,8 +149,11 @@ fn arm_rebinds_local(node: Node<'_>) -> bool {
     {
         return true;
     }
-    let mut cursor = node.walk();
-    node.named_children(&mut cursor).any(arm_rebinds_local)
+    // grow_stack: full-subtree recursion; grow rather than overflow on a hostile deep arm (#543).
+    crate::index::grow_stack(|| {
+        let mut cursor = node.walk();
+        node.named_children(&mut cursor).any(arm_rebinds_local)
+    })
 }
 
 /// Whether `node`'s subtree contains an `identifier` — used to decide if an assignment target can
@@ -159,8 +162,10 @@ fn subtree_has_identifier(node: Node<'_>) -> bool {
     if node.kind() == "identifier" {
         return true;
     }
-    let mut cursor = node.walk();
-    node.named_children(&mut cursor).any(subtree_has_identifier)
+    crate::index::grow_stack(|| {
+        let mut cursor = node.walk();
+        node.named_children(&mut cursor).any(subtree_has_identifier)
+    })
 }
 
 /// See [`collect_handler_calls`]. `scope` maps an in-scope binding name to the ALREADY-RESOLVED
@@ -168,6 +173,17 @@ fn subtree_has_identifier(node: Node<'_>) -> bool {
 /// assignment of the same name replaces the entry). A binding read just contributes its stored
 /// handlers — there is no binding→binding recursion, hence no depth/cycle guard.
 fn result_handler_calls<'a>(
+    node: Node<'a>,
+    text: &str,
+    scope: &std::collections::HashMap<String, Vec<Node<'a>>>,
+    out: &mut Vec<Node<'a>>,
+) {
+    // grow_stack: recurses to full expression depth across many arms; wrap the whole recursion so a
+    // hostile deeply-nested handler expression grows the stack rather than overflowing (#543).
+    crate::index::grow_stack(|| result_handler_calls_impl(node, text, scope, out));
+}
+
+fn result_handler_calls_impl<'a>(
     node: Node<'a>,
     text: &str,
     scope: &std::collections::HashMap<String, Vec<Node<'a>>>,
@@ -474,6 +490,12 @@ fn unwrap_to_call(node: Node<'_>) -> Option<Node<'_>> {
 /// their producer and to mask match-arm payloads so they don't resolve to an outer `let` (#208
 /// review).
 fn pattern_binding_names(pattern: Node<'_>, text: &str, out: &mut Vec<String>) {
+    // grow_stack: recurses to full pattern depth across several arms; wrap the whole recursion so a
+    // hostile deeply-nested destructuring pattern grows the stack rather than overflowing (#543).
+    crate::index::grow_stack(|| pattern_binding_names_impl(pattern, text, out));
+}
+
+fn pattern_binding_names_impl(pattern: Node<'_>, text: &str, out: &mut Vec<String>) {
     match pattern.kind() {
         "shorthand_field_identifier" =>
             if let Ok(name) = pattern.utf8_text(text.as_bytes()) {

--- a/crates/rag-rat-core/src/index/edges/helpers.rs
+++ b/crates/rag-rat-core/src/index/edges/helpers.rs
@@ -127,16 +127,20 @@ pub(crate) fn child_name_text(node: Node<'_>, text: &str) -> Option<String> {
         .map(ToOwned::to_owned)
 }
 pub(crate) fn first_identifier_text(node: Node<'_>, text: &str) -> Option<String> {
-    let mut cursor = node.walk();
-    for child in node.named_children(&mut cursor) {
-        if is_identifier_kind(child.kind()) {
-            return child.utf8_text(text.as_bytes()).ok().map(ToOwned::to_owned);
+    // grow_stack: this recurses to full subtree depth; a hostile deeply-nested callee must grow
+    // the stack, not overflow it (#543).
+    crate::index::grow_stack(|| {
+        let mut cursor = node.walk();
+        for child in node.named_children(&mut cursor) {
+            if is_identifier_kind(child.kind()) {
+                return child.utf8_text(text.as_bytes()).ok().map(ToOwned::to_owned);
+            }
+            if let Some(value) = first_identifier_text(child, text) {
+                return Some(value);
+            }
         }
-        if let Some(value) = first_identifier_text(child, text) {
-            return Some(value);
-        }
-    }
-    None
+        None
+    })
 }
 pub(crate) fn last_identifier_text(node: Node<'_>, text: &str) -> Option<String> {
     identifiers_under(node, text).into_iter().last()
@@ -155,25 +159,31 @@ pub(crate) fn collect_identifiers(node: Node<'_>, text: &str, out: &mut Vec<Stri
         }
         return;
     }
-    let mut cursor = node.walk();
-    for child in node.named_children(&mut cursor) {
-        collect_identifiers(child, text, out);
-    }
+    // grow_stack: full-subtree recursion; grow rather than overflow on a hostile deep subtree
+    // (#543).
+    crate::index::grow_stack(|| {
+        let mut cursor = node.walk();
+        for child in node.named_children(&mut cursor) {
+            collect_identifiers(child, text, out);
+        }
+    });
 }
 /// Node-returning twin of [`first_identifier_text`]: the first identifier-kind node in document
 /// order, so its byte range can be recorded for the SCIP join (#67). Same traversal, so the node it
 /// returns is exactly the token whose text [`first_identifier_text`] would have produced.
 pub(crate) fn first_identifier_node(node: Node<'_>) -> Option<Node<'_>> {
-    let mut cursor = node.walk();
-    for child in node.named_children(&mut cursor) {
-        if is_identifier_kind(child.kind()) {
-            return Some(child);
+    crate::index::grow_stack(|| {
+        let mut cursor = node.walk();
+        for child in node.named_children(&mut cursor) {
+            if is_identifier_kind(child.kind()) {
+                return Some(child);
+            }
+            if let Some(found) = first_identifier_node(child) {
+                return Some(found);
+            }
         }
-        if let Some(found) = first_identifier_node(child) {
-            return Some(found);
-        }
-    }
-    None
+        None
+    })
 }
 /// Node-returning twin of [`last_identifier_text`]: the last identifier-kind node under `node`.
 pub(crate) fn last_identifier_node(node: Node<'_>) -> Option<Node<'_>> {
@@ -193,10 +203,12 @@ fn collect_identifier_nodes<'tree>(node: Node<'tree>, out: &mut Vec<Node<'tree>>
         out.push(node);
         return;
     }
-    let mut cursor = node.walk();
-    for child in node.named_children(&mut cursor) {
-        collect_identifier_nodes(child, out);
-    }
+    crate::index::grow_stack(|| {
+        let mut cursor = node.walk();
+        for child in node.named_children(&mut cursor) {
+            collect_identifier_nodes(child, out);
+        }
+    });
 }
 /// Narrow a scoped/dotted identifier node (`scoped_identifier` / `scoped_type_identifier`, whose
 /// text is the full `a::b::c`) down to its final segment — the callee/type name `c`. The

--- a/crates/rag-rat-core/src/index/parser.rs
+++ b/crates/rag-rat-core/src/index/parser.rs
@@ -497,16 +497,20 @@ fn child_name(node: Node<'_>) -> Option<Node<'_>> {
 }
 
 fn first_descendant_node<'tree>(node: Node<'tree>, kinds: &[&str]) -> Option<Node<'tree>> {
-    let mut cursor = node.walk();
-    for child in node.named_children(&mut cursor) {
-        if kinds.contains(&child.kind()) {
-            return Some(child);
+    // grow_stack: full-subtree recursion; grow rather than overflow on a hostile deep subtree
+    // (#543).
+    crate::index::grow_stack(|| {
+        let mut cursor = node.walk();
+        for child in node.named_children(&mut cursor) {
+            if kinds.contains(&child.kind()) {
+                return Some(child);
+            }
+            if let Some(value) = first_descendant_node(child, kinds) {
+                return Some(value);
+            }
         }
-        if let Some(value) = first_descendant_node(child, kinds) {
-            return Some(value);
-        }
-    }
-    None
+        None
+    })
 }
 
 /// Whether a C/C++ `*_specifier` node carries its body (`field_declaration_list` /
@@ -579,15 +583,17 @@ fn kotlin_property_name(node: Node<'_>) -> Option<Node<'_>> {
 }
 
 fn kotlin_variable_declaration(node: Node<'_>) -> Option<Node<'_>> {
-    let mut cursor = node.walk();
-    node.named_children(&mut cursor).find_map(|child| {
-        if child.kind() == "variable_declaration" {
-            Some(child)
-        } else if matches!(child.kind(), "modifiers" | "type_parameters" | "type_constraints") {
-            None
-        } else {
-            kotlin_variable_declaration(child)
-        }
+    crate::index::grow_stack(|| {
+        let mut cursor = node.walk();
+        node.named_children(&mut cursor).find_map(|child| {
+            if child.kind() == "variable_declaration" {
+                Some(child)
+            } else if matches!(child.kind(), "modifiers" | "type_parameters" | "type_constraints") {
+                None
+            } else {
+                kotlin_variable_declaration(child)
+            }
+        })
     })
 }
 
@@ -601,17 +607,19 @@ fn function_name(node: Node<'_>) -> Option<Node<'_>> {
 }
 
 fn last_descendant_node<'tree>(node: Node<'tree>, kinds: &[&str]) -> Option<Node<'tree>> {
-    let mut cursor = node.walk();
-    let mut last = None;
-    for child in node.named_children(&mut cursor) {
-        if kinds.contains(&child.kind()) {
-            last = Some(child);
+    crate::index::grow_stack(|| {
+        let mut cursor = node.walk();
+        let mut last = None;
+        for child in node.named_children(&mut cursor) {
+            if kinds.contains(&child.kind()) {
+                last = Some(child);
+            }
+            if let Some(value) = last_descendant_node(child, kinds) {
+                last = Some(value);
+            }
         }
-        if let Some(value) = last_descendant_node(child, kinds) {
-            last = Some(value);
-        }
-    }
-    last
+        last
+    })
 }
 
 fn impl_name(node: Node<'_>) -> Option<Node<'_>> {

--- a/crates/rag-rat-core/src/index/parser_tests.rs
+++ b/crates/rag-rat-core/src/index/parser_tests.rs
@@ -360,3 +360,81 @@ fn deeply_nested_input_does_not_overflow_the_symbol_walk() {
         "the function symbol survives the deep walk",
     );
 }
+
+/// #543 tripwire: EVERY function under `src/index/` that both recurses (references its own name)
+/// AND descends via `named_children` / `.children()` must wrap its recursion in `grow_stack`.
+/// Point-wrapping known helpers kept missing new ones; this enforces the invariant at test time so
+/// a newly-added tree-sitter helper can't silently reintroduce the stack-overflow class. Dogfoods
+/// `parse_symbols` to split functions (no hand brace-matching), and walks the whole `index/` tree
+/// so a new `edges/extract/<lang>.rs` is covered automatically.
+///
+/// KNOWN LIMITATIONS (this catches the common direct-recursion mistake, not every conceivable
+/// shape): mutual recursion `A -> B -> A` where neither references its own name evades it — the two
+/// intentional wrapper/`_impl` splits here are that shape, both verified `grow_stack`-guarded; and
+/// a recurser that descends ONLY via `.child(i)` / `named_child(i)` / `goto_first_child` /
+/// `child_by_field_name` (no `named_children`/`.children()` loop) is not seen as descending. The
+/// paren-callee regression test is the end-to-end backstop.
+#[test]
+fn every_recursive_tree_descender_grows_the_stack() {
+    // Whole-word occurrence of `name` in `body` — matches a direct call `name(` AND a
+    // function-pointer reference `.any(name)` / `find_map(.. name)` (no trailing `(`). Word
+    // boundaries on both sides so `foo` matches neither `foo_bar` nor `xfoo`.
+    fn references_self(body: &str, name: &str) -> bool {
+        let bytes = body.as_bytes();
+        let is_word = |b: u8| matches!(b, b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'_');
+        let mut from = 0;
+        while let Some(rel) = body[from..].find(name) {
+            let at = from + rel;
+            let end = at + name.len();
+            let before_ok = at == 0 || !is_word(bytes[at - 1]);
+            let after_ok = end >= bytes.len() || !is_word(bytes[end]);
+            if before_ok && after_ok {
+                return true;
+            }
+            from = at + name.len();
+        }
+        false
+    }
+
+    fn rs_files(dir: &Path, out: &mut Vec<std::path::PathBuf>) {
+        for entry in std::fs::read_dir(dir).unwrap_or_else(|e| panic!("read_dir {dir:?}: {e}")) {
+            let path = entry.expect("dir entry").path();
+            if path.is_dir() {
+                rs_files(&path, out);
+            } else if path.extension().is_some_and(|ext| ext == "rs") {
+                out.push(path);
+            }
+        }
+    }
+
+    let index_root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/index");
+    let mut files = Vec::new();
+    rs_files(&index_root, &mut files);
+    assert!(files.len() > 20, "index/ walk found only {} files; wrong root?", files.len());
+
+    let mut offenders = Vec::new();
+    for path in &files {
+        let rel =
+            path.strip_prefix(env!("CARGO_MANIFEST_DIR")).unwrap_or(path).display().to_string();
+        let src = std::fs::read_to_string(path).unwrap_or_else(|e| panic!("read {rel}: {e}"));
+        let symbols = parser::parse_symbols(path, Language::Rust, &src).expect("parse source");
+        for symbol in symbols.iter().filter(|s| s.kind == "function") {
+            let span = &src[symbol.start_byte..symbol.end_byte];
+            // Body only (skip the signature, which contains the function's own name).
+            let body = span.split_once('{').map(|(_, rest)| rest).unwrap_or(span);
+            let recursive = references_self(body, &symbol.name);
+            let descends = body.contains("named_children") || body.contains(".children(");
+            if recursive && descends && !body.contains("grow_stack(") {
+                offenders.push(format!("{rel}::{}", symbol.name));
+            }
+        }
+    }
+    offenders.sort();
+    offenders.dedup();
+    assert!(
+        offenders.is_empty(),
+        "recursive tree descenders missing a grow_stack wrap (a deeply-nested source file \
+         overflows the indexer stack via these — wrap the recursion in crate::index::grow_stack, \
+         #543):\n{offenders:#?}",
+    );
+}

--- a/crates/rag-rat-core/src/index/util.rs
+++ b/crates/rag-rat-core/src/index/util.rs
@@ -2,6 +2,23 @@
 
 use super::*;
 
+/// When fewer than this many bytes of stack remain, [`grow_stack`] allocates a fresh segment
+/// before running its closure. Comfortably larger than the deepest single (per-recursion-level)
+/// frame chain so a level can never straddle the boundary and overflow before the next check.
+const STACK_RED_ZONE: usize = 128 * 1024;
+/// Size of each stack segment [`grow_stack`] allocates when the red zone is hit.
+const STACK_SEGMENT: usize = 4 * 1024 * 1024;
+
+/// Run `f`, first growing the stack if it is near exhaustion (#543). Wrap the body of any
+/// tree-sitter descent helper that recurses to unbounded subtree depth — a callee that is thousands
+/// of nested parens, a thousands-deep generic type — so parsing a hostile source file grows the
+/// stack instead of overflowing the indexer's worker-thread stack (`stacker`, the mechanism rustc
+/// uses). It is a no-op fast path (one stack-pointer comparison) when ample stack remains, so real
+/// shallow inputs pay effectively nothing, and it does not change any output.
+pub(crate) fn grow_stack<R>(f: impl FnOnce() -> R) -> R {
+    stacker::maybe_grow(STACK_RED_ZONE, STACK_SEGMENT, f)
+}
+
 pub(crate) fn read_meta(conn: &rusqlite::Connection, key: &str) -> anyhow::Result<Option<String>> {
     Ok(conn
         .query_row("SELECT value FROM index_meta WHERE key = ?1", [key], |row| row.get(0))


### PR DESCRIPTION
The whole-tree walks were made iterative in #540, but the per-language edge extractors call name-finding / handler helpers that still recurse to full **subtree** depth. A hostile source file whose callee is thousands of nested parens, or whose Python type annotation is a thousands-deep PEP 604 union (`A|A|…`) or nested generic, parses within budget and under the 512 KB cap, but recursing that subtree overflows the indexer's worker-thread stack — one bad file aborts the whole indexing process. Found by adversarial review of #540 and reproduced.

Fixes #543. Fixes #520.

## The fix: grow the stack, don't overflow it

Adds `stacker` and a `crate::index::grow_stack` wrapper (`stacker::maybe_grow`). Each self-recursive tree-descent helper wraps its recursion in it — when the current stack segment is near exhaustion, a fresh 4 MiB segment is allocated and the recursion continues there (the mechanism rustc uses for deeply-nested ASTs). It's a no-op fast path (one stack-pointer comparison) when ample stack remains, so real shallow inputs pay nothing and **output is unchanged**; a pathological deep subtree grows the stack instead of crashing.

## A tripwire, not a hunt

Hand-hunting the helpers missed several across review rounds (point-patching a class). So a **tripwire test** (`every_recursive_tree_descender_grows_the_stack`) scans the extraction/clone/policy source, splits functions via `parse_symbols` (dogfooding), and **fails if any function that both recurses and descends via `named_children`/`.children` lacks a `grow_stack` wrap**. It enumerated every offender; all are now wrapped, and it keeps the class closed as new extractor helpers are added:

- `edges/helpers.rs`: `first_identifier_text`, `collect_identifiers`, `first_identifier_node`, `collect_identifier_nodes`
- `parser.rs`: `first_descendant_node`, `last_descendant_node`, `kotlin_variable_declaration`
- `edges/extract/python.rs`: `emit_python_type_refs`, `python_assignment_target_binds`, `python_import_binds_name`, `python_import_target`, `python_rebinding_effective_byte`
- `edges/extract/rust_dispatch.rs`: `arm_rebinds_local`, `subtree_has_identifier`, `result_handler_calls`, `pattern_binding_names`
- `clones/normalize.rs`: `walk_spanned`
- `ai/policy.rs`: `span_is_plumbing`

## Why `stacker` over a depth cap

A shared depth cap would also work (no dep) but truncates results on adversarial input and would be threaded through 18 helpers of different shapes. `stacker` is a uniform one-line wrap, byte-identical everywhere, and is the standard solution (rustc/servo). rag-rat is native-only, so no wasm concern; `stacker`/`psm` are permissive-licensed.

## Test

`a_call_with_a_deeply_nested_paren_callee_does_not_overflow` drives a call with an 8000-deep paren callee through edge extraction on a 512 KB stack: it aborts with a stack overflow without the wraps and completes with them. Full workspace suite (2134 tests) unchanged, confirming byte-identical output.

Together with #540, this closes #520.
