### PR TITLE
feat(impact): windowed file-pair change-coupling signal (V056)

### DIFF
--- a/crates/rag-rat-core/src/index/change_coupling.rs
+++ b/crates/rag-rat-core/src/index/change_coupling.rs
@@ -1,0 +1,454 @@
+//! Windowed file-pair change coupling, derived from `git_file_changes` (V056, #566).
+//!
+//! Persists a *symmetric* per-pair co-change table over a bounded recency window of eligible
+//! commits, surfaced as `impact_surface`'s "changes-alongside" section.
+//!
+//! INVARIANT — the stored table is a PURE FUNCTION of `(git-history window, params version)`. It
+//! has NO dependence on the `files` view (generation, generated flag, worktree scope): the
+//! co-change counts, endpoint counts, and the write-time storage filter all read only `git_commits`
+//! / `git_file_changes`. This makes the freshness stamp (`history_freshness_key:params`) COMPLETE
+//! by construction — a reindex, a generated-flag flip, a new files generation, or a worktree-scope
+//! change can never make the stored rows stale, because none of them shape the table. The generated
+//! / absent-at-HEAD filter is a READ-time concern (a partner that isn't surfaceable stays stored).
+//!
+//! The write-time storage bound is the LIFT FLOOR, not a per-file cap. A pair is stored iff
+//! `co_change_count >= MIN_COUPLING_SUPPORT` AND `lift = co * N / (a_count * b_count) >=
+//! MIN_COUPLING_LIFT` — all four inputs are pure history. This bounds the table without a per-file
+//! cap: a HUB file (touched in most window commits) has `lift <= ~1` with everything, so its pairs
+//! are dropped at write; genuinely coupled high-lift pairs survive regardless of how many partners
+//! either endpoint has. No ranking over unsurfaced partners, so there is no cap to mis-rank.
+//!
+//! Substrate semantics this pass must respect (see the `git_file_changes` co-change memory bound to
+//! `git_history.rs`, and `plan-change-coupling-signal.md`):
+//!  - Merge commits record no per-file rows (`changed_file_count = 0`), so the `>= 2` eligibility
+//!    gate drops them automatically.
+//!  - `changed_file_count` is populated at insert time — a free per-commit set-size filter, used
+//!    here for single-file and mega-commit exclusion without scanning `git_file_changes`.
+//!  - Renames land once at the destination path, so a renamed file starts a fresh coupling
+//!    identity; co-change history does not bridge the rename.
+//!  - `git_commits` / `git_file_changes` are direct `repo_id`-scoped (V040): every read joins AND
+//!    filters on `repo_id`, because forks share commit hashes.
+//!  - History rows are append-mostly but occasionally *wholesale-replaced* (rebase / amend /
+//!    force-push / shallow / root-drift / torn state). So this is a `DerivedIndex` table: it is
+//!    fully recomputed on a freshness-stamp mismatch, never patched incrementally.
+//!
+//! Two co-change notions coexist until clusters converge: this *windowed / persisted* table
+//! (impact) versus `query/clusters.rs::co_touch_pairs`' *unwindowed / transient* one
+//! (`repo_clusters`). The shared [`MAX_COUPLING_COMMIT_FILES`] cap keeps the two consumers aligned.
+
+use std::collections::HashMap;
+
+use rusqlite::{Connection, params};
+
+use crate::index::{repo_meta, set_repo_meta};
+
+/// The last N *eligible* commits per repo define the window, ordered `(committed_at_s DESC, hash
+/// DESC)` for determinism (commit timestamps collide, so the hash breaks the tie). A commit-count
+/// window bounds compute and table size independent of repo age — a time window would decay to
+/// empty on a dormant repo and grow unbounded on a monorepo.
+pub(crate) const COUPLING_WINDOW_COMMITS: i64 = 1000;
+
+/// A commit touching more than this many files contributes *no* pairs: a 500-file `cargo fmt` sweep
+/// or license-header pass would otherwise emit `C(500, 2)` spurious pairs and couple everything to
+/// everything. Shared with `query/clusters.rs::co_touch_pairs` (formerly its own
+/// `MAX_COTOUCH_COMMIT_FILES`) so the two consumers' caps can never drift.
+pub(crate) const MAX_COUPLING_COMMIT_FILES: usize = 40;
+
+/// Write-time support floor: a single co-occurrence is noise and would dominate the row count.
+pub(crate) const MIN_COUPLING_SUPPORT: i64 = 2;
+
+/// WRITE-TIME storage floor (the table's size bound; also a redundant read-time defense). A pair is
+/// stored iff `lift = co * N / (a_count * b_count) >= MIN_COUPLING_LIFT`. This is a base-rate
+/// correction: a HUB file present in most commits scores `lift ~= 1` with everything, so its pairs
+/// are dropped here — bounding the table WITHOUT a per-file cap and without ranking over unsurfaced
+/// partners. All four inputs (`co`, `N`, `a_count`, `b_count`) are pure git history, so the filter
+/// keeps the stored set a pure function of history.
+pub(crate) const MIN_COUPLING_LIFT: f64 = 1.5;
+
+/// Bump when ANY storage-affecting knob changes — the window size ([`COUPLING_WINDOW_COMMITS`]),
+/// the mega-commit gate ([`MAX_COUPLING_COMMIT_FILES`]), the support floor
+/// ([`MIN_COUPLING_SUPPORT`]), or the lift floor ([`MIN_COUPLING_LIFT`]) — because each now changes
+/// the STORED set. It is folded into the freshness stamp, so a change invalidates every repo's
+/// coupling rows *without* a schema migration (the `GENERATED_FLAGS_VERSION` pattern).
+pub(crate) const COUPLING_PARAMS_VERSION: u32 = 1;
+
+/// `repo_meta` key holding the freshness stamp
+/// `"{history_freshness_key}:{COUPLING_PARAMS_VERSION}"` — the freshness authority for the derived
+/// table (row-level integrity is deliberately not, so the table survives a history full-replace
+/// between recompute passes). The stored table is a pure function of `(git-history window,
+/// params)`, so these two axes are COMPLETE: the git-history cursor snapshot (head + root +
+/// shallow + complete — so a rewrite at the same HEAD invalidates) and the params version (so a
+/// window / gate / floor const change invalidates without a migration). Deliberately NO
+/// files-generation / generated-flag / worktree axis — the table does not depend on the `files`
+/// view.
+const COUPLING_STAMP_META: &str = "git_coupling_stamp";
+
+/// One coupled file for a queried path, with the read-time metrics already derived from the stored
+/// counts. `confidence = P(other | this)`; `lift` is the symmetric base-rate correction.
+#[derive(Debug, Clone)]
+pub(crate) struct CoupledFile {
+    pub other_path: String,
+    pub co_change_count: i64,
+    pub this_change_count: i64,
+    pub window_commit_count: i64,
+    pub confidence: f64,
+    pub lift: f64,
+    pub last_co_change_at_s: i64,
+    pub language: String,
+    pub kind: String,
+}
+
+/// Per-pair accumulator over the window. `last_at_s` is the newest co-change's `committed_at_s`
+/// (recency evidence); it starts at `i64::MIN` so the first observation always wins regardless of
+/// the timestamp's sign.
+struct PairAcc {
+    count: i64,
+    last_at_s: i64,
+}
+
+/// Recompute-if-stale gate: the `DerivedIndex` self-heal, mirroring `ensure_fts_fresh` /
+/// `cached_blame`. Cheap stamp SELECT, then a full recompute on mismatch. Idempotent — concurrent
+/// writers serialize on SQLite's write lock and last-writer-wins an identical result; readers see
+/// old-or-new rows, never a mix (the recompute is one transaction).
+pub(crate) fn ensure_coupling_fresh(conn: &Connection, now_ms: i64) -> anyhow::Result<()> {
+    let repo_id = crate::index::schema::active_repo_id(conn)?;
+    if coupling_stamp_current(conn, &repo_id)? {
+        return Ok(());
+    }
+    recompute_couplings(conn, &repo_id, now_ms)
+}
+
+/// The stamp a fresh table for `repo_id` must carry, over the ONLY two axes the stored table
+/// depends on: the git-history freshness key (the `is_history_current` cursor snapshot — reused
+/// verbatim so a history rewrite at the same HEAD is caught) and the params version. There is
+/// deliberately no files-generation component: the stored table is a pure function of git history,
+/// so a files-view change can never stale it.
+fn coupling_stamp_value(conn: &Connection, repo_id: &str) -> anyhow::Result<String> {
+    let history_key =
+        crate::index::git_history::history_freshness_key(conn, repo_id)?.unwrap_or_default();
+    Ok(format!("{history_key}:{COUPLING_PARAMS_VERSION}"))
+}
+
+fn coupling_stamp_current(conn: &Connection, repo_id: &str) -> anyhow::Result<bool> {
+    let stored = repo_meta(conn, repo_id, COUPLING_STAMP_META)?;
+    Ok(stored.as_deref() == Some(coupling_stamp_value(conn, repo_id)?.as_str()))
+}
+
+/// Full recompute for one repo: read the window, accumulate pair + endpoint counts in memory, prune
+/// (support + lift floors — both pure git history), then `DELETE` + batched `INSERT` + stamp in one
+/// transaction. Never patches incrementally — the window slides under append and a history
+/// full-replace invalidates everything anyway, so a bounded full recompute is the simple correct
+/// choice (see the module header).
+pub(crate) fn recompute_couplings(
+    conn: &Connection,
+    repo_id: &str,
+    now_ms: i64,
+) -> anyhow::Result<()> {
+    // Stamp value is captured against the CURRENT head before we write, so a head move mid-flight
+    // is caught by the next read (this recompute stamps the head it actually read).
+    let stamp = coupling_stamp_value(conn, repo_id)?;
+
+    // The window size actually used (shallow repos have fewer commits) — the base-rate population N
+    // for lift, counted from the eligible-commit CTE directly (by `changed_file_count`). Pure git
+    // history, matching the accumulation below.
+    let window_commit_count = eligible_window_commit_count(conn, repo_id)?;
+
+    let (pairs, path_window_count, paths) = accumulate_window_pairs(conn, repo_id)?;
+
+    let surviving = prune_pairs(pairs, &path_window_count, window_commit_count);
+
+    let tx = conn.unchecked_transaction()?;
+    conn.execute("DELETE FROM git_change_couplings WHERE repo_id = ?1", params![repo_id])?;
+    {
+        let mut insert = conn.prepare(
+            "INSERT INTO git_change_couplings(
+                 repo_id, path_a, path_b, co_change_count, path_a_change_count,
+                 path_b_change_count, window_commit_count, last_co_change_at_s, computed_at_ms
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+        )?;
+        for pair in &surviving {
+            // Canonicalize by PATH STRING (the `path_a < path_b` BINARY invariant), not by interned
+            // id — the interner assigns ids in first-seen order, which is unrelated to path order.
+            let path_lo = &paths[pair.lo as usize];
+            let path_hi = &paths[pair.hi as usize];
+            let (path_a, id_a, path_b, id_b) = if path_lo < path_hi {
+                (path_lo, pair.lo, path_hi, pair.hi)
+            } else {
+                (path_hi, pair.hi, path_lo, pair.lo)
+            };
+            let a_count = path_window_count.get(&id_a).copied().unwrap_or(0);
+            let b_count = path_window_count.get(&id_b).copied().unwrap_or(0);
+            insert.execute(params![
+                repo_id,
+                path_a,
+                path_b,
+                pair.count,
+                a_count,
+                b_count,
+                window_commit_count,
+                pair.last_at_s,
+                now_ms,
+            ])?;
+        }
+    }
+    set_repo_meta(conn, repo_id, COUPLING_STAMP_META, &stamp)?;
+    tx.commit()?;
+    Ok(())
+}
+
+/// Count the eligible commits in the window (`changed_file_count BETWEEN 2 AND cap`, capped at
+/// [`COUPLING_WINDOW_COMMITS`]) — the base-rate population N, a pure function of git history (no
+/// `files` dependency).
+fn eligible_window_commit_count(conn: &Connection, repo_id: &str) -> anyhow::Result<i64> {
+    let count: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM (
+             SELECT hash FROM git_commits
+             WHERE repo_id = ?1 AND changed_file_count BETWEEN 2 AND ?2
+             ORDER BY committed_at_s DESC, hash DESC
+             LIMIT ?3
+         )",
+        params![repo_id, MAX_COUPLING_COMMIT_FILES as i64, COUPLING_WINDOW_COMMITS],
+        |row| row.get(0),
+    )?;
+    Ok(count)
+}
+
+/// A canonicalized (by interned id) unordered pair with its window counts.
+struct SurvivingPair {
+    lo: u32,
+    hi: u32,
+    count: i64,
+    last_at_s: i64,
+}
+
+/// Stream the window rows grouped per commit (mirroring `co_touch_pairs`' streaming loop) and
+/// accumulate: `HashMap<(lo, hi), PairAcc>` for co-change counts and `HashMap<id, count>` for each
+/// endpoint's window touch count. Returns the two maps plus the id→path interner table.
+#[allow(clippy::type_complexity)]
+fn accumulate_window_pairs(
+    conn: &Connection,
+    repo_id: &str,
+) -> anyhow::Result<(HashMap<(u32, u32), PairAcc>, HashMap<u32, i64>, Vec<String>)> {
+    // PURE GIT HISTORY — deliberately does NOT join `files`. Co-change counts and endpoint counts
+    // read only `git_commits` / `git_file_changes`, so the stored table is a pure function of the
+    // history window (+ params), and the `history:params` stamp fully covers it. Generated /
+    // absent-at-HEAD paths DO enter the accumulator here (a generated partner is stored but not
+    // surfaced — the generated/existence filter is a READ-time concern in
+    // `coupled_files_for_path`). The storage bound is the lift floor at write, not a files-view
+    // filter. Repo isolation is the `changes.repo_id = ?1` predicate (V040).
+    let mut stmt = conn.prepare(
+        "
+        WITH window_commits AS (
+            SELECT hash, committed_at_s
+            FROM git_commits
+            WHERE repo_id = ?1
+              AND changed_file_count BETWEEN 2 AND ?2
+            ORDER BY committed_at_s DESC, hash DESC
+            LIMIT ?3
+        )
+        SELECT wc.hash, wc.committed_at_s, changes.path
+        FROM window_commits wc
+        JOIN git_file_changes changes
+          ON changes.commit_hash = wc.hash AND changes.repo_id = ?1
+        ORDER BY wc.committed_at_s DESC, wc.hash DESC
+        ",
+    )?;
+    let mut rows =
+        stmt.query(params![repo_id, MAX_COUPLING_COMMIT_FILES as i64, COUPLING_WINDOW_COMMITS])?;
+
+    let mut path_ids: HashMap<String, u32> = HashMap::new();
+    let mut paths: Vec<String> = Vec::new();
+    let mut pairs: HashMap<(u32, u32), PairAcc> = HashMap::new();
+    let mut path_window_count: HashMap<u32, i64> = HashMap::new();
+
+    let mut current_hash = String::new();
+    let mut current_at_s: i64 = 0;
+    let mut commit_ids: Vec<u32> = Vec::new();
+
+    while let Some(row) = rows.next()? {
+        let hash: String = row.get(0)?;
+        let at_s: i64 = row.get(1)?;
+        let path: String = row.get(2)?;
+        if current_hash.is_empty() {
+            current_hash = hash.clone();
+            current_at_s = at_s;
+        }
+        if hash != current_hash {
+            flush_commit(&mut pairs, &mut path_window_count, &mut commit_ids, current_at_s);
+            current_hash = hash;
+            current_at_s = at_s;
+        }
+        let id = intern_path(&mut path_ids, &mut paths, path);
+        commit_ids.push(id);
+    }
+    if !current_hash.is_empty() {
+        flush_commit(&mut pairs, &mut path_window_count, &mut commit_ids, current_at_s);
+    }
+
+    Ok((pairs, path_window_count, paths))
+}
+
+fn intern_path(path_ids: &mut HashMap<String, u32>, paths: &mut Vec<String>, path: String) -> u32 {
+    if let Some(&id) = path_ids.get(&path) {
+        return id;
+    }
+    let id = u32::try_from(paths.len()).expect("window path count exceeds u32");
+    path_ids.insert(path.clone(), id);
+    paths.push(path);
+    id
+}
+
+/// Fold one commit's file set into the accumulators, then clear the scratch buffer. All of the
+/// commit's paths reach here (pure git history — no files filter). Every path bumps its window
+/// touch count (the confidence denominator). Pairs are only generated for
+/// `2..=MAX_COUPLING_COMMIT_FILES` distinct paths; the upper bound mirrors the `changed_file_count`
+/// window gate and the `< 2` bound is a defensive guard (a windowed commit already has `>= 2`
+/// change rows).
+fn flush_commit(
+    pairs: &mut HashMap<(u32, u32), PairAcc>,
+    path_window_count: &mut HashMap<u32, i64>,
+    commit_ids: &mut Vec<u32>,
+    at_s: i64,
+) {
+    commit_ids.sort_unstable();
+    commit_ids.dedup();
+    for &id in commit_ids.iter() {
+        *path_window_count.entry(id).or_insert(0) += 1;
+    }
+    let n = commit_ids.len();
+    if (2..=MAX_COUPLING_COMMIT_FILES).contains(&n) {
+        for left in 0..n {
+            for right in (left + 1)..n {
+                // commit_ids is sorted asc + deduped, so (lo, hi) is canonical by interned id.
+                let acc = pairs
+                    .entry((commit_ids[left], commit_ids[right]))
+                    .or_insert(PairAcc { count: 0, last_at_s: i64::MIN });
+                acc.count += 1;
+                acc.last_at_s = acc.last_at_s.max(at_s);
+            }
+        }
+    }
+    commit_ids.clear();
+}
+
+/// Prune to the persisted set with the two PURE-GIT-HISTORY storage floors: `co >=
+/// MIN_COUPLING_SUPPORT` AND `lift = co * N / (a_count * b_count) >= MIN_COUPLING_LIFT`. The lift
+/// floor is what bounds the table without a per-file cap: a hub file (`a_count ~= N`) satisfies
+/// `lift = co / b_count <= 1` for every partner, so its pairs are dropped here — no per-file
+/// ranking (so nothing can mis-rank an unsurfaced partner), no files-view dependence.
+fn prune_pairs(
+    pairs: HashMap<(u32, u32), PairAcc>,
+    path_window_count: &HashMap<u32, i64>,
+    window_commit_count: i64,
+) -> Vec<SurvivingPair> {
+    pairs
+        .into_iter()
+        .filter(|((lo, hi), acc)| {
+            if acc.count < MIN_COUPLING_SUPPORT {
+                return false;
+            }
+            let a_count = path_window_count.get(lo).copied().unwrap_or(0);
+            let b_count = path_window_count.get(hi).copied().unwrap_or(0);
+            let denom = a_count as f64 * b_count as f64;
+            let lift = if denom > 0.0 {
+                acc.count as f64 * window_commit_count as f64 / denom
+            } else {
+                0.0
+            };
+            lift >= MIN_COUPLING_LIFT
+        })
+        .map(|((lo, hi), acc)| SurvivingPair { lo, hi, count: acc.count, last_at_s: acc.last_at_s })
+        .collect()
+}
+
+/// Given a file `path` in `repo_id`, the top coupled files ranked by asymmetric confidence
+/// `P(other | path)`, then truncated to `limit`. This is the ONLY files-view touch: the partner
+/// join applies the generated / existence filter (a generated or absent-at-HEAD partner is stored
+/// but not surfaced) and dedups the bare-view multi-row-per-path (finding 4). The stored rows
+/// already pass the lift floor (enforced at write), so the read-time lift check is a redundant
+/// defense.
+pub(crate) fn coupled_files_for_path(
+    conn: &Connection,
+    repo_id: &str,
+    path: &str,
+    limit: u32,
+) -> anyhow::Result<Vec<CoupledFile>> {
+    // `git_change_couplings` is direct `repo_id`-scoped (V040): filter on repo_id so a fork sharing
+    // commit hashes never surfaces a sibling repo's couplings. The partner subquery is the sole
+    // files-view dependence and does two READ-time jobs: (1) `WHERE generated = 0` drops a partner
+    // that is generated or absent-at-HEAD (stored but not surfaceable); (2) `GROUP BY path`
+    // collapses the BARE repo-generation `files` view's MULTIPLE rows per path (distinct commit_sha
+    // / worktree_id at one live generation — the MCP `call_tool` read path, `write_repo_generation_
+    // view`, no dedup) to one row, so a plain join can't emit a duplicate partner that eats `limit`
+    // (finding 4). `c` already has exactly one row per (repo, path_a, path_b).
+    let mut stmt = conn.prepare(
+        "
+        SELECT
+            CASE WHEN c.path_a = ?2 THEN c.path_b ELSE c.path_a END AS other_path,
+            c.co_change_count,
+            CASE WHEN c.path_a = ?2 THEN c.path_a_change_count
+                 ELSE c.path_b_change_count END                     AS this_count,
+            c.path_a_change_count,
+            c.path_b_change_count,
+            c.window_commit_count,
+            c.last_co_change_at_s,
+            files.language,
+            files.kind
+        FROM git_change_couplings c
+        JOIN (SELECT path, MIN(language) AS language, MIN(kind) AS kind
+              FROM files WHERE generated = 0 GROUP BY path)
+             files ON files.path = CASE WHEN c.path_a = ?2 THEN c.path_b ELSE c.path_a END
+        WHERE c.repo_id = ?1
+          AND (c.path_a = ?2 OR c.path_b = ?2)
+          AND c.co_change_count >= ?3
+        ",
+    )?;
+    let rows = stmt.query_map(params![repo_id, path, MIN_COUPLING_SUPPORT], |row| {
+        Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, i64>(1)?,
+            row.get::<_, i64>(2)?,
+            row.get::<_, i64>(3)?,
+            row.get::<_, i64>(4)?,
+            row.get::<_, i64>(5)?,
+            row.get::<_, i64>(6)?,
+            row.get::<_, String>(7)?,
+            row.get::<_, String>(8)?,
+        ))
+    })?;
+
+    let mut out = Vec::new();
+    for row in rows {
+        let (other_path, co, this_count, a_count, b_count, window, last_at_s, language, kind) =
+            row?;
+        let confidence = if this_count > 0 { co as f64 / this_count as f64 } else { 0.0 };
+        let denom = a_count as f64 * b_count as f64;
+        let lift = if denom > 0.0 { co as f64 * window as f64 / denom } else { 0.0 };
+        // Redundant defense: the lift floor is the WRITE-time storage bound, so every stored row
+        // already passes it. Kept so a read stays correct even if rows predate a floor change that
+        // hasn't recomputed yet (the params-version stamp forces that recompute on the next read).
+        if lift < MIN_COUPLING_LIFT {
+            continue;
+        }
+        out.push(CoupledFile {
+            other_path,
+            co_change_count: co,
+            this_change_count: this_count,
+            window_commit_count: window,
+            confidence,
+            lift,
+            last_co_change_at_s: last_at_s,
+            language,
+            kind,
+        });
+    }
+    out.sort_by(|a, b| {
+        b.confidence
+            .partial_cmp(&a.confidence)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| b.co_change_count.cmp(&a.co_change_count))
+            .then_with(|| a.other_path.cmp(&b.other_path))
+    });
+    out.truncate(usize::try_from(limit).unwrap_or(usize::MAX));
+    Ok(out)
+}

