### PR TITLE
perf(index): route the heal path through the shared single-parse core

### DIFF
--- a/crates/rag-rat-cli/src/init/wizard/draft.rs
+++ b/crates/rag-rat-cli/src/init/wizard/draft.rs
@@ -625,10 +625,8 @@ fn raw_remote_draft(doc: &DocumentMut) -> Option<RemoteDraft> {
     let model = string("model")?;
     let mode = if let Some(endpoint) = string("endpoint") {
         RemoteMode::Connect(endpoint)
-    } else if let Some(cookbook) = string("cookbook") {
-        RemoteMode::Ephemeral(cookbook)
     } else {
-        return None;
+        RemoteMode::Ephemeral(string("cookbook")?)
     };
     let batch_size = remote
         .get("batch_size")

--- a/crates/rag-rat-core/src/index/file_index.rs
+++ b/crates/rag-rat-core/src/index/file_index.rs
@@ -76,76 +76,26 @@ impl IndexDatabase {
         text: &str,
         scope: &FileScope,
     ) -> anyhow::Result<()> {
-        if language != Language::Markdown && kind != TargetKind::Generated {
-            if text.len() > chunker::MAX_STRUCTURAL_PARSE_BYTES {
-                // Large source files are intentionally coarse-indexed to keep full-repo indexing
-                // responsive. This is not a parser failure.
-            } else if let Some(message) = parser::parse_error(path, language, text)
-                .unwrap_or_else(|err| Some(err.to_string()))
-            {
-                self.insert_parser_failure(path, language, &message)?;
-            }
-        }
-        let sha256 = hex_sha256(text.as_bytes());
-        let chunks = if kind == TargetKind::Generated {
-            chunker::generated_chunks_for_file(path, text)
-        } else {
-            chunker::chunks_for_file(path, language, text)
+        // Heal path: prepare from the bytes already in hand through the SAME single-parse core the
+        // full-rebuild / changed-file passes use, then route through `insert_prepared_file` in
+        // incremental mode (`graph = None`). ONE tree-sitter parse instead of 5, and no duplicated
+        // generated-file gate / parser-failure / chunk-source / has_test_code logic (#518).
+        // `heal_file`'s `remove_file_in_scope` already cleared the prior file row and its parser
+        // failure, so the incremental insert writes the live generation in place; `full_path` is
+        // unused by the insert (the bytes are already parsed).
+        let content = prepare_index_content_from_text(path, language, kind, text, modified_at_ms);
+        let prepared_file = PreparedIndexFile {
+            file: IndexFile {
+                full_path: path.to_path_buf(),
+                relative_path: path.to_path_buf(),
+                language,
+                kind,
+                commit_sha: scope.commit_sha.clone(),
+                worktree_id: scope.worktree_id.clone(),
+            },
+            prepared: Ok(content),
         };
-        // No shared tree on the heal path yet (it re-parses per derivation, #518), so the
-        // low-signal gate keeps its text-based fallback here.
-        let chunks = prepare_chunks(path, language.as_str(), kind.as_str(), chunks, text, None);
-        // has_test_code from the SAME chunk-text marker set as insert_prepared_file + the V024
-        // backfill, so a file healed through this path matches a fully-indexed one (#77). The heal
-        // path is a second files-insert site; chunks are prepared up here (they don't need file_id)
-        // so the flag can be set in the INSERT instead of left at the default 0.
-        let has_test_code = chunks.iter().any(|pc| text_has_test_marker(&pc.chunk.text));
-        let file_id = self.storage.connection().query_row(
-            "INSERT INTO main.files(path, language, kind, sha256, modified_at_ms, generated, \
-             indexed_at_ms, indexed_revision, commit_sha, worktree_id, has_test_code, repo_id, \
-             generation)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
-             RETURNING id",
-            params![
-                path_string(path),
-                language.as_str(),
-                kind.as_str(),
-                sha256,
-                modified_at_ms,
-                file_is_generated(kind, &path_string(path)),
-                now_ms(),
-                sha256,
-                &scope.commit_sha,
-                &scope.worktree_id,
-                has_test_code,
-                self.active_repo_id,
-                // A6: heal writes land on the connection's live generation.
-                self.active_generation,
-            ],
-            |row| row.get::<_, i64>(0),
-        )?;
-        let symbols =
-            if kind == TargetKind::Generated || text.len() > chunker::MAX_STRUCTURAL_PARSE_BYTES {
-                Vec::new()
-            } else {
-                symbols::symbols_for_file(path, language, text)
-            };
-        // Inline/heal path: keep chunk_fts in sync per row (partial file replace would otherwise
-        // desync the external-content index until the next forced rebuild).
-        self.insert_chunks(ChunkInsertFile { file_id, source_revision: &sha256 }, &chunks)?;
-        let symbol_ids = self.insert_symbols(file_id, language, &symbols)?;
-        // (#232 #6) Skip generated files on the incremental/heal path too — same write-side hygiene
-        // and the same `file_is_generated` arg as the full-rebuild prepare gate (prep.rs). Catches
-        // PATH-heuristic codegen under a Source target (`src/generated/*.rs`, `*.d.ts`); the
-        // `kind=Generated` case is already symbol-empty above.
-        if !file_is_generated(kind, &path_string(path)) {
-            self.store_symbol_fingerprints(language, path, text, &symbols, &symbol_ids)?;
-        }
-        if kind != TargetKind::Generated && text.len() <= edges::MAX_GRAPH_PARSE_BYTES {
-            edges::index_file_edges(self.storage.connection(), file_id, path, language, text)?;
-        }
-        self.mark_fts_dirty()?;
-        Ok(())
+        self.insert_prepared_file(&prepared_file, None)
     }
 
     /// `graph`: on a full rebuild, `Some` accumulator — symbols (with their new DB ids) and
@@ -278,38 +228,6 @@ impl IndexDatabase {
         }
         self.mark_fts_dirty()?;
         Ok(())
-    }
-
-    /// Compute + persist baseline clone fingerprints for the file's function symbols (#215). A
-    /// fingerprint is a pure function of the symbol body, so it is scope-independent and keyed by
-    /// symbol_id; the FK cascade discards it when the symbol is removed on reindex. Re-parses the
-    /// file to walk the AST — the incremental/heal path that calls this already re-reads the file,
-    /// so the extra parse is local to that path. The full-rebuild path computes fingerprints in the
-    /// parallel prepare phase (#230) and calls `write_symbol_fingerprints` directly instead.
-    fn store_symbol_fingerprints(
-        &self,
-        language: Language,
-        path: &Path,
-        text: &str,
-        symbols: &[Symbol],
-        symbol_ids: &[i64],
-    ) -> anyhow::Result<()> {
-        // `kind == "function"` symbols AND function-valued `const` declarators are fingerprinted
-        // (#215; #232 #5). This is a node-free PRE-PARSE early-bail, so it can only widen on the
-        // `kind` SUPERSET — a function-valued declarator is `kind == "const"` (parser.rs) — and let
-        // `fingerprint_symbols` + `symbol_is_function_valued` reject plain-value consts AFTER the
-        // parse. Bail before re-parsing only when NO `function` and NO `const` symbol exists — the
-        // parse is the expensive part of this incremental/heal wrapper.
-        if symbols.iter().all(|s| s.kind != "function" && s.kind != "const") {
-            return Ok(());
-        }
-        let Some(parsed) = parser::parse_file(path, language, text) else {
-            return Ok(());
-        };
-        let fingerprints = clones::fingerprint_symbols(parsed.root(), text, language, symbols);
-        // Heal/inline path runs no full-rebuild finalize, so the LIVE df is kept current here via
-        // the per-token bump (drift-tolerated; see write_symbol_fingerprints).
-        self.write_symbol_fingerprints(symbol_ids, &fingerprints, BumpDf(true))
     }
 
     /// Write precomputed baseline clone fingerprints (#215). `fingerprints` carries

--- a/crates/rag-rat-core/src/index/parser.rs
+++ b/crates/rag-rat-core/src/index/parser.rs
@@ -251,10 +251,11 @@ pub(crate) fn grammar_for(kind: ParserKind) -> Option<tree_sitter::Language> {
     })
 }
 
