### PR TITLE
ci(release): dedicated release-npm.yml (bin + skills + cookbook); glama uses the prebuilt @rag-rat/bin

### DIFF
--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -2,15 +2,14 @@
 #
 # cargo-dist does not support android as a platform (`dist plan --target aarch64-linux-android` skips
 # every installer), so the release workflow it generates neither builds the android binary nor teaches
-# @rag-rat/bin about it. This workflow fills both gaps:
+# @rag-rat/bin about it. This workflow builds the android binary and attaches it to the release:
 #
 #   build-android : cross-compile rag-rat for aarch64-linux-android (bionic) with the NDK + cargo-ndk,
 #                   and attach rag-rat-aarch64-linux-android.tar.gz to the GitHub release.
-#   publish-npm   : download cargo-dist's own npm package (attached to the release), inject android
-#                   support (dist-android/patch-npm-package.mjs), prove it resolves
-#                   (test-npm-package.cjs), then publish @rag-rat/bin. cargo-dist's own npm publish is
-#                   disabled (publish-jobs = [] in dist-workspace.toml) so there is no version
-#                   collision — this is the sole publisher.
+#
+# The npm publish that injects this android archive into @rag-rat/bin lives in release-npm.yml (the
+# sole npm publisher — cargo-dist's own npm publish is disabled, publish-jobs = [] in
+# dist-workspace.toml). release-npm.yml waits for this workflow's android asset before publishing.
 #
 # Triggered on the SAME tag push as cargo-dist's release.yml (`on: push: tags`), NOT `release:
 # published`. Flow: release-plz pushes the vX.Y.Z tag with a PAT (RELEASE_PLZ_TOKEN), which fires
@@ -40,9 +39,10 @@ env:
 
 jobs:
   build-android:
-    # Skip prereleases, matching cargo-dist's own npm publisher default — a prerelease must not become
-    # the npm `latest` dist-tag. A semver prerelease tag carries a `-` (v1.2.3-rc.1); a normal release
-    # tag (v1.2.3) does not. publish-npm needs this job, so it skips too.
+    # Skip prereleases: a prerelease's android archive must not feed the npm `latest` installer. A
+    # semver prerelease tag carries a `-` (v1.2.3-rc.1); a normal release tag (v1.2.3) does not.
+    # release-npm.yml skips prereleases the same way, so the android asset and the npm publish stay
+    # consistent.
     if: ${{ !contains(github.ref_name, '-') }}
     runs-on: ubuntu-latest
     steps:
@@ -99,73 +99,3 @@ jobs:
           gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null # fail loudly if still absent
           gh release upload "$TAG" "${STAGE}.tar.gz" "${STAGE}.tar.gz.sha256" \
             --repo "$GITHUB_REPOSITORY" --clobber
