### PR TITLE
feat(papertrail): add tracker config and provider ref grammar

### DIFF
--- a/crates/rag-rat-cli/src/commands/clones.rs
+++ b/crates/rag-rat-cli/src/commands/clones.rs
@@ -277,6 +277,8 @@ mod tests {
         std::fs::write(root.join("src/b.rs"), &clone_body).unwrap();
 
         let config = Config {
+            trackers: Vec::new(),
+            papertrail: Default::default(),
             repo_id_override: None,
             database_key_pinned: true,
             root: root.clone(),

--- a/crates/rag-rat-cli/src/commands/index_ops.rs
+++ b/crates/rag-rat-cli/src/commands/index_ops.rs
@@ -632,6 +632,8 @@ mod tests {
         std::fs::create_dir_all(root.join("docs")).unwrap();
         std::fs::write(root.join("docs/a.md"), "# Title\nalpha token\n").unwrap();
         let config = Config {
+            trackers: Vec::new(),
+            papertrail: Default::default(),
             repo_id_override: None,
             database_key_pinned: true,
             root: root.clone(),
@@ -691,6 +693,8 @@ mod tests {
         git(&main, &["add", "-A"]);
         git(&main, &["commit", "-qm", "base"]);
         let config = Config {
+            trackers: Vec::new(),
+            papertrail: Default::default(),
             repo_id_override: None,
             database_key_pinned: true,
             root: main.clone(),
@@ -772,6 +776,8 @@ mod tests {
         git(&main, &["add", "-A"]);
         git(&main, &["commit", "-qm", "base"]);
         let config = Config {
+            trackers: Vec::new(),
+            papertrail: Default::default(),
             repo_id_override: None,
             database_key_pinned: true,
             root: main.clone(),
@@ -851,6 +857,8 @@ mod tests {
         git(&root, &["add", "-A"]);
         git(&root, &["commit", "-qm", "base"]);
         let config = Config {
+            trackers: Vec::new(),
+            papertrail: Default::default(),
             repo_id_override: None,
             database_key_pinned: true,
             root: root.clone(),
@@ -921,6 +929,8 @@ mod tests {
         git(&root, &["add", "-A"]);
         git(&root, &["commit", "-qm", "base"]);
         let config = Config {
+            trackers: Vec::new(),
+            papertrail: Default::default(),
             repo_id_override: None,
             database_key_pinned: true,
             root: root.clone(),
@@ -995,6 +1005,8 @@ mod tests {
         std::fs::create_dir_all(root.join("src")).unwrap();
         std::fs::write(root.join("src/lib.rs"), "pub fn f() {}\n").unwrap();
         let config = Config {
+            trackers: Vec::new(),
+            papertrail: Default::default(),
             repo_id_override: None,
             database_key_pinned: true,
             root: root.clone(),
@@ -1070,6 +1082,8 @@ mod tests {
         )
         .unwrap();
         let config = Config {
+            trackers: Vec::new(),
+            papertrail: Default::default(),
             repo_id_override: None,
             database_key_pinned: true,
             root: root.clone(),

--- a/crates/rag-rat-cli/src/commands/oracle.rs
+++ b/crates/rag-rat-cli/src/commands/oracle.rs
@@ -465,6 +465,8 @@ mod tests {
         std::fs::write(root.join("src/lib.rs"), "fn caller() { target(); } fn target() {}\n")
             .unwrap();
         let config = Config {
+            trackers: Vec::new(),
+            papertrail: Default::default(),
             repo_id_override: None,
             database_key_pinned: true,
             root: root.clone(),
@@ -516,6 +518,8 @@ mod tests {
         // A target carrying the SAME default filters the simple `[target_bindings]` form renders
         // (`include = ["**/*.rs"]`, no exclude), so the bindings-match check accepts it.
         let config_with = |include: Vec<String>, exclude: Vec<String>| Config {
+            trackers: Vec::new(),
+            papertrail: Default::default(),
             repo_id_override: None,
             database_key_pinned: true,
             root: PathBuf::from("/x"),

--- a/crates/rag-rat-core/benches/shared/mod.rs
+++ b/crates/rag-rat-core/benches/shared/mod.rs
@@ -53,6 +53,8 @@ pub fn temp_db_path() -> PathBuf {
 /// A Config indexing `subdir` of the corpus into a fresh temp DB.
 pub fn bench_config(subdir: &str) -> Config {
     Config {
+        trackers: Vec::new(),
+        papertrail: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
         root: corpus_dir(),

--- a/crates/rag-rat-core/src/config/load.rs
+++ b/crates/rag-rat-core/src/config/load.rs
@@ -4,8 +4,8 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
 use super::{
-    self as config, Config, ConfigError, LlmConfig, LogConfig, MemoryConfig, RawConfig, RawTarget,
-    ResolvedTarget, TargetKind,
+    self as config, Config, ConfigError, LlmConfig, LogConfig, MemoryConfig, PapertrailConfig,
+    RawConfig, RawTarget, ResolvedTarget, TargetKind, TrackerConfig,
 };
 use crate::language::Language;
 
@@ -101,15 +101,7 @@ impl Config {
         // The `[local_ai]` / `[dream]` rejections are part of local validity — see the
         // `RawConfig` presence-capture fields.
         let local_parse: Result<RawConfig, ConfigError> =
-            toml::from_str::<RawConfig>(&text).map_err(ConfigError::from).and_then(|raw| {
-                if raw.local_ai.is_some() {
-                    Err(ConfigError::LocalAiTableRenamed)
-                } else if raw.dream.is_some() {
-                    Err(ConfigError::DreamTableMoved)
-                } else {
-                    Ok(raw)
-                }
-            });
+            toml::from_str::<RawConfig>(&text).map_err(ConfigError::from).and_then(validate_raw);
         let local_config_dir = path.parent().unwrap_or_else(|| Path::new("."));
         // The topology subject must be a discoverable directory: a RELATIVE config path like
         // `rag-rat.toml` has the EMPTY path as its parent (`Path::parent` yields `Some("")`, not
@@ -272,6 +264,9 @@ impl Config {
         let oracle = raw.oracle.into();
         let search = raw.search.into();
         let memory = MemoryConfig::try_from(raw.memory)?;
+        let trackers =
+            raw.tracker.into_iter().map(TrackerConfig::try_from).collect::<Result<Vec<_>, _>>()?;
+        let papertrail = PapertrailConfig::default();
         let mut log = LogConfig::try_from(raw.log)?;
         // Finalize `dir`: empty (unset) → sibling of the db (`<db_parent>/logs`); a set value is
         // resolved relative to the GOVERNING config dir (absolute honored).
@@ -293,6 +288,8 @@ impl Config {
             oracle,
             search,
             memory,
+            trackers,
+            papertrail,
             log,
             repo_id_override,
             database_key_pinned,
@@ -316,14 +313,24 @@ fn governing_main_config(main_top: &Path) -> Result<Option<(RawConfig, PathBuf)>
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
         Err(err) => return Err(err.into()),
     };
-    let raw: RawConfig = toml::from_str(&text)?;
+    let raw = validate_raw(toml::from_str(&text)?)?;
+    Ok(Some((raw, main_top)))
+}
+
+/// Presence-captured retired/reserved tables are invalid regardless of which checkout's config
+/// wins the governing seam. Keep this validation single-sourced so loading the same config from
+/// main and from a linked worktree cannot disagree.
+fn validate_raw(raw: RawConfig) -> Result<RawConfig, ConfigError> {
     if raw.local_ai.is_some() {
         return Err(ConfigError::LocalAiTableRenamed);
     }
     if raw.dream.is_some() {
         return Err(ConfigError::DreamTableMoved);
     }
-    Ok(Some((raw, main_top)))
+    if raw.papertrail.is_some() {
+        return Err(ConfigError::PapertrailSchedulingNotSupported);
+    }
+    Ok(raw)
 }
 
 pub(crate) fn resolve_targets(

--- a/crates/rag-rat-core/src/config/mod.rs
+++ b/crates/rag-rat-core/src/config/mod.rs
@@ -137,6 +137,31 @@ pub enum ConfigError {
     UnknownLogFormat(String),
     #[error("[memory] `surface` must be `full` or `summary` (got `{0}`)")]
     UnknownMemorySurface(String),
+    #[error(
+        "each [[tracker]] binding requires a `provider` (`github`, `gitlab`, `bitbucket`, or \
+         `jira`)"
+    )]
+    TrackerProviderMissing,
+    #[error(
+        "[[tracker]] `provider` must be one of `github`, `gitlab`, `bitbucket`, or `jira` (got \
+         `{0}`)"
+    )]
+    UnknownTrackerProvider(String),
+    #[error("[[tracker]] `provider = \"jira\"` requires an explicit `project`")]
+    JiraTrackerRequiresProject,
+    #[error("[[tracker]] `project = \"{project}\"` is not valid for provider `{provider}`")]
+    InvalidTrackerProject { provider: &'static str, project: String },
+    #[error("[[tracker]] `auth` requires exactly one of `env` or `token_command`")]
+    TrackerAuthExactlyOne,
+    #[error("[[tracker]] `base_url` must be an http(s) URL (got `{0}`)")]
+    TrackerBaseUrlNotHttp(String),
+    #[error("[[tracker]] `base_url` must not embed credentials in the URL")]
+    TrackerBaseUrlHasCredentials,
+    #[error(
+        "[papertrail] scheduling settings are not supported until the provider mirror scheduler \
+         is active"
+    )]
+    PapertrailSchedulingNotSupported,
 }
 
 pub use discovery::{
@@ -153,9 +178,9 @@ pub(crate) use raw::{RawMemory, RawOracle, RawSearch, RawVersionCheck, RawWatch}
 pub use types::{
     Config, DEFAULT_QUERY_ENDPOINT, DreamLlmConfig, EmbeddingBackend, EmbeddingConfig,
     EmbeddingRuntimeConfig, LlmConfig, LogConfig, LogFormat, LogLevel,
-    MAX_REMOTE_EMBEDDING_CONCURRENCY, MemoryConfig, MemorySurface, OracleConfig, RemoteBackend,
-    RemoteDreamConfig, RemoteEmbeddingConfig, ResolvedTarget, SearchConfig, TargetKind,
-    VersionCheckConfig, WatchConfig,
+    MAX_REMOTE_EMBEDDING_CONCURRENCY, MemoryConfig, MemorySurface, OracleConfig, PapertrailConfig,
+    RemoteBackend, RemoteDreamConfig, RemoteEmbeddingConfig, ResolvedTarget, SearchConfig,
+    TargetKind, Tracker, TrackerAuth, TrackerConfig, VersionCheckConfig, WatchConfig,
 };
 
 #[cfg(test)]

--- a/crates/rag-rat-core/src/config/raw.rs
+++ b/crates/rag-rat-core/src/config/raw.rs
@@ -7,7 +7,8 @@ use super::{
     ConfigError, DEFAULT_QUERY_ENDPOINT, DreamLlmConfig, EmbeddingBackend, EmbeddingConfig,
     EmbeddingRuntimeConfig, LlmConfig, LogConfig, LogFormat, LogLevel,
     MAX_REMOTE_EMBEDDING_CONCURRENCY, MemoryConfig, MemorySurface, OracleConfig, RemoteBackend,
-    RemoteDreamConfig, RemoteEmbeddingConfig, SearchConfig, VersionCheckConfig, WatchConfig,
+    RemoteDreamConfig, RemoteEmbeddingConfig, SearchConfig, Tracker, TrackerAuth, TrackerConfig,
+    VersionCheckConfig, WatchConfig,
 };
 use crate::embedding_models::Backend;
 
@@ -43,10 +44,116 @@ pub(crate) struct RawConfig {
     pub(crate) search: RawSearch,
     #[serde(default)]
     pub(crate) memory: RawMemory,
+    #[serde(default, rename = "tracker")]
+    pub(crate) tracker: Vec<RawTracker>,
+    /// Reserved for the provider mirror scheduler. Capture the table so config cannot silently
+    /// accept cadence/rate knobs before any production path consumes them.
+    #[serde(default)]
+    pub(crate) papertrail: Option<toml::Value>,
     #[serde(default)]
     pub(crate) target_bindings: BTreeMap<String, Vec<String>>,
     #[serde(default, rename = "target")]
     pub(crate) target: Vec<RawTarget>,
+}
+
+#[derive(Debug, Default, Deserialize, PartialEq)]
+pub(crate) struct RawTracker {
+    provider: Option<String>,
+    project: Option<String>,
+    remote: Option<String>,
+    base_url: Option<String>,
+    auth: Option<RawTrackerAuth>,
+    tags: Option<Vec<String>>,
+}
+
+#[derive(Debug, Default, Deserialize, PartialEq)]
+struct RawTrackerAuth {
+    env: Option<String>,
+    token_command: Option<String>,
+}
+
+impl TryFrom<RawTracker> for TrackerConfig {
+    type Error = ConfigError;
+    fn try_from(raw: RawTracker) -> Result<Self, Self::Error> {
+        let trimmed = |s: Option<String>| s.map(|v| v.trim().to_string()).filter(|v| !v.is_empty());
+        let provider = match trimmed(raw.provider) {
+            None => return Err(ConfigError::TrackerProviderMissing),
+            Some(p) => Tracker::parse_config(&p).ok_or(ConfigError::UnknownTrackerProvider(p))?,
+        };
+        let project = trimmed(raw.project);
+        if provider == Tracker::Jira && project.is_none() {
+            return Err(ConfigError::JiraTrackerRequiresProject);
+        }
+        if let Some(project) = project.as_deref()
+            && !valid_tracker_project(provider, project)
+        {
+            return Err(ConfigError::InvalidTrackerProject {
+                provider: provider.as_db_str(),
+                project: project.to_string(),
+            });
+        }
+        let base_url = match trimmed(raw.base_url) {
+            None => None,
+            Some(url) => {
+                let Some((scheme, rest)) = url.split_once("://") else {
+                    return Err(ConfigError::TrackerBaseUrlNotHttp(url));
+                };
+                let authority = rest.split(['/', '?', '#']).next().unwrap_or_default();
+                if !matches!(scheme, "http" | "https")
+                    || authority.is_empty()
+                    || authority.starts_with(':')
+                    || authority.chars().any(char::is_whitespace)
+                {
+                    return Err(ConfigError::TrackerBaseUrlNotHttp(url));
+                }
+                if endpoint_authority_has_userinfo(&url) {
+                    return Err(ConfigError::TrackerBaseUrlHasCredentials);
+                }
+                Some(url.trim_end_matches('/').to_string())
+            },
+        };
+        let auth = raw.auth.map(TrackerAuth::try_from).transpose()?;
+        let tags = raw
+            .tags
+            .unwrap_or_default()
+            .into_iter()
+            .map(|v| v.trim().to_string())
+            .filter(|v| !v.is_empty())
+            .collect();
+        Ok(Self {
+            provider,
+            project,
+            remote: trimmed(raw.remote).unwrap_or_else(|| "origin".to_string()),
+            base_url,
+            auth,
+            tags,
+        })
+    }
+}
+
+fn valid_tracker_project(provider: Tracker, project: &str) -> bool {
+    let parts = project.split('/').collect::<Vec<_>>();
+    match provider {
+        Tracker::Github | Tracker::Bitbucket =>
+            parts.len() == 2 && parts.iter().all(|part| !part.is_empty()),
+        Tracker::Gitlab => parts.len() >= 2 && parts.iter().all(|part| !part.is_empty()),
+        Tracker::Jira =>
+            project.chars().count() >= 2
+                && project.chars().next().is_some_and(|first| first.is_ascii_uppercase())
+                && project.chars().all(|ch| ch.is_ascii_uppercase() || ch.is_ascii_digit()),
+    }
+}
+
+impl TryFrom<RawTrackerAuth> for TrackerAuth {
+    type Error = ConfigError;
+    fn try_from(raw: RawTrackerAuth) -> Result<Self, Self::Error> {
+        let trimmed = |s: Option<String>| s.map(|v| v.trim().to_string()).filter(|v| !v.is_empty());
+        match (trimmed(raw.env), trimmed(raw.token_command)) {
+            (Some(v), None) => Ok(Self::Env(v)),
+            (None, Some(v)) => Ok(Self::TokenCommand(v)),
+            _ => Err(ConfigError::TrackerAuthExactlyOne),
+        }
+    }
 }
 
 #[derive(Debug, Default, Deserialize, PartialEq)]

--- a/crates/rag-rat-core/src/config/tests.rs
+++ b/crates/rag-rat-core/src/config/tests.rs
@@ -8,8 +8,8 @@ use super::{
     self as config, Config, ConfigError, EmbeddingRuntimeConfig, LlmConfig, LogConfig, LogFormat,
     LogLevel, MemoryConfig, MemorySurface, OracleConfig, RawConfig, RawMemory, RawOracle,
     RawSearch, RawTarget, RawVersionCheck, RawWatch, RemoteBackend, RemoteDreamConfig,
-    RemoteEmbeddingConfig, ResolvedTarget, SearchConfig, TargetKind, VersionCheckConfig,
-    WatchConfig,
+    RemoteEmbeddingConfig, ResolvedTarget, SearchConfig, TargetKind, TrackerAuth,
+    VersionCheckConfig, WatchConfig,
 };
 use crate::language::Language;
 
@@ -64,6 +64,171 @@ fn config_load_resolves_main_and_linked_worktrees_to_one_database() {
     );
 
     let _ = std::fs::remove_dir_all(&tmp);
+}
+
+#[test]
+fn tracker_and_papertrail_config_parse_with_defaults() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("rag-rat.toml"),
+        "[[tracker]]\nprovider = \"github\"\nproject = \"owner/repo\"\n",
+    )
+    .unwrap();
+    let cfg = Config::load(dir.path().join("rag-rat.toml")).unwrap();
+    assert_eq!(cfg.trackers.len(), 1);
+    assert_eq!(cfg.trackers[0].provider, super::Tracker::Github);
+    assert_eq!(cfg.trackers[0].project.as_deref(), Some("owner/repo"));
+    assert_eq!(cfg.trackers[0].remote, "origin");
+}
+
+#[test]
+fn jira_tracker_requires_an_explicit_project() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("rag-rat.toml"), "[[tracker]]\nprovider = \"jira\"\n").unwrap();
+    assert!(matches!(
+        Config::load(dir.path().join("rag-rat.toml")),
+        Err(ConfigError::JiraTrackerRequiresProject)
+    ));
+}
+
+#[test]
+fn tracker_auth_requires_exactly_one_source() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("rag-rat.toml"),
+        "[[tracker]]\nprovider = \"gitlab\"\nauth = { env = \"TOKEN\", token_command = \"glab \
+         auth token\" }\n",
+    )
+    .unwrap();
+    assert!(matches!(
+        Config::load(dir.path().join("rag-rat.toml")),
+        Err(ConfigError::TrackerAuthExactlyOne)
+    ));
+}
+
+#[test]
+fn tracker_auth_accepts_each_supported_source() {
+    for (auth, expected) in [
+        ("env = \"TOKEN\"", TrackerAuth::Env("TOKEN".to_string())),
+        (
+            "token_command = \"gh auth token\"",
+            TrackerAuth::TokenCommand("gh auth token".to_string()),
+        ),
+    ] {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("rag-rat.toml"),
+            format!(
+                "[[tracker]]\nprovider = \"github\"\nproject = \"org/repo\"\nauth = {{ {auth} }}\n"
+            ),
+        )
+        .unwrap();
+        let config = Config::load(dir.path().join("rag-rat.toml")).unwrap();
+        assert_eq!(config.trackers[0].auth.as_ref(), Some(&expected));
+    }
+}
+
+#[test]
+fn tracker_provider_is_required_and_closed() {
+    for (body, expected) in [
+        ("[[tracker]]\nproject = \"org/repo\"\n", "requires a `provider`"),
+        ("[[tracker]]\nprovider = \"forgejo\"\n", "must be one of"),
+    ] {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("rag-rat.toml"), body).unwrap();
+        let error = Config::load(dir.path().join("rag-rat.toml")).unwrap_err().to_string();
+        assert!(error.contains(expected), "{error}");
+    }
+}
+
+#[test]
+fn tracker_projects_are_validated_by_provider() {
+    for (provider, project) in [
+        ("github", "org/team/repo"),
+        ("bitbucket", "workspace/repo/extra"),
+        ("gitlab", "repo"),
+        ("jira", "Proj"),
+        ("jira", "A"),
+    ] {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("rag-rat.toml"),
+            format!("[[tracker]]\nprovider = \"{provider}\"\nproject = \"{project}\"\n"),
+        )
+        .unwrap();
+        assert!(matches!(
+            Config::load(dir.path().join("rag-rat.toml")),
+            Err(ConfigError::InvalidTrackerProject { .. })
+        ));
+    }
+
+    for (provider, project) in
+        [("github", "org/repo"), ("bitbucket", "workspace/repo"), ("gitlab", "group/sub/repo")]
+    {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("rag-rat.toml"),
+            format!("[[tracker]]\nprovider = \"{provider}\"\nproject = \"{project}\"\n"),
+        )
+        .unwrap();
+        Config::load(dir.path().join("rag-rat.toml")).unwrap();
+    }
+}
+
+#[test]
+fn tracker_base_url_requires_a_nonempty_authority() {
+    for base_url in [
+        "https://",
+        "https:///gitlab",
+        "ftp://gitlab.example.com",
+        "gitlab.example.com",
+        "https://:8443",
+        "https://gitlab example.com",
+    ] {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("rag-rat.toml"),
+            format!("[[tracker]]\nprovider = \"gitlab\"\nbase_url = \"{base_url}\"\n"),
+        )
+        .unwrap();
+        assert!(matches!(
+            Config::load(dir.path().join("rag-rat.toml")),
+            Err(ConfigError::TrackerBaseUrlNotHttp(_))
+        ));
+    }
+}
+
+#[test]
+fn tracker_base_url_rejects_credentials_and_normalizes_trailing_slashes() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("rag-rat.toml"),
+        "[[tracker]]\nprovider = \"gitlab\"\nbase_url = \"https://user:token@gitlab.example.com\"\n",
+    )
+    .unwrap();
+    assert!(matches!(
+        Config::load(dir.path().join("rag-rat.toml")),
+        Err(ConfigError::TrackerBaseUrlHasCredentials)
+    ));
+
+    std::fs::write(
+        dir.path().join("rag-rat.toml"),
+        "[[tracker]]\nprovider = \"gitlab\"\nbase_url = \"http://gitlab.example.com:8080/\"\n",
+    )
+    .unwrap();
+    let config = Config::load(dir.path().join("rag-rat.toml")).unwrap();
+    assert_eq!(config.trackers[0].base_url.as_deref(), Some("http://gitlab.example.com:8080"));
+}
+
+#[test]
+fn papertrail_scheduling_table_is_rejected_until_it_is_consumed() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("rag-rat.toml"), "[papertrail]\nprobe_interval_secs = 60\n")
+        .unwrap();
+    assert!(matches!(
+        Config::load(dir.path().join("rag-rat.toml")),
+        Err(ConfigError::PapertrailSchedulingNotSupported)
+    ));
 }
 
 #[test]
@@ -2471,11 +2636,51 @@ fn config_load_propagates_main_parse_error_from_linked_worktree() {
 }
 
 #[test]
+fn config_load_rejects_reserved_papertrail_table_from_governing_main() {
+    let git = |dir: &Path, args: &[&str]| {
+        std::process::Command::new("git").arg("-C").arg(dir).args(args).output().unwrap()
+    };
+    let id = CFG_TEMP.fetch_add(1, Ordering::Relaxed);
+    let tmp =
+        std::env::temp_dir().join(format!("ragrat-main-papertrail-{}-{id}", std::process::id()));
+    let main = tmp.join("main");
+    std::fs::create_dir_all(main.join("src")).unwrap();
+    std::fs::write(main.join("src/lib.rs"), "pub fn a() {}\n").unwrap();
+    std::fs::write(
+        main.join("rag-rat.toml"),
+        "[index]\nroot = \".\"\n[papertrail]\nprobe_interval_secs = 60\n",
+    )
+    .unwrap();
+    git(&main, &["init", "-q"]);
+    git(&main, &["config", "user.email", "t@example.com"]);
+    git(&main, &["config", "user.name", "t"]);
+    git(&main, &["add", "-A"]);
+    git(&main, &["commit", "-qm", "seed"]);
+
+    let linked = tmp.join("wt");
+    git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    std::fs::write(
+        linked.join("rag-rat.toml"),
+        "[index]\nroot = \".\"\n[target_bindings]\nrust = [\"src\"]\n",
+    )
+    .unwrap();
+
+    assert!(matches!(
+        Config::load(linked.join("rag-rat.toml")),
+        Err(ConfigError::PapertrailSchedulingNotSupported)
+    ));
+
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+#[test]
 fn target_directories_deduplicates_across_targets() {
     let dir = tempfile::tempdir().unwrap();
     std::fs::create_dir_all(dir.path().join("src")).unwrap();
     std::fs::create_dir_all(dir.path().join("extra")).unwrap();
     let cfg = Config {
+        trackers: Vec::new(),
+        papertrail: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
         root: dir.path().to_path_buf(),

--- a/crates/rag-rat-core/src/config/types.rs
+++ b/crates/rag-rat-core/src/config/types.rs
@@ -22,6 +22,8 @@ pub struct Config {
     pub oracle: OracleConfig,
     pub search: SearchConfig,
     pub memory: MemoryConfig,
+    pub trackers: Vec<TrackerConfig>,
+    pub papertrail: PapertrailConfig,
     /// Optional `[index] repo_id` override for the consolidated global store — pins the repo's
     /// identity instead of deriving it from the root-commit hash. `None` = derive. Consumed by
     /// `crate::repo_identity::resolve_repo_identity`. An EXPLICIT `database` path never depends on
@@ -46,6 +48,87 @@ pub struct Config {
     /// `index --allow-empty` flag sets this `true`; every other caller (watcher, git-hook
     /// `maintenance`, MCP, init) leaves it `false`. Not read from TOML — set per invocation.
     pub allow_empty: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TrackerConfig {
+    pub provider: Tracker,
+    pub project: Option<String>,
+    pub remote: String,
+    pub base_url: Option<String>,
+    pub auth: Option<TrackerAuth>,
+    pub tags: Vec<String>,
+}
+
+/// One provider identity shared by configuration, runtime bindings, and every persisted
+/// `papertrail_*` key. Database parsing is exact and closed; config parsing is deliberately
+/// case-insensitive at the user-input boundary.
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    serde::Serialize,
+    serde::Deserialize,
+    strum::EnumString,
+    strum::IntoStaticStr,
+)]
+#[strum(serialize_all = "lowercase")]
+#[serde(rename_all = "lowercase")]
+pub enum Tracker {
+    Github,
+    Gitlab,
+    Bitbucket,
+    Jira,
+}
+
+impl Tracker {
+    pub fn as_db_str(self) -> &'static str {
+        self.into()
+    }
+    pub fn from_db_str(value: &str) -> anyhow::Result<Self> {
+        value.parse().map_err(|_| anyhow::anyhow!("unknown tracker token `{value}`"))
+    }
+    pub(crate) fn parse_config(s: &str) -> Option<Self> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "github" => Some(Self::Github),
+            "gitlab" => Some(Self::Gitlab),
+            "bitbucket" => Some(Self::Bitbucket),
+            "jira" => Some(Self::Jira),
+            _ => None,
+        }
+    }
+    pub fn is_code_host(self) -> bool {
+        !matches!(self, Self::Jira)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TrackerAuth {
+    Env(String),
+    TokenCommand(String),
+}
+
+/// Reserved scheduler defaults. User overrides remain rejected until the provider mirror
+/// scheduler consumes them; retaining the typed defaults keeps the runtime contract explicit.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PapertrailConfig {
+    pub probe_interval_secs: u64,
+    pub sync_min_interval_secs: u64,
+    pub full_sync_interval_secs: u64,
+    pub rate_limit_reserve: f64,
+}
+
+impl Default for PapertrailConfig {
+    fn default() -> Self {
+        Self {
+            probe_interval_secs: 900,
+            sync_min_interval_secs: 900,
+            full_sync_interval_secs: 86_400,
+            rate_limit_reserve: 0.35,
+        }
+    }
 }
 
 /// Search-ranking knobs (`[search]`). Default OFF so the shipped fuse is byte-identical to today;

--- a/crates/rag-rat-core/src/index/adoption_hints.rs
+++ b/crates/rag-rat-core/src/index/adoption_hints.rs
@@ -240,6 +240,8 @@ mod tests {
 
     fn source_config(root: PathBuf, language: Language) -> Config {
         Config {
+            trackers: Vec::new(),
+            papertrail: Default::default(),
             repo_id_override: None,
             database_key_pinned: true,
             root: root.clone(),

--- a/crates/rag-rat-core/src/index/lifecycle.rs
+++ b/crates/rag-rat-core/src/index/lifecycle.rs
@@ -175,9 +175,10 @@ impl IndexDatabase {
             active_commit_sha: String::new(),
             active_worktree_id: String::new(),
             active_generation: 0,
-            // Real usage: resolve the GitHub repo context from the local `gh` CLI here, at the
-            // boundary. rebuild/open (used by tests and the bare index command) leave it offline.
-            papertrail: papertrail::PapertrailContext::from_gh(),
+            // Real usage: resolve the tracker context (config bindings, or auto-detect from the
+            // git remote) here, at the boundary. rebuild/open (used by tests and the bare index
+            // command) leave it offline.
+            papertrail: papertrail::PapertrailContext::resolve(config),
             config: Some(config.clone()),
             _identity_lock: None,
             drift_snapshot: std::sync::Mutex::new(None),
@@ -344,7 +345,7 @@ impl IndexDatabase {
             active_commit_sha: String::new(),
             active_worktree_id: String::new(),
             active_generation: 0,
-            papertrail: papertrail::PapertrailContext::from_gh(),
+            papertrail: papertrail::PapertrailContext::resolve(config),
             config: Some(config.clone()),
             _identity_lock: None,
             drift_snapshot: std::sync::Mutex::new(None),
@@ -381,8 +382,12 @@ impl IndexDatabase {
 
     /// Set the GitHub repo context explicitly (tests / non-gh callers), so the library never
     /// shells out to `gh`.
-    pub fn set_papertrail_context(&mut self, default_repo: Option<&str>, gh_available: bool) {
-        self.papertrail = papertrail::PapertrailContext::new(default_repo, gh_available);
+    pub fn set_papertrail_context(
+        &mut self,
+        default_repo: Option<&str>,
+        github_cli_available: bool,
+    ) {
+        self.papertrail = papertrail::PapertrailContext::new(default_repo, github_cli_available);
     }
 
     pub fn migrate(path: &Path) -> anyhow::Result<schema::SchemaStatus> {

--- a/crates/rag-rat-core/src/index/papertrail/api.rs
+++ b/crates/rag-rat-core/src/index/papertrail/api.rs
@@ -23,7 +23,17 @@ pub(crate) async fn sync_from_refs_with_progress<C: PapertrailClient>(
         SyncRefsReport::default()
     } else {
         let client = client.ok_or_else(|| anyhow::anyhow!("papertrail sync requires a client"))?;
-        sync_refs(conn, client, refs.iter(), &mut progress).await?
+        // The stacked schema lets production discovery persist every provider's refs. Live
+        // transport is still GitHub-only until #589 lands, so never send another provider's
+        // identity through GitHubClient. Multi-provider mirror dispatch is the remaining #590
+        // sync slice, intentionally outside this config/grammar PR.
+        sync_refs(
+            conn,
+            client,
+            refs.iter().filter(|reference| reference.tracker == Tracker::Github),
+            &mut progress,
+        )
+        .await?
     };
     let repo_id = schema::active_repo_id(conn)?;
     set_repo_meta(conn, &repo_id, "papertrail_last_sync_ms", &now_ms().to_string())?;
@@ -46,6 +56,7 @@ pub(crate) async fn sync_issue<C: PapertrailClient>(
 ) -> anyhow::Result<PapertrailSyncReport> {
     let parsed = parse_issue_ref(issue_ref, ctx.default_repo())
         .ok_or_else(|| anyhow::anyhow!("invalid tracker item reference `{issue_ref}`"))?;
+    let project = parsed.project.clone();
     let item_key = parsed.number.to_string();
     store_ref(conn, &parsed.into_ref("manual", None, None, issue_ref.to_string()))?;
     let refs = refs(conn)?;
@@ -53,7 +64,17 @@ pub(crate) async fn sync_issue<C: PapertrailClient>(
         SyncRefsReport::default()
     } else {
         let client = client.ok_or_else(|| anyhow::anyhow!("papertrail sync requires a client"))?;
-        sync_refs(conn, client, refs.iter().filter(|r| r.item_key == item_key), &mut |_| {}).await?
+        sync_refs(
+            conn,
+            client,
+            refs.iter().filter(|reference| {
+                reference.tracker == Tracker::Github
+                    && reference.project == project
+                    && reference.item_key == item_key
+            }),
+            &mut |_| {},
+        )
+        .await?
     };
     let repo_id = schema::active_repo_id(conn)?;
     set_repo_meta(conn, &repo_id, "papertrail_last_sync_ms", &now_ms().to_string())?;
@@ -89,7 +110,7 @@ pub(crate) fn status(
         comments: scoped_table_row_count(conn, "papertrail_comments", &repo_id)?,
         last_sync_ms: repo_meta(conn, &repo_id, "papertrail_last_sync_ms")?
             .and_then(|value| value.parse().ok()),
-        capability: if ctx.gh_available {
+        capability: if ctx.github_cli_available {
             "gh_cli_available".to_string()
         } else {
             "gh_cli_missing".to_string()
@@ -111,14 +132,27 @@ pub(crate) fn rationale_search(
     ctx: &PapertrailContext,
 ) -> anyhow::Result<Vec<PapertrailEvidence>> {
     let mut evidence = Vec::new();
-    for parsed in parse_refs(query, ctx.default_repo()) {
+    for parsed in parse_tracker_refs(query, &ctx.trackers) {
         evidence.extend(evidence_for_item(
             conn,
-            Tracker::Github,
+            parsed.provider,
             &parsed.project,
-            &parsed.number.to_string(),
+            &parsed.item_key,
+            parsed.item_kind,
             limit,
         )?);
+    }
+    if ctx.trackers.is_empty() {
+        for parsed in parse_refs(query, None) {
+            evidence.extend(evidence_for_item(
+                conn,
+                Tracker::Github,
+                &parsed.project,
+                &parsed.number.to_string(),
+                None,
+                limit,
+            )?);
+        }
     }
     evidence.extend(search_fts(conn, query, None, limit)?);
     dedupe_evidence(&mut evidence);
@@ -133,8 +167,8 @@ pub(crate) fn refs_for_path(
     let repo_id = schema::active_repo_id(conn)?;
     let mut stmt = conn.prepare(
         "
-        SELECT tracker, project, item_key, ref_kind, source_kind, source_path, source_commit, \
-         source_text
+        SELECT tracker, project, item_key, item_kind, ref_kind, source_kind, source_path, \
+         source_commit, source_text
         FROM papertrail_refs
         WHERE source_path = ?1 AND repo_id = ?3
         ORDER BY id DESC

--- a/crates/rag-rat-core/src/index/papertrail/evidence.rs
+++ b/crates/rag-rat-core/src/index/papertrail/evidence.rs
@@ -13,6 +13,7 @@ pub(crate) fn evidence_for_path(
             reference.tracker,
             &reference.project,
             &reference.item_key,
+            reference.item_kind,
             limit,
         )?);
     }
@@ -53,6 +54,7 @@ pub(crate) fn evidence_for_item(
     tracker: Tracker,
     project: &str,
     item_key: &str,
+    item_kind: Option<ItemKind>,
     limit: u32,
 ) -> anyhow::Result<Vec<PapertrailEvidence>> {
     let repo_id = crate::index::schema::active_repo_id(conn)?;
@@ -62,11 +64,19 @@ pub(crate) fn evidence_for_item(
          classification, 0.0
         FROM papertrail_fts
         WHERE tracker = ?1 AND project = ?2 AND item_key = ?3 AND repo_id = ?5
+          AND (?6 IS NULL OR item_kind = ?6)
         LIMIT ?4
         ",
     )?;
     let rows = stmt.query_map(
-        params![tracker.as_db_str(), project, item_key, i64::from(limit), repo_id],
+        params![
+            tracker.as_db_str(),
+            project,
+            item_key,
+            i64::from(limit),
+            repo_id,
+            item_kind.map(ItemKind::as_db_str)
+        ],
         evidence_row,
     )?;
     let mut evidence = collect_rows(rows)?;
@@ -84,7 +94,7 @@ pub(crate) fn evidence_for_commit_refs(
     let repo_id = crate::index::schema::active_repo_id(conn)?;
     let mut stmt = conn.prepare(
         "
-        SELECT tracker, project, item_key
+        SELECT tracker, project, item_key, item_kind
         FROM papertrail_refs
         WHERE source_kind = 'commit'
           AND source_commit LIKE ?1
@@ -95,16 +105,22 @@ pub(crate) fn evidence_for_commit_refs(
     )?;
     let commit_like = format!("{commit_hash}%");
     let refs = stmt.query_map(params![commit_like, i64::from(limit), repo_id], |row| {
-        Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?, row.get::<_, String>(2)?))
+        Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, String>(1)?,
+            row.get::<_, String>(2)?,
+            row.get::<_, Option<String>>(3)?,
+        ))
     })?;
     let mut evidence = Vec::new();
     for reference in refs {
-        let (tracker, project, item_key) = reference?;
+        let (tracker, project, item_key, item_kind) = reference?;
         evidence.extend(evidence_for_item(
             conn,
             Tracker::from_db_str(&tracker)?,
             &project,
             &item_key,
+            item_kind.as_deref().map(ItemKind::from_db_str).transpose()?,
             limit,
         )?);
     }
@@ -200,18 +216,29 @@ pub(crate) fn ref_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<PapertrailRef
         })?,
         project: row.get(1)?,
         item_key: row.get(2)?,
-        ref_kind: row.get(3)?,
-        source_kind: row.get(4)?,
-        source_path: row.get(5)?,
-        source_commit: row.get(6)?,
-        source_text: row.get(7)?,
+        item_kind: row
+            .get::<_, Option<String>>(3)?
+            .map(|kind| ItemKind::from_db_str(&kind))
+            .transpose()
+            .map_err(|err| {
+                rusqlite::Error::FromSqlConversionFailure(
+                    3,
+                    rusqlite::types::Type::Text,
+                    err.into(),
+                )
+            })?,
+        ref_kind: row.get(4)?,
+        source_kind: row.get(5)?,
+        source_path: row.get(6)?,
+        source_commit: row.get(7)?,
+        source_text: row.get(8)?,
     })
 }
 pub(crate) fn refs(conn: &Connection) -> anyhow::Result<Vec<PapertrailRef>> {
     let repo_id = crate::index::schema::active_repo_id(conn)?;
     let mut stmt = conn.prepare(
-        "SELECT tracker, project, item_key, ref_kind, source_kind, source_path, source_commit, \
-         source_text FROM papertrail_refs WHERE repo_id = ?1",
+        "SELECT tracker, project, item_key, item_kind, ref_kind, source_kind, source_path, \
+         source_commit, source_text FROM papertrail_refs WHERE repo_id = ?1",
     )?;
     let rows = stmt.query_map([repo_id], ref_row)?;
     collect_rows(rows)

--- a/crates/rag-rat-core/src/index/papertrail/mod.rs
+++ b/crates/rag-rat-core/src/index/papertrail/mod.rs
@@ -3,6 +3,7 @@ mod evidence;
 mod parse;
 mod store;
 mod sync;
+mod trackers;
 use std::collections::BTreeSet;
 use std::path::Path;
 use std::process::Command;
@@ -11,40 +12,68 @@ use std::sync::OnceLock;
 pub(crate) use api::*;
 pub(crate) use evidence::*;
 pub(crate) use parse::*;
+pub use parse::{TrackerParsedRef, parse_tracker_refs};
 use rusqlite::{Connection, OptionalExtension, params};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 pub(crate) use store::*;
 pub(crate) use sync::*;
+pub(crate) use trackers::resolve_trackers;
+pub use trackers::{ResolvedTracker, detect_tracker_from_remote_url, normalized_tags};
 
+pub use crate::config::Tracker;
 use crate::index::now_ms;
 
-/// Resolved GitHub repo context, injected into the sync/query paths instead of being resolved
-/// from the local `gh` CLI inside the library. `gh` is network-bound, non-deterministic under
-/// parallelism, and unauthenticated in CI — so it is resolved ONLY at the real-usage boundary
-/// (`IndexDatabase::open_config`) and never in tests, which pass an explicit context (#60).
+/// Resolved tracker context, injected into the sync/query paths instead of being resolved inside
+/// the library. Resolution runs ONLY at the real-usage boundary (`IndexDatabase::open_config`)
+/// and never in tests, which pass an explicit context (#60): it reads local git state (the
+/// remote URL) plus a `gh --version` capability probe — the old `gh repo view` network shell-out
+/// is gone.
 #[derive(Debug, Clone, Default)]
 pub struct PapertrailContext {
-    /// `owner/repo` used to qualify bare `#N` refs. `None` leaves bare refs unresolved.
-    pub default_repo: Option<String>,
-    /// Whether the `gh` CLI is available (reported as a capability in status).
-    pub gh_available: bool,
+    /// Resolved tracker bindings, in config order (or the single auto-detected code host).
+    /// Production discovery and rationale lookup consume every binding. On the #588 stack the
+    /// network client remains GitHub-only; #589 supplies transport for parallel provider sync.
+    pub trackers: Vec<ResolvedTracker>,
+    /// Whether the `gh` CLI is available (reported as a capability in status; the current
+    /// GitHub client still shells out to it until the native transport lands).
+    pub github_cli_available: bool,
 }
 
 impl PapertrailContext {
-    /// Resolve from the local `gh` CLI. Call ONLY at the real-usage boundary (open_config),
-    /// never inside the library internals or tests.
-    pub(crate) fn from_gh() -> Self {
-        Self { default_repo: default_repo(), gh_available: gh_available() }
+    /// Resolve from the repo config: `[[tracker]]` bindings when present, otherwise a binding
+    /// auto-detected from the git `origin` remote. Call ONLY at the real-usage boundary
+    /// (open_config), never inside the library internals or tests.
+    pub(crate) fn resolve(config: &crate::config::Config) -> Self {
+        Self {
+            trackers: resolve_trackers(&config.trackers, &config.root),
+            github_cli_available: github_cli_available(),
+        }
     }
 
-    /// An explicit context that never touches `gh` — for tests and non-gh callers.
-    pub(crate) fn new(default_repo: Option<&str>, gh_available: bool) -> Self {
-        Self { default_repo: default_repo.map(str::to_string), gh_available }
+    /// An explicit GitHub-repo context that never touches git or `gh` — for tests and non-gh
+    /// callers.
+    pub(crate) fn new(default_repo: Option<&str>, github_cli_available: bool) -> Self {
+        let trackers = default_repo
+            .map(|project| ResolvedTracker {
+                provider: Tracker::Github,
+                project: project.to_string(),
+                base_url: None,
+                auth: None,
+                tags: Vec::new(),
+            })
+            .into_iter()
+            .collect();
+        Self { trackers, github_cli_available }
     }
 
+    /// `owner/repo` qualifying a manually requested legacy GitHub reference. Production
+    /// discovery and rationale parsing use all bindings through [`parse_tracker_refs`].
     fn default_repo(&self) -> Option<&str> {
-        self.default_repo.as_deref()
+        self.trackers
+            .iter()
+            .find(|tracker| tracker.provider == Tracker::Github)
+            .map(|tracker| tracker.project.as_str())
     }
 }
 
@@ -101,6 +130,7 @@ pub struct PapertrailRef {
     pub tracker: Tracker,
     pub project: String,
     pub item_key: String,
+    pub item_kind: Option<ItemKind>,
     pub ref_kind: String,
     pub source_kind: String,
     pub source_path: Option<String>,
@@ -142,41 +172,6 @@ pub struct CurrentSourceEvidence {
     pub start_line: Option<i64>,
     pub end_line: Option<i64>,
     pub symbol: Option<String>,
-}
-
-/// The tracker provider a papertrail row belongs to — the persisted `tracker` column of every
-/// `papertrail_*` table. A CLOSED token set: readers reject unknown tokens instead of guessing, so
-/// a new provider lands by adding a variant here (with its exact-token test), never by writing a
-/// free-form string. Only GitHub exists today; GitLab / Bitbucket / Jira arrive with their
-/// provider clients.
-#[derive(
-    Debug,
-    Clone,
-    Copy,
-    PartialEq,
-    Eq,
-    Serialize,
-    Deserialize,
-    strum::EnumString,
-    strum::IntoStaticStr,
-)]
-#[strum(serialize_all = "lowercase")]
-#[serde(rename_all = "lowercase")]
-pub enum Tracker {
-    Github,
-}
-
-impl Tracker {
-    /// The exact persisted token (`papertrail_*.tracker`).
-    pub fn as_db_str(self) -> &'static str {
-        self.into()
-    }
-
-    /// Parse a persisted token, rejecting anything outside the closed set — a papertrail row with
-    /// an unknown tracker is a bug (or a newer binary's data), never something to coerce.
-    pub fn from_db_str(value: &str) -> anyhow::Result<Self> {
-        value.parse().map_err(|_| anyhow::anyhow!("unknown tracker token `{value}`"))
-    }
 }
 
 /// Provider-neutral item kind. GitHub's shared issue/PR numbering is the exception, not the
@@ -511,6 +506,7 @@ impl ParsedRef {
             tracker: Tracker::Github,
             project: self.project,
             item_key: self.number.to_string(),
+            item_kind: None,
             ref_kind: self.kind,
             source_kind: source_kind.to_string(),
             source_path,
@@ -529,9 +525,16 @@ mod token_tests {
     // row read back with a drifted token is a bug to surface, not to coerce.
     #[test]
     fn tracker_tokens_are_exact_and_closed() {
-        assert_eq!(Tracker::Github.as_db_str(), "github");
-        assert_eq!(Tracker::from_db_str("github").unwrap(), Tracker::Github);
-        for rejected in ["GitHub", "GITHUB", " github", "github ", "gitlab", ""] {
+        for (tracker, token) in [
+            (Tracker::Github, "github"),
+            (Tracker::Gitlab, "gitlab"),
+            (Tracker::Bitbucket, "bitbucket"),
+            (Tracker::Jira, "jira"),
+        ] {
+            assert_eq!(tracker.as_db_str(), token);
+            assert_eq!(Tracker::from_db_str(token).unwrap(), tracker);
+        }
+        for rejected in ["GitHub", "GITHUB", " github", "github ", "sourcehut", ""] {
             assert!(Tracker::from_db_str(rejected).is_err(), "must reject `{rejected}`");
         }
     }

--- a/crates/rag-rat-core/src/index/papertrail/parse.rs
+++ b/crates/rag-rat-core/src/index/papertrail/parse.rs
@@ -1,14 +1,17 @@
 use super::*;
 
-pub(crate) fn parse_refs(text: &str, default_repo: Option<&str>) -> Vec<ParsedRef> {
-    let mut refs = Vec::new();
-    let tokens = text
-        .split(|c: char| c.is_whitespace() || [',', ';', ')', ']', '}'].contains(&c))
+/// Ref-bearing tokens of `text` — the shared tokenizer of the legacy GitHub-only lane
+/// ([`parse_refs`]) and the provider-keyed grammar ([`parse_tracker_refs`]). The split/trim sets
+/// deliberately exclude `#`, `!`, and `-`, which are ref syntax.
+fn ref_tokens(text: &str) -> impl Iterator<Item = &str> {
+    text.split(|c: char| c.is_whitespace() || [',', ';', ')', ']', '}'].contains(&c))
         .map(|token| token.trim_matches(|c: char| ['(', '[', '{', '.', ':'].contains(&c)))
         .filter(|token| !token.is_empty())
-        .collect::<Vec<_>>();
+}
+pub(crate) fn parse_refs(text: &str, default_repo: Option<&str>) -> Vec<ParsedRef> {
+    let mut refs = Vec::new();
     let mut previous = "";
-    for token in tokens {
+    for token in ref_tokens(text) {
         let kind = ref_kind(previous);
         if let Some(parsed) = parse_issue_ref(token, default_repo) {
             refs.push(ParsedRef { kind, ..parsed });
@@ -17,46 +20,302 @@ pub(crate) fn parse_refs(text: &str, default_repo: Option<&str>) -> Vec<ParsedRe
     }
     refs
 }
+/// The legacy GitHub-only parser retained for the manual single-item API and compatibility tests.
+/// Production discovery and rationale lookup consume [`parse_tracker_refs`] directly.
 pub(crate) fn parse_issue_ref(token: &str, default_repo: Option<&str>) -> Option<ParsedRef> {
-    if let Some(rest) = token.strip_prefix("https://github.com/") {
+    let parsed = github_token_ref(token, default_repo, "https://github.com", true)?;
+    // The GitHub grammar only ever emits two-segment `owner/repo` projects.
+    split_repo(&parsed.project)?;
+    Some(ParsedRef {
+        project: parsed.project,
+        number: parsed.number,
+        kind: parsed.shape.to_string(),
+    })
+}
+struct GithubTokenRef {
+    project: String,
+    number: i64,
+    /// `Some` only for `/pull/`, whose path unambiguously names the kind. `/issues/` and shorthand
+    /// refs stay `None`: GitHub serves pull requests through issue URLs too, so the provider must
+    /// resolve their kind.
+    item_kind: Option<ItemKind>,
+    shape: &'static str,
+}
+/// The GitHub token grammar — `<base>/owner/repo/{issues|pull}/N` URLs, `owner/repo#N`, `GH-N`,
+/// bare `#N` — shared by the legacy lane and the provider-keyed grammar so the two can never
+/// drift. `local_number` gates the bare-`#N` arm: bare refs resolve against the code-host
+/// binding only.
+fn github_token_ref(
+    token: &str,
+    default_project: Option<&str>,
+    url_base: &str,
+    local_number: bool,
+) -> Option<GithubTokenRef> {
+    if let Some(rest) = token.strip_prefix(url_base).and_then(|rest| rest.strip_prefix('/')) {
         let parts = rest.split('/').collect::<Vec<_>>();
         if parts.len() >= 4 && (parts[2] == "issues" || parts[2] == "pull") {
-            return Some(ParsedRef {
+            return Some(GithubTokenRef {
                 project: format!("{}/{}", parts[0], parts[1]),
                 number: parts[3].parse().ok()?,
-                kind: "url".to_string(),
+                item_kind: (parts[2] == "pull").then_some(ItemKind::ChangeRequest),
+                shape: "url",
             });
         }
     }
     if let Some((repo_ref, number)) = token.split_once('#') {
         let parts = repo_ref.split('/').collect::<Vec<_>>();
         if parts.len() == 2 {
-            return Some(ParsedRef {
+            return Some(GithubTokenRef {
                 project: repo_ref.to_string(),
                 number: number.parse().ok()?,
-                kind: "cross_repo".to_string(),
+                item_kind: None,
+                shape: "cross_repo",
             });
         }
     }
     if let Some(number) = token.strip_prefix("GH-") {
-        // The default project must be an `owner/repo` path — reject anything else rather than
-        // storing a malformed project key.
-        split_repo(default_repo?)?;
-        return Some(ParsedRef {
-            project: default_repo?.to_string(),
+        return Some(GithubTokenRef {
+            project: default_project?.to_string(),
             number: number.parse().ok()?,
-            kind: "gh_dash".to_string(),
+            item_kind: None,
+            shape: "gh_dash",
         });
     }
-    if let Some(number) = token.strip_prefix('#') {
-        split_repo(default_repo?)?;
-        return Some(ParsedRef {
-            project: default_repo?.to_string(),
+    if local_number && let Some(number) = token.strip_prefix('#') {
+        return Some(GithubTokenRef {
+            project: default_project?.to_string(),
             number: number.parse().ok()?,
-            kind: "local_number".to_string(),
+            item_kind: None,
+            shape: "local_number",
         });
     }
     None
+}
+/// A tracker item reference parsed from free text under one binding's grammar — the
+/// provider-keyed successor of [`ParsedRef`]. `item_kind` is `Some` only where the SYNTAX names
+/// the kind unambiguously (a GitHub `/pull/` URL, GitLab's `!N`); GitHub `/issues/` and `#N` stay
+/// `None` for the shared-numbering provider to resolve.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TrackerParsedRef {
+    pub provider: Tracker,
+    pub project: String,
+    /// Provider item key, stringly — numeric for the code hosts, `PROJ-123` for Jira.
+    pub item_key: String,
+    pub item_kind: Option<ItemKind>,
+    /// `closing` / `reference` / `unknown` from the preceding word, exactly as [`parse_refs`].
+    pub ref_kind: String,
+}
+
+impl TrackerParsedRef {
+    pub(crate) fn into_ref(
+        self,
+        source_kind: &str,
+        source_path: Option<String>,
+        source_commit: Option<String>,
+        source_text: String,
+    ) -> PapertrailRef {
+        PapertrailRef {
+            tracker: self.provider,
+            project: self.project,
+            item_key: self.item_key,
+            item_kind: self.item_kind,
+            ref_kind: self.ref_kind,
+            source_kind: source_kind.to_string(),
+            source_path,
+            source_commit,
+            source_text,
+        }
+    }
+}
+/// Provider-keyed ref discovery over `text` for the resolved bindings — the annotation-layer
+/// grammar behind the multi-tracker mirror. Tokenization matches [`parse_refs`]; each token is
+/// claimed by the FIRST binding whose grammar matches, which keeps overlapping grammars
+/// deterministic (`o/r#1` parses under GitHub and GitLab alike; `GH-1` under GitHub and a Jira
+/// `GH` project). Bare `#N` resolves against the FIRST code-host binding only, per the config
+/// contract; GitLab's bare `!N` is provider-explicit syntax and resolves against its own
+/// binding regardless.
+pub fn parse_tracker_refs(text: &str, trackers: &[ResolvedTracker]) -> Vec<TrackerParsedRef> {
+    let code_host = trackers.iter().position(|tracker| tracker.provider.is_code_host());
+    let mut refs = Vec::new();
+    let mut previous = "";
+    for token in ref_tokens(text) {
+        let ref_kind = ref_kind(previous);
+        if let Some(mut parsed) = trackers.iter().enumerate().find_map(|(index, tracker)| {
+            tracker_token_ref(token, tracker, code_host == Some(index))
+        }) {
+            parsed.ref_kind = ref_kind;
+            refs.push(parsed);
+        }
+        previous = token;
+    }
+    refs
+}
+fn tracker_token_ref(
+    token: &str,
+    tracker: &ResolvedTracker,
+    is_code_host: bool,
+) -> Option<TrackerParsedRef> {
+    match tracker.provider {
+        Tracker::Github => {
+            let base = url_base(tracker, "https://github.com");
+            let parsed = github_token_ref(token, Some(&tracker.project), base, is_code_host)?;
+            Some(tracker_ref(tracker, parsed.project, parsed.number.to_string(), parsed.item_kind))
+        },
+        Tracker::Gitlab => gitlab_token_ref(token, tracker, is_code_host),
+        Tracker::Bitbucket => bitbucket_token_ref(token, tracker, is_code_host),
+        Tracker::Jira => jira_token_ref(token, &tracker.project)
+            .map(|key| tracker_ref(tracker, tracker.project.clone(), key, Some(ItemKind::Issue))),
+    }
+}
+fn tracker_ref(
+    tracker: &ResolvedTracker,
+    project: String,
+    item_key: String,
+    item_kind: Option<ItemKind>,
+) -> TrackerParsedRef {
+    // `ref_kind` comes from the surrounding text; the caller stamps it.
+    TrackerParsedRef {
+        provider: tracker.provider,
+        project,
+        item_key,
+        item_kind,
+        ref_kind: String::new(),
+    }
+}
+/// The URL prefix a binding's URL grammar matches. A self-hosted binding matches ONLY its own
+/// host — a cloud URL in text names the cloud instance's project, never the self-hosted one.
+fn url_base<'a>(tracker: &'a ResolvedTracker, cloud: &'a str) -> &'a str {
+    tracker.base_url.as_deref().unwrap_or(cloud)
+}
+/// GitLab grammar: `<base>/<namespace...>/-/issues/N` + `/-/merge_requests/N` URLs,
+/// cross-project `namespace/path#N` / `namespace/path!N` (multi-level subgroup paths), and the
+/// bare `#N` / `!N` shorthands. GitLab numbers issues and merge requests in SEPARATE iid
+/// namespaces, so every arm names the kind.
+fn gitlab_token_ref(
+    token: &str,
+    tracker: &ResolvedTracker,
+    is_code_host: bool,
+) -> Option<TrackerParsedRef> {
+    let base = url_base(tracker, "https://gitlab.com");
+    if let Some(rest) = token.strip_prefix(base).and_then(|rest| rest.strip_prefix('/')) {
+        let (project, tail) = rest.split_once("/-/")?;
+        let parts = tail.split('/').collect::<Vec<_>>();
+        if parts.len() < 2 || project.is_empty() {
+            return None;
+        }
+        let item_kind = match parts[0] {
+            "issues" => ItemKind::Issue,
+            "merge_requests" => ItemKind::ChangeRequest,
+            _ => return None,
+        };
+        let number: i64 = parts[1].parse().ok()?;
+        return Some(tracker_ref(
+            tracker,
+            project.to_string(),
+            number.to_string(),
+            Some(item_kind),
+        ));
+    }
+    for (separator, item_kind) in [('!', ItemKind::ChangeRequest), ('#', ItemKind::Issue)] {
+        let Some((path, number)) = token.split_once(separator) else {
+            continue;
+        };
+        let Ok(number) = number.parse::<i64>() else {
+            continue;
+        };
+        if path.is_empty() {
+            // Bare shorthand → the binding's own project. `#N` is the cross-provider bare form
+            // (code-host binding only); `!N` is GitLab-specific and always resolves here.
+            if separator == '#' && !is_code_host {
+                continue;
+            }
+            return Some(tracker_ref(
+                tracker,
+                tracker.project.clone(),
+                number.to_string(),
+                Some(item_kind),
+            ));
+        }
+        let segments = path.split('/').collect::<Vec<_>>();
+        if segments.len() >= 2 && segments.iter().all(|segment| !segment.is_empty()) {
+            return Some(tracker_ref(
+                tracker,
+                path.to_string(),
+                number.to_string(),
+                Some(item_kind),
+            ));
+        }
+    }
+    None
+}
+/// Bitbucket grammar: Cloud `<base>/<workspace>/<repo>/{issues|pull-requests}/N`, Data Center
+/// `<base>/projects/<project>/repos/<repo>/pull-requests/N`, and the bare `#N` shorthand.
+fn bitbucket_token_ref(
+    token: &str,
+    tracker: &ResolvedTracker,
+    is_code_host: bool,
+) -> Option<TrackerParsedRef> {
+    let base = url_base(tracker, "https://bitbucket.org");
+    if let Some(rest) = token.strip_prefix(base).and_then(|rest| rest.strip_prefix('/')) {
+        let parts = rest.split('/').collect::<Vec<_>>();
+        if let ["projects", project, "repos", repo, "pull-requests", number, ..] = parts.as_slice()
+        {
+            let number: i64 = number.parse().ok()?;
+            return Some(tracker_ref(
+                tracker,
+                format!("{project}/{repo}"),
+                number.to_string(),
+                Some(ItemKind::ChangeRequest),
+            ));
+        }
+        if parts.len() < 4 {
+            return None;
+        }
+        let item_kind = match parts[2] {
+            "issues" => ItemKind::Issue,
+            "pull-requests" => ItemKind::ChangeRequest,
+            _ => return None,
+        };
+        let number: i64 = parts[3].parse().ok()?;
+        return Some(tracker_ref(
+            tracker,
+            format!("{}/{}", parts[0], parts[1]),
+            number.to_string(),
+            Some(item_kind),
+        ));
+    }
+    if is_code_host
+        && let Some(number) = token.strip_prefix('#')
+        && let Ok(number) = number.parse::<i64>()
+    {
+        return Some(tracker_ref(
+            tracker,
+            tracker.project.clone(),
+            number.to_string(),
+            Some(ItemKind::Issue),
+        ));
+    }
+    None
+}
+/// Jira bare keys: `[A-Z][A-Z0-9]+-\d+`, WHOLE-token anchored (the tokenizer split is the word
+/// boundary, so `XPROJ-12` never matches a `PROJ` binding) and ONLY for the bound project key —
+/// an unscoped pattern would drown discovery in `UTF-8` / `ISO-8601` / `SHA-256`-shaped false
+/// positives and collide with GitHub's `GH-N` shorthand.
+fn jira_token_ref(token: &str, project: &str) -> Option<String> {
+    if !is_jira_key_project(project) {
+        return None;
+    }
+    let number = token.strip_prefix(project)?.strip_prefix('-')?;
+    (!number.is_empty() && number.bytes().all(|byte| byte.is_ascii_digit()))
+        .then(|| token.to_string())
+}
+/// Whether the configured Jira project is key-shaped (`[A-Z][A-Z0-9]+`). A non-key project can
+/// never engage the bare-key grammar — its word-boundary guarantees don't hold.
+fn is_jira_key_project(project: &str) -> bool {
+    let bytes = project.as_bytes();
+    bytes.len() >= 2
+        && bytes[0].is_ascii_uppercase()
+        && bytes.iter().all(|byte| byte.is_ascii_uppercase() || byte.is_ascii_digit())
 }
 pub(crate) fn ref_kind(previous: &str) -> String {
     let previous = previous.to_ascii_lowercase();
@@ -208,18 +467,7 @@ pub(crate) fn gh_api_paginated(path: &str) -> anyhow::Result<Vec<Value>> {
     }
     Ok(out)
 }
-pub(crate) fn default_repo() -> Option<String> {
-    let output = Command::new("gh")
-        .args(["repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"])
-        .output()
-        .ok()?;
-    output
-        .status
-        .success()
-        .then(|| String::from_utf8_lossy(&output.stdout).trim().to_string())
-        .filter(|value| !value.is_empty())
-}
-pub(crate) fn gh_available() -> bool {
+pub(crate) fn github_cli_available() -> bool {
     Command::new("gh").arg("--version").output().is_ok_and(|output| output.status.success())
 }
 pub(crate) fn string_value(value: &Value, key: &str) -> String {
@@ -247,6 +495,199 @@ pub(crate) fn collect_rows<T>(
         out.push(row?);
     }
     Ok(out)
+}
+
+#[cfg(test)]
+mod grammar_tests {
+    use super::*;
+
+    fn tracker(provider: Tracker, project: &str) -> ResolvedTracker {
+        ResolvedTracker {
+            provider,
+            project: project.to_string(),
+            base_url: None,
+            auth: None,
+            tags: Vec::new(),
+        }
+    }
+
+    fn self_hosted(provider: Tracker, project: &str, base_url: &str) -> ResolvedTracker {
+        ResolvedTracker { base_url: Some(base_url.to_string()), ..tracker(provider, project) }
+    }
+
+    /// (project, item_key, item_kind) of every ref parsed from `text` under the bindings.
+    fn table(text: &str, trackers: &[ResolvedTracker]) -> Vec<(String, String, Option<ItemKind>)> {
+        parse_tracker_refs(text, trackers)
+            .into_iter()
+            .map(|r| (r.project, r.item_key, r.item_kind))
+            .collect()
+    }
+
+    fn one(text: &str, trackers: &[ResolvedTracker]) -> (String, String, Option<ItemKind>) {
+        let mut refs = table(text, trackers);
+        assert_eq!(refs.len(), 1, "{text}: expected exactly one ref, got {refs:?}");
+        refs.remove(0)
+    }
+
+    #[test]
+    fn github_grammar_covers_shorthands_and_urls() {
+        let gh = [tracker(Tracker::Github, "o/r")];
+        // Shorthand kinds stay None — GitHub's shared numbering means the provider resolves.
+        assert_eq!(one("fixes #12", &gh), ("o/r".into(), "12".into(), None));
+        assert_eq!(one("see GH-7", &gh), ("o/r".into(), "7".into(), None));
+        assert_eq!(one("ref other/repo#3", &gh), ("other/repo".into(), "3".into(), None));
+        // `/issues/` is ambiguous because GitHub also serves PRs there; `/pull/` is not.
+        assert_eq!(one("https://github.com/a/b/issues/42", &gh), ("a/b".into(), "42".into(), None));
+        assert_eq!(
+            one("https://github.com/a/b/pull/7", &gh),
+            ("a/b".into(), "7".into(), Some(ItemKind::ChangeRequest))
+        );
+        // Non-refs stay quiet.
+        assert_eq!(table("#notanumber a/b/c#4 https://github.com/a/b", &gh), Vec::new());
+        // The ref-kind words still classify the surrounding text.
+        let refs = parse_tracker_refs("fixes #1 and see #2, #3", &gh);
+        assert_eq!(refs.iter().map(|r| r.ref_kind.as_str()).collect::<Vec<_>>(), [
+            "closing",
+            "reference",
+            "unknown"
+        ]);
+    }
+
+    #[test]
+    fn gitlab_grammar_names_kinds_and_keeps_subgroup_paths() {
+        let gl = [tracker(Tracker::Gitlab, "group/sub/repo")];
+        // GitLab iid namespaces are separate, so every arm names the kind.
+        assert_eq!(
+            one("fixes !7", &gl),
+            ("group/sub/repo".into(), "7".into(), Some(ItemKind::ChangeRequest))
+        );
+        assert_eq!(
+            one("closes #9", &gl),
+            ("group/sub/repo".into(), "9".into(), Some(ItemKind::Issue))
+        );
+        // Cross-project shorthands keep multi-level namespace paths.
+        assert_eq!(
+            one("other/team/app!4", &gl),
+            ("other/team/app".into(), "4".into(), Some(ItemKind::ChangeRequest))
+        );
+        assert_eq!(
+            one("other/team/app#5", &gl),
+            ("other/team/app".into(), "5".into(), Some(ItemKind::Issue))
+        );
+        // URLs, subgroups included.
+        assert_eq!(
+            one("https://gitlab.com/g/s/r/-/issues/11", &gl),
+            ("g/s/r".into(), "11".into(), Some(ItemKind::Issue))
+        );
+        assert_eq!(
+            one("https://gitlab.com/g/s/r/-/merge_requests/3", &gl),
+            ("g/s/r".into(), "3".into(), Some(ItemKind::ChangeRequest))
+        );
+        assert_eq!(table("https://gitlab.com/g/r/-/pipelines/3 solo#2", &gl), Vec::new());
+    }
+
+    #[test]
+    fn self_hosted_bindings_match_only_their_own_host() {
+        let gl = [self_hosted(Tracker::Gitlab, "group/repo", "https://gitlab.example.com")];
+        assert_eq!(
+            one("https://gitlab.example.com/g/s/r/-/issues/6", &gl),
+            ("g/s/r".into(), "6".into(), Some(ItemKind::Issue))
+        );
+        // A cloud URL names the CLOUD instance's project — never the self-hosted binding's.
+        assert_eq!(table("https://gitlab.com/g/s/r/-/issues/6", &gl), Vec::new());
+    }
+
+    #[test]
+    fn bitbucket_grammar_covers_urls_and_bare_issue_refs() {
+        let bb = [tracker(Tracker::Bitbucket, "ws/repo")];
+        assert_eq!(
+            one("https://bitbucket.org/ws/repo/pull-requests/5", &bb),
+            ("ws/repo".into(), "5".into(), Some(ItemKind::ChangeRequest))
+        );
+        assert_eq!(
+            one("https://bitbucket.org/ws/repo/issues/8", &bb),
+            ("ws/repo".into(), "8".into(), Some(ItemKind::Issue))
+        );
+        // Bare `#N` is issue-shaped on Bitbucket (independent PR numbering).
+        assert_eq!(one("fixes #4", &bb), ("ws/repo".into(), "4".into(), Some(ItemKind::Issue)));
+        assert_eq!(table("https://bitbucket.org/ws/repo/branches/x", &bb), Vec::new());
+
+        let dc = [self_hosted(Tracker::Bitbucket, "PROJ/repo", "https://bitbucket.example.com")];
+        assert_eq!(
+            one("https://bitbucket.example.com/projects/PROJ/repos/repo/pull-requests/11", &dc,),
+            ("PROJ/repo".into(), "11".into(), Some(ItemKind::ChangeRequest)),
+        );
+    }
+
+    #[test]
+    fn jira_grammar_matches_only_the_bound_project_key_whole_token() {
+        let jira = [tracker(Tracker::Jira, "PROJ")];
+        assert_eq!(
+            one("fixes PROJ-123", &jira),
+            ("PROJ".into(), "PROJ-123".into(), Some(ItemKind::Issue))
+        );
+        assert_eq!(one("(PROJ-9)", &jira), ("PROJ".into(), "PROJ-9".into(), Some(ItemKind::Issue)));
+        // Word-boundary anchored (whole token), digits required, bound project only, and the
+        // uppercase key-shaped lookalikes stay quiet.
+        assert_eq!(
+            table("XPROJ-12 proj-12 PROJ- PROJ-1a OTHER-5 UTF-8 ISO-8601 SHA-256", &jira),
+            Vec::new()
+        );
+        // A bare `#N` never resolves against Jira — it is not a code host.
+        assert_eq!(table("fixes #12", &jira), Vec::new());
+        // A non-key-shaped configured project cannot engage the bare-key grammar.
+        assert_eq!(table("proj-12", &[tracker(Tracker::Jira, "proj")]), Vec::new());
+    }
+
+    #[test]
+    fn bare_refs_resolve_against_the_first_code_host_binding_only() {
+        let jira_then_gitlab =
+            [tracker(Tracker::Jira, "PROJ"), tracker(Tracker::Gitlab, "group/repo")];
+        // Jira is skipped for code-host resolution even when listed first.
+        assert_eq!(
+            one("fixes #3", &jira_then_gitlab),
+            ("group/repo".into(), "3".into(), Some(ItemKind::Issue))
+        );
+
+        let github_then_gitlab =
+            [tracker(Tracker::Github, "o/r"), tracker(Tracker::Gitlab, "group/repo")];
+        // `#N` goes to the FIRST code host; `!N` is GitLab-specific syntax and still resolves.
+        assert_eq!(one("#5", &github_then_gitlab), ("o/r".into(), "5".into(), None));
+        assert_eq!(
+            one("!5", &github_then_gitlab),
+            ("group/repo".into(), "5".into(), Some(ItemKind::ChangeRequest))
+        );
+        // Overlapping grammars are deterministic: the first binding claims `a/b#1` once.
+        assert_eq!(one("a/b#1", &github_then_gitlab), ("a/b".into(), "1".into(), None));
+    }
+
+    #[test]
+    fn one_repo_can_bind_a_code_host_and_jira_together() {
+        let both = [tracker(Tracker::Github, "o/r"), tracker(Tracker::Jira, "PROJ")];
+        assert_eq!(table("fixes #2 and PROJ-7", &both), vec![
+            ("o/r".to_string(), "2".to_string(), None),
+            ("PROJ".to_string(), "PROJ-7".to_string(), Some(ItemKind::Issue)),
+        ]);
+        // `GH-1` is claimed by the GitHub binding before a Jira `GH` project could see it.
+        let gh_project = [tracker(Tracker::Github, "o/r"), tracker(Tracker::Jira, "GH")];
+        assert_eq!(one("GH-1", &gh_project), ("o/r".into(), "1".into(), None));
+    }
+
+    #[test]
+    fn legacy_github_lane_stays_projection_equal_to_the_tracker_grammar() {
+        // `parse_refs` (the github_* sync lane) and `parse_tracker_refs` under a GitHub binding
+        // share `github_token_ref`; pin the projection so the lanes cannot drift apart.
+        let text = "fixes #1, see other/repo#2 and https://github.com/a/b/pull/3 GH-4";
+        let legacy = parse_refs(text, Some("o/r"));
+        let keyed = parse_tracker_refs(text, &[tracker(Tracker::Github, "o/r")]);
+        assert_eq!(legacy.len(), 4);
+        assert_eq!(legacy.len(), keyed.len());
+        for (old, new) in legacy.iter().zip(&keyed) {
+            assert_eq!(old.project, new.project);
+            assert_eq!(old.number.to_string(), new.item_key);
+            assert_eq!(old.kind, new.ref_kind);
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/rag-rat-core/src/index/papertrail/store.rs
+++ b/crates/rag-rat-core/src/index/papertrail/store.rs
@@ -26,17 +26,18 @@ pub(crate) fn store_ref(conn: &Connection, reference: &PapertrailRef) -> anyhow:
     conn.execute(
         "
         INSERT INTO papertrail_refs(
-            tracker, project, item_key, ref_kind, source_kind, source_path, source_commit, \
-         source_text, discovered_at_ms, repo_id
+            tracker, project, item_key, item_kind, ref_kind, source_kind, source_path, \
+         source_commit, source_text, discovered_at_ms, repo_id
         )
-        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
-        ON CONFLICT(repo_id, tracker, project, item_key, source_kind, COALESCE(source_path, ''), \
-         COALESCE(source_commit, ''), source_text) DO NOTHING
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)
+        ON CONFLICT(repo_id, tracker, project, COALESCE(item_kind, ''), item_key, source_kind, \
+         COALESCE(source_path, ''), COALESCE(source_commit, ''), source_text) DO NOTHING
         ",
         params![
             reference.tracker.as_db_str(),
             reference.project,
             reference.item_key,
+            reference.item_kind.map(ItemKind::as_db_str),
             reference.ref_kind,
             reference.source_kind,
             reference.source_path,

--- a/crates/rag-rat-core/src/index/papertrail/sync.rs
+++ b/crates/rag-rat-core/src/index/papertrail/sync.rs
@@ -5,17 +5,21 @@ pub(crate) fn discover_and_store_refs(
     root: &Path,
     ctx: &PapertrailContext,
 ) -> anyhow::Result<Vec<PapertrailRef>> {
-    let default_repo = ctx.default_repo().map(str::to_string);
     let mut refs = Vec::new();
-    discover_commit_refs(conn, default_repo.as_deref(), &mut refs)?;
-    discover_file_refs(conn, root, default_repo.as_deref(), &mut refs)?;
+    discover_commit_refs(conn, &ctx.trackers, &mut refs)?;
+    discover_file_refs(conn, root, &ctx.trackers, &mut refs)?;
     let branch = crate::index::git_context::discover_repo(root)
         .ok()
         .and_then(|repo| repo.head_name().ok().flatten())
         .map(|name| name.shorten().to_string())
         .unwrap_or_default();
-    for parsed in parse_refs(&branch, default_repo.as_deref()) {
+    for parsed in parse_tracker_refs(&branch, &ctx.trackers) {
         refs.push(parsed.into_ref("branch", None, None, branch.clone()));
+    }
+    if ctx.trackers.is_empty() {
+        for parsed in parse_refs(&branch, None) {
+            refs.push(parsed.into_ref("branch", None, None, branch.clone()));
+        }
     }
     let mut unique = BTreeSet::new();
     refs.retain(|r| {
@@ -23,6 +27,7 @@ pub(crate) fn discover_and_store_refs(
             r.tracker.as_db_str(),
             r.project.clone(),
             r.item_key.clone(),
+            r.item_kind.map(ItemKind::as_db_str),
             r.source_kind.clone(),
             r.source_path.clone(),
             r.source_commit.clone(),
@@ -42,7 +47,12 @@ pub(crate) async fn sync_refs<'a, C: PapertrailClient>(
 ) -> anyhow::Result<SyncRefsReport> {
     let refs = refs.collect::<Vec<_>>();
     let identity = |reference: &PapertrailRef| {
-        (reference.tracker.as_db_str(), reference.project.clone(), reference.item_key.clone())
+        (
+            reference.tracker.as_db_str(),
+            reference.project.clone(),
+            reference.item_kind.map(ItemKind::as_db_str),
+            reference.item_key.clone(),
+        )
     };
     let total = refs.iter().map(|reference| identity(reference)).collect::<BTreeSet<_>>().len();
     let mut report = SyncRefsReport::default();
@@ -163,7 +173,7 @@ pub(crate) fn is_not_found_error(message: &str) -> bool {
 }
 pub(crate) fn discover_commit_refs(
     conn: &Connection,
-    default_repo: Option<&str>,
+    trackers: &[ResolvedTracker],
     out: &mut Vec<PapertrailRef>,
 ) -> anyhow::Result<()> {
     // `git_commits` is direct-scoped (V040), so discovery only mines the ACTIVE repo's commit
@@ -178,8 +188,13 @@ pub(crate) fn discover_commit_refs(
     for row in rows {
         let (hash, subject, body) = row?;
         for text in [subject, body] {
-            for parsed in parse_refs(&text, default_repo) {
+            for parsed in parse_tracker_refs(&text, trackers) {
                 out.push(parsed.into_ref("commit", None, Some(hash.clone()), text.clone()));
+            }
+            if trackers.is_empty() {
+                for parsed in parse_refs(&text, None) {
+                    out.push(parsed.into_ref("commit", None, Some(hash.clone()), text.clone()));
+                }
             }
         }
     }
@@ -188,7 +203,7 @@ pub(crate) fn discover_commit_refs(
 pub(crate) fn discover_file_refs(
     conn: &Connection,
     root: &Path,
-    default_repo: Option<&str>,
+    trackers: &[ResolvedTracker],
     out: &mut Vec<PapertrailRef>,
 ) -> anyhow::Result<()> {
     let mut stmt = conn.prepare("SELECT path FROM files ORDER BY path")?;
@@ -199,13 +214,23 @@ pub(crate) fn discover_file_refs(
             continue;
         };
         for line in text.lines() {
-            for parsed in parse_refs(line, default_repo) {
+            for parsed in parse_tracker_refs(line, trackers) {
                 out.push(parsed.into_ref(
                     "file",
                     Some(path.clone()),
                     None,
                     line.trim().to_string(),
                 ));
+            }
+            if trackers.is_empty() {
+                for parsed in parse_refs(line, None) {
+                    out.push(parsed.into_ref(
+                        "file",
+                        Some(path.clone()),
+                        None,
+                        line.trim().to_string(),
+                    ));
+                }
             }
         }
     }

--- a/crates/rag-rat-core/src/index/papertrail/trackers.rs
+++ b/crates/rag-rat-core/src/index/papertrail/trackers.rs
@@ -1,0 +1,514 @@
+//! Tracker bindings resolved for one checkout: the `[[tracker]]` config list (or, with no
+//! config, a binding auto-detected from the git `origin` remote) turned into concrete
+//! (provider, project) pairs the sync and ref-grammar layers consume. Resolution reads only
+//! local git state — the old `gh repo view` network shell-out is gone.
+
+use std::collections::BTreeSet;
+use std::fmt::Write as _;
+use std::path::Path;
+
+use sha2::{Digest, Sha256};
+
+use crate::config::{Tracker, TrackerAuth, TrackerConfig};
+
+/// One tracker binding with its `project` resolved to a concrete value — the runtime shape
+/// behind [`super::PapertrailContext`]. The context carries a LIST of these so the mirror sync
+/// can drive every binding concurrently, each under its own rate governor; a binding whose
+/// project cannot be resolved (no usable git remote) is dropped at resolution.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedTracker {
+    pub provider: Tracker,
+    /// Concrete project path/key: `owner/repo`, a full GitLab namespace path (subgroups kept),
+    /// `workspace/repo`, or a Jira project key.
+    pub project: String,
+    /// Self-hosted base URL (no trailing slash). `None` = the provider's cloud host.
+    pub base_url: Option<String>,
+    pub auth: Option<TrackerAuth>,
+    /// Configured tags as written (trimmed, non-empty); matching and fingerprinting normalize
+    /// on demand via [`normalized_tags`].
+    pub tags: Vec<String>,
+}
+
+impl ResolvedTracker {
+    /// Whether an item with these label-like facets is tracked: OR across the configured tags,
+    /// case-insensitive; an EMPTY tag list tracks everything. Callers must not apply the filter
+    /// to item kinds with no tag facet (e.g. Bitbucket pull requests) — those are always
+    /// tracked, per the config contract, so this is never called for them.
+    pub fn tracks<'a>(&self, facets: impl IntoIterator<Item = &'a str>) -> bool {
+        if self.tags.is_empty() {
+            return true;
+        }
+        let tags = normalized_tags(&self.tags);
+        facets.into_iter().any(|facet| tags.binary_search(&normalize_tag(facet)).is_ok())
+    }
+
+    /// Stable fingerprint of the normalized tag list for the sync cursor's `filter_fingerprint`:
+    /// hex sha256 over the NUL-joined normalized tags. The EMPTY list (track all) is the empty
+    /// string, so "no filter" stays legible in the cursor row. Case/order/duplicate changes that
+    /// leave the tag SET intact keep the fingerprint — only a real widening/narrowing changes it
+    /// (which is what resets or prunes the backfill descent).
+    pub fn filter_fingerprint(&self) -> String {
+        let normalized = normalized_tags(&self.tags);
+        if normalized.is_empty() {
+            return String::new();
+        }
+        let mut hasher = Sha256::new();
+        for tag in &normalized {
+            hasher.update(tag.as_bytes());
+            // NUL-terminate each tag so list boundaries stay unambiguous (a tag cannot contain
+            // NUL after TOML parsing + trimming, unlike `\n` or `,`).
+            hasher.update([0u8]);
+        }
+        let mut out = String::with_capacity(64);
+        for byte in hasher.finalize() {
+            let _ = write!(out, "{byte:02x}");
+        }
+        out
+    }
+}
+
+/// Case-insensitive tag normalization: trim + Unicode-lowercase (labels are user text, not
+/// ASCII identifiers).
+fn normalize_tag(tag: &str) -> String {
+    tag.trim().to_lowercase()
+}
+
+/// The normalized tag list: lowercased, deduplicated, sorted — the canonical form behind both
+/// [`ResolvedTracker::tracks`] and [`ResolvedTracker::filter_fingerprint`].
+pub fn normalized_tags(tags: &[String]) -> Vec<String> {
+    tags.iter()
+        .map(|tag| normalize_tag(tag))
+        .filter(|tag| !tag.is_empty())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
+/// Resolve the configured bindings (or auto-detect one) against the checkout at `root`. With an
+/// explicit `[[tracker]]` list, each code-host binding missing `project` derives it from its
+/// configured git remote; a binding that cannot resolve is DROPPED — the same silent posture as
+/// the old `gh repo view` failure, because this runs on every index open and an unresolvable
+/// binding is a no-op there, not an error. With NO configured binding, the `origin` remote picks
+/// the provider by host and the project from the URL path; Jira is never auto-detected.
+pub(crate) fn resolve_trackers(bindings: &[TrackerConfig], root: &Path) -> Vec<ResolvedTracker> {
+    if bindings.is_empty() {
+        return auto_detect_tracker(root).into_iter().collect();
+    }
+    bindings.iter().filter_map(|binding| resolve_binding(binding, root)).collect()
+}
+
+fn resolve_binding(binding: &TrackerConfig, root: &Path) -> Option<ResolvedTracker> {
+    let (project, derived_base_url) = match &binding.project {
+        Some(project) => (project.clone(), None),
+        // Config validation already demands an explicit Jira project; belt-and-braces here so a
+        // hand-built binding can never derive a Jira "project" from a git remote.
+        None if !binding.provider.is_code_host() => return None,
+        None => {
+            let url = git_remote_url(root, &binding.remote)?;
+            let parts = parse_git_remote_url(&url)?;
+            // An explicit provider may identify an otherwise unknown self-hosted forge, but a
+            // host that names a DIFFERENT known provider cannot lend its project identity.
+            if detect_provider(&parts.host).is_some_and(|provider| provider != binding.provider) {
+                return None;
+            }
+            let project = remote_url_project(&parts, binding.provider)?;
+            let base_url = remote_base_url(&parts, binding.provider);
+            (project, base_url)
+        },
+    };
+    Some(ResolvedTracker {
+        provider: binding.provider,
+        project,
+        base_url: binding.base_url.clone().or(derived_base_url),
+        auth: binding.auth.clone(),
+        tags: binding.tags.clone(),
+    })
+}
+
+/// Zero-config detection from the `origin` remote URL.
+fn auto_detect_tracker(root: &Path) -> Option<ResolvedTracker> {
+    detect_tracker_from_remote_url(&git_remote_url(root, "origin")?)
+}
+
+/// Detect (provider, project, base_url) from one git remote URL: `github.com` → GitHub, a
+/// `gitlab.`-containing host (cloud or self-hosted) → GitLab, `bitbucket.org` → Bitbucket.
+/// Self-hosted GitHub/Bitbucket — and Jira, always — need an explicit `[[tracker]]` binding.
+pub fn detect_tracker_from_remote_url(url: &str) -> Option<ResolvedTracker> {
+    let parts = parse_git_remote_url(url)?;
+    let provider = detect_provider(&parts.host)?;
+    let project = remote_url_project(&parts, provider)?;
+    let base_url = remote_base_url(&parts, provider);
+    Some(ResolvedTracker { provider, project, base_url, auth: None, tags: Vec::new() })
+}
+
+/// A self-hosted remote's authority is part of provider identity: both URL parsing and transport
+/// must use it. Cloud remotes keep `None` so the provider default remains canonical.
+fn remote_base_url(parts: &GitRemoteParts, provider: Tracker) -> Option<String> {
+    (Some(parts.host.as_str()) != cloud_host(provider))
+        .then(|| parts.base_url.clone().unwrap_or_else(|| format!("https://{}", parts.host)))
+}
+
+fn detect_provider(host: &str) -> Option<Tracker> {
+    if host == "github.com" {
+        Some(Tracker::Github)
+    } else if host.contains("gitlab.") {
+        // Substring, not equality: self-hosted GitLab conventionally lives at a
+        // `gitlab.<company>.<tld>` host, and `gitlab.com` itself matches too.
+        Some(Tracker::Gitlab)
+    } else if host == "bitbucket.org" {
+        Some(Tracker::Bitbucket)
+    } else {
+        None
+    }
+}
+
+/// The provider's cloud host, `None` for Jira (every Jira instance is "self-hosted" from the
+/// binding's point of view — site URLs are per-tenant).
+fn cloud_host(provider: Tracker) -> Option<&'static str> {
+    match provider {
+        Tracker::Github => Some("github.com"),
+        Tracker::Gitlab => Some("gitlab.com"),
+        Tracker::Bitbucket => Some("bitbucket.org"),
+        Tracker::Jira => None,
+    }
+}
+
+/// Project path for `provider` from parsed remote parts. GitHub and Bitbucket Cloud projects are
+/// exactly `owner/repo`; Bitbucket Data Center clone URLs add a `/scm/` prefix. GitLab keeps the
+/// full (possibly subgroup-nested) namespace path.
+fn remote_url_project(parts: &GitRemoteParts, provider: Tracker) -> Option<String> {
+    match provider {
+        Tracker::Github => (parts.segments.len() == 2).then(|| parts.segments.join("/")),
+        Tracker::Bitbucket => match parts.segments.as_slice() {
+            [scm, project, repo] if scm.eq_ignore_ascii_case("scm") =>
+                Some(format!("{project}/{repo}")),
+            [workspace, repo] => Some(format!("{workspace}/{repo}")),
+            _ => None,
+        },
+        Tracker::Gitlab => (parts.segments.len() >= 2).then(|| parts.segments.join("/")),
+        Tracker::Jira => None,
+    }
+}
+
+/// Host + project path parsed out of a git remote URL.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct GitRemoteParts {
+    /// Lowercased host, userinfo and port stripped.
+    pub host: String,
+    pub base_url: Option<String>,
+    /// Path segments with the `.git` suffix stripped (e.g. `["group", "sub", "repo"]`).
+    pub segments: Vec<String>,
+}
+
+/// Parse a git remote URL: the scheme forms (`https://host/path`, `http://`, `ssh://git@host
+/// [:port]/path`, `git://host/path`) and the scp-like form (`git@host:path`). `None` for local
+/// paths, unsupported schemes, or an empty/degenerate path.
+pub(crate) fn parse_git_remote_url(url: &str) -> Option<GitRemoteParts> {
+    let url = url.trim();
+    let (host_part, path, scheme) = if let Some((scheme, rest)) = url.split_once("://") {
+        let scheme = scheme.to_ascii_lowercase();
+        if !matches!(scheme.as_str(), "http" | "https" | "ssh" | "git") {
+            return None;
+        }
+        let (host, path) = rest.split_once('/')?;
+        (host, path, Some(scheme))
+    } else {
+        // scp-like `git@host:path`. A local path (`/srv/git/repo`, `../repo`) has no `:`; a
+        // slash BEFORE the first `:` means the colon is inside a path, not a host separator.
+        let (host_part, path) = url.split_once(':')?;
+        if host_part.contains('/') || path.starts_with("//") {
+            return None;
+        }
+        (host_part, path, None)
+    };
+    // Remote URLs may embed transport credentials. They are neither provider identity nor safe
+    // configuration: strip them once, then use only this sanitized authority for BOTH host
+    // detection and a derived HTTP(S) base URL.
+    let sanitized_authority = host_part.rsplit_once('@').map_or(host_part, |(_, host)| host);
+    // Strip a `:port` (the scheme forms carry it on the host part). Bracketed IPv6 literals are
+    // not code-host names — rejected below with every other non-hostname shape.
+    let host = sanitized_authority
+        .split_once(':')
+        .map_or(sanitized_authority, |(host, _)| host)
+        .to_ascii_lowercase();
+    if host.is_empty() || host.contains(['[', ']']) {
+        return None;
+    }
+    let path = path.trim_matches('/');
+    let path = path.strip_suffix(".git").unwrap_or(path).trim_end_matches('/');
+    if path.is_empty() {
+        return None;
+    }
+    let segments = path.split('/').map(str::to_string).collect::<Vec<_>>();
+    if segments.iter().any(String::is_empty) {
+        return None;
+    }
+    let base_url = scheme
+        .filter(|scheme| matches!(scheme.as_str(), "http" | "https"))
+        .map(|scheme| format!("{scheme}://{}", sanitized_authority.to_ascii_lowercase()));
+    Some(GitRemoteParts { host, base_url, segments })
+}
+
+/// The configured URL of `remote` for the repo containing `root` (`remote.<name>.url`), read
+/// from git config via gix — no subprocess, works offline, and resolves the SHARED repo config
+/// from any linked worktree.
+fn git_remote_url(root: &Path, remote: &str) -> Option<String> {
+    let repo = crate::index::git_context::discover_repo(root).ok()?;
+    let key = format!("remote.{remote}.url");
+    let url = repo.config_snapshot().string(key.as_str())?.to_string();
+    let url = url.trim();
+    (!url.is_empty()).then(|| url.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    use super::*;
+
+    fn github(project: &str) -> Option<ResolvedTracker> {
+        Some(ResolvedTracker {
+            provider: Tracker::Github,
+            project: project.to_string(),
+            base_url: None,
+            auth: None,
+            tags: Vec::new(),
+        })
+    }
+
+    #[test]
+    fn auto_detect_covers_the_cloud_hosts_over_ssh_and_https() {
+        // github.com — scp-like ssh + https, `.git` suffix optional.
+        assert_eq!(
+            detect_tracker_from_remote_url("git@github.com:owner/repo.git"),
+            github("owner/repo")
+        );
+        assert_eq!(
+            detect_tracker_from_remote_url("https://github.com/owner/repo"),
+            github("owner/repo")
+        );
+        assert_eq!(
+            detect_tracker_from_remote_url("https://github.com/owner/repo.git"),
+            github("owner/repo")
+        );
+        assert_eq!(
+            detect_tracker_from_remote_url("ssh://git@github.com/owner/repo.git"),
+            github("owner/repo")
+        );
+
+        // gitlab.com keeps multi-level subgroup paths.
+        let gitlab = detect_tracker_from_remote_url("git@gitlab.com:group/sub/repo.git").unwrap();
+        assert_eq!(gitlab.provider, Tracker::Gitlab);
+        assert_eq!(gitlab.project, "group/sub/repo");
+        assert_eq!(gitlab.base_url, None);
+
+        let bitbucket =
+            detect_tracker_from_remote_url("https://user@bitbucket.org/workspace/repo.git")
+                .unwrap();
+        assert_eq!(bitbucket.provider, Tracker::Bitbucket);
+        assert_eq!(bitbucket.project, "workspace/repo");
+        assert_eq!(bitbucket.base_url, None);
+    }
+
+    #[test]
+    fn auto_detect_resolves_self_hosted_gitlab_by_host_substring() {
+        // Self-hosted GitLab: provider by the `gitlab.` substring, base_url from the host, an
+        // ssh port stripped.
+        let tracker =
+            detect_tracker_from_remote_url("ssh://git@gitlab.example.com:2222/group/sub/repo.git")
+                .unwrap();
+        assert_eq!(tracker.provider, Tracker::Gitlab);
+        assert_eq!(tracker.project, "group/sub/repo");
+        assert_eq!(tracker.base_url.as_deref(), Some("https://gitlab.example.com"));
+
+        let https = detect_tracker_from_remote_url("https://gitlab.example.com/team/app").unwrap();
+        assert_eq!(https.base_url.as_deref(), Some("https://gitlab.example.com"));
+
+        let http_port =
+            detect_tracker_from_remote_url("http://gitlab.example.com:8080/team/app.git").unwrap();
+        assert_eq!(http_port.base_url.as_deref(), Some("http://gitlab.example.com:8080"));
+
+        let credentialed = detect_tracker_from_remote_url(
+            "https://oauth2:TOKEN@gitlab.example.com:8443/team/app.git",
+        )
+        .unwrap();
+        assert_eq!(credentialed.project, "team/app");
+        assert_eq!(credentialed.base_url.as_deref(), Some("https://gitlab.example.com:8443"));
+    }
+
+    #[test]
+    fn auto_detect_rejects_unknown_hosts_local_paths_and_degenerate_urls() {
+        // Unknown hosts (incl. self-hosted GitHub Enterprise — explicit config only), local
+        // paths, unsupported schemes, and non-project path depths all stay undetected.
+        for url in [
+            "git@codeberg.org:owner/repo.git",
+            "git@github.example.com:owner/repo.git", // GHE is NOT auto-detected
+            "/srv/git/repo.git",
+            "../sibling/repo",
+            "file:///srv/git/repo.git",
+            "https://github.com/owner", // too shallow for owner/repo
+            "https://github.com/owner/repo/extra", // too deep for owner/repo
+            "https://github.com//repo.git", // empty segment
+            "https://gitlab.com/solo",  // gitlab needs namespace/project
+        ] {
+            assert_eq!(detect_tracker_from_remote_url(url), None, "{url}");
+        }
+    }
+
+    #[test]
+    fn parse_git_remote_url_normalizes_host_and_path() {
+        let parts =
+            parse_git_remote_url("SSH://Git@GitLab.Example.COM:2222/Group/Repo.git").unwrap();
+        assert_eq!(parts.host, "gitlab.example.com");
+        assert_eq!(parts.segments, ["Group", "Repo"]); // path case is meaningful; host case is not
+        assert_eq!(parse_git_remote_url(""), None);
+        assert_eq!(parse_git_remote_url("git@github.com:"), None);
+    }
+
+    static REMOTE_TEMP: AtomicU64 = AtomicU64::new(0);
+
+    fn git(dir: &Path, args: &[&str]) {
+        let out = std::process::Command::new("git").arg("-C").arg(dir).args(args).output().unwrap();
+        assert!(out.status.success(), "git {args:?}: {}", String::from_utf8_lossy(&out.stderr));
+    }
+
+    fn temp_git_repo() -> PathBuf {
+        let id = REMOTE_TEMP.fetch_add(1, Ordering::Relaxed);
+        let root =
+            std::env::temp_dir().join(format!("ragrat-trackers-{}-{id}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).unwrap();
+        git(&root, &["init", "-q"]);
+        root
+    }
+
+    #[test]
+    fn resolve_trackers_auto_detects_from_the_origin_remote_when_unconfigured() {
+        let root = temp_git_repo();
+        git(&root, &["remote", "add", "origin", "git@github.com:owner/repo.git"]);
+        let trackers = resolve_trackers(&[], &root);
+        assert_eq!(trackers, vec![github("owner/repo").unwrap()]);
+        std::fs::remove_dir_all(&root).unwrap();
+    }
+
+    #[test]
+    fn resolve_trackers_is_empty_without_a_recognizable_remote() {
+        let root = temp_git_repo();
+        assert_eq!(resolve_trackers(&[], &root), Vec::new(), "no remote at all");
+        git(&root, &["remote", "add", "origin", "git@codeberg.org:owner/repo.git"]);
+        assert_eq!(resolve_trackers(&[], &root), Vec::new(), "unknown host");
+        std::fs::remove_dir_all(&root).unwrap();
+    }
+
+    #[test]
+    fn resolve_trackers_derives_a_projectless_binding_from_its_named_remote() {
+        let root = temp_git_repo();
+        git(&root, &["remote", "add", "origin", "git@github.com:owner/repo.git"]);
+        git(&root, &["remote", "add", "upstream", "git@gitlab.example.com:group/sub/repo.git"]);
+        git(&root, &[
+            "remote",
+            "add",
+            "bitbucket",
+            "https://bitbucket.example.com/scm/PROJ/repo.git",
+        ]);
+        let bindings = vec![
+            TrackerConfig {
+                provider: Tracker::Gitlab,
+                project: None,
+                remote: "upstream".to_string(),
+                base_url: None,
+                auth: None,
+                tags: vec!["bug".to_string()],
+            },
+            TrackerConfig {
+                provider: Tracker::Bitbucket,
+                project: None,
+                remote: "bitbucket".to_string(),
+                base_url: None,
+                auth: None,
+                tags: Vec::new(),
+            },
+            // A recognized host owned by another provider cannot supply this binding's identity.
+            TrackerConfig {
+                provider: Tracker::Gitlab,
+                project: None,
+                remote: "origin".to_string(),
+                base_url: None,
+                auth: None,
+                tags: Vec::new(),
+            },
+            // Explicit project: no remote lookup, `remote` is irrelevant.
+            TrackerConfig {
+                provider: Tracker::Jira,
+                project: Some("PROJ".to_string()),
+                remote: "origin".to_string(),
+                base_url: Some("https://example.atlassian.net".to_string()),
+                auth: None,
+                tags: Vec::new(),
+            },
+            // Unresolvable code-host binding (remote absent): dropped, not an error.
+            TrackerConfig {
+                provider: Tracker::Bitbucket,
+                project: None,
+                remote: "missing".to_string(),
+                base_url: None,
+                auth: None,
+                tags: Vec::new(),
+            },
+        ];
+        let trackers = resolve_trackers(&bindings, &root);
+        assert_eq!(trackers.len(), 3);
+        assert_eq!(
+            (trackers[0].provider, trackers[0].project.as_str(), trackers[0].base_url.as_deref(),),
+            (Tracker::Gitlab, "group/sub/repo", Some("https://gitlab.example.com"))
+        );
+        assert_eq!(
+            (trackers[1].provider, trackers[1].project.as_str(), trackers[1].base_url.as_deref(),),
+            (Tracker::Bitbucket, "PROJ/repo", Some("https://bitbucket.example.com"))
+        );
+        assert_eq!((trackers[2].provider, trackers[2].project.as_str()), (Tracker::Jira, "PROJ"));
+        std::fs::remove_dir_all(&root).unwrap();
+    }
+
+    fn tagged(tags: &[&str]) -> ResolvedTracker {
+        ResolvedTracker {
+            provider: Tracker::Github,
+            project: "o/r".to_string(),
+            base_url: None,
+            auth: None,
+            tags: tags.iter().map(|t| t.to_string()).collect(),
+        }
+    }
+
+    #[test]
+    fn tag_filter_is_or_matched_and_case_insensitive_with_empty_meaning_all() {
+        let all = tagged(&[]);
+        assert!(all.tracks(["anything"]) && all.tracks([]));
+
+        let filtered = tagged(&["Bug", "perf"]);
+        assert!(filtered.tracks(["BUG"]), "case-insensitive both ways");
+        assert!(filtered.tracks(["docs", "Perf"]), "OR across the list");
+        assert!(!filtered.tracks(["docs"]));
+        assert!(!filtered.tracks([]), "a label-bearing kind with no labels is filtered out");
+    }
+
+    #[test]
+    fn filter_fingerprint_is_stable_under_case_order_and_duplicates() {
+        let canonical = tagged(&["bug", "perf"]).filter_fingerprint();
+        assert_eq!(canonical.len(), 64);
+        assert_eq!(tagged(&["Perf", "BUG", "bug"]).filter_fingerprint(), canonical);
+        assert_ne!(tagged(&["bug"]).filter_fingerprint(), canonical, "narrowing changes it");
+        assert_ne!(
+            tagged(&["bug", "perf", "docs"]).filter_fingerprint(),
+            canonical,
+            "widening changes it"
+        );
+        assert_eq!(tagged(&[]).filter_fingerprint(), "", "track-all is the empty sentinel");
+        // The join is boundary-unambiguous: ["ab","c"] and ["a","bc"] must differ.
+        assert_ne!(
+            tagged(&["ab", "c"]).filter_fingerprint(),
+            tagged(&["a", "bc"]).filter_fingerprint()
+        );
+    }
+}

--- a/crates/rag-rat-core/src/index/query_api/clones/of_text.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/of_text.rs
@@ -665,6 +665,8 @@ mod tests {
         )
         .unwrap();
         let config = crate::Config {
+            trackers: Vec::new(),
+            papertrail: Default::default(),
             repo_id_override: None,
             database_key_pinned: true,
             root: root.clone(),
@@ -780,6 +782,8 @@ mod tests {
         .unwrap();
         let db_path = root.join(".rag-rat/index.sqlite");
         let config = crate::Config {
+            trackers: Vec::new(),
+            papertrail: Default::default(),
             repo_id_override: None,
             database_key_pinned: true,
             root: root.clone(),
@@ -849,6 +853,8 @@ mod tests {
         )
         .unwrap();
         let config = crate::Config {
+            trackers: Vec::new(),
+            papertrail: Default::default(),
             repo_id_override: None,
             database_key_pinned: true,
             root: root.clone(),
@@ -949,6 +955,8 @@ mod tests {
             kind: crate::config::TargetKind::Source,
         };
         let config = crate::Config {
+            trackers: Vec::new(),
+            papertrail: Default::default(),
             repo_id_override: None,
             database_key_pinned: true,
             root: root.clone(),

--- a/crates/rag-rat-core/src/index/query_api/clones/precompute.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/precompute.rs
@@ -1062,6 +1062,8 @@ pub(super) mod tests {
         )
         .unwrap();
         crate::Config {
+            trackers: Vec::new(),
+            papertrail: Default::default(),
             repo_id_override: None,
             database_key_pinned: true,
             root: root.clone(),

--- a/crates/rag-rat-core/src/index/query_api/clones/tests.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/tests.rs
@@ -193,6 +193,8 @@ fn find_clones_rejects_nan_and_non_finite_min_similarity() {
     std::fs::create_dir_all(root.join("src")).unwrap();
     std::fs::write(root.join("src/lib.rs"), "pub fn f() {}\n").unwrap();
     let config = crate::Config {
+        trackers: Vec::new(),
+        papertrail: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
         root: root.clone(),
@@ -779,6 +781,8 @@ fn recall_candidates_identical_blob_vs_postings_grouping() {
     )
     .unwrap();
     let config = crate::Config {
+        trackers: Vec::new(),
+        papertrail: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
         root: root.clone(),

--- a/crates/rag-rat-core/src/index/query_api/db_file_health.rs
+++ b/crates/rag-rat-core/src/index/query_api/db_file_health.rs
@@ -263,6 +263,8 @@ mod tests {
         std::fs::create_dir_all(root.join("src")).unwrap();
         std::fs::write(root.join("src/a.rs"), "pub fn health_probe() -> i32 { 1 }\n").unwrap();
         crate::Config {
+            trackers: Vec::new(),
+            papertrail: Default::default(),
             repo_id_override: None,
             database_key_pinned: true,
             root: root.clone(),

--- a/crates/rag-rat-core/src/index/query_api/oracle_surfacing_tests.rs
+++ b/crates/rag-rat-core/src/index/query_api/oracle_surfacing_tests.rs
@@ -29,6 +29,8 @@ fn temp_root() -> PathBuf {
 
 fn rust_config(root: PathBuf) -> Config {
     Config {
+        trackers: Vec::new(),
+        papertrail: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
         root: root.clone(),
@@ -1147,6 +1149,8 @@ fn deleted_and_generated_paths_counted_in_skipped() {
     fs::write(root.join("gen/out.rs"), "pub fn generated_fn() {}\n").unwrap();
     // A config with a Generated target for `gen/` so `out.rs` indexes generated.
     let config = Config {
+        trackers: Vec::new(),
+        papertrail: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
         root: root.clone(),

--- a/crates/rag-rat-core/src/index/schema/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema/migrations.rs
@@ -1255,6 +1255,7 @@ pub(crate) fn known_version(migrations: &[AppliedMigration]) -> u32 {
             MIGRATION_058_ID => Some(58),
             MIGRATION_059_ID => Some(59),
             MIGRATION_060_ID => Some(60),
+            MIGRATION_061_ID => Some(61),
             _ => None,
         })
         .max()
@@ -1324,6 +1325,7 @@ pub(crate) fn known_migration(id: &str) -> bool {
             | MIGRATION_058_ID
             | MIGRATION_059_ID
             | MIGRATION_060_ID
+            | MIGRATION_061_ID
             | DIRTY_MIGRATION_ID
     )
 }
@@ -1390,6 +1392,7 @@ pub(crate) fn migration_checksum_mismatch(migration: &AppliedMigration) -> bool 
         MIGRATION_058_ID => migration.checksum != MIGRATION_058_CHECKSUM,
         MIGRATION_059_ID => migration.checksum != MIGRATION_059_CHECKSUM,
         MIGRATION_060_ID => migration.checksum != MIGRATION_060_CHECKSUM,
+        MIGRATION_061_ID => migration.checksum != MIGRATION_061_CHECKSUM,
         _ => false,
     }
 }
@@ -3090,6 +3093,7 @@ pub(crate) fn create_papertrail_tables(conn: &Connection) -> rusqlite::Result<()
             tracker TEXT NOT NULL,
             project TEXT NOT NULL,
             item_key TEXT NOT NULL,
+            item_kind TEXT,
             ref_kind TEXT NOT NULL DEFAULT 'unknown',
             source_kind TEXT NOT NULL,
             source_path TEXT,
@@ -3100,9 +3104,10 @@ pub(crate) fn create_papertrail_tables(conn: &Connection) -> rusqlite::Result<()
         ) STRICT;
         CREATE INDEX IF NOT EXISTS idx_papertrail_refs_path ON papertrail_refs(source_path);
         CREATE INDEX IF NOT EXISTS idx_papertrail_refs_item
-            ON papertrail_refs(repo_id, tracker, project, item_key);
+            ON papertrail_refs(repo_id, tracker, project, item_kind, item_key);
         CREATE UNIQUE INDEX IF NOT EXISTS idx_papertrail_refs_unique
-            ON papertrail_refs(repo_id, tracker, project, item_key, source_kind,
+            ON papertrail_refs(repo_id, tracker, project, COALESCE(item_kind, ''), item_key, \
+         source_kind,
                                COALESCE(source_path, ''), COALESCE(source_commit, ''), \
          source_text);
 
@@ -3236,6 +3241,22 @@ pub(crate) fn apply_papertrail_provider_neutral_schema(conn: &Connection) -> rus
         return result;
     }
     conn.execute_batch("COMMIT;")
+}
+
+pub(crate) fn apply_papertrail_ref_item_kind(conn: &Connection) -> rusqlite::Result<()> {
+    if !column_exists(conn, "papertrail_refs", "item_kind")? {
+        conn.execute_batch("ALTER TABLE papertrail_refs ADD COLUMN item_kind TEXT;")?;
+    }
+    conn.execute_batch(
+        "DROP INDEX IF EXISTS idx_papertrail_refs_item;
+         DROP INDEX IF EXISTS idx_papertrail_refs_unique;
+         CREATE INDEX idx_papertrail_refs_item
+             ON papertrail_refs(repo_id, tracker, project, item_kind, item_key);
+         CREATE UNIQUE INDEX idx_papertrail_refs_unique
+             ON papertrail_refs(repo_id, tracker, project, COALESCE(item_kind, ''), item_key,
+                                source_kind, COALESCE(source_path, ''),
+                                COALESCE(source_commit, ''), source_text);",
+    )
 }
 
 /// The V060 base-table backfill (step 2 of [`apply_papertrail_provider_neutral_schema`]): runs

--- a/crates/rag-rat-core/src/index/schema/mod.rs
+++ b/crates/rag-rat-core/src/index/schema/mod.rs
@@ -19,7 +19,7 @@ pub use registry::{LEGACY_REPO_ID, RegisteredRepo, register_repo, register_repo_
 use rusqlite::{Connection, OptionalExtension, params};
 use serde::Serialize;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 60;
+pub const LATEST_SCHEMA_VERSION: u32 = 61;
 
 /// Every oracle-DERIVED persisted table — the outputs an `oracle run` writes that must OUTLIVE a
 /// reindex.
@@ -431,6 +431,11 @@ const MIGRATION_060_DESCRIPTION: &str =
      github_* tables then DROPS them (hard rename, no aliases); renames the memory binding kind \
      github -> tracker (tracker/project/item_key columns backfilled, github_* columns dropped) \
      and the github_last_sync_ms repo_meta key to papertrail_last_sync_ms";
+const MIGRATION_061_ID: &str = "061_papertrail_ref_item_kind";
+const MIGRATION_061_CHECKSUM: &str = "sha256:rag-rat-papertrail-ref-item-kind-v61";
+const MIGRATION_061_DESCRIPTION: &str = "Preserve the nullable item_kind on papertrail_refs so \
+                                         providers with separate issue/change-request namespaces \
+                                         cannot collapse #N and !N annotations";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -936,6 +941,12 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         checksum: MIGRATION_060_CHECKSUM,
         description: MIGRATION_060_DESCRIPTION,
         apply: apply_papertrail_provider_neutral_schema,
+    },
+    Migration {
+        id: MIGRATION_061_ID,
+        checksum: MIGRATION_061_CHECKSUM,
+        description: MIGRATION_061_DESCRIPTION,
+        apply: apply_papertrail_ref_item_kind,
     },
 ];
 

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/clones.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/clones.rs
@@ -1068,6 +1068,8 @@ fn multi_language_clone_integration_finds_within_language_no_cross() {
     .unwrap();
 
     let config = Config {
+        trackers: Vec::new(),
+        papertrail: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
         root: root.clone(),
@@ -1283,6 +1285,8 @@ fn find_clones_ranks_a_clean_clone_class_with_metrics() {
     .unwrap();
 
     let config = Config {
+        trackers: Vec::new(),
+        papertrail: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
         root: root.clone(),

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/dir_memory_tree.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/dir_memory_tree.rs
@@ -307,6 +307,8 @@ fn dir_tree_label_depth_collapse_single_child_chain() {
         fs::write(root.join("src/pkg/inner/deep").join(name), "pub fn f() {}\n").unwrap();
     }
     let config = Config {
+        trackers: Vec::new(),
+        papertrail: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
         root: root.clone(),
@@ -539,6 +541,8 @@ fn dir_tree_truncates_at_max_nodes() {
         fs::write(dir.join("lib.rs"), "pub fn f() {}\n").unwrap();
     }
     let config = Config {
+        trackers: Vec::new(),
+        papertrail: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
         root: root.clone(),
@@ -688,6 +692,8 @@ fn dir_tree_children_of_collapsed_node_use_leaf_labels() {
         fs::write(root.join("top/mid/y").join(name), "pub fn fy() {}\n").unwrap();
     }
     let config = Config {
+        trackers: Vec::new(),
+        papertrail: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
         root: root.clone(),

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/mod.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/mod.rs
@@ -74,6 +74,8 @@ fn git_history_targets() -> Vec<ResolvedTarget> {
 
 fn rag_rat_config(root: &Path) -> Config {
     Config {
+        trackers: Vec::new(),
+        papertrail: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
         root: root.to_path_buf(),
@@ -199,6 +201,8 @@ fn markdown_config(text: &str) -> (PathBuf, Config) {
 
 fn markdown_config_for_root(root: PathBuf) -> Config {
     Config {
+        trackers: Vec::new(),
+        papertrail: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
         root: root.clone(),
@@ -349,6 +353,8 @@ pub(crate) fn poison_test_config(tag: &str) -> (PathBuf, Config) {
 
 fn source_config(root: PathBuf, language: Language) -> Config {
     Config {
+        trackers: Vec::new(),
+        papertrail: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
         root: root.clone(),
@@ -717,6 +723,8 @@ fn git_fixture_for_overlay_tests() -> (PathBuf, Config) {
     run_git(&root, &["add", "."]);
     run_git(&root, &["commit", "-m", "init"]);
     let config = Config {
+        trackers: Vec::new(),
+        papertrail: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
         root: root.clone(),
@@ -848,6 +856,8 @@ fn write_four_renamed_clones(root: &Path) -> IndexDatabase {
 /// fixture) before rebuilding.
 fn four_clone_config(root: &Path) -> Config {
     Config {
+        trackers: Vec::new(),
+        papertrail: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
         root: root.to_path_buf(),

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/orientation_healing.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/orientation_healing.rs
@@ -164,6 +164,8 @@ fn clean_checkout_file_resolves_against_its_own_package_roots() {
     run_git(&root, &["commit", "-m", "init"]);
 
     let config = Config {
+        trackers: Vec::new(),
+        papertrail: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
         root: root.clone(),

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/papertrail_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/papertrail_tests.rs
@@ -1,6 +1,207 @@
 use super::*;
 
 #[test]
+fn configless_discovery_keeps_self_contained_github_refs_from_files_and_commits() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("docs")).unwrap();
+    run_git(&root, &["init"]);
+    run_git(&root, &["config", "user.name", "Rag Rat"]);
+    run_git(&root, &["config", "user.email", "rag@example.com"]);
+    fs::write(root.join("docs/search.md"), "File rationale cq27-dev/rag-rat#7\n").unwrap();
+    run_git(&root, &["add", "."]);
+    run_git(&root, &["commit", "-m", "Commit rationale cq27-dev/rag-rat#8"]);
+
+    let config = markdown_config_for_root(root.clone());
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let ctx = papertrail::PapertrailContext::default();
+    let report = sync_from_refs_blocking::<MockGitHubClient>(
+        db.storage.connection(),
+        &root,
+        None,
+        true,
+        &ctx,
+    )
+    .unwrap();
+    assert_eq!(report.discovered_refs, 2);
+
+    let refs = papertrail::refs(db.storage.connection()).unwrap();
+    for (source_kind, key) in [("file", "7"), ("commit", "8")] {
+        assert!(refs.iter().any(|reference| {
+            reference.tracker == papertrail::Tracker::Github
+                && reference.project == "cq27-dev/rag-rat"
+                && reference.item_key == key
+                && reference.source_kind == source_kind
+        }));
+    }
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn manual_sync_validates_client_and_routes_only_the_requested_github_identity() {
+    let (root, config) = markdown_config("GitLab group/repo#42\n");
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let ctx = test_gh_ctx();
+
+    let invalid = papertrail::block_on(papertrail::sync_issue::<MockGitHubClient>(
+        db.storage.connection(),
+        "not-a-ref",
+        None,
+        false,
+        &ctx,
+    ))
+    .unwrap_err()
+    .to_string();
+    assert!(invalid.contains("invalid tracker item reference"), "{invalid}");
+
+    let missing_client = papertrail::block_on(papertrail::sync_issue::<MockGitHubClient>(
+        db.storage.connection(),
+        "cq27-dev/rag-rat#42",
+        None,
+        false,
+        &ctx,
+    ))
+    .unwrap_err()
+    .to_string();
+    assert!(missing_client.contains("requires a client"), "{missing_client}");
+
+    papertrail::store_ref(db.storage.connection(), &papertrail::PapertrailRef {
+        tracker: papertrail::Tracker::Gitlab,
+        project: "group/repo".to_string(),
+        item_kind: Some(papertrail::ItemKind::Issue),
+        item_key: "42".to_string(),
+        ref_kind: "reference".to_string(),
+        source_kind: "manual".to_string(),
+        source_path: None,
+        source_commit: None,
+        source_text: "group/repo#42".to_string(),
+    })
+    .unwrap();
+
+    let live = papertrail::block_on(papertrail::sync_issue(
+        db.storage.connection(),
+        "cq27-dev/rag-rat#42",
+        Some(&MockGitHubClient),
+        false,
+        &ctx,
+    ))
+    .unwrap();
+    assert_eq!(live.synced_items, 5);
+    assert_eq!(live.failed_refs, 0);
+
+    let offline = papertrail::block_on(papertrail::sync_issue::<MockGitHubClient>(
+        db.storage.connection(),
+        "cq27-dev/rag-rat#43",
+        None,
+        true,
+        &ctx,
+    ))
+    .unwrap();
+    assert!(offline.offline);
+    assert_eq!(offline.synced_items, 0);
+
+    let gitlab_cached: i64 = db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT COUNT(*) FROM papertrail_items WHERE tracker = 'gitlab' AND project = \
+             'group/repo'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(gitlab_cached, 0, "manual GitHub sync must not dispatch the same-key GitLab ref");
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn rationale_lookup_keeps_self_contained_github_refs_without_a_binding() {
+    let (root, config) = markdown_config("# Decision\nalpha\n");
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+    let reference = papertrail::PapertrailRef {
+        tracker: papertrail::Tracker::Github,
+        project: "cq27-dev/rag-rat".to_string(),
+        item_kind: None,
+        item_key: "42".to_string(),
+        ref_kind: "reference".to_string(),
+        source_kind: "manual".to_string(),
+        source_path: None,
+        source_commit: None,
+        source_text: "cq27-dev/rag-rat#42".to_string(),
+    };
+    papertrail::store_ref(db.storage.connection(), &reference).unwrap();
+    papertrail::block_on(papertrail::sync_refs(
+        db.storage.connection(),
+        &MockGitHubClient,
+        std::iter::once(&reference),
+        &mut |_| {},
+    ))
+    .unwrap();
+    db.set_papertrail_context(None, false);
+
+    let evidence = db.rationale_search("cq27-dev/rag-rat#42", 10).unwrap();
+    assert!(
+        evidence.iter().any(|item| item.project == "cq27-dev/rag-rat" && item.item_key == "42")
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn production_discovery_persists_refs_for_every_configured_tracker() {
+    let (root, config) = markdown_config(
+        "# Links\nGitLab group/sub/repo#7 and group/sub/repo!7 plus Jira PROJ-42 annotate this \
+         file.\n",
+    );
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let ctx = papertrail::PapertrailContext {
+        trackers: vec![
+            papertrail::ResolvedTracker {
+                provider: papertrail::Tracker::Gitlab,
+                project: "group/sub/repo".to_string(),
+                base_url: None,
+                auth: None,
+                tags: Vec::new(),
+            },
+            papertrail::ResolvedTracker {
+                provider: papertrail::Tracker::Jira,
+                project: "PROJ".to_string(),
+                base_url: Some("https://example.atlassian.net".to_string()),
+                auth: None,
+                tags: Vec::new(),
+            },
+        ],
+        github_cli_available: false,
+    };
+
+    sync_from_refs_blocking(db.storage.connection(), &root, Some(&MockGitHubClient), true, &ctx)
+        .unwrap();
+
+    let refs = db.papertrail_refs_for_path("docs/search.md", 10).unwrap();
+    assert!(refs.iter().any(|reference| {
+        reference.tracker == papertrail::Tracker::Gitlab
+            && reference.project == "group/sub/repo"
+            && reference.item_key == "7"
+            && reference.item_kind == Some(papertrail::ItemKind::Issue)
+    }));
+    assert!(refs.iter().any(|reference| {
+        reference.tracker == papertrail::Tracker::Gitlab
+            && reference.project == "group/sub/repo"
+            && reference.item_key == "7"
+            && reference.item_kind == Some(papertrail::ItemKind::ChangeRequest)
+    }));
+    assert!(refs.iter().any(|reference| {
+        reference.tracker == papertrail::Tracker::Jira
+            && reference.project == "PROJ"
+            && reference.item_key == "PROJ-42"
+    }));
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
 fn papertrail_for_commit_prefers_commit_sourced_tracker_refs() {
     let root = unique_temp_root();
     let _ = fs::remove_dir_all(&root);
@@ -299,6 +500,8 @@ fn parser_failures_report_paths() {
     fs::create_dir_all(&src).unwrap();
     fs::write(src.join("broken.rs"), "pub fn broken(").unwrap();
     let config = Config {
+        trackers: Vec::new(),
+        papertrail: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
         root: root.clone(),
@@ -338,10 +541,11 @@ fn parser_failures_report_paths() {
 fn v060_creates_the_papertrail_tables_on_fresh_apply() {
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     schema::apply(&conn).unwrap();
-    // V060 is the schema tip — this test carries the absolute pin (the older tests dropped to
-    // the symbolic `current_version == LATEST` check).
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 60, "V060 is the schema tip");
-    assert_eq!(schema::status(&conn).unwrap().current_version, 60, "schema at LATEST after apply");
+    assert_eq!(
+        schema::status(&conn).unwrap().current_version,
+        schema::LATEST_SCHEMA_VERSION,
+        "fresh apply reaches the current schema tip",
+    );
     for table in [
         "papertrail_items",
         "papertrail_comments",
@@ -374,10 +578,10 @@ fn v060_creates_the_papertrail_tables_on_fresh_apply() {
     schema::apply(&conn).unwrap();
     assert!(conn_table_exists(&conn, "papertrail_items"), "survives re-apply");
 
-    // A V059 ledger advances through the new papertrail step and records V060 as the tip.
+    // A V059 ledger advances through both papertrail steps and reaches the current tip.
     truncate_schema_to(&conn, 59);
     schema::migrate_forward(&conn).unwrap();
-    assert_eq!(schema::status(&conn).unwrap().current_version, 60);
+    assert_eq!(schema::status(&conn).unwrap().current_version, schema::LATEST_SCHEMA_VERSION);
 }
 
 /// The load-bearing multi-repo invariant carried over from V044/V045: two repos can each cache
@@ -971,6 +1175,7 @@ fn migration_060_backfills_papertrail_from_the_legacy_github_tables() {
     assert_eq!(projects, 3, "tracker/project derive from the legacy owner/repo columns");
 
     let migrated_ref = |item_key: &str| papertrail::PapertrailRef {
+        item_kind: None,
         tracker: papertrail::Tracker::Github,
         project: "o/r".to_string(),
         item_key: item_key.to_string(),

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/reconcile_embeddings.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/reconcile_embeddings.rs
@@ -726,6 +726,8 @@ fn policy_skip_summary_recomputes_exactly_for_a_non_default_char_cap() {
         "// generated data line with sufficient length to matter for the cap xxxxx\n".repeat(80);
     fs::write(root.join("gen/bindings.rs"), &big).unwrap();
     let config = Config {
+        trackers: Vec::new(),
+        papertrail: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
         root: root.clone(),
@@ -973,6 +975,8 @@ fn git_history_indexes_commits_paths_queries_and_blame() {
     run_git(&root, &["commit", "-m", "Refresh beta docs"]);
 
     let config = Config {
+        trackers: Vec::new(),
+        papertrail: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
         root: root.clone(),

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_memory.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_memory.rs
@@ -2498,6 +2498,8 @@ fn repo_brief_ranks_churn_and_god_module_candidates() {
     }
 
     let config = Config {
+        trackers: Vec::new(),
+        papertrail: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
         root: root.clone(),
@@ -2585,6 +2587,8 @@ fn repo_clusters_groups_cotouched_files() {
     }
 
     let config = Config {
+        trackers: Vec::new(),
+        papertrail: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
         root: root.clone(),

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_registry.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_registry.rs
@@ -2726,6 +2726,7 @@ fn a_syncing_repo_is_isolated_from_stranded_placeholder_papertrail_rows() {
     // and refetches the item with fresh content. The incremental FTS writer refreshes only
     // repo-a's own mirror row.
     let reference = crate::index::papertrail::PapertrailRef {
+        item_kind: None,
         tracker: crate::index::papertrail::Tracker::Github,
         project: "o/r".to_string(),
         item_key: "7".to_string(),

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
@@ -8,6 +8,8 @@ fn rebuild_bootstraps_sqlite_schema_for_empty_target_root() {
     fs::create_dir_all(&docs).unwrap();
 
     let config = Config {
+        trackers: Vec::new(),
+        papertrail: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
         root: root.clone(),

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/symbol_search_lookup.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/symbol_search_lookup.rs
@@ -521,6 +521,8 @@ DEVICE_DT_INST_DEFINE(0, entropy_init, NULL, NULL, NULL,
     )
     .unwrap();
     let config = Config {
+        trackers: Vec::new(),
+        papertrail: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
         root: root.clone(),
@@ -1298,6 +1300,8 @@ where
     )
     .unwrap();
     let config = Config {
+        trackers: Vec::new(),
+        papertrail: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
         root: root.clone(),

--- a/crates/rag-rat-core/src/logging/mod.rs
+++ b/crates/rag-rat-core/src/logging/mod.rs
@@ -129,6 +129,8 @@ mod tests {
 
     fn test_config(dir: &std::path::Path, enabled: bool) -> Config {
         Config {
+            trackers: Vec::new(),
+            papertrail: Default::default(),
             repo_id_override: None,
             database_key_pinned: true,
             root: dir.to_path_buf(),

--- a/crates/rag-rat-core/src/watch/tests.rs
+++ b/crates/rag-rat-core/src/watch/tests.rs
@@ -28,6 +28,8 @@ fn mutation_event(path: PathBuf) -> Event {
 /// `&Config` for the target-relation gate, #332).
 fn whole_root_config(root: &Path, target_dirs: &[PathBuf]) -> Config {
     Config {
+        trackers: Vec::new(),
+        papertrail: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
         root: root.to_path_buf(),
@@ -910,6 +912,8 @@ fn created_dir_placement_classifies_target_ancestors_and_subtrees() {
 #[test]
 fn event_touches_worktree_matches_checkout_targets_and_registry() {
     let config = Config {
+        trackers: Vec::new(),
+        papertrail: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
         root: PathBuf::from("/main"),
@@ -1620,6 +1624,8 @@ fn event_touches_worktree_rebases_subdir_rooted_config() {
     // `config.root` is the `crate` SUBDIR of the repo.
     let config_root = repo.join("crate").canonicalize().unwrap();
     let config = Config {
+        trackers: Vec::new(),
+        papertrail: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
         root: config_root,
@@ -1666,6 +1672,8 @@ fn event_is_relevant_skips_gitignored_paths_consistently_with_walker() {
     std::fs::write(root.join(".gitignore"), "gen/\n").unwrap();
 
     let config = Config {
+        trackers: Vec::new(),
+        papertrail: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
         root: root.clone(),
@@ -1730,6 +1738,8 @@ fn gitignore_edit_is_relevant_and_recompile_reflects_new_rules() {
     std::fs::write(root.join(".gitignore"), "").unwrap();
 
     let config = Config {
+        trackers: Vec::new(),
+        papertrail: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
         root: root.clone(),
@@ -1805,6 +1815,8 @@ fn worktree_root_gitignore_edit_recompiles_for_subdir_config_root() {
     let sub = wt.join("crates"); // config.root is the subdirectory.
     let target_dirs = vec![PathBuf::from(".")];
     let config = Config {
+        trackers: Vec::new(),
+        papertrail: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
         root: sub.clone(),
@@ -2159,6 +2171,8 @@ fn worktree_watch_targets_excludes_the_main_checkout_for_a_subdir_config_root() 
 
     let sub = main.join("crate").canonicalize().unwrap(); // config.root is the subdir.
     let config = Config {
+        trackers: Vec::new(),
+        papertrail: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
         root: sub.clone(),
@@ -2500,6 +2514,8 @@ fn a_bare_directory_create_is_not_relevant_so_placement_must_be_unconditional() 
     std::fs::create_dir_all(root.join("src")).unwrap();
     let root = root.canonicalize().unwrap();
     let config = Config {
+        trackers: Vec::new(),
+        papertrail: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
         root: root.clone(),

--- a/crates/rag-rat-mcp/src/server.rs
+++ b/crates/rag-rat-mcp/src/server.rs
@@ -365,6 +365,8 @@ mod tests {
         std::fs::create_dir_all(root.join("src")).unwrap();
         std::fs::write(root.join("src/lib.rs"), "pub fn open_database() {}\n").unwrap();
         let config = Config {
+            trackers: Vec::new(),
+            papertrail: Default::default(),
             repo_id_override: None,
             database_key_pinned: true,
             root: root.clone(),

--- a/crates/rag-rat-mcp/src/tools/tests.rs
+++ b/crates/rag-rat-mcp/src/tools/tests.rs
@@ -1038,6 +1038,8 @@ fn mixed_config() -> (PathBuf, Config) {
     fs::write(root.join("docs/search.md"), "# Title\nalpha token\n").unwrap();
     fs::write(root.join("src/lib.rs"), "pub fn alpha_symbol() {}\n").unwrap();
     (root.clone(), Config {
+        trackers: Vec::new(),
+        papertrail: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
         root: root.clone(),
@@ -1077,6 +1079,8 @@ fn markdown_config(text: &str) -> (PathBuf, Config) {
     fs::create_dir_all(root.join("docs")).unwrap();
     fs::write(root.join("docs/search.md"), text).unwrap();
     (root.clone(), Config {
+        trackers: Vec::new(),
+        papertrail: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
         root: root.clone(),
@@ -1103,6 +1107,8 @@ fn markdown_config(text: &str) -> (PathBuf, Config) {
 
 fn rust_config(root: PathBuf) -> Config {
     Config {
+        trackers: Vec::new(),
+        papertrail: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
         root: root.clone(),

--- a/docs/config.md
+++ b/docs/config.md
@@ -556,3 +556,59 @@ surface = "summary"   # default; or "full" — return whole bodies everywhere
 the body), and the grep-augmentation hook context. A memory with no summary for its current body
 falls back to title-only. `memory show` / `memory_show` **always** return the full body, regardless
 of this setting — it is the expand path.
+
+## Issue trackers (`[[tracker]]`) and papertrail sync (`[papertrail]`)
+
+`[[tracker]]` binds the repo to the issue tracker(s) whose items annotate its papertrail. It is
+list-valued: one repo can bind a code host **and** Jira at the same time.
+
+```toml
+[[tracker]]
+provider = "github"            # github | gitlab | bitbucket | jira
+# project = "owner/repo"       # default: derived from the git remote; jira: the project KEY
+# remote = "origin"            # which git remote to derive `project` from
+# base_url = "https://gitlab.example.com"   # self-hosted / enterprise instance
+# auth = { env = "GITLAB_TOKEN" }           # or { token_command = "glab auth token" }
+# tags = ["bug", "perf"]       # tracked tags/labels; empty or missing = track ALL
+```
+
+**Zero-config default.** With no `[[tracker]]` at all, the binding is auto-detected from the git
+`origin` remote URL (ssh and https forms alike): a `github.com` remote binds GitHub, a `gitlab.*`
+host (gitlab.com or self-hosted — the base URL is taken from the host) binds GitLab, and
+`bitbucket.org` binds Bitbucket. Most repos never need a `[[tracker]]` section. Writing one
+**replaces** auto-detection entirely.
+
+Per-key notes:
+
+- `provider` — required, one of `github` / `gitlab` / `bitbucket` / `jira`.
+- `project` — optional for the code hosts (derived from the git remote named by `remote`,
+  default `origin`); GitLab keeps full subgroup paths (`group/sub/repo`). **Required for Jira**
+  (the project key, e.g. `PROJ`): Jira is not a code host, so it is never auto-detected and has
+  no remote to derive from.
+- `base_url` — self-hosted / enterprise instances (`https://gitlab.example.com`). Must be an
+  http(s) URL without inline credentials. Self-hosted GitHub Enterprise and Bitbucket instances
+  are configured this way — only the three cloud hosts auto-detect.
+- `auth` — exactly one of `env` (the NAME of an env var holding the token — never the token
+  itself) or `token_command` (a command printing the token to stdout). Omitted = anonymous /
+  provider-native fallback.
+- `tags` — the tracked subset, OR-matched case-insensitively against the provider's label-like
+  facets (labels on GitHub/GitLab; labels + components on Jira; kind + component on Bitbucket
+  issues). Empty or missing tracks everything; item kinds with no tag facet (e.g. Bitbucket pull
+  requests) are always tracked. The normalized list is fingerprinted into the sync cursor, so
+  widening the list restarts the backfill and narrowing prunes.
+
+Ref grammar per provider (what the annotation layer recognizes in commits, files, and branch
+names): GitHub `#N` / `GH-N` / `owner/repo#N` / issue+PR URLs; GitLab `#N` (issues), `!N` (merge
+requests), `namespace/path#N` / `!N` with subgroups, and `/-/issues/N` / `/-/merge_requests/N`
+URLs; Bitbucket `#N` (issues) and `/issues/N` / `/pull-requests/N` URLs; Jira bare keys
+(`PROJ-123`) for the bound project. A bare `#N` resolves against the first code-host binding
+only. A self-hosted binding's URL grammar matches its own host, not the cloud host.
+
+On the `#588` schema stack, all bindings participate in production reference discovery and
+annotation lookup, but the live network client remains GitHub-only. GitLab, Bitbucket, and Jira
+refs are persisted without being sent through the GitHub client. Parallel per-binding mirror sync
+lands with the shared provider transport from `#589`; until then these settings describe the
+stable configuration/cursor contract, not an already-active non-GitHub network mirror.
+
+The `[papertrail]` cadence and rate-governance keys land with the provider mirror scheduler; they
+are intentionally not accepted before that production path can consume them.


### PR DESCRIPTION
Part of #590. Built on the provider-neutral schema delivered by #632.

## What changed

- add list-valued `[[tracker]]` configuration for GitHub, GitLab, Bitbucket, and Jira
- use one closed `Tracker` enum across config, resolved bindings, and persisted identities
- validate explicit provider project shapes and HTTP(S) base URLs at config load
- derive provider/project/base URL from SSH and HTTP(S) remotes, preserving self-hosted scheme and port
- add provider-aware reference parsing and production commit/file/branch discovery
- preserve nullable item kind end-to-end for providers with separate issue/change-request namespaces
- add V061 to migrate `papertrail_refs.item_kind` without mutating delivered V060
- constrain manual GitHub sync by full tracker/project/key identity and retain self-contained GitHub discovery without an origin

## Sync scope

All configured providers participate in production reference discovery and annotation lookup. Live network synchronization remains GitHub-only until #633/#589 lands; non-GitHub refs are never dispatched through `GitHubClient`. Transport-only settings (`auth`, tag-filtered mirror behavior, enterprise API routing) are documented as inactive until that shared transport lands. The `[papertrail]` cadence/rate table is rejected until the provider mirror scheduler can consume it, preventing silently inactive configuration.

## Validation

- `cargo nextest run -p rag-rat-core` — 2,134 passed
- `cargo nextest run -p rag-rat-core config::tests::` — 85 passed
- `cargo nextest run -p rag-rat-core papertrail` — 65 passed
- `cargo clippy -p rag-rat-core --all-targets -- -D warnings`
- `git diff --check`
