### PR TITLE
feat(papertrail): add automatic sync scheduling core

### DIFF
--- a/crates/rag-rat-core/src/config/mod.rs
+++ b/crates/rag-rat-core/src/config/mod.rs
@@ -158,11 +158,6 @@ pub enum ConfigError {
     #[error("[[tracker]] `base_url` must not embed credentials in the URL")]
     TrackerBaseUrlHasCredentials,
     #[error(
-        "[papertrail] scheduling settings are not supported until the provider mirror scheduler \
-         is active"
-    )]
-    PapertrailSchedulingNotSupported,
-    #[error(
         "[papertrail] `rate_limit_reserve` must be a finite fraction from 0.0 up to (but not \
          including) 1.0 (got `{0}`)"
     )]

--- a/crates/rag-rat-core/src/config/raw.rs
+++ b/crates/rag-rat-core/src/config/raw.rs
@@ -46,8 +46,7 @@ pub(crate) struct RawConfig {
     pub(crate) memory: RawMemory,
     #[serde(default, rename = "tracker")]
     pub(crate) tracker: Vec<RawTracker>,
-    /// Papertrail transport/scheduler settings. The transport consumes `rate_limit_reserve` now;
-    /// cadence fields are captured so they can be rejected until the scheduler consumes them.
+    /// Papertrail transport and automatic synchronization settings.
     #[serde(default)]
     pub(crate) papertrail: Option<RawPapertrail>,
     #[serde(default)]
@@ -69,18 +68,22 @@ impl TryFrom<RawPapertrail> for PapertrailConfig {
     type Error = ConfigError;
 
     fn try_from(raw: RawPapertrail) -> Result<Self, Self::Error> {
-        if raw.probe_interval_secs.is_some()
-            || raw.sync_min_interval_secs.is_some()
-            || raw.full_sync_interval_secs.is_some()
-        {
-            return Err(ConfigError::PapertrailSchedulingNotSupported);
-        }
         let default = PapertrailConfig::default();
+        let probe_interval_secs = raw.probe_interval_secs.unwrap_or(default.probe_interval_secs);
+        let sync_min_interval_secs =
+            raw.sync_min_interval_secs.unwrap_or(default.sync_min_interval_secs);
+        let full_sync_interval_secs =
+            raw.full_sync_interval_secs.unwrap_or(default.full_sync_interval_secs);
         let rate_limit_reserve = raw.rate_limit_reserve.unwrap_or(default.rate_limit_reserve);
         if !rate_limit_reserve.is_finite() || !(0.0..1.0).contains(&rate_limit_reserve) {
             return Err(ConfigError::PapertrailRateLimitReserveOutOfRange(rate_limit_reserve));
         }
-        Ok(PapertrailConfig { rate_limit_reserve, ..default })
+        Ok(PapertrailConfig {
+            probe_interval_secs,
+            sync_min_interval_secs,
+            full_sync_interval_secs,
+            rate_limit_reserve,
+        })
     }
 }
 

--- a/crates/rag-rat-core/src/config/tests.rs
+++ b/crates/rag-rat-core/src/config/tests.rs
@@ -227,14 +227,14 @@ fn tracker_base_url_rejects_credentials_and_normalizes_trailing_slashes() {
 }
 
 #[test]
-fn papertrail_scheduling_table_is_rejected_until_it_is_consumed() {
+fn papertrail_scheduling_intervals_are_parsed() {
     let dir = tempfile::tempdir().unwrap();
     std::fs::write(dir.path().join("rag-rat.toml"), "[papertrail]\nprobe_interval_secs = 60\n")
         .unwrap();
-    assert!(matches!(
-        Config::load(dir.path().join("rag-rat.toml")),
-        Err(ConfigError::PapertrailSchedulingNotSupported)
-    ));
+    let config = Config::load(dir.path().join("rag-rat.toml")).unwrap();
+    assert_eq!(config.papertrail.probe_interval_secs, 60);
+    assert_eq!(config.papertrail.sync_min_interval_secs, 900);
+    assert_eq!(config.papertrail.full_sync_interval_secs, 86_400);
 }
 
 #[test]
@@ -2692,10 +2692,7 @@ fn config_load_rejects_reserved_papertrail_table_from_governing_main() {
     )
     .unwrap();
 
-    assert!(matches!(
-        Config::load(linked.join("rag-rat.toml")),
-        Err(ConfigError::PapertrailSchedulingNotSupported)
-    ));
+    Config::load(linked.join("rag-rat.toml")).unwrap();
 
     let _ = std::fs::remove_dir_all(&tmp);
 }

--- a/crates/rag-rat-core/src/config/types.rs
+++ b/crates/rag-rat-core/src/config/types.rs
@@ -110,8 +110,7 @@ pub enum TrackerAuth {
     TokenCommand(String),
 }
 
-/// Papertrail transport and reserved scheduler settings. `rate_limit_reserve` is live in the
-/// shared transport; user cadence overrides remain rejected until the scheduler consumes them.
+/// Papertrail transport and automatic synchronization settings.
 #[derive(Debug, Clone, PartialEq)]
 pub struct PapertrailConfig {
     pub probe_interval_secs: u64,

--- a/crates/rag-rat-core/src/index/papertrail/api.rs
+++ b/crates/rag-rat-core/src/index/papertrail/api.rs
@@ -18,12 +18,6 @@ pub(crate) async fn sync_mirror(
         let attempted_at = now_ms();
         record_attempt(conn, binding, attempted_at)?;
         if binding.provider != Tracker::Github {
-            record_failure(
-                conn,
-                binding,
-                PapertrailErrorClass::Provider,
-                Some("provider mirror client is not implemented"),
-            )?;
             errors.push(PapertrailSyncError {
                 tracker: binding.provider,
                 project: binding.project.clone(),
@@ -249,7 +243,7 @@ pub(crate) fn status(
         .iter()
         .map(|binding| {
             let (health, error_class, error_detail, stored_filter_fingerprint) =
-                load_persisted_health(conn, &repo_id, binding.provider, &binding.project)?;
+                load_persisted_health(conn, &repo_id, binding)?;
             let filter_changed = stored_filter_fingerprint != binding.filter_fingerprint();
             let overdue = decide_schedule(now, &ctx.schedule, health, filter_changed)
                 != ScheduleDecision::Skip;
@@ -261,7 +255,7 @@ pub(crate) fn status(
                 last_successful_mirror_ms: health.last_successful_mirror_ms,
                 last_full_walk_ms: health.last_full_walk_ms,
                 retry_not_before_ms: health.retry_not_before_ms,
-                full_walk_in_progress: health.full_walk_in_progress,
+                full_walk_in_progress: health.continuation == MirrorContinuation::Full,
                 error_class,
                 error_detail,
                 overdue,
@@ -653,5 +647,9 @@ mod capability_tests {
             vec!["provider_client_pending", "authentication_or_transport", "failed"]
         );
         assert_eq!(failed_handle.join().unwrap().len(), 1);
+        let pending =
+            report.status.bindings.iter().find(|binding| binding.project == "group/repo").unwrap();
+        assert!(!pending.failed);
+        assert_eq!(pending.error_class, None);
     }
 }

--- a/crates/rag-rat-core/src/index/papertrail/api.rs
+++ b/crates/rag-rat-core/src/index/papertrail/api.rs
@@ -245,8 +245,9 @@ pub(crate) fn status(
             let (health, error_class, error_detail, stored_filter_fingerprint) =
                 load_persisted_health(conn, &repo_id, binding)?;
             let filter_changed = stored_filter_fingerprint != binding.filter_fingerprint();
-            let overdue = decide_schedule(now, &ctx.schedule, health, filter_changed)
-                != ScheduleDecision::Skip;
+            let synchronization = tracker_synchronization(binding);
+            let decision = decide_schedule(now, &ctx.schedule, health, filter_changed);
+            let (overdue, failed) = binding_status_flags(synchronization, decision, error_class);
             Ok(PapertrailBindingStatus {
                 tracker: binding.provider,
                 project: binding.project.clone(),
@@ -259,7 +260,7 @@ pub(crate) fn status(
                 error_class,
                 error_detail,
                 overdue,
-                failed: error_class.is_some(),
+                failed,
             })
         })
         .collect::<anyhow::Result<Vec<_>>>()?;
@@ -317,6 +318,20 @@ fn tracker_synchronization(binding: &ResolvedTracker) -> TrackerSynchronization 
         Tracker::Github => TrackerSynchronization::Native,
         _ => TrackerSynchronization::ProviderClientPending,
     }
+}
+
+fn binding_status_flags(
+    synchronization: TrackerSynchronization,
+    decision: ScheduleDecision,
+    error_class: Option<PapertrailErrorClass>,
+) -> (bool, bool) {
+    if synchronization == TrackerSynchronization::ProviderClientPending {
+        return (false, false);
+    }
+    (
+        decision != ScheduleDecision::Skip,
+        error_class.is_some_and(|class| class != PapertrailErrorClass::RateLimited),
+    )
 }
 pub(crate) fn issue_search(
     conn: &Connection,
@@ -498,6 +513,49 @@ mod capability_tests {
     }
 
     #[test]
+    fn public_binding_status_distinguishes_capability_pause_and_failure() {
+        assert_eq!(
+            binding_status_flags(
+                TrackerSynchronization::ProviderClientPending,
+                ScheduleDecision::Full,
+                Some(PapertrailErrorClass::Provider),
+            ),
+            (false, false)
+        );
+        assert_eq!(
+            binding_status_flags(
+                TrackerSynchronization::Native,
+                ScheduleDecision::Skip,
+                Some(PapertrailErrorClass::RateLimited),
+            ),
+            (false, false)
+        );
+        assert_eq!(
+            binding_status_flags(
+                TrackerSynchronization::Native,
+                ScheduleDecision::Incremental,
+                Some(PapertrailErrorClass::Authentication),
+            ),
+            (true, true)
+        );
+    }
+
+    #[test]
+    fn persisted_rate_limit_pause_is_not_reported_as_a_failure() {
+        let binding = github(None);
+        let ctx =
+            PapertrailContext { trackers: vec![binding.clone()], ..PapertrailContext::default() };
+        let conn = Connection::open_in_memory().unwrap();
+        schema::apply(&conn).unwrap();
+        record_pause(&conn, &binding, i64::MAX).unwrap();
+
+        let binding_status = status(&conn, &ctx).unwrap().bindings.remove(0);
+        assert_eq!(binding_status.error_class, Some(PapertrailErrorClass::RateLimited));
+        assert!(!binding_status.overdue);
+        assert!(!binding_status.failed);
+    }
+
+    #[test]
     fn paused_mirror_is_not_a_successful_operation() {
         let report = MirrorBindingReport {
             tracker: Tracker::Github,
@@ -650,6 +708,7 @@ mod capability_tests {
         let pending =
             report.status.bindings.iter().find(|binding| binding.project == "group/repo").unwrap();
         assert!(!pending.failed);
+        assert!(!pending.overdue);
         assert_eq!(pending.error_class, None);
     }
 }

--- a/crates/rag-rat-core/src/index/papertrail/api.rs
+++ b/crates/rag-rat-core/src/index/papertrail/api.rs
@@ -42,6 +42,8 @@ pub(crate) async fn sync_mirror(
                     synced_items += report.stored_items;
                     if let Some(operation) = completed_mirror_operation(&report, full) {
                         record_success(conn, binding, operation, now_ms())?;
+                    } else if let Some(resume_at_ms) = report.paused_until_ms {
+                        record_pause(conn, binding, resume_at_ms)?;
                     }
                     bindings.push(report);
                 },
@@ -245,6 +247,7 @@ pub(crate) fn status(
                 last_successful_probe_ms: health.last_successful_probe_ms,
                 last_successful_mirror_ms: health.last_successful_mirror_ms,
                 last_full_walk_ms: health.last_full_walk_ms,
+                retry_not_before_ms: health.retry_not_before_ms,
                 error_class,
                 error_detail,
                 overdue,

--- a/crates/rag-rat-core/src/index/papertrail/api.rs
+++ b/crates/rag-rat-core/src/index/papertrail/api.rs
@@ -101,7 +101,7 @@ fn completed_mirror_operation(
     if report.paused_until_ms.is_some() {
         return None;
     }
-    Some(if full {
+    Some(if full || report.completed_full_walk {
         SuccessfulOperation::FullMirror
     } else {
         SuccessfulOperation::IncrementalMirror
@@ -248,6 +248,7 @@ pub(crate) fn status(
                 last_successful_mirror_ms: health.last_successful_mirror_ms,
                 last_full_walk_ms: health.last_full_walk_ms,
                 retry_not_before_ms: health.retry_not_before_ms,
+                full_walk_in_progress: health.full_walk_in_progress,
                 error_class,
                 error_detail,
                 overdue,
@@ -499,6 +500,7 @@ mod capability_tests {
             pruned_items: 0,
             paused_until_ms: Some(42),
             pause_reason: Some("rate_limited".to_string()),
+            completed_full_walk: false,
         };
         assert_eq!(completed_mirror_operation(&report, false), None);
         assert_eq!(completed_mirror_operation(&report, true), None);
@@ -510,6 +512,24 @@ mod capability_tests {
         );
         assert_eq!(
             completed_mirror_operation(&completed, true),
+            Some(SuccessfulOperation::FullMirror)
+        );
+    }
+
+    #[test]
+    fn completed_initial_backfill_is_a_full_walk() {
+        let report = MirrorBindingReport {
+            tracker: Tracker::Github,
+            project: "o/r".to_string(),
+            stored_items: 1,
+            stored_comments: 0,
+            pruned_items: 0,
+            paused_until_ms: None,
+            pause_reason: None,
+            completed_full_walk: true,
+        };
+        assert_eq!(
+            completed_mirror_operation(&report, false),
             Some(SuccessfulOperation::FullMirror)
         );
     }
@@ -550,6 +570,8 @@ mod capability_tests {
         assert_eq!(report.bindings.len(), 2);
         assert_eq!(report.bindings[0].project, "a/one");
         assert_eq!(report.bindings[1].project, "b/two");
+        assert!(report.bindings.iter().all(|binding| binding.completed_full_walk));
+        assert!(report.status.bindings.iter().all(|binding| binding.last_full_walk_ms.is_some()));
         assert_eq!(report.status.issues, 2);
         assert_eq!(first_handle.join().unwrap().len(), 7);
         assert_eq!(second_handle.join().unwrap().len(), 7);

--- a/crates/rag-rat-core/src/index/papertrail/api.rs
+++ b/crates/rag-rat-core/src/index/papertrail/api.rs
@@ -40,17 +40,10 @@ pub(crate) async fn sync_mirror(
             Ok(client) => match mirror_binding(conn, binding, &client, full).await {
                 Ok(report) => {
                     synced_items += report.stored_items;
+                    if let Some(operation) = completed_mirror_operation(&report, full) {
+                        record_success(conn, binding, operation, now_ms())?;
+                    }
                     bindings.push(report);
-                    record_success(
-                        conn,
-                        binding,
-                        if full {
-                            SuccessfulOperation::FullMirror
-                        } else {
-                            SuccessfulOperation::IncrementalMirror
-                        },
-                        now_ms(),
-                    )?;
                 },
                 Err(error) => {
                     record_failure(
@@ -96,6 +89,20 @@ pub(crate) async fn sync_mirror(
         bindings,
         errors,
         status: status(conn, ctx)?,
+    })
+}
+
+fn completed_mirror_operation(
+    report: &MirrorBindingReport,
+    full: bool,
+) -> Option<SuccessfulOperation> {
+    if report.paused_until_ms.is_some() {
+        return None;
+    }
+    Some(if full {
+        SuccessfulOperation::FullMirror
+    } else {
+        SuccessfulOperation::IncrementalMirror
     })
 }
 
@@ -476,6 +483,31 @@ mod capability_tests {
         assert_eq!(
             tracker_synchronization(&enterprise.trackers[0]),
             TrackerSynchronization::Native
+        );
+    }
+
+    #[test]
+    fn paused_mirror_is_not_a_successful_operation() {
+        let report = MirrorBindingReport {
+            tracker: Tracker::Github,
+            project: "o/r".to_string(),
+            stored_items: 1,
+            stored_comments: 0,
+            pruned_items: 0,
+            paused_until_ms: Some(42),
+            pause_reason: Some("rate_limited".to_string()),
+        };
+        assert_eq!(completed_mirror_operation(&report, false), None);
+        assert_eq!(completed_mirror_operation(&report, true), None);
+
+        let completed = MirrorBindingReport { paused_until_ms: None, ..report };
+        assert_eq!(
+            completed_mirror_operation(&completed, false),
+            Some(SuccessfulOperation::IncrementalMirror)
+        );
+        assert_eq!(
+            completed_mirror_operation(&completed, true),
+            Some(SuccessfulOperation::FullMirror)
         );
     }
 

--- a/crates/rag-rat-core/src/index/papertrail/api.rs
+++ b/crates/rag-rat-core/src/index/papertrail/api.rs
@@ -64,11 +64,12 @@ pub(crate) async fn sync_mirror(
                 },
             },
             Err(error) => {
+                let persisted_detail = authentication_failure_detail(binding, &error);
                 record_failure(
                     conn,
                     binding,
                     PapertrailErrorClass::Authentication,
-                    Some(&error.to_string()),
+                    persisted_detail.as_deref(),
                 )?;
                 errors.push(PapertrailSyncError {
                     tracker: binding.provider,
@@ -92,6 +93,17 @@ pub(crate) async fn sync_mirror(
         errors,
         status: status(conn, ctx)?,
     })
+}
+
+fn authentication_failure_detail(
+    binding: &ResolvedTracker,
+    error: &anyhow::Error,
+) -> Option<String> {
+    match binding.auth {
+        Some(crate::config::TrackerAuth::TokenCommand(_)) =>
+            Some("configured token command failed".to_string()),
+        _ => Some(error.to_string()),
+    }
 }
 
 fn completed_mirror_operation(
@@ -596,6 +608,18 @@ mod capability_tests {
         let refs: i64 =
             conn.query_row("SELECT COUNT(*) FROM papertrail_refs", [], |row| row.get(0)).unwrap();
         assert_eq!(refs, 0);
+    }
+
+    #[test]
+    fn token_command_failure_detail_is_redacted_before_persistence() {
+        let mut binding = github(None);
+        binding.auth =
+            Some(crate::config::TrackerAuth::TokenCommand("secret-bearing command".to_string()));
+        let error = anyhow::anyhow!("token_command `secret-bearing command` failed: secret stderr");
+        assert_eq!(
+            authentication_failure_detail(&binding, &error).as_deref(),
+            Some("configured token command failed")
+        );
     }
 
     #[test]

--- a/crates/rag-rat-core/src/index/papertrail/api.rs
+++ b/crates/rag-rat-core/src/index/papertrail/api.rs
@@ -15,7 +15,15 @@ pub(crate) async fn sync_mirror(
     let mut bindings = Vec::new();
     let mut errors = Vec::new();
     for binding in &ctx.trackers {
+        let attempted_at = now_ms();
+        record_attempt(conn, binding, attempted_at)?;
         if binding.provider != Tracker::Github {
+            record_failure(
+                conn,
+                binding,
+                PapertrailErrorClass::Provider,
+                Some("provider mirror client is not implemented"),
+            )?;
             errors.push(PapertrailSyncError {
                 tracker: binding.provider,
                 project: binding.project.clone(),
@@ -33,22 +41,48 @@ pub(crate) async fn sync_mirror(
                 Ok(report) => {
                     synced_items += report.stored_items;
                     bindings.push(report);
+                    record_success(
+                        conn,
+                        binding,
+                        if full {
+                            SuccessfulOperation::FullMirror
+                        } else {
+                            SuccessfulOperation::IncrementalMirror
+                        },
+                        now_ms(),
+                    )?;
                 },
-                Err(error) => errors.push(PapertrailSyncError {
+                Err(error) => {
+                    record_failure(
+                        conn,
+                        binding,
+                        PapertrailErrorClass::Provider,
+                        Some(&error.to_string()),
+                    )?;
+                    errors.push(PapertrailSyncError {
+                        tracker: binding.provider,
+                        project: binding.project.clone(),
+                        item_key: String::new(),
+                        status: "failed".to_string(),
+                        error: error.to_string(),
+                    });
+                },
+            },
+            Err(error) => {
+                record_failure(
+                    conn,
+                    binding,
+                    PapertrailErrorClass::Authentication,
+                    Some(&error.to_string()),
+                )?;
+                errors.push(PapertrailSyncError {
                     tracker: binding.provider,
                     project: binding.project.clone(),
                     item_key: String::new(),
-                    status: "failed".to_string(),
+                    status: "authentication_or_transport".to_string(),
                     error: error.to_string(),
-                }),
+                });
             },
-            Err(error) => errors.push(PapertrailSyncError {
-                tracker: binding.provider,
-                project: binding.project.clone(),
-                item_key: String::new(),
-                status: "authentication_or_transport".to_string(),
-                error: error.to_string(),
-            }),
         }
     }
     let repo_id = schema::active_repo_id(conn)?;
@@ -188,6 +222,29 @@ pub(crate) fn status(
         )?;
         Ok(u64::try_from(count).unwrap_or_default())
     };
+    let now = now_ms();
+    let bindings = ctx
+        .trackers
+        .iter()
+        .map(|binding| {
+            let (health, error_class, error_detail) =
+                load_persisted_health(conn, &repo_id, binding.provider, &binding.project)?;
+            let overdue =
+                decide_schedule(now, &ctx.schedule, health, false) != ScheduleDecision::Skip;
+            Ok(PapertrailBindingStatus {
+                tracker: binding.provider,
+                project: binding.project.clone(),
+                last_attempt_ms: health.last_attempt_ms,
+                last_successful_probe_ms: health.last_successful_probe_ms,
+                last_successful_mirror_ms: health.last_successful_mirror_ms,
+                last_full_walk_ms: health.last_full_walk_ms,
+                error_class,
+                error_detail,
+                overdue,
+                failed: error_class.is_some(),
+            })
+        })
+        .collect::<anyhow::Result<Vec<_>>>()?;
     Ok(PapertrailStatus {
         refs: scoped_table_row_count(conn, "papertrail_refs", &repo_id)?,
         issues: items_by_kind(ItemKind::Issue)?,
@@ -205,6 +262,7 @@ pub(crate) fn status(
                 synchronization: tracker_synchronization(binding),
             })
             .collect(),
+        bindings,
     })
 }
 

--- a/crates/rag-rat-core/src/index/papertrail/api.rs
+++ b/crates/rag-rat-core/src/index/papertrail/api.rs
@@ -236,10 +236,11 @@ pub(crate) fn status(
         .trackers
         .iter()
         .map(|binding| {
-            let (health, error_class, error_detail) =
+            let (health, error_class, error_detail, stored_filter_fingerprint) =
                 load_persisted_health(conn, &repo_id, binding.provider, &binding.project)?;
-            let overdue =
-                decide_schedule(now, &ctx.schedule, health, false) != ScheduleDecision::Skip;
+            let filter_changed = stored_filter_fingerprint != binding.filter_fingerprint();
+            let overdue = decide_schedule(now, &ctx.schedule, health, filter_changed)
+                != ScheduleDecision::Skip;
             Ok(PapertrailBindingStatus {
                 tracker: binding.provider,
                 project: binding.project.clone(),

--- a/crates/rag-rat-core/src/index/papertrail/api.rs
+++ b/crates/rag-rat-core/src/index/papertrail/api.rs
@@ -42,12 +42,8 @@ pub(crate) async fn sync_mirror(
                     bindings.push(report);
                 },
                 Err(error) => {
-                    record_failure(
-                        conn,
-                        binding,
-                        PapertrailErrorClass::Provider,
-                        Some(&error.to_string()),
-                    )?;
+                    let class = classify_mirror_failure(&error);
+                    record_failure(conn, binding, class, Some(&error.to_string()))?;
                     errors.push(PapertrailSyncError {
                         tracker: binding.provider,
                         project: binding.project.clone(),
@@ -98,6 +94,26 @@ fn authentication_failure_detail(
             Some("configured token command failed".to_string()),
         _ => Some(error.to_string()),
     }
+}
+
+fn classify_mirror_failure(error: &anyhow::Error) -> PapertrailErrorClass {
+    for cause in error.chain() {
+        if cause.downcast_ref::<rusqlite::Error>().is_some() {
+            return PapertrailErrorClass::Storage;
+        }
+        if let Some(transport) = cause.downcast_ref::<transport::TransportError>() {
+            return match transport {
+                transport::TransportError::Http(_) => PapertrailErrorClass::Network,
+                transport::TransportError::Paused { .. } => PapertrailErrorClass::RateLimited,
+                transport::TransportError::UrlOutsideBinding { .. } =>
+                    PapertrailErrorClass::Provider,
+            };
+        }
+        if cause.downcast_ref::<reqwest::Error>().is_some() {
+            return PapertrailErrorClass::Network;
+        }
+    }
+    PapertrailErrorClass::Provider
 }
 
 fn completed_mirror_operation(
@@ -672,6 +688,21 @@ mod capability_tests {
             authentication_failure_detail(&binding, &error).as_deref(),
             Some("configured token command failed")
         );
+    }
+
+    #[test]
+    fn mirror_failure_classification_uses_the_error_chain() {
+        let storage =
+            anyhow::Error::new(rusqlite::Error::InvalidQuery).context("commit mirror page");
+        assert_eq!(classify_mirror_failure(&storage), PapertrailErrorClass::Storage);
+
+        let network =
+            anyhow::Error::new(reqwest::Client::new().get("://invalid").build().unwrap_err())
+                .context("fetch mirror page");
+        assert_eq!(classify_mirror_failure(&network), PapertrailErrorClass::Network);
+
+        let provider = anyhow::anyhow!("provider payload did not match the expected schema");
+        assert_eq!(classify_mirror_failure(&provider), PapertrailErrorClass::Provider);
     }
 
     #[test]

--- a/crates/rag-rat-core/src/index/papertrail/mirror.rs
+++ b/crates/rag-rat-core/src/index/papertrail/mirror.rs
@@ -78,6 +78,7 @@ pub struct MirrorBindingReport {
     pub pruned_items: usize,
     pub paused_until_ms: Option<i64>,
     pub pause_reason: Option<String>,
+    pub completed_full_walk: bool,
 }
 
 pub(crate) async fn mirror_binding<C: PapertrailClient>(
@@ -87,6 +88,7 @@ pub(crate) async fn mirror_binding<C: PapertrailClient>(
     full: bool,
 ) -> anyhow::Result<MirrorBindingReport> {
     let mut cursor = load_cursor(conn, binding)?;
+    let had_completed_backfill = cursor.backfill_done;
     let fingerprint = binding.filter_fingerprint();
     let filter_changed = cursor.filter_fingerprint != fingerprint;
     let starting_full_rewalk = full && !cursor.full_rewalk;
@@ -132,6 +134,7 @@ pub(crate) async fn mirror_binding<C: PapertrailClient>(
         pruned_items: 0,
         paused_until_ms: None,
         pause_reason: None,
+        completed_full_walk: false,
     };
     if filter_changed {
         report.pruned_items += prune_unmatched(conn, binding)?;
@@ -140,7 +143,11 @@ pub(crate) async fn mirror_binding<C: PapertrailClient>(
 
     let result = mirror_binding_inner(conn, binding, client, &mut cursor, &mut report).await;
     match result {
-        Ok(()) => Ok(report),
+        Ok(()) => {
+            report.completed_full_walk =
+                cursor.backfill_done && (!had_completed_backfill || starting_full_rewalk);
+            Ok(report)
+        },
         Err(error) if pause(&error).is_some() => {
             let (resume_at_ms, reason) = pause(&error).expect("checked");
             report.paused_until_ms = Some(resume_at_ms);

--- a/crates/rag-rat-core/src/index/papertrail/mirror.rs
+++ b/crates/rag-rat-core/src/index/papertrail/mirror.rs
@@ -82,12 +82,15 @@ impl MirrorCursor {
         if self.full_rewalk {
             return MirrorContinuation::Full;
         }
-        if !self.backfill_done
-            || self.item_delta_in_progress
+        if self.item_delta_in_progress
             || self.item_delta_replay_required
             || self.item_delta_page_token.is_some()
             || self.backfill_page_cursor.is_some()
             || self.item_thread_cursor.is_some()
+            || (!self.backfill_done
+                && (self.low_mark_at.is_some()
+                    || self.high_mark_at.is_some()
+                    || !self.backfill_processed_keys.is_empty()))
             || self.comment_page_token.is_some()
             || self.comment_stream_cursors.values().any(|stream| stream.page_token.is_some())
         {
@@ -1982,6 +1985,7 @@ mod tests {
 
     #[test]
     fn continuation_classification_covers_every_persisted_resume_lane() {
+        assert_eq!(MirrorCursor::default().continuation(), MirrorContinuation::None);
         let mut cursor = MirrorCursor { backfill_done: true, ..Default::default() };
         assert_eq!(cursor.continuation(), MirrorContinuation::None);
 
@@ -1996,6 +2000,12 @@ mod tests {
 
         cursor.full_rewalk = true;
         assert_eq!(cursor.continuation(), MirrorContinuation::Full);
+
+        let partial_backfill = MirrorCursor {
+            low_mark_at: Some("2026-01-01T00:00:00Z".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(partial_backfill.continuation(), MirrorContinuation::Incremental);
     }
 
     #[test]

--- a/crates/rag-rat-core/src/index/papertrail/mirror.rs
+++ b/crates/rag-rat-core/src/index/papertrail/mirror.rs
@@ -144,8 +144,8 @@ pub(crate) async fn mirror_binding<C: PapertrailClient>(
     let result = mirror_binding_inner(conn, binding, client, &mut cursor, &mut report).await;
     match result {
         Ok(()) => {
-            report.completed_full_walk =
-                cursor.backfill_done && (!had_completed_backfill || starting_full_rewalk);
+            report.completed_full_walk = cursor.backfill_done
+                && (!had_completed_backfill || starting_full_rewalk || filter_changed);
             Ok(report)
         },
         Err(error) if pause(&error).is_some() => {
@@ -1886,6 +1886,7 @@ mod tests {
         ]);
         let report = block_on(mirror_binding(&conn, &docs, &changed, false)).unwrap();
         assert_eq!(report.pruned_items, 1);
+        assert!(report.completed_full_walk);
         assert_eq!(keys(&conn), vec!["2"]);
     }
 

--- a/crates/rag-rat-core/src/index/papertrail/mirror.rs
+++ b/crates/rag-rat-core/src/index/papertrail/mirror.rs
@@ -69,6 +69,41 @@ struct MirrorCursor {
     full_rewalk: bool,
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) enum MirrorContinuation {
+    #[default]
+    None,
+    Incremental,
+    Full,
+}
+
+impl MirrorCursor {
+    fn continuation(&self) -> MirrorContinuation {
+        if self.full_rewalk {
+            return MirrorContinuation::Full;
+        }
+        if !self.backfill_done
+            || self.item_delta_in_progress
+            || self.item_delta_replay_required
+            || self.item_delta_page_token.is_some()
+            || self.backfill_page_cursor.is_some()
+            || self.item_thread_cursor.is_some()
+            || self.comment_page_token.is_some()
+            || self.comment_stream_cursors.values().any(|stream| stream.page_token.is_some())
+        {
+            return MirrorContinuation::Incremental;
+        }
+        MirrorContinuation::None
+    }
+}
+
+pub(crate) fn load_mirror_continuation(
+    conn: &Connection,
+    binding: &ResolvedTracker,
+) -> anyhow::Result<MirrorContinuation> {
+    Ok(load_cursor(conn, binding)?.continuation())
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct MirrorBindingReport {
     pub tracker: Tracker,
@@ -88,6 +123,7 @@ pub(crate) async fn mirror_binding<C: PapertrailClient>(
     full: bool,
 ) -> anyhow::Result<MirrorBindingReport> {
     let mut cursor = load_cursor(conn, binding)?;
+    let resumed_continuation = cursor.continuation();
     let had_completed_backfill = cursor.backfill_done;
     let fingerprint = binding.filter_fingerprint();
     let filter_changed = cursor.filter_fingerprint != fingerprint;
@@ -145,7 +181,10 @@ pub(crate) async fn mirror_binding<C: PapertrailClient>(
     match result {
         Ok(()) => {
             report.completed_full_walk = cursor.backfill_done
-                && (!had_completed_backfill || starting_full_rewalk || filter_changed);
+                && (!had_completed_backfill
+                    || starting_full_rewalk
+                    || resumed_continuation == MirrorContinuation::Full
+                    || filter_changed);
             Ok(report)
         },
         Err(error) if pause(&error).is_some() => {
@@ -1935,9 +1974,28 @@ mod tests {
 
         let resumed = ScriptClient::new(vec![page(Vec::new())]);
         let report = block_on(mirror_binding(&conn, &binding, &resumed, false)).unwrap();
+        assert!(report.completed_full_walk);
         assert_eq!(report.pruned_items, 1);
         assert!(!load_cursor(&conn, &binding).unwrap().full_rewalk);
         assert_eq!(keys(&conn), vec!["1"]);
+    }
+
+    #[test]
+    fn continuation_classification_covers_every_persisted_resume_lane() {
+        let mut cursor = MirrorCursor { backfill_done: true, ..Default::default() };
+        assert_eq!(cursor.continuation(), MirrorContinuation::None);
+
+        cursor.item_delta_replay_required = true;
+        assert_eq!(cursor.continuation(), MirrorContinuation::Incremental);
+        cursor.item_delta_replay_required = false;
+        cursor.comment_stream_cursors.insert("default".to_string(), CommentStreamCursor {
+            page_token: Some("next".to_string()),
+            ..Default::default()
+        });
+        assert_eq!(cursor.continuation(), MirrorContinuation::Incremental);
+
+        cursor.full_rewalk = true;
+        assert_eq!(cursor.continuation(), MirrorContinuation::Full);
     }
 
     #[test]

--- a/crates/rag-rat-core/src/index/papertrail/mod.rs
+++ b/crates/rag-rat-core/src/index/papertrail/mod.rs
@@ -3,6 +3,7 @@ mod evidence;
 mod github;
 mod mirror;
 mod parse;
+mod schedule;
 mod store;
 mod sync;
 mod trackers;
@@ -19,6 +20,7 @@ pub(crate) use mirror::mirror_binding;
 pub(crate) use parse::*;
 pub use parse::{TrackerParsedRef, parse_tracker_refs};
 use rusqlite::{Connection, OptionalExtension, params};
+pub(crate) use schedule::*;
 use serde::{Deserialize, Serialize};
 pub(crate) use store::*;
 pub(crate) use sync::*;
@@ -39,6 +41,7 @@ pub struct PapertrailContext {
     /// Production discovery, rationale lookup, and manual mirror sync consume every binding.
     pub trackers: Vec<ResolvedTracker>,
     pub(crate) transport_options: transport::TransportOptions,
+    pub(crate) schedule: crate::config::PapertrailConfig,
 }
 
 impl PapertrailContext {
@@ -54,6 +57,7 @@ impl PapertrailContext {
         Self {
             trackers,
             transport_options: transport::TransportOptions::from(&config.papertrail),
+            schedule: config.papertrail.clone(),
         }
     }
 
@@ -71,7 +75,11 @@ impl PapertrailContext {
             })
             .into_iter()
             .collect();
-        Self { trackers, transport_options: transport::TransportOptions::default() }
+        Self {
+            trackers,
+            transport_options: transport::TransportOptions::default(),
+            schedule: crate::config::PapertrailConfig::default(),
+        }
     }
 
     /// `owner/repo` qualifying a manually requested legacy GitHub reference. Production
@@ -111,6 +119,21 @@ pub struct PapertrailStatus {
     pub comments: u64,
     pub last_sync_ms: Option<i64>,
     pub capabilities: Vec<TrackerCapability>,
+    pub bindings: Vec<PapertrailBindingStatus>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct PapertrailBindingStatus {
+    pub tracker: Tracker,
+    pub project: String,
+    pub last_attempt_ms: Option<i64>,
+    pub last_successful_probe_ms: Option<i64>,
+    pub last_successful_mirror_ms: Option<i64>,
+    pub last_full_walk_ms: Option<i64>,
+    pub error_class: Option<PapertrailErrorClass>,
+    pub error_detail: Option<String>,
+    pub overdue: bool,
+    pub failed: bool,
 }
 
 /// Per-binding auth and live-sync capability. Environment auth reflects token presence; command

--- a/crates/rag-rat-core/src/index/papertrail/mod.rs
+++ b/crates/rag-rat-core/src/index/papertrail/mod.rs
@@ -16,7 +16,7 @@ pub(crate) use api::*;
 pub(crate) use evidence::*;
 pub(crate) use github::*;
 pub use mirror::MirrorBindingReport;
-pub(crate) use mirror::mirror_binding;
+pub(crate) use mirror::{MirrorContinuation, load_mirror_continuation, mirror_binding};
 pub(crate) use parse::*;
 pub use parse::{TrackerParsedRef, parse_tracker_refs};
 use rusqlite::{Connection, OptionalExtension, params};

--- a/crates/rag-rat-core/src/index/papertrail/mod.rs
+++ b/crates/rag-rat-core/src/index/papertrail/mod.rs
@@ -131,6 +131,7 @@ pub struct PapertrailBindingStatus {
     pub last_successful_mirror_ms: Option<i64>,
     pub last_full_walk_ms: Option<i64>,
     pub retry_not_before_ms: Option<i64>,
+    pub full_walk_in_progress: bool,
     pub error_class: Option<PapertrailErrorClass>,
     pub error_detail: Option<String>,
     pub overdue: bool,

--- a/crates/rag-rat-core/src/index/papertrail/mod.rs
+++ b/crates/rag-rat-core/src/index/papertrail/mod.rs
@@ -130,6 +130,7 @@ pub struct PapertrailBindingStatus {
     pub last_successful_probe_ms: Option<i64>,
     pub last_successful_mirror_ms: Option<i64>,
     pub last_full_walk_ms: Option<i64>,
+    pub retry_not_before_ms: Option<i64>,
     pub error_class: Option<PapertrailErrorClass>,
     pub error_detail: Option<String>,
     pub overdue: bool,

--- a/crates/rag-rat-core/src/index/papertrail/schedule.rs
+++ b/crates/rag-rat-core/src/index/papertrail/schedule.rs
@@ -1,0 +1,254 @@
+use rusqlite::{Connection, OptionalExtension, params};
+use serde::Serialize;
+
+use super::ResolvedTracker;
+use crate::config::{PapertrailConfig, Tracker};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ScheduleDecision {
+    Skip,
+    Probe,
+    Incremental,
+    Full,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct BindingScheduleState {
+    pub last_attempt_ms: Option<i64>,
+    pub last_successful_probe_ms: Option<i64>,
+    pub last_successful_mirror_ms: Option<i64>,
+    pub last_full_walk_ms: Option<i64>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum PapertrailErrorClass {
+    Authentication,
+    Network,
+    RateLimited,
+    Provider,
+    Storage,
+    Unknown,
+}
+
+impl PapertrailErrorClass {
+    pub(crate) fn as_db_str(self) -> &'static str {
+        match self {
+            Self::Authentication => "authentication",
+            Self::Network => "network",
+            Self::RateLimited => "rate_limited",
+            Self::Provider => "provider",
+            Self::Storage => "storage",
+            Self::Unknown => "unknown",
+        }
+    }
+
+    fn from_db_str(value: &str) -> Option<Self> {
+        match value {
+            "authentication" => Some(Self::Authentication),
+            "network" => Some(Self::Network),
+            "rate_limited" => Some(Self::RateLimited),
+            "provider" => Some(Self::Provider),
+            "storage" => Some(Self::Storage),
+            "unknown" => Some(Self::Unknown),
+            _ => None,
+        }
+    }
+}
+
+pub(crate) fn decide_schedule(
+    now_ms: i64,
+    config: &PapertrailConfig,
+    state: BindingScheduleState,
+    change_detected: bool,
+) -> ScheduleDecision {
+    let elapsed = |then: Option<i64>, interval_secs: u64| {
+        then.is_none_or(|then| now_ms.saturating_sub(then) >= millis(interval_secs))
+    };
+    if elapsed(state.last_full_walk_ms, config.full_sync_interval_secs) {
+        return ScheduleDecision::Full;
+    }
+    if !elapsed(state.last_attempt_ms, config.sync_min_interval_secs) {
+        return ScheduleDecision::Skip;
+    }
+    if change_detected {
+        return ScheduleDecision::Incremental;
+    }
+    if elapsed(state.last_successful_probe_ms, config.probe_interval_secs) {
+        return ScheduleDecision::Probe;
+    }
+    ScheduleDecision::Skip
+}
+
+fn millis(seconds: u64) -> i64 {
+    i64::try_from(seconds.saturating_mul(1_000)).unwrap_or(i64::MAX)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SuccessfulOperation {
+    #[allow(dead_code, reason = "the watcher probe worker lands in the dependent #592 slice")]
+    Probe,
+    IncrementalMirror,
+    FullMirror,
+}
+
+pub(crate) fn record_attempt(
+    conn: &Connection,
+    binding: &ResolvedTracker,
+    at_ms: i64,
+) -> anyhow::Result<()> {
+    ensure_health_row(conn, binding)?;
+    update_health(conn, binding, "last_attempt_ms=?4", at_ms)
+}
+
+pub(crate) fn record_success(
+    conn: &Connection,
+    binding: &ResolvedTracker,
+    operation: SuccessfulOperation,
+    at_ms: i64,
+) -> anyhow::Result<()> {
+    ensure_health_row(conn, binding)?;
+    let assignment = match operation {
+        SuccessfulOperation::Probe => "last_successful_probe_ms=?4",
+        SuccessfulOperation::IncrementalMirror => "last_successful_mirror_ms=?4",
+        SuccessfulOperation::FullMirror => "last_successful_mirror_ms=?4, last_full_sync_ms=?4",
+    };
+    update_health(
+        conn,
+        binding,
+        &format!("{assignment}, error_class=NULL, error_detail=NULL"),
+        at_ms,
+    )
+}
+
+pub(crate) fn record_failure(
+    conn: &Connection,
+    binding: &ResolvedTracker,
+    class: PapertrailErrorClass,
+    detail: Option<&str>,
+) -> anyhow::Result<()> {
+    ensure_health_row(conn, binding)?;
+    let detail = detail.map(sanitize_error_detail);
+    let repo_id = crate::index::schema::active_repo_id(conn)?;
+    conn.execute(
+        "UPDATE papertrail_sync_cursor SET error_class=?4, error_detail=?5
+         WHERE repo_id=?1 AND tracker=?2 AND project=?3",
+        params![repo_id, binding.provider.as_db_str(), binding.project, class.as_db_str(), detail,],
+    )?;
+    Ok(())
+}
+
+fn ensure_health_row(conn: &Connection, binding: &ResolvedTracker) -> anyhow::Result<()> {
+    let repo_id = crate::index::schema::active_repo_id(conn)?;
+    conn.execute(
+        "INSERT OR IGNORE INTO papertrail_sync_cursor(tracker, project, repo_id)
+         VALUES (?1, ?2, ?3)",
+        params![binding.provider.as_db_str(), binding.project, repo_id],
+    )?;
+    Ok(())
+}
+
+fn update_health(
+    conn: &Connection,
+    binding: &ResolvedTracker,
+    assignment: &str,
+    at_ms: i64,
+) -> anyhow::Result<()> {
+    let repo_id = crate::index::schema::active_repo_id(conn)?;
+    let sql = format!(
+        "UPDATE papertrail_sync_cursor SET {assignment}
+         WHERE repo_id=?1 AND tracker=?2 AND project=?3"
+    );
+    conn.execute(&sql, params![repo_id, binding.provider.as_db_str(), binding.project, at_ms])?;
+    Ok(())
+}
+
+fn sanitize_error_detail(detail: &str) -> String {
+    detail
+        .chars()
+        .map(|ch| if ch.is_control() { ' ' } else { ch })
+        .take(512)
+        .collect::<String>()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+pub(crate) type PersistedHealth =
+    (BindingScheduleState, Option<PapertrailErrorClass>, Option<String>);
+
+pub(crate) fn load_persisted_health(
+    conn: &Connection,
+    repo_id: &str,
+    tracker: Tracker,
+    project: &str,
+) -> anyhow::Result<PersistedHealth> {
+    Ok(conn
+        .query_row(
+            "SELECT last_attempt_ms, last_successful_probe_ms, last_successful_mirror_ms,
+                    last_full_sync_ms, error_class, error_detail
+             FROM papertrail_sync_cursor
+             WHERE repo_id=?1 AND tracker=?2 AND project=?3",
+            params![repo_id, tracker.as_db_str(), project],
+            |row| {
+                let error: Option<String> = row.get(4)?;
+                Ok((
+                    BindingScheduleState {
+                        last_attempt_ms: row.get(0)?,
+                        last_successful_probe_ms: row.get(1)?,
+                        last_successful_mirror_ms: row.get(2)?,
+                        last_full_walk_ms: row.get(3)?,
+                    },
+                    error.as_deref().and_then(PapertrailErrorClass::from_db_str),
+                    row.get(5)?,
+                ))
+            },
+        )
+        .optional()?
+        .unwrap_or_default())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config() -> PapertrailConfig {
+        PapertrailConfig::default()
+    }
+
+    #[test]
+    fn full_backstop_has_priority() {
+        let state = BindingScheduleState { last_full_walk_ms: Some(0), ..Default::default() };
+        assert_eq!(decide_schedule(86_400_000, &config(), state, false), ScheduleDecision::Full);
+    }
+
+    #[test]
+    fn minimum_interval_suppresses_triggered_incremental_work() {
+        let state = BindingScheduleState {
+            last_attempt_ms: Some(10_000),
+            last_full_walk_ms: Some(10_000),
+            ..Default::default()
+        };
+        assert_eq!(decide_schedule(20_000, &config(), state, true), ScheduleDecision::Skip);
+    }
+
+    #[test]
+    fn due_probe_and_detected_change_are_explicit() {
+        let state = BindingScheduleState {
+            last_attempt_ms: Some(0),
+            last_successful_probe_ms: Some(0),
+            last_full_walk_ms: Some(1),
+            ..Default::default()
+        };
+        assert_eq!(decide_schedule(900_000, &config(), state, false), ScheduleDecision::Probe);
+        assert_eq!(decide_schedule(900_000, &config(), state, true), ScheduleDecision::Incremental);
+    }
+
+    #[test]
+    fn error_detail_is_bounded_and_single_line() {
+        let detail = format!("token\n{}", "x".repeat(600));
+        let sanitized = sanitize_error_detail(&detail);
+        assert!(!sanitized.contains('\n'));
+        assert!(sanitized.chars().count() <= 512);
+    }
+}

--- a/crates/rag-rat-core/src/index/papertrail/schedule.rs
+++ b/crates/rag-rat-core/src/index/papertrail/schedule.rs
@@ -1,8 +1,8 @@
 use rusqlite::{Connection, OptionalExtension, params};
 use serde::Serialize;
 
-use super::ResolvedTracker;
-use crate::config::{PapertrailConfig, Tracker};
+use super::{MirrorContinuation, ResolvedTracker, load_mirror_continuation};
+use crate::config::PapertrailConfig;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ScheduleDecision {
@@ -19,8 +19,7 @@ pub(crate) struct BindingScheduleState {
     pub last_successful_mirror_ms: Option<i64>,
     pub last_full_walk_ms: Option<i64>,
     pub retry_not_before_ms: Option<i64>,
-    pub full_walk_in_progress: bool,
-    pub mirror_work_in_progress: bool,
+    pub continuation: MirrorContinuation,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
@@ -74,11 +73,10 @@ pub(crate) fn decide_schedule(
     if !elapsed(state.last_attempt_ms, config.sync_min_interval_secs) {
         return ScheduleDecision::Skip;
     }
-    if state.full_walk_in_progress {
-        return ScheduleDecision::Full;
-    }
-    if state.mirror_work_in_progress {
-        return ScheduleDecision::Incremental;
+    match state.continuation {
+        MirrorContinuation::Full => return ScheduleDecision::Full,
+        MirrorContinuation::Incremental => return ScheduleDecision::Incremental,
+        MirrorContinuation::None => {},
     }
     if elapsed(state.last_full_walk_ms, config.full_sync_interval_secs) {
         return ScheduleDecision::Full;
@@ -211,24 +209,18 @@ pub(crate) type PersistedHealth =
 pub(crate) fn load_persisted_health(
     conn: &Connection,
     repo_id: &str,
-    tracker: Tracker,
-    project: &str,
+    binding: &ResolvedTracker,
 ) -> anyhow::Result<PersistedHealth> {
-    Ok(conn
+    let persisted = conn
         .query_row(
             "SELECT last_attempt_ms, last_successful_probe_ms, last_successful_mirror_ms,
-                    last_full_sync_ms, retry_not_before_ms, full_rewalk,
-                    backfill_done = 0 OR item_delta_in_progress = 1
-                        OR item_delta_page_token IS NOT NULL
-                        OR backfill_page_cursor IS NOT NULL
-                        OR item_thread_cursor IS NOT NULL
-                        OR comment_page_token IS NOT NULL,
+                    last_full_sync_ms, retry_not_before_ms,
                     error_class, error_detail, filter_fingerprint
              FROM papertrail_sync_cursor
              WHERE repo_id=?1 AND tracker=?2 AND project=?3",
-            params![repo_id, tracker.as_db_str(), project],
+            params![repo_id, binding.provider.as_db_str(), binding.project],
             |row| {
-                let error: Option<String> = row.get(7)?;
+                let error: Option<String> = row.get(5)?;
                 Ok((
                     BindingScheduleState {
                         last_attempt_ms: row.get(0)?,
@@ -236,22 +228,26 @@ pub(crate) fn load_persisted_health(
                         last_successful_mirror_ms: row.get(2)?,
                         last_full_walk_ms: row.get(3)?,
                         retry_not_before_ms: row.get(4)?,
-                        full_walk_in_progress: row.get(5)?,
-                        mirror_work_in_progress: row.get(6)?,
+                        continuation: MirrorContinuation::None,
                     },
                     error.as_deref().and_then(PapertrailErrorClass::from_db_str),
-                    row.get(8)?,
-                    row.get::<_, Option<String>>(9)?.unwrap_or_default(),
+                    row.get(6)?,
+                    row.get::<_, Option<String>>(7)?.unwrap_or_default(),
                 ))
             },
         )
-        .optional()?
-        .unwrap_or_default())
+        .optional()?;
+    let Some((mut state, error, detail, fingerprint)) = persisted else {
+        return Ok(PersistedHealth::default());
+    };
+    state.continuation = load_mirror_continuation(conn, binding)?;
+    Ok((state, error, detail, fingerprint))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::Tracker;
     use crate::index::papertrail::TrackerAuthentication;
     use crate::index::schema;
 
@@ -324,8 +320,7 @@ mod tests {
         record_pause(&conn, &binding, 20_000).unwrap();
         record_success(&conn, &binding, SuccessfulOperation::IncrementalMirror, 10_000).unwrap();
         let repo_id = schema::active_repo_id(&conn).unwrap();
-        let (state, error, _, _) =
-            load_persisted_health(&conn, &repo_id, Tracker::Github, "o/r").unwrap();
+        let (state, error, _, _) = load_persisted_health(&conn, &repo_id, &binding).unwrap();
         assert_eq!(state.last_successful_probe_ms, Some(10_000));
         assert_eq!(state.last_successful_mirror_ms, Some(10_000));
         assert_eq!(state.retry_not_before_ms, None);
@@ -339,8 +334,7 @@ mod tests {
         let binding = binding();
         record_pause(&conn, &binding, 20_000).unwrap();
         let repo_id = schema::active_repo_id(&conn).unwrap();
-        let (state, error, detail, _) =
-            load_persisted_health(&conn, &repo_id, Tracker::Github, "o/r").unwrap();
+        let (state, error, detail, _) = load_persisted_health(&conn, &repo_id, &binding).unwrap();
         assert_eq!(state.retry_not_before_ms, Some(20_000));
         assert_eq!(error, Some(PapertrailErrorClass::RateLimited));
         assert_eq!(detail, None);
@@ -360,8 +354,7 @@ mod tests {
         .unwrap();
         record_pause(&conn, &binding, 20_000).unwrap();
         let repo_id = schema::active_repo_id(&conn).unwrap();
-        let (_, error, detail, _) =
-            load_persisted_health(&conn, &repo_id, Tracker::Github, "o/r").unwrap();
+        let (_, error, detail, _) = load_persisted_health(&conn, &repo_id, &binding).unwrap();
         assert_eq!(error, Some(PapertrailErrorClass::RateLimited));
         assert_eq!(detail, None);
     }
@@ -380,8 +373,7 @@ mod tests {
         )
         .unwrap();
         let repo_id = schema::active_repo_id(&conn).unwrap();
-        let (state, error, detail, _) =
-            load_persisted_health(&conn, &repo_id, Tracker::Github, "o/r").unwrap();
+        let (state, error, detail, _) = load_persisted_health(&conn, &repo_id, &binding).unwrap();
         assert_eq!(state.retry_not_before_ms, None);
         assert_eq!(error, Some(PapertrailErrorClass::Authentication));
         assert_eq!(detail.as_deref(), Some("new auth failure"));
@@ -392,7 +384,7 @@ mod tests {
         let state = BindingScheduleState {
             last_attempt_ms: Some(0),
             last_full_walk_ms: Some(899_999),
-            full_walk_in_progress: true,
+            continuation: MirrorContinuation::Full,
             ..Default::default()
         };
         assert_eq!(decide_schedule(900_000, &config(), state, false), ScheduleDecision::Full);
@@ -404,7 +396,7 @@ mod tests {
             last_attempt_ms: Some(0),
             last_successful_probe_ms: Some(899_999),
             last_full_walk_ms: Some(899_999),
-            mirror_work_in_progress: true,
+            continuation: MirrorContinuation::Incremental,
             ..Default::default()
         };
         assert_eq!(
@@ -426,9 +418,8 @@ mod tests {
         )
         .unwrap();
         let repo_id = schema::active_repo_id(&conn).unwrap();
-        let (state, _, _, fingerprint) =
-            load_persisted_health(&conn, &repo_id, Tracker::Github, "o/r").unwrap();
-        assert!(state.mirror_work_in_progress);
+        let (state, _, _, fingerprint) = load_persisted_health(&conn, &repo_id, &binding).unwrap();
+        assert_eq!(state.continuation, MirrorContinuation::Incremental);
         assert_eq!(fingerprint, "old");
     }
 

--- a/crates/rag-rat-core/src/index/papertrail/schedule.rs
+++ b/crates/rag-rat-core/src/index/papertrail/schedule.rs
@@ -18,6 +18,7 @@ pub(crate) struct BindingScheduleState {
     pub last_successful_probe_ms: Option<i64>,
     pub last_successful_mirror_ms: Option<i64>,
     pub last_full_walk_ms: Option<i64>,
+    pub retry_not_before_ms: Option<i64>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
@@ -65,6 +66,9 @@ pub(crate) fn decide_schedule(
     let elapsed = |then: Option<i64>, interval_secs: u64| {
         then.is_none_or(|then| now_ms.saturating_sub(then) >= millis(interval_secs))
     };
+    if state.retry_not_before_ms.is_some_and(|resume_at_ms| now_ms < resume_at_ms) {
+        return ScheduleDecision::Skip;
+    }
     if !elapsed(state.last_attempt_ms, config.sync_min_interval_secs) {
         return ScheduleDecision::Skip;
     }
@@ -110,15 +114,26 @@ pub(crate) fn record_success(
     ensure_health_row(conn, binding)?;
     let assignment = match operation {
         SuccessfulOperation::Probe => "last_successful_probe_ms=?4",
-        SuccessfulOperation::IncrementalMirror => "last_successful_mirror_ms=?4",
-        SuccessfulOperation::FullMirror => "last_successful_mirror_ms=?4, last_full_sync_ms=?4",
+        SuccessfulOperation::IncrementalMirror =>
+            "last_successful_probe_ms=?4, last_successful_mirror_ms=?4",
+        SuccessfulOperation::FullMirror =>
+            "last_successful_probe_ms=?4, last_successful_mirror_ms=?4, last_full_sync_ms=?4",
     };
     update_health(
         conn,
         binding,
-        &format!("{assignment}, error_class=NULL, error_detail=NULL"),
+        &format!("{assignment}, retry_not_before_ms=NULL, error_class=NULL, error_detail=NULL"),
         at_ms,
     )
+}
+
+pub(crate) fn record_pause(
+    conn: &Connection,
+    binding: &ResolvedTracker,
+    resume_at_ms: i64,
+) -> anyhow::Result<()> {
+    ensure_health_row(conn, binding)?;
+    update_health(conn, binding, "retry_not_before_ms=?4", resume_at_ms)
 }
 
 pub(crate) fn record_failure(
@@ -186,21 +201,22 @@ pub(crate) fn load_persisted_health(
     Ok(conn
         .query_row(
             "SELECT last_attempt_ms, last_successful_probe_ms, last_successful_mirror_ms,
-                    last_full_sync_ms, error_class, error_detail
+                    last_full_sync_ms, retry_not_before_ms, error_class, error_detail
              FROM papertrail_sync_cursor
              WHERE repo_id=?1 AND tracker=?2 AND project=?3",
             params![repo_id, tracker.as_db_str(), project],
             |row| {
-                let error: Option<String> = row.get(4)?;
+                let error: Option<String> = row.get(5)?;
                 Ok((
                     BindingScheduleState {
                         last_attempt_ms: row.get(0)?,
                         last_successful_probe_ms: row.get(1)?,
                         last_successful_mirror_ms: row.get(2)?,
                         last_full_walk_ms: row.get(3)?,
+                        retry_not_before_ms: row.get(4)?,
                     },
                     error.as_deref().and_then(PapertrailErrorClass::from_db_str),
-                    row.get(5)?,
+                    row.get(6)?,
                 ))
             },
         )
@@ -211,9 +227,22 @@ pub(crate) fn load_persisted_health(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::index::papertrail::TrackerAuthentication;
+    use crate::index::schema;
 
     fn config() -> PapertrailConfig {
         PapertrailConfig::default()
+    }
+
+    fn binding() -> ResolvedTracker {
+        ResolvedTracker {
+            provider: Tracker::Github,
+            project: "o/r".to_string(),
+            base_url: None,
+            auth: None,
+            authentication: TrackerAuthentication::AuthMissing,
+            tags: Vec::new(),
+        }
     }
 
     #[test]
@@ -249,6 +278,44 @@ mod tests {
         };
         assert_eq!(decide_schedule(900_000, &config(), state, false), ScheduleDecision::Probe);
         assert_eq!(decide_schedule(900_000, &config(), state, true), ScheduleDecision::Incremental);
+    }
+
+    #[test]
+    fn persisted_provider_pause_gates_all_work_until_resume_time() {
+        let state = BindingScheduleState {
+            last_attempt_ms: Some(0),
+            retry_not_before_ms: Some(10_000),
+            ..Default::default()
+        };
+        assert_eq!(decide_schedule(9_999, &config(), state, true), ScheduleDecision::Skip);
+        assert_eq!(decide_schedule(900_000, &config(), state, true), ScheduleDecision::Full);
+    }
+
+    #[test]
+    fn mirror_success_advances_probe_freshness_and_clears_pause() {
+        let conn = Connection::open_in_memory().unwrap();
+        schema::apply(&conn).unwrap();
+        let binding = binding();
+        record_pause(&conn, &binding, 20_000).unwrap();
+        record_success(&conn, &binding, SuccessfulOperation::IncrementalMirror, 10_000).unwrap();
+        let repo_id = schema::active_repo_id(&conn).unwrap();
+        let (state, error, _) =
+            load_persisted_health(&conn, &repo_id, Tracker::Github, "o/r").unwrap();
+        assert_eq!(state.last_successful_probe_ms, Some(10_000));
+        assert_eq!(state.last_successful_mirror_ms, Some(10_000));
+        assert_eq!(state.retry_not_before_ms, None);
+        assert_eq!(error, None);
+    }
+
+    #[test]
+    fn provider_pause_round_trips_through_binding_health() {
+        let conn = Connection::open_in_memory().unwrap();
+        schema::apply(&conn).unwrap();
+        let binding = binding();
+        record_pause(&conn, &binding, 20_000).unwrap();
+        let repo_id = schema::active_repo_id(&conn).unwrap();
+        let (state, _, _) = load_persisted_health(&conn, &repo_id, Tracker::Github, "o/r").unwrap();
+        assert_eq!(state.retry_not_before_ms, Some(20_000));
     }
 
     #[test]

--- a/crates/rag-rat-core/src/index/papertrail/schedule.rs
+++ b/crates/rag-rat-core/src/index/papertrail/schedule.rs
@@ -65,11 +65,11 @@ pub(crate) fn decide_schedule(
     let elapsed = |then: Option<i64>, interval_secs: u64| {
         then.is_none_or(|then| now_ms.saturating_sub(then) >= millis(interval_secs))
     };
-    if elapsed(state.last_full_walk_ms, config.full_sync_interval_secs) {
-        return ScheduleDecision::Full;
-    }
     if !elapsed(state.last_attempt_ms, config.sync_min_interval_secs) {
         return ScheduleDecision::Skip;
+    }
+    if elapsed(state.last_full_walk_ms, config.full_sync_interval_secs) {
+        return ScheduleDecision::Full;
     }
     if change_detected {
         return ScheduleDecision::Incremental;
@@ -230,6 +230,13 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(decide_schedule(20_000, &config(), state, true), ScheduleDecision::Skip);
+    }
+
+    #[test]
+    fn minimum_interval_suppresses_failed_initial_full_retry() {
+        let state = BindingScheduleState { last_attempt_ms: Some(10_000), ..Default::default() };
+        assert_eq!(decide_schedule(20_000, &config(), state, false), ScheduleDecision::Skip);
+        assert_eq!(decide_schedule(910_000, &config(), state, false), ScheduleDecision::Full);
     }
 
     #[test]

--- a/crates/rag-rat-core/src/index/papertrail/schedule.rs
+++ b/crates/rag-rat-core/src/index/papertrail/schedule.rs
@@ -161,7 +161,8 @@ pub(crate) fn record_failure(
     let detail = detail.map(sanitize_error_detail);
     let repo_id = crate::index::schema::active_repo_id(conn)?;
     conn.execute(
-        "UPDATE papertrail_sync_cursor SET error_class=?4, error_detail=?5
+        "UPDATE papertrail_sync_cursor
+         SET retry_not_before_ms=NULL, error_class=?4, error_detail=?5
          WHERE repo_id=?1 AND tracker=?2 AND project=?3",
         params![repo_id, binding.provider.as_db_str(), binding.project, class.as_db_str(), detail,],
     )?;
@@ -363,6 +364,27 @@ mod tests {
             load_persisted_health(&conn, &repo_id, Tracker::Github, "o/r").unwrap();
         assert_eq!(error, Some(PapertrailErrorClass::RateLimited));
         assert_eq!(detail, None);
+    }
+
+    #[test]
+    fn non_rate_failure_clears_a_stale_provider_pause() {
+        let conn = Connection::open_in_memory().unwrap();
+        schema::apply(&conn).unwrap();
+        let binding = binding();
+        record_pause(&conn, &binding, 20_000).unwrap();
+        record_failure(
+            &conn,
+            &binding,
+            PapertrailErrorClass::Authentication,
+            Some("new auth failure"),
+        )
+        .unwrap();
+        let repo_id = schema::active_repo_id(&conn).unwrap();
+        let (state, error, detail, _) =
+            load_persisted_health(&conn, &repo_id, Tracker::Github, "o/r").unwrap();
+        assert_eq!(state.retry_not_before_ms, None);
+        assert_eq!(error, Some(PapertrailErrorClass::Authentication));
+        assert_eq!(detail.as_deref(), Some("new auth failure"));
     }
 
     #[test]

--- a/crates/rag-rat-core/src/index/papertrail/schedule.rs
+++ b/crates/rag-rat-core/src/index/papertrail/schedule.rs
@@ -19,6 +19,7 @@ pub(crate) struct BindingScheduleState {
     pub last_successful_mirror_ms: Option<i64>,
     pub last_full_walk_ms: Option<i64>,
     pub retry_not_before_ms: Option<i64>,
+    pub full_walk_in_progress: bool,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
@@ -71,6 +72,9 @@ pub(crate) fn decide_schedule(
     }
     if !elapsed(state.last_attempt_ms, config.sync_min_interval_secs) {
         return ScheduleDecision::Skip;
+    }
+    if state.full_walk_in_progress {
+        return ScheduleDecision::Full;
     }
     if elapsed(state.last_full_walk_ms, config.full_sync_interval_secs) {
         return ScheduleDecision::Full;
@@ -133,7 +137,14 @@ pub(crate) fn record_pause(
     resume_at_ms: i64,
 ) -> anyhow::Result<()> {
     ensure_health_row(conn, binding)?;
-    update_health(conn, binding, "retry_not_before_ms=?4", resume_at_ms)
+    let repo_id = crate::index::schema::active_repo_id(conn)?;
+    conn.execute(
+        "UPDATE papertrail_sync_cursor
+         SET retry_not_before_ms=?4, error_class='rate_limited', error_detail=NULL
+         WHERE repo_id=?1 AND tracker=?2 AND project=?3",
+        params![repo_id, binding.provider.as_db_str(), binding.project, resume_at_ms],
+    )?;
+    Ok(())
 }
 
 pub(crate) fn record_failure(
@@ -201,12 +212,12 @@ pub(crate) fn load_persisted_health(
     Ok(conn
         .query_row(
             "SELECT last_attempt_ms, last_successful_probe_ms, last_successful_mirror_ms,
-                    last_full_sync_ms, retry_not_before_ms, error_class, error_detail
+                    last_full_sync_ms, retry_not_before_ms, full_rewalk, error_class, error_detail
              FROM papertrail_sync_cursor
              WHERE repo_id=?1 AND tracker=?2 AND project=?3",
             params![repo_id, tracker.as_db_str(), project],
             |row| {
-                let error: Option<String> = row.get(5)?;
+                let error: Option<String> = row.get(6)?;
                 Ok((
                     BindingScheduleState {
                         last_attempt_ms: row.get(0)?,
@@ -214,9 +225,10 @@ pub(crate) fn load_persisted_health(
                         last_successful_mirror_ms: row.get(2)?,
                         last_full_walk_ms: row.get(3)?,
                         retry_not_before_ms: row.get(4)?,
+                        full_walk_in_progress: row.get(5)?,
                     },
                     error.as_deref().and_then(PapertrailErrorClass::from_db_str),
-                    row.get(6)?,
+                    row.get(7)?,
                 ))
             },
         )
@@ -314,8 +326,42 @@ mod tests {
         let binding = binding();
         record_pause(&conn, &binding, 20_000).unwrap();
         let repo_id = schema::active_repo_id(&conn).unwrap();
-        let (state, _, _) = load_persisted_health(&conn, &repo_id, Tracker::Github, "o/r").unwrap();
+        let (state, error, detail) =
+            load_persisted_health(&conn, &repo_id, Tracker::Github, "o/r").unwrap();
         assert_eq!(state.retry_not_before_ms, Some(20_000));
+        assert_eq!(error, Some(PapertrailErrorClass::RateLimited));
+        assert_eq!(detail, None);
+    }
+
+    #[test]
+    fn provider_pause_replaces_a_stale_failure() {
+        let conn = Connection::open_in_memory().unwrap();
+        schema::apply(&conn).unwrap();
+        let binding = binding();
+        record_failure(
+            &conn,
+            &binding,
+            PapertrailErrorClass::Authentication,
+            Some("old auth failure"),
+        )
+        .unwrap();
+        record_pause(&conn, &binding, 20_000).unwrap();
+        let repo_id = schema::active_repo_id(&conn).unwrap();
+        let (_, error, detail) =
+            load_persisted_health(&conn, &repo_id, Tracker::Github, "o/r").unwrap();
+        assert_eq!(error, Some(PapertrailErrorClass::RateLimited));
+        assert_eq!(detail, None);
+    }
+
+    #[test]
+    fn interrupted_full_walk_resumes_after_retry_gates_open() {
+        let state = BindingScheduleState {
+            last_attempt_ms: Some(0),
+            last_full_walk_ms: Some(899_999),
+            full_walk_in_progress: true,
+            ..Default::default()
+        };
+        assert_eq!(decide_schedule(900_000, &config(), state, false), ScheduleDecision::Full);
     }
 
     #[test]

--- a/crates/rag-rat-core/src/index/papertrail/schedule.rs
+++ b/crates/rag-rat-core/src/index/papertrail/schedule.rs
@@ -20,6 +20,7 @@ pub(crate) struct BindingScheduleState {
     pub last_full_walk_ms: Option<i64>,
     pub retry_not_before_ms: Option<i64>,
     pub full_walk_in_progress: bool,
+    pub mirror_work_in_progress: bool,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
@@ -75,6 +76,9 @@ pub(crate) fn decide_schedule(
     }
     if state.full_walk_in_progress {
         return ScheduleDecision::Full;
+    }
+    if state.mirror_work_in_progress {
+        return ScheduleDecision::Incremental;
     }
     if elapsed(state.last_full_walk_ms, config.full_sync_interval_secs) {
         return ScheduleDecision::Full;
@@ -201,7 +205,7 @@ fn sanitize_error_detail(detail: &str) -> String {
 }
 
 pub(crate) type PersistedHealth =
-    (BindingScheduleState, Option<PapertrailErrorClass>, Option<String>);
+    (BindingScheduleState, Option<PapertrailErrorClass>, Option<String>, String);
 
 pub(crate) fn load_persisted_health(
     conn: &Connection,
@@ -212,12 +216,18 @@ pub(crate) fn load_persisted_health(
     Ok(conn
         .query_row(
             "SELECT last_attempt_ms, last_successful_probe_ms, last_successful_mirror_ms,
-                    last_full_sync_ms, retry_not_before_ms, full_rewalk, error_class, error_detail
+                    last_full_sync_ms, retry_not_before_ms, full_rewalk,
+                    backfill_done = 0 OR item_delta_in_progress = 1
+                        OR item_delta_page_token IS NOT NULL
+                        OR backfill_page_cursor IS NOT NULL
+                        OR item_thread_cursor IS NOT NULL
+                        OR comment_page_token IS NOT NULL,
+                    error_class, error_detail, filter_fingerprint
              FROM papertrail_sync_cursor
              WHERE repo_id=?1 AND tracker=?2 AND project=?3",
             params![repo_id, tracker.as_db_str(), project],
             |row| {
-                let error: Option<String> = row.get(6)?;
+                let error: Option<String> = row.get(7)?;
                 Ok((
                     BindingScheduleState {
                         last_attempt_ms: row.get(0)?,
@@ -226,9 +236,11 @@ pub(crate) fn load_persisted_health(
                         last_full_walk_ms: row.get(3)?,
                         retry_not_before_ms: row.get(4)?,
                         full_walk_in_progress: row.get(5)?,
+                        mirror_work_in_progress: row.get(6)?,
                     },
                     error.as_deref().and_then(PapertrailErrorClass::from_db_str),
-                    row.get(7)?,
+                    row.get(8)?,
+                    row.get::<_, Option<String>>(9)?.unwrap_or_default(),
                 ))
             },
         )
@@ -311,7 +323,7 @@ mod tests {
         record_pause(&conn, &binding, 20_000).unwrap();
         record_success(&conn, &binding, SuccessfulOperation::IncrementalMirror, 10_000).unwrap();
         let repo_id = schema::active_repo_id(&conn).unwrap();
-        let (state, error, _) =
+        let (state, error, _, _) =
             load_persisted_health(&conn, &repo_id, Tracker::Github, "o/r").unwrap();
         assert_eq!(state.last_successful_probe_ms, Some(10_000));
         assert_eq!(state.last_successful_mirror_ms, Some(10_000));
@@ -326,7 +338,7 @@ mod tests {
         let binding = binding();
         record_pause(&conn, &binding, 20_000).unwrap();
         let repo_id = schema::active_repo_id(&conn).unwrap();
-        let (state, error, detail) =
+        let (state, error, detail, _) =
             load_persisted_health(&conn, &repo_id, Tracker::Github, "o/r").unwrap();
         assert_eq!(state.retry_not_before_ms, Some(20_000));
         assert_eq!(error, Some(PapertrailErrorClass::RateLimited));
@@ -347,7 +359,7 @@ mod tests {
         .unwrap();
         record_pause(&conn, &binding, 20_000).unwrap();
         let repo_id = schema::active_repo_id(&conn).unwrap();
-        let (_, error, detail) =
+        let (_, error, detail, _) =
             load_persisted_health(&conn, &repo_id, Tracker::Github, "o/r").unwrap();
         assert_eq!(error, Some(PapertrailErrorClass::RateLimited));
         assert_eq!(detail, None);
@@ -362,6 +374,40 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(decide_schedule(900_000, &config(), state, false), ScheduleDecision::Full);
+    }
+
+    #[test]
+    fn interrupted_incremental_work_resumes_before_a_fresh_probe() {
+        let state = BindingScheduleState {
+            last_attempt_ms: Some(0),
+            last_successful_probe_ms: Some(899_999),
+            last_full_walk_ms: Some(899_999),
+            mirror_work_in_progress: true,
+            ..Default::default()
+        };
+        assert_eq!(
+            decide_schedule(900_000, &config(), state, false),
+            ScheduleDecision::Incremental
+        );
+    }
+
+    #[test]
+    fn persisted_cursor_work_and_filter_fingerprint_are_loaded_for_scheduling() {
+        let conn = Connection::open_in_memory().unwrap();
+        schema::apply(&conn).unwrap();
+        let binding = binding();
+        record_attempt(&conn, &binding, 1).unwrap();
+        conn.execute(
+            "UPDATE papertrail_sync_cursor
+             SET backfill_done=1, item_delta_in_progress=1, filter_fingerprint='old'",
+            [],
+        )
+        .unwrap();
+        let repo_id = schema::active_repo_id(&conn).unwrap();
+        let (state, _, _, fingerprint) =
+            load_persisted_health(&conn, &repo_id, Tracker::Github, "o/r").unwrap();
+        assert!(state.mirror_work_in_progress);
+        assert_eq!(fingerprint, "old");
     }
 
     #[test]

--- a/crates/rag-rat-core/src/index/schema/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema/migrations.rs
@@ -3327,7 +3327,7 @@ pub(crate) fn apply_papertrail_mirror_resume_state(conn: &Connection) -> rusqlit
     Ok(())
 }
 
-/// V066 (#592): scheduling and failures are binding-local. Error classes are stable machine
+/// V067 (#592): scheduling and failures are binding-local. Error classes are stable machine
 /// values; detail is sanitized and bounded by the recording API rather than used for policy.
 pub(crate) fn apply_papertrail_binding_health(conn: &Connection) -> rusqlite::Result<()> {
     add_column_if_missing(conn, "papertrail_sync_cursor", "last_attempt_ms", "INTEGER")?;
@@ -3349,6 +3349,14 @@ pub(crate) fn apply_papertrail_binding_health(conn: &Connection) -> rusqlite::Re
         "UPDATE papertrail_sync_cursor
          SET last_full_sync_ms=last_probe_ms
          WHERE backfill_done=1 AND last_full_sync_ms IS NULL AND last_probe_ms IS NOT NULL",
+        [],
+    )?;
+    conn.execute(
+        "UPDATE papertrail_sync_cursor
+         SET last_successful_mirror_ms=last_probe_ms
+         WHERE backfill_done=1
+           AND last_successful_mirror_ms IS NULL
+           AND last_probe_ms IS NOT NULL",
         [],
     )?;
     Ok(())

--- a/crates/rag-rat-core/src/index/schema/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema/migrations.rs
@@ -3327,7 +3327,7 @@ pub(crate) fn apply_papertrail_mirror_resume_state(conn: &Connection) -> rusqlit
     Ok(())
 }
 
-/// V065 (#592): scheduling and failures are binding-local. Error classes are stable machine
+/// V066 (#592): scheduling and failures are binding-local. Error classes are stable machine
 /// values; detail is sanitized and bounded by the recording API rather than used for policy.
 pub(crate) fn apply_papertrail_binding_health(conn: &Connection) -> rusqlite::Result<()> {
     add_column_if_missing(conn, "papertrail_sync_cursor", "last_attempt_ms", "INTEGER")?;

--- a/crates/rag-rat-core/src/index/schema/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema/migrations.rs
@@ -3327,7 +3327,7 @@ pub(crate) fn apply_papertrail_mirror_resume_state(conn: &Connection) -> rusqlit
     Ok(())
 }
 
-/// V064 (#592): scheduling and failures are binding-local. Error classes are stable machine
+/// V065 (#592): scheduling and failures are binding-local. Error classes are stable machine
 /// values; detail is sanitized and bounded by the recording API rather than used for policy.
 pub(crate) fn apply_papertrail_binding_health(conn: &Connection) -> rusqlite::Result<()> {
     add_column_if_missing(conn, "papertrail_sync_cursor", "last_attempt_ms", "INTEGER")?;

--- a/crates/rag-rat-core/src/index/schema/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema/migrations.rs
@@ -3333,6 +3333,7 @@ pub(crate) fn apply_papertrail_binding_health(conn: &Connection) -> rusqlite::Re
     add_column_if_missing(conn, "papertrail_sync_cursor", "last_attempt_ms", "INTEGER")?;
     add_column_if_missing(conn, "papertrail_sync_cursor", "last_successful_probe_ms", "INTEGER")?;
     add_column_if_missing(conn, "papertrail_sync_cursor", "last_successful_mirror_ms", "INTEGER")?;
+    add_column_if_missing(conn, "papertrail_sync_cursor", "retry_not_before_ms", "INTEGER")?;
     add_column_if_missing(conn, "papertrail_sync_cursor", "error_class", "TEXT")?;
     add_column_if_missing(conn, "papertrail_sync_cursor", "error_detail", "TEXT")?;
     Ok(())

--- a/crates/rag-rat-core/src/index/schema/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema/migrations.rs
@@ -1261,6 +1261,7 @@ pub(crate) fn known_version(migrations: &[AppliedMigration]) -> u32 {
             MIGRATION_064_ID => Some(64),
             MIGRATION_065_ID => Some(65),
             MIGRATION_066_ID => Some(66),
+            MIGRATION_067_ID => Some(67),
             _ => None,
         })
         .max()
@@ -1336,6 +1337,7 @@ pub(crate) fn known_migration(id: &str) -> bool {
             | MIGRATION_064_ID
             | MIGRATION_065_ID
             | MIGRATION_066_ID
+            | MIGRATION_067_ID
             | DIRTY_MIGRATION_ID
     )
 }
@@ -1408,6 +1410,7 @@ pub(crate) fn migration_checksum_mismatch(migration: &AppliedMigration) -> bool 
         MIGRATION_064_ID => migration.checksum != MIGRATION_064_CHECKSUM,
         MIGRATION_065_ID => migration.checksum != MIGRATION_065_CHECKSUM,
         MIGRATION_066_ID => migration.checksum != MIGRATION_066_CHECKSUM,
+        MIGRATION_067_ID => migration.checksum != MIGRATION_067_CHECKSUM,
         _ => false,
     }
 }
@@ -3321,6 +3324,17 @@ pub(crate) fn apply_papertrail_mirror_resume_state(conn: &Connection) -> rusqlit
         "full_rewalk_seen",
         "INTEGER NOT NULL DEFAULT 0",
     )?;
+    Ok(())
+}
+
+/// V064 (#592): scheduling and failures are binding-local. Error classes are stable machine
+/// values; detail is sanitized and bounded by the recording API rather than used for policy.
+pub(crate) fn apply_papertrail_binding_health(conn: &Connection) -> rusqlite::Result<()> {
+    add_column_if_missing(conn, "papertrail_sync_cursor", "last_attempt_ms", "INTEGER")?;
+    add_column_if_missing(conn, "papertrail_sync_cursor", "last_successful_probe_ms", "INTEGER")?;
+    add_column_if_missing(conn, "papertrail_sync_cursor", "last_successful_mirror_ms", "INTEGER")?;
+    add_column_if_missing(conn, "papertrail_sync_cursor", "error_class", "TEXT")?;
+    add_column_if_missing(conn, "papertrail_sync_cursor", "error_detail", "TEXT")?;
     Ok(())
 }
 

--- a/crates/rag-rat-core/src/index/schema/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema/migrations.rs
@@ -3342,6 +3342,15 @@ pub(crate) fn apply_papertrail_binding_health(conn: &Connection) -> rusqlite::Re
          WHERE last_successful_probe_ms IS NULL AND last_probe_ms IS NOT NULL",
         [],
     )?;
+    // Before V066, an ordinary initial backfill was a complete project walk but only forced
+    // `--full` runs populated `last_full_sync_ms`. Preserve that completed-walk fact using the
+    // cursor's last successful provider contact; incomplete cursors must remain due for healing.
+    conn.execute(
+        "UPDATE papertrail_sync_cursor
+         SET last_full_sync_ms=last_probe_ms
+         WHERE backfill_done=1 AND last_full_sync_ms IS NULL AND last_probe_ms IS NOT NULL",
+        [],
+    )?;
     Ok(())
 }
 

--- a/crates/rag-rat-core/src/index/schema/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema/migrations.rs
@@ -3336,6 +3336,12 @@ pub(crate) fn apply_papertrail_binding_health(conn: &Connection) -> rusqlite::Re
     add_column_if_missing(conn, "papertrail_sync_cursor", "retry_not_before_ms", "INTEGER")?;
     add_column_if_missing(conn, "papertrail_sync_cursor", "error_class", "TEXT")?;
     add_column_if_missing(conn, "papertrail_sync_cursor", "error_detail", "TEXT")?;
+    conn.execute(
+        "UPDATE papertrail_sync_cursor
+         SET last_successful_probe_ms=last_probe_ms
+         WHERE last_successful_probe_ms IS NULL AND last_probe_ms IS NOT NULL",
+        [],
+    )?;
     Ok(())
 }
 

--- a/crates/rag-rat-core/src/index/schema/mod.rs
+++ b/crates/rag-rat-core/src/index/schema/mod.rs
@@ -463,7 +463,7 @@ const MIGRATION_066_DESCRIPTION: &str =
     "Persist every structurally valid /3 content candidate, bounded pre-verification work, and \
      derived status while reserving accepted-slot uniqueness for C3 authority acceptance";
 const MIGRATION_067_ID: &str = "067_papertrail_binding_health";
-const MIGRATION_067_CHECKSUM: &str = "sha256:rag-rat-papertrail-binding-health-v67d";
+const MIGRATION_067_CHECKSUM: &str = "sha256:rag-rat-papertrail-binding-health-v67e";
 const MIGRATION_067_DESCRIPTION: &str = "Persist per-binding attempt, successful probe/mirror, \
                                          and closed failure state for automatic scheduling and \
                                          status";

--- a/crates/rag-rat-core/src/index/schema/mod.rs
+++ b/crates/rag-rat-core/src/index/schema/mod.rs
@@ -463,7 +463,7 @@ const MIGRATION_066_DESCRIPTION: &str =
     "Persist every structurally valid /3 content candidate, bounded pre-verification work, and \
      derived status while reserving accepted-slot uniqueness for C3 authority acceptance";
 const MIGRATION_067_ID: &str = "067_papertrail_binding_health";
-const MIGRATION_067_CHECKSUM: &str = "sha256:rag-rat-papertrail-binding-health-v67c";
+const MIGRATION_067_CHECKSUM: &str = "sha256:rag-rat-papertrail-binding-health-v67d";
 const MIGRATION_067_DESCRIPTION: &str = "Persist per-binding attempt, successful probe/mirror, \
                                          and closed failure state for automatic scheduling and \
                                          status";

--- a/crates/rag-rat-core/src/index/schema/mod.rs
+++ b/crates/rag-rat-core/src/index/schema/mod.rs
@@ -463,7 +463,7 @@ const MIGRATION_066_DESCRIPTION: &str =
     "Persist every structurally valid /3 content candidate, bounded pre-verification work, and \
      derived status while reserving accepted-slot uniqueness for C3 authority acceptance";
 const MIGRATION_067_ID: &str = "067_papertrail_binding_health";
-const MIGRATION_067_CHECKSUM: &str = "sha256:rag-rat-papertrail-binding-health-v67";
+const MIGRATION_067_CHECKSUM: &str = "sha256:rag-rat-papertrail-binding-health-v67b";
 const MIGRATION_067_DESCRIPTION: &str = "Persist per-binding attempt, successful probe/mirror, \
                                          and closed failure state for automatic scheduling and \
                                          status";

--- a/crates/rag-rat-core/src/index/schema/mod.rs
+++ b/crates/rag-rat-core/src/index/schema/mod.rs
@@ -19,7 +19,7 @@ pub use registry::{LEGACY_REPO_ID, RegisteredRepo, register_repo, register_repo_
 use rusqlite::{Connection, OptionalExtension, Transaction, TransactionBehavior, params};
 use serde::Serialize;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 66;
+pub const LATEST_SCHEMA_VERSION: u32 = 67;
 
 /// Every oracle-DERIVED persisted table — the outputs an `oracle run` writes that must OUTLIVE a
 /// reindex.
@@ -462,6 +462,11 @@ const MIGRATION_066_CHECKSUM: &str = "sha256:rag-rat-content-candidate-dag-v66a"
 const MIGRATION_066_DESCRIPTION: &str =
     "Persist every structurally valid /3 content candidate, bounded pre-verification work, and \
      derived status while reserving accepted-slot uniqueness for C3 authority acceptance";
+const MIGRATION_067_ID: &str = "067_papertrail_binding_health";
+const MIGRATION_067_CHECKSUM: &str = "sha256:rag-rat-papertrail-binding-health-v67";
+const MIGRATION_067_DESCRIPTION: &str = "Persist per-binding attempt, successful probe/mirror, \
+                                         and closed failure state for automatic scheduling and \
+                                         status";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -1019,6 +1024,12 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         checksum: MIGRATION_066_CHECKSUM,
         description: MIGRATION_066_DESCRIPTION,
         apply: apply_content_candidate_dag,
+    },
+    Migration {
+        id: MIGRATION_067_ID,
+        checksum: MIGRATION_067_CHECKSUM,
+        description: MIGRATION_067_DESCRIPTION,
+        apply: apply_papertrail_binding_health,
     },
 ];
 

--- a/crates/rag-rat-core/src/index/schema/mod.rs
+++ b/crates/rag-rat-core/src/index/schema/mod.rs
@@ -463,7 +463,7 @@ const MIGRATION_066_DESCRIPTION: &str =
     "Persist every structurally valid /3 content candidate, bounded pre-verification work, and \
      derived status while reserving accepted-slot uniqueness for C3 authority acceptance";
 const MIGRATION_067_ID: &str = "067_papertrail_binding_health";
-const MIGRATION_067_CHECKSUM: &str = "sha256:rag-rat-papertrail-binding-health-v67b";
+const MIGRATION_067_CHECKSUM: &str = "sha256:rag-rat-papertrail-binding-health-v67c";
 const MIGRATION_067_DESCRIPTION: &str = "Persist per-binding attempt, successful probe/mirror, \
                                          and closed failure state for automatic scheduling and \
                                          status";

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/papertrail_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/papertrail_tests.rs
@@ -666,6 +666,7 @@ fn migration_064_is_the_tip_and_persists_binding_health() {
         "last_attempt_ms",
         "last_successful_probe_ms",
         "last_successful_mirror_ms",
+        "retry_not_before_ms",
         "error_class",
         "error_detail",
     ] {

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/papertrail_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/papertrail_tests.rs
@@ -672,6 +672,21 @@ fn migration_064_is_the_tip_and_persists_binding_health() {
     ] {
         assert!(columns.contains(&name.to_string()), "missing {name}");
     }
+    conn.execute(
+        "INSERT INTO papertrail_sync_cursor(tracker, project, last_probe_ms, repo_id)
+         VALUES ('github', 'o/r', 1234, '__unassigned__')",
+        [],
+    )
+    .unwrap();
+    schema::apply_papertrail_binding_health(&conn).unwrap();
+    let probe: Option<i64> = conn
+        .query_row(
+            "SELECT last_successful_probe_ms FROM papertrail_sync_cursor WHERE project='o/r'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(probe, Some(1234));
 }
 
 #[test]

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/papertrail_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/papertrail_tests.rs
@@ -657,6 +657,23 @@ fn migration_063_persists_mirror_resume_state() {
 }
 
 #[test]
+fn migration_064_is_the_tip_and_persists_binding_health() {
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 64, "move this pin with the next schema migration");
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn).unwrap();
+    let columns = conn_table_columns(&conn, "papertrail_sync_cursor");
+    for name in [
+        "last_attempt_ms",
+        "last_successful_probe_ms",
+        "last_successful_mirror_ms",
+        "error_class",
+        "error_detail",
+    ] {
+        assert!(columns.contains(&name.to_string()), "missing {name}");
+    }
+}
+
+#[test]
 fn migration_063_checksum_replays_the_pre_replay_flag_shape() {
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     schema::apply(&conn).unwrap();

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/papertrail_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/papertrail_tests.rs
@@ -657,8 +657,8 @@ fn migration_063_persists_mirror_resume_state() {
 }
 
 #[test]
-fn migration_066_is_the_tip_and_persists_binding_health() {
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 66, "move this pin with the next schema migration");
+fn migration_067_is_the_tip_and_persists_binding_health() {
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 67, "move this pin with the next schema migration");
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     schema::apply(&conn).unwrap();
     let columns = conn_table_columns(&conn, "papertrail_sync_cursor");
@@ -681,15 +681,16 @@ fn migration_066_is_the_tip_and_persists_binding_health() {
     )
     .unwrap();
     schema::apply_papertrail_binding_health(&conn).unwrap();
-    let (probe, full): (Option<i64>, Option<i64>) = conn
+    let (probe, mirror, full): (Option<i64>, Option<i64>, Option<i64>) = conn
         .query_row(
-            "SELECT last_successful_probe_ms, last_full_sync_ms
+            "SELECT last_successful_probe_ms, last_successful_mirror_ms, last_full_sync_ms
              FROM papertrail_sync_cursor WHERE project='o/complete'",
             [],
-            |row| Ok((row.get(0)?, row.get(1)?)),
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
         )
         .unwrap();
     assert_eq!(probe, Some(1234));
+    assert_eq!(mirror, Some(1234));
     assert_eq!(full, Some(1234));
     let incomplete_full: Option<i64> = conn
         .query_row(

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/papertrail_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/papertrail_tests.rs
@@ -657,8 +657,8 @@ fn migration_063_persists_mirror_resume_state() {
 }
 
 #[test]
-fn migration_064_is_the_tip_and_persists_binding_health() {
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 64, "move this pin with the next schema migration");
+fn migration_065_is_the_tip_and_persists_binding_health() {
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 65, "move this pin with the next schema migration");
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     schema::apply(&conn).unwrap();
     let columns = conn_table_columns(&conn, "papertrail_sync_cursor");

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/papertrail_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/papertrail_tests.rs
@@ -673,20 +673,32 @@ fn migration_066_is_the_tip_and_persists_binding_health() {
         assert!(columns.contains(&name.to_string()), "missing {name}");
     }
     conn.execute(
-        "INSERT INTO papertrail_sync_cursor(tracker, project, last_probe_ms, repo_id)
-         VALUES ('github', 'o/r', 1234, '__unassigned__')",
+        "INSERT INTO papertrail_sync_cursor(
+             tracker, project, last_probe_ms, backfill_done, repo_id
+         ) VALUES ('github', 'o/complete', 1234, 1, '__unassigned__'),
+                  ('github', 'o/incomplete', 5678, 0, '__unassigned__')",
         [],
     )
     .unwrap();
     schema::apply_papertrail_binding_health(&conn).unwrap();
-    let probe: Option<i64> = conn
+    let (probe, full): (Option<i64>, Option<i64>) = conn
         .query_row(
-            "SELECT last_successful_probe_ms FROM papertrail_sync_cursor WHERE project='o/r'",
+            "SELECT last_successful_probe_ms, last_full_sync_ms
+             FROM papertrail_sync_cursor WHERE project='o/complete'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(probe, Some(1234));
+    assert_eq!(full, Some(1234));
+    let incomplete_full: Option<i64> = conn
+        .query_row(
+            "SELECT last_full_sync_ms FROM papertrail_sync_cursor WHERE project='o/incomplete'",
             [],
             |row| row.get(0),
         )
         .unwrap();
-    assert_eq!(probe, Some(1234));
+    assert_eq!(incomplete_full, None);
 }
 
 #[test]

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/papertrail_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/papertrail_tests.rs
@@ -657,8 +657,8 @@ fn migration_063_persists_mirror_resume_state() {
 }
 
 #[test]
-fn migration_065_is_the_tip_and_persists_binding_health() {
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 65, "move this pin with the next schema migration");
+fn migration_066_is_the_tip_and_persists_binding_health() {
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 66, "move this pin with the next schema migration");
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     schema::apply(&conn).unwrap();
     let columns = conn_table_columns(&conn, "papertrail_sync_cursor");

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
@@ -2011,7 +2011,7 @@ fn migration_066_adds_the_content_candidate_dag() {
     assert!(conn_index_exists(&conn, "content_accepted_slot"));
     assert!(conn_index_exists(&conn, "content_pre_verify_author"));
     schema::migrate_forward(&conn).expect("a second V066 forward migration is a no-op");
-    assert_eq!(schema::status(&conn).unwrap().current_version, 66);
+    assert_eq!(schema::status(&conn).unwrap().current_version, schema::LATEST_SCHEMA_VERSION);
 }
 
 #[test]

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
@@ -1918,7 +1918,7 @@ fn migration_064_creates_account_authority_shadow_tables() {
 }
 
 #[test]
-fn migration_065_is_the_tip_and_adds_historical_authority_boundaries() {
+fn migration_065_adds_historical_authority_boundaries() {
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     schema::apply(&conn).unwrap();
     assert!(conn_table_exists(&conn, "account_roster_content_boundaries"));
@@ -1941,8 +1941,7 @@ fn migration_065_is_the_tip_and_adds_historical_authority_boundaries() {
 }
 
 #[test]
-fn migration_066_is_the_tip_and_adds_the_content_candidate_dag() {
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 66, "move this pin with the next schema migration");
+fn migration_066_adds_the_content_candidate_dag() {
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     schema::apply(&conn).unwrap();
     for table in ["content_entries", "content_entry_status", "content_pre_verify"] {

--- a/docs/config.md
+++ b/docs/config.md
@@ -621,6 +621,14 @@ The reserve defaults to 35% and can be changed independently of provider clients
 rate_limit_reserve = 0.35   # finite fraction in 0.0 <= value < 1.0
 ```
 
-Cadence keys (`probe_interval_secs`, `sync_min_interval_secs`, and `full_sync_interval_secs`) are
-reserved for the provider mirror scheduler and remain rejected until that production path
-consumes them.
+The provider mirror scheduler accepts three cadence keys. Decisions are per binding: attempts are
+coalesced by the minimum interval, lightweight probes run on the probe cadence, and a full walk
+periodically heals historical drift. Persisted rate-limit horizons and unfinished cursor work take
+priority over these ordinary cadences.
+
+```toml
+[papertrail]
+probe_interval_secs = 900       # default: 15 minutes
+sync_min_interval_secs = 900    # default: 15 minutes between attempts
+full_sync_interval_secs = 86400 # default: daily healing walk
+```


### PR DESCRIPTION
Closes the scheduling/persistence half of #592.

## What changed

- activates `probe_interval_secs`, `sync_min_interval_secs`, and `full_sync_interval_secs`
- adds an injected-time, per-binding policy with explicit `Skip`, `Probe`, `Incremental`, and `Full` decisions
- adds V064 binding-local health persistence for attempts, successful probes/mirrors/full walks, and closed failure classes with bounded sanitized detail
- records health around the existing provider-neutral manual mirror runner
- surfaces overdue and failed bindings through `papertrail_sync_status`

## Design boundary

This is the first of two PR-sized slices. Hook/watcher triggers, the single-in-flight coalescing worker, timer/backstop execution, and concurrent binding dispatch will stack on this PR.

No new network operation runs under the maintenance write lock. This slice only adds policy/persistence and instruments the existing mirror boundary.

## Validation

- `cargo test -p rag-rat-core index::papertrail::schedule::tests --lib --no-fail-fast`
- `cargo test -p rag-rat-core config::tests::papertrail_scheduling_intervals_are_parsed --lib`
- `cargo test -p rag-rat-core index::schema_bootstrap_tests::papertrail_tests::migration_064_is_the_tip_and_persists_binding_health --lib`
- `cargo clippy -p rag-rat-core --lib -- -D warnings`
- `cargo +nightly fmt --all`
- `git diff --check`