### PR TITLE
feat(oracle): check_library_usage — external-dependency contracts + deprecation from SCIP external_symbols (#114)

### DIFF
--- a/crates/rag-rat-core/src/index/oracle/library_usage.rs
+++ b/crates/rag-rat-core/src/index/oracle/library_usage.rs
@@ -1,0 +1,520 @@
+//! `check_library_usage` (#114): join `resolved-external` call sites to the `external_symbols`
+//! dependency contracts the oracle parsed out of `index.external_symbols`, surface each
+//! dependency's CURRENT signature + docs as inline context, and assert deprecated-but-compiling
+//! usage.
+//!
+//! POSTURE (load-bearing, honest scope). The ONLY asserted verdict is `deprecated` — a
+//! deterministic docs marker. `signature_text` / `documentation` are surfaced as CONTEXT for the
+//! agent to reason about (arity, order, misuse); NO arity or removed/renamed verdict is asserted
+//! here, because call-site arg-counts are not instrumented and a "removed" verdict needs a
+//! cross-version baseline (the re-index-on-lockfile-change diff — a documented #114 follow-up).
+//! Surfacing-not-asserting for non-deterministic drift is the deliberate design, mirroring the
+//! issue's guidance.
+
+use rusqlite::Connection;
+use serde::Serialize;
+
+use super::{OracleTool, latest_runs_in_scope, package_of, store};
+
+/// The note surfaced on an `ok` report so a consuming agent knows what is asserted vs. contextual.
+const POSTURE_NOTE: &str = "Asserted verdict: `deprecated` (a deterministic 'deprecated' marker \
+                            in the dependency's docs/signature). Context only — reason yourself, \
+                            no verdict is asserted: `signature_text` / `documentation` are the \
+                            dependency's CURRENT contract at each call site, for judging arity / \
+                            misuse. Removed-or-renamed and arity drift are NOT asserted here.";
+
+/// Note for the `no_oracle_run` status.
+const NO_ORACLE_RUN_NOTE: &str = "No oracle run for this checkout. Run `rag-rat oracle run` (e.g. \
+                                  `--tool scip-python`), then retry.";
+
+/// Note for the `no_external_symbols` status. Deliberately does NOT assert the indexer emits none —
+/// an oracle run from BEFORE this feature (pre-V057) also leaves the table empty, so a rerun is the
+/// first thing to try (the report's counts still show how many external calls are uncovered).
+const NO_EXTERNAL_SYMBOLS_NOTE: &str =
+    "No external-symbol contracts for this checkout. If you upgraded rag-rat since the last \
+     oracle run, run `rag-rat oracle run` to (re)populate — older runs predate this data. If a \
+     fresh run is still empty, the indexer emits no external symbol info (scip-python does; \
+     rust-analyzer / scip-typescript do not).";
+
+/// The status-appropriate note.
+fn note_for(status: &LibraryUsageStatus) -> &'static str {
+    match status {
+        LibraryUsageStatus::Ok => POSTURE_NOTE,
+        LibraryUsageStatus::NoOracleRun => NO_ORACLE_RUN_NOTE,
+        LibraryUsageStatus::NoExternalSymbols => NO_EXTERNAL_SYMBOLS_NOTE,
+    }
+}
+
+/// The default `limit` when a caller does not set one — mirrors the MCP `default_graph_limit`.
+pub const DEFAULT_LIMIT: usize = 50;
+
+/// Max call sites surfaced per moniker entry. `call_count` still reports the TRUE total; this only
+/// caps the enumerated `call_sites` so a hot symbol (thousands of calls) can't balloon the
+/// response.
+const MAX_CALL_SITES_PER_ENTRY: usize = 25;
+
+/// Filters for a [`check_library_usage`] read.
+#[derive(Debug)]
+pub struct LibraryUsageOptions {
+    /// Restrict to external call sites in this exact file or under this directory prefix.
+    pub path: Option<String>,
+    /// Restrict to external calls whose dependency package (the moniker's package component)
+    /// equals this, e.g. `ky` / `tokio`.
+    pub package: Option<String>,
+    /// Only surface contracts flagged `deprecated`.
+    pub deprecated_only: bool,
+    /// Max moniker entries returned — a hard cap honored exactly (`0` returns no entries, only the
+    /// summary counts, which always cover the full pre-limit set). Pass a large value for "all".
+    pub limit: usize,
+}
+
+impl Default for LibraryUsageOptions {
+    fn default() -> Self {
+        Self { path: None, package: None, deprecated_only: false, limit: DEFAULT_LIMIT }
+    }
+}
+
+/// Why a report carries no `entries` (or how to read an empty one).
+#[derive(Debug, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum LibraryUsageStatus {
+    /// External call sites were joined to dependency contracts (entries may still be empty if a
+    /// filter excluded them).
+    Ok,
+    /// No oracle run exists for this checkout — run `rag-rat oracle run` first.
+    NoOracleRun,
+    /// The oracle ran but emitted no external `SymbolInformation` (the indexer did not populate
+    /// `index.external_symbols`), so there are no dependency contracts to surface.
+    NoExternalSymbols,
+}
+
+/// One call site of an external dependency symbol.
+#[derive(Debug, Serialize)]
+pub struct LibraryUsageCallSite {
+    pub path: String,
+    pub start_line: i64,
+    pub end_line: i64,
+}
+
+/// One external dependency symbol the corpus calls, with its contract and every call site.
+#[derive(Debug, Serialize)]
+pub struct LibraryUsageEntry {
+    /// The raw SCIP moniker (carries the dependency's version component).
+    pub moniker: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub package: Option<String>,
+    pub kind: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub display_name: String,
+    /// CONTEXT (not a verdict): the dependency's current printed signature.
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub signature_text: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub signature_language: String,
+    /// CONTEXT (not a verdict): the dependency's current documentation.
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub documentation: String,
+    /// ASSERTED verdict: this contract is marked deprecated.
+    pub deprecated: bool,
+    pub call_count: usize,
+    pub call_sites: Vec<LibraryUsageCallSite>,
+}
+
+/// The `check_library_usage` result.
+#[derive(Debug, Serialize)]
+pub struct LibraryUsageReport {
+    pub status: LibraryUsageStatus,
+    pub note: &'static str,
+    pub total_external_call_sites: usize,
+    pub distinct_monikers: usize,
+    pub deprecated_call_sites: usize,
+    /// External call sites whose moniker has NO contract in `external_symbols` (the indexer
+    /// emitted no info for it) — coverage transparency, NOT a finding.
+    pub call_sites_without_signature_info: usize,
+    pub entries: Vec<LibraryUsageEntry>,
+}
+
+impl LibraryUsageReport {
+    fn empty(status: LibraryUsageStatus) -> Self {
+        Self {
+            note: note_for(&status),
+            status,
+            total_external_call_sites: 0,
+            distinct_monikers: 0,
+            deprecated_call_sites: 0,
+            call_sites_without_signature_info: 0,
+            entries: Vec::new(),
+        }
+    }
+}
+
+/// A dependency contract loaded ONCE per moniker from `external_symbols`. The doc/signature text is
+/// fetched a single time here (keyed by moniker), never repeated per call site.
+struct Contract {
+    kind: String,
+    display_name: String,
+    signature_text: String,
+    signature_language: String,
+    documentation: String,
+    deprecated: bool,
+}
+
+/// One external call site — moniker + location only, NO contract text (that is looked up from the
+/// contract map by moniker, so a hot symbol's large docs are not materialized per call).
+struct CallSiteRow {
+    moniker: String,
+    source_path: String,
+    start_line: i64,
+    end_line: i64,
+}
+
+/// Per-moniker accumulator built while scanning call sites — counts + sites only, so the expensive
+/// contract payload is cloned once per SURVIVING entry (after ranking + truncation), not per call.
+struct MonikerAgg {
+    call_count: usize,
+    call_sites: Vec<LibraryUsageCallSite>,
+    deprecated: bool,
+}
+
+/// Run `f` inside a deferred READ transaction (one WAL snapshot) when the connection is idle, so a
+/// multi-statement read sees a CONSISTENT view — a concurrent writer committing between statements
+/// can't change what a later statement sees. A no-op when a transaction is already open (the
+/// caller's snapshot governs). Read-only, so the snapshot is only ever released. Mirrors
+/// `query_api::clones::of_text::with_clone_read_snapshot`.
+fn with_read_snapshot<T>(
+    conn: &Connection,
+    f: impl FnOnce() -> anyhow::Result<T>,
+) -> anyhow::Result<T> {
+    if !conn.is_autocommit() {
+        return f();
+    }
+    conn.execute_batch("BEGIN DEFERRED")?;
+    let result = f();
+    let _ = conn.execute_batch(if result.is_ok() { "COMMIT" } else { "ROLLBACK" });
+    result
+}
+
+/// `check_library_usage` (#114). Runs the whole read inside ONE WAL snapshot
+/// ([`with_read_snapshot`]) so the multi-statement read — flag index → call-site scan → survivor
+/// contract bodies — is consistent: a concurrent `oracle run` committing mid-read cannot make a
+/// ranked moniker's contract vanish between statements. See [`check_library_usage_inner`] for the
+/// read itself.
+pub fn check_library_usage(
+    conn: &Connection,
+    commit_sha: &str,
+    worktree_id: &str,
+    opts: &LibraryUsageOptions,
+) -> anyhow::Result<LibraryUsageReport> {
+    with_read_snapshot(conn, || check_library_usage_inner(conn, commit_sha, worktree_id, opts))
+}
+
+/// Join external call sites to `external_symbols` contracts for the active checkout, across every
+/// oracle tool that has a run. Groups per moniker, asserts deprecation, surfaces the current
+/// signature/docs as context.
+///
+/// COST SHAPE (load-bearing): the flag index (moniker → deprecated) is loaded first, call sites are
+/// scanned WITHOUT contract text, monikers are ranked on the cheap `(deprecated, call_count)`
+/// fields, and only the surviving top-`limit` monikers materialize their doc/signature. So a symbol
+/// called thousands of times with a large docstring never repeats that docstring per call, and the
+/// `limit` bounds the doc/signature payload (not the whole dependency surface).
+fn check_library_usage_inner(
+    conn: &Connection,
+    commit_sha: &str,
+    worktree_id: &str,
+    opts: &LibraryUsageOptions,
+) -> anyhow::Result<LibraryUsageReport> {
+    let runs = latest_runs_in_scope(conn, commit_sha, worktree_id)?;
+    if runs.is_empty() {
+        return Ok(LibraryUsageReport::empty(LibraryUsageStatus::NoOracleRun));
+    }
+
+    let package_filter = opts.package.as_deref().map(str::trim).filter(|pkg| !pkg.is_empty());
+
+    // LIGHTWEIGHT rank/coverage index: `moniker -> deprecated` flag, NO doc/signature text.
+    // Presence means a contract exists; the value is the asserted verdict. Loading only the
+    // flag keeps the scan + ranking cheap — the heavy doc/signature bodies are fetched below
+    // for SURVIVING entries only, so the payload is bounded by `limit`, not by the dependency
+    // surface. Monikers are tool-unique (the SCIP scheme names the tool), so merging tools is
+    // collision-free. An EMPTY index means the indexer emitted no `index.external_symbols` (the
+    // `no_external_symbols` diagnostic) — but we still scan the call sites so the coverage
+    // counts reflect the real gap.
+    let mut flags: std::collections::HashMap<String, bool> = std::collections::HashMap::new();
+    for (tool, _) in &runs {
+        for (moniker, deprecated) in load_contract_flags(conn, *tool, commit_sha, worktree_id)? {
+            flags.insert(moniker, deprecated);
+        }
+    }
+    let no_contracts = flags.is_empty();
+
+    // Group external call sites by moniker — counts + (deterministically capped) locations only.
+    let mut agg: std::collections::HashMap<String, MonikerAgg> = std::collections::HashMap::new();
+    let mut total = 0usize;
+    let mut without_info = 0usize;
+    let mut deprecated_sites = 0usize;
+    for (tool, tool_version) in &runs {
+        for site in external_call_sites(conn, *tool, tool_version, commit_sha, worktree_id, opts)? {
+            // The package filter is applied here (not in SQL) because the package component is
+            // extracted by `scip::symbol::parse_symbol`, not a stored column.
+            if let Some(pkg) = package_filter
+                && package_of(&site.moniker).as_deref() != Some(pkg)
+            {
+                continue;
+            }
+            let deprecated = flags.get(&site.moniker).copied();
+            // `deprecated_only` keeps only call sites whose contract is deprecated (a call site
+            // with no contract can never be deprecated, so it drops too).
+            if opts.deprecated_only && deprecated != Some(true) {
+                continue;
+            }
+            total += 1;
+            let Some(deprecated) = deprecated else {
+                without_info += 1;
+                continue;
+            };
+            if deprecated {
+                deprecated_sites += 1;
+            }
+            let entry = agg.entry(site.moniker).or_insert_with(|| MonikerAgg {
+                call_count: 0,
+                call_sites: Vec::new(),
+                deprecated,
+            });
+            // `call_count` is the TRUE total; the surfaced `call_sites` are capped at
+            // [`MAX_CALL_SITES_PER_ENTRY`] so a symbol called thousands of times can't balloon the
+            // response. `external_call_sites` orders deterministically, so the kept subset is
+            // stable across reindex / query-plan changes (not an arbitrary SQL row
+            // order).
+            if entry.call_sites.len() < MAX_CALL_SITES_PER_ENTRY {
+                entry.call_sites.push(LibraryUsageCallSite {
+                    path: site.source_path,
+                    start_line: site.start_line,
+                    end_line: site.end_line,
+                });
+            }
+            entry.call_count += 1;
+        }
+    }
+
+    let distinct_monikers = agg.len();
+    // Rank on the cheap fields (deprecated first — the actionable ones — then most-called, then
+    // moniker for stability) and truncate to `limit` BEFORE any doc/signature is loaded (`0` yields
+    // no entries; the summary counts above still cover the full pre-limit set).
+    let mut ranked: Vec<(String, MonikerAgg)> = agg.into_iter().collect();
+    ranked.sort_by(|(a_mon, a), (b_mon, b)| {
+        b.deprecated.cmp(&a.deprecated).then(b.call_count.cmp(&a.call_count)).then(a_mon.cmp(b_mon))
+    });
+    ranked.truncate(opts.limit);
+
+    // NOW fetch the heavy contract bodies — for the SURVIVING monikers only — so the doc/signature
+    // payload materialized is bounded by `limit`, not by the whole dependency surface.
+    let survivors: Vec<&str> = ranked.iter().map(|(moniker, _)| moniker.as_str()).collect();
+    let mut contracts: std::collections::HashMap<String, Contract> =
+        std::collections::HashMap::new();
+    if !survivors.is_empty() {
+        for (tool, _) in &runs {
+            for (moniker, contract) in
+                load_contracts_for(conn, *tool, commit_sha, worktree_id, &survivors)?
+            {
+                contracts.insert(moniker, contract);
+            }
+        }
+    }
+
+    let entries = ranked
+        .into_iter()
+        .map(|(moniker, agg)| {
+            let contract = contracts.get(&moniker).expect("survivor monikers all carry a contract");
+            LibraryUsageEntry {
+                package: package_of(&moniker),
+                moniker,
+                kind: contract.kind.clone(),
+                display_name: contract.display_name.clone(),
+                signature_text: contract.signature_text.clone(),
+                signature_language: contract.signature_language.clone(),
+                documentation: contract.documentation.clone(),
+                deprecated: contract.deprecated,
+                call_count: agg.call_count,
+                call_sites: agg.call_sites,
+            }
+        })
+        .collect();
+
+    // `no_external_symbols` when the indexer emitted no contracts (the useful diagnostic), else
+    // `ok`. Either way the coverage counts above are populated from the real call-site scan — so a
+    // repo whose indexer omits `index.external_symbols` still sees HOW MANY external calls have no
+    // contract (`total_external_call_sites` / `call_sites_without_signature_info`), not a bare
+    // zero.
+    let status =
+        if no_contracts { LibraryUsageStatus::NoExternalSymbols } else { LibraryUsageStatus::Ok };
+
+    Ok(LibraryUsageReport {
+        note: note_for(&status),
+        status,
+        total_external_call_sites: total,
+        distinct_monikers,
+        deprecated_call_sites: deprecated_sites,
+        call_sites_without_signature_info: without_info,
+        entries,
+    })
+}
+
+/// The LIGHTWEIGHT rank/coverage index for `(tool, checkout, repo)` — `moniker` + the `deprecated`
+/// flag ONLY, no doc/signature bodies. Loaded before the scan so ranking + coverage counting never
+/// pulls the heavy contract text; the surviving entries' bodies come from [`load_contracts_for`].
+fn load_contract_flags(
+    conn: &Connection,
+    tool: OracleTool,
+    commit_sha: &str,
+    worktree_id: &str,
+) -> anyhow::Result<Vec<(String, bool)>> {
+    let repo_clause = store::oracle_repo_scope_clause(conn, "external_symbols")?;
+    let sql = format!(
+        "SELECT moniker, deprecated FROM external_symbols
+         WHERE tool = ?1 AND commit_sha = ?2 AND worktree_id = ?3{repo_clause}"
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt
+        .query_map(rusqlite::params![tool.as_db_str(), commit_sha, worktree_id], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, bool>(1)?))
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    Ok(rows)
+}
+
+/// The FULL `external_symbols` contracts (kind / display_name / signature / docs) for a BOUNDED set
+/// of `monikers` in `(tool, checkout, repo)` — used to materialize ONLY the surviving entries after
+/// ranking, so the heavy payload is bounded by `limit`. A tool's table holds only its own monikers,
+/// so passing the full survivor set to each tool is safe (non-matching monikers just don't join).
+fn load_contracts_for(
+    conn: &Connection,
+    tool: OracleTool,
+    commit_sha: &str,
+    worktree_id: &str,
+    monikers: &[&str],
+) -> anyhow::Result<Vec<(String, Contract)>> {
+    if monikers.is_empty() {
+        return Ok(Vec::new());
+    }
+    let repo_clause = store::oracle_repo_scope_clause(conn, "external_symbols")?;
+    // Chunk the moniker IN-list so a huge `limit` (many surviving monikers) can't exceed SQLite's
+    // host-parameter cap (default 999): 3 fixed params (?1..?3) + one placeholder per moniker.
+    const CHUNK: usize = 500;
+    let mut out = Vec::with_capacity(monikers.len());
+    for chunk in monikers.chunks(CHUNK) {
+        // The moniker IN-list placeholders start at ?4 (?1..?3 are tool / commit_sha /
+        // worktree_id).
+        let placeholders =
+            (0..chunk.len()).map(|i| format!("?{}", i + 4)).collect::<Vec<_>>().join(", ");
+        let sql = format!(
+            "SELECT moniker, kind, display_name, signature_text, signature_language, \
+             documentation, deprecated
+             FROM external_symbols
+             WHERE tool = ?1 AND commit_sha = ?2 AND worktree_id = ?3{repo_clause}
+               AND moniker IN ({placeholders})"
+        );
+        let mut binds: Vec<&str> = vec![tool.as_db_str(), commit_sha, worktree_id];
+        binds.extend_from_slice(chunk);
+        let mut stmt = conn.prepare(&sql)?;
+        let rows = stmt
+            .query_map(rusqlite::params_from_iter(binds), |row| {
+                Ok((row.get::<_, String>(0)?, Contract {
+                    kind: row.get(1)?,
+                    display_name: row.get(2)?,
+                    signature_text: row.get(3)?,
+                    signature_language: row.get(4)?,
+                    documentation: row.get(5)?,
+                    deprecated: row.get(6)?,
+                }))
+            })?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        out.extend(rows);
+    }
+    Ok(out)
+}
+
+/// The external call sites for ONE oracle tool's run — moniker + location, NO contract text. Reuses
+/// [`store::edge_oracle_scope_join`] verbatim (the canonical active-checkout + repo scope predicate
+/// is never re-spelled, #248).
+///
+/// EXTERNAL POPULATION (load-bearing): the filter is `edge_oracle.resolved_symbol_id IS NULL`, NOT
+/// `kind = 'resolved-external'`. That NULL captures the COMPLETE external set — both
+/// `resolved-external` AND the external-target `contradict` (where the heuristic mis-bound a
+/// dependency call to an in-corpus symbol; SCIP disagrees and resolves it external, keeping the
+/// external moniker with a NULL resolved id). Every in-corpus verdict resolves to a symbol, so NULL
+/// excludes them exactly.
+fn external_call_sites(
+    conn: &Connection,
+    tool: OracleTool,
+    tool_version: &str,
+    commit_sha: &str,
+    worktree_id: &str,
+    opts: &LibraryUsageOptions,
+) -> anyhow::Result<Vec<CallSiteRow>> {
+    let scope_join = store::edge_oracle_scope_join(conn)?;
+
+    // Path filter: exact file OR anything under `<path>/`. `instr(x, y) = 1` (y is a prefix of x)
+    // avoids LIKE metacharacter hazards on a caller-supplied path; the trailing `/` pins a
+    // directory boundary so `src/foo` never matches `src/foobar`. Trailing separators are
+    // trimmed first, so a caller passing `src/` builds the `src/` boundary (not a no-matching
+    // `src//`).
+    let path_filter = opts
+        .path
+        .as_deref()
+        .map(|path| path.trim().trim_end_matches('/'))
+        .filter(|path| !path.is_empty());
+    let path_clause = if path_filter.is_some() {
+        " AND (edge_oracle.source_path = ?5 OR instr(edge_oracle.source_path, ?5 || '/') = 1)"
+    } else {
+        ""
+    };
+
+    // Restrict to INVOCATION edges — the kinds where a dependency's callable is actually called:
+    // `calls_name` (function/method calls), `constructs` (constructor calls, e.g. `new Foo()`), and
+    // `dispatches` (dynamic dispatch). This is the same call-edge set find_callers/trace_callees
+    // use (`query::graph::CALL_EDGE_KINDS`). An external token ALSO produces `references_type`
+    // / `uses_macro` / `imports` edges (each with a NULL resolved id); without this filter a
+    // type-referenced dependency would be miscounted as a call — double-counting a token that both
+    // calls and type-references, and mislabeling a type ref as a call site.
+    // GROUP BY the physical CALLEE-token identity `(source_path, callee_start_byte,
+    // callee_end_byte)` — one row per source call site, NOT per verdict. This collapses BOTH:
+    //  * the content join's fan-out (a verdict CAN match >1 live edge), and
+    //  * a single call that emits MULTIPLE invocation edge kinds at the SAME callee span — e.g. a
+    //    Kotlin constructor `Foo()` produces both a `calls_name` and a `constructs` edge, stored as
+    //    separate `edge_oracle` rows because `edge_kind` is part of its key.
+    // Without this, one source call would count 2× and burn the per-entry site cap on the
+    // duplicate. A callee span uniquely identifies a token in a file, so the grouped
+    // `scip_symbol` / `edges.*` columns are identical across the collapsed rows.
+    let sql = format!(
+        "SELECT edge_oracle.scip_symbol, edge_oracle.source_path, edges.source_start_line, \
+         edges.source_end_line
+         {scope_join} AND edge_oracle.resolved_symbol_id IS NULL AND edge_oracle.edge_kind IN \
+         ('calls_name', 'constructs', 'dispatches'){path_clause}
+         GROUP BY edge_oracle.source_path, edge_oracle.callee_start_byte, \
+         edge_oracle.callee_end_byte
+         ORDER BY edge_oracle.source_path, edge_oracle.callee_start_byte"
+    );
+
+    // Bind slots ?1..?4 are fixed by `edge_oracle_scope_join`; ?5 is the optional path filter.
+    let mut binds: Vec<String> = vec![
+        tool.as_db_str().to_string(),
+        tool_version.to_string(),
+        commit_sha.to_string(),
+        worktree_id.to_string(),
+    ];
+    if let Some(path) = path_filter {
+        binds.push(path.to_string());
+    }
+
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt
+        .query_map(rusqlite::params_from_iter(binds.iter()), |row| {
+            Ok(CallSiteRow {
+                moniker: row.get(0)?,
+                source_path: row.get(1)?,
+                start_line: row.get(2)?,
+                end_line: row.get(3)?,
+            })
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    Ok(rows)
+}

--- a/crates/rag-rat-core/src/index/oracle/mod.rs
+++ b/crates/rag-rat-core/src/index/oracle/mod.rs
@@ -21,6 +21,7 @@
 mod auto_run;
 mod corpus;
 mod join;
+mod library_usage;
 mod lsp;
 mod manifest;
 mod report;
@@ -39,6 +40,10 @@ pub use corpus::{
     HealthViolation, check_corpus_health, corpora_for_tier, corpus_by_id, load_corpora,
 };
 pub(crate) use join::package_of;
+pub use library_usage::{
+    LibraryUsageCallSite, LibraryUsageEntry, LibraryUsageOptions, LibraryUsageReport,
+    LibraryUsageStatus, check_library_usage,
+};
 pub use manifest::{ToolAvailability, ToolManifest};
 pub use report::{
     CorpusHealth, CorpusProfile, OracleResolutionReport, REPORT_SCHEMA_VERSION, ResolutionBefore,
@@ -585,6 +590,18 @@ pub fn prune_oracle_runs_outside_scope(
     store::prune_oracle_runs_outside_scope(conn, live_commits, live_worktrees)
 }
 
+/// Prune `external_symbols` rows for dead `(commit_sha, worktree_id)` checkouts (#114) — the gc
+/// companion for the checkout-keyed dependency-contract table (nothing cascades it, keyed by
+/// `(commit, worktree)`, like `oracle_runs`). See [`store::prune_external_symbols_outside_scope`].
+/// Returns rows deleted.
+pub fn prune_external_symbols_outside_scope(
+    conn: &Connection,
+    live_commits: &[String],
+    live_worktrees: &[String],
+) -> anyhow::Result<u64> {
+    store::prune_external_symbols_outside_scope(conn, live_commits, live_worktrees)
+}
+
 /// Sweep `edge_oracle` verdicts whose content key matches no live edge ANYWHERE — the gc
 /// replacement for the `edges_data` FK cascade dropped in #248 (correctness no longer depends on
 /// it; it is anti-growth hygiene). GLOBAL, not checkout-scoped, so a sweep never deletes a sibling
@@ -806,6 +823,10 @@ pub struct OracleReport {
     /// (fields/variants map up to the enclosing symbol); only the deterministic best (shortest)
     /// moniker is written, so this counts rows, not defs.
     pub monikers_written: u64,
+    /// `external_symbols` rows written this pass — distinct external dependency monikers whose
+    /// `SymbolInformation` the `.scip` carried in `index.external_symbols` (#114). The dependency
+    /// contract `check_library_usage` reads.
+    pub external_symbols_written: u64,
     pub status: String,
 }
 

--- a/crates/rag-rat-core/src/index/oracle/report.rs
+++ b/crates/rag-rat-core/src/index/oracle/report.rs
@@ -346,6 +346,7 @@ mod tests {
             no_occurrence: 0,
             rows_written: 13,
             monikers_written: monikers,
+            external_symbols_written: 0,
             status: "Completed".to_string(),
         };
         OracleResolutionReport::assemble(

--- a/crates/rag-rat-core/src/index/oracle/run.rs
+++ b/crates/rag-rat-core/src/index/oracle/run.rs
@@ -102,6 +102,9 @@ pub(crate) fn run_in_tx(
     // Monikers are authoritative per tool the same way verdicts are per (tool, tool_version):
     // clear, then write the current `.scip`'s definitions, all in this transaction (#70).
     store::clear_logical_symbol_monikers_for_tool(conn, input.tool)?;
+    // External dependency contracts are authoritative per tool too (#114): clear, then write the
+    // current `.scip`'s `external_symbols` after the moniker pass, all in this transaction.
+    store::clear_external_symbols_for_tool(conn, input.tool, input.commit_sha, input.worktree_id)?;
 
     // Parse the `.scip`, reading each document's current checkout bytes for encoding conversion.
     // The bytes we read here are the SAME bytes whose hash we compare against each candidate's
@@ -407,6 +410,32 @@ pub(crate) fn run_in_tx(
             &moniker,
         )?;
         report.monikers_written += 1;
+    }
+
+    // External dependency contracts (#114): persist the `SymbolInformation` parsed from
+    // `index.external_symbols` — the kind/signature/docs/deprecation `check_library_usage` joins to
+    // `resolved-external` call sites. Unlike the moniker pass these describe OUT-of-corpus symbols
+    // with no local file, so no content-drift gate applies; write each verbatim (the authoritative
+    // clear ran up front). The moniker is stored RAW (never `stabilize_moniker_version`'d) so it
+    // exact-joins `edge_oracle.scip_symbol`, which is likewise the occurrence symbol unstabilized.
+    for (moniker, info) in &index.external_symbol_info {
+        store::write_external_symbol(
+            conn,
+            input.tool,
+            input.tool_version,
+            input.commit_sha,
+            input.worktree_id,
+            &store::ExternalSymbolRow {
+                moniker,
+                kind: &info.kind,
+                display_name: &info.display_name,
+                signature_text: &info.signature_text,
+                signature_language: &info.signature_language,
+                documentation: &info.documentation,
+                deprecated: info.deprecated,
+            },
+        )?;
+        report.external_symbols_written += 1;
     }
 
     // Recall gap: in-corpus *reference* occurrences whose symbol resolves inside the corpus but

--- a/crates/rag-rat-core/src/index/oracle/scip.rs
+++ b/crates/rag-rat-core/src/index/oracle/scip.rs
@@ -22,7 +22,7 @@
 use std::collections::HashMap;
 
 use ::protobuf::Message;
-use ::scip::types::{Index, PositionEncoding};
+use ::scip::types::{Index, PositionEncoding, SymbolInformation};
 
 /// A SCIP occurrence reduced to what the join needs: the **byte** range of the identifier token on
 /// its line and the SCIP symbol it refers to. Byte offsets are absolute within the file (not
@@ -49,13 +49,55 @@ pub(crate) struct ScipDefinition {
     pub(crate) end_byte: usize,
 }
 
-/// The parsed `.scip`, reduced to the join's two maps.
+/// The `SymbolInformation` for one EXTERNAL dependency symbol — the metadata `from_index`
+/// previously discarded (#114). `check_library_usage` surfaces `signature_text` + `documentation`
+/// as inline context at external call sites and asserts the `deprecated` verdict.
+#[derive(Debug, Clone)]
+pub(crate) struct ScipSymbolInformation {
+    /// The `SymbolInformation.Kind` variant name (display context, e.g. "Function"/"Method"), or
+    /// "unspecified" for the protobuf default.
+    pub(crate) kind: String,
+    pub(crate) display_name: String,
+    /// `signature_documentation.text` — a printed, language-specific signature string (NOT
+    /// structured params). May be empty when the indexer emits no signature.
+    pub(crate) signature_text: String,
+    /// `signature_documentation.language`, may be empty.
+    pub(crate) signature_language: String,
+    /// `documentation` strings joined with a blank line, may be empty.
+    pub(crate) documentation: String,
+    /// True when the docs/signature mark this symbol deprecated (the one deterministic verdict).
+    pub(crate) deprecated: bool,
+}
+
+impl ScipSymbolInformation {
+    fn from_scip(info: &SymbolInformation) -> Self {
+        let signature = info.signature_documentation.as_ref();
+        let signature_text = signature.map(|sig| sig.text.clone()).unwrap_or_default();
+        let signature_language = signature.map(|sig| sig.language.clone()).unwrap_or_default();
+        let documentation = info.documentation.join("\n\n");
+        let deprecated = documentation_marks_deprecated(&documentation, &signature_text);
+        Self {
+            kind: scip_kind_label(info.kind.enum_value_or_default()),
+            display_name: info.display_name.clone(),
+            signature_text,
+            signature_language,
+            documentation,
+            deprecated,
+        }
+    }
+}
+
+/// The parsed `.scip`, reduced to the join's maps.
 #[derive(Debug, Default)]
 pub(crate) struct ScipIndex {
     /// `relative_path -> occurrences` (definitions and references both), byte-keyed.
     pub(crate) occurrences_by_path: HashMap<String, Vec<ScipOccurrence>>,
     /// `scip_symbol -> definition site`. First definition wins (SCIP emits one per symbol).
     pub(crate) definitions: HashMap<String, ScipDefinition>,
+    /// `raw moniker -> external dependency symbol info`, from `index.external_symbols` (#114). The
+    /// key is the RAW SCIP symbol string, so it exact-matches `edge_oracle.scip_symbol`; first
+    /// entry wins (SCIP emits one `SymbolInformation` per symbol).
+    pub(crate) external_symbol_info: HashMap<String, ScipSymbolInformation>,
 }
 
 impl ScipIndex {
@@ -173,8 +215,51 @@ impl ScipIndex {
             }
             out.occurrences_by_path.insert(path, occurrences);
         }
+
+        // External dependency `SymbolInformation` — the kind/signature/docs the occurrence loop
+        // above ignores. `index.external_symbols` is SCIP's own out-of-corpus symbol set, i.e. the
+        // dependency contracts `check_library_usage` joins to `resolved-external` call sites
+        // (#114). `local N` symbols carry no cross-file meaning (mirrors the occurrence
+        // filter above) and are dropped. First entry wins (SCIP emits one
+        // `SymbolInformation` per symbol).
+        for info in &index.external_symbols {
+            if is_local_symbol(&info.symbol) {
+                continue;
+            }
+            out.external_symbol_info
+                .entry(info.symbol.clone())
+                .or_insert_with(|| ScipSymbolInformation::from_scip(info));
+        }
+
         Ok(out)
     }
+}
+
+/// A legible label for a SCIP `SymbolInformation.Kind`: the enum variant name (e.g. "Function" /
+/// "Method" / "StaticMethod"), with the protobuf default rendered as "unspecified". Stored as
+/// display CONTEXT on `external_symbols.kind` — not a parsed key — so the exact variant name (the
+/// full SCIP taxonomy, not a hand-maintained subset) is the useful, zero-maintenance form.
+fn scip_kind_label(kind: ::scip::types::symbol_information::Kind) -> String {
+    use ::scip::types::symbol_information::Kind;
+    match kind {
+        Kind::UnspecifiedKind => "unspecified".to_string(),
+        other => format!("{other:?}"),
+    }
+}
+
+/// Whether a symbol's docs/signature mark it deprecated — the one deterministic library-usage
+/// verdict. A case-insensitive scan for "deprecated", which is the near-universal marker across
+/// ecosystems: Rust `#[deprecated]` (rendered into rustdoc), TS/JS `@deprecated` (JSDoc), Python
+/// `.. deprecated::` / "Deprecated:" (Sphinx/docstrings). Deliberately a substring and NOT a claim
+/// about *why*: a false positive only surfaces one extra advisory the agent can dismiss — it never
+/// asserts a signature break — which is the honest posture for a heuristic marker.
+fn documentation_marks_deprecated(documentation: &str, signature_text: &str) -> bool {
+    let mut haystack = String::with_capacity(documentation.len() + signature_text.len() + 1);
+    haystack.push_str(documentation);
+    haystack.push('\n');
+    haystack.push_str(signature_text);
+    haystack.make_ascii_lowercase();
+    haystack.contains("deprecated")
 }
 
 /// `SymbolRole.Definition` is bit 1 (value `1`) of the `symbol_roles` bitset.

--- a/crates/rag-rat-core/src/index/oracle/store.rs
+++ b/crates/rag-rat-core/src/index/oracle/store.rs
@@ -495,6 +495,99 @@ pub(crate) fn write_logical_symbol_moniker(
     Ok(())
 }
 
+/// Delete the `external_symbols` contracts for a `(tool, checkout)` scope. Called at the start of a
+/// run so the pass is AUTHORITATIVE for its tool in this checkout: a moniker the prior `.scip`
+/// described but the current one no longer emits must not keep a stale contract (upsert alone only
+/// overwrites monikers the current run revisits). Run inside the same transaction that writes the
+/// current rows so the table is never observed mid-clear.
+///
+/// SCOPE (load-bearing): restricted to the ACTIVE `(commit_sha, worktree_id)` checkout AND repo
+/// (`external_symbols.repo_id`, its own column from birth, V056) — the SAME per-checkout, per-repo
+/// scope `oracle_runs` uses, and the reason external_symbols carries those columns. Without the
+/// checkout predicate a run in one linked worktree would erase a SIBLING checkout's contracts (they
+/// share `(repo_id, tool)` but resolve different dependency versions); without the repo predicate a
+/// sibling repo's contracts would go. The clear is per-tool (not per-tool_version) because the
+/// moniker's own version component already separates dependency versions within a checkout.
+pub(crate) fn clear_external_symbols_for_tool(
+    conn: &Connection,
+    tool: OracleTool,
+    commit_sha: &str,
+    worktree_id: &str,
+) -> anyhow::Result<()> {
+    let repo_clause = oracle_repo_scope_clause(conn, "external_symbols")?;
+    conn.execute(
+        &format!(
+            "DELETE FROM external_symbols WHERE tool = ?1 AND commit_sha = ?2 AND worktree_id = \
+             ?3{repo_clause}"
+        ),
+        params![tool.as_db_str(), commit_sha, worktree_id],
+    )?;
+    Ok(())
+}
+
+/// One external dependency contract to persist: the `SymbolInformation` parsed from
+/// `index.external_symbols`, keyed by its RAW moniker (== `edge_oracle.scip_symbol`).
+pub(crate) struct ExternalSymbolRow<'a> {
+    pub(crate) moniker: &'a str,
+    pub(crate) kind: &'a str,
+    pub(crate) display_name: &'a str,
+    pub(crate) signature_text: &'a str,
+    pub(crate) signature_language: &'a str,
+    pub(crate) documentation: &'a str,
+    pub(crate) deprecated: bool,
+}
+
+/// Upsert one `external_symbols` row. Keyed by `(repo_id, tool, commit_sha, worktree_id, moniker)`
+/// — re-running the same tool in the SAME checkout overwrites the prior contract, while a sibling
+/// checkout's rows are untouched. `external_symbols` is born post-A5 (V056), so `repo_id` is ALWAYS
+/// present and leads the PK; it is stamped unconditionally here (unlike the moniker / edge writers,
+/// which straddle the pre-/post-A5 table shapes).
+pub(crate) fn write_external_symbol(
+    conn: &Connection,
+    tool: OracleTool,
+    tool_version: &str,
+    commit_sha: &str,
+    worktree_id: &str,
+    row: &ExternalSymbolRow<'_>,
+) -> anyhow::Result<()> {
+    let repo_id = oracle_repo_scope(conn)?
+        .ok_or_else(|| anyhow::anyhow!("external_symbols requires post-A5 repo scoping"))?;
+    conn.execute(
+        "
+        INSERT INTO external_symbols(
+            repo_id, tool, tool_version, commit_sha, worktree_id, moniker, kind, display_name,
+            signature_text, signature_language, documentation, deprecated, computed_at_ms
+        )
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
+        ON CONFLICT(repo_id, tool, commit_sha, worktree_id, moniker) DO UPDATE SET
+            tool_version = excluded.tool_version,
+            kind = excluded.kind,
+            display_name = excluded.display_name,
+            signature_text = excluded.signature_text,
+            signature_language = excluded.signature_language,
+            documentation = excluded.documentation,
+            deprecated = excluded.deprecated,
+            computed_at_ms = excluded.computed_at_ms
+        ",
+        params![
+            repo_id,
+            tool.as_db_str(),
+            tool_version,
+            commit_sha,
+            worktree_id,
+            row.moniker,
+            row.kind,
+            row.display_name,
+            row.signature_text,
+            row.signature_language,
+            row.documentation,
+            row.deprecated,
+            now_ms(),
+        ],
+    )?;
+    Ok(())
+}
+
 /// Delete the `edge_oracle` verdicts for a `(tool, tool_version)` scope **within the active
 /// checkout**. Called at the start of a run so the pass is **authoritative** for its tool version:
 /// an edge the prior `.scip` covered but the current one no longer yields a verdict for must NOT
@@ -1270,6 +1363,35 @@ pub(crate) fn prune_oracle_runs_outside_scope(
     let deleted = conn.execute(
         &format!(
             "DELETE FROM oracle_runs
+             WHERE commit_sha NOT IN ({commit_list})
+               AND worktree_id NOT IN ({worktree_list}){repo_clause}"
+        ),
+        [],
+    )?;
+    Ok(u64::try_from(deleted).unwrap_or(0))
+}
+
+/// Prune `external_symbols` contracts for dead `(commit_sha, worktree_id)` checkouts (#114) — the
+/// gc companion for the checkout-keyed contract table. Like `oracle_runs`, nothing cascades it, so
+/// a retired branch / linked worktree would otherwise leave its dependency signature+doc payloads
+/// keyed by a dead checkout forever (unbounded growth). Uses the SAME live sets and the SAME
+/// per-repo, both-columns-dead predicate as [`prune_oracle_runs_outside_scope`], so a dropped
+/// checkout's runs and its contracts are pruned together and a sibling repo's rows are never
+/// touched.
+pub(crate) fn prune_external_symbols_outside_scope(
+    conn: &Connection,
+    live_commits: &[String],
+    live_worktrees: &[String],
+) -> anyhow::Result<u64> {
+    if live_commits.is_empty() && live_worktrees.is_empty() {
+        return Ok(0);
+    }
+    let commit_list = sql_quoted_list(live_commits);
+    let worktree_list = sql_quoted_list(live_worktrees);
+    let repo_clause = oracle_repo_scope_clause(conn, "external_symbols")?;
+    let deleted = conn.execute(
+        &format!(
+            "DELETE FROM external_symbols
              WHERE commit_sha NOT IN ({commit_list})
                AND worktree_id NOT IN ({worktree_list}){repo_clause}"
         ),

--- a/crates/rag-rat-core/src/index/oracle/tests/library_usage.rs
+++ b/crates/rag-rat-core/src/index/oracle/tests/library_usage.rs
@@ -1,0 +1,527 @@
+//! `check_library_usage` (#114): the end-to-end read — run the oracle over a `.scip` that carries a
+//! `resolved-external` call site AND its `external_symbols` contract, then assert the join surfaces
+//! the current signature/docs and the deprecation verdict.
+use super::*;
+use crate::index::oracle::{
+    LibraryUsageOptions, LibraryUsageStatus, OracleResolutionKind, check_library_usage,
+};
+
+/// Build a `.scip` for a single external call site in `caller.rs` plus the external contracts.
+fn scip_external_call(
+    call_moniker: &str,
+    externals: Vec<::scip::types::SymbolInformation>,
+) -> Vec<u8> {
+    use ::protobuf::{EnumOrUnknown, Message};
+    use ::scip::types::{Document, Index};
+    Index {
+        documents: vec![Document {
+            relative_path: "caller.rs".to_string(),
+            // The callee token `fetch` sits at bytes 14..19 of "fn caller() { fetch(); }".
+            occurrences: vec![occurrence(
+                0,
+                14,
+                19,
+                call_moniker,
+                SymbolRole::UnspecifiedSymbolRole as i32,
+            )],
+            position_encoding: EnumOrUnknown::new(
+                PositionEncoding::UTF8CodeUnitOffsetFromLineStart,
+            ),
+            ..Default::default()
+        }],
+        external_symbols: externals,
+        ..Default::default()
+    }
+    .write_to_bytes()
+    .unwrap()
+}
+
+fn external(
+    moniker: &str,
+    display_name: &str,
+    docs: Vec<String>,
+    sig: &str,
+) -> ::scip::types::SymbolInformation {
+    use ::protobuf::{EnumOrUnknown, MessageField};
+    use ::scip::types::symbol_information::Kind;
+    use ::scip::types::{Signature, SymbolInformation};
+    SymbolInformation {
+        symbol: moniker.to_string(),
+        display_name: display_name.to_string(),
+        kind: EnumOrUnknown::new(Kind::Function),
+        documentation: docs,
+        signature_documentation: MessageField::some(Signature {
+            language: "typescript".to_string(),
+            text: sig.to_string(),
+            ..Default::default()
+        }),
+        ..Default::default()
+    }
+}
+
+/// The core join: a `resolved-external` call site + its contract → one entry carrying the current
+/// signature (context) and the asserted deprecation verdict, with the call-site location.
+#[test]
+fn check_library_usage_surfaces_signature_and_asserts_deprecation() {
+    let h = Harness::new();
+    let caller = h.add_file("caller.rs", "fn caller() { fetch(); }\n");
+    // NameOnly + no in-corpus target, so the oracle bins the call `resolved-external`.
+    let edge = h.add_edge(caller, "fetch", 14, 19, "NameOnly", None);
+
+    let moniker = "scip-typescript npm ky 1.7.2 index.ts/get().";
+    let bytes = scip_external_call(moniker, vec![external(
+        moniker,
+        "get",
+        vec!["@deprecated use fetch2 instead.".to_string()],
+        "get(url: string): ResponsePromise",
+    )]);
+    let report =
+        run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None, None).unwrap();
+    assert_eq!(report.resolved_external, 1, "the call resolved external");
+    assert_eq!(report.external_symbols_written, 1, "the contract persisted");
+    let (kind, resolved, _) = h.verdict(edge).expect("verdict written");
+    assert_eq!(kind, OracleResolutionKind::ResolvedExternal.as_db_str());
+    assert_eq!(resolved, None);
+
+    let out =
+        check_library_usage(&h.conn, COMMIT, WORKTREE, &LibraryUsageOptions::default()).unwrap();
+    assert_eq!(out.status, LibraryUsageStatus::Ok);
+    assert_eq!(out.total_external_call_sites, 1);
+    assert_eq!(out.deprecated_call_sites, 1);
+    assert_eq!(out.call_sites_without_signature_info, 0);
+    assert_eq!(out.distinct_monikers, 1);
+    assert_eq!(out.entries.len(), 1);
+
+    let entry = &out.entries[0];
+    assert_eq!(entry.moniker, moniker);
+    assert_eq!(entry.package.as_deref(), Some("ky"));
+    assert_eq!(entry.kind, "Function");
+    assert!(entry.deprecated, "the @deprecated doc is the asserted verdict");
+    assert!(entry.signature_text.contains("ResponsePromise"), "signature surfaced as context");
+    assert_eq!(entry.call_count, 1);
+    assert_eq!(entry.call_sites[0].path, "caller.rs");
+    assert_eq!(entry.call_sites[0].start_line, 0);
+}
+
+/// `deprecated_only` keeps a deprecated contract; a non-matching `package` filter excludes it (and
+/// zeroes the counts, since the filter runs before tallying).
+#[test]
+fn check_library_usage_filters_by_deprecation_and_package() {
+    let h = Harness::new();
+    let caller = h.add_file("caller.rs", "fn caller() { fetch(); }\n");
+    h.add_edge(caller, "fetch", 14, 19, "NameOnly", None);
+
+    let moniker = "scip-typescript npm ky 1.7.2 index.ts/get().";
+    let bytes = scip_external_call(moniker, vec![external(
+        moniker,
+        "get",
+        vec!["@deprecated".to_string()],
+        "get(url: string): ResponsePromise",
+    )]);
+    run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None, None).unwrap();
+
+    let deprecated_only = check_library_usage(&h.conn, COMMIT, WORKTREE, &LibraryUsageOptions {
+        deprecated_only: true,
+        ..Default::default()
+    })
+    .unwrap();
+    assert_eq!(deprecated_only.entries.len(), 1, "deprecated contract kept");
+
+    let other_pkg = check_library_usage(&h.conn, COMMIT, WORKTREE, &LibraryUsageOptions {
+        package: Some("tokio".to_string()),
+        ..Default::default()
+    })
+    .unwrap();
+    assert_eq!(other_pkg.entries.len(), 0, "a non-matching package filter excludes the ky call");
+    assert_eq!(other_pkg.total_external_call_sites, 0);
+    assert_eq!(other_pkg.status, LibraryUsageStatus::Ok);
+}
+
+/// Multi-worktree isolation (the #114 review finding): an oracle run in a SIBLING checkout must NOT
+/// clobber this checkout's contracts. Checkout A writes its contract; checkout B (a different
+/// commit) runs the same tool with a DIFFERENT contract set; A's `check_library_usage` still
+/// returns A's contract and never B's.
+#[test]
+fn check_library_usage_is_isolated_across_checkouts() {
+    let h = Harness::new();
+    let caller = h.add_file("caller.rs", "fn caller() { fetch(); }\n");
+    h.add_edge(caller, "fetch", 14, 19, "NameOnly", None);
+
+    let moniker = "scip-typescript npm ky 1.7.2 index.ts/get().";
+    let bytes = scip_external_call(moniker, vec![external(moniker, "get", vec![], "get(): X")]);
+    run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None, None).unwrap();
+
+    // Checkout B (a DIFFERENT commit) runs the SAME tool with a DIFFERENT contract, and its
+    // authoritative per-checkout clear runs against B's scope only.
+    let other = "scip-typescript npm dep 2.0.0 index.ts/run().";
+    let bytes_b = scip_external_call(other, vec![external(other, "run", vec![], "run(): Y")]);
+    run_oracle(
+        &h.conn,
+        TOOL,
+        VERSION,
+        OTHER_COMMIT,
+        OTHER_WORKTREE,
+        &bytes_b,
+        h.root(),
+        None,
+        None,
+    )
+    .unwrap();
+
+    // A's contract survived B's run (per-checkout scope), and A never sees B's contract.
+    let a =
+        check_library_usage(&h.conn, COMMIT, WORKTREE, &LibraryUsageOptions::default()).unwrap();
+    assert_eq!(a.entries.len(), 1, "A keeps exactly its own contract");
+    assert_eq!(a.entries[0].moniker, moniker);
+    let total: i64 =
+        h.conn.query_row("SELECT COUNT(*) FROM external_symbols", [], |r| r.get(0)).unwrap();
+    assert_eq!(total, 2, "both checkouts' contracts coexist in the table");
+}
+
+/// A dependency call the heuristic MIS-binds to an in-corpus symbol becomes a `contradict` verdict
+/// (not `resolved-external`) but still carries the external moniker with a NULL resolved id — it
+/// must be counted (#114 review). The `resolved_symbol_id IS NULL` filter captures it.
+#[test]
+fn check_library_usage_includes_external_contradictions() {
+    let h = Harness::new();
+    // An in-corpus `fetch` the heuristic (wrongly) binds the call to.
+    let defs = h.add_file("defs.rs", "fn fetch() {}\n");
+    let sym = h.add_symbol_qualified(defs, "fetch", "defs.rs::fetch", "function", 0, 13);
+    h.add_chunk(defs, "defs.rs::fetch", "fn fetch() {}\n");
+    let caller = h.add_file("caller.rs", "fn caller() { fetch(); }\n");
+    // Exact + a concrete in-corpus target → SCIP resolves external → the oracle records
+    // `contradict`.
+    h.add_edge(caller, "fetch", 14, 19, "Exact", Some(sym));
+
+    let moniker = "scip-typescript npm ky 1.7.2 index.ts/get().";
+    let bytes = scip_external_call(moniker, vec![external(moniker, "get", vec![], "get(): X")]);
+    let report =
+        run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None, None).unwrap();
+    assert_eq!(report.contradicted, 1, "the mis-bound dependency call is a contradiction");
+    assert_eq!(report.resolved_external, 0, "not recorded as resolved-external");
+
+    let out =
+        check_library_usage(&h.conn, COMMIT, WORKTREE, &LibraryUsageOptions::default()).unwrap();
+    assert_eq!(out.total_external_call_sites, 1, "the external contradiction is counted");
+    assert_eq!(out.entries.len(), 1);
+    assert_eq!(out.entries[0].moniker, moniker);
+    assert!(out.entries[0].signature_text.contains('X'), "its contract is surfaced");
+}
+
+/// With no oracle run, the report is `NoOracleRun`; a run that emits NO external symbols is
+/// `NoExternalSymbols` — the two diagnostics that tell an agent WHY there is nothing to show.
+#[test]
+fn check_library_usage_reports_missing_oracle_and_missing_external_symbols() {
+    let h = Harness::new();
+    h.add_file("caller.rs", "fn caller() {}\n");
+
+    // No oracle run yet.
+    let no_run =
+        check_library_usage(&h.conn, COMMIT, WORKTREE, &LibraryUsageOptions::default()).unwrap();
+    assert_eq!(no_run.status, LibraryUsageStatus::NoOracleRun);
+
+    // A run whose `.scip` carries NO external_symbols.
+    let bytes = {
+        use ::protobuf::{EnumOrUnknown, Message};
+        use ::scip::types::{Document, Index};
+        Index {
+            documents: vec![Document {
+                relative_path: "caller.rs".to_string(),
+                position_encoding: EnumOrUnknown::new(
+                    PositionEncoding::UTF8CodeUnitOffsetFromLineStart,
+                ),
+                ..Default::default()
+            }],
+            ..Default::default()
+        }
+        .write_to_bytes()
+        .unwrap()
+    };
+    run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None, None).unwrap();
+    let no_ext =
+        check_library_usage(&h.conn, COMMIT, WORKTREE, &LibraryUsageOptions::default()).unwrap();
+    assert_eq!(no_ext.status, LibraryUsageStatus::NoExternalSymbols);
+}
+
+/// When external calls EXIST but the indexer emitted no `index.external_symbols`, the report is
+/// still `NoExternalSymbols` yet the coverage counts reflect the real gap (#114 review) — not a
+/// bare zero that hides how many external calls lack a contract.
+#[test]
+fn check_library_usage_no_contracts_still_reports_coverage_counts() {
+    let h = Harness::new();
+    let caller = h.add_file("caller.rs", "fn caller() { fetch(); }\n");
+    h.add_edge(caller, "fetch", 14, 19, "NameOnly", None);
+    let moniker = "scip-typescript npm ky 1.7.2 index.ts/get().";
+    // The external call occurrence is present, but the `.scip` carries NO external_symbols
+    // contract.
+    let bytes = scip_external_call(moniker, vec![]);
+    let report =
+        run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None, None).unwrap();
+    assert_eq!(report.resolved_external, 1);
+    assert_eq!(report.external_symbols_written, 0);
+
+    let out =
+        check_library_usage(&h.conn, COMMIT, WORKTREE, &LibraryUsageOptions::default()).unwrap();
+    assert_eq!(out.status, LibraryUsageStatus::NoExternalSymbols);
+    assert_eq!(out.total_external_call_sites, 1, "the external call is still counted");
+    assert_eq!(out.call_sites_without_signature_info, 1, "and reported as an uncovered gap");
+    assert_eq!(out.distinct_monikers, 0);
+    assert!(out.entries.is_empty());
+    assert!(
+        out.note.contains("oracle run"),
+        "the note nudges a rerun (pre-V057 runs lack the data)"
+    );
+}
+
+fn count_external_symbols(conn: &rusqlite::Connection) -> i64 {
+    conn.query_row("SELECT COUNT(*) FROM external_symbols", [], |r| r.get(0)).unwrap()
+}
+
+/// `limit` is a hard cap honored exactly: `limit: 0` returns NO entries, but the summary counts
+/// still cover the full pre-limit set (the #114-review contract fix — 0 is not "unlimited").
+#[test]
+fn check_library_usage_limit_is_a_hard_cap() {
+    let h = Harness::new();
+    let caller = h.add_file("caller.rs", "fn caller() { fetch(); }\n");
+    h.add_edge(caller, "fetch", 14, 19, "NameOnly", None);
+    let moniker = "scip-typescript npm ky 1.7.2 index.ts/get().";
+    let bytes = scip_external_call(moniker, vec![external(moniker, "get", vec![], "get(): X")]);
+    run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None, None).unwrap();
+
+    let zero = check_library_usage(&h.conn, COMMIT, WORKTREE, &LibraryUsageOptions {
+        limit: 0,
+        ..Default::default()
+    })
+    .unwrap();
+    assert_eq!(zero.entries.len(), 0, "limit 0 returns no entries");
+    assert_eq!(zero.total_external_call_sites, 1, "summary counts still cover the full set");
+    assert_eq!(zero.distinct_monikers, 1);
+}
+
+/// gc (#114): `prune_external_symbols_outside_scope` drops a dead checkout's contracts (both
+/// columns dead), keeps a live-worktree-overlay contract (the OR rule, matching `oracle_runs`), and
+/// is a no-op on empty live sets so a missing live set never wipes everything.
+#[test]
+fn prune_external_symbols_drops_dead_checkouts_only() {
+    let h = Harness::new();
+    let row = |moniker: &'static str| store::ExternalSymbolRow {
+        moniker,
+        kind: "Function",
+        display_name: "f",
+        signature_text: "f()",
+        signature_language: "rust",
+        documentation: "",
+        deprecated: false,
+    };
+    store::write_external_symbol(
+        &h.conn,
+        TOOL,
+        "v1",
+        "live-commit",
+        "live-wt",
+        &row("pkg a 1 m/l()."),
+    )
+    .unwrap();
+    store::write_external_symbol(
+        &h.conn,
+        TOOL,
+        "v1",
+        "dead-commit",
+        "dead-wt",
+        &row("pkg a 1 m/d()."),
+    )
+    .unwrap();
+    // Dead commit but LIVE worktree overlay → survives (OR rule).
+    store::write_external_symbol(
+        &h.conn,
+        TOOL,
+        "v1",
+        "dead-commit",
+        "live-wt",
+        &row("pkg a 1 m/o()."),
+    )
+    .unwrap();
+    assert_eq!(count_external_symbols(&h.conn), 3);
+
+    // Empty live sets are a no-op (never wipe everything).
+    assert_eq!(store::prune_external_symbols_outside_scope(&h.conn, &[], &[]).unwrap(), 0);
+    assert_eq!(count_external_symbols(&h.conn), 3);
+
+    let deleted =
+        store::prune_external_symbols_outside_scope(&h.conn, &["live-commit".to_string()], &[
+            "live-wt".to_string(),
+        ])
+        .unwrap();
+    assert_eq!(deleted, 1, "only the (dead-commit, dead-wt) contract is pruned");
+    assert_eq!(count_external_symbols(&h.conn), 2);
+}
+
+/// A non-call external edge (`references_type`) must NOT count as a call site (#114 review): its
+/// verdict also has a NULL resolved id, so the read filters on `edge_kind = 'calls_name'`.
+#[test]
+fn check_library_usage_ignores_non_call_external_edges() {
+    let h = Harness::new();
+    let caller = h.add_file("caller.rs", "fn caller() { fetch(); }\n");
+    // A TYPE reference (not a call) to an external symbol.
+    h.add_edge_with_kind(caller, "fetch", 14, 19, "references_type", "NameOnly", None);
+    let moniker = "scip-typescript npm ky 1.7.2 index.ts/get().";
+    let bytes = scip_external_call(moniker, vec![external(moniker, "get", vec![], "get(): X")]);
+    let report =
+        run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None, None).unwrap();
+    assert_eq!(report.resolved_external, 1, "the oracle still resolves the type ref external");
+
+    let out =
+        check_library_usage(&h.conn, COMMIT, WORKTREE, &LibraryUsageOptions::default()).unwrap();
+    assert_eq!(out.total_external_call_sites, 0, "but a references_type edge is not a call site");
+    assert!(out.entries.is_empty());
+}
+
+/// A CONSTRUCTOR invocation of an external symbol (`edge_kind = 'constructs'`) IS library usage and
+/// must be counted (#114 review): the read includes the full invocation set (`calls_name`,
+/// `constructs`, `dispatches`), not just `calls_name`.
+#[test]
+fn check_library_usage_counts_constructor_calls() {
+    let h = Harness::new();
+    let caller = h.add_file("caller.rs", "fn caller() { fetch(); }\n");
+    // A constructor call to an external symbol (e.g. `new Ky(...)`).
+    h.add_edge_with_kind(caller, "fetch", 14, 19, "constructs", "NameOnly", None);
+    let moniker = "scip-typescript npm ky 1.7.2 index.ts/Ky#constructor().";
+    let bytes = scip_external_call(moniker, vec![external(moniker, "Ky", vec![], "constructor()")]);
+    run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None, None).unwrap();
+
+    let out =
+        check_library_usage(&h.conn, COMMIT, WORKTREE, &LibraryUsageOptions::default()).unwrap();
+    assert_eq!(out.total_external_call_sites, 1, "a constructor call counts as library usage");
+    assert_eq!(out.entries.len(), 1);
+    assert_eq!(out.entries[0].moniker, moniker);
+}
+
+/// One source call that emits MULTIPLE invocation edge kinds at the SAME callee span (e.g. a Kotlin
+/// constructor → both `calls_name` and `constructs`) counts as ONE call site, not two (#114
+/// review).
+#[test]
+fn check_library_usage_deduplicates_multi_kind_edges_at_one_call_site() {
+    let h = Harness::new();
+    let caller = h.add_file("caller.rs", "fn caller() { fetch(); }\n");
+    // Both edge kinds at the SAME callee span (14..19) — two `edge_oracle` rows, one physical call.
+    h.add_edge_with_kind(caller, "fetch", 14, 19, "calls_name", "NameOnly", None);
+    h.add_edge_with_kind(caller, "fetch", 14, 19, "constructs", "NameOnly", None);
+    let moniker = "scip-typescript npm ky 1.7.2 index.ts/get().";
+    let bytes = scip_external_call(moniker, vec![external(moniker, "get", vec![], "get()")]);
+    let report =
+        run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None, None).unwrap();
+    assert_eq!(report.resolved_external, 2, "both edge kinds get a verdict");
+
+    let out =
+        check_library_usage(&h.conn, COMMIT, WORKTREE, &LibraryUsageOptions::default()).unwrap();
+    assert_eq!(
+        out.total_external_call_sites, 1,
+        "the two edge kinds at one span count as ONE call"
+    );
+    assert_eq!(out.entries.len(), 1);
+    assert_eq!(out.entries[0].call_count, 1);
+    assert_eq!(out.entries[0].call_sites.len(), 1);
+}
+
+/// A `path` filter with a trailing slash (`src/`) matches files under that directory (#114 review):
+/// trailing separators are trimmed before the boundary predicate is built.
+#[test]
+fn check_library_usage_path_filter_tolerates_trailing_slash() {
+    use ::protobuf::{EnumOrUnknown, Message};
+    use ::scip::types::{Document, Index};
+    let h = Harness::new();
+    std::fs::create_dir_all(h.root().join("src")).unwrap();
+    let caller = h.add_file("src/caller.rs", "fn caller() { fetch(); }\n");
+    h.add_edge(caller, "fetch", 14, 19, "NameOnly", None);
+    let moniker = "scip-typescript npm ky 1.7.2 index.ts/get().";
+    let bytes = Index {
+        documents: vec![Document {
+            relative_path: "src/caller.rs".to_string(),
+            occurrences: vec![occurrence(
+                0,
+                14,
+                19,
+                moniker,
+                SymbolRole::UnspecifiedSymbolRole as i32,
+            )],
+            position_encoding: EnumOrUnknown::new(
+                PositionEncoding::UTF8CodeUnitOffsetFromLineStart,
+            ),
+            ..Default::default()
+        }],
+        external_symbols: vec![external(moniker, "get", vec![], "get(): X")],
+        ..Default::default()
+    }
+    .write_to_bytes()
+    .unwrap();
+    run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None, None).unwrap();
+
+    for filter in ["src", "src/"] {
+        let out = check_library_usage(&h.conn, COMMIT, WORKTREE, &LibraryUsageOptions {
+            path: Some(filter.to_string()),
+            ..Default::default()
+        })
+        .unwrap();
+        assert_eq!(out.total_external_call_sites, 1, "path {filter:?} matches src/caller.rs");
+    }
+    let none = check_library_usage(&h.conn, COMMIT, WORKTREE, &LibraryUsageOptions {
+        path: Some("other".to_string()),
+        ..Default::default()
+    })
+    .unwrap();
+    assert_eq!(none.total_external_call_sites, 0, "a non-matching directory yields nothing");
+}
+
+/// Per-entry call sites are capped (#114 review): a symbol called far more than the cap reports the
+/// TRUE `call_count` but a bounded `call_sites` list, so the response can't balloon.
+#[test]
+fn check_library_usage_caps_call_sites_per_entry() {
+    use ::protobuf::{EnumOrUnknown, Message};
+    use ::scip::types::{Document, Index};
+    let h = Harness::new();
+    let n = 30usize;
+    // "f();f();…" — each `f` token is 4 bytes apart (f ( ) ;).
+    let src = format!("{}\n", "f();".repeat(n));
+    let caller = h.add_file("caller.rs", &src);
+    let moniker = "scip-typescript npm ky 1.7.2 index.ts/f().";
+    let mut occs = Vec::new();
+    for i in 0..n {
+        let start = (i * 4) as i32;
+        h.add_edge(caller, "f", start as usize, start as usize + 1, "NameOnly", None);
+        occs.push(occurrence(
+            0,
+            start,
+            start + 1,
+            moniker,
+            SymbolRole::UnspecifiedSymbolRole as i32,
+        ));
+    }
+    let bytes = Index {
+        documents: vec![Document {
+            relative_path: "caller.rs".to_string(),
+            occurrences: occs,
+            position_encoding: EnumOrUnknown::new(
+                PositionEncoding::UTF8CodeUnitOffsetFromLineStart,
+            ),
+            ..Default::default()
+        }],
+        external_symbols: vec![external(moniker, "f", vec![], "f()")],
+        ..Default::default()
+    }
+    .write_to_bytes()
+    .unwrap();
+    let report =
+        run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None, None).unwrap();
+    assert_eq!(report.resolved_external, n as u64, "all N calls resolved external");
+
+    let out =
+        check_library_usage(&h.conn, COMMIT, WORKTREE, &LibraryUsageOptions::default()).unwrap();
+    assert_eq!(out.entries.len(), 1);
+    assert_eq!(out.entries[0].call_count, n, "call_count is the TRUE total");
+    assert_eq!(
+        out.entries[0].call_sites.len(),
+        25,
+        "call_sites capped at MAX_CALL_SITES_PER_ENTRY"
+    );
+    assert_eq!(out.total_external_call_sites, n);
+}