-/// A single tree-sitter parse of a file plus everything derived directly from the tree. The
-/// full-rebuild prepare phase parses each file ONCE through this and feeds the tree to chunking,
-/// symbols, and edges — instead of re-parsing the same file 4× (parse_error + chunker + symbols +
-/// edges). `tree` is kept so callers can walk it (e.g. edge extraction) without re-parsing.
+/// A single tree-sitter parse of a file plus everything derived directly from the tree. Both the
+/// full-rebuild prepare phase and the heal path parse each file ONCE through this and feed the tree
+/// to chunking, symbols, edges, and the parser-failure flag — instead of re-parsing the same file
+/// per derivation (#518). `tree` is kept so callers can walk it (e.g. edge extraction) without
+/// re-parsing.
 pub struct ParsedFile {
     tree: tree_sitter::Tree,
     pub symbols: Vec<ParsedSymbol>,
@@ -294,14 +295,6 @@ pub fn parse_symbols(
         Some(parsed) => Ok(parsed.symbols),
         // Markdown (no grammar) yields no symbols; a hard parse failure is the error case.
         None if parser_kind(path, language) == ParserKind::Markdown => Ok(Vec::new()),
-        None => Err(anyhow::anyhow!("tree-sitter parse failed")),
-    }
-}
-
-pub fn parse_error(path: &Path, language: Language, text: &str) -> anyhow::Result<Option<String>> {
-    match parse_file(path, language, text) {
-        Some(parsed) => Ok(parsed.parser_failure()),
-        None if parser_kind(path, language) == ParserKind::Markdown => Ok(None),
         None => Err(anyhow::anyhow!("tree-sitter parse failed")),
     }
 }

