### PR TITLE
chore: release v0.18.0

### DIFF
--- a/.agents/skills/init-rag-rat/SKILL.md
+++ b/.agents/skills/init-rag-rat/SKILL.md
@@ -32,7 +32,7 @@ hand-write a config blind, and let a real config load re-check it before indexin
    do **not** use `@latest`, and **don't blindly trust an on-`PATH` `rag-rat`**:
    - If `rag-rat` is on `PATH`, check `rag-rat --version` and use it **only if it matches** the
      plugin/MCP version — a stale global install would build the index with the wrong binary.
-   - Otherwise (or on a version mismatch) use `npx -y @rag-rat/bin@0.17.0 …` — the plugin pins
+   - Otherwise (or on a version mismatch) use `npx -y @rag-rat/bin@0.18.0 …` — the plugin pins
      `@rag-rat/bin` to its own version and caches the binary privately, so this is the
      version-matched CLI; `npx` runs it in the current directory.
 

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "rag-rat",
       "description": "Local repo-intelligence index + MCP server: semantic search, symbol/graph navigation, impact-surface preflight, git + GitHub papertrail, and a source-anchored memory graph.",
-      "version": "0.17.0",
+      "version": "0.18.0",
       "source": "./plugin",
       "category": "developer-tools",
       "license": "MIT",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-core-v0.17.0...rag-rat-core-v0.18.0) - 2026-07-14
