### PR TITLE
fix(cookbook): self-destruct a leaked Modal box on idleness — window = provision budget + 3 min grace (release 0.6.3)

### DIFF
--- a/cookbook/package-lock.json
+++ b/cookbook/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rag-rat/cookbook",
-  "version": "0.6.1",
+  "version": "0.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rag-rat/cookbook",
-      "version": "0.6.1",
+      "version": "0.6.3",
       "license": "MIT",
       "dependencies": {
         "modal": "^0.8.1"

--- a/cookbook/package.json
+++ b/cookbook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rag-rat/cookbook",
-  "version": "0.6.1",
+  "version": "0.6.3",
   "description": "Ephemeral remote-runtime provisioning recipes for rag-rat. rag-rat (Rust) spawns a recipe as a subprocess, reads a typed JSONL event stream from its stdout (status/log/ready/error), embeds against the endpoint, then signals teardown.",
   "license": "MIT",
   "repository": {

--- a/cookbook/recipes/modal.mts
+++ b/cookbook/recipes/modal.mts
@@ -22,8 +22,13 @@
  *   - GPU: ollama/infinity default to CPU (GPU is opt-in and, for ollama, must attach before its
  *     discovery watchdog times out or the box dies exit 137). vLLM's image is CUDA-only, so when the
  *     backend `requiresGpu` and the caller passed none we default one in ({@link MODAL_DEFAULT_GPU}).
- *   - timeout=1800s (30 min) is the provider-side max-lifetime backstop: if rag-rat dies or
- *     SIGKILLs us before teardown runs, Modal self-destructs the box. (RunPod has no equivalent.)
+ *   - Two provider-side backstops guard against a leaked box when rag-rat dies or SIGKILLs us
+ *     before teardown runs. idleTimeoutMs self-destructs the box once it goes idle (Modal counts
+ *     only a running exec, an stdin write, or an open tunnel TCP connection as activity — NOT the
+ *     serve process); timeout=1800s (30 min) is the unconditional max-lifetime cap. The idle window
+ *     is `provisionTimeoutMs + SERVING_IDLE_GRACE_MS`, NOT a bare few minutes: the idle clock runs
+ *     from creation and a vLLM/infinity cold start opens no tunnel until it serves, so a short
+ *     window would kill a legit slow boot. (RunPod has neither backstop.)
  *
  * The harness ({@link runRecipe}) owns the terminate-on-error wrapper and the provision-timeout
  * clamp, so this recipe is just: create the box, report it via `ctx.onBox`, (pull,) verify, return.
@@ -52,6 +57,39 @@ import { assertCapabilitySupported, selectBackendSpec } from "./backends.mjs";
 
 /** Provider-side max-lifetime backstop in ms — a leaked box self-destructs after this. */
 const BOX_MAX_LIFETIME_MS = 1_800_000; // 30 minutes
+/**
+ * Serving-phase margin (ms) added ON TOP OF the provisioning budget to form the box's `idleTimeoutMs`
+ * (see {@link idleWindowMs}). Modal terminates a box after `idleTimeoutMs` of NO activity — where
+ * "active" means a running `sb.exec`, an `sb.stdin` write, or an OPEN TCP CONNECTION OVER A TUNNEL;
+ * the main serve process does NOT count. Once serving, rag-rat's keep-alive HTTP pool holds a tunnel
+ * connection open, so a live job keeps the box active; when the owning rag-rat process dies (crash,
+ * killed terminal) its connections drop and the box eventually goes idle and self-destructs instead
+ * of billing to BOX_MAX_LIFETIME_MS.
+ *
+ * Why the window is provision-budget + margin, not a bare few minutes: the idle clock runs from
+ * CREATION, and a vLLM/infinity cold start (image pull + model load) opens no tunnel until the
+ * recipe's verify step, so a short window would self-destruct a legit slow boot before it ever
+ * serves. The provision budget already bounds that boot-idle gap (the recipe aborts + tears down if
+ * boot overruns it), so a window ≥ it can never fire mid-boot.
+ *
+ * RECLAIM TIME, stated honestly: Modal restarts the idle countdown on EVERY activity, so a box
+ * orphaned mid-serve is reclaimed after the FULL window elapses from its last request — i.e.
+ * `provisionTimeoutMs + this margin`, NOT just this margin. That is minutes-to-low-tens-of-minutes
+ * (well under the 30-min max-lifetime cap), the price of a single static value: SDK 0.8.1 has no
+ * post-create setter to tighten the idle timeout once the box is past boot and serving.
+ */
+const SERVING_IDLE_GRACE_MS = 180_000; // 3 minutes past the provisioning budget
+
+/**
+ * The box's idle window: the provisioning budget (rounded UP to a whole second) plus the
+ * serving-phase margin. Rounding keeps it an integer number of seconds — Modal encodes idle timeout
+ * as a uint32 seconds field, so a fractional `provision_timeout_s` (the contract allows one) must
+ * not produce a sub-second `idleTimeoutMs`. Rounding UP preserves the "≥ provisionTimeoutMs" boot
+ * guarantee above.
+ */
+function idleWindowMs(provisionTimeoutMs: number): number {
+  return Math.ceil(provisionTimeoutMs / 1000) * 1000 + SERVING_IDLE_GRACE_MS;
+}
 /** Default provisioning budget (boot + pull + first serving response) when input omits it. */
 const DEFAULT_PROVISION_TIMEOUT_S = 600;
 /** Modal app the sandboxes are grouped under (created on first use). */
@@ -121,6 +159,7 @@ async function provision(ctx: ProvisionContext<Sandbox>): Promise<Provisioned<Sa
         encryptedPorts: [port],
         readinessProbe: Probe.withTcp(port, { intervalMs: 1000 }),
         timeoutMs: BOX_MAX_LIFETIME_MS,
+        idleTimeoutMs: idleWindowMs(provisionTimeoutMs),
         ...(gpu !== null ? { gpu } : {}),
       });
       return createRef.promise;


