### PR TITLE
fix(oplog): self-healing per-node reconcile so no memory row is a permanent ghost (#541)

### DIFF
--- a/crates/rag-rat-core/src/index/consolidate.rs
+++ b/crates/rag-rat-core/src/index/consolidate.rs
@@ -276,6 +276,21 @@ pub fn run(config: &Config) -> anyhow::Result<ConsolidateOutcome> {
     let counts = import_from_source(source_storage.connection(), target_conn, &repo_id)?;
     drop(source_storage);
 
+    // Author the freshly-imported (remapped) rows into the TARGET's owner stream so the
+    // consolidated store's signed history is complete under its OWN device identity (#541). The
+    // per-chain backfill gate would otherwise skip them (the target chain is already
+    // non-empty), and a later update/obsolete on an imported memory would author an inert op.
+    // The source's pre-remap signed entries are deliberately NOT carried — their signatures
+    // cover the source identity + pre-remap ids. Runs BEFORE the rename, so a failure leaves
+    // the legacy file in place to retry.
+    //
+    // KNOWN retry-window gap (decision 8): a re-run's presence-only reconcile does NOT re-author a
+    // CONTENT edit made in the window between a committed import and a failed rename, nor tombstone
+    // a window edge REMOVAL (a phantom projected edge). Both fall under the same out-of-scope
+    // class as raw out-of-band content divergence; they are content/tombstone divergence, not the
+    // missing-NodeCreate bug #541 fixes, and the log is a shadow until phase D.
+    crate::query::memory::reconcile_owner_stream_for_repo(target_conn, &repo_id, schema::now_ms())?;
+
     // Rename the legacy file so a keyless config now resolves to the global store (via the
     // `.imported` latch), and a re-run is a no-op. AFTER the import commits, so a failure leaves
     // the legacy file in place to retry. The WAL sidecars travel WITH the archive: a bare
@@ -2066,6 +2081,95 @@ mod tests {
         assert!(
             custom.contains("-wal"),
             "custom shape warns about WAL sidecars holding recent writes: {custom}"
+        );
+    }
+
+    // --- consolidation re-authors imported rows into the target owner stream (#541 Task 5) ---
+
+    /// A target owner stream is rooted via a REAL `create_memory` call (not raw SQL) so the chain
+    /// is genuinely non-empty — `fresh_target()` registers exactly one repo (`global-repo`), so
+    /// `memory_repo_scope`'s sole-repo fallback resolves it without any extra connection-context
+    /// setup.
+    fn seeded_target_with_rooted_chain() -> Connection {
+        let target = fresh_target();
+        crate::query::memory::create_memory(&target, crate::query::memory::RepoMemoryCreate {
+            kind: "Concept".to_string(),
+            title: "seed".to_string(),
+            body: "body".to_string(),
+            confidence: "high".to_string(),
+            created_by: None,
+            source: None,
+            tags: Vec::new(),
+            payload_json: None,
+            bind: crate::query::memory::RepoMemoryBindTarget::default(),
+        })
+        .unwrap();
+        target
+    }
+
+    /// Before #541 Task 5, consolidation's import never touched the op-log: the imported rows
+    /// landed in `repo_memories`/`repo_node_edges` but the per-CHAIN backfill gate saw the target's
+    /// owner stream was already non-empty (this test's seed rooted it) and skipped authoring them
+    /// entirely — a later `mark_obsolete` on such a row would author an inert `NodeStatus` with no
+    /// `NodeCreate` behind it. This test proves the reconcile call `run` now makes closes that gap:
+    /// an imported memory is present in the target's projection, and a follow-up `mark_obsolete` is
+    /// NOT inert.
+    #[test]
+    fn consolidation_authors_imported_memories_into_target_owner_stream() {
+        let source = seeded_source();
+        let target = seeded_target_with_rooted_chain();
+
+        // PREMISE SELF-CHECK: the seed must have rooted a non-empty local chain for `global-repo`,
+        // or this test silently degrades to the (already-covered) genesis path and stops exercising
+        // the per-chain-gate bypass #541 fixes.
+        let device = crate::oplog::local_device(&target, 0).unwrap();
+        let stream = crate::oplog::owner_stream("global-repo").unwrap();
+        assert!(
+            crate::oplog::chain_tail(&target, stream, device.fingerprint()).unwrap().is_some(),
+            "the seed must root a non-empty owner chain, or this test degrades to the genesis path"
+        );
+
+        // The import itself does NOT touch the op-log (it predates #541's reconcile call) — only
+        // `repo_memories`/`repo_node_edges` gain the imported rows.
+        let counts = import_from_source(&source, &target, "global-repo").unwrap();
+        assert_eq!(counts.memories, 3, "sanity: the import still carries all 3 source memories");
+        assert!(
+            !crate::oplog::load_projection(&target, stream)
+                .unwrap()
+                .nodes
+                .contains_key(&crate::oplog::NodeId::from("m1")),
+            "pre-reconcile: the imported memory m1 must NOT yet be projected (the per-chain gate \
+             skipped it, the bug #541 fixes) — only the seed memory should be projected here"
+        );
+
+        // The call this task wires into `run`, immediately after `import_from_source` and before
+        // the legacy-file rename.
+        crate::query::memory::reconcile_owner_stream_for_repo(
+            &target,
+            "global-repo",
+            schema::now_ms(),
+        )
+        .unwrap();
+
+        // An imported memory is now present in the target owner stream's projection.
+        let projected = crate::oplog::load_projection(&target, stream).unwrap();
+        assert!(
+            projected.nodes.contains_key(&crate::oplog::NodeId::from("m1")),
+            "the imported memory m1 must be present in the target owner stream's projection"
+        );
+
+        // A follow-up `mark_obsolete` on the imported memory is NOT inert: it flips the projected
+        // status (which requires the `NodeCreate` the reconcile just authored).
+        crate::query::memory::mark_obsolete(&target, "m1").unwrap();
+        let projected = crate::oplog::load_projection(&target, stream).unwrap();
+        let node = projected
+            .nodes
+            .get(&crate::oplog::NodeId::from("m1"))
+            .expect("m1 must still be projected after mark_obsolete");
+        assert_eq!(
+            node.status,
+            crate::oplog::NodeStatus::Obsolete,
+            "mark_obsolete on an imported memory must not be inert"
         );
     }
 }

--- a/crates/rag-rat-core/src/oplog/mod.rs
+++ b/crates/rag-rat-core/src/oplog/mod.rs
@@ -47,15 +47,21 @@ mod stream;
 // direction of the dependency (`oplog` never depends back on `query::memory`).
 pub(crate) use identity::local_device;
 pub(crate) use op::{EdgeKey, EdgeSpec, MemoryOp, NodeContent, NodeId, NodeStatus};
-// `author_batch_in_tx` is the gate-free batch-author primitive (#541) extracted for the
-// reconcile — not yet wired into a live caller (that lands in a later increment), so its
-// re-export stays `allow(unused_imports)` until then.
+// The reconcile's tests read the materialized shadow projection as a `ProjectedState` via
+// `load_projection` (below) — test-only today (the live path folds in-txn), so `allow`'d.
 #[allow(unused_imports)]
+pub(crate) use project::ProjectedState;
+// `author_batch_in_tx` is the gate-free batch-author primitive (#541) the reconcile authors
+// its ghost batch through (`query::memory::authoring::sync_owner_stream`).
 pub(crate) use store::author_batch_in_tx;
-// `author_op` / `author_batch` are the standalone (own-txn) wrappers — still only test-used,
-// so their re-export stays `allow(unused_imports)`. The live write path uses the in-txn
-// primitives.
+// `load_projection` materializes a `ProjectedState` from the shadow tables — the
+// reconcile-test read seam above; only test-used for now, so `allow`'d.
+#[allow(unused_imports)]
+pub(crate) use store::load_projection;
+// `author_batch` / `author_op` are the standalone (own-txn) wrappers — `author_batch` is only
+// test-used and `author_op` is only reached from a test helper, so their re-export stays
+// `allow(unused_imports)`. The live write path uses the in-txn primitives.
 #[allow(unused_imports)]
 pub(crate) use store::{author_batch, author_op};
-pub(crate) use store::{author_genesis_in_tx, author_in_tx, chain_tail};
+pub(crate) use store::{author_in_tx, chain_tail};
 pub(crate) use stream::{StreamId, owner_stream};

--- a/crates/rag-rat-core/src/oplog/mod.rs
+++ b/crates/rag-rat-core/src/oplog/mod.rs
@@ -47,6 +47,11 @@ mod stream;
 // direction of the dependency (`oplog` never depends back on `query::memory`).
 pub(crate) use identity::local_device;
 pub(crate) use op::{EdgeKey, EdgeSpec, MemoryOp, NodeContent, NodeId, NodeStatus};
+// `author_batch_in_tx` is the gate-free batch-author primitive (#541) extracted for the
+// reconcile — not yet wired into a live caller (that lands in a later increment), so its
+// re-export stays `allow(unused_imports)` until then.
+#[allow(unused_imports)]
+pub(crate) use store::author_batch_in_tx;
 // `author_op` / `author_batch` are the standalone (own-txn) wrappers — still only test-used,
 // so their re-export stays `allow(unused_imports)`. The live write path uses the in-txn
 // primitives.

--- a/crates/rag-rat-core/src/oplog/store.rs
+++ b/crates/rag-rat-core/src/oplog/store.rs
@@ -208,14 +208,36 @@ pub(crate) fn author_op(
     Ok(entry_hash)
 }
 
-/// Author `ops` as the GENESIS batch of `stream` WITHIN a caller-provided txn — gate on an empty
-/// chain, then chain every entry from genesis with a SINGLE projection re-fold at the end, but
-/// NEITHER open NOR commit. The empty-chain gate lives INSIDE the txn (the caller's), so two
-/// concurrent first-authoring callers converge: the winner authors genesis→N, and the loser —
-/// serialized behind the winner's write — sees a non-empty chain and no-ops. Returns whether it
-/// authored (`false` = a chain already existed). The backfill opens its OWN `IMMEDIATE` txn, reads
-/// the memory snapshot UNDER that write lock, and calls this so the snapshot read + gate + write
-/// are one atomic unit (no memory created between the read and the batch is lost from the history).
+/// Author `ops` as a continuation batch on `stream` WITHIN the caller's txn: chain each entry from
+/// the current tail (genesis when the chain is empty), with a SINGLE projection re-fold at the end.
+/// NO empty-chain gate — the caller has already decided these ops belong. Neither opens nor commits
+/// the txn. Empty `ops` authors no entry (the loop is zero iterations) but STILL re-folds + stamps
+/// the projection — an idempotent sweep, not a no-op. That preserves the pre-refactor empty-genesis
+/// behavior, where the 0-iteration loop still ran `reproject_after_write` +
+/// `stamp_projector_version`.
+pub(crate) fn author_batch_in_tx(
+    tx: &Transaction<'_>,
+    stream: StreamId,
+    device: &LocalDevice,
+    ops: &[MemoryOp],
+    now_ms: i64,
+) -> anyhow::Result<()> {
+    assert_projector_not_newer(tx)?;
+    for op in ops {
+        // The tail read sees prior in-txn inserts, so each op chains off the one before it.
+        author_one(tx, stream, device, op, now_ms)?;
+    }
+    reproject_after_write(tx, stream)?;
+    stamp_projector_version(tx)?;
+    Ok(())
+}
+
+/// The GENESIS batch — [`author_batch_in_tx`] GATED on an empty chain so two concurrent
+/// first-authoring callers converge: the winner authors genesis→N, and the loser — serialized
+/// behind the winner's write — sees a non-empty chain and no-ops. Returns whether it authored
+/// (`false` = a chain already existed). The backfill opens its OWN `IMMEDIATE` txn, reads the
+/// memory snapshot UNDER that write lock, and calls this so the snapshot read + gate + write are
+/// one atomic unit (no memory created between the read and the batch is lost from the history).
 pub(crate) fn author_genesis_in_tx(
     tx: &Transaction<'_>,
     stream: StreamId,
@@ -227,12 +249,7 @@ pub(crate) fn author_genesis_in_tx(
     if chain_tail(tx, stream, device.fingerprint())?.is_some() {
         return Ok(false);
     }
-    for op in ops {
-        // The tail read sees prior in-txn inserts, so each op chains off the one before it.
-        author_one(tx, stream, device, op, now_ms)?;
-    }
-    reproject_after_write(tx, stream)?;
-    stamp_projector_version(tx)?;
+    author_batch_in_tx(tx, stream, device, ops, now_ms)?;
     Ok(true)
 }
 
@@ -1008,6 +1025,26 @@ mod tests {
             author_batch(&conn, stream_a(), &device, &[create("mem_b", "b")], 2_000).unwrap();
         assert!(!authored, "a genesis batch no-ops on a non-empty chain");
         assert_eq!(entry_count(&conn), 1, "the non-empty chain is left untouched");
+    }
+
+    #[test]
+    fn author_batch_in_tx_chains_a_continuation_and_refolds_once() {
+        let conn = db();
+        let device = crate::oplog::local_device(&conn, 0).unwrap();
+        let stream = stream_a();
+        let tx = Transaction::new_unchecked(&conn, TransactionBehavior::Immediate).unwrap();
+        // NON-empty chain seeded, then a continuation batch on the SAME chain (must not gate).
+        author_batch_in_tx(&tx, stream, &device, &[create("mem_a", "first")], 10).unwrap();
+        author_batch_in_tx(&tx, stream, &device, &[create("mem_b", "second")], 20).unwrap();
+        let before = entry_count(&tx);
+        // An empty batch authors NO entry but still re-folds + stamps (idempotent sweep, not a
+        // no-op).
+        author_batch_in_tx(&tx, stream, &device, &[], 30).unwrap();
+        assert_eq!(entry_count(&tx), before, "an empty batch adds no oplog entry");
+        tx.commit().unwrap();
+        let state = load_projection(&conn, stream).unwrap();
+        assert!(state.nodes.contains_key(&NodeId::from("mem_a")));
+        assert!(state.nodes.contains_key(&NodeId::from("mem_b")));
     }
 
     #[test]

--- a/crates/rag-rat-core/src/query/memory/authoring.rs
+++ b/crates/rag-rat-core/src/query/memory/authoring.rs
@@ -1,5 +1,5 @@
-//! Translating persisted memories into signed op-log entries, and the one-time full backfill of a
-//! store's pre-existing memories into the log (#524).
+//! Translating persisted memories into signed op-log entries, and the per-node/edge reconcile that
+//! keeps the log a COMPLETE signed mirror of `repo_memories` / `repo_node_edges` (#524, #541).
 //!
 //! This bridges `repo_memories` / `repo_node_edges` (owned by this module) and the op-log MINTING
 //! primitives ([`crate::oplog`]) — a ONE-WAY dependency, so `oplog` never depends back on the
@@ -9,6 +9,12 @@
 //! (before the first live entry) and the `author_*` seams below INSIDE their own transaction, so
 //! the op-append and the table write commit — or roll back — together (strict-atomic). Authoring is
 //! a NO-OP under an unstable scope ([`stable_owner_stream`]), leaving scope-less callers untouched.
+//!
+//! [`backfill_memory_oplog`] is a per-node/edge RECONCILE (#541), not a per-chain gate: it authors
+//! every table row MISSING from the materialized shadow projection, so a row that entered the
+//! tables outside the wired path (a pre-#532 binary, a raw writer, a consolidation import) is
+//! signed on the next mutation and no later lifecycle op on it is ever inert. Genesis is just the
+//! empty-chain case where every row is missing.
 
 use rusqlite::{Connection, Transaction, TransactionBehavior, params};
 
@@ -48,9 +54,9 @@ impl Drop for AuthoredDurability<'_> {
         let _ = self.conn.execute_batch("PRAGMA synchronous = NORMAL;");
     }
 }