--- a/crates/rag-rat-core/src/index/git_history.rs
+++ b/crates/rag-rat-core/src/index/git_history.rs
@@ -496,6 +496,25 @@ fn history_cursors(conn: &Connection, repo_id: &str) -> anyhow::Result<Option<Hi
     Ok(raw_history_cursors(conn, repo_id)?.filter(|cursor| cursor.complete))
 }
 
+/// The STORED git-history freshness key for `repo_id` — the exact `(head, root_key, shallow,
+/// complete)` cursor snapshot `is_history_current` keys on — serialized to a stable string. A
+/// derived table computed FROM `git_commits` / `git_file_changes` (change_coupling) folds this into
+/// its own freshness stamp so a history REWRITE at the same HEAD (shallow deepen, subtree re-point,
+/// a best-effort reload flipping `complete`) — which moves these cursors even though HEAD does not
+/// — also invalidates the derived table. `None` when any cursor meta is unset (no committed history
+/// snapshot yet), which a derived table treats as an empty key.
+pub(crate) fn history_freshness_key(
+    conn: &Connection,
+    repo_id: &str,
+) -> anyhow::Result<Option<String>> {
+    Ok(raw_history_cursors(conn, repo_id)?.map(|cursor| {
+        format!(
+            "{}|{}|{}|{}",
+            cursor.head, cursor.root_key, cursor.shallow as u8, cursor.complete as u8
+        )
+    }))
+}
+
 fn expected_history_cursors_match(
     conn: &Connection,
     repo_id: &str,

--- a/crates/rag-rat-core/src/index/mod.rs
+++ b/crates/rag-rat-core/src/index/mod.rs
@@ -14,6 +14,7 @@ pub mod walker;
 pub mod consolidate;
 
 mod adoption_hints;
+pub(crate) mod change_coupling;
 pub(crate) mod chunk_text_store;
 pub(crate) mod clones;
 mod discovery;

--- a/crates/rag-rat-core/src/index/query_api/graph.rs
+++ b/crates/rag-rat-core/src/index/query_api/graph.rs
@@ -740,6 +740,14 @@ impl IndexDatabase {
         if options.include_tests || options.include_docs || options.include_text_fallback {
             self.ensure_fts_fresh()?;
         }
+        // Change coupling is a DerivedIndex table (windowed file-pair co-change): lazily self-heal
+        // it on read, exactly where `ensure_fts_fresh` heals the text sections — but only
+        // when the git evidence lane is requested (the same `include_git` gate the coupling
+        // section rides). Kept OFF the index pass's terminal transaction; the read path is
+        // its recompute trigger.
+        if options.include_git {
+            self.ensure_coupling_fresh()?;
+        }
         // Surface the `Compiler` tier on impact's direct graph neighbors too (same read-side JOIN
         // as trace_callees/find_callers). The enrichment is now injected INTO the builder so it
         // runs over the OVERFETCHED candidate set before the re-rank + limit truncation (#82
@@ -792,11 +800,27 @@ impl IndexDatabase {
             .chain(report.tests_touching_symbol_path.iter())
             .chain(report.docs_mentioning_symbol_path.iter())
             .chain(report.text_fallback_hits.iter())
+            // A co-changed file that's dirty-since-index must count toward `stale_files` too, else
+            // the caller trusts a surface whose coupling lane has moved under it (#566 finding 2).
+            .chain(report.files_co_changed_with_symbol_path.iter())
         {
             result_paths.push(item.path.clone());
         }
         report.completeness_and_caveats.stale_files =
             u64::try_from(self.stale_source_paths(&result_paths)?.len()).unwrap_or(u64::MAX);
         Ok(report)
+    }
+
+    /// Lazy self-heal for the windowed change-coupling table (V056) — the DerivedIndex twin of
+    /// `ensure_fts_fresh`: recompute from `git_file_changes` when the `git_coupling_stamp` lags the
+    /// git-history freshness key (cursor snapshot) + params version, else a cheap stamp-only no-op.
+    /// The stored table is pure git-history, so a files-view change never triggers this.
+    /// Write-bearing (same posture as `ensure_fts_fresh` / `store_blame`), so it stays OFF the
+    /// index pass's terminal transaction.
+    pub(crate) fn ensure_coupling_fresh(&self) -> anyhow::Result<()> {
+        crate::index::change_coupling::ensure_coupling_fresh(
+            self.storage.connection(),
+            crate::index::now_ms(),
+        )
     }
 }

--- a/crates/rag-rat-core/src/index/schema/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema/migrations.rs
@@ -1190,6 +1190,7 @@ pub(crate) fn known_version(migrations: &[AppliedMigration]) -> u32 {
             MIGRATION_053_ID => Some(53),
             MIGRATION_054_ID => Some(54),
             MIGRATION_055_ID => Some(55),
+            MIGRATION_056_ID => Some(56),
             _ => None,
         })
         .max()
