### PR TITLE
feat(account): add pure content acceptance evaluator; split auth_len freshness out of the authority seam

### DIFF
--- a/crates/rag-rat-core/src/oplog/account/content/acceptance.rs
+++ b/crates/rag-rat-core/src/oplog/account/content/acceptance.rs
@@ -1,33 +1,46 @@
 //! Pure C3 `/3` acceptance predicate (§13).
 //!
-//! Persistence supplies provenance-bound authority facts and ancestry observations from one
-//! snapshot. Late control or ancestry arrival re-evaluates the same candidates; history is never
-//! mutated. Freshness is deliberately separate from authority so the frozen order remains
-//! authority/registers → branch → freshness.
+//! Persistence resolves every authority citation against the CURRENT fold — the only authority
+//! snapshot there is (§7: `auth_len` never selects a historical view) — and must read them all in
+//! ONE snapshot, so a refold committing mid-evaluation cannot combine an old grant with a new cut.
+//! Late control or ancestry arrival re-evaluates the same candidates; history is never mutated.
+//!
+//! Freshness is a separate axis from authority, applied LAST, so an author who cites control ops we
+//! have not folded cannot mask a condemnation or a fork the content DAG already decides. Its one
+//! reach backward is the rejection gate: a citation our fold reads as ineffective is fold-dependent
+//! (a `CutExtend` we have not folded re-blesses it, §11.4), so while we are behind the author that
+//! parks as `auth_len_ahead` instead of hardening into a rejection.
 
 use super::ContentEntryHeader;
 use crate::oplog::account::{
-    AccountId, AuthorityBoundary, AuthorityInvalidReason, GrantDeviceAuthority,
-    GrantDeviceBoundary, GrantRole, RosterContentAuthority,
+    AccountId, AuthorityBoundary, AuthorityFreshness, AuthorityInvalidReason, AuthorityQuery,
+    GrantDeviceAuthority, GrantDeviceBoundary, GrantRole, RosterContentAuthority,
 };
 use crate::oplog::stream::StreamId;
 
 type EntryHash = [u8; 32];
+
+/// Why an ancestry walk against a cut watermark could not be decided (mirrors the account fold's
+/// `UnknownCause`: a withheld watermark parks, and never flips a verdict — I11).
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum UnknownAncestry {
+    /// The cut's watermark entry itself is not held.
+    UnknownCutTarget,
+    /// A link on the walk from the watermark toward the entry is missing.
+    IncompleteCutAncestry,
+}
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum AncestryRelation {
     /// The entry is the watermark itself or an ancestor reached walking backward from it.
     OnBranch,
     OffBranch,
-    Unknown,
+    Unknown(UnknownAncestry),
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) enum AuthorityFreshness {
-    CurrentOrBehind,
-    Ahead,
-}
-
+/// One freshness observation, bound to the exact query it answers. The pair (account, asserted
+/// length) is carried so a result computed for the owner cannot be read as the author's, and a
+/// result computed for a shorter assertion cannot stand in for the header's.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) struct CitedFreshness {
     pub(crate) account_id: AccountId,
