### PR TITLE
fix(schema): don't let dev/test builds silently migrate the shared global DB (#585)

### DIFF
--- a/crates/rag-rat-cli/build.rs
+++ b/crates/rag-rat-cli/build.rs
@@ -1,0 +1,84 @@
+//! Stamps `RAG_RAT_VERSION` at build time: a plain `CARGO_PKG_VERSION` for a pristine release
+//! (built at a `v*` tag with a clean tree, or from a cargo-packaged crates.io source), else
+//! `<version>+g<short_hash>` (`.dirty` for uncommitted changes) for a git dev build, or
+//! `<version>+src` for a source tree with neither git nor cargo package metadata. So any build that
+//! isn't a vetted release names itself in `--version` and the migration-provenance record (#585),
+//! and the gate treats it as a dev build. The formatter is shared with the crate's tests via
+//! `include!`.
+
+use std::path::Path;
+use std::process::Command;
+
+include!("src/version_describe.rs");
+
+fn main() {
+    let pkg = std::env::var("CARGO_PKG_VERSION").unwrap_or_default();
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap_or_default();
+    let version = match git_state(&manifest_dir) {
+        Some(state) =>
+            describe_version(&pkg, state.exact_tag, Some(&state.short_hash), state.dirty),
+        // No git: a cargo-packaged (crates.io) build is a real release → plain version; a raw
+        // source tree (GitHub source archive, copied checkout) is NOT vetted → mark it `+src` so
+        // the migration gate (#585) sees the `+` and treats it as a dev build rather than a
+        // release.
+        None if is_packaged_release(&manifest_dir) => pkg,
+        None => format!("{pkg}+src"),
+    };
+    println!("cargo:rustc-env=RAG_RAT_VERSION={version}");
+    force_rerun();
+}
+
+/// A cargo-packaged build (what crates.io serves) carries `.cargo_vcs_info.json` beside its
+/// manifest; a raw source tree does not. Distinguishes a published release (plain version) from an
+/// untracked source build (marked `+src`, so #585 gates it like any other dev build).
+fn is_packaged_release(manifest_dir: &str) -> bool {
+    Path::new(manifest_dir).join(".cargo_vcs_info.json").exists()
+}
+
+struct GitState {
+    exact_tag: bool,
+    short_hash: String,
+    dirty: bool,
+}
+
+/// The git state for `dir`, or `None` when git is unavailable / this isn't the rag-rat repo. The
+/// toplevel-sentinel guard (`rag-rat.toml` at the repo root) means a copy of these sources vendored
+/// inside a FOREIGN git repo can't stamp that repo's hash — it degrades to the plain version.
+fn git_state(dir: &str) -> Option<GitState> {
+    let toplevel = git_output(dir, &["rev-parse", "--show-toplevel"])?;
+    if !Path::new(toplevel.trim()).join("rag-rat.toml").exists() {
+        return None;
+    }
+    let short_hash = git_output(dir, &["rev-parse", "--short=12", "HEAD"])?.trim().to_string();
+    if short_hash.is_empty() {
+        return None;
+    }
+    let exact_tag = Command::new("git")
+        .current_dir(dir)
+        .args(["describe", "--tags", "--match", "v*", "--exact-match", "HEAD"])
+        .output()
+        .map(|out| out.status.success())
+        .unwrap_or(false);
+    let dirty =
+        git_output(dir, &["status", "--porcelain"]).is_some_and(|out| !out.trim().is_empty());
+    Some(GitState { exact_tag, short_hash, dirty })
+}
+
+/// stdout of a successful `git` invocation in `dir`, else `None`.
+fn git_output(dir: &str, args: &[&str]) -> Option<String> {
+    let out = Command::new("git").current_dir(dir).args(args).output().ok()?;
+    out.status.success().then(|| String::from_utf8_lossy(&out.stdout).into_owned())
+}
+
+/// Re-run this build script on EVERY build. The stamp encodes the whole-worktree `git status` dirty
+/// bit and the HEAD hash, and NEITHER maps to a stable set of file triggers a `rerun-if-changed`
+/// could name: an uncommitted edit anywhere in the workspace changes `git status` but touches no
+/// git ref, and (because emitting any `rerun-if-changed` disables Cargo's default package scan) a
+/// plain stamp from a clean tag build would otherwise survive a later dirty `cargo install
+/// --force`. The migration gate (#585) keys on this stamp's `+g` suffix, so a stale one would
+/// misclassify a dirty dev build as a release and let it migrate the shared global DB. Depending on
+/// a path that never exists is Cargo's documented way to force a re-run every build; the script is
+/// cheap (a few `git` calls) and only the tiny leaf CLI crate carries it.
+fn force_rerun() {
+    println!("cargo:rerun-if-changed=RAG_RAT_ALWAYS_RESTAMP");
+}

--- a/crates/rag-rat-cli/src/cli.rs
+++ b/crates/rag-rat-cli/src/cli.rs
@@ -10,7 +10,7 @@ use clap::{Args, Parser, Subcommand, ValueEnum};
 #[derive(Debug, Parser)]
 #[command(
     name = "rag-rat",
-    version,
+    version = env!("RAG_RAT_VERSION"),
     about = "Local repo-intelligence index, graph, history, and memory — CLI + MCP server.",
     propagate_version = true
 )]

