### PR TITLE
feat(papertrail): add native GitHub project mirror

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,7 +489,7 @@ rag-rat clusters --limit 10
 rag-rat oracle run | status        # compiler-grade resolution (docs/oracle.md)
 rag-rat models list | install <model>
 rag-rat reconcile --changed-first --max-seconds 60 --batch-size 64
-rag-rat papertrail sync --from-refs
+rag-rat papertrail sync            # add --full to force a historical healing pass
 rag-rat memory list | show <id> | doctor | rebind <id>    # inspect / re-anchor repo memories
 rag-rat dream [--verify|--compact] [<id> --accept|--dismiss|--reset]   # memory-maintenance worklist
 rag-rat consolidate                # import a legacy per-repo index into the global store

--- a/crates/rag-rat-cli/src/cli.rs
+++ b/crates/rag-rat-cli/src/cli.rs
@@ -608,15 +608,9 @@ pub(crate) struct PapertrailArgs {
 pub(crate) enum PapertrailCommand {
     /// Sync tracker items (issues / change requests) into the papertrail.
     Sync {
-        /// Sync only refs already mentioned in indexed source/commits.
+        /// Force a complete historical re-walk to heal cached rows.
         #[arg(long)]
-        from_refs: bool,
-        /// Sync a single item (owner/repo#number).
-        #[arg(long)]
-        issue: Option<String>,
-        /// Do not hit the network; use cached evidence only.
-        #[arg(long)]
-        offline: bool,
+        full: bool,
     },
 }
 

--- a/crates/rag-rat-cli/src/commands/hooks.rs
+++ b/crates/rag-rat-cli/src/commands/hooks.rs
@@ -6,23 +6,14 @@ use std::fs;
 use rag_rat_core::Config;
 
 use crate::cli::{HookAction, HooksArgs, PapertrailArgs, PapertrailCommand};
-use crate::render::{print_output, render_papertrail_sync_progress};
+use crate::render::print_output;
 use crate::{MANAGED_HOOKS, git_paths, install_hook, is_rag_rat_hook, open_index};
 
 pub(crate) fn papertrail(config: &Config, args: &PapertrailArgs) -> anyhow::Result<()> {
     match &args.command {
-        PapertrailCommand::Sync { from_refs, issue, offline } => {
+        PapertrailCommand::Sync { full } => {
             let db = open_index(config)?;
-            let report = if let Some(issue) = issue {
-                db.papertrail_sync_issue(issue, *offline)?
-            } else if *from_refs {
-                db.papertrail_sync_from_refs_with_progress(
-                    *offline,
-                    render_papertrail_sync_progress,
-                )?
-            } else {
-                anyhow::bail!("papertrail sync needs --from-refs or --issue <owner/repo#number>");
-            };
+            let report = db.papertrail_sync(*full)?;
             print_output(&report)
         },
     }

--- a/crates/rag-rat-cli/src/main.rs
+++ b/crates/rag-rat-cli/src/main.rs
@@ -15,7 +15,6 @@ pub(crate) use commands::*;
 pub(crate) use fs_atomic::*;
 pub(crate) use hooks_support::*;
 use rag_rat_core::index::IndexProgress;
-use rag_rat_core::index::papertrail::PapertrailSyncAction;
 use rag_rat_core::search::lexical::SearchHit;
 use rag_rat_core::{Config, IndexDatabase};
 pub(crate) use render::*;

--- a/crates/rag-rat-cli/src/render.rs
+++ b/crates/rag-rat-cli/src/render.rs
@@ -192,32 +192,6 @@ pub(crate) fn render_reconcile_progress(progress: rag_rat_core::index::ai::Recon
 pub(crate) fn progress_percent(current: u64, total: u64) -> u64 {
     current.saturating_mul(100).checked_div(total).unwrap_or(100).min(100)
 }
-pub(crate) fn render_papertrail_sync_progress(
-    progress: rag_rat_core::index::papertrail::PapertrailSyncProgress,
-) {
-    match progress.action {
-        PapertrailSyncAction::Syncing => eprintln!(
-            "papertrail sync: {}/{} fetching {}#{}",
-            progress.current, progress.total, progress.project, progress.item_key
-        ),
-        PapertrailSyncAction::Skipped => eprintln!(
-            "papertrail sync: {}/{} skip cached {}#{}",
-            progress.current, progress.total, progress.project, progress.item_key
-        ),
-        PapertrailSyncAction::Synced => eprintln!(
-            "papertrail sync: {}/{} synced {}#{}",
-            progress.current, progress.total, progress.project, progress.item_key
-        ),
-        PapertrailSyncAction::Failed => eprintln!(
-            "papertrail sync: {}/{} failed {}#{}: {}",
-            progress.current,
-            progress.total,
-            progress.project,
-            progress.item_key,
-            progress.message.unwrap_or_else(|| "unknown error".to_string())
-        ),
-    }
-}
 /// Print a serializable result in the process-wide output format (TOON by default, JSON under
 /// `--json`). Renamed from `print_json` because it is no longer always JSON — the format is the
 /// global flag's choice, read from `output_format()`.

--- a/crates/rag-rat-core/src/config/raw.rs
+++ b/crates/rag-rat-core/src/config/raw.rs
@@ -127,10 +127,12 @@ impl TryFrom<RawTracker> for TrackerConfig {
                     return Err(ConfigError::TrackerBaseUrlNotHttp(url));
                 };
                 let authority = rest.split(['/', '?', '#']).next().unwrap_or_default();
+                let suffix = &rest[authority.len()..];
                 if !matches!(scheme, "http" | "https")
                     || authority.is_empty()
                     || authority.starts_with(':')
                     || authority.chars().any(char::is_whitespace)
+                    || !suffix.chars().all(|ch| ch == '/')
                 {
                     return Err(ConfigError::TrackerBaseUrlNotHttp(url));
                 }
@@ -161,10 +163,17 @@ impl TryFrom<RawTracker> for TrackerConfig {
 
 fn valid_tracker_project(provider: Tracker, project: &str) -> bool {
     let parts = project.split('/').collect::<Vec<_>>();
+    let valid_code_host_segment = |part: &&str| {
+        !part.is_empty()
+            && !matches!(*part, "." | "..")
+            && part.chars().all(|ch| {
+                !ch.is_control() && !ch.is_whitespace() && !matches!(ch, '?' | '#' | '%' | '\\')
+            })
+    };
     match provider {
         Tracker::Github | Tracker::Bitbucket =>
-            parts.len() == 2 && parts.iter().all(|part| !part.is_empty()),
-        Tracker::Gitlab => parts.len() >= 2 && parts.iter().all(|part| !part.is_empty()),
+            parts.len() == 2 && parts.iter().all(valid_code_host_segment),
+        Tracker::Gitlab => parts.len() >= 2 && parts.iter().all(valid_code_host_segment),
         Tracker::Jira =>
             project.chars().count() >= 2
                 && project.chars().next().is_some_and(|first| first.is_ascii_uppercase())

--- a/crates/rag-rat-core/src/config/tests.rs
+++ b/crates/rag-rat-core/src/config/tests.rs
@@ -147,6 +147,9 @@ fn tracker_projects_are_validated_by_provider() {
         ("github", "org/team/repo"),
         ("bitbucket", "workspace/repo/extra"),
         ("gitlab", "repo"),
+        ("github", "org/repo?query=1"),
+        ("github", "org/%2e%2e"),
+        ("gitlab", "group/../repo"),
         ("jira", "Proj"),
         ("jira", "A"),
     ] {
@@ -184,6 +187,9 @@ fn tracker_base_url_requires_a_nonempty_authority() {
         "gitlab.example.com",
         "https://:8443",
         "https://gitlab example.com",
+        "https://gitlab.example.com/path",
+        "https://gitlab.example.com?query=1",
+        "https://gitlab.example.com#fragment",
     ] {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(

--- a/crates/rag-rat-core/src/eval.rs
+++ b/crates/rag-rat-core/src/eval.rs
@@ -651,7 +651,7 @@ fn evaluate_query(
     if query.requires_papertrail_cache && !papertrail_cache_available(db)? {
         return Ok(skipped_report(
             query,
-            "papertrail cache is empty; run `rag-rat papertrail sync --from-refs`",
+            "papertrail cache is empty; run `rag-rat papertrail sync`",
         ));
     }
 

--- a/crates/rag-rat-core/src/index/papertrail/api.rs
+++ b/crates/rag-rat-core/src/index/papertrail/api.rs
@@ -1,6 +1,85 @@
 use super::*;
 use crate::index::{repo_meta, schema, scoped_table_row_count, set_repo_meta};
 
+pub(crate) async fn sync_mirror(
+    conn: &Connection,
+    root: &Path,
+    full: bool,
+    ctx: &PapertrailContext,
+) -> anyhow::Result<PapertrailSyncReport> {
+    ensure_unique_mirror_bindings(&ctx.trackers)?;
+    let refs = discover_and_store_refs(conn, root, ctx)?;
+    let registry = transport::GovernorRegistry::default();
+    let options = ctx.transport_options.clone();
+    let mut synced_items = 0;
+    let mut bindings = Vec::new();
+    let mut errors = Vec::new();
+    for binding in &ctx.trackers {
+        if binding.provider != Tracker::Github {
+            errors.push(PapertrailSyncError {
+                tracker: binding.provider,
+                project: binding.project.clone(),
+                item_key: String::new(),
+                status: "provider_client_pending".to_string(),
+                error: format!(
+                    "{} mirror client is not implemented yet",
+                    binding.provider.as_db_str()
+                ),
+            });
+            continue;
+        }
+        match GitHubClient::new(binding, &registry, options.clone()) {
+            Ok(client) => match mirror_binding(conn, binding, &client, full).await {
+                Ok(report) => {
+                    synced_items += report.stored_items;
+                    bindings.push(report);
+                },
+                Err(error) => errors.push(PapertrailSyncError {
+                    tracker: binding.provider,
+                    project: binding.project.clone(),
+                    item_key: String::new(),
+                    status: "failed".to_string(),
+                    error: error.to_string(),
+                }),
+            },
+            Err(error) => errors.push(PapertrailSyncError {
+                tracker: binding.provider,
+                project: binding.project.clone(),
+                item_key: String::new(),
+                status: "authentication_or_transport".to_string(),
+                error: error.to_string(),
+            }),
+        }
+    }
+    let repo_id = schema::active_repo_id(conn)?;
+    set_repo_meta(conn, &repo_id, "papertrail_last_sync_ms", &now_ms().to_string())?;
+    Ok(PapertrailSyncReport {
+        offline: false,
+        discovered_refs: refs.len(),
+        skipped_refs: 0,
+        failed_refs: errors.len(),
+        synced_items,
+        bindings,
+        errors,
+        status: status(conn, ctx)?,
+    })
+}
+
+fn ensure_unique_mirror_bindings(trackers: &[ResolvedTracker]) -> anyhow::Result<()> {
+    let mut seen = BTreeSet::new();
+    for binding in trackers {
+        anyhow::ensure!(
+            seen.insert((binding.provider.as_db_str(), binding.project.as_str())),
+            "duplicate papertrail binding for {} project `{}`; mirror cache and cursor identity \
+             require one binding per provider/project",
+            binding.provider.as_db_str(),
+            binding.project
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
 pub(crate) async fn sync_from_refs<C: PapertrailClient>(
     conn: &Connection,
     root: &Path,
@@ -10,6 +89,7 @@ pub(crate) async fn sync_from_refs<C: PapertrailClient>(
 ) -> anyhow::Result<PapertrailSyncReport> {
     sync_from_refs_with_progress(conn, root, client, offline, ctx, |_| {}).await
 }
+#[cfg(test)]
 pub(crate) async fn sync_from_refs_with_progress<C: PapertrailClient>(
     conn: &Connection,
     root: &Path,
@@ -43,10 +123,12 @@ pub(crate) async fn sync_from_refs_with_progress<C: PapertrailClient>(
         skipped_refs: sync.skipped_refs,
         failed_refs: sync.failed_refs,
         synced_items: sync.synced_items,
+        bindings: Vec::new(),
         errors: sync.errors,
         status: status(conn, ctx)?,
     })
 }
+#[cfg(test)]
 pub(crate) async fn sync_issue<C: PapertrailClient>(
     conn: &Connection,
     issue_ref: &str,
@@ -86,6 +168,7 @@ pub(crate) async fn sync_issue<C: PapertrailClient>(
         skipped_refs: sync.skipped_refs,
         failed_refs: sync.failed_refs,
         synced_items: sync.synced_items,
+        bindings: Vec::new(),
         errors: sync.errors,
         status: status(conn, ctx)?,
     })
@@ -105,11 +188,6 @@ pub(crate) fn status(
         )?;
         Ok(u64::try_from(count).unwrap_or_default())
     };
-    let needs_github_cli = ctx
-        .trackers
-        .iter()
-        .any(|binding| binding.provider == Tracker::Github && binding.base_url.is_none());
-    let github_cli_available = needs_github_cli && github_cli_available();
     Ok(PapertrailStatus {
         refs: scoped_table_row_count(conn, "papertrail_refs", &repo_id)?,
         issues: items_by_kind(ItemKind::Issue)?,
@@ -124,15 +202,15 @@ pub(crate) fn status(
                 tracker: binding.provider,
                 project: binding.project.clone(),
                 authentication: binding.authentication,
-                synchronization: tracker_synchronization(binding, github_cli_available),
+                synchronization: tracker_synchronization(binding),
             })
             .collect(),
     })
 }
 
-/// The legacy `gh api` client is cloud-GitHub-only. Discovered refs follow the binding that claimed
-/// their source text, so a self-hosted binding waits for its native provider client rather than
-/// accidentally querying github.com. Explicit manual refs are routed directly by [`sync_issue`].
+/// Test-only compatibility routing for the retired reference-driven sync fixtures. Production
+/// synchronization uses [`sync_mirror`]; references are annotations only.
+#[cfg(test)]
 fn discovered_ref_uses_legacy_github_client(
     ctx: &PapertrailContext,
     reference: &PapertrailRef,
@@ -158,13 +236,9 @@ fn discovered_ref_uses_legacy_github_client(
         .is_some_and(|(binding_index, _)| ctx.trackers[binding_index].base_url.is_none())
 }
 
-fn tracker_synchronization(
-    binding: &ResolvedTracker,
-    github_cli_available: bool,
-) -> TrackerSynchronization {
-    match (binding.provider, binding.base_url.is_none(), github_cli_available) {
-        (Tracker::Github, true, true) => TrackerSynchronization::LegacyGithubCli,
-        (Tracker::Github, true, false) => TrackerSynchronization::LegacyGithubCliMissing,
+fn tracker_synchronization(binding: &ResolvedTracker) -> TrackerSynchronization {
+    match binding.provider {
+        Tracker::Github => TrackerSynchronization::Native,
         _ => TrackerSynchronization::ProviderClientPending,
     }
 }
@@ -319,7 +393,9 @@ pub(crate) fn mark_fallback_evidence(evidence: &mut [PapertrailEvidence]) {
 
 #[cfg(test)]
 mod capability_tests {
+    use super::super::transport::stub::{StubResponse, spawn_script_stub};
     use super::*;
+    use crate::index::schema;
 
     fn github(base_url: Option<&str>) -> ResolvedTracker {
         ResolvedTracker {
@@ -332,73 +408,110 @@ mod capability_tests {
         }
     }
 
-    fn reference() -> PapertrailRef {
-        PapertrailRef {
-            tracker: Tracker::Github,
-            project: "o/r".to_string(),
-            item_key: "1".to_string(),
-            item_kind: Some(ItemKind::Issue),
-            ref_kind: "explicit".to_string(),
-            source_kind: "test".to_string(),
-            source_path: None,
-            source_commit: None,
-            source_text: "o/r#1".to_string(),
-        }
+    #[test]
+    fn synchronization_reports_native_github_for_cloud_and_enterprise() {
+        assert_eq!(tracker_synchronization(&github(None)), TrackerSynchronization::Native);
+        let enterprise = PapertrailContext {
+            trackers: vec![github(Some("https://github.example.com"))],
+            ..PapertrailContext::default()
+        };
+        assert_eq!(
+            tracker_synchronization(&enterprise.trackers[0]),
+            TrackerSynchronization::Native
+        );
     }
 
     #[test]
-    fn synchronization_reports_missing_gh_and_keeps_enterprise_off_the_legacy_path() {
-        assert_eq!(
-            tracker_synchronization(&github(None), false),
-            TrackerSynchronization::LegacyGithubCliMissing
-        );
-        assert_eq!(
-            tracker_synchronization(&github(None), true),
-            TrackerSynchronization::LegacyGithubCli
-        );
-        let enterprise =
-            PapertrailContext { trackers: vec![github(Some("https://github.example.com"))] };
-        assert_eq!(
-            tracker_synchronization(&enterprise.trackers[0], true),
-            TrackerSynchronization::ProviderClientPending
-        );
-        assert!(!discovered_ref_uses_legacy_github_client(&enterprise, &reference()));
-        assert!(discovered_ref_uses_legacy_github_client(
-            &PapertrailContext::default(),
-            &reference()
-        ));
-
-        let cloud = PapertrailContext { trackers: vec![github(None)] };
-        let mut cross_repo = reference();
-        cross_repo.project = "other/repo".to_string();
-        cross_repo.item_kind = None;
-        cross_repo.source_text = "https://github.com/other/repo/issues/1".to_string();
-        assert!(
-            discovered_ref_uses_legacy_github_client(&cloud, &cross_repo),
-            "fully-qualified cloud refs can be fetched by gh regardless of the binding project"
-        );
-
-        let mixed = PapertrailContext {
-            trackers: vec![github(None), ResolvedTracker {
-                project: "enterprise/repo".to_string(),
-                ..github(Some("https://github.example.com"))
-            }],
+    fn manual_mirror_dispatches_every_resolved_github_binding() {
+        let script = |project: &str| {
+            vec![
+                StubResponse::ok(&format!(
+                    r#"{{"incomplete_results":false,"items":[{{"number":1,"html_url":"https://example.test/{project}/issues/1","state":"open","title":"{project}","body":"","updated_at":"2026-01-01T00:00:00Z","labels":[]}}]}}"#
+                )),
+                StubResponse::ok("[]"),
+                StubResponse::ok(r#"{"incomplete_results":false,"items":[]}"#),
+                StubResponse::ok(r#"{"incomplete_results":false,"items":[]}"#),
+                StubResponse::ok(r#"{"incomplete_results":false,"items":[]}"#),
+                StubResponse::ok("[]"),
+                StubResponse::ok("[]"),
+            ]
         };
-        let mut enterprise = reference();
-        enterprise.project = "enterprise/other".to_string();
-        enterprise.item_kind = None;
-        enterprise.source_text = "https://github.example.com/enterprise/other/issues/1".to_string();
-        assert!(
-            !discovered_ref_uses_legacy_github_client(&mixed, &enterprise),
-            "the Enterprise binding that claimed the URL keeps it off github.com"
-        );
+        let (first_url, first_handle) = spawn_script_stub(script("a/one"));
+        let (second_url, second_handle) = spawn_script_stub(script("b/two"));
+        let binding = |project: &str, base_url: String| ResolvedTracker {
+            provider: Tracker::Github,
+            project: project.to_string(),
+            base_url: Some(base_url),
+            auth: None,
+            authentication: TrackerAuthentication::AuthMissing,
+            tags: Vec::new(),
+        };
+        let ctx = PapertrailContext {
+            trackers: vec![binding("a/one", first_url), binding("b/two", second_url)],
+            ..PapertrailContext::default()
+        };
+        let conn = Connection::open_in_memory().unwrap();
+        schema::apply(&conn).unwrap();
+        let report = block_on(sync_mirror(&conn, Path::new("."), false, &ctx)).unwrap();
+        assert_eq!(report.synced_items, 2);
+        assert_eq!(report.bindings.len(), 2);
+        assert_eq!(report.bindings[0].project, "a/one");
+        assert_eq!(report.bindings[1].project, "b/two");
+        assert_eq!(report.status.issues, 2);
+        assert_eq!(first_handle.join().unwrap().len(), 7);
+        assert_eq!(second_handle.join().unwrap().len(), 7);
+    }
 
-        let mut migrated_pull = reference();
-        migrated_pull.item_kind = None;
-        migrated_pull.source_text = "https://github.com/o/r/pull/1".to_string();
+    #[test]
+    fn manual_mirror_rejects_duplicate_provider_projects_before_dispatch() {
+        let mut first = github(Some("https://github.com"));
+        first.tags = vec!["first".to_string()];
+        let mut second = github(Some("https://github.example.com"));
+        second.tags = vec!["second".to_string()];
+        let ctx =
+            PapertrailContext { trackers: vec![first, second], ..PapertrailContext::default() };
+        let conn = Connection::open_in_memory().unwrap();
+        schema::apply(&conn).unwrap();
+
+        let error = block_on(sync_mirror(&conn, Path::new("."), false, &ctx)).unwrap_err();
         assert!(
-            discovered_ref_uses_legacy_github_client(&cloud, &migrated_pull),
-            "a migrated NULL kind remains compatible with syntax that now identifies a PR"
+            error.to_string().contains("duplicate papertrail binding for github project `o/r`")
         );
+        let refs: i64 =
+            conn.query_row("SELECT COUNT(*) FROM papertrail_refs", [], |row| row.get(0)).unwrap();
+        assert_eq!(refs, 0);
+    }
+
+    #[test]
+    fn manual_mirror_reports_pending_invalid_and_failed_bindings_independently() {
+        let (failed_url, failed_handle) =
+            spawn_script_stub(vec![StubResponse::status("500 Internal Server Error", "boom")]);
+        let tracker = |provider, project: &str, base_url: Option<String>| ResolvedTracker {
+            provider,
+            project: project.to_string(),
+            base_url,
+            auth: None,
+            authentication: TrackerAuthentication::AuthMissing,
+            tags: Vec::new(),
+        };
+        let ctx = PapertrailContext {
+            trackers: vec![
+                tracker(Tracker::Gitlab, "group/repo", Some("https://gitlab.com".to_string())),
+                tracker(Tracker::Github, "bad/origin", Some("not an absolute URL".to_string())),
+                tracker(Tracker::Github, "fails/http", Some(failed_url)),
+            ],
+            ..PapertrailContext::default()
+        };
+        let conn = Connection::open_in_memory().unwrap();
+        schema::apply(&conn).unwrap();
+
+        let report = block_on(sync_mirror(&conn, Path::new("."), false, &ctx)).unwrap();
+        assert_eq!(report.bindings.len(), 0);
+        assert_eq!(report.failed_refs, 3);
+        assert_eq!(
+            report.errors.iter().map(|error| error.status.as_str()).collect::<Vec<_>>(),
+            vec!["provider_client_pending", "authentication_or_transport", "failed"]
+        );
+        assert_eq!(failed_handle.join().unwrap().len(), 1);
     }
 }

--- a/crates/rag-rat-core/src/index/papertrail/evidence.rs
+++ b/crates/rag-rat-core/src/index/papertrail/evidence.rs
@@ -234,6 +234,7 @@ pub(crate) fn ref_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<PapertrailRef
         source_text: row.get(8)?,
     })
 }
+#[cfg(test)]
 pub(crate) fn refs(conn: &Connection) -> anyhow::Result<Vec<PapertrailRef>> {
     let repo_id = crate::index::schema::active_repo_id(conn)?;
     let mut stmt = conn.prepare(

--- a/crates/rag-rat-core/src/index/papertrail/github.rs
+++ b/crates/rag-rat-core/src/index/papertrail/github.rs
@@ -1,0 +1,1216 @@
+//! Native GitHub provider client. Endpoint construction, pagination decoding, quota-lane
+//! selection, and GitHub payload mapping live here; mirror policy stays in `mirror`.
+
+use reqwest::Url;
+use reqwest::header::{ETAG, IF_NONE_MATCH, LINK};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use super::transport::{GovernorRegistry, Transport, TransportOptions, TransportParams};
+use super::*;
+
+const ACCEPT: &str = "application/vnd.github+json";
+const API_VERSION: &str = "2022-11-28";
+const SEARCH_BACKFILL_STREAM: &str = "search_backfill";
+
+#[derive(Debug, Serialize, Deserialize)]
+struct SearchContinuation {
+    #[serde(default)]
+    kind: SearchKind,
+    #[serde(default)]
+    cycle_before: Option<String>,
+    #[serde(default)]
+    cycle_boundary: Option<String>,
+    boundary: Option<String>,
+    total_count: Option<u64>,
+    fetched: usize,
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum SearchKind {
+    #[default]
+    Issue,
+    PullRequest,
+}
+
+impl SearchKind {
+    fn qualifier(self) -> &'static str {
+        match self {
+            Self::Issue => "is:issue",
+            Self::PullRequest => "is:pull-request",
+        }
+    }
+}
+
+pub(crate) struct GitHubClient {
+    api_origin: String,
+    core: Transport,
+    search: Transport,
+}
+
+impl GitHubClient {
+    pub(crate) fn new(
+        binding: &ResolvedTracker,
+        registry: &GovernorRegistry,
+        options: TransportOptions,
+    ) -> anyhow::Result<Self> {
+        anyhow::ensure!(binding.provider == Tracker::Github, "not a GitHub binding");
+        let parsed = match binding.base_url.as_deref() {
+            None => Url::parse("https://api.github.com")?,
+            Some(base) => {
+                let mut base = Url::parse(base)?;
+                anyhow::ensure!(
+                    matches!(base.scheme(), "http" | "https"),
+                    "GitHub base URL must use http(s)"
+                );
+                anyhow::ensure!(
+                    base.username().is_empty() && base.password().is_none(),
+                    "GitHub base URL must not contain credentials"
+                );
+                anyhow::ensure!(
+                    matches!(base.path(), "" | "/")
+                        && base.query().is_none()
+                        && base.fragment().is_none(),
+                    "GitHub base URL must be an origin without a path, query, or fragment"
+                );
+                base.set_path("/api/v3");
+                base
+            },
+        };
+        let host =
+            parsed.host_str().ok_or_else(|| anyhow::anyhow!("GitHub API origin has no host"))?;
+        let authority_host = if host.contains(':') && !host.starts_with('[') {
+            format!("[{host}]")
+        } else {
+            host.to_string()
+        };
+        let authority = parsed
+            .port()
+            .map_or_else(|| authority_host.clone(), |port| format!("{authority_host}:{port}"));
+        let api_origin = parsed.as_str().trim_end_matches('/').to_string();
+        let token = transport::resolve_token(binding.auth.as_ref())?;
+        let transport = |lane| {
+            Transport::new_with_token(
+                TransportParams {
+                    provider: "github",
+                    lane,
+                    host: &authority,
+                    auth: None,
+                    registry,
+                    options: options.clone(),
+                },
+                token.as_deref(),
+            )
+        };
+        Ok(Self { api_origin, core: transport("core")?, search: transport("search")? })
+    }
+
+    fn endpoint(&self, path: &str) -> String {
+        format!("{}/{}", self.api_origin, path.trim_start_matches('/'))
+    }
+
+    async fn get_json(
+        &self,
+        transport: &Transport,
+        url: &str,
+    ) -> anyhow::Result<(Value, Option<String>)> {
+        let response = transport.get(url, &github_headers()).await?;
+        ensure_success(response.status, &response.body)?;
+        let next = next_link(&response.headers)?;
+        Ok((serde_json::from_str(&response.body)?, next))
+    }
+
+    async fn resolve_pull(&self, item: &mut PapertrailItem) -> anyhow::Result<()> {
+        if item.item_kind == ItemKind::ChangeRequest {
+            let url = self.endpoint(&format!("repos/{}/pulls/{}", item.project, item.item_key));
+            let (value, _) = self.get_json(&self.core, &url).await?;
+            enrich_item_from_pull_value(item, &value);
+        }
+        Ok(())
+    }
+
+    fn search_url(&self, project: &str, before: &str, kind: SearchKind) -> anyhow::Result<String> {
+        validate_github_project(project)?;
+        let mut url = Url::parse(&self.endpoint("search/issues"))?;
+        url.query_pairs_mut()
+            .append_pair("q", &format!("repo:{project} {} updated:<{before}", kind.qualifier()))
+            .append_pair("sort", "updated")
+            .append_pair("order", "desc")
+            .append_pair("per_page", "100");
+        Ok(url.into())
+    }
+}
+
+impl PapertrailClient for GitHubClient {
+    fn comment_streams(&self) -> &'static [&'static str] {
+        &["issue_comments", "review_comments"]
+    }
+
+    async fn item(
+        &self,
+        project: &str,
+        _kind: ItemKind,
+        key: &str,
+    ) -> anyhow::Result<PapertrailItem> {
+        validate_github_project(project)?;
+        let url = self.endpoint(&format!("repos/{project}/issues/{key}"));
+        let (value, _) = self.get_json(&self.core, &url).await?;
+        validate_positive_id(&value, "number", "GitHub item")?;
+        anyhow::ensure!(
+            value["updated_at"].as_str().is_some(),
+            "GitHub item has no valid updated_at"
+        );
+        let mut item = item_from_issue_value(project, &value);
+        self.resolve_pull(&mut item).await?;
+        Ok(item)
+    }
+
+    async fn item_comments(
+        &self,
+        project: &str,
+        kind: ItemKind,
+        key: &str,
+    ) -> anyhow::Result<Vec<PapertrailComment>> {
+        let mut comments = Vec::new();
+        for stream in self.item_comment_streams(kind) {
+            let mut cursor =
+                PageCursor { stream: Some((*stream).to_string()), ..PageCursor::default() };
+            loop {
+                let page = self.item_comments_page(project, kind, key, &cursor).await?;
+                comments.extend(page.comments);
+                let Some(next) = page.next else { break };
+                cursor = next;
+            }
+        }
+        Ok(comments)
+    }
+
+    fn item_comment_streams(&self, kind: ItemKind) -> &'static [&'static str] {
+        match kind {
+            ItemKind::Issue => &["issue_comments"],
+            ItemKind::ChangeRequest => &["issue_comments", "reviews", "review_comments"],
+        }
+    }
+
+    async fn item_comments_page(
+        &self,
+        project: &str,
+        kind: ItemKind,
+        key: &str,
+        cursor: &PageCursor,
+    ) -> anyhow::Result<CommentsPage> {
+        validate_github_project(project)?;
+        let stream = cursor.stream.as_deref().unwrap_or("issue_comments");
+        let path = match stream {
+            "issue_comments" => format!("repos/{project}/issues/{key}/comments"),
+            "reviews" if kind == ItemKind::ChangeRequest => {
+                format!("repos/{project}/pulls/{key}/reviews")
+            },
+            "review_comments" if kind == ItemKind::ChangeRequest => {
+                format!("repos/{project}/pulls/{key}/comments")
+            },
+            _ => anyhow::bail!("unknown GitHub item-comment stream `{stream}` for {kind:?}"),
+        };
+        let url = cursor.page_token.clone().unwrap_or_else(|| with_per_page(self.endpoint(&path)));
+        let (value, next_url) = self.get_json(&self.core, &url).await?;
+        let values = value
+            .as_array()
+            .ok_or_else(|| anyhow::anyhow!("GitHub item comments returned a non-array page"))?;
+        for value in values {
+            validate_positive_id(value, "id", "GitHub item comment")?;
+        }
+        let comments = values
+            .iter()
+            .map(|value| match stream {
+                "issue_comments" => comment_from_value(project, kind, key, value),
+                "reviews" => review_to_comment_from_value(project, kind, key, value),
+                "review_comments" =>
+                    review_comment_to_comment_from_value(project, kind, key, value),
+                _ => unreachable!("validated stream"),
+            })
+            .collect();
+        let next = next_url.map(|page_token| PageCursor {
+            stream: Some(stream.to_string()),
+            page_token: Some(page_token),
+            ..PageCursor::default()
+        });
+        Ok(CommentsPage { comments, next })
+    }
+
+    async fn enrich_item(&self, item: &mut PapertrailItem) -> anyhow::Result<()> {
+        self.resolve_pull(item).await
+    }
+
+    async fn items_page(&self, project: &str, cursor: &PageCursor) -> anyhow::Result<ItemsPage> {
+        validate_github_project(project)?;
+        if cursor.updated_before.is_some() && cursor.updated_since.is_some() {
+            anyhow::bail!("an item page cannot be both delta and backfill");
+        }
+        let (transport, url, search) = if let Some(next) = cursor.page_token.clone() {
+            let is_search = cursor.stream.as_deref() == Some(SEARCH_BACKFILL_STREAM)
+                || next.contains("/search/issues?");
+            (if is_search { &self.search } else { &self.core }, next, is_search)
+        } else if let Some(before) = cursor.updated_before.as_deref() {
+            (&self.search, self.search_url(project, before, SearchKind::Issue)?, true)
+        } else {
+            let mut url = Url::parse(&self.endpoint(&format!("repos/{project}/issues")))?;
+            {
+                let mut query = url.query_pairs_mut();
+                query
+                    .append_pair("state", "all")
+                    .append_pair("sort", "updated")
+                    // Keep the first page as a consumed prefix. The mirror advances only to that
+                    // page's inclusive upper timestamp when mutable REST continuations exist.
+                    .append_pair("direction", "asc")
+                    .append_pair("per_page", "100");
+                if let Some(since) = cursor.updated_since.as_deref() {
+                    query.append_pair("since", since);
+                }
+            }
+            (&self.core, url.into(), false)
+        };
+        let (value, next_url) = self.get_json(transport, &url).await?;
+        let (values, next, backfill_boundary) = if search {
+            let page = search_items(&value)?;
+            let mut state = match cursor.provider_state.as_deref() {
+                Some(state) => serde_json::from_str::<SearchContinuation>(state)?,
+                None => SearchContinuation {
+                    kind: SearchKind::Issue,
+                    cycle_before: cursor.updated_before.clone(),
+                    cycle_boundary: None,
+                    boundary: None,
+                    total_count: None,
+                    fetched: 0,
+                },
+            };
+            // Pre-split cursors represent one combined issue/PR Search stream. Finish that
+            // persisted stream at its original tie boundary; switching it into the split cycle
+            // would lose the outer backfill boundary when the new PR phase is empty.
+            let legacy_combined = cursor.provider_state.is_some()
+                && state.cycle_before.is_none()
+                && state.cycle_boundary.is_none();
+            if !legacy_combined {
+                state.cycle_before = state.cycle_before.or_else(|| cursor.updated_before.clone());
+            }
+            if state.boundary.is_none() {
+                state.boundary = search_boundary(page)?;
+                state.total_count = value["total_count"].as_u64();
+                state.fetched = 0;
+                state.cycle_boundary =
+                    safe_search_boundary(state.cycle_boundary.take(), state.boundary.clone());
+            }
+            state.fetched = state.fetched.saturating_add(page.len());
+            let mut reached_older_item = false;
+            let mut values = Vec::new();
+            for item in page {
+                let updated_at = search_item_updated_at(item)?;
+                if state.boundary.as_deref().is_some_and(|boundary| updated_at < boundary) {
+                    reached_older_item = true;
+                    break;
+                }
+                values.push(item.clone());
+            }
+            let next_url = (!reached_older_item).then_some(next_url).flatten();
+            if next_url.is_none()
+                && !reached_older_item
+                && let Some(total_count) = state.total_count
+            {
+                anyhow::ensure!(
+                    u64::try_from(state.fetched).unwrap_or(u64::MAX) >= total_count,
+                    "GitHub Search capped the result set before the timestamp tie was drained"
+                );
+            }
+            let next = if let Some(page_token) = next_url {
+                Some(PageCursor {
+                    stream: Some(SEARCH_BACKFILL_STREAM.to_string()),
+                    updated_before: if legacy_combined {
+                        state.boundary.clone()
+                    } else {
+                        state.cycle_boundary.clone().or_else(|| state.cycle_before.clone())
+                    },
+                    page_token: Some(page_token),
+                    provider_state: Some(serde_json::to_string(&state)?),
+                    ..PageCursor::default()
+                })
+            } else if state.kind == SearchKind::Issue && !legacy_combined {
+                let cycle_before = state
+                    .cycle_before
+                    .clone()
+                    .ok_or_else(|| anyhow::anyhow!("GitHub Search continuation lost its cutoff"))?;
+                state.kind = SearchKind::PullRequest;
+                state.boundary = None;
+                state.total_count = None;
+                state.fetched = 0;
+                Some(PageCursor {
+                    stream: Some(SEARCH_BACKFILL_STREAM.to_string()),
+                    updated_before: state
+                        .cycle_boundary
+                        .clone()
+                        .or_else(|| Some(cycle_before.clone())),
+                    page_token: Some(self.search_url(
+                        project,
+                        &cycle_before,
+                        SearchKind::PullRequest,
+                    )?),
+                    provider_state: Some(serde_json::to_string(&state)?),
+                    ..PageCursor::default()
+                })
+            } else {
+                None
+            };
+            let boundary = if legacy_combined && next.is_none() {
+                state.boundary.clone()
+            } else {
+                (state.kind == SearchKind::PullRequest && next.is_none())
+                    .then(|| state.cycle_boundary.clone())
+                    .flatten()
+            };
+            (values, next, boundary)
+        } else {
+            (
+                value
+                    .as_array()
+                    .ok_or_else(|| anyhow::anyhow!("GitHub issues response is not an array"))?
+                    .to_vec(),
+                next_url.map(|page_token| PageCursor {
+                    stream: None,
+                    updated_since: cursor.updated_since.clone(),
+                    updated_before: cursor.updated_before.clone(),
+                    page_token: Some(page_token),
+                    provider_state: None,
+                }),
+                None,
+            )
+        };
+        for value in &values {
+            validate_positive_id(value, "number", "GitHub item")?;
+            anyhow::ensure!(
+                value["updated_at"].as_str().is_some(),
+                "GitHub item has no valid updated_at"
+            );
+        }
+        let items =
+            values.iter().map(|value| item_from_issue_value(project, value)).collect::<Vec<_>>();
+        Ok(ItemsPage { items, next, backfill_boundary })
+    }
+
+    async fn comments_page(
+        &self,
+        project: &str,
+        cursor: &PageCursor,
+    ) -> anyhow::Result<CommentsPage> {
+        validate_github_project(project)?;
+        let since = cursor.updated_since.as_deref();
+        let stream = |path: &str| -> anyhow::Result<String> {
+            let mut url = Url::parse(&self.endpoint(path))?;
+            let mut query = url.query_pairs_mut();
+            query
+                .append_pair("per_page", "100")
+                .append_pair("sort", "updated")
+                // Ascending order gives the mirror a conservative consumed frontier at the first
+                // page's inclusive upper timestamp even though later page numbers are mutable.
+                .append_pair("direction", "asc");
+            if let Some(since) = since {
+                query.append_pair("since", since);
+            }
+            drop(query);
+            Ok(url.into())
+        };
+        let stream_name = cursor.stream.as_deref().unwrap_or("issue_comments");
+        let (path, anchored) = match stream_name {
+            "issue_comments" => (format!("repos/{project}/issues/comments"), false),
+            "review_comments" => (format!("repos/{project}/pulls/comments"), true),
+            other => anyhow::bail!("unknown GitHub comment stream `{other}`"),
+        };
+        let url = if let Some(next) = cursor.page_token.clone() { next } else { stream(&path)? };
+        let (value, next_url) = self.get_json(&self.core, &url).await?;
+        let values = value
+            .as_array()
+            .ok_or_else(|| anyhow::anyhow!("GitHub comments response is not an array"))?;
+        let mut comments = Vec::new();
+        for value in values {
+            if let Some(comment) = repo_comment_from_value(project, value, anchored) {
+                validate_positive_id(value, "id", "GitHub repository comment")?;
+                anyhow::ensure!(
+                    value["updated_at"].as_str().is_some(),
+                    "GitHub repository comment has no valid updated_at"
+                );
+                comments.push(comment);
+            }
+        }
+        let next = next_url.map(|page_token| PageCursor {
+            stream: Some(stream_name.to_string()),
+            updated_since: cursor.updated_since.clone(),
+            updated_before: None,
+            page_token: Some(page_token),
+            provider_state: None,
+        });
+        Ok(CommentsPage { comments, next })
+    }
+
+    async fn freshness_probe(
+        &self,
+        project: &str,
+        probe: &FreshnessProbe,
+    ) -> anyhow::Result<FreshnessResult> {
+        validate_github_project(project)?;
+        let mut url = Url::parse(&self.endpoint(&format!("repos/{project}/issues")))?;
+        url.query_pairs_mut()
+            .append_pair("state", "all")
+            .append_pair("sort", "updated")
+            .append_pair("direction", "desc")
+            .append_pair("per_page", "1");
+        let mut headers = github_headers();
+        if let Some(etag) = probe.etag.as_deref() {
+            headers.push((IF_NONE_MATCH.as_str(), etag));
+        }
+        let response = self.core.get(url.as_str(), &headers).await?;
+        let etag = response
+            .headers
+            .get(ETAG)
+            .and_then(|value| value.to_str().ok())
+            .map(str::to_string)
+            .or_else(|| probe.etag.clone());
+        if response.status == 304 {
+            return Ok(FreshnessResult { latest: None, etag, not_modified: true });
+        }
+        ensure_success(response.status, &response.body)?;
+        let value: Value = serde_json::from_str(&response.body)?;
+        let latest = value
+            .as_array()
+            .and_then(|items| items.first())
+            .and_then(|item| item["updated_at"].as_str())
+            .map(str::to_string);
+        Ok(FreshnessResult {
+            latest: probe_advance(latest, probe.updated_since.as_deref()),
+            etag,
+            not_modified: false,
+        })
+    }
+}
+
+fn validate_positive_id(value: &Value, field: &str, resource: &str) -> anyhow::Result<()> {
+    anyhow::ensure!(
+        value[field].as_u64().is_some_and(|id| id > 0),
+        "{resource} has no valid {field}"
+    );
+    Ok(())
+}
+
+fn github_headers() -> Vec<(&'static str, &'static str)> {
+    vec![("accept", ACCEPT), ("x-github-api-version", API_VERSION)]
+}
+
+fn validate_github_project(project: &str) -> anyhow::Result<()> {
+    let mut segments = project.split('/');
+    let owner = segments.next().unwrap_or_default();
+    let repository = segments.next().unwrap_or_default();
+    let safe = |segment: &str| {
+        !segment.is_empty()
+            && !matches!(segment, "." | "..")
+            && segment.chars().all(|ch| {
+                !ch.is_control() && !ch.is_whitespace() && !matches!(ch, '?' | '#' | '%' | '\\')
+            })
+    };
+    anyhow::ensure!(
+        segments.next().is_none() && safe(owner) && safe(repository),
+        "invalid GitHub project `{project}`"
+    );
+    Ok(())
+}
+
+fn with_per_page(url: String) -> String {
+    format!("{url}?per_page=100")
+}
+
+fn ensure_success(status: u16, body: &str) -> anyhow::Result<()> {
+    if status == 404 {
+        return Err(PapertrailClientError::ItemNotFound.into());
+    }
+    anyhow::ensure!((200..300).contains(&status), "GitHub HTTP {status}: {body}");
+    Ok(())
+}
+
+fn search_items(value: &Value) -> anyhow::Result<&[Value]> {
+    anyhow::ensure!(
+        !value["incomplete_results"].as_bool().unwrap_or(true),
+        "GitHub Search returned incomplete_results; refusing to advance backfill"
+    );
+    value["items"]
+        .as_array()
+        .map(Vec::as_slice)
+        .ok_or_else(|| anyhow::anyhow!("GitHub Search response has no items array"))
+}
+
+fn search_boundary(items: &[Value]) -> anyhow::Result<Option<String>> {
+    let timestamps =
+        items.iter().map(search_item_updated_at).collect::<anyhow::Result<Vec<_>>>()?;
+    Ok(timestamps.into_iter().min().map(str::to_string))
+}
+
+fn search_item_updated_at(item: &Value) -> anyhow::Result<&str> {
+    item["updated_at"]
+        .as_str()
+        .ok_or_else(|| anyhow::anyhow!("GitHub Search item has no updated_at boundary"))
+}
+
+fn safe_search_boundary(left: Option<String>, right: Option<String>) -> Option<String> {
+    match (left, right) {
+        // Each split stream has consumed everything newer than its own tie boundary. Descend only
+        // below the newer boundary: the older stream may replay a suffix, but the newer stream
+        // cannot skip the interval it has not consumed yet.
+        (Some(left), Some(right)) => Some(left.max(right)),
+        (left, right) => left.or(right),
+    }
+}
+
+fn next_link(headers: &reqwest::header::HeaderMap) -> anyhow::Result<Option<String>> {
+    let Some(link) = headers.get(LINK) else { return Ok(None) };
+    let link = link.to_str()?;
+    Ok(link.split(',').find_map(|part| {
+        let (url, rel) = part.trim().split_once(';')?;
+        rel.trim().eq(r#"rel="next""#).then(|| url.trim().trim_matches(['<', '>']).to_string())
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::transport::stub::{StubResponse, spawn_script_stub};
+    use super::*;
+
+    fn binding(base_url: String) -> ResolvedTracker {
+        ResolvedTracker {
+            provider: Tracker::Github,
+            project: "o/r".to_string(),
+            base_url: Some(base_url),
+            auth: None,
+            authentication: TrackerAuthentication::AuthMissing,
+            tags: Vec::new(),
+        }
+    }
+
+    fn issue(number: i64) -> String {
+        format!(
+            r#"{{"number":{number},"html_url":"{{BASE}}/o/r/issues/{number}","state":"open","title":"item","body":"body","created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-02T00:00:00Z","labels":[{{"name":"bug"}}]}}"#
+        )
+    }
+
+    #[test]
+    fn enterprise_binding_keeps_items_comments_pagination_search_and_probe_on_its_origin() {
+        let mut first_comments = StubResponse::ok(r#"[{"id":10,"body":"first"}]"#);
+        first_comments.headers.push((
+            "Link".to_string(),
+            "<{BASE}/api/v3/repos/o/r/issues/1/comments?per_page=100&page=2>; rel=\"next\""
+                .to_string(),
+        ));
+        let mut not_modified = StubResponse::status("304 Not Modified", "");
+        not_modified.headers.push(("ETag".to_string(), "\"v1\"".to_string()));
+        let (base, handle) = spawn_script_stub(vec![
+            StubResponse::ok(&issue(1)),
+            first_comments,
+            StubResponse::ok(r#"[{"id":11,"body":"second"}]"#),
+            StubResponse::ok(&format!(r#"{{"incomplete_results":false,"items":[{}]}}"#, issue(1))),
+            not_modified,
+        ]);
+        let registry = GovernorRegistry::default();
+        let client =
+            GitHubClient::new(&binding(base), &registry, TransportOptions::default()).unwrap();
+
+        let item = block_on(client.item("o/r", ItemKind::Issue, "1")).unwrap();
+        assert_eq!(item.tags, vec!["bug"]);
+        let comments = block_on(client.item_comments("o/r", ItemKind::Issue, "1")).unwrap();
+        assert_eq!(comments.len(), 2);
+        let page = block_on(client.items_page("o/r", &PageCursor {
+            updated_before: Some(INITIAL_BOUNDARY.to_string()),
+            ..PageCursor::default()
+        }))
+        .unwrap();
+        assert_eq!(page.items.len(), 1);
+        let probe = block_on(client.freshness_probe("o/r", &FreshnessProbe {
+            updated_since: Some("2026-01-02T00:00:00Z".to_string()),
+            etag: Some("\"v1\"".to_string()),
+        }))
+        .unwrap();
+        assert!(probe.not_modified);
+
+        let requests = handle.join().unwrap();
+        assert_eq!(requests.len(), 5);
+        assert!(requests.iter().all(|request| request.starts_with("GET /api/v3/")));
+        assert!(requests[4].to_ascii_lowercase().contains("if-none-match: \"v1\""));
+    }
+
+    #[test]
+    fn cross_origin_pagination_is_rejected_before_following_it() {
+        let mut response = StubResponse::ok(r#"[{"id":10,"body":"first"}]"#);
+        response.headers.push((
+            "Link".to_string(),
+            "<https://api.github.com/repos/o/r/issues/1/comments?page=2>; rel=\"next\"".to_string(),
+        ));
+        let (base, handle) = spawn_script_stub(vec![response]);
+        let registry = GovernorRegistry::default();
+        let client =
+            GitHubClient::new(&binding(base), &registry, TransportOptions::default()).unwrap();
+        let error = block_on(client.item_comments("o/r", ItemKind::Issue, "1")).unwrap_err();
+        assert!(error.to_string().contains("outside the binding"), "{error:#}");
+        assert_eq!(handle.join().unwrap().len(), 1, "the foreign URL was never requested");
+    }
+
+    #[test]
+    fn item_comment_resources_return_one_provider_page_at_a_time() {
+        let mut first = StubResponse::ok(r#"[{"id":10,"body":"first"}]"#);
+        first.headers.push((
+            "Link".to_string(),
+            "<{BASE}/api/v3/repos/o/r/issues/1/comments?page=2>; rel=\"next\"".to_string(),
+        ));
+        let (base, handle) =
+            spawn_script_stub(vec![first, StubResponse::ok(r#"[{"id":11,"body":"second"}]"#)]);
+        let client = GitHubClient::new(
+            &binding(base),
+            &GovernorRegistry::default(),
+            TransportOptions::default(),
+        )
+        .unwrap();
+        let first_page =
+            block_on(client.item_comments_page("o/r", ItemKind::Issue, "1", &PageCursor {
+                stream: Some("issue_comments".to_string()),
+                ..PageCursor::default()
+            }))
+            .unwrap();
+        assert_eq!(first_page.comments.len(), 1);
+        let second_page = block_on(client.item_comments_page(
+            "o/r",
+            ItemKind::Issue,
+            "1",
+            first_page.next.as_ref().unwrap(),
+        ))
+        .unwrap();
+        assert_eq!(second_page.comments.len(), 1);
+        assert!(second_page.next.is_none());
+        assert_eq!(handle.join().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn constructor_validates_provider_and_api_origin() {
+        let registry = GovernorRegistry::default();
+        let mut tracker = binding("https://github.example.com/".to_string());
+        tracker.provider = Tracker::Gitlab;
+        assert!(GitHubClient::new(&tracker, &registry, TransportOptions::default()).is_err());
+
+        tracker.provider = Tracker::Github;
+        tracker.base_url = Some("not an absolute URL".to_string());
+        assert!(GitHubClient::new(&tracker, &registry, TransportOptions::default()).is_err());
+        for invalid in [
+            "https://github.example.com/path",
+            "https://github.example.com?query=1",
+            "https://github.example.com#fragment",
+        ] {
+            tracker.base_url = Some(invalid.to_string());
+            assert!(GitHubClient::new(&tracker, &registry, TransportOptions::default()).is_err());
+        }
+
+        tracker.base_url = Some("http://[::1]:8443".to_string());
+        let client = GitHubClient::new(&tracker, &registry, TransportOptions::default()).unwrap();
+        assert_eq!(client.api_origin, "http://[::1]:8443/api/v3");
+
+        tracker.base_url = None;
+        let client = GitHubClient::new(&tracker, &registry, TransportOptions::default()).unwrap();
+        assert_eq!(client.api_origin, "https://api.github.com");
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn multi_lane_client_resolves_a_token_command_once() {
+        let counter = tempfile::NamedTempFile::new().unwrap();
+        let mut tracker = binding("http://127.0.0.1:9".to_string());
+        tracker.auth = Some(crate::config::TrackerAuth::TokenCommand(format!(
+            "printf x >> {}; printf token",
+            counter.path().display()
+        )));
+        GitHubClient::new(&tracker, &GovernorRegistry::default(), TransportOptions::default())
+            .unwrap();
+        assert_eq!(std::fs::read_to_string(counter.path()).unwrap(), "x");
+    }
+
+    #[test]
+    fn malformed_project_is_rejected_before_a_request() {
+        let (base, handle) = spawn_script_stub(Vec::new());
+        let client = GitHubClient::new(
+            &binding(base),
+            &GovernorRegistry::default(),
+            TransportOptions::default(),
+        )
+        .unwrap();
+        let error =
+            block_on(client.items_page("owner/repo?leak=1", &PageCursor::default())).unwrap_err();
+        assert!(error.to_string().contains("invalid GitHub project"));
+        assert!(handle.join().unwrap().is_empty());
+    }
+
+    #[test]
+    fn pull_item_and_all_comment_kinds_are_mapped() {
+        let pull_issue = r#"{"pull_request":{},"number":7,"html_url":"{BASE}/o/r/pull/7","state":"open","title":"change","body":"body","updated_at":"2026-01-02T00:00:00Z","labels":[]}"#;
+        let (base, handle) = spawn_script_stub(vec![
+            StubResponse::ok(pull_issue),
+            StubResponse::ok(r#"{"state":"closed","merged_at":"2026-01-03T00:00:00Z"}"#),
+            StubResponse::ok(r#"[{"id":10,"body":"thread"}]"#),
+            StubResponse::ok(
+                r#"[{"id":11,"body":"review","state":"APPROVED","submitted_at":"2026-01-03T01:00:00Z"}]"#,
+            ),
+            StubResponse::ok(r#"[{"id":12,"body":"anchored","path":"src/lib.rs"}]"#),
+        ]);
+        let registry = GovernorRegistry::default();
+        let client =
+            GitHubClient::new(&binding(base), &registry, TransportOptions::default()).unwrap();
+
+        let item = block_on(client.item("o/r", ItemKind::Issue, "7")).unwrap();
+        assert_eq!(item.item_kind, ItemKind::ChangeRequest);
+        assert_eq!(item.state, "closed");
+        assert_eq!(item.merged_at.as_deref(), Some("2026-01-03T00:00:00Z"));
+        let comments = block_on(client.item_comments("o/r", ItemKind::ChangeRequest, "7")).unwrap();
+        assert_eq!(comments.len(), 3);
+        assert_eq!(comments[1].review_state.as_deref(), Some("APPROVED"));
+        assert_eq!(comments[2].anchor_path.as_deref(), Some("src/lib.rs"));
+        assert_eq!(handle.join().unwrap().len(), 5);
+    }
+
+    #[test]
+    fn app_compatible_backfill_searches_issues_and_pulls_and_enriches_pull_state() {
+        let pull_issue = r#"{"pull_request":{},"number":7,"html_url":"{BASE}/o/r/pull/7","state":"closed","title":"change","body":"body","updated_at":"2026-01-02T00:00:00Z","labels":[]}"#;
+        let (base, handle) = spawn_script_stub(vec![
+            StubResponse::ok(r#"{"total_count":0,"incomplete_results":false,"items":[]}"#),
+            StubResponse::ok(&format!(
+                r#"{{"total_count":1,"incomplete_results":false,"items":[{pull_issue}]}}"#
+            )),
+            StubResponse::ok(r#"{"state":"closed","merged_at":"2026-01-03T00:00:00Z"}"#),
+        ]);
+        let client = GitHubClient::new(
+            &binding(base),
+            &GovernorRegistry::default(),
+            TransportOptions::default(),
+        )
+        .unwrap();
+        let issues = block_on(client.items_page("o/r", &PageCursor {
+            updated_before: Some(INITIAL_BOUNDARY.to_string()),
+            ..PageCursor::default()
+        }))
+        .unwrap();
+        assert!(issues.items.is_empty());
+        let pulls = block_on(client.items_page("o/r", issues.next.as_ref().unwrap())).unwrap();
+        assert_eq!(pulls.items.len(), 1);
+        assert_eq!(pulls.items[0].item_kind, ItemKind::ChangeRequest);
+        let mut pull = pulls.items[0].clone();
+        block_on(client.enrich_item(&mut pull)).unwrap();
+        assert_eq!(pull.merged_at.as_deref(), Some("2026-01-03T00:00:00Z"));
+        assert!(pulls.next.is_none());
+        assert_eq!(pulls.backfill_boundary.as_deref(), Some("2026-01-02T00:00:00Z"));
+
+        let requests = handle.join().unwrap();
+        assert!(requests[0].contains("is%3Aissue"));
+        assert!(requests[1].contains("is%3Apull-request"));
+        assert!(requests[2].contains("/repos/o/r/pulls/7"));
+    }
+
+    #[test]
+    fn pull_enrichment_failure_checkpoints_prior_items_and_keeps_the_cursor_retryable() {
+        let pull = |number| {
+            format!(
+                r#"{{"pull_request":{{}},"number":{number},"html_url":"{{BASE}}/o/r/pull/{number}","state":"closed","title":"change","body":"body","updated_at":"2026-01-02T00:00:00Z","labels":[]}}"#
+            )
+        };
+        let (base, handle) = spawn_script_stub(vec![
+            StubResponse::ok(r#"{"total_count":0,"incomplete_results":false,"items":[]}"#),
+            StubResponse::ok(&format!(
+                r#"{{"total_count":2,"incomplete_results":false,"items":[{},{}]}}"#,
+                pull(2),
+                pull(1)
+            )),
+            StubResponse::ok(r#"{"state":"closed","merged_at":"2026-01-03T00:00:00Z"}"#),
+            StubResponse::ok("[]"),
+            StubResponse::ok("[]"),
+            StubResponse::ok("[]"),
+            StubResponse::status("403 Forbidden", r#"{"message":"denied"}"#),
+        ]);
+        let binding = binding(base);
+        let client =
+            GitHubClient::new(&binding, &GovernorRegistry::default(), TransportOptions::default())
+                .unwrap();
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        crate::index::schema::apply(&conn).unwrap();
+
+        let error = block_on(mirror_binding(&conn, &binding, &client, false)).unwrap_err();
+        assert!(error.to_string().contains("GitHub HTTP 403"));
+        let stored: i64 =
+            conn.query_row("SELECT COUNT(*) FROM papertrail_items", [], |row| row.get(0)).unwrap();
+        assert_eq!(stored, 1, "each completed enrichment is checkpointed independently");
+        let persisted: String = conn
+            .query_row("SELECT backfill_page_cursor FROM papertrail_sync_cursor", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        assert!(persisted.contains("is%3Apull-request"));
+        let processed: String = conn
+            .query_row("SELECT backfill_processed_keys FROM papertrail_sync_cursor", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        assert!(processed.contains(r#""key":"2""#));
+        assert_eq!(handle.join().unwrap().len(), 7);
+    }
+
+    #[test]
+    fn delta_pagination_repo_comments_and_freshness_are_native() {
+        let mut delta = StubResponse::ok(&format!("[{}]", issue(2)));
+        delta.headers.push((
+            "Link".to_string(),
+            "<{BASE}/api/v3/repos/o/r/issues?page=2>; rel=\"next\"".to_string(),
+        ));
+        let mut fresh = StubResponse::ok(r#"[{"number":3,"updated_at":"2026-01-04T00:00:00Z"}]"#);
+        fresh.headers.push(("ETag".to_string(), "\"v2\"".to_string()));
+        let mut issue_comments = StubResponse::ok(
+            r#"[{"id":20,"body":"plain","issue_url":"https://example/o/r/issues/2","updated_at":"2026-01-03T00:00:00Z"},{"id":99,"body":"orphan"}]"#,
+        );
+        issue_comments.headers.push((
+            "Link".to_string(),
+            "<{BASE}/api/v3/repos/o/r/issues/comments?page=2>; rel=\"next\"".to_string(),
+        ));
+        let (base, handle) = spawn_script_stub(vec![
+            delta,
+            StubResponse::ok(&format!("[{}]", issue(1))),
+            issue_comments,
+            StubResponse::ok("[]"),
+            StubResponse::ok(
+                r#"[{"id":21,"body":"anchored","pull_request_url":"https://example/o/r/pulls/3","path":"src/lib.rs","updated_at":"2026-01-03T00:00:00Z"}]"#,
+            ),
+            fresh,
+        ]);
+        let registry = GovernorRegistry::default();
+        let client =
+            GitHubClient::new(&binding(base), &registry, TransportOptions::default()).unwrap();
+
+        let first = block_on(client.items_page("o/r", &PageCursor {
+            updated_since: Some("2026-01-01T00:00:00Z".to_string()),
+            ..PageCursor::default()
+        }))
+        .unwrap();
+        let second = block_on(client.items_page("o/r", first.next.as_ref().unwrap())).unwrap();
+        assert_eq!(second.items[0].item_key, "1");
+        let first_comments = block_on(client.comments_page("o/r", &PageCursor {
+            stream: Some("issue_comments".to_string()),
+            updated_since: Some("2026-01-02T00:00:00Z".to_string()),
+            ..PageCursor::default()
+        }))
+        .unwrap();
+        let second_comments =
+            block_on(client.comments_page("o/r", first_comments.next.as_ref().unwrap())).unwrap();
+        assert!(second_comments.next.is_none());
+        let third_comments = block_on(client.comments_page("o/r", &PageCursor {
+            stream: Some("review_comments".to_string()),
+            updated_since: Some("2026-01-02T00:00:00Z".to_string()),
+            ..PageCursor::default()
+        }))
+        .unwrap();
+        let comments = first_comments
+            .comments
+            .into_iter()
+            .chain(second_comments.comments)
+            .chain(third_comments.comments)
+            .collect::<Vec<_>>();
+        assert_eq!(comments.len(), 2);
+        assert_eq!(comments[1].item_kind, ItemKind::ChangeRequest);
+        let probe = block_on(client.freshness_probe("o/r", &FreshnessProbe {
+            updated_since: Some("2026-01-02T00:00:00Z".to_string()),
+            etag: Some("\"v1\"".to_string()),
+        }))
+        .unwrap();
+        assert_eq!(probe.latest.as_deref(), Some("2026-01-04T00:00:00Z"));
+        assert_eq!(probe.etag.as_deref(), Some("\"v2\""));
+        assert!(!probe.not_modified);
+
+        let requests = handle.join().unwrap();
+        assert!(requests[0].contains("since=2026-01-01T00%3A00%3A00Z"));
+        assert!(requests[2].contains("since=2026-01-02T00%3A00%3A00Z"));
+        assert!(requests[2].contains("sort=updated&direction=asc"));
+        assert!(requests[4].contains("sort=updated&direction=asc"));
+    }
+
+    #[test]
+    fn ascending_updated_order_keeps_an_edited_comment_ahead_of_the_cursor() {
+        let mut first = StubResponse::ok(
+            r#"[{"id":20,"body":"page-one","issue_url":"https://example/o/r/issues/2","updated_at":"2026-01-02T00:00:00Z"}]"#,
+        );
+        first.headers.push((
+            "Link".to_string(),
+            "<{BASE}/api/v3/repos/o/r/issues/comments?sort=updated&direction=asc&page=2>; \
+             rel=\"next\""
+                .to_string(),
+        ));
+        let (base, handle) = spawn_script_stub(vec![
+            first,
+            // Comment 10 was edited between requests. Ascending updated order moves it forward,
+            // so it remains reachable from the continuation instead of jumping behind it.
+            StubResponse::ok(
+                r#"[{"id":10,"body":"moved","issue_url":"https://example/o/r/issues/1","updated_at":"2026-01-03T00:00:00Z"}]"#,
+            ),
+        ]);
+        let registry = GovernorRegistry::default();
+        let client =
+            GitHubClient::new(&binding(base), &registry, TransportOptions::default()).unwrap();
+        let scan = PageCursor {
+            stream: Some("issue_comments".to_string()),
+            updated_since: Some("2026-01-01T23:59:59Z".to_string()),
+            ..PageCursor::default()
+        };
+
+        let page_one = block_on(client.comments_page("o/r", &scan)).unwrap();
+        let page_two =
+            block_on(client.comments_page("o/r", page_one.next.as_ref().unwrap())).unwrap();
+        assert_eq!(page_two.comments.len(), 1);
+        assert_eq!(page_two.comments[0].body, "moved");
+
+        let requests = handle.join().unwrap();
+        assert!(requests[0].contains("sort=updated&direction=asc"));
+        assert!(requests[1].contains("sort=updated&direction=asc&page=2"));
+    }
+
+    #[test]
+    fn legacy_combined_search_cursor_finishes_at_its_persisted_boundary() {
+        let (base, handle) = spawn_script_stub(vec![StubResponse::ok(&format!(
+            r#"{{"total_count":2,"incomplete_results":false,"items":[{}]}}"#,
+            issue(1)
+        ))]);
+        let client = GitHubClient::new(
+            &binding(base.clone()),
+            &GovernorRegistry::default(),
+            TransportOptions::default(),
+        )
+        .unwrap();
+        let page =
+            block_on(
+                client.items_page("o/r", &PageCursor {
+                    stream: Some(SEARCH_BACKFILL_STREAM.to_string()),
+                    updated_before: Some("2026-01-02T00:00:00Z".to_string()),
+                    page_token: Some(format!("{base}/api/v3/search/issues?q=legacy-page-2")),
+                    provider_state: Some(
+                        r#"{"boundary":"2026-01-02T00:00:00Z","total_count":2,"fetched":1}"#
+                            .to_string(),
+                    ),
+                    ..PageCursor::default()
+                }),
+            )
+            .unwrap();
+
+        assert_eq!(page.items.len(), 1);
+        assert!(page.next.is_none());
+        assert_eq!(page.backfill_boundary.as_deref(), Some("2026-01-02T00:00:00Z"));
+        assert_eq!(handle.join().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn search_backfill_drains_tied_pages_before_returning_a_boundary() {
+        let mut first = StubResponse::ok(&format!(
+            r#"{{"total_count":3,"incomplete_results":false,"items":[{}]}}"#,
+            issue(2)
+        ));
+        first.headers.push((
+            "Link".to_string(),
+            "<{BASE}/api/v3/search/issues?q=page-2>; rel=\"next\"".to_string(),
+        ));
+        let (base, handle) = spawn_script_stub(vec![
+            first,
+            StubResponse::ok(&format!(
+                r#"{{"incomplete_results":false,"items":[{},{}]}}"#,
+                issue(1),
+                issue(0).replace("2026-01-02T00:00:00Z", "2026-01-01T23:59:59Z")
+            )),
+            StubResponse::ok(r#"{"total_count":0,"incomplete_results":false,"items":[]}"#),
+        ]);
+        let client = GitHubClient::new(
+            &binding(base),
+            &GovernorRegistry::default(),
+            TransportOptions::default(),
+        )
+        .unwrap();
+        let first_page = block_on(client.items_page("o/r", &PageCursor {
+            updated_before: Some(INITIAL_BOUNDARY.to_string()),
+            ..PageCursor::default()
+        }))
+        .unwrap();
+        assert_eq!(first_page.items.len(), 1);
+        let second_page =
+            block_on(client.items_page("o/r", first_page.next.as_ref().unwrap())).unwrap();
+        assert_eq!(second_page.items.len(), 1);
+        let pull_page =
+            block_on(client.items_page("o/r", second_page.next.as_ref().unwrap())).unwrap();
+        assert!(pull_page.items.is_empty());
+        assert!(pull_page.next.is_none());
+        assert_eq!(pull_page.backfill_boundary.as_deref(), Some("2026-01-02T00:00:00Z"));
+        let requests = handle.join().unwrap();
+        assert_eq!(requests.len(), 3);
+        assert!(requests[0].contains("is%3Aissue"));
+        assert!(requests[2].contains("is%3Apull-request"));
+    }
+
+    #[test]
+    fn split_search_descends_only_below_the_newer_stream_boundary() {
+        let issue_at =
+            |number, timestamp: &str| issue(number).replace("2026-01-02T00:00:00Z", timestamp);
+        let pull_at = |number, timestamp: &str| {
+            issue_at(number, timestamp).replace(
+                &format!(r#"{{"number":{number},"#),
+                &format!(r#"{{"pull_request":{{}},"number":{number},"#),
+            )
+        };
+        let mut first_pull = StubResponse::ok(&format!(
+            r#"{{"total_count":2,"incomplete_results":false,"items":[{}]}}"#,
+            pull_at(2, "2026-01-20T00:00:00Z")
+        ));
+        first_pull.headers.push((
+            "Link".to_string(),
+            "<{BASE}/api/v3/search/issues?q=pull-page-2>; rel=\"next\"".to_string(),
+        ));
+        let (base, handle) = spawn_script_stub(vec![
+            StubResponse::ok(&format!(
+                r#"{{"total_count":1,"incomplete_results":false,"items":[{}]}}"#,
+                issue_at(1, "2026-01-10T00:00:00Z")
+            )),
+            first_pull,
+            StubResponse::ok(&format!(
+                r#"{{"incomplete_results":false,"items":[{}]}}"#,
+                pull_at(3, "2026-01-15T00:00:00Z")
+            )),
+        ]);
+        let client = GitHubClient::new(
+            &binding(base),
+            &GovernorRegistry::default(),
+            TransportOptions::default(),
+        )
+        .unwrap();
+        let issues = block_on(client.items_page("o/r", &PageCursor {
+            updated_before: Some(INITIAL_BOUNDARY.to_string()),
+            ..PageCursor::default()
+        }))
+        .unwrap();
+        let pulls = block_on(client.items_page("o/r", issues.next.as_ref().unwrap())).unwrap();
+        let boundary = block_on(client.items_page("o/r", pulls.next.as_ref().unwrap())).unwrap();
+
+        assert!(boundary.items.is_empty(), "the older PR belongs to the next strict window");
+        assert_eq!(boundary.backfill_boundary.as_deref(), Some("2026-01-20T00:00:00Z"));
+        assert_eq!(handle.join().unwrap().len(), 3);
+    }
+
+    #[test]
+    fn search_backfill_rejects_a_cap_before_a_tie_is_drained() {
+        let mut first = StubResponse::ok(&format!(
+            r#"{{"total_count":1001,"incomplete_results":false,"items":[{}]}}"#,
+            issue(2)
+        ));
+        first.headers.push((
+            "Link".to_string(),
+            "<{BASE}/api/v3/search/issues?q=page-2>; rel=\"next\"".to_string(),
+        ));
+        let (base, handle) = spawn_script_stub(vec![
+            first,
+            StubResponse::ok(&format!(r#"{{"incomplete_results":false,"items":[{}]}}"#, issue(1))),
+        ]);
+        let client = GitHubClient::new(
+            &binding(base),
+            &GovernorRegistry::default(),
+            TransportOptions::default(),
+        )
+        .unwrap();
+        let first_page = block_on(client.items_page("o/r", &PageCursor {
+            updated_before: Some(INITIAL_BOUNDARY.to_string()),
+            ..PageCursor::default()
+        }))
+        .unwrap();
+        let error =
+            block_on(client.items_page("o/r", first_page.next.as_ref().unwrap())).unwrap_err();
+        assert!(error.to_string().contains("timestamp tie"));
+        assert_eq!(handle.join().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn item_page_rejects_ambiguous_and_malformed_provider_pages() {
+        let registry = GovernorRegistry::default();
+        let (base, handle) = spawn_script_stub(Vec::new());
+        let client =
+            GitHubClient::new(&binding(base), &registry, TransportOptions::default()).unwrap();
+        let error = block_on(client.items_page("o/r", &PageCursor {
+            stream: None,
+            updated_since: Some("2026-01-01T00:00:00Z".to_string()),
+            updated_before: Some("2026-01-02T00:00:00Z".to_string()),
+            page_token: None,
+            provider_state: None,
+        }))
+        .unwrap_err();
+        assert!(error.to_string().contains("both delta and backfill"));
+        assert!(handle.join().unwrap().is_empty());
+
+        let cases = [
+            r#"{"incomplete_results":true,"items":[]}"#,
+            r#"{"incomplete_results":false}"#,
+            r#"{"not":"an array"}"#,
+        ];
+        for (index, body) in cases.into_iter().enumerate() {
+            let (base, handle) = spawn_script_stub(vec![StubResponse::ok(body)]);
+            let client = GitHubClient::new(
+                &binding(base.clone()),
+                &GovernorRegistry::default(),
+                TransportOptions::default(),
+            )
+            .unwrap();
+            let cursor = if index < 2 {
+                PageCursor {
+                    updated_before: Some(INITIAL_BOUNDARY.to_string()),
+                    ..PageCursor::default()
+                }
+            } else {
+                PageCursor::default()
+            };
+            assert!(block_on(client.items_page("o/r", &cursor)).is_err());
+            assert_eq!(handle.join().unwrap().len(), 1);
+        }
+    }
+
+    #[test]
+    fn pages_reject_missing_identities_and_cursor_timestamps() {
+        let (base, handle) = spawn_script_stub(vec![
+            StubResponse::ok(r#"[{"updated_at":"2026-01-01T00:00:00Z"}]"#),
+            StubResponse::ok(
+                r#"[{"issue_url":"https://example/o/r/issues/1","updated_at":"2026-01-01T00:00:00Z"}]"#,
+            ),
+            StubResponse::ok(r#"[{"number":1}]"#),
+        ]);
+        let client = GitHubClient::new(
+            &binding(base),
+            &GovernorRegistry::default(),
+            TransportOptions::default(),
+        )
+        .unwrap();
+
+        let item_error = block_on(client.items_page("o/r", &PageCursor::default())).unwrap_err();
+        assert!(item_error.to_string().contains("valid number"));
+
+        let comment_error = block_on(client.comments_page("o/r", &PageCursor {
+            stream: Some("issue_comments".to_string()),
+            ..PageCursor::default()
+        }))
+        .unwrap_err();
+        assert!(comment_error.to_string().contains("valid id"));
+
+        let timestamp_error =
+            block_on(client.items_page("o/r", &PageCursor::default())).unwrap_err();
+        assert!(timestamp_error.to_string().contains("valid updated_at"));
+        assert_eq!(handle.join().unwrap().len(), 3);
+    }
+
+    #[test]
+    fn not_found_status_is_a_typed_item_outcome() {
+        let error = ensure_success(404, "missing").unwrap_err();
+        assert!(error.downcast_ref::<PapertrailClientError>().is_some());
+        assert!(ensure_success(500, "broken").unwrap_err().to_string().contains("HTTP 500"));
+    }
+
+    const INITIAL_BOUNDARY: &str = "2970-12-31T23:59:59Z";
+}

--- a/crates/rag-rat-core/src/index/papertrail/mirror.rs
+++ b/crates/rag-rat-core/src/index/papertrail/mirror.rs
@@ -1,0 +1,2362 @@
+//! Provider-neutral whole-project mirror runner. This module owns cursor arbitration,
+//! fetch-then-commit page semantics, tag pruning, pause/resume, and full healing.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use rusqlite::types::Type;
+use rusqlite::{Connection, OptionalExtension, params};
+
+use super::transport::{PauseReason, TransportError};
+use super::*;
+
+// GitHub Search accepts years only through 2970. This remains safely beyond any real item while
+// keeping the initial strict `updated:<boundary` query valid.
+const INITIAL_BACKFILL_BOUNDARY: &str = "2970-12-31T23:59:59Z";
+/// An empty initial walk has consumed no provider item. Persist the lowest practical timestamp so
+/// later runs enter the normal probe/delta path and discover items created after that walk.
+const EMPTY_PROJECT_HIGH_MARK: &str = "1970-01-01T00:00:00Z";
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+struct ProcessedItem {
+    kind: String,
+    key: String,
+    updated_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct CommentStreamCursor {
+    high_mark_at: Option<String>,
+    page_token: Option<String>,
+    scan_since: Option<String>,
+    #[serde(default)]
+    scan_high_mark_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ItemThreadCursor {
+    item: ProcessedItem,
+    lane: PageLane,
+    stream_index: usize,
+    page_cursor: Option<PageCursor>,
+    #[serde(default)]
+    seen_comment_ids: BTreeSet<String>,
+    #[serde(default)]
+    previous_comment_ids: Option<BTreeSet<String>>,
+    #[serde(default)]
+    saw_pagination: bool,
+}
+
+#[derive(Debug, Clone, Default)]
+struct MirrorCursor {
+    high_mark_at: Option<String>,
+    comment_high_mark_at: Option<String>,
+    comment_page_token: Option<String>,
+    comment_scan_since: Option<String>,
+    comment_stream_cursors: BTreeMap<String, CommentStreamCursor>,
+    low_mark_at: Option<String>,
+    probe_etag: Option<String>,
+    backfill_done: bool,
+    filter_fingerprint: String,
+    item_delta_page_token: Option<String>,
+    item_delta_scan_since: Option<String>,
+    item_delta_high_mark_at: Option<String>,
+    item_delta_in_progress: bool,
+    item_delta_replay_required: bool,
+    backfill_page_cursor: Option<PageCursor>,
+    item_thread_cursor: Option<ItemThreadCursor>,
+    delta_processed_keys: BTreeSet<ProcessedItem>,
+    backfill_processed_keys: BTreeSet<ProcessedItem>,
+    full_rewalk: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct MirrorBindingReport {
+    pub tracker: Tracker,
+    pub project: String,
+    pub stored_items: usize,
+    pub stored_comments: usize,
+    pub pruned_items: usize,
+    pub paused_until_ms: Option<i64>,
+    pub pause_reason: Option<String>,
+}
+
+pub(crate) async fn mirror_binding<C: PapertrailClient>(
+    conn: &Connection,
+    binding: &ResolvedTracker,
+    client: &C,
+    full: bool,
+) -> anyhow::Result<MirrorBindingReport> {
+    let mut cursor = load_cursor(conn, binding)?;
+    let fingerprint = binding.filter_fingerprint();
+    let filter_changed = cursor.filter_fingerprint != fingerprint;
+    let starting_full_rewalk = full && !cursor.full_rewalk;
+    if starting_full_rewalk {
+        reset_for_full_rewalk(conn, binding, &mut cursor)?;
+    }
+    if filter_changed {
+        cursor.low_mark_at = None;
+        cursor.backfill_done = false;
+        cursor.filter_fingerprint = fingerprint;
+        cursor.comment_page_token = None;
+        cursor.comment_scan_since = None;
+        cursor.comment_stream_cursors.clear();
+        cursor.item_delta_page_token = None;
+        cursor.item_delta_scan_since = None;
+        cursor.item_delta_high_mark_at = None;
+        cursor.item_delta_in_progress = false;
+        cursor.item_delta_replay_required = false;
+        cursor.backfill_page_cursor = None;
+        cursor.item_thread_cursor = None;
+        cursor.delta_processed_keys.clear();
+        cursor.backfill_processed_keys.clear();
+        if cursor.full_rewalk {
+            reset_full_seen(conn, binding)?;
+        }
+    }
+    // Opaque item-comment page tokens are not snapshots. IDs seen before a process-level pause
+    // cannot prove that those comments still exist when the walk resumes, so restart the thread's
+    // mark phase from its first stream. Stored rows remain intact until the restarted walk
+    // finishes.
+    if let Some(thread) = cursor.item_thread_cursor.as_mut()
+        && (thread.stream_index != 0 || thread.page_cursor.is_some())
+    {
+        thread.stream_index = 0;
+        thread.page_cursor = None;
+        thread.seen_comment_ids.clear();
+    }
+    let mut report = MirrorBindingReport {
+        tracker: binding.provider,
+        project: binding.project.clone(),
+        stored_items: 0,
+        stored_comments: 0,
+        pruned_items: 0,
+        paused_until_ms: None,
+        pause_reason: None,
+    };
+    if filter_changed {
+        report.pruned_items += prune_unmatched(conn, binding)?;
+        save_cursor(conn, binding, &cursor, false)?;
+    }
+
+    let result = mirror_binding_inner(conn, binding, client, &mut cursor, &mut report).await;
+    match result {
+        Ok(()) => Ok(report),
+        Err(error) if pause(&error).is_some() => {
+            let (resume_at_ms, reason) = pause(&error).expect("checked");
+            report.paused_until_ms = Some(resume_at_ms);
+            report.pause_reason = Some(reason.as_str().to_string());
+            Ok(report)
+        },
+        Err(error) => Err(error),
+    }
+}
+
+async fn mirror_binding_inner<C: PapertrailClient>(
+    conn: &Connection,
+    binding: &ResolvedTracker,
+    client: &C,
+    cursor: &mut MirrorCursor,
+    report: &mut MirrorBindingReport,
+) -> anyhow::Result<()> {
+    let previous_high = cursor.high_mark_at.clone();
+    if !cursor.full_rewalk
+        && let Some(high) = previous_high.as_deref()
+    {
+        if cursor.item_delta_in_progress {
+            cursor.item_delta_scan_since.get_or_insert_with(|| overlap_timestamp(high));
+            save_cursor(conn, binding, cursor, false)?;
+            sync_item_delta(conn, binding, client, cursor, report).await?;
+        } else {
+            let probe = client
+                .freshness_probe(&binding.project, &FreshnessProbe {
+                    updated_since: Some(high.to_string()),
+                    etag: cursor.probe_etag.clone(),
+                })
+                .await?;
+            cursor.probe_etag = probe.etag;
+            if !probe.not_modified {
+                cursor.item_delta_in_progress = true;
+                cursor.item_delta_scan_since = Some(overlap_timestamp(high));
+                cursor.item_delta_high_mark_at = probe.latest;
+                save_cursor(conn, binding, cursor, false)?;
+                sync_item_delta(conn, binding, client, cursor, report).await?;
+            } else {
+                save_cursor(conn, binding, cursor, false)?;
+            }
+        }
+        sync_comment_delta(conn, binding, client, cursor, report).await?;
+    }
+
+    while !cursor.backfill_done {
+        let boundary =
+            cursor.low_mark_at.clone().unwrap_or_else(|| INITIAL_BACKFILL_BOUNDARY.to_string());
+        let request = cursor.backfill_page_cursor.clone().unwrap_or_else(|| PageCursor {
+            updated_before: Some(boundary.clone()),
+            ..PageCursor::default()
+        });
+        let page = client.items_page(&binding.project, &request).await?;
+        if page.items.is_empty() && page.next.is_none() && page.backfill_boundary.is_none() {
+            cursor.backfill_done = true;
+            cursor.high_mark_at.get_or_insert_with(|| EMPTY_PROJECT_HIGH_MARK.to_string());
+            cursor.backfill_processed_keys.clear();
+            save_cursor(conn, binding, cursor, false)?;
+            break;
+        }
+        if let Some(next) = &page.next {
+            ensure_cursor_advanced(&request, next, "backfill")?;
+        }
+        store_item_page_resumably(
+            conn,
+            binding,
+            client,
+            &page.items,
+            PageLane::Backfill,
+            cursor,
+            report,
+        )
+        .await?;
+        if cursor.high_mark_at.is_none() {
+            cursor.high_mark_at = max_item_updated_at(&page.items);
+        }
+        if let Some(next) = page.next {
+            cursor.backfill_page_cursor = Some(next);
+            save_cursor(conn, binding, cursor, false)?;
+            continue;
+        }
+        let next_low = page
+            .backfill_boundary
+            .or_else(|| min_item_updated_at(&page.items))
+            .or_else(|| request.page_token.as_ref().and_then(|_| request.updated_before.clone()))
+            .ok_or_else(|| anyhow::anyhow!("backfill page has no updated_at boundary"))?;
+        anyhow::ensure!(next_low < boundary, "backfill boundary did not advance below {boundary}");
+        cursor.low_mark_at = Some(next_low);
+        cursor.backfill_page_cursor = None;
+        cursor.backfill_processed_keys.clear();
+        save_cursor(conn, binding, cursor, false)?;
+    }
+    if previous_high.is_none() || cursor.full_rewalk {
+        sync_comment_delta(conn, binding, client, cursor, report).await?;
+    }
+    if cursor.full_rewalk {
+        let tx = conn.unchecked_transaction()?;
+        report.pruned_items += prune_missing(&tx, binding)?;
+        rebuild_fts(&tx)?;
+        cursor.full_rewalk = false;
+        save_cursor(&tx, binding, cursor, true)?;
+        tx.commit()?;
+    }
+    Ok(())
+}
+
+async fn sync_item_delta<C: PapertrailClient>(
+    conn: &Connection,
+    binding: &ResolvedTracker,
+    client: &C,
+    cursor: &mut MirrorCursor,
+    report: &mut MirrorBindingReport,
+) -> anyhow::Result<()> {
+    let mut request = PageCursor {
+        updated_since: cursor.item_delta_scan_since.clone(),
+        page_token: cursor.item_delta_page_token.clone(),
+        ..PageCursor::default()
+    };
+    loop {
+        let page = client.items_page(&binding.project, &request).await?;
+        let first_page_high = request
+            .page_token
+            .is_none()
+            .then(|| page.items.iter().filter_map(|item| item.updated_at.clone()).max());
+        let next = if let Some(mut next) = page.next {
+            next.updated_since = cursor.item_delta_scan_since.clone();
+            next.updated_before = None;
+            ensure_cursor_advanced(&request, &next, "item delta")?;
+            Some(next)
+        } else {
+            None
+        };
+        if let Some(first_page_high) = first_page_high {
+            // GitHub's updated-order REST pages are mutable. Once pagination is present, only
+            // the first page is a proven consumed prefix: an edit can move a row from that page
+            // later and shift an unseen boundary row behind the current offset. Persisting the
+            // first page's inclusive upper timestamp makes the next scan replay that boundary.
+            // A single physical page consumed the whole observed window, but still must not
+            // jump to a probe timestamp that the list response did not contain.
+            let reached_probe =
+                if cursor.item_delta_replay_required && cursor.item_delta_high_mark_at.is_none() {
+                    first_page_high == cursor.high_mark_at
+                } else {
+                    first_page_high == cursor.item_delta_high_mark_at && next.is_none()
+                };
+            cursor.item_delta_high_mark_at = first_page_high;
+            cursor.item_delta_replay_required = !reached_probe;
+            if cursor.item_delta_replay_required {
+                // The next run must probe unconditionally so this conservative frontier is
+                // replayed even when the prior probe's ETag is otherwise still current.
+                cursor.probe_etag = None;
+            }
+        }
+        store_item_page_resumably(
+            conn,
+            binding,
+            client,
+            &page.items,
+            PageLane::Delta,
+            cursor,
+            report,
+        )
+        .await?;
+        if let Some(next) = next {
+            cursor.delta_processed_keys.clear();
+            cursor.item_delta_page_token = next.page_token.clone();
+            cursor.item_delta_in_progress = true;
+            save_cursor(conn, binding, cursor, false)?;
+            request = next;
+        } else {
+            cursor.high_mark_at =
+                max_timestamp(cursor.high_mark_at.take(), cursor.item_delta_high_mark_at.take());
+            cursor.delta_processed_keys.clear();
+            cursor.item_delta_page_token = None;
+            cursor.item_delta_scan_since = None;
+            cursor.item_delta_in_progress = false;
+            save_cursor(conn, binding, cursor, false)?;
+            break;
+        }
+    }
+    Ok(())
+}
+
+async fn sync_comment_delta<C: PapertrailClient>(
+    conn: &Connection,
+    binding: &ResolvedTracker,
+    client: &C,
+    cursor: &mut MirrorCursor,
+    report: &mut MirrorBindingReport,
+) -> anyhow::Result<()> {
+    // A legacy shared watermark may seed every stream exactly once. Never seed a stream from the
+    // aggregate while this loop is advancing siblings: that recreates the cross-stream race this
+    // map exists to prevent. A provider stream added later starts from scratch, which is safe.
+    let legacy_high = cursor
+        .comment_stream_cursors
+        .is_empty()
+        .then(|| cursor.comment_high_mark_at.clone())
+        .flatten();
+    for stream in client.comment_streams() {
+        let state =
+            cursor.comment_stream_cursors.entry((*stream).to_string()).or_insert_with(|| {
+                CommentStreamCursor {
+                    high_mark_at: legacy_high.clone(),
+                    page_token: None,
+                    scan_since: None,
+                    scan_high_mark_at: None,
+                }
+            });
+        let scan_since = state.scan_since.clone().unwrap_or_else(|| {
+            state.high_mark_at.as_deref().map(overlap_timestamp).unwrap_or_default()
+        });
+        let mut request = PageCursor {
+            stream: Some((*stream).to_string()),
+            updated_since: (!scan_since.is_empty()).then_some(scan_since.clone()),
+            page_token: state.page_token.clone(),
+            ..PageCursor::default()
+        };
+        loop {
+            let page = client.comments_page(&binding.project, &request).await?;
+            let first_page_high = request.page_token.is_none().then(|| {
+                page.comments.iter().filter_map(|comment| comment.updated_at.clone()).max()
+            });
+            let next = if let Some(mut next) = page.next {
+                anyhow::ensure!(
+                    next.stream.as_deref().is_none_or(|next_stream| next_stream == *stream),
+                    "comment pagination crossed from `{stream}` into another stream"
+                );
+                next.stream = Some((*stream).to_string());
+                next.updated_since = (!scan_since.is_empty()).then_some(scan_since.clone());
+                ensure_cursor_advanced(&request, &next, "repository comment")?;
+                Some(next)
+            } else {
+                None
+            };
+            store_repo_comments(conn, binding, &page.comments, report)?;
+            let state = cursor.comment_stream_cursors.get_mut(*stream).expect("stream inserted");
+            if let Some(first_page_high) = first_page_high {
+                // As with item deltas, a mutable continuation proves no more than the first
+                // ascending page. Replaying its inclusive upper boundary prevents offset shifts
+                // from stranding an unseen or stale comment below the durable watermark.
+                state.scan_high_mark_at = first_page_high;
+            }
+            state.page_token = next.as_ref().and_then(|next| next.page_token.clone());
+            state.scan_since = next.as_ref().map(|_| scan_since.clone());
+            if next.is_none() {
+                state.high_mark_at =
+                    max_timestamp(state.high_mark_at.take(), state.scan_high_mark_at.take());
+            }
+            cursor.comment_high_mark_at = common_comment_high_mark(&cursor.comment_stream_cursors);
+            save_cursor(conn, binding, cursor, false)?;
+            let Some(next) = next else { break };
+            request = next;
+        }
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum PageLane {
+    Delta,
+    Backfill,
+}
+
+async fn store_item_page_resumably<C: PapertrailClient>(
+    conn: &Connection,
+    binding: &ResolvedTracker,
+    client: &C,
+    items: &[PapertrailItem],
+    lane: PageLane,
+    cursor: &mut MirrorCursor,
+    report: &mut MirrorBindingReport,
+) -> anyhow::Result<()> {
+    if let Some(active) = cursor.item_thread_cursor.clone() {
+        if let Some(item) = items.iter().find(|item| {
+            item.item_kind.as_db_str() == active.item.kind && item.item_key == active.item.key
+        }) {
+            let current = processed_item(item);
+            if current != active.item {
+                let mut item = item.clone();
+                client.enrich_item(&mut item).await?;
+                if binding.tracks(item.tags.iter().map(String::as_str)) {
+                    begin_item_thread(conn, binding, &item, lane, cursor, report)?;
+                } else {
+                    report.pruned_items +=
+                        usize::from(delete_item(conn, binding, item.item_kind, &item.item_key)?);
+                    cursor.item_thread_cursor = None;
+                    mark_processed(cursor, lane, current);
+                    save_cursor(conn, binding, cursor, false)?;
+                }
+            }
+        }
+        if cursor.item_thread_cursor.is_some() {
+            resume_item_thread(conn, binding, client, cursor, report).await?;
+        }
+    }
+    for item in items {
+        let key = processed_item(item);
+        let already_stored = match lane {
+            PageLane::Delta => cursor.delta_processed_keys.contains(&key),
+            PageLane::Backfill => cursor.backfill_processed_keys.contains(&key),
+        };
+        if already_stored {
+            continue;
+        }
+        let mut item = item.clone();
+        client.enrich_item(&mut item).await?;
+        if binding.tracks(item.tags.iter().map(String::as_str)) {
+            begin_item_thread(conn, binding, &item, lane, cursor, report)?;
+            resume_item_thread(conn, binding, client, cursor, report).await?;
+        } else {
+            report.pruned_items +=
+                usize::from(delete_item(conn, binding, item.item_kind, &item.item_key)?);
+            mark_processed(cursor, lane, key);
+            save_cursor(conn, binding, cursor, false)?;
+        }
+    }
+    Ok(())
+}
+
+fn processed_item(item: &PapertrailItem) -> ProcessedItem {
+    ProcessedItem {
+        kind: item.item_kind.as_db_str().to_string(),
+        key: item.item_key.clone(),
+        updated_at: item.updated_at.clone(),
+    }
+}
+
+fn begin_item_thread(
+    conn: &Connection,
+    binding: &ResolvedTracker,
+    item: &PapertrailItem,
+    lane: PageLane,
+    cursor: &mut MirrorCursor,
+    report: &mut MirrorBindingReport,
+) -> anyhow::Result<()> {
+    let tx = conn.unchecked_transaction()?;
+    store_item(&tx, binding.provider, item)?;
+    replace_tags(&tx, binding, item)?;
+    if cursor.full_rewalk {
+        mark_full_seen(&tx, binding, item)?;
+    }
+    cursor.item_thread_cursor = Some(ItemThreadCursor {
+        item: processed_item(item),
+        lane,
+        stream_index: 0,
+        page_cursor: None,
+        seen_comment_ids: BTreeSet::new(),
+        previous_comment_ids: None,
+        saw_pagination: false,
+    });
+    save_cursor(&tx, binding, cursor, false)?;
+    tx.commit()?;
+    report.stored_items += 1;
+    Ok(())
+}
+
+async fn resume_item_thread<C: PapertrailClient>(
+    conn: &Connection,
+    binding: &ResolvedTracker,
+    client: &C,
+    cursor: &mut MirrorCursor,
+    report: &mut MirrorBindingReport,
+) -> anyhow::Result<()> {
+    loop {
+        let thread = cursor.item_thread_cursor.clone().expect("active item thread");
+        let kind = ItemKind::from_db_str(&thread.item.kind)?;
+        let streams = client.item_comment_streams(kind);
+        let Some(stream) = streams.get(thread.stream_index) else {
+            if thread.saw_pagination
+                && thread.previous_comment_ids.as_ref() != Some(&thread.seen_comment_ids)
+            {
+                // GitHub item-comment continuations are mutable page numbers. Require two
+                // identical complete walks before treating absence as deletion; a row shifted
+                // behind one walk is rediscovered by the next instead of being pruned locally.
+                let active = cursor.item_thread_cursor.as_mut().expect("active item thread");
+                active.previous_comment_ids = Some(thread.seen_comment_ids);
+                active.seen_comment_ids.clear();
+                active.stream_index = 0;
+                active.page_cursor = None;
+                save_cursor(conn, binding, cursor, false)?;
+                continue;
+            }
+            let tx = conn.unchecked_transaction()?;
+            prune_unseen_item_comments(
+                &tx,
+                binding,
+                kind,
+                &thread.item.key,
+                &thread.seen_comment_ids,
+            )?;
+            cursor.item_thread_cursor = None;
+            mark_processed(cursor, thread.lane, thread.item);
+            save_cursor(&tx, binding, cursor, false)?;
+            tx.commit()?;
+            return Ok(());
+        };
+        let request = thread.page_cursor.clone().unwrap_or_else(|| PageCursor {
+            stream: Some((*stream).to_string()),
+            ..PageCursor::default()
+        });
+        let page = match client
+            .item_comments_page(&binding.project, kind, &thread.item.key, &request)
+            .await
+        {
+            Ok(page) => page,
+            Err(error) if is_item_not_found(&error) => {
+                // GitHub deliberately uses 404 both for absent and inaccessible resources, and
+                // a stale comment continuation says nothing about the parent. Unpin ordinary
+                // sync without erasing the last complete cache; a successful full rewalk owns
+                // authoritative item pruning.
+                let tx = conn.unchecked_transaction()?;
+                cursor.item_thread_cursor = None;
+                mark_processed(cursor, thread.lane, thread.item);
+                save_cursor(&tx, binding, cursor, false)?;
+                tx.commit()?;
+                return Ok(());
+            },
+            Err(error) => return Err(error),
+        };
+        let next = page.next;
+        if let Some(next) = &next {
+            anyhow::ensure!(
+                next.stream.as_deref().is_none_or(|next_stream| next_stream == *stream),
+                "item-comment pagination crossed from `{stream}` into another stream"
+            );
+            ensure_cursor_advanced(&request, next, "item comment")?;
+        }
+        let active = cursor.item_thread_cursor.as_mut().expect("active item thread");
+        active
+            .seen_comment_ids
+            .extend(page.comments.iter().map(|comment| comment.comment_id.clone()));
+        if let Some(mut next) = next {
+            next.stream = Some((*stream).to_string());
+            active.page_cursor = Some(next);
+            active.saw_pagination = true;
+        } else {
+            active.stream_index += 1;
+            active.page_cursor = None;
+        }
+        let tx = conn.unchecked_transaction()?;
+        for comment in &page.comments {
+            store_comment(&tx, binding.provider, comment)?;
+        }
+        save_cursor(&tx, binding, cursor, false)?;
+        tx.commit()?;
+        report.stored_comments += page.comments.len();
+    }
+}
+
+fn ensure_cursor_advanced(
+    current: &PageCursor,
+    next: &PageCursor,
+    lane: &str,
+) -> anyhow::Result<()> {
+    anyhow::ensure!(next != current, "{lane} pagination cursor did not advance");
+    Ok(())
+}
+
+fn is_item_not_found(error: &anyhow::Error) -> bool {
+    error.chain().any(|cause| {
+        matches!(
+            cause.downcast_ref::<PapertrailClientError>(),
+            Some(PapertrailClientError::ItemNotFound)
+        )
+    })
+}
+
+fn mark_processed(cursor: &mut MirrorCursor, lane: PageLane, key: ProcessedItem) {
+    let stored = match lane {
+        PageLane::Delta => &mut cursor.delta_processed_keys,
+        PageLane::Backfill => &mut cursor.backfill_processed_keys,
+    };
+    stored.retain(|item| item.kind != key.kind || item.key != key.key);
+    stored.insert(key);
+}
+
+fn load_cursor(conn: &Connection, binding: &ResolvedTracker) -> anyhow::Result<MirrorCursor> {
+    let repo_id = crate::index::schema::active_repo_id(conn)?;
+    Ok(conn
+        .query_row(
+            "SELECT high_mark_at, comment_high_mark_at, comment_page_token, comment_scan_since,
+                    comment_stream_cursors, low_mark_at, probe_etag, backfill_done, \
+             filter_fingerprint,
+                    item_delta_page_token, item_delta_scan_since, item_delta_high_mark_at,
+                    item_delta_in_progress, item_delta_replay_required, backfill_page_cursor,
+                    item_thread_cursor, delta_processed_keys, backfill_processed_keys, full_rewalk
+             FROM papertrail_sync_cursor
+             WHERE tracker = ?1 AND project = ?2 AND repo_id = ?3",
+            params![binding.provider.as_db_str(), binding.project, repo_id],
+            |row| {
+                Ok(MirrorCursor {
+                    high_mark_at: row.get(0)?,
+                    comment_high_mark_at: row.get(1)?,
+                    comment_page_token: row.get(2)?,
+                    comment_scan_since: row.get(3)?,
+                    comment_stream_cursors: decode_json(row.get(4)?, 4)?,
+                    low_mark_at: row.get(5)?,
+                    probe_etag: row.get(6)?,
+                    backfill_done: row.get(7)?,
+                    filter_fingerprint: row.get::<_, Option<String>>(8)?.unwrap_or_default(),
+                    item_delta_page_token: row.get(9)?,
+                    item_delta_scan_since: row.get(10)?,
+                    item_delta_high_mark_at: row.get(11)?,
+                    item_delta_in_progress: row.get(12)?,
+                    item_delta_replay_required: row.get(13)?,
+                    backfill_page_cursor: decode_json(row.get(14)?, 14)?,
+                    item_thread_cursor: decode_json(row.get(15)?, 15)?,
+                    delta_processed_keys: decode_processed_items(row.get(16)?, 16)?,
+                    backfill_processed_keys: decode_processed_items(row.get(17)?, 17)?,
+                    full_rewalk: row.get(18)?,
+                })
+            },
+        )
+        .optional()?
+        .unwrap_or_default())
+}
+
+fn save_cursor(
+    conn: &Connection,
+    binding: &ResolvedTracker,
+    cursor: &MirrorCursor,
+    full: bool,
+) -> anyhow::Result<()> {
+    let repo_id = crate::index::schema::active_repo_id(conn)?;
+    let delta_processed_keys = serde_json::to_string(&cursor.delta_processed_keys)?;
+    let backfill_processed_keys = serde_json::to_string(&cursor.backfill_processed_keys)?;
+    let comment_stream_cursors = serde_json::to_string(&cursor.comment_stream_cursors)?;
+    let backfill_page_cursor =
+        cursor.backfill_page_cursor.as_ref().map(serde_json::to_string).transpose()?;
+    let item_thread_cursor =
+        cursor.item_thread_cursor.as_ref().map(serde_json::to_string).transpose()?;
+    conn.execute(
+        "INSERT INTO papertrail_sync_cursor(
+             tracker, project, high_mark_at, comment_high_mark_at, comment_page_token,
+             comment_scan_since, comment_stream_cursors, low_mark_at, probe_etag, backfill_done, \
+         filter_fingerprint,
+             item_delta_page_token, item_delta_scan_since, item_delta_high_mark_at,
+             item_delta_in_progress, item_delta_replay_required, backfill_page_cursor,
+             item_thread_cursor, delta_processed_keys, backfill_processed_keys, full_rewalk,
+             last_probe_ms, last_full_sync_ms, repo_id
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14,
+                   ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, CASE WHEN ?23 THEN ?22 END, ?24)
+         ON CONFLICT(repo_id, tracker, project) DO UPDATE SET
+             high_mark_at = excluded.high_mark_at,
+             comment_high_mark_at = excluded.comment_high_mark_at,
+             comment_page_token = excluded.comment_page_token,
+             comment_scan_since = excluded.comment_scan_since,
+             comment_stream_cursors = excluded.comment_stream_cursors,
+             low_mark_at = excluded.low_mark_at,
+             probe_etag = excluded.probe_etag,
+             backfill_done = excluded.backfill_done,
+             filter_fingerprint = excluded.filter_fingerprint,
+             item_delta_page_token = excluded.item_delta_page_token,
+             item_delta_scan_since = excluded.item_delta_scan_since,
+             item_delta_high_mark_at = excluded.item_delta_high_mark_at,
+             item_delta_in_progress = excluded.item_delta_in_progress,
+             item_delta_replay_required = excluded.item_delta_replay_required,
+             backfill_page_cursor = excluded.backfill_page_cursor,
+             item_thread_cursor = excluded.item_thread_cursor,
+             delta_processed_keys = excluded.delta_processed_keys,
+             backfill_processed_keys = excluded.backfill_processed_keys,
+             full_rewalk = excluded.full_rewalk,
+             last_probe_ms = excluded.last_probe_ms,
+             last_full_sync_ms = CASE WHEN ?23 THEN excluded.last_full_sync_ms
+                                      ELSE papertrail_sync_cursor.last_full_sync_ms END",
+        params![
+            binding.provider.as_db_str(),
+            binding.project,
+            cursor.high_mark_at,
+            cursor.comment_high_mark_at,
+            cursor.comment_page_token,
+            cursor.comment_scan_since,
+            comment_stream_cursors,
+            cursor.low_mark_at,
+            cursor.probe_etag,
+            cursor.backfill_done,
+            cursor.filter_fingerprint,
+            cursor.item_delta_page_token,
+            cursor.item_delta_scan_since,
+            cursor.item_delta_high_mark_at,
+            cursor.item_delta_in_progress,
+            cursor.item_delta_replay_required,
+            backfill_page_cursor,
+            item_thread_cursor,
+            delta_processed_keys,
+            backfill_processed_keys,
+            cursor.full_rewalk,
+            now_ms(),
+            full,
+            repo_id,
+        ],
+    )?;
+    Ok(())
+}
+
+fn decode_json<T: serde::de::DeserializeOwned + Default>(
+    value: Option<String>,
+    column: usize,
+) -> rusqlite::Result<T> {
+    value.map_or_else(
+        || Ok(T::default()),
+        |value| {
+            serde_json::from_str(&value).map_err(|error| {
+                rusqlite::Error::FromSqlConversionFailure(column, Type::Text, Box::new(error))
+            })
+        },
+    )
+}
+
+fn decode_processed_items(
+    value: Option<String>,
+    column: usize,
+) -> rusqlite::Result<BTreeSet<ProcessedItem>> {
+    let Some(value) = value else { return Ok(BTreeSet::new()) };
+    if let Ok(items) = serde_json::from_str(&value) {
+        return Ok(items);
+    }
+    serde_json::from_str::<BTreeSet<(String, String)>>(&value)
+        .map(|legacy| {
+            legacy
+                .into_iter()
+                .map(|(kind, key)| ProcessedItem { kind, key, updated_at: None })
+                .collect()
+        })
+        .map_err(|error| {
+            rusqlite::Error::FromSqlConversionFailure(column, Type::Text, Box::new(error))
+        })
+}
+
+fn reset_for_full_rewalk(
+    conn: &Connection,
+    binding: &ResolvedTracker,
+    cursor: &mut MirrorCursor,
+) -> anyhow::Result<()> {
+    cursor.high_mark_at = None;
+    cursor.comment_high_mark_at = None;
+    cursor.comment_page_token = None;
+    cursor.comment_scan_since = None;
+    cursor.comment_stream_cursors.clear();
+    cursor.low_mark_at = None;
+    cursor.backfill_done = false;
+    cursor.item_delta_page_token = None;
+    cursor.item_delta_in_progress = false;
+    cursor.item_delta_replay_required = false;
+    cursor.backfill_page_cursor = None;
+    cursor.item_thread_cursor = None;
+    cursor.delta_processed_keys.clear();
+    cursor.backfill_processed_keys.clear();
+    cursor.full_rewalk = true;
+    reset_full_seen(conn, binding)?;
+    save_cursor(conn, binding, cursor, false)
+}
+
+fn reset_full_seen(conn: &Connection, binding: &ResolvedTracker) -> anyhow::Result<()> {
+    let repo_id = crate::index::schema::active_repo_id(conn)?;
+    conn.execute(
+        "UPDATE papertrail_items SET full_rewalk_seen=0
+         WHERE repo_id=?1 AND tracker=?2 AND project=?3",
+        params![repo_id, binding.provider.as_db_str(), binding.project],
+    )?;
+    Ok(())
+}
+
+fn mark_full_seen(
+    conn: &Connection,
+    binding: &ResolvedTracker,
+    item: &PapertrailItem,
+) -> anyhow::Result<()> {
+    let repo_id = crate::index::schema::active_repo_id(conn)?;
+    conn.execute(
+        "UPDATE papertrail_items SET full_rewalk_seen=1
+         WHERE repo_id=?1 AND tracker=?2 AND project=?3 AND item_kind=?4 AND item_key=?5",
+        params![
+            repo_id,
+            binding.provider.as_db_str(),
+            binding.project,
+            item.item_kind.as_db_str(),
+            item.item_key,
+        ],
+    )?;
+    Ok(())
+}
+
+fn replace_tags(
+    conn: &Connection,
+    binding: &ResolvedTracker,
+    item: &PapertrailItem,
+) -> anyhow::Result<()> {
+    let repo_id = crate::index::schema::active_repo_id(conn)?;
+    conn.execute(
+        "DELETE FROM papertrail_item_tags WHERE tracker=?1 AND project=?2 AND item_kind=?3 AND \
+         item_key=?4 AND repo_id=?5",
+        params![
+            binding.provider.as_db_str(),
+            binding.project,
+            item.item_kind.as_db_str(),
+            item.item_key,
+            repo_id
+        ],
+    )?;
+    for tag in normalized_tags(&item.tags) {
+        conn.execute(
+            "INSERT INTO papertrail_item_tags(tracker, project, item_kind, item_key, tag, repo_id)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            params![
+                binding.provider.as_db_str(),
+                binding.project,
+                item.item_kind.as_db_str(),
+                item.item_key,
+                tag,
+                repo_id
+            ],
+        )?;
+    }
+    Ok(())
+}
+
+fn prune_unmatched(conn: &Connection, binding: &ResolvedTracker) -> anyhow::Result<usize> {
+    if binding.tags.is_empty() {
+        return Ok(0);
+    }
+    let repo_id = crate::index::schema::active_repo_id(conn)?;
+    let wanted = normalized_tags(&binding.tags);
+    let mut stmt = conn.prepare(
+        "SELECT i.item_kind, i.item_key, t.tag
+         FROM papertrail_items i
+         LEFT JOIN papertrail_item_tags t ON t.repo_id=i.repo_id AND t.tracker=i.tracker
+              AND t.project=i.project AND t.item_kind=i.item_kind AND t.item_key=i.item_key
+         WHERE i.tracker=?1 AND i.project=?2 AND i.repo_id=?3
+         ORDER BY i.item_kind, i.item_key",
+    )?;
+    let rows =
+        stmt.query_map(params![binding.provider.as_db_str(), binding.project, repo_id], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, Option<String>>(2)?,
+            ))
+        })?;
+    let mut grouped = std::collections::BTreeMap::<(String, String), Vec<String>>::new();
+    for row in rows {
+        let (kind, key, tag) = row?;
+        if let Some(tag) = tag {
+            grouped.entry((kind, key)).or_default().push(tag);
+        } else {
+            grouped.entry((kind, key)).or_default();
+        }
+    }
+    drop(stmt);
+    let mut pruned = 0;
+    for ((kind, key), tags) in grouped {
+        if !tags.iter().any(|tag| wanted.binary_search(tag).is_ok()) {
+            pruned += usize::from(delete_item(conn, binding, ItemKind::from_db_str(&kind)?, &key)?);
+        }
+    }
+    Ok(pruned)
+}
+
+fn delete_item(
+    conn: &Connection,
+    binding: &ResolvedTracker,
+    kind: ItemKind,
+    key: &str,
+) -> anyhow::Result<bool> {
+    let repo_id = crate::index::schema::active_repo_id(conn)?;
+    let args =
+        params![repo_id, binding.provider.as_db_str(), binding.project, kind.as_db_str(), key];
+    conn.execute(
+        "DELETE FROM papertrail_fts WHERE repo_id=?1 AND tracker=?2 AND project=?3 AND \
+         item_kind=?4 AND item_key=?5",
+        args,
+    )?;
+    conn.execute(
+        "DELETE FROM papertrail_comments WHERE repo_id=?1 AND tracker=?2 AND project=?3 AND \
+         item_kind=?4 AND item_key=?5",
+        params![repo_id, binding.provider.as_db_str(), binding.project, kind.as_db_str(), key],
+    )?;
+    conn.execute(
+        "DELETE FROM papertrail_item_tags WHERE repo_id=?1 AND tracker=?2 AND project=?3 AND \
+         item_kind=?4 AND item_key=?5",
+        params![repo_id, binding.provider.as_db_str(), binding.project, kind.as_db_str(), key],
+    )?;
+    Ok(conn.execute(
+        "DELETE FROM papertrail_items WHERE repo_id=?1 AND tracker=?2 AND project=?3 AND \
+         item_kind=?4 AND item_key=?5",
+        params![repo_id, binding.provider.as_db_str(), binding.project, kind.as_db_str(), key],
+    )? > 0)
+}
+
+fn prune_unseen_item_comments(
+    conn: &Connection,
+    binding: &ResolvedTracker,
+    kind: ItemKind,
+    key: &str,
+    seen: &BTreeSet<String>,
+) -> anyhow::Result<()> {
+    let repo_id = crate::index::schema::active_repo_id(conn)?;
+    let stale = {
+        let mut stmt = conn.prepare(
+            "SELECT comment_id FROM papertrail_comments
+             WHERE repo_id=?1 AND tracker=?2 AND project=?3 AND item_kind=?4 AND item_key=?5",
+        )?;
+        stmt.query_map(
+            params![repo_id, binding.provider.as_db_str(), binding.project, kind.as_db_str(), key],
+            |row| row.get::<_, String>(0),
+        )?
+        .collect::<rusqlite::Result<Vec<_>>>()?
+        .into_iter()
+        .filter(|comment_id| !seen.contains(comment_id))
+        .collect::<Vec<_>>()
+    };
+    for comment_id in stale {
+        conn.execute(
+            "DELETE FROM papertrail_fts WHERE repo_id=?1 AND tracker=?2 AND project=?3 AND
+             item_kind=?4 AND item_key=?5 AND comment_id=?6 AND doc_kind='comment'",
+            params![
+                repo_id,
+                binding.provider.as_db_str(),
+                binding.project,
+                kind.as_db_str(),
+                key,
+                comment_id,
+            ],
+        )?;
+        conn.execute(
+            "DELETE FROM papertrail_comments WHERE repo_id=?1 AND tracker=?2 AND project=?3 AND
+             item_kind=?4 AND item_key=?5 AND comment_id=?6",
+            params![
+                repo_id,
+                binding.provider.as_db_str(),
+                binding.project,
+                kind.as_db_str(),
+                key,
+                comment_id,
+            ],
+        )?;
+    }
+    Ok(())
+}
+
+fn prune_missing(conn: &Connection, binding: &ResolvedTracker) -> anyhow::Result<usize> {
+    let repo_id = crate::index::schema::active_repo_id(conn)?;
+    let cached = {
+        let mut stmt = conn.prepare(
+            "SELECT item_kind, item_key FROM papertrail_items
+             WHERE repo_id=?1 AND tracker=?2 AND project=?3 AND full_rewalk_seen=0",
+        )?;
+        stmt.query_map(params![repo_id, binding.provider.as_db_str(), binding.project], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?
+    };
+    let mut pruned = 0;
+    for (kind, key) in cached {
+        let kind = ItemKind::from_db_str(&kind)?;
+        pruned += usize::from(delete_item(conn, binding, kind, &key)?);
+    }
+    Ok(pruned)
+}
+
+fn store_repo_comments(
+    conn: &Connection,
+    binding: &ResolvedTracker,
+    comments: &[PapertrailComment],
+    report: &mut MirrorBindingReport,
+) -> anyhow::Result<()> {
+    let repo_id = crate::index::schema::active_repo_id(conn)?;
+    let tx = conn.unchecked_transaction()?;
+    for comment in comments {
+        let kind = tx
+            .query_row(
+                "SELECT item_kind FROM papertrail_items WHERE repo_id=?1 AND tracker=?2 AND \
+                 project=?3 AND item_key=?4 LIMIT 1",
+                params![repo_id, binding.provider.as_db_str(), binding.project, comment.item_key],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()?;
+        let Some(kind) = kind else { continue };
+        let mut comment = comment.clone();
+        comment.item_kind = ItemKind::from_db_str(&kind)?;
+        store_comment(&tx, binding.provider, &comment)?;
+        report.stored_comments += 1;
+    }
+    tx.commit()?;
+    Ok(())
+}
+
+fn min_item_updated_at(items: &[PapertrailItem]) -> Option<String> {
+    items.iter().filter_map(|item| item.updated_at.clone()).min()
+}
+
+fn max_item_updated_at(items: &[PapertrailItem]) -> Option<String> {
+    items.iter().filter_map(|item| item.updated_at.clone()).max()
+}
+
+fn max_timestamp(left: Option<String>, right: Option<String>) -> Option<String> {
+    left.into_iter().chain(right).max()
+}
+
+fn common_comment_high_mark(streams: &BTreeMap<String, CommentStreamCursor>) -> Option<String> {
+    streams
+        .values()
+        .map(|stream| stream.high_mark_at.clone())
+        .collect::<Option<Vec<_>>>()?
+        .into_iter()
+        .min()
+}
+
+fn overlap_timestamp(timestamp: &str) -> String {
+    let Some(core) = timestamp.strip_suffix('Z') else { return timestamp.to_string() };
+    let Some((date, time)) = core.split_once('T') else { return timestamp.to_string() };
+    let Some((year, month, day)) = parse_date(date) else { return timestamp.to_string() };
+    let Some((mut hour, mut minute, mut second)) = parse_time(time) else {
+        return timestamp.to_string();
+    };
+    let (mut year, mut month, mut day) = (year, month, day);
+    if second > 0 {
+        second -= 1;
+    } else {
+        second = 59;
+        if minute > 0 {
+            minute -= 1;
+        } else {
+            minute = 59;
+            if hour > 0 {
+                hour -= 1;
+            } else {
+                hour = 23;
+                if day > 1 {
+                    day -= 1;
+                } else {
+                    if month > 1 {
+                        month -= 1;
+                    } else {
+                        year -= 1;
+                        month = 12;
+                    }
+                    day = days_in_month(year, month);
+                }
+            }
+        }
+    }
+    format!("{year:04}-{month:02}-{day:02}T{hour:02}:{minute:02}:{second:02}Z")
+}
+
+fn parse_date(value: &str) -> Option<(i32, u32, u32)> {
+    let mut parts = value.split('-');
+    let parsed =
+        (parts.next()?.parse().ok()?, parts.next()?.parse().ok()?, parts.next()?.parse().ok()?);
+    parts.next().is_none().then_some(parsed)
+}
+
+fn parse_time(value: &str) -> Option<(u32, u32, u32)> {
+    let mut parts = value.split(':');
+    let parsed =
+        (parts.next()?.parse().ok()?, parts.next()?.parse().ok()?, parts.next()?.parse().ok()?);
+    parts.next().is_none().then_some(parsed)
+}
+
+fn days_in_month(year: i32, month: u32) -> u32 {
+    match month {
+        4 | 6 | 9 | 11 => 30,
+        2 if year % 4 == 0 && (year % 100 != 0 || year % 400 == 0) => 29,
+        2 => 28,
+        _ => 31,
+    }
+}
+
+fn pause(error: &anyhow::Error) -> Option<(i64, PauseReason)> {
+    error.chain().find_map(|cause| {
+        cause.downcast_ref::<TransportError>().and_then(|error| match error {
+            TransportError::Paused { resume_at_ms, reason } => Some((*resume_at_ms, *reason)),
+            _ => None,
+        })
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::RefCell;
+    use std::collections::VecDeque;
+
+    use super::*;
+    use crate::index::schema;
+
+    struct ScriptClient {
+        comment_streams: &'static [&'static str],
+        pages: RefCell<VecDeque<anyhow::Result<ItemsPage>>>,
+        probes: RefCell<VecDeque<FreshnessResult>>,
+        item_comments: RefCell<VecDeque<anyhow::Result<Vec<PapertrailComment>>>>,
+        item_comment_pages: RefCell<VecDeque<anyhow::Result<CommentsPage>>>,
+        repo_comments: RefCell<VecDeque<anyhow::Result<CommentsPage>>>,
+        item_page_requests: RefCell<Vec<PageCursor>>,
+        item_comment_requests: RefCell<Vec<String>>,
+        item_comment_page_requests: RefCell<Vec<PageCursor>>,
+        repo_comment_requests: RefCell<Vec<PageCursor>>,
+    }
+
+    impl ScriptClient {
+        fn new(pages: Vec<anyhow::Result<ItemsPage>>) -> Self {
+            Self {
+                comment_streams: &["default"],
+                pages: RefCell::new(pages.into()),
+                probes: RefCell::new(VecDeque::new()),
+                item_comments: RefCell::new(VecDeque::new()),
+                item_comment_pages: RefCell::new(VecDeque::new()),
+                repo_comments: RefCell::new(VecDeque::new()),
+                item_page_requests: RefCell::new(Vec::new()),
+                item_comment_requests: RefCell::new(Vec::new()),
+                item_comment_page_requests: RefCell::new(Vec::new()),
+                repo_comment_requests: RefCell::new(Vec::new()),
+            }
+        }
+
+        fn with_probe(self, probe: FreshnessResult) -> Self {
+            self.probes.borrow_mut().push_back(probe);
+            self
+        }
+
+        fn with_comment_streams(mut self, streams: &'static [&'static str]) -> Self {
+            self.comment_streams = streams;
+            self
+        }
+
+        fn with_item_comments(self, comments: Vec<PapertrailComment>) -> Self {
+            self.item_comments.borrow_mut().push_back(Ok(comments));
+            self
+        }
+
+        fn with_item_comment_results(
+            self,
+            results: Vec<anyhow::Result<Vec<PapertrailComment>>>,
+        ) -> Self {
+            self.item_comments.borrow_mut().extend(results);
+            self
+        }
+
+        fn with_item_comment_pages(self, pages: Vec<anyhow::Result<CommentsPage>>) -> Self {
+            self.item_comment_pages.borrow_mut().extend(pages);
+            self
+        }
+
+        fn with_repo_comments(self, comments: Vec<PapertrailComment>) -> Self {
+            self.repo_comments.borrow_mut().push_back(Ok(CommentsPage { comments, next: None }));
+            self
+        }
+
+        fn with_repo_comment_pages(self, pages: Vec<anyhow::Result<CommentsPage>>) -> Self {
+            self.repo_comments.borrow_mut().extend(pages);
+            self
+        }
+    }
+
+    impl PapertrailClient for ScriptClient {
+        fn comment_streams(&self) -> &'static [&'static str] {
+            self.comment_streams
+        }
+
+        async fn item(
+            &self,
+            _project: &str,
+            _kind: ItemKind,
+            _key: &str,
+        ) -> anyhow::Result<PapertrailItem> {
+            anyhow::bail!("unused")
+        }
+
+        async fn item_comments(
+            &self,
+            _project: &str,
+            _kind: ItemKind,
+            key: &str,
+        ) -> anyhow::Result<Vec<PapertrailComment>> {
+            self.item_comment_requests.borrow_mut().push(key.to_string());
+            self.item_comments.borrow_mut().pop_front().unwrap_or(Ok(Vec::new()))
+        }
+
+        async fn item_comments_page(
+            &self,
+            _project: &str,
+            _kind: ItemKind,
+            key: &str,
+            cursor: &PageCursor,
+        ) -> anyhow::Result<CommentsPage> {
+            self.item_comment_requests.borrow_mut().push(key.to_string());
+            self.item_comment_page_requests.borrow_mut().push(cursor.clone());
+            if let Some(page) = self.item_comment_pages.borrow_mut().pop_front() {
+                return page;
+            }
+            Ok(CommentsPage {
+                comments: self.item_comments.borrow_mut().pop_front().unwrap_or(Ok(Vec::new()))?,
+                next: None,
+            })
+        }
+
+        async fn items_page(
+            &self,
+            _project: &str,
+            cursor: &PageCursor,
+        ) -> anyhow::Result<ItemsPage> {
+            self.item_page_requests.borrow_mut().push(cursor.clone());
+            self.pages.borrow_mut().pop_front().expect("scripted item page")
+        }
+
+        async fn comments_page(
+            &self,
+            _project: &str,
+            cursor: &PageCursor,
+        ) -> anyhow::Result<CommentsPage> {
+            self.repo_comment_requests.borrow_mut().push(cursor.clone());
+            self.repo_comments
+                .borrow_mut()
+                .pop_front()
+                .unwrap_or(Ok(CommentsPage { comments: Vec::new(), next: None }))
+        }
+
+        async fn freshness_probe(
+            &self,
+            _project: &str,
+            probe: &FreshnessProbe,
+        ) -> anyhow::Result<FreshnessResult> {
+            Ok(self.probes.borrow_mut().pop_front().unwrap_or(FreshnessResult {
+                latest: None,
+                etag: probe.etag.clone(),
+                not_modified: true,
+            }))
+        }
+    }
+
+    #[test]
+    fn provider_pagination_must_advance_some_cursor_state() {
+        let current =
+            PageCursor { page_token: Some("page-2".to_string()), ..PageCursor::default() };
+        assert!(ensure_cursor_advanced(&current, &current, "test").is_err());
+
+        let mut next = current.clone();
+        next.provider_state = Some("opaque-state".to_string());
+        ensure_cursor_advanced(&current, &next, "test").unwrap();
+    }
+
+    fn binding(tags: &[&str]) -> ResolvedTracker {
+        ResolvedTracker {
+            provider: Tracker::Github,
+            project: "o/r".to_string(),
+            base_url: None,
+            auth: None,
+            authentication: TrackerAuthentication::AuthMissing,
+            tags: tags.iter().map(|tag| (*tag).to_string()).collect(),
+        }
+    }
+
+    fn item(key: &str, updated_at: &str, title: &str, tags: &[&str]) -> PapertrailItem {
+        PapertrailItem {
+            project: "o/r".to_string(),
+            item_kind: ItemKind::Issue,
+            item_key: key.to_string(),
+            url: format!("https://github.com/o/r/issues/{key}"),
+            state: "open".to_string(),
+            title: title.to_string(),
+            body: String::new(),
+            author: None,
+            created_at: None,
+            updated_at: Some(updated_at.to_string()),
+            merged_at: None,
+            tags: tags.iter().map(|tag| (*tag).to_string()).collect(),
+        }
+    }
+
+    fn page(items: Vec<PapertrailItem>) -> anyhow::Result<ItemsPage> {
+        Ok(ItemsPage { items, next: None, backfill_boundary: None })
+    }
+
+    fn comment(key: &str, id: &str, updated_at: &str) -> PapertrailComment {
+        PapertrailComment {
+            project: "o/r".to_string(),
+            item_kind: ItemKind::Issue,
+            item_key: key.to_string(),
+            comment_id: id.to_string(),
+            url: None,
+            body: "comment".to_string(),
+            author: None,
+            created_at: Some(updated_at.to_string()),
+            updated_at: Some(updated_at.to_string()),
+            review_state: None,
+            anchor_path: None,
+        }
+    }
+
+    fn db() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        schema::apply(&conn).unwrap();
+        conn
+    }
+
+    fn keys(conn: &Connection) -> Vec<String> {
+        let mut stmt =
+            conn.prepare("SELECT item_key FROM papertrail_items ORDER BY item_key").unwrap();
+        stmt.query_map([], |row| row.get(0)).unwrap().map(Result::unwrap).collect()
+    }
+
+    #[test]
+    fn lifo_backfill_resumes_after_pause_without_gaps_or_duplicates() {
+        let conn = db();
+        let binding = binding(&[]);
+        let paused = anyhow::Error::new(TransportError::Paused {
+            resume_at_ms: 42,
+            reason: PauseReason::QuotaReserve,
+        });
+        let first = ScriptClient::new(vec![
+            page(vec![
+                item("3", "2026-01-03T00:00:00Z", "three", &[]),
+                item("2", "2026-01-02T00:00:00Z", "two", &[]),
+            ]),
+            Err(paused),
+        ]);
+        let report = block_on(mirror_binding(&conn, &binding, &first, false)).unwrap();
+        assert_eq!(report.paused_until_ms, Some(42));
+        assert_eq!(keys(&conn), vec!["2", "3"]);
+
+        let second = ScriptClient::new(vec![
+            page(vec![item("1", "2026-01-01T00:00:00Z", "one", &[])]),
+            page(Vec::new()),
+        ]);
+        block_on(mirror_binding(&conn, &binding, &second, false)).unwrap();
+        assert_eq!(keys(&conn), vec!["1", "2", "3"]);
+        let distinct: i64 = conn
+            .query_row("SELECT COUNT(DISTINCT item_key) FROM papertrail_items", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        assert_eq!(distinct, 3);
+    }
+
+    #[test]
+    fn item_threads_commit_individually_and_resume_without_refetching_finished_threads() {
+        let conn = db();
+        let binding = binding(&[]);
+        let same_page = vec![
+            item("2", "2026-01-02T00:00:00Z", "two", &[]),
+            item("1", "2026-01-01T00:00:00Z", "one", &[]),
+        ];
+        let first =
+            ScriptClient::new(vec![page(same_page.clone())]).with_item_comment_results(vec![
+                Ok(vec![comment("2", "two-comment", "2026-01-02T01:00:00Z")]),
+                Err(anyhow::Error::new(TransportError::Paused {
+                    resume_at_ms: 42,
+                    reason: PauseReason::PassBudget,
+                })),
+            ]);
+        let report = block_on(mirror_binding(&conn, &binding, &first, false)).unwrap();
+        assert_eq!(report.paused_until_ms, Some(42));
+        assert_eq!(keys(&conn), vec!["1", "2"]);
+
+        let resumed = ScriptClient::new(vec![page(same_page), page(Vec::new())])
+            .with_item_comments(vec![comment("1", "one-comment", "2026-01-01T01:00:00Z")]);
+        block_on(mirror_binding(&conn, &binding, &resumed, false)).unwrap();
+        assert_eq!(resumed.item_comment_requests.borrow().as_slice(), ["1"]);
+        assert_eq!(keys(&conn), vec!["1", "2"]);
+    }
+
+    #[test]
+    fn resumed_item_thread_revalidates_earlier_pages_before_pruning_deleted_comments() {
+        let conn = db();
+        let binding = binding(&[]);
+        let provider_page = vec![item("1", "2026-01-01T00:00:00Z", "one", &[])];
+        let next = PageCursor {
+            stream: Some("default".to_string()),
+            page_token: Some("thread-page-2".to_string()),
+            ..PageCursor::default()
+        };
+        let first =
+            ScriptClient::new(vec![page(provider_page.clone())]).with_item_comment_pages(vec![
+                Ok(CommentsPage {
+                    comments: vec![comment("1", "first", "2026-01-01T01:00:00Z")],
+                    next: Some(next),
+                }),
+                Err(anyhow::Error::new(TransportError::Paused {
+                    resume_at_ms: 42,
+                    reason: PauseReason::PassBudget,
+                })),
+            ]);
+        let report = block_on(mirror_binding(&conn, &binding, &first, false)).unwrap();
+        assert_eq!(report.paused_until_ms, Some(42));
+        assert_eq!(report.stored_comments, 1);
+        let cursor = load_cursor(&conn, &binding).unwrap();
+        assert_eq!(
+            cursor
+                .item_thread_cursor
+                .as_ref()
+                .and_then(|thread| thread.page_cursor.as_ref())
+                .and_then(|cursor| cursor.page_token.as_deref()),
+            Some("thread-page-2")
+        );
+
+        let resumed = ScriptClient::new(vec![page(provider_page), page(Vec::new())])
+            .with_item_comment_pages(vec![
+                Ok(CommentsPage {
+                    // The first-page comment was deleted while this thread was paused.
+                    comments: Vec::new(),
+                    next: Some(PageCursor {
+                        stream: Some("default".to_string()),
+                        page_token: Some("thread-page-2".to_string()),
+                        ..PageCursor::default()
+                    }),
+                }),
+                Ok(CommentsPage {
+                    comments: vec![comment("1", "second", "2026-01-01T02:00:00Z")],
+                    next: None,
+                }),
+                // The confirming walk is identical, so absence of the deleted first comment is
+                // now safe to apply destructively.
+                Ok(CommentsPage {
+                    comments: vec![comment("1", "second", "2026-01-01T02:00:00Z")],
+                    next: None,
+                }),
+            ]);
+        block_on(mirror_binding(&conn, &binding, &resumed, false)).unwrap();
+        let requests = resumed.item_comment_page_requests.borrow();
+        assert_eq!(requests[0].page_token, None);
+        assert_eq!(requests[1].page_token.as_deref(), Some("thread-page-2"));
+        assert_eq!(requests[2].page_token, None);
+        assert!(load_cursor(&conn, &binding).unwrap().item_thread_cursor.is_none());
+        let comments: Vec<String> = conn
+            .prepare("SELECT comment_id FROM papertrail_comments ORDER BY comment_id")
+            .unwrap()
+            .query_map([], |row| row.get(0))
+            .unwrap()
+            .collect::<rusqlite::Result<_>>()
+            .unwrap();
+        assert_eq!(comments, vec!["second"]);
+    }
+
+    #[test]
+    fn search_tie_pages_commit_and_resume_from_the_opaque_provider_cursor() {
+        let conn = db();
+        let binding = binding(&[]);
+        let continuation = PageCursor {
+            stream: Some("search_backfill".to_string()),
+            updated_before: Some("2026-01-02T00:00:00Z".to_string()),
+            page_token: Some("tie-page-2".to_string()),
+            provider_state: Some("opaque-tie-state".to_string()),
+            ..PageCursor::default()
+        };
+        let first = ScriptClient::new(vec![
+            Ok(ItemsPage {
+                items: vec![item("2", "2026-01-02T00:00:00Z", "two", &[])],
+                next: Some(continuation),
+                backfill_boundary: None,
+            }),
+            Err(anyhow::Error::new(TransportError::Paused {
+                resume_at_ms: 42,
+                reason: PauseReason::QuotaReserve,
+            })),
+        ]);
+        let report = block_on(mirror_binding(&conn, &binding, &first, false)).unwrap();
+        assert_eq!(report.paused_until_ms, Some(42));
+        assert_eq!(keys(&conn), vec!["2"]);
+        assert_eq!(
+            load_cursor(&conn, &binding)
+                .unwrap()
+                .backfill_page_cursor
+                .and_then(|cursor| cursor.page_token),
+            Some("tie-page-2".to_string())
+        );
+
+        let resumed = ScriptClient::new(vec![
+            page(vec![item("1", "2026-01-02T00:00:00Z", "one", &[])]),
+            page(Vec::new()),
+        ]);
+        block_on(mirror_binding(&conn, &binding, &resumed, false)).unwrap();
+        let request = &resumed.item_page_requests.borrow()[0];
+        assert_eq!(request.page_token.as_deref(), Some("tie-page-2"));
+        assert_eq!(request.provider_state.as_deref(), Some("opaque-tie-state"));
+        assert_eq!(keys(&conn), vec!["1", "2"]);
+    }
+
+    #[test]
+    fn compound_provider_boundary_advances_below_every_physical_stream_page() {
+        let conn = db();
+        let binding = binding(&[]);
+        let client = ScriptClient::new(vec![
+            Ok(ItemsPage {
+                items: vec![item("5", "2026-01-05T00:00:00Z", "pull", &[])],
+                next: None,
+                backfill_boundary: Some("2026-01-01T00:00:00Z".to_string()),
+            }),
+            page(Vec::new()),
+        ]);
+        block_on(mirror_binding(&conn, &binding, &client, false)).unwrap();
+
+        let requests = client.item_page_requests.borrow();
+        assert_eq!(requests.len(), 2);
+        assert_eq!(requests[1].updated_before.as_deref(), Some("2026-01-01T00:00:00Z"));
+    }
+
+    #[test]
+    fn resumed_page_refreshes_a_completed_item_when_its_provider_version_changed() {
+        let conn = db();
+        let binding = binding(&[]);
+        let old_page = vec![
+            item("2", "2026-01-02T00:00:00Z", "old", &[]),
+            item("1", "2026-01-01T00:00:00Z", "one", &[]),
+        ];
+        let first = ScriptClient::new(vec![page(old_page)]).with_item_comment_results(vec![
+            Ok(vec![comment("2", "old-comment", "2026-01-02T01:00:00Z")]),
+            Err(anyhow::Error::new(TransportError::Paused {
+                resume_at_ms: 42,
+                reason: PauseReason::PassBudget,
+            })),
+        ]);
+        block_on(mirror_binding(&conn, &binding, &first, false)).unwrap();
+
+        let changed_page = vec![
+            item("2", "2026-01-03T00:00:00Z", "new", &[]),
+            item("1", "2026-01-01T00:00:00Z", "one", &[]),
+        ];
+        let resumed = ScriptClient::new(vec![page(changed_page), page(Vec::new())])
+            .with_item_comment_results(vec![
+                Ok(Vec::new()),
+                Ok(vec![comment("2", "new-comment", "2026-01-03T01:00:00Z")]),
+            ]);
+        block_on(mirror_binding(&conn, &binding, &resumed, false)).unwrap();
+
+        assert_eq!(resumed.item_comment_requests.borrow().as_slice(), ["1", "2"]);
+        let title: String = conn
+            .query_row("SELECT title FROM papertrail_items WHERE item_key='2'", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        assert_eq!(title, "new");
+        let comment_ids = conn
+            .prepare("SELECT comment_id FROM papertrail_comments WHERE item_key='2'")
+            .unwrap()
+            .query_map([], |row| row.get::<_, String>(0))
+            .unwrap()
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .unwrap();
+        assert_eq!(comment_ids, vec!["new-comment"]);
+    }
+
+    #[test]
+    fn resumed_changed_item_is_pruned_when_it_no_longer_matches_the_binding() {
+        let conn = db();
+        let binding = binding(&["bug"]);
+        let first =
+            ScriptClient::new(vec![page(vec![item("1", "2026-01-01T00:00:00Z", "old", &["bug"])])])
+                .with_item_comment_results(vec![Err(anyhow::Error::new(TransportError::Paused {
+                    resume_at_ms: 42,
+                    reason: PauseReason::PassBudget,
+                }))]);
+        let report = block_on(mirror_binding(&conn, &binding, &first, false)).unwrap();
+        assert_eq!(report.paused_until_ms, Some(42));
+        assert_eq!(keys(&conn), vec!["1"]);
+
+        let resumed = ScriptClient::new(vec![
+            page(vec![item("1", "2026-01-02T00:00:00Z", "changed", &["feature"])]),
+            page(Vec::new()),
+        ]);
+        let report = block_on(mirror_binding(&conn, &binding, &resumed, false)).unwrap();
+        assert_eq!(report.pruned_items, 1);
+        assert!(keys(&conn).is_empty());
+        assert!(resumed.item_comment_requests.borrow().is_empty());
+        assert!(load_cursor(&conn, &binding).unwrap().item_thread_cursor.is_none());
+    }
+
+    #[test]
+    fn empty_initial_project_enters_delta_polling_and_discovers_later_items() {
+        let conn = db();
+        let binding = binding(&[]);
+        block_on(mirror_binding(
+            &conn,
+            &binding,
+            &ScriptClient::new(vec![page(Vec::new())]),
+            false,
+        ))
+        .unwrap();
+        let cursor = load_cursor(&conn, &binding).unwrap();
+        assert!(cursor.backfill_done);
+        assert_eq!(cursor.high_mark_at.as_deref(), Some(EMPTY_PROJECT_HIGH_MARK));
+
+        let later =
+            ScriptClient::new(vec![page(vec![item("1", "2026-01-01T00:00:00Z", "later", &[])])])
+                .with_probe(FreshnessResult {
+                    latest: Some("2026-01-01T00:00:00Z".to_string()),
+                    etag: Some("v1".to_string()),
+                    not_modified: false,
+                });
+        block_on(mirror_binding(&conn, &binding, &later, false)).unwrap();
+        assert_eq!(keys(&conn), vec!["1"]);
+        assert_eq!(
+            later.item_page_requests.borrow()[0].updated_since.as_deref(),
+            Some("1969-12-31T23:59:59Z")
+        );
+    }
+
+    #[test]
+    fn delta_catches_an_item_updated_while_backfill_is_paused() {
+        let conn = db();
+        let binding = binding(&[]);
+        let first = ScriptClient::new(vec![
+            page(vec![item("2", "2026-01-02T00:00:00Z", "old", &[])]),
+            Err(anyhow::Error::new(TransportError::Paused {
+                resume_at_ms: 42,
+                reason: PauseReason::PassBudget,
+            })),
+        ]);
+        block_on(mirror_binding(&conn, &binding, &first, false)).unwrap();
+        let second = ScriptClient::new(vec![
+            page(vec![item("2", "2026-01-04T00:00:00Z", "updated", &[])]),
+            page(Vec::new()),
+            page(Vec::new()),
+        ])
+        .with_probe(FreshnessResult {
+            latest: Some("2026-01-04T00:00:00Z".to_string()),
+            etag: Some("v2".to_string()),
+            not_modified: false,
+        });
+        block_on(mirror_binding(&conn, &binding, &second, false)).unwrap();
+        let title: String = conn
+            .query_row("SELECT title FROM papertrail_items WHERE item_key='2'", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        assert_eq!(title, "updated");
+    }
+
+    #[test]
+    fn changed_etag_replays_the_overlap_even_when_latest_timestamp_is_tied() {
+        let conn = db();
+        let binding = binding(&[]);
+        let initial = ScriptClient::new(vec![
+            page(vec![item("1", "2026-01-02T00:00:00Z", "old", &[])]),
+            page(Vec::new()),
+        ]);
+        block_on(mirror_binding(&conn, &binding, &initial, false)).unwrap();
+
+        let tied = ScriptClient::new(vec![page(vec![item(
+            "2",
+            "2026-01-02T00:00:00Z",
+            "same-second",
+            &[],
+        )])])
+        .with_probe(FreshnessResult {
+            latest: None,
+            etag: Some("changed".to_string()),
+            not_modified: false,
+        });
+        block_on(mirror_binding(&conn, &binding, &tied, false)).unwrap();
+        assert_eq!(keys(&conn), vec!["1", "2"]);
+        assert_eq!(
+            load_cursor(&conn, &binding).unwrap().high_mark_at.as_deref(),
+            Some("2026-01-02T00:00:00Z")
+        );
+    }
+
+    #[test]
+    fn item_delta_persists_the_next_page_before_a_pause() {
+        let conn = db();
+        let binding = binding(&[]);
+        let initial = ScriptClient::new(vec![
+            page(vec![item("1", "2026-01-01T00:00:00Z", "one", &[])]),
+            page(Vec::new()),
+        ]);
+        block_on(mirror_binding(&conn, &binding, &initial, false)).unwrap();
+
+        let next = PageCursor {
+            updated_since: Some("2025-12-31T23:59:59Z".to_string()),
+            page_token: Some("delta-page-2".to_string()),
+            ..PageCursor::default()
+        };
+        let paused = ScriptClient::new(vec![
+            Ok(ItemsPage {
+                items: vec![item("2", "2026-01-02T00:00:00Z", "two", &[])],
+                next: Some(next),
+                backfill_boundary: None,
+            }),
+            Err(anyhow::Error::new(TransportError::Paused {
+                resume_at_ms: 42,
+                reason: PauseReason::PassBudget,
+            })),
+        ])
+        .with_probe(FreshnessResult {
+            latest: Some("2026-01-02T00:00:00Z".to_string()),
+            etag: Some("v2".to_string()),
+            not_modified: false,
+        });
+        let report = block_on(mirror_binding(&conn, &binding, &paused, false)).unwrap();
+        assert_eq!(report.paused_until_ms, Some(42));
+        let cursor = load_cursor(&conn, &binding).unwrap();
+        assert!(cursor.item_delta_in_progress);
+        assert_eq!(cursor.item_delta_page_token.as_deref(), Some("delta-page-2"));
+
+        let resumed =
+            ScriptClient::new(vec![page(vec![item("3", "2026-01-03T00:00:00Z", "three", &[])])]);
+        block_on(mirror_binding(&conn, &binding, &resumed, false)).unwrap();
+        assert_eq!(
+            resumed.item_page_requests.borrow()[0].page_token.as_deref(),
+            Some("delta-page-2")
+        );
+        assert_eq!(
+            resumed.item_page_requests.borrow()[0].updated_since.as_deref(),
+            Some("2025-12-31T23:59:59Z")
+        );
+        assert_eq!(keys(&conn), vec!["1", "2", "3"]);
+    }
+
+    #[test]
+    fn paginated_item_delta_advances_only_to_the_first_page_frontier() {
+        let conn = db();
+        let binding = binding(&[]);
+        let initial = ScriptClient::new(vec![
+            page(vec![item("1", "2026-01-01T00:00:00Z", "one", &[])]),
+            page(Vec::new()),
+        ]);
+        block_on(mirror_binding(&conn, &binding, &initial, false)).unwrap();
+
+        let next =
+            PageCursor { page_token: Some("delta-page-2".to_string()), ..Default::default() };
+        let delta = ScriptClient::new(vec![
+            Ok(ItemsPage {
+                items: vec![item("2", "2026-01-02T00:00:00Z", "two", &[])],
+                next: Some(next),
+                backfill_boundary: None,
+            }),
+            page(vec![item("3", "2026-01-04T00:00:00Z", "three", &[])]),
+        ])
+        .with_probe(FreshnessResult {
+            latest: Some("2026-01-05T00:00:00Z".to_string()),
+            etag: Some("v2".to_string()),
+            not_modified: false,
+        });
+        block_on(mirror_binding(&conn, &binding, &delta, false)).unwrap();
+
+        let cursor = load_cursor(&conn, &binding).unwrap();
+        assert_eq!(cursor.high_mark_at.as_deref(), Some("2026-01-02T00:00:00Z"));
+        assert!(cursor.probe_etag.is_none(), "the conservative frontier must force a replay");
+        assert_eq!(keys(&conn), vec!["1", "2", "3"]);
+
+        let replay = ScriptClient::new(vec![page(vec![item(
+            "4",
+            "2026-01-03T00:00:00Z",
+            "shifted boundary row",
+            &[],
+        )])])
+        .with_probe(FreshnessResult {
+            latest: Some("2026-01-05T00:00:00Z".to_string()),
+            etag: Some("v2".to_string()),
+            not_modified: false,
+        });
+        block_on(mirror_binding(&conn, &binding, &replay, false)).unwrap();
+        assert_eq!(keys(&conn), vec!["1", "2", "3", "4"]);
+    }
+
+    #[test]
+    fn item_delta_does_not_advance_to_an_unobserved_probe_timestamp() {
+        let conn = db();
+        let binding = binding(&[]);
+        let initial = ScriptClient::new(vec![
+            page(vec![item("1", "2026-01-01T00:00:00Z", "one", &[])]),
+            page(Vec::new()),
+        ]);
+        block_on(mirror_binding(&conn, &binding, &initial, false)).unwrap();
+
+        let raced = ScriptClient::new(vec![page(Vec::new())]).with_probe(FreshnessResult {
+            latest: Some("2026-01-05T00:00:00Z".to_string()),
+            etag: Some("v2".to_string()),
+            not_modified: false,
+        });
+        block_on(mirror_binding(&conn, &binding, &raced, false)).unwrap();
+
+        let cursor = load_cursor(&conn, &binding).unwrap();
+        assert_eq!(cursor.high_mark_at.as_deref(), Some("2026-01-01T00:00:00Z"));
+        assert!(cursor.probe_etag.is_none());
+    }
+
+    #[test]
+    fn a_stable_paginated_tie_settles_after_one_forced_replay() {
+        let conn = db();
+        let binding = binding(&[]);
+        let initial = ScriptClient::new(vec![
+            page(vec![item("1", "2026-01-01T00:00:00Z", "one", &[])]),
+            page(Vec::new()),
+        ]);
+        block_on(mirror_binding(&conn, &binding, &initial, false)).unwrap();
+
+        let tied_page = || {
+            Ok(ItemsPage {
+                items: vec![item("2", "2026-01-02T00:00:00Z", "tie", &[])],
+                next: Some(PageCursor {
+                    page_token: Some("tie-page-2".to_string()),
+                    ..PageCursor::default()
+                }),
+                backfill_boundary: None,
+            })
+        };
+        let first =
+            ScriptClient::new(vec![tied_page(), page(Vec::new())]).with_probe(FreshnessResult {
+                latest: Some("2026-01-02T00:00:00Z".to_string()),
+                etag: Some("v2".to_string()),
+                not_modified: false,
+            });
+        block_on(mirror_binding(&conn, &binding, &first, false)).unwrap();
+        let cursor = load_cursor(&conn, &binding).unwrap();
+        assert!(cursor.item_delta_replay_required);
+        assert!(cursor.probe_etag.is_none());
+
+        let replay =
+            ScriptClient::new(vec![tied_page(), page(Vec::new())]).with_probe(FreshnessResult {
+                latest: None,
+                etag: Some("v2".to_string()),
+                not_modified: false,
+            });
+        block_on(mirror_binding(&conn, &binding, &replay, false)).unwrap();
+        let cursor = load_cursor(&conn, &binding).unwrap();
+        assert!(!cursor.item_delta_replay_required);
+        assert_eq!(cursor.probe_etag.as_deref(), Some("v2"));
+    }
+
+    #[test]
+    fn changing_tag_filter_prunes_and_backfills_the_new_match_set() {
+        let conn = db();
+        let bug = binding(&["bug"]);
+        let initial = ScriptClient::new(vec![
+            page(vec![item("1", "2026-01-02T00:00:00Z", "bug", &["bug"])]),
+            page(Vec::new()),
+        ]);
+        block_on(mirror_binding(&conn, &bug, &initial, false)).unwrap();
+        assert_eq!(keys(&conn), vec!["1"]);
+
+        let docs = binding(&["docs"]);
+        let changed = ScriptClient::new(vec![
+            page(vec![item("2", "2026-01-03T00:00:00Z", "docs", &["docs"])]),
+            page(Vec::new()),
+        ]);
+        let report = block_on(mirror_binding(&conn, &docs, &changed, false)).unwrap();
+        assert_eq!(report.pruned_items, 1);
+        assert_eq!(keys(&conn), vec!["2"]);
+    }
+
+    #[test]
+    fn forced_full_rewalk_heals_a_poisoned_row() {
+        let conn = db();
+        let binding = binding(&[]);
+        store_item(&conn, Tracker::Github, &item("1", "2026-01-01T00:00:00Z", "poison", &[]))
+            .unwrap();
+        store_item(&conn, Tracker::Github, &item("2", "2026-01-01T00:00:00Z", "deleted", &[]))
+            .unwrap();
+        let client = ScriptClient::new(vec![
+            page(vec![item("1", "2026-01-01T00:00:00Z", "healed", &[])]),
+            page(Vec::new()),
+        ]);
+        let report = block_on(mirror_binding(&conn, &binding, &client, true)).unwrap();
+        let title: String = conn
+            .query_row("SELECT title FROM papertrail_items WHERE item_key='1'", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        assert_eq!(title, "healed");
+        assert_eq!(report.pruned_items, 1);
+        assert_eq!(keys(&conn), vec!["1"]);
+    }
+
+    #[test]
+    fn full_rewalk_pruning_survives_a_pause_and_an_ordinary_resume() {
+        let conn = db();
+        let binding = binding(&[]);
+        store_item(&conn, Tracker::Github, &item("1", "2026-01-01T00:00:00Z", "kept", &[]))
+            .unwrap();
+        store_item(&conn, Tracker::Github, &item("2", "2026-01-01T00:00:00Z", "gone", &[]))
+            .unwrap();
+        let paused = ScriptClient::new(vec![
+            page(vec![item("1", "2026-01-01T00:00:00Z", "kept", &[])]),
+            Err(anyhow::Error::new(TransportError::Paused {
+                resume_at_ms: 42,
+                reason: PauseReason::PassBudget,
+            })),
+        ]);
+        let report = block_on(mirror_binding(&conn, &binding, &paused, true)).unwrap();
+        assert_eq!(report.paused_until_ms, Some(42));
+        assert!(load_cursor(&conn, &binding).unwrap().full_rewalk);
+        assert_eq!(keys(&conn), vec!["1", "2"]);
+
+        let resumed = ScriptClient::new(vec![page(Vec::new())]);
+        let report = block_on(mirror_binding(&conn, &binding, &resumed, false)).unwrap();
+        assert_eq!(report.pruned_items, 1);
+        assert!(!load_cursor(&conn, &binding).unwrap().full_rewalk);
+        assert_eq!(keys(&conn), vec!["1"]);
+    }
+
+    #[test]
+    fn non_pause_errors_propagate_and_pause_classifier_ignores_them() {
+        let conn = db();
+        let binding = binding(&[]);
+        let client = ScriptClient::new(vec![Err(anyhow::anyhow!("provider failed"))]);
+        let error = block_on(mirror_binding(&conn, &binding, &client, false)).unwrap_err();
+        assert_eq!(error.to_string(), "provider failed");
+        assert!(pause(&error).is_none());
+
+        let unused = block_on(client.item("o/r", ItemKind::Issue, "1")).unwrap_err();
+        assert_eq!(unused.to_string(), "unused");
+    }
+
+    #[test]
+    fn failed_comment_refresh_keeps_the_previous_complete_thread() {
+        let conn = db();
+        let binding = binding(&[]);
+        let initial = ScriptClient::new(vec![
+            page(vec![item("1", "2026-01-01T00:00:00Z", "initial", &[])]),
+            page(Vec::new()),
+        ])
+        .with_item_comments(vec![comment("1", "old", "2026-01-01T01:00:00Z")]);
+        block_on(mirror_binding(&conn, &binding, &initial, false)).unwrap();
+
+        let failed =
+            ScriptClient::new(vec![page(vec![item("1", "2026-01-02T00:00:00Z", "updated", &[])])])
+                .with_probe(FreshnessResult {
+                    latest: Some("2026-01-02T00:00:00Z".to_string()),
+                    etag: Some("v2".to_string()),
+                    not_modified: false,
+                })
+                .with_item_comment_results(vec![Err(anyhow::anyhow!("comment fetch failed"))]);
+        let error = block_on(mirror_binding(&conn, &binding, &failed, false)).unwrap_err();
+        assert_eq!(error.to_string(), "comment fetch failed");
+        let comments: Vec<String> = conn
+            .prepare("SELECT comment_id FROM papertrail_comments ORDER BY comment_id")
+            .unwrap()
+            .query_map([], |row| row.get(0))
+            .unwrap()
+            .collect::<rusqlite::Result<_>>()
+            .unwrap();
+        assert_eq!(comments, vec!["old"]);
+    }
+
+    #[test]
+    fn invalid_item_delta_continuation_is_not_persisted() {
+        let conn = db();
+        let binding = binding(&[]);
+        let initial = ScriptClient::new(vec![
+            page(vec![item("1", "2026-01-01T00:00:00Z", "initial", &[])]),
+            page(Vec::new()),
+        ]);
+        block_on(mirror_binding(&conn, &binding, &initial, false)).unwrap();
+
+        let unchanged = PageCursor {
+            updated_since: Some("2025-12-31T23:59:59Z".to_string()),
+            ..PageCursor::default()
+        };
+        let invalid = ScriptClient::new(vec![Ok(ItemsPage {
+            items: vec![item("2", "2026-01-02T00:00:00Z", "must-not-commit", &[])],
+            next: Some(unchanged),
+            backfill_boundary: None,
+        })])
+        .with_probe(FreshnessResult {
+            latest: Some("2026-01-02T00:00:00Z".to_string()),
+            etag: Some("v2".to_string()),
+            not_modified: false,
+        });
+        let error = block_on(mirror_binding(&conn, &binding, &invalid, false)).unwrap_err();
+        assert!(error.to_string().contains("did not advance"));
+        let cursor = load_cursor(&conn, &binding).unwrap();
+        assert_eq!(cursor.item_delta_page_token, None);
+        assert!(cursor.item_delta_in_progress, "the valid scan start remains retryable");
+        assert_eq!(keys(&conn), vec!["1"]);
+    }
+
+    #[test]
+    fn invalid_repo_comment_continuation_commits_neither_page_nor_cursor() {
+        let conn = db();
+        let binding = binding(&[]);
+        let initial = ScriptClient::new(vec![
+            page(vec![item("1", "2026-01-01T00:00:00Z", "initial", &[])]),
+            page(Vec::new()),
+        ]);
+        block_on(mirror_binding(&conn, &binding, &initial, false)).unwrap();
+
+        let invalid = ScriptClient::new(Vec::new())
+            .with_probe(FreshnessResult {
+                latest: None,
+                etag: Some("v1".to_string()),
+                not_modified: true,
+            })
+            .with_repo_comment_pages(vec![Ok(CommentsPage {
+                comments: vec![comment("1", "must-not-commit", "2026-01-02T00:00:00Z")],
+                next: Some(PageCursor {
+                    stream: Some("other".to_string()),
+                    page_token: Some("page-2".to_string()),
+                    ..PageCursor::default()
+                }),
+            })]);
+        let error = block_on(mirror_binding(&conn, &binding, &invalid, false)).unwrap_err();
+        assert!(error.to_string().contains("crossed"));
+        assert_eq!(
+            conn.query_row("SELECT COUNT(*) FROM papertrail_comments", [], |row| row
+                .get::<_, i64>(0))
+                .unwrap(),
+            0
+        );
+        let cursor = load_cursor(&conn, &binding).unwrap();
+        assert!(cursor.comment_stream_cursors["default"].page_token.is_none());
+        assert!(cursor.comment_stream_cursors["default"].scan_high_mark_at.is_none());
+    }
+
+    #[test]
+    fn delta_walks_continuations_and_updates_repo_wide_comments() {
+        let conn = db();
+        let binding = binding(&[]);
+        let initial = ScriptClient::new(vec![
+            page(vec![item("1", "2026-01-01T00:00:00Z", "initial", &[])]),
+            page(Vec::new()),
+        ])
+        .with_item_comments(vec![comment("1", "initial", "2026-01-01T01:00:00Z")]);
+        block_on(mirror_binding(&conn, &binding, &initial, false)).unwrap();
+
+        let continuation = PageCursor {
+            updated_since: Some("2026-01-01T00:00:00Z".to_string()),
+            page_token: Some("page-2".to_string()),
+            ..PageCursor::default()
+        };
+        let delta = ScriptClient::new(vec![
+            Ok(ItemsPage {
+                items: vec![item("1", "2026-01-02T00:00:00Z", "updated", &[])],
+                next: Some(continuation),
+                backfill_boundary: None,
+            }),
+            page(Vec::new()),
+        ])
+        .with_probe(FreshnessResult {
+            latest: Some("2026-01-03T00:00:00Z".to_string()),
+            etag: Some("v2".to_string()),
+            not_modified: false,
+        })
+        .with_item_comments(vec![comment("1", "item", "2026-01-02T01:00:00Z")])
+        .with_repo_comments(vec![
+            comment("1", "repo", "2026-01-03T00:00:00Z"),
+            comment("404", "orphan", "2026-01-04T00:00:00Z"),
+        ]);
+        let report = block_on(mirror_binding(&conn, &binding, &delta, false)).unwrap();
+        assert_eq!(report.stored_items, 1);
+        assert_eq!(report.stored_comments, 2);
+        let comments: i64 = conn
+            .query_row("SELECT COUNT(*) FROM papertrail_comments", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(comments, 2, "the complete item thread replaces its stale predecessor");
+        let cursor = load_cursor(&conn, &binding).unwrap();
+        assert_eq!(
+            cursor.high_mark_at.as_deref(),
+            Some("2026-01-02T00:00:00Z"),
+            "a mutable continuation advances only through the first consumed page"
+        );
+        assert_eq!(cursor.comment_high_mark_at.as_deref(), Some("2026-01-04T00:00:00Z"));
+        assert!(cursor.probe_etag.is_none());
+    }
+
+    #[test]
+    fn comment_pages_commit_progress_before_a_pause_and_resume_from_the_token() {
+        let conn = db();
+        let binding = binding(&[]);
+        let initial = ScriptClient::new(vec![
+            page(vec![item("1", "2026-01-01T00:00:00Z", "one", &[])]),
+            page(Vec::new()),
+        ])
+        .with_repo_comments(vec![comment("1", "seed", "2026-01-01T00:00:00Z")]);
+        block_on(mirror_binding(&conn, &binding, &initial, false)).unwrap();
+
+        let next = PageCursor { page_token: Some("page-2".to_string()), ..PageCursor::default() };
+        let paused = ScriptClient::new(Vec::new())
+            .with_probe(FreshnessResult {
+                latest: None,
+                etag: Some("v1".to_string()),
+                not_modified: true,
+            })
+            .with_repo_comment_pages(vec![
+                Ok(CommentsPage {
+                    comments: vec![comment("1", "first", "2026-01-03T00:00:00Z")],
+                    next: Some(next),
+                }),
+                Err(anyhow::Error::new(TransportError::Paused {
+                    resume_at_ms: 42,
+                    reason: PauseReason::PassBudget,
+                })),
+            ]);
+        let report = block_on(mirror_binding(&conn, &binding, &paused, false)).unwrap();
+        assert_eq!(report.paused_until_ms, Some(42));
+        let cursor = load_cursor(&conn, &binding).unwrap();
+        let stream = &cursor.comment_stream_cursors["default"];
+        assert_eq!(stream.page_token.as_deref(), Some("page-2"));
+        assert_eq!(cursor.comment_high_mark_at.as_deref(), Some("2026-01-01T00:00:00Z"));
+        assert_eq!(stream.scan_high_mark_at.as_deref(), Some("2026-01-03T00:00:00Z"));
+
+        let resumed = ScriptClient::new(Vec::new())
+            .with_probe(FreshnessResult {
+                latest: None,
+                etag: Some("v1".to_string()),
+                not_modified: true,
+            })
+            .with_repo_comments(vec![comment("1", "second", "2026-01-02T00:00:00Z")]);
+        block_on(mirror_binding(&conn, &binding, &resumed, false)).unwrap();
+        let cursor = load_cursor(&conn, &binding).unwrap();
+        assert!(cursor.comment_stream_cursors["default"].page_token.is_none());
+        assert_eq!(cursor.comment_high_mark_at.as_deref(), Some("2026-01-03T00:00:00Z"));
+        let comments: i64 = conn
+            .query_row("SELECT COUNT(*) FROM papertrail_comments", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(comments, 3);
+    }
+
+    #[test]
+    fn paginated_repo_comments_advance_only_to_the_first_page_frontier() {
+        let conn = db();
+        let binding = binding(&[]);
+        let initial = ScriptClient::new(vec![
+            page(vec![item("1", "2026-01-01T00:00:00Z", "one", &[])]),
+            page(Vec::new()),
+        ])
+        .with_repo_comments(vec![comment("1", "seed", "2026-01-01T00:00:00Z")]);
+        block_on(mirror_binding(&conn, &binding, &initial, false)).unwrap();
+
+        let next =
+            PageCursor { page_token: Some("comments-page-2".to_string()), ..Default::default() };
+        let delta = ScriptClient::new(Vec::new())
+            .with_probe(FreshnessResult {
+                latest: None,
+                etag: Some("v1".to_string()),
+                not_modified: true,
+            })
+            .with_repo_comment_pages(vec![
+                Ok(CommentsPage {
+                    comments: vec![comment("1", "first", "2026-01-02T00:00:00Z")],
+                    next: Some(next),
+                }),
+                Ok(CommentsPage {
+                    comments: vec![comment("1", "later", "2026-01-04T00:00:00Z")],
+                    next: None,
+                }),
+            ]);
+        block_on(mirror_binding(&conn, &binding, &delta, false)).unwrap();
+
+        let cursor = load_cursor(&conn, &binding).unwrap();
+        assert_eq!(
+            cursor.comment_stream_cursors["default"].high_mark_at.as_deref(),
+            Some("2026-01-02T00:00:00Z")
+        );
+    }
+
+    #[test]
+    fn comment_not_found_skips_the_thread_without_erasing_cached_evidence() {
+        let conn = db();
+        let binding = binding(&[]);
+        let initial = ScriptClient::new(vec![
+            page(vec![item("1", "2026-01-01T00:00:00Z", "one", &[])]),
+            page(Vec::new()),
+        ])
+        .with_item_comments(vec![comment("1", "seed", "2026-01-01T01:00:00Z")]);
+        block_on(mirror_binding(&conn, &binding, &initial, false)).unwrap();
+
+        let missing =
+            ScriptClient::new(vec![page(vec![item("1", "2026-01-02T00:00:00Z", "updated", &[])])])
+                .with_probe(FreshnessResult {
+                    latest: Some("2026-01-02T00:00:00Z".to_string()),
+                    etag: Some("v2".to_string()),
+                    not_modified: false,
+                })
+                .with_item_comment_results(vec![Err(PapertrailClientError::ItemNotFound.into())]);
+        let report = block_on(mirror_binding(&conn, &binding, &missing, false)).unwrap();
+
+        assert_eq!(report.pruned_items, 0);
+        assert_eq!(keys(&conn), vec!["1"]);
+        let cursor = load_cursor(&conn, &binding).unwrap();
+        assert!(cursor.item_thread_cursor.is_none());
+        assert!(!cursor.item_delta_in_progress);
+    }
+
+    #[test]
+    fn repo_comment_delta_overlaps_its_watermark_and_keeps_the_scan_boundary_across_pages() {
+        let conn = db();
+        let binding = binding(&[]);
+        let initial = ScriptClient::new(vec![
+            page(vec![item("1", "2026-01-01T00:00:00Z", "one", &[])]),
+            page(Vec::new()),
+        ])
+        .with_repo_comments(vec![comment("1", "first", "2026-01-02T00:00:00Z")]);
+        block_on(mirror_binding(&conn, &binding, &initial, false)).unwrap();
+
+        let next =
+            PageCursor { page_token: Some("comments-page-2".to_string()), ..Default::default() };
+        let delta = ScriptClient::new(Vec::new())
+            .with_probe(FreshnessResult {
+                latest: None,
+                etag: Some("v1".to_string()),
+                not_modified: true,
+            })
+            .with_repo_comment_pages(vec![
+                Ok(CommentsPage { comments: Vec::new(), next: Some(next) }),
+                Ok(CommentsPage { comments: Vec::new(), next: None }),
+            ]);
+        block_on(mirror_binding(&conn, &binding, &delta, false)).unwrap();
+        let requests = delta.repo_comment_requests.borrow();
+        assert_eq!(requests[0].updated_since.as_deref(), Some("2026-01-01T23:59:59Z"));
+        assert_eq!(requests[1].updated_since, requests[0].updated_since);
+    }
+
+    #[test]
+    fn independent_comment_streams_do_not_advance_an_unscanned_stream() {
+        let conn = db();
+        let binding = binding(&[]);
+        let initial = ScriptClient::new(vec![
+            page(vec![item("1", "2026-01-01T00:00:00Z", "one", &[])]),
+            page(Vec::new()),
+        ])
+        .with_comment_streams(&["issue_comments", "review_comments"])
+        .with_repo_comment_pages(vec![
+            Ok(CommentsPage {
+                comments: vec![comment("1", "issue", "2026-01-01T00:00:00Z")],
+                next: None,
+            }),
+            Ok(CommentsPage {
+                comments: vec![comment("1", "review", "2026-01-03T00:00:00Z")],
+                next: None,
+            }),
+        ]);
+        block_on(mirror_binding(&conn, &binding, &initial, false)).unwrap();
+
+        let cursor = load_cursor(&conn, &binding).unwrap();
+        assert_eq!(
+            cursor.comment_stream_cursors["issue_comments"].high_mark_at.as_deref(),
+            Some("2026-01-01T00:00:00Z")
+        );
+        assert_eq!(
+            cursor.comment_stream_cursors["review_comments"].high_mark_at.as_deref(),
+            Some("2026-01-03T00:00:00Z")
+        );
+        assert_eq!(cursor.comment_high_mark_at.as_deref(), Some("2026-01-01T00:00:00Z"));
+        let initial_requests = initial.repo_comment_requests.borrow();
+        assert!(initial_requests.iter().all(|request| request.updated_since.is_none()));
+
+        let next = ScriptClient::new(Vec::new())
+            .with_comment_streams(&["issue_comments", "review_comments"])
+            .with_probe(FreshnessResult {
+                latest: None,
+                etag: Some("v1".to_string()),
+                not_modified: true,
+            })
+            .with_repo_comment_pages(vec![
+                Ok(CommentsPage {
+                    comments: vec![comment("1", "late-issue", "2026-01-02T00:00:00Z")],
+                    next: None,
+                }),
+                Ok(CommentsPage { comments: Vec::new(), next: None }),
+            ]);
+        block_on(mirror_binding(&conn, &binding, &next, false)).unwrap();
+        let requests = next.repo_comment_requests.borrow();
+        assert_eq!(requests[0].stream.as_deref(), Some("issue_comments"));
+        assert_eq!(requests[0].updated_since.as_deref(), Some("2025-12-31T23:59:59Z"));
+        assert_eq!(requests[1].stream.as_deref(), Some("review_comments"));
+        assert_eq!(requests[1].updated_since.as_deref(), Some("2026-01-02T23:59:59Z"));
+    }
+
+    #[test]
+    fn item_thread_snapshots_do_not_advance_the_repo_comment_watermark() {
+        let conn = db();
+        let binding = binding(&[]);
+        let client = ScriptClient::new(vec![
+            page(vec![item("1", "2026-01-01T00:00:00Z", "one", &[])]),
+            page(Vec::new()),
+        ])
+        .with_item_comments(vec![comment("1", "thread", "2026-02-01T00:00:00Z")]);
+        block_on(mirror_binding(&conn, &binding, &client, false)).unwrap();
+        assert_eq!(client.repo_comment_requests.borrow()[0].updated_since, None);
+        assert_eq!(load_cursor(&conn, &binding).unwrap().comment_high_mark_at, None);
+    }
+
+    #[test]
+    fn delta_overlap_rewinds_one_second_without_changing_provider_tokens() {
+        assert_eq!(overlap_timestamp("2026-01-02T00:00:00Z"), "2026-01-01T23:59:59Z");
+        assert_eq!(overlap_timestamp("2026-01-01T00:00:01Z"), "2026-01-01T00:00:00Z");
+        assert_eq!(overlap_timestamp("2026-01-01T00:01:00Z"), "2026-01-01T00:00:59Z");
+        assert_eq!(overlap_timestamp("2026-01-01T01:00:00Z"), "2026-01-01T00:59:59Z");
+        assert_eq!(overlap_timestamp("2026-05-01T00:00:00Z"), "2026-04-30T23:59:59Z");
+        assert_eq!(overlap_timestamp("2024-03-01T00:00:00Z"), "2024-02-29T23:59:59Z");
+        assert_eq!(overlap_timestamp("2026-03-01T00:00:00Z"), "2026-02-28T23:59:59Z");
+        assert_eq!(overlap_timestamp("2026-01-01T00:00:00Z"), "2025-12-31T23:59:59Z");
+        assert_eq!(overlap_timestamp("2026-01-01TinvalidZ"), "2026-01-01TinvalidZ");
+        assert_eq!(overlap_timestamp("provider-token"), "provider-token");
+
+        let outside = anyhow::Error::new(TransportError::UrlOutsideBinding {
+            url: "https://other.example".to_string(),
+            host: "github.example".to_string(),
+            problem: "origin differs",
+        });
+        assert!(pause(&outside).is_none());
+
+        let legacy = decode_processed_items(Some(r#"[["issue","1"]]"#.to_string()), 0).unwrap();
+        assert!(legacy.contains(&ProcessedItem {
+            kind: "issue".to_string(),
+            key: "1".to_string(),
+            updated_at: None,
+        }));
+    }
+
+    #[test]
+    fn unmatched_pages_skip_comments_and_delete_cached_items() {
+        let conn = db();
+        let all = binding(&[]);
+        assert_eq!(prune_unmatched(&conn, &all).unwrap(), 0);
+        store_item(&conn, Tracker::Github, &item("1", "2026-01-01T00:00:00Z", "cached", &["docs"]))
+            .unwrap();
+
+        let bugs = binding(&["bug"]);
+        let client = ScriptClient::new(vec![
+            page(vec![item("1", "2026-01-02T00:00:00Z", "still docs", &["docs"])]),
+            page(Vec::new()),
+        ]);
+        let report = block_on(mirror_binding(&conn, &bugs, &client, false)).unwrap();
+        assert!(report.pruned_items >= 1);
+        assert!(keys(&conn).is_empty());
+    }
+}

--- a/crates/rag-rat-core/src/index/papertrail/mod.rs
+++ b/crates/rag-rat-core/src/index/papertrail/mod.rs
@@ -1,26 +1,25 @@
 mod api;
 mod evidence;
+mod github;
+mod mirror;
 mod parse;
 mod store;
 mod sync;
 mod trackers;
-// Shared HTTP substrate for the native provider clients (#589): reqwest transport, per-
-// (provider, host, token) rate governor, env/token_command auth. `dead_code`/`unused_imports`
-// are allowed until the first native client consumes it (#591) — drop the allow there.
-#[allow(dead_code, unused_imports)]
 pub(crate) mod transport;
 use std::collections::BTreeSet;
 use std::path::Path;
-use std::process::{Command, Stdio};
 use std::sync::OnceLock;
 
 pub(crate) use api::*;
 pub(crate) use evidence::*;
+pub(crate) use github::*;
+pub use mirror::MirrorBindingReport;
+pub(crate) use mirror::mirror_binding;
 pub(crate) use parse::*;
 pub use parse::{TrackerParsedRef, parse_tracker_refs};
 use rusqlite::{Connection, OptionalExtension, params};
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 pub(crate) use store::*;
 pub(crate) use sync::*;
 pub(crate) use trackers::resolve_trackers;
@@ -37,9 +36,9 @@ use crate::index::now_ms;
 #[derive(Debug, Clone, Default)]
 pub struct PapertrailContext {
     /// Resolved tracker bindings, in config order (or the single auto-detected code host).
-    /// Production discovery and rationale lookup consume every binding. Live network sync remains
-    /// GitHub-only until the provider-client PRs build on [`transport`].
+    /// Production discovery, rationale lookup, and manual mirror sync consume every binding.
     pub trackers: Vec<ResolvedTracker>,
+    pub(crate) transport_options: transport::TransportOptions,
 }
 
 impl PapertrailContext {
@@ -47,7 +46,15 @@ impl PapertrailContext {
     /// auto-detected from the git `origin` remote. Call ONLY at the real-usage boundary
     /// (open_config), never inside the library internals or tests.
     pub(crate) fn resolve(config: &crate::config::Config) -> Self {
-        Self { trackers: resolve_trackers(&config.trackers, &config.root) }
+        let mut trackers = resolve_trackers(&config.trackers, &config.root);
+        // GitHub's provider-native fallback is environment auth. Materialize the ENV-VAR NAME
+        // into the binding (never its value) so status and transport use the same per-binding
+        // capability instead of a process-global `gh_available` bit.
+        apply_implicit_github_auth(&mut trackers, |name| std::env::var(name).ok());
+        Self {
+            trackers,
+            transport_options: transport::TransportOptions::from(&config.papertrail),
+        }
     }
 
     /// An explicit GitHub-repo context that never touches git or `gh` — for tests and non-gh
@@ -64,16 +71,35 @@ impl PapertrailContext {
             })
             .into_iter()
             .collect();
-        Self { trackers }
+        Self { trackers, transport_options: transport::TransportOptions::default() }
     }
 
     /// `owner/repo` qualifying a manually requested legacy GitHub reference. Production
     /// discovery and rationale parsing use all bindings through [`parse_tracker_refs`].
+    #[cfg(test)]
     fn default_repo(&self) -> Option<&str> {
         self.trackers
             .iter()
             .find(|tracker| tracker.provider == Tracker::Github)
             .map(|tracker| tracker.project.as_str())
+    }
+}
+
+fn apply_implicit_github_auth(
+    trackers: &mut [ResolvedTracker],
+    env: impl Fn(&str) -> Option<String>,
+) {
+    for tracker in trackers {
+        if tracker.provider == Tracker::Github
+            && tracker.base_url.is_none()
+            && tracker.auth.is_none()
+            && let Some(name) = ["GH_TOKEN", "GITHUB_TOKEN"]
+                .into_iter()
+                .find(|name| env(name).is_some_and(|value| !value.trim().is_empty()))
+        {
+            tracker.auth = Some(crate::config::TrackerAuth::Env(name.to_string()));
+            tracker.authentication = TrackerAuthentication::AuthConfigured;
+        }
     }
 }
 
@@ -108,8 +134,7 @@ pub enum TrackerAuthentication {
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum TrackerSynchronization {
-    LegacyGithubCli,
-    LegacyGithubCliMissing,
+    Native,
     ProviderClientPending,
 }
 
@@ -120,6 +145,8 @@ pub struct PapertrailSyncReport {
     pub skipped_refs: usize,
     pub failed_refs: usize,
     pub synced_items: usize,
+    /// One resumable outcome per dispatched binding, including rate-governed pauses.
+    pub bindings: Vec<MirrorBindingReport>,
     pub errors: Vec<PapertrailSyncError>,
     pub status: PapertrailStatus,
 }
@@ -133,6 +160,7 @@ pub struct PapertrailSyncError {
     pub error: String,
 }
 
+#[cfg(test)]
 #[derive(Debug, Clone)]
 pub struct PapertrailSyncProgress {
     pub current: usize,
@@ -143,6 +171,7 @@ pub struct PapertrailSyncProgress {
     pub message: Option<String>,
 }
 
+#[cfg(test)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PapertrailSyncAction {
     Syncing,
@@ -250,6 +279,8 @@ pub struct PapertrailItem {
     pub updated_at: Option<String>,
     /// Change requests only; `None` for issues and unmerged change requests.
     pub merged_at: Option<String>,
+    /// Provider facets used by the binding's client-side OR filter (GitHub labels today).
+    pub tags: Vec<String>,
 }
 
 /// One comment on a tracker item, unified across the provider review models: a plain thread
@@ -278,24 +309,58 @@ pub struct PapertrailComment {
 
 /// Position in a provider's `updated_at`-ordered item/comment stream. The mirror sync keeps one
 /// persisted cursor per (tracker, project); a page fetch returns the cursor to continue from.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PageCursor {
+    /// Provider-defined logical stream within an operation (for example GitHub issue comments
+    /// versus review comments). Each stream owns independent durable progress.
+    pub stream: Option<String>,
     /// Fetch entries updated at-or-after this provider-format timestamp.
     pub updated_since: Option<String>,
+    /// Strict upper boundary for newest-first historical descent.
+    pub updated_before: Option<String>,
     /// Provider-opaque continuation token, when the provider paginates by token.
     pub page_token: Option<String>,
+    /// Provider-opaque state needed to interpret a continuation (for example a Search tie
+    /// boundary and the number of results already observed). The mirror persists but never
+    /// interprets this value.
+    pub provider_state: Option<String>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct FreshnessProbe {
+    pub updated_since: Option<String>,
+    pub etag: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct FreshnessResult {
+    pub latest: Option<String>,
+    pub etag: Option<String>,
+    pub not_modified: bool,
 }
 
 #[derive(Debug, Clone)]
 pub struct ItemsPage {
     pub items: Vec<PapertrailItem>,
     pub next: Option<PageCursor>,
+    /// Provider-confirmed strict boundary below every item consumed in this logical backfill
+    /// page. Compound provider streams may need this because the last physical response does not
+    /// necessarily contain the oldest item observed across the whole page.
+    pub backfill_boundary: Option<String>,
 }
 
 #[derive(Debug, Clone)]
 pub struct CommentsPage {
     pub comments: Vec<PapertrailComment>,
     pub next: Option<PageCursor>,
+}
+
+/// Provider outcomes that affect mirror control flow rather than representing a retryable
+/// transport or payload failure.
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum PapertrailClientError {
+    #[error("tracker item not found")]
+    ItemNotFound,
 }
 
 /// Advance decision for a freshness probe: the newest `updated_at` the provider reported vs the
@@ -333,9 +398,40 @@ pub trait PapertrailClient {
         kind: ItemKind,
         key: &str,
     ) -> anyhow::Result<Vec<PapertrailComment>>;
+    /// Stable logical comment streams for one item. Providers with several independently paged
+    /// resources expose each one here so the mirror can checkpoint after every returned page.
+    fn item_comment_streams(&self, _kind: ItemKind) -> &'static [&'static str] {
+        &["default"]
+    }
+
+    /// One page from exactly one [`Self::item_comment_streams`] lane. The default adapts legacy
+    /// clients that return a whole thread in one call; native paginated clients override it.
+    async fn item_comments_page(
+        &self,
+        project: &str,
+        kind: ItemKind,
+        key: &str,
+        cursor: &PageCursor,
+    ) -> anyhow::Result<CommentsPage> {
+        anyhow::ensure!(cursor.page_token.is_none(), "legacy item comments cannot resume a page");
+        Ok(CommentsPage { comments: self.item_comments(project, kind, key).await?, next: None })
+    }
+    /// Complete provider-specific item fields before the mirror starts the item's durable thread.
+    /// The mirror invokes this one item at a time and checkpoints each completed item, so a
+    /// transport pause cannot force an entire provider page to be enriched again.
+    async fn enrich_item(&self, _item: &mut PapertrailItem) -> anyhow::Result<()> {
+        Ok(())
+    }
     /// A page of items updated since the cursor, newest first (mirror backfill/delta).
     async fn items_page(&self, project: &str, cursor: &PageCursor) -> anyhow::Result<ItemsPage>;
-    /// A page of comments updated since the cursor (mirror delta).
+    /// Stable logical comment streams whose cursors must advance independently.
+    fn comment_streams(&self) -> &'static [&'static str] {
+        &["default"]
+    }
+
+    /// A page of comments from exactly one [`Self::comment_streams`] lane. Implementations must not
+    /// advance into another stream through `next`; the mirror persists each stream
+    /// independently.
     async fn comments_page(
         &self,
         project: &str,
@@ -346,8 +442,8 @@ pub trait PapertrailClient {
     async fn freshness_probe(
         &self,
         project: &str,
-        cursor: &PageCursor,
-    ) -> anyhow::Result<Option<String>>;
+        probe: &FreshnessProbe,
+    ) -> anyhow::Result<FreshnessResult>;
 }
 
 /// Drive a papertrail future to completion from the synchronous call paths (CLI, maintenance).
@@ -377,112 +473,7 @@ pub(crate) fn block_on<T>(
     }
 }
 
-/// The GitHub provider, currently backed by the `gh` CLI (`gh api`); replaced by a native HTTP
-/// client when the mirror sync lands. The subprocess calls block inside the async methods, which
-/// is acceptable on the private [`block_on`] runtime — nothing else shares it.
-pub struct GitHubClient;
-
-impl PapertrailClient for GitHubClient {
-    async fn item(
-        &self,
-        project: &str,
-        _kind: ItemKind,
-        key: &str,
-    ) -> anyhow::Result<PapertrailItem> {
-        // GitHub numbers issues and PRs in one namespace, so the requested kind is advisory:
-        // the issues endpoint resolves either, and the returned item carries the real kind.
-        let value = gh_api_json(&format!("repos/{project}/issues/{key}"))?;
-        let mut item = item_from_issue_value(project, &value);
-        if item.item_kind == ItemKind::ChangeRequest {
-            enrich_item_from_pull_value(
-                &mut item,
-                &gh_api_json(&format!("repos/{project}/pulls/{key}"))?,
-            );
-        }
-        Ok(item)
-    }
-
-    async fn item_comments(
-        &self,
-        project: &str,
-        kind: ItemKind,
-        key: &str,
-    ) -> anyhow::Result<Vec<PapertrailComment>> {
-        let mut comments = Vec::new();
-        for value in gh_api_paginated(&format!("repos/{project}/issues/{key}/comments"))? {
-            comments.push(comment_from_value(project, kind, key, &value));
-        }
-        // Review endpoints exist only for change requests; the caller passes the RESOLVED kind,
-        // so any failure here (rate limit, auth, network) is a real failure and must propagate —
-        // swallowing it would cache an incomplete comment list and mark the ref synced forever.
-        if kind == ItemKind::ChangeRequest {
-            for value in gh_api_paginated(&format!("repos/{project}/pulls/{key}/reviews"))? {
-                comments.push(review_to_comment_from_value(project, kind, key, &value));
-            }
-            for value in gh_api_paginated(&format!("repos/{project}/pulls/{key}/comments"))? {
-                comments.push(review_comment_to_comment_from_value(project, kind, key, &value));
-            }
-        }
-        Ok(comments)
-    }
-
-    async fn items_page(&self, project: &str, cursor: &PageCursor) -> anyhow::Result<ItemsPage> {
-        // `gh api --paginate` drains every page in one call, so the returned cursor is always
-        // terminal. The native client replaces this with true per-page fetches.
-        let mut path =
-            format!("repos/{project}/issues?state=all&sort=updated&direction=desc&per_page=100");
-        if let Some(since) = cursor.updated_since.as_deref() {
-            path.push_str(&format!("&since={since}"));
-        }
-        let items = gh_api_paginated(&path)?
-            .iter()
-            .map(|value| item_from_issue_value(project, value))
-            .collect();
-        Ok(ItemsPage { items, next: None })
-    }
-
-    async fn comments_page(
-        &self,
-        project: &str,
-        cursor: &PageCursor,
-    ) -> anyhow::Result<CommentsPage> {
-        // Repo-wide comment streams; review *events* have no repo-wide updated-since endpoint,
-        // so the mirror delta re-walks changed items for those (native-client concern).
-        let since = cursor
-            .updated_since
-            .as_deref()
-            .map(|since| format!("?since={since}"))
-            .unwrap_or_default();
-        let mut comments = Vec::new();
-        for value in gh_api_paginated(&format!("repos/{project}/issues/comments{since}"))? {
-            if let Some(comment) = repo_comment_from_value(project, &value, false) {
-                comments.push(comment);
-            }
-        }
-        for value in gh_api_paginated(&format!("repos/{project}/pulls/comments{since}"))? {
-            if let Some(comment) = repo_comment_from_value(project, &value, true) {
-                comments.push(comment);
-            }
-        }
-        Ok(CommentsPage { comments, next: None })
-    }
-
-    async fn freshness_probe(
-        &self,
-        project: &str,
-        cursor: &PageCursor,
-    ) -> anyhow::Result<Option<String>> {
-        let value = gh_api_json(&format!(
-            "repos/{project}/issues?state=all&sort=updated&direction=desc&per_page=1"
-        ))?;
-        let latest = value
-            .as_array()
-            .and_then(|items| items.first())
-            .and_then(|item| item["updated_at"].as_str())
-            .map(str::to_string);
-        Ok(probe_advance(latest, cursor.updated_since.as_deref()))
-    }
-}
+#[cfg(test)]
 #[derive(Default)]
 pub(crate) struct SyncRefsReport {
     synced_items: usize,
@@ -574,6 +565,30 @@ mod token_tests {
         for rejected in ["Issue", "pull", "change-request", " issue", ""] {
             assert!(ItemKind::from_db_str(rejected).is_err(), "must reject `{rejected}`");
         }
+    }
+
+    #[test]
+    fn implicit_cloud_token_never_crosses_an_enterprise_binding() {
+        let tracker = |base_url: Option<&str>| ResolvedTracker {
+            provider: Tracker::Github,
+            project: "o/r".to_string(),
+            base_url: base_url.map(str::to_string),
+            auth: None,
+            authentication: TrackerAuthentication::AuthMissing,
+            tags: Vec::new(),
+        };
+        let mut trackers = vec![tracker(None), tracker(Some("https://github.example.com"))];
+        apply_implicit_github_auth(&mut trackers, |name| {
+            (name == "GH_TOKEN").then(|| "cloud-secret".to_string())
+        });
+
+        assert!(matches!(
+            trackers[0].auth,
+            Some(crate::config::TrackerAuth::Env(ref name)) if name == "GH_TOKEN"
+        ));
+        assert_eq!(trackers[0].authentication, TrackerAuthentication::AuthConfigured);
+        assert!(trackers[1].auth.is_none());
+        assert_eq!(trackers[1].authentication, TrackerAuthentication::AuthMissing);
     }
 }
 

--- a/crates/rag-rat-core/src/index/papertrail/parse.rs
+++ b/crates/rag-rat-core/src/index/papertrail/parse.rs
@@ -1,3 +1,5 @@
+use serde_json::Value;
+
 use super::*;
 
 /// Ref-bearing tokens of `text` — the shared tokenizer of the legacy GitHub-only lane
@@ -366,7 +368,7 @@ pub(crate) fn item_from_issue_value(project: &str, value: &Value) -> PapertrailI
     PapertrailItem {
         project: project.to_string(),
         item_kind: if shadow.is_some() { ItemKind::ChangeRequest } else { ItemKind::Issue },
-        item_key: value["number"].as_i64().unwrap_or_default().to_string(),
+        item_key: value["number"].as_u64().unwrap_or_default().to_string(),
         url: string_value(value, "html_url"),
         state: string_value(value, "state"),
         title: string_value(value, "title"),
@@ -375,6 +377,12 @@ pub(crate) fn item_from_issue_value(project: &str, value: &Value) -> PapertrailI
         created_at: value["created_at"].as_str().map(str::to_string),
         updated_at: value["updated_at"].as_str().map(str::to_string),
         merged_at: shadow.and_then(|shadow| shadow["merged_at"].as_str()).map(str::to_string),
+        tags: value["labels"]
+            .as_array()
+            .into_iter()
+            .flatten()
+            .filter_map(|label| label["name"].as_str().map(str::to_string))
+            .collect(),
     }
 }
 /// Fold the richer pulls-endpoint payload into a change request built from its issue shadow.
@@ -396,7 +404,7 @@ pub(crate) fn comment_from_value(
         project: project.to_string(),
         item_kind: kind,
         item_key: key.to_string(),
-        comment_id: format!("comment:{}", value["id"].as_i64().unwrap_or_default()),
+        comment_id: format!("comment:{}", value["id"].as_u64().unwrap_or_default()),
         url: value["html_url"].as_str().map(str::to_string),
         body: string_value(value, "body"),
         author: value.pointer("/user/login").and_then(Value::as_str).map(str::to_string),
@@ -418,7 +426,7 @@ pub(crate) fn review_to_comment_from_value(
         review_state: Some(string_value(value, "state")),
         ..comment_from_value(project, kind, key, value)
     };
-    comment.comment_id = format!("review:{}", value["id"].as_i64().unwrap_or_default());
+    comment.comment_id = format!("review:{}", value["id"].as_u64().unwrap_or_default());
     comment
 }
 pub(crate) fn review_comment_to_comment_from_value(
@@ -431,7 +439,7 @@ pub(crate) fn review_comment_to_comment_from_value(
         anchor_path: value["path"].as_str().map(str::to_string),
         ..comment_from_value(project, kind, key, value)
     };
-    comment.comment_id = format!("review_comment:{}", value["id"].as_i64().unwrap_or_default());
+    comment.comment_id = format!("review_comment:{}", value["id"].as_u64().unwrap_or_default());
     comment
 }
 /// Map one entry of a repo-wide comment stream, deriving the parent item key from the payload's
@@ -456,40 +464,6 @@ pub(crate) fn repo_comment_from_value(
         comment.anchor_path = value["path"].as_str().map(str::to_string);
     }
     Some(comment)
-}
-pub(crate) fn gh_api_json(path: &str) -> anyhow::Result<Value> {
-    let output = Command::new("gh").args(["api", path]).output()?;
-    if !output.status.success() {
-        anyhow::bail!("{}", String::from_utf8_lossy(&output.stderr).trim());
-    }
-    Ok(serde_json::from_slice(&output.stdout)?)
-}
-pub(crate) fn gh_api_paginated(path: &str) -> anyhow::Result<Vec<Value>> {
-    let output = Command::new("gh").args(["api", "--paginate", "--slurp", path]).output()?;
-    if !output.status.success() {
-        anyhow::bail!("{}", String::from_utf8_lossy(&output.stderr).trim());
-    }
-    let value: Value = serde_json::from_slice(&output.stdout)?;
-    let mut out = Vec::new();
-    if let Some(pages) = value.as_array() {
-        for page in pages {
-            if let Some(items) = page.as_array() {
-                out.extend(items.iter().cloned());
-            }
-        }
-    }
-    Ok(out)
-}
-/// The legacy GitHub sync path shells out to `gh api`; status checks ONLY executable presence.
-/// Authentication is intentionally deferred to sync, where `gh api` returns the actionable error.
-pub(crate) fn github_cli_available() -> bool {
-    Command::new("gh")
-        .arg("--version")
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
-        .is_ok_and(|status| status.success())
 }
 pub(crate) fn string_value(value: &Value, key: &str) -> String {
     value[key].as_str().unwrap_or_default().to_string()

--- a/crates/rag-rat-core/src/index/papertrail/store.rs
+++ b/crates/rag-rat-core/src/index/papertrail/store.rs
@@ -273,6 +273,7 @@ mod fts_mirror_tests {
             created_at: None,
             updated_at: None,
             merged_at: None,
+            tags: Vec::new(),
         }
     }
 

--- a/crates/rag-rat-core/src/index/papertrail/sync.rs
+++ b/crates/rag-rat-core/src/index/papertrail/sync.rs
@@ -39,6 +39,7 @@ pub(crate) fn discover_and_store_refs(
     }
     Ok(refs)
 }
+#[cfg(test)]
 pub(crate) async fn sync_refs<'a, C: PapertrailClient>(
     conn: &Connection,
     client: &C,
@@ -108,6 +109,7 @@ pub(crate) async fn sync_refs<'a, C: PapertrailClient>(
 /// row landed, comment fetch failed) would masquerade as a completed sync forever. Storing nothing
 /// until every fetch succeeded keeps a failed ref retryable with no state row. The FTS mirror
 /// follows incrementally inside the store writers.
+#[cfg(test)]
 pub(crate) async fn sync_one_ref<C: PapertrailClient>(
     conn: &Connection,
     client: &C,
@@ -130,6 +132,7 @@ pub(crate) async fn sync_one_ref<C: PapertrailClient>(
     tx.commit()?;
     Ok(synced)
 }
+#[cfg(test)]
 pub(crate) fn sync_progress(
     reference: &PapertrailRef,
     current: usize,
@@ -151,6 +154,7 @@ pub(crate) fn sync_progress(
 /// mirror sync; the ref lane keeps no per-ref state). No `item_kind` filter: a bare `#N` ref could
 /// name either kind, and either cached kind means the item was synced. A not-found item retries on
 /// every sync (no memo) — acceptable for the referenced-only lane the mirror sync supersedes.
+#[cfg(test)]
 pub(crate) fn papertrail_ref_synced(
     conn: &Connection,
     reference: &PapertrailRef,
@@ -168,6 +172,7 @@ pub(crate) fn papertrail_ref_synced(
     )?;
     Ok(cached)
 }
+#[cfg(test)]
 pub(crate) fn is_not_found_error(message: &str) -> bool {
     message.contains("HTTP 404") || message.to_ascii_lowercase().contains("not found")
 }

--- a/crates/rag-rat-core/src/index/papertrail/transport/client.rs
+++ b/crates/rag-rat-core/src/index/papertrail/transport/client.rs
@@ -11,7 +11,7 @@ use reqwest::header::{self, HeaderMap};
 use super::auth;
 use super::governor::{
     Admission, GovernorConfig, GovernorKey, GovernorRegistry, PauseReason, QuotaSnapshot,
-    RateGovernor, backoff_delay_ms,
+    RateGovernor, RetryHold, backoff_delay_ms,
 };
 use crate::config::{PapertrailConfig, TrackerAuth};
 use crate::index::util::now_ms;
@@ -93,9 +93,12 @@ impl From<&PapertrailConfig> for TransportOptions {
 pub(crate) struct TransportParams<'a> {
     /// Provider id (`github`, `gitlab`, …).
     pub provider: &'a str,
+    /// Provider quota resource. GitHub Search and core REST are independent lanes.
+    pub lane: &'a str,
     /// Authority the binding talks to — `api.github.com`, `gitlab.example.com:8443`, never a
     /// URL. Keys the governor AND pins every request: a URL outside it is refused.
     pub host: &'a str,
+    #[cfg_attr(not(test), allow(dead_code))]
     pub auth: Option<&'a TrackerAuth>,
     /// Shared registry so sibling bindings on the same (provider, host, token) share one
     /// governor and jointly account their consumption.
@@ -110,6 +113,7 @@ type Clock = Arc<dyn Fn() -> i64 + Send + Sync>;
 pub(crate) struct Transport {
     client: reqwest::Client,
     governor: Arc<RateGovernor>,
+    retry_hold: Arc<RetryHold>,
     /// Prebuilt `Authorization` value; `None` for anonymous bindings.
     auth_header: Option<String>,
     /// The binding's pinned authority (lowercased host, optional port) — every request URL must
@@ -127,20 +131,39 @@ impl Transport {
     /// Build the transport for one binding: resolves the token (fails fast on a configured-but-
     /// missing one), joins the shared governor for (provider, host, token), and constructs the
     /// rustls HTTP client. The pass's wall-clock deadline starts here.
+    #[cfg_attr(not(test), allow(dead_code))]
     pub(crate) fn new(params: TransportParams<'_>) -> anyhow::Result<Self> {
         Self::with_clock(params, Arc::new(now_ms))
     }
 
+    /// Build a sibling quota lane from one already-resolved binding credential. Provider clients
+    /// with several lanes must snapshot auth once so token commands cannot yield split identities.
+    pub(crate) fn new_with_token(
+        params: TransportParams<'_>,
+        token: Option<&str>,
+    ) -> anyhow::Result<Self> {
+        Self::with_clock_and_token(params, Arc::new(now_ms), token.map(str::to_string))
+    }
+
+    #[cfg_attr(not(test), allow(dead_code))]
     pub(crate) fn with_clock(params: TransportParams<'_>, clock: Clock) -> anyhow::Result<Self> {
         let token = auth::resolve_token(params.auth)?;
+        Self::with_clock_and_token(params, clock, token)
+    }
+
+    fn with_clock_and_token(
+        params: TransportParams<'_>,
+        clock: Clock,
+        token: Option<String>,
+    ) -> anyhow::Result<Self> {
         let auth_header =
             token.as_deref().map(|token| format!("{} {token}", params.options.auth_scheme));
         let (bound_host, bound_port) = parse_bound_authority(params.host)?;
         let governor_authority = canonical_governor_authority(&bound_host, bound_port);
-        let governor = params.registry.governor(
-            GovernorKey::new(params.provider, &governor_authority, token.as_deref()),
-            &params.options.governor,
-        );
+        let governor_key =
+            GovernorKey::new(params.provider, &governor_authority, token.as_deref(), params.lane);
+        let retry_hold = params.registry.retry_hold(&governor_key);
+        let governor = params.registry.governor(governor_key, &params.options.governor);
         let mut builder = reqwest::Client::builder()
             .timeout(Duration::from_secs(params.options.request_timeout_s))
             // Redirects are provider semantics. Following them here would bypass the per-hop URL
@@ -156,6 +179,7 @@ impl Transport {
         Ok(Self {
             client: builder.build()?,
             governor,
+            retry_hold,
             auth_header,
             bound_host,
             bound_port,
@@ -189,6 +213,12 @@ impl Transport {
                     reason: PauseReason::PassBudget,
                 });
             }
+            if let Some(resume_at_ms) = self.retry_hold.paused_until(now) {
+                return Err(TransportError::Paused {
+                    resume_at_ms,
+                    reason: PauseReason::RetryAfter,
+                });
+            }
             if let Admission::PausedUntil { resume_at_ms, reason } = self.governor.admit(now) {
                 return Err(TransportError::Paused { resume_at_ms, reason });
             }
@@ -209,6 +239,15 @@ impl Transport {
             // Drain the body on every path — a rate-limited reply carries one too, and leaving
             // it unread can abort the connection.
             let body = response.text().await?;
+            let conditional_not_modified = self.is_github
+                && self.auth_header.is_some()
+                && status == 304
+                && extra_headers
+                    .iter()
+                    .any(|(name, _)| name.eq_ignore_ascii_case(header::IF_NONE_MATCH.as_str()));
+            if conditional_not_modified {
+                self.governor.refund_admission();
+            }
             let github_secondary = self.is_github && is_github_secondary_limit(status, &body);
             if !is_rate_limited(status, &headers, now) && !github_secondary {
                 return Ok(TransportResponse { status, headers, body });
@@ -218,9 +257,15 @@ impl Transport {
             let delay_ms = backoff_delay_ms(attempt, retry_after_ms, self.backoff_base_ms);
             attempt += 1;
             let resume_at_ms = now.saturating_add(delay_ms);
-            // Hold the whole (provider, host, token) key, not just this request — a sibling
-            // fetch on the same token must also stand down.
-            self.governor.record_hold(resume_at_ms);
+            // GitHub secondary/abuse limits cover REST as a whole, while primary quota windows
+            // remain lane-specific. Other providers retain the conservative lane-local hold.
+            let shared_github_hold = self.is_github
+                && (github_secondary || status == 429 || headers.contains_key(header::RETRY_AFTER));
+            if shared_github_hold {
+                self.retry_hold.record(resume_at_ms);
+            } else {
+                self.governor.record_hold(resume_at_ms);
+            }
             if resume_at_ms > self.pass_deadline_ms {
                 return Err(TransportError::Paused {
                     resume_at_ms,
@@ -364,6 +409,7 @@ fn retry_after_ms(headers: &HeaderMap, now_ms: i64) -> Option<i64> {
 
 #[cfg(test)]
 mod tests {
+    use super::super::governor;
     use super::super::stub::{StubResponse, spawn_script_stub};
     use super::*;
 
@@ -379,12 +425,23 @@ mod tests {
 
     fn transport(url: &str, auth: Option<&TrackerAuth>, options: TransportOptions) -> Transport {
         let registry = GovernorRegistry::default();
+        transport_in_lane(url, auth, options, &registry, "core")
+    }
+
+    fn transport_in_lane(
+        url: &str,
+        auth: Option<&TrackerAuth>,
+        options: TransportOptions,
+        registry: &GovernorRegistry,
+        lane: &str,
+    ) -> Transport {
         let host = url.trim_start_matches("http://").split(':').next().unwrap().to_string();
         Transport::new(TransportParams {
             provider: "github",
+            lane,
             host: &host,
             auth,
-            registry: &registry,
+            registry,
             options,
         })
         .expect("transport")
@@ -403,6 +460,29 @@ mod tests {
             options.governor.fallback_budget.max_requests,
             TransportOptions::default().governor.fallback_budget.max_requests
         );
+    }
+
+    #[test]
+    fn authenticated_github_conditional_304_refunds_the_local_budget() {
+        let (url, handle) = spawn_script_stub(vec![
+            StubResponse::status("304 Not Modified", ""),
+            StubResponse::ok(r#"{"ok":true}"#),
+        ]);
+        let mut options = fast_options();
+        options.governor.fallback_budget =
+            governor::BudgetPolicy { max_requests: 1, window_ms: 60_000 };
+        let auth = TrackerAuth::TokenCommand("echo stub-token".to_string());
+        let transport = transport(&url, Some(&auth), options);
+        drive(async {
+            let first = transport
+                .get(&format!("{url}/probe"), &[(header::IF_NONE_MATCH.as_str(), "\"v1\"")])
+                .await
+                .unwrap();
+            assert_eq!(first.status, 304);
+            let second = transport.get(&format!("{url}/items"), &[]).await.unwrap();
+            assert_eq!(second.status, 200);
+        });
+        assert_eq!(handle.join().unwrap().len(), 2);
     }
 
     #[test]
@@ -500,6 +580,26 @@ mod tests {
     }
 
     #[test]
+    fn a_github_secondary_hold_stops_sibling_quota_lanes_before_they_send() {
+        let (url, handle) = spawn_script_stub(vec![StubResponse::status(
+            "403 Forbidden",
+            "You have exceeded a secondary rate limit.",
+        )]);
+        let options = TransportOptions { pass_budget_ms: 1_000, ..fast_options() };
+        let registry = GovernorRegistry::default();
+        let core = transport_in_lane(&url, None, options.clone(), &registry, "core");
+        let search = transport_in_lane(&url, None, options, &registry, "search");
+
+        let core_error = drive(async { core.get(&format!("{url}/issues"), &[]).await })
+            .expect_err("secondary limit pauses core");
+        assert!(matches!(core_error, TransportError::Paused { .. }));
+        let search_error = drive(async { search.get(&format!("{url}/search"), &[]).await })
+            .expect_err("shared secondary hold pauses search");
+        assert!(matches!(search_error, TransportError::Paused { .. }));
+        assert_eq!(handle.join().unwrap().len(), 1, "search never touched the network");
+    }
+
+    #[test]
     fn a_plain_403_is_returned_to_the_caller_not_retried() {
         let (url, handle) =
             spawn_script_stub(vec![StubResponse::status("403 Forbidden", "no access")]);
@@ -515,6 +615,7 @@ mod tests {
         let registry = GovernorRegistry::default();
         let transport = Transport::new(TransportParams {
             provider: "github",
+            lane: "core",
             host: "api.github.com",
             auth: None,
             registry: &registry,
@@ -556,6 +657,7 @@ mod tests {
         let build = |host: &str| {
             Transport::new(TransportParams {
                 provider: "github",
+                lane: "core",
                 host,
                 auth: None,
                 registry: &registry,
@@ -573,6 +675,7 @@ mod tests {
         let registry = GovernorRegistry::default();
         let transport = Transport::new(TransportParams {
             provider: "gitlab",
+            lane: "core",
             host: "gitlab.example.com:8443",
             auth: None,
             registry: &registry,
@@ -597,6 +700,7 @@ mod tests {
         let transport = Transport::with_clock(
             TransportParams {
                 provider: "github",
+                lane: "core",
                 host: "127.0.0.1",
                 auth: None,
                 registry: &registry,
@@ -651,6 +755,7 @@ mod tests {
         let registry = GovernorRegistry::default();
         let err = Transport::new(TransportParams {
             provider: "gitlab",
+            lane: "core",
             host: "gitlab.example.com:not-a-port",
             auth: None,
             registry: &registry,
@@ -666,6 +771,7 @@ mod tests {
         let registry = GovernorRegistry::default();
         let err = Transport::new(TransportParams {
             provider: "github",
+            lane: "core",
             host: "api.github.com",
             auth: Some(&TrackerAuth::Env("RAG_RAT_TEST_UNSET_TOKEN_VAR".to_string())),
             registry: &registry,

--- a/crates/rag-rat-core/src/index/papertrail/transport/governor.rs
+++ b/crates/rag-rat-core/src/index/papertrail/transport/governor.rs
@@ -1,4 +1,5 @@
-//! Rate governance for the papertrail transport, one governor per (provider, host, token).
+//! Rate governance for the papertrail transport, one governor per
+//! (provider, host, token, provider quota lane).
 //!
 //! Header-driven where the provider reports quota (GitHub `x-ratelimit-*`, GitLab `RateLimit-*`):
 //! after each response the governor updates its view and stops consuming once
@@ -43,15 +44,61 @@ pub(crate) struct GovernorKey {
     pub host: String,
     /// Fingerprint of the resolved token — never the token itself; `anonymous` without one.
     pub token_fingerprint: String,
+    /// Provider quota resource (`core`, `search`, ...). GitHub reports these as independent
+    /// windows; mixing their response headers would let one lane corrupt the other's budget.
+    pub lane: String,
 }
 
 impl GovernorKey {
-    pub(crate) fn new(provider: &str, host: &str, token: Option<&str>) -> Self {
+    pub(crate) fn new(provider: &str, host: &str, token: Option<&str>, lane: &str) -> Self {
         Self {
             provider: provider.to_string(),
             host: host.to_string(),
             token_fingerprint: token_fingerprint(token),
+            lane: lane.to_string(),
         }
+    }
+
+    fn retry_hold_key(&self) -> RetryHoldKey {
+        RetryHoldKey {
+            provider: self.provider.clone(),
+            host: self.host.clone(),
+            token_fingerprint: self.token_fingerprint.clone(),
+        }
+    }
+}
+
+/// Secondary/abuse limits are scoped more broadly than provider primary-quota lanes. This key
+/// deliberately omits `lane`, so core and search transports for one host/token stand down
+/// together without mixing their independent quota headers.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct RetryHoldKey {
+    provider: String,
+    host: String,
+    token_fingerprint: String,
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct RetryHold {
+    until_ms: Mutex<Option<i64>>,
+}
+
+impl RetryHold {
+    pub(crate) fn paused_until(&self, now_ms: i64) -> Option<i64> {
+        let mut hold = self.until_ms.lock().expect("retry-hold mutex");
+        match *hold {
+            Some(until) if now_ms < until => Some(until),
+            Some(_) => {
+                *hold = None;
+                None
+            },
+            None => None,
+        }
+    }
+
+    pub(crate) fn record(&self, until_ms: i64) {
+        let mut hold = self.until_ms.lock().expect("retry-hold mutex");
+        *hold = Some(hold.map_or(until_ms, |current| current.max(until_ms)));
     }
 }
 
@@ -263,6 +310,17 @@ impl RateGovernor {
         Admission::Proceed
     }
 
+    /// Undo one completed admission that the provider explicitly documents as quota-free (GitHub
+    /// authenticated conditional `304`). This is never used for failed/timed-out requests.
+    pub(crate) fn refund_admission(&self) {
+        let mut state = self.state.lock().expect("governor mutex");
+        if let Some(quota) = state.quota.as_mut() {
+            quota.remaining = quota.remaining.saturating_add(1).min(quota.limit);
+        } else {
+            state.window_requests = state.window_requests.saturating_sub(1);
+        }
+    }
+
     /// Record the quota view a response reported. Merged monotonically: within the same provider
     /// window `remaining` only ratchets DOWN — an out-of-order older response cannot raise it
     /// back. Resetless views and nearby reset horizons are the same live window; an older window
@@ -317,6 +375,7 @@ pub(crate) fn backoff_delay_ms(attempt: u32, retry_after_ms: Option<i64>, base_m
 #[derive(Debug, Default)]
 pub(crate) struct GovernorRegistry {
     inner: Mutex<HashMap<GovernorKey, Arc<RateGovernor>>>,
+    retry_holds: Mutex<HashMap<RetryHoldKey, Arc<RetryHold>>>,
 }
 
 impl GovernorRegistry {
@@ -327,6 +386,16 @@ impl GovernorRegistry {
                 .expect("governor registry mutex")
                 .entry(key)
                 .or_insert_with(|| Arc::new(RateGovernor::new(config.clone()))),
+        )
+    }
+
+    pub(crate) fn retry_hold(&self, key: &GovernorKey) -> Arc<RetryHold> {
+        Arc::clone(
+            self.retry_holds
+                .lock()
+                .expect("retry-hold registry mutex")
+                .entry(key.retry_hold_key())
+                .or_default(),
         )
     }
 }
@@ -716,6 +785,18 @@ mod tests {
     }
 
     #[test]
+    fn refund_restores_header_quota_without_exceeding_the_limit() {
+        let governor = governor(0.0, DEFAULT_FALLBACK_BUDGET);
+        governor.record_quota(QuotaSnapshot { limit: 10, remaining: 8, reset_at_ms: None });
+        assert_eq!(governor.admit(T0), Admission::Proceed);
+        governor.refund_admission();
+        governor.refund_admission();
+        governor.refund_admission();
+        let state = governor.state.lock().unwrap();
+        assert_eq!(state.quota.as_ref().unwrap().remaining, 10);
+    }
+
+    #[test]
     fn backoff_grows_exponentially_and_retry_after_wins_when_longer() {
         assert_eq!(backoff_delay_ms(0, None, 1_000), 1_000);
         assert_eq!(backoff_delay_ms(1, None, 1_000), 2_000);
@@ -732,18 +813,24 @@ mod tests {
 
     #[test]
     fn governor_key_fingerprints_tokens_without_storing_them() {
-        let with_token = GovernorKey::new("github", "api.github.com", Some("ghp_secret_token"));
-        let same_token = GovernorKey::new("github", "api.github.com", Some("ghp_secret_token"));
-        let other_token = GovernorKey::new("github", "api.github.com", Some("ghp_other_token"));
-        let anonymous = GovernorKey::new("github", "api.github.com", None);
+        let with_token =
+            GovernorKey::new("github", "api.github.com", Some("ghp_secret_token"), "core");
+        let same_token =
+            GovernorKey::new("github", "api.github.com", Some("ghp_secret_token"), "core");
+        let other_token =
+            GovernorKey::new("github", "api.github.com", Some("ghp_other_token"), "core");
+        let anonymous = GovernorKey::new("github", "api.github.com", None, "core");
+        let search =
+            GovernorKey::new("github", "api.github.com", Some("ghp_secret_token"), "search");
         assert_eq!(with_token, same_token);
         assert_ne!(with_token, other_token);
+        assert_ne!(with_token, search, "provider quota lanes are independent");
         assert_eq!(anonymous.token_fingerprint, "anonymous");
         assert!(!with_token.token_fingerprint.contains("secret"), "never the token itself");
         assert_eq!(with_token.token_fingerprint.len(), 16, "8 digest bytes as hex");
         // Blank tokens govern as anonymous, not as a distinct pool.
         assert_eq!(
-            GovernorKey::new("github", "api.github.com", Some("  ")).token_fingerprint,
+            GovernorKey::new("github", "api.github.com", Some("  "), "core").token_fingerprint,
             "anonymous"
         );
     }
@@ -751,12 +838,13 @@ mod tests {
     #[test]
     fn registry_shares_one_governor_per_key() {
         let registry = GovernorRegistry::default();
-        let key = GovernorKey::new("github", "api.github.com", Some("tok"));
+        let key = GovernorKey::new("github", "api.github.com", Some("tok"), "core");
         let config = GovernorConfig::default();
         let first = registry.governor(key.clone(), &config);
         let second = registry.governor(key, &config);
         assert!(Arc::ptr_eq(&first, &second), "same key → same governor");
-        let other = registry.governor(GovernorKey::new("github", "api.github.com", None), &config);
+        let other =
+            registry.governor(GovernorKey::new("github", "api.github.com", None, "core"), &config);
         assert!(!Arc::ptr_eq(&first, &other), "different token → separate accounting");
     }
 }

--- a/crates/rag-rat-core/src/index/papertrail/transport/mod.rs
+++ b/crates/rag-rat-core/src/index/papertrail/transport/mod.rs
@@ -16,7 +16,7 @@ pub(crate) use client::*;
 pub(crate) use governor::*;
 
 #[cfg(test)]
-mod stub;
+pub(super) mod stub;
 
 #[cfg(test)]
 mod pagination_tests {
@@ -88,6 +88,7 @@ mod pagination_tests {
         let transport = Transport::with_clock(
             TransportParams {
                 provider: "github",
+                lane: "core",
                 host: "127.0.0.1",
                 auth: None,
                 registry: &registry,

--- a/crates/rag-rat-core/src/index/papertrail/transport/stub.rs
+++ b/crates/rag-rat-core/src/index/papertrail/transport/stub.rs
@@ -11,23 +11,23 @@ use std::time::{Duration, Instant};
 
 /// One scripted response. The stub serves them in order, one connection each
 /// (`Connection: close`).
-pub(super) struct StubResponse {
+pub(crate) struct StubResponse {
     pub status: &'static str,
     pub headers: Vec<(String, String)>,
     pub body: String,
 }
 
 impl StubResponse {
-    pub(super) fn ok(body: &str) -> Self {
+    pub(crate) fn ok(body: &str) -> Self {
         Self::status("200 OK", body)
     }
 
-    pub(super) fn status(status: &'static str, body: &str) -> Self {
+    pub(crate) fn status(status: &'static str, body: &str) -> Self {
         Self { status, headers: Vec::new(), body: body.to_string() }
     }
 
     /// A `200 OK` carrying GitHub-style quota headers.
-    pub(super) fn ok_with_quota(
+    pub(crate) fn ok_with_quota(
         body: &str,
         limit: i64,
         remaining: i64,
@@ -49,7 +49,7 @@ impl StubResponse {
 /// connection per response — and returns the base URL plus a join handle yielding the captured
 /// request HEADS (request line + headers) in arrival order, so tests can assert the exact page
 /// sequence. Accepts poll with a deadline so a client-side bug can't hang the join forever.
-pub(super) fn spawn_script_stub(
+pub(crate) fn spawn_script_stub(
     responses: Vec<StubResponse>,
 ) -> (String, thread::JoinHandle<Vec<String>>) {
     spawn_script_stub_with_timeout(responses, Duration::from_secs(10))
@@ -62,6 +62,17 @@ fn spawn_script_stub_with_timeout(
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
     listener.set_nonblocking(true).expect("nonblocking listener");
     let port = listener.local_addr().unwrap().port();
+    let base = format!("http://127.0.0.1:{port}");
+    let responses = responses
+        .into_iter()
+        .map(|mut response| {
+            response.body = response.body.replace("{BASE}", &base);
+            for (_, value) in &mut response.headers {
+                *value = value.replace("{BASE}", &base);
+            }
+            response
+        })
+        .collect::<Vec<_>>();
     let handle = thread::spawn(move || {
         let mut captured = Vec::new();
         for response in responses {
@@ -93,7 +104,7 @@ fn spawn_script_stub_with_timeout(
         }
         captured
     });
-    (format!("http://127.0.0.1:{port}"), handle)
+    (base, handle)
 }
 
 /// Read the request head + its full `Content-Length` body (drained, discarded), returning the

--- a/crates/rag-rat-core/src/index/query_api/history.rs
+++ b/crates/rag-rat-core/src/index/query_api/history.rs
@@ -147,62 +147,18 @@ impl IndexDatabase {
         Ok(Some(summary))
     }
 
-    pub fn papertrail_sync_from_refs(&self, offline: bool) -> anyhow::Result<PapertrailSyncReport> {
-        self.papertrail_sync_from_refs_with_progress(offline, |_| {})
-    }
-
-    pub fn papertrail_sync_from_refs_with_progress(
-        &self,
-        offline: bool,
-        progress: impl FnMut(papertrail::PapertrailSyncProgress),
-    ) -> anyhow::Result<PapertrailSyncReport> {
+    /// Mirror every resolved tracker binding. References remain an annotation layer and do not
+    /// select the network fetch set.
+    pub fn papertrail_sync(&self, full: bool) -> anyhow::Result<PapertrailSyncReport> {
         let Some(root) = self.storage.source_root() else {
             anyhow::bail!("index has no source_root metadata; rebuild required");
         };
-        if offline {
-            papertrail::block_on(papertrail::sync_from_refs::<papertrail::GitHubClient>(
-                self.storage.connection(),
-                root,
-                None,
-                true,
-                &self.papertrail,
-            ))
-        } else {
-            let client = papertrail::GitHubClient;
-            papertrail::block_on(papertrail::sync_from_refs_with_progress(
-                self.storage.connection(),
-                root,
-                Some(&client),
-                false,
-                &self.papertrail,
-                progress,
-            ))
-        }
-    }
-
-    pub fn papertrail_sync_issue(
-        &self,
-        issue_ref: &str,
-        offline: bool,
-    ) -> anyhow::Result<PapertrailSyncReport> {
-        if offline {
-            papertrail::block_on(papertrail::sync_issue::<papertrail::GitHubClient>(
-                self.storage.connection(),
-                issue_ref,
-                None,
-                true,
-                &self.papertrail,
-            ))
-        } else {
-            let client = papertrail::GitHubClient;
-            papertrail::block_on(papertrail::sync_issue(
-                self.storage.connection(),
-                issue_ref,
-                Some(&client),
-                false,
-                &self.papertrail,
-            ))
-        }
+        papertrail::block_on(papertrail::sync_mirror(
+            self.storage.connection(),
+            root,
+            full,
+            &self.papertrail,
+        ))
     }
 
     pub fn papertrail_issue_search(

--- a/crates/rag-rat-core/src/index/schema/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema/migrations.rs
@@ -1256,6 +1256,8 @@ pub(crate) fn known_version(migrations: &[AppliedMigration]) -> u32 {
             MIGRATION_059_ID => Some(59),
             MIGRATION_060_ID => Some(60),
             MIGRATION_061_ID => Some(61),
+            MIGRATION_062_ID => Some(62),
+            MIGRATION_063_ID => Some(63),
             _ => None,
         })
         .max()
@@ -1326,6 +1328,8 @@ pub(crate) fn known_migration(id: &str) -> bool {
             | MIGRATION_059_ID
             | MIGRATION_060_ID
             | MIGRATION_061_ID
+            | MIGRATION_062_ID
+            | MIGRATION_063_ID
             | DIRTY_MIGRATION_ID
     )
 }
@@ -1393,6 +1397,8 @@ pub(crate) fn migration_checksum_mismatch(migration: &AppliedMigration) -> bool 
         MIGRATION_059_ID => migration.checksum != MIGRATION_059_CHECKSUM,
         MIGRATION_060_ID => migration.checksum != MIGRATION_060_CHECKSUM,
         MIGRATION_061_ID => migration.checksum != MIGRATION_061_CHECKSUM,
+        MIGRATION_062_ID => migration.checksum != MIGRATION_062_CHECKSUM,
+        MIGRATION_063_ID => migration.checksum != MIGRATION_063_CHECKSUM,
         _ => false,
     }
 }
@@ -3257,6 +3263,56 @@ pub(crate) fn apply_papertrail_ref_item_kind(conn: &Connection) -> rusqlite::Res
                                 source_kind, COALESCE(source_path, ''),
                                 COALESCE(source_commit, ''), source_text);",
     )
+}
+
+/// V062 (#591): repo-wide comments have an independent timestamp lane and a page token that is
+/// committed only after its page is stored. Existing cursors start with no comment watermark, so
+/// the first native pass safely replays the comment streams instead of inheriting the item mark.
+pub(crate) fn apply_papertrail_comment_cursor(conn: &Connection) -> rusqlite::Result<()> {
+    add_column_if_missing(conn, "papertrail_sync_cursor", "comment_high_mark_at", "TEXT")?;
+    add_column_if_missing(conn, "papertrail_sync_cursor", "comment_page_token", "TEXT")?;
+    Ok(())
+}
+
+/// V063 (#591): every multi-request mirror lane persists enough state to resume after a governed
+/// pause. The processed-key sets are bounded by one provider page; `full_rewalk_seen` lives on the
+/// item row so a full walk can mark/sweep across arbitrarily many invocations without a giant
+/// in-memory set.
+pub(crate) fn apply_papertrail_mirror_resume_state(conn: &Connection) -> rusqlite::Result<()> {
+    add_column_if_missing(conn, "papertrail_sync_cursor", "comment_scan_since", "TEXT")?;
+    add_column_if_missing(conn, "papertrail_sync_cursor", "comment_stream_cursors", "TEXT")?;
+    add_column_if_missing(conn, "papertrail_sync_cursor", "item_delta_page_token", "TEXT")?;
+    add_column_if_missing(conn, "papertrail_sync_cursor", "item_delta_scan_since", "TEXT")?;
+    add_column_if_missing(conn, "papertrail_sync_cursor", "item_delta_high_mark_at", "TEXT")?;
+    add_column_if_missing(conn, "papertrail_sync_cursor", "backfill_page_cursor", "TEXT")?;
+    add_column_if_missing(conn, "papertrail_sync_cursor", "item_thread_cursor", "TEXT")?;
+    add_column_if_missing(
+        conn,
+        "papertrail_sync_cursor",
+        "item_delta_in_progress",
+        "INTEGER NOT NULL DEFAULT 0",
+    )?;
+    add_column_if_missing(
+        conn,
+        "papertrail_sync_cursor",
+        "item_delta_replay_required",
+        "INTEGER NOT NULL DEFAULT 0",
+    )?;
+    add_column_if_missing(conn, "papertrail_sync_cursor", "delta_processed_keys", "TEXT")?;
+    add_column_if_missing(conn, "papertrail_sync_cursor", "backfill_processed_keys", "TEXT")?;
+    add_column_if_missing(
+        conn,
+        "papertrail_sync_cursor",
+        "full_rewalk",
+        "INTEGER NOT NULL DEFAULT 0",
+    )?;
+    add_column_if_missing(
+        conn,
+        "papertrail_items",
+        "full_rewalk_seen",
+        "INTEGER NOT NULL DEFAULT 0",
+    )?;
+    Ok(())
 }
 
 /// The V060 base-table backfill (step 2 of [`apply_papertrail_provider_neutral_schema`]): runs

--- a/crates/rag-rat-core/src/index/schema/mod.rs
+++ b/crates/rag-rat-core/src/index/schema/mod.rs
@@ -19,7 +19,7 @@ pub use registry::{LEGACY_REPO_ID, RegisteredRepo, register_repo, register_repo_
 use rusqlite::{Connection, OptionalExtension, params};
 use serde::Serialize;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 61;
+pub const LATEST_SCHEMA_VERSION: u32 = 63;
 
 /// Every oracle-DERIVED persisted table — the outputs an `oracle run` writes that must OUTLIVE a
 /// reindex.
@@ -436,6 +436,16 @@ const MIGRATION_061_CHECKSUM: &str = "sha256:rag-rat-papertrail-ref-item-kind-v6
 const MIGRATION_061_DESCRIPTION: &str = "Preserve the nullable item_kind on papertrail_refs so \
                                          providers with separate issue/change-request namespaces \
                                          cannot collapse #N and !N annotations";
+const MIGRATION_062_ID: &str = "062_papertrail_comment_cursor";
+const MIGRATION_062_CHECKSUM: &str = "sha256:rag-rat-papertrail-comment-cursor-v62";
+const MIGRATION_062_DESCRIPTION: &str = "Split repo-wide comment progress from the item watermark \
+                                         and persist comment pagination only after each stored \
+                                         page";
+const MIGRATION_063_ID: &str = "063_papertrail_mirror_resume_state";
+const MIGRATION_063_CHECKSUM: &str = "sha256:rag-rat-papertrail-mirror-resume-state-v63e";
+const MIGRATION_063_DESCRIPTION: &str =
+    "Persist item-page, item-thread, Search-tie, per-stream comment-scan, immutable item-delta \
+     windows, and full-rewalk state so every stored unit resumes without replay or lost pruning";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -947,6 +957,18 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         checksum: MIGRATION_061_CHECKSUM,
         description: MIGRATION_061_DESCRIPTION,
         apply: apply_papertrail_ref_item_kind,
+    },
+    Migration {
+        id: MIGRATION_062_ID,
+        checksum: MIGRATION_062_CHECKSUM,
+        description: MIGRATION_062_DESCRIPTION,
+        apply: apply_papertrail_comment_cursor,
+    },
+    Migration {
+        id: MIGRATION_063_ID,
+        checksum: MIGRATION_063_CHECKSUM,
+        description: MIGRATION_063_DESCRIPTION,
+        apply: apply_papertrail_mirror_resume_state,
     },
 ];
 

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/mod.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/mod.rs
@@ -579,6 +579,7 @@ impl MockGitHubClient {
             created_at: Some("2026-01-01T00:00:00Z".to_string()),
             updated_at: Some("2026-01-02T00:00:00Z".to_string()),
             merged_at: None,
+            tags: Vec::new(),
         }
     }
 
@@ -638,7 +639,11 @@ impl papertrail::PapertrailClient for MockGitHubClient {
         project: &str,
         _cursor: &papertrail::PageCursor,
     ) -> anyhow::Result<papertrail::ItemsPage> {
-        Ok(papertrail::ItemsPage { items: vec![Self::mock_item(project, "42")], next: None })
+        Ok(papertrail::ItemsPage {
+            items: vec![Self::mock_item(project, "42")],
+            next: None,
+            backfill_boundary: None,
+        })
     }
 
     async fn comments_page(
@@ -652,12 +657,13 @@ impl papertrail::PapertrailClient for MockGitHubClient {
     async fn freshness_probe(
         &self,
         _project: &str,
-        cursor: &papertrail::PageCursor,
-    ) -> anyhow::Result<Option<String>> {
-        Ok(match cursor.updated_since.as_deref() {
+        probe: &papertrail::FreshnessProbe,
+    ) -> anyhow::Result<papertrail::FreshnessResult> {
+        let latest = match probe.updated_since.as_deref() {
             Some(since) if since >= "2026-01-02T00:00:00Z" => None,
             _ => Some("2026-01-02T00:00:00Z".to_string()),
-        })
+        };
+        Ok(papertrail::FreshnessResult { latest, etag: None, not_modified: false })
     }
 }
 
@@ -704,9 +710,9 @@ impl papertrail::PapertrailClient for PartiallyFailingGitHubClient {
     async fn freshness_probe(
         &self,
         project: &str,
-        cursor: &papertrail::PageCursor,
-    ) -> anyhow::Result<Option<String>> {
-        MockGitHubClient.freshness_probe(project, cursor).await
+        probe: &papertrail::FreshnessProbe,
+    ) -> anyhow::Result<papertrail::FreshnessResult> {
+        MockGitHubClient.freshness_probe(project, probe).await
     }
 }
 

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/papertrail_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/papertrail_tests.rs
@@ -99,6 +99,7 @@ fn manual_sync_validates_client_and_routes_only_the_requested_github_identity() 
             authentication: papertrail::TrackerAuthentication::AuthMissing,
             tags: Vec::new(),
         }],
+        ..papertrail::PapertrailContext::default()
     };
     let explicit_without_github_binding = papertrail::block_on(papertrail::sync_issue(
         db.storage.connection(),
@@ -196,6 +197,7 @@ fn production_discovery_persists_refs_for_every_configured_tracker() {
                 tags: Vec::new(),
             },
         ],
+        ..papertrail::PapertrailContext::default()
     };
 
     sync_from_refs_blocking(db.storage.connection(), &root, Some(&MockGitHubClient), true, &ctx)
@@ -612,6 +614,9 @@ fn v060_creates_the_papertrail_tables_on_fresh_apply() {
         conn_index_exists(&conn, "idx_papertrail_comments_natural_key"),
         "comments natural key"
     );
+    let cursor_columns = conn_table_columns(&conn, "papertrail_sync_cursor");
+    assert!(cursor_columns.contains(&"comment_high_mark_at".to_string()));
+    assert!(cursor_columns.contains(&"comment_page_token".to_string()));
     schema::apply(&conn).unwrap();
     assert!(conn_table_exists(&conn, "papertrail_items"), "survives re-apply");
 
@@ -619,6 +624,60 @@ fn v060_creates_the_papertrail_tables_on_fresh_apply() {
     truncate_schema_to(&conn, 59);
     schema::migrate_forward(&conn).unwrap();
     assert_eq!(schema::status(&conn).unwrap().current_version, schema::LATEST_SCHEMA_VERSION);
+}
+
+#[test]
+fn migration_063_is_the_tip_and_persists_mirror_resume_state() {
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 63, "move this pin with the next schema migration");
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn).unwrap();
+    let columns = conn_table_columns(&conn, "papertrail_sync_cursor");
+    assert!(columns.contains(&"comment_high_mark_at".to_string()));
+    assert!(columns.contains(&"comment_page_token".to_string()));
+    for column in [
+        "comment_scan_since",
+        "comment_stream_cursors",
+        "item_delta_page_token",
+        "item_delta_scan_since",
+        "item_delta_high_mark_at",
+        "backfill_page_cursor",
+        "item_thread_cursor",
+        "item_delta_in_progress",
+        "item_delta_replay_required",
+        "delta_processed_keys",
+        "backfill_processed_keys",
+        "full_rewalk",
+    ] {
+        assert!(columns.contains(&column.to_string()), "cursor has {column}");
+    }
+    assert!(
+        conn_table_columns(&conn, "papertrail_items").contains(&"full_rewalk_seen".to_string())
+    );
+    schema::apply_papertrail_mirror_resume_state(&conn).unwrap();
+    assert_eq!(conn_table_columns(&conn, "papertrail_sync_cursor"), columns, "V063 is idempotent");
+}
+
+#[test]
+fn migration_063_checksum_replays_the_pre_replay_flag_shape() {
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn).unwrap();
+    conn.execute("ALTER TABLE papertrail_sync_cursor DROP COLUMN item_delta_replay_required", [])
+        .unwrap();
+    conn.execute(
+        "UPDATE schema_version
+         SET checksum = 'sha256:rag-rat-papertrail-mirror-resume-state-v63d'
+         WHERE id = '063_papertrail_mirror_resume_state'",
+        [],
+    )
+    .unwrap();
+
+    schema::apply(&conn).unwrap();
+
+    assert!(
+        conn_table_columns(&conn, "papertrail_sync_cursor")
+            .contains(&"item_delta_replay_required".to_string())
+    );
+    assert_eq!(schema::status(&conn).unwrap().state, schema::SchemaState::Compatible);
 }
 
 /// The load-bearing multi-repo invariant carried over from V044/V045: two repos can each cache
@@ -903,9 +962,9 @@ impl papertrail::PapertrailClient for RecoveringCommentsClient {
     async fn freshness_probe(
         &self,
         project: &str,
-        cursor: &papertrail::PageCursor,
-    ) -> anyhow::Result<Option<String>> {
-        MockGitHubClient.freshness_probe(project, cursor).await
+        probe: &papertrail::FreshnessProbe,
+    ) -> anyhow::Result<papertrail::FreshnessResult> {
+        MockGitHubClient.freshness_probe(project, probe).await
     }
 }
 
@@ -1011,15 +1070,18 @@ fn papertrail_client_batch_surface_round_trips_through_the_trait() {
     assert_eq!(comments.comments.iter().filter(|c| c.review_state.is_some()).count(), 1);
     assert_eq!(comments.comments.iter().filter(|c| c.anchor_path.is_some()).count(), 1);
 
-    let moved = papertrail::block_on(MockGitHubClient.freshness_probe("o/r", &cursor)).unwrap();
-    assert_eq!(moved.as_deref(), Some("2026-01-02T00:00:00Z"));
-    let quiet_cursor = papertrail::PageCursor {
+    let moved = papertrail::block_on(
+        MockGitHubClient.freshness_probe("o/r", &papertrail::FreshnessProbe::default()),
+    )
+    .unwrap();
+    assert_eq!(moved.latest.as_deref(), Some("2026-01-02T00:00:00Z"));
+    let quiet_probe = papertrail::FreshnessProbe {
         updated_since: Some("2026-01-02T00:00:00Z".into()),
-        page_token: None,
+        etag: None,
     };
     let quiet =
-        papertrail::block_on(MockGitHubClient.freshness_probe("o/r", &quiet_cursor)).unwrap();
-    assert_eq!(quiet, None, "a probe at the cursor position reports no movement");
+        papertrail::block_on(MockGitHubClient.freshness_probe("o/r", &quiet_probe)).unwrap();
+    assert_eq!(quiet.latest, None, "a probe at the cursor position reports no movement");
 }
 
 // --- V060: the github_* -> papertrail_* backfill against a POPULATED pre-migration DB ---

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_registry.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_registry.rs
@@ -2752,6 +2752,7 @@ fn a_syncing_repo_is_isolated_from_stranded_placeholder_papertrail_rows() {
             created_at: None,
             updated_at: None,
             merged_at: None,
+            tags: Vec::new(),
         },
     )
     .unwrap();

--- a/docs/config.md
+++ b/docs/config.md
@@ -604,15 +604,17 @@ URLs; Bitbucket `#N` (issues) and `/issues/N` / `/pull-requests/N` URLs; Jira ba
 (`PROJ-123`) for the bound project. A bare `#N` resolves against the first code-host binding
 only. A self-hosted binding's URL grammar matches its own host, not the cloud host.
 
-All bindings participate in production reference discovery and annotation lookup, but live
-network synchronization remains GitHub-only. GitLab, Bitbucket, and Jira refs are persisted
-without being sent through the GitHub client. The shared transport resolves each binding's
-`auth` source and governs its quota, but native provider clients and parallel per-binding mirror
-dispatch land in the later provider-client PRs; these settings do not yet activate a non-GitHub
-network mirror.
+All bindings participate in production reference discovery, annotation lookup, and manual mirror
+dispatch. GitHub bindings use the native client now; GitLab, Bitbucket, and Jira bindings report a
+provider-client-pending result until their provider PRs land, and are never sent through the GitHub
+client. The shared runner keeps every result, cursor, auth source, and quota governor scoped to its
+binding. A repository may have at most one resolved binding for a given `(provider, project)`:
+the mirror rejects duplicates before dispatch because API origin and tag filters are not part of
+the persisted item/cache cursor identity. Use one binding and one combined tag set for that
+provider project.
 
 The shared transport keeps part of each header-reported quota untouched for the user's own tools.
-The reserve defaults to 35% and can be changed independently of the later provider clients:
+The reserve defaults to 35% and can be changed independently of provider clients:
 
 ```toml
 [papertrail]

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -421,9 +421,10 @@ and caches it by `source_text_hash`.
 commit count, and file-change count. Non-git roots report unavailable history without failing source
 or docs indexing.
 
-Papertrail tools read the local cache only. `rag-rat papertrail sync --from-refs` discovers refs
-and fetches through `gh api --paginate`; `rag-rat papertrail sync --issue owner/repo#123` fetches
-one item thread; `--offline` updates discovered refs and reports cache status without network use.
+Papertrail tools read the local cache only. `rag-rat papertrail sync` mirrors every resolved
+tracker binding through its native provider client; `--full` forces a complete historical re-walk
+to heal cached rows. Source and commit references remain annotations and do not select what the
+mirror fetches.
 
 Papertrail outputs keep `current_source` separate from `evidence`. Cached snippets are labeled as
 historical tracker evidence (`historical_tracker` / `literal_tracker_ref`) and classified as
@@ -432,7 +433,7 @@ row names its `tracker` (`github`), `project` (`owner/repo`), `item_kind` (`issu
 `change_request`), `item_key`, and `doc_kind` (`item` | `comment`).
 
 `index_status.papertrail` reports cached refs, issues, change requests, comments, last sync time,
-and whether the `gh` CLI capability is available.
+and each binding's authentication and native synchronization capability.
 `papertrail_sync_status` returns that cache section directly. `heal_index` repairs or removes
 already-indexed files whose current source no longer matches the stored SQLite index, then refreshes
 SQLite FTS. It does not discover brand-new files; run `rag-rat index` for discovery.


### PR DESCRIPTION
Closes #591

## What changed

- replaces the retired `gh`/reference-selected production path with a native, binding-scoped GitHub client
- adds a provider-neutral whole-project mirror runner with independent item-high, provider-comment-stream, and LIFO backfill cursors
- validates continuations before page writes; repository-comment pages checkpoint opaque state, while resumed item-comment deletion walks restart and require two identical complete ID sets before pruning
- walks equal-timestamp Search spillover one commit-able page at a time before tightening the strict backfill boundary, without persisting unstable page numbers or walking into the 1,000-result cap
- splits historical Search into App-compatible `is:issue` and `is:pull-request` streams and reports one safe boundary across both; persisted pre-split combined cursors retain their old semantics
- enriches issue-shaped pull-request results from the origin-pinned pulls endpoint one item at a time; each completed item checkpoints independently, so pauses and failures retry only the current item
- scans mutable item and repository-comment REST streams in ascending updated-time order; durable progress advances only to the first page's proven inclusive frontier, and item deltas require a complete overlapped verification replay before restoring conditional probes
- uses version-bound processed markers so refetched items changed during a pause are refreshed and re-filtered before their page advances
- overlaps item and repo-comment deltas by one second; item scans persist immutable lower bounds, conservative first-page frontiers, and replay-required state across pauses, including stable pagination ties
- persists tags and prunes items that stop matching; forced full walks persist mark/sweep state across resumptions, remove missing items and stale comments only after completion, then rebuild FTS
- supports issues, pull requests, issue comments, reviews, anchored review comments, independently checkpointed repo-wide comment streams, pagination, and conditional probes
- keeps authentication, API origins, primary quota lanes, cursors, and results binding-scoped; ambient GitHub credentials are used only for cloud GitHub
- rejects duplicate resolved provider/project bindings before dispatch because origin and filters are not separate persisted cache identities
- shares GitHub secondary/abuse holds across core and Search lanes for the same host/token
- rejects cross-origin pagination and redirects before credentials can leave a binding
- changes the CLI and documentation to `rag-rat papertrail sync [--full]`; references remain annotations only

## Validation

- `cargo nextest run --workspace`: 2,590 passed
- `cargo clippy -p rag-rat-core --all-targets -- -D warnings`
- `cargo +nightly fmt --all -- --check`
- focused papertrail regression suite: 135 passed
- two separate edge-case review agents: pagination, replacement-cache, auth, and origin-validation findings addressed before push
- Codecov patch coverage: passing on the current head
- stub regressions cover all review findings plus LIFO pause/resume, mid-backfill updates, tag changes, 304 probes, Enterprise origin pinning, cross-origin rejection, payload mapping, and multi-binding dispatch
- authenticated isolated live smoke against `cq27-dev/rag-rat`: pass 1 stored 300 items and paused at the pass budget; pass 2 resumed and completed with 638 distinct items / 3,402 comments and no errors
- live MCP `papertrail_issue_search` returned PR #638, which had no `papertrail_refs` row, proving whole-project discovery beyond referenced items