### PR TITLE
fix(mcp): boot a dormant server outside a rag-rat repo instead of dying (#603)

### DIFF
--- a/crates/rag-rat-cli/src/claude_hook/mod.rs
+++ b/crates/rag-rat-cli/src/claude_hook/mod.rs
@@ -668,18 +668,12 @@ pub fn format_digest(o: &Orientation, live: bool, enabled: bool) -> String {
     out
 }
 
-/// Walk up from the hook's cwd to the nearest rag-rat.toml. `None` ⇒ not a rag-rat repo ⇒
-/// silent no-op (what makes `--global` install safe).
+/// Walk up from the hook's cwd to the nearest rag-rat.toml and load it. `None` ⇒ not a rag-rat repo
+/// ⇒ silent no-op (what makes `--global` install safe). Shares the upward-walk primitive with
+/// `Config::load`'s discovery seam ([`rag_rat_core::config::nearest_config_at_or_above`]).
 fn find_config(start: &Path) -> Option<Config> {
-    let mut dir = Some(start);
-    while let Some(current) = dir {
-        let candidate = current.join("rag-rat.toml");
-        if candidate.is_file() {
-            return Config::load(&candidate).ok();
-        }
-        dir = current.parent();
-    }
-    None
+    rag_rat_core::config::nearest_config_at_or_above(start)
+        .and_then(|path| Config::load(&path).ok())
 }
 
 /// Outer Option: did the listener answer at all (None ⇒ fall back). Inner Option: did it

--- a/crates/rag-rat-cli/src/commands/index_ops.rs
+++ b/crates/rag-rat-cli/src/commands/index_ops.rs
@@ -3,6 +3,7 @@
 //! re-encode), `maintenance` (the git-hook pass, coalesced), `doctor` (health snapshot), and the
 //! `run_watch` / `run_maintenance_pass` helpers they drive.
 use std::fs;
+use std::path::Path;
 use std::time::Instant;
 
 use rag_rat_core::{Config, IndexDatabase, OutputFormat};
@@ -237,6 +238,7 @@ pub(crate) fn doctor(config: &Config) -> anyhow::Result<()> {
             (None, None, None, None, None)
         };
     print_output(&serde_json::json!({
+        "scope": "repo",
         "config_root": config.root,
         "database": config.database,
         "schema": schema,
@@ -251,6 +253,30 @@ pub(crate) fn doctor(config: &Config) -> anyhow::Result<()> {
             "kind": target.kind.as_str(),
         })).collect::<Vec<_>>(),
         "index": index,
+        "mcp": {
+            "transport": "stdio",
+            "tools": rag_rat_mcp::tools::TOOL_NAMES,
+            "source_read_only": true,
+            "index_writes": "sqlite_auto_heal"
+        }
+    }))
+}
+
+/// `doctor` for the config-less case: report the machine-global store — its schema, on-disk size,
+/// and the registry of repos it holds — rather than a specific repo. Reached from `run_doctor` when
+/// no `rag-rat.toml` is found at or above the cwd. The repo-scoped opens can't run against a
+/// consolidated multi-repo store, so this is a deliberately distinct DB-level report.
+pub(crate) fn doctor_global_store(database: &Path) -> anyhow::Result<()> {
+    let overview = IndexDatabase::global_store_overview(database)?;
+    print_output(&serde_json::json!({
+        "scope": "global-store",
+        "note": "No rag-rat.toml found at or above the cwd — reporting the machine-global store. \
+                 cd into an indexed repo (or run `rag-rat init` here) for a repo-scoped report.",
+        "database": overview.database,
+        "exists": overview.exists,
+        "size_bytes": overview.size_bytes,
+        "schema": overview.schema,
+        "repos": overview.repos,
         "mcp": {
             "transport": "stdio",
             "tools": rag_rat_mcp::tools::TOOL_NAMES,

--- a/crates/rag-rat-cli/src/commands/mod.rs
+++ b/crates/rag-rat-cli/src/commands/mod.rs
@@ -21,7 +21,7 @@ pub(crate) use config_info::{dump_config, version_check};
 pub(crate) use consolidate::consolidate;
 pub(crate) use format::{output_format, set_output_format};
 pub(crate) use hooks::{claude_hooks, hooks, papertrail};
-pub(crate) use index_ops::{doctor, index, maintenance, reconcile};
+pub(crate) use index_ops::{doctor, doctor_global_store, index, maintenance, reconcile};
 pub(crate) use memory::{dream, memory};
 pub(crate) use models::models;
 #[cfg(feature = "eval")]

--- a/crates/rag-rat-cli/src/main.rs
+++ b/crates/rag-rat-cli/src/main.rs
@@ -67,11 +67,15 @@ fn main() -> anyhow::Result<()> {
         rag_rat_core::OutputFormat::Toon
     });
 
-    // These commands must work without a config file present — `init` creates one, and the
-    // Claude Code hook entrypoint reads its event from stdin. Everything else needs a config.
+    // These commands must tolerate the ABSENCE of a config: `init` creates one; `claude-hook`
+    // reads its event from stdin; `mcp` serves a dormant server so a globally-registered MCP stays
+    // alive outside a rag-rat repo (#603); `doctor` reports the machine-global store. Everything
+    // else needs a resolved config and fails with a friendly hint when there isn't one.
     match &cli.command {
         Cmd::Init(args) => return init::run(args, cli.config.as_deref().unwrap_or("rag-rat.toml")),
         Cmd::ClaudeHook => return claude_hook::run(),
+        Cmd::Mcp => return run_mcp(cli.config.as_deref(), cli.json),
+        Cmd::Doctor => return run_doctor(cli.config.as_deref()),
         _ => {},
     }
 
@@ -86,44 +90,15 @@ fn main() -> anyhow::Result<()> {
     let _log = rag_rat_core::logging::init_logging(&config, log_role(&cli.command));
 
     match cli.command {
-        Cmd::Init(_) | Cmd::ClaudeHook => unreachable!("handled before the config load above"),
+        Cmd::Init(_) | Cmd::ClaudeHook | Cmd::Mcp | Cmd::Doctor =>
+            unreachable!("handled before the config load above"),
         Cmd::Index(args) => index(&config, &args)?,
-        Cmd::Doctor => doctor(&config)?,
         Cmd::Query(args) => query(&config, &args)?,
         Cmd::Brief(args) => brief(&config, &args)?,
         Cmd::Clusters(args) => clusters(&config, &args)?,
         Cmd::ImportantSymbols(args) => important_symbols(&config, &args)?,
         Cmd::Clones(args) => clones(&config, &args)?,
         Cmd::ClonesFor(args) => clones_for(&config, &args)?,
-        Cmd::Mcp => {
-            // Refresh the crates.io version cache out of band (a detached thread on this long-lived
-            // server) when stale + opted-in, so `index_status` and the next SessionStart digest
-            // read a fresh result without ever blocking startup or a request. Fail-open
-            // (#version-check).
-            spawn_detached_version_refresh(&config);
-            // Keep SCIP-grade ranking self-maintaining: a heavily-throttled detached thread runs
-            // the oracle when the active checkout's index is stale AND quiet (opt-in
-            // via `[oracle] auto_run`, default OFF). Mirrors the version-refresh thread
-            // — fail-open, dies with the process. No-op unless enabled.
-            spawn_detached_oracle_auto_run(&config);
-            // The MCP server is an stdio JSON-RPC loop (one client, mostly serial) plus a SIGUSR1
-            // task; the file watcher runs on its own OS thread and CPU-heavy indexing is rayon, not
-            // tokio. The default runtime's ~num_cpus workers are therefore idle overhead, so cap it
-            // small (issue #63, facet 3). Stay multi_thread (not current_thread) so a blocking tool
-            // handler can't stall the serve loop or the upgrade-signal task.
-            tokio::runtime::Builder::new_multi_thread()
-                .worker_threads(2)
-                .enable_all()
-                .build()?
-                .block_on(rag_rat_mcp::server::run_stdio(
-                    config,
-                    if cli.json {
-                        rag_rat_core::OutputFormat::Json
-                    } else {
-                        rag_rat_core::OutputFormat::Toon
-                    },
-                ))?;
-        },
         Cmd::Memory(args) => memory(&config, &args)?,
         Cmd::Dream(args) => dream(&config, &args)?,
         Cmd::Github(args) => papertrail(&config, &args)?,
@@ -347,26 +322,101 @@ fn now_epoch_ms() -> i64 {
 
 /// Load the config, mapping a missing file to a friendly hint instead of a raw IO error.
 /// `init`/`--help`/`--version` never reach here, so this only guards commands that genuinely
-/// need a configured repo.
-///
-/// `explicit` is the user's `--config` value, taken literally; `None` resolves through
-/// [`rag_rat_core::config::discover_config_path`] — the discovery side of the governing seam, so
-/// a linked worktree with no branch-local `rag-rat.toml` (the state `init`'s refusal leaves)
-/// finds the MAIN worktree's config instead of dying at the existence check, and the hint in a
-/// truly config-less repo names the path where the config BELONGS (main's, in a linked checkout).
+/// need a configured repo. `mcp`/`doctor` deliberately do NOT — they degrade gracefully via
+/// [`discover_config_optional`] instead (dormant server / global-store report).
 pub(crate) fn load_config_or_hint(explicit: Option<&str>) -> anyhow::Result<Config> {
-    let path = match explicit {
-        Some(path) => std::path::PathBuf::from(path),
-        None => rag_rat_core::config::discover_config_path(Path::new(".")),
-    };
-    if !path.exists() {
-        anyhow::bail!(
+    match discover_config_optional(explicit)? {
+        Some(config) => Ok(config),
+        None => anyhow::bail!(
             "No rag-rat config found at `{}`.\nRun `rag-rat init` to create one, or pass --config \
              <path>.",
-            path.display()
-        );
+            rag_rat_core::config::discover_config_path(Path::new(".")).display()
+        ),
     }
-    Ok(Config::load(path)?)
+}
+
+/// Resolve a config WITHOUT the fail-fast hint, distinguishing "absent" from "broken":
+///  * explicit `--config` given → taken literally; a MISSING file is a loud error (a user override
+///    that can't be honored), an invalid file propagates its parse error.
+///  * no `--config` → discover from cwd via [`rag_rat_core::config::discover_config_path`] (the
+///    governing seam: local file, else linked-worktree main, else the ancestor walk). Absent ⇒
+///    `Ok(None)` so the caller can degrade gracefully (dormant `mcp`, global-store `doctor`);
+///    present-but-invalid ⇒ the parse error — a real repo with a broken config must NOT silently
+///    degrade to dormancy.
+fn discover_config_optional(explicit: Option<&str>) -> anyhow::Result<Option<Config>> {
+    match explicit {
+        Some(path) => {
+            let path = PathBuf::from(path);
+            if !path.exists() {
+                anyhow::bail!(
+                    "No rag-rat config found at `{}`.\nRun `rag-rat init` to create one, or pass \
+                     --config <path>.",
+                    path.display()
+                );
+            }
+            Ok(Some(Config::load(path)?))
+        },
+        None => {
+            let path = rag_rat_core::config::discover_config_path(Path::new("."));
+            if !path.is_file() {
+                return Ok(None);
+            }
+            Ok(Some(Config::load(path)?))
+        },
+    }
+}
+
+/// Serve the stdio MCP server, tolerating the ABSENCE of a config. A globally-registered
+/// `rag-rat mcp` is spawned in EVERY project, so outside a rag-rat repo it must serve a DORMANT
+/// server (stays alive; every tool call returns a "no index here" notice) instead of exiting and
+/// taking repo intelligence down for the whole session (#603). A config that is PRESENT but invalid
+/// — or an explicit `--config` path that is missing — is still a loud error.
+fn run_mcp(explicit: Option<&str>, json: bool) -> anyhow::Result<()> {
+    let output_format =
+        if json { rag_rat_core::OutputFormat::Json } else { rag_rat_core::OutputFormat::Toon };
+    let config = discover_config_optional(explicit)?;
+    // Repo-specific setup only when a config actually resolved. `_log` holds the tracing guard for
+    // the server's lifetime; a dormant server writes no log (there is no repo to anchor it to).
+    let _log = config.as_ref().map(|config| {
+        apply_embedding_runtime_env(&config.llm.embedding.runtime);
+        rag_rat_core::logging::init_logging(config, rag_rat_core::logging::Role::Mcp)
+    });
+    if let Some(config) = &config {
+        // Detached, fail-open, dies with the process — no-ops unless opted in. Never spawned for a
+        // dormant server (no repo to refresh or rank).
+        spawn_detached_version_refresh(config);
+        spawn_detached_oracle_auto_run(config);
+    }
+    // Small worker pool: the stdio JSON-RPC loop is mostly serial and CPU-heavy indexing is rayon,
+    // not tokio; stay multi_thread so a blocking tool handler can't stall the serve/upgrade tasks
+    // (issue #63, facet 3).
+    tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .enable_all()
+        .build()?
+        .block_on(rag_rat_mcp::server::run_stdio(config, output_format))?;
+    Ok(())
+}
+
+/// Run `doctor`, tolerating the ABSENCE of a config: with no `rag-rat.toml` at or above the cwd,
+/// report the machine-global store (`$XDG_DATA_HOME/rag-rat/rag-rat.sqlite`) instead of erroring —
+/// "no local config" is not "no data". Only when this platform resolves no data dir at all does it
+/// fall back to the friendly "run rag-rat init" hint.
+fn run_doctor(explicit: Option<&str>) -> anyhow::Result<()> {
+    if let Some(config) = discover_config_optional(explicit)? {
+        let _log = rag_rat_core::logging::init_logging(&config, log_role(&Cmd::Doctor));
+        return doctor(&config);
+    }
+    // No rag-rat.toml at or above the cwd: report the machine-global store instead of erroring.
+    match rag_rat_core::data_dir::global_database_path() {
+        Some(database) => doctor_global_store(&database),
+        None => anyhow::bail!(
+            "No rag-rat config found at `{}`, and this platform has no data directory for a \
+             machine-global store.\nRun `rag-rat init` to create a config, or pass --config \
+             <path>.",
+            rag_rat_core::config::discover_config_path(Path::new(".")).display()
+        ),
+    }
 }
 
 /// Map the invoked subcommand to a debug-log [`Role`](rag_rat_core::logging::Role) (drives the log

--- a/crates/rag-rat-cli/src/main.rs
+++ b/crates/rag-rat-cli/src/main.rs
@@ -358,7 +358,11 @@ fn discover_config_optional(explicit: Option<&str>) -> anyhow::Result<Option<Con
         },
         None => {
             let path = rag_rat_core::config::discover_config_path(Path::new("."));
-            if !path.is_file() {
+            // Only a GENUINELY ABSENT path is "no config" (graceful). A path that EXISTS but is not
+            // a readable config file (e.g. a directory named `rag-rat.toml`) is
+            // present-but-invalid: let `Config::load` surface the error rather than
+            // silently going dormant.
+            if !path.exists() {
                 return Ok(None);
             }
             Ok(Some(Config::load(path)?))
@@ -390,11 +394,14 @@ fn run_mcp(explicit: Option<&str>, json: bool) -> anyhow::Result<()> {
     // Small worker pool: the stdio JSON-RPC loop is mostly serial and CPU-heavy indexing is rayon,
     // not tokio; stay multi_thread so a blocking tool handler can't stall the serve/upgrade tasks
     // (issue #63, facet 3).
-    tokio::runtime::Builder::new_multi_thread()
-        .worker_threads(2)
-        .enable_all()
-        .build()?
-        .block_on(rag_rat_mcp::server::run_stdio(config, output_format))?;
+    let runtime =
+        tokio::runtime::Builder::new_multi_thread().worker_threads(2).enable_all().build()?;
+    // A resolved config → the active server; none → the dormant one. Kept as two calls so the
+    // published `run_stdio(Config, …)` entry point stays source-compatible (#603).
+    match config {
+        Some(config) => runtime.block_on(rag_rat_mcp::server::run_stdio(config, output_format))?,
+        None => runtime.block_on(rag_rat_mcp::server::run_stdio_dormant(output_format))?,
+    }
     Ok(())
 }
 

--- a/crates/rag-rat-cli/tests/mcp_stdio.rs
+++ b/crates/rag-rat-cli/tests/mcp_stdio.rs
@@ -261,8 +261,14 @@ fn mcp_stdio_dormant_result_is_valid_json_in_json_mode() {
 /// Self-healing (#603): a server that started DORMANT activates its tools as soon as the directory
 /// becomes a rag-rat repo mid-session — a `rag-rat init` + index run reachable through the dormant
 /// notice actually works, with NO MCP restart. The server re-discovers the config on each call.
+/// Dormancy is BINARY and decided at launch: a server that started dormant does NOT half-activate
+/// when the directory becomes a rag-rat repo mid-session — it keeps returning the notice (which
+/// tells the user to restart) rather than serving through a config it discovered per-call. A
+/// per-call-discovered server would lack the active lifecycle (watcher / git-hook freshness) and
+/// could return results not validated against current source, breaking rag-rat's core guarantee
+/// (#603). Activation requires a restart; the smoke test covers the launched-with-config path.
 #[test]
-fn mcp_stdio_dormant_server_activates_after_the_repo_is_indexed() {
+fn mcp_stdio_dormant_server_stays_dormant_until_restart() {
     let root = unique_temp_root();
     fs::create_dir_all(root.join("src")).unwrap();
     fs::write(root.join("src/lib.rs"), "pub fn healed_symbol_marker() {}\n").unwrap();
@@ -302,8 +308,7 @@ fn mcp_stdio_dormant_server_activates_after_the_repo_is_indexed() {
     let before = recv(&mut reader)["result"]["content"][0]["text"].as_str().unwrap().to_string();
     assert!(before.contains("no_index"), "must be dormant before the repo is indexed: {before}");
 
-    // The agent (here, the test) turns the dir into an indexed rag-rat repo — exactly what the
-    // dormant notice instructs. The server's cwd IS `root`, so its re-discovery finds this config.
+    // Turn the dir into an indexed rag-rat repo mid-session — but do NOT restart the server.
     fs::write(
         root.join("rag-rat.toml"),
         "[index]\nroot = \".\"\ndatabase = \".rag-rat/index.sqlite\"\n\n[target_bindings]\nrust = \
@@ -313,24 +318,17 @@ fn mcp_stdio_dormant_server_activates_after_the_repo_is_indexed() {
     let config = Config::load(root.join("rag-rat.toml")).unwrap();
     rag_rat_core::IndexDatabase::rebuild(&config).unwrap();
 
-    // After init+index: the SAME server now serves the tool for real — no restart.
-    // `semantic_search` returns actual hits (the smoke test proves it works on a fresh
-    // hash-embedder index).
+    // Without a restart the SAME server stays dormant — it does not half-activate against the new
+    // config; the notice (restart to activate) still stands.
     send(
         &mut stdin,
         json!({"jsonrpc": "2.0", "id": 3, "method": "tools/call",
                "params": {"name": "semantic_search", "arguments": {"query": "healed", "limit": 3}}}),
     );
-    let after = recv(&mut reader);
-    let after_text = after["result"]["content"][0]["text"].as_str().unwrap().to_string();
+    let after = recv(&mut reader)["result"]["content"][0]["text"].as_str().unwrap().to_string();
     assert!(
-        !after_text.contains("no_index"),
-        "server must self-heal after indexing, still dormant: {after_text}"
-    );
-    let hits = response_text_json(after);
-    assert!(
-        hits.as_array().is_some_and(|hits| !hits.is_empty()),
-        "the self-healed server must serve real search hits, got: {after_text}",
+        after.contains("no_index"),
+        "a launched-dormant server must stay dormant until restart, got: {after}",
     );
 
     stop(child);

--- a/crates/rag-rat-cli/tests/mcp_stdio.rs
+++ b/crates/rag-rat-cli/tests/mcp_stdio.rs
@@ -119,6 +119,224 @@ fn mcp_stdio_smoke_lists_and_calls_core_tools() {
     fs::remove_dir_all(root).unwrap();
 }
 
+/// A `rag-rat mcp` launched OUTSIDE any rag-rat repo (no `rag-rat.toml` at or above cwd) must NOT
+/// exit — a globally-registered MCP server is spawned in EVERY project, so dying in a non-rag-rat
+/// one would take repo intelligence down for the whole session (#603). It serves a DORMANT server:
+/// `initialize` + `tools/list` (full catalog) succeed, every `tools/call` returns the informative
+/// dormant notice as a NON-error result, and the process stays alive across calls.
+#[test]
+fn mcp_stdio_serves_dormant_without_a_config() {
+    let root = unique_temp_root();
+    // A bare directory — deliberately NO rag-rat.toml here or (temp roots have none) above it.
+    fs::create_dir_all(&root).unwrap();
+
+    let binary = env!("CARGO_BIN_EXE_rag-rat");
+    let mut child = Command::new(binary)
+        .arg("mcp") // NO --config: discovery from this cwd finds nothing → dormant.
+        .current_dir(&root)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    let mut stdin = child.stdin.take().unwrap();
+    let stdout = child.stdout.take().unwrap();
+    let mut reader = BufReader::new(stdout);
+
+    send(
+        &mut stdin,
+        json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {"name": "rag-rat-test", "version": "0.1"}
+            }
+        }),
+    );
+    let initialize = recv(&mut reader);
+    assert_eq!(initialize["id"], 1, "a dormant server must still answer initialize");
+
+    send(
+        &mut stdin,
+        json!({"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}}),
+    );
+    send(&mut stdin, json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}));
+    let tools = recv(&mut reader);
+    let tool_names = tools["result"]["tools"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|tool| tool["name"].as_str().unwrap())
+        .collect::<Vec<_>>();
+    assert!(
+        tool_names.contains(&"semantic_search"),
+        "a dormant server still advertises the full tool catalog",
+    );
+
+    // A tool call returns the dormant notice as a NON-error result (the agent reads it as a normal
+    // response), not an MCP error and not a dead pipe.
+    send(
+        &mut stdin,
+        json!({
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": {"name": "semantic_search", "arguments": {"query": "anything"}}
+        }),
+    );
+    let response = recv(&mut reader);
+    assert_ne!(
+        response["result"]["isError"],
+        json!(true),
+        "the dormant tool result must not be an error",
+    );
+    let text = response["result"]["content"][0]["text"].as_str().unwrap();
+    assert!(
+        text.contains("no_index"),
+        "the dormant tool result must carry the no-index notice, got: {text}",
+    );
+
+    // The server is still alive after a tool call — a second request is answered.
+    send(&mut stdin, json!({"jsonrpc": "2.0", "id": 4, "method": "tools/list"}));
+    assert_eq!(recv(&mut reader)["id"], 4, "the dormant server stays alive across calls");
+
+    stop(child);
+    fs::remove_dir_all(root).unwrap();
+}
+
+/// The dormant tool result honors `--json` mode: its text block must be directly parseable as JSON
+/// (the JSON-output contract holds even with no repo), not the default TOON prose. A JSON-parsing
+/// MCP client would otherwise fail ONLY in dormant mode.
+#[test]
+fn mcp_stdio_dormant_result_is_valid_json_in_json_mode() {
+    let root = unique_temp_root();
+    fs::create_dir_all(&root).unwrap();
+
+    let binary = env!("CARGO_BIN_EXE_rag-rat");
+    let mut child = Command::new(binary)
+        .arg("mcp")
+        .arg("--json")
+        .current_dir(&root)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    let mut stdin = child.stdin.take().unwrap();
+    let mut reader = BufReader::new(child.stdout.take().unwrap());
+
+    send(
+        &mut stdin,
+        json!({
+            "jsonrpc": "2.0", "id": 1, "method": "initialize",
+            "params": {"protocolVersion": "2024-11-05", "capabilities": {},
+                       "clientInfo": {"name": "rag-rat-test", "version": "0.1"}}
+        }),
+    );
+    assert_eq!(recv(&mut reader)["id"], 1);
+    send(
+        &mut stdin,
+        json!({"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}}),
+    );
+    send(
+        &mut stdin,
+        json!({
+            "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+            "params": {"name": "semantic_search", "arguments": {"query": "anything"}}
+        }),
+    );
+    let text = recv(&mut reader)["result"]["content"][0]["text"].as_str().unwrap().to_string();
+    let parsed: Value = serde_json::from_str(&text)
+        .unwrap_or_else(|err| panic!("dormant --json result must be valid JSON ({err}): {text}"));
+    assert_eq!(parsed["status"], "no_index", "dormant JSON payload carries the no-index status");
+
+    stop(child);
+    fs::remove_dir_all(root).unwrap();
+}
+
+/// Self-healing (#603): a server that started DORMANT activates its tools as soon as the directory
+/// becomes a rag-rat repo mid-session — a `rag-rat init` + index run reachable through the dormant
+/// notice actually works, with NO MCP restart. The server re-discovers the config on each call.
+#[test]
+fn mcp_stdio_dormant_server_activates_after_the_repo_is_indexed() {
+    let root = unique_temp_root();
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), "pub fn healed_symbol_marker() {}\n").unwrap();
+
+    let binary = env!("CARGO_BIN_EXE_rag-rat");
+    let mut child = Command::new(binary)
+        .arg("mcp")
+        .current_dir(&root) // NO --config, NO rag-rat.toml yet → starts dormant.
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    let mut stdin = child.stdin.take().unwrap();
+    let mut reader = BufReader::new(child.stdout.take().unwrap());
+
+    send(
+        &mut stdin,
+        json!({
+            "jsonrpc": "2.0", "id": 1, "method": "initialize",
+            "params": {"protocolVersion": "2024-11-05", "capabilities": {},
+                       "clientInfo": {"name": "rag-rat-test", "version": "0.1"}}
+        }),
+    );
+    assert_eq!(recv(&mut reader)["id"], 1);
+    send(
+        &mut stdin,
+        json!({"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}}),
+    );
+
+    // Before init: a tool call is dormant.
+    send(
+        &mut stdin,
+        json!({"jsonrpc": "2.0", "id": 2, "method": "tools/call",
+               "params": {"name": "semantic_search", "arguments": {"query": "healed", "limit": 3}}}),
+    );
+    let before = recv(&mut reader)["result"]["content"][0]["text"].as_str().unwrap().to_string();
+    assert!(before.contains("no_index"), "must be dormant before the repo is indexed: {before}");
+
+    // The agent (here, the test) turns the dir into an indexed rag-rat repo — exactly what the
+    // dormant notice instructs. The server's cwd IS `root`, so its re-discovery finds this config.
+    fs::write(
+        root.join("rag-rat.toml"),
+        "[index]\nroot = \".\"\ndatabase = \".rag-rat/index.sqlite\"\n\n[target_bindings]\nrust = \
+         [\"src\"]\n",
+    )
+    .unwrap();
+    let config = Config::load(root.join("rag-rat.toml")).unwrap();
+    rag_rat_core::IndexDatabase::rebuild(&config).unwrap();
+
+    // After init+index: the SAME server now serves the tool for real — no restart.
+    // `semantic_search` returns actual hits (the smoke test proves it works on a fresh
+    // hash-embedder index).
+    send(
+        &mut stdin,
+        json!({"jsonrpc": "2.0", "id": 3, "method": "tools/call",
+               "params": {"name": "semantic_search", "arguments": {"query": "healed", "limit": 3}}}),
+    );
+    let after = recv(&mut reader);
+    let after_text = after["result"]["content"][0]["text"].as_str().unwrap().to_string();
+    assert!(
+        !after_text.contains("no_index"),
+        "server must self-heal after indexing, still dormant: {after_text}"
+    );
+    let hits = response_text_json(after);
+    assert!(
+        hits.as_array().is_some_and(|hits| !hits.is_empty()),
+        "the self-healed server must serve real search hits, got: {after_text}",
+    );
+
+    stop(child);
+    fs::remove_dir_all(root).unwrap();
+}
+
 /// Regression guard: every tool advertised by `tools/list` (built from `TOOL_NAMES`) must be
 /// ROUTABLE by `tools/call`. The two are built from different sources — `list_tools` from
 /// `TOOL_NAMES`, the call router from the `#[tool]`-annotated methods — so a tool added to one but

--- a/crates/rag-rat-cli/tests/mcp_stdio.rs
+++ b/crates/rag-rat-cli/tests/mcp_stdio.rs
@@ -200,9 +200,26 @@ fn mcp_stdio_serves_dormant_without_a_config() {
         "the dormant tool result must carry the no-index notice, got: {text}",
     );
 
-    // The server is still alive after a tool call — a second request is answered.
-    send(&mut stdin, json!({"jsonrpc": "2.0", "id": 4, "method": "tools/list"}));
-    assert_eq!(recv(&mut reader)["id"], 4, "the dormant server stays alive across calls");
+    // An UNKNOWN tool name is still rejected as an error — dormancy must not mask a typo/stale tool
+    // as `no_index` (a client can't otherwise tell an invalid call from genuine dormancy).
+    send(
+        &mut stdin,
+        json!({
+            "jsonrpc": "2.0",
+            "id": 4,
+            "method": "tools/call",
+            "params": {"name": "definitely_not_a_tool", "arguments": {}}
+        }),
+    );
+    let unknown = recv(&mut reader);
+    assert!(
+        unknown["error"]["message"].as_str().unwrap_or_default().contains("unknown tool"),
+        "a dormant server must reject an unknown tool, got: {unknown}",
+    );
+
+    // The server is still alive after those calls — a further request is answered.
+    send(&mut stdin, json!({"jsonrpc": "2.0", "id": 5, "method": "tools/list"}));
+    assert_eq!(recv(&mut reader)["id"], 5, "the dormant server stays alive across calls");
 
     stop(child);
     fs::remove_dir_all(root).unwrap();

--- a/crates/rag-rat-core/src/config.rs
+++ b/crates/rag-rat-core/src/config.rs
@@ -1223,7 +1223,9 @@ fn anchor_root_to_main_worktree(root: &Path) -> PathBuf {
 ///    the seam (governance is identical either way).
 ///  * no local file, linked worktree → the MAIN worktree's `rag-rat.toml` (whether or not it exists
 ///    yet — a missing-config hint should name the path where the config BELONGS).
-///  * no local file, main/non-git → the local path (the hint names it).
+///  * no local file, main/non-git → the nearest `rag-rat.toml` in an ANCESTOR directory, so a
+///    launch from a SUBDIRECTORY of a rag-rat repo still finds the repo's config; failing that, the
+///    local path (the hint names it).
 ///
 /// An EXPLICIT `--config` path never routes through this — a user override is taken literally.
 pub fn discover_config_path(dir: &Path) -> PathBuf {
@@ -1232,9 +1234,38 @@ pub fn discover_config_path(dir: &Path) -> PathBuf {
         return local;
     }
     match linked_worktree_main_root(dir) {
+        // Linked worktree: the MAIN checkout's config governs UNCONDITIONALLY — return its path
+        // even when the file is missing. This is the governing seam; the ancestor walk
+        // below must never preempt it (a subdir of the MAIN worktree is deliberately NOT
+        // classified as linked, so it falls into the `None` arm and the walk finds main's
+        // config there).
         Some(main_top) => main_top.join("rag-rat.toml"),
-        None => local,
+        None => nearest_config_at_or_above(dir).unwrap_or(local),
     }
+}
+
+/// Walk upward from `dir` to the nearest directory (at or above `dir`) holding a `rag-rat.toml`,
+/// returning that file's path. `None` ⇒ no rag-rat repo at or above `dir`. The single upward-walk
+/// primitive: `discover_config_path`'s non-worktree arm uses it so a subdirectory launch inside a
+/// repo finds the repo's config, and the Claude-hook cwd→config resolver
+/// (`claude_hook::find_config`) loads the returned path. Unbounded (to the filesystem root),
+/// matching a repo that has no other marker than its `rag-rat.toml`.
+pub fn nearest_config_at_or_above(dir: &Path) -> Option<PathBuf> {
+    // Resolve to an ABSOLUTE path first. A relative `dir` such as `.` has `parent() == Some("")`
+    // then `None`, so the ancestor walk would only ever inspect `.` and never climb the real
+    // filesystem tree (the callers pass `Path::new(".")` for cwd). `canonicalize` also collapses
+    // `..`/symlinks so the climb follows the true directory chain. If it fails (a non-existent
+    // `dir`), fall back to walking `dir` as given rather than aborting discovery.
+    let absolute = dir.canonicalize().ok();
+    let mut current = absolute.as_deref().or(Some(dir));
+    while let Some(cur) = current {
+        let candidate = cur.join("rag-rat.toml");
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+        current = cur.parent();
+    }
+    None
 }
 
 /// The MAIN worktree top for `root` when `root` sits in a LINKED git worktree — `None` when the
@@ -2329,6 +2360,41 @@ mod tests {
         let plain = tmp.join("plain");
         std::fs::create_dir_all(&plain).unwrap();
         assert_eq!(discover_config_path(&plain), plain.join("rag-rat.toml"));
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    /// The ANCESTOR-WALK arm (non-worktree): a launch from a SUBDIRECTORY of a rag-rat repo
+    /// resolves to the repo root's `rag-rat.toml` instead of dying at the local existence
+    /// check, while a genuinely config-less tree still yields the local (non-existent) path for
+    /// the hint. Also guards the relative-path footgun the walk fixed:
+    /// `nearest_config_at_or_above` must resolve a `.`-style dir to ABSOLUTE before climbing —
+    /// a relative `parent()` is `Some("")` then `None`, so the walk would never leave the
+    /// starting dir.
+    #[test]
+    fn discover_config_path_walks_up_to_a_parent_repo_config() {
+        let id = CFG_TEMP.fetch_add(1, Ordering::Relaxed);
+        let tmp = std::env::temp_dir().join(format!("ragrat-walkup-{}-{id}", std::process::id()));
+        let repo = tmp.join("repo");
+        let nested = repo.join("crates").join("cli").join("src");
+        std::fs::create_dir_all(&nested).unwrap();
+        std::fs::write(repo.join("rag-rat.toml"), "[index]\nroot = \".\"\n").unwrap();
+
+        // The walk returns a canonical absolute path (a found file), so compare canonically — temp
+        // roots can be symlinked (macOS `/tmp` → `/private/tmp`).
+        let want = repo.join("rag-rat.toml").canonicalize().unwrap();
+        assert_eq!(
+            discover_config_path(&nested).canonicalize().unwrap(),
+            want,
+            "subdir → repo cfg"
+        );
+        assert_eq!(discover_config_path(&repo).canonicalize().unwrap(), want, "repo root → local");
+
+        // A config-less tree with NO ancestor config: the local (non-existent) path, unchanged —
+        // the not-found fallback returns the original `dir/rag-rat.toml` for the hint, uncanonical.
+        let bare = tmp.join("bare").join("deep");
+        std::fs::create_dir_all(&bare).unwrap();
+        assert_eq!(discover_config_path(&bare), bare.join("rag-rat.toml"));
 
         let _ = std::fs::remove_dir_all(&tmp);
     }

--- a/crates/rag-rat-core/src/config.rs
+++ b/crates/rag-rat-core/src/config.rs
@@ -1221,11 +1221,14 @@ fn anchor_root_to_main_worktree(root: &Path) -> PathBuf {
 ///    AND emits the divergence warning — routing discovery straight to main when a branch file
 ///    exists would silently skip that warning, so the file's presence keeps the load going through
 ///    the seam (governance is identical either way).
-///  * no local file, linked worktree → the MAIN worktree's `rag-rat.toml` (whether or not it exists
-///    yet — a missing-config hint should name the path where the config BELONGS).
-///  * no local file, main/non-git → the nearest `rag-rat.toml` in an ANCESTOR directory, so a
-///    launch from a SUBDIRECTORY of a rag-rat repo still finds the repo's config; failing that, the
-///    local path (the hint names it).
+///  * linked worktree, no local file at `dir` → the nearest `rag-rat.toml` in an ANCESTOR up to the
+///    linked worktree root (a subdirectory launch still finds a branch-local config → seam +
+///    warning); failing that, the MAIN worktree's `rag-rat.toml` (whether or not it exists yet — a
+///    missing-config hint should name where the config BELONGS).
+///  * main/non-git, no local file → the nearest `rag-rat.toml` in an ANCESTOR directory (bounded at
+///    the enclosing git root so a nested checkout never adopts a parent repo's config), so a launch
+///    from a SUBDIRECTORY of a rag-rat repo still finds the repo's config; failing that, the local
+///    path (the hint names it).
 ///
 /// An EXPLICIT `--config` path never routes through this — a user override is taken literally.
 pub fn discover_config_path(dir: &Path) -> PathBuf {
@@ -1234,12 +1237,16 @@ pub fn discover_config_path(dir: &Path) -> PathBuf {
         return local;
     }
     match linked_worktree_main_root(dir) {
-        // Linked worktree: the MAIN checkout's config governs UNCONDITIONALLY — return its path
-        // even when the file is missing. This is the governing seam; the ancestor walk
-        // below must never preempt it (a subdir of the MAIN worktree is deliberately NOT
-        // classified as linked, so it falls into the `None` arm and the walk finds main's
-        // config there).
-        Some(main_top) => main_top.join("rag-rat.toml"),
+        // Linked worktree: a BRANCH-LOCAL rag-rat.toml (at the worktree root, or an ancestor of
+        // `dir` within it) must still be found from a SUBDIRECTORY launch — it routes the load
+        // through the governing seam, which governs from main AND emits the divergence warning
+        // (jumping straight to main would skip that warning, or wrongly go dormant when main has no
+        // config). `nearest_config_at_or_above` is bounded at the enclosing git root (the linked
+        // worktree root), so it cannot escape into main or a parent. No branch-local config
+        // ANYWHERE in the linked worktree ⇒ main's config path (even if missing) — the
+        // governing-seam invariant.
+        Some(main_top) =>
+            nearest_config_at_or_above(dir).unwrap_or_else(|| main_top.join("rag-rat.toml")),
         None => nearest_config_at_or_above(dir).unwrap_or(local),
     }
 }
@@ -1248,8 +1255,12 @@ pub fn discover_config_path(dir: &Path) -> PathBuf {
 /// returning that file's path. `None` ⇒ no rag-rat repo at or above `dir`. The single upward-walk
 /// primitive: `discover_config_path`'s non-worktree arm uses it so a subdirectory launch inside a
 /// repo finds the repo's config, and the Claude-hook cwd→config resolver
-/// (`claude_hook::find_config`) loads the returned path. Unbounded (to the filesystem root),
-/// matching a repo that has no other marker than its `rag-rat.toml`.
+/// (`claude_hook::find_config`) loads the returned path.
+///
+/// The climb STOPS at the enclosing git repository root: a nested checkout or submodule that has no
+/// `rag-rat.toml` of its own must NOT bind to an indexed PARENT repo's config — that would target
+/// the wrong repository for searches and, worse, for memory writes. When `dir` is not inside a git
+/// repo there is no such boundary, so the walk runs to the filesystem root.
 pub fn nearest_config_at_or_above(dir: &Path) -> Option<PathBuf> {
     // Resolve to an ABSOLUTE path first. A relative `dir` such as `.` has `parent() == Some("")`
     // then `None`, so the ancestor walk would only ever inspect `.` and never climb the real
@@ -1257,11 +1268,24 @@ pub fn nearest_config_at_or_above(dir: &Path) -> Option<PathBuf> {
     // `..`/symlinks so the climb follows the true directory chain. If it fails (a non-existent
     // `dir`), fall back to walking `dir` as given rather than aborting discovery.
     let absolute = dir.canonicalize().ok();
-    let mut current = absolute.as_deref().or(Some(dir));
+    let start = absolute.as_deref().unwrap_or(dir);
+    // The enclosing git repo's workdir root — the ceiling the climb must not cross (canonicalized
+    // so it compares equal to the canonicalized `cur`). `None` for a non-git `dir` ⇒ no
+    // ceiling.
+    let boundary = crate::index::discover_repo(start)
+        .ok()
+        .and_then(|repo| repo.workdir().map(Path::to_path_buf))
+        .and_then(|workdir| workdir.canonicalize().ok());
+    let mut current = Some(start);
     while let Some(cur) = current {
         let candidate = cur.join("rag-rat.toml");
         if candidate.is_file() {
             return Some(candidate);
+        }
+        // At the git repo root: its `rag-rat.toml` was just checked; never climb into a parent
+        // repo.
+        if boundary.as_deref() == Some(cur) {
+            break;
         }
         current = cur.parent();
     }
@@ -2395,6 +2419,83 @@ mod tests {
         let bare = tmp.join("bare").join("deep");
         std::fs::create_dir_all(&bare).unwrap();
         assert_eq!(discover_config_path(&bare), bare.join("rag-rat.toml"));
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    /// The ancestor walk STOPS at the enclosing git repo root: a nested checkout / submodule with
+    /// no `rag-rat.toml` of its own must NOT bind to an indexed PARENT repo's config — that
+    /// would point searches and (worse) memory writes at the wrong repository (#611 review,
+    /// P2).
+    #[test]
+    fn discover_config_path_does_not_cross_a_nested_repo_boundary() {
+        let git = |dir: &Path, args: &[&str]| {
+            let out =
+                std::process::Command::new("git").arg("-C").arg(dir).args(args).output().unwrap();
+            assert!(out.status.success(), "git {args:?}: {}", String::from_utf8_lossy(&out.stderr));
+        };
+        let id = CFG_TEMP.fetch_add(1, Ordering::Relaxed);
+        let tmp = std::env::temp_dir().join(format!("ragrat-nested-{}-{id}", std::process::id()));
+        let parent = tmp.join("parent");
+        let nested = parent.join("vendor").join("nested");
+        std::fs::create_dir_all(&nested).unwrap();
+        // Parent IS a rag-rat repo (git + rag-rat.toml at its root).
+        git(&parent, &["init", "-q"]);
+        std::fs::write(parent.join("rag-rat.toml"), "[index]\nroot = \".\"\n").unwrap();
+        // `nested` is its OWN git repo (submodule-like), with no rag-rat.toml.
+        git(&nested, &["init", "-q"]);
+
+        // Launched from the nested repo, discovery stays WITHIN it (no toml) → its local path,
+        // never the parent's config.
+        let got = discover_config_path(&nested);
+        assert_eq!(got, nested.join("rag-rat.toml"), "must not adopt the parent repo's config");
+        assert_ne!(
+            got.canonicalize().ok(),
+            parent.join("rag-rat.toml").canonicalize().ok(),
+            "the parent repo's rag-rat.toml must not leak across the nested boundary",
+        );
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    /// A SUBDIRECTORY launch inside a LINKED worktree finds a BRANCH-LOCAL `rag-rat.toml` at the
+    /// worktree root (routing the load through the governing seam + divergence warning) instead of
+    /// jumping straight to main; with no branch-local config anywhere in the worktree it still
+    /// resolves to MAIN's path (the governing-seam invariant). #611 review, P2 (linked arm).
+    #[test]
+    fn discover_config_path_finds_a_branch_local_config_from_a_linked_worktree_subdir() {
+        let git = |dir: &Path, args: &[&str]| {
+            let out =
+                std::process::Command::new("git").arg("-C").arg(dir).args(args).output().unwrap();
+            assert!(out.status.success(), "git {args:?}: {}", String::from_utf8_lossy(&out.stderr));
+        };
+        let id = CFG_TEMP.fetch_add(1, Ordering::Relaxed);
+        let tmp = std::env::temp_dir().join(format!("ragrat-wtsub-{}-{id}", std::process::id()));
+        let main = tmp.join("main");
+        std::fs::create_dir_all(main.join("src")).unwrap();
+        std::fs::write(main.join("src/lib.rs"), "pub fn a() {}\n").unwrap();
+        git(&main, &["init", "-q"]);
+        git(&main, &["config", "user.email", "t@e"]);
+        git(&main, &["config", "user.name", "t"]);
+        git(&main, &["add", "-A"]);
+        git(&main, &["commit", "-qm", "seed"]);
+        let linked = tmp.join("wt");
+        git(&main, &["worktree", "add", "--detach", "-q", linked.to_str().unwrap()]);
+        let main_c = main.canonicalize().unwrap();
+        let sub = linked.join("src");
+        std::fs::create_dir_all(&sub).unwrap();
+
+        // No branch-local config anywhere in the worktree: a subdir launch resolves to MAIN's path.
+        assert_eq!(discover_config_path(&sub), main_c.join("rag-rat.toml"), "invariant: → main");
+
+        // A branch-local config at the LINKED worktree root: the subdir launch now finds IT (never
+        // climbing past the worktree root into main).
+        std::fs::write(linked.join("rag-rat.toml"), "[index]\nroot = \".\"\n").unwrap();
+        assert_eq!(
+            discover_config_path(&sub).canonicalize().unwrap(),
+            linked.join("rag-rat.toml").canonicalize().unwrap(),
+            "a subdir launch must find the branch-local config, not jump to main",
+        );
 
         let _ = std::fs::remove_dir_all(&tmp);
     }

--- a/crates/rag-rat-core/src/index/lifecycle.rs
+++ b/crates/rag-rat-core/src/index/lifecycle.rs
@@ -456,9 +456,14 @@ impl IndexDatabase {
             });
         }
         let size_bytes = std::fs::metadata(path).ok().map(|meta| meta.len());
-        let schema = Self::migration_check(path)?;
+        // READ-ONLY throughout: this diagnostic must work on a read-only mount / backup, so it must
+        // not use the read-WRITE `migration_check` (whose `IndexConnection::open` runs
+        // write-oriented setup pragmas). One read-only connection serves both the schema
+        // status and the registry read. NB: a read-only open never auto-migrates, which is
+        // correct here — the report states the schema STATE, it does not change it.
+        let storage = IndexConnection::open_read_only_blocking(path)?;
+        let schema = schema::status(storage.connection())?;
         let repos = if schema.state == schema::SchemaState::Compatible {
-            let storage = IndexConnection::open_read_only_blocking(path)?;
             schema::registered_repos(storage.connection())?
         } else {
             Vec::new()

--- a/crates/rag-rat-core/src/index/lifecycle.rs
+++ b/crates/rag-rat-core/src/index/lifecycle.rs
@@ -34,6 +34,18 @@ pub(super) enum AdoptIntent {
     ReadOnly,
 }
 
+/// A DB-level, repo-agnostic snapshot of a store, produced by
+/// [`IndexDatabase::global_store_overview`] for the config-less `doctor` path. `schema` is `None`
+/// only when the store file does not exist. Serialized straight into the doctor report.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct GlobalStoreOverview {
+    pub database: PathBuf,
+    pub exists: bool,
+    pub size_bytes: Option<u64>,
+    pub schema: Option<schema::SchemaStatus>,
+    pub repos: Vec<schema::RegisteredRepo>,
+}
+
 impl IndexDatabase {
     pub fn open(path: &Path) -> anyhow::Result<Self> {
         Self::open_bare(path, BareOpenMode::ConfigLess)
@@ -426,6 +438,40 @@ impl IndexDatabase {
         schema::status(storage.connection())
     }
 
+    /// A DB-LEVEL, repo-agnostic overview of the store at `path` — for `doctor` invoked OUTSIDE any
+    /// rag-rat repo, where the repo-scoped opens (`open`, `open_config`) deliberately refuse to
+    /// guess a repo in a consolidated multi-repo store. Reports on-disk presence/size, the schema
+    /// status, and the registry of real repos the store holds (each with its recorded roots).
+    /// Side-effect-free when the file is ABSENT (returns `exists: false` without opening/creating
+    /// it); the registry is read only when the schema is `Compatible` (a Missing/Newer/Dirty schema
+    /// has no queryable `repos` table). The registry read is READ-ONLY.
+    pub fn global_store_overview(path: &Path) -> anyhow::Result<GlobalStoreOverview> {
+        if !path.is_file() {
+            return Ok(GlobalStoreOverview {
+                database: path.to_path_buf(),
+                exists: false,
+                size_bytes: None,
+                schema: None,
+                repos: Vec::new(),
+            });
+        }
+        let size_bytes = std::fs::metadata(path).ok().map(|meta| meta.len());
+        let schema = Self::migration_check(path)?;
+        let repos = if schema.state == schema::SchemaState::Compatible {
+            let storage = IndexConnection::open_read_only_blocking(path)?;
+            schema::registered_repos(storage.connection())?
+        } else {
+            Vec::new()
+        };
+        Ok(GlobalStoreOverview {
+            database: path.to_path_buf(),
+            exists: true,
+            size_bytes,
+            schema: Some(schema),
+            repos,
+        })
+    }
+
     /// Create-or-migrate the schema for a full [`rebuild`](Self::rebuild). Leaves the repo scope
     /// UNSET (`active_repo_id` empty): `rebuild` registers/adopts the repo and installs the scope
     /// context itself (so the model-manifest heal and every direct-scoped write see the right repo,
@@ -756,4 +802,71 @@ fn write_repo_generation_view(
         ",
     )?;
     Ok(())
+}
+
+#[cfg(test)]
+mod global_store_overview_tests {
+    use std::path::{Path, PathBuf};
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    use crate::index::IndexDatabase;
+    use crate::index::schema::{self, register_repo};
+    use crate::repo_identity::{RepoIdentity, RepoIdentityClass};
+    use crate::storage::IndexConnection;
+
+    static N: AtomicU64 = AtomicU64::new(0);
+
+    fn temp_db() -> PathBuf {
+        let id = N.fetch_add(1, Ordering::Relaxed);
+        std::env::temp_dir()
+            .join(format!("ragrat-gso-{}-{id}", std::process::id()))
+            .join("rag-rat.sqlite")
+    }
+
+    /// An ABSENT store is reported as `exists: false` WITHOUT opening or creating the file —
+    /// `doctor` invoked on a machine that has never indexed anything must not conjure an empty
+    /// global store.
+    #[test]
+    fn overview_reports_an_absent_store_without_creating_it() {
+        let path = temp_db();
+        let overview = IndexDatabase::global_store_overview(&path).unwrap();
+        assert!(!overview.exists);
+        assert!(overview.schema.is_none());
+        assert!(overview.repos.is_empty());
+        assert!(!path.exists(), "reporting an absent store must not create it");
+    }
+
+    /// A store with a registered repo lists it (with its recorded root) and EXCLUDES the
+    /// `__unassigned__` adoption placeholder — the DB-level report the config-less `doctor` shows.
+    #[test]
+    fn overview_lists_registered_repos_excluding_the_placeholder() {
+        let path = temp_db();
+        {
+            let conn = IndexConnection::open(&path).unwrap();
+            schema::apply(conn.connection()).unwrap();
+            register_repo(
+                conn.connection(),
+                &RepoIdentity {
+                    repo_id: "repo-xyz".to_string(),
+                    display_name: "demo".to_string(),
+                    class: RepoIdentityClass::Portable,
+                    shallow_boundary: Vec::new(),
+                },
+                Path::new("/src/demo"),
+                42,
+            )
+            .unwrap();
+        }
+
+        let overview = IndexDatabase::global_store_overview(&path).unwrap();
+        assert!(overview.exists);
+        assert_eq!(overview.schema.unwrap().state, schema::SchemaState::Compatible);
+        assert_eq!(overview.repos.len(), 1, "the '__unassigned__' placeholder is excluded");
+        let repo = &overview.repos[0];
+        assert_eq!(repo.repo_id, "repo-xyz");
+        assert_eq!(repo.display_name, "demo");
+        assert_eq!(repo.roots, vec!["/src/demo".to_string()]);
+
+        let _ = std::fs::remove_dir_all(path.parent().unwrap());
+    }
 }

--- a/crates/rag-rat-core/src/index/mod.rs
+++ b/crates/rag-rat-core/src/index/mod.rs
@@ -54,7 +54,7 @@ pub(crate) use git_context::*;
 // fallback. Gate the re-export so the non-test build doesn't warn it unused.
 #[cfg(test)]
 pub(crate) use lifecycle::install_scope_view;
-pub use lifecycle::{install_worktree_scope_view, resolve_scope_repo_id};
+pub use lifecycle::{GlobalStoreOverview, install_worktree_scope_view, resolve_scope_repo_id};
 pub(crate) use mem_diag::{maybe_set_sqlite_soft_heap_limit, mem_trace};
 pub(crate) use meta::{delete_repo_meta, repo_meta, set_repo_meta};
 pub use parser_failures::ParserFailure;
@@ -67,6 +67,7 @@ pub use query_api::{
     OracleShaSnapshots, RoiFactors, SearchRequest, TextCloneMatch, WAL_CHECKPOINT_MIN_BYTES,
     WalCheckpointReport,
 };
+pub use schema::RegisteredRepo;
 pub(crate) use util::*;
 pub use worktree_overlay::WorktreeOverlayReport;
 

--- a/crates/rag-rat-core/src/index/schema/mod.rs
+++ b/crates/rag-rat-core/src/index/schema/mod.rs
@@ -11,11 +11,11 @@ pub(crate) use registry::multiple_real_repos;
 pub(crate) use registry::{
     CONNECTION_CONTEXT_GENERATION_KEY, CONNECTION_CONTEXT_REPO_KEY, LIVE_FILES_GENERATION_META_KEY,
     active_generation, active_repo_id, connection_context_value, earliest_recorded_root,
-    live_files_generation, periphery_repo_scope, periphery_repo_scope_clause,
+    live_files_generation, periphery_repo_scope, periphery_repo_scope_clause, registered_repos,
     repo_has_recorded_root, repo_id_is_registered, resolve_config_repo_id, scope_context_repo_id,
     sole_repo_id,
 };
-pub use registry::{LEGACY_REPO_ID, register_repo, register_repo_read_only};
+pub use registry::{LEGACY_REPO_ID, RegisteredRepo, register_repo, register_repo_read_only};
 use rusqlite::{Connection, OptionalExtension, params};
 use serde::Serialize;
 

--- a/crates/rag-rat-core/src/index/schema/registry.rs
+++ b/crates/rag-rat-core/src/index/schema/registry.rs
@@ -1038,6 +1038,45 @@ pub(crate) fn multiple_real_repos(conn: &Connection) -> rusqlite::Result<bool> {
     Ok(count > 1)
 }
 
+/// One REAL (non-placeholder) repo in this database's registry, with its recorded source roots —
+/// the read-only shape `doctor`'s machine-global-store report lists. `roots` can be empty (identity
+/// registered but no root recorded yet).
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct RegisteredRepo {
+    pub repo_id: String,
+    pub display_name: String,
+    pub roots: Vec<String>,
+    pub registered_at_ms: i64,
+}
+
+/// List every REAL (non-placeholder) repo in the registry with its recorded roots, ordered by
+/// display name then id — read-only, for `doctor`'s global-store overview. Excludes the
+/// [`LEGACY_REPO_ID`] adoption placeholder.
+pub(crate) fn registered_repos(conn: &Connection) -> rusqlite::Result<Vec<RegisteredRepo>> {
+    let mut repos = conn
+        .prepare(
+            "SELECT repo_id, display_name, registered_at_ms FROM repos WHERE repo_id != ?1 ORDER \
+             BY display_name, repo_id",
+        )?
+        .query_map([LEGACY_REPO_ID], |row| {
+            Ok(RegisteredRepo {
+                repo_id: row.get(0)?,
+                display_name: row.get(1)?,
+                registered_at_ms: row.get(2)?,
+                roots: Vec::new(),
+            })
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    let mut roots_stmt =
+        conn.prepare("SELECT root FROM repo_roots WHERE repo_id = ?1 ORDER BY root")?;
+    for repo in &mut repos {
+        repo.roots = roots_stmt
+            .query_map([&repo.repo_id], |row| row.get::<_, String>(0))?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+    }
+    Ok(repos)
+}
+
 /// Resolve the `repo_id` a config maps to on a connection WITHOUT registering anything — the
 /// READ-path counterpart to [`register_repo`]. Used by the read-only open
 /// (`try_open_config_read_only`) and the raw-connection scope-view installers (the Claude Code /

--- a/crates/rag-rat-mcp/src/server.rs
+++ b/crates/rag-rat-mcp/src/server.rs
@@ -21,7 +21,11 @@ const TOOL_WORKERS_ENV: &str = "RAG_RAT_MCP_TOOL_WORKERS";
 
 #[derive(Clone)]
 pub struct RagRatService {
-    config: Config,
+    /// `None` ⇒ DORMANT: the server was launched outside any rag-rat repo (no `rag-rat.toml` at or
+    /// above cwd). It still speaks MCP so a globally-registered server stays alive, but every tool
+    /// call returns the dormant notice ([`dormant_tool_result`]) instead of touching an index.
+    /// `Some` ⇒ the active server bound to a resolved repo config.
+    config: Option<Config>,
     /// Output format for tool results. Defaults to TOON (denser for the LLM that reads them); set
     /// to JSON when the server was launched as `rag-rat mcp --json` — MCP has no per-call flag, so
     /// the choice is made once at launch (the CLI `--json` flag flows in via `run_stdio`).
@@ -34,7 +38,7 @@ pub struct RagRatService {
 }
 
 impl RagRatService {
-    pub fn new(config: Config, output_format: rag_rat_core::OutputFormat) -> Self {
+    pub fn new(config: Option<Config>, output_format: rag_rat_core::OutputFormat) -> Self {
         Self {
             config,
             output_format,
@@ -51,7 +55,15 @@ impl RagRatService {
     }
 
     fn call(&self, name: &str, value: Value) -> Result<CallToolResult, ErrorData> {
-        let value = crate::tools::call_tool_for_config(&self.config, name, value)
+        // Dormant (launched outside a repo): return the notice. We deliberately do NOT re-discover
+        // and serve a config that appears mid-session — a server without the active lifecycle
+        // (watcher, git-hook freshness) could return results NOT validated against current source,
+        // breaking rag-rat's core guarantee. Dormancy is binary: dormant, or fully active from
+        // launch. The notice tells the user to restart the MCP server after `init` + `index` (#603).
+        let Some(config) = &self.config else {
+            return Ok(self.dormant_tool_result());
+        };
+        let value = crate::tools::call_tool_for_config(config, name, value)
             .map_err(|err| ErrorData::internal_error(err.to_string(), None))?;
         // MCP tool results are text content read by an LLM, so render TOON by default — it is
         // materially denser than JSON on the uniform-row payloads that dominate these tools, and
@@ -96,10 +108,13 @@ impl RagRatService {
     /// (or concatenate all text blocks), and a prose block would break them. The nudge is
     /// agent-directed prose, meaningful only in the default TOON (LLM-facing) mode.
     fn stale_memory_nudge(&self) -> Option<String> {
+        // No nudge in dormant mode (no index to read) or in `--json` mode (prose breaks JSON
+        // clients).
+        let config = self.config.as_ref()?;
         if self.output_format == rag_rat_core::OutputFormat::Json {
             return None;
         }
-        let n = rag_rat_core::memory_attention_count(&self.config.database);
+        let n = rag_rat_core::memory_attention_count(&config.database);
         (n > 0).then(|| {
             let noun = if n == 1 { "memory" } else { "memories" };
             format!(
@@ -108,6 +123,23 @@ impl RagRatService {
                  source-anchored memory stays trustworthy for the next agent."
             )
         })
+    }
+
+    /// The result every tool call returns while the server is DORMANT (launched outside any rag-rat
+    /// repo, and cwd STILL has no config). Rendered through the SAME output-format path as every
+    /// tool result, so `--json` mode yields a directly-parseable JSON block (the JSON contract
+    /// holds in dormant mode too) while the default TOON mode stays LLM-friendly. NON-error:
+    /// the agent reads it as a normal response explaining how to enable an index.
+    fn dormant_tool_result(&self) -> CallToolResult {
+        let payload = serde_json::json!({
+            "status": "no_index",
+            "message": "rag-rat has no index for this directory — it doesn't look like a rag-rat \
+                        repository (no `rag-rat.toml` here or in any parent directory).",
+            "remedy": "Run `rag-rat init` then `rag-rat index` in the repository root; this server \
+                       picks up the new index on the next tool call, no restart needed.",
+        });
+        let text = rag_rat_core::render(&payload, self.output_format);
+        CallToolResult::success(vec![Content::text(text)])
     }
 }
 
@@ -319,7 +351,24 @@ fn tool_timeout_error(
     ))
 }
 
+/// `Some(config)` ⇒ the ACTIVE server bound to a resolved repo. `None` ⇒ a DORMANT server: the
+/// launch directory (and every parent) had no `rag-rat.toml`, so there is no repo to serve. A
+/// dormant server still speaks MCP — it just returns the dormant notice from every tool call —
+/// because a globally-registered `rag-rat mcp` is spawned in EVERY project, and dying in a
+/// non-rag-rat one takes repo intelligence down for that whole session (#603).
 pub async fn run_stdio(
+    config: Option<Config>,
+    output_format: rag_rat_core::OutputFormat,
+) -> anyhow::Result<()> {
+    match config {
+        Some(config) => run_stdio_active(config, output_format).await,
+        None => run_stdio_dormant(output_format).await,
+    }
+}
+
+/// The active server: keeps the index fresh (watcher), serves the grep-hook listener, and (Unix)
+/// arms the SIGUSR1 hot-upgrade.
+async fn run_stdio_active(
     config: Config,
     output_format: rag_rat_core::OutputFormat,
 ) -> anyhow::Result<()> {
@@ -332,10 +381,19 @@ pub async fn run_stdio(
         // Keep the index fresh while a session is connected; dropping the watcher on shutdown
         // runs a final timeout-skip pass. (Hot-upgrade is Unix-only.)
         let _watcher = rag_rat_core::watch::Watcher::spawn(config.clone());
-        let service = RagRatService::new(config, output_format).serve(stdio()).await?;
+        let service = RagRatService::new(Some(config), output_format).serve(stdio()).await?;
         service.waiting().await?;
         Ok(())
     }
+}
+
+/// The dormant server (no config resolved): no watcher, no hook listener, no hot-upgrade — nothing
+/// to keep fresh. It just serves the MCP protocol until the client disconnects; `tools/list` still
+/// advertises the full catalog, but every `tools/call` returns [`dormant_tool_result`].
+async fn run_stdio_dormant(output_format: rag_rat_core::OutputFormat) -> anyhow::Result<()> {
+    let running = RagRatService::new(None, output_format).serve(rmcp::transport::stdio()).await?;
+    running.waiting().await?;
+    Ok(())
 }
 
 /// Aborts a spawned task when dropped. Used to tear down the hook listener on normal EOF
@@ -366,7 +424,7 @@ async fn run_stdio_unix(
     use crate::upgrade::{self, GatedStdin, Upgrade, UpgradeGate};
 
     let gate = UpgradeGate::new();
-    let service = RagRatService::new(config.clone(), output_format);
+    let service = RagRatService::new(Some(config.clone()), output_format);
     let inflight = service.inflight();
 
     let transport = (GatedStdin::new(tokio::io::stdin(), Arc::clone(&gate)), tokio::io::stdout());
@@ -487,7 +545,7 @@ mod tests {
 
     fn service_over_temp_repo() -> (PathBuf, RagRatService) {
         let (root, config) = config_over_temp_repo();
-        (root, RagRatService::new(config, OutputFormat::Toon))
+        (root, RagRatService::new(Some(config), OutputFormat::Toon))
     }
 
     fn ok_result() -> CallToolResult {
@@ -710,7 +768,7 @@ mod tests {
     fn stale_memory_nudge_rides_toon_but_not_json() {
         let (root, config) = config_over_temp_repo();
         // A memory bound to an unindexed/absent path resolves `gone` → drift the nudge reports.
-        let toon = RagRatService::new(config.clone(), OutputFormat::Toon);
+        let toon = RagRatService::new(Some(config.clone()), OutputFormat::Toon);
         toon.call(
             "memory_create",
             json!({
@@ -732,7 +790,7 @@ mod tests {
         assert_eq!(toon_result.content.len(), 2, "TOON result carries the nudge block");
 
         // JSON mode: suppressed (single parseable block).
-        let json_svc = RagRatService::new(config, OutputFormat::Json);
+        let json_svc = RagRatService::new(Some(config), OutputFormat::Json);
         let json_result = json_svc.call("index_status", json!({})).unwrap();
         assert_eq!(json_result.content.len(), 1, "JSON result omits the prose nudge");
 

--- a/crates/rag-rat-mcp/src/server.rs
+++ b/crates/rag-rat-mcp/src/server.rs
@@ -59,7 +59,8 @@ impl RagRatService {
         // and serve a config that appears mid-session — a server without the active lifecycle
         // (watcher, git-hook freshness) could return results NOT validated against current source,
         // breaking rag-rat's core guarantee. Dormancy is binary: dormant, or fully active from
-        // launch. The notice tells the user to restart the MCP server after `init` + `index` (#603).
+        // launch. The notice tells the user to restart the MCP server after `init` + `index`
+        // (#603).
         let Some(config) = &self.config else {
             return Ok(self.dormant_tool_result());
         };
@@ -133,10 +134,10 @@ impl RagRatService {
     fn dormant_tool_result(&self) -> CallToolResult {
         let payload = serde_json::json!({
             "status": "no_index",
-            "message": "rag-rat has no index for this directory — it doesn't look like a rag-rat \
-                        repository (no `rag-rat.toml` here or in any parent directory).",
-            "remedy": "Run `rag-rat init` then `rag-rat index` in the repository root; this server \
-                       picks up the new index on the next tool call, no restart needed.",
+            "message": "This rag-rat MCP server was started outside an indexed rag-rat repository, \
+                        so it has no index to serve here.",
+            "remedy": "Run `rag-rat init` then `rag-rat index` in the repository root, then restart \
+                       (reconnect) the rag-rat MCP server so it activates against the new index.",
         });
         let text = rag_rat_core::render(&payload, self.output_format);
         CallToolResult::success(vec![Content::text(text)])

--- a/crates/rag-rat-mcp/src/server.rs
+++ b/crates/rag-rat-mcp/src/server.rs
@@ -38,7 +38,24 @@ pub struct RagRatService {
 }
 
 impl RagRatService {
-    pub fn new(config: Option<Config>, output_format: rag_rat_core::OutputFormat) -> Self {
+    /// The ACTIVE server bound to a resolved repo config. Published constructor — its
+    /// `new(Config, …)` signature is preserved for source compatibility; the config-less DORMANT
+    /// server is built via [`RagRatService::new_dormant`] instead of widening this to `Option`.
+    pub fn new(config: Config, output_format: rag_rat_core::OutputFormat) -> Self {
+        Self::with_optional_config(Some(config), output_format)
+    }
+
+    /// The DORMANT server (launched outside any rag-rat repo): no config, so every tool call
+    /// returns [`RagRatService::dormant_tool_result`]. Separate from [`RagRatService::new`] so
+    /// that constructor's published signature stays source-compatible (#603).
+    pub(crate) fn new_dormant(output_format: rag_rat_core::OutputFormat) -> Self {
+        Self::with_optional_config(None, output_format)
+    }
+
+    fn with_optional_config(
+        config: Option<Config>,
+        output_format: rag_rat_core::OutputFormat,
+    ) -> Self {
         Self {
             config,
             output_format,
@@ -62,6 +79,12 @@ impl RagRatService {
         // launch. The notice tells the user to restart the MCP server after `init` + `index`
         // (#603).
         let Some(config) = &self.config else {
+            // A dormant server still rejects an UNKNOWN tool name exactly like an active one, so a
+            // typo or stale tool surfaces as an error instead of being masked as `no_index`. Only a
+            // KNOWN (advertised) tool earns the dormant notice.
+            if !crate::tools::is_known_tool(name) {
+                return Err(ErrorData::internal_error(format!("unknown tool `{name}`"), None));
+            }
             return Ok(self.dormant_tool_result());
         };
         let value = crate::tools::call_tool_for_config(config, name, value)
@@ -352,24 +375,11 @@ fn tool_timeout_error(
     ))
 }
 
-/// `Some(config)` ⇒ the ACTIVE server bound to a resolved repo. `None` ⇒ a DORMANT server: the
-/// launch directory (and every parent) had no `rag-rat.toml`, so there is no repo to serve. A
-/// dormant server still speaks MCP — it just returns the dormant notice from every tool call —
-/// because a globally-registered `rag-rat mcp` is spawned in EVERY project, and dying in a
-/// non-rag-rat one takes repo intelligence down for that whole session (#603).
+/// Serve the stdio MCP server for a RESOLVED repo config — the ACTIVE server: keeps the index fresh
+/// (watcher), serves the grep-hook listener, and (Unix) arms the SIGUSR1 hot-upgrade. Published
+/// entry point; its `run_stdio(Config, …)` signature is preserved for source compatibility. The
+/// config-less DORMANT server is [`run_stdio_dormant`].
 pub async fn run_stdio(
-    config: Option<Config>,
-    output_format: rag_rat_core::OutputFormat,
-) -> anyhow::Result<()> {
-    match config {
-        Some(config) => run_stdio_active(config, output_format).await,
-        None => run_stdio_dormant(output_format).await,
-    }
-}
-
-/// The active server: keeps the index fresh (watcher), serves the grep-hook listener, and (Unix)
-/// arms the SIGUSR1 hot-upgrade.
-async fn run_stdio_active(
     config: Config,
     output_format: rag_rat_core::OutputFormat,
 ) -> anyhow::Result<()> {
@@ -382,17 +392,20 @@ async fn run_stdio_active(
         // Keep the index fresh while a session is connected; dropping the watcher on shutdown
         // runs a final timeout-skip pass. (Hot-upgrade is Unix-only.)
         let _watcher = rag_rat_core::watch::Watcher::spawn(config.clone());
-        let service = RagRatService::new(Some(config), output_format).serve(stdio()).await?;
+        let service = RagRatService::new(config, output_format).serve(stdio()).await?;
         service.waiting().await?;
         Ok(())
     }
 }
 
-/// The dormant server (no config resolved): no watcher, no hook listener, no hot-upgrade — nothing
-/// to keep fresh. It just serves the MCP protocol until the client disconnects; `tools/list` still
-/// advertises the full catalog, but every `tools/call` returns [`dormant_tool_result`].
-async fn run_stdio_dormant(output_format: rag_rat_core::OutputFormat) -> anyhow::Result<()> {
-    let running = RagRatService::new(None, output_format).serve(rmcp::transport::stdio()).await?;
+/// The DORMANT server (launched outside any rag-rat repo, so no config resolved): no watcher, no
+/// hook listener, no hot-upgrade — nothing to keep fresh. It just serves the MCP protocol until the
+/// client disconnects; `tools/list` still advertises the full catalog, but every `tools/call`
+/// returns [`RagRatService::dormant_tool_result`]. Split from [`run_stdio`] so that published
+/// `run_stdio(Config)` signature stays source-compatible, while a globally-registered `rag-rat mcp`
+/// can still stay alive in a non-rag-rat project instead of dying (#603).
+pub async fn run_stdio_dormant(output_format: rag_rat_core::OutputFormat) -> anyhow::Result<()> {
+    let running = RagRatService::new_dormant(output_format).serve(rmcp::transport::stdio()).await?;
     running.waiting().await?;
     Ok(())
 }
@@ -425,7 +438,7 @@ async fn run_stdio_unix(
     use crate::upgrade::{self, GatedStdin, Upgrade, UpgradeGate};
 
     let gate = UpgradeGate::new();
-    let service = RagRatService::new(Some(config.clone()), output_format);
+    let service = RagRatService::new(config.clone(), output_format);
     let inflight = service.inflight();
 
     let transport = (GatedStdin::new(tokio::io::stdin(), Arc::clone(&gate)), tokio::io::stdout());
@@ -546,7 +559,7 @@ mod tests {
 
     fn service_over_temp_repo() -> (PathBuf, RagRatService) {
         let (root, config) = config_over_temp_repo();
-        (root, RagRatService::new(Some(config), OutputFormat::Toon))
+        (root, RagRatService::new(config, OutputFormat::Toon))
     }
 
     fn ok_result() -> CallToolResult {
@@ -769,7 +782,7 @@ mod tests {
     fn stale_memory_nudge_rides_toon_but_not_json() {
         let (root, config) = config_over_temp_repo();
         // A memory bound to an unindexed/absent path resolves `gone` → drift the nudge reports.
-        let toon = RagRatService::new(Some(config.clone()), OutputFormat::Toon);
+        let toon = RagRatService::new(config.clone(), OutputFormat::Toon);
         toon.call(
             "memory_create",
             json!({
@@ -791,7 +804,7 @@ mod tests {
         assert_eq!(toon_result.content.len(), 2, "TOON result carries the nudge block");
 
         // JSON mode: suppressed (single parseable block).
-        let json_svc = RagRatService::new(Some(config), OutputFormat::Json);
+        let json_svc = RagRatService::new(config, OutputFormat::Json);
         let json_result = json_svc.call("index_status", json!({})).unwrap();
         assert_eq!(json_result.content.len(), 1, "JSON result omits the prose nudge");
 

--- a/crates/rag-rat-mcp/src/tools/mod.rs
+++ b/crates/rag-rat-mcp/src/tools/mod.rs
@@ -71,6 +71,15 @@ fn is_read_only_tool(name: &str) -> bool {
     !is_write_tool(name)
 }
 
+/// Whether `name` is an advertised tool. [`TOOL_NAMES`] is the single source of truth `list_tools`
+/// advertises and is kept routable by the dispatcher
+/// (`mcp_stdio_every_advertised_tool_is_routable`), so this is the same "is this a real tool" test
+/// the active `call_tool_for_config` applies — used by the dormant server to reject an
+/// unknown/misspelled name instead of masking it as `no_index`.
+pub(crate) fn is_known_tool(name: &str) -> bool {
+    TOOL_NAMES.contains(&name)
+}
+
 /// Read tools that compare indexed graph/symbol data against LIVE on-disk source text, read through
 /// the stored `source_root` (the MAIN checkout). Under a linked-worktree overlay scope these tools'
 /// GRAPH side would come from the branch overlay while their TEXT side still read the main


### PR DESCRIPTION
## Problem

`rag-rat` is typically registered as a **global** MCP server, so the harness (Claude Code / Codex) spawns `rag-rat mcp` in *every* project — including ones with no `rag-rat.toml`. `main()` loaded the config for every command except `init`/`claude-hook`; with no config it `bail!`ed and the process exited **1**. For `mcp` this happened *before* `run_stdio`, so the server never spoke a single JSON-RPC frame — the client saw a dead server and repo intelligence was down for the whole session.

```
$ rag-rat mcp        # dir with no rag-rat.toml
Error: No rag-rat config found at `./rag-rat.toml`.
exit=1
```

## What changed

- **`rag-rat mcp` boots dormant instead of dying.** With no config at or above cwd it serves the full `tools/list` catalog and returns a structured `{status:"no_index", message, remedy}` result from every `tools/call`, rendered through the launch output format (so `--json` stays parseable), and stays alive. It still **rejects an unknown tool name** like an active server (a typo surfaces as an error, not `no_index`). A **present-but-invalid** config, an explicit `--config` that is missing, or a path that exists but isn't a readable file, is still a loud error.
- **Dormancy is binary, decided at launch.** A launched-dormant server does **not** re-discover and serve a config that appears mid-session — a server without the active lifecycle (watcher, git-hook freshness) could return results not validated against current source, breaking rag-rat's core guarantee. The notice tells the user to **restart the MCP server** after `init` + `index`; a restart brings up the full active server.
- **Config discovery walks up the directory tree**, bounded at the enclosing git repo root. A launch from a subdirectory of a rag-rat repo resolves that repo's config; a nested checkout / submodule with no config of its own does **not** adopt an indexed parent's config (that would mis-target searches and memory writes). A subdirectory launch inside a **linked worktree** finds a branch-local `rag-rat.toml` at the worktree root (routing through the governing seam + divergence warning) before falling back to main — with no branch-local config anywhere it still resolves to main's path (the governing-seam invariant).
- **`rag-rat doctor` reports the machine-global store** (`$XDG_DATA_HOME/rag-rat/rag-rat.sqlite`) when there is no local config — schema, on-disk size, and the registry of repos it holds — instead of erroring. It reads through a **read-only** connection so it works on a read-only mount/backup. (The repo-scoped opens can't run against a multi-repo store, so this is a distinct DB-level report.)

## Compatibility

`rag-rat-mcp` is published, so the `RagRatService::new(Config, …)` and `run_stdio(Config, …)` signatures are **preserved**; the dormant path uses new `new_dormant` / `run_stdio_dormant` entry points. No source-breaking change to the published API.

## Behavior matrix

| cwd state | `rag-rat mcp` | `rag-rat doctor` |
|---|---|---|
| local `rag-rat.toml` | active server | repo report |
| subdir of a rag-rat repo | active (walk-up finds) | repo report (walk-up) |
| linked worktree subdir, branch-local config | active (branch config) | repo report (branch config) |
| linked worktree, no branch config | active (main governs) | repo report (main governs) |
| nested repo / submodule, no own config | **dormant** (boundary) | **global-store report** |
| no config anywhere, global store exists | **dormant, stays alive** | **global-store report** |
| no config, no data dir | dormant, stays alive | friendly "no config" hint |
| present-but-invalid / bad `--config` | loud error | loud error |

## Tests

- `discover_config_path_*` — subdir → repo config; **nested repo boundary** (no parent adoption); **linked-worktree subdir** finds a branch-local config, else main; the relative-`.` walk footgun; existing governing-seam regressions retained.
- `mcp_stdio_serves_dormant_without_a_config` — dormant server answers `initialize` + `tools/list`, returns the `no_index` result, **rejects an unknown tool**, stays alive.
- `mcp_stdio_dormant_result_is_valid_json_in_json_mode` — the dormant result is valid JSON under `--json`.
- `mcp_stdio_dormant_server_stays_dormant_until_restart` — no mid-session half-activation.
- `global_store_overview` unit tests — absent store reported without creating it; registered repos listed with roots, placeholder excluded; read-only throughout.

Full workspace suite green (`cargo nextest run --workspace --no-default-features`), fmt + clippy clean.

Fixes #603