--- a/crates/rag-rat-core/src/index/oracle/tests/mod.rs
+++ b/crates/rag-rat-core/src/index/oracle/tests/mod.rs
@@ -517,6 +517,7 @@ fn move_target_with_edit(h: &Harness, old_file: i64, new_kind: &str) -> i64 {
 
 mod edge_view;
 mod join_tests;
+mod library_usage;
 mod memory_bindings;
 mod monikers;
 mod persisted_enums;

--- a/crates/rag-rat-core/src/index/oracle/tests/monikers.rs
+++ b/crates/rag-rat-core/src/index/oracle/tests/monikers.rs
@@ -42,6 +42,98 @@ fn oracle_run_writes_monikers_for_in_corpus_defs() {
     assert_eq!(total, 1, "the unindexed dep def must not write a row");
 }
 
+/// An oracle run persists `index.external_symbols` into the `external_symbols` table (#114): the
+/// raw moniker (so it exact-joins `edge_oracle`), the kind/signature/docs, and the derived
+/// deprecation flag. A re-run is authoritative — a moniker the new `.scip` drops is cleared.
+#[test]
+fn oracle_run_persists_external_symbols_and_reclears_them() {
+    use ::protobuf::{EnumOrUnknown, Message, MessageField};
+    use ::scip::types::symbol_information::Kind;
+    use ::scip::types::{Document, Index, Signature, SymbolInformation};
+
+    let h = Harness::new();
+    // A trivial in-corpus file gives the run a checkout to scope to.
+    h.add_file("caller.rs", "fn caller() {}\n");
+
+    let deprecated = "rust-analyzer cargo dep 1.0.0 old_api().";
+    let current = "rust-analyzer cargo dep 1.0.0 new_api().";
+    let scip_with = |symbols: Vec<SymbolInformation>| {
+        Index {
+            documents: vec![Document {
+                relative_path: "caller.rs".to_string(),
+                position_encoding: EnumOrUnknown::new(
+                    PositionEncoding::UTF8CodeUnitOffsetFromLineStart,
+                ),
+                ..Default::default()
+            }],
+            external_symbols: symbols,
+            ..Default::default()
+        }
+        .write_to_bytes()
+        .unwrap()
+    };
+    let external = |moniker: &str, docs: Vec<String>, sig: &str| SymbolInformation {
+        symbol: moniker.to_string(),
+        display_name: "api".to_string(),
+        kind: EnumOrUnknown::new(Kind::Function),
+        documentation: docs,
+        signature_documentation: MessageField::some(Signature {
+            language: "rust".to_string(),
+            text: sig.to_string(),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+
+    let bytes = scip_with(vec![
+        external(deprecated, vec!["@deprecated use new_api".to_string()], "fn old_api()"),
+        external(current, vec!["The supported entry point.".to_string()], "fn new_api()"),
+    ]);
+    let report =
+        run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None, None).unwrap();
+    assert_eq!(report.external_symbols_written, 2, "both external contracts persisted");
+
+    // The deprecated contract landed with the raw moniker, kind, signature, and the derived flag.
+    let (kind, sig, dep): (String, String, bool) = h
+        .conn
+        .query_row(
+            "SELECT kind, signature_text, deprecated FROM external_symbols WHERE moniker = ?1",
+            [deprecated],
+            |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+        )
+        .unwrap();
+    assert_eq!(kind, "Function");
+    assert_eq!(sig, "fn old_api()");
+    assert!(dep, "the @deprecated doc marks the contract deprecated");
+    // The clean contract is present and NOT flagged.
+    let clean_dep: bool = h
+        .conn
+        .query_row("SELECT deprecated FROM external_symbols WHERE moniker = ?1", [current], |r| {
+            r.get(0)
+        })
+        .unwrap();
+    assert!(!clean_dep);
+
+    // Authoritative re-run: a `.scip` that drops `old_api` clears its stale contract.
+    let bytes2 = scip_with(vec![external(current, vec![], "fn new_api()")]);
+    let report2 =
+        run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes2, h.root(), None, None)
+            .unwrap();
+    assert_eq!(report2.external_symbols_written, 1);
+    let remaining: i64 =
+        h.conn.query_row("SELECT COUNT(*) FROM external_symbols", [], |r| r.get(0)).unwrap();
+    assert_eq!(remaining, 1, "the dropped moniker's stale contract was cleared");
+    let has_old: bool = h
+        .conn
+        .query_row(
+            "SELECT EXISTS(SELECT 1 FROM external_symbols WHERE moniker = ?1)",
+            [deprecated],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert!(!has_old, "old_api no longer described → its contract is gone");
+}
+
 /// A re-run is authoritative for the tool: monikers the current `.scip` no longer defines are
 /// cleared, not left stale.
 #[test]

--- a/crates/rag-rat-core/src/index/oracle/tests/scip_parse.rs
+++ b/crates/rag-rat-core/src/index/oracle/tests/scip_parse.rs
@@ -243,3 +243,133 @@ fn parse_utf16_astral_character_shifts_offset_by_surrogate_width() {
     // Correct surrogate accounting lands the byte range on `foo` (bytes 6..9).
     assert_eq!((occs[0].start_byte, occs[0].end_byte), (6, 9));
 }
+
+// ---------------------------------------------------------------------------
+// scip.rs — external `SymbolInformation` side map (#114): kind / signature / docs / deprecation.
+// ---------------------------------------------------------------------------
+
+/// Build a `SymbolInformation` for an external dependency symbol. `signature` is `(language,
+/// text)`.
+fn external_symbol(
+    moniker: &str,
+    kind: ::scip::types::symbol_information::Kind,
+    display_name: &str,
+    signature: Option<(&str, &str)>,
+    docs: &[&str],
+) -> ::scip::types::SymbolInformation {
+    ::scip::types::SymbolInformation {
+        symbol: moniker.to_string(),
+        display_name: display_name.to_string(),
+        kind: ::protobuf::EnumOrUnknown::new(kind),
+        documentation: docs.iter().map(|doc| doc.to_string()).collect(),
+        signature_documentation: signature
+            .map(|(language, text)| {
+                ::protobuf::MessageField::some(::scip::types::Signature {
+                    language: language.to_string(),
+                    text: text.to_string(),
+                    ..Default::default()
+                })
+            })
+            .unwrap_or_default(),
+        ..Default::default()
+    }
+}
+
+/// Parse an index carrying only `external_symbols` (no documents to read).
+fn parse_external(symbols: Vec<::scip::types::SymbolInformation>) -> ScipIndex {
+    let index = Index { external_symbols: symbols, ..Default::default() };
+    ScipIndex::from_index(&index, PositionEncoding::UTF8CodeUnitOffsetFromLineStart, &mut |_| None)
+        .unwrap()
+}
+
+/// `index.external_symbols` populate the moniker-keyed side map with kind / display_name /
+/// signature text+language / documentation, keyed by the RAW moniker (so it exact-joins
+/// `edge_oracle`).
+#[test]
+fn parse_external_symbols_populates_the_side_map() {
+    use ::scip::types::symbol_information::Kind;
+    let moniker = "scip-typescript npm ky 1.7.2 index.ts/Ky#get().";
+    let idx = parse_external(vec![external_symbol(
+        moniker,
+        Kind::Method,
+        "get",
+        Some(("typescript", "get(url: string, options?: Options): ResponsePromise")),
+        &["Fetches the URL with the given options."],
+    )]);
+
+    let info = idx.external_symbol_info.get(moniker).expect("moniker keyed raw, exact");
+    assert_eq!(info.kind, "Method");
+    assert_eq!(info.display_name, "get");
+    assert_eq!(info.signature_language, "typescript");
+    assert!(info.signature_text.contains("ResponsePromise"), "signature text preserved");
+    assert_eq!(info.documentation, "Fetches the URL with the given options.");
+    assert!(!info.deprecated, "no deprecation marker present");
+}
+
+/// The deprecation verdict fires on a case-insensitive "deprecated" in EITHER the documentation or
+/// the signature text, and stays false when absent.
+#[test]
+fn parse_external_symbols_detect_deprecation_in_docs_or_signature() {
+    use ::scip::types::symbol_information::Kind;
+    let deprecated_in_docs = "pkg a 1 mod/old().";
+    let deprecated_in_sig = "pkg a 1 mod/old2().";
+    let clean = "pkg a 1 mod/current().";
+    let idx = parse_external(vec![
+        external_symbol(deprecated_in_docs, Kind::Function, "old", None, &[
+            "@deprecated Use `new` instead."
+        ]),
+        external_symbol(
+            deprecated_in_sig,
+            Kind::Function,
+            "old2",
+            // Capitalized marker in the signature, none in docs — still caught (case-insensitive).
+            Some(("rust", "fn old2() // DEPRECATED")),
+            &[],
+        ),
+        external_symbol(clean, Kind::Function, "current", Some(("rust", "fn current()")), &[
+            "The supported entry point.",
+        ]),
+    ]);
+
+    assert!(idx.external_symbol_info.get(deprecated_in_docs).unwrap().deprecated);
+    assert!(idx.external_symbol_info.get(deprecated_in_sig).unwrap().deprecated);
+    assert!(!idx.external_symbol_info.get(clean).unwrap().deprecated);
+}
+
+/// `local N` external entries carry no cross-file meaning and are dropped; a duplicate moniker
+/// keeps the FIRST `SymbolInformation` (SCIP emits one per symbol, but the map must be
+/// deterministic).
+#[test]
+fn parse_external_symbols_skip_locals_and_keep_first_on_duplicate() {
+    use ::scip::types::symbol_information::Kind;
+    let dup = "pkg a 1 mod/dup().";
+    let idx = parse_external(vec![
+        external_symbol("local 0", Kind::Function, "scratch", None, &[]),
+        external_symbol(dup, Kind::Function, "first", Some(("rust", "fn dup()")), &[]),
+        external_symbol(dup, Kind::Method, "second", Some(("rust", "fn dup(x)")), &[]),
+    ]);
+
+    assert!(!idx.external_symbol_info.contains_key("local 0"), "local symbols dropped");
+    assert_eq!(
+        idx.external_symbol_info.get(dup).unwrap().display_name,
+        "first",
+        "first entry wins"
+    );
+    assert_eq!(idx.external_symbol_info.len(), 1);
+}
+
+/// A symbol with no `signature_documentation` and an unset `kind` yields empty signature fields and
+/// the "unspecified" kind label — no panic, graceful empties.
+#[test]
+fn parse_external_symbols_tolerate_missing_signature_and_kind() {
+    use ::scip::types::symbol_information::Kind;
+    let moniker = "pkg a 1 mod/bare().";
+    let idx = parse_external(vec![external_symbol(moniker, Kind::UnspecifiedKind, "", None, &[])]);
+
+    let info = idx.external_symbol_info.get(moniker).unwrap();
+    assert_eq!(info.kind, "unspecified");
+    assert_eq!(info.signature_text, "");
+    assert_eq!(info.signature_language, "");
+    assert_eq!(info.documentation, "");
+    assert!(!info.deprecated);
+}

--- a/crates/rag-rat-core/src/index/query_api/gc.rs
+++ b/crates/rag-rat-core/src/index/query_api/gc.rs
@@ -179,6 +179,10 @@ impl IndexDatabase {
         // `multiple_real_repos` guard, so the prune runs unconditionally again (exactly as it did
         // on a single-repo DB before scoping).
         oracle::prune_oracle_runs_outside_scope(conn, live_commits, live_worktrees)?;
+        // #114: `external_symbols` is checkout-keyed like `oracle_runs` (nothing cascades it), so a
+        // dead checkout's dependency contracts need the SAME per-repo, dead-scope prune — otherwise
+        // signature/doc payloads for retired branches/worktrees accumulate without bound.
+        oracle::prune_external_symbols_outside_scope(conn, live_commits, live_worktrees)?;
         // #357: `embedding_cache` is content-keyed too (survives reindex, like the oracle above),
         // so it needs the SAME global sweep — drop vectors no live chunk references in ANY
         // context (a sibling worktree / branch may still use one, so this must not be

--- a/crates/rag-rat-core/src/index/query_api/graph.rs
+++ b/crates/rag-rat-core/src/index/query_api/graph.rs
@@ -16,6 +16,23 @@ impl IndexDatabase {
         crate::query::graph::traverse(self.storage.connection(), symbol, true, limit)
     }
 
+    /// `check_library_usage` (#114): join the active checkout's `resolved-external` call sites to
+    /// the `external_symbols` dependency contracts, surface each dependency's current
+    /// signature/docs as context, and assert deprecated-but-compiling usage. Read-only;
+    /// requires an `oracle run` to have populated the side tables (else a `NoOracleRun` /
+    /// `NoExternalSymbols` status).
+    pub fn check_library_usage(
+        &self,
+        opts: &crate::index::oracle::LibraryUsageOptions,
+    ) -> anyhow::Result<crate::index::oracle::LibraryUsageReport> {
+        crate::index::oracle::check_library_usage(
+            self.storage.connection(),
+            &self.active_commit_sha,
+            &self.active_worktree_id,
+            opts,
+        )
+    }
+
     pub fn find_callers_with_options(
         &self,
         symbol: &str,

--- a/crates/rag-rat-core/src/index/schema/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema/migrations.rs
@@ -693,6 +693,58 @@ pub(crate) fn apply_scip_moniker_anchors(conn: &Connection) -> rusqlite::Result<
     Ok(())
 }
 
+/// V056 (#114): `external_symbols` — the per-moniker `SymbolInformation` (`kind`, `display_name`,
+/// `signature_documentation.text`, `documentation`, a derived `deprecated` flag) that `oracle run`
+/// parses out of `index.external_symbols` and previously DISCARDED. This is the dependency-side
+/// contract that `check_library_usage` joins to external call sites to surface signature/docs as
+/// inline context and to assert deprecated-but-compiling usage.
+///
+/// JOIN CONTRACT (load-bearing): `moniker` is the RAW SCIP symbol string, stored byte-for-byte as
+/// it appears in `SymbolInformation.symbol` — the SAME form `edge_oracle.scip_symbol` stores (an
+/// occurrence's `symbol`, unstabilized; see `oracle::join::classify_edge`). The read join is an
+/// exact string match on `moniker = edge_oracle.scip_symbol`; applying `stabilize_moniker_version`
+/// to one side and not the other would silently break it. External monikers carry the dependency's
+/// real version, so a cross-version re-index naturally produces distinct rows (the drift the spike
+/// targets).
+///
+/// INVARIANT (oracle-persisted, #248): NO foreign key — the table is content/moniker-keyed and its
+/// reads JOIN live `edge_oracle`, so a dangling row never resolves rather than being CASCADE-wiped
+/// on reindex. Listed in [`super::ORACLE_PERSISTED_TABLES`]. Born post-A5, so `repo_id` is a birth
+/// column and leads the PK.
+///
+/// CHECKOUT-SCOPED like its run sibling `oracle_runs` (NOT like `logical_symbol_monikers`): the
+/// contract set is the product of ONE oracle run in ONE checkout, so the PK carries `(commit_sha,
+/// worktree_id)`. Two linked worktrees of the same repo — at different dependency versions — keep
+/// DISJOINT contract sets, so the later run's authoritative per-`(tool, checkout)` clear cannot
+/// erase a sibling checkout's contracts (the same multi-worktree isolation `edge_oracle` /
+/// `oracle_runs` already enforce). `tool_version` rides along as write provenance; the moniker's
+/// version component still distinguishes dependency versions within a checkout.
+pub(crate) fn apply_external_symbols(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "
+        CREATE TABLE IF NOT EXISTS external_symbols(
+            repo_id            TEXT NOT NULL,
+            tool               TEXT NOT NULL,
+            tool_version       TEXT NOT NULL,
+            commit_sha         TEXT NOT NULL,
+            worktree_id        TEXT NOT NULL,
+            moniker            TEXT NOT NULL,
+            kind               TEXT NOT NULL,
+            display_name       TEXT NOT NULL,
+            signature_text     TEXT NOT NULL,
+            signature_language TEXT NOT NULL,
+            documentation      TEXT NOT NULL,
+            deprecated         INTEGER NOT NULL,
+            computed_at_ms     INTEGER NOT NULL,
+            PRIMARY KEY(repo_id, tool, commit_sha, worktree_id, moniker)
+        ) STRICT;
+
+        CREATE INDEX IF NOT EXISTS idx_external_symbols_deprecated
+            ON external_symbols(repo_id, tool, commit_sha, worktree_id, deprecated);
+        ",
+    )
+}
+
 /// The integer indexes on `edges_data` (#79) — the successors of the old TEXT indexes on `edges`.
 /// Called from baseline (fresh DBs) AND after the V020 conversion (upgrading DBs, where the
 /// same-named legacy indexes blocked `IF NOT EXISTS` until `DROP TABLE edges` removed them).
@@ -1191,6 +1243,7 @@ pub(crate) fn known_version(migrations: &[AppliedMigration]) -> u32 {
             MIGRATION_054_ID => Some(54),
             MIGRATION_055_ID => Some(55),
             MIGRATION_056_ID => Some(56),
+            MIGRATION_057_ID => Some(57),
             _ => None,
         })
         .max()
@@ -1256,6 +1309,7 @@ pub(crate) fn known_migration(id: &str) -> bool {
             | MIGRATION_054_ID
             | MIGRATION_055_ID
             | MIGRATION_056_ID
+            | MIGRATION_057_ID
             | DIRTY_MIGRATION_ID
     )
 }
@@ -1318,6 +1372,7 @@ pub(crate) fn migration_checksum_mismatch(migration: &AppliedMigration) -> bool 
         MIGRATION_054_ID => migration.checksum != MIGRATION_054_CHECKSUM,
         MIGRATION_055_ID => migration.checksum != MIGRATION_055_CHECKSUM,
         MIGRATION_056_ID => migration.checksum != MIGRATION_056_CHECKSUM,
+        MIGRATION_057_ID => migration.checksum != MIGRATION_057_CHECKSUM,
         _ => false,
     }
 }