### PR DESCRIPTION
## Problem

The Modal recipe (`cookbook/recipes/modal.mts`) set only `timeoutMs` (30-min max-lifetime) on `sandboxes.create`. So a box whose owning rag-rat process dies before SIGTERM teardown runs — a crashed terminal, a `SIGKILL` — or whose `sb.terminate()` transiently fails kept billing for up to the full 30 minutes. The Rust-side teardown (`teardown_group`: SIGTERM → grace → SIGKILL on the process group) reliably reaps the **local** processes, but only the recipe's `sb.terminate()` reclaims the **remote** GPU box; when that one call doesn't land, the max-lifetime cap was the only net. Observed in the wild: a `--compact` run finished, the log showed SIGTERM being sent, and the previous `rag-rat-cookbook` GPU sandbox kept serving for ~17 minutes.

## Fix

Add Modal's `idleTimeoutMs` so an idle box self-destructs sooner. Modal counts a running `sb.exec`, an `sb.stdin` write, or an open tunnel TCP connection as activity (the serve process does **not** count), so rag-rat's keep-alive HTTP pool keeps a live job's box active and a dead client's dropped connections let it go idle.

The idle window is `provisionTimeoutMs + SERVING_IDLE_GRACE_MS` (3-min grace), **not** a bare few minutes:

- The idle clock runs from **creation**, and a vLLM/infinity cold start (image pull + model load) opens no tunnel until the recipe's verify step — a short window would self-destruct a legitimate slow boot before it ever serves.
- The provision budget already bounds the boot-idle gap (the recipe aborts and tears down if boot overruns it), so a window ≥ it can never fire mid-boot.
- Rounded up to a whole second: Modal encodes the idle timeout as a uint32 seconds field, and the contract allows a fractional `provision_timeout_s`.

**Reclaim time, stated honestly:** Modal restarts the idle countdown on every activity, so an orphaned box is reclaimed after the full window from its last request (`provisionTimeoutMs + 3 min`) — minutes to low-tens-of-minutes, well under the 30-min cap. A single static create-time value can't also give a flat 3-min reclaim: SDK 0.8.1 has no post-create setter to tighten the idle timeout once the box is past boot. Layering is now SIGTERM teardown (primary) → idle window (crash/flake recovery) → 30-min max-lifetime (final cap). Applies to every Modal backend; RunPod has no equivalent.

## Release

- Bumps `@rag-rat/cookbook` to **0.6.3** (published). `0.6.2` briefly shipped a bare 3-min idle that could kill a slow cold start and has been **deprecated** on npm in favor of `>= 0.6.3`.