### PR TITLE
fix(account): preserve bounded historical authority

### DIFF
--- a/crates/rag-rat-core/src/index/schema/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema/migrations.rs
@@ -1259,6 +1259,7 @@ pub(crate) fn known_version(migrations: &[AppliedMigration]) -> u32 {
             MIGRATION_062_ID => Some(62),
             MIGRATION_063_ID => Some(63),
             MIGRATION_064_ID => Some(64),
+            MIGRATION_065_ID => Some(65),
             _ => None,
         })
         .max()
@@ -1332,6 +1333,7 @@ pub(crate) fn known_migration(id: &str) -> bool {
             | MIGRATION_062_ID
             | MIGRATION_063_ID
             | MIGRATION_064_ID
+            | MIGRATION_065_ID
             | DIRTY_MIGRATION_ID
     )
 }
@@ -1402,6 +1404,7 @@ pub(crate) fn migration_checksum_mismatch(migration: &AppliedMigration) -> bool 
         MIGRATION_062_ID => migration.checksum != MIGRATION_062_CHECKSUM,
         MIGRATION_063_ID => migration.checksum != MIGRATION_063_CHECKSUM,
         MIGRATION_064_ID => migration.checksum != MIGRATION_064_CHECKSUM,
+        MIGRATION_065_ID => migration.checksum != MIGRATION_065_CHECKSUM,
         _ => false,
     }
 }
@@ -4430,6 +4433,43 @@ pub(crate) fn apply_account_authority_projection(conn: &Connection) -> rusqlite:
          ) STRICT;
          CREATE INDEX IF NOT EXISTS account_stream_grant_cuts_owner
              ON account_stream_grant_cuts(owner_account_id, grant_id);",
+    )?;
+    // V064's transactional backfill immediately calls the current projection writer. Provision
+    // the additive boundary shape here too, so a database upgrading from V063 can be backfilled by
+    // this binary; V065 repeats it idempotently for databases that already recorded old V064.
+    apply_account_authority_boundaries(conn)
+}
+
+/// V065: retain the exact chain boundaries of closed roster and owner citations. The V064 rows
+/// remain historical facts; these columns make their valid prefix explicit instead of forcing a
+/// caller to choose between accepting a revoked citation and rejecting valid late delivery.
+pub(crate) fn apply_account_authority_boundaries(conn: &Connection) -> rusqlite::Result<()> {
+    for (table, prefix) in [
+        ("account_roster_history", "control"),
+        ("account_roster_history", "secrets"),
+        ("account_owner_incarnations", "control"),
+        ("account_owner_incarnations", "secrets"),
+    ] {
+        add_column_if_missing(
+            conn,
+            table,
+            &format!("{prefix}_boundary"),
+            "TEXT NOT NULL DEFAULT 'open'",
+        )?;
+        add_column_if_missing(conn, table, &format!("{prefix}_seq"), "BLOB")?;
+        add_column_if_missing(conn, table, &format!("{prefix}_hash"), "BLOB")?;
+    }
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS account_roster_content_boundaries(
+             roster_ref BLOB NOT NULL,
+             account_id BLOB NOT NULL,
+             stream_id  BLOB NOT NULL,
+             seq        BLOB NOT NULL CHECK(length(seq) = 8),
+             entry_hash BLOB NOT NULL CHECK(length(entry_hash) = 32),
+             PRIMARY KEY(roster_ref, stream_id)
+         ) STRICT;
+         CREATE INDEX IF NOT EXISTS account_roster_content_boundaries_account
+             ON account_roster_content_boundaries(account_id, roster_ref);",
     )
 }
 