--- a/crates/rag-rat-core/src/index/schema/mod.rs
+++ b/crates/rag-rat-core/src/index/schema/mod.rs
@@ -19,7 +19,7 @@ pub use registry::{LEGACY_REPO_ID, register_repo, register_repo_read_only};
 use rusqlite::{Connection, OptionalExtension, params};
 use serde::Serialize;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 56;
+pub const LATEST_SCHEMA_VERSION: u32 = 57;
 
 /// Every oracle-DERIVED persisted table — the outputs an `oracle run` writes that must OUTLIVE a
 /// reindex.
@@ -45,7 +45,7 @@ pub const LATEST_SCHEMA_VERSION: u32 = 56;
 // it is intentionally a durable schema-invariant declaration.
 #[cfg_attr(not(test), allow(dead_code))]
 pub(crate) const ORACLE_PERSISTED_TABLES: &[&str] =
-    &["edge_oracle", "logical_symbol_monikers", "oracle_runs"];
+    &["edge_oracle", "logical_symbol_monikers", "oracle_runs", "external_symbols"];
 
 /// The parent tables a reindex REWRITES (full rebuild and/or per-file `remove_file_in_scope`), so
 /// an `ON DELETE CASCADE`/`RESTRICT` FK from an oracle-derived table to one of these wipes the
