### PR TITLE
test(reconcile): cover the fast-path freshness invariants left open by #530

### DIFF
--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/embedding_policy_fast_path.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/embedding_policy_fast_path.rs
@@ -169,3 +169,94 @@ fn reconcile_plan_classifies_at_the_requested_cap() {
     );
     let _ = fs::remove_dir_all(root);
 }
+
+#[test]
+fn incremental_edit_keeps_the_certified_column_fresh() {
+    // The fast path reads the PERSISTED `chunks.embedding_policy` column, so it stays correct after
+    // EDITS only if incremental indexing keeps that column fresh — it routes through the same
+    // single chunk-writer and never restamps. Flip a chunk's class via an edit + heal and read
+    // the column DIRECTLY: this proves the incremental writer updated it in place, regardless
+    // of which summary path would run (a summary assertion alone can't distinguish the column
+    // from a recompute — the recompute would see the edited import-only file as low-signal
+    // too).
+    let root = unique_temp_root();
+    // A >= MIN_EMBEDDING_CHARS real fn, so it classifies Embed (a shorter one would be
+    // SkipTooSmall).
+    rust_fixture(&root);
+    let db = IndexDatabase::rebuild(&source_config(root.clone(), Language::Rust)).unwrap();
+    let conn = db.storage.connection();
+
+    // Count a policy in the PERSISTED column, read via the SAME FROM/JOIN the fast path
+    // (`policy_skip_summary_from_column`) uses — `chunks` scoped by the `files` view AND joined to
+    // `chunk_text` — so it counts exactly the row set the fast path would, not a superset. (Without
+    // the `chunk_text` join, a heal that wrote the policy but dropped the chunk_text row would
+    // count here yet be excluded by the real summary.) No recompute, no summary.
+    let policy_in_column = |value: &str| -> i64 {
+        conn.query_row(
+            "SELECT COUNT(*) FROM chunks
+             JOIN files ON files.id = chunks.file_id
+             JOIN chunk_text ON chunk_text.chunk_id = chunks.id
+             WHERE chunks.embedding_policy = ?1",
+            [value],
+            |r| r.get(0),
+        )
+        .unwrap()
+    };
+
+    // Fresh rebuild: the fn chunk is stamped Embed in the column; the fast path is live.
+    assert_eq!(policy_version(&db).as_deref(), Some(ai::EMBEDDING_POLICY_VERSION));
+    assert!(policy_in_column("Embed") >= 1, "the fn chunk is Embed in the column");
+    assert_eq!(policy_in_column("SkipLowSignal"), 0, "no low-signal chunk yet");
+
+    // Edit the file to pure imports (low-signal) and heal it (the incremental single-writer path).
+    fs::write(
+        root.join("src/code.rs"),
+        "use std::collections::HashMap;\nuse std::fmt::Debug;\nuse std::io::Read;\nuse \
+         std::sync::Arc;\n",
+    )
+    .unwrap();
+    db.heal_file(std::path::Path::new("src/code.rs")).unwrap();
+
+    // The incremental writer updated the PERSISTED column IN PLACE — the old Embed value is gone
+    // and the flipped SkipLowSignal value is written — while leaving the version stamp valid.
+    // So the fast path serves the fresh column with no full rebuild.
+    assert_eq!(policy_in_column("Embed"), 0, "the old Embed value is gone from the column");
+    assert!(
+        policy_in_column("SkipLowSignal") >= 1,
+        "the heal wrote the flipped policy into the certified column"
+    );
+    assert_eq!(
+        policy_version(&db).as_deref(),
+        Some(ai::EMBEDDING_POLICY_VERSION),
+        "incremental indexing must not invalidate the stamp"
+    );
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn absent_stamp_takes_the_recompute_path() {
+    // A never-stamped index (a pre-#530 DB, or one never fully rebuilt with this binary) has NO
+    // version key — the fast path must fall back to recompute exactly like a stale stamp. Poison
+    // the column and DELETE the stamp: the summary must IGNORE the poison and recompute from
+    // source.
+    let root = unique_temp_root();
+    rust_fixture(&root);
+    let db = IndexDatabase::rebuild(&source_config(root.clone(), Language::Rust)).unwrap();
+    let conn = db.storage.connection();
+    let repo_id = crate::index::schema::active_repo_id(conn).unwrap();
+    conn.execute(
+        "UPDATE main.chunks SET embedding_policy = 'SkipGenerated'
+         WHERE id = (SELECT MIN(id) FROM main.chunks WHERE embedding_policy = 'Embed')",
+        [],
+    )
+    .unwrap();
+    crate::index::meta::delete_repo_meta(conn, &repo_id, ai::EMBEDDING_POLICY_VERSION_KEY).unwrap();
+
+    let summary = ai::embedding_policy_skip_summary(conn, ai::DEFAULT_MAX_EMBEDDING_CHARS).unwrap();
+    assert_eq!(
+        summary.get("SkipGenerated").copied().unwrap_or(0),
+        0,
+        "an absent stamp forces a recompute that ignores the poisoned column: {summary:?}"
+    );
+    let _ = fs::remove_dir_all(root);
+}

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/multi_repo_scope.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/multi_repo_scope.rs
@@ -2028,3 +2028,45 @@ fn current_callee_monikers_ignores_a_sibling_repos_rows() {
          the sibling's row — and the sibling's newer run must not supersede the active repo's"
     );
 }
