### PR TITLE
ci(dist): don't run the release workflow on pull requests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,6 @@ permissions:
 # If there's a prerelease-style suffix to the version, then the release(s)
 # will be marked as a prerelease.
 on:
-  pull_request:
   push:
     tags:
       - '**[0-9]+.[0-9]+.[0-9]+*'

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -7,6 +7,11 @@ members = ["cargo:."]
 cargo-dist-version = "0.32.0"
 # CI backends to support
 ci = "github"
+# Don't run the release workflow on pull requests. The default ("plan") runs `dist plan` on every
+# PR, which also emits a skipped `build-local-artifacts` matrix job whose name can't be expanded for
+# a skipped job — so the checks list shows the raw `${{ join(matrix.targets, ', ') }}` template.
+# "skip" drops the PR trigger entirely; the release path (version tags) is unaffected.
+pr-run-mode = "skip"
 # The installers to generate for each app. `npm` produces an npm package that fetches the
 # prebuilt binary from the GitHub release — so `npx @rag-rat/bin` works with no Rust toolchain.
 installers = ["shell", "powershell", "npm"]


### PR DESCRIPTION
## The raw-template check on PRs

cargo-dist's `release.yml` runs on PRs in the default `pr-run-mode = "plan"`. That mode still emits the `build-local-artifacts` matrix job, which is **skipped** on PRs (its `if:` is false when not publishing). GitHub can't expand a skipped matrix job's `${{ matrix.targets }}` name, so the PR checks list shows the check with the template unsubstituted:

```
Release / build-local-artifacts (${{ join(matrix.targets, ', ') }}) (pull_request)
```

## Fix

Set `pr-run-mode = "skip"` in `dist-workspace.toml` and regenerate. The release workflow now triggers only on version tags, so the raw-template check no longer appears on PRs. Release/publish behaviour on tags is unchanged.

`release.yml` is regenerated with `dist generate` (dist 0.32.0, matching `cargo-dist-version`); the sole workflow change is dropping the `on: pull_request` trigger.