-use super::{EdgeRelation, NodeEdge, RepoMemory, all_edges_from, memory_repo_scope};
+use super::{EdgeRelation, NodeEdge, RepoMemory, memory_repo_scope};
 use crate::oplog::{
-    EdgeKey, EdgeSpec, MemoryOp, NodeContent, NodeId, NodeStatus, StreamId, author_genesis_in_tx,
+    EdgeKey, EdgeSpec, MemoryOp, NodeContent, NodeId, NodeStatus, StreamId, author_batch_in_tx,
     author_in_tx, chain_tail, local_device, owner_stream,
 };
 
@@ -69,8 +75,7 @@ struct MemoryRow {
 }
 
 /// Build the op model's content register from a memory's projectable columns — shared by the
-/// backfill ([`memory_to_ops`]) and the live create/update authors, so all three agree
-/// byte-for-byte.
+/// reconcile ([`node_ops`]) and the live create/update authors, so all three agree byte-for-byte.
 fn node_content(
     kind: &str,
     title: &str,
@@ -91,16 +96,20 @@ fn node_content(
     }
 }
 
-/// Translate one memory into its BACKFILL op sequence: a `NodeCreate` for content, a `NodeStatus`
-/// ONLY when the status is not the fold's `active` create-time default, and an `EdgeAdd` per
-/// outgoing typed node-edge (in `edge_key` order, so the authored chain is reproducible).
-/// Code-anchor BINDINGS are excluded — per-device derived resolution state, never part of the
-/// shared node graph.
-fn memory_to_ops(
-    row: &MemoryRow,
-    owner_repo_id: &str,
-    edges: &[NodeEdge],
-) -> anyhow::Result<Vec<MemoryOp>> {
+/// A memory's NODE ops: a `NodeCreate` for content, then a `NodeStatus`.
+///
+/// `elide_active_status = true` (GENESIS on an empty chain, no stale registers) emits the status op
+/// ONLY when non-active — the fold's create-time default handles `active`, so genesis stays
+/// byte-identical to the pre-#541 backfill. `false` (INCREMENTAL heal on a non-empty chain) ALWAYS
+/// emits `NodeStatus`, so a healed node's status wins its register at the new, higher Lamport even
+/// if an inert `NodeStatus` from an old binary left a stale value in it (the fold's status register
+/// is independent of existence — a `NodeCreate` never touches it — so authoring only the create
+/// would let that stale register surface; see decision 6 of #541).
+///
+/// An unrecognized status token FAILS — a signed op cannot be corrected, and coercing to `active`
+/// would permanently mint the wrong status into the immutable history. Code-anchor BINDINGS are
+/// excluded — per-device derived resolution state, never part of the shared node graph.
+fn node_ops(row: &MemoryRow, elide_active_status: bool) -> anyhow::Result<Vec<MemoryOp>> {
     let node_id = NodeId::from(row.memory_id.as_str());
     let mut ops = vec![MemoryOp::NodeCreate {
         node_id: node_id.clone(),
@@ -114,99 +123,144 @@ fn memory_to_ops(
             row.payload_json.as_deref(),
         ),
     }];
-    // `active` is the fold's create-time default, so it needs no op. A status token this binary
-    // does NOT recognize (a newer binary's future status) must NOT be silently dropped — that would
-    // permanently mint this row as `active` in the SIGNED history, and a signed op cannot be
-    // corrected later. FAIL the backfill instead, so a binary that understands the token authors
-    // it.
-    if row.status != NodeStatus::default().as_db_str() {
+    let is_active = row.status == NodeStatus::default().as_db_str();
+    if !(elide_active_status && is_active) {
         let status = NodeStatus::from_db_str(&row.status).ok_or_else(|| {
             anyhow::anyhow!(
-                "cannot backfill memory `{}`: unknown status token `{}` (a newer binary must \
-                 author this history)",
+                "cannot author memory `{}`: unknown status token `{}` (a newer binary must author \
+                 this history)",
                 row.memory_id,
                 row.status
             )
         })?;
-        ops.push(MemoryOp::NodeStatus { node_id: node_id.clone(), status });
-    }
-    // An `EdgeAdd` ONLY — deliberately NO `Rebind`. `EdgeAdd` carries the edge's presence and the
-    // DURABLE spec (incl. the `target_repo_id` `all_edges_from` re-resolved to current). The
-    // `Rebind` op's resolved dimension (`target_node_id`, `anchor_status`) is PER-DEVICE
-    // derived state: `anchor_status` (current/gone/unresolved — is the target present in THIS
-    // db) differs by device and is recomputed on every read by `reresolve_on_read`. Signing it
-    // into the immutable shared history would bake one device's view into the log — excluded
-    // for the same reason code-anchor BINDINGS are. The projection's `resolved` column stays
-    // NULL for a backfilled edge; the reader recomputes it locally, exactly as the live edge
-    // table does.
-    let mut edges = edges.to_vec();
-    edges.sort_by(|a, b| a.edge_key.cmp(&b.edge_key));
-    for edge in &edges {
-        ops.push(MemoryOp::EdgeAdd {
-            edge: EdgeSpec {
-                source_node_id: NodeId::from(edge.source_node_id.as_str()),
-                relation: EdgeRelation::from_db_str(&edge.relation)?,
-                target_repo_id: edge.target_repo_id.clone(),
-                target_kind: edge.target_kind.clone(),
-                target_anchor: edge.target_anchor.clone(),
-                owner_repo_id: owner_repo_id.to_string(),
-            },
-        });
+        ops.push(MemoryOp::NodeStatus { node_id, status });
     }
     Ok(ops)
 }
 
-/// Author every one of the active repo's pre-existing memories into its owner stream — the one-time
-/// full backfill that makes the op-log the complete signed history from genesis. Idempotent and
-/// scope-gated:
-/// - a NO-OP on an unscoped database (no active repo → no owner stream to root the log on);
-/// - a NO-OP once the owner chain is non-empty: because [`crate::oplog::author_batch`] is atomic, a
-///   non-empty chain is a COMPLETED backfill (no partial state to resume). The next increment's
-///   "backfill before the first live author" ordering keeps this gate correct once live ops share
-///   the chain.
-///
-/// Memories are ordered deterministically `(created_at_ms, memory_id)` — a reproducible Lamport
-/// assignment. Each contributes NodeCreate, then a NodeStatus when non-active, then its EdgeAdds.
-/// ALL statuses are backfilled (obsolete/rejected included): the log is the whole history.
-pub(crate) fn backfill_memory_oplog(conn: &Connection, now_ms: i64) -> anyhow::Result<()> {
-    let Some(repo_id) = memory_repo_scope(conn)? else {
-        return Ok(());
-    };
-    // Only a STABLE repo id may root an IMMUTABLE owner stream. Two ids get re-pointed later, which
-    // would strand a stream signed under the old id: the legacy `__unassigned__` placeholder (an
-    // unadopted DB, re-pointed on adoption) and a machine-local `local:` shallow-clone id (upgraded
-    // to a portable id when the clone is deepened). No-op until a stable id is active — as if
-    // unscoped.
+/// One `EdgeAdd` — presence + the durable, RE-RESOLVED spec only. `edge.target_repo_id` is already
+/// current: `unauthored_edges`'s `reresolve_on_read` repaired the add-time snapshot before the
+/// reconcile signs it (a signed op cannot be corrected later). Deliberately NO `Rebind`: the
+/// `Rebind` op's resolved dimension (`target_node_id`, `anchor_status`) is PER-DEVICE derived state
+/// recomputed on every read by `reresolve_on_read`, so signing it would bake one device's view into
+/// the immutable shared history — excluded for the same reason code-anchor BINDINGS are.
+fn edge_add_op(edge: &NodeEdge, owner_repo_id: &str) -> anyhow::Result<MemoryOp> {
+    Ok(MemoryOp::EdgeAdd {
+        edge: EdgeSpec {
+            source_node_id: NodeId::from(edge.source_node_id.as_str()),
+            relation: EdgeRelation::from_db_str(&edge.relation)?,
+            target_repo_id: edge.target_repo_id.clone(),
+            target_kind: edge.target_kind.clone(),
+            target_anchor: edge.target_anchor.clone(),
+            owner_repo_id: owner_repo_id.to_string(),
+        },
+    })
+}
+
+/// The ordered reconcile batch. Missing edges are grouped by `source_node_id`; for each missing
+/// memory in `(created_at_ms, id)` order it emits [`node_ops`] then that memory's missing edges (in
+/// the `edge_key` order [`unauthored_edges`] returned), then a final pass for edges whose source is
+/// an already-authored node. On an EMPTY projection with `elide_active_status = true` this is
+/// byte-identical to today's genesis sequence: every source memory is missing (`FK ON DELETE
+/// CASCADE` on `source_node_id` rules out an orphan edge), so the final pass is empty and each
+/// memory's edges follow its `NodeCreate`/`NodeStatus` in `edge_key` order.
+fn build_reconcile_ops(
+    missing_nodes: &[MemoryRow],
+    missing_edges: &[NodeEdge],
+    owner_repo_id: &str,
+    elide_active_status: bool,
+) -> anyhow::Result<Vec<MemoryOp>> {
+    use std::collections::BTreeMap;
+    let mut by_source: BTreeMap<&str, Vec<&NodeEdge>> = BTreeMap::new();
+    for edge in missing_edges {
+        by_source.entry(edge.source_node_id.as_str()).or_default().push(edge);
+    }
+    let mut ops = Vec::new();
+    for row in missing_nodes {
+        ops.extend(node_ops(row, elide_active_status)?);
+        if let Some(group) = by_source.remove(row.memory_id.as_str()) {
+            for edge in group {
+                ops.push(edge_add_op(edge, owner_repo_id)?);
+            }
+        }
+    }
+    // Lone ghost edges whose source node was already authored (absent on a genesis projection).
+    for (_source, group) in by_source {
+        for edge in group {
+            ops.push(edge_add_op(edge, owner_repo_id)?);
+        }
+    }
+    Ok(ops)
+}
+
+/// Reconcile the owner stream against the repo's tables: author every `repo_memories` /
+/// `repo_node_edges` row MISSING from the shadow projection. Genesis (empty chain) authors the full
+/// history; a populated chain authors only the ghosts. Idempotent and scope-gated (LEGACY /
+/// `local:` ids never root an immutable stream). Scope-EXPLICIT — `repo_id` is passed, and the
+/// readers + re-resolution are scope-independent, so the consolidation importer's unscoped
+/// connection can call it. Concurrency: two racing callers serialize on the IMMEDIATE lock; the
+/// loser re-reads under the lock and authors only what the winner left missing.
+fn sync_owner_stream(conn: &Connection, repo_id: &str, now_ms: i64) -> anyhow::Result<()> {
+    // Only a STABLE id may root an IMMUTABLE owner stream. Two ids get re-pointed later, which
+    // would strand a stream signed under the old id: the legacy `__unassigned__` placeholder
+    // (an unadopted DB, re-pointed on adoption) and a machine-local `local:` shallow-clone id
+    // (upgraded to a portable id when the clone is deepened). No-op until a stable id is active
+    // — as if unscoped.
     if repo_id == crate::index::schema::LEGACY_REPO_ID
         || repo_id.starts_with(crate::repo_identity::LOCAL_ONLY_ID_PREFIX)
     {
         return Ok(());
     }
-    let stream = owner_stream(&repo_id)?;
-    let device = local_device(conn, now_ms)?;
-    // Cheap fast-path: skip opening the write txn when a chain already exists. NOT the correctness
-    // gate — `author_genesis_in_tx` re-checks emptiness inside the txn below.
-    if chain_tail(conn, stream, device.fingerprint())?.is_some() {
+    let stream = owner_stream(repo_id)?;
+    // Cheap autocommit probe: return WITHOUT a write lock when nothing is missing (steady state).
+    if read_unauthored_memory_rows(conn, repo_id, stream)?.is_empty()
+        && crate::query::memory::edges::unauthored_edges(conn, repo_id, stream)?.is_empty()
+    {
         return Ok(());
     }
-    // ATOMIC snapshot: open the write txn FIRST — the `IMMEDIATE` lock blocks concurrent memory
-    // writers — THEN read the memory/edge snapshot and author it, so a memory created between the
-    // read and the batch cannot be silently omitted from the complete history (after which the
-    // idempotency gate would hide it forever). The empty-chain gate is re-checked inside this txn.
-    // The genesis backfill mints signed op-log entries — authored, irreplaceable data — so it
-    // commits durably (#560).
+    let device = local_device(conn, now_ms)?;
+    // Authored, irreplaceable data → durable (#560). FULL for this txn only, restored on drop; set
+    // OUTSIDE the txn (SQLite applies a `synchronous` change to SUBSEQUENT transactions only).
     let _durability = AuthoredDurability::begin(conn)?;
     let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
-    let mut ops = Vec::new();
-    for row in read_memory_rows(&tx, &repo_id)? {
-        // `all_edges_from`, not `edges_from`: a backfilled obsolete/rejected memory still carries
-        // its persisted edges into the complete-history log (the live reader hides them).
-        let edges = all_edges_from(&tx, &row.memory_id)?;
-        ops.extend(memory_to_ops(&row, &repo_id, &edges)?);
-    }
-    author_genesis_in_tx(&tx, stream, &device, &ops, now_ms)?;
+    // Authoritative re-read UNDER the write lock (TOCTOU): a concurrent author may have healed or
+    // added rows between the probe and the lock, so re-read the missing set and re-derive `genesis`
+    // here. `genesis` decides the status-elision: an empty LOCAL chain ⇒ no stale registers ⇒ elide
+    // `active` (byte-identical to the pre-#541 genesis). This equivalence holds ONLY under the
+    // single-local-writer owner stream (see the module header); phase D (foreign devices can
+    // populate the stream) must revisit whether local-chain-empty still implies register-clean.
+    let genesis = chain_tail(&tx, stream, device.fingerprint())?.is_none();
+    let missing_nodes = read_unauthored_memory_rows(&tx, repo_id, stream)?;
+    let missing_edges = crate::query::memory::edges::unauthored_edges(&tx, repo_id, stream)?;
+    let ops = build_reconcile_ops(&missing_nodes, &missing_edges, repo_id, genesis)?;
+    author_batch_in_tx(&tx, stream, &device, &ops, now_ms)?;
     tx.commit()?;
     Ok(())
+}
+
+/// Reconcile the ACTIVE repo's owner stream (scope read from the connection) — the idempotent call
+/// every live memory/edge mutation makes before authoring (#532), now self-healing per node/edge (a
+/// ghost row is authored on the next mutation, so no later lifecycle op on it is inert). A no-op on
+/// an unscoped DB.
+pub(crate) fn backfill_memory_oplog(conn: &Connection, now_ms: i64) -> anyhow::Result<()> {
+    let Some(repo_id) = memory_repo_scope(conn)? else {
+        return Ok(());
+    };
+    sync_owner_stream(conn, &repo_id, now_ms)
+}
+
+/// Reconcile a SPECIFIC repo's owner stream independent of connection scope — the seam
+/// consolidation uses to author freshly-imported (remapped) rows into the TARGET's owner stream
+/// under the TARGET's identity (#541). The source's pre-remap signed entries are intentionally NOT
+/// carried (they are signed under the source device over pre-remap ids). Wired into consolidation
+/// by Task 5 of #541.
+#[allow(dead_code)]
+pub(crate) fn reconcile_owner_stream_for_repo(
+    conn: &Connection,
+    repo_id: &str,
+    now_ms: i64,
+) -> anyhow::Result<()> {
+    sync_owner_stream(conn, repo_id, now_ms)
 }
 
 /// The active repo's owner stream, but ONLY when the scope is a STABLE identity to root an
@@ -343,41 +397,11 @@ fn content_of(memory: &RepoMemory) -> NodeContent {
     )
 }
 
-/// The active repo's memories in deterministic `(created_at_ms, memory_id)` order, tags attached.
-fn read_memory_rows(conn: &Connection, repo_id: &str) -> anyhow::Result<Vec<MemoryRow>> {
-    let mut stmt = conn.prepare(
-        "SELECT id, kind, title, body, confidence, status, source, payload_json
-         FROM repo_memories WHERE repo_id = ?1 ORDER BY created_at_ms, id",
-    )?;
-    let mut rows = stmt
-        .query_map(params![repo_id], |row| {
-            Ok(MemoryRow {
-                memory_id: row.get(0)?,
-                kind: row.get(1)?,
-                title: row.get(2)?,
-                body: row.get(3)?,
-                confidence: row.get(4)?,
-                status: row.get(5)?,
-                source: row.get(6)?,
-                payload_json: row.get(7)?,
-                tags: Vec::new(),
-            })
-        })?
-        .collect::<Result<Vec<_>, _>>()?;
-    for row in &mut rows {
-        // Reuse the memory subsystem's own tag reader (the op encoder sorts + dedupes anyway).
-        row.tags = tags_for_memory(conn, &row.memory_id)?;
-    }
-    Ok(rows)
-}
-
 /// The repo's memories with NO projected node on `stream` — the rows the signed log is MISSING —
 /// in deterministic `(created_at_ms, id)` order, tags attached. On an EMPTY projection this is
 /// every memory (genesis); on a populated one, the ghosts a raw writer or an old binary left
-/// behind (#541).
-///
-/// Not yet called outside its own test — Task 3 (#541) wires this into the reconcile.
-#[allow(dead_code)]
+/// behind (#541). Reuses the memory subsystem's own tag reader (the op encoder sorts + dedupes
+/// anyway).
 fn read_unauthored_memory_rows(
     conn: &Connection,
     repo_id: &str,
@@ -454,6 +478,42 @@ mod tests {
         .unwrap();
     }
 
+    /// Read the materialized shadow projection for `stream` — the completeness mirror the reconcile
+    /// heals into.
+    fn projected_state(conn: &Connection, stream: StreamId) -> crate::oplog::ProjectedState {
+        crate::oplog::load_projection(conn, stream).unwrap()
+    }
+
+    /// Insert a node-edge by RAW SQL, bypassing the wired `add_edge` author — a "ghost edge" that
+    /// exists in `repo_node_edges` but was never signed into the op-log.
+    fn insert_raw_node_edge(conn: &Connection, source: &str, relation: &str, target: &str) {
+        let key = crate::query::memory::edge_key(source, relation, "node", target);
+        conn.execute(
+            "INSERT INTO repo_node_edges(edge_key, repo_id, source_node_id, relation, \
+             target_repo_id,
+                 target_kind, target_anchor, target_node_id, anchor_status, created_at_ms)
+             VALUES (?1, ?2, ?3, ?4, ?2, 'node', ?5, ?5, 'current', 100)",
+            params![key, REPO, source, relation, target],
+        )
+        .unwrap();
+    }
+
+    /// Author a BARE `NodeStatus` for a node with NO `NodeCreate` — simulates the INERT op a
+    /// pre-fix (#532) binary authored when it `mark_obsolete`'d a still-ghost memory. Leaves a
+    /// stale status register with no projected node.
+    fn author_inert_status_op(conn: &Connection, node_id: &str, status: NodeStatus) {
+        let device = crate::oplog::local_device(conn, 0).unwrap();
+        let stream = crate::oplog::owner_stream(REPO).unwrap();
+        crate::oplog::author_op(
+            conn,
+            stream,
+            &device,
+            &MemoryOp::NodeStatus { node_id: NodeId::from(node_id), status },
+            100,
+        )
+        .unwrap();
+    }
+
     fn entry_count(conn: &Connection) -> i64 {
         conn.query_row("SELECT COUNT(*) FROM oplog_entries", [], |r| r.get(0)).unwrap()
     }
@@ -494,19 +554,36 @@ mod tests {
         std::fs::remove_dir_all(&dir).ok();
     }
 
-    #[test]
-    fn memory_to_ops_translates_content_status_and_edges() {
-        let row = MemoryRow {
+    /// A `MemoryRow` with the given status, no payload, one tag — the fixture the ported op-split
+    /// tests translate.
+    fn op_row(status: &str) -> MemoryRow {
+        MemoryRow {
             memory_id: "mem_a".to_string(),
             kind: "Invariant".to_string(),
             title: "t".to_string(),
             body: "b".to_string(),
             confidence: "high".to_string(),
-            status: "obsolete".to_string(),
+            status: status.to_string(),
             source: "agent".to_string(),
             payload_json: None,
             tags: vec!["x".to_string()],
-        };
+        }
+    }
+
+    #[test]
+    fn node_ops_and_edge_add_op_translate_content_status_and_an_edge() {
+        // GENESIS (elide=true) on a non-active memory: NodeCreate then a NodeStatus (obsolete is
+        // not the active default). `edge_add_op` yields one EdgeAdd and DELIBERATELY no
+        // Rebind — the per-device resolved dimension (target_node_id / anchor_status) is
+        // recomputed on read, never signed into the log.
+        let ops = node_ops(&op_row("obsolete"), true).unwrap();
+        assert_eq!(ops.len(), 2);
+        assert!(
+            matches!(&ops[0], MemoryOp::NodeCreate { node_id, .. } if node_id.as_str() == "mem_a")
+        );
+        assert!(
+            matches!(&ops[1], MemoryOp::NodeStatus { status, .. } if status.as_db_str() == "obsolete")
+        );
         let edge = NodeEdge {
             edge_key: "k1".to_string(),
             source_node_id: "mem_a".to_string(),
@@ -517,58 +594,45 @@ mod tests {
             target_node_id: Some("mem_b".to_string()),
             anchor_status: "current".to_string(),
         };
-        let ops = memory_to_ops(&row, REPO, std::slice::from_ref(&edge)).unwrap();
-        // NodeCreate, then a NodeStatus (obsolete is not the active default), then the EdgeAdd.
-        assert_eq!(ops.len(), 3);
+        let edge_op = edge_add_op(&edge, REPO).unwrap();
+        assert!(matches!(&edge_op, MemoryOp::EdgeAdd { .. }));
+        let all_ops: Vec<MemoryOp> = ops.into_iter().chain(std::iter::once(edge_op)).collect();
         assert!(
-            matches!(&ops[0], MemoryOp::NodeCreate { node_id, .. } if node_id.as_str() == "mem_a")
-        );
-        assert!(
-            matches!(&ops[1], MemoryOp::NodeStatus { status, .. } if status.as_db_str() == "obsolete")
-        );
-        // An EdgeAdd, and DELIBERATELY no Rebind — the per-device resolved dimension
-        // (target_node_id / anchor_status) is recomputed on read, never signed into the log.
-        assert!(matches!(&ops[2], MemoryOp::EdgeAdd { .. }));
-        assert!(
-            !ops.iter().any(|op| matches!(op, MemoryOp::Rebind { .. })),
-            "the backfill omits the per-device resolved dimension"
+            !all_ops.iter().any(|op| matches!(op, MemoryOp::Rebind { .. })),
+            "the reconcile omits the per-device resolved dimension"
         );
     }
 
     #[test]
-    fn an_active_memory_emits_no_status_op() {
-        let row = MemoryRow {
-            memory_id: "mem_a".to_string(),
-            kind: "Invariant".to_string(),
-            title: "t".to_string(),
-            body: "b".to_string(),
-            confidence: "high".to_string(),
-            status: "active".to_string(),
-            source: "agent".to_string(),
-            payload_json: None,
-            tags: Vec::new(),
-        };
-        let ops = memory_to_ops(&row, REPO, &[]).unwrap();
-        assert_eq!(ops.len(), 1, "an active, edgeless memory is just its NodeCreate");
+    fn genesis_node_ops_for_an_active_memory_emit_no_status_op() {
+        // elide=true (genesis, no stale registers): an active, edgeless memory is just its
+        // NodeCreate — the fold's create-time default handles `active`.
+        let ops = node_ops(&op_row("active"), true).unwrap();
+        assert_eq!(ops.len(), 1, "an active memory on genesis is just its NodeCreate");
+        assert!(matches!(&ops[0], MemoryOp::NodeCreate { .. }));
     }
 
     #[test]
-    fn memory_to_ops_fails_on_an_unknown_status() {
-        // A status token this binary can't map must FAIL the backfill, not silently default the
-        // signed history to `active`.
-        let row = MemoryRow {
-            memory_id: "mem_a".to_string(),
-            kind: "Invariant".to_string(),
-            title: "t".to_string(),
-            body: "b".to_string(),
-            confidence: "high".to_string(),
-            status: "future_status_from_a_newer_binary".to_string(),
-            source: "agent".to_string(),
-            payload_json: None,
-            tags: Vec::new(),
-        };
-        let err = memory_to_ops(&row, REPO, &[]).unwrap_err();
-        assert!(err.to_string().contains("unknown status"), "an unknown status fails the backfill");
+    fn incremental_node_ops_for_an_active_memory_do_emit_an_explicit_status() {
+        // elide=false (incremental heal on a non-empty chain): ALWAYS emit NodeStatus, even
+        // `active`, so a healed node's status wins its register at the new Lamport and overrides
+        // any stale register a prior inert op left behind (decision 6 of #541).
+        let ops = node_ops(&op_row("active"), false).unwrap();
+        assert_eq!(ops.len(), 2, "an active memory on a heal emits an explicit NodeStatus");
+        assert!(matches!(&ops[0], MemoryOp::NodeCreate { .. }));
+        assert!(
+            matches!(&ops[1], MemoryOp::NodeStatus { status, .. } if status.as_db_str() == "active"),
+            "the incremental branch emits NodeStatus{{active}} to win the register"
+        );
+    }
+
+    #[test]
+    fn node_ops_fails_on_an_unknown_status() {
+        // A status token this binary can't map must FAIL, not silently default the signed history
+        // to `active`. Holds in either branch — an unknown token is never the active
+        // default.
+        let err = node_ops(&op_row("future_status_from_a_newer_binary"), true).unwrap_err();
+        assert!(err.to_string().contains("unknown status"), "an unknown status fails authoring");
     }
 
     /// #541: the reconcile's memory reader anti-joins `repo_memories` against
@@ -587,6 +651,85 @@ mod tests {
         .unwrap();
         let missing = read_unauthored_memory_rows(&conn, REPO, stream).unwrap();
         assert_eq!(missing.iter().map(|r| r.memory_id.as_str()).collect::<Vec<_>>(), ["mem_ghost"]);
+    }
+
+    // --- the per-node/edge self-healing reconcile (#541) ---
+
+    #[test]
+    fn a_ghost_memory_is_authored_on_the_next_reconcile() {
+        let conn = scoped_conn();
+        create_concept(&conn, "seed").unwrap(); // roots the chain via genesis
+        insert_memory(&conn, "mem_ghost", "obsolete", 500); // raw, un-authored ghost
+        backfill_memory_oplog(&conn, 9_000).unwrap();
+        let stream = crate::oplog::owner_stream(REPO).unwrap();
+        let g = projected_state(&conn, stream)
+            .nodes
+            .get(&NodeId::from("mem_ghost"))
+            .cloned()
+            .expect("ghost is now authored");
+        assert_eq!(g.status, NodeStatus::Obsolete, "create-time status carried");
+    }
+
+    #[test]
+    fn heal_overrides_a_stale_status_register_left_by_an_inert_op() {
+        // The decision-6 divergence: an inert NodeStatus{obsolete} exists, the row is now active,
+        // the heal must author an explicit NodeStatus{active} so the projection matches the table.
+        let conn = scoped_conn();
+        let id = create_concept(&conn, "seed").unwrap().memory.memory_id;
+        // Author an inert NodeStatus for a NOT-yet-created ghost by hand (simulate the old binary):
+        let ghost = "mem_ghost";
+        author_inert_status_op(&conn, ghost, NodeStatus::Obsolete);
+        insert_memory(&conn, ghost, "active", 500); // the table says active
+        backfill_memory_oplog(&conn, 9_000).unwrap();
+        let stream = crate::oplog::owner_stream(REPO).unwrap();
+        let node = projected_state(&conn, stream)
+            .nodes
+            .get(&NodeId::from(ghost))
+            .cloned()
+            .expect("ghost healed");
+        assert_eq!(
+            node.status,
+            NodeStatus::Active,
+            "explicit NodeStatus{{active}} overrode the stale register"
+        );
+        let _ = id;
+    }
+
+    #[test]
+    fn a_ghost_edge_on_a_live_node_is_authored_on_the_next_reconcile() {
+        let conn = scoped_conn();
+        let a = create_concept(&conn, "a").unwrap().memory.memory_id;
+        let b = create_concept(&conn, "b").unwrap().memory.memory_id;
+        insert_raw_node_edge(&conn, &a, "relates_to", &b); // writes repo_node_edges directly
+        backfill_memory_oplog(&conn, 9_000).unwrap();
+        let stream = crate::oplog::owner_stream(REPO).unwrap();
+        assert_eq!(projected_state(&conn, stream).edges.len(), 1, "ghost edge now signed");
+    }
+
+    #[test]
+    fn reconcile_is_idempotent_and_a_clean_repo_authors_nothing() {
+        let conn = scoped_conn();
+        create_concept(&conn, "seed").unwrap();
+        let stream = crate::oplog::owner_stream(REPO).unwrap();
+        let fp = crate::oplog::local_device(&conn, 0).unwrap().fingerprint();
+        let before = crate::oplog::chain_tail(&conn, stream, fp).unwrap();
+        backfill_memory_oplog(&conn, 9_000).unwrap();
+        assert_eq!(
+            crate::oplog::chain_tail(&conn, stream, fp).unwrap(),
+            before,
+            "no ghost → no new op"
+        );
+    }
+
+    #[test]
+    fn an_unreadable_status_ghost_fails_the_mutation_path_loudly() {
+        // Blast-radius pin: a ghost carrying a status token THIS binary cannot decode makes the
+        // whole reconcile (hence the mutation that triggered it) fail, rather than silently minting
+        // `active`.
+        let conn = scoped_conn();
+        create_concept(&conn, "seed").unwrap();
+        insert_memory(&conn, "mem_future", "some_future_status", 500);
+        assert!(backfill_memory_oplog(&conn, 9_000).is_err());
     }
 
     #[test]

--- a/crates/rag-rat-core/src/query/memory/authoring.rs
+++ b/crates/rag-rat-core/src/query/memory/authoring.rs
@@ -371,6 +371,48 @@ fn read_memory_rows(conn: &Connection, repo_id: &str) -> anyhow::Result<Vec<Memo
     Ok(rows)
 }
 
+/// The repo's memories with NO projected node on `stream` — the rows the signed log is MISSING —
+/// in deterministic `(created_at_ms, id)` order, tags attached. On an EMPTY projection this is
+/// every memory (genesis); on a populated one, the ghosts a raw writer or an old binary left
+/// behind (#541).
+///
+/// Not yet called outside its own test — Task 3 (#541) wires this into the reconcile.
+#[allow(dead_code)]
+fn read_unauthored_memory_rows(
+    conn: &Connection,
+    repo_id: &str,
+    stream: StreamId,
+) -> anyhow::Result<Vec<MemoryRow>> {
+    let mut stmt = conn.prepare(
+        "SELECT m.id, m.kind, m.title, m.body, m.confidence, m.status, m.source, m.payload_json
+         FROM repo_memories m
+         WHERE m.repo_id = ?1
+           AND NOT EXISTS (
+                 SELECT 1 FROM oplog_projected_nodes p
+                 WHERE p.stream_id = ?2 AND p.node_id = m.id)
+         ORDER BY m.created_at_ms, m.id",
+    )?;
+    let mut rows = stmt
+        .query_map(params![repo_id, stream.to_bytes().as_slice()], |row| {
+            Ok(MemoryRow {
+                memory_id: row.get(0)?,
+                kind: row.get(1)?,
+                title: row.get(2)?,
+                body: row.get(3)?,
+                confidence: row.get(4)?,
+                status: row.get(5)?,
+                source: row.get(6)?,
+                payload_json: row.get(7)?,
+                tags: Vec::new(),
+            })
+        })?
+        .collect::<Result<Vec<_>, _>>()?;
+    for row in &mut rows {
+        row.tags = tags_for_memory(conn, &row.memory_id)?;
+    }
+    Ok(rows)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -527,6 +569,24 @@ mod tests {
         };
         let err = memory_to_ops(&row, REPO, &[]).unwrap_err();
         assert!(err.to_string().contains("unknown status"), "an unknown status fails the backfill");
+    }
+
+    /// #541: the reconcile's memory reader anti-joins `repo_memories` against
+    /// `oplog_projected_nodes` — only a row with no projected node (never signed) comes back.
+    #[test]
+    fn read_unauthored_memory_rows_returns_only_rows_absent_from_the_projection() {
+        let conn = scoped_conn();
+        insert_memory(&conn, "mem_live", "active", 100);
+        insert_memory(&conn, "mem_ghost", "active", 200);
+        let stream = crate::oplog::owner_stream(REPO).unwrap();
+        conn.execute(
+            "INSERT INTO oplog_projected_nodes(stream_id, node_id, content_json, status)
+             VALUES (?1, 'mem_live', '{}', 'active')",
+            params![stream.to_bytes().as_slice()],
+        )
+        .unwrap();
+        let missing = read_unauthored_memory_rows(&conn, REPO, stream).unwrap();
+        assert_eq!(missing.iter().map(|r| r.memory_id.as_str()).collect::<Vec<_>>(), ["mem_ghost"]);
     }
 
     #[test]

--- a/crates/rag-rat-core/src/query/memory/authoring.rs
+++ b/crates/rag-rat-core/src/query/memory/authoring.rs
@@ -253,8 +253,8 @@ pub(crate) fn backfill_memory_oplog(conn: &Connection, now_ms: i64) -> anyhow::R
 /// consolidation uses to author freshly-imported (remapped) rows into the TARGET's owner stream
 /// under the TARGET's identity (#541). The source's pre-remap signed entries are intentionally NOT
 /// carried (they are signed under the source device over pre-remap ids). Wired into consolidation
-/// by Task 5 of #541.
-#[allow(dead_code)]
+/// by [`crate::index::consolidate::run`] (#541 Task 5), immediately after the import commits and
+/// before the legacy file is renamed away.
 pub(crate) fn reconcile_owner_stream_for_repo(
     conn: &Connection,
     repo_id: &str,

--- a/crates/rag-rat-core/src/query/memory/authoring.rs
+++ b/crates/rag-rat-core/src/query/memory/authoring.rs
@@ -983,6 +983,58 @@ mod tests {
         assert_eq!(projected_edge_count(&conn), 0, "remove_edge authored an EdgeRemove tombstone");
     }
 
+    // --- live mutation seam self-heals a ghost end to end (#541 Task 4) ---
+
+    #[test]
+    fn mark_obsolete_on_a_ghost_authors_a_create_not_an_inert_status() {
+        let conn = scoped_conn();
+        create_concept(&conn, "seed").unwrap(); // roots the chain
+        insert_memory(&conn, "mem_ghost", "active", 500); // raw, un-authored ghost
+        // mark_obsolete reconciles first (heals NodeCreate + NodeStatus{active}), THEN authors the
+        // obsolete NodeStatus — so it is NOT inert and the node projects obsolete.
+        crate::query::memory::mark_obsolete(&conn, "mem_ghost").unwrap();
+        let stream = crate::oplog::owner_stream(REPO).unwrap();
+        let node = projected_state(&conn, stream)
+            .nodes
+            .get(&NodeId::from("mem_ghost"))
+            .cloned()
+            .expect("ghost healed then obsoleted");
+        assert_eq!(node.status, NodeStatus::Obsolete);
+    }
+
+    #[test]
+    fn remove_edge_on_a_ghost_edge_heals_then_tombstones_not_an_inert_remove() {
+        // The EdgeRemove path: `remove_edge` calls backfill (edges.rs) BEFORE its delete txn, so a
+        // raw ghost edge is first healed (EdgeAdd authored), then the delete authors EdgeRemove —
+        // the signed history is add→remove (complete), and the projection ends with the
+        // edge ABSENT (not an inert tombstone with no matching add).
+        //
+        // `remove_edge` authors its `EdgeRemove` unconditionally once the raw row is deleted
+        // (edges.rs gates it on `n > 0`, NOT on whether an `EdgeAdd` was ever signed) — so
+        // `edges.is_empty()` alone is satisfied whether or not the heal ran (a
+        // never-authored edge and a healed-then-removed edge both project empty). The
+        // `entry_count` delta is what actually distinguishes them: it is +2 (heal's
+        // `EdgeAdd` + `remove_edge`'s own `EdgeRemove`) only when the reconcile fired; a
+        // disabled reconcile would author just the bare `EdgeRemove` (+1).
+        let conn = scoped_conn();
+        let a = create_concept(&conn, "a").unwrap().memory.memory_id;
+        let b = create_concept(&conn, "b").unwrap().memory.memory_id;
+        insert_raw_node_edge(&conn, &a, "relates_to", &b);
+        let key = crate::query::memory::edge_key(&a, "relates_to", "node", &b);
+        let before = entry_count(&conn);
+        crate::query::memory::remove_edge(&conn, &key).unwrap();
+        assert_eq!(
+            entry_count(&conn),
+            before + 2,
+            "the heal's EdgeAdd + remove_edge's own EdgeRemove — not a bare, inert tombstone"
+        );
+        let stream = crate::oplog::owner_stream(REPO).unwrap();
+        assert!(
+            projected_state(&conn, stream).edges.is_empty(),
+            "healed then tombstoned → edge absent"
+        );
+    }
+
     #[test]
     fn a_failed_author_rolls_back_the_memory_write() {
         let conn = scoped_conn();

--- a/crates/rag-rat-core/src/query/memory/edges.rs
+++ b/crates/rag-rat-core/src/query/memory/edges.rs
@@ -12,6 +12,7 @@
 //! once its target repo is indexed and its `target_repo_id` self-heals across a repo-id re-point.
 
 use super::*;
+use crate::oplog::StreamId;
 use crate::query::memory::authoring;
 
 /// The relation an edge expresses, from a source memory node to its target. Persisted in
@@ -338,6 +339,34 @@ pub(crate) fn edge_by_key(conn: &Connection, edge_key: &str) -> anyhow::Result<O
         .map_err(Into::into)
 }
 
+/// The repo's node-edges with NO projected edge on `stream` — the `EdgeAdd`s the signed log is
+/// MISSING — in `edge_key` order. Run through [`reresolve_on_read`] so a node target's
+/// `target_repo_id` is repaired to CURRENT before the reconcile signs it (the stored column is
+/// only an add-time snapshot; a signed op cannot be corrected later — see decision 5 of #541).
+/// Scope-INDEPENDENT: filters on the explicit `repo_id`, and re-resolution is a global by-node-id
+/// lookup, so consolidation's unscoped connection may call it directly.
+///
+/// Not yet called outside its own test — Task 3 (#541) wires this into the reconcile.
+#[allow(dead_code)]
+pub(crate) fn unauthored_edges(
+    conn: &Connection,
+    repo_id: &str,
+    stream: StreamId,
+) -> anyhow::Result<Vec<NodeEdge>> {
+    let mut stmt = conn.prepare(&format!(
+        "{EDGE_SELECT} e
+         WHERE e.repo_id = ?1
+           AND NOT EXISTS (
+                 SELECT 1 FROM oplog_projected_edges p
+                 WHERE p.stream_id = ?2 AND p.edge_key = e.edge_key)
+         ORDER BY e.edge_key"
+    ))?;
+    let raw = stmt
+        .query_map(params![repo_id, stream.to_bytes().as_slice()], edge_row)?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    reresolve_on_read(conn, raw)
+}
+
 const UNASSIGNED_REPO: &str = "__unassigned__";
 
 const EDGE_SELECT: &str = "
@@ -459,6 +488,65 @@ fn reresolve_on_read(conn: &Connection, mut edges: Vec<NodeEdge>) -> anyhow::Res
 mod tests {
     use super::*;
 
+    const REPO: &str = "repo-a";
+
+    /// A DB with the memory schema, one registered repo, and the connection scoped to it — the
+    /// minimal setup `memory_repo_scope` needs to resolve an active repo. Mirrors
+    /// `authoring::tests::scoped_conn` (each module's test scaffolding is self-contained).
+    fn scoped_conn() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("PRAGMA foreign_keys = ON;").unwrap();
+        crate::index::schema::apply(&conn).unwrap();
+        conn.execute(
+            "INSERT INTO repos(repo_id, display_name, registered_at_ms) VALUES (?1, ?1, 0)",
+            [REPO],
+        )
+        .unwrap();
+        conn.execute_batch(
+            "CREATE TEMP TABLE IF NOT EXISTS connection_context(key TEXT PRIMARY KEY, value TEXT);",
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT OR REPLACE INTO temp.connection_context(key, value) VALUES ('repo_id', ?1)",
+            [REPO],
+        )
+        .unwrap();
+        conn
+    }
+
+    fn insert_memory(conn: &Connection, id: &str, status: &str, created_at_ms: i64) {
+        conn.execute(
+            "INSERT INTO repo_memories(
+                 id, kind, title, body, confidence, status, created_by, created_at_ms,
+                 updated_at_ms, source, input_hash, memory_version, repo_id)
+             VALUES (?1, 'Invariant', ?1, 'body', 'high', ?2, 'agent', ?3, ?3, 'agent', 'h', 'v1',
+                 ?4)",
+            params![id, status, created_at_ms, REPO],
+        )
+        .unwrap();
+    }
+
+    /// Insert a node-edge by RAW SQL, bypassing the wired `add_edge` author — a "ghost edge" that
+    /// exists in `repo_node_edges` but was never signed into the op-log. Returns the computed
+    /// `edge_key` so callers can seed/inspect the projection by it.
+    fn insert_raw_node_edge(
+        conn: &Connection,
+        source: &str,
+        relation: &str,
+        target: &str,
+    ) -> String {
+        let key = edge_key(source, relation, "node", target);
+        conn.execute(
+            "INSERT INTO repo_node_edges(edge_key, repo_id, source_node_id, relation,
+                 target_repo_id, target_kind, target_anchor, target_node_id, anchor_status,
+                 created_at_ms)
+             VALUES (?1, ?2, ?3, ?4, ?2, 'node', ?5, ?5, 'current', 100)",
+            params![key, REPO, source, relation, target],
+        )
+        .unwrap();
+        key
+    }
+
     /// The strum-derived tokens are PERSISTED in `repo_node_edges.relation` — pin them exactly so a
     /// rename or reorder can't silently repoint stored rows (the `as_db_str`/`from_db_str`
     /// contract).
@@ -475,5 +563,50 @@ mod tests {
             assert_eq!(EdgeRelation::from_db_str(token).unwrap(), relation);
         }
         assert!(EdgeRelation::from_db_str("bogus").is_err(), "an unknown token must not resolve");
+    }
+
+    /// #541: the reconcile's edge reader anti-joins `repo_node_edges` against
+    /// `oplog_projected_edges` and re-resolves what it returns. Proves BOTH halves of the
+    /// correctness crux: (a) only the edge absent from the projection comes back, and (b) its
+    /// `target_repo_id` — deliberately stale on the stored row, simulating an add-time snapshot
+    /// left behind by a repo-id re-point — is repaired to the CURRENT owner before it would be
+    /// signed.
+    #[test]
+    fn unauthored_edges_returns_only_edges_absent_from_the_projection_reresolved() {
+        let conn = scoped_conn();
+        insert_memory(&conn, "mem_a", "active", 100);
+        insert_memory(&conn, "mem_b", "active", 200);
+        insert_memory(&conn, "mem_c", "active", 300);
+        let authored_key = insert_raw_node_edge(&conn, "mem_a", "relates_to", "mem_b");
+        let ghost_key = insert_raw_node_edge(&conn, "mem_a", "depends_on", "mem_c");
+
+        let stream = crate::oplog::owner_stream(REPO).unwrap();
+        // Seed the projection with the `relates_to` edge only — it is already authored.
+        conn.execute(
+            "INSERT INTO oplog_projected_edges(stream_id, edge_key, spec_json, resolved_json)
+             VALUES (?1, ?2, '{}', NULL)",
+            params![stream.to_bytes().as_slice(), authored_key],
+        )
+        .unwrap();
+        // Simulate an add-time snapshot gone stale: the ghost edge's stored `target_repo_id` no
+        // longer matches mem_c's CURRENT owning repo (as if a repo-id re-point happened after the
+        // edge row was written).
+        conn.execute(
+            "UPDATE repo_node_edges SET target_repo_id = 'stale-repo-id' WHERE edge_key = ?1",
+            [&ghost_key],
+        )
+        .unwrap();
+
+        let missing = unauthored_edges(&conn, REPO, stream).unwrap();
+        assert_eq!(
+            missing.iter().map(|e| e.edge_key.as_str()).collect::<Vec<_>>(),
+            [ghost_key.as_str()],
+            "only the edge absent from the projection returns"
+        );
+        assert_eq!(
+            missing[0].target_repo_id, REPO,
+            "reresolve_on_read must repair the stale stored target_repo_id to the CURRENT owner \
+             before the reconcile signs it"
+        );
     }
 }

--- a/crates/rag-rat-core/src/query/memory/edges.rs
+++ b/crates/rag-rat-core/src/query/memory/edges.rs
@@ -262,49 +262,17 @@ pub(crate) fn remove_edge(conn: &Connection, edge_key: &str) -> anyhow::Result<b
     Ok(n > 0)
 }
 
-/// Every edge OUT of `source_node_id` (its outgoing graph — deps, mind-map links, tracks).
+/// Every edge OUT of `source_node_id` (its outgoing graph — deps, mind-map links, tracks). Owner-
+/// scoped, filtered to a LIVE source (a `stale` node is live; only `obsolete`/`rejected` are dead,
+/// exactly as the binding reads filter — see [`LIVE_SOURCE_PREDICATE`]), and re-resolved on read.
+/// The complete-history read the op-log reconcile needs is [`unauthored_edges`], not this — it
+/// anti-joins the projection across EVERY source regardless of status.
 pub(crate) fn edges_from(conn: &Connection, source_node_id: &str) -> anyhow::Result<Vec<NodeEdge>> {
-    edges_from_source(conn, source_node_id, SourceScope::LiveOnly)
-}
-
-/// Every edge FROM `source_node_id`, INCLUDING those whose source memory is `obsolete`/`rejected` —
-/// the complete-history read the op-log backfill needs. It is exactly [`edges_from`] MINUS the
-/// `LIVE_SOURCE_PREDICATE` (a non-live source's edges stay visible); it KEEPS `reresolve_on_read`,
-/// so a node target's `target_repo_id` is repaired to CURRENT before it is signed into the op-log
-/// `EdgeSpec` (the stored column is only an add-time snapshot — stale after a repo-id re-point or
-/// if the target was `unresolved` at add time, and a signed op cannot be corrected later).
-/// `edge_key` itself folds node ids, not repo ids, so it is stable regardless.
-pub(crate) fn all_edges_from(
-    conn: &Connection,
-    source_node_id: &str,
-) -> anyhow::Result<Vec<NodeEdge>> {
-    edges_from_source(conn, source_node_id, SourceScope::All)
-}
-
-/// Whether an outgoing-edge read is filtered to a LIVE source (the recall surface) or spans EVERY
-/// source regardless of its memory's status (the complete-history backfill).
-enum SourceScope {
-    LiveOnly,
-    All,
-}
-
-/// Shared body of [`edges_from`] / [`all_edges_from`]: the only difference is whether the
-/// `LIVE_SOURCE_PREDICATE` is applied. Both are owner-scoped and both re-resolve node targets on
-/// read.
-fn edges_from_source(
-    conn: &Connection,
-    source_node_id: &str,
-    scope_kind: SourceScope,
-) -> anyhow::Result<Vec<NodeEdge>> {
     let scope = memory_repo_scope(conn)?;
     let repo_clause = periphery_edge_scope_clause(&scope);
-    let live_clause = match scope_kind {
-        SourceScope::LiveOnly => LIVE_SOURCE_PREDICATE,
-        SourceScope::All => "",
-    };
     let mut stmt = conn.prepare(&format!(
-        "{EDGE_SELECT} WHERE source_node_id = ?1{repo_clause}{live_clause} ORDER BY relation, \
-         target_anchor"
+        "{EDGE_SELECT} WHERE source_node_id = ?1{repo_clause}{LIVE_SOURCE_PREDICATE} ORDER BY \
+         relation, target_anchor"
     ))?;
     let rows = stmt.query_map([source_node_id], edge_row)?.collect::<rusqlite::Result<_>>()?;
     reresolve_on_read(conn, rows)
@@ -344,10 +312,8 @@ pub(crate) fn edge_by_key(conn: &Connection, edge_key: &str) -> anyhow::Result<O
 /// `target_repo_id` is repaired to CURRENT before the reconcile signs it (the stored column is
 /// only an add-time snapshot; a signed op cannot be corrected later — see decision 5 of #541).
 /// Scope-INDEPENDENT: filters on the explicit `repo_id`, and re-resolution is a global by-node-id
-/// lookup, so consolidation's unscoped connection may call it directly.
-///
-/// Not yet called outside its own test — Task 3 (#541) wires this into the reconcile.
-#[allow(dead_code)]
+/// lookup, so consolidation's unscoped connection may call it directly. The reconcile
+/// (`authoring::sync_owner_stream`) authors what this returns.
 pub(crate) fn unauthored_edges(
     conn: &Connection,
     repo_id: &str,

--- a/crates/rag-rat-core/src/query/memory/mod.rs
+++ b/crates/rag-rat-core/src/query/memory/mod.rs
@@ -12,9 +12,7 @@ use std::collections::BTreeSet;
 pub use api::memory_evidence_for_symbol;
 pub(crate) use api::*;
 // The scope-explicit reconcile entry (#541): `authoring` is a PRIVATE module, so
-// `index::consolidate` can only name this through a re-export. Wired into consolidation by
-// Task 5 of #541, so it stays `allow(unused_imports)` until that non-test caller lands.
-#[allow(unused_imports)]
+// `index::consolidate` names this through this re-export (Task 5 of #541).
 pub(crate) use authoring::reconcile_owner_stream_for_repo;
 // The typed-edge public surface (#464): the boundary types cross the FFI/MCP/CLI edge, so they
 // are `pub`; the query fns stay crate-internal.

--- a/crates/rag-rat-core/src/query/memory/mod.rs
+++ b/crates/rag-rat-core/src/query/memory/mod.rs
@@ -11,10 +11,15 @@ use std::collections::BTreeSet;
 
 pub use api::memory_evidence_for_symbol;
 pub(crate) use api::*;
+// The scope-explicit reconcile entry (#541): `authoring` is a PRIVATE module, so
+// `index::consolidate` can only name this through a re-export. Wired into consolidation by
+// Task 5 of #541, so it stays `allow(unused_imports)` until that non-test caller lands.
+#[allow(unused_imports)]
+pub(crate) use authoring::reconcile_owner_stream_for_repo;
 // The typed-edge public surface (#464): the boundary types cross the FFI/MCP/CLI edge, so they
 // are `pub`; the query fns stay crate-internal.
 pub use edges::{EdgeRelation, EdgeTarget, NodeEdge};
-pub(crate) use edges::{add_edge, all_edges_from, edge_key, edges_from, edges_into, remove_edge};
+pub(crate) use edges::{add_edge, edge_key, edges_from, edges_into, remove_edge};
 pub(crate) use hydrate::*;
 pub(crate) use moniker::*;
 pub(crate) use resolve::*;


### PR DESCRIPTION
## Problem

The memory op-log's genesis backfill was a per-**chain** gate: once a repo's owner chain had any entry, `backfill_memory_oplog` returned early forever. Combined with the fold rule that a `NodeUpdate`/`NodeStatus` without a `NodeCreate` is inert, any `repo_memories`/`repo_node_edges` row that entered the tables *after* the chain was rooted, without going through the wired authoring path, became a permanent **ghost**: present in the table, absent from the signed projection, and a later `update`/`mark_obsolete`/edge op on it silently authored an inert signed op.

Entry paths that produce ghosts:
- **Consolidation** — `import_from_source` copies the memory tables (with remapped node ids) but not the op-log, into a target whose chain is already non-empty, so imported memories were never authored into the target's signed history.
- **Mixed-version rollout / raw writers** — a pre-authoring-wiring binary sharing the global DB, or any out-of-band writer (e.g. the `dream` passes write `repo_memories` directly), roots ghosts the per-chain gate never revisited.

## Fix

Convert `backfill_memory_oplog` from a per-chain gate into a per-**node/edge reconcile** against the materialized shadow projection (`oplog_projected_nodes` / `oplog_projected_edges`): author a `NodeCreate` (with current status) / `EdgeAdd` for every table row missing from the projection. Because all four live mutation sites (`create_memory`, `update_memory`/`mark_obsolete`, `add_edge`, `remove_edge`) already call the backfill before authoring, this makes the authoring seam **self-healing** with one primitive — a ghost is healed on the next mutation of anything in the repo, so no lifecycle op is ever inert. Consolidation calls the same reconcile explicitly (scope-parameterized) after import, so an imported store's signed history is complete under the target's own device identity.

Steady state is preserved: two indexed anti-join probes in autocommit and an early return with no write lock when nothing is missing; a durable `IMMEDIATE` transaction is opened only when there is actually a ghost to heal.

## Commits

1. `refactor(oplog)` — extract a gate-free `author_batch_in_tx` (batch author + single projection re-fold) for the reconcile to reuse; `author_genesis_in_tx` delegates to it after its empty-chain gate.
2. `feat(oplog)` — the two anti-join readers that find rows missing from the projection; the edge reader runs `reresolve_on_read` so a node target's `target_repo_id` is repaired to current **before** it is signed (a signed op cannot be corrected later).
3. `feat(oplog)` — the per-node/edge reconcile core + the scope-explicit entry point, plus a dead-code sweep of the superseded genesis helpers.
4. `test(oplog)` — end-to-end tests that the live `mark_obsolete` / `remove_edge` paths self-heal a ghost row rather than authoring an inert op.
5. `fix(consolidate)` — call the reconcile after `import_from_source`, before the rename, so imported (remapped) rows are authored into the target owner stream.

## Correctness notes

- **Status register:** the incremental (non-genesis) branch always authors an explicit `NodeStatus` — including `active` — because the fold's status register is independent of node existence; a `NodeCreate` alone would let a stale inert `NodeStatus` surface once existence is established. The genesis branch keeps the `active`-is-default elision, so genesis output stays byte-identical.
- **Concurrency:** the autocommit probe is only a fast-path gate; the missing set and the genesis flag are both re-read under the write lock, so racing callers converge (the loser authors only what the winner left missing).
- **Edge re-resolution** happens once, at sign time — this is a completeness mirror (every row is present), not a continuously-current-anchor mirror.

## Out of scope (deliberate)

- Ongoing edge-spec drift on an already-authored edge, and the consolidation retry-window between a committed import and a failed rename — both are content/tombstone divergence, not the missing-op bug this fixes; the live edge table already re-resolves on read, and the log is a shadow (nothing reads the projection yet).
- An idle-repo backstop (reconcile at `rag-rat reconcile` so a ghost in a repo with no subsequent mutation self-heals without waiting for a write) was scoped out; ghosts still heal on the next mutation and on consolidation, and a full reconcile lands at the phase-C/D schema bump.

## Tests

Full `rag-rat-core` suite green (1856/1856). New coverage: the reconcile heals a ghost memory and a ghost edge; a stale status register left by an inert op is overridden; an unreadable status token fails loudly rather than minting `active`; the live `mark_obsolete`/`remove_edge` paths self-heal (with entry-count assertions that distinguish a real heal from a vacuous pass); consolidation authors imported memories into the target owner stream (with a premise self-check that the target chain is genuinely non-empty). Ported the op-construction unit tests, preserving the no-`Rebind` and unknown-status-failure pins.

Fixes #541.