--- a/crates/rag-rat-core/src/index/prep.rs
+++ b/crates/rag-rat-core/src/index/prep.rs
@@ -256,17 +256,38 @@ pub(crate) fn should_report_file_progress(current: usize, total: usize) -> bool 
 pub(crate) fn prepare_index_content(file: &IndexFile) -> anyhow::Result<PreparedIndexContent> {
     let text = fs::read_to_string(&file.full_path)?;
     let modified_at_ms = file_metadata_ms(&file.full_path)?;
+    Ok(prepare_index_content_from_text(
+        &file.relative_path,
+        file.language,
+        file.kind,
+        &text,
+        modified_at_ms,
+    ))
+}
+
+/// The parse-once core of [`prepare_index_content`], operating on text already in hand (no file
+/// I/O). ONE tree-sitter parse feeds chunks + symbols + edges + fingerprints + the parser-failure
+/// flag, instead of re-parsing the same file. Shared by the full-rebuild / changed-file prepare
+/// phase (which reads the file first) AND the heal path (`file_index::index_file`, which already
+/// holds the bytes) — so a lazily-healed file parses ONCE like a fully-indexed one instead of 5×
+/// (#518), and the two entry points can't drift on the generated-file gate, the chunk-source
+/// selection, or the parser-failure message.
+pub(crate) fn prepare_index_content_from_text(
+    relative_path: &Path,
+    language: Language,
+    kind: TargetKind,
+    text: &str,
+    modified_at_ms: i64,
+) -> PreparedIndexContent {
     let sha256 = hex_sha256(text.as_bytes());
 
-    // ONE tree-sitter parse per file, shared by chunks + symbols + edges + the parser-failure flag,
-    // instead of re-parsing the same file four times. Only for structural (non-generated,
-    // non-markdown) code within the parse-size cap; everything else takes the line-based paths.
-    let structural_eligible = file.kind != TargetKind::Generated
-        && file.language != Language::Markdown
+    // Only structural (non-generated, non-markdown) code within the parse-size cap gets a shared
+    // tree; everything else takes the line-based paths.
+    let structural_eligible = kind != TargetKind::Generated
+        && language != Language::Markdown
         && text.len() <= chunker::MAX_STRUCTURAL_PARSE_BYTES;
-    let parsed = structural_eligible
-        .then(|| parser::parse_file(&file.relative_path, file.language, &text))
-        .flatten();
+    let parsed =
+        structural_eligible.then(|| parser::parse_file(relative_path, language, text)).flatten();
 
     let symbols = parsed.as_ref().map(|p| symbols::from_parsed(&p.symbols)).unwrap_or_default();
 
@@ -282,22 +303,22 @@ pub(crate) fn prepare_index_content(file: &IndexFile) -> anyhow::Result<Prepared
         None
     };
 