+
+#[test]
+fn rebuild_certifies_the_policy_version_only_for_the_active_repo() {
+    // The #530 fast-path stamp lives in PER-REPO `repo_meta` (keyed by repo_id), so a rebuild
+    // certifies ONLY the active repo. Exercise the isolation with repo B present in the shared DB
+    // DURING a rebuild of repo A: give B a SENTINEL stamp first, then rebuild A. A repo-scoped
+    // stamp leaves B's sentinel untouched; a repo-blind / global stamp would overwrite it to
+    // current — so this catches the regression the "seed B after the rebuild" shape could not.
+    let fx = two_repo_fixture();
+    let conn = fx.db.storage.connection();
+    crate::index::meta::set_repo_meta(
+        conn,
+        REPO_B,
+        ai::EMBEDDING_POLICY_VERSION_KEY,
+        "repo-b-sentinel",
+    )
+    .unwrap();
+    let db_path: String = conn
+        .query_row("SELECT file FROM pragma_database_list WHERE name = 'main'", [], |r| r.get(0))
+        .unwrap();
+
+    // Rebuild repo A AGAIN, now with repo B co-resident in the shared DB.
+    let mut config_a = source_config(fx.root_a.clone(), Language::Rust);
+    config_a.database = PathBuf::from(db_path);
+    let db = IndexDatabase::rebuild(&config_a).unwrap();
+    let conn = db.storage.connection();
+
+    assert_eq!(
+        crate::index::meta::repo_meta(conn, &fx.repo_a_id, ai::EMBEDDING_POLICY_VERSION_KEY)
+            .unwrap()
+            .as_deref(),
+        Some(ai::EMBEDDING_POLICY_VERSION),
+        "repo A's rebuild certified repo A"
+    );
+    assert_eq!(
+        crate::index::meta::repo_meta(conn, REPO_B, ai::EMBEDDING_POLICY_VERSION_KEY)
+            .unwrap()
+            .as_deref(),
+        Some("repo-b-sentinel"),
+        "the rebuild of repo A must leave co-resident repo B's stamp untouched"
+    );
+}


### PR DESCRIPTION
#530 shipped the version-stamped fast-path skip-summary with a suite covering the certification gates. This adds the three load-bearing freshness invariants that suite left untested:

- **Incremental freshness** — incremental indexing routes through the same single chunk-writer, so it updates `chunks.embedding_policy` in place while the version stamp stays valid. An edit + heal that flips a chunk's class (`Embed` → `SkipLowSignal`) is reflected by the fast path — guarding against a valid stamp serving stale counts after edits.
- **Absent stamp** — a never-stamped index (pre-#530, or never fully rebuilt with this binary) falls back to the recompute, exactly like a stale stamp.
- **Per-repo isolation** — the stamp lives in per-repo `repo_meta`, so one repo's rebuild never certifies a co-resident repo's column in a shared database (reuses the two-repo fixture).

Test-only; no behavior change. Follow-up to #530 (#575).