### PR TITLE
fix(cli): gate jemalloc off android so the CLI builds for aarch64-linux-android (#615)

### DIFF
--- a/crates/rag-rat-cli/Cargo.toml
+++ b/crates/rag-rat-cli/Cargo.toml
@@ -38,8 +38,11 @@ libc.workspace = true
 # Idle-RSS fix: glibc malloc never returns freed pages to the OS, so a long-lived `rag-rat mcp`
 # server retains its peak RSS (~625 MB observed) after the watcher's heavy index/graph passes.
 # jemalloc + a background purge thread gives dirty/muzzy pages back shortly after they go idle.
-# Gated off msvc (jemalloc has no msvc support); the `#[global_allocator]` cfg matches.
-[target.'cfg(not(target_env = "msvc"))'.dependencies]
+# Gated off msvc (jemalloc has no msvc support) and android (the NDK dropped libgcc in r23+, but
+# tikv-jemalloc-sys's link line still references `-lgcc` → an `unable to find -lgcc` link failure;
+# Android isn't the long-lived-server idle-RSS case, so the system allocator is the right fallback).
+# The `#[global_allocator]` cfg in main.rs matches this exactly.
+[target.'cfg(all(not(target_env = "msvc"), not(target_os = "android")))'.dependencies]
 tikv-jemallocator = { version = "0.6", features = ["background_threads"] }
 tikv-jemalloc-ctl = "0.6"
 

--- a/crates/rag-rat-cli/src/main.rs
+++ b/crates/rag-rat-cli/src/main.rs
@@ -29,7 +29,10 @@ mod init;
 // Idle-RSS fix: glibc malloc never hands freed pages back to the OS, so a long-lived `rag-rat mcp`
 // server keeps its peak RSS (~625 MB observed) after the watcher's heavy index/graph passes.
 // jemalloc with a background purge thread returns idle dirty/muzzy pages to the OS instead.
-#[cfg(not(target_env = "msvc"))]
+// Excluded on msvc (no jemalloc support) and android: the NDK dropped libgcc in r23+, but
+// tikv-jemalloc-sys's link line still references `-lgcc`, so the binary fails to link there.
+// Android isn't the long-lived-server case anyway — the system allocator is the right fallback.
+#[cfg(all(not(target_env = "msvc"), not(target_os = "android")))]
 #[global_allocator]
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
@@ -37,7 +40,7 @@ static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 /// decayed pages are only reclaimed on later alloc calls, which a quiet server rarely makes) and
 /// tighten the decay window from the 10s default so an idle server releases memory within ~1s.
 /// Best-effort — a server that holds slightly more RAM is better than one that won't boot.
-#[cfg(not(target_env = "msvc"))]
+#[cfg(all(not(target_env = "msvc"), not(target_os = "android")))]
 fn configure_jemalloc() {
     use tikv_jemalloc_ctl::{background_thread, raw};
     // Purge decayed pages on a background thread; a quiet server makes few alloc calls, which is
@@ -61,7 +64,7 @@ fn main() -> anyhow::Result<()> {
     // Record this binary's git-stamped version (#585) so migration provenance and the stranded-
     // binary refusal name a dev build (`0.16.0+g<hash>`) distinctly from a release (`0.16.0`).
     rag_rat_core::set_binary_version(env!("RAG_RAT_VERSION"));
-    #[cfg(not(target_env = "msvc"))]
+    #[cfg(all(not(target_env = "msvc"), not(target_os = "android")))]
     configure_jemalloc();
     let cli = Cli::parse();
 


### PR DESCRIPTION
## Problem

Building `rag-rat` for any Android target (`aarch64-linux-android`, Termux) fails at the final link:

```
ld.lld: error: unable to find library -lgcc
```

`rag-rat-cli` uses `tikv-jemallocator` as its `#[global_allocator]` (the idle-RSS fix for the long-lived `mcp` server), gated only off `msvc`. Android's `target_env` is empty, so jemalloc was compiled in on android — and `tikv-jemalloc-sys`'s link line references `-lgcc`, which the NDK removed in r23+ (replaced by libunwind + compiler-rt). No Android binary could be produced.

## Fix

Widen the gate to also exclude `target_os = "android"` — the `[target.'cfg(...)'.dependencies]` block plus all three `cfg` sites in `main.rs` (the `#[global_allocator]` static, `configure_jemalloc`, and its call). Android falls back to the system allocator, which is correct there: it is not the long-lived-server idle-RSS scenario the gate targets.

## Verification

Cross-built for `aarch64-linux-android` with NDK r27b:

- **Before:** the exact build fails on `unable to find -lgcc`.
- **After:** links to a valid `ELF 64-bit LSB pie executable, ARM aarch64, for Android 24`.
- Native `cargo clippy --workspace --all-targets` stays green (jemalloc still active on non-android).

jemalloc was the sole `-lgcc` source — everything else (model2vec, rusqlite, esaxx-rs C++, tree-sitter C, zstd, ring) cross-compiles cleanly. The full default build also links: fastembed statically embeds a pyke `aarch64-linux-android` ONNX Runtime, so this unblocks `cargo install rag-rat` on Termux with full features.

Prerequisite for #616 (adding the target to the release distribution).

Fixes #615