@@ -392,6 +392,16 @@ const MIGRATION_056_DESCRIPTION: &str =
      (repo_id-scoped, no FK to the volatile history rows): wholesale-recomputed lazily on the \
      impact_surface read path against a repo_meta 'git_coupling_stamp', never patched \
      incrementally. Fresh + empty on create; the first git-inclusive impact read fills it";
+const MIGRATION_057_ID: &str = "057_external_symbols";
+const MIGRATION_057_CHECKSUM: &str = "sha256:rag-rat-external-symbols-v57";
+const MIGRATION_057_DESCRIPTION: &str =
+    "Add external_symbols (#114), the per-moniker dependency contract oracle run parses out of \
+     the .scip index.external_symbols (kind, display_name, signature_documentation text, \
+     documentation, a derived deprecated flag) — data from_index previously discarded. \
+     Oracle-persisted, content/moniker-keyed with NO reindex-cascading FK, checkout-scoped \
+     (repo_id, tool, commit_sha, worktree_id) from birth; moniker is the RAW SCIP symbol string \
+     so it exact-joins edge_oracle.scip_symbol. Backs the check_library_usage tool that surfaces \
+     the current signature/docs at external call sites and flags deprecated usage";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -869,6 +879,12 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         checksum: MIGRATION_056_CHECKSUM,
         description: MIGRATION_056_DESCRIPTION,
         apply: apply_git_change_couplings,