+
+### Added
+
+- *(account)* add /3 candidate ancestry and branch selection ([#647](https://github.com/cq27-dev/rag-rat/pull/647))
+- *(lang)* add Swift baseline support ([#639](https://github.com/cq27-dev/rag-rat/pull/639))
+- *(account)* add pure content acceptance evaluator; split auth_len freshness out of the authority seam ([#645](https://github.com/cq27-dev/rag-rat/pull/645))
+- *(papertrail)* add automatic sync scheduling core ([#640](https://github.com/cq27-dev/rag-rat/pull/640))
+- *(account)* add signed content entry envelope ([#643](https://github.com/cq27-dev/rag-rat/pull/643))
+- *(account)* finish C1 authority projection and query seams ([#604](https://github.com/cq27-dev/rag-rat/pull/604)) ([#641](https://github.com/cq27-dev/rag-rat/pull/641))
+- *(papertrail)* add native GitHub project mirror ([#638](https://github.com/cq27-dev/rag-rat/pull/638))
+- *(papertrail)* add shared provider transport ([#633](https://github.com/cq27-dev/rag-rat/pull/633))
+- *(papertrail)* add tracker config and provider ref grammar ([#631](https://github.com/cq27-dev/rag-rat/pull/631))
+- *(papertrail)* add provider-neutral schema ([#632](https://github.com/cq27-dev/rag-rat/pull/632))
+- *(account)* C1 candidate-DAG storage — ingest, refold + branch selection (V059) ([#627](https://github.com/cq27-dev/rag-rat/pull/627))
+
+### Fixed
+
+- *(account)* preserve bounded historical authority ([#642](https://github.com/cq27-dev/rag-rat/pull/642))
+- *(account)* bound candidate ingest work ([#634](https://github.com/cq27-dev/rag-rat/pull/634))
+
+### Other
+
+- add content candidate DAG storage ([#644](https://github.com/cq27-dev/rag-rat/pull/644))
+- tiered god-module sweep (watch, config, mcp, embed_loop) ([#630](https://github.com/cq27-dev/rag-rat/pull/630))
+- explain Codex MCP approval for reviews ([#628](https://github.com/cq27-dev/rag-rat/pull/628))
+
 ## [0.17.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-core-v0.16.0...rag-rat-core-v0.17.0) - 2026-07-11
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3449,7 +3449,7 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rag-rat"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3475,7 +3475,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-core"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -3527,7 +3527,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-mcp"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "3"
 # and the internal path deps below pin the same literal, so the three crates always publish in
 # lockstep. Bump this one line (and the two internal-dep `version`s under workspace.dependencies)
 # to release.
-version = "0.17.0"
+version = "0.18.0"
 authors = ["Kristaps Karlsons"]
 edition = "2024"
 # Bundled SQLite (rusqlite `bundled` -> libsqlite3-sys 0.38.1) compiles a build script that uses the
@@ -28,8 +28,8 @@ categories = ["command-line-utilities", "development-tools"]
 # Internal crates — declared once here so the version requirement is set in lockstep with
 # [workspace.package].version above. Members reference these via `{ workspace = true }` and add
 # their own feature toggles at the use site.
-rag-rat-core = { version = "0.17.0", path = "crates/rag-rat-core", default-features = false }
-rag-rat-mcp = { version = "0.17.0", path = "crates/rag-rat-mcp", default-features = false }
+rag-rat-core = { version = "0.18.0", path = "crates/rag-rat-core", default-features = false }
+rag-rat-mcp = { version = "0.18.0", path = "crates/rag-rat-mcp", default-features = false }
 anyhow = "1.0"
 # ed25519 device-identity signing for the op-log's signed entry envelope (§C4 layer-1). Default
 # features (incl. `zeroize`, which zeroizes a `SigningKey`'s seed on drop) are kept; the `rand_core`

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "rag-rat",
   "displayName": "rag-rat",
   "description": "Local repo-intelligence index + MCP server: semantic search, symbol/graph navigation, impact-surface preflight, git + GitHub papertrail, and a source-anchored memory graph.",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "author": { "name": "Kristaps Karlsons" },
   "homepage": "https://github.com/cq27-dev/rag-rat",
   "repository": "https://github.com/cq27-dev/rag-rat",
@@ -11,7 +11,7 @@
   "mcpServers": {
     "rag-rat": {
       "command": "npx",
-      "args": ["-y", "@rag-rat/bin@0.17.0", "mcp"]
+      "args": ["-y", "@rag-rat/bin@0.18.0", "mcp"]
     }
   }
 }

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rag-rat",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Local repo-intelligence index + MCP server: semantic search, symbol/graph navigation, impact-surface preflight, git + GitHub papertrail, and a source-anchored memory graph.",
   "author": { "name": "Kristaps Karlsons", "url": "https://github.com/cq27-dev/rag-rat" },
   "homepage": "https://github.com/cq27-dev/rag-rat",

--- a/plugin/.mcp.json
+++ b/plugin/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "rag-rat": {
       "command": "npx",
-      "args": ["-y", "@rag-rat/bin@0.17.0", "mcp"]
+      "args": ["-y", "@rag-rat/bin@0.18.0", "mcp"]
     }
   }
 }

--- a/plugin/skills/init-rag-rat/SKILL.md
+++ b/plugin/skills/init-rag-rat/SKILL.md
@@ -32,7 +32,7 @@ hand-write a config blind, and let a real config load re-check it before indexin
    do **not** use `@latest`, and **don't blindly trust an on-`PATH` `rag-rat`**:
    - If `rag-rat` is on `PATH`, check `rag-rat --version` and use it **only if it matches** the
      plugin/MCP version — a stale global install would build the index with the wrong binary.
-   - Otherwise (or on a version mismatch) use `npx -y @rag-rat/bin@0.17.0 …` — the plugin pins
+   - Otherwise (or on a version mismatch) use `npx -y @rag-rat/bin@0.18.0 …` — the plugin pins
      `@rag-rat/bin` to its own version and caches the binary privately, so this is the
      version-matched CLI; `npx` runs it in the current directory.
 


### PR DESCRIPTION



## 🤖 New release

* `rag-rat-core`: 0.17.0 -> 0.18.0 (⚠ API breaking changes)
* `rag-rat-mcp`: 0.17.0 -> 0.18.0 (⚠ API breaking changes)
* `rag-rat`: 0.17.0 -> 0.18.0

### ⚠ `rag-rat-core` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field PapertrailEvidence.tracker in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-core/src/index/papertrail/mod.rs:223
  field PapertrailEvidence.project in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-core/src/index/papertrail/mod.rs:224
  field PapertrailEvidence.item_key in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-core/src/index/papertrail/mod.rs:227
  field PapertrailEvidence.doc_kind in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-core/src/index/papertrail/mod.rs:229
  field PapertrailEvidence.comment_id in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-core/src/index/papertrail/mod.rs:231
  field PageCursor.stream in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-core/src/index/papertrail/mod.rs:341
  field PageCursor.updated_before in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-core/src/index/papertrail/mod.rs:345
  field PageCursor.provider_state in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-core/src/index/papertrail/mod.rs:351
  field IndexStatus.papertrail in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-core/src/index/mod.rs:233
  field IndexStatus.papertrail in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-core/src/index/mod.rs:233
  field RepoMemoryBinding.tracker in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-core/src/query/memory/mod.rs:121
  field RepoMemoryBinding.project in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-core/src/query/memory/mod.rs:123
  field RepoMemoryBinding.item_key in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-core/src/query/memory/mod.rs:125
  field PapertrailRef.tracker in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-core/src/index/papertrail/mod.rs:210
  field PapertrailRef.project in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-core/src/index/papertrail/mod.rs:211
  field PapertrailRef.item_key in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-core/src/index/papertrail/mod.rs:212
  field PapertrailRef.item_kind in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-core/src/index/papertrail/mod.rs:213
  field PapertrailSyncError.tracker in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-core/src/index/papertrail/mod.rs:181
  field PapertrailSyncError.project in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-core/src/index/papertrail/mod.rs:182
  field PapertrailSyncError.item_key in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-core/src/index/papertrail/mod.rs:183
  field RepoMemoryBindTarget.tracker in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-core/src/query/memory/mod.rs:210
  field RepoMemoryBindTarget.project in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-core/src/query/memory/mod.rs:211
  field RepoMemoryBindTarget.item_key in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-core/src/query/memory/mod.rs:212
  field PapertrailContext.trackers in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-core/src/index/papertrail/mod.rs:42
  field RepoBriefMetrics.papertrail_ref_count in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-core/src/query/repo_brief.rs:121
  field PapertrailStatus.change_requests in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-core/src/index/papertrail/mod.rs:118
  field PapertrailStatus.capabilities in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-core/src/index/papertrail/mod.rs:121
  field PapertrailStatus.bindings in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-core/src/index/papertrail/mod.rs:122
  field Papertrail.evidence in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-core/src/index/papertrail/mod.rs:243
  field Papertrail.fallback_evidence in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-core/src/index/papertrail/mod.rs:245
  field Config.trackers in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-core/src/config/types.rs:25
  field Config.papertrail in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-core/src/config/types.rs:26
  field Config.trackers in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-core/src/config/types.rs:25
  field Config.papertrail in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-core/src/config/types.rs:26
  field ItemsPage.backfill_boundary in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-core/src/index/papertrail/mod.rs:374
  field ScoreComponents.papertrail in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-core/src/search/lexical.rs:84
  field PapertrailItem.tags in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-core/src/index/papertrail/mod.rs:308
  field PapertrailSyncReport.bindings in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-core/src/index/papertrail/mod.rs:174
  field ImpactSurfaceReport.papertrail_rationale_items in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-core/src/query/impact/mod.rs:103

--- failure constructible_struct_adds_private_field: struct no longer constructible due to new private field ---

Description:
A struct constructible with a struct literal has a new non-public field. It can no longer be constructed using a struct literal outside of its crate.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_private_field.ron

Failed in:
  field PapertrailContext.transport_options in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-core/src/index/papertrail/mod.rs:43
  field PapertrailContext.schedule in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-core/src/index/papertrail/mod.rs:44

--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_missing.ron

Failed in:
  enum rag_rat_core::index::papertrail::PapertrailSyncAction, previously in file /tmp/.tmpf04Inu/rag-rat-core/src/index/papertrail/mod.rs:95

--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant EdgeKind::UsesMacro 4 -> 6 in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-core/src/index/edges/mod.rs:35
  variant EdgeKind::ReferencesType 5 -> 7 in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-core/src/index/edges/mod.rs:36
  variant EdgeKind::Implements 6 -> 8 in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-core/src/index/edges/mod.rs:37
  variant EdgeKind::Contains 7 -> 9 in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-core/src/index/edges/mod.rs:38
  variant EdgeKind::Dispatches 8 -> 10 in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-core/src/index/edges/mod.rs:43
  variant EdgeKind::DispatchConstruct 9 -> 11 in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-core/src/index/edges/mod.rs:47
  variant EdgeKind::DispatchHandle 10 -> 12 in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-core/src/index/edges/mod.rs:52
  variant Language::Markdown 6 -> 7 in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-core/src/language.rs:18
  variant ParserKind::Markdown 7 -> 8 in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-core/src/index/parser.rs:216

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_added.ron

Failed in:
  variant ConfigError:TrackerProviderMissing in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-core/src/config/mod.rs:144
  variant ConfigError:UnknownTrackerProvider in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-core/src/config/mod.rs:149
  variant ConfigError:JiraTrackerRequiresProject in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-core/src/config/mod.rs:151
  variant ConfigError:InvalidTrackerProject in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-core/src/config/mod.rs:153
  variant ConfigError:TrackerAuthExactlyOne in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-core/src/config/mod.rs:155
  variant ConfigError:TrackerBaseUrlNotHttp in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-core/src/config/mod.rs:157
  variant ConfigError:TrackerBaseUrlHasCredentials in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-core/src/config/mod.rs:159
  variant ConfigError:PapertrailRateLimitReserveOutOfRange in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-core/src/config/mod.rs:164
  variant ParserKind:Swift in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-core/src/index/parser.rs:215
  variant EdgeKind:UsesOperator in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-core/src/index/edges/mod.rs:32
  variant EdgeKind:UsesPrecedenceGroup in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-core/src/index/edges/mod.rs:34
  variant Language:Swift in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-core/src/language.rs:17

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/inherent_method_missing.ron

Failed in:
  IndexDatabase::papertrail_sync_from_refs, previously in file /tmp/.tmpf04Inu/rag-rat-core/src/index/query_api/history.rs:150
  IndexDatabase::papertrail_sync_from_refs_with_progress, previously in file /tmp/.tmpf04Inu/rag-rat-core/src/index/query_api/history.rs:154
  IndexDatabase::papertrail_sync_issue, previously in file /tmp/.tmpf04Inu/rag-rat-core/src/index/query_api/history.rs:183
  IndexDatabase::papertrail_sync_from_refs, previously in file /tmp/.tmpf04Inu/rag-rat-core/src/index/query_api/history.rs:150
  IndexDatabase::papertrail_sync_from_refs_with_progress, previously in file /tmp/.tmpf04Inu/rag-rat-core/src/index/query_api/history.rs:154
  IndexDatabase::papertrail_sync_issue, previously in file /tmp/.tmpf04Inu/rag-rat-core/src/index/query_api/history.rs:183
  ItemKind::as_str, previously in file /tmp/.tmpf04Inu/rag-rat-core/src/index/papertrail/mod.rs:158

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/method_parameter_count_changed.ron

Failed in:
  rag_rat_core::index::IndexDatabase::set_papertrail_context takes 2 parameters in /tmp/.tmpf04Inu/rag-rat-core/src/index/lifecycle.rs:384, but now takes 1 parameters in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-core/src/index/lifecycle.rs:384
  rag_rat_core::IndexDatabase::set_papertrail_context takes 2 parameters in /tmp/.tmpf04Inu/rag-rat-core/src/index/lifecycle.rs:384, but now takes 1 parameters in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-core/src/index/lifecycle.rs:384

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_missing.ron

Failed in:
  struct rag_rat_core::index::papertrail::PapertrailSyncProgress, previously in file /tmp/.tmpf04Inu/rag-rat-core/src/index/papertrail/mod.rs:84
  struct rag_rat_core::index::papertrail::GitHubClient, previously in file /tmp/.tmpf04Inu/rag-rat-core/src/index/papertrail/mod.rs:312

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field github of struct IndexStatus, previously in file /tmp/.tmpf04Inu/rag-rat-core/src/index/mod.rs:232
  field github of struct IndexStatus, previously in file /tmp/.tmpf04Inu/rag-rat-core/src/index/mod.rs:232
  field github_ref_count of struct RepoBriefMetrics, previously in file /tmp/.tmpf04Inu/rag-rat-core/src/query/repo_brief.rs:121
  field github of struct ScoreComponents, previously in file /tmp/.tmpf04Inu/rag-rat-core/src/search/lexical.rs:82
  field github_rationale_issues_prs of struct ImpactSurfaceReport, previously in file /tmp/.tmpf04Inu/rag-rat-core/src/query/impact/mod.rs:103
  field pulls of struct PapertrailStatus, previously in file /tmp/.tmpf04Inu/rag-rat-core/src/index/papertrail/mod.rs:56
  field reviews of struct PapertrailStatus, previously in file /tmp/.tmpf04Inu/rag-rat-core/src/index/papertrail/mod.rs:57
  field review_comments of struct PapertrailStatus, previously in file /tmp/.tmpf04Inu/rag-rat-core/src/index/papertrail/mod.rs:58
  field capability of struct PapertrailStatus, previously in file /tmp/.tmpf04Inu/rag-rat-core/src/index/papertrail/mod.rs:60
  field default_repo of struct PapertrailContext, previously in file /tmp/.tmpf04Inu/rag-rat-core/src/index/papertrail/mod.rs:29
  field gh_available of struct PapertrailContext, previously in file /tmp/.tmpf04Inu/rag-rat-core/src/index/papertrail/mod.rs:31
  field owner of struct PapertrailRef, previously in file /tmp/.tmpf04Inu/rag-rat-core/src/index/papertrail/mod.rs:105
  field repo of struct PapertrailRef, previously in file /tmp/.tmpf04Inu/rag-rat-core/src/index/papertrail/mod.rs:106
  field number of struct PapertrailRef, previously in file /tmp/.tmpf04Inu/rag-rat-core/src/index/papertrail/mod.rs:107
  field github_owner of struct RepoMemoryBinding, previously in file /tmp/.tmpf04Inu/rag-rat-core/src/query/memory/mod.rs:121
  field github_repo of struct RepoMemoryBinding, previously in file /tmp/.tmpf04Inu/rag-rat-core/src/query/memory/mod.rs:123
  field github_number of struct RepoMemoryBinding, previously in file /tmp/.tmpf04Inu/rag-rat-core/src/query/memory/mod.rs:125
  field owner of struct PapertrailSyncError, previously in file /tmp/.tmpf04Inu/rag-rat-core/src/index/papertrail/mod.rs:76
  field repo of struct PapertrailSyncError, previously in file /tmp/.tmpf04Inu/rag-rat-core/src/index/papertrail/mod.rs:77
  field number of struct PapertrailSyncError, previously in file /tmp/.tmpf04Inu/rag-rat-core/src/index/papertrail/mod.rs:78
  field owner of struct PapertrailEvidence, previously in file /tmp/.tmpf04Inu/rag-rat-core/src/index/papertrail/mod.rs:117
  field repo of struct PapertrailEvidence, previously in file /tmp/.tmpf04Inu/rag-rat-core/src/index/papertrail/mod.rs:118
  field number of struct PapertrailEvidence, previously in file /tmp/.tmpf04Inu/rag-rat-core/src/index/papertrail/mod.rs:119
  field item_id of struct PapertrailEvidence, previously in file /tmp/.tmpf04Inu/rag-rat-core/src/index/papertrail/mod.rs:121
  field github_evidence of struct Papertrail, previously in file /tmp/.tmpf04Inu/rag-rat-core/src/index/papertrail/mod.rs:133
  field fallback_github_evidence of struct Papertrail, previously in file /tmp/.tmpf04Inu/rag-rat-core/src/index/papertrail/mod.rs:135
  field github_owner of struct RepoMemoryBindTarget, previously in file /tmp/.tmpf04Inu/rag-rat-core/src/query/memory/mod.rs:210
  field github_repo of struct RepoMemoryBindTarget, previously in file /tmp/.tmpf04Inu/rag-rat-core/src/query/memory/mod.rs:211
  field github_number of struct RepoMemoryBindTarget, previously in file /tmp/.tmpf04Inu/rag-rat-core/src/query/memory/mod.rs:212

--- warning partial_ord_enum_variants_reordered: enum variants reordered in #[derive(PartialOrd)] enum ---

Description:
A public enum that derives PartialOrd had its variants reordered. #[derive(PartialOrd)] uses the enum variant order to set the enum's ordering behavior, so this change may break downstream code that relies on the previous order.
        ref: https://doc.rust-lang.org/std/cmp/trait.PartialOrd.html#derivable
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/partial_ord_enum_variants_reordered.ron

Failed in:
  EdgeKind::UsesMacro moved from position 5 to 7, in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-core/src/index/edges/mod.rs:35
  EdgeKind::ReferencesType moved from position 6 to 8, in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-core/src/index/edges/mod.rs:36
  EdgeKind::Implements moved from position 7 to 9, in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-core/src/index/edges/mod.rs:37
  EdgeKind::Contains moved from position 8 to 10, in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-core/src/index/edges/mod.rs:38
  EdgeKind::Dispatches moved from position 9 to 11, in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-core/src/index/edges/mod.rs:43
  EdgeKind::DispatchConstruct moved from position 10 to 12, in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-core/src/index/edges/mod.rs:47
  EdgeKind::DispatchHandle moved from position 11 to 13, in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-core/src/index/edges/mod.rs:52
  Language::Markdown moved from position 7 to 8, in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-core/src/language.rs:18
```

### ⚠ `rag-rat-mcp` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field MemoryBindArgs.tracker in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-mcp/src/tools/requests.rs:633
  field MemoryBindArgs.project in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-mcp/src/tools/requests.rs:634
  field MemoryBindArgs.item_key in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-mcp/src/tools/requests.rs:635

--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant McpGraphEdgeKind::Dispatches 2 -> 4 in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-mcp/src/tools/requests.rs:92
  variant McpGraphEdgeKind::UsesMacro 3 -> 5 in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-mcp/src/tools/requests.rs:93
  variant McpGraphEdgeKind::ReferencesType 4 -> 6 in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-mcp/src/tools/requests.rs:94
  variant McpGraphEdgeKind::Imports 5 -> 7 in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-mcp/src/tools/requests.rs:95
  variant McpGraphEdgeKind::Exports 6 -> 8 in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-mcp/src/tools/requests.rs:96
  variant McpGraphEdgeKind::Contains 7 -> 9 in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-mcp/src/tools/requests.rs:97
  variant McpGraphEdgeKind::Implements 8 -> 10 in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-mcp/src/tools/requests.rs:98

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_added.ron

Failed in:
  variant McpGraphEdgeKind:UsesOperator in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-mcp/src/tools/requests.rs:90
  variant McpGraphEdgeKind:UsesPrecedenceGroup in /tmp/.tmpy0Qlag/rag-rat/crates/rag-rat-mcp/src/tools/requests.rs:91

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field github_owner of struct MemoryBindArgs, previously in file /tmp/.tmpf04Inu/rag-rat-mcp/src/tools/requests.rs:626
  field github_repo of struct MemoryBindArgs, previously in file /tmp/.tmpf04Inu/rag-rat-mcp/src/tools/requests.rs:627
  field github_number of struct MemoryBindArgs, previously in file /tmp/.tmpf04Inu/rag-rat-mcp/src/tools/requests.rs:628
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `rag-rat-core`

<blockquote>

## [0.18.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-core-v0.17.0...rag-rat-core-v0.18.0) - 2026-07-14

### Added

- *(account)* add /3 candidate ancestry and branch selection ([#647](https://github.com/cq27-dev/rag-rat/pull/647))
- *(lang)* add Swift baseline support ([#639](https://github.com/cq27-dev/rag-rat/pull/639))
- *(account)* add pure content acceptance evaluator; split auth_len freshness out of the authority seam ([#645](https://github.com/cq27-dev/rag-rat/pull/645))
- *(papertrail)* add automatic sync scheduling core ([#640](https://github.com/cq27-dev/rag-rat/pull/640))
- *(account)* add signed content entry envelope ([#643](https://github.com/cq27-dev/rag-rat/pull/643))
- *(account)* finish C1 authority projection and query seams ([#604](https://github.com/cq27-dev/rag-rat/pull/604)) ([#641](https://github.com/cq27-dev/rag-rat/pull/641))
- *(papertrail)* add native GitHub project mirror ([#638](https://github.com/cq27-dev/rag-rat/pull/638))
- *(papertrail)* add shared provider transport ([#633](https://github.com/cq27-dev/rag-rat/pull/633))
- *(papertrail)* add tracker config and provider ref grammar ([#631](https://github.com/cq27-dev/rag-rat/pull/631))
- *(papertrail)* add provider-neutral schema ([#632](https://github.com/cq27-dev/rag-rat/pull/632))
- *(account)* C1 candidate-DAG storage — ingest, refold + branch selection (V059) ([#627](https://github.com/cq27-dev/rag-rat/pull/627))

### Fixed

- *(account)* preserve bounded historical authority ([#642](https://github.com/cq27-dev/rag-rat/pull/642))
- *(account)* bound candidate ingest work ([#634](https://github.com/cq27-dev/rag-rat/pull/634))

### Other

- add content candidate DAG storage ([#644](https://github.com/cq27-dev/rag-rat/pull/644))
- tiered god-module sweep (watch, config, mcp, embed_loop) ([#630](https://github.com/cq27-dev/rag-rat/pull/630))
- explain Codex MCP approval for reviews ([#628](https://github.com/cq27-dev/rag-rat/pull/628))
</blockquote>

## `rag-rat-mcp`

<blockquote>

## [0.18.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-core-v0.17.0...rag-rat-core-v0.18.0) - 2026-07-14

### Added

- *(account)* add /3 candidate ancestry and branch selection ([#647](https://github.com/cq27-dev/rag-rat/pull/647))
- *(lang)* add Swift baseline support ([#639](https://github.com/cq27-dev/rag-rat/pull/639))
- *(account)* add pure content acceptance evaluator; split auth_len freshness out of the authority seam ([#645](https://github.com/cq27-dev/rag-rat/pull/645))
- *(papertrail)* add automatic sync scheduling core ([#640](https://github.com/cq27-dev/rag-rat/pull/640))
- *(account)* add signed content entry envelope ([#643](https://github.com/cq27-dev/rag-rat/pull/643))
- *(account)* finish C1 authority projection and query seams ([#604](https://github.com/cq27-dev/rag-rat/pull/604)) ([#641](https://github.com/cq27-dev/rag-rat/pull/641))
- *(papertrail)* add native GitHub project mirror ([#638](https://github.com/cq27-dev/rag-rat/pull/638))
- *(papertrail)* add shared provider transport ([#633](https://github.com/cq27-dev/rag-rat/pull/633))
- *(papertrail)* add tracker config and provider ref grammar ([#631](https://github.com/cq27-dev/rag-rat/pull/631))
- *(papertrail)* add provider-neutral schema ([#632](https://github.com/cq27-dev/rag-rat/pull/632))
- *(account)* C1 candidate-DAG storage — ingest, refold + branch selection (V059) ([#627](https://github.com/cq27-dev/rag-rat/pull/627))

### Fixed

- *(account)* preserve bounded historical authority ([#642](https://github.com/cq27-dev/rag-rat/pull/642))
- *(account)* bound candidate ingest work ([#634](https://github.com/cq27-dev/rag-rat/pull/634))

### Other

- add content candidate DAG storage ([#644](https://github.com/cq27-dev/rag-rat/pull/644))
- tiered god-module sweep (watch, config, mcp, embed_loop) ([#630](https://github.com/cq27-dev/rag-rat/pull/630))
- explain Codex MCP approval for reviews ([#628](https://github.com/cq27-dev/rag-rat/pull/628))
</blockquote>

## `rag-rat`

<blockquote>

## [0.18.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-core-v0.17.0...rag-rat-core-v0.18.0) - 2026-07-14

### Added

- *(account)* add /3 candidate ancestry and branch selection ([#647](https://github.com/cq27-dev/rag-rat/pull/647))
- *(lang)* add Swift baseline support ([#639](https://github.com/cq27-dev/rag-rat/pull/639))
- *(account)* add pure content acceptance evaluator; split auth_len freshness out of the authority seam ([#645](https://github.com/cq27-dev/rag-rat/pull/645))
- *(papertrail)* add automatic sync scheduling core ([#640](https://github.com/cq27-dev/rag-rat/pull/640))
- *(account)* add signed content entry envelope ([#643](https://github.com/cq27-dev/rag-rat/pull/643))
- *(account)* finish C1 authority projection and query seams ([#604](https://github.com/cq27-dev/rag-rat/pull/604)) ([#641](https://github.com/cq27-dev/rag-rat/pull/641))
- *(papertrail)* add native GitHub project mirror ([#638](https://github.com/cq27-dev/rag-rat/pull/638))
- *(papertrail)* add shared provider transport ([#633](https://github.com/cq27-dev/rag-rat/pull/633))
- *(papertrail)* add tracker config and provider ref grammar ([#631](https://github.com/cq27-dev/rag-rat/pull/631))
- *(papertrail)* add provider-neutral schema ([#632](https://github.com/cq27-dev/rag-rat/pull/632))
- *(account)* C1 candidate-DAG storage — ingest, refold + branch selection (V059) ([#627](https://github.com/cq27-dev/rag-rat/pull/627))

### Fixed

- *(account)* preserve bounded historical authority ([#642](https://github.com/cq27-dev/rag-rat/pull/642))
- *(account)* bound candidate ingest work ([#634](https://github.com/cq27-dev/rag-rat/pull/634))

### Other

- add content candidate DAG storage ([#644](https://github.com/cq27-dev/rag-rat/pull/644))
- tiered god-module sweep (watch, config, mcp, embed_loop) ([#630](https://github.com/cq27-dev/rag-rat/pull/630))
- explain Codex MCP approval for reviews ([#628](https://github.com/cq27-dev/rag-rat/pull/628))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).