@@ -1254,6 +1255,7 @@ pub(crate) fn known_migration(id: &str) -> bool {
             | MIGRATION_053_ID
             | MIGRATION_054_ID
             | MIGRATION_055_ID
+            | MIGRATION_056_ID
             | DIRTY_MIGRATION_ID
     )
 }
@@ -1315,6 +1317,7 @@ pub(crate) fn migration_checksum_mismatch(migration: &AppliedMigration) -> bool 
         MIGRATION_053_ID => migration.checksum != MIGRATION_053_CHECKSUM,
         MIGRATION_054_ID => migration.checksum != MIGRATION_054_CHECKSUM,
         MIGRATION_055_ID => migration.checksum != MIGRATION_055_CHECKSUM,
+        MIGRATION_056_ID => migration.checksum != MIGRATION_056_CHECKSUM,
         _ => false,
     }
 }
@@ -3694,6 +3697,53 @@ pub(crate) fn apply_oplog_device_identity(conn: &Connection) -> rusqlite::Result
 pub(crate) fn apply_binding_downgrade_marker(conn: &Connection) -> rusqlite::Result<()> {
     add_column_if_missing(conn, "repo_memory_bindings", "downgrade_pending_at_ms", "INTEGER")?;
     Ok(())
+}
+
+/// V056 (#566): the windowed file-pair change-coupling table, derived from `git_file_changes` over
+/// a bounded recency window of eligible commits. INVARIANTS:
+///  * PURE GIT-HISTORY table: the stored rows are a function of `(git-history window, params)` ONLY
+///    — no `files`-view dependence (generation / generated flag / worktree scope). This makes the
+///    freshness stamp complete by construction; the generated / existence filter is a READ-time
+///    concern (a generated or absent-at-HEAD partner is stored but not surfaced).
+///  * `path_a < path_b` (BINARY) — exactly ONE symmetric row per unordered pair; the two
+///    directional confidences (`P(B|A)` / `P(A|B)`) are derived at READ time from the endpoint
+///    counts.
+///  * DerivedIndex posture: rows are wholesale `DELETE` + `INSERT`ed per recompute inside one
+///    transaction, stamped via `repo_meta` `'git_coupling_stamp'` (=
+///    `history_freshness_key:params`). Rows are never patched incrementally; a stale/absent stamp
+///    means "recompute or treat as absent", never "trust the rows". No FK to `git_file_changes` /
+///    `git_commits`: the row aggregates over commits and must survive a history full-replace
+///    between recompute passes (the stamp, not row integrity, is the freshness authority).
+///  * WRITE-time storage floors (both pure git-history): `co_change_count >= MIN_COUPLING_SUPPORT`
+///    AND `lift = co * N / (a_count * b_count) >= MIN_COUPLING_LIFT`. The lift floor bounds the
+///    table without a per-file cap — a hub file scores `lift ~= 1` with everything and is dropped
+///    here.
+///  * Direct `repo_id` scope (V040): every reader joins AND filters on `repo_id` — a fork sharing
+///    commit hashes must never surface a sibling repo's couplings. The PK covers `(repo_id,
+///    path_a)` lookups; the secondary index covers `(repo_id, path_b)`, so one `OR` query serves
+///    both directions of the symmetric row.
+///
+/// Additive + idempotent (`CREATE ... IF NOT EXISTS`); a fresh DB creates it empty and the first
+/// git-inclusive `impact_surface` read fills it.
+pub(crate) fn apply_git_change_couplings(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "
+        CREATE TABLE IF NOT EXISTS git_change_couplings(
+            repo_id TEXT NOT NULL,
+            path_a TEXT NOT NULL,
+            path_b TEXT NOT NULL,
+            co_change_count INTEGER NOT NULL,
+            path_a_change_count INTEGER NOT NULL,
+            path_b_change_count INTEGER NOT NULL,
+            window_commit_count INTEGER NOT NULL,
+            last_co_change_at_s INTEGER NOT NULL,
+            computed_at_ms INTEGER NOT NULL,
+            PRIMARY KEY(repo_id, path_a, path_b)
+        ) STRICT;
+        CREATE INDEX IF NOT EXISTS idx_git_change_couplings_b
+            ON git_change_couplings(repo_id, path_b);
+        ",
+    )
 }
 
 pub(crate) fn apply_symbols_is_test(conn: &Connection) -> rusqlite::Result<()> {

--- a/crates/rag-rat-core/src/index/schema/mod.rs
+++ b/crates/rag-rat-core/src/index/schema/mod.rs
@@ -19,7 +19,7 @@ pub use registry::{LEGACY_REPO_ID, register_repo, register_repo_read_only};
 use rusqlite::{Connection, OptionalExtension, params};
 use serde::Serialize;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 55;
+pub const LATEST_SCHEMA_VERSION: u32 = 56;
 
 /// Every oracle-DERIVED persisted table — the outputs an `oracle run` writes that must OUTLIVE a
 /// reindex.
@@ -382,6 +382,16 @@ const MIGRATION_055_DESCRIPTION: &str =
      instead of stamping, and only a SECOND consecutive gone observation persists the downgrade — \
      so a single torn observation (a validate racing a rebuild window, or a sweep from a narrower \
      checkout) cannot flip a healthy anchor to gone and hand doctor destructive advice";
+const MIGRATION_056_ID: &str = "056_git_change_couplings";
+const MIGRATION_056_CHECKSUM: &str = "sha256:rag-rat-git-change-couplings-v56";
+const MIGRATION_056_DESCRIPTION: &str =
+    "Add git_change_couplings (#566), the windowed file-pair change-coupling table derived from \
+     git_file_changes: one STRICT symmetric row per unordered pair (path_a < path_b) holding raw \
+     co-change + endpoint counts over a bounded recency window of eligible commits, keyed \
+     (repo_id, path_a, path_b) with a secondary (repo_id, path_b) index. A DerivedIndex table \
+     (repo_id-scoped, no FK to the volatile history rows): wholesale-recomputed lazily on the \
+     impact_surface read path against a repo_meta 'git_coupling_stamp', never patched \
+     incrementally. Fresh + empty on create; the first git-inclusive impact read fills it";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -853,6 +863,12 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         checksum: MIGRATION_055_CHECKSUM,
         description: MIGRATION_055_DESCRIPTION,
         apply: apply_binding_downgrade_marker,
+    },
+    Migration {
+        id: MIGRATION_056_ID,
+        checksum: MIGRATION_056_CHECKSUM,
+        description: MIGRATION_056_DESCRIPTION,
+        apply: apply_git_change_couplings,
     },
 ];
 

