### PR TITLE
feat(papertrail): add shared async transport and rate governor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2250,6 +2250,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hybrid-array"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3477,6 +3483,7 @@ dependencies = [
  "fastembed",
  "getrandom 0.3.4",
  "gix",
+ "httpdate",
  "iai-callgrind",
  "ignore",
  "libc",
@@ -3487,6 +3494,7 @@ dependencies = [
  "protobuf",
  "rayon",
  "regex",
+ "reqwest",
  "rusqlite",
  "scip",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,11 +48,16 @@ fastembed = { version = "5.17.2", default-features = false, features = ["hf-hub-
 # `rand`/`rand_core` pulled in for this), keeping `from_seed` the sole key constructor.
 getrandom = "0.3"
 gix = { version = "0.85.0", default-features = false, features = ["status", "parallel", "sha1", "sha256", "revision", "blob-diff", "blame"] }
+httpdate = "1.0"
 libc = "0.2"
 # Separator-aware path→forward-slash conversion. Unlike a raw `\`→`/` replace, it only rewrites the
 # actual path SEPARATOR — so a literal backslash in a Unix filename is preserved. Used where a path
 # becomes a string for a non-filesystem consumer (a `node`/`npx` command arg, a TOML value).
 path-slash = "0.2"
+# Async HTTP for the papertrail provider clients (#589). rustls (no system OpenSSL), no default
+# features — the transport is driven on the papertrail module's private runtime at the sync
+# boundary, so nothing else in the tree grows an async dependency.
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 rmcp = { version = "1.8.0", features = ["transport-io"] }
 rusqlite = { version = "0.40", features = ["bundled"] }
 rayon = "1.12"
@@ -68,9 +73,10 @@ sha2 = "0.11"
 stacker = "0.1"
 strum = { version = "0.28.0", features = ["derive"] }
 thiserror = "2.0"
-tokio = { version = "1.52", features = ["rt-multi-thread", "macros", "io-std"] }
-# Minimal blocking HTTP for the crates.io version check (and future GitHub/GitLab/Bitbucket REST).
-# rustls (no system OpenSSL); gzip off — the responses are tiny. The only HTTP at the core edge.
+# `time` backs the papertrail transport's rate-limit backoff sleeps (tokio::time::sleep).
+tokio = { version = "1.52", features = ["rt-multi-thread", "macros", "io-std", "time"] }
+# Minimal blocking HTTP for the crates.io version check. rustls (no system OpenSSL); gzip off —
+# the responses are tiny. Tracker REST traffic lives on `reqwest` (papertrail transport, #589).
 ureq = { version = "3", default-features = false, features = ["rustls"] }
 # TOON (Token-Oriented Object Notation): the default render for CLI + MCP output. ~34% fewer tokens
 # than compact JSON on uniform-row payloads, neutral on nested ones — see rag_rat_core::output.

--- a/crates/rag-rat-core/Cargo.toml
+++ b/crates/rag-rat-core/Cargo.toml
@@ -19,6 +19,7 @@ x25519-dalek.workspace = true
 fastembed = { workspace = true, optional = true }
 getrandom.workspace = true
 gix.workspace = true
+httpdate.workspace = true
 ignore = "0.4.26"
 model2vec-rs = { version = "0.2.1", default-features = false, features = ["hf-hub", "fancy-regex"], optional = true }
 notify = "8.2.0"
@@ -30,6 +31,7 @@ rusqlite.workspace = true
 # `protobuf` is scip's own transitive dep, pulled in directly so we can call `Message::parse_*`
 # on the generated SCIP types; pinned to the version scip 0.8 generates against.
 protobuf = "3.7"
+reqwest.workspace = true
 scip = "0.8.1"
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/rag-rat-core/benches/shared/mod.rs
+++ b/crates/rag-rat-core/benches/shared/mod.rs
@@ -104,6 +104,6 @@ pub fn open_like_production(config: &Config) -> IndexDatabase {
     let mut db = IndexDatabase::open(&config.database).expect("open index");
     let (commit_sha, worktree_id) = rag_rat_core::index::resolve_git_context(&config.root);
     db.set_context(&commit_sha, &worktree_id).expect("install active-checkout scope");
-    db.set_papertrail_context(None, false);
+    db.set_papertrail_context(None);
     db
 }

--- a/crates/rag-rat-core/src/config/load.rs
+++ b/crates/rag-rat-core/src/config/load.rs
@@ -266,7 +266,8 @@ impl Config {
         let memory = MemoryConfig::try_from(raw.memory)?;
         let trackers =
             raw.tracker.into_iter().map(TrackerConfig::try_from).collect::<Result<Vec<_>, _>>()?;
-        let papertrail = PapertrailConfig::default();
+        let papertrail =
+            raw.papertrail.map(PapertrailConfig::try_from).transpose()?.unwrap_or_default();
         let mut log = LogConfig::try_from(raw.log)?;
         // Finalize `dir`: empty (unset) → sibling of the db (`<db_parent>/logs`); a set value is
         // resolved relative to the GOVERNING config dir (absolute honored).
@@ -326,9 +327,6 @@ fn validate_raw(raw: RawConfig) -> Result<RawConfig, ConfigError> {
     }
     if raw.dream.is_some() {
         return Err(ConfigError::DreamTableMoved);
-    }
-    if raw.papertrail.is_some() {
-        return Err(ConfigError::PapertrailSchedulingNotSupported);
     }
     Ok(raw)
 }

--- a/crates/rag-rat-core/src/config/mod.rs
+++ b/crates/rag-rat-core/src/config/mod.rs
@@ -162,6 +162,11 @@ pub enum ConfigError {
          is active"
     )]
     PapertrailSchedulingNotSupported,
+    #[error(
+        "[papertrail] `rate_limit_reserve` must be a finite fraction from 0.0 up to (but not \
+         including) 1.0 (got `{0}`)"
+    )]
+    PapertrailRateLimitReserveOutOfRange(f64),
 }
 
 pub use discovery::{

--- a/crates/rag-rat-core/src/config/raw.rs
+++ b/crates/rag-rat-core/src/config/raw.rs
@@ -6,9 +6,9 @@ use serde::Deserialize;
 use super::{
     ConfigError, DEFAULT_QUERY_ENDPOINT, DreamLlmConfig, EmbeddingBackend, EmbeddingConfig,
     EmbeddingRuntimeConfig, LlmConfig, LogConfig, LogFormat, LogLevel,
-    MAX_REMOTE_EMBEDDING_CONCURRENCY, MemoryConfig, MemorySurface, OracleConfig, RemoteBackend,
-    RemoteDreamConfig, RemoteEmbeddingConfig, SearchConfig, Tracker, TrackerAuth, TrackerConfig,
-    VersionCheckConfig, WatchConfig,
+    MAX_REMOTE_EMBEDDING_CONCURRENCY, MemoryConfig, MemorySurface, OracleConfig, PapertrailConfig,
+    RemoteBackend, RemoteDreamConfig, RemoteEmbeddingConfig, SearchConfig, Tracker, TrackerAuth,
+    TrackerConfig, VersionCheckConfig, WatchConfig,
 };
 use crate::embedding_models::Backend;
 
@@ -46,14 +46,42 @@ pub(crate) struct RawConfig {
     pub(crate) memory: RawMemory,
     #[serde(default, rename = "tracker")]
     pub(crate) tracker: Vec<RawTracker>,
-    /// Reserved for the provider mirror scheduler. Capture the table so config cannot silently
-    /// accept cadence/rate knobs before any production path consumes them.
+    /// Papertrail transport/scheduler settings. The transport consumes `rate_limit_reserve` now;
+    /// cadence fields are captured so they can be rejected until the scheduler consumes them.
     #[serde(default)]
-    pub(crate) papertrail: Option<toml::Value>,
+    pub(crate) papertrail: Option<RawPapertrail>,
     #[serde(default)]
     pub(crate) target_bindings: BTreeMap<String, Vec<String>>,
     #[serde(default, rename = "target")]
     pub(crate) target: Vec<RawTarget>,
+}
+
+#[derive(Debug, Default, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct RawPapertrail {
+    pub(crate) probe_interval_secs: Option<u64>,
+    pub(crate) sync_min_interval_secs: Option<u64>,
+    pub(crate) full_sync_interval_secs: Option<u64>,
+    pub(crate) rate_limit_reserve: Option<f64>,
+}
+
+impl TryFrom<RawPapertrail> for PapertrailConfig {
+    type Error = ConfigError;
+
+    fn try_from(raw: RawPapertrail) -> Result<Self, Self::Error> {
+        if raw.probe_interval_secs.is_some()
+            || raw.sync_min_interval_secs.is_some()
+            || raw.full_sync_interval_secs.is_some()
+        {
+            return Err(ConfigError::PapertrailSchedulingNotSupported);
+        }
+        let default = PapertrailConfig::default();
+        let rate_limit_reserve = raw.rate_limit_reserve.unwrap_or(default.rate_limit_reserve);
+        if !rate_limit_reserve.is_finite() || !(0.0..1.0).contains(&rate_limit_reserve) {
+            return Err(ConfigError::PapertrailRateLimitReserveOutOfRange(rate_limit_reserve));
+        }
+        Ok(PapertrailConfig { rate_limit_reserve, ..default })
+    }
 }
 
 #[derive(Debug, Default, Deserialize, PartialEq)]

--- a/crates/rag-rat-core/src/config/tests.rs
+++ b/crates/rag-rat-core/src/config/tests.rs
@@ -232,6 +232,27 @@ fn papertrail_scheduling_table_is_rejected_until_it_is_consumed() {
 }
 
 #[test]
