### PR TITLE
fix(oracle): surface real I/O errors from the tool-output read

### DIFF
--- a/crates/rag-rat-core/src/index/oracle/mod.rs
+++ b/crates/rag-rat-core/src/index/oracle/mod.rs
@@ -346,7 +346,22 @@ pub fn produce_scip_with_tool(
         .wait()
         .map_err(|err| anyhow::anyhow!("failed waiting for {}: {err}", manifest.program))?;
     let _ = forwarder.join();
-    let bytes = std::fs::read(scip_output).unwrap_or_default();
+    // A MISSING output is the expected "tool crashed before writing the .scip" case — an empty read
+    // lets `accept_produced_index` bail with the accurate "produced no readable index". Any OTHER
+    // read error (permissions, an unreadable partial file, …) is a real I/O failure that must NOT
+    // be masked by that message, so surface it with context instead of swallowing it to an
+    // empty Vec.
+    let bytes = match std::fs::read(scip_output) {
+        Ok(bytes) => bytes,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Vec::new(),
+        Err(err) => {
+            return Err(anyhow::anyhow!(
+                "failed to read {} output at {}: {err}",
+                manifest.program,
+                scip_output.display()
+            ));
+        },
+    };
     if let Some(note) = accept_produced_index(
         status.success(),
         tool.exit_code_reflects_diagnostics(),

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/mod.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/mod.rs
@@ -809,7 +809,7 @@ fn cascading_fks_to_volatile_parents(conn: &rusqlite::Connection) -> Vec<(String
 /// Helper: write four renamed clones (identical structure, different identifiers) across two
 /// directories into `root`, returning the rebuilt index. The four functions form ONE clean,
 /// high-fidelity clone class — the canonical refine fixture.
-fn write_four_renamed_clones(root: &PathBuf) -> IndexDatabase {
+fn write_four_renamed_clones(root: &Path) -> IndexDatabase {
     let _ = fs::remove_dir_all(root);
     fs::create_dir_all(root.join("a")).unwrap();
     fs::create_dir_all(root.join("b")).unwrap();


### PR DESCRIPTION
Two review findings on the oracle module.

## 1. Tool-output read masked real I/O errors

`produce_scip_with_tool` read the tool's `.scip` output with `std::fs::read(...).unwrap_or_default()`, collapsing **any** read failure to an empty `Vec`. Downstream, `accept_produced_index` treats empty bytes as "produced no readable index" and bails — so a permissions error or an unreadable partial file surfaced as that misleading message instead of the real I/O error.

A **missing** output is the legitimate "tool crashed before writing the .scip" case and still yields the accurate bail; every **other** read error now propagates with context (program + path).

## 2. `&Path` in a test helper

`write_four_renamed_clones` took `&PathBuf`; changed to `&Path` — idiomatic and consistent with `four_clone_config` and the rest of the module. All seven call sites pass `&PathBuf`, which coerces.

Clippy (`-D warnings`) clean, 507 clone+oracle tests green, fmt clean.