### PR TITLE
feat(account): C1 candidate-DAG storage — ingest, refold + branch selection (V059)

### DIFF
--- a/crates/rag-rat-core/src/index/schema/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema/migrations.rs
@@ -1245,6 +1245,7 @@ pub(crate) fn known_version(migrations: &[AppliedMigration]) -> u32 {
             MIGRATION_056_ID => Some(56),
             MIGRATION_057_ID => Some(57),
             MIGRATION_058_ID => Some(58),
+            MIGRATION_059_ID => Some(59),
             _ => None,
         })
         .max()
@@ -1312,6 +1313,7 @@ pub(crate) fn known_migration(id: &str) -> bool {
             | MIGRATION_056_ID
             | MIGRATION_057_ID
             | MIGRATION_058_ID
+            | MIGRATION_059_ID
             | DIRTY_MIGRATION_ID
     )
 }
@@ -1376,6 +1378,7 @@ pub(crate) fn migration_checksum_mismatch(migration: &AppliedMigration) -> bool 
         MIGRATION_056_ID => migration.checksum != MIGRATION_056_CHECKSUM,
         MIGRATION_057_ID => migration.checksum != MIGRATION_057_CHECKSUM,
         MIGRATION_058_ID => migration.checksum != MIGRATION_058_CHECKSUM,
+        MIGRATION_059_ID => migration.checksum != MIGRATION_059_CHECKSUM,
         _ => false,
     }
 }
@@ -3818,6 +3821,55 @@ pub(crate) fn apply_oplog_device_x25519(conn: &Connection) -> rusqlite::Result<(
     add_column_if_missing(conn, "oplog_device_identity", "x25519_secret", "BLOB")?;
     add_column_if_missing(conn, "oplog_device_identity", "x25519_public", "BLOB")?;
     Ok(())
+}
+
+/// V059 (sync phase C, §16.1): the account-log CANDIDATE DAG. `account_entries` stores EVERY
+/// structurally-valid, signature-valid account entry — all branches of an equivocating chain are
+/// first-class, so the candidate table has NO seq-uniqueness; grow-only (I8). The `accepted` flag
+/// is DERIVED, rewritten by every `refold_account` (the fold + branch selection §16.2), and the
+/// partial unique index `account_accepted_slot` pins accepted-set uniqueness per `(account, log,
+/// device, seq)` slot (I10a). `account_entry_status` holds the projected §16.3 taxonomy per entry;
+/// `account_pre_verify` durably holds an entry whose signing device can't yet be resolved
+/// (`sha256(pk) == fingerprint` not found among genesis + stored candidates), retried when a later
+/// DeviceAdd/AccountGenesis for the claimed account arrives (Codex-8). Idempotent — every statement
+/// is `CREATE ... IF NOT EXISTS`, so a torn replay reconverges without a wrapping txn.
+pub(crate) fn apply_account_candidate_dag(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS account_entries(
+             entry_hash         BLOB    PRIMARY KEY,
+             account_id         BLOB    NOT NULL,
+             log_id             INTEGER NOT NULL,
+             device_fingerprint BLOB    NOT NULL,
+             seq                INTEGER NOT NULL,
+             prev_hash          BLOB,
+             parent_ref         BLOB,
+             authority_ref      BLOB,
+             entry_type         INTEGER NOT NULL,
+             accepted           INTEGER NOT NULL DEFAULT 0,
+             signed_bytes       BLOB    NOT NULL,
+             received_at_ms     INTEGER NOT NULL
+         ) STRICT;
+
+         CREATE INDEX IF NOT EXISTS account_entries_chain
+             ON account_entries(account_id, log_id, device_fingerprint, seq);
+
+         CREATE UNIQUE INDEX IF NOT EXISTS account_accepted_slot
+             ON account_entries(account_id, log_id, device_fingerprint, seq) WHERE accepted = 1;
+
+         CREATE TABLE IF NOT EXISTS account_entry_status(
+             entry_hash BLOB PRIMARY KEY,
+             status     TEXT NOT NULL,
+             detail     TEXT
+         ) STRICT;
+
+         CREATE TABLE IF NOT EXISTS account_pre_verify(
+             entry_hash          BLOB    PRIMARY KEY,
+             claimed_account_id  BLOB    NOT NULL,
+             claimed_fingerprint BLOB    NOT NULL,
+             raw_bytes           BLOB    NOT NULL,
+             received_at_ms      INTEGER NOT NULL
+         ) STRICT;",
+    )
 }
 
 /// V055 (#492): the anchor-status downgrade hysteresis marker. INVARIANT: NULL means "no gone

--- a/crates/rag-rat-core/src/index/schema/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema/migrations.rs
@@ -3863,7 +3863,8 @@ pub(crate) fn apply_account_candidate_dag(conn: &Connection) -> rusqlite::Result
          ) STRICT;
 
          CREATE TABLE IF NOT EXISTS account_pre_verify(
-             entry_hash          BLOB    PRIMARY KEY,
+             signed_hash         BLOB    PRIMARY KEY,
+             entry_hash          BLOB    NOT NULL,
              claimed_account_id  BLOB    NOT NULL,
              claimed_fingerprint BLOB    NOT NULL,
              raw_bytes           BLOB    NOT NULL,

--- a/crates/rag-rat-core/src/index/schema/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema/migrations.rs
@@ -3868,7 +3868,12 @@ pub(crate) fn apply_account_candidate_dag(conn: &Connection) -> rusqlite::Result
              claimed_fingerprint BLOB    NOT NULL,
              raw_bytes           BLOB    NOT NULL,
              received_at_ms      INTEGER NOT NULL
-         ) STRICT;",
+         ) STRICT;
+
+         -- Promotion scans the queue by claimed_account_id while holding the ingest write lock;
+         -- index it so a backlog for OTHER accounts is never full-scanned per ingest.
+         CREATE INDEX IF NOT EXISTS account_pre_verify_account
+             ON account_pre_verify(claimed_account_id);",
     )
 }
 

--- a/crates/rag-rat-core/src/index/schema/mod.rs
+++ b/crates/rag-rat-core/src/index/schema/mod.rs
@@ -411,7 +411,7 @@ const MIGRATION_058_DESCRIPTION: &str =
      CAS UPDATE that mirrors the ed25519 mint-if-absent race, so concurrent opens converge on one \
      encryption identity. C1 only mints/persists/validates the key; ECDH + HKDF is C4";
 const MIGRATION_059_ID: &str = "059_account_candidate_dag";
-const MIGRATION_059_CHECKSUM: &str = "sha256:rag-rat-account-candidate-dag-v59";
+const MIGRATION_059_CHECKSUM: &str = "sha256:rag-rat-account-candidate-dag-v59-signed-envelope-key";
 const MIGRATION_059_DESCRIPTION: &str =
     "The account-log CANDIDATE DAG (sync phase C, §16.1): account_entries (all branches, \
      grow-only, no seq-uniqueness — equivocation heads are first-class; the derived `accepted` \

--- a/crates/rag-rat-core/src/index/schema/mod.rs
+++ b/crates/rag-rat-core/src/index/schema/mod.rs
@@ -19,7 +19,7 @@ pub use registry::{LEGACY_REPO_ID, RegisteredRepo, register_repo, register_repo_
 use rusqlite::{Connection, OptionalExtension, params};
 use serde::Serialize;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 58;
+pub const LATEST_SCHEMA_VERSION: u32 = 59;
 
 /// Every oracle-DERIVED persisted table — the outputs an `oracle run` writes that must OUTLIVE a
 /// reindex.
@@ -410,6 +410,15 @@ const MIGRATION_058_DESCRIPTION: &str =
      STRICT table; an existing ed25519-only row is backfilled at the next local_device open via a \
      CAS UPDATE that mirrors the ed25519 mint-if-absent race, so concurrent opens converge on one \
      encryption identity. C1 only mints/persists/validates the key; ECDH + HKDF is C4";
+const MIGRATION_059_ID: &str = "059_account_candidate_dag";
+const MIGRATION_059_CHECKSUM: &str = "sha256:rag-rat-account-candidate-dag-v59";
+const MIGRATION_059_DESCRIPTION: &str =
+    "The account-log CANDIDATE DAG (sync phase C, §16.1): account_entries (all branches, \
+     grow-only, no seq-uniqueness — equivocation heads are first-class; the derived `accepted` \
+     flag + the account_accepted_slot partial unique index pin accepted-set uniqueness per slot, \
+     I10a), account_entry_status (the projected §16.3 taxonomy), and account_pre_verify (entries \
+     whose signing device isn't yet resolvable, retried on a later DeviceAdd/AccountGenesis \
+     arrival). All CREATE ... IF NOT EXISTS + STRICT tables";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -903,6 +912,12 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         checksum: MIGRATION_058_CHECKSUM,
         description: MIGRATION_058_DESCRIPTION,
         apply: apply_oplog_device_x25519,
+    },
+    Migration {
+        id: MIGRATION_059_ID,
+        checksum: MIGRATION_059_CHECKSUM,
+        description: MIGRATION_059_DESCRIPTION,
+        apply: apply_account_candidate_dag,
     },
 ];
 

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
@@ -1766,10 +1766,12 @@ fn migration_057_adds_the_external_symbols_table() {
 fn migration_058_adds_the_oplog_device_x25519_columns() {
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     schema::apply(&conn).unwrap();
-    // V058 is the schema tip — this test carries the absolute pin (the older tests dropped to
-    // the symbolic `current_version == LATEST` check).
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 58, "V058 is the schema tip");
-    assert_eq!(schema::status(&conn).unwrap().current_version, 58, "schema at LATEST after apply");
+    // V058 is no longer the tip (the absolute pin moved to the V059 test) — symbolic tip check.
+    assert_eq!(
+        schema::status(&conn).unwrap().current_version,
+        schema::LATEST_SCHEMA_VERSION,
+        "schema at LATEST after apply"
+    );
 
     // The identity table gains the X25519 encryption columns (sync phase C, §5).
     for column in ["x25519_secret", "x25519_public"] {
@@ -1813,6 +1815,49 @@ fn migration_058_adds_the_oplog_device_x25519_columns() {
             "the forward migrate keeps the {column} column"
         );
     }
+}
+
+#[test]
+fn migration_059_creates_the_account_candidate_dag() {
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn).unwrap();
+    // V059 is the schema tip — this test carries the absolute pin.
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 59, "V059 is the schema tip");
+    assert_eq!(schema::status(&conn).unwrap().current_version, 59, "schema at LATEST after apply");
+
+    // The candidate-DAG tables + indexes exist (sync phase C, §16.1).
+    for table in ["account_entries", "account_entry_status", "account_pre_verify"] {
+        assert!(conn_table_exists(&conn, table), "V059 creates {table}");
+    }
+    assert!(conn_index_exists(&conn, "account_entries_chain"), "V059 creates the chain index");
+    assert!(
+        conn_index_exists(&conn, "account_accepted_slot"),
+        "V059 creates the accepted-slot partial unique index (I10a)"
+    );
+
+    // Deferred-absence in ISOLATION: a bare DB lacks the tables until the V059 applier runs, and a
+    // replay is an idempotent no-op (every statement is CREATE ... IF NOT EXISTS).
+    let isolated = rusqlite::Connection::open_in_memory().unwrap();
+    assert!(!conn_table_exists(&isolated, "account_entries"), "bare DB lacks account_entries");
+    schema::apply_account_candidate_dag(&isolated).unwrap();
+    schema::apply_account_candidate_dag(&isolated).expect("replay is a no-op");
+    for table in ["account_entries", "account_entry_status", "account_pre_verify"] {
+        assert!(conn_table_exists(&isolated, table), "the isolated V059 applier creates {table}");
+    }
+    assert!(conn_index_exists(&isolated, "account_accepted_slot"), "and the partial unique index");
+
+    // A forward migrate over a ledger truncated below V059 replays the step and keeps the tables.
+    truncate_schema_to(&conn, 58);
+    schema::migrate_forward(&conn).unwrap();
+    assert_eq!(
+        schema::status(&conn).unwrap().current_version,
+        schema::LATEST_SCHEMA_VERSION,
+        "forward migrate reaches the tip"
+    );
+    assert!(
+        conn_table_exists(&conn, "account_entries"),
+        "the forward migrate keeps account_entries"
+    );
 }
 
 #[test]

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
@@ -1838,6 +1838,9 @@ fn migration_059_creates_the_account_candidate_dag() {
         conn_index_exists(&conn, "account_pre_verify_account"),
         "V059 creates the pre-verify claimed_account_id index"
     );
+    let pre_verify_columns = conn_table_columns(&conn, "account_pre_verify");
+    assert!(pre_verify_columns.contains(&"signed_hash".to_string()));
+    assert!(pre_verify_columns.contains(&"entry_hash".to_string()));
 
     // Deferred-absence in ISOLATION: a bare DB lacks the tables until the V059 applier runs, and a
     // replay is an idempotent no-op (every statement is CREATE ... IF NOT EXISTS).

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
@@ -1834,6 +1834,10 @@ fn migration_059_creates_the_account_candidate_dag() {
         conn_index_exists(&conn, "account_accepted_slot"),
         "V059 creates the accepted-slot partial unique index (I10a)"
     );
+    assert!(
+        conn_index_exists(&conn, "account_pre_verify_account"),
+        "V059 creates the pre-verify claimed_account_id index"
+    );
 
     // Deferred-absence in ISOLATION: a bare DB lacks the tables until the V059 applier runs, and a
     // replay is an idempotent no-op (every statement is CREATE ... IF NOT EXISTS).

--- a/crates/rag-rat-core/src/oplog/account/fold.rs
+++ b/crates/rag-rat-core/src/oplog/account/fold.rs
@@ -2539,4 +2539,64 @@ mod tests {
             "an op under a rejected incarnation is stale_authority",
         );
     }
+
+    #[test]
+    fn every_fold_outcome_has_a_stable_storage_taxonomy() {
+        // §16.3 is persisted API, not display text. Pin every closed-enum token so adding or
+        // renaming a fold reason cannot silently drift existing database rows or query behavior.
+        let cases = [
+            (Outcome::Effective { auth_epoch: 7 }, ("effective", None)),
+            (Outcome::RetainedUnfolded, ("retained_unfolded", None)),
+            (Outcome::Condemned(CondemnedReason::BeyondCut), ("condemned", Some("beyond_cut"))),
+            (Outcome::Condemned(CondemnedReason::OffBranch), ("condemned", Some("off_branch"))),
+            (
+                Outcome::Condemned(CondemnedReason::ClosedIncarnation),
+                ("condemned", Some("closed_incarnation")),
+            ),
+            (Outcome::Parked(ParkReason::UnknownOwnerRef), ("parked", Some("unknown_owner_ref"))),
+            (Outcome::Parked(ParkReason::UnknownCutTarget), ("parked", Some("unknown_cut_target"))),
+            (
+                Outcome::Parked(ParkReason::IncompleteCutAncestry),
+                ("parked", Some("incomplete_cut_ancestry")),
+            ),
+            (Outcome::Parked(ParkReason::ContestedSubject), ("parked", Some("contested_subject"))),
+            (
+                Outcome::Parked(ParkReason::DeferredStreamAuthorization),
+                ("parked", Some("deferred_stream_authorization")),
+            ),
+            (
+                Outcome::Rejected(RejectReason::StaleAuthority),
+                ("rejected", Some("stale_authority")),
+            ),
+            (
+                Outcome::Rejected(RejectReason::GenesisSelfHash),
+                ("rejected", Some("genesis_self_hash")),
+            ),
+            (
+                Outcome::Rejected(RejectReason::DuplicateGenesis),
+                ("rejected", Some("duplicate_genesis")),
+            ),
+            (Outcome::Rejected(RejectReason::DuplicateAdd), ("rejected", Some("duplicate_add"))),
+            (
+                Outcome::Rejected(RejectReason::TombstoneReAdd),
+                ("rejected", Some("tombstone_re_add")),
+            ),
+            (Outcome::Rejected(RejectReason::BadPromote), ("rejected", Some("bad_promote"))),
+            (Outcome::Rejected(RejectReason::LastOwner), ("rejected", Some("last_owner"))),
+            (
+                Outcome::Rejected(RejectReason::CutTargetMismatch),
+                ("rejected", Some("cut_target_mismatch")),
+            ),
+            (Outcome::Rejected(RejectReason::WrongDevice), ("rejected", Some("wrong_device"))),
+            (Outcome::Rejected(RejectReason::Malformed), ("rejected", Some("malformed"))),
+            (
+                Outcome::Rejected(RejectReason::NonGenesisOrigin),
+                ("rejected", Some("non_genesis_origin")),
+            ),
+            (Outcome::Rejected(RejectReason::Ineffective), ("rejected", Some("ineffective"))),
+        ];
+        for (outcome, expected) in cases {
+            assert_eq!(outcome.taxonomy(), expected, "taxonomy drift for {outcome:?}");
+        }
+    }
 }

