### PR TITLE
feat(reconcile): heal op-log ghosts at index reconcile — idle-repo backstop (#583)

### DIFF
--- a/crates/rag-rat-core/src/index/query_api/ai_lifecycle.rs
+++ b/crates/rag-rat-core/src/index/query_api/ai_lifecycle.rs
@@ -65,7 +65,30 @@ impl IndexDatabase {
         options: ai::ReconcileOptions,
         progress: impl FnMut(ai::ReconcileProgress),
     ) -> anyhow::Result<ReconcileReport> {
-        ai::reconcile_with_options_progress(self.storage.connection(), options, progress)
+        let report =
+            ai::reconcile_with_options_progress(self.storage.connection(), options, progress)?;
+        self.heal_memory_oplog_ghosts()?;
+        Ok(report)
+    }
+
+    /// Idle-repo op-log ghost backstop (#583, follow-up to #541). The per-node op-log reconcile
+    /// (#541) heals a "ghost" memory/edge — a row present in `repo_memories`/`repo_node_edges` but
+    /// absent from the signed projection, left by a pre-#532 binary or a raw writer such as the
+    /// `dream` passes — on the next MEMORY mutation. A repo with no subsequent memory mutation
+    /// would carry the ghost indefinitely, so a reconcile pass runs the same idempotent
+    /// reconcile: both `rag-rat reconcile` and the watcher's incremental pass route through
+    /// [`Self::reconcile_with_options_progress`], so this one seam covers every idle-repo trigger.
+    ///
+    /// Cheap and safe on the hot path: [`backfill_memory_oplog`] probes with two indexed anti-joins
+    /// that return empty in steady state and take NO write lock when nothing is missing, and it is
+    /// a no-op under an absent/unstable scope. Runs after the embedding reconcile has
+    /// committed, so its authored write (a durable `IMMEDIATE` txn only when a ghost exists)
+    /// never nests inside it.
+    pub(crate) fn heal_memory_oplog_ghosts(&self) -> anyhow::Result<()> {
+        crate::query::memory::backfill_memory_oplog(
+            self.storage.connection(),
+            crate::index::now_ms(),
+        )
     }
 
     pub fn current_embedding_count(&self, model_id: &str) -> anyhow::Result<u64> {

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/reconcile_embeddings.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/reconcile_embeddings.rs
@@ -1389,3 +1389,88 @@ fn self_heal_does_not_certify_a_repo_with_another_live_scope() {
 
     let _ = fs::remove_dir_all(root);
 }
+
+#[test]
+fn reconcile_heals_an_op_log_ghost_in_an_idle_repo() {
+    // #583 (follow-up to #541). The per-node op-log reconcile heals a "ghost" — a row present in
+    // `repo_memories` but absent from the signed projection, left by a raw writer / a pre-#532
+    // binary — on the next MEMORY mutation. A repo that gets NO subsequent memory mutation would
+    // carry the ghost indefinitely, so an index reconcile pass runs the same idempotent reconcile.
+    // Both `rag-rat reconcile` and the watcher's incremental pass route through
+    // `reconcile_with_options_progress`, so exercising it here covers every idle-repo trigger.
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), "pub fn seed() {}\n").unwrap();
+    // A COMMITTED git repo yields a stable repo_id — the op-log reconcile only roots an immutable
+    // owner stream on a stable id, so a `local:` (uncommitted) id would make it a no-op and the
+    // ghost would never heal, silently voiding the test.
+    run_git(&root, &["init"]);
+    run_git(&root, &["add", "."]);
+    run_git(&root, &[
+        "-c",
+        "user.name=Rag Rat Test",
+        "-c",
+        "user.email=rag-rat@example.invalid",
+        "commit",
+        "-m",
+        "initial",
+    ]);
+    let root = root.canonicalize().unwrap();
+
+    let mut config = source_config(root.clone(), Language::Rust);
+    config.llm.embedding.backend = HASH_MODEL_ID.parse().unwrap();
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    db.install_model(HASH_MODEL_ID, None).unwrap();
+
+    // Root the owner chain with a real authored memory — the realistic idle-repo precondition is a
+    // repo that ALREADY has signed history when a ghost slips in (exercises the INCREMENTAL heal,
+    // not genesis). Unanchored `Concept` per #465.
+    db.memory_create(crate::query::memory::RepoMemoryCreate {
+        kind: "Concept".to_string(),
+        title: "seed concept".to_string(),
+        body: "roots the owner chain".to_string(),
+        confidence: "high".to_string(),
+        created_by: Some("test-agent".to_string()),
+        source: Some("agent".to_string()),
+        tags: vec![],
+        payload_json: None,
+        bind: crate::query::memory::RepoMemoryBindTarget::default(),
+    })
+    .unwrap();
+
+    // A ghost written by RAW SQL — never authored into the signed log.
+    let conn = db.storage.connection();
+    let repo_id = crate::index::schema::active_repo_id(conn).unwrap();
+    conn.execute(
+        "INSERT INTO repo_memories(
+             id, kind, title, body, confidence, status, created_by, created_at_ms, updated_at_ms,
+             source, input_hash, memory_version, repo_id)
+         VALUES ('mem_ghost_583', 'Concept', 'ghost', 'raw-written ghost', 'high', 'active',
+             'raw', 1000, 1000, 'agent', 'h583', 'v1', ?1)",
+        [&repo_id],
+    )
+    .unwrap();
+
+    let ghost_in_projection = |conn: &rusqlite::Connection| -> i64 {
+        conn.query_row(
+            "SELECT COUNT(*) FROM oplog_projected_nodes WHERE node_id = 'mem_ghost_583'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap()
+    };
+    assert_eq!(ghost_in_projection(conn), 0, "the raw ghost is absent from the signed projection");
+
+    // The idle-repo backstop: a reconcile pass heals the ghost though no memory mutation ran.
+    db.reconcile_with_options_progress(crate::index::ai::ReconcileOptions::default(), |_| {})
+        .unwrap();
+
+    assert_eq!(
+        ghost_in_projection(db.storage.connection()),
+        1,
+        "the reconcile pass authored the idle-repo ghost into the signed log"
+    );
+
+    let _ = fs::remove_dir_all(root);
+}

