### PR TITLE
perf(reconcile): serve the skip-summary from a version-stamped column

### DIFF
--- a/crates/rag-rat-cli/src/commands/index_ops.rs
+++ b/crates/rag-rat-cli/src/commands/index_ops.rs
@@ -132,7 +132,11 @@ pub(crate) fn reconcile(config: &Config, args: &ReconcileArgs) -> anyhow::Result
     // `reconcile --plan --reencode-vectors` from mutating the index during a dry run. Do not
     // reorder.
     if args.plan {
-        let plan = db.reconcile_plan()?;
+        // Same cap the actual reconcile below resolves (`args` override else config), so `--plan`
+        // classifies against exactly what the run it previews will use.
+        let plan = db.reconcile_plan_with_cap(
+            args.max_embedding_chars.unwrap_or(config.llm.embedding.runtime.max_embedding_chars),
+        )?;
         // `--plan` prints a human summary by default; the global `--json` switches to the
         // structured plan.
         if output_format() == OutputFormat::Json {

--- a/crates/rag-rat-core/src/index/ai/policy.rs
+++ b/crates/rag-rat-core/src/index/ai/policy.rs
@@ -1,5 +1,27 @@
 use super::*;
 
+/// Behavior version of the embedding-policy classifier. It certifies that a persisted
+/// `chunks.embedding_policy` value reflects the CURRENT classifier — the reconcile skip-summary
+/// reads the column via `GROUP BY` (the always-fast path, #530) only when a full rebuild has
+/// stamped this version into `repo_meta`. It is the hash of `embedding_policy_for_chunk`'s
+/// decisions over a fixed corpus, pinned by `policy_version_tests`: any behavior change — a
+/// threshold, a gate, a plumbing node kind, or a tree-sitter grammar bump that reclassifies a node
+/// with zero rag-rat source diff — changes the hash and reddens that test with the value to set
+/// here. That is what makes the version impossible to forget: a hand-bumped const fails UNSAFE (a
+/// stale-but-matching stamp would let the fast path serve mixed-code counts). A version mismatch
+/// instead correctly forces the slow recompute. See the freshness-model Risk memory bound to this
+/// file.
+pub(crate) const EMBEDDING_POLICY_VERSION: &str = "255dcc2c31e35a19";
+
+/// `repo_meta` keys carrying the embedding-policy freshness stamp a full rebuild writes
+/// (`mark_embedding_policy_current`). PER-REPO, not the DB-global `index_meta`: one database can
+/// host several repos and a rebuild of one must not certify another's un-rebuilt column.
+/// `_VERSION_KEY` stores [`EMBEDDING_POLICY_VERSION`]; `_CAP_KEY` stores the char cap the column
+/// was stamped at (always [`DEFAULT_MAX_EMBEDDING_CHARS`] — prep stamps at the default), so the
+/// fast path can refuse a request at a different cap that would re-bucket `SkipTooLarge`.
+pub(crate) const EMBEDDING_POLICY_VERSION_KEY: &str = "embedding_policy_version";
+pub(crate) const EMBEDDING_POLICY_CAP_KEY: &str = "embedding_policy_cap";
+
 pub(crate) fn needs_embedding(
     chunk: &CurrentChunk,
     model_id: &str,
@@ -458,5 +480,332 @@ mod low_signal_span_tests {
         let src = "use a::b;\nfn real() {}\n";
         let file = parsed("s.rs", Language::Rust, src);
         assert!(!is_low_signal_span(Language::Rust, file.root(), 0, src.len()));
+    }
+}
+
+/// Behavior-hash tripwire for [`EMBEDDING_POLICY_VERSION`] (#530). The corpus routes through every
+/// embedding-policy gate — the parse-free cheap gates and the low-signal gate, the latter both
+/// `FromText` and `FromSpan` across every grammar — so any classifier change (a threshold, a gate,
+/// a plumbing node kind) or a tree-sitter grammar bump that reclassifies a node changes the hash
+/// and fails this test with the value to set. The version certifies the persisted
+/// `chunks.embedding_policy` column, so it must move whenever the classifier's output could.
+#[cfg(test)]
+mod policy_version_tests {
+    use std::fmt::Write as _;
+    use std::path::Path;
+
+    use super::{
+        DEFAULT_MAX_EMBEDDING_CHARS, EMBEDDING_POLICY_VERSION, LowSignalCheck, MIN_EMBEDDING_CHARS,
+        embedding_policy_for_chunk,
+    };
+    use crate::index::parser;
+    use crate::index::util::hex_sha256;
+    use crate::language::Language;
+
+    fn record(sig: &mut String, label: &str, d: &super::EmbeddingPolicyDecision) {
+        let _ = writeln!(sig, "{label}|{}|{}|{}", d.policy, d.priority, d.eligible);
+    }
+
+    fn behavior_signature() -> String {
+        let mut sig = String::new();
+        let big = "x".repeat(20_000);
+        // Boundary-adjacent lengths pinned as LITERALS (not `MIN_EMBEDDING_CHARS`, which would move
+        // with the constant and never flip): one exactly AT the current MIN and one just BELOW it,
+        // so a `<` vs `<=` change or an off-by-one shift of the SkipTooSmall gate flips the
+        // hash.
+        let at_min = "a".repeat(80);
+        let below_min = "a".repeat(79);
+
+        // Parse-free cheap gates (FromText — no tree needed for these to decide).
+        // (label, path, language, file_kind, chunk_kind, symbol_path, text, cap)
+        type TextCase<'a> =
+            (&'a str, &'a str, &'a str, &'a str, &'a str, Option<&'a str>, &'a str, usize);
+        let text_cases: &[TextCase] = &[
+            ("too_large_generated", "a.rs", "rust", "generated", "code", None, &big, 4000),
+            ("too_large_no_symbol", "a.rs", "rust", "source", "code", None, &big, 4000),
+            ("at_min_len", "a.rs", "rust", "source", "code", Some("s"), &at_min, 4000),
+            ("below_min_len", "a.rs", "rust", "source", "code", Some("s"), &below_min, 4000),
+            // FromText low-signal branch (`is_low_signal_chunk`) — the classifier used for
+            // oversized / markdown / parse-failure files, which the span cases below
+            // do NOT exercise. An all-imports block (>= MIN) is low-signal; a real
+            // definition is not.
+            (
+                "fromtext_plumbing",
+                "a.rs",
+                "rust",
+                "source",
+                "code",
+                Some("s"),
+                "use std::collections::HashMap;\nuse std::fmt::Debug;\nuse std::io::Read;\nuse \
+                 std::sync::Arc;\n",
+                4000,
+            ),
+            (
+                "fromtext_signal",
+                "a.rs",
+                "rust",
+                "source",
+                "code",
+                Some("s"),
+                "pub fn real_function(x: i64) -> i64 {\n    let value = x * 2 + 1;\n    \
+                 value.wrapping_mul(3)\n}\n",
+                4000,
+            ),
+            (
+                "generated_file_kind",
+                "a.rs",
+                "rust",
+                "generated",
+                "code",
+                Some("s"),
+                "fn a() {}",
+                4000,
+            ),
+            (
+                "generated_chunk_kind",
+                "a.rs",
+                "rust",
+                "source",
+                "generated",
+                Some("s"),
+                "fn a() {}",
+                4000,
+            ),
+            (
+                "generated_path",
+                "pkg/target/a.rs",
+                "rust",
+                "source",
+                "code",
+                Some("s"),
+                "fn a() { let value = compute(); process(value); }",
+                4000,
+            ),
+            (
+                "test_fixture_path",
+                "pkg/fixtures/a.rs",
+                "rust",
+                "source",
+                "code",
+                Some("s"),
+                "fn a() { let value = compute(); process(value); }",
+                4000,
+            ),
+            (
+                "lang_unsupported",
+                "a.txt",
+                "plaintext",
+                "source",
+                "code",
+                Some("s"),
+                "some prose here that is long enough to clear the small gate for sure",
+                4000,
+            ),
+            ("too_small", "a.rs", "rust", "source", "code", Some("s"), "fn a() {}", 4000),
+            (
+                "embed_plain",
+                "a.rs",
+                "rust",
+                "source",
+                "code",
+                Some("s"),
+                "fn real() { let value = compute_something(); process_the(value); done(); }",
+                4000,
+            ),
+        ];
+        for (label, path, lang, fk, ck, sp, text, cap) in text_cases {
+            let d = embedding_policy_for_chunk(
+                Path::new(path),
+                lang,
+                fk,
+                ck,
+                *sp,
+                text,
+                *cap,
+                LowSignalCheck::FromText,
+            );
+            record(&mut sig, label, &d);
+        }
+
+        // EVERY path-predicate branch of `looks_generated_path` + `is_test_fixture_path`, so an
+        // edit to any one of them flips the hash (the two path cases above only sample
+        // `/target/` and `/fixtures/`). A non-generated, non-fixture path is the code
+        // default and is already covered by `embed_plain` / the span cases.
+        let path_cases: &[&str] = &[
+            "pkg/generated/a.rs",
+            "pkg/src/generated/a.rs",
+            "pkg/target/a.rs",
+            "Cargo.lock",
+            "some/dir/package-lock.json",
+            "some/dir/pnpm-lock.yaml",
+            "pkg/fixtures/a.rs",
+            "pkg/__fixtures__/a.rs",
+            "pkg/testdata/a.rs",
+            "pkg/snapshots/a.rs",
+            "pkg/thing.snap",
+        ];
+        for path in path_cases {
+            // A path gate fires before the low-signal check, so the text and cap are immaterial
+            // here.
+            let d = embedding_policy_for_chunk(
+                Path::new(path),
+                "rust",
+                "source",
+                "code",
+                Some("s"),
+                "fn a() { let value = compute(); process(value); }",
+                4000,
+                LowSignalCheck::FromText,
+            );
+            record(&mut sig, &format!("path_{path}"), &d);
+        }
+
+        // Low-signal via FromSpan across every grammar: a pure-plumbing file (imports/comments
+        // only, >=80 chars so it reaches the low-signal gate) classifies low-signal; a file
+        // with a real definition classifies as signal. Exercises `is_plumbing_node` per
+        // language + the grammar. (label, path, language, plumbing_src, def_src)
+        // Every fixture is >=80 chars so it clears the SkipTooSmall gate and actually reaches the
+        // span classifier (the point of the FromSpan cases). Whatever each classifies as is the
+        // pinned behavior; a grammar bump that reclassifies a node flips the hash.
+        let span_cases: &[(&str, &str, Language, &str, &str)] = &[
+            (
+                "rust",
+                "s.rs",
+                Language::Rust,
+                "use std::collections::HashMap;\nuse std::fmt::Debug;\n// a descriptive comment \
+                 line\nuse std::io::Read;\nuse std::sync::Arc;\n",
+                "pub fn real_function(input: i32) -> i32 {\n    let value = input + 1;\n    \
+                 println!(\"{}\", value);\n    another_call(value)\n}\n",
+            ),
+            (
+                "typescript",
+                "s.ts",
+                Language::TypeScript,
+                "import defaultThing from 'a';\n// a descriptive comment line here now\nimport { \
+                 namedThing } from 'b';\nimport * as ns from 'c';\n",
+                "export function realFunction(input: number): number {\n    const value = input + \
+                 1;\n    return value + compute(value);\n}\n",
+            ),
+            (
+                "kotlin",
+                "s.kt",
+                Language::Kotlin,
+                "package com.example.app\nimport kotlin.collections.List\n// a descriptive \
+                 comment line here now\nimport kotlin.io.println\n",
+                "fun realFunction(input: Int): Int {\n    val value = input + 1\n    return value \
+                 + compute(value)\n}\n",
+            ),
+            (
+                "c",
+                "s.c",
+                Language::C,
+                "#include <stdio.h>\n#include \"local_header.h\"\n// a descriptive comment line \
+                 here now goes on\n#include <string.h>\n",
+                "int real_function(int input) {\n    int value = input + 1;\n    return value + \
+                 compute(value);\n}\n",
+            ),
+            (
+                "cpp",
+                "s.cpp",
+                Language::Cpp,
+                "#include <vector>\n#include <string>\n// a descriptive comment line here now \
+                 goes on and on\n#include <memory>\n",
+                "int real_function(int input) {\n    int value = input + 1;\n    return value + \
+                 compute(value);\n}\n",
+            ),
+            (
+                "python",
+                "s.py",
+                Language::Python,
+                "import os\nimport sys\nfrom collections import defaultdict\n# a descriptive \
+                 comment line here now goes on\n",
+                "def real_function(input):\n    value = input + 1\n    result = value + \
+                 compute(value)\n    return result\n",
+            ),
+        ];
+        for (label, path, language, plumbing, def) in span_cases {
+            let pf =
+                parser::parse_file(Path::new(path), *language, plumbing).expect("plumbing parses");
+            let d = embedding_policy_for_chunk(
+                Path::new(path),
+                &language.to_string(),
+                "source",
+                "code",
+                Some("s"),
+                plumbing,
+                4000,
+                LowSignalCheck::FromSpan {
+                    language: *language,
+                    root: pf.root(),
+                    start_byte: 0,
+                    end_byte: plumbing.len(),
+                },
+            );
+            record(&mut sig, &format!("span_plumbing_{label}"), &d);
+
+            let df = parser::parse_file(Path::new(path), *language, def).expect("def parses");
+            let d = embedding_policy_for_chunk(
+                Path::new(path),
+                &language.to_string(),
+                "source",
+                "code",
+                Some("s"),
+                def,
+                4000,
+                LowSignalCheck::FromSpan {
+                    language: *language,
+                    root: df.root(),
+                    start_byte: 0,
+                    end_byte: def.len(),
+                },
+            );
+            record(&mut sig, &format!("span_def_{label}"), &d);
+        }
+
+        // Fold the governing thresholds in directly, so a change to any of them flips the hash even
+        // if no corpus case happens to straddle the new boundary (the `MIN 80→79` blind spot).
+        let _ = writeln!(
+            sig,
+            "consts|{}|{}|{}",
+            MIN_EMBEDDING_CHARS,
+            DEFAULT_MAX_EMBEDDING_CHARS,
+            crate::index::chunker::MAX_STRUCTURAL_PARSE_BYTES,
+        );
+
+        sig
+    }
+
+    #[test]
+    fn policy_version_pins_classifier_behavior() {
+        let hash = &hex_sha256(behavior_signature().as_bytes())[..16];
+        assert_eq!(
+            hash, EMBEDDING_POLICY_VERSION,
+            "embedding-policy behavior changed (a classifier gate/threshold or a tree-sitter \
+             grammar bump); set EMBEDDING_POLICY_VERSION to \"{hash}\""
+        );
+    }
+
+    #[test]
+    fn corpus_exercises_every_policy() {
+        // The tripwire only pins the HASH; this guards that the corpus keeps EXERCISING every
+        // policy outcome, so a future corpus edit that collapses cases (e.g. every case
+        // falling into `SkipTooSmall`) can't silently weaken the version guard. `record`
+        // writes `label|policy|..`.
+        let sig = behavior_signature();
+        for expected in [
+            "SkipTooLarge",
+            "SkipGenerated",
+            "SkipTestFixture",
+            "SkipLanguageUnsupported",
+            "SkipTooSmall",
+            "SkipLowSignal",
+            "Embed",
+        ] {
+            assert!(
+                sig.contains(&format!("|{expected}|")),
+                "the version corpus must exercise {expected} — otherwise the hash guard covers \
+                 less than it appears to"
+            );
+        }
     }
 }

--- a/crates/rag-rat-core/src/index/ai/reconcile/embed_loop.rs
+++ b/crates/rag-rat-core/src/index/ai/reconcile/embed_loop.rs
@@ -130,6 +130,14 @@ pub(crate) fn reconcile_with_options_progress(
     // like the Ready path.
     let acquired = match acquired {
         skip @ (ChunkEmbedder::SkipEphemeral | ChunkEmbedder::NoEphemeralWork) => {
+            // NoEphemeralWork is an EXPLICIT `rag-rat reconcile` with nothing to embed — still a
+            // good moment to certify the policy column after a version bump so later
+            // plans take the fast path. SkipEphemeral is a FREQUENT watcher/maintenance
+            // deferral and must stay cheap: no heal scan. (The heal itself no-ops
+            // unless the stamp is stale at the DEFAULT cap.)
+            if matches!(skip, ChunkEmbedder::NoEphemeralWork) {
+                maybe_heal_embedding_policy(conn, max_embedding_chars);
+            }
             let (status, message) = match skip {
                 ChunkEmbedder::SkipEphemeral => (
                     "Blocked",
@@ -187,7 +195,9 @@ pub(crate) fn reconcile_with_options_progress(
     };
 
     // Ready / NotReady: BOTH report the per-policy skip counts, so run the repo-wide policy summary
-    // now. (SkipEphemeral already returned above without paying it.)
+    // now. (SkipEphemeral already returned above without paying it.) Self-heal the policy column
+    // first so this summary and every later reconcile/plan take the fast GROUP BY path.
+    maybe_heal_embedding_policy(conn, max_embedding_chars);
     let skipped_by_policy = embedding_policy_skip_summary(conn, max_embedding_chars)?;
     let skipped_chunks = skipped_by_policy.values().sum();
     let mut report = ReconcileReport {
@@ -736,8 +746,11 @@ fn remote_request_group_ranges(
 }
 
 /// One chunk's fields needed to re-derive its embedding policy in
-/// [`embedding_policy_skip_summary`].
+/// [`embedding_policy_skip_summary`]. `id` + `current_policy` let the self-heal write back ONLY the
+/// chunks whose recomputed policy actually differs from what is persisted.
 struct ChunkForPolicy {
+    id: i64,
+    current_policy: String,
     chunk_kind: String,
     symbol_path: Option<String>,
     start_byte: usize,
@@ -766,18 +779,18 @@ fn reconstruct_file_text(chunks: &[ChunkForPolicy]) -> Option<String> {
     Some(buf)
 }
 
-/// Count `chunk` into `out` when its policy is ineligible, using `low_signal` for the low-signal
-/// gate (span-based off a shared tree, or the chunk's own text).
-fn tally_chunk_policy(
+/// Re-derive one chunk's embedding policy, using `low_signal` for the low-signal gate (span-based
+/// off a shared tree, or the chunk's own text). Callers decide what to do with the decision (tally
+/// it, or write it back).
+fn classify_chunk(
     path: &str,
     language: &str,
     file_kind: &str,
     chunk: &ChunkForPolicy,
     low_signal: LowSignalCheck<'_>,
     max_embedding_chars: usize,
-    out: &mut BTreeMap<String, u64>,
-) {
-    let decision = embedding_policy_for_chunk(
+) -> EmbeddingPolicyDecision {
+    embedding_policy_for_chunk(
         std::path::Path::new(path),
         language,
         file_kind,
@@ -786,24 +799,21 @@ fn tally_chunk_policy(
         &chunk.text,
         max_embedding_chars,
         low_signal,
-    );
-    if !decision.eligible {
-        *out.entry(decision.policy).or_default() += 1;
-    }
+    )
 }
 
 /// Classify one structural file's collected chunks. Reconstructs the file text and parses it ONCE
 /// for span-based low-signal (#516 index-time semantics) — but only when the reconstruction hashes
 /// to `files.sha256`; otherwise each chunk falls back to classification from its own text.
-fn tally_collected_file(
+fn classify_collected_file(
     path: &str,
     language: &str,
     file_kind: &str,
     sha256: &str,
     chunks: &[ChunkForPolicy],
     max_embedding_chars: usize,
-    out: &mut BTreeMap<String, u64>,
-) {
+    emit: &mut impl FnMut(&ChunkForPolicy, EmbeddingPolicyDecision) -> anyhow::Result<()>,
+) -> anyhow::Result<()> {
     // Only reconstruct + parse if at least one chunk actually REACHES the low-signal gate — a file
     // whose every chunk is eliminated by a cheaper, parse-free gate (path-generated, test-fixture,
     // too-small, unsupported language) needs no tree-sitter work at all, exactly like the old
@@ -841,43 +851,128 @@ fn tally_collected_file(
             },
             None => LowSignalCheck::FromText,
         };
-        tally_chunk_policy(path, language, file_kind, chunk, low_signal, max_embedding_chars, out);
+        emit(
+            chunk,
+            classify_chunk(path, language, file_kind, chunk, low_signal, max_embedding_chars),
+        )?;
     }
+    Ok(())
 }
 
+/// Per-skip-reason counts of the chunks the embedding policy would skip. DIAGNOSTIC-ONLY (reported
+/// in the reconcile report and `reconcile --plan`; nothing gates real work on it).
+///
+/// FAST PATH (#530): when a full rebuild has certified `chunks.embedding_policy` current for this
+/// repo (the `repo_meta` version stamp matches [`EMBEDDING_POLICY_VERSION`]) AND the caller wants
+/// the cap the column was stamped at, the counts come straight from the column via `GROUP BY` — no
+/// tree-sitter parse, no chunk-text decompress. A stale/absent stamp, or a different cap, falls
+/// through to the slow recompute (correct, but O(files) parses). The column is the index-time
+/// truth; the recompute approximates it, so they can differ by a few chunks that slice a long
+/// comment/string (FromSpan vs FromText) — acceptable for a diagnostic, and precisely why the
+/// version stamp gates the read.
 pub(crate) fn embedding_policy_skip_summary(
     conn: &Connection,
     max_embedding_chars: usize,
 ) -> anyhow::Result<BTreeMap<String, u64>> {
-    // Re-derive each chunk's policy and count the ineligible ones by category. DIAGNOSTIC-ONLY
-    // (reported in status/plan; nothing gates work on it). It deliberately does NOT read the
-    // persisted `chunks.embedding_policy` (stamped at DEFAULT_MAX_EMBEDDING_CHARS and, for
-    // pre-migration chunks, defaulting to 'Embed' with no backfill), which would under-report
-    // skips.
-    //
-    // Low-signal is classified from the file's SHARED parse (`FromSpan`, #516), not by re-parsing
-    // each chunk's text (`FromText`): the summary groups chunks by file, reconstructs the file text
-    // from the chunks' verbatim substrings, and — only when that reconstruction hashes to the
-    // stored `files.sha256` — parses it ONCE and classifies each chunk's span. That is O(files)
-    // parses instead of O(chunks) (chunks overlap, so per-chunk text re-parses overlapped
-    // regions). A file that is generated/markdown, oversized (any chunk past the parse cap), or
-    // whose text does not hash-match (CRLF/normalized/older-chunker rows) falls back to
-    // per-chunk `FromText`.
-    //
-    // NOTE: this makes the summary mirror prep's #516 low-signal classification rather than the
-    // embed path's `FromText`; the two agree except for chunks that slice into a long comment or
-    // string, where `FromSpan` treats the sliced leaf as plumbing — acceptable for a diagnostic.
-    //
-    // Memory is bounded to one structural file's chunks; a file with any oversized chunk flips to
-    // streaming per-chunk classification immediately (#379).
+    if let Some(fast) = policy_skip_summary_from_column(conn, max_embedding_chars)? {
+        return Ok(fast);
+    }
+    recompute_policy_skip_summary(conn, max_embedding_chars)
+}
+
+/// Read the per-policy counts straight from the persisted `chunks.embedding_policy` column, but
+/// ONLY when a full rebuild has stamped it current for this repo (`EMBEDDING_POLICY_VERSION`) at
+/// the requested cap. `None` — stamp absent/stale, or a different cap — tells the caller to
+/// recompute.
+fn policy_skip_summary_from_column(
+    conn: &Connection,
+    max_embedding_chars: usize,
+) -> anyhow::Result<Option<BTreeMap<String, u64>>> {
+    let repo_id = crate::index::schema::active_repo_id(conn)?;
+    let version = crate::index::meta::repo_meta(conn, &repo_id, EMBEDDING_POLICY_VERSION_KEY)?;
+    let cap = crate::index::meta::repo_meta(conn, &repo_id, EMBEDDING_POLICY_CAP_KEY)?;
+    // Trust the column ONLY when the CURRENT classifier stamped it (version) AND at the cap the
+    // caller wants: a different cap re-buckets SkipTooLarge/truncation, which the
+    // default-stamped column can't reflect. Both gates fail SAFE — a miss just recomputes.
+    if version.as_deref() != Some(EMBEDDING_POLICY_VERSION)
+        || cap.as_deref() != Some(max_embedding_chars.to_string().as_str())
+    {
+        return Ok(None);
+    }
+    // BYTE-IDENTICAL FROM/JOIN to the recompute (scope view + chunk_text presence) so the counted
+    // row SET is the same; only the classification source differs. `Embed` is the sole eligible
+    // policy, so excluding it yields exactly the ineligible-skip counts the recompute tallies.
+    let mut stmt = conn.prepare(
+        "
+        SELECT chunks.embedding_policy, COUNT(*)
+        FROM chunks
+        JOIN files ON files.id = chunks.file_id
+        JOIN chunk_text ON chunk_text.chunk_id = chunks.id
+        WHERE chunks.embedding_policy != 'Embed'
+        GROUP BY chunks.embedding_policy
+        ",
+    )?;
+    let mut out = BTreeMap::new();
+    let mut rows = stmt.query([])?;
+    while let Some(row) = rows.next()? {
+        let policy: String = row.get(0)?;
+        let count: i64 = row.get(1)?;
+        out.insert(policy, u64::try_from(count).unwrap_or(0));
+    }
+    Ok(Some(out))
+}
+
+/// The slow path: re-derive each chunk's policy from source and count the ineligible ones by
+/// category. Used when the fast path can't certify the column (stale/absent stamp, or a non-default
+/// cap). It deliberately does NOT read `chunks.embedding_policy` (stamped at
+/// `DEFAULT_MAX_EMBEDDING_CHARS`, and for pre-migration chunks defaulting to 'Embed' with no
+/// backfill) — that uncertified column is what the fast path gates on; here we recompute the ground
+/// truth.
+fn recompute_policy_skip_summary(
+    conn: &Connection,
+    max_embedding_chars: usize,
+) -> anyhow::Result<BTreeMap<String, u64>> {
     let mut skipped_by_policy = BTreeMap::new();
+    for_each_recomputed_chunk_policy(conn, max_embedding_chars, |_chunk, decision| {
+        if !decision.eligible {
+            *skipped_by_policy.entry(decision.policy).or_default() += 1;
+        }
+        Ok(())
+    })?;
+    Ok(skipped_by_policy)
+}
+
+/// Re-derive every chunk's embedding policy from source and hand each `(chunk_id, decision)` to
+/// `emit`. This is the shared engine behind the skip-summary recompute (which tallies) and the
+/// reconcile self-heal (which writes the decision back to `chunks.embedding_policy`).
+///
+/// Low-signal is classified from the file's SHARED parse (`FromSpan`, #516), not by re-parsing each
+/// chunk's text (`FromText`): it groups chunks by file, reconstructs the file text from the chunks'
+/// verbatim substrings, and — only when that reconstruction hashes to the stored `files.sha256` —
+/// parses it ONCE and classifies each chunk's span. That is O(files) parses instead of O(chunks)
+/// (chunks overlap, so per-chunk text re-parses overlapped regions). A file that is generated/
+/// markdown, oversized (any chunk past the parse cap), or whose text does not hash-match
+/// (CRLF/normalized/older-chunker rows) falls back to per-chunk `FromText`.
+///
+/// NOTE: this mirrors prep's #516 low-signal classification, so the self-heal writeback re-derives
+/// exactly what a reindex would stamp; it differs from the embed path's `FromText` only for chunks
+/// that slice into a long comment/string, where `FromSpan` treats the sliced leaf as plumbing.
+///
+/// Memory is bounded to one structural file's chunks; a file with any oversized chunk flips to
+/// streaming per-chunk classification immediately (#379).
+fn for_each_recomputed_chunk_policy(
+    conn: &Connection,
+    max_embedding_chars: usize,
+    mut emit: impl FnMut(&ChunkForPolicy, EmbeddingPolicyDecision) -> anyhow::Result<()>,
+) -> anyhow::Result<()> {
     let dicts = crate::query::chunk_text_dicts(conn)?;
     let mut decoder = crate::index::text_compression::ChunkTextDecoder::new(&dicts);
     let mut stmt = conn.prepare(
         "
-        SELECT files.id, files.path, files.language, files.kind, files.sha256, chunks.chunk_kind,
-               chunks.symbol_path, chunks.start_byte, chunks.end_byte,
-               chunk_text.blob, chunk_text.raw_len, chunk_text.dict_version
+        SELECT files.id, files.path, files.language, files.kind, files.sha256, chunks.id,
+               chunks.chunk_kind, chunks.symbol_path, chunks.start_byte, chunks.end_byte,
+               chunk_text.blob, chunk_text.raw_len, chunk_text.dict_version, \
+         chunks.embedding_policy
         FROM chunks
         JOIN files ON files.id = chunks.file_id
         JOIN chunk_text ON chunk_text.chunk_id = chunks.id
@@ -898,15 +993,15 @@ pub(crate) fn embedding_policy_skip_summary(
         let row_file_id: i64 = row.get(0)?;
         if row_file_id != file_id {
             if file_id != -1 && !streaming {
-                tally_collected_file(
+                classify_collected_file(
                     &path,
                     &language,
                     &file_kind,
                     &sha256,
                     &collected,
                     max_embedding_chars,
-                    &mut skipped_by_policy,
-                );
+                    &mut emit,
+                )?;
             }
             file_id = row_file_id;
             path = row.get(1)?;
@@ -917,16 +1012,18 @@ pub(crate) fn embedding_policy_skip_summary(
             streaming = false;
         }
         let chunk = ChunkForPolicy {
-            chunk_kind: row.get(5)?,
-            symbol_path: row.get(6)?,
-            start_byte: row.get::<_, i64>(7)? as usize,
-            end_byte: row.get::<_, i64>(8)? as usize,
+            id: row.get(5)?,
+            chunk_kind: row.get(6)?,
+            symbol_path: row.get(7)?,
+            start_byte: row.get::<_, i64>(8)? as usize,
+            end_byte: row.get::<_, i64>(9)? as usize,
             text: crate::index::text_compression::ChunkTextRow {
-                blob: row.get(9)?,
-                raw_len: row.get(10)?,
-                dict_version: row.get(11)?,
+                blob: row.get(10)?,
+                raw_len: row.get(11)?,
+                dict_version: row.get(12)?,
             }
             .resolve(&mut decoder)?,
+            current_policy: row.get(13)?,
         };
         // A structural file (has a grammar, not generated) within the parse cap classifies from its
         // shared tree; anything else streams per-chunk text, bounding memory for huge files.
@@ -937,54 +1034,200 @@ pub(crate) fn embedding_policy_skip_summary(
                 .parse::<crate::language::Language>()
                 .is_ok_and(|l| l != crate::language::Language::Markdown);
         if streaming {
-            tally_chunk_policy(
-                &path,
-                &language,
-                &file_kind,
+            emit(
                 &chunk,
-                LowSignalCheck::FromText,
-                max_embedding_chars,
-                &mut skipped_by_policy,
-            );
-        } else if !structural || chunk.end_byte > crate::index::chunker::MAX_STRUCTURAL_PARSE_BYTES
-        {
-            for collected_chunk in collected.drain(..) {
-                tally_chunk_policy(
+                classify_chunk(
                     &path,
                     &language,
                     &file_kind,
-                    &collected_chunk,
+                    &chunk,
                     LowSignalCheck::FromText,
                     max_embedding_chars,
-                    &mut skipped_by_policy,
-                );
+                ),
+            )?;
+        } else if !structural || chunk.end_byte > crate::index::chunker::MAX_STRUCTURAL_PARSE_BYTES
+        {
+            for collected_chunk in collected.drain(..) {
+                emit(
+                    &collected_chunk,
+                    classify_chunk(
+                        &path,
+                        &language,
+                        &file_kind,
+                        &collected_chunk,
+                        LowSignalCheck::FromText,
+                        max_embedding_chars,
+                    ),
+                )?;
             }
-            tally_chunk_policy(
-                &path,
-                &language,
-                &file_kind,
+            emit(
                 &chunk,
-                LowSignalCheck::FromText,
-                max_embedding_chars,
-                &mut skipped_by_policy,
-            );
+                classify_chunk(
+                    &path,
+                    &language,
+                    &file_kind,
+                    &chunk,
+                    LowSignalCheck::FromText,
+                    max_embedding_chars,
+                ),
+            )?;
             streaming = true;
         } else {
             collected.push(chunk);
         }
     }
     if file_id != -1 && !streaming {
-        tally_collected_file(
+        classify_collected_file(
             &path,
             &language,
             &file_kind,
             &sha256,
             &collected,
             max_embedding_chars,
-            &mut skipped_by_policy,
-        );
+            &mut emit,
+        )?;
     }
-    Ok(skipped_by_policy)
+    Ok(())
+}
+
+/// Reconcile-only self-heal (#530). When the persisted `chunks.embedding_policy` column is NOT
+/// certified current for this repo (a stale/absent version stamp — e.g. after a rag-rat upgrade
+/// that changed the classifier or bumped a tree-sitter grammar), re-derive every chunk's policy at
+/// the DEFAULT cap (what prep stamps) and write it back, then stamp the version current. One slow
+/// reconcile pays for it; every later reconcile/plan then takes the fast GROUP BY path — so a
+/// version bump does not leave a long-lived, never-fully-rebuilt index paying the O(files) parse
+/// forever.
+///
+/// Runs ONLY on the reconcile write path (holds the write flock); `status`/plan stays read-only and
+/// simply recomputes in the rare stale window. For the small fraction of files whose reconstruction
+/// does not hash-match (CRLF/normalized), the writeback persists the FromText decision; the next
+/// incremental reindex of those files overwrites it with prep's FromSpan value. Diagnostic-only, so
+/// that transient difference is acceptable.
+/// Whether the connection's active scope covers the repo's ENTIRE live file set — i.e. there is no
+/// other live scope this connection can't see. "Outside the active scope" is `commit_sha != active
+/// AND worktree_id != active` at the live generation, the exact predicate
+/// `carry_forward_live_overlays` uses (a row is in scope when its commit matches the active HEAD OR
+/// its worktree matches the active overlay). Correctly ignores the base checkout's own committed +
+/// dirty split (both share one of the active keys) and only trips on a second linked-worktree
+/// overlay / other-commit leftover.
+fn active_scope_covers_all_live_rows(conn: &Connection, repo_id: &str) -> anyhow::Result<bool> {
+    use crate::index::schema::{active_generation, connection_context_value};
+    let generation = active_generation(conn)?;
+    let commit_sha = connection_context_value(conn, "commit_sha").unwrap_or_default();
+    let worktree_id = connection_context_value(conn, "worktree_id").unwrap_or_default();
+    // A whole-generation BARE open (`write_repo_generation_view`, e.g. the MCP read path) serves
+    // EVERY live row for the repo with NO commit/worktree filter, writing both context keys empty.
+    // Every scoped open — even a non-git base — carries a non-empty `worktree_id` (the root path
+    // via `worktree_id_of`), so `("", "")` uniquely means "the active `files` view already
+    // covers the whole live set", i.e. the heal reparses everything. Full coverage.
+    if commit_sha.is_empty() && worktree_id.is_empty() {
+        return Ok(true);
+    }
+    let has_other_scope: bool = conn.query_row(
+        "SELECT EXISTS(
+             SELECT 1 FROM main.files
+             WHERE repo_id = ?1 AND generation = ?2 AND commit_sha != ?3 AND worktree_id != ?4
+         )",
+        params![repo_id, generation, commit_sha, worktree_id],
+        |row| row.get(0),
+    )?;
+    Ok(!has_other_scope)
+}
+
+/// Best-effort self-heal wrapper for the reconcile paths. Runs [`ensure_embedding_policy_current`]
+/// ONLY when this reconcile is at the DEFAULT cap: the heal reclassifies + stamps the column at
+/// DEFAULT, which only the DEFAULT-cap fast path can then read. A custom-cap reconcile would still
+/// recompute the summary at its own cap, so healing at DEFAULT would just DOUBLE the parse pass —
+/// skip it there. A heal failure is swallowed (the slow recompute is still correct), so it never
+/// aborts the reconcile.
+fn maybe_heal_embedding_policy(conn: &Connection, max_embedding_chars: usize) {
+    if max_embedding_chars != DEFAULT_MAX_EMBEDDING_CHARS {
+        return;
+    }
+    if let Err(err) = ensure_embedding_policy_current(conn) {
+        tracing::debug!(?err, "embedding-policy column self-heal skipped");
+    }
+}
+
+pub(crate) fn ensure_embedding_policy_current(conn: &Connection) -> anyhow::Result<()> {
+    let repo_id = crate::index::schema::active_repo_id(conn)?;
+    let version = crate::index::meta::repo_meta(conn, &repo_id, EMBEDDING_POLICY_VERSION_KEY)?;
+    let cap = crate::index::meta::repo_meta(conn, &repo_id, EMBEDDING_POLICY_CAP_KEY)?;
+    if version.as_deref() == Some(EMBEDDING_POLICY_VERSION)
+        && cap.as_deref() == Some(DEFAULT_MAX_EMBEDDING_CHARS.to_string().as_str())
+    {
+        return Ok(()); // already certified current at the default cap — nothing to heal.
+    }
+    // The scan, writeback, and STAMP must be ONE serialized unit. The CLI reconcile path holds no
+    // per-repo `WriteLock`, so an old watcher mid-upgrade could commit an old-classifier chunk
+    // BETWEEN an unlocked scan and the stamp — the stamp would then certify a mixed-version column
+    // and the fast summary would trust it. `BEGIN IMMEDIATE` takes the SQLite write lock up front,
+    // so no other writer interleaves until we COMMIT. Held only for a one-per-version-bump heal
+    // (same posture as a full rebuild). The temp table is created OUTSIDE the txn so a ROLLBACK
+    // leaves it to be reused/dropped, not half-created.
+    conn.execute_batch(
+        "CREATE TEMP TABLE IF NOT EXISTS embedding_policy_heal(id INTEGER PRIMARY KEY, policy \
+         TEXT NOT NULL);",
+    )?;
+    conn.execute_batch("BEGIN IMMEDIATE;")?;
+    // NEVER return with an open transaction: the caller (`maybe_heal_embedding_policy`) swallows
+    // our error, and a dangling txn would then break the reconcile's later `BEGIN IMMEDIATE`
+    // embed batches. So on ANY failure — including a COMMIT that itself fails — roll back
+    // before returning.
+    let outcome = heal_embedding_policy_locked(conn, &repo_id)
+        .and_then(|()| conn.execute_batch("COMMIT;").map_err(Into::into));
+    if let Err(err) = outcome {
+        let _ = conn.execute_batch("ROLLBACK;");
+        let _ = conn.execute_batch("DROP TABLE IF EXISTS temp.embedding_policy_heal;");
+        return Err(err);
+    }
+    conn.execute_batch("DROP TABLE IF EXISTS temp.embedding_policy_heal;")?;
+    Ok(())
+}
+
+/// The scan + writeback + stamp, run INSIDE the caller's `BEGIN IMMEDIATE` (which holds the write
+/// lock). Re-checks coverage HERE, inside the lock: if another live scope exists — a second
+/// linked-worktree overlay or an other-commit leftover — it would go un-healed while the repo-wide
+/// stamp certified it, so we stamp NOTHING (committing an empty heal; every scope keeps
+/// recomputing). Streams only the CHANGED chunks into the temp table (bounded RAM regardless of how
+/// many reclassified; the recompute itself streams one file at a time, #379), then corrects
+/// `main.chunks` with one `UPDATE ... FROM` after the read cursor closes.
+fn heal_embedding_policy_locked(conn: &Connection, repo_id: &str) -> anyhow::Result<()> {
+    conn.execute_batch("DELETE FROM temp.embedding_policy_heal;")?;
+    if !active_scope_covers_all_live_rows(conn, repo_id)? {
+        return Ok(());
+    }
+    {
+        let mut stage = conn.prepare(
+            "INSERT OR REPLACE INTO temp.embedding_policy_heal(id, policy) VALUES (?1, ?2)",
+        )?;
+        for_each_recomputed_chunk_policy(conn, DEFAULT_MAX_EMBEDDING_CHARS, |chunk, decision| {
+            if decision.policy != chunk.current_policy {
+                stage.execute(params![chunk.id, decision.policy])?;
+            }
+            Ok(())
+        })?;
+    }
+    conn.execute(
+        "UPDATE main.chunks
+         SET embedding_policy = (SELECT policy FROM temp.embedding_policy_heal WHERE id = \
+         main.chunks.id)
+         WHERE id IN (SELECT id FROM temp.embedding_policy_heal)",
+        [],
+    )?;
+    crate::index::meta::set_repo_meta(
+        conn,
+        repo_id,
+        EMBEDDING_POLICY_VERSION_KEY,
+        EMBEDDING_POLICY_VERSION,
+    )?;
+    crate::index::meta::set_repo_meta(
+        conn,
+        repo_id,
+        EMBEDDING_POLICY_CAP_KEY,
+        &DEFAULT_MAX_EMBEDDING_CHARS.to_string(),
+    )?;
+    Ok(())
 }
 
 pub(crate) fn finish_reconcile_attempt(
@@ -1050,6 +1293,8 @@ mod freshness_version_tests {
 
     fn chunk(start_byte: usize, end_byte: usize, text: &str) -> ChunkForPolicy {
         ChunkForPolicy {
+            id: 0,
+            current_policy: "Embed".to_string(),
             chunk_kind: "code".to_string(),
             symbol_path: None,
             start_byte,

--- a/crates/rag-rat-core/src/index/ai/reconcile/status.rs
+++ b/crates/rag-rat-core/src/index/ai/reconcile/status.rs
@@ -111,7 +111,10 @@ fn ready_embedding_scan_parts(
     Ok(Some((model_id, model_version, dim, max_embedding_chars)))
 }
 
-pub(crate) fn reconcile_plan(conn: &Connection) -> anyhow::Result<ReconcilePlan> {
+pub(crate) fn reconcile_plan(
+    conn: &Connection,
+    max_embedding_chars: usize,
+) -> anyhow::Result<ReconcilePlan> {
     ensure_model_manifest(conn)?;
     let model_id = active_embedding_model_id(conn)?;
     let model = model(conn, &model_id)?;
@@ -119,6 +122,10 @@ pub(crate) fn reconcile_plan(conn: &Connection) -> anyhow::Result<ReconcilePlan>
     let dim = usize::try_from(model.embedding_dim.unwrap_or_default()).unwrap_or(0);
     let available = validate_ready_model(&model).is_ok();
     let message = (!available).then(|| model_not_ready_reason(&model));
+    // The plan must classify against the SAME cap the reconcile it previews will use
+    // (`options.max_embedding_chars.max(MIN_EMBEDDING_CHARS)`), or its skip counts and per-job
+    // decisions diverge from what `reconcile` actually does at a non-default configured cap.
+    let max_embedding_chars = max_embedding_chars.max(MIN_EMBEDDING_CHARS);
     Ok(ReconcilePlan {
         embeddings: embedding_reconcile_plan(
             conn,
@@ -127,6 +134,7 @@ pub(crate) fn reconcile_plan(conn: &Connection) -> anyhow::Result<ReconcilePlan>
             dim,
             available,
             message,
+            max_embedding_chars,
         )?,
         summaries: SummaryReconcilePlan {
             enabled: false,
@@ -142,8 +150,9 @@ pub(crate) fn embedding_reconcile_plan(
     dim: usize,
     available: bool,
     message: Option<String>,
+    max_embedding_chars: usize,
 ) -> anyhow::Result<EmbeddingReconcilePlan> {
-    let skipped_by_policy = embedding_policy_skip_summary(conn, DEFAULT_MAX_EMBEDDING_CHARS)?;
+    let skipped_by_policy = embedding_policy_skip_summary(conn, max_embedding_chars)?;
     let mut missing_by_priority = BTreeMap::new();
     let mut current = 0_u64;
     let mut missing = 0_u64;
@@ -158,7 +167,7 @@ pub(crate) fn embedding_reconcile_plan(
     // over `embedding_job_candidates(None)`, so the counts are identical; only the peak memory
     // drops.
     for_each_embedding_candidate(conn, &model.model_id, model_version, dim, None, false, |job| {
-        let policy = policy_for_job(&job, DEFAULT_MAX_EMBEDDING_CHARS);
+        let policy = policy_for_job(&job, max_embedding_chars);
         if !policy.eligible {
             return Ok(());
         }
@@ -168,14 +177,14 @@ pub(crate) fn embedding_reconcile_plan(
             && job.embedding_dim == Some(i64::try_from(dim).unwrap_or(i64::MAX))
             && job.embedding_text_version.as_deref() == Some(EMBEDDING_TEXT_VERSION)
             && job.input_hash.as_deref().is_some_and(|input_hash| {
-                let input = build_embedding_input(&job, DEFAULT_MAX_EMBEDDING_CHARS);
+                let input = build_embedding_input(&job, max_embedding_chars);
                 input_hash == embedding_input_hash(&model.model_id, model_version, &input.text)
             });
         if current_artifact {
             current += 1;
             return Ok(());
         }
-        let reason = job.reason(model_version, dim, now_ms(), DEFAULT_MAX_EMBEDDING_CHARS);
+        let reason = job.reason(model_version, dim, now_ms(), max_embedding_chars);
         match reason {
             ReconcileReason::Missing => missing += 1,
             ReconcileReason::SourceChanged => stale += 1,

--- a/crates/rag-rat-core/src/index/file_index.rs
+++ b/crates/rag-rat-core/src/index/file_index.rs
@@ -314,6 +314,12 @@ impl IndexDatabase {
     /// embedding policy were all computed in the parallel prepare phase (see `prepare_chunks`), so
     /// nothing here hashes or parses.
     ///
+    /// SINGLE WRITER of `chunks.embedding_policy`: full rebuild, incremental, and heal all route
+    /// their chunk inserts through here, so a full rebuild's version stamp can certify the whole
+    /// column for the reconcile fast path (#530). A NEW insert path that bypasses `prepare_chunks`
+    /// would write the `NOT NULL DEFAULT 'Embed'` fallback and silently poison that fast path under
+    /// a still-valid stamp — route any new chunk insert through here (or re-derive + restamp).
+    ///
     /// Writes the per-row `chunk_fts` token row inline on EVERY path. `chunk_fts` is contentless
     /// (#77 Phase 2), so it cannot be bulk-rebuilt from a content column — the only way it stays in
     /// sync is this inline write at index time (full rebuild, incremental, and heal all insert

--- a/crates/rag-rat-core/src/index/file_rows.rs
+++ b/crates/rag-rat-core/src/index/file_rows.rs
@@ -298,6 +298,21 @@ impl IndexDatabase {
         self.set_meta(GENERATED_FLAGS_VERSION_KEY, GENERATED_FLAGS_VERSION)
     }
 
+    /// Stamp the embedding-policy freshness for THIS repo (`repo_meta`, not the DB-global
+    /// `index_meta`), certifying that every `chunks.embedding_policy` reflects the current
+    /// classifier ([`EMBEDDING_POLICY_VERSION`](crate::index::ai::EMBEDDING_POLICY_VERSION)) at
+    /// the default cap. The reconcile skip-summary then reads the column via `GROUP BY` instead
+    /// of re-parsing every file (#530). Called ONLY where every chunk was (re)derived by
+    /// current code — a full rebuild and the reconcile self-heal — NEVER an incremental pass,
+    /// which restamps only changed files and so cannot certify unchanged chunks.
+    pub(super) fn mark_embedding_policy_current(&self) -> anyhow::Result<()> {
+        self.set_repo_meta(ai::EMBEDDING_POLICY_VERSION_KEY, ai::EMBEDDING_POLICY_VERSION)?;
+        self.set_repo_meta(
+            ai::EMBEDDING_POLICY_CAP_KEY,
+            &ai::DEFAULT_MAX_EMBEDDING_CHARS.to_string(),
+        )
+    }
+
     fn rederive_generated_flags(&self) -> anyhow::Result<()> {
         let conn = self.storage.connection();
         // The generated flag is a property of the file PATH (+ target kind), not the active scope,

--- a/crates/rag-rat-core/src/index/query_api/ai_lifecycle.rs
+++ b/crates/rag-rat-core/src/index/query_api/ai_lifecycle.rs
@@ -33,8 +33,21 @@ impl IndexDatabase {
         ai::reconcile(self.storage.connection(), limit, batch_size)
     }
 
+    /// Plan the embedding reconcile at the DEFAULT char cap. The CLI uses the cap-aware
+    /// [`reconcile_plan_with_cap`](Self::reconcile_plan_with_cap) so `--plan` classifies against
+    /// the same cap the run will; this default-cap form stays for callers without a configured
+    /// cap.
     pub fn reconcile_plan(&self) -> anyhow::Result<ReconcilePlan> {
-        ai::reconcile_plan(self.storage.connection())
+        self.reconcile_plan_with_cap(ai::DEFAULT_MAX_EMBEDDING_CHARS)
+    }
+
+    /// `max_embedding_chars` is the caller's configured/overridden cap, so the plan classifies
+    /// against the SAME cap the reconcile it previews will use.
+    pub fn reconcile_plan_with_cap(
+        &self,
+        max_embedding_chars: usize,
+    ) -> anyhow::Result<ReconcilePlan> {
+        ai::reconcile_plan(self.storage.connection(), max_embedding_chars)
     }
 
     pub fn reconcile_with_progress(

--- a/crates/rag-rat-core/src/index/rebuild.rs
+++ b/crates/rag-rat-core/src/index/rebuild.rs
@@ -279,6 +279,19 @@ impl IndexDatabase {
             // Full rebuild writes correct `files.generated`, so stamp the flags version current and
             // skip a redundant re-derive on next open (#202).
             db.mark_generated_flags_current()?;
+            // A full rebuild (re)derived every chunk's `embedding_policy` with the current
+            // classifier, so certify the column current for this repo — the reconcile skip-summary
+            // then reads it via GROUP BY instead of re-parsing every file (#530). Gate on
+            // `carried_rows == 0` for the SAME reason as the logical-key version stamp above: a
+            // carried overlay / other-commit leftover rode along WITHOUT a reparse, so its column
+            // still holds the OLD-classifier policy — a repo-wide stamp would wrongly certify it. A
+            // repo with live overlays keeps recomputing (correct) until a carry-free rebuild; the
+            // reconcile self-heal is likewise gated on the active scope covering the whole live
+            // set. NOT stamped on the incremental path, which restamps only changed
+            // files.
+            if carried_rows == 0 {
+                db.mark_embedding_policy_current()?;
+            }
             // The git AUTHORITY writes ride the flip (batch-4 P2): `git_commit`/`git_dirty` meta
             // and the history reload-gate cursors say "this index reflects commit H" — true only
             // once the generation built at H is published. Deferring them here means a tail

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/embedding_policy_fast_path.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/embedding_policy_fast_path.rs
@@ -1,0 +1,171 @@
+//! Coverage for the version-stamped fast-path certification gates (#530): the rebuild stamp and its
+//! `carried_rows` gate, the fast-path cap gate, the self-heal cap gate, and the plan's cap
+//! threading. The end-to-end fast-path/self-heal behaviour lives in `reconcile_embeddings.rs`;
+//! these target the individual GATES that decide whether the column may be trusted.
+
+use super::*;
+use crate::index::ai;
+
+fn policy_version(db: &IndexDatabase) -> Option<String> {
+    let conn = db.storage.connection();
+    let repo_id = crate::index::schema::active_repo_id(conn).unwrap();
+    crate::index::meta::repo_meta(conn, &repo_id, ai::EMBEDDING_POLICY_VERSION_KEY).unwrap()
+}
+
+fn stale_the_stamp(db: &IndexDatabase) {
+    let conn = db.storage.connection();
+    let repo_id = crate::index::schema::active_repo_id(conn).unwrap();
+    crate::index::meta::set_repo_meta(
+        conn,
+        &repo_id,
+        ai::EMBEDDING_POLICY_VERSION_KEY,
+        "pre-upgrade",
+    )
+    .unwrap();
+}
+
+fn rust_fixture(root: &std::path::Path) {
+    let _ = fs::remove_dir_all(root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(
+        root.join("src/code.rs"),
+        "pub fn compute(x: i64, y: i64) -> i64 {\n    let sum = x * 2 + y - 1;\n    \
+         sum.wrapping_mul(3)\n}\n",
+    )
+    .unwrap();
+}
+
+#[test]
+fn rebuild_stamps_the_policy_version_current() {
+    // A full rebuild (re)derives every chunk's policy with the current classifier, so it certifies
+    // the column: the version + the DEFAULT cap the fast path reads at.
+    let root = unique_temp_root();
+    rust_fixture(&root);
+    let db = IndexDatabase::rebuild(&source_config(root.clone(), Language::Rust)).unwrap();
+    let conn = db.storage.connection();
+    let repo_id = crate::index::schema::active_repo_id(conn).unwrap();
+    assert_eq!(policy_version(&db).as_deref(), Some(ai::EMBEDDING_POLICY_VERSION));
+    assert_eq!(
+        crate::index::meta::repo_meta(conn, &repo_id, ai::EMBEDDING_POLICY_CAP_KEY)
+            .unwrap()
+            .as_deref(),
+        Some(ai::DEFAULT_MAX_EMBEDDING_CHARS.to_string().as_str()),
+        "the stamp records the DEFAULT cap the column was derived at"
+    );
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn rebuild_carrying_overlay_rows_does_not_certify() {
+    // A rebuild that CARRIES un-reparsed rows forward (a second linked-worktree overlay /
+    // other-commit leftover) must NOT (re)stamp the version — those rows kept their
+    // old-classifier column, so a repo-wide stamp would let a fast summary trust them after an
+    // upgrade. Same gate as the logical-key version's `carried_rows == 0`.
+    let (root, config) = git_fixture_for_overlay_tests();
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    assert_eq!(policy_version(&db).as_deref(), Some(ai::EMBEDDING_POLICY_VERSION));
+
+    // Seed a live overlay row so the NEXT rebuild carries it, and simulate a classifier-version
+    // bump since that clean stamp.
+    insert_stale_overlay_row(&db, "src/lib.rs", "some-linked-worktree");
+    stale_the_stamp(&db);
+
+    // The carry-ful rebuild must leave the (stale) stamp untouched — never certify current.
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    assert_ne!(
+        policy_version(&db).as_deref(),
+        Some(ai::EMBEDDING_POLICY_VERSION),
+        "a rebuild that carried un-reparsed overlay rows must not certify the version current"
+    );
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn fast_path_refused_at_non_default_cap() {
+    // The fast path may only read the column at the cap it was stamped at (DEFAULT). Poison a
+    // chunk's column: at DEFAULT the fast path reads the poison; at a NON-DEFAULT cap the
+    // cap-gate forces a recompute from source that ignores it.
+    let root = unique_temp_root();
+    rust_fixture(&root);
+    let db = IndexDatabase::rebuild(&source_config(root.clone(), Language::Rust)).unwrap();
+    let conn = db.storage.connection();
+    conn.execute(
+        "UPDATE main.chunks SET embedding_policy = 'SkipGenerated'
+         WHERE id = (SELECT MIN(id) FROM main.chunks WHERE embedding_policy = 'Embed')",
+        [],
+    )
+    .unwrap();
+
+    let fast = ai::embedding_policy_skip_summary(conn, ai::DEFAULT_MAX_EMBEDDING_CHARS).unwrap();
+    let recomputed =
+        ai::embedding_policy_skip_summary(conn, ai::DEFAULT_MAX_EMBEDDING_CHARS + 1_000).unwrap();
+    assert!(
+        fast.get("SkipGenerated").copied().unwrap_or(0)
+            > recomputed.get("SkipGenerated").copied().unwrap_or(0),
+        "default-cap fast path reads the poisoned column; a non-default cap recomputes from \
+         source: {fast:?} vs {recomputed:?}"
+    );
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn self_heal_skipped_at_non_default_cap() {
+    // A stale-stamp reconcile at a NON-DEFAULT cap must NOT self-heal: the heal reclassifies +
+    // stamps at DEFAULT (which only a DEFAULT-cap summary can read), so healing here would just
+    // double the parse pass. The stamp stays stale.
+    let root = unique_temp_root();
+    rust_fixture(&root);
+    let db = IndexDatabase::rebuild(&source_config(root.clone(), Language::Rust)).unwrap();
+    stale_the_stamp(&db);
+    db.reconcile_with_options_progress(
+        ai::ReconcileOptions {
+            batch_size: Some(8),
+            max_embedding_chars: ai::DEFAULT_MAX_EMBEDDING_CHARS + 1_000,
+            ..Default::default()
+        },
+        |_| {},
+    )
+    .unwrap();
+    assert_eq!(
+        policy_version(&db).as_deref(),
+        Some("pre-upgrade"),
+        "a non-default-cap reconcile must not certify the DEFAULT-cap column"
+    );
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn reconcile_plan_classifies_at_the_requested_cap() {
+    // The `--plan` preview must bucket by the cap it is GIVEN (matching the reconcile it previews):
+    // a ~5 KB generated chunk is SkipGenerated at the default cap but SkipTooLarge at cap=1000.
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("gen")).unwrap();
+    let big =
+        "// generated data line with sufficient length to matter for the cap xxxxx\n".repeat(80);
+    fs::write(root.join("gen/bindings.rs"), &big).unwrap();
+    let mut config = source_config(root.clone(), Language::Rust);
+    config.targets = vec![ResolvedTarget {
+        name: "generated".to_string(),
+        language: Language::Rust,
+        directories: vec![PathBuf::from("gen")],
+        include: vec!["gen/".to_string()],
+        exclude: Vec::new(),
+        kind: TargetKind::Generated,
+    }];
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let default_plan = db.reconcile_plan().unwrap();
+    assert!(
+        default_plan.embeddings.skipped_by_policy.contains_key("SkipGenerated"),
+        "default cap: the generated chunk is SkipGenerated: {:?}",
+        default_plan.embeddings.skipped_by_policy
+    );
+    let small_plan = db.reconcile_plan_with_cap(1_000).unwrap();
+    assert!(
+        small_plan.embeddings.skipped_by_policy.contains_key("SkipTooLarge"),
+        "cap=1000: the same chunk is now SkipTooLarge: {:?}",
+        small_plan.embeddings.skipped_by_policy
+    );
+    let _ = fs::remove_dir_all(root);
+}

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/mod.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/mod.rs
@@ -887,6 +887,7 @@ mod chunk_store_migrations;
 mod clones;
 mod dir_memory_tree;
 mod dispatch;
+mod embedding_policy_fast_path;
 mod generation_rebuild;
 mod git_history_reload;
 mod github_papertrail;

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/reconcile_embeddings.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/reconcile_embeddings.rs
@@ -1180,8 +1180,18 @@ fn skip_summary_shared_parse_matches_per_chunk_text() {
         out
     };
 
+    // #530: a fresh rebuild stamps the policy version, so the summary takes the FAST path (GROUP BY
+    // the certified column). Both paths must agree with the per-chunk FromText reference here.
+    let fast = embedding_policy_skip_summary(conn, ai::DEFAULT_MAX_EMBEDDING_CHARS).unwrap();
+    assert_eq!(fast, reference, "fast-path (certified column) must equal the FromText reference");
+
+    // Clear the stamp → the slow recompute (#572's subject: FromSpan reconstruction + sha-verify)
+    // runs and must also equal the reference.
+    let repo_id = crate::index::schema::active_repo_id(conn).unwrap();
+    crate::index::meta::set_repo_meta(conn, &repo_id, ai::EMBEDDING_POLICY_VERSION_KEY, "stale")
+        .unwrap();
     let span = embedding_policy_skip_summary(conn, ai::DEFAULT_MAX_EMBEDDING_CHARS).unwrap();
-    assert_eq!(span, reference, "shared-parse summary must equal the per-chunk FromText reference");
+    assert_eq!(span, reference, "slow recompute must equal the per-chunk FromText reference");
     assert!(
         span.get("SkipLowSignal").copied().unwrap_or(0) >= 1,
         "the all-import file must contribute a low-signal skip (exercises the shared-parse span \
@@ -1191,6 +1201,190 @@ fn skip_summary_shared_parse_matches_per_chunk_text() {
         span.get("SkipTestFixture").copied().unwrap_or(0) >= 1,
         "the fixtures/ file must be a test-fixture skip (exercises the parse-free cheap gate): \
          {span:?}"
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn skip_summary_fast_path_reads_certified_column_and_falls_back_when_stale() {
+    use crate::index::ai::{self, embedding_policy_skip_summary};
+
+    // #530: after a full rebuild the policy version is stamped, so the summary reads its counts
+    // from the certified `chunks.embedding_policy` column (GROUP BY, no parse). Prove (a) the
+    // fast path really READS the column — poisoning one chunk moves the count — and (b) a stale
+    // stamp falls back to the recompute, which classifies from source and so IGNORES the
+    // poisoned column.
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(
+        root.join("src/code.rs"),
+        "pub fn compute(x: i64, y: i64) -> i64 {\n    let sum = x * 2 + y - 1;\n    \
+         sum.wrapping_mul(3)\n}\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("src/plumbing.rs"),
+        "use std::collections::HashMap;\nuse std::collections::BTreeMap;\nuse \
+         std::path::PathBuf;\nuse std::sync::Arc;\npub use crate::foo::Bar;\n",
+    )
+    .unwrap();
+
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let conn = db.storage.connection();
+
+    // Fresh rebuild certified the column: fast path.
+    let fast = embedding_policy_skip_summary(conn, ai::DEFAULT_MAX_EMBEDDING_CHARS).unwrap();
+    let embed_before: i64 = conn
+        .query_row("SELECT COUNT(*) FROM chunks WHERE embedding_policy = 'Embed'", [], |r| r.get(0))
+        .unwrap();
+    assert!(embed_before >= 1, "fixture must have an eligible (Embed) chunk to poison");
+
+    // Poison one Embed chunk in the base table; the fast path must reflect the (wrong) column
+    // value.
+    conn.execute(
+        "UPDATE main.chunks SET embedding_policy = 'SkipGenerated'
+         WHERE id = (SELECT MIN(id) FROM main.chunks WHERE embedding_policy = 'Embed')",
+        [],
+    )
+    .unwrap();
+    let poisoned = embedding_policy_skip_summary(conn, ai::DEFAULT_MAX_EMBEDDING_CHARS).unwrap();
+    assert_eq!(
+        poisoned.get("SkipGenerated").copied().unwrap_or(0),
+        fast.get("SkipGenerated").copied().unwrap_or(0) + 1,
+        "fast path must read the poisoned column: {poisoned:?} vs fresh {fast:?}"
+    );
+
+    // Clear the stamp → recompute from source ignores the poisoned column and returns ground truth.
+    let repo_id = crate::index::schema::active_repo_id(conn).unwrap();
+    crate::index::meta::set_repo_meta(conn, &repo_id, ai::EMBEDDING_POLICY_VERSION_KEY, "stale")
+        .unwrap();
+    let recomputed = embedding_policy_skip_summary(conn, ai::DEFAULT_MAX_EMBEDDING_CHARS).unwrap();
+    assert_eq!(
+        recomputed, fast,
+        "stale stamp must recompute from source, ignoring the poisoned column: {recomputed:?} vs \
+         {fast:?}"
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn reconcile_self_heals_stale_policy_column_and_restamps() {
+    use crate::index::ai::{self, embedding_policy_skip_summary};
+
+    // #530: after a rag-rat upgrade bumps the classifier version, an incrementally-maintained index
+    // never full-rebuilds, so its column stays uncertified and every summary pays the O(files)
+    // parse. The reconcile self-heal fixes that: it recomputes from source, writes the column
+    // back, and restamps the version — so the FIRST reconcile after the bump pays once and
+    // every later reconcile/plan takes the fast path.
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(
+        root.join("src/code.rs"),
+        "pub fn compute(x: i64, y: i64) -> i64 {\n    let sum = x * 2 + y - 1;\n    \
+         sum.wrapping_mul(3)\n}\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("src/plumbing.rs"),
+        "use std::collections::HashMap;\nuse std::collections::BTreeMap;\nuse \
+         std::path::PathBuf;\nuse std::sync::Arc;\npub use crate::foo::Bar;\n",
+    )
+    .unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let conn = db.storage.connection();
+    let repo_id = crate::index::schema::active_repo_id(conn).unwrap();
+
+    // Ground truth from the freshly certified column.
+    let truth = embedding_policy_skip_summary(conn, ai::DEFAULT_MAX_EMBEDDING_CHARS).unwrap();
+
+    // Simulate a version bump that left the column stale: poison one chunk AND stale the stamp.
+    conn.execute(
+        "UPDATE main.chunks SET embedding_policy = 'SkipGenerated'
+         WHERE id = (SELECT MIN(id) FROM main.chunks WHERE embedding_policy = 'Embed')",
+        [],
+    )
+    .unwrap();
+    crate::index::meta::set_repo_meta(conn, &repo_id, ai::EMBEDDING_POLICY_VERSION_KEY, "stale")
+        .unwrap();
+
+    // A reconcile (no model → NotReady, but it still runs the summary + self-heal) must repair the
+    // column and restamp the version current.
+    let _ = db.reconcile(None, Some(8)).unwrap();
+    assert_eq!(
+        crate::index::meta::repo_meta(conn, &repo_id, ai::EMBEDDING_POLICY_VERSION_KEY)
+            .unwrap()
+            .as_deref(),
+        Some(ai::EMBEDDING_POLICY_VERSION),
+        "reconcile must restamp the policy version current"
+    );
+    let healed = embedding_policy_skip_summary(conn, ai::DEFAULT_MAX_EMBEDDING_CHARS).unwrap();
+    assert_eq!(healed, truth, "self-heal must restore the column to ground truth: {healed:?}");
+
+    // Prove it is the FAST path now: re-poisoning moves the count (a recompute would ignore it).
+    conn.execute(
+        "UPDATE main.chunks SET embedding_policy = 'SkipGenerated'
+         WHERE id = (SELECT MIN(id) FROM main.chunks WHERE embedding_policy = 'Embed')",
+        [],
+    )
+    .unwrap();
+    let after = embedding_policy_skip_summary(conn, ai::DEFAULT_MAX_EMBEDDING_CHARS).unwrap();
+    assert_eq!(
+        after.get("SkipGenerated").copied().unwrap_or(0),
+        truth.get("SkipGenerated").copied().unwrap_or(0) + 1,
+        "after self-heal the summary reads the certified column (fast path): {after:?}"
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn self_heal_does_not_certify_a_repo_with_another_live_scope() {
+    use crate::index::ai::{self};
+
+    // #530 (Codex): the self-heal reparses only the ACTIVE scope, so it must NOT write the
+    // repo-wide version stamp when another live scope exists (a second linked-worktree overlay
+    // / other-commit leftover) — that scope would go un-healed while the stamp certified it.
+    // Simulate the other scope with a live `main.files` row outside the active (base) scope and
+    // assert the reconcile self-heal leaves the stamp stale (so every scope keeps recomputing).
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/code.rs"), "pub fn compute(x: i64) -> i64 {\n    x * 2 + 1\n}\n")
+        .unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let conn = db.storage.connection();
+    let repo_id = crate::index::schema::active_repo_id(conn).unwrap();
+    let generation = crate::index::schema::active_generation(conn).unwrap();
+
+    // Stale the stamp (simulate a version bump) so the self-heal would otherwise fire and restamp.
+    crate::index::meta::set_repo_meta(conn, &repo_id, ai::EMBEDDING_POLICY_VERSION_KEY, "stale")
+        .unwrap();
+    // A live row OUTSIDE the active base scope (git-less fixture ⇒ active commit_sha/worktree_id
+    // are both ''): commit_sha != '' AND worktree_id != '' is what
+    // `carry_forward_live_overlays` treats as a foreign scope.
+    conn.execute(
+        "INSERT INTO main.files(path, language, kind, sha256, modified_at_ms, indexed_at_ms,
+                                repo_id, generation, commit_sha, worktree_id)
+         VALUES ('other/f.rs', 'rust', 'source', 'deadbeef', 0, 0, ?1, ?2, 'othercommit', \
+         'otherwt')",
+        rusqlite::params![repo_id, generation],
+    )
+    .unwrap();
+
+    let _ = db.reconcile(None, Some(8)).unwrap();
+    assert_eq!(
+        crate::index::meta::repo_meta(conn, &repo_id, ai::EMBEDDING_POLICY_VERSION_KEY)
+            .unwrap()
+            .as_deref(),
+        Some("stale"),
+        "self-heal must NOT certify a repo whose active scope is not its whole live set"
     );
 
     let _ = fs::remove_dir_all(root);


### PR DESCRIPTION
`embedding_policy_skip_summary` re-parsed every file on each `reconcile` and `reconcile --plan` to recompute its diagnostic skip counts — ~6s on a ~2k-file repo, linear in file count, and the tree-sitter parse is 96% of that. #516/#572 already reduced it to one parse per file, so the only lever left is to not parse at all.

## What changed

A full rebuild derives every chunk's `embedding_policy` with the current classifier, so it now stamps a per-repo `repo_meta` version + cap. When the stamp matches the current classifier version at the requested cap, the summary reads its counts straight from `chunks.embedding_policy` via a single `GROUP BY` (no parse, no decompress) — fast even on a cold call. A stale/absent stamp, or a non-default cap, falls back to the existing FromSpan recompute, which is always correct.

- **Behavior-hash version.** `EMBEDDING_POLICY_VERSION` is the hash of the classifier's decisions over a fixed corpus, pinned by a test. Any gate/threshold change — or a tree-sitter grammar bump that reclassifies a node with zero source diff — changes the hash and fails CI with the value to set, so a stale stamp can never let the fast path serve mixed-code counts.
- **Scope-safe stamping.** Only a rebuild that carried no overlay/other-commit rows (and a reconcile whose active scope is the repo's whole live set) may stamp — a repo with linked-worktree overlays keeps recomputing rather than certifying rows a rebuild didn't reparse.
- **Reconcile self-heal.** After a version bump, the reconcile write path re-derives, writes back, and restamps the column at the default cap (streaming only the changed rows through a temp table, so RAM stays bounded), so a long-lived, never-fully-rebuilt index doesn't pay the parse forever.
- **Cap consistency.** `reconcile --plan` now classifies at the same cap the run it previews uses (CLI override else config), fixing a pre-existing default-vs-configured divergence.

The summary remains diagnostic-only — nothing gates embedding work on it.

Fixes #530.