### PR TITLE
feat(dist): ship an Android/Termux binary + make npx @rag-rat/bin work there (#616)

### DIFF
--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -1,0 +1,171 @@
+# Android/Termux distribution — the piece cargo-dist can't do.
+#
+# cargo-dist does not support android as a platform (`dist plan --target aarch64-linux-android` skips
+# every installer), so the release workflow it generates neither builds the android binary nor teaches
+# @rag-rat/bin about it. This workflow fills both gaps:
+#
+#   build-android : cross-compile rag-rat for aarch64-linux-android (bionic) with the NDK + cargo-ndk,
+#                   and attach rag-rat-aarch64-linux-android.tar.gz to the GitHub release.
+#   publish-npm   : download cargo-dist's own npm package (attached to the release), inject android
+#                   support (dist-android/patch-npm-package.mjs), prove it resolves
+#                   (test-npm-package.cjs), then publish @rag-rat/bin. cargo-dist's own npm publish is
+#                   disabled (publish-jobs = [] in dist-workspace.toml) so there is no version
+#                   collision — this is the sole publisher.
+#
+# Triggered on the SAME tag push as cargo-dist's release.yml (`on: push: tags`), NOT `release:
+# published`. Flow: release-plz pushes the vX.Y.Z tag with a PAT (RELEASE_PLZ_TOKEN), which fires
+# tag-push workflows; cargo-dist's release.yml then builds the desktop binaries and creates the GitHub
+# release with the default GITHUB_TOKEN. GitHub suppresses downstream runs for GITHUB_TOKEN-created
+# release events, so a `release: published` trigger does NOT fire on the automated flow (verified:
+# v0.16.0 was authored by github-actions[bot] and no release-triggered workflow ran on it). So we ride
+# the tag push and wait for cargo-dist to create the release + attach its assets before adding ours.
+#
+# The android binary ships the full feature set: fastembed statically links the pyke
+# aarch64-linux-android ONNX Runtime, so no libonnxruntime.so is needed at runtime (only bionic +
+# libc++_shared, both present on Termux). Requires the jemalloc-off-android gate (#615).
+name: release-android
+
+on:
+  push:
+    tags:
+      - "**[0-9]+.[0-9]+.[0-9]+*"
+
+permissions:
+  contents: write # attach the android asset to the release
+
+env:
+  ANDROID_TARGET: aarch64-linux-android
+  ANDROID_ABI: arm64-v8a
+  ANDROID_API: "24"
+
+jobs:
+  build-android:
+    # Skip prereleases, matching cargo-dist's own npm publisher default — a prerelease must not become
+    # the npm `latest` dist-tag. A semver prerelease tag carries a `-` (v1.2.3-rc.1); a normal release
+    # tag (v1.2.3) does not. publish-npm needs this job, so it skips too.
+    if: ${{ !contains(github.ref_name, '-') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Install Rust + android target
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup target add "$ANDROID_TARGET"
+      - name: Install cargo-ndk
+        run: cargo install cargo-ndk --locked
+      - name: Cross-compile rag-rat (release, full features)
+        run: |
+          set -euo pipefail
+          # ubuntu-latest injects ANDROID_NDK_LATEST_HOME (r23+) into the shell env, not the ${{ env }}
+          # expression context; point cargo-ndk at it. r23+ is exactly why the jemalloc gate (#615) is
+          # needed — the allocator's -lgcc link fails otherwise.
+          export ANDROID_NDK_HOME="${ANDROID_NDK_LATEST_HOME:?no NDK on runner}"
+          echo "Using NDK: $ANDROID_NDK_HOME"
+          cargo ndk -t "$ANDROID_ABI" --platform "$ANDROID_API" build --release -p rag-rat
+      - name: Package + checksum (matches cargo-dist archive layout)
+        run: |
+          set -euo pipefail
+          STAGE="rag-rat-${ANDROID_TARGET}"
+          mkdir -p "$STAGE"
+          # Strip to keep the mobile download small; ONNX is statically linked so the binary is large.
+          "$ANDROID_NDK_LATEST_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-strip" \
+            -o "$STAGE/rag-rat" "target/${ANDROID_TARGET}/release/rag-rat"
+          cp README.md LICENSE "$STAGE/" 2>/dev/null || true
+          # Single top-level dir; the npm/shell installers untar with --strip-components 1.
+          tar czf "${STAGE}.tar.gz" "$STAGE"
+          sha256sum "${STAGE}.tar.gz" > "${STAGE}.tar.gz.sha256"
+          file "$STAGE/rag-rat"
+          ls -la "${STAGE}.tar.gz" "${STAGE}.tar.gz.sha256"
+      - name: Attach to the release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          STAGE="rag-rat-${ANDROID_TARGET}"
+          # We ride the same tag push as cargo-dist's release.yml, which builds the desktop binaries
+          # (~15-20 min) before its `gh release create ... artifacts/*`. Wait for that release to exist
+          # before adding the android archive; cargo-dist's build can be slow (mac/win/onnx), allow ~45m.
+          for i in $(seq 1 180); do
+            if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+              echo "release $TAG exists"
+              break
+            fi
+            echo "waiting for cargo-dist to create release $TAG ($i/180)…"
+            sleep 15
+          done
+          gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null # fail loudly if still absent
+          gh release upload "$TAG" "${STAGE}.tar.gz" "${STAGE}.tar.gz.sha256" \
+            --repo "$GITHUB_REPOSITORY" --clobber
+
+  publish-npm:
+    if: ${{ !contains(github.ref_name, '-') }}
+    runs-on: ubuntu-latest
+    needs: build-android # the android asset must exist before the installer that points at it ships
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+      - name: Fetch cargo-dist's npm package + wait for its desktop assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          # Use cargo-dist's OWN generated npm package (attached to the release as
+          # rag-rat-npm-package.tar.gz) rather than regenerating it here — the published package is then
+          # byte-identical to cargo-dist's for every desktop platform, and this job needs no dist
+          # install. Wait for the tarball to appear (both workflows race on the tag push), download it.
+          for i in $(seq 1 180); do
+            gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json assets --jq '.assets[].name' 2>/dev/null \
+              | grep -qxF "rag-rat-npm-package.tar.gz" && break
+            echo "waiting for npm package artifact ($i/180)…"
+            sleep 15
+          done
+          gh release download "$TAG" --repo "$GITHUB_REPOSITORY" -p "rag-rat-npm-package.tar.gz" -D . --clobber
+          mkdir -p pkg && tar xzf rag-rat-npm-package.tar.gz -C pkg --strip-components 1
+          # The package lists exactly the desktop archives the installer will point users at. gh release
+          # create exposes the release before those finish uploading, so wait until each is present —
+          # otherwise a desktop `npm i @rag-rat/bin` could 404.
+          mapfile -t EXPECTED < <(node -e '
+            const p = require("./pkg/package.json");
+            for (const k of Object.keys(p.supportedPlatforms)) console.log(p.supportedPlatforms[k].artifactName);
+          ' | sort -u)
+          echo "expecting desktop assets: ${EXPECTED[*]}"
+          for i in $(seq 1 180); do
+            present="$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json assets --jq '.assets[].name' || true)"
+            missing=""
+            for a in "${EXPECTED[@]}"; do
+              printf '%s\n' "$present" | grep -qxF "$a" || missing="$missing $a"
+            done
+            if [ -z "$missing" ]; then echo "all desktop assets present"; break; fi
+            echo "waiting for desktop assets ($i/180):$missing"
+            sleep 15
+          done
+          present="$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json assets --jq '.assets[].name')"
+          for a in "${EXPECTED[@]}"; do
+            printf '%s\n' "$present" | grep -qxF "$a" || { echo "desktop asset never appeared: $a"; exit 1; }
+          done
+      - name: Inject android support
+        run: node dist-android/patch-npm-package.mjs pkg
+      - name: Verify the patched installer resolves android + desktop
+        working-directory: pkg
+        run: |
+          # We only need detect-libc present so binary.js can be require()d by the resolution test.
+          # `npm install` (not `npm ci`) so it works whether or not the package ships a lockfile — we
+          # don't need a reproducible install here. --ignore-scripts is load-bearing: this package's own
+          # `postinstall` (install.js) DOWNLOADS the platform binary from the release, which we neither
+          # need nor want here (getPackage resolves a URL, it doesn't download).
+          npm install --omit=dev --ignore-scripts
+          node "$GITHUB_WORKSPACE/dist-android/test-npm-package.cjs" .
+      - name: Publish @rag-rat/bin
+        working-directory: pkg
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -283,43 +283,14 @@ jobs:
 
           gh release create "${{ needs.plan.outputs.tag }}" --target "$RELEASE_COMMIT" $PRERELEASE_FLAG --title "$ANNOUNCEMENT_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" artifacts/*
 
-  publish-npm:
-    needs:
-      - plan
-      - host
-    runs-on: "ubuntu-22.04"
-    env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      PLAN: ${{ needs.plan.outputs.val }}
-    if: ${{ !fromJson(needs.plan.outputs.val).announcement_is_prerelease || fromJson(needs.plan.outputs.val).publish_prereleases }}
-    steps:
-      - name: Fetch npm packages
-        uses: actions/download-artifact@v8
-        with:
-          pattern: artifacts-*
-          path: npm/
-          merge-multiple: true
-      - uses: actions/setup-node@v6
-        with:
-          node-version: '20.x'
-          registry-url: 'https://registry.npmjs.org'
-      - run: |
-          for release in $(echo "$PLAN" | jq --compact-output '.releases[] | select([.artifacts[] | endswith("-npm-package.tar.gz")] | any)'); do
-            pkg=$(echo "$release" | jq '.artifacts[] | select(endswith("-npm-package.tar.gz"))' --raw-output)
-            npm publish --access public "./npm/${pkg}"
-          done
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
   announce:
     needs:
       - plan
       - host
-      - publish-npm
     # use "always() && ..." to allow us to wait for all publish jobs while
     # still allowing individual publish jobs to skip themselves (for prereleases).
     # "host" however must run to completion, no skipping allowed!
-    if: ${{ always() && needs.host.result == 'success' && (needs.publish-npm.result == 'skipped' || needs.publish-npm.result == 'success') }}
+    if: ${{ always() && needs.host.result == 'success' }}
     runs-on: "ubuntu-22.04"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -51,6 +51,20 @@ sequenceDiagram
 
 ## Install
 
+The quickest way is a prebuilt binary — no Rust toolchain — for Apple Silicon macOS, glibc ≥2.38
+Linux (x86-64 and arm64), Windows x64, and Android/Termux (arm64):
+
+```bash
+npm install -g @rag-rat/bin        # puts `rag-rat` on your PATH
+# or run it once, without installing:
+npx @rag-rat/bin --help
+```
+
+`@rag-rat/bin` fetches the prebuilt binary for your platform from the matching GitHub release. It is
+the full build — FastEmbed's ONNX Runtime is statically linked, so nothing else is needed at runtime.
+
+**Build from source** if you'd rather compile it yourself (or assemble it from parts):
+
 ```bash
 cargo install rag-rat              # from crates.io (FastEmbed included by default)
 ```
@@ -61,9 +75,26 @@ From a checkout:
 cargo install --path crates/rag-rat-cli --bin rag-rat
 ```
 
-Add `--no-default-features` for a smaller hash-only build without real embeddings. SQLite is bundled
-(compiled in via `rusqlite`), so there is no system-library prerequisite — see
-[Platform support](#platform-support) for the per-OS C-toolchain note.
+The default build links FastEmbed's ONNX Runtime, whose prebuilt needs **glibc ≥2.38** and doesn't
+exist for **Intel macOS** or **musl/Alpine Linux**. On any of those — an older glibc (e.g. Ubuntu
+22.04), Intel Mac, or musl — build the pure-Rust embedder instead (real embeddings, no ONNX):
+
+```bash
+cargo install rag-rat --no-default-features --features model2vec
+```
+
+`--no-default-features` alone gives a smaller hash-only build with no real embeddings. SQLite is
+bundled (compiled in via `rusqlite`), so there is no system-library prerequisite — see
+[Platform support](#platform-support) for the per-OS C-toolchain note. On Android/Termux, `cargo
+install rag-rat` also builds from source (needs the `rust` package).
+
+**Then add the agent skills** so your agent actually reaches for the index:
+
+```bash
+npx @rag-rat/skills
+```
+
+See [Quickstart](#quickstart) for what the skills do and the one-time `rag-rat init` setup.
 
 ## Quickstart
 
@@ -388,7 +419,9 @@ indexed targets so they're never chunked or embedded, and keep secrets out of qu
 
 rag-rat builds and tests on Linux, macOS, and Windows. Linux is covered on every PR and on every
 push to main; macOS and Windows are exercised on release, so `cargo install rag-rat` builds and
-links on all three.
+links on all three. Android (aarch64, bionic) is also a release target — a prebuilt binary is
+attached to each release and published to `@rag-rat/bin`, so `npx @rag-rat/bin` works on Termux; see
+[Install](#install).
 SQLite is bundled (compiled from source via `rusqlite`), so there's no system-library prerequisite,
 but each platform needs a C toolchain: Linux ships one; on macOS install the Xcode Command Line
 Tools (`xcode-select --install`); on Windows install the Visual Studio Build Tools with the C++

--- a/dist-android/README.md
+++ b/dist-android/README.md
@@ -1,0 +1,24 @@
+# dist-android
+
+Android/Termux release machinery that cargo-dist can't provide itself.
+
+cargo-dist does not treat android as a supported platform: `dist plan --target aarch64-linux-android`
+skips every installer, so the generated release workflow neither cross-compiles the android binary
+nor teaches the `@rag-rat/bin` npm installer about it. `.github/workflows/release-android.yml` fills
+both gaps on the same release cargo-dist publishes, using the scripts here:
+
+- **`patch-npm-package.mjs`** — run against cargo-dist's own `@rag-rat/bin` package (downloaded from
+  the release as `rag-rat-npm-package.tar.gz`). Adds an `aarch64-linux-android` entry to
+  `supportedPlatforms` and a `process.platform === "android"` short-circuit to `binary.js`
+  `getPlatform()` (on Termux `os.type()` reports `"Linux"`, so the stock glibc/musl detection would
+  mis-resolve). The `getPlatform()` anchor is whitespace-tolerant but still fails loudly if the
+  function is gone, so a real cargo-dist template change forces a re-review instead of shipping broken.
+- **`test-npm-package.cjs`** — run after patching (with deps installed): asserts Termux/android
+  resolves to the android tarball and a desktop platform still resolves to its own artifact.
+
+cargo-dist's own npm publisher is disabled (`publish-jobs = []` in `dist-workspace.toml`) so
+release-android.yml is the sole publisher of `@rag-rat/bin` — otherwise it would republish the
+android-less package under the same version. The android binary is the full build: FastEmbed's ONNX
+Runtime is statically linked (pyke ships an `aarch64-linux-android` prebuilt), so only bionic +
+`libc++_shared` are needed at runtime, both present on Termux. Requires the jemalloc-off-android gate
+(the allocator's `-lgcc` link fails on NDK r23+).

--- a/dist-android/patch-npm-package.mjs
+++ b/dist-android/patch-npm-package.mjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+// Inject aarch64-linux-android support into the cargo-dist-generated @rag-rat/bin npm package.
+//
+// cargo-dist does not treat android as a supported platform: `dist plan --target
+// aarch64-linux-android` skips every installer ("not building any supported platforms"). So the
+// generated npm installer omits android from its supportedPlatforms map and has no android branch
+// in getPlatform(). Termux/Android needs the bionic aarch64-linux-android binary, which we build and
+// attach to the GitHub release separately (release-android.yml).
+//
+// This runs on the freshly generated package BEFORE publish and:
+//   1. adds an `aarch64-linux-android` entry to package.json `supportedPlatforms`, and
+//   2. inserts a `process.platform === "android"` short-circuit at the top of binary.js
+//      getPlatform() — os.type() reports "Linux" on Termux, so the stock glibc/musl detection would
+//      mis-resolve to a triple that either errors or downloads a non-bionic binary.
+//
+// It FAILS LOUDLY if the expected structure is absent: a cargo-dist upgrade that changes the npm
+// template must be re-reviewed, never silently shipped as a broken package.
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const ANDROID_TRIPLE = "aarch64-linux-android";
+
+// `.tar.gz`, not cargo-dist's default `.tar.xz`: Termux always ships gzip, but `xz-utils` is an
+// extra package the installer's `tar xf` would otherwise silently need.
+const ANDROID_ENTRY = {
+  artifactName: `rag-rat-${ANDROID_TRIPLE}.tar.gz`,
+  bins: { "rag-rat": "rag-rat" },
+  zipExt: ".tar.gz",
+};
+
+// Injected verbatim right after `const getPlatform = () => {`. Uses only identifiers already in
+// binary.js scope: os, supportedPlatforms, error, name.
+const ANDROID_BRANCH = `  // Termux/Android reports os.type() === "Linux" but process.platform === "android", and needs the
+  // bionic aarch64-linux-android build (not a glibc/musl one). Resolve it before the Linux/libc path.
+  if (process.platform === "android") {
+    let androidArch = "";
+    switch (os.arch()) {
+      case "arm64":
+        androidArch = "aarch64";
+        break;
+      case "x64":
+        androidArch = "x86_64";
+        break;
+    }
+    const androidPlatform = supportedPlatforms[\`\${androidArch}-linux-android\`];
+    if (!androidPlatform) {
+      error(
+        \`Platform with type "android" and architecture "\${os.arch()}" is not supported by \${name}.\`,
+      );
+    }
+    return androidPlatform;
+  }
+`;
+
+function fail(msg) {
+  console.error(`patch-npm-package: ${msg}`);
+  process.exit(1);
+}
+
+const pkgDir = process.argv[2] || "target/distrib/rag-rat-npm-package";
+
+// 1. package.json supportedPlatforms
+const pkgPath = join(pkgDir, "package.json");
+const pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
+if (!pkg.supportedPlatforms || typeof pkg.supportedPlatforms !== "object") {
+  fail(`${pkgPath}: no supportedPlatforms object — cargo-dist npm template changed, re-review`);
+}
+if (pkg.supportedPlatforms[ANDROID_TRIPLE]) {
+  fail(`${pkgPath}: ${ANDROID_TRIPLE} already present — double patch?`);
+}
+pkg.supportedPlatforms[ANDROID_TRIPLE] = ANDROID_ENTRY;
+writeFileSync(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`);
+
+// 2. binary.js getPlatform() short-circuit. Match the function's opening brace tolerantly — the
+// whitespace/newline after `{` can shift across cargo-dist template revisions — and inject the branch
+// as its first statement. Still fails loudly if getPlatform() is gone entirely (a real template change).
+const binPath = join(pkgDir, "binary.js");
+let bin = readFileSync(binPath, "utf8");
+const anchorRe = /const getPlatform = \(\) => \{[ \t]*\r?\n?/;
+if (!anchorRe.test(bin)) {
+  fail(`${binPath}: getPlatform() opening not found — cargo-dist npm template changed, re-review`);
+}
+if (bin.includes('process.platform === "android"')) {
+  fail(`${binPath}: android branch already present — double patch?`);
+}
+bin = bin.replace(anchorRe, (opening) => opening + ANDROID_BRANCH);
+writeFileSync(binPath, bin);
+
+console.error(`patch-npm-package: injected ${ANDROID_TRIPLE} into ${pkgDir}`);

--- a/dist-android/test-npm-package.cjs
+++ b/dist-android/test-npm-package.cjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+// Validates the android-patched @rag-rat/bin package: run AFTER patch-npm-package.mjs against the
+// same package dir, with its deps installed (binary.js requires detect-libc). Asserts that
+//   - Termux/Android (process.platform="android", os.arch="arm64") resolves to the android tarball, and
+//   - a desktop platform (Darwin/arm64) still resolves to its own artifact (no regression).
+// Exits non-zero on mismatch so the release workflow refuses to publish a broken installer.
+
+const os = require("os");
+const path = require("path");
+const assert = require("assert");
+
+const pkgDir = path.resolve(process.argv[2] || "target/distrib/rag-rat-npm-package");
+const binaryPath = path.join(pkgDir, "binary.js");
+const pkgJsonPath = path.join(pkgDir, "package.json");
+
+// Load a fresh binary.js under a faked os.type()/os.arch()/process.platform, and return the
+// download URL getPackage() would fetch. Cache-busts so each case re-evaluates getPlatform().
+function urlUnder({ platform, type, arch }) {
+  const origType = os.type;
+  const origArch = os.arch;
+  const origPlatform = process.platform;
+  os.type = () => type;
+  os.arch = () => arch;
+  Object.defineProperty(process, "platform", { value: platform, configurable: true });
+  try {
+    delete require.cache[binaryPath];
+    delete require.cache[pkgJsonPath];
+    const binary = require(binaryPath);
+    return binary.getPackage().url;
+  } finally {
+    os.type = origType;
+    os.arch = origArch;
+    Object.defineProperty(process, "platform", { value: origPlatform, configurable: true });
+  }
+}
+
+const androidUrl = urlUnder({ platform: "android", type: "Linux", arch: "arm64" });
+assert.ok(
+  androidUrl.endsWith("/rag-rat-aarch64-linux-android.tar.gz"),
+  `Termux/android should resolve to the android tarball, got: ${androidUrl}`,
+);
+
+// Desktop regression guard: Darwin/arm64 takes no libc branch, so it needs no detect-libc mocking.
+const darwinUrl = urlUnder({ platform: "darwin", type: "Darwin", arch: "arm64" });
+assert.ok(
+  darwinUrl.endsWith("/rag-rat-aarch64-apple-darwin.tar.xz"),
+  `desktop (darwin/arm64) should still resolve to apple-darwin, got: ${darwinUrl}`,
+);
+
+console.error("test-npm-package: android + desktop resolution OK");
+console.error(`  android: ${androidUrl}`);
+console.error(`  darwin:  ${darwinUrl}`);

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -18,9 +18,15 @@ installers = ["shell", "powershell", "npm"]
 # Publish the npm installer as `@rag-rat/bin` (alongside @rag-rat/skills, @rag-rat/setup).
 npm-scope = "@rag-rat"
 npm-package = "bin"
-# On each release, publish `@rag-rat/bin` to the npm registry. The release job reads the `NPM_TOKEN`
-# repo secret (must have publish rights to the @rag-rat org); scoped packages publish `--access public`.
-publish-jobs = ["npm"]
+# npm publish is handled by .github/workflows/release-android.yml, NOT cargo-dist. That workflow
+# regenerates this same package, injects aarch64-linux-android support (which cargo-dist can't build
+# or describe — `dist plan --target aarch64-linux-android` skips every installer), and publishes the
+# result as the SOLE publisher of `@rag-rat/bin`. Leaving cargo-dist's own npm publisher on would
+# republish the android-less package under the same version (a collision). `npm` stays in `installers`
+# above so cargo-dist still ATTACHES the package (rag-rat-npm-package.tar.gz) to the release for that
+# workflow to download + patch; the `NPM_TOKEN` repo secret (publish rights to the @rag-rat org) is
+# read there.
+publish-jobs = []
 # Target platforms to build apps for (Rust target-triple syntax).
 # NOTE: x86_64-apple-darwin (Intel Mac) is intentionally absent — `ort` ships no prebuilt ONNX
 # Runtime for that target (ort-sys build/download/dist.txt lists aarch64- but not x86_64-apple-darwin),


### PR DESCRIPTION
## Problem

`npx @rag-rat/bin` and `cargo install rag-rat` had no Android/Termux path — no android binary was built, and the dist matrix omitted the target (#616). Termux is bionic libc, so the glibc linux build won't run there either.

## What this does

The android binary builds **fully**: FastEmbed statically links a pyke `aarch64-linux-android` ONNX Runtime, so it's self-contained (only bionic + `libc++_shared` at runtime, both present on Termux). But **cargo-dist doesn't support android as a platform** — `dist plan --target aarch64-linux-android` skips every installer — so it can't build or distribute it. This adds the missing pieces:

- **`.github/workflows/release-android.yml`** (rides the same tag push as cargo-dist's `release.yml`):
  - `build-android` — cross-compiles via cargo-ndk + the runner NDK, waits for cargo-dist to create the release, and attaches `rag-rat-aarch64-linux-android.tar.gz`.
  - `publish-npm` — downloads cargo-dist's own attached npm package, waits for the desktop assets, injects android support, verifies resolution, and publishes `@rag-rat/bin`.
- **`dist-android/`** — `patch-npm-package.mjs` adds the android `supportedPlatforms` entry + a `process.platform === "android"` branch (Termux's `os.type()` reports `"Linux"`, so stock glibc/musl detection mis-resolves), with a whitespace-tolerant `getPlatform()` anchor that fails loudly if cargo-dist's template genuinely changes; `test-npm-package.cjs` asserts android → android tarball and desktop → unchanged.
- **`dist-workspace.toml`** — `publish-jobs = []` so release-android.yml is the sole npm publisher (otherwise cargo-dist would republish the android-less package under the same version); `npm` stays in `installers` so the package tarball is still attached to the release; regenerated `release.yml` to match.
- **README** — install now leads with the prebuilt `npx @rag-rat/bin` (qualified to the platforms actually built: Apple Silicon macOS, glibc Linux, Windows x64, Android/Termux), keeps `cargo install`, routes Intel Mac / musl to the `--no-default-features --features model2vec` source build, and points at `@rag-rat/skills`.

## Design notes

- Triggered on the **tag push**, not `release: published` — cargo-dist creates the release with the default `GITHUB_TOKEN`, and GitHub suppresses downstream `release` events from `GITHUB_TOKEN` (verified: v0.16.0 was authored by `github-actions[bot]` and no `release:`-triggered workflow ran on it). release-plz pushes the tag with a PAT, which is what fires the tag-push workflows (cargo-dist's `release.yml` included). The two race, so `build-android` waits for the release, and `publish-npm` waits for its assets.
- `publish-npm` downloads cargo-dist's own attached `rag-rat-npm-package.tar.gz` (so the published package is byte-identical to cargo-dist's for desktop), waits for **all desktop assets**, and runs `npm ci --ignore-scripts` — so it never publishes an installer that 404s a desktop user, and never triggers a binary download during CI.
- Prereleases skip (`!contains(github.ref_name, '-')`), matching cargo-dist's default.
- The npm publish depends on the android build passing; re-run the workflow if the android build fails.

## Verification

Everything except the actual npm publish + on-device Termux run is verified locally: the cross-compile links (needs #615), and the full npm flow against the **real attached release tarball** — download → patch → resolution test (android → android, desktop → unchanged) → `npm publish --dry-run` clean; the desktop-asset wait resolves to the correct four archives; `dist generate --check` passes.

Depends on #615 (merged). Fixes #616