--- a/crates/rag-rat-core/src/index/schema/mod.rs
+++ b/crates/rag-rat-core/src/index/schema/mod.rs
@@ -19,7 +19,7 @@ pub use registry::{LEGACY_REPO_ID, RegisteredRepo, register_repo, register_repo_
 use rusqlite::{Connection, OptionalExtension, Transaction, TransactionBehavior, params};
 use serde::Serialize;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 64;
+pub const LATEST_SCHEMA_VERSION: u32 = 65;
 
 /// Every oracle-DERIVED persisted table — the outputs an `oracle run` writes that must OUTLIVE a
 /// reindex.
@@ -453,6 +453,10 @@ const MIGRATION_064_DESCRIPTION: &str =
      stream ownership, exact grant incarnations, and revoke device cuts. refold_account rewrites \
      these shadow tables in the same IMMEDIATE transaction as accepted/status, so /3 authority \
      checks never rescan the bounded candidate DAG";
+const MIGRATION_065_ID: &str = "065_account_authority_boundaries";
+const MIGRATION_065_CHECKSUM: &str = "sha256:rag-rat-account-authority-boundaries-v65a";
+const MIGRATION_065_DESCRIPTION: &str =
+    "Persist closed roster and owner chain boundaries for bounded historical citations";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -608,7 +612,7 @@ struct Migration {
 /// share one IMMEDIATE transaction so older writers cannot land an unprojected candidate in a
 /// migration race.
 fn apply_and_record_migration(conn: &Connection, step: &Migration) -> rusqlite::Result<()> {
-    if step.id != MIGRATION_064_ID {
+    if !matches!(step.id, MIGRATION_064_ID | MIGRATION_065_ID) {
         (step.apply)(conn)?;
         return record_migration(conn, step.id, step.checksum, step.description);
     }
@@ -998,6 +1002,12 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         checksum: MIGRATION_064_CHECKSUM,
         description: MIGRATION_064_DESCRIPTION,
         apply: apply_account_authority_projection,
+    },
+    Migration {
+        id: MIGRATION_065_ID,
+        checksum: MIGRATION_065_CHECKSUM,
+        description: MIGRATION_065_DESCRIPTION,
+        apply: apply_account_authority_boundaries,
     },
 ];
 

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
@@ -1865,8 +1865,7 @@ fn migration_059_creates_the_account_candidate_dag() {
 }
 
 #[test]
-fn migration_064_is_the_tip_and_creates_account_authority_shadow_tables() {
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 64, "move this pin with the next schema migration");
+fn migration_064_creates_account_authority_shadow_tables() {
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     schema::apply(&conn).unwrap();
     for table in [
@@ -1914,8 +1913,32 @@ fn migration_064_is_the_tip_and_creates_account_authority_shadow_tables() {
     )
     .unwrap();
     schema::migrate_forward(&conn).unwrap();
-    assert_eq!(schema::status(&conn).unwrap().current_version, 64);
+    assert_eq!(schema::status(&conn).unwrap().current_version, schema::LATEST_SCHEMA_VERSION);
     assert!(conn_table_exists(&conn, "account_auth_state"));
+}
+
+#[test]
+fn migration_065_is_the_tip_and_adds_historical_authority_boundaries() {
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 65, "move this pin with the next schema migration");
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn).unwrap();
+    assert!(conn_table_exists(&conn, "account_roster_content_boundaries"));
+    for table in ["account_roster_history", "account_owner_incarnations"] {
+        for column in [
+            "control_boundary",
+            "control_seq",
+            "control_hash",
+            "secrets_boundary",
+            "secrets_seq",
+            "secrets_hash",
+        ] {
+            assert!(
+                conn_table_columns(&conn, table).contains(&column.to_string()),
+                "V065 adds {table}.{column}"
+            );
+        }
+    }
+    schema::apply_account_authority_boundaries(&conn).expect("V065 replay is idempotent");
 }
 
 #[test]

--- a/crates/rag-rat-core/src/oplog/account/fold.rs
+++ b/crates/rag-rat-core/src/oplog/account/fold.rs
@@ -216,12 +216,38 @@ pub(crate) enum AuthorityInvalidReason {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct RosterAuthority {
     pub(crate) device_fingerprint: DeviceFingerprint,
-    pub(crate) role: DeviceRole,
+    /// Current roster metadata, not authority for an owner-required operation. Owner authority is
+    /// established only by citing a fresh `owner_id` and applying both revocation registers.
+    pub(crate) current_role: DeviceRole,
+}
+
+/// The valid prefix of a cited device chain. `Closed` is the empty cut: no entry on that chain is
+/// admissible. Callers must still verify ancestry for `Cut`; the hash prevents an equal/older
+/// off-branch entry from laundering through a sequence-only check.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AuthorityBoundary {
+    Open,
+    Cut { seq: u64, hash: [u8; 32] },
+    Closed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct RosterContentAuthority {
+    pub(crate) device_fingerprint: DeviceFingerprint,
+    pub(crate) boundary: AuthorityBoundary,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct OwnerAuthority {
     pub(crate) device_fingerprint: DeviceFingerprint,
+}
+
+/// Owner-required entries are admitted by the conjunction of these two independent registers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct OwnerChainAuthority {
+    pub(crate) owner: OwnerAuthority,
+    pub(crate) device_boundary: AuthorityBoundary,
+    pub(crate) incarnation_boundary: AuthorityBoundary,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -246,11 +272,14 @@ pub(crate) enum GrantDeviceBoundary {
     Closed,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub(super) struct RosterFact {
     pub(super) authority: RosterAuthority,
     pub(super) effective_at: u64,
     pub(super) closed_at: Option<u64>,
+    pub(super) control_boundary: AuthorityBoundary,
+    pub(super) secrets_boundary: AuthorityBoundary,
+    pub(super) content_boundaries: HashMap<StreamId, AuthorityBoundary>,
 }
 
 #[derive(Clone, Copy)]
@@ -258,6 +287,8 @@ pub(super) struct OwnerIncarnationFact {
     pub(super) authority: OwnerAuthority,
     pub(super) effective_at: u64,
     pub(super) closed_at: Option<u64>,
+    pub(super) control_boundary: AuthorityBoundary,
+    pub(super) secrets_boundary: AuthorityBoundary,
 }
 
 #[derive(Clone, Copy)]
@@ -334,6 +365,39 @@ impl AccountAuthHistory {
         )
     }
 
+    pub(super) fn roster_content_authority(
+        &self,
+        roster_ref: [u8; 32],
+        device_fingerprint: DeviceFingerprint,
+        stream_id: StreamId,
+        auth_len: u64,
+    ) -> AuthorityQuery<RosterContentAuthority> {
+        if auth_len > self.effective_count {
+            return AuthorityQuery::Parked(AuthorityParkReason::AuthLenAhead);
+        }
+        let Some(fact) = self.roster_refs.get(&roster_ref) else {
+            return if self.outcomes.contains_key(&roster_ref) {
+                AuthorityQuery::Invalid(AuthorityInvalidReason::ReferencedEntryNotEffective)
+            } else {
+                AuthorityQuery::Parked(AuthorityParkReason::UnknownReference)
+            };
+        };
+        if fact.authority.device_fingerprint != device_fingerprint {
+            return AuthorityQuery::Invalid(AuthorityInvalidReason::WrongSubject);
+        }
+        let boundary = fact.content_boundaries.get(&stream_id).copied().unwrap_or_else(|| {
+            if fact.closed_at.is_none() {
+                AuthorityBoundary::Open
+            } else {
+                AuthorityBoundary::Closed
+            }
+        });
+        AuthorityQuery::Effective(RosterContentAuthority {
+            device_fingerprint: fact.authority.device_fingerprint,
+            boundary,
+        })
+    }
+
     pub(super) fn owner_incarnation_effective(
         &self,
         owner_id: [u8; 32],
@@ -350,6 +414,69 @@ impl AccountAuthHistory {
             device_fingerprint,
             self.outcomes.contains_key(&owner_id),
         )
+    }
+
+    pub(super) fn owner_control_authority(
+        &self,
+        owner_id: [u8; 32],
+        device_fingerprint: DeviceFingerprint,
+        auth_len: u64,
+    ) -> AuthorityQuery<OwnerChainAuthority> {
+        self.owner_chain_authority(
+            owner_id,
+            device_fingerprint,
+            auth_len,
+            |fact| fact.control_boundary,
+            |fact| fact.control_boundary,
+        )
+    }
+
+    pub(super) fn owner_secrets_authority(
+        &self,
+        owner_id: [u8; 32],
+        device_fingerprint: DeviceFingerprint,
+        auth_len: u64,
+    ) -> AuthorityQuery<OwnerChainAuthority> {
+        self.owner_chain_authority(
+            owner_id,
+            device_fingerprint,
+            auth_len,
+            |fact| fact.secrets_boundary,
+            |fact| fact.secrets_boundary,
+        )
+    }
+
+    fn owner_chain_authority(
+        &self,
+        owner_id: [u8; 32],
+        device_fingerprint: DeviceFingerprint,
+        auth_len: u64,
+        device_boundary: impl Fn(&RosterFact) -> AuthorityBoundary,
+        incarnation_boundary: impl Fn(&OwnerIncarnationFact) -> AuthorityBoundary,
+    ) -> AuthorityQuery<OwnerChainAuthority> {
+        if auth_len > self.effective_count {
+            return AuthorityQuery::Parked(AuthorityParkReason::AuthLenAhead);
+        }
+        let Some(owner) = self.owner_incarnations.get(&owner_id) else {
+            return if self.outcomes.contains_key(&owner_id) {
+                AuthorityQuery::Invalid(AuthorityInvalidReason::ReferencedEntryNotEffective)
+            } else {
+                AuthorityQuery::Parked(AuthorityParkReason::UnknownReference)
+            };
+        };
+        if owner.authority.device_fingerprint != device_fingerprint {
+            return AuthorityQuery::Invalid(AuthorityInvalidReason::WrongSubject);
+        }
+        let device = self
+            .roster_refs
+            .values()
+            .find(|fact| fact.authority.device_fingerprint == device_fingerprint)
+            .map_or(AuthorityBoundary::Closed, device_boundary);
+        AuthorityQuery::Effective(OwnerChainAuthority {
+            owner: owner.authority,
+            device_boundary: device,
+            incarnation_boundary: incarnation_boundary(owner),
+        })
     }
 
     pub(super) fn grant_effective(
@@ -1306,7 +1433,7 @@ fn fold_account_pass(
             discovered.insert(candidate.hash(), Outcome::Parked(ParkReason::AuthLenAhead));
         }
     }
-    let facts = derive_authority_facts(&candidates, &outcomes);
+    let facts = derive_authority_facts(&candidates, &outcomes, &registers);
     (
         AccountAuthHistory {
             outcomes,
@@ -1477,6 +1604,7 @@ struct AuthorityFacts {
 fn derive_authority_facts(
     candidates: &[Candidate],
     outcomes: &HashMap<[u8; 32], Outcome>,
+    registers: &HashMap<RegisterKey, Cut>,
 ) -> AuthorityFacts {
     let mut effective: Vec<(&Candidate, u64)> = candidates
         .iter()
@@ -1498,15 +1626,20 @@ fn derive_authority_facts(
                 facts.roster_refs.insert(hash, RosterFact {
                     authority: RosterAuthority {
                         device_fingerprint: device,
-                        role: DeviceRole::Owner,
+                        current_role: DeviceRole::Owner,
                     },
                     effective_at: epoch,
                     closed_at: None,
+                    control_boundary: AuthorityBoundary::Open,
+                    secrets_boundary: AuthorityBoundary::Open,
+                    content_boundaries: HashMap::new(),
                 });
                 facts.owner_incarnations.insert(hash, OwnerIncarnationFact {
                     authority: OwnerAuthority { device_fingerprint: device },
                     effective_at: epoch,
                     closed_at: None,
+                    control_boundary: AuthorityBoundary::Open,
+                    secrets_boundary: AuthorityBoundary::Open,
                 });
                 roster.insert(device, hash);
                 owners.insert(device, hash);
@@ -1516,10 +1649,13 @@ fn derive_authority_facts(
                 facts.roster_refs.insert(hash, RosterFact {
                     authority: RosterAuthority {
                         device_fingerprint: *device_fingerprint,
-                        role: *role,
+                        current_role: *role,
                     },
                     effective_at: epoch,
                     closed_at: None,
+                    control_boundary: AuthorityBoundary::Open,
+                    secrets_boundary: AuthorityBoundary::Open,
+                    content_boundaries: HashMap::new(),
                 });
                 roster.insert(*device_fingerprint, hash);
                 if *role == DeviceRole::Owner {
@@ -1527,6 +1663,8 @@ fn derive_authority_facts(
                         authority: OwnerAuthority { device_fingerprint: *device_fingerprint },
                         effective_at: epoch,
                         closed_at: None,
+                        control_boundary: AuthorityBoundary::Open,
+                        secrets_boundary: AuthorityBoundary::Open,
                     });
                     owners.insert(*device_fingerprint, hash);
                 }
@@ -1536,19 +1674,39 @@ fn derive_authority_facts(
                 let roster_ref = roster
                     .get(device_fingerprint)
                     .expect("promoted device has an active roster fact");
-                facts.roster_refs.get_mut(roster_ref).expect("active roster fact").authority.role =
-                    DeviceRole::Owner;
+                facts
+                    .roster_refs
+                    .get_mut(roster_ref)
+                    .expect("active roster fact")
+                    .authority
+                    .current_role = DeviceRole::Owner;
                 facts.owner_incarnations.insert(hash, OwnerIncarnationFact {
                     authority: OwnerAuthority { device_fingerprint: *device_fingerprint },
                     effective_at: epoch,
                     closed_at: None,
+                    control_boundary: AuthorityBoundary::Open,
+                    secrets_boundary: AuthorityBoundary::Open,
                 });
                 owners.insert(*device_fingerprint, hash);
             },
-            AccountOp::DeviceRemove { device_fingerprint, .. } => {
+            AccountOp::DeviceRemove { device_fingerprint, secrets_cut, content_cuts, .. } => {
                 if let Some(roster_ref) = roster.remove(device_fingerprint) {
-                    facts.roster_refs.get_mut(&roster_ref).expect("active roster fact").closed_at =
-                        Some(epoch);
+                    let fact = facts.roster_refs.get_mut(&roster_ref).expect("active roster fact");
+                    fact.closed_at = Some(epoch);
+                    fact.control_boundary = registers
+                        .get(&RegisterKey::Device {
+                            account: candidate.header().account_id,
+                            log: 0,
+                            device: *device_fingerprint,
+                        })
+                        .map_or(AuthorityBoundary::Closed, boundary_from_cut);
+                    fact.secrets_boundary = boundary_from_cut(secrets_cut);
+                    fact.content_boundaries = content_cuts
+                        .iter()
+                        .map(|cut| {
+                            (cut.stream_id, AuthorityBoundary::Cut { seq: cut.seq, hash: cut.hash })
+                        })
+                        .collect();
                 }
                 if let Some(owner_id) = owners.remove(device_fingerprint) {
                     facts
@@ -1558,7 +1716,7 @@ fn derive_authority_facts(
                         .closed_at = Some(epoch);
                 }
             },
-            AccountOp::OwnerDemote { device_fingerprint, owner_id, .. } => {
+            AccountOp::OwnerDemote { device_fingerprint, owner_id, secrets_cut, .. } => {
                 if owners.get(device_fingerprint) == Some(owner_id) {
                     owners.remove(device_fingerprint);
                     let roster_ref = roster
@@ -1569,12 +1727,19 @@ fn derive_authority_facts(
                         .get_mut(roster_ref)
                         .expect("active roster fact")
                         .authority
-                        .role = DeviceRole::Member;
-                    facts
-                        .owner_incarnations
-                        .get_mut(owner_id)
-                        .expect("active owner fact")
-                        .closed_at = Some(epoch);
+                        .current_role = DeviceRole::Member;
+                    let fact =
+                        facts.owner_incarnations.get_mut(owner_id).expect("active owner fact");
+                    fact.closed_at = Some(epoch);
+                    fact.control_boundary = registers
+                        .get(&RegisterKey::OwnerIncarnation {
+                            account: candidate.header().account_id,
+                            log: 0,
+                            device: *device_fingerprint,
+                            owner_id: *owner_id,
+                        })
+                        .map_or(AuthorityBoundary::Closed, boundary_from_cut);
+                    fact.secrets_boundary = boundary_from_cut(secrets_cut);
                 }
             },
             AccountOp::StreamOwn { stream_id, .. } => {
@@ -1603,7 +1768,28 @@ fn derive_authority_facts(
             AccountOp::CutExtend { .. } | AccountOp::AccountReRoot { .. } => {},
         }
     }
+    // Register creators can be retained even when their state mutation is ineffective (notably a
+    // remove that arrived before enrollment). Project the fold's FINAL device register onto every
+    // roster incarnation for that device; deriving only from effective close ops would otherwise
+    // expose Open while the fold condemns that chain.
+    for fact in facts.roster_refs.values_mut() {
+        if let Some(cut) = registers.iter().find_map(|(key, cut)| match key {
+            RegisterKey::Device { log: 0, device, .. }
+                if *device == fact.authority.device_fingerprint =>
+                Some(cut),
+            _ => None,
+        }) {
+            fact.control_boundary = boundary_from_cut(cut);
+        }
+    }
     facts
+}
+
+fn boundary_from_cut(cut: &Cut) -> AuthorityBoundary {
+    match cut {
+        Cut::Empty => AuthorityBoundary::Closed,
+        Cut::At { seq, hash } => AuthorityBoundary::Cut { seq: *seq, hash: *hash },
+    }
 }
 
 /// The genesis candidate: an `AccountGenesis` whose payload hashes to the shared `account_id` (§4)
@@ -2296,7 +2482,7 @@ mod tests {
             h.roster_ref_effective(valid, device.fp, h.effective_count()),
             AuthorityQuery::Effective(RosterAuthority {
                 device_fingerprint: device.fp,
-                role: DeviceRole::Owner,
+                current_role: DeviceRole::Owner,
             }),
         );
         assert_eq!(
@@ -3100,7 +3286,7 @@ mod tests {
             h.roster_ref_effective(add, member.fp, 2),
             AuthorityQuery::Effective(RosterAuthority {
                 device_fingerprint: member.fp,
-                role: DeviceRole::Owner,
+                current_role: DeviceRole::Owner,
             }),
         );
         assert_eq!(
@@ -3123,7 +3309,7 @@ mod tests {
             h.roster_ref_effective(add, member.fp, 4),
             AuthorityQuery::Effective(RosterAuthority {
                 device_fingerprint: member.fp,
-                role: DeviceRole::Member,
+                current_role: DeviceRole::Member,
             }),
         );
         assert_eq!(
@@ -3454,6 +3640,8 @@ mod tests {
             "removing a never-enrolled device is ineffective",
         );
         assert!(h.is_effective(&add), "the device is not pre-tombstoned, so it can still be added");
+        let fact = h.roster_refs.get(&add).expect("later enrollment has a roster fact");
+        assert_eq!(fact.control_boundary, AuthorityBoundary::Closed);
     }
 
     #[test]

--- a/crates/rag-rat-core/src/oplog/account/mod.rs
+++ b/crates/rag-rat-core/src/oplog/account/mod.rs
@@ -26,13 +26,14 @@ mod registers;
 mod storage;
 
 pub(crate) use fold::{
-    AuthorityInvalidReason, AuthorityParkReason, AuthorityQuery, GrantAuthority,
-    GrantDeviceAuthority, GrantDeviceBoundary, OwnerAuthority, RosterAuthority,
+    AuthorityBoundary, AuthorityInvalidReason, AuthorityParkReason, AuthorityQuery, GrantAuthority,
+    GrantDeviceAuthority, GrantDeviceBoundary, OwnerAuthority, OwnerChainAuthority,
+    RosterContentAuthority,
 };
 pub(crate) use id::AccountId;
 pub(crate) use ops::{DeviceCut, DeviceRole, GrantRole};
 pub(crate) use storage::{
     CapacityScope, IngestOutcome, account_ingest, backfill_authority_projection,
-    grant_effective_for_device, owner_incarnation_effective, roster_ref_effective,
-    stream_owner_effective,
+    grant_effective_for_device, owner_control_authority, owner_secrets_authority,
+    roster_content_authority, stream_owner_effective,
 };

--- a/crates/rag-rat-core/src/oplog/account/storage.rs
+++ b/crates/rag-rat-core/src/oplog/account/storage.rs
@@ -295,12 +295,189 @@ pub(crate) fn roster_ref_effective(
     };
     let authority = fold::RosterAuthority {
         device_fingerprint: DeviceFingerprint::from_bytes(fixed(&device)?),
-        role: DeviceRole::from_db_str(&role)?,
+        current_role: DeviceRole::from_db_str(&role)?,
     };
     if authority.device_fingerprint != device_fingerprint {
         return Ok(fold::AuthorityQuery::Invalid(fold::AuthorityInvalidReason::WrongSubject));
     }
     validated_open_fact(authority, effective_at, closed_at)
+}
+
+pub(crate) fn roster_content_authority(
+    conn: &Connection,
+    account_id: AccountId,
+    roster_ref: EntryHash,
+    device_fingerprint: DeviceFingerprint,
+    stream_id: StreamId,
+    auth_len: u64,
+) -> anyhow::Result<fold::AuthorityQuery<fold::RosterContentAuthority>> {
+    let read_tx = Transaction::new_unchecked(conn, TransactionBehavior::Deferred)?;
+    let conn: &Connection = &read_tx;
+    if let Some(reason) = auth_len_preflight(conn, account_id, auth_len)? {
+        return Ok(fold::AuthorityQuery::Parked(reason));
+    }
+    let row: Option<(Vec<u8>, String, i64, Option<i64>)> = conn
+        .query_row(
+            "SELECT device_fingerprint, role, effective_at, closed_at
+             FROM account_roster_history WHERE account_id = ?1 AND roster_ref = ?2",
+            params![account_id.to_bytes().as_slice(), roster_ref.as_slice()],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+        )
+        .optional()?;
+    let Some((device, role, effective_at, closed_at)) = row else {
+        return missing_reference(conn, account_id, &roster_ref);
+    };
+    let roster = fold::RosterAuthority {
+        device_fingerprint: DeviceFingerprint::from_bytes(fixed(&device)?),
+        current_role: DeviceRole::from_db_str(&role)?,
+    };
+    if roster.device_fingerprint != device_fingerprint {
+        return Ok(fold::AuthorityQuery::Invalid(fold::AuthorityInvalidReason::WrongSubject));
+    }
+    let _ = (u64::try_from(effective_at)?, closed_at.map(u64::try_from).transpose()?);
+    let cut: Option<(Vec<u8>, Vec<u8>)> = conn
+        .query_row(
+            "SELECT seq, entry_hash FROM account_roster_content_boundaries
+             WHERE account_id = ?1 AND roster_ref = ?2 AND stream_id = ?3",
+            params![
+                account_id.to_bytes().as_slice(),
+                roster_ref.as_slice(),
+                stream_id.to_bytes().as_slice(),
+            ],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .optional()?;
+    let boundary = match cut {
+        Some((seq, hash)) => fold::AuthorityBoundary::Cut {
+            seq: u64::from_be_bytes(fixed(&seq)?),
+            hash: fixed(&hash)?,
+        },
+        None if closed_at.is_none() => fold::AuthorityBoundary::Open,
+        None => fold::AuthorityBoundary::Closed,
+    };
+    Ok(fold::AuthorityQuery::Effective(fold::RosterContentAuthority {
+        device_fingerprint: roster.device_fingerprint,
+        boundary,
+    }))
+}
+
+pub(crate) fn owner_control_authority(
+    conn: &Connection,
+    account_id: AccountId,
+    owner_id: EntryHash,
+    device_fingerprint: DeviceFingerprint,
+    auth_len: u64,
+) -> anyhow::Result<fold::AuthorityQuery<fold::OwnerChainAuthority>> {
+    owner_chain_authority(conn, account_id, owner_id, device_fingerprint, auth_len, "control")
+}
+
+pub(crate) fn owner_secrets_authority(
+    conn: &Connection,
+    account_id: AccountId,
+    owner_id: EntryHash,
+    device_fingerprint: DeviceFingerprint,
+    auth_len: u64,
+) -> anyhow::Result<fold::AuthorityQuery<fold::OwnerChainAuthority>> {
+    owner_chain_authority(conn, account_id, owner_id, device_fingerprint, auth_len, "secrets")
+}
+
+fn owner_chain_authority(
+    conn: &Connection,
+    account_id: AccountId,
+    owner_id: EntryHash,
+    device_fingerprint: DeviceFingerprint,
+    auth_len: u64,
+    chain: &str,
+) -> anyhow::Result<fold::AuthorityQuery<fold::OwnerChainAuthority>> {
+    let read_tx = Transaction::new_unchecked(conn, TransactionBehavior::Deferred)?;
+    let conn: &Connection = &read_tx;
+    if let Some(reason) = auth_len_preflight(conn, account_id, auth_len)? {
+        return Ok(fold::AuthorityQuery::Parked(reason));
+    }
+    let sql = format!(
+        "SELECT o.device_fingerprint, o.effective_at, o.closed_at,
+                o.{chain}_boundary, o.{chain}_seq, o.{chain}_hash,
+                r.effective_at, r.closed_at, r.{chain}_boundary, r.{chain}_seq, r.{chain}_hash
+         FROM account_owner_incarnations o
+         LEFT JOIN account_roster_history r
+           ON r.account_id = o.account_id AND r.device_fingerprint = o.device_fingerprint
+         WHERE o.account_id = ?1 AND o.owner_id = ?2"
+    );
+    type BoundaryRow = (
+        Vec<u8>,
+        i64,
+        Option<i64>,
+        String,
+        Option<Vec<u8>>,
+        Option<Vec<u8>>,
+        Option<i64>,
+        Option<i64>,
+        Option<String>,
+        Option<Vec<u8>>,
+        Option<Vec<u8>>,
+    );
+    let row: Option<BoundaryRow> = conn
+        .query_row(&sql, params![account_id.to_bytes().as_slice(), owner_id.as_slice()], |row| {
+            Ok((
+                row.get(0)?,
+                row.get(1)?,
+                row.get(2)?,
+                row.get(3)?,
+                row.get(4)?,
+                row.get(5)?,
+                row.get(6)?,
+                row.get(7)?,
+                row.get(8)?,
+                row.get(9)?,
+                row.get(10)?,
+            ))
+        })
+        .optional()?;
+    let Some((
+        device,
+        owner_effective,
+        owner_closed,
+        owner_kind,
+        owner_seq,
+        owner_hash,
+        device_effective,
+        device_closed,
+        device_kind,
+        device_seq,
+        device_hash,
+    )) = row
+    else {
+        return missing_reference(conn, account_id, &owner_id);
+    };
+    let owner =
+        fold::OwnerAuthority { device_fingerprint: DeviceFingerprint::from_bytes(fixed(&device)?) };
+    if owner.device_fingerprint != device_fingerprint {
+        return Ok(fold::AuthorityQuery::Invalid(fold::AuthorityInvalidReason::WrongSubject));
+    }
+    let _ = (
+        u64::try_from(owner_effective)?,
+        owner_closed.map(u64::try_from).transpose()?,
+        device_effective.map(u64::try_from).transpose()?,
+        device_closed.map(u64::try_from).transpose()?,
+    );
+    let device_boundary = match device_kind {
+        Some(kind) =>
+            decode_stored_boundary(&kind, device_seq, device_hash, device_closed, false, true)?,
+        None => fold::AuthorityBoundary::Closed,
+    };
+    let incarnation_boundary = decode_stored_boundary(
+        &owner_kind,
+        owner_seq,
+        owner_hash,
+        owner_closed,
+        device_boundary != fold::AuthorityBoundary::Open,
+        false,
+    )?;
+    Ok(fold::AuthorityQuery::Effective(fold::OwnerChainAuthority {
+        owner,
+        device_boundary,
+        incarnation_boundary,
+    }))
 }
 
 pub(crate) fn owner_incarnation_effective(
@@ -586,6 +763,45 @@ fn validated_open_fact<T>(
     })
 }
 
+fn stored_boundary(
+    boundary: fold::AuthorityBoundary,
+) -> (&'static str, Option<[u8; 8]>, Option<[u8; 32]>) {
+    match boundary {
+        fold::AuthorityBoundary::Open => ("open", None, None),
+        fold::AuthorityBoundary::Closed => ("closed", None, None),
+        fold::AuthorityBoundary::Cut { seq, hash } => ("cut", Some(seq.to_be_bytes()), Some(hash)),
+    }
+}
+
+fn decode_stored_boundary(
+    kind: &str,
+    seq: Option<Vec<u8>>,
+    hash: Option<Vec<u8>>,
+    closed_at: Option<i64>,
+    allow_closed_open: bool,
+    allow_open_bounded: bool,
+) -> anyhow::Result<fold::AuthorityBoundary> {
+    let boundary = match (kind, seq, hash) {
+        ("open", None, None) => fold::AuthorityBoundary::Open,
+        ("closed", None, None) => fold::AuthorityBoundary::Closed,
+        ("cut", Some(seq), Some(hash)) => fold::AuthorityBoundary::Cut {
+            seq: u64::from_be_bytes(fixed(&seq)?),
+            hash: fixed(&hash)?,
+        },
+        _ => anyhow::bail!("malformed persisted authority boundary"),
+    };
+    match (closed_at.is_some(), boundary) {
+        (false, fold::AuthorityBoundary::Open)
+        | (true, fold::AuthorityBoundary::Cut { .. } | fold::AuthorityBoundary::Closed) =>
+            Ok(boundary),
+        (true, fold::AuthorityBoundary::Open) if allow_closed_open => Ok(boundary),
+        (false, fold::AuthorityBoundary::Cut { .. } | fold::AuthorityBoundary::Closed)
+            if allow_open_bounded =>
+            Ok(boundary),
+        _ => anyhow::bail!("authority closure and boundary disagree"),
+    }
+}
+
 /// The refold body (caller owns the txn). Returns each entry_hash → its projected status.
 fn refold_in_tx(
     tx: &Transaction<'_>,
@@ -642,6 +858,7 @@ fn rewrite_authority_projection(
 ) -> anyhow::Result<()> {
     let account = account_id.to_bytes();
     for table in [
+        "account_roster_content_boundaries",
         "account_roster_history",
         "account_owner_incarnations",
         "account_stream_ownership",
@@ -678,31 +895,68 @@ fn rewrite_authority_projection(
     )?;
 
     for (roster_ref, fact) in history.roster_facts() {
+        let (control_kind, control_seq, control_hash) = stored_boundary(fact.control_boundary);
+        let (secrets_kind, secrets_seq, secrets_hash) = stored_boundary(fact.secrets_boundary);
         tx.execute(
             "INSERT INTO account_roster_history(
-                 roster_ref, account_id, device_fingerprint, role, effective_at, closed_at
-             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                 roster_ref, account_id, device_fingerprint, role, effective_at, closed_at,
+                 control_boundary, control_seq, control_hash,
+                 secrets_boundary, secrets_seq, secrets_hash
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
             params![
                 roster_ref.as_slice(),
                 account.as_slice(),
                 fact.authority.device_fingerprint.to_bytes().as_slice(),
-                fact.authority.role.as_db_str(),
+                fact.authority.current_role.as_db_str(),
                 i64::try_from(fact.effective_at)?,
                 fact.closed_at.map(i64::try_from).transpose()?,
+                control_kind,
+                control_seq.as_ref().map(<[u8; 8]>::as_slice),
+                control_hash.as_ref().map(<[u8; 32]>::as_slice),
+                secrets_kind,
+                secrets_seq.as_ref().map(<[u8; 8]>::as_slice),
+                secrets_hash.as_ref().map(<[u8; 32]>::as_slice),
             ],
         )?;
+        for (stream_id, boundary) in &fact.content_boundaries {
+            let fold::AuthorityBoundary::Cut { seq, hash } = boundary else {
+                continue;
+            };
+            tx.execute(
+                "INSERT INTO account_roster_content_boundaries(
+                     roster_ref, account_id, stream_id, seq, entry_hash
+                 ) VALUES (?1, ?2, ?3, ?4, ?5)",
+                params![
+                    roster_ref.as_slice(),
+                    account.as_slice(),
+                    stream_id.to_bytes().as_slice(),
+                    seq.to_be_bytes().as_slice(),
+                    hash.as_slice(),
+                ],
+            )?;
+        }
     }
     for (owner_id, fact) in history.owner_incarnation_facts() {
+        let (control_kind, control_seq, control_hash) = stored_boundary(fact.control_boundary);
+        let (secrets_kind, secrets_seq, secrets_hash) = stored_boundary(fact.secrets_boundary);
         tx.execute(
             "INSERT INTO account_owner_incarnations(
-                 owner_id, account_id, device_fingerprint, effective_at, closed_at
-             ) VALUES (?1, ?2, ?3, ?4, ?5)",
+                 owner_id, account_id, device_fingerprint, effective_at, closed_at,
+                 control_boundary, control_seq, control_hash,
+                 secrets_boundary, secrets_seq, secrets_hash
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
             params![
                 owner_id.as_slice(),
                 account.as_slice(),
                 fact.authority.device_fingerprint.to_bytes().as_slice(),
                 i64::try_from(fact.effective_at)?,
                 fact.closed_at.map(i64::try_from).transpose()?,
+                control_kind,
+                control_seq.as_ref().map(<[u8; 8]>::as_slice),
+                control_hash.as_ref().map(<[u8; 32]>::as_slice),
+                secrets_kind,
+                secrets_seq.as_ref().map(<[u8; 8]>::as_slice),
+                secrets_hash.as_ref().map(<[u8; 32]>::as_slice),
             ],
         )?;
     }
@@ -1279,7 +1533,7 @@ mod tests {
     use super::*;
     use crate::index::schema;
     use crate::oplog::account::envelope::sign_account_entry;
-    use crate::oplog::account::ops::{DeviceCut, DeviceRole, GrantRole};
+    use crate::oplog::account::ops::{ContentCut, DeviceCut, DeviceRole, GrantRole};
     use crate::oplog::device::{DeviceSecret, DeviceX25519Secret};
     use crate::oplog::stream::{self, StreamSpec, StreamSpecV2};
 
@@ -1651,7 +1905,10 @@ mod tests {
         );
         assert!(matches!(
             roster_ref_effective(&conn, account_id, genesis_hash, founder.fp, 1).unwrap(),
-            fold::AuthorityQuery::Effective(fold::RosterAuthority { role: DeviceRole::Owner, .. })
+            fold::AuthorityQuery::Effective(fold::RosterAuthority {
+                current_role: DeviceRole::Owner,
+                ..
+            })
         ));
         assert!(matches!(
             owner_incarnation_effective(&conn, account_id, genesis_hash, founder.fp, 1).unwrap(),
@@ -1854,9 +2111,12 @@ mod tests {
         );
         assert!(matches!(
             roster_ref_effective(&conn, account_id, genesis_hash, founder.fp, 2).unwrap(),
-            fold::AuthorityQuery::Effective(fold::RosterAuthority { role: DeviceRole::Owner, .. })
+            fold::AuthorityQuery::Effective(fold::RosterAuthority {
+                current_role: DeviceRole::Owner,
+                ..
+            })
         ));
-        assert_eq!(schema::status(&conn).unwrap().current_version, 64);
+        assert_eq!(schema::status(&conn).unwrap().current_version, schema::LATEST_SCHEMA_VERSION);
     }
 
     #[test]
@@ -2831,6 +3091,37 @@ mod tests {
             roster_ref_effective(&conn, account_id, b2, g.fp, 7).unwrap(),
             fold::AuthorityQuery::Effective(_)
         ));
+        assert_eq!(
+            owner_control_authority(&conn, account_id, add_owner, owner.fp, 7).unwrap(),
+            fold::AuthorityQuery::Effective(fold::OwnerChainAuthority {
+                owner: fold::OwnerAuthority { device_fingerprint: owner.fp },
+                device_boundary: fold::AuthorityBoundary::Cut { seq: 2, hash: b2 },
+                incarnation_boundary: fold::AuthorityBoundary::Open,
+            }),
+            "the query exposes the final joined device register and the independent incarnation",
+        );
+
+        // Simulate an already-populated V064 projection upgrading: additive columns begin at
+        // their legacy-safe Open default, then V065's same-transaction refold must replace them
+        // before its ledger stamp commits.
+        conn.execute("DELETE FROM schema_version WHERE id = '065_account_authority_boundaries'", [
+        ])
+        .unwrap();
+        conn.execute(
+            "UPDATE account_roster_history
+             SET control_boundary = 'open', control_seq = NULL, control_hash = NULL
+             WHERE roster_ref = ?1",
+            [add_owner.as_slice()],
+        )
+        .unwrap();
+        schema::migrate_forward(&conn).unwrap();
+        assert!(matches!(
+            owner_control_authority(&conn, account_id, add_owner, owner.fp, 7).unwrap(),
+            fold::AuthorityQuery::Effective(fold::OwnerChainAuthority {
+                device_boundary: fold::AuthorityBoundary::Cut { seq: 2, hash },
+                ..
+            }) if hash == b2
+        ));
     }
 
     #[test]
@@ -2895,6 +3186,110 @@ mod tests {
             )
             .unwrap();
         assert_eq!(owner_count, 3, "only state-before owner incarnations are projected");
+    }
+
+    #[test]
+    fn owner_query_preserves_and_extends_both_registers_independently() {
+        let conn = db();
+        let founder = Dev::new(1);
+        let owner = Dev::new(2);
+        let (account, genesis_bytes, genesis) = genesis(&founder);
+        account_ingest(&conn, &genesis_bytes, NOW).unwrap();
+        let (add_bytes, owner_id) = op(
+            account,
+            &founder,
+            1,
+            Some(genesis),
+            Some(genesis),
+            &device_add(&owner, DeviceRole::Owner),
+        );
+        account_ingest(&conn, &add_bytes, NOW + 1).unwrap();
+        let mut prev = None;
+        let mut heads = Vec::new();
+        for (seq, seed) in [(0, 10), (1, 11), (2, 12)] {
+            let member = Dev::new(seed);
+            let (bytes, hash) = op(
+                account,
+                &owner,
+                seq,
+                prev,
+                Some(owner_id),
+                &device_add(&member, DeviceRole::Member),
+            );
+            account_ingest(&conn, &bytes, NOW + 2 + i64::try_from(seq).unwrap()).unwrap();
+            prev = Some(hash);
+            heads.push(hash);
+        }
+        let demote = AccountOp::OwnerDemote {
+            device_fingerprint: owner.fp,
+            owner_id,
+            control_cut: super::super::cut::Cut::At { seq: 0, hash: heads[0] },
+            secrets_cut: super::super::cut::Cut::Empty,
+            reason: "demote".to_string(),
+        };
+        let (demote_bytes, demote_hash) =
+            op(account, &founder, 2, Some(owner_id), Some(genesis), &demote);
+        account_ingest(&conn, &demote_bytes, NOW + 5).unwrap();
+        let (remove_bytes, remove_hash) = op(
+            account,
+            &founder,
+            3,
+            Some(demote_hash),
+            Some(genesis),
+            &device_remove(&owner, super::super::cut::Cut::At { seq: 1, hash: heads[1] }),
+        );
+        account_ingest(&conn, &remove_bytes, NOW + 6).unwrap();
+        let expected = |device_boundary, incarnation_boundary| {
+            fold::AuthorityQuery::Effective(fold::OwnerChainAuthority {
+                owner: fold::OwnerAuthority { device_fingerprint: owner.fp },
+                device_boundary,
+                incarnation_boundary,
+            })
+        };
+        assert_eq!(
+            owner_control_authority(&conn, account, owner_id, owner.fp, 0).unwrap(),
+            expected(
+                fold::AuthorityBoundary::Cut { seq: 1, hash: heads[1] },
+                fold::AuthorityBoundary::Cut { seq: 0, hash: heads[0] },
+            ),
+        );
+        let extend_incarnation = AccountOp::CutExtend {
+            chain_kind: super::super::ops::ChainKind::Ctrl,
+            stream_id: None,
+            incarnation_id: Some(owner_id),
+            subject_account_id: account,
+            device_fingerprint: owner.fp,
+            new_seq: 2,
+            new_entry_hash: heads[2],
+        };
+        let (bytes, extend_hash) =
+            op(account, &founder, 4, Some(remove_hash), Some(genesis), &extend_incarnation);
+        account_ingest(&conn, &bytes, NOW + 7).unwrap();
+        assert_eq!(
+            owner_control_authority(&conn, account, owner_id, owner.fp, 0).unwrap(),
+            expected(
+                fold::AuthorityBoundary::Cut { seq: 1, hash: heads[1] },
+                fold::AuthorityBoundary::Cut { seq: 2, hash: heads[2] },
+            ),
+            "extending the incarnation register leaves the device register unchanged",
+        );
+        let (bytes, _) = op(
+            account,
+            &founder,
+            5,
+            Some(extend_hash),
+            Some(genesis),
+            &cut_extend_ctrl(account, &owner, 2, heads[2]),
+        );
+        account_ingest(&conn, &bytes, NOW + 8).unwrap();
+        assert_eq!(
+            owner_control_authority(&conn, account, owner_id, owner.fp, 0).unwrap(),
+            expected(
+                fold::AuthorityBoundary::Cut { seq: 2, hash: heads[2] },
+                fold::AuthorityBoundary::Cut { seq: 2, hash: heads[2] },
+            ),
+            "extending the device register leaves the incarnation register unchanged",
+        );
     }
 
     #[test]
@@ -3018,7 +3413,7 @@ mod tests {
             roster_ref_effective(&conn, account_id, add, member.fp, 3).unwrap(),
             fold::AuthorityQuery::Effective(fold::RosterAuthority {
                 device_fingerprint: member.fp,
-                role: DeviceRole::Owner,
+                current_role: DeviceRole::Owner,
             }),
         );
 
@@ -3035,7 +3430,7 @@ mod tests {
             roster_ref_effective(&conn, account_id, add, member.fp, 4).unwrap(),
             fold::AuthorityQuery::Effective(fold::RosterAuthority {
                 device_fingerprint: member.fp,
-                role: DeviceRole::Member,
+                current_role: DeviceRole::Member,
             }),
         );
         assert_eq!(
@@ -3480,5 +3875,95 @@ mod tests {
             )
             .unwrap();
         assert_eq!(accepted, 2, "repeated clear-and-set refolds keep the same accepted chain");
+    }
+
+    #[test]
+    fn removed_roster_citation_keeps_only_its_per_stream_prefix() {
+        let conn = db();
+        let founder = Dev::new(1);
+        let member = Dev::new(2);
+        let (account, genesis_bytes, genesis_hash) = genesis(&founder);
+        account_ingest(&conn, &genesis_bytes, NOW).unwrap();
+        let (add_bytes, roster_ref) = op(
+            account,
+            &founder,
+            1,
+            Some(genesis_hash),
+            Some(genesis_hash),
+            &device_add(&member, DeviceRole::Member),
+        );
+        account_ingest(&conn, &add_bytes, NOW + 1).unwrap();
+        let listed = StreamId::from_bytes([0x41; 32]);
+        let unlisted = StreamId::from_bytes([0x42; 32]);
+        let remove = AccountOp::DeviceRemove {
+            device_fingerprint: member.fp,
+            control_cut: super::super::cut::Cut::Empty,
+            secrets_cut: super::super::cut::Cut::Empty,
+            content_cuts: vec![ContentCut { stream_id: listed, seq: u64::MAX, hash: [0xa5; 32] }],
+            reason: "revoked".to_string(),
+        };
+        let (remove_bytes, _) =
+            op(account, &founder, 2, Some(roster_ref), Some(genesis_hash), &remove);
+        account_ingest(&conn, &remove_bytes, NOW + 2).unwrap();
+
+        assert_eq!(
+            roster_content_authority(&conn, account, roster_ref, member.fp, listed, 3).unwrap(),
+            fold::AuthorityQuery::Effective(fold::RosterContentAuthority {
+                device_fingerprint: member.fp,
+                boundary: fold::AuthorityBoundary::Cut { seq: u64::MAX, hash: [0xa5; 32] },
+            }),
+        );
+        assert_eq!(
+            roster_content_authority(&conn, account, roster_ref, member.fp, unlisted, 3).unwrap(),
+            fold::AuthorityQuery::Effective(fold::RosterContentAuthority {
+                device_fingerprint: member.fp,
+                boundary: fold::AuthorityBoundary::Closed,
+            }),
+            "an omitted content chain is the empty cut, never open",
+        );
+    }
+
+    #[test]
+    fn malformed_persisted_owner_boundary_fails_closed() {
+        let conn = db();
+        let founder = Dev::new(1);
+        let (account, genesis_bytes, owner_id) = genesis(&founder);
+        account_ingest(&conn, &genesis_bytes, NOW).unwrap();
+        conn.execute(
+            "UPDATE account_owner_incarnations
+             SET control_boundary = 'cut', control_seq = NULL, control_hash = NULL
+             WHERE owner_id = ?1",
+            [owner_id.as_slice()],
+        )
+        .unwrap();
+        assert!(
+            owner_control_authority(&conn, account, owner_id, founder.fp, 1).is_err(),
+            "a partial cut tuple must never become open authority",
+        );
+        conn.execute(
+            "UPDATE account_owner_incarnations
+             SET control_boundary = 'open', effective_at = -1
+             WHERE owner_id = ?1",
+            [owner_id.as_slice()],
+        )
+        .unwrap();
+        assert!(
+            owner_control_authority(&conn, account, owner_id, founder.fp, 1).is_err(),
+            "negative fact epochs fail closed",
+        );
+        conn.execute(
+            "UPDATE account_owner_incarnations SET effective_at = 0, closed_at = 2
+             WHERE owner_id = ?1",
+            [owner_id.as_slice()],
+        )
+        .unwrap();
+        conn.execute("UPDATE account_roster_history SET closed_at = 2 WHERE roster_ref = ?1", [
+            owner_id.as_slice(),
+        ])
+        .unwrap();
+        assert!(
+            owner_control_authority(&conn, account, owner_id, founder.fp, 1).is_err(),
+            "a closed roster and owner cannot jointly retain Open/Open authority",
+        );
     }
 }

--- a/crates/rag-rat-core/src/oplog/mod.rs
+++ b/crates/rag-rat-core/src/oplog/mod.rs
@@ -47,11 +47,12 @@ mod stream;
 // cross the phase boundary.
 #[expect(unused_imports, reason = "C2 authority seam is frozen before its caller lands")]
 pub(crate) use account::{
-    AccountId, AuthorityInvalidReason, AuthorityParkReason, AuthorityQuery, CapacityScope,
-    DeviceCut, DeviceRole, GrantAuthority, GrantDeviceAuthority, GrantDeviceBoundary, GrantRole,
-    IngestOutcome, OwnerAuthority, RosterAuthority, account_ingest, backfill_authority_projection,
-    grant_effective_for_device, owner_incarnation_effective, roster_ref_effective,
-    stream_owner_effective,
+    AccountId, AuthorityBoundary, AuthorityInvalidReason, AuthorityParkReason, AuthorityQuery,
+    CapacityScope, DeviceCut, DeviceRole, GrantAuthority, GrantDeviceAuthority,
+    GrantDeviceBoundary, GrantRole, IngestOutcome, OwnerAuthority, OwnerChainAuthority,
+    RosterContentAuthority, account_ingest, backfill_authority_projection,
+    grant_effective_for_device, owner_control_authority, owner_secrets_authority,
+    roster_content_authority, stream_owner_effective,
 };
 // The op-log's first crate-internal API surface (#524): the MINTING primitives + the op
 // vocabulary the memory subsystem needs to author + backfill entries. Every submodule above is


### PR DESCRIPTION
Hardens the C1 authority seam after #641.

- preserves exact historical roster and owner citations under typed Open/Cut/Closed boundaries
- exposes per-stream content cuts and independent device + owner-incarnation control/secrets boundaries
- projects control cuts from the fold final joined registers, including retained pre-enrollment control registers
- removes the legacy unbounded queries and mutable role metadata from the curated C2 seam
- adds forward V065 storage with atomic populated-V064 backfill, full-u64 encoding, and fail-closed tuple/epoch validation
- adds defensive coverage for unlisted streams, corruption, final CutExtend joins, and independent register extension

Validation:
- cargo +nightly fmt --all
- cargo nextest run -p rag-rat-core account --no-fail-fast (155 passed)
- cargo nextest run -p rag-rat-core migration_065
- cargo clippy --workspace --all-targets -- -D warnings
- three final adversarial reviews: no blockers