### PR TITLE
feat(account): sync phase C1 wire/crypto layer + fold foundation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3511,6 +3511,7 @@ dependencies = [
  "tree-sitter-typescript",
  "unicode-normalization",
  "ureq 3.3.0",
+ "x25519-dalek",
  "zeroize",
  "zstd",
 ]
@@ -5532,6 +5533,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core 0.6.4",
+ "serde",
+ "zeroize",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5600,6 +5613,20 @@ name = "zeroize"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,12 @@ anyhow = "1.0"
 # CSPRNG-keygen feature stays OFF — device keys derive deterministically from a seed via
 # `SigningKey::from_bytes`. Verification uses `verify_strict` (rejects malleable / small-order sigs).
 ed25519-dalek = "2"
+# X25519 device ENCRYPTION keypair beside the ed25519 signing key (sync phase C, §5). Shares
+# curve25519-dalek 4 with ed25519-dalek 2 (no second curve impl in the tree). `static_secrets`
+# enables the persistable `StaticSecret`, reconstructed from the stored 32-byte secret exactly as the
+# ed25519 key is rebuilt from its seed; the default `zeroize` scrubs it on drop. C1 only mints,
+# persists, and validates the key (rejecting small-order / identity public keys); ECDH + HKDF is C4.
+x25519-dalek = { version = "2", features = ["static_secrets"] }
 fastembed = { version = "5.17.2", default-features = false, features = ["hf-hub-rustls-tls", "ort-download-binaries-rustls-tls"] }
 # OS CSPRNG for the op-log device key: fills a 32-byte ed25519 seed at first use, which then flows
 # through the existing deterministic `SigningKey::from_bytes`. The lowest-level entropy source (no

--- a/crates/rag-rat-core/Cargo.toml
+++ b/crates/rag-rat-core/Cargo.toml
@@ -15,6 +15,7 @@ categories.workspace = true
 tokio = { workspace = true }
 anyhow.workspace = true
 ed25519-dalek.workspace = true
+x25519-dalek.workspace = true
 fastembed = { workspace = true, optional = true }
 getrandom.workspace = true
 gix.workspace = true

--- a/crates/rag-rat-core/src/index/schema/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema/migrations.rs
@@ -1375,6 +1375,7 @@ pub(crate) fn migration_checksum_mismatch(migration: &AppliedMigration) -> bool 
         MIGRATION_055_ID => migration.checksum != MIGRATION_055_CHECKSUM,
         MIGRATION_056_ID => migration.checksum != MIGRATION_056_CHECKSUM,
         MIGRATION_057_ID => migration.checksum != MIGRATION_057_CHECKSUM,
+        MIGRATION_058_ID => migration.checksum != MIGRATION_058_CHECKSUM,
         _ => false,
     }
 }

--- a/crates/rag-rat-core/src/index/schema/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema/migrations.rs
@@ -1244,6 +1244,7 @@ pub(crate) fn known_version(migrations: &[AppliedMigration]) -> u32 {
             MIGRATION_055_ID => Some(55),
             MIGRATION_056_ID => Some(56),
             MIGRATION_057_ID => Some(57),
+            MIGRATION_058_ID => Some(58),
             _ => None,
         })
         .max()
@@ -1310,6 +1311,7 @@ pub(crate) fn known_migration(id: &str) -> bool {
             | MIGRATION_055_ID
             | MIGRATION_056_ID
             | MIGRATION_057_ID
+            | MIGRATION_058_ID
             | DIRTY_MIGRATION_ID
     )
 }
@@ -3800,6 +3802,20 @@ pub(crate) fn apply_oplog_device_identity(conn: &Connection) -> rusqlite::Result
 
          COMMIT;",
     )?;
+    Ok(())
+}
+
+/// V058 (sync phase C, §5): give the single device identity an X25519 ENCRYPTION keypair beside its
+/// ed25519 signing key. Two nullable `BLOB` columns — `x25519_secret` (the 32-byte scalar, the sole
+/// durable copy, D4) and `x25519_public` — added to the STRICT `oplog_device_identity` table
+/// (`BLOB` is a valid STRICT type). Nullable + additive: an existing row keeps its ed25519 identity
+/// and is backfilled at the next `local_device` open via a CAS UPDATE (mirroring the ed25519
+/// mint-if-absent race), so a concurrent open cannot split into two encryption identities.
+/// Idempotent via `add_column_if_missing`; on a fresh DB this runs right after V054 creates the
+/// table, so both columns are present before the first `local_device` call.
+pub(crate) fn apply_oplog_device_x25519(conn: &Connection) -> rusqlite::Result<()> {
+    add_column_if_missing(conn, "oplog_device_identity", "x25519_secret", "BLOB")?;
+    add_column_if_missing(conn, "oplog_device_identity", "x25519_public", "BLOB")?;
     Ok(())
 }
 

--- a/crates/rag-rat-core/src/index/schema/mod.rs
+++ b/crates/rag-rat-core/src/index/schema/mod.rs
@@ -19,7 +19,7 @@ pub use registry::{LEGACY_REPO_ID, register_repo, register_repo_read_only};
 use rusqlite::{Connection, OptionalExtension, params};
 use serde::Serialize;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 57;
+pub const LATEST_SCHEMA_VERSION: u32 = 58;
 
 /// Every oracle-DERIVED persisted table — the outputs an `oracle run` writes that must OUTLIVE a
 /// reindex.
@@ -402,6 +402,14 @@ const MIGRATION_057_DESCRIPTION: &str =
      (repo_id, tool, commit_sha, worktree_id) from birth; moniker is the RAW SCIP symbol string \
      so it exact-joins edge_oracle.scip_symbol. Backs the check_library_usage tool that surfaces \
      the current signature/docs at external call sites and flags deprecated usage";
+const MIGRATION_058_ID: &str = "058_oplog_device_x25519";
+const MIGRATION_058_CHECKSUM: &str = "sha256:rag-rat-oplog-device-x25519-v58";
+const MIGRATION_058_DESCRIPTION: &str =
+    "Add x25519_secret + x25519_public (nullable BLOB) to oplog_device_identity (sync phase C, \
+     §5): the device's X25519 ENCRYPTION keypair beside its ed25519 signing key. Additive on the \
+     STRICT table; an existing ed25519-only row is backfilled at the next local_device open via a \
+     CAS UPDATE that mirrors the ed25519 mint-if-absent race, so concurrent opens converge on one \
+     encryption identity. C1 only mints/persists/validates the key; ECDH + HKDF is C4";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -889,6 +897,12 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         checksum: MIGRATION_057_CHECKSUM,
         description: MIGRATION_057_DESCRIPTION,
         apply: apply_external_symbols,
+    },
+    Migration {
+        id: MIGRATION_058_ID,
+        checksum: MIGRATION_058_CHECKSUM,
+        description: MIGRATION_058_DESCRIPTION,
+        apply: apply_oplog_device_x25519,
     },
 ];
 

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
@@ -1492,17 +1492,31 @@ fn migration_054_adds_the_single_row_device_identity_table() {
     }
 
     // `CHECK (id = 0)` + the primary key make it a strict single-row table: id 0 inserts once; a
-    // non-zero id is refused by the CHECK; a second id-0 insert is refused by the PK.
-    conn.execute("INSERT INTO oplog_device_identity VALUES (0, x'00', x'11', x'22', 0)", [])
-        .expect("the sole id=0 identity row inserts");
+    // non-zero id is refused by the CHECK; a second id-0 insert is refused by the PK. (Columns are
+    // named because V058 added the nullable x25519 columns — a positional 5-value insert no longer
+    // matches the 7-column table.)
+    conn.execute(
+        "INSERT INTO oplog_device_identity(id, seed, public_key, fingerprint, created_at_ms)
+         VALUES (0, x'00', x'11', x'22', 0)",
+        [],
+    )
+    .expect("the sole id=0 identity row inserts");
     assert!(
-        conn.execute("INSERT INTO oplog_device_identity VALUES (1, x'00', x'11', x'22', 0)", [])
-            .is_err(),
+        conn.execute(
+            "INSERT INTO oplog_device_identity(id, seed, public_key, fingerprint, created_at_ms)
+             VALUES (1, x'00', x'11', x'22', 0)",
+            [],
+        )
+        .is_err(),
         "CHECK (id = 0) rejects a second, non-zero identity"
     );
     assert!(
-        conn.execute("INSERT INTO oplog_device_identity VALUES (0, x'99', x'88', x'77', 1)", [])
-            .is_err(),
+        conn.execute(
+            "INSERT INTO oplog_device_identity(id, seed, public_key, fingerprint, created_at_ms)
+             VALUES (0, x'99', x'88', x'77', 1)",
+            [],
+        )
+        .is_err(),
         "the id=0 primary key rejects a second identity"
     );
 
@@ -1616,10 +1630,13 @@ fn migration_056_adds_the_git_change_couplings_table() {
 fn migration_057_adds_the_external_symbols_table() {
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     schema::apply(&conn).unwrap();
-    // V057 is the schema tip — this test carries the absolute pin (the older tests dropped to
-    // the symbolic `current_version == LATEST` check).
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 57, "V057 is the schema tip");
-    assert_eq!(schema::status(&conn).unwrap().current_version, 57, "schema at LATEST after apply");
+    // The absolute tip pin moved to `migration_058_*` (V058 is the tip now); this drops to the
+    // symbolic `current_version == LATEST` check, per the ladder convention.
+    assert_eq!(
+        schema::status(&conn).unwrap().current_version,
+        schema::LATEST_SCHEMA_VERSION,
+        "schema at LATEST after apply"
+    );
 
     // The external-symbol contract table exists with its full column set.
     for column in [
@@ -1743,6 +1760,59 @@ fn migration_057_adds_the_external_symbols_table() {
         conn_table_exists(&conn, "external_symbols"),
         "the forward migrate re-creates external_symbols"
     );
+}
+
+#[test]
+fn migration_058_adds_the_oplog_device_x25519_columns() {
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn).unwrap();
+    // V058 is the schema tip — this test carries the absolute pin (the older tests dropped to
+    // the symbolic `current_version == LATEST` check).
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 58, "V058 is the schema tip");
+    assert_eq!(schema::status(&conn).unwrap().current_version, 58, "schema at LATEST after apply");
+
+    // The identity table gains the X25519 encryption columns (sync phase C, §5).
+    for column in ["x25519_secret", "x25519_public"] {
+        assert!(
+            conn_table_columns(&conn, "oplog_device_identity").contains(&column.to_string()),
+            "V058 gives oplog_device_identity its {column} column"
+        );
+    }
+
+    // Deferred-absence in ISOLATION: build the table from the V054 DDL ALONE (never the full
+    // ladder's end state) — the x25519 columns are absent — then the V058 applier adds them, and a
+    // replay is an idempotent no-op (add_column_if_missing).
+    let isolated = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply_oplog_device_identity(&isolated).unwrap();
+    for column in ["x25519_secret", "x25519_public"] {
+        assert!(
+            !conn_table_columns(&isolated, "oplog_device_identity").contains(&column.to_string()),
+            "the V054 table alone lacks the {column} column"
+        );
+    }
+    schema::apply_oplog_device_x25519(&isolated).unwrap();
+    schema::apply_oplog_device_x25519(&isolated).expect("replay is a no-op");
+    for column in ["x25519_secret", "x25519_public"] {
+        assert!(
+            conn_table_columns(&isolated, "oplog_device_identity").contains(&column.to_string()),
+            "the isolated V058 applier adds the {column} column"
+        );
+    }
+
+    // A forward migrate over a ledger truncated below V058 replays the step and keeps the columns.
+    truncate_schema_to(&conn, 57);
+    schema::migrate_forward(&conn).unwrap();
+    assert_eq!(
+        schema::status(&conn).unwrap().current_version,
+        schema::LATEST_SCHEMA_VERSION,
+        "forward migrate reaches the tip"
+    );
+    for column in ["x25519_secret", "x25519_public"] {
+        assert!(
+            conn_table_columns(&conn, "oplog_device_identity").contains(&column.to_string()),
+            "the forward migrate keeps the {column} column"
+        );
+    }
 }
 
 #[test]

