### PR TITLE
perf(reconcile): classify skip-summary low-signal from one shared parse per file

### DIFF
--- a/crates/rag-rat-core/src/index/ai/policy.rs
+++ b/crates/rag-rat-core/src/index/ai/policy.rs
@@ -57,6 +57,43 @@ impl LowSignalCheck<'_> {
     }
 }
 
+/// The policy from the cheap, PARSE-FREE gates that precede the low-signal check (`trimmed` is the
+/// pre-trimmed chunk text), or `None` when the chunk REACHES the low-signal gate — the only gate
+/// that needs a tree-sitter parse. A caller that shares one parse across a file's chunks uses this
+/// to skip the parse entirely when no chunk reaches the low-signal gate.
+pub(crate) fn cheap_skip_policy(
+    path: &Path,
+    language: &str,
+    file_kind: &str,
+    chunk_kind: &str,
+    symbol_path: Option<&str>,
+    trimmed: &str,
+    max_embedding_chars: usize,
+) -> Option<EmbeddingPolicyDecision> {
+    let path_text = path.to_string_lossy();
+    if trimmed.chars().count() > max_embedding_chars.saturating_mul(4)
+        && (file_kind == "generated" || chunk_kind == "generated" || symbol_path.is_none())
+    {
+        return Some(policy("SkipTooLarge", 9, false));
+    }
+    if file_kind == "generated" || chunk_kind == "generated" || looks_generated_path(&path_text) {
+        return Some(policy("SkipGenerated", 9, false));
+    }
+    if is_test_fixture_path(&path_text) {
+        return Some(policy("SkipTestFixture", 9, false));
+    }
+    let Ok(language_kind) = language.parse::<Language>() else {
+        return Some(policy("SkipLanguageUnsupported", 9, false));
+    };
+    if !language_kind.supports_embeddings() {
+        return Some(policy("SkipLanguageUnsupported", 9, false));
+    }
+    if trimmed.chars().count() < MIN_EMBEDDING_CHARS {
+        return Some(policy("SkipTooSmall", 9, false));
+    }
+    None
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn embedding_policy_for_chunk(
     path: &Path,
@@ -68,31 +105,22 @@ pub(crate) fn embedding_policy_for_chunk(
     max_embedding_chars: usize,
     low_signal: LowSignalCheck<'_>,
 ) -> EmbeddingPolicyDecision {
-    let path_text = path.to_string_lossy();
     let trimmed = text.trim();
-    if trimmed.chars().count() > max_embedding_chars.saturating_mul(4)
-        && (file_kind == "generated" || chunk_kind == "generated" || symbol_path.is_none())
-    {
-        return policy("SkipTooLarge", 9, false);
-    }
-    if file_kind == "generated" || chunk_kind == "generated" || looks_generated_path(&path_text) {
-        return policy("SkipGenerated", 9, false);
-    }
-    if is_test_fixture_path(&path_text) {
-        return policy("SkipTestFixture", 9, false);
-    }
-    let Ok(language_kind) = language.parse::<Language>() else {
-        return policy("SkipLanguageUnsupported", 9, false);
-    };
-    if !language_kind.supports_embeddings() {
-        return policy("SkipLanguageUnsupported", 9, false);
-    }
-    if trimmed.chars().count() < MIN_EMBEDDING_CHARS {
-        return policy("SkipTooSmall", 9, false);
+    if let Some(skip) = cheap_skip_policy(
+        path,
+        language,
+        file_kind,
+        chunk_kind,
+        symbol_path,
+        trimmed,
+        max_embedding_chars,
+    ) {
+        return skip;
     }
     if low_signal.is_low_signal(language, chunk_kind, symbol_path, trimmed) {
         return policy("SkipLowSignal", 9, false);
     }
+    let path_text = path.to_string_lossy();
     policy("Embed", embedding_priority(&path_text, language, chunk_kind, symbol_path), true)
 }
 

--- a/crates/rag-rat-core/src/index/ai/reconcile/embed_loop.rs
+++ b/crates/rag-rat-core/src/index/ai/reconcile/embed_loop.rs
@@ -735,61 +735,254 @@ fn remote_request_group_ranges(
     ranges
 }
 
+/// One chunk's fields needed to re-derive its embedding policy in
+/// [`embedding_policy_skip_summary`].
+struct ChunkForPolicy {
+    chunk_kind: String,
+    symbol_path: Option<String>,
+    start_byte: usize,
+    end_byte: usize,
+    text: String,
+}
+
+/// Reconstruct a file's text from its `start_byte`-ordered chunks. A chunk's stored text is
+/// `file[start_byte..end_byte]` for an LF file, so appending each chunk's tail past the running
+/// length rebuilds the file (overlaps are consistent; `.get()` keeps char boundaries). The chunker
+/// omits WHITESPACE-ONLY gaps (blank lines between symbols) and uses `\n` line endings, so a gap is
+/// padded with newlines — a common case that would otherwise defeat the shared parse. `None` only
+/// on a non-char-boundary slice. The caller trusts the result ONLY when it hashes to
+/// `files.sha256`, so any wrong guess (CRLF / spaces-in-a-gap / older-chunker rows) fails the hash
+/// and the caller falls back to per-chunk text.
+fn reconstruct_file_text(chunks: &[ChunkForPolicy]) -> Option<String> {
+    let mut buf = String::new();
+    for chunk in chunks {
+        for _ in buf.len()..chunk.start_byte {
+            buf.push('\n'); // whitespace-only gap the chunker didn't emit — guess `\n`, sha validates
+        }
+        if chunk.end_byte > buf.len() {
+            buf.push_str(chunk.text.get(buf.len() - chunk.start_byte..)?);
+        }
+    }
+    Some(buf)
+}
+
+/// Count `chunk` into `out` when its policy is ineligible, using `low_signal` for the low-signal
+/// gate (span-based off a shared tree, or the chunk's own text).
+fn tally_chunk_policy(
+    path: &str,
+    language: &str,
+    file_kind: &str,
+    chunk: &ChunkForPolicy,
+    low_signal: LowSignalCheck<'_>,
+    max_embedding_chars: usize,
+    out: &mut BTreeMap<String, u64>,
+) {
+    let decision = embedding_policy_for_chunk(
+        std::path::Path::new(path),
+        language,
+        file_kind,
+        &chunk.chunk_kind,
+        chunk.symbol_path.as_deref(),
+        &chunk.text,
+        max_embedding_chars,
+        low_signal,
+    );
+    if !decision.eligible {
+        *out.entry(decision.policy).or_default() += 1;
+    }
+}
+
+/// Classify one structural file's collected chunks. Reconstructs the file text and parses it ONCE
+/// for span-based low-signal (#516 index-time semantics) — but only when the reconstruction hashes
+/// to `files.sha256`; otherwise each chunk falls back to classification from its own text.
+fn tally_collected_file(
+    path: &str,
+    language: &str,
+    file_kind: &str,
+    sha256: &str,
+    chunks: &[ChunkForPolicy],
+    max_embedding_chars: usize,
+    out: &mut BTreeMap<String, u64>,
+) {
+    // Only reconstruct + parse if at least one chunk actually REACHES the low-signal gate — a file
+    // whose every chunk is eliminated by a cheaper, parse-free gate (path-generated, test-fixture,
+    // too-small, unsupported language) needs no tree-sitter work at all, exactly like the old
+    // per-chunk path which parsed lazily at the low-signal gate.
+    let needs_low_signal = chunks.iter().any(|chunk| {
+        cheap_skip_policy(
+            std::path::Path::new(path),
+            language,
+            file_kind,
+            &chunk.chunk_kind,
+            chunk.symbol_path.as_deref(),
+            chunk.text.trim(),
+            max_embedding_chars,
+        )
+        .is_none()
+    });
+    let parsed = needs_low_signal
+        .then(|| {
+            reconstruct_file_text(chunks)
+                .filter(|buf| crate::index::util::hex_sha256(buf.as_bytes()) == sha256)
+                .and_then(|buf| {
+                    let lang = language.parse::<crate::language::Language>().ok()?;
+                    crate::index::parser::parse_file(std::path::Path::new(path), lang, &buf)
+                        .map(|pf| (lang, pf))
+                })
+        })
+        .flatten();
+    for chunk in chunks {
+        let low_signal = match &parsed {
+            Some((lang, pf)) => LowSignalCheck::FromSpan {
+                language: *lang,
+                root: pf.root(),
+                start_byte: chunk.start_byte,
+                end_byte: chunk.end_byte,
+            },
+            None => LowSignalCheck::FromText,
+        };
+        tally_chunk_policy(path, language, file_kind, chunk, low_signal, max_embedding_chars, out);
+    }
+}
+
 pub(crate) fn embedding_policy_skip_summary(
     conn: &Connection,
     max_embedding_chars: usize,
 ) -> anyhow::Result<BTreeMap<String, u64>> {
-    // Re-derive each chunk's policy from its text and count the ineligible ones by category. This
-    // is DIAGNOSTIC-ONLY (reported in status/plan; nothing gates work on it). It deliberately does
-    // NOT read the persisted `chunks.embedding_policy`: that column is stamped at index time with
-    // DEFAULT_MAX_EMBEDDING_CHARS and (for chunks predating its migration) defaults to 'Embed'
-    // without a backfill, so aggregating it would under-report the skips the authoritative
-    // `select_reconcile_batch` (which recomputes with the runtime cap) actually makes — defeating
-    // the summary's whole job of explaining WHY nothing embedded. Recomputing keeps it exact for
-    // any cap and any index age. Streams one chunk at a time to bound memory (#379): the previous
-    // `current_chunks(conn, None)` materialized every chunk's decompressed text into a `Vec`.
+    // Re-derive each chunk's policy and count the ineligible ones by category. DIAGNOSTIC-ONLY
+    // (reported in status/plan; nothing gates work on it). It deliberately does NOT read the
+    // persisted `chunks.embedding_policy` (stamped at DEFAULT_MAX_EMBEDDING_CHARS and, for
+    // pre-migration chunks, defaulting to 'Embed' with no backfill), which would under-report
+    // skips.
     //
-    // The hotter watcher/maintenance gate (`estimated_reconcile_jobs`) avoids this scan entirely by
-    // ordering its freshness check before the policy check (#522), so the parse there fires only
-    // for genuinely stale chunks.
+    // Low-signal is classified from the file's SHARED parse (`FromSpan`, #516), not by re-parsing
+    // each chunk's text (`FromText`): the summary groups chunks by file, reconstructs the file text
+    // from the chunks' verbatim substrings, and — only when that reconstruction hashes to the
+    // stored `files.sha256` — parses it ONCE and classifies each chunk's span. That is O(files)
+    // parses instead of O(chunks) (chunks overlap, so per-chunk text re-parses overlapped
+    // regions). A file that is generated/markdown, oversized (any chunk past the parse cap), or
+    // whose text does not hash-match (CRLF/normalized/older-chunker rows) falls back to
+    // per-chunk `FromText`.
+    //
+    // NOTE: this makes the summary mirror prep's #516 low-signal classification rather than the
+    // embed path's `FromText`; the two agree except for chunks that slice into a long comment or
+    // string, where `FromSpan` treats the sliced leaf as plumbing — acceptable for a diagnostic.
+    //
+    // Memory is bounded to one structural file's chunks; a file with any oversized chunk flips to
+    // streaming per-chunk classification immediately (#379).
     let mut skipped_by_policy = BTreeMap::new();
     let dicts = crate::query::chunk_text_dicts(conn)?;
     let mut decoder = crate::index::text_compression::ChunkTextDecoder::new(&dicts);
     let mut stmt = conn.prepare(
         "
-        SELECT files.path, files.language, files.kind, chunks.chunk_kind, chunks.symbol_path,
+        SELECT files.id, files.path, files.language, files.kind, files.sha256, chunks.chunk_kind,
+               chunks.symbol_path, chunks.start_byte, chunks.end_byte,
                chunk_text.blob, chunk_text.raw_len, chunk_text.dict_version
         FROM chunks
         JOIN files ON files.id = chunks.file_id
         JOIN chunk_text ON chunk_text.chunk_id = chunks.id
+        ORDER BY files.id, chunks.start_byte
         ",
     )?;
     let mut rows = stmt.query([])?;
+
+    let mut file_id: i64 = -1;
+    let mut path = String::new();
+    let mut language = String::new();
+    let mut file_kind = String::new();
+    let mut sha256 = String::new();
+    let mut collected: Vec<ChunkForPolicy> = Vec::new();
+    let mut streaming = false; // this file already flipped to per-chunk FromText
+
     while let Some(row) = rows.next()? {
-        let path = row.get::<_, String>(0)?;
-        let language = row.get::<_, String>(1)?;
-        let file_kind = row.get::<_, String>(2)?;
-        let chunk_kind = row.get::<_, String>(3)?;
-        let symbol_path = row.get::<_, Option<String>>(4)?;
-        let text = crate::index::text_compression::ChunkTextRow {
-            blob: row.get(5)?,
-            raw_len: row.get(6)?,
-            dict_version: row.get(7)?,
+        let row_file_id: i64 = row.get(0)?;
+        if row_file_id != file_id {
+            if file_id != -1 && !streaming {
+                tally_collected_file(
+                    &path,
+                    &language,
+                    &file_kind,
+                    &sha256,
+                    &collected,
+                    max_embedding_chars,
+                    &mut skipped_by_policy,
+                );
+            }
+            file_id = row_file_id;
+            path = row.get(1)?;
+            language = row.get(2)?;
+            file_kind = row.get(3)?;
+            sha256 = row.get(4)?;
+            collected.clear();
+            streaming = false;
         }
-        .resolve(&mut decoder)?;
-        let decision = embedding_policy_for_chunk(
-            std::path::Path::new(&path),
+        let chunk = ChunkForPolicy {
+            chunk_kind: row.get(5)?,
+            symbol_path: row.get(6)?,
+            start_byte: row.get::<_, i64>(7)? as usize,
+            end_byte: row.get::<_, i64>(8)? as usize,
+            text: crate::index::text_compression::ChunkTextRow {
+                blob: row.get(9)?,
+                raw_len: row.get(10)?,
+                dict_version: row.get(11)?,
+            }
+            .resolve(&mut decoder)?,
+        };
+        // A structural file (has a grammar, not generated) within the parse cap classifies from its
+        // shared tree; anything else streams per-chunk text, bounding memory for huge files.
+        // Markdown is the only indexed language without a tree-sitter grammar (mirrors prep's
+        // gate).
+        let structural = file_kind != "generated"
+            && language
+                .parse::<crate::language::Language>()
+                .is_ok_and(|l| l != crate::language::Language::Markdown);
+        if streaming {
+            tally_chunk_policy(
+                &path,
+                &language,
+                &file_kind,
+                &chunk,
+                LowSignalCheck::FromText,
+                max_embedding_chars,
+                &mut skipped_by_policy,
+            );
+        } else if !structural || chunk.end_byte > crate::index::chunker::MAX_STRUCTURAL_PARSE_BYTES
+        {
+            for collected_chunk in collected.drain(..) {
+                tally_chunk_policy(
+                    &path,
+                    &language,
+                    &file_kind,
+                    &collected_chunk,
+                    LowSignalCheck::FromText,
+                    max_embedding_chars,
+                    &mut skipped_by_policy,
+                );
+            }
+            tally_chunk_policy(
+                &path,
+                &language,
+                &file_kind,
+                &chunk,
+                LowSignalCheck::FromText,
+                max_embedding_chars,
+                &mut skipped_by_policy,
+            );
+            streaming = true;
+        } else {
+            collected.push(chunk);
+        }
+    }
+    if file_id != -1 && !streaming {
+        tally_collected_file(
+            &path,
             &language,
             &file_kind,
-            &chunk_kind,
-            symbol_path.as_deref(),
-            &text,
+            &sha256,
+            &collected,
             max_embedding_chars,
-            LowSignalCheck::FromText,
+            &mut skipped_by_policy,
         );
-        if !decision.eligible {
-            *skipped_by_policy.entry(decision.policy).or_default() += 1;
-        }
     }
     Ok(skipped_by_policy)
 }
@@ -854,6 +1047,42 @@ mod freshness_version_tests {
 
     use super::*;
     use crate::embedding_models::{FASTEMBED_MODEL_ID, HASH_MODEL_ID, spec};
+
+    fn chunk(start_byte: usize, end_byte: usize, text: &str) -> ChunkForPolicy {
+        ChunkForPolicy {
+            chunk_kind: "code".to_string(),
+            symbol_path: None,
+            start_byte,
+            end_byte,
+            text: text.to_string(),
+        }
+    }
+
+    #[test]
+    fn reconstruct_file_text_rebuilds_from_overlapping_chunks() {
+        // Chunks store `file[start..end]`; an overlapping inner chunk's already-buffered prefix is
+        // skipped and only its tail appended. file = "abcdefgh".
+        let chunks = [chunk(0, 5, "abcde"), chunk(3, 8, "defgh")];
+        assert_eq!(reconstruct_file_text(&chunks).as_deref(), Some("abcdefgh"));
+    }
+
+    #[test]
+    fn reconstruct_file_text_handles_abutting_and_multibyte() {
+        // Abutting chunks tile cleanly; a UTF-8 boundary in the middle is respected by `.get()`.
+        let chunks = [chunk(0, 3, "abc"), chunk(3, 6, "def")];
+        assert_eq!(reconstruct_file_text(&chunks).as_deref(), Some("abcdef"));
+        // "café" is 5 bytes (é = 2); split [0,3)="caf" + [3,5)="é".
+        let mb = [chunk(0, 3, "caf"), chunk(3, 5, "é")];
+        assert_eq!(reconstruct_file_text(&mb).as_deref(), Some("café"));
+    }
+
+    #[test]
+    fn reconstruct_file_text_pads_whitespace_gaps_with_newlines() {
+        // Bytes 3..5 are an unchunked whitespace-only gap (blank lines) → padded with '\n'. The
+        // caller's sha check validates the guess; a wrong guess (spaces/CRLF) just fails the hash.
+        let chunks = [chunk(0, 3, "abc"), chunk(5, 8, "fgh")];
+        assert_eq!(reconstruct_file_text(&chunks).as_deref(), Some("abc\n\nfgh"));
+    }
 
     /// One-shot HTTP/1.1 stub replying to the install probe's `/api/embed` with a `dim`-wide
     /// vector.

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/reconcile_embeddings.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/reconcile_embeddings.rs
@@ -1075,3 +1075,123 @@ fn git_history_reload_is_skipped_when_head_is_unchanged() {
 
     let _ = fs::remove_dir_all(root);
 }
+
+#[test]
+fn skip_summary_shared_parse_matches_per_chunk_text() {
+    use std::collections::BTreeMap;
+    use std::path::Path;
+
+    use crate::index::ai::{
+        self, LowSignalCheck, embedding_policy_for_chunk, embedding_policy_skip_summary,
+    };
+    use crate::index::text_compression::{ChunkTextDecoder, ChunkTextRow};
+
+    // The FromSpan (shared-parse) summary must equal the per-chunk FromText computation on a real
+    // index — exercising reconstruction + sha-verify + one-parse-per-file span classification, and
+    // the markdown-fallback gate. Nested symbols (`impl` methods) create OVERLAPPING chunks.
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    // Plumbing-only file (a use-block ≥ MIN_EMBEDDING_CHARS so it reaches the low-signal gate
+    // rather than SkipTooSmall) → low-signal; real-code file → embeds; markdown → fallback
+    // path.
+    fs::write(
+        root.join("src/plumbing.rs"),
+        "use std::collections::HashMap;\nuse std::collections::BTreeMap;\nuse \
+         std::path::PathBuf;\nuse std::sync::Arc;\npub use crate::foo::Bar;\nuse \
+         a::b::c::d::e::f;\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("src/code.rs"),
+        // Blank lines between symbols become unchunked whitespace gaps → exercises `\n`-padded
+        // reconstruction on the shared-parse path (still hash-matches, so FromSpan applies).
+        "pub fn compute(x: i64, y: i64) -> i64 {\n    let sum = x * 2 + y - 1;\n    let scaled = \
+         sum.wrapping_mul(3);\n    scaled - x + y\n}\n\npub struct Foo {\n    n: i64,\n}\n\nimpl \
+         Foo {\n    pub fn bar(&self) -> i64 {\n        self.n + compute(4, 5)\n    }\n}\n",
+    )
+    .unwrap();
+    // A file under `fixtures/` → every chunk is SkipTestFixture (a cheap gate before low-signal),
+    // so the shared-parse path must not reconstruct/parse it.
+    fs::create_dir_all(root.join("src/fixtures")).unwrap();
+    fs::write(
+        root.join("src/fixtures/data.rs"),
+        "pub fn fixture_helper_that_is_long_enough_to_clear_the_min_embedding_chars() -> i64 {\n    \
+         7\n}\n",
+    )
+    .unwrap();
+    // A CRLF file: chunk text is LF-normalized while byte offsets count `\r\n`, so reconstruction
+    // will NOT hash-match `files.sha256` and must fall back to per-chunk FromText (without the
+    // sha-verify guard this would silently corrupt, failing the equality below).
+    fs::write(
+        root.join("src/crlf.rs"),
+        "use std::io::Read;\r\nuse std::io::Write;\r\nuse std::path::Path;\r\npub use \
+         crate::x::Y;\r\nuse a::b::c::d::e;\r\n",
+    )
+    .unwrap();
+    fs::write(root.join("src/readme.md"), "# Title\n\nsome prose that is not code.\n").unwrap();
+
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let conn = db.storage.connection();
+
+    // Reference: the previous per-chunk FromText classification.
+    let reference: BTreeMap<String, u64> = {
+        let dicts = crate::query::chunk_text_dicts(conn).unwrap();
+        let mut decoder = ChunkTextDecoder::new(&dicts);
+        let mut out = BTreeMap::new();
+        let mut stmt = conn
+            .prepare(
+                "SELECT files.path, files.language, files.kind, chunks.chunk_kind,
+                        chunks.symbol_path, chunk_text.blob, chunk_text.raw_len,
+                        chunk_text.dict_version
+                 FROM chunks JOIN files ON files.id = chunks.file_id
+                 JOIN chunk_text ON chunk_text.chunk_id = chunks.id",
+            )
+            .unwrap();
+        let mut rows = stmt.query([]).unwrap();
+        while let Some(row) = rows.next().unwrap() {
+            let path: String = row.get(0).unwrap();
+            let language: String = row.get(1).unwrap();
+            let file_kind: String = row.get(2).unwrap();
+            let chunk_kind: String = row.get(3).unwrap();
+            let symbol_path: Option<String> = row.get(4).unwrap();
+            let text = ChunkTextRow {
+                blob: row.get(5).unwrap(),
+                raw_len: row.get(6).unwrap(),
+                dict_version: row.get(7).unwrap(),
+            }
+            .resolve(&mut decoder)
+            .unwrap();
+            let decision = embedding_policy_for_chunk(
+                Path::new(&path),
+                &language,
+                &file_kind,
+                &chunk_kind,
+                symbol_path.as_deref(),
+                &text,
+                ai::DEFAULT_MAX_EMBEDDING_CHARS,
+                LowSignalCheck::FromText,
+            );
+            if !decision.eligible {
+                *out.entry(decision.policy).or_default() += 1;
+            }
+        }
+        out
+    };
+
+    let span = embedding_policy_skip_summary(conn, ai::DEFAULT_MAX_EMBEDDING_CHARS).unwrap();
+    assert_eq!(span, reference, "shared-parse summary must equal the per-chunk FromText reference");
+    assert!(
+        span.get("SkipLowSignal").copied().unwrap_or(0) >= 1,
+        "the all-import file must contribute a low-signal skip (exercises the shared-parse span \
+         classification): {span:?}"
+    );
+    assert!(
+        span.get("SkipTestFixture").copied().unwrap_or(0) >= 1,
+        "the fixtures/ file must be a test-fixture skip (exercises the parse-free cheap gate): \
+         {span:?}"
+    );
+
+    let _ = fs::remove_dir_all(root);
+}


### PR DESCRIPTION
## What

`embedding_policy_skip_summary` (the diagnostic explaining why chunks didn't embed) re-parsed **each chunk's text** with tree-sitter to derive its low-signal policy — O(chunks) parses on every reconcile, and chunks overlap so overlapped regions were parsed multiple times over.

It now classifies low-signal from **one shared parse per file** (`FromSpan`, the same #516 index-time path): group chunks by file, reconstruct the file text from the chunks' verbatim substrings, and — **only when that reconstruction hashes to the stored `files.sha256`** — parse each file once and classify every chunk's span. O(files) parses instead of O(chunks).

## Correctness

`chunk_text` is line-ending-**normalized** (the chunker strips `\r` and re-adds `\n` while advancing byte offsets over raw lengths), so `raw_len == end − start` is an LF-repo coincidence, not an invariant. The `files.sha256` verification is what makes reconstruction safe: any file whose rebuilt text doesn't hash-match (CRLF / no-trailing-newline / older-chunker rows) falls back to per-chunk `FromText`. Generated / markdown / oversized files also fall back; memory stays bounded to one structural file's chunks (an oversized file flips to streaming per-chunk classification immediately).

## Tradeoff (deliberate)

The summary now mirrors prep's #516 low-signal classification rather than the embed path's `FromText`. The two agree except for a chunk that slices into a long comment/string (where `FromSpan` treats the sliced leaf as plumbing). The summary is diagnostic-only — nothing gates on it — so this is acceptable; documented inline.

## Tests

- `reconstruct_file_text` unit tests: overlap, coverage gap, multibyte boundary.
- End-to-end: the shared-parse summary equals the per-chunk `FromText` reference on a real index — including a **CRLF file**, which exercises the sha-verify fallback (without it the reconstruction would silently corrupt the diagnostic).

Refs #530 — complementary to its version-stamp caching (this makes the recompute cheaper; the stamp skips it when the index is certified unchanged).