-    let chunks = if file.kind == TargetKind::Generated {
-        chunker::generated_chunks_for_file(&file.relative_path, &text)
+    let chunks = if kind == TargetKind::Generated {
+        chunker::generated_chunks_for_file(relative_path, text)
     } else if let Some(p) = &parsed {
-        chunker::code_chunks_for_symbols(&file.relative_path, &text, &p.symbols)
+        chunker::code_chunks_for_symbols(relative_path, text, &p.symbols)
     } else {
         // Markdown, oversized, or a hard parse failure: line-based chunking, no shared tree.
-        chunker::chunks_for_file(&file.relative_path, file.language, &text)
+        chunker::chunks_for_file(relative_path, language, text)
     };
     // Precompute per-chunk hashes / anchor / embedding policy here, in parallel. The low-signal
     // gate classifies chunk spans against the shared tree (one parse per file, #516).
     let chunks = prepare_chunks(
-        &file.relative_path,
-        file.language.as_str(),
-        file.kind.as_str(),
+        relative_path,
+        language.as_str(),
+        kind.as_str(),
         chunks,
-        &text,
+        text,
         parsed.as_ref().map(|p| p.root()),
     );
 
@@ -305,14 +326,8 @@ pub(crate) fn prepare_index_content(file: &IndexFile) -> anyhow::Result<Prepared
     // index, remapped to the real DB id at insert time. Empty when there's no structural parse.
     let edge_candidates = match &parsed {
         Some(p) => {
-            let local = edges::IndexedSymbol::local_from_prepared(file.language, &symbols);
-            edges::edge_candidates_from_root(
-                &file.relative_path,
-                file.language,
-                &text,
-                p.root(),
-                &local,
-            )
+            let local = edges::IndexedSymbol::local_from_prepared(language, &symbols);
+            edges::edge_candidates_from_root(relative_path, language, text, p.root(), &local)
         },
         None => Vec::new(),
     };
@@ -327,16 +342,16 @@ pub(crate) fn prepare_index_content(file: &IndexFile) -> anyhow::Result<Prepared
     // codegen under a SOURCE target (`src/generated/*.rs`, `*.d.ts`) — those DO get symbols and
     // so used to get fingerprints. The arg is byte-identical to the `files.generated` INSERT
     // (file_index.rs), so the index skip and the read filter agree.
-    let symbol_fingerprints = if file_is_generated(file.kind, &path_string(&file.relative_path)) {
+    let symbol_fingerprints = if file_is_generated(kind, &path_string(relative_path)) {
         Vec::new()
     } else {
         parsed
             .as_ref()
-            .map(|p| clones::fingerprint_symbols(p.root(), &text, file.language, &symbols))
+            .map(|p| clones::fingerprint_symbols(p.root(), text, language, &symbols))
             .unwrap_or_default()
     };
 
-    Ok(PreparedIndexContent {
+    PreparedIndexContent {
         modified_at_ms,
         sha256,
         chunks,
@@ -344,7 +359,7 @@ pub(crate) fn prepare_index_content(file: &IndexFile) -> anyhow::Result<Prepared
         edge_candidates,
         symbol_fingerprints,
         parser_failure,
-    })
+    }
 }
 
 #[cfg(test)]

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/chunk_store_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/chunk_store_migrations.rs
@@ -754,6 +754,73 @@ fn files_has_test_code_flag_survives_the_heal_path() {
 }
 
 #[test]
+fn heal_reindexes_a_file_to_the_same_chunk_policies_as_a_full_rebuild() {
+    // #518: the heal path (`heal_file` -> `index_file`) now prepares each file through the SAME
+    // single-parse core (`prepare_index_content_from_text` -> `insert_prepared_file`) the
+    // full-rebuild / changed passes use, instead of its own 5×-parse derivation with a text-based
+    // low-signal fallback. This pins the end-to-end consequence: a file re-indexed by heal lands
+    // the SAME per-chunk `embedding_policy` (the span-based low-signal decision) as the full
+    // rebuild that first indexed it. If `index_file` ever regresses to a bespoke derivation,
+    // the policies drift and this fails.
+    let _poison = crate::index::poison_sibling::disable_poison_sibling();
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    // A doc-comment + `use` block (low-signal) alongside real function bodies (embed) — the same
+    // shape as prep.rs's `span_and_text_low_signal_paths_agree_on_prepared_chunk_policies`, so both
+    // policy outcomes occur and the parity check below is non-vacuous.
+    let src = "//! Module documentation explaining what this file is for.\n\nuse \
+               std::collections::BTreeMap;\nuse std::collections::HashSet;\nuse \
+               std::path::PathBuf;\n\npub fn real_work(input: usize) -> usize {\n    let doubled \
+               = input * 2;\n    let shifted = doubled + 7;\n    shifted * shifted\n}\n\npub fn \
+               more_work(count: usize) -> usize {\n    let mut total = 0;\n    for step in \
+               0..count {\n        total += step;\n    }\n    total\n}\n";
+    fs::write(root.join("src/lib.rs"), src).unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let repo_id = crate::index::schema::active_repo_id(db.storage.connection()).unwrap();
+    // Content-keyed (not rowid-keyed: heal removes + re-inserts, so ids change) chunk-policy
+    // snapshot for the file, scoped to the active repo (the poison-sibling harness seeds a
+    // same-path row under a sibling repo).
+    let policies = || -> Vec<(i64, i64, String)> {
+        let conn = db.storage.connection();
+        let mut stmt = conn
+            .prepare(
+                "SELECT c.start_byte, c.end_byte, c.embedding_policy
+                 FROM main.chunks c JOIN main.files f ON f.id = c.file_id
+                 WHERE f.path = 'src/lib.rs' AND f.repo_id = ?1
+                 ORDER BY c.start_byte, c.end_byte",
+            )
+            .unwrap();
+        stmt.query_map([&repo_id], |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)))
+            .unwrap()
+            .map(Result::unwrap)
+            .collect()
+    };
+
+    let before = policies();
+    assert!(
+        before.iter().any(|(.., p)| p == "SkipLowSignal"),
+        "fixture must exercise the low-signal outcome: {before:?}"
+    );
+    assert!(
+        before.iter().any(|(.., p)| p == "Embed"),
+        "fixture must exercise the embed outcome: {before:?}"
+    );
+
+    // Heal the UNCHANGED file: the heal derivation must reproduce the rebuild's chunk policies.
+    db.heal_file(std::path::Path::new("src/lib.rs")).unwrap();
+    assert_eq!(
+        policies(),
+        before,
+        "heal re-indexes the file to the same span-based chunk policies as the full rebuild (#518)"
+    );
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+#[test]
 fn has_test_code_backfill_is_case_sensitive() {
     // PR #223 review: the V024 backfill must use the SAME case rules as the index-time
     // `str::contains` (case-sensitive). SQLite `LIKE` is case-insensitive for ASCII, so it would


### PR DESCRIPTION
## The heal path parsed each file five times

`heal_file -> index_file` (the lazy single-file heal behind a search miss / stale
row) re-derived a file from scratch: a `parse_error` probe, then
`chunks_for_file`, `symbols_for_file`, `store_symbol_fingerprints`, and
`index_file_edges` — **five** tree-sitter parses of the same bytes. It also
carried its own copy of the file-row INSERT, the generated-file gate, the
parser-failure message shape, and the `has_test_code` computation that already
live in the full-rebuild prepare/insert path, so the two paths could silently
drift.

## One parse, one code path

`prepare_index_content` already parses a file **once** and feeds the shared tree
to chunks + symbols + edges + fingerprints + the parser-failure flag. This splits
its parse-once body into an infallible text core,
`prepare_index_content_from_text(relative_path, language, kind, text,
modified_at_ms)`, and routes `index_file` through it and `insert_prepared_file`
in incremental mode (`graph = None`).

Result: **one parse instead of five**, and the heal and full-rebuild paths can no
longer diverge on the INSERT, the generated gate, the parser-failure message, or
`has_test_code`. `heal_file`'s `remove_file_in_scope` already clears the prior
file row and its parser failure, so the incremental insert is byte-identical to
the old bespoke heal. The heal path's low-signal chunk gate also moves from the
text-based fallback to the same span-based classification the rebuild uses —
proven equivalent by the existing `prepare_chunks` span-vs-text parity test.

Removes the now-dead `store_symbol_fingerprints` and `parser::parse_error`.

## Test

Adds `heal_reindexes_a_file_to_the_same_chunk_policies_as_a_full_rebuild`: indexes
a file (doc/`use` block + real functions, so both low-signal and embed policies
occur) via full rebuild, snapshots the per-chunk `embedding_policy` set, heals the
unchanged file, and asserts the policies are identical — end-to-end proof the heal
derivation matches the rebuild. The existing 42 heal tests + full 1819-test core
suite stay green, confirming behavior is preserved.

Fixes #518

## Also in this branch

A one-line unrelated fix so the workspace CI + eval gates go green again: Rust
1.97's `question_mark` lint (the stable toolchain CI pulls bumped to 1.97) flags a
pre-existing `else if let … else { return None }` chain in the init wizard's
`raw_remote_draft` as a manual `?`. Rewritten accordingly; verified against clippy
1.97 in all feature shapes the gates run (`--no-default-features`, default, and
`--features eval`).