--- a/crates/rag-rat-core/src/index/schema/registry.rs
+++ b/crates/rag-rat-core/src/index/schema/registry.rs
@@ -47,6 +47,13 @@ const DIRECT_SCOPED_ADOPTION_TABLES: &[&str] = &[
     "github_review_comments",
     "github_ref_sync",
     "github_fts",
+    // V056 (#566) derived change-coupling table: standalone, direct `repo_id`, no FK children, so
+    // a LocalOnly→Portable adoption re-points its rows here (moving them together with the
+    // `git_coupling_stamp` repo_meta so the derived table stays consistent + fresh), and the
+    // late-merge path DELETEs the retiring id's rows. Without this the stamp would move but the
+    // rows strand — `ensure_coupling_fresh` would then see a matching stamp and serve an empty
+    // section.
+    "git_change_couplings",
 ];
 
 /// The periphery tables that gain a `repo_id` column in the phase-A5 periphery-scoping migration

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/change_coupling.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/change_coupling.rs
@@ -1,0 +1,818 @@
+//! Tests for the windowed file-pair change-coupling pass (`crate::index::change_coupling`, V056,
+//! #566). The STORED table is a pure function of `(git-history window, params)` — no `files`-view
+//! dependence — so the compute-level fixtures are direct synthetic inserts into `git_commits` /
+//! `git_file_changes` on a raw connection. The generated / existence filter and the dedup are
+//! READ-time (`coupled_files_for_path`), so the read-level and integration tests also seed `files`.
+
+use rusqlite::{Connection, params};
+
+use super::*;
+use crate::index::change_coupling::{
+    COUPLING_WINDOW_COMMITS, coupled_files_for_path, ensure_coupling_fresh, recompute_couplings,
+};
+
+/// The active repo id a fresh `schema::apply` connection resolves to (the legacy placeholder), used
+/// for the single-repo fixtures whose inserts default `repo_id` to the same value.
+fn repo() -> String {
+    crate::index::schema::LEGACY_REPO_ID.to_string()
+}
+
+fn fresh_conn() -> Connection {
+    let conn = Connection::open_in_memory().unwrap();
+    crate::index::schema::apply(&conn).unwrap();
+    conn
+}
+
+fn add_file(conn: &Connection, path: &str, generated: i64) {
+    conn.execute(
+        "INSERT INTO files(path, language, kind, sha256, modified_at_ms, indexed_at_ms, \
+         generated) VALUES (?1, 'rust', 'source', 'sha', 0, 0, ?2)",
+        params![path, generated],
+    )
+    .unwrap();
+}
+
+/// Insert a non-generated `files` row for `path` scoped to a specific `commit_sha` — lets a test
+/// seed MULTIPLE `main.files` rows for the same path at the same live generation (what the bare
+/// repo-generation view serves), which the `UNIQUE(repo_id, path, commit_sha, worktree_id,
+/// generation)` key allows.
+fn add_file_at_commit(conn: &Connection, path: &str, commit_sha: &str) {
+    conn.execute(
+        "INSERT INTO files(path, language, kind, sha256, modified_at_ms, indexed_at_ms, \
+         generated, commit_sha) VALUES (?1, 'rust', 'source', 'sha', 0, 0, 0, ?2)",
+        params![path, commit_sha],
+    )
+    .unwrap();
+}
+
+/// Insert a commit for `repo_id` touching `paths` (each recorded as a change row).
+/// `changed_file_count` is set to the change-row count, mirroring `insert_history_rows`, so the
+/// eligibility filter reads a realistic value. An empty `paths` slice models a MERGE tip
+/// (`changed_file_count = 0`, no rows).
+fn add_commit(conn: &Connection, repo_id: &str, hash: &str, committed_at_s: i64, paths: &[&str]) {
+    add_commit_counted(conn, repo_id, hash, committed_at_s, paths, paths.len() as i64);
+}
+
+/// Like [`add_commit`] but forces `changed_file_count` independently of the recorded rows — used to
+/// exercise the mega-commit gate at the exact boundary.
+fn add_commit_counted(
+    conn: &Connection,
+    repo_id: &str,
+    hash: &str,
+    committed_at_s: i64,
+    paths: &[&str],
+    changed_file_count: i64,
+) {
+    conn.execute(
+        "INSERT INTO git_commits(hash, author_name, author_email, authored_at_s, committed_at_s, \
+         subject, body, changed_file_count, repo_id) VALUES (?1, 'a', 'a@b', ?2, ?2, 's', '', ?3, \
+         ?4)",
+        params![hash, committed_at_s, changed_file_count, repo_id],
+    )
+    .unwrap();
+    for path in paths {
+        conn.execute(
+            "INSERT INTO git_file_changes(commit_hash, path, additions, deletions, change_kind, \
+             repo_id) VALUES (?1, ?2, 0, 0, 'modified', ?3)",
+            params![hash, path, repo_id],
+        )
+        .unwrap();
+    }
+}
+
+/// Add `count` distinct 2-file filler commits (each a unique pair → co=1, dropped by the support
+/// floor) starting at `start_ts`, purely to raise the eligible-window count N so a real pair's
+/// `lift = co * N / (a * b)` clears the floor. Filler paths embed `start_ts` so repeated calls
+/// never collide into a surviving pair; they are never asserted on.
+fn add_fillers(conn: &Connection, repo_id: &str, count: usize, start_ts: i64) {
+    for i in 0..count {
+        add_commit(conn, repo_id, &format!("fill-{start_ts}-{i}"), start_ts + i as i64, &[
+            &format!("fa-{start_ts}-{i}.rs"),
+            &format!("fb-{start_ts}-{i}.rs"),
+        ]);
+    }
+}
+
+/// `(path_a, path_b, co, a_count, b_count, window, last_at_s)` rows for a repo, ordered by pair.
+fn coupling_rows(
+    conn: &Connection,
+    repo_id: &str,
+) -> Vec<(String, String, i64, i64, i64, i64, i64)> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT path_a, path_b, co_change_count, path_a_change_count, path_b_change_count, \
+             window_commit_count, last_co_change_at_s FROM git_change_couplings WHERE repo_id = \
+             ?1 ORDER BY path_a, path_b",
+        )
+        .unwrap();
+    let rows = stmt
+        .query_map(params![repo_id], |r| {
+            Ok((
+                r.get::<_, String>(0)?,
+                r.get::<_, String>(1)?,
+                r.get::<_, i64>(2)?,
+                r.get::<_, i64>(3)?,
+                r.get::<_, i64>(4)?,
+                r.get::<_, i64>(5)?,
+                r.get::<_, i64>(6)?,
+            ))
+        })
+        .unwrap();
+    rows.map(|r| r.unwrap()).collect()
+}
+
+/// Insert a `git_change_couplings` row DIRECTLY, bypassing recompute and its write-time floors, so
+/// a read-path test can pin behavior on a row it fully controls — a row that predates a lift-floor
+/// increase, or a crafted tie set for the read ordering. `path_a < path_b` (the stored invariant)
+/// is the caller's responsibility.
+fn insert_coupling(
+    conn: &Connection,
+    repo_id: &str,
+    path_a: &str,
+    path_b: &str,
+    counts: (i64, i64, i64, i64), // (co, a_count, b_count, window)
+) {
+    let (co, a_count, b_count, window) = counts;
+    conn.execute(
+        "INSERT INTO git_change_couplings(repo_id, path_a, path_b, co_change_count, \
+         path_a_change_count, path_b_change_count, window_commit_count, last_co_change_at_s, \
+         computed_at_ms) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 0, 0)",
+        params![repo_id, path_a, path_b, co, a_count, b_count, window],
+    )
+    .unwrap();
+}
+
+/// The read re-applies the lift floor as a defense (the write floor is the storage authority, but a
+/// row can predate a floor increase before its params-version recompute lands). A stored pair whose
+/// lift is below the floor must be filtered at read, never surfaced.
+#[test]
+fn read_drops_a_stored_pair_below_the_lift_floor() {
+    let conn = fresh_conn();
+    let repo = repo();
+    add_file(&conn, "b.rs", 0); // partner needs a non-generated `files` row for the read join
+    // lift = co * window / (a * b) = 2 * 10 / (10 * 10) = 0.2, below MIN_COUPLING_LIFT (1.5).
+    insert_coupling(&conn, &repo, "a.rs", "b.rs", (2, 10, 10, 10));
+    assert!(
+        coupled_files_for_path(&conn, &repo, "a.rs", 10).unwrap().is_empty(),
+        "a stored row below the lift floor must be dropped at read, not surfaced"
+    );
+}
+
+/// The read comparator is deterministic — confidence DESC, then co DESC, then path ASC — so the
+/// `truncate(limit)` top-K is stable regardless of row/scan order. `pa`/`pb` tie on (confidence,
+/// co) and split by path; `pc` outranks both on confidence. (`aaa.rs` sorts before every partner,
+/// so it is `path_a` in each row and its count is `path_a_change_count`.)
+#[test]
+fn read_orders_partners_by_confidence_then_co_then_path() {
+    let conn = fresh_conn();
+    let repo = repo();
+    for p in ["pa.rs", "pb.rs", "pc.rs"] {
+        add_file(&conn, p, 0);
+    }
+    insert_coupling(&conn, &repo, "aaa.rs", "pc.rs", (6, 8, 6, 100)); // confidence 0.75
+    insert_coupling(&conn, &repo, "aaa.rs", "pa.rs", (4, 8, 8, 100)); // confidence 0.50, co 4
+    insert_coupling(&conn, &repo, "aaa.rs", "pb.rs", (4, 8, 4, 100)); // confidence 0.50, co 4 (tie)
+    let got: Vec<String> = coupled_files_for_path(&conn, &repo, "aaa.rs", 10)
+        .unwrap()
+        .into_iter()
+        .map(|c| c.other_path)
+        .collect();
+    assert_eq!(got, vec!["pc.rs", "pa.rs", "pb.rs"]);
+}
+
+/// A window commit whose change rows collapse to fewer than two DISTINCT paths (here
+/// `changed_file_count` is eligible at 2 but only one path row is recorded — a count/row mismatch)
+/// yields no pair: the `(2..=MAX_COUPLING_COMMIT_FILES).contains(&n)` guard's false arm.
+#[test]
+fn commit_with_fewer_than_two_distinct_paths_contributes_no_pairs() {
+    let conn = fresh_conn();
+    let repo = repo();
+    add_commit_counted(&conn, &repo, "one", 10, &["only.rs"], 2);
+    add_fillers(&conn, &repo, 2, 100);
+    recompute_couplings(&conn, &repo, 1).unwrap();
+    assert!(
+        coupling_rows(&conn, &repo).is_empty(),
+        "a commit with a single distinct path must produce no coupling pairs"
+    );
+}
+
+/// Exact support / endpoint counts / recency for a scripted commit set. Pins the derived confidence
+/// (asymmetric) and lift, computed from the stored counts. Fillers lift the surviving pair over the
+/// write-time lift floor without touching its endpoint counts.
+#[test]
+fn exact_support_confidence_lift_from_scripted_commits() {
+    let conn = fresh_conn();
+    let repo = repo();
+    // a,b co-change twice; a also touches x once (so a_count=3 != b_count=2 — asymmetric
+    // confidence). Two fillers raise N to 5, so (a,b)'s lift = 2*5/(3*2) = 1.667 clears the floor.
+    add_commit(&conn, &repo, "c1", 10, &["a.rs", "b.rs"]);
+    add_commit(&conn, &repo, "c2", 20, &["a.rs", "b.rs"]);
+    add_commit(&conn, &repo, "c3", 30, &["a.rs", "x.rs"]);
+    add_fillers(&conn, &repo, 2, 100);
+
+    recompute_couplings(&conn, &repo, 777).unwrap();
+
+    // (a,x) is support 1 and fillers are support 1; only (a,b) clears BOTH the support and lift
+    // floors at write.
+    let rows = coupling_rows(&conn, &repo);
+    assert_eq!(rows.len(), 1, "only (a,b) clears support>=2 AND lift>=1.5: {rows:?}");
+    let (path_a, path_b, co, a_count, b_count, window, last_at_s) = rows[0].clone();
+    assert_eq!((path_a.as_str(), path_b.as_str()), ("a.rs", "b.rs"), "canonical path order");
+    assert_eq!(co, 2, "co-changed in both {{a,b}} commits");
+    assert_eq!(a_count, 3, "a.rs touched c1,c2,c3");
+    assert_eq!(b_count, 2, "b.rs touched c1,c2");
+    assert_eq!(window, 5, "N = 3 real + 2 filler eligible commits");
+    assert_eq!(last_at_s, 20, "newest (a,b) co-change committed_at_s");
+
+    let confidence_a_to_b = co as f64 / a_count as f64; // 2/3
+    let confidence_b_to_a = co as f64 / b_count as f64; // 2/2
+    let lift = co as f64 * window as f64 / (a_count as f64 * b_count as f64); // 2*5/(3*2)
+    assert!((confidence_a_to_b - 2.0 / 3.0).abs() < 1e-9);
+    assert!((confidence_b_to_a - 1.0).abs() < 1e-9);
+    assert!((lift - 10.0 / 6.0).abs() < 1e-9, "lift = {lift}");
+}
+
+/// The lift floor is the WRITE-time storage bound: a below-threshold pair is never stored (nothing
+/// to read), while an above-threshold pair is stored and surfaced.
+#[test]
+fn lift_floor_drops_below_threshold_pairs_and_keeps_above() {
+    // Below the floor: a is a mini-hub (in every commit), so lift(a,b) = 2*4/(4*2) = 1.0 → the pair
+    // is dropped AT WRITE. Nothing is stored, so nothing reads back.
+    let conn = fresh_conn();
+    let repo = repo();
+    add_commit(&conn, &repo, "c1", 10, &["a.rs", "b.rs"]);
+    add_commit(&conn, &repo, "c2", 20, &["a.rs", "b.rs"]);
+    add_commit(&conn, &repo, "c3", 30, &["a.rs", "c.rs"]);
+    add_commit(&conn, &repo, "c4", 40, &["a.rs", "c.rs"]);
+    recompute_couplings(&conn, &repo, 1).unwrap();
+    assert!(coupling_rows(&conn, &repo).is_empty(), "hub pairs (lift 1.0) dropped at write");
+    assert!(coupled_files_for_path(&conn, &repo, "a.rs", 10).unwrap().is_empty());
+
+    // Above the floor: a,b co-change exclusively; fillers raise N to 4 → lift = 2.0.
+    let conn = fresh_conn();
+    add_file(&conn, "a.rs", 0);
+    add_file(&conn, "b.rs", 0);
+    add_commit(&conn, &repo, "c1", 10, &["a.rs", "b.rs"]);
+    add_commit(&conn, &repo, "c2", 20, &["a.rs", "b.rs"]);
+    add_fillers(&conn, &repo, 2, 100);
+    recompute_couplings(&conn, &repo, 1).unwrap();
+    let coupled = coupled_files_for_path(&conn, &repo, "a.rs", 10).unwrap();
+    assert_eq!(coupled.len(), 1, "one coupled file above the floor: {coupled:?}");
+    assert_eq!(coupled[0].other_path, "b.rs");
+    assert!((coupled[0].confidence - 1.0).abs() < 1e-9, "confidence(a->b) = 2/2");
+    assert!((coupled[0].lift - 2.0).abs() < 1e-9, "lift = 2*4/(2*2) = 2.0");
+    assert_eq!(coupled[0].window_commit_count, 4, "N = 2 real + 2 filler");
+}
+
+/// The LIFT FLOOR is the storage bound that replaces the per-file cap: a HUB file touched in ~all
+/// window commits yields NO stored pairs (each scores lift ~= 1), while a genuine high-lift
+/// low-count pair IS stored regardless of how few commits it spans. This is what makes dropping the
+/// per-file cap safe — no ranking, so nothing can mis-rank an unsurfaced partner.
+#[test]
+fn lift_floor_bounds_storage() {
+    let conn = fresh_conn();
+    let repo = repo();
+    let tx = conn.unchecked_transaction().unwrap();
+    // Hub H co-changes (support 2) with 10 distinct partners → 20 commits, so H is in 20 of the 22
+    // window commits. Each (H, Xi): co=2, a_count(H)=20, b_count(Xi)=2 → lift = 2*22/(20*2) = 1.1.
+    for i in 0..10 {
+        let partner = format!("x{i:02}.rs");
+        add_commit(&conn, &repo, &format!("h{i:02}a"), 10, &["hub.rs", &partner]);
+        add_commit(&conn, &repo, &format!("h{i:02}b"), 20, &["hub.rs", &partner]);
+    }
+    // A tight, low-count pair {p,q} co-changes exclusively → co=2, a=b=2, lift = 2*22/(2*2) = 11.
+    add_commit(&conn, &repo, "pq1", 30, &["p.rs", "q.rs"]);
+    add_commit(&conn, &repo, "pq2", 40, &["p.rs", "q.rs"]);
+    tx.commit().unwrap();
+
+    recompute_couplings(&conn, &repo, 1).unwrap();
+    let rows = coupling_rows(&conn, &repo);
+
+    // Every one of the hub's 10 partner pairs (lift 1.1 < 1.5) is dropped at write — no per-file
+    // cap.
+    assert!(
+        !rows.iter().any(|(a, b, ..)| a == "hub.rs" || b == "hub.rs"),
+        "the hub's pairs are pruned by the lift floor, not a cap: {rows:?}"
+    );
+    // The genuine high-lift pair survives, however few its commits.
+    assert_eq!(rows.len(), 1, "only the tight high-lift pair is stored: {rows:?}");
+    let (path_a, path_b, co, a_count, b_count, window) =
+        (&rows[0].0, &rows[0].1, rows[0].2, rows[0].3, rows[0].4, rows[0].5);
+    assert_eq!((path_a.as_str(), path_b.as_str()), ("p.rs", "q.rs"));
+    assert_eq!((co, a_count, b_count, window), (2, 2, 2, 22), "co=2, endpoints=2, N=22");
+    let lift = co as f64 * window as f64 / (a_count as f64 * b_count as f64);
+    assert!(lift >= 1.5, "the low-count pair's lift = {lift} clears the floor");
+}
+
+/// A 41-file commit contributes zero pairs (mega-commit exclusion); a 40-file commit contributes.
+#[test]
+fn mega_commit_excluded_but_max_files_commit_contributes() {
+    let conn = fresh_conn();
+    let repo = repo();
+    let mega: Vec<String> = (0..41).map(|i| format!("mega_{i:02}.rs")).collect();
+    let maxed: Vec<String> = (0..40).map(|i| format!("max_{i:02}.rs")).collect();
+    let mega_paths: Vec<&str> = mega.iter().map(String::as_str).collect();
+    let maxed_paths: Vec<&str> = maxed.iter().map(String::as_str).collect();
+    let tx = conn.unchecked_transaction().unwrap();
+    // Two identical commits per group so any surviving pair clears the support floor.
+    add_commit(&conn, &repo, "mega1", 10, &mega_paths);
+    add_commit(&conn, &repo, "mega2", 20, &mega_paths);
+    add_commit(&conn, &repo, "max1", 30, &maxed_paths);
+    add_commit(&conn, &repo, "max2", 40, &maxed_paths);
+    // Fillers raise N to 4 so each maxed pair's lift = 2*4/(2*2) = 2.0 clears the floor.
+    add_fillers(&conn, &repo, 2, 100);
+    tx.commit().unwrap();
+
+    recompute_couplings(&conn, &repo, 1).unwrap();
+    let rows = coupling_rows(&conn, &repo);
+
+    assert!(
+        !rows.iter().any(|(a, b, ..)| a.starts_with("mega_") || b.starts_with("mega_")),
+        "the 41-file commit contributes no pairs"
+    );
+    let maxed_rows =
+        rows.iter().filter(|(a, b, ..)| a.starts_with("max_") && b.starts_with("max_")).count();
+    assert_eq!(maxed_rows, 780, "C(40,2) = 780 surviving pairs from the eligible 40-file commit");
+    assert!(
+        rows.iter().any(|(a, b, ..)| a == "max_00.rs" && b == "max_01.rs"),
+        "a specific 40-file pair is present"
+    );
+}
+
+/// A merge tip (`changed_file_count = 0`, no change rows) contributes nothing and is excluded from
+/// the base-rate window count.
+#[test]
+fn merge_commit_contributes_nothing() {
+    let conn = fresh_conn();
+    let repo = repo();
+    add_commit(&conn, &repo, "real1", 10, &["a.rs", "b.rs"]);
+    add_commit(&conn, &repo, "real2", 20, &["a.rs", "b.rs"]);
+    add_fillers(&conn, &repo, 2, 100); // N=4 so (a,b) clears the lift floor
+    // Merge: no change rows, changed_file_count stays 0 (mirrors read_history_inner numstat
+    // parity).
+    add_commit(&conn, &repo, "merge", 30, &[]);
+
+    recompute_couplings(&conn, &repo, 1).unwrap();
+    let rows = coupling_rows(&conn, &repo);
+    assert_eq!(rows.len(), 1, "only the (a,b) pair survives (fillers/merge contribute none)");
+    assert_eq!((rows[0].0.as_str(), rows[0].1.as_str()), ("a.rs", "b.rs"));
+    // window_commit_count = 4 (2 real + 2 filler); the merge (changed_file_count=0) is not counted.
+    // (If the merge counted it would be 5.)
+    assert_eq!(rows[0].5, 4, "the merge does not inflate the base-rate window: {rows:?}");
+}
+
+/// The window keeps the newest `COUPLING_WINDOW_COMMITS` eligible commits; a pair whose commits
+/// fall entirely outside it is evicted, and `window_commit_count` caps at the window size.
+#[test]
+fn window_evicts_commits_beyond_the_cap() {
+    let conn = fresh_conn();
+    let repo = repo();
+    let window = COUPLING_WINDOW_COMMITS as usize;
+    let tx = conn.unchecked_transaction().unwrap();
+    // The two OLDEST eligible commits pair {y,z} at ts 1,2.
+    add_commit(&conn, &repo, "yz1", 1, &["y.rs", "z.rs"]);
+    add_commit(&conn, &repo, "yz2", 2, &["y.rs", "z.rs"]);
+    // (window - 2) distinct filler pairs fill the middle of the window (ts 1000..).
+    add_fillers(&conn, &repo, window - 2, 1000);
+    // {a,b} co-change in the two NEWEST commits (high ts) → high lift, well inside the window.
+    add_commit(&conn, &repo, "ab1", 100_000, &["a.rs", "b.rs"]);
+    add_commit(&conn, &repo, "ab2", 100_001, &["a.rs", "b.rs"]);
+    tx.commit().unwrap();
+
+    recompute_couplings(&conn, &repo, 1).unwrap();
+    let rows = coupling_rows(&conn, &repo);
+
+    let ab = rows.iter().find(|(a, b, ..)| a == "a.rs" && b == "b.rs").expect("(a,b) in window");
+    assert_eq!(ab.2, 2, "(a,b) co-changed in the two newest commits");
+    assert_eq!(ab.5, window as i64, "window_commit_count caps at COUPLING_WINDOW_COMMITS");
+    assert!(
+        !rows.iter().any(|(a, b, ..)| a == "y.rs" && b == "z.rs"),
+        "the two oldest {{y,z}} commits are evicted (outside the newest {window})"
+    );
+}
+
+/// Pure git history: a generated partner IS stored (the compute has no `files` dependence), but is
+/// NOT surfaced at read (the partner join requires `files.generated = 0`).
+#[test]
+fn generated_partner_stored_but_filtered_at_read() {
+    let conn = fresh_conn();
+    let repo = repo();
+    add_file(&conn, "real.rs", 0);
+    add_file(&conn, "part.rs", 0);
+    add_file(&conn, "gen.rs", 1); // generated
+    // real co-changes with part AND with gen (support 2 each). real_count = 4, so with N=7 both
+    // pairs clear the lift floor: 2*7/(4*2) = 1.75.
+    add_commit(&conn, &repo, "rp1", 10, &["real.rs", "part.rs"]);
+    add_commit(&conn, &repo, "rp2", 20, &["real.rs", "part.rs"]);
+    add_commit(&conn, &repo, "rg1", 30, &["real.rs", "gen.rs"]);
+    add_commit(&conn, &repo, "rg2", 40, &["real.rs", "gen.rs"]);
+    add_fillers(&conn, &repo, 3, 100);
+
+    recompute_couplings(&conn, &repo, 1).unwrap();
+
+    // Both pairs are STORED — the generated flag has no bearing on the pure-history storage.
+    let rows = coupling_rows(&conn, &repo);
+    assert!(
+        rows.iter().any(|(a, b, ..)| a == "gen.rs" && b == "real.rs"),
+        "the generated partner IS stored (pure git history): {rows:?}"
+    );
+    assert!(
+        rows.iter().any(|(a, b, ..)| a == "part.rs" && b == "real.rs"),
+        "the non-generated partner is stored: {rows:?}"
+    );
+
+    // At READ, the generated partner is filtered; only the non-generated one surfaces.
+    let coupled = coupled_files_for_path(&conn, &repo, "real.rs", 10).unwrap();
+    assert!(
+        coupled.iter().all(|c| c.other_path != "gen.rs"),
+        "the generated partner is not surfaced at read: {coupled:?}"
+    );
+    assert!(
+        coupled.iter().any(|c| c.other_path == "part.rs"),
+        "the non-generated partner surfaces: {coupled:?}"
+    );
+}
+
+/// A generated sibling in the same commits adds its OWN pairs but never perturbs a non-generated
+/// pair's stored co / endpoint / window counts.
+#[test]
+fn generated_sibling_does_not_perturb_non_generated_pair() {
+    let counts = |with_gen: bool| -> (i64, i64, i64, i64) {
+        let conn = fresh_conn();
+        let repo = repo();
+        let commit_paths: Vec<&str> = if with_gen {
+            vec!["real.rs", "other.rs", "gen.rs"]
+        } else {
+            vec!["real.rs", "other.rs"]
+        };
+        add_commit(&conn, &repo, "c1", 10, &commit_paths);
+        add_commit(&conn, &repo, "c2", 20, &commit_paths);
+        add_fillers(&conn, &repo, 2, 100); // N=4 → (real,other) lift = 2.0
+        recompute_couplings(&conn, &repo, 1).unwrap();
+        let row = coupling_rows(&conn, &repo)
+            .into_iter()
+            .find(|(a, b, ..)| a == "other.rs" && b == "real.rs")
+            .expect("(other.rs, real.rs) row");
+        (row.2, row.3, row.4, row.5) // co, path_a_change_count, path_b_change_count, window
+    };
+    assert_eq!(
+        counts(false),
+        counts(true),
+        "a generated sibling never perturbs the non-generated pair's counts (co / endpoints / N)"
+    );
+}
+
+/// Codex #566 finding 4: the read query must return each coupled partner EXACTLY ONCE even when the
+/// bare repo-generation `files` view holds multiple rows for that path (distinct commit_sha /
+/// worktree_id at one generation). The accumulator already dedups (one stored pair per (repo,
+/// path_a, path_b)); the risk is purely the partner `files` join cardinality, fixed by
+/// pre-aggregating it to one row per path. Without that dedup this returns "partner.rs" twice.
+#[test]
+fn coupled_partner_deduplicated_across_multiple_files_rows() {
+    let conn = fresh_conn();
+    let repo = repo();
+    add_file(&conn, "hub.rs", 0);
+    // The coupled partner has TWO `main.files` rows at the same generation — as the bare
+    // repo-generation view (all commits/worktrees, un-deduped) can serve.
+    add_file_at_commit(&conn, "partner.rs", "commit-a");
+    add_file_at_commit(&conn, "partner.rs", "commit-b");
+    // hub <-> partner co-change; fillers raise N so the pair clears the lift floor (lift = 2.0).
+    add_commit(&conn, &repo, "c1", 10, &["hub.rs", "partner.rs"]);
+    add_commit(&conn, &repo, "c2", 20, &["hub.rs", "partner.rs"]);
+    add_fillers(&conn, &repo, 2, 100);
+
+    recompute_couplings(&conn, &repo, 1).unwrap();
+
+    // Exactly one stored pair, and the read returns the partner ONCE despite its two `files` rows.
+    assert_eq!(coupling_rows(&conn, &repo).len(), 1, "one stored pair (compute dedups per commit)");
+    let coupled = coupled_files_for_path(&conn, &repo, "hub.rs", 10).unwrap();
+    let partner_rows = coupled.iter().filter(|c| c.other_path == "partner.rs").count();
+    assert_eq!(
+        partner_rows, 1,
+        "the coupled partner is not duplicated by its two files rows: {coupled:?}"
+    );
+    assert_eq!(coupled.len(), 1, "no phantom duplicate consumes the caller's limit: {coupled:?}");
+}
+
+/// Repo scoping (V040): two repos sharing commit hashes AND paths never cross. A recompute for one
+/// leaves the other repo's rows and stamp untouched.
+#[test]
+fn repo_scoping_isolates_couplings_and_stamps() {
+    let conn = fresh_conn();
+    // git_commits.repo_id REFERENCES repos(repo_id), so both sibling repos must be registered.
+    conn.execute(
+        "INSERT INTO repos(repo_id, display_name, registered_at_ms) VALUES ('repo_a', 'a', 1), \
+         ('repo_b', 'b', 2)",
+        [],
+    )
+    .unwrap();
+    add_file(&conn, "a.rs", 0);
+    add_file(&conn, "b.rs", 0);
+
+    // Both repos reuse hash "c1"/"c2" (the fork collision). repo_a co(a,b)=2 (N=4, lift 2.0);
+    // repo_b co(a,b)=3 (N=5, lift = 3*5/(3*3) = 1.667). Fillers keep each above the floor.
+    add_commit(&conn, "repo_a", "c1", 10, &["a.rs", "b.rs"]);
+    add_commit(&conn, "repo_a", "c2", 20, &["a.rs", "b.rs"]);
+    add_fillers(&conn, "repo_a", 2, 100);
+    add_commit(&conn, "repo_b", "c1", 10, &["a.rs", "b.rs"]);
+    add_commit(&conn, "repo_b", "c2", 20, &["a.rs", "b.rs"]);
+    add_commit(&conn, "repo_b", "c3", 25, &["a.rs", "b.rs"]);
+    add_fillers(&conn, "repo_b", 2, 200);
+
+    recompute_couplings(&conn, "repo_a", 100).unwrap();
+    recompute_couplings(&conn, "repo_b", 200).unwrap();
+
+    assert_eq!(coupling_rows(&conn, "repo_a")[0].2, 2, "repo_a co-count independent");
+    assert_eq!(coupling_rows(&conn, "repo_b")[0].2, 3, "repo_b co-count independent");
+    // repo_a's read never surfaces repo_b's rows (same path, sibling repo).
+    let read_a = coupled_files_for_path(&conn, "repo_a", "a.rs", 10).unwrap();
+    assert_eq!(read_a.len(), 1, "repo_a reads exactly its own coupling: {read_a:?}");
+    assert_eq!(read_a[0].co_change_count, 2, "read is scoped to repo_a, not repo_b's co=3");
+
+    // Recomputing repo_a again must not disturb repo_b's rows or its stamp.
+    let stamp_b_before: String = conn
+        .query_row(
+            "SELECT value FROM repo_meta WHERE repo_id = 'repo_b' AND key = 'git_coupling_stamp'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    recompute_couplings(&conn, "repo_a", 300).unwrap();
+    assert_eq!(coupling_rows(&conn, "repo_b")[0].2, 3, "repo_b rows untouched by repo_a recompute");
+    let stamp_b_after: String = conn
+        .query_row(
+            "SELECT value FROM repo_meta WHERE repo_id = 'repo_b' AND key = 'git_coupling_stamp'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(stamp_b_before, stamp_b_after, "repo_b stamp untouched");
+}
+
+/// Seed the four git-history cursor meta rows (the `is_history_current` freshness snapshot the
+/// coupling stamp folds in) so the stamp's history key is non-empty and moves with them.
+fn set_history_cursors(
+    conn: &Connection,
+    repo_id: &str,
+    head: &str,
+    root: &str,
+    shallow: bool,
+    complete: bool,
+) {
+    let bit = |b: bool| if b { "1" } else { "0" };
+    crate::index::set_repo_meta(conn, repo_id, "git_history_indexed_head", head).unwrap();
+    crate::index::set_repo_meta(conn, repo_id, "git_history_indexed_root", root).unwrap();
+    crate::index::set_repo_meta(conn, repo_id, "git_history_indexed_shallow", bit(shallow))
+        .unwrap();
+    crate::index::set_repo_meta(conn, repo_id, "git_history_indexed_complete", bit(complete))
+        .unwrap();
+}
+
+fn coupling_computed_at(conn: &Connection, repo_id: &str) -> i64 {
+    conn.query_row(
+        "SELECT computed_at_ms FROM git_change_couplings WHERE repo_id = ?1 LIMIT 1",
+        params![repo_id],
+        |r| r.get(0),
+    )
+    .unwrap()
+}
+
+/// Seed a two-commit {a,b} fixture (+ fillers so it clears the lift floor at N=4), ready for the
+/// stamp tests to establish cursors and drive ensure_coupling_fresh.
+fn stamp_fixture() -> (Connection, String) {
+    let conn = fresh_conn();
+    let repo = repo();
+    add_commit(&conn, &repo, "c1", 10, &["a.rs", "b.rs"]);
+    add_commit(&conn, &repo, "c2", 20, &["a.rs", "b.rs"]);
+    add_fillers(&conn, &repo, 2, 100);
+    (conn, repo)
+}
+
+/// The freshness stamp gates recompute: a no-op when the history cursors + params are unchanged,
+/// and a recompute on a HEAD move or a params-version drift.
+#[test]
+fn stamp_gates_recompute_on_head_and_params() {
+    let (conn, repo) = stamp_fixture();
+
+    set_history_cursors(&conn, &repo, "h1", "root-key", false, true);
+    ensure_coupling_fresh(&conn, 100).unwrap();
+    assert_eq!(coupling_computed_at(&conn, &repo), 100, "first read recomputes");
+
+    // Cursors + params unchanged → no-op.
+    ensure_coupling_fresh(&conn, 200).unwrap();
+    assert_eq!(coupling_computed_at(&conn, &repo), 100, "unchanged stamp is a no-op");
+
+    // HEAD moves (rewrite) → recompute.
+    set_history_cursors(&conn, &repo, "h2", "root-key", false, true);
+    ensure_coupling_fresh(&conn, 300).unwrap();
+    assert_eq!(coupling_computed_at(&conn, &repo), 300, "head move forces recompute");
+
+    // Params version drift (simulated by rewriting the stored stamp) → recompute.
+    crate::index::set_repo_meta(&conn, &repo, "git_coupling_stamp", "bogus").unwrap();
+    ensure_coupling_fresh(&conn, 400).unwrap();
+    assert_eq!(coupling_computed_at(&conn, &repo), 400, "a params mismatch forces recompute");
+}
+
+/// Codex #566 finding 1: git_file_changes can be REWRITTEN at the SAME HEAD (unshallow / deepen, or
+/// an indexed-subtree re-point). The stamp folds the full `is_history_current` cursor snapshot, so
+/// a cursor change with an UNCHANGED head still invalidates and forces a recompute.
+#[test]
+fn history_rewrite_at_same_head_invalidates_stamp() {
+    let (conn, repo) = stamp_fixture();
+
+    // Shallow, incomplete history first.
+    set_history_cursors(&conn, &repo, "h1", "root-key", true, false);
+    ensure_coupling_fresh(&conn, 100).unwrap();
+    assert_eq!(coupling_computed_at(&conn, &repo), 100, "first read recomputes");
+
+    // Deepen at the SAME head: shallow 1→0, complete 0→1. Head unchanged, cursor snapshot moved.
+    set_history_cursors(&conn, &repo, "h1", "root-key", false, true);
+    ensure_coupling_fresh(&conn, 200).unwrap();
+    assert_eq!(
+        coupling_computed_at(&conn, &repo),
+        200,
+        "same-head unshallow/deepen forces recompute"
+    );
+
+    // Subtree re-point at the same head (root_key changes) → recompute.
+    set_history_cursors(&conn, &repo, "h1", "root-key-2", false, true);
+    ensure_coupling_fresh(&conn, 300).unwrap();
+    assert_eq!(coupling_computed_at(&conn, &repo), 300, "root-key change forces recompute");
+}
+
+/// The stamp is PURE (history:params) — it does NOT fold the files generation, because the stored
+/// table is a pure function of git history. So a files-generation bump alone does NOT recompute.
+/// (Inverts the earlier composite-stamp behavior.)
+#[test]
+fn files_generation_change_does_not_invalidate_stamp() {
+    let (conn, repo) = stamp_fixture();
+
+    set_history_cursors(&conn, &repo, "h1", "root-key", false, true);
+    ensure_coupling_fresh(&conn, 100).unwrap();
+    assert_eq!(coupling_computed_at(&conn, &repo), 100, "first read recomputes");
+
+    // Bump the live files generation — the stored table doesn't depend on it, so NO recompute.
+    crate::index::set_repo_meta(&conn, &repo, "live_files_generation", "1").unwrap();
+    ensure_coupling_fresh(&conn, 200).unwrap();
+    assert_eq!(
+        coupling_computed_at(&conn, &repo),
+        100,
+        "a files-generation bump does NOT recompute (stamp is pure git-history)"
+    );
+}
+
+/// A partner flipped to generated stops surfacing at READ with NO recompute: the stamp is pure
+/// git-history (unchanged by a files-view edit) and the generated filter lives on the read path.
+#[test]
+fn generated_flag_change_does_not_recompute_but_read_reflects_it() {
+    let conn = fresh_conn();
+    let repo = repo();
+    add_file(&conn, "a.rs", 0);
+    add_file(&conn, "b.rs", 0);
+    add_commit(&conn, &repo, "c1", 10, &["a.rs", "b.rs"]);
+    add_commit(&conn, &repo, "c2", 20, &["a.rs", "b.rs"]);
+    add_fillers(&conn, &repo, 2, 100); // N=4 → lift 2.0
+    set_history_cursors(&conn, &repo, "h1", "root-key", false, true);
+    ensure_coupling_fresh(&conn, 100).unwrap();
+    assert_eq!(coupling_computed_at(&conn, &repo), 100, "first read recomputes");
+    assert_eq!(coupled_files_for_path(&conn, &repo, "a.rs", 10).unwrap().len(), 1, "b surfaces");
+
+    // Flip b to generated — no history / params change.
+    conn.execute("UPDATE files SET generated = 1 WHERE path = 'b.rs'", []).unwrap();
+    ensure_coupling_fresh(&conn, 200).unwrap();
+    assert_eq!(
+        coupling_computed_at(&conn, &repo),
+        100,
+        "the generated flip does NOT recompute (stamp unchanged)"
+    );
+    assert!(
+        coupled_files_for_path(&conn, &repo, "a.rs", 10).unwrap().is_empty(),
+        "b no longer surfaces at read (now generated), with no recompute"
+    );
+}
+
+/// End-to-end: the `impact_surface` report carries the coupling section, it self-heals on the git
+/// path, and it is omitted when `include_git` is off; the section participates in
+/// `truncated_sections`.
+#[test]
+fn impact_report_surfaces_and_gates_coupling_section() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/store.rs"), "pub fn target_symbol() {}\n").unwrap();
+    fs::write(root.join("src/helper.rs"), "pub fn helper_fn() {}\n").unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    // Synthetic history on the indexed DB: store.rs + helper.rs co-change twice; two filler commits
+    // (non-indexed paths) raise N = 4 so (store,helper)'s lift = 2.0 clears the floor.
+    let conn = db.storage.connection();
+    let repo_id = crate::index::schema::active_repo_id(conn).unwrap();
+    add_commit(conn, &repo_id, "c1", 10, &["src/store.rs", "src/helper.rs"]);
+    add_commit(conn, &repo_id, "c2", 20, &["src/store.rs", "src/helper.rs"]);
+    add_commit(conn, &repo_id, "c3", 30, &["ext_a.rs", "ext_b.rs"]);
+    add_commit(conn, &repo_id, "c4", 40, &["ext_c.rs", "ext_d.rs"]);
+
+    let selector = crate::query::symbol::SymbolSelector {
+        logical_symbol_id: None,
+        symbol_id: None,
+        symbol_path: None,
+        symbol: Some("target_symbol".to_string()),
+        language: Some(Language::Rust),
+        allow_ambiguous: false,
+        limit: 10,
+    };
+    let symbol = db.select_symbol(&selector).unwrap().unwrap().expect("symbol");
+
+    // include_git on (default): the coupling section surfaces helper.rs (lazy recompute on read).
+    let report = db
+        .impact_surface_report_for_selected_symbol(
+            &symbol,
+            50,
+            &crate::query::impact::ImpactSurfaceOptions::default(),
+        )
+        .unwrap();
+    let coupled = &report.files_co_changed_with_symbol_path;
+    assert_eq!(coupled.len(), 1, "one coupled file: {coupled:?}");
+    assert!(coupled[0].path.ends_with("src/helper.rs"), "coupled to helper.rs: {coupled:?}");
+    assert_eq!(coupled[0].reason, "file_co_changed_in_recent_commits");
+
+    // include_git off: the section is empty (and no recompute is triggered on that path).
+    let git_off =
+        crate::query::impact::ImpactSurfaceOptions { include_git: false, ..Default::default() };
+    let report_off = db.impact_surface_report_for_selected_symbol(&symbol, 50, &git_off).unwrap();
+    assert!(
+        report_off.files_co_changed_with_symbol_path.is_empty(),
+        "include_git off omits the coupling section"
+    );
+
+    // At limit=1 the (exactly-full) section is flagged in truncated_sections (#49 no silent caps).
+    let capped =
+        db.impact_surface_report_for_selected_symbol(&symbol, 1, &Default::default()).unwrap();
+    assert!(
+        capped
+            .completeness_and_caveats
+            .truncated_sections
+            .iter()
+            .any(|s| s == "files_co_changed_with_symbol_path"),
+        "coupling section participates in truncated_sections: {:?}",
+        capped.completeness_and_caveats.truncated_sections
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+/// Codex #566 finding 2: a co-changed file that is dirty-since-index must count toward
+/// `stale_files`, else the caller trusts a surface whose coupling lane has moved under it. The
+/// coupled file is NOT a caller / callee / test / doc / text-match of the symbol, so it reaches the
+/// stale scan ONLY through the `files_co_changed_with_symbol_path` lane.
+#[test]
+fn dirty_co_changed_file_counts_toward_stale_files() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/store.rs"), "pub fn target_symbol() {}\n").unwrap();
+    fs::write(root.join("src/helper.rs"), "pub fn helper_fn() {}\n").unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let conn = db.storage.connection();
+    let repo_id = crate::index::schema::active_repo_id(conn).unwrap();
+    add_commit(conn, &repo_id, "c1", 10, &["src/store.rs", "src/helper.rs"]);
+    add_commit(conn, &repo_id, "c2", 20, &["src/store.rs", "src/helper.rs"]);
+    add_commit(conn, &repo_id, "c3", 30, &["ext_a.rs", "ext_b.rs"]);
+    add_commit(conn, &repo_id, "c4", 40, &["ext_c.rs", "ext_d.rs"]);
+
+    // Dirty the coupled file on disk AFTER indexing — its content hash now differs from the index.
+    fs::write(root.join("src/helper.rs"), "pub fn helper_fn() { let _changed = 1; }\n").unwrap();
+
+    let selector = crate::query::symbol::SymbolSelector {
+        logical_symbol_id: None,
+        symbol_id: None,
+        symbol_path: None,
+        symbol: Some("target_symbol".to_string()),
+        language: Some(Language::Rust),
+        allow_ambiguous: false,
+        limit: 10,
+    };
+    let symbol = db.select_symbol(&selector).unwrap().unwrap().expect("symbol");
+    let report = db
+        .impact_surface_report_for_selected_symbol(
+            &symbol,
+            50,
+            &crate::query::impact::ImpactSurfaceOptions::default(),
+        )
+        .unwrap();
+
+    assert!(
+        report.files_co_changed_with_symbol_path.iter().any(|i| i.path.ends_with("src/helper.rs")),
+        "helper.rs surfaces in the coupling lane"
+    );
+    assert!(
+        report.completeness_and_caveats.stale_files >= 1,
+        "the dirty co-changed file is counted in stale_files: {}",
+        report.completeness_and_caveats.stale_files
+    );
+
+    let _ = fs::remove_dir_all(root);
+}

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/mod.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/mod.rs
@@ -882,6 +882,7 @@ fn fingerprinted_symbol_id_for_ref(db: &IndexDatabase, qualified_name: &str) -> 
         .unwrap_or_else(|e| panic!("no fingerprinted symbol id for ref {qualified_name}: {e}"))
 }
 
+mod change_coupling;
 mod chunk_store_migrations;
 mod clones;
 mod dir_memory_tree;

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_registry.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_registry.rs
@@ -3175,6 +3175,15 @@ fn full_ladder_v037_to_v042_scopes_both_workstreams_data() {
         [LEGACY_REPO_ID],
     )
     .unwrap();
+    // A V056 derived change-coupling row — repo_id-scoped, no FK; adoption must re-point it too so
+    // it stays consistent with the (separately relocated) git_coupling_stamp repo_meta.
+    conn.execute(
+        "INSERT INTO git_change_couplings(repo_id, path_a, path_b, co_change_count, \
+         path_a_change_count, path_b_change_count, window_commit_count, last_co_change_at_s, \
+         computed_at_ms) VALUES (?1, 'a.rs', 'b.rs', 2, 2, 2, 4, 100, 0)",
+        [LEGACY_REPO_ID],
+    )
+    .unwrap();
 
     // Roll the ledger back to the pre-A-phase tip and forward-migrate the WHOLE A-phase ladder.
     truncate_schema_to(&conn, 37);
@@ -3209,6 +3218,7 @@ fn full_ladder_v037_to_v042_scopes_both_workstreams_data() {
         ("clone_graph_generations", "generation = 1"),
         ("memory_reality", "memory_id = 'm1'"),
         ("memory_model_failures", "memory_id = 'm1'"),
+        ("git_change_couplings", "path_a = 'a.rs'"),
     ] {
         assert_eq!(
             placeholder_count(&format!(
@@ -3257,4 +3267,63 @@ fn full_ladder_v037_to_v042_scopes_both_workstreams_data() {
         "repo-real",
         "adoption re-points the V047 memory_model_failures sibling"
     );
+    assert_eq!(
+        real_repo("SELECT repo_id FROM git_change_couplings WHERE path_a = 'a.rs'"),
+        "repo-real",
+        "adoption re-points the V056 git_change_couplings derived table"
+    );
+}
+
+/// Codex #566 finding B: `git_change_couplings` is in `DIRECT_SCOPED_ADOPTION_TABLES`, so a
+/// LocalOnly→Portable adoption re-points its rows TOGETHER with the `git_coupling_stamp` repo_meta
+/// — keeping the derived table stamp-consistent. Without the registration the stamp would move but
+/// the rows would strand, and `ensure_coupling_fresh` would then see a matching stamp and serve an
+/// EMPTY section instead of the adopted rows.
+#[test]
+fn adoption_repoints_change_couplings_consistently_with_its_stamp() {
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn).unwrap();
+
+    // A derived coupling row + a CONSISTENT freshness stamp (head h1 + params 1), both under the
+    // placeholder — the shape a legacy single-repo index carries pre-adoption.
+    conn.execute(
+        "INSERT INTO git_change_couplings(repo_id, path_a, path_b, co_change_count, \
+         path_a_change_count, path_b_change_count, window_commit_count, last_co_change_at_s, \
+         computed_at_ms) VALUES (?1, 'a.rs', 'b.rs', 2, 2, 2, 4, 100, 50)",
+        [LEGACY_REPO_ID],
+    )
+    .unwrap();
+    // A stamp CONSISTENT with the seeded state: no git-history cursors set ⇒ empty history key,
+    // plus the current params version. The stamp is pure git-history (`history_key:params`, no
+    // files axis), so the post-adoption `ensure_coupling_fresh` sees a matching stamp and does
+    // NOT recompute.
+    let consistent_stamp = format!(":{}", crate::index::change_coupling::COUPLING_PARAMS_VERSION);
+    crate::index::set_repo_meta(&conn, LEGACY_REPO_ID, "git_coupling_stamp", &consistent_stamp)
+        .unwrap();
+
+    register_repo(&conn, &identity("repo-real", "r"), Path::new("/src/r"), 1).unwrap();
+
+    // Rows re-pointed onto the real id, none stranded under the placeholder.
+    let count_for = |repo: &str| -> i64 {
+        conn.query_row(
+            "SELECT COUNT(*) FROM git_change_couplings WHERE repo_id = ?1",
+            [repo],
+            |r| r.get(0),
+        )
+        .unwrap()
+    };
+    assert_eq!(count_for("repo-real"), 1, "coupling row re-pointed onto the real id");
+    assert_eq!(count_for(LEGACY_REPO_ID), 0, "no coupling row stranded under the placeholder");
+
+    // Stamp + rows consistent (the stamp relocated to the real id too), so ensure_coupling_fresh is
+    // a NO-OP — it must NOT recompute the freshly-adopted rows away to an empty section.
+    crate::index::change_coupling::ensure_coupling_fresh(&conn, 999).unwrap();
+    let computed_at: i64 = conn
+        .query_row(
+            "SELECT computed_at_ms FROM git_change_couplings WHERE repo_id = 'repo-real'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(computed_at, 50, "matching stamp => no recompute; the adopted rows survive intact");
 }

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
@@ -1522,10 +1522,13 @@ fn migration_054_adds_the_single_row_device_identity_table() {
 fn migration_055_adds_the_binding_downgrade_marker_column() {
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     schema::apply(&conn).unwrap();
-    // V055 is the schema tip — this test carries the absolute pin (the older tests dropped to
-    // the symbolic `current_version == LATEST` check).
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 55, "V055 is the schema tip");
-    assert_eq!(schema::status(&conn).unwrap().current_version, 55, "schema at LATEST after apply");
+    // V056 now holds the absolute tip pin (migration_056's test); this drops to the symbolic
+    // `current_version == LATEST` freshness check.
+    assert_eq!(
+        schema::status(&conn).unwrap().current_version,
+        schema::LATEST_SCHEMA_VERSION,
+        "schema at LATEST after apply"
+    );
     assert!(
         conn_table_columns(&conn, "repo_memory_bindings")
             .contains(&"downgrade_pending_at_ms".to_string()),
@@ -1541,6 +1544,59 @@ fn migration_055_adds_the_binding_downgrade_marker_column() {
     // A forward migrate over a ledger truncated below V055 replays the step and lands the
     // column (the standard lagging-index path).
     truncate_schema_to(&conn, 54);
+    schema::migrate_forward(&conn).unwrap();
+    assert_eq!(
+        schema::status(&conn).unwrap().current_version,
+        schema::LATEST_SCHEMA_VERSION,
+        "forward migrate reaches the tip"
+    );
+}
+
+#[test]
+fn migration_056_adds_the_git_change_couplings_table() {
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn).unwrap();
+    // V056 is the schema tip — this test carries the absolute pin (the older tests dropped to the
+    // symbolic `current_version == LATEST` check).
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 56, "V056 is the schema tip");
+    assert_eq!(schema::status(&conn).unwrap().current_version, 56, "schema at LATEST after apply");
+    assert!(
+        conn_table_exists(&conn, "git_change_couplings"),
+        "V056 creates the git_change_couplings table"
+    );
+
+    // STRICT + composite (repo_id, path_a, path_b) PK: a duplicate pair is rejected.
+    conn.execute(
+        "INSERT INTO git_change_couplings(repo_id, path_a, path_b, co_change_count, \
+         path_a_change_count, path_b_change_count, window_commit_count, last_co_change_at_s, \
+         computed_at_ms) VALUES ('r', 'a.rs', 'b.rs', 2, 3, 4, 10, 100, 1)",
+        [],
+    )
+    .unwrap();
+    assert!(
+        conn.execute(
+            "INSERT INTO git_change_couplings(repo_id, path_a, path_b, co_change_count, \
+             path_a_change_count, path_b_change_count, window_commit_count, last_co_change_at_s, \
+             computed_at_ms) VALUES ('r', 'a.rs', 'b.rs', 9, 9, 9, 9, 9, 9)",
+            [],
+        )
+        .is_err(),
+        "the composite PK rejects a duplicate (repo_id, path_a, path_b)"
+    );
+
+    // Deferred-absence in ISOLATION: drop + re-run the applier alone; it recreates, replay is a
+    // no-op.
+    conn.execute_batch("DROP TABLE git_change_couplings;").unwrap();
+    assert!(!conn_table_exists(&conn, "git_change_couplings"), "dropped before the isolated apply");
+    schema::apply_git_change_couplings(&conn).unwrap();
+    schema::apply_git_change_couplings(&conn).expect("replay is a no-op");
+    assert!(
+        conn_table_exists(&conn, "git_change_couplings"),
+        "the isolated applier recreates the table"
+    );
+
+    // A forward migrate over a ledger truncated below V056 replays the step and reaches the tip.
+    truncate_schema_to(&conn, 55);
     schema::migrate_forward(&conn).unwrap();
     assert_eq!(
         schema::status(&conn).unwrap().current_version,

--- a/crates/rag-rat-core/src/query/clusters.rs
+++ b/crates/rag-rat-core/src/query/clusters.rs
@@ -3,12 +3,15 @@ use std::collections::{BTreeMap, BTreeSet, HashMap};
 use rusqlite::Connection;
 use serde::Serialize;
 
+// The per-commit co-touch cap is shared with the persisted change-coupling pass
+// (`impact_surface`) so the transient (this file) and windowed/persisted (change_coupling)
+// consumers can't drift.
+use crate::index::change_coupling::MAX_COUPLING_COMMIT_FILES as MAX_COTOUCH_COMMIT_FILES;
 use crate::query::repo_brief::{
     self, FileBriefRow, RepoBriefMemoryCounts, enrich_memory_counts, enrich_symbol_kinds,
 };
 
 const MAX_PATH_BUCKET_FILES: usize = 120;
-const MAX_COTOUCH_COMMIT_FILES: usize = 40;
 const MAX_CLUSTER_PATHS: usize = 8;
 const MIN_EDGE_SCORE: f64 = 0.34;
 

--- a/crates/rag-rat-core/src/query/impact/items.rs
+++ b/crates/rag-rat-core/src/query/impact/items.rs
@@ -213,6 +213,43 @@ pub(crate) fn git_commit_items(
     Ok(surface.into_items(usize::try_from(limit).unwrap_or(usize::MAX)))
 }
 
+/// The "changes-alongside" section: files that historically co-changed with `path` within the
+/// recency window, ranked by asymmetric confidence `P(other | path)` with the read-time lift floor
+/// (see `crate::index::change_coupling`). Pure reader — the freshness recompute is the
+/// `ensure_coupling_fresh` seam on the impact query path, not here. Repo-scoped via
+/// `active_repo_id` (the direct V040 posture), matching `git_commit_items`.
+pub(crate) fn coupling_items(
+    conn: &Connection,
+    path: &str,
+    limit: u32,
+) -> anyhow::Result<Vec<ImpactItem>> {
+    let repo_id = crate::index::schema::active_repo_id(conn)?;
+    let coupled =
+        crate::index::change_coupling::coupled_files_for_path(conn, &repo_id, path, limit)?;
+    Ok(coupled
+        .into_iter()
+        .map(|c| ImpactItem {
+            path: c.other_path,
+            language: c.language,
+            kind: c.kind,
+            symbol: None,
+            category: ImpactCategory::HistoricalPapertrail.as_str().to_string(),
+            reason: "file_co_changed_in_recent_commits".to_string(),
+            evidence: vec![format!(
+                "co-changed with {path} in {co} of {this} commits that touched it, within the \
+                 last {window} eligible commits (confidence {confidence:.2}, lift {lift:.1}); \
+                 last together at {last_at_s}",
+                co = c.co_change_count,
+                this = c.this_change_count,
+                window = c.window_commit_count,
+                confidence = c.confidence,
+                lift = c.lift,
+                last_at_s = c.last_co_change_at_s,
+            )],
+        })
+        .collect())
+}
+
 pub(crate) fn github_ref_items(
     conn: &Connection,
     paths: &[String],

--- a/crates/rag-rat-core/src/query/impact/mod.rs
+++ b/crates/rag-rat-core/src/query/impact/mod.rs
@@ -99,6 +99,7 @@ pub struct ImpactSurfaceReport {
     pub docs_mentioning_symbol_path: Vec<ImpactItem>,
     pub text_fallback_hits: Vec<ImpactItem>,
     pub recent_commits_touching_symbol_path: Vec<ImpactItem>,
+    pub files_co_changed_with_symbol_path: Vec<ImpactItem>,
     pub github_rationale_issues_prs: Vec<ImpactItem>,
     pub repo_memories: RepoMemoryEvidenceView,
     pub completeness_and_caveats: ImpactCompleteness,
@@ -242,6 +243,11 @@ pub fn impact_surface_report_for_symbol(
     } else {
         Vec::new()
     };
+    // Change coupling is git-derived evidence, so it rides the existing `include_git` gate (no new
+    // `ImpactInclude` variant). The DerivedIndex table is kept fresh by `ensure_coupling_fresh` on
+    // the IndexDatabase seam before this pure reader runs.
+    let files_co_changed_with_symbol_path =
+        if options.include_git { coupling_items(conn, &symbol.path, limit)? } else { Vec::new() };
     let github_rationale_issues_prs = if options.include_papertrail {
         let mut items = github_ref_items(conn, std::slice::from_ref(&symbol.path), limit)?;
         items.extend(github_rationale_items(conn, &symbol.qualified_name, limit)?);
@@ -298,6 +304,7 @@ pub fn impact_surface_report_for_symbol(
         ("docs_mentioning_symbol_path", docs_mentioning_symbol_path.len()),
         ("text_fallback_hits", text_fallback_hits.len()),
         ("recent_commits_touching_symbol_path", recent_commits_touching_symbol_path.len()),
+        ("files_co_changed_with_symbol_path", files_co_changed_with_symbol_path.len()),
         ("github_rationale_issues_prs", github_rationale_issues_prs.len()),
     ]
     .into_iter()
@@ -360,6 +367,7 @@ pub fn impact_surface_report_for_symbol(
         docs_mentioning_symbol_path,
         text_fallback_hits,
         recent_commits_touching_symbol_path,
+        files_co_changed_with_symbol_path,
         github_rationale_issues_prs,
         repo_memories,
     })

--- a/crates/rag-rat-mcp/src/tools/requests.rs
+++ b/crates/rag-rat-mcp/src/tools/requests.rs
@@ -445,7 +445,9 @@ pub struct ImpactArgs {
     pub limit: u32,
     /// What to include — `tests`, `docs`, `git`, `papertrail`, `text_fallback`, `memories`, ALL on
     /// by default (impact's value is the bundled evidence). Omit to keep them; pass an explicit
-    /// list to narrow, e.g. `["git"]` for git history only.
+    /// list to narrow, e.g. `["git"]` for git history only. `git` bundles both the recent commits
+    /// touching the symbol's file and the files that historically co-changed with it (the windowed
+    /// change-coupling section).
     #[serde(default, deserialize_with = "de_seq_or_json_string")]
     pub include: Option<Vec<ImpactInclude>>,
     /// Return full memory bodies + every binding + call paths instead of the default compact,


### PR DESCRIPTION
## What

Adds a windowed **file-pair change-coupling** signal — "when I edit file A, which files have historically changed alongside it?" — derived from `git_file_changes` and surfaced in `impact_surface`. The substrate already existed (per-commit file sets in `git_file_changes`, and a transient co-occurrence pass in `query/clusters.rs::co_touch_pairs`); this persists it, windows it, and exposes it.

## Storage

New STRICT table `git_change_couplings` (migration **V056**), one symmetric row per unordered pair (`path_a < path_b` BINARY), storing raw counts only:

```
repo_id, path_a, path_b, co_change_count,
path_a_change_count, path_b_change_count,
window_commit_count, last_co_change_at_s, computed_at_ms
```

- **Metric derived at read time:** asymmetric confidence `P(B changes | A changes) = co / a_count` (the "what comes along when I edit A" measure), with a **lift ≥ 1.5** floor to suppress hub-file noise. Jaccard rejected (penalizes asymmetric coupling); PMI-as-key rejected (unstable at low support).
- **Window / caps:** last 1000 eligible commits where `changed_file_count BETWEEN 2 AND 40` (drops merges, single-file commits, and mega-commit refactors); write-time support floor ≥ 2; per-file top-100 pair cap (endpoint union).
- **DerivedIndex posture:** wholesale `DELETE` + `INSERT` recompute in one transaction, healed lazily on the git-inclusive `impact_surface` read via a `repo_meta` stamp (`git_history_indexed_head` + a params-version tag) — mirroring `ensure_fts_fresh` / the blame cache. Never wired into the terminal index transaction or the fast-forward git-append seam. No FK to `git_commits`/`git_file_changes`: the aggregate must survive a history full-replace between recomputes; the stamp, not row integrity, is the freshness authority.

## Freshness is a pure function of git history

The stored table is a function of `(git window, params)` only — the generated/existence filter runs at **read time** (`coupled_files_for_path` inner-joins each partner path to the live scoped `files` view and requires `generated = 0`), not at compute time. This keeps the `head:params` stamp exactly correct and generation/worktree-safe: a `files`-view change with no git-head move (a reindex to a new generation, a `generated`-flag flip) is reflected immediately by the read without a stale-stamp hazard. Repo isolation is the `changes.repo_id` predicate (V040), independent of the files join.

## Repo-id lifecycle

`git_change_couplings` is registered in `DIRECT_SCOPED_ADOPTION_TABLES` (per the coverage mandate in `schema/registry.rs`), so a LocalOnly→Portable in-place upgrade re-points its rows together with the `git_coupling_stamp` meta (staying consistent), and the late-merge path drops the retiring id's rows — no stranded-behind-a-moved-stamp rows, no invisible garbage.

## Surface

A `files_co_changed_with_symbol_path` section on `ImpactSurfaceReport`, gated by the existing `include_git` flag (no MCP schema churn) and participating in `truncated_sections`. Ranked by confidence DESC, co-count DESC, path ASC.

## Tests

Exact support/confidence/lift from scripted commits; lift-floor drop/keep; mega-commit and merge exclusion; window eviction; write-time support floor + per-file-cap union; repo-scoping isolation with shared commit hashes; stamp gating on head-move and params-drift; read-time generated filtering (stored keeps the pair, read drops it) incl. a `generated`-flip-without-recompute case; a generated sibling leaving a non-generated pair's counts byte-identical; an end-to-end `impact_surface` integration + `include_git` gate + truncation; a repo-id adoption re-point test; and the V056 migration-ladder pin. Full `cargo nextest run -p rag-rat-core` green; clippy and nightly fmt clean.

Fixes #566
