### PR TITLE
chore: release v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-core-v0.15.0...rag-rat-core-v0.16.0) - 2026-07-10
+
+### Added
+
+- *(papertrail)* PapertrailClient substrate — async provider trait, normalized DTOs, index/github → index/papertrail ([#600](https://github.com/cq27-dev/rag-rat/pull/600))
+- *(reconcile)* heal op-log ghosts at index reconcile — idle-repo backstop ([#583](https://github.com/cq27-dev/rag-rat/pull/583)) ([#584](https://github.com/cq27-dev/rag-rat/pull/584))
+- *(oracle)* check_library_usage — external-dependency contracts + deprecation from SCIP external_symbols ([#114](https://github.com/cq27-dev/rag-rat/pull/114)) ([#580](https://github.com/cq27-dev/rag-rat/pull/580))
+- *(impact)* windowed file-pair change-coupling signal (V056) ([#570](https://github.com/cq27-dev/rag-rat/pull/570))
+
+### Fixed
+
+- *(schema)* don't let dev/test builds silently migrate the shared global DB ([#585](https://github.com/cq27-dev/rag-rat/pull/585)) ([#601](https://github.com/cq27-dev/rag-rat/pull/601))
+- *(clones)* meter delta hydration against a work budget + memoize posting lists across bags ([#598](https://github.com/cq27-dev/rag-rat/pull/598)) ([#599](https://github.com/cq27-dev/rag-rat/pull/599))
+- *(oplog)* self-healing per-node reconcile so no memory row is a permanent ghost ([#541](https://github.com/cq27-dev/rag-rat/pull/541)) ([#576](https://github.com/cq27-dev/rag-rat/pull/576))
+- *(index)* hoist incremental reads off the SQLite write lock; commit authored writes durably ([#560](https://github.com/cq27-dev/rag-rat/pull/560)) ([#561](https://github.com/cq27-dev/rag-rat/pull/561))
+- *(dream)* four-tier identifier resolution to kill memory_divergence false positives ([#559](https://github.com/cq27-dev/rag-rat/pull/559))
+
+### Other
+
+- *(watch)* event-scoped worktree-overlay refresh with a per-worktree diff basis ([#579](https://github.com/cq27-dev/rag-rat/pull/579))
+- *(reconcile)* cover the fast-path freshness invariants left open by #530 ([#578](https://github.com/cq27-dev/rag-rat/pull/578))
+- *(reconcile)* serve the skip-summary from a version-stamped column ([#575](https://github.com/cq27-dev/rag-rat/pull/575))
+- *(search)* materialize the FTS scope view once per candidate query ([#568](https://github.com/cq27-dev/rag-rat/pull/568))
+- *(reconcile)* classify skip-summary low-signal from one shared parse per file ([#572](https://github.com/cq27-dev/rag-rat/pull/572))
+- *(benchmarks)* refresh kernel-index + SCIP-oracle numbers to v0.15.0 ([#563](https://github.com/cq27-dev/rag-rat/pull/563))
+
 ## [0.15.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-core-v0.14.0...rag-rat-core-v0.15.0) - 2026-07-09
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3443,7 +3443,7 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rag-rat"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3469,7 +3469,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-core"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -3517,7 +3517,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-mcp"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "3"
 # and the internal path deps below pin the same literal, so the three crates always publish in
 # lockstep. Bump this one line (and the two internal-dep `version`s under workspace.dependencies)
 # to release.
-version = "0.15.0"
+version = "0.16.0"
 authors = ["Kristaps Karlsons"]
 edition = "2024"
 # Bundled SQLite (rusqlite `bundled` -> libsqlite3-sys 0.38.1) compiles a build script that uses the
@@ -28,8 +28,8 @@ categories = ["command-line-utilities", "development-tools"]
 # Internal crates — declared once here so the version requirement is set in lockstep with
 # [workspace.package].version above. Members reference these via `{ workspace = true }` and add
 # their own feature toggles at the use site.
-rag-rat-core = { version = "0.15.0", path = "crates/rag-rat-core", default-features = false }
-rag-rat-mcp = { version = "0.15.0", path = "crates/rag-rat-mcp", default-features = false }
+rag-rat-core = { version = "0.16.0", path = "crates/rag-rat-core", default-features = false }
+rag-rat-mcp = { version = "0.16.0", path = "crates/rag-rat-mcp", default-features = false }
 anyhow = "1.0"
 # ed25519 device-identity signing for the op-log's signed entry envelope (§C4 layer-1). Default
 # features (incl. `zeroize`, which zeroizes a `SigningKey`'s seed on drop) are kept; the `rand_core`


### PR DESCRIPTION



## 🤖 New release

* `rag-rat-core`: 0.15.0 -> 0.16.0 (⚠ API breaking changes)
* `rag-rat-mcp`: 0.15.0 -> 0.16.0 (✓ API compatible changes)
* `rag-rat`: 0.15.0 -> 0.16.0

### ⚠ `rag-rat-core` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field CloneDeltaReport.posting_rows_requested in /tmp/.tmpwqvSe6/rag-rat/crates/rag-rat-core/src/index/query_api/clones/delta.rs:81
  field CloneDeltaReport.posting_rows_fetched in /tmp/.tmpwqvSe6/rag-rat/crates/rag-rat-core/src/index/query_api/clones/delta.rs:83
  field IdentifierResolution.kind in /tmp/.tmpwqvSe6/rag-rat/crates/rag-rat-core/src/dream/verify.rs:199
  field ImpactSurfaceReport.files_co_changed_with_symbol_path in /tmp/.tmpwqvSe6/rag-rat/crates/rag-rat-core/src/query/impact/mod.rs:102
  field OracleReport.external_symbols_written in /tmp/.tmpwqvSe6/rag-rat/crates/rag-rat-core/src/index/oracle/mod.rs:829

--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_missing.ron

Failed in:
  enum rag_rat_core::index::github::GitHubSyncAction, previously in file /tmp/.tmpJ0HNn2/rag-rat-core/src/index/github/mod.rs:94

--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/function_parameter_count_changed.ron

Failed in:
  rag_rat_core::watch::refresh_worktree_overlays now takes 4 parameters instead of 3, in /tmp/.tmpwqvSe6/rag-rat/crates/rag-rat-core/src/watch.rs:608

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/inherent_method_missing.ron

Failed in:
  IndexDatabase::set_github_context, previously in file /tmp/.tmpJ0HNn2/rag-rat-core/src/index/lifecycle.rs:366
  IndexDatabase::github_sync_from_refs, previously in file /tmp/.tmpJ0HNn2/rag-rat-core/src/index/query_api/history.rs:150
  IndexDatabase::github_sync_from_refs_with_progress, previously in file /tmp/.tmpJ0HNn2/rag-rat-core/src/index/query_api/history.rs:154
  IndexDatabase::github_sync_issue, previously in file /tmp/.tmpJ0HNn2/rag-rat-core/src/index/query_api/history.rs:183
  IndexDatabase::github_issue_search, previously in file /tmp/.tmpJ0HNn2/rag-rat-core/src/index/query_api/history.rs:208
  IndexDatabase::github_refs_for_path, previously in file /tmp/.tmpJ0HNn2/rag-rat-core/src/index/query_api/history.rs:220
  IndexDatabase::github_sync_status, previously in file /tmp/.tmpJ0HNn2/rag-rat-core/src/index/query_api/history.rs:228
  IndexDatabase::set_github_context, previously in file /tmp/.tmpJ0HNn2/rag-rat-core/src/index/lifecycle.rs:366
  IndexDatabase::github_sync_from_refs, previously in file /tmp/.tmpJ0HNn2/rag-rat-core/src/index/query_api/history.rs:150
  IndexDatabase::github_sync_from_refs_with_progress, previously in file /tmp/.tmpJ0HNn2/rag-rat-core/src/index/query_api/history.rs:154
  IndexDatabase::github_sync_issue, previously in file /tmp/.tmpJ0HNn2/rag-rat-core/src/index/query_api/history.rs:183
  IndexDatabase::github_issue_search, previously in file /tmp/.tmpJ0HNn2/rag-rat-core/src/index/query_api/history.rs:208
  IndexDatabase::github_refs_for_path, previously in file /tmp/.tmpJ0HNn2/rag-rat-core/src/index/query_api/history.rs:220
  IndexDatabase::github_sync_status, previously in file /tmp/.tmpJ0HNn2/rag-rat-core/src/index/query_api/history.rs:228

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/module_missing.ron

Failed in:
  mod rag_rat_core::index::github, previously in file /tmp/.tmpJ0HNn2/rag-rat-core/src/index/github/mod.rs:1

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_missing.ron

Failed in:
  struct rag_rat_core::index::github::GitHubComment, previously in file /tmp/.tmpJ0HNn2/rag-rat-core/src/index/github/mod.rs:162
  struct rag_rat_core::index::github::GitHubReviewComment, previously in file /tmp/.tmpJ0HNn2/rag-rat-core/src/index/github/mod.rs:203
  struct rag_rat_core::index::github::GhCliGitHubClient, previously in file /tmp/.tmpJ0HNn2/rag-rat-core/src/index/github/mod.rs:244
  struct rag_rat_core::index::github::GitHubSyncProgress, previously in file /tmp/.tmpJ0HNn2/rag-rat-core/src/index/github/mod.rs:83
  struct rag_rat_core::index::github::CurrentSourceEvidence, previously in file /tmp/.tmpJ0HNn2/rag-rat-core/src/index/github/mod.rs:138
  struct rag_rat_core::index::github::GitHubEvidence, previously in file /tmp/.tmpJ0HNn2/rag-rat-core/src/index/github/mod.rs:115
  struct rag_rat_core::index::github::Papertrail, previously in file /tmp/.tmpJ0HNn2/rag-rat-core/src/index/github/mod.rs:130
  struct rag_rat_core::index::github::GitHubIssue, previously in file /tmp/.tmpJ0HNn2/rag-rat-core/src/index/github/mod.rs:147
  struct rag_rat_core::index::github::GitHubReview, previously in file /tmp/.tmpJ0HNn2/rag-rat-core/src/index/github/mod.rs:190
  struct rag_rat_core::index::github::GitHubSyncError, previously in file /tmp/.tmpJ0HNn2/rag-rat-core/src/index/github/mod.rs:74
  struct rag_rat_core::index::github::GitHubSyncReport, previously in file /tmp/.tmpJ0HNn2/rag-rat-core/src/index/github/mod.rs:63
  struct rag_rat_core::index::github::GitHubStatus, previously in file /tmp/.tmpJ0HNn2/rag-rat-core/src/index/github/mod.rs:51
  struct rag_rat_core::index::github::GitHubPullRequest, previously in file /tmp/.tmpJ0HNn2/rag-rat-core/src/index/github/mod.rs:175
  struct rag_rat_core::index::github::GitHubContext, previously in file /tmp/.tmpJ0HNn2/rag-rat-core/src/index/github/mod.rs:26
  struct rag_rat_core::index::github::GitHubRef, previously in file /tmp/.tmpJ0HNn2/rag-rat-core/src/index/github/mod.rs:103

--- failure trait_missing: pub trait removed or renamed ---

Description:
A publicly-visible trait cannot be imported by its prior path. A `pub use` may have been removed, or the trait itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/trait_missing.ron

Failed in:
  trait rag_rat_core::index::github::GitHubClient, previously in file /tmp/.tmpJ0HNn2/rag-rat-core/src/index/github/mod.rs:216
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `rag-rat-core`

<blockquote>

## [0.16.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-core-v0.15.0...rag-rat-core-v0.16.0) - 2026-07-10

### Added

- *(papertrail)* PapertrailClient substrate — async provider trait, normalized DTOs, index/github → index/papertrail ([#600](https://github.com/cq27-dev/rag-rat/pull/600))
- *(reconcile)* heal op-log ghosts at index reconcile — idle-repo backstop ([#583](https://github.com/cq27-dev/rag-rat/pull/583)) ([#584](https://github.com/cq27-dev/rag-rat/pull/584))
- *(oracle)* check_library_usage — external-dependency contracts + deprecation from SCIP external_symbols ([#114](https://github.com/cq27-dev/rag-rat/pull/114)) ([#580](https://github.com/cq27-dev/rag-rat/pull/580))
- *(impact)* windowed file-pair change-coupling signal (V056) ([#570](https://github.com/cq27-dev/rag-rat/pull/570))

### Fixed

- *(schema)* don't let dev/test builds silently migrate the shared global DB ([#585](https://github.com/cq27-dev/rag-rat/pull/585)) ([#601](https://github.com/cq27-dev/rag-rat/pull/601))
- *(clones)* meter delta hydration against a work budget + memoize posting lists across bags ([#598](https://github.com/cq27-dev/rag-rat/pull/598)) ([#599](https://github.com/cq27-dev/rag-rat/pull/599))
- *(oplog)* self-healing per-node reconcile so no memory row is a permanent ghost ([#541](https://github.com/cq27-dev/rag-rat/pull/541)) ([#576](https://github.com/cq27-dev/rag-rat/pull/576))
- *(index)* hoist incremental reads off the SQLite write lock; commit authored writes durably ([#560](https://github.com/cq27-dev/rag-rat/pull/560)) ([#561](https://github.com/cq27-dev/rag-rat/pull/561))
- *(dream)* four-tier identifier resolution to kill memory_divergence false positives ([#559](https://github.com/cq27-dev/rag-rat/pull/559))

### Other

- *(watch)* event-scoped worktree-overlay refresh with a per-worktree diff basis ([#579](https://github.com/cq27-dev/rag-rat/pull/579))
- *(reconcile)* cover the fast-path freshness invariants left open by #530 ([#578](https://github.com/cq27-dev/rag-rat/pull/578))
- *(reconcile)* serve the skip-summary from a version-stamped column ([#575](https://github.com/cq27-dev/rag-rat/pull/575))
- *(search)* materialize the FTS scope view once per candidate query ([#568](https://github.com/cq27-dev/rag-rat/pull/568))
- *(reconcile)* classify skip-summary low-signal from one shared parse per file ([#572](https://github.com/cq27-dev/rag-rat/pull/572))
- *(benchmarks)* refresh kernel-index + SCIP-oracle numbers to v0.15.0 ([#563](https://github.com/cq27-dev/rag-rat/pull/563))
</blockquote>

## `rag-rat-mcp`

<blockquote>

## [0.16.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-core-v0.15.0...rag-rat-core-v0.16.0) - 2026-07-10

### Added

- *(papertrail)* PapertrailClient substrate — async provider trait, normalized DTOs, index/github → index/papertrail ([#600](https://github.com/cq27-dev/rag-rat/pull/600))
- *(reconcile)* heal op-log ghosts at index reconcile — idle-repo backstop ([#583](https://github.com/cq27-dev/rag-rat/pull/583)) ([#584](https://github.com/cq27-dev/rag-rat/pull/584))
- *(oracle)* check_library_usage — external-dependency contracts + deprecation from SCIP external_symbols ([#114](https://github.com/cq27-dev/rag-rat/pull/114)) ([#580](https://github.com/cq27-dev/rag-rat/pull/580))
- *(impact)* windowed file-pair change-coupling signal (V056) ([#570](https://github.com/cq27-dev/rag-rat/pull/570))

### Fixed

- *(schema)* don't let dev/test builds silently migrate the shared global DB ([#585](https://github.com/cq27-dev/rag-rat/pull/585)) ([#601](https://github.com/cq27-dev/rag-rat/pull/601))
- *(clones)* meter delta hydration against a work budget + memoize posting lists across bags ([#598](https://github.com/cq27-dev/rag-rat/pull/598)) ([#599](https://github.com/cq27-dev/rag-rat/pull/599))
- *(oplog)* self-healing per-node reconcile so no memory row is a permanent ghost ([#541](https://github.com/cq27-dev/rag-rat/pull/541)) ([#576](https://github.com/cq27-dev/rag-rat/pull/576))
- *(index)* hoist incremental reads off the SQLite write lock; commit authored writes durably ([#560](https://github.com/cq27-dev/rag-rat/pull/560)) ([#561](https://github.com/cq27-dev/rag-rat/pull/561))
- *(dream)* four-tier identifier resolution to kill memory_divergence false positives ([#559](https://github.com/cq27-dev/rag-rat/pull/559))

### Other

- *(watch)* event-scoped worktree-overlay refresh with a per-worktree diff basis ([#579](https://github.com/cq27-dev/rag-rat/pull/579))
- *(reconcile)* cover the fast-path freshness invariants left open by #530 ([#578](https://github.com/cq27-dev/rag-rat/pull/578))
- *(reconcile)* serve the skip-summary from a version-stamped column ([#575](https://github.com/cq27-dev/rag-rat/pull/575))
- *(search)* materialize the FTS scope view once per candidate query ([#568](https://github.com/cq27-dev/rag-rat/pull/568))
- *(reconcile)* classify skip-summary low-signal from one shared parse per file ([#572](https://github.com/cq27-dev/rag-rat/pull/572))
- *(benchmarks)* refresh kernel-index + SCIP-oracle numbers to v0.15.0 ([#563](https://github.com/cq27-dev/rag-rat/pull/563))
</blockquote>

## `rag-rat`

<blockquote>

## [0.16.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-core-v0.15.0...rag-rat-core-v0.16.0) - 2026-07-10

### Added

- *(papertrail)* PapertrailClient substrate — async provider trait, normalized DTOs, index/github → index/papertrail ([#600](https://github.com/cq27-dev/rag-rat/pull/600))
- *(reconcile)* heal op-log ghosts at index reconcile — idle-repo backstop ([#583](https://github.com/cq27-dev/rag-rat/pull/583)) ([#584](https://github.com/cq27-dev/rag-rat/pull/584))
- *(oracle)* check_library_usage — external-dependency contracts + deprecation from SCIP external_symbols ([#114](https://github.com/cq27-dev/rag-rat/pull/114)) ([#580](https://github.com/cq27-dev/rag-rat/pull/580))
- *(impact)* windowed file-pair change-coupling signal (V056) ([#570](https://github.com/cq27-dev/rag-rat/pull/570))

### Fixed

- *(schema)* don't let dev/test builds silently migrate the shared global DB ([#585](https://github.com/cq27-dev/rag-rat/pull/585)) ([#601](https://github.com/cq27-dev/rag-rat/pull/601))
- *(clones)* meter delta hydration against a work budget + memoize posting lists across bags ([#598](https://github.com/cq27-dev/rag-rat/pull/598)) ([#599](https://github.com/cq27-dev/rag-rat/pull/599))
- *(oplog)* self-healing per-node reconcile so no memory row is a permanent ghost ([#541](https://github.com/cq27-dev/rag-rat/pull/541)) ([#576](https://github.com/cq27-dev/rag-rat/pull/576))
- *(index)* hoist incremental reads off the SQLite write lock; commit authored writes durably ([#560](https://github.com/cq27-dev/rag-rat/pull/560)) ([#561](https://github.com/cq27-dev/rag-rat/pull/561))
- *(dream)* four-tier identifier resolution to kill memory_divergence false positives ([#559](https://github.com/cq27-dev/rag-rat/pull/559))

### Other

- *(watch)* event-scoped worktree-overlay refresh with a per-worktree diff basis ([#579](https://github.com/cq27-dev/rag-rat/pull/579))
- *(reconcile)* cover the fast-path freshness invariants left open by #530 ([#578](https://github.com/cq27-dev/rag-rat/pull/578))
- *(reconcile)* serve the skip-summary from a version-stamped column ([#575](https://github.com/cq27-dev/rag-rat/pull/575))
- *(search)* materialize the FTS scope view once per candidate query ([#568](https://github.com/cq27-dev/rag-rat/pull/568))
- *(reconcile)* classify skip-summary low-signal from one shared parse per file ([#572](https://github.com/cq27-dev/rag-rat/pull/572))
- *(benchmarks)* refresh kernel-index + SCIP-oracle numbers to v0.15.0 ([#563](https://github.com/cq27-dev/rag-rat/pull/563))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).