### PR TITLE
chore: release v0.17.0

### DIFF
--- a/.agents/skills/init-rag-rat/SKILL.md
+++ b/.agents/skills/init-rag-rat/SKILL.md
@@ -32,7 +32,7 @@ hand-write a config blind, and let a real config load re-check it before indexin
    do **not** use `@latest`, and **don't blindly trust an on-`PATH` `rag-rat`**:
    - If `rag-rat` is on `PATH`, check `rag-rat --version` and use it **only if it matches** the
      plugin/MCP version — a stale global install would build the index with the wrong binary.
-   - Otherwise (or on a version mismatch) use `npx -y @rag-rat/bin@0.16.0 …` — the plugin pins
+   - Otherwise (or on a version mismatch) use `npx -y @rag-rat/bin@0.17.0 …` — the plugin pins
      `@rag-rat/bin` to its own version and caches the binary privately, so this is the
      version-matched CLI; `npx` runs it in the current directory.
 

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "rag-rat",
       "description": "Local repo-intelligence index + MCP server: semantic search, symbol/graph navigation, impact-surface preflight, git + GitHub papertrail, and a source-anchored memory graph.",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "source": "./plugin",
       "category": "developer-tools",
       "license": "MIT",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-core-v0.16.0...rag-rat-core-v0.17.0) - 2026-07-11