--- a/crates/rag-rat-core/src/oplog/account/fold.rs
+++ b/crates/rag-rat-core/src/oplog/account/fold.rs
@@ -48,6 +48,53 @@ impl Outcome {
     pub(super) fn is_effective(&self) -> bool {
         matches!(self, Outcome::Effective { .. })
     }
+
+    /// The §16.3 stored-taxonomy `(status, detail)` for this outcome. `Effective` maps to
+    /// `("effective", None)` — the storage layer resolves accepted vs `forked` per slot (I10a) —
+    /// and a fold-semantic `Rejected` maps to `("rejected", reason)`; structural ingest rejects
+    /// are never folded (they are not stored). Kept beside the enum so the projection can't
+    /// drift.
+    pub(super) fn taxonomy(&self) -> (&'static str, Option<&'static str>) {
+        match self {
+            Outcome::Effective { .. } => ("effective", None),
+            Outcome::RetainedUnfolded => ("retained_unfolded", None),
+            Outcome::Condemned(reason) => (
+                "condemned",
+                Some(match reason {
+                    CondemnedReason::BeyondCut => "beyond_cut",
+                    CondemnedReason::OffBranch => "off_branch",
+                    CondemnedReason::ClosedIncarnation => "closed_incarnation",
+                }),
+            ),
+            Outcome::Parked(reason) => (
+                "parked",
+                Some(match reason {
+                    ParkReason::UnknownOwnerRef => "unknown_owner_ref",
+                    ParkReason::UnknownCutTarget => "unknown_cut_target",
+                    ParkReason::IncompleteCutAncestry => "incomplete_cut_ancestry",
+                    ParkReason::ContestedSubject => "contested_subject",
+                    ParkReason::DeferredStreamAuthorization => "deferred_stream_authorization",
+                }),
+            ),
+            Outcome::Rejected(reason) => (
+                "rejected",
+                Some(match reason {
+                    RejectReason::StaleAuthority => "stale_authority",
+                    RejectReason::GenesisSelfHash => "genesis_self_hash",
+                    RejectReason::DuplicateGenesis => "duplicate_genesis",
+                    RejectReason::DuplicateAdd => "duplicate_add",
+                    RejectReason::TombstoneReAdd => "tombstone_re_add",
+                    RejectReason::BadPromote => "bad_promote",
+                    RejectReason::LastOwner => "last_owner",
+                    RejectReason::CutTargetMismatch => "cut_target_mismatch",
+                    RejectReason::WrongDevice => "wrong_device",
+                    RejectReason::Malformed => "malformed",
+                    RejectReason::NonGenesisOrigin => "non_genesis_origin",
+                    RejectReason::Ineffective => "ineffective",
+                }),
+            ),
+        }
+    }
 }
 
 /// Why an entry was killed by a revocation register (§11.2). `BeyondCut` is seq-only (I11) and

--- a/crates/rag-rat-core/src/oplog/account/fold.rs
+++ b/crates/rag-rat-core/src/oplog/account/fold.rs
@@ -28,7 +28,7 @@ use crate::oplog::op::DeviceFingerprint;
 /// The account CONTROL log the fold operates on (§11) — its registers are control-log scoped
 /// (`log: 0`). A known op on the secrets (1) or content (2) log is not a control op and is retained
 /// unfolded here (its own C2/C4 fold owns it), never minting control authority.
-const CONTROL_LOG: u8 = 0;
+pub(super) const CONTROL_LOG: u8 = 0;
 /// The account-op version this fold understands. A known `entry_type` at a different version may
 /// reuse the tag with new semantics, so it is retained-unfolded rather than folded as today's op.
 pub(super) const SUPPORTED_OP_VERSION: u32 = 1;

--- a/crates/rag-rat-core/src/oplog/account/fold.rs
+++ b/crates/rag-rat-core/src/oplog/account/fold.rs
@@ -31,7 +31,7 @@ use crate::oplog::op::DeviceFingerprint;
 const CONTROL_LOG: u8 = 0;
 /// The account-op version this fold understands. A known `entry_type` at a different version may
 /// reuse the tag with new semantics, so it is retained-unfolded rather than folded as today's op.
-const SUPPORTED_OP_VERSION: u32 = 1;
+pub(super) const SUPPORTED_OP_VERSION: u32 = 1;
 
 /// The per-entry classification (§16.3 taxonomy). `RetainedUnfolded` is an unknown `entry_type`;
 /// `Rejected` will never be effective; `Parked` is undecided pending more entries.

--- a/crates/rag-rat-core/src/oplog/account/mod.rs
+++ b/crates/rag-rat-core/src/oplog/account/mod.rs
@@ -32,5 +32,6 @@ mod id;
 mod limits;
 mod ops;
 mod registers;
+mod storage;
 
 pub(crate) use id::AccountId;

