### PR TITLE
fix(dist): unbreak the prebuilt-binary release for Linux, Windows, Intel Mac

### DIFF
--- a/.github/workflows/dist-build-setup/steps.yml
+++ b/.github/workflows/dist-build-setup/steps.yml
@@ -1,0 +1,18 @@
+# Injected into cargo-dist's `build-local-artifacts` job before `dist build`
+# (via `github-build-setup` in dist-workspace.toml). Kept out of `.github/workflows/` root on
+# purpose — a bare steps array is not a valid workflow, and GitHub only parses YAML directly in the
+# workflows dir, so nesting it one level down avoids an "invalid workflow" annotation.
+#
+# Windows CRT alignment (mirrors ci-cross-platform.yml): esaxx-rs (a C++ dep reached via
+# tokenizers <- model2vec/fastembed) hardcodes cc's `.static_crt(true)` => /MT, but the ort_sys ONNX
+# Runtime prebuilt is /MD. `msvc-crt-static = false` flips Rust's own objects to /MD, which then
+# leaves esaxx's /MT as the odd one out => LNK2038/LNK1319. cc appends env CFLAGS/CXXFLAGS AFTER its
+# own /MT and cl.exe is last-flag-wins, so /MD here overrides esaxx's /MT to match ort. MUST stay
+# Windows-only: on macOS the esaxx build is clang, where `-MD` means "emit make dependencies" and
+# would break the build.
+- name: Align MSVC CRT to dynamic (/MD) to match the ort prebuilt
+  if: runner.os == 'Windows'
+  shell: bash
+  run: |
+    echo "CFLAGS=-MD" >> "$GITHUB_ENV"
+    echo "CXXFLAGS=-MD" >> "$GITHUB_ENV"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,6 +126,12 @@ jobs:
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
             echo "$HOME/.cargo/bin" >> $GITHUB_PATH
           fi
+      - name: "Align MSVC CRT to dynamic (/MD) to match the ort prebuilt"
+        if: "runner.os == 'Windows'"
+        run: |
+          echo "CFLAGS=-MD" >> "$GITHUB_ENV"
+          echo "CXXFLAGS=-MD" >> "$GITHUB_ENV"
+        shell: "bash"
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -21,5 +21,33 @@ npm-package = "bin"
 # On each release, publish `@rag-rat/bin` to the npm registry. The release job reads the `NPM_TOKEN`
 # repo secret (must have publish rights to the @rag-rat org); scoped packages publish `--access public`.
 publish-jobs = ["npm"]
-# Target platforms to build apps for (Rust target-triple syntax)
-targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
+# Target platforms to build apps for (Rust target-triple syntax).
+# NOTE: x86_64-apple-darwin (Intel Mac) is intentionally absent — `ort` ships no prebuilt ONNX
+# Runtime for that target (ort-sys build/download/dist.txt lists aarch64- but not x86_64-apple-darwin),
+# so the only way to build it is compiling ONNX from source. Apple Silicon (aarch64) is covered.
+# Bare `cargo install rag-rat` does NOT work on Intel Mac either — the default features enable
+# fastembed → ort and hit the same missing target. Intel Mac's only source path is the pure-Rust
+# embedder: `cargo install rag-rat --no-default-features --features model2vec` (drops the ONNX/E5
+# fastembed backend, keeps model2vec).
+targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
+
+# Link the Windows CRT dynamically (default is static/+crt-static). The prebuilt ONNX Runtime that
+# `ort` downloads is built against the dynamic CRT (/MD); static linking left its stdio imports
+# (__imp_tolower, __imp__wsopen_s, __imp_fgetc, …) unresolved → LNK2019. Dynamic CRT matches it.
+# This flips only Rust's own objects; esaxx-rs (C++) still hardcodes /MT, so github-build-setup below
+# additionally forces CFLAGS/CXXFLAGS=/MD on Windows to avoid an LNK2038 CRT mismatch.
+msvc-crt-static = false
+
+# Steps injected into the build job before `dist build`. Used for the Windows /MD CRT alignment that
+# msvc-crt-static alone can't do (esaxx-rs hardcodes /MT); see the file's comment. Path is relative
+# to `.github/workflows/`.
+github-build-setup = "dist-build-setup/steps.yml"
+
+# Build the Linux targets on glibc-2.39 images instead of dist's default ubuntu-22.04 (glibc 2.35).
+# The prebuilt ONNX Runtime references the C23 strtol family (__isoc23_strtoll/strtoull/strtol),
+# added in glibc 2.38 — on 2.35 they're undefined at link time. The resulting binaries then require
+# glibc ≥2.38 at runtime, which they already did (they statically embed a glibc-2.38 ONNX build).
+# aarch64 builds natively on an arm runner rather than cross-compiling.
+[dist.github-custom-runners]
+x86_64-unknown-linux-gnu = "ubuntu-24.04"
+aarch64-unknown-linux-gnu = "ubuntu-24.04-arm"


### PR DESCRIPTION
The first cargo-dist release (`v0.15.0`) shipped a prebuilt binary for only `aarch64-apple-darwin`. The other four targets failed to link the prebuilt ONNX Runtime that `ort` pulls in for embeddings, so no GitHub release and no `@rag-rat/bin` npm package were published. (`cargo install rag-rat` from crates.io was unaffected — release-plz publishes that independently, and 0.15.0 is live there.)

## Failures and fixes

| Target | Failure | Fix |
|---|---|---|
| `x86_64` / `aarch64-linux-gnu` | `undefined symbol: __isoc23_strtoll/strtoull/strtol` — dist builds on `ubuntu-22.04` (glibc 2.35), but the ONNX prebuilt references the C23 `strtol` family added in **glibc 2.38** | Build on `ubuntu-24.04` / `ubuntu-24.04-arm` (glibc 2.39) via `[dist.github-custom-runners]`; aarch64 now builds natively instead of cross-compiling |
| `x86_64-pc-windows-msvc` | `unresolved external __imp_tolower / __imp__wsopen_s / __imp_fgetc` (LNK2019) — dist forces the **static** CRT (`+crt-static`), but the ONNX prebuilt targets the **dynamic** CRT (`/MD`) | `msvc-crt-static = false` |
| `x86_64-apple-darwin` (Intel Mac) | `ort` ships **no prebuilt ONNX** for this target | Drop it. Apple Silicon is covered; Intel Macs `cargo install` from crates.io |

The Linux binaries already required glibc ≥2.38 (they statically embed a glibc-2.38 ONNX build), so pinning the build image to 2.39 loses no portability we had.

## Scope

Only `dist-workspace.toml` changes. Targets and runners are resolved at runtime by the `plan` job from the config, so the generated `release.yml` is byte-identical (re-ran `dist generate` to confirm). `pr-run-mode` stays `"skip"` (#555) — the release workflow still runs only on version tags.

## Validation

The build matrix only runs on a real release tag (PR runs are `skip`ped by #555, and cargo-dist takes the workflow definition from the base branch anyway), so this can't be exercised on the PR without publishing. Each fix is a direct match to its error: glibc-2.39 image supplies the C23 symbols; dynamic CRT matches ONNX's `/MD`; Intel Mac has no prebuilt to link. The next tagged release is the end-to-end test; a failure there is contained (crates.io still publishes; the cargo-dist run is a re-run, not a broken release).