+
+### Added
+
+- *(plugin)* one-step plugin for Claude Code + Codex — MCP via npx, harness-neutral hooks ([#569](https://github.com/cq27-dev/rag-rat/pull/569))
+- *(account)* the stratified control-log fold (§11–§12) ([#622](https://github.com/cq27-dev/rag-rat/pull/622))
+- *(dist)* ship an android/Termux binary + make npx @rag-rat/bin work there ([#616](https://github.com/cq27-dev/rag-rat/pull/616)) ([#621](https://github.com/cq27-dev/rag-rat/pull/621))
+- *(account)* sync phase C1 wire/crypto layer + fold foundation ([#618](https://github.com/cq27-dev/rag-rat/pull/618))
+- *(doctor)* reclaim freelist dead space with `doctor --vacuum` ([#574](https://github.com/cq27-dev/rag-rat/pull/574)) ([#613](https://github.com/cq27-dev/rag-rat/pull/613))
+
+### Fixed
+
+- *(mcp)* boot a dormant server outside a rag-rat repo instead of dying ([#603](https://github.com/cq27-dev/rag-rat/pull/603)) ([#611](https://github.com/cq27-dev/rag-rat/pull/611))
+
 ## [0.16.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-core-v0.15.0...rag-rat-core-v0.16.0) - 2026-07-10
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3443,7 +3443,7 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rag-rat"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3469,7 +3469,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-core"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -3518,7 +3518,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-mcp"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "3"
 # and the internal path deps below pin the same literal, so the three crates always publish in
 # lockstep. Bump this one line (and the two internal-dep `version`s under workspace.dependencies)
 # to release.
-version = "0.16.0"
+version = "0.17.0"
 authors = ["Kristaps Karlsons"]
 edition = "2024"
 # Bundled SQLite (rusqlite `bundled` -> libsqlite3-sys 0.38.1) compiles a build script that uses the
@@ -28,8 +28,8 @@ categories = ["command-line-utilities", "development-tools"]
 # Internal crates — declared once here so the version requirement is set in lockstep with
 # [workspace.package].version above. Members reference these via `{ workspace = true }` and add
 # their own feature toggles at the use site.
-rag-rat-core = { version = "0.16.0", path = "crates/rag-rat-core", default-features = false }
-rag-rat-mcp = { version = "0.16.0", path = "crates/rag-rat-mcp", default-features = false }
+rag-rat-core = { version = "0.17.0", path = "crates/rag-rat-core", default-features = false }
+rag-rat-mcp = { version = "0.17.0", path = "crates/rag-rat-mcp", default-features = false }
 anyhow = "1.0"
 # ed25519 device-identity signing for the op-log's signed entry envelope (§C4 layer-1). Default
 # features (incl. `zeroize`, which zeroizes a `SigningKey`'s seed on drop) are kept; the `rand_core`

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "rag-rat",
   "displayName": "rag-rat",
   "description": "Local repo-intelligence index + MCP server: semantic search, symbol/graph navigation, impact-surface preflight, git + GitHub papertrail, and a source-anchored memory graph.",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "author": { "name": "Kristaps Karlsons" },
   "homepage": "https://github.com/cq27-dev/rag-rat",
   "repository": "https://github.com/cq27-dev/rag-rat",
@@ -11,7 +11,7 @@
   "mcpServers": {
     "rag-rat": {
       "command": "npx",
-      "args": ["-y", "@rag-rat/bin@0.16.0", "mcp"]
+      "args": ["-y", "@rag-rat/bin@0.17.0", "mcp"]
     }
   }
 }

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rag-rat",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Local repo-intelligence index + MCP server: semantic search, symbol/graph navigation, impact-surface preflight, git + GitHub papertrail, and a source-anchored memory graph.",
   "author": { "name": "Kristaps Karlsons", "url": "https://github.com/cq27-dev/rag-rat" },
   "homepage": "https://github.com/cq27-dev/rag-rat",

--- a/plugin/.mcp.json
+++ b/plugin/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "rag-rat": {
       "command": "npx",
-      "args": ["-y", "@rag-rat/bin@0.16.0", "mcp"]
+      "args": ["-y", "@rag-rat/bin@0.17.0", "mcp"]
     }
   }
 }

--- a/plugin/skills/init-rag-rat/SKILL.md
+++ b/plugin/skills/init-rag-rat/SKILL.md
@@ -32,7 +32,7 @@ hand-write a config blind, and let a real config load re-check it before indexin
    do **not** use `@latest`, and **don't blindly trust an on-`PATH` `rag-rat`**:
    - If `rag-rat` is on `PATH`, check `rag-rat --version` and use it **only if it matches** the
      plugin/MCP version — a stale global install would build the index with the wrong binary.
-   - Otherwise (or on a version mismatch) use `npx -y @rag-rat/bin@0.16.0 …` — the plugin pins
+   - Otherwise (or on a version mismatch) use `npx -y @rag-rat/bin@0.17.0 …` — the plugin pins
      `@rag-rat/bin` to its own version and caches the binary privately, so this is the
      version-matched CLI; `npx` runs it in the current directory.
 


### PR DESCRIPTION



## 🤖 New release

* `rag-rat-core`: 0.16.0 -> 0.17.0 (✓ API compatible changes)
* `rag-rat-mcp`: 0.16.0 -> 0.17.0 (⚠ API breaking changes)
* `rag-rat`: 0.16.0 -> 0.17.0

### ⚠ `rag-rat-mcp` breaking changes

```text
--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/function_missing.ron

Failed in:
  function rag_rat_mcp::claude_hook::socket_path_for, previously in file /tmp/.tmpi9MRDQ/rag-rat-mcp/src/claude_hook.rs:59
  function rag_rat_mcp::claude_hook::spawn_listener, previously in file /tmp/.tmpi9MRDQ/rag-rat-mcp/src/claude_hook.rs:77

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/module_missing.ron

Failed in:
  mod rag_rat_mcp::claude_hook, previously in file /tmp/.tmpi9MRDQ/rag-rat-mcp/src/claude_hook.rs:1

--- failure pub_module_level_const_missing: pub module-level const is missing ---

Description:
A public const is missing or renamed
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/pub_module_level_const_missing.ron

Failed in:
  PROTOCOL_VERSION in file /tmp/.tmpi9MRDQ/rag-rat-mcp/src/claude_hook.rs:8

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_missing.ron

Failed in:
  struct rag_rat_mcp::claude_hook::HookRequest, previously in file /tmp/.tmpi9MRDQ/rag-rat-mcp/src/claude_hook.rs:13
  struct rag_rat_mcp::claude_hook::HookResponse, previously in file /tmp/.tmpi9MRDQ/rag-rat-mcp/src/claude_hook.rs:29
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `rag-rat-core`

<blockquote>

## [0.17.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-core-v0.16.0...rag-rat-core-v0.17.0) - 2026-07-11

### Added

- *(plugin)* one-step plugin for Claude Code + Codex — MCP via npx, harness-neutral hooks ([#569](https://github.com/cq27-dev/rag-rat/pull/569))
- *(account)* the stratified control-log fold (§11–§12) ([#622](https://github.com/cq27-dev/rag-rat/pull/622))
- *(dist)* ship an android/Termux binary + make npx @rag-rat/bin work there ([#616](https://github.com/cq27-dev/rag-rat/pull/616)) ([#621](https://github.com/cq27-dev/rag-rat/pull/621))
- *(account)* sync phase C1 wire/crypto layer + fold foundation ([#618](https://github.com/cq27-dev/rag-rat/pull/618))
- *(doctor)* reclaim freelist dead space with `doctor --vacuum` ([#574](https://github.com/cq27-dev/rag-rat/pull/574)) ([#613](https://github.com/cq27-dev/rag-rat/pull/613))

### Fixed

- *(mcp)* boot a dormant server outside a rag-rat repo instead of dying ([#603](https://github.com/cq27-dev/rag-rat/pull/603)) ([#611](https://github.com/cq27-dev/rag-rat/pull/611))
</blockquote>

## `rag-rat-mcp`

<blockquote>

## [0.17.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-core-v0.16.0...rag-rat-core-v0.17.0) - 2026-07-11

### Added

- *(plugin)* one-step plugin for Claude Code + Codex — MCP via npx, harness-neutral hooks ([#569](https://github.com/cq27-dev/rag-rat/pull/569))
- *(account)* the stratified control-log fold (§11–§12) ([#622](https://github.com/cq27-dev/rag-rat/pull/622))
- *(dist)* ship an android/Termux binary + make npx @rag-rat/bin work there ([#616](https://github.com/cq27-dev/rag-rat/pull/616)) ([#621](https://github.com/cq27-dev/rag-rat/pull/621))
- *(account)* sync phase C1 wire/crypto layer + fold foundation ([#618](https://github.com/cq27-dev/rag-rat/pull/618))
- *(doctor)* reclaim freelist dead space with `doctor --vacuum` ([#574](https://github.com/cq27-dev/rag-rat/pull/574)) ([#613](https://github.com/cq27-dev/rag-rat/pull/613))

### Fixed

- *(mcp)* boot a dormant server outside a rag-rat repo instead of dying ([#603](https://github.com/cq27-dev/rag-rat/pull/603)) ([#611](https://github.com/cq27-dev/rag-rat/pull/611))
</blockquote>

## `rag-rat`

<blockquote>

## [0.17.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-core-v0.16.0...rag-rat-core-v0.17.0) - 2026-07-11

### Added

- *(plugin)* one-step plugin for Claude Code + Codex — MCP via npx, harness-neutral hooks ([#569](https://github.com/cq27-dev/rag-rat/pull/569))
- *(account)* the stratified control-log fold (§11–§12) ([#622](https://github.com/cq27-dev/rag-rat/pull/622))
- *(dist)* ship an android/Termux binary + make npx @rag-rat/bin work there ([#616](https://github.com/cq27-dev/rag-rat/pull/616)) ([#621](https://github.com/cq27-dev/rag-rat/pull/621))
- *(account)* sync phase C1 wire/crypto layer + fold foundation ([#618](https://github.com/cq27-dev/rag-rat/pull/618))
- *(doctor)* reclaim freelist dead space with `doctor --vacuum` ([#574](https://github.com/cq27-dev/rag-rat/pull/574)) ([#613](https://github.com/cq27-dev/rag-rat/pull/613))

### Fixed

- *(mcp)* boot a dormant server outside a rag-rat repo instead of dying ([#603](https://github.com/cq27-dev/rag-rat/pull/603)) ([#611](https://github.com/cq27-dev/rag-rat/pull/611))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).