### PR TITLE
feat(account): finish C1 authority projection and query seams

### DIFF
--- a/crates/rag-rat-core/src/index/schema/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema/migrations.rs
@@ -1258,6 +1258,7 @@ pub(crate) fn known_version(migrations: &[AppliedMigration]) -> u32 {
             MIGRATION_061_ID => Some(61),
             MIGRATION_062_ID => Some(62),
             MIGRATION_063_ID => Some(63),
+            MIGRATION_064_ID => Some(64),
             _ => None,
         })
         .max()
@@ -1330,6 +1331,7 @@ pub(crate) fn known_migration(id: &str) -> bool {
             | MIGRATION_061_ID
             | MIGRATION_062_ID
             | MIGRATION_063_ID
+            | MIGRATION_064_ID
             | DIRTY_MIGRATION_ID
     )
 }
@@ -1399,6 +1401,7 @@ pub(crate) fn migration_checksum_mismatch(migration: &AppliedMigration) -> bool 
         MIGRATION_061_ID => migration.checksum != MIGRATION_061_CHECKSUM,
         MIGRATION_062_ID => migration.checksum != MIGRATION_062_CHECKSUM,
         MIGRATION_063_ID => migration.checksum != MIGRATION_063_CHECKSUM,
+        MIGRATION_064_ID => migration.checksum != MIGRATION_064_CHECKSUM,
         _ => false,
     }
 }
@@ -4353,6 +4356,80 @@ pub(crate) fn apply_account_candidate_dag(conn: &Connection) -> rusqlite::Result
          -- index it so a backlog for OTHER accounts is never full-scanned per ingest.
          CREATE INDEX IF NOT EXISTS account_pre_verify_account
              ON account_pre_verify(claimed_account_id);",
+    )
+}
+
+/// V064 (sync phase C1, §16): query-ready authority facts derived from the accepted account fold.
+/// These are shadow tables, never independent sources of truth: `refold_account` deletes and
+/// rewrites every row for one account inside the SAME IMMEDIATE transaction as accepted/status.
+/// History intervals (`effective_at`, `closed_at`) preserve audit/projection facts. `auth_len` is
+/// only a synchronization assertion: ahead parks for refetch, while behind is informational and
+/// never selects historical authority. Exact citations and device cuts make authorization keyed
+/// lookups instead of adversary-amplified replay of up to 4096 candidates.
+pub(crate) fn apply_account_authority_projection(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS account_auth_state(
+             account_id        BLOB PRIMARY KEY,
+             classification    TEXT NOT NULL,
+             contested_depth   INTEGER,
+             successor_account_id BLOB,
+             effective_count   INTEGER NOT NULL
+         ) STRICT;
+
+         CREATE TABLE IF NOT EXISTS account_roster_history(
+             roster_ref         BLOB PRIMARY KEY,
+             account_id         BLOB NOT NULL,
+             device_fingerprint BLOB NOT NULL,
+             role               TEXT NOT NULL,
+             effective_at       INTEGER NOT NULL,
+             closed_at          INTEGER
+         ) STRICT;
+         CREATE INDEX IF NOT EXISTS account_roster_history_account
+             ON account_roster_history(account_id, device_fingerprint);
+
+         CREATE TABLE IF NOT EXISTS account_owner_incarnations(
+             owner_id           BLOB PRIMARY KEY,
+             account_id         BLOB NOT NULL,
+             device_fingerprint BLOB NOT NULL,
+             effective_at       INTEGER NOT NULL,
+             closed_at          INTEGER
+         ) STRICT;
+         CREATE INDEX IF NOT EXISTS account_owner_incarnations_account
+             ON account_owner_incarnations(account_id, device_fingerprint);
+
+         CREATE TABLE IF NOT EXISTS account_stream_ownership(
+             stream_id      BLOB PRIMARY KEY,
+             account_id     BLOB NOT NULL,
+             own_id         BLOB NOT NULL,
+             effective_at   INTEGER NOT NULL
+         ) STRICT;
+         CREATE INDEX IF NOT EXISTS account_stream_ownership_account
+             ON account_stream_ownership(account_id);
+
+         CREATE TABLE IF NOT EXISTS account_stream_grants(
+             grant_id           BLOB PRIMARY KEY,
+             owner_account_id   BLOB NOT NULL,
+             stream_id          BLOB NOT NULL,
+             grantee_account_id BLOB NOT NULL,
+             role               TEXT NOT NULL,
+             effective_at       INTEGER NOT NULL,
+             closed_at          INTEGER
+         ) STRICT;
+         CREATE INDEX IF NOT EXISTS account_stream_grants_owner
+             ON account_stream_grants(owner_account_id, stream_id, grantee_account_id);
+
+         CREATE TABLE IF NOT EXISTS account_stream_grant_cuts(
+             grant_id           BLOB NOT NULL,
+             owner_account_id   BLOB NOT NULL,
+             device_fingerprint BLOB NOT NULL,
+             -- Fixed-width big-endian bytes preserve the full protocol u64 domain and sort in
+             -- unsigned numeric order; SQLite INTEGER is signed and would reject high cuts.
+             seq                BLOB NOT NULL CHECK(length(seq) = 8),
+             entry_hash         BLOB NOT NULL,
+             PRIMARY KEY(grant_id, device_fingerprint)
+         ) STRICT;
+         CREATE INDEX IF NOT EXISTS account_stream_grant_cuts_owner
+             ON account_stream_grant_cuts(owner_account_id, grant_id);",
     )
 }
 

--- a/crates/rag-rat-core/src/index/schema/mod.rs
+++ b/crates/rag-rat-core/src/index/schema/mod.rs
@@ -16,10 +16,10 @@ pub(crate) use registry::{
     sole_repo_id,
 };
 pub use registry::{LEGACY_REPO_ID, RegisteredRepo, register_repo, register_repo_read_only};
-use rusqlite::{Connection, OptionalExtension, params};
+use rusqlite::{Connection, OptionalExtension, Transaction, TransactionBehavior, params};
 use serde::Serialize;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 63;
+pub const LATEST_SCHEMA_VERSION: u32 = 64;
 
 /// Every oracle-DERIVED persisted table — the outputs an `oracle run` writes that must OUTLIVE a
 /// reindex.
@@ -446,6 +446,13 @@ const MIGRATION_063_CHECKSUM: &str = "sha256:rag-rat-papertrail-mirror-resume-st
 const MIGRATION_063_DESCRIPTION: &str =
     "Persist item-page, item-thread, Search-tie, per-stream comment-scan, immutable item-delta \
      windows, and full-rewalk state so every stored unit resumes without replay or lost pruning";
+const MIGRATION_064_ID: &str = "064_account_authority_projection";
+const MIGRATION_064_CHECKSUM: &str = "sha256:rag-rat-account-authority-projection-v64b";
+const MIGRATION_064_DESCRIPTION: &str =
+    "Persist the fully folded account classification, roster and owner incarnations, immutable \
+     stream ownership, exact grant incarnations, and revoke device cuts. refold_account rewrites \
+     these shadow tables in the same IMMEDIATE transaction as accepted/status, so /3 authority \
+     checks never rescan the bounded candidate DAG";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -571,8 +578,7 @@ pub fn apply(conn: &Connection) -> rusqlite::Result<()> {
     // Every additive migration in order. A fresh DB runs them all; data backfills on empty tables
     // are no-ops. (An EXISTING DB takes the forward-only path via `migrate_forward`, not this.)
     for step in ADDITIVE_MIGRATIONS {
-        (step.apply)(conn)?;
-        record_migration(conn, step.id, step.checksum, step.description)?;
+        apply_and_record_migration(conn, step)?;
     }
     // `index --full` is the sanctioned recovery the Dirty refusal names, and apply is its schema
     // step: every migration just re-ran to completion, so a `__dirty__` marker that still
@@ -595,6 +601,23 @@ struct Migration {
     checksum: &'static str,
     description: &'static str,
     apply: fn(&Connection) -> rusqlite::Result<()>,
+}
+
+/// Apply one migration and stamp its ledger row. V064 is special because it projects existing
+/// grow-only account history: DDL, source snapshot, all-account refold, and the ledger stamp must
+/// share one IMMEDIATE transaction so older writers cannot land an unprojected candidate in a
+/// migration race.
+fn apply_and_record_migration(conn: &Connection, step: &Migration) -> rusqlite::Result<()> {
+    if step.id != MIGRATION_064_ID {
+        (step.apply)(conn)?;
+        return record_migration(conn, step.id, step.checksum, step.description);
+    }
+
+    let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
+    (step.apply)(&tx)?;
+    crate::oplog::backfill_authority_projection(&tx)?;
+    record_migration(&tx, step.id, step.checksum, step.description)?;
+    tx.commit()
 }
 
 const ADDITIVE_MIGRATIONS: &[Migration] = &[
@@ -970,6 +993,12 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         description: MIGRATION_063_DESCRIPTION,
         apply: apply_papertrail_mirror_resume_state,
     },
+    Migration {
+        id: MIGRATION_064_ID,
+        checksum: MIGRATION_064_CHECKSUM,
+        description: MIGRATION_064_DESCRIPTION,
+        apply: apply_account_authority_projection,
+    },
 ];
 
 /// Apply ONLY the additive migrations not already recorded, in order — the forward-only path for an
@@ -997,8 +1026,7 @@ pub fn migrate_forward(conn: &Connection) -> anyhow::Result<()> {
     provision_baseline(conn)?;
     for step in ADDITIVE_MIGRATIONS {
         if !applied.contains(step.id) {
-            (step.apply)(conn)?;
-            record_migration(conn, step.id, step.checksum, step.description)?;
+            apply_and_record_migration(conn, step)?;
         }
     }
     // #585: this path only runs when a forward migration actually happened (early-returned above

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/papertrail_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/papertrail_tests.rs
@@ -627,8 +627,7 @@ fn v060_creates_the_papertrail_tables_on_fresh_apply() {
 }
 
 #[test]
-fn migration_063_is_the_tip_and_persists_mirror_resume_state() {
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 63, "move this pin with the next schema migration");
+fn migration_063_persists_mirror_resume_state() {
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     schema::apply(&conn).unwrap();
     let columns = conn_table_columns(&conn, "papertrail_sync_cursor");

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
@@ -1865,6 +1865,60 @@ fn migration_059_creates_the_account_candidate_dag() {
 }
 
 #[test]
+fn migration_064_is_the_tip_and_creates_account_authority_shadow_tables() {
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 64, "move this pin with the next schema migration");
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn).unwrap();
+    for table in [
+        "account_auth_state",
+        "account_roster_history",
+        "account_owner_incarnations",
+        "account_stream_ownership",
+        "account_stream_grants",
+        "account_stream_grant_cuts",
+    ] {
+        assert!(conn_table_exists(&conn, table), "V064 creates {table}");
+    }
+    let isolated = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply_account_authority_projection(&isolated).unwrap();
+    schema::apply_account_authority_projection(&isolated).expect("V064 replay is idempotent");
+    assert!(conn_table_exists(&isolated, "account_auth_state"));
+    let seq_type: String = isolated
+        .query_row(
+            "SELECT type FROM pragma_table_info('account_stream_grant_cuts') WHERE name = 'seq'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(seq_type, "BLOB", "device cuts retain the full unsigned u64 domain");
+    assert!(
+        isolated
+            .execute(
+                "INSERT INTO account_stream_grant_cuts(
+                     grant_id, owner_account_id, device_fingerprint, seq, entry_hash
+                 ) VALUES (?1, ?1, ?1, ?2, ?1)",
+                rusqlite::params![[0u8; 32].as_slice(), [0u8; 7].as_slice()],
+            )
+            .is_err(),
+        "the fixed-width cut coordinate rejects corrupt stored values",
+    );
+
+    truncate_schema_to(&conn, 63);
+    conn.execute_batch(
+        "DROP TABLE account_stream_grant_cuts;
+         DROP TABLE account_stream_grants;
+         DROP TABLE account_stream_ownership;
+         DROP TABLE account_owner_incarnations;
+         DROP TABLE account_roster_history;
+         DROP TABLE account_auth_state;",
+    )
+    .unwrap();
+    schema::migrate_forward(&conn).unwrap();
+    assert_eq!(schema::status(&conn).unwrap().current_version, 64);
+    assert!(conn_table_exists(&conn, "account_auth_state"));
+}
+
+#[test]
 fn migration_047_deferred_absence_and_reconverges_from_torn_state() {
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     conn.execute_batch("CREATE TABLE memory_model_failures(leftover INTEGER);").unwrap();

--- a/crates/rag-rat-core/src/oplog/account/fold.rs
+++ b/crates/rag-rat-core/src/oplog/account/fold.rs
@@ -20,10 +20,11 @@ use super::candidate::{self, Ancestry, CutCoordinate, HeaderView, JoinResult, Un
 use super::cut::{Cut, beyond};
 use super::envelope::{AccountEntryHeader, VerifiedAccountEntry};
 use super::id::account_id_from_genesis_payload;
-use super::ops::{self, AccountOp, ChainKind, DecodedAccountOp, DeviceRole};
+use super::ops::{self, AccountOp, ChainKind, DecodedAccountOp, DeviceCut, DeviceRole, GrantRole};
 use super::registers::RegisterKey;
 use crate::oplog::cbor;
 use crate::oplog::op::DeviceFingerprint;
+use crate::oplog::stream::{self, StreamId};
 
 /// The account CONTROL log the fold operates on (§11) — its registers are control-log scoped
 /// (`log: 0`). A known op on the secrets (1) or content (2) log is not a control op and is retained
@@ -73,6 +74,7 @@ impl Outcome {
                     ParkReason::UnknownCutTarget => "unknown_cut_target",
                     ParkReason::IncompleteCutAncestry => "incomplete_cut_ancestry",
                     ParkReason::ContestedSubject => "contested_subject",
+                    ParkReason::AuthLenAhead => "auth_len_ahead",
                     ParkReason::DeferredStreamAuthorization => "deferred_stream_authorization",
                 }),
             ),
@@ -90,6 +92,7 @@ impl Outcome {
                     RejectReason::WrongDevice => "wrong_device",
                     RejectReason::Malformed => "malformed",
                     RejectReason::NonGenesisOrigin => "non_genesis_origin",
+                    RejectReason::InvalidStreamSpec => "invalid_stream_spec",
                     RejectReason::Ineffective => "ineffective",
                 }),
             ),