+fn papertrail_rate_limit_reserve_is_parsed_and_validated() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("rag-rat.toml");
+    std::fs::write(&path, "[papertrail]\nrate_limit_reserve = 0.2\n").unwrap();
+    let config = Config::load(&path).unwrap();
+    assert_eq!(config.papertrail.rate_limit_reserve, 0.2);
+
+    std::fs::write(&path, "[papertrail]\nrate_limit_reserve = 0.0\n").unwrap();
+    let config = Config::load(&path).unwrap();
+    assert_eq!(config.papertrail.rate_limit_reserve, 0.0, "zero disables the reserved slice");
+
+    for invalid in ["-0.1", "1.0", "nan"] {
+        std::fs::write(&path, format!("[papertrail]\nrate_limit_reserve = {invalid}\n")).unwrap();
+        assert!(matches!(
+            Config::load(&path),
+            Err(ConfigError::PapertrailRateLimitReserveOutOfRange(_))
+        ));
+    }
+}
+
+#[test]
 fn repo_id_override_is_parsed_and_does_not_change_the_database_path() {
     let id = CFG_TEMP.fetch_add(1, Ordering::Relaxed);
     let tmp = std::env::temp_dir().join(format!("ragrat-repoid-{}-{id}", std::process::id()));

--- a/crates/rag-rat-core/src/config/types.rs
+++ b/crates/rag-rat-core/src/config/types.rs
@@ -110,8 +110,8 @@ pub enum TrackerAuth {
     TokenCommand(String),
 }
 
-/// Reserved scheduler defaults. User overrides remain rejected until the provider mirror
-/// scheduler consumes them; retaining the typed defaults keeps the runtime contract explicit.
+/// Papertrail transport and reserved scheduler settings. `rate_limit_reserve` is live in the
+/// shared transport; user cadence overrides remain rejected until the scheduler consumes them.
 #[derive(Debug, Clone, PartialEq)]
 pub struct PapertrailConfig {
     pub probe_interval_secs: u64,

--- a/crates/rag-rat-core/src/index/lifecycle.rs
+++ b/crates/rag-rat-core/src/index/lifecycle.rs
@@ -380,14 +380,9 @@ impl IndexDatabase {
         Ok(Some(db))
     }
 
-    /// Set the GitHub repo context explicitly (tests / non-gh callers), so the library never
-    /// shells out to `gh`.
-    pub fn set_papertrail_context(
-        &mut self,
-        default_repo: Option<&str>,
-        github_cli_available: bool,
-    ) {
-        self.papertrail = papertrail::PapertrailContext::new(default_repo, github_cli_available);
+    /// Set the GitHub repo context explicitly for tests and embedding callers.
+    pub fn set_papertrail_context(&mut self, default_repo: Option<&str>) {
+        self.papertrail = papertrail::PapertrailContext::new(default_repo);
     }
 
     pub fn migrate(path: &Path) -> anyhow::Result<schema::SchemaStatus> {

--- a/crates/rag-rat-core/src/index/papertrail/api.rs
+++ b/crates/rag-rat-core/src/index/papertrail/api.rs
@@ -23,14 +23,14 @@ pub(crate) async fn sync_from_refs_with_progress<C: PapertrailClient>(
         SyncRefsReport::default()
     } else {
         let client = client.ok_or_else(|| anyhow::anyhow!("papertrail sync requires a client"))?;
-        // The stacked schema lets production discovery persist every provider's refs. Live
-        // transport is still GitHub-only until #589 lands, so never send another provider's
-        // identity through GitHubClient. Multi-provider mirror dispatch is the remaining #590
-        // sync slice, intentionally outside this config/grammar PR.
+        // Production discovery persists every provider's refs, but live sync remains GitHub-only
+        // until the provider-client PRs build on the shared transport. Never send another
+        // provider's identity through GitHubClient.
         sync_refs(
             conn,
             client,
-            refs.iter().filter(|reference| reference.tracker == Tracker::Github),
+            refs.iter()
+                .filter(|reference| discovered_ref_uses_legacy_github_client(ctx, reference)),
             &mut progress,
         )
         .await?
@@ -67,6 +67,8 @@ pub(crate) async fn sync_issue<C: PapertrailClient>(
         sync_refs(
             conn,
             client,
+            // `parse_issue_ref` is the explicit legacy GitHub command grammar. Its routing must
+            // not depend on which discovery bindings happen to be configured for this repo.
             refs.iter().filter(|reference| {
                 reference.tracker == Tracker::Github
                     && reference.project == project
@@ -103,6 +105,11 @@ pub(crate) fn status(
         )?;
         Ok(u64::try_from(count).unwrap_or_default())
     };
+    let needs_github_cli = ctx
+        .trackers
+        .iter()
+        .any(|binding| binding.provider == Tracker::Github && binding.base_url.is_none());
+    let github_cli_available = needs_github_cli && github_cli_available();
     Ok(PapertrailStatus {
         refs: scoped_table_row_count(conn, "papertrail_refs", &repo_id)?,
         issues: items_by_kind(ItemKind::Issue)?,
@@ -110,12 +117,56 @@ pub(crate) fn status(
         comments: scoped_table_row_count(conn, "papertrail_comments", &repo_id)?,
         last_sync_ms: repo_meta(conn, &repo_id, "papertrail_last_sync_ms")?
             .and_then(|value| value.parse().ok()),
-        capability: if ctx.github_cli_available {
-            "gh_cli_available".to_string()
-        } else {
-            "gh_cli_missing".to_string()
-        },
+        capabilities: ctx
+            .trackers
+            .iter()
+            .map(|binding| TrackerCapability {
+                tracker: binding.provider,
+                project: binding.project.clone(),
+                authentication: binding.authentication,
+                synchronization: tracker_synchronization(binding, github_cli_available),
+            })
+            .collect(),
     })
+}
+
+/// The legacy `gh api` client is cloud-GitHub-only. Discovered refs follow the binding that claimed
+/// their source text, so a self-hosted binding waits for its native provider client rather than
+/// accidentally querying github.com. Explicit manual refs are routed directly by [`sync_issue`].
+fn discovered_ref_uses_legacy_github_client(
+    ctx: &PapertrailContext,
+    reference: &PapertrailRef,
+) -> bool {
+    if reference.tracker != Tracker::Github {
+        return false;
+    }
+    if ctx.trackers.is_empty() {
+        return true;
+    }
+    parse_tracker_refs_with_bindings(&reference.source_text, &ctx.trackers)
+        .into_iter()
+        .find(|(_, parsed)| {
+            parsed.provider == reference.tracker
+                && parsed.project == reference.project
+                && parsed.item_key == reference.item_key
+                // V060-migrated GitHub refs have NULL kind even when their source URL now parses
+                // as `/pull/N`; NULL is unknown, not a conflicting kind.
+                && reference
+                    .item_kind
+                    .is_none_or(|kind| parsed.item_kind == Some(kind))
+        })
+        .is_some_and(|(binding_index, _)| ctx.trackers[binding_index].base_url.is_none())
+}
+
+fn tracker_synchronization(
+    binding: &ResolvedTracker,
+    github_cli_available: bool,
+) -> TrackerSynchronization {
+    match (binding.provider, binding.base_url.is_none(), github_cli_available) {
+        (Tracker::Github, true, true) => TrackerSynchronization::LegacyGithubCli,
+        (Tracker::Github, true, false) => TrackerSynchronization::LegacyGithubCliMissing,
+        _ => TrackerSynchronization::ProviderClientPending,
+    }
 }
 pub(crate) fn issue_search(
     conn: &Connection,
@@ -263,5 +314,91 @@ pub(crate) fn mark_fallback_evidence(evidence: &mut [PapertrailEvidence]) {
             _ => "fallback_tracker_evidence",
         };
         item.score = item.score.min(0.25);
+    }
+}
+
+#[cfg(test)]
+mod capability_tests {
+    use super::*;
+
+    fn github(base_url: Option<&str>) -> ResolvedTracker {
+        ResolvedTracker {
+            provider: Tracker::Github,
+            project: "o/r".to_string(),
+            base_url: base_url.map(str::to_string),
+            auth: None,
+            authentication: TrackerAuthentication::AuthMissing,
+            tags: Vec::new(),
+        }
+    }
+
+    fn reference() -> PapertrailRef {
+        PapertrailRef {
+            tracker: Tracker::Github,
+            project: "o/r".to_string(),
+            item_key: "1".to_string(),
+            item_kind: Some(ItemKind::Issue),
+            ref_kind: "explicit".to_string(),
+            source_kind: "test".to_string(),
+            source_path: None,
+            source_commit: None,
+            source_text: "o/r#1".to_string(),
+        }
+    }
+
+    #[test]
+    fn synchronization_reports_missing_gh_and_keeps_enterprise_off_the_legacy_path() {
+        assert_eq!(
+            tracker_synchronization(&github(None), false),
+            TrackerSynchronization::LegacyGithubCliMissing
+        );
+        assert_eq!(
+            tracker_synchronization(&github(None), true),
+            TrackerSynchronization::LegacyGithubCli
+        );
+        let enterprise =
+            PapertrailContext { trackers: vec![github(Some("https://github.example.com"))] };
+        assert_eq!(
+            tracker_synchronization(&enterprise.trackers[0], true),
+            TrackerSynchronization::ProviderClientPending
+        );
+        assert!(!discovered_ref_uses_legacy_github_client(&enterprise, &reference()));
+        assert!(discovered_ref_uses_legacy_github_client(
+            &PapertrailContext::default(),
+            &reference()
+        ));
+
+        let cloud = PapertrailContext { trackers: vec![github(None)] };
+        let mut cross_repo = reference();
+        cross_repo.project = "other/repo".to_string();
+        cross_repo.item_kind = None;
+        cross_repo.source_text = "https://github.com/other/repo/issues/1".to_string();
+        assert!(
+            discovered_ref_uses_legacy_github_client(&cloud, &cross_repo),
+            "fully-qualified cloud refs can be fetched by gh regardless of the binding project"
+        );
+
+        let mixed = PapertrailContext {
+            trackers: vec![github(None), ResolvedTracker {
+                project: "enterprise/repo".to_string(),
+                ..github(Some("https://github.example.com"))
+            }],
+        };
+        let mut enterprise = reference();
+        enterprise.project = "enterprise/other".to_string();
+        enterprise.item_kind = None;
+        enterprise.source_text = "https://github.example.com/enterprise/other/issues/1".to_string();
+        assert!(
+            !discovered_ref_uses_legacy_github_client(&mixed, &enterprise),
+            "the Enterprise binding that claimed the URL keeps it off github.com"
+        );
+
+        let mut migrated_pull = reference();
+        migrated_pull.item_kind = None;
+        migrated_pull.source_text = "https://github.com/o/r/pull/1".to_string();
+        assert!(
+            discovered_ref_uses_legacy_github_client(&cloud, &migrated_pull),
+            "a migrated NULL kind remains compatible with syntax that now identifies a PR"
+        );
     }
 }

--- a/crates/rag-rat-core/src/index/papertrail/mod.rs
+++ b/crates/rag-rat-core/src/index/papertrail/mod.rs
@@ -4,9 +4,14 @@ mod parse;
 mod store;
 mod sync;
 mod trackers;
+// Shared HTTP substrate for the native provider clients (#589): reqwest transport, per-
+// (provider, host, token) rate governor, env/token_command auth. `dead_code`/`unused_imports`
+// are allowed until the first native client consumes it (#591) — drop the allow there.
+#[allow(dead_code, unused_imports)]
+pub(crate) mod transport;
 use std::collections::BTreeSet;
 use std::path::Path;
-use std::process::Command;
+use std::process::{Command, Stdio};
 use std::sync::OnceLock;
 
 pub(crate) use api::*;
@@ -27,17 +32,14 @@ use crate::index::now_ms;
 /// Resolved tracker context, injected into the sync/query paths instead of being resolved inside
 /// the library. Resolution runs ONLY at the real-usage boundary (`IndexDatabase::open_config`)
 /// and never in tests, which pass an explicit context (#60): it reads local git state (the
-/// remote URL) plus a `gh --version` capability probe — the old `gh repo view` network shell-out
-/// is gone.
+/// remote URL). Authentication is carried per binding; there is no process-global `gh`
+/// capability bit.
 #[derive(Debug, Clone, Default)]
 pub struct PapertrailContext {
     /// Resolved tracker bindings, in config order (or the single auto-detected code host).
-    /// Production discovery and rationale lookup consume every binding. On the #588 stack the
-    /// network client remains GitHub-only; #589 supplies transport for parallel provider sync.
+    /// Production discovery and rationale lookup consume every binding. Live network sync remains
+    /// GitHub-only until the provider-client PRs build on [`transport`].
     pub trackers: Vec<ResolvedTracker>,
-    /// Whether the `gh` CLI is available (reported as a capability in status; the current
-    /// GitHub client still shells out to it until the native transport lands).
-    pub github_cli_available: bool,
 }
 
 impl PapertrailContext {
@@ -45,26 +47,24 @@ impl PapertrailContext {
     /// auto-detected from the git `origin` remote. Call ONLY at the real-usage boundary
     /// (open_config), never inside the library internals or tests.
     pub(crate) fn resolve(config: &crate::config::Config) -> Self {
-        Self {
-            trackers: resolve_trackers(&config.trackers, &config.root),
-            github_cli_available: github_cli_available(),
-        }
+        Self { trackers: resolve_trackers(&config.trackers, &config.root) }
     }
 
     /// An explicit GitHub-repo context that never touches git or `gh` — for tests and non-gh
     /// callers.
-    pub(crate) fn new(default_repo: Option<&str>, github_cli_available: bool) -> Self {
+    pub(crate) fn new(default_repo: Option<&str>) -> Self {
         let trackers = default_repo
             .map(|project| ResolvedTracker {
                 provider: Tracker::Github,
                 project: project.to_string(),
                 base_url: None,
                 auth: None,
+                authentication: TrackerAuthentication::AuthMissing,
                 tags: Vec::new(),
             })
             .into_iter()
             .collect();
-        Self { trackers, github_cli_available }
+        Self { trackers }
     }
 
     /// `owner/repo` qualifying a manually requested legacy GitHub reference. Production
@@ -84,7 +84,33 @@ pub struct PapertrailStatus {
     pub change_requests: u64,
     pub comments: u64,
     pub last_sync_ms: Option<i64>,
-    pub capability: String,
+    pub capabilities: Vec<TrackerCapability>,
+}
+
+/// Per-binding auth and live-sync capability. Environment auth reflects token presence; command
+/// auth reflects a configured source without running shell code on read paths. The transport
+/// resolves either source when a network client is built.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct TrackerCapability {
+    pub tracker: Tracker,
+    pub project: String,
+    pub authentication: TrackerAuthentication,
+    pub synchronization: TrackerSynchronization,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum TrackerAuthentication {
+    AuthConfigured,
+    AuthMissing,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum TrackerSynchronization {
+    LegacyGithubCli,
+    LegacyGithubCliMissing,
+    ProviderClientPending,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/crates/rag-rat-core/src/index/papertrail/parse.rs
+++ b/crates/rag-rat-core/src/index/papertrail/parse.rs
@@ -135,16 +135,29 @@ impl TrackerParsedRef {
 /// contract; GitLab's bare `!N` is provider-explicit syntax and resolves against its own
 /// binding regardless.
 pub fn parse_tracker_refs(text: &str, trackers: &[ResolvedTracker]) -> Vec<TrackerParsedRef> {
+    parse_tracker_refs_with_bindings(text, trackers).into_iter().map(|(_, parsed)| parsed).collect()
+}
+
+/// The routing-aware form of [`parse_tracker_refs`]. The binding index is the exact binding whose
+/// grammar claimed the token under the same first-match rule, so callers can distinguish cloud
+/// GitHub from Enterprise without reconstructing provenance from the normalized project.
+pub(crate) fn parse_tracker_refs_with_bindings(
+    text: &str,
+    trackers: &[ResolvedTracker],
+) -> Vec<(usize, TrackerParsedRef)> {
     let code_host = trackers.iter().position(|tracker| tracker.provider.is_code_host());
     let mut refs = Vec::new();
     let mut previous = "";
     for token in ref_tokens(text) {
         let ref_kind = ref_kind(previous);
-        if let Some(mut parsed) = trackers.iter().enumerate().find_map(|(index, tracker)| {
-            tracker_token_ref(token, tracker, code_host == Some(index))
-        }) {
+        if let Some((binding_index, mut parsed)) =
+            trackers.iter().enumerate().find_map(|(index, tracker)| {
+                tracker_token_ref(token, tracker, code_host == Some(index))
+                    .map(|parsed| (index, parsed))
+            })
+        {
             parsed.ref_kind = ref_kind;
-            refs.push(parsed);
+            refs.push((binding_index, parsed));
         }
         previous = token;
     }
@@ -467,8 +480,16 @@ pub(crate) fn gh_api_paginated(path: &str) -> anyhow::Result<Vec<Value>> {
     }
     Ok(out)
 }
+/// The legacy GitHub sync path shells out to `gh api`; status checks ONLY executable presence.
+/// Authentication is intentionally deferred to sync, where `gh api` returns the actionable error.
 pub(crate) fn github_cli_available() -> bool {
-    Command::new("gh").arg("--version").output().is_ok_and(|output| output.status.success())
+    Command::new("gh")
+        .arg("--version")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .is_ok_and(|status| status.success())
 }
 pub(crate) fn string_value(value: &Value, key: &str) -> String {
     value[key].as_str().unwrap_or_default().to_string()
@@ -507,6 +528,7 @@ mod grammar_tests {
             project: project.to_string(),
             base_url: None,
             auth: None,
+            authentication: TrackerAuthentication::AuthMissing,
             tags: Vec::new(),
         }
     }

--- a/crates/rag-rat-core/src/index/papertrail/trackers.rs
+++ b/crates/rag-rat-core/src/index/papertrail/trackers.rs
@@ -9,6 +9,7 @@ use std::path::Path;
 
 use sha2::{Digest, Sha256};
 
+use super::TrackerAuthentication;
 use crate::config::{Tracker, TrackerAuth, TrackerConfig};
 
 /// One tracker binding with its `project` resolved to a concrete value — the runtime shape
@@ -24,6 +25,10 @@ pub struct ResolvedTracker {
     /// Self-hosted base URL (no trailing slash). `None` = the provider's cloud host.
     pub base_url: Option<String>,
     pub auth: Option<TrackerAuth>,
+    /// Authentication capability snapshotted when the binding is resolved. Environment sources
+    /// are checked for token presence; commands are treated as configured without executing shell
+    /// code on ordinary index opens. Transport construction resolves and fails fast at sync time.
+    pub authentication: TrackerAuthentication,
     /// Configured tags as written (trimmed, non-empty); matching and fingerprinting normalize
     /// on demand via [`normalized_tags`].
     pub tags: Vec<String>,
@@ -121,6 +126,7 @@ fn resolve_binding(binding: &TrackerConfig, root: &Path) -> Option<ResolvedTrack
         project,
         base_url: binding.base_url.clone().or(derived_base_url),
         auth: binding.auth.clone(),
+        authentication: super::transport::authentication(binding.auth.as_ref()),
         tags: binding.tags.clone(),
     })
 }
@@ -138,7 +144,14 @@ pub fn detect_tracker_from_remote_url(url: &str) -> Option<ResolvedTracker> {
     let provider = detect_provider(&parts.host)?;
     let project = remote_url_project(&parts, provider)?;
     let base_url = remote_base_url(&parts, provider);
-    Some(ResolvedTracker { provider, project, base_url, auth: None, tags: Vec::new() })
+    Some(ResolvedTracker {
+        provider,
+        project,
+        base_url,
+        auth: None,
+        authentication: TrackerAuthentication::AuthMissing,
+        tags: Vec::new(),
+    })
 }
 
 /// A self-hosted remote's authority is part of provider identity: both URL parsing and transport
@@ -273,8 +286,28 @@ mod tests {
             project: project.to_string(),
             base_url: None,
             auth: None,
+            authentication: TrackerAuthentication::AuthMissing,
             tags: Vec::new(),
         })
+    }
+
+    #[test]
+    fn resolved_binding_defers_token_commands_but_detects_missing_env() {
+        let binding = |command: &str| TrackerConfig {
+            provider: Tracker::Gitlab,
+            project: Some("group/repo".to_string()),
+            remote: "origin".to_string(),
+            base_url: None,
+            auth: Some(TrackerAuth::TokenCommand(command.to_string())),
+            tags: Vec::new(),
+        };
+        let root = Path::new(".");
+        let configured = resolve_trackers(&[binding("exit 3")], root);
+        assert_eq!(configured[0].authentication, TrackerAuthentication::AuthConfigured);
+        let mut missing_binding = binding("echo unused");
+        missing_binding.auth = Some(TrackerAuth::Env("RAG_RAT_TEST_UNSET_TOKEN_VAR".to_string()));
+        let missing = resolve_trackers(&[missing_binding], root);
+        assert_eq!(missing[0].authentication, TrackerAuthentication::AuthMissing);
     }
 
     #[test]
@@ -477,6 +510,7 @@ mod tests {
             project: "o/r".to_string(),
             base_url: None,
             auth: None,
+            authentication: TrackerAuthentication::AuthMissing,
             tags: tags.iter().map(|t| t.to_string()).collect(),
         }
     }

--- a/crates/rag-rat-core/src/index/papertrail/transport/auth.rs
+++ b/crates/rag-rat-core/src/index/papertrail/transport/auth.rs
@@ -1,0 +1,218 @@
+//! Secret-free auth resolution for tracker bindings: config names WHERE the token lives (an env
+//! var or a command that prints it), never the token itself — `rag-rat.toml` stays committable.
+
+use std::process::Command;
+
+use anyhow::Context as _;
+
+use crate::config::TrackerAuth;
+use crate::index::papertrail::TrackerAuthentication;
+
+/// Snapshot a binding's authentication capability without running configured shell code merely
+/// because an index is opened for search/status. Environment lookup is side-effect free; a token
+/// command is treated as configured and resolved later by explicit transport construction.
+pub(crate) fn authentication(spec: Option<&TrackerAuth>) -> TrackerAuthentication {
+    match spec {
+        Some(TrackerAuth::Env(var))
+            if std::env::var(var).is_ok_and(|token| !token.trim().is_empty()) =>
+            TrackerAuthentication::AuthConfigured,
+        Some(TrackerAuth::TokenCommand(command)) if !command.trim().is_empty() =>
+            TrackerAuthentication::AuthConfigured,
+        _ => TrackerAuthentication::AuthMissing,
+    }
+}
+
+/// Resolve the binding's token. `None` spec → `Ok(None)` (anonymous); a configured-but-missing
+/// token is an error — the operator asked for auth, silently degrading to the anonymous quota
+/// would both surprise them and burn the shared unauthenticated pool. Error text names the env
+/// var / command, never any token value.
+pub(crate) fn resolve_token(spec: Option<&TrackerAuth>) -> anyhow::Result<Option<String>> {
+    resolve_token_with(spec, |var| std::env::var(var).ok(), run_token_command)
+}
+
+/// Dependency-injected core: `env_lookup` stands in for the process environment and
+/// `run_command` for the shell, because env mutation is `unsafe` (and flaky under nextest's
+/// parallel runner) in Rust 2024 — the same pattern as the embedding backends' auth resolution.
+fn resolve_token_with(
+    spec: Option<&TrackerAuth>,
+    env_lookup: impl Fn(&str) -> Option<String>,
+    run_command: impl Fn(&str) -> anyhow::Result<String>,
+) -> anyhow::Result<Option<String>> {
+    match spec {
+        None => Ok(None),
+        Some(TrackerAuth::Env(var)) => {
+            let var = var.trim();
+            anyhow::ensure!(!var.is_empty(), "tracker auth env var name is empty");
+            let token = env_lookup(var)
+                .map(|token| token.trim().to_string())
+                .filter(|token| !token.is_empty())
+                .with_context(|| {
+                    format!(
+                        "tracker auth env var `{var}` is configured but missing or empty in the \
+                         environment"
+                    )
+                })?;
+            Ok(Some(token))
+        },
+        Some(TrackerAuth::TokenCommand(command)) => {
+            let command = command.trim();
+            anyhow::ensure!(!command.is_empty(), "tracker token_command is empty");
+            let token = run_command(command)?.trim().to_string();
+            anyhow::ensure!(!token.is_empty(), "token_command `{command}` printed no token");
+            Ok(Some(token))
+        },
+    }
+}
+
+/// Run the token command through the platform shell and return its stdout. Stderr is surfaced on
+/// failure (that's where `gh`/`glab` explain a missing login); stdout is NOT — it may hold a
+/// partial token.
+fn run_token_command(command: &str) -> anyhow::Result<String> {
+    let output = shell_command(command)
+        .output()
+        .with_context(|| format!("token_command `{command}` could not be spawned"))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!(
+            "token_command `{command}` failed ({}): {}",
+            output.status,
+            stderr.trim().chars().take(300).collect::<String>()
+        );
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+#[cfg(windows)]
+fn shell_command(command: &str) -> Command {
+    let mut shell = Command::new("cmd");
+    shell.arg("/C").arg(command);
+    shell
+}
+
+#[cfg(not(windows))]
+fn shell_command(command: &str) -> Command {
+    let mut shell = Command::new("sh");
+    shell.arg("-c").arg(command);
+    shell
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn env_lookup(var: &str) -> Option<String> {
+        std::env::var(var).ok()
+    }
+
+    #[test]
+    fn none_spec_resolves_to_anonymous() {
+        let token = resolve_token_with(None, env_lookup, run_token_command).unwrap();
+        assert_eq!(token, None);
+    }
+
+    #[test]
+    fn env_spec_resolves_and_trims_the_token() {
+        let spec = TrackerAuth::Env("GITHUB_TOKEN".to_string());
+        let token = resolve_token_with(
+            Some(&spec),
+            |var| (var == "GITHUB_TOKEN").then(|| "  ghp_tok \n".to_string()),
+            run_token_command,
+        )
+        .unwrap();
+        assert_eq!(token.as_deref(), Some("ghp_tok"));
+    }
+
+    #[test]
+    fn env_spec_errors_when_the_var_is_missing_or_empty() {
+        let spec = TrackerAuth::Env("GITHUB_TOKEN".to_string());
+        let missing =
+            resolve_token_with(Some(&spec), |_| None, run_token_command).unwrap_err().to_string();
+        assert!(missing.contains("GITHUB_TOKEN"), "{missing}");
+        let empty = resolve_token_with(Some(&spec), |_| Some("   ".to_string()), run_token_command)
+            .unwrap_err()
+            .to_string();
+        assert!(empty.contains("missing or empty"), "{empty}");
+        // A blank var NAME is a config mistake, not an anonymous binding.
+        let blank = TrackerAuth::Env("  ".into());
+        assert!(resolve_token_with(Some(&blank), |_| None, run_token_command).is_err());
+    }
+
+    #[test]
+    fn command_spec_uses_trimmed_stdout() {
+        let spec = TrackerAuth::TokenCommand("gh auth token".to_string());
+        let token = resolve_token_with(Some(&spec), env_lookup, |command| {
+            assert_eq!(command, "gh auth token");
+            Ok("tok-from-command\n".to_string())
+        })
+        .unwrap();
+        assert_eq!(token.as_deref(), Some("tok-from-command"));
+    }
+
+    #[test]
+    fn command_spec_errors_on_failure_or_empty_output() {
+        let spec = TrackerAuth::TokenCommand("gh auth token".to_string());
+        let failed =
+            resolve_token_with(Some(&spec), env_lookup, |_| anyhow::bail!("not logged in"))
+                .unwrap_err()
+                .to_string();
+        assert!(failed.contains("not logged in"), "{failed}");
+        let empty = resolve_token_with(Some(&spec), env_lookup, |_| Ok("  \n".to_string()))
+            .unwrap_err()
+            .to_string();
+        assert!(empty.contains("printed no token"), "{empty}");
+        assert!(
+            resolve_token_with(
+                Some(&TrackerAuth::TokenCommand(" ".into())),
+                env_lookup,
+                run_token_command,
+            )
+            .is_err(),
+            "blank command is a config mistake"
+        );
+    }
+
+    // The real shell path, kept portable: `echo` exists in both `sh -c` and `cmd /C`, and the
+    // trim handles the `\r\n` that `cmd` emits.
+    #[test]
+    fn real_shell_round_trip_prints_and_trims_a_token() {
+        let spec = TrackerAuth::TokenCommand("echo shell-token".to_string());
+        let token = resolve_token(Some(&spec)).unwrap();
+        assert_eq!(token.as_deref(), Some("shell-token"));
+    }
+
+    #[test]
+    fn real_shell_failure_and_silence_are_errors() {
+        // `exit 3` fails under both shells; the error names the command, never a token.
+        let failed = resolve_token(Some(&TrackerAuth::TokenCommand("exit 3".to_string())))
+            .unwrap_err()
+            .to_string();
+        assert!(failed.contains("exit 3"), "{failed}");
+        // `exit 0` succeeds while printing nothing under both shells.
+        let silent = resolve_token(Some(&TrackerAuth::TokenCommand("exit 0".to_string())))
+            .unwrap_err()
+            .to_string();
+        assert!(silent.contains("printed no token"), "{silent}");
+    }
+
+    #[test]
+    fn authentication_probes_env_but_defers_configured_commands_until_transport() {
+        assert_eq!(authentication(None), TrackerAuthentication::AuthMissing);
+        assert!(env_lookup("PATH").is_some(), "test process must expose PATH");
+        assert_eq!(
+            authentication(Some(&TrackerAuth::Env("PATH".to_string()))),
+            TrackerAuthentication::AuthConfigured
+        );
+        assert_eq!(
+            authentication(Some(&TrackerAuth::TokenCommand("exit 3".to_string()))),
+            TrackerAuthentication::AuthConfigured
+        );
+        assert_eq!(
+            authentication(Some(&TrackerAuth::TokenCommand("  ".to_string()))),
+            TrackerAuthentication::AuthMissing
+        );
+        assert_eq!(
+            authentication(Some(&TrackerAuth::Env("RAG_RAT_TEST_UNSET_TOKEN_VAR".to_string()))),
+            TrackerAuthentication::AuthMissing
+        );
+    }
+}

--- a/crates/rag-rat-core/src/index/papertrail/transport/client.rs
+++ b/crates/rag-rat-core/src/index/papertrail/transport/client.rs
@@ -1,0 +1,688 @@
+//! The binding-scoped HTTP client: async `reqwest` over rustls, driven through the rate governor
+//! on every request. Provider-neutral — URL building, pagination, and payload mapping stay in the
+//! per-provider clients built on top; this layer owns admission, quota-header recording,
+//! `429`/`Retry-After` backoff, and the sync pass's wall-clock cap.
+
+use std::sync::Arc;
+use std::time::{Duration, UNIX_EPOCH};
+
+use reqwest::header::{self, HeaderMap};
+
+use super::auth;
+use super::governor::{
+    Admission, GovernorConfig, GovernorKey, GovernorRegistry, PauseReason, QuotaSnapshot,
+    RateGovernor, backoff_delay_ms,
+};
+use crate::config::{PapertrailConfig, TrackerAuth};
+use crate::index::util::now_ms;
+
+/// How one transport call ends besides success.
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum TransportError {
+    /// Rate-governed stop — NOT a failure. The caller keeps its pagination cursor and resumes
+    /// at/after `resume_at_ms`; the next sync window continues mid-pagination.
+    #[error("rate-governed pause ({reason}) until {resume_at_ms}")]
+    Paused { resume_at_ms: i64, reason: PauseReason },
+    /// The request URL escaped the binding's authority — refused before any bytes go out, so
+    /// the binding's token can never travel to a foreign origin or over plaintext.
+    #[error("url `{url}` is outside the binding `{host}`: {problem}")]
+    UrlOutsideBinding { url: String, host: String, problem: &'static str },
+    /// Connect/send/read failure from the HTTP stack.
+    #[error(transparent)]
+    Http(#[from] reqwest::Error),
+}
+
+#[cfg(test)]
+impl TransportError {
+    pub(super) fn pause_details(&self) -> Option<(i64, PauseReason)> {
+        match self {
+            Self::Paused { resume_at_ms, reason } => Some((*resume_at_ms, *reason)),
+            _ => None,
+        }
+    }
+}
+
+/// One completed HTTP exchange. Every non-rate-limited status comes back as `Ok` — provider
+/// clients own status semantics (a 404 can be signal, not failure).
+#[derive(Debug)]
+pub(crate) struct TransportResponse {
+    pub status: u16,
+    pub headers: HeaderMap,
+    pub body: String,
+}
+
+/// Transport knobs. Everything has a conservative default; the config layer maps `[[tracker]]`
+/// settings onto this.
+#[derive(Debug, Clone)]
+pub(crate) struct TransportOptions {
+    pub governor: GovernorConfig,
+    pub request_timeout_s: u64,
+    /// Wall-clock budget for the whole sync pass, measured from construction: no request is sent
+    /// past the deadline (healthy pagination included, not just backoff), in-flight timeouts are
+    /// tightened to the remaining budget, and `429` backoff never sleeps past it — past it the
+    /// call returns [`TransportError::Paused`] and the caller keeps its cursor.
+    pub pass_budget_ms: i64,
+    /// First backoff step; doubles per retry. `Retry-After` overrides when longer.
+    pub backoff_base_ms: i64,
+    /// `Authorization` scheme prefix. `Bearer` fits GitHub and GitLab; providers with another
+    /// scheme override it.
+    pub auth_scheme: &'static str,
+}
+
+impl Default for TransportOptions {
+    fn default() -> Self {
+        Self {
+            governor: GovernorConfig::default(),
+            request_timeout_s: 30,
+            pass_budget_ms: 300_000,
+            backoff_base_ms: 1_000,
+            auth_scheme: "Bearer",
+        }
+    }
+}
+
+impl From<&PapertrailConfig> for TransportOptions {
+    fn from(config: &PapertrailConfig) -> Self {
+        let mut options = Self::default();
+        options.governor.reserve = config.rate_limit_reserve;
+        options
+    }
+}
+
+/// Construction inputs for one binding's transport.
+pub(crate) struct TransportParams<'a> {
+    /// Provider id (`github`, `gitlab`, …).
+    pub provider: &'a str,
+    /// Authority the binding talks to — `api.github.com`, `gitlab.example.com:8443`, never a
+    /// URL. Keys the governor AND pins every request: a URL outside it is refused.
+    pub host: &'a str,
+    pub auth: Option<&'a TrackerAuth>,
+    /// Shared registry so sibling bindings on the same (provider, host, token) share one
+    /// governor and jointly account their consumption.
+    pub registry: &'a GovernorRegistry,
+    pub options: TransportOptions,
+}
+
+/// Injected clock: feeds every governor decision so tests exercise pause/resume deterministically
+/// without real sleeps. Production uses [`now_ms`].
+type Clock = Arc<dyn Fn() -> i64 + Send + Sync>;
+
+pub(crate) struct Transport {
+    client: reqwest::Client,
+    governor: Arc<RateGovernor>,
+    /// Prebuilt `Authorization` value; `None` for anonymous bindings.
+    auth_header: Option<String>,
+    /// The binding's pinned authority (lowercased host, optional port) — every request URL must
+    /// stay inside it.
+    bound_host: String,
+    bound_port: Option<u16>,
+    is_github: bool,
+    pass_deadline_ms: i64,
+    request_timeout_ms: i64,
+    backoff_base_ms: i64,
+    clock: Clock,
+}
+
+impl Transport {
+    /// Build the transport for one binding: resolves the token (fails fast on a configured-but-
+    /// missing one), joins the shared governor for (provider, host, token), and constructs the
+    /// rustls HTTP client. The pass's wall-clock deadline starts here.
+    pub(crate) fn new(params: TransportParams<'_>) -> anyhow::Result<Self> {
+        Self::with_clock(params, Arc::new(now_ms))
+    }
+
+    pub(crate) fn with_clock(params: TransportParams<'_>, clock: Clock) -> anyhow::Result<Self> {
+        let token = auth::resolve_token(params.auth)?;
+        let auth_header =
+            token.as_deref().map(|token| format!("{} {token}", params.options.auth_scheme));
+        let (bound_host, bound_port) = parse_bound_authority(params.host)?;
+        let governor_authority = canonical_governor_authority(&bound_host, bound_port);
+        let governor = params.registry.governor(
+            GovernorKey::new(params.provider, &governor_authority, token.as_deref()),
+            &params.options.governor,
+        );
+        let mut builder = reqwest::Client::builder()
+            .timeout(Duration::from_secs(params.options.request_timeout_s))
+            // Redirects are provider semantics. Following them here would bypass the per-hop URL
+            // guard and governor admission, potentially forwarding auth to another authority.
+            .redirect(reqwest::redirect::Policy::none())
+            .user_agent(concat!("rag-rat/", env!("CARGO_PKG_VERSION")));
+        // Loopback bindings (tests, a forge on localhost) bypass the ambient HTTP proxy, same as
+        // the embedding transport; remote hosts inherit it.
+        if is_loopback_host(&bound_host) {
+            builder = builder.no_proxy();
+        }
+        let pass_deadline_ms = clock() + params.options.pass_budget_ms;
+        Ok(Self {
+            client: builder.build()?,
+            governor,
+            auth_header,
+            bound_host,
+            bound_port,
+            is_github: params.provider.eq_ignore_ascii_case("github"),
+            pass_deadline_ms,
+            request_timeout_ms: i64::try_from(params.options.request_timeout_s)
+                .unwrap_or(i64::MAX)
+                .saturating_mul(1000),
+            backoff_base_ms: params.options.backoff_base_ms,
+            clock,
+        })
+    }
+
+    /// GET `url` with the binding's auth plus `extra_headers`, rate-governed: URL pinned to the
+    /// binding's authority, pass deadline and governor admission checked before every send, quota
+    /// headers recorded after, and rate-limited replies retried on an exponential backoff that a
+    /// `Retry-After` can only lengthen — never sleeping past the pass's wall-clock deadline
+    /// (past it: [`TransportError::Paused`], cursor intact).
+    pub(crate) async fn get(
+        &self,
+        url: &str,
+        extra_headers: &[(&str, &str)],
+    ) -> Result<TransportResponse, TransportError> {
+        self.validate_url(url)?;
+        let mut attempt: u32 = 0;
+        loop {
+            let now = (self.clock)();
+            if now > self.pass_deadline_ms {
+                return Err(TransportError::Paused {
+                    resume_at_ms: now,
+                    reason: PauseReason::PassBudget,
+                });
+            }
+            if let Admission::PausedUntil { resume_at_ms, reason } = self.governor.admit(now) {
+                return Err(TransportError::Paused { resume_at_ms, reason });
+            }
+            let mut request = self.client.get(url).timeout(self.request_timeout(now));
+            if let Some(auth_header) = &self.auth_header {
+                request = request.header(header::AUTHORIZATION, auth_header);
+            }
+            for (name, value) in extra_headers {
+                request = request.header(*name, *value);
+            }
+            let response = request.send().await?;
+            let status = response.status().as_u16();
+            let headers = response.headers().clone();
+            let now = (self.clock)();
+            if let Some(snapshot) = QuotaSnapshot::from_headers(&headers, now) {
+                self.governor.record_quota(snapshot);
+            }
+            // Drain the body on every path — a rate-limited reply carries one too, and leaving
+            // it unread can abort the connection.
+            let body = response.text().await?;
+            let github_secondary = self.is_github && is_github_secondary_limit(status, &body);
+            if !is_rate_limited(status, &headers, now) && !github_secondary {
+                return Ok(TransportResponse { status, headers, body });
+            }
+            let retry_after_ms =
+                retry_after_ms(&headers, now).or_else(|| github_secondary.then_some(60_000));
+            let delay_ms = backoff_delay_ms(attempt, retry_after_ms, self.backoff_base_ms);
+            attempt += 1;
+            let resume_at_ms = now.saturating_add(delay_ms);
+            // Hold the whole (provider, host, token) key, not just this request — a sibling
+            // fetch on the same token must also stand down.
+            self.governor.record_hold(resume_at_ms);
+            if resume_at_ms > self.pass_deadline_ms {
+                return Err(TransportError::Paused {
+                    resume_at_ms,
+                    reason: PauseReason::RetryAfter,
+                });
+            }
+            tokio::time::sleep(Duration::from_millis(delay_ms.max(0) as u64)).await;
+        }
+    }
+
+    /// Pin every request to the binding's authority BEFORE anything is consumed or sent: the
+    /// binding's token must never travel to a foreign origin (a hostile or malformed absolute
+    /// pagination URL would otherwise exfiltrate it) and never over plaintext except to loopback
+    /// (stubs, local forges). A bound port pins the port; without one, only the scheme-default
+    /// port passes — except on loopback, where stubs bind ephemeral ports.
+    fn validate_url(&self, url: &str) -> Result<(), TransportError> {
+        let outside = |problem: &'static str| TransportError::UrlOutsideBinding {
+            url: url.to_string(),
+            host: self.bound_host.clone(),
+            problem,
+        };
+        let parsed = reqwest::Url::parse(url).map_err(|_| outside("not a valid absolute URL"))?;
+        // The url crate keeps IPv6 hosts bracketed; the bound side stores them bare.
+        let host = parsed.host_str().unwrap_or("").trim_matches(['[', ']']).to_ascii_lowercase();
+        if host.is_empty() || host != self.bound_host {
+            return Err(outside("host differs from the binding's"));
+        }
+        let port_ok = match self.bound_port {
+            Some(bound) => parsed.port_or_known_default() == Some(bound),
+            // `Url::port()` is `None` for the scheme-default port, so this rejects exactly the
+            // explicit non-default ports.
+            None => is_loopback_host(&host) || parsed.port().is_none(),
+        };
+        if !port_ok {
+            return Err(outside("port differs from the binding's"));
+        }
+        match parsed.scheme() {
+            "https" => Ok(()),
+            "http" if is_loopback_host(&host) => Ok(()),
+            _ => Err(outside("requires https (http is loopback-only)")),
+        }
+    }
+
+    /// Per-request timeout: the configured request timeout, tightened to the remaining pass
+    /// budget (floored at one second) so an in-flight request cannot outlive the pass by more
+    /// than a beat.
+    fn request_timeout(&self, now_ms: i64) -> Duration {
+        let remaining_ms = self.pass_deadline_ms.saturating_sub(now_ms).max(1_000);
+        Duration::from_millis(self.request_timeout_ms.min(remaining_ms).max(1) as u64)
+    }
+}
+
+/// Canonical quota-pool authority. Case was normalized by `parse_bound_authority`; an explicit
+/// HTTPS default port names the same origin as no port, while non-default ports remain distinct.
+fn canonical_governor_authority(host: &str, port: Option<u16>) -> String {
+    match port {
+        None | Some(443) => host.to_string(),
+        Some(port) if host.contains(':') => format!("[{host}]:{port}"),
+        Some(port) => format!("{host}:{port}"),
+    }
+}
+
+/// Split a configured authority into (lowercased host, optional port). Accepts `host`,
+/// `host:port`, `[v6]`, `[v6]:port`, and a bare IPv6 literal (multiple colons, no port).
+/// Malformed input is an ERROR, never normalized — silently dropping a bad port would quietly
+/// re-point the binding (and its token) at the host's scheme-default port.
+fn parse_bound_authority(authority: &str) -> anyhow::Result<(String, Option<u16>)> {
+    let authority = authority.trim();
+    let parse_port = |port: &str| {
+        port.parse::<u16>()
+            .map_err(|_| anyhow::anyhow!("invalid port `{port}` in tracker host `{authority}`"))
+    };
+    if let Some(rest) = authority.strip_prefix('[') {
+        let Some((host, tail)) = rest.split_once(']') else {
+            anyhow::bail!("unclosed `[` in tracker host `{authority}`");
+        };
+        anyhow::ensure!(!host.is_empty(), "empty host in tracker host `{authority}`");
+        let port = match tail.strip_prefix(':') {
+            Some(port) => Some(parse_port(port)?),
+            None if tail.is_empty() => None,
+            None => anyhow::bail!("unexpected `{tail}` after `]` in tracker host `{authority}`"),
+        };
+        return Ok((host.to_ascii_lowercase(), port));
+    }
+    match authority.split_once(':') {
+        Some((host, port)) if !port.contains(':') => {
+            anyhow::ensure!(!host.is_empty(), "empty host in tracker host `{authority}`");
+            Ok((host.to_ascii_lowercase(), Some(parse_port(port)?)))
+        },
+        _ => {
+            anyhow::ensure!(!authority.is_empty(), "tracker host is empty");
+            // A colon here means a bare IPv6 literal — anything else with colons is malformed.
+            anyhow::ensure!(
+                !authority.contains(':') || authority.parse::<std::net::Ipv6Addr>().is_ok(),
+                "malformed tracker host `{authority}`"
+            );
+            Ok((authority.to_ascii_lowercase(), None))
+        },
+    }
+}
+
+/// Loopback spellings a binding/test can use; these allow plain http and arbitrary ports.
+fn is_loopback_host(host: &str) -> bool {
+    matches!(host, "127.0.0.1" | "localhost" | "::1")
+}
+
+/// Whether a response is a rate-limit signal. `429` always; GitHub reports its primary limit as
+/// `403` + `x-ratelimit-remaining: 0` and its secondary limits as `403` + `Retry-After`, so
+/// those count too — still pure header semantics, no provider branching.
+fn is_rate_limited(status: u16, headers: &HeaderMap, now_ms: i64) -> bool {
+    match status {
+        429 => true,
+        403 =>
+            headers.contains_key(header::RETRY_AFTER)
+                || QuotaSnapshot::from_headers(headers, now_ms)
+                    .is_some_and(|quota| quota.remaining == 0),
+        _ => false,
+    }
+}
+
+fn is_github_secondary_limit(status: u16, body: &str) -> bool {
+    if status != 403 && status != 429 {
+        return false;
+    }
+    let body = body.to_ascii_lowercase();
+    body.contains("secondary rate limit") || body.contains("abuse detection")
+}
+
+/// `Retry-After` in milliseconds: delta-seconds or the HTTP-date form required by RFC 9110.
+fn retry_after_ms(headers: &HeaderMap, now_ms: i64) -> Option<i64> {
+    let value = headers.get(header::RETRY_AFTER)?.to_str().ok()?.trim();
+    if let Some(seconds) = value.parse::<i64>().ok().filter(|seconds| *seconds >= 0) {
+        return Some(seconds.saturating_mul(1000));
+    }
+    let target_ms = i64::try_from(
+        httpdate::parse_http_date(value).ok()?.duration_since(UNIX_EPOCH).ok()?.as_millis(),
+    )
+    .ok()?;
+    Some(target_ms.saturating_sub(now_ms).max(0))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::stub::{StubResponse, spawn_script_stub};
+    use super::*;
+
+    /// Drive a transport future on a current-thread runtime — the same flavor the papertrail
+    /// `block_on` bridge uses in production.
+    fn drive<T>(future: impl Future<Output = T>) -> T {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("test runtime")
+            .block_on(future)
+    }
+
+    fn transport(url: &str, auth: Option<&TrackerAuth>, options: TransportOptions) -> Transport {
+        let registry = GovernorRegistry::default();
+        let host = url.trim_start_matches("http://").split(':').next().unwrap().to_string();
+        Transport::new(TransportParams {
+            provider: "github",
+            host: &host,
+            auth,
+            registry: &registry,
+            options,
+        })
+        .expect("transport")
+    }
+
+    fn fast_options() -> TransportOptions {
+        TransportOptions { backoff_base_ms: 10, ..TransportOptions::default() }
+    }
+
+    #[test]
+    fn papertrail_config_sets_the_governor_reserve() {
+        let config = PapertrailConfig { rate_limit_reserve: 0.2, ..PapertrailConfig::default() };
+        let options = TransportOptions::from(&config);
+        assert_eq!(options.governor.reserve, 0.2);
+        assert_eq!(
+            options.governor.fallback_budget.max_requests,
+            TransportOptions::default().governor.fallback_budget.max_requests
+        );
+    }
+
+    #[test]
+    fn get_sends_auth_and_extra_headers() {
+        let (url, handle) = spawn_script_stub(vec![StubResponse::ok(r#"{"ok":true}"#)]);
+        let auth = TrackerAuth::TokenCommand("echo stub-token".to_string());
+        let transport = transport(&url, Some(&auth), fast_options());
+        let response = drive(async {
+            transport.get(&format!("{url}/items"), &[("accept", "application/json")]).await
+        })
+        .expect("success");
+        assert_eq!(response.status, 200);
+        assert_eq!(response.body, r#"{"ok":true}"#);
+        let requests = handle.join().unwrap();
+        assert_eq!(requests.len(), 1);
+        let head = requests[0].to_ascii_lowercase();
+        assert!(head.starts_with("get /items http/1.1"), "{head}");
+        assert!(head.contains("authorization: bearer stub-token"), "{head}");
+        assert!(head.contains("accept: application/json"), "{head}");
+        assert!(head.contains("user-agent: rag-rat/"), "{head}");
+    }
+
+    #[test]
+    fn a_429_is_retried_with_backoff_and_succeeds() {
+        let (url, handle) = spawn_script_stub(vec![
+            StubResponse::status("429 Too Many Requests", "slow down"),
+            StubResponse::ok("recovered"),
+        ]);
+        let transport = transport(&url, None, fast_options());
+        let response =
+            drive(async { transport.get(&format!("{url}/items"), &[]).await }).expect("retried");
+        assert_eq!(response.status, 200);
+        assert_eq!(response.body, "recovered");
+        assert_eq!(handle.join().unwrap().len(), 2, "one retry after the 429");
+    }
+
+    #[test]
+    fn a_retry_after_beyond_the_pass_budget_pauses_instead_of_sleeping() {
+        let (url, handle) = spawn_script_stub(vec![StubResponse {
+            status: "429 Too Many Requests",
+            headers: vec![("retry-after".into(), "3600".into())],
+            body: "later".to_string(),
+        }]);
+        let options = TransportOptions { pass_budget_ms: 1_000, ..fast_options() };
+        let transport = transport(&url, None, options);
+        let before = now_ms();
+        let err = drive(async { transport.get(&format!("{url}/items"), &[]).await })
+            .expect_err("must pause");
+        let (resume_at_ms, reason) = err.pause_details().expect("expected Paused");
+        assert_eq!(reason, PauseReason::RetryAfter);
+        assert!(
+            resume_at_ms >= before + 3_600_000,
+            "resume honors Retry-After: {resume_at_ms} vs {before}"
+        );
+        assert_eq!(handle.join().unwrap().len(), 1, "no retry once the budget is overrun");
+        // The hold covers the whole key: the next call stands down WITHOUT touching the network
+        // (the stub has no scripted responses left — a request would fail, not pause).
+        let second = drive(async { transport.get(&format!("{url}/items"), &[]).await })
+            .expect_err("still held");
+        assert!(matches!(second, TransportError::Paused { .. }), "{second:?}");
+    }
+
+    #[test]
+    fn a_secondary_403_with_retry_after_is_rate_limited() {
+        let (url, handle) = spawn_script_stub(vec![
+            StubResponse {
+                status: "403 Forbidden",
+                headers: vec![("retry-after".into(), "0".into())],
+                body: "secondary limit".to_string(),
+            },
+            StubResponse::ok("recovered"),
+        ]);
+        let transport = transport(&url, None, fast_options());
+        let response =
+            drive(async { transport.get(&format!("{url}/items"), &[]).await }).expect("retried");
+        assert_eq!(response.body, "recovered");
+        assert_eq!(handle.join().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn a_body_only_github_secondary_limit_pauses_for_at_least_a_minute() {
+        let (url, handle) = spawn_script_stub(vec![StubResponse::status(
+            "403 Forbidden",
+            "You have exceeded a secondary rate limit.",
+        )]);
+        let options = TransportOptions { pass_budget_ms: 1_000, ..fast_options() };
+        let transport = transport(&url, None, options);
+        let before = now_ms();
+        let err = drive(async { transport.get(&format!("{url}/items"), &[]).await })
+            .expect_err("body-only secondary limit must pause");
+        let (resume_at_ms, reason) = err.pause_details().expect("expected Paused");
+        assert_eq!(reason, PauseReason::RetryAfter);
+        assert!(resume_at_ms >= before + 60_000);
+        assert_eq!(handle.join().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn a_plain_403_is_returned_to_the_caller_not_retried() {
+        let (url, handle) =
+            spawn_script_stub(vec![StubResponse::status("403 Forbidden", "no access")]);
+        let transport = transport(&url, None, fast_options());
+        let response = drive(async { transport.get(&format!("{url}/items"), &[]).await })
+            .expect("statuses are the provider's business");
+        assert_eq!(response.status, 403);
+        assert_eq!(handle.join().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn requests_outside_the_bound_authority_are_refused_before_any_send() {
+        let registry = GovernorRegistry::default();
+        let transport = Transport::new(TransportParams {
+            provider: "github",
+            host: "api.github.com",
+            auth: None,
+            registry: &registry,
+            options: TransportOptions::default(),
+        })
+        .expect("transport");
+        // No stub, no network: every one of these must be refused by the URL guard alone.
+        for (url, why) in [
+            ("https://evil.example.com/items", "foreign host"),
+            ("https://api.github.com.evil.example.com/items", "suffix-spoofed host"),
+            ("http://api.github.com/items", "plaintext to a non-loopback host"),
+            ("https://api.github.com:8443/items", "non-default port without a bound one"),
+            ("not a url", "unparseable"),
+        ] {
+            let err = drive(async { transport.get(url, &[]).await }).expect_err(why);
+            assert!(matches!(err, TransportError::UrlOutsideBinding { .. }), "{why}: {err}");
+            assert_eq!(err.pause_details(), None);
+        }
+    }
+
+    #[test]
+    fn redirects_are_returned_without_following_an_unguarded_hop() {
+        let (url, origin) = spawn_script_stub(vec![StubResponse {
+            status: "302 Found",
+            // Port 9 has no test server: following this hop would fail the request.
+            headers: vec![("location".into(), "http://127.0.0.1:9/secret".into())],
+            body: String::new(),
+        }]);
+        let transport = transport(&url, None, fast_options());
+        let response = drive(async { transport.get(&format!("{url}/items"), &[]).await })
+            .expect("redirect is provider semantics");
+        assert_eq!(response.status, 302);
+        assert_eq!(origin.join().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn equivalent_authority_spellings_share_one_governor() {
+        let registry = GovernorRegistry::default();
+        let build = |host: &str| {
+            Transport::new(TransportParams {
+                provider: "github",
+                host,
+                auth: None,
+                registry: &registry,
+                options: TransportOptions::default(),
+            })
+            .expect("transport")
+        };
+        let lowercase = build("api.github.com");
+        let uppercase_default_port = build("API.GitHub.com:443");
+        assert!(Arc::ptr_eq(&lowercase.governor, &uppercase_default_port.governor));
+    }
+
+    #[test]
+    fn a_bound_port_pins_requests_to_that_port() {
+        let registry = GovernorRegistry::default();
+        let transport = Transport::new(TransportParams {
+            provider: "gitlab",
+            host: "gitlab.example.com:8443",
+            auth: None,
+            registry: &registry,
+            options: TransportOptions::default(),
+        })
+        .expect("transport");
+        let err = drive(async { transport.get("https://gitlab.example.com/x", &[]).await })
+            .expect_err("default port differs from the bound 8443");
+        assert!(matches!(err, TransportError::UrlOutsideBinding { .. }), "{err}");
+    }
+
+    #[test]
+    fn an_expired_pass_budget_pauses_before_any_send() {
+        use std::sync::atomic::{AtomicI64, Ordering};
+        let (url, handle) = spawn_script_stub(vec![]);
+        let now = Arc::new(AtomicI64::new(1_700_000_000_000));
+        let clock = {
+            let now = Arc::clone(&now);
+            Arc::new(move || now.load(Ordering::SeqCst))
+        };
+        let registry = GovernorRegistry::default();
+        let transport = Transport::with_clock(
+            TransportParams {
+                provider: "github",
+                host: "127.0.0.1",
+                auth: None,
+                registry: &registry,
+                options: TransportOptions { pass_budget_ms: 1_000, ..fast_options() },
+            },
+            clock,
+        )
+        .expect("transport");
+        now.fetch_add(1_001, Ordering::SeqCst);
+        let err = drive(async { transport.get(&format!("{url}/items"), &[]).await })
+            .expect_err("the pass budget is spent");
+        assert!(
+            matches!(err, TransportError::Paused { reason: PauseReason::PassBudget, .. }),
+            "{err:?}"
+        );
+        assert!(handle.join().unwrap().is_empty(), "nothing was sent past the deadline");
+    }
+
+    #[test]
+    fn bound_authority_parsing_accepts_valid_forms_and_rejects_malformed_ones() {
+        assert_eq!(
+            parse_bound_authority("API.GitHub.com").unwrap(),
+            ("api.github.com".to_string(), None)
+        );
+        assert_eq!(
+            parse_bound_authority("gitlab.example.com:8443").unwrap(),
+            ("gitlab.example.com".to_string(), Some(8443))
+        );
+        assert_eq!(parse_bound_authority("[::1]:9000").unwrap(), ("::1".to_string(), Some(9000)));
+        assert_eq!(parse_bound_authority("[::1]").unwrap(), ("::1".to_string(), None));
+        assert_eq!(parse_bound_authority("::1").unwrap(), ("::1".to_string(), None));
+        // Malformed authorities ERROR instead of silently re-pointing the binding at the
+        // scheme-default port.
+        for bad in [
+            "gitlab.example.com:not-a-port",
+            "gitlab.example.com:",
+            "gitlab.example.com:70000",
+            "[::1",
+            "[::1]x",
+            "[::1]:bad",
+            "[]",
+            ":8443",
+            "a:1:2",
+            "",
+        ] {
+            assert!(parse_bound_authority(bad).is_err(), "`{bad}` must be rejected");
+        }
+    }
+
+    #[test]
+    fn a_malformed_bound_authority_fails_construction() {
+        let registry = GovernorRegistry::default();
+        let err = Transport::new(TransportParams {
+            provider: "gitlab",
+            host: "gitlab.example.com:not-a-port",
+            auth: None,
+            registry: &registry,
+            options: TransportOptions::default(),
+        })
+        .err()
+        .expect("a malformed authority must fail fast");
+        assert!(err.to_string().contains("not-a-port"), "{err}");
+    }
+
+    #[test]
+    fn a_configured_but_missing_token_fails_construction() {
+        let registry = GovernorRegistry::default();
+        let err = Transport::new(TransportParams {
+            provider: "github",
+            host: "api.github.com",
+            auth: Some(&TrackerAuth::Env("RAG_RAT_TEST_UNSET_TOKEN_VAR".to_string())),
+            registry: &registry,
+            options: TransportOptions::default(),
+        })
+        .err()
+        .expect("fail fast, never degrade to anonymous");
+        assert!(err.to_string().contains("RAG_RAT_TEST_UNSET_TOKEN_VAR"), "{err}");
+    }
+
+    #[test]
+    fn retry_after_accepts_delta_seconds_and_http_dates() {
+        let mut headers = HeaderMap::new();
+        headers.insert(header::RETRY_AFTER, "60".parse().unwrap());
+        assert_eq!(retry_after_ms(&headers, 1_700_000_000_000), Some(60_000));
+
+        headers.insert(header::RETRY_AFTER, "Tue, 14 Nov 2023 22:14:20 GMT".parse().unwrap());
+        assert_eq!(retry_after_ms(&headers, 1_700_000_000_000), Some(60_000));
+    }
+}

--- a/crates/rag-rat-core/src/index/papertrail/transport/governor.rs
+++ b/crates/rag-rat-core/src/index/papertrail/transport/governor.rs
@@ -1,0 +1,762 @@
+//! Rate governance for the papertrail transport, one governor per (provider, host, token).
+//!
+//! Header-driven where the provider reports quota (GitHub `x-ratelimit-*`, GitLab `RateLimit-*`):
+//! after each response the governor updates its view and stops consuming once
+//! `remaining <= reserve × limit` — the reserved fraction (default 35%) stays untouched for the
+//! user's own CLI tools on the same token. Budget-driven fallback where headers are absent
+//! (Bitbucket-style per-hour endpoint-group quotas): a conservative fixed request budget per
+//! window. A `429`/`Retry-After` hold always wins over both.
+//!
+//! The governor is a pure state machine over injected wall-clock instants (`now_ms` parameters),
+//! so every pause/resume path is deterministic under test; the transport supplies real time.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use reqwest::header::HeaderMap;
+
+/// Fraction of a header-reported quota kept for the user's own tools on the same token: the
+/// governor stops consuming once `remaining <= reserve * limit`.
+pub(crate) const DEFAULT_RATE_LIMIT_RESERVE: f64 = 0.35;
+
+/// Resume horizon when a reserve pause has no `*-reset` header to anchor to: check back after a
+/// minute — the next response's headers re-establish the real window.
+const RESET_FALLBACK_MS: i64 = 60_000;
+
+/// Delta reset headers are anchored to each response's local receive time, so responses from the
+/// same provider window can differ slightly through latency/rounding. Treat nearby horizons as
+/// one window and ratchet quota down; real adjacent windows are minutes or hours apart.
+const RESET_DRIFT_TOLERANCE_MS: u64 = 10_000;
+
+/// `*-reset` values at or above this are Unix-epoch seconds (GitHub, GitLab); below it they are
+/// delta seconds (the IETF RateLimit draft form). The floor is ~2001-09-09 — no live reset
+/// timestamp is older, and no sane delta is longer.
+const EPOCH_SECONDS_FLOOR: i64 = 1_000_000_000;
+
+/// Identity of one governed quota pool. Two bindings that talk to the same host with the same
+/// token share a governor, so their consumption is jointly accounted.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct GovernorKey {
+    /// Provider id (`github`, `gitlab`, …) — distinguishes co-hosted APIs behind one host.
+    pub provider: String,
+    /// Host the binding talks to (`api.github.com`, a self-hosted GitLab).
+    pub host: String,
+    /// Fingerprint of the resolved token — never the token itself; `anonymous` without one.
+    pub token_fingerprint: String,
+}
+
+impl GovernorKey {
+    pub(crate) fn new(provider: &str, host: &str, token: Option<&str>) -> Self {
+        Self {
+            provider: provider.to_string(),
+            host: host.to_string(),
+            token_fingerprint: token_fingerprint(token),
+        }
+    }
+}
+
+/// Short sha256 fingerprint so the key never holds a copy of the secret. Eight bytes of digest
+/// are plenty to tell two tokens apart in an in-process map.
+fn token_fingerprint(token: Option<&str>) -> String {
+    use sha2::{Digest, Sha256};
+    match token.map(str::trim).filter(|t| !t.is_empty()) {
+        None => "anonymous".to_string(),
+        Some(token) =>
+            Sha256::digest(token.as_bytes())[..8].iter().map(|b| format!("{b:02x}")).collect(),
+    }
+}
+
+/// Fixed request budget for providers that report no quota headers: at most `max_requests` per
+/// `window_ms`, then pause until the window rolls.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct BudgetPolicy {
+    pub max_requests: u32,
+    pub window_ms: i64,
+}
+
+/// Conservative default: 300 requests/hour — well under Bitbucket's 1000/hour endpoint-group
+/// quotas even with several bindings sharing a workspace token.
+pub(crate) const DEFAULT_FALLBACK_BUDGET: BudgetPolicy =
+    BudgetPolicy { max_requests: 300, window_ms: 3_600_000 };
+
+#[derive(Debug, Clone)]
+pub(crate) struct GovernorConfig {
+    /// Stop-consuming threshold: paused while `remaining <= reserve * limit`.
+    pub reserve: f64,
+    /// Applied only while no header-reported quota view exists.
+    pub fallback_budget: BudgetPolicy,
+}
+
+impl Default for GovernorConfig {
+    fn default() -> Self {
+        Self { reserve: DEFAULT_RATE_LIMIT_RESERVE, fallback_budget: DEFAULT_FALLBACK_BUDGET }
+    }
+}
+
+/// One header-reported quota view. GitHub (`x-ratelimit-*`) and GitLab (`RateLimit-*`) report the
+/// same triple; the un-prefixed spelling also covers IETF-draft providers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct QuotaSnapshot {
+    pub limit: i64,
+    pub remaining: i64,
+    /// Wall-clock instant the provider window resets; `None` when the provider omits it.
+    pub reset_at_ms: Option<i64>,
+}
+
+impl QuotaSnapshot {
+    /// Parse a quota view out of response headers; `None` when the provider reports none (the
+    /// budget fallback governs then). `limit` and `remaining` are required and must be sane;
+    /// `reset` is optional and accepted as epoch seconds or delta seconds (see
+    /// [`EPOCH_SECONDS_FLOOR`]).
+    pub(crate) fn from_headers(headers: &HeaderMap, now_ms: i64) -> Option<Self> {
+        let read = |name: &str| headers.get(name)?.to_str().ok()?.trim().parse::<i64>().ok();
+        let quota_header = |suffix: &str| {
+            read(&format!("x-ratelimit-{suffix}")).or_else(|| read(&format!("ratelimit-{suffix}")))
+        };
+        let limit = quota_header("limit").filter(|limit| *limit > 0)?;
+        let remaining = quota_header("remaining").filter(|remaining| *remaining >= 0)?;
+        let reset_at_ms = quota_header("reset").filter(|reset| *reset >= 0).map(|reset| {
+            if reset >= EPOCH_SECONDS_FLOOR {
+                reset.saturating_mul(1000)
+            } else {
+                now_ms.saturating_add(reset.saturating_mul(1000))
+            }
+        });
+        Some(Self { limit, remaining, reset_at_ms })
+    }
+}
+
+/// Why an [`Admission`] came back paused.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PauseReason {
+    /// A `429`/`Retry-After` hold (or a backoff that would overrun the sync pass's budget).
+    RetryAfter,
+    /// Header-reported quota is at/below the user reserve; resume when the window resets.
+    QuotaReserve,
+    /// The headerless fallback budget for this window is spent.
+    RequestBudget,
+    /// The sync pass's wall-clock budget is spent; the next pass resumes from the kept cursor.
+    PassBudget,
+}
+
+impl PauseReason {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::RetryAfter => "retry_after",
+            Self::QuotaReserve => "quota_reserve",
+            Self::RequestBudget => "request_budget",
+            Self::PassBudget => "pass_budget",
+        }
+    }
+}
+
+impl std::fmt::Display for PauseReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Admission decision for one outbound request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Admission {
+    Proceed,
+    /// Stand down until `resume_at_ms`. The caller keeps its pagination cursor — the next sync
+    /// window resumes mid-pagination, nothing is dropped or refetched.
+    PausedUntil {
+        resume_at_ms: i64,
+        reason: PauseReason,
+    },
+}
+
+#[derive(Debug, Default)]
+struct GovernorState {
+    /// Latest header-reported quota; `None` until a response carries quota headers (and again
+    /// after a view goes stale past its reset).
+    quota: Option<QuotaSnapshot>,
+    /// Fallback-budget window accounting; consulted only while `quota` is `None`.
+    window_started_at_ms: Option<i64>,
+    window_requests: u32,
+    /// Hard hold from a `429`/`Retry-After`; wins over both quota and budget until it expires.
+    hold_until_ms: Option<i64>,
+}
+
+/// Shared, thread-safe rate governor for one [`GovernorKey`]. All decisions run against caller-
+/// supplied `now_ms` instants — the governor itself never reads the clock.
+#[derive(Debug)]
+pub(crate) struct RateGovernor {
+    config: GovernorConfig,
+    state: Mutex<GovernorState>,
+}
+
+impl RateGovernor {
+    pub(crate) fn new(config: GovernorConfig) -> Self {
+        Self { config, state: Mutex::new(GovernorState::default()) }
+    }
+
+    /// Decide whether one request may go out now. Every `Proceed` permanently debits the active
+    /// local quota view before returning: a timed-out send may still have consumed server-side
+    /// quota, and concurrent siblings must not all spend the same reported `remaining` slot.
+    pub(crate) fn admit(&self, now_ms: i64) -> Admission {
+        let mut state = self.state.lock().expect("governor mutex");
+        if let Some(hold) = state.hold_until_ms {
+            if now_ms < hold {
+                return Admission::PausedUntil {
+                    resume_at_ms: hold,
+                    reason: PauseReason::RetryAfter,
+                };
+            }
+            state.hold_until_ms = None;
+        }
+        if let Some(quota) = state.quota {
+            match quota.reset_at_ms {
+                // A view whose window already reset is stale: drop it and fall through to the
+                // budget lane; the next response re-establishes the real remaining.
+                Some(reset) if now_ms >= reset => state.quota = None,
+                _ => {
+                    let reserved_requests =
+                        (self.config.reserve * quota.limit as f64).ceil() as i64;
+                    // Judge the state AFTER this admission: fractional reserves round up, so a
+                    // limit of 99 at 35% keeps 35 whole requests, never 34.
+                    if quota.remaining == 0 || quota.remaining.saturating_sub(1) < reserved_requests
+                    {
+                        // No reset header to anchor the pause: materialize a short horizon into
+                        // the stored view so the stale-view drop above ends the pause instead of
+                        // it renewing forever.
+                        let resume_at_ms = quota.reset_at_ms.unwrap_or_else(|| {
+                            let resume = now_ms + RESET_FALLBACK_MS;
+                            if let Some(view) = state.quota.as_mut() {
+                                view.reset_at_ms = Some(resume);
+                            }
+                            resume
+                        });
+                        return Admission::PausedUntil {
+                            resume_at_ms,
+                            reason: PauseReason::QuotaReserve,
+                        };
+                    }
+                    // Debit at admission, not completion. Response snapshots merge monotonically
+                    // below, so failures without headers cannot refund a possibly consumed call.
+                    if let Some(view) = state.quota.as_mut() {
+                        view.remaining = view.remaining.saturating_sub(1);
+                    }
+                    return Admission::Proceed;
+                },
+            }
+        }
+        // Budget fallback: no live header view — count requests against the fixed window.
+        let window_ms = self.config.fallback_budget.window_ms.max(1);
+        let window_start = match state.window_started_at_ms {
+            Some(start) if now_ms.saturating_sub(start) < window_ms => start,
+            _ => {
+                state.window_started_at_ms = Some(now_ms);
+                state.window_requests = 0;
+                now_ms
+            },
+        };
+        if state.window_requests >= self.config.fallback_budget.max_requests {
+            return Admission::PausedUntil {
+                resume_at_ms: window_start + window_ms,
+                reason: PauseReason::RequestBudget,
+            };
+        }
+        state.window_requests += 1;
+        Admission::Proceed
+    }
+
+    /// Record the quota view a response reported. Merged monotonically: within the same provider
+    /// window `remaining` only ratchets DOWN — an out-of-order older response cannot raise it
+    /// back. Resetless views and nearby reset horizons are the same live window; an older window
+    /// is dropped and a genuinely newer window replaces the view. Never clears a `429` hold.
+    pub(crate) fn record_quota(&self, snapshot: QuotaSnapshot) {
+        let mut state = self.state.lock().expect("governor mutex");
+        state.quota = Some(match state.quota {
+            Some(current) => match (current.reset_at_ms, snapshot.reset_at_ms) {
+                (Some(current_reset), Some(new_reset))
+                    if new_reset.abs_diff(current_reset) <= RESET_DRIFT_TOLERANCE_MS =>
+                    merge_quota(current, snapshot, Some(current_reset.max(new_reset))),
+                (Some(current_reset), Some(new_reset)) if new_reset < current_reset => current,
+                (Some(_), Some(_)) => snapshot,
+                (None, None) => merge_quota(current, snapshot, None),
+                (Some(reset), None) => merge_quota(current, snapshot, Some(reset)),
+                (None, Some(reset)) => merge_quota(current, snapshot, Some(reset)),
+            },
+            None => snapshot,
+        });
+    }
+
+    /// Record a `429`/`Retry-After` hold: nothing on this key goes out before `until_ms`. Holds
+    /// only extend — a shorter later hold never shortens an earlier one.
+    pub(crate) fn record_hold(&self, until_ms: i64) {
+        let mut state = self.state.lock().expect("governor mutex");
+        state.hold_until_ms = Some(state.hold_until_ms.map_or(until_ms, |h| h.max(until_ms)));
+    }
+}
+
+fn merge_quota(
+    current: QuotaSnapshot,
+    snapshot: QuotaSnapshot,
+    reset_at_ms: Option<i64>,
+) -> QuotaSnapshot {
+    QuotaSnapshot {
+        limit: current.limit.max(snapshot.limit),
+        remaining: current.remaining.min(snapshot.remaining),
+        reset_at_ms,
+    }
+}
+
+/// Delay before retry `attempt` (0-based) of a rate-limited request: exponential from `base_ms`,
+/// but a server-provided `Retry-After` always wins when longer. The shift is clamped so a long
+/// retry storm cannot overflow — the per-pass wall-clock cap ends it far earlier anyway.
+pub(crate) fn backoff_delay_ms(attempt: u32, retry_after_ms: Option<i64>, base_ms: i64) -> i64 {
+    let exponential = base_ms.max(1).saturating_mul(1_i64 << attempt.min(20));
+    exponential.max(retry_after_ms.unwrap_or(0))
+}
+
+/// Process-wide registry: hands out the shared governor for a key, creating it on first sight
+/// with the caller's config (later callers on the same key inherit the existing governor).
+#[derive(Debug, Default)]
+pub(crate) struct GovernorRegistry {
+    inner: Mutex<HashMap<GovernorKey, Arc<RateGovernor>>>,
+}
+
+impl GovernorRegistry {
+    pub(crate) fn governor(&self, key: GovernorKey, config: &GovernorConfig) -> Arc<RateGovernor> {
+        Arc::clone(
+            self.inner
+                .lock()
+                .expect("governor registry mutex")
+                .entry(key)
+                .or_insert_with(|| Arc::new(RateGovernor::new(config.clone()))),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
+
+    use super::*;
+
+    const T0: i64 = 1_700_000_000_000;
+
+    fn headers(pairs: &[(&str, &str)]) -> HeaderMap {
+        let mut map = HeaderMap::new();
+        for (name, value) in pairs {
+            map.insert(
+                name.parse::<HeaderName>().expect("header name"),
+                HeaderValue::from_str(value).expect("header value"),
+            );
+        }
+        map
+    }
+
+    fn governor(reserve: f64, budget: BudgetPolicy) -> RateGovernor {
+        RateGovernor::new(GovernorConfig { reserve, fallback_budget: budget })
+    }
+
+    #[test]
+    fn pause_reasons_have_stable_machine_strings_and_display() {
+        for (reason, expected) in [
+            (PauseReason::RetryAfter, "retry_after"),
+            (PauseReason::QuotaReserve, "quota_reserve"),
+            (PauseReason::RequestBudget, "request_budget"),
+            (PauseReason::PassBudget, "pass_budget"),
+        ] {
+            assert_eq!(reason.as_str(), expected);
+            assert_eq!(reason.to_string(), expected);
+        }
+    }
+
+    #[test]
+    fn quota_snapshot_parses_github_style_headers() {
+        let map = headers(&[
+            ("x-ratelimit-limit", "5000"),
+            ("x-ratelimit-remaining", "4321"),
+            ("x-ratelimit-reset", "1700000123"),
+        ]);
+        assert_eq!(
+            QuotaSnapshot::from_headers(&map, T0),
+            Some(QuotaSnapshot {
+                limit: 5000,
+                remaining: 4321,
+                reset_at_ms: Some(1_700_000_123_000),
+            })
+        );
+    }
+
+    #[test]
+    fn quota_snapshot_parses_gitlab_style_headers() {
+        // GitLab spells them without the `x-` prefix (`RateLimit-*`); HeaderMap lookups are
+        // case-insensitive, so the canonical lowercase names cover the wire form.
+        let map = headers(&[
+            ("ratelimit-limit", "600"),
+            ("ratelimit-remaining", "599"),
+            ("ratelimit-reset", "1700000060"),
+        ]);
+        assert_eq!(
+            QuotaSnapshot::from_headers(&map, T0),
+            Some(QuotaSnapshot {
+                limit: 600,
+                remaining: 599,
+                reset_at_ms: Some(1_700_000_060_000)
+            })
+        );
+    }
+
+    #[test]
+    fn quota_snapshot_treats_small_reset_as_delta_seconds() {
+        // The IETF RateLimit draft form: `RateLimit-Reset: 30` means "in 30 seconds".
+        let map = headers(&[
+            ("ratelimit-limit", "100"),
+            ("ratelimit-remaining", "50"),
+            ("ratelimit-reset", "30"),
+        ]);
+        assert_eq!(QuotaSnapshot::from_headers(&map, T0).unwrap().reset_at_ms, Some(T0 + 30_000));
+    }
+
+    #[test]
+    fn quota_snapshot_requires_sane_limit_and_remaining() {
+        // Missing remaining.
+        assert_eq!(
+            QuotaSnapshot::from_headers(&headers(&[("x-ratelimit-limit", "100")]), T0),
+            None
+        );
+        // Missing limit.
+        assert_eq!(
+            QuotaSnapshot::from_headers(&headers(&[("x-ratelimit-remaining", "10")]), T0),
+            None
+        );
+        // Garbage values.
+        assert_eq!(
+            QuotaSnapshot::from_headers(
+                &headers(&[("x-ratelimit-limit", "many"), ("x-ratelimit-remaining", "10")]),
+                T0
+            ),
+            None
+        );
+        // Non-positive limit / negative remaining are not a usable view.
+        assert_eq!(
+            QuotaSnapshot::from_headers(
+                &headers(&[("x-ratelimit-limit", "0"), ("x-ratelimit-remaining", "0")]),
+                T0
+            ),
+            None
+        );
+        assert_eq!(
+            QuotaSnapshot::from_headers(
+                &headers(&[("x-ratelimit-limit", "100"), ("x-ratelimit-remaining", "-1")]),
+                T0
+            ),
+            None
+        );
+        // No quota headers at all.
+        assert_eq!(QuotaSnapshot::from_headers(&HeaderMap::new(), T0), None);
+    }
+
+    #[test]
+    fn admit_pauses_at_the_reserve_threshold_and_not_above_it() {
+        let governor = governor(0.35, DEFAULT_FALLBACK_BUDGET);
+        let reset = T0 + 60_000;
+        // remaining 36 > 35 = 0.35 × 100 → proceed.
+        governor.record_quota(QuotaSnapshot {
+            limit: 100,
+            remaining: 36,
+            reset_at_ms: Some(reset),
+        });
+        assert_eq!(governor.admit(T0), Admission::Proceed);
+        // remaining 35 <= 35 → paused until the provider window resets (threshold is <=).
+        governor.record_quota(QuotaSnapshot {
+            limit: 100,
+            remaining: 35,
+            reset_at_ms: Some(reset),
+        });
+        assert_eq!(governor.admit(T0), Admission::PausedUntil {
+            resume_at_ms: reset,
+            reason: PauseReason::QuotaReserve
+        });
+    }
+
+    #[test]
+    fn fractional_reserve_rounds_up_before_admitting() {
+        let fractional = governor(0.35, DEFAULT_FALLBACK_BUDGET);
+        let reset = T0 + 60_000;
+        fractional.record_quota(QuotaSnapshot {
+            limit: 99,
+            remaining: 35,
+            reset_at_ms: Some(reset),
+        });
+        assert_eq!(fractional.admit(T0), Admission::PausedUntil {
+            resume_at_ms: reset,
+            reason: PauseReason::QuotaReserve,
+        });
+        fractional.record_quota(QuotaSnapshot {
+            limit: 99,
+            remaining: 36,
+            reset_at_ms: Some(reset + 60_000),
+        });
+        assert_eq!(fractional.admit(T0), Admission::Proceed);
+
+        let no_reserve = governor(0.0, DEFAULT_FALLBACK_BUDGET);
+        no_reserve.record_quota(QuotaSnapshot {
+            limit: 99,
+            remaining: 0,
+            reset_at_ms: Some(reset),
+        });
+        assert!(matches!(no_reserve.admit(T0), Admission::PausedUntil { .. }));
+    }
+
+    #[test]
+    fn reserve_pause_resumes_once_the_window_resets() {
+        let governor = governor(0.35, DEFAULT_FALLBACK_BUDGET);
+        let reset = T0 + 60_000;
+        governor.record_quota(QuotaSnapshot {
+            limit: 100,
+            remaining: 10,
+            reset_at_ms: Some(reset),
+        });
+        assert!(matches!(governor.admit(T0), Admission::PausedUntil { .. }));
+        // At the reset instant the stale view is dropped and the request proceeds.
+        assert_eq!(governor.admit(reset), Admission::Proceed);
+    }
+
+    #[test]
+    fn reserve_pause_without_a_reset_header_materializes_a_resume_horizon() {
+        let governor = governor(0.35, DEFAULT_FALLBACK_BUDGET);
+        governor.record_quota(QuotaSnapshot { limit: 100, remaining: 10, reset_at_ms: None });
+        let expected_resume = T0 + RESET_FALLBACK_MS;
+        assert_eq!(governor.admit(T0), Admission::PausedUntil {
+            resume_at_ms: expected_resume,
+            reason: PauseReason::QuotaReserve,
+        });
+        // The horizon sticks (re-asking earlier keeps the same resume, not a sliding one) …
+        assert_eq!(governor.admit(T0 + 1), Admission::PausedUntil {
+            resume_at_ms: expected_resume,
+            reason: PauseReason::QuotaReserve,
+        });
+        // … and past it the pause ends instead of renewing forever.
+        assert_eq!(governor.admit(expected_resume), Admission::Proceed);
+    }
+
+    #[test]
+    fn budget_fallback_counts_requests_and_rolls_the_window() {
+        let budget = BudgetPolicy { max_requests: 3, window_ms: 10_000 };
+        let governor = governor(0.35, budget);
+        for i in 0..3 {
+            assert_eq!(governor.admit(T0 + i), Admission::Proceed, "request {i} within budget");
+        }
+        assert_eq!(governor.admit(T0 + 3), Admission::PausedUntil {
+            resume_at_ms: T0 + 10_000,
+            reason: PauseReason::RequestBudget,
+        });
+        // The next window admits again.
+        assert_eq!(governor.admit(T0 + 10_000), Admission::Proceed);
+    }
+
+    #[test]
+    fn a_live_header_view_supersedes_the_fallback_budget() {
+        // Exhaust a tiny budget, then let headers arrive: header quota is the ground truth, so
+        // requests proceed even though the local budget counter is spent.
+        let governor = governor(0.35, BudgetPolicy { max_requests: 1, window_ms: 10_000 });
+        assert_eq!(governor.admit(T0), Admission::Proceed);
+        assert!(matches!(governor.admit(T0 + 1), Admission::PausedUntil { .. }));
+        governor.record_quota(QuotaSnapshot {
+            limit: 100,
+            remaining: 90,
+            reset_at_ms: Some(T0 + 60_000),
+        });
+        assert_eq!(governor.admit(T0 + 2), Admission::Proceed);
+    }
+
+    #[test]
+    fn a_retry_after_hold_wins_over_healthy_quota_and_expires() {
+        let governor = governor(0.35, DEFAULT_FALLBACK_BUDGET);
+        governor.record_quota(QuotaSnapshot {
+            limit: 100,
+            remaining: 90,
+            reset_at_ms: Some(T0 + 60_000),
+        });
+        governor.record_hold(T0 + 5_000);
+        assert_eq!(governor.admit(T0), Admission::PausedUntil {
+            resume_at_ms: T0 + 5_000,
+            reason: PauseReason::RetryAfter
+        });
+        // A shorter later hold never shortens the earlier one.
+        governor.record_hold(T0 + 1_000);
+        assert_eq!(governor.admit(T0), Admission::PausedUntil {
+            resume_at_ms: T0 + 5_000,
+            reason: PauseReason::RetryAfter
+        });
+        assert_eq!(governor.admit(T0 + 5_000), Admission::Proceed);
+    }
+
+    #[test]
+    fn admissions_retain_their_quota_debit_without_a_response_snapshot() {
+        // 37 remaining, threshold 35: only TWO requests may be admitted — a third would spend
+        // the reserve. Completion without a newer snapshot must not refund either debit.
+        let governor = governor(0.35, DEFAULT_FALLBACK_BUDGET);
+        let reset = T0 + 60_000;
+        governor.record_quota(QuotaSnapshot {
+            limit: 100,
+            remaining: 37,
+            reset_at_ms: Some(reset),
+        });
+        assert_eq!(governor.admit(T0), Admission::Proceed, "effective 37");
+        assert_eq!(governor.admit(T0), Admission::Proceed, "effective 36");
+        assert!(
+            matches!(governor.admit(T0), Admission::PausedUntil {
+                reason: PauseReason::QuotaReserve,
+                ..
+            }),
+            "effective 35 <= reserve — a concurrent third must stand down"
+        );
+        // An out-of-order/header-only completion cannot raise the local view or reopen admission.
+        governor.record_quota(QuotaSnapshot {
+            limit: 100,
+            remaining: 37,
+            reset_at_ms: Some(reset),
+        });
+        assert!(matches!(governor.admit(T0 + 1), Admission::PausedUntil { .. }));
+
+        // A genuinely new provider window replaces the debited view and restores capacity.
+        governor.record_quota(QuotaSnapshot {
+            limit: 100,
+            remaining: 100,
+            reset_at_ms: Some(reset + 60_000),
+        });
+        assert_eq!(governor.admit(T0 + 1), Admission::Proceed);
+    }
+
+    #[test]
+    fn same_window_snapshots_merge_monotonically_and_new_windows_replace() {
+        let governor = governor(0.35, DEFAULT_FALLBACK_BUDGET);
+        let reset = T0 + 60_000;
+        governor.record_quota(QuotaSnapshot {
+            limit: 100,
+            remaining: 30,
+            reset_at_ms: Some(reset),
+        });
+        // An out-of-order OLDER response from the same window cannot raise `remaining` back.
+        governor.record_quota(QuotaSnapshot {
+            limit: 100,
+            remaining: 80,
+            reset_at_ms: Some(reset),
+        });
+        assert!(matches!(governor.admit(T0), Admission::PausedUntil {
+            reason: PauseReason::QuotaReserve,
+            ..
+        }));
+        // A late snapshot from a PREVIOUS window (earlier reset) is dropped entirely.
+        governor.record_quota(QuotaSnapshot {
+            limit: 100,
+            remaining: 90,
+            reset_at_ms: Some(reset - 30_000),
+        });
+        assert!(matches!(governor.admit(T0), Admission::PausedUntil { .. }));
+        // A NEWER window replaces the view outright.
+        governor.record_quota(QuotaSnapshot {
+            limit: 100,
+            remaining: 95,
+            reset_at_ms: Some(reset + 3_600_000),
+        });
+        assert_eq!(governor.admit(T0), Admission::Proceed);
+    }
+
+    #[test]
+    fn resetless_and_nearby_delta_reset_snapshots_merge_monotonically() {
+        let resetless = governor(0.35, DEFAULT_FALLBACK_BUDGET);
+        resetless.record_quota(QuotaSnapshot { limit: 100, remaining: 30, reset_at_ms: None });
+        resetless.record_quota(QuotaSnapshot { limit: 100, remaining: 80, reset_at_ms: None });
+        assert!(matches!(resetless.admit(T0), Admission::PausedUntil { .. }));
+
+        let governor = governor(0.35, DEFAULT_FALLBACK_BUDGET);
+        governor.record_quota(QuotaSnapshot {
+            limit: 100,
+            remaining: 30,
+            reset_at_ms: Some(T0 + 60_000),
+        });
+        // Same provider window, but a delayed delta-reset response computes a horizon 3s later.
+        governor.record_quota(QuotaSnapshot {
+            limit: 100,
+            remaining: 80,
+            reset_at_ms: Some(T0 + 63_000),
+        });
+        assert!(matches!(governor.admit(T0), Admission::PausedUntil { .. }));
+    }
+
+    #[test]
+    fn resetless_and_reset_anchored_snapshots_share_the_live_window() {
+        let reset = T0 + 60_000;
+        let anchored_first = governor(0.35, DEFAULT_FALLBACK_BUDGET);
+        anchored_first.record_quota(QuotaSnapshot {
+            limit: 100,
+            remaining: 30,
+            reset_at_ms: Some(reset),
+        });
+        anchored_first.record_quota(QuotaSnapshot { limit: 100, remaining: 80, reset_at_ms: None });
+        assert_eq!(anchored_first.admit(T0), Admission::PausedUntil {
+            resume_at_ms: reset,
+            reason: PauseReason::QuotaReserve,
+        });
+
+        let resetless_first = governor(0.35, DEFAULT_FALLBACK_BUDGET);
+        resetless_first.record_quota(QuotaSnapshot {
+            limit: 100,
+            remaining: 30,
+            reset_at_ms: None,
+        });
+        resetless_first.record_quota(QuotaSnapshot {
+            limit: 100,
+            remaining: 80,
+            reset_at_ms: Some(reset),
+        });
+        assert_eq!(resetless_first.admit(T0), Admission::PausedUntil {
+            resume_at_ms: reset,
+            reason: PauseReason::QuotaReserve,
+        });
+    }
+
+    #[test]
+    fn backoff_grows_exponentially_and_retry_after_wins_when_longer() {
+        assert_eq!(backoff_delay_ms(0, None, 1_000), 1_000);
+        assert_eq!(backoff_delay_ms(1, None, 1_000), 2_000);
+        assert_eq!(backoff_delay_ms(2, None, 1_000), 4_000);
+        // Retry-After longer than the schedule → Retry-After wins.
+        assert_eq!(backoff_delay_ms(0, Some(30_000), 1_000), 30_000);
+        // Retry-After shorter than the schedule → the schedule holds the floor.
+        assert_eq!(backoff_delay_ms(3, Some(1_000), 1_000), 8_000);
+        // A zero base can never spin a hot retry loop.
+        assert!(backoff_delay_ms(0, None, 0) >= 1);
+        // The shift clamp keeps huge attempts finite instead of overflowing.
+        assert!(backoff_delay_ms(63, None, 1_000) > 0);
+    }
+
+    #[test]
+    fn governor_key_fingerprints_tokens_without_storing_them() {
+        let with_token = GovernorKey::new("github", "api.github.com", Some("ghp_secret_token"));
+        let same_token = GovernorKey::new("github", "api.github.com", Some("ghp_secret_token"));
+        let other_token = GovernorKey::new("github", "api.github.com", Some("ghp_other_token"));
+        let anonymous = GovernorKey::new("github", "api.github.com", None);
+        assert_eq!(with_token, same_token);
+        assert_ne!(with_token, other_token);
+        assert_eq!(anonymous.token_fingerprint, "anonymous");
+        assert!(!with_token.token_fingerprint.contains("secret"), "never the token itself");
+        assert_eq!(with_token.token_fingerprint.len(), 16, "8 digest bytes as hex");
+        // Blank tokens govern as anonymous, not as a distinct pool.
+        assert_eq!(
+            GovernorKey::new("github", "api.github.com", Some("  ")).token_fingerprint,
+            "anonymous"
+        );
+    }
+
+    #[test]
+    fn registry_shares_one_governor_per_key() {
+        let registry = GovernorRegistry::default();
+        let key = GovernorKey::new("github", "api.github.com", Some("tok"));
+        let config = GovernorConfig::default();
+        let first = registry.governor(key.clone(), &config);
+        let second = registry.governor(key, &config);
+        assert!(Arc::ptr_eq(&first, &second), "same key → same governor");
+        let other = registry.governor(GovernorKey::new("github", "api.github.com", None), &config);
+        assert!(!Arc::ptr_eq(&first, &other), "different token → separate accounting");
+    }
+}

--- a/crates/rag-rat-core/src/index/papertrail/transport/mod.rs
+++ b/crates/rag-rat-core/src/index/papertrail/transport/mod.rs
@@ -1,0 +1,137 @@
+//! Shared HTTP substrate for the papertrail provider clients (#589): an async `reqwest`/rustls
+//! transport on the workspace tokio, a per-(provider, host, token) rate governor that keeps a
+//! user reserve (default 35%) of header-reported quota untouched, and secret-free auth
+//! resolution (env var / `token_command`). NO provider logic lives here — URL building,
+//! pagination, and payload mapping belong to the per-provider clients built on top (#591+).
+//!
+//! The transport's futures are driven through the papertrail module's `block_on` bridge at the
+//! synchronous entry points, exactly like the `PapertrailClient` trait methods.
+
+mod auth;
+mod client;
+mod governor;
+
+pub(crate) use auth::*;
+pub(crate) use client::*;
+pub(crate) use governor::*;
+
+#[cfg(test)]
+mod stub;
+
+#[cfg(test)]
+mod pagination_tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicI64, Ordering};
+
+    use super::stub::{StubResponse, spawn_script_stub};
+    use super::*;
+
+    const T0: i64 = 1_700_000_000_000;
+
+    /// Fake wall clock: every governor decision reads it, so pause/resume runs deterministically
+    /// with zero real sleeping.
+    fn fake_clock(now: &Arc<AtomicI64>) -> Arc<dyn Fn() -> i64 + Send + Sync> {
+        let now = Arc::clone(now);
+        Arc::new(move || now.load(Ordering::SeqCst))
+    }
+
+    fn drive<T>(future: impl Future<Output = T>) -> T {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("test runtime")
+            .block_on(future)
+    }
+
+    /// The generic paginated-fetch shape the provider clients will use: fetch pages from the
+    /// cursor, collecting items, until the stream ends — or the governor pauses, in which case
+    /// the cursor is KEPT where it stands so the next window resumes mid-pagination.
+    fn fetch_from_cursor(
+        transport: &Transport,
+        base: &str,
+        cursor: &mut u32,
+        collected: &mut Vec<i64>,
+    ) -> Result<(), TransportError> {
+        drive(async {
+            loop {
+                let response = transport.get(&format!("{base}/items?page={cursor}"), &[]).await?;
+                let page: serde_json::Value =
+                    serde_json::from_str(&response.body).expect("stub page json");
+                collected.extend(
+                    page["items"].as_array().expect("items").iter().map(|v| v.as_i64().unwrap()),
+                );
+                match page["next"].as_u64() {
+                    Some(next) => *cursor = next as u32,
+                    None => return Ok(()),
+                }
+            }
+        })
+    }
+
+    // The issue's acceptance scenario end-to-end: a paginated fetch whose second page's quota
+    // headers fall to the reserve pauses BEFORE the third request, keeps its cursor, and the
+    // next window resumes mid-pagination without dropping or duplicating a single item.
+    #[test]
+    fn paginated_fetch_pauses_at_the_reserve_and_resumes_without_loss_or_duplication() {
+        let reset_epoch_s = T0 / 1000 + 60;
+        let (url, handle) = spawn_script_stub(vec![
+            // Page 1: plenty of quota left (80 > 35 = 0.35 × 100).
+            StubResponse::ok_with_quota(r#"{"items":[1,2],"next":2}"#, 100, 80, reset_epoch_s),
+            // Page 2: the response itself succeeds, but its headers report the reserve reached
+            // (30 <= 35) — the pause lands before the NEXT request.
+            StubResponse::ok_with_quota(r#"{"items":[3,4],"next":3}"#, 100, 30, reset_epoch_s),
+            // Page 3, served in the next window: quota replenished, stream ends.
+            StubResponse::ok_with_quota(r#"{"items":[5,6]}"#, 100, 95, reset_epoch_s + 3600),
+        ]);
+        let now = Arc::new(AtomicI64::new(T0));
+        let registry = GovernorRegistry::default();
+        let transport = Transport::with_clock(
+            TransportParams {
+                provider: "github",
+                host: "127.0.0.1",
+                auth: None,
+                registry: &registry,
+                options: TransportOptions::default(),
+            },
+            fake_clock(&now),
+        )
+        .expect("transport");
+
+        let mut cursor = 1;
+        let mut collected = Vec::new();
+        let err = fetch_from_cursor(&transport, &url, &mut cursor, &mut collected)
+            .expect_err("must pause at the reserve");
+        let (resume_at_ms, reason) = err.pause_details().expect("expected Paused");
+        assert_eq!(reason, PauseReason::QuotaReserve);
+        assert_eq!(resume_at_ms, reset_epoch_s * 1000, "resume anchors to the provider reset");
+        assert_eq!(collected, vec![1, 2, 3, 4], "both delivered pages are kept");
+        assert_eq!(cursor, 3, "the cursor stays on the unfetched page");
+
+        // Retrying within the same window stays paused — and never touches the network.
+        let mut early_cursor = cursor;
+        let mut early_items = collected.clone();
+        assert!(matches!(
+            fetch_from_cursor(&transport, &url, &mut early_cursor, &mut early_items),
+            Err(TransportError::Paused { .. })
+        ));
+        assert_eq!(early_cursor, 3, "a paused retry moves nothing");
+
+        // The next window: resume from the KEPT cursor.
+        now.store(resume_at_ms + 1, Ordering::SeqCst);
+        fetch_from_cursor(&transport, &url, &mut cursor, &mut collected).expect("resumes cleanly");
+        assert_eq!(collected, vec![1, 2, 3, 4, 5, 6], "no item dropped, none duplicated");
+
+        // The wire agrees: each page was fetched exactly once, in order.
+        let pages: Vec<String> = handle
+            .join()
+            .unwrap()
+            .iter()
+            .map(|head| head.lines().next().unwrap().to_string())
+            .collect();
+        assert_eq!(pages, vec![
+            "GET /items?page=1 HTTP/1.1",
+            "GET /items?page=2 HTTP/1.1",
+            "GET /items?page=3 HTTP/1.1",
+        ]);
+    }
+}

--- a/crates/rag-rat-core/src/index/papertrail/transport/stub.rs
+++ b/crates/rag-rat-core/src/index/papertrail/transport/stub.rs
@@ -1,0 +1,177 @@
+//! Test-only scripted HTTP/1.1 stub for the transport tests, following the in-process stub
+//! discipline from the embedding backends: accepted sockets are forced BLOCKING (macOS/BSD
+//! `accept()` inherits the listener's `O_NONBLOCK`, which turns read timeouts into truncation)
+//! and every request is fully drained before the response is written (closing with unread bytes
+//! in the recv buffer is an abortive RST on Windows, surfacing as a transport error).
+
+use std::io::{Read as _, Write as _};
+use std::net::{TcpListener, TcpStream};
+use std::thread;
+use std::time::{Duration, Instant};
+
+/// One scripted response. The stub serves them in order, one connection each
+/// (`Connection: close`).
+pub(super) struct StubResponse {
+    pub status: &'static str,
+    pub headers: Vec<(String, String)>,
+    pub body: String,
+}
+
+impl StubResponse {
+    pub(super) fn ok(body: &str) -> Self {
+        Self::status("200 OK", body)
+    }
+
+    pub(super) fn status(status: &'static str, body: &str) -> Self {
+        Self { status, headers: Vec::new(), body: body.to_string() }
+    }
+
+    /// A `200 OK` carrying GitHub-style quota headers.
+    pub(super) fn ok_with_quota(
+        body: &str,
+        limit: i64,
+        remaining: i64,
+        reset_epoch_s: i64,
+    ) -> Self {
+        Self {
+            status: "200 OK",
+            headers: vec![
+                ("x-ratelimit-limit".to_string(), limit.to_string()),
+                ("x-ratelimit-remaining".to_string(), remaining.to_string()),
+                ("x-ratelimit-reset".to_string(), reset_epoch_s.to_string()),
+            ],
+            body: body.to_string(),
+        }
+    }
+}
+
+/// Spawn a stub on `127.0.0.1:0` that serves the scripted responses in order — one accepted
+/// connection per response — and returns the base URL plus a join handle yielding the captured
+/// request HEADS (request line + headers) in arrival order, so tests can assert the exact page
+/// sequence. Accepts poll with a deadline so a client-side bug can't hang the join forever.
+pub(super) fn spawn_script_stub(
+    responses: Vec<StubResponse>,
+) -> (String, thread::JoinHandle<Vec<String>>) {
+    spawn_script_stub_with_timeout(responses, Duration::from_secs(10))
+}
+
+fn spawn_script_stub_with_timeout(
+    responses: Vec<StubResponse>,
+    accept_timeout: Duration,
+) -> (String, thread::JoinHandle<Vec<String>>) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+    listener.set_nonblocking(true).expect("nonblocking listener");
+    let port = listener.local_addr().unwrap().port();
+    let handle = thread::spawn(move || {
+        let mut captured = Vec::new();
+        for response in responses {
+            let deadline = Instant::now() + accept_timeout;
+            let mut stream = loop {
+                match listener.accept() {
+                    Ok((stream, _)) => break stream,
+                    Err(_) if Instant::now() < deadline => thread::sleep(Duration::from_millis(5)),
+                    Err(_) => return captured,
+                }
+            };
+            if let Some(head) = read_full_request(&mut stream) {
+                captured.push(head);
+            }
+            let payload = format!(
+                "HTTP/1.1 {}\r\n{}Content-Type: application/json\r\nContent-Length: \
+                 {}\r\nConnection: close\r\n\r\n{}",
+                response.status,
+                response
+                    .headers
+                    .iter()
+                    .map(|(name, value)| format!("{name}: {value}\r\n"))
+                    .collect::<String>(),
+                response.body.len(),
+                response.body
+            );
+            let _ = stream.write_all(payload.as_bytes());
+            let _ = stream.flush();
+        }
+        captured
+    });
+    (format!("http://127.0.0.1:{port}"), handle)
+}
+
+/// Read the request head + its full `Content-Length` body (drained, discarded), returning the
+/// head. The blocking flip is the macOS/BSD fix; the full drain is the Windows fix.
+fn read_full_request(stream: &mut TcpStream) -> Option<String> {
+    stream.set_nonblocking(false).ok();
+    stream.set_read_timeout(Some(Duration::from_secs(2))).ok();
+    let mut raw = Vec::new();
+    let mut buf = [0u8; 8192];
+    loop {
+        if let Some(end) = raw.windows(4).position(|window| window == b"\r\n\r\n") {
+            let head = String::from_utf8_lossy(&raw[..end]).to_string();
+            let content_len = head
+                .to_ascii_lowercase()
+                .lines()
+                .find_map(|line| line.strip_prefix("content-length:"))
+                .and_then(|value| value.trim().parse::<usize>().ok())
+                .unwrap_or(0);
+            let body_start = end + 4;
+            while raw.len() < body_start + content_len {
+                match stream.read(&mut buf) {
+                    Ok(0) | Err(_) => break,
+                    Ok(n) => raw.extend_from_slice(&buf[..n]),
+                }
+            }
+            return Some(head);
+        }
+        match stream.read(&mut buf) {
+            Ok(0) | Err(_) => return None,
+            Ok(n) => raw.extend_from_slice(&buf[..n]),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::Shutdown;
+
+    use super::*;
+
+    fn connected_pair() -> (TcpStream, TcpStream) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind pair listener");
+        let client =
+            TcpStream::connect(listener.local_addr().expect("pair address")).expect("connect pair");
+        let (server, _) = listener.accept().expect("accept pair");
+        (client, server)
+    }
+
+    #[test]
+    fn scripted_stub_stops_waiting_after_its_accept_deadline() {
+        let (_, handle) =
+            spawn_script_stub_with_timeout(vec![StubResponse::ok("unused")], Duration::ZERO);
+        assert!(handle.join().expect("stub thread").is_empty());
+    }
+
+    #[test]
+    fn request_reader_returns_none_when_the_peer_closes_before_a_head() {
+        let (client, mut server) = connected_pair();
+        client.shutdown(Shutdown::Write).expect("close writer");
+        assert_eq!(read_full_request(&mut server), None);
+    }
+
+    #[test]
+    fn request_reader_keeps_the_head_when_a_declared_body_is_truncated() {
+        let (mut client, mut server) = connected_pair();
+        client.set_nodelay(true).expect("disable buffering");
+        let writer = thread::spawn(move || {
+            client
+                .write_all(b"POST /items HTTP/1.1\r\nContent-Length: 10\r\n\r\n")
+                .expect("write request head");
+            thread::sleep(Duration::from_millis(20));
+            client.write_all(b"short").expect("write partial body");
+            client.shutdown(Shutdown::Write).expect("close writer");
+        });
+        assert_eq!(
+            read_full_request(&mut server).as_deref(),
+            Some("POST /items HTTP/1.1\r\nContent-Length: 10")
+        );
+        writer.join().expect("writer thread");
+    }
+}

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/mod.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/mod.rs
@@ -229,7 +229,7 @@ fn markdown_config_for_root(root: PathBuf) -> Config {
 
 /// GitHub context for tests: the rag-rat repo itself, never the live `gh` CLI (#60).
 fn test_gh_ctx() -> papertrail::PapertrailContext {
-    papertrail::PapertrailContext::new(Some("cq27-dev/rag-rat"), false)
+    papertrail::PapertrailContext::new(Some("cq27-dev/rag-rat"))
 }
 
 /// Test-side bridge over the async sync entry point, mirroring the IndexDatabase boundary.

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/papertrail_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/papertrail_tests.rs
@@ -90,6 +90,27 @@ fn manual_sync_validates_client_and_routes_only_the_requested_github_identity() 
     assert_eq!(live.synced_items, 5);
     assert_eq!(live.failed_refs, 0);
 
+    let gitlab_only_ctx = papertrail::PapertrailContext {
+        trackers: vec![papertrail::ResolvedTracker {
+            provider: papertrail::Tracker::Gitlab,
+            project: "group/repo".to_string(),
+            base_url: None,
+            auth: None,
+            authentication: papertrail::TrackerAuthentication::AuthMissing,
+            tags: Vec::new(),
+        }],
+    };
+    let explicit_without_github_binding = papertrail::block_on(papertrail::sync_issue(
+        db.storage.connection(),
+        "cq27-dev/rag-rat#43",
+        Some(&MockGitHubClient),
+        false,
+        &gitlab_only_ctx,
+    ))
+    .unwrap();
+    assert_eq!(explicit_without_github_binding.synced_items, 5);
+    assert_eq!(explicit_without_github_binding.failed_refs, 0);
+
     let offline = papertrail::block_on(papertrail::sync_issue::<MockGitHubClient>(
         db.storage.connection(),
         "cq27-dev/rag-rat#43",
@@ -139,7 +160,7 @@ fn rationale_lookup_keeps_self_contained_github_refs_without_a_binding() {
         &mut |_| {},
     ))
     .unwrap();
-    db.set_papertrail_context(None, false);
+    db.set_papertrail_context(None);
 
     let evidence = db.rationale_search("cq27-dev/rag-rat#42", 10).unwrap();
     assert!(
@@ -162,7 +183,8 @@ fn production_discovery_persists_refs_for_every_configured_tracker() {
                 provider: papertrail::Tracker::Gitlab,
                 project: "group/sub/repo".to_string(),
                 base_url: None,
-                auth: None,
+                auth: Some(crate::config::TrackerAuth::Env("GITLAB_TOKEN".to_string())),
+                authentication: papertrail::TrackerAuthentication::AuthConfigured,
                 tags: Vec::new(),
             },
             papertrail::ResolvedTracker {
@@ -170,14 +192,29 @@ fn production_discovery_persists_refs_for_every_configured_tracker() {
                 project: "PROJ".to_string(),
                 base_url: Some("https://example.atlassian.net".to_string()),
                 auth: None,
+                authentication: papertrail::TrackerAuthentication::AuthMissing,
                 tags: Vec::new(),
             },
         ],
-        github_cli_available: false,
     };
 
     sync_from_refs_blocking(db.storage.connection(), &root, Some(&MockGitHubClient), true, &ctx)
         .unwrap();
+
+    let status = papertrail::status(db.storage.connection(), &ctx).unwrap();
+    assert_eq!(status.capabilities.len(), 2);
+    assert_eq!(
+        status.capabilities[0].authentication,
+        papertrail::TrackerAuthentication::AuthConfigured
+    );
+    assert_eq!(
+        status.capabilities[0].synchronization,
+        papertrail::TrackerSynchronization::ProviderClientPending
+    );
+    assert_eq!(
+        status.capabilities[1].authentication,
+        papertrail::TrackerAuthentication::AuthMissing
+    );
 
     let refs = db.papertrail_refs_for_path("docs/search.md", 10).unwrap();
     assert!(refs.iter().any(|reference| {

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/symbol_search_lookup.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/symbol_search_lookup.rs
@@ -1728,7 +1728,7 @@ fn papertrail_sync_caches_rationale_without_query_time_crawling() {
     let mut db = IndexDatabase::rebuild(&config).unwrap();
     // Resolve the repo context explicitly so db.rationale_search("Fixes #42") qualifies the bare
     // ref without shelling out to `gh` (#60).
-    db.set_papertrail_context(Some("cq27-dev/rag-rat"), false);
+    db.set_papertrail_context(Some("cq27-dev/rag-rat"));
     let mock = MockGitHubClient;
 
     let offline = sync_from_refs_blocking::<MockGitHubClient>(

--- a/crates/rag-rat-mcp/src/tools/tests.rs
+++ b/crates/rag-rat-mcp/src/tools/tests.rs
@@ -398,7 +398,7 @@ fn mcp_tool_calls_preserve_compatibility_shapes() {
     assert!(papertrail["evidence"].is_array());
 
     let sync_status = call_tool(&config.database, "papertrail_sync_status", json!({})).unwrap();
-    assert!(sync_status["capability"].is_string());
+    assert!(sync_status["capabilities"].is_array());
 
     let llm = call_tool(&config.database, "llm_status", json!({})).unwrap();
     assert_eq!(llm["embedding"]["state"], "MissingModel");

--- a/docs/config.md
+++ b/docs/config.md
@@ -604,11 +604,21 @@ URLs; Bitbucket `#N` (issues) and `/issues/N` / `/pull-requests/N` URLs; Jira ba
 (`PROJ-123`) for the bound project. A bare `#N` resolves against the first code-host binding
 only. A self-hosted binding's URL grammar matches its own host, not the cloud host.
 
-On the `#588` schema stack, all bindings participate in production reference discovery and
-annotation lookup, but the live network client remains GitHub-only. GitLab, Bitbucket, and Jira
-refs are persisted without being sent through the GitHub client. Parallel per-binding mirror sync
-lands with the shared provider transport from `#589`; until then these settings describe the
-stable configuration/cursor contract, not an already-active non-GitHub network mirror.
+All bindings participate in production reference discovery and annotation lookup, but live
+network synchronization remains GitHub-only. GitLab, Bitbucket, and Jira refs are persisted
+without being sent through the GitHub client. The shared transport resolves each binding's
+`auth` source and governs its quota, but native provider clients and parallel per-binding mirror
+dispatch land in the later provider-client PRs; these settings do not yet activate a non-GitHub
+network mirror.
 
-The `[papertrail]` cadence and rate-governance keys land with the provider mirror scheduler; they
-are intentionally not accepted before that production path can consume them.
+The shared transport keeps part of each header-reported quota untouched for the user's own tools.
+The reserve defaults to 35% and can be changed independently of the later provider clients:
+
+```toml
+[papertrail]
+rate_limit_reserve = 0.35   # finite fraction in 0.0 <= value < 1.0
+```
+
+Cadence keys (`probe_interval_secs`, `sync_min_interval_secs`, and `full_sync_interval_secs`) are
+reserved for the provider mirror scheduler and remain rejected until that production path
+consumes them.


### PR DESCRIPTION
Closes #589.

Rebased on current main and converged with #631 / #590.

## What changed

- adds a shared async reqwest/rustls transport for native papertrail providers
- adds a per-provider, canonical-host, and token-fingerprint rate governor with a configurable 35% default user quota reserve
- parses and validates `[papertrail].rate_limit_reserve`, then maps it into the transport governor; inactive cadence and unknown keys remain rejected
- ratchets same-window quota snapshots monotonically across missing or slightly drifting reset headers and rounds fractional reserves up before admission
- handles provider quota headers, conservative headerless budgets, HTTP-date/delta `Retry-After`, GitHub body-only secondary limits, exponential backoff, and per-pass wall-clock limits
- pins every request to its binding authority and leaves redirects to provider clients so auth and governor admission cannot be bypassed
- converges transport auth on #631’s `TrackerAuth`; no parallel `AuthSpec` remains
- reports authentication and synchronization per resolved tracker binding: env token presence is checked, token commands are deferred until explicit sync, cloud GitHub distinguishes authenticated/missing `gh`, and self-hosted bindings wait for native clients
- preserves pagination cursors when a sync window pauses at the reserve threshold

## Delivery boundary

All configured trackers participate in production reference discovery and annotation lookup. Live network synchronization remains GitHub-only in this stack; GitLab, Bitbucket, Jira, and self-hosted GitHub provider clients plus parallel dispatch are explicitly delivered by later provider-client PRs.

## Validation

- `cargo nextest run --workspace` — 2,527 passed
- focused review coverage — 70 passed
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`