@@ -40,13 +53,6 @@ pub(crate) enum SubjectAuthorityHold {
     Clear,
     UnknownCutTarget,
     Contested,
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) enum ResolvedAuthority<T> {
-    Effective(T),
-    Unknown,
-    Invalid(AuthorityInvalidReason),
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -155,9 +161,9 @@ where
     pub(crate) owner_account_id: AccountId,
     pub(crate) dense_predecessor_reachable: bool,
     pub(crate) branch_selected: bool,
-    pub(crate) ownership: ResolvedAuthority<CitedOwnership>,
-    pub(crate) roster: ResolvedAuthority<CitedRosterAuthority>,
-    pub(crate) grant: Option<ResolvedAuthority<CitedGrantAuthority>>,
+    pub(crate) ownership: AuthorityQuery<CitedOwnership>,
+    pub(crate) roster: AuthorityQuery<CitedRosterAuthority>,
+    pub(crate) grant: Option<AuthorityQuery<CitedGrantAuthority>>,
     pub(crate) owner_freshness: CitedFreshness,
     pub(crate) author_freshness: CitedFreshness,
     pub(crate) subject_hold: SubjectAuthorityHold,
@@ -170,6 +176,18 @@ pub(crate) fn evaluate_content_acceptance<F>(
 where
     F: Fn(EntryHash, EntryHash) -> AncestryRelation,
 {
+    // Provenance first: a freshness verdict computed for another account, or for a shorter
+    // assertion than the header makes, decides nothing about THIS entry.
+    if input.owner_freshness.account_id != input.owner_account_id
+        || input.owner_freshness.asserted_auth_len != input.header.owner_auth_len
+        || input.author_freshness.account_id != input.header.author_account_id
+        || input.author_freshness.asserted_auth_len != input.header.author_auth_len
+    {
+        return Err(ContentAcceptanceInputError::FreshnessProvenance);
+    }
+    let owner_freshness = input.owner_freshness.state;
+    let author_freshness = input.author_freshness.state;
+
     let is_owner = input.header.author_account_id == input.owner_account_id;
     if is_owner && (input.header.grant_id.is_some() || input.grant.is_some()) {
         return Ok(ContentAcceptance::Rejected(ContentRejectReason::UnexpectedGrant));
@@ -178,40 +196,64 @@ where
         return Ok(ContentAcceptance::Rejected(ContentRejectReason::GrantRequired));
     }
     match input.ownership {
-        ResolvedAuthority::Effective(fact)
+        AuthorityQuery::Effective(fact)
             if fact.owner_account_id == input.owner_account_id
                 && fact.stream_id == input.header.stream_id => {},
-        ResolvedAuthority::Unknown =>
+        AuthorityQuery::Unknown =>
             return Ok(ContentAcceptance::Parked(ContentParkReason::UnknownOwner)),
-        ResolvedAuthority::Effective(_) | ResolvedAuthority::Invalid(_) =>
+        // Ownership is minted in the OWNER's log, so the owner's freshness gates its rejection.
+        AuthorityQuery::Invalid(reason) =>
+            return Ok(invalid_citation(
+                reason,
+                owner_freshness,
+                ContentRejectReason::OwnerReferenceInvalid,
+                ContentParkReason::OwnerAuthLenAhead,
+            )),
+        AuthorityQuery::Effective(_) =>
             return Ok(ContentAcceptance::Rejected(ContentRejectReason::OwnerReferenceInvalid)),
     }
     let roster = match input.roster {
-        ResolvedAuthority::Effective(fact)
+        AuthorityQuery::Effective(fact)
             if fact.account_id == input.header.author_account_id
                 && fact.roster_ref == input.header.roster_ref
                 && fact.stream_id == input.header.stream_id
                 && fact.authority.device_fingerprint == input.header.device_fingerprint =>
             fact,
-        ResolvedAuthority::Unknown =>
+        AuthorityQuery::Unknown =>
             return Ok(ContentAcceptance::Parked(ContentParkReason::UnknownRosterRef)),
-        ResolvedAuthority::Effective(_) | ResolvedAuthority::Invalid(_) =>
+        // The roster enrollment lives in the AUTHOR's log — the author's freshness gates it.
+        AuthorityQuery::Invalid(reason) =>
+            return Ok(invalid_citation(
+                reason,
+                author_freshness,
+                ContentRejectReason::RosterReferenceInvalid,
+                ContentParkReason::AuthorAuthLenAhead,
+            )),
+        AuthorityQuery::Effective(_) =>
             return Ok(ContentAcceptance::Rejected(ContentRejectReason::RosterReferenceInvalid)),
     };
     let mut boundaries = vec![roster.authority.boundary];
 
     if !is_owner {
         let grant = match input.grant.as_ref() {
-            Some(ResolvedAuthority::Effective(fact))
+            Some(AuthorityQuery::Effective(fact))
                 if fact.owner_account_id == input.owner_account_id
                     && Some(fact.grant_id) == input.header.grant_id
                     && fact.authority.grant.stream_id == input.header.stream_id
                     && fact.authority.grant.grantee_account_id
                         == input.header.author_account_id =>
                 fact,
-            Some(ResolvedAuthority::Unknown) | None =>
+            Some(AuthorityQuery::Unknown) | None =>
                 return Ok(ContentAcceptance::Parked(ContentParkReason::UnknownGrant)),
-            Some(ResolvedAuthority::Effective(_)) | Some(ResolvedAuthority::Invalid(_)) =>
+            // The grant is minted in the OWNER's log — the owner's freshness gates it.
+            Some(AuthorityQuery::Invalid(reason)) =>
+                return Ok(invalid_citation(
+                    *reason,
+                    owner_freshness,
+                    ContentRejectReason::GrantReferenceInvalid,
+                    ContentParkReason::OwnerAuthLenAhead,
+                )),
+            Some(AuthorityQuery::Effective(_)) =>
                 return Ok(ContentAcceptance::Rejected(ContentRejectReason::GrantReferenceInvalid)),
         };
         if grant.authority.grant.role != GrantRole::Writer {
@@ -249,22 +291,44 @@ where
     if !input.branch_selected {
         return Ok(ContentAcceptance::Forked);
     }
-    if input.owner_freshness.account_id != input.owner_account_id
-        || input.owner_freshness.asserted_auth_len != input.header.owner_auth_len
-        || input.author_freshness.account_id != input.header.author_account_id
-        || input.author_freshness.asserted_auth_len != input.header.author_auth_len
-    {
-        return Err(ContentAcceptanceInputError::FreshnessProvenance);
-    }
-    if input.owner_freshness.state == AuthorityFreshness::Ahead {
+    // Freshness last (§13): an author citing control ops we have not folded parks for refetch, but
+    // only once every verdict the current fold CAN decide — condemnation, fork — has been ruled
+    // out.
+    if owner_freshness == AuthorityFreshness::Ahead {
         return Ok(ContentAcceptance::Parked(ContentParkReason::OwnerAuthLenAhead));
     }
-    if input.author_freshness.state == AuthorityFreshness::Ahead {
+    if author_freshness == AuthorityFreshness::Ahead {
         return Ok(ContentAcceptance::Parked(ContentParkReason::AuthorAuthLenAhead));
     }
     Ok(ContentAcceptance::Accepted)
 }
 
+/// Lower an `Invalid` citation into a verdict. `WrongSubject` is decided by bytes we already hold,
+/// so it rejects outright; `ReferencedEntryNotEffective` is a verdict of OUR fold, and a fold
+/// behind the author's may still be missing the `CutExtend` that re-blesses the citation (§11.4) —
+/// so while that account's control log is ahead of us, it parks for refetch rather than hardening
+/// into a rejection we would have to walk back.
+fn invalid_citation(
+    reason: AuthorityInvalidReason,
+    freshness: AuthorityFreshness,
+    reject: ContentRejectReason,
+    ahead: ContentParkReason,
+) -> ContentAcceptance {
+    match (reason, freshness) {
+        (AuthorityInvalidReason::WrongSubject, _)
+        | (
+            AuthorityInvalidReason::ReferencedEntryNotEffective,
+            AuthorityFreshness::CurrentOrBehind,
+        ) => ContentAcceptance::Rejected(reject),
+        (AuthorityInvalidReason::ReferencedEntryNotEffective, AuthorityFreshness::Ahead) =>
+            ContentAcceptance::Parked(ahead),
+    }
+}
+
+/// Combine every applicable revocation register into one verdict, with the account fold's frozen
+/// precedence (`register_verdict`): a definite condemnation outranks any park, so incomplete
+/// ancestry on one register can never mask a `beyond_cut` (which needs no ancestry at all) on
+/// another; a withheld watermark outranks a missing mid-chain link; `Open`/on-branch is clear.
 fn combine_boundaries<F>(
     boundaries: &[AuthorityBoundary],
     seq: u64,
@@ -277,12 +341,13 @@ where
     let rank = boundaries.iter().fold(0, |rank, boundary| {
         let candidate = match *boundary {
             AuthorityBoundary::Open => 0,
-            AuthorityBoundary::Closed => 4,
-            AuthorityBoundary::Cut { seq: cut_seq, .. } if seq > cut_seq => 2,
+            AuthorityBoundary::Closed => 5,
+            AuthorityBoundary::Cut { seq: cut_seq, .. } if seq > cut_seq => 3,
             AuthorityBoundary::Cut { hash, .. } => match ancestry(entry_hash, hash) {
                 AncestryRelation::OnBranch => 0,
-                AncestryRelation::Unknown => 1,
-                AncestryRelation::OffBranch => 3,
+                AncestryRelation::Unknown(UnknownAncestry::IncompleteCutAncestry) => 1,
+                AncestryRelation::Unknown(UnknownAncestry::UnknownCutTarget) => 2,
+                AncestryRelation::OffBranch => 4,
             },
         };
         rank.max(candidate)
@@ -290,9 +355,10 @@ where
     match rank {
         0 => None,
         1 => Some(ContentAcceptance::Parked(ContentParkReason::IncompleteCutAncestry)),
-        2 => Some(ContentAcceptance::Condemned(ContentCondemnReason::BeyondCut)),
-        3 => Some(ContentAcceptance::Condemned(ContentCondemnReason::OffBranch)),
-        4 => Some(ContentAcceptance::Condemned(ContentCondemnReason::ClosedIncarnation)),
+        2 => Some(ContentAcceptance::Parked(ContentParkReason::UnknownCutTarget)),
+        3 => Some(ContentAcceptance::Condemned(ContentCondemnReason::BeyondCut)),
+        4 => Some(ContentAcceptance::Condemned(ContentCondemnReason::OffBranch)),
+        5 => Some(ContentAcceptance::Condemned(ContentCondemnReason::ClosedIncarnation)),
         _ => unreachable!("boundary ranks are closed"),
     }
 }
@@ -329,8 +395,8 @@ mod tests {
         }
     }
 
-    fn ownership(header: &ContentEntryHeader) -> ResolvedAuthority<CitedOwnership> {
-        ResolvedAuthority::Effective(CitedOwnership {
+    fn ownership(header: &ContentEntryHeader) -> AuthorityQuery<CitedOwnership> {
+        AuthorityQuery::Effective(CitedOwnership {
             owner_account_id: owner(),
             stream_id: header.stream_id,
         })
@@ -339,8 +405,8 @@ mod tests {
     fn roster(
         header: &ContentEntryHeader,
         boundary: AuthorityBoundary,
-    ) -> ResolvedAuthority<CitedRosterAuthority> {
-        ResolvedAuthority::Effective(CitedRosterAuthority {
+    ) -> AuthorityQuery<CitedRosterAuthority> {
+        AuthorityQuery::Effective(CitedRosterAuthority {
             account_id: header.author_account_id,
             roster_ref: header.roster_ref,
             stream_id: header.stream_id,
@@ -355,8 +421,8 @@ mod tests {
         header: &ContentEntryHeader,
         role: GrantRole,
         boundary: GrantDeviceBoundary,
-    ) -> ResolvedAuthority<CitedGrantAuthority> {
-        ResolvedAuthority::Effective(CitedGrantAuthority {
+    ) -> AuthorityQuery<CitedGrantAuthority> {
+        AuthorityQuery::Effective(CitedGrantAuthority {
             owner_account_id: owner(),
             grant_id: header.grant_id.unwrap(),
             authority: GrantDeviceAuthority {
@@ -380,8 +446,8 @@ mod tests {
 
     fn evaluate(
         header: &ContentEntryHeader,
-        roster: ResolvedAuthority<CitedRosterAuthority>,
-        grant: Option<ResolvedAuthority<CitedGrantAuthority>>,
+        roster: AuthorityQuery<CitedRosterAuthority>,
+        grant: Option<AuthorityQuery<CitedGrantAuthority>>,
         relation: AncestryRelation,
     ) -> ContentAcceptance {
         evaluate_content_acceptance(&ContentAcceptanceInput {
@@ -470,21 +536,21 @@ mod tests {
     fn exact_query_provenance_prevents_cross_owner_and_readd_laundering() {
         let entry = header(author(), Some([7; 32]), 0);
         let mut wrong_roster = match roster(&entry, AuthorityBoundary::Open) {
-            ResolvedAuthority::Effective(fact) => fact,
+            AuthorityQuery::Effective(fact) => fact,
             _ => unreachable!(),
         };
         wrong_roster.roster_ref = [0xaa; 32];
         assert_eq!(
             evaluate(
                 &entry,
-                ResolvedAuthority::Effective(wrong_roster),
+                AuthorityQuery::Effective(wrong_roster),
                 Some(grant(&entry, GrantRole::Writer, GrantDeviceBoundary::Open)),
                 AncestryRelation::OnBranch
             ),
             ContentAcceptance::Rejected(ContentRejectReason::RosterReferenceInvalid)
         );
         let mut wrong_grant = match grant(&entry, GrantRole::Writer, GrantDeviceBoundary::Open) {
-            ResolvedAuthority::Effective(fact) => fact,
+            AuthorityQuery::Effective(fact) => fact,
             _ => unreachable!(),
         };
         wrong_grant.owner_account_id = AccountId::from_bytes([0xbb; 32]);
@@ -492,13 +558,13 @@ mod tests {
             evaluate(
                 &entry,
                 roster(&entry, AuthorityBoundary::Open),
-                Some(ResolvedAuthority::Effective(wrong_grant)),
+                Some(AuthorityQuery::Effective(wrong_grant)),
                 AncestryRelation::OnBranch
             ),
             ContentAcceptance::Rejected(ContentRejectReason::GrantReferenceInvalid)
         );
         let mut wrong_ownership = match ownership(&entry) {
-            ResolvedAuthority::Effective(fact) => fact,
+            AuthorityQuery::Effective(fact) => fact,
             _ => unreachable!(),
         };
         wrong_ownership.stream_id = StreamId::from_bytes([0xcc; 32]);
@@ -508,7 +574,7 @@ mod tests {
             owner_account_id: owner(),
             dense_predecessor_reachable: true,
             branch_selected: true,
-            ownership: ResolvedAuthority::Effective(wrong_ownership),
+            ownership: AuthorityQuery::Effective(wrong_ownership),
             roster: roster(&entry, AuthorityBoundary::Open),
             grant: Some(grant(&entry, GrantRole::Writer, GrantDeviceBoundary::Open)),
             owner_freshness: freshness(
@@ -534,15 +600,21 @@ mod tests {
     fn definite_boundary_outcomes_dominate_incomplete_sibling_boundaries() {
         let entry = header(author(), Some([7; 32]), 3);
         let cut = DeviceCut { device_fingerprint: entry.device_fingerprint, seq: 2, hash: [8; 32] };
-        assert_eq!(
-            evaluate(
-                &entry,
-                roster(&entry, AuthorityBoundary::Cut { seq: 9, hash: [0xaa; 32] }),
-                Some(grant(&entry, GrantRole::Writer, GrantDeviceBoundary::Cut(cut))),
-                AncestryRelation::Unknown
-            ),
-            ContentAcceptance::Condemned(ContentCondemnReason::BeyondCut)
-        );
+        // The grant cut condemns on `seq` alone (no ancestry needed). Neither undecided ancestry
+        // cause on the roster's register may mask it — otherwise a peer could park a condemnation
+        // indefinitely by withholding one watermark.
+        for undecided in [UnknownAncestry::IncompleteCutAncestry, UnknownAncestry::UnknownCutTarget]
+        {
+            assert_eq!(
+                evaluate(
+                    &entry,
+                    roster(&entry, AuthorityBoundary::Cut { seq: 9, hash: [0xaa; 32] }),
+                    Some(grant(&entry, GrantRole::Writer, GrantDeviceBoundary::Cut(cut.clone()))),
+                    AncestryRelation::Unknown(undecided)
+                ),
+                ContentAcceptance::Condemned(ContentCondemnReason::BeyondCut)
+            );
+        }
         assert_eq!(
             evaluate(
                 &entry,
@@ -551,6 +623,73 @@ mod tests {
                 AncestryRelation::OnBranch
             ),
             ContentAcceptance::Condemned(ContentCondemnReason::ClosedIncarnation)
+        );
+    }
+
+    /// A withheld watermark and a missing mid-chain link are DIFFERENT states of not-knowing, and
+    /// the account fold already names them apart. C3 keeps them apart too — a missing cut target
+    /// tells a peer to fetch that entry, an incomplete chain tells it to fetch the walk — and it
+    /// keeps the fold's precedence: the withheld watermark is the one reported when both apply.
+    #[test]
+    fn undecided_ancestry_causes_stay_distinct_and_keep_the_folds_precedence() {
+        let entry = header(owner(), None, 2);
+        let boundary = AuthorityBoundary::Cut { seq: 5, hash: [7; 32] };
+        assert_eq!(
+            evaluate(
+                &entry,
+                roster(&entry, boundary),
+                None,
+                AncestryRelation::Unknown(UnknownAncestry::UnknownCutTarget)
+            ),
+            ContentAcceptance::Parked(ContentParkReason::UnknownCutTarget)
+        );
+        assert_eq!(
+            evaluate(
+                &entry,
+                roster(&entry, boundary),
+                None,
+                AncestryRelation::Unknown(UnknownAncestry::IncompleteCutAncestry)
+            ),
+            ContentAcceptance::Parked(ContentParkReason::IncompleteCutAncestry)
+        );
+        // Two registers, each undecided for a different reason: the withheld watermark wins.
+        let contributor = header(author(), Some([7; 32]), 2);
+        let cut =
+            DeviceCut { device_fingerprint: contributor.device_fingerprint, seq: 5, hash: [8; 32] };
+        let decision = evaluate_content_acceptance(&ContentAcceptanceInput {
+            header: &contributor,
+            entry_hash: ENTRY_HASH,
+            owner_account_id: owner(),
+            dense_predecessor_reachable: true,
+            branch_selected: true,
+            ownership: ownership(&contributor),
+            roster: roster(&contributor, boundary),
+            grant: Some(grant(&contributor, GrantRole::Writer, GrantDeviceBoundary::Cut(cut))),
+            owner_freshness: freshness(
+                owner(),
+                contributor.owner_auth_len,
+                AuthorityFreshness::CurrentOrBehind,
+            ),
+            author_freshness: freshness(
+                author(),
+                contributor.author_auth_len,
+                AuthorityFreshness::CurrentOrBehind,
+            ),
+            subject_hold: SubjectAuthorityHold::Clear,
+            // The roster's watermark [7; 32] is held but its chain has a gap; the grant's watermark
+            // [8; 32] is not held at all.
+            ancestry: |_, watermark| {
+                if watermark == [8; 32] {
+                    AncestryRelation::Unknown(UnknownAncestry::UnknownCutTarget)
+                } else {
+                    AncestryRelation::Unknown(UnknownAncestry::IncompleteCutAncestry)
+                }
+            },
+        });
+        assert_eq!(
+            decision,
+            Ok(ContentAcceptance::Parked(ContentParkReason::UnknownCutTarget)),
+            "a withheld watermark outranks a missing mid-chain link, as in the account fold",
         );
     }
 
@@ -571,12 +710,41 @@ mod tests {
             subject_hold: SubjectAuthorityHold::Clear,
             ancestry: |_, _| AncestryRelation::OnBranch,
         };
+        // A fork is decided by the content DAG alone, so an ahead control log cannot hide it.
         assert_eq!(evaluate_content_acceptance(&base), Ok(ContentAcceptance::Forked));
+        // But a citation our own fold reads as ineffective is a verdict OF that fold, and while the
+        // author's control log runs ahead of ours the CutExtend that re-blesses it may simply be
+        // one of the ops we have not fetched (§11.4). Park for refetch — never harden into a
+        // rejection we would have to walk back.
         assert_eq!(
             evaluate_content_acceptance(&ContentAcceptanceInput {
-                roster: ResolvedAuthority::Invalid(
+                roster: AuthorityQuery::Invalid(
                     AuthorityInvalidReason::ReferencedEntryNotEffective,
                 ),
+                ..base.clone()
+            }),
+            Ok(ContentAcceptance::Parked(ContentParkReason::AuthorAuthLenAhead))
+        );
+        // Once we are level with the author, the same citation is a lie and rejects.
+        assert_eq!(
+            evaluate_content_acceptance(&ContentAcceptanceInput {
+                roster: AuthorityQuery::Invalid(
+                    AuthorityInvalidReason::ReferencedEntryNotEffective,
+                ),
+                author_freshness: freshness(
+                    owner(),
+                    entry.author_auth_len,
+                    AuthorityFreshness::CurrentOrBehind,
+                ),
+                ..base.clone()
+            }),
+            Ok(ContentAcceptance::Rejected(ContentRejectReason::RosterReferenceInvalid))
+        );
+        // A wrong-subject citation is contradicted by bytes we already hold, so no depth of control
+        // log can rescue it: it rejects even while we are behind.
+        assert_eq!(
+            evaluate_content_acceptance(&ContentAcceptanceInput {
+                roster: AuthorityQuery::Invalid(AuthorityInvalidReason::WrongSubject),
                 ..base
             }),
             Ok(ContentAcceptance::Rejected(ContentRejectReason::RosterReferenceInvalid))
@@ -596,7 +764,7 @@ mod tests {
                 ContentAcceptance::Condemned(ContentCondemnReason::OffBranch),
             ),
             (
-                AncestryRelation::Unknown,
+                AncestryRelation::Unknown(UnknownAncestry::IncompleteCutAncestry),
                 ContentAcceptance::Parked(ContentParkReason::IncompleteCutAncestry),
             ),
         ] {
@@ -651,7 +819,7 @@ mod tests {
         };
         assert_eq!(
             evaluate_content_acceptance(&ContentAcceptanceInput {
-                roster: ResolvedAuthority::Invalid(AuthorityInvalidReason::WrongSubject),
+                roster: AuthorityQuery::Invalid(AuthorityInvalidReason::WrongSubject),
                 ..base.clone()
             }),
             Ok(ContentAcceptance::Rejected(ContentRejectReason::RosterReferenceInvalid))
@@ -681,18 +849,25 @@ mod tests {
             ownership: ownership(&entry),
             roster: roster(&entry, AuthorityBoundary::Open),
             grant: None,
+            // Laundered: the owner's slot carries a verdict computed for the AUTHOR's account.
             owner_freshness: freshness(author(), entry.owner_auth_len, AuthorityFreshness::Ahead),
             author_freshness: freshness(owner(), entry.author_auth_len, AuthorityFreshness::Ahead),
             subject_hold: SubjectAuthorityHold::Clear,
             ancestry: |_, _| AncestryRelation::OnBranch,
         };
-        assert_eq!(evaluate_content_acceptance(&input), Ok(ContentAcceptance::Forked));
-        input.branch_selected = true;
+        // Provenance is a PRECONDITION, not a lazily-consulted value. The authority phase already
+        // gates its rejections on freshness, so a verdict computed for the wrong account has to be
+        // refused before ANY decision is derived from it — reaching a fork first does not excuse
+        // it.
         assert_eq!(
             evaluate_content_acceptance(&input),
             Err(ContentAcceptanceInputError::FreshnessProvenance)
         );
         input.owner_freshness.account_id = owner();
+        // With honest provenance, freshness still runs LAST: the fork the content DAG has already
+        // decided is reported, never masked by an ahead counter.
+        assert_eq!(evaluate_content_acceptance(&input), Ok(ContentAcceptance::Forked));
+        input.branch_selected = true;
         assert_eq!(
             evaluate_content_acceptance(&input),
             Ok(ContentAcceptance::Parked(ContentParkReason::OwnerAuthLenAhead))
@@ -729,7 +904,7 @@ mod tests {
                 ContentAcceptance::Condemned(ContentCondemnReason::OffBranch),
             ),
             (
-                AncestryRelation::Unknown,
+                AncestryRelation::Unknown(UnknownAncestry::IncompleteCutAncestry),
                 ContentAcceptance::Parked(ContentParkReason::IncompleteCutAncestry),
             ),
         ] {
@@ -822,28 +997,28 @@ mod tests {
         };
         assert_eq!(
             evaluate_content_acceptance(&ContentAcceptanceInput {
-                ownership: ResolvedAuthority::Unknown,
+                ownership: AuthorityQuery::Unknown,
                 ..base.clone()
             }),
             Ok(ContentAcceptance::Parked(ContentParkReason::UnknownOwner))
         );
         assert_eq!(
             evaluate_content_acceptance(&ContentAcceptanceInput {
-                roster: ResolvedAuthority::Invalid(AuthorityInvalidReason::WrongSubject),
+                roster: AuthorityQuery::Invalid(AuthorityInvalidReason::WrongSubject),
                 ..base.clone()
             }),
             Ok(ContentAcceptance::Rejected(ContentRejectReason::RosterReferenceInvalid))
         );
         assert_eq!(
             evaluate_content_acceptance(&ContentAcceptanceInput {
-                grant: Some(ResolvedAuthority::Unknown),
+                grant: Some(AuthorityQuery::Unknown),
                 ..base.clone()
             }),
             Ok(ContentAcceptance::Parked(ContentParkReason::UnknownGrant))
         );
         assert_eq!(
             evaluate_content_acceptance(&ContentAcceptanceInput {
-                grant: Some(ResolvedAuthority::Invalid(
+                grant: Some(AuthorityQuery::Invalid(
                     AuthorityInvalidReason::ReferencedEntryNotEffective,
                 )),
                 ..base
@@ -890,7 +1065,7 @@ mod tests {
                 subject_hold: SubjectAuthorityHold::Clear,
                 ancestry: |_, _| {
                     calls.set(calls.get() + 1);
-                    AncestryRelation::Unknown
+                    AncestryRelation::Unknown(UnknownAncestry::UnknownCutTarget)
                 },
             });
             assert_eq!(decision, Ok(expected));
@@ -956,7 +1131,7 @@ mod tests {
                 owner_account_id: owner(),
                 dense_predecessor_reachable: true,
                 branch_selected: true,
-                ownership: ResolvedAuthority::Effective(fact),
+                ownership: AuthorityQuery::Effective(fact),
                 roster: roster(&entry, AuthorityBoundary::Open),
                 grant: Some(grant(&entry, GrantRole::Writer, GrantDeviceBoundary::Open)),
                 owner_freshness: freshness(
@@ -976,7 +1151,7 @@ mod tests {
         }
 
         let valid_roster = match roster(&entry, AuthorityBoundary::Open) {
-            ResolvedAuthority::Effective(fact) => fact,
+            AuthorityQuery::Effective(fact) => fact,
             _ => unreachable!(),
         };
         for fact in [
@@ -994,7 +1169,7 @@ mod tests {
             assert_eq!(
                 evaluate(
                     &entry,
-                    ResolvedAuthority::Effective(fact),
+                    AuthorityQuery::Effective(fact),
                     Some(grant(&entry, GrantRole::Writer, GrantDeviceBoundary::Open)),
                     AncestryRelation::OnBranch,
                 ),
@@ -1003,7 +1178,7 @@ mod tests {
         }
 
         let valid_grant = match grant(&entry, GrantRole::Writer, GrantDeviceBoundary::Open) {
-            ResolvedAuthority::Effective(fact) => fact,
+            AuthorityQuery::Effective(fact) => fact,
             _ => unreachable!(),
         };
         let mut wrong_grant_id = valid_grant.clone();
@@ -1022,7 +1197,7 @@ mod tests {
                 evaluate(
                     &entry,
                     roster(&entry, AuthorityBoundary::Open),
-                    Some(ResolvedAuthority::Effective(fact)),
+                    Some(AuthorityQuery::Effective(fact)),
                     AncestryRelation::OnBranch,
                 ),
                 ContentAcceptance::Rejected(ContentRejectReason::GrantReferenceInvalid)
@@ -1108,7 +1283,7 @@ mod tests {
                 if hash == [1; 32] {
                     AncestryRelation::OffBranch
                 } else {
-                    AncestryRelation::Unknown
+                    AncestryRelation::Unknown(UnknownAncestry::UnknownCutTarget)
                 }
             }),
             Some(ContentAcceptance::Condemned(ContentCondemnReason::OffBranch))
@@ -1162,7 +1337,9 @@ mod tests {
                 owner_freshness: freshness(owner(), 1, AuthorityFreshness::CurrentOrBehind),
                 author_freshness: freshness(owner(), 1, AuthorityFreshness::CurrentOrBehind),
                 subject_hold: hold,
-                ancestry: |_, _| AncestryRelation::Unknown,
+                // Incomplete (not withheld) ancestry, so the boundary's own park is the WEAKER
+                // token: each expected verdict below is attributable to the hold, not to this.
+                ancestry: |_, _| AncestryRelation::Unknown(UnknownAncestry::IncompleteCutAncestry),
             });
             assert_eq!(decision, Ok(expected));
         }

--- a/crates/rag-rat-core/src/oplog/account/content/acceptance.rs
+++ b/crates/rag-rat-core/src/oplog/account/content/acceptance.rs
@@ -1,0 +1,1280 @@
+//! Pure C3 `/3` acceptance predicate (§13).
+//!
+//! Persistence supplies provenance-bound authority facts and ancestry observations from one
+//! snapshot. Late control or ancestry arrival re-evaluates the same candidates; history is never
+//! mutated. Freshness is deliberately separate from authority so the frozen order remains
+//! authority/registers → branch → freshness.
+
+use super::ContentEntryHeader;
+use crate::oplog::account::{
+    AccountId, AuthorityBoundary, AuthorityInvalidReason, GrantDeviceAuthority,
+    GrantDeviceBoundary, GrantRole, RosterContentAuthority,
+};
+use crate::oplog::stream::StreamId;
+
+type EntryHash = [u8; 32];
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum AncestryRelation {
+    /// The entry is the watermark itself or an ancestor reached walking backward from it.
+    OnBranch,
+    OffBranch,
+    Unknown,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum AuthorityFreshness {
+    CurrentOrBehind,
+    Ahead,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct CitedFreshness {
+    pub(crate) account_id: AccountId,
+    pub(crate) asserted_auth_len: u64,
+    pub(crate) state: AuthorityFreshness,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum SubjectAuthorityHold {
+    Clear,
+    UnknownCutTarget,
+    Contested,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ResolvedAuthority<T> {
+    Effective(T),
+    Unknown,
+    Invalid(AuthorityInvalidReason),
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct CitedOwnership {
+    pub(crate) owner_account_id: AccountId,
+    pub(crate) stream_id: StreamId,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct CitedRosterAuthority {
+    pub(crate) account_id: AccountId,
+    pub(crate) roster_ref: EntryHash,
+    pub(crate) stream_id: StreamId,
+    pub(crate) authority: RosterContentAuthority,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct CitedGrantAuthority {
+    pub(crate) owner_account_id: AccountId,
+    pub(crate) grant_id: EntryHash,
+    pub(crate) authority: GrantDeviceAuthority,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ContentParkReason {
+    MissingPredecessor,
+    UnknownOwner,
+    UnknownRosterRef,
+    UnknownGrant,
+    OwnerAuthLenAhead,
+    AuthorAuthLenAhead,
+    IncompleteCutAncestry,
+    UnknownCutTarget,
+    ContestedSubject,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ContentCondemnReason {
+    BeyondCut,
+    OffBranch,
+    ClosedIncarnation,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ContentRejectReason {
+    OwnerReferenceInvalid,
+    RosterReferenceInvalid,
+    GrantReferenceInvalid,
+    GrantRequired,
+    UnexpectedGrant,
+    GrantDoesNotPermitWrite,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ContentAcceptanceInputError {
+    FreshnessProvenance,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ContentAcceptance {
+    Accepted,
+    Forked,
+    Parked(ContentParkReason),
+    Condemned(ContentCondemnReason),
+    Rejected(ContentRejectReason),
+}
+
+impl ContentAcceptance {
+    pub(crate) fn as_db_str(self) -> &'static str {
+        match self {
+            Self::Accepted => "accepted",
+            Self::Forked => "forked",
+            Self::Parked(ContentParkReason::MissingPredecessor) => "parked{missing_predecessor}",
+            Self::Parked(ContentParkReason::UnknownOwner) => "parked{unknown_account}",
+            Self::Parked(ContentParkReason::UnknownRosterRef) => "parked{unknown_roster_ref}",
+            Self::Parked(ContentParkReason::UnknownGrant) => "parked{unknown_grant}",
+            Self::Parked(ContentParkReason::OwnerAuthLenAhead)
+            | Self::Parked(ContentParkReason::AuthorAuthLenAhead) => "parked{auth_len_ahead}",
+            Self::Parked(ContentParkReason::IncompleteCutAncestry) =>
+                "parked{incomplete_cut_ancestry}",
+            Self::Parked(ContentParkReason::UnknownCutTarget) => "parked{unknown_cut_target}",
+            Self::Parked(ContentParkReason::ContestedSubject) => "parked{contested_subject}",
+            Self::Condemned(ContentCondemnReason::BeyondCut) => "condemned{beyond_cut}",
+            Self::Condemned(ContentCondemnReason::OffBranch) => "condemned{off_branch}",
+            Self::Condemned(ContentCondemnReason::ClosedIncarnation) =>
+                "condemned{closed_incarnation}",
+            Self::Rejected(ContentRejectReason::OwnerReferenceInvalid) => "rejected{invalid_owner}",
+            Self::Rejected(ContentRejectReason::RosterReferenceInvalid) =>
+                "rejected{invalid_roster_ref}",
+            Self::Rejected(ContentRejectReason::GrantReferenceInvalid) => "rejected{invalid_grant}",
+            Self::Rejected(ContentRejectReason::GrantRequired) => "rejected{grant_required}",
+            Self::Rejected(ContentRejectReason::UnexpectedGrant) => "rejected{unexpected_grant}",
+            Self::Rejected(ContentRejectReason::GrantDoesNotPermitWrite) =>
+                "rejected{grant_not_writer}",
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct ContentAcceptanceInput<'a, F>
+where
+    F: Fn(EntryHash, EntryHash) -> AncestryRelation,
+{
+    pub(crate) header: &'a ContentEntryHeader,
+    pub(crate) entry_hash: EntryHash,
+    pub(crate) owner_account_id: AccountId,
+    pub(crate) dense_predecessor_reachable: bool,
+    pub(crate) branch_selected: bool,
+    pub(crate) ownership: ResolvedAuthority<CitedOwnership>,
+    pub(crate) roster: ResolvedAuthority<CitedRosterAuthority>,
+    pub(crate) grant: Option<ResolvedAuthority<CitedGrantAuthority>>,
+    pub(crate) owner_freshness: CitedFreshness,
+    pub(crate) author_freshness: CitedFreshness,
+    pub(crate) subject_hold: SubjectAuthorityHold,
+    pub(crate) ancestry: F,
+}
+
+pub(crate) fn evaluate_content_acceptance<F>(
+    input: &ContentAcceptanceInput<'_, F>,
+) -> Result<ContentAcceptance, ContentAcceptanceInputError>
+where
+    F: Fn(EntryHash, EntryHash) -> AncestryRelation,
+{
+    let is_owner = input.header.author_account_id == input.owner_account_id;
+    if is_owner && (input.header.grant_id.is_some() || input.grant.is_some()) {
+        return Ok(ContentAcceptance::Rejected(ContentRejectReason::UnexpectedGrant));
+    }
+    if !is_owner && input.header.grant_id.is_none() {
+        return Ok(ContentAcceptance::Rejected(ContentRejectReason::GrantRequired));
+    }
+    match input.ownership {
+        ResolvedAuthority::Effective(fact)
+            if fact.owner_account_id == input.owner_account_id
+                && fact.stream_id == input.header.stream_id => {},
+        ResolvedAuthority::Unknown =>
+            return Ok(ContentAcceptance::Parked(ContentParkReason::UnknownOwner)),
+        ResolvedAuthority::Effective(_) | ResolvedAuthority::Invalid(_) =>
+            return Ok(ContentAcceptance::Rejected(ContentRejectReason::OwnerReferenceInvalid)),
+    }
+    let roster = match input.roster {
+        ResolvedAuthority::Effective(fact)
+            if fact.account_id == input.header.author_account_id
+                && fact.roster_ref == input.header.roster_ref
+                && fact.stream_id == input.header.stream_id
+                && fact.authority.device_fingerprint == input.header.device_fingerprint =>
+            fact,
+        ResolvedAuthority::Unknown =>
+            return Ok(ContentAcceptance::Parked(ContentParkReason::UnknownRosterRef)),
+        ResolvedAuthority::Effective(_) | ResolvedAuthority::Invalid(_) =>
+            return Ok(ContentAcceptance::Rejected(ContentRejectReason::RosterReferenceInvalid)),
+    };
+    let mut boundaries = vec![roster.authority.boundary];
+
+    if !is_owner {
+        let grant = match input.grant.as_ref() {
+            Some(ResolvedAuthority::Effective(fact))
+                if fact.owner_account_id == input.owner_account_id
+                    && Some(fact.grant_id) == input.header.grant_id
+                    && fact.authority.grant.stream_id == input.header.stream_id
+                    && fact.authority.grant.grantee_account_id
+                        == input.header.author_account_id =>
+                fact,
+            Some(ResolvedAuthority::Unknown) | None =>
+                return Ok(ContentAcceptance::Parked(ContentParkReason::UnknownGrant)),
+            Some(ResolvedAuthority::Effective(_)) | Some(ResolvedAuthority::Invalid(_)) =>
+                return Ok(ContentAcceptance::Rejected(ContentRejectReason::GrantReferenceInvalid)),
+        };
+        if grant.authority.grant.role != GrantRole::Writer {
+            return Ok(ContentAcceptance::Rejected(ContentRejectReason::GrantDoesNotPermitWrite));
+        }
+        boundaries.push(match &grant.authority.boundary {
+            GrantDeviceBoundary::Open => AuthorityBoundary::Open,
+            GrantDeviceBoundary::Cut(cut)
+                if cut.device_fingerprint == input.header.device_fingerprint =>
+                AuthorityBoundary::Cut { seq: cut.seq, hash: cut.hash },
+            GrantDeviceBoundary::Cut(_) =>
+                return Ok(ContentAcceptance::Rejected(ContentRejectReason::GrantReferenceInvalid)),
+            GrantDeviceBoundary::Closed => AuthorityBoundary::Closed,
+        });
+    }
+
+    let boundary_decision =
+        combine_boundaries(&boundaries, input.header.seq, input.entry_hash, &input.ancestry);
+    if matches!(boundary_decision, Some(ContentAcceptance::Condemned(_))) {
+        return Ok(boundary_decision.expect("matched Some"));
+    }
+    match input.subject_hold {
+        SubjectAuthorityHold::UnknownCutTarget =>
+            return Ok(ContentAcceptance::Parked(ContentParkReason::UnknownCutTarget)),
+        SubjectAuthorityHold::Contested =>
+            return Ok(ContentAcceptance::Parked(ContentParkReason::ContestedSubject)),
+        SubjectAuthorityHold::Clear => {},
+    }
+    if let Some(decision) = boundary_decision {
+        return Ok(decision);
+    }
+    if !input.dense_predecessor_reachable {
+        return Ok(ContentAcceptance::Parked(ContentParkReason::MissingPredecessor));
+    }
+    if !input.branch_selected {
+        return Ok(ContentAcceptance::Forked);
+    }
+    if input.owner_freshness.account_id != input.owner_account_id
+        || input.owner_freshness.asserted_auth_len != input.header.owner_auth_len
+        || input.author_freshness.account_id != input.header.author_account_id
+        || input.author_freshness.asserted_auth_len != input.header.author_auth_len
+    {
+        return Err(ContentAcceptanceInputError::FreshnessProvenance);
+    }
+    if input.owner_freshness.state == AuthorityFreshness::Ahead {
+        return Ok(ContentAcceptance::Parked(ContentParkReason::OwnerAuthLenAhead));
+    }
+    if input.author_freshness.state == AuthorityFreshness::Ahead {
+        return Ok(ContentAcceptance::Parked(ContentParkReason::AuthorAuthLenAhead));
+    }
+    Ok(ContentAcceptance::Accepted)
+}
+
+fn combine_boundaries<F>(
+    boundaries: &[AuthorityBoundary],
+    seq: u64,
+    entry_hash: EntryHash,
+    ancestry: &F,
+) -> Option<ContentAcceptance>
+where
+    F: Fn(EntryHash, EntryHash) -> AncestryRelation,
+{
+    let rank = boundaries.iter().fold(0, |rank, boundary| {
+        let candidate = match *boundary {
+            AuthorityBoundary::Open => 0,
+            AuthorityBoundary::Closed => 4,
+            AuthorityBoundary::Cut { seq: cut_seq, .. } if seq > cut_seq => 2,
+            AuthorityBoundary::Cut { hash, .. } => match ancestry(entry_hash, hash) {
+                AncestryRelation::OnBranch => 0,
+                AncestryRelation::Unknown => 1,
+                AncestryRelation::OffBranch => 3,
+            },
+        };
+        rank.max(candidate)
+    });
+    match rank {
+        0 => None,
+        1 => Some(ContentAcceptance::Parked(ContentParkReason::IncompleteCutAncestry)),
+        2 => Some(ContentAcceptance::Condemned(ContentCondemnReason::BeyondCut)),
+        3 => Some(ContentAcceptance::Condemned(ContentCondemnReason::OffBranch)),
+        4 => Some(ContentAcceptance::Condemned(ContentCondemnReason::ClosedIncarnation)),
+        _ => unreachable!("boundary ranks are closed"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::oplog::account::{DeviceCut, GrantAuthority};
+    use crate::oplog::op::DeviceFingerprint;
+
+    const ENTRY_HASH: EntryHash = [9; 32];
+    fn owner() -> AccountId {
+        AccountId::from_bytes([5; 32])
+    }
+
+    fn author() -> AccountId {
+        AccountId::from_bytes([6; 32])
+    }
+
+    fn header(author: AccountId, grant_id: Option<EntryHash>, seq: u64) -> ContentEntryHeader {
+        ContentEntryHeader {
+            stream_id: StreamId::from_bytes([1; 32]),
+            author_account_id: author,
+            device_fingerprint: DeviceFingerprint::from_bytes([2; 32]),
+            seq,
+            lamport: u64::MAX,
+            prev_hash: (seq > 0).then_some([3; 32]),
+            grant_id,
+            roster_ref: [4; 32],
+            owner_auth_len: 1,
+            author_auth_len: 1,
+            crypto_suite: 0,
+            key_id: None,
+        }
+    }
+
+    fn ownership(header: &ContentEntryHeader) -> ResolvedAuthority<CitedOwnership> {
+        ResolvedAuthority::Effective(CitedOwnership {
+            owner_account_id: owner(),
+            stream_id: header.stream_id,
+        })
+    }
+
+    fn roster(
+        header: &ContentEntryHeader,
+        boundary: AuthorityBoundary,
+    ) -> ResolvedAuthority<CitedRosterAuthority> {
+        ResolvedAuthority::Effective(CitedRosterAuthority {
+            account_id: header.author_account_id,
+            roster_ref: header.roster_ref,
+            stream_id: header.stream_id,
+            authority: RosterContentAuthority {
+                device_fingerprint: header.device_fingerprint,
+                boundary,
+            },
+        })
+    }
+
+    fn grant(
+        header: &ContentEntryHeader,
+        role: GrantRole,
+        boundary: GrantDeviceBoundary,
+    ) -> ResolvedAuthority<CitedGrantAuthority> {
+        ResolvedAuthority::Effective(CitedGrantAuthority {
+            owner_account_id: owner(),
+            grant_id: header.grant_id.unwrap(),
+            authority: GrantDeviceAuthority {
+                grant: GrantAuthority {
+                    stream_id: header.stream_id,
+                    grantee_account_id: header.author_account_id,
+                    role,
+                },
+                boundary,
+            },
+        })
+    }
+
+    fn freshness(
+        account_id: AccountId,
+        asserted_auth_len: u64,
+        state: AuthorityFreshness,
+    ) -> CitedFreshness {
+        CitedFreshness { account_id, asserted_auth_len, state }
+    }
+
+    fn evaluate(
+        header: &ContentEntryHeader,
+        roster: ResolvedAuthority<CitedRosterAuthority>,
+        grant: Option<ResolvedAuthority<CitedGrantAuthority>>,
+        relation: AncestryRelation,
+    ) -> ContentAcceptance {
+        evaluate_content_acceptance(&ContentAcceptanceInput {
+            header,
+            entry_hash: ENTRY_HASH,
+            owner_account_id: owner(),
+            dense_predecessor_reachable: true,
+            branch_selected: true,
+            ownership: ownership(header),
+            roster,
+            grant,
+            owner_freshness: freshness(
+                owner(),
+                header.owner_auth_len,
+                AuthorityFreshness::CurrentOrBehind,
+            ),
+            author_freshness: freshness(
+                header.author_account_id,
+                header.author_auth_len,
+                AuthorityFreshness::CurrentOrBehind,
+            ),
+            subject_hold: SubjectAuthorityHold::Clear,
+            ancestry: move |_, _| relation,
+        })
+        .expect("test input has consistent freshness provenance")
+    }
+
+    #[test]
+    fn owner_and_contributor_happy_paths_enforce_grant_shape_and_role() {
+        let owner = header(owner(), None, 0);
+        assert_eq!(
+            evaluate(
+                &owner,
+                roster(&owner, AuthorityBoundary::Open),
+                None,
+                AncestryRelation::OnBranch
+            ),
+            ContentAcceptance::Accepted
+        );
+        let contributor = header(author(), Some([7; 32]), 0);
+        assert_eq!(
+            evaluate(
+                &contributor,
+                roster(&contributor, AuthorityBoundary::Open),
+                Some(grant(&contributor, GrantRole::Writer, GrantDeviceBoundary::Open)),
+                AncestryRelation::OnBranch
+            ),
+            ContentAcceptance::Accepted
+        );
+        assert_eq!(
+            evaluate(
+                &contributor,
+                roster(&contributor, AuthorityBoundary::Open),
+                Some(grant(&contributor, GrantRole::Reader, GrantDeviceBoundary::Open)),
+                AncestryRelation::OnBranch
+            ),
+            ContentAcceptance::Rejected(ContentRejectReason::GrantDoesNotPermitWrite)
+        );
+    }
+
+    #[test]
+    fn structural_grant_coupling_precedes_cut_classification() {
+        let malformed_owner = header(owner(), Some([7; 32]), 3);
+        assert_eq!(
+            evaluate(
+                &malformed_owner,
+                roster(&malformed_owner, AuthorityBoundary::Closed),
+                None,
+                AncestryRelation::OffBranch
+            ),
+            ContentAcceptance::Rejected(ContentRejectReason::UnexpectedGrant)
+        );
+        let malformed_contributor = header(author(), None, 3);
+        assert_eq!(
+            evaluate(
+                &malformed_contributor,
+                roster(&malformed_contributor, AuthorityBoundary::Closed),
+                None,
+                AncestryRelation::OffBranch
+            ),
+            ContentAcceptance::Rejected(ContentRejectReason::GrantRequired)
+        );
+    }
+
+    #[test]
+    fn exact_query_provenance_prevents_cross_owner_and_readd_laundering() {
+        let entry = header(author(), Some([7; 32]), 0);
+        let mut wrong_roster = match roster(&entry, AuthorityBoundary::Open) {
+            ResolvedAuthority::Effective(fact) => fact,
+            _ => unreachable!(),
+        };
+        wrong_roster.roster_ref = [0xaa; 32];
+        assert_eq!(
+            evaluate(
+                &entry,
+                ResolvedAuthority::Effective(wrong_roster),
+                Some(grant(&entry, GrantRole::Writer, GrantDeviceBoundary::Open)),
+                AncestryRelation::OnBranch
+            ),
+            ContentAcceptance::Rejected(ContentRejectReason::RosterReferenceInvalid)
+        );
+        let mut wrong_grant = match grant(&entry, GrantRole::Writer, GrantDeviceBoundary::Open) {
+            ResolvedAuthority::Effective(fact) => fact,
+            _ => unreachable!(),
+        };
+        wrong_grant.owner_account_id = AccountId::from_bytes([0xbb; 32]);
+        assert_eq!(
+            evaluate(
+                &entry,
+                roster(&entry, AuthorityBoundary::Open),
+                Some(ResolvedAuthority::Effective(wrong_grant)),
+                AncestryRelation::OnBranch
+            ),
+            ContentAcceptance::Rejected(ContentRejectReason::GrantReferenceInvalid)
+        );
+        let mut wrong_ownership = match ownership(&entry) {
+            ResolvedAuthority::Effective(fact) => fact,
+            _ => unreachable!(),
+        };
+        wrong_ownership.stream_id = StreamId::from_bytes([0xcc; 32]);
+        let input = ContentAcceptanceInput {
+            header: &entry,
+            entry_hash: ENTRY_HASH,
+            owner_account_id: owner(),
+            dense_predecessor_reachable: true,
+            branch_selected: true,
+            ownership: ResolvedAuthority::Effective(wrong_ownership),
+            roster: roster(&entry, AuthorityBoundary::Open),
+            grant: Some(grant(&entry, GrantRole::Writer, GrantDeviceBoundary::Open)),
+            owner_freshness: freshness(
+                owner(),
+                entry.owner_auth_len,
+                AuthorityFreshness::CurrentOrBehind,
+            ),
+            author_freshness: freshness(
+                author(),
+                entry.author_auth_len,
+                AuthorityFreshness::CurrentOrBehind,
+            ),
+            subject_hold: SubjectAuthorityHold::Clear,
+            ancestry: |_, _| AncestryRelation::OnBranch,
+        };
+        assert_eq!(
+            evaluate_content_acceptance(&input),
+            Ok(ContentAcceptance::Rejected(ContentRejectReason::OwnerReferenceInvalid))
+        );
+    }
+
+    #[test]
+    fn definite_boundary_outcomes_dominate_incomplete_sibling_boundaries() {
+        let entry = header(author(), Some([7; 32]), 3);
+        let cut = DeviceCut { device_fingerprint: entry.device_fingerprint, seq: 2, hash: [8; 32] };
+        assert_eq!(
+            evaluate(
+                &entry,
+                roster(&entry, AuthorityBoundary::Cut { seq: 9, hash: [0xaa; 32] }),
+                Some(grant(&entry, GrantRole::Writer, GrantDeviceBoundary::Cut(cut))),
+                AncestryRelation::Unknown
+            ),
+            ContentAcceptance::Condemned(ContentCondemnReason::BeyondCut)
+        );
+        assert_eq!(
+            evaluate(
+                &entry,
+                roster(&entry, AuthorityBoundary::Closed),
+                Some(grant(&entry, GrantRole::Writer, GrantDeviceBoundary::Open)),
+                AncestryRelation::OnBranch
+            ),
+            ContentAcceptance::Condemned(ContentCondemnReason::ClosedIncarnation)
+        );
+    }
+
+    #[test]
+    fn branch_precedes_freshness_but_authority_precedes_branch() {
+        let entry = header(owner(), None, 0);
+        let base = ContentAcceptanceInput {
+            header: &entry,
+            entry_hash: ENTRY_HASH,
+            owner_account_id: owner(),
+            dense_predecessor_reachable: true,
+            branch_selected: false,
+            ownership: ownership(&entry),
+            roster: roster(&entry, AuthorityBoundary::Open),
+            grant: None,
+            owner_freshness: freshness(owner(), entry.owner_auth_len, AuthorityFreshness::Ahead),
+            author_freshness: freshness(owner(), entry.author_auth_len, AuthorityFreshness::Ahead),
+            subject_hold: SubjectAuthorityHold::Clear,
+            ancestry: |_, _| AncestryRelation::OnBranch,
+        };
+        assert_eq!(evaluate_content_acceptance(&base), Ok(ContentAcceptance::Forked));
+        assert_eq!(
+            evaluate_content_acceptance(&ContentAcceptanceInput {
+                roster: ResolvedAuthority::Invalid(
+                    AuthorityInvalidReason::ReferencedEntryNotEffective,
+                ),
+                ..base
+            }),
+            Ok(ContentAcceptance::Rejected(ContentRejectReason::RosterReferenceInvalid))
+        );
+    }
+
+    #[test]
+    fn exact_cut_edge_freezes_ancestry_direction_and_missing_link_behavior() {
+        use std::cell::Cell;
+
+        let entry = header(owner(), None, 2);
+        let boundary = AuthorityBoundary::Cut { seq: 2, hash: [7; 32] };
+        for (relation, expected) in [
+            (AncestryRelation::OnBranch, ContentAcceptance::Accepted),
+            (
+                AncestryRelation::OffBranch,
+                ContentAcceptance::Condemned(ContentCondemnReason::OffBranch),
+            ),
+            (
+                AncestryRelation::Unknown,
+                ContentAcceptance::Parked(ContentParkReason::IncompleteCutAncestry),
+            ),
+        ] {
+            assert_eq!(evaluate(&entry, roster(&entry, boundary), None, relation), expected);
+        }
+        let arguments = Cell::new(None);
+        let decision = evaluate_content_acceptance(&ContentAcceptanceInput {
+            header: &entry,
+            entry_hash: ENTRY_HASH,
+            owner_account_id: owner(),
+            dense_predecessor_reachable: true,
+            branch_selected: true,
+            ownership: ownership(&entry),
+            roster: roster(&entry, boundary),
+            grant: None,
+            owner_freshness: freshness(
+                owner(),
+                entry.owner_auth_len,
+                AuthorityFreshness::CurrentOrBehind,
+            ),
+            author_freshness: freshness(
+                owner(),
+                entry.author_auth_len,
+                AuthorityFreshness::CurrentOrBehind,
+            ),
+            subject_hold: SubjectAuthorityHold::Clear,
+            ancestry: |entry_hash, cut_hash| {
+                arguments.set(Some((entry_hash, cut_hash)));
+                AncestryRelation::OnBranch
+            },
+        });
+        assert_eq!(decision, Ok(ContentAcceptance::Accepted));
+        assert_eq!(arguments.get(), Some((ENTRY_HASH, [7; 32])));
+    }
+
+    #[test]
+    fn authority_and_boundaries_precede_predecessor_branch_and_freshness() {
+        let entry = header(owner(), None, 0);
+        let base = ContentAcceptanceInput {
+            header: &entry,
+            entry_hash: ENTRY_HASH,
+            owner_account_id: owner(),
+            dense_predecessor_reachable: false,
+            branch_selected: false,
+            ownership: ownership(&entry),
+            roster: roster(&entry, AuthorityBoundary::Open),
+            grant: None,
+            owner_freshness: freshness(owner(), entry.owner_auth_len, AuthorityFreshness::Ahead),
+            author_freshness: freshness(owner(), entry.author_auth_len, AuthorityFreshness::Ahead),
+            subject_hold: SubjectAuthorityHold::Clear,
+            ancestry: |_, _| AncestryRelation::OnBranch,
+        };
+        assert_eq!(
+            evaluate_content_acceptance(&ContentAcceptanceInput {
+                roster: ResolvedAuthority::Invalid(AuthorityInvalidReason::WrongSubject),
+                ..base.clone()
+            }),
+            Ok(ContentAcceptance::Rejected(ContentRejectReason::RosterReferenceInvalid))
+        );
+        assert_eq!(
+            evaluate_content_acceptance(&ContentAcceptanceInput {
+                roster: roster(&entry, AuthorityBoundary::Closed),
+                ..base.clone()
+            }),
+            Ok(ContentAcceptance::Condemned(ContentCondemnReason::ClosedIncarnation))
+        );
+        assert_eq!(
+            evaluate_content_acceptance(&base),
+            Ok(ContentAcceptance::Parked(ContentParkReason::MissingPredecessor))
+        );
+    }
+
+    #[test]
+    fn freshness_is_provenance_bound_and_runs_after_branch_selection() {
+        let entry = header(owner(), None, 0);
+        let mut input = ContentAcceptanceInput {
+            header: &entry,
+            entry_hash: ENTRY_HASH,
+            owner_account_id: owner(),
+            dense_predecessor_reachable: true,
+            branch_selected: false,
+            ownership: ownership(&entry),
+            roster: roster(&entry, AuthorityBoundary::Open),
+            grant: None,
+            owner_freshness: freshness(author(), entry.owner_auth_len, AuthorityFreshness::Ahead),
+            author_freshness: freshness(owner(), entry.author_auth_len, AuthorityFreshness::Ahead),
+            subject_hold: SubjectAuthorityHold::Clear,
+            ancestry: |_, _| AncestryRelation::OnBranch,
+        };
+        assert_eq!(evaluate_content_acceptance(&input), Ok(ContentAcceptance::Forked));
+        input.branch_selected = true;
+        assert_eq!(
+            evaluate_content_acceptance(&input),
+            Err(ContentAcceptanceInputError::FreshnessProvenance)
+        );
+        input.owner_freshness.account_id = owner();
+        assert_eq!(
+            evaluate_content_acceptance(&input),
+            Ok(ContentAcceptance::Parked(ContentParkReason::OwnerAuthLenAhead))
+        );
+        input.owner_freshness.state = AuthorityFreshness::CurrentOrBehind;
+        assert_eq!(
+            evaluate_content_acceptance(&input),
+            Ok(ContentAcceptance::Parked(ContentParkReason::AuthorAuthLenAhead))
+        );
+    }
+
+    #[test]
+    fn grant_cut_requires_same_device_and_obeys_exact_and_closed_boundaries() {
+        use std::cell::Cell;
+
+        let entry = header(author(), Some([7; 32]), 2);
+        let exact = DeviceCut {
+            device_fingerprint: entry.device_fingerprint,
+            seq: entry.seq,
+            hash: [7; 32],
+        };
+        assert_eq!(
+            evaluate(
+                &entry,
+                roster(&entry, AuthorityBoundary::Open),
+                Some(grant(&entry, GrantRole::Writer, GrantDeviceBoundary::Cut(exact.clone()),)),
+                AncestryRelation::OnBranch,
+            ),
+            ContentAcceptance::Accepted
+        );
+        for (relation, expected) in [
+            (
+                AncestryRelation::OffBranch,
+                ContentAcceptance::Condemned(ContentCondemnReason::OffBranch),
+            ),
+            (
+                AncestryRelation::Unknown,
+                ContentAcceptance::Parked(ContentParkReason::IncompleteCutAncestry),
+            ),
+        ] {
+            assert_eq!(
+                evaluate(
+                    &entry,
+                    roster(&entry, AuthorityBoundary::Open),
+                    Some(
+                        grant(&entry, GrantRole::Writer, GrantDeviceBoundary::Cut(exact.clone()),)
+                    ),
+                    relation,
+                ),
+                expected
+            );
+        }
+        let arguments = Cell::new(None);
+        let decision = evaluate_content_acceptance(&ContentAcceptanceInput {
+            header: &entry,
+            entry_hash: ENTRY_HASH,
+            owner_account_id: owner(),
+            dense_predecessor_reachable: true,
+            branch_selected: true,
+            ownership: ownership(&entry),
+            roster: roster(&entry, AuthorityBoundary::Open),
+            grant: Some(grant(&entry, GrantRole::Writer, GrantDeviceBoundary::Cut(exact.clone()))),
+            owner_freshness: freshness(
+                owner(),
+                entry.owner_auth_len,
+                AuthorityFreshness::CurrentOrBehind,
+            ),
+            author_freshness: freshness(
+                author(),
+                entry.author_auth_len,
+                AuthorityFreshness::CurrentOrBehind,
+            ),
+            subject_hold: SubjectAuthorityHold::Clear,
+            ancestry: |entry_hash, cut_hash| {
+                arguments.set(Some((entry_hash, cut_hash)));
+                AncestryRelation::OnBranch
+            },
+        });
+        assert_eq!(decision, Ok(ContentAcceptance::Accepted));
+        assert_eq!(arguments.get(), Some((ENTRY_HASH, exact.hash)));
+        assert_eq!(
+            evaluate(
+                &entry,
+                roster(&entry, AuthorityBoundary::Open),
+                Some(grant(&entry, GrantRole::Writer, GrantDeviceBoundary::Closed)),
+                AncestryRelation::OnBranch,
+            ),
+            ContentAcceptance::Condemned(ContentCondemnReason::ClosedIncarnation)
+        );
+        let wrong_device =
+            DeviceCut { device_fingerprint: DeviceFingerprint::from_bytes([0xee; 32]), ..exact };
+        assert_eq!(
+            evaluate(
+                &entry,
+                roster(&entry, AuthorityBoundary::Open),
+                Some(grant(&entry, GrantRole::Writer, GrantDeviceBoundary::Cut(wrong_device))),
+                AncestryRelation::OnBranch,
+            ),
+            ContentAcceptance::Rejected(ContentRejectReason::GrantReferenceInvalid)
+        );
+    }
+
+    #[test]
+    fn unresolved_and_invalid_authority_states_are_contextual_and_fail_closed() {
+        let entry = header(author(), Some([7; 32]), 0);
+        let base = ContentAcceptanceInput {
+            header: &entry,
+            entry_hash: ENTRY_HASH,
+            owner_account_id: owner(),
+            dense_predecessor_reachable: true,
+            branch_selected: true,
+            ownership: ownership(&entry),
+            roster: roster(&entry, AuthorityBoundary::Open),
+            grant: Some(grant(&entry, GrantRole::Writer, GrantDeviceBoundary::Open)),
+            owner_freshness: freshness(
+                owner(),
+                entry.owner_auth_len,
+                AuthorityFreshness::CurrentOrBehind,
+            ),
+            author_freshness: freshness(
+                author(),
+                entry.author_auth_len,
+                AuthorityFreshness::CurrentOrBehind,
+            ),
+            subject_hold: SubjectAuthorityHold::Clear,
+            ancestry: |_, _| AncestryRelation::OnBranch,
+        };
+        assert_eq!(
+            evaluate_content_acceptance(&ContentAcceptanceInput {
+                ownership: ResolvedAuthority::Unknown,
+                ..base.clone()
+            }),
+            Ok(ContentAcceptance::Parked(ContentParkReason::UnknownOwner))
+        );
+        assert_eq!(
+            evaluate_content_acceptance(&ContentAcceptanceInput {
+                roster: ResolvedAuthority::Invalid(AuthorityInvalidReason::WrongSubject),
+                ..base.clone()
+            }),
+            Ok(ContentAcceptance::Rejected(ContentRejectReason::RosterReferenceInvalid))
+        );
+        assert_eq!(
+            evaluate_content_acceptance(&ContentAcceptanceInput {
+                grant: Some(ResolvedAuthority::Unknown),
+                ..base.clone()
+            }),
+            Ok(ContentAcceptance::Parked(ContentParkReason::UnknownGrant))
+        );
+        assert_eq!(
+            evaluate_content_acceptance(&ContentAcceptanceInput {
+                grant: Some(ResolvedAuthority::Invalid(
+                    AuthorityInvalidReason::ReferencedEntryNotEffective,
+                )),
+                ..base
+            }),
+            Ok(ContentAcceptance::Rejected(ContentRejectReason::GrantReferenceInvalid))
+        );
+    }
+
+    #[test]
+    fn beyond_and_closed_boundaries_do_not_consult_ancestry() {
+        use std::cell::Cell;
+
+        let entry = header(owner(), None, u64::MAX);
+        for (boundary, expected) in [
+            (
+                AuthorityBoundary::Cut { seq: u64::MAX - 1, hash: [7; 32] },
+                ContentAcceptance::Condemned(ContentCondemnReason::BeyondCut),
+            ),
+            (
+                AuthorityBoundary::Closed,
+                ContentAcceptance::Condemned(ContentCondemnReason::ClosedIncarnation),
+            ),
+        ] {
+            let calls = Cell::new(0);
+            let decision = evaluate_content_acceptance(&ContentAcceptanceInput {
+                header: &entry,
+                entry_hash: ENTRY_HASH,
+                owner_account_id: owner(),
+                dense_predecessor_reachable: true,
+                branch_selected: true,
+                ownership: ownership(&entry),
+                roster: roster(&entry, boundary),
+                grant: None,
+                owner_freshness: freshness(
+                    owner(),
+                    entry.owner_auth_len,
+                    AuthorityFreshness::CurrentOrBehind,
+                ),
+                author_freshness: freshness(
+                    owner(),
+                    entry.author_auth_len,
+                    AuthorityFreshness::CurrentOrBehind,
+                ),
+                subject_hold: SubjectAuthorityHold::Clear,
+                ancestry: |_, _| {
+                    calls.set(calls.get() + 1);
+                    AncestryRelation::Unknown
+                },
+            });
+            assert_eq!(decision, Ok(expected));
+            assert_eq!(calls.get(), 0);
+        }
+    }
+
+    #[test]
+    fn subject_holds_are_fail_closed_and_re_evaluable() {
+        let entry = header(owner(), None, 0);
+        for (hold, expected) in [
+            (
+                SubjectAuthorityHold::UnknownCutTarget,
+                ContentAcceptance::Parked(ContentParkReason::UnknownCutTarget),
+            ),
+            (
+                SubjectAuthorityHold::Contested,
+                ContentAcceptance::Parked(ContentParkReason::ContestedSubject),
+            ),
+        ] {
+            assert_eq!(
+                evaluate_content_acceptance(&ContentAcceptanceInput {
+                    header: &entry,
+                    entry_hash: ENTRY_HASH,
+                    owner_account_id: owner(),
+                    dense_predecessor_reachable: true,
+                    branch_selected: true,
+                    ownership: ownership(&entry),
+                    roster: roster(&entry, AuthorityBoundary::Open),
+                    grant: None,
+                    owner_freshness: freshness(
+                        owner(),
+                        entry.owner_auth_len,
+                        AuthorityFreshness::CurrentOrBehind
+                    ),
+                    author_freshness: freshness(
+                        owner(),
+                        entry.author_auth_len,
+                        AuthorityFreshness::CurrentOrBehind
+                    ),
+                    subject_hold: hold,
+                    ancestry: |_, _| AncestryRelation::OnBranch,
+                }),
+                Ok(expected)
+            );
+        }
+    }
+
+    #[test]
+    fn every_authority_provenance_component_is_enforced() {
+        let entry = header(author(), Some([7; 32]), 0);
+        let expected = Ok(ContentAcceptance::Rejected(ContentRejectReason::OwnerReferenceInvalid));
+        for fact in [
+            CitedOwnership { owner_account_id: author(), stream_id: entry.stream_id },
+            CitedOwnership {
+                owner_account_id: owner(),
+                stream_id: StreamId::from_bytes([0xa1; 32]),
+            },
+        ] {
+            let input = ContentAcceptanceInput {
+                header: &entry,
+                entry_hash: ENTRY_HASH,
+                owner_account_id: owner(),
+                dense_predecessor_reachable: true,
+                branch_selected: true,
+                ownership: ResolvedAuthority::Effective(fact),
+                roster: roster(&entry, AuthorityBoundary::Open),
+                grant: Some(grant(&entry, GrantRole::Writer, GrantDeviceBoundary::Open)),
+                owner_freshness: freshness(
+                    owner(),
+                    entry.owner_auth_len,
+                    AuthorityFreshness::CurrentOrBehind,
+                ),
+                author_freshness: freshness(
+                    author(),
+                    entry.author_auth_len,
+                    AuthorityFreshness::CurrentOrBehind,
+                ),
+                subject_hold: SubjectAuthorityHold::Clear,
+                ancestry: |_, _| AncestryRelation::OnBranch,
+            };
+            assert_eq!(evaluate_content_acceptance(&input), expected);
+        }
+
+        let valid_roster = match roster(&entry, AuthorityBoundary::Open) {
+            ResolvedAuthority::Effective(fact) => fact,
+            _ => unreachable!(),
+        };
+        for fact in [
+            CitedRosterAuthority { account_id: owner(), ..valid_roster },
+            CitedRosterAuthority { roster_ref: [0xa2; 32], ..valid_roster },
+            CitedRosterAuthority { stream_id: StreamId::from_bytes([0xa3; 32]), ..valid_roster },
+            CitedRosterAuthority {
+                authority: RosterContentAuthority {
+                    device_fingerprint: DeviceFingerprint::from_bytes([0xa4; 32]),
+                    boundary: AuthorityBoundary::Open,
+                },
+                ..valid_roster
+            },
+        ] {
+            assert_eq!(
+                evaluate(
+                    &entry,
+                    ResolvedAuthority::Effective(fact),
+                    Some(grant(&entry, GrantRole::Writer, GrantDeviceBoundary::Open)),
+                    AncestryRelation::OnBranch,
+                ),
+                ContentAcceptance::Rejected(ContentRejectReason::RosterReferenceInvalid)
+            );
+        }
+
+        let valid_grant = match grant(&entry, GrantRole::Writer, GrantDeviceBoundary::Open) {
+            ResolvedAuthority::Effective(fact) => fact,
+            _ => unreachable!(),
+        };
+        let mut wrong_grant_id = valid_grant.clone();
+        wrong_grant_id.grant_id = [0xa5; 32];
+        let mut wrong_stream = valid_grant.clone();
+        wrong_stream.authority.grant.stream_id = StreamId::from_bytes([0xa6; 32]);
+        let mut wrong_grantee = valid_grant.clone();
+        wrong_grantee.authority.grant.grantee_account_id = owner();
+        for fact in [
+            CitedGrantAuthority { owner_account_id: author(), ..valid_grant.clone() },
+            wrong_grant_id,
+            wrong_stream,
+            wrong_grantee,
+        ] {
+            assert_eq!(
+                evaluate(
+                    &entry,
+                    roster(&entry, AuthorityBoundary::Open),
+                    Some(ResolvedAuthority::Effective(fact)),
+                    AncestryRelation::OnBranch,
+                ),
+                ContentAcceptance::Rejected(ContentRejectReason::GrantReferenceInvalid)
+            );
+        }
+    }
+
+    #[test]
+    fn every_freshness_provenance_component_is_enforced() {
+        let entry = header(author(), Some([7; 32]), 0);
+        let base = ContentAcceptanceInput {
+            header: &entry,
+            entry_hash: ENTRY_HASH,
+            owner_account_id: owner(),
+            dense_predecessor_reachable: true,
+            branch_selected: true,
+            ownership: ownership(&entry),
+            roster: roster(&entry, AuthorityBoundary::Open),
+            grant: Some(grant(&entry, GrantRole::Writer, GrantDeviceBoundary::Open)),
+            owner_freshness: freshness(
+                owner(),
+                entry.owner_auth_len,
+                AuthorityFreshness::CurrentOrBehind,
+            ),
+            author_freshness: freshness(
+                author(),
+                entry.author_auth_len,
+                AuthorityFreshness::CurrentOrBehind,
+            ),
+            subject_hold: SubjectAuthorityHold::Clear,
+            ancestry: |_, _| AncestryRelation::OnBranch,
+        };
+        for input in [
+            ContentAcceptanceInput {
+                owner_freshness: freshness(
+                    author(),
+                    entry.owner_auth_len,
+                    AuthorityFreshness::CurrentOrBehind,
+                ),
+                ..base.clone()
+            },
+            ContentAcceptanceInput {
+                owner_freshness: freshness(
+                    owner(),
+                    entry.owner_auth_len + 1,
+                    AuthorityFreshness::CurrentOrBehind,
+                ),
+                ..base.clone()
+            },
+            ContentAcceptanceInput {
+                author_freshness: freshness(
+                    owner(),
+                    entry.author_auth_len,
+                    AuthorityFreshness::CurrentOrBehind,
+                ),
+                ..base.clone()
+            },
+            ContentAcceptanceInput {
+                author_freshness: freshness(
+                    author(),
+                    entry.author_auth_len + 1,
+                    AuthorityFreshness::CurrentOrBehind,
+                ),
+                ..base
+            },
+        ] {
+            assert_eq!(
+                evaluate_content_acceptance(&input),
+                Err(ContentAcceptanceInputError::FreshnessProvenance)
+            );
+        }
+    }
+
+    #[test]
+    fn combined_boundaries_and_subject_holds_have_stable_precedence() {
+        let boundaries =
+            [AuthorityBoundary::Cut { seq: 9, hash: [1; 32] }, AuthorityBoundary::Cut {
+                seq: 1,
+                hash: [2; 32],
+            }];
+        assert_eq!(
+            combine_boundaries(&boundaries, 2, ENTRY_HASH, &|_, hash| {
+                if hash == [1; 32] {
+                    AncestryRelation::OffBranch
+                } else {
+                    AncestryRelation::Unknown
+                }
+            }),
+            Some(ContentAcceptance::Condemned(ContentCondemnReason::OffBranch))
+        );
+        assert_eq!(
+            combine_boundaries(
+                &[AuthorityBoundary::Cut { seq: 9, hash: [1; 32] }, AuthorityBoundary::Closed],
+                2,
+                ENTRY_HASH,
+                &|_, _| AncestryRelation::OffBranch,
+            ),
+            Some(ContentAcceptance::Condemned(ContentCondemnReason::ClosedIncarnation))
+        );
+
+        let entry = header(owner(), None, 1);
+        for (boundary, hold, predecessor, expected) in [
+            (
+                AuthorityBoundary::Closed,
+                SubjectAuthorityHold::Contested,
+                false,
+                ContentAcceptance::Condemned(ContentCondemnReason::ClosedIncarnation),
+            ),
+            (
+                AuthorityBoundary::Cut { seq: 0, hash: [1; 32] },
+                SubjectAuthorityHold::UnknownCutTarget,
+                false,
+                ContentAcceptance::Condemned(ContentCondemnReason::BeyondCut),
+            ),
+            (
+                AuthorityBoundary::Cut { seq: 1, hash: [1; 32] },
+                SubjectAuthorityHold::Contested,
+                true,
+                ContentAcceptance::Parked(ContentParkReason::ContestedSubject),
+            ),
+            (
+                AuthorityBoundary::Open,
+                SubjectAuthorityHold::UnknownCutTarget,
+                false,
+                ContentAcceptance::Parked(ContentParkReason::UnknownCutTarget),
+            ),
+        ] {
+            let decision = evaluate_content_acceptance(&ContentAcceptanceInput {
+                header: &entry,
+                entry_hash: ENTRY_HASH,
+                owner_account_id: owner(),
+                dense_predecessor_reachable: predecessor,
+                branch_selected: true,
+                ownership: ownership(&entry),
+                roster: roster(&entry, boundary),
+                grant: None,
+                owner_freshness: freshness(owner(), 1, AuthorityFreshness::CurrentOrBehind),
+                author_freshness: freshness(owner(), 1, AuthorityFreshness::CurrentOrBehind),
+                subject_hold: hold,
+                ancestry: |_, _| AncestryRelation::Unknown,
+            });
+            assert_eq!(decision, Ok(expected));
+        }
+    }
+
+    #[test]
+    fn owner_rejects_an_unexpected_supplied_grant_fact() {
+        let owner_entry = header(owner(), None, 0);
+        let contributor_entry = header(author(), Some([7; 32]), 0);
+        assert_eq!(
+            evaluate(
+                &owner_entry,
+                roster(&owner_entry, AuthorityBoundary::Open),
+                Some(grant(&contributor_entry, GrantRole::Writer, GrantDeviceBoundary::Open,)),
+                AncestryRelation::OnBranch,
+            ),
+            ContentAcceptance::Rejected(ContentRejectReason::UnexpectedGrant)
+        );
+    }
+
+    #[test]
+    fn lamport_is_irrelevant_and_status_tokens_cover_frozen_states() {
+        let mut first = header(owner(), None, 0);
+        let mut second = first.clone();
+        first.lamport = 0;
+        second.lamport = u64::MAX;
+        assert_eq!(
+            evaluate(
+                &first,
+                roster(&first, AuthorityBoundary::Open),
+                None,
+                AncestryRelation::OnBranch
+            ),
+            evaluate(
+                &second,
+                roster(&second, AuthorityBoundary::Open),
+                None,
+                AncestryRelation::OnBranch
+            )
+        );
+        let cases = [
+            (ContentAcceptance::Accepted, "accepted"),
+            (ContentAcceptance::Forked, "forked"),
+            (
+                ContentAcceptance::Parked(ContentParkReason::MissingPredecessor),
+                "parked{missing_predecessor}",
+            ),
+            (ContentAcceptance::Parked(ContentParkReason::UnknownOwner), "parked{unknown_account}"),
+            (
+                ContentAcceptance::Parked(ContentParkReason::UnknownRosterRef),
+                "parked{unknown_roster_ref}",
+            ),
+            (ContentAcceptance::Parked(ContentParkReason::UnknownGrant), "parked{unknown_grant}"),
+            (
+                ContentAcceptance::Parked(ContentParkReason::OwnerAuthLenAhead),
+                "parked{auth_len_ahead}",
+            ),
+            (
+                ContentAcceptance::Parked(ContentParkReason::AuthorAuthLenAhead),
+                "parked{auth_len_ahead}",
+            ),
+            (
+                ContentAcceptance::Parked(ContentParkReason::IncompleteCutAncestry),
+                "parked{incomplete_cut_ancestry}",
+            ),
+            (
+                ContentAcceptance::Parked(ContentParkReason::UnknownCutTarget),
+                "parked{unknown_cut_target}",
+            ),
+            (
+                ContentAcceptance::Parked(ContentParkReason::ContestedSubject),
+                "parked{contested_subject}",
+            ),
+            (
+                ContentAcceptance::Condemned(ContentCondemnReason::BeyondCut),
+                "condemned{beyond_cut}",
+            ),
+            (
+                ContentAcceptance::Condemned(ContentCondemnReason::OffBranch),
+                "condemned{off_branch}",
+            ),
+            (
+                ContentAcceptance::Condemned(ContentCondemnReason::ClosedIncarnation),
+                "condemned{closed_incarnation}",
+            ),
+            (
+                ContentAcceptance::Rejected(ContentRejectReason::OwnerReferenceInvalid),
+                "rejected{invalid_owner}",
+            ),
+            (
+                ContentAcceptance::Rejected(ContentRejectReason::RosterReferenceInvalid),
+                "rejected{invalid_roster_ref}",
+            ),
+            (
+                ContentAcceptance::Rejected(ContentRejectReason::GrantReferenceInvalid),
+                "rejected{invalid_grant}",
+            ),
+            (
+                ContentAcceptance::Rejected(ContentRejectReason::GrantRequired),
+                "rejected{grant_required}",
+            ),
+            (
+                ContentAcceptance::Rejected(ContentRejectReason::UnexpectedGrant),
+                "rejected{unexpected_grant}",
+            ),
+            (
+                ContentAcceptance::Rejected(ContentRejectReason::GrantDoesNotPermitWrite),
+                "rejected{grant_not_writer}",
+            ),
+        ];
+        for (decision, token) in cases {
+            assert_eq!(decision.as_db_str(), token);
+        }
+    }
+}

--- a/crates/rag-rat-core/src/oplog/account/content/mod.rs
+++ b/crates/rag-rat-core/src/oplog/account/content/mod.rs
@@ -6,10 +6,10 @@ mod storage;
 
 #[allow(unused_imports, reason = "C3.1 freezes the pure evaluator before C3.2 storage wiring")]
 pub(crate) use acceptance::{
-    AncestryRelation, AuthorityFreshness, CitedFreshness, CitedGrantAuthority, CitedOwnership,
-    CitedRosterAuthority, ContentAcceptance, ContentAcceptanceInput, ContentAcceptanceInputError,
-    ContentCondemnReason, ContentParkReason, ContentRejectReason, ResolvedAuthority,
-    SubjectAuthorityHold, evaluate_content_acceptance,
+    AncestryRelation, CitedFreshness, CitedGrantAuthority, CitedOwnership, CitedRosterAuthority,
+    ContentAcceptance, ContentAcceptanceInput, ContentAcceptanceInputError, ContentCondemnReason,
+    ContentParkReason, ContentRejectReason, SubjectAuthorityHold, UnknownAncestry,
+    evaluate_content_acceptance,
 };
 pub(in crate::oplog) use envelope::{
     ContentEntryHeader, SignedContentEntry, VerifiedContentEntry, decode_content_signed,

--- a/crates/rag-rat-core/src/oplog/account/content/mod.rs
+++ b/crates/rag-rat-core/src/oplog/account/content/mod.rs
@@ -1,8 +1,16 @@
 //! Owner-bound `/3` content entries (sync phase C2).
 
+mod acceptance;
 mod envelope;
 mod storage;
 
+#[allow(unused_imports, reason = "C3.1 freezes the pure evaluator before C3.2 storage wiring")]
+pub(crate) use acceptance::{
+    AncestryRelation, AuthorityFreshness, CitedFreshness, CitedGrantAuthority, CitedOwnership,
+    CitedRosterAuthority, ContentAcceptance, ContentAcceptanceInput, ContentAcceptanceInputError,
+    ContentCondemnReason, ContentParkReason, ContentRejectReason, ResolvedAuthority,
+    SubjectAuthorityHold, evaluate_content_acceptance,
+};
 pub(in crate::oplog) use envelope::{
     ContentEntryHeader, SignedContentEntry, VerifiedContentEntry, decode_content_signed,
     sign_content_entry, verify_content_signed,

--- a/crates/rag-rat-core/src/oplog/account/fold.rs
+++ b/crates/rag-rat-core/src/oplog/account/fold.rs
@@ -194,22 +194,38 @@ pub(super) struct AccountAuthHistory {
     grant_cuts: HashMap<[u8; 32], Vec<DeviceCut>>,
 }
 
+/// One authority fact resolved against the CURRENT fold. There is exactly one snapshot to resolve
+/// against — `auth_len` selects no historical view (§7: it is never an authority input), so a fact
+/// query answers from what we have folded and says nothing about the author's own control length.
+/// Freshness is a separate axis ([`AuthorityFreshness`]) the caller applies in its own phase.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum AuthorityQuery<T> {
     Effective(T),
-    Parked(AuthorityParkReason),
+    /// The citation names an entry our fold does not hold. Recoverable: refetch and re-evaluate.
+    Unknown,
     Invalid(AuthorityInvalidReason),
 }
 
+/// The author's asserted control-fold length measured against ours (§7). `auth_len` is never an
+/// authority input; it only tells us whether the author folded ops we have not. Ahead ⇒ park +
+/// refetch, never a rejection — the missing ops are recoverable and may still re-bless a citation
+/// our fold currently reads as ineffective (§11.4).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum AuthorityParkReason {
-    AuthLenAhead,
-    UnknownReference,
+pub(crate) enum AuthorityFreshness {
+    /// The author cites a control log no longer than the one we hold.
+    CurrentOrBehind,
+    /// The author cites effective ops we have not folded yet.
+    Ahead,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum AuthorityInvalidReason {
+    /// The cited entry's own header names a different subject than the citation claims. Decided by
+    /// bytes we already hold, so a deeper control log can never overturn it.
     WrongSubject,
+    /// The cited entry is held but our fold reads it as ineffective. This one is FOLD-DEPENDENT: a
+    /// `CutExtend` we have not folded can re-bless it (§11.4), so a caller that is behind the
+    /// author ([`AuthorityFreshness::Ahead`]) must park on it rather than treat it as a lie.
     ReferencedEntryNotEffective,
 }
 
@@ -347,15 +363,23 @@ impl AccountAuthHistory {
         self.grant_cuts.iter().map(|(grant_id, cuts)| (grant_id, cuts.as_slice()))
     }
 
+    /// Measure an asserted control-fold length against ours (§7). This is the ONE seam that reads
+    /// `auth_len`; the fact queries below never see it, so an ahead counter can neither select a
+    /// historical authority view nor pre-empt a verdict the current fold already decides.
+    pub(super) fn auth_len_freshness(&self, asserted_auth_len: u64) -> AuthorityFreshness {
+        if asserted_auth_len > self.effective_count {
+            AuthorityFreshness::Ahead
+        } else {
+            AuthorityFreshness::CurrentOrBehind
+        }
+    }
+
     pub(super) fn roster_ref_effective(
         &self,
         roster_ref: [u8; 32],
         device_fingerprint: DeviceFingerprint,
-        auth_len: u64,
     ) -> AuthorityQuery<RosterAuthority> {
         query_fact(
-            self.effective_count,
-            auth_len,
             self.roster_refs
                 .get(&roster_ref)
                 .filter(|fact| fact.closed_at.is_none())
@@ -370,16 +394,12 @@ impl AccountAuthHistory {
         roster_ref: [u8; 32],
         device_fingerprint: DeviceFingerprint,
         stream_id: StreamId,
-        auth_len: u64,
     ) -> AuthorityQuery<RosterContentAuthority> {
-        if auth_len > self.effective_count {
-            return AuthorityQuery::Parked(AuthorityParkReason::AuthLenAhead);
-        }
         let Some(fact) = self.roster_refs.get(&roster_ref) else {
             return if self.outcomes.contains_key(&roster_ref) {
                 AuthorityQuery::Invalid(AuthorityInvalidReason::ReferencedEntryNotEffective)
             } else {
-                AuthorityQuery::Parked(AuthorityParkReason::UnknownReference)
+                AuthorityQuery::Unknown
             };
         };
         if fact.authority.device_fingerprint != device_fingerprint {
@@ -402,11 +422,8 @@ impl AccountAuthHistory {
         &self,
         owner_id: [u8; 32],
         device_fingerprint: DeviceFingerprint,
-        auth_len: u64,
     ) -> AuthorityQuery<OwnerAuthority> {
         query_fact(
-            self.effective_count,
-            auth_len,
             self.owner_incarnations
                 .get(&owner_id)
                 .filter(|fact| fact.closed_at.is_none())
@@ -420,12 +437,10 @@ impl AccountAuthHistory {
         &self,
         owner_id: [u8; 32],
         device_fingerprint: DeviceFingerprint,
-        auth_len: u64,
     ) -> AuthorityQuery<OwnerChainAuthority> {
         self.owner_chain_authority(
             owner_id,
             device_fingerprint,
-            auth_len,
             |fact| fact.control_boundary,
             |fact| fact.control_boundary,
         )
@@ -435,12 +450,10 @@ impl AccountAuthHistory {
         &self,
         owner_id: [u8; 32],
         device_fingerprint: DeviceFingerprint,
-        auth_len: u64,
     ) -> AuthorityQuery<OwnerChainAuthority> {
         self.owner_chain_authority(
             owner_id,
             device_fingerprint,
-            auth_len,
             |fact| fact.secrets_boundary,
             |fact| fact.secrets_boundary,
         )
@@ -450,18 +463,14 @@ impl AccountAuthHistory {
         &self,
         owner_id: [u8; 32],
         device_fingerprint: DeviceFingerprint,
-        auth_len: u64,
         device_boundary: impl Fn(&RosterFact) -> AuthorityBoundary,
         incarnation_boundary: impl Fn(&OwnerIncarnationFact) -> AuthorityBoundary,
     ) -> AuthorityQuery<OwnerChainAuthority> {
-        if auth_len > self.effective_count {
-            return AuthorityQuery::Parked(AuthorityParkReason::AuthLenAhead);
-        }
         let Some(owner) = self.owner_incarnations.get(&owner_id) else {
             return if self.outcomes.contains_key(&owner_id) {
                 AuthorityQuery::Invalid(AuthorityInvalidReason::ReferencedEntryNotEffective)
             } else {
-                AuthorityQuery::Parked(AuthorityParkReason::UnknownReference)
+                AuthorityQuery::Unknown
             };
         };
         if owner.authority.device_fingerprint != device_fingerprint {
@@ -484,16 +493,12 @@ impl AccountAuthHistory {
         grant_id: [u8; 32],
         stream_id: StreamId,
         grantee_account_id: AccountId,
-        auth_len: u64,
     ) -> AuthorityQuery<GrantAuthority> {
-        if auth_len > self.effective_count {
-            return AuthorityQuery::Parked(AuthorityParkReason::AuthLenAhead);
-        }
         let Some(fact) = self.grants.get(&grant_id) else {
             return if self.outcomes.contains_key(&grant_id) {
                 AuthorityQuery::Invalid(AuthorityInvalidReason::ReferencedEntryNotEffective)
             } else {
-                AuthorityQuery::Parked(AuthorityParkReason::UnknownReference)
+                AuthorityQuery::Unknown
             };
         };
         if fact.authority.stream_id != stream_id
@@ -504,16 +509,9 @@ impl AccountAuthHistory {
         AuthorityQuery::Effective(fact.authority)
     }
 
-    pub(super) fn stream_owner_effective(
-        &self,
-        stream_id: StreamId,
-        auth_len: u64,
-    ) -> AuthorityQuery<[u8; 32]> {
-        if auth_len > self.effective_count {
-            return AuthorityQuery::Parked(AuthorityParkReason::AuthLenAhead);
-        }
+    pub(super) fn stream_owner_effective(&self, stream_id: StreamId) -> AuthorityQuery<[u8; 32]> {
         let Some(fact) = self.stream_ownership.get(&stream_id) else {
-            return AuthorityQuery::Parked(AuthorityParkReason::UnknownReference);
+            return AuthorityQuery::Unknown;
         };
         AuthorityQuery::Effective(fact.own_id)
     }
@@ -524,20 +522,15 @@ impl AccountAuthHistory {
 }
 
 fn query_fact<T: Copy, S: PartialEq>(
-    effective_count: u64,
-    auth_len: u64,
     fact: Option<(T, S)>,
     expected_subject: S,
     reference_is_known: bool,
 ) -> AuthorityQuery<T> {
-    if auth_len > effective_count {
-        return AuthorityQuery::Parked(AuthorityParkReason::AuthLenAhead);
-    }
     let Some((authority, subject)) = fact else {
         return if reference_is_known {
             AuthorityQuery::Invalid(AuthorityInvalidReason::ReferencedEntryNotEffective)
         } else {
-            AuthorityQuery::Parked(AuthorityParkReason::UnknownReference)
+            AuthorityQuery::Unknown
         };
     };
     if subject != expected_subject {
@@ -2364,7 +2357,7 @@ mod tests {
         let h = f.fold();
         assert_eq!(h.outcome(&ahead), Some(Outcome::Parked(ParkReason::AuthLenAhead)));
         assert_eq!(
-            h.roster_ref_effective(ahead, ahead_device.fp, h.effective_count()),
+            h.roster_ref_effective(ahead, ahead_device.fp),
             AuthorityQuery::Invalid(AuthorityInvalidReason::ReferencedEntryNotEffective),
             "an ahead candidate must not leave a projected roster mutation",
         );
@@ -2479,14 +2472,14 @@ mod tests {
             "the promotion must recover with the valid enrollment on the next readiness pass",
         );
         assert_eq!(
-            h.roster_ref_effective(valid, device.fp, h.effective_count()),
+            h.roster_ref_effective(valid, device.fp),
             AuthorityQuery::Effective(RosterAuthority {
                 device_fingerprint: device.fp,
                 current_role: DeviceRole::Owner,
             }),
         );
         assert_eq!(
-            h.owner_incarnation_effective(promote, device.fp, h.effective_count()),
+            h.owner_incarnation_effective(promote, device.fp),
             AuthorityQuery::Effective(OwnerAuthority { device_fingerprint: device.fp }),
         );
     }
@@ -3015,33 +3008,25 @@ mod tests {
         assert!(h.is_effective(&grant));
         assert!(h.is_effective(&revoke));
         assert_eq!(h.effective_count(), 4);
+        // The exact citation resolves against the fold we hold, and NOTHING else: revocation bounds
+        // content through cuts, so no assertion the author makes about its own control length can
+        // reopen, close, or deny this grant. That counter is a separate, purely informational axis.
         assert_eq!(
-            h.grant_effective(grant, stream, grantee, 2),
+            h.grant_effective(grant, stream, grantee),
             AuthorityQuery::Effective(GrantAuthority {
                 stream_id: stream,
                 grantee_account_id: grantee,
                 role: GrantRole::Reader,
             }),
-            "a behind auth_len is informational and cannot deny an exact citation",
         );
-        assert!(matches!(
-            h.grant_effective(grant, stream, grantee, 3),
-            AuthorityQuery::Effective(GrantAuthority { role: GrantRole::Reader, .. })
-        ));
+        assert_eq!(h.auth_len_freshness(3), AuthorityFreshness::CurrentOrBehind);
+        assert_eq!(h.auth_len_freshness(4), AuthorityFreshness::CurrentOrBehind);
         assert_eq!(
-            h.grant_effective(grant, stream, grantee, 4),
-            AuthorityQuery::Effective(GrantAuthority {
-                stream_id: stream,
-                grantee_account_id: grantee,
-                role: GrantRole::Reader,
-            }),
-            "revocation bounds content through cuts; stale auth_len cannot reopen or close a grant",
+            h.auth_len_freshness(5),
+            AuthorityFreshness::Ahead,
+            "an author citing more effective ops than we folded is a refetch signal, not a verdict",
         );
-        assert_eq!(
-            h.grant_effective(grant, stream, grantee, 5),
-            AuthorityQuery::Parked(AuthorityParkReason::AuthLenAhead),
-        );
-        assert_eq!(h.stream_owner_effective(stream, 2), AuthorityQuery::Effective(own));
+        assert_eq!(h.stream_owner_effective(stream), AuthorityQuery::Effective(own));
     }
 
     #[test]
@@ -3066,7 +3051,7 @@ mod tests {
         assert!(h.is_effective(&own));
         assert!(h.is_effective(&grant));
         assert_eq!(
-            h.grant_effective(early_grant, stream, grantee, h.effective_count()),
+            h.grant_effective(early_grant, stream, grantee),
             AuthorityQuery::Invalid(AuthorityInvalidReason::ReferencedEntryNotEffective),
             "a held but ineffective grant is invalid, not parked as if it were missing",
         );
@@ -3106,13 +3091,10 @@ mod tests {
         assert!(expected.is_effective(&remove_founder));
         assert_eq!(expected.outcome(&grant), Some(Outcome::Rejected(RejectReason::Ineffective)));
         assert_eq!(
-            expected.grant_effective(grant, stream, grantee, expected.effective_count()),
+            expected.grant_effective(grant, stream, grantee),
             AuthorityQuery::Invalid(AuthorityInvalidReason::ReferencedEntryNotEffective),
         );
-        assert_eq!(
-            expected.stream_owner_effective(stream, expected.effective_count()),
-            AuthorityQuery::Parked(AuthorityParkReason::UnknownReference),
-        );
+        assert_eq!(expected.stream_owner_effective(stream), AuthorityQuery::Unknown);
         for rotation in 1..f.entries.len() {
             assert_eq!(f.fold_rotated(rotation).outcomes, expected.outcomes);
         }
@@ -3141,7 +3123,7 @@ mod tests {
         );
         assert!(!expected.is_effective(&promote));
         assert_eq!(
-            expected.owner_incarnation_effective(promote, member.fp, expected.effective_count(),),
+            expected.owner_incarnation_effective(promote, member.fp,),
             AuthorityQuery::Invalid(AuthorityInvalidReason::ReferencedEntryNotEffective),
             "a promotion cannot survive solely through a condemned enrollment mutation",
         );
@@ -3204,7 +3186,7 @@ mod tests {
         assert!(expected.is_effective(&remove_founder));
         assert_eq!(expected.outcome(&revoke), Some(Outcome::Rejected(RejectReason::Ineffective)));
         assert_eq!(
-            expected.grant_effective(grant, stream, grantee, expected.effective_count()),
+            expected.grant_effective(grant, stream, grantee),
             AuthorityQuery::Invalid(AuthorityInvalidReason::ReferencedEntryNotEffective),
         );
         assert!(expected.grant_cuts.is_empty());
@@ -3283,44 +3265,44 @@ mod tests {
         let h = f.fold();
 
         assert_eq!(
-            h.roster_ref_effective(add, member.fp, 2),
+            h.roster_ref_effective(add, member.fp),
             AuthorityQuery::Effective(RosterAuthority {
                 device_fingerprint: member.fp,
                 current_role: DeviceRole::Owner,
             }),
         );
         assert_eq!(
-            h.roster_ref_effective(add, fdr.fp, 2),
+            h.roster_ref_effective(add, fdr.fp),
             AuthorityQuery::Invalid(AuthorityInvalidReason::WrongSubject),
         );
         assert_eq!(
-            h.owner_incarnation_effective(promote, member.fp, 2),
+            h.owner_incarnation_effective(promote, member.fp),
             AuthorityQuery::Effective(OwnerAuthority { device_fingerprint: member.fp }),
             "a behind auth_len does not deny an exact owner citation",
         );
         assert_eq!(
-            h.owner_incarnation_effective(promote, member.fp, 3),
+            h.owner_incarnation_effective(promote, member.fp),
             AuthorityQuery::Effective(OwnerAuthority { device_fingerprint: member.fp }),
         );
 
         f.author(&fdr, Some(f.genesis_hash), &owner_demote(&member, promote, Cut::Empty));
         let h = f.fold();
         assert_eq!(
-            h.roster_ref_effective(add, member.fp, 4),
+            h.roster_ref_effective(add, member.fp),
             AuthorityQuery::Effective(RosterAuthority {
                 device_fingerprint: member.fp,
                 current_role: DeviceRole::Member,
             }),
         );
         assert_eq!(
-            h.owner_incarnation_effective(promote, member.fp, 4),
+            h.owner_incarnation_effective(promote, member.fp),
             AuthorityQuery::Invalid(AuthorityInvalidReason::ReferencedEntryNotEffective),
         );
 
         f.author(&fdr, Some(f.genesis_hash), &device_remove(&member, Cut::Empty));
         let h = f.fold();
         assert_eq!(
-            h.roster_ref_effective(add, member.fp, 5),
+            h.roster_ref_effective(add, member.fp),
             AuthorityQuery::Invalid(AuthorityInvalidReason::ReferencedEntryNotEffective),
         );
     }

--- a/crates/rag-rat-core/src/oplog/account/mod.rs
+++ b/crates/rag-rat-core/src/oplog/account/mod.rs
@@ -33,14 +33,14 @@ pub(in crate::oplog) use content::{
     verify_content_signed,
 };
 pub(crate) use fold::{
-    AuthorityBoundary, AuthorityInvalidReason, AuthorityParkReason, AuthorityQuery, GrantAuthority,
+    AuthorityBoundary, AuthorityFreshness, AuthorityInvalidReason, AuthorityQuery, GrantAuthority,
     GrantDeviceAuthority, GrantDeviceBoundary, OwnerAuthority, OwnerChainAuthority,
     RosterContentAuthority,
 };
 pub(crate) use id::AccountId;
 pub(crate) use ops::{DeviceCut, DeviceRole, GrantRole};
 pub(crate) use storage::{
-    CapacityScope, IngestOutcome, account_ingest, backfill_authority_projection,
-    grant_effective_for_device, owner_control_authority, owner_secrets_authority,
-    roster_content_authority, stream_owner_effective,
+    CapacityScope, IngestOutcome, account_ingest, auth_len_freshness,
+    backfill_authority_projection, grant_effective_for_device, owner_control_authority,
+    owner_secrets_authority, roster_content_authority, stream_owner_effective,
 };

--- a/crates/rag-rat-core/src/oplog/account/storage.rs
+++ b/crates/rag-rat-core/src/oplog/account/storage.rs
@@ -298,20 +298,17 @@ pub(crate) fn backfill_authority_projection(tx: &Transaction<'_>) -> rusqlite::R
 }
 
 /// Exact roster citation lookup over the V064 shadow projection. This is the hot-path seam for
-/// `/3` ingest: a keyed read, never a candidate-DAG replay. `auth_len` only detects a caller ahead
-/// of the local fold; a behind value is informational and never selects historical authority.
+/// `/3` ingest: a keyed read, never a candidate-DAG replay. It resolves against the current fold —
+/// the only authority snapshot there is (§7) — and says nothing about the citing author's own
+/// control length; that is [`auth_len_freshness`]'s separate job.
 pub(crate) fn roster_ref_effective(
     conn: &Connection,
     account_id: AccountId,
     roster_ref: EntryHash,
     device_fingerprint: DeviceFingerprint,
-    auth_len: u64,
 ) -> anyhow::Result<fold::AuthorityQuery<fold::RosterAuthority>> {
     let read_tx = Transaction::new_unchecked(conn, TransactionBehavior::Deferred)?;
     let conn: &Connection = &read_tx;
-    if let Some(reason) = auth_len_preflight(conn, account_id, auth_len)? {
-        return Ok(fold::AuthorityQuery::Parked(reason));
-    }
     let row: Option<(Vec<u8>, String, i64, Option<i64>)> = conn
         .query_row(
             "SELECT device_fingerprint, role, effective_at, closed_at
@@ -339,13 +336,9 @@ pub(crate) fn roster_content_authority(
     roster_ref: EntryHash,
     device_fingerprint: DeviceFingerprint,
     stream_id: StreamId,
-    auth_len: u64,
 ) -> anyhow::Result<fold::AuthorityQuery<fold::RosterContentAuthority>> {
     let read_tx = Transaction::new_unchecked(conn, TransactionBehavior::Deferred)?;
     let conn: &Connection = &read_tx;
-    if let Some(reason) = auth_len_preflight(conn, account_id, auth_len)? {
-        return Ok(fold::AuthorityQuery::Parked(reason));
-    }
     let row: Option<(Vec<u8>, String, i64, Option<i64>)> = conn
         .query_row(
             "SELECT device_fingerprint, role, effective_at, closed_at
@@ -396,9 +389,8 @@ pub(crate) fn owner_control_authority(
     account_id: AccountId,
     owner_id: EntryHash,
     device_fingerprint: DeviceFingerprint,
-    auth_len: u64,
 ) -> anyhow::Result<fold::AuthorityQuery<fold::OwnerChainAuthority>> {
-    owner_chain_authority(conn, account_id, owner_id, device_fingerprint, auth_len, "control")
+    owner_chain_authority(conn, account_id, owner_id, device_fingerprint, "control")
 }
 
 pub(crate) fn owner_secrets_authority(
@@ -406,9 +398,8 @@ pub(crate) fn owner_secrets_authority(
     account_id: AccountId,
     owner_id: EntryHash,
     device_fingerprint: DeviceFingerprint,
-    auth_len: u64,
 ) -> anyhow::Result<fold::AuthorityQuery<fold::OwnerChainAuthority>> {
-    owner_chain_authority(conn, account_id, owner_id, device_fingerprint, auth_len, "secrets")
+    owner_chain_authority(conn, account_id, owner_id, device_fingerprint, "secrets")
 }
 
 fn owner_chain_authority(
@@ -416,14 +407,10 @@ fn owner_chain_authority(
     account_id: AccountId,
     owner_id: EntryHash,
     device_fingerprint: DeviceFingerprint,
-    auth_len: u64,
     chain: &str,
 ) -> anyhow::Result<fold::AuthorityQuery<fold::OwnerChainAuthority>> {
     let read_tx = Transaction::new_unchecked(conn, TransactionBehavior::Deferred)?;
     let conn: &Connection = &read_tx;
-    if let Some(reason) = auth_len_preflight(conn, account_id, auth_len)? {
-        return Ok(fold::AuthorityQuery::Parked(reason));
-    }
     let sql = format!(
         "SELECT o.device_fingerprint, o.effective_at, o.closed_at,
                 o.{chain}_boundary, o.{chain}_seq, o.{chain}_hash,
@@ -515,13 +502,9 @@ pub(crate) fn owner_incarnation_effective(
     account_id: AccountId,
     owner_id: EntryHash,
     device_fingerprint: DeviceFingerprint,
-    auth_len: u64,
 ) -> anyhow::Result<fold::AuthorityQuery<fold::OwnerAuthority>> {
     let read_tx = Transaction::new_unchecked(conn, TransactionBehavior::Deferred)?;
     let conn: &Connection = &read_tx;
-    if let Some(reason) = auth_len_preflight(conn, account_id, auth_len)? {
-        return Ok(fold::AuthorityQuery::Parked(reason));
-    }
     let row: Option<(Vec<u8>, i64, Option<i64>)> = conn
         .query_row(
             "SELECT device_fingerprint, effective_at, closed_at
@@ -549,13 +532,9 @@ pub(crate) fn grant_effective(
     grant_id: EntryHash,
     stream_id: StreamId,
     grantee_account_id: AccountId,
-    auth_len: u64,
 ) -> anyhow::Result<fold::AuthorityQuery<fold::GrantAuthority>> {
     let read_tx = Transaction::new_unchecked(conn, TransactionBehavior::Deferred)?;
     let conn: &Connection = &read_tx;
-    if let Some(reason) = auth_len_preflight(conn, owner_account_id, auth_len)? {
-        return Ok(fold::AuthorityQuery::Parked(reason));
-    }
     let row: Option<StoredGrantRow> = conn
         .query_row(
             "SELECT stream_id, grantee_account_id, role, effective_at, closed_at
@@ -588,7 +567,6 @@ pub(crate) fn grant_effective_for_device(
     stream_id: StreamId,
     grantee_account_id: AccountId,
     device_fingerprint: DeviceFingerprint,
-    auth_len: u64,
 ) -> anyhow::Result<fold::AuthorityQuery<fold::GrantDeviceAuthority>> {
     let read_tx = Transaction::new_unchecked(conn, TransactionBehavior::Deferred)?;
     grant_effective_for_device_in_snapshot(
@@ -598,7 +576,6 @@ pub(crate) fn grant_effective_for_device(
         stream_id,
         grantee_account_id,
         device_fingerprint,
-        auth_len,
     )
 }
 
@@ -609,11 +586,7 @@ fn grant_effective_for_device_in_snapshot(
     stream_id: StreamId,
     grantee_account_id: AccountId,
     device_fingerprint: DeviceFingerprint,
-    auth_len: u64,
 ) -> anyhow::Result<fold::AuthorityQuery<fold::GrantDeviceAuthority>> {
-    if let Some(reason) = auth_len_preflight(conn, owner_account_id, auth_len)? {
-        return Ok(fold::AuthorityQuery::Parked(reason));
-    }
     let row: Option<StoredGrantRow> = conn
         .query_row(
             "SELECT stream_id, grantee_account_id, role, effective_at, closed_at
@@ -644,19 +617,15 @@ fn grant_effective_for_device_in_snapshot(
     Ok(fold::AuthorityQuery::Effective(fold::GrantDeviceAuthority { grant, boundary }))
 }
 
-/// Resolve the owner-bound `StreamOwn` fact from the same authority snapshot as the `auth_len`
-/// preflight. A missing ownership fact is recoverable: the caller may simply be ahead of us.
+/// Resolve the owner-bound `StreamOwn` fact from the current fold. A missing ownership fact is
+/// recoverable: the citing author may simply hold control ops we have not folded yet.
 pub(crate) fn stream_owner_effective(
     conn: &Connection,
     account_id: AccountId,
     stream_id: StreamId,
-    auth_len: u64,
 ) -> anyhow::Result<fold::AuthorityQuery<EntryHash>> {
     let read_tx = Transaction::new_unchecked(conn, TransactionBehavior::Deferred)?;
     let conn: &Connection = &read_tx;
-    if let Some(reason) = auth_len_preflight(conn, account_id, auth_len)? {
-        return Ok(fold::AuthorityQuery::Parked(reason));
-    }
     let row: Option<(Vec<u8>, i64)> = conn
         .query_row(
             "SELECT own_id, effective_at FROM account_stream_ownership
@@ -666,7 +635,7 @@ pub(crate) fn stream_owner_effective(
         )
         .optional()?;
     let Some((own_id, effective_at)) = row else {
-        return Ok(fold::AuthorityQuery::Parked(fold::AuthorityParkReason::UnknownReference));
+        return Ok(fold::AuthorityQuery::Unknown);
     };
     validated_fact(fixed(&own_id)?, effective_at, None)
 }
@@ -678,13 +647,9 @@ pub(super) fn grant_device_cut(
     owner_account_id: AccountId,
     grant_id: EntryHash,
     device_fingerprint: DeviceFingerprint,
-    auth_len: u64,
 ) -> anyhow::Result<fold::AuthorityQuery<Option<DeviceCut>>> {
     let read_tx = Transaction::new_unchecked(conn, TransactionBehavior::Deferred)?;
     let conn: &Connection = &read_tx;
-    if let Some(reason) = auth_len_preflight(conn, owner_account_id, auth_len)? {
-        return Ok(fold::AuthorityQuery::Parked(reason));
-    }
     let grant_exists: bool = conn.query_row(
         "SELECT EXISTS(
              SELECT 1 FROM account_stream_grants
@@ -728,11 +693,17 @@ fn load_grant_device_cut(
     .transpose()
 }
 
-fn auth_len_preflight(
+/// Measure an asserted control-fold length against our own folded view (§7) — the ONE seam that
+/// reads `auth_len`. Keeping it out of the fact queries above is what stops a counter from acting
+/// as an authority input: facts always answer from the current fold, and the caller applies this
+/// verdict as its own phase, where an `Ahead` author parks rather than pre-empting a decision the
+/// fold has already made. An account we hold nothing for has folded zero effective ops (its facts
+/// resolve `Unknown` long before freshness is consulted).
+pub(crate) fn auth_len_freshness(
     conn: &Connection,
     account_id: AccountId,
-    auth_len: u64,
-) -> anyhow::Result<Option<fold::AuthorityParkReason>> {
+    asserted_auth_len: u64,
+) -> anyhow::Result<fold::AuthorityFreshness> {
     let effective_count: Option<i64> = conn
         .query_row(
             "SELECT effective_count FROM account_auth_state WHERE account_id = ?1",
@@ -740,14 +711,12 @@ fn auth_len_preflight(
             |row| row.get(0),
         )
         .optional()?;
-    let Some(effective_count) = effective_count else {
-        return Ok(Some(fold::AuthorityParkReason::UnknownReference));
-    };
-    if auth_len > u64::try_from(effective_count)? {
-        Ok(Some(fold::AuthorityParkReason::AuthLenAhead))
+    let effective_count = effective_count.map(u64::try_from).transpose()?.unwrap_or_default();
+    Ok(if asserted_auth_len > effective_count {
+        fold::AuthorityFreshness::Ahead
     } else {
-        Ok(None)
-    }
+        fold::AuthorityFreshness::CurrentOrBehind
+    })
 }
 
 fn missing_reference<T>(
@@ -763,7 +732,7 @@ fn missing_reference<T>(
         )
         .optional()?;
     Ok(match stored_account {
-        None => fold::AuthorityQuery::Parked(fold::AuthorityParkReason::UnknownReference),
+        None => fold::AuthorityQuery::Unknown,
         Some(stored) if fixed(&stored)? != account_id.to_bytes() =>
             fold::AuthorityQuery::Invalid(fold::AuthorityInvalidReason::WrongSubject),
         Some(_) =>
@@ -1796,7 +1765,6 @@ mod tests {
                 stream_id,
                 grantee,
                 grantee_device.fp,
-                3,
             )
             .unwrap(),
             fold::AuthorityQuery::Effective(fold::GrantDeviceAuthority {
@@ -1855,11 +1823,11 @@ mod tests {
             ),
         );
         assert_eq!(
-            stream_owner_effective(&conn, account_id, stream_id, 4).unwrap(),
+            stream_owner_effective(&conn, account_id, stream_id).unwrap(),
             fold::AuthorityQuery::Effective(own_hash),
         );
         assert_eq!(
-            grant_device_cut(&conn, account_id, grant_id, grantee_device.fp, 4).unwrap(),
+            grant_device_cut(&conn, account_id, grant_id, grantee_device.fp).unwrap(),
             fold::AuthorityQuery::Effective(Some(DeviceCut {
                 device_fingerprint: grantee_device.fp,
                 seq: u64::MAX,
@@ -1874,7 +1842,6 @@ mod tests {
                 stream_id,
                 grantee,
                 grantee_device.fp,
-                4,
             )
             .unwrap(),
             fold::AuthorityQuery::Effective(fold::GrantDeviceAuthority {
@@ -1891,7 +1858,7 @@ mod tests {
             }),
         );
         assert_eq!(
-            grant_device_cut(&conn, account_id, grant_id, Dev::new(3).fp, 4).unwrap(),
+            grant_device_cut(&conn, account_id, grant_id, Dev::new(3).fp).unwrap(),
             fold::AuthorityQuery::Effective(None),
         );
         assert!(matches!(
@@ -1902,7 +1869,6 @@ mod tests {
                 stream_id,
                 grantee,
                 Dev::new(3).fp,
-                4,
             )
             .unwrap(),
             fold::AuthorityQuery::Effective(fold::GrantDeviceAuthority {
@@ -1910,23 +1876,37 @@ mod tests {
                 ..
             }),
         ));
+        // A citation that files a grant we DO hold under an account it does not belong to is
+        // refuted by the entry's own bytes, so it is a wrong subject — not an unknown reference.
+        // (The account-wide `auth_len` preflight used to mask this as `Unknown` whenever we
+        // happened to hold no authority state for the claimed account.)
         assert_eq!(
             grant_device_cut(
                 &conn,
                 AccountId::from_bytes([0x66; 32]),
                 grant_id,
                 grantee_device.fp,
-                0,
             )
             .unwrap(),
-            fold::AuthorityQuery::Parked(fold::AuthorityParkReason::UnknownReference),
+            fold::AuthorityQuery::Invalid(fold::AuthorityInvalidReason::WrongSubject),
+        );
+        // A grant we hold nothing about stays recoverable: refetch and re-evaluate.
+        assert_eq!(
+            grant_device_cut(
+                &conn,
+                AccountId::from_bytes([0x66; 32]),
+                [0x77; 32],
+                grantee_device.fp,
+            )
+            .unwrap(),
+            fold::AuthorityQuery::Unknown,
         );
         assert!(matches!(
-            grant_effective(&conn, account_id, grant_id, stream_id, grantee, 3).unwrap(),
+            grant_effective(&conn, account_id, grant_id, stream_id, grantee).unwrap(),
             fold::AuthorityQuery::Effective(fold::GrantAuthority { role: GrantRole::Writer, .. })
         ));
         assert_eq!(
-            grant_effective(&conn, account_id, grant_id, stream_id, grantee, 4).unwrap(),
+            grant_effective(&conn, account_id, grant_id, stream_id, grantee).unwrap(),
             fold::AuthorityQuery::Effective(fold::GrantAuthority {
                 stream_id,
                 grantee_account_id: grantee,
@@ -1934,19 +1914,19 @@ mod tests {
             }),
         );
         assert!(matches!(
-            roster_ref_effective(&conn, account_id, genesis_hash, founder.fp, 1).unwrap(),
+            roster_ref_effective(&conn, account_id, genesis_hash, founder.fp).unwrap(),
             fold::AuthorityQuery::Effective(fold::RosterAuthority {
                 current_role: DeviceRole::Owner,
                 ..
             })
         ));
         assert!(matches!(
-            owner_incarnation_effective(&conn, account_id, genesis_hash, founder.fp, 1).unwrap(),
+            owner_incarnation_effective(&conn, account_id, genesis_hash, founder.fp).unwrap(),
             fold::AuthorityQuery::Effective(_)
         ));
         assert_eq!(
-            grant_effective(&conn, account_id, [0xaa; 32], stream_id, grantee, 4).unwrap(),
-            fold::AuthorityQuery::Parked(fold::AuthorityParkReason::UnknownReference),
+            grant_effective(&conn, account_id, [0xaa; 32], stream_id, grantee).unwrap(),
+            fold::AuthorityQuery::Unknown,
         );
 
         // Corrupt projection state must fail closed: an open grant cannot legitimately retain a
@@ -1964,7 +1944,6 @@ mod tests {
             stream_id,
             grantee,
             grantee_device.fp,
-            4,
         )
         .unwrap_err();
         assert!(
@@ -2018,7 +1997,10 @@ mod tests {
         let reader = Connection::open(&path).unwrap();
         let writer = Connection::open(&path).unwrap();
         let snapshot = Transaction::new_unchecked(&reader, TransactionBehavior::Deferred).unwrap();
-        assert_eq!(auth_len_preflight(&snapshot, account_id, 4).unwrap(), None);
+        assert_eq!(
+            auth_len_freshness(&snapshot, account_id, 4).unwrap(),
+            fold::AuthorityFreshness::CurrentOrBehind,
+        );
 
         let write_tx = Transaction::new_unchecked(&writer, TransactionBehavior::Immediate).unwrap();
         write_tx
@@ -2044,7 +2026,6 @@ mod tests {
             stream_id,
             grantee,
             grantee_device.fp,
-            4,
         )
         .unwrap();
         assert!(matches!(
@@ -2064,7 +2045,6 @@ mod tests {
                 stream_id,
                 grantee,
                 grantee_device.fp,
-                4,
             )
             .unwrap(),
             fold::AuthorityQuery::Effective(fold::GrantDeviceAuthority {
@@ -2136,11 +2116,11 @@ mod tests {
 
         schema::migrate_forward(&conn).unwrap();
         assert_eq!(
-            stream_owner_effective(&conn, account_id, stream_id, 2).unwrap(),
+            stream_owner_effective(&conn, account_id, stream_id).unwrap(),
             fold::AuthorityQuery::Effective(own_hash),
         );
         assert!(matches!(
-            roster_ref_effective(&conn, account_id, genesis_hash, founder.fp, 2).unwrap(),
+            roster_ref_effective(&conn, account_id, genesis_hash, founder.fp).unwrap(),
             fold::AuthorityQuery::Effective(fold::RosterAuthority {
                 current_role: DeviceRole::Owner,
                 ..
@@ -2232,9 +2212,25 @@ mod tests {
         );
         account_ingest(&conn, &self_grant_bytes, NOW + 3).unwrap();
 
+        // Freshness is its own seam: an ahead assertion is measured against the fold, and it does
+        // NOT reach into the fact queries — the grant resolves from the current fold either way, so
+        // an ahead counter can neither hide nor manufacture an authority verdict.
         assert_eq!(
-            grant_effective(&conn, account_id, grant_id, stream_id, grantee, 99).unwrap(),
-            fold::AuthorityQuery::Parked(fold::AuthorityParkReason::AuthLenAhead),
+            auth_len_freshness(&conn, account_id, 99).unwrap(),
+            fold::AuthorityFreshness::Ahead,
+        );
+        assert_eq!(
+            auth_len_freshness(&conn, account_id, 3).unwrap(),
+            fold::AuthorityFreshness::CurrentOrBehind,
+        );
+        assert!(matches!(
+            grant_effective(&conn, account_id, grant_id, stream_id, grantee).unwrap(),
+            fold::AuthorityQuery::Effective(_),
+        ));
+        assert_eq!(
+            auth_len_freshness(&conn, AccountId::from_bytes([0x7e; 32]), 1).unwrap(),
+            fold::AuthorityFreshness::Ahead,
+            "an account we hold nothing for has folded zero effective ops",
         );
         assert_eq!(
             grant_effective(
@@ -2243,13 +2239,12 @@ mod tests {
                 grant_id,
                 crate::oplog::stream::StreamId::from_bytes([0x55; 32]),
                 grantee,
-                3,
             )
             .unwrap(),
             fold::AuthorityQuery::Invalid(fold::AuthorityInvalidReason::WrongSubject),
         );
         assert_eq!(
-            grant_effective(&conn, account_id, self_grant_id, stream_id, account_id, 3).unwrap(),
+            grant_effective(&conn, account_id, self_grant_id, stream_id, account_id).unwrap(),
             fold::AuthorityQuery::Invalid(
                 fold::AuthorityInvalidReason::ReferencedEntryNotEffective,
             ),
@@ -2259,14 +2254,14 @@ mod tests {
             grant_id.as_slice(),
         ])
         .unwrap();
-        assert!(grant_effective(&conn, account_id, grant_id, stream_id, grantee, 3).is_err());
+        assert!(grant_effective(&conn, account_id, grant_id, stream_id, grantee).is_err());
         conn.execute(
             "UPDATE account_stream_grants SET role = 'reader', effective_at = -1
              WHERE grant_id = ?1",
             [grant_id.as_slice()],
         )
         .unwrap();
-        assert!(grant_effective(&conn, account_id, grant_id, stream_id, grantee, 3).is_err());
+        assert!(grant_effective(&conn, account_id, grant_id, stream_id, grantee).is_err());
         conn.execute("UPDATE account_stream_grants SET effective_at = 2 WHERE grant_id = ?1", [
             grant_id.as_slice(),
         ])
@@ -2276,12 +2271,12 @@ mod tests {
             params![stream_id.to_bytes().as_slice(), [0u8; 31].as_slice()],
         )
         .unwrap();
-        assert!(stream_owner_effective(&conn, account_id, stream_id, 3).is_err());
+        assert!(stream_owner_effective(&conn, account_id, stream_id).is_err());
         conn.execute("UPDATE account_auth_state SET effective_count = -1 WHERE account_id = ?1", [
             account_id.to_bytes().as_slice(),
         ])
         .unwrap();
-        assert!(roster_ref_effective(&conn, account_id, genesis_hash, founder.fp, 0).is_err());
+        assert!(auth_len_freshness(&conn, account_id, 0).is_err());
     }
 
     #[test]
@@ -3084,7 +3079,7 @@ mod tests {
             account_ingest(&conn, bytes, NOW + 2 + i64::try_from(offset).unwrap()).unwrap();
         }
         assert!(matches!(
-            roster_ref_effective(&conn, account_id, b2, g.fp, 5).unwrap(),
+            roster_ref_effective(&conn, account_id, b2, g.fp).unwrap(),
             fold::AuthorityQuery::Effective(_)
         ));
 
@@ -3100,7 +3095,7 @@ mod tests {
         assert_eq!(status(&conn, &b1).as_deref(), Some("condemned"));
         assert_eq!(status(&conn, &b2).as_deref(), Some("condemned"));
         assert_eq!(
-            roster_ref_effective(&conn, account_id, b2, g.fp, 4).unwrap(),
+            roster_ref_effective(&conn, account_id, b2, g.fp).unwrap(),
             fold::AuthorityQuery::Invalid(
                 fold::AuthorityInvalidReason::ReferencedEntryNotEffective
             ),
@@ -3118,11 +3113,11 @@ mod tests {
         assert_eq!(status(&conn, &b1).as_deref(), Some("accepted"));
         assert_eq!(status(&conn, &b2).as_deref(), Some("accepted"));
         assert!(matches!(
-            roster_ref_effective(&conn, account_id, b2, g.fp, 7).unwrap(),
+            roster_ref_effective(&conn, account_id, b2, g.fp).unwrap(),
             fold::AuthorityQuery::Effective(_)
         ));
         assert_eq!(
-            owner_control_authority(&conn, account_id, add_owner, owner.fp, 7).unwrap(),
+            owner_control_authority(&conn, account_id, add_owner, owner.fp).unwrap(),
             fold::AuthorityQuery::Effective(fold::OwnerChainAuthority {
                 owner: fold::OwnerAuthority { device_fingerprint: owner.fp },
                 device_boundary: fold::AuthorityBoundary::Cut { seq: 2, hash: b2 },
@@ -3146,7 +3141,7 @@ mod tests {
         .unwrap();
         schema::migrate_forward(&conn).unwrap();
         assert!(matches!(
-            owner_control_authority(&conn, account_id, add_owner, owner.fp, 7).unwrap(),
+            owner_control_authority(&conn, account_id, add_owner, owner.fp).unwrap(),
             fold::AuthorityQuery::Effective(fold::OwnerChainAuthority {
                 device_boundary: fold::AuthorityBoundary::Cut { seq: 2, hash },
                 ..
@@ -3277,7 +3272,7 @@ mod tests {
             })
         };
         assert_eq!(
-            owner_control_authority(&conn, account, owner_id, owner.fp, 0).unwrap(),
+            owner_control_authority(&conn, account, owner_id, owner.fp).unwrap(),
             expected(
                 fold::AuthorityBoundary::Cut { seq: 1, hash: heads[1] },
                 fold::AuthorityBoundary::Cut { seq: 0, hash: heads[0] },
@@ -3296,7 +3291,7 @@ mod tests {
             op(account, &founder, 4, Some(remove_hash), Some(genesis), &extend_incarnation);
         account_ingest(&conn, &bytes, NOW + 7).unwrap();
         assert_eq!(
-            owner_control_authority(&conn, account, owner_id, owner.fp, 0).unwrap(),
+            owner_control_authority(&conn, account, owner_id, owner.fp).unwrap(),
             expected(
                 fold::AuthorityBoundary::Cut { seq: 1, hash: heads[1] },
                 fold::AuthorityBoundary::Cut { seq: 2, hash: heads[2] },
@@ -3313,7 +3308,7 @@ mod tests {
         );
         account_ingest(&conn, &bytes, NOW + 8).unwrap();
         assert_eq!(
-            owner_control_authority(&conn, account, owner_id, owner.fp, 0).unwrap(),
+            owner_control_authority(&conn, account, owner_id, owner.fp).unwrap(),
             expected(
                 fold::AuthorityBoundary::Cut { seq: 2, hash: heads[2] },
                 fold::AuthorityBoundary::Cut { seq: 2, hash: heads[2] },
@@ -3440,7 +3435,7 @@ mod tests {
             });
         account_ingest(&conn, &promote_bytes, NOW + 2).unwrap();
         assert_eq!(
-            roster_ref_effective(&conn, account_id, add, member.fp, 3).unwrap(),
+            roster_ref_effective(&conn, account_id, add, member.fp).unwrap(),
             fold::AuthorityQuery::Effective(fold::RosterAuthority {
                 device_fingerprint: member.fp,
                 current_role: DeviceRole::Owner,
@@ -3457,14 +3452,14 @@ mod tests {
         );
         account_ingest(&conn, &demote_bytes, NOW + 3).unwrap();
         assert_eq!(
-            roster_ref_effective(&conn, account_id, add, member.fp, 4).unwrap(),
+            roster_ref_effective(&conn, account_id, add, member.fp).unwrap(),
             fold::AuthorityQuery::Effective(fold::RosterAuthority {
                 device_fingerprint: member.fp,
                 current_role: DeviceRole::Member,
             }),
         );
         assert_eq!(
-            owner_incarnation_effective(&conn, account_id, promote, member.fp, 4).unwrap(),
+            owner_incarnation_effective(&conn, account_id, promote, member.fp).unwrap(),
             fold::AuthorityQuery::Invalid(
                 fold::AuthorityInvalidReason::ReferencedEntryNotEffective,
             ),
@@ -3480,7 +3475,7 @@ mod tests {
         );
         account_ingest(&conn, &remove_bytes, NOW + 4).unwrap();
         assert_eq!(
-            roster_ref_effective(&conn, account_id, add, member.fp, 5).unwrap(),
+            roster_ref_effective(&conn, account_id, add, member.fp).unwrap(),
             fold::AuthorityQuery::Invalid(
                 fold::AuthorityInvalidReason::ReferencedEntryNotEffective,
             ),
@@ -3937,14 +3932,14 @@ mod tests {
         account_ingest(&conn, &remove_bytes, NOW + 2).unwrap();
 
         assert_eq!(
-            roster_content_authority(&conn, account, roster_ref, member.fp, listed, 3).unwrap(),
+            roster_content_authority(&conn, account, roster_ref, member.fp, listed).unwrap(),
             fold::AuthorityQuery::Effective(fold::RosterContentAuthority {
                 device_fingerprint: member.fp,
                 boundary: fold::AuthorityBoundary::Cut { seq: u64::MAX, hash: [0xa5; 32] },
             }),
         );
         assert_eq!(
-            roster_content_authority(&conn, account, roster_ref, member.fp, unlisted, 3).unwrap(),
+            roster_content_authority(&conn, account, roster_ref, member.fp, unlisted).unwrap(),
             fold::AuthorityQuery::Effective(fold::RosterContentAuthority {
                 device_fingerprint: member.fp,
                 boundary: fold::AuthorityBoundary::Closed,
@@ -3967,7 +3962,7 @@ mod tests {
         )
         .unwrap();
         assert!(
-            owner_control_authority(&conn, account, owner_id, founder.fp, 1).is_err(),
+            owner_control_authority(&conn, account, owner_id, founder.fp).is_err(),
             "a partial cut tuple must never become open authority",
         );
         conn.execute(
@@ -3978,7 +3973,7 @@ mod tests {
         )
         .unwrap();
         assert!(
-            owner_control_authority(&conn, account, owner_id, founder.fp, 1).is_err(),
+            owner_control_authority(&conn, account, owner_id, founder.fp).is_err(),
             "negative fact epochs fail closed",
         );
         conn.execute(
@@ -3992,7 +3987,7 @@ mod tests {
         ])
         .unwrap();
         assert!(
-            owner_control_authority(&conn, account, owner_id, founder.fp, 1).is_err(),
+            owner_control_authority(&conn, account, owner_id, founder.fp).is_err(),
             "a closed roster and owner cannot jointly retain Open/Open authority",
         );
     }

--- a/crates/rag-rat-core/src/oplog/mod.rs
+++ b/crates/rag-rat-core/src/oplog/mod.rs
@@ -47,10 +47,10 @@ mod stream;
 // cross the phase boundary.
 #[expect(unused_imports, reason = "C2 authority seam is frozen before its caller lands")]
 pub(crate) use account::{
-    AccountId, AuthorityBoundary, AuthorityInvalidReason, AuthorityParkReason, AuthorityQuery,
+    AccountId, AuthorityBoundary, AuthorityFreshness, AuthorityInvalidReason, AuthorityQuery,
     CapacityScope, DeviceCut, DeviceRole, GrantAuthority, GrantDeviceAuthority,
     GrantDeviceBoundary, GrantRole, IngestOutcome, OwnerAuthority, OwnerChainAuthority,
-    RosterContentAuthority, account_ingest, backfill_authority_projection,
+    RosterContentAuthority, account_ingest, auth_len_freshness, backfill_authority_projection,
     grant_effective_for_device, owner_control_authority, owner_secrets_authority,
     roster_content_authority, stream_owner_effective,
 };


### PR DESCRIPTION
## Summary

- add the pure C3 `/3` content acceptance evaluator defined by issue #606 section 13
- split the `auth_len` preflight out of the C1 authority fact queries, so authority and freshness stop being entangled at the seam
- bind ownership, roster, grant, and freshness observations to their exact query provenance
- freeze authority, boundary, subject-hold, predecessor, branch, and freshness ordering
- expose closed, stable acceptance status tokens without adding persistence or migrations

## Why

C3.1 is the policy boundary that later storage and reconciliation work will call. Keeping it pure makes the frozen protocol rules directly testable before C3.2 adds persistence, and prevents query-result laundering or phase-order changes from silently accepting invalid content.

The seam split is the root fix behind the review round below. The C1 seam ran an `auth_len` preflight inside every authority fact query, so a query could park on `AuthLenAhead` before resolving anything. That forced C3's frozen §13 order to invert — a parked query returns no fact, so the register and branch phases can never run, and an ahead counter would mask a condemnation or a fork the content DAG already decides. §7 is explicit that `auth_len` is *never an authority input*, and the lookups genuinely ignore it, so the two axes are now separate seams:

- authority fact queries take no `auth_len` and resolve against the current fold; `AuthorityQuery` loses `Parked(AuthorityParkReason)` in favour of `Unknown`
- `auth_len_freshness` is the one seam that reads an asserted control length

Dropping the preflight also stops it masking wrong-subject detection: a citation filing an entry under an account it demonstrably does not belong to used to come back `Unknown` whenever we held no auth state for the claimed account. It is now judged on the bytes we hold.

The preflight's one real job — never issuing a *permanent* rejection from a stale fold — moves into the evaluator as an explicit rule, since `ReferencedEntryNotEffective` is a verdict of our own fold and an unfolded `CutExtend` can re-bless it (§11.4):

| citation | control log ahead of ours | level with ours |
|---|---|---|
| `ReferencedEntryNotEffective` | `parked{auth_len_ahead}` | `rejected{invalid_*}` |
| `WrongSubject` | `rejected{invalid_*}` | `rejected{invalid_*}` |

Freshness provenance is therefore validated as a precondition, not lazily at the freshness phase.

Finally, the evaluator keeps the two undecided-ancestry causes apart, exactly as the account fold already does (`candidate::UnknownCause` / `fold::register_verdict`): a withheld watermark parks as `unknown_cut_target`, a missing mid-chain link as `incomplete_cut_ancestry`, with the fold's precedence (a definite condemnation outranks either park; a withheld watermark outranks a missing link). Collapsing them into one `Unknown` had made `parked{unknown_cut_target}` unreachable from a boundary cut.

## Validation

- `cargo +nightly fmt --all --check`
- `cargo clippy --workspace --all-targets --no-default-features --locked -- -D warnings` (CI's exact invocation), and the `--features eval` variant
- `cargo nextest run -p rag-rat-core` — 2,365 passed, 0 failed

Refs #606