### PR TITLE
docs(benchmarks): refresh kernel-index + SCIP-oracle numbers to v0.15.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ of hoping. (`rag-rat eval` requires a `--features eval` build; it is absent from
 
 ## Benchmarks
 
-The headline workload is indexing the whole Linux kernel (v7.0, ~63k C/H files, 11.2M graph edges).
+The headline workload is indexing the whole Linux kernel (v7.0, ~63k C/H files, 9.14M graph edges).
 Full numbers — wall-clock, throughput, peak RSS, on-disk size, unresolved-edge taxonomy — are in
 [`docs/benchmarks.md`](docs/benchmarks.md). Performance is tracked per-push and gated per-PR; the live
 history is at [bencher.dev/perf/rag-rat/plots](https://bencher.dev/perf/rag-rat/plots) (wiring:

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -6,15 +6,17 @@ profile that workload exposes and how syntactic resolution compares to a real co
 workflows, and `tools/bench-kernel.sh`). Numbers here are single cold runs, not statistically-gated
 CI signals; treat them as "what one run looks like," not a regression gate.
 
-These numbers are the **v0.5.0** baseline. v0.5.0 indexes the kernel ~2.7× faster than v0.4.x — and
-that is a *correctness* change, not lost coverage: see [v0.5.0 rebaseline](#v050-rebaseline-why-the-kernel-got-27-faster).
+These numbers are a fresh **v0.15.0** run. The extracted-fact counts — symbols, edges, chunks — are
+byte-identical to v0.5.0 (the indexing work is unchanged); peak RSS is lower. v0.5.0 itself indexes
+the kernel ~2.7× faster than v0.4.x, a *correctness* change, not lost coverage: see
+[v0.5.0 rebaseline](#v050-rebaseline-why-the-kernel-got-27-faster).
 
 ## Test harness
 
 The kernel index runs on a self-hosted big-memory box (the `bench-release` workflow's
 `[self-hosted, bigmem]` runner), inside the pinned bench container so the toolchain and SCIP indexers
-are reproducible. It runs here rather than on a hosted runner for a stable, uncontended wall-clock —
-not because it no longer fits a hosted box (the peak is 4.15 GiB; see below).
+are reproducible. It runs here rather than on a hosted runner for a stable wall-clock — not because
+it no longer fits a hosted box (the peak is 3.49 GiB; see below).
 
 | | |
 |---|---|
@@ -37,17 +39,26 @@ full index (`index --full`), whole tree (`RAG_RAT_KERNEL_SUBDIRS=.`), hash embed
 | Metric | Value |
 |---|---|
 | Files indexed (C/H) | 62,903 |
-| **Wall-clock** | **269.1 s** (4.49 min) |
-| Throughput | 233.7 files/s |
-| **Peak RSS** | **4.15 GiB** (4,249 MiB maxrss; 1 Hz sampler agrees at 4,250 MiB) |
-| On-disk index DB | 4.98 GiB (5,099 MiB, post-checkpoint) |
+| **Wall-clock** | **319.1 s** (5.32 min) — median of 3 cold runs (range 310.1–325.1 s) |
+| Throughput | 197.1 files/s |
+| **Peak RSS** | **3.49 GiB** (3,570 MiB maxrss; 1 Hz sampler caught 3,370 MiB) |
+| On-disk index DB | 4.65 GiB (4,758 MiB, post-checkpoint) |
 | Symbols | 1,057,527 |
 | Edges (call graph) | 9,144,061 |
-| Edges resolved | 5,371,873 (58.7%) |
+| Edges resolved | 5,320,408 (58.2%) |
 | Chunks | 1,611,390 |
 
-Unresolved-edge taxonomy (the 41.3% / 3,772,188 edges the syntactic graph leaves dangling, by kind):
-`calls_name` 1,861,690 (49.4%), `references_type` 1,508,646 (40.0%), `imports` 401,852 (10.7%). The
+Each wall-clock figure is one cold rebuild on a shared box (the runner also hosts unrelated
+services); the headline **319.1 s is the median of three** back-to-back cold rebuilds that clustered
+tightly at 310.1–325.1 s (±2.4%), so it is a stable figure, not transient contention — but it is
+~50 s above v0.5.0's 269 s single-run number. The extracted-fact counts (symbols, edges, chunks) are
+byte-identical to v0.5.0, so the indexing *work* is unchanged; the gap is execution time on identical
+work, which a cold wall-clock on a shared box can't cleanly split between pipeline changes across
+0.6→0.15 and heavier background load at measurement time. Peak RSS moved the other way
+(4.15 → 3.49 GiB).
+
+Unresolved-edge taxonomy (the 41.8% / 3,823,653 edges the syntactic graph leaves dangling, by kind):
+`calls_name` 1,861,753 (48.7%), `references_type` 1,560,047 (40.8%), `imports` 401,853 (10.5%). The
 `calls_name` bucket is extern / macro / function-pointer call targets the syntactic resolver can't
 bind without a compilation database; `references_type` is dominated by references whose type
 *definition* lives in an uncompiled or external header — both are exactly what the SCIP oracle
@@ -84,12 +95,14 @@ The two numbers that look *worse* are both improvements:
   1556-byte definition). The same change took measured C `references_type` precision from **18% →
   91%** (see below). Lower rate, far higher correctness.
 
-So v0.5.0's 269 s is the correct baseline for "indexes the Linux kernel" — a correctness-driven
-speedup, not a coverage regression.
+So the #61 definitions-only change is what makes "indexes the Linux kernel" fast — a correctness-
+driven speedup, not a coverage regression. v0.15.0 carries the identical symbol, edge, and chunk
+counts (the headline table above is the current run; wall-clock, peak RSS, on-disk size, and the
+resolved rate shifted).
 
 ## C edge resolution: heuristic vs compiler (SCIP oracle)
 
-The headline resolves 58.7% of edges *syntactically* — by name, no compiler. The SCIP oracle (#61)
+The headline resolves 58.2% of edges *syntactically* — by name, no compiler. The SCIP oracle (#61)
 measures how good that syntactic resolution actually is: it replays a real compilation through
 `scip-clang` (a clang-based SCIP indexer) and diffs its ground-truth bindings against the heuristic's.
 Numbers below are one heavy-tier `scip-clang` oracle run (`oracle.yml`, `scip-clang 0.4.0`, kernel `defconfig`, containerized
@@ -100,16 +113,16 @@ units `defconfig` actually compiles — not the whole 62,903-file tree the headl
 | Metric | Value | Meaning |
 |---|---|---|
 | Compiled TUs | 2,956 | the `defconfig` compilation database scip-clang consumes |
-| **Compiler precision (blended)** | **91.5%** | confirmed / (confirmed + contradicted), over every judged edge kind |
-| — `calls_name` | **91.8%** | function-call resolution (315,099 confirm / 28,068 contradict) |
-| — `references_type` | **91.1%** | type references (215,997 / 21,226) — after the definitions-only fix |
-| Call recall | 44.3% | covered / (covered + oracle-only) — of calls the compiler saw, the share the graph had a `calls_name` edge for |
-| Confirmed | 531,096 | heuristic target matched the compiler's |
-| Contradicted | 49,294 | heuristic bound a different target than the compiler |
-| Upgraded | 334,259 | edges promoted to `Compiler`-tier confidence |
-| Resolved-external | 28,951 | dangling refs the compiler bound to a cross-TU / external symbol the heuristic couldn't reach |
+| **Compiler precision (blended)** | **92.8%** | confirmed / (confirmed + contradicted), over every judged edge kind |
+| — `calls_name` | **91.8%** | function-call resolution (315,205 confirm / 28,071 contradict) |
+| — `references_type` | **94.2%** | type references (211,868 / 13,122) — after the definitions-only fix |
+| Call recall | 32.0% | covered / (covered + oracle-only) — of calls the compiler saw, the share the graph had a `calls_name` edge for |
+| Confirmed | 527,073 | heuristic target matched the compiler's |
+| Contradicted | 41,193 | heuristic bound a different target than the compiler |
+| Upgraded | 346,091 | edges promoted to `Compiler`-tier confidence |
+| Resolved-external | 29,535 | dangling refs the compiler bound to a cross-TU / external symbol the heuristic couldn't reach |
 
-The headline: on the compiled subset, name-based resolution agrees with the compiler **~92% of the
+The headline: on the compiled subset, name-based resolution agrees with the compiler **~93% of the
 time** on the edges it commits to — and that's after the oracle caught a real indexing bug. Getting
 here is the instructive part, and it is the same change that rebaselined the kernel headline above:
 
@@ -123,14 +136,15 @@ here is the instructive part, and it is the same change that rebaselined the ker
   function prototypes. A `references_type` edge then bound to a tiny bodyless forward-decl/use
   occurrence instead of the real definition.
 - **The fix:** index **definitions only** — a specifier must carry its body, and bare prototypes are
-  dropped. `references_type` precision jumped **18% → 91.1%**, `calls_name` rose **85% → 91.8%** (the
-  same change removed mis-resolutions to prototypes), and the blend went **50.1% → 91.5%**. This is
-  also what cut the kernel-index symbol/chunk counts (and therefore wall-clock) above.
+  dropped. `references_type` precision jumped from **18%** into the 90s (**94.2%** in this v0.15.0
+  run), `calls_name` rose from **85%** to **91.8%** (the same change removed mis-resolutions to
+  prototypes), and the blend went from **50.1%** to the low 90s (**92.8%** here). This is also what
+  cut the kernel-index symbol/chunk counts above.
 
-So the honest story is the opposite of the first read: C heuristic resolution is **~92% precise**,
+So the honest story is the opposite of the first read: C heuristic resolution is **~93% precise**,
 and the SCIP oracle's value showed up twice — it *found* the forward-declaration bug, then quantified
-the fix. Beyond precision, this run **upgraded 334k** unresolved/low-confidence edges to
-compiler-grade confidence and recovered **29k cross-TU externals** the heuristic couldn't bind.
+the fix. Beyond precision, this run **upgraded 346k** unresolved/low-confidence edges to
+compiler-grade confidence and recovered **29.5k cross-TU externals** the heuristic couldn't bind.
 ("committed to": the resolver leaves `NameOnly`/`Ambiguous` when it can't pick a target, so precision
 is over edges where the graph made a definite claim. The bulk of edges are `no_occurrence` — call
 sites outside the compiled subset or with no SCIP occurrence at their byte range — expected, since the
@@ -139,44 +153,43 @@ index spans the whole tree while the compilation database spans `defconfig`.)
 ## Rust edge resolution: heuristic vs compiler (rust-analyzer SCIP oracle)
 
 The Rust sibling, and the contrast that matters: one heavy-tier `rust-analyzer` oracle run over **rust-lang/cargo**
-(tag 0.97.1, the same pinned corpus as the iai/criterion benches), `rust-analyzer 0.3.2929`. Unlike
-scip-clang's compiled subset, rust-analyzer analyzes the **whole workspace**, so these cover every
-indexed `.rs` file (no subset caveat).
+(tag 0.97.1, `rust-analyzer 0.3.2929`). The corpus binds the `src` + `crates` workspace paths — **355**
+`.rs` files, cargo's library and workspace-member sources (not its large `tests/` tree). Unlike
+scip-clang's compiled subset, rust-analyzer analyzes the whole workspace, so the oracle covers every
+one of those indexed `.rs` files — no compiled-subset gap like C.
 
 | Metric | Value | Meaning |
 |---|---|---|
-| Rust files indexed | 1,349 | the cargo workspace |
-| **Compiler precision (blended)** | **81.4%** | confirmed / (confirmed + contradicted), over every judged edge kind |
-| — `calls_name` | **88.6%** | function-call resolution (15,907 / 2,045) |
-| — `references_type` | **73.4%** | type references (12,012 / 4,356) — after the resolution fixes below |
-| **Call recall** | **95.4%** | covered / (covered + oracle-only) — the graph had a `calls_name` edge for ~all calls the compiler saw |
-| Confirmed | 28,216 | heuristic target matched the compiler's |
-| Contradicted | 6,437 | heuristic bound a different target than the compiler |
-| Upgraded | 56,916 | edges promoted to `Compiler`-tier confidence |
-| Resolved-external | 68,358 | calls/refs the compiler bound to std / a dependency crate (the bulk of cargo's) |
+| Rust files indexed | 355 | the `src` + `crates` workspace paths |
+| **Compiler precision (blended)** | **81.7%** | confirmed / (confirmed + contradicted), over every judged edge kind |
+| — `calls_name` | **83.1%** | function-call resolution (5,378 / 1,096) |
+| — `references_type` | **80.9%** | type references (10,743 / 2,536) — after the resolution fixes below |
+| **Call recall** | **93.2%** | covered / (covered + oracle-only) — the graph had a `calls_name` edge for ~all calls the compiler saw |
+| Confirmed | 16,348 | heuristic target matched the compiler's |
+| Contradicted | 3,668 | heuristic bound a different target than the compiler |
+| Upgraded | 12,777 | edges promoted to `Compiler`-tier confidence |
+| Resolved-external | 51,201 | calls/refs the compiler bound to std / a dependency crate (the bulk of cargo's) |
 
-Read the two side by side: **call resolution `calls_name` — C 91.8% vs Rust 88.6%**; blended C 91.5%
-vs Rust 81.4%. Rust's lower blend is its `references_type` at 73.4%. Three resolution fixes lifted the
-Rust numbers from a 78.4% blend:
+Read the two side by side: **call resolution `calls_name` — C 91.8% vs Rust 83.1%**; blended C 92.8%
+vs Rust 81.7%. Rust's lower blend is spread across both kinds (`calls_name` 83.1%, `references_type`
+80.9%), each a few points under C's. Three resolution fixes got the Rust blend to where it is:
 
-- **type-only resolution** (a `references_type` reference no longer binds to a non-type symbol — an
-  `impl` block, module, etc. — in Rust/C/C++): removed 621 mis-binds, `references_type` 70.2% → 72.5%.
-- **semantic scope paths** (symbols carry a `scope_path` like `Workspace::new` that aligns with an
-  edge's source path, so the strong qualified match fires for methods instead of bare-name guessing):
-  `calls_name` 87.5% → 88.6%, blended → 80.9%.
-- **crate-aware import scope** (a name `use`d from an external dependency crate isn't bound to a local
-  same-named symbol — local workspace crates are told apart from deps by scanning the corpus's
-  Cargo.toml manifests, per package): `references_type` 72.5% → 73.4%, blended → 81.4%.
+- **type-only resolution** — a `references_type` reference no longer binds to a non-type symbol (an
+  `impl` block, module, etc.) in Rust/C/C++.
+- **semantic scope paths** — symbols carry a `scope_path` like `Workspace::new` that aligns with an
+  edge's source path, so the strong qualified match fires for methods instead of bare-name guessing.
+- **crate-aware import scope** — a name `use`d from an external dependency crate isn't bound to a
+  local same-named symbol; local workspace crates are told apart from deps by scanning the corpus's
+  Cargo.toml manifests, per package.
 
-What keeps `references_type` at ~73% rather than higher is mostly **not a resolver bug**: a large
-share is **cross-crate workspace references** — a type defined in the `cargo` crate but referenced
-from a sibling member is emitted by rust-analyzer as an external moniker with no local definition, so
-the oracle can't credit rag-rat's *correct* in-corpus binding. That's a measurement floor; real
-`references_type` precision is meaningfully above the reported number. Recall: C 44.3% (oracle sees
-only the compiled `defconfig` subset) vs Rust 95.4% (rust-analyzer sees the whole workspace). The low
-in-corpus call rate is not a weakness: cargo calls overwhelmingly into `std`/dependency crates, and
-the oracle correctly bins **68k** of those as `resolved-external` rather than forcing a wrong
-in-corpus target.
+Part of what keeps `references_type` shy of C's is **not a resolver bug**: a share is **cross-crate
+workspace references** — a type defined in one workspace crate but referenced from a sibling member is
+emitted by rust-analyzer as an external moniker with no local definition, so the oracle can't credit
+rag-rat's *correct* in-corpus binding. That's a measurement floor; real `references_type` precision is
+somewhat above the reported number. Recall: C 32.0% (oracle sees only the compiled `defconfig`
+subset) vs Rust 93.2% (rust-analyzer sees the whole workspace). The low in-corpus call rate is not a
+weakness: cargo calls overwhelmingly into `std`/dependency crates, and the oracle correctly bins
+**51k** of those as `resolved-external` rather than forcing a wrong in-corpus target.
 
 Run them yourself via the unified runner: `CORPUS=linux-kernel bash tools/oracle-run.sh` (C) and
 `CORPUS=rust-cargo bash tools/oracle-run.sh` (Rust), or dispatch `oracle.yml` with `tier=heavy` to
@@ -186,9 +199,9 @@ every verdict is reproducible.
 
 ## Memory profile: where the peak lives
 
-The v0.5.0 kernel index peaks at **4.15 GiB** (4,249 MiB maxrss; the 1 Hz `/proc` VmRSS sampler
-agrees at 4,250 MiB). The run has **two** memory humps, and the higher one is missed by the named
-per-phase probes:
+The v0.15.0 kernel index peaks at **3.49 GiB** (3,570 MiB maxrss; a 1 Hz `/proc` VmRSS sampler caught
+3,370 MiB — sampling undershoots the instantaneous peak). The run has **two** memory humps, and the
+higher one is missed by the named per-phase probes:
 
 1. **The edge-resolution window** (inside the rebuild transaction). The whole symbol + edge graph is
    held in memory until the single resolve-and-insert pass; once `index_targets` frees it, RSS drops
@@ -202,7 +215,8 @@ per-phase probes:
 
 Both humps shrank from v0.4.x with the #61 symbol/chunk reduction: a smaller in-memory graph lowers
 the edge window, and ~62% fewer chunks lower the reconcile's materialization — together taking the
-peak from 5.60 GiB to 4.15 GiB. To regenerate the per-phase curve on your own run, set
+peak from 5.60 GiB (v0.4.x) to 4.15 GiB (v0.5.0), and lower still to 3.49 GiB by v0.15.0. To
+regenerate the per-phase curve on your own run, set
 `RAG_RAT_MEM_TRACE=1` (rebuild transaction phases, to stderr) plus the sampler CSV the bench writes
 (`RSS_CSV`, the post-COMMIT reconcile the MEM_TRACE probes miss).
 


### PR DESCRIPTION
Re-ran the headline Linux-kernel full-index and both heavy SCIP oracles (scip-clang over the kernel `defconfig`, rust-analyzer over cargo) on the documented bench box with rag-rat at v0.15.0, and refreshed the numbers in `docs/benchmarks.md` and the README.

## Headline (kernel v7.0, 62,903 C/H files)
- symbols / edges / chunks: **byte-identical** to v0.5.0 (the indexing work is unchanged)
- peak RSS: 4.15 → **3.49 GiB**; on-disk DB: 4.98 → **4.65 GiB**
- wall-clock: 269 → **319 s** (median of 3 cold runs, 310–325 s) — identical counts, so this is execution time on the same work; a single cold wall-clock on a shared box can't cleanly split it between pipeline changes across 0.6→0.15 and background load
- edges resolved: 58.7% → 58.2%

## C oracle (scip-clang 0.4.0, 2,956 `defconfig` TUs)
- blended precision 91.5 → **92.8%**; `references_type` 91.1 → **94.2%**; `calls_name` unchanged at 91.8%

## Rust oracle (rust-analyzer 0.3.2929)
- blended precision 81.4 → **81.7%**
- **corrected the file count**: the committed corpus binds `src` + `crates` (**355** `.rs` files), not the whole cargo checkout — the old "1,349 files / whole workspace" figure had borrowed the iai/criterion whole-checkout count. The "no compiled-subset gap" contrast with C still holds (rust-analyzer covers all 355 indexed files).

## README
- stale "11.2M graph edges" (a pre-#61 v0.4.x figure) → **9.14M**, matching the current headline

The v0.4.x→v0.5.0 rebaseline table and the #61 / three-fix narratives are kept as history; only the current figures were refreshed.