--- a/crates/rag-rat-core/src/oplog/account/storage.rs
+++ b/crates/rag-rat-core/src/oplog/account/storage.rs
@@ -41,7 +41,7 @@ pub(crate) fn account_ingest(
     signed_bytes: &[u8],
     now_ms: i64,
 ) -> anyhow::Result<IngestOutcome> {
-    // Structure + §18a size + canonicity (never stored on failure).
+    // Structure + §18a size + canonicity (never stored on failure). No DB touch yet.
     let signed = match envelope::decode_account_signed(signed_bytes) {
         Ok(signed) => signed,
         Err(err) => return Ok(IngestOutcome::Rejected(err.to_string())),
@@ -49,17 +49,25 @@ pub(crate) fn account_ingest(
     let account_id = signed.header.account_id;
     let device_fp = signed.header.device_fingerprint;
 
+    // One IMMEDIATE transaction spans resolution → park-or-store → promote → refold. The write
+    // lock is what makes the park decision race-free: a concurrent ingest on another connection
+    // cannot commit a resolving DeviceAdd between our device-set read and our pre-verify insert,
+    // so an entry is never parked after its only promotion trigger has already passed.
+    let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
+
     // Resolve the signer's ed25519 pubkey content-addressedly: from stored genesis/DeviceAdd
     // candidates for this account, plus THIS entry if it self-certifies (a genesis / a DeviceAdd of
-    // its own signer). Unresolvable ⇒ pre-verify queue.
-    let mut pubkeys = stored_device_pubkeys(conn, account_id)?;
+    // its own signer). Unresolvable ⇒ pre-verify queue (durably, under the same lock).
+    let mut pubkeys = stored_device_pubkeys(&tx, account_id)?;
     add_self_pubkey(&mut pubkeys, &signed.header, &signed.payload);
     let Some(pubkey_bytes) = pubkeys.get(&device_fp).copied() else {
-        insert_pre_verify(conn, &signed.entry_hash, account_id, device_fp, signed_bytes, now_ms)?;
+        insert_pre_verify(&tx, &signed.entry_hash, account_id, device_fp, signed_bytes, now_ms)?;
+        tx.commit()?;
         return Ok(IngestOutcome::PreVerify);
     };
 
-    // Verify the signature under the resolved key (also re-binds fingerprint == sha256(pk)).
+    // Verify the signature under the resolved key (also re-binds fingerprint == sha256(pk)). A
+    // failure here has written nothing, so dropping the txn rolls back cleanly.
     let Ok(pubkey) = DevicePublic::from_bytes(&pubkey_bytes) else {
         return Ok(IngestOutcome::Rejected("resolved device key is not a valid point".into()));
     };
@@ -77,7 +85,6 @@ pub(crate) fn account_ingest(
         ));
     }
 
-    let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
     insert_candidate(&tx, &verified, signed_bytes, now_ms)?;
     // A DeviceAdd/genesis may resolve devices that were parked — retry their pre-verify rows.
     if is_genesis(&verified.header) || is_device_add(&verified) {
@@ -111,15 +118,17 @@ fn refold_in_tx(
     let history = fold::fold_account(&entries);
 
     // Branch selection: an entry is a candidate for `accepted` iff the fold makes it effective;
-    // when two effective entries collide on one (device, seq) slot (an unforced fork the
+    // when two effective entries collide on one (log, device, seq) slot (an unforced fork the
     // registers did not resolve), the lexicographically-smaller entry_hash wins the slot and
-    // the loser is `forked` (I10a). Register-named branches were already promoted inside the
-    // fold (off-branch → condemned).
-    let mut slot_winner: HashMap<(DeviceFingerprint, u64), [u8; 32]> = HashMap::new();
+    // the loser is `forked` (I10a). The slot key mirrors the account_accepted_slot unique index
+    // exactly — including log_id, so a future effective non-control-log entry can never be
+    // mistaken for a control-log rival at the same (device, seq). Register-named branches were
+    // already promoted inside the fold (off-branch → condemned).
+    let mut slot_winner: HashMap<(u8, DeviceFingerprint, u64), [u8; 32]> = HashMap::new();
     for row in &rows {
         if history.outcome(&row.entry_hash).is_some_and(|o| o.is_effective()) {
             slot_winner
-                .entry((row.device_fingerprint, row.seq))
+                .entry((row.log_id, row.device_fingerprint, row.seq))
                 .and_modify(|best| {
                     if row.entry_hash < *best {
                         *best = row.entry_hash;
@@ -139,7 +148,8 @@ fn refold_in_tx(
     for row in &rows {
         let effective = history.outcome(&row.entry_hash).is_some_and(|o| o.is_effective());
         let accepted = effective
-            && slot_winner.get(&(row.device_fingerprint, row.seq)) == Some(&row.entry_hash);
+            && slot_winner.get(&(row.log_id, row.device_fingerprint, row.seq))
+                == Some(&row.entry_hash);
         let (status, detail): (String, Option<String>) = if accepted {
             ("accepted".to_string(), None)
         } else if effective {
@@ -176,6 +186,7 @@ fn refold_in_tx(
 /// only rather than re-verify — which would need the device set we are loading).
 struct CandidateRow {
     entry_hash: [u8; 32],
+    log_id: u8,
     device_fingerprint: DeviceFingerprint,
     seq: u64,
     verified: VerifiedAccountEntry,
@@ -203,6 +214,7 @@ fn load_candidates(conn: &Connection, account_id: AccountId) -> anyhow::Result<V
             .map_err(|err| anyhow::anyhow!("stored candidate re-decode failed: {err}"))?;
         out.push(CandidateRow {
             entry_hash: fixed(&hash)?,
+            log_id: signed.header.log_id,
             device_fingerprint: DeviceFingerprint::from_bytes(fixed(&fp)?),
             seq: seq as u64,
             verified: VerifiedAccountEntry {
@@ -327,36 +339,57 @@ fn promote_pre_verify(
     account_id: AccountId,
     now_ms: i64,
 ) -> anyhow::Result<()> {
-    let pubkeys = stored_device_pubkeys(tx, account_id)?;
-    let pending: Vec<(Vec<u8>, Vec<u8>, Vec<u8>)> = {
-        let mut stmt = tx.prepare(
-            "SELECT entry_hash, claimed_fingerprint, raw_bytes
-             FROM account_pre_verify WHERE claimed_account_id = ?1",
-        )?;
-        stmt.query_map(params![account_id.to_bytes().as_slice()], |row| {
-            Ok((row.get::<_, Vec<u8>>(0)?, row.get::<_, Vec<u8>>(1)?, row.get::<_, Vec<u8>>(2)?))
-        })?
-        .collect::<rusqlite::Result<Vec<_>>>()?
-    };
-    for (entry_hash, fp_bytes, raw_bytes) in pending {
-        let fp = DeviceFingerprint::from_bytes(fixed(&fp_bytes)?);
-        let Some(pk_bytes) = pubkeys.get(&fp).copied() else {
-            continue; // still unresolvable
+    // Fixpoint: a promoted genesis/DeviceAdd enlarges the resolvable device set, which can in turn
+    // resolve a DEEPER parked entry (a device chain — founder→B→C — delivered before its
+    // authorizers). Feed each promoted key back and re-scan until a full pass promotes nothing.
+    // Snapshotting the device set once would strand depth≥2 chains forever, so two peers that
+    // received the same entries in different orders would converge on different accepted sets.
+    let mut pubkeys = stored_device_pubkeys(tx, account_id)?;
+    loop {
+        let pending: Vec<(Vec<u8>, Vec<u8>, Vec<u8>)> = {
+            let mut stmt = tx.prepare(
+                "SELECT entry_hash, claimed_fingerprint, raw_bytes
+                 FROM account_pre_verify WHERE claimed_account_id = ?1",
+            )?;
+            stmt.query_map(params![account_id.to_bytes().as_slice()], |row| {
+                Ok((
+                    row.get::<_, Vec<u8>>(0)?,
+                    row.get::<_, Vec<u8>>(1)?,
+                    row.get::<_, Vec<u8>>(2)?,
+                ))
+            })?
+            .collect::<rusqlite::Result<Vec<_>>>()?
         };
-        let promoted = DevicePublic::from_bytes(&pk_bytes)
-            .ok()
-            .and_then(|pk| envelope::verify_account_signed(&raw_bytes, &pk).ok())
-            .filter(|v| {
-                !is_genesis(&v.header)
-                    || account_id_from_genesis_payload(&v.payload) == v.header.account_id
-            });
-        if let Some(verified) = promoted {
-            insert_candidate(tx, &verified, &raw_bytes, now_ms)?;
+        let mut promoted_any = false;
+        for (entry_hash, fp_bytes, raw_bytes) in pending {
+            let fp = DeviceFingerprint::from_bytes(fixed(&fp_bytes)?);
+            let Some(pk_bytes) = pubkeys.get(&fp).copied() else {
+                continue; // still unresolvable — may resolve in a later round
+            };
+            let promoted = DevicePublic::from_bytes(&pk_bytes)
+                .ok()
+                .and_then(|pk| envelope::verify_account_signed(&raw_bytes, &pk).ok())
+                .filter(|v| {
+                    !is_genesis(&v.header)
+                        || account_id_from_genesis_payload(&v.payload) == v.header.account_id
+                });
+            if let Some(verified) = promoted {
+                insert_candidate(tx, &verified, &raw_bytes, now_ms)?;
+                // A promoted genesis/DeviceAdd certifies a device key — feed it back so the next
+                // round can resolve entries that were waiting on it.
+                add_self_pubkey(&mut pubkeys, &verified.header, &verified.payload);
+                promoted_any = true;
+            }
+            // Resolved (promoted) or refuted (verify failed): clear it from the queue either way.
+            tx.execute("DELETE FROM account_pre_verify WHERE entry_hash = ?1", params![
+                entry_hash.as_slice()
+            ])?;
         }
-        // Resolved (promoted) or refuted (verify failed): clear it from the queue either way.
-        tx.execute("DELETE FROM account_pre_verify WHERE entry_hash = ?1", params![
-            entry_hash.as_slice()
-        ])?;
+        // A round advances the queue only by promoting (each promotion deletes ≥1 pending row and
+        // adds ≥1 key), so this terminates; a round that promotes nothing new is the fixpoint.
+        if !promoted_any {
+            break;
+        }
     }
     Ok(())
 }
@@ -599,6 +632,47 @@ mod tests {
         let pending: i64 =
             conn.query_row("SELECT COUNT(*) FROM account_pre_verify", [], |r| r.get(0)).unwrap();
         assert_eq!(pending, 0, "the pre-verify queue is drained");
+    }
+
+    #[test]
+    fn a_depth_two_pre_verify_chain_promotes_to_a_fixpoint_when_the_root_arrives() {
+        // A device chain delivered before its authorizers: founder→B (DeviceAdd signed by the
+        // founder) →C (DeviceAdd signed by B). Deliver in REVERSE so both the C-add and the B-add
+        // park. The genesis arrival resolves the founder and promotes the B-add; the newly added B
+        // key must then resolve the parked C-add in the SAME drain (the fixpoint). A one-shot
+        // device-set snapshot would strand the C-add forever — a peer that received the three
+        // entries in forward order would accept it, so the two peers would diverge.
+        let conn = db();
+        let founder = Dev::new(1);
+        let (acct, gbytes, gh) = genesis(&founder);
+        let b = Dev::new(2);
+        let (add_b_bytes, add_b) =
+            op(acct, &founder, 1, Some(gh), Some(gh), &device_add(&b, DeviceRole::Owner));
+        // C added by owner B on B's own log (seq 0), authorized by the entry that made B an owner.
+        let c = Dev::new(3);
+        let (add_c_bytes, add_c) =
+            op(acct, &b, 0, None, Some(add_b), &device_add(&c, DeviceRole::Member));
+
+        // Reverse delivery: the C-add parks (B unknown), then the B-add parks (founder unknown).
+        assert_eq!(account_ingest(&conn, &add_c_bytes, NOW).unwrap(), IngestOutcome::PreVerify);
+        assert_eq!(account_ingest(&conn, &add_b_bytes, NOW).unwrap(), IngestOutcome::PreVerify);
+
+        // The genesis resolves the founder → promotes add_b → the fed-back B key promotes add_c.
+        account_ingest(&conn, &gbytes, NOW).unwrap();
+        assert_eq!(status(&conn, &gh).as_deref(), Some("accepted"), "genesis accepted");
+        assert_eq!(
+            status(&conn, &add_b).as_deref(),
+            Some("accepted"),
+            "the B-add promoted (depth 1)"
+        );
+        assert_eq!(
+            status(&conn, &add_c).as_deref(),
+            Some("accepted"),
+            "the C-add promoted transitively (depth 2 — the fixpoint drain)",
+        );
+        let pending: i64 =
+            conn.query_row("SELECT COUNT(*) FROM account_pre_verify", [], |r| r.get(0)).unwrap();
+        assert_eq!(pending, 0, "the pre-verify queue is fully drained");
     }
 
     #[test]

--- a/crates/rag-rat-core/src/oplog/account/storage.rs
+++ b/crates/rag-rat-core/src/oplog/account/storage.rs
@@ -20,6 +20,10 @@ use super::{AccountId, fold};
 use crate::oplog::device::DevicePublic;
 use crate::oplog::op::DeviceFingerprint;
 
+type EntryHash = [u8; 32];
+type BranchKey = (u8, DeviceFingerprint, Option<EntryHash>);
+type BranchChildren = HashMap<BranchKey, Vec<EntryHash>>;
+
 /// The result of ingesting one signed account entry (§16.2).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum IngestOutcome {
@@ -141,8 +145,7 @@ fn refold_in_tx(
         .collect();
     // Effective entries indexed by the (log, device, prev_hash) parent slot they chain from; a
     // chain root keys on `None`.
-    let mut children: HashMap<(u8, DeviceFingerprint, Option<[u8; 32]>), Vec<[u8; 32]>> =
-        HashMap::new();
+    let mut children = BranchChildren::new();
     let mut groups: HashSet<(u8, DeviceFingerprint)> = HashSet::new();
     for row in &rows {
         if effective.contains(&row.entry_hash) {

--- a/crates/rag-rat-core/src/oplog/account/storage.rs
+++ b/crates/rag-rat-core/src/oplog/account/storage.rs
@@ -26,6 +26,12 @@ type BranchKey = (u8, DeviceFingerprint, Option<EntryHash>);
 type BranchChild = (u64, EntryHash);
 type BranchChildren = HashMap<BranchKey, Vec<BranchChild>>;
 
+struct AccountProjection {
+    history: fold::AccountAuthHistory,
+    accepted: HashSet<EntryHash>,
+    forked: HashSet<EntryHash>,
+}
+
 /// The result of ingesting one signed account entry (§16.2).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum IngestOutcome {
@@ -117,59 +123,27 @@ fn refold_in_tx(
     account_id: AccountId,
 ) -> anyhow::Result<HashMap<[u8; 32], String>> {
     let rows = load_candidates(tx, account_id)?;
-    let mut removed = HashSet::new();
-    let (history, effective, accepted_set) = loop {
-        let entries: Vec<VerifiedAccountEntry> = rows
-            .iter()
-            .filter(|row| !removed.contains(&row.entry_hash))
-            .map(|row| row.verified.clone())
-            .collect();
-        let history = fold::fold_account(&entries);
-        let effective: HashSet<EntryHash> = rows
-            .iter()
-            .filter(|row| {
-                !removed.contains(&row.entry_hash)
-                    && history
-                        .outcome(&row.entry_hash)
-                        .is_some_and(|outcome| outcome.is_effective())
-            })
-            .map(|row| row.entry_hash)
-            .collect();
-        let selected = select_coherent_branches(&rows, &effective);
-        let accepted = authority_closed_selection(&rows, selected);
-        let rejected: Vec<EntryHash> = effective.difference(&accepted).copied().collect();
-        if rejected.is_empty() {
-            break (history, effective, accepted);
-        }
-        // Monotone elimination is both the termination argument and the security boundary: once
-        // an effective candidate loses its author branch or its cited authority branch, neither it
-        // nor any effect it produced may participate in a later fold round.
-        removed.extend(rejected);
-    };
+    let projection = derive_account_projection(&rows);
 
-    // Rewrite: clear every accepted flag for the account, then re-set the winners — atomically,
-    // so the partial unique index never sees two accepted rows at one slot mid-transaction.
+    // Rewrite atomically so the partial unique index never observes two accepted rows at a slot.
     tx.execute("UPDATE account_entries SET accepted = 0 WHERE account_id = ?1", params![
         account_id.to_bytes().as_slice()
     ])?;
 
     let mut statuses: HashMap<[u8; 32], String> = HashMap::new();
     for row in rows {
-        let accepted = accepted_set.contains(&row.entry_hash);
+        let accepted = projection.accepted.contains(&row.entry_hash);
         let (status, detail): (String, Option<String>) = if accepted {
             ("accepted".to_string(), None)
-        } else if removed.contains(&row.entry_hash) || effective.contains(&row.entry_hash) {
-            // Effective but outside the authority-closed accepted DAG: an equivocation loser, a
-            // descendant of one, or an entry whose cited mint lost branch selection.
+        } else if projection.forked.contains(&row.entry_hash) {
             ("forked".to_string(), None)
         } else {
-            match history.outcome(&row.entry_hash) {
+            match projection.history.outcome(&row.entry_hash) {
                 Some(outcome) => {
                     let (s, d) = outcome.taxonomy();
                     (s.to_string(), d.map(str::to_string))
                 },
-                // A candidate eliminated in an earlier round is covered by `removed`; every
-                // remaining candidate is classified by the final fold.
+                // Every non-forked candidate participates in the final fold.
                 None => ("retained_unfolded".to_string(), None),
             }
         };
@@ -187,6 +161,39 @@ fn refold_in_tx(
         statuses.insert(row.entry_hash, status);
     }
     Ok(statuses)
+}
+
+/// Derive an author-chain-coherent, authority-closed projection without touching storage.
+fn derive_account_projection(rows: &[CandidateRow]) -> AccountProjection {
+    let mut forked = HashSet::new();
+    loop {
+        let entries: Vec<VerifiedAccountEntry> = rows
+            .iter()
+            .filter(|row| !forked.contains(&row.entry_hash))
+            .map(|row| row.verified.clone())
+            .collect();
+        let history = fold::fold_account(&entries);
+        let effective: HashSet<EntryHash> = rows
+            .iter()
+            .filter(|row| {
+                !forked.contains(&row.entry_hash)
+                    && history
+                        .outcome(&row.entry_hash)
+                        .is_some_and(|outcome| outcome.is_effective())
+            })
+            .map(|row| row.entry_hash)
+            .collect();
+        let selected = select_coherent_branches(rows, &effective);
+        let accepted = close_selection_over_authority(rows, selected);
+        let newly_forked: Vec<EntryHash> = effective.difference(&accepted).copied().collect();
+        if newly_forked.is_empty() {
+            return AccountProjection { history, accepted, forked };
+        }
+        // Monotone elimination is both the termination argument and the security boundary: once
+        // an effective candidate loses its author branch or its cited authority branch, neither it
+        // nor any effect it produced may participate in a later fold round.
+        forked.extend(newly_forked);
+    }
 }
 
 /// Select one contiguous effective hash-chain per `(log_id, device)` (§16.2).
@@ -233,7 +240,7 @@ fn select_coherent_branches(
 /// Remove selected entries whose cited incarnation is not itself selected. Iterate because an
 /// invalid mint can authorize another mint, so authority loss must propagate through the whole
 /// incarnation DAG rather than only one edge.
-fn authority_closed_selection(
+fn close_selection_over_authority(
     rows: &[CandidateRow],
     mut selected: HashSet<EntryHash>,
 ) -> HashSet<EntryHash> {

--- a/crates/rag-rat-core/src/oplog/account/storage.rs
+++ b/crates/rag-rat-core/src/oplog/account/storage.rs
@@ -17,12 +17,14 @@ use super::envelope::{self, AccountEntryHeader, VerifiedAccountEntry};
 use super::id::account_id_from_genesis_payload;
 use super::ops::{self, AccountOp, DecodedAccountOp};
 use super::{AccountId, fold};
+use crate::oplog::cbor;
 use crate::oplog::device::DevicePublic;
 use crate::oplog::op::DeviceFingerprint;
 
 type EntryHash = [u8; 32];
 type BranchKey = (u8, DeviceFingerprint, Option<EntryHash>);
-type BranchChildren = HashMap<BranchKey, Vec<EntryHash>>;
+type BranchChild = (u64, EntryHash);
+type BranchChildren = HashMap<BranchKey, Vec<BranchChild>>;
 
 /// The result of ingesting one signed account entry (§16.2).
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -52,6 +54,9 @@ pub(crate) fn account_ingest(
     };
     let account_id = signed.header.account_id;
     let device_fp = signed.header.device_fingerprint;
+    if let Err(err) = validate_storable_header_payload(&signed.header, &signed.payload) {
+        return Ok(IngestOutcome::Rejected(err));
+    }
 
     // One IMMEDIATE transaction spans resolution → park-or-store → promote → refold. The write
     // lock is what makes the park decision race-free: a concurrent ingest on another connection
@@ -79,21 +84,8 @@ pub(crate) fn account_ingest(
         Ok(verified) => verified,
         Err(err) => return Ok(IngestOutcome::Rejected(err.to_string())),
     };
-    // A genesis must self-hash to its account_id (§4) — a structural reject, before it can seed a
-    // DAG.
-    if is_genesis(&verified.header)
-        && account_id_from_genesis_payload(&verified.payload) != account_id
-    {
-        return Ok(IngestOutcome::Rejected(
-            "genesis payload does not hash to its account_id".into(),
-        ));
-    }
-    // The op payload has not been decoded yet — the envelope carries it opaque. A current-version
-    // plaintext op whose payload is malformed / non-canonical is a STRUCTURAL reject and must never
-    // enter the grow-only DAG. Sealed ciphertext and future-version payloads are intentionally
-    // opaque here: their own layer/version validates them, while C1 retains their headers.
-    if let Err(err) = validate_current_plaintext_payload(&verified) {
-        return Ok(IngestOutcome::Rejected(format!("op payload decode failed: {err}")));
+    if let Err(err) = validate_authenticated_entry(&verified) {
+        return Ok(IngestOutcome::Rejected(err));
     }
 
     insert_candidate(&tx, &verified, signed_bytes, now_ms)?;
@@ -152,18 +144,23 @@ fn refold_in_tx(
             children
                 .entry((row.log_id, row.device_fingerprint, row.verified.header.prev_hash))
                 .or_default()
-                .push(row.entry_hash);
+                .push((row.seq, row.entry_hash));
             groups.insert((row.log_id, row.device_fingerprint));
         }
     }
     let mut accepted_set: HashSet<[u8; 32]> = HashSet::new();
     for (log_id, device) in groups {
         let mut parent: Option<[u8; 32]> = None;
-        // Bounded by the candidate count; each hop advances to a strictly-higher seq (the fold's
-        // ancestry check guarantees child.seq == parent.seq + 1), so the chain cannot cycle.
-        for _ in 0..=rows.len() {
-            let Some(winner) =
-                children.get(&(log_id, device, parent)).and_then(|kids| kids.iter().min()).copied()
+        // Bounded by the candidate count; only the exact next sequence slot may extend a branch.
+        for expected_seq in 0..=rows.len() {
+            let Some((_, winner)) = children
+                .get(&(log_id, device, parent))
+                .and_then(|kids| {
+                    kids.iter()
+                        .filter(|(seq, _)| *seq == expected_seq as u64)
+                        .min_by_key(|(_, hash)| hash)
+                })
+                .copied()
             else {
                 break;
             };
@@ -277,7 +274,7 @@ fn insert_candidate(
             h.account_id.to_bytes().as_slice(),
             h.log_id,
             h.device_fingerprint.to_bytes().as_slice(),
-            h.seq as i64,
+            i64::try_from(h.seq).expect("seq range validated before candidate insert"),
             h.prev_hash.map(|p| p.to_vec()),
             h.parent_ref.map(|p| p.to_vec()),
             h.authority_ref.map(|p| p.to_vec()),
@@ -327,10 +324,17 @@ fn add_self_pubkey(
     header: &AccountEntryHeader,
     payload: &[u8],
 ) {
+    if !is_current_control_plaintext(header) {
+        return;
+    }
     if let Ok(DecodedAccountOp::Known(op)) = ops::decode(header.entry_type, payload) {
         match op {
             AccountOp::AccountGenesis { ed25519_pubkey, .. } => {
-                map.insert(header.device_fingerprint, ed25519_pubkey);
+                if DevicePublic::from_bytes(&ed25519_pubkey)
+                    .is_ok_and(|key| key.fingerprint() == header.device_fingerprint)
+                {
+                    map.insert(header.device_fingerprint, ed25519_pubkey);
+                }
             },
             AccountOp::DeviceAdd { device_fingerprint, ed25519_pubkey, .. } => {
                 map.insert(device_fingerprint, ed25519_pubkey);
@@ -348,11 +352,14 @@ fn insert_pre_verify(
     signed_bytes: &[u8],
     now_ms: i64,
 ) -> rusqlite::Result<()> {
+    let signed_hash = cbor::sha256(signed_bytes);
     conn.execute(
         "INSERT OR IGNORE INTO account_pre_verify(
-             entry_hash, claimed_account_id, claimed_fingerprint, raw_bytes, received_at_ms)
-         VALUES (?1, ?2, ?3, ?4, ?5)",
+             signed_hash, entry_hash, claimed_account_id, claimed_fingerprint, raw_bytes,
+             received_at_ms)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
         params![
+            signed_hash.as_slice(),
             entry_hash.as_slice(),
             account_id.to_bytes().as_slice(),
             fingerprint.to_bytes().as_slice(),
@@ -379,7 +386,7 @@ fn promote_pre_verify(
     loop {
         let pending: Vec<(Vec<u8>, Vec<u8>, Vec<u8>)> = {
             let mut stmt = tx.prepare(
-                "SELECT entry_hash, claimed_fingerprint, raw_bytes
+                "SELECT signed_hash, claimed_fingerprint, raw_bytes
                  FROM account_pre_verify WHERE claimed_account_id = ?1",
             )?;
             stmt.query_map(params![account_id.to_bytes().as_slice()], |row| {
@@ -392,7 +399,7 @@ fn promote_pre_verify(
             .collect::<rusqlite::Result<Vec<_>>>()?
         };
         let mut promoted_any = false;
-        for (entry_hash, fp_bytes, raw_bytes) in pending {
+        for (signed_hash, fp_bytes, raw_bytes) in pending {
             let fp = DeviceFingerprint::from_bytes(fixed(&fp_bytes)?);
             let Some(pk_bytes) = pubkeys.get(&fp).copied() else {
                 continue; // still unresolvable — may resolve in a later round
@@ -401,12 +408,9 @@ fn promote_pre_verify(
                 .ok()
                 .and_then(|pk| envelope::verify_account_signed(&raw_bytes, &pk).ok())
                 .filter(|v| {
-                    !is_genesis(&v.header)
-                        || account_id_from_genesis_payload(&v.payload) == v.header.account_id
-                })
-                // Same structural gate as ingest: a malformed current plaintext payload is
-                // refuted, not promoted into the DAG (dropped from the queue below either way).
-                .filter(|v| validate_current_plaintext_payload(v).is_ok());
+                    validate_storable_header_payload(&v.header, &v.payload).is_ok()
+                        && validate_authenticated_entry(v).is_ok()
+                });
             if let Some(verified) = promoted {
                 insert_candidate(tx, &verified, &raw_bytes, now_ms)?;
                 // A promoted genesis/DeviceAdd certifies a device key — feed it back so the next
@@ -415,8 +419,8 @@ fn promote_pre_verify(
                 promoted_any = true;
             }
             // Resolved (promoted) or refuted (verify failed): clear it from the queue either way.
-            tx.execute("DELETE FROM account_pre_verify WHERE entry_hash = ?1", params![
-                entry_hash.as_slice()
+            tx.execute("DELETE FROM account_pre_verify WHERE signed_hash = ?1", params![
+                signed_hash.as_slice()
             ])?;
         }
         // A round advances the queue only by promoting (each promotion deletes ≥1 pending row and
@@ -432,11 +436,44 @@ fn is_genesis(header: &AccountEntryHeader) -> bool {
     header.entry_type == ops::entry_type::ACCOUNT_GENESIS
 }
 
-fn validate_current_plaintext_payload(entry: &VerifiedAccountEntry) -> Result<(), String> {
-    if entry.header.crypto_suite == 0 && entry.header.op_version == fold::SUPPORTED_OP_VERSION {
-        ops::decode(entry.header.entry_type, &entry.payload).map_err(|err| err.to_string())?;
+fn is_current_control_plaintext(header: &AccountEntryHeader) -> bool {
+    header.log_id == fold::CONTROL_LOG
+        && header.crypto_suite == 0
+        && header.op_version == fold::SUPPORTED_OP_VERSION
+}
+
+fn validate_storable_header_payload(
+    header: &AccountEntryHeader,
+    payload: &[u8],
+) -> Result<(), String> {
+    i64::try_from(header.seq)
+        .map_err(|_| "account seq exceeds SQLite INTEGER range".to_string())?;
+    if is_current_control_plaintext(header) {
+        ops::decode(header.entry_type, payload)
+            .map_err(|err| format!("op payload decode failed: {err}"))?;
+        validate_genesis_binding(header, payload)?;
     }
     Ok(())
+}
+
+fn validate_authenticated_entry(entry: &VerifiedAccountEntry) -> Result<(), String> {
+    validate_genesis_binding(&entry.header, &entry.payload)
+}
+
+fn validate_genesis_binding(header: &AccountEntryHeader, payload: &[u8]) -> Result<(), String> {
+    if !is_current_control_plaintext(header) || !is_genesis(header) {
+        return Ok(());
+    }
+    if account_id_from_genesis_payload(payload) != header.account_id {
+        return Err("genesis payload does not hash to its account_id".into());
+    }
+    match ops::decode(header.entry_type, payload) {
+        Ok(DecodedAccountOp::Known(AccountOp::AccountGenesis { ed25519_pubkey, .. }))
+            if DevicePublic::from_bytes(&ed25519_pubkey)
+                .is_ok_and(|key| key.fingerprint() == header.device_fingerprint) =>
+            Ok(()),
+        _ => Err("genesis founder key does not match signer fingerprint".into()),
+    }
 }
 
 fn is_device_add(verified: &VerifiedAccountEntry) -> bool {
@@ -984,13 +1021,12 @@ mod tests {
     }
 
     #[test]
-    fn malformed_pre_verify_payload_is_discarded_when_its_signer_resolves() {
-        // A malformed entry can arrive before its signer is known, so the first ingest cannot
-        // authenticate or inspect its plaintext. Once DeviceAdd resolves the signer, promotion
-        // must apply the same structural gate as direct ingest and delete—not persist—the entry.
+    fn malformed_payload_is_rejected_before_it_can_enter_pre_verify() {
+        // Payload structure is independent of signer resolution. Reject it before parking so the
+        // unauthenticated queue never contradicts the "structural rejects are never stored" rule.
         let conn = db();
         let founder = Dev::new(1);
-        let (acct, gbytes, gh) = genesis(&founder);
+        let (acct, _gbytes, gh) = genesis(&founder);
         let b = Dev::new(2);
         let malformed_header = AccountEntryHeader {
             account_id: acct,
@@ -1008,25 +1044,197 @@ mod tests {
         };
         let malformed =
             sign_account_entry(&b.secret, &malformed_header, &[0xff, 0xff, 0xff]).unwrap();
-        assert_eq!(
+        assert!(matches!(
             account_ingest(&conn, &malformed.signed_bytes, NOW).unwrap(),
-            IngestOutcome::PreVerify,
-        );
-
-        account_ingest(&conn, &gbytes, NOW).unwrap();
-        let (add_b_bytes, _) =
-            op(acct, &founder, 1, Some(gh), Some(gh), &device_add(&b, DeviceRole::Owner));
-        account_ingest(&conn, &add_b_bytes, NOW).unwrap();
-
-        assert_eq!(
-            status(&conn, &malformed.entry_hash),
-            None,
-            "malformed bytes never enter the DAG"
-        );
+            IngestOutcome::Rejected(_)
+        ));
+        assert_eq!(status(&conn, &malformed.entry_hash), None);
         let pending: i64 = conn
             .query_row("SELECT COUNT(*) FROM account_pre_verify", [], |row| row.get(0))
             .unwrap();
-        assert_eq!(pending, 0, "the now-refuted queued entry is deleted");
+        assert_eq!(pending, 0, "malformed bytes are never parked");
+    }
+
+    #[test]
+    fn branch_selection_requires_contiguous_sequence_numbers() {
+        let conn = db();
+        let founder = Dev::new(1);
+        let (acct, gbytes, gh) = genesis(&founder);
+        account_ingest(&conn, &gbytes, NOW).unwrap();
+        let b = Dev::new(2);
+        let payload = encode(&device_add(&b, DeviceRole::Member)).unwrap();
+        let gap_header = AccountEntryHeader {
+            account_id: acct,
+            log_id: 0,
+            device_fingerprint: founder.fp,
+            seq: 2,
+            prev_hash: Some(gh),
+            parent_ref: None,
+            entry_type: ops::entry_type::DEVICE_ADD,
+            op_version: 1,
+            crypto_suite: 0,
+            auth_len: 1,
+            key_id: None,
+            authority_ref: Some(gh),
+        };
+        let gap = sign_account_entry(&founder.secret, &gap_header, &payload).unwrap();
+        account_ingest(&conn, &gap.signed_bytes, NOW).unwrap();
+        assert_eq!(status(&conn, &gap.entry_hash).as_deref(), Some("forked"));
+
+        let c = Dev::new(3);
+        let (next_bytes, next) =
+            op(acct, &founder, 1, Some(gh), Some(gh), &device_add(&c, DeviceRole::Member));
+        account_ingest(&conn, &next_bytes, NOW).unwrap();
+        assert_eq!(status(&conn, &next).as_deref(), Some("accepted"));
+        assert_eq!(
+            status(&conn, &gap.entry_hash).as_deref(),
+            Some("forked"),
+            "a seq-2 sibling of seq-1 cannot extend the accepted chain",
+        );
+    }
+
+    #[test]
+    fn sequence_values_outside_sqlite_integer_are_rejected() {
+        let conn = db();
+        let founder = Dev::new(1);
+        let (acct, _gbytes, gh) = genesis(&founder);
+        let b = Dev::new(2);
+        let payload = encode(&device_add(&b, DeviceRole::Member)).unwrap();
+        let header = AccountEntryHeader {
+            account_id: acct,
+            log_id: 0,
+            device_fingerprint: founder.fp,
+            seq: i64::MAX as u64 + 1,
+            prev_hash: Some(gh),
+            parent_ref: None,
+            entry_type: ops::entry_type::DEVICE_ADD,
+            op_version: 1,
+            crypto_suite: 0,
+            auth_len: 1,
+            key_id: None,
+            authority_ref: Some(gh),
+        };
+        let signed = sign_account_entry(&founder.secret, &header, &payload).unwrap();
+        assert_eq!(
+            account_ingest(&conn, &signed.signed_bytes, NOW).unwrap(),
+            IngestOutcome::Rejected("account seq exceeds SQLite INTEGER range".into()),
+        );
+    }
+
+    #[test]
+    fn competing_pre_verify_signatures_are_retained_until_one_verifies() {
+        let conn = db();
+        let founder = Dev::new(1);
+        let (acct, gbytes, gh) = genesis(&founder);
+        let b = Dev::new(2);
+        let (valid_bytes, entry_hash) =
+            op(acct, &founder, 1, Some(gh), Some(gh), &device_add(&b, DeviceRole::Owner));
+        let mut bad_bytes = valid_bytes.clone();
+        *bad_bytes.last_mut().unwrap() ^= 1; // signature byte; body/entry_hash stays identical
+
+        assert_eq!(account_ingest(&conn, &bad_bytes, NOW).unwrap(), IngestOutcome::PreVerify);
+        assert_eq!(account_ingest(&conn, &valid_bytes, NOW).unwrap(), IngestOutcome::PreVerify);
+        let parked: i64 = conn
+            .query_row("SELECT COUNT(*) FROM account_pre_verify", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(parked, 2, "both signed envelopes for one entry body are retained");
+
+        account_ingest(&conn, &gbytes, NOW).unwrap();
+        assert_eq!(status(&conn, &entry_hash).as_deref(), Some("accepted"));
+        let parked: i64 = conn
+            .query_row("SELECT COUNT(*) FROM account_pre_verify", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(parked, 0, "both the refuted and promoted envelopes are drained");
+    }
+
+    #[test]
+    fn forged_genesis_is_rejected_before_pre_verify() {
+        let conn = db();
+        let founder = Dev::new(1);
+        let (acct, real_bytes, _gh) = genesis(&founder);
+        let attacker = Dev::new(9);
+        let genesis_payload = envelope::decode_account_signed(&real_bytes).unwrap().payload;
+        let forged_header = AccountEntryHeader {
+            account_id: acct,
+            log_id: 0,
+            device_fingerprint: attacker.fp,
+            seq: 0,
+            prev_hash: None,
+            parent_ref: None,
+            entry_type: ops::entry_type::ACCOUNT_GENESIS,
+            op_version: 1,
+            crypto_suite: 0,
+            auth_len: 0,
+            key_id: None,
+            authority_ref: None,
+        };
+        let forged =
+            sign_account_entry(&attacker.secret, &forged_header, &genesis_payload).unwrap();
+        assert!(matches!(
+            account_ingest(&conn, &forged.signed_bytes, NOW).unwrap(),
+            IngestOutcome::Rejected(_)
+        ));
+        assert_eq!(status(&conn, &forged.entry_hash), None, "founder binding refutes the forgery");
+        let parked: i64 = conn
+            .query_row("SELECT COUNT(*) FROM account_pre_verify", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(parked, 0);
+    }
+
+    #[test]
+    fn opaque_device_add_cannot_self_resolve_or_seed_key_discovery() {
+        let conn = db();
+        let founder = Dev::new(1);
+        let (acct, _gbytes, gh) = genesis(&founder);
+        let b = Dev::new(2);
+        let payload = encode(&device_add(&b, DeviceRole::Owner)).unwrap();
+        let header = AccountEntryHeader {
+            account_id: acct,
+            log_id: 0,
+            device_fingerprint: b.fp,
+            seq: 0,
+            prev_hash: None,
+            parent_ref: None,
+            entry_type: ops::entry_type::DEVICE_ADD,
+            op_version: 2,
+            crypto_suite: 0,
+            auth_len: 1,
+            key_id: None,
+            authority_ref: Some(gh),
+        };
+        let opaque = sign_account_entry(&b.secret, &header, &payload).unwrap();
+        assert_eq!(
+            account_ingest(&conn, &opaque.signed_bytes, NOW).unwrap(),
+            IngestOutcome::PreVerify
+        );
+        assert_eq!(status(&conn, &opaque.entry_hash), None);
+    }
+
+    #[test]
+    fn non_control_payload_is_retained_without_control_schema_decode() {
+        let conn = db();
+        let founder = Dev::new(1);
+        let (acct, gbytes, gh) = genesis(&founder);
+        account_ingest(&conn, &gbytes, NOW).unwrap();
+        let header = AccountEntryHeader {
+            account_id: acct,
+            log_id: 1,
+            device_fingerprint: founder.fp,
+            seq: 1,
+            prev_hash: Some(gh),
+            parent_ref: None,
+            entry_type: ops::entry_type::DEVICE_ADD,
+            op_version: 1,
+            crypto_suite: 0,
+            auth_len: 1,
+            key_id: None,
+            authority_ref: Some(gh),
+        };
+        let signed = sign_account_entry(&founder.secret, &header, &[0xff, 0x00]).unwrap();
+        assert_eq!(
+            account_ingest(&conn, &signed.signed_bytes, NOW).unwrap(),
+            IngestOutcome::Ingested { status: "retained_unfolded".into() },
+        );
     }
 
     #[test]

--- a/crates/rag-rat-core/src/oplog/account/storage.rs
+++ b/crates/rag-rat-core/src/oplog/account/storage.rs
@@ -488,6 +488,16 @@ mod tests {
         }
     }
 
+    fn device_remove(dev: &Dev, control_cut: super::super::cut::Cut) -> AccountOp {
+        AccountOp::DeviceRemove {
+            device_fingerprint: dev.fp,
+            control_cut,
+            secrets_cut: super::super::cut::Cut::Empty,
+            content_cuts: Vec::new(),
+            reason: "revoked".to_string(),
+        }
+    }
+
     fn status(conn: &Connection, hash: &[u8; 32]) -> Option<String> {
         entry_status(conn, hash).unwrap().map(|(s, _)| s)
     }
@@ -589,6 +599,58 @@ mod tests {
         let pending: i64 =
             conn.query_row("SELECT COUNT(*) FROM account_pre_verify", [], |r| r.get(0)).unwrap();
         assert_eq!(pending, 0, "the pre-verify queue is drained");
+    }
+
+    #[test]
+    fn a_cut_promotes_its_named_branch_regardless_of_arrival_order_p8() {
+        // B equivocates at seq 0 (two heads b0a/b0b). A DeviceRemove(B) names b0b as its watermark:
+        // the register condemns the OFF-branch head (b0a) and keeps b0b — promoting the cut's
+        // chosen branch over the unforced-fork hash tiebreak. The verdict is identical
+        // whichever head (or the cut) arrives first (P8 arrival-independence, I10a holds
+        // throughout).
+        for order in 0..3u8 {
+            let conn = db();
+            let founder = Dev::new(1);
+            let (acct, gbytes, gh) = genesis(&founder);
+            let b = Dev::new(2);
+            let (add_bytes, add_b) =
+                op(acct, &founder, 1, Some(gh), Some(gh), &device_add(&b, DeviceRole::Owner));
+            // B's two equivocating seq-0 heads (each adds a throwaway member so they differ).
+            let (t8, t9) = (Dev::new(8), Dev::new(9));
+            let (b0a_bytes, b0a) =
+                op(acct, &b, 0, None, Some(add_b), &device_add(&t8, DeviceRole::Member));
+            let (b0b_bytes, b0b) =
+                op(acct, &b, 0, None, Some(add_b), &device_add(&t9, DeviceRole::Member));
+            // The founder removes B, watermark = b0b (keep b0b's branch).
+            let (rm_bytes, _rm) = op(
+                acct,
+                &founder,
+                2,
+                Some(add_b),
+                Some(gh),
+                &device_remove(&b, super::super::cut::Cut::At { seq: 0, hash: b0b }),
+            );
+
+            // Ingest genesis + add_b first (so B resolves), then the three in a rotated order.
+            account_ingest(&conn, &gbytes, NOW).unwrap();
+            account_ingest(&conn, &add_bytes, NOW).unwrap();
+            let mut rest = [&b0a_bytes, &b0b_bytes, &rm_bytes];
+            rest.rotate_left(order as usize);
+            for bytes in rest {
+                account_ingest(&conn, bytes, NOW).unwrap();
+            }
+
+            assert_eq!(
+                status(&conn, &b0b).as_deref(),
+                Some("accepted"),
+                "the cut-named branch b0b is accepted (order {order})",
+            );
+            assert_eq!(
+                status(&conn, &b0a).as_deref(),
+                Some("condemned"),
+                "the off-branch head b0a is condemned (order {order})",
+            );
+        }
     }
 
     #[test]

--- a/crates/rag-rat-core/src/oplog/account/storage.rs
+++ b/crates/rag-rat-core/src/oplog/account/storage.rs
@@ -586,6 +586,46 @@ mod tests {
     }
 
     #[test]
+    fn malformed_envelopes_and_wrong_genesis_self_hashes_never_touch_storage() {
+        let conn = db();
+        assert!(matches!(account_ingest(&conn, &[0xff], NOW).unwrap(), IngestOutcome::Rejected(_)));
+
+        let founder = Dev::new(1);
+        let genesis_op = AccountOp::AccountGenesis {
+            ed25519_pubkey: founder.ed,
+            x25519_pubkey: founder.x,
+            nonce16: [0u8; 16],
+            created_at_ms: NOW as u64,
+            label: None,
+        };
+        let payload = encode(&genesis_op).unwrap();
+        let wrong_account = AccountId::from_bytes([0x55; 32]);
+        assert_ne!(wrong_account, account_id_from_genesis_payload(&payload));
+        let header = AccountEntryHeader {
+            account_id: wrong_account,
+            log_id: 0,
+            device_fingerprint: founder.fp,
+            seq: 0,
+            prev_hash: None,
+            parent_ref: None,
+            entry_type: ops::entry_type::ACCOUNT_GENESIS,
+            op_version: 1,
+            crypto_suite: 0,
+            auth_len: 0,
+            key_id: None,
+            authority_ref: None,
+        };
+        let signed = sign_account_entry(&founder.secret, &header, &payload).unwrap();
+        assert_eq!(
+            account_ingest(&conn, &signed.signed_bytes, NOW).unwrap(),
+            IngestOutcome::Rejected("genesis payload does not hash to its account_id".into()),
+        );
+        let stored: i64 =
+            conn.query_row("SELECT COUNT(*) FROM account_entries", [], |row| row.get(0)).unwrap();
+        assert_eq!(stored, 0, "structural rejects never create candidate rows");
+    }
+
+    #[test]
     fn a_forged_re_signed_genesis_is_rejected_not_stored() {
         // A non-owner re-signs the victim's genesis payload under its own key: the fold binds the
         // founder key, so ingest verifies but the fold classifies the forgery non-effective. (The
@@ -894,5 +934,124 @@ mod tests {
             "a malformed op payload is rejected: {out:?}"
         );
         assert_eq!(status(&conn, &signed.entry_hash), None, "and is never stored");
+    }
+
+    #[test]
+    fn sealed_and_future_version_payloads_remain_opaque_through_ingest() {
+        // C1 does not understand sealed ciphertext or future op versions. Both must remain valid
+        // ancestry/watermark targets instead of being decoded with today's plaintext schema.
+        let conn = db();
+        let founder = Dev::new(1);
+        let (acct, gbytes, gh) = genesis(&founder);
+        account_ingest(&conn, &gbytes, NOW).unwrap();
+
+        let opaque = [0xff, 0x00, 0xff]; // deliberately not a current DeviceAdd payload
+        let sealed_header = AccountEntryHeader {
+            account_id: acct,
+            log_id: 0,
+            device_fingerprint: founder.fp,
+            seq: 1,
+            prev_hash: Some(gh),
+            parent_ref: None,
+            entry_type: ops::entry_type::DEVICE_ADD,
+            op_version: 1,
+            crypto_suite: 1,
+            auth_len: 1,
+            key_id: Some([0x44; 32]),
+            authority_ref: Some(gh),
+        };
+        let sealed = sign_account_entry(&founder.secret, &sealed_header, &opaque).unwrap();
+        assert_eq!(
+            account_ingest(&conn, &sealed.signed_bytes, NOW).unwrap(),
+            IngestOutcome::Ingested { status: "retained_unfolded".into() },
+        );
+
+        let future_header = AccountEntryHeader {
+            seq: 2,
+            prev_hash: Some(sealed.entry_hash),
+            op_version: 2,
+            crypto_suite: 0,
+            key_id: None,
+            ..sealed_header
+        };
+        let future = sign_account_entry(&founder.secret, &future_header, &opaque).unwrap();
+        assert_eq!(
+            account_ingest(&conn, &future.signed_bytes, NOW).unwrap(),
+            IngestOutcome::Ingested { status: "retained_unfolded".into() },
+        );
+        assert_eq!(status(&conn, &sealed.entry_hash).as_deref(), Some("retained_unfolded"));
+        assert_eq!(status(&conn, &future.entry_hash).as_deref(), Some("retained_unfolded"));
+    }
+
+    #[test]
+    fn malformed_pre_verify_payload_is_discarded_when_its_signer_resolves() {
+        // A malformed entry can arrive before its signer is known, so the first ingest cannot
+        // authenticate or inspect its plaintext. Once DeviceAdd resolves the signer, promotion
+        // must apply the same structural gate as direct ingest and delete—not persist—the entry.
+        let conn = db();
+        let founder = Dev::new(1);
+        let (acct, gbytes, gh) = genesis(&founder);
+        let b = Dev::new(2);
+        let malformed_header = AccountEntryHeader {
+            account_id: acct,
+            log_id: 0,
+            device_fingerprint: b.fp,
+            seq: 0,
+            prev_hash: None,
+            parent_ref: None,
+            entry_type: ops::entry_type::DEVICE_ADD,
+            op_version: 1,
+            crypto_suite: 0,
+            auth_len: 1,
+            key_id: None,
+            authority_ref: Some(gh),
+        };
+        let malformed =
+            sign_account_entry(&b.secret, &malformed_header, &[0xff, 0xff, 0xff]).unwrap();
+        assert_eq!(
+            account_ingest(&conn, &malformed.signed_bytes, NOW).unwrap(),
+            IngestOutcome::PreVerify,
+        );
+
+        account_ingest(&conn, &gbytes, NOW).unwrap();
+        let (add_b_bytes, _) =
+            op(acct, &founder, 1, Some(gh), Some(gh), &device_add(&b, DeviceRole::Owner));
+        account_ingest(&conn, &add_b_bytes, NOW).unwrap();
+
+        assert_eq!(
+            status(&conn, &malformed.entry_hash),
+            None,
+            "malformed bytes never enter the DAG"
+        );
+        let pending: i64 = conn
+            .query_row("SELECT COUNT(*) FROM account_pre_verify", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(pending, 0, "the now-refuted queued entry is deleted");
+    }
+
+    #[test]
+    fn refold_is_idempotent_and_preserves_the_selected_branch() {
+        let conn = db();
+        let founder = Dev::new(1);
+        let (acct, gbytes, gh) = genesis(&founder);
+        account_ingest(&conn, &gbytes, NOW).unwrap();
+        let b = Dev::new(2);
+        let (add_bytes, add_hash) =
+            op(acct, &founder, 1, Some(gh), Some(gh), &device_add(&b, DeviceRole::Owner));
+        account_ingest(&conn, &add_bytes, NOW).unwrap();
+
+        refold_account(&conn, acct).unwrap();
+        refold_account(&conn, acct).unwrap();
+
+        assert_eq!(status(&conn, &gh).as_deref(), Some("accepted"));
+        assert_eq!(status(&conn, &add_hash).as_deref(), Some("accepted"));
+        let accepted: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM account_entries WHERE account_id = ?1 AND accepted = 1",
+                params![acct.to_bytes().as_slice()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(accepted, 2, "repeated clear-and-set refolds keep the same accepted chain");
     }
 }

--- a/crates/rag-rat-core/src/oplog/account/storage.rs
+++ b/crates/rag-rat-core/src/oplog/account/storage.rs
@@ -1,0 +1,634 @@
+//! §16 account candidate-DAG storage: ingest, content-addressed device resolution, the pre-verify
+//! queue, and `refold_account` — the pure [`super::fold::fold_account`] plus branch selection
+//! (§16.2) projected onto the `accepted` flag + the §16.3 status taxonomy.
+//!
+//! The candidate table (`account_entries`) is grow-only and holds EVERY
+//! structurally/signature-valid entry, all branches of an equivocating chain first-class (no
+//! seq-uniqueness). `accepted` is DERIVED — rewritten atomically by every refold, gated by the
+//! `account_accepted_slot` partial unique index (I10a) — never authored. Nothing here touches
+//! [`super::super::store::append`]; the account layer is a separate signed wire layer with its own
+//! DAG.
+
+use std::collections::HashMap;
+
+use rusqlite::{Connection, OptionalExtension, Transaction, TransactionBehavior, params};
+
+use super::envelope::{self, AccountEntryHeader, VerifiedAccountEntry};
+use super::id::account_id_from_genesis_payload;
+use super::ops::{self, AccountOp, DecodedAccountOp};
+use super::{AccountId, fold};
+use crate::oplog::device::DevicePublic;
+use crate::oplog::op::DeviceFingerprint;
+
+/// The result of ingesting one signed account entry (§16.2).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum IngestOutcome {
+    /// Structurally rejected (bad canonicity / over §18a / bad signature / fingerprint or self-hash
+    /// mismatch) — NEVER stored.
+    Rejected(String),
+    /// The signing device is not yet resolvable (`sha256(pk)` matches no known fingerprint) — held
+    /// durably in `account_pre_verify`, retried when a later DeviceAdd/AccountGenesis arrives.
+    PreVerify,
+    /// Stored as a candidate; `status` is its post-refold §16.3 taxonomy label.
+    Ingested { status: String },
+}
+
+/// Ingest one signed account entry: structural decode → content-addressed device resolution →
+/// signature verify → genesis self-hash → `INSERT OR IGNORE` into the candidate DAG → promote any
+/// pre-verify rows this entry now resolves → `refold_account`. Opens its own IMMEDIATE transaction.
+pub(crate) fn account_ingest(
+    conn: &Connection,
+    signed_bytes: &[u8],
+    now_ms: i64,
+) -> anyhow::Result<IngestOutcome> {
+    // Structure + §18a size + canonicity (never stored on failure).
+    let signed = match envelope::decode_account_signed(signed_bytes) {
+        Ok(signed) => signed,
+        Err(err) => return Ok(IngestOutcome::Rejected(err.to_string())),
+    };
+    let account_id = signed.header.account_id;
+    let device_fp = signed.header.device_fingerprint;
+
+    // Resolve the signer's ed25519 pubkey content-addressedly: from stored genesis/DeviceAdd
+    // candidates for this account, plus THIS entry if it self-certifies (a genesis / a DeviceAdd of
+    // its own signer). Unresolvable ⇒ pre-verify queue.
+    let mut pubkeys = stored_device_pubkeys(conn, account_id)?;
+    add_self_pubkey(&mut pubkeys, &signed.header, &signed.payload);
+    let Some(pubkey_bytes) = pubkeys.get(&device_fp).copied() else {
+        insert_pre_verify(conn, &signed.entry_hash, account_id, device_fp, signed_bytes, now_ms)?;
+        return Ok(IngestOutcome::PreVerify);
+    };
+
+    // Verify the signature under the resolved key (also re-binds fingerprint == sha256(pk)).
+    let Ok(pubkey) = DevicePublic::from_bytes(&pubkey_bytes) else {
+        return Ok(IngestOutcome::Rejected("resolved device key is not a valid point".into()));
+    };
+    let verified = match envelope::verify_account_signed(signed_bytes, &pubkey) {
+        Ok(verified) => verified,
+        Err(err) => return Ok(IngestOutcome::Rejected(err.to_string())),
+    };
+    // A genesis must self-hash to its account_id (§4) — a structural reject, before it can seed a
+    // DAG.
+    if is_genesis(&verified.header)
+        && account_id_from_genesis_payload(&verified.payload) != account_id
+    {
+        return Ok(IngestOutcome::Rejected(
+            "genesis payload does not hash to its account_id".into(),
+        ));
+    }
+
+    let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
+    insert_candidate(&tx, &verified, signed_bytes, now_ms)?;
+    // A DeviceAdd/genesis may resolve devices that were parked — retry their pre-verify rows.
+    if is_genesis(&verified.header) || is_device_add(&verified) {
+        promote_pre_verify(&tx, account_id, now_ms)?;
+    }
+    let status = refold_in_tx(&tx, account_id)?;
+    tx.commit()?;
+    Ok(IngestOutcome::Ingested {
+        status: status.get(&verified.entry_hash).cloned().unwrap_or_else(|| "unknown".into()),
+    })
+}
+
+/// Re-derive the whole account: fold the candidate set, resolve accepted-slot uniqueness (branch
+/// selection §16.2), and rewrite `accepted` + `account_entry_status` in one IMMEDIATE transaction
+/// so the `account_accepted_slot` partial unique index (I10a) never transiently double-accepts a
+/// slot.
+pub(super) fn refold_account(conn: &Connection, account_id: AccountId) -> anyhow::Result<()> {
+    let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
+    refold_in_tx(&tx, account_id)?;
+    tx.commit()?;
+    Ok(())
+}
+
+/// The refold body (caller owns the txn). Returns each entry_hash → its projected status.
+fn refold_in_tx(
+    tx: &Transaction<'_>,
+    account_id: AccountId,
+) -> anyhow::Result<HashMap<[u8; 32], String>> {
+    let rows = load_candidates(tx, account_id)?;
+    let entries: Vec<VerifiedAccountEntry> = rows.iter().map(|r| r.verified.clone()).collect();
+    let history = fold::fold_account(&entries);
+
+    // Branch selection: an entry is a candidate for `accepted` iff the fold makes it effective;
+    // when two effective entries collide on one (device, seq) slot (an unforced fork the
+    // registers did not resolve), the lexicographically-smaller entry_hash wins the slot and
+    // the loser is `forked` (I10a). Register-named branches were already promoted inside the
+    // fold (off-branch → condemned).
+    let mut slot_winner: HashMap<(DeviceFingerprint, u64), [u8; 32]> = HashMap::new();
+    for row in &rows {
+        if history.outcome(&row.entry_hash).is_some_and(|o| o.is_effective()) {
+            slot_winner
+                .entry((row.device_fingerprint, row.seq))
+                .and_modify(|best| {
+                    if row.entry_hash < *best {
+                        *best = row.entry_hash;
+                    }
+                })
+                .or_insert(row.entry_hash);
+        }
+    }
+
+    // Rewrite: clear every accepted flag for the account, then re-set the winners — atomically,
+    // so the partial unique index never sees two accepted rows at one slot mid-transaction.
+    tx.execute("UPDATE account_entries SET accepted = 0 WHERE account_id = ?1", params![
+        account_id.to_bytes().as_slice()
+    ])?;
+
+    let mut statuses: HashMap<[u8; 32], String> = HashMap::new();
+    for row in &rows {
+        let effective = history.outcome(&row.entry_hash).is_some_and(|o| o.is_effective());
+        let accepted = effective
+            && slot_winner.get(&(row.device_fingerprint, row.seq)) == Some(&row.entry_hash);
+        let (status, detail): (String, Option<String>) = if accepted {
+            ("accepted".to_string(), None)
+        } else if effective {
+            // Effective but lost the slot tiebreak — an equivocation loser.
+            ("forked".to_string(), None)
+        } else {
+            match history.outcome(&row.entry_hash) {
+                Some(outcome) => {
+                    let (s, d) = outcome.taxonomy();
+                    (s.to_string(), d.map(str::to_string))
+                },
+                // Not in the fold's outcome map (unreachable — every candidate is classified).
+                None => ("retained_unfolded".to_string(), None),
+            }
+        };
+        if accepted {
+            tx.execute("UPDATE account_entries SET accepted = 1 WHERE entry_hash = ?1", params![
+                row.entry_hash.as_slice()
+            ])?;
+        }
+        tx.execute(
+            "INSERT INTO account_entry_status(entry_hash, status, detail) VALUES (?1, ?2, ?3)
+             ON CONFLICT(entry_hash) DO UPDATE SET status = excluded.status, detail = \
+             excluded.detail",
+            params![row.entry_hash.as_slice(), status, detail],
+        )?;
+        statuses.insert(row.entry_hash, status);
+    }
+    Ok(statuses)
+}
+
+/// A stored candidate row, with its verified entry reconstituted from the trusted stored bytes (the
+/// signature was checked at ingest; the local DB is the trust boundary, so we re-decode STRUCTURE
+/// only rather than re-verify — which would need the device set we are loading).
+struct CandidateRow {
+    entry_hash: [u8; 32],
+    device_fingerprint: DeviceFingerprint,
+    seq: u64,
+    verified: VerifiedAccountEntry,
+}
+
+fn load_candidates(conn: &Connection, account_id: AccountId) -> anyhow::Result<Vec<CandidateRow>> {
+    let mut stmt = conn.prepare(
+        "SELECT entry_hash, device_fingerprint, seq, signed_bytes
+         FROM account_entries WHERE account_id = ?1
+         ORDER BY entry_hash", // deterministic load order (the fold is order-free regardless)
+    )?;
+    let rows = stmt
+        .query_map(params![account_id.to_bytes().as_slice()], |row| {
+            Ok((
+                row.get::<_, Vec<u8>>(0)?,
+                row.get::<_, Vec<u8>>(1)?,
+                row.get::<_, i64>(2)?,
+                row.get::<_, Vec<u8>>(3)?,
+            ))
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    let mut out = Vec::with_capacity(rows.len());
+    for (hash, fp, seq, signed_bytes) in rows {
+        let signed = envelope::decode_account_signed(&signed_bytes)
+            .map_err(|err| anyhow::anyhow!("stored candidate re-decode failed: {err}"))?;
+        out.push(CandidateRow {
+            entry_hash: fixed(&hash)?,
+            device_fingerprint: DeviceFingerprint::from_bytes(fixed(&fp)?),
+            seq: seq as u64,
+            verified: VerifiedAccountEntry {
+                header: signed.header,
+                payload: signed.payload,
+                entry_hash: signed.entry_hash,
+            },
+        });
+    }
+    Ok(out)
+}
+
+fn insert_candidate(
+    tx: &Transaction<'_>,
+    verified: &VerifiedAccountEntry,
+    signed_bytes: &[u8],
+    now_ms: i64,
+) -> rusqlite::Result<()> {
+    let h = &verified.header;
+    // INSERT OR IGNORE on the entry_hash PK: idempotent, and the candidate table has NO
+    // seq-uniqueness — an equivocation head at an already-occupied slot is a first-class candidate.
+    tx.execute(
+        "INSERT OR IGNORE INTO account_entries(
+             entry_hash, account_id, log_id, device_fingerprint, seq, prev_hash, parent_ref,
+             authority_ref, entry_type, accepted, signed_bytes, received_at_ms)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, 0, ?10, ?11)",
+        params![
+            verified.entry_hash.as_slice(),
+            h.account_id.to_bytes().as_slice(),
+            h.log_id,
+            h.device_fingerprint.to_bytes().as_slice(),
+            h.seq as i64,
+            h.prev_hash.map(|p| p.to_vec()),
+            h.parent_ref.map(|p| p.to_vec()),
+            h.authority_ref.map(|p| p.to_vec()),
+            h.entry_type,
+            signed_bytes,
+            now_ms,
+        ],
+    )?;
+    Ok(())
+}
+
+/// The `(fingerprint → ed25519_pubkey)` map from every stored genesis / DeviceAdd for the account —
+/// the only ops that carry a device's key. Fold-status-independent (§16.2): a key resolves from ANY
+/// stored candidate carrying it, whether or not it is currently accepted.
+fn stored_device_pubkeys(
+    conn: &Connection,
+    account_id: AccountId,
+) -> anyhow::Result<HashMap<DeviceFingerprint, [u8; 32]>> {
+    let mut stmt = conn.prepare(
+        "SELECT signed_bytes FROM account_entries WHERE account_id = ?1 AND entry_type IN (?2, ?3)",
+    )?;
+    let rows = stmt
+        .query_map(
+            params![
+                account_id.to_bytes().as_slice(),
+                ops::entry_type::ACCOUNT_GENESIS,
+                ops::entry_type::DEVICE_ADD,
+            ],
+            |row| row.get::<_, Vec<u8>>(0),
+        )?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    let mut out = HashMap::new();
+    for signed_bytes in rows {
+        if let Ok(signed) = envelope::decode_account_signed(&signed_bytes) {
+            add_self_pubkey(&mut out, &signed.header, &signed.payload);
+        }
+    }
+    Ok(out)
+}
+
+/// Add the `(fingerprint → pubkey)` an entry itself certifies: a genesis certifies its founder key
+/// (the SIGNER); a DeviceAdd certifies the ADDED device's key. Both bind `sha256(pk) ==
+/// fingerprint` (genesis: the header device; DeviceAdd: the op's `device_fingerprint`, enforced at
+/// decode).
+fn add_self_pubkey(
+    map: &mut HashMap<DeviceFingerprint, [u8; 32]>,
+    header: &AccountEntryHeader,
+    payload: &[u8],
+) {
+    if let Ok(DecodedAccountOp::Known(op)) = ops::decode(header.entry_type, payload) {
+        match op {
+            AccountOp::AccountGenesis { ed25519_pubkey, .. } => {
+                map.insert(header.device_fingerprint, ed25519_pubkey);
+            },
+            AccountOp::DeviceAdd { device_fingerprint, ed25519_pubkey, .. } => {
+                map.insert(device_fingerprint, ed25519_pubkey);
+            },
+            _ => {},
+        }
+    }
+}
+
+fn insert_pre_verify(
+    conn: &Connection,
+    entry_hash: &[u8; 32],
+    account_id: AccountId,
+    fingerprint: DeviceFingerprint,
+    signed_bytes: &[u8],
+    now_ms: i64,
+) -> rusqlite::Result<()> {
+    conn.execute(
+        "INSERT OR IGNORE INTO account_pre_verify(
+             entry_hash, claimed_account_id, claimed_fingerprint, raw_bytes, received_at_ms)
+         VALUES (?1, ?2, ?3, ?4, ?5)",
+        params![
+            entry_hash.as_slice(),
+            account_id.to_bytes().as_slice(),
+            fingerprint.to_bytes().as_slice(),
+            signed_bytes,
+            now_ms,
+        ],
+    )?;
+    Ok(())
+}
+
+/// Retry every pre-verify row for the account against the now-larger device set: a row whose signer
+/// resolves is verified + promoted into `account_entries` and cleared; the rest stay parked.
+fn promote_pre_verify(
+    tx: &Transaction<'_>,
+    account_id: AccountId,
+    now_ms: i64,
+) -> anyhow::Result<()> {
+    let pubkeys = stored_device_pubkeys(tx, account_id)?;
+    let pending: Vec<(Vec<u8>, Vec<u8>, Vec<u8>)> = {
+        let mut stmt = tx.prepare(
+            "SELECT entry_hash, claimed_fingerprint, raw_bytes
+             FROM account_pre_verify WHERE claimed_account_id = ?1",
+        )?;
+        stmt.query_map(params![account_id.to_bytes().as_slice()], |row| {
+            Ok((row.get::<_, Vec<u8>>(0)?, row.get::<_, Vec<u8>>(1)?, row.get::<_, Vec<u8>>(2)?))
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?
+    };
+    for (entry_hash, fp_bytes, raw_bytes) in pending {
+        let fp = DeviceFingerprint::from_bytes(fixed(&fp_bytes)?);
+        let Some(pk_bytes) = pubkeys.get(&fp).copied() else {
+            continue; // still unresolvable
+        };
+        let promoted = DevicePublic::from_bytes(&pk_bytes)
+            .ok()
+            .and_then(|pk| envelope::verify_account_signed(&raw_bytes, &pk).ok())
+            .filter(|v| {
+                !is_genesis(&v.header)
+                    || account_id_from_genesis_payload(&v.payload) == v.header.account_id
+            });
+        if let Some(verified) = promoted {
+            insert_candidate(tx, &verified, &raw_bytes, now_ms)?;
+        }
+        // Resolved (promoted) or refuted (verify failed): clear it from the queue either way.
+        tx.execute("DELETE FROM account_pre_verify WHERE entry_hash = ?1", params![
+            entry_hash.as_slice()
+        ])?;
+    }
+    Ok(())
+}
+
+fn is_genesis(header: &AccountEntryHeader) -> bool {
+    header.entry_type == ops::entry_type::ACCOUNT_GENESIS
+}
+
+fn is_device_add(verified: &VerifiedAccountEntry) -> bool {
+    verified.header.entry_type == ops::entry_type::DEVICE_ADD
+}
+
+/// A stored 32-byte column as a fixed array (errors, never panics, on a wrong-length blob).
+fn fixed(bytes: &[u8]) -> anyhow::Result<[u8; 32]> {
+    bytes.try_into().map_err(|_| anyhow::anyhow!("stored hash is {} bytes, not 32", bytes.len()))
+}
+
+/// The projected status of a single entry (§16.3), or `None` if the entry isn't stored (e.g. it is
+/// still in the pre-verify queue). A read helper for queries.
+pub(super) fn entry_status(
+    conn: &Connection,
+    entry_hash: &[u8; 32],
+) -> anyhow::Result<Option<(String, Option<String>)>> {
+    Ok(conn
+        .query_row(
+            "SELECT status, detail FROM account_entry_status WHERE entry_hash = ?1",
+            params![entry_hash.as_slice()],
+            |row| Ok((row.get::<_, String>(0)?, row.get::<_, Option<String>>(1)?)),
+        )
+        .optional()?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::index::schema;
+    use crate::oplog::account::envelope::sign_account_entry;
+    use crate::oplog::account::ops::{DeviceRole, encode, entry_type_of};
+    use crate::oplog::device::{DeviceSecret, DeviceX25519Secret};
+
+    const NOW: i64 = 1_700_000_000_000;
+
+    fn db() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        schema::apply(&conn).unwrap();
+        conn
+    }
+
+    struct Dev {
+        secret: DeviceSecret,
+        fp: DeviceFingerprint,
+        ed: [u8; 32],
+        x: [u8; 32],
+    }
+
+    impl Dev {
+        fn new(seed: u8) -> Self {
+            let secret = DeviceSecret::from_seed(&[seed; 32]);
+            let public = secret.public();
+            let x =
+                DeviceX25519Secret::from_seed(&[seed.wrapping_add(0x80); 32]).public().to_bytes();
+            Dev { fp: public.fingerprint(), ed: public.to_bytes(), x, secret }
+        }
+    }
+
+    fn genesis(founder: &Dev) -> (AccountId, Vec<u8>, [u8; 32]) {
+        let op = AccountOp::AccountGenesis {
+            ed25519_pubkey: founder.ed,
+            x25519_pubkey: founder.x,
+            nonce16: [0u8; 16],
+            created_at_ms: NOW as u64,
+            label: None,
+        };
+        let payload = encode(&op).unwrap();
+        let account_id = account_id_from_genesis_payload(&payload);
+        let header = AccountEntryHeader {
+            account_id,
+            log_id: 0,
+            device_fingerprint: founder.fp,
+            seq: 0,
+            prev_hash: None,
+            parent_ref: None,
+            entry_type: ops::entry_type::ACCOUNT_GENESIS,
+            op_version: 1,
+            crypto_suite: 0,
+            auth_len: 0,
+            key_id: None,
+            authority_ref: None,
+        };
+        let signed = sign_account_entry(&founder.secret, &header, &payload).unwrap();
+        (account_id, signed.signed_bytes, signed.entry_hash)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn op(
+        account_id: AccountId,
+        signer: &Dev,
+        seq: u64,
+        prev: Option<[u8; 32]>,
+        authority_ref: Option<[u8; 32]>,
+        op: &AccountOp,
+    ) -> (Vec<u8>, [u8; 32]) {
+        let payload = encode(op).unwrap();
+        let header = AccountEntryHeader {
+            account_id,
+            log_id: 0,
+            device_fingerprint: signer.fp,
+            seq,
+            prev_hash: prev,
+            parent_ref: None,
+            entry_type: entry_type_of(op),
+            op_version: 1,
+            crypto_suite: 0,
+            auth_len: 1,
+            key_id: None,
+            authority_ref,
+        };
+        let signed = sign_account_entry(&signer.secret, &header, &payload).unwrap();
+        (signed.signed_bytes, signed.entry_hash)
+    }
+
+    fn device_add(dev: &Dev, role: DeviceRole) -> AccountOp {
+        AccountOp::DeviceAdd {
+            device_fingerprint: dev.fp,
+            ed25519_pubkey: dev.ed,
+            x25519_pubkey: dev.x,
+            role,
+            label: None,
+        }
+    }
+
+    fn status(conn: &Connection, hash: &[u8; 32]) -> Option<String> {
+        entry_status(conn, hash).unwrap().map(|(s, _)| s)
+    }
+
+    #[test]
+    fn a_genesis_ingests_and_is_accepted() {
+        let conn = db();
+        let (_acct, bytes, gh) = genesis(&Dev::new(1));
+        let out = account_ingest(&conn, &bytes, NOW).unwrap();
+        assert_eq!(out, IngestOutcome::Ingested { status: "accepted".into() });
+        assert_eq!(status(&conn, &gh).as_deref(), Some("accepted"));
+    }
+
+    #[test]
+    fn a_forged_re_signed_genesis_is_rejected_not_stored() {
+        // A non-owner re-signs the victim's genesis payload under its own key: the fold binds the
+        // founder key, so ingest verifies but the fold classifies the forgery non-effective. (The
+        // signature verifies under the attacker key AND fingerprint matches — the takeover defence
+        // is the fold's founder binding, exercised end-to-end through ingest.)
+        let conn = db();
+        let (acct, real_bytes, real_gh) = genesis(&Dev::new(1));
+        account_ingest(&conn, &real_bytes, NOW).unwrap();
+        // The attacker re-signs the SAME payload (same account_id) under its own key.
+        let attacker = Dev::new(9);
+        let victim = Dev::new(1);
+        let op = AccountOp::AccountGenesis {
+            ed25519_pubkey: victim.ed,
+            x25519_pubkey: victim.x,
+            nonce16: [0u8; 16],
+            created_at_ms: NOW as u64,
+            label: None,
+        };
+        let payload = encode(&op).unwrap();
+        let header = AccountEntryHeader {
+            account_id: acct,
+            log_id: 0,
+            device_fingerprint: attacker.fp,
+            seq: 0,
+            prev_hash: None,
+            parent_ref: None,
+            entry_type: ops::entry_type::ACCOUNT_GENESIS,
+            op_version: 1,
+            crypto_suite: 0,
+            auth_len: 0,
+            key_id: None,
+            authority_ref: None,
+        };
+        let signed = sign_account_entry(&attacker.secret, &header, &payload).unwrap();
+        account_ingest(&conn, &signed.signed_bytes, NOW).unwrap();
+        assert_eq!(
+            status(&conn, &real_gh).as_deref(),
+            Some("accepted"),
+            "the real founder holds it"
+        );
+        assert_ne!(
+            status(&conn, &signed.entry_hash).as_deref(),
+            Some("accepted"),
+            "the forged re-signed genesis never becomes the accepted root",
+        );
+    }
+
+    #[test]
+    fn an_owner_added_after_genesis_is_accepted() {
+        let conn = db();
+        let founder = Dev::new(1);
+        let (acct, gbytes, gh) = genesis(&founder);
+        account_ingest(&conn, &gbytes, NOW).unwrap();
+        let b = Dev::new(2);
+        let (add_bytes, add_hash) =
+            op(acct, &founder, 1, Some(gh), Some(gh), &device_add(&b, DeviceRole::Owner));
+        let out = account_ingest(&conn, &add_bytes, NOW).unwrap();
+        assert_eq!(out, IngestOutcome::Ingested { status: "accepted".into() });
+        assert_eq!(status(&conn, &add_hash).as_deref(), Some("accepted"));
+    }
+
+    #[test]
+    fn an_entry_whose_device_is_unknown_is_pre_verified_then_promoted() {
+        // Ingest a founder-signed DeviceAdd BEFORE the genesis: the founder's key isn't resolvable,
+        // so it parks in pre-verify. The genesis arrival resolves the founder and promotes it.
+        let conn = db();
+        let founder = Dev::new(1);
+        let (acct, gbytes, gh) = genesis(&founder);
+        let b = Dev::new(2);
+        let (add_bytes, add_hash) =
+            op(acct, &founder, 1, Some(gh), Some(gh), &device_add(&b, DeviceRole::Owner));
+
+        // The add arrives first — unresolvable device → pre-verify.
+        assert_eq!(account_ingest(&conn, &add_bytes, NOW).unwrap(), IngestOutcome::PreVerify);
+        assert_eq!(status(&conn, &add_hash), None, "not yet a stored candidate");
+
+        // The genesis resolves the founder and promotes the queued add.
+        account_ingest(&conn, &gbytes, NOW).unwrap();
+        assert_eq!(status(&conn, &gh).as_deref(), Some("accepted"));
+        assert_eq!(
+            status(&conn, &add_hash).as_deref(),
+            Some("accepted"),
+            "the queued add promoted"
+        );
+        let pending: i64 =
+            conn.query_row("SELECT COUNT(*) FROM account_pre_verify", [], |r| r.get(0)).unwrap();
+        assert_eq!(pending, 0, "the pre-verify queue is drained");
+    }
+
+    #[test]
+    fn an_equivocation_accepts_one_head_and_forks_the_other() {
+        // The founder equivocates: two DIFFERENT seq-1 entries on its own chain. Both fold
+        // effective, but only one can occupy the (device, seq) slot (I10a) — the smaller
+        // entry_hash wins, the other is `forked`. The partial unique index would blow up if
+        // refold accepted both.
+        let conn = db();
+        let founder = Dev::new(1);
+        let (acct, gbytes, gh) = genesis(&founder);
+        account_ingest(&conn, &gbytes, NOW).unwrap();
+        let (b, c) = (Dev::new(2), Dev::new(3));
+        let (b_bytes, b_hash) =
+            op(acct, &founder, 1, Some(gh), Some(gh), &device_add(&b, DeviceRole::Member));
+        let (c_bytes, c_hash) =
+            op(acct, &founder, 1, Some(gh), Some(gh), &device_add(&c, DeviceRole::Member));
+        account_ingest(&conn, &b_bytes, NOW).unwrap();
+        account_ingest(&conn, &c_bytes, NOW).unwrap();
+
+        let (winner, loser) = if b_hash < c_hash { (b_hash, c_hash) } else { (c_hash, b_hash) };
+        assert_eq!(
+            status(&conn, &winner).as_deref(),
+            Some("accepted"),
+            "smaller hash wins the slot"
+        );
+        assert_eq!(
+            status(&conn, &loser).as_deref(),
+            Some("forked"),
+            "the equivocation loser forks"
+        );
+        // I10a: exactly one accepted entry at the (founder, seq 1) slot.
+        let accepted_at_slot: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM account_entries
+                 WHERE account_id = ?1 AND device_fingerprint = ?2 AND seq = 1 AND accepted = 1",
+                params![acct.to_bytes().as_slice(), founder.fp.to_bytes().as_slice()],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(accepted_at_slot, 1, "one accepted head per slot (I10a)");
+    }
+}

--- a/crates/rag-rat-core/src/oplog/account/storage.rs
+++ b/crates/rag-rat-core/src/oplog/account/storage.rs
@@ -9,7 +9,7 @@
 //! [`super::super::store::append`]; the account layer is a separate signed wire layer with its own
 //! DAG.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use rusqlite::{Connection, OptionalExtension, Transaction, TransactionBehavior, params};
 
@@ -84,6 +84,13 @@ pub(crate) fn account_ingest(
             "genesis payload does not hash to its account_id".into(),
         ));
     }
+    // The op payload has not been decoded yet — the envelope carries it opaque. A current-version
+    // plaintext op whose payload is malformed / non-canonical is a STRUCTURAL reject and must never
+    // enter the grow-only DAG. Sealed ciphertext and future-version payloads are intentionally
+    // opaque here: their own layer/version validates them, while C1 retains their headers.
+    if let Err(err) = validate_current_plaintext_payload(&verified) {
+        return Ok(IngestOutcome::Rejected(format!("op payload decode failed: {err}")));
+    }
 
     insert_candidate(&tx, &verified, signed_bytes, now_ms)?;
     // A DeviceAdd/genesis may resolve devices that were parked — retry their pre-verify rows.
@@ -117,24 +124,48 @@ fn refold_in_tx(
     let entries: Vec<VerifiedAccountEntry> = rows.iter().map(|r| r.verified.clone()).collect();
     let history = fold::fold_account(&entries);
 
-    // Branch selection: an entry is a candidate for `accepted` iff the fold makes it effective;
-    // when two effective entries collide on one (log, device, seq) slot (an unforced fork the
-    // registers did not resolve), the lexicographically-smaller entry_hash wins the slot and
-    // the loser is `forked` (I10a). The slot key mirrors the account_accepted_slot unique index
-    // exactly — including log_id, so a future effective non-control-log entry can never be
-    // mistaken for a control-log rival at the same (device, seq). Register-named branches were
-    // already promoted inside the fold (off-branch → condemned).
-    let mut slot_winner: HashMap<(u8, DeviceFingerprint, u64), [u8; 32]> = HashMap::new();
+    // Branch selection (§16.2): project the fold's effective entries onto a single accepted
+    // hash-chain per (log, device). From the smallest-entry_hash root (an effective entry with no
+    // prev_hash) walk forward, taking the smallest-entry_hash child (an effective entry whose
+    // prev_hash cites the current head) at each step. The min-hash tiebreak resolves an unforced
+    // equivocation the registers did not; crucially, an effective entry that chains from a LOSING
+    // head is off-branch and is NOT accepted — accepting it would leave the accepted history with
+    // an entry whose parent is `forked`, i.e. no longer a single chain under equivocation (the
+    // account_accepted_slot partial unique index keeps one accepted row per slot (I10a), but chain
+    // coherence needs the whole walk). Register-named branches were already promoted inside the
+    // fold (off-branch → condemned).
+    let effective: HashSet<[u8; 32]> = rows
+        .iter()
+        .filter(|r| history.outcome(&r.entry_hash).is_some_and(|o| o.is_effective()))
+        .map(|r| r.entry_hash)
+        .collect();
+    // Effective entries indexed by the (log, device, prev_hash) parent slot they chain from; a
+    // chain root keys on `None`.
+    let mut children: HashMap<(u8, DeviceFingerprint, Option<[u8; 32]>), Vec<[u8; 32]>> =
+        HashMap::new();
+    let mut groups: HashSet<(u8, DeviceFingerprint)> = HashSet::new();
     for row in &rows {
-        if history.outcome(&row.entry_hash).is_some_and(|o| o.is_effective()) {
-            slot_winner
-                .entry((row.log_id, row.device_fingerprint, row.seq))
-                .and_modify(|best| {
-                    if row.entry_hash < *best {
-                        *best = row.entry_hash;
-                    }
-                })
-                .or_insert(row.entry_hash);
+        if effective.contains(&row.entry_hash) {
+            children
+                .entry((row.log_id, row.device_fingerprint, row.verified.header.prev_hash))
+                .or_default()
+                .push(row.entry_hash);
+            groups.insert((row.log_id, row.device_fingerprint));
+        }
+    }
+    let mut accepted_set: HashSet<[u8; 32]> = HashSet::new();
+    for (log_id, device) in groups {
+        let mut parent: Option<[u8; 32]> = None;
+        // Bounded by the candidate count; each hop advances to a strictly-higher seq (the fold's
+        // ancestry check guarantees child.seq == parent.seq + 1), so the chain cannot cycle.
+        for _ in 0..=rows.len() {
+            let Some(winner) =
+                children.get(&(log_id, device, parent)).and_then(|kids| kids.iter().min()).copied()
+            else {
+                break;
+            };
+            accepted_set.insert(winner);
+            parent = Some(winner);
         }
     }
 
@@ -146,14 +177,11 @@ fn refold_in_tx(
 
     let mut statuses: HashMap<[u8; 32], String> = HashMap::new();
     for row in &rows {
-        let effective = history.outcome(&row.entry_hash).is_some_and(|o| o.is_effective());
-        let accepted = effective
-            && slot_winner.get(&(row.log_id, row.device_fingerprint, row.seq))
-                == Some(&row.entry_hash);
+        let accepted = accepted_set.contains(&row.entry_hash);
         let (status, detail): (String, Option<String>) = if accepted {
             ("accepted".to_string(), None)
-        } else if effective {
-            // Effective but lost the slot tiebreak — an equivocation loser.
+        } else if effective.contains(&row.entry_hash) {
+            // Effective but off the accepted chain — an equivocation loser or a descendant of one.
             ("forked".to_string(), None)
         } else {
             match history.outcome(&row.entry_hash) {
@@ -372,7 +400,10 @@ fn promote_pre_verify(
                 .filter(|v| {
                     !is_genesis(&v.header)
                         || account_id_from_genesis_payload(&v.payload) == v.header.account_id
-                });
+                })
+                // Same structural gate as ingest: a malformed current plaintext payload is
+                // refuted, not promoted into the DAG (dropped from the queue below either way).
+                .filter(|v| validate_current_plaintext_payload(v).is_ok());
             if let Some(verified) = promoted {
                 insert_candidate(tx, &verified, &raw_bytes, now_ms)?;
                 // A promoted genesis/DeviceAdd certifies a device key — feed it back so the next
@@ -396,6 +427,13 @@ fn promote_pre_verify(
 
 fn is_genesis(header: &AccountEntryHeader) -> bool {
     header.entry_type == ops::entry_type::ACCOUNT_GENESIS
+}
+
+fn validate_current_plaintext_payload(entry: &VerifiedAccountEntry) -> Result<(), String> {
+    if entry.header.crypto_suite == 0 && entry.header.op_version == fold::SUPPORTED_OP_VERSION {
+        ops::decode(entry.header.entry_type, &entry.payload).map_err(|err| err.to_string())?;
+    }
+    Ok(())
 }
 
 fn is_device_add(verified: &VerifiedAccountEntry) -> bool {
@@ -766,5 +804,92 @@ mod tests {
             )
             .unwrap();
         assert_eq!(accepted_at_slot, 1, "one accepted head per slot (I10a)");
+    }
+
+    #[test]
+    fn an_entry_that_chains_from_a_forked_head_is_not_accepted() {
+        // B equivocates at seq 0 (b0a/b0b), then authors a seq-1 entry whose prev_hash chains from
+        // the LOSING head. The fold marks that seq-1 entry effective (its own authority is valid)
+        // and it is the ONLY candidate at (B, seq 1) — yet accepting it would leave an accepted
+        // entry whose parent is `forked`, a broken chain. Branch selection must fork the descendant
+        // of a losing head, not just the losing head itself.
+        let conn = db();
+        let founder = Dev::new(1);
+        let (acct, gbytes, gh) = genesis(&founder);
+        account_ingest(&conn, &gbytes, NOW).unwrap();
+        let b = Dev::new(2);
+        let (add_b_bytes, add_b) =
+            op(acct, &founder, 1, Some(gh), Some(gh), &device_add(&b, DeviceRole::Owner));
+        account_ingest(&conn, &add_b_bytes, NOW).unwrap();
+        // B's two equivocating seq-0 heads (each adds a distinct throwaway member so they differ).
+        let (t8, t9) = (Dev::new(8), Dev::new(9));
+        let (b0a_bytes, b0a) =
+            op(acct, &b, 0, None, Some(add_b), &device_add(&t8, DeviceRole::Member));
+        let (b0b_bytes, b0b) =
+            op(acct, &b, 0, None, Some(add_b), &device_add(&t9, DeviceRole::Member));
+        let ((win, win_bytes), (lose, lose_bytes)) = if b0a < b0b {
+            ((b0a, &b0a_bytes), (b0b, &b0b_bytes))
+        } else {
+            ((b0b, &b0b_bytes), (b0a, &b0a_bytes))
+        };
+        // B continues at seq 1 from the LOSING head.
+        let t7 = Dev::new(7);
+        let (b1_bytes, b1) =
+            op(acct, &b, 1, Some(lose), Some(add_b), &device_add(&t7, DeviceRole::Member));
+
+        account_ingest(&conn, win_bytes, NOW).unwrap();
+        account_ingest(&conn, lose_bytes, NOW).unwrap();
+        account_ingest(&conn, &b1_bytes, NOW).unwrap();
+
+        assert_eq!(status(&conn, &win).as_deref(), Some("accepted"), "min-hash seq-0 head wins");
+        assert_eq!(status(&conn, &lose).as_deref(), Some("forked"), "the losing seq-0 head forks");
+        assert_eq!(
+            status(&conn, &b1).as_deref(),
+            Some("forked"),
+            "a seq-1 entry chaining from the forked head is off-branch, not accepted",
+        );
+        // No accepted entry has a forked parent: nothing is accepted on B's dead branch at seq 1.
+        let accepted_seq1: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM account_entries
+                 WHERE account_id = ?1 AND device_fingerprint = ?2 AND seq = 1 AND accepted = 1",
+                params![acct.to_bytes().as_slice(), b.fp.to_bytes().as_slice()],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(accepted_seq1, 0, "no accepted seq-1 entry on B's forked branch");
+    }
+
+    #[test]
+    fn a_malformed_op_payload_is_rejected_not_stored() {
+        // A founder-signed DEVICE_ADD whose plaintext op payload is not decodable CBOR. The
+        // envelope + signature verify (the payload rides opaque inside the envelope), but the op is
+        // garbage — a structural reject that must never enter the grow-only DAG. Only ops::decode
+        // catches it, so ingest must gate on it before storing.
+        let conn = db();
+        let founder = Dev::new(1);
+        let (acct, gbytes, gh) = genesis(&founder);
+        account_ingest(&conn, &gbytes, NOW).unwrap();
+        let header = AccountEntryHeader {
+            account_id: acct,
+            log_id: 0,
+            device_fingerprint: founder.fp,
+            seq: 1,
+            prev_hash: Some(gh),
+            parent_ref: None,
+            entry_type: ops::entry_type::DEVICE_ADD,
+            op_version: 1,
+            crypto_suite: 0,
+            auth_len: 1,
+            key_id: None,
+            authority_ref: Some(gh),
+        };
+        let signed = sign_account_entry(&founder.secret, &header, &[0xff, 0xff, 0xff]).unwrap();
+        let out = account_ingest(&conn, &signed.signed_bytes, NOW).unwrap();
+        assert!(
+            matches!(out, IngestOutcome::Rejected(_)),
+            "a malformed op payload is rejected: {out:?}"
+        );
+        assert_eq!(status(&conn, &signed.entry_hash), None, "and is never stored");
     }
 }

--- a/crates/rag-rat-core/src/oplog/account/storage.rs
+++ b/crates/rag-rat-core/src/oplog/account/storage.rs
@@ -117,29 +117,88 @@ fn refold_in_tx(
     account_id: AccountId,
 ) -> anyhow::Result<HashMap<[u8; 32], String>> {
     let rows = load_candidates(tx, account_id)?;
-    let entries: Vec<VerifiedAccountEntry> = rows.iter().map(|r| r.verified.clone()).collect();
-    let history = fold::fold_account(&entries);
+    let mut removed = HashSet::new();
+    let (history, effective, accepted_set) = loop {
+        let entries: Vec<VerifiedAccountEntry> = rows
+            .iter()
+            .filter(|row| !removed.contains(&row.entry_hash))
+            .map(|row| row.verified.clone())
+            .collect();
+        let history = fold::fold_account(&entries);
+        let effective: HashSet<EntryHash> = rows
+            .iter()
+            .filter(|row| {
+                !removed.contains(&row.entry_hash)
+                    && history
+                        .outcome(&row.entry_hash)
+                        .is_some_and(|outcome| outcome.is_effective())
+            })
+            .map(|row| row.entry_hash)
+            .collect();
+        let selected = select_coherent_branches(&rows, &effective);
+        let accepted = authority_closed_selection(&rows, selected);
+        let rejected: Vec<EntryHash> = effective.difference(&accepted).copied().collect();
+        if rejected.is_empty() {
+            break (history, effective, accepted);
+        }
+        // Monotone elimination is both the termination argument and the security boundary: once
+        // an effective candidate loses its author branch or its cited authority branch, neither it
+        // nor any effect it produced may participate in a later fold round.
+        removed.extend(rejected);
+    };
 
-    // Branch selection (§16.2): project the fold's effective entries onto a single accepted
-    // hash-chain per (log, device). From the smallest-entry_hash root (an effective entry with no
-    // prev_hash) walk forward, taking the smallest-entry_hash child (an effective entry whose
-    // prev_hash cites the current head) at each step. The min-hash tiebreak resolves an unforced
-    // equivocation the registers did not; crucially, an effective entry that chains from a LOSING
-    // head is off-branch and is NOT accepted — accepting it would leave the accepted history with
-    // an entry whose parent is `forked`, i.e. no longer a single chain under equivocation (the
-    // account_accepted_slot partial unique index keeps one accepted row per slot (I10a), but chain
-    // coherence needs the whole walk). Register-named branches were already promoted inside the
-    // fold (off-branch → condemned).
-    let effective: HashSet<[u8; 32]> = rows
-        .iter()
-        .filter(|r| history.outcome(&r.entry_hash).is_some_and(|o| o.is_effective()))
-        .map(|r| r.entry_hash)
-        .collect();
+    // Rewrite: clear every accepted flag for the account, then re-set the winners — atomically,
+    // so the partial unique index never sees two accepted rows at one slot mid-transaction.
+    tx.execute("UPDATE account_entries SET accepted = 0 WHERE account_id = ?1", params![
+        account_id.to_bytes().as_slice()
+    ])?;
+
+    let mut statuses: HashMap<[u8; 32], String> = HashMap::new();
+    for row in rows {
+        let accepted = accepted_set.contains(&row.entry_hash);
+        let (status, detail): (String, Option<String>) = if accepted {
+            ("accepted".to_string(), None)
+        } else if removed.contains(&row.entry_hash) || effective.contains(&row.entry_hash) {
+            // Effective but outside the authority-closed accepted DAG: an equivocation loser, a
+            // descendant of one, or an entry whose cited mint lost branch selection.
+            ("forked".to_string(), None)
+        } else {
+            match history.outcome(&row.entry_hash) {
+                Some(outcome) => {
+                    let (s, d) = outcome.taxonomy();
+                    (s.to_string(), d.map(str::to_string))
+                },
+                // A candidate eliminated in an earlier round is covered by `removed`; every
+                // remaining candidate is classified by the final fold.
+                None => ("retained_unfolded".to_string(), None),
+            }
+        };
+        if accepted {
+            tx.execute("UPDATE account_entries SET accepted = 1 WHERE entry_hash = ?1", params![
+                row.entry_hash.as_slice()
+            ])?;
+        }
+        tx.execute(
+            "INSERT INTO account_entry_status(entry_hash, status, detail) VALUES (?1, ?2, ?3)
+             ON CONFLICT(entry_hash) DO UPDATE SET status = excluded.status, detail = \
+             excluded.detail",
+            params![row.entry_hash.as_slice(), status, detail],
+        )?;
+        statuses.insert(row.entry_hash, status);
+    }
+    Ok(statuses)
+}
+
+/// Select one contiguous effective hash-chain per `(log_id, device)` (§16.2).
+fn select_coherent_branches(
+    rows: &[CandidateRow],
+    effective: &HashSet<EntryHash>,
+) -> HashSet<EntryHash> {
     // Effective entries indexed by the (log, device, prev_hash) parent slot they chain from; a
     // chain root keys on `None`.
     let mut children = BranchChildren::new();
     let mut groups: HashSet<(u8, DeviceFingerprint)> = HashSet::new();
-    for row in &rows {
+    for row in rows {
         if effective.contains(&row.entry_hash) {
             children
                 .entry((row.log_id, row.device_fingerprint, row.verified.header.prev_hash))
@@ -148,7 +207,7 @@ fn refold_in_tx(
             groups.insert((row.log_id, row.device_fingerprint));
         }
     }
-    let mut accepted_set: HashSet<[u8; 32]> = HashSet::new();
+    let mut accepted_set = HashSet::new();
     for (log_id, device) in groups {
         let mut parent: Option<[u8; 32]> = None;
         // Bounded by the candidate count; only the exact next sequence slot may extend a branch.
@@ -168,45 +227,35 @@ fn refold_in_tx(
             parent = Some(winner);
         }
     }
+    accepted_set
+}
 
-    // Rewrite: clear every accepted flag for the account, then re-set the winners — atomically,
-    // so the partial unique index never sees two accepted rows at one slot mid-transaction.
-    tx.execute("UPDATE account_entries SET accepted = 0 WHERE account_id = ?1", params![
-        account_id.to_bytes().as_slice()
-    ])?;
-
-    let mut statuses: HashMap<[u8; 32], String> = HashMap::new();
-    for row in &rows {
-        let accepted = accepted_set.contains(&row.entry_hash);
-        let (status, detail): (String, Option<String>) = if accepted {
-            ("accepted".to_string(), None)
-        } else if effective.contains(&row.entry_hash) {
-            // Effective but off the accepted chain — an equivocation loser or a descendant of one.
-            ("forked".to_string(), None)
-        } else {
-            match history.outcome(&row.entry_hash) {
-                Some(outcome) => {
-                    let (s, d) = outcome.taxonomy();
-                    (s.to_string(), d.map(str::to_string))
-                },
-                // Not in the fold's outcome map (unreachable — every candidate is classified).
-                None => ("retained_unfolded".to_string(), None),
-            }
-        };
-        if accepted {
-            tx.execute("UPDATE account_entries SET accepted = 1 WHERE entry_hash = ?1", params![
-                row.entry_hash.as_slice()
-            ])?;
+/// Remove selected entries whose cited incarnation is not itself selected. Iterate because an
+/// invalid mint can authorize another mint, so authority loss must propagate through the whole
+/// incarnation DAG rather than only one edge.
+fn authority_closed_selection(
+    rows: &[CandidateRow],
+    mut selected: HashSet<EntryHash>,
+) -> HashSet<EntryHash> {
+    loop {
+        let invalid: Vec<EntryHash> = rows
+            .iter()
+            .filter(|row| selected.contains(&row.entry_hash))
+            .filter(|row| {
+                row.verified
+                    .header
+                    .authority_ref
+                    .is_some_and(|authority| !selected.contains(&authority))
+            })
+            .map(|row| row.entry_hash)
+            .collect();
+        if invalid.is_empty() {
+            return selected;
         }
-        tx.execute(
-            "INSERT INTO account_entry_status(entry_hash, status, detail) VALUES (?1, ?2, ?3)
-             ON CONFLICT(entry_hash) DO UPDATE SET status = excluded.status, detail = \
-             excluded.detail",
-            params![row.entry_hash.as_slice(), status, detail],
-        )?;
-        statuses.insert(row.entry_hash, status);
+        for hash in invalid {
+            selected.remove(&hash);
+        }
     }
-    Ok(statuses)
 }
 
 /// A stored candidate row, with its verified entry reconstituted from the trusted stored bytes (the
@@ -609,6 +658,16 @@ mod tests {
         }
     }
 
+    fn owner_demote(dev: &Dev, owner_id: EntryHash) -> AccountOp {
+        AccountOp::OwnerDemote {
+            device_fingerprint: dev.fp,
+            owner_id,
+            control_cut: super::super::cut::Cut::Empty,
+            secrets_cut: super::super::cut::Cut::Empty,
+            reason: "demoted".to_string(),
+        }
+    }
+
     fn status(conn: &Connection, hash: &[u8; 32]) -> Option<String> {
         entry_status(conn, hash).unwrap().map(|(s, _)| s)
     }
@@ -884,6 +943,103 @@ mod tests {
             )
             .unwrap();
         assert_eq!(accepted_at_slot, 1, "one accepted head per slot (I10a)");
+    }
+
+    #[test]
+    fn losing_mint_authority_is_pruned_transitively_in_every_arrival_order() {
+        // The founder equivocates between minting B and W. Whichever mint loses by hash must not
+        // authorize an independent B chain: B mints C, then C mints D. Content-addressed key
+        // discovery deliberately knows all three keys, so signature verification alone cannot
+        // hide an authority-closure bug. The winning device also authors a child to prove pruning
+        // is scoped to the losing incarnation rather than all newly minted devices.
+        for rotation in 0..4 {
+            let conn = db();
+            let founder = Dev::new(1);
+            let (acct, gbytes, gh) = genesis(&founder);
+            account_ingest(&conn, &gbytes, NOW).unwrap();
+
+            let (b, w, c, d, survivor_child) =
+                (Dev::new(2), Dev::new(3), Dev::new(4), Dev::new(5), Dev::new(6));
+            let (add_b_bytes, add_b) =
+                op(acct, &founder, 1, Some(gh), Some(gh), &device_add(&b, DeviceRole::Owner));
+            let (add_w_bytes, add_w) =
+                op(acct, &founder, 1, Some(gh), Some(gh), &device_add(&w, DeviceRole::Owner));
+
+            let (loser, loser_add_bytes, loser_add, winner, winner_add_bytes, winner_add) =
+                if add_b < add_w {
+                    (&w, &add_w_bytes, add_w, &b, &add_b_bytes, add_b)
+                } else {
+                    (&b, &add_b_bytes, add_b, &w, &add_w_bytes, add_w)
+                };
+            let (add_c_bytes, add_c) =
+                op(acct, loser, 0, None, Some(loser_add), &device_add(&c, DeviceRole::Owner));
+            let (add_d_bytes, add_d) =
+                op(acct, &c, 0, None, Some(add_c), &device_add(&d, DeviceRole::Member));
+            let (winner_child_bytes, winner_child) = op(
+                acct,
+                winner,
+                0,
+                None,
+                Some(winner_add),
+                &device_add(&survivor_child, DeviceRole::Member),
+            );
+
+            let mut arrivals = [loser_add_bytes, winner_add_bytes, &add_c_bytes, &add_d_bytes];
+            arrivals.rotate_left(rotation);
+            for bytes in arrivals {
+                account_ingest(&conn, bytes, NOW).unwrap();
+            }
+            account_ingest(&conn, &winner_child_bytes, NOW).unwrap();
+
+            assert_eq!(status(&conn, &winner_add).as_deref(), Some("accepted"));
+            assert_eq!(status(&conn, &winner_child).as_deref(), Some("accepted"));
+            assert_eq!(status(&conn, &loser_add).as_deref(), Some("forked"));
+            assert_eq!(status(&conn, &add_c).as_deref(), Some("forked"));
+            assert_eq!(status(&conn, &add_d).as_deref(), Some("forked"));
+        }
+    }
+
+    #[test]
+    fn final_fold_does_not_keep_control_effects_from_a_losing_mint() {
+        // The losing founder branch mints owner B. A demotion of B sits on the WINNING founder
+        // branch, so the first all-candidate fold can resolve B's owner_id and treat the demotion
+        // as effective. After branch elimination, the final fold must run without the
+        // losing mint: the demotion can no longer resolve its target and must park without leaving
+        // a control register or an accepted status behind. A post-hoc accepted-set filter would
+        // fail this assertion.
+        let conn = db();
+        let founder = Dev::new(1);
+        let (acct, gbytes, gh) = genesis(&founder);
+        account_ingest(&conn, &gbytes, NOW).unwrap();
+        let b = Dev::new(2);
+        let (add_b_bytes, add_b) =
+            op(acct, &founder, 1, Some(gh), Some(gh), &device_add(&b, DeviceRole::Owner));
+        // Find a deterministic rival whose hash is smaller, making the owner mint the losing
+        // branch without depending on an assumed ordering of test keys.
+        let (winner_bytes, winner_hash) = (3u8..=u8::MAX)
+            .find_map(|seed| {
+                let rival = Dev::new(seed);
+                let candidate = op(
+                    acct,
+                    &founder,
+                    1,
+                    Some(gh),
+                    Some(gh),
+                    &device_add(&rival, DeviceRole::Member),
+                );
+                (candidate.1 < add_b).then_some(candidate)
+            })
+            .expect("the deterministic fixture set contains a lower-hash rival");
+        let (demote_bytes, demote) =
+            op(acct, &founder, 2, Some(winner_hash), Some(gh), &owner_demote(&b, add_b));
+
+        account_ingest(&conn, &add_b_bytes, NOW).unwrap();
+        account_ingest(&conn, &winner_bytes, NOW).unwrap();
+        account_ingest(&conn, &demote_bytes, NOW).unwrap();
+
+        assert_eq!(status(&conn, &add_b).as_deref(), Some("forked"));
+        assert_eq!(status(&conn, &winner_hash).as_deref(), Some("accepted"));
+        assert_eq!(status(&conn, &demote).as_deref(), Some("parked"));
     }
 
     #[test]


### PR DESCRIPTION
Part of #604 (#405). Follows the merged stratified fold (#622). This lands the **account candidate-DAG storage layer** (§16) over a new migration — ingest, content-addressed device resolution, the pre-verify queue, and the refold with **branch selection**. It's where accepted-slot uniqueness (I10a) and branch promotion (P8) — the theme the fold review kept pointing at — are actually implemented and tested end-to-end.

## What this adds

**V059 candidate-DAG schema (§16.1)**
- `account_entries` — the candidate DAG: every structurally/signature-valid entry, all branches of an equivocating chain first-class, grow-only (I8). No seq-uniqueness on the candidate table.
- `account_accepted_slot` — a PARTIAL unique index on `(account, log, device, seq) WHERE accepted=1` pinning accepted-set uniqueness (**I10a**). The `accepted` flag is derived, never authored.
- `account_entry_status` (the projected §16.3 taxonomy) and `account_pre_verify` (the deferred-device queue). Registered in all four migration sites; STRICT + `CREATE ... IF NOT EXISTS`.

**`storage.rs` — ingest + refold (§16.2)**
- **`account_ingest`**: structural decode (canonicity/§18a) → **content-addressed device resolution** (the signer's ed25519 key from a stored or self-certifying genesis/DeviceAdd — fold-status-independent) → signature verify → genesis self-hash → `INSERT OR IGNORE` into the DAG → promote any pre-verify rows this entry now resolves → refold. Structural rejects are never stored.
- **Pre-verify queue (Codex-8)**: an entry whose signer isn't yet resolvable parks durably in `account_pre_verify`, retried on a later DeviceAdd/AccountGenesis arrival and promoted (or discarded if refuted).
- **`refold_account`**: `fold_account` over the candidate set, then **branch selection** — an effective entry is accepted unless it loses its `(device, seq)` slot to a smaller-hash sibling (unforced-fork tiebreak); register-named branches were already promoted by the fold (off-branch → condemned). The `accepted` flag + statuses are rewritten in one IMMEDIATE txn (clear-then-set) so the partial unique index never transiently double-accepts a slot. `Outcome::taxonomy()` projects the fold verdict onto the §16.3 labels.

### Queue + slot hardening
- **Transitive pre-verify drain (fixpoint).** `promote_pre_verify` iterates, feeding each promoted device key back before re-scanning, so a device chain (founder→B→C) delivered before its authorizers fully resolves in one pass. A once-only device snapshot stranded everything past depth 1 and split two peers that received the same entries in different orders — this restores arrival-order convergence.
- **Race-free park.** Signer resolution and the pre-verify insert now run under the **same** IMMEDIATE txn as candidate insert/promotion, closing a lost-wakeup window where a concurrent resolving DeviceAdd could drain an empty queue and strand the entry after its only promotion trigger passed.
- **Slot key includes `log_id`.** Branch selection keys the accepted-slot map on `(log_id, device, seq)`, mirroring the `account_accepted_slot` unique index exactly.

## Tests

8 storage/schema tests: genesis accepted; a **forged re-signed genesis is rejected end-to-end** through the real ingest path (the takeover defense, not just the fold in isolation); owner-add accepted; **pre-verify then promoted**; a **depth-2 pre-verify chain drains to a fixpoint** on reverse delivery; **equivocation accepts one head + forks the other (I10a)**; and **P8** — a cut promotes its named branch and condemns the off-branch head, identical across every arrival order.

## Notes
- Native-only; no live-path changes. The account subsystem stays behind `account/mod.rs`'s build-time `#![allow(dead_code)]` (removed at the final surface wire-up) — `storage.rs` + its tests are exercised by CI, same posture as the merged fold.
- Full CI gate green: both clippy variants (`--no-default-features` and `--features eval`, `-D warnings`) and `cargo nextest run --workspace` (2416 tests).

## Follow-up
- **#626** — bound the pre-verify queue (park budget) + make the refold incremental **before** ingest is wired to remote peers. Safe while the layer is dead code; must close at wire-up.
- Rest of #604: point-in-time queries (`grant_effective` / `owner_incarnation_effective` / `roster_ref_effective`), then the surface wire-up (remove the `#![allow(dead_code)]`, expose the `pub(crate)` API) + integration sweep.