-
-  publish-npm:
-    if: ${{ !contains(github.ref_name, '-') }}
-    runs-on: ubuntu-latest
-    needs: build-android # the android asset must exist before the installer that points at it ships
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-          registry-url: "https://registry.npmjs.org"
-      - name: Fetch cargo-dist's npm package + wait for its desktop assets
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ github.ref_name }}
-        run: |
-          set -euo pipefail
-          # Use cargo-dist's OWN generated npm package (attached to the release as
-          # rag-rat-npm-package.tar.gz) rather than regenerating it here — the published package is then
-          # byte-identical to cargo-dist's for every desktop platform, and this job needs no dist
-          # install. Wait for the tarball to appear (both workflows race on the tag push), download it.
-          for i in $(seq 1 180); do
-            gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json assets --jq '.assets[].name' 2>/dev/null \
-              | grep -qxF "rag-rat-npm-package.tar.gz" && break
-            echo "waiting for npm package artifact ($i/180)…"
-            sleep 15
-          done
-          gh release download "$TAG" --repo "$GITHUB_REPOSITORY" -p "rag-rat-npm-package.tar.gz" -D . --clobber
-          mkdir -p pkg && tar xzf rag-rat-npm-package.tar.gz -C pkg --strip-components 1
-          # The package lists exactly the desktop archives the installer will point users at. gh release
-          # create exposes the release before those finish uploading, so wait until each is present —
-          # otherwise a desktop `npm i @rag-rat/bin` could 404.
-          mapfile -t EXPECTED < <(node -e '
-            const p = require("./pkg/package.json");
-            for (const k of Object.keys(p.supportedPlatforms)) console.log(p.supportedPlatforms[k].artifactName);
-          ' | sort -u)
-          echo "expecting desktop assets: ${EXPECTED[*]}"
-          for i in $(seq 1 180); do
-            present="$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json assets --jq '.assets[].name' || true)"
-            missing=""
-            for a in "${EXPECTED[@]}"; do
-              printf '%s\n' "$present" | grep -qxF "$a" || missing="$missing $a"
-            done
-            if [ -z "$missing" ]; then echo "all desktop assets present"; break; fi
-            echo "waiting for desktop assets ($i/180):$missing"
-            sleep 15
-          done
-          present="$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json assets --jq '.assets[].name')"
-          for a in "${EXPECTED[@]}"; do
-            printf '%s\n' "$present" | grep -qxF "$a" || { echo "desktop asset never appeared: $a"; exit 1; }
-          done
-      - name: Inject android support
-        run: node dist-android/patch-npm-package.mjs pkg
-      - name: Verify the patched installer resolves android + desktop
-        working-directory: pkg
-        run: |
-          # We only need detect-libc present so binary.js can be require()d by the resolution test.
-          # `npm install` (not `npm ci`) so it works whether or not the package ships a lockfile — we
-          # don't need a reproducible install here. --ignore-scripts is load-bearing: this package's own
-          # `postinstall` (install.js) DOWNLOADS the platform binary from the release, which we neither
-          # need nor want here (getPackage resolves a URL, it doesn't download).
-          npm install --omit=dev --ignore-scripts
-          node "$GITHUB_WORKSPACE/dist-android/test-npm-package.cjs" .
-      - name: Publish @rag-rat/bin
-        working-directory: pkg
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --access public

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -96,11 +96,21 @@ jobs:
           # binary from the release, which we neither need nor want here (getPackage resolves a URL).
           npm install --omit=dev --ignore-scripts
           node "$GITHUB_WORKSPACE/dist-android/test-npm-package.cjs" .
-      - name: Publish @rag-rat/bin
+      - name: Publish @rag-rat/bin (only if this version is new)
         working-directory: pkg
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --access public
+        run: |
+          set -euo pipefail
+          # Guard the same way as the auxiliary packages below: npm rejects re-publishing a version,
+          # so without this a transient failure AFTER @rag-rat/bin published would make every rerun
+          # die here and never reach the skills/cookbook steps. Skip if it's already up.
+          ver="$(node -p "require('./package.json').version")"
+          if npm view "@rag-rat/bin@$ver" version >/dev/null 2>&1; then
+            echo "@rag-rat/bin@$ver already on npm — skipping so a rerun can finish the release"
+          else
+            npm publish --access public
+          fi
 
       # ── @rag-rat/skills + @rag-rat/cookbook: publish only when their version is new ───────────────
       - name: Publish @rag-rat/skills (only if this version is new)

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -1,0 +1,132 @@
+# The SOLE npm publisher for a release — @rag-rat/bin plus the auxiliary packages.
+#
+# Rides the SAME tag push as cargo-dist's release.yml and release-android.yml. release-plz pushes the
+# vX.Y.Z tag with a PAT (RELEASE_PLZ_TOKEN), which fires tag-push workflows; a `release: published`
+# trigger would NOT fire for a GITHUB_TOKEN-created release. cargo-dist's own npm publish is disabled
+# (publish-jobs = [] in dist-workspace.toml) so this is the only publisher — no version collision.
+#
+#   @rag-rat/bin      — cargo-dist's generated installer package with aarch64-linux-android injected.
+#                       release.yml builds the desktop archives; release-android.yml builds + attaches
+#                       the android archive; this job waits for ALL of them on the release, patches
+#                       android in, proves it resolves, and publishes. (Previously lived in
+#                       release-android.yml; moved here so npm publishing is not buried in the android
+#                       workflow.)
+#   @rag-rat/skills   — the agent-skills installer (a thin wrapper; the skills are fetched from GitHub).
+#   @rag-rat/cookbook — the ephemeral-provisioning recipes.
+#
+# @rag-rat/skills and @rag-rat/cookbook are versioned INDEPENDENTLY of the crate, so each publishes
+# only when its package.json version is not already on npm — a re-run, or a release that didn't bump
+# them, is a no-op. (`npm publish` also rejects a duplicate version, so the guard is belt-and-braces.)
+name: release-npm
+
+on:
+  push:
+    tags:
+      - "**[0-9]+.[0-9]+.[0-9]+*"
+
+permissions:
+  contents: read # read the release assets (publishing goes to npm via NPM_TOKEN)
+
+jobs:
+  publish:
+    # Skip prereleases — a `-` tag (v1.2.3-rc.1) must not become the npm `latest` dist-tag. Matches
+    # release-android.yml's build-android skip, so a prerelease attaches no android asset either.
+    if: ${{ !contains(github.ref_name, '-') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+
+      # ── @rag-rat/bin: cargo-dist's package + injected android, published as the unified installer ──
+      - name: Fetch cargo-dist's npm package + wait for all platform assets (desktop + android)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          # Use cargo-dist's OWN generated npm package (attached to the release as
+          # rag-rat-npm-package.tar.gz) rather than regenerating it — the published package is then
+          # byte-identical to cargo-dist's for every desktop platform. All release workflows race on the
+          # tag push, so wait for the tarball to appear, then download it.
+          for i in $(seq 1 180); do
+            gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json assets --jq '.assets[].name' 2>/dev/null \
+              | grep -qxF "rag-rat-npm-package.tar.gz" && break
+            echo "waiting for npm package artifact ($i/180)…"
+            sleep 15
+          done
+          gh release download "$TAG" --repo "$GITHUB_REPOSITORY" -p "rag-rat-npm-package.tar.gz" -D . --clobber
+          mkdir -p pkg && tar xzf rag-rat-npm-package.tar.gz -C pkg --strip-components 1
+          # The package lists the desktop archives the installer points users at; gh release create
+          # exposes the release before those finish uploading, so wait until each is present (else a
+          # desktop `npm i @rag-rat/bin` could 404). ALSO wait for the android archive that
+          # release-android.yml attaches — this cross-workflow wait is what replaces the old in-workflow
+          # `needs: build-android`.
+          mapfile -t EXPECTED < <(node -e '
+            const p = require("./pkg/package.json");
+            for (const k of Object.keys(p.supportedPlatforms)) console.log(p.supportedPlatforms[k].artifactName);
+          ' | sort -u)
+          EXPECTED+=("rag-rat-aarch64-linux-android.tar.gz")
+          echo "expecting assets: ${EXPECTED[*]}"
+          for i in $(seq 1 180); do
+            present="$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json assets --jq '.assets[].name' || true)"
+            missing=""
+            for a in "${EXPECTED[@]}"; do
+              printf '%s\n' "$present" | grep -qxF "$a" || missing="$missing $a"
+            done
+            if [ -z "$missing" ]; then echo "all platform assets present"; break; fi
+            echo "waiting for platform assets ($i/180):$missing"
+            sleep 15
+          done
+          present="$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json assets --jq '.assets[].name')"
+          for a in "${EXPECTED[@]}"; do
+            printf '%s\n' "$present" | grep -qxF "$a" || { echo "asset never appeared: $a"; exit 1; }
+          done
+      - name: Inject android support
+        run: node dist-android/patch-npm-package.mjs pkg
+      - name: Verify the patched installer resolves android + desktop
+        working-directory: pkg
+        run: |
+          # detect-libc must be present so binary.js can be require()d by the resolution test.
+          # --ignore-scripts is load-bearing: this package's own postinstall DOWNLOADS the platform
+          # binary from the release, which we neither need nor want here (getPackage resolves a URL).
+          npm install --omit=dev --ignore-scripts
+          node "$GITHUB_WORKSPACE/dist-android/test-npm-package.cjs" .
+      - name: Publish @rag-rat/bin
+        working-directory: pkg
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public
+
+      # ── @rag-rat/skills + @rag-rat/cookbook: publish only when their version is new ───────────────
+      - name: Publish @rag-rat/skills (only if this version is new)
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          set -euo pipefail
+          name="$(node -p "require('./skills/package.json').name")"
+          ver="$(node -p "require('./skills/package.json').version")"
+          if npm view "$name@$ver" version >/dev/null 2>&1; then
+            echo "$name@$ver already on npm — skipping"
+          else
+            echo "publishing $name@$ver"
+            (cd skills && npm publish --access public)
+          fi
+      - name: Publish @rag-rat/cookbook (only if this version is new)
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          set -euo pipefail
+          name="$(node -p "require('./cookbook/package.json').name")"
+          ver="$(node -p "require('./cookbook/package.json').version")"
+          if npm view "$name@$ver" version >/dev/null 2>&1; then
+            echo "$name@$ver already on npm — skipping"
+          else
+            echo "publishing $name@$ver"
+            # `npm ci` restores devDeps (typescript/tsx) so the prepack `tsc` can build dist/.
+            (cd cookbook && npm ci && npm publish --access public)
+          fi

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -18,14 +18,14 @@ installers = ["shell", "powershell", "npm"]
 # Publish the npm installer as `@rag-rat/bin` (alongside @rag-rat/skills, @rag-rat/setup).
 npm-scope = "@rag-rat"
 npm-package = "bin"
-# npm publish is handled by .github/workflows/release-android.yml, NOT cargo-dist. That workflow
-# regenerates this same package, injects aarch64-linux-android support (which cargo-dist can't build
-# or describe — `dist plan --target aarch64-linux-android` skips every installer), and publishes the
-# result as the SOLE publisher of `@rag-rat/bin`. Leaving cargo-dist's own npm publisher on would
-# republish the android-less package under the same version (a collision). `npm` stays in `installers`
-# above so cargo-dist still ATTACHES the package (rag-rat-npm-package.tar.gz) to the release for that
-# workflow to download + patch; the `NPM_TOKEN` repo secret (publish rights to the @rag-rat org) is
-# read there.
+# npm publish is handled by .github/workflows/release-npm.yml, NOT cargo-dist. That workflow downloads
+# this generated package, injects aarch64-linux-android support (which cargo-dist can't build or
+# describe — `dist plan --target aarch64-linux-android` skips every installer), and publishes the
+# result as the SOLE publisher of `@rag-rat/bin` (release-android.yml builds + attaches the android
+# archive that release-npm.yml waits for). Leaving cargo-dist's own npm publisher on would republish
+# the android-less package under the same version (a collision). `npm` stays in `installers` above so
+# cargo-dist still ATTACHES the package (rag-rat-npm-package.tar.gz) to the release for release-npm.yml
+# to download + patch; the `NPM_TOKEN` repo secret (publish rights to the @rag-rat org) is read there.
 publish-jobs = []
 # Target platforms to build apps for (Rust target-triple syntax).
 # NOTE: x86_64-apple-darwin (Intel Mac) is intentionally absent — `ort` ships no prebuilt ONNX

--- a/glama.Dockerfile
+++ b/glama.Dockerfile
@@ -1,43 +1,33 @@
 # Local reproduction of Glama's hosted MCP build for cq27-dev/rag-rat.
 #
-# Glama builds from its own Build Spec (base image + node + mcp-proxy, clone repo, then `buildSteps`,
-# then `cmdArguments`), NOT from this file. This Dockerfile bundles the same steps into one runnable
-# image so the Glama build can be reproduced and tested locally. The Build Spec's `buildSteps` must
-# install a Rust toolchain and `cargo install` rag-rat (Glama's base has none), and `cmdArguments`
-# must be `mcp-proxy -- rag-rat --config /workspace/rag-rat.toml mcp` — mcp-proxy spawns rag-rat as a
-# stdio MCP server and exposes it at :8080/mcp (+/sse) with the /ping health check Glama polls.
+# Glama builds from its own Build Spec (base image + node + mcp-proxy, then buildSteps, then
+# cmdArguments), NOT from this file. This Dockerfile bundles the same steps into one runnable image so
+# the Glama build can be reproduced + tested locally. buildSteps install the PREBUILT rag-rat CLI from
+# npm (@rag-rat/bin — no Rust toolchain, no compile), and cmdArguments must be
+# `mcp-proxy -- rag-rat --config /workspace/rag-rat.toml mcp` — mcp-proxy spawns rag-rat as a stdio
+# MCP server at :8080/mcp (+/sse) with the /ping health check Glama polls.
 #
-# The server roots itself in a tiny sample repo with embeddings off, so introspection
-# (initialize + tools/list, served from a static catalog) boots instantly — no model download,
-# no outbound network.
+# @rag-rat/bin is installed at BUILD time (its postinstall fetches the platform prebuilt), so the
+# server roots itself in a tiny sample repo with embeddings off and boots instantly — no model
+# download, no cargo compile, no outbound network at runtime.
 FROM debian:trixie-slim
 
 ENV DEBIAN_FRONTEND=noninteractive \
     GLAMA_VERSION="1.0.0" \
     PYTHONUNBUFFERED=1 \
-    RAG_RAT_NO_WATCH=1 \
-    RUSTUP_HOME=/usr/local/rustup \
-    CARGO_HOME=/usr/local/cargo \
-    PATH="/usr/local/cargo/bin:/app/node_modules/.bin:$PATH"
+    RAG_RAT_NO_WATCH=1
 
-# node + mcp-proxy (Glama's harness); build-essential/pkg-config for rusqlite's bundled SQLite (cc);
-# rustup toolchain pinned to satisfy rag-rat's 1.95+ MSRV.
+# node + mcp-proxy (Glama's harness) + git (rag-rat roots itself in a git worktree). No Rust
+# toolchain / build-essential: rag-rat is the prebuilt @rag-rat/bin npm package. `npm i -g @rag-rat/bin`
+# runs its postinstall, which downloads the platform binary (glibc >=2.38 — trixie has it; FastEmbed's
+# ONNX Runtime is statically linked, so no libonnxruntime.so at runtime) and puts `rag-rat` on PATH.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        ca-certificates curl git build-essential pkg-config \
+        ca-certificates curl git \
     && curl -fsSL https://deb.nodesource.com/setup_26.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
-    && npm install -g mcp-proxy@6.4.3 \
-    && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
-         | sh -s -- -y --default-toolchain 1.96.0 --profile minimal \
+    && npm install -g mcp-proxy@6.4.3 @rag-rat/bin@latest \
+    && rag-rat --version \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-WORKDIR /app
-# Track main HEAD, matching the Glama Build Spec's `pinnedCommit: null`.
-RUN git clone --depth 1 https://github.com/cq27-dev/rag-rat .
-
-# Hash-only build (no FastEmbed) -> small and offline; identical MCP tool surface for introspection.
-RUN cargo install --locked --path crates/rag-rat-cli --bin rag-rat \
-        --no-default-features --root /usr/local
 
 # Minimal sample repo the server roots itself in. Absolute paths so it's CWD-independent;
 # model="none" (BM25-only) downloads nothing; watcher + crates.io version check disabled.

--- a/glama.Dockerfile
+++ b/glama.Dockerfile
@@ -17,12 +17,13 @@ ENV DEBIAN_FRONTEND=noninteractive \
     PYTHONUNBUFFERED=1 \
     RAG_RAT_NO_WATCH=1
 
-# node + mcp-proxy (Glama's harness) + git (rag-rat roots itself in a git worktree). No Rust
-# toolchain / build-essential: rag-rat is the prebuilt @rag-rat/bin npm package. `npm i -g @rag-rat/bin`
-# runs its postinstall, which downloads the platform binary (glibc >=2.38 — trixie has it; FastEmbed's
-# ONNX Runtime is statically linked, so no libonnxruntime.so at runtime) and puts `rag-rat` on PATH.
+# node + mcp-proxy (Glama's harness) + git (rag-rat roots itself in a git worktree) + xz-utils (the
+# postinstall extracts cargo-dist's `.tar.xz` Linux archive — `tar` alone can't). No Rust toolchain /
+# build-essential: rag-rat is the prebuilt @rag-rat/bin npm package. `npm i -g @rag-rat/bin` runs its
+# postinstall, which downloads the platform binary (glibc >=2.38 — trixie has it; FastEmbed's ONNX
+# Runtime is statically linked, so no libonnxruntime.so at runtime) and puts `rag-rat` on PATH.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        ca-certificates curl git \
+        ca-certificates curl git xz-utils \
     && curl -fsSL https://deb.nodesource.com/setup_26.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
     && npm install -g mcp-proxy@6.4.3 @rag-rat/bin@latest \


### PR DESCRIPTION
Two related changes so the repo leans on the published npm packages instead of ad-hoc placement / source builds.

## `release-npm.yml` — one npm publisher

npm publishing lived inside the *android* workflow (`release-android.yml`), which read as a mistake (`# npm publish is handled by release-android.yml, NOT cargo-dist`). Moved it all into a dedicated `release-npm.yml`, the **sole npm publisher** (cargo-dist's own stays disabled, `publish-jobs = []`):

- **`@rag-rat/bin`** — moved verbatim from `release-android.yml`. It waits for the android archive on the release (a cross-workflow poll that replaces the old in-workflow `needs: build-android`) plus the desktop assets, injects android (`patch-npm-package.mjs`), verifies resolution, and publishes.
- **`@rag-rat/skills` + `@rag-rat/cookbook`** — now auto-published too, closing the gap where recipe/skill-wrapper updates needed a manual `npm publish`. They're versioned **independently** of the crate, so each publishes **only when its `package.json` version isn't already on npm** (a re-run / untouched release is a no-op; `npm publish` also rejects a duplicate version as a backstop).

`release-android.yml` keeps only the android **binary** build + attach; its header and the `dist-workspace.toml` comment now point at `release-npm.yml`.

## glama image uses the prebuilt binary

`glama.Dockerfile` installed a full Rust toolchain and `cargo install`-ed rag-rat from a source clone. Now it `npm i -g @rag-rat/bin` — the platform prebuilt, fetched at build time. Much smaller/faster image, no toolchain; runtime stays offline + instant (`model="none"`, introspection only).

**Note:** to actually ship an updated `@rag-rat/skills` or `@rag-rat/cookbook`, bump its `package.json` version in the PR that changes it — the workflow publishes on version-change, not on every release.