### PR TITLE
ci(oracle): pin the small tier's rust-analyzer to 1.96.0

### DIFF
--- a/.github/workflows/oracle.yml
+++ b/.github/workflows/oracle.yml
@@ -111,9 +111,13 @@ jobs:
         corpus: ${{ fromJSON(needs.matrix.outputs.corpora) }}
     steps:
       - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
-        # rust-analyzer as a toolchain component pins the SCIP emitter to the stable release (not the
-        # weekly `releases/latest`), so the `rust-time` leg's numbers don't shift under the PR.
+      # Pinned to 1.96.0, not `@stable`: rust-analyzer 1.97's `next_solver` panics generating the
+      # ground-truth SCIP for the rust-time corpus ("expected int of size 8, but got size 1") — see
+      # #553. 1.96.0 is the last stable whose rust-analyzer emits the fixture SCIP cleanly; revert to
+      # `@stable` once a released RA no longer panics. rust-analyzer as a toolchain component still
+      # pins the SCIP emitter to a stable release (not the weekly `releases/latest`), so the rust-time
+      # leg's numbers don't shift under the PR.
+      - uses: dtolnay/rust-toolchain@1.96.0
         with:
           components: rust-analyzer
       - uses: Swatinem/rust-cache@v2
@@ -128,9 +132,13 @@ jobs:
           echo "installing $tool for ${{ matrix.corpus }}"
           case "$tool" in
             rust-analyzer)
-              # Already installed as a rustup component (toolchain step). Resolve the proxy to an
-              # absolute path on PATH so the oracle's `rust-analyzer scip` probe finds it.
-              ra="$(rustup which --toolchain stable rust-analyzer)"
+              # Already installed as a rustup component (toolchain step). Resolve the proxy from the
+              # DEFAULT toolchain the `dtolnay/rust-toolchain` step set — NOT a hardcoded `--toolchain
+              # stable`, which would ignore the pin (currently 1.96.0, see the toolchain step) and copy
+              # the panicking stable rust-analyzer. Toolchain-agnostic, so the pin's `uses:` version is
+              # the single line to change when un-pinning. Copy the proxy to an absolute path on PATH
+              # so the oracle's `rust-analyzer scip` probe finds it.
+              ra="$(rustup which rust-analyzer)"
               install -m 0755 "$ra" /usr/local/bin/rust-analyzer
               rust-analyzer --version ;;
             scip-clang)


### PR DESCRIPTION
## Oracle `rust-time` leg is red on a rust-analyzer toolchain regression

The oracle `small (rust-time)` job generates its ground-truth SCIP with
`rust-analyzer scip`. rust-analyzer 1.97's `next_solver` panics on the
`time-rs/time@v0.3.36` corpus:

```
thread 'main' panicked at .../next_solver/consts/valtree.rs:435:13:
expected int of size 8, but got size 1
Error: rust-analyzer scip exited non-zero — no usable index
```

rag-rat's own `index --full` runs fine — the crash is inside the ground-truth
tool. rust-analyzer ships as the stable rustup component, so when stable rustc
bumped to 1.97.0 (2026-07-07) every oracle run went red on `rust-time`
repo-wide (main + all PRs); every run before was green. It is a toolchain
regression, not a code change, and can't be fixed from rag-rat.

## Fix

Pin the `small` job to `dtolnay/rust-toolchain@1.96.0` — the last stable whose
rust-analyzer emits the fixture SCIP cleanly — reproducing the last-green oracle
state. The component still pins the SCIP emitter to a stable release, so the
`rust-time` numbers don't drift under a PR.

This is a temporary workaround. Revert to `@stable` once a released
rust-analyzer no longer panics; the pin carries a comment pointing at the
tracking issue.

Refs #553