@@ -139,6 +142,9 @@ pub(super) enum RejectReason {
     /// A seq-0 origin entry on the FOUNDER's chain that is not the genesis — a second seq-0 slot
     /// competing with the root (equivocation). The founder's origin slot is the genesis alone.
     NonGenesisOrigin,
+    /// A `StreamOwn` preimage is not the canonical owner-bound `/2` spec named by its account and
+    /// `stream_id`.
+    InvalidStreamSpec,
     /// A duplicate / no-op / self-referential op with no effect — incl. an `AccountReRoot` in a
     /// `Live` account (admissible only as the terminal recovery op once contested, §12).
     Ineffective,
@@ -157,10 +163,10 @@ pub(super) enum ParkReason {
     /// The entry's author is a subject of a residue cut op in a `contested` account (§12) — parked,
     /// quota-bounded, reclassified if the account recovers.
     ContestedSubject,
-    /// A `StreamOwn` / `StreamGrant` / `StreamRevoke`: stream ownership + grant authority is folded
-    /// by the C2 content-chain acceptance predicate (which owns the `/2` spec decoder and the
-    /// grant registers), not the C1 control fold. Parked here so C1 trusts NOTHING from an
-    /// unvalidated stream op; C2 reclassifies it.
+    /// The entry asserts a control-fold length not yet present locally. This is recoverable:
+    /// refetch missing control ancestry and refold; the counter never grants authority.
+    AuthLenAhead,
+    /// A secrets/content cut whose target register belongs to a later phase.
     DeferredStreamAuthorization,
 }
 
@@ -180,6 +186,91 @@ pub(super) struct AccountAuthHistory {
     /// — the smallest `successor_account_id` by byte order among the admitted re-roots (§12).
     /// `None` when the account is `Live` or no pre-contest owner has re-rooted yet.
     contested_successor: Option<AccountId>,
+    effective_count: u64,
+    roster_refs: HashMap<[u8; 32], RosterFact>,
+    owner_incarnations: HashMap<[u8; 32], OwnerIncarnationFact>,
+    stream_ownership: HashMap<StreamId, StreamOwnershipFact>,
+    grants: HashMap<[u8; 32], GrantFact>,
+    grant_cuts: HashMap<[u8; 32], Vec<DeviceCut>>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AuthorityQuery<T> {
+    Effective(T),
+    Parked(AuthorityParkReason),
+    Invalid(AuthorityInvalidReason),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AuthorityParkReason {
+    AuthLenAhead,
+    UnknownReference,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AuthorityInvalidReason {
+    WrongSubject,
+    ReferencedEntryNotEffective,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct RosterAuthority {
+    pub(crate) device_fingerprint: DeviceFingerprint,
+    pub(crate) role: DeviceRole,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct OwnerAuthority {
+    pub(crate) device_fingerprint: DeviceFingerprint,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct GrantAuthority {
+    pub(crate) stream_id: StreamId,
+    pub(crate) grantee_account_id: AccountId,
+    pub(crate) role: GrantRole,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct GrantDeviceAuthority {
+    pub(crate) grant: GrantAuthority,
+    pub(crate) boundary: GrantDeviceBoundary,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum GrantDeviceBoundary {
+    Open,
+    Cut(DeviceCut),
+    /// The grant is revoked and this device was not named in its prefix-preserving cuts. A fresh
+    /// or unlisted device gets the empty register: no content entry is admissible.
+    Closed,
+}
+
+#[derive(Clone, Copy)]
+pub(super) struct RosterFact {
+    pub(super) authority: RosterAuthority,
+    pub(super) effective_at: u64,
+    pub(super) closed_at: Option<u64>,
+}
+
+#[derive(Clone, Copy)]
+pub(super) struct OwnerIncarnationFact {
+    pub(super) authority: OwnerAuthority,
+    pub(super) effective_at: u64,
+    pub(super) closed_at: Option<u64>,
+}
+
+#[derive(Clone, Copy)]
+pub(super) struct StreamOwnershipFact {
+    pub(super) own_id: [u8; 32],
+    pub(super) effective_at: u64,
+}
+
+#[derive(Clone, Copy)]
+pub(super) struct GrantFact {
+    pub(super) authority: GrantAuthority,
+    pub(super) effective_at: u64,
+    pub(super) closed_at: Option<u64>,
 }
 
 impl AccountAuthHistory {
@@ -197,9 +288,135 @@ impl AccountAuthHistory {
         self.contested_successor
     }
 
+    pub(super) fn effective_count(&self) -> u64 {
+        self.effective_count
+    }
+
+    pub(super) fn roster_facts(&self) -> impl Iterator<Item = (&[u8; 32], &RosterFact)> {
+        self.roster_refs.iter()
+    }
+
+    pub(super) fn owner_incarnation_facts(
+        &self,
+    ) -> impl Iterator<Item = (&[u8; 32], &OwnerIncarnationFact)> {
+        self.owner_incarnations.iter()
+    }
+
+    pub(super) fn stream_ownership_facts(
+        &self,
+    ) -> impl Iterator<Item = (&StreamId, &StreamOwnershipFact)> {
+        self.stream_ownership.iter()
+    }
+
+    pub(super) fn grant_facts(&self) -> impl Iterator<Item = (&[u8; 32], &GrantFact)> {
+        self.grants.iter()
+    }
+
+    pub(super) fn grant_cuts(&self) -> impl Iterator<Item = (&[u8; 32], &[DeviceCut])> {
+        self.grant_cuts.iter().map(|(grant_id, cuts)| (grant_id, cuts.as_slice()))
+    }
+
+    pub(super) fn roster_ref_effective(
+        &self,
+        roster_ref: [u8; 32],
+        device_fingerprint: DeviceFingerprint,
+        auth_len: u64,
+    ) -> AuthorityQuery<RosterAuthority> {
+        query_fact(
+            self.effective_count,
+            auth_len,
+            self.roster_refs
+                .get(&roster_ref)
+                .filter(|fact| fact.closed_at.is_none())
+                .map(|fact| (fact.authority, fact.authority.device_fingerprint)),
+            device_fingerprint,
+            self.outcomes.contains_key(&roster_ref),
+        )
+    }
+
+    pub(super) fn owner_incarnation_effective(
+        &self,
+        owner_id: [u8; 32],
+        device_fingerprint: DeviceFingerprint,
+        auth_len: u64,
+    ) -> AuthorityQuery<OwnerAuthority> {
+        query_fact(
+            self.effective_count,
+            auth_len,
+            self.owner_incarnations
+                .get(&owner_id)
+                .filter(|fact| fact.closed_at.is_none())
+                .map(|fact| (fact.authority, fact.authority.device_fingerprint)),
+            device_fingerprint,
+            self.outcomes.contains_key(&owner_id),
+        )
+    }
+
+    pub(super) fn grant_effective(
+        &self,
+        grant_id: [u8; 32],
+        stream_id: StreamId,
+        grantee_account_id: AccountId,
+        auth_len: u64,
+    ) -> AuthorityQuery<GrantAuthority> {
+        if auth_len > self.effective_count {
+            return AuthorityQuery::Parked(AuthorityParkReason::AuthLenAhead);
+        }
+        let Some(fact) = self.grants.get(&grant_id) else {
+            return if self.outcomes.contains_key(&grant_id) {
+                AuthorityQuery::Invalid(AuthorityInvalidReason::ReferencedEntryNotEffective)
+            } else {
+                AuthorityQuery::Parked(AuthorityParkReason::UnknownReference)
+            };
+        };
+        if fact.authority.stream_id != stream_id
+            || fact.authority.grantee_account_id != grantee_account_id
+        {
+            return AuthorityQuery::Invalid(AuthorityInvalidReason::WrongSubject);
+        }
+        AuthorityQuery::Effective(fact.authority)
+    }
+
+    pub(super) fn stream_owner_effective(
+        &self,
+        stream_id: StreamId,
+        auth_len: u64,
+    ) -> AuthorityQuery<[u8; 32]> {
+        if auth_len > self.effective_count {
+            return AuthorityQuery::Parked(AuthorityParkReason::AuthLenAhead);
+        }
+        let Some(fact) = self.stream_ownership.get(&stream_id) else {
+            return AuthorityQuery::Parked(AuthorityParkReason::UnknownReference);
+        };
+        AuthorityQuery::Effective(fact.own_id)
+    }
+
     fn is_effective(&self, entry_hash: &[u8; 32]) -> bool {
         self.outcome(entry_hash).is_some_and(|o| o.is_effective())
     }
+}
+
+fn query_fact<T: Copy, S: PartialEq>(
+    effective_count: u64,
+    auth_len: u64,
+    fact: Option<(T, S)>,
+    expected_subject: S,
+    reference_is_known: bool,
+) -> AuthorityQuery<T> {
+    if auth_len > effective_count {
+        return AuthorityQuery::Parked(AuthorityParkReason::AuthLenAhead);
+    }
+    let Some((authority, subject)) = fact else {
+        return if reference_is_known {
+            AuthorityQuery::Invalid(AuthorityInvalidReason::ReferencedEntryNotEffective)
+        } else {
+            AuthorityQuery::Parked(AuthorityParkReason::UnknownReference)
+        };
+    };
+    if subject != expected_subject {
+        return AuthorityQuery::Invalid(AuthorityInvalidReason::WrongSubject);
+    }
+    AuthorityQuery::Effective(authority)
 }
 
 /// A structurally-valid, signature-valid candidate the fold considers: the verified entry + its
@@ -347,6 +564,19 @@ struct FoldState {
     genesis_seen: bool,
     /// 0-based effective index assigned as `auth_epoch`.
     next_auth_epoch: u64,
+    /// Effective immutable stream ownership roots, keyed by owner-bound stream id.
+    stream_ownership: HashMap<StreamId, [u8; 32]>,
+    /// Effective grant incarnations. A revoke closes exactly one id; a later grant gets a fresh
+    /// hash and remains independent.
+    grants: HashMap<[u8; 32], LiveGrant>,
+}
+
+#[derive(Clone, Copy)]
+struct LiveGrant {
+    stream_id: StreamId,
+    grantee_account_id: AccountId,
+    role: GrantRole,
+    open: bool,
 }
 
 /// A hash-keyed [`HeaderView`] over ALL verified entries — the ancestry walk + cut-target binding
@@ -572,6 +802,34 @@ fn join_register(
 /// MUST share `account_id` (the caller groups by account). Order-independent: the result is
 /// identical under every permutation of `entries`.
 pub(super) fn fold_account(entries: &[VerifiedAccountEntry]) -> AccountAuthHistory {
+    // Readiness is monotone: once an entry proves it was authored ahead of the locally folded
+    // authority history (or depends on authority that did not survive the fold), it cannot
+    // contribute a register or phase-E mutation in this fold. Re-run the frozen stratified pass
+    // with those entries held out until no new readiness exclusions appear. This is not a graph
+    // fixpoint: each pass still performs exactly the §11.1 one-way, per-depth register fold, and
+    // exclusions only grow.
+    let mut readiness_exclusions = HashMap::new();
+    loop {
+        let (history, discovered) = fold_account_pass(entries, &readiness_exclusions);
+        let mut changed = false;
+        for (hash, outcome) in discovered {
+            if let std::collections::hash_map::Entry::Vacant(entry) =
+                readiness_exclusions.entry(hash)
+            {
+                entry.insert(outcome);
+                changed = true;
+            }
+        }
+        if !changed {
+            return history;
+        }
+    }
+}
+
+fn fold_account_pass(
+    entries: &[VerifiedAccountEntry],
+    readiness_exclusions: &HashMap<[u8; 32], Outcome>,
+) -> (AccountAuthHistory, HashMap<[u8; 32], Outcome>) {
     let mut outcomes: HashMap<[u8; 32], Outcome> = HashMap::new();
 
     // Decode once, then classify. `candidates` are the ops the fold actually folds; `all_headers`
@@ -626,11 +884,20 @@ pub(super) fn fold_account(entries: &[VerifiedAccountEntry]) -> AccountAuthHisto
         for c in &candidates {
             outcomes.insert(c.hash(), Outcome::Parked(ParkReason::UnknownOwnerRef));
         }
-        return AccountAuthHistory {
-            outcomes,
-            classification: AccountClassification::Live,
-            contested_successor: None,
-        };
+        return (
+            AccountAuthHistory {
+                outcomes,
+                classification: AccountClassification::Live,
+                contested_successor: None,
+                effective_count: 0,
+                roster_refs: HashMap::new(),
+                owner_incarnations: HashMap::new(),
+                stream_ownership: HashMap::new(),
+                grants: HashMap::new(),
+                grant_cuts: HashMap::new(),
+            },
+            HashMap::new(),
+        );
     };
     let genesis_owner_id = genesis.hash();
     let genesis_founder = genesis.subject_device();
@@ -640,6 +907,10 @@ pub(super) fn fold_account(entries: &[VerifiedAccountEntry]) -> AccountAuthHisto
     // Group resolvable candidates by author-depth; unresolvable citations park.
     let mut strata: BTreeMap<usize, Vec<usize>> = BTreeMap::new();
     for (idx, c) in candidates.iter().enumerate() {
+        if let Some(outcome) = readiness_exclusions.get(&c.hash()) {
+            outcomes.insert(c.hash(), *outcome);
+            continue;
+        }
         // The founder's seq-0 origin slot is the genesis ALONE. A second seq-0 entry on the
         // founder's chain is an origin equivocation with the root — reject it (else, sorting before
         // genesis by hash, it could take auth_epoch 0 and mutate state before the root is applied).
@@ -661,22 +932,20 @@ pub(super) fn fold_account(entries: &[VerifiedAccountEntry]) -> AccountAuthHisto
     // A single per-depth pass over the strata (§11.1): each depth admits its live cut ops'
     // registers, detects contested, condemns/parks against the registers so far, then runs the
     // effect pass. A CutExtend re-blesses its cone via the same-depth `⊔` join (cross-depth
-    // recovery is the deferred fixpoint's job — a global recompute could preserve a register
-    // whose creator the fold condemns).
+    // recovery is deliberately excluded by the stratified model).
     let mut state = FoldState { live: HashSet::from([genesis_owner_id]), ..Default::default() };
     // The revocation registers accumulated so far (extend-only, joined by `⊔`), every entry a
     // register condemns (grows monotonically — a lower-depth decision is final, no oscillation) /
     // parks (rebuilt fresh each depth), and the cut ops decided in the register pass (a binding
-    // failure / I2). Per-depth monotone, matching §11.1 — a CutExtend re-blesses its cone via the
-    // same-depth `⊔` join, not a global recompute (a global seed could preserve a register whose
-    // creator the fold later condemns).
+    // failure / I2).
     let mut registers: HashMap<RegisterKey, Cut> = HashMap::new();
     let mut condemned: HashMap<[u8; 32], CondemnedReason> = HashMap::new();
     let mut parked: HashMap<[u8; 32], ParkReason> = HashMap::new();
     let mut cut_verdicts: HashMap<[u8; 32], Outcome> = HashMap::new();
+    let mut register_contributors: HashSet<[u8; 32]> = HashSet::new();
     let mut classification = AccountClassification::Live;
 
-    'depths: for (depth, idxs) in strata {
+    'depths: for (&depth, idxs) in &strata {
         let view = CandidateView { headers: &all_headers };
 
         // (a) REGISTER PASS. A cut op installs a register iff its author is AUTHORIZED
@@ -685,7 +954,7 @@ pub(super) fn fold_account(entries: &[VerifiedAccountEntry]) -> AccountAuthHisto
         // owner impersonation), it passes cut-target binding (§11.3), and — for
         // OwnerDemote — its target `owner_id` names its subject device.
         let mut admitted: Vec<AdmittedCut<'_>> = Vec::new();
-        for &i in &idxs {
+        for &i in idxs {
             let c = &candidates[i];
             // A condemned OR parked cut op installs nothing — parked authority (its own chain is
             // under a not-yet-decided watermark) must not have register side effects before it is
@@ -788,7 +1057,9 @@ pub(super) fn fold_account(entries: &[VerifiedAccountEntry]) -> AccountAuthHisto
         // this) are a same-depth mutual condemnation ⇒ contested, never a chosen hash.
         for a in &admitted {
             match join_register(&mut registers, a.key.clone(), a.cut.clone(), &view) {
-                RegisterJoin::Applied => {},
+                RegisterJoin::Applied => {
+                    register_contributors.insert(a.op.hash());
+                },
                 RegisterJoin::Contested => {
                     classification = AccountClassification::Contested { state_before_depth: depth };
                     break 'depths;
@@ -808,7 +1079,7 @@ pub(super) fn fold_account(entries: &[VerifiedAccountEntry]) -> AccountAuthHisto
         // bare extend). An extend for a not-yet-established register parks until
         // the creator syncs.
         let mut extends: Vec<(&Candidate, RegisterKey, Cut)> = Vec::new();
-        for &i in &idxs {
+        for &i in idxs {
             let c = &candidates[i];
             if condemned.contains_key(&c.hash()) || parked.contains_key(&c.hash()) {
                 continue;
@@ -835,7 +1106,9 @@ pub(super) fn fold_account(entries: &[VerifiedAccountEntry]) -> AccountAuthHisto
         extends.sort_by_key(|(c, _, _)| c.hash());
         for (c, key, cut) in extends {
             match join_register(&mut registers, key, cut, &view) {
-                RegisterJoin::Applied => {},
+                RegisterJoin::Applied => {
+                    register_contributors.insert(c.hash());
+                },
                 RegisterJoin::Contested => {
                     classification = AccountClassification::Contested { state_before_depth: depth };
                     break 'depths;
@@ -847,21 +1120,8 @@ pub(super) fn fold_account(entries: &[VerifiedAccountEntry]) -> AccountAuthHisto
         }
 
         // Re-derive condemnation + parking against the current registers. Condemnation grows
-        // monotonically (a lower-depth decision is never revised); parking is rebuilt fresh (a
-        // withheld watermark parks the under-cut prefix — I11). Pruning a condemned MINT from
-        // `live` kills its dependents transitively (they cite an owner_id no longer live →
-        // stale).
-        //
-        // BOUNDARY (per-depth model): a register that retroactively condemns an already-effective
-        // NON-mint entry (e.g. a member DeviceAdd) is reflected in that entry's outcome (the final
-        // overlay), but its roster/tombstone side effect is not rolled back, and a same-depth
-        // dependent may read the stale roster. Reaching that state requires an OWNER surgically
-        // cutting a co-owner's incarnation to strand a member it is concurrently promoting —
-        // Byzantine owner behaviour, which the trusted-owner threat model puts out of automated
-        // resolution (owner-key compromise ⇒ `contested`, never silently reconciled). A full
-        // effect-state rebuild + register-provenance fixpoint would close it and is the natural
-        // home for cross-depth `CutExtend` recovery too; both are deferred with that model in
-        // force.
+        // monotonically: the frozen stratified model never lets a deeper authority revise a
+        // lower-depth decision. Parking is rebuilt because missing ancestry can arrive later.
         parked.clear();
         for c in &candidates {
             // The genesis is the account's ROOT axiom — it can never be condemned, else a cut on
@@ -906,7 +1166,7 @@ pub(super) fn fold_account(entries: &[VerifiedAccountEntry]) -> AccountAuthHisto
         // (b) EFFECT PASS over the stratum in (chain, seq, hash) order — a TOTAL order, so an
         // equivocation (same device + seq, different content) sorts identically under every
         // arrival permutation (I9).
-        let mut ordered = idxs;
+        let mut ordered = idxs.clone();
         ordered.sort_by_key(|&i| {
             let h = candidates[i].header();
             (h.device_fingerprint.to_bytes(), h.seq, candidates[i].hash())
@@ -932,6 +1192,26 @@ pub(super) fn fold_account(entries: &[VerifiedAccountEntry]) -> AccountAuthHisto
             outcomes.insert(c.hash(), outcome);
         }
     }
+
+    // Registers and their per-depth condemnation decisions are now final. Rebuild ONLY phase-E
+    // state against those fixed verdicts so a retroactively condemned non-mint cannot leave a
+    // roster, tombstone, ownership, or grant mutation behind. This is deliberately not a graph
+    // fixpoint: no register is added/removed and no lower-depth condemnation is revised.
+    let replay_before_depth = match classification {
+        AccountClassification::Live => None,
+        AccountClassification::Contested { state_before_depth } => Some(state_before_depth),
+    };
+    state = replay_effect_state(
+        &candidates,
+        &strata,
+        &incarnations,
+        genesis_owner_id,
+        replay_before_depth,
+        &condemned,
+        &parked,
+        &cut_verdicts,
+        &mut outcomes,
+    );
 
     // Overlay the FINAL register verdicts: a candidate effective at a shallow depth but
     // condemned / parked by a later register reflects that here (the strictest verdict
@@ -995,7 +1275,335 @@ pub(super) fn fold_account(entries: &[VerifiedAccountEntry]) -> AccountAuthHisto
         }
     }
 
-    AccountAuthHistory { outcomes, classification, contested_successor }
+    let mut discovered = close_final_authority_dependencies(&candidates, &mut outcomes);
+    if matches!(classification, AccountClassification::Contested { .. }) {
+        contested_successor = candidates
+            .iter()
+            .filter(|candidate| outcomes.get(&candidate.hash()).is_some_and(Outcome::is_effective))
+            .filter_map(|candidate| match candidate.op {
+                AccountOp::AccountReRoot { successor_account_id, .. } => Some(successor_account_id),
+                _ => None,
+            })
+            .min_by_key(|account_id| account_id.to_bytes());
+    }
+    let effective_count = normalize_auth_epochs(&mut outcomes);
+    // Effective candidates use `effective_count - 1` inside the closure above. Also inspect
+    // condemned, contested, and actual register contributors against the fully-folded count: a
+    // mint can provisionally authorize the descendant cut that later condemns it; mutually-
+    // condemning ahead cuts can manufacture `Contested`; and a cut may install a register before
+    // phase E rejects it as ineffective (for example, removing a never-enrolled device).
+    // Structurally rejected and ordinarily parked candidates retain their stronger verdict when
+    // they contributed neither state nor a register.
+    for candidate in &candidates {
+        if !readiness_exclusions.contains_key(&candidate.hash())
+            && (register_contributors.contains(&candidate.hash())
+                || matches!(
+                    outcomes.get(&candidate.hash()),
+                    Some(Outcome::Condemned(_) | Outcome::Parked(ParkReason::ContestedSubject))
+                ))
+            && candidate.header().auth_len > effective_count
+        {
+            discovered.insert(candidate.hash(), Outcome::Parked(ParkReason::AuthLenAhead));
+        }
+    }
+    let facts = derive_authority_facts(&candidates, &outcomes);
+    (
+        AccountAuthHistory {
+            outcomes,
+            classification,
+            contested_successor,
+            effective_count,
+            roster_refs: facts.roster_refs,
+            owner_incarnations: facts.owner_incarnations,
+            stream_ownership: facts.stream_ownership,
+            grants: facts.grants,
+            grant_cuts: facts.grant_cuts,
+        },
+        discovered,
+    )
+}
+
+#[expect(clippy::too_many_arguments, reason = "fixed fold verdicts are explicit replay inputs")]
+fn replay_effect_state(
+    candidates: &[Candidate],
+    strata: &BTreeMap<usize, Vec<usize>>,
+    incarnations: &Incarnations<'_>,
+    genesis_owner_id: [u8; 32],
+    before_depth: Option<usize>,
+    condemned: &HashMap<[u8; 32], CondemnedReason>,
+    parked: &HashMap<[u8; 32], ParkReason>,
+    cut_verdicts: &HashMap<[u8; 32], Outcome>,
+    outcomes: &mut HashMap<[u8; 32], Outcome>,
+) -> FoldState {
+    let mut state = FoldState { live: HashSet::from([genesis_owner_id]), ..Default::default() };
+    for (&depth, idxs) in strata {
+        if before_depth.is_some_and(|limit| depth >= limit) {
+            break;
+        }
+        let mut ordered = idxs.clone();
+        ordered.sort_by_key(|&i| {
+            let header = candidates[i].header();
+            (header.device_fingerprint.to_bytes(), header.seq, candidates[i].hash())
+        });
+        for i in ordered {
+            let candidate = &candidates[i];
+            let outcome = if let Some(reason) = condemned.get(&candidate.hash()) {
+                Outcome::Condemned(*reason)
+            } else if let Some(reason) = parked.get(&candidate.hash()) {
+                Outcome::Parked(*reason)
+            } else if let Some(verdict) = cut_verdicts.get(&candidate.hash()) {
+                *verdict
+            } else {
+                classify_effect(candidate, incarnations, &state, parked)
+            };
+            if outcome.is_effective() {
+                apply_effect(candidate, &mut state);
+            }
+            outcomes.insert(candidate.hash(), outcome);
+        }
+    }
+    state
+}
+
+fn normalize_auth_epochs(outcomes: &mut HashMap<[u8; 32], Outcome>) -> u64 {
+    let mut effective: Vec<([u8; 32], u64)> = outcomes
+        .iter()
+        .filter_map(|(hash, outcome)| match outcome {
+            Outcome::Effective { auth_epoch } => Some((*hash, *auth_epoch)),
+            _ => None,
+        })
+        .collect();
+    effective.sort_by_key(|(hash, old_epoch)| (*old_epoch, *hash));
+    for (new_epoch, (hash, _)) in effective.iter().enumerate() {
+        outcomes.insert(*hash, Outcome::Effective { auth_epoch: new_epoch as u64 });
+    }
+    effective.len() as u64
+}
+
+/// Final fail-closed dependency closure after fixed-register phase-E replay. No authority fact may
+/// survive without its final-effective roster / ownership / grant prerequisite. Freshness is also
+/// decided against the fully folded count here — never against transient hash iteration order, and
+/// never as an authority input.
+fn close_final_authority_dependencies(
+    candidates: &[Candidate],
+    outcomes: &mut HashMap<[u8; 32], Outcome>,
+) -> HashMap<[u8; 32], Outcome> {
+    let mut discovered = HashMap::new();
+    loop {
+        let effective_count = normalize_auth_epochs(outcomes);
+        let effective_roster: HashSet<DeviceFingerprint> = candidates
+            .iter()
+            .filter(|candidate| outcomes.get(&candidate.hash()).is_some_and(Outcome::is_effective))
+            .filter_map(|candidate| match candidate.op {
+                AccountOp::AccountGenesis { .. } => Some(candidate.header().device_fingerprint),
+                AccountOp::DeviceAdd { device_fingerprint, .. } => Some(device_fingerprint),
+                _ => None,
+            })
+            .collect();
+        let effective_ownership: HashSet<StreamId> = candidates
+            .iter()
+            .filter(|candidate| outcomes.get(&candidate.hash()).is_some_and(Outcome::is_effective))
+            .filter_map(|candidate| match candidate.op {
+                AccountOp::StreamOwn { stream_id, .. } => Some(stream_id),
+                _ => None,
+            })
+            .collect();
+        let effective_grants: HashMap<[u8; 32], (StreamId, AccountId)> = candidates
+            .iter()
+            .filter(|candidate| outcomes.get(&candidate.hash()).is_some_and(Outcome::is_effective))
+            .filter_map(|candidate| match candidate.op {
+                AccountOp::StreamGrant { stream_id, grantee_account_id, .. } =>
+                    Some((candidate.hash(), (stream_id, grantee_account_id))),
+                _ => None,
+            })
+            .collect();
+
+        let mut changed = false;
+        for candidate in candidates {
+            if !outcomes.get(&candidate.hash()).is_some_and(Outcome::is_effective) {
+                continue;
+            }
+            let replacement = if candidate.header().auth_len > effective_count.saturating_sub(1) {
+                Some(Outcome::Parked(ParkReason::AuthLenAhead))
+            } else if let Some(authority_ref) = candidate.header().authority_ref
+                && !outcomes.get(&authority_ref).is_some_and(Outcome::is_effective)
+            {
+                Some(match outcomes.get(&authority_ref) {
+                    Some(Outcome::Parked(reason)) => Outcome::Parked(*reason),
+                    _ => Outcome::Rejected(RejectReason::StaleAuthority),
+                })
+            } else {
+                match &candidate.op {
+                    AccountOp::OwnerPromote { device_fingerprint }
+                        if !effective_roster.contains(device_fingerprint) =>
+                        Some(Outcome::Rejected(RejectReason::Ineffective)),
+                    AccountOp::StreamGrant { stream_id, .. }
+                        if !effective_ownership.contains(stream_id) =>
+                        Some(Outcome::Rejected(RejectReason::Ineffective)),
+                    AccountOp::StreamRevoke { stream_id, grantee_account_id, grant_id, .. }
+                        if effective_grants.get(grant_id)
+                            != Some(&(*stream_id, *grantee_account_id)) =>
+                        Some(Outcome::Rejected(RejectReason::Ineffective)),
+                    _ => None,
+                }
+            };
+            if let Some(replacement) = replacement {
+                outcomes.insert(candidate.hash(), replacement);
+                // Only freshness is monotone across readiness passes. A stale citation or failed
+                // state precondition can recover after an ahead competing effect is excluded, so
+                // those verdicts must be recomputed rather than permanently held out.
+                if replacement == Outcome::Parked(ParkReason::AuthLenAhead) {
+                    discovered.insert(candidate.hash(), replacement);
+                }
+                changed = true;
+            }
+        }
+        if !changed {
+            break;
+        }
+    }
+    discovered
+}
+
+#[derive(Default)]
+struct AuthorityFacts {
+    roster_refs: HashMap<[u8; 32], RosterFact>,
+    owner_incarnations: HashMap<[u8; 32], OwnerIncarnationFact>,
+    stream_ownership: HashMap<StreamId, StreamOwnershipFact>,
+    grants: HashMap<[u8; 32], GrantFact>,
+    grant_cuts: HashMap<[u8; 32], Vec<DeviceCut>>,
+}
+
+fn derive_authority_facts(
+    candidates: &[Candidate],
+    outcomes: &HashMap<[u8; 32], Outcome>,
+) -> AuthorityFacts {
+    let mut effective: Vec<(&Candidate, u64)> = candidates
+        .iter()
+        .filter_map(|candidate| match outcomes.get(&candidate.hash()) {
+            Some(Outcome::Effective { auth_epoch }) => Some((candidate, *auth_epoch)),
+            _ => None,
+        })
+        .collect();
+    effective.sort_by_key(|(candidate, epoch)| (*epoch, candidate.hash()));
+
+    let mut facts = AuthorityFacts::default();
+    let mut roster = HashMap::<DeviceFingerprint, [u8; 32]>::new();
+    let mut owners = HashMap::<DeviceFingerprint, [u8; 32]>::new();
+    for (candidate, epoch) in effective {
+        match &candidate.op {
+            AccountOp::AccountGenesis { .. } => {
+                let device = candidate.subject_device();
+                let hash = candidate.hash();
+                facts.roster_refs.insert(hash, RosterFact {
+                    authority: RosterAuthority {
+                        device_fingerprint: device,
+                        role: DeviceRole::Owner,
+                    },
+                    effective_at: epoch,
+                    closed_at: None,
+                });
+                facts.owner_incarnations.insert(hash, OwnerIncarnationFact {
+                    authority: OwnerAuthority { device_fingerprint: device },
+                    effective_at: epoch,
+                    closed_at: None,
+                });
+                roster.insert(device, hash);
+                owners.insert(device, hash);
+            },
+            AccountOp::DeviceAdd { device_fingerprint, role, .. } => {
+                let hash = candidate.hash();
+                facts.roster_refs.insert(hash, RosterFact {
+                    authority: RosterAuthority {
+                        device_fingerprint: *device_fingerprint,
+                        role: *role,
+                    },
+                    effective_at: epoch,
+                    closed_at: None,
+                });
+                roster.insert(*device_fingerprint, hash);
+                if *role == DeviceRole::Owner {
+                    facts.owner_incarnations.insert(hash, OwnerIncarnationFact {
+                        authority: OwnerAuthority { device_fingerprint: *device_fingerprint },
+                        effective_at: epoch,
+                        closed_at: None,
+                    });
+                    owners.insert(*device_fingerprint, hash);
+                }
+            },
+            AccountOp::OwnerPromote { device_fingerprint } => {
+                let hash = candidate.hash();
+                let roster_ref = roster
+                    .get(device_fingerprint)
+                    .expect("promoted device has an active roster fact");
+                facts.roster_refs.get_mut(roster_ref).expect("active roster fact").authority.role =
+                    DeviceRole::Owner;
+                facts.owner_incarnations.insert(hash, OwnerIncarnationFact {
+                    authority: OwnerAuthority { device_fingerprint: *device_fingerprint },
+                    effective_at: epoch,
+                    closed_at: None,
+                });
+                owners.insert(*device_fingerprint, hash);
+            },
+            AccountOp::DeviceRemove { device_fingerprint, .. } => {
+                if let Some(roster_ref) = roster.remove(device_fingerprint) {
+                    facts.roster_refs.get_mut(&roster_ref).expect("active roster fact").closed_at =
+                        Some(epoch);
+                }
+                if let Some(owner_id) = owners.remove(device_fingerprint) {
+                    facts
+                        .owner_incarnations
+                        .get_mut(&owner_id)
+                        .expect("active owner fact")
+                        .closed_at = Some(epoch);
+                }
+            },
+            AccountOp::OwnerDemote { device_fingerprint, owner_id, .. } => {
+                if owners.get(device_fingerprint) == Some(owner_id) {
+                    owners.remove(device_fingerprint);
+                    let roster_ref = roster
+                        .get(device_fingerprint)
+                        .expect("demoted device has an active roster fact");
+                    facts
+                        .roster_refs
+                        .get_mut(roster_ref)
+                        .expect("active roster fact")
+                        .authority
+                        .role = DeviceRole::Member;
+                    facts
+                        .owner_incarnations
+                        .get_mut(owner_id)
+                        .expect("active owner fact")
+                        .closed_at = Some(epoch);
+                }
+            },
+            AccountOp::StreamOwn { stream_id, .. } => {
+                facts.stream_ownership.insert(*stream_id, StreamOwnershipFact {
+                    own_id: candidate.hash(),
+                    effective_at: epoch,
+                });
+            },
+            AccountOp::StreamGrant { stream_id, grantee_account_id, grant_role } => {
+                facts.grants.insert(candidate.hash(), GrantFact {
+                    authority: GrantAuthority {
+                        stream_id: *stream_id,
+                        grantee_account_id: *grantee_account_id,
+                        role: *grant_role,
+                    },
+                    effective_at: epoch,
+                    closed_at: None,
+                });
+            },
+            AccountOp::StreamRevoke { grant_id, device_cuts, .. } => {
+                if let Some(grant) = facts.grants.get_mut(grant_id) {
+                    grant.closed_at = Some(epoch);
+                    facts.grant_cuts.insert(*grant_id, device_cuts.clone());
+                }
+            },
+            AccountOp::CutExtend { .. } | AccountOp::AccountReRoot { .. } => {},
+        }
+    }
+    facts
 }
 
 /// The genesis candidate: an `AccountGenesis` whose payload hashes to the shared `account_id` (§4)
@@ -1132,13 +1740,49 @@ fn classify_effect(
                 Outcome::Rejected(RejectReason::BadPromote)
             }
         },
-        // Stream ownership + grant authority (self-certifying `/2` spec, grant registers, content
-        // chains) is folded by the C2 predicate — C1 defers it rather than trust an unvalidated
-        // stream op.
-        AccountOp::StreamOwn { .. }
-        | AccountOp::StreamGrant { .. }
-        | AccountOp::StreamRevoke { .. } =>
-            Outcome::Parked(ParkReason::DeferredStreamAuthorization),
+        AccountOp::StreamOwn { stream_id, stream_spec_bytes } => {
+            let valid = stream::decode_spec_v2(stream_spec_bytes)
+                .and_then(|spec| {
+                    anyhow::ensure!(spec.owner_account_id == c.header().account_id);
+                    Ok(stream::derive_v2(&spec)? == *stream_id)
+                })
+                .unwrap_or(false);
+            if !valid {
+                Outcome::Rejected(RejectReason::InvalidStreamSpec)
+            } else if state.stream_ownership.contains_key(stream_id) {
+                Outcome::Rejected(RejectReason::Ineffective)
+            } else {
+                effective(state)
+            }
+        },
+        AccountOp::StreamGrant { stream_id, grantee_account_id, grant_role } => {
+            let duplicate = state.grants.values().any(|grant| {
+                grant.open
+                    && grant.stream_id == *stream_id
+                    && grant.grantee_account_id == *grantee_account_id
+                    && grant.role == *grant_role
+            });
+            if !state.stream_ownership.contains_key(stream_id)
+                || *grantee_account_id == c.header().account_id
+                || duplicate
+            {
+                Outcome::Rejected(RejectReason::Ineffective)
+            } else {
+                effective(state)
+            }
+        },
+        AccountOp::StreamRevoke { stream_id, grantee_account_id, grant_id, .. } => {
+            let matches_open_grant = state.grants.get(grant_id).is_some_and(|grant| {
+                grant.open
+                    && grant.stream_id == *stream_id
+                    && grant.grantee_account_id == *grantee_account_id
+            });
+            if state.stream_ownership.contains_key(stream_id) && matches_open_grant {
+                effective(state)
+            } else {
+                Outcome::Rejected(RejectReason::Ineffective)
+            }
+        },
         // `AccountReRoot` is admissible ONLY as the terminal recovery op once the account is
         // contested (§12) — the contested path admits it. In a `Live` account it has no effect.
         AccountOp::AccountReRoot { .. } => Outcome::Rejected(RejectReason::Ineffective),
@@ -1192,6 +1836,22 @@ fn apply_effect(c: &Candidate, state: &mut FoldState) {
             state.owners.insert(*device_fingerprint, c.hash());
             state.live.insert(c.hash());
         },
+        AccountOp::StreamOwn { stream_id, .. } => {
+            state.stream_ownership.insert(*stream_id, c.hash());
+        },
+        AccountOp::StreamGrant { stream_id, grantee_account_id, grant_role } => {
+            state.grants.insert(c.hash(), LiveGrant {
+                stream_id: *stream_id,
+                grantee_account_id: *grantee_account_id,
+                role: *grant_role,
+                open: true,
+            });
+        },
+        AccountOp::StreamRevoke { grant_id, .. } => {
+            if let Some(grant) = state.grants.get_mut(grant_id) {
+                grant.open = false;
+            }
+        },
         // An effective removal tombstones the device (I4: never re-enroll) and drops it from the
         // roster/owner sets. The register it installed handles condemning its beyond-cut entries.
         AccountOp::DeviceRemove { device_fingerprint, .. } => {
@@ -1213,11 +1873,10 @@ fn apply_effect(c: &Candidate, state: &mut FoldState) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::oplog::account::AccountId;
     use crate::oplog::account::envelope::{sign_account_entry, verify_account_signed};
-    use crate::oplog::account::ops::{encode, entry_type, entry_type_of};
+    use crate::oplog::account::{AccountId, ops as account_ops};
     use crate::oplog::device::{DeviceSecret, DeviceX25519Secret};
-    use crate::oplog::stream::StreamId;
+    use crate::oplog::stream::{StreamId, StreamSpec, StreamSpecV2};
 
     /// A seed-deterministic test device: its ed25519 signer + fingerprint + the pubkeys a
     /// Genesis/DeviceAdd op carries.
@@ -1270,7 +1929,7 @@ mod tests {
                 created_at_ms: 1_700_000_000_000,
                 label: None,
             };
-            let payload = encode(&op).unwrap();
+            let payload = account_ops::encode(&op).unwrap();
             let account_id = account_id_from_genesis_payload(&payload);
             let header = AccountEntryHeader {
                 account_id,
@@ -1279,7 +1938,7 @@ mod tests {
                 seq: 0,
                 prev_hash: None,
                 parent_ref: None,
-                entry_type: entry_type::ACCOUNT_GENESIS,
+                entry_type: account_ops::entry_type::ACCOUNT_GENESIS,
                 op_version: 1,
                 crypto_suite: 0,
                 auth_len: 0,
@@ -1304,7 +1963,17 @@ mod tests {
             authority_ref: Option<[u8; 32]>,
             op: &AccountOp,
         ) -> [u8; 32] {
-            let payload = encode(op).unwrap();
+            self.author_at_auth_len(author, authority_ref, op, 1)
+        }
+
+        fn author_at_auth_len(
+            &mut self,
+            author: &Dev,
+            authority_ref: Option<[u8; 32]>,
+            op: &AccountOp,
+            auth_len: u64,
+        ) -> [u8; 32] {
+            let payload = account_ops::encode(op).unwrap();
             let (seq, prev) = self.chains.get(&author.fp.to_bytes()).copied().unwrap_or((0, None));
             let header = AccountEntryHeader {
                 account_id: self.account_id,
@@ -1313,9 +1982,9 @@ mod tests {
                 seq,
                 prev_hash: prev,
                 parent_ref: Some(self.genesis_hash),
-                entry_type: entry_type_of(op),
+                entry_type: account_ops::entry_type_of(op),
                 op_version: 1,
-                auth_len: 1,
+                auth_len,
                 crypto_suite: 0,
                 key_id: None,
                 authority_ref,
@@ -1340,7 +2009,7 @@ mod tests {
             seq: u64,
             prev_hash: Option<[u8; 32]>,
         ) -> [u8; 32] {
-            let payload = encode(op).unwrap();
+            let payload = account_ops::encode(op).unwrap();
             let header = AccountEntryHeader {
                 account_id: self.account_id,
                 log_id: 0,
@@ -1348,7 +2017,7 @@ mod tests {
                 seq,
                 prev_hash,
                 parent_ref: Some(self.genesis_hash),
-                entry_type: entry_type_of(op),
+                entry_type: account_ops::entry_type_of(op),
                 op_version: 1,
                 auth_len: 1,
                 crypto_suite: 0,
@@ -1425,8 +2094,19 @@ mod tests {
         AccountOp::AccountReRoot { successor_account_id: successor, note: None }
     }
 
-    fn stream_own(stream: StreamId) -> AccountOp {
-        AccountOp::StreamOwn { stream_id: stream, stream_spec_bytes: vec![0x80] }
+    fn stream_own(account_id: AccountId) -> (StreamId, AccountOp) {
+        let spec = StreamSpecV2 {
+            owner_account_id: account_id,
+            policy: StreamSpec {
+                repo_set: vec!["repo-a".to_string()],
+                kind_allow_list: None,
+                relation_policy: None,
+                node_overrides: Vec::new(),
+            },
+        };
+        let stream_id = stream::derive_v2(&spec).unwrap();
+        let stream_spec_bytes = stream::canonical_spec_v2_bytes(&spec).unwrap();
+        (stream_id, AccountOp::StreamOwn { stream_id, stream_spec_bytes })
     }
 
     fn stream_grant(stream: StreamId, grantee: AccountId) -> AccountOp {
@@ -1434,6 +2114,16 @@ mod tests {
             stream_id: stream,
             grantee_account_id: grantee,
             grant_role: ops::GrantRole::Reader,
+        }
+    }
+
+    fn stream_revoke(stream: StreamId, grantee: AccountId, grant_id: [u8; 32]) -> AccountOp {
+        AccountOp::StreamRevoke {
+            stream_id: stream,
+            grantee_account_id: grantee,
+            grant_id,
+            device_cuts: Vec::new(),
+            reason: "access ended".to_string(),
         }
     }
 
@@ -1464,6 +2154,192 @@ mod tests {
         let h = f.fold();
         assert!(h.is_effective(&f.genesis_hash), "the genesis is effective");
         assert_eq!(h.classification(), AccountClassification::Live);
+    }
+
+    #[test]
+    fn auth_len_ahead_parks_but_a_behind_assertion_never_grants_or_denies_authority() {
+        let founder = Dev::new(1);
+        let ahead_device = Dev::new(2);
+        let behind_device = Dev::new(3);
+        let mut f = Fixture::genesis(&founder);
+        let ahead = f.author_at_auth_len(
+            &founder,
+            Some(f.genesis_hash),
+            &device_add(&ahead_device, DeviceRole::Member),
+            10,
+        );
+        let behind = f.author_at_auth_len(
+            &founder,
+            Some(f.genesis_hash),
+            &device_add(&behind_device, DeviceRole::Member),
+            0,
+        );
+
+        let h = f.fold();
+        assert_eq!(h.outcome(&ahead), Some(Outcome::Parked(ParkReason::AuthLenAhead)));
+        assert_eq!(
+            h.roster_ref_effective(ahead, ahead_device.fp, h.effective_count()),
+            AuthorityQuery::Invalid(AuthorityInvalidReason::ReferencedEntryNotEffective),
+            "an ahead candidate must not leave a projected roster mutation",
+        );
+        assert!(h.is_effective(&behind), "a stale count is informational, never authority");
+    }
+
+    #[test]
+    fn a_candidate_cannot_satisfy_its_own_auth_len() {
+        let (founder, device) = (Dev::new(1), Dev::new(2));
+        let mut f = Fixture::genesis(&founder);
+        let ahead = f.author_at_auth_len(
+            &founder,
+            Some(f.genesis_hash),
+            &device_add(&device, DeviceRole::Member),
+            2,
+        );
+
+        let h = f.fold();
+        assert_eq!(h.effective_count(), 1, "only genesis preceded the candidate");
+        assert_eq!(h.outcome(&ahead), Some(Outcome::Parked(ParkReason::AuthLenAhead)));
+    }
+
+    #[test]
+    fn an_auth_len_ahead_cut_has_no_register_side_effect() {
+        let (founder, b, member) = (Dev::new(1), Dev::new(2), Dev::new(3));
+        let mut f = Fixture::genesis(&founder);
+        let add_b = f.author(&founder, Some(f.genesis_hash), &device_add(&b, DeviceRole::Owner));
+        let ahead_remove = f.author_at_auth_len(
+            &founder,
+            Some(f.genesis_hash),
+            &device_remove(&b, Cut::Empty),
+            u64::MAX,
+        );
+        let add_member = f.author(&b, Some(add_b), &device_add(&member, DeviceRole::Member));
+
+        let h = f.fold();
+        assert_eq!(h.outcome(&ahead_remove), Some(Outcome::Parked(ParkReason::AuthLenAhead)),);
+        assert!(h.is_effective(&add_member), "a parked cut must not condemn B's chain");
+        assert_eq!(h.classification(), AccountClassification::Live);
+    }
+
+    #[test]
+    fn an_ahead_ineffective_cut_cannot_poison_a_later_enrollment() {
+        let (founder, device, member) = (Dev::new(1), Dev::new(2), Dev::new(3));
+        let mut f = Fixture::genesis(&founder);
+        let ahead_remove = f.author_at_auth_len(
+            &founder,
+            Some(f.genesis_hash),
+            &device_remove(&device, Cut::Empty),
+            u64::MAX,
+        );
+        let add_device =
+            f.author(&founder, Some(f.genesis_hash), &device_add(&device, DeviceRole::Owner));
+        let add_member =
+            f.author(&device, Some(add_device), &device_add(&member, DeviceRole::Member));
+
+        let h = f.fold();
+        assert_eq!(
+            h.outcome(&ahead_remove),
+            Some(Outcome::Parked(ParkReason::AuthLenAhead)),
+            "freshness dominates the phase-E ineffective verdict for a register contributor",
+        );
+        assert!(h.is_effective(&add_device));
+        assert!(
+            h.is_effective(&add_member),
+            "the rejected ahead cut must leave no empty register on the enrolled device",
+        );
+    }
+
+    #[test]
+    fn an_auth_len_ahead_owner_mint_cannot_authorize_a_descendant_cut() {
+        let (founder, b) = (Dev::new(1), Dev::new(2));
+        let mut f = Fixture::genesis(&founder);
+        let ahead_add = f.author_at_auth_len(
+            &founder,
+            Some(f.genesis_hash),
+            &device_add(&b, DeviceRole::Owner),
+            u64::MAX,
+        );
+        let remove_founder = f.author(&b, Some(ahead_add), &device_remove(&founder, Cut::Empty));
+
+        let h = f.fold();
+        assert_eq!(h.outcome(&ahead_add), Some(Outcome::Parked(ParkReason::AuthLenAhead)));
+        assert_eq!(
+            h.outcome(&remove_founder),
+            Some(Outcome::Rejected(RejectReason::StaleAuthority)),
+            "an excluded mint cannot launder authority into its descendant",
+        );
+        assert_eq!(h.classification(), AccountClassification::Live);
+        assert!(h.is_effective(&f.genesis_hash));
+    }
+
+    #[test]
+    fn an_auth_len_ahead_effect_cannot_poison_a_valid_successor_or_its_dependent() {
+        let (founder, device) = (Dev::new(1), Dev::new(2));
+        let mut f = Fixture::genesis(&founder);
+        let ahead = f.author_at_auth_len(
+            &founder,
+            Some(f.genesis_hash),
+            &device_add(&device, DeviceRole::Member),
+            u64::MAX,
+        );
+        let valid =
+            f.author(&founder, Some(f.genesis_hash), &device_add(&device, DeviceRole::Member));
+        let promote = f.author(&founder, Some(f.genesis_hash), &owner_promote(&device));
+
+        let h = f.fold();
+        assert_eq!(h.outcome(&ahead), Some(Outcome::Parked(ParkReason::AuthLenAhead)));
+        assert!(h.is_effective(&valid), "the parked add must not cause DuplicateAdd");
+        assert!(
+            h.is_effective(&promote),
+            "the promotion must recover with the valid enrollment on the next readiness pass",
+        );
+        assert_eq!(
+            h.roster_ref_effective(valid, device.fp, h.effective_count()),
+            AuthorityQuery::Effective(RosterAuthority {
+                device_fingerprint: device.fp,
+                role: DeviceRole::Owner,
+            }),
+        );
+        assert_eq!(
+            h.owner_incarnation_effective(promote, device.fp, h.effective_count()),
+            AuthorityQuery::Effective(OwnerAuthority { device_fingerprint: device.fp }),
+        );
+    }
+
+    #[test]
+    fn a_dependent_grant_recovers_after_an_ahead_ownership_competitor_is_excluded() {
+        let founder = Dev::new(1);
+        let grantee = AccountId::from_bytes([0x44; 32]);
+        let mut f = Fixture::genesis(&founder);
+        let (stream, own) = stream_own(f.account_id);
+        let ahead_own = f.author_at_auth_len(&founder, Some(f.genesis_hash), &own, u64::MAX);
+        let valid_own = f.author(&founder, Some(f.genesis_hash), &own);
+        let grant = f.author(&founder, Some(f.genesis_hash), &stream_grant(stream, grantee));
+
+        let h = f.fold();
+        assert_eq!(h.outcome(&ahead_own), Some(Outcome::Parked(ParkReason::AuthLenAhead)));
+        assert!(h.is_effective(&valid_own), "the valid StreamOwn must replace its ahead twin");
+        assert!(
+            h.is_effective(&grant),
+            "a state-dependent grant must be recomputed, not permanently readiness-excluded",
+        );
+    }
+
+    #[test]
+    fn mutually_condemning_ahead_cuts_do_not_manufacture_contested() {
+        let (founder, a, b) = (Dev::new(1), Dev::new(2), Dev::new(3));
+        let mut f = Fixture::genesis(&founder);
+        let add_a = f.author(&founder, Some(f.genesis_hash), &device_add(&a, DeviceRole::Owner));
+        let add_b = f.author(&founder, Some(f.genesis_hash), &device_add(&b, DeviceRole::Owner));
+        let remove_b =
+            f.author_at_auth_len(&a, Some(add_a), &device_remove(&b, Cut::Empty), u64::MAX);
+        let remove_a =
+            f.author_at_auth_len(&b, Some(add_b), &device_remove(&a, Cut::Empty), u64::MAX);
+
+        let h = f.fold();
+        assert_eq!(h.classification(), AccountClassification::Live);
+        assert_eq!(h.outcome(&remove_a), Some(Outcome::Parked(ParkReason::AuthLenAhead)));
+        assert_eq!(h.outcome(&remove_b), Some(Outcome::Parked(ParkReason::AuthLenAhead)));
+        assert!(h.is_effective(&add_a) && h.is_effective(&add_b));
     }
 
     #[test]
@@ -1661,6 +2537,25 @@ mod tests {
             );
             assert_eq!(r.contested_successor(), Some(small), "rotation {rot} successor");
         }
+    }
+
+    #[test]
+    fn an_auth_len_ahead_reroot_cannot_select_the_contested_successor() {
+        let (founder, a, b) = (Dev::new(1), Dev::new(2), Dev::new(3));
+        let (ahead_small, valid_big) =
+            (AccountId::from_bytes([0x11; 32]), AccountId::from_bytes([0x22; 32]));
+        let mut f = Fixture::genesis(&founder);
+        let add_a = f.author(&founder, Some(f.genesis_hash), &device_add(&a, DeviceRole::Owner));
+        let add_b = f.author(&founder, Some(f.genesis_hash), &device_add(&b, DeviceRole::Owner));
+        f.author(&a, Some(add_a), &device_remove(&b, Cut::Empty));
+        f.author(&b, Some(add_b), &device_remove(&a, Cut::Empty));
+        let ahead = f.author_at_auth_len(&a, Some(add_a), &account_reroot(ahead_small), u64::MAX);
+        let valid = f.author(&a, Some(add_a), &account_reroot(valid_big));
+
+        let h = f.fold();
+        assert_eq!(h.outcome(&ahead), Some(Outcome::Parked(ParkReason::AuthLenAhead)));
+        assert!(h.is_effective(&valid));
+        assert_eq!(h.contested_successor(), Some(valid_big));
     }
 
     #[test]
@@ -1920,27 +2815,328 @@ mod tests {
     }
 
     #[test]
-    fn stream_ops_are_deferred_to_c2_not_folded_as_authority() {
-        // Stream ownership + grant authority (the self-certifying `/2` spec, grant registers,
-        // content chains) is folded by the C2 predicate, not the C1 control fold. So StreamOwn /
-        // StreamGrant establish NO authority here — they park, and C1 trusts nothing from an
-        // unvalidated stream op (P11's floor: a grant is never effective before its owner because
-        // neither is ever effective in C1).
+    fn stream_ownership_grant_and_revoke_are_folded_as_citation_authority() {
         let fdr = Dev::new(1);
-        let stream = StreamId::from_bytes([0x33; 32]);
         let grantee = AccountId::from_bytes([0x44; 32]);
         let mut f = Fixture::genesis(&fdr);
-        let own = f.author(&fdr, Some(f.genesis_hash), &stream_own(stream));
+        let (stream, own_op) = stream_own(f.account_id);
+        let own = f.author(&fdr, Some(f.genesis_hash), &own_op);
         let grant = f.author(&fdr, Some(f.genesis_hash), &stream_grant(stream, grantee));
+        let revoke = f.author(&fdr, Some(f.genesis_hash), &stream_revoke(stream, grantee, grant));
 
         let h = f.fold();
-        for (op, label) in [(own, "StreamOwn"), (grant, "StreamGrant")] {
+        assert!(h.is_effective(&own));
+        assert!(h.is_effective(&grant));
+        assert!(h.is_effective(&revoke));
+        assert_eq!(h.effective_count(), 4);
+        assert_eq!(
+            h.grant_effective(grant, stream, grantee, 2),
+            AuthorityQuery::Effective(GrantAuthority {
+                stream_id: stream,
+                grantee_account_id: grantee,
+                role: GrantRole::Reader,
+            }),
+            "a behind auth_len is informational and cannot deny an exact citation",
+        );
+        assert!(matches!(
+            h.grant_effective(grant, stream, grantee, 3),
+            AuthorityQuery::Effective(GrantAuthority { role: GrantRole::Reader, .. })
+        ));
+        assert_eq!(
+            h.grant_effective(grant, stream, grantee, 4),
+            AuthorityQuery::Effective(GrantAuthority {
+                stream_id: stream,
+                grantee_account_id: grantee,
+                role: GrantRole::Reader,
+            }),
+            "revocation bounds content through cuts; stale auth_len cannot reopen or close a grant",
+        );
+        assert_eq!(
+            h.grant_effective(grant, stream, grantee, 5),
+            AuthorityQuery::Parked(AuthorityParkReason::AuthLenAhead),
+        );
+        assert_eq!(h.stream_owner_effective(stream, 2), AuthorityQuery::Effective(own));
+    }
+
+    #[test]
+    fn stream_preconditions_fail_closed_without_minting_authority_p11() {
+        let fdr = Dev::new(1);
+        let grantee = AccountId::from_bytes([0x44; 32]);
+        let mut f = Fixture::genesis(&fdr);
+        let (stream, own_op) = stream_own(f.account_id);
+        let early_grant = f.author(&fdr, Some(f.genesis_hash), &stream_grant(stream, grantee));
+        let own = f.author(&fdr, Some(f.genesis_hash), &own_op);
+        let duplicate_own = f.author(&fdr, Some(f.genesis_hash), &own_op);
+        let self_grant = f.author(&fdr, Some(f.genesis_hash), &stream_grant(stream, f.account_id));
+        let grant = f.author(&fdr, Some(f.genesis_hash), &stream_grant(stream, grantee));
+        let duplicate_grant = f.author(&fdr, Some(f.genesis_hash), &stream_grant(stream, grantee));
+        let wrong_revoke = f.author(
+            &fdr,
+            Some(f.genesis_hash),
+            &stream_revoke(stream, AccountId::from_bytes([0x55; 32]), grant),
+        );
+
+        let h = f.fold();
+        assert!(h.is_effective(&own));
+        assert!(h.is_effective(&grant));
+        assert_eq!(
+            h.grant_effective(early_grant, stream, grantee, h.effective_count()),
+            AuthorityQuery::Invalid(AuthorityInvalidReason::ReferencedEntryNotEffective),
+            "a held but ineffective grant is invalid, not parked as if it were missing",
+        );
+        for (hash, label) in [
+            (early_grant, "grant before ownership"),
+            (duplicate_own, "duplicate ownership"),
+            (self_grant, "self grant"),
+            (duplicate_grant, "duplicate same-role grant"),
+            (wrong_revoke, "revoke with mismatched grantee"),
+        ] {
             assert_eq!(
-                h.outcome(&op),
-                Some(Outcome::Parked(ParkReason::DeferredStreamAuthorization)),
-                "{label} is deferred to C2, never authority-bearing in C1",
+                h.outcome(&hash),
+                Some(Outcome::Rejected(RejectReason::Ineffective)),
+                "{label}",
             );
         }
+    }
+
+    #[test]
+    fn retroactive_ownership_condemnation_transitively_invalidates_a_grant() {
+        let (founder, owner) = (Dev::new(1), Dev::new(2));
+        let grantee = AccountId::from_bytes([0x44; 32]);
+        let mut f = Fixture::genesis(&founder);
+        let add_owner =
+            f.author(&founder, Some(f.genesis_hash), &device_add(&owner, DeviceRole::Owner));
+        let (stream, own_op) = stream_own(f.account_id);
+        let own = f.author(&founder, Some(f.genesis_hash), &own_op);
+        let remove_founder = f.author(
+            &owner,
+            Some(add_owner),
+            &device_remove(&founder, Cut::At { seq: 1, hash: add_owner }),
+        );
+        let grant = f.author(&owner, Some(add_owner), &stream_grant(stream, grantee));
+
+        let expected = f.fold();
+        assert_eq!(expected.outcome(&own), Some(Outcome::Condemned(CondemnedReason::BeyondCut)));
+        assert!(expected.is_effective(&remove_founder));
+        assert_eq!(expected.outcome(&grant), Some(Outcome::Rejected(RejectReason::Ineffective)));
+        assert_eq!(
+            expected.grant_effective(grant, stream, grantee, expected.effective_count()),
+            AuthorityQuery::Invalid(AuthorityInvalidReason::ReferencedEntryNotEffective),
+        );
+        assert_eq!(
+            expected.stream_owner_effective(stream, expected.effective_count()),
+            AuthorityQuery::Parked(AuthorityParkReason::UnknownReference),
+        );
+        for rotation in 1..f.entries.len() {
+            assert_eq!(f.fold_rotated(rotation).outcomes, expected.outcomes);
+        }
+    }
+
+    #[test]
+    fn retroactive_enrollment_condemnation_removes_a_promotion_side_effect() {
+        let (founder, owner, member) = (Dev::new(1), Dev::new(2), Dev::new(3));
+        let mut f = Fixture::genesis(&founder);
+        let add_owner =
+            f.author(&founder, Some(f.genesis_hash), &device_add(&owner, DeviceRole::Owner));
+        let add_member =
+            f.author(&founder, Some(f.genesis_hash), &device_add(&member, DeviceRole::Member));
+        let promote = f.author(&owner, Some(add_owner), &owner_promote(&member));
+        let cut = f.author(
+            &owner,
+            Some(add_owner),
+            &device_remove(&founder, Cut::At { seq: 1, hash: add_owner }),
+        );
+
+        let expected = f.fold();
+        assert!(expected.is_effective(&cut));
+        assert_eq!(
+            expected.outcome(&add_member),
+            Some(Outcome::Condemned(CondemnedReason::BeyondCut)),
+        );
+        assert!(!expected.is_effective(&promote));
+        assert_eq!(
+            expected.owner_incarnation_effective(promote, member.fp, expected.effective_count(),),
+            AuthorityQuery::Invalid(AuthorityInvalidReason::ReferencedEntryNotEffective),
+            "a promotion cannot survive solely through a condemned enrollment mutation",
+        );
+        for rotation in 1..f.entries.len() {
+            assert_eq!(f.fold_rotated(rotation).outcomes, expected.outcomes);
+        }
+    }
+
+    #[test]
+    fn fixed_register_replay_removes_a_condemned_tombstone_side_effect() {
+        let (founder, owner, member) = (Dev::new(1), Dev::new(2), Dev::new(3));
+        let mut f = Fixture::genesis(&founder);
+        let add_owner =
+            f.author(&founder, Some(f.genesis_hash), &device_add(&owner, DeviceRole::Owner));
+        let add_member =
+            f.author(&founder, Some(f.genesis_hash), &device_add(&member, DeviceRole::Member));
+        let remove_member =
+            f.author(&founder, Some(f.genesis_hash), &device_remove(&member, Cut::Empty));
+        f.author(
+            &owner,
+            Some(add_owner),
+            &device_remove(&founder, Cut::At { seq: 2, hash: add_member }),
+        );
+        let promote = f.author(&owner, Some(add_owner), &owner_promote(&member));
+
+        let expected = f.fold();
+        assert_eq!(
+            expected.outcome(&remove_member),
+            Some(Outcome::Condemned(CondemnedReason::BeyondCut)),
+        );
+        assert!(
+            expected.is_effective(&promote),
+            "phase-E replay restores the enrolled member after its tombstone op is condemned",
+        );
+        for rotation in 1..f.entries.len() {
+            assert_eq!(f.fold_rotated(rotation).outcomes, expected.outcomes);
+        }
+    }
+
+    #[test]
+    fn retroactive_grant_condemnation_invalidates_revoke_without_stale_cut_facts() {
+        let (founder, owner) = (Dev::new(1), Dev::new(2));
+        let grantee = AccountId::from_bytes([0x44; 32]);
+        let mut f = Fixture::genesis(&founder);
+        let add_owner =
+            f.author(&founder, Some(f.genesis_hash), &device_add(&owner, DeviceRole::Owner));
+        let (stream, own_op) = stream_own(f.account_id);
+        let own = f.author(&founder, Some(f.genesis_hash), &own_op);
+        let grant = f.author(&founder, Some(f.genesis_hash), &stream_grant(stream, grantee));
+        let remove_founder = f.author(
+            &owner,
+            Some(add_owner),
+            &device_remove(&founder, Cut::At { seq: 2, hash: own }),
+        );
+        let revoke = f.author(&owner, Some(add_owner), &stream_revoke(stream, grantee, grant));
+
+        let expected = f.fold();
+        assert!(expected.is_effective(&own));
+        assert_eq!(expected.outcome(&grant), Some(Outcome::Condemned(CondemnedReason::BeyondCut)));
+        assert!(expected.is_effective(&remove_founder));
+        assert_eq!(expected.outcome(&revoke), Some(Outcome::Rejected(RejectReason::Ineffective)));
+        assert_eq!(
+            expected.grant_effective(grant, stream, grantee, expected.effective_count()),
+            AuthorityQuery::Invalid(AuthorityInvalidReason::ReferencedEntryNotEffective),
+        );
+        assert!(expected.grant_cuts.is_empty());
+        for rotation in 1..f.entries.len() {
+            assert_eq!(f.fold_rotated(rotation).outcomes, expected.outcomes);
+        }
+    }
+
+    #[test]
+    fn final_auth_len_closure_is_independent_of_device_order() {
+        let mut saw_orderings = HashSet::new();
+        for e_is_a in [true, false] {
+            let (founder, a, b) = (Dev::new(1), Dev::new(2), Dev::new(3));
+            let mut f = Fixture::genesis(&founder);
+            let add_a =
+                f.author(&founder, Some(f.genesis_hash), &device_add(&a, DeviceRole::Owner));
+            let add_b =
+                f.author(&founder, Some(f.genesis_hash), &device_add(&b, DeviceRole::Owner));
+            let (e_author, e_ref, x_author, x_ref) =
+                if e_is_a { (&a, add_a, &b, add_b) } else { (&b, add_b, &a, add_a) };
+            saw_orderings.insert(e_author.fp < x_author.fp);
+            let x = f.author_at_auth_len(
+                x_author,
+                Some(x_ref),
+                &device_add(&Dev::new(4), DeviceRole::Member),
+                3,
+            );
+            let e = f.author_at_auth_len(
+                e_author,
+                Some(e_ref),
+                &device_add(&Dev::new(5), DeviceRole::Member),
+                4,
+            );
+
+            let expected = f.fold();
+            assert!(expected.is_effective(&x));
+            assert!(expected.is_effective(&e));
+            assert_eq!(expected.effective_count(), 5);
+            for rotation in 1..f.entries.len() {
+                assert_eq!(f.fold_rotated(rotation).outcomes, expected.outcomes);
+            }
+        }
+        assert_eq!(saw_orderings, HashSet::from([false, true]));
+    }
+
+    #[test]
+    fn stream_own_rejects_wrong_owner_wrong_hash_and_malformed_preimages() {
+        let fdr = Dev::new(1);
+        let mut f = Fixture::genesis(&fdr);
+        let (stream, valid) = stream_own(f.account_id);
+        let AccountOp::StreamOwn { stream_spec_bytes, .. } = valid else { unreachable!() };
+        let wrong_hash = f.author(&fdr, Some(f.genesis_hash), &AccountOp::StreamOwn {
+            stream_id: StreamId::from_bytes([0x77; 32]),
+            stream_spec_bytes: stream_spec_bytes.clone(),
+        });
+        let (_, wrong_owner_op) = stream_own(AccountId::from_bytes([0x66; 32]));
+        let wrong_owner = f.author(&fdr, Some(f.genesis_hash), &wrong_owner_op);
+        let malformed = f.author(&fdr, Some(f.genesis_hash), &AccountOp::StreamOwn {
+            stream_id: stream,
+            stream_spec_bytes: vec![0x80],
+        });
+
+        let h = f.fold();
+        for hash in [wrong_hash, wrong_owner, malformed] {
+            assert_eq!(h.outcome(&hash), Some(Outcome::Rejected(RejectReason::InvalidStreamSpec)),);
+        }
+    }
+
+    #[test]
+    fn roster_and_owner_queries_are_citation_time_and_subject_bound() {
+        let fdr = Dev::new(1);
+        let member = Dev::new(2);
+        let mut f = Fixture::genesis(&fdr);
+        let add = f.author(&fdr, Some(f.genesis_hash), &device_add(&member, DeviceRole::Member));
+        let promote = f.author(&fdr, Some(f.genesis_hash), &owner_promote(&member));
+        let h = f.fold();
+
+        assert_eq!(
+            h.roster_ref_effective(add, member.fp, 2),
+            AuthorityQuery::Effective(RosterAuthority {
+                device_fingerprint: member.fp,
+                role: DeviceRole::Owner,
+            }),
+        );
+        assert_eq!(
+            h.roster_ref_effective(add, fdr.fp, 2),
+            AuthorityQuery::Invalid(AuthorityInvalidReason::WrongSubject),
+        );
+        assert_eq!(
+            h.owner_incarnation_effective(promote, member.fp, 2),
+            AuthorityQuery::Effective(OwnerAuthority { device_fingerprint: member.fp }),
+            "a behind auth_len does not deny an exact owner citation",
+        );
+        assert_eq!(
+            h.owner_incarnation_effective(promote, member.fp, 3),
+            AuthorityQuery::Effective(OwnerAuthority { device_fingerprint: member.fp }),
+        );
+
+        f.author(&fdr, Some(f.genesis_hash), &owner_demote(&member, promote, Cut::Empty));
+        let h = f.fold();
+        assert_eq!(
+            h.roster_ref_effective(add, member.fp, 4),
+            AuthorityQuery::Effective(RosterAuthority {
+                device_fingerprint: member.fp,
+                role: DeviceRole::Member,
+            }),
+        );
+        assert_eq!(
+            h.owner_incarnation_effective(promote, member.fp, 4),
+            AuthorityQuery::Invalid(AuthorityInvalidReason::ReferencedEntryNotEffective),
+        );
+
+        f.author(&fdr, Some(f.genesis_hash), &device_remove(&member, Cut::Empty));
+        let h = f.fold();
+        assert_eq!(
+            h.roster_ref_effective(add, member.fp, 5),
+            AuthorityQuery::Invalid(AuthorityInvalidReason::ReferencedEntryNotEffective),
+        );
     }
 
     #[test]
@@ -1950,9 +3146,8 @@ mod tests {
         // same-depth `⊔`, covered by `cut_extend_reblesses_a_condemned_cone_p7`). Here F removes B
         // at depth 0 (condemning b1/b2) and a DEEPER owner A (depth 1) extends the cut — because
         // A's extend lands a stratum later than the depth-0 condemnation, the cone stays
-        // condemned in this fold. (A global recompute would fix this but could preserve a
-        // register whose creator the fold later condemns — a laundering hole — so we stay
-        // faithful to the per-depth model.)
+        // condemned in this fold. A global graph fixpoint is forbidden by the frozen v5 model
+        // because it can preserve register power for an already-condemned creator.
         let (fdr, a, b) = (Dev::new(1), Dev::new(2), Dev::new(3));
         let (d, e, g) = (Dev::new(5), Dev::new(6), Dev::new(7));
         let mut f = Fixture::genesis(&fdr);
@@ -1970,7 +3165,7 @@ mod tests {
         assert_eq!(
             h.outcome(&b1),
             Some(Outcome::Condemned(CondemnedReason::BeyondCut)),
-            "a deeper-depth extend does not re-bless a shallower depth's condemnation",
+            "a deeper-depth extend does not revise a shallower depth's final condemnation",
         );
     }
 
@@ -2100,7 +3295,7 @@ mod tests {
             created_at_ms: 1_700_000_000_000,
             label: None,
         };
-        let payload = encode(&op).unwrap();
+        let payload = account_ops::encode(&op).unwrap();
         let account_id = account_id_from_genesis_payload(&payload);
         let genesis_header = |signer: &Dev| AccountEntryHeader {
             account_id,
@@ -2109,7 +3304,7 @@ mod tests {
             seq: 0,
             prev_hash: None,
             parent_ref: None,
-            entry_type: entry_type::ACCOUNT_GENESIS,
+            entry_type: account_ops::entry_type::ACCOUNT_GENESIS,
             op_version: 1,
             crypto_suite: 0,
             auth_len: 0,
@@ -2125,7 +3320,7 @@ mod tests {
         let forged = signed(&attacker, &genesis_header(&attacker), &payload);
         // The attacker adds itself as owner, citing its forged genesis.
         let add_op = device_add(&x, DeviceRole::Owner);
-        let add_payload = encode(&add_op).unwrap();
+        let add_payload = account_ops::encode(&add_op).unwrap();
         let add_header = AccountEntryHeader {
             account_id,
             log_id: 0,
@@ -2133,7 +3328,7 @@ mod tests {
             seq: 1,
             prev_hash: Some(forged.entry_hash),
             parent_ref: Some(forged.entry_hash),
-            entry_type: entry_type_of(&add_op),
+            entry_type: account_ops::entry_type_of(&add_op),
             op_version: 1,
             auth_len: 1,
             crypto_suite: 0,
@@ -2184,7 +3379,7 @@ mod tests {
         let (fdr, x) = (Dev::new(1), Dev::new(2));
         let f = Fixture::genesis(&fdr);
         let op = device_add(&x, DeviceRole::Owner);
-        let payload = encode(&op).unwrap();
+        let payload = account_ops::encode(&op).unwrap();
         let header = AccountEntryHeader {
             account_id: f.account_id,
             log_id: 1, // secrets log — not the control log
@@ -2192,7 +3387,7 @@ mod tests {
             seq: 1,
             prev_hash: Some(f.genesis_hash),
             parent_ref: Some(f.genesis_hash),
-            entry_type: entry_type_of(&op),
+            entry_type: account_ops::entry_type_of(&op),
             op_version: 1,
             auth_len: 1,
             crypto_suite: 0,
@@ -2219,7 +3414,7 @@ mod tests {
         let (fdr, x) = (Dev::new(1), Dev::new(2));
         let f = Fixture::genesis(&fdr);
         let op = device_add(&x, DeviceRole::Owner);
-        let payload = encode(&op).unwrap();
+        let payload = account_ops::encode(&op).unwrap();
         let header = AccountEntryHeader {
             account_id: f.account_id,
             log_id: 0,
@@ -2227,7 +3422,7 @@ mod tests {
             seq: 1,
             prev_hash: Some(f.genesis_hash),
             parent_ref: Some(f.genesis_hash),
-            entry_type: entry_type_of(&op),
+            entry_type: account_ops::entry_type_of(&op),
             op_version: 2, // future version
             auth_len: 1,
             crypto_suite: 0,
@@ -2326,7 +3521,7 @@ mod tests {
             created_at_ms: 1_700_000_000_000,
             label: None,
         };
-        let payload = encode(&op).unwrap();
+        let payload = account_ops::encode(&op).unwrap();
         let account_id = account_id_from_genesis_payload(&payload);
         let header = AccountEntryHeader {
             account_id,
@@ -2335,7 +3530,7 @@ mod tests {
             seq: 0,
             prev_hash: None,
             parent_ref: Some([0x01; 32]), // a root has no parent
-            entry_type: entry_type::ACCOUNT_GENESIS,
+            entry_type: account_ops::entry_type::ACCOUNT_GENESIS,
             op_version: 1,
             auth_len: 0,
             crypto_suite: 0,
@@ -2364,7 +3559,7 @@ mod tests {
         let (fdr, x) = (Dev::new(1), Dev::new(2));
         let f = Fixture::genesis(&fdr);
         let op = device_add(&x, DeviceRole::Owner);
-        let payload = encode(&op).unwrap();
+        let payload = account_ops::encode(&op).unwrap();
         let header = AccountEntryHeader {
             account_id: f.account_id,
             log_id: 0,
@@ -2372,7 +3567,7 @@ mod tests {
             seq: 0,
             prev_hash: None,
             parent_ref: Some(f.genesis_hash),
-            entry_type: entry_type_of(&op),
+            entry_type: account_ops::entry_type_of(&op),
             op_version: 1,
             auth_len: 1,
             crypto_suite: 0,
@@ -2406,7 +3601,7 @@ mod tests {
             seq: 1,
             prev_hash: Some(f.genesis_hash),
             parent_ref: Some(f.genesis_hash),
-            entry_type: entry_type::DEVICE_ADD,
+            entry_type: account_ops::entry_type::DEVICE_ADD,
             op_version: 1,
             auth_len: 1,
             crypto_suite: 1,          // sealed
@@ -2441,7 +3636,7 @@ mod tests {
             seq: 1,
             prev_hash: Some(f.genesis_hash),
             parent_ref: Some(f.genesis_hash),
-            entry_type: entry_type::DEVICE_ADD,
+            entry_type: account_ops::entry_type::DEVICE_ADD,
             op_version: 1,
             auth_len: 1,
             crypto_suite: 0,
@@ -2469,7 +3664,7 @@ mod tests {
         let (fdr, x) = (Dev::new(1), Dev::new(2));
         let f = Fixture::genesis(&fdr);
         let op = device_add(&x, DeviceRole::Owner);
-        let payload = encode(&op).unwrap(); // valid DeviceAdd bytes, but the header marks it sealed
+        let payload = account_ops::encode(&op).unwrap(); // valid DeviceAdd bytes, but the header marks it sealed
         let header = AccountEntryHeader {
             account_id: f.account_id,
             log_id: 0,
@@ -2477,7 +3672,7 @@ mod tests {
             seq: 1,
             prev_hash: Some(f.genesis_hash),
             parent_ref: Some(f.genesis_hash),
-            entry_type: entry_type_of(&op),
+            entry_type: account_ops::entry_type_of(&op),
             op_version: 1,
             auth_len: 1,
             crypto_suite: 1,
@@ -2560,6 +3755,7 @@ mod tests {
                 ("parked", Some("incomplete_cut_ancestry")),
             ),
             (Outcome::Parked(ParkReason::ContestedSubject), ("parked", Some("contested_subject"))),
+            (Outcome::Parked(ParkReason::AuthLenAhead), ("parked", Some("auth_len_ahead"))),
             (
                 Outcome::Parked(ParkReason::DeferredStreamAuthorization),
                 ("parked", Some("deferred_stream_authorization")),
@@ -2592,6 +3788,10 @@ mod tests {
             (
                 Outcome::Rejected(RejectReason::NonGenesisOrigin),
                 ("rejected", Some("non_genesis_origin")),
+            ),
+            (
+                Outcome::Rejected(RejectReason::InvalidStreamSpec),
+                ("rejected", Some("invalid_stream_spec")),
             ),
             (Outcome::Rejected(RejectReason::Ineffective), ("rejected", Some("ineffective"))),
         ];

--- a/crates/rag-rat-core/src/oplog/account/mod.rs
+++ b/crates/rag-rat-core/src/oplog/account/mod.rs
@@ -15,15 +15,6 @@
 //! - [`id`]: [`AccountId`] + the §4 genesis commitment.
 //! - [`limits`]: §18a protocol-validity constants + the account-layer domain strings.
 //! - [`envelope`]: the 13-part signed account-entry envelope (§6).
-//!
-//! **Build-time lint posture.** The account subsystem is built bottom-up over the C1 slices: a
-//! lower layer (envelope, ops, cut, registers) is consumed only by a higher one (fold, storage) or
-//! by a later phase (C2–C5), so a freshly-landed layer reads as `dead_code` until its consumer
-//! arrives. This blanket allow spans the build; it is REMOVED at Phase 6 (surface wire-up), where
-//! the final `-D warnings` clippy gate + the reviewer catch anything genuinely unreachable, and the
-//! handful of truly C2–C5-deferred seams get precise per-item allows.
-#![allow(dead_code)]
-
 mod candidate;
 mod cut;
 mod envelope;
@@ -34,4 +25,14 @@ mod ops;
 mod registers;
 mod storage;
 
+pub(crate) use fold::{
+    AuthorityInvalidReason, AuthorityParkReason, AuthorityQuery, GrantAuthority,
+    GrantDeviceAuthority, GrantDeviceBoundary, OwnerAuthority, RosterAuthority,
+};
 pub(crate) use id::AccountId;
+pub(crate) use ops::{DeviceCut, DeviceRole, GrantRole};
+pub(crate) use storage::{
+    CapacityScope, IngestOutcome, account_ingest, backfill_authority_projection,
+    grant_effective_for_device, owner_incarnation_effective, roster_ref_effective,
+    stream_owner_effective,
+};

--- a/crates/rag-rat-core/src/oplog/account/ops.rs
+++ b/crates/rag-rat-core/src/oplog/account/ops.rs
@@ -48,12 +48,27 @@ pub(super) mod entry_type {
 /// A device's role in an account roster (§9). Owner holds all control/secrets ops; a member authors
 /// content on granted streams only.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) enum DeviceRole {
+pub(crate) enum DeviceRole {
     Member,
     Owner,
 }
 
 impl DeviceRole {
+    pub(super) fn as_db_str(self) -> &'static str {
+        match self {
+            DeviceRole::Member => "member",
+            DeviceRole::Owner => "owner",
+        }
+    }
+
+    pub(super) fn from_db_str(value: &str) -> anyhow::Result<Self> {
+        match value {
+            "member" => Ok(DeviceRole::Member),
+            "owner" => Ok(DeviceRole::Owner),
+            other => anyhow::bail!("unknown persisted device role `{other}`"),
+        }
+    }
+
     fn as_u8(self) -> u8 {
         match self {
             DeviceRole::Member => 1,
@@ -73,12 +88,27 @@ impl DeviceRole {
 /// A cross-account grant's role on a stream (§9). Reader = wrap recipient (sealed) / free (public);
 /// writer = reader + content accepted.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) enum GrantRole {
+pub(crate) enum GrantRole {
     Reader,
     Writer,
 }
 
 impl GrantRole {
+    pub(super) fn as_db_str(self) -> &'static str {
+        match self {
+            GrantRole::Reader => "reader",
+            GrantRole::Writer => "writer",
+        }
+    }
+
+    pub(super) fn from_db_str(value: &str) -> anyhow::Result<Self> {
+        match value {
+            "reader" => Ok(GrantRole::Reader),
+            "writer" => Ok(GrantRole::Writer),
+            other => anyhow::bail!("unknown persisted grant role `{other}`"),
+        }
+    }
+
     fn as_u8(self) -> u8 {
         match self {
             GrantRole::Reader => 1,
@@ -133,10 +163,10 @@ pub(super) struct ContentCut {
 
 /// One device-chain cut inside a `StreamRevoke`: `[device_fingerprint, seq, entry_hash]`.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(super) struct DeviceCut {
-    pub(super) device_fingerprint: DeviceFingerprint,
-    pub(super) seq: u64,
-    pub(super) hash: [u8; 32],
+pub(crate) struct DeviceCut {
+    pub(crate) device_fingerprint: DeviceFingerprint,
+    pub(crate) seq: u64,
+    pub(crate) hash: [u8; 32],
 }
 
 /// The ten control-log ops (§10). Field order is the frozen wire order; goldens pin the bytes.
@@ -853,6 +883,21 @@ mod tests {
         for et in 0..=9u32 {
             round_trip(&sample(et));
         }
+    }
+
+    #[test]
+    fn persisted_role_tokens_round_trip_and_reject_unknown_values() {
+        for (role, token) in [(DeviceRole::Member, "member"), (DeviceRole::Owner, "owner")] {
+            assert_eq!(role.as_db_str(), token);
+            assert_eq!(DeviceRole::from_db_str(token).unwrap(), role);
+        }
+        assert!(DeviceRole::from_db_str("admin").is_err());
+
+        for (role, token) in [(GrantRole::Reader, "reader"), (GrantRole::Writer, "writer")] {
+            assert_eq!(role.as_db_str(), token);
+            assert_eq!(GrantRole::from_db_str(token).unwrap(), role);
+        }
+        assert!(GrantRole::from_db_str("owner").is_err());
     }
 
     #[test]

--- a/crates/rag-rat-core/src/oplog/account/storage.rs
+++ b/crates/rag-rat-core/src/oplog/account/storage.rs
@@ -15,11 +15,12 @@ use rusqlite::{Connection, OptionalExtension, Transaction, TransactionBehavior, 
 
 use super::envelope::{self, AccountEntryHeader, VerifiedAccountEntry};
 use super::id::account_id_from_genesis_payload;
-use super::ops::{self, AccountOp, DecodedAccountOp};
+use super::ops::{self, AccountOp, DecodedAccountOp, DeviceCut, DeviceRole, GrantRole};
 use super::{AccountId, fold};
 use crate::oplog::cbor;
 use crate::oplog::device::DevicePublic;
 use crate::oplog::op::DeviceFingerprint;
+use crate::oplog::stream::StreamId;
 
 type EntryHash = [u8; 32];
 type BranchKey = (u8, DeviceFingerprint, Option<EntryHash>);
@@ -237,11 +238,352 @@ fn stored_status_for_exact_envelope(
 /// selection §16.2), and rewrite `accepted` + `account_entry_status` in one IMMEDIATE transaction
 /// so the `account_accepted_slot` partial unique index (I10a) never transiently double-accepts a
 /// slot.
-pub(super) fn refold_account(conn: &Connection, account_id: AccountId) -> anyhow::Result<()> {
+pub(crate) fn refold_account(conn: &Connection, account_id: AccountId) -> anyhow::Result<()> {
     let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
     refold_in_tx(&tx, account_id)?;
     tx.commit()?;
     Ok(())
+}
+
+/// Populate V064's derived authority tables from every account already present in the V059
+/// candidate DAG. The migration owns `tx`; replaying all accounts and recording V064 therefore
+/// commits as one writer-locked unit, with no source-history gap between the scan and ledger.
+pub(crate) fn backfill_authority_projection(tx: &Transaction<'_>) -> rusqlite::Result<()> {
+    let account_ids = {
+        let mut stmt =
+            tx.prepare("SELECT DISTINCT account_id FROM account_entries ORDER BY account_id")?;
+        stmt.query_map([], |row| row.get::<_, Vec<u8>>(0))?.collect::<rusqlite::Result<Vec<_>>>()?
+    };
+    for account_bytes in account_ids {
+        let result = fixed(&account_bytes)
+            .map(AccountId::from_bytes)
+            .and_then(|account_id| refold_in_tx(tx, account_id));
+        if let Err(err) = result {
+            return Err(rusqlite::Error::ToSqlConversionFailure(Box::new(std::io::Error::other(
+                format!("V064 authority backfill failed: {err:#}"),
+            ))));
+        }
+    }
+    Ok(())
+}
+
+/// Exact roster citation lookup over the V064 shadow projection. This is the hot-path seam for
+/// `/3` ingest: a keyed read, never a candidate-DAG replay. `auth_len` only detects a caller ahead
+/// of the local fold; a behind value is informational and never selects historical authority.
+pub(crate) fn roster_ref_effective(
+    conn: &Connection,
+    account_id: AccountId,
+    roster_ref: EntryHash,
+    device_fingerprint: DeviceFingerprint,
+    auth_len: u64,
+) -> anyhow::Result<fold::AuthorityQuery<fold::RosterAuthority>> {
+    let read_tx = Transaction::new_unchecked(conn, TransactionBehavior::Deferred)?;
+    let conn: &Connection = &read_tx;
+    if let Some(reason) = auth_len_preflight(conn, account_id, auth_len)? {
+        return Ok(fold::AuthorityQuery::Parked(reason));
+    }
+    let row: Option<(Vec<u8>, String, i64, Option<i64>)> = conn
+        .query_row(
+            "SELECT device_fingerprint, role, effective_at, closed_at
+             FROM account_roster_history WHERE account_id = ?1 AND roster_ref = ?2",
+            params![account_id.to_bytes().as_slice(), roster_ref.as_slice()],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+        )
+        .optional()?;
+    let Some((device, role, effective_at, closed_at)) = row else {
+        return missing_reference(conn, account_id, &roster_ref);
+    };
+    let authority = fold::RosterAuthority {
+        device_fingerprint: DeviceFingerprint::from_bytes(fixed(&device)?),
+        role: DeviceRole::from_db_str(&role)?,
+    };
+    if authority.device_fingerprint != device_fingerprint {
+        return Ok(fold::AuthorityQuery::Invalid(fold::AuthorityInvalidReason::WrongSubject));
+    }
+    validated_open_fact(authority, effective_at, closed_at)
+}
+
+pub(crate) fn owner_incarnation_effective(
+    conn: &Connection,
+    account_id: AccountId,
+    owner_id: EntryHash,
+    device_fingerprint: DeviceFingerprint,
+    auth_len: u64,
+) -> anyhow::Result<fold::AuthorityQuery<fold::OwnerAuthority>> {
+    let read_tx = Transaction::new_unchecked(conn, TransactionBehavior::Deferred)?;
+    let conn: &Connection = &read_tx;
+    if let Some(reason) = auth_len_preflight(conn, account_id, auth_len)? {
+        return Ok(fold::AuthorityQuery::Parked(reason));
+    }
+    let row: Option<(Vec<u8>, i64, Option<i64>)> = conn
+        .query_row(
+            "SELECT device_fingerprint, effective_at, closed_at
+             FROM account_owner_incarnations WHERE account_id = ?1 AND owner_id = ?2",
+            params![account_id.to_bytes().as_slice(), owner_id.as_slice()],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .optional()?;
+    let Some((device, effective_at, closed_at)) = row else {
+        return missing_reference(conn, account_id, &owner_id);
+    };
+    let authority =
+        fold::OwnerAuthority { device_fingerprint: DeviceFingerprint::from_bytes(fixed(&device)?) };
+    if authority.device_fingerprint != device_fingerprint {
+        return Ok(fold::AuthorityQuery::Invalid(fold::AuthorityInvalidReason::WrongSubject));
+    }
+    validated_open_fact(authority, effective_at, closed_at)
+}
+
+type StoredGrantRow = (Vec<u8>, Vec<u8>, String, i64, Option<i64>);
+
+pub(crate) fn grant_effective(
+    conn: &Connection,
+    owner_account_id: AccountId,
+    grant_id: EntryHash,
+    stream_id: StreamId,
+    grantee_account_id: AccountId,
+    auth_len: u64,
+) -> anyhow::Result<fold::AuthorityQuery<fold::GrantAuthority>> {
+    let read_tx = Transaction::new_unchecked(conn, TransactionBehavior::Deferred)?;
+    let conn: &Connection = &read_tx;
+    if let Some(reason) = auth_len_preflight(conn, owner_account_id, auth_len)? {
+        return Ok(fold::AuthorityQuery::Parked(reason));
+    }
+    let row: Option<StoredGrantRow> = conn
+        .query_row(
+            "SELECT stream_id, grantee_account_id, role, effective_at, closed_at
+             FROM account_stream_grants WHERE owner_account_id = ?1 AND grant_id = ?2",
+            params![owner_account_id.to_bytes().as_slice(), grant_id.as_slice()],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?, row.get(4)?)),
+        )
+        .optional()?;
+    let Some((stored_stream, stored_grantee, role, effective_at, closed_at)) = row else {
+        return missing_reference(conn, owner_account_id, &grant_id);
+    };
+    let authority = fold::GrantAuthority {
+        stream_id: StreamId::from_bytes(fixed(&stored_stream)?),
+        grantee_account_id: AccountId::from_bytes(fixed(&stored_grantee)?),
+        role: GrantRole::from_db_str(&role)?,
+    };
+    if authority.stream_id != stream_id || authority.grantee_account_id != grantee_account_id {
+        return Ok(fold::AuthorityQuery::Invalid(fold::AuthorityInvalidReason::WrongSubject));
+    }
+    validated_fact(authority, effective_at, closed_at)
+}
+
+/// Resolve a grant and the requesting device's revoke cut as ONE authorization decision. C2 must
+/// use this combined seam when admitting content: two independent calls could otherwise straddle
+/// a refold and combine an old effective grant with a new (or absent) cut projection.
+pub(crate) fn grant_effective_for_device(
+    conn: &Connection,
+    owner_account_id: AccountId,
+    grant_id: EntryHash,
+    stream_id: StreamId,
+    grantee_account_id: AccountId,
+    device_fingerprint: DeviceFingerprint,
+    auth_len: u64,
+) -> anyhow::Result<fold::AuthorityQuery<fold::GrantDeviceAuthority>> {
+    let read_tx = Transaction::new_unchecked(conn, TransactionBehavior::Deferred)?;
+    grant_effective_for_device_in_snapshot(
+        &read_tx,
+        owner_account_id,
+        grant_id,
+        stream_id,
+        grantee_account_id,
+        device_fingerprint,
+        auth_len,
+    )
+}
+
+fn grant_effective_for_device_in_snapshot(
+    conn: &Connection,
+    owner_account_id: AccountId,
+    grant_id: EntryHash,
+    stream_id: StreamId,
+    grantee_account_id: AccountId,
+    device_fingerprint: DeviceFingerprint,
+    auth_len: u64,
+) -> anyhow::Result<fold::AuthorityQuery<fold::GrantDeviceAuthority>> {
+    if let Some(reason) = auth_len_preflight(conn, owner_account_id, auth_len)? {
+        return Ok(fold::AuthorityQuery::Parked(reason));
+    }
+    let row: Option<StoredGrantRow> = conn
+        .query_row(
+            "SELECT stream_id, grantee_account_id, role, effective_at, closed_at
+             FROM account_stream_grants WHERE owner_account_id = ?1 AND grant_id = ?2",
+            params![owner_account_id.to_bytes().as_slice(), grant_id.as_slice()],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?, row.get(4)?)),
+        )
+        .optional()?;
+    let Some((stored_stream, stored_grantee, role, effective_at, closed_at)) = row else {
+        return missing_reference(conn, owner_account_id, &grant_id);
+    };
+    let grant = fold::GrantAuthority {
+        stream_id: StreamId::from_bytes(fixed(&stored_stream)?),
+        grantee_account_id: AccountId::from_bytes(fixed(&stored_grantee)?),
+        role: GrantRole::from_db_str(&role)?,
+    };
+    if grant.stream_id != stream_id || grant.grantee_account_id != grantee_account_id {
+        return Ok(fold::AuthorityQuery::Invalid(fold::AuthorityInvalidReason::WrongSubject));
+    }
+    let _ = validated_fact(grant, effective_at, closed_at)?;
+    let device_cut = load_grant_device_cut(conn, owner_account_id, grant_id, device_fingerprint)?;
+    let boundary = match (closed_at, device_cut) {
+        (None, None) => fold::GrantDeviceBoundary::Open,
+        (None, Some(_)) => anyhow::bail!("open grant unexpectedly has a persisted device cut"),
+        (Some(_), Some(cut)) => fold::GrantDeviceBoundary::Cut(cut),
+        (Some(_), None) => fold::GrantDeviceBoundary::Closed,
+    };
+    Ok(fold::AuthorityQuery::Effective(fold::GrantDeviceAuthority { grant, boundary }))
+}
+
+/// Resolve the owner-bound `StreamOwn` fact from the same authority snapshot as the `auth_len`
+/// preflight. A missing ownership fact is recoverable: the caller may simply be ahead of us.
+pub(crate) fn stream_owner_effective(
+    conn: &Connection,
+    account_id: AccountId,
+    stream_id: StreamId,
+    auth_len: u64,
+) -> anyhow::Result<fold::AuthorityQuery<EntryHash>> {
+    let read_tx = Transaction::new_unchecked(conn, TransactionBehavior::Deferred)?;
+    let conn: &Connection = &read_tx;
+    if let Some(reason) = auth_len_preflight(conn, account_id, auth_len)? {
+        return Ok(fold::AuthorityQuery::Parked(reason));
+    }
+    let row: Option<(Vec<u8>, i64)> = conn
+        .query_row(
+            "SELECT own_id, effective_at FROM account_stream_ownership
+             WHERE account_id = ?1 AND stream_id = ?2",
+            params![account_id.to_bytes().as_slice(), stream_id.to_bytes().as_slice()],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .optional()?;
+    let Some((own_id, effective_at)) = row else {
+        return Ok(fold::AuthorityQuery::Parked(fold::AuthorityParkReason::UnknownReference));
+    };
+    validated_fact(fixed(&own_id)?, effective_at, None)
+}
+
+/// Keyed per-device cut lookup for C2 content authorization. The grant's final effectiveness and
+/// the optional cut are read from one SQLite snapshot, so a concurrent refold cannot mix rounds.
+pub(super) fn grant_device_cut(
+    conn: &Connection,
+    owner_account_id: AccountId,
+    grant_id: EntryHash,
+    device_fingerprint: DeviceFingerprint,
+    auth_len: u64,
+) -> anyhow::Result<fold::AuthorityQuery<Option<DeviceCut>>> {
+    let read_tx = Transaction::new_unchecked(conn, TransactionBehavior::Deferred)?;
+    let conn: &Connection = &read_tx;
+    if let Some(reason) = auth_len_preflight(conn, owner_account_id, auth_len)? {
+        return Ok(fold::AuthorityQuery::Parked(reason));
+    }
+    let grant_exists: bool = conn.query_row(
+        "SELECT EXISTS(
+             SELECT 1 FROM account_stream_grants
+             WHERE owner_account_id = ?1 AND grant_id = ?2
+         )",
+        params![owner_account_id.to_bytes().as_slice(), grant_id.as_slice()],
+        |row| row.get(0),
+    )?;
+    if !grant_exists {
+        return missing_reference(conn, owner_account_id, &grant_id);
+    }
+    let cut = load_grant_device_cut(conn, owner_account_id, grant_id, device_fingerprint)?;
+    Ok(fold::AuthorityQuery::Effective(cut))
+}
+
+fn load_grant_device_cut(
+    conn: &Connection,
+    owner_account_id: AccountId,
+    grant_id: EntryHash,
+    device_fingerprint: DeviceFingerprint,
+) -> anyhow::Result<Option<DeviceCut>> {
+    let row: Option<(Vec<u8>, Vec<u8>)> = conn
+        .query_row(
+            "SELECT seq, entry_hash FROM account_stream_grant_cuts
+             WHERE owner_account_id = ?1 AND grant_id = ?2 AND device_fingerprint = ?3",
+            params![
+                owner_account_id.to_bytes().as_slice(),
+                grant_id.as_slice(),
+                device_fingerprint.to_bytes().as_slice(),
+            ],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .optional()?;
+    row.map(|(seq, hash)| -> anyhow::Result<DeviceCut> {
+        Ok(DeviceCut {
+            device_fingerprint,
+            seq: u64::from_be_bytes(fixed(&seq)?),
+            hash: fixed(&hash)?,
+        })
+    })
+    .transpose()
+}
+
+fn auth_len_preflight(
+    conn: &Connection,
+    account_id: AccountId,
+    auth_len: u64,
+) -> anyhow::Result<Option<fold::AuthorityParkReason>> {
+    let effective_count: Option<i64> = conn
+        .query_row(
+            "SELECT effective_count FROM account_auth_state WHERE account_id = ?1",
+            [account_id.to_bytes().as_slice()],
+            |row| row.get(0),
+        )
+        .optional()?;
+    let Some(effective_count) = effective_count else {
+        return Ok(Some(fold::AuthorityParkReason::UnknownReference));
+    };
+    if auth_len > u64::try_from(effective_count)? {
+        Ok(Some(fold::AuthorityParkReason::AuthLenAhead))
+    } else {
+        Ok(None)
+    }
+}
+
+fn missing_reference<T>(
+    conn: &Connection,
+    account_id: AccountId,
+    reference: &EntryHash,
+) -> anyhow::Result<fold::AuthorityQuery<T>> {
+    let stored_account: Option<Vec<u8>> = conn
+        .query_row(
+            "SELECT account_id FROM account_entries WHERE entry_hash = ?1",
+            [reference.as_slice()],
+            |row| row.get(0),
+        )
+        .optional()?;
+    Ok(match stored_account {
+        None => fold::AuthorityQuery::Parked(fold::AuthorityParkReason::UnknownReference),
+        Some(stored) if fixed(&stored)? != account_id.to_bytes() =>
+            fold::AuthorityQuery::Invalid(fold::AuthorityInvalidReason::WrongSubject),
+        Some(_) =>
+            fold::AuthorityQuery::Invalid(fold::AuthorityInvalidReason::ReferencedEntryNotEffective),
+    })
+}
+
+fn validated_fact<T>(
+    authority: T,
+    effective_at: i64,
+    closed_at: Option<i64>,
+) -> anyhow::Result<fold::AuthorityQuery<T>> {
+    let _ = (u64::try_from(effective_at)?, closed_at.map(u64::try_from).transpose()?);
+    Ok(fold::AuthorityQuery::Effective(authority))
+}
+
+fn validated_open_fact<T>(
+    authority: T,
+    effective_at: i64,
+    closed_at: Option<i64>,
+) -> anyhow::Result<fold::AuthorityQuery<T>> {
+    let fact = validated_fact(authority, effective_at, closed_at)?;
+    Ok(if closed_at.is_some() {
+        fold::AuthorityQuery::Invalid(fold::AuthorityInvalidReason::ReferencedEntryNotEffective)
+    } else {
+        fact
+    })
 }
 
 /// The refold body (caller owns the txn). Returns each entry_hash → its projected status.
@@ -287,7 +629,129 @@ fn refold_in_tx(
         )?;
         statuses.insert(row.entry_hash, status);
     }
+    rewrite_authority_projection(tx, account_id, &projection.history)?;
     Ok(statuses)
+}
+
+/// Replace every query-ready authority fact for this account. The caller's IMMEDIATE refold txn
+/// also owns accepted/status, so readers can never observe authority from a different fold round.
+fn rewrite_authority_projection(
+    tx: &Transaction<'_>,
+    account_id: AccountId,
+    history: &fold::AccountAuthHistory,
+) -> anyhow::Result<()> {
+    let account = account_id.to_bytes();
+    for table in [
+        "account_roster_history",
+        "account_owner_incarnations",
+        "account_stream_ownership",
+        "account_stream_grants",
+        "account_stream_grant_cuts",
+        "account_auth_state",
+    ] {
+        let account_column = match table {
+            "account_stream_grants" | "account_stream_grant_cuts" => "owner_account_id",
+            _ => "account_id",
+        };
+        tx.execute(&format!("DELETE FROM {table} WHERE {account_column} = ?1"), [
+            account.as_slice()
+        ])?;
+    }
+
+    let (classification, contested_depth) = match history.classification() {
+        fold::AccountClassification::Live => ("live", None),
+        fold::AccountClassification::Contested { state_before_depth } =>
+            ("contested", Some(i64::try_from(state_before_depth)?)),
+    };
+    let successor = history.contested_successor().map(AccountId::to_bytes);
+    tx.execute(
+        "INSERT INTO account_auth_state(
+             account_id, classification, contested_depth, successor_account_id, effective_count
+         ) VALUES (?1, ?2, ?3, ?4, ?5)",
+        params![
+            account.as_slice(),
+            classification,
+            contested_depth,
+            successor.as_ref().map(<[u8; 32]>::as_slice),
+            i64::try_from(history.effective_count())?,
+        ],
+    )?;
+
+    for (roster_ref, fact) in history.roster_facts() {
+        tx.execute(
+            "INSERT INTO account_roster_history(
+                 roster_ref, account_id, device_fingerprint, role, effective_at, closed_at
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            params![
+                roster_ref.as_slice(),
+                account.as_slice(),
+                fact.authority.device_fingerprint.to_bytes().as_slice(),
+                fact.authority.role.as_db_str(),
+                i64::try_from(fact.effective_at)?,
+                fact.closed_at.map(i64::try_from).transpose()?,
+            ],
+        )?;
+    }
+    for (owner_id, fact) in history.owner_incarnation_facts() {
+        tx.execute(
+            "INSERT INTO account_owner_incarnations(
+                 owner_id, account_id, device_fingerprint, effective_at, closed_at
+             ) VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![
+                owner_id.as_slice(),
+                account.as_slice(),
+                fact.authority.device_fingerprint.to_bytes().as_slice(),
+                i64::try_from(fact.effective_at)?,
+                fact.closed_at.map(i64::try_from).transpose()?,
+            ],
+        )?;
+    }
+    for (stream_id, fact) in history.stream_ownership_facts() {
+        tx.execute(
+            "INSERT INTO account_stream_ownership(stream_id, account_id, own_id, effective_at)
+             VALUES (?1, ?2, ?3, ?4)",
+            params![
+                stream_id.to_bytes().as_slice(),
+                account.as_slice(),
+                fact.own_id.as_slice(),
+                i64::try_from(fact.effective_at)?,
+            ],
+        )?;
+    }
+    for (grant_id, fact) in history.grant_facts() {
+        tx.execute(
+            "INSERT INTO account_stream_grants(
+                 grant_id, owner_account_id, stream_id, grantee_account_id, role, effective_at,
+                 closed_at
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            params![
+                grant_id.as_slice(),
+                account.as_slice(),
+                fact.authority.stream_id.to_bytes().as_slice(),
+                fact.authority.grantee_account_id.to_bytes().as_slice(),
+                fact.authority.role.as_db_str(),
+                i64::try_from(fact.effective_at)?,
+                fact.closed_at.map(i64::try_from).transpose()?,
+            ],
+        )?;
+    }
+    for (grant_id, cuts) in history.grant_cuts() {
+        for cut in cuts {
+            tx.execute(
+                "INSERT INTO account_stream_grant_cuts(
+                     grant_id, owner_account_id, device_fingerprint, seq, entry_hash
+                 ) VALUES (?1, ?2, ?3, ?4, ?5)",
+                params![
+                    grant_id.as_slice(),
+                    account.as_slice(),
+                    cut.device_fingerprint.to_bytes().as_slice(),
+                    cut.seq.to_be_bytes().as_slice(),
+                    cut.hash.as_slice(),
+                ],
+            )?;
+        }
+    }
+    Ok(())
 }
 
 /// Derive an author-chain-coherent, authority-closed projection without touching storage.
@@ -786,9 +1250,9 @@ fn is_device_add(verified: &VerifiedAccountEntry) -> bool {
     verified.header.entry_type == ops::entry_type::DEVICE_ADD
 }
 
-/// A stored 32-byte column as a fixed array (errors, never panics, on a wrong-length blob).
-fn fixed(bytes: &[u8]) -> anyhow::Result<[u8; 32]> {
-    bytes.try_into().map_err(|_| anyhow::anyhow!("stored hash is {} bytes, not 32", bytes.len()))
+/// A stored fixed-width blob as an array (errors, never panics, on a wrong-length value).
+fn fixed<const N: usize>(bytes: &[u8]) -> anyhow::Result<[u8; N]> {
+    bytes.try_into().map_err(|_| anyhow::anyhow!("stored blob is {} bytes, not {N}", bytes.len()))
 }
 
 /// The projected status of a single entry (§16.3), or `None` if the entry isn't stored (e.g. it is
@@ -815,8 +1279,9 @@ mod tests {
     use super::*;
     use crate::index::schema;
     use crate::oplog::account::envelope::sign_account_entry;
-    use crate::oplog::account::ops::{DeviceRole, encode, entry_type_of};
+    use crate::oplog::account::ops::{DeviceCut, DeviceRole, GrantRole};
     use crate::oplog::device::{DeviceSecret, DeviceX25519Secret};
+    use crate::oplog::stream::{self, StreamSpec, StreamSpecV2};
 
     const NOW: i64 = 1_700_000_000_000;
 
@@ -851,7 +1316,7 @@ mod tests {
             created_at_ms: NOW as u64,
             label: None,
         };
-        let payload = encode(&op).unwrap();
+        let payload = ops::encode(&op).unwrap();
         let account_id = account_id_from_genesis_payload(&payload);
         let header = AccountEntryHeader {
             account_id,
@@ -880,7 +1345,7 @@ mod tests {
         authority_ref: Option<[u8; 32]>,
         op: &AccountOp,
     ) -> (Vec<u8>, [u8; 32]) {
-        let payload = encode(op).unwrap();
+        let payload = ops::encode(op).unwrap();
         let header = AccountEntryHeader {
             account_id,
             log_id: 0,
@@ -888,7 +1353,7 @@ mod tests {
             seq,
             prev_hash: prev,
             parent_ref: None,
-            entry_type: entry_type_of(op),
+            entry_type: ops::entry_type_of(op),
             op_version: 1,
             crypto_suite: 0,
             auth_len: 1,
@@ -909,6 +1374,21 @@ mod tests {
         }
     }
 
+    fn stream_own(account_id: AccountId) -> (crate::oplog::stream::StreamId, AccountOp) {
+        let spec = StreamSpecV2 {
+            owner_account_id: account_id,
+            policy: StreamSpec {
+                repo_set: vec!["repo-a".to_string()],
+                kind_allow_list: None,
+                relation_policy: None,
+                node_overrides: Vec::new(),
+            },
+        };
+        let stream_id = stream::derive_v2(&spec).unwrap();
+        let stream_spec_bytes = stream::canonical_spec_v2_bytes(&spec).unwrap();
+        (stream_id, AccountOp::StreamOwn { stream_id, stream_spec_bytes })
+    }
+
     fn device_remove(dev: &Dev, control_cut: super::super::cut::Cut) -> AccountOp {
         AccountOp::DeviceRemove {
             device_fingerprint: dev.fp,
@@ -926,6 +1406,23 @@ mod tests {
             control_cut: super::super::cut::Cut::Empty,
             secrets_cut: super::super::cut::Cut::Empty,
             reason: "demoted".to_string(),
+        }
+    }
+
+    fn cut_extend_ctrl(
+        account_id: AccountId,
+        subject: &Dev,
+        new_seq: u64,
+        new_entry_hash: EntryHash,
+    ) -> AccountOp {
+        AccountOp::CutExtend {
+            chain_kind: super::super::ops::ChainKind::Ctrl,
+            stream_id: None,
+            incarnation_id: None,
+            subject_account_id: account_id,
+            device_fingerprint: subject.fp,
+            new_seq,
+            new_entry_hash,
         }
     }
 
@@ -987,6 +1484,517 @@ mod tests {
     }
 
     #[test]
+    fn refold_projects_stream_authority_and_revoke_cuts_for_keyed_queries() {
+        let conn = db();
+        let founder = Dev::new(1);
+        let grantee_device = Dev::new(2);
+        let grantee = AccountId::from_bytes([0x44; 32]);
+        let (account_id, genesis_bytes, genesis_hash) = genesis(&founder);
+        account_ingest(&conn, &genesis_bytes, NOW).unwrap();
+
+        let (stream_id, own_op) = stream_own(account_id);
+        let (own_bytes, own_hash) =
+            op(account_id, &founder, 1, Some(genesis_hash), Some(genesis_hash), &own_op);
+        account_ingest(&conn, &own_bytes, NOW + 1).unwrap();
+        let grant_op = AccountOp::StreamGrant {
+            stream_id,
+            grantee_account_id: grantee,
+            grant_role: GrantRole::Writer,
+        };
+        let (grant_bytes, grant_id) =
+            op(account_id, &founder, 2, Some(own_hash), Some(genesis_hash), &grant_op);
+        account_ingest(&conn, &grant_bytes, NOW + 2).unwrap();
+        assert!(matches!(
+            grant_effective_for_device(
+                &conn,
+                account_id,
+                grant_id,
+                stream_id,
+                grantee,
+                grantee_device.fp,
+                3,
+            )
+            .unwrap(),
+            fold::AuthorityQuery::Effective(fold::GrantDeviceAuthority {
+                boundary: fold::GrantDeviceBoundary::Open,
+                ..
+            }),
+        ));
+        let cut_hash = [0x99; 32];
+        let revoke_op = AccountOp::StreamRevoke {
+            stream_id,
+            grantee_account_id: grantee,
+            grant_id,
+            device_cuts: vec![DeviceCut {
+                device_fingerprint: grantee_device.fp,
+                seq: u64::MAX,
+                hash: cut_hash,
+            }],
+            reason: "access ended".to_string(),
+        };
+        let (revoke_bytes, _) =
+            op(account_id, &founder, 3, Some(grant_id), Some(genesis_hash), &revoke_op);
+        account_ingest(&conn, &revoke_bytes, NOW + 3).unwrap();
+
+        let state: (String, i64) = conn
+            .query_row(
+                "SELECT classification, effective_count FROM account_auth_state
+                 WHERE account_id = ?1",
+                [account_id.to_bytes().as_slice()],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(state, ("live".to_string(), 4));
+        let grant: (String, i64, Option<i64>) = conn
+            .query_row(
+                "SELECT role, effective_at, closed_at FROM account_stream_grants
+                 WHERE grant_id = ?1",
+                [grant_id.as_slice()],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(grant, ("writer".to_string(), 2, Some(3)));
+        let cut: (Vec<u8>, Vec<u8>, Vec<u8>) = conn
+            .query_row(
+                "SELECT device_fingerprint, seq, entry_hash
+                 FROM account_stream_grant_cuts WHERE grant_id = ?1",
+                [grant_id.as_slice()],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(
+            cut,
+            (
+                grantee_device.fp.to_bytes().to_vec(),
+                u64::MAX.to_be_bytes().to_vec(),
+                cut_hash.to_vec(),
+            ),
+        );
+        assert_eq!(
+            stream_owner_effective(&conn, account_id, stream_id, 4).unwrap(),
+            fold::AuthorityQuery::Effective(own_hash),
+        );
+        assert_eq!(
+            grant_device_cut(&conn, account_id, grant_id, grantee_device.fp, 4).unwrap(),
+            fold::AuthorityQuery::Effective(Some(DeviceCut {
+                device_fingerprint: grantee_device.fp,
+                seq: u64::MAX,
+                hash: cut_hash,
+            })),
+        );
+        assert_eq!(
+            grant_effective_for_device(
+                &conn,
+                account_id,
+                grant_id,
+                stream_id,
+                grantee,
+                grantee_device.fp,
+                4,
+            )
+            .unwrap(),
+            fold::AuthorityQuery::Effective(fold::GrantDeviceAuthority {
+                grant: fold::GrantAuthority {
+                    stream_id,
+                    grantee_account_id: grantee,
+                    role: GrantRole::Writer,
+                },
+                boundary: fold::GrantDeviceBoundary::Cut(DeviceCut {
+                    device_fingerprint: grantee_device.fp,
+                    seq: u64::MAX,
+                    hash: cut_hash,
+                }),
+            }),
+        );
+        assert_eq!(
+            grant_device_cut(&conn, account_id, grant_id, Dev::new(3).fp, 4).unwrap(),
+            fold::AuthorityQuery::Effective(None),
+        );
+        assert!(matches!(
+            grant_effective_for_device(
+                &conn,
+                account_id,
+                grant_id,
+                stream_id,
+                grantee,
+                Dev::new(3).fp,
+                4,
+            )
+            .unwrap(),
+            fold::AuthorityQuery::Effective(fold::GrantDeviceAuthority {
+                boundary: fold::GrantDeviceBoundary::Closed,
+                ..
+            }),
+        ));
+        assert_eq!(
+            grant_device_cut(
+                &conn,
+                AccountId::from_bytes([0x66; 32]),
+                grant_id,
+                grantee_device.fp,
+                0,
+            )
+            .unwrap(),
+            fold::AuthorityQuery::Parked(fold::AuthorityParkReason::UnknownReference),
+        );
+        assert!(matches!(
+            grant_effective(&conn, account_id, grant_id, stream_id, grantee, 3).unwrap(),
+            fold::AuthorityQuery::Effective(fold::GrantAuthority { role: GrantRole::Writer, .. })
+        ));
+        assert_eq!(
+            grant_effective(&conn, account_id, grant_id, stream_id, grantee, 4).unwrap(),
+            fold::AuthorityQuery::Effective(fold::GrantAuthority {
+                stream_id,
+                grantee_account_id: grantee,
+                role: GrantRole::Writer,
+            }),
+        );
+        assert!(matches!(
+            roster_ref_effective(&conn, account_id, genesis_hash, founder.fp, 1).unwrap(),
+            fold::AuthorityQuery::Effective(fold::RosterAuthority { role: DeviceRole::Owner, .. })
+        ));
+        assert!(matches!(
+            owner_incarnation_effective(&conn, account_id, genesis_hash, founder.fp, 1).unwrap(),
+            fold::AuthorityQuery::Effective(_)
+        ));
+        assert_eq!(
+            grant_effective(&conn, account_id, [0xaa; 32], stream_id, grantee, 4).unwrap(),
+            fold::AuthorityQuery::Parked(fold::AuthorityParkReason::UnknownReference),
+        );
+
+        // Corrupt projection state must fail closed: an open grant cannot legitimately retain a
+        // revoke cut from an older projection round.
+        conn.execute(
+            "UPDATE account_stream_grants SET closed_at = NULL
+             WHERE owner_account_id = ?1 AND grant_id = ?2",
+            params![account_id.to_bytes().as_slice(), grant_id.as_slice()],
+        )
+        .unwrap();
+        let error = grant_effective_for_device(
+            &conn,
+            account_id,
+            grant_id,
+            stream_id,
+            grantee,
+            grantee_device.fp,
+            4,
+        )
+        .unwrap_err();
+        assert!(
+            error.to_string().contains("open grant unexpectedly has a persisted device cut"),
+            "unexpected corrupt-projection error: {error:#}",
+        );
+    }
+
+    #[test]
+    fn combined_grant_query_never_mixes_projection_rounds_across_connections() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("grant-snapshot.db");
+        let setup = Connection::open(&path).unwrap();
+        schema::apply(&setup).unwrap();
+        setup.execute_batch("PRAGMA journal_mode = WAL;").unwrap();
+
+        let founder = Dev::new(1);
+        let grantee_device = Dev::new(2);
+        let grantee = AccountId::from_bytes([0x44; 32]);
+        let (account_id, genesis_bytes, genesis_hash) = genesis(&founder);
+        account_ingest(&setup, &genesis_bytes, NOW).unwrap();
+        let (stream_id, own_op) = stream_own(account_id);
+        let (own_bytes, own_hash) =
+            op(account_id, &founder, 1, Some(genesis_hash), Some(genesis_hash), &own_op);
+        account_ingest(&setup, &own_bytes, NOW + 1).unwrap();
+        let grant_op = AccountOp::StreamGrant {
+            stream_id,
+            grantee_account_id: grantee,
+            grant_role: GrantRole::Writer,
+        };
+        let (grant_bytes, grant_id) =
+            op(account_id, &founder, 2, Some(own_hash), Some(genesis_hash), &grant_op);
+        account_ingest(&setup, &grant_bytes, NOW + 2).unwrap();
+        let cut_hash = [0x99; 32];
+        let revoke_op = AccountOp::StreamRevoke {
+            stream_id,
+            grantee_account_id: grantee,
+            grant_id,
+            device_cuts: vec![DeviceCut {
+                device_fingerprint: grantee_device.fp,
+                seq: 7,
+                hash: cut_hash,
+            }],
+            reason: "access ended".to_string(),
+        };
+        let (revoke_bytes, _) =
+            op(account_id, &founder, 3, Some(grant_id), Some(genesis_hash), &revoke_op);
+        account_ingest(&setup, &revoke_bytes, NOW + 3).unwrap();
+        drop(setup);
+
+        let reader = Connection::open(&path).unwrap();
+        let writer = Connection::open(&path).unwrap();
+        let snapshot = Transaction::new_unchecked(&reader, TransactionBehavior::Deferred).unwrap();
+        assert_eq!(auth_len_preflight(&snapshot, account_id, 4).unwrap(), None);
+
+        let write_tx = Transaction::new_unchecked(&writer, TransactionBehavior::Immediate).unwrap();
+        write_tx
+            .execute(
+                "DELETE FROM account_stream_grant_cuts
+                 WHERE owner_account_id = ?1 AND grant_id = ?2",
+                params![account_id.to_bytes().as_slice(), grant_id.as_slice()],
+            )
+            .unwrap();
+        write_tx
+            .execute(
+                "UPDATE account_stream_grants SET closed_at = NULL
+                 WHERE owner_account_id = ?1 AND grant_id = ?2",
+                params![account_id.to_bytes().as_slice(), grant_id.as_slice()],
+            )
+            .unwrap();
+        write_tx.commit().unwrap();
+
+        let old_round = grant_effective_for_device_in_snapshot(
+            &snapshot,
+            account_id,
+            grant_id,
+            stream_id,
+            grantee,
+            grantee_device.fp,
+            4,
+        )
+        .unwrap();
+        assert!(matches!(
+            old_round,
+            fold::AuthorityQuery::Effective(fold::GrantDeviceAuthority {
+                boundary: fold::GrantDeviceBoundary::Cut(DeviceCut { seq: 7, hash, .. }),
+                ..
+            }) if hash == cut_hash
+        ));
+        drop(snapshot);
+
+        assert!(matches!(
+            grant_effective_for_device(
+                &reader,
+                account_id,
+                grant_id,
+                stream_id,
+                grantee,
+                grantee_device.fp,
+                4,
+            )
+            .unwrap(),
+            fold::AuthorityQuery::Effective(fold::GrantDeviceAuthority {
+                boundary: fold::GrantDeviceBoundary::Open,
+                ..
+            }),
+        ));
+    }
+
+    #[test]
+    fn authority_projection_failure_rolls_back_candidate_status_and_prior_shadow_state() {
+        let conn = db();
+        let founder = Dev::new(1);
+        let (account_id, genesis_bytes, genesis_hash) = genesis(&founder);
+        account_ingest(&conn, &genesis_bytes, NOW).unwrap();
+        conn.execute_batch(
+            "CREATE TRIGGER fail_stream_authority_projection
+             BEFORE INSERT ON account_stream_ownership
+             BEGIN SELECT RAISE(ABORT, 'injected authority projection failure'); END;",
+        )
+        .unwrap();
+        let (_, own_op) = stream_own(account_id);
+        let (own_bytes, own_hash) =
+            op(account_id, &founder, 1, Some(genesis_hash), Some(genesis_hash), &own_op);
+
+        assert!(account_ingest(&conn, &own_bytes, NOW + 1).is_err());
+        let candidate_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM account_entries WHERE account_id = ?1",
+                [account_id.to_bytes().as_slice()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(candidate_count, 1, "the newly inserted candidate rolled back");
+        assert_eq!(status(&conn, &own_hash), None, "its projected status rolled back");
+        let effective_count: i64 = conn
+            .query_row(
+                "SELECT effective_count FROM account_auth_state WHERE account_id = ?1",
+                [account_id.to_bytes().as_slice()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(effective_count, 1, "the prior shadow projection survived intact");
+    }
+
+    #[test]
+    fn v064_forward_migration_backfills_populated_account_histories() {
+        let conn = db();
+        let founder = Dev::new(1);
+        let (account_id, genesis_bytes, genesis_hash) = genesis(&founder);
+        account_ingest(&conn, &genesis_bytes, NOW).unwrap();
+        let (stream_id, own_op) = stream_own(account_id);
+        let (own_bytes, own_hash) =
+            op(account_id, &founder, 1, Some(genesis_hash), Some(genesis_hash), &own_op);
+        account_ingest(&conn, &own_bytes, NOW + 1).unwrap();
+
+        conn.execute("DELETE FROM schema_version WHERE id = '064_account_authority_projection'", [
+        ])
+        .unwrap();
+        conn.execute_batch(
+            "DROP TABLE account_stream_grant_cuts;
+             DROP TABLE account_stream_grants;
+             DROP TABLE account_stream_ownership;
+             DROP TABLE account_owner_incarnations;
+             DROP TABLE account_roster_history;
+             DROP TABLE account_auth_state;",
+        )
+        .unwrap();
+
+        schema::migrate_forward(&conn).unwrap();
+        assert_eq!(
+            stream_owner_effective(&conn, account_id, stream_id, 2).unwrap(),
+            fold::AuthorityQuery::Effective(own_hash),
+        );
+        assert!(matches!(
+            roster_ref_effective(&conn, account_id, genesis_hash, founder.fp, 2).unwrap(),
+            fold::AuthorityQuery::Effective(fold::RosterAuthority { role: DeviceRole::Owner, .. })
+        ));
+        assert_eq!(schema::status(&conn).unwrap().current_version, 64);
+    }
+
+    #[test]
+    fn v064_backfill_failure_rolls_back_ddl_projection_and_ledger_together() {
+        let conn = db();
+        conn.execute("DELETE FROM schema_version WHERE id = '064_account_authority_projection'", [
+        ])
+        .unwrap();
+        conn.execute_batch(
+            "DROP TABLE account_stream_grant_cuts;
+             DROP TABLE account_stream_grants;
+             DROP TABLE account_stream_ownership;
+             DROP TABLE account_owner_incarnations;
+             DROP TABLE account_roster_history;
+             DROP TABLE account_auth_state;",
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO account_entries(
+                 entry_hash, account_id, log_id, device_fingerprint, seq, entry_type,
+                 accepted, signed_bytes, received_at_ms
+             ) VALUES (?1, ?2, 0, ?1, 0, 99, 0, X'00', 0)",
+            params![[0x11u8; 32].as_slice(), [0x22u8; 31].as_slice()],
+        )
+        .unwrap();
+
+        assert!(schema::migrate_forward(&conn).is_err());
+        let table_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master
+                 WHERE type = 'table' AND name = 'account_auth_state'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(table_count, 0, "V064 DDL rolled back with the failed backfill");
+        let ledger_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM schema_version
+                 WHERE id = '064_account_authority_projection'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(ledger_count, 0, "a failed projection never claims V064 was applied");
+    }
+
+    #[test]
+    fn authority_queries_fail_closed_on_subject_mismatch_ahead_state_and_corrupt_rows() {
+        let conn = db();
+        let founder = Dev::new(1);
+        let grantee = AccountId::from_bytes([0x44; 32]);
+        let (account_id, genesis_bytes, genesis_hash) = genesis(&founder);
+        account_ingest(&conn, &genesis_bytes, NOW).unwrap();
+        let (stream_id, own_op) = stream_own(account_id);
+        let (own_bytes, own_hash) =
+            op(account_id, &founder, 1, Some(genesis_hash), Some(genesis_hash), &own_op);
+        account_ingest(&conn, &own_bytes, NOW + 1).unwrap();
+        let (grant_bytes, grant_id) = op(
+            account_id,
+            &founder,
+            2,
+            Some(own_hash),
+            Some(genesis_hash),
+            &AccountOp::StreamGrant {
+                stream_id,
+                grantee_account_id: grantee,
+                grant_role: GrantRole::Reader,
+            },
+        );
+        account_ingest(&conn, &grant_bytes, NOW + 2).unwrap();
+        let (self_grant_bytes, self_grant_id) = op(
+            account_id,
+            &founder,
+            3,
+            Some(grant_id),
+            Some(genesis_hash),
+            &AccountOp::StreamGrant {
+                stream_id,
+                grantee_account_id: account_id,
+                grant_role: GrantRole::Reader,
+            },
+        );
+        account_ingest(&conn, &self_grant_bytes, NOW + 3).unwrap();
+
+        assert_eq!(
+            grant_effective(&conn, account_id, grant_id, stream_id, grantee, 99).unwrap(),
+            fold::AuthorityQuery::Parked(fold::AuthorityParkReason::AuthLenAhead),
+        );
+        assert_eq!(
+            grant_effective(
+                &conn,
+                account_id,
+                grant_id,
+                crate::oplog::stream::StreamId::from_bytes([0x55; 32]),
+                grantee,
+                3,
+            )
+            .unwrap(),
+            fold::AuthorityQuery::Invalid(fold::AuthorityInvalidReason::WrongSubject),
+        );
+        assert_eq!(
+            grant_effective(&conn, account_id, self_grant_id, stream_id, account_id, 3).unwrap(),
+            fold::AuthorityQuery::Invalid(
+                fold::AuthorityInvalidReason::ReferencedEntryNotEffective,
+            ),
+        );
+
+        conn.execute("UPDATE account_stream_grants SET role = 'admin' WHERE grant_id = ?1", [
+            grant_id.as_slice(),
+        ])
+        .unwrap();
+        assert!(grant_effective(&conn, account_id, grant_id, stream_id, grantee, 3).is_err());
+        conn.execute(
+            "UPDATE account_stream_grants SET role = 'reader', effective_at = -1
+             WHERE grant_id = ?1",
+            [grant_id.as_slice()],
+        )
+        .unwrap();
+        assert!(grant_effective(&conn, account_id, grant_id, stream_id, grantee, 3).is_err());
+        conn.execute("UPDATE account_stream_grants SET effective_at = 2 WHERE grant_id = ?1", [
+            grant_id.as_slice(),
+        ])
+        .unwrap();
+        conn.execute(
+            "UPDATE account_stream_ownership SET own_id = ?2 WHERE stream_id = ?1",
+            params![stream_id.to_bytes().as_slice(), [0u8; 31].as_slice()],
+        )
+        .unwrap();
+        assert!(stream_owner_effective(&conn, account_id, stream_id, 3).is_err());
+        conn.execute("UPDATE account_auth_state SET effective_count = -1 WHERE account_id = ?1", [
+            account_id.to_bytes().as_slice(),
+        ])
+        .unwrap();
+        assert!(roster_ref_effective(&conn, account_id, genesis_hash, founder.fp, 0).is_err());
+    }
+
+    #[test]
     fn malformed_envelopes_and_wrong_genesis_self_hashes_never_touch_storage() {
         let conn = db();
         assert!(matches!(account_ingest(&conn, &[0xff], NOW).unwrap(), IngestOutcome::Rejected(_)));
@@ -999,7 +2007,7 @@ mod tests {
             created_at_ms: NOW as u64,
             label: None,
         };
-        let payload = encode(&genesis_op).unwrap();
+        let payload = ops::encode(&genesis_op).unwrap();
         let wrong_account = AccountId::from_bytes([0x55; 32]);
         assert_ne!(wrong_account, account_id_from_genesis_payload(&payload));
         let header = AccountEntryHeader {
@@ -1045,7 +2053,7 @@ mod tests {
             created_at_ms: NOW as u64,
             label: None,
         };
-        let payload = encode(&op).unwrap();
+        let payload = ops::encode(&op).unwrap();
         let header = AccountEntryHeader {
             account_id: acct,
             log_id: 0,
@@ -1749,6 +2757,147 @@ mod tests {
     }
 
     #[test]
+    fn late_cut_and_extend_atomically_remove_then_restore_authority_shadow_rows() {
+        let conn = db();
+        let (founder, owner, d, e, g) =
+            (Dev::new(1), Dev::new(2), Dev::new(5), Dev::new(6), Dev::new(7));
+        let (account_id, genesis_bytes, genesis_hash) = genesis(&founder);
+        account_ingest(&conn, &genesis_bytes, NOW).unwrap();
+        let (add_owner_bytes, add_owner) = op(
+            account_id,
+            &founder,
+            1,
+            Some(genesis_hash),
+            Some(genesis_hash),
+            &device_add(&owner, DeviceRole::Owner),
+        );
+        account_ingest(&conn, &add_owner_bytes, NOW + 1).unwrap();
+        let (b0_bytes, b0) =
+            op(account_id, &owner, 0, None, Some(add_owner), &device_add(&d, DeviceRole::Member));
+        let (b1_bytes, b1) = op(
+            account_id,
+            &owner,
+            1,
+            Some(b0),
+            Some(add_owner),
+            &device_add(&e, DeviceRole::Member),
+        );
+        let (b2_bytes, b2) = op(
+            account_id,
+            &owner,
+            2,
+            Some(b1),
+            Some(add_owner),
+            &device_add(&g, DeviceRole::Member),
+        );
+        for (offset, bytes) in [&b0_bytes, &b1_bytes, &b2_bytes].into_iter().enumerate() {
+            account_ingest(&conn, bytes, NOW + 2 + i64::try_from(offset).unwrap()).unwrap();
+        }
+        assert!(matches!(
+            roster_ref_effective(&conn, account_id, b2, g.fp, 5).unwrap(),
+            fold::AuthorityQuery::Effective(_)
+        ));
+
+        let (remove_bytes, remove_hash) = op(
+            account_id,
+            &founder,
+            2,
+            Some(add_owner),
+            Some(genesis_hash),
+            &device_remove(&owner, super::super::cut::Cut::At { seq: 0, hash: b0 }),
+        );
+        account_ingest(&conn, &remove_bytes, NOW + 5).unwrap();
+        assert_eq!(status(&conn, &b1).as_deref(), Some("condemned"));
+        assert_eq!(status(&conn, &b2).as_deref(), Some("condemned"));
+        assert_eq!(
+            roster_ref_effective(&conn, account_id, b2, g.fp, 4).unwrap(),
+            fold::AuthorityQuery::Invalid(
+                fold::AuthorityInvalidReason::ReferencedEntryNotEffective
+            ),
+        );
+
+        let (extend_bytes, _) = op(
+            account_id,
+            &founder,
+            3,
+            Some(remove_hash),
+            Some(genesis_hash),
+            &cut_extend_ctrl(account_id, &owner, 2, b2),
+        );
+        account_ingest(&conn, &extend_bytes, NOW + 6).unwrap();
+        assert_eq!(status(&conn, &b1).as_deref(), Some("accepted"));
+        assert_eq!(status(&conn, &b2).as_deref(), Some("accepted"));
+        assert!(matches!(
+            roster_ref_effective(&conn, account_id, b2, g.fp, 7).unwrap(),
+            fold::AuthorityQuery::Effective(_)
+        ));
+    }
+
+    #[test]
+    fn contested_fold_persists_the_state_before_depth_and_halts_authority_mutation() {
+        let conn = db();
+        let (founder, a, b) = (Dev::new(1), Dev::new(2), Dev::new(3));
+        let (account_id, genesis_bytes, genesis_hash) = genesis(&founder);
+        account_ingest(&conn, &genesis_bytes, NOW).unwrap();
+        let (add_a_bytes, add_a) = op(
+            account_id,
+            &founder,
+            1,
+            Some(genesis_hash),
+            Some(genesis_hash),
+            &device_add(&a, DeviceRole::Owner),
+        );
+        let (add_b_bytes, add_b) = op(
+            account_id,
+            &founder,
+            2,
+            Some(add_a),
+            Some(genesis_hash),
+            &device_add(&b, DeviceRole::Owner),
+        );
+        account_ingest(&conn, &add_a_bytes, NOW + 1).unwrap();
+        account_ingest(&conn, &add_b_bytes, NOW + 2).unwrap();
+        let (remove_b_bytes, remove_b) = op(
+            account_id,
+            &a,
+            0,
+            None,
+            Some(add_a),
+            &device_remove(&b, super::super::cut::Cut::Empty),
+        );
+        let (remove_a_bytes, remove_a) = op(
+            account_id,
+            &b,
+            0,
+            None,
+            Some(add_b),
+            &device_remove(&a, super::super::cut::Cut::Empty),
+        );
+        account_ingest(&conn, &remove_b_bytes, NOW + 3).unwrap();
+        account_ingest(&conn, &remove_a_bytes, NOW + 4).unwrap();
+
+        let state: (String, Option<i64>, Option<Vec<u8>>, i64) = conn
+            .query_row(
+                "SELECT classification, contested_depth, successor_account_id, effective_count
+                 FROM account_auth_state WHERE account_id = ?1",
+                [account_id.to_bytes().as_slice()],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .unwrap();
+        assert_eq!(state, ("contested".to_string(), Some(1), None, 3));
+        assert_eq!(status(&conn, &remove_a).as_deref(), Some("parked"));
+        assert_eq!(status(&conn, &remove_b).as_deref(), Some("parked"));
+        let owner_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM account_owner_incarnations WHERE account_id = ?1",
+                [account_id.to_bytes().as_slice()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(owner_count, 3, "only state-before owner incarnations are projected");
+    }
+
+    #[test]
     fn an_equivocation_accepts_one_head_and_forks_the_other() {
         // The founder equivocates: two DIFFERENT seq-1 entries on its own chain. Both fold
         // effective, but only one can occupy the (device, seq) slot (I10a) — the smaller
@@ -1841,6 +2990,76 @@ mod tests {
             assert_eq!(status(&conn, &add_c).as_deref(), Some("forked"));
             assert_eq!(status(&conn, &add_d).as_deref(), Some("forked"));
         }
+    }
+
+    #[test]
+    fn roster_and_owner_projection_tracks_role_changes_and_closures() {
+        let conn = db();
+        let founder = Dev::new(1);
+        let member = Dev::new(2);
+        let (account_id, genesis_bytes, genesis_hash) = genesis(&founder);
+        account_ingest(&conn, &genesis_bytes, NOW).unwrap();
+
+        let (add_bytes, add) = op(
+            account_id,
+            &founder,
+            1,
+            Some(genesis_hash),
+            Some(genesis_hash),
+            &device_add(&member, DeviceRole::Member),
+        );
+        account_ingest(&conn, &add_bytes, NOW + 1).unwrap();
+        let (promote_bytes, promote) =
+            op(account_id, &founder, 2, Some(add), Some(genesis_hash), &AccountOp::OwnerPromote {
+                device_fingerprint: member.fp,
+            });
+        account_ingest(&conn, &promote_bytes, NOW + 2).unwrap();
+        assert_eq!(
+            roster_ref_effective(&conn, account_id, add, member.fp, 3).unwrap(),
+            fold::AuthorityQuery::Effective(fold::RosterAuthority {
+                device_fingerprint: member.fp,
+                role: DeviceRole::Owner,
+            }),
+        );
+
+        let (demote_bytes, demote) = op(
+            account_id,
+            &founder,
+            3,
+            Some(promote),
+            Some(genesis_hash),
+            &owner_demote(&member, promote),
+        );
+        account_ingest(&conn, &demote_bytes, NOW + 3).unwrap();
+        assert_eq!(
+            roster_ref_effective(&conn, account_id, add, member.fp, 4).unwrap(),
+            fold::AuthorityQuery::Effective(fold::RosterAuthority {
+                device_fingerprint: member.fp,
+                role: DeviceRole::Member,
+            }),
+        );
+        assert_eq!(
+            owner_incarnation_effective(&conn, account_id, promote, member.fp, 4).unwrap(),
+            fold::AuthorityQuery::Invalid(
+                fold::AuthorityInvalidReason::ReferencedEntryNotEffective,
+            ),
+        );
+
+        let (remove_bytes, _) = op(
+            account_id,
+            &founder,
+            4,
+            Some(demote),
+            Some(genesis_hash),
+            &device_remove(&member, super::super::cut::Cut::Empty),
+        );
+        account_ingest(&conn, &remove_bytes, NOW + 4).unwrap();
+        assert_eq!(
+            roster_ref_effective(&conn, account_id, add, member.fp, 5).unwrap(),
+            fold::AuthorityQuery::Invalid(
+                fold::AuthorityInvalidReason::ReferencedEntryNotEffective,
+            ),
+        );
     }
 
     #[test]
@@ -2062,7 +3281,7 @@ mod tests {
         let (acct, gbytes, gh) = genesis(&founder);
         account_ingest(&conn, &gbytes, NOW).unwrap();
         let b = Dev::new(2);
-        let payload = encode(&device_add(&b, DeviceRole::Member)).unwrap();
+        let payload = ops::encode(&device_add(&b, DeviceRole::Member)).unwrap();
         let gap_header = AccountEntryHeader {
             account_id: acct,
             log_id: 0,
@@ -2099,7 +3318,7 @@ mod tests {
         let founder = Dev::new(1);
         let (acct, _gbytes, gh) = genesis(&founder);
         let b = Dev::new(2);
-        let payload = encode(&device_add(&b, DeviceRole::Member)).unwrap();
+        let payload = ops::encode(&device_add(&b, DeviceRole::Member)).unwrap();
         let header = AccountEntryHeader {
             account_id: acct,
             log_id: 0,
@@ -2187,7 +3406,7 @@ mod tests {
         let founder = Dev::new(1);
         let (acct, _gbytes, gh) = genesis(&founder);
         let b = Dev::new(2);
-        let payload = encode(&device_add(&b, DeviceRole::Owner)).unwrap();
+        let payload = ops::encode(&device_add(&b, DeviceRole::Owner)).unwrap();
         let header = AccountEntryHeader {
             account_id: acct,
             log_id: 0,

--- a/crates/rag-rat-core/src/oplog/mod.rs
+++ b/crates/rag-rat-core/src/oplog/mod.rs
@@ -42,10 +42,21 @@ mod project;
 mod store;
 mod stream;
 
-// The op-log's first crate-internal API surface (#524): the MINTING primitives + the op vocabulary
-// the memory subsystem needs to author + backfill entries. Every submodule above is otherwise
-// private, so this curated re-export is the ONE seam `query::memory` reaches through — and the only
-// direction of the dependency (`oplog` never depends back on `query::memory`).
+// C1's curated authority seam for the C2 `/3` content envelope and candidate DAG. The account
+// implementation stays private; only typed ingest results and snapshot-consistent point queries
+// cross the phase boundary.
+#[expect(unused_imports, reason = "C2 authority seam is frozen before its caller lands")]
+pub(crate) use account::{
+    AccountId, AuthorityInvalidReason, AuthorityParkReason, AuthorityQuery, CapacityScope,
+    DeviceCut, DeviceRole, GrantAuthority, GrantDeviceAuthority, GrantDeviceBoundary, GrantRole,
+    IngestOutcome, OwnerAuthority, RosterAuthority, account_ingest, backfill_authority_projection,
+    grant_effective_for_device, owner_incarnation_effective, roster_ref_effective,
+    stream_owner_effective,
+};
+// The op-log's first crate-internal API surface (#524): the MINTING primitives + the op
+// vocabulary the memory subsystem needs to author + backfill entries. Every submodule above is
+// otherwise private, so this curated re-export is the ONE seam `query::memory` reaches through
+// — and the only direction of the dependency (`oplog` never depends back on `query::memory`).
 pub(crate) use identity::local_device;
 pub(crate) use op::{EdgeKey, EdgeSpec, MemoryOp, NodeContent, NodeId, NodeStatus};
 // The reconcile's tests read the materialized shadow projection as a `ProjectedState` via

--- a/crates/rag-rat-core/src/oplog/stream.rs
+++ b/crates/rag-rat-core/src/oplog/stream.rs
@@ -31,10 +31,12 @@
 //! inside the hash so a synced `/3` content entry transitively names its owner. C1 adds `/2`
 //! ALONGSIDE `/1` (byte-unchanged); nothing switches the live path until C3 adoption.
 
-use minicbor::Encoder;
+use minicbor::data::Type;
+use minicbor::{Decoder, Encoder};
 use sha2::{Digest, Sha256};
 
 use super::account::AccountId;
+use super::cbor;
 
 /// Domain tag + version for the stream-identity derivation. Bump only when the canonical rule
 /// itself changes — never when a kind/relation token is added.
@@ -200,9 +202,6 @@ pub(crate) struct StreamSpecV2 {
 /// owner_account_id (b32), repo_set, kind_allow_list|null, relation_policy|null, override_set]))`.
 /// C1 ships this ALONGSIDE [`owner_stream`] / [`derive`] (`/1`), which the live phase-B authoring
 /// path keeps using until C3 adoption — nothing switches the live path here.
-///
-/// Consumed by `StreamOwn` validation in the fold (Phase 4); the allow drops when that lands.
-#[allow(dead_code)]
 pub(crate) fn derive_v2(spec: &StreamSpecV2) -> anyhow::Result<StreamId> {
     let bytes = canonical_spec_v2_bytes(spec)?;
     let mut out = [0u8; 32];
@@ -213,7 +212,7 @@ pub(crate) fn derive_v2(spec: &StreamSpecV2) -> anyhow::Result<StreamId> {
 /// The canonical CBOR tuple the `/2` identity hashes — `[domain, owner_account_id (b32), repo_set,
 /// kind_allow_list | null, relation_policy | null, override_pairs]`. The owner sits between the
 /// domain and the shared policy tail.
-fn canonical_spec_v2_bytes(spec: &StreamSpecV2) -> anyhow::Result<Vec<u8>> {
+pub(crate) fn canonical_spec_v2_bytes(spec: &StreamSpecV2) -> anyhow::Result<Vec<u8>> {
     let policy = canonical_policy(&spec.policy)?;
     let mut buf = Vec::with_capacity(128);
     {
@@ -224,6 +223,73 @@ fn canonical_spec_v2_bytes(spec: &StreamSpecV2) -> anyhow::Result<Vec<u8>> {
         encode_policy(&mut enc, &policy);
     }
     Ok(buf)
+}
+
+/// Decode and validate a canonical owner-bound `/2` stream specification. `StreamOwn` carries
+/// these bytes as a self-certifying preimage, so accepting merely a matching SHA-256 digest is not
+/// enough: the tuple must have the frozen shape, contain a valid policy, and already be in its
+/// unique canonical encoding.
+pub(crate) fn decode_spec_v2(bytes: &[u8]) -> anyhow::Result<StreamSpecV2> {
+    cbor::require_canonical_cbor(bytes)?;
+    let mut dec = Decoder::new(bytes);
+    anyhow::ensure!(dec.array()? == Some(6), "stream/2 spec must be a 6-element array");
+    anyhow::ensure!(dec.str()? == STREAM_V2_DOMAIN, "unknown stream spec domain");
+    let owner_account_id = AccountId::from_bytes(decode_fixed::<32>(&mut dec, "owner account")?);
+    let policy = StreamSpec {
+        repo_set: decode_str_array(&mut dec)?,
+        kind_allow_list: decode_optional_str_array(&mut dec)?,
+        relation_policy: decode_optional_str_array(&mut dec)?,
+        node_overrides: decode_overrides(&mut dec)?,
+    };
+    anyhow::ensure!(dec.position() == bytes.len(), "trailing bytes in stream/2 spec");
+    let spec = StreamSpecV2 { owner_account_id, policy };
+    anyhow::ensure!(
+        canonical_spec_v2_bytes(&spec)? == bytes,
+        "stream/2 spec is not in canonical set order"
+    );
+    Ok(spec)
+}
+
+fn decode_fixed<const N: usize>(
+    dec: &mut Decoder<'_>,
+    field: &'static str,
+) -> anyhow::Result<[u8; N]> {
+    let value = dec.bytes()?;
+    value.try_into().map_err(|_| anyhow::anyhow!("{field} must be {N} bytes"))
+}
+
+fn decode_str_array(dec: &mut Decoder<'_>) -> anyhow::Result<Vec<String>> {
+    let len = dec.array()?.ok_or_else(|| anyhow::anyhow!("indefinite arrays are not canonical"))?;
+    let mut values = Vec::with_capacity(len as usize);
+    for _ in 0..len {
+        values.push(dec.str()?.to_string());
+    }
+    Ok(values)
+}
+
+fn decode_optional_str_array(dec: &mut Decoder<'_>) -> anyhow::Result<Option<Vec<String>>> {
+    if dec.datatype()? == Type::Null {
+        dec.null()?;
+        Ok(None)
+    } else {
+        Ok(Some(decode_str_array(dec)?))
+    }
+}
+
+fn decode_overrides(dec: &mut Decoder<'_>) -> anyhow::Result<Vec<NodeOverride>> {
+    let len = dec.array()?.ok_or_else(|| anyhow::anyhow!("indefinite arrays are not canonical"))?;
+    let mut overrides = Vec::with_capacity(len as usize);
+    for _ in 0..len {
+        anyhow::ensure!(dec.array()? == Some(2), "stream override must be a 2-element array");
+        let node_id = dec.str()?.to_string();
+        let action = match dec.str()? {
+            "include" => NodeOverrideAction::Include,
+            "exclude" => NodeOverrideAction::Exclude,
+            other => anyhow::bail!("unknown stream override action `{other}`"),
+        };
+        overrides.push(NodeOverride { node_id, action });
+    }
+    Ok(overrides)
 }
 
 /// Byte-sort + dedup a token list into canonical SET order (the same rule as `NodeContent` tags).
@@ -461,6 +527,108 @@ mod tests {
         assert_eq!(bytes[62], 0x80, "empty override set");
         assert_eq!(bytes.len(), 63);
         cbor::require_canonical_cbor(&bytes).expect("stream/2 tuple is canonical CBOR");
+        assert_eq!(decode_spec_v2(&bytes).unwrap(), StreamSpecV2 {
+            owner_account_id: AccountId::from_bytes([0x11; 32]),
+            policy: StreamSpec {
+                repo_set: vec!["repo-a".to_string()],
+                kind_allow_list: None,
+                relation_policy: None,
+                node_overrides: Vec::new(),
+            },
+        });
+    }
+
+    #[test]
+    fn stream_v2_decoder_round_trips_every_policy_dimension() {
+        let expected = spec_v2();
+        let bytes = canonical_spec_v2_bytes(&expected).unwrap();
+        let decoded = decode_spec_v2(&bytes).unwrap();
+        assert_eq!(decoded.owner_account_id, expected.owner_account_id);
+        assert_eq!(decoded.policy.repo_set, ["repo-a", "repo-b"]);
+        assert_eq!(
+            decoded.policy.kind_allow_list.as_deref(),
+            Some(["Decision".to_string(), "Invariant".to_string()].as_slice()),
+        );
+        assert_eq!(
+            decoded.policy.relation_policy.as_deref(),
+            Some(["tracks".to_string()].as_slice())
+        );
+        assert_eq!(decoded.policy.node_overrides, expected.policy.node_overrides);
+        assert_eq!(canonical_spec_v2_bytes(&decoded).unwrap(), bytes);
+    }
+
+    fn raw_v2(domain: &str, owner: &[u8], repos: &[&str], overrides: &[(&str, &str)]) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        let mut enc = Encoder::new(&mut bytes);
+        enc.array(6).unwrap();
+        enc.str(domain).unwrap();
+        enc.bytes(owner).unwrap();
+        enc.array(repos.len() as u64).unwrap();
+        for repo in repos {
+            enc.str(repo).unwrap();
+        }
+        enc.null().unwrap();
+        enc.null().unwrap();
+        enc.array(overrides.len() as u64).unwrap();
+        for (node, action) in overrides {
+            enc.array(2).unwrap();
+            enc.str(node).unwrap();
+            enc.str(action).unwrap();
+        }
+        bytes
+    }
+
+    #[test]
+    fn stream_v2_decoder_rejects_malformed_self_certifying_preimages() {
+        let owner = owner().to_bytes();
+        let mut trailing = raw_v2(STREAM_V2_DOMAIN, &owner, &["repo-a"], &[]);
+        trailing.push(0x00);
+        let cases = [
+            ("wrong domain", raw_v2(STREAM_DOMAIN, &owner, &["repo-a"], &[])),
+            ("short owner", raw_v2(STREAM_V2_DOMAIN, &[0x11; 31], &["repo-a"], &[])),
+            (
+                "unknown override action",
+                raw_v2(STREAM_V2_DOMAIN, &owner, &["repo-a"], &[("mem-1", "unknown")]),
+            ),
+            (
+                "conflicting override",
+                raw_v2(STREAM_V2_DOMAIN, &owner, &["repo-a"], &[
+                    ("mem-1", "exclude"),
+                    ("mem-1", "include"),
+                ]),
+            ),
+            ("trailing bytes", trailing),
+        ];
+        for (label, bytes) in cases {
+            assert!(decode_spec_v2(&bytes).is_err(), "accepted {label}");
+        }
+    }
+
+    #[test]
+    fn stream_v2_decoder_rejects_structural_cbor_that_is_not_in_canonical_set_order() {
+        let mut bytes = canonical_spec_v2_bytes(&StreamSpecV2 {
+            owner_account_id: owner(),
+            policy: StreamSpec {
+                repo_set: vec!["repo-a".to_string(), "repo-b".to_string()],
+                kind_allow_list: None,
+                relation_policy: None,
+                node_overrides: Vec::new(),
+            },
+        })
+        .unwrap();
+        let a = bytes.windows(6).position(|window| window == b"repo-a").unwrap();
+        let b = bytes.windows(6).position(|window| window == b"repo-b").unwrap();
+        let repo_a = bytes[a..a + 6].to_vec();
+        let repo_b = bytes[b..b + 6].to_vec();
+        bytes[a..a + 6].copy_from_slice(&repo_b);
+        bytes[b..b + 6].copy_from_slice(&repo_a);
+
+        cbor::require_canonical_cbor(&bytes)
+            .expect("the CBOR itself remains structurally canonical");
+        assert!(
+            decode_spec_v2(&bytes).is_err(),
+            "semantic set ordering is part of the stream identity's canonical preimage",
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #604.

Completes the remaining C1 spine from the frozen phase-C v5 design:

- finishes the stratified account fold, control-side stream ownership/grant/revoke effects, contested recovery, and point-in-time authority facts
- adds monotone auth_len readiness gating so parked authority cannot leak registers or state while recoverable dependency failures are recomputed
- adds V064 authority projection and atomic backfill/rollback coverage
- exposes typed roster, owner, stream, and combined grant/device queries; grant plus device boundary is read from one SQLite snapshot and fails closed as Open, Cut, or Closed
- keeps raw grant/cut helpers private to the account module
- adds defensive fold, migration, transaction, corruption, order-independence, laundering, state-replay, and two-connection WAL snapshot tests

Validation:

- cargo +nightly fmt --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo nextest run --workspace (2634 passed)
- three final adversarial reviews: no actionable blockers