--- a/crates/rag-rat-cli/src/main.rs
+++ b/crates/rag-rat-cli/src/main.rs
@@ -3,6 +3,10 @@ mod commands;
 mod fs_atomic;
 mod hooks_support;
 mod render;
+// The version-string formatter is shared with `build.rs` via `include!`; the crate only needs it
+// under test (the runtime reads the baked `RAG_RAT_VERSION`), so compiling it here is test-only.
+#[cfg(test)]
+mod version_describe;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -54,6 +58,9 @@ fn configure_jemalloc() {
 }
 
 fn main() -> anyhow::Result<()> {
+    // Record this binary's git-stamped version (#585) so migration provenance and the stranded-
+    // binary refusal name a dev build (`0.16.0+g<hash>`) distinctly from a release (`0.16.0`).
+    rag_rat_core::set_binary_version(env!("RAG_RAT_VERSION"));
     #[cfg(not(target_env = "msvc"))]
     configure_jemalloc();
     let cli = Cli::parse();

--- a/crates/rag-rat-cli/src/version_describe.rs
+++ b/crates/rag-rat-cli/src/version_describe.rs
@@ -1,0 +1,67 @@
+// Pure version-string formatting shared by `build.rs` (which stamps `RAG_RAT_VERSION` at build
+// time from the git state) and its unit tests. `include!`d verbatim by `build.rs` (so it must use
+// only `//` comments — an inner `//!` doc is illegal at an include point); compiled into the crate
+// itself only under `cfg(test)` (the runtime reads the baked `RAG_RAT_VERSION`, never this fn), so
+// it carries no dead code in a release build.
+
+/// The reported version string. Plain `pkg` for a pristine release — built at an exact release tag
+/// with a clean tree, or with no git at all (a crates.io tarball / prebuilt binary). Otherwise
+/// `pkg+g<short_hash>`, with a trailing `.dirty` when the working tree has uncommitted changes — so
+/// a development build names itself in `--version` and in the migration-provenance record (#585).
+pub(crate) fn describe_version(
+    pkg: &str,
+    exact_tag: bool,
+    short_hash: Option<&str>,
+    dirty: bool,
+) -> String {
+    match short_hash {
+        // No git → a released tarball / prebuilt binary: report the plain version.
+        None => pkg.to_string(),
+        // A pristine release: exactly on a tag with nothing uncommitted.
+        Some(_) if exact_tag && !dirty => pkg.to_string(),
+        // Anything else is a development build — fingerprint it.
+        Some(hash) => {
+            let mut version = format!("{pkg}+g{hash}");
+            if dirty {
+                version.push_str(".dirty");
+            }
+            version
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::describe_version;
+
+    #[test]
+    fn pristine_release_tag_reads_plain() {
+        assert_eq!(describe_version("0.16.0", true, Some("abc1234"), false), "0.16.0");
+    }
+
+    #[test]
+    fn no_git_reads_plain() {
+        assert_eq!(describe_version("0.16.0", false, None, false), "0.16.0");
+    }
+
+    #[test]
+    fn off_tag_gets_a_hash_suffix() {
+        assert_eq!(describe_version("0.16.0", false, Some("abc1234"), false), "0.16.0+gabc1234");
+    }
+
+    #[test]
+    fn uncommitted_tree_is_marked_dirty() {
+        assert_eq!(
+            describe_version("0.16.0", false, Some("abc1234"), true),
+            "0.16.0+gabc1234.dirty"
+        );
+    }
+
+    #[test]
+    fn a_dirty_tree_even_at_a_tag_is_not_a_pristine_release() {
+        assert_eq!(
+            describe_version("0.16.0", true, Some("abc1234"), true),
+            "0.16.0+gabc1234.dirty"
+        );
+    }
+}

--- a/crates/rag-rat-core/src/index/lifecycle.rs
+++ b/crates/rag-rat-core/src/index/lifecycle.rs
@@ -65,6 +65,12 @@ impl IndexDatabase {
         // (read/MCP/init open) still takes the real lock. Compatible/Newer/Dirty/Missing
         // need no lock — `ensure_compatible_or_migrate` returns or refuses without writing.
         if schema::status(storage.connection())?.state == schema::SchemaState::Older {
+            // #585: refuse a dev/test build's silent forward-migration of the shared global store
+            // BEFORE taking the schema lock — on a box with one global DB the newest-migration
+            // binary otherwise wins the schema race for every process. Installed binaries and
+            // RAG_RAT_ALLOW_MIGRATE proceed; per-repo/temp DBs are never gated.
+            super::migration_gate::MigrationGate::from_env()
+                .ensure_migration_permitted(path, schema::SchemaState::Older)?;
             // A6: the GLOBAL schema lock, not a per-repo write lock — a migration rewrites the
             // shared ladder (every repo's tables), so it serializes across all repos.
             // Reentrant on the holding thread, so a CLI write command that opens under
@@ -469,7 +475,13 @@ impl IndexDatabase {
                         "timed out waiting for the schema-migration lock to apply the schema"
                     )
                 })?;
-        if schema::status(conn)?.state != schema::SchemaState::Compatible {
+        let state = schema::status(conn)?.state;
+        if state != schema::SchemaState::Compatible {
+            // #585: a dev/test build must not silently forward-migrate the shared global store —
+            // it would strand every process still on an older binary. Refused here (Older only;
+            // Missing is first-time init) unless RAG_RAT_ALLOW_MIGRATE / an installed binary.
+            super::migration_gate::MigrationGate::from_env()
+                .ensure_migration_permitted(path, state)?;
             schema::apply(conn)?;
         }
         Ok(())

--- a/crates/rag-rat-core/src/index/migration_gate.rs
+++ b/crates/rag-rat-core/src/index/migration_gate.rs
@@ -1,0 +1,234 @@
+//! Migration provenance gate (#585): a dev/test build must not silently forward-migrate the SHARED
+//! GLOBAL store.
+//!
+//! On a box with one consolidated global DB and many long-lived processes (watcher, git hooks, MCP
+//! servers on the installed binary), whichever binary knows the newest migration wins the schema
+//! race for everyone — the moment a dev/test build opens the global store write-capable and applies
+//! a forward migration, every process still on an older binary refuses the now-newer schema
+//! (`SchemaState::Newer`). Migrations are forward-only, so there is no undo: the result is a
+//! fleet-wide loss of index access until a matching binary is installed.
+//!
+//! So an `Older` global store is migrated only by an installed release binary, or under an explicit
+//! `RAG_RAT_ALLOW_MIGRATE=1` operator override. Per-repo / temp DBs (the whole test suite,
+//! single-binary machines) and first-time `Missing` init keep migrating automatically — there is no
+//! fleet to strand in those cases.
+
+use std::path::{Path, PathBuf};
+
+use super::schema::SchemaState;
+
+/// Operator escape hatch: set truthy to let a dev/test build migrate the global store anyway.
+const ALLOW_MIGRATE_ENV: &str = "RAG_RAT_ALLOW_MIGRATE";
+
+/// The inputs the migration gate decides on. INJECTED (not read from the ambient environment inside
+/// the decision) so the refusal is unit-testable without mutating process-global env or faking
+/// `current_exe`; [`MigrationGate::from_env`] builds the real-world instance.
+pub(crate) struct MigrationGate {
+    /// This binary is a development build, not a pristine release. Three signals feed it in
+    /// [`from_env`](Self::from_env): `debug_assertions` and [`running_from_target_dir`] catch
+    /// `cargo run`/`test`/`build`, and [`version_indicates_dev_build`] catches a release-profile
+    /// dev binary installed OUTSIDE a `target/` dir (`cargo install --path .` off a branch) by its
+    /// `+g<hash>` version stamp.
+    pub is_dev_build: bool,
+    /// `RAG_RAT_ALLOW_MIGRATE` is set truthy.
+    pub allow_override: bool,
+    /// The consolidated global store path, if one resolves (`data_dir::global_database_path`).
+    pub global_db_path: Option<PathBuf>,
+}
+
+impl MigrationGate {
+    /// Build the gate from the real environment (the wiring the live open paths use).
+    pub(crate) fn from_env() -> Self {
+        Self {
+            is_dev_build: cfg!(debug_assertions)
+                || running_from_target_dir()
+                || version_indicates_dev_build(crate::binary_version()),
+            allow_override: env_flag(ALLOW_MIGRATE_ENV),
+            global_db_path: crate::data_dir::global_database_path(),
+        }
+    }
+
+    /// Refuse a schema apply that ADVANCES an existing global store from a dev/test build. `Older`
+    /// (forward migration) and `Dirty` (an `index --full` recovery, which re-applies the ladder to
+    /// this binary's latest) both advance the schema and can strand the fleet; `Missing` is
+    /// first-time init (no fleet to strand) and `Compatible`/`Newer` never apply forward, so those
+    /// pass. Returns `Ok(())` when the apply may proceed.
+    pub(crate) fn ensure_migration_permitted(
+        &self,
+        db_path: &Path,
+        state: SchemaState,
+    ) -> anyhow::Result<()> {
+        // Both `Older` (auto forward-migrate) and `Dirty` (`create_or_migrate` → `schema::apply`
+        // recovery) run the ladder to THIS binary's LATEST on an existing store, so a dev binary
+        // doing either bumps the shared schema past installed releases. `Missing` is first-time
+        // init (nothing to strand); `Compatible`/`Newer` never apply forward. An installed
+        // release binary, or an explicit operator override, always proceeds.
+        let advances_existing_schema = matches!(state, SchemaState::Older | SchemaState::Dirty);
+        if !advances_existing_schema || !self.is_dev_build || self.allow_override {
+            return Ok(());
+        }
+        let Some(global) = self.global_db_path.as_deref() else {
+            return Ok(());
+        };
+        if !same_file(db_path, global) {
+            return Ok(());
+        }
+        anyhow::bail!(
+            "refusing to auto-migrate the shared global index ({}) from a development build: it \
+             would forward-migrate the schema for every rag-rat process on this machine and \
+             strand any still on an older binary (#585). Install a released rag-rat and let it \
+             migrate, or re-run with {ALLOW_MIGRATE_ENV}=1 to override.",
+            global.display()
+        )
+    }
+}
+
+/// Whether the running executable lives under a Cargo `target/` build directory — the signal that
+/// distinguishes a `cargo run` / `cargo test` / `cargo build` binary from an installed one. Matches
+/// a path COMPONENT named `target` (not a substring), and FAILS OPEN — an unreadable `current_exe`
+/// is treated as installed, so a platform that can't resolve it never over-refuses a real release.
+fn running_from_target_dir() -> bool {
+    std::env::current_exe()
+        .ok()
+        .is_some_and(|exe| exe.components().any(|component| component.as_os_str() == "target"))
+}
+
+/// Whether a git-stamped version string denotes a development build rather than a pristine release.
+/// `build.rs` stamps `<pkg>+g<hash>` (a semver local-version segment) for anything not built at an
+/// exact release tag; a real release is the bare `<pkg>`. So the presence of `+` is the build
+/// provenance that catches a dev binary installed OUTSIDE a `target/` dir (`cargo install --path .`
+/// off a branch) — which `debug_assertions` and the exe-path check miss (#585, Codex P1).
+fn version_indicates_dev_build(version: &str) -> bool {
+    version.contains('+')
+}
+
+/// A truthy env flag: set, non-empty, and not `0`/`false`.
+fn env_flag(key: &str) -> bool {
+    std::env::var(key).is_ok_and(|value| {
+        let value = value.trim();
+        !value.is_empty() && value != "0" && !value.eq_ignore_ascii_case("false")
+    })
+}
+
+/// Whether `a` and `b` name the same on-disk file, comparing CANONICAL paths — a bare/MCP open
+/// arrives as a client-supplied string, so a symlinked `$HOME` (or `/tmp`) would break literal
+/// equality. Both sides are canonicalized (per the `strip_prefix` two-sided-canonicalize rule);
+/// falls back to literal comparison when either path can't be canonicalized.
+fn same_file(a: &Path, b: &Path) -> bool {
+    match (a.canonicalize(), b.canonicalize()) {
+        (Ok(a), Ok(b)) => a == b,
+        _ => a == b,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::TempDir;
+
+    use super::*;
+
+    /// A gate whose global store is `global`, with the dev/override knobs set explicitly.
+    fn gate(global: &Path, is_dev_build: bool, allow_override: bool) -> MigrationGate {
+        MigrationGate { is_dev_build, allow_override, global_db_path: Some(global.to_path_buf()) }
+    }
+
+    /// Create the global store file so `canonicalize` resolves it.
+    fn global_store() -> (TempDir, PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("rag-rat.sqlite");
+        fs::write(&path, b"db").unwrap();
+        (dir, path)
+    }
+
+    #[test]
+    fn a_release_version_is_not_a_dev_build() {
+        assert!(!version_indicates_dev_build("0.15.0"));
+        assert!(!version_indicates_dev_build("1.2.3"));
+    }
+
+    #[test]
+    fn a_git_stamped_version_is_a_dev_build() {
+        assert!(version_indicates_dev_build("0.15.0+g7eb89f28b5ae"));
+        assert!(version_indicates_dev_build("0.15.0+g7eb89f28b5ae.dirty"));
+    }
+
+    #[test]
+    fn dev_build_refuses_to_migrate_the_global_store() {
+        let (_dir, global) = global_store();
+        let err = gate(&global, true, false)
+            .ensure_migration_permitted(&global, SchemaState::Older)
+            .expect_err("a dev build must refuse to migrate the global store");
+        assert!(
+            err.to_string().contains("global"),
+            "refusal should name the global store; got: {err}"
+        );
+    }
+
+    #[test]
+    fn override_lets_a_dev_build_migrate_the_global_store() {
+        let (_dir, global) = global_store();
+        gate(&global, true, true)
+            .ensure_migration_permitted(&global, SchemaState::Older)
+            .expect("RAG_RAT_ALLOW_MIGRATE overrides the gate");
+    }
+
+    #[test]
+    fn installed_build_migrates_the_global_store() {
+        let (_dir, global) = global_store();
+        gate(&global, false, false)
+            .ensure_migration_permitted(&global, SchemaState::Older)
+            .expect("an installed release binary may migrate the global store");
+    }
+
+    #[test]
+    fn dev_build_migrates_a_per_repo_store() {
+        let (_dir, global) = global_store();
+        let per_repo = _dir.path().join("index.sqlite");
+        fs::write(&per_repo, b"db").unwrap();
+        gate(&global, true, false)
+            .ensure_migration_permitted(&per_repo, SchemaState::Older)
+            .expect("a per-repo/temp DB is never gated");
+    }
+
+    #[test]
+    fn dev_build_may_initialize_a_missing_global_store() {
+        let (_dir, global) = global_store();
+        gate(&global, true, false)
+            .ensure_migration_permitted(&global, SchemaState::Missing)
+            .expect("first-time Missing init is not gated — no fleet to strand");
+    }
+
+    #[test]
+    fn dev_build_refuses_to_recover_a_dirty_global_store() {
+        // `index --full` recovery (`create_or_migrate` → `schema::apply`) advances a Dirty store to
+        // this binary's latest, so it strands the fleet exactly like an Older forward-migration.
+        let (_dir, global) = global_store();
+        let err = gate(&global, true, false)
+            .ensure_migration_permitted(&global, SchemaState::Dirty)
+            .expect_err("a dev build must not recover (advance) a dirty global store");
+        assert!(err.to_string().contains("global"), "got: {err}");
+    }
+
+    #[test]
+    fn dev_build_may_open_a_newer_global_store() {
+        // A Newer store was migrated by a FUTURE binary; this (older) dev binary can't advance it,
+        // so there is nothing to gate — the open refuses for a different reason (unknown
+        // migration).
+        let (_dir, global) = global_store();
+        gate(&global, true, false)
+            .ensure_migration_permitted(&global, SchemaState::Newer)
+            .expect("Newer is not gated — an older dev binary cannot advance the schema");
+    }
+
+    #[test]
+    fn no_global_store_path_never_gates() {
+        let (_dir, some_db) = global_store();
+        let no_global =
+            MigrationGate { is_dev_build: true, allow_override: false, global_db_path: None };
+        no_global
+            .ensure_migration_permitted(&some_db, SchemaState::Older)
+            .expect("without a resolvable global store, nothing is gated");
+    }
+}

--- a/crates/rag-rat-core/src/index/mod.rs
+++ b/crates/rag-rat-core/src/index/mod.rs
@@ -28,6 +28,7 @@ mod incremental;
 mod lifecycle;
 mod mem_diag;
 mod meta;
+mod migration_gate;
 mod packages;
 mod parser_failures;
 mod prep;

--- a/crates/rag-rat-core/src/index/schema/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema/migrations.rs
@@ -1391,6 +1391,65 @@ pub(crate) fn record_migration(
     Ok(())
 }
 
+/// GLOBAL `index_meta` keys recording WHO last brought this store's schema current (#585). About
+/// the DB file, not a repo — so they live in `index_meta`, not `repo_meta`. Overwritten each time a
+/// migration/create runs, so a stranded fleet is diagnosable in one query instead of forensics.
+pub(crate) const MIGRATION_PROVENANCE_KEYS: &[&str] = &[
+    "last_migration_binary_version",
+    "last_migration_binary_exe",
+    "last_migration_to_version",
+    "last_migration_at_ms",
+];
+
+/// Stamp the migration-provenance keys after the schema is brought current. The binary version is
+/// [`crate::binary_version`] (the CLI's git-stamped `RAG_RAT_VERSION`, else `CARGO_PKG_VERSION`),
+/// so a dev build that migrates a shared store leaves a `+g<hash>` fingerprint that names it.
+///
+/// ONE atomic multi-row upsert: statement-level atomicity means a mid-write failure (e.g. a
+/// concurrent writer's `SQLITE_BUSY`) leaves NO partial provenance — all four keys land or none do,
+/// so the reader never sees a half-written record. Call sites treat a failure here as best-effort
+/// (the migration already committed; provenance is diagnostic), so a stamp failure never fails the
+/// migration — it just leaves the record absent until the next one, which the reader handles.
+pub(crate) fn record_migration_provenance(conn: &Connection) -> rusqlite::Result<()> {
+    let exe =
+        std::env::current_exe().ok().map(|path| path.display().to_string()).unwrap_or_default();
+    conn.execute(
+        "INSERT INTO index_meta(key, value) VALUES (?1, ?2), (?3, ?4), (?5, ?6), (?7, ?8) ON \
+         CONFLICT(key) DO UPDATE SET value = excluded.value",
+        params![
+            MIGRATION_PROVENANCE_KEYS[0],
+            crate::binary_version(),
+            MIGRATION_PROVENANCE_KEYS[1],
+            exe,
+            MIGRATION_PROVENANCE_KEYS[2],
+            LATEST_SCHEMA_VERSION.to_string(),
+            MIGRATION_PROVENANCE_KEYS[3],
+            now_ms().to_string(),
+        ],
+    )?;
+    Ok(())
+}
+
+/// A human note naming who last migrated this store, appended to the `Newer` refusal (#585). Empty
+/// when no provenance is recorded (an older DB, or one never migrated by a provenance-aware
+/// binary). Defensive: any read error yields "" — `status` must never fail on a weird DB.
+pub(crate) fn migration_provenance_note(conn: &Connection) -> String {
+    let read = |key: &str| -> Option<String> {
+        conn.query_row("SELECT value FROM index_meta WHERE key = ?1", [key], |row| {
+            row.get::<_, String>(0)
+        })
+        .ok()
+        .filter(|value| !value.is_empty())
+    };
+    match (read("last_migration_binary_version"), read("last_migration_binary_exe")) {
+        (Some(version), Some(exe)) => {
+            format!("; the index was last migrated by rag-rat {version} at {exe}")
+        },
+        (Some(version), None) => format!("; the index was last migrated by rag-rat {version}"),
+        _ => String::new(),
+    }
+}
+
 pub(crate) fn table_exists(conn: &Connection, table: &str) -> anyhow::Result<bool> {
     let exists = conn
         .query_row(

--- a/crates/rag-rat-core/src/index/schema/mod.rs
+++ b/crates/rag-rat-core/src/index/schema/mod.rs
@@ -536,6 +536,10 @@ pub fn apply(conn: &Connection) -> rusqlite::Result<()> {
     // clear it, or the remedy would leave the DB refusing every open forever (#498). A crash
     // before this point keeps the marker, so a genuinely torn apply still reads as Dirty.
     conn.execute("DELETE FROM schema_version WHERE id = ?1", [DIRTY_MIGRATION_ID])?;
+    // #585: record which binary brought the schema current, so a stranded fleet is diagnosable.
+    // Best-effort: the schema is already applied, and provenance is diagnostic — a stamp failure
+    // must not fail the migration (the reader tolerates an absent record).
+    let _ = record_migration_provenance(conn);
     Ok(())
 }
 
@@ -917,6 +921,10 @@ pub fn migrate_forward(conn: &Connection) -> anyhow::Result<()> {
             record_migration(conn, step.id, step.checksum, step.description)?;
         }
     }
+    // #585: this path only runs when a forward migration actually happened (early-returned above
+    // otherwise) — stamp who did it (the shared-store stranding path). Best-effort: the migration
+    // has committed; a diagnostic stamp failure must not fail it (the reader tolerates absence).
+    let _ = record_migration_provenance(conn);
     Ok(())
 }
 
@@ -988,13 +996,17 @@ pub fn status(conn: &Connection) -> anyhow::Result<SchemaStatus> {
             current_version: known_version(&migrations),
             latest_version: LATEST_SCHEMA_VERSION,
             migrations,
-            // #484: on a shared global DB one upgraded agent migrates the schema and every
-            // process still on an older binary lands here — the refusal must carry the remedy,
-            // because it surfaces as the error text of every CLI/MCP open.
+            // #484/#585: on a shared global DB one upgraded agent migrates the schema and every
+            // process still on an older binary lands here — the refusal must carry the remedy AND
+            // name this binary's schema ceiling + WHO migrated the store (from provenance), because
+            // it surfaces as the error text of every CLI/MCP open and is how a fleet outage is
+            // diagnosed.
             message: format!(
-                "index schema was created by a newer rag-rat; refusing to open — upgrade rag-rat \
-                 or restart sessions/servers still running an older binary{}",
-                hot_upgrade_caveat()
+                "index schema was created by a newer rag-rat; refusing to open — this rag-rat \
+                 supports up to schema v{LATEST_SCHEMA_VERSION}, so upgrade rag-rat or restart \
+                 sessions/servers still running an older binary{}{}",
+                hot_upgrade_caveat(),
+                migration_provenance_note(conn),
             ),
         });
     }

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/migration_gate_wiring.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/migration_gate_wiring.rs
@@ -1,0 +1,105 @@
+//! Wiring for the #585 migration gate: opening/migrating an `Older` GLOBAL store from a dev build
+//! must be refused through the real open paths (both funnels — `open_and_migrate` and
+//! `apply_schema_under_lock`), while an explicit override lets it through. The decision matrix
+//! itself is unit-tested in `index::migration_gate`; these tests pin that the live paths CALL it.
+//!
+//! The test process is itself a dev build (`cfg!(debug_assertions)` + a `target/` exe), so the gate
+//! sees `is_dev_build == true` without any faking — exactly the incident configuration.
+
+use std::path::Path;
+use std::sync::{Mutex, PoisonError};
+
+use rusqlite::Connection;
+
+use super::unique_temp_root;
+use crate::index::{IndexDatabase, schema};
+
+/// Serializes the env-mutating global-store tests (`RAG_RAT_DATA_DIR` / `RAG_RAT_ALLOW_MIGRATE` are
+/// process-global). nextest's process-per-test isolation makes it moot in CI; the mutex keeps a
+/// thread-based `cargo test` honest.
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+/// Point `data_dir::global_database_path` at a fresh temp dir and run `body` with the global store
+/// path, optionally with `RAG_RAT_ALLOW_MIGRATE=1`. Restores the prior environment afterward.
+fn with_global_store(allow_migrate: bool, body: impl FnOnce(&Path)) {
+    let _guard = ENV_LOCK.lock().unwrap_or_else(PoisonError::into_inner);
+    let data_dir = unique_temp_root();
+    std::fs::create_dir_all(&data_dir).unwrap();
+    let global = data_dir.join("rag-rat.sqlite");
+
+    let saved_data_dir = std::env::var_os("RAG_RAT_DATA_DIR");
+    let saved_allow = std::env::var_os("RAG_RAT_ALLOW_MIGRATE");
+    // SAFETY: env access is serialized by ENV_LOCK for the duration of this call.
+    unsafe {
+        std::env::set_var("RAG_RAT_DATA_DIR", &data_dir);
+        if allow_migrate {
+            std::env::set_var("RAG_RAT_ALLOW_MIGRATE", "1");
+        } else {
+            std::env::remove_var("RAG_RAT_ALLOW_MIGRATE");
+        }
+    }
+
+    body(&global);
+
+    // SAFETY: same serialized scope; restore the prior values.
+    unsafe {
+        match saved_data_dir {
+            Some(value) => std::env::set_var("RAG_RAT_DATA_DIR", value),
+            None => std::env::remove_var("RAG_RAT_DATA_DIR"),
+        }
+        match saved_allow {
+            Some(value) => std::env::set_var("RAG_RAT_ALLOW_MIGRATE", value),
+            None => std::env::remove_var("RAG_RAT_ALLOW_MIGRATE"),
+        }
+    }
+}
+
+/// Create the global store at `path` and roll it back to look `Older` (drop the newest migration
+/// row so `current_version < LATEST`). First-time init (`Missing`) is never gated, so this succeeds
+/// even from a dev build.
+fn older_global_store(path: &Path) {
+    IndexDatabase::migrate(path).expect("first-time global-store init is not gated");
+    let conn = Connection::open(path).unwrap();
+    conn.execute(
+        "DELETE FROM schema_version WHERE id = (SELECT id FROM schema_version ORDER BY id DESC \
+         LIMIT 1)",
+        [],
+    )
+    .unwrap();
+    assert_eq!(
+        schema::status(&conn).unwrap().state,
+        schema::SchemaState::Older,
+        "fixture must be Older before the gated open"
+    );
+}
+
+#[test]
+fn dev_build_refuses_to_migrate_an_older_global_store_via_migrate() {
+    with_global_store(false, |global| {
+        older_global_store(global);
+        let err = IndexDatabase::migrate(global)
+            .expect_err("apply_schema_under_lock funnel must refuse the global store");
+        assert!(err.to_string().contains("global"), "got: {err}");
+    });
+}
+
+#[test]
+fn dev_build_refuses_to_open_an_older_global_store() {
+    with_global_store(false, |global| {
+        older_global_store(global);
+        let err = IndexDatabase::open(global)
+            .map(|_| ())
+            .expect_err("open_and_migrate funnel must refuse the global store");
+        assert!(err.to_string().contains("global"), "got: {err}");
+    });
+}
+
+#[test]
+fn allow_migrate_override_lets_a_dev_build_migrate_the_global_store() {
+    with_global_store(true, |global| {
+        older_global_store(global);
+        let status = IndexDatabase::migrate(global)
+            .expect("RAG_RAT_ALLOW_MIGRATE=1 lets a dev build migrate the global store");
+        assert_eq!(status.state, schema::SchemaState::Compatible);
+    });
+}

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/mod.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/mod.rs
@@ -905,6 +905,7 @@ mod git_history_reload;
 mod github_papertrail;
 mod graph_edges;
 mod head_move_carry;
+mod migration_gate_wiring;
 mod multi_repo_scope;
 mod orientation_healing;
 mod reconcile_embeddings;

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
@@ -665,6 +665,10 @@ fn compatible_open_refuses_dirty_and_newer_schema() {
     // the schema and every older-binary process hits this, so a bare refusal reads as breakage.
     assert!(err.contains("upgrade rag-rat"), "{err}");
     assert!(err.contains("restart"), "{err}");
+    // #585: it also names this binary's schema ceiling. (This fixture never recorded provenance —
+    // no index_meta — so the "who migrated" clause is correctly absent; the defensive note yields
+    // "".)
+    assert!(err.contains(&format!("schema v{}", schema::LATEST_SCHEMA_VERSION)), "{err}");
     // The fleet hot-upgrade re-execs armed MCP servers only on Linux; elsewhere the message must
     // say running servers stay stale until their sessions restart.
     if cfg!(target_os = "linux") {
@@ -1839,4 +1843,95 @@ fn migration_046_deferred_absence_and_reconverges_from_torn_state() {
         [],
     )
     .expect("a new content_hash is a distinct summary row");
+}
+
+/// #585: bringing the schema current records WHO did it into the global `index_meta`, so a stranded
+/// fleet is diagnosable in one query instead of forensics. Covers the `schema::apply` (create /
+/// funnel-2) path.
+#[test]
+fn applying_the_schema_records_migration_provenance() {
+    use rusqlite::OptionalExtension;
+
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn).unwrap();
+    let read = |key: &str| -> Option<String> {
+        conn.query_row("SELECT value FROM index_meta WHERE key = ?1", [key], |row| row.get(0))
+            .optional()
+            .unwrap()
+    };
+
+    assert_eq!(
+        read("last_migration_to_version").as_deref(),
+        Some(schema::LATEST_SCHEMA_VERSION.to_string().as_str()),
+        "provenance records the schema version migrated TO"
+    );
+    assert_eq!(
+        read("last_migration_binary_version").as_deref(),
+        Some(crate::binary_version()),
+        "provenance records this binary's version string"
+    );
+    assert!(read("last_migration_binary_exe").is_some(), "provenance records the binary path");
+    assert!(
+        read("last_migration_at_ms").and_then(|value| value.parse::<i64>().ok()).unwrap_or(0) > 0,
+        "provenance records a timestamp"
+    );
+}
+
+/// #585: the `Newer`-schema refusal (what every stranded process prints) names this binary's schema
+/// ceiling AND who last migrated the store, so the fleet outage is diagnosable from the error text.
+#[test]
+fn newer_schema_refusal_names_the_migrating_binary_and_ceiling() {
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn).unwrap(); // stamps provenance for THIS binary
+    // Fabricate a Newer schema: an applied migration this binary doesn't know.
+    conn.execute(
+        "INSERT INTO schema_version(id, applied_at_ms, checksum, description) VALUES \
+         ('999_from_the_future', 0, 'sha256:future', 'a migration this binary lacks')",
+        [],
+    )
+    .unwrap();
+
+    let status = schema::status(&conn).unwrap();
+    assert_eq!(status.state, schema::SchemaState::Newer);
+    assert!(
+        status.message.contains(crate::binary_version()),
+        "refusal should name the migrating binary version; got: {}",
+        status.message
+    );
+    assert!(
+        status.message.contains(&schema::LATEST_SCHEMA_VERSION.to_string()),
+        "refusal should name this binary's schema ceiling; got: {}",
+        status.message
+    );
+}
+
+/// #585: a forward migration of an existing store (the `migrate_forward` funnel) also stamps
+/// provenance — the stranding path, not just create.
+#[test]
+fn forward_migration_records_migration_provenance() {
+    use rusqlite::OptionalExtension;
+
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn).unwrap();
+    // Roll back one migration and clear provenance, then forward-migrate.
+    conn.execute(
+        "DELETE FROM schema_version WHERE id = (SELECT id FROM schema_version ORDER BY id DESC \
+         LIMIT 1)",
+        [],
+    )
+    .unwrap();
+    conn.execute("DELETE FROM index_meta WHERE key LIKE 'last_migration_%'", []).unwrap();
+    assert_eq!(schema::status(&conn).unwrap().state, schema::SchemaState::Older);
+
+    schema::migrate_forward(&conn).unwrap();
+
+    let to: Option<String> = conn
+        .query_row(
+            "SELECT value FROM index_meta WHERE key = 'last_migration_to_version'",
+            [],
+            |row| row.get(0),
+        )
+        .optional()
+        .unwrap();
+    assert_eq!(to.as_deref(), Some(schema::LATEST_SCHEMA_VERSION.to_string().as_str()));
 }

--- a/crates/rag-rat-core/src/lib.rs
+++ b/crates/rag-rat-core/src/lib.rs
@@ -29,6 +29,23 @@ pub use config::{Config, ResolvedTarget, TargetKind, WatchConfig};
 pub use index::{IndexDatabase, IndexStatus};
 pub use output::{OutputFormat, render};
 
+/// The running binary's version string, for migration provenance (#585) and diagnostics. The CLI
+/// sets it once at startup from its git-stamped `RAG_RAT_VERSION` (a dev build reads e.g.
+/// `0.16.0+g<hash>`, a tagged release `0.16.0`); left unset (library callers, tests) it falls back
+/// to this crate's compile-time `CARGO_PKG_VERSION`.
+static BINARY_VERSION: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+
+/// Record the running binary's version once, at process startup. Idempotent: only the first call
+/// wins, so a later mistaken call can't rewrite provenance mid-run.
+pub fn set_binary_version(version: impl Into<String>) {
+    let _ = BINARY_VERSION.set(version.into());
+}
+
+/// The version string [`set_binary_version`] recorded, or this crate's `CARGO_PKG_VERSION` default.
+pub fn binary_version() -> &'static str {
+    BINARY_VERSION.get().map(String::as_str).unwrap_or(env!("CARGO_PKG_VERSION"))
+}
+
 /// Lightweight, lock-free count of active repo memories whose anchor is `gone`/`stale` — the same
 /// population `memory_doctor` lists. Opens a BARE read-only connection (no git resolution, scope
 /// view, or schema migration), so it is cheap enough to call on every MCP tool result to nudge the


