### PR TITLE
perf(search): materialize the FTS scope view once per candidate query

### DIFF
--- a/crates/rag-rat-core/src/search/lexical.rs
+++ b/crates/rag-rat-core/src/search/lexical.rs
@@ -347,6 +347,51 @@ fn lexical_rank_score(rank: usize) -> f64 {
     1.0 / ((rank + 1) as f64).sqrt()
 }
 
+/// The bm25 candidate statement. `files` is the per-connection scope VIEW (a two-branch UNION ALL
+/// over `main.files`; see `lifecycle::write_scope_view`), which SQLite otherwise flattens into a
+/// compound MERGE that runs the whole FTS scan + `chunks`/`chunk_text` probe pipeline once PER
+/// BRANCH. Materializing the (small — it is the FILE table, not chunks) scope view once per query
+/// collapses the plan to a SINGLE FTS pipeline.
+///
+/// `ORDER BY` stays on the `bm25()` alias, NOT `chunk_fts.rank`: the alias defers scoring until
+/// after the scope join, so out-of-scope matches (sibling repos, superseded generations, worktree
+/// shadowing) are never scored, whereas `ORDER BY rank` forces FTS5's internal sorter to score
+/// every physical match — a measured regression on consolidated / pre-gc-window DBs. The `LIMIT`
+/// still applies AFTER the scope filter, preserving the per-repo recall bound documented at the
+/// call site (`search_with_query_embedding`).
+///
+/// The secondary `chunks.id` sort key makes equal-`bm25()` ties DETERMINISTIC. It is free (the
+/// `USE TEMP B-TREE FOR ORDER BY` step already exists) and load-bearing: the caller turns candidate
+/// POSITION into a sub-score via `lexical_rank_score(rank)`, and `LIMIT` decides which tied rows
+/// survive — so an unstable tie order is an observable ranking change. The pre-materialization
+/// direct-`files` join returned ties in scope-branch order (overlay rows before base rows), a
+/// fragile plan artifact; a single materialized scan would otherwise return them in rowid order.
+/// Pinning `(score, chunks.id)` fixes the order regardless of scan plan (strictly better than the
+/// old plan-dependent tie order). Rewrite is otherwise behavior-preserving: same rows, same
+/// generation/repo/worktree scoping.
+fn bm25_candidates_sql(include_generated: bool) -> String {
+    let generated_filter = if include_generated { "1 = 1" } else { "scoped_files.generated = 0" };
+    format!(
+        "
+        WITH scoped_files AS MATERIALIZED (
+            SELECT id, path, language, kind, generated FROM files
+        )
+        SELECT chunks.id, scoped_files.path, scoped_files.language, scoped_files.kind,
+               chunks.start_line, chunks.end_line, chunks.symbol_path,
+               bm25(chunk_fts) AS score,
+               chunk_text.blob, chunk_text.raw_len, chunk_text.dict_version
+        FROM chunk_fts
+        JOIN chunks ON chunks.id = chunk_fts.rowid
+        JOIN scoped_files ON scoped_files.id = chunks.file_id
+        JOIN chunk_text ON chunk_text.chunk_id = chunks.id
+        WHERE chunk_fts MATCH ?1
+          AND {generated_filter}
+        ORDER BY score, chunks.id
+        LIMIT ?2
+        "
+    )
+}
+
 fn bm25_candidates(
     conn: &Connection,
     query: &str,
@@ -358,23 +403,7 @@ fn bm25_candidates(
     if fts_query == "\"\"" {
         return Ok(Vec::new());
     }
-    let generated_filter = if include_generated { "1 = 1" } else { "files.generated = 0" };
-    let sql = format!(
-        "
-        SELECT chunks.id, files.path, files.language, files.kind,
-               chunks.start_line, chunks.end_line, chunks.symbol_path,
-               bm25(chunk_fts) AS score,
-               chunk_text.blob, chunk_text.raw_len, chunk_text.dict_version
-        FROM chunk_fts
-        JOIN chunks ON chunks.id = chunk_fts.rowid
-        JOIN files ON files.id = chunks.file_id
-        JOIN chunk_text ON chunk_text.chunk_id = chunks.id
-        WHERE chunk_fts MATCH ?1
-          AND {generated_filter}
-        ORDER BY score
-        LIMIT ?2
-        "
-    );
+    let sql = bm25_candidates_sql(include_generated);
     let mut stmt = conn.prepare(&sql)?;
     // Snippet text comes from the compressed store (#77); collect blob + raw_len here and
     // decompress in the post-loop — decompress returns anyhow::Result, which can't cross the
@@ -409,29 +438,26 @@ fn bm25_candidates(
     Ok(hits)
 }
 
-fn vector_candidates(
-    conn: &Connection,
-    query: &str,
-    limit: i64,
-    include_generated: bool,
-    query_embedding: Option<ai::QueryEmbedding>,
-    decoder: &mut text_compression::ChunkTextDecoder,
-) -> anyhow::Result<Vec<(SearchHit, f32)>> {
-    let Some(query_embedding) = query_embedding else {
-        return Ok(Vec::new());
-    };
-    let model_version = ai::active_embedding_model_version(conn, &query_embedding.model_id)?;
-    let generated_filter = if include_generated { "1 = 1" } else { "files.generated = 0" };
-    let sql = format!(
+/// The vector candidate statement. Same scope-view materialization as `bm25_candidates_sql`: the
+/// `files` two-branch view would otherwise double the whole brute-force `chunk_embeddings` scan +
+/// blob-decode pipeline under the compound MERGE. Ordering and truncation happen in Rust after
+/// cosine scoring, so there is no `ORDER BY` / `LIMIT` here — the CTE only replaces the direct
+/// `files` join, leaving the result set (and therefore the Rust-side ranking) byte-identical.
+fn vector_candidates_sql(include_generated: bool) -> String {
+    let generated_filter = if include_generated { "1 = 1" } else { "scoped_files.generated = 0" };
+    format!(
         "
-        SELECT chunks.id, files.path, files.language, files.kind,
+        WITH scoped_files AS MATERIALIZED (
+            SELECT id, path, language, kind, generated FROM files
+        )
+        SELECT chunks.id, scoped_files.path, scoped_files.language, scoped_files.kind,
                chunks.start_line, chunks.end_line, chunks.symbol_path,
                chunk_embeddings.vector_blob, chunk_text.blob, chunk_text.raw_len,
                chunk_text.dict_version
         FROM chunk_embeddings
         JOIN ai_models ON ai_models.model_id = chunk_embeddings.model_id
         JOIN chunks ON chunks.id = chunk_embeddings.chunk_id
-        JOIN files ON files.id = chunks.file_id
+        JOIN scoped_files ON scoped_files.id = chunks.file_id
         JOIN chunk_text ON chunk_text.chunk_id = chunks.id
         WHERE chunk_embeddings.model_id = ?1
           AND ai_models.installed = 1
@@ -445,8 +471,23 @@ fn vector_candidates(
           AND chunk_embeddings.embedding_text_version = ?4
           AND chunk_embeddings.input_hash != ''
           AND {generated_filter}
-        ",
-    );
+        "
+    )
+}
+
+fn vector_candidates(
+    conn: &Connection,
+    query: &str,
+    limit: i64,
+    include_generated: bool,
+    query_embedding: Option<ai::QueryEmbedding>,
+    decoder: &mut text_compression::ChunkTextDecoder,
+) -> anyhow::Result<Vec<(SearchHit, f32)>> {
+    let Some(query_embedding) = query_embedding else {
+        return Ok(Vec::new());
+    };
+    let model_version = ai::active_embedding_model_version(conn, &query_embedding.model_id)?;
+    let sql = vector_candidates_sql(include_generated);
     let mut stmt = conn.prepare(&sql)?;
     let rows = stmt.query_map(
         params![
@@ -500,7 +541,17 @@ fn vector_candidates(
             scored.push((hit, similarity, text_row));
         }
     }
-    scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+    // Descending similarity, then ASCENDING chunk_id as a deterministic tie-break BEFORE the
+    // truncate. The scope-view materialization (vector_candidates_sql) changed the SQL row
+    // iteration order feeding this sort, so equal-similarity candidates straddling `limit` would
+    // otherwise pick a plan-dependent survivor (the same tie hazard bm25_candidates_sql fixes with
+    // `ORDER BY score, chunks.id`). chunk_id is unique, so the top-`limit` window is fully
+    // determined regardless of scan plan.
+    scored.sort_by(|a, b| {
+        b.1.partial_cmp(&a.1)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.0.chunk_id.cmp(&b.0.chunk_id))
+    });
     scored.truncate(usize::try_from(limit).unwrap_or(usize::MAX));
     let mut hits = Vec::with_capacity(scored.len());
     for (mut hit, similarity, text_row) in scored {
@@ -969,6 +1020,397 @@ mod tests {
         assert!(
             !plan.contains("SCAN f"),
             "graph_boost repo scope must PK-search files, not scan it, got plan:\n{plan}"
+        );
+    }
+
+    /// The pre-materialization bm25 JOIN shape (joins the scope VIEW `files` directly, no CTE) —
+    /// otherwise identical to production, INCLUDING the `ORDER BY score, chunks.id` tie-break, so
+    /// the equivalence test isolates the materialization as the ONLY difference and the
+    /// comparison is order-deterministic (the honest guarantee: identical rows AND identical
+    /// order once ties break by chunk_id). Also the plan-pin tombstone: under the two-branch
+    /// scope view SQLite flattens `files` into a compound MERGE and runs the FTS pipeline once
+    /// PER BRANCH, so this shape shows TWO `SCAN chunk_fts`; the materialized rewrite collapses
+    /// it to one.
+    fn legacy_bm25_sql(include_generated: bool) -> String {
+        let generated_filter = if include_generated { "1 = 1" } else { "files.generated = 0" };
+        format!(
+            "
+            SELECT chunks.id, files.path, files.language, files.kind,
+                   chunks.start_line, chunks.end_line, chunks.symbol_path,
+                   bm25(chunk_fts) AS score,
+                   chunk_text.blob, chunk_text.raw_len, chunk_text.dict_version
+            FROM chunk_fts
+            JOIN chunks ON chunks.id = chunk_fts.rowid
+            JOIN files ON files.id = chunks.file_id
+            JOIN chunk_text ON chunk_text.chunk_id = chunks.id
+            WHERE chunk_fts MATCH ?1
+              AND {generated_filter}
+            ORDER BY score, chunks.id
+            LIMIT ?2
+            "
+        )
+    }
+
+    fn register_repo(conn: &Connection, repo_id: &str) {
+        conn.execute(
+            "INSERT INTO repos(repo_id, display_name, registered_at_ms) VALUES (?1, ?1, 0)",
+            params![repo_id],
+        )
+        .unwrap();
+    }
+
+    /// Seed one scoped file + its chunk + compressed chunk_text + contentless chunk_fts token row,
+    /// returning the chunk id. The FULL scope key `(repo_id, path, commit_sha, worktree_id,
+    /// generation, generated)` is caller-controlled so a single DB can carry every scope class the
+    /// view partitions on (base / worktree-overlay / shadowed twin / superseded generation /
+    /// sibling repo / generated).
+    #[allow(clippy::too_many_arguments)]
+    fn seed_scoped_chunk(
+        conn: &Connection,
+        path: &str,
+        repo_id: &str,
+        commit_sha: &str,
+        worktree_id: &str,
+        generation: i64,
+        generated: bool,
+        text: &str,
+    ) -> i64 {
+        let file_id: i64 = conn
+            .query_row(
+                "INSERT INTO main.files(path, language, kind, sha256, modified_at_ms, \
+                 indexed_at_ms,
+                                        commit_sha, worktree_id, generation, generated, repo_id)
+                 VALUES (?1, 'rust', 'source', ?2, 0, 0, ?3, ?4, ?5, ?6, ?7)
+                 RETURNING id",
+                params![
+                    path,
+                    format!("sha-{repo_id}-{path}-{commit_sha}-{worktree_id}-{generation}"),
+                    commit_sha,
+                    worktree_id,
+                    generation,
+                    generated as i64,
+                    repo_id
+                ],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let chunk_id: i64 = conn
+            .query_row(
+                "INSERT INTO chunks(file_id, chunk_kind, symbol_path, start_byte, end_byte,
+                                    start_line, end_line, text_hash)
+                 VALUES (?1, 'symbol', ?2, 0, 10, 1, 20, ?3)
+                 RETURNING id",
+                params![file_id, path, format!("h-{file_id}")],
+                |row| row.get(0),
+            )
+            .unwrap();
+        crate::index::chunk_text_store::seed_chunk_text(conn, chunk_id, text).unwrap();
+        conn.execute("INSERT INTO chunk_fts(rowid, text) VALUES (?1, ?2)", params![chunk_id, text])
+            .unwrap();
+        chunk_id
+    }
+
+    fn candidate_ids_and_scores(
+        conn: &Connection,
+        sql: &str,
+        query: &str,
+        limit: i64,
+    ) -> Vec<(i64, f64)> {
+        conn.prepare(sql)
+            .unwrap()
+            .query_map(params![fts_query(query), limit], |row| {
+                Ok((row.get::<_, i64>(0)?, row.get::<_, f64>(7)?))
+            })
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap()
+    }
+
+    fn fts_scan_count(conn: &Connection, sql: &str) -> usize {
+        let plan = conn
+            .prepare(&format!("EXPLAIN QUERY PLAN {sql}"))
+            .unwrap()
+            .query_map(params!["alpha", 10_i64], |row| row.get::<_, String>(3))
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap()
+            .join("\n");
+        plan.matches("SCAN chunk_fts").count()
+    }
+
+    /// PLAN PIN (plan §5.1): under the production two-branch scope VIEW, the materialized bm25
+    /// statement must run the FTS scan + probe pipeline EXACTLY ONCE. The legacy shape shows it
+    /// twice (the compound MERGE duplication the rewrite exists to kill); pinning `new == 1` also
+    /// guards against a future SQLite/view change silently re-doubling the pipeline.
+    #[test]
+    fn bm25_materialized_scope_view_runs_the_fts_pipeline_once() {
+        let conn = seeded_conn();
+        crate::index::install_scope_view(&conn, "somecommit", "someworktree").unwrap();
+
+        let legacy_scans = fts_scan_count(&conn, &legacy_bm25_sql(false));
+        let new_scans = fts_scan_count(&conn, &bm25_candidates_sql(false));
+
+        assert_eq!(new_scans, 1, "materialized bm25 must scan chunk_fts exactly once");
+        assert!(
+            legacy_scans > new_scans,
+            "the two-branch view must double the legacy FTS pipeline (legacy={legacy_scans}, \
+             new={new_scans}) — otherwise this pin proves nothing"
+        );
+    }
+
+    /// BEHAVIOR EQUIVALENCE (plan §5.2): on a DB carrying every scope class — in-scope base file,
+    /// worktree overlay + its shadowed base twin, superseded generation, sibling repo, generated
+    /// file, PLUS an equal-bm25 tie pair spanning the base/overlay branch boundary — the
+    /// materialized rewrite returns byte-identical `(chunk_id, score)` rows in the same order as
+    /// the legacy join shape, ties broken deterministically by `chunks.id`. The post-filter
+    /// `LIMIT` still yields a PER-REPO window (single-repo, multi-repo, worktree-overlay), and
+    /// a LIMIT that cuts through the tie keeps the same survivor in both statements.
+    #[test]
+    fn bm25_materialized_is_byte_identical_to_the_legacy_query() {
+        let conn = seeded_conn();
+        // seeded_conn already inserted one `__unassigned__` file+chunk; drop it so the scope is
+        // exactly the classes we seed below (the placeholder repo would otherwise pollute counts).
+        conn.execute("DELETE FROM chunk_fts", []).unwrap();
+        conn.execute("DELETE FROM chunk_text", []).unwrap();
+        conn.execute("DELETE FROM chunks", []).unwrap();
+        conn.execute("DELETE FROM main.files", []).unwrap();
+
+        register_repo(&conn, "repo-a");
+        register_repo(&conn, "repo-b");
+        let commit = "commit-a";
+        let worktree = "wt-a";
+
+        // Every text carries exactly one `alpha`; distinct token counts give distinct bm25 scores
+        // (shorter doc = more relevant) EXCEPT the deliberate tie pair below. IN SCOPE (repo-a,
+        // live generation 0):
+        let base1 =
+            seed_scoped_chunk(&conn, "base1.rs", "repo-a", commit, "", 0, false, "alpha b1");
+        let base2 =
+            seed_scoped_chunk(&conn, "base2.rs", "repo-a", commit, "", 0, false, "alpha b2 c2");
+        let base3 =
+            seed_scoped_chunk(&conn, "base3.rs", "repo-a", commit, "", 0, false, "alpha b3 c3 d3");
+        // Worktree overlay wins over its same-path committed twin (branch-1 vs the NOT IN shadow).
+        let overlay = seed_scoped_chunk(
+            &conn,
+            "overlay.rs",
+            "repo-a",
+            "",
+            worktree,
+            0,
+            false,
+            "alpha o1 o2 o3 o4",
+        );
+        // TIE ACROSS THE BASE/OVERLAY BRANCH BOUNDARY (the Codex repro that the plain rewrite got
+        // wrong): two chunks with IDENTICAL text → identical bm25. `tie_base` is in the commit
+        // branch, `tie_overlay` in the worktree branch, and `tie_base` is seeded FIRST so
+        // tie_base.id < tie_overlay.id. Under the OLD direct-`files` join the worktree branch is
+        // emitted first, so a score-ONLY sort returned the pair in scope-branch order
+        // [tie_overlay, tie_base] (higher id first); a single materialized scan would return them
+        // in rowid order. The `(score, chunks.id)` tie-break both statements now carry makes the
+        // deterministic order [tie_base, tie_overlay] regardless of scan plan.
+        let tie_base = seed_scoped_chunk(
+            &conn,
+            "tie_base.rs",
+            "repo-a",
+            commit,
+            "",
+            0,
+            false,
+            "alpha t1 t2 t3 t4 t5",
+        );
+        let tie_overlay = seed_scoped_chunk(
+            &conn,
+            "tie_overlay.rs",
+            "repo-a",
+            "",
+            worktree,
+            0,
+            false,
+            "alpha t1 t2 t3 t4 t5",
+        );
+        // Generated file: in scope, but excluded when include_generated = false.
+        let generated = seed_scoped_chunk(
+            &conn,
+            "generated.rs",
+            "repo-a",
+            commit,
+            "",
+            0,
+            true,
+            "alpha g1 g2 g3 g4 g5 g6",
+        );
+
+        // OUT OF SCOPE — each is a SHORTER doc (higher bm25) than any in-scope row, so a statement
+        // that applied LIMIT before the scope join would surface them and starve the window. They
+        // must never appear:
+        // shadowed base twin of overlay.rs (same repo/commit, empty worktree) — dropped by NOT IN.
+        let _twin = seed_scoped_chunk(&conn, "overlay.rs", "repo-a", commit, "", 0, false, "alpha");
+        // superseded generation (generation 9 ≠ live 0).
+        let _superseded =
+            seed_scoped_chunk(&conn, "old.rs", "repo-a", commit, "", 9, false, "alpha");
+        // sibling repo.
+        let _sibling = seed_scoped_chunk(&conn, "sib.rs", "repo-b", commit, "", 0, false, "alpha");
+
+        crate::index::install_scope_view(&conn, commit, worktree).unwrap();
+
+        // include_generated = false: the visible set is exactly the non-generated in-scope chunks,
+        // ordered by bm25 (shortest doc first), and the equal-score tie pair breaks by chunks.id
+        // (tie_base before tie_overlay) in BOTH statements — identical rows AND identical order.
+        let legacy = candidate_ids_and_scores(&conn, &legacy_bm25_sql(false), "alpha", 80);
+        let materialized =
+            candidate_ids_and_scores(&conn, &bm25_candidates_sql(false), "alpha", 80);
+        assert_eq!(
+            legacy, materialized,
+            "materialized bm25 must be byte-identical to the legacy join shape (rows AND order)"
+        );
+        assert_eq!(
+            materialized.iter().map(|(id, _)| *id).collect::<Vec<_>>(),
+            vec![base1, base2, base3, overlay, tie_base, tie_overlay],
+            "in-scope non-generated chunks in bm25 order; ties deterministic by chunk_id"
+        );
+
+        // include_generated = true: the generated chunk joins the set (still no out-of-scope leak).
+        let legacy_gen = candidate_ids_and_scores(&conn, &legacy_bm25_sql(true), "alpha", 80);
+        let materialized_gen =
+            candidate_ids_and_scores(&conn, &bm25_candidates_sql(true), "alpha", 80);
+        assert_eq!(legacy_gen, materialized_gen, "include_generated path must match too");
+        assert_eq!(
+            materialized_gen.iter().map(|(id, _)| *id).collect::<Vec<_>>(),
+            vec![base1, base2, base3, overlay, tie_base, tie_overlay, generated],
+            "generated chunk is visible under include_generated, still no out-of-scope rows"
+        );
+
+        // RECALL BOUND: LIMIT applies AFTER the scope filter, so a small limit returns a per-repo
+        // window of in-scope rows (the two most-relevant), never the shorter out-of-scope docs a
+        // pre-LIMIT statement would have grabbed.
+        let legacy_limited = candidate_ids_and_scores(&conn, &legacy_bm25_sql(false), "alpha", 2);
+        let materialized_limited =
+            candidate_ids_and_scores(&conn, &bm25_candidates_sql(false), "alpha", 2);
+        assert_eq!(legacy_limited, materialized_limited);
+        assert_eq!(
+            materialized_limited.iter().map(|(id, _)| *id).collect::<Vec<_>>(),
+            vec![base1, base2],
+            "LIMIT after the scope filter keeps the per-repo top-2, not a starved global window"
+        );
+
+        // DETERMINISTIC TIE CUT: a LIMIT that falls in the middle of the tie pair must keep the
+        // SAME survivor (tie_base, the lower chunk_id) in both statements — otherwise the position
+        // fed to `lexical_rank_score(rank)` and the surviving candidate depend on scan plan.
+        let legacy_cut = candidate_ids_and_scores(&conn, &legacy_bm25_sql(false), "alpha", 5);
+        let materialized_cut =
+            candidate_ids_and_scores(&conn, &bm25_candidates_sql(false), "alpha", 5);
+        assert_eq!(legacy_cut, materialized_cut);
+        assert_eq!(
+            materialized_cut.iter().map(|(id, _)| *id).collect::<Vec<_>>(),
+            vec![base1, base2, base3, overlay, tie_base],
+            "LIMIT cutting through the tie keeps the lower-chunk_id row, deterministically"
+        );
+    }
+
+    /// Insert a `Current` int8 embedding for `chunk_id` under `model_id`. Sets exactly the columns
+    /// `vector_candidates_sql` filters on: `model_version` = "v1" and `embedding_text_version` =
+    /// `ai::EMBEDDING_TEXT_VERSION` (the two the query binds via `active_embedding_model_version` /
+    /// `EMBEDDING_TEXT_VERSION`), and `source_text_hash` copied from the chunk so the freshness
+    /// join matches. The rest take their schema defaults.
+    fn seed_embedding(
+        conn: &Connection,
+        chunk_id: i64,
+        model_id: &str,
+        dim: usize,
+        vector: &[f32],
+    ) {
+        let text_hash: String = conn
+            .query_row("SELECT text_hash FROM chunks WHERE id = ?1", [chunk_id], |row| row.get(0))
+            .unwrap();
+        conn.execute(
+            "INSERT INTO chunk_embeddings(
+                 chunk_id, model_id, model_version, source_text_hash, input_hash,
+                 embedding_text_version, embedding_dim, vector_blob, status, created_at_ms
+             )
+             VALUES (?1, ?2, 'v1', ?3, 'ih', ?4, ?5, ?6, 'Current', 0)",
+            params![
+                chunk_id,
+                model_id,
+                text_hash,
+                ai::EMBEDDING_TEXT_VERSION,
+                i64::try_from(dim).unwrap(),
+                ai::encode_vector(vector)
+            ],
+        )
+        .unwrap();
+    }
+
+    /// VECTOR TIE-BREAK (Codex #568 review, the vector twin of the bm25 tie fix): the scope-view
+    /// materialization changed the flat-scan row order feeding the vector scorer, so equal-
+    /// similarity candidates straddling the candidate limit must be truncated deterministically.
+    /// Two chunks share an IDENTICAL vector → identical similarity; their embedding rows are
+    /// inserted in REVERSE chunk_id order so `chunk_embeddings`'s AUTOINCREMENT rowid makes the
+    /// flat scan surface the higher-chunk_id one FIRST. Without the `(similarity, chunk_id)`
+    /// tie-break the stable sort would keep that order and truncate the wrong survivor. The
+    /// lower chunk_id must win.
+    #[test]
+    fn vector_candidates_break_similarity_ties_by_chunk_id() {
+        let conn = seeded_conn();
+        // Clear the placeholder file+chunk seeded_conn inserted; seed our own candidates only.
+        conn.execute("DELETE FROM chunk_fts", []).unwrap();
+        conn.execute("DELETE FROM chunk_text", []).unwrap();
+        conn.execute("DELETE FROM chunks", []).unwrap();
+        conn.execute("DELETE FROM main.files", []).unwrap();
+
+        // A fake installed+ready embedding model (dim 4). It is not a known spec, so
+        // `active_embedding_model_version` resolves to the default "v1" the rows carry.
+        conn.execute(
+            "INSERT INTO ai_models(model_id, capability, embedding_dim, runtime, installed,
+                                   disabled, status, installed_at_ms)
+             VALUES ('test-model', 'embedding', 4, 'local', 1, 0, 'Ready', 0)",
+            [],
+        )
+        .unwrap();
+
+        // No scope view installed ⇒ `files` resolves to raw main.files, so all three chunks are
+        // visible. `high` decodes to [1,0,0,0] (dot 1.0, strictly top); `tie_lo`/`tie_hi` decode to
+        // [0.5,0,0,0] (dot 0.5, identical). tie_lo is seeded first ⇒ tie_lo.chunk_id <
+        // tie_hi.chunk_id.
+        let high = seed_scoped_chunk(&conn, "high.rs", "__unassigned__", "", "", 0, false, "alpha");
+        let tie_lo =
+            seed_scoped_chunk(&conn, "tie_lo.rs", "__unassigned__", "", "", 0, false, "beta");
+        let tie_hi =
+            seed_scoped_chunk(&conn, "tie_hi.rs", "__unassigned__", "", "", 0, false, "gamma");
+
+        // Reverse-order embedding inserts: chunk_embeddings.id is AUTOINCREMENT, so tie_hi's row
+        // gets the lower rowid and the flat scan surfaces tie_hi before tie_lo.
+        seed_embedding(&conn, tie_hi, "test-model", 4, &[0.5, 0.0, 0.0, 0.0]);
+        seed_embedding(&conn, tie_lo, "test-model", 4, &[0.5, 0.0, 0.0, 0.0]);
+        seed_embedding(&conn, high, "test-model", 4, &[1.0, 0.0, 0.0, 0.0]);
+
+        let make_qe = || ai::QueryEmbedding {
+            model_id: "test-model".to_string(),
+            dim: 4,
+            vector: vec![1.0, 0.0, 0.0, 0.0],
+        };
+        let dicts = crate::query::chunk_text_dicts(&conn).unwrap();
+        let mut decoder = text_compression::ChunkTextDecoder::new(&dicts);
+
+        // Full result (limit 3): descending similarity, ties by ASCENDING chunk_id, and the tie is
+        // genuine (equal similarity) with `high` strictly greater.
+        let all =
+            vector_candidates(&conn, "alpha", 3, false, Some(make_qe()), &mut decoder).unwrap();
+        assert_eq!(
+            all.iter().map(|(hit, _)| hit.chunk_id).collect::<Vec<_>>(),
+            vec![high, tie_lo, tie_hi],
+            "vector order is descending similarity, ties broken by ascending chunk_id"
+        );
+        assert_eq!(all[1].1, all[2].1, "tie_lo and tie_hi must carry identical similarity");
+        assert!(all[0].1 > all[1].1, "high must be strictly the most similar");
+
+        // limit 2 straddles the tie: exactly ONE tie candidate survives, and it must be the lower
+        // chunk_id (tie_lo) regardless of the flat-scan row order.
+        let truncated =
+            vector_candidates(&conn, "alpha", 2, false, Some(make_qe()), &mut decoder).unwrap();
+        assert_eq!(
+            truncated.iter().map(|(hit, _)| hit.chunk_id).collect::<Vec<_>>(),
+            vec![high, tie_lo],
+            "LIMIT straddling the tie keeps the lower-chunk_id survivor, deterministically"
         );
     }
 


### PR DESCRIPTION
## Problem

Hybrid search runs two candidate queries per request — `bm25_candidates` and `vector_candidates` (`crates/rag-rat-core/src/search/lexical.rs`) — and both join the `files` scope view, a two-branch `UNION ALL` (base generation + worktree overlay). `EXPLAIN QUERY PLAN` shows the branches flatten to a `MERGE` plan that re-executes the whole scan + join pipeline, rebuilding the scope view once per candidate query.

## Change

Materialize the scope view once per query and join it in both branches:

```sql
WITH scoped_files AS MATERIALIZED (SELECT id, path, language, kind, generated FROM files)
```

- EQP now scans `chunk_fts` once (was twice).
- `bm25_candidates` ordering is pinned to `ORDER BY score, chunks.id`. The `chunks.id` secondary key is load-bearing: `lexical_rank_score(rank)` turns candidate position into a sub-score and `LIMIT` selects which equal-`bm25()` ties survive, so tie order must be deterministic and independent of the scan plan. The old `files` UNION-ALL branch order (overlay-before-base) was a plan artifact, not a contract; ordering by the chunk PK is deterministic and strictly better.
- `vector_candidates` has no `ORDER BY`/`LIMIT` (ranking happens in Rust) and is unchanged apart from the materialized join.

Behavior-preserving: identical rows and identical order (ties broken by `chunk_id`) across single-repo, multi-repo, and worktree-overlay scoping.

## Why this shape

- The "WAND / MaxScore" inner pre-`LIMIT` subquery on the FTS `MATCH` does **not** apply: SQLite FTS5 has no MaxScore early-termination, and pre-limiting before the scope filter is incorrect here — the post-join `LIMIT` is the per-repo recall bound.
- `ORDER BY chunk_fts.rank` was rejected: faster on clean single-repo DBs but ~1.45× slower when most FTS rows are out of scope (consolidated / pre-GC indexes), because rank-consumption forces scoring every physical match.

Result: byte-identical result sets; ~1.25–1.35× latency across regimes. Small in absolute terms — the payoff is the latency-sensitive grep-augment hook and consolidated multi-repo indexes.

## Tests

- `bm25_materialized_scope_view_runs_the_fts_pipeline_once` — EQP pin: the materialized statement scans `chunk_fts` exactly once; the legacy shape scans it more, so the pin has teeth.
- `bm25_materialized_is_byte_identical_to_the_legacy_query` — a seed carrying every scope class (in-scope base, worktree overlay + shadowed base twin, superseded generation, sibling repo, generated) **plus an identical-`bm25()` tie pair spanning the base/overlay boundary**; asserts old-vs-new `(chunk_id, score)` are identical under the deterministic tie-break, including a tie-cutting `LIMIT` case.

`cargo nextest run -p rag-rat-core` green on the touched surface; `cargo clippy --all-targets` and `cargo +nightly fmt --check` clean.

Fixes #565