--- a/crates/rag-rat-core/src/query/memory/mod.rs
+++ b/crates/rag-rat-core/src/query/memory/mod.rs
@@ -11,6 +11,11 @@ use std::collections::BTreeSet;
 
 pub use api::memory_evidence_for_symbol;
 pub(crate) use api::*;
+// The scope-READING reconcile entry (#541): reconciles the active repo's owner stream, reading
+// the repo id from the connection scope and no-oping under an absent/unstable scope.
+// Re-exported so the index reconcile path (the idle-repo ghost backstop, #583) can name it
+// across the private module.
+pub(crate) use authoring::backfill_memory_oplog;
 // The scope-explicit reconcile entry (#541): `authoring` is a PRIVATE module, so
 // `index::consolidate` names this through this re-export (Task 5 of #541).
 pub(crate) use authoring::reconcile_owner_stream_for_repo;


### PR DESCRIPTION
## Problem

The per-node op-log reconcile (#541) heals a "ghost" — a `repo_memories`/`repo_node_edges` row present in the tables but absent from the signed projection, left by a pre-#532 binary or a raw writer such as the `dream` passes — on the next **memory mutation** and on consolidation import. A repo that gets no subsequent memory mutation carries the ghost indefinitely, so its signed history stays incomplete.

## Fix

Run the same idempotent reconcile at the end of a successful index reconcile, so an idle repo self-heals. Both `rag-rat reconcile` and the watcher's incremental pass route through `IndexDatabase::reconcile_with_options_progress`, so one hook there covers every production idle-repo trigger. The hook is a thin `heal_memory_oplog_ghosts()` delegate (following the existing `ensure_coupling_fresh` convention) that calls the scope-reading `backfill_memory_oplog` on the reconcile connection.

Safe on the hot path: the reconcile probes with two read-only anti-joins that return **without a write lock** when nothing is missing, and it is a no-op under an absent/unstable scope (a `local:`/`__unassigned__` id). It runs after the embedding reconcile has committed, so its authored write (a durable `IMMEDIATE` txn, only when a ghost exists) never nests inside it; a heal error propagates rather than being swallowed.

## Scope

The two non-healing `IndexDatabase` reconcile variants (`reconcile` / `reconcile_with_progress`, which call the AI module directly) are used only by the eval harness and AI-module tests — not by the CLI or watcher — so the idle-repo backstop covers every real trigger.

## Tests

`reconcile_heals_an_op_log_ghost_in_an_idle_repo`: a committed git repo (stable repo_id) with the hash embedder, the owner chain rooted by an authored `Concept`, then a raw-SQL ghost inserted; the reconcile pass authors the ghost into the signed projection (asserted absent before, present after). Full `rag-rat-core` suite green (1917/1917) — the hook running on every reconcile regresses no existing reconcile/watcher test.

Fixes #583.