### PR DESCRIPTION
## What & why

`open` / `open_config` auto-migrate the schema forward on any write-capable open. On a machine with one shared consolidated global DB and many long-lived processes (watcher, git hooks, MCP servers on the installed binary), a development or test build that opened the global store would silently forward-migrate its schema — and every process still on an older binary then refuses the now-newer schema (forward-only migrations, no undo). The result is a fleet-wide loss of index access until a matching binary is installed. This happened on a shared dev box: a `cargo test` binary and a dev build installed to `~/.cargo/bin` each migrated the global schema out from under the released binary.

## What changed

**Gate dev/test builds from migrating the shared global store.** A forward migration (`SchemaState::Older`) of the global store is refused when the running binary is a development build — a `target/`-dir or `debug_assertions` binary, or one whose git-stamped version carries a `+g<hash>` suffix (a `cargo install --path .` build off a branch, installed outside `target/`). Installed releases, per-repo/temp DBs, and first-time (`Missing`) init are never gated; `RAG_RAT_ALLOW_MIGRATE=1` is the operator override. The gate sits at both apply funnels (`open_and_migrate` and `apply_schema_under_lock`), before the schema lock, and recognizes the global store by a canonicalized path match against `data_dir::global_database_path()`.

**Migration provenance + a friendlier stranded-binary error.** Bringing the schema current stamps who did it into the global `index_meta` (binary version, exe path, target schema version, timestamp) in one atomic, best-effort write. The `Newer`-schema refusal — the error every stranded process prints — now names this binary's schema ceiling and, from that provenance, which binary last migrated the store, so a fleet outage is diagnosable from the error text alone.

**Git-stamped version.** A `build.rs` stamps `RAG_RAT_VERSION`: a plain `CARGO_PKG_VERSION` for a pristine release (built at a `v*` tag with a clean tree, or with no git — a crates.io tarball / prebuilt binary), else `<version>+g<short_hash>` (`.dirty` for uncommitted changes). `--version` and the provenance record read it, so a dev build reports `0.15.0+gABC…` where a release reports `0.15.0` — the last-mile fingerprint for a dev binary that migrated a shared store.

## Tests

TDD throughout: the gate decision matrix (unit) and both funnels refusing an `Older` global store (integration); provenance recorded on `apply` and `migrate_forward`; the `Newer` refusal naming ceiling + migrator; the pure version formatter. Full workspace suite green; both clippy gates (`--no-default-features` and `--features eval`, `-D warnings`) clean.

Fixes #585.
