### PR TITLE
feat(lang): add Swift baseline support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3516,6 +3516,7 @@ dependencies = [
  "tree-sitter-kotlin-ng",
  "tree-sitter-python",
  "tree-sitter-rust",
+ "tree-sitter-swift",
  "tree-sitter-typescript",
  "unicode-normalization",
  "ureq 3.3.0",
@@ -4909,6 +4910,16 @@ name = "tree-sitter-rust"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439e577dbe07423ec2582ac62c7531120dbfccfa6e5f92406f93dd271a120e45"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-swift"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe36052155b9dd69ca82b3b8f1b4ccfb2d867125ac1a4db1dd7331829242668c"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,7 @@ tree-sitter-cpp = "=0.23.4"
 tree-sitter-kotlin = { package = "tree-sitter-kotlin-ng", version = "1.1.0" }
 tree-sitter-python = "=0.25.0"
 tree-sitter-rust = "=0.24.2"
+tree-sitter-swift = "=0.7.3"
 tree-sitter-typescript = "=0.23.2"
 # Secret-material hygiene for the op-log device seed — `Zeroizing<[u8; 32]>` scrubs the seed copy on
 # drop (already in the tree transitively via ed25519-dalek; pinned here as a direct dep).

--- a/README.md
+++ b/README.md
@@ -38,8 +38,9 @@ sequenceDiagram
   are *not* assistant memory: they are versioned, local, source-anchored facts about **this**
   repository that any future agent retrieves with evidence.
 - **A real code graph.** tree-sitter callers/callees/imports across Rust, TypeScript/TSX, Kotlin,
-  C/C++, and Python — with an optional [compiler-grade SCIP oracle](docs/oracle.md) that upgrades
-  edges to `Compiler` confidence and ranks the load-bearing symbols.
+  C/C++, Python, and Swift — with an optional [compiler-grade SCIP oracle](docs/oracle.md) for
+  configured toolchains that upgrades edges to `Compiler` confidence and ranks the load-bearing
+  symbols.
 - **History as evidence.** Git history, lazy chunk blame, and cached GitHub issue/PR/review
   rationale, all queryable.
 - **Rides your existing grep.** A [PreToolUse hook](docs/grep-augmentation.md) injects the memories

--- a/crates/rag-rat-cli/src/init/mod.rs
+++ b/crates/rag-rat-cli/src/init/mod.rs
@@ -319,6 +319,31 @@ mod tests {
     }
 
     #[test]
+    fn rendered_swift_binding_round_trips_with_default_glob() {
+        let root = std::env::temp_dir().join(format!("ragrat-render-swift-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(root.join("Sources/App")).unwrap();
+        std::fs::write(root.join("Sources/App/App.swift"), "struct App {}\n").unwrap();
+        let plan = InitPlan {
+            root_value: ".".to_string(),
+            languages: vec![Language::Swift],
+            bindings: BTreeMap::from([(Language::Swift, vec![PathBuf::from("Sources")])]),
+            backend: EmbeddingBackend::fast_embed(),
+            oracle_auto_run: false,
+        };
+
+        let text = render_config(&plan);
+        assert!(text.contains("swift = [\"Sources\"]"));
+        std::fs::write(root.join("rag-rat.toml"), text).unwrap();
+        let config = Config::load(root.join("rag-rat.toml")).unwrap();
+        assert_eq!(config.targets.len(), 1);
+        assert_eq!(config.targets[0].language, Language::Swift);
+        assert_eq!(config.targets[0].directories, vec![PathBuf::from("Sources")]);
+        assert_eq!(config.targets[0].include, vec!["**/*.swift"]);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
     fn render_config_emits_full_commented_surface_that_round_trips() {
         // The generated config documents the full surface (commented), still parses via
         // Config::load, and the example [[target]] / [watch] / [version_check] tables stay

--- a/crates/rag-rat-cli/src/init/scan.rs
+++ b/crates/rag-rat-cli/src/init/scan.rs
@@ -212,6 +212,12 @@ pub(crate) fn default_dir(scan: &RepoScan, language: Language, path: &Path) -> b
                     || text.ends_with("/src")
                     || directly_contains_source(scan, language, path)
                     || python_root_has_direct_source(scan, path)),
+        Language::Swift =>
+            !text.split('/').any(|component| component == ".build")
+                && (text == "Sources"
+                    || text.ends_with("/Sources")
+                    || text == "src"
+                    || text.ends_with("/src")),
         Language::Markdown => text == "docs" || text == ".",
     }
 }
@@ -337,6 +343,74 @@ mod header_assignment_tests {
         assert_eq!(scan.language_counts.get(&Language::Cpp).copied().unwrap_or(0), 0, "no C++");
 
         fs::remove_dir_all(&root).ok();
+    }
+}
+
+#[cfg(test)]
+mod swift_dir_tests {
+    use super::*;
+
+    #[test]
+    fn swiftpm_sources_is_the_default_binding() {
+        let scan = RepoScan::default();
+        assert!(default_dir(&scan, Language::Swift, Path::new("Sources")));
+        assert!(default_dir(&scan, Language::Swift, Path::new("Packages/Feature/Sources")));
+        assert!(!default_dir(
+            &scan,
+            Language::Swift,
+            Path::new(".build/checkouts/Dependency/Sources")
+        ));
+        assert!(!default_dir(&scan, Language::Swift, Path::new("Tests")));
+    }
+
+    #[test]
+    fn swiftpm_build_checkouts_are_not_scanned_as_project_source() {
+        let root = tempfile::tempdir().unwrap();
+        fs::create_dir_all(root.path().join("Sources/App")).unwrap();
+        fs::write(root.path().join("Sources/App/Main.swift"), "struct App {}\n").unwrap();
+        fs::create_dir_all(root.path().join(".build/checkouts/Dep/Sources/Dep")).unwrap();
+        fs::write(
+            root.path().join(".build/checkouts/Dep/Sources/Dep/Dep.swift"),
+            "struct Dependency {}\n",
+        )
+        .unwrap();
+
+        let scan = scan_repo(root.path()).unwrap();
+        assert_eq!(scan.language_counts.get(&Language::Swift), Some(&1));
+        assert!(
+            candidate_dirs(&scan, Language::Swift)
+                .iter()
+                .all(|candidate| !candidate.path.starts_with(".build")),
+            "SwiftPM build checkouts must not become init candidates"
+        );
+    }
+
+    #[test]
+    fn swift_root_fallback_remains_safe_for_the_indexer() {
+        let root = tempfile::tempdir().unwrap();
+        fs::write(root.path().join("Main.swift"), "struct App {}\n").unwrap();
+        fs::create_dir_all(root.path().join(".build/checkouts/Dep/Sources/Dep")).unwrap();
+        fs::write(
+            root.path().join(".build/checkouts/Dep/Sources/Dep/Dep.swift"),
+            "struct Dependency {}\n",
+        )
+        .unwrap();
+
+        let scan = scan_repo(root.path()).unwrap();
+        let candidates = candidate_dirs(&scan, Language::Swift);
+        assert!(
+            candidates
+                .iter()
+                .any(|candidate| candidate.path == Path::new(".") && candidate.default),
+            "a non-SwiftPM layout should exercise the generated root fallback: {candidates:#?}"
+        );
+
+        let matcher = IgnoreMatcher::compile(root.path(), &[PathBuf::from(".")]);
+        assert!(matcher.is_ignored(
+            &root.path().join(".build/checkouts/Dep/Sources/Dep/Dep.swift"),
+            false,
+        ));
+        assert!(!matcher.is_ignored(&root.path().join("Main.swift"), false));
     }
 }
 

--- a/crates/rag-rat-cli/src/init/wizard/steps/tests.rs
+++ b/crates/rag-rat-cli/src/init/wizard/steps/tests.rs
@@ -222,6 +222,26 @@ fn indexing_reentry_preserves_disabled_detected_languages() {
 }
 
 #[test]
+fn indexing_exposes_and_preselects_detected_swiftpm_sources() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(dir.path().join("Sources/App")).unwrap();
+    std::fs::write(dir.path().join("Sources/App/App.swift"), "struct App {}\n").unwrap();
+    let scan = scan_repo(dir.path()).unwrap();
+    let draft = WizardDraft::from_scan(&scan, ".".to_string(), dir.path().to_path_buf());
+    let mut state = WizardState::new(draft, scan);
+
+    state.step = Some(init_step(StepId::Indexing, &state));
+
+    assert_eq!(language_toggle(&state, Language::Swift), Some(true));
+    assert!(
+        candidates_for(Language::Swift, &state)
+            .iter()
+            .any(|candidate| candidate.path == std::path::Path::new("Sources") && candidate.default),
+        "the wizard should preselect the SwiftPM Sources directory"
+    );
+}
+
+#[test]
 fn indexing_tree_page_down_moves_selection() {
     let (_dir, mut state) = rust_state(18);
     step_handle_key(StepId::Indexing, key(KeyCode::Tab), &mut state);

--- a/crates/rag-rat-cli/tests/init_yes_writes_valid_config.rs
+++ b/crates/rag-rat-cli/tests/init_yes_writes_valid_config.rs
@@ -41,10 +41,13 @@ fn init_yes_writes_a_config_that_config_load_accepts() {
     // test's temp dir so init's index build can never touch the developer's real global store.
     let data_dir = root.join("data");
     std::fs::create_dir_all(root.join("src")).unwrap();
+    std::fs::create_dir_all(root.join("Sources/App")).unwrap();
     std::fs::create_dir_all(&cache).unwrap();
-    // A trivial Rust source tree so the scan binds `rust = ["src"]` (a non-empty plan; an empty
-    // plan would make `init` bail by design — that path is covered in `init_dir_selection.rs`).
+    // Trivial Rust and SwiftPM source trees make the scan bind both default source directories (a
+    // non-empty plan; an empty plan would make `init` bail by design — that path is covered in
+    // `init_dir_selection.rs`).
     std::fs::write(root.join("src/lib.rs"), "pub fn alpha() -> u32 {\n    1\n}\n").unwrap();
+    std::fs::write(root.join("Sources/App/App.swift"), "struct App {}\n").unwrap();
     // `init --yes` auto-accepts the git-maintenance-hook install (its pre-wizard behavior, which
     // this test pins as unchanged), and that install needs a real git repo — so make one. The
     // hooks themselves never fire here: `RAG_RAT_HOOK_DISABLE=1` short-circuits them.
@@ -100,6 +103,15 @@ fn init_yes_writes_a_config_that_config_load_accepts() {
     assert!(
         config.targets.iter().any(|t| t.language == rag_rat_core::language::Language::Rust),
         "the rust source tree must bind a rust target, got: {:?}",
+        config.targets
+    );
+    assert!(
+        config.targets.iter().any(|target| {
+            target.language == rag_rat_core::language::Language::Swift
+                && target.directories == [std::path::PathBuf::from("Sources")]
+                && target.include == ["**/*.swift"]
+        }),
+        "the SwiftPM source tree must bind a Swift target with default globs, got: {:?}",
         config.targets
     );
 

--- a/crates/rag-rat-core/Cargo.toml
+++ b/crates/rag-rat-core/Cargo.toml
@@ -54,6 +54,7 @@ tree-sitter-cpp.workspace = true
 tree-sitter-kotlin.workspace = true
 tree-sitter-python.workspace = true
 tree-sitter-rust.workspace = true
+tree-sitter-swift.workspace = true
 tree-sitter-typescript.workspace = true
 minicbor = { version = "2.2.2", features = ["alloc"] }
 unicode-normalization = "0.1.25"

--- a/crates/rag-rat-core/src/dream/findings.rs
+++ b/crates/rag-rat-core/src/dream/findings.rs
@@ -183,7 +183,10 @@ pub(super) fn coverage_gap(conn: &Connection, limit: usize) -> anyhow::Result<Ve
     let inbound: HashSet<i64> = conn
         .prepare(
             "SELECT DISTINCT d.to_symbol_id FROM edges_data d JOIN files ON files.id = \
-             d.source_file_id WHERE d.to_symbol_id IS NOT NULL AND d.from_symbol_id IS NOT NULL",
+             d.source_file_id WHERE d.to_symbol_id IS NOT NULL AND d.from_symbol_id IS NOT NULL
+             AND d.resolution_id NOT IN (
+                 SELECT id FROM name_strings WHERE value = 'suppressed'
+             )",
         )?
         .query_map([], |r| r.get::<_, i64>(0))?
         .collect::<rusqlite::Result<_>>()?;

--- a/crates/rag-rat-core/src/index/adoption_hints.rs
+++ b/crates/rag-rat-core/src/index/adoption_hints.rs
@@ -220,6 +220,7 @@ pub struct EmptyIndexRefused {
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     use super::*;
     use crate::config::{Config, ResolvedTarget, TargetKind};
@@ -228,12 +229,20 @@ mod tests {
     // `schema_bootstrap_tests::source_config` / `unique_temp_root` are private to that module and
     // not reachable from here (a sibling of `index`, not a descendant of `schema_bootstrap_tests`)
     // — build the fixtures inline instead of widening their visibility just for this test.
+    /// A temp root unique across BOTH test runners. pid + millisecond is not: `cargo test` (what
+    /// the coverage job runs) executes tests as THREADS IN ONE PROCESS, so two tests entering
+    /// within the same millisecond derive the SAME path — and one test's `remove_dir_all` then
+    /// races the other's `git init`, which fails with a bare "git [\"init\"] failed". nextest
+    /// hides the race by giving each test its own process (its own pid). The atomic counter
+    /// makes the name unique regardless of runner.
     fn unique_temp_root() -> PathBuf {
+        static NEXT_ROOT: AtomicUsize = AtomicUsize::new(0);
         let mut root = std::env::temp_dir();
         root.push(format!(
-            "rag-rat-adoption-hints-test-{}-{}",
+            "rag-rat-adoption-hints-test-{}-{}-{}",
             std::process::id(),
-            crate::index::now_ms()
+            crate::index::now_ms(),
+            NEXT_ROOT.fetch_add(1, Ordering::Relaxed),
         ));
         root
     }

--- a/crates/rag-rat-core/src/index/ai/policy.rs
+++ b/crates/rag-rat-core/src/index/ai/policy.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::index::parser;
 
 /// Behavior version of the embedding-policy classifier. It certifies that a persisted
 /// `chunks.embedding_policy` value reflects the CURRENT classifier — the reconcile skip-summary
@@ -11,7 +12,7 @@ use super::*;
 /// stale-but-matching stamp would let the fast path serve mixed-code counts). A version mismatch
 /// instead correctly forces the slow recompute. See the freshness-model Risk memory bound to this
 /// file.
-pub(crate) const EMBEDDING_POLICY_VERSION: &str = "aa8d3ccc14daf73c";
+pub(crate) const EMBEDDING_POLICY_VERSION: &str = "c426172dd063e4c0";
 
 /// `repo_meta` keys carrying the embedding-policy freshness stamp a full rebuild writes
 /// (`mark_embedding_policy_current`). PER-REPO, not the DB-global `index_meta`: one database can
@@ -166,23 +167,28 @@ pub(crate) fn policy_for_job(
     )
 }
 
+/// Embedding budget order: source symbols (0) before docs (1) before tests (2).
+///
+/// Test detection is the CANONICAL [`parser::is_test_path`], not a local list. The local copy this
+/// replaced knew only lowercase `tests/`/`test/` segments and Rust/TS filename suffixes, so SwiftPM
+/// layouts (`Tests/AppTests/AppTests.swift` — capitalized directory, `*Tests` stem) read as
+/// production source and competed with it for the priority-0 budget, while the rest of the system
+/// (`staleness`, `repo_brief`, the graph's test-callsite filter, `symbols.is_test`) called the very
+/// same file a test. One predicate, one answer, every language.
 pub(crate) fn embedding_priority(
     path: &str,
     language: &str,
     chunk_kind: &str,
     symbol_path: Option<&str>,
 ) -> i64 {
-    if symbol_path.is_some()
-        && matches!(chunk_kind, "code")
-        && !is_test_path(path)
-        && language != "markdown"
-    {
+    let is_test = parser::is_test_path(path);
+    if symbol_path.is_some() && matches!(chunk_kind, "code") && !is_test && language != "markdown" {
         return 0;
     }
     if language == "markdown" {
         return 1;
     }
-    if is_test_path(path) {
+    if is_test {
         return 2;
     }
     1
@@ -199,24 +205,21 @@ pub(crate) fn priority_label(priority: i64) -> &'static str {
     }
 }
 
+/// Build output and dependency trees, plus the lockfiles that sit at their root. `/.build/` and
+/// `Package.resolved` are SwiftPM's `target/`+`Cargo.lock`; `Pods/` is CocoaPods' vendored
+/// dependency tree.
 pub(crate) fn looks_generated_path(path: &str) -> bool {
     path.contains("/generated/")
         || path.contains("/src/generated/")
         || path.contains("/target/")
+        || path.contains("/.build/")
+        || path.starts_with(".build/")
+        || path.contains("/Pods/")
+        || path.starts_with("Pods/")
         || path.ends_with("Cargo.lock")
         || path.ends_with("package-lock.json")
         || path.ends_with("pnpm-lock.yaml")
-}
-
-pub(crate) fn is_test_path(path: &str) -> bool {
-    path.contains("/tests/")
-        || path.contains("/test/")
-        || path.contains("__tests__")
-        || path.ends_with("_test.rs")
-        || path.ends_with(".test.ts")
-        || path.ends_with(".spec.ts")
-        || path.ends_with(".test.tsx")
-        || path.ends_with(".spec.tsx")
+        || path.ends_with("Package.resolved")
 }
 
 pub(crate) fn is_test_fixture_path(path: &str) -> bool {
@@ -465,6 +468,7 @@ mod low_signal_span_tests {
 /// `chunks.embedding_policy` column, so it must move whenever the classifier's output could.
 #[cfg(test)]
 mod policy_version_tests {
+    use std::collections::HashSet;
     use std::fmt::Write as _;
     use std::path::Path;
 
@@ -605,29 +609,56 @@ mod policy_version_tests {
         // edit to any one of them flips the hash (the two path cases above only sample
         // `/target/` and `/fixtures/`). A non-generated, non-fixture path is the code
         // default and is already covered by `embed_plain` / the span cases.
-        let path_cases: &[&str] = &[
-            "pkg/generated/a.rs",
-            "pkg/src/generated/a.rs",
-            "pkg/target/a.rs",
-            "Cargo.lock",
-            "some/dir/package-lock.json",
-            "some/dir/pnpm-lock.yaml",
-            "pkg/fixtures/a.rs",
-            "pkg/__fixtures__/a.rs",
-            "pkg/testdata/a.rs",
-            "pkg/snapshots/a.rs",
-            "pkg/thing.snap",
+        //
+        // ALSO the `embedding_priority` test-path branch, which nothing pinned before: every case
+        // here carries a symbol and real (>= MIN) source text, so a non-skipped path records
+        // priority 0 (source) vs 2 (test) and the CANONICAL `parser::is_test_path` is under the
+        // hash. It has to be — a local test-path copy silently drifted from the canonical one and
+        // mis-ranked every SwiftPM `Tests/` file as production source, with no test to catch it.
+        // Cases run in their OWN language so the `FromText` low-signal re-parse sees code it can
+        // actually parse.
+        const RUST_SRC: &str = "fn real_function(input: i64) -> i64 {\n    let value = input * 2 \
+                                + 1;\n    another_call(value)\n}\n";
+        const SWIFT_SRC: &str = "func realFunction(_ input: Int) -> Int {\n    let value = input \
+                                 + 1\n    return value + compute(value)\n}\n";
+        const MD_SRC: &str = "# Guide\n\nThis document explains how the indexer resolves \
+                              candidate edges to real symbols.\n";
+        let path_cases: &[(&str, &str, &str)] = &[
+            ("pkg/generated/a.rs", "rust", RUST_SRC),
+            ("pkg/src/generated/a.rs", "rust", RUST_SRC),
+            ("pkg/target/a.rs", "rust", RUST_SRC),
+            ("Cargo.lock", "rust", RUST_SRC),
+            ("some/dir/package-lock.json", "rust", RUST_SRC),
+            ("some/dir/pnpm-lock.yaml", "rust", RUST_SRC),
+            ("pkg/fixtures/a.rs", "rust", RUST_SRC),
+            ("pkg/__fixtures__/a.rs", "rust", RUST_SRC),
+            ("pkg/testdata/a.rs", "rust", RUST_SRC),
+            ("pkg/snapshots/a.rs", "rust", RUST_SRC),
+            ("pkg/thing.snap", "rust", RUST_SRC),
+            // SwiftPM / CocoaPods build + dependency trees (`looks_generated_path`).
+            ("app/.build/checkouts/dep/Sources/dep/a.swift", "swift", SWIFT_SRC),
+            (".build/checkouts/dep/Sources/dep/a.swift", "swift", SWIFT_SRC),
+            ("Package.resolved", "swift", SWIFT_SRC),
+            ("Pods/Alamofire/Source/a.swift", "swift", SWIFT_SRC),
+            // Test paths (priority 2) vs production source (priority 0), per language convention.
+            ("pkg/tests/a.rs", "rust", RUST_SRC),
+            ("pkg/src/a_test.rs", "rust", RUST_SRC),
+            ("Tests/AppTests/AppTests.swift", "swift", SWIFT_SRC),
+            ("Sources/App/ClientTests.swift", "swift", SWIFT_SRC),
+            ("Sources/App/Client.swift", "swift", SWIFT_SRC),
+            ("pkg/src/thing.rs", "rust", RUST_SRC),
+            // Docs (priority 1) — the remaining `embedding_priority` branch.
+            ("docs/guide.md", "markdown", MD_SRC),
         ];
-        for path in path_cases {
-            // A path gate fires before the low-signal check, so the text and cap are immaterial
-            // here.
+        for (path, lang, text) in path_cases {
+            // A path gate fires before the low-signal check, so the cap is immaterial here.
             let d = embedding_policy_for_chunk(
                 Path::new(path),
-                "rust",
+                lang,
                 "source",
                 "code",
                 Some("s"),
-                "fn a() { let value = compute(); process(value); }",
+                text,
                 4000,
                 LowSignalCheck::FromText,
             );
@@ -788,6 +819,21 @@ mod policy_version_tests {
                 sig.contains(&format!("|{expected}|")),
                 "the version corpus must exercise {expected} — otherwise the hash guard covers \
                  less than it appears to"
+            );
+        }
+        // ...and every embedding PRIORITY, so the test-path predicate the priority depends on is
+        // under the hash too. It wasn't: no corpus case was a test path, so `embedding_priority`'s
+        // test branch went unpinned — and a local test-path copy drifted from the canonical
+        // predicate, mis-ranking every SwiftPM `Tests/` file as priority-0 production source, with
+        // nothing to redden. `record` writes `label|policy|priority|eligible`.
+        let priorities: HashSet<&str> =
+            sig.lines().filter_map(|line| line.split('|').nth(2)).collect();
+        for expected in ["0", "1", "2"] {
+            assert!(
+                priorities.contains(expected),
+                "the version corpus must exercise embedding priority {expected} ({}) — otherwise \
+                 a change to the test-path predicate that decides it cannot flip the hash",
+                super::priority_label(expected.parse().unwrap()),
             );
         }
     }

--- a/crates/rag-rat-core/src/index/ai/policy.rs
+++ b/crates/rag-rat-core/src/index/ai/policy.rs
@@ -11,7 +11,7 @@ use super::*;
 /// stale-but-matching stamp would let the fast path serve mixed-code counts). A version mismatch
 /// instead correctly forces the slow recompute. See the freshness-model Risk memory bound to this
 /// file.
-pub(crate) const EMBEDDING_POLICY_VERSION: &str = "255dcc2c31e35a19";
+pub(crate) const EMBEDDING_POLICY_VERSION: &str = "aa8d3ccc14daf73c";
 
 /// `repo_meta` keys carrying the embedding-policy freshness stamp a full rebuild writes
 /// (`mark_embedding_policy_current`). PER-REPO, not the DB-global `index_meta`: one database can
@@ -308,36 +308,10 @@ fn span_is_plumbing(
     })
 }
 
-/// A top-level node carrying no embed-worthy signal: a comment, or a per-language import/include /
-/// package / docstring / `pass`. NOT a definition-introducing form (a C `#define` macro, a Rust
-/// `mod`, a Python `def`/`class`) — those are symbols and must keep their embedding.
+/// A top-level node carrying no embed-worthy signal according to its structural language package.
+/// Definition-introducing forms remain signal and keep their embedding.
 fn is_plumbing_node(language: Language, node: tree_sitter::Node<'_>) -> bool {
-    let kind = node.kind();
-    if kind.contains("comment") {
-        return true;
-    }
-    match language {
-        Language::Rust => kind == "use_declaration",
-        Language::TypeScript => kind == "import_statement",
-        Language::Kotlin => matches!(kind, "import_header" | "package_header"),
-        Language::C | Language::Cpp => kind == "preproc_include",
-        Language::Python =>
-            matches!(
-                kind,
-                "import_statement"
-                    | "import_from_statement"
-                    | "future_import_statement"
-                    | "pass_statement"
-            ) || is_python_docstring_statement(node),
-        Language::Markdown => true,
-    }
-}
-
-/// A Python bare docstring: an `expression_statement` whose sole child is a string literal.
-fn is_python_docstring_statement(node: tree_sitter::Node<'_>) -> bool {
-    node.kind() == "expression_statement"
-        && node.named_child_count() == 1
-        && node.named_child(0).is_some_and(|child| child.kind() == "string")
+    crate::index::languages::is_plumbing_node(language, node)
 }
 
 #[cfg(test)]
@@ -721,6 +695,15 @@ mod policy_version_tests {
                  comment line here now goes on\n",
                 "def real_function(input):\n    value = input + 1\n    result = value + \
                  compute(value)\n    return result\n",
+            ),
+            (
+                "swift",
+                "s.swift",
+                Language::Swift,
+                "import Foundation\nimport Dispatch\n// a descriptive comment line here now goes \
+                 on long enough\nimport Observation\n",
+                "func realFunction(_ input: Int) -> Int {\n    let value = input + 1\n    return \
+                 value + compute(value)\n}\n",
             ),
         ];
         for (label, path, language, plumbing, def) in span_cases {

--- a/crates/rag-rat-core/src/index/clones/mod.rs
+++ b/crates/rag-rat-core/src/index/clones/mod.rs
@@ -31,7 +31,17 @@ use tree_sitter::Node;
 /// instead of alpha-renaming; (2) the C/C++ `char_literal` VALUE leaf (`character`) now buckets to
 /// `LIT_CHARACTER` instead of leaking the char value verbatim. Same auto-exclude-then-recompute
 /// path as the v2 bump (no schema migration); a bump forces re-fingerprinting on the next reindex.
-pub(crate) const NORM_VERSION: i64 = 3;
+///
+/// `4` (#635): Swift's string-BODY leaves (`line_str_text`, `multi_line_str_text`, `raw_str_part`,
+/// `raw_str_end_part`, `str_escaped_char`) now bucket instead of leaking their VALUE verbatim.
+/// tree-sitter-swift wraps them in an internal `line_string_literal` node, and only LEAVES bucket,
+/// so the `ends_with("literal")` arm never fired for the value — two Swift bodies differing only in
+/// a string constant failed to normalize equal. Partition-contained like the v3 bump (missed-clone
+/// recall, never false positives). Also widens the fingerprintable set: Swift closure properties
+/// (`let f = { … }`) and `constructor` (`init`) bodies now fingerprint like every other function
+/// body. Same auto-exclude-then-recompute path; the bump forces re-fingerprinting on the next
+/// reindex.
+pub(crate) const NORM_VERSION: i64 = 4;
 /// Bumped when the LCS alignment / refinement algorithm changes; participates in the content-
 /// addressed `refinement_key` and in the `clone_refinements` cache freshness predicate, so a bump
 /// invalidates every cached refinement without a schema migration (the same discipline as
@@ -105,19 +115,24 @@ pub(crate) fn fingerprint_symbol(
 
 /// `true` when a symbol's AST node is a FUNCTION-VALUED declarator: a `variable_declarator`
 /// (`const f = () => {…}`, `let f = function(){…}`) or `public_field_definition` (a class-field
-/// arrow handler) whose `value` child is an `arrow_function` / `function_expression` (#232 #5).
+/// arrow handler) whose `value` child is an `arrow_function` / `function_expression` (#232 #5), or
+/// Swift's `property_declaration` whose `value` is a `lambda_literal`
+/// (`let handler: (Int) -> Void = { … }`).
 ///
-/// These carry symbol `kind = "const"` in `parser.rs` (NOT changed — `kind` drives chunking, graph
-/// edges, and search facets; see the plan's invariant) but ARE real function bodies worth
-/// fingerprinting: two `const x = () => {…}` clones match each other (same declarator shape). The
-/// node-level check is what keeps a plain-value `const x = 5;` excluded — its `value` child is a
-/// `number`, not a function. Probe-confirmed against the wired TS grammar: matches const-arrow,
-/// const-func-expr, let-async-arrow, and class-field-arrow; rejects destructure / number / object.
+/// These carry symbol `kind = "const"` / `"property"` in `parser.rs` (NOT changed — `kind` drives
+/// chunking, graph edges, and search facets; see the plan's invariant) but ARE real function bodies
+/// worth fingerprinting: two `const x = () => {…}` clones match each other (same declarator shape).
+/// The node-level check is what keeps a plain-value `const x = 5;` / `let plain = 5` excluded — its
+/// `value` child is a `number` / `integer_literal`, not a function. Probe-confirmed against the
+/// wired grammars: matches TS const-arrow, const-func-expr, let-async-arrow, class-field-arrow and
+/// Swift closure properties; rejects destructure / number / object.
 fn symbol_is_function_valued(node: Node<'_>) -> bool {
-    matches!(node.kind(), "variable_declarator" | "public_field_definition")
-        && node
-            .child_by_field_name("value")
-            .is_some_and(|v| matches!(v.kind(), "arrow_function" | "function_expression"))
+    matches!(
+        node.kind(),
+        "variable_declarator" | "public_field_definition" | "property_declaration"
+    ) && node.child_by_field_name("value").is_some_and(|v| {
+        matches!(v.kind(), "arrow_function" | "function_expression" | "lambda_literal")
+    })
 }
 
 /// Baseline fingerprints for a file's fingerprintable symbols, walking the SHARED parse tree (no
@@ -139,9 +154,13 @@ pub(crate) fn fingerprint_symbols(
         let Some(node) = root.descendant_for_byte_range(symbol.start_byte, symbol.end_byte) else {
             continue;
         };
-        // Fingerprint a `function` symbol OR a function-valued declarator (the node check rejects
-        // plain-value consts — `const x = 5;` — so symbol `kind` stays unchanged, #232 #5 / R2).
-        if symbol.kind != "function" && !symbol_is_function_valued(node) {
+        // Fingerprint a `function` symbol, a `constructor` (Swift `init` — a real function body,
+        // and the direct analog of a Rust `fn new()`, which fingerprints as a `function`),
+        // OR a function-valued declarator (the node check rejects plain-value consts —
+        // `const x = 5;` — so symbol `kind` stays unchanged, #232 #5 / R2).
+        if !matches!(symbol.kind.as_str(), "function" | "constructor")
+            && !symbol_is_function_valued(node)
+        {
             continue;
         }
         if let Some(fp) = fingerprint_symbol(node, text, lang) {
@@ -198,13 +217,53 @@ mod tests {
     }
 
     #[test]
-    fn norm_version_is_3() {
-        // #253: the Kotlin boolean/null leaf-text override + the C/C++ `character` value bucket
-        // changed the normalization stream again (on top of the #232 comment-skip + multi-language
-        // bucketing that took it to 2), so NORM_VERSION must be 3. The read filter + content-
+    fn norm_version_is_4() {
+        // #635: Swift string-body leaves now bucket (their VALUE used to leak into the stream), and
+        // Swift closure properties + `init` bodies joined the fingerprintable set — a stream change
+        // on top of the #253 Kotlin/C++ bucketing that took it to 3. The read filter + content-
         // addressed refinement key both key off this constant, so a stream change without the bump
         // silently serves stale fingerprints/refinements.
-        assert_eq!(NORM_VERSION, 3);
+        assert_eq!(NORM_VERSION, 4);
+    }
+
+    /// Swift closure-valued properties and `init` bodies are fingerprintable function bodies, and a
+    /// plain-value property is not — the `value`-field check is what separates them.
+    #[test]
+    fn swift_closure_properties_and_inits_fingerprint_but_plain_values_do_not() {
+        let closure = "struct S {\n  let handler: (Int) -> Void = { value in\n    let a = \
+                       compute(value)\n    let b = transform(a)\n    let c = combine(a, b)\n    \
+                       report(c)\n  }\n}\n";
+        assert!(
+            fp_lang(closure, "S.swift", Language::Swift).is_some(),
+            "a Swift closure-valued property is a real function body"
+        );
+
+        let init = "struct S {\n  init(seed: Int) {\n    let a = compute(seed)\n    let b = \
+                    transform(a)\n    let c = combine(a, b)\n    report(c)\n  }\n}\n";
+        assert!(
+            fp_lang(init, "S.swift", Language::Swift).is_some(),
+            "a Swift init is a real function body (the analog of a Rust `fn new()`)"
+        );
+
+        // A plain-value property has an `integer_literal` value, not a closure: not
+        // fingerprintable.
+        let parsed = parser::parse_file(
+            Path::new("S.swift"),
+            Language::Swift,
+            "struct S {\n  let plain = 5\n}\n",
+        )
+        .expect("parse");
+        let symbols = symbols::from_parsed(&parsed.symbols);
+        let fingerprints = fingerprint_symbols(
+            parsed.root(),
+            "struct S {\n  let plain = 5\n}\n",
+            Language::Swift,
+            &symbols,
+        );
+        assert!(
+            fingerprints.is_empty(),
+            "a plain-value Swift property must not be fingerprinted: {fingerprints:?}"
+        );
     }
 
     #[test]

--- a/crates/rag-rat-core/src/index/clones/normalize.rs
+++ b/crates/rag-rat-core/src/index/clones/normalize.rs
@@ -24,11 +24,33 @@ fn is_identifier_kind(kind: &str) -> bool {
 /// (#253). GATED to C/C++ via `lang`: `character` is a generic-enough kind name that we only bucket
 /// it where it's known to be the char-literal value leaf, never speculatively across other
 /// grammars.
+///
+/// `line_str_text` / `multi_line_str_text` / `raw_str_part` / `raw_str_end_part` /
+/// `str_escaped_char` are Swift's string-body leaves — the counterparts to Python's
+/// `string_content` and TS's `string_fragment`. tree-sitter-swift wraps them in a
+/// `line_string_literal` (an INTERNAL node: quote, text, quote), and only LEAVES are bucketed, so
+/// the wrapper's `ends_with("literal")` never fires for the value: without these names the text
+/// leaf falls through to the keep-verbatim branch and the string's VALUE lands in the normalized
+/// token stream. Two Swift bodies differing only in a string constant would then fail to normalize
+/// equal — silently costing Swift clone recall that every other language has. (Interpolation
+/// segments are internal nodes and still recurse as real code.) `raw_str_end_part` carries the
+/// delimiters as well as the text — an uninterpolated `#"one"#` arrives as ONE leaf — which is why
+/// it must bucket rather than pass through as punctuation.
 fn is_literal_kind(kind: &str, lang: Language) -> bool {
     kind.ends_with("literal")
         || matches!(
             kind,
-            "string_content" | "string_fragment" | "integer" | "float" | "number" | "char"
+            "string_content"
+                | "string_fragment"
+                | "line_str_text"
+                | "multi_line_str_text"
+                | "raw_str_part"
+                | "raw_str_end_part"
+                | "str_escaped_char"
+                | "integer"
+                | "float"
+                | "number"
+                | "char"
         )
         || (matches!(lang, Language::C | Language::Cpp) && kind == "character")
 }
@@ -372,6 +394,61 @@ mod tests {
         let nf = norm_lang(b_false, "t.ts", Language::TypeScript);
         assert_eq!(nt, nf, "TS true/false-only diff must normalize equal (LIT_BOOL)");
         assert!(nt.iter().any(|t| t == "LIT_BOOL"), "TS boolean must emit LIT_BOOL: {nt:?}");
+    }
+
+    /// Swift string bodies bucket like every other language's: two bodies differing ONLY in string
+    /// contents normalize equal. Swift wraps its text leaf (`line_str_text`) in an INTERNAL
+    /// `line_string_literal` node, so the `ends_with("literal")` arm — which only ever fires on a
+    /// LEAF — never saw the value, and the string contents leaked verbatim into the token stream.
+    /// Covers the line, multi-line, and raw string leaves, plus the escaped-char leaf.
+    #[test]
+    fn swift_strings_and_booleans_bucket() {
+        let s1 = "func f() -> Int { let a = log(\"hello\"); let b = log(\"world\"); return a }";
+        let s2 = "func f() -> Int { let a = log(\"foo\"); let b = log(\"bar\"); return a }";
+        let n1 = norm_lang(s1, "t.swift", Language::Swift);
+        assert_eq!(
+            n1,
+            norm_lang(s2, "t.swift", Language::Swift),
+            "Swift string-content-only diff must normalize equal (line_str_text bucketed)"
+        );
+        assert!(
+            !n1.iter().any(|t| t == "hello" || t == "world"),
+            "Swift string VALUES must never reach the normalized stream: {n1:?}"
+        );
+
+        // Escaped chars are value-bearing leaves of their own (`str_escaped_char`).
+        let e1 = "func f() -> Int { let a = log(\"a\\nb\"); let b = log(\"c\"); return a }";
+        let e2 = "func f() -> Int { let a = log(\"x\\ty\"); let b = log(\"z\"); return a }";
+        assert_eq!(
+            norm_lang(e1, "t.swift", Language::Swift),
+            norm_lang(e2, "t.swift", Language::Swift),
+            "Swift escaped-char-only diff must normalize equal (str_escaped_char bucketed)"
+        );
+
+        // Raw strings (`raw_str_part`) and multi-line strings (`multi_line_str_text`).
+        let r1 = "func f() -> Int { let a = log(#\"one\"#); let b = log(#\"two\"#); return a }";
+        let r2 = "func f() -> Int { let a = log(#\"three\"#); let b = log(#\"four\"#); return a }";
+        let nr = norm_lang(r1, "t.swift", Language::Swift);
+        assert_eq!(
+            nr,
+            norm_lang(r2, "t.swift", Language::Swift),
+            "Swift raw-string-only diff must normalize equal (raw_str_part bucketed)"
+        );
+        assert!(
+            !nr.iter().any(|t| t == "one" || t == "two"),
+            "Swift raw-string VALUES must never reach the normalized stream: {nr:?}"
+        );
+
+        // Booleans already bucket via the shared `true`/`false` leaf kinds — pin it for Swift too.
+        let b_true = "func f() -> Bool { let x = check(); let y = x; return true }";
+        let b_false = "func f() -> Bool { let x = check(); let y = x; return false }";
+        let nt = norm_lang(b_true, "t.swift", Language::Swift);
+        assert_eq!(
+            nt,
+            norm_lang(b_false, "t.swift", Language::Swift),
+            "Swift true/false-only diff must normalize equal (LIT_BOOL)"
+        );
+        assert!(nt.iter().any(|t| t == "LIT_BOOL"), "Swift boolean must emit LIT_BOOL: {nt:?}");
     }
 
     /// Python booleans (`True`/`False`, leaf kinds `true`/`false`) bucket to `LIT_BOOL`; `None`

--- a/crates/rag-rat-core/src/index/clones/refine/antiunify/widen.rs
+++ b/crates/rag-rat-core/src/index/clones/refine/antiunify/widen.rs
@@ -6,8 +6,22 @@ use super::spans::subtree_token_count;
 /// `LIT_STRING_CONTENT` / `LIT_STRING_FRAGMENT`): Rust/Python `string_content` and TS/JS
 /// `string_fragment` (#232 #2a). Both are the inner text leaf that needs widening to its enclosing
 /// quote-bearing node so the hole covers the WHOLE `"hello"`.
+///
+/// Swift's are `line_str_text` / `multi_line_str_text` (the `"…"` and `"""…"""` bodies) and
+/// `raw_str_part` / `raw_str_end_part` (the `#"…"#` body — an UNINTERPOLATED raw string arrives as
+/// a single `raw_str_end_part` leaf carrying its own delimiters). They must widen for the same
+/// reason every other language's do: a hole over the bare text leaf, with the quotes left as fixed
+/// template text, does not describe the `&str` value that actually varies.
 fn is_string_body_leaf_kind(kind: &str) -> bool {
-    matches!(kind, "string_content" | "string_fragment")
+    matches!(
+        kind,
+        "string_content"
+            | "string_fragment"
+            | "line_str_text"
+            | "multi_line_str_text"
+            | "raw_str_part"
+            | "raw_str_end_part"
+    )
 }
 
 /// The quote-bearing string-NODE kinds that wrap a string-body leaf: Rust/Python `string_literal`,
@@ -21,8 +35,21 @@ fn is_string_body_leaf_kind(kind: &str) -> bool {
 /// by REFUSING to widen to any string node whose subtree carries a `template_substitution` — the
 /// bare fragment run is left as-is (an honest under-report, never an over-claim). So this predicate
 /// stays a simple kind test; the interpolation safety lives in the widen gate.
+///
+/// Swift's quote-bearing nodes are `line_string_literal` (`"…"`), `multi_line_string_literal`
+/// (`"""…"""`), and `raw_string_literal` (`#"…"#`). They carry the SAME interpolation hazard as a
+/// template string — Swift's `\(x)` — so the widen gate rejects them on the same grounds; see
+/// [`string_node_has_interpolation`].
 pub(super) fn is_string_node_kind(kind: &str) -> bool {
-    matches!(kind, "string_literal" | "string" | "template_string")
+    matches!(
+        kind,
+        "string_literal"
+            | "string"
+            | "template_string"
+            | "line_string_literal"
+            | "multi_line_string_literal"
+            | "raw_string_literal"
+    )
 }
 
 /// `true` for a leaf that can legitimately sit INSIDE a quote-bearing string node — either the
@@ -35,21 +62,28 @@ pub(super) fn is_string_node_kind(kind: &str) -> bool {
 /// inside a non-empty literal are also string-internal and widen the same way.
 ///
 /// NOT a `template_substitution` delimiter (`${` / `}`): those bound an interpolation, which the
-/// widen gate refuses to cross — see [`is_string_node_kind`].
+/// widen gate refuses to cross — see [`is_string_node_kind`]. Same for Swift's `\(` interpolation
+/// start; its `"""` multi-line delimiter and `str_escaped_char` escape leaf ARE string-internal and
+/// widen like every other grammar's.
 fn is_string_delimiter_or_body_leaf_kind(kind: &str) -> bool {
-    is_string_body_leaf_kind(kind) || matches!(kind, "\"" | "`" | "'" | "escape_sequence")
+    is_string_body_leaf_kind(kind)
+        || matches!(kind, "\"" | "`" | "'" | "\"\"\"" | "escape_sequence" | "str_escaped_char")
 }
 
-/// `true` when the anchor subtree rooted at `str_col` contains a `template_substitution` — i.e. it
-/// is an INTERPOLATED template literal (`` `hi${x}lo` ``). Widening a fragment/quote run to such a
-/// node would swallow the `${…}` interpolation into the hole, so [`widen_string_content_run`] does
-/// not widen across it (#254 caution). Walks the contiguous pre-order subtree by byte containment,
-/// mirroring [`subtree_token_count`].
+/// `true` when the anchor subtree rooted at `str_col` contains an interpolation — a TS/JS
+/// `template_substitution` (`` `hi${x}lo` ``), or Swift's `interpolated_expression` /
+/// `raw_str_interpolation` (`"hi\(x)lo"`, `#"r\#(y)s"#`). Widening a fragment/quote run to such a
+/// node would swallow the interpolated EXPRESSION — live code, not a value — into the hole, so
+/// [`widen_string_content_run`] does not widen across it (#254 caution). Walks the contiguous
+/// pre-order subtree by byte containment, mirroring [`subtree_token_count`].
 fn string_node_has_interpolation(anchor: &RefineMember, str_col: usize) -> bool {
     let root_end = anchor.node_spans[str_col].end_byte;
     let mut k = str_col + 1;
     while k < anchor.node_spans.len() && anchor.node_spans[k].start_byte < root_end {
-        if anchor.node_spans[k].kind == "template_substitution" {
+        if matches!(
+            anchor.node_spans[k].kind,
+            "template_substitution" | "interpolated_expression" | "raw_str_interpolation"
+        ) {
             return true;
         }
         k += 1;

--- a/crates/rag-rat-core/src/index/edges/extract/mod.rs
+++ b/crates/rag-rat-core/src/index/edges/extract/mod.rs
@@ -1,12 +1,5 @@
 use super::*;
 
-mod c_like;
-mod kotlin;
-mod python;
-mod rust;
-mod rust_dispatch;
-mod typescript;
-
 pub(crate) fn index_file_edges(
     conn: &Connection,
     file_id: i64,
@@ -33,7 +26,7 @@ pub(crate) fn edge_candidates(
     text: &str,
     symbols: &[IndexedSymbol],
 ) -> anyhow::Result<Vec<EdgeCandidate>> {
-    if language == Language::Markdown {
+    if crate::index::languages::edge_backend(language).is_none() {
         return Ok(Vec::new());
     }
     let mut candidates = contains_edges(symbols);
@@ -50,7 +43,7 @@ pub(crate) fn edge_candidates_from_root(
     root: Node<'_>,
     symbols: &[IndexedSymbol],
 ) -> Vec<EdgeCandidate> {
-    if language == Language::Markdown {
+    if crate::index::languages::edge_backend(language).is_none() {
         return Vec::new();
     }
     let mut candidates = contains_edges(symbols);
@@ -121,8 +114,7 @@ pub(crate) fn syntactic_edges(
     text: &str,
     symbols: &[IndexedSymbol],
 ) -> anyhow::Result<Vec<EdgeCandidate>> {
-    // Single source of truth for the grammar mapping (#519); `None` (Markdown / no grammar) yields
-    // no edges, same as the old `ParserKind::Markdown` arm.
+    // The parser registry owns grammar selection; a language without a grammar yields no edges.
     let Some(grammar) = parser::grammar_for(parser::parser_kind(path, language)) else {
         return Ok(Vec::new());
     };
@@ -142,12 +134,9 @@ pub(crate) fn syntactic_edges(
 }
 /// Pre-order DFS over the named nodes of `root`, running the per-language edge extractor at each.
 ///
-/// Iterative (#520): the old per-node recursion allocated a fresh `node.walk()` cursor each frame
-/// and recursed to full tree depth, overflowing the stack on a deeply-nested 512 KB file. An
-/// explicit heap stack keeps the call stack O(1); one reused cursor + one reused child buffer keep
-/// it single-allocation. The per-language extractors are unchanged. Error/missing subtrees are
-/// pruned and named children pop in document order — same visit set/order, so edges are emitted
-/// identically.
+/// An explicit heap stack keeps the call stack O(1) on deeply nested files. One reused cursor and
+/// child buffer keep traversal single-allocation; error/missing subtrees are pruned and named
+/// children are visited in document order.
 pub(crate) fn collect_edges(
     language: Language,
     text: &str,
@@ -156,6 +145,9 @@ pub(crate) fn collect_edges(
     path: &Path,
     out: &mut Vec<EdgeCandidate>,
 ) {
+    let Some(backend) = crate::index::languages::edge_backend(language) else {
+        return;
+    };
     let mut stack = vec![root];
     let mut cursor = root.walk();
     let mut named_children = Vec::new();
@@ -163,14 +155,7 @@ pub(crate) fn collect_edges(
         if node.is_error() || node.is_missing() {
             continue;
         }
-        match language {
-            Language::Rust => rust::rust_edges(text, node, symbols, path, out),
-            Language::TypeScript => typescript::typescript_edges(text, node, symbols, path, out),
-            Language::Kotlin => kotlin::kotlin_edges(text, node, symbols, path, out),
-            Language::C | Language::Cpp => c_like::c_like_edges(text, node, symbols, path, out),
-            Language::Python => python::python_edges(text, node, symbols, path, out),
-            Language::Markdown => {},
-        }
+        backend.edges(text, node, symbols, path, out);
         named_children.clear();
         named_children.extend(node.named_children(&mut cursor));
         for &child in named_children.iter().rev() {

--- a/crates/rag-rat-core/src/index/edges/imports.rs
+++ b/crates/rag-rat-core/src/index/edges/imports.rs
@@ -414,24 +414,24 @@ pub(crate) struct ImportScope {
     /// `Url`. Only a genuinely non-Cargo corpus (no manifest at all) fails open. Set true by
     /// [`Self::mark_has_manifests`] when any package row is loaded.
     has_manifests: bool,
-    /// Per-file Python import aliases: `alias name → its bindings` (#174). A `from m import T as
+    /// Per-file import aliases: `alias name → its bindings` (#174). A `from m import T as
     /// A` records `A → T` so a later reference to `A` resolves to the IMPORTED symbol `T`, not
     /// an unrelated local `A`. Distinct from `by_file` (Rust external-import suppression):
     /// this REBINDS an alias use to its in-corpus target name, rather than just flagging it
     /// external.
-    python_aliases: HashMap<i64, HashMap<String, Vec<PythonAlias>>>,
+    import_aliases: HashMap<i64, HashMap<String, Vec<ImportAlias>>>,
 }
 
 /// One Python import alias binding: the imported target name the alias stands for, scoped to a byte
 /// range (whole-file today — Python imports are module-global). Mirrors [`ImportBinding`] but
 /// carries the TARGET name (for rebinding) rather than the crate root (for external detection).
-struct PythonAlias {
+struct ImportAlias {
     target: String,
     scope_start: usize,
     scope_end: usize,
 }
 
-impl PythonAlias {
+impl ImportAlias {
     fn covers(&self, ref_byte: usize) -> bool {
         ref_byte >= self.scope_start && ref_byte < self.scope_end
     }
@@ -464,7 +464,7 @@ impl ImportScope {
     /// scoped to the import's byte range. The carrier is the aliased import's Imports edge — its
     /// `to_name` is `target` and its `evidence` is `alias` (set by extraction's
     /// `python_import_target`).
-    pub(crate) fn add_python_alias(
+    pub(crate) fn add_import_alias(
         &mut self,
         file_id: i64,
         alias: String,
@@ -473,8 +473,8 @@ impl ImportScope {
     ) {
         // A binding with no scope can't be range-tested; skip rather than bind file-wide blindly.
         let Some(scope) = scope else { return };
-        self.python_aliases.entry(file_id).or_default().entry(alias).or_default().push(
-            PythonAlias { target, scope_start: scope.scope_start, scope_end: scope.scope_end },
+        self.import_aliases.entry(file_id).or_default().entry(alias).or_default().push(
+            ImportAlias { target, scope_start: scope.scope_start, scope_end: scope.scope_end },
         );
     }
 
@@ -482,7 +482,7 @@ impl ImportScope {
     /// caller resolves the reference under this target name instead of the alias — so `Account()`
     /// after `from models import User as Account` binds to `User`. `None` for non-Python files (the
     /// map is empty) or a name that isn't an in-scope alias.
-    pub(crate) fn python_alias_target(
+    pub(crate) fn import_alias_target(
         &self,
         file_id: i64,
         name: &str,
@@ -498,7 +498,7 @@ impl ImportScope {
         // than pick one by byte order. All-same-target overlaps (try/except importing the same
         // symbol from different modules) still resolve.
         let mut covering = self
-            .python_aliases
+            .import_aliases
             .get(&file_id)?
             .get(name)?
             .iter()

--- a/crates/rag-rat-core/src/index/edges/mod.rs
+++ b/crates/rag-rat-core/src/index/edges/mod.rs
@@ -1,4 +1,4 @@
-mod extract;
+pub(in crate::index) mod extract;
 mod helpers;
 mod imports;
 mod intern;
@@ -27,6 +27,11 @@ pub enum EdgeKind {
     Exports,
     CallsName,
     Constructs,
+    /// A language-level operator token references its declaration independently of the callable
+    /// implementation reached by the companion `calls_name` edge.
+    UsesOperator,
+    /// An operator declaration depends on the precedence group that defines its parse behavior.
+    UsesPrecedenceGroup,
     UsesMacro,
     ReferencesType,
     Implements,
@@ -54,6 +59,8 @@ impl EdgeKind {
             Self::Exports => "exports",
             Self::CallsName => "calls_name",
             Self::Constructs => "constructs",
+            Self::UsesOperator => "uses_operator",
+            Self::UsesPrecedenceGroup => "uses_precedence_group",
             Self::UsesMacro => "uses_macro",
             Self::ReferencesType => "references_type",
             Self::Implements => "implements",
@@ -93,8 +100,8 @@ impl EdgeConfidence {
 /// file-level / `contains` edges and for constructs where a clean identifier node isn't available.
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct CalleeRange {
-    start_byte: usize,
-    end_byte: usize,
+    pub(in crate::index) start_byte: usize,
+    pub(in crate::index) end_byte: usize,
 }
 
 impl CalleeRange {
@@ -125,36 +132,36 @@ pub(crate) const MOD_FILE_ROOT: i64 = -1;
 
 #[derive(Debug, Clone)]
 pub(crate) struct EdgeCandidate {
-    from_symbol_id: Option<i64>,
-    from_name: Option<String>,
-    to_name: String,
-    target_qualified_name: Option<String>,
-    evidence: Option<String>,
-    receiver_hint: Option<String>,
-    source_span: EdgeSpan,
+    pub(in crate::index) from_symbol_id: Option<i64>,
+    pub(in crate::index) from_name: Option<String>,
+    pub(in crate::index) to_name: String,
+    pub(in crate::index) target_qualified_name: Option<String>,
+    pub(in crate::index) evidence: Option<String>,
+    pub(in crate::index) receiver_hint: Option<String>,
+    pub(in crate::index) source_span: EdgeSpan,
     /// Byte range of the callee identifier token; see [`CalleeRange`]. `None` for non-symbol
     /// edges.
-    callee_span: Option<CalleeRange>,
+    pub(in crate::index) callee_span: Option<CalleeRange>,
     /// Module-aware import scope; see [`ImportScopeRange`]. `Some` only for Rust Imports edges (a
     /// `use`'s enclosing scope, or an inline `mod`'s body range); `None` for every other edge.
-    import_scope: Option<ImportScopeRange>,
-    edge_kind: EdgeKind,
-    confidence: EdgeConfidence,
+    pub(in crate::index) import_scope: Option<ImportScopeRange>,
+    pub(in crate::index) edge_kind: EdgeKind,
+    pub(in crate::index) confidence: EdgeConfidence,
 }
 
 #[derive(Debug, Clone)]
 pub(crate) struct IndexedSymbol {
-    id: i64,
-    file_id: i64,
-    language: String,
-    name: String,
-    qualified_name: String,
-    scope_path: String,
-    kind: String,
-    start_byte: usize,
-    end_byte: usize,
-    start_line: i64,
-    end_line: i64,
+    pub(in crate::index) id: i64,
+    pub(in crate::index) file_id: i64,
+    pub(in crate::index) language: String,
+    pub(in crate::index) name: String,
+    pub(in crate::index) qualified_name: String,
+    pub(in crate::index) scope_path: String,
+    pub(in crate::index) kind: String,
+    pub(in crate::index) start_byte: usize,
+    pub(in crate::index) end_byte: usize,
+    pub(in crate::index) start_line: i64,
+    pub(in crate::index) end_line: i64,
 }
 
 impl IndexedSymbol {
@@ -435,16 +442,16 @@ impl FullRebuildGraph {
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct EdgeSpan {
-    start_line: i64,
-    end_line: i64,
-    start_byte: i64,
-    end_byte: i64,
+    pub(in crate::index) start_line: i64,
+    pub(in crate::index) end_line: i64,
+    pub(in crate::index) start_byte: i64,
+    pub(in crate::index) end_byte: i64,
 }
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct EdgeContext {
-    target_qualified_name: Option<String>,
-    receiver_hint: Option<String>,
+    pub(in crate::index) target_qualified_name: Option<String>,
+    pub(in crate::index) receiver_hint: Option<String>,
 }
 
 impl IndexedSymbol {
@@ -476,8 +483,6 @@ pub(crate) struct SymbolIndex<'a> {
     /// `::`-segment of the qualified name (a name ending in `::{q}` necessarily shares `q`'s
     /// tail).
     by_qn_tail: HashMap<&'a str, Vec<&'a IndexedSymbol>>,
-    /// Language of each source file (first symbol seen for the file).
-    file_language: HashMap<i64, &'a str>,
 }
 
 impl<'a> SymbolIndex<'a> {
@@ -486,19 +491,17 @@ impl<'a> SymbolIndex<'a> {
         let mut by_scope_path: HashMap<&str, Vec<&IndexedSymbol>> = HashMap::new();
         let mut by_name: HashMap<&str, Vec<&IndexedSymbol>> = HashMap::new();
         let mut by_qn_tail: HashMap<&str, Vec<&IndexedSymbol>> = HashMap::new();
-        let mut file_language: HashMap<i64, &str> = HashMap::new();
         for symbol in symbols {
             by_qualified.entry(symbol.qualified_name.as_str()).or_default().push(symbol);
             by_scope_path.entry(symbol.scope_path.as_str()).or_default().push(symbol);
             by_name.entry(symbol.name.as_str()).or_default().push(symbol);
             by_qn_tail.entry(qn_tail(&symbol.qualified_name)).or_default().push(symbol);
-            file_language.entry(symbol.file_id).or_insert(symbol.language.as_str());
         }
-        Self { by_qualified, by_scope_path, by_name, by_qn_tail, file_language }
+        Self { by_qualified, by_scope_path, by_name, by_qn_tail }
     }
 
-    /// Whether `file_id` itself defines a symbol named `name`. The Python alias rebind uses this to
-    /// DEFER when the imported target's bare name is ALSO defined locally (#174 review): a bare
+    /// Whether `file_id` itself defines a symbol named `name`. Import-alias rebinding defers when
+    /// the imported target's bare name is also defined locally: a bare
     /// rewrite of `Account` → `User` could grab a same-file `User` instead of the import, so leave
     /// it to normal resolution. (The alias-shadow ordering — a same-module `class Account` /
     /// `Account = …` after the import reassigning the name — is handled at extraction by bounding

--- a/crates/rag-rat-core/src/index/edges/resolve/mod.rs
+++ b/crates/rag-rat-core/src/index/edges/resolve/mod.rs
@@ -810,13 +810,27 @@ pub(crate) fn resolve_symbol<'a>(
         }
     }
     let short = short_name(request.name);
+    // A reference that carried a qualifier or a receiver has already had its qualified shape tried
+    // above; reaching the bare-name fallback means that shape found nothing. Some target kinds are
+    // only ever evidenced by the BARE shape (a Swift enum case, reachable by bare name only through
+    // shorthand `.idle`), so binding one to a qualified/receiver-bearing reference here would
+    // manufacture a dependency the source never expressed — `client.idle()` becoming a "caller" of
+    // `enum Status { case idle }`. Let the language policy exclude those kinds from this fallback.
+    let reference_is_bare = request.target_qualified_name.is_none_or(str::is_empty)
+        && request.receiver_hint.is_none_or(str::is_empty);
+    let bare_shape_ok = |symbol: &IndexedSymbol| {
+        reference_is_bare
+            || !policy.is_some_and(|policy| {
+                policy.kind_requires_unqualified_reference(request.edge_kind, &symbol.kind)
+            })
+    };
     let matches = index
         .by_name
         .get(short)
         .into_iter()
         .flatten()
         .copied()
-        .filter(|symbol| kind_matches(symbol))
+        .filter(|symbol| kind_matches(symbol) && bare_shape_ok(symbol))
         .collect::<Vec<_>>();
     let preferred = preferred_matches(request.edge_kind, request.source_language, &matches);
     // Language policy decides whether a type-position reference may bind a value declaration.

--- a/crates/rag-rat-core/src/index/edges/resolve/mod.rs
+++ b/crates/rag-rat-core/src/index/edges/resolve/mod.rs
@@ -21,90 +21,36 @@ fn import_scope_from_row(
     })
 }
 
-/// How a Python from-import alias reference is rewritten before resolution (#174). Empty (all
-/// `None`) when nothing is an in-scope alias. The order/scope correctness lives in extraction:
-/// each alias binding's `scope_end` already stops at the next module-scope rebinding of the name,
-/// so `python_alias_target` only returns an alias that is genuinely in effect at `ref_byte`.
-#[derive(Default)]
-struct PythonAliasRebind {
-    /// Override the leaf name passed to `resolve_symbol` — a BARE alias reference (`Account()` →
-    /// resolve `User`).
-    name: Option<String>,
-    /// Override `target_qualified_name` — a QUALIFIED reference whose receiver root is an alias
-    /// (`Account.from_id` → `User.from_id`).
-    target_qualified_name: Option<String>,
-    /// Override `receiver_hint` — the rebound receiver (`Account` → `User`).
-    receiver_hint: Option<String>,
-}
-
-/// Resolve a Python from-import alias to its imported target name, or `None` (#174). Picks the
-/// alias in effect at `ref_byte` (extraction already bounded its scope at the next module-scope
-/// rebinding), then declines if the file ALSO defines the target's bare name locally — a bare
-/// rewrite could grab the local definition instead of the import, so leave it to normal resolution
-/// (no edge beats a wrong one).
-fn python_alias_target<'i>(
-    import_scope: &'i imports::ImportScope,
-    index: &SymbolIndex<'_>,
+/// Apply a language package's import-alias rewrite. The shared resolver owns scope lookup and the
+/// collision guard; the policy owns which reference shapes are rewritten.
+struct ImportAliasResolveRequest<'a> {
     file_id: i64,
-    name: &str,
+    source_language: Option<&'a str>,
+    to_name: &'a str,
+    target_qualified_name: Option<&'a str>,
+    receiver_hint: Option<&'a str>,
     ref_byte: usize,
-) -> Option<&'i str> {
-    let target = import_scope.python_alias_target(file_id, name, ref_byte)?;
-    if index.file_defines(file_id, short_name(target)) {
-        return None;
-    }
-    Some(target)
 }
 
-/// Rewrite a Python from-import alias reference before resolution (#174). A BARE reference
-/// (`Account()`) rebinds the leaf; a QUALIFIED reference rebinds only the RECEIVER root
-/// (`Account.from_id()` → `User.from_id`), never the leaf — `pkg.Account` is `pkg`'s member, not
-/// the local alias `Account`, so the leaf of a qualified reference is never treated as an alias.
-///
-/// MODEL BOUNDARY: this is a MODULE-scope alias model (#174 review). The alias's scope is bounded
-/// at the next MODULE-scope rebinding of the name (extraction's `python_next_module_binding`). It
-/// does NOT model per-nested-scope lexical shadowing: a reference inside a `def`/`class` body that
-/// has its OWN local binding of the alias name is still rebound to the module import. That is rare
-/// (a nested local class/def reusing an imported alias's exact name) and resolving it would require
-/// full lexical-scope analysis at the reference site, beyond "module-scope binding statements".
-fn python_alias_rebind(
+fn import_alias_rebind(
     import_scope: &imports::ImportScope,
     index: &SymbolIndex<'_>,
-    file_id: i64,
-    to_name: &str,
-    target_qualified_name: Option<&str>,
-    receiver_hint: Option<&str>,
-    ref_byte: usize,
-) -> PythonAliasRebind {
-    match receiver_hint {
-        Some(receiver) => {
-            let Some(target) =
-                python_alias_target(import_scope, index, file_id, receiver, ref_byte)
-            else {
-                return PythonAliasRebind::default();
-            };
-            PythonAliasRebind {
-                name: None,
-                target_qualified_name: target_qualified_name
-                    .map(|qualified| replace_qualified_root(qualified, target)),
-                receiver_hint: Some(target.to_string()),
-            }
-        },
-        None => {
-            let target =
-                python_alias_target(import_scope, index, file_id, short_name(to_name), ref_byte);
-            PythonAliasRebind { name: target.map(str::to_string), ..PythonAliasRebind::default() }
-        },
-    }
-}
-
-/// Replace the first `::`-separated segment (the receiver root) of a dotted qualified name with
-/// `root` — `replace_qualified_root("Account::from_id", "User") == "User::from_id"`.
-fn replace_qualified_root(qualified: &str, root: &str) -> String {
-    match qualified.split_once("::") {
-        Some((_, rest)) => format!("{root}::{rest}"),
-        None => root.to_string(),
-    }
+    request: ImportAliasResolveRequest<'_>,
+) -> crate::index::languages::ImportAliasRebind {
+    let Some(policy) = crate::index::languages::resolver_policy_for_name(request.source_language)
+    else {
+        return Default::default();
+    };
+    let mut lookup = |name: &str| {
+        let target = import_scope.import_alias_target(request.file_id, name, request.ref_byte)?;
+        (!index.file_defines(request.file_id, short_name(target))).then(|| target.to_string())
+    };
+    policy.rebind_import_alias(crate::index::languages::ImportAliasRequest {
+        to_name: request.to_name,
+        target_qualified_name: request.target_qualified_name,
+        receiver_hint: request.receiver_hint,
+        lookup: &mut lookup,
+    })
 }
 
 /// Load the per-package local-crate sets and COMPUTE each active file's owning package into `scope`
@@ -314,13 +260,13 @@ fn resolve_edges_with_scope(conn: &Connection, write: EdgeWriteScope<'_>) -> any
             let to_name: Option<String> = row.get(2)?;
             let evidence: Option<String> = row.get(3)?;
             let scope = import_scope_from_row(row.get(4)?, row.get(5)?, row.get(6)?);
-            if language == Language::Python.as_str() {
-                // A Python `from m import T as A` alias edge carries `evidence = A` (alias),
-                // `to_name = T` (target), and a whole-file scope (#174); non-aliased Python imports
-                // have no scope and `add_python_alias` skips them. Python imports never go through
-                // `add_use` (that parses Rust `use` text).
+            let carries_alias = crate::index::languages::resolver_policy_for_name(Some(&language))
+                .is_some_and(|policy| policy.import_edges_carry_aliases());
+            if carries_alias {
+                // Alias carriers encode `evidence = alias`, `to_name = target`, and a lexical
+                // scope. Non-aliased imports have no scope and are ignored by this path.
                 if let (Some(alias), Some(target)) = (evidence, to_name) {
-                    import_scope.add_python_alias(file_id, alias, target, scope);
+                    import_scope.add_import_alias(file_id, alias, target, scope);
                 }
             } else if let Some(evidence) = evidence {
                 import_scope.add_use(file_id, &evidence, scope);
@@ -338,7 +284,7 @@ fn resolve_edges_with_scope(conn: &Connection, write: EdgeWriteScope<'_>) -> any
     // rewritten; empty for the base/incremental/full-rebuild path.
     let mut stmt = conn.prepare(&format!(
         "SELECT d.id, d.source_file_id, tn.value, tqn.value, ek.value, conf.value, d.evidence, \
-         rh.value, d.source_start_byte FROM edges_data d JOIN files ON files.id = \
+         rh.value, d.source_start_byte, files.language FROM edges_data d JOIN files ON files.id = \
          d.source_file_id LEFT JOIN name_strings tn ON tn.id = d.to_name_id LEFT JOIN \
          name_strings tqn ON tqn.id = d.target_qualified_name_id LEFT JOIN name_strings ek ON \
          ek.id = d.edge_kind_id LEFT JOIN name_strings conf ON conf.id = d.confidence_id LEFT \
@@ -356,6 +302,7 @@ fn resolve_edges_with_scope(conn: &Connection, write: EdgeWriteScope<'_>) -> any
             row.get::<_, Option<String>>(6)?,
             row.get::<_, Option<String>>(7)?,
             row.get::<_, i64>(8)?,
+            row.get::<_, String>(9)?,
         ))
     })?;
     let rows = rows.collect::<Result<Vec<_>, _>>()?;
@@ -369,6 +316,7 @@ fn resolve_edges_with_scope(conn: &Connection, write: EdgeWriteScope<'_>) -> any
         evidence,
         receiver_hint,
         source_start_byte,
+        source_language,
     ) in rows
     {
         // #200: a `dispatch_construct` fact's `to_name` is a synthetic `Enum::Variant` key, NOT a
@@ -390,22 +338,19 @@ fn resolve_edges_with_scope(conn: &Connection, write: EdgeWriteScope<'_>) -> any
         }
         // The reference's byte position drives the module-aware covering test (#61).
         let ref_byte = usize::try_from(source_start_byte).unwrap_or(0);
-        // Python from-import alias rebind (#174): resolve a reference written under an alias using
-        // its imported TARGET — `Account()` after `from m import User as Account` binds to `User`,
-        // and `Account.from_id()` to `User.from_id`. Only reference edges — the Imports edge itself
-        // already names the real target. Non-Python files have no alias entries (cheap miss).
+        // A language-owned import-alias policy may rewrite a reference to its imported target.
+        // Imports edges retain their own target name.
         let rebind = if edge_kind == EdgeKind::Imports.as_str() {
-            PythonAliasRebind::default()
+            Default::default()
         } else {
-            python_alias_rebind(
-                &import_scope,
-                &index,
-                source_file_id,
-                &to_name,
-                target_qualified_name.as_deref(),
-                receiver_hint.as_deref(),
+            import_alias_rebind(&import_scope, &index, ImportAliasResolveRequest {
+                file_id: source_file_id,
+                source_language: Some(source_language.as_str()),
+                to_name: &to_name,
+                target_qualified_name: target_qualified_name.as_deref(),
+                receiver_hint: receiver_hint.as_deref(),
                 ref_byte,
-            )
+            })
         };
         let resolve_name = rebind.name.as_deref().unwrap_or(to_name.as_str());
         let resolve_qualified =
@@ -419,7 +364,7 @@ fn resolve_edges_with_scope(conn: &Connection, write: EdgeWriteScope<'_>) -> any
                 evidence: evidence.as_deref(),
                 receiver_hint: resolve_receiver,
                 source_file_id,
-                source_language: index.file_language.get(&source_file_id).copied(),
+                source_language: Some(source_language.as_str()),
                 imported_external: import_scope.is_external_import(
                     source_file_id,
                     short_name(&to_name),
@@ -433,6 +378,11 @@ fn resolve_edges_with_scope(conn: &Connection, write: EdgeWriteScope<'_>) -> any
             &index,
         );
         let Some((to_symbol_id, confidence, reason)) = resolution else {
+            let suppressed =
+                crate::index::languages::resolver_policy_for_name(Some(&source_language))
+                    .is_some_and(|policy| {
+                        policy.suppress_unresolved_reference(&edge_kind, evidence.as_deref())
+                    });
             let confidence = if current_confidence == EdgeConfidence::Ambiguous.as_str() {
                 EdgeConfidence::Ambiguous
             } else {
@@ -441,7 +391,8 @@ fn resolve_edges_with_scope(conn: &Connection, write: EdgeWriteScope<'_>) -> any
             // prepare_cached: one UPDATE per edge; cache the statement so the SQL compiles once per
             // connection instead of on every call.
             let confidence_id = interner.get(conn, confidence.as_str())?;
-            let resolution_id = interner.get(conn, "unresolved")?;
+            let resolution_id =
+                interner.get(conn, if suppressed { "suppressed" } else { "unresolved" })?;
             conn.prepare_cached(
                 "UPDATE edges_data
                  SET to_symbol_id = NULL,
@@ -532,12 +483,8 @@ pub(crate) fn resolve_and_insert_edges(
     // accumulator vs DB rows).
     let mut import_scope = imports::ImportScope::new(imports::load_local_roots(conn));
     load_package_roots_into_scope(conn, &mut import_scope)?;
-    // File languages from the DB, NOT `index.file_language` (built only from files that contributed
-    // a symbol). A Python entrypoint that ONLY does `from m import X as A; A()` has no symbol row
-    // for its own file, so `index.file_language` would miss it and the alias carrier would feed
-    // neither `add_python_alias` nor `add_use` under `index --full` (#174 review); the DB row
-    // is authoritative. The incremental driver already joins `files.language`, so this keeps
-    // the two drivers in lockstep.
+    // File languages come from the DB because files without symbols still need their language
+    // policy. The incremental driver also joins `files.language`, keeping both drivers in lockstep.
     let file_language: HashMap<i64, String> = {
         let mut stmt = conn.prepare("SELECT id, language FROM files")?;
         let rows =
@@ -547,13 +494,13 @@ pub(crate) fn resolve_and_insert_edges(
     for (file_id, candidate) in &edges {
         if candidate.edge_kind == EdgeKind::Imports {
             let evidence = arena.get_opt(candidate.evidence).unwrap_or("");
-            if file_language.get(file_id).map(String::as_str) == Some(Language::Python.as_str()) {
-                // Python from-import alias carrier (#174): evidence = alias, to_name = target,
-                // whole-file scope. Non-aliased Python imports have no scope → `add_python_alias`
-                // skips them; Python imports never feed `add_use` (Rust `use`-text parsing).
+            let source_language = file_language.get(file_id).map(String::as_str);
+            let carries_alias = crate::index::languages::resolver_policy_for_name(source_language)
+                .is_some_and(|policy| policy.import_edges_carry_aliases());
+            if carries_alias {
                 let target = arena.get(candidate.to_name).trim();
                 if !evidence.is_empty() && !target.is_empty() {
-                    import_scope.add_python_alias(
+                    import_scope.add_import_alias(
                         *file_id,
                         evidence.to_string(),
                         target.to_string(),
@@ -601,22 +548,19 @@ pub(crate) fn resolve_and_insert_edges(
         // The reference's byte position drives the module-aware covering test (#61) — same input
         // the DB driver reads from `source_start_byte`.
         let ref_byte = candidate.source_span.start_byte as usize;
-        // Python from-import alias rebind (#174): mirror the DB driver — resolve a reference under
-        // its imported TARGET, so `Account()` binds to `User` and `Account.from_id()` to
-        // `User.from_id`. Imports edges keep their own target name; non-Python files have no alias
-        // entries.
+        // Mirror the DB driver: a language-owned alias policy may rewrite a reference to its
+        // imported target. Imports edges keep their own target name.
         let rebind = if candidate.edge_kind == EdgeKind::Imports {
-            PythonAliasRebind::default()
+            Default::default()
         } else {
-            python_alias_rebind(
-                &import_scope,
-                &index,
-                *file_id,
+            import_alias_rebind(&import_scope, &index, ImportAliasResolveRequest {
+                file_id: *file_id,
+                source_language: file_language.get(file_id).map(String::as_str),
                 to_name,
                 target_qualified_name,
                 receiver_hint,
                 ref_byte,
-            )
+            })
         };
         let resolve_name = rebind.name.as_deref().unwrap_or(to_name);
         let resolve_qualified = rebind.target_qualified_name.as_deref().or(target_qualified_name);
@@ -636,7 +580,7 @@ pub(crate) fn resolve_and_insert_edges(
                     evidence,
                     receiver_hint: resolve_receiver,
                     source_file_id: *file_id,
-                    source_language: index.file_language.get(file_id).copied(),
+                    source_language: file_language.get(file_id).map(String::as_str),
                     imported_external: import_scope.is_external_import(
                         *file_id,
                         short_name(to_name),
@@ -660,12 +604,24 @@ pub(crate) fn resolve_and_insert_edges(
                     reason,
                 ),
                 None => {
+                    let suppressed = crate::index::languages::resolver_policy_for_name(
+                        file_language.get(file_id).map(String::as_str),
+                    )
+                    .is_some_and(|policy| {
+                        policy.suppress_unresolved_reference(candidate.edge_kind.as_str(), evidence)
+                    });
                     let confidence = if candidate.confidence == EdgeConfidence::Ambiguous {
                         EdgeConfidence::Ambiguous
                     } else {
                         EdgeConfidence::NameOnly
                     };
-                    (None, confidence, None, None, "unresolved")
+                    (
+                        None,
+                        confidence,
+                        None,
+                        None,
+                        if suppressed { "suppressed" } else { "unresolved" },
+                    )
                 },
             };
         // NULL when the sentinel marks an absent callee range; see
@@ -742,7 +698,13 @@ pub(crate) fn resolve_symbol<'a>(
     index: &SymbolIndex<'a>,
 ) -> Option<(&'a IndexedSymbol, EdgeConfidence, &'static str)> {
     let kind_matches = |symbol: &IndexedSymbol| {
-        request.edge_kind != EdgeKind::UsesMacro.as_str() || symbol.kind == "macro"
+        (request.edge_kind != EdgeKind::UsesMacro.as_str() || symbol.kind == "macro")
+            && crate::index::languages::target_matches_policy(
+                request.source_language,
+                request.edge_kind,
+                &symbol.language,
+                &symbol.kind,
+            )
     };
     // Crate-aware import suppression (#61 Project B): the name is `use`d from an external
     // dependency crate, so it denotes that dependency's item — never a local same-named symbol.
@@ -751,24 +713,17 @@ pub(crate) fn resolve_symbol<'a>(
     // correct cross-crate binds into local workspace crates (those roots are in the local-crate
     // set, so not external).
     //
-    // EXCEPTION: an explicitly LOCAL-qualified reference (`crate::Url`, `self::Url`, `super::Url`)
-    // names a local item by construction — the qualifier overrides the bare-leaf import. Don't
-    // suppress it just because the file also imports a same-named external item; fall through so
-    // the qualified path can bind.
-    if request.imported_external && !targets_local_qualified_path(request.target_qualified_name) {
+    let policy = crate::index::languages::resolver_policy_for_name(request.source_language);
+    // A language-owned local qualifier overrides an external bare-leaf import.
+    if request.imported_external
+        && !request.target_qualified_name.and_then(|path| path.split_once("::")).is_some_and(
+            |(root, _)| policy.is_some_and(|policy| policy.is_local_qualified_root(root)),
+        )
+    {
         return None;
     }
-    // A Rust `references_type` to a GENERIC PARAMETER (`T`, `V`, `T1`) or an associated-type
-    // PROJECTION (`Self::Value`, `T::Output`, `V::Value`) has no in-corpus definition to point at —
-    // its concrete type is only known after type inference. Name-based resolution would bind it to
-    // whatever same-named concrete type happens to exist (serde has a `T` type and 50 `Value`s),
-    // asserting `Syntactic`; the SCIP oracle then counts that as a contradiction. Leave it
-    // unresolved (the edge is still recorded) instead of guessing. A real module-qualified type
-    // (`de::Deserializer`) has a lowercase path root and is NOT caught. Rust-only: TS/Kotlin/Python
-    // type parameters don't share this single-uppercase convention.
-    if request.source_language == Some(Language::Rust.as_str())
-        && request.edge_kind == EdgeKind::ReferencesType.as_str()
-        && rust_type_ref_is_unresolvable(request.name)
+    if policy
+        .is_some_and(|policy| policy.reference_is_unresolvable(request.edge_kind, request.name))
     {
         return None;
     }
@@ -864,26 +819,18 @@ pub(crate) fn resolve_symbol<'a>(
         .filter(|symbol| kind_matches(symbol))
         .collect::<Vec<_>>();
     let preferred = preferred_matches(request.edge_kind, request.source_language, &matches);
-    // In languages with separate type/value namespaces (Rust, C, C++), a `references_type`
-    // reference must resolve to a type DEFINITION (struct/enum/trait/type/…). If none of the
-    // same-named candidates is one, do NOT fall back to a non-type symbol (an `impl` block, a
-    // module, a function/const/macro) — leave it unresolved, so the graph never points a type
-    // reference at a non-type. Those fallbacks were pure contradictions (#61): when a type's real
-    // definition is external / in another crate, the only in-corpus same-named symbol is often an
-    // `impl Foo` or a module, and binding to it is always wrong. NOT applied to TS/Kotlin, where a
-    // type-position reference legitimately targets a value (a React component `const`/`function`).
+    // Language policy decides whether a type-position reference may bind a value declaration.
     if preferred.is_empty()
         && request.edge_kind == EdgeKind::ReferencesType.as_str()
-        && matches!(request.source_language, Some("rust" | "c" | "cpp"))
+        && policy.is_some_and(|policy| policy.type_reference_requires_type_definition())
     {
         return None;
     }
-    // A Python `implements` (base class) that found no in-corpus PYTHON class must NOT fall back to
-    // the all-matches set: that would bind the base to a same-named non-class or a foreign-language
-    // class (#172 review). Leave it unresolved — the ReferencesType edge still records the base.
     if preferred.is_empty()
-        && request.edge_kind == EdgeKind::Implements.as_str()
-        && request.source_language == Some(Language::Python.as_str())
+        && crate::index::languages::requires_same_language_target(
+            request.source_language,
+            request.edge_kind,
+        )
     {
         return None;
     }
@@ -927,6 +874,17 @@ pub(crate) fn same_logical_symbol(symbols: &[&IndexedSymbol]) -> bool {
     let Some(first) = symbols.first() else {
         return false;
     };
+    // A language policy can preserve ambiguity when stored identity does not distinguish distinct
+    // declarations. Languages without that restriction retain variant collapsing.
+    if first
+        .language
+        .parse::<Language>()
+        .ok()
+        .and_then(crate::index::languages::resolver_policy)
+        .is_some_and(|policy| !policy.collapse_same_named_declarations())
+    {
+        return false;
+    }
     symbols.iter().all(|symbol| {
         symbol.qualified_name == first.qualified_name
             && symbol.name == first.name
@@ -934,27 +892,6 @@ pub(crate) fn same_logical_symbol(symbols: &[&IndexedSymbol]) -> bool {
             && symbol.scope_path == first.scope_path
     })
 }
-/// Whether a Rust `references_type` target is a generic parameter or an associated-type projection
-/// — a reference name-based resolution can't (and shouldn't) bind to a concrete in-corpus type.
-/// True for a BARE generic-parameter name (`T`, `V`, `T1` — Rust's short-uppercase convention) or
-/// any PROJECTION whose root segment is `Self` or such a parameter (`Self::Value`, `T::Output`,
-/// `V::Value`). A module-qualified type (`de::Deserializer`, lowercase root) is NOT a projection.
-fn rust_type_ref_is_unresolvable(name: &str) -> bool {
-    match name.split_once("::") {
-        Some((root, _)) => root == "Self" || looks_like_type_parameter(root),
-        None => looks_like_type_parameter(name),
-    }
-}
-
-/// Rust generic-parameter NAME shape: one uppercase ASCII letter, then only digits (`T`, `K`, `V`,
-/// `T1`, `T2`). Deliberately narrow — a real two-letter type (`Id`, `IO`, `Ok`) or any longer name
-/// is NOT a parameter, so only the unambiguous single-letter convention is suppressed.
-fn looks_like_type_parameter(name: &str) -> bool {
-    let mut chars = name.chars();
-    chars.next().is_some_and(|first| first.is_ascii_uppercase())
-        && chars.all(|rest| rest.is_ascii_digit())
-}
-
 pub(crate) fn allow_unqualified_fallback(
     edge_kind: &str,
     qualified: &str,
@@ -974,62 +911,29 @@ pub(crate) fn allow_unqualified_fallback(
         .split("::")
         .next()
         .unwrap_or_default();
-    if matches!(qualifier, "crate" | "self" | "super") {
+    let policy = crate::index::languages::resolver_policy_for_name(source_language);
+    if policy.is_some_and(|policy| policy.is_local_qualified_root(qualifier)) {
         return true;
     }
     if receiver_hint
         .is_some_and(|receiver| looks_like_type_name(receiver) && !is_common_member_name(target))
-        && matches!(source_language, Some("rust" | "kotlin"))
+        && policy.is_some_and(|policy| policy.allow_type_receiver_fallback())
     {
         return true;
     }
     if receiver_hint.is_some_and(|receiver| !matches!(receiver, "self" | "Self"))
         && evidence.is_some_and(|value| value.contains('.'))
     {
-        return source_language == Some(Language::Kotlin.as_str())
+        return policy.is_some_and(|policy| policy.allow_value_receiver_fallback())
             && !is_common_member_name(target);
     }
-    if is_external_rust_root(qualifier) {
+    if policy.is_some_and(|policy| policy.rejects_qualified_root(qualifier)) {
         return false;
     }
     if looks_like_type_name(qualifier) && is_common_member_name(target) {
         return false;
     }
     true
-}
-/// Whether an edge's `target_qualified_name` is an explicitly LOCAL-rooted path (`crate::…`,
-/// `self::…`, `super::…`) — code disambiguating a local item with a qualifier. Such a reference is
-/// exempt from crate-aware import suppression (#61 Project B) even when the file also imports a
-/// same-named external item.
-fn targets_local_qualified_path(target_qualified_name: Option<&str>) -> bool {
-    target_qualified_name
-        .and_then(|path| path.split_once("::"))
-        .is_some_and(|(root, _)| matches!(root, "crate" | "self" | "super"))
-}
-pub(crate) fn is_external_rust_root(value: &str) -> bool {
-    matches!(
-        value,
-        "std"
-            | "core"
-            | "alloc"
-            | "tokio"
-            | "serde"
-            | "serde_json"
-            | "anyhow"
-            | "thiserror"
-            | "rusqlite"
-            | "tree_sitter"
-            | "tracing"
-            | "log"
-            | "Vec"
-            | "String"
-            | "Option"
-            | "Result"
-            | "HashMap"
-            | "BTreeMap"
-            | "HashSet"
-            | "BTreeSet"
-    )
 }
 pub(crate) fn is_common_member_name(value: &str) -> bool {
     matches!(
@@ -1057,23 +961,7 @@ pub(crate) fn preferred_matches<'a>(
     source_language: Option<&str>,
     matches: &[&'a IndexedSymbol],
 ) -> Vec<&'a IndexedSymbol> {
-    // Python base-class inheritance emits an `implements` edge to a CLASS — Python has no
-    // traits/interfaces — so prefer class-like kinds for Python (#172). This case ALSO filters by
-    // LANGUAGE: the name buckets are repo-wide, so without it a Python base would bind to a
-    // same-named TS/Kotlin/C++ class or Kotlin `object` in a mixed-language index (#172 review).
-    // Kept language-scoped so Kotlin/TS are otherwise UNCHANGED (`implements`/`: I` targets an
-    // interface, and a same-named class must not be preferred over it).
-    if edge_kind == "implements" && source_language == Some(Language::Python.as_str()) {
-        return matches
-            .iter()
-            .copied()
-            .filter(|symbol| {
-                matches!(symbol.kind.as_str(), "class" | "object")
-                    && symbol.language.as_str() == Language::Python.as_str()
-            })
-            .collect();
-    }
-    let preferred_kinds: &[&str] = match edge_kind {
+    let generic_preferred_kinds: &[&str] = match edge_kind {
         // `dispatch_handle` (#200) is a call to the handler the match arm delegates to — resolve it
         // with the SAME callable preference as a direct call, so a same-named type/const never wins
         // over the handler function/method.
@@ -1084,14 +972,37 @@ pub(crate) fn preferred_matches<'a>(
         "references_type" => &["struct", "enum", "trait", "type", "class", "interface", "object"],
         _ => &[],
     };
+    let source_language = source_language.and_then(|name| name.parse::<Language>().ok());
+    let language_preference = source_language
+        .and_then(crate::index::languages::resolver_policy)
+        .and_then(|policy| policy.preferred_kinds(edge_kind));
+    let preferred_kinds = language_preference
+        .as_ref()
+        .map_or(generic_preferred_kinds, |preference| preference.symbol_kinds);
     if preferred_kinds.is_empty() {
         return Vec::new();
     }
-    matches
+    let preferred = matches
         .iter()
         .copied()
         .filter(|symbol| preferred_kinds.contains(&symbol.kind.as_str()))
-        .collect()
+        .collect::<Vec<_>>();
+    if let (Some(source_language), Some(language_preference)) =
+        (source_language, language_preference)
+    {
+        let same_language = preferred
+            .iter()
+            .copied()
+            .filter(|symbol| symbol.language == source_language.as_str())
+            .collect::<Vec<_>>();
+        if !same_language.is_empty() {
+            return same_language;
+        }
+        if language_preference.same_language_only {
+            return Vec::new();
+        }
+    }
+    preferred
 }
 
 #[cfg(test)]

--- a/crates/rag-rat-core/src/index/edges/resolve/tests.rs
+++ b/crates/rag-rat-core/src/index/edges/resolve/tests.rs
@@ -537,6 +537,83 @@ fn swift_qualified_edges_do_not_bind_foreign_scope_paths() {
     }
 }
 
+/// An enum case is bindable by BARE NAME only through Swift's shorthand `.idle`, the one shape that
+/// evidences a case. A value-receiver method call (`client.idle()`) and a static member read
+/// (`Config.idle`) share the same `calls_name` edge kind but carry a receiver/qualifier — binding
+/// those to an unrelated `enum Status { case idle }` would report an ordinary call or property read
+/// as a caller of that case. Poisons the index with ONLY the case symbol, so a resolution can come
+/// from nowhere else: without the bare-shape rule the receiver/qualified edges bind it and this
+/// fails.
+#[test]
+fn swift_enum_cases_bind_by_bare_name_only_for_the_shorthand_shape() {
+    let conn = seeded_conn();
+    let source = add_file(&conn, "Caller.swift", NEW);
+    conn.execute("UPDATE main.files SET language = 'swift' WHERE id = ?1", [source]).unwrap();
+    let definitions = add_file(&conn, "Status.swift", NEW);
+    conn.execute("UPDATE main.files SET language = 'swift' WHERE id = ?1", [definitions]).unwrap();
+    // The ONLY `idle` in the repo is an enum case.
+    let idle = add_symbol_scope_language(
+        &conn,
+        definitions,
+        "idle",
+        "Status.swift::idle",
+        "Status::idle",
+        "enum_case",
+        Language::Swift,
+    );
+
+    // `client.idle()` — a value receiver, not a case.
+    conn.execute(
+        "INSERT INTO edges(source_file_id, to_name, edge_kind, confidence, resolution, \
+         receiver_hint) VALUES (?1, 'idle', 'calls_name', 'NameOnly', 'unresolved', 'client')",
+        params![source],
+    )
+    .unwrap();
+    let receiver_call: i64 =
+        conn.query_row("SELECT MAX(id) FROM edges_data", [], |row| row.get(0)).unwrap();
+
+    // `Config.idle` — a static member read of a type that has no such member.
+    conn.execute(
+        "INSERT INTO edges(source_file_id, to_name, edge_kind, confidence, resolution, \
+         target_qualified_name, receiver_hint) VALUES (?1, 'idle', 'calls_name', 'NameOnly', \
+         'unresolved', 'Config::idle', 'Config')",
+        params![source],
+    )
+    .unwrap();
+    let static_read: i64 =
+        conn.query_row("SELECT MAX(id) FROM edges_data", [], |row| row.get(0)).unwrap();
+
+    // `.idle` — the shorthand: no qualifier, no receiver. This one IS the case.
+    conn.execute(
+        "INSERT INTO edges(source_file_id, to_name, edge_kind, confidence, resolution) VALUES \
+         (?1, 'idle', 'calls_name', 'NameOnly', 'unresolved')",
+        params![source],
+    )
+    .unwrap();
+    let shorthand: i64 =
+        conn.query_row("SELECT MAX(id) FROM edges_data", [], |row| row.get(0)).unwrap();
+
+    crate::index::install_scope_view(&conn, NEW, "").unwrap();
+    resolve_all_edges(&conn).unwrap();
+
+    let (receiver_target, ..) = edge_state(&conn, receiver_call);
+    assert_eq!(
+        receiver_target, None,
+        "a value-receiver call must not bind an enum case by bare name"
+    );
+    let (static_target, ..) = edge_state(&conn, static_read);
+    assert_eq!(
+        static_target, None,
+        "a static member read must not bind an unrelated enum case by bare name"
+    );
+    let (shorthand_target, ..) = edge_state(&conn, shorthand);
+    assert_eq!(
+        shorthand_target,
+        Some(idle),
+        "the shorthand `.idle` shape still resolves to the case"
+    );
+}
+
 #[test]
 fn swift_value_receiver_calls_resolve_by_bare_name() {
     let conn = seeded_conn();

--- a/crates/rag-rat-core/src/index/edges/resolve/tests.rs
+++ b/crates/rag-rat-core/src/index/edges/resolve/tests.rs
@@ -147,26 +147,553 @@ fn add_symbol_kind(
     qualified: &str,
     kind: &str,
 ) -> i64 {
+    add_symbol_kind_language(conn, file_id, name, qualified, kind, Language::Rust)
+}
+
+fn add_symbol_kind_language(
+    conn: &Connection,
+    file_id: i64,
+    name: &str,
+    qualified: &str,
+    kind: &str,
+    language: Language,
+) -> i64 {
     conn.execute("INSERT OR IGNORE INTO name_strings(value) VALUES (?1)", params![qualified])
         .unwrap();
     conn.execute(
         "INSERT INTO symbols(file_id, language, name, qualified_name_id, kind, start_byte, \
          end_byte, start_line, end_line)
-         VALUES (?1, 'rust', ?2, (SELECT id FROM name_strings WHERE value = ?3), ?4, 0, 10, 1, 1)",
-        params![file_id, name, qualified, kind],
+         VALUES (?1, ?2, ?3, (SELECT id FROM name_strings WHERE value = ?4), ?5, 0, 10, 1, 1)",
+        params![file_id, language.as_str(), name, qualified, kind],
     )
     .unwrap();
     conn.last_insert_rowid()
 }
 
 fn add_type_ref_edge(conn: &Connection, source_file_id: i64, to_name: &str) -> i64 {
+    add_named_edge(conn, source_file_id, to_name, EdgeKind::ReferencesType)
+}
+
+fn add_named_edge(
+    conn: &Connection,
+    source_file_id: i64,
+    to_name: &str,
+    edge_kind: EdgeKind,
+) -> i64 {
     conn.execute(
         "INSERT INTO edges(source_file_id, to_name, edge_kind, confidence, resolution) VALUES \
-         (?1, ?2, 'references_type', 'NameOnly', 'unresolved')",
-        params![source_file_id, to_name],
+         (?1, ?2, ?3, 'NameOnly', 'unresolved')",
+        params![source_file_id, to_name, edge_kind.as_str()],
     )
     .unwrap();
     conn.query_row("SELECT MAX(id) FROM edges_data", [], |row| row.get(0)).unwrap()
+}
+
+fn preferred_candidate(id: i64, language: Language, kind: &str) -> IndexedSymbol {
+    IndexedSymbol {
+        id,
+        file_id: id,
+        language: language.as_str().to_string(),
+        name: "Target".to_string(),
+        qualified_name: format!("target-{id}::Target"),
+        scope_path: "Target".to_string(),
+        kind: kind.to_string(),
+        start_byte: 0,
+        end_byte: 10,
+        start_line: 1,
+        end_line: 1,
+    }
+}
+
+#[test]
+fn swift_type_edges_prefer_swift_protocols_and_actors_over_foreign_types() {
+    let protocol = preferred_candidate(1, Language::Swift, "protocol");
+    let foreign_trait = preferred_candidate(2, Language::Rust, "trait");
+    let actor = preferred_candidate(3, Language::Swift, "actor");
+    let foreign_struct = preferred_candidate(4, Language::Rust, "struct");
+    let swift_class = preferred_candidate(5, Language::Swift, "class");
+    let swift_macro = preferred_candidate(6, Language::Swift, "macro");
+    let foreign_macro = preferred_candidate(7, Language::Rust, "macro");
+    let swift_enum = preferred_candidate(8, Language::Swift, "enum");
+    let swift_method = preferred_candidate(9, Language::Swift, "method");
+    let foreign_function = preferred_candidate(10, Language::Rust, "function");
+    let swift_constructor = preferred_candidate(11, Language::Swift, "constructor");
+
+    let implements =
+        preferred_matches(EdgeKind::Implements.as_str(), Some(Language::Swift.as_str()), &[
+            &foreign_trait,
+            &protocol,
+        ]);
+    assert_eq!(implements.iter().map(|symbol| symbol.id).collect::<Vec<_>>(), vec![protocol.id]);
+
+    let inheritance =
+        preferred_matches(EdgeKind::Implements.as_str(), Some(Language::Swift.as_str()), &[
+            &foreign_trait,
+            &swift_class,
+        ]);
+    assert_eq!(inheritance.iter().map(|symbol| symbol.id).collect::<Vec<_>>(), vec![
+        swift_class.id
+    ]);
+
+    let protocol_reference =
+        preferred_matches(EdgeKind::ReferencesType.as_str(), Some(Language::Swift.as_str()), &[
+            &foreign_trait,
+            &protocol,
+        ]);
+    assert_eq!(protocol_reference.iter().map(|symbol| symbol.id).collect::<Vec<_>>(), vec![
+        protocol.id
+    ]);
+
+    for edge_kind in [EdgeKind::Constructs, EdgeKind::ReferencesType] {
+        let preferred = preferred_matches(edge_kind.as_str(), Some(Language::Swift.as_str()), &[
+            &foreign_struct,
+            &actor,
+        ]);
+        assert_eq!(
+            preferred.iter().map(|symbol| symbol.id).collect::<Vec<_>>(),
+            vec![actor.id],
+            "{edge_kind:?} must prefer the Swift actor"
+        );
+    }
+
+    let macro_use =
+        preferred_matches(EdgeKind::UsesMacro.as_str(), Some(Language::Swift.as_str()), &[
+            &foreign_macro,
+            &swift_macro,
+        ]);
+    assert_eq!(macro_use.iter().map(|symbol| symbol.id).collect::<Vec<_>>(), vec![swift_macro.id]);
+
+    let enum_construction =
+        preferred_matches(EdgeKind::Constructs.as_str(), Some(Language::Swift.as_str()), &[
+            &foreign_struct,
+            &swift_enum,
+        ]);
+    assert_eq!(enum_construction.iter().map(|symbol| symbol.id).collect::<Vec<_>>(), vec![
+        swift_enum.id
+    ]);
+
+    let call = preferred_matches(EdgeKind::CallsName.as_str(), Some(Language::Swift.as_str()), &[
+        &foreign_function,
+        &swift_method,
+    ]);
+    assert_eq!(call.iter().map(|symbol| symbol.id).collect::<Vec<_>>(), vec![swift_method.id]);
+
+    let initializer_call =
+        preferred_matches(EdgeKind::CallsName.as_str(), Some(Language::Swift.as_str()), &[
+            &foreign_function,
+            &swift_constructor,
+        ]);
+    assert_eq!(initializer_call.iter().map(|symbol| symbol.id).collect::<Vec<_>>(), vec![
+        swift_constructor.id
+    ]);
+
+    assert!(
+        preferred_matches(EdgeKind::ReferencesType.as_str(), Some(Language::Swift.as_str()), &[
+            &foreign_struct
+        ],)
+        .is_empty(),
+        "Swift type names without a Swift target must not prefer a foreign symbol"
+    );
+    assert!(
+        preferred_matches(EdgeKind::UsesMacro.as_str(), Some(Language::Swift.as_str()), &[
+            &foreign_macro
+        ],)
+        .is_empty(),
+        "Swift macro names without a Swift target must not prefer a foreign macro"
+    );
+    assert!(
+        preferred_matches(EdgeKind::CallsName.as_str(), Some(Language::Swift.as_str()), &[
+            &foreign_function
+        ],)
+        .is_empty(),
+        "Swift calls without a Swift target must not prefer a foreign function"
+    );
+}
+
+#[test]
+fn generic_resolution_does_not_prefer_swift_only_symbol_kinds() {
+    let swift_protocol = preferred_candidate(1, Language::Swift, "protocol");
+    let rust_trait = preferred_candidate(2, Language::Rust, "trait");
+    let swift_actor = preferred_candidate(3, Language::Swift, "actor");
+    let rust_struct = preferred_candidate(4, Language::Rust, "struct");
+
+    let implements =
+        preferred_matches(EdgeKind::Implements.as_str(), Some(Language::TypeScript.as_str()), &[
+            &swift_protocol,
+            &rust_trait,
+        ]);
+    assert_eq!(implements.iter().map(|symbol| symbol.id).collect::<Vec<_>>(), vec![rust_trait.id]);
+
+    for edge_kind in [EdgeKind::Constructs, EdgeKind::ReferencesType] {
+        let preferred =
+            preferred_matches(edge_kind.as_str(), Some(Language::TypeScript.as_str()), &[
+                &swift_actor,
+                &rust_struct,
+            ]);
+        assert_eq!(preferred.iter().map(|symbol| symbol.id).collect::<Vec<_>>(), vec![
+            rust_struct.id
+        ]);
+    }
+}
+
+#[test]
+fn swift_name_only_edges_do_not_fall_back_to_foreign_symbols() {
+    let conn = seeded_conn();
+    let source = add_file(&conn, "Caller.swift", NEW);
+    conn.execute("UPDATE main.files SET language = 'swift' WHERE id = ?1", [source]).unwrap();
+    // Top-level Swift scripts can contain calls without declaring any indexed symbol. Resolution
+    // must use the source file's language rather than inferring it from the symbol table.
+    let foreign = add_file(&conn, "foreign.rs", NEW);
+    add_symbol_kind(&conn, foreign, "URL", "foreign.rs::URL", "struct");
+    add_symbol_kind(&conn, foreign, "stringify", "foreign.rs::stringify", "macro");
+    add_symbol_kind(&conn, foreign, "parse", "foreign.rs::parse", "function");
+    add_symbol_kind_language(
+        &conn,
+        source,
+        "Foundation",
+        "Caller.swift::Foundation",
+        "struct",
+        Language::Swift,
+    );
+    let type_edge = add_type_ref_edge(&conn, source, "URL");
+    let macro_edge = add_named_edge(&conn, source, "stringify", EdgeKind::UsesMacro);
+    let call_edge = add_named_edge(&conn, source, "parse", EdgeKind::CallsName);
+    let import_edge = add_named_edge(&conn, source, "Foundation", EdgeKind::Imports);
+
+    crate::index::install_scope_view(&conn, NEW, "").unwrap();
+    resolve_all_edges(&conn).unwrap();
+
+    for (edge, description) in [
+        (type_edge, "Swift SDK/external type"),
+        (macro_edge, "Swift external macro"),
+        (call_edge, "Swift external function"),
+        (import_edge, "Swift module import"),
+    ] {
+        let (to, _, resolution) = edge_state(&conn, edge);
+        assert_eq!(to, None, "a {description} must not bind to a foreign symbol");
+        assert_eq!(resolution, "unresolved");
+    }
+}
+
+#[test]
+fn swift_suppresses_and_re_resolves_attached_macro_candidates() {
+    let conn = seeded_conn();
+    let source = add_file(&conn, "Caller.swift", NEW);
+    let definitions = add_file(&conn, "Macros.swift", NEW);
+    conn.execute("UPDATE main.files SET language = 'swift' WHERE id IN (?1, ?2)", params![
+        source,
+        definitions
+    ])
+    .unwrap();
+    conn.execute(
+        "INSERT INTO edges(source_file_id, to_name, edge_kind, confidence, resolution, evidence) \
+         VALUES (?1, 'Observable', 'uses_macro', 'NameOnly', 'unresolved', '@Observable'), (?1, \
+         'available', 'uses_macro', 'NameOnly', 'unresolved', '@available(*, deprecated)'), (?1, \
+         'external', 'uses_macro', 'NameOnly', 'unresolved', '#external')",
+        [source],
+    )
+    .unwrap();
+
+    crate::index::install_scope_view(&conn, NEW, "").unwrap();
+    resolve_all_edges(&conn).unwrap();
+
+    let suppressed_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM edges_data d
+             JOIN name_strings r ON r.id = d.resolution_id
+             WHERE r.value = 'suppressed'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(suppressed_count, 2, "attached candidates remain available for later resolution");
+    let attached_visible_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM edges WHERE to_name IN ('Observable', 'available')",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(attached_visible_count, 0, "unresolved attributes stay out of graph queries");
+    let freestanding_count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM edges WHERE to_name = 'external'", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(freestanding_count, 1, "unresolved freestanding macros remain graph evidence");
+
+    let observable = add_symbol_kind_language(
+        &conn,
+        definitions,
+        "Observable",
+        "Macros.swift::Observable",
+        "macro",
+        Language::Swift,
+    );
+    resolve_all_edges(&conn).unwrap();
+    let resolved_macro: Option<i64> = conn
+        .query_row("SELECT to_symbol_id FROM edges WHERE to_name = 'Observable'", [], |row| {
+            row.get(0)
+        })
+        .unwrap();
+    assert_eq!(resolved_macro, Some(observable), "a later macro definition must heal the edge");
+
+    conn.execute("DELETE FROM symbols WHERE id = ?1", [observable]).unwrap();
+    resolve_all_edges(&conn).unwrap();
+    let visible_after_removal: i64 = conn
+        .query_row("SELECT COUNT(*) FROM edges WHERE to_name = 'Observable'", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(visible_after_removal, 0, "removing the macro must suppress the candidate again");
+}
+
+#[test]
+fn full_rebuild_uses_language_of_symbol_less_swift_files() {
+    let conn = seeded_conn();
+    let source = add_file(&conn, "script.swift", NEW);
+    conn.execute("UPDATE main.files SET language = 'swift' WHERE id = ?1", [source]).unwrap();
+    let foreign = add_file(&conn, "foreign.rs", NEW);
+    let target_id = add_symbol_kind(&conn, foreign, "parse", "foreign.rs::parse", "function");
+    let target = crate::index::symbols::Symbol {
+        name: "parse".to_string(),
+        qualified_name: "foreign.rs::parse".to_string(),
+        scope_path: "parse".to_string(),
+        kind: "function".to_string(),
+        start_byte: 0,
+        end_byte: 10,
+        start_line: 1,
+        end_line: 1,
+        signature: None,
+        docs: None,
+        is_test: false,
+        facts: Vec::new(),
+    };
+    let candidate = EdgeCandidate {
+        from_symbol_id: None,
+        from_name: Some("script.swift".to_string()),
+        to_name: "parse".to_string(),
+        target_qualified_name: None,
+        evidence: Some("parse()".to_string()),
+        receiver_hint: None,
+        source_span: EdgeSpan { start_line: 1, end_line: 1, start_byte: 0, end_byte: 7 },
+        callee_span: None,
+        import_scope: None,
+        edge_kind: EdgeKind::CallsName,
+        confidence: EdgeConfidence::NameOnly,
+    };
+    let mut graph = FullRebuildGraph::default();
+    graph.push_symbol(target_id, foreign, Language::Rust, &target);
+    graph.push_edge(source, &candidate, &[]);
+
+    crate::index::install_scope_view(&conn, NEW, "").unwrap();
+    resolve_and_insert_edges(&conn, graph).unwrap();
+
+    let edge: i64 = conn.query_row("SELECT MAX(id) FROM edges_data", [], |row| row.get(0)).unwrap();
+    let (to, _, resolution) = edge_state(&conn, edge);
+    assert_eq!(to, None, "the full driver must apply Swift policy without a source symbol");
+    assert_eq!(resolution, "unresolved");
+}
+
+#[test]
+fn swift_qualified_edges_do_not_bind_foreign_scope_paths() {
+    let conn = seeded_conn();
+    let source = add_file(&conn, "Caller.swift", NEW);
+    conn.execute("UPDATE main.files SET language = 'swift' WHERE id = ?1", [source]).unwrap();
+    let foreign = add_file(&conn, "foreign.rs", NEW);
+    add_symbol_scope_language(
+        &conn,
+        foreign,
+        "fetch",
+        "foreign.rs::fetch",
+        "Client::fetch",
+        "function",
+        Language::Rust,
+    );
+    add_symbol_scope_language(
+        &conn,
+        foreign,
+        "Request",
+        "foreign.rs::Request",
+        "API::Request",
+        "struct",
+        Language::Rust,
+    );
+    let call = add_edge(&conn, source, "fetch", "Client::fetch");
+    let type_ref = {
+        conn.execute(
+            "INSERT INTO edges(source_file_id, to_name, target_qualified_name, edge_kind, \
+             confidence, resolution) VALUES (?1, 'Request', 'API::Request', 'references_type', \
+             'NameOnly', 'unresolved')",
+            params![source],
+        )
+        .unwrap();
+        conn.query_row("SELECT MAX(id) FROM edges_data", [], |row| row.get(0)).unwrap()
+    };
+
+    crate::index::install_scope_view(&conn, NEW, "").unwrap();
+    resolve_all_edges(&conn).unwrap();
+
+    for edge in [call, type_ref] {
+        let (to, _, resolution) = edge_state(&conn, edge);
+        assert_eq!(to, None, "qualified Swift references must not bind foreign scope paths");
+        assert_eq!(resolution, "unresolved");
+    }
+}
+
+#[test]
+fn swift_value_receiver_calls_resolve_by_bare_name() {
+    let conn = seeded_conn();
+    let source = add_file(&conn, "Caller.swift", NEW);
+    conn.execute("UPDATE main.files SET language = 'swift' WHERE id = ?1", [source]).unwrap();
+    let definitions = add_file(&conn, "Client.swift", NEW);
+    conn.execute("UPDATE main.files SET language = 'swift' WHERE id = ?1", [definitions]).unwrap();
+    let fetch = add_symbol_scope_language(
+        &conn,
+        definitions,
+        "fetch",
+        "Client.swift::fetch",
+        "Client::fetch",
+        "function",
+        Language::Swift,
+    );
+    conn.execute(
+        "INSERT INTO edges(source_file_id, to_name, edge_kind, confidence, resolution, \
+         receiver_hint) VALUES (?1, 'fetch', 'calls_name', 'NameOnly', 'unresolved', 'client')",
+        params![source],
+    )
+    .unwrap();
+    let call: i64 = conn.query_row("SELECT MAX(id) FROM edges_data", [], |row| row.get(0)).unwrap();
+
+    crate::index::install_scope_view(&conn, NEW, "").unwrap();
+    resolve_all_edges(&conn).unwrap();
+
+    let (to, confidence, resolution) = edge_state(&conn, call);
+    assert_eq!(to, Some(fetch));
+    assert_eq!(confidence, "Syntactic");
+    assert_eq!(resolution, "target_name_fallback");
+    let receiver: String = conn
+        .query_row("SELECT receiver_hint FROM edges WHERE id = ?1", [call], |row| row.get(0))
+        .unwrap();
+    assert_eq!(receiver, "client");
+}
+
+#[test]
+fn swift_local_receivers_override_external_bare_name_suppression() {
+    let mut make = preferred_candidate(1, Language::Swift, "function");
+    make.name = "make".to_string();
+    make.qualified_name = "Store.swift::make".to_string();
+    make.scope_path = "Store::make".to_string();
+    let symbols = [make];
+    let index = SymbolIndex::build(&symbols);
+
+    for receiver in ["Self", "self", "super"] {
+        let qualified = format!("{receiver}::make");
+        let resolved = resolve_symbol(
+            ResolveSymbolRequest {
+                name: "make",
+                target_qualified_name: Some(&qualified),
+                edge_kind: EdgeKind::CallsName.as_str(),
+                evidence: Some("make()"),
+                receiver_hint: Some(receiver),
+                source_file_id: 1,
+                source_language: Some(Language::Swift.as_str()),
+                imported_external: true,
+            },
+            &index,
+        );
+        let (target, confidence, resolution) =
+            resolved.unwrap_or_else(|| panic!("{receiver} must override external suppression"));
+        assert_eq!(target.id, symbols[0].id);
+        assert_eq!(confidence, EdgeConfidence::Syntactic);
+        assert_eq!(resolution, "target_name_fallback");
+    }
+}
+
+#[test]
+fn swift_self_and_super_init_calls_resolve_to_constructors() {
+    let conn = seeded_conn();
+    let source = add_file(&conn, "Child.swift", NEW);
+    conn.execute("UPDATE main.files SET language = 'swift' WHERE id = ?1", [source]).unwrap();
+    let definitions = add_file(&conn, "Parent.swift", NEW);
+    conn.execute("UPDATE main.files SET language = 'swift' WHERE id = ?1", [definitions]).unwrap();
+    let init = add_symbol_kind_language(
+        &conn,
+        definitions,
+        "init",
+        "Parent.swift::init",
+        "constructor",
+        Language::Swift,
+    );
+    let calls = ["Self", "self", "super"].map(|receiver| {
+        conn.execute(
+            "INSERT INTO edges(source_file_id, to_name, edge_kind, confidence, resolution, \
+             receiver_hint) VALUES (?1, 'init', 'calls_name', 'NameOnly', 'unresolved', ?2)",
+            params![source, receiver],
+        )
+        .unwrap();
+        conn.query_row("SELECT MAX(id) FROM edges_data", [], |row| row.get(0)).unwrap()
+    });
+
+    crate::index::install_scope_view(&conn, NEW, "").unwrap();
+    resolve_all_edges(&conn).unwrap();
+
+    for call in calls {
+        let (to, confidence, resolution) = edge_state(&conn, call);
+        assert_eq!(to, Some(init));
+        assert_eq!(confidence, "Syntactic");
+        assert_eq!(resolution, "target_name_fallback");
+    }
+}
+
+#[test]
+fn swift_enum_constructions_resolve_to_enum_symbols() {
+    let conn = seeded_conn();
+    let source = add_file(&conn, "Caller.swift", NEW);
+    conn.execute("UPDATE main.files SET language = 'swift' WHERE id = ?1", [source]).unwrap();
+    add_symbol_kind_language(
+        &conn,
+        source,
+        "caller",
+        "Caller.swift::caller",
+        "function",
+        Language::Swift,
+    );
+    let definitions = add_file(&conn, "Status.swift", NEW);
+    conn.execute("UPDATE main.files SET language = 'swift' WHERE id = ?1", [definitions]).unwrap();
+    let status = add_symbol_kind_language(
+        &conn,
+        definitions,
+        "Status",
+        "Status.swift::Status",
+        "enum",
+        Language::Swift,
+    );
+    let construction = add_named_edge(&conn, source, "Status", EdgeKind::Constructs);
+
+    crate::index::install_scope_view(&conn, NEW, "").unwrap();
+    resolve_all_edges(&conn).unwrap();
+
+    let (to, confidence, resolution) = edge_state(&conn, construction);
+    assert_eq!(to, Some(status));
+    assert_eq!(confidence, "Syntactic");
+    assert_eq!(resolution, "target_name_fallback");
+}
+
+#[test]
+fn swift_overloads_do_not_collapse_to_one_logical_variant() {
+    let mut by_id = preferred_candidate(1, Language::Swift, "function");
+    by_id.name = "fetch".to_string();
+    by_id.qualified_name = "Service.swift::fetch".to_string();
+    by_id.scope_path = "Service::fetch".to_string();
+    by_id.start_byte = 10;
+    by_id.end_byte = 30;
+
+    let mut by_name = by_id.clone();
+    by_name.id = 2;
+    by_name.start_byte = 40;
+    by_name.end_byte = 65;
+
+    assert!(
+        !same_logical_symbol(&[&by_id, &by_name]),
+        "same-name Swift overloads must remain ambiguous until signatures enter stored identity"
+    );
 }
 
 /// #61: a `references_type` reference resolves only to a type DEFINITION. When the sole
@@ -178,8 +705,8 @@ fn references_type_does_not_resolve_to_a_non_type_symbol() {
     let conn = seeded_conn();
     let user = add_file(&conn, "a.rs", NEW);
     let defs = add_file(&conn, "b.rs", NEW);
-    // A symbol in the source file so the index knows it's Rust (source_language drives the
-    // type/value-namespace strictness; a real source file always has at least the caller).
+    // The source function owns the type-reference edges; `files.language` selects Rust's strict
+    // type namespace policy.
     add_symbol(&conn, user, "user_fn", "crate::a::user_fn");
     // Only same-named candidate for `Widget` is an impl block (no struct/enum/trait in-corpus).
     add_symbol_kind(&conn, defs, "Widget", "crate::b::Widget", "impl");
@@ -311,14 +838,33 @@ fn add_symbol_scope(
     qualified: &str,
     scope_path: &str,
 ) -> i64 {
+    add_symbol_scope_language(
+        conn,
+        file_id,
+        name,
+        qualified,
+        scope_path,
+        "function",
+        Language::Rust,
+    )
+}
+
+fn add_symbol_scope_language(
+    conn: &Connection,
+    file_id: i64,
+    name: &str,
+    qualified: &str,
+    scope_path: &str,
+    kind: &str,
+    language: Language,
+) -> i64 {
     conn.execute("INSERT OR IGNORE INTO name_strings(value) VALUES (?1)", params![qualified])
         .unwrap();
     conn.execute(
         "INSERT INTO symbols(file_id, language, name, qualified_name_id, scope_path, kind, \
          start_byte, end_byte, start_line, end_line)
-         VALUES (?1, 'rust', ?2, (SELECT id FROM name_strings WHERE value = ?3), ?4, 'function', \
-         0, 10, 1, 1)",
-        params![file_id, name, qualified, scope_path],
+         VALUES (?1, ?2, ?3, (SELECT id FROM name_strings WHERE value = ?4), ?5, ?6, 0, 10, 1, 1)",
+        params![file_id, language.as_str(), name, qualified, scope_path, kind],
     )
     .unwrap();
     conn.last_insert_rowid()
@@ -742,9 +1288,7 @@ fn python_implements_prefers_a_base_class_over_a_non_class() {
     let sub = py_source(&conn, "sub.py");
     let base = py_source(&conn, "base.py");
     let other = py_source(&conn, "other.py");
-    // A symbol in sub.py so the resolver knows the reference's source language is Python (a file's
-    // language is inferred from its symbols, and the language-scoped `implements` preference is
-    // what this exercises).
+    // The subclass declaration owns the edge; `files.language` selects Python's class preference.
     py_sym(&conn, sub, "Sub", "sub.py::Sub", "class");
     // The real base class, and a DECOY same-named non-class (a module-level function `Base`).
     let base_class = py_sym(&conn, base, "Base", "base.py::Base", "class");

--- a/crates/rag-rat-core/src/index/ignore_rules.rs
+++ b/crates/rag-rat-core/src/index/ignore_rules.rs
@@ -67,6 +67,9 @@ const FLOOR_DIRS: &[&str] = &[
     "target",
     "dist",
     "build",
+    // SwiftPM's build tree contains generated output and dependency checkouts whose nested
+    // `Sources/` directories otherwise look indistinguishable from first-party Swift packages.
+    ".build",
     "coverage",
     // Python virtualenv / dependency / cache trees: never project source. `site-packages` is the
     // load-bearing one — installed deps live there regardless of the venv dir's name (`.venv`,
@@ -441,6 +444,7 @@ mod tests {
         assert!(m.is_ignored(&tmp.join(".claude/settings.json"), false));
         assert!(m.is_ignored(&tmp.join(".codex/config.toml"), false));
         assert!(m.is_ignored(&tmp.join("node_modules/pkg/index.ts"), false));
+        assert!(m.is_ignored(&tmp.join(".build/checkouts/Dep/Sources/Dep.swift"), false));
         assert!(!m.is_ignored(&tmp.join("src/lib.rs"), false));
         fs::remove_dir_all(&tmp).ok();
     }

--- a/crates/rag-rat-core/src/index/ignore_rules.rs
+++ b/crates/rag-rat-core/src/index/ignore_rules.rs
@@ -70,6 +70,12 @@ const FLOOR_DIRS: &[&str] = &[
     // SwiftPM's build tree contains generated output and dependency checkouts whose nested
     // `Sources/` directories otherwise look indistinguishable from first-party Swift packages.
     ".build",
+    // CocoaPods' vendored dependency tree — the same hazard as `.build/checkouts`, and worse for
+    // an app with no `Sources/`-style layout (root `AppDelegate.swift`), where the Swift
+    // target can fall back to `.` and swallow every pod's source as first-party. Flooring it
+    // here covers BOTH the `init` scan and the indexer, which is why the floor is the right
+    // seam: excluding it in only one of them leaves the other ingesting vendored code.
+    "Pods",
     "coverage",
     // Python virtualenv / dependency / cache trees: never project source. `site-packages` is the
     // load-bearing one — installed deps live there regardless of the venv dir's name (`.venv`,

--- a/crates/rag-rat-core/src/index/languages/c_family/edges.rs
+++ b/crates/rag-rat-core/src/index/languages/c_family/edges.rs
@@ -1,6 +1,10 @@
-//! C / C++ graph-edge extraction — the `Language::C | Language::Cpp` arm of `syntactic_edges`.
-//! Split out of edges/extract.
-use super::*;
+//! C and C++ graph-edge extraction for the shared structural edge walk.
+use std::path::Path;
+
+use tree_sitter::Node;
+
+use crate::index::edges::extract::*;
+use crate::index::edges::*;
 
 pub(super) fn c_like_edges(
     text: &str,

--- a/crates/rag-rat-core/src/index/languages/c_family/mod.rs
+++ b/crates/rag-rat-core/src/index/languages/c_family/mod.rs
@@ -1,0 +1,134 @@
+use std::path::Path;
+
+use tree_sitter::Node;
+
+use super::{EdgeBackend, ParserBackend, ResolverPolicy, SymbolMatch};
+use crate::index::edges::{EdgeCandidate, IndexedSymbol};
+use crate::index::parser::{self, ParserKind};
+
+mod edges;
+
+pub(super) static C_SUPPORT: C = C;
+pub(super) static CPP_SUPPORT: Cpp = Cpp;
+
+pub(super) struct C;
+pub(super) struct Cpp;
+
+impl ParserBackend for C {
+    fn parser_kind(&self, _path: &Path) -> ParserKind {
+        ParserKind::C
+    }
+
+    fn symbol_node<'tree>(&self, node: Node<'tree>, _text: &str) -> Option<SymbolMatch<'tree>> {
+        // Index definitions, not prototypes/forward declarations/uses: otherwise type-reference
+        // edges bind to the tiny declaration occurrence instead of the real definition (#61).
+        match node.kind() {
+            "function_definition" =>
+                Some(("function", function_name(node).or_else(|| parser::child_name(node))?)),
+            "struct_specifier" if has_body(node) => Some(("struct", parser::child_name(node)?)),
+            "union_specifier" if has_body(node) => Some(("union", parser::child_name(node)?)),
+            "enum_specifier" if has_body(node) => Some(("enum", parser::child_name(node)?)),
+            "type_definition" => Some(("type", parser::child_name(node)?)),
+            "preproc_function_def" => Some(("macro", parser::child_name(node)?)),
+            _ => None,
+        }
+    }
+
+    fn scope_segment(&self, node: Node<'_>, text: &str) -> Option<String> {
+        match node.kind() {
+            "struct_specifier" | "union_specifier" if has_body(node) =>
+                parser::node_text(parser::child_name(node)?, text),
+            _ => None,
+        }
+    }
+
+    fn is_plumbing_node(&self, node: Node<'_>) -> bool {
+        node.kind().contains("comment") || node.kind() == "preproc_include"
+    }
+}
+
+impl ParserBackend for Cpp {
+    fn parser_kind(&self, _path: &Path) -> ParserKind {
+        ParserKind::Cpp
+    }
+
+    fn symbol_node<'tree>(&self, node: Node<'tree>, _text: &str) -> Option<SymbolMatch<'tree>> {
+        // As for C, bodyless declarations are deliberately not symbols (#61).
+        match node.kind() {
+            "function_definition" =>
+                Some(("function", function_name(node).or_else(|| parser::child_name(node))?)),
+            "class_specifier" if has_body(node) => Some(("class", parser::child_name(node)?)),
+            "struct_specifier" if has_body(node) => Some(("struct", parser::child_name(node)?)),
+            "union_specifier" if has_body(node) => Some(("union", parser::child_name(node)?)),
+            "enum_specifier" if has_body(node) => Some(("enum", parser::child_name(node)?)),
+            "type_definition" | "alias_declaration" => Some(("type", parser::child_name(node)?)),
+            "namespace_definition" => Some(("namespace", parser::child_name(node)?)),
+            "preproc_function_def" => Some(("macro", parser::child_name(node)?)),
+            _ => None,
+        }
+    }
+
+    fn scope_segment(&self, node: Node<'_>, text: &str) -> Option<String> {
+        let name = match node.kind() {
+            "namespace_definition" => parser::child_name(node)?,
+            "struct_specifier" | "union_specifier" | "class_specifier" if has_body(node) =>
+                parser::child_name(node)?,
+            _ => return None,
+        };
+        parser::node_text(name, text)
+    }
+
+    fn is_plumbing_node(&self, node: Node<'_>) -> bool {
+        node.kind().contains("comment") || node.kind() == "preproc_include"
+    }
+}
+
+fn has_body(node: Node<'_>) -> bool {
+    node.child_by_field_name("body").is_some()
+}
+
+fn function_name(node: Node<'_>) -> Option<Node<'_>> {
+    let declarator = parser::first_descendant_node(node, &["function_declarator"]).unwrap_or(node);
+    let name_root = declarator.child_by_field_name("declarator").unwrap_or(declarator);
+    if parser::NAME_KINDS.contains(&name_root.kind()) {
+        return Some(name_root);
+    }
+    parser::last_descendant_node(name_root, parser::NAME_KINDS)
+}
+
+macro_rules! impl_edges {
+    ($backend:ty) => {
+        impl EdgeBackend for $backend {
+            fn edges(
+                &self,
+                text: &str,
+                node: Node<'_>,
+                symbols: &[IndexedSymbol],
+                path: &Path,
+                out: &mut Vec<EdgeCandidate>,
+            ) {
+                edges::c_like_edges(text, node, symbols, path, out);
+            }
+        }
+    };
+}
+
+impl_edges!(C);
+impl_edges!(Cpp);
+
+macro_rules! impl_resolver_policy {
+    ($backend:ty) => {
+        impl ResolverPolicy for $backend {
+            fn preferred_kinds(&self, _edge_kind: &str) -> Option<super::KindPreference> {
+                None
+            }
+
+            fn type_reference_requires_type_definition(&self) -> bool {
+                true
+            }
+        }
+    };
+}
+
+impl_resolver_policy!(C);
+impl_resolver_policy!(Cpp);

--- a/crates/rag-rat-core/src/index/languages/c_family/mod.rs
+++ b/crates/rag-rat-core/src/index/languages/c_family/mod.rs
@@ -15,6 +15,10 @@ pub(super) struct C;
 pub(super) struct Cpp;
 
 impl ParserBackend for C {
+    fn symbol_kinds(&self) -> &'static [&'static str] {
+        &["enum", "function", "macro", "struct", "type", "union"]
+    }
+
     fn parser_kind(&self, _path: &Path) -> ParserKind {
         ParserKind::C
     }
@@ -48,6 +52,10 @@ impl ParserBackend for C {
 }
 
 impl ParserBackend for Cpp {
+    fn symbol_kinds(&self) -> &'static [&'static str] {
+        &["class", "enum", "function", "macro", "namespace", "struct", "type", "union"]
+    }
+
     fn parser_kind(&self, _path: &Path) -> ParserKind {
         ParserKind::Cpp
     }

--- a/crates/rag-rat-core/src/index/languages/kotlin/edges.rs
+++ b/crates/rag-rat-core/src/index/languages/kotlin/edges.rs
@@ -1,6 +1,10 @@
-//! Kotlin graph-edge extraction — the `Language::Kotlin` arm of `syntactic_edges`.
-//! Split out of edges/extract.
-use super::*;
+//! Kotlin graph-edge extraction for the shared structural edge walk.
+use std::path::Path;
+
+use tree_sitter::Node;
+
+use crate::index::edges::extract::*;
+use crate::index::edges::*;
 
 pub(super) fn kotlin_edges(
     text: &str,

--- a/crates/rag-rat-core/src/index/languages/kotlin/mod.rs
+++ b/crates/rag-rat-core/src/index/languages/kotlin/mod.rs
@@ -1,0 +1,123 @@
+use std::path::Path;
+
+use tree_sitter::Node;
+
+use super::{EdgeBackend, ParserBackend, ResolverPolicy, SymbolMatch};
+use crate::index::edges::{EdgeCandidate, IndexedSymbol};
+use crate::index::parser::{self, ParserKind};
+
+mod edges;
+
+pub(super) static SUPPORT: Kotlin = Kotlin;
+
+pub(super) struct Kotlin;
+
+impl ParserBackend for Kotlin {
+    fn parser_kind(&self, _path: &Path) -> ParserKind {
+        ParserKind::Kotlin
+    }
+
+    fn symbol_node<'tree>(&self, node: Node<'tree>, _text: &str) -> Option<SymbolMatch<'tree>> {
+        match node.kind() {
+            "class_declaration" => Some(("class", parser::child_name(node)?)),
+            "object_declaration" => Some(("object", parser::child_name(node)?)),
+            "function_declaration" => Some(("function", parser::child_name(node)?)),
+            "property_declaration" => Some(("property", property_name(node)?)),
+            "companion_object" | "companion_object_declaration" =>
+                Some(("object", companion_name(node).unwrap_or(node))),
+            _ => None,
+        }
+    }
+
+    fn scope_segment(&self, node: Node<'_>, text: &str) -> Option<String> {
+        match node.kind() {
+            "class_declaration" | "object_declaration" =>
+                parser::node_text(parser::child_name(node)?, text),
+            _ => None,
+        }
+    }
+
+    fn is_test_symbol(&self, text: &str, node: Node<'_>, _scope_path: &str, _name: &str) -> bool {
+        let mut cursor = node.walk();
+        node.named_children(&mut cursor).any(|child| {
+            child.kind() == "modifiers"
+                && parser::node_text(child, text)
+                    .as_deref()
+                    .is_some_and(modifiers_have_test_annotation)
+        })
+    }
+
+    fn is_plumbing_node(&self, node: Node<'_>) -> bool {
+        node.kind().contains("comment") || matches!(node.kind(), "import_header" | "package_header")
+    }
+}
+
+fn modifiers_have_test_annotation(modifiers: &str) -> bool {
+    modifiers.split('@').skip(1).any(|annotation| {
+        let name = annotation.split(['(', ' ', '\n', '\t', '\r']).next().unwrap_or_default();
+        let last = name.rsplit('.').next().unwrap_or(name);
+        matches!(last, "Test" | "ParameterizedTest" | "RepeatedTest" | "TestFactory")
+    })
+}
+
+fn companion_name(node: Node<'_>) -> Option<Node<'_>> {
+    for index in 0..node.child_count() {
+        let Some(index) = u32::try_from(index).ok() else {
+            continue;
+        };
+        if let Some(child) = node.child(index)
+            && child.kind() == "companion"
+        {
+            return Some(child);
+        }
+    }
+    let mut cursor = node.walk();
+    node.named_children(&mut cursor)
+        .find(|child| matches!(child.kind(), "simple_identifier" | "type_identifier"))
+}
+
+fn property_name(node: Node<'_>) -> Option<Node<'_>> {
+    parser::child_name(variable_declaration(node).unwrap_or(node))
+}
+
+fn variable_declaration(node: Node<'_>) -> Option<Node<'_>> {
+    crate::index::grow_stack(|| {
+        let mut cursor = node.walk();
+        node.named_children(&mut cursor).find_map(|child| {
+            if child.kind() == "variable_declaration" {
+                Some(child)
+            } else if matches!(child.kind(), "modifiers" | "type_parameters" | "type_constraints") {
+                None
+            } else {
+                variable_declaration(child)
+            }
+        })
+    })
+}
+
+impl EdgeBackend for Kotlin {
+    fn edges(
+        &self,
+        text: &str,
+        node: Node<'_>,
+        symbols: &[IndexedSymbol],
+        path: &Path,
+        out: &mut Vec<EdgeCandidate>,
+    ) {
+        edges::kotlin_edges(text, node, symbols, path, out);
+    }
+}
+
+impl ResolverPolicy for Kotlin {
+    fn preferred_kinds(&self, _edge_kind: &str) -> Option<super::KindPreference> {
+        None
+    }
+
+    fn allow_type_receiver_fallback(&self) -> bool {
+        true
+    }
+
+    fn allow_value_receiver_fallback(&self) -> bool {
+        true
+    }
+}

--- a/crates/rag-rat-core/src/index/languages/kotlin/mod.rs
+++ b/crates/rag-rat-core/src/index/languages/kotlin/mod.rs
@@ -13,6 +13,10 @@ pub(super) static SUPPORT: Kotlin = Kotlin;
 pub(super) struct Kotlin;
 
 impl ParserBackend for Kotlin {
+    fn symbol_kinds(&self) -> &'static [&'static str] {
+        &["class", "function", "object", "property"]
+    }
+
     fn parser_kind(&self, _path: &Path) -> ParserKind {
         ParserKind::Kotlin
     }

--- a/crates/rag-rat-core/src/index/languages/markdown/mod.rs
+++ b/crates/rag-rat-core/src/index/languages/markdown/mod.rs
@@ -10,6 +10,11 @@ pub(super) static SUPPORT: Markdown = Markdown;
 pub(super) struct Markdown;
 
 impl ParserBackend for Markdown {
+    /// Prose is chunked, never symbolized — markdown emits no declarations.
+    fn symbol_kinds(&self) -> &'static [&'static str] {
+        &[]
+    }
+
     fn parser_kind(&self, _path: &Path) -> ParserKind {
         ParserKind::Markdown
     }

--- a/crates/rag-rat-core/src/index/languages/markdown/mod.rs
+++ b/crates/rag-rat-core/src/index/languages/markdown/mod.rs
@@ -1,0 +1,28 @@
+use std::path::Path;
+
+use tree_sitter::Node;
+
+use super::{ParserBackend, SymbolMatch};
+use crate::index::parser::ParserKind;
+
+pub(super) static SUPPORT: Markdown = Markdown;
+
+pub(super) struct Markdown;
+
+impl ParserBackend for Markdown {
+    fn parser_kind(&self, _path: &Path) -> ParserKind {
+        ParserKind::Markdown
+    }
+
+    fn symbol_node<'tree>(&self, _node: Node<'tree>, _text: &str) -> Option<SymbolMatch<'tree>> {
+        None
+    }
+
+    fn scope_segment(&self, _node: Node<'_>, _text: &str) -> Option<String> {
+        None
+    }
+
+    fn is_plumbing_node(&self, _node: Node<'_>) -> bool {
+        true
+    }
+}

--- a/crates/rag-rat-core/src/index/languages/mod.rs
+++ b/crates/rag-rat-core/src/index/languages/mod.rs
@@ -121,6 +121,17 @@ pub(super) trait ResolverPolicy: Sync {
         false
     }
 
+    /// A target kind the BARE-NAME fallback may bind only when the reference itself carried no
+    /// qualifier and no receiver — i.e. only for the syntactic shape that is actual evidence for
+    /// that kind.
+    ///
+    /// The qualified/receiver-bearing shapes are unaffected: they resolve through the qualified
+    /// path (`Status.idle` → the `Status::idle` case) and only fall back to the bare name when
+    /// that path finds nothing — which is exactly where a wrong bind would be manufactured.
+    fn kind_requires_unqualified_reference(&self, _edge_kind: &str, _target_kind: &str) -> bool {
+        false
+    }
+
     fn suppress_unresolved_reference(&self, _edge_kind: &str, _evidence: Option<&str>) -> bool {
         false
     }

--- a/crates/rag-rat-core/src/index/languages/mod.rs
+++ b/crates/rag-rat-core/src/index/languages/mod.rs
@@ -4,6 +4,8 @@
 //! resolver policy in one package. The parser walk, edge walk, and resolver orchestration stay in
 //! their subsystem modules and depend only on the narrow traits defined here.
 
+#[cfg(test)]
+use std::collections::BTreeSet;
 use std::path::Path;
 
 use tree_sitter::Node;
@@ -26,6 +28,16 @@ pub(super) type SymbolMatch<'tree> = (&'static str, Node<'tree>);
 /// walk.
 pub(super) trait ParserBackend: Sync {
     fn parser_kind(&self, path: &Path) -> ParserKind;
+
+    /// Every symbol kind this backend can emit — the declared contract behind [`all_symbol_kinds`].
+    ///
+    /// Required (not defaulted) on purpose: downstream consumers rank and filter by symbol kind,
+    /// and a kind nobody downstream knows about silently sorts into the "unknown" bucket.
+    /// Making this part of the trait means a new language cannot be added without stating its
+    /// kinds, and `symbol_kind_rank_covers_every_indexed_kind` then fails until the ranking
+    /// accounts for them. The parser walk debug-asserts that what a backend emits is what it
+    /// declared here.
+    fn symbol_kinds(&self) -> &'static [&'static str];
 
     fn symbol_node<'tree>(&self, node: Node<'tree>, text: &str) -> Option<SymbolMatch<'tree>>;
 
@@ -213,6 +225,24 @@ pub(super) fn resolver_policy_for_name(
 
 pub(super) fn is_plumbing_node(language: Language, node: Node<'_>) -> bool {
     parser_backend(language).is_plumbing_node(node)
+}
+
+/// Every symbol kind ANY registered language can emit, deduplicated and sorted — the single source
+/// of truth for the completeness tests guarding downstream code that must handle the full kind
+/// universe (today: the `symbol_lookup` kind ranking). Derived from the backends themselves, so
+/// registering a language adds its kinds here automatically and the consumers' completeness tests
+/// fail until they account for them.
+///
+/// Test-only: the production consumer is a static table, and this exists to PROVE that table covers
+/// the registry. [`ParserBackend::symbol_kinds`] itself is live in every build — the parser walk
+/// debug-asserts each emitted kind against it.
+#[cfg(test)]
+pub(crate) fn all_symbol_kinds() -> BTreeSet<&'static str> {
+    Language::all()
+        .iter()
+        .flat_map(|&language| parser_backend(language).symbol_kinds())
+        .copied()
+        .collect()
 }
 
 pub(super) fn requires_same_language_target(

--- a/crates/rag-rat-core/src/index/languages/mod.rs
+++ b/crates/rag-rat-core/src/index/languages/mod.rs
@@ -1,0 +1,250 @@
+//! Structural language implementations.
+//!
+//! Each language owns its grammar-specific parser classification, edge extraction, and optional
+//! resolver policy in one package. The parser walk, edge walk, and resolver orchestration stay in
+//! their subsystem modules and depend only on the narrow traits defined here.
+
+use std::path::Path;
+
+use tree_sitter::Node;
+
+use super::edges::{EdgeCandidate, IndexedSymbol};
+use super::parser::ParserKind;
+use crate::language::Language;
+
+mod c_family;
+mod kotlin;
+mod markdown;
+mod python;
+mod rust;
+mod swift;
+mod typescript;
+
+pub(super) type SymbolMatch<'tree> = (&'static str, Node<'tree>);
+
+/// Grammar-specific declaration and scope recognition for one node visited by the shared parser
+/// walk.
+pub(super) trait ParserBackend: Sync {
+    fn parser_kind(&self, path: &Path) -> ParserKind;
+
+    fn symbol_node<'tree>(&self, node: Node<'tree>, text: &str) -> Option<SymbolMatch<'tree>>;
+
+    fn symbol_name(&self, _node: Node<'_>, name_node: Node<'_>, text: &str) -> String {
+        super::parser::node_text(name_node, text).unwrap_or_default()
+    }
+
+    fn for_each_symbol<'tree>(
+        &self,
+        node: Node<'tree>,
+        text: &str,
+        emit: &mut dyn FnMut(Node<'tree>, SymbolMatch<'tree>),
+    ) {
+        if let Some(symbol) = self.symbol_node(node, text) {
+            emit(node, symbol);
+        }
+    }
+
+    fn for_each_recovered_symbol<'tree>(
+        &self,
+        _node: Node<'tree>,
+        _text: &str,
+        _emit: &mut dyn FnMut(Node<'tree>, SymbolMatch<'tree>),
+    ) {
+    }
+
+    fn scope_segment(&self, node: Node<'_>, text: &str) -> Option<String>;
+
+    fn is_test_symbol(&self, _text: &str, _node: Node<'_>, _scope_path: &str, _name: &str) -> bool {
+        false
+    }
+
+    fn signature_source_node<'tree>(&self, node: Node<'tree>) -> Node<'tree> {
+        node
+    }
+
+    fn symbol_facts(&self, _text: &str, _node: Node<'_>) -> Vec<super::parser::ParsedSymbolFact> {
+        Vec::new()
+    }
+
+    fn is_plumbing_node(&self, node: Node<'_>) -> bool {
+        node.kind().contains("comment")
+    }
+}
+
+/// Grammar-specific edge recognition for one node visited by the shared depth-safe edge walk.
+pub(super) trait EdgeBackend: Sync {
+    fn edges(
+        &self,
+        text: &str,
+        node: Node<'_>,
+        symbols: &[IndexedSymbol],
+        path: &Path,
+        out: &mut Vec<EdgeCandidate>,
+    );
+}
+
+#[derive(Clone, Copy)]
+pub(super) struct KindPreference {
+    pub(super) symbol_kinds: &'static [&'static str],
+    pub(super) same_language_only: bool,
+}
+
+/// Language-semantic resolution rules that cannot be derived from generic symbol kinds.
+pub(super) trait ResolverPolicy: Sync {
+    fn preferred_kinds(&self, edge_kind: &str) -> Option<KindPreference>;
+
+    fn collapse_same_named_declarations(&self) -> bool {
+        true
+    }
+
+    fn import_edges_carry_aliases(&self) -> bool {
+        false
+    }
+
+    fn rebind_import_alias(&self, _request: ImportAliasRequest<'_>) -> ImportAliasRebind {
+        ImportAliasRebind::default()
+    }
+
+    fn reference_is_unresolvable(&self, _edge_kind: &str, _name: &str) -> bool {
+        false
+    }
+
+    fn suppress_unresolved_reference(&self, _edge_kind: &str, _evidence: Option<&str>) -> bool {
+        false
+    }
+
+    fn type_reference_requires_type_definition(&self) -> bool {
+        false
+    }
+
+    fn allow_type_receiver_fallback(&self) -> bool {
+        false
+    }
+
+    fn allow_value_receiver_fallback(&self) -> bool {
+        false
+    }
+
+    fn rejects_qualified_root(&self, _root: &str) -> bool {
+        false
+    }
+
+    fn is_local_qualified_root(&self, _root: &str) -> bool {
+        false
+    }
+}
+
+pub(super) struct ImportAliasRequest<'a> {
+    pub(super) to_name: &'a str,
+    pub(super) target_qualified_name: Option<&'a str>,
+    pub(super) receiver_hint: Option<&'a str>,
+    pub(super) lookup: &'a mut dyn FnMut(&str) -> Option<String>,
+}
+
+#[derive(Default)]
+pub(super) struct ImportAliasRebind {
+    pub(super) name: Option<String>,
+    pub(super) target_qualified_name: Option<String>,
+    pub(super) receiver_hint: Option<String>,
+}
+
+pub(super) fn target_matches_policy(
+    source_language: Option<&str>,
+    edge_kind: &str,
+    target_language: &str,
+    target_kind: &str,
+) -> bool {
+    let Some(source_language) = source_language.and_then(|name| name.parse::<Language>().ok())
+    else {
+        return true;
+    };
+    let Some(preference) =
+        resolver_policy(source_language).and_then(|policy| policy.preferred_kinds(edge_kind))
+    else {
+        return true;
+    };
+    (!preference.same_language_only || target_language == source_language.as_str())
+        && preference.symbol_kinds.contains(&target_kind)
+}
+
+pub(super) fn parser_backend(language: Language) -> &'static dyn ParserBackend {
+    match language {
+        Language::Rust => &rust::SUPPORT,
+        Language::TypeScript => &typescript::SUPPORT,
+        Language::Kotlin => &kotlin::SUPPORT,
+        Language::C => &c_family::C_SUPPORT,
+        Language::Cpp => &c_family::CPP_SUPPORT,
+        Language::Python => &python::SUPPORT,
+        Language::Swift => &swift::SUPPORT,
+        Language::Markdown => &markdown::SUPPORT,
+    }
+}
+
+pub(super) fn edge_backend(language: Language) -> Option<&'static dyn EdgeBackend> {
+    match language {
+        Language::Rust => Some(&rust::SUPPORT),
+        Language::TypeScript => Some(&typescript::SUPPORT),
+        Language::Kotlin => Some(&kotlin::SUPPORT),
+        Language::C => Some(&c_family::C_SUPPORT),
+        Language::Cpp => Some(&c_family::CPP_SUPPORT),
+        Language::Python => Some(&python::SUPPORT),
+        Language::Swift => Some(&swift::SUPPORT),
+        Language::Markdown => None,
+    }
+}
+
+pub(super) fn resolver_policy(language: Language) -> Option<&'static dyn ResolverPolicy> {
+    match language {
+        Language::Rust => Some(&rust::SUPPORT),
+        Language::Kotlin => Some(&kotlin::SUPPORT),
+        Language::C => Some(&c_family::C_SUPPORT),
+        Language::Cpp => Some(&c_family::CPP_SUPPORT),
+        Language::Python => Some(&python::SUPPORT),
+        Language::Swift => Some(&swift::SUPPORT),
+        _ => None,
+    }
+}
+
+pub(super) fn resolver_policy_for_name(
+    language: Option<&str>,
+) -> Option<&'static dyn ResolverPolicy> {
+    language.and_then(|name| name.parse::<Language>().ok()).and_then(resolver_policy)
+}
+
+pub(super) fn is_plumbing_node(language: Language, node: Node<'_>) -> bool {
+    parser_backend(language).is_plumbing_node(node)
+}
+
+pub(super) fn requires_same_language_target(
+    source_language: Option<&str>,
+    edge_kind: &str,
+) -> bool {
+    source_language
+        .and_then(|language| language.parse::<Language>().ok())
+        .and_then(resolver_policy)
+        .and_then(|policy| policy.preferred_kinds(edge_kind))
+        .is_some_and(|preference| preference.same_language_only)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use super::{edge_backend, parser_backend};
+    use crate::index::parser::{self, ParserKind};
+    use crate::language::Language;
+
+    #[test]
+    fn registry_agrees_with_structural_capabilities() {
+        for &language in Language::all() {
+            let path = match language {
+                Language::TypeScript => Path::new("src/App.tsx"),
+                _ => Path::new("src/file"),
+            };
+            let kind = parser_backend(language).parser_kind(path);
+            assert_eq!(kind == ParserKind::Markdown, language == Language::Markdown);
+            assert_eq!(parser::grammar_for(kind).is_some(), language != Language::Markdown);
+            assert_eq!(edge_backend(language).is_some(), language != Language::Markdown);
+        }
+    }
+}

--- a/crates/rag-rat-core/src/index/languages/python/edges.rs
+++ b/crates/rag-rat-core/src/index/languages/python/edges.rs
@@ -1,9 +1,12 @@
-//! Python graph-edge extraction — the `Language::Python` arm of `syntactic_edges`, split out
-//! of the edges/extract god-module. `python_edges` walks the CST; the `python_*` helpers +
-//! `emit_python_type_refs` are its closed-recognizer internals (PEP 604 unions, the
-//! static-base allowlist, relative-import normalization). The CST-edge design principles and
-//! the #172/#... Python bug patterns are captured as repo memories bound here and on the parent.
-use super::*;
+//! Python graph-edge extraction, co-located with Python's parser and resolver policy.
+//! `python_edges` walks the CST. Its private helpers recognize PEP 604 unions, static base types,
+//! and relative imports.
+use std::path::Path;
+
+use tree_sitter::Node;
+
+use crate::index::edges::extract::*;
+use crate::index::edges::*;
 
 pub(super) fn python_edges(
     text: &str,
@@ -584,7 +587,7 @@ fn python_import_target(
 mod python_edge_tests {
     use std::path::Path;
 
-    use super::super::*;
+    use super::*;
     use crate::language::Language;
 
     fn edges(src: &str) -> Vec<EdgeCandidate> {

--- a/crates/rag-rat-core/src/index/languages/python/mod.rs
+++ b/crates/rag-rat-core/src/index/languages/python/mod.rs
@@ -1,0 +1,176 @@
+use std::path::Path;
+
+use tree_sitter::Node;
+
+use super::{
+    EdgeBackend, ImportAliasRebind, ImportAliasRequest, KindPreference, ParserBackend,
+    ResolverPolicy, SymbolMatch,
+};
+use crate::index::edges::{EdgeCandidate, IndexedSymbol};
+use crate::index::parser::{self, ParserKind};
+
+mod edges;
+
+pub(super) static SUPPORT: Python = Python;
+
+pub(super) struct Python;
+
+impl ParserBackend for Python {
+    fn parser_kind(&self, _path: &Path) -> ParserKind {
+        ParserKind::Python
+    }
+
+    fn symbol_node<'tree>(&self, node: Node<'tree>, text: &str) -> Option<SymbolMatch<'tree>> {
+        match node.kind() {
+            // The decorated node owns the span so API-defining decorators stay in the chunk; its
+            // inner declaration supplies the name and signature source.
+            "decorated_definition" => {
+                let inner = node.child_by_field_name("definition")?;
+                let kind = match inner.kind() {
+                    "function_definition" => "function",
+                    "class_definition" => "class",
+                    _ => return None,
+                };
+                Some((kind, parser::child_name(inner)?))
+            },
+            "function_definition" if !parent_is_decorated(node) =>
+                Some(("function", parser::child_name(node)?)),
+            "class_definition" if !parent_is_decorated(node) =>
+                Some(("class", parser::child_name(node)?)),
+            "type_alias_statement" => Some(("type", parser::child_name(node)?)),
+            // Only module/class SCREAMING_SNAKE_CASE assignments are symbols, never uppercase
+            // function-local temporaries.
+            "assignment" if assignment_is_const_scope(node) => {
+                let target = node.child_by_field_name("left")?;
+                let name = parser::node_text(target, text)?;
+                (target.kind() == "identifier" && is_screaming_snake_case(&name))
+                    .then_some(("const", target))
+            },
+            _ => None,
+        }
+    }
+
+    fn scope_segment(&self, node: Node<'_>, text: &str) -> Option<String> {
+        match node.kind() {
+            "class_definition" | "function_definition" =>
+                parser::node_text(parser::child_name(node)?, text),
+            _ => None,
+        }
+    }
+
+    fn is_test_symbol(&self, _text: &str, _node: Node<'_>, scope_path: &str, name: &str) -> bool {
+        name.starts_with("test_") || scope_path_has_test_class(scope_path)
+    }
+
+    fn signature_source_node<'tree>(&self, node: Node<'tree>) -> Node<'tree> {
+        if node.kind() == "decorated_definition"
+            && let Some(inner) = node.child_by_field_name("definition")
+        {
+            return inner;
+        }
+        node
+    }
+
+    fn is_plumbing_node(&self, node: Node<'_>) -> bool {
+        node.kind().contains("comment")
+            || matches!(
+                node.kind(),
+                "import_statement"
+                    | "import_from_statement"
+                    | "future_import_statement"
+                    | "pass_statement"
+            )
+            || is_docstring_statement(node)
+    }
+}
+
+fn is_docstring_statement(node: Node<'_>) -> bool {
+    node.kind() == "expression_statement"
+        && node.named_child_count() == 1
+        && node.named_child(0).is_some_and(|child| child.kind() == "string")
+}
+
+fn scope_path_has_test_class(scope_path: &str) -> bool {
+    scope_path.split("::").any(|segment| {
+        segment.starts_with("Test") || segment.ends_with("Test") || segment.ends_with("TestCase")
+    })
+}
+
+fn is_screaming_snake_case(name: &str) -> bool {
+    name.chars().any(|c| c.is_ascii_uppercase())
+        && name.chars().all(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || c == '_')
+}
+
+fn parent_is_decorated(node: Node<'_>) -> bool {
+    node.parent().is_some_and(|parent| parent.kind() == "decorated_definition")
+}
+
+fn assignment_is_const_scope(node: Node<'_>) -> bool {
+    let mut ancestor = node.parent();
+    while let Some(current) = ancestor {
+        match current.kind() {
+            "function_definition" | "lambda" => return false,
+            "class_definition" | "module" => return true,
+            _ => ancestor = current.parent(),
+        }
+    }
+    false
+}
+
+impl EdgeBackend for Python {
+    fn edges(
+        &self,
+        text: &str,
+        node: Node<'_>,
+        symbols: &[IndexedSymbol],
+        path: &Path,
+        out: &mut Vec<EdgeCandidate>,
+    ) {
+        edges::python_edges(text, node, symbols, path, out);
+    }
+}
+
+impl ResolverPolicy for Python {
+    fn preferred_kinds(&self, edge_kind: &str) -> Option<KindPreference> {
+        (edge_kind == "implements").then_some(KindPreference {
+            symbol_kinds: &["class", "object"],
+            same_language_only: true,
+        })
+    }
+
+    fn import_edges_carry_aliases(&self) -> bool {
+        true
+    }
+
+    fn rebind_import_alias(&self, request: ImportAliasRequest<'_>) -> ImportAliasRebind {
+        match request.receiver_hint {
+            Some(receiver) => {
+                let Some(target) = (request.lookup)(receiver) else {
+                    return ImportAliasRebind::default();
+                };
+                ImportAliasRebind {
+                    name: None,
+                    target_qualified_name: request
+                        .target_qualified_name
+                        .map(|qualified| replace_qualified_root(qualified, &target)),
+                    receiver_hint: Some(target),
+                }
+            },
+            None => ImportAliasRebind {
+                name: (request.lookup)(short_name(request.to_name)),
+                ..ImportAliasRebind::default()
+            },
+        }
+    }
+}
+
+fn short_name(name: &str) -> &str {
+    name.rsplit("::").next().unwrap_or(name)
+}
+
+fn replace_qualified_root(qualified: &str, root: &str) -> String {
+    match qualified.split_once("::") {
+        Some((_, rest)) => format!("{root}::{rest}"),
+        None => root.to_string(),
+    }
+}

--- a/crates/rag-rat-core/src/index/languages/python/mod.rs
+++ b/crates/rag-rat-core/src/index/languages/python/mod.rs
@@ -16,6 +16,10 @@ pub(super) static SUPPORT: Python = Python;
 pub(super) struct Python;
 
 impl ParserBackend for Python {
+    fn symbol_kinds(&self) -> &'static [&'static str] {
+        &["class", "const", "function", "type"]
+    }
+
     fn parser_kind(&self, _path: &Path) -> ParserKind {
         ParserKind::Python
     }

--- a/crates/rag-rat-core/src/index/languages/rust/dispatch.rs
+++ b/crates/rag-rat-core/src/index/languages/rust/dispatch.rs
@@ -1,10 +1,12 @@
 //! Rust dispatch-edge synthesis (#200/#207/#208) — emits the actor-channel
-//! `dispatch_construct` / `dispatch_handle` graph facts, split out of edges/extract. `rust_edges`
+//! `dispatch_construct` / `dispatch_handle` graph facts. `rust_edges`
 //! calls the four `pub(super)` entry points (`enum_variant_key`, `dispatch_fact`,
 //! `scoped_identifier_in_value_position`, `rust_dispatch_handle_facts`); everything else is the
 //! CLOSED conservative handler-call recognizer (`result_handler_calls` & friends) whose
 //! false-edge-is-a-bug contract is documented in the repo memories bound here and on the parent.
-use super::*;
+use tree_sitter::Node;
+
+use crate::index::edges::*;
 
 /// PascalCase test for the enum/variant convention (#200): first char uppercase AND at least one
 /// lowercase — so `MlReq`/`Upsert` qualify but `new`, a SCREAMING `CONST`, and a bare `T` do not.

--- a/crates/rag-rat-core/src/index/languages/rust/edges.rs
+++ b/crates/rag-rat-core/src/index/languages/rust/edges.rs
@@ -1,7 +1,12 @@
-//! Rust graph-edge extraction — the `Language::Rust` arm of `syntactic_edges`. Walks the CST
-//! for calls/types/constructs/imports and the impl-header edges, and emits the dispatch facts
-//! through the sibling `rust_dispatch` module's entry points. Split out of edges/extract.
-use super::{rust_dispatch, *};
+//! Rust graph-edge extraction for the shared structural edge walk. It recognizes calls, types,
+//! constructions, imports, impl headers, and dispatch facts.
+use std::path::Path;
+
+use tree_sitter::Node;
+
+use super::dispatch;
+use crate::index::edges::extract::*;
+use crate::index::edges::*;
 
 pub(super) fn rust_edges(
     text: &str,
@@ -119,9 +124,9 @@ pub(super) fn rust_edges(
             // `crate`). `Foo::new()` / `T::CONST` are excluded (tail not PascalCase).
             if let Some(key) = node
                 .child_by_field_name("function")
-                .and_then(|f| rust_dispatch::enum_variant_key(f, text))
+                .and_then(|f| dispatch::enum_variant_key(f, text))
             {
-                out.push(rust_dispatch::dispatch_fact(
+                out.push(dispatch::dispatch_fact(
                     symbols,
                     node,
                     key,
@@ -134,11 +139,10 @@ pub(super) fn rust_edges(
         "struct_expression" =>
         // #200 dispatch construct fact: a struct enum-variant construction `Enum::Variant { .. }`.
         {
-            if let Some(key) = node
-                .child_by_field_name("name")
-                .and_then(|n| rust_dispatch::enum_variant_key(n, text))
+            if let Some(key) =
+                node.child_by_field_name("name").and_then(|n| dispatch::enum_variant_key(n, text))
             {
-                out.push(rust_dispatch::dispatch_fact(
+                out.push(dispatch::dispatch_fact(
                     symbols,
                     node,
                     key,
@@ -157,10 +161,10 @@ pub(super) fn rust_edges(
         // variant whose head is a unique in-scope `enum`, so a non-enum head never yields a
         // `dispatches` edge.
         {
-            if rust_dispatch::scoped_identifier_in_value_position(node)
-                && let Some(key) = rust_dispatch::enum_variant_key(node, text)
+            if dispatch::scoped_identifier_in_value_position(node)
+                && let Some(key) = dispatch::enum_variant_key(node, text)
             {
-                out.push(rust_dispatch::dispatch_fact(
+                out.push(dispatch::dispatch_fact(
                     symbols,
                     node,
                     key,
@@ -170,7 +174,7 @@ pub(super) fn rust_edges(
                 ));
             }
         },
-        "match_arm" => rust_dispatch::rust_dispatch_handle_facts(text, node, symbols, out),
+        "match_arm" => dispatch::rust_dispatch_handle_facts(text, node, symbols, out),
         "macro_invocation" =>
             if let Some(name) = first_identifier_text(node, text) {
                 out.push(symbol_edge_with_context(

--- a/crates/rag-rat-core/src/index/languages/rust/mod.rs
+++ b/crates/rag-rat-core/src/index/languages/rust/mod.rs
@@ -1,0 +1,205 @@
+use std::path::Path;
+
+use tree_sitter::Node;
+
+use super::{EdgeBackend, ParserBackend, ResolverPolicy, SymbolMatch};
+use crate::index::edges::{EdgeCandidate, IndexedSymbol};
+use crate::index::parser::{self, ParsedSymbolFact, ParserKind};
+
+mod dispatch;
+mod edges;
+
+pub(super) static SUPPORT: Rust = Rust;
+
+pub(super) struct Rust;
+
+impl ParserBackend for Rust {
+    fn parser_kind(&self, _path: &Path) -> ParserKind {
+        ParserKind::Rust
+    }
+
+    fn symbol_node<'tree>(&self, node: Node<'tree>, _text: &str) -> Option<SymbolMatch<'tree>> {
+        match node.kind() {
+            "function_item" => Some(("function", parser::child_name(node)?)),
+            "struct_item" => Some(("struct", parser::child_name(node)?)),
+            "enum_item" => Some(("enum", parser::child_name(node)?)),
+            "trait_item" => Some(("trait", parser::child_name(node)?)),
+            "impl_item" => Some(("impl", impl_name(node).unwrap_or(node))),
+            "mod_item" => Some(("module", parser::child_name(node)?)),
+            "const_item" => Some(("const", parser::child_name(node)?)),
+            "static_item" => Some(("static", parser::child_name(node)?)),
+            "type_item" => Some(("type", parser::child_name(node)?)),
+            "macro_definition" => Some(("macro", parser::child_name(node)?)),
+            _ => None,
+        }
+    }
+
+    fn scope_segment(&self, node: Node<'_>, text: &str) -> Option<String> {
+        let name = match node.kind() {
+            "mod_item" | "trait_item" => parser::child_name(node)?,
+            "impl_item" => impl_name(node)?,
+            _ => return None,
+        };
+        parser::node_text(name, text)
+    }
+
+    fn is_test_symbol(&self, text: &str, node: Node<'_>, _scope_path: &str, _name: &str) -> bool {
+        attribute_items(text, node).iter().any(|attribute| attribute_is_test(attribute))
+            || in_cfg_test_module(node, text)
+    }
+
+    fn symbol_facts(&self, text: &str, node: Node<'_>) -> Vec<ParsedSymbolFact> {
+        let mut facts = Vec::new();
+        for attribute in attribute_items(text, node) {
+            if attribute.contains("uniffi::export") || attribute.contains("::uniffi::export") {
+                facts.push(ParsedSymbolFact {
+                    kind: "rust_attr".to_string(),
+                    value: "uniffi_export".to_string(),
+                });
+            }
+        }
+        facts.sort_by(|left, right| (&left.kind, &left.value).cmp(&(&right.kind, &right.value)));
+        facts.dedup();
+        facts
+    }
+
+    fn is_plumbing_node(&self, node: Node<'_>) -> bool {
+        node.kind().contains("comment") || node.kind() == "use_declaration"
+    }
+}
+
+fn impl_name(node: Node<'_>) -> Option<Node<'_>> {
+    let mut cursor = node.walk();
+    node.named_children(&mut cursor).find(|child| {
+        matches!(child.kind(), "type_identifier" | "generic_type" | "scoped_type_identifier")
+    })
+}
+
+fn attribute_is_test(attribute: &str) -> bool {
+    let inner = attribute
+        .trim()
+        .trim_start_matches('#')
+        .trim_start_matches('!')
+        .trim_start_matches('[')
+        .trim_end_matches(']');
+    let head = inner.split(['(', '[']).next().unwrap_or_default().trim();
+    let last = head.rsplit("::").next().unwrap_or(head).trim();
+    last == "test" || last == "rstest" || last.starts_with("test_case")
+}
+
+fn in_cfg_test_module(node: Node<'_>, text: &str) -> bool {
+    let mut current = node.parent();
+    while let Some(ancestor) = current {
+        if ancestor.kind() == "mod_item"
+            && attribute_items(text, ancestor)
+                .iter()
+                .any(|attribute| attribute.contains("cfg") && attribute.contains("test"))
+        {
+            return true;
+        }
+        current = ancestor.parent();
+    }
+    false
+}
+
+fn attribute_items(text: &str, node: Node<'_>) -> Vec<String> {
+    let mut attributes = Vec::new();
+    let mut cursor = node.walk();
+    for child in node.named_children(&mut cursor) {
+        if child.kind() == "attribute_item" {
+            attributes.push(parser::node_text(child, text).unwrap_or_default());
+        }
+    }
+
+    let mut preceding = Vec::new();
+    let mut sibling = node.prev_named_sibling();
+    while let Some(previous) = sibling {
+        if previous.kind() != "attribute_item" {
+            break;
+        }
+        preceding.push(parser::node_text(previous, text).unwrap_or_default());
+        sibling = previous.prev_named_sibling();
+    }
+    preceding.reverse();
+    preceding.extend(attributes);
+    preceding
+}
+
+impl EdgeBackend for Rust {
+    fn edges(
+        &self,
+        text: &str,
+        node: Node<'_>,
+        symbols: &[IndexedSymbol],
+        path: &Path,
+        out: &mut Vec<EdgeCandidate>,
+    ) {
+        edges::rust_edges(text, node, symbols, path, out);
+    }
+}
+
+impl ResolverPolicy for Rust {
+    fn preferred_kinds(&self, _edge_kind: &str) -> Option<super::KindPreference> {
+        None
+    }
+
+    fn reference_is_unresolvable(&self, edge_kind: &str, name: &str) -> bool {
+        edge_kind == crate::index::edges::EdgeKind::ReferencesType.as_str()
+            && type_ref_is_unresolvable(name)
+    }
+
+    fn type_reference_requires_type_definition(&self) -> bool {
+        true
+    }
+
+    fn allow_type_receiver_fallback(&self) -> bool {
+        true
+    }
+
+    fn rejects_qualified_root(&self, root: &str) -> bool {
+        is_external_root(root)
+    }
+
+    fn is_local_qualified_root(&self, root: &str) -> bool {
+        matches!(root, "crate" | "self" | "super")
+    }
+}
+
+fn type_ref_is_unresolvable(name: &str) -> bool {
+    match name.split_once("::") {
+        Some((root, _)) => root == "Self" || looks_like_type_parameter(root),
+        None => looks_like_type_parameter(name),
+    }
+}
+
+fn looks_like_type_parameter(name: &str) -> bool {
+    let mut chars = name.chars();
+    chars.next().is_some_and(|first| first.is_ascii_uppercase())
+        && chars.all(|rest| rest.is_ascii_digit())
+}
+
+fn is_external_root(value: &str) -> bool {
+    matches!(
+        value,
+        "std"
+            | "core"
+            | "alloc"
+            | "tokio"
+            | "serde"
+            | "serde_json"
+            | "anyhow"
+            | "thiserror"
+            | "rusqlite"
+            | "tree_sitter"
+            | "tracing"
+            | "log"
+            | "Vec"
+            | "String"
+            | "Option"
+            | "Result"
+            | "HashMap"
+            | "BTreeMap"
+            | "HashSet"
+            | "BTreeSet"
+    )
+}

--- a/crates/rag-rat-core/src/index/languages/rust/mod.rs
+++ b/crates/rag-rat-core/src/index/languages/rust/mod.rs
@@ -14,6 +14,13 @@ pub(super) static SUPPORT: Rust = Rust;
 pub(super) struct Rust;
 
 impl ParserBackend for Rust {
+    fn symbol_kinds(&self) -> &'static [&'static str] {
+        &[
+            "const", "enum", "function", "impl", "macro", "module", "static", "struct", "trait",
+            "type",
+        ]
+    }
+
     fn parser_kind(&self, _path: &Path) -> ParserKind {
         ParserKind::Rust
     }

--- a/crates/rag-rat-core/src/index/languages/swift/edges.rs
+++ b/crates/rag-rat-core/src/index/languages/swift/edges.rs
@@ -1,0 +1,1662 @@
+//! Swift graph-edge extraction for the shared structural edge walk.
+
+use std::path::Path;
+
+use tree_sitter::Node;
+
+use super::syntax;
+use crate::index::edges::extract::*;
+use crate::index::edges::*;
+
+pub(super) fn swift_edges(
+    text: &str,
+    node: Node<'_>,
+    symbols: &[IndexedSymbol],
+    path: &Path,
+    out: &mut Vec<EdgeCandidate>,
+) {
+    match node.kind() {
+        "source_file"
+            if text.contains(',')
+                && (text.contains("higherThan:") || text.contains("lowerThan:")) =>
+            swift_precedence_group_relation_list_edges(text, node, symbols, out),
+        "import_declaration" => {
+            let identifiers = swift_import_identifiers(node, text);
+            if !identifiers.is_empty() {
+                out.push(file_edge(
+                    path,
+                    node,
+                    text,
+                    identifiers.join("::"),
+                    EdgeKind::Imports,
+                    EdgeConfidence::NameOnly,
+                ));
+            }
+        },
+        "call_expression" => swift_call_edges(text, node, symbols, out),
+        "constructor_expression" => swift_constructor_edges(text, node, symbols, out),
+        "macro_invocation" => swift_macro_edges(text, node, symbols, out),
+        "operator_declaration" => swift_precedence_group_edges(text, node, symbols, out),
+        "precedence_group_attribute" =>
+            swift_precedence_group_relation_edges(text, node, symbols, out),
+        "postfix_expression"
+        | "prefix_expression"
+        | "multiplicative_expression"
+        | "additive_expression"
+        | "range_expression"
+        | "infix_expression"
+        | "comparison_expression"
+        | "equality_expression"
+        | "conjunction_expression"
+        | "disjunction_expression"
+        | "bitwise_operation" => swift_operator_or_shorthand_case_edges(text, node, symbols, out),
+        "navigation_expression" => swift_qualified_case_edges(text, node, symbols, out),
+        "attribute" if !swift_node_is_import_modifier(node) =>
+            swift_attribute_macro_edges(text, node, symbols, out),
+        "inheritance_specifier" => {
+            let Some(type_path) = swift_inherited_type_name(node) else {
+                return;
+            };
+            let identifier_nodes = syntax::identifier_nodes(type_path);
+            let identifiers = identifier_nodes
+                .iter()
+                .map(|&identifier| node_text(identifier, text))
+                .collect::<Vec<_>>();
+            let Some(name) = identifiers.last().cloned() else {
+                return;
+            };
+            let edge_kind = if swift_inheritance_is_enum_raw_type(node, text) {
+                EdgeKind::ReferencesType
+            } else {
+                EdgeKind::Implements
+            };
+            out.push(symbol_edge_with_context(
+                symbols,
+                node,
+                text,
+                name,
+                edge_kind,
+                EdgeConfidence::NameOnly,
+                swift_edge_context(&identifiers),
+                identifier_nodes.last().copied().map(CalleeRange::of_node),
+            ));
+        },
+        "user_type"
+            if !swift_node_is_declaration_name(node)
+                && !swift_node_is_import_modifier(node)
+                && !swift_has_ancestor_kind(node, "attribute")
+                && !swift_node_is_type_parameter_reference(node, text) =>
+        {
+            let identifier_nodes = syntax::identifier_nodes(node);
+            let Some(type_node) = identifier_nodes.last().copied() else {
+                return;
+            };
+            let identifiers = identifier_nodes
+                .iter()
+                .map(|&identifier| node_text(identifier, text))
+                .collect::<Vec<_>>();
+            let Some(name) = identifiers.last().cloned() else {
+                return;
+            };
+            out.push(symbol_edge_with_context(
+                symbols,
+                node,
+                text,
+                name,
+                EdgeKind::ReferencesType,
+                EdgeConfidence::NameOnly,
+                swift_edge_context(&identifiers),
+                Some(CalleeRange::of_node(type_node)),
+            ));
+        },
+        "type_identifier"
+            if node.parent().is_none_or(|parent| parent.kind() != "user_type")
+                && !swift_node_is_declaration_name(node)
+                && !swift_node_is_type_parameter_declaration(node)
+                && !swift_node_is_type_parameter_reference(node, text)
+                && !swift_has_ancestor_kind(node, "attribute")
+                && !swift_node_is_import_modifier(node) =>
+        {
+            let name = node_text(node, text);
+            out.push(symbol_edge(
+                symbols,
+                node,
+                name,
+                EdgeKind::ReferencesType,
+                EdgeConfidence::NameOnly,
+                Some(CalleeRange::of_node(node)),
+            ));
+        },
+        _ => {},
+    }
+}
+
+fn swift_operator_or_shorthand_case_edges(
+    text: &str,
+    node: Node<'_>,
+    symbols: &[IndexedSymbol],
+    out: &mut Vec<EdgeCandidate>,
+) {
+    let Some(operation) =
+        node.child_by_field_name("op").or_else(|| node.child_by_field_name("operation"))
+    else {
+        return;
+    };
+    if operation.kind() == "." {
+        let Some(case_name) = node.child_by_field_name("target") else {
+            return;
+        };
+        out.push(symbol_edge(
+            symbols,
+            node,
+            node_text(case_name, text),
+            EdgeKind::CallsName,
+            EdgeConfidence::NameOnly,
+            Some(CalleeRange::of_node(case_name)),
+        ));
+        return;
+    }
+    if node.kind() == "postfix_expression" && node_text(operation, text) == "!" {
+        // Swift reserves postfix `!` for optional force-unwrapping. Other postfix operator
+        // tokens remain callable, but this language construct must not bind to an overload.
+        return;
+    }
+    if !syntax::is_operator_token(operation.kind()) {
+        return;
+    }
+    out.push(symbol_edge(
+        symbols,
+        node,
+        node_text(operation, text),
+        EdgeKind::UsesOperator,
+        EdgeConfidence::NameOnly,
+        Some(CalleeRange::of_node(operation)),
+    ));
+    out.push(symbol_edge(
+        symbols,
+        node,
+        node_text(operation, text),
+        EdgeKind::CallsName,
+        EdgeConfidence::NameOnly,
+        Some(CalleeRange::of_node(operation)),
+    ));
+}
+
+fn swift_qualified_case_edges(
+    text: &str,
+    node: Node<'_>,
+    symbols: &[IndexedSymbol],
+    out: &mut Vec<EdgeCandidate>,
+) {
+    if node.parent().is_some_and(|parent| {
+        parent.kind() == "call_expression" && swift_call_target(parent) == Some(node)
+    }) {
+        return;
+    }
+    let identifier_nodes = syntax::identifier_nodes(node);
+    let identifiers =
+        identifier_nodes.iter().map(|&identifier| node_text(identifier, text)).collect::<Vec<_>>();
+    if identifiers.len() < 2 || !looks_like_type_name(&identifiers[0]) {
+        return;
+    }
+    let Some(case_name) = identifier_nodes.last().copied() else {
+        return;
+    };
+    out.push(symbol_edge_with_context(
+        symbols,
+        node,
+        text,
+        node_text(case_name, text),
+        EdgeKind::CallsName,
+        EdgeConfidence::NameOnly,
+        swift_edge_context(&identifiers),
+        Some(CalleeRange::of_node(case_name)),
+    ));
+}
+
+fn swift_call_edges(
+    text: &str,
+    node: Node<'_>,
+    symbols: &[IndexedSymbol],
+    out: &mut Vec<EdgeCandidate>,
+) {
+    if swift_subscript_suffix(node, text).is_some() {
+        let Some(target) = swift_call_target(node) else {
+            return;
+        };
+        let Some((mut identifiers, _)) = swift_call_target_parts(target, text) else {
+            return;
+        };
+        if identifiers.len() == 1
+            && swift_name_is_type_parameter_in_scope(&identifiers[0], target, text)
+        {
+            return;
+        }
+        identifiers.push("subscript".to_string());
+        emit_swift_call_edges(text, node, symbols, out, identifiers, None, false);
+        return;
+    }
+    let Some(target) = swift_call_target(node) else {
+        return;
+    };
+    let Some((identifiers, callee_range)) = swift_call_target_parts(target, text) else {
+        return;
+    };
+    if identifiers.len() == 1
+        && swift_name_is_type_parameter_in_scope(&identifiers[0], target, text)
+    {
+        return;
+    }
+    let constructs = identifiers.last().is_some_and(|name| looks_like_type_name(name));
+    emit_swift_call_edges(text, node, symbols, out, identifiers, callee_range, constructs);
+}
+
+fn swift_constructor_edges(
+    text: &str,
+    node: Node<'_>,
+    symbols: &[IndexedSymbol],
+    out: &mut Vec<EdgeCandidate>,
+) {
+    let Some(constructed_type) = node.child_by_field_name("constructed_type") else {
+        return;
+    };
+    let Some((identifiers, callee_range)) = swift_call_target_parts(constructed_type, text) else {
+        return;
+    };
+    if identifiers.len() == 1
+        && swift_name_is_type_parameter_in_scope(&identifiers[0], constructed_type, text)
+    {
+        return;
+    }
+    emit_swift_call_edges(text, node, symbols, out, identifiers, callee_range, true);
+}
+
+fn emit_swift_call_edges(
+    text: &str,
+    node: Node<'_>,
+    symbols: &[IndexedSymbol],
+    out: &mut Vec<EdgeCandidate>,
+    identifiers: Vec<String>,
+    callee_range: Option<CalleeRange>,
+    constructs: bool,
+) {
+    let Some(name) = identifiers.last().cloned() else {
+        return;
+    };
+    out.push(symbol_edge_with_context(
+        symbols,
+        node,
+        text,
+        name.clone(),
+        if constructs { EdgeKind::Constructs } else { EdgeKind::CallsName },
+        EdgeConfidence::NameOnly,
+        if constructs {
+            swift_edge_context(&identifiers)
+        } else {
+            swift_call_edge_context(&identifiers)
+        },
+        callee_range,
+    ));
+    if constructs {
+        out.push(symbol_edge_with_context(
+            symbols,
+            node,
+            text,
+            name,
+            EdgeKind::ReferencesType,
+            EdgeConfidence::NameOnly,
+            swift_edge_context(&identifiers),
+            callee_range,
+        ));
+    }
+}
+
+fn swift_macro_edges(
+    text: &str,
+    node: Node<'_>,
+    symbols: &[IndexedSymbol],
+    out: &mut Vec<EdgeCandidate>,
+) {
+    let Some(name_node) = syntax::identifier_nodes(node).first().copied() else {
+        return;
+    };
+    if node_text(name_node, text) == "externalMacro"
+        && swift_has_ancestor_kind(node, "macro_declaration")
+    {
+        return;
+    }
+    out.push(symbol_edge(
+        symbols,
+        node,
+        node_text(name_node, text),
+        EdgeKind::UsesMacro,
+        EdgeConfidence::NameOnly,
+        Some(CalleeRange::of_node(name_node)),
+    ));
+}
+
+fn swift_has_ancestor_kind(node: Node<'_>, kind: &str) -> bool {
+    let mut ancestor = node.parent();
+    while let Some(current) = ancestor {
+        if current.kind() == kind {
+            return true;
+        }
+        ancestor = current.parent();
+    }
+    false
+}
+
+fn swift_attribute_macro_edges(
+    text: &str,
+    node: Node<'_>,
+    symbols: &[IndexedSymbol],
+    out: &mut Vec<EdgeCandidate>,
+) {
+    let Some(attribute_name) = node.named_child(0) else {
+        return;
+    };
+    let identifier_nodes = syntax::identifier_nodes(attribute_name);
+    let identifiers =
+        identifier_nodes.iter().map(|&identifier| node_text(identifier, text)).collect::<Vec<_>>();
+    let Some(name_node) = identifier_nodes.last().copied() else {
+        return;
+    };
+    let Some(name) = identifiers.last().cloned() else {
+        return;
+    };
+    out.push(symbol_edge_with_context(
+        symbols,
+        node,
+        text,
+        name.clone(),
+        EdgeKind::UsesMacro,
+        EdgeConfidence::NameOnly,
+        swift_edge_context(&identifiers),
+        Some(CalleeRange::of_node(name_node)),
+    ));
+    // The grammar uses the same attribute shape for macros, property wrappers, and result
+    // builders. Emit both semantic possibilities; language-policy resolution keeps only the one
+    // whose declaration kind exists and suppresses both candidates when the attribute is external.
+    out.push(symbol_edge_with_context(
+        symbols,
+        node,
+        text,
+        name,
+        EdgeKind::ReferencesType,
+        EdgeConfidence::NameOnly,
+        swift_edge_context(&identifiers),
+        Some(CalleeRange::of_node(name_node)),
+    ));
+}
+
+fn swift_precedence_group_edges(
+    text: &str,
+    node: Node<'_>,
+    symbols: &[IndexedSymbol],
+    out: &mut Vec<EdgeCandidate>,
+) {
+    let Some(group) = syntax::identifier_nodes(node).last().copied() else {
+        return;
+    };
+    out.push(symbol_edge(
+        symbols,
+        node,
+        node_text(group, text),
+        EdgeKind::UsesPrecedenceGroup,
+        EdgeConfidence::NameOnly,
+        Some(CalleeRange::of_node(group)),
+    ));
+}
+
+fn swift_precedence_group_relation_edges(
+    text: &str,
+    node: Node<'_>,
+    symbols: &[IndexedSymbol],
+    out: &mut Vec<EdgeCandidate>,
+) {
+    let identifiers = syntax::identifier_nodes(node);
+    let Some((relation, dependencies)) = identifiers.split_first() else {
+        return;
+    };
+    if dependencies.is_empty()
+        || !matches!(node_text(*relation, text).as_str(), "higherThan" | "lowerThan")
+    {
+        return;
+    }
+    for dependency in dependencies {
+        let edge = symbol_edge(
+            symbols,
+            node,
+            node_text(*dependency, text),
+            EdgeKind::UsesPrecedenceGroup,
+            EdgeConfidence::NameOnly,
+            Some(CalleeRange::of_node(*dependency)),
+        );
+        if !out.iter().any(|existing| {
+            existing.edge_kind == edge.edge_kind
+                && existing.to_name == edge.to_name
+                && existing.callee_span.is_some_and(|span| {
+                    edge.callee_span.is_some_and(|candidate| {
+                        span.start_byte == candidate.start_byte
+                            && span.end_byte == candidate.end_byte
+                    })
+                })
+        }) {
+            out.push(edge);
+        }
+    }
+}
+
+/// tree-sitter-swift 0.7 models one precedence dependency per attribute even though Swift accepts
+/// comma-separated lists. Recover relation lists from comment/string-masked declaration bodies;
+/// single dependencies still deduplicate against the structured attribute-node path above.
+fn swift_precedence_group_relation_list_edges(
+    text: &str,
+    node: Node<'_>,
+    symbols: &[IndexedSymbol],
+    out: &mut Vec<EdgeCandidate>,
+) {
+    let source = node_text(node, text);
+    let code = swift_code_without_comments_or_strings(&source);
+    let mut declaration_cursor = 0;
+    while let Some(relative) = code[declaration_cursor..].find("precedencegroup") {
+        let declaration_start = declaration_cursor + relative;
+        let keyword_end = declaration_start + "precedencegroup".len();
+        let has_identifier_prefix =
+            code[..declaration_start].chars().next_back().is_some_and(is_swift_identifier_char);
+        let has_required_separator =
+            code.as_bytes().get(keyword_end).is_some_and(u8::is_ascii_whitespace);
+        if has_identifier_prefix || !has_required_separator {
+            declaration_cursor = keyword_end;
+            continue;
+        }
+        let name_start = keyword_end;
+        let name_start =
+            name_start + code[name_start..].bytes().take_while(u8::is_ascii_whitespace).count();
+        let name_len = swift_identifier_len(&code[name_start..]);
+        let after_name = name_start + name_len;
+        let open =
+            after_name + code[after_name..].bytes().take_while(u8::is_ascii_whitespace).count();
+        if name_len == 0 || code.as_bytes().get(open) != Some(&b'{') {
+            declaration_cursor = keyword_end;
+            continue;
+        }
+        let mut depth = 1_usize;
+        let mut close = open + 1;
+        for (offset, byte) in code[open + 1..].bytes().enumerate() {
+            match byte {
+                b'{' => depth += 1,
+                b'}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        close = open + 1 + offset;
+                        break;
+                    }
+                },
+                _ => {},
+            }
+        }
+        if depth != 0 {
+            break;
+        }
+        let group = &source[name_start..name_start + name_len];
+        let source_symbol =
+            symbols.iter().find(|symbol| symbol.kind == "precedence_group" && symbol.name == group);
+        swift_recovered_precedence_relations(
+            text,
+            node.start_byte(),
+            &source,
+            &code,
+            open + 1,
+            close,
+            source_symbol,
+            out,
+        );
+        declaration_cursor = close + 1;
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn swift_recovered_precedence_relations(
+    text: &str,
+    source_offset: usize,
+    source: &str,
+    code: &str,
+    body_start: usize,
+    body_end: usize,
+    source_symbol: Option<&IndexedSymbol>,
+    out: &mut Vec<EdgeCandidate>,
+) {
+    let mut cursor = body_start;
+    while cursor < body_end {
+        let relation = ["higherThan:", "lowerThan:"]
+            .into_iter()
+            .filter_map(|label| code[cursor..body_end].find(label).map(|offset| (label, offset)))
+            .filter(|(_, offset)| {
+                let start = cursor + *offset;
+                start == body_start
+                    || !code[..start].chars().next_back().is_some_and(is_swift_identifier_char)
+            })
+            .min_by_key(|(_, offset)| *offset);
+        let Some((label, relative)) = relation else {
+            break;
+        };
+        let relation_start = cursor + relative;
+        let mut dependency_cursor = relation_start + label.len();
+        let mut relation_end = dependency_cursor;
+        let mut dependencies = Vec::new();
+        loop {
+            dependency_cursor += code[dependency_cursor..body_end]
+                .bytes()
+                .take_while(u8::is_ascii_whitespace)
+                .count();
+            let name_len = swift_identifier_len(&code[dependency_cursor..body_end]);
+            if name_len == 0 {
+                break;
+            }
+            let name = &source[dependency_cursor..dependency_cursor + name_len];
+            let start_byte = source_offset + dependency_cursor;
+            relation_end = dependency_cursor + name_len;
+            dependencies.push((name.to_string(), start_byte, name_len));
+            dependency_cursor = relation_end;
+            dependency_cursor += code[dependency_cursor..body_end]
+                .bytes()
+                .take_while(u8::is_ascii_whitespace)
+                .count();
+            if code.as_bytes().get(dependency_cursor) != Some(&b',') {
+                break;
+            }
+            dependency_cursor += 1;
+        }
+        let source_start = source_offset + relation_start;
+        let source_end = source_offset + relation_end;
+        let start_line =
+            i64::try_from(text[..source_start].bytes().filter(|&b| b == b'\n').count())
+                .unwrap_or(i64::MAX)
+                + 1;
+        let end_line = i64::try_from(text[..source_end].bytes().filter(|&b| b == b'\n').count())
+            .unwrap_or(i64::MAX)
+            + 1;
+        let evidence = source[relation_start..relation_end].trim().to_string();
+        let source_span = EdgeSpan {
+            start_line,
+            end_line,
+            start_byte: i64::try_from(source_start).unwrap_or(i64::MAX),
+            end_byte: i64::try_from(source_end).unwrap_or(i64::MAX),
+        };
+        for (name, start_byte, name_len) in dependencies {
+            let edge = EdgeCandidate {
+                from_symbol_id: source_symbol.map(|symbol| symbol.id),
+                from_name: source_symbol.map(|symbol| symbol.qualified_name.clone()),
+                to_name: name,
+                target_qualified_name: None,
+                evidence: Some(evidence.clone()),
+                receiver_hint: None,
+                source_span,
+                callee_span: Some(CalleeRange { start_byte, end_byte: start_byte + name_len }),
+                import_scope: None,
+                edge_kind: EdgeKind::UsesPrecedenceGroup,
+                confidence: EdgeConfidence::NameOnly,
+            };
+            if !out.iter().any(|existing| {
+                existing.edge_kind == edge.edge_kind
+                    && existing.to_name == edge.to_name
+                    && existing.callee_span.is_some_and(|span| span.start_byte == start_byte)
+            }) {
+                out.push(edge);
+            }
+        }
+        cursor = relation_end.max(relation_start + label.len());
+    }
+}
+
+fn swift_identifier_len(text: &str) -> usize {
+    if let Some(rest) = text.strip_prefix('`') {
+        return rest.find('`').map_or(0, |end| end + 2);
+    }
+    text.char_indices()
+        .take_while(|(_, character)| is_swift_identifier_char(*character))
+        .map(|(offset, character)| offset + character.len_utf8())
+        .last()
+        .unwrap_or(0)
+}
+
+fn is_swift_identifier_char(character: char) -> bool {
+    character == '_' || character.is_alphanumeric() || !character.is_ascii()
+}
+
+fn swift_code_without_comments_or_strings(source: &str) -> String {
+    let bytes = source.as_bytes();
+    let mut code = bytes.to_vec();
+    let mut cursor = 0;
+    let mut block_depth = 0_u32;
+    let mut string_delimiter: Option<(usize, bool)> = None;
+    while cursor < bytes.len() {
+        if let Some((hashes, multiline)) = string_delimiter {
+            let quote_count = if multiline { 3 } else { 1 };
+            let terminator_len = quote_count + hashes;
+            let is_terminator = bytes
+                .get(cursor..cursor + quote_count)
+                .is_some_and(|quotes| quotes.iter().all(|&byte| byte == b'"'))
+                && bytes
+                    .get(cursor + quote_count..cursor + terminator_len)
+                    .is_some_and(|suffix| suffix.iter().all(|&byte| byte == b'#'));
+            if is_terminator {
+                for byte in &mut code[cursor..cursor + terminator_len] {
+                    *byte = b' ';
+                }
+                cursor += terminator_len;
+                string_delimiter = None;
+                continue;
+            }
+            if hashes == 0 && bytes[cursor] == b'\\' {
+                code[cursor] = b' ';
+                if cursor + 1 < bytes.len() {
+                    code[cursor + 1] = b' ';
+                }
+                cursor += 2;
+                continue;
+            }
+            if bytes[cursor] != b'\n' {
+                code[cursor] = b' ';
+            }
+            cursor += 1;
+            continue;
+        }
+        if block_depth > 0 {
+            if bytes[cursor..].starts_with(b"/*") {
+                block_depth += 1;
+                code[cursor] = b' ';
+                code[cursor + 1] = b' ';
+                cursor += 2;
+            } else if bytes[cursor..].starts_with(b"*/") {
+                block_depth -= 1;
+                code[cursor] = b' ';
+                code[cursor + 1] = b' ';
+                cursor += 2;
+            } else {
+                if bytes[cursor] != b'\n' {
+                    code[cursor] = b' ';
+                }
+                cursor += 1;
+            }
+            continue;
+        }
+        if bytes[cursor..].starts_with(b"//") {
+            while cursor < bytes.len() && bytes[cursor] != b'\n' {
+                code[cursor] = b' ';
+                cursor += 1;
+            }
+        } else if bytes[cursor..].starts_with(b"/*") {
+            block_depth = 1;
+            code[cursor] = b' ';
+            code[cursor + 1] = b' ';
+            cursor += 2;
+        } else if bytes[cursor] == b'"' || bytes[cursor] == b'#' {
+            let hashes = bytes[cursor..].iter().take_while(|&&byte| byte == b'#').count();
+            let quote = cursor + hashes;
+            if bytes.get(quote) == Some(&b'"') {
+                let multiline = bytes[quote..].starts_with(b"\"\"\"");
+                let opener_len = hashes + if multiline { 3 } else { 1 };
+                for byte in &mut code[cursor..cursor + opener_len] {
+                    *byte = b' ';
+                }
+                cursor += opener_len;
+                string_delimiter = Some((hashes, multiline));
+            } else {
+                cursor += 1;
+            }
+        } else {
+            cursor += 1;
+        }
+    }
+    String::from_utf8(code).expect("masking source bytes preserves UTF-8")
+}
+
+fn swift_edge_context(identifiers: &[String]) -> EdgeContext {
+    EdgeContext {
+        target_qualified_name: (identifiers.len() > 1)
+            .then(|| syntax::canonical_name(identifiers))
+            .flatten(),
+        receiver_hint: identifiers.first().filter(|_| identifiers.len() > 1).cloned(),
+    }
+}
+
+fn swift_call_edge_context(identifiers: &[String]) -> EdgeContext {
+    let mut context = swift_edge_context(identifiers);
+    if identifiers.first().is_some_and(|receiver| {
+        identifiers.len() > 1
+            && !looks_like_type_name(receiver)
+            && !super::is_local_qualified_root(receiver)
+    }) {
+        // A value receiver is not a lexical symbol scope: `client::fetch` can never match the
+        // method declared under its nominal type. Keep the receiver hint, but resolve by callee.
+        context.target_qualified_name = None;
+    }
+    context
+}
+
+fn swift_call_target(node: Node<'_>) -> Option<Node<'_>> {
+    let mut cursor = node.walk();
+    node.named_children(&mut cursor).find(|child| child.kind() != "call_suffix")
+}
+
+fn swift_call_target_parts(
+    target: Node<'_>,
+    text: &str,
+) -> Option<(Vec<String>, Option<CalleeRange>)> {
+    match target.kind() {
+        "array_type" | "array_literal" =>
+            Some((vec!["Array".to_string()], Some(CalleeRange::of_node(target)))),
+        "dictionary_type" | "dictionary_literal" =>
+            Some((vec!["Dictionary".to_string()], Some(CalleeRange::of_node(target)))),
+        _ => {
+            if !swift_callable_is_static_path(target) {
+                return None;
+            }
+            let mut identifier_nodes = syntax::identifier_nodes(target);
+            if identifier_nodes.len() > 1
+                && identifier_nodes.last().is_some_and(|&node| node_text(node, text) == "init")
+                && identifier_nodes.get(identifier_nodes.len() - 2).is_some_and(|&node| {
+                    let receiver = node_text(node, text);
+                    looks_like_type_name(&receiver) && !super::is_local_qualified_root(&receiver)
+                })
+            {
+                identifier_nodes.pop();
+            }
+            let identifiers =
+                identifier_nodes.iter().map(|&node| node_text(node, text)).collect::<Vec<_>>();
+            let callee_range = identifier_nodes.last().copied().map(CalleeRange::of_node);
+            Some((identifiers, callee_range))
+        },
+    }
+}
+
+fn swift_callable_is_static_path(root: Node<'_>) -> bool {
+    let mut stack = vec![root];
+    let mut children = Vec::new();
+    while let Some(node) = stack.pop() {
+        match node.kind() {
+            "identifier" | "simple_identifier" | "type_identifier" | "type_arguments"
+            | "self_expression" | "super_expression" => continue,
+            "user_type" | "navigation_expression" | "navigation_suffix" => {},
+            _ => return false,
+        }
+        let mut cursor = node.walk();
+        children.clear();
+        children.extend(node.named_children(&mut cursor));
+        for &child in children.iter().rev() {
+            stack.push(child);
+        }
+    }
+    true
+}
+
+fn swift_subscript_suffix<'tree>(node: Node<'tree>, text: &str) -> Option<Node<'tree>> {
+    let mut cursor = node.walk();
+    node.named_children(&mut cursor)
+        .filter(|child| child.kind() == "call_suffix")
+        .find(|suffix| node_text(*suffix, text).trim_start().starts_with('['))
+}
+
+fn swift_import_identifiers(node: Node<'_>, text: &str) -> Vec<String> {
+    let mut cursor = node.walk();
+    node.named_children(&mut cursor)
+        .filter(|child| child.kind() == "identifier")
+        .map(|child| node_text(child, text))
+        .collect()
+}
+
+fn swift_node_is_declaration_name(node: Node<'_>) -> bool {
+    let Some(parent) = node.parent() else {
+        return false;
+    };
+    if parent.kind() == "class_declaration" && parent.child_by_field_name("name") == Some(node) {
+        return parent
+            .child_by_field_name("declaration_kind")
+            .is_none_or(|kind| kind.kind() != "extension");
+    }
+    matches!(
+        parent.kind(),
+        "protocol_declaration"
+            | "function_declaration"
+            | "protocol_function_declaration"
+            | "typealias_declaration"
+            | "associatedtype_declaration"
+    ) && parent.child_by_field_name("name") == Some(node)
+}
+
+fn swift_node_is_type_parameter_declaration(node: Node<'_>) -> bool {
+    node.parent().is_some_and(|parent| parent.kind() == "type_parameter")
+}
+
+fn swift_node_is_type_parameter_reference(node: Node<'_>, text: &str) -> bool {
+    let reference_segments = syntax::identifier_nodes(node);
+    let Some(reference_root) = reference_segments.first().copied() else {
+        return false;
+    };
+    let reference_root = node_text(reference_root, text);
+    reference_root == "Self" || swift_name_is_type_parameter_in_scope(&reference_root, node, text)
+}
+
+fn swift_name_is_type_parameter_in_scope(reference_name: &str, node: Node<'_>, text: &str) -> bool {
+    let mut ancestor = node.parent();
+    while let Some(scope) = ancestor {
+        let mut cursor = scope.walk();
+        for parameters in scope.named_children(&mut cursor).filter(|child| {
+            matches!(
+                child.kind(),
+                "type_parameters" | "enum_type_parameters" | "lambda_function_type_parameters"
+            )
+        }) {
+            let mut parameter_cursor = parameters.walk();
+            for parameter in parameters
+                .named_children(&mut parameter_cursor)
+                .filter(|child| child.kind() == "type_parameter")
+            {
+                if syntax::identifier_nodes(parameter)
+                    .first()
+                    .is_some_and(|&name| node_text(name, text) == reference_name)
+                {
+                    return true;
+                }
+            }
+        }
+        ancestor = scope.parent();
+    }
+    false
+}
+
+fn swift_node_is_import_modifier(node: Node<'_>) -> bool {
+    let mut ancestor = node.parent();
+    while let Some(current) = ancestor {
+        if current.kind() == "import_declaration" {
+            return true;
+        }
+        ancestor = current.parent();
+    }
+    false
+}
+
+fn swift_inherited_type_name(node: Node<'_>) -> Option<Node<'_>> {
+    let inherited = node.child_by_field_name("inherits_from")?;
+    if inherited.kind() == "user_type" {
+        return Some(inherited);
+    }
+    last_identifier_node(inherited).map(final_segment_node)
+}
+
+fn swift_inheritance_is_enum_raw_type(node: Node<'_>, text: &str) -> bool {
+    let mut ancestor = node.parent();
+    let declaration = loop {
+        let Some(current) = ancestor else {
+            return false;
+        };
+        if current.kind() == "class_declaration" {
+            break current;
+        }
+        ancestor = current.parent();
+    };
+    if declaration.child_by_field_name("declaration_kind").is_none_or(|kind| kind.kind() != "enum")
+    {
+        return false;
+    }
+    let mut cursor = declaration.walk();
+    let first_inheritance = declaration
+        .named_children(&mut cursor)
+        .find(|child| child.kind() == "inheritance_specifier");
+    first_inheritance == Some(node)
+        && (swift_inheritance_is_builtin_raw_type(node, text)
+            || swift_enum_has_explicit_raw_value(declaration))
+}
+
+fn swift_inheritance_is_builtin_raw_type(node: Node<'_>, text: &str) -> bool {
+    let Some(type_name) = swift_inherited_type_name(node) else {
+        return false;
+    };
+    let identifiers = syntax::identifier_nodes(type_name);
+    let segments =
+        identifiers.iter().map(|&identifier| node_text(identifier, text)).collect::<Vec<_>>();
+    let raw_type = match segments.as_slice() {
+        [raw_type] => raw_type.as_str(),
+        [module, raw_type] if module == "Swift" => raw_type.as_str(),
+        _ => return false,
+    };
+    if raw_type.is_empty() {
+        return false;
+    }
+    matches!(
+        raw_type,
+        "Character"
+            | "String"
+            | "Int"
+            | "Int8"
+            | "Int16"
+            | "Int32"
+            | "Int64"
+            | "UInt"
+            | "UInt8"
+            | "UInt16"
+            | "UInt32"
+            | "UInt64"
+            | "Float"
+            | "Double"
+            | "Float80"
+    )
+}
+
+fn swift_enum_has_explicit_raw_value(declaration: Node<'_>) -> bool {
+    let mut stack = vec![declaration];
+    let mut children = Vec::new();
+    while let Some(node) = stack.pop() {
+        if node.kind() == "enum_entry" && node.child_by_field_name("raw_value").is_some() {
+            return true;
+        }
+        if node != declaration && node.kind() == "class_declaration" {
+            continue;
+        }
+        let mut cursor = node.walk();
+        children.clear();
+        children.extend(node.named_children(&mut cursor));
+        stack.extend(children.iter().copied());
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use super::*;
+    use crate::language::Language;
+
+    fn edges(src: &str) -> Vec<EdgeCandidate> {
+        syntactic_edges(Path::new("Sources/App/App.swift"), Language::Swift, src, &[])
+            .expect("Swift fixture parses")
+    }
+
+    fn has(edges: &[EdgeCandidate], kind: EdgeKind, target: &str) -> bool {
+        edges.iter().any(|edge| edge.edge_kind == kind && edge.to_name == target)
+    }
+
+    fn callee_text<'a>(edge: &EdgeCandidate, src: &'a str) -> Option<&'a str> {
+        let span = edge.callee_span?;
+        src.get(span.start_byte..span.end_byte)
+    }
+
+    fn source_text<'a>(edge: &EdgeCandidate, src: &'a str) -> Option<&'a str> {
+        let start = usize::try_from(edge.source_span.start_byte).ok()?;
+        let end = usize::try_from(edge.source_span.end_byte).ok()?;
+        src.get(start..end)
+    }
+
+    #[test]
+    fn extracts_import_calls_construction_conformance_and_exact_callee_ranges() {
+        let src = r#"
+import Foundation
+
+protocol Worker<Element> {}
+
+class Parent {}
+class Child: Parent {}
+
+struct Runner: Worker<Service> {
+    func run(service: Service?) async {
+        let client = Client()
+        await client.fetch(id: 1) { value in print(value) }
+        service?.ping()
+    }
+}
+"#;
+        let edges = edges(src);
+        assert!(has(&edges, EdgeKind::Imports, "Foundation"), "import missing: {edges:#?}");
+        assert!(has(&edges, EdgeKind::Implements, "Worker"), "conformance missing: {edges:#?}");
+        assert!(
+            !has(&edges, EdgeKind::Implements, "Service"),
+            "generic arguments are type references, not conformances: {edges:#?}"
+        );
+        assert!(has(&edges, EdgeKind::Implements, "Parent"), "inheritance missing: {edges:#?}");
+        assert!(has(&edges, EdgeKind::Constructs, "Client"), "construction missing: {edges:#?}");
+        assert!(has(&edges, EdgeKind::ReferencesType, "Service"), "type ref missing: {edges:#?}");
+
+        for callee in ["Client", "fetch", "ping"] {
+            let edge = edges
+                .iter()
+                .find(|edge| edge.to_name == callee)
+                .unwrap_or_else(|| panic!("missing {callee} edge: {edges:#?}"));
+            assert_eq!(callee_text(edge, src), Some(callee), "wrong callee range for {callee}");
+            let source = source_text(edge, src)
+                .unwrap_or_else(|| panic!("missing source range for {callee}: {edges:#?}"));
+            assert!(
+                source.contains(callee),
+                "source range for {callee} must cover its callee: {source:?}"
+            );
+        }
+
+        let fetch = edges
+            .iter()
+            .find(|edge| edge.to_name == "fetch")
+            .unwrap_or_else(|| panic!("missing awaited fetch edge: {edges:#?}"));
+        assert!(
+            source_text(fetch, src).is_some_and(|source| source.contains("client.fetch")),
+            "await must preserve the underlying call-expression source range: {fetch:#?}"
+        );
+        assert_eq!(fetch.target_qualified_name, None, "value receivers resolve by callee name");
+        assert_eq!(fetch.receiver_hint.as_deref(), Some("client"));
+    }
+
+    #[test]
+    fn generic_declarations_are_not_type_references_and_outer_types_keep_their_names() {
+        let src = r#"
+struct T {}
+struct Namespace { struct T {} }
+struct Box<Element> {}
+
+func transform<T: Codable, U>(_ value: Box<T>, _ qualified: Namespace.T) -> Box<U> { value }
+"#;
+        let edges = edges(src);
+        let references = |target: &str| {
+            edges
+                .iter()
+                .filter(|edge| edge.edge_kind == EdgeKind::ReferencesType && edge.to_name == target)
+                .count()
+        };
+
+        assert_eq!(references("Element"), 0, "generic declarations are not uses: {edges:#?}");
+        assert_eq!(references("T"), 1, "only Namespace.T is a nominal reference: {edges:#?}");
+        assert_eq!(references("U"), 0, "generic return types are lexical bindings: {edges:#?}");
+        assert_eq!(references("Codable"), 1, "generic constraints remain type uses: {edges:#?}");
+        assert_eq!(references("Box"), 2, "generic arguments must not replace Box: {edges:#?}");
+        assert!(
+            edges.iter().any(|edge| {
+                edge.edge_kind == EdgeKind::ReferencesType
+                    && edge.to_name == "T"
+                    && edge.target_qualified_name.as_deref() == Some("Namespace::T")
+            }),
+            "qualified nominal types are not lexical generic references: {edges:#?}"
+        );
+        assert!(
+            edges
+                .iter()
+                .filter(|edge| edge.to_name == "Box")
+                .all(|edge| { callee_text(edge, src) == Some("Box") }),
+            "outer type edges must retain exact Box ranges: {edges:#?}"
+        );
+    }
+
+    #[test]
+    fn operator_and_enum_case_expressions_emit_callable_edges() {
+        let src = r####"
+enum Status { case idle, failed(Error) }
+precedencegroup BasePrecedence {}
+precedencegroup SecondaryPrecedence {}
+precedencegroup MergePrecedence {
+    // } must not close the declaration scanner.
+    // note { higherThan: BasePrecedence, SecondaryPrecedence
+    higherThan: BasePrecedence,
+        SecondaryPrecedence
+    /* higherThan: BasePrecedence, SecondaryPrecedence */
+    associativity: left
+}
+precedencegroup InlinePrecedence { higherThan: BasePrecedence, SecondaryPrecedence }
+precedencegroup LowerPrecedence { lowerThan: BasePrecedence }
+precedencegroup Métrique { higherThan: Élément, `class` }
+precedencegroup Élément {}
+precedencegroup `class` {}
+precedencegroup Broken
+let malformedApostrophe = 'x'
+precedencegroup GoodPrecedence { higherThan: BasePrecedence, SecondaryPrecedence }
+let relationString = "higherThan: BasePrecedence, SecondaryPrecedence"
+let rawRelation = #"ignored " precedencegroup Fake { higherThan: BasePrecedence, SecondaryPrecedence }"#
+let rawMultiline = ##"""
+precedencegroup AlsoFake { higherThan: BasePrecedence, SecondaryPrecedence }
+"""##
+/*
+higherThan: BasePrecedence, SecondaryPrecedence
+*/
+infix operator <+>: MergePrecedence
+prefix operator !
+func <+>(lhs: Int, rhs: Int) -> Int { lhs + rhs }
+
+let merged = lhs <+> rhs
+let inverted = !flag
+let qualified = Status.idle
+let shorthand: Status = .idle
+let qualifiedPayload = Status.failed(error)
+let shorthandPayload: Status = .failed(error)
+let unrelated = client.idle
+"####;
+        let edges = edges(src);
+        for operator in ["<+>", "!"] {
+            for kind in [EdgeKind::CallsName, EdgeKind::UsesOperator] {
+                let edge = edges
+                    .iter()
+                    .find(|edge| edge.edge_kind == kind && edge.to_name == operator)
+                    .unwrap_or_else(|| {
+                        panic!("missing {kind:?} operator edge to {operator}: {edges:#?}")
+                    });
+                assert_eq!(callee_text(edge, src), Some(operator));
+            }
+        }
+        let precedence = edges
+            .iter()
+            .find(|edge| {
+                edge.edge_kind == EdgeKind::UsesPrecedenceGroup && edge.to_name == "MergePrecedence"
+            })
+            .unwrap_or_else(|| panic!("missing precedence-group dependency: {edges:#?}"));
+        assert_eq!(callee_text(precedence, src), Some("MergePrecedence"));
+        let group_dependencies = edges
+            .iter()
+            .filter(|edge| {
+                edge.edge_kind == EdgeKind::UsesPrecedenceGroup && edge.to_name == "BasePrecedence"
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            group_dependencies.len(),
+            4,
+            "valid declarations each emit once while malformed and raw decoys do not: {edges:#?}"
+        );
+        assert!(
+            group_dependencies.iter().all(|edge| callee_text(edge, src) == Some("BasePrecedence"))
+        );
+        let secondary_dependencies = edges
+            .iter()
+            .filter(|edge| {
+                edge.edge_kind == EdgeKind::UsesPrecedenceGroup
+                    && edge.to_name == "SecondaryPrecedence"
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(secondary_dependencies.len(), 3, "all valid list forms emit once: {edges:#?}");
+        let recovered = edges
+            .iter()
+            .filter(|edge| {
+                edge.edge_kind == EdgeKind::UsesPrecedenceGroup
+                    && edge.evidence.as_deref().is_some_and(|evidence| evidence.contains(','))
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(recovered.len(), 8, "comments and strings must not create dependencies");
+        assert!(recovered.iter().all(|edge| {
+            callee_text(edge, src) == Some(edge.to_name.as_str())
+                && source_text(edge, src).is_some_and(|source| {
+                    source.contains("higherThan:") && source.len() < src.len()
+                })
+        }));
+        for (owner, dependency) in [("Métrique", "Élément"), ("Métrique", "`class`")] {
+            let edge = edges
+                .iter()
+                .find(|edge| {
+                    edge.edge_kind == EdgeKind::UsesPrecedenceGroup && edge.to_name == dependency
+                })
+                .unwrap_or_else(|| panic!("missing {owner} -> {dependency}: {edges:#?}"));
+            assert_eq!(callee_text(edge, src), Some(dependency));
+        }
+        assert!(edges.iter().all(|edge| !matches!(edge.to_name.as_str(), "Fake" | "AlsoFake")));
+
+        let cases = |name: &str| {
+            edges
+                .iter()
+                .filter(|edge| edge.edge_kind == EdgeKind::CallsName && edge.to_name == name)
+                .collect::<Vec<_>>()
+        };
+        let idle = cases("idle");
+        assert_eq!(idle.len(), 2, "qualified and shorthand cases each emit once: {edges:#?}");
+        assert!(
+            idle.iter().any(|edge| {
+                edge.target_qualified_name.as_deref() == Some("Status::idle")
+                    && edge.receiver_hint.as_deref() == Some("Status")
+            }),
+            "qualified cases retain enum context: {edges:#?}"
+        );
+        assert!(
+            idle.iter().all(|edge| callee_text(edge, src) == Some("idle")),
+            "case edges retain exact leaf ranges: {edges:#?}"
+        );
+        assert_eq!(
+            cases("failed").len(),
+            2,
+            "qualified and shorthand associated-value cases each emit once: {edges:#?}"
+        );
+    }
+
+    #[test]
+    fn forced_unwraps_are_not_operator_calls_but_other_postfix_tokens_are() {
+        let src = r#"
+postfix operator ++
+postfix func ++(value: Int) -> Int { value }
+
+let unwrapped = maybe!
+let transformed = value++
+"#;
+        let edges = edges(src);
+        for kind in [EdgeKind::CallsName, EdgeKind::UsesOperator] {
+            assert!(
+                edges.iter().any(|edge| {
+                    edge.edge_kind == kind
+                        && edge.to_name == "++"
+                        && callee_text(edge, src) == Some("++")
+                }),
+                "non-bang postfix token must emit {kind:?}: {edges:#?}"
+            );
+            assert!(
+                !edges.iter().any(|edge| edge.edge_kind == kind && edge.to_name == "!"),
+                "force unwrap must not emit {kind:?}: {edges:#?}"
+            );
+        }
+    }
+
+    #[test]
+    fn local_receiver_calls_keep_their_qualified_roots() {
+        let src = r#"
+class Parent { class func make() {} }
+class Store: Parent {
+    class func make() {
+        Self.make()
+        self.make()
+        super.make()
+    }
+}
+"#;
+        let edges = edges(src);
+        for receiver in ["Self", "self", "super"] {
+            let qualified = format!("{receiver}::make");
+            let call = edges
+                .iter()
+                .find(|edge| {
+                    edge.edge_kind == EdgeKind::CallsName
+                        && edge.target_qualified_name.as_deref() == Some(qualified.as_str())
+                })
+                .unwrap_or_else(|| panic!("missing {receiver}.make call: {edges:#?}"));
+            assert_eq!(call.receiver_hint.as_deref(), Some(receiver));
+            assert_eq!(callee_text(call, src), Some("make"));
+        }
+    }
+
+    #[test]
+    fn attributed_imports_only_name_the_imported_module() {
+        let src = r#"
+@testable import App
+@_exported import Foo.Bar
+"#;
+        let edges = edges(src);
+        assert!(has(&edges, EdgeKind::Imports, "App"), "testable import missing: {edges:#?}");
+        assert!(has(&edges, EdgeKind::Imports, "Foo.Bar"), "re-export import missing: {edges:#?}");
+        assert!(
+            !edges.iter().any(|edge| {
+                edge.edge_kind == EdgeKind::Imports
+                    && (edge.to_name.contains("testable") || edge.to_name.contains("_exported"))
+            }),
+            "import modifiers must not enter module names: {edges:#?}"
+        );
+        assert!(
+            !has(&edges, EdgeKind::ReferencesType, "testable")
+                && !has(&edges, EdgeKind::ReferencesType, "_exported"),
+            "import attributes are not type references: {edges:#?}"
+        );
+        assert!(
+            !has(&edges, EdgeKind::UsesMacro, "testable")
+                && !has(&edges, EdgeKind::UsesMacro, "_exported"),
+            "import modifiers are not attached macro uses: {edges:#?}"
+        );
+    }
+
+    #[test]
+    fn enum_raw_types_are_references_while_protocols_remain_conformances() {
+        let src = r#"
+protocol Codable {}
+enum Status: String, Codable { case ready = "ready" }
+enum Direction: Int { case north, south }
+enum Empty: String {}
+enum Plain: Codable { case ready }
+enum Qualified: Domain.String { case ready }
+enum Outer: Codable {
+    enum Inner: String { case value = "value" }
+}
+"#;
+        let edges = edges(src);
+        assert!(
+            has(&edges, EdgeKind::ReferencesType, "String"),
+            "raw enum type must be a type reference: {edges:#?}"
+        );
+        assert!(
+            !edges.iter().any(|edge| {
+                edge.edge_kind == EdgeKind::Implements
+                    && edge.to_name == "String"
+                    && edge.target_qualified_name.is_none()
+            }),
+            "unqualified raw enum types must not become conformances: {edges:#?}"
+        );
+        assert_eq!(
+            edges
+                .iter()
+                .filter(|edge| edge.edge_kind == EdgeKind::Implements && edge.to_name == "Codable")
+                .count(),
+            3,
+            "protocol conformances on raw, plain, and nested enums remain visible: {edges:#?}"
+        );
+        assert!(
+            edges.iter().any(|edge| {
+                edge.edge_kind == EdgeKind::Implements
+                    && edge.target_qualified_name.as_deref() == Some("Domain::String")
+            }),
+            "an arbitrary qualified String is a conformance without raw-value evidence: {edges:#?}"
+        );
+        for raw_type in ["Int", "String"] {
+            assert!(
+                has(&edges, EdgeKind::ReferencesType, raw_type),
+                "implicit and empty raw enums retain {raw_type} type edges: {edges:#?}"
+            );
+        }
+    }
+
+    #[test]
+    fn bracket_syntax_emits_subscript_calls_with_receiver_context() {
+        let src = r#"
+let value = store[id]
+let staticValue = Store[id]
+func generic<T>(_ index: Int) {
+    _ = T[index]
+    _ = Namespace.T[index]
+}
+"#;
+        let edges = edges(src);
+        let subscripts = edges
+            .iter()
+            .filter(|edge| edge.edge_kind == EdgeKind::CallsName && edge.to_name == "subscript")
+            .collect::<Vec<_>>();
+        assert_eq!(subscripts.len(), 3, "eligible bracket expressions emit one call: {edges:#?}");
+        assert!(subscripts.iter().any(|edge| {
+            edge.receiver_hint.as_deref() == Some("store") && edge.target_qualified_name.is_none()
+        }));
+        assert!(subscripts.iter().any(|edge| {
+            edge.receiver_hint.as_deref() == Some("Store")
+                && edge.target_qualified_name.as_deref() == Some("Store::subscript")
+        }));
+        assert!(subscripts.iter().any(|edge| {
+            edge.receiver_hint.as_deref() == Some("Namespace")
+                && edge.target_qualified_name.as_deref() == Some("Namespace::T::subscript")
+        }));
+        assert!(
+            !subscripts.iter().any(|edge| {
+                edge.receiver_hint.as_deref() == Some("T")
+                    && edge.target_qualified_name.as_deref() == Some("T::subscript")
+            }),
+            "a lexical generic root must not bind to a nominal subscript: {edges:#?}"
+        );
+    }
+
+    #[test]
+    fn generic_calls_and_constructor_expressions_keep_the_constructed_type() {
+        let src = r#"
+struct Box<T> {}
+protocol DefaultInit {}
+
+func make() {
+    let box = Box<Int>()
+    let array = Array<String>()
+    let dictionary = [String: Int]()
+}
+
+func makeGeneric<T: DefaultInit>() -> T {
+    let direct = T()
+    let explicit = T.init()
+    return direct
+}
+"#;
+        let edges = edges(src);
+        for target in ["Box", "Array", "Dictionary"] {
+            let edge = edges
+                .iter()
+                .find(|edge| edge.edge_kind == EdgeKind::Constructs && edge.to_name == target)
+                .unwrap_or_else(|| panic!("missing {target} construction: {edges:#?}"));
+            assert!(
+                source_text(edge, src).is_some_and(|source| source.contains('(')),
+                "construction source must cover the initializer call: {edge:#?}"
+            );
+        }
+        assert!(
+            !has(&edges, EdgeKind::Constructs, "Int")
+                && !has(&edges, EdgeKind::Constructs, "String")
+                && !has(&edges, EdgeKind::Constructs, "T"),
+            "generic arguments are not constructed call targets: {edges:#?}"
+        );
+        assert!(
+            !edges.iter().any(|edge| {
+                matches!(edge.edge_kind, EdgeKind::CallsName | EdgeKind::Constructs)
+                    && edge.to_name == "T"
+            }),
+            "generic initializer spellings must not emit callable edges: {edges:#?}"
+        );
+        let box_edge = edges
+            .iter()
+            .find(|edge| edge.edge_kind == EdgeKind::Constructs && edge.to_name == "Box")
+            .unwrap();
+        assert_eq!(callee_text(box_edge, src), Some("Box"));
+    }
+
+    #[test]
+    fn explicit_init_calls_construct_the_qualifying_type() {
+        let src = r#"
+func make() {
+    let client = Client.init()
+    let qualified = Module.Service.init()
+    client.init()
+    Self.init()
+    self.init()
+    super.init()
+}
+"#;
+        let edges = edges(src);
+        for target in ["Client", "Service"] {
+            let edge = edges
+                .iter()
+                .find(|edge| edge.edge_kind == EdgeKind::Constructs && edge.to_name == target)
+                .unwrap_or_else(|| panic!("missing {target} construction: {edges:#?}"));
+            assert_eq!(callee_text(edge, src), Some(target));
+        }
+        assert!(
+            has(&edges, EdgeKind::CallsName, "init"),
+            "lowercase receiver init remains a method call: {edges:#?}"
+        );
+        assert!(
+            edges.iter().any(|edge| {
+                edge.edge_kind == EdgeKind::CallsName
+                    && edge.to_name == "init"
+                    && edge.receiver_hint.as_deref() == Some("client")
+            }),
+            "a value-receiver init must retain its receiver hint: {edges:#?}"
+        );
+        for call in ["Self.init()", "self.init()", "super.init()"] {
+            let receiver = call.split_once('.').map(|(receiver, _)| receiver).unwrap();
+            let qualified = format!("{receiver}::init");
+            assert!(
+                edges.iter().any(|edge| {
+                    edge.edge_kind == EdgeKind::CallsName
+                        && edge.to_name == "init"
+                        && edge.evidence.as_deref() == Some(call)
+                        && edge.receiver_hint.as_deref() == Some(receiver)
+                        && edge.target_qualified_name.as_deref() == Some(qualified.as_str())
+                }),
+                "{call} must retain its local receiver context: {edges:#?}"
+            );
+        }
+        assert!(
+            !edges
+                .iter()
+                .any(|edge| edge.edge_kind == EdgeKind::Constructs && edge.to_name == "init"),
+            "init is not itself a constructed type: {edges:#?}"
+        );
+    }
+
+    #[test]
+    fn qualified_type_references_keep_the_canonical_path() {
+        let src = "func load(_ request: API.Request) -> Other.Request { request }";
+        let edges = edges(src);
+        let qualified_names = edges
+            .iter()
+            .filter(|edge| edge.edge_kind == EdgeKind::ReferencesType && edge.to_name == "Request")
+            .map(|edge| {
+                (
+                    edge.target_qualified_name.as_deref(),
+                    edge.receiver_hint.as_deref(),
+                    callee_text(edge, src),
+                )
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(qualified_names, vec![
+            (Some("API::Request"), Some("API"), Some("Request")),
+            (Some("Other::Request"), Some("Other"), Some("Request")),
+        ]);
+    }
+
+    #[test]
+    fn generic_and_self_associated_type_projections_are_not_nominal_references() {
+        let src = r#"
+struct Element {}
+protocol Container { associatedtype Item }
+func generic<T: Container>(_ value: T) -> T.Item { value as! T.Item }
+extension Container { func local() -> Self.Item { fatalError() } }
+"#;
+        let edges = edges(src);
+        assert!(
+            !edges.iter().any(|edge| {
+                edge.edge_kind == EdgeKind::ReferencesType
+                    && matches!(edge.to_name.as_str(), "T" | "Item" | "Self")
+            }),
+            "generic/Self projections must not bind unrelated nominal types: {edges:#?}"
+        );
+        assert!(has(&edges, EdgeKind::ReferencesType, "Container"));
+    }
+
+    #[test]
+    fn qualified_inheritance_and_construction_share_canonical_paths() {
+        let src = "class Child: API.Parent { let request = API.Request() }";
+        let edges = edges(src);
+        for (kind, target, qualified) in [
+            (EdgeKind::Implements, "Parent", "API::Parent"),
+            (EdgeKind::Constructs, "Request", "API::Request"),
+            (EdgeKind::ReferencesType, "Request", "API::Request"),
+        ] {
+            assert!(
+                edges.iter().any(|edge| {
+                    edge.edge_kind == kind
+                        && edge.to_name == target
+                        && edge.target_qualified_name.as_deref() == Some(qualified)
+                }),
+                "missing canonical {kind:?} edge to {qualified}: {edges:#?}"
+            );
+        }
+    }
+
+    #[test]
+    fn macro_invocations_emit_uses_macro_edges() {
+        let src = r#"
+macro stringify<T>(_ value: T) = #externalMacro(module: "Macros", type: "StringifyMacro")
+let result = #stringify(value)
+"#;
+        let edges = edges(src);
+        let invocation = edges
+            .iter()
+            .find(|edge| edge.edge_kind == EdgeKind::UsesMacro && edge.to_name == "stringify")
+            .unwrap_or_else(|| panic!("missing Swift macro-use edge: {edges:#?}"));
+        assert_eq!(callee_text(invocation, src), Some("stringify"));
+        assert!(source_text(invocation, src).is_some_and(|source| source == "#stringify(value)"));
+        assert!(
+            !has(&edges, EdgeKind::UsesMacro, "externalMacro"),
+            "the compiler implementation hook is not a macro call: {edges:#?}"
+        );
+    }
+
+    #[test]
+    fn ordinary_attributes_and_extension_targets_emit_type_references() {
+        let src = r#"
+@MainActor
+@Macros.Observable(source: "fixture")
+class Model {
+    @Wrapper var value: Int
+}
+
+extension Model {
+    func refresh() {}
+}
+"#;
+        let edges = edges(src);
+        for target in ["MainActor", "Observable", "Wrapper"] {
+            assert!(
+                has(&edges, EdgeKind::ReferencesType, target),
+                "attribute type {target} must remain visible: {edges:#?}"
+            );
+            assert!(has(&edges, EdgeKind::UsesMacro, target));
+        }
+        assert!(
+            !has(&edges, EdgeKind::UsesMacro, "source"),
+            "attribute argument labels are not macro names: {edges:#?}"
+        );
+        let extension_target = edges
+            .iter()
+            .find(|edge| {
+                edge.edge_kind == EdgeKind::ReferencesType
+                    && edge.to_name == "Model"
+                    && source_text(edge, src).is_some_and(|source| source.starts_with("Model"))
+            })
+            .unwrap_or_else(|| panic!("extension target must reference Model: {edges:#?}"));
+        assert_eq!(callee_text(extension_target, src), Some("Model"));
+    }
+
+    #[test]
+    fn attached_attributes_emit_resolver_candidates_without_argument_labels() {
+        let src = r#"
+@attached(member) macro Observable() = #externalMacro(module: "Macros", type: "ObservableMacro")
+@Observable struct Model {}
+@Macros.Observable struct QualifiedModel {}
+@available(*, deprecated) struct LegacyModel {}
+@objc class ObjectiveCModel {}
+@MainActor class ActorModel {}
+"#;
+        let edges = edges(src);
+        let macro_uses =
+            edges.iter().filter(|edge| edge.edge_kind == EdgeKind::UsesMacro).collect::<Vec<_>>();
+        for attribute in ["attached", "Observable", "available", "objc", "MainActor"] {
+            assert!(
+                macro_uses.iter().any(|edge| edge.to_name == attribute),
+                "attribute {attribute} must reach resolver policy: {edges:#?}"
+            );
+        }
+        let qualified = macro_uses
+            .iter()
+            .find(|edge| edge.target_qualified_name.as_deref() == Some("Macros::Observable"))
+            .unwrap_or_else(|| {
+                panic!("qualified macro use must retain module context: {edges:#?}")
+            });
+        assert_eq!(qualified.receiver_hint.as_deref(), Some("Macros"));
+        assert!(!has(&edges, EdgeKind::UsesMacro, "member"));
+        assert!(!has(&edges, EdgeKind::UsesMacro, "externalMacro"));
+    }
+
+    #[test]
+    fn expression_valued_callables_do_not_invent_outer_call_targets() {
+        let src = r#"
+let immediate = { helper() }()
+let selected = handlers[key]()
+plain()
+client.fetch()
+self.refresh()
+super.finish()
+"#;
+        let edges = edges(src);
+        let helper_calls = edges
+            .iter()
+            .filter(|edge| edge.edge_kind == EdgeKind::CallsName && edge.to_name == "helper")
+            .collect::<Vec<_>>();
+        assert_eq!(helper_calls.len(), 1, "closure IIFE must emit only its inner call");
+        assert_eq!(source_text(helper_calls[0], src), Some("helper()"));
+        assert!(has(&edges, EdgeKind::CallsName, "plain"), "direct call missing");
+        assert!(has(&edges, EdgeKind::CallsName, "fetch"), "static member call missing");
+        assert!(has(&edges, EdgeKind::CallsName, "refresh"), "self member call missing");
+        assert!(has(&edges, EdgeKind::CallsName, "finish"), "super member call missing");
+        assert!(
+            !has(&edges, EdgeKind::CallsName, "key")
+                && !has(&edges, EdgeKind::CallsName, "handlers"),
+            "subscripted/dynamic callable must not invent a named outer call: {edges:#?}"
+        );
+    }
+}

--- a/crates/rag-rat-core/src/index/languages/swift/mod.rs
+++ b/crates/rag-rat-core/src/index/languages/swift/mod.rs
@@ -18,6 +18,25 @@ fn is_local_qualified_root(root: &str) -> bool {
 }
 
 impl ParserBackend for Swift {
+    fn symbol_kinds(&self) -> &'static [&'static str] {
+        &[
+            "actor",
+            "class",
+            "constructor",
+            "enum",
+            "enum_case",
+            "extension",
+            "function",
+            "macro",
+            "operator",
+            "precedence_group",
+            "property",
+            "protocol",
+            "struct",
+            "type",
+        ]
+    }
+
     fn parser_kind(&self, _path: &Path) -> ParserKind {
         ParserKind::Swift
     }
@@ -91,9 +110,65 @@ impl ParserBackend for Swift {
         }
     }
 
+    /// Swift's two test frameworks, neither of which the path heuristic alone catches:
+    /// swift-testing marks tests with an `@Test` / `@Suite` ATTRIBUTE, and XCTest by inheriting
+    /// `XCTestCase` with `test`-prefixed methods. A test living outside a `Tests/` directory —
+    /// an XCTestCase beside the code it exercises, a `@Test` in a sample target — is otherwise
+    /// indexed as production source and never demoted in search or `repo_brief`. Every other
+    /// language with a test convention (Rust `#[test]`, Kotlin `@Test`, Python `test_*`)
+    /// already overrides this; Swift declared none.
+    fn is_test_symbol(&self, text: &str, node: Node<'_>, scope_path: &str, name: &str) -> bool {
+        has_test_attribute(node, text)
+            || inherits_xctest_case(node, text)
+            || (name.starts_with("test") && scope_path_has_test_type(scope_path))
+    }
+
     fn is_plumbing_node(&self, node: Node<'_>) -> bool {
         node.kind().contains("comment") || node.kind() == "import_declaration"
     }
+}
+
+/// A swift-testing `@Test` / `@Suite` attribute on this declaration. tree-sitter-swift nests
+/// attributes under a `modifiers` child (`modifiers` → `attribute` → `user_type`), so this descends
+/// one level rather than scanning the declaration's direct children. Matched on the attribute's own
+/// name node, so `@TestHarness` does not read as `@Test`.
+fn has_test_attribute(node: Node<'_>, text: &str) -> bool {
+    let mut cursor = node.walk();
+    node.children(&mut cursor)
+        .filter(|child| child.kind() == "modifiers")
+        .flat_map(|modifiers| {
+            let mut inner = modifiers.walk();
+            modifiers.children(&mut inner).collect::<Vec<_>>()
+        })
+        .filter(|child| child.kind() == "attribute")
+        .any(|attribute| {
+            syntax::identifier_nodes(attribute)
+                .first()
+                .and_then(|name| parser::node_text(*name, text))
+                .is_some_and(|name| matches!(name.as_str(), "Test" | "Suite"))
+        })
+}
+
+/// An XCTest base class in this type's inheritance clause (`class FooTests: XCTestCase`). The
+/// conformance list is where XCTest declares itself; there is no attribute to key on.
+fn inherits_xctest_case(node: Node<'_>, text: &str) -> bool {
+    if node.kind() != "class_declaration" {
+        return false;
+    }
+    let mut cursor = node.walk();
+    node.children(&mut cursor)
+        .filter(|child| child.kind() == "inheritance_specifier")
+        .filter_map(|specifier| parser::node_text(specifier, text))
+        .any(|specifier| specifier.trim_end_matches("()").ends_with("XCTestCase"))
+}
+
+/// A `test`-prefixed method inside a type whose name reads as a test type (`FooTests`,
+/// `FooTestCase`) — the XCTest convention, mirroring the Python backend's
+/// `scope_path_has_test_class` for members of a class the parser sees only by name.
+fn scope_path_has_test_type(scope_path: &str) -> bool {
+    scope_path
+        .split("::")
+        .any(|segment| segment.ends_with("Tests") || segment.ends_with("TestCase"))
 }
 
 fn recovered_precedence_group_name<'tree>(node: Node<'tree>, text: &str) -> Option<Node<'tree>> {

--- a/crates/rag-rat-core/src/index/languages/swift/mod.rs
+++ b/crates/rag-rat-core/src/index/languages/swift/mod.rs
@@ -119,7 +119,7 @@ impl ParserBackend for Swift {
     /// already overrides this; Swift declared none.
     fn is_test_symbol(&self, text: &str, node: Node<'_>, scope_path: &str, name: &str) -> bool {
         has_test_attribute(node, text)
-            || inherits_xctest_case(node, text)
+            || enclosed_by_xctest_case(node, text)
             || (name.starts_with("test") && scope_path_has_test_type(scope_path))
     }
 
@@ -149,9 +149,22 @@ fn has_test_attribute(node: Node<'_>, text: &str) -> bool {
         })
 }
 
-/// An XCTest base class in this type's inheritance clause (`class FooTests: XCTestCase`). The
+/// This declaration IS an XCTest class (`class FooTests: XCTestCase`) or lives INSIDE one. The
 /// conformance list is where XCTest declares itself; there is no attribute to key on.
-fn inherits_xctest_case(node: Node<'_>, text: &str) -> bool {
+///
+/// Walking ancestors (not just the node) is what keeps a test class's MEMBERS out of production
+/// symbols. The class-name suffix check below can't do it: `class LoginFlow: XCTestCase` gives its
+/// methods the scope path `LoginFlow::testLogin`, whose root ends in neither `Tests` nor
+/// `TestCase`, so a sidecar XCTest living outside a `Tests/` directory would have had its methods —
+/// and its helpers — indexed as production code and fed to embeddings and clone analysis.
+/// Everything inside an XCTestCase is test scaffolding, `test`-prefixed or not.
+fn enclosed_by_xctest_case(node: Node<'_>, text: &str) -> bool {
+    std::iter::successors(Some(node), |current| current.parent())
+        .any(|ancestor| declares_xctest_case(ancestor, text))
+}
+
+/// One declaration node whose own inheritance clause names an XCTest base class.
+fn declares_xctest_case(node: Node<'_>, text: &str) -> bool {
     if node.kind() != "class_declaration" {
         return false;
     }
@@ -292,6 +305,21 @@ impl ResolverPolicy for Swift {
 
     fn reference_is_unresolvable(&self, edge_kind: &str, name: &str) -> bool {
         edge_kind == "imports" || (edge_kind == "calls_name" && operator_has_builtin_meaning(name))
+    }
+
+    /// An enum case is reachable by BARE NAME only through Swift's shorthand `.idle` — the one
+    /// shape that is evidence of a case (the enum is inferred, so no qualifier exists to match
+    /// on).
+    ///
+    /// Everything else that lands on `calls_name` shares that AST shape without being a case: a
+    /// value-receiver method call (`client.idle()`) and a static member read (`Config.idle`) both
+    /// carry a receiver/qualifier. Those resolve through the qualified path when the member really
+    /// exists; when it does NOT, the bare-name fallback would otherwise bind them to an unrelated
+    /// `enum Status { case idle }` and report an ordinary property read or method call as a caller
+    /// of that case. Enum cases cannot be invoked through an arbitrary value receiver, so the bind
+    /// is never right — require the bare shape.
+    fn kind_requires_unqualified_reference(&self, edge_kind: &str, target_kind: &str) -> bool {
+        edge_kind == "calls_name" && target_kind == "enum_case"
     }
 
     fn suppress_unresolved_reference(&self, edge_kind: &str, evidence: Option<&str>) -> bool {

--- a/crates/rag-rat-core/src/index/languages/swift/mod.rs
+++ b/crates/rag-rat-core/src/index/languages/swift/mod.rs
@@ -1,0 +1,278 @@
+use std::path::Path;
+
+use tree_sitter::Node;
+
+use super::{EdgeBackend, KindPreference, ParserBackend, ResolverPolicy, SymbolMatch};
+use crate::index::edges::{EdgeCandidate, IndexedSymbol};
+use crate::index::parser::{self, ParserKind};
+
+mod edges;
+pub(super) mod syntax;
+
+pub(super) static SUPPORT: Swift = Swift;
+
+pub(super) struct Swift;
+
+fn is_local_qualified_root(root: &str) -> bool {
+    matches!(root, "Self" | "self" | "super")
+}
+
+impl ParserBackend for Swift {
+    fn parser_kind(&self, _path: &Path) -> ParserKind {
+        ParserKind::Swift
+    }
+
+    fn symbol_node<'tree>(&self, node: Node<'tree>, _text: &str) -> Option<SymbolMatch<'tree>> {
+        symbol_node(node)
+    }
+
+    fn symbol_name(&self, node: Node<'_>, name_node: Node<'_>, text: &str) -> String {
+        let name = parser::node_text(name_node, text).unwrap_or_default();
+        let is_extension = node.kind() == "class_declaration"
+            && node
+                .child_by_field_name("declaration_kind")
+                .is_some_and(|kind| kind.kind() == "extension");
+        if is_extension { format!("extension {name}") } else { name }
+    }
+
+    fn for_each_symbol<'tree>(
+        &self,
+        node: Node<'tree>,
+        text: &str,
+        emit: &mut dyn FnMut(Node<'tree>, SymbolMatch<'tree>),
+    ) {
+        if matches!(node.kind(), "property_declaration" | "protocol_property_declaration") {
+            let mut cursor = node.walk();
+            let patterns = node.children_by_field_name("name", &mut cursor).collect::<Vec<_>>();
+            let bindings = patterns.into_iter().flat_map(property_names).collect::<Vec<_>>();
+            let multiple_bindings = bindings.len() > 1;
+            for name in bindings {
+                // A multi-binding declaration needs one symbol/chunk per binding. Use the bound
+                // identifier as its unique span; single-binding properties retain the complete
+                // declaration span and the caller always takes its signature from there.
+                emit(if multiple_bindings { name } else { node }, ("property", name));
+            }
+        } else if node.kind() == "enum_entry" {
+            let mut cursor = node.walk();
+            let names = node.children_by_field_name("name", &mut cursor).collect::<Vec<_>>();
+            let multiple_cases = names.len() > 1;
+            for name in names {
+                emit(if multiple_cases { name } else { node }, ("enum_case", name));
+            }
+        } else if let Some(symbol) = self.symbol_node(node, text) {
+            emit(node, symbol);
+        }
+    }
+
+    fn for_each_recovered_symbol<'tree>(
+        &self,
+        node: Node<'tree>,
+        text: &str,
+        emit: &mut dyn FnMut(Node<'tree>, SymbolMatch<'tree>),
+    ) {
+        if let Some(name) = recovered_precedence_group_name(node, text) {
+            // tree-sitter-swift 0.7 recovers a valid comma-separated higherThan/lowerThan clause
+            // as an ERROR node. Preserve the declaration symbol so recovered dependency edges
+            // still have their real precedence-group owner.
+            emit(node, ("precedence_group", name));
+        }
+    }
+
+    fn scope_segment(&self, node: Node<'_>, text: &str) -> Option<String> {
+        match node.kind() {
+            "class_declaration" | "protocol_declaration" =>
+                syntax::qualified_name(parser::child_name(node)?, text),
+            "function_declaration" => parser::node_text(parser::child_name(node)?, text),
+            "init_declaration" => parser::node_text(direct_child_of_kind(node, "init")?, text),
+            "deinit_declaration" => parser::node_text(direct_child_of_kind(node, "deinit")?, text),
+            "subscript_declaration" =>
+                parser::node_text(direct_child_of_kind(node, "subscript")?, text),
+            _ => None,
+        }
+    }
+
+    fn is_plumbing_node(&self, node: Node<'_>) -> bool {
+        node.kind().contains("comment") || node.kind() == "import_declaration"
+    }
+}
+
+fn recovered_precedence_group_name<'tree>(node: Node<'tree>, text: &str) -> Option<Node<'tree>> {
+    (node.kind() == "ERROR"
+        && parser::node_text(node, text)?.trim_start().starts_with("precedencegroup"))
+    .then(|| syntax::identifier_nodes(node).into_iter().next())
+    .flatten()
+}
+
+fn symbol_node(node: Node<'_>) -> Option<SymbolMatch<'_>> {
+    match node.kind() {
+        "class_declaration" => {
+            let declaration_kind = node.child_by_field_name("declaration_kind")?;
+            let kind = match declaration_kind.kind() {
+                "actor" => "actor",
+                "class" => "class",
+                "enum" => "enum",
+                "extension" => "extension",
+                "struct" => "struct",
+                _ => return None,
+            };
+            Some((kind, parser::child_name(node)?))
+        },
+        "protocol_declaration" => Some(("protocol", parser::child_name(node)?)),
+        "function_declaration" | "protocol_function_declaration" =>
+            Some(("function", parser::child_name(node)?)),
+        "init_declaration" => Some(("constructor", direct_child_of_kind(node, "init")?)),
+        "deinit_declaration" => Some(("function", direct_child_of_kind(node, "deinit")?)),
+        "subscript_declaration" => Some(("function", direct_child_of_kind(node, "subscript")?)),
+        "typealias_declaration" | "associatedtype_declaration" =>
+            Some(("type", parser::child_name(node)?)),
+        "macro_declaration" => Some(("macro", parser::child_name(node)?)),
+        "operator_declaration" => Some(("operator", operator_name(node)?)),
+        "precedence_group_declaration" => Some(("precedence_group", parser::child_name(node)?)),
+        _ => None,
+    }
+}
+
+fn operator_name(node: Node<'_>) -> Option<Node<'_>> {
+    let mut saw_operator_keyword = false;
+    (0..node.child_count()).find_map(|index| {
+        let child = node.child(u32::try_from(index).ok()?)?;
+        if !saw_operator_keyword {
+            saw_operator_keyword = child.kind() == "operator";
+            return None;
+        }
+        if child.is_extra() {
+            return None;
+        }
+        syntax::is_operator_token(child.kind()).then_some(child)
+    })
+}
+
+fn property_names(pattern: Node<'_>) -> Vec<Node<'_>> {
+    let mut names = Vec::new();
+    let mut stack = vec![pattern];
+    let mut cursor = pattern.walk();
+    while let Some(node) = stack.pop() {
+        if let Some(name) = node.child_by_field_name("bound_identifier") {
+            names.push(name);
+            continue;
+        }
+        // Destructuring patterns are aliases in tree-sitter-swift and do not expose the
+        // `bound_identifier` field. A binding is a pattern whose sole named child is its
+        // identifier. Tuple labels are direct identifier children of the OUTER pattern alongside
+        // nested pattern children, so this shape deliberately excludes them.
+        if node.kind() == "pattern"
+            && node.named_child_count() == 1
+            && let Some(name) =
+                node.named_child(0).filter(|child| child.kind() == "simple_identifier")
+        {
+            names.push(name);
+            continue;
+        }
+        let mut children = node.named_children(&mut cursor).collect::<Vec<_>>();
+        children.reverse();
+        stack.extend(children);
+    }
+    names
+}
+
+fn direct_child_of_kind<'tree>(node: Node<'tree>, kind: &str) -> Option<Node<'tree>> {
+    (0..node.child_count()).find_map(|index| {
+        let index = u32::try_from(index).ok()?;
+        node.child(index).filter(|child| child.kind() == kind)
+    })
+}
+
+impl EdgeBackend for Swift {
+    fn edges(
+        &self,
+        text: &str,
+        node: Node<'_>,
+        symbols: &[IndexedSymbol],
+        path: &Path,
+        out: &mut Vec<EdgeCandidate>,
+    ) {
+        edges::swift_edges(text, node, symbols, path, out);
+    }
+}
+
+impl ResolverPolicy for Swift {
+    fn preferred_kinds(&self, edge_kind: &str) -> Option<KindPreference> {
+        let symbol_kinds: &'static [&'static str] = match edge_kind {
+            "calls_name" => &["function", "method", "constructor", "enum_case"],
+            "constructs" => &["struct", "enum", "class", "object", "actor"],
+            "implements" => &["protocol", "class"],
+            "references_type" =>
+                &["struct", "enum", "type", "class", "object", "actor", "protocol"],
+            "uses_macro" => &["macro"],
+            "uses_operator" => &["operator"],
+            "uses_precedence_group" => &["precedence_group"],
+            _ => return None,
+        };
+        Some(KindPreference { symbol_kinds, same_language_only: true })
+    }
+
+    fn collapse_same_named_declarations(&self) -> bool {
+        false
+    }
+
+    fn reference_is_unresolvable(&self, edge_kind: &str, name: &str) -> bool {
+        edge_kind == "imports" || (edge_kind == "calls_name" && operator_has_builtin_meaning(name))
+    }
+
+    fn suppress_unresolved_reference(&self, edge_kind: &str, evidence: Option<&str>) -> bool {
+        matches!(edge_kind, "uses_macro" | "references_type")
+            && evidence.is_some_and(|source| source.trim_start().starts_with('@'))
+    }
+
+    fn is_local_qualified_root(&self, root: &str) -> bool {
+        is_local_qualified_root(root)
+    }
+}
+
+fn operator_has_builtin_meaning(name: &str) -> bool {
+    matches!(
+        name,
+        "=" | "+"
+            | "-"
+            | "*"
+            | "/"
+            | "%"
+            | "=="
+            | "!="
+            | "==="
+            | "!=="
+            | ">"
+            | "<"
+            | ">="
+            | "<="
+            | "&&"
+            | "||"
+            | "!"
+            | "&"
+            | "|"
+            | "^"
+            | "~"
+            | "<<"
+            | ">>"
+            | "+="
+            | "-="
+            | "*="
+            | "/="
+            | "%="
+            | "&="
+            | "|="
+            | "^="
+            | "<<="
+            | ">>="
+            | "&+"
+            | "&-"
+            | "&*"
+            | "&+="
+            | "&-="
+            | "&*="
+            | "~="
+            | "??"
+            | "..."
+            | "..<"
+    )
+}

--- a/crates/rag-rat-core/src/index/languages/swift/syntax.rs
+++ b/crates/rag-rat-core/src/index/languages/swift/syntax.rs
@@ -1,0 +1,83 @@
+use tree_sitter::Node;
+
+/// Swift source paths use `.` while the graph's canonical scope paths use `::`. Extract only the
+/// lexical path segments, excluding generic arguments, so declarations and edges share one
+/// representation (`API::Request`, never `API.Request` or `API::Request::Element`).
+pub(crate) fn identifier_nodes(root: Node<'_>) -> Vec<Node<'_>> {
+    let mut identifiers = Vec::new();
+    let mut stack = vec![root];
+    let mut children = Vec::new();
+    while let Some(node) = stack.pop() {
+        if matches!(node.kind(), "type_arguments" | "type_parameters") {
+            continue;
+        }
+        if matches!(
+            node.kind(),
+            "identifier"
+                | "simple_identifier"
+                | "type_identifier"
+                | "self_expression"
+                | "super_expression"
+        ) {
+            identifiers.push(node);
+            continue;
+        }
+        let mut cursor = node.walk();
+        children.clear();
+        children.extend(node.named_children(&mut cursor));
+        for &child in children.iter().rev() {
+            stack.push(child);
+        }
+    }
+    identifiers
+}
+
+pub(crate) fn segments(root: Node<'_>, text: &str) -> Vec<String> {
+    identifier_nodes(root)
+        .into_iter()
+        .filter_map(|node| node.utf8_text(text.as_bytes()).ok().map(str::to_owned))
+        .collect()
+}
+
+pub(crate) fn canonical_name(segments: &[String]) -> Option<String> {
+    (!segments.is_empty()).then(|| segments.join("::"))
+}
+
+pub(crate) fn qualified_name(root: Node<'_>, text: &str) -> Option<String> {
+    canonical_name(&segments(root, text))
+}
+
+pub(crate) fn is_operator_token(kind: &str) -> bool {
+    matches!(
+        kind,
+        "custom_operator"
+            | "bang"
+            | "!="
+            | "!=="
+            | "%"
+            | "%="
+            | "&"
+            | "*"
+            | "*="
+            | "+"
+            | "++"
+            | "+="
+            | "-"
+            | "--"
+            | "-="
+            | "/"
+            | "/="
+            | "<"
+            | "<<"
+            | "<="
+            | "="
+            | "=="
+            | "==="
+            | ">"
+            | ">="
+            | ">>"
+            | "^"
+            | "|"
+            | "~"
+    )
+}

--- a/crates/rag-rat-core/src/index/languages/typescript/edges.rs
+++ b/crates/rag-rat-core/src/index/languages/typescript/edges.rs
@@ -1,6 +1,10 @@
-//! TypeScript graph-edge extraction — the `Language::TypeScript` arm of `syntactic_edges`.
-//! Split out of edges/extract.
-use super::*;
+//! TypeScript graph-edge extraction for the shared structural edge walk.
+use std::path::Path;
+
+use tree_sitter::Node;
+
+use crate::index::edges::extract::*;
+use crate::index::edges::*;
 
 pub(super) fn typescript_edges(
     text: &str,

--- a/crates/rag-rat-core/src/index/languages/typescript/mod.rs
+++ b/crates/rag-rat-core/src/index/languages/typescript/mod.rs
@@ -1,0 +1,65 @@
+use std::path::Path;
+
+use tree_sitter::Node;
+
+use super::{EdgeBackend, ParserBackend, SymbolMatch};
+use crate::index::edges::{EdgeCandidate, IndexedSymbol};
+use crate::index::parser::{self, ParserKind};
+
+mod edges;
+
+pub(super) static SUPPORT: TypeScript = TypeScript;
+
+pub(super) struct TypeScript;
+
+impl ParserBackend for TypeScript {
+    fn parser_kind(&self, path: &Path) -> ParserKind {
+        if path.extension().and_then(|ext| ext.to_str()) == Some("tsx") {
+            ParserKind::Tsx
+        } else {
+            ParserKind::TypeScript
+        }
+    }
+
+    fn symbol_node<'tree>(&self, node: Node<'tree>, _text: &str) -> Option<SymbolMatch<'tree>> {
+        match node.kind() {
+            "function_declaration" | "method_definition" | "generator_function_declaration" =>
+                Some(("function", parser::child_name(node)?)),
+            "class_declaration" => Some(("class", parser::child_name(node)?)),
+            "interface_declaration" => Some(("interface", parser::child_name(node)?)),
+            "type_alias_declaration" => Some(("type", parser::child_name(node)?)),
+            "variable_declarator" | "public_field_definition" =>
+                Some(("const", parser::child_name(node)?)),
+            _ => None,
+        }
+    }
+
+    fn scope_segment(&self, node: Node<'_>, text: &str) -> Option<String> {
+        let name = match node.kind() {
+            "class_declaration"
+            | "interface_declaration"
+            | "internal_module"
+            | "module"
+            | "namespace_declaration" => parser::child_name(node)?,
+            _ => return None,
+        };
+        parser::node_text(name, text)
+    }
+
+    fn is_plumbing_node(&self, node: Node<'_>) -> bool {
+        node.kind().contains("comment") || node.kind() == "import_statement"
+    }
+}
+
+impl EdgeBackend for TypeScript {
+    fn edges(
+        &self,
+        text: &str,
+        node: Node<'_>,
+        symbols: &[IndexedSymbol],
+        path: &Path,
+        out: &mut Vec<EdgeCandidate>,
+    ) {
+        edges::typescript_edges(text, node, symbols, path, out);
+    }
+}

--- a/crates/rag-rat-core/src/index/languages/typescript/mod.rs
+++ b/crates/rag-rat-core/src/index/languages/typescript/mod.rs
@@ -13,6 +13,10 @@ pub(super) static SUPPORT: TypeScript = TypeScript;
 pub(super) struct TypeScript;
 
 impl ParserBackend for TypeScript {
+    fn symbol_kinds(&self) -> &'static [&'static str] {
+        &["class", "const", "function", "interface", "type"]
+    }
+
     fn parser_kind(&self, path: &Path) -> ParserKind {
         if path.extension().and_then(|ext| ext.to_str()) == Some("tsx") {
             ParserKind::Tsx

--- a/crates/rag-rat-core/src/index/mod.rs
+++ b/crates/rag-rat-core/src/index/mod.rs
@@ -4,7 +4,7 @@ pub mod chunker;
 pub mod edges;
 pub mod git_history;
 pub mod ignore_rules;
-mod languages;
+pub(crate) mod languages;
 pub mod oracle;
 pub mod papertrail;
 pub mod parser;

--- a/crates/rag-rat-core/src/index/mod.rs
+++ b/crates/rag-rat-core/src/index/mod.rs
@@ -4,6 +4,7 @@ pub mod chunker;
 pub mod edges;
 pub mod git_history;
 pub mod ignore_rules;
+mod languages;
 pub mod oracle;
 pub mod papertrail;
 pub mod parser;

--- a/crates/rag-rat-core/src/index/oracle/store.rs
+++ b/crates/rag-rat-core/src/index/oracle/store.rs
@@ -636,6 +636,9 @@ pub(crate) fn clear_edge_oracle_for_tool(
               AND edges_data.callee_start_byte = edge_oracle.callee_start_byte
               AND edges_data.callee_end_byte = edge_oracle.callee_end_byte
               AND ek.value = edge_oracle.edge_kind
+              AND edges_data.resolution_id NOT IN (
+                  SELECT id FROM name_strings WHERE value = 'suppressed'
+              )
               AND {scope}
           )
         ",
@@ -1439,6 +1442,9 @@ pub(crate) fn prune_edge_oracle_without_live_edge(conn: &Connection) -> anyhow::
               AND edges_data.callee_start_byte = edge_oracle.callee_start_byte
               AND edges_data.callee_end_byte = edge_oracle.callee_end_byte
               AND ek.value = edge_oracle.edge_kind
+              AND edges_data.resolution_id NOT IN (
+                  SELECT id FROM name_strings WHERE value = 'suppressed'
+              )
         ){repo_clause}
         "
         ),

--- a/crates/rag-rat-core/src/index/parser.rs
+++ b/crates/rag-rat-core/src/index/parser.rs
@@ -434,6 +434,15 @@ fn make_symbol(
     name: String,
 ) -> ParsedSymbol {
     let SymbolBuildContext { path, backend, text } = *context;
+    // Every emitted kind must be one the backend DECLARED in `symbol_kinds()` — that declaration is
+    // what downstream consumers (the `symbol_lookup` kind ranking) are completeness-tested against,
+    // so an undeclared kind would sort into the unknown bucket with nothing to catch it.
+    // Debug-only: this is a contract check on our own backends, not input validation, and it
+    // runs on every symbol of every parse in the test suite and the corpus evals.
+    debug_assert!(
+        backend.symbol_kinds().contains(&kind),
+        "{kind} is not declared in this backend's symbol_kinds(); add it there and rank it",
+    );
     let start_byte = node.start_byte();
     let end_byte = node.end_byte();
     // tree-sitter already computed each node's 1-based line span during the parse — read it off the

--- a/crates/rag-rat-core/src/index/parser.rs
+++ b/crates/rag-rat-core/src/index/parser.rs
@@ -194,7 +194,7 @@ pub struct ParsedSymbolFact {
     pub value: String,
 }
 
-const NAME_KINDS: &[&str] = &[
+pub(super) const NAME_KINDS: &[&str] = &[
     "identifier",
     "type_identifier",
     "property_identifier",
@@ -212,24 +212,12 @@ pub enum ParserKind {
     C,
     Cpp,
     Python,
+    Swift,
     Markdown,
 }
 
 pub fn parser_kind(path: &Path, language: Language) -> ParserKind {
-    match language {
-        Language::Rust => ParserKind::Rust,
-        Language::TypeScript =>
-            if path.extension().and_then(|ext| ext.to_str()) == Some("tsx") {
-                ParserKind::Tsx
-            } else {
-                ParserKind::TypeScript
-            },
-        Language::Kotlin => ParserKind::Kotlin,
-        Language::C => ParserKind::C,
-        Language::Cpp => ParserKind::Cpp,
-        Language::Python => ParserKind::Python,
-        Language::Markdown => ParserKind::Markdown,
-    }
+    crate::index::languages::parser_backend(language).parser_kind(path)
 }
 
 const PARSE_ERROR_MESSAGE: &str =
@@ -247,6 +235,7 @@ pub(crate) fn grammar_for(kind: ParserKind) -> Option<tree_sitter::Language> {
         ParserKind::C => tree_sitter_c::LANGUAGE.into(),
         ParserKind::Cpp => tree_sitter_cpp::LANGUAGE.into(),
         ParserKind::Python => tree_sitter_python::LANGUAGE.into(),
+        ParserKind::Swift => tree_sitter_swift::LANGUAGE.into(),
         ParserKind::Markdown => return None,
     })
 }
@@ -315,23 +304,34 @@ fn collect_symbols(
     root: Node<'_>,
     out: &mut Vec<ParsedSymbol>,
 ) {
+    let backend = crate::index::languages::parser_backend(language);
+    let context = SymbolBuildContext { path, backend, text };
     let mut stack = vec![root];
     let mut cursor = root.walk();
     let mut named_children = Vec::new();
     while let Some(node) = stack.pop() {
-        if node.is_error() || node.is_missing() {
+        if node.is_error() {
+            backend.for_each_recovered_symbol(node, text, &mut |span_node, (kind, name_node)| {
+                let name = backend.symbol_name(node, name_node, text);
+                if !name.is_empty() {
+                    out.push(make_symbol(&context, span_node, node, kind, name));
+                }
+            });
             continue;
         }
-        if let Some((kind, name_node)) = symbol_node(language, node, text) {
-            let name = node_text(name_node, text).unwrap_or_default();
-            if !name.is_empty() {
-                // The span (chunk/embedding) is the matched `node`; the SIGNATURE is read from the
-                // declaration node, which differs for a decorated Python def (the span starts at
-                // the decorator, but the signature must be the `def`/`class` line).
-                let signature_node = signature_source_node(language, node);
-                out.push(make_symbol(path, language, text, node, signature_node, kind, name));
-            }
+        if node.is_missing() {
+            continue;
         }
+        backend.for_each_symbol(node, text, &mut |span_node, (kind, name_node)| {
+            let name = backend.symbol_name(node, name_node, text);
+            if !name.is_empty() {
+                // The span (chunk/embedding) is the backend-selected `span_node`; the SIGNATURE is
+                // read from the declaration node. Those differ for decorated Python definitions
+                // and for each binding in a multi-property Swift declaration.
+                let signature_node = backend.signature_source_node(node);
+                out.push(make_symbol(&context, span_node, signature_node, kind, name));
+            }
+        });
         named_children.clear();
         named_children.extend(node.named_children(&mut cursor));
         for &child in named_children.iter().rev() {
@@ -340,140 +340,7 @@ fn collect_symbols(
     }
 }
 
-fn symbol_node<'a>(
-    language: Language,
-    node: Node<'a>,
-    text: &str,
-) -> Option<(&'static str, Node<'a>)> {
-    let kind = node.kind();
-    match language {
-        Language::Rust => match kind {
-            "function_item" => Some(("function", child_name(node)?)),
-            "struct_item" => Some(("struct", child_name(node)?)),
-            "enum_item" => Some(("enum", child_name(node)?)),
-            "trait_item" => Some(("trait", child_name(node)?)),
-            "impl_item" => Some(("impl", impl_name(node).unwrap_or(node))),
-            "mod_item" => Some(("module", child_name(node)?)),
-            "const_item" => Some(("const", child_name(node)?)),
-            "static_item" => Some(("static", child_name(node)?)),
-            "type_item" => Some(("type", child_name(node)?)),
-            "macro_definition" => Some(("macro", child_name(node)?)),
-            _ => None,
-        },
-        Language::TypeScript => match kind {
-            "function_declaration" | "method_definition" | "generator_function_declaration" =>
-                Some(("function", child_name(node)?)),
-            "class_declaration" => Some(("class", child_name(node)?)),
-            "interface_declaration" => Some(("interface", child_name(node)?)),
-            "type_alias_declaration" => Some(("type", child_name(node)?)),
-            "variable_declarator" | "public_field_definition" => Some(("const", child_name(node)?)),
-            _ => None,
-        },
-        Language::Kotlin => match kind {
-            "class_declaration" => Some(("class", child_name(node)?)),
-            "object_declaration" => Some(("object", child_name(node)?)),
-            "function_declaration" => Some(("function", child_name(node)?)),
-            "property_declaration" => Some(("property", kotlin_property_name(node)?)),
-            "companion_object" | "companion_object_declaration" =>
-                Some(("object", companion_name(node).unwrap_or(node))),
-            _ => None,
-        },
-        // C/C++ index DEFINITIONS, not bare declarations. A function prototype (`int foo(void);`,
-        // a `declaration` with a `function_declarator`) and a bodyless type specifier — a forward
-        // declaration (`struct X;`) or a use (`struct X *p`) — are NOT definitions, so they are not
-        // emitted as symbols. Indexing them made `references_type` edges bind to a tiny
-        // forward-decl/use occurrence instead of the real definition (#61: 18% type precision, vs
-        // 85% for calls). `has_body` distinguishes a definition (`struct X { … }`) from the rest.
-        Language::C => match kind {
-            "function_definition" =>
-                Some(("function", function_name(node).or_else(|| child_name(node))?)),
-            "struct_specifier" if has_body(node) => Some(("struct", child_name(node)?)),
-            "union_specifier" if has_body(node) => Some(("union", child_name(node)?)),
-            "enum_specifier" if has_body(node) => Some(("enum", child_name(node)?)),
-            "type_definition" => Some(("type", child_name(node)?)),
-            "preproc_function_def" => Some(("macro", child_name(node)?)),
-            _ => None,
-        },
-        Language::Cpp => match kind {
-            "function_definition" =>
-                Some(("function", function_name(node).or_else(|| child_name(node))?)),
-            "class_specifier" if has_body(node) => Some(("class", child_name(node)?)),
-            "struct_specifier" if has_body(node) => Some(("struct", child_name(node)?)),
-            "union_specifier" if has_body(node) => Some(("union", child_name(node)?)),
-            "enum_specifier" if has_body(node) => Some(("enum", child_name(node)?)),
-            "type_definition" | "alias_declaration" => Some(("type", child_name(node)?)),
-            "namespace_definition" => Some(("namespace", child_name(node)?)),
-            "preproc_function_def" => Some(("macro", child_name(node)?)),
-            _ => None,
-        },
-        Language::Python => match kind {
-            // A decorated def OWNS the symbol span (so `@app.get(...)` / `@dataclass` / `@property`
-            // decorator lines — which often define the API surface — are inside the chunk), using
-            // the inner def's name + kind. The inner `function_definition`/`class_definition` arms
-            // below are guarded so they don't ALSO emit a duplicate with the bare (decorator-less)
-            // span.
-            "decorated_definition" => {
-                let inner = node.child_by_field_name("definition")?;
-                let kind = match inner.kind() {
-                    "function_definition" => "function",
-                    "class_definition" => "class",
-                    _ => return None,
-                };
-                Some((kind, child_name(inner)?))
-            },
-            "function_definition" if !python_parent_is_decorated(node) =>
-                Some(("function", child_name(node)?)),
-            "class_definition" if !python_parent_is_decorated(node) =>
-                Some(("class", child_name(node)?)),
-            // PEP 695 type alias (`type UserId = int`) — index the alias like Rust/TS/C++ type
-            // aliases. `child_name` finds the first identifier (the alias name `UserId`).
-            "type_alias_statement" => Some(("type", child_name(node)?)),
-            // Constants are MODULE- or CLASS-level SCREAMING_SNAKE_CASE assignments only. Gating on
-            // scope keeps function-local uppercase temporaries (`TIMEOUT = compute()`) out of the
-            // symbol table, and the screaming-snake check keeps ordinary lowercase
-            // locals/attributes out.
-            "assignment" if python_assignment_is_const_scope(node) => {
-                let target = node.child_by_field_name("left")?;
-                let name = node_text(target, text)?;
-                (target.kind() == "identifier" && is_screaming_snake_case(&name))
-                    .then_some(("const", target))
-            },
-            _ => None,
-        },
-        Language::Markdown => None,
-    }
-}
-
-/// `true` for a Python constant name (SCREAMING_SNAKE_CASE): at least one ASCII uppercase letter
-/// and only uppercase / digits / underscore. Keeps `DEFAULT_NAME` but rejects `bridge_name` /
-/// `Api`.
-fn is_screaming_snake_case(name: &str) -> bool {
-    name.chars().any(|c| c.is_ascii_uppercase())
-        && name.chars().all(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || c == '_')
-}
-
-/// Whether a Python def node's parent is a `decorated_definition` (so the parent arm owns its
-/// symbol span and the inner arm must not emit a duplicate).
-fn python_parent_is_decorated(node: Node<'_>) -> bool {
-    node.parent().is_some_and(|parent| parent.kind() == "decorated_definition")
-}
-
-/// Whether a Python `assignment` is at module or class scope (a constant), vs a function-local
-/// temporary. Walks ancestors to the first scope boundary: a `function_definition`/`lambda` means
-/// local (not a constant); a `class_definition`/`module` means module/class level (a constant).
-fn python_assignment_is_const_scope(node: Node<'_>) -> bool {
-    let mut ancestor = node.parent();
-    while let Some(current) = ancestor {
-        match current.kind() {
-            "function_definition" | "lambda" => return false,
-            "class_definition" | "module" => return true,
-            _ => ancestor = current.parent(),
-        }
-    }
-    false
-}
-
-fn child_name(node: Node<'_>) -> Option<Node<'_>> {
+pub(super) fn child_name(node: Node<'_>) -> Option<Node<'_>> {
     if let Some(name) = node.child_by_field_name("name") {
         return Some(name);
     }
@@ -489,7 +356,10 @@ fn child_name(node: Node<'_>) -> Option<Node<'_>> {
     node.named_children(&mut cursor).find_map(|child| first_descendant_node(child, NAME_KINDS))
 }
 
-fn first_descendant_node<'tree>(node: Node<'tree>, kinds: &[&str]) -> Option<Node<'tree>> {
+pub(super) fn first_descendant_node<'tree>(
+    node: Node<'tree>,
+    kinds: &[&str],
+) -> Option<Node<'tree>> {
     // grow_stack: full-subtree recursion; grow rather than overflow on a hostile deep subtree
     // (#543).
     crate::index::grow_stack(|| {
@@ -506,23 +376,19 @@ fn first_descendant_node<'tree>(node: Node<'tree>, kinds: &[&str]) -> Option<Nod
     })
 }
 
-/// Whether a C/C++ `*_specifier` node carries its body (`field_declaration_list` /
-/// `enumerator_list` via the grammar's `body` field) — i.e. it is a DEFINITION (`struct X { … }`),
-/// not a forward declaration (`struct X;`) or a use (`struct X *p`). Only definitions are indexed
-/// as symbols so `references_type` edges resolve to the real definition rather than a bodyless
-/// occurrence (#61).
-fn has_body(node: Node<'_>) -> bool {
-    node.child_by_field_name("body").is_some()
-}
-
 /// The semantic scope path for a symbol node: enclosing type/module/namespace/trait names
 /// (outermost first) joined with `::`, ending in the symbol's own `name`. A top-level free function
 /// or type yields just its name. See [`ParsedSymbol::scope_path`].
-fn scope_path(language: Language, node: Node<'_>, text: &str, name: &str) -> String {
+fn scope_path(
+    backend: &dyn crate::index::languages::ParserBackend,
+    node: Node<'_>,
+    text: &str,
+    name: &str,
+) -> String {
     let mut segments = Vec::new();
     let mut current = node.parent();
     while let Some(parent) = current {
-        if let Some(segment) = scope_segment(language, parent, text) {
+        if let Some(segment) = backend.scope_segment(parent, text) {
             segments.push(segment);
         }
         current = parent.parent();
@@ -532,74 +398,10 @@ fn scope_path(language: Language, node: Node<'_>, text: &str, name: &str) -> Str
     segments.join("::")
 }
 
-/// The scope-name contributed by an ENCLOSING node, if it introduces a named scope (a module, the
-/// type an `impl` is for, a class/trait/namespace). Returns `None` for nodes that don't nest a
-/// scope, so the walk skips blocks/expressions and only collects real path segments.
-fn scope_segment(language: Language, node: Node<'_>, text: &str) -> Option<String> {
-    let name_node = match (language, node.kind()) {
-        (Language::Rust, "mod_item" | "trait_item") => child_name(node)?,
-        (Language::Rust, "impl_item") => impl_name(node)?,
-        (Language::TypeScript, "class_declaration" | "interface_declaration") => child_name(node)?,
-        (Language::TypeScript, "internal_module" | "module" | "namespace_declaration") =>
-            child_name(node)?,
-        (Language::Kotlin, "class_declaration" | "object_declaration") => child_name(node)?,
-        // Python nests methods in classes and closures in functions — both bound `scope_path`.
-        (Language::Python, "class_definition" | "function_definition") => child_name(node)?,
-        (Language::Cpp, "namespace_definition") => child_name(node)?,
-        (
-            Language::C | Language::Cpp,
-            "struct_specifier" | "union_specifier" | "class_specifier",
-        ) if has_body(node) => child_name(node)?,
-        _ => return None,
-    };
-    node_text(name_node, text)
-}
-
-fn companion_name(node: Node<'_>) -> Option<Node<'_>> {
-    for index in 0..node.child_count() {
-        let Some(index) = u32::try_from(index).ok() else {
-            continue;
-        };
-        if let Some(child) = node.child(index)
-            && child.kind() == "companion"
-        {
-            return Some(child);
-        }
-    }
-    let mut cursor = node.walk();
-    node.named_children(&mut cursor)
-        .find(|child| matches!(child.kind(), "simple_identifier" | "type_identifier"))
-}
-
-fn kotlin_property_name(node: Node<'_>) -> Option<Node<'_>> {
-    child_name(kotlin_variable_declaration(node).unwrap_or(node))
-}
-
-fn kotlin_variable_declaration(node: Node<'_>) -> Option<Node<'_>> {
-    crate::index::grow_stack(|| {
-        let mut cursor = node.walk();
-        node.named_children(&mut cursor).find_map(|child| {
-            if child.kind() == "variable_declaration" {
-                Some(child)
-            } else if matches!(child.kind(), "modifiers" | "type_parameters" | "type_constraints") {
-                None
-            } else {
-                kotlin_variable_declaration(child)
-            }
-        })
-    })
-}
-
-fn function_name(node: Node<'_>) -> Option<Node<'_>> {
-    let declarator = first_descendant_node(node, &["function_declarator"]).unwrap_or(node);
-    let name_root = declarator.child_by_field_name("declarator").unwrap_or(declarator);
-    if NAME_KINDS.contains(&name_root.kind()) {
-        return Some(name_root);
-    }
-    last_descendant_node(name_root, NAME_KINDS)
-}
-
-fn last_descendant_node<'tree>(node: Node<'tree>, kinds: &[&str]) -> Option<Node<'tree>> {
+pub(super) fn last_descendant_node<'tree>(
+    node: Node<'tree>,
+    kinds: &[&str],
+) -> Option<Node<'tree>> {
     crate::index::grow_stack(|| {
         let mut cursor = node.walk();
         let mut last = None;
@@ -615,17 +417,14 @@ fn last_descendant_node<'tree>(node: Node<'tree>, kinds: &[&str]) -> Option<Node
     })
 }
 
-fn impl_name(node: Node<'_>) -> Option<Node<'_>> {
-    let mut cursor = node.walk();
-    node.named_children(&mut cursor).find(|child| {
-        matches!(child.kind(), "type_identifier" | "generic_type" | "scoped_type_identifier")
-    })
+struct SymbolBuildContext<'a> {
+    path: &'a Path,
+    backend: &'a dyn crate::index::languages::ParserBackend,
+    text: &'a str,
 }
 
 fn make_symbol(
-    path: &Path,
-    language: Language,
-    text: &str,
+    context: &SymbolBuildContext<'_>,
     node: Node<'_>,
     // The declaration node the SIGNATURE is read from. Equals `node` except for a decorated Python
     // def, where `node` is the `decorated_definition` (so the chunk span includes the decorators)
@@ -634,14 +433,15 @@ fn make_symbol(
     kind: &str,
     name: String,
 ) -> ParsedSymbol {
+    let SymbolBuildContext { path, backend, text } = *context;
     let start_byte = node.start_byte();
     let end_byte = node.end_byte();
     // tree-sitter already computed each node's 1-based line span during the parse — read it off the
     // node (O(1) struct field) instead of rescanning the file text for newlines. `row` is 0-based.
     let start_line = node.start_position().row + 1;
     let end_line = node.end_position().row + 1;
-    let scope_path = scope_path(language, node, text, &name);
-    let is_test = detect_is_test(path, language, text, node, &scope_path, &name);
+    let scope_path = scope_path(backend, node, text, &name);
+    let is_test = is_test_path(path) || backend.is_test_symbol(text, node, &scope_path, &name);
     ParsedSymbol {
         qualified_name: format!("{}::{name}", path.to_string_lossy().replace('\\', "/")),
         scope_path,
@@ -654,43 +454,7 @@ fn make_symbol(
         signature: signature_for(text, signature_node.start_byte(), signature_node.end_byte()),
         docs: docs_before(text, start_byte),
         is_test,
-        facts: symbol_facts(language, text, node),
-    }
-}
-
-/// Whether a symbol is test code — persisted as `symbols.is_test` so clone detection can exclude
-/// it. Cross-language: a test FILE path (every language) OR a language-specific in-source marker.
-/// Tests are repetitive by construction (fixture → call → assert), so leaving them in the clone
-/// corpus floods near-clone results — the write-time clone check is the main consumer.
-fn detect_is_test(
-    path: &Path,
-    language: Language,
-    text: &str,
-    node: Node<'_>,
-    scope_path: &str,
-    name: &str,
-) -> bool {
-    if is_test_path(path) {
-        return true;
-    }
-    match language {
-        // Rust unit tests live INLINE in source files, so the path check misses them: a `#[test]`
-        // (or `#[tokio::test]`/`#[rstest]`/…) on the fn, or any ancestor `#[cfg(test)]` module
-        // (catches test helpers too).
-        Language::Rust =>
-            rust_attribute_items(text, node)
-                .iter()
-                .any(|attribute| rust_attribute_is_test(attribute))
-                || rust_in_cfg_test_module(node, text),
-        // Kotlin: a JUnit `@Test`-family annotation on the fn (path catches `*Test.kt` /
-        // `src/test/`).
-        Language::Kotlin => kotlin_has_test_annotation(text, node),
-        // Python: pytest/unittest by convention — `test_*` functions, methods of a `*Test*`/
-        // `*TestCase` class (via scope_path), or anything in `conftest.py` (path).
-        Language::Python => name.starts_with("test_") || scope_path_has_test_class(scope_path),
-        // C / C++ / TypeScript: test bodies aren't named symbols (macros / closures), so the file
-        // path conventions above carry these.
-        _ => false,
+        facts: backend.symbol_facts(text, node),
     }
 }
 
@@ -730,122 +494,7 @@ pub(crate) fn is_test_path(path: impl AsRef<Path>) -> bool {
         || stem.ends_with("TestCase")
 }
 
-/// A Rust attribute that marks a test function: `#[test]`, `#[tokio::test]`, `#[rstest]`,
-/// `#[test_case(..)]`, etc. (a `#[cfg(test)]` is the MODULE marker — handled separately so it
-/// doesn't read as a per-fn test attribute).
-fn rust_attribute_is_test(attribute: &str) -> bool {
-    let inner = attribute
-        .trim()
-        .trim_start_matches('#')
-        .trim_start_matches('!')
-        .trim_start_matches('[')
-        .trim_end_matches(']');
-    let head = inner.split(['(', '[']).next().unwrap_or_default().trim();
-    let last = head.rsplit("::").next().unwrap_or(head).trim();
-    last == "test" || last == "rstest" || last.starts_with("test_case")
-}
-
-/// Whether `node` is nested in any `#[cfg(test)]` module — catches inline unit tests AND their
-/// helpers (a fixture fn in `#[cfg(test)] mod tests` has no `#[test]` of its own).
-fn rust_in_cfg_test_module(node: Node<'_>, text: &str) -> bool {
-    let mut current = node.parent();
-    while let Some(ancestor) = current {
-        if ancestor.kind() == "mod_item"
-            && rust_attribute_items(text, ancestor)
-                .iter()
-                .any(|attribute| attribute.contains("cfg") && attribute.contains("test"))
-        {
-            return true;
-        }
-        current = ancestor.parent();
-    }
-    false
-}
-
-/// Whether a Kotlin function carries a JUnit `@Test`-family annotation (in its `modifiers`).
-fn kotlin_has_test_annotation(text: &str, node: Node<'_>) -> bool {
-    let mut cursor = node.walk();
-    node.named_children(&mut cursor).any(|child| {
-        child.kind() == "modifiers"
-            && node_text(child, text).as_deref().map(kotlin_modifiers_have_test).unwrap_or(false)
-    })
-}
-
-fn kotlin_modifiers_have_test(modifiers: &str) -> bool {
-    modifiers.split('@').skip(1).any(|annotation| {
-        let name = annotation.split(['(', ' ', '\n', '\t', '\r']).next().unwrap_or_default();
-        let last = name.rsplit('.').next().unwrap_or(name);
-        matches!(last, "Test" | "ParameterizedTest" | "RepeatedTest" | "TestFactory")
-    })
-}
-
-/// Whether a Python symbol's enclosing scope is a test class (`Test*` / `*Test` / `*TestCase`),
-/// e.g. a `unittest.TestCase` subclass. `scope_path` is `Class::method`-style.
-fn scope_path_has_test_class(scope_path: &str) -> bool {
-    scope_path.split("::").any(|segment| {
-        segment.starts_with("Test") || segment.ends_with("Test") || segment.ends_with("TestCase")
-    })
-}
-
-/// The node a symbol's signature is read from. For a decorated Python def this is the inner
-/// `def`/`class` (so the signature is the declaration, not the `@decorator` line the span starts
-/// at); for everything else it's the matched node itself.
-fn signature_source_node<'a>(language: Language, node: Node<'a>) -> Node<'a> {
-    if language == Language::Python
-        && node.kind() == "decorated_definition"
-        && let Some(inner) = node.child_by_field_name("definition")
-    {
-        return inner;
-    }
-    node
-}
-
-fn symbol_facts(language: Language, text: &str, node: Node<'_>) -> Vec<ParsedSymbolFact> {
-    if language != Language::Rust {
-        return Vec::new();
-    }
-    let mut facts = Vec::new();
-    for attribute in rust_attribute_items(text, node) {
-        if rust_attribute_is_uniffi_export(&attribute) {
-            facts.push(ParsedSymbolFact {
-                kind: "rust_attr".to_string(),
-                value: "uniffi_export".to_string(),
-            });
-        }
-    }
-    facts.sort_by(|left, right| (&left.kind, &left.value).cmp(&(&right.kind, &right.value)));
-    facts.dedup();
-    facts
-}
-
-fn rust_attribute_items(text: &str, node: Node<'_>) -> Vec<String> {
-    let mut attributes = Vec::new();
-    let mut cursor = node.walk();
-    for child in node.named_children(&mut cursor) {
-        if child.kind() == "attribute_item" {
-            attributes.push(node_text(child, text).unwrap_or_default());
-        }
-    }
-
-    let mut preceding = Vec::new();
-    let mut sibling = node.prev_named_sibling();
-    while let Some(previous) = sibling {
-        if previous.kind() != "attribute_item" {
-            break;
-        }
-        preceding.push(node_text(previous, text).unwrap_or_default());
-        sibling = previous.prev_named_sibling();
-    }
-    preceding.reverse();
-    preceding.extend(attributes);
-    preceding
-}
-
-fn rust_attribute_is_uniffi_export(attribute: &str) -> bool {
-    attribute.contains("uniffi::export") || attribute.contains("::uniffi::export")
-}
-
-fn node_text(node: Node<'_>, text: &str) -> Option<String> {
+pub(super) fn node_text(node: Node<'_>, text: &str) -> Option<String> {
     node.utf8_text(text.as_bytes()).ok().map(ToOwned::to_owned)
 }
 

--- a/crates/rag-rat-core/src/index/parser_tests.rs
+++ b/crates/rag-rat-core/src/index/parser_tests.rs
@@ -343,6 +343,53 @@ macro stringify<T>(_ value: T) = #externalMacro(module: "Macros", type: "Stringi
     assert_no_symbol(&symbols, "macro", "module");
 }
 
+/// Swift test symbols are recognized by their FRAMEWORK, not just by living under a `Tests/` path:
+/// swift-testing's `@Test`/`@Suite` attributes and XCTest's `XCTestCase` inheritance. The fixture
+/// path here deliberately has NO test segment (`Sources/App/…`), so a passing assertion can only
+/// come from symbol-level detection — an XCTestCase beside the code it exercises would otherwise be
+/// indexed as production source and never demoted in search or `repo_brief`.
+#[test]
+fn swift_test_symbols_are_detected_by_framework_not_only_by_path() {
+    let text = r#"
+import Testing
+import XCTest
+
+@Test func checksTheThing() {}
+
+@Suite struct ClientSuite {
+    @Test func checksAnother() {}
+}
+
+class ClientTests: XCTestCase {
+    func testFetchSucceeds() {}
+}
+
+@TestHarness struct NotATest {}
+
+func realWork() -> Int { 1 }
+"#;
+    let symbols =
+        parser::parse_symbols(Path::new("Sources/App/Client.swift"), Language::Swift, text)
+            .expect("Swift fixture parses");
+
+    let is_test = |name: &str| {
+        symbols
+            .iter()
+            .find(|symbol| symbol.name == name)
+            .unwrap_or_else(|| panic!("missing symbol {name}: {symbols:#?}"))
+            .is_test
+    };
+
+    assert!(is_test("checksTheThing"), "@Test function is a test symbol");
+    assert!(is_test("ClientSuite"), "@Suite type is a test symbol");
+    assert!(is_test("checksAnother"), "@Test method inside a suite is a test symbol");
+    assert!(is_test("ClientTests"), "an XCTestCase subclass is a test symbol");
+    assert!(is_test("testFetchSucceeds"), "a test* method of an XCTestCase is a test symbol");
+    // Neither a lookalike attribute nor ordinary code is a test.
+    assert!(!is_test("NotATest"), "@TestHarness is not @Test");
+    assert!(!is_test("realWork"), "production code in a non-test path stays production code");
+}
+
 #[test]
 fn qualified_swift_extension_members_use_canonical_scope_paths() {
     let text = r#"

--- a/crates/rag-rat-core/src/index/parser_tests.rs
+++ b/crates/rag-rat-core/src/index/parser_tests.rs
@@ -90,6 +90,279 @@ fn extracts_kotlin_symbols() {
 }
 
 #[test]
+fn extracts_swift_symbols_and_nested_scope_paths() {
+    let text = r#"
+import Foundation
+
+protocol Repository: Sendable {
+    associatedtype Item
+    var count: Int { get }
+    func load(id: Int) async throws -> Item
+}
+
+extension Repository {
+    func cached(id: Int) async throws -> Item { try await load(id: id) }
+}
+
+actor Store<T>: Repository {
+    typealias Item = T
+    @Wrapper(source: "fixture") private var values: [T] = []
+
+    init(seed: T) { values = [seed] }
+    deinit {}
+    subscript(index: Int) -> T { values[index] }
+
+    func load(id: Int) async throws -> T { values[id] }
+}
+
+extension Store {
+    func mapped<U>(_ transform: (T) -> U) -> [U] { values.map(transform) }
+}
+
+class BaseService {}
+
+class Service: BaseService {
+    struct Request {
+        let id: Int
+    }
+
+    func fetch(_ id: Int) {}
+    func fetch(_ name: String) {}
+}
+
+enum AppState { case idle, failed(Error), running }
+
+precedencegroup MergePrecedence {
+    associativity: left
+    higherThan: AdditionPrecedence
+}
+infix operator <+>: MergePrecedence
+prefix operator /* built-in operator comment */ !
+
+struct Client {
+    func run() async {
+        func local() {}
+        local()
+    }
+}
+"#;
+    let symbols = parser::parse_symbols(Path::new("Sources/App/App.swift"), Language::Swift, text)
+        .expect("Swift fixture parses");
+    assert_eq!(
+        parser::parser_kind(Path::new("Sources/App/App.swift"), Language::Swift),
+        ParserKind::Swift
+    );
+    assert_symbol(&symbols, "protocol", "Repository");
+    assert_symbol(&symbols, "type", "Item");
+    assert_symbol(&symbols, "property", "count");
+    assert_symbol(&symbols, "function", "load");
+    assert!(
+        symbols
+            .iter()
+            .any(|symbol| symbol.name == "cached" && symbol.scope_path == "Repository::cached"),
+        "protocol extension method should carry the extended protocol: {symbols:#?}"
+    );
+    assert_symbol(&symbols, "actor", "Store");
+    assert_symbol(&symbols, "property", "values");
+    assert_no_symbol(&symbols, "property", "source");
+    assert_symbol(&symbols, "constructor", "init");
+    assert_symbol(&symbols, "function", "deinit");
+    assert_symbol(&symbols, "function", "subscript");
+    assert_symbol(&symbols, "extension", "extension Store");
+    assert_no_symbol(&symbols, "extension", "Store");
+    assert_symbol(&symbols, "function", "mapped");
+    assert_symbol(&symbols, "class", "Service");
+    assert!(
+        symbols
+            .iter()
+            .any(|symbol| symbol.name == "Request" && symbol.scope_path == "Service::Request"),
+        "nested nominal types should carry their enclosing type: {symbols:#?}"
+    );
+    assert_eq!(
+        symbols.iter().filter(|symbol| symbol.name == "fetch").count(),
+        2,
+        "both overloads must remain independently indexed: {symbols:#?}"
+    );
+    let int_fetch = symbols
+        .iter()
+        .find(|symbol| {
+            symbol.name == "fetch"
+                && symbol.signature.as_deref() == Some("func fetch(_ id: Int) {}")
+        })
+        .unwrap_or_else(|| panic!("missing exact Swift signature: {symbols:#?}"));
+    assert_eq!(
+        text.get(int_fetch.start_byte..int_fetch.end_byte),
+        Some("func fetch(_ id: Int) {}"),
+        "Swift symbol byte range must cover the complete declaration"
+    );
+    assert_eq!(int_fetch.start_line, int_fetch.end_line);
+    assert_symbol(&symbols, "enum", "AppState");
+    let enum_cases = ["idle", "failed", "running"].map(|case| {
+        let symbol = symbols
+            .iter()
+            .find(|symbol| {
+                symbol.kind == "enum_case"
+                    && symbol.name == case
+                    && symbol.scope_path == format!("AppState::{case}")
+            })
+            .unwrap_or_else(|| {
+                panic!("enum case {case} should carry its enclosing enum scope: {symbols:#?}")
+            });
+        assert_eq!(
+            text.get(symbol.start_byte..symbol.end_byte),
+            Some(case),
+            "multi-case declarations need identifier-precise symbol spans"
+        );
+        assert_eq!(
+            symbol.signature.as_deref(),
+            Some("case idle, failed(Error), running"),
+            "each case retains the complete declaration signature"
+        );
+        (symbol.start_byte, symbol.end_byte)
+    });
+    assert_eq!(
+        enum_cases.into_iter().collect::<std::collections::HashSet<_>>().len(),
+        3,
+        "each case needs a distinct source span"
+    );
+    assert_symbol(&symbols, "precedence_group", "MergePrecedence");
+    assert_symbol(&symbols, "operator", "<+>");
+    assert_symbol(&symbols, "operator", "!");
+    assert_symbol(&symbols, "struct", "Client");
+    assert!(
+        symbols.iter().any(|symbol| symbol.name == "load" && symbol.scope_path == "Store::load"),
+        "actor method should carry its enclosing type: {symbols:#?}"
+    );
+    assert!(
+        symbols
+            .iter()
+            .any(|symbol| symbol.name == "local" && symbol.scope_path == "Client::run::local"),
+        "nested function should carry type and function scopes: {symbols:#?}"
+    );
+}
+
+#[test]
+fn extracts_each_swift_property_binding_with_a_unique_span() {
+    let text = r#"
+struct Size {
+    let depth: Int
+    let width, height: Int
+    var x = 0, y = 0
+}
+let (row, column) = (1, 2)
+let (x: a, y: (b, c)) = (x: 1, y: (2, 3))
+"#;
+    let symbols = parser::parse_symbols(Path::new("Sources/App/Size.swift"), Language::Swift, text)
+        .expect("Swift fixture parses");
+
+    for name in ["width", "height", "x", "y", "row", "column", "a", "b", "c"] {
+        let symbol = symbols
+            .iter()
+            .find(|symbol| symbol.name == name)
+            .unwrap_or_else(|| panic!("missing property {name}: {symbols:#?}"));
+        let expected_scope = if matches!(name, "row" | "column" | "a" | "b" | "c") {
+            name.to_string()
+        } else {
+            format!("Size::{name}")
+        };
+        assert_eq!(symbol.scope_path, expected_scope);
+        assert!(
+            symbol.signature.as_deref().is_some_and(|signature| signature.contains(name)),
+            "property signature should retain its complete declaration: {symbol:#?}"
+        );
+    }
+
+    let mut spans = symbols
+        .iter()
+        .filter(|symbol| {
+            ["width", "height", "x", "y", "row", "column", "a", "b", "c"]
+                .contains(&symbol.name.as_str())
+        })
+        .map(|symbol| (symbol.start_byte, symbol.end_byte))
+        .collect::<Vec<_>>();
+    spans.sort_unstable();
+    spans.dedup();
+    assert_eq!(spans.len(), 9, "each binding must own a unique chunk span: {symbols:#?}");
+    assert_eq!(
+        symbols.iter().filter(|symbol| matches!(symbol.name.as_str(), "x" | "y")).count(),
+        2,
+        "tuple labels must not be indexed as additional bindings: {symbols:#?}"
+    );
+
+    let depth = symbols.iter().find(|symbol| symbol.name == "depth").unwrap();
+    assert_eq!(
+        text.get(depth.start_byte..depth.end_byte),
+        Some("let depth: Int"),
+        "single-binding properties should retain their complete declaration chunk"
+    );
+}
+
+#[test]
+fn swift_local_declarations_include_special_member_scopes() {
+    let text = r#"
+struct Collection {
+    init() { func validateInit() {} }
+    deinit { func validateDeinit() {} }
+    subscript(index: Int) -> Int {
+        func validateSubscript() {}
+        return index
+    }
+}
+"#;
+    let symbols =
+        parser::parse_symbols(Path::new("Sources/App/Collection.swift"), Language::Swift, text)
+            .expect("Swift fixture parses");
+
+    for (name, scope) in [
+        ("validateInit", "Collection::init::validateInit"),
+        ("validateDeinit", "Collection::deinit::validateDeinit"),
+        ("validateSubscript", "Collection::subscript::validateSubscript"),
+    ] {
+        assert!(
+            symbols.iter().any(|symbol| symbol.name == name && symbol.scope_path == scope),
+            "missing {scope}: {symbols:#?}"
+        );
+    }
+}
+
+#[test]
+fn swift_macro_definition_body_is_not_a_second_symbol() {
+    let text = r#"
+macro stringify<T>(_ value: T) = #externalMacro(module: "Macros", type: "StringifyMacro")
+"#;
+    let symbols =
+        parser::parse_symbols(Path::new("Sources/App/Macros.swift"), Language::Swift, text)
+            .expect("Swift fixture parses");
+
+    assert_eq!(
+        symbols.iter().filter(|symbol| symbol.kind == "macro").count(),
+        1,
+        "only the outer macro declaration should be indexed: {symbols:#?}"
+    );
+    assert_symbol(&symbols, "macro", "stringify");
+    assert_no_symbol(&symbols, "macro", "module");
+}
+
+#[test]
+fn qualified_swift_extension_members_use_canonical_scope_paths() {
+    let text = r#"
+enum API { struct Request {} }
+extension API.Request {
+    func decode() {}
+}
+"#;
+    let symbols =
+        parser::parse_symbols(Path::new("Sources/App/Request.swift"), Language::Swift, text)
+            .expect("Swift fixture parses");
+
+    let decode = symbols
+        .iter()
+        .find(|symbol| symbol.name == "decode")
+        .unwrap_or_else(|| panic!("missing extension member: {symbols:#?}"));
+    assert_eq!(decode.scope_path, "API::Request::decode");
+}
+
+#[test]
 fn extracts_python_symbols() {
     let text = include_str!("../../../../tests/fixtures/held-mini/src/Main.py");
     let symbols = parser::parse_symbols(Path::new("src/Main.py"), Language::Python, text).unwrap();

--- a/crates/rag-rat-core/src/index/parser_tests.rs
+++ b/crates/rag-rat-core/src/index/parser_tests.rs
@@ -364,6 +364,13 @@ class ClientTests: XCTestCase {
     func testFetchSucceeds() {}
 }
 
+// An XCTestCase whose name carries NO `Tests`/`TestCase` suffix: its members are still test code,
+// and only an ancestor walk can see that (their scope path root is just `LoginFlow`).
+class LoginFlow: XCTestCase {
+    func testLogin() {}
+    func makeFixture() -> Int { 1 }
+}
+
 @TestHarness struct NotATest {}
 
 func realWork() -> Int { 1 }
@@ -385,6 +392,11 @@ func realWork() -> Int { 1 }
     assert!(is_test("checksAnother"), "@Test method inside a suite is a test symbol");
     assert!(is_test("ClientTests"), "an XCTestCase subclass is a test symbol");
     assert!(is_test("testFetchSucceeds"), "a test* method of an XCTestCase is a test symbol");
+    // Members of an XCTestCase are test code even when the class name carries no `Tests` suffix —
+    // the scope path alone cannot tell (`LoginFlow::testLogin`), so this needs the ancestor walk.
+    assert!(is_test("LoginFlow"), "an XCTestCase named without a Tests suffix is still a test");
+    assert!(is_test("testLogin"), "a test method of a suffix-less XCTestCase is a test symbol");
+    assert!(is_test("makeFixture"), "a HELPER inside an XCTestCase is test scaffolding too");
     // Neither a lookalike attribute nor ordinary code is a test.
     assert!(!is_test("NotATest"), "@TestHarness is not @Test");
     assert!(!is_test("realWork"), "production code in a non-test path stays production code");

--- a/crates/rag-rat-core/src/index/schema/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema/migrations.rs
@@ -782,10 +782,10 @@ pub(crate) fn ensure_edges_data_indexes(conn: &Connection) -> rusqlite::Result<(
 /// `last_insert_rowid()` REVERTS after an INSTEAD OF trigger ends — an insert through the view
 /// cannot read back the new edge id that way. The production insert paths write `edges_data`
 /// directly with interned ids for this reason (and for bulk speed).
-/// V023 (#200): recreate the `edges` compatibility view so its definition excludes the internal
-/// dispatch FACT rows. `ensure_edges_view` is idempotent (DROP + CREATE), so this simply rebuilds
-/// the view with the new body on an existing index; the underlying `edges_data` rows are untouched.
-pub(crate) fn apply_dispatch_edge_facts_view_exclusion(conn: &Connection) -> rusqlite::Result<()> {
+/// Recreate the `edges` compatibility view after a migration changes which persisted candidates
+/// are public graph edges. `ensure_edges_view` is idempotent (DROP + CREATE), and the underlying
+/// `edges_data` rows remain available to internal indexing passes.
+pub(crate) fn apply_edges_view_refresh(conn: &Connection) -> rusqlite::Result<()> {
     ensure_edges_view(conn)
 }
 
@@ -978,6 +978,9 @@ pub(crate) fn ensure_edges_view(conn: &Connection) -> rusqlite::Result<()> {
         -- planner keeps the indexed-id predicates, not a value-join string compare.
         WHERE d.edge_kind_id NOT IN (
             SELECT id FROM name_strings WHERE value IN ('dispatch_construct', 'dispatch_handle')
+        )
+        AND d.resolution_id NOT IN (
+            SELECT id FROM name_strings WHERE value = 'suppressed'
         );
 
         -- Interning per column: `INSERT OR IGNORE` + `value NOT NULL` means a NULL string is
@@ -1262,6 +1265,7 @@ pub(crate) fn known_version(migrations: &[AppliedMigration]) -> u32 {
             MIGRATION_065_ID => Some(65),
             MIGRATION_066_ID => Some(66),
             MIGRATION_067_ID => Some(67),
+            MIGRATION_068_ID => Some(68),
             _ => None,
         })
         .max()
@@ -1338,6 +1342,7 @@ pub(crate) fn known_migration(id: &str) -> bool {
             | MIGRATION_065_ID
             | MIGRATION_066_ID
             | MIGRATION_067_ID
+            | MIGRATION_068_ID
             | DIRTY_MIGRATION_ID
     )
 }
@@ -1411,6 +1416,7 @@ pub(crate) fn migration_checksum_mismatch(migration: &AppliedMigration) -> bool 
         MIGRATION_065_ID => migration.checksum != MIGRATION_065_CHECKSUM,
         MIGRATION_066_ID => migration.checksum != MIGRATION_066_CHECKSUM,
         MIGRATION_067_ID => migration.checksum != MIGRATION_067_CHECKSUM,
+        MIGRATION_068_ID => migration.checksum != MIGRATION_068_CHECKSUM,
         _ => false,
     }
 }

--- a/crates/rag-rat-core/src/index/schema/mod.rs
+++ b/crates/rag-rat-core/src/index/schema/mod.rs
@@ -19,7 +19,7 @@ pub use registry::{LEGACY_REPO_ID, RegisteredRepo, register_repo, register_repo_
 use rusqlite::{Connection, OptionalExtension, Transaction, TransactionBehavior, params};
 use serde::Serialize;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 67;
+pub const LATEST_SCHEMA_VERSION: u32 = 68;
 
 /// Every oracle-DERIVED persisted table — the outputs an `oracle run` writes that must OUTLIVE a
 /// reindex.
@@ -467,6 +467,11 @@ const MIGRATION_067_CHECKSUM: &str = "sha256:rag-rat-papertrail-binding-health-v
 const MIGRATION_067_DESCRIPTION: &str = "Persist per-binding attempt, successful probe/mirror, \
                                          and closed failure state for automatic scheduling and \
                                          status";
+const MIGRATION_068_ID: &str = "068_suppressed_edge_candidates";
+const MIGRATION_068_CHECKSUM: &str = "sha256:rag-rat-suppressed-edge-candidates-v68";
+const MIGRATION_068_DESCRIPTION: &str = "Hide suppressed unresolved edge candidates from the \
+                                         compatibility view while retaining them for later \
+                                         incremental re-resolution";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -765,7 +770,7 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         id: MIGRATION_023_ID,
         checksum: MIGRATION_023_CHECKSUM,
         description: MIGRATION_023_DESCRIPTION,
-        apply: apply_dispatch_edge_facts_view_exclusion,
+        apply: apply_edges_view_refresh,
     },
     Migration {
         id: MIGRATION_024_ID,
@@ -1030,6 +1035,12 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         checksum: MIGRATION_067_CHECKSUM,
         description: MIGRATION_067_DESCRIPTION,
         apply: apply_papertrail_binding_health,
+    },
+    Migration {
+        id: MIGRATION_068_ID,
+        checksum: MIGRATION_068_CHECKSUM,
+        description: MIGRATION_068_DESCRIPTION,
+        apply: apply_edges_view_refresh,
     },
 ];
 

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/papertrail_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/papertrail_tests.rs
@@ -657,8 +657,7 @@ fn migration_063_persists_mirror_resume_state() {
 }
 
 #[test]
-fn migration_067_is_the_tip_and_persists_binding_health() {
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 67, "move this pin with the next schema migration");
+fn migration_067_persists_binding_health() {
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     schema::apply(&conn).unwrap();
     let columns = conn_table_columns(&conn, "papertrail_sync_cursor");

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
@@ -2015,6 +2015,61 @@ fn migration_066_adds_the_content_candidate_dag() {
 }
 
 #[test]
+fn migration_068_is_the_tip_and_hides_suppressed_edge_candidates() {
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 68, "move this pin with the next schema migration");
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn).unwrap();
+    conn.execute(
+        "INSERT INTO files(path, language, kind, sha256, modified_at_ms, indexed_at_ms, \
+         commit_sha, worktree_id) VALUES ('App.swift', 'swift', 'source', 'sha', 0, 0, 'head', '')",
+        [],
+    )
+    .unwrap();
+    let file_id = conn.last_insert_rowid();
+    conn.execute(
+        "INSERT INTO edges(source_file_id, to_name, edge_kind, confidence, resolution, evidence) \
+         VALUES (?1, 'Observable', 'uses_macro', 'NameOnly', 'suppressed', '@Observable')",
+        [file_id],
+    )
+    .unwrap();
+    truncate_schema_to(&conn, 67);
+    let current_view: String = conn
+        .query_row(
+            "SELECT sql FROM sqlite_master WHERE type = 'view' AND name = 'edges'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    let v67_view = current_view.replace(
+        "\n        AND d.resolution_id NOT IN (\n            SELECT id FROM name_strings WHERE \
+         value = 'suppressed'\n        )",
+        "",
+    );
+    assert_ne!(v67_view, current_view, "fixture must remove the V068 public-edge filter");
+    conn.execute_batch("DROP VIEW edges;").unwrap();
+    conn.execute_batch(&v67_view).unwrap();
+    let visible_before_upgrade: i64 =
+        conn.query_row("SELECT COUNT(*) FROM edges", [], |row| row.get(0)).unwrap();
+    assert_eq!(visible_before_upgrade, 1, "the V067 view exposes the retained candidate");
+
+    schema::migrate_forward(&conn).unwrap();
+    let raw_count: i64 =
+        conn.query_row("SELECT COUNT(*) FROM edges_data", [], |row| row.get(0)).unwrap();
+    let visible_count: i64 =
+        conn.query_row("SELECT COUNT(*) FROM edges", [], |row| row.get(0)).unwrap();
+    assert_eq!(raw_count, 1, "suppressed candidates remain available to the resolver");
+    assert_eq!(visible_count, 0, "suppressed candidates stay out of query-layer reads");
+    let v68_recorded: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM schema_version WHERE id = '068_suppressed_edge_candidates'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(v68_recorded, 1, "the forward migration records V068");
+}
+
+#[test]
 fn migration_047_deferred_absence_and_reconverges_from_torn_state() {
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     conn.execute_batch("CREATE TABLE memory_model_failures(leftover INTEGER);").unwrap();

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/symbol_search_lookup.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/symbol_search_lookup.rs
@@ -94,6 +94,31 @@ fn search_and_read_chunk_attach_bounded_graph_evidence() {
     );
     assert!(helper_graph.callers.is_empty(), "search keeps graph compact");
 
+    // The SAME poisoned edge must be invisible to `impact_surface`, whose Fuzzy mode matches by
+    // NAME — the last consumer still admitting it. An unresolved `uses_operator` row is a BUILT-IN
+    // operator token (Swift emits one per `+` / `==`), so letting it through reports every
+    // arithmetic expression as a direct caller of any same-named symbol. `operator_noise` only ever
+    // "calls" `helper` through that poisoned edge, so its presence here is exactly the bug.
+    for resolution_mode in [
+        crate::query::graph::GraphResolutionMode::Exact,
+        crate::query::graph::GraphResolutionMode::Syntactic,
+        crate::query::graph::GraphResolutionMode::Fuzzy,
+    ] {
+        let items = db.impact_surface_with_options("helper", 20, resolution_mode).unwrap();
+        // The graph lane records the edge kind in its evidence ("<kind> edge to <symbol>"), so an
+        // admitted operator edge is visible there. `operator_noise` still legitimately appears via
+        // OTHER lanes (it is a same-file sibling of `helper`), which is why this asserts on the
+        // evidence rather than on the symbol's mere presence.
+        assert!(
+            items
+                .iter()
+                .flat_map(|item| &item.evidence)
+                .all(|evidence| !evidence.contains("uses_operator")),
+            "an unresolved operator use must not surface as an impact neighbor \
+             ({resolution_mode:?}): {items:#?}"
+        );
+    }
+
     let caller_hit = hits
         .iter()
         .find(|hit| hit.symbol_path.as_deref().is_some_and(|path| path.ends_with("caller")))

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/symbol_search_lookup.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/symbol_search_lookup.rs
@@ -60,11 +60,20 @@ fn search_and_read_chunk_attach_bounded_graph_evidence() {
     fs::create_dir_all(root.join("src")).unwrap();
     fs::write(
         root.join("src/lib.rs"),
-        "pub fn helper() {}\n\npub fn caller() {\n    helper();\n}\n",
+        "pub fn helper() {}\n\npub fn caller() {\n    helper();\n}\n\npub fn operator_noise() {}\n",
     )
     .unwrap();
     let config = source_config(root.clone(), Language::Rust);
     let db = IndexDatabase::rebuild(&config).unwrap();
+    db.storage
+        .connection()
+        .execute(
+            "INSERT INTO edges(source_file_id, from_symbol_id, to_name, edge_kind, confidence, \
+             resolution) SELECT file_id, id, 'helper', 'uses_operator', 'NameOnly', 'unresolved' \
+             FROM symbols WHERE name = 'operator_noise'",
+            [],
+        )
+        .unwrap();
 
     let hits = db.search("helper caller", 10, false).unwrap();
     let helper_hit = hits
@@ -79,6 +88,10 @@ fn search_and_read_chunk_attach_bounded_graph_evidence() {
             && caller.callsite.span == [4, 4]
             && caller.confidence == "syntactic"
     }));
+    assert!(
+        helper_graph.top_callers.iter().all(|caller| caller.edge_kind != "uses_operator"),
+        "unresolved operator uses must not fall back to a same-named symbol: {helper_graph:#?}"
+    );
     assert!(helper_graph.callers.is_empty(), "search keeps graph compact");
 
     let caller_hit = hits
@@ -459,6 +472,225 @@ export const callRun = () => run();
         }),
         "callRun callees: {callees:?}"
     );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn indexes_swift_symbols_chunks_and_graph_edges_end_to_end() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    let source = r#"
+import Foundation
+
+protocol Worker<Element> {}
+
+@propertyWrapper
+struct Wrapper<Value> {
+    var wrappedValue: Value
+}
+
+struct Service {}
+struct Client {}
+struct T {}
+struct Vector {}
+
+@Observable struct Model {}
+@available(*, deprecated) struct LegacyModel {}
+
+enum Status { case idle }
+precedencegroup BasePrecedence {}
+precedencegroup SecondaryPrecedence {}
+precedencegroup MergePrecedence {
+    higherThan: BasePrecedence,
+        SecondaryPrecedence
+}
+infix operator <+>: MergePrecedence
+func <+>(lhs: Int, rhs: Int) -> Int { lhs + rhs }
+func +(lhs: Vector, rhs: Vector) -> Vector { lhs }
+
+func helper() {}
+func identity<T>(_ value: T) -> T { value }
+
+struct Runner: Worker<Service> {
+    @Wrapper var count: Int = 0
+
+    func fetch(_ id: Int) -> Int { id }
+    func fetch(_ name: String) -> Int { name.count }
+
+    func run() {
+        let client = Client()
+        let state = Status.idle
+        let next: Status = .idle
+        let merged = 1 <+> 2
+        helper()
+    }
+}
+"#;
+    fs::write(
+        root.join("src/Macros.swift"),
+        "@attached(member) macro Observable() = #externalMacro(module: \"Macros\", type: \
+         \"ObservableMacro\")\n",
+    )
+    .unwrap();
+    fs::write(root.join("src/App.swift"), source).unwrap();
+    let config = source_config(root.clone(), Language::Swift);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let conn = db.storage.connection();
+    let property_names = |name: &str| {
+        conn.query_row(
+            "SELECT COUNT(*) FROM symbols WHERE kind = 'property' AND name = ?1",
+            [name],
+            |row| row.get::<_, i64>(0),
+        )
+        .unwrap()
+    };
+    assert_eq!(property_names("count"), 1, "property wrapper must not replace the property name");
+    assert_eq!(property_names("Wrapper"), 0, "wrapper type must not become the property name");
+
+    let overloads = conn
+        .query_row(
+            "SELECT COUNT(*), COUNT(DISTINCT signature) FROM symbols WHERE name = 'fetch'",
+            [],
+            |row| Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?)),
+        )
+        .unwrap();
+    assert_eq!(overloads, (2, 2), "overloads must retain distinct symbol rows and signatures");
+    let overload_chunks = conn
+        .query_row(
+            "SELECT COUNT(*) FROM chunks WHERE chunk_kind = 'code' AND symbol_path LIKE '%::fetch'",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .unwrap();
+    assert_eq!(overload_chunks, 2, "each overload must retain its structural chunk");
+
+    assert_edge(&db, "src/App.swift", "Foundation", "imports", "NameOnly");
+    assert_edge(&db, "Runner", "Worker", "implements", "Syntactic");
+    assert_edge(&db, "Runner", "run", "contains", "Exact");
+    assert_edge(&db, "run", "Client", "constructs", "Syntactic");
+    assert_edge(&db, "run", "idle", "calls_name", "Exact");
+    assert_edge(&db, "run", "idle", "calls_name", "Syntactic");
+    assert_edge(&db, "run", "<+>", "calls_name", "Syntactic");
+    assert_edge(&db, "run", "<+>", "uses_operator", "Syntactic");
+    assert_edge(&db, "<+>", "MergePrecedence", "uses_precedence_group", "Syntactic");
+    assert_edge(&db, "MergePrecedence", "BasePrecedence", "uses_precedence_group", "Syntactic");
+    assert_edge(
+        &db,
+        "MergePrecedence",
+        "SecondaryPrecedence",
+        "uses_precedence_group",
+        "Syntactic",
+    );
+    assert_edge(&db, "run", "helper", "calls_name", "Syntactic");
+    assert_edge(&db, "src/App.swift", "Observable", "uses_macro", "Syntactic");
+    assert_edge(&db, "src/App.swift", "Wrapper", "references_type", "Syntactic");
+    let false_attribute_macros = conn
+        .query_row(
+            "SELECT COUNT(*) FROM edges WHERE edge_kind = 'uses_macro' AND to_name IN \
+             ('available', 'attached', 'externalMacro')",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .unwrap();
+    assert_eq!(false_attribute_macros, 0, "unresolved attributes and compiler hooks are omitted");
+    let false_attribute_types = conn
+        .query_row(
+            "SELECT COUNT(*) FROM edges WHERE edge_kind = 'references_type' AND to_name IN \
+             ('available', 'attached', 'externalMacro')",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .unwrap();
+    assert_eq!(false_attribute_types, 0, "unresolved attribute type candidates are omitted");
+    for (edge_kind, target_kind) in [("calls_name", "function"), ("uses_operator", "operator")] {
+        let resolved_kind = conn
+            .query_row(
+                "
+                SELECT symbols.kind
+                FROM edges
+                JOIN symbols ON symbols.id = edges.to_symbol_id
+                WHERE edges.edge_kind = ?1
+                  AND edges.to_name = '<+>'
+                  AND edges.from_name LIKE '%run%'
+                ",
+                [edge_kind],
+                |row| row.get::<_, String>(0),
+            )
+            .unwrap();
+        assert_eq!(
+            resolved_kind, target_kind,
+            "operator calls and declaration uses must resolve independently"
+        );
+    }
+    let operator_function_id = conn
+        .query_row("SELECT id FROM symbols WHERE name = '<+>' AND kind = 'function'", [], |row| {
+            row.get::<_, i64>(0)
+        })
+        .unwrap();
+    for resolution_mode in [
+        crate::query::graph::GraphResolutionMode::Exact,
+        crate::query::graph::GraphResolutionMode::Syntactic,
+    ] {
+        let callees = db
+            .trace_callees_with_options("<+>", 20, &crate::query::graph::GraphTraversalOptions {
+                resolution_mode,
+                symbol_id: Some(operator_function_id),
+                ..Default::default()
+            })
+            .unwrap();
+        assert!(
+            callees.iter().all(|edge| {
+                edge.edge_kind != "uses_operator" || edge.target.as_deref() != Some("+")
+            }),
+            "unresolved built-in operators must stay out of {resolution_mode:?} traversal: \
+             {callees:?}"
+        );
+    }
+    let resolved_builtin_operator_calls = conn
+        .query_row(
+            "SELECT COUNT(*) FROM edges WHERE edge_kind = 'calls_name' AND to_name = '+' AND \
+             to_symbol_id IS NOT NULL",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .unwrap();
+    assert_eq!(
+        resolved_builtin_operator_calls, 0,
+        "built-in operator syntax must not bind to a same-named local overload"
+    );
+    let generic_type_false_positives = conn
+        .query_row(
+            "SELECT COUNT(*) FROM edges WHERE edge_kind = 'references_type' AND to_name = 'T'",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .unwrap();
+    assert_eq!(
+        generic_type_false_positives, 0,
+        "generic parameter uses must not resolve to the nominal type T"
+    );
+    let false_conformances = conn
+        .query_row(
+            "SELECT COUNT(*) FROM edges WHERE edge_kind = 'implements' AND to_name = 'Service'",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .unwrap();
+    assert_eq!(false_conformances, 0, "generic arguments must not become conformances");
+
+    for callee in ["Client", "helper"] {
+        let (start, end) = callee_byte_range(
+            &db,
+            "run",
+            callee,
+            if callee == "Client" { "constructs" } else { "calls_name" },
+        )
+        .unwrap_or_else(|| panic!("missing persisted callee range for {callee}"));
+        assert_eq!(&source[start as usize..end as usize], callee);
+    }
 
     let _ = fs::remove_dir_all(root);
 }

--- a/crates/rag-rat-core/src/language.rs
+++ b/crates/rag-rat-core/src/language.rs
@@ -6,6 +6,7 @@ use thiserror::Error;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
+#[repr(u8)]
 pub enum Language {
     Rust,
     TypeScript,
@@ -13,17 +14,96 @@ pub enum Language {
     C,
     Cpp,
     Python,
+    Swift,
     Markdown,
 }
 
+#[derive(Debug, Clone, Copy)]
+struct LanguageSpec {
+    language: Language,
+    name: &'static str,
+    aliases: &'static [&'static str],
+    simple_extensions: &'static [&'static str],
+    target_extensions: &'static [&'static str],
+    supports_embeddings: bool,
+}
+
+const LANGUAGE_SPECS: [LanguageSpec; 8] = [
+    LanguageSpec {
+        language: Language::Rust,
+        name: "rust",
+        aliases: &["rs"],
+        simple_extensions: &["rs"],
+        target_extensions: &["rs"],
+        supports_embeddings: true,
+    },
+    LanguageSpec {
+        language: Language::TypeScript,
+        name: "typescript",
+        aliases: &["ts", "tsx"],
+        simple_extensions: &["ts", "tsx"],
+        target_extensions: &["ts", "tsx"],
+        supports_embeddings: true,
+    },
+    LanguageSpec {
+        language: Language::Kotlin,
+        name: "kotlin",
+        aliases: &["kt"],
+        simple_extensions: &["kt", "kts"],
+        target_extensions: &["kt", "kts"],
+        supports_embeddings: true,
+    },
+    LanguageSpec {
+        language: Language::C,
+        name: "c",
+        aliases: &[],
+        simple_extensions: &["c", "h"],
+        target_extensions: &["c", "h"],
+        supports_embeddings: true,
+    },
+    LanguageSpec {
+        language: Language::Cpp,
+        name: "cpp",
+        aliases: &["c++", "cc", "cxx"],
+        simple_extensions: &["cc", "cpp", "cxx", "c++", "hh", "hpp", "hxx", "h++"],
+        target_extensions: &["cc", "cpp", "cxx", "c++", "hh", "hpp", "hxx", "h++", "h"],
+        supports_embeddings: true,
+    },
+    LanguageSpec {
+        language: Language::Python,
+        name: "python",
+        aliases: &["py"],
+        simple_extensions: &["py", "pyi"],
+        target_extensions: &["py", "pyi"],
+        supports_embeddings: true,
+    },
+    LanguageSpec {
+        language: Language::Swift,
+        name: "swift",
+        aliases: &[],
+        simple_extensions: &["swift"],
+        target_extensions: &["swift"],
+        supports_embeddings: true,
+    },
+    LanguageSpec {
+        language: Language::Markdown,
+        name: "markdown",
+        aliases: &["md"],
+        simple_extensions: &["md", "markdown"],
+        target_extensions: &["md", "markdown"],
+        supports_embeddings: true,
+    },
+];
+
 impl Language {
-    pub const ALL: [Self; 7] = [
+    pub const ALL: [Self; 8] = [
         Self::Rust,
         Self::TypeScript,
         Self::Kotlin,
         Self::C,
         Self::Cpp,
         Self::Python,
+        Self::Swift,
         Self::Markdown,
     ];
 
@@ -32,15 +112,7 @@ impl Language {
     }
 
     pub fn as_str(self) -> &'static str {
-        match self {
-            Self::Rust => "rust",
-            Self::TypeScript => "typescript",
-            Self::Kotlin => "kotlin",
-            Self::C => "c",
-            Self::Cpp => "cpp",
-            Self::Python => "python",
-            Self::Markdown => "markdown",
-        }
+        self.spec().name
     }
 
     /// Extensions used for **bare** language detection ([`Self::from_path`]) — the unambiguous
@@ -48,15 +120,7 @@ impl Language {
     /// default for the ambiguous C/C++ header); an explicit `cpp` binding upgrades it via
     /// [`Self::target_extensions`].
     pub fn simple_extensions(self) -> &'static [&'static str] {
-        match self {
-            Self::Rust => &["rs"],
-            Self::TypeScript => &["ts", "tsx"],
-            Self::Kotlin => &["kt", "kts"],
-            Self::C => &["c", "h"],
-            Self::Cpp => &["cc", "cpp", "cxx", "c++", "hh", "hpp", "hxx", "h++"],
-            Self::Python => &["py", "pyi"],
-            Self::Markdown => &["md", "markdown"],
-        }
+        self.spec().simple_extensions
     }
 
     /// Extensions an **explicit** target/binding of this language claims for indexing. Identical to
@@ -66,10 +130,7 @@ impl Language {
     /// `.h` files — most of them — gets no header symbols, so cross-file calls resolve to
     /// nothing).
     pub fn target_extensions(self) -> &'static [&'static str] {
-        match self {
-            Self::Cpp => &["cc", "cpp", "cxx", "c++", "hh", "hpp", "hxx", "h++", "h"],
-            _ => self.simple_extensions(),
-        }
+        self.spec().target_extensions
     }
 
     /// Whether an explicit target of this language claims a file with this extension (see
@@ -103,21 +164,16 @@ impl Language {
     }
 
     pub fn supports_embeddings(self) -> bool {
-        matches!(
-            self,
-            Self::Rust
-                | Self::TypeScript
-                | Self::Kotlin
-                | Self::C
-                | Self::Cpp
-                | Self::Python
-                | Self::Markdown
-        )
+        self.spec().supports_embeddings
     }
 
     pub fn from_path(path: &std::path::Path) -> Option<Self> {
         let ext = path.extension()?.to_str()?;
         Self::all().iter().copied().find(|language| language.simple_extensions().contains(&ext))
+    }
+
+    fn spec(self) -> &'static LanguageSpec {
+        &LANGUAGE_SPECS[self as usize]
     }
 }
 
@@ -131,16 +187,12 @@ impl FromStr for Language {
     type Err = LanguageError;
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value.trim().to_ascii_lowercase().as_str() {
-            "rust" | "rs" => Ok(Self::Rust),
-            "typescript" | "ts" | "tsx" => Ok(Self::TypeScript),
-            "kotlin" | "kt" => Ok(Self::Kotlin),
-            "c" => Ok(Self::C),
-            "cpp" | "c++" | "cc" | "cxx" => Ok(Self::Cpp),
-            "python" | "py" => Ok(Self::Python),
-            "markdown" | "md" => Ok(Self::Markdown),
-            other => Err(LanguageError::Unknown(other.to_string())),
-        }
+        let normalized = value.trim().to_ascii_lowercase();
+        LANGUAGE_SPECS
+            .iter()
+            .find(|spec| spec.name == normalized || spec.aliases.contains(&normalized.as_str()))
+            .map(|spec| spec.language)
+            .ok_or(LanguageError::Unknown(normalized))
     }
 }
 
@@ -152,9 +204,38 @@ pub enum LanguageError {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
     use std::path::Path;
+    use std::str::FromStr;
 
-    use super::Language;
+    use super::{LANGUAGE_SPECS, Language};
+
+    #[test]
+    fn language_registry_is_complete_unique_and_round_trips_every_name() {
+        assert_eq!(
+            LANGUAGE_SPECS.iter().map(|spec| spec.language).collect::<Vec<_>>(),
+            Language::all()
+        );
+        let mut names = HashSet::new();
+        for spec in LANGUAGE_SPECS {
+            assert_eq!(
+                spec.language.as_str(),
+                spec.name,
+                "Language discriminant/spec order drifted"
+            );
+            assert!(names.insert(spec.name), "duplicate canonical language name: {}", spec.name);
+            assert_eq!(Language::from_str(spec.name).unwrap(), spec.language);
+            for alias in spec.aliases {
+                assert!(names.insert(alias), "duplicate language name or alias: {alias}");
+                assert_eq!(Language::from_str(alias).unwrap(), spec.language);
+            }
+            assert!(
+                spec.simple_extensions.iter().all(|ext| spec.target_extensions.contains(ext)),
+                "target extensions must include every simple extension for {}",
+                spec.name
+            );
+        }
+    }
 
     #[test]
     fn bare_detection_resolves_h_to_c_not_cpp() {
@@ -162,6 +243,7 @@ mod tests {
         assert_eq!(Language::from_path(Path::new("a/b.h")), Some(Language::C));
         assert_eq!(Language::from_path(Path::new("a/b.cpp")), Some(Language::Cpp));
         assert_eq!(Language::from_path(Path::new("a/b.rs")), Some(Language::Rust));
+        assert_eq!(Language::from_path(Path::new("a/b.swift")), Some(Language::Swift));
         assert_eq!(Language::from_path(Path::new("a/README")), None);
     }
 

--- a/crates/rag-rat-core/src/query/graph/mod.rs
+++ b/crates/rag-rat-core/src/query/graph/mod.rs
@@ -7,20 +7,22 @@ use rusqlite::{Connection, params_from_iter};
 use serde::Serialize;
 pub(crate) use traverse::*;
 
-// `dispatches` (#200) rides with the call kinds so find_callers/trace_callees surface the
-// construct→handler dispatch hop by default — it is exactly the missing call-graph signal. The
+// `dispatches` (#200) and `uses_operator` ride with the call kinds so graph traversal surfaces the
+// synthesized handler hop and an operator declaration alongside its callable implementation. The
 // internal `dispatch_construct`/`dispatch_handle` FACT kinds are deliberately absent from every
 // set.
-const CALL_EDGE_KINDS: &[&str] = &["calls_name", "constructs", "dispatches"];
+const CALL_EDGE_KINDS: &[&str] = &["calls_name", "constructs", "dispatches", "uses_operator"];
 const MACRO_EDGE_KINDS: &[&str] = &["uses_macro"];
 const REFERENCE_EDGE_KINDS: &[&str] =
-    &["references_type", "imports", "exports", "contains", "implements"];
+    &["references_type", "uses_precedence_group", "imports", "exports", "contains", "implements"];
 const OPTIONAL_EDGE_KINDS: &[&str] = &[
     "calls_name",
     "constructs",
     "dispatches",
+    "uses_operator",
     "uses_macro",
     "references_type",
+    "uses_precedence_group",
     "imports",
     "exports",
     "contains",

--- a/crates/rag-rat-core/src/query/graph/predicates.rs
+++ b/crates/rag-rat-core/src/query/graph/predicates.rs
@@ -227,8 +227,12 @@ pub(crate) fn forward_visibility_filter(options: &GraphTraversalOptions) -> &'st
                 edges.edge_kind = 'constructs'
                 AND edges.to_symbol_id IS NOT NULL
             )
+            OR (
+                edges.edge_kind = 'uses_operator'
+                AND edges.to_symbol_id IS NOT NULL
+            )
             OR edges.edge_kind = 'uses_macro'
-            OR edges.edge_kind NOT IN ('calls_name', 'constructs')
+            OR edges.edge_kind NOT IN ('calls_name', 'constructs', 'uses_operator')
             ",
         (false, true, false) =>
             "
@@ -252,8 +256,12 @@ pub(crate) fn forward_visibility_filter(options: &GraphTraversalOptions) -> &'st
                 edges.edge_kind = 'constructs'
                 AND edges.to_symbol_id IS NOT NULL
             )
+            OR (
+                edges.edge_kind = 'uses_operator'
+                AND edges.to_symbol_id IS NOT NULL
+            )
             OR edges.edge_kind = 'uses_macro'
-            OR edges.edge_kind NOT IN ('calls_name', 'constructs')
+            OR edges.edge_kind NOT IN ('calls_name', 'constructs', 'uses_operator')
             ",
         (false, false, true) =>
             "
@@ -271,7 +279,11 @@ pub(crate) fn forward_visibility_filter(options: &GraphTraversalOptions) -> &'st
                     edges.edge_kind = 'constructs'
                     AND edges.to_symbol_id IS NOT NULL
                 )
-                OR edges.edge_kind NOT IN ('calls_name', 'constructs')
+                OR (
+                    edges.edge_kind = 'uses_operator'
+                    AND edges.to_symbol_id IS NOT NULL
+                )
+                OR edges.edge_kind NOT IN ('calls_name', 'constructs', 'uses_operator')
             )
             ",
         (false, false, false) =>
@@ -299,7 +311,11 @@ pub(crate) fn forward_visibility_filter(options: &GraphTraversalOptions) -> &'st
                     edges.edge_kind = 'constructs'
                     AND edges.to_symbol_id IS NOT NULL
                 )
-                OR edges.edge_kind NOT IN ('calls_name', 'constructs')
+                OR (
+                    edges.edge_kind = 'uses_operator'
+                    AND edges.to_symbol_id IS NOT NULL
+                )
+                OR edges.edge_kind NOT IN ('calls_name', 'constructs', 'uses_operator')
             )
             ",
     }

--- a/crates/rag-rat-core/src/query/graph/predicates.rs
+++ b/crates/rag-rat-core/src/query/graph/predicates.rs
@@ -9,6 +9,24 @@ use super::*;
 // name_strings WHERE value = ?3)`) are an edge-side pool lookup and are independent of these symbol
 // joins.
 
+/// The guard EVERY query that admits `uses_operator` edges must carry.
+///
+/// An UNRESOLVED `uses_operator` row is a BUILT-IN operator token — Swift emits one for every `+`,
+/// `==`, `!` in the repo — not a use of an in-repo `operator` declaration. Admitting those rows
+/// into a query that falls back to matching by NAME makes every `Int + Int` expression a "caller"
+/// of any same-named custom operator, flooding callers/impact with dependencies that do not exist.
+/// A resolved row (`to_symbol_id IS NOT NULL`) is by definition bound to a real operator symbol, so
+/// requiring resolution is what separates the two.
+///
+/// Valid wherever the edges table is named or aliased `edges`. `forward_visibility_filter` /
+/// `reverse_visibility_filter` below encode the same rule in positive form, inside their OR-chains,
+/// and `graph_meta` splices this guard directly.
+/// `search_and_read_chunk_attach_bounded_graph_evidence` poisons the index with one unresolved
+/// operator edge and asserts EVERY consumer — search graph metadata and all three `impact_surface`
+/// resolution modes — leaves it out; impact was the lane that had been missing the guard.
+pub(crate) const RESOLVED_OPERATOR_ONLY: &str =
+    "(edges.edge_kind != 'uses_operator' OR edges.to_symbol_id IS NOT NULL)";
+
 pub(crate) fn validate_edge_kinds(edge_kinds: &[String]) -> anyhow::Result<()> {
     for edge_kind in edge_kinds {
         if !OPTIONAL_EDGE_KINDS.contains(&edge_kind.as_str()) {

--- a/crates/rag-rat-core/src/query/graph_meta.rs
+++ b/crates/rag-rat-core/src/query/graph_meta.rs
@@ -261,7 +261,8 @@ fn count_callers(conn: &Connection, symbol: &PrimarySymbol) -> anyhow::Result<u6
         SELECT COUNT(DISTINCT COALESCE(edges.from_symbol_id, -edges.id))
         FROM edges
         JOIN files source_files ON source_files.id = edges.source_file_id
-        WHERE edges.edge_kind IN ('calls_name', 'constructs', 'uses_macro')
+        WHERE edges.edge_kind IN ('calls_name', 'constructs', 'uses_operator', 'uses_macro')
+          AND (edges.edge_kind != 'uses_operator' OR edges.to_symbol_id IS NOT NULL)
           AND (edges.to_symbol_id = ?1 OR (edges.to_symbol_id IS NULL AND edges.to_name_id = \
              (SELECT id FROM name_strings WHERE value = ?2)))
         ",
@@ -279,11 +280,15 @@ fn count_callees(conn: &Connection, symbol_id: i64) -> anyhow::Result<u64> {
         SELECT COUNT(DISTINCT COALESCE(CAST(to_symbol_id AS TEXT), to_name))
         FROM edges
         WHERE from_symbol_id = ?1
-          AND edge_kind IN ('calls_name', 'constructs', 'uses_macro')
+          AND edge_kind IN ('calls_name', 'constructs', 'uses_operator', 'uses_macro')
           AND (
               edge_kind != 'calls_name'
               OR to_symbol_id IS NOT NULL
               OR (confidence = 'Syntactic' AND target_qualified_name IS NOT NULL)
+          )
+          AND (
+              edge_kind != 'uses_operator'
+              OR to_symbol_id IS NOT NULL
           )
         ",
         )?
@@ -365,7 +370,8 @@ fn callers(
         LEFT JOIN chunks source_chunks ON source_chunks.file_id = edges.source_file_id
           AND source_symbols.start_byte >= source_chunks.start_byte
           AND source_symbols.start_byte < source_chunks.end_byte
-        WHERE edges.edge_kind IN ('calls_name', 'constructs', 'uses_macro')
+        WHERE edges.edge_kind IN ('calls_name', 'constructs', 'uses_operator', 'uses_macro')
+          AND (edges.edge_kind != 'uses_operator' OR edges.to_symbol_id IS NOT NULL)
           AND (edges.to_symbol_id = ?1 OR (edges.to_symbol_id IS NULL AND edges.to_name_id = \
          (SELECT id FROM name_strings WHERE value = ?2)))
         ORDER BY
@@ -434,14 +440,18 @@ fn callees(conn: &Connection, symbol_id: i64, limit: u32) -> anyhow::Result<Vec<
           AND source_symbols.start_byte >= source_chunks.start_byte
           AND source_symbols.start_byte < source_chunks.end_byte
         WHERE edges.from_symbol_id = ?1
-          AND edges.edge_kind IN ('calls_name', 'constructs', 'uses_macro')
-          -- Drop unresolved name-only calls (`.map()`, `.var_os()`, std combinators): they
-          -- resolve to nothing in-repo and are pure noise in a chunk's callee summary. Keep
-          -- resolved calls and syntactically-resolvable ones, plus constructs/macros.
+          AND edges.edge_kind IN ('calls_name', 'constructs', 'uses_operator', 'uses_macro')
+          -- Drop unresolved name-only calls and operator declarations: they resolve to nothing
+          -- in-repo and are pure noise in a chunk's callee summary. Calls may retain qualified
+          -- syntactic targets; operator declarations must resolve to an indexed symbol.
           AND (
               edges.edge_kind != 'calls_name'
               OR edges.to_symbol_id IS NOT NULL
               OR (edges.confidence = 'Syntactic' AND edges.target_qualified_name IS NOT NULL)
+          )
+          AND (
+              edges.edge_kind != 'uses_operator'
+              OR edges.to_symbol_id IS NOT NULL
           )
         ORDER BY
           CASE edges.confidence

--- a/crates/rag-rat-core/src/query/grep_augment.rs
+++ b/crates/rag-rat-core/src/query/grep_augment.rs
@@ -151,6 +151,26 @@ const DEFINITION_KEYWORDS: &[&str] = &[
     "unsafe",
     "where",
     "dyn",
+    // Swift. Without these, `protocol Fetcher` / `actor Store` / `extension Client` leave two
+    // identifier-shaped tokens, so the pattern reads as ambiguous and drops to the lexical lane —
+    // while `func Fetcher` (a keyword we already knew) correctly reached the symbol lane.
+    "protocol",
+    "actor",
+    "extension",
+    "init",
+    "deinit",
+    "subscript",
+    "operator",
+    "precedencegroup",
+    "macro",
+    "open",
+    "internal",
+    "fileprivate",
+    "mutating",
+    "nonmutating",
+    "inout",
+    "some",
+    "any",
 ];
 
 /// The single identifier a pattern targets, for the symbol lane. A lone identifier is used
@@ -812,6 +832,21 @@ mod tests {
         assert_eq!(extract_symbol_identifier("election retry loop"), None);
         // Free text token (not keyword, not identifier-shaped) → lexical lane.
         assert_eq!(extract_symbol_identifier("foo == bar"), None);
+    }
+
+    /// Swift's declaration keywords reach the symbol lane like every other language's. Before they
+    /// were known keywords, `protocol Fetcher` read as two identifiers and fell to the lexical lane
+    /// — even though `func Fetcher` did not, which is the tell that the list, not the pattern, was
+    /// wrong.
+    #[test]
+    fn extract_symbol_identifier_handles_swift_definition_patterns() {
+        assert_eq!(extract_symbol_identifier("protocol Fetcher"), Some("Fetcher"));
+        assert_eq!(extract_symbol_identifier("actor Store"), Some("Store"));
+        assert_eq!(extract_symbol_identifier("extension Client"), Some("Client"));
+        assert_eq!(extract_symbol_identifier("public actor SyncStore"), Some("SyncStore"));
+        assert_eq!(extract_symbol_identifier("mutating func reset"), Some("reset"));
+        assert_eq!(extract_symbol_identifier("open class ViewModel"), Some("ViewModel"));
+        assert_eq!(extract_symbol_identifier("macro stringify"), Some("stringify"));
     }
 
     #[test]

--- a/crates/rag-rat-core/src/query/impact/neighbors.rs
+++ b/crates/rag-rat-core/src/query/impact/neighbors.rs
@@ -1,3 +1,6 @@
+use rusqlite::params_from_iter;
+use rusqlite::types::Value;
+
 use super::*;
 
 pub(crate) fn graph_neighbors(
@@ -30,6 +33,12 @@ pub(crate) fn graph_neighbors(
         "COALESCE(to_qn.value, edges.to_name)"
     };
     let predicate = impact_graph_predicate(reverse, resolution_mode);
+    // Impact's Fuzzy predicate falls back to matching by NAME (`edges.to_name_id = …`), so without
+    // this guard every built-in `+` / `==` token — which Swift emits as an unresolved
+    // `uses_operator` edge — would surface as a direct caller of any same-named custom
+    // operator. Graph traversal and graph metadata already require a resolved operator target;
+    // impact must too.
+    let resolved_operator_only = crate::query::graph::RESOLVED_OPERATOR_ONLY;
     let sql = format!(
         "
         SELECT {source_path_col}, {source_language_col}, {source_kind_col},
@@ -45,6 +54,7 @@ pub(crate) fn graph_neighbors(
         WHERE edges.edge_kind IN (
             'calls_name', 'constructs', 'uses_operator', 'uses_precedence_group', 'implements'
         )
+          AND {resolved_operator_only}
           AND ({predicate})
           AND {source_path_col} IS NOT NULL
         ORDER BY
@@ -60,8 +70,18 @@ pub(crate) fn graph_neighbors(
         ",
     );
     let mut stmt = conn.prepare(&sql)?;
+    // Bind exactly the placeholders the CHOSEN predicate references. Every arm uses `?1` (the
+    // symbol id), but only the name-matching arms use `?2` — the two `Exact` arms match on the id
+    // alone. Binding an unreferenced `?2` makes rusqlite reject the statement outright ("Wrong
+    // number of parameters passed to query. Got 2, needed 1"), which is why `impact_surface` with
+    // `resolution = exact` returned an error instead of a surface.
+    let binds_name = predicate.contains("?2");
     for target in targets {
-        let rows = stmt.query_map(params![target.id, target.qualified_name], |row| {
+        let mut args = vec![Value::Integer(target.id)];
+        if binds_name {
+            args.push(Value::Text(target.qualified_name.clone()));
+        }
+        let rows = stmt.query_map(params_from_iter(args), |row| {
             Ok((
                 row.get::<_, String>(0)?,
                 row.get::<_, String>(1)?,
@@ -82,7 +102,11 @@ pub(crate) fn graph_neighbors(
         }
     }
     for name in target_names {
-        if resolution_mode != GraphResolutionMode::Fuzzy && !is_qualified_symbol(name) {
+        // Without a `?2` the predicate cannot match on a name at all, so the name pass has nothing
+        // to contribute (an id-only `Exact` predicate against a NULL id matches nothing).
+        if !binds_name
+            || (resolution_mode != GraphResolutionMode::Fuzzy && !is_qualified_symbol(name))
+        {
             continue;
         }
         let rows = stmt.query_map(params![Option::<i64>::None, name], |row| {

--- a/crates/rag-rat-core/src/query/impact/neighbors.rs
+++ b/crates/rag-rat-core/src/query/impact/neighbors.rs
@@ -42,7 +42,9 @@ pub(crate) fn graph_neighbors(
         LEFT JOIN name_strings from_qn ON from_qn.id = from_symbols.qualified_name_id
         LEFT JOIN name_strings to_qn ON to_qn.id = to_symbols.qualified_name_id
         LEFT JOIN files source_files ON source_files.id = edges.source_file_id
-        WHERE edges.edge_kind IN ('calls_name', 'constructs', 'implements')
+        WHERE edges.edge_kind IN (
+            'calls_name', 'constructs', 'uses_operator', 'uses_precedence_group', 'implements'
+        )
           AND ({predicate})
           AND {source_path_col} IS NOT NULL
         ORDER BY

--- a/crates/rag-rat-core/src/query/load_bearing.rs
+++ b/crates/rag-rat-core/src/query/load_bearing.rs
@@ -222,6 +222,9 @@ pub fn scoped_weighted_fan_in(
          JOIN name_strings ek ON ek.id = d.edge_kind_id
          JOIN name_strings cf ON cf.id = d.confidence_id
          WHERE d.to_symbol_id = ?1
+           AND d.resolution_id NOT IN (
+               SELECT id FROM name_strings WHERE value = 'suppressed'
+           )
            -- Internal dispatch FACT rows (#200) are synthesis inputs, not real in-edges — the
            -- handle fact duplicates the dispatcher's existing calls_name, so counting it would
            -- double-weight the handler. The synthesized `dispatches` edge IS counted.

--- a/crates/rag-rat-core/src/query/pagerank.rs
+++ b/crates/rag-rat-core/src/query/pagerank.rs
@@ -39,7 +39,9 @@ pub(crate) fn edge_weight(kind: &str) -> f64 {
         // so they contribute nothing even if a query forgets to exclude them (defense in depth).
         "dispatch_construct" | "dispatch_handle" => 0.0,
         "references_type" | "constructs" => 0.7,
-        "uses_macro" => 0.5,
+        // Operator syntax emits a full-weight call to its implementation plus a declaration-use
+        // edge; downweight the latter so one expression does not count as two direct calls.
+        "uses_macro" | "uses_operator" | "uses_precedence_group" => 0.5,
         "imports" | "exports" => 0.3,
         "contains" => 0.2,
         _ => 1.0,
@@ -332,6 +334,9 @@ pub fn important_symbols(
          JOIN name_strings ek ON ek.id = d.edge_kind_id
          JOIN name_strings cf ON cf.id = d.confidence_id
          WHERE d.from_symbol_id IS NOT NULL
+           AND d.resolution_id NOT IN (
+               SELECT id FROM name_strings WHERE value = 'suppressed'
+           )
            -- Internal dispatch FACT rows (#200) are synthesis inputs, not real edges — they'd
            -- double-count (the handle fact duplicates the dispatcher's existing calls_name) and
            -- inflate rank. The synthesized `dispatches` edge IS counted (it's a real dependency).
@@ -545,6 +550,7 @@ mod tests {
     fn edge_weight_downweights_weak_kinds() {
         assert!(edge_weight("calls_name") > edge_weight("imports"));
         assert!(edge_weight("implements") > edge_weight("contains"));
+        assert!(edge_weight("calls_name") > edge_weight("uses_operator"));
         assert_eq!(edge_weight("something_new"), 1.0, "unknown kinds default to full weight");
     }
 
@@ -593,6 +599,32 @@ mod tests {
         let bare = Connection::open_in_memory().unwrap();
         schema::apply(&bare).unwrap();
         assert!(important_symbols(&bare, opts(10, &[])).unwrap().symbols.is_empty());
+    }
+
+    #[test]
+    fn important_symbols_ignores_suppressed_edges() {
+        let conn = conf_conn(2, &[]);
+        conn.execute(
+            "INSERT INTO edges(source_file_id, from_symbol_id, to_symbol_id, to_name,
+                               target_qualified_name, edge_kind, confidence, resolution)
+             VALUES (1, 1, NULL, 's2', 'a::s2', 'uses_macro', 'NameOnly', 'suppressed')",
+            [],
+        )
+        .unwrap();
+        let edge_id: i64 =
+            conn.query_row("SELECT MAX(id) FROM edges_data", [], |row| row.get(0)).unwrap();
+        let effects = HashMap::from([(edge_id, EdgeOracleEffect::Retarget(2))]);
+        assert!(
+            important_symbols(&conn, ImportanceOptions {
+                limit: 10,
+                personalize_to: &[],
+                oracle_effects: Some(&effects),
+            })
+            .unwrap()
+            .symbols
+            .is_empty(),
+            "even a stale oracle retarget cannot revive a suppressed candidate"
+        );
     }
 
     /// Insert `n` symbols (`s1..sn`, ids `1..=n`) plus `edges` as `(from_id, to_id)` calls, all in

--- a/crates/rag-rat-core/src/query/repo_brief.rs
+++ b/crates/rag-rat-core/src/query/repo_brief.rs
@@ -521,7 +521,10 @@ pub(crate) fn summary_counts(conn: &Connection) -> anyhow::Result<SummaryCounts>
     let graph_edges: u64 = conn.query_row(
         "SELECT COUNT(*) FROM edges_data e
            JOIN main.files f ON f.id = e.source_file_id
-          WHERE f.repo_id = ?1 AND f.generation = ?2",
+          WHERE f.repo_id = ?1 AND f.generation = ?2
+            AND e.resolution_id NOT IN (
+                SELECT id FROM name_strings WHERE value = 'suppressed'
+            )",
         rusqlite::params![repo_id, generation],
         |row| row_u64(row, 0),
     )?;
@@ -838,4 +841,32 @@ fn add_memory_count(counts: &mut RepoBriefMemoryCounts, row: (String, u64)) {
 fn row_u64(row: &Row<'_>, idx: usize) -> rusqlite::Result<u64> {
     let value = row.get::<_, i64>(idx)?;
     Ok(u64::try_from(value.max(0)).unwrap_or(0))
+}
+
+#[cfg(test)]
+mod summary_tests {
+    use rusqlite::Connection;
+
+    use super::summary_counts;
+    use crate::index::schema;
+
+    #[test]
+    fn summary_excludes_suppressed_edge_candidates() {
+        let conn = Connection::open_in_memory().unwrap();
+        schema::apply(&conn).unwrap();
+        conn.execute(
+            "INSERT INTO files(path, language, kind, sha256, modified_at_ms, indexed_at_ms)
+             VALUES ('App.swift', 'swift', 'source', 'sha', 0, 0)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO edges(source_file_id, to_name, edge_kind, confidence, resolution)
+             VALUES (1, 'real', 'calls_name', 'NameOnly', 'unresolved'),
+                    (1, 'available', 'uses_macro', 'NameOnly', 'suppressed')",
+            [],
+        )
+        .unwrap();
+        assert_eq!(summary_counts(&conn).unwrap().graph_edges, 1);
+    }
 }

--- a/crates/rag-rat-core/src/query/symbol.rs
+++ b/crates/rag-rat-core/src/query/symbol.rs
@@ -264,6 +264,61 @@ fn candidates_for_selector(
     Ok(hits)
 }
 
+/// Tie-break order for same-named `symbol_lookup` candidates, by symbol kind: the definition a
+/// human most likely meant, first. Nominal types (0) before named/abstract types (1) before
+/// callables (2) before members and values (3) before namespaces (4); a container that merely
+/// EXTENDS a type someone else declared (Rust `impl`, Swift `extension`) sorts near-last (8), and
+/// an unranked kind last (9).
+///
+/// Covers every kind ANY backend can emit — `symbol_kind_rank_covers_every_indexed_kind` proves it
+/// against `languages::all_symbol_kinds()`. That completeness is the point: this used to be a
+/// literal SQL `CASE` that knew only the Rust/TS/Kotlin kinds, so a Swift `protocol` or `actor`, a
+/// C++ `namespace` or `union`, and a Rust `module` or `macro` all fell into the unknown bucket and
+/// ranked BELOW `impl` — a `protocol Foo` losing to an unrelated `const Foo`.
+const SYMBOL_KIND_RANK: &[(&str, i64)] = &[
+    // Nominal aggregate types.
+    ("struct", 0),
+    ("class", 0),
+    ("object", 0),
+    ("actor", 0),
+    ("union", 0),
+    // Named and abstract types.
+    ("enum", 1),
+    ("trait", 1),
+    ("interface", 1),
+    ("protocol", 1),
+    ("type", 1),
+    // Callables.
+    ("function", 2),
+    ("method", 2),
+    ("constructor", 2),
+    ("macro", 2),
+    ("operator", 2),
+    // Members and values.
+    ("const", 3),
+    ("property", 3),
+    ("static", 3),
+    ("enum_case", 3),
+    ("precedence_group", 3),
+    // Namespaces.
+    ("module", 4),
+    ("namespace", 4),
+    // Extenders of a type declared elsewhere.
+    ("impl", 8),
+    ("extension", 8),
+];
+
+/// [`SYMBOL_KIND_RANK`] as the SQL `CASE` expression the lookup's `ORDER BY` uses. Generated rather
+/// than hand-written so the table stays the single source of truth.
+fn symbol_kind_rank_sql() -> String {
+    let arms = SYMBOL_KIND_RANK
+        .iter()
+        .map(|(kind, rank)| format!("WHEN '{kind}' THEN {rank}"))
+        .collect::<Vec<_>>()
+        .join("\n            ");
+    format!("CASE symbols.kind\n            {arms}\n            ELSE 9\n          END")
+}
+
 fn lookup_name(
     conn: &Connection,
     name: &str,
@@ -293,31 +348,17 @@ fn lookup_name(
     if language.is_some() {
         sql.push_str(" AND symbols.language = ?3");
     }
-    sql.push_str(
+    sql.push_str(&format!(
         "
         ORDER BY
           CASE WHEN symbols.name = ?1 THEN 0 ELSE 1 END,
-          CASE symbols.kind
-            WHEN 'struct' THEN 0
-            WHEN 'class' THEN 0
-            WHEN 'object' THEN 0
-            WHEN 'enum' THEN 1
-            WHEN 'trait' THEN 1
-            WHEN 'interface' THEN 1
-            WHEN 'type' THEN 1
-            WHEN 'function' THEN 2
-            WHEN 'method' THEN 2
-            WHEN 'const' THEN 3
-            WHEN 'property' THEN 3
-            WHEN 'static' THEN 3
-            WHEN 'impl' THEN 8
-            ELSE 9
-          END,
+          {},
           files.path,
           symbols.start_byte
         LIMIT ?
         ",
-    );
+        symbol_kind_rank_sql(),
+    ));
 
     let fuzzy = format!("%{name}%");
     let mut stmt = conn.prepare(&sql)?;
@@ -543,7 +584,48 @@ fn enrich_symbol_hit(conn: &Connection, hit: &mut SymbolHit) -> anyhow::Result<(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
+
     use super::*;
+
+    /// The class tripwire (#635): EVERY symbol kind any language backend can emit must carry an
+    /// explicit rank. Driven off `languages::all_symbol_kinds()` — the backends' own declaration —
+    /// so registering a language with a new kind (a Swift `protocol`, a C++ `namespace`) reddens
+    /// HERE, at the point the ranking would silently dump it into the unknown bucket, instead of
+    /// shipping a lookup that sorts it below `impl`. Ranking is a downstream consumer of the
+    /// language registry; this is what keeps the two from drifting.
+    #[test]
+    fn symbol_kind_rank_covers_every_indexed_kind() {
+        let ranked: HashSet<&str> = SYMBOL_KIND_RANK.iter().map(|(kind, _)| *kind).collect();
+        let unranked: Vec<&str> = crate::index::languages::all_symbol_kinds()
+            .into_iter()
+            .filter(|kind| !ranked.contains(kind))
+            .collect();
+        assert!(
+            unranked.is_empty(),
+            "symbol kinds emitted by a language backend but never ranked in SYMBOL_KIND_RANK \
+             (they would sort into the unknown bucket, below `impl`): {unranked:?}"
+        );
+    }
+
+    /// The rank table is a tie-break, so it is only meaningful if the kinds actually order against
+    /// each other: a nominal type outranks a callable outranks a member, and both outrank the
+    /// extender/unknown buckets.
+    #[test]
+    fn symbol_kind_rank_orders_types_before_callables_before_extenders() {
+        let rank = |kind: &str| {
+            SYMBOL_KIND_RANK.iter().find(|(name, _)| *name == kind).map_or(9, |(_, rank)| *rank)
+        };
+        assert!(rank("actor") < rank("function"), "a type outranks a callable");
+        assert!(rank("protocol") < rank("function"), "a protocol outranks a callable");
+        assert!(rank("function") < rank("property"), "a callable outranks a member");
+        assert!(rank("enum_case") < rank("extension"), "a member outranks a bare extension");
+        assert!(rank("extension") < rank("nonexistent_kind"), "a known kind outranks an unknown");
+        // The generated SQL keeps the table's arms and the unknown fallback.
+        let sql = symbol_kind_rank_sql();
+        assert!(sql.contains("WHEN 'protocol' THEN 1"), "{sql}");
+        assert!(sql.contains("ELSE 9"), "{sql}");
+    }
 
     fn selector(logical_symbol_id: Option<i64>, symbol_path: Option<&str>) -> SymbolSelector {
         SymbolSelector {

--- a/crates/rag-rat-core/src/search/lexical.rs
+++ b/crates/rag-rat-core/src/search/lexical.rs
@@ -1,10 +1,12 @@
 use std::collections::BTreeMap;
+use std::path::Path;
 
 use rusqlite::{Connection, params};
 use serde::Serialize;
 
 use crate::index::text_compression::ChunkTextRow;
 use crate::index::{ai, text_compression};
+use crate::language::Language;
 use crate::query::graph_meta::GraphEvidence;
 
 const BM25_WEIGHT: f64 = 0.45;
@@ -714,11 +716,24 @@ impl GraphEdgeEvidence {
     }
 }
 
+/// The bare qualified name (`Type::method`) inside an indexed symbol path
+/// (`src/thing.rs::Type::method`) — the form graph edges store as an endpoint name, so
+/// `graph_boost` can match a search hit against its incoming/outgoing edges.
+///
+/// The file/name boundary is found by testing each `::` against the LANGUAGE REGISTRY rather than a
+/// hardcoded extension list. A literal list silently skips whichever language nobody remembered to
+/// add — it was missing `.swift`, `.py`, `.c`, and `.cpp`, so hits in those languages kept the
+/// whole path as their name, matched no edge endpoint, and got zero graph boost. Deriving the
+/// boundary from [`Language`] means a language registered later is covered without touching this
+/// function.
 fn qualified_symbol_name(symbol_path: &str) -> &str {
-    for marker in [".rs::", ".ts::", ".tsx::", ".kt::", ".kts::"] {
-        if let Some(index) = symbol_path.find(marker) {
-            return &symbol_path[(index + marker.len())..];
+    let mut cursor = 0;
+    while let Some(offset) = symbol_path[cursor..].find("::") {
+        let split = cursor + offset;
+        if Language::from_path(Path::new(&symbol_path[..split])).is_some() {
+            return &symbol_path[split + "::".len()..];
         }
+        cursor = split + "::".len();
     }
     symbol_path
 }
@@ -1059,6 +1074,30 @@ mod tests {
         let repo_id = schema::active_repo_id(&conn).unwrap();
         let boost = graph_boost(&conn, &hit, &["available".to_string()], &repo_id).unwrap();
         assert_eq!(boost, 0.0, "suppressed resolver candidates are not ranking evidence");
+    }
+
+    /// Registry-driven tripwire: `qualified_symbol_name` must strip the file prefix for EVERY
+    /// indexed language, not just the ones a literal list happened to name. Drives the assertion
+    /// off `Language::all()` × `target_extensions()`, so registering a language without
+    /// teaching the stripper about it reddens here instead of silently costing that language
+    /// its graph boost (which is how `.swift`, `.py`, `.c`, and `.cpp` were all missing at
+    /// once).
+    #[test]
+    fn qualified_symbol_name_strips_the_file_prefix_for_every_registered_language() {
+        for language in Language::all() {
+            for ext in language.target_extensions() {
+                let path = format!("crates/pkg/src/thing.{ext}::Type::method");
+                assert_eq!(
+                    qualified_symbol_name(&path),
+                    "Type::method",
+                    "{language} (.{ext}) symbol paths must reduce to the bare qualified name"
+                );
+            }
+        }
+        // A bare name (no file prefix) and an unindexed extension are both passed through
+        // unchanged.
+        assert_eq!(qualified_symbol_name("Type::method"), "Type::method");
+        assert_eq!(qualified_symbol_name("notes.txt::heading"), "notes.txt::heading");
     }
 
     /// The pre-materialization bm25 JOIN shape (joins the scope VIEW `files` directly, no CTE) —

--- a/crates/rag-rat-core/src/search/lexical.rs
+++ b/crates/rag-rat-core/src/search/lexical.rs
@@ -645,6 +645,9 @@ fn graph_boost(
         JOIN name_strings tn ON tn.id = d.to_name_id
         WHERE (d.from_name_id IN (SELECT id FROM name_strings WHERE value IN (?1, ?2))
             OR d.to_name_id IN (SELECT id FROM name_strings WHERE value IN (?1, ?2)))
+          AND d.resolution_id NOT IN (
+              SELECT id FROM name_strings WHERE value = 'suppressed'
+          )
           AND EXISTS (SELECT 1 FROM main.files f
                        WHERE f.id = d.source_file_id AND f.repo_id = ?3)
         ORDER BY
@@ -732,7 +735,8 @@ fn confidence_weight(confidence: &str) -> f64 {
 
 fn relation_weight(edge_kind: &str) -> f64 {
     match edge_kind {
-        "calls_name" | "constructs" | "uses_macro" => 1.0,
+        "calls_name" | "constructs" | "uses_operator" | "uses_precedence_group" | "uses_macro" =>
+            1.0,
         "imports" | "exports" => 0.60,
         "references_type" | "implements" | "extends" => 0.40,
         "contains" => 0.20,
@@ -999,6 +1003,9 @@ mod tests {
                  JOIN name_strings ek ON ek.id = d.edge_kind_id
                  WHERE (d.from_name_id IN (SELECT id FROM name_strings WHERE value IN ('a', 'b'))
                      OR d.to_name_id IN (SELECT id FROM name_strings WHERE value IN ('a', 'b')))
+                   AND d.resolution_id NOT IN (
+                       SELECT id FROM name_strings WHERE value = 'suppressed'
+                   )
                    AND EXISTS (SELECT 1 FROM main.files f
                                 WHERE f.id = d.source_file_id AND f.repo_id = 'r')",
             )
@@ -1021,6 +1028,37 @@ mod tests {
             !plan.contains("SCAN f"),
             "graph_boost repo scope must PK-search files, not scan it, got plan:\n{plan}"
         );
+    }
+
+    #[test]
+    fn graph_boost_ignores_suppressed_edge_candidates() {
+        let conn = seeded_conn();
+        conn.execute(
+            "INSERT INTO edges(source_file_id, from_name, to_name, edge_kind, confidence,
+                               resolution, evidence)
+             VALUES (1, 'watcher_main', 'available', 'uses_macro', 'NameOnly', 'suppressed',
+                     '@available')",
+            [],
+        )
+        .unwrap();
+        let hit = SearchHit {
+            chunk_id: 1,
+            path: "src/watch.rs".to_string(),
+            language: "rust".to_string(),
+            kind: "symbol".to_string(),
+            start_line: 1,
+            end_line: 20,
+            symbol_path: Some("watcher_main".to_string()),
+            score: 0.0,
+            retrieval_mode: "lexical".to_string(),
+            summary: String::new(),
+            graph: None,
+            score_components: None,
+            importance: None,
+        };
+        let repo_id = schema::active_repo_id(&conn).unwrap();
+        let boost = graph_boost(&conn, &hit, &["available".to_string()], &repo_id).unwrap();
+        assert_eq!(boost, 0.0, "suppressed resolver candidates are not ranking evidence");
     }
 
     /// The pre-materialization bm25 JOIN shape (joins the scope VIEW `files` directly, no CTE) —

--- a/crates/rag-rat-mcp/src/tools/catalog.rs
+++ b/crates/rag-rat-mcp/src/tools/catalog.rs
@@ -74,9 +74,9 @@ pub fn description(name: &str) -> &'static str {
              (every hit 'lexical') when no embedding model is present.",
         "symbol_lookup" =>
             "Resolve a symbol name (or ref/id) to its definition(s) in Rust, TypeScript, Kotlin, \
-             C, C++, or Python — exact or fuzzy. Returns candidates with signatures, locations, \
-             logical-symbol grouping (cfg variants), and any bound repo memories. Use to \
-             disambiguate before a graph or read call. Generated bindings (codegen, ubrn FFI \
+             C, C++, Python, or Swift — exact or fuzzy. Returns candidates with signatures, \
+             locations, logical-symbol grouping (cfg variants), and any bound repo memories. Use \
+             to disambiguate before a graph or read call. Generated bindings (codegen, ubrn FFI \
              output) are excluded by default; pass include: [\"generated\"] to see them.",
         "find_callers" =>
             "Find what calls a symbol (reverse call graph), instead of grepping for call sites. \

--- a/crates/rag-rat-mcp/src/tools/requests.rs
+++ b/crates/rag-rat-mcp/src/tools/requests.rs
@@ -87,6 +87,8 @@ impl McpGraphResolutionMode {
 pub enum McpGraphEdgeKind {
     CallsName,
     Constructs,
+    UsesOperator,
+    UsesPrecedenceGroup,
     Dispatches,
     UsesMacro,
     ReferencesType,
@@ -101,6 +103,8 @@ impl McpGraphEdgeKind {
         match self {
             Self::CallsName => "calls_name",
             Self::Constructs => "constructs",
+            Self::UsesOperator => "uses_operator",
+            Self::UsesPrecedenceGroup => "uses_precedence_group",
             Self::Dispatches => "dispatches",
             Self::UsesMacro => "uses_macro",
             Self::ReferencesType => "references_type",

--- a/crates/rag-rat-mcp/src/tools/tests.rs
+++ b/crates/rag-rat-mcp/src/tools/tests.rs
@@ -214,6 +214,8 @@ fn list_tools_exposes_complete_typed_schemas() {
     assert_schema_array_item_enum(tools, "find_callers", "edge_kinds", &[
         "calls_name",
         "constructs",
+        "uses_operator",
+        "uses_precedence_group",
         "dispatches",
         "uses_macro",
         "references_type",

--- a/docs/config.md
+++ b/docs/config.md
@@ -277,15 +277,17 @@ include = ["**/*.ts"]
 exclude = ["**/*.map"]
 ```
 
-Supported languages are `rust`, `typescript`, `kotlin`, `c`, `cpp`, `python`, and `markdown`. Rust,
-TypeScript/TSX, Kotlin, C, C++, and Python source use tree-sitter structural indexing when files are
-under the parser size cap.
+Supported languages are `rust`, `typescript`, `kotlin`, `c`, `cpp`, `python`, `swift`, and
+`markdown`. Rust, TypeScript/TSX, Kotlin, C, C++, Python, and Swift source use tree-sitter structural
+indexing when files are under the parser size cap.
 Markdown uses heading-section chunking and does not use tree-sitter. Supported target kinds are
 `source`, `generated`, `docs`, and `tests`; generated targets are indexed with coarse chunks and
 still obey `include_generated` filtering.
 
-Parser grammar dependencies are exact-pinned in `Cargo.toml`: `tree-sitter` 0.22.6,
-`tree-sitter-rust` 0.21.2, `tree-sitter-typescript` 0.21.2, and `tree-sitter-kotlin` 0.3.8.
+Parser grammar dependencies are exact-pinned in `Cargo.toml`: `tree-sitter` 0.26.9,
+`tree-sitter-rust` 0.24.2, `tree-sitter-typescript` 0.23.2, `tree-sitter-kotlin-ng` 1.1.0,
+`tree-sitter-c` 0.24.2, `tree-sitter-cpp` 0.23.4, `tree-sitter-python` 0.25.0, and
+`tree-sitter-swift` 0.7.3.
 
 `[llm.embedding.runtime]` controls reconcile defaults for local embedding generation. CLI flags
 still take precedence: `--batch-size` overrides `batch_size`, and `--max-embedding-chars` overrides

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -236,7 +236,8 @@ caller knows whether embeddings contributed without setting `explain`. It is `le
 hit when no embedding model is active.
 
 Graph tools are backed by tree-sitter-derived syntax edges. Edge kinds are `imports`, `exports`,
-`calls_name`, `constructs`, `uses_macro`, `references_type`, `implements`, and `contains`; confidence is reported as
+`calls_name`, `constructs`, `dispatches`, `uses_macro`, `uses_operator`, `uses_precedence_group`,
+`references_type`, `implements`, and `contains`; confidence is reported as
 `edge_confidence` (`confidence` is retained as the compatibility alias) with values `Exact`,
 `Syntactic`, `NameOnly`, or `Ambiguous`. Graph evidence is syntactic, confidence-labeled evidence,
 not compiler-grade name resolution or hard truth. Search results default to compact graph evidence


### PR DESCRIPTION
## Summary

- add Swift as a first-class indexed language using `tree-sitter-swift`
- extract Swift declarations, structural chunks, imports, calls, construction, type references, inheritance/conformance, and containment
- centralize static language metadata and introduce narrow parser/edge backend traits
- expose Swift through config, documentation, `init --yes`, and the interactive init wizard
- add focused parser, graph, persistence, configuration, SwiftPM discovery, and wizard regression coverage

## Why

This establishes the tree-sitter Swift baseline needed before corpus-quality work and SourceKit semantic resolution. It also removes scattered language dispatch so future language additions have explicit registry and backend contracts.

Closes #635.

## Validation

- `cargo nextest run --workspace --no-fail-fast` — 2,541 passed
- `cargo clippy --workspace --all-targets --no-default-features -- -D warnings`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`