+    },
+    Migration {
+        id: MIGRATION_057_ID,
+        checksum: MIGRATION_057_CHECKSUM,
+        description: MIGRATION_057_DESCRIPTION,
+        apply: apply_external_symbols,
     },
 ];
 

--- a/crates/rag-rat-core/src/index/schema/registry.rs
+++ b/crates/rag-rat-core/src/index/schema/registry.rs
@@ -78,6 +78,9 @@ const A5_PERIPHERY_DIRECT_SCOPED_TABLES: &[&str] = &[
     "oracle_runs",
     "edge_oracle",
     "logical_symbol_monikers",
+    // V056 (#114): the per-moniker external dependency contract, repo_id-scoped from birth like
+    // its oracle-periphery siblings; a LocalOnly→Portable adoption must re-point its rows too.
+    "external_symbols",
     "reconcile_attempts",
     "dream_findings",
     "repo_memories",
@@ -557,6 +560,9 @@ const LATE_MERGE_DERIVED_PERIPHERY_TABLES: &[&str] = &[
     "oracle_runs",
     "edge_oracle",
     "logical_symbol_monikers",
+    // V056 (#114): DERIVED (re-produced by a fresh oracle run under the target id), so it is
+    // DROPPED under the retiring id, not moved — same posture as edge_oracle.
+    "external_symbols",
     "reconcile_attempts",
     "dream_findings",
 ];

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
@@ -1522,8 +1522,8 @@ fn migration_054_adds_the_single_row_device_identity_table() {
 fn migration_055_adds_the_binding_downgrade_marker_column() {
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     schema::apply(&conn).unwrap();
-    // V056 now holds the absolute tip pin (migration_056's test); this drops to the symbolic
-    // `current_version == LATEST` freshness check.
+    // The absolute tip pin lives with the newest migration's test (`migration_057_*` now); this
+    // drops to the symbolic `current_version == LATEST` freshness check.
     assert_eq!(
         schema::status(&conn).unwrap().current_version,
         schema::LATEST_SCHEMA_VERSION,
@@ -1556,10 +1556,13 @@ fn migration_055_adds_the_binding_downgrade_marker_column() {
 fn migration_056_adds_the_git_change_couplings_table() {
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     schema::apply(&conn).unwrap();
-    // V056 is the schema tip — this test carries the absolute pin (the older tests dropped to the
-    // symbolic `current_version == LATEST` check).
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 56, "V056 is the schema tip");
-    assert_eq!(schema::status(&conn).unwrap().current_version, 56, "schema at LATEST after apply");
+    // The absolute tip pin lives with the newest migration's test (`migration_057_*` now); this
+    // drops to the symbolic `current_version == LATEST` freshness check.
+    assert_eq!(
+        schema::status(&conn).unwrap().current_version,
+        schema::LATEST_SCHEMA_VERSION,
+        "schema at LATEST after apply"
+    );
     assert!(
         conn_table_exists(&conn, "git_change_couplings"),
         "V056 creates the git_change_couplings table"
@@ -1602,6 +1605,139 @@ fn migration_056_adds_the_git_change_couplings_table() {
         schema::status(&conn).unwrap().current_version,
         schema::LATEST_SCHEMA_VERSION,
         "forward migrate reaches the tip"
+    );
+}
+
+#[test]
+fn migration_057_adds_the_external_symbols_table() {
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn).unwrap();
+    // V057 is the schema tip — this test carries the absolute pin (the older tests dropped to
+    // the symbolic `current_version == LATEST` check).
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 57, "V057 is the schema tip");
+    assert_eq!(schema::status(&conn).unwrap().current_version, 57, "schema at LATEST after apply");
+
+    // The external-symbol contract table exists with its full column set.
+    for column in [
+        "repo_id",
+        "tool",
+        "tool_version",
+        "commit_sha",
+        "worktree_id",
+        "moniker",
+        "kind",
+        "display_name",
+        "signature_text",
+        "signature_language",
+        "documentation",
+        "deprecated",
+        "computed_at_ms",
+    ] {
+        assert!(
+            conn_table_columns(&conn, "external_symbols").contains(&column.to_string()),
+            "V057 gives external_symbols its {column} column"
+        );
+    }
+
+    // PK `(repo_id, tool, commit_sha, worktree_id, moniker)`: a second row with the same key is
+    // rejected even when the payload differs; the SAME moniker under a DIFFERENT checkout inserts
+    // (the multi-worktree isolation), as does a distinct moniker.
+    let insert = "INSERT INTO external_symbols(repo_id, tool, tool_version, commit_sha, \
+                  worktree_id, moniker, kind, display_name, signature_text, signature_language, \
+                  documentation, deprecated, computed_at_ms) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, \
+                  ?8, ?9, ?10, ?11, ?12, ?13)";
+    conn.execute(insert, rusqlite::params![
+        "r",
+        "rust-analyzer",
+        "1.0",
+        "sha1",
+        "",
+        "crate a 1.0 mod/get().",
+        "Function",
+        "get",
+        "fn get()",
+        "rust",
+        "docs",
+        0,
+        123_i64
+    ])
+    .expect("first external-symbol row inserts");
+    assert!(
+        conn.execute(insert, rusqlite::params![
+            "r",
+            "rust-analyzer",
+            "2.0",
+            "sha1",
+            "",
+            "crate a 1.0 mod/get().",
+            "Method",
+            "get",
+            "fn get(x)",
+            "rust",
+            "other",
+            1,
+            456_i64
+        ])
+        .is_err(),
+        "the (repo_id, tool, commit_sha, worktree_id, moniker) primary key rejects a duplicate"
+    );
+    conn.execute(insert, rusqlite::params![
+        "r",
+        "rust-analyzer",
+        "1.0",
+        "sha2",
+        "",
+        "crate a 1.0 mod/get().",
+        "Function",
+        "get",
+        "fn get()",
+        "rust",
+        "docs",
+        0,
+        123_i64
+    ])
+    .expect("the same moniker under a different checkout (commit_sha) inserts — worktree-isolated");
+    conn.execute(insert, rusqlite::params![
+        "r",
+        "rust-analyzer",
+        "1.0",
+        "sha1",
+        "",
+        "crate a 1.0 mod/other().",
+        "Function",
+        "other",
+        "fn other()",
+        "rust",
+        "docs",
+        0,
+        123_i64
+    ])
+    .expect("a distinct moniker inserts");
+
+    // Deferred-absence in ISOLATION: drop the table and re-run the applier alone (never against the
+    // full ladder's end state). It recreates the table, and a replay is a no-op (CREATE … IF NOT
+    // EXISTS).
+    conn.execute_batch("DROP TABLE external_symbols;").unwrap();
+    assert!(!conn_table_exists(&conn, "external_symbols"), "dropped before the isolated apply");
+    schema::apply_external_symbols(&conn).unwrap();
+    schema::apply_external_symbols(&conn).expect("replay is a no-op");
+    assert!(
+        conn_table_columns(&conn, "external_symbols").contains(&"moniker".to_string()),
+        "the isolated applier recreates the table"
+    );
+
+    // A forward migrate over a ledger truncated below V057 replays the step and lands the table.
+    conn.execute_batch("DROP TABLE external_symbols;").unwrap();
+    truncate_schema_to(&conn, 56);
+    schema::migrate_forward(&conn).unwrap();
+    assert_eq!(
+        schema::status(&conn).unwrap().current_version,
+        schema::LATEST_SCHEMA_VERSION,
+        "forward migrate reaches the tip"
+    );
+    assert!(
+        conn_table_exists(&conn, "external_symbols"),
+        "the forward migrate re-creates external_symbols"
     );
 }
 

--- a/crates/rag-rat-mcp/src/tools/catalog.rs
+++ b/crates/rag-rat-mcp/src/tools/catalog.rs
@@ -8,6 +8,7 @@ pub const TOOL_NAMES: &[&str] = &[
     "compare_graph_to_text",
     "compare_graph_to_scip",
     "impact_surface",
+    "check_library_usage",
     "repo_brief",
     "repo_clusters",
     "important_symbols",
@@ -101,6 +102,15 @@ pub fn description(name: &str) -> &'static str {
             "Pre-edit blast radius for a symbol or path: graph callers/callees, tests, docs, git \
              history, GitHub papertrail, and the repo memories crossing it, with a completeness / \
              risk summary. Run this before changing anything non-trivial.",
+        "check_library_usage" =>
+            "Dependency-contract check for the code's EXTERNAL library calls, from the SCIP \
+             oracle's external symbol info. For each `resolved-external` call site it surfaces the \
+             dependency's CURRENT signature + docs as inline context (judge arity / misuse \
+             yourself) and ASSERTS a `deprecated` verdict when the docs mark it so. Filter by \
+             `path`, `package`, or `deprecated_only`. Requires an `oracle run`; returns a \
+             `NoOracleRun` / `NoExternalSymbols` status otherwise. Does NOT assert arity or \
+             removed/renamed drift (not instrumented / needs a cross-version baseline) — those \
+             stay context.",
         "repo_brief" =>
             "Orientation for an unfamiliar repo: ranked files by mode — spine (central coupling), \
              churn, god_modules, or refactor_candidates — with size/coupling/churn/memory signals \
@@ -258,6 +268,7 @@ pub fn schema(name: &str) -> Value {
         "compare_graph_to_text" => schema_for::<CompareGraphTextArgs>(),
         "compare_graph_to_scip" => schema_for::<EmptyArgs>(),
         "impact_surface" => schema_for::<ImpactArgs>(),
+        "check_library_usage" => schema_for::<CheckLibraryUsageArgs>(),
         "repo_brief" => schema_for::<RepoBriefArgs>(),
         "repo_clusters" => schema_for::<RepoClustersArgs>(),
         "important_symbols" => schema_for::<ImportantSymbolsArgs>(),

--- a/crates/rag-rat-mcp/src/tools/handlers.rs
+++ b/crates/rag-rat-mcp/src/tools/handlers.rs
@@ -59,6 +59,15 @@ pub(crate) fn call_tool_with_db(
             let resolution_mode = resolution_mode(args.resolution);
             impact_tool(db, args, resolution_mode, memory_surface)?
         },
+        "check_library_usage" => {
+            let args: CheckLibraryUsageArgs = serde_json::from_value(arguments)?;
+            json!(db.check_library_usage(&LibraryUsageOptions {
+                path: args.path,
+                package: args.package,
+                deprecated_only: args.deprecated_only,
+                limit: args.limit as usize,
+            })?)
+        },
         "repo_brief" => {
             let args: RepoBriefArgs = serde_json::from_value(arguments)?;
             json!(db.repo_brief(RepoBriefOptions {

--- a/crates/rag-rat-mcp/src/tools/mod.rs
+++ b/crates/rag-rat-mcp/src/tools/mod.rs
@@ -10,6 +10,7 @@ pub use catalog::*;
 pub(crate) use defaults::*;
 pub(crate) use handlers::*;
 use rag_rat_core::config::MemorySurface;
+use rag_rat_core::index::oracle::LibraryUsageOptions;
 use rag_rat_core::language::Language;
 use rag_rat_core::query::clusters::RepoClustersOptions;
 use rag_rat_core::query::graph::{GraphResolutionMode, GraphTraversalOptions};

--- a/crates/rag-rat-mcp/src/tools/requests.rs
+++ b/crates/rag-rat-mcp/src/tools/requests.rs
@@ -470,6 +470,27 @@ pub struct LimitArgs {
 }
 
 #[derive(Debug, Deserialize, Serialize, schemars::JsonSchema)]
+pub struct CheckLibraryUsageArgs {
+    /// Restrict to external call sites in this exact file or under this directory prefix (e.g.
+    /// `src/net`). Omit for the whole checkout.
+    #[serde(default)]
+    pub path: Option<String>,
+    /// Restrict to one dependency package — the moniker's package component, e.g. `ky` / `tokio`.
+    #[serde(default)]
+    pub package: Option<String>,
+    /// Only surface contracts flagged deprecated (the asserted verdict).
+    #[serde(default)]
+    pub deprecated_only: bool,
+    /// Max dependency-symbol entries returned; summary counts always cover the full set.
+    #[serde(default = "default_graph_limit")]
+    pub limit: u32,
+    /// Absolute path to a linked git worktree you're working in; serves that worktree's branch
+    /// overlay over the indexed checkout. Omit for the indexed checkout.
+    #[serde(default)]
+    pub worktree: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize, schemars::JsonSchema)]
 pub struct ReadChunkArgs {
     pub chunk_id: i64,
     #[serde(default = "default_read_chunk_graph_mode")]

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -54,7 +54,7 @@ To run from a checkout without installing, use a project-scoped server whose com
 
 ## Tools
 
-The MCP surface is **46 tools** in nine groups. The signatures are below; the prose sections that
+The MCP surface is **47 tools** in nine groups. The signatures are below; the prose sections that
 follow describe response shapes and per-tool behavior. Every symbol/search/read tool additionally
 accepts an optional `"worktree": string` — an absolute path to a linked git worktree, served as a
 branch overlay over the indexed checkout — omitted from the signatures below for brevity.
@@ -70,6 +70,7 @@ branch overlay over the indexed checkout — omitted from the signatures below f
 - `find_callers`: `{ "symbol"?: string, "ref"?: string, "id"?: string, "resolution"?: "exact" | "syntactic" | "fuzzy", "allow_ambiguous"?: boolean, "limit"?: number, "include"?: ("references" | "unresolved" | "macros" | "common_methods" | "coverage" | "memories")[], "edge_kinds"?: string[] }`
 - `trace_callees`: `{ "symbol"?: string, "ref"?: string, "id"?: string, "resolution"?: "exact" | "syntactic" | "fuzzy", "allow_ambiguous"?: boolean, "limit"?: number, "include"?: ("references" | "unresolved" | "macros" | "common_methods" | "coverage" | "memories")[], "edge_kinds"?: string[] }`
 - `impact_surface`: `{ "query"?: string, "symbol"?: string, "ref"?: string, "id"?: string, "resolution"?: "exact" | "syntactic" | "fuzzy", "allow_ambiguous"?: boolean, "limit"?: number, "include"?: ("tests" | "docs" | "git" | "papertrail" | "text_fallback" | "memories")[], "full_memories"?: boolean }`
+- `check_library_usage`: `{ "path"?: string, "package"?: string, "deprecated_only"?: boolean, "limit"?: number }`
 - `compare_graph_to_text`: `{ "symbol"?: string, "ref"?: string, "id"?: string, "pattern": string, "resolution"?: "exact" | "syntactic" | "fuzzy", "allow_ambiguous"?: boolean, "limit"?: number, "include"?: ("tests" | "references" | "unresolved" | "macros" | "common_methods")[], "edge_kinds"?: string[] }`
 - `compare_graph_to_scip`: `{}`
 - `ffi_surface`: `{ "limit"?: number }`
@@ -392,6 +393,23 @@ array — `tests`, `docs`, `git`, `papertrail`, `text_fallback`, `memories`, all
 are empty but text fallback finds symbol/path hits, the caveats
 section explicitly says that graph extraction or resolution gaps are likely. Free-text `query`
 requests retain the older flat impact item shape for compatibility.
+
+`check_library_usage` reports how the code uses its EXTERNAL libraries, from the SCIP oracle's
+external symbol info (`index.external_symbols`, parsed into the `external_symbols` table by
+`oracle run` — data the reader used to discard). It joins every `resolved-external` call site to its
+dependency contract by moniker and groups per dependency symbol. Each `entries[]` element carries the
+`moniker`, `package`, `kind`, `display_name`, the dependency's current `signature_text` /
+`signature_language` / `documentation` (**context** — reason about arity / misuse yourself, nothing
+is asserted), the `deprecated` flag (**the one asserted verdict** — a deterministic "deprecated"
+marker in the docs/signature), and the `call_sites` (`path` + line span) with a `call_count`. The
+report also returns `total_external_call_sites`, `distinct_monikers`, `deprecated_call_sites`, and
+`call_sites_without_signature_info` (external calls whose moniker had no contract — coverage
+transparency, not a finding). Filter with `path` (a file or directory prefix), `package` (a single
+dependency), and `deprecated_only`. `status` is `ok`, `no_oracle_run` (run `rag-rat oracle run`
+first), or `no_external_symbols` (the indexer emitted no external symbol info). It does NOT assert
+arity or removed/renamed drift: call-site arg counts are not instrumented and a "removed" verdict
+needs a cross-version baseline (re-index on lockfile change) — both are follow-ups. See
+[`oracle.md`](oracle.md).
 
 Git history tools return historical evidence. `commit_search` searches commit subjects and bodies;
 `git_history_for_path` returns commits touching a current path; `git_history_for_symbol` resolves


### PR DESCRIPTION
Parse the external `SymbolInformation` the SCIP oracle previously parsed-and-discarded (`index.external_symbols`) into a new oracle-persisted `external_symbols` table (V057), and add a `check_library_usage` MCP tool that joins `resolved-external` call sites to those dependency contracts by moniker.

## What it does
- Surfaces each external dependency's **current signature + docs as inline context** at the call site.
- Asserts one deterministic verdict — **`deprecated`** (a docs/signature marker). It does NOT assert arity (call-site arg counts aren't instrumented) or removed/renamed drift (needs a cross-version baseline) — both are surfaced as context / documented follow-ups, not verdicts.
- Filters: `path`, `package`, `deprecated_only`, `limit`. Reports coverage (`call_sites_without_signature_info`) plus a `no_oracle_run` / `no_external_symbols` status with a rerun nudge.

## Schema (V057, oracle-persisted)
`external_symbols(moniker, kind, display_name, signature_text, signature_language, documentation, deprecated)` — content/moniker-keyed with **no reindex-cascading FK**, **checkout-scoped** `(repo_id, tool, commit_sha, worktree_id, moniker)` like `oracle_runs` (so linked worktrees at different dependency versions keep disjoint contract sets), cleared+upserted per oracle run beside the moniker pass, and dead-checkout-pruned by gc. The moniker is stored **raw** so it exact-joins `edge_oracle.scip_symbol`.

## Honest scope (verified on real indexer output)
`index.external_symbols` is **indexer-dependent**: **scip-python populates it** (docstrings / typeshed signatures — the tool returns the real signature at each call site), while **rust-analyzer and scip-typescript emit none** (external call targets appear only as occurrence references). So the differentiated value lands on **dynamically-typed languages**; on Rust/TS the tool honestly returns `no_external_symbols`. The read counts only real invocation edges (`calls_name` / `constructs` / `dispatches`), dedupes per physical call site, and bounds its payload by `limit`.

Fixes #114.