--- a/crates/rag-rat-core/src/oplog/account/candidate.rs
+++ b/crates/rag-rat-core/src/oplog/account/candidate.rs
@@ -1,0 +1,297 @@
+//! The candidate-graph substrate the fold walks (§11): a hash-keyed header view, the `prev_hash`
+//! ancestry walk, cut-target binding (§11.3), and the `⊔` comparable-ancestor join.
+//!
+//! These are the parts of cut evaluation that need the CANDIDATE DAG (not just a `[seq]`, which the
+//! self-contained [`super::cut::beyond`] handles). They are pure functions of a [`HeaderView`] —
+//! the fold implements it over its candidate map; tests implement it over a small `HashMap`.
+
+use std::collections::{HashMap, HashSet};
+
+use super::AccountId;
+use super::cut::Cut;
+use super::envelope::AccountEntryHeader;
+use crate::oplog::op::DeviceFingerprint;
+
+/// A read view over candidate entries keyed by `entry_hash` — the seam the ancestry walk and cut
+/// binding use without depending on the fold's storage.
+pub(super) trait HeaderView {
+    fn header(&self, entry_hash: &[u8; 32]) -> Option<&AccountEntryHeader>;
+}
+
+impl HeaderView for HashMap<[u8; 32], AccountEntryHeader> {
+    fn header(&self, entry_hash: &[u8; 32]) -> Option<&AccountEntryHeader> {
+        self.get(entry_hash)
+    }
+}
+
+/// Why an ancestry walk could not be decided yet (a WITHHELD watermark parks, never flips a verdict
+/// — I11).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum UnknownCause {
+    /// The cut's watermark entry itself is not held.
+    UnknownCutTarget,
+    /// A link on the walk from the watermark toward the target is missing.
+    IncompleteCutAncestry,
+}
+
+/// The result of walking `prev_hash` from a cut's watermark toward a target entry (§11).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum Ancestry {
+    /// The target is an ancestor of (or equal to) the watermark — within the cut's accepted branch.
+    OnBranch,
+    /// The watermark's branch reaches genesis without passing the target — a different branch (L2).
+    OffBranch,
+    /// Undecidable until more entries arrive.
+    Unknown(UnknownCause),
+}
+
+/// Walk `prev_hash` from `cut`'s watermark and decide whether `target` lies on that branch (§11). A
+/// withheld watermark / missing link parks (`Unknown`); it NEVER flips an on/off verdict. `Empty`
+/// has no branch, so ancestry is `OffBranch` (callers test [`super::cut::beyond`] first).
+pub(super) fn ancestry(target: &[u8; 32], cut: &Cut, view: &dyn HeaderView) -> Ancestry {
+    let Some(watermark) = cut.hash() else {
+        return Ancestry::OffBranch;
+    };
+    if view.header(&watermark).is_none() {
+        return Ancestry::Unknown(UnknownCause::UnknownCutTarget);
+    }
+    // Hash chains cannot cycle (a cycle needs a sha256 collision), but guard a corrupt input
+    // against an infinite loop by refusing to revisit a hash.
+    let mut visited: HashSet<[u8; 32]> = HashSet::new();
+    let mut current = watermark;
+    loop {
+        if &current == target {
+            return Ancestry::OnBranch;
+        }
+        if !visited.insert(current) {
+            return Ancestry::OffBranch;
+        }
+        match view.header(&current) {
+            None => return Ancestry::Unknown(UnknownCause::IncompleteCutAncestry),
+            Some(header) => match header.prev_hash {
+                Some(prev) => current = prev,
+                None => return Ancestry::OffBranch,
+            },
+        }
+    }
+}
+
+/// The `(account, log, device)` coordinate a control/secrets cut's watermark MUST name (§11.3). (A
+/// content cut names a `stream_id`; that binding is C2.)
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct CutCoordinate {
+    pub(super) account: AccountId,
+    pub(super) log: u8,
+    pub(super) device: DeviceFingerprint,
+}
+
+/// The outcome of validating a cut's watermark hash against the coordinate its register is for
+/// (§11.3).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum CutBinding {
+    /// `Empty`, or the watermark names the exact `(coordinate, seq)`.
+    Ok,
+    /// The watermark entry is not held yet — park, do not reject.
+    TargetNotHeld,
+    /// The watermark names a DIFFERENT coordinate — a structural reject (§11.3).
+    Mismatch,
+}
+
+/// Validate a cut's watermark hash names the exact `(account, log, device, seq)` its register is
+/// for (§11.3). A hash naming a different coordinate is a structural reject; a not-yet-held
+/// watermark parks.
+pub(super) fn validate_cut_target(
+    cut: &Cut,
+    expected: &CutCoordinate,
+    view: &dyn HeaderView,
+) -> CutBinding {
+    let Cut::At { seq, hash } = cut else {
+        return CutBinding::Ok;
+    };
+    match view.header(hash) {
+        None => CutBinding::TargetNotHeld,
+        Some(header) => {
+            let names_coordinate = header.account_id == expected.account
+                && header.log_id == expected.log
+                && header.device_fingerprint == expected.device
+                && header.seq == *seq;
+            if names_coordinate { CutBinding::Ok } else { CutBinding::Mismatch }
+        },
+    }
+}
+
+/// The result of the `⊔` comparable-ancestor join of two cuts for one register key (§11.3).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum JoinResult {
+    /// The two are on one branch; the join is the higher watermark.
+    Extended(Cut),
+    /// Equal-seq different-hash, or divergent branches — a same-depth mutual condemnation ⇒
+    /// contested.
+    Incomparable,
+    /// The branch relation can't be decided yet (a withheld watermark) — park.
+    Unknown,
+}
+
+/// Join two cuts for one register key (§11.3): `Empty` is the bottom; equal seq requires equal hash
+/// (else `Incomparable`); otherwise the higher watermark must be `OnBranch`-descended from the
+/// lower.
+pub(super) fn join_cuts(a: &Cut, b: &Cut, view: &dyn HeaderView) -> JoinResult {
+    match (a, b) {
+        (Cut::Empty, other) | (other, Cut::Empty) => JoinResult::Extended(other.clone()),
+        (Cut::At { seq: seq_a, hash: hash_a }, Cut::At { seq: seq_b, hash: hash_b }) => {
+            if seq_a == seq_b {
+                return if hash_a == hash_b {
+                    JoinResult::Extended(a.clone())
+                } else {
+                    JoinResult::Incomparable
+                };
+            }
+            let (lower, higher) = if seq_a < seq_b { (a, b) } else { (b, a) };
+            // `higher` must descend `lower`: walking prev_hash from higher's watermark reaches
+            // lower's watermark.
+            let lower_hash = lower.hash().expect("At cut has a hash");
+            match ancestry(&lower_hash, higher, view) {
+                Ancestry::OnBranch => JoinResult::Extended(higher.clone()),
+                Ancestry::OffBranch => JoinResult::Incomparable,
+                Ancestry::Unknown(_) => JoinResult::Unknown,
+            }
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a header at `(account 0xaa, log 0, device 0xbb, seq)` with `prev_hash`, keyed in
+    /// `view` under `entry_hash`.
+    fn insert_chain_entry(
+        view: &mut HashMap<[u8; 32], AccountEntryHeader>,
+        entry_hash: [u8; 32],
+        seq: u64,
+        prev_hash: Option<[u8; 32]>,
+    ) {
+        view.insert(entry_hash, AccountEntryHeader {
+            account_id: AccountId::from_bytes([0xaa; 32]),
+            log_id: 0,
+            device_fingerprint: DeviceFingerprint::from_bytes([0xbb; 32]),
+            seq,
+            prev_hash,
+            parent_ref: None,
+            entry_type: 3,
+            op_version: 1,
+            crypto_suite: 0,
+            auth_len: seq,
+            key_id: None,
+            authority_ref: None,
+        });
+    }
+
+    /// A three-entry chain g(seq0) <- m(seq1) <- t(seq2), hashes g/m/t.
+    fn linear_chain() -> HashMap<[u8; 32], AccountEntryHeader> {
+        let mut view = HashMap::new();
+        insert_chain_entry(&mut view, [0x0a; 32], 0, None);
+        insert_chain_entry(&mut view, [0x0b; 32], 1, Some([0x0a; 32]));
+        insert_chain_entry(&mut view, [0x0c; 32], 2, Some([0x0b; 32]));
+        view
+    }
+
+    #[test]
+    fn ancestry_on_and_off_branch() {
+        let view = linear_chain();
+        let cut = Cut::At { seq: 2, hash: [0x0c; 32] };
+        // g and m are ancestors of the seq-2 watermark; a stranger is not.
+        assert_eq!(ancestry(&[0x0a; 32], &cut, &view), Ancestry::OnBranch);
+        assert_eq!(ancestry(&[0x0b; 32], &cut, &view), Ancestry::OnBranch);
+        assert_eq!(ancestry(&[0x0c; 32], &cut, &view), Ancestry::OnBranch);
+        assert_eq!(ancestry(&[0xff; 32], &cut, &view), Ancestry::OffBranch);
+    }
+
+    #[test]
+    fn ancestry_parks_on_a_withheld_watermark_but_not_forever() {
+        let view = linear_chain();
+        // A watermark we don't hold ⇒ Unknown(UnknownCutTarget), never a flipped verdict (I11).
+        let cut = Cut::At { seq: 9, hash: [0x99; 32] };
+        assert_eq!(
+            ancestry(&[0x0a; 32], &cut, &view),
+            Ancestry::Unknown(UnknownCause::UnknownCutTarget),
+        );
+    }
+
+    #[test]
+    fn ancestry_parks_on_a_missing_mid_chain_link() {
+        // Hold the seq-2 watermark but NOT its predecessor: the walk can't reach the target.
+        let mut view = HashMap::new();
+        insert_chain_entry(&mut view, [0x0c; 32], 2, Some([0x0b; 32]));
+        let cut = Cut::At { seq: 2, hash: [0x0c; 32] };
+        assert_eq!(
+            ancestry(&[0x0a; 32], &cut, &view),
+            Ancestry::Unknown(UnknownCause::IncompleteCutAncestry),
+        );
+    }
+
+    #[test]
+    fn validate_cut_target_binds_the_exact_coordinate() {
+        let view = linear_chain();
+        let coord = CutCoordinate {
+            account: AccountId::from_bytes([0xaa; 32]),
+            log: 0,
+            device: DeviceFingerprint::from_bytes([0xbb; 32]),
+        };
+        // The seq-2 watermark names (aa,0,bb,2) — Ok.
+        assert_eq!(
+            validate_cut_target(&Cut::At { seq: 2, hash: [0x0c; 32] }, &coord, &view),
+            CutBinding::Ok
+        );
+        // Empty is always Ok (no target).
+        assert_eq!(validate_cut_target(&Cut::Empty, &coord, &view), CutBinding::Ok);
+        // A watermark whose entry claims seq 2 but the cut says seq 1 ⇒ Mismatch.
+        assert_eq!(
+            validate_cut_target(&Cut::At { seq: 1, hash: [0x0c; 32] }, &coord, &view),
+            CutBinding::Mismatch
+        );
+        // A different device coordinate ⇒ Mismatch.
+        let other = CutCoordinate { device: DeviceFingerprint::from_bytes([0xcc; 32]), ..coord };
+        assert_eq!(
+            validate_cut_target(&Cut::At { seq: 2, hash: [0x0c; 32] }, &other, &view),
+            CutBinding::Mismatch
+        );
+        // A not-yet-held watermark parks.
+        assert_eq!(
+            validate_cut_target(&Cut::At { seq: 5, hash: [0x55; 32] }, &coord, &view),
+            CutBinding::TargetNotHeld
+        );
+    }
+
+    #[test]
+    fn join_extends_on_one_branch_and_flags_incomparable_forks() {
+        let view = linear_chain();
+        let lo = Cut::At { seq: 1, hash: [0x0b; 32] };
+        let hi = Cut::At { seq: 2, hash: [0x0c; 32] };
+        // hi descends lo ⇒ Extended(hi).
+        assert_eq!(join_cuts(&lo, &hi, &view), JoinResult::Extended(hi.clone()));
+        assert_eq!(join_cuts(&hi, &lo, &view), JoinResult::Extended(hi.clone()));
+        // Empty ⊔ anything = anything.
+        assert_eq!(join_cuts(&Cut::Empty, &hi, &view), JoinResult::Extended(hi.clone()));
+        // Equal seq, different hash ⇒ Incomparable (the contested trigger).
+        let other_at_2 = Cut::At { seq: 2, hash: [0xee; 32] };
+        assert_eq!(join_cuts(&hi, &other_at_2, &view), JoinResult::Incomparable);
+        // Higher seq on a FULLY-HELD divergent branch (forks at genesis) ⇒ OffBranch ⇒
+        // Incomparable.
+        let mut forked = view.clone();
+        insert_chain_entry(&mut forked, [0xd1; 32], 1, Some([0x0a; 32])); // sibling of 0x0b off genesis
+        insert_chain_entry(&mut forked, [0xd2; 32], 2, Some([0xd1; 32]));
+        assert_eq!(
+            join_cuts(&lo, &Cut::At { seq: 2, hash: [0xd2; 32] }, &forked),
+            JoinResult::Incomparable,
+        );
+        // Higher seq whose branch has a WITHHELD predecessor ⇒ Unknown (park, never a flipped
+        // verdict).
+        let mut incomplete = view.clone();
+        insert_chain_entry(&mut incomplete, [0xdd; 32], 3, Some([0xff; 32])); // 0xff is not held
+        assert_eq!(
+            join_cuts(&lo, &Cut::At { seq: 3, hash: [0xdd; 32] }, &incomplete),
+            JoinResult::Unknown,
+        );
+    }
+}

--- a/crates/rag-rat-core/src/oplog/account/cut.rs
+++ b/crates/rag-rat-core/src/oplog/account/cut.rs
@@ -1,0 +1,165 @@
+//! The revocation `Cut` — the content-addressed watermark that bounds a chain's valid prefix (§11).
+//!
+//! `Cut = null | [seq, entry_hash]`. It is the L2 half of the two soundness lemmas (§2): an
+//! owner-attested cut on a subject's own hash chain content-addressably fixes the valid prefix —
+//! slots `seq ≤ s` are determined by the ancestry of `hash`, slots `seq > s` are condemned
+//! regardless of any asserted ordering. Because the cut names a hash, "pretending older" is useless
+//! (the ancestry is fixed) and "pretending newer" is impossible (it would need a hash collision).
+//!
+//! This module owns the WIRE + the seq-only [`beyond`] test (evaluable from `[seq]` alone — I11).
+//! The ancestry walk, cut-target binding, and the `⊔` join operate over the candidate DAG and live
+//! with the fold ([`super::fold`]), which holds those structures.
+
+use minicbor::Encoder;
+use minicbor::data::Type;
+use minicbor::decode::{Decoder, Error as CborError};
+
+use crate::oplog::cbor;
+
+/// Writing CBOR into a `Vec` cannot fail (its `Write` impl is infallible) — mirrors `super::super`.
+const INFALLIBLE: &str = "encoding CBOR to a Vec is infallible";
+
+/// A cut (§11): `Empty` (CBOR `null`) means nothing on the chain is valid; `At { seq, hash }` pins
+/// the valid prefix to slots `≤ seq` on the branch ending at `hash`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum Cut {
+    Empty,
+    At { seq: u64, hash: [u8; 32] },
+}
+
+impl Cut {
+    /// Write the cut into an existing encoder (op payloads carry cuts inline): `null` for `Empty`,
+    /// else the 2-array `[seq, hash]` with minimal integer + a 32-byte bstr.
+    pub(super) fn encode_into(&self, enc: &mut Encoder<&mut Vec<u8>>) {
+        match self {
+            Cut::Empty => {
+                enc.null().expect(INFALLIBLE);
+            },
+            Cut::At { seq, hash } => {
+                enc.array(2).expect(INFALLIBLE);
+                enc.u64(*seq).expect(INFALLIBLE);
+                enc.bytes(hash).expect(INFALLIBLE);
+            },
+        }
+    }
+
+    /// Encode a standalone cut to canonical CBOR (used by goldens + tests).
+    pub(super) fn encode(&self) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(40);
+        {
+            let mut enc = Encoder::new(&mut buf);
+            self.encode_into(&mut enc);
+        }
+        buf
+    }
+
+    /// Decode a cut from a decoder positioned at the cut item: CBOR `null` → `Empty`, else `[seq,
+    /// hash]` (a definite-length 2-array, minimal seq, 32-byte hash).
+    pub(super) fn decode(d: &mut Decoder<'_>) -> Result<Cut, CborError> {
+        if d.datatype()? == Type::Null {
+            d.null()?;
+            Ok(Cut::Empty)
+        } else {
+            cbor::expect_array(d, 2)?;
+            let seq = d.u64()?;
+            let hash = cbor::fixed_bytes::<32>(d.bytes()?, "cut hash")?;
+            Ok(Cut::At { seq, hash })
+        }
+    }
+
+    /// The watermark seq if this is an `At` cut.
+    pub(super) fn seq(&self) -> Option<u64> {
+        match self {
+            Cut::Empty => None,
+            Cut::At { seq, .. } => Some(*seq),
+        }
+    }
+
+    /// The watermark entry_hash if this is an `At` cut.
+    pub(super) fn hash(&self) -> Option<[u8; 32]> {
+        match self {
+            Cut::Empty => None,
+            Cut::At { hash, .. } => Some(*hash),
+        }
+    }
+}
+
+/// Whether entry `entry_seq` is BEYOND `cut` — the seq-only condemnation test (I11), evaluable from
+/// `[seq]` alone and NEVER needing the watermark entry. `Empty` ⇒ every slot is beyond (nothing
+/// valid). This is what makes a back-dated forgery past the cut condemnable even when the watermark
+/// entry itself has not been synced yet.
+pub(super) fn beyond(entry_seq: u64, cut: &Cut) -> bool {
+    match cut {
+        Cut::Empty => true,
+        Cut::At { seq, .. } => entry_seq > *seq,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hex(bytes: &[u8]) -> String {
+        bytes.iter().map(|byte| format!("{byte:02x}")).collect()
+    }
+
+    #[test]
+    fn cut_wire_is_frozen() {
+        // `Empty` is a bare CBOR null; `At` is `[seq, hash]`. These bytes ride inside DeviceRemove
+        // / OwnerDemote / CutExtend payloads, so a change is a wire bump.
+        assert_eq!(hex(&Cut::Empty.encode()), "f6", "empty cut is null");
+        let at = Cut::At { seq: 5, hash: [0x11; 32] };
+        assert_eq!(
+            hex(&at.encode()),
+            "82055820".to_string() + &"11".repeat(32),
+            "At cut is [seq, hash]",
+        );
+    }
+
+    #[test]
+    fn cut_round_trips_through_decode() {
+        for cut in
+            [Cut::Empty, Cut::At { seq: 0, hash: [0u8; 32] }, Cut::At { seq: 42, hash: [0xab; 32] }]
+        {
+            let bytes = cut.encode();
+            let mut d = Decoder::new(&bytes);
+            assert_eq!(Cut::decode(&mut d).unwrap(), cut);
+        }
+    }
+
+    #[test]
+    fn non_canonical_and_malformed_cuts_are_rejected() {
+        // A wrong-length hash.
+        let mut buf = Vec::new();
+        {
+            let mut enc = Encoder::new(&mut buf);
+            enc.array(2).unwrap();
+            enc.u64(1).unwrap();
+            enc.bytes(&[0u8; 16]).unwrap();
+        }
+        let mut d = Decoder::new(&buf);
+        assert!(Cut::decode(&mut d).is_err(), "16-byte cut hash is rejected");
+        // A 3-element array.
+        let mut buf = Vec::new();
+        {
+            let mut enc = Encoder::new(&mut buf);
+            enc.array(3).unwrap();
+            enc.u64(1).unwrap();
+            enc.bytes(&[0u8; 32]).unwrap();
+            enc.u64(0).unwrap();
+        }
+        let mut d = Decoder::new(&buf);
+        assert!(Cut::decode(&mut d).is_err(), "wrong arity is rejected");
+    }
+
+    #[test]
+    fn beyond_is_seq_only() {
+        // Empty condemns everything; At condemns strictly-greater seqs, from `[seq]` alone.
+        assert!(beyond(0, &Cut::Empty));
+        assert!(beyond(u64::MAX, &Cut::Empty));
+        let cut = Cut::At { seq: 41, hash: [0x11; 32] };
+        assert!(!beyond(41, &cut), "the watermark slot itself is within the cut");
+        assert!(!beyond(0, &cut), "under-cut slots are within");
+        assert!(beyond(42, &cut), "slot past the watermark is beyond");
+    }
+}

--- a/crates/rag-rat-core/src/oplog/account/envelope.rs
+++ b/crates/rag-rat-core/src/oplog/account/envelope.rs
@@ -89,6 +89,15 @@ pub(super) fn sign_account_entry(
     header: &AccountEntryHeader,
     payload: &[u8],
 ) -> SignedAccountEntry {
+    // Fail fast at the authoring site if the header names a different device than the signing key —
+    // `verify_account_signed` would reject it later, but a local bug should surface here, not on
+    // the wire. (Aligns this layer's posture with `super::super::entry::sign_entry`, which
+    // derives the fingerprint internally.)
+    debug_assert_eq!(
+        header.device_fingerprint,
+        secret.public().fingerprint(),
+        "header.device_fingerprint must be the signing key's fingerprint",
+    );
     let header_bytes = encode_header(header);
     let body_bytes = encode_body(&header_bytes, payload);
     let entry_hash = cbor::sha256(&body_bytes);
@@ -412,39 +421,41 @@ mod tests {
         let wrong = DeviceSecret::from_seed(&[9u8; 32]).public();
         assert!(verify_account_signed(&signed.signed_bytes, &wrong).is_err(), "wrong key");
 
-        // A header claiming device B's fingerprint but signed by A must fail under both keys.
+        // A header claiming device B's fingerprint but signed by A must fail under both keys. Build
+        // the wire MANUALLY — `sign_account_entry`'s debug_assert deliberately refuses to author a
+        // header/key mismatch, so this exercises verify's fingerprint bind at the wire level.
+        let secret_a = secret();
         let secret_b = DeviceSecret::from_seed(&[9u8; 32]);
         let mut forged = genesis_header();
         forged.device_fingerprint = secret_b.public().fingerprint();
-        let signed_forged = sign_account_entry(&secret(), &forged, &payload());
+        let header_bytes = encode_header(&forged);
+        let body_bytes = encode_body(&header_bytes, &payload());
+        let signature = secret_a.sign(&body_bytes);
+        let forged_wire = encode_signed(&body_bytes, &signature);
         assert!(
-            verify_account_signed(&signed_forged.signed_bytes, &secret().public()).is_err(),
+            verify_account_signed(&forged_wire, &secret_a.public()).is_err(),
             "A's key vs a header claiming B",
         );
         assert!(
-            verify_account_signed(&signed_forged.signed_bytes, &secret_b.public()).is_err(),
+            verify_account_signed(&forged_wire, &secret_b.public()).is_err(),
             "B's key vs a body A signed",
         );
     }
 
     #[test]
-    fn tampering_the_header_or_payload_is_rejected() {
+    fn tampering_any_byte_is_rejected() {
+        // Every byte of the wire is load-bearing: flipping one in the outer frame / domain / body
+        // bstr header breaks the structural decode, and flipping one in the body or signature
+        // breaks the signature. So verification must fail no matter which byte is flipped.
         let signed = sign_account_entry(&secret(), &genesis_header(), &payload());
-        // The body starts after the outer [0x83, 0x77, 23-byte domain, 0x58, len] = 27-byte header.
-        let body_start = 2 + 23 + 2;
-        for offset in [3usize, 60, 108] {
+        for index in 0..signed.signed_bytes.len() {
             let mut wire = signed.signed_bytes.clone();
-            wire[body_start + offset] ^= 0x01;
+            wire[index] ^= 0x01;
             assert!(
                 verify_account_signed(&wire, &secret().public()).is_err(),
-                "flipping a body byte at offset {offset} must fail verification",
+                "flipping byte {index} must fail decode or verification",
             );
         }
-        // Flipping the trailing signature byte fails too.
-        let mut wire = signed.signed_bytes.clone();
-        let last = wire.len() - 1;
-        wire[last] ^= 0x01;
-        assert!(verify_account_signed(&wire, &secret().public()).is_err(), "signature tamper");
     }
 
     #[test]

--- a/crates/rag-rat-core/src/oplog/account/envelope.rs
+++ b/crates/rag-rat-core/src/oplog/account/envelope.rs
@@ -82,29 +82,27 @@ pub(super) struct VerifiedAccountEntry {
 
 /// Author a signed account entry: encode the header, wrap `[header, payload]` as the body, sign the
 /// body under `secret`, and build the transport envelope. Pure + deterministic given `secret`
-/// (ed25519 signing is deterministic). The caller supplies a header whose `device_fingerprint` is
-/// `secret.public().fingerprint()`; [`verify_account_signed`] rejects any mismatch.
+/// (ed25519 signing is deterministic). The author device is DERIVED from `secret` — the header's
+/// `device_fingerprint` is overwritten with `secret.public().fingerprint()` — so a signed entry can
+/// never name a device other than its signer (mirrors `super::super::entry::sign_entry`).
 pub(super) fn sign_account_entry(
     secret: &DeviceSecret,
     header: &AccountEntryHeader,
     payload: &[u8],
 ) -> SignedAccountEntry {
-    // Fail fast at the authoring site if the header names a different device than the signing key —
-    // `verify_account_signed` would reject it later, but a local bug should surface here, not on
-    // the wire. (Aligns this layer's posture with `super::super::entry::sign_entry`, which
-    // derives the fingerprint internally.)
-    debug_assert_eq!(
-        header.device_fingerprint,
-        secret.public().fingerprint(),
-        "header.device_fingerprint must be the signing key's fingerprint",
-    );
-    let header_bytes = encode_header(header);
+    // The signing key IS the author device: derive `device_fingerprint` from `secret` rather than
+    // trusting the caller-supplied field. A `debug_assert` would be compiled out in release and let
+    // a release-build authoring bug ship a self-invalid entry; overwriting is a structural
+    // guarantee that holds in every build.
+    let mut header = header.clone();
+    header.device_fingerprint = secret.public().fingerprint();
+    let header_bytes = encode_header(&header);
     let body_bytes = encode_body(&header_bytes, payload);
     let entry_hash = cbor::sha256(&body_bytes);
     let signature = secret.sign(&body_bytes);
     let signed_bytes = encode_signed(&body_bytes, &signature);
     SignedAccountEntry {
-        header: header.clone(),
+        header,
         payload: payload.to_vec(),
         signature,
         header_bytes,

--- a/crates/rag-rat-core/src/oplog/account/envelope.rs
+++ b/crates/rag-rat-core/src/oplog/account/envelope.rs
@@ -89,7 +89,7 @@ pub(super) fn sign_account_entry(
     secret: &DeviceSecret,
     header: &AccountEntryHeader,
     payload: &[u8],
-) -> SignedAccountEntry {
+) -> anyhow::Result<SignedAccountEntry> {
     // The signing key IS the author device: derive `device_fingerprint` from `secret` rather than
     // trusting the caller-supplied field. A `debug_assert` would be compiled out in release and let
     // a release-build authoring bug ship a self-invalid entry; overwriting is a structural
@@ -98,10 +98,18 @@ pub(super) fn sign_account_entry(
     header.device_fingerprint = secret.public().fingerprint();
     let header_bytes = encode_header(&header);
     let body_bytes = encode_body(&header_bytes, payload);
-    let entry_hash = cbor::sha256(&body_bytes);
     let signature = secret.sign(&body_bytes);
     let signed_bytes = encode_signed(&body_bytes, &signature);
-    SignedAccountEntry {
+    // Refuse to emit an over-§18a-limit entry: `decode_account_signed` rejects those exact bytes,
+    // so the authoring path must not sign something peers (and its own re-decode) would refuse.
+    if signed_bytes.len() > ACCOUNT_ENVELOPE_MAX_BYTES {
+        anyhow::bail!(
+            "account entry is {} bytes, over the {ACCOUNT_ENVELOPE_MAX_BYTES}-byte §18a limit",
+            signed_bytes.len(),
+        );
+    }
+    let entry_hash = cbor::sha256(&body_bytes);
+    Ok(SignedAccountEntry {
         header,
         payload: payload.to_vec(),
         signature,
@@ -109,7 +117,7 @@ pub(super) fn sign_account_entry(
         body_bytes,
         signed_bytes,
         entry_hash,
-    }
+    })
 }
 
 /// Decode a signed account entry, STRUCTURE only (no signature check — that is
@@ -344,7 +352,7 @@ mod tests {
     fn account_signed_pins_the_envelope() {
         // Frozen primitive: the signature, entry_hash, and chain all build on these bytes; a
         // canonical-rule change must break this and force a deliberate domain bump.
-        let signed = sign_account_entry(&secret(), &genesis_header(), &payload());
+        let signed = sign_account_entry(&secret(), &genesis_header(), &payload()).unwrap();
         assert_eq!(
             hex(&signed.body_bytes),
             "8258678d777261672d7261742f6163636f756e742d656e7472792f315820aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa005820fe812c12f3ab4ce6ac5db69ac352f906cb1b11ef43fb33e252ef7ff55226388900f6f600010000f6f6458501020304",
@@ -359,7 +367,7 @@ mod tests {
 
     #[test]
     fn header_bytes_have_the_expected_13_part_structure() {
-        let signed = sign_account_entry(&secret(), &genesis_header(), &payload());
+        let signed = sign_account_entry(&secret(), &genesis_header(), &payload()).unwrap();
         let h = &signed.header_bytes;
         assert_eq!(h[0], 0x8d, "13-element array header");
         assert_eq!(h[1], 0x77, "text header, len 23");
@@ -384,7 +392,7 @@ mod tests {
 
     #[test]
     fn body_wraps_header_and_payload_as_bstrs() {
-        let signed = sign_account_entry(&secret(), &genesis_header(), &payload());
+        let signed = sign_account_entry(&secret(), &genesis_header(), &payload()).unwrap();
         let b = &signed.body_bytes;
         assert_eq!(b[0], 0x82, "2-element array (header, payload)");
         assert_eq!(b[1], 0x58, "header bstr header (1-byte len)");
@@ -401,7 +409,7 @@ mod tests {
 
     #[test]
     fn round_trips_through_verify() {
-        let signed = sign_account_entry(&secret(), &genesis_header(), &payload());
+        let signed = sign_account_entry(&secret(), &genesis_header(), &payload()).unwrap();
         let verified =
             verify_account_signed(&signed.signed_bytes, &secret().public()).expect("verifies");
         assert_eq!(verified.header, genesis_header());
@@ -415,7 +423,7 @@ mod tests {
 
     #[test]
     fn verify_rejects_the_wrong_key_and_a_fingerprint_mismatch() {
-        let signed = sign_account_entry(&secret(), &genesis_header(), &payload());
+        let signed = sign_account_entry(&secret(), &genesis_header(), &payload()).unwrap();
         let wrong = DeviceSecret::from_seed(&[9u8; 32]).public();
         assert!(verify_account_signed(&signed.signed_bytes, &wrong).is_err(), "wrong key");
 
@@ -445,7 +453,7 @@ mod tests {
         // Every byte of the wire is load-bearing: flipping one in the outer frame / domain / body
         // bstr header breaks the structural decode, and flipping one in the body or signature
         // breaks the signature. So verification must fail no matter which byte is flipped.
-        let signed = sign_account_entry(&secret(), &genesis_header(), &payload());
+        let signed = sign_account_entry(&secret(), &genesis_header(), &payload()).unwrap();
         for index in 0..signed.signed_bytes.len() {
             let mut wire = signed.signed_bytes.clone();
             wire[index] ^= 0x01;
@@ -458,7 +466,7 @@ mod tests {
 
     #[test]
     fn structural_rejections() {
-        let good = sign_account_entry(&secret(), &genesis_header(), &payload());
+        let good = sign_account_entry(&secret(), &genesis_header(), &payload()).unwrap();
         // Trailing bytes.
         let mut trailing = good.signed_bytes.clone();
         trailing.push(0x00);
@@ -476,26 +484,26 @@ mod tests {
         let mut bad_prev = genesis_header();
         bad_prev.seq = 5;
         bad_prev.prev_hash = None;
-        let signed = sign_account_entry(&secret(), &bad_prev, &payload());
+        let signed = sign_account_entry(&secret(), &bad_prev, &payload()).unwrap();
         assert!(decode_account_signed(&signed.signed_bytes).is_err(), "seq>0 needs prev_hash");
 
         // seq 0 with a non-null prev_hash is rejected.
         let mut bad_genesis = genesis_header();
         bad_genesis.prev_hash = Some([0x11; 32]);
-        let signed = sign_account_entry(&secret(), &bad_genesis, &payload());
+        let signed = sign_account_entry(&secret(), &bad_genesis, &payload()).unwrap();
         assert!(decode_account_signed(&signed.signed_bytes).is_err(), "genesis has no prev_hash");
 
         // crypto_suite 0 (plaintext) with a non-null key_id is rejected (§15).
         let mut bad_key = genesis_header();
         bad_key.key_id = Some([0x22; 32]);
-        let signed = sign_account_entry(&secret(), &bad_key, &payload());
+        let signed = sign_account_entry(&secret(), &bad_key, &payload()).unwrap();
         assert!(decode_account_signed(&signed.signed_bytes).is_err(), "plaintext has no key_id");
 
         // crypto_suite 1 (sealed) with a null key_id is rejected.
         let mut bad_sealed = genesis_header();
         bad_sealed.crypto_suite = 1;
         bad_sealed.key_id = None;
-        let signed = sign_account_entry(&secret(), &bad_sealed, &payload());
+        let signed = sign_account_entry(&secret(), &bad_sealed, &payload()).unwrap();
         assert!(decode_account_signed(&signed.signed_bytes).is_err(), "sealed needs a key_id");
     }
 
@@ -503,14 +511,25 @@ mod tests {
     fn header_aad_is_the_header_content_not_the_payload() {
         // Same header, different payload ⇒ identical AAD (the header bytes); the payload is not in
         // it.
-        let a = sign_account_entry(&secret(), &genesis_header(), &payload());
-        let b = sign_account_entry(&secret(), &genesis_header(), &[0xff, 0xfe]);
+        let a = sign_account_entry(&secret(), &genesis_header(), &payload()).unwrap();
+        let b = sign_account_entry(&secret(), &genesis_header(), &[0xff, 0xfe]).unwrap();
         assert_eq!(header_aad(&a), header_aad(&b), "AAD is independent of the payload");
         assert_eq!(header_aad(&a), a.header_bytes.as_slice(), "AAD is the header content bytes");
         // A changed header field changes the AAD.
         let mut other = genesis_header();
         other.auth_len = 9;
-        let c = sign_account_entry(&secret(), &other, &payload());
+        let c = sign_account_entry(&secret(), &other, &payload()).unwrap();
         assert_ne!(header_aad(&a), header_aad(&c), "a header change changes the AAD");
+    }
+
+    #[test]
+    fn sign_refuses_an_over_size_entry() {
+        // A payload large enough to push the signed entry over the §18a limit is refused rather
+        // than signed — `decode_account_signed` would reject those exact bytes.
+        let huge = vec![0u8; ACCOUNT_ENVELOPE_MAX_BYTES];
+        assert!(
+            sign_account_entry(&secret(), &genesis_header(), &huge).is_err(),
+            "an over-§18a-limit entry must not be signed",
+        );
     }
 }

--- a/crates/rag-rat-core/src/oplog/account/envelope.rs
+++ b/crates/rag-rat-core/src/oplog/account/envelope.rs
@@ -96,6 +96,11 @@ pub(super) fn sign_account_entry(
     // guarantee that holds in every build.
     let mut header = header.clone();
     header.device_fingerprint = secret.public().fingerprint();
+    // Enforce the same header nullity rules decode does, so the authoring path can't sign a header
+    // (seq>0 with a null prev_hash, a crypto_suite/key_id mismatch, …) that decode would reject.
+    if let Some(msg) = header_nullity_error(&header) {
+        anyhow::bail!(msg);
+    }
     let header_bytes = encode_header(&header);
     let body_bytes = encode_body(&header_bytes, payload);
     let signature = secret.sign(&body_bytes);
@@ -274,15 +279,7 @@ fn decode_header(header_bytes: &[u8]) -> Result<AccountEntryHeader, CborError> {
     let auth_len = d.u64()?;
     let key_id = decode_opt_hash(&mut d, "key_id")?;
     let authority_ref = decode_opt_hash(&mut d, "authority_ref")?;
-    // Self-contained structural nullity rules (§6). The `authority_ref` ⇔ `AccountGenesis` coupling
-    // needs entry_type SEMANTICS and is enforced where entry_type is interpreted (ops / fold).
-    if (seq == 0) != prev_hash.is_none() {
-        return Err(CborError::message("prev_hash must be null iff seq == 0"));
-    }
-    if (crypto_suite == 0) != key_id.is_none() {
-        return Err(CborError::message("key_id must be null iff crypto_suite == 0"));
-    }
-    Ok(AccountEntryHeader {
+    let header = AccountEntryHeader {
         account_id,
         log_id,
         device_fingerprint,
@@ -295,7 +292,25 @@ fn decode_header(header_bytes: &[u8]) -> Result<AccountEntryHeader, CborError> {
         auth_len,
         key_id,
         authority_ref,
-    })
+    };
+    if let Some(msg) = header_nullity_error(&header) {
+        return Err(CborError::message(msg));
+    }
+    Ok(header)
+}
+
+/// The self-contained header nullity rules (§6): `prev_hash` is null iff `seq == 0`, and `key_id`
+/// is null iff `crypto_suite == 0`. `Some(msg)` if a rule is violated. Enforced BOTH at decode and
+/// at [`sign_account_entry`] so the authoring path can't sign a header decode would reject. (The
+/// `authority_ref` ⇔ `AccountGenesis` coupling needs entry_type SEMANTICS and lives in ops / fold.)
+fn header_nullity_error(header: &AccountEntryHeader) -> Option<&'static str> {
+    if (header.seq == 0) != header.prev_hash.is_none() {
+        return Some("prev_hash must be null iff seq == 0");
+    }
+    if (header.crypto_suite == 0) != header.key_id.is_none() {
+        return Some("key_id must be null iff crypto_suite == 0");
+    }
+    None
 }
 
 /// Decode a hash slot: CBOR null → `None`, else a 32-byte bstr.
@@ -479,32 +494,35 @@ mod tests {
     }
 
     #[test]
-    fn prev_hash_and_key_id_nullity_rules_are_enforced() {
-        // seq > 0 with a null prev_hash is rejected.
+    fn nullity_rules_are_enforced_at_both_sign_and_decode() {
+        // seq>0 + null prev_hash; seq0 + non-null prev_hash; plaintext + key_id; sealed + null
+        // key_id.
         let mut bad_prev = genesis_header();
         bad_prev.seq = 5;
         bad_prev.prev_hash = None;
-        let signed = sign_account_entry(&secret(), &bad_prev, &payload()).unwrap();
-        assert!(decode_account_signed(&signed.signed_bytes).is_err(), "seq>0 needs prev_hash");
-
-        // seq 0 with a non-null prev_hash is rejected.
         let mut bad_genesis = genesis_header();
         bad_genesis.prev_hash = Some([0x11; 32]);
-        let signed = sign_account_entry(&secret(), &bad_genesis, &payload()).unwrap();
-        assert!(decode_account_signed(&signed.signed_bytes).is_err(), "genesis has no prev_hash");
-
-        // crypto_suite 0 (plaintext) with a non-null key_id is rejected (§15).
         let mut bad_key = genesis_header();
         bad_key.key_id = Some([0x22; 32]);
-        let signed = sign_account_entry(&secret(), &bad_key, &payload()).unwrap();
-        assert!(decode_account_signed(&signed.signed_bytes).is_err(), "plaintext has no key_id");
-
-        // crypto_suite 1 (sealed) with a null key_id is rejected.
         let mut bad_sealed = genesis_header();
         bad_sealed.crypto_suite = 1;
         bad_sealed.key_id = None;
-        let signed = sign_account_entry(&secret(), &bad_sealed, &payload()).unwrap();
-        assert!(decode_account_signed(&signed.signed_bytes).is_err(), "sealed needs a key_id");
+
+        for (bad, why) in [
+            (bad_prev, "seq>0 needs prev_hash"),
+            (bad_genesis, "genesis has no prev_hash"),
+            (bad_key, "plaintext has no key_id"),
+            (bad_sealed, "sealed needs a key_id"),
+        ] {
+            // The authoring path refuses to sign it...
+            assert!(sign_account_entry(&secret(), &bad, &payload()).is_err(), "sign: {why}");
+            // ...and a manually-forged wire with that header is rejected at decode too.
+            let header_bytes = encode_header(&bad);
+            let body_bytes = encode_body(&header_bytes, &payload());
+            let signature = secret().sign(&body_bytes);
+            let forged = encode_signed(&body_bytes, &signature);
+            assert!(decode_account_signed(&forged).is_err(), "decode: {why}");
+        }
     }
 
     #[test]

--- a/crates/rag-rat-core/src/oplog/account/envelope.rs
+++ b/crates/rag-rat-core/src/oplog/account/envelope.rs
@@ -1,0 +1,507 @@
+//! The signed account-entry envelope — `rag-rat/account-entry/1` / `rag-rat/account-signed/1` (§6).
+//!
+//! An account log entry wraps an opaque control/secrets-op payload in a per-`(account, log,
+//! device)` signed, hash-chained record. Three nested canonical-CBOR objects, all definite-length +
+//! minimal-header (the same discipline [`super::super::cbor`] enforces):
+//!
+//! ```text
+//! header_bytes = cbor([ "rag-rat/account-entry/1", account_id, log_id, device_fingerprint, seq,
+//!                       prev_hash|null, parent_ref|null, entry_type, op_version, crypto_suite,
+//!                       auth_len, key_id|null, authority_ref|null ])          -- 13 parts, fixed order
+//! body_bytes   = cbor([ header_bytes (bstr), payload (bstr) ])
+//! signed_bytes = cbor([ "rag-rat/account-signed/1", body_bytes (bstr), signature (64-byte bstr) ])
+//! ```
+//!
+//! - The header is a SELF-CONTAINED canonical-CBOR **bstr** inside the body — it is the AAD unit
+//!   for the C4/C5 sealed suites, so a decryptor authenticates the exact header content. `payload`
+//!   is ALWAYS a bstr (plaintext canonical-CBOR op bytes today; ciphertext once sealing ships).
+//! - **The signature covers `body_bytes`** (header + payload), and `entry_hash =
+//!   sha256(body_bytes)` is the chain link + content address. The AEAD AAD is the header
+//!   **content** bytes ([`header_aad`]) — NOT the bstr wrapper.
+//! - `entry_type` / `op_version` / `auth_len` / `authority_ref` are carried as opaque scalars here,
+//!   exactly as [`super::super::entry`] carries `op_bytes` opaquely: this layer validates the
+//!   SELF-CONTAINED structural rules (canonicity, arity, `prev_hash` ⇔ `seq==0`, `key_id` ⇔
+//!   `crypto_suite==0`) and leaves every entry-type-SEMANTIC rule (the `authority_ref` ⇔
+//!   `AccountGenesis` coupling, payload shape, authority) to the ops/fold layers that interpret
+//!   them.
+
+use minicbor::Encoder;
+use minicbor::data::Type;
+use minicbor::decode::{Decoder, Error as CborError};
+
+use super::AccountId;
+use super::limits::{ACCOUNT_ENTRY_DOMAIN, ACCOUNT_ENVELOPE_MAX_BYTES, ACCOUNT_SIGNED_DOMAIN};
+use crate::oplog::cbor;
+use crate::oplog::device::{DevicePublic, DeviceSecret};
+use crate::oplog::op::DeviceFingerprint;
+
+/// Writing CBOR into a `Vec` cannot fail (its `Write` impl is infallible) — mirrors `super::super`.
+const INFALLIBLE: &str = "encoding CBOR to a Vec is infallible";
+
+/// The 13-part account-entry header (§6), fixed field order. `domain` (part 0) is a constant and is
+/// not stored — it is written at encode and asserted at decode. `entry_type` and `authority_ref`
+/// are opaque to this layer; the ops/fold layers interpret them.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct AccountEntryHeader {
+    pub(super) account_id: AccountId,
+    pub(super) log_id: u8,
+    pub(super) device_fingerprint: DeviceFingerprint,
+    pub(super) seq: u64,
+    pub(super) prev_hash: Option<[u8; 32]>,
+    pub(super) parent_ref: Option<[u8; 32]>,
+    pub(super) entry_type: u32,
+    pub(super) op_version: u32,
+    pub(super) crypto_suite: u8,
+    pub(super) auth_len: u64,
+    pub(super) key_id: Option<[u8; 32]>,
+    pub(super) authority_ref: Option<[u8; 32]>,
+}
+
+/// A signed account-entry: its structured header, the opaque payload, the signature over
+/// `body_bytes`, and all three wire encodings. `signed_bytes` is the transport/storage form;
+/// `header_bytes` is the AAD unit; `body_bytes` is exactly what the signature and `entry_hash`
+/// cover.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct SignedAccountEntry {
+    pub(super) header: AccountEntryHeader,
+    pub(super) payload: Vec<u8>,
+    pub(super) signature: [u8; 64],
+    pub(super) header_bytes: Vec<u8>,
+    pub(super) body_bytes: Vec<u8>,
+    pub(super) signed_bytes: Vec<u8>,
+    pub(super) entry_hash: [u8; 32],
+}
+
+/// A decoded + cryptographically-verified account entry (payload left opaque).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct VerifiedAccountEntry {
+    pub(super) header: AccountEntryHeader,
+    pub(super) payload: Vec<u8>,
+    pub(super) entry_hash: [u8; 32],
+}
+
+/// Author a signed account entry: encode the header, wrap `[header, payload]` as the body, sign the
+/// body under `secret`, and build the transport envelope. Pure + deterministic given `secret`
+/// (ed25519 signing is deterministic). The caller supplies a header whose `device_fingerprint` is
+/// `secret.public().fingerprint()`; [`verify_account_signed`] rejects any mismatch.
+pub(super) fn sign_account_entry(
+    secret: &DeviceSecret,
+    header: &AccountEntryHeader,
+    payload: &[u8],
+) -> SignedAccountEntry {
+    let header_bytes = encode_header(header);
+    let body_bytes = encode_body(&header_bytes, payload);
+    let entry_hash = cbor::sha256(&body_bytes);
+    let signature = secret.sign(&body_bytes);
+    let signed_bytes = encode_signed(&body_bytes, &signature);
+    SignedAccountEntry {
+        header: header.clone(),
+        payload: payload.to_vec(),
+        signature,
+        header_bytes,
+        body_bytes,
+        signed_bytes,
+        entry_hash,
+    }
+}
+
+/// Decode a signed account entry, STRUCTURE only (no signature check — that is
+/// [`verify_account_signed`]). Enforces the §18a size limit, canonicity at every nesting level, the
+/// arities + domains, and the self-contained header nullity rules.
+pub(super) fn decode_account_signed(bytes: &[u8]) -> anyhow::Result<SignedAccountEntry> {
+    if bytes.len() > ACCOUNT_ENVELOPE_MAX_BYTES {
+        anyhow::bail!(
+            "account entry wire is {} bytes, over the {ACCOUNT_ENVELOPE_MAX_BYTES}-byte §18a limit",
+            bytes.len(),
+        );
+    }
+    decode_account_signed_cbor(bytes)
+        .map_err(|err| anyhow::anyhow!("account entry decode failed: {err}"))
+}
+
+/// Decode + cryptographically verify a signed account entry under `pubkey`: `verify_strict` over
+/// `body_bytes`, then assert `pubkey.fingerprint() == header.device_fingerprint` so the key is
+/// bound to the device the header names (mirrors [`super::super::entry::verify_signed`]).
+pub(super) fn verify_account_signed(
+    bytes: &[u8],
+    pubkey: &DevicePublic,
+) -> anyhow::Result<VerifiedAccountEntry> {
+    let signed = decode_account_signed(bytes)?;
+    pubkey.verify(&signed.body_bytes, &signed.signature)?;
+    if pubkey.fingerprint() != signed.header.device_fingerprint {
+        anyhow::bail!("device fingerprint does not match the verifying key");
+    }
+    Ok(VerifiedAccountEntry {
+        header: signed.header,
+        payload: signed.payload,
+        entry_hash: signed.entry_hash,
+    })
+}
+
+/// The AAD unit for the sealed suites (C4/C5): the header CONTENT bytes (the inner canonical CBOR),
+/// NOT the bstr wrapper the body uses to carry them. A decryptor authenticates exactly these bytes.
+pub(super) fn header_aad(signed: &SignedAccountEntry) -> &[u8] {
+    &signed.header_bytes
+}
+
+/// Encode the 13-part header array (§6). `Option` hashes become CBOR `null`; every integer is
+/// minimal (minicbor emits the smallest form), so the encoding is canonical.
+fn encode_header(h: &AccountEntryHeader) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(256);
+    {
+        let mut enc = Encoder::new(&mut buf);
+        enc.array(13).expect(INFALLIBLE);
+        enc.str(ACCOUNT_ENTRY_DOMAIN).expect(INFALLIBLE);
+        enc.bytes(&h.account_id.to_bytes()).expect(INFALLIBLE);
+        enc.u8(h.log_id).expect(INFALLIBLE);
+        enc.bytes(&h.device_fingerprint.to_bytes()).expect(INFALLIBLE);
+        enc.u64(h.seq).expect(INFALLIBLE);
+        encode_opt_hash(&mut enc, h.prev_hash);
+        encode_opt_hash(&mut enc, h.parent_ref);
+        enc.u32(h.entry_type).expect(INFALLIBLE);
+        enc.u32(h.op_version).expect(INFALLIBLE);
+        enc.u8(h.crypto_suite).expect(INFALLIBLE);
+        enc.u64(h.auth_len).expect(INFALLIBLE);
+        encode_opt_hash(&mut enc, h.key_id);
+        encode_opt_hash(&mut enc, h.authority_ref);
+    }
+    buf
+}
+
+/// Encode the body: `[header_bytes (bstr), payload (bstr)]`. THESE are the bytes the signature and
+/// `entry_hash` cover.
+fn encode_body(header_bytes: &[u8], payload: &[u8]) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(header_bytes.len() + payload.len() + 16);
+    {
+        let mut enc = Encoder::new(&mut buf);
+        enc.array(2).expect(INFALLIBLE);
+        enc.bytes(header_bytes).expect(INFALLIBLE);
+        enc.bytes(payload).expect(INFALLIBLE);
+    }
+    buf
+}
+
+/// Encode the outer transport envelope: `[domain, body_bytes (bstr), signature (bstr)]`. NOT
+/// signed.
+fn encode_signed(body_bytes: &[u8], signature: &[u8; 64]) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(body_bytes.len() + 96);
+    {
+        let mut enc = Encoder::new(&mut buf);
+        enc.array(3).expect(INFALLIBLE);
+        enc.str(ACCOUNT_SIGNED_DOMAIN).expect(INFALLIBLE);
+        enc.bytes(body_bytes).expect(INFALLIBLE);
+        enc.bytes(signature).expect(INFALLIBLE);
+    }
+    buf
+}
+
+/// A 32-byte bstr for `Some`, CBOR `null` for `None` — the distinguished "no value" marker (never
+/// an all-zero hash).
+fn encode_opt_hash(enc: &mut Encoder<&mut Vec<u8>>, hash: Option<[u8; 32]>) {
+    match hash {
+        Some(hash) => {
+            enc.bytes(&hash).expect(INFALLIBLE);
+        },
+        None => {
+            enc.null().expect(INFALLIBLE);
+        },
+    }
+}
+
+fn decode_account_signed_cbor(bytes: &[u8]) -> Result<SignedAccountEntry, CborError> {
+    // The whole wire is exactly one canonical CBOR item, no trailing bytes.
+    cbor::require_canonical_cbor(bytes)?;
+    let mut d = Decoder::new(bytes);
+    cbor::expect_array(&mut d, 3)?;
+    cbor::expect_domain(&mut d, ACCOUNT_SIGNED_DOMAIN)?;
+    let body_bytes = d.bytes()?.to_vec();
+    let signature = cbor::fixed_bytes::<64>(d.bytes()?, "signature")?;
+    let (header, header_bytes, payload) = decode_body(&body_bytes)?;
+    let entry_hash = cbor::sha256(&body_bytes);
+    Ok(SignedAccountEntry {
+        header,
+        payload,
+        signature,
+        header_bytes,
+        body_bytes,
+        signed_bytes: bytes.to_vec(),
+        entry_hash,
+    })
+}
+
+fn decode_body(body_bytes: &[u8]) -> Result<(AccountEntryHeader, Vec<u8>, Vec<u8>), CborError> {
+    // The body must independently be exactly one canonical CBOR item; the header bstr is validated
+    // in turn by `decode_header`, and `payload` stays an opaque bstr.
+    cbor::require_canonical_cbor(body_bytes)?;
+    let mut d = Decoder::new(body_bytes);
+    cbor::expect_array(&mut d, 2)?;
+    let header_bytes = d.bytes()?.to_vec();
+    let payload = d.bytes()?.to_vec();
+    let header = decode_header(&header_bytes)?;
+    Ok((header, header_bytes, payload))
+}
+
+fn decode_header(header_bytes: &[u8]) -> Result<AccountEntryHeader, CborError> {
+    cbor::require_canonical_cbor(header_bytes)?;
+    let mut d = Decoder::new(header_bytes);
+    cbor::expect_array(&mut d, 13)?;
+    cbor::expect_domain(&mut d, ACCOUNT_ENTRY_DOMAIN)?;
+    let account_id = AccountId::from_bytes(cbor::fixed_bytes::<32>(d.bytes()?, "account_id")?);
+    let log_id = d.u8()?;
+    let device_fingerprint =
+        DeviceFingerprint::from_bytes(cbor::fixed_bytes::<32>(d.bytes()?, "device_fingerprint")?);
+    let seq = d.u64()?;
+    let prev_hash = decode_opt_hash(&mut d, "prev_hash")?;
+    let parent_ref = decode_opt_hash(&mut d, "parent_ref")?;
+    let entry_type = d.u32()?;
+    let op_version = d.u32()?;
+    let crypto_suite = d.u8()?;
+    let auth_len = d.u64()?;
+    let key_id = decode_opt_hash(&mut d, "key_id")?;
+    let authority_ref = decode_opt_hash(&mut d, "authority_ref")?;
+    // Self-contained structural nullity rules (§6). The `authority_ref` ⇔ `AccountGenesis` coupling
+    // needs entry_type SEMANTICS and is enforced where entry_type is interpreted (ops / fold).
+    if (seq == 0) != prev_hash.is_none() {
+        return Err(CborError::message("prev_hash must be null iff seq == 0"));
+    }
+    if (crypto_suite == 0) != key_id.is_none() {
+        return Err(CborError::message("key_id must be null iff crypto_suite == 0"));
+    }
+    Ok(AccountEntryHeader {
+        account_id,
+        log_id,
+        device_fingerprint,
+        seq,
+        prev_hash,
+        parent_ref,
+        entry_type,
+        op_version,
+        crypto_suite,
+        auth_len,
+        key_id,
+        authority_ref,
+    })
+}
+
+/// Decode a hash slot: CBOR null → `None`, else a 32-byte bstr.
+fn decode_opt_hash(d: &mut Decoder<'_>, field: &str) -> Result<Option<[u8; 32]>, CborError> {
+    if d.datatype()? == Type::Null {
+        d.null()?;
+        Ok(None)
+    } else {
+        Ok(Some(cbor::fixed_bytes::<32>(d.bytes()?, field)?))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hex(bytes: &[u8]) -> String {
+        bytes.iter().map(|byte| format!("{byte:02x}")).collect()
+    }
+
+    fn secret() -> DeviceSecret {
+        DeviceSecret::from_seed(&[7u8; 32])
+    }
+
+    fn account() -> AccountId {
+        AccountId::from_bytes([0xaau8; 32])
+    }
+
+    /// A valid genesis-shaped header: control log, seq 0, no predecessor / parent / authority,
+    /// plaintext suite, `auth_len` 0. The device fingerprint is the fixture key's.
+    fn genesis_header() -> AccountEntryHeader {
+        AccountEntryHeader {
+            account_id: account(),
+            log_id: 0,
+            device_fingerprint: secret().public().fingerprint(),
+            seq: 0,
+            prev_hash: None,
+            parent_ref: None,
+            entry_type: 0,
+            op_version: 1,
+            crypto_suite: 0,
+            auth_len: 0,
+            key_id: None,
+            authority_ref: None,
+        }
+    }
+
+    /// A fixed opaque payload — the envelope treats it as bytes.
+    fn payload() -> Vec<u8> {
+        vec![0x85, 0x01, 0x02, 0x03, 0x04]
+    }
+
+    #[test]
+    fn account_signed_pins_the_envelope() {
+        // Frozen primitive: the signature, entry_hash, and chain all build on these bytes; a
+        // canonical-rule change must break this and force a deliberate domain bump.
+        let signed = sign_account_entry(&secret(), &genesis_header(), &payload());
+        assert_eq!(
+            hex(&signed.body_bytes),
+            "8258678d777261672d7261742f6163636f756e742d656e7472792f315820aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa005820fe812c12f3ab4ce6ac5db69ac352f906cb1b11ef43fb33e252ef7ff55226388900f6f600010000f6f6458501020304",
+            "body_bytes golden",
+        );
+        assert_eq!(
+            hex(&signed.signed_bytes),
+            "8378187261672d7261742f6163636f756e742d7369676e65642f3158708258678d777261672d7261742f6163636f756e742d656e7472792f315820aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa005820fe812c12f3ab4ce6ac5db69ac352f906cb1b11ef43fb33e252ef7ff55226388900f6f600010000f6f645850102030458405ddb630fd5cb881a048e989ed09ff5d4b6b259a178430d08cf3e55dfafaaae78c71eee26b6cc4671bd5d5ed9d43aadc6123d7dcfc946cc5427d6df150a92ff02",
+            "signed_bytes golden",
+        );
+    }
+
+    #[test]
+    fn header_bytes_have_the_expected_13_part_structure() {
+        let signed = sign_account_entry(&secret(), &genesis_header(), &payload());
+        let h = &signed.header_bytes;
+        assert_eq!(h[0], 0x8d, "13-element array header");
+        assert_eq!(h[1], 0x77, "text header, len 23");
+        assert_eq!(&h[2..25], b"rag-rat/account-entry/1");
+        assert_eq!(&h[25..27], &[0x58, 0x20], "account_id bstr header, len 32");
+        assert_eq!(&h[27..59], &account().to_bytes(), "account_id bytes");
+        assert_eq!(h[59], 0x00, "log_id 0, minimal uint");
+        assert_eq!(&h[60..62], &[0x58, 0x20], "device_fingerprint bstr header");
+        assert_eq!(&h[62..94], &secret().public().fingerprint().to_bytes(), "device_fingerprint");
+        assert_eq!(h[94], 0x00, "seq 0");
+        assert_eq!(h[95], 0xf6, "prev_hash null (genesis)");
+        assert_eq!(h[96], 0xf6, "parent_ref null (genesis)");
+        assert_eq!(h[97], 0x00, "entry_type 0");
+        assert_eq!(h[98], 0x01, "op_version 1");
+        assert_eq!(h[99], 0x00, "crypto_suite 0 (plaintext)");
+        assert_eq!(h[100], 0x00, "auth_len 0");
+        assert_eq!(h[101], 0xf6, "key_id null (plaintext)");
+        assert_eq!(h[102], 0xf6, "authority_ref null (genesis)");
+        assert_eq!(h.len(), 103);
+        cbor::require_canonical_cbor(h).expect("header is canonical CBOR");
+    }
+
+    #[test]
+    fn body_wraps_header_and_payload_as_bstrs() {
+        let signed = sign_account_entry(&secret(), &genesis_header(), &payload());
+        let b = &signed.body_bytes;
+        assert_eq!(b[0], 0x82, "2-element array (header, payload)");
+        assert_eq!(b[1], 0x58, "header bstr header (1-byte len)");
+        assert_eq!(b[2], 0x67, "header len 103");
+        assert_eq!(&b[3..106], signed.header_bytes.as_slice(), "header content");
+        assert_eq!(b[106], 0x45, "payload bstr, len 5");
+        assert_eq!(&b[107..112], payload().as_slice(), "payload content");
+        assert_eq!(
+            signed.entry_hash,
+            cbor::sha256(&signed.body_bytes),
+            "entry_hash = sha256(body)"
+        );
+    }
+
+    #[test]
+    fn round_trips_through_verify() {
+        let signed = sign_account_entry(&secret(), &genesis_header(), &payload());
+        let verified =
+            verify_account_signed(&signed.signed_bytes, &secret().public()).expect("verifies");
+        assert_eq!(verified.header, genesis_header());
+        assert_eq!(verified.payload, payload());
+        assert_eq!(verified.entry_hash, signed.entry_hash);
+        // Structural decode alone yields the same header + payload.
+        let decoded = decode_account_signed(&signed.signed_bytes).unwrap();
+        assert_eq!(decoded.header, genesis_header());
+        assert_eq!(decoded.payload, payload());
+    }
+
+    #[test]
+    fn verify_rejects_the_wrong_key_and_a_fingerprint_mismatch() {
+        let signed = sign_account_entry(&secret(), &genesis_header(), &payload());
+        let wrong = DeviceSecret::from_seed(&[9u8; 32]).public();
+        assert!(verify_account_signed(&signed.signed_bytes, &wrong).is_err(), "wrong key");
+
+        // A header claiming device B's fingerprint but signed by A must fail under both keys.
+        let secret_b = DeviceSecret::from_seed(&[9u8; 32]);
+        let mut forged = genesis_header();
+        forged.device_fingerprint = secret_b.public().fingerprint();
+        let signed_forged = sign_account_entry(&secret(), &forged, &payload());
+        assert!(
+            verify_account_signed(&signed_forged.signed_bytes, &secret().public()).is_err(),
+            "A's key vs a header claiming B",
+        );
+        assert!(
+            verify_account_signed(&signed_forged.signed_bytes, &secret_b.public()).is_err(),
+            "B's key vs a body A signed",
+        );
+    }
+
+    #[test]
+    fn tampering_the_header_or_payload_is_rejected() {
+        let signed = sign_account_entry(&secret(), &genesis_header(), &payload());
+        // The body starts after the outer [0x83, 0x77, 23-byte domain, 0x58, len] = 27-byte header.
+        let body_start = 2 + 23 + 2;
+        for offset in [3usize, 60, 108] {
+            let mut wire = signed.signed_bytes.clone();
+            wire[body_start + offset] ^= 0x01;
+            assert!(
+                verify_account_signed(&wire, &secret().public()).is_err(),
+                "flipping a body byte at offset {offset} must fail verification",
+            );
+        }
+        // Flipping the trailing signature byte fails too.
+        let mut wire = signed.signed_bytes.clone();
+        let last = wire.len() - 1;
+        wire[last] ^= 0x01;
+        assert!(verify_account_signed(&wire, &secret().public()).is_err(), "signature tamper");
+    }
+
+    #[test]
+    fn structural_rejections() {
+        let good = sign_account_entry(&secret(), &genesis_header(), &payload());
+        // Trailing bytes.
+        let mut trailing = good.signed_bytes.clone();
+        trailing.push(0x00);
+        assert!(decode_account_signed(&trailing).is_err(), "trailing bytes");
+        // Empty / non-array.
+        assert!(decode_account_signed(&[0x00]).is_err(), "not an array");
+        // Over the §18a size limit.
+        let huge = vec![0u8; ACCOUNT_ENVELOPE_MAX_BYTES + 1];
+        assert!(decode_account_signed(&huge).is_err(), "over the §18a limit");
+    }
+
+    #[test]
+    fn prev_hash_and_key_id_nullity_rules_are_enforced() {
+        // seq > 0 with a null prev_hash is rejected.
+        let mut bad_prev = genesis_header();
+        bad_prev.seq = 5;
+        bad_prev.prev_hash = None;
+        let signed = sign_account_entry(&secret(), &bad_prev, &payload());
+        assert!(decode_account_signed(&signed.signed_bytes).is_err(), "seq>0 needs prev_hash");
+
+        // seq 0 with a non-null prev_hash is rejected.
+        let mut bad_genesis = genesis_header();
+        bad_genesis.prev_hash = Some([0x11; 32]);
+        let signed = sign_account_entry(&secret(), &bad_genesis, &payload());
+        assert!(decode_account_signed(&signed.signed_bytes).is_err(), "genesis has no prev_hash");
+
+        // crypto_suite 0 (plaintext) with a non-null key_id is rejected (§15).
+        let mut bad_key = genesis_header();
+        bad_key.key_id = Some([0x22; 32]);
+        let signed = sign_account_entry(&secret(), &bad_key, &payload());
+        assert!(decode_account_signed(&signed.signed_bytes).is_err(), "plaintext has no key_id");
+
+        // crypto_suite 1 (sealed) with a null key_id is rejected.
+        let mut bad_sealed = genesis_header();
+        bad_sealed.crypto_suite = 1;
+        bad_sealed.key_id = None;
+        let signed = sign_account_entry(&secret(), &bad_sealed, &payload());
+        assert!(decode_account_signed(&signed.signed_bytes).is_err(), "sealed needs a key_id");
+    }
+
+    #[test]
+    fn header_aad_is_the_header_content_not_the_payload() {
+        // Same header, different payload ⇒ identical AAD (the header bytes); the payload is not in
+        // it.
+        let a = sign_account_entry(&secret(), &genesis_header(), &payload());
+        let b = sign_account_entry(&secret(), &genesis_header(), &[0xff, 0xfe]);
+        assert_eq!(header_aad(&a), header_aad(&b), "AAD is independent of the payload");
+        assert_eq!(header_aad(&a), a.header_bytes.as_slice(), "AAD is the header content bytes");
+        // A changed header field changes the AAD.
+        let mut other = genesis_header();
+        other.auth_len = 9;
+        let c = sign_account_entry(&secret(), &other, &payload());
+        assert_ne!(header_aad(&a), header_aad(&c), "a header change changes the AAD");
+    }
+}

--- a/crates/rag-rat-core/src/oplog/account/id.rs
+++ b/crates/rag-rat-core/src/oplog/account/id.rs
@@ -7,9 +7,9 @@
 //! principal.
 
 use minicbor::Encoder;
-use sha2::{Digest, Sha256};
 
 use super::limits::ACCOUNT_ID_DOMAIN;
+use crate::oplog::cbor;
 
 /// Writing CBOR into a `Vec` cannot fail (its `Write` impl is infallible) — mirrors `super::super`.
 const INFALLIBLE: &str = "encoding CBOR to a Vec is infallible";
@@ -44,13 +44,13 @@ pub(super) fn account_id_from_genesis_payload(genesis_payload_bytes: &[u8]) -> A
         enc.str(ACCOUNT_ID_DOMAIN).expect(INFALLIBLE);
         enc.bytes(genesis_payload_bytes).expect(INFALLIBLE);
     }
-    let mut out = [0u8; 32];
-    out.copy_from_slice(&Sha256::digest(&buf));
-    AccountId(out)
+    AccountId(cbor::sha256(&buf))
 }
 
 #[cfg(test)]
 mod tests {
+    use sha2::{Digest, Sha256};
+
     use super::*;
     use crate::oplog::cbor;
 

--- a/crates/rag-rat-core/src/oplog/account/id.rs
+++ b/crates/rag-rat-core/src/oplog/account/id.rs
@@ -1,0 +1,114 @@
+//! The account identity — [`AccountId`] and its genesis-committing derivation (§4).
+//!
+//! `account_id = sha256(cbor(["rag-rat/account/1", genesis_payload_bytes]))` commits to the ENTIRE
+//! founding state of the account (the `AccountGenesis` payload). Two devices claiming one account
+//! is therefore cryptographically impossible, and any peer can verify the id offline from the
+//! genesis entry alone. Store-global and immutable — the exact analog of a `StreamId` for a
+//! principal.
+
+use minicbor::Encoder;
+use sha2::{Digest, Sha256};
+
+use super::limits::ACCOUNT_ID_DOMAIN;
+
+/// Writing CBOR into a `Vec` cannot fail (its `Write` impl is infallible) — mirrors `super::super`.
+const INFALLIBLE: &str = "encoding CBOR to a Vec is infallible";
+
+/// An account's immutable, content-derived identity: `sha256` of the domain-tagged genesis
+/// commitment. The store-global key for a principal's roster, grants, and folds.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct AccountId([u8; 32]);
+
+impl AccountId {
+    pub(crate) fn from_bytes(bytes: [u8; 32]) -> Self {
+        Self(bytes)
+    }
+
+    /// By value — `AccountId` is `Copy` (clippy `wrong_self_convention` flags `to_*` on `&self`).
+    pub(crate) fn to_bytes(self) -> [u8; 32] {
+        self.0
+    }
+}
+
+/// Derive the `account_id` from the canonical-CBOR bytes of the account's `AccountGenesis` payload
+/// (§4). The payload is carried as an opaque byte string — this layer commits to it verbatim, so a
+/// change to ANY genesis byte yields a different account. The domain tag disambiguates the hash
+/// from every other object on the wire.
+///
+/// Consumed by the fold / ingest genesis self-hash check (Phase 4/5).
+pub(super) fn account_id_from_genesis_payload(genesis_payload_bytes: &[u8]) -> AccountId {
+    let mut buf = Vec::with_capacity(64);
+    {
+        let mut enc = Encoder::new(&mut buf);
+        enc.array(2).expect(INFALLIBLE);
+        enc.str(ACCOUNT_ID_DOMAIN).expect(INFALLIBLE);
+        enc.bytes(genesis_payload_bytes).expect(INFALLIBLE);
+    }
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&Sha256::digest(&buf));
+    AccountId(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::oplog::cbor;
+
+    fn hex(bytes: &[u8]) -> String {
+        bytes.iter().map(|byte| format!("{byte:02x}")).collect()
+    }
+
+    /// A fixed opaque "genesis payload". The id derivation treats it as opaque bytes, so its
+    /// internal structure is irrelevant here — the real `AccountGenesis` payload encoding is
+    /// pinned in `ops.rs`. Distinctive bytes make the fixture visually recognizable in the
+    /// wire.
+    fn genesis_payload() -> Vec<u8> {
+        vec![0x85, 0x01, 0x02, 0x03, 0x04]
+    }
+
+    #[test]
+    fn account_id_pins_the_genesis_commitment() {
+        // Frozen primitive: stream ids, grants, and folds all key on these 32 bytes, so a
+        // canonical-rule change must break this test and force a deliberate `rag-rat/account/1`
+        // domain bump.
+        let id = account_id_from_genesis_payload(&genesis_payload());
+        assert_eq!(
+            hex(&id.to_bytes()),
+            "8e305e528169a19412449905c460978472d61f38d12bf532898c88a40c961dcf",
+            "account_id golden",
+        );
+    }
+
+    #[test]
+    fn account_id_is_sha256_of_the_domain_committed_payload() {
+        // Independent recomputation of the frozen `[domain, payload-bstr]` preimage shape, so the
+        // structure is pinned separately from the opaque golden hash.
+        let payload = genesis_payload();
+        let mut preimage = Vec::new();
+        {
+            let mut enc = Encoder::new(&mut preimage);
+            enc.array(2).unwrap();
+            enc.str("rag-rat/account/1").unwrap();
+            enc.bytes(&payload).unwrap();
+        }
+        cbor::require_canonical_cbor(&preimage).expect("preimage is canonical CBOR");
+        let mut expected = [0u8; 32];
+        expected.copy_from_slice(&Sha256::digest(&preimage));
+        assert_eq!(account_id_from_genesis_payload(&payload).to_bytes(), expected);
+    }
+
+    #[test]
+    fn account_id_is_a_function_of_the_whole_genesis_payload() {
+        let baseline = account_id_from_genesis_payload(&genesis_payload());
+        // Flipping any byte of the payload yields a different account.
+        for index in 0..genesis_payload().len() {
+            let mut mutated = genesis_payload();
+            mutated[index] ^= 0x01;
+            assert_ne!(
+                account_id_from_genesis_payload(&mutated),
+                baseline,
+                "flipping payload byte {index} must change the account_id",
+            );
+        }
+    }
+}

--- a/crates/rag-rat-core/src/oplog/account/limits.rs
+++ b/crates/rag-rat-core/src/oplog/account/limits.rs
@@ -1,0 +1,62 @@
+//! Frozen wire constants for the account layer: the domain tags and the §18a protocol-VALIDITY
+//! limits.
+//!
+//! Two flavours of constant live here, and the distinction is load-bearing:
+//! - **Domain tags** version the wire. An old binary rejects a bumped tag rather than misreading
+//!   it.
+//! - **§18a validity limits** are frozen protocol constants: a violation is a STRUCTURAL REJECT in
+//!   *every* implementation, and changing one is a deliberate wire bump — NOT a tunable. (The
+//!   local, tunable quotas of §18b — park budgets, fold caps — are implementation-local and live
+//!   with the code that enforces them, never here.)
+//!
+//! CBOR nesting depth reuses [`super::super::cbor::MAX_CBOR_DEPTH`] (= 32), the same floor the
+//! phase-B op wire enforces — an account object is not allowed to nest deeper than an op entry.
+
+/// Domain tag for the account-entry BODY header (the bytes the signature and `entry_hash` cover).
+pub(super) const ACCOUNT_ENTRY_DOMAIN: &str = "rag-rat/account-entry/1";
+/// Domain tag for the outer signed account-entry transport envelope (body + signature).
+pub(super) const ACCOUNT_SIGNED_DOMAIN: &str = "rag-rat/account-signed/1";
+/// Domain tag committed into the `account_id` genesis hash (§4).
+pub(super) const ACCOUNT_ID_DOMAIN: &str = "rag-rat/account/1";
+
+/// §18a — max encoded size of an account-log entry wire. A larger envelope is a structural reject.
+pub(super) const ACCOUNT_ENVELOPE_MAX_BYTES: usize = 64 * 1024;
+/// §18a — max encoded size of a `/3` content entry wire. Consumed by C2 (the `/3` envelope); pinned
+/// here now so the whole §18a set is frozen together at C1.
+pub(super) const CONTENT_ENVELOPE_MAX_BYTES: usize = 256 * 1024;
+/// §18a — max `device_cuts` entries in a `DeviceRemove` / `StreamRevoke` payload. Consumed by the
+/// control-op decoders (Phase 3, `ops.rs`).
+pub(super) const DEVICE_CUTS_MAX: usize = 256;
+/// §18a — max `content_cuts` entries in a `DeviceRemove` payload. Consumed by the control-op
+/// decoders (Phase 3, `ops.rs`).
+pub(super) const CONTENT_CUTS_MAX: usize = 1024;
+/// §18a — max wrap recipients in a `StreamKeyWrap`. Consumed by C4 (key wraps); pinned here now so
+/// the whole §18a set is frozen together at C1.
+pub(super) const WRAP_RECIPIENTS_MAX: usize = 1024;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn domain_tags_are_frozen() {
+        // A change to any tag is a wire-version bump — an old binary must reject the new tag, not
+        // misread it. These strings are the security boundary; pin them exactly.
+        assert_eq!(ACCOUNT_ENTRY_DOMAIN, "rag-rat/account-entry/1");
+        assert_eq!(ACCOUNT_SIGNED_DOMAIN, "rag-rat/account-signed/1");
+        assert_eq!(ACCOUNT_ID_DOMAIN, "rag-rat/account/1");
+    }
+
+    #[test]
+    fn validity_limits_are_frozen_wire_constants() {
+        // §18a: a violation is a structural reject in every impl, and changing one of these is a
+        // deliberate wire bump. Pin the exact values so a drift breaks the build, not a live peer.
+        assert_eq!(ACCOUNT_ENVELOPE_MAX_BYTES, 65_536);
+        assert_eq!(CONTENT_ENVELOPE_MAX_BYTES, 262_144);
+        assert_eq!(DEVICE_CUTS_MAX, 256);
+        assert_eq!(CONTENT_CUTS_MAX, 1_024);
+        assert_eq!(WRAP_RECIPIENTS_MAX, 1_024);
+        // CBOR depth is shared with the op wire, not re-declared here.
+        assert_eq!(crate::oplog::cbor::MAX_CBOR_DEPTH, 32);
+    }
+}

--- a/crates/rag-rat-core/src/oplog/account/mod.rs
+++ b/crates/rag-rat-core/src/oplog/account/mod.rs
@@ -1,0 +1,31 @@
+//! The account identity/crypto layer (sync phase C) — self-sovereign device rosters, roles,
+//! cross-account grants, revocation, and the depth-stratified control fold, layered ABOVE the
+//! phase-B op-log (layer 1) and reusing its canonical-CBOR discipline ([`super::cbor`]), device
+//! keys ([`super::device`]), and [`super::stream::StreamId`].
+//!
+//! An **account** is a principal (a person or org): a self-sovereign device roster managed only by
+//! its own hash-chained, signed logs. Account entries are a SEPARATE signed wire layer
+//! (`rag-rat/account-entry/1`) that never touches [`super::store::append`] — they get their own
+//! candidate-DAG storage and a pure `fold_account` that derives ALL authority from
+//! content-addressed citations (a cited grant / owner-incarnation / cut), never from ordering. See
+//! the frozen design note `sync-phase-c-design.md` (v5) for the whole-phase contract; C1 builds the
+//! spine.
+//!
+//! C1 modules (this slice):
+//! - [`id`]: [`AccountId`] + the §4 genesis commitment.
+//! - [`limits`]: §18a protocol-validity constants + the account-layer domain strings.
+//! - [`envelope`]: the 13-part signed account-entry envelope (§6).
+//!
+//! **Build-time lint posture.** The account subsystem is built bottom-up over the C1 slices: a
+//! lower layer (envelope, ops, cut, registers) is consumed only by a higher one (fold, storage) or
+//! by a later phase (C2–C5), so a freshly-landed layer reads as `dead_code` until its consumer
+//! arrives. This blanket allow spans the build; it is REMOVED at Phase 6 (surface wire-up), where
+//! the final `-D warnings` clippy gate + the reviewer catch anything genuinely unreachable, and the
+//! handful of truly C2–C5-deferred seams get precise per-item allows.
+#![allow(dead_code)]
+
+mod envelope;
+mod id;
+mod limits;
+
+pub(crate) use id::AccountId;

--- a/crates/rag-rat-core/src/oplog/account/mod.rs
+++ b/crates/rag-rat-core/src/oplog/account/mod.rs
@@ -24,8 +24,10 @@
 //! handful of truly C2–C5-deferred seams get precise per-item allows.
 #![allow(dead_code)]
 
+mod cut;
 mod envelope;
 mod id;
 mod limits;
+mod ops;
 
 pub(crate) use id::AccountId;

--- a/crates/rag-rat-core/src/oplog/account/mod.rs
+++ b/crates/rag-rat-core/src/oplog/account/mod.rs
@@ -24,10 +24,12 @@
 //! handful of truly C2–C5-deferred seams get precise per-item allows.
 #![allow(dead_code)]
 
+mod candidate;
 mod cut;
 mod envelope;
 mod id;
 mod limits;
 mod ops;
+mod registers;
 
 pub(crate) use id::AccountId;

--- a/crates/rag-rat-core/src/oplog/account/ops.rs
+++ b/crates/rag-rat-core/src/oplog/account/ops.rs
@@ -1,0 +1,890 @@
+//! The control-log op payloads (`log_id = 0`) and their canonical-CBOR wire (§10).
+//!
+//! Each op is a domain-less fixed-length CBOR array carried as the `payload` bstr of an account
+//! entry (the domain + versioning live in the envelope header, §6). The op is discriminated by the
+//! header's `entry_type`, whose frozen tag set is [`entry_type`]. An UNKNOWN `entry_type` is
+//! RETAINED, never rejected ([`DecodedAccountOp::Unknown`]) — a forward-version op still stores +
+//! chains, exactly as `super::super::op` keeps a forward op opaque.
+//!
+//! This layer owns STRUCTURAL wire validity: arity, canonicity (`encode(decode) == bytes`), closed
+//! role/kind tokens, §18a cut-array bounds, sorted-unique cut arrays, the `CutExtend` stream_id ⇔
+//! kind coupling, and public-key point-validity (an ed25519 non-point / identity-or-small-order
+//! X25519 key is refused here). The CRYPTO-CONSISTENCY + authority rules that need other entries or
+//! the header (genesis self-hash, roster/grant citation, last-owner, StreamOwn spec match) live in
+//! the fold ([`super::fold`]).
+
+use minicbor::Encoder;
+use minicbor::data::Type;
+use minicbor::decode::{Decoder, Error as CborError};
+
+use super::AccountId;
+use super::cut::Cut;
+use super::limits::{CONTENT_CUTS_MAX, DEVICE_CUTS_MAX};
+use crate::oplog::cbor;
+use crate::oplog::device::{DevicePublic, DeviceX25519Public};
+use crate::oplog::op::DeviceFingerprint;
+use crate::oplog::stream::StreamId;
+
+/// Writing CBOR into a `Vec` cannot fail (its `Write` impl is infallible) — mirrors `super::super`.
+const INFALLIBLE: &str = "encoding CBOR to a Vec is infallible";
+
+/// The frozen `entry_type` tag set (header part 7). A tag is a wire constant — a renumber is a wire
+/// bump. Values 10.. are reserved (`PublicStreamConfig`, `ModerationOp` — C3/E).
+pub(super) mod entry_type {
+    pub(in crate::oplog::account) const ACCOUNT_GENESIS: u32 = 0;
+    pub(in crate::oplog::account) const DEVICE_ADD: u32 = 1;
+    pub(in crate::oplog::account) const DEVICE_REMOVE: u32 = 2;
+    pub(in crate::oplog::account) const OWNER_PROMOTE: u32 = 3;
+    pub(in crate::oplog::account) const OWNER_DEMOTE: u32 = 4;
+    pub(in crate::oplog::account) const CUT_EXTEND: u32 = 5;
+    pub(in crate::oplog::account) const STREAM_OWN: u32 = 6;
+    pub(in crate::oplog::account) const STREAM_GRANT: u32 = 7;
+    pub(in crate::oplog::account) const STREAM_REVOKE: u32 = 8;
+    pub(in crate::oplog::account) const ACCOUNT_REROOT: u32 = 9;
+}
+
+/// A device's role in an account roster (§9). Owner holds all control/secrets ops; a member authors
+/// content on granted streams only.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum DeviceRole {
+    Member,
+    Owner,
+}
+
+impl DeviceRole {
+    fn as_u8(self) -> u8 {
+        match self {
+            DeviceRole::Member => 1,
+            DeviceRole::Owner => 2,
+        }
+    }
+
+    fn from_u8(value: u8) -> Result<Self, CborError> {
+        match value {
+            1 => Ok(DeviceRole::Member),
+            2 => Ok(DeviceRole::Owner),
+            other => Err(CborError::message(format!("unknown device role {other}"))),
+        }
+    }
+}
+
+/// A cross-account grant's role on a stream (§9). Reader = wrap recipient (sealed) / free (public);
+/// writer = reader + content accepted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum GrantRole {
+    Reader,
+    Writer,
+}
+
+impl GrantRole {
+    fn as_u8(self) -> u8 {
+        match self {
+            GrantRole::Reader => 1,
+            GrantRole::Writer => 2,
+        }
+    }
+
+    fn from_u8(value: u8) -> Result<Self, CborError> {
+        match value {
+            1 => Ok(GrantRole::Reader),
+            2 => Ok(GrantRole::Writer),
+            other => Err(CborError::message(format!("unknown grant role {other}"))),
+        }
+    }
+}
+
+/// Which chain a `CutExtend` extends (§10). Content (2) requires a `stream_id`; ctrl/secrets do
+/// not.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ChainKind {
+    Ctrl,
+    Secrets,
+    Content,
+}
+
+impl ChainKind {
+    fn as_u8(self) -> u8 {
+        match self {
+            ChainKind::Ctrl => 0,
+            ChainKind::Secrets => 1,
+            ChainKind::Content => 2,
+        }
+    }
+
+    fn from_u8(value: u8) -> Result<Self, CborError> {
+        match value {
+            0 => Ok(ChainKind::Ctrl),
+            1 => Ok(ChainKind::Secrets),
+            2 => Ok(ChainKind::Content),
+            other => Err(CborError::message(format!("unknown chain kind {other}"))),
+        }
+    }
+}
+
+/// One content-chain cut inside a `DeviceRemove`: `[stream_id, seq, entry_hash]`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct ContentCut {
+    pub(super) stream_id: StreamId,
+    pub(super) seq: u64,
+    pub(super) hash: [u8; 32],
+}
+
+/// One device-chain cut inside a `StreamRevoke`: `[device_fingerprint, seq, entry_hash]`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct DeviceCut {
+    pub(super) device_fingerprint: DeviceFingerprint,
+    pub(super) seq: u64,
+    pub(super) hash: [u8; 32],
+}
+
+/// The ten control-log ops (§10). Field order is the frozen wire order; goldens pin the bytes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum AccountOp {
+    AccountGenesis {
+        ed25519_pubkey: [u8; 32],
+        x25519_pubkey: [u8; 32],
+        nonce16: [u8; 16],
+        created_at_ms: u64,
+        label: Option<String>,
+    },
+    DeviceAdd {
+        device_fingerprint: DeviceFingerprint,
+        ed25519_pubkey: [u8; 32],
+        x25519_pubkey: [u8; 32],
+        role: DeviceRole,
+        label: Option<String>,
+    },
+    DeviceRemove {
+        device_fingerprint: DeviceFingerprint,
+        control_cut: Cut,
+        secrets_cut: Cut,
+        content_cuts: Vec<ContentCut>,
+        reason: String,
+    },
+    OwnerPromote {
+        device_fingerprint: DeviceFingerprint,
+    },
+    OwnerDemote {
+        device_fingerprint: DeviceFingerprint,
+        owner_id: [u8; 32],
+        control_cut: Cut,
+        secrets_cut: Cut,
+        reason: String,
+    },
+    CutExtend {
+        chain_kind: ChainKind,
+        stream_id: Option<StreamId>,
+        incarnation_id: Option<[u8; 32]>,
+        subject_account_id: AccountId,
+        device_fingerprint: DeviceFingerprint,
+        new_seq: u64,
+        new_entry_hash: [u8; 32],
+    },
+    StreamOwn {
+        stream_id: StreamId,
+        stream_spec_bytes: Vec<u8>,
+    },
+    StreamGrant {
+        stream_id: StreamId,
+        grantee_account_id: AccountId,
+        grant_role: GrantRole,
+    },
+    StreamRevoke {
+        stream_id: StreamId,
+        grantee_account_id: AccountId,
+        grant_id: [u8; 32],
+        device_cuts: Vec<DeviceCut>,
+        reason: String,
+    },
+    AccountReRoot {
+        successor_account_id: AccountId,
+        note: Option<String>,
+    },
+}
+
+/// The result of decoding an op payload against its header `entry_type`: a known op or a retained
+/// opaque forward-version op (never an error for an unrecognized `entry_type`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum DecodedAccountOp {
+    Known(AccountOp),
+    Unknown { entry_type: u32, bytes: Vec<u8> },
+}
+
+/// The `entry_type` tag an op carries in its header (§10).
+pub(super) fn entry_type_of(op: &AccountOp) -> u32 {
+    match op {
+        AccountOp::AccountGenesis { .. } => entry_type::ACCOUNT_GENESIS,
+        AccountOp::DeviceAdd { .. } => entry_type::DEVICE_ADD,
+        AccountOp::DeviceRemove { .. } => entry_type::DEVICE_REMOVE,
+        AccountOp::OwnerPromote { .. } => entry_type::OWNER_PROMOTE,
+        AccountOp::OwnerDemote { .. } => entry_type::OWNER_DEMOTE,
+        AccountOp::CutExtend { .. } => entry_type::CUT_EXTEND,
+        AccountOp::StreamOwn { .. } => entry_type::STREAM_OWN,
+        AccountOp::StreamGrant { .. } => entry_type::STREAM_GRANT,
+        AccountOp::StreamRevoke { .. } => entry_type::STREAM_REVOKE,
+        AccountOp::AccountReRoot { .. } => entry_type::ACCOUNT_REROOT,
+    }
+}
+
+/// Encode an op to its canonical-CBOR payload (§10). Sorted cut arrays are emitted in binary-id
+/// order (the decoder rejects an unsorted wire, so `encode(decode) == bytes`).
+pub(super) fn encode(op: &AccountOp) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(128);
+    {
+        let mut enc = Encoder::new(&mut buf);
+        match op {
+            AccountOp::AccountGenesis {
+                ed25519_pubkey,
+                x25519_pubkey,
+                nonce16,
+                created_at_ms,
+                label,
+            } => {
+                enc.array(5).expect(INFALLIBLE);
+                enc.bytes(ed25519_pubkey).expect(INFALLIBLE);
+                enc.bytes(x25519_pubkey).expect(INFALLIBLE);
+                enc.bytes(nonce16).expect(INFALLIBLE);
+                enc.u64(*created_at_ms).expect(INFALLIBLE);
+                encode_opt_str(&mut enc, label.as_deref());
+            },
+            AccountOp::DeviceAdd {
+                device_fingerprint,
+                ed25519_pubkey,
+                x25519_pubkey,
+                role,
+                label,
+            } => {
+                enc.array(5).expect(INFALLIBLE);
+                enc.bytes(&device_fingerprint.to_bytes()).expect(INFALLIBLE);
+                enc.bytes(ed25519_pubkey).expect(INFALLIBLE);
+                enc.bytes(x25519_pubkey).expect(INFALLIBLE);
+                enc.u8(role.as_u8()).expect(INFALLIBLE);
+                encode_opt_str(&mut enc, label.as_deref());
+            },
+            AccountOp::DeviceRemove {
+                device_fingerprint,
+                control_cut,
+                secrets_cut,
+                content_cuts,
+                reason,
+            } => {
+                enc.array(5).expect(INFALLIBLE);
+                enc.bytes(&device_fingerprint.to_bytes()).expect(INFALLIBLE);
+                control_cut.encode_into(&mut enc);
+                secrets_cut.encode_into(&mut enc);
+                encode_content_cuts(&mut enc, content_cuts);
+                enc.str(reason).expect(INFALLIBLE);
+            },
+            AccountOp::OwnerPromote { device_fingerprint } => {
+                enc.array(1).expect(INFALLIBLE);
+                enc.bytes(&device_fingerprint.to_bytes()).expect(INFALLIBLE);
+            },
+            AccountOp::OwnerDemote {
+                device_fingerprint,
+                owner_id,
+                control_cut,
+                secrets_cut,
+                reason,
+            } => {
+                enc.array(5).expect(INFALLIBLE);
+                enc.bytes(&device_fingerprint.to_bytes()).expect(INFALLIBLE);
+                enc.bytes(owner_id).expect(INFALLIBLE);
+                control_cut.encode_into(&mut enc);
+                secrets_cut.encode_into(&mut enc);
+                enc.str(reason).expect(INFALLIBLE);
+            },
+            AccountOp::CutExtend {
+                chain_kind,
+                stream_id,
+                incarnation_id,
+                subject_account_id,
+                device_fingerprint,
+                new_seq,
+                new_entry_hash,
+            } => {
+                enc.array(7).expect(INFALLIBLE);
+                enc.u8(chain_kind.as_u8()).expect(INFALLIBLE);
+                encode_opt_b32(&mut enc, stream_id.map(StreamId::to_bytes));
+                encode_opt_b32(&mut enc, *incarnation_id);
+                enc.bytes(&subject_account_id.to_bytes()).expect(INFALLIBLE);
+                enc.bytes(&device_fingerprint.to_bytes()).expect(INFALLIBLE);
+                enc.u64(*new_seq).expect(INFALLIBLE);
+                enc.bytes(new_entry_hash).expect(INFALLIBLE);
+            },
+            AccountOp::StreamOwn { stream_id, stream_spec_bytes } => {
+                enc.array(2).expect(INFALLIBLE);
+                enc.bytes(&stream_id.to_bytes()).expect(INFALLIBLE);
+                enc.bytes(stream_spec_bytes).expect(INFALLIBLE);
+            },
+            AccountOp::StreamGrant { stream_id, grantee_account_id, grant_role } => {
+                enc.array(3).expect(INFALLIBLE);
+                enc.bytes(&stream_id.to_bytes()).expect(INFALLIBLE);
+                enc.bytes(&grantee_account_id.to_bytes()).expect(INFALLIBLE);
+                enc.u8(grant_role.as_u8()).expect(INFALLIBLE);
+            },
+            AccountOp::StreamRevoke {
+                stream_id,
+                grantee_account_id,
+                grant_id,
+                device_cuts,
+                reason,
+            } => {
+                enc.array(5).expect(INFALLIBLE);
+                enc.bytes(&stream_id.to_bytes()).expect(INFALLIBLE);
+                enc.bytes(&grantee_account_id.to_bytes()).expect(INFALLIBLE);
+                enc.bytes(grant_id).expect(INFALLIBLE);
+                encode_device_cuts(&mut enc, device_cuts);
+                enc.str(reason).expect(INFALLIBLE);
+            },
+            AccountOp::AccountReRoot { successor_account_id, note } => {
+                enc.array(2).expect(INFALLIBLE);
+                enc.bytes(&successor_account_id.to_bytes()).expect(INFALLIBLE);
+                encode_opt_str(&mut enc, note.as_deref());
+            },
+        }
+    }
+    buf
+}
+
+/// Decode an op payload against its header `entry_type`. A known type is fully validated
+/// (structure, canonicity via re-encode, closed tokens, bounds); an unknown type is retained
+/// opaque.
+pub(super) fn decode(entry_type: u32, bytes: &[u8]) -> Result<DecodedAccountOp, CborError> {
+    let op = match entry_type {
+        entry_type::ACCOUNT_GENESIS => decode_account_genesis(bytes)?,
+        entry_type::DEVICE_ADD => decode_device_add(bytes)?,
+        entry_type::DEVICE_REMOVE => decode_device_remove(bytes)?,
+        entry_type::OWNER_PROMOTE => decode_owner_promote(bytes)?,
+        entry_type::OWNER_DEMOTE => decode_owner_demote(bytes)?,
+        entry_type::CUT_EXTEND => decode_cut_extend(bytes)?,
+        entry_type::STREAM_OWN => decode_stream_own(bytes)?,
+        entry_type::STREAM_GRANT => decode_stream_grant(bytes)?,
+        entry_type::STREAM_REVOKE => decode_stream_revoke(bytes)?,
+        entry_type::ACCOUNT_REROOT => decode_account_reroot(bytes)?,
+        other => return Ok(DecodedAccountOp::Unknown { entry_type: other, bytes: bytes.to_vec() }),
+    };
+    // Canonicity guarantee for a KNOWN op: the decoded value must re-encode to the exact wire (this
+    // rejects non-minimal ints, unsorted cut arrays, trailing bytes, etc. in one check).
+    if encode(&op) != bytes {
+        return Err(CborError::message("op payload is not canonical (re-encode differs)"));
+    }
+    Ok(DecodedAccountOp::Known(op))
+}
+
+fn decode_account_genesis(bytes: &[u8]) -> Result<AccountOp, CborError> {
+    let mut d = decoder(bytes, 5)?;
+    let ed25519_pubkey = cbor::fixed_bytes::<32>(d.bytes()?, "ed25519_pubkey")?;
+    let x25519_pubkey = cbor::fixed_bytes::<32>(d.bytes()?, "x25519_pubkey")?;
+    validate_keys(&ed25519_pubkey, &x25519_pubkey)?;
+    let nonce16 = cbor::fixed_bytes::<16>(d.bytes()?, "nonce16")?;
+    let created_at_ms = d.u64()?;
+    let label = decode_opt_str(&mut d)?;
+    Ok(AccountOp::AccountGenesis { ed25519_pubkey, x25519_pubkey, nonce16, created_at_ms, label })
+}
+
+fn decode_device_add(bytes: &[u8]) -> Result<AccountOp, CborError> {
+    let mut d = decoder(bytes, 5)?;
+    let device_fingerprint =
+        DeviceFingerprint::from_bytes(cbor::fixed_bytes::<32>(d.bytes()?, "device_fingerprint")?);
+    let ed25519_pubkey = cbor::fixed_bytes::<32>(d.bytes()?, "ed25519_pubkey")?;
+    let x25519_pubkey = cbor::fixed_bytes::<32>(d.bytes()?, "x25519_pubkey")?;
+    validate_keys(&ed25519_pubkey, &x25519_pubkey)?;
+    // Self-contained consistency: the fingerprint must be sha256 of the ed25519 key (both are in
+    // the payload). The roster/authority checks are the fold's.
+    if device_fingerprint.to_bytes() != cbor::sha256(&ed25519_pubkey) {
+        return Err(CborError::message("device_fingerprint is not sha256(ed25519_pubkey)"));
+    }
+    let role = DeviceRole::from_u8(d.u8()?)?;
+    let label = decode_opt_str(&mut d)?;
+    Ok(AccountOp::DeviceAdd { device_fingerprint, ed25519_pubkey, x25519_pubkey, role, label })
+}
+
+fn decode_device_remove(bytes: &[u8]) -> Result<AccountOp, CborError> {
+    let mut d = decoder(bytes, 5)?;
+    let device_fingerprint =
+        DeviceFingerprint::from_bytes(cbor::fixed_bytes::<32>(d.bytes()?, "device_fingerprint")?);
+    let control_cut = Cut::decode(&mut d)?;
+    let secrets_cut = Cut::decode(&mut d)?;
+    let content_cuts = decode_content_cuts(&mut d)?;
+    let reason = d.str()?.to_string();
+    Ok(AccountOp::DeviceRemove {
+        device_fingerprint,
+        control_cut,
+        secrets_cut,
+        content_cuts,
+        reason,
+    })
+}
+
+fn decode_owner_promote(bytes: &[u8]) -> Result<AccountOp, CborError> {
+    let mut d = decoder(bytes, 1)?;
+    let device_fingerprint =
+        DeviceFingerprint::from_bytes(cbor::fixed_bytes::<32>(d.bytes()?, "device_fingerprint")?);
+    Ok(AccountOp::OwnerPromote { device_fingerprint })
+}
+
+fn decode_owner_demote(bytes: &[u8]) -> Result<AccountOp, CborError> {
+    let mut d = decoder(bytes, 5)?;
+    let device_fingerprint =
+        DeviceFingerprint::from_bytes(cbor::fixed_bytes::<32>(d.bytes()?, "device_fingerprint")?);
+    let owner_id = cbor::fixed_bytes::<32>(d.bytes()?, "owner_id")?;
+    let control_cut = Cut::decode(&mut d)?;
+    let secrets_cut = Cut::decode(&mut d)?;
+    let reason = d.str()?.to_string();
+    Ok(AccountOp::OwnerDemote { device_fingerprint, owner_id, control_cut, secrets_cut, reason })
+}
+
+fn decode_cut_extend(bytes: &[u8]) -> Result<AccountOp, CborError> {
+    let mut d = decoder(bytes, 7)?;
+    let chain_kind = ChainKind::from_u8(d.u8()?)?;
+    let stream_id = decode_opt_b32(&mut d, "stream_id")?.map(StreamId::from_bytes);
+    let incarnation_id = decode_opt_b32(&mut d, "incarnation_id")?;
+    // A content cut names a stream; a ctrl/secrets cut does not (§10).
+    if (chain_kind == ChainKind::Content) != stream_id.is_some() {
+        return Err(CborError::message("CutExtend stream_id is present iff chain_kind is content"));
+    }
+    let subject_account_id =
+        AccountId::from_bytes(cbor::fixed_bytes::<32>(d.bytes()?, "subject_account_id")?);
+    let device_fingerprint =
+        DeviceFingerprint::from_bytes(cbor::fixed_bytes::<32>(d.bytes()?, "device_fingerprint")?);
+    let new_seq = d.u64()?;
+    let new_entry_hash = cbor::fixed_bytes::<32>(d.bytes()?, "new_entry_hash")?;
+    Ok(AccountOp::CutExtend {
+        chain_kind,
+        stream_id,
+        incarnation_id,
+        subject_account_id,
+        device_fingerprint,
+        new_seq,
+        new_entry_hash,
+    })
+}
+
+fn decode_stream_own(bytes: &[u8]) -> Result<AccountOp, CborError> {
+    let mut d = decoder(bytes, 2)?;
+    let stream_id = StreamId::from_bytes(cbor::fixed_bytes::<32>(d.bytes()?, "stream_id")?);
+    let stream_spec_bytes = d.bytes()?.to_vec();
+    Ok(AccountOp::StreamOwn { stream_id, stream_spec_bytes })
+}
+
+fn decode_stream_grant(bytes: &[u8]) -> Result<AccountOp, CborError> {
+    let mut d = decoder(bytes, 3)?;
+    let stream_id = StreamId::from_bytes(cbor::fixed_bytes::<32>(d.bytes()?, "stream_id")?);
+    let grantee_account_id =
+        AccountId::from_bytes(cbor::fixed_bytes::<32>(d.bytes()?, "grantee_account_id")?);
+    let grant_role = GrantRole::from_u8(d.u8()?)?;
+    Ok(AccountOp::StreamGrant { stream_id, grantee_account_id, grant_role })
+}
+
+fn decode_stream_revoke(bytes: &[u8]) -> Result<AccountOp, CborError> {
+    let mut d = decoder(bytes, 5)?;
+    let stream_id = StreamId::from_bytes(cbor::fixed_bytes::<32>(d.bytes()?, "stream_id")?);
+    let grantee_account_id =
+        AccountId::from_bytes(cbor::fixed_bytes::<32>(d.bytes()?, "grantee_account_id")?);
+    let grant_id = cbor::fixed_bytes::<32>(d.bytes()?, "grant_id")?;
+    let device_cuts = decode_device_cuts(&mut d)?;
+    let reason = d.str()?.to_string();
+    Ok(AccountOp::StreamRevoke { stream_id, grantee_account_id, grant_id, device_cuts, reason })
+}
+
+fn decode_account_reroot(bytes: &[u8]) -> Result<AccountOp, CborError> {
+    let mut d = decoder(bytes, 2)?;
+    let successor_account_id =
+        AccountId::from_bytes(cbor::fixed_bytes::<32>(d.bytes()?, "successor_account_id")?);
+    let note = decode_opt_str(&mut d)?;
+    Ok(AccountOp::AccountReRoot { successor_account_id, note })
+}
+
+/// Open a decoder over `bytes`, requiring a canonical `arity`-element array header. Trailing bytes
+/// and non-canonicity are caught by the top-level `encode(decode) == bytes` re-encode check.
+fn decoder(bytes: &[u8], arity: u64) -> Result<Decoder<'_>, CborError> {
+    let mut d = Decoder::new(bytes);
+    cbor::expect_array(&mut d, arity)?;
+    Ok(d)
+}
+
+fn validate_keys(ed25519: &[u8; 32], x25519: &[u8; 32]) -> Result<(), CborError> {
+    DevicePublic::from_bytes(ed25519)
+        .map_err(|_| CborError::message("ed25519_pubkey is not a valid curve point"))?;
+    DeviceX25519Public::from_bytes(x25519)
+        .map_err(|_| CborError::message("x25519_pubkey is a small-order / identity point"))?;
+    Ok(())
+}
+
+fn encode_content_cuts(enc: &mut Encoder<&mut Vec<u8>>, cuts: &[ContentCut]) {
+    let mut sorted = cuts.to_vec();
+    sorted.sort_by_key(|cut| cut.stream_id.to_bytes());
+    enc.array(sorted.len() as u64).expect(INFALLIBLE);
+    for cut in &sorted {
+        enc.array(3).expect(INFALLIBLE);
+        enc.bytes(&cut.stream_id.to_bytes()).expect(INFALLIBLE);
+        enc.u64(cut.seq).expect(INFALLIBLE);
+        enc.bytes(&cut.hash).expect(INFALLIBLE);
+    }
+}
+
+fn decode_content_cuts(d: &mut Decoder<'_>) -> Result<Vec<ContentCut>, CborError> {
+    let len = cbor::expect_definite_len(d)?;
+    if len > CONTENT_CUTS_MAX as u64 {
+        return Err(CborError::message("content_cuts exceeds the §18a bound"));
+    }
+    let mut cuts = Vec::with_capacity(len as usize);
+    let mut prev: Option<[u8; 32]> = None;
+    for _ in 0..len {
+        cbor::expect_array(d, 3)?;
+        let stream_bytes = cbor::fixed_bytes::<32>(d.bytes()?, "content_cut stream_id")?;
+        // Strictly ascending by stream_id ⇒ sorted AND unique in one check.
+        if prev.is_some_and(|p| stream_bytes <= p) {
+            return Err(CborError::message("content_cuts not sorted-unique by stream_id"));
+        }
+        prev = Some(stream_bytes);
+        let seq = d.u64()?;
+        let hash = cbor::fixed_bytes::<32>(d.bytes()?, "content_cut hash")?;
+        cuts.push(ContentCut { stream_id: StreamId::from_bytes(stream_bytes), seq, hash });
+    }
+    Ok(cuts)
+}
+
+fn encode_device_cuts(enc: &mut Encoder<&mut Vec<u8>>, cuts: &[DeviceCut]) {
+    let mut sorted = cuts.to_vec();
+    sorted.sort_by_key(|cut| cut.device_fingerprint.to_bytes());
+    enc.array(sorted.len() as u64).expect(INFALLIBLE);
+    for cut in &sorted {
+        enc.array(3).expect(INFALLIBLE);
+        enc.bytes(&cut.device_fingerprint.to_bytes()).expect(INFALLIBLE);
+        enc.u64(cut.seq).expect(INFALLIBLE);
+        enc.bytes(&cut.hash).expect(INFALLIBLE);
+    }
+}
+
+fn decode_device_cuts(d: &mut Decoder<'_>) -> Result<Vec<DeviceCut>, CborError> {
+    let len = cbor::expect_definite_len(d)?;
+    if len > DEVICE_CUTS_MAX as u64 {
+        return Err(CborError::message("device_cuts exceeds the §18a bound"));
+    }
+    let mut cuts = Vec::with_capacity(len as usize);
+    let mut prev: Option<[u8; 32]> = None;
+    for _ in 0..len {
+        cbor::expect_array(d, 3)?;
+        let fp_bytes = cbor::fixed_bytes::<32>(d.bytes()?, "device_cut fingerprint")?;
+        if prev.is_some_and(|p| fp_bytes <= p) {
+            return Err(CborError::message("device_cuts not sorted-unique by device_fingerprint"));
+        }
+        prev = Some(fp_bytes);
+        let seq = d.u64()?;
+        let hash = cbor::fixed_bytes::<32>(d.bytes()?, "device_cut hash")?;
+        cuts.push(DeviceCut {
+            device_fingerprint: DeviceFingerprint::from_bytes(fp_bytes),
+            seq,
+            hash,
+        });
+    }
+    Ok(cuts)
+}
+
+/// `Some(text)` → a CBOR text string; `None` → CBOR `null`.
+fn encode_opt_str(enc: &mut Encoder<&mut Vec<u8>>, text: Option<&str>) {
+    match text {
+        Some(text) => {
+            enc.str(text).expect(INFALLIBLE);
+        },
+        None => {
+            enc.null().expect(INFALLIBLE);
+        },
+    }
+}
+
+fn decode_opt_str(d: &mut Decoder<'_>) -> Result<Option<String>, CborError> {
+    if d.datatype()? == Type::Null {
+        d.null()?;
+        Ok(None)
+    } else {
+        Ok(Some(d.str()?.to_string()))
+    }
+}
+
+/// `Some(b32)` → a 32-byte bstr; `None` → CBOR `null`.
+fn encode_opt_b32(enc: &mut Encoder<&mut Vec<u8>>, value: Option<[u8; 32]>) {
+    match value {
+        Some(value) => {
+            enc.bytes(&value).expect(INFALLIBLE);
+        },
+        None => {
+            enc.null().expect(INFALLIBLE);
+        },
+    }
+}
+
+fn decode_opt_b32(d: &mut Decoder<'_>, field: &str) -> Result<Option<[u8; 32]>, CborError> {
+    if d.datatype()? == Type::Null {
+        d.null()?;
+        Ok(None)
+    } else {
+        Ok(Some(cbor::fixed_bytes::<32>(d.bytes()?, field)?))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::oplog::device::{DeviceSecret, DeviceX25519Secret};
+
+    fn hex(bytes: &[u8]) -> String {
+        bytes.iter().map(|byte| format!("{byte:02x}")).collect()
+    }
+
+    fn ed25519() -> [u8; 32] {
+        DeviceSecret::from_seed(&[7u8; 32]).public().to_bytes()
+    }
+
+    fn x25519() -> [u8; 32] {
+        DeviceX25519Secret::from_seed(&[7u8; 32]).public().to_bytes()
+    }
+
+    fn founder_fp() -> DeviceFingerprint {
+        DeviceSecret::from_seed(&[7u8; 32]).public().fingerprint()
+    }
+
+    fn account(byte: u8) -> AccountId {
+        AccountId::from_bytes([byte; 32])
+    }
+
+    fn stream(byte: u8) -> StreamId {
+        StreamId::from_bytes([byte; 32])
+    }
+
+    /// One representative op per variant, deterministic and distinctive.
+    fn sample(entry_type: u32) -> AccountOp {
+        match entry_type {
+            entry_type::ACCOUNT_GENESIS => AccountOp::AccountGenesis {
+                ed25519_pubkey: ed25519(),
+                x25519_pubkey: x25519(),
+                nonce16: [0xcc; 16],
+                created_at_ms: 1_700_000_000_000,
+                label: None,
+            },
+            entry_type::DEVICE_ADD => AccountOp::DeviceAdd {
+                device_fingerprint: founder_fp(),
+                ed25519_pubkey: ed25519(),
+                x25519_pubkey: x25519(),
+                role: DeviceRole::Owner,
+                label: Some("laptop".to_string()),
+            },
+            entry_type::DEVICE_REMOVE => AccountOp::DeviceRemove {
+                device_fingerprint: DeviceFingerprint::from_bytes([0xbb; 32]),
+                control_cut: Cut::At { seq: 3, hash: [0x11; 32] },
+                secrets_cut: Cut::Empty,
+                content_cuts: vec![ContentCut {
+                    stream_id: stream(0x33),
+                    seq: 7,
+                    hash: [0x44; 32],
+                }],
+                reason: "left".to_string(),
+            },
+            entry_type::OWNER_PROMOTE => AccountOp::OwnerPromote {
+                device_fingerprint: DeviceFingerprint::from_bytes([0xbb; 32]),
+            },
+            entry_type::OWNER_DEMOTE => AccountOp::OwnerDemote {
+                device_fingerprint: DeviceFingerprint::from_bytes([0xbb; 32]),
+                owner_id: [0x55; 32],
+                control_cut: Cut::At { seq: 2, hash: [0x66; 32] },
+                secrets_cut: Cut::Empty,
+                reason: "demoted".to_string(),
+            },
+            entry_type::CUT_EXTEND => AccountOp::CutExtend {
+                chain_kind: ChainKind::Ctrl,
+                stream_id: None,
+                incarnation_id: Some([0x77; 32]),
+                subject_account_id: account(0xaa),
+                device_fingerprint: DeviceFingerprint::from_bytes([0xbb; 32]),
+                new_seq: 9,
+                new_entry_hash: [0x88; 32],
+            },
+            entry_type::STREAM_OWN => AccountOp::StreamOwn {
+                stream_id: stream(0x33),
+                stream_spec_bytes: vec![0x85, 0x01, 0x02],
+            },
+            entry_type::STREAM_GRANT => AccountOp::StreamGrant {
+                stream_id: stream(0x33),
+                grantee_account_id: account(0x99),
+                grant_role: GrantRole::Writer,
+            },
+            entry_type::STREAM_REVOKE => AccountOp::StreamRevoke {
+                stream_id: stream(0x33),
+                grantee_account_id: account(0x99),
+                grant_id: [0xaa; 32],
+                device_cuts: vec![DeviceCut {
+                    device_fingerprint: DeviceFingerprint::from_bytes([0xbb; 32]),
+                    seq: 41,
+                    hash: [0xcc; 32],
+                }],
+                reason: "revoked".to_string(),
+            },
+            entry_type::ACCOUNT_REROOT => AccountOp::AccountReRoot {
+                successor_account_id: account(0xdd),
+                note: Some("compromised".to_string()),
+            },
+            other => panic!("no sample for entry_type {other}"),
+        }
+    }
+
+    fn round_trip(op: &AccountOp) {
+        let bytes = encode(op);
+        assert_eq!(decode(entry_type_of(op), &bytes).unwrap(), DecodedAccountOp::Known(op.clone()));
+    }
+
+    #[test]
+    fn every_op_round_trips_and_re_encodes_canonically() {
+        for et in 0..=9u32 {
+            round_trip(&sample(et));
+        }
+    }
+
+    #[test]
+    fn golden_account_genesis() {
+        assert_eq!(hex(&encode(&sample(entry_type::ACCOUNT_GENESIS))), "855820ea4a6c63e29c520abef5507b132ec5f9954776aebebe7b92421eea691446d22c582013be4feaeaf204c7fd3358fc9c00721881d174278128227ec674f37f7fe97b6d50cccccccccccccccccccccccccccccccc1b0000018bcfe56800f6");
+    }
+
+    #[test]
+    fn golden_device_add() {
+        assert_eq!(hex(&encode(&sample(entry_type::DEVICE_ADD))), "855820fe812c12f3ab4ce6ac5db69ac352f906cb1b11ef43fb33e252ef7ff5522638895820ea4a6c63e29c520abef5507b132ec5f9954776aebebe7b92421eea691446d22c582013be4feaeaf204c7fd3358fc9c00721881d174278128227ec674f37f7fe97b6d02666c6170746f70");
+    }
+
+    #[test]
+    fn golden_device_remove() {
+        assert_eq!(hex(&encode(&sample(entry_type::DEVICE_REMOVE))), "855820bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb820358201111111111111111111111111111111111111111111111111111111111111111f68183582033333333333333333333333333333333333333333333333333333333333333330758204444444444444444444444444444444444444444444444444444444444444444646c656674");
+    }
+
+    #[test]
+    fn golden_owner_promote() {
+        assert_eq!(
+            hex(&encode(&sample(entry_type::OWNER_PROMOTE))),
+            "815820bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        );
+    }
+
+    #[test]
+    fn golden_owner_demote() {
+        assert_eq!(hex(&encode(&sample(entry_type::OWNER_DEMOTE))), "855820bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb58205555555555555555555555555555555555555555555555555555555555555555820258206666666666666666666666666666666666666666666666666666666666666666f66764656d6f746564");
+    }
+
+    #[test]
+    fn golden_cut_extend() {
+        assert_eq!(hex(&encode(&sample(entry_type::CUT_EXTEND))), "8700f6582077777777777777777777777777777777777777777777777777777777777777775820aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa5820bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb0958208888888888888888888888888888888888888888888888888888888888888888");
+    }
+
+    #[test]
+    fn golden_stream_own() {
+        assert_eq!(
+            hex(&encode(&sample(entry_type::STREAM_OWN))),
+            "825820333333333333333333333333333333333333333333333333333333333333333343850102"
+        );
+    }
+
+    #[test]
+    fn golden_stream_grant() {
+        assert_eq!(hex(&encode(&sample(entry_type::STREAM_GRANT))), "83582033333333333333333333333333333333333333333333333333333333333333335820999999999999999999999999999999999999999999999999999999999999999902");
+    }
+
+    #[test]
+    fn golden_stream_revoke() {
+        assert_eq!(hex(&encode(&sample(entry_type::STREAM_REVOKE))), "8558203333333333333333333333333333333333333333333333333333333333333333582099999999999999999999999999999999999999999999999999999999999999995820aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa81835820bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb18295820cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc677265766f6b6564");
+    }
+
+    #[test]
+    fn golden_account_reroot() {
+        assert_eq!(hex(&encode(&sample(entry_type::ACCOUNT_REROOT))), "825820dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd6b636f6d70726f6d69736564");
+    }
+
+    #[test]
+    fn unknown_entry_type_is_retained_not_rejected() {
+        let bytes = vec![0x81, 0x00];
+        let decoded = decode(999, &bytes).unwrap();
+        assert_eq!(decoded, DecodedAccountOp::Unknown { entry_type: 999, bytes });
+    }
+
+    #[test]
+    fn closed_tokens_reject_unknown_values() {
+        // role 3, grant_role 9, chain_kind 5 are all rejected.
+        let mut buf = Vec::new();
+        {
+            let mut enc = Encoder::new(&mut buf);
+            enc.array(1).unwrap();
+            enc.bytes(&[0xbb; 32]).unwrap();
+        }
+        // OwnerPromote decodes fine (control) — sanity that the fixture wire is valid shape.
+        assert!(decode(entry_type::OWNER_PROMOTE, &buf).is_ok());
+
+        let mut bad_role = Vec::new();
+        {
+            let mut enc = Encoder::new(&mut bad_role);
+            enc.array(5).unwrap();
+            enc.bytes(&founder_fp().to_bytes()).unwrap();
+            enc.bytes(&ed25519()).unwrap();
+            enc.bytes(&x25519()).unwrap();
+            enc.u8(3).unwrap();
+            enc.null().unwrap();
+        }
+        assert!(decode(entry_type::DEVICE_ADD, &bad_role).is_err(), "role 3 is rejected");
+    }
+
+    #[test]
+    fn device_add_rejects_a_fingerprint_that_is_not_sha256_of_the_key() {
+        let mut buf = Vec::new();
+        {
+            let mut enc = Encoder::new(&mut buf);
+            enc.array(5).unwrap();
+            enc.bytes(&[0x00; 32]).unwrap(); // wrong fingerprint
+            enc.bytes(&ed25519()).unwrap();
+            enc.bytes(&x25519()).unwrap();
+            enc.u8(2).unwrap();
+            enc.null().unwrap();
+        }
+        assert!(
+            decode(entry_type::DEVICE_ADD, &buf).is_err(),
+            "fingerprint must be sha256(ed25519)"
+        );
+    }
+
+    #[test]
+    fn cut_extend_stream_id_kind_coupling_is_enforced() {
+        // Content kind (2) WITHOUT a stream_id is rejected.
+        let mut buf = Vec::new();
+        {
+            let mut enc = Encoder::new(&mut buf);
+            enc.array(7).unwrap();
+            enc.u8(2).unwrap(); // content
+            enc.null().unwrap(); // stream_id absent — illegal for content
+            enc.null().unwrap();
+            enc.bytes(&[0xaa; 32]).unwrap();
+            enc.bytes(&[0xbb; 32]).unwrap();
+            enc.u64(1).unwrap();
+            enc.bytes(&[0x88; 32]).unwrap();
+        }
+        assert!(decode(entry_type::CUT_EXTEND, &buf).is_err(), "content cut needs a stream_id");
+    }
+
+    #[test]
+    fn unsorted_device_cuts_are_rejected() {
+        // Two device_cuts out of ascending order — a re-encode would reorder, so decode rejects.
+        let mut buf = Vec::new();
+        {
+            let mut enc = Encoder::new(&mut buf);
+            enc.array(5).unwrap();
+            enc.bytes(&[0x33; 32]).unwrap();
+            enc.bytes(&[0x99; 32]).unwrap();
+            enc.bytes(&[0xaa; 32]).unwrap();
+            enc.array(2).unwrap();
+            enc.array(3).unwrap();
+            enc.bytes(&[0xff; 32]).unwrap(); // higher fp first — out of order
+            enc.u64(1).unwrap();
+            enc.bytes(&[0x00; 32]).unwrap();
+            enc.array(3).unwrap();
+            enc.bytes(&[0x11; 32]).unwrap();
+            enc.u64(2).unwrap();
+            enc.bytes(&[0x00; 32]).unwrap();
+            enc.str("r").unwrap();
+        }
+        assert!(decode(entry_type::STREAM_REVOKE, &buf).is_err(), "unsorted device_cuts rejected");
+    }
+}

--- a/crates/rag-rat-core/src/oplog/account/ops.rs
+++ b/crates/rag-rat-core/src/oplog/account/ops.rs
@@ -29,7 +29,9 @@ use crate::oplog::stream::StreamId;
 const INFALLIBLE: &str = "encoding CBOR to a Vec is infallible";
 
 /// The frozen `entry_type` tag set (header part 7). A tag is a wire constant — a renumber is a wire
-/// bump. Values 10.. are reserved (`PublicStreamConfig`, `ModerationOp` — C3/E).
+/// bump. Deferred control ops land ADDITIVELY at 10+ (`StandoffResolve` §12, `PublicStreamConfig`,
+/// `ModerationOp` — C3/E). NOTE: §10 lists `StandoffResolve` before `AccountReRoot`, but
+/// `AccountReRoot` is frozen at 9 here, so `StandoffResolve` takes a 10+ slot, never 9.
 pub(super) mod entry_type {
     pub(in crate::oplog::account) const ACCOUNT_GENESIS: u32 = 0;
     pub(in crate::oplog::account) const DEVICE_ADD: u32 = 1;
@@ -361,7 +363,16 @@ pub(super) fn decode(entry_type: u32, bytes: &[u8]) -> Result<DecodedAccountOp, 
         entry_type::STREAM_GRANT => decode_stream_grant(bytes)?,
         entry_type::STREAM_REVOKE => decode_stream_revoke(bytes)?,
         entry_type::ACCOUNT_REROOT => decode_account_reroot(bytes)?,
-        other => return Ok(DecodedAccountOp::Unknown { entry_type: other, bytes: bytes.to_vec() }),
+        other => {
+            // A forward-version op is RETAINED opaque (we can't re-encode it), but it must STILL be
+            // exactly one canonical CBOR item — otherwise a future binary that learns this
+            // entry_type would run the `encode(decode) == bytes` check below and REJECT an entry an
+            // older peer accepted + chained, splitting consensus on a signed log. The envelope
+            // validates the payload only as an opaque bstr (it never recurses into it), so this is
+            // the ONLY place the payload interior is checked. (Mirrors `super::super::op::decode`.)
+            cbor::require_canonical_cbor(bytes)?;
+            return Ok(DecodedAccountOp::Unknown { entry_type: other, bytes: bytes.to_vec() });
+        },
     };
     // Canonicity guarantee for a KNOWN op: the decoded value must re-encode to the exact wire (this
     // rejects non-minimal ints, unsorted cut arrays, trailing bytes, etc. in one check).
@@ -801,6 +812,33 @@ mod tests {
         let bytes = vec![0x81, 0x00];
         let decoded = decode(999, &bytes).unwrap();
         assert_eq!(decoded, DecodedAccountOp::Unknown { entry_type: 999, bytes });
+    }
+
+    #[test]
+    fn unknown_entry_type_with_a_non_canonical_payload_is_rejected() {
+        // A forward op is retained opaque, but its payload must STILL be canonical — else a future
+        // binary that learns the type would reject (via encode(decode)==bytes) an entry an older
+        // peer accepted + chained, splitting consensus on a signed log.
+        let non_minimal_uint = vec![0x81, 0x18, 0x05]; // [uint 5] with a non-minimal 1-byte header
+        assert!(decode(999, &non_minimal_uint).is_err(), "non-canonical unknown payload rejected");
+        let trailing = vec![0x81, 0x00, 0xff]; // a valid item + a trailing byte
+        assert!(decode(999, &trailing).is_err(), "trailing bytes after an unknown op rejected");
+    }
+
+    #[test]
+    fn entry_type_tag_set_is_frozen() {
+        // The tags live in the envelope header (part 7), so the op goldens don't pin them — pin
+        // them here. A renumber is a wire bump.
+        assert_eq!(entry_type::ACCOUNT_GENESIS, 0);
+        assert_eq!(entry_type::DEVICE_ADD, 1);
+        assert_eq!(entry_type::DEVICE_REMOVE, 2);
+        assert_eq!(entry_type::OWNER_PROMOTE, 3);
+        assert_eq!(entry_type::OWNER_DEMOTE, 4);
+        assert_eq!(entry_type::CUT_EXTEND, 5);
+        assert_eq!(entry_type::STREAM_OWN, 6);
+        assert_eq!(entry_type::STREAM_GRANT, 7);
+        assert_eq!(entry_type::STREAM_REVOKE, 8);
+        assert_eq!(entry_type::ACCOUNT_REROOT, 9);
     }
 
     #[test]

--- a/crates/rag-rat-core/src/oplog/account/ops.rs
+++ b/crates/rag-rat-core/src/oplog/account/ops.rs
@@ -525,6 +525,11 @@ fn validate_keys(ed25519: &[u8; 32], x25519: &[u8; 32]) -> Result<(), CborError>
 fn encode_content_cuts(enc: &mut Encoder<&mut Vec<u8>>, cuts: &[ContentCut]) {
     let mut sorted = cuts.to_vec();
     sorted.sort_by_key(|cut| cut.stream_id.to_bytes());
+    // Collapse EXACT-duplicate cuts (stable sort keeps them adjacent) so encode never emits a
+    // payload the sorted-unique decoder / peers would reject. Two DIFFERENT cuts for one
+    // stream_id remain a caller error the decoder rejects — the authoring path must supply one
+    // cut per stream.
+    sorted.dedup();
     enc.array(sorted.len() as u64).expect(INFALLIBLE);
     for cut in &sorted {
         enc.array(3).expect(INFALLIBLE);
@@ -559,6 +564,9 @@ fn decode_content_cuts(d: &mut Decoder<'_>) -> Result<Vec<ContentCut>, CborError
 fn encode_device_cuts(enc: &mut Encoder<&mut Vec<u8>>, cuts: &[DeviceCut]) {
     let mut sorted = cuts.to_vec();
     sorted.sort_by_key(|cut| cut.device_fingerprint.to_bytes());
+    // Collapse EXACT-duplicate cuts (see `encode_content_cuts`) so encode output always
+    // round-trips.
+    sorted.dedup();
     enc.array(sorted.len() as u64).expect(INFALLIBLE);
     for cut in &sorted {
         enc.array(3).expect(INFALLIBLE);
@@ -924,5 +932,37 @@ mod tests {
             enc.str("r").unwrap();
         }
         assert!(decode(entry_type::STREAM_REVOKE, &buf).is_err(), "unsorted device_cuts rejected");
+    }
+
+    #[test]
+    fn exact_duplicate_cuts_are_collapsed_on_encode() {
+        // A caller supplying the same cut twice must still produce a payload the sorted-unique
+        // decoder accepts — encode collapses exact duplicates rather than emitting a dup key that
+        // decode (and peers) would reject. (encode_content_cuts shares the codepath.)
+        let cut = DeviceCut {
+            device_fingerprint: DeviceFingerprint::from_bytes([0xbb; 32]),
+            seq: 41,
+            hash: [0xcc; 32],
+        };
+        let doubled = AccountOp::StreamRevoke {
+            stream_id: stream(0x33),
+            grantee_account_id: account(0x99),
+            grant_id: [0xaa; 32],
+            device_cuts: vec![cut.clone(), cut.clone()],
+            reason: "revoked".to_string(),
+        };
+        let single = AccountOp::StreamRevoke {
+            stream_id: stream(0x33),
+            grantee_account_id: account(0x99),
+            grant_id: [0xaa; 32],
+            device_cuts: vec![cut],
+            reason: "revoked".to_string(),
+        };
+        // The duplicate encodes to the same bytes as the single, and round-trips to the single.
+        assert_eq!(encode(&doubled), encode(&single), "exact-duplicate cuts collapse on encode");
+        assert_eq!(
+            decode(entry_type::STREAM_REVOKE, &encode(&doubled)).unwrap(),
+            DecodedAccountOp::Known(single),
+        );
     }
 }

--- a/crates/rag-rat-core/src/oplog/account/ops.rs
+++ b/crates/rag-rat-core/src/oplog/account/ops.rs
@@ -439,6 +439,12 @@ pub(super) fn decode(entry_type: u32, bytes: &[u8]) -> Result<DecodedAccountOp, 
             // validates the payload only as an opaque bstr (it never recurses into it), so this is
             // the ONLY place the payload interior is checked. (Mirrors `super::super::op::decode`.)
             cbor::require_canonical_cbor(bytes)?;
+            // Every account op is a fixed-length CBOR ARRAY (every known decoder starts with an
+            // array header). A future binary that learns this entry_type would reject a
+            // non-array payload on shape, so require the array here too — else an old
+            // peer accepts bytes a newer peer cannot fold, splitting consensus on a
+            // signed log.
+            cbor::expect_definite_len(&mut Decoder::new(bytes))?;
             return Ok(DecodedAccountOp::Unknown { entry_type: other, bytes: bytes.to_vec() });
         },
     };
@@ -921,6 +927,10 @@ mod tests {
         assert!(decode(999, &non_minimal_uint).is_err(), "non-canonical unknown payload rejected");
         let trailing = vec![0x81, 0x00, 0xff]; // a valid item + a trailing byte
         assert!(decode(999, &trailing).is_err(), "trailing bytes after an unknown op rejected");
+        // A canonical NON-array payload (a bare uint) is rejected: every account op is an array, so
+        // a future binary that learns this entry_type would reject it on shape.
+        assert!(decode(999, &[0x00]).is_err(), "a non-array unknown payload is rejected");
+        assert!(decode(999, &[0xa0]).is_err(), "an empty map unknown payload is rejected");
     }
 
     #[test]

--- a/crates/rag-rat-core/src/oplog/account/ops.rs
+++ b/crates/rag-rat-core/src/oplog/account/ops.rs
@@ -230,7 +230,75 @@ pub(super) fn entry_type_of(op: &AccountOp) -> u32 {
 
 /// Encode an op to its canonical-CBOR payload (§10). Sorted cut arrays are emitted in binary-id
 /// order (the decoder rejects an unsorted wire, so `encode(decode) == bytes`).
-pub(super) fn encode(op: &AccountOp) -> Vec<u8> {
+pub(super) fn encode(op: &AccountOp) -> Result<Vec<u8>, CborError> {
+    Ok(encode_canonical(&canonicalize(op)?))
+}
+
+/// Validate + canonicalize an op so its encoding ALWAYS round-trips through [`decode`] — the
+/// authoring path must never sign a payload the sorted-unique / bounded / self-consistent decoder
+/// (and peers) would reject. Derives the `DeviceAdd` fingerprint from its own key, rejects invalid
+/// public keys, sorts + dedups + reject-conflicting + bound-checks the cut arrays, and enforces the
+/// `CutExtend` kind ⇔ stream_id coupling. Everything decode enforces at the op level is enforced
+/// here too, so `encode` cannot emit dead bytes.
+fn canonicalize(op: &AccountOp) -> Result<AccountOp, CborError> {
+    Ok(match op {
+        AccountOp::AccountGenesis { ed25519_pubkey, x25519_pubkey, .. } => {
+            validate_keys(ed25519_pubkey, x25519_pubkey)?;
+            op.clone()
+        },
+        AccountOp::DeviceAdd { ed25519_pubkey, x25519_pubkey, role, label, .. } => {
+            validate_keys(ed25519_pubkey, x25519_pubkey)?;
+            AccountOp::DeviceAdd {
+                // The fingerprint is DERIVED data — sha256 of the added device's own ed25519 key. A
+                // caller-supplied value is ignored, so a stale/placeholder fp can never be signed.
+                device_fingerprint: DeviceFingerprint::from_bytes(cbor::sha256(ed25519_pubkey)),
+                ed25519_pubkey: *ed25519_pubkey,
+                x25519_pubkey: *x25519_pubkey,
+                role: *role,
+                label: label.clone(),
+            }
+        },
+        AccountOp::DeviceRemove {
+            device_fingerprint,
+            control_cut,
+            secrets_cut,
+            content_cuts,
+            reason,
+        } => AccountOp::DeviceRemove {
+            device_fingerprint: *device_fingerprint,
+            control_cut: control_cut.clone(),
+            secrets_cut: secrets_cut.clone(),
+            content_cuts: canonical_content_cuts(content_cuts)?,
+            reason: reason.clone(),
+        },
+        AccountOp::StreamRevoke {
+            stream_id,
+            grantee_account_id,
+            grant_id,
+            device_cuts,
+            reason,
+        } => AccountOp::StreamRevoke {
+            stream_id: *stream_id,
+            grantee_account_id: *grantee_account_id,
+            grant_id: *grant_id,
+            device_cuts: canonical_device_cuts(device_cuts)?,
+            reason: reason.clone(),
+        },
+        AccountOp::CutExtend { chain_kind, stream_id, .. } => {
+            if (*chain_kind == ChainKind::Content) != stream_id.is_some() {
+                return Err(CborError::message(
+                    "CutExtend stream_id is present iff chain_kind is content",
+                ));
+            }
+            op.clone()
+        },
+        _ => op.clone(),
+    })
+}
+
+/// Serialize an ALREADY-canonical op (see [`canonicalize`]) to CBOR. Infallible — the cut arrays
+/// are pre-sorted-unique and every invariant has been checked, so the writers only emit bytes.
+fn encode_canonical(op: &AccountOp) -> Vec<u8> {
     let mut buf = Vec::with_capacity(128);
     {
         let mut enc = Encoder::new(&mut buf);
@@ -274,7 +342,7 @@ pub(super) fn encode(op: &AccountOp) -> Vec<u8> {
                 enc.bytes(&device_fingerprint.to_bytes()).expect(INFALLIBLE);
                 control_cut.encode_into(&mut enc);
                 secrets_cut.encode_into(&mut enc);
-                encode_content_cuts(&mut enc, content_cuts);
+                write_content_cuts(&mut enc, content_cuts);
                 enc.str(reason).expect(INFALLIBLE);
             },
             AccountOp::OwnerPromote { device_fingerprint } => {
@@ -335,7 +403,7 @@ pub(super) fn encode(op: &AccountOp) -> Vec<u8> {
                 enc.bytes(&stream_id.to_bytes()).expect(INFALLIBLE);
                 enc.bytes(&grantee_account_id.to_bytes()).expect(INFALLIBLE);
                 enc.bytes(grant_id).expect(INFALLIBLE);
-                encode_device_cuts(&mut enc, device_cuts);
+                write_device_cuts(&mut enc, device_cuts);
                 enc.str(reason).expect(INFALLIBLE);
             },
             AccountOp::AccountReRoot { successor_account_id, note } => {
@@ -375,8 +443,9 @@ pub(super) fn decode(entry_type: u32, bytes: &[u8]) -> Result<DecodedAccountOp, 
         },
     };
     // Canonicity guarantee for a KNOWN op: the decoded value must re-encode to the exact wire (this
-    // rejects non-minimal ints, unsorted cut arrays, trailing bytes, etc. in one check).
-    if encode(&op) != bytes {
+    // rejects non-minimal ints, unsorted cut arrays, trailing bytes, etc. in one check). A decoded
+    // op already satisfies every invariant `canonicalize` checks, so the re-encode cannot fail.
+    if encode(&op)? != bytes {
         return Err(CborError::message("op payload is not canonical (re-encode differs)"));
     }
     Ok(DecodedAccountOp::Known(op))
@@ -522,16 +591,26 @@ fn validate_keys(ed25519: &[u8; 32], x25519: &[u8; 32]) -> Result<(), CborError>
     Ok(())
 }
 
-fn encode_content_cuts(enc: &mut Encoder<&mut Vec<u8>>, cuts: &[ContentCut]) {
+/// Validate + canonicalize a content-cut array so it matches exactly what the sorted-unique decoder
+/// accepts: sort by stream_id, drop EXACT duplicates, reject two CONFLICTING cuts for one stream (a
+/// silent drop would lose a revocation, so this errors), and enforce the §18a bound.
+fn canonical_content_cuts(cuts: &[ContentCut]) -> Result<Vec<ContentCut>, CborError> {
     let mut sorted = cuts.to_vec();
     sorted.sort_by_key(|cut| cut.stream_id.to_bytes());
-    // Collapse EXACT-duplicate cuts (stable sort keeps them adjacent) so encode never emits a
-    // payload the sorted-unique decoder / peers would reject. Two DIFFERENT cuts for one
-    // stream_id remain a caller error the decoder rejects — the authoring path must supply one
-    // cut per stream.
     sorted.dedup();
-    enc.array(sorted.len() as u64).expect(INFALLIBLE);
-    for cut in &sorted {
+    if sorted.windows(2).any(|pair| pair[0].stream_id == pair[1].stream_id) {
+        return Err(CborError::message("content_cuts has conflicting entries for one stream_id"));
+    }
+    if sorted.len() > CONTENT_CUTS_MAX {
+        return Err(CborError::message("content_cuts exceeds the §18a bound"));
+    }
+    Ok(sorted)
+}
+
+/// Emit an ALREADY-canonical content-cut array (see [`canonical_content_cuts`]).
+fn write_content_cuts(enc: &mut Encoder<&mut Vec<u8>>, cuts: &[ContentCut]) {
+    enc.array(cuts.len() as u64).expect(INFALLIBLE);
+    for cut in cuts {
         enc.array(3).expect(INFALLIBLE);
         enc.bytes(&cut.stream_id.to_bytes()).expect(INFALLIBLE);
         enc.u64(cut.seq).expect(INFALLIBLE);
@@ -561,14 +640,25 @@ fn decode_content_cuts(d: &mut Decoder<'_>) -> Result<Vec<ContentCut>, CborError
     Ok(cuts)
 }
 
-fn encode_device_cuts(enc: &mut Encoder<&mut Vec<u8>>, cuts: &[DeviceCut]) {
+/// Validate + canonicalize a device-cut array (see [`canonical_content_cuts`]) — sort by
+/// device_fingerprint, drop exact duplicates, reject conflicting entries, enforce the §18a bound.
+fn canonical_device_cuts(cuts: &[DeviceCut]) -> Result<Vec<DeviceCut>, CborError> {
     let mut sorted = cuts.to_vec();
     sorted.sort_by_key(|cut| cut.device_fingerprint.to_bytes());
-    // Collapse EXACT-duplicate cuts (see `encode_content_cuts`) so encode output always
-    // round-trips.
     sorted.dedup();
-    enc.array(sorted.len() as u64).expect(INFALLIBLE);
-    for cut in &sorted {
+    if sorted.windows(2).any(|pair| pair[0].device_fingerprint == pair[1].device_fingerprint) {
+        return Err(CborError::message("device_cuts has conflicting entries for one device"));
+    }
+    if sorted.len() > DEVICE_CUTS_MAX {
+        return Err(CborError::message("device_cuts exceeds the §18a bound"));
+    }
+    Ok(sorted)
+}
+
+/// Emit an ALREADY-canonical device-cut array (see [`canonical_device_cuts`]).
+fn write_device_cuts(enc: &mut Encoder<&mut Vec<u8>>, cuts: &[DeviceCut]) {
+    enc.array(cuts.len() as u64).expect(INFALLIBLE);
+    for cut in cuts {
         enc.array(3).expect(INFALLIBLE);
         enc.bytes(&cut.device_fingerprint.to_bytes()).expect(INFALLIBLE);
         enc.u64(cut.seq).expect(INFALLIBLE);
@@ -748,7 +838,7 @@ mod tests {
     }
 
     fn round_trip(op: &AccountOp) {
-        let bytes = encode(op);
+        let bytes = encode(op).unwrap();
         assert_eq!(decode(entry_type_of(op), &bytes).unwrap(), DecodedAccountOp::Known(op.clone()));
     }
 
@@ -761,58 +851,58 @@ mod tests {
 
     #[test]
     fn golden_account_genesis() {
-        assert_eq!(hex(&encode(&sample(entry_type::ACCOUNT_GENESIS))), "855820ea4a6c63e29c520abef5507b132ec5f9954776aebebe7b92421eea691446d22c582013be4feaeaf204c7fd3358fc9c00721881d174278128227ec674f37f7fe97b6d50cccccccccccccccccccccccccccccccc1b0000018bcfe56800f6");
+        assert_eq!(hex(&encode(&sample(entry_type::ACCOUNT_GENESIS)).unwrap()), "855820ea4a6c63e29c520abef5507b132ec5f9954776aebebe7b92421eea691446d22c582013be4feaeaf204c7fd3358fc9c00721881d174278128227ec674f37f7fe97b6d50cccccccccccccccccccccccccccccccc1b0000018bcfe56800f6");
     }
 
     #[test]
     fn golden_device_add() {
-        assert_eq!(hex(&encode(&sample(entry_type::DEVICE_ADD))), "855820fe812c12f3ab4ce6ac5db69ac352f906cb1b11ef43fb33e252ef7ff5522638895820ea4a6c63e29c520abef5507b132ec5f9954776aebebe7b92421eea691446d22c582013be4feaeaf204c7fd3358fc9c00721881d174278128227ec674f37f7fe97b6d02666c6170746f70");
+        assert_eq!(hex(&encode(&sample(entry_type::DEVICE_ADD)).unwrap()), "855820fe812c12f3ab4ce6ac5db69ac352f906cb1b11ef43fb33e252ef7ff5522638895820ea4a6c63e29c520abef5507b132ec5f9954776aebebe7b92421eea691446d22c582013be4feaeaf204c7fd3358fc9c00721881d174278128227ec674f37f7fe97b6d02666c6170746f70");
     }
 
     #[test]
     fn golden_device_remove() {
-        assert_eq!(hex(&encode(&sample(entry_type::DEVICE_REMOVE))), "855820bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb820358201111111111111111111111111111111111111111111111111111111111111111f68183582033333333333333333333333333333333333333333333333333333333333333330758204444444444444444444444444444444444444444444444444444444444444444646c656674");
+        assert_eq!(hex(&encode(&sample(entry_type::DEVICE_REMOVE)).unwrap()), "855820bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb820358201111111111111111111111111111111111111111111111111111111111111111f68183582033333333333333333333333333333333333333333333333333333333333333330758204444444444444444444444444444444444444444444444444444444444444444646c656674");
     }
 
     #[test]
     fn golden_owner_promote() {
         assert_eq!(
-            hex(&encode(&sample(entry_type::OWNER_PROMOTE))),
+            hex(&encode(&sample(entry_type::OWNER_PROMOTE)).unwrap()),
             "815820bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
         );
     }
 
     #[test]
     fn golden_owner_demote() {
-        assert_eq!(hex(&encode(&sample(entry_type::OWNER_DEMOTE))), "855820bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb58205555555555555555555555555555555555555555555555555555555555555555820258206666666666666666666666666666666666666666666666666666666666666666f66764656d6f746564");
+        assert_eq!(hex(&encode(&sample(entry_type::OWNER_DEMOTE)).unwrap()), "855820bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb58205555555555555555555555555555555555555555555555555555555555555555820258206666666666666666666666666666666666666666666666666666666666666666f66764656d6f746564");
     }
 
     #[test]
     fn golden_cut_extend() {
-        assert_eq!(hex(&encode(&sample(entry_type::CUT_EXTEND))), "8700f6582077777777777777777777777777777777777777777777777777777777777777775820aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa5820bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb0958208888888888888888888888888888888888888888888888888888888888888888");
+        assert_eq!(hex(&encode(&sample(entry_type::CUT_EXTEND)).unwrap()), "8700f6582077777777777777777777777777777777777777777777777777777777777777775820aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa5820bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb0958208888888888888888888888888888888888888888888888888888888888888888");
     }
 
     #[test]
     fn golden_stream_own() {
         assert_eq!(
-            hex(&encode(&sample(entry_type::STREAM_OWN))),
+            hex(&encode(&sample(entry_type::STREAM_OWN)).unwrap()),
             "825820333333333333333333333333333333333333333333333333333333333333333343850102"
         );
     }
 
     #[test]
     fn golden_stream_grant() {
-        assert_eq!(hex(&encode(&sample(entry_type::STREAM_GRANT))), "83582033333333333333333333333333333333333333333333333333333333333333335820999999999999999999999999999999999999999999999999999999999999999902");
+        assert_eq!(hex(&encode(&sample(entry_type::STREAM_GRANT)).unwrap()), "83582033333333333333333333333333333333333333333333333333333333333333335820999999999999999999999999999999999999999999999999999999999999999902");
     }
 
     #[test]
     fn golden_stream_revoke() {
-        assert_eq!(hex(&encode(&sample(entry_type::STREAM_REVOKE))), "8558203333333333333333333333333333333333333333333333333333333333333333582099999999999999999999999999999999999999999999999999999999999999995820aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa81835820bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb18295820cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc677265766f6b6564");
+        assert_eq!(hex(&encode(&sample(entry_type::STREAM_REVOKE)).unwrap()), "8558203333333333333333333333333333333333333333333333333333333333333333582099999999999999999999999999999999999999999999999999999999999999995820aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa81835820bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb18295820cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc677265766f6b6564");
     }
 
     #[test]
     fn golden_account_reroot() {
-        assert_eq!(hex(&encode(&sample(entry_type::ACCOUNT_REROOT))), "825820dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd6b636f6d70726f6d69736564");
+        assert_eq!(hex(&encode(&sample(entry_type::ACCOUNT_REROOT)).unwrap()), "825820dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd6b636f6d70726f6d69736564");
     }
 
     #[test]
@@ -959,10 +1049,104 @@ mod tests {
             reason: "revoked".to_string(),
         };
         // The duplicate encodes to the same bytes as the single, and round-trips to the single.
-        assert_eq!(encode(&doubled), encode(&single), "exact-duplicate cuts collapse on encode");
         assert_eq!(
-            decode(entry_type::STREAM_REVOKE, &encode(&doubled)).unwrap(),
+            encode(&doubled).unwrap(),
+            encode(&single).unwrap(),
+            "exact-duplicate cuts collapse on encode"
+        );
+        assert_eq!(
+            decode(entry_type::STREAM_REVOKE, &encode(&doubled).unwrap()).unwrap(),
             DecodedAccountOp::Known(single),
         );
+    }
+
+    fn revoke_with(device_cuts: Vec<DeviceCut>) -> AccountOp {
+        AccountOp::StreamRevoke {
+            stream_id: stream(0x33),
+            grantee_account_id: account(0x99),
+            grant_id: [0xaa; 32],
+            device_cuts,
+            reason: "r".to_string(),
+        }
+    }
+
+    #[test]
+    fn encode_rejects_conflicting_and_over_bound_cuts() {
+        // Two DIFFERENT cuts for one device ⇒ encode errors (a silent drop would lose a
+        // revocation).
+        let conflicting = revoke_with(vec![
+            DeviceCut {
+                device_fingerprint: DeviceFingerprint::from_bytes([0xbb; 32]),
+                seq: 1,
+                hash: [0x01; 32],
+            },
+            DeviceCut {
+                device_fingerprint: DeviceFingerprint::from_bytes([0xbb; 32]),
+                seq: 2,
+                hash: [0x02; 32],
+            },
+        ]);
+        assert!(encode(&conflicting).is_err(), "conflicting device_cuts rejected at encode");
+
+        // DEVICE_CUTS_MAX + 1 DISTINCT cuts ⇒ encode errors (decode would reject them too).
+        let many: Vec<DeviceCut> = (0..=DEVICE_CUTS_MAX as u32)
+            .map(|i| {
+                let mut fp = [0u8; 32];
+                fp[..4].copy_from_slice(&i.to_be_bytes());
+                DeviceCut {
+                    device_fingerprint: DeviceFingerprint::from_bytes(fp),
+                    seq: 1,
+                    hash: [0u8; 32],
+                }
+            })
+            .collect();
+        assert!(encode(&revoke_with(many)).is_err(), "over-bound device_cuts rejected at encode");
+    }
+
+    #[test]
+    fn encode_derives_the_device_add_fingerprint_and_validates_keys() {
+        // A DeviceAdd carrying a WRONG fingerprint encodes to the same bytes as the derived-fp op,
+        // and round-trips to the derived one — a stale/placeholder fp can never be signed.
+        let wrong = AccountOp::DeviceAdd {
+            device_fingerprint: DeviceFingerprint::from_bytes([0x00; 32]),
+            ed25519_pubkey: ed25519(),
+            x25519_pubkey: x25519(),
+            role: DeviceRole::Owner,
+            label: Some("laptop".to_string()),
+        };
+        let derived = sample(entry_type::DEVICE_ADD); // fingerprint == sha256(ed25519())
+        assert_eq!(
+            encode(&wrong).unwrap(),
+            encode(&derived).unwrap(),
+            "fingerprint is derived, not trusted"
+        );
+        assert_eq!(
+            decode(entry_type::DEVICE_ADD, &encode(&wrong).unwrap()).unwrap(),
+            DecodedAccountOp::Known(derived),
+        );
+        // An identity X25519 key ⇒ encode errors (validate_keys, mirroring decode).
+        let bad_key = AccountOp::DeviceAdd {
+            device_fingerprint: founder_fp(),
+            ed25519_pubkey: ed25519(),
+            x25519_pubkey: [0u8; 32],
+            role: DeviceRole::Owner,
+            label: None,
+        };
+        assert!(encode(&bad_key).is_err(), "identity x25519 key rejected at encode");
+    }
+
+    #[test]
+    fn encode_rejects_a_cut_extend_coupling_violation() {
+        // Content kind without a stream_id ⇒ encode errors, matching the decode-side rejection.
+        let bad = AccountOp::CutExtend {
+            chain_kind: ChainKind::Content,
+            stream_id: None,
+            incarnation_id: None,
+            subject_account_id: account(0xaa),
+            device_fingerprint: DeviceFingerprint::from_bytes([0xbb; 32]),
+            new_seq: 1,
+            new_entry_hash: [0x88; 32],
+        };
+        assert!(encode(&bad).is_err(), "content CutExtend without stream_id rejected at encode");
     }
 }

--- a/crates/rag-rat-core/src/oplog/account/registers.rs
+++ b/crates/rag-rat-core/src/oplog/account/registers.rs
@@ -1,0 +1,142 @@
+//! The three revocation register families (§11) — the extend-only watermarks the fold derives from
+//! cut ops and then uses to condemn entries.
+//!
+//! Every register is a `(key, cut)`: a [`RegisterKey`] identifying WHICH chain it bounds, and a
+//! [`Cut`] giving the valid-prefix watermark. Three families, each minted by a different cut op:
+//! - **device-level** `(account, log, device)` — from `DeviceRemove`; scopes ALL entries on that
+//!   device's chain.
+//! - **owner-incarnation** `(account, log, device, owner_id)` — from `OwnerDemote`; scopes only the
+//!   entries on that chain whose `authority_ref` cites `owner_id` (the ops authored under exactly
+//!   that promotion).
+//! - **grant-level** `(stream, grantee, grant_id, device)` — from `StreamRevoke`; scopes `/3`
+//!   CONTENT entries only. C1 has no content chains, so a grant register never scopes an
+//!   account-log entry here — it is recorded for the C2 acceptance predicate to consume.
+//!
+//! Re-grant / re-promotion mints a FRESH incarnation (a new `owner_id` / `grant_id`), hence a fresh
+//! register key with no watermark — which is why a re-authorized device resumes (§11).
+
+use super::AccountId;
+use super::cut::Cut;
+use super::envelope::AccountEntryHeader;
+use crate::oplog::op::DeviceFingerprint;
+use crate::oplog::stream::StreamId;
+
+/// Which chain a register bounds (§11). The variant selects the family; the fields are the family's
+/// key.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(super) enum RegisterKey {
+    /// From `DeviceRemove` — the whole `(account, log, device)` chain.
+    Device { account: AccountId, log: u8, device: DeviceFingerprint },
+    /// From `OwnerDemote` — entries on `(account, log, device)` whose `authority_ref` cites
+    /// `owner_id`.
+    OwnerIncarnation { account: AccountId, log: u8, device: DeviceFingerprint, owner_id: [u8; 32] },
+    /// From `StreamRevoke` — `/3` content on `(stream, grantee, grant_id, device)` (C2 consumes
+    /// it).
+    Grant { stream: StreamId, grantee: AccountId, grant_id: [u8; 32], device: DeviceFingerprint },
+}
+
+/// An extend-only revocation register: a chain key + its valid-prefix cut.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct Register {
+    pub(super) key: RegisterKey,
+    pub(super) cut: Cut,
+}
+
+impl RegisterKey {
+    /// Whether this register scopes `header` — i.e. the entry lies on the chain the register
+    /// bounds. (Whether a scoped entry is CONDEMNED is a further `beyond` / off-branch test,
+    /// §11.)
+    pub(super) fn scopes(&self, header: &AccountEntryHeader) -> bool {
+        match self {
+            RegisterKey::Device { account, log, device } =>
+                header.account_id == *account
+                    && header.log_id == *log
+                    && header.device_fingerprint == *device,
+            RegisterKey::OwnerIncarnation { account, log, device, owner_id } =>
+                header.account_id == *account
+                    && header.log_id == *log
+                    && header.device_fingerprint == *device
+                    && header.authority_ref == Some(*owner_id),
+            // Grant registers bound `/3` content chains, which do not exist in C1; an account-log
+            // entry is never in a grant register's scope.
+            RegisterKey::Grant { .. } => false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A control-log header on `(account 0xaa, log 0, device 0xbb)` citing `authority_ref`.
+    fn header(
+        account: u8,
+        log: u8,
+        device: u8,
+        authority_ref: Option<[u8; 32]>,
+    ) -> AccountEntryHeader {
+        AccountEntryHeader {
+            account_id: AccountId::from_bytes([account; 32]),
+            log_id: log,
+            device_fingerprint: DeviceFingerprint::from_bytes([device; 32]),
+            seq: 4,
+            prev_hash: Some([0x01; 32]),
+            parent_ref: Some([0x02; 32]),
+            entry_type: 3,
+            op_version: 1,
+            crypto_suite: 0,
+            auth_len: 2,
+            key_id: None,
+            authority_ref,
+        }
+    }
+
+    #[test]
+    fn device_register_scopes_the_whole_chain() {
+        let key = RegisterKey::Device {
+            account: AccountId::from_bytes([0xaa; 32]),
+            log: 0,
+            device: DeviceFingerprint::from_bytes([0xbb; 32]),
+        };
+        assert!(key.scopes(&header(0xaa, 0, 0xbb, None)), "same chain, any authority_ref");
+        assert!(
+            key.scopes(&header(0xaa, 0, 0xbb, Some([0x77; 32]))),
+            "same chain, any authority_ref"
+        );
+        assert!(!key.scopes(&header(0xaa, 0, 0xcc, None)), "different device");
+        assert!(!key.scopes(&header(0xdd, 0, 0xbb, None)), "different account");
+        assert!(!key.scopes(&header(0xaa, 1, 0xbb, None)), "different log");
+    }
+
+    #[test]
+    fn owner_incarnation_register_scopes_only_citing_entries() {
+        let owner_id = [0x77; 32];
+        let key = RegisterKey::OwnerIncarnation {
+            account: AccountId::from_bytes([0xaa; 32]),
+            log: 0,
+            device: DeviceFingerprint::from_bytes([0xbb; 32]),
+            owner_id,
+        };
+        assert!(key.scopes(&header(0xaa, 0, 0xbb, Some(owner_id))), "cites this incarnation");
+        assert!(
+            !key.scopes(&header(0xaa, 0, 0xbb, Some([0x88; 32]))),
+            "cites a different incarnation"
+        );
+        assert!(!key.scopes(&header(0xaa, 0, 0xbb, None)), "cites nothing (genesis-scope)");
+        assert!(!key.scopes(&header(0xaa, 0, 0xcc, Some(owner_id))), "different device");
+    }
+
+    #[test]
+    fn grant_register_never_scopes_an_account_log_entry() {
+        let key = RegisterKey::Grant {
+            stream: StreamId::from_bytes([0x33; 32]),
+            grantee: AccountId::from_bytes([0x99; 32]),
+            grant_id: [0xaa; 32],
+            device: DeviceFingerprint::from_bytes([0xbb; 32]),
+        };
+        assert!(
+            !key.scopes(&header(0xaa, 0, 0xbb, Some([0xaa; 32]))),
+            "grant scopes content, not control"
+        );
+    }
+}

--- a/crates/rag-rat-core/src/oplog/cbor.rs
+++ b/crates/rag-rat-core/src/oplog/cbor.rs
@@ -20,6 +20,7 @@
 //! the encoding-level floor beneath that.
 
 use minicbor::decode::{Decoder, Error as CborError};
+use sha2::{Digest, Sha256};
 
 /// Validate that `bytes` is EXACTLY one canonical CBOR item (RFC 8949 §4.2 core-deterministic) with
 /// no trailing bytes: MINIMAL-length argument headers, DEFINITE lengths only, sorted + unique map
@@ -174,4 +175,32 @@ pub(super) fn expect_array(d: &mut Decoder<'_>, want: u64) -> Result<(), CborErr
 /// array (canonical CBOR is definite-length only).
 pub(super) fn expect_definite_len(d: &mut Decoder<'_>) -> Result<u64, CborError> {
     d.array()?.ok_or_else(|| CborError::message("expected a definite-length array"))
+}
+
+/// `sha256` into a fixed 32-byte array — the entry-hash / content-address primitive shared by the
+/// op-log entry envelope ([`super::entry`]) and the account layer ([`super::account`]).
+pub(super) fn sha256(bytes: &[u8]) -> [u8; 32] {
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&Sha256::digest(bytes));
+    out
+}
+
+/// Convert an opaque byte slice to a fixed `[u8; N]`, erroring with the field name on a length
+/// mismatch (a wrong-length hash / fingerprint / signature is a structural error). Shared by every
+/// signed-wire decoder in `oplog`.
+pub(super) fn fixed_bytes<const N: usize>(bytes: &[u8], field: &str) -> Result<[u8; N], CborError> {
+    <[u8; N]>::try_from(bytes)
+        .map_err(|_| CborError::message(format!("{field} must be {N} bytes, got {}", bytes.len())))
+}
+
+/// Read a leading domain string and assert it matches `want` — a wrong/absent tag is a foreign or
+/// version-bumped object an old binary must reject, never misread. Shared by every domain-tagged
+/// decoder in `oplog`.
+pub(super) fn expect_domain(d: &mut Decoder<'_>, want: &str) -> Result<(), CborError> {
+    let got = d.str()?;
+    if got == want {
+        Ok(())
+    } else {
+        Err(CborError::message(format!("unknown domain tag `{got}` (expected `{want}`)")))
+    }
 }

--- a/crates/rag-rat-core/src/oplog/device.rs
+++ b/crates/rag-rat-core/src/oplog/device.rs
@@ -18,6 +18,7 @@
 use anyhow::Context;
 use ed25519_dalek::{Signature, Signer, SigningKey, VerifyingKey};
 use sha2::{Digest, Sha256};
+use x25519_dalek::{PublicKey as X25519PublicKey, StaticSecret};
 use zeroize::Zeroizing;
 
 use super::op::DeviceFingerprint;
@@ -100,6 +101,128 @@ impl DevicePublic {
         let signature = Signature::from_bytes(sig);
         self.0.verify_strict(msg, &signature).context("ed25519 signature verification failed")
     }
+}
+
+/// A device's X25519 ENCRYPTION secret — minted BESIDE the ed25519 signing key (sync phase C, §5),
+/// and, like it, rebuilt deterministically from persisted bytes. C1 only holds, persists, and
+/// validates it; no ECDH happens until C4. Its seed is INDEPENDENT of the ed25519 seed — the
+/// signing and encryption identities never share entropy. Intentionally not `Debug` / `Clone`.
+pub(super) struct DeviceX25519Secret(StaticSecret);
+
+impl DeviceX25519Secret {
+    /// Rebuild the X25519 secret from its persisted 32-byte scalar. `StaticSecret::from` clamps, so
+    /// the round-trip through [`secret_bytes`](Self::secret_bytes) is stable — the reopen /
+    /// backfill path re-derives the SAME key. Deterministic (the backfill tests rely on it).
+    pub(super) fn from_seed(seed: &[u8; 32]) -> Self {
+        // Scrub the stack copy; `StaticSecret` zeroizes its own copy on drop (dalek `zeroize`).
+        let seed = Zeroizing::new(*seed);
+        Self(StaticSecret::from(*seed))
+    }
+
+    /// Mint a FRESH X25519 secret from OS entropy — the production keygen path, routed through
+    /// [`from_seed`](Self::from_seed) so seeding stays the one construction point. Fails only if
+    /// the OS CSPRNG is unavailable.
+    pub(super) fn generate() -> anyhow::Result<Self> {
+        let mut seed = Zeroizing::new([0u8; 32]);
+        getrandom::fill(seed.as_mut_slice())
+            .map_err(|e| anyhow::anyhow!("OS CSPRNG failed to seed an X25519 device key: {e}"))?;
+        Ok(Self::from_seed(&seed))
+    }
+
+    /// The 32-byte secret scalar, scrubbed. The persistence layer stores this so a reopened store
+    /// re-derives the same key — the only durable copy (plaintext-at-rest, D4).
+    pub(super) fn secret_bytes(&self) -> Zeroizing<[u8; 32]> {
+        Zeroizing::new(self.0.to_bytes())
+    }
+
+    /// The matching public encryption key.
+    pub(super) fn public(&self) -> DeviceX25519Public {
+        DeviceX25519Public(X25519PublicKey::from(&self.0).to_bytes())
+    }
+}
+
+/// A device's X25519 ENCRYPTION public key — a Montgomery-u coordinate. Every 32-byte string
+/// decodes to *some* u-coordinate, so unlike an ed25519 key there is no curve-point rejection;
+/// [`from_bytes`](Self::from_bytes) is where the identity + small-order points are refused instead
+/// (the C1 half of §5 — the all-zero-shared-secret check is C4).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct DeviceX25519Public([u8; 32]);
+
+impl DeviceX25519Public {
+    /// Parse a 32-byte X25519 public key, rejecting the identity and the known small-order points
+    /// (a key that would force an all-zero shared secret). X25519 ignores bit 255 of the
+    /// u-coordinate, so the comparison masks it — a `| 0x80` variant of a blocklisted point is
+    /// the same point and must not slip past.
+    pub(super) fn from_bytes(bytes: &[u8; 32]) -> anyhow::Result<Self> {
+        if is_small_order(bytes) {
+            anyhow::bail!("X25519 public key is a small-order / identity point");
+        }
+        Ok(Self(*bytes))
+    }
+
+    /// The 32-byte public key.
+    pub(super) fn to_bytes(self) -> [u8; 32] {
+        self.0
+    }
+}
+
+/// `p + delta` (`p = 2^255 - 19`) in little-endian 32-byte form, with bit 255 cleared. `delta ∈
+/// {0,1,2}` builds `p-1`, `p`, `p+1` (their byte-0 is `0xec`/`0xed`/`0xee`; the rest is the `0xff…`
+/// run ending `0x7f`). A `const fn` so the `0xff` run can't be mis-transcribed by hand.
+const fn p_offset(byte0: u8) -> [u8; 32] {
+    let mut v = [0xffu8; 32];
+    v[0] = byte0;
+    v[31] = 0x7f;
+    v
+}
+
+/// `1` (order-4 point) in little-endian 32-byte form.
+const fn low_order_one() -> [u8; 32] {
+    let mut v = [0u8; 32];
+    v[0] = 1;
+    v
+}
+
+/// The canonical X25519 small-order point blocklist (RFC 7748 §6.1 / the libsodium
+/// `crypto_scalarmult_curve25519` blacklist): the identity, the order-2/4/8 points, and the three
+/// `p-1`/`p`/`p+1` encodings. A public key equal (mod the ignored high bit) to any of these yields
+/// an all-zero shared secret and must be refused at `DeviceAdd`.
+const X25519_SMALL_ORDER_POINTS: [[u8; 32]; 7] = [
+    // 0 — the identity (order 1).
+    [0u8; 32],
+    // 1 — order 4.
+    low_order_one(),
+    // 325606250916557431795983626356110631294008115727848805560023387167927233504 — order 8.
+    [
+        0xe0, 0xeb, 0x7a, 0x7c, 0x3b, 0x41, 0xb8, 0xae, 0x16, 0x56, 0xe3, 0xfa, 0xf1, 0x9f, 0xc4,
+        0x6a, 0xda, 0x09, 0x8d, 0xeb, 0x9c, 0x32, 0xb1, 0xfd, 0x86, 0x62, 0x05, 0x16, 0x5f, 0x49,
+        0xb8, 0x00,
+    ],
+    // 39382357235489614581723060781553021112529911719440698176882885853963445705823 — order 8.
+    [
+        0x5f, 0x9c, 0x95, 0xbc, 0xa3, 0x50, 0x8c, 0x24, 0xb1, 0xd0, 0xb1, 0x55, 0x9c, 0x83, 0xef,
+        0x5b, 0x04, 0x44, 0x5c, 0xc4, 0x58, 0x1c, 0x8e, 0x86, 0xd8, 0x22, 0x4e, 0xdd, 0xd0, 0x9f,
+        0x11, 0x57,
+    ],
+    // p-1 — order 2.
+    p_offset(0xec),
+    // p — order 4 (≡ identity on the prime-order subgroup).
+    p_offset(0xed),
+    // p+1 — order 1.
+    p_offset(0xee),
+];
+
+/// Whether `bytes` encodes a small-order / identity X25519 point. Masks bit 255 (which X25519
+/// clears) before comparing, so a high-bit-set variant of a blocklisted point is still caught. A
+/// plain (non-constant-time) compare is fine: the input is a public key, not secret material.
+fn is_small_order(bytes: &[u8; 32]) -> bool {
+    let mut candidate = *bytes;
+    candidate[31] &= 0x7f;
+    X25519_SMALL_ORDER_POINTS.iter().any(|bad| {
+        let mut bad = *bad;
+        bad[31] &= 0x7f;
+        candidate == bad
+    })
 }
 
 #[cfg(test)]
@@ -207,5 +330,62 @@ mod tests {
         assert!(refused > 0, "from_bytes must reject non-curve encodings");
         let real = DeviceSecret::from_seed(&seed_a()).public().to_bytes();
         assert!(DevicePublic::from_bytes(&real).is_ok(), "a genuine pubkey must parse");
+    }
+
+    #[test]
+    fn x25519_from_seed_is_deterministic() {
+        // The same seed yields the same X25519 key; a different seed differs — the property the
+        // reopen/backfill path relies on.
+        let a1 = DeviceX25519Secret::from_seed(&seed_a());
+        let a2 = DeviceX25519Secret::from_seed(&seed_a());
+        assert_eq!(a1.public().to_bytes(), a2.public().to_bytes());
+        let b = DeviceX25519Secret::from_seed(&seed_b());
+        assert_ne!(
+            a1.public().to_bytes(),
+            b.public().to_bytes(),
+            "a different seed is a different key"
+        );
+        // The secret round-trips through its persisted bytes (the reopen path).
+        let reloaded = DeviceX25519Secret::from_seed(&a1.secret_bytes());
+        assert_eq!(
+            a1.public().to_bytes(),
+            reloaded.public().to_bytes(),
+            "secret_bytes reconstructs the key"
+        );
+    }
+
+    #[test]
+    fn x25519_generate_is_nondeterministic() {
+        // Two independent generations must not collide — the CSPRNG, not a fixed seed, is the
+        // source.
+        let a = DeviceX25519Secret::generate().expect("OS CSPRNG available");
+        let b = DeviceX25519Secret::generate().expect("OS CSPRNG available");
+        assert_ne!(a.public().to_bytes(), b.public().to_bytes(), "generate must not repeat a key");
+    }
+
+    #[test]
+    fn x25519_from_bytes_rejects_small_order_and_identity_points() {
+        // Every canonical small-order encoding (identity + order 2/4/8 + p-1/p/p+1) must be
+        // refused, INCLUDING the high-bit-set variant X25519 treats as the same point —
+        // else a peer could add a device whose encryption key forces an all-zero shared
+        // secret.
+        for bad in X25519_SMALL_ORDER_POINTS {
+            assert!(
+                DeviceX25519Public::from_bytes(&bad).is_err(),
+                "small-order point accepted: {bad:02x?}",
+            );
+            let mut high_bit = bad;
+            high_bit[31] |= 0x80;
+            assert!(
+                DeviceX25519Public::from_bytes(&high_bit).is_err(),
+                "high-bit variant of a small-order point accepted: {high_bit:02x?}",
+            );
+        }
+        // A genuine device public key parses.
+        let real = DeviceX25519Secret::from_seed(&seed_a()).public().to_bytes();
+        assert!(
+            DeviceX25519Public::from_bytes(&real).is_ok(),
+            "a genuine X25519 pubkey must parse"
+        );
     }
 }

--- a/crates/rag-rat-core/src/oplog/device.rs
+++ b/crates/rag-rat-core/src/oplog/device.rs
@@ -110,9 +110,11 @@ impl DevicePublic {
 pub(super) struct DeviceX25519Secret(StaticSecret);
 
 impl DeviceX25519Secret {
-    /// Rebuild the X25519 secret from its persisted 32-byte scalar. `StaticSecret::from` clamps, so
-    /// the round-trip through [`secret_bytes`](Self::secret_bytes) is stable — the reopen /
-    /// backfill path re-derives the SAME key. Deterministic (the backfill tests rely on it).
+    /// Rebuild the X25519 secret from its persisted 32-byte scalar. `StaticSecret::from` and
+    /// `to_bytes` are inverses — x25519-dalek 2 stores the scalar VERBATIM (clamping happens at DH
+    /// / public derivation, not construction) — so the round-trip through
+    /// [`secret_bytes`](Self::secret_bytes) re-derives the SAME key. Deterministic (the backfill
+    /// tests rely on it).
     pub(super) fn from_seed(seed: &[u8; 32]) -> Self {
         // Scrub the stack copy; `StaticSecret` zeroizes its own copy on drop (dalek `zeroize`).
         let seed = Zeroizing::new(*seed);
@@ -145,6 +147,11 @@ impl DeviceX25519Secret {
 /// decodes to *some* u-coordinate, so unlike an ed25519 key there is no curve-point rejection;
 /// [`from_bytes`](Self::from_bytes) is where the identity + small-order points are refused instead
 /// (the C1 half of §5 — the all-zero-shared-secret check is C4).
+///
+/// The type does NOT itself guarantee "blocklist-validated": [`DeviceX25519Secret::public`]
+/// constructs one directly (a key derived from a real secret is never small-order). The guarantee
+/// only matters for PEER keys — C4's `DeviceAdd` handling MUST route an incoming public key through
+/// [`from_bytes`](Self::from_bytes) to hit the blocklist.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) struct DeviceX25519Public([u8; 32]);
 
@@ -176,7 +183,7 @@ const fn p_offset(byte0: u8) -> [u8; 32] {
     v
 }
 
-/// `1` (order-4 point) in little-endian 32-byte form.
+/// The `u = 1` low-order X25519 point in little-endian 32-byte form.
 const fn low_order_one() -> [u8; 32] {
     let mut v = [0u8; 32];
     v[0] = 1;
@@ -184,31 +191,33 @@ const fn low_order_one() -> [u8; 32] {
 }
 
 /// The canonical X25519 small-order point blocklist (RFC 7748 §6.1 / the libsodium
-/// `crypto_scalarmult_curve25519` blacklist): the identity, the order-2/4/8 points, and the three
-/// `p-1`/`p`/`p+1` encodings. A public key equal (mod the ignored high bit) to any of these yields
-/// an all-zero shared secret and must be refused at `DeviceAdd`.
+/// `crypto_scalarmult_curve25519` blacklist). Every entry is a low-order point: DH with ANY scalar
+/// yields the all-zero shared secret, so accepting one as a peer's public key would silently
+/// produce a predictable key. A public key equal (mod the ignored high bit) to any of these is
+/// refused at `DeviceAdd`. Each is annotated by its u-coordinate, not its torsion order — order
+/// labels vary between references, whereas the verified property is the all-zero DH output.
 const X25519_SMALL_ORDER_POINTS: [[u8; 32]; 7] = [
-    // 0 — the identity (order 1).
+    // u = 0.
     [0u8; 32],
-    // 1 — order 4.
+    // u = 1.
     low_order_one(),
-    // 325606250916557431795983626356110631294008115727848805560023387167927233504 — order 8.
+    // u = 325606250916557431795983626356110631294008115727848805560023387167927233504.
     [
         0xe0, 0xeb, 0x7a, 0x7c, 0x3b, 0x41, 0xb8, 0xae, 0x16, 0x56, 0xe3, 0xfa, 0xf1, 0x9f, 0xc4,
         0x6a, 0xda, 0x09, 0x8d, 0xeb, 0x9c, 0x32, 0xb1, 0xfd, 0x86, 0x62, 0x05, 0x16, 0x5f, 0x49,
         0xb8, 0x00,
     ],
-    // 39382357235489614581723060781553021112529911719440698176882885853963445705823 — order 8.
+    // u = 39382357235489614581723060781553021112529911719440698176882885853963445705823.
     [
         0x5f, 0x9c, 0x95, 0xbc, 0xa3, 0x50, 0x8c, 0x24, 0xb1, 0xd0, 0xb1, 0x55, 0x9c, 0x83, 0xef,
         0x5b, 0x04, 0x44, 0x5c, 0xc4, 0x58, 0x1c, 0x8e, 0x86, 0xd8, 0x22, 0x4e, 0xdd, 0xd0, 0x9f,
         0x11, 0x57,
     ],
-    // p-1 — order 2.
+    // u = p - 1  (p = 2^255 - 19).
     p_offset(0xec),
-    // p — order 4 (≡ identity on the prime-order subgroup).
+    // u = p      (≡ u = 0 mod p).
     p_offset(0xed),
-    // p+1 — order 1.
+    // u = p + 1  (≡ u = 1 mod p).
     p_offset(0xee),
 ];
 

--- a/crates/rag-rat-core/src/oplog/entry.rs
+++ b/crates/rag-rat-core/src/oplog/entry.rs
@@ -34,7 +34,6 @@ use anyhow::Context;
 use minicbor::Encoder;
 use minicbor::data::Type;
 use minicbor::decode::{Decoder, Error as CborError};
-use sha2::{Digest, Sha256};
 
 use super::cbor;
 use super::device::{DevicePublic, DeviceSecret};
@@ -110,7 +109,7 @@ pub(super) fn sign_entry(
         device_fingerprint,
         op_bytes: &op_bytes,
     });
-    let entry_hash = sha256(&body_bytes);
+    let entry_hash = cbor::sha256(&body_bytes);
     let signature = secret.sign(&body_bytes);
     let signed_bytes = encode_signed(&body_bytes, &signature);
     SignedEntry {
@@ -148,7 +147,7 @@ pub(super) fn sign_entry_from_op_bytes(
         device_fingerprint,
         op_bytes: &op_bytes,
     });
-    let entry_hash = sha256(&body_bytes);
+    let entry_hash = cbor::sha256(&body_bytes);
     let signature = secret.sign(&body_bytes);
     let signed_bytes = encode_signed(&body_bytes, &signature);
     SignedEntry {
@@ -269,9 +268,9 @@ fn decode_signed_cbor(bytes: &[u8]) -> Result<SignedEntry, CborError> {
     cbor::require_canonical_cbor(bytes)?;
     let mut d = Decoder::new(bytes);
     cbor::expect_array(&mut d, 3)?;
-    expect_domain(&mut d, SIGNED_DOMAIN)?;
+    cbor::expect_domain(&mut d, SIGNED_DOMAIN)?;
     let body_bytes = d.bytes()?.to_vec();
-    let signature = fixed_bytes::<64>(d.bytes()?, "signature")?;
+    let signature = cbor::fixed_bytes::<64>(d.bytes()?, "signature")?;
     let entry = decode_body(&body_bytes)?;
     Ok(SignedEntry { entry, signature, body_bytes, signed_bytes: bytes.to_vec() })
 }
@@ -282,26 +281,15 @@ fn decode_body(body_bytes: &[u8]) -> Result<VerifiedEntry, CborError> {
     cbor::require_canonical_cbor(body_bytes)?;
     let mut d = Decoder::new(body_bytes);
     cbor::expect_array(&mut d, 6)?;
-    expect_domain(&mut d, ENTRY_DOMAIN)?;
-    let stream_id = StreamId::from_bytes(fixed_bytes::<32>(d.bytes()?, "stream_id")?);
+    cbor::expect_domain(&mut d, ENTRY_DOMAIN)?;
+    let stream_id = StreamId::from_bytes(cbor::fixed_bytes::<32>(d.bytes()?, "stream_id")?);
     let prev_hash = decode_prev_hash(&mut d)?;
     let lamport = d.u64()?;
     let device_fingerprint =
-        DeviceFingerprint::from_bytes(fixed_bytes::<32>(d.bytes()?, "device fingerprint")?);
+        DeviceFingerprint::from_bytes(cbor::fixed_bytes::<32>(d.bytes()?, "device fingerprint")?);
     let op_bytes = d.bytes()?.to_vec();
-    let entry_hash = sha256(body_bytes);
+    let entry_hash = cbor::sha256(body_bytes);
     Ok(VerifiedEntry { stream_id, prev_hash, lamport, device_fingerprint, op_bytes, entry_hash })
-}
-
-/// Read the leading domain string and assert it matches `want` — a wrong/absent tag is a foreign or
-/// version-bumped object an old binary must reject, never misread.
-fn expect_domain(d: &mut Decoder<'_>, want: &str) -> Result<(), CborError> {
-    let got = d.str()?;
-    if got == want {
-        Ok(())
-    } else {
-        Err(CborError::message(format!("unknown domain tag `{got}` (expected `{want}`)")))
-    }
 }
 
 /// Decode the `prev_hash` slot: CBOR null → genesis (`None`), else a 32-byte bstr link.
@@ -310,22 +298,8 @@ fn decode_prev_hash(d: &mut Decoder<'_>) -> Result<Option<[u8; 32]>, CborError> 
         d.null()?;
         Ok(None)
     } else {
-        Ok(Some(fixed_bytes::<32>(d.bytes()?, "prev_hash")?))
+        Ok(Some(cbor::fixed_bytes::<32>(d.bytes()?, "prev_hash")?))
     }
-}
-
-/// Convert an opaque byte slice to a fixed `[u8; N]`, erroring with the field name on a length
-/// mismatch (a wrong-length hash / fingerprint / signature is a structural error).
-fn fixed_bytes<const N: usize>(bytes: &[u8], field: &str) -> Result<[u8; N], CborError> {
-    <[u8; N]>::try_from(bytes)
-        .map_err(|_| CborError::message(format!("{field} must be {N} bytes, got {}", bytes.len())))
-}
-
-/// `sha256` into a fixed 32-byte array — the entry-hash / content-address primitive.
-fn sha256(bytes: &[u8]) -> [u8; 32] {
-    let mut out = [0u8; 32];
-    out.copy_from_slice(&Sha256::digest(bytes));
-    out
 }
 
 #[cfg(test)]
@@ -423,7 +397,7 @@ mod tests {
     #[test]
     fn entry_hash_is_sha256_of_the_body() {
         let signed = sign_entry(&secret(), stream(), None, 1, &MemoryOp::Snapshot);
-        assert_eq!(signed.entry.entry_hash, sha256(&signed.body_bytes));
+        assert_eq!(signed.entry.entry_hash, cbor::sha256(&signed.body_bytes));
     }
 
     #[test]

--- a/crates/rag-rat-core/src/oplog/identity.rs
+++ b/crates/rag-rat-core/src/oplog/identity.rs
@@ -112,8 +112,9 @@ pub(crate) fn local_device(conn: &Connection, now_ms: i64) -> anyhow::Result<Loc
             x25519_public,
         }),
         // A row minted before V058 carries no X25519 key yet — backfill it under a CAS so
-        // concurrent opens can't split into two encryption identities.
-        None => backfill_x25519(conn, stored),
+        // concurrent opens can't split into two encryption identities. `stored`'s ed25519 identity
+        // is the same row the backfill re-reads, so nothing from it is needed past this point.
+        None => backfill_x25519(conn),
     }
 }
 
@@ -124,7 +125,7 @@ pub(crate) fn local_device(conn: &Connection, now_ms: i64) -> anyhow::Result<Loc
 /// count; the mandatory re-read below is the source of truth (winner reads its own write, loser
 /// adopts the incumbent), exactly as the ed25519 mint path's `ON CONFLICT DO NOTHING` + re-read
 /// does.
-fn backfill_x25519(conn: &Connection, stored: StoredIdentity) -> anyhow::Result<LocalDevice> {
+fn backfill_x25519(conn: &Connection) -> anyhow::Result<LocalDevice> {
     let fresh = DeviceX25519Secret::generate()?;
     conn.execute(
         "UPDATE oplog_device_identity
@@ -132,14 +133,10 @@ fn backfill_x25519(conn: &Connection, stored: StoredIdentity) -> anyhow::Result<
           WHERE id = 0 AND x25519_secret IS NULL",
         params![fresh.secret_bytes().as_slice(), fresh.public().to_bytes().as_slice()],
     )?;
-    let reread = read_identity(conn)?
+    read_identity(conn)?
         .context("device identity vanished during X25519 backfill")?
         .into_local()
-        .context("X25519 columns still NULL immediately after the backfill CAS")?;
-    // `stored`'s ed25519 identity and the re-read one are the same row; the re-read is
-    // authoritative for the X25519 key that actually landed.
-    let _ = stored;
-    Ok(reread)
+        .context("X25519 columns still NULL immediately after the backfill CAS")
 }
 
 impl StoredIdentity {

--- a/crates/rag-rat-core/src/oplog/identity.rs
+++ b/crates/rag-rat-core/src/oplog/identity.rs
@@ -17,15 +17,24 @@ use anyhow::Context;
 use rusqlite::{Connection, OptionalExtension, params};
 use zeroize::Zeroizing;
 
-use super::device::{DevicePublic, DeviceSecret};
+use super::device::{DevicePublic, DeviceSecret, DeviceX25519Public, DeviceX25519Secret};
 use super::op::DeviceFingerprint;
 
-/// The store's local signing identity: the secret (for signing), its verifying key, and the opaque
-/// op-model fingerprint. Owns the secret, so it is neither `Clone` nor `Debug`-printable.
+/// The store's local device identity: the ed25519 signing key (secret + verifying key + opaque
+/// fingerprint) AND the X25519 encryption key (sync phase C, §5). Owns both secrets, so it is
+/// neither `Clone` nor `Debug`-printable.
 pub(crate) struct LocalDevice {
     secret: DeviceSecret,
     public: DevicePublic,
     fingerprint: DeviceFingerprint,
+    // The X25519 encryption keypair. C1 mints/persists/validates it; the first CONSUMER is C4
+    // (account.secrets sealed-box wrap / unwrap, #607), so the accessors are unused this slice —
+    // carried now so the identity owns both keys per §5, mirroring how mod.rs pre-exports
+    // not-yet-wired seams.
+    #[allow(dead_code)]
+    x25519_secret: DeviceX25519Secret,
+    #[allow(dead_code)]
+    x25519_public: DeviceX25519Public,
 }
 
 impl LocalDevice {
@@ -48,60 +57,151 @@ impl LocalDevice {
     pub(crate) fn fingerprint(&self) -> DeviceFingerprint {
         self.fingerprint
     }
+
+    /// The device's X25519 public encryption key. `pub(super)`; C4 (sealed-box wrap) is the first
+    /// caller.
+    #[allow(dead_code)]
+    pub(super) fn x25519_public(&self) -> DeviceX25519Public {
+        self.x25519_public
+    }
+
+    /// The device's X25519 secret. `pub(super)`; C4 (sealed-box unwrap / ECDH) is the first caller.
+    #[allow(dead_code)]
+    pub(super) fn x25519_secret(&self) -> &DeviceX25519Secret {
+        &self.x25519_secret
+    }
 }
 
-/// Return this store's persisted device identity, minting + persisting one on the first call.
-/// Idempotent: every later call returns the SAME identity (a stable fingerprint). `now_ms` stamps a
+/// The identity row as stored: the ed25519 device (always present) plus the X25519 encryption key
+/// IF it has been minted/backfilled yet (a pre-V058 row carries neither X25519 column).
+struct StoredIdentity {
+    secret: DeviceSecret,
+    public: DevicePublic,
+    fingerprint: DeviceFingerprint,
+    x25519: Option<(DeviceX25519Secret, DeviceX25519Public)>,
+}
+
+/// Return this store's persisted device identity, minting + persisting one on the first call and
+/// backfilling the X25519 key for a pre-V058 ed25519-only row. Idempotent: every later call returns
+/// the SAME identity (a stable fingerprint AND a stable encryption key). `now_ms` stamps a
 /// freshly-minted row (injected, matching the op-log store convention); it is ignored once an
 /// identity already exists.
 pub(crate) fn local_device(conn: &Connection, now_ms: i64) -> anyhow::Result<LocalDevice> {
-    if let Some(device) = read_identity(conn)? {
-        return Ok(device);
+    let stored = match read_identity(conn)? {
+        Some(stored) => stored,
+        None => {
+            // First use: mint BOTH keys from OS entropy and persist. Under a concurrent first open
+            // another process may win the insert; `ON CONFLICT DO NOTHING` makes our write a no-op
+            // and the mandatory re-read returns whichever identity actually landed — so we adopt
+            // the incumbent and drop our own freshly-minted seeds rather than ever
+            // holding keys the store didn't record.
+            let ed = DeviceSecret::generate()?;
+            let x = DeviceX25519Secret::generate()?;
+            persist_identity(conn, &ed, &x, now_ms)?;
+            read_identity(conn)?.context(
+                "device identity missing immediately after persist (single-row insert lost?)",
+            )?
+        },
+    };
+    match stored.x25519 {
+        Some((x25519_secret, x25519_public)) => Ok(LocalDevice {
+            secret: stored.secret,
+            public: stored.public,
+            fingerprint: stored.fingerprint,
+            x25519_secret,
+            x25519_public,
+        }),
+        // A row minted before V058 carries no X25519 key yet — backfill it under a CAS so
+        // concurrent opens can't split into two encryption identities.
+        None => backfill_x25519(conn, stored),
     }
-    // First use: mint from OS entropy and persist. Under a concurrent first open another process
-    // may win the insert; `ON CONFLICT DO NOTHING` makes our write a no-op and the mandatory
-    // re-read below returns whichever identity actually landed — so we adopt the incumbent and drop
-    // our own freshly-minted seed rather than ever holding a key the store didn't record.
-    let fresh = DeviceSecret::generate()?;
-    persist_identity(conn, &fresh, now_ms)?;
-    read_identity(conn)?
-        .context("device identity missing immediately after persist (single-row insert lost?)")
 }
 
-/// Insert the identity as the sole row (`id = 0`); a no-op if one already exists.
-fn persist_identity(conn: &Connection, secret: &DeviceSecret, now_ms: i64) -> anyhow::Result<()> {
+/// Backfill the X25519 key for a pre-V058 ed25519-only identity. Mints a FRESH, independent X25519
+/// key, then swaps it in with a guarded UPDATE — the compare-and-swap is the `WHERE x25519_secret
+/// IS NULL` clause: SQLite serializes writers, so a racing opener's UPDATE (running only after ours
+/// commits) matches no rows and its own re-read adopts our key. We never branch on the affected-row
+/// count; the mandatory re-read below is the source of truth (winner reads its own write, loser
+/// adopts the incumbent), exactly as the ed25519 mint path's `ON CONFLICT DO NOTHING` + re-read
+/// does.
+fn backfill_x25519(conn: &Connection, stored: StoredIdentity) -> anyhow::Result<LocalDevice> {
+    let fresh = DeviceX25519Secret::generate()?;
+    conn.execute(
+        "UPDATE oplog_device_identity
+            SET x25519_secret = ?1, x25519_public = ?2
+          WHERE id = 0 AND x25519_secret IS NULL",
+        params![fresh.secret_bytes().as_slice(), fresh.public().to_bytes().as_slice()],
+    )?;
+    let reread = read_identity(conn)?
+        .context("device identity vanished during X25519 backfill")?
+        .into_local()
+        .context("X25519 columns still NULL immediately after the backfill CAS")?;
+    // `stored`'s ed25519 identity and the re-read one are the same row; the re-read is
+    // authoritative for the X25519 key that actually landed.
+    let _ = stored;
+    Ok(reread)
+}
+
+impl StoredIdentity {
+    /// Consume into a complete [`LocalDevice`], or `None` if the X25519 key is not present yet.
+    fn into_local(self) -> Option<LocalDevice> {
+        let (x25519_secret, x25519_public) = self.x25519?;
+        Some(LocalDevice {
+            secret: self.secret,
+            public: self.public,
+            fingerprint: self.fingerprint,
+            x25519_secret,
+            x25519_public,
+        })
+    }
+}
+
+/// Insert the identity as the sole row (`id = 0`) with BOTH keys; a no-op if one already exists.
+fn persist_identity(
+    conn: &Connection,
+    secret: &DeviceSecret,
+    x25519: &DeviceX25519Secret,
+    now_ms: i64,
+) -> anyhow::Result<()> {
     let public = secret.public();
     conn.execute(
-        "INSERT INTO oplog_device_identity(id, seed, public_key, fingerprint, created_at_ms)
-         VALUES (0, ?1, ?2, ?3, ?4)
+        "INSERT INTO oplog_device_identity(
+             id, seed, public_key, fingerprint, created_at_ms, x25519_secret, x25519_public)
+         VALUES (0, ?1, ?2, ?3, ?4, ?5, ?6)
          ON CONFLICT(id) DO NOTHING",
         params![
             secret.seed().as_slice(),
             public.to_bytes().as_slice(),
             public.fingerprint().to_bytes().as_slice(),
-            now_ms
+            now_ms,
+            x25519.secret_bytes().as_slice(),
+            x25519.public().to_bytes().as_slice(),
         ],
     )?;
     Ok(())
 }
 
-/// Read the sole identity row, re-deriving the key from its seed and asserting the stored derived
-/// columns still agree. `None` when no identity has been minted yet.
-fn read_identity(conn: &Connection) -> anyhow::Result<Option<LocalDevice>> {
+/// Read the sole identity row, re-deriving each key from its stored secret and asserting the stored
+/// derived columns still agree. `None` when no identity has been minted yet; the returned
+/// [`StoredIdentity`] carries `x25519: None` for a pre-V058 row awaiting backfill.
+fn read_identity(conn: &Connection) -> anyhow::Result<Option<StoredIdentity>> {
     let row = conn
         .query_row(
-            "SELECT seed, public_key, fingerprint FROM oplog_device_identity WHERE id = 0",
+            "SELECT seed, public_key, fingerprint, x25519_secret, x25519_public
+               FROM oplog_device_identity WHERE id = 0",
             [],
             |row| {
                 Ok((
                     row.get::<_, Vec<u8>>(0)?,
                     row.get::<_, Vec<u8>>(1)?,
                     row.get::<_, Vec<u8>>(2)?,
+                    row.get::<_, Option<Vec<u8>>>(3)?,
+                    row.get::<_, Option<Vec<u8>>>(4)?,
                 ))
             },
         )
         .optional()?;
-    let Some((seed, stored_public, stored_fingerprint)) = row else {
+    let Some((seed, stored_public, stored_fingerprint, x_secret_col, x_public_col)) = row else {
         return Ok(None);
     };
 
@@ -122,7 +222,39 @@ fn read_identity(conn: &Connection) -> anyhow::Result<Option<LocalDevice>> {
         fingerprint.to_bytes().as_slice() == stored_fingerprint.as_slice(),
         "stored device fingerprint does not match sha256(public_key)"
     );
-    Ok(Some(LocalDevice { secret, public, fingerprint }))
+    let x25519 = read_x25519(x_secret_col, x_public_col)?;
+    Ok(Some(StoredIdentity { secret, public, fingerprint, x25519 }))
+}
+
+/// Re-derive + validate the X25519 key from its stored columns. Both present ⇒ rebuild from the
+/// secret and assert the stored public agrees (same legibility-copy discipline as ed25519). Both
+/// absent ⇒ `None` (a pre-V058 row awaiting backfill). Exactly one present ⇒ a corrupted row,
+/// refused.
+fn read_x25519(
+    secret_col: Option<Vec<u8>>,
+    public_col: Option<Vec<u8>>,
+) -> anyhow::Result<Option<(DeviceX25519Secret, DeviceX25519Public)>> {
+    match (secret_col, public_col) {
+        (Some(secret_bytes), Some(stored_public)) => {
+            let secret_bytes: [u8; 32] = secret_bytes
+                .as_slice()
+                .try_into()
+                .context("stored device x25519_secret is not exactly 32 bytes")?;
+            let secret_bytes = Zeroizing::new(secret_bytes);
+            let x25519_secret = DeviceX25519Secret::from_seed(&secret_bytes);
+            let x25519_public = x25519_secret.public();
+            anyhow::ensure!(
+                x25519_public.to_bytes().as_slice() == stored_public.as_slice(),
+                "stored device x25519_public does not match the key derived from its x25519_secret"
+            );
+            Ok(Some((x25519_secret, x25519_public)))
+        },
+        (None, None) => Ok(None),
+        _ => anyhow::bail!(
+            "oplog_device_identity has exactly one of x25519_secret / x25519_public set — \
+             corrupted"
+        ),
+    }
 }
 
 #[cfg(test)]
@@ -130,7 +262,7 @@ mod tests {
     use super::*;
     use crate::index::schema;
 
-    /// A migrated in-memory DB carrying the V054 identity table.
+    /// A fully-migrated in-memory DB carrying the identity table with its V058 X25519 columns.
     fn conn() -> Connection {
         let conn = Connection::open_in_memory().expect("open in-memory db");
         schema::apply(&conn).expect("apply schema");
@@ -197,8 +329,10 @@ mod tests {
         let incumbent = local_device(&conn, now()).expect("incumbent identity");
         // A second `persist_identity` with a different key must be a no-op (the id=0 conflict).
         let intruder = DeviceSecret::generate().expect("csprng");
+        let intruder_x = DeviceX25519Secret::generate().expect("csprng");
         assert_ne!(incumbent.public().to_bytes(), intruder.public().to_bytes());
-        persist_identity(&conn, &intruder, now() + 1).expect("conflicting insert is a no-op");
+        persist_identity(&conn, &intruder, &intruder_x, now() + 1)
+            .expect("conflicting insert is a no-op");
         let after = local_device(&conn, now() + 2).expect("re-read");
         assert_eq!(
             incumbent.public().to_bytes(),
@@ -222,5 +356,117 @@ mod tests {
         let err =
             local_device(&conn, now()).map(|_| ()).expect_err("corrupted identity must be refused");
         assert!(err.to_string().contains("public_key"), "error names the mismatched column");
+    }
+
+    #[test]
+    fn mint_persists_both_keys() {
+        let conn = conn();
+        local_device(&conn, now()).expect("mint identity");
+        // A freshly minted identity carries the ed25519 seed AND the X25519 encryption key.
+        let (x_secret, x_public): (Option<Vec<u8>>, Option<Vec<u8>>) = conn
+            .query_row(
+                "SELECT x25519_secret, x25519_public FROM oplog_device_identity WHERE id = 0",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .expect("read row");
+        assert!(x_secret.is_some(), "x25519_secret is persisted at mint");
+        assert!(x_public.is_some(), "x25519_public is persisted at mint");
+    }
+
+    #[test]
+    fn x25519_is_backfilled_for_a_pre_existing_ed25519_only_identity() {
+        let conn = conn();
+        let original = local_device(&conn, now()).expect("mint identity");
+        // Simulate a pre-V058 row: strip the X25519 columns back to NULL.
+        conn.execute(
+            "UPDATE oplog_device_identity SET x25519_secret = NULL, x25519_public = NULL WHERE id \
+             = 0",
+            [],
+        )
+        .expect("null out x25519");
+        // The next open backfills the X25519 key while preserving the ed25519 identity.
+        let backfilled = local_device(&conn, now() + 1).expect("backfill x25519");
+        assert_eq!(
+            original.fingerprint().to_bytes(),
+            backfilled.fingerprint().to_bytes(),
+            "the ed25519 identity is preserved across the backfill",
+        );
+        // The columns are now non-null and internally consistent (public derives from secret).
+        let (x_secret, x_public): (Vec<u8>, Vec<u8>) = conn
+            .query_row(
+                "SELECT x25519_secret, x25519_public FROM oplog_device_identity WHERE id = 0",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .expect("read backfilled row");
+        let seed: [u8; 32] = x_secret.as_slice().try_into().expect("32-byte x25519 secret");
+        assert_eq!(
+            DeviceX25519Secret::from_seed(&seed).public().to_bytes().as_slice(),
+            x_public.as_slice(),
+            "the backfilled x25519 columns are consistent",
+        );
+        // Stable across the next reopen — no re-backfill, no drift.
+        let reopened = local_device(&conn, now() + 2).expect("reopen");
+        assert_eq!(
+            backfilled.x25519_public().to_bytes(),
+            reopened.x25519_public().to_bytes(),
+            "the backfilled key is stable across reopens",
+        );
+    }
+
+    #[test]
+    fn concurrent_x25519_backfill_adopts_the_incumbent() {
+        let conn = conn();
+        local_device(&conn, now()).expect("mint identity");
+        // Model the race: strip to a pre-V058 row, then a COMPETING writer wins the backfill with a
+        // known key before our open runs its guarded CAS.
+        conn.execute(
+            "UPDATE oplog_device_identity SET x25519_secret = NULL, x25519_public = NULL WHERE id \
+             = 0",
+            [],
+        )
+        .expect("null out x25519");
+        let incumbent_x = DeviceX25519Secret::from_seed(&[0x42; 32]);
+        conn.execute(
+            "UPDATE oplog_device_identity SET x25519_secret = ?1, x25519_public = ?2 WHERE id = 0",
+            params![
+                incumbent_x.secret_bytes().as_slice(),
+                incumbent_x.public().to_bytes().as_slice()
+            ],
+        )
+        .expect("incumbent backfill");
+        // The guarded CAS itself writes NOTHING once the key is set — the loser's UPDATE is a
+        // no-op.
+        let rows = conn
+            .execute(
+                "UPDATE oplog_device_identity SET x25519_secret = ?1, x25519_public = ?2
+                   WHERE id = 0 AND x25519_secret IS NULL",
+                params![[9u8; 32].as_slice(), [9u8; 32].as_slice()],
+            )
+            .expect("guarded update");
+        assert_eq!(rows, 0, "the CAS guard writes nothing when the key is already set");
+        // And our open adopts the incumbent's key, never overwriting it.
+        let adopted = local_device(&conn, now() + 1).expect("adopt incumbent");
+        assert_eq!(
+            adopted.x25519_public().to_bytes(),
+            incumbent_x.public().to_bytes(),
+            "the incumbent x25519 key survives a concurrent open",
+        );
+    }
+
+    #[test]
+    fn a_corrupted_x25519_public_column_is_refused() {
+        let conn = conn();
+        local_device(&conn, now()).expect("mint identity");
+        // Corrupt x25519_public so it no longer derives from the stored secret; a load must refuse
+        // it.
+        conn.execute("UPDATE oplog_device_identity SET x25519_public = ?1 WHERE id = 0", params![
+            [0u8; 32].as_slice()
+        ])
+        .expect("corrupt row");
+        let err =
+            local_device(&conn, now()).map(|_| ()).expect_err("corrupted x25519 must be refused");
+        assert!(err.to_string().contains("x25519_public"), "error names the mismatched column");
     }
 }

--- a/crates/rag-rat-core/src/oplog/mod.rs
+++ b/crates/rag-rat-core/src/oplog/mod.rs
@@ -32,6 +32,7 @@
 //! seam, roster/epochs, and transport) — this mirrors the `content_hash` freeze: pin the semantic
 //! primitive first, in isolation-testable form.
 
+mod account;
 mod cbor;
 mod device;
 mod entry;

--- a/crates/rag-rat-core/src/oplog/stream.rs
+++ b/crates/rag-rat-core/src/oplog/stream.rs
@@ -24,6 +24,12 @@
 //!
 //! Tokens (repo ids, kind/relation tokens, node ids) are machine identifiers and are encoded
 //! VERBATIM — no NFC/trim (the same "structural canonicity only" rule as [`super::op`]).
+//!
+//! **Two derivations coexist (sync phase C).** [`owner_stream`] / [`derive`] produce the original
+//! `rag-rat/stream/1` id — LOCAL-only, what the live phase-B authoring path mints. [`derive_v2`]
+//! produces the owner-bound `rag-rat/stream/2` id (§14), which commits the owning `AccountId`
+//! inside the hash so a synced `/3` content entry transitively names its owner. C1 adds `/2`
+//! ALONGSIDE `/1` (byte-unchanged); nothing switches the live path until C3 adoption.
 
 use minicbor::Encoder;
 use sha2::{Digest, Sha256};

--- a/crates/rag-rat-core/src/oplog/stream.rs
+++ b/crates/rag-rat-core/src/oplog/stream.rs
@@ -28,9 +28,17 @@
 use minicbor::Encoder;
 use sha2::{Digest, Sha256};
 
+use super::account::AccountId;
+
 /// Domain tag + version for the stream-identity derivation. Bump only when the canonical rule
 /// itself changes — never when a kind/relation token is added.
 const STREAM_DOMAIN: &str = "rag-rat/stream/1";
+
+/// Domain tag for the OWNER-BOUND stream identity (sync phase C, §14). `/2` commits the owning
+/// `AccountId` inside the hashed identity, so a `/3` content entry that names the stream
+/// transitively names its owner — two accounts claiming one stream is cryptographically impossible.
+/// `/1` stays local-only (never on the wire); `/2` is what sync mints.
+const STREAM_V2_DOMAIN: &str = "rag-rat/stream/2";
 
 /// Writing CBOR into a `Vec` cannot fail (its `Write` impl is infallible) — mirrors `super::op`.
 const INFALLIBLE: &str = "encoding CBOR to a Vec is infallible";
@@ -113,9 +121,33 @@ pub(crate) fn derive(spec: &StreamSpec) -> anyhow::Result<StreamId> {
     Ok(StreamId(out))
 }
 
-/// The canonical CBOR tuple the identity hashes — `[domain, repo_set, kind_allow_list | null,
+/// The canonical CBOR tuple the `/1` identity hashes — `[domain, repo_set, kind_allow_list | null,
 /// relation_policy | null, override_pairs]`, definite lengths + minimal headers throughout.
 fn canonical_spec_bytes(spec: &StreamSpec) -> anyhow::Result<Vec<u8>> {
+    let policy = canonical_policy(spec)?;
+    let mut buf = Vec::with_capacity(96);
+    {
+        let mut enc = Encoder::new(&mut buf);
+        enc.array(5).expect(INFALLIBLE);
+        enc.str(STREAM_DOMAIN).expect(INFALLIBLE);
+        encode_policy(&mut enc, &policy);
+    }
+    Ok(buf)
+}
+
+/// The validated + canonicalized policy fields shared by the `/1` and `/2` derivations. Extracting
+/// them keeps the two identities byte-identical in everything but the domain tag + owner prefix.
+struct CanonicalPolicy {
+    repo_set: Vec<String>,
+    kind_allow_list: Option<Vec<String>>,
+    relation_policy: Option<Vec<String>>,
+    overrides: Vec<NodeOverride>,
+}
+
+/// Validate + canonicalize a stream's policy (sort + dedup; reject an empty/blank `repo_set` or a
+/// node with conflicting overrides) — the identity-defining rules, independent of the domain
+/// version.
+fn canonical_policy(spec: &StreamSpec) -> anyhow::Result<CanonicalPolicy> {
     let repo_set = sorted_deduped(&spec.repo_set);
     if repo_set.is_empty() {
         anyhow::bail!("a stream must carry at least one repo");
@@ -123,24 +155,67 @@ fn canonical_spec_bytes(spec: &StreamSpec) -> anyhow::Result<Vec<u8>> {
     if repo_set.iter().any(|repo| repo.is_empty()) {
         anyhow::bail!("a stream repo id must be non-empty");
     }
-    let kind_allow_list = spec.kind_allow_list.as_deref().map(sorted_deduped);
-    let relation_policy = spec.relation_policy.as_deref().map(sorted_deduped);
-    let overrides = canonical_overrides(&spec.node_overrides)?;
+    Ok(CanonicalPolicy {
+        repo_set,
+        kind_allow_list: spec.kind_allow_list.as_deref().map(sorted_deduped),
+        relation_policy: spec.relation_policy.as_deref().map(sorted_deduped),
+        overrides: canonical_overrides(&spec.node_overrides)?,
+    })
+}
 
-    let mut buf = Vec::with_capacity(96);
+/// Append the four policy fields (`repo_set, kind_allow_list|null, relation_policy|null,
+/// override_pairs`) to `enc` in the frozen order. The BYTES are identical whether they follow the
+/// `/1` header or the `/2` header+owner — the shared tail of both identities.
+fn encode_policy(enc: &mut Encoder<&mut Vec<u8>>, policy: &CanonicalPolicy) {
+    encode_str_array(enc, &policy.repo_set);
+    encode_optional_str_array(enc, policy.kind_allow_list.as_deref());
+    encode_optional_str_array(enc, policy.relation_policy.as_deref());
+    enc.array(policy.overrides.len() as u64).expect(INFALLIBLE);
+    for entry in &policy.overrides {
+        enc.array(2).expect(INFALLIBLE);
+        enc.str(&entry.node_id).expect(INFALLIBLE);
+        enc.str(entry.action.as_wire_str()).expect(INFALLIBLE);
+    }
+}
+
+/// The owner-bound stream policy (`/2`, §14): the `/1` visibility policy plus the owning account.
+/// The owner is committed INSIDE the hashed identity, so ownership is self-certifying and
+/// immutable.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct StreamSpecV2 {
+    /// The account that owns this stream — all its authorization lives in this account's logs.
+    pub(crate) owner_account_id: AccountId,
+    /// The visibility policy (repos, kind/relation filters, per-node overrides), same shape as
+    /// `/1`.
+    pub(crate) policy: StreamSpec,
+}
+
+/// Derive the owner-bound `stream_id` (`/2`, §14): `sha256(cbor(["rag-rat/stream/2",
+/// owner_account_id (b32), repo_set, kind_allow_list|null, relation_policy|null, override_set]))`.
+/// C1 ships this ALONGSIDE [`owner_stream`] / [`derive`] (`/1`), which the live phase-B authoring
+/// path keeps using until C3 adoption — nothing switches the live path here.
+///
+/// Consumed by `StreamOwn` validation in the fold (Phase 4); the allow drops when that lands.
+#[allow(dead_code)]
+pub(crate) fn derive_v2(spec: &StreamSpecV2) -> anyhow::Result<StreamId> {
+    let bytes = canonical_spec_v2_bytes(spec)?;
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&Sha256::digest(&bytes));
+    Ok(StreamId(out))
+}
+
+/// The canonical CBOR tuple the `/2` identity hashes — `[domain, owner_account_id (b32), repo_set,
+/// kind_allow_list | null, relation_policy | null, override_pairs]`. The owner sits between the
+/// domain and the shared policy tail.
+fn canonical_spec_v2_bytes(spec: &StreamSpecV2) -> anyhow::Result<Vec<u8>> {
+    let policy = canonical_policy(&spec.policy)?;
+    let mut buf = Vec::with_capacity(128);
     {
         let mut enc = Encoder::new(&mut buf);
-        enc.array(5).expect(INFALLIBLE);
-        enc.str(STREAM_DOMAIN).expect(INFALLIBLE);
-        encode_str_array(&mut enc, &repo_set);
-        encode_optional_str_array(&mut enc, kind_allow_list.as_deref());
-        encode_optional_str_array(&mut enc, relation_policy.as_deref());
-        enc.array(overrides.len() as u64).expect(INFALLIBLE);
-        for entry in &overrides {
-            enc.array(2).expect(INFALLIBLE);
-            enc.str(&entry.node_id).expect(INFALLIBLE);
-            enc.str(entry.action.as_wire_str()).expect(INFALLIBLE);
-        }
+        enc.array(6).expect(INFALLIBLE);
+        enc.str(STREAM_V2_DOMAIN).expect(INFALLIBLE);
+        enc.bytes(&spec.owner_account_id.to_bytes()).expect(INFALLIBLE);
+        encode_policy(&mut enc, &policy);
     }
     Ok(buf)
 }
@@ -331,5 +406,77 @@ mod tests {
             ],
         };
         assert!(derive(&spec).is_err(), "one node cannot be both included and excluded");
+    }
+
+    fn owner() -> AccountId {
+        AccountId::from_bytes([0x11; 32])
+    }
+
+    fn spec_v2() -> StreamSpecV2 {
+        StreamSpecV2 { owner_account_id: owner(), policy: filtered_spec() }
+    }
+
+    #[test]
+    fn stream_v2_pins_the_owner_bound_identity() {
+        // The `/2` derivation is a frozen primitive (StreamOwn validation + `/3` bodies build on
+        // it); a canonical-rule change must break this and force a deliberate
+        // `rag-rat/stream/2` bump.
+        let id = derive_v2(&spec_v2()).unwrap();
+        assert_eq!(
+            hex(&id.to_bytes()),
+            "d998110a767b415646b18c09745d6586b2ae6afdeb3144fe5f0907d2761557e3",
+            "stream/2 golden",
+        );
+    }
+
+    #[test]
+    fn stream_v2_canonical_bytes_have_the_expected_structure() {
+        // The owner b32 sits between the domain and the shared policy tail.
+        let bytes = canonical_spec_v2_bytes(&StreamSpecV2 {
+            owner_account_id: AccountId::from_bytes([0x11; 32]),
+            policy: StreamSpec {
+                repo_set: vec!["repo-a".to_string()],
+                kind_allow_list: None,
+                relation_policy: None,
+                node_overrides: Vec::new(),
+            },
+        })
+        .unwrap();
+        assert_eq!(bytes[0], 0x86, "6-element array header");
+        assert_eq!(bytes[1], 0x70, "text header, len 16");
+        assert_eq!(&bytes[2..18], b"rag-rat/stream/2");
+        assert_eq!(&bytes[18..20], &[0x58, 0x20], "owner_account_id bstr header, len 32");
+        assert_eq!(&bytes[20..52], &[0x11; 32], "owner_account_id bytes");
+        assert_eq!(bytes[52], 0x81, "repo_set: 1-element array");
+        assert_eq!(bytes[53], 0x66, "text header, len 6");
+        assert_eq!(&bytes[54..60], b"repo-a");
+        assert_eq!(bytes[60], 0xf6, "unfiltered kind_allow_list is CBOR null");
+        assert_eq!(bytes[61], 0xf6, "all-relations policy is CBOR null");
+        assert_eq!(bytes[62], 0x80, "empty override set");
+        assert_eq!(bytes.len(), 63);
+        cbor::require_canonical_cbor(&bytes).expect("stream/2 tuple is canonical CBOR");
+    }
+
+    #[test]
+    fn two_owners_cannot_derive_the_same_stream_id() {
+        // Same policy, different owner ⇒ different stream — ownership is committed inside the id,
+        // so two accounts claiming one stream is impossible.
+        let a = derive_v2(&StreamSpecV2 {
+            owner_account_id: AccountId::from_bytes([0x11; 32]),
+            policy: filtered_spec(),
+        })
+        .unwrap();
+        let b = derive_v2(&StreamSpecV2 {
+            owner_account_id: AccountId::from_bytes([0x22; 32]),
+            policy: filtered_spec(),
+        })
+        .unwrap();
+        assert_ne!(a, b, "a different owner must derive a different stream_id");
+    }
+
+    #[test]
+    fn stream_v2_is_distinct_from_the_legacy_v1_identity() {
+        // The same visibility policy under `/2` (owner-bound) must not collide with its `/1` id.
+        assert_ne!(derive(&filtered_spec()).unwrap(), derive_v2(&spec_v2()).unwrap());
     }
 }


### PR DESCRIPTION
Part of #604 (#405). This lands the frozen wire + crypto surface of the sync phase C account layer and the fold's graph foundation — a pure, offline-testable library above the phase-B op-log. The stratified fold algorithm itself and the candidate-DAG storage follow in a subsequent PR.

## What this adds

**Device identity (§5)**
- An X25519 encryption keypair beside the ed25519 signing key, seed-deterministic and rejecting small-order / identity public keys (RFC 7748 blocklist). C1 only mints/persists/validates it; ECDH + sealing is C4.
- **V058**: nullable `x25519_secret` / `x25519_public` columns on `oplog_device_identity` + a guarded CAS backfill at open so concurrent opens of a pre-V058 row converge on one encryption identity.

**Frozen wire objects (golden-pinned)**
- `account_id = sha256(cbor(["rag-rat/account/1", genesis_payload]))` (§4).
- `derive_v2` + the owner-bound `rag-rat/stream/2` identity (§14), added alongside the byte-unchanged `/1` — the live authoring path is untouched until C3 adoption.
- The 13-part signed account-entry envelope `rag-rat/account-entry/1` (§6): header (the AAD unit) + opaque payload, sign/verify, `entry_hash`, with the self-contained nullity rules (`prev_hash`⇔`seq==0`, `key_id`⇔`crypto_suite==0`).
- The `Cut` revocation watermark (§11) + all 10 control-op payloads (§10): AccountGenesis, DeviceAdd, DeviceRemove, OwnerPromote, OwnerDemote, CutExtend, StreamOwn, StreamGrant, StreamRevoke, AccountReRoot — with the frozen `entry_type` tag set, closed role/kind enums, §18a cut-array bounds, sorted-unique cut arrays, and `encode(decode) == bytes` canonicity. Unknown `entry_type`s are retained opaque (and canonicity-checked, so a forward op can't split consensus).

**Fold foundation (§11)**
- The three register families (device-level, owner-incarnation, grant-level) + their scope predicates.
- The candidate-graph substrate: a hash-keyed header view, the `prev_hash` ancestry walk (a withheld watermark parks and never flips a verdict — I11), cut-target binding (§11.3 — a hash naming a different coordinate is a structural reject), and the `⊔` comparable-ancestor join.

## Notes
- Native-only; no live-path changes.
- Every wire object is golden-pinned and byte-verified against the frozen design; the shared `sha256` / `fixed_bytes` / `expect_domain` helpers are lifted into `cbor.rs` as one canonical-CBOR floor for both signed-wire layers.
- New schema migration is V058 (registered in all three recognizers — `known_version`, `known_migration`, `migration_checksum_mismatch`).

## Follow-up (rest of #604)
The stratified `fold_account` (§11) built against the §21 P1–P11 adversarial suite, point-in-time authority queries, and the candidate-DAG storage / ingest (V059).
