### PR TITLE
feat(papertrail): automatic sync orchestration — watcher deadline, hook trigger, coalesced single-flight

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3481,6 +3481,7 @@ dependencies = [
  "criterion",
  "ed25519-dalek",
  "fastembed",
+ "futures-util",
  "getrandom 0.3.4",
  "gix",
  "httpdate",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,9 @@ ed25519-dalek = "2"
 # persists, and validates the key (rejecting small-order / identity public keys); ECDH + HKDF is C4.
 x25519-dalek = { version = "2", features = ["static_secrets"] }
 fastembed = { version = "5.17.2", default-features = false, features = ["hf-hub-rustls-tls", "ort-download-binaries-rustls-tls"] }
+# `join_all` drives the per-binding mirror jobs concurrently on the papertrail
+# current-thread runtime (reqwest already pulls futures-util transitively).
+futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
 # OS CSPRNG for the op-log device key: fills a 32-byte ed25519 seed at first use, which then flows
 # through the existing deterministic `SigningKey::from_bytes`. The lowest-level entropy source (no
 # `rand`/`rand_core` pulled in for this), keeping `from_seed` the sole key constructor.

--- a/crates/rag-rat-cli/src/commands/hooks.rs
+++ b/crates/rag-rat-cli/src/commands/hooks.rs
@@ -4,16 +4,25 @@
 use std::fs;
 
 use rag_rat_core::Config;
+use rag_rat_core::index::papertrail::autosync;
 
 use crate::cli::{HookAction, HooksArgs, PapertrailArgs, PapertrailCommand};
 use crate::render::print_output;
-use crate::{MANAGED_HOOKS, git_paths, install_hook, is_rag_rat_hook, open_index};
+use crate::{MANAGED_HOOKS, git_paths, install_hook, is_rag_rat_hook};
 
 pub(crate) fn papertrail(config: &Config, args: &PapertrailArgs) -> anyhow::Result<()> {
     match &args.command {
         PapertrailCommand::Sync { full } => {
-            let db = open_index(config)?;
-            let report = db.papertrail_sync(*full)?;
+            // Manual sync shares the per-repo flight lock with automatic sync: two mirror runs
+            // over one binding would interleave their cursor load/save cycles and clobber each
+            // other's walk state. A running automatic flight is waited out (observably), never
+            // substituted for the unconditional manual pass.
+            let report = autosync::run_manual(config, *full, || {
+                eprintln!(
+                    "papertrail: an automatic sync flight is running; waiting for it to finish \
+                     (Ctrl-C to abort)…"
+                );
+            })?;
             print_output(&report)
         },
     }

--- a/crates/rag-rat-cli/src/commands/hooks.rs
+++ b/crates/rag-rat-cli/src/commands/hooks.rs
@@ -8,11 +8,13 @@ use rag_rat_core::index::papertrail::autosync;
 
 use crate::cli::{HookAction, HooksArgs, PapertrailArgs, PapertrailCommand};
 use crate::render::print_output;
-use crate::{MANAGED_HOOKS, git_paths, install_hook, is_rag_rat_hook};
+use crate::{MANAGED_HOOKS, ensure_index_exists, git_paths, install_hook, is_rag_rat_hook};
 
 pub(crate) fn papertrail(config: &Config, args: &PapertrailArgs) -> anyhow::Result<()> {
     match &args.command {
         PapertrailCommand::Sync { full } => {
+            // The friendly missing-index hint, before any lock or open work.
+            ensure_index_exists(config)?;
             // Manual sync shares the per-repo flight lock with automatic sync: two mirror runs
             // over one binding would interleave their cursor load/save cycles and clobber each
             // other's walk state. A running automatic flight is waited out (observably), never

--- a/crates/rag-rat-cli/src/commands/index_ops.rs
+++ b/crates/rag-rat-cli/src/commands/index_ops.rs
@@ -373,15 +373,21 @@ pub(crate) fn maintenance(config: &Config, args: &MaintenanceArgs) -> anyhow::Re
     {
         let Some(_maint) = rag_rat_core::locks::FileLock::try_acquire(&lock_path)? else {
             let _ = fs::File::create(&pending);
-            // No papertrail trigger here: the in-flight runner fires one after its own passes,
-            // covering this trigger's change signal.
-            return print_output(&serde_json::json!({
+            let mut skip_report = serde_json::json!({
                 "trigger": trigger,
                 "status": "skipped",
                 "reason": "another maintenance pass is in flight (coalesced, #267)",
                 "old_head": old_head,
                 "new_head": new_head,
-            }));
+            });
+            // A HOOK trigger still fires its own papertrail request: the in-flight maintenance
+            // holder may be a manual/cron run that never triggers papertrail, so relying on it
+            // would drop this trigger's change signal. The flight lock and pending marker dedup
+            // this against any flight the holder (or the watcher) does run.
+            if hook_trigger {
+                skip_report["papertrail"] = papertrail_hook_trigger(config);
+            }
+            return print_output(&skip_report);
         };
         loop {
             // This pass covers the current state, so clear any prior rerun request first; a
@@ -423,6 +429,10 @@ fn papertrail_hook_trigger(config: &Config) -> serde_json::Value {
         Ok(autosync::AutosyncOutcome::Disabled) => {
             serde_json::json!({"status": "disabled", "reason": "no tracker bindings"})
         },
+        Ok(autosync::AutosyncOutcome::NotIndexed) => serde_json::json!({
+            "status": "deferred",
+            "reason": "repo is not indexed yet; automatic sync starts after the first index pass",
+        }),
         Ok(autosync::AutosyncOutcome::Coalesced) => serde_json::json!({
             "status": "coalesced",
             "reason": "another papertrail flight is in the air; request queued",
@@ -1302,6 +1312,58 @@ mod papertrail_hook_tests {
         assert!(
             !rag_rat_core::locks::papertrail_pending_path(&config.database, &lock_repo).exists()
         );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// A hook trigger that coalesces behind an in-flight maintenance run still fires its own
+    /// papertrail request: the holder may be a manual/cron run that never triggers papertrail,
+    /// so deferring to it would drop the change signal. A coalesced NON-hook trigger stays
+    /// mirror-free.
+    #[test]
+    fn coalesced_hook_trigger_still_fires_papertrail() {
+        use rag_rat_core::locks::{FileLock, maintenance_lock_path, write_lock_repo_id};
+
+        let root = std::env::temp_dir().join(format!(
+            "rag-rat-cli-papertrail-coalesced-{}-{}",
+            std::process::id(),
+            N.fetch_add(1, Ordering::Relaxed)
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::write(root.join("src/lib.rs"), "pub fn f() {}\n").unwrap();
+        let config = config_with_unreachable_tracker(&root);
+        IndexDatabase::rebuild(&config).unwrap();
+
+        let lock_repo = write_lock_repo_id(&config);
+        let held = FileLock::try_acquire(&maintenance_lock_path(&config.database, &lock_repo))
+            .unwrap()
+            .unwrap();
+        let args = |trigger: &str| super::MaintenanceArgs {
+            trigger: Some(trigger.to_string()),
+            max_seconds: Some(0),
+            branch_checkout: None,
+            old_head: None,
+            new_head: None,
+        };
+        let mirror_attempts = || -> i64 {
+            rusqlite::Connection::open(&config.database)
+                .unwrap()
+                .query_row(
+                    "SELECT COUNT(*) FROM papertrail_sync_cursor WHERE project='o/r'",
+                    [],
+                    |row| row.get(0),
+                )
+                .unwrap()
+        };
+
+        // A coalesced non-hook trigger must not start mirror work...
+        super::maintenance(&config, &args("manual")).unwrap();
+        assert_eq!(mirror_attempts(), 0);
+        // ...while a coalesced HOOK trigger fires the papertrail flight inline.
+        super::maintenance(&config, &args("post-commit")).unwrap();
+        assert_eq!(mirror_attempts(), 1, "the hook's change signal must not be dropped");
+        drop(held);
 
         let _ = std::fs::remove_dir_all(&root);
     }

--- a/crates/rag-rat-cli/src/commands/index_ops.rs
+++ b/crates/rag-rat-cli/src/commands/index_ops.rs
@@ -337,12 +337,17 @@ pub(crate) fn maintenance(config: &Config, args: &MaintenanceArgs) -> anyhow::Re
     if matches!(trigger.as_str(), "post-checkout" | "post-merge")
         && crate::agent_hook::watcher_state(config).0
     {
+        // The git action is still a tracker-change signal even when the index pass is the
+        // watcher's job: run the papertrail trigger before deferring (it coalesces with the
+        // watcher's own worker through the flight lock).
+        let papertrail = papertrail_hook_trigger(config);
         print_output(&serde_json::json!({
             "trigger": trigger,
             "status": "skipped",
             "reason": "watcher live — deferring to the watcher's pass",
             "old_head": old_head,
             "new_head": new_head,
+            "papertrail": papertrail,
         }))?;
         return Ok(());
     }
@@ -358,28 +363,71 @@ pub(crate) fn maintenance(config: &Config, args: &MaintenanceArgs) -> anyhow::Re
     let lock_repo = rag_rat_core::locks::write_lock_repo_id(config);
     let pending = rag_rat_core::locks::maintenance_pending_path(&config.database, &lock_repo);
     let lock_path = rag_rat_core::locks::maintenance_lock_path(&config.database, &lock_repo);
-    let Some(_maint) = rag_rat_core::locks::FileLock::try_acquire(&lock_path)? else {
-        let _ = fs::File::create(&pending);
-        return print_output(&serde_json::json!({
-            "trigger": trigger,
-            "status": "skipped",
-            "reason": "another maintenance pass is in flight (coalesced, #267)",
-            "old_head": old_head,
-            "new_head": new_head,
-        }));
-    };
-
     let mut report;
-    loop {
-        // This pass covers the current state, so clear any prior rerun request first; a trigger
-        // that fires after this point re-sets it and earns the rerun below.
-        let _ = fs::remove_file(&pending);
-        report = run_maintenance_pass(config, args, &trigger)?;
-        if !pending.exists() {
-            break;
+    {
+        let Some(_maint) = rag_rat_core::locks::FileLock::try_acquire(&lock_path)? else {
+            let _ = fs::File::create(&pending);
+            // No papertrail trigger here: the in-flight runner fires one after its own passes,
+            // covering this trigger's change signal.
+            return print_output(&serde_json::json!({
+                "trigger": trigger,
+                "status": "skipped",
+                "reason": "another maintenance pass is in flight (coalesced, #267)",
+                "old_head": old_head,
+                "new_head": new_head,
+            }));
+        };
+        loop {
+            // This pass covers the current state, so clear any prior rerun request first; a
+            // trigger that fires after this point re-sets it and earns the rerun below.
+            let _ = fs::remove_file(&pending);
+            report = run_maintenance_pass(config, args, &trigger)?;
+            if !pending.exists() {
+                break;
+            }
         }
+        // The maintenance coordination lock is released HERE, before the papertrail trigger: a
+        // network-bound mirror flight must not make concurrent git triggers coalesce-skip their
+        // ordinary index passes.
+    }
+    let papertrail = papertrail_hook_trigger(config);
+    if let Some(report) = report.as_object_mut() {
+        report.insert("papertrail".to_string(), papertrail);
     }
     print_output(&report)
+}
+
+/// Best-effort papertrail auto-sync riding the git trigger (#592): runs AFTER ordinary
+/// maintenance and after the coordination lock is dropped, and never holds the repo write lock —
+/// the flight's commits are short transactions serialized by SQLite. Every failure is folded
+/// into the report; a broken mirror must never fail the git hook. Per-binding failure and
+/// staleness detail is persisted as binding health inside the flight and retried by the
+/// scheduling policy on later triggers.
+fn papertrail_hook_trigger(config: &Config) -> serde_json::Value {
+    use rag_rat_core::index::papertrail::{AutosyncRequest, autosync};
+    match autosync::run(config, AutosyncRequest::Incremental) {
+        Ok(autosync::AutosyncOutcome::Disabled) => {
+            serde_json::json!({"status": "disabled", "reason": "no tracker bindings"})
+        },
+        Ok(autosync::AutosyncOutcome::Coalesced) => serde_json::json!({
+            "status": "coalesced",
+            "reason": "another papertrail flight is in the air; request queued",
+        }),
+        Ok(autosync::AutosyncOutcome::Ran(report)) => serde_json::json!({
+            "status": "ran",
+            "synced_items": report.synced_items,
+            "bindings": report.bindings.len(),
+            "errors": report.errors.len(),
+        }),
+        Err(error) => {
+            tracing::warn!(
+                target: "rag_rat_core::papertrail",
+                error = %error,
+                "papertrail auto-sync failed; a later trigger retries"
+            );
+            serde_json::json!({"status": "error", "error": error.to_string()})
+        },
+    }
 }
 
 /// One maintenance pass: discover-index under the write lock, refresh every live linked-worktree
@@ -1146,6 +1194,100 @@ mod tests {
             )
             .unwrap();
         assert_eq!(complete, 1, "the quiet-elapsed hook pass builds the graph to completion");
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+}
+
+#[cfg(test)]
+mod papertrail_hook_tests {
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    use rag_rat_core::config::{ResolvedTarget, TargetKind, Tracker, TrackerConfig};
+    use rag_rat_core::language::Language;
+    use rag_rat_core::{Config, IndexDatabase};
+
+    static N: AtomicU64 = AtomicU64::new(0);
+
+    fn config_with_unreachable_tracker(root: &std::path::Path) -> Config {
+        Config {
+            trackers: vec![TrackerConfig {
+                provider: Tracker::Github,
+                project: Some("o/r".to_string()),
+                remote: "origin".to_string(),
+                // Nothing listens on the discard port: the mirror flight fails fast with a
+                // network error, which must never fail the git hook.
+                base_url: Some("http://127.0.0.1:9".to_string()),
+                auth: None,
+                tags: Vec::new(),
+            }],
+            papertrail: Default::default(),
+            repo_id_override: None,
+            database_key_pinned: true,
+            root: root.to_path_buf(),
+            database: root.join(".rag-rat/index.sqlite"),
+            targets: vec![ResolvedTarget {
+                name: "rust".to_string(),
+                language: Language::Rust,
+                directories: vec![PathBuf::from("src")],
+                include: vec!["src/".to_string()],
+                exclude: Vec::new(),
+                kind: TargetKind::Source,
+            }],
+            llm: Default::default(),
+            watch: Default::default(),
+            version_check: Default::default(),
+            oracle: Default::default(),
+            search: Default::default(),
+            memory: Default::default(),
+            log: Default::default(),
+            source_root_reanchored_from: None,
+            allow_empty: false,
+        }
+    }
+
+    #[test]
+    fn maintenance_triggers_papertrail_after_the_pass_and_a_broken_mirror_never_fails_the_hook() {
+        let root = std::env::temp_dir().join(format!(
+            "rag-rat-cli-papertrail-hook-{}-{}",
+            std::process::id(),
+            N.fetch_add(1, Ordering::Relaxed)
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::write(root.join("src/lib.rs"), "pub fn f() {}\n").unwrap();
+        let config = config_with_unreachable_tracker(&root);
+        IndexDatabase::rebuild(&config).unwrap();
+
+        let args = super::MaintenanceArgs {
+            trigger: Some("post-commit".to_string()),
+            max_seconds: Some(0),
+            branch_checkout: None,
+            old_head: None,
+            new_head: None,
+        };
+        // The mirror flight fails (nothing listens on the binding's base_url) — maintenance must
+        // still succeed, with the failure persisted as binding health for later retries.
+        super::maintenance(&config, &args).unwrap();
+
+        let conn = rusqlite::Connection::open(&config.database).unwrap();
+        let (attempted, error_class): (Option<i64>, Option<String>) = conn
+            .query_row(
+                "SELECT last_attempt_ms, error_class FROM papertrail_sync_cursor
+                 WHERE tracker='github' AND project='o/r'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert!(attempted.is_some(), "the flight recorded its attempt");
+        assert_eq!(error_class.as_deref(), Some("network"), "the failure class is persisted");
+
+        // The flight consumed its own coordination state: no pending marker survives a run.
+        let lock_repo = rag_rat_core::locks::write_lock_repo_id(&config);
+        assert!(
+            !rag_rat_core::locks::papertrail_pending_path(&config.database, &lock_repo).exists()
+        );
 
         let _ = std::fs::remove_dir_all(&root);
     }

--- a/crates/rag-rat-cli/src/commands/index_ops.rs
+++ b/crates/rag-rat-cli/src/commands/index_ops.rs
@@ -315,6 +315,11 @@ pub(crate) fn maintenance(config: &Config, args: &MaintenanceArgs) -> anyhow::Re
     let branch_checkout = args.branch_checkout.clone();
     let old_head = args.old_head.clone();
     let new_head = args.new_head.clone();
+    // Papertrail auto-sync rides GIT-HOOK triggers only. A manual / foreground `maintenance`
+    // run must stay bounded by its index budget — a mirror flight can start a full backfill or
+    // wait on provider rate limits, far past `--max-seconds`. Explicit mirroring is
+    // `rag-rat papertrail sync`.
+    let hook_trigger = crate::MANAGED_HOOKS.contains(&trigger.as_str());
 
     if trigger == "post-checkout" && branch_checkout.as_deref() == Some("0") {
         print_output(&serde_json::json!({
@@ -339,7 +344,8 @@ pub(crate) fn maintenance(config: &Config, args: &MaintenanceArgs) -> anyhow::Re
     {
         // The git action is still a tracker-change signal even when the index pass is the
         // watcher's job: run the papertrail trigger before deferring (it coalesces with the
-        // watcher's own worker through the flight lock).
+        // watcher's own worker through the flight lock). This path is only reachable for
+        // hook triggers (post-checkout / post-merge).
         let papertrail = papertrail_hook_trigger(config);
         print_output(&serde_json::json!({
             "trigger": trigger,
@@ -390,7 +396,15 @@ pub(crate) fn maintenance(config: &Config, args: &MaintenanceArgs) -> anyhow::Re
         // network-bound mirror flight must not make concurrent git triggers coalesce-skip their
         // ordinary index passes.
     }
-    let papertrail = papertrail_hook_trigger(config);
+    let papertrail = if hook_trigger {
+        papertrail_hook_trigger(config)
+    } else {
+        serde_json::json!({
+            "status": "skipped",
+            "reason": "papertrail auto-sync rides git-hook triggers only; run `rag-rat \
+                       papertrail sync` for an explicit mirror pass",
+        })
+    };
     if let Some(report) = report.as_object_mut() {
         report.insert("papertrail".to_string(), papertrail);
     }
@@ -1288,6 +1302,42 @@ mod papertrail_hook_tests {
         assert!(
             !rag_rat_core::locks::papertrail_pending_path(&config.database, &lock_repo).exists()
         );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// Papertrail auto-sync rides GIT-HOOK triggers only: a manual / foreground `maintenance`
+    /// run must stay bounded by its index budget and never start a network mirror flight.
+    #[test]
+    fn manual_maintenance_never_triggers_papertrail() {
+        let root = std::env::temp_dir().join(format!(
+            "rag-rat-cli-papertrail-manual-{}-{}",
+            std::process::id(),
+            N.fetch_add(1, Ordering::Relaxed)
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::write(root.join("src/lib.rs"), "pub fn f() {}\n").unwrap();
+        let config = config_with_unreachable_tracker(&root);
+        IndexDatabase::rebuild(&config).unwrap();
+
+        for trigger in [None, Some("manual".to_string()), Some("cron".to_string())] {
+            let args = super::MaintenanceArgs {
+                trigger,
+                max_seconds: Some(0),
+                branch_checkout: None,
+                old_head: None,
+                new_head: None,
+            };
+            super::maintenance(&config, &args).unwrap();
+        }
+
+        // The flight never ran: no binding health row was ever created.
+        let conn = rusqlite::Connection::open(&config.database).unwrap();
+        let cursor_rows: i64 = conn
+            .query_row("SELECT COUNT(*) FROM papertrail_sync_cursor", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(cursor_rows, 0, "a non-hook trigger must not start a mirror flight");
 
         let _ = std::fs::remove_dir_all(&root);
     }

--- a/crates/rag-rat-cli/src/main.rs
+++ b/crates/rag-rat-cli/src/main.rs
@@ -473,13 +473,20 @@ fn is_git_hook_trigger(trigger: Option<&str>) -> bool {
 /// Open the index for a read command, mapping a not-yet-built index to a friendly hint instead
 /// of an empty auto-created SQLite file. Commands that build the index (`index`, `maintenance`)
 /// or tolerate a missing schema (`doctor`, `migrate`) deliberately do not go through this.
-pub(crate) fn open_index(config: &Config) -> anyhow::Result<IndexDatabase> {
+/// The friendly missing-index guard, shared by [`open_index`] and the commands that reach the
+/// database through their own open path (manual papertrail sync goes through the flight lock).
+pub(crate) fn ensure_index_exists(config: &Config) -> anyhow::Result<()> {
     if !config.database.exists() {
         anyhow::bail!(
             "No index found at {}.\nRun `rag-rat index` to build it first.",
             config.database.display()
         );
     }
+    Ok(())
+}
+
+pub(crate) fn open_index(config: &Config) -> anyhow::Result<IndexDatabase> {
+    ensure_index_exists(config)?;
     IndexDatabase::open_config(config)
 }
 

--- a/crates/rag-rat-core/Cargo.toml
+++ b/crates/rag-rat-core/Cargo.toml
@@ -18,6 +18,7 @@ ed25519-dalek.workspace = true
 x25519-dalek.workspace = true
 fastembed = { workspace = true, optional = true }
 getrandom.workspace = true
+futures-util.workspace = true
 gix.workspace = true
 httpdate.workspace = true
 ignore = "0.4.26"

--- a/crates/rag-rat-core/src/config/mod.rs
+++ b/crates/rag-rat-core/src/config/mod.rs
@@ -162,6 +162,11 @@ pub enum ConfigError {
          including) 1.0 (got `{0}`)"
     )]
     PapertrailRateLimitReserveOutOfRange(f64),
+    #[error(
+        "[papertrail] `{0}` must be positive — a zero cadence would silently disable automatic \
+         sync"
+    )]
+    PapertrailIntervalZero(&'static str),
 }
 
 pub use discovery::{

--- a/crates/rag-rat-core/src/config/raw.rs
+++ b/crates/rag-rat-core/src/config/raw.rs
@@ -78,6 +78,18 @@ impl TryFrom<RawPapertrail> for PapertrailConfig {
         if !rate_limit_reserve.is_finite() || !(0.0..1.0).contains(&rate_limit_reserve) {
             return Err(ConfigError::PapertrailRateLimitReserveOutOfRange(rate_limit_reserve));
         }
+        // The wake cadences must be positive: the watcher derives its evaluation deadline from
+        // their minimum, so an accepted zero would silently disable automatic sync — including
+        // the OTHER, positive cadence. (`sync_min_interval_secs = 0` stays legal: it only
+        // removes the attempt gate, disabling nothing.)
+        for (key, value) in [
+            ("probe_interval_secs", probe_interval_secs),
+            ("full_sync_interval_secs", full_sync_interval_secs),
+        ] {
+            if value == 0 {
+                return Err(ConfigError::PapertrailIntervalZero(key));
+            }
+        }
         Ok(PapertrailConfig {
             probe_interval_secs,
             sync_min_interval_secs,

--- a/crates/rag-rat-core/src/config/tests.rs
+++ b/crates/rag-rat-core/src/config/tests.rs
@@ -238,6 +238,24 @@ fn papertrail_scheduling_intervals_are_parsed() {
 }
 
 #[test]
+fn papertrail_wake_cadences_reject_zero_but_the_attempt_gate_may_be_zero() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("rag-rat.toml");
+    // A zero wake cadence would silently disable automatic sync (the watcher's deadline is the
+    // minimum of the two), so both are rejected at load.
+    for key in ["probe_interval_secs", "full_sync_interval_secs"] {
+        std::fs::write(&path, format!("[papertrail]\n{key} = 0\n")).unwrap();
+        assert!(
+            matches!(Config::load(&path), Err(ConfigError::PapertrailIntervalZero(rejected)) if rejected == key),
+            "`{key} = 0` must be rejected"
+        );
+    }
+    // The minimum attempt interval only gates retries; zero disables nothing and stays legal.
+    std::fs::write(&path, "[papertrail]\nsync_min_interval_secs = 0\n").unwrap();
+    assert_eq!(Config::load(&path).unwrap().papertrail.sync_min_interval_secs, 0);
+}
+
+#[test]
 fn papertrail_rate_limit_reserve_is_parsed_and_validated() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("rag-rat.toml");

--- a/crates/rag-rat-core/src/index/papertrail/api.rs
+++ b/crates/rag-rat-core/src/index/papertrail/api.rs
@@ -1210,4 +1210,187 @@ mod scheduled_tests {
         assert_eq!(first_handle.join().unwrap().len(), 3);
         assert_eq!(second_handle.join().unwrap().len(), 3);
     }
+
+    /// A walk interrupted by a provider failure persists its cursor and failure class; the next
+    /// due dispatch resumes from that cursor and completes the walk, clearing the failure.
+    #[test]
+    fn interrupted_walk_resumes_from_the_persisted_cursor_on_the_next_dispatch() {
+        let conn = open_schema();
+        // First dispatch: the first logical backfill page lands completely (issue leg with one
+        // item, its comment thread, then the empty pull leg), and the SECOND page's first
+        // request explodes — the walk is interrupted at a clean page boundary with its low mark
+        // persisted.
+        let (first_url, first_handle) = spawn_script_stub(vec![
+            StubResponse::ok(
+                r#"{"incomplete_results":false,"items":[{"number":1,"html_url":"https://example.test/o/r/issues/1","state":"open","title":"one","body":"","updated_at":"2026-01-01T00:00:00Z","labels":[]}]}"#,
+            ),
+            StubResponse::ok("[]"),
+            StubResponse::ok(r#"{"incomplete_results":false,"items":[]}"#),
+            StubResponse::status("500 Internal Server Error", "boom"),
+        ]);
+        let binding = github_binding("o/r", &first_url);
+        let ctx =
+            PapertrailContext { trackers: vec![binding.clone()], ..PapertrailContext::default() };
+        let report =
+            block_on(sync_mirror_scheduled(&conn, &ctx, AutosyncRequest::Incremental)).unwrap();
+        assert_eq!(report.errors.len(), 1, "the interruption surfaces as a binding error");
+        let interrupted = persisted(&conn, &binding);
+        // The first walk of a fresh binding is a FULL walk; its interruption must stay a Full
+        // decision (never degrade to incremental) so the healing walk actually completes.
+        assert_eq!(interrupted.continuation, MirrorContinuation::Full);
+        assert_eq!(first_handle.join().unwrap().len(), 4);
+
+        // The minimum attempt interval gates the immediate retry...
+        let gated =
+            block_on(sync_mirror_scheduled(&conn, &ctx, AutosyncRequest::Incremental)).unwrap();
+        assert!(gated.bindings.is_empty() && gated.errors.is_empty());
+
+        // ...and once it elapses, the next dispatch resumes the descent from the persisted
+        // low mark and completes the full walk, clearing the failure.
+        conn.execute(
+            "UPDATE papertrail_sync_cursor SET last_attempt_ms = last_attempt_ms - 1200000",
+            [],
+        )
+        .unwrap();
+        // A full-rewalk continuation skips the probe entirely: the resumed descent continues
+        // below the persisted low mark (empty issue + pull legs), then the repo-comment streams
+        // close the walk out.
+        let (resume_url, resume_handle) = spawn_script_stub(vec![
+            StubResponse::ok(r#"{"incomplete_results":false,"items":[]}"#),
+            StubResponse::ok(r#"{"incomplete_results":false,"items":[]}"#),
+            StubResponse::ok("[]"),
+            StubResponse::ok("[]"),
+        ]);
+        let resumed_binding = github_binding("o/r", &resume_url);
+        let ctx = PapertrailContext {
+            trackers: vec![resumed_binding.clone()],
+            ..PapertrailContext::default()
+        };
+        let report =
+            block_on(sync_mirror_scheduled(&conn, &ctx, AutosyncRequest::Evaluate)).unwrap();
+        assert!(report.errors.is_empty(), "{:?}", report.errors);
+        assert_eq!(report.bindings.len(), 1);
+        assert!(report.bindings[0].completed_full_walk, "the resumed descent completes the walk");
+        let healed = persisted(&conn, &resumed_binding);
+        // Regression guard: a walk completing on a CHAINED empty provider leg must clear the
+        // consumed page cursor, or the policy misreads the completed walk as interrupted work
+        // forever (perpetual incremental dispatches instead of probes).
+        assert_eq!(healed.continuation, MirrorContinuation::None);
+        assert!(healed.last_full_walk_ms.is_some());
+        assert_eq!(resume_handle.join().unwrap().len(), 4);
+        // The item stored before the interruption was marked seen by the SAME walk, so the
+        // completing rewalk's prune keeps it.
+        let repo_id = schema::active_repo_id(&conn).unwrap();
+        let items: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM papertrail_items WHERE repo_id = ?1",
+                params![repo_id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(items, 1);
+        let (_, error, _, _) = load_persisted_health(&conn, &repo_id, &resumed_binding).unwrap();
+        assert_eq!(error, None, "a completed walk clears the persisted failure");
+    }
+
+    /// A quota-reserve pause persists a retry horizon; later evaluations skip the binding until
+    /// the horizon passes — even under an explicit Full request — and the pause is reported as a
+    /// paused binding, never as a failure.
+    #[test]
+    fn rate_paused_binding_persists_a_retry_horizon_that_gates_later_dispatches() {
+        let conn = open_schema();
+        let reset_epoch_s = now_ms() / 1000 + 3600;
+        // Quota is governed per LANE: the search-lane backfill pages are unaffected, but the
+        // item's comment-thread response (core lane) reports the user reserve reached
+        // (30 <= 35% of 100), so the next CORE request — the repo-comment stream — pauses
+        // until the provider reset.
+        let (url, handle) = spawn_script_stub(vec![
+            StubResponse::ok(
+                r#"{"incomplete_results":false,"items":[{"number":1,"html_url":"https://example.test/o/r/issues/1","state":"open","title":"one","body":"","updated_at":"2026-01-01T00:00:00Z","labels":[]}]}"#,
+            ),
+            StubResponse::ok_with_quota("[]", 100, 30, reset_epoch_s),
+            StubResponse::ok(r#"{"incomplete_results":false,"items":[]}"#),
+            StubResponse::ok(r#"{"incomplete_results":false,"items":[]}"#),
+            StubResponse::ok(r#"{"incomplete_results":false,"items":[]}"#),
+        ]);
+        let binding = github_binding("o/r", &url);
+        let ctx =
+            PapertrailContext { trackers: vec![binding.clone()], ..PapertrailContext::default() };
+
+        let report =
+            block_on(sync_mirror_scheduled(&conn, &ctx, AutosyncRequest::Incremental)).unwrap();
+        assert!(report.errors.is_empty(), "a pause is not a failure: {:?}", report.errors);
+        assert_eq!(report.bindings.len(), 1);
+        assert_eq!(report.bindings[0].paused_until_ms, Some(reset_epoch_s * 1000));
+        assert_eq!(report.bindings[0].stored_items, 1, "work before the pause is kept");
+        assert_eq!(handle.join().unwrap().len(), 5, "the pause lands before the next CORE request");
+        let paused = persisted(&conn, &binding);
+        assert_eq!(paused.retry_not_before_ms, Some(reset_epoch_s * 1000));
+
+        // Past the attempt interval but inside the retry horizon: nothing dispatches, for any
+        // request strength. The stub is gone, so an escaped dispatch would surface as an error.
+        conn.execute(
+            "UPDATE papertrail_sync_cursor SET last_attempt_ms = last_attempt_ms - 1200000",
+            [],
+        )
+        .unwrap();
+        for request in [AutosyncRequest::Evaluate, AutosyncRequest::Full] {
+            let gated = block_on(sync_mirror_scheduled(&conn, &ctx, request)).unwrap();
+            assert!(
+                gated.bindings.is_empty() && gated.errors.is_empty(),
+                "{request:?} must stay gated by the retry horizon"
+            );
+        }
+    }
+
+    /// A changed tag filter is a change signal in its own right: even with fresh probe and
+    /// mirror freshness, the next evaluation dispatches and the mirror restarts its walk under
+    /// the new filter (the fingerprint reset is what re-scopes the cache).
+    #[test]
+    fn filter_fingerprint_change_dispatches_despite_fresh_probe_and_mirror_timestamps() {
+        let conn = open_schema();
+        // The filter change dispatches an ordinary incremental run; inside it the mirror resets
+        // the backfill under the new fingerprint: probe (not modified) -> repo-comment streams
+        // -> re-descent from scratch (one page + its thread) -> done.
+        let (url, _handle) = spawn_script_stub(vec![
+            StubResponse::status("304 Not Modified", ""),
+            StubResponse::ok("[]"),
+            StubResponse::ok("[]"),
+            StubResponse::ok(
+                r#"{"incomplete_results":false,"items":[{"number":1,"html_url":"https://example.test/o/r/issues/1","state":"open","title":"bugged","body":"","updated_at":"2026-01-01T00:00:00Z","labels":[{"name":"bug"}]}]}"#,
+            ),
+            StubResponse::ok("[]"),
+            StubResponse::ok(r#"{"incomplete_results":false,"items":[]}"#),
+            StubResponse::ok(r#"{"incomplete_results":false,"items":[]}"#),
+            StubResponse::ok(r#"{"incomplete_results":false,"items":[]}"#),
+        ]);
+        let mut binding = github_binding("o/r", &url);
+        binding.tags = vec!["bug".to_string()];
+        let now = now_ms();
+        // The stored cursor was fingerprinted under a DIFFERENT (empty) tag filter.
+        record_attempt(&conn, &binding, 0).unwrap();
+        conn.execute(
+            "UPDATE papertrail_sync_cursor
+             SET backfill_done=1, high_mark_at=?1, filter_fingerprint=''",
+            params![HIGH_MARK],
+        )
+        .unwrap();
+        seed_health(&conn, &binding, &SeededHealth {
+            attempt: now - HOUR_MS,
+            probe: now - 60_000,
+            mirror: now - 60_000,
+            full: now - HOUR_MS,
+        });
+        let ctx =
+            PapertrailContext { trackers: vec![binding.clone()], ..PapertrailContext::default() };
+
+        let report =
+            block_on(sync_mirror_scheduled(&conn, &ctx, AutosyncRequest::Evaluate)).unwrap();
+        assert!(report.errors.is_empty(), "{:?}", report.errors);
+        assert_eq!(report.bindings.len(), 1, "the filter change alone must dispatch");
+        assert!(
+            report.bindings[0].completed_full_walk,
+            "a re-scoped filter restarts and completes the walk"
+        );
+    }
 }

--- a/crates/rag-rat-core/src/index/papertrail/api.rs
+++ b/crates/rag-rat-core/src/index/papertrail/api.rs
@@ -1,6 +1,9 @@
 use super::*;
 use crate::index::{repo_meta, schema, scoped_table_row_count, set_repo_meta};
 
+/// Mirror every resolved binding, unconditionally (the explicit `papertrail sync` command).
+/// Provider-client-pending and unauthenticatable bindings surface as report errors so the
+/// operator sees exactly what a manual run could not do.
 pub(crate) async fn sync_mirror(
     conn: &Connection,
     root: &Path,
@@ -10,72 +13,213 @@ pub(crate) async fn sync_mirror(
     ensure_unique_mirror_bindings(&ctx.trackers)?;
     let refs = discover_and_store_refs(conn, root, ctx)?;
     let registry = transport::GovernorRegistry::default();
-    let options = ctx.transport_options.clone();
-    let mut synced_items = 0;
-    let mut bindings = Vec::new();
     let mut errors = Vec::new();
+    let mut jobs = Vec::new();
     for binding in &ctx.trackers {
-        let attempted_at = now_ms();
-        record_attempt(conn, binding, attempted_at)?;
+        record_attempt(conn, binding, now_ms())?;
         if binding.provider != Tracker::Github {
-            errors.push(PapertrailSyncError {
-                tracker: binding.provider,
-                project: binding.project.clone(),
-                item_key: String::new(),
-                status: "provider_client_pending".to_string(),
-                error: format!(
-                    "{} mirror client is not implemented yet",
-                    binding.provider.as_db_str()
-                ),
-            });
+            errors.push(binding_error(
+                binding,
+                "provider_client_pending",
+                format!("{} mirror client is not implemented yet", binding.provider.as_db_str()),
+            ));
             continue;
         }
-        match GitHubClient::new(binding, &registry, options.clone()) {
-            Ok(client) => match mirror_binding(conn, binding, &client, full).await {
-                Ok(report) => {
-                    synced_items += report.stored_items;
-                    if let Some(operation) = completed_mirror_operation(&report, full) {
-                        record_success(conn, binding, operation, now_ms())?;
-                    } else if let Some(resume_at_ms) = report.paused_until_ms {
-                        record_pause(conn, binding, resume_at_ms)?;
-                    }
-                    bindings.push(report);
-                },
-                Err(error) => {
-                    let class = classify_mirror_failure(&error);
-                    record_failure(conn, binding, class, Some(&error.to_string()))?;
-                    errors.push(PapertrailSyncError {
-                        tracker: binding.provider,
-                        project: binding.project.clone(),
-                        item_key: String::new(),
-                        status: "failed".to_string(),
-                        error: error.to_string(),
-                    });
-                },
-            },
-            Err(error) => {
-                let persisted_detail = authentication_failure_detail(binding, &error);
-                record_failure(
-                    conn,
-                    binding,
-                    PapertrailErrorClass::Authentication,
-                    persisted_detail.as_deref(),
-                )?;
-                errors.push(PapertrailSyncError {
-                    tracker: binding.provider,
-                    project: binding.project.clone(),
-                    item_key: String::new(),
-                    status: "authentication_or_transport".to_string(),
-                    error: error.to_string(),
-                });
-            },
+        if let Some(job) = prepare_binding_job(
+            conn,
+            binding,
+            &registry,
+            &ctx.transport_options,
+            full,
+            &mut errors,
+        )? {
+            jobs.push(job);
         }
+    }
+    let outcomes = run_binding_jobs(conn, jobs).await?;
+    assemble_mirror_report(conn, ctx, refs.len(), outcomes, errors)
+}
+
+/// Mirror the bindings the scheduling policy says are due, all evaluated against ONE clock
+/// snapshot (the automatic watcher/hook path). Differences from the manual [`sync_mirror`]:
+/// provider-client-pending bindings are silently filtered (an automatic tick must not log the
+/// same capability gap every 15 minutes — `status` reports it), `Skip` decisions never record an
+/// attempt, and reference discovery does not run (it re-reads every indexed file from disk; the
+/// annotation layer refreshes on manual sync).
+pub(crate) async fn sync_mirror_scheduled(
+    conn: &Connection,
+    ctx: &PapertrailContext,
+    request: AutosyncRequest,
+) -> anyhow::Result<PapertrailSyncReport> {
+    ensure_unique_mirror_bindings(&ctx.trackers)?;
+    let repo_id = schema::active_repo_id(conn)?;
+    let registry = transport::GovernorRegistry::default();
+    let now = now_ms();
+    let mut errors = Vec::new();
+    let mut jobs = Vec::new();
+    for binding in &ctx.trackers {
+        if tracker_synchronization(binding) != TrackerSynchronization::Native {
+            continue;
+        }
+        let (health, _, _, stored_fingerprint) = load_persisted_health(conn, &repo_id, binding)?;
+        let filter_changed = stored_fingerprint != binding.filter_fingerprint();
+        let change_detected = filter_changed || request >= AutosyncRequest::Incremental;
+        let decision = decide_schedule(now, &ctx.schedule, health, change_detected);
+        let Some(full) = scheduled_walk_depth(decision, request) else {
+            continue;
+        };
+        record_attempt(conn, binding, now)?;
+        if let Some(job) = prepare_binding_job(
+            conn,
+            binding,
+            &registry,
+            &ctx.transport_options,
+            full,
+            &mut errors,
+        )? {
+            jobs.push(job);
+        }
+    }
+    if jobs.is_empty() && errors.is_empty() {
+        // Nothing was due: report current status without stamping a sync that never ran.
+        return Ok(PapertrailSyncReport {
+            offline: false,
+            discovered_refs: 0,
+            skipped_refs: 0,
+            failed_refs: 0,
+            synced_items: 0,
+            bindings: Vec::new(),
+            errors: Vec::new(),
+            status: status(conn, ctx)?,
+        });
+    }
+    let outcomes = run_binding_jobs(conn, jobs).await?;
+    assemble_mirror_report(conn, ctx, 0, outcomes, errors)
+}
+
+/// Walk depth for one binding the policy evaluated: `None` = do not dispatch, `Some(full)`
+/// otherwise. A `Full` request upgrades any allowed decision — a daily/full trigger must never
+/// be weakened by a weaker concurrent one — while `Skip` always wins: persisted pauses and the
+/// minimum attempt interval gate even explicitly requested work.
+fn scheduled_walk_depth(decision: ScheduleDecision, request: AutosyncRequest) -> Option<bool> {
+    match decision {
+        ScheduleDecision::Skip => None,
+        ScheduleDecision::Full => Some(true),
+        ScheduleDecision::Probe | ScheduleDecision::Incremental =>
+            Some(request == AutosyncRequest::Full),
+    }
+}
+
+/// One dispatchable per-binding mirror run: the provider client is already constructed and the
+/// walk depth decided. Skipped and provider-client-pending bindings never become jobs.
+struct BindingJob<'a> {
+    binding: &'a ResolvedTracker,
+    client: GitHubClient,
+    full: bool,
+}
+
+/// What one dispatched binding produced: a resumable report, or the error entry to surface.
+/// Health rows are already updated either way; a failed binding never cancels its siblings.
+struct BindingOutcome {
+    report: Option<MirrorBindingReport>,
+    error: Option<PapertrailSyncError>,
+}
+
+/// Build the binding's client, or record the authentication failure and surface it into
+/// `errors`. `None` = not dispatchable this run. Only a storage-layer error propagates.
+fn prepare_binding_job<'a>(
+    conn: &Connection,
+    binding: &'a ResolvedTracker,
+    registry: &transport::GovernorRegistry,
+    options: &transport::TransportOptions,
+    full: bool,
+    errors: &mut Vec<PapertrailSyncError>,
+) -> anyhow::Result<Option<BindingJob<'a>>> {
+    match GitHubClient::new(binding, registry, options.clone()) {
+        Ok(client) => Ok(Some(BindingJob { binding, client, full })),
+        Err(error) => {
+            let persisted_detail = authentication_failure_detail(binding, &error);
+            record_failure(
+                conn,
+                binding,
+                PapertrailErrorClass::Authentication,
+                persisted_detail.as_deref(),
+            )?;
+            errors.push(binding_error(binding, "authentication_or_transport", error.to_string()));
+            Ok(None)
+        },
+    }
+}
+
+/// Run every prepared job CONCURRENTLY on the papertrail current-thread runtime. Network waits
+/// (page fetches, rate-governor sleeps) overlap across bindings, while every database commit
+/// stays a short synchronous transaction between awaits on the single driving thread — commits
+/// are serialized by construction, and no SQLite transaction, connection guard, or repository
+/// write lock ever spans an await. Each job records its own success / pause / failure health, so
+/// one binding's provider failure never cancels a sibling; only a storage-layer error (the
+/// connection itself is broken) propagates, after every job has finished.
+async fn run_binding_jobs(
+    conn: &Connection,
+    jobs: Vec<BindingJob<'_>>,
+) -> anyhow::Result<Vec<BindingOutcome>> {
+    futures_util::future::join_all(jobs.into_iter().map(|job| run_binding_job(conn, job)))
+        .await
+        .into_iter()
+        .collect()
+}
+
+async fn run_binding_job(conn: &Connection, job: BindingJob<'_>) -> anyhow::Result<BindingOutcome> {
+    match mirror_binding(conn, job.binding, &job.client, job.full).await {
+        Ok(report) => {
+            if let Some(operation) = completed_mirror_operation(&report, job.full) {
+                record_success(conn, job.binding, operation, now_ms())?;
+            } else if let Some(resume_at_ms) = report.paused_until_ms {
+                record_pause(conn, job.binding, resume_at_ms)?;
+            }
+            Ok(BindingOutcome { report: Some(report), error: None })
+        },
+        Err(error) => {
+            let class = classify_mirror_failure(&error);
+            record_failure(conn, job.binding, class, Some(&error.to_string()))?;
+            Ok(BindingOutcome {
+                report: None,
+                error: Some(binding_error(job.binding, "failed", error.to_string())),
+            })
+        },
+    }
+}
+
+fn binding_error(binding: &ResolvedTracker, status: &str, error: String) -> PapertrailSyncError {
+    PapertrailSyncError {
+        tracker: binding.provider,
+        project: binding.project.clone(),
+        item_key: String::new(),
+        status: status.to_string(),
+        error,
+    }
+}
+
+fn assemble_mirror_report(
+    conn: &Connection,
+    ctx: &PapertrailContext,
+    discovered_refs: usize,
+    outcomes: Vec<BindingOutcome>,
+    mut errors: Vec<PapertrailSyncError>,
+) -> anyhow::Result<PapertrailSyncReport> {
+    let mut synced_items = 0;
+    let mut bindings = Vec::new();
+    for outcome in outcomes {
+        if let Some(report) = outcome.report {
+            synced_items += report.stored_items;
+            bindings.push(report);
+        }
+        errors.extend(outcome.error);
     }
     let repo_id = schema::active_repo_id(conn)?;
     set_repo_meta(conn, &repo_id, "papertrail_last_sync_ms", &now_ms().to_string())?;
     Ok(PapertrailSyncReport {
         offline: false,
-        discovered_refs: refs.len(),
+        discovered_refs,
         skipped_refs: 0,
         failed_refs: errors.len(),
         synced_items,
@@ -123,8 +267,18 @@ fn completed_mirror_operation(
     if report.paused_until_ms.is_some() {
         return None;
     }
-    Some(if full || report.completed_full_walk {
-        SuccessfulOperation::FullMirror
+    if full || report.completed_full_walk {
+        return Some(SuccessfulOperation::FullMirror);
+    }
+    // A run whose item probe answered not-modified AND that stored / pruned nothing verified
+    // freshness without mirroring anything: advance probe freshness only, so
+    // `last_successful_mirror_ms` keeps meaning "content actually moved".
+    let probe_only = report.probe_not_modified
+        && report.stored_items == 0
+        && report.stored_comments == 0
+        && report.pruned_items == 0;
+    Some(if probe_only {
+        SuccessfulOperation::Probe
     } else {
         SuccessfulOperation::IncrementalMirror
     })
@@ -582,6 +736,7 @@ mod capability_tests {
             paused_until_ms: Some(42),
             pause_reason: Some("rate_limited".to_string()),
             completed_full_walk: false,
+            probe_not_modified: false,
         };
         assert_eq!(completed_mirror_operation(&report, false), None);
         assert_eq!(completed_mirror_operation(&report, true), None);
@@ -608,11 +763,53 @@ mod capability_tests {
             paused_until_ms: None,
             pause_reason: None,
             completed_full_walk: true,
+            probe_not_modified: false,
         };
         assert_eq!(
             completed_mirror_operation(&report, false),
             Some(SuccessfulOperation::FullMirror)
         );
+    }
+
+    #[test]
+    fn quiet_probe_run_is_a_probe_success_but_any_stored_work_is_a_mirror() {
+        let quiet = MirrorBindingReport {
+            tracker: Tracker::Github,
+            project: "o/r".to_string(),
+            stored_items: 0,
+            stored_comments: 0,
+            pruned_items: 0,
+            paused_until_ms: None,
+            pause_reason: None,
+            completed_full_walk: false,
+            probe_not_modified: true,
+        };
+        assert_eq!(completed_mirror_operation(&quiet, false), Some(SuccessfulOperation::Probe));
+        // Comment deltas can move even when the item probe answers not-modified; stored work
+        // makes the run a real mirror.
+        let stored_comments = MirrorBindingReport { stored_comments: 2, ..quiet.clone() };
+        assert_eq!(
+            completed_mirror_operation(&stored_comments, false),
+            Some(SuccessfulOperation::IncrementalMirror)
+        );
+        // An explicitly requested full walk is never downgraded by a quiet probe.
+        assert_eq!(completed_mirror_operation(&quiet, true), Some(SuccessfulOperation::FullMirror));
+    }
+
+    #[test]
+    fn scheduled_walk_depth_upgrades_on_full_requests_and_respects_skip() {
+        use ScheduleDecision::{Full, Incremental, Probe, Skip};
+        for request in
+            [AutosyncRequest::Evaluate, AutosyncRequest::Incremental, AutosyncRequest::Full]
+        {
+            assert_eq!(scheduled_walk_depth(Skip, request), None, "Skip gates {request:?}");
+            assert_eq!(scheduled_walk_depth(Full, request), Some(true));
+        }
+        for decision in [Probe, Incremental] {
+            assert_eq!(scheduled_walk_depth(decision, AutosyncRequest::Evaluate), Some(false));
+            assert_eq!(scheduled_walk_depth(decision, AutosyncRequest::Incremental), Some(false));
+            assert_eq!(scheduled_walk_depth(decision, AutosyncRequest::Full), Some(true));
+        }
     }
 
     #[test]
@@ -741,5 +938,276 @@ mod capability_tests {
         assert!(!pending.failed);
         assert!(!pending.overdue);
         assert_eq!(pending.error_class, None);
+    }
+}
+
+#[cfg(test)]
+mod scheduled_tests {
+    use super::super::transport::stub::{
+        StubResponse, spawn_script_stub, spawn_script_stub_coordinated,
+    };
+    use super::*;
+    use crate::index::schema;
+
+    const HOUR_MS: i64 = 3_600_000;
+    const HIGH_MARK: &str = "2026-01-01T00:00:00Z";
+
+    fn github_binding(project: &str, base_url: &str) -> ResolvedTracker {
+        ResolvedTracker {
+            provider: Tracker::Github,
+            project: project.to_string(),
+            base_url: Some(base_url.to_string()),
+            auth: None,
+            authentication: TrackerAuthentication::AuthMissing,
+            tags: Vec::new(),
+        }
+    }
+
+    fn open_schema() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        schema::apply(&conn).unwrap();
+        conn
+    }
+
+    /// Persist a completed-backfill cursor whose filter fingerprint matches the binding, so a
+    /// scheduled run enters the ordinary probe/delta lane instead of a first-walk backfill.
+    fn seed_quiet_cursor(conn: &Connection, binding: &ResolvedTracker) {
+        record_attempt(conn, binding, 0).unwrap();
+        conn.execute(
+            "UPDATE papertrail_sync_cursor
+             SET backfill_done=1, high_mark_at=?1, filter_fingerprint=?2",
+            params![HIGH_MARK, binding.filter_fingerprint()],
+        )
+        .unwrap();
+    }
+
+    struct SeededHealth {
+        attempt: i64,
+        probe: i64,
+        mirror: i64,
+        full: i64,
+    }
+
+    fn seed_health(conn: &Connection, binding: &ResolvedTracker, health: &SeededHealth) {
+        record_attempt(conn, binding, health.attempt).unwrap();
+        conn.execute(
+            "UPDATE papertrail_sync_cursor
+             SET last_successful_probe_ms=?1, last_successful_mirror_ms=?2, last_full_sync_ms=?3",
+            params![health.probe, health.mirror, health.full],
+        )
+        .unwrap();
+    }
+
+    fn persisted(conn: &Connection, binding: &ResolvedTracker) -> BindingScheduleState {
+        let repo_id = schema::active_repo_id(conn).unwrap();
+        load_persisted_health(conn, &repo_id, binding).unwrap().0
+    }
+
+    /// The wire shape of a quiet probe run: a not-modified item probe, then one empty page per
+    /// repo-comment stream.
+    fn probe_script() -> Vec<StubResponse> {
+        vec![
+            StubResponse::status("304 Not Modified", ""),
+            StubResponse::ok("[]"),
+            StubResponse::ok("[]"),
+        ]
+    }
+
+    fn full_walk_script(project: &str) -> Vec<StubResponse> {
+        vec![
+            StubResponse::ok(&format!(
+                r#"{{"incomplete_results":false,"items":[{{"number":1,"html_url":"https://example.test/{project}/issues/1","state":"open","title":"{project}","body":"","updated_at":"2026-01-01T00:00:00Z","labels":[]}}]}}"#
+            )),
+            StubResponse::ok("[]"),
+            StubResponse::ok(r#"{"incomplete_results":false,"items":[]}"#),
+            StubResponse::ok(r#"{"incomplete_results":false,"items":[]}"#),
+            StubResponse::ok(r#"{"incomplete_results":false,"items":[]}"#),
+            StubResponse::ok("[]"),
+            StubResponse::ok("[]"),
+        ]
+    }
+
+    #[test]
+    fn bindings_inside_the_minimum_attempt_interval_are_skipped_for_every_request() {
+        let conn = open_schema();
+        let (url, handle) = spawn_script_stub(Vec::new());
+        let binding = github_binding("o/r", &url);
+        let now = now_ms();
+        seed_quiet_cursor(&conn, &binding);
+        seed_health(&conn, &binding, &SeededHealth {
+            attempt: now - 1_000,
+            probe: now - 2 * HOUR_MS,
+            mirror: now - 2 * HOUR_MS,
+            full: now - 2 * HOUR_MS,
+        });
+        let ctx =
+            PapertrailContext { trackers: vec![binding.clone()], ..PapertrailContext::default() };
+
+        for request in
+            [AutosyncRequest::Evaluate, AutosyncRequest::Incremental, AutosyncRequest::Full]
+        {
+            let report = block_on(sync_mirror_scheduled(&conn, &ctx, request)).unwrap();
+            assert!(report.bindings.is_empty(), "{request:?} must not dispatch");
+            assert!(report.errors.is_empty());
+            assert_eq!(report.synced_items, 0);
+        }
+        // The recent attempt is untouched — a skipped binding records nothing.
+        assert_eq!(persisted(&conn, &binding).last_attempt_ms, Some(now - 1_000));
+        assert!(handle.join().unwrap().is_empty(), "no network request may be made");
+    }
+
+    #[test]
+    fn due_probe_advances_probe_freshness_without_touching_mirror_timestamps() {
+        let conn = open_schema();
+        let (url, handle) = spawn_script_stub(probe_script());
+        let binding = github_binding("o/r", &url);
+        let now = now_ms();
+        seed_quiet_cursor(&conn, &binding);
+        let seeded = SeededHealth {
+            attempt: now - HOUR_MS,
+            probe: now - HOUR_MS,
+            mirror: now - HOUR_MS,
+            full: now - 2 * HOUR_MS,
+        };
+        seed_health(&conn, &binding, &seeded);
+        let ctx =
+            PapertrailContext { trackers: vec![binding.clone()], ..PapertrailContext::default() };
+
+        let report =
+            block_on(sync_mirror_scheduled(&conn, &ctx, AutosyncRequest::Evaluate)).unwrap();
+        assert!(report.errors.is_empty(), "{:?}", report.errors);
+        assert_eq!(report.bindings.len(), 1);
+        assert!(report.bindings[0].probe_not_modified);
+        assert_eq!(report.synced_items, 0);
+
+        let health = persisted(&conn, &binding);
+        assert!(health.last_successful_probe_ms.unwrap() >= now, "probe freshness advances");
+        assert_eq!(health.last_successful_mirror_ms, Some(seeded.mirror), "mirror is untouched");
+        assert_eq!(health.last_full_walk_ms, Some(seeded.full), "full walk is untouched");
+        assert_eq!(handle.join().unwrap().len(), 3);
+    }
+
+    #[test]
+    fn overdue_full_backstop_dominates_a_fresh_probe_and_completes_a_full_walk() {
+        let conn = open_schema();
+        let (url, _handle) = spawn_script_stub(full_walk_script("o/r"));
+        let binding = github_binding("o/r", &url);
+        let now = now_ms();
+        seed_quiet_cursor(&conn, &binding);
+        seed_health(&conn, &binding, &SeededHealth {
+            attempt: now - 2 * HOUR_MS,
+            probe: now - 60_000, // fresh probe: the daily backstop must still win
+            mirror: now - 2 * HOUR_MS,
+            full: now - 25 * HOUR_MS,
+        });
+        let ctx =
+            PapertrailContext { trackers: vec![binding.clone()], ..PapertrailContext::default() };
+
+        let report =
+            block_on(sync_mirror_scheduled(&conn, &ctx, AutosyncRequest::Evaluate)).unwrap();
+        assert!(report.errors.is_empty(), "{:?}", report.errors);
+        assert_eq!(report.bindings.len(), 1);
+        assert!(report.bindings[0].completed_full_walk, "the backstop runs a FULL walk");
+        assert_eq!(report.synced_items, 1);
+        let health = persisted(&conn, &binding);
+        assert!(health.last_full_walk_ms.unwrap() >= now, "full-walk freshness advances");
+    }
+
+    #[test]
+    fn scheduled_bindings_fail_independently_and_persist_health() {
+        let conn = open_schema();
+        let (failing_url, failing_handle) =
+            spawn_script_stub(vec![StubResponse::status("500 Internal Server Error", "boom")]);
+        let (good_url, _good_handle) = spawn_script_stub(full_walk_script("b/two"));
+        let failing = github_binding("a/one", &failing_url);
+        let good = github_binding("b/two", &good_url);
+        let ctx = PapertrailContext {
+            trackers: vec![failing.clone(), good.clone()],
+            ..PapertrailContext::default()
+        };
+
+        let report =
+            block_on(sync_mirror_scheduled(&conn, &ctx, AutosyncRequest::Incremental)).unwrap();
+        assert_eq!(report.errors.len(), 1);
+        assert_eq!(report.errors[0].project, "a/one");
+        assert_eq!(report.errors[0].status, "failed");
+        assert_eq!(report.bindings.len(), 1, "the sibling binding completes");
+        assert_eq!(report.bindings[0].project, "b/two");
+        assert!(report.bindings[0].completed_full_walk);
+
+        let failing_status =
+            report.status.bindings.iter().find(|binding| binding.project == "a/one").unwrap();
+        assert!(failing_status.error_class.is_some(), "the failure class is persisted");
+        let good_status =
+            report.status.bindings.iter().find(|binding| binding.project == "b/two").unwrap();
+        assert_eq!(good_status.error_class, None);
+        assert!(good_status.last_full_walk_ms.is_some());
+        assert_eq!(failing_handle.join().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn provider_client_pending_bindings_are_silently_filtered_from_scheduled_runs() {
+        let conn = open_schema();
+        let binding = ResolvedTracker {
+            provider: Tracker::Gitlab,
+            project: "group/repo".to_string(),
+            base_url: Some("https://gitlab.com".to_string()),
+            auth: None,
+            authentication: TrackerAuthentication::AuthMissing,
+            tags: Vec::new(),
+        };
+        let ctx =
+            PapertrailContext { trackers: vec![binding.clone()], ..PapertrailContext::default() };
+
+        let report = block_on(sync_mirror_scheduled(&conn, &ctx, AutosyncRequest::Full)).unwrap();
+        assert!(report.errors.is_empty(), "an automatic tick must not log the capability gap");
+        assert!(report.bindings.is_empty());
+        // No attempt is recorded either — the binding was never evaluated for dispatch.
+        assert_eq!(persisted(&conn, &binding).last_attempt_ms, None);
+    }
+
+    #[test]
+    fn due_bindings_overlap_network_requests_while_commits_stay_serialized() {
+        let conn = open_schema();
+        // Stub A holds its FIRST response until stub B has RECEIVED a request: if the two
+        // binding jobs ran serially, A's probe would block the whole run and the gate would time
+        // out into a 500 the assertions below catch. Overlapping network futures are the only
+        // way both probes complete cleanly.
+        let (gate_tx, gate_rx) = std::sync::mpsc::channel();
+        let (first_url, first_handle) =
+            spawn_script_stub_coordinated(probe_script(), None, Some(gate_rx));
+        let (second_url, second_handle) =
+            spawn_script_stub_coordinated(probe_script(), Some(gate_tx), None);
+        let first = github_binding("a/one", &first_url);
+        let second = github_binding("b/two", &second_url);
+        let now = now_ms();
+        for binding in [&first, &second] {
+            seed_quiet_cursor(&conn, binding);
+            seed_health(&conn, binding, &SeededHealth {
+                attempt: now - HOUR_MS,
+                probe: now - HOUR_MS,
+                mirror: now - HOUR_MS,
+                full: now - 2 * HOUR_MS,
+            });
+        }
+        let ctx = PapertrailContext {
+            trackers: vec![first.clone(), second.clone()],
+            ..PapertrailContext::default()
+        };
+
+        let report =
+            block_on(sync_mirror_scheduled(&conn, &ctx, AutosyncRequest::Evaluate)).unwrap();
+        assert!(
+            report.errors.is_empty(),
+            "serial dispatch would gate-timeout: {:?}",
+            report.errors
+        );
+        assert_eq!(report.bindings.len(), 2);
+        assert!(report.bindings.iter().all(|binding| binding.probe_not_modified));
+        for binding in [&first, &second] {
+            assert!(persisted(&conn, binding).last_successful_probe_ms.unwrap() >= now);
+        }
+        assert_eq!(first_handle.join().unwrap().len(), 3);
+        assert_eq!(second_handle.join().unwrap().len(), 3);
     }
 }

--- a/crates/rag-rat-core/src/index/papertrail/autosync.rs
+++ b/crates/rag-rat-core/src/index/papertrail/autosync.rs
@@ -42,15 +42,26 @@ pub fn run(config: &Config, request: AutosyncRequest) -> anyhow::Result<Autosync
     let lock_repo = locks::write_lock_repo_id(config);
     let lock_path = locks::papertrail_lock_path(&config.database, &lock_repo);
     let pending = PendingMarker::new(&config.database, &lock_repo);
-    let Some(_flight) = FileLock::try_acquire(&lock_path)? else {
-        pending.merge(request)?;
-        return Ok(AutosyncOutcome::Coalesced);
+    // Acquire-or-coalesce atomically under the marker lock: pairing the failed flight
+    // try-acquire with the marker write in one critical section is one half of the exit
+    // handoff below — a request only ever lands in the marker while some runner is still
+    // obligated to check it.
+    let flight = {
+        let guard = pending.lock()?;
+        match FileLock::try_acquire(&lock_path)? {
+            Some(flight) => flight,
+            None => {
+                guard.merge(request)?;
+                return Ok(AutosyncOutcome::Coalesced);
+            },
+        }
     };
+    let mut flight = Some(flight);
     let mut request = request;
     let last_report = loop {
         // This run covers everything requested so far: absorb (and clear) the marker BEFORE
         // running, so only triggers arriving mid-flight earn the follow-up evaluation below.
-        if let Some(coalesced) = pending.take()? {
+        if let Some(coalesced) = pending.lock()?.take()? {
             request = request.max(coalesced);
         }
         let report = match run_flight(config, request) {
@@ -58,13 +69,24 @@ pub fn run(config: &Config, request: AutosyncRequest) -> anyhow::Result<Autosync
             Err(error) => {
                 // Best-effort retry signal: a failing marker write must not shadow the flight
                 // error the caller is about to log.
-                let _ = pending.merge(request);
+                if let Ok(guard) = pending.lock() {
+                    let _ = guard.merge(request);
+                }
                 return Err(error);
             },
         };
-        if !pending.is_set() {
+        // The exit handoff: the final marker check and the flight-lock release happen under ONE
+        // marker-lock hold. A contender's merge-and-try-acquire section is serialized either
+        // before this check (its marker is seen here and earns the follow-up) or after the
+        // flight lock is already free (its try-acquire wins and IT becomes the runner).
+        // Checking without the lock — or releasing the flight lock outside it — reopens the
+        // window where a coalesced request is written into the void and never runs.
+        let guard = pending.lock()?;
+        if !guard.is_set() {
+            drop(flight.take());
             break report;
         }
+        drop(guard);
         // The follow-up's strength comes from the marker itself, absorbed at the loop top.
         request = AutosyncRequest::Evaluate;
     };
@@ -77,11 +99,12 @@ fn run_flight(config: &Config, request: AutosyncRequest) -> anyhow::Result<Paper
 }
 
 /// The pending-marker pair: the marker file carrying the strongest coalesced request, and the
-/// short-lived lock serializing every read-modify-write of it. Without the lock two coalescing
-/// contenders can interleave their max-merge — one reads the old marker, another writes `full`,
-/// the first overwrites it with `incremental` — silently postponing an explicitly queued full
-/// walk. Distinct from the flight lock, which the runner holds for the whole network-bound run;
-/// this one is held for microseconds per update, so contenders never wait on a flight.
+/// lock serializing every access to it. All reads and writes flow through a held [`MarkerGuard`]
+/// so no path can touch the file outside the lock — without it, two coalescing contenders can
+/// interleave their max-merge (a weaker request overwrites a queued `full`), and a runner's exit
+/// check can miss a marker written just before its flight lock releases. Distinct from the
+/// flight lock, which the runner holds for the whole network-bound run; this one is held for
+/// microseconds per section, so contenders never wait on a flight.
 struct PendingMarker {
     path: PathBuf,
     update_lock: PathBuf,
@@ -95,31 +118,42 @@ impl PendingMarker {
         }
     }
 
+    fn lock(&self) -> anyhow::Result<MarkerGuard<'_>> {
+        Ok(MarkerGuard { marker: self, _update: FileLock::acquire_blocking(&self.update_lock)? })
+    }
+}
+
+/// One held marker-lock section. Lock ordering: a runner holding the FLIGHT lock may block on
+/// this lock; a contender holding this lock only ever TRY-acquires the flight lock — the
+/// non-blocking edge is what makes the pair deadlock-free.
+struct MarkerGuard<'a> {
+    marker: &'a PendingMarker,
+    _update: FileLock,
+}
+
+impl MarkerGuard<'_> {
     /// Record `request` into the marker, max-merged with whatever is already queued there.
     fn merge(&self, request: AutosyncRequest) -> anyhow::Result<()> {
-        let _update = FileLock::acquire_blocking(&self.update_lock)?;
-        let merged = match fs::read_to_string(&self.path) {
+        let merged = match fs::read_to_string(&self.marker.path) {
             Ok(existing) => request.max(AutosyncRequest::from_marker_str(&existing)),
             Err(_) => request,
         };
-        fs::write(&self.path, merged.as_marker_str())?;
+        fs::write(&self.marker.path, merged.as_marker_str())?;
         Ok(())
     }
 
-    /// Consume the marker. Runs under the same update lock as [`Self::merge`], so a request
-    /// merged concurrently is either absorbed into the returned value or lands after the removal
-    /// and survives for the next check.
+    /// Consume the marker. A request merged concurrently is either absorbed into the returned
+    /// value or lands after the removal and survives for the next check.
     fn take(&self) -> anyhow::Result<Option<AutosyncRequest>> {
-        let _update = FileLock::acquire_blocking(&self.update_lock)?;
-        let Ok(content) = fs::read_to_string(&self.path) else {
+        let Ok(content) = fs::read_to_string(&self.marker.path) else {
             return Ok(None);
         };
-        let _ = fs::remove_file(&self.path);
+        let _ = fs::remove_file(&self.marker.path);
         Ok(Some(AutosyncRequest::from_marker_str(&content)))
     }
 
     fn is_set(&self) -> bool {
-        self.path.exists()
+        self.marker.path.exists()
     }
 }
 
@@ -150,19 +184,19 @@ mod tests {
         let tmp = tempfile::TempDir::new().unwrap();
         let marker = PendingMarker::new(&tmp.path().join("locks/index.sqlite"), "repo");
 
-        marker.merge(AutosyncRequest::Full).unwrap();
+        marker.lock().unwrap().merge(AutosyncRequest::Full).unwrap();
         // A later, weaker trigger must not weaken the queued full walk.
-        marker.merge(AutosyncRequest::Incremental).unwrap();
+        marker.lock().unwrap().merge(AutosyncRequest::Incremental).unwrap();
         assert_eq!(fs::read_to_string(&marker.path).unwrap(), "full");
 
-        assert_eq!(marker.take().unwrap(), Some(AutosyncRequest::Full));
-        assert!(!marker.is_set());
-        assert_eq!(marker.take().unwrap(), None);
+        assert_eq!(marker.lock().unwrap().take().unwrap(), Some(AutosyncRequest::Full));
+        assert!(!marker.lock().unwrap().is_set());
+        assert_eq!(marker.lock().unwrap().take().unwrap(), None);
 
         // And the upgrade direction: a stronger trigger replaces a weaker queued one.
-        marker.merge(AutosyncRequest::Evaluate).unwrap();
-        marker.merge(AutosyncRequest::Incremental).unwrap();
-        assert_eq!(marker.take().unwrap(), Some(AutosyncRequest::Incremental));
+        marker.lock().unwrap().merge(AutosyncRequest::Evaluate).unwrap();
+        marker.lock().unwrap().merge(AutosyncRequest::Incremental).unwrap();
+        assert_eq!(marker.lock().unwrap().take().unwrap(), Some(AutosyncRequest::Incremental));
     }
 
     #[test]
@@ -184,13 +218,67 @@ mod tests {
                         AutosyncRequest::Incremental
                     };
                     for _ in 0..50 {
-                        marker.merge(request).unwrap();
+                        marker.lock().unwrap().merge(request).unwrap();
                     }
                 });
             }
         });
         let marker = PendingMarker::new(&database, "repo");
-        assert_eq!(marker.take().unwrap(), Some(AutosyncRequest::Full));
+        assert_eq!(marker.lock().unwrap().take().unwrap(), Some(AutosyncRequest::Full));
+    }
+
+    /// The exit handoff under contention: any trigger accepted as `Coalesced` must eventually be
+    /// covered by a runner — after every concurrent `run` returns, no request may be left
+    /// orphaned in the marker. Races many triggers against fast flights (the binding's endpoint
+    /// is unreachable, so each flight fails fast and persists health; after the first attempt
+    /// the minimum interval makes evaluations near-instant).
+    #[test]
+    fn racing_triggers_never_orphan_a_coalesced_request() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let mut config = test_config(tmp.path());
+        config.trackers = vec![crate::config::TrackerConfig {
+            provider: crate::config::Tracker::Github,
+            project: Some("o/r".to_string()),
+            remote: "origin".to_string(),
+            // The discard port: connection refused, so flights fail fast without network.
+            base_url: Some("http://127.0.0.1:9".to_string()),
+            auth: None,
+            tags: Vec::new(),
+        }];
+        config.allow_empty = true;
+        IndexDatabase::rebuild(&config).unwrap();
+
+        let mut ran = 0;
+        let mut coalesced = 0;
+        std::thread::scope(|scope| {
+            let handles: Vec<_> = (0..8)
+                .map(|contender| {
+                    let config = &config;
+                    scope.spawn(move || {
+                        let request = if contender % 2 == 0 {
+                            AutosyncRequest::Incremental
+                        } else {
+                            AutosyncRequest::Full
+                        };
+                        run(config, request).unwrap()
+                    })
+                })
+                .collect();
+            for handle in handles {
+                match handle.join().unwrap() {
+                    AutosyncOutcome::Ran(_) => ran += 1,
+                    AutosyncOutcome::Coalesced => coalesced += 1,
+                    AutosyncOutcome::Disabled => panic!("bindings are configured"),
+                }
+            }
+        });
+        assert!(ran >= 1, "at least one trigger must have run the flight");
+        let lock_repo = locks::write_lock_repo_id(&config);
+        let pending = locks::papertrail_pending_path(&config.database, &lock_repo);
+        assert!(
+            !pending.exists(),
+            "an accepted trigger was orphaned in the marker ({ran} ran, {coalesced} coalesced)"
+        );
     }
 
     #[test]

--- a/crates/rag-rat-core/src/index/papertrail/autosync.rs
+++ b/crates/rag-rat-core/src/index/papertrail/autosync.rs
@@ -1,0 +1,312 @@
+//! Cross-process papertrail auto-sync orchestration: one coalesced mirror flight per repository,
+//! shared by every trigger source — the watcher's periodic deadline, git-hook maintenance, and
+//! any number of concurrent processes. The flight lock + pending marker follow the maintenance
+//! coalescing pattern (#267), with one addition: the marker carries the strongest coalesced
+//! [`AutosyncRequest`] so a queued full walk is never weakened by a later incremental trigger.
+//!
+//! The flight NEVER holds the repository write lock: mirror runs wait on the network (page
+//! fetches, rate-governor sleeps) for arbitrarily long, and every database commit inside them is
+//! a short synchronous transaction serialized by SQLite itself. Ordinary index maintenance and
+//! this flight therefore proceed independently.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use super::{AutosyncRequest, PapertrailContext, PapertrailSyncReport};
+use crate::config::Config;
+use crate::index::IndexDatabase;
+use crate::locks::{self, FileLock};
+
+/// What one auto-sync trigger produced.
+#[derive(Debug)]
+pub enum AutosyncOutcome {
+    /// The repo resolves no tracker bindings; there is nothing to sync.
+    Disabled,
+    /// Another flight holds this repository's lock. The request was merged into the pending
+    /// marker; the holder's follow-up pass (or the next periodic deadline) covers it.
+    Coalesced,
+    /// This process ran the flight, absorbing any coalesced follow-ups; the LAST run's report.
+    Ran(Box<PapertrailSyncReport>),
+}
+
+/// Run — or coalesce into — the repository's single papertrail flight. Callers treat this as
+/// best-effort: per-binding provider failures are persisted as binding health inside the run and
+/// never surface here; only a process-level failure (the database cannot be opened, storage is
+/// broken) returns `Err`, and it leaves the pending marker set so a later trigger retries.
+pub fn run(config: &Config, request: AutosyncRequest) -> anyhow::Result<AutosyncOutcome> {
+    // Resolve bindings from the config BEFORE opening the database: with no tracker bindings the
+    // trigger is a no-op, and a per-commit git hook must not pay a database open to learn that.
+    if PapertrailContext::resolve(config).trackers.is_empty() {
+        return Ok(AutosyncOutcome::Disabled);
+    }
+    let lock_repo = locks::write_lock_repo_id(config);
+    let lock_path = locks::papertrail_lock_path(&config.database, &lock_repo);
+    let pending = PendingMarker::new(&config.database, &lock_repo);
+    let Some(_flight) = FileLock::try_acquire(&lock_path)? else {
+        pending.merge(request)?;
+        return Ok(AutosyncOutcome::Coalesced);
+    };
+    let mut request = request;
+    let last_report = loop {
+        // This run covers everything requested so far: absorb (and clear) the marker BEFORE
+        // running, so only triggers arriving mid-flight earn the follow-up evaluation below.
+        if let Some(coalesced) = pending.take()? {
+            request = request.max(coalesced);
+        }
+        let report = match run_flight(config, request) {
+            Ok(report) => report,
+            Err(error) => {
+                // Best-effort retry signal: a failing marker write must not shadow the flight
+                // error the caller is about to log.
+                let _ = pending.merge(request);
+                return Err(error);
+            },
+        };
+        if !pending.is_set() {
+            break report;
+        }
+        // The follow-up's strength comes from the marker itself, absorbed at the loop top.
+        request = AutosyncRequest::Evaluate;
+    };
+    Ok(AutosyncOutcome::Ran(Box::new(last_report)))
+}
+
+fn run_flight(config: &Config, request: AutosyncRequest) -> anyhow::Result<PapertrailSyncReport> {
+    let db = IndexDatabase::open_config(config)?;
+    db.papertrail_sync_scheduled(request)
+}
+
+/// The pending-marker pair: the marker file carrying the strongest coalesced request, and the
+/// short-lived lock serializing every read-modify-write of it. Without the lock two coalescing
+/// contenders can interleave their max-merge — one reads the old marker, another writes `full`,
+/// the first overwrites it with `incremental` — silently postponing an explicitly queued full
+/// walk. Distinct from the flight lock, which the runner holds for the whole network-bound run;
+/// this one is held for microseconds per update, so contenders never wait on a flight.
+struct PendingMarker {
+    path: PathBuf,
+    update_lock: PathBuf,
+}
+
+impl PendingMarker {
+    fn new(database: &Path, repo_id: &str) -> Self {
+        Self {
+            path: locks::papertrail_pending_path(database, repo_id),
+            update_lock: locks::papertrail_marker_lock_path(database, repo_id),
+        }
+    }
+
+    /// Record `request` into the marker, max-merged with whatever is already queued there.
+    fn merge(&self, request: AutosyncRequest) -> anyhow::Result<()> {
+        let _update = FileLock::acquire_blocking(&self.update_lock)?;
+        let merged = match fs::read_to_string(&self.path) {
+            Ok(existing) => request.max(AutosyncRequest::from_marker_str(&existing)),
+            Err(_) => request,
+        };
+        fs::write(&self.path, merged.as_marker_str())?;
+        Ok(())
+    }
+
+    /// Consume the marker. Runs under the same update lock as [`Self::merge`], so a request
+    /// merged concurrently is either absorbed into the returned value or lands after the removal
+    /// and survives for the next check.
+    fn take(&self) -> anyhow::Result<Option<AutosyncRequest>> {
+        let _update = FileLock::acquire_blocking(&self.update_lock)?;
+        let Ok(content) = fs::read_to_string(&self.path) else {
+            return Ok(None);
+        };
+        let _ = fs::remove_file(&self.path);
+        Ok(Some(AutosyncRequest::from_marker_str(&content)))
+    }
+
+    fn is_set(&self) -> bool {
+        self.path.exists()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn request_strength_orders_evaluate_below_incremental_below_full() {
+        assert!(AutosyncRequest::Evaluate < AutosyncRequest::Incremental);
+        assert!(AutosyncRequest::Incremental < AutosyncRequest::Full);
+    }
+
+    #[test]
+    fn marker_tokens_round_trip_and_unknown_content_degrades_to_evaluate() {
+        for request in
+            [AutosyncRequest::Evaluate, AutosyncRequest::Incremental, AutosyncRequest::Full]
+        {
+            assert_eq!(AutosyncRequest::from_marker_str(request.as_marker_str()), request);
+        }
+        assert_eq!(AutosyncRequest::from_marker_str(" full\n"), AutosyncRequest::Full);
+        assert_eq!(AutosyncRequest::from_marker_str("garbage"), AutosyncRequest::Evaluate);
+        assert_eq!(AutosyncRequest::from_marker_str(""), AutosyncRequest::Evaluate);
+    }
+
+    #[test]
+    fn pending_marker_merges_max_wins_and_is_consumed_once() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let marker = PendingMarker::new(&tmp.path().join("locks/index.sqlite"), "repo");
+
+        marker.merge(AutosyncRequest::Full).unwrap();
+        // A later, weaker trigger must not weaken the queued full walk.
+        marker.merge(AutosyncRequest::Incremental).unwrap();
+        assert_eq!(fs::read_to_string(&marker.path).unwrap(), "full");
+
+        assert_eq!(marker.take().unwrap(), Some(AutosyncRequest::Full));
+        assert!(!marker.is_set());
+        assert_eq!(marker.take().unwrap(), None);
+
+        // And the upgrade direction: a stronger trigger replaces a weaker queued one.
+        marker.merge(AutosyncRequest::Evaluate).unwrap();
+        marker.merge(AutosyncRequest::Incremental).unwrap();
+        assert_eq!(marker.take().unwrap(), Some(AutosyncRequest::Incremental));
+    }
+
+    #[test]
+    fn concurrent_marker_merges_never_lose_the_strongest_request() {
+        // Race many cross-"process" contenders (threads sharing no state but the filesystem, the
+        // exact shape of concurrent hook invocations): one queues a FULL walk while weaker
+        // contenders storm the marker. The update lock makes every read-modify-write atomic, so
+        // the surviving marker must be `full` no matter the interleaving.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let database = tmp.path().join("locks/index.sqlite");
+        std::thread::scope(|scope| {
+            for contender in 0..8 {
+                let database = database.clone();
+                scope.spawn(move || {
+                    let marker = PendingMarker::new(&database, "repo");
+                    let request = if contender == 3 {
+                        AutosyncRequest::Full
+                    } else {
+                        AutosyncRequest::Incremental
+                    };
+                    for _ in 0..50 {
+                        marker.merge(request).unwrap();
+                    }
+                });
+            }
+        });
+        let marker = PendingMarker::new(&database, "repo");
+        assert_eq!(marker.take().unwrap(), Some(AutosyncRequest::Full));
+    }
+
+    #[test]
+    fn trigger_without_tracker_bindings_is_disabled_before_any_lock_or_database_open() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let config = test_config(tmp.path());
+        let outcome = run(&config, AutosyncRequest::Full).unwrap();
+        assert!(matches!(outcome, AutosyncOutcome::Disabled));
+        assert!(!config.database.exists(), "a disabled trigger must not create the database");
+        let lock_repo = locks::write_lock_repo_id(&config);
+        assert!(!locks::papertrail_pending_path(&config.database, &lock_repo).exists());
+    }
+
+    #[test]
+    fn concurrent_triggers_coalesce_into_the_held_flight() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let mut config = test_config(tmp.path());
+        config.trackers = vec![crate::config::TrackerConfig {
+            provider: crate::config::Tracker::Github,
+            project: Some("o/r".to_string()),
+            remote: "origin".to_string(),
+            base_url: None,
+            auth: None,
+            tags: Vec::new(),
+        }];
+
+        let lock_repo = locks::write_lock_repo_id(&config);
+        let held =
+            FileLock::try_acquire(&locks::papertrail_lock_path(&config.database, &lock_repo))
+                .unwrap()
+                .unwrap();
+        let outcome = run(&config, AutosyncRequest::Incremental).unwrap();
+        assert!(matches!(outcome, AutosyncOutcome::Coalesced));
+        let pending = locks::papertrail_pending_path(&config.database, &lock_repo);
+        assert_eq!(fs::read_to_string(&pending).unwrap(), "incremental");
+        // A second, stronger trigger upgrades the queued request in place.
+        let outcome = run(&config, AutosyncRequest::Full).unwrap();
+        assert!(matches!(outcome, AutosyncOutcome::Coalesced));
+        assert_eq!(fs::read_to_string(&pending).unwrap(), "full");
+        drop(held);
+    }
+
+    #[test]
+    fn flight_runs_the_scheduled_mirror_and_persists_binding_health_end_to_end() {
+        use super::super::transport::stub::{StubResponse, spawn_script_stub};
+        let script = vec![
+            StubResponse::ok(
+                r#"{"incomplete_results":false,"items":[{"number":1,"html_url":"https://example.test/o/r/issues/1","state":"open","title":"one","body":"","updated_at":"2026-01-01T00:00:00Z","labels":[]}]}"#,
+            ),
+            StubResponse::ok("[]"),
+            StubResponse::ok(r#"{"incomplete_results":false,"items":[]}"#),
+            StubResponse::ok(r#"{"incomplete_results":false,"items":[]}"#),
+            StubResponse::ok(r#"{"incomplete_results":false,"items":[]}"#),
+            StubResponse::ok("[]"),
+            StubResponse::ok("[]"),
+        ];
+        let (url, _stub) = spawn_script_stub(script);
+        let tmp = tempfile::TempDir::new().unwrap();
+        let mut config = test_config(tmp.path());
+        config.trackers = vec![crate::config::TrackerConfig {
+            provider: crate::config::Tracker::Github,
+            project: Some("o/r".to_string()),
+            remote: "origin".to_string(),
+            base_url: Some(url),
+            auth: None,
+            tags: Vec::new(),
+        }];
+
+        // Auto-sync runs against an EXISTING index (hooks and the watcher only exist for
+        // indexed repos); the flight refuses to create one.
+        config.allow_empty = true;
+        IndexDatabase::rebuild(&config).unwrap();
+
+        // A fresh binding is due for its first full walk; the flight opens the database itself,
+        // runs the policy-gated mirror, and reports the run.
+        let outcome = run(&config, AutosyncRequest::Incremental).unwrap();
+        let AutosyncOutcome::Ran(report) = outcome else {
+            panic!("expected a completed flight, got {outcome:?}");
+        };
+        assert!(report.errors.is_empty(), "{:?}", report.errors);
+        assert_eq!(report.bindings.len(), 1);
+        assert!(report.bindings[0].completed_full_walk);
+
+        // Binding health survives in the on-disk database for the next trigger's evaluation.
+        let conn = rusqlite::Connection::open(&config.database).unwrap();
+        let full_walk_ms: Option<i64> = conn
+            .query_row(
+                "SELECT last_full_sync_ms FROM papertrail_sync_cursor
+                 WHERE tracker='github' AND project='o/r'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(full_walk_ms.is_some());
+        let lock_repo = locks::write_lock_repo_id(&config);
+        assert!(!locks::papertrail_pending_path(&config.database, &lock_repo).exists());
+    }
+
+    fn test_config(root: &Path) -> Config {
+        Config {
+            trackers: Vec::new(),
+            papertrail: Default::default(),
+            repo_id_override: None,
+            database_key_pinned: true,
+            root: root.to_path_buf(),
+            database: root.join("db/index.sqlite"),
+            targets: Vec::new(),
+            llm: Default::default(),
+            watch: Default::default(),
+            version_check: Default::default(),
+            oracle: Default::default(),
+            search: Default::default(),
+            memory: Default::default(),
+            log: Default::default(),
+            source_root_reanchored_from: None,
+            allow_empty: false,
+        }
+    }
+}

--- a/crates/rag-rat-core/src/index/papertrail/autosync.rs
+++ b/crates/rag-rat-core/src/index/papertrail/autosync.rs
@@ -22,6 +22,10 @@ use crate::locks::{self, FileLock};
 pub enum AutosyncOutcome {
     /// The repo resolves no tracker bindings; there is nothing to sync.
     Disabled,
+    /// The repo has never been indexed. Automatic sync serves already-indexed repos only — a
+    /// deferred first-time-empty hook, or a shared database where this repo was only ever
+    /// registered read-only, must not start mirroring. The first index pass unlocks it.
+    NotIndexed,
     /// Another flight holds this repository's lock. The request was merged into the pending
     /// marker; the holder's follow-up pass (or the next periodic deadline) covers it.
     Coalesced,
@@ -42,30 +46,133 @@ pub fn run(config: &Config, request: AutosyncRequest) -> anyhow::Result<Autosync
     let lock_repo = locks::write_lock_repo_id(config);
     let lock_path = locks::papertrail_lock_path(&config.database, &lock_repo);
     let pending = PendingMarker::new(&config.database, &lock_repo);
-    // Acquire-or-coalesce atomically under the marker lock: pairing the failed flight
-    // try-acquire with the marker write in one critical section is one half of the exit
-    // handoff below — a request only ever lands in the marker while some runner is still
-    // obligated to check it.
-    let flight = {
-        let guard = pending.lock()?;
-        match FileLock::try_acquire(&lock_path)? {
-            Some(flight) => flight,
-            None => {
-                guard.merge(request)?;
-                return Ok(AutosyncOutcome::Coalesced);
-            },
-        }
+    let Some(flight) = acquire_or_coalesce(&lock_path, &pending, request)? else {
+        return Ok(AutosyncOutcome::Coalesced);
     };
+    Ok(match drain(config, &lock_repo, &pending, flight, Some(request))? {
+        Drained::NotIndexed => AutosyncOutcome::NotIndexed,
+        Drained::Ran(Some(report)) => AutosyncOutcome::Ran(report),
+        // Only reachable defensively (the initial pass always runs before any guard can stop
+        // the drain); a later trigger re-evaluates.
+        Drained::Ran(None) => AutosyncOutcome::Coalesced,
+    })
+}
+
+/// The explicit `papertrail sync` command: unconditional manual semantics (every binding
+/// dispatched, reference discovery refreshed, `full` honored), SHARING the per-repo flight lock
+/// with automatic sync — two mirror runs over one binding would interleave their cursor
+/// load/save cycles and clobber each other's walk state. Unlike automatic triggers, a manual
+/// invocation never degrades into a policy-gated follow-up: when an automatic flight is in the
+/// air it WAITS for the lock (announcing the wait through `on_wait`, interruptible like any
+/// foreground command) and then runs the full manual pass itself.
+pub fn run_manual(
+    config: &Config,
+    full: bool,
+    on_wait: impl FnOnce(),
+) -> anyhow::Result<PapertrailSyncReport> {
+    let lock_repo = locks::write_lock_repo_id(config);
+    let lock_path = locks::papertrail_lock_path(&config.database, &lock_repo);
+    let pending = PendingMarker::new(&config.database, &lock_repo);
+    // No marker lock is held while blocking here (a contender holding the marker lock must
+    // never block on the flight lock — see [`MarkerGuard`]); the runner's exit handoff releases
+    // the flight lock only with an empty marker, so this wait ends at a clean boundary.
+    let flight = match FileLock::try_acquire(&lock_path)? {
+        Some(flight) => flight,
+        None => {
+            on_wait();
+            FileLock::acquire_blocking(&lock_path)?
+        },
+    };
+    let manual_report = {
+        let db = IndexDatabase::open_config(config)?;
+        db.papertrail_sync(full)?
+    };
+    // Triggers that coalesced behind the manual pass still get their follow-up (and the exit
+    // handoff) before the flight lock releases.
+    drain(config, &lock_repo, &pending, flight, None)?;
+    Ok(manual_report)
+}
+
+/// Take the flight lock, or coalesce `request` into the pending marker — atomically under the
+/// marker lock, so a request only ever lands in the marker while some runner is still obligated
+/// to check it (one half of the exit handoff in [`drain`]).
+fn acquire_or_coalesce(
+    lock_path: &Path,
+    pending: &PendingMarker,
+    request: AutosyncRequest,
+) -> anyhow::Result<Option<FileLock>> {
+    let guard = pending.lock()?;
+    match FileLock::try_acquire(lock_path)? {
+        Some(flight) => Ok(Some(flight)),
+        None => {
+            guard.merge(request)?;
+            Ok(None)
+        },
+    }
+}
+
+enum Drained {
+    Ran(Option<Box<PapertrailSyncReport>>),
+    NotIndexed,
+}
+
+/// Drive scheduled passes while holding the flight lock: `initial` first (when given), then any
+/// follow-ups coalesced into the marker mid-pass, until the EXIT HANDOFF — absorbing the marker
+/// and releasing the flight lock under ONE marker-lock hold — finds nothing queued. A
+/// contender's merge-and-try-acquire section ([`acquire_or_coalesce`]) is serialized either
+/// before that hold (its request is seen here and earns the follow-up) or after the flight lock
+/// is already free (its own try-acquire wins and IT becomes the runner); checking without the
+/// lock, or releasing the flight lock outside it, reopens the window where a coalesced request
+/// is written into the void and never runs.
+fn drain(
+    config: &Config,
+    lock_repo: &str,
+    pending: &PendingMarker,
+    flight: FileLock,
+    initial: Option<AutosyncRequest>,
+) -> anyhow::Result<Drained> {
     let mut flight = Some(flight);
-    let mut request = request;
-    let last_report = loop {
-        // This run covers everything requested so far: absorb (and clear) the marker BEFORE
-        // running, so only triggers arriving mid-flight earn the follow-up evaluation below.
-        if let Some(coalesced) = pending.lock()?.take()? {
-            request = request.max(coalesced);
+    let mut next = initial;
+    let mut first_pass = next.is_some();
+    let mut last_report = None;
+    loop {
+        {
+            let guard = pending.lock()?;
+            match (guard.take()?, next.take()) {
+                (Some(queued), current) =>
+                    next = Some(current.map_or(queued, |request| request.max(queued))),
+                (None, Some(current)) => next = Some(current),
+                (None, None) => {
+                    // The exit handoff: release under the same hold that observed the empty
+                    // marker.
+                    drop(flight.take());
+                    return Ok(Drained::Ran(last_report));
+                },
+            }
         }
-        let report = match run_flight(config, request) {
-            Ok(report) => report,
+        // Identity re-key guard for marker-driven follow-ups: the flight lock was keyed from
+        // the identity resolved at entry, and a long pass can outlive an identity transition
+        // (a shallow clone upgrading to its portable id). Triggers arriving under the NEW
+        // identity key their own flight lock, so continuing under the stale key would run two
+        // concurrent flights over one cursor — step aside instead; the scheduling policy
+        // re-derives any lost urgency from persisted cursor state on the next tick.
+        if !first_pass && locks::write_lock_repo_id(config) != lock_repo {
+            drop(flight.take());
+            return Ok(Drained::Ran(last_report));
+        }
+        first_pass = false;
+        let request = next.take().expect("the loop is only entered with a request");
+        match run_flight(config, request) {
+            Ok(FlightPass::Report(report)) => last_report = Some(report),
+            Ok(FlightPass::NotIndexed) => {
+                // Nothing can run until the first index pass, and any queued follow-up is
+                // equally unservable: consume it under the exit hold and stop. Post-index
+                // triggers start synchronization.
+                let guard = pending.lock()?;
+                let _ = guard.take()?;
+                drop(flight.take());
+                return Ok(Drained::NotIndexed);
+            },
             Err(error) => {
                 // Best-effort retry signal: a failing marker write must not shadow the flight
                 // error the caller is about to log.
@@ -74,28 +181,25 @@ pub fn run(config: &Config, request: AutosyncRequest) -> anyhow::Result<Autosync
                 }
                 return Err(error);
             },
-        };
-        // The exit handoff: the final marker check and the flight-lock release happen under ONE
-        // marker-lock hold. A contender's merge-and-try-acquire section is serialized either
-        // before this check (its marker is seen here and earns the follow-up) or after the
-        // flight lock is already free (its try-acquire wins and IT becomes the runner).
-        // Checking without the lock — or releasing the flight lock outside it — reopens the
-        // window where a coalesced request is written into the void and never runs.
-        let guard = pending.lock()?;
-        if !guard.is_set() {
-            drop(flight.take());
-            break report;
         }
-        drop(guard);
-        // The follow-up's strength comes from the marker itself, absorbed at the loop top.
-        request = AutosyncRequest::Evaluate;
-    };
-    Ok(AutosyncOutcome::Ran(Box::new(last_report)))
+    }
 }
 
-fn run_flight(config: &Config, request: AutosyncRequest) -> anyhow::Result<PapertrailSyncReport> {
+enum FlightPass {
+    Report(Box<PapertrailSyncReport>),
+    NotIndexed,
+}
+
+fn run_flight(config: &Config, request: AutosyncRequest) -> anyhow::Result<FlightPass> {
     let db = IndexDatabase::open_config(config)?;
-    db.papertrail_sync_scheduled(request)
+    // Automatic sync serves already-INDEXED repos only. `open_config` registers read-only (it
+    // never creates an index), so on a shared database this repo can be registered yet never
+    // indexed; the #427 "an index pass ran here" signal (a recorded root, or the source_root
+    // meta an identity-less root gets) is what separates the two.
+    if !crate::index::is_root_already_indexed_conn(db.storage.connection(), config)? {
+        return Ok(FlightPass::NotIndexed);
+    }
+    Ok(FlightPass::Report(Box::new(db.papertrail_sync_scheduled(request)?)))
 }
 
 /// The pending-marker pair: the marker file carrying the strongest coalesced request, and the
@@ -152,6 +256,9 @@ impl MarkerGuard<'_> {
         Ok(Some(AutosyncRequest::from_marker_str(&content)))
     }
 
+    /// Test-only visibility into the marker's presence; production paths decide through
+    /// [`Self::take`] so the decision and the consumption share one hold.
+    #[cfg(test)]
     fn is_set(&self) -> bool {
         self.marker.path.exists()
     }
@@ -269,6 +376,7 @@ mod tests {
                     AutosyncOutcome::Ran(_) => ran += 1,
                     AutosyncOutcome::Coalesced => coalesced += 1,
                     AutosyncOutcome::Disabled => panic!("bindings are configured"),
+                    AutosyncOutcome::NotIndexed => panic!("the index was built above"),
                 }
             }
         });
@@ -375,6 +483,173 @@ mod tests {
         assert!(full_walk_ms.is_some());
         let lock_repo = locks::write_lock_repo_id(&config);
         assert!(!locks::papertrail_pending_path(&config.database, &lock_repo).exists());
+    }
+
+    /// A shared database can hold a repo that was REGISTERED (read-only opens do that) but
+    /// never indexed; automatic sync must defer until the first index pass instead of starting
+    /// a mirror for it.
+    #[test]
+    fn flight_defers_until_the_repo_is_indexed() {
+        let indexed_tmp = tempfile::TempDir::new().unwrap();
+        let mut indexed_config = test_config(indexed_tmp.path());
+        indexed_config.allow_empty = true;
+        IndexDatabase::rebuild(&indexed_config).unwrap();
+
+        // A second repo (a real git repo, so it resolves its OWN identity instead of falling
+        // back to the sole registered one) sharing the same database, with a binding but no
+        // index pass ever run.
+        let unindexed_root = temp_git_repo("autosync-unindexed");
+        let mut config = test_config(&unindexed_root);
+        config.database = indexed_config.database.clone();
+        config.trackers = vec![crate::config::TrackerConfig {
+            provider: crate::config::Tracker::Github,
+            project: Some("o/r".to_string()),
+            remote: "origin".to_string(),
+            base_url: Some("http://127.0.0.1:9".to_string()),
+            auth: None,
+            tags: Vec::new(),
+        }];
+
+        let outcome = run(&config, AutosyncRequest::Full).unwrap();
+        assert!(matches!(outcome, AutosyncOutcome::NotIndexed), "{outcome:?}");
+        // No mirror work happened and no follow-up signal is owed. (Counts are scoped to the
+        // binding under test — the schema bootstrap seeds a poison-sibling row into every
+        // repo-scoped table.)
+        let conn = rusqlite::Connection::open(&config.database).unwrap();
+        let cursor_rows: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM papertrail_sync_cursor WHERE project='o/r'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(cursor_rows, 0);
+        let lock_repo = locks::write_lock_repo_id(&config);
+        assert!(!locks::papertrail_pending_path(&config.database, &lock_repo).exists());
+
+        // The first index pass unlocks automatic sync (the flight then runs and persists the
+        // unreachable binding's failure as health).
+        config.allow_empty = true;
+        IndexDatabase::rebuild(&config).unwrap();
+        let outcome = run(&config, AutosyncRequest::Incremental).unwrap();
+        assert!(matches!(outcome, AutosyncOutcome::Ran(_)), "{outcome:?}");
+        let cursor_rows: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM papertrail_sync_cursor WHERE project='o/r'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(cursor_rows, 1);
+    }
+
+    /// An explicit sync never degrades into a policy-gated follow-up: it announces the wait,
+    /// blocks until the running flight releases the lock, then runs the full manual pass.
+    #[test]
+    fn manual_sync_waits_out_a_running_flight_instead_of_degrading() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let mut config = test_config(tmp.path());
+        config.allow_empty = true;
+        IndexDatabase::rebuild(&config).unwrap();
+        let lock_repo = locks::write_lock_repo_id(&config);
+        let lock_path = locks::papertrail_lock_path(&config.database, &lock_repo);
+        let held = FileLock::try_acquire(&lock_path).unwrap().unwrap();
+
+        let waited = std::sync::atomic::AtomicBool::new(false);
+        std::thread::scope(|scope| {
+            let holder = scope.spawn(|| {
+                std::thread::sleep(std::time::Duration::from_millis(200));
+                drop(held);
+            });
+            // No bindings: the manual pass itself is a cheap local report — the point is the
+            // lock choreography, not the mirror.
+            let report = run_manual(&config, false, || {
+                waited.store(true, std::sync::atomic::Ordering::Relaxed);
+            })
+            .unwrap();
+            assert!(report.bindings.is_empty());
+            holder.join().unwrap();
+        });
+        assert!(waited.load(std::sync::atomic::Ordering::Relaxed), "the wait is announced");
+        // No degraded follow-up was queued anywhere.
+        assert!(!locks::papertrail_pending_path(&config.database, &lock_repo).exists());
+    }
+
+    /// Manual sync holds the shared flight lock for its whole pass, then drains any follow-up
+    /// requests that coalesced behind it before releasing.
+    #[test]
+    fn manual_sync_runs_under_the_flight_lock_and_drains_queued_followups() {
+        use super::super::transport::stub::{StubResponse, spawn_script_stub};
+        let script = vec![
+            StubResponse::ok(
+                r#"{"incomplete_results":false,"items":[{"number":1,"html_url":"https://example.test/o/r/issues/1","state":"open","title":"one","body":"","updated_at":"2026-01-01T00:00:00Z","labels":[]}]}"#,
+            ),
+            StubResponse::ok("[]"),
+            StubResponse::ok(r#"{"incomplete_results":false,"items":[]}"#),
+            StubResponse::ok(r#"{"incomplete_results":false,"items":[]}"#),
+            StubResponse::ok(r#"{"incomplete_results":false,"items":[]}"#),
+            StubResponse::ok("[]"),
+            StubResponse::ok("[]"),
+        ];
+        let (url, _stub) = spawn_script_stub(script);
+        let tmp = tempfile::TempDir::new().unwrap();
+        let mut config = test_config(tmp.path());
+        config.trackers = vec![crate::config::TrackerConfig {
+            provider: crate::config::Tracker::Github,
+            project: Some("o/r".to_string()),
+            remote: "origin".to_string(),
+            base_url: Some(url),
+            auth: None,
+            tags: Vec::new(),
+        }];
+        config.allow_empty = true;
+        IndexDatabase::rebuild(&config).unwrap();
+
+        // A request queued before the manual pass rides its drain: the manual walk covers it
+        // (the follow-up evaluation lands inside the attempt interval and settles to a skip).
+        let lock_repo = locks::write_lock_repo_id(&config);
+        PendingMarker::new(&config.database, &lock_repo)
+            .lock()
+            .unwrap()
+            .merge(AutosyncRequest::Incremental)
+            .unwrap();
+
+        let report = run_manual(&config, false, || panic!("the lock is free; no wait")).unwrap();
+        assert!(report.errors.is_empty(), "{:?}", report.errors);
+        assert_eq!(report.bindings.len(), 1);
+        assert!(report.bindings[0].completed_full_walk);
+
+        // Everything queued was drained and the flight lock released.
+        assert!(!locks::papertrail_pending_path(&config.database, &lock_repo).exists());
+        assert!(
+            FileLock::try_acquire(&locks::papertrail_lock_path(&config.database, &lock_repo))
+                .unwrap()
+                .is_some()
+        );
+    }
+
+    fn temp_git_repo(tag: &str) -> std::path::PathBuf {
+        let root = std::env::temp_dir().join(format!("ragrat-{tag}-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&root).unwrap();
+        let git = |args: &[&str]| {
+            let out =
+                std::process::Command::new("git").arg("-C").arg(&root).args(args).output().unwrap();
+            assert!(out.status.success(), "git {args:?}: {}", String::from_utf8_lossy(&out.stderr));
+        };
+        git(&["init", "-q"]);
+        git(&[
+            "-c",
+            "user.email=t@example.invalid",
+            "-c",
+            "user.name=t",
+            "commit",
+            "-q",
+            "--allow-empty",
+            "-m",
+            "root",
+        ]);
+        root
     }
 
     fn test_config(root: &Path) -> Config {

--- a/crates/rag-rat-core/src/index/papertrail/autosync.rs
+++ b/crates/rag-rat-core/src/index/papertrail/autosync.rs
@@ -43,19 +43,47 @@ pub fn run(config: &Config, request: AutosyncRequest) -> anyhow::Result<Autosync
     if PapertrailContext::resolve(config).trackers.is_empty() {
         return Ok(AutosyncOutcome::Disabled);
     }
+    // Identity re-key retry: when a pass discovers its flight lock was keyed from a
+    // since-upgraded identity, the stranded request (max-merged with anything consumed from the
+    // old-key marker) is carried to fresh keys and re-run — an `Incremental` change signal is
+    // not re-derivable from persisted cursor state, so it must not be dropped. Transitions are
+    // one-time per repo; the cap only bounds pathological churn.
+    let mut request = request;
+    for _ in 0..3 {
+        let lock_repo = locks::write_lock_repo_id(config);
+        let lock_path = locks::papertrail_lock_path(&config.database, &lock_repo);
+        let pending = PendingMarker::new(&config.database, &lock_repo);
+        let Some(flight) = acquire_or_coalesce(&lock_path, &pending, request)? else {
+            return Ok(AutosyncOutcome::Coalesced);
+        };
+        match drain(config, &lock_repo, &pending, flight, Some(request))? {
+            Drained::NotIndexed => return Ok(AutosyncOutcome::NotIndexed),
+            Drained::Ran(Some(report)) => return Ok(AutosyncOutcome::Ran(report)),
+            // Defensive: unreachable with `initial = Some` (the first pass reports, defers,
+            // re-keys, or errors before the drain can exit empty-handed).
+            Drained::Ran(None) => return Ok(AutosyncOutcome::Coalesced),
+            Drained::Rekeyed(stranded) => request = stranded,
+        }
+    }
+    // Pathological identity churn: preserve the signal where fresh-keyed triggers will find it,
+    // and surface the condition to the caller's log.
+    preserve_for_fresh_key(config, request);
+    anyhow::bail!(
+        "the repo identity kept changing across papertrail flight attempts; the request was \
+         queued for the next trigger"
+    )
+}
+
+/// Best-effort: queue a request stranded by an identity re-key into the CURRENT identity's
+/// pending marker, where fresh-keyed triggers absorb it. The marker sits until the next trigger
+/// (the watcher deadline bounds the wait) — the same bounded staleness every error-path marker
+/// accepts.
+fn preserve_for_fresh_key(config: &Config, request: AutosyncRequest) {
     let lock_repo = locks::write_lock_repo_id(config);
-    let lock_path = locks::papertrail_lock_path(&config.database, &lock_repo);
     let pending = PendingMarker::new(&config.database, &lock_repo);
-    let Some(flight) = acquire_or_coalesce(&lock_path, &pending, request)? else {
-        return Ok(AutosyncOutcome::Coalesced);
-    };
-    Ok(match drain(config, &lock_repo, &pending, flight, Some(request))? {
-        Drained::NotIndexed => AutosyncOutcome::NotIndexed,
-        Drained::Ran(Some(report)) => AutosyncOutcome::Ran(report),
-        // A stale-keyed runner stepped aside before its first pass (identity re-key guard in
-        // `run_flight`); a later trigger under the fresh identity covers the request.
-        Drained::Ran(None) => AutosyncOutcome::Coalesced,
-    })
+    if let Ok(guard) = pending.lock() {
+        let _ = guard.merge(request);
+    }
 }
 
 /// The explicit `papertrail sync` command: unconditional manual semantics (every binding
@@ -68,29 +96,51 @@ pub fn run(config: &Config, request: AutosyncRequest) -> anyhow::Result<Autosync
 pub fn run_manual(
     config: &Config,
     full: bool,
-    on_wait: impl FnOnce(),
+    mut on_wait: impl FnMut(),
 ) -> anyhow::Result<PapertrailSyncReport> {
-    let lock_repo = locks::write_lock_repo_id(config);
-    let lock_path = locks::papertrail_lock_path(&config.database, &lock_repo);
-    let pending = PendingMarker::new(&config.database, &lock_repo);
-    // No marker lock is held while blocking here (a contender holding the marker lock must
-    // never block on the flight lock — see [`MarkerGuard`]); the runner's exit handoff releases
-    // the flight lock only with an empty marker, so this wait ends at a clean boundary.
-    let flight = match FileLock::try_acquire(&lock_path)? {
-        Some(flight) => flight,
-        None => {
-            on_wait();
-            FileLock::acquire_blocking(&lock_path)?
-        },
-    };
-    let manual_report = {
+    // The same identity re-key guard as `run_flight`, with manual semantics: the identity can
+    // move between resolving the lock key and the post-open re-check (the wait for the flight
+    // slot and `open_config`'s own git reads take real time, and the open can itself upgrade
+    // the identity). An automatic runner steps aside; an explicit command instead RE-KEYS and
+    // retries under the fresh identity so the user still gets their unconditional pass. A
+    // transition is one-time per repo — the cap only bounds pathological churn.
+    for _ in 0..3 {
+        let lock_repo = locks::write_lock_repo_id(config);
+        let lock_path = locks::papertrail_lock_path(&config.database, &lock_repo);
+        let pending = PendingMarker::new(&config.database, &lock_repo);
+        // No marker lock is held while blocking here (a contender holding the marker lock must
+        // never block on the flight lock — see [`MarkerGuard`]); the runner's exit handoff
+        // releases the flight lock only with an empty marker, so this wait ends at a clean
+        // boundary.
+        let flight = match FileLock::try_acquire(&lock_path)? {
+            Some(flight) => flight,
+            None => {
+                on_wait();
+                FileLock::acquire_blocking(&lock_path)?
+            },
+        };
         let db = IndexDatabase::open_config(config)?;
-        db.papertrail_sync(full)?
-    };
-    // Triggers that coalesced behind the manual pass still get their follow-up (and the exit
-    // handoff) before the flight lock releases.
-    drain(config, &lock_repo, &pending, flight, None)?;
-    Ok(manual_report)
+        if locks::write_lock_repo_id(config) != lock_repo {
+            // Never mirror under a stale-keyed flight lock: a trigger resolving the upgraded
+            // identity keys a DIFFERENT lock and could run concurrently over the same cursor.
+            drop(db);
+            drop(flight);
+            continue;
+        }
+        let manual_report = db.papertrail_sync(full)?;
+        drop(db);
+        // Triggers that coalesced behind the manual pass still get their follow-up (and the
+        // exit handoff) before the flight lock releases. A follow-up stranded by an identity
+        // transition mid-drain is queued for fresh-keyed triggers instead of dropped.
+        if let Drained::Rekeyed(stranded) = drain(config, &lock_repo, &pending, flight, None)? {
+            preserve_for_fresh_key(config, stranded);
+        }
+        return Ok(manual_report);
+    }
+    anyhow::bail!(
+        "the repo identity kept changing while acquiring the papertrail flight lock; re-run \
+         `rag-rat papertrail sync` once the checkout settles"
+    )
 }
 
 /// Take the flight lock, or coalesce `request` into the pending marker — atomically under the
@@ -114,6 +164,10 @@ fn acquire_or_coalesce(
 enum Drained {
     Ran(Option<Box<PapertrailSyncReport>>),
     NotIndexed,
+    /// The flight lock's key no longer matches the resolved identity; the stranded request
+    /// (max-merged with anything consumed from the old-key marker) must be carried to fresh
+    /// keys by the caller.
+    Rekeyed(AutosyncRequest),
 }
 
 /// Drive scheduled passes while holding the flight lock: `initial` first (when given), then any
@@ -165,14 +219,15 @@ fn drain(
                 // The identity this open resolved no longer matches the held lock's key (a
                 // shallow clone upgrading to its portable id mid-flight). Triggers arriving
                 // under the NEW identity key their own flight lock, so mirroring under the
-                // stale key would run two concurrent flights over one cursor — step aside.
-                // The old-key marker is unreachable for new-key triggers: consume it rather
-                // than strand the file; the scheduling policy re-derives any lost urgency from
-                // persisted cursor state on the next tick.
+                // stale key would run two concurrent flights over one cursor — stop here. The
+                // old-key marker is unreachable for new-key triggers: fold it into the
+                // stranded request the caller re-keys and retries with.
                 let guard = pending.lock()?;
-                let _ = guard.take()?;
+                let queued = guard.take()?;
                 drop(flight.take());
-                return Ok(Drained::Ran(last_report));
+                drop(guard);
+                let stranded = queued.map_or(request, |carried| request.max(carried));
+                return Ok(Drained::Rekeyed(stranded));
             },
             Err(error) => {
                 // Best-effort retry signal: a failing marker write must not shadow the flight
@@ -672,7 +727,12 @@ mod tests {
         let drained =
             drain(&config, stale_repo, &pending, flight, Some(AutosyncRequest::Incremental))
                 .unwrap();
-        assert!(matches!(drained, Drained::Ran(None)), "no pass may run under the stale key");
+        // The stranded request carries the strongest of the trigger and the old-key marker, so
+        // the caller's re-key retry loses nothing.
+        assert!(
+            matches!(drained, Drained::Rekeyed(AutosyncRequest::Full)),
+            "no pass may run under the stale key"
+        );
         // No mirror work happened, the stranded old-key marker was consumed, and the stale
         // flight lock was released.
         let conn = rusqlite::Connection::open(&config.database).unwrap();

--- a/crates/rag-rat-core/src/index/papertrail/autosync.rs
+++ b/crates/rag-rat-core/src/index/papertrail/autosync.rs
@@ -52,8 +52,8 @@ pub fn run(config: &Config, request: AutosyncRequest) -> anyhow::Result<Autosync
     Ok(match drain(config, &lock_repo, &pending, flight, Some(request))? {
         Drained::NotIndexed => AutosyncOutcome::NotIndexed,
         Drained::Ran(Some(report)) => AutosyncOutcome::Ran(report),
-        // Only reachable defensively (the initial pass always runs before any guard can stop
-        // the drain); a later trigger re-evaluates.
+        // A stale-keyed runner stepped aside before its first pass (identity re-key guard in
+        // `run_flight`); a later trigger under the fresh identity covers the request.
         Drained::Ran(None) => AutosyncOutcome::Coalesced,
     })
 }
@@ -133,7 +133,6 @@ fn drain(
 ) -> anyhow::Result<Drained> {
     let mut flight = Some(flight);
     let mut next = initial;
-    let mut first_pass = next.is_some();
     let mut last_report = None;
     loop {
         {
@@ -150,19 +149,8 @@ fn drain(
                 },
             }
         }
-        // Identity re-key guard for marker-driven follow-ups: the flight lock was keyed from
-        // the identity resolved at entry, and a long pass can outlive an identity transition
-        // (a shallow clone upgrading to its portable id). Triggers arriving under the NEW
-        // identity key their own flight lock, so continuing under the stale key would run two
-        // concurrent flights over one cursor — step aside instead; the scheduling policy
-        // re-derives any lost urgency from persisted cursor state on the next tick.
-        if !first_pass && locks::write_lock_repo_id(config) != lock_repo {
-            drop(flight.take());
-            return Ok(Drained::Ran(last_report));
-        }
-        first_pass = false;
         let request = next.take().expect("the loop is only entered with a request");
-        match run_flight(config, request) {
+        match run_flight(config, lock_repo, request) {
             Ok(FlightPass::Report(report)) => last_report = Some(report),
             Ok(FlightPass::NotIndexed) => {
                 // Nothing can run until the first index pass, and any queued follow-up is
@@ -172,6 +160,19 @@ fn drain(
                 let _ = guard.take()?;
                 drop(flight.take());
                 return Ok(Drained::NotIndexed);
+            },
+            Ok(FlightPass::Rekeyed) => {
+                // The identity this open resolved no longer matches the held lock's key (a
+                // shallow clone upgrading to its portable id mid-flight). Triggers arriving
+                // under the NEW identity key their own flight lock, so mirroring under the
+                // stale key would run two concurrent flights over one cursor — step aside.
+                // The old-key marker is unreachable for new-key triggers: consume it rather
+                // than strand the file; the scheduling policy re-derives any lost urgency from
+                // persisted cursor state on the next tick.
+                let guard = pending.lock()?;
+                let _ = guard.take()?;
+                drop(flight.take());
+                return Ok(Drained::Ran(last_report));
             },
             Err(error) => {
                 // Best-effort retry signal: a failing marker write must not shadow the flight
@@ -188,10 +189,23 @@ fn drain(
 enum FlightPass {
     Report(Box<PapertrailSyncReport>),
     NotIndexed,
+    Rekeyed,
 }
 
-fn run_flight(config: &Config, request: AutosyncRequest) -> anyhow::Result<FlightPass> {
+fn run_flight(
+    config: &Config,
+    lock_repo: &str,
+    request: AutosyncRequest,
+) -> anyhow::Result<FlightPass> {
     let db = IndexDatabase::open_config(config)?;
+    // Identity re-key guard, on EVERY pass (the first included) at the latest pre-walk moment:
+    // the flight lock was keyed from the identity resolved at entry, and both the wait for this
+    // slot and `open_config`'s own git reads take real time. A fresh resolution here is exactly
+    // what a future trigger would key its lock from, so a mismatch means a concurrent
+    // fresh-keyed flight is possible and this runner must not start the walk.
+    if locks::write_lock_repo_id(config) != lock_repo {
+        return Ok(FlightPass::Rekeyed);
+    }
     // Automatic sync serves already-INDEXED repos only. `open_config` registers read-only (it
     // never creates an index), so on a shared database this repo can be registered yet never
     // indexed; the #427 "an index pass ran here" signal (a recorded root, or the source_root
@@ -626,6 +640,52 @@ mod tests {
                 .unwrap()
                 .is_some()
         );
+    }
+
+    /// A runner whose flight lock was keyed from a since-upgraded identity must step aside
+    /// BEFORE any mirror work — on the first pass too, not only marker-driven follow-ups — so
+    /// it can never overlap a fresh-keyed flight over the same cursor.
+    #[test]
+    fn stale_keyed_runner_steps_aside_before_any_mirror_work() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let mut config = test_config(tmp.path());
+        config.trackers = vec![crate::config::TrackerConfig {
+            provider: crate::config::Tracker::Github,
+            project: Some("o/r".to_string()),
+            remote: "origin".to_string(),
+            base_url: Some("http://127.0.0.1:9".to_string()),
+            auth: None,
+            tags: Vec::new(),
+        }];
+        config.allow_empty = true;
+        IndexDatabase::rebuild(&config).unwrap();
+
+        // Simulate the post-transition world: the runner still holds a flight lock keyed from
+        // the OLD identity, while the config now resolves to a different id.
+        let stale_repo = "stale-pre-upgrade-id";
+        assert_ne!(locks::write_lock_repo_id(&config), stale_repo);
+        let stale_lock_path = locks::papertrail_lock_path(&config.database, stale_repo);
+        let flight = FileLock::try_acquire(&stale_lock_path).unwrap().unwrap();
+        let pending = PendingMarker::new(&config.database, stale_repo);
+        pending.lock().unwrap().merge(AutosyncRequest::Full).unwrap();
+
+        let drained =
+            drain(&config, stale_repo, &pending, flight, Some(AutosyncRequest::Incremental))
+                .unwrap();
+        assert!(matches!(drained, Drained::Ran(None)), "no pass may run under the stale key");
+        // No mirror work happened, the stranded old-key marker was consumed, and the stale
+        // flight lock was released.
+        let conn = rusqlite::Connection::open(&config.database).unwrap();
+        let cursor_rows: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM papertrail_sync_cursor WHERE project='o/r'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(cursor_rows, 0);
+        assert!(!locks::papertrail_pending_path(&config.database, stale_repo).exists());
+        assert!(FileLock::try_acquire(&stale_lock_path).unwrap().is_some());
     }
 
     fn temp_git_repo(tag: &str) -> std::path::PathBuf {

--- a/crates/rag-rat-core/src/index/papertrail/autosync.rs
+++ b/crates/rag-rat-core/src/index/papertrail/autosync.rs
@@ -24,7 +24,8 @@ pub enum AutosyncOutcome {
     Disabled,
     /// The repo has never been indexed. Automatic sync serves already-indexed repos only — a
     /// deferred first-time-empty hook, or a shared database where this repo was only ever
-    /// registered read-only, must not start mirroring. The first index pass unlocks it.
+    /// registered read-only, must not start mirroring. The request is queued in the pending
+    /// marker so the first post-index trigger runs with it.
     NotIndexed,
     /// Another flight holds this repository's lock. The request was merged into the pending
     /// marker; the holder's follow-up pass (or the next periodic deadline) covers it.
@@ -43,11 +44,14 @@ pub fn run(config: &Config, request: AutosyncRequest) -> anyhow::Result<Autosync
     if PapertrailContext::resolve(config).trackers.is_empty() {
         return Ok(AutosyncOutcome::Disabled);
     }
-    // The non-creating half of the indexed-only gate, BEFORE any lock or open: opening a
-    // missing database creates the (empty) file first and only then refuses on the missing
-    // schema, and that artifact defeats every later `database.exists()` "build the index first"
-    // hint. A repo with no store at all is trivially not indexed.
+    // The non-creating half of the indexed-only gate, BEFORE any open: opening a missing
+    // database creates the (empty) file first and only then refuses on the missing schema, and
+    // that artifact defeats every later `database.exists()` "build the index first" hint. A
+    // repo with no store at all is trivially not indexed — but the accepted signal is queued
+    // (see the NotIndexed drain arm) so a first index pass racing this trigger cannot lose it.
     if !config.database.exists() {
+        let lock_repo = locks::write_lock_repo_id(config);
+        PendingMarker::new(&config.database, &lock_repo).lock()?.merge(request)?;
         return Ok(AutosyncOutcome::NotIndexed);
     }
     // Identity re-key retry: when a pass discovers its flight lock was keyed from a
@@ -227,11 +231,14 @@ fn drain(
         match run_flight(config, lock_repo, request) {
             Ok(FlightPass::Report(report)) => last_report = Some(report),
             Ok(FlightPass::NotIndexed) => {
-                // Nothing can run until the first index pass, and any queued follow-up is
-                // equally unservable: consume it under the exit hold and stop. Post-index
-                // triggers start synchronization.
+                // Nothing can run until the first index pass — but the accepted signal must
+                // not drop: a hook can lose the maintenance lock to a manual run that is
+                // CREATING the first index and will never fire papertrail itself. Queue the
+                // request instead. This is the one deliberate "marker without an obligated
+                // runner" exception to the exit-handoff rule: the first post-index trigger
+                // absorbs it, and on a never-indexed repo it is an inert one-word file.
                 let guard = pending.lock()?;
-                let _ = guard.take()?;
+                guard.merge(request)?;
                 drop(flight.take());
                 return Ok(Drained::NotIndexed);
             },
@@ -599,6 +606,11 @@ mod tests {
         let outcome = run(&config, AutosyncRequest::Incremental).unwrap();
         assert!(matches!(outcome, AutosyncOutcome::NotIndexed), "{outcome:?}");
         assert!(!config.database.exists(), "a deferred trigger must not create the database");
+        // The signal is queued even though no store exists yet: a first index pass racing
+        // this trigger must not lose it.
+        let lock_repo = locks::write_lock_repo_id(&config);
+        let pending = locks::papertrail_pending_path(&config.database, &lock_repo);
+        assert_eq!(fs::read_to_string(&pending).unwrap(), "incremental");
 
         let error = run_manual(&config, true, || {}).unwrap_err().to_string();
         assert!(error.contains("no index at this path yet"), "{error}");
@@ -644,15 +656,18 @@ mod tests {
             )
             .unwrap();
         assert_eq!(cursor_rows, 0);
+        // The accepted signal is queued for the first post-index trigger, at full strength.
         let lock_repo = locks::write_lock_repo_id(&config);
-        assert!(!locks::papertrail_pending_path(&config.database, &lock_repo).exists());
+        let pending = locks::papertrail_pending_path(&config.database, &lock_repo);
+        assert_eq!(fs::read_to_string(&pending).unwrap(), "full");
 
-        // The first index pass unlocks automatic sync (the flight then runs and persists the
-        // unreachable binding's failure as health).
+        // The first index pass unlocks automatic sync (the flight then runs, absorbing the
+        // queued signal, and persists the unreachable binding's failure as health).
         config.allow_empty = true;
         IndexDatabase::rebuild(&config).unwrap();
         let outcome = run(&config, AutosyncRequest::Incremental).unwrap();
         assert!(matches!(outcome, AutosyncOutcome::Ran(_)), "{outcome:?}");
+        assert!(!pending.exists(), "the queued signal was absorbed");
         let cursor_rows: i64 = conn
             .query_row(
                 "SELECT COUNT(*) FROM papertrail_sync_cursor WHERE project='o/r'",

--- a/crates/rag-rat-core/src/index/papertrail/autosync.rs
+++ b/crates/rag-rat-core/src/index/papertrail/autosync.rs
@@ -43,6 +43,13 @@ pub fn run(config: &Config, request: AutosyncRequest) -> anyhow::Result<Autosync
     if PapertrailContext::resolve(config).trackers.is_empty() {
         return Ok(AutosyncOutcome::Disabled);
     }
+    // The non-creating half of the indexed-only gate, BEFORE any lock or open: opening a
+    // missing database creates the (empty) file first and only then refuses on the missing
+    // schema, and that artifact defeats every later `database.exists()` "build the index first"
+    // hint. A repo with no store at all is trivially not indexed.
+    if !config.database.exists() {
+        return Ok(AutosyncOutcome::NotIndexed);
+    }
     // Identity re-key retry: when a pass discovers its flight lock was keyed from a
     // since-upgraded identity, the stranded request (max-merged with anything consumed from the
     // old-key marker) is carried to fresh keys and re-run — an `Incremental` change signal is
@@ -98,6 +105,13 @@ pub fn run_manual(
     full: bool,
     mut on_wait: impl FnMut(),
 ) -> anyhow::Result<PapertrailSyncReport> {
+    // Refuse BEFORE any lock or open: opening a missing database creates the (empty) file
+    // first and only then refuses on the missing schema, and that artifact defeats every later
+    // `database.exists()` "build the index first" hint.
+    anyhow::ensure!(
+        config.database.exists(),
+        "no index at this path yet; build one with `rag-rat index` or `rag-rat index --full`"
+    );
     // The same identity re-key guard as `run_flight`, with manual semantics: the identity can
     // move between resolving the lock key and the post-open re-check (the wait for the flight
     // slot and `open_config`'s own git reads take real time, and the open can itself upgrade
@@ -123,7 +137,13 @@ pub fn run_manual(
         if locks::write_lock_repo_id(config) != lock_repo {
             // Never mirror under a stale-keyed flight lock: a trigger resolving the upgraded
             // identity keys a DIFFERENT lock and could run concurrently over the same cursor.
+            // A follow-up that coalesced into the OLD-key marker while this runner held the
+            // stale lock is unreachable for fresh-keyed triggers — carry it forward (the
+            // automatic path's `Rekeyed` carry, manual flavor) before releasing.
             drop(db);
+            if let Some(stranded) = pending.lock()?.take()? {
+                preserve_for_fresh_key(config, stranded);
+            }
             drop(flight);
             continue;
         }
@@ -481,6 +501,10 @@ mod tests {
             auth: None,
             tags: Vec::new(),
         }];
+        // The store must exist: the non-creating indexed gate defers before the coalesce path
+        // otherwise (and no real flight can hold the lock without one).
+        config.allow_empty = true;
+        IndexDatabase::rebuild(&config).unwrap();
 
         let lock_repo = locks::write_lock_repo_id(&config);
         let held =
@@ -552,6 +576,33 @@ mod tests {
         assert!(full_walk_ms.is_some());
         let lock_repo = locks::write_lock_repo_id(&config);
         assert!(!locks::papertrail_pending_path(&config.database, &lock_repo).exists());
+    }
+
+    /// The non-creating gate: a trigger firing before `rag-rat index` ever created the store
+    /// must defer WITHOUT leaving an empty database file behind — opening a missing database
+    /// creates the file before the schema check refuses, and that artifact defeats every later
+    /// `database.exists()` "build the index first" hint. The manual command refuses the same
+    /// way.
+    #[test]
+    fn triggers_before_any_store_exists_defer_without_creating_the_database() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let mut config = test_config(tmp.path());
+        config.trackers = vec![crate::config::TrackerConfig {
+            provider: crate::config::Tracker::Github,
+            project: Some("o/r".to_string()),
+            remote: "origin".to_string(),
+            base_url: Some("http://127.0.0.1:9".to_string()),
+            auth: None,
+            tags: Vec::new(),
+        }];
+
+        let outcome = run(&config, AutosyncRequest::Incremental).unwrap();
+        assert!(matches!(outcome, AutosyncOutcome::NotIndexed), "{outcome:?}");
+        assert!(!config.database.exists(), "a deferred trigger must not create the database");
+
+        let error = run_manual(&config, true, || {}).unwrap_err().to_string();
+        assert!(error.contains("no index at this path yet"), "{error}");
+        assert!(!config.database.exists(), "a refused manual sync must not create the database");
     }
 
     /// A shared database can hold a repo that was REGISTERED (read-only opens do that) but

--- a/crates/rag-rat-core/src/index/papertrail/mirror.rs
+++ b/crates/rag-rat-core/src/index/papertrail/mirror.rs
@@ -117,6 +117,10 @@ pub struct MirrorBindingReport {
     pub paused_until_ms: Option<i64>,
     pub pause_reason: Option<String>,
     pub completed_full_walk: bool,
+    /// The item freshness probe answered not-modified. Combined with zero stored / pruned work
+    /// this classifies the run as a successful PROBE — advancing probe freshness only, never the
+    /// mirror or full-walk timestamps.
+    pub probe_not_modified: bool,
 }
 
 pub(crate) async fn mirror_binding<C: PapertrailClient>(
@@ -174,6 +178,7 @@ pub(crate) async fn mirror_binding<C: PapertrailClient>(
         paused_until_ms: None,
         pause_reason: None,
         completed_full_walk: false,
+        probe_not_modified: false,
     };
     if filter_changed {
         report.pruned_items += prune_unmatched(conn, binding)?;
@@ -230,6 +235,7 @@ async fn mirror_binding_inner<C: PapertrailClient>(
                 save_cursor(conn, binding, cursor, false)?;
                 sync_item_delta(conn, binding, client, cursor, report).await?;
             } else {
+                report.probe_not_modified = true;
                 save_cursor(conn, binding, cursor, false)?;
             }
         }

--- a/crates/rag-rat-core/src/index/papertrail/mirror.rs
+++ b/crates/rag-rat-core/src/index/papertrail/mirror.rs
@@ -254,6 +254,11 @@ async fn mirror_binding_inner<C: PapertrailClient>(
             cursor.backfill_done = true;
             cursor.high_mark_at.get_or_insert_with(|| EMPTY_PROJECT_HIGH_MARK.to_string());
             cursor.backfill_processed_keys.clear();
+            // The consumed continuation must not outlive the walk: a chained provider leg (the
+            // request that produced THIS empty page) was persisted as `backfill_page_cursor` on
+            // the previous iteration, and leaving it behind makes `continuation()` misread the
+            // COMPLETED walk as interrupted work forever.
+            cursor.backfill_page_cursor = None;
             save_cursor(conn, binding, cursor, false)?;
             break;
         }

--- a/crates/rag-rat-core/src/index/papertrail/mod.rs
+++ b/crates/rag-rat-core/src/index/papertrail/mod.rs
@@ -1,4 +1,5 @@
 mod api;
+pub mod autosync;
 mod evidence;
 mod github;
 mod mirror;
@@ -20,6 +21,7 @@ pub(crate) use mirror::{MirrorContinuation, load_mirror_continuation, mirror_bin
 pub(crate) use parse::*;
 pub use parse::{TrackerParsedRef, parse_tracker_refs};
 use rusqlite::{Connection, OptionalExtension, params};
+pub use schedule::AutosyncRequest;
 pub(crate) use schedule::*;
 use serde::{Deserialize, Serialize};
 pub(crate) use store::*;

--- a/crates/rag-rat-core/src/index/papertrail/schedule.rs
+++ b/crates/rag-rat-core/src/index/papertrail/schedule.rs
@@ -96,10 +96,49 @@ fn millis(seconds: u64) -> i64 {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum SuccessfulOperation {
-    #[allow(dead_code, reason = "the watcher probe worker lands in the dependent #592 slice")]
     Probe,
     IncrementalMirror,
     FullMirror,
+}
+
+/// A coalescible automatic-sync trigger. The variant order IS the strength order (`Ord`): when
+/// triggers coalesce — in the in-process worker queue or through the cross-process pending
+/// marker — the merged request is the maximum, so a daily/full trigger is never weakened by a
+/// later incremental or evaluation tick.
+///
+/// - `Evaluate` — a timer tick: let [`decide_schedule`] pick per binding (probe when due, the full
+///   backstop when overdue, resuming interrupted work first).
+/// - `Incremental` — an external change signal (a git hook fired): bindings due for any work run a
+///   delta walk without waiting for probe cadence.
+/// - `Full` — a healing walk was explicitly requested; bindings not gated by pauses or the minimum
+///   attempt interval run a full re-walk.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum AutosyncRequest {
+    Evaluate,
+    Incremental,
+    Full,
+}
+
+impl AutosyncRequest {
+    /// The exact token persisted in the cross-process pending marker file.
+    pub(crate) fn as_marker_str(self) -> &'static str {
+        match self {
+            Self::Evaluate => "evaluate",
+            Self::Incremental => "incremental",
+            Self::Full => "full",
+        }
+    }
+
+    /// Parse a pending-marker token. Unknown content (a torn write, a future token) degrades to
+    /// `Evaluate`: the scheduling policy re-decides everything an evaluation can, and interrupted
+    /// work resumes from the persisted cursor regardless.
+    pub(crate) fn from_marker_str(value: &str) -> Self {
+        match value.trim() {
+            "incremental" => Self::Incremental,
+            "full" => Self::Full,
+            _ => Self::Evaluate,
+        }
+    }
 }
 
 pub(crate) fn record_attempt(

--- a/crates/rag-rat-core/src/index/papertrail/transport/stub.rs
+++ b/crates/rag-rat-core/src/index/papertrail/transport/stub.rs
@@ -55,9 +55,36 @@ pub(crate) fn spawn_script_stub(
     spawn_script_stub_with_timeout(responses, Duration::from_secs(10))
 }
 
+/// [`spawn_script_stub`] with cross-stub coordination for concurrency tests:
+/// `notify_first_request` fires after the FIRST request head is read, and `gate_first_response`
+/// holds the FIRST response until the paired stub signals. A gate that times out serves a `500`
+/// instead of hanging the test — a serial (non-overlapping) client then observes a failure the
+/// test can assert on.
+pub(crate) fn spawn_script_stub_coordinated(
+    responses: Vec<StubResponse>,
+    notify_first_request: Option<std::sync::mpsc::Sender<()>>,
+    gate_first_response: Option<std::sync::mpsc::Receiver<()>>,
+) -> (String, thread::JoinHandle<Vec<String>>) {
+    spawn_script_stub_inner(
+        responses,
+        Duration::from_secs(10),
+        notify_first_request,
+        gate_first_response,
+    )
+}
+
 fn spawn_script_stub_with_timeout(
     responses: Vec<StubResponse>,
     accept_timeout: Duration,
+) -> (String, thread::JoinHandle<Vec<String>>) {
+    spawn_script_stub_inner(responses, accept_timeout, None, None)
+}
+
+fn spawn_script_stub_inner(
+    responses: Vec<StubResponse>,
+    accept_timeout: Duration,
+    notify_first_request: Option<std::sync::mpsc::Sender<()>>,
+    gate_first_response: Option<std::sync::mpsc::Receiver<()>>,
 ) -> (String, thread::JoinHandle<Vec<String>>) {
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
     listener.set_nonblocking(true).expect("nonblocking listener");
@@ -75,7 +102,9 @@ fn spawn_script_stub_with_timeout(
         .collect::<Vec<_>>();
     let handle = thread::spawn(move || {
         let mut captured = Vec::new();
-        for response in responses {
+        let mut notify_first_request = notify_first_request;
+        let mut gate_first_response = gate_first_response;
+        for mut response in responses {
             let deadline = Instant::now() + accept_timeout;
             let mut stream = loop {
                 match listener.accept() {
@@ -86,6 +115,14 @@ fn spawn_script_stub_with_timeout(
             };
             if let Some(head) = read_full_request(&mut stream) {
                 captured.push(head);
+            }
+            if let Some(notify) = notify_first_request.take() {
+                let _ = notify.send(());
+            }
+            if let Some(gate) = gate_first_response.take()
+                && gate.recv_timeout(Duration::from_secs(5)).is_err()
+            {
+                response = StubResponse::status("500 Internal Server Error", "gate timed out");
             }
             let payload = format!(
                 "HTTP/1.1 {}\r\n{}Content-Type: application/json\r\nContent-Length: \

--- a/crates/rag-rat-core/src/index/query_api/history.rs
+++ b/crates/rag-rat-core/src/index/query_api/history.rs
@@ -161,6 +161,19 @@ impl IndexDatabase {
         ))
     }
 
+    /// Mirror only the bindings the scheduling policy says are due (the automatic watcher / hook
+    /// path); [`Self::papertrail_sync`] is the unconditional manual pass.
+    pub fn papertrail_sync_scheduled(
+        &self,
+        request: papertrail::AutosyncRequest,
+    ) -> anyhow::Result<PapertrailSyncReport> {
+        papertrail::block_on(papertrail::sync_mirror_scheduled(
+            self.storage.connection(),
+            &self.papertrail,
+            request,
+        ))
+    }
+
     pub fn papertrail_issue_search(
         &self,
         query: &str,

--- a/crates/rag-rat-core/src/locks.rs
+++ b/crates/rag-rat-core/src/locks.rs
@@ -222,6 +222,37 @@ pub fn maintenance_pending_path(database: &Path, repo_id: &str) -> PathBuf {
     lock_dir(database).join(format!("rag-rat-maintenance-{}.pending", lock_discriminator(repo_id)))
 }
 
+/// Per-DB, PER-REPO papertrail auto-sync flight lock (#592), held for one whole coalesced
+/// papertrail run so at most ONE mirror flight per repository is in the air across every trigger
+/// source — watcher timer ticks, git-hook maintenance, other processes. Separate from
+/// [`maintenance_lock_path`]: a mirror flight waits on the NETWORK (pages, rate-governor sleeps)
+/// and must neither hold up nor be held up by ordinary index maintenance. The flight never holds
+/// the repo [`write_lock_path`] — its commits are short synchronous transactions serialized by
+/// SQLite itself.
+pub fn papertrail_lock_path(database: &Path, repo_id: &str) -> PathBuf {
+    lock_dir(database).join(format!("rag-rat-papertrail-{}.lock", lock_discriminator(repo_id)))
+}
+
+/// Marker a coalesced papertrail trigger sets to ask the in-flight runner for one follow-up
+/// evaluation, pairing with [`papertrail_lock_path`] exactly as the maintenance marker pairs with
+/// its lock (#267 pattern). The file CONTENT is the strongest coalesced request token
+/// (`evaluate` / `incremental` / `full`), merged max-wins so a queued full walk is never weakened
+/// by a later incremental trigger. Every read-modify-write of the marker runs under
+/// [`papertrail_marker_lock_path`].
+pub fn papertrail_pending_path(database: &Path, repo_id: &str) -> PathBuf {
+    lock_dir(database).join(format!("rag-rat-papertrail-{}.pending", lock_discriminator(repo_id)))
+}
+
+/// Serializes every read-modify-write of the pending marker: without it two coalescing
+/// contenders can interleave their max-merge and a weaker request overwrites a queued full walk.
+/// Distinct from [`papertrail_lock_path`] — the RUNNER holds that one for the whole
+/// network-bound flight, while this lock is held only for the microseconds of one marker update
+/// (runner and contenders alike), so contenders never wait on the flight.
+pub fn papertrail_marker_lock_path(database: &Path, repo_id: &str) -> PathBuf {
+    lock_dir(database)
+        .join(format!("rag-rat-papertrail-{}.pending.lock", lock_discriminator(repo_id)))
+}
+
 /// Order two repo ids by the CANONICAL LOCK ORDER (see the module doc): lexicographic on the
 /// sanitized discriminator, i.e. the order of the lock FILE NAMES themselves. Multi-lock
 /// acquirers sort with this before acquiring. Ties (same discriminator — same repo) are the

--- a/crates/rag-rat-core/src/watch/event_loop.rs
+++ b/crates/rag-rat-core/src/watch/event_loop.rs
@@ -9,6 +9,7 @@ use std::time::{Duration, Instant};
 use notify::recommended_watcher;
 
 use super::overlay::OverlayScope;
+use super::papertrail::{self, PapertrailClock, PapertrailScheduler};
 use super::pass::{
     Debounce, LoopMsg, PassRequest, PassScheduler, SKIP_TIMEOUT, SweepClock,
     maintenance_pass_scoped, spawn_pass_worker, startup_catchup_pass,
@@ -22,6 +23,7 @@ use crate::config::Config;
 use crate::fleet;
 use crate::index::IndexDatabase;
 use crate::index::ignore_rules::IgnoreMatcher;
+use crate::index::papertrail::{AutosyncRequest, autosync};
 use crate::locks::{self, FileLock};
 
 pub(crate) const FLEET_DEBOUNCE: Duration = Duration::from_millis(500);
@@ -162,6 +164,32 @@ fn watcher_main(
         fleet_bin.as_deref(),
     );
 
+    // Papertrail auto-sync (#592): its own worker + queue, deliberately separate from the pass
+    // worker — a mirror flight waits on the network (pages, rate-governor sleeps) and must
+    // neither delay index passes nor be delayed by them. `None` interval (no resolved tracker
+    // bindings) disables the trigger entirely. The worker handle is dropped, never joined; see
+    // `spawn_papertrail_worker` for why shutdown stays bounded anyway.
+    let papertrail_interval = papertrail::papertrail_tick_interval(&config);
+    let mut papertrail_tx = None;
+    if papertrail_interval.is_some() {
+        let (request_tx, request_rx) = std::sync::mpsc::channel();
+        let spawned = papertrail::spawn_papertrail_worker(request_rx, tx.clone(), {
+            let config = config.clone();
+            move |request| {
+                if let Err(error) = autosync::run(&config, request) {
+                    tracing::warn!(
+                        target: "rag_rat_core::papertrail",
+                        error = %error,
+                        "papertrail auto-sync failed; a later trigger retries"
+                    );
+                }
+            }
+        });
+        if spawned.is_some() {
+            papertrail_tx = Some(request_tx);
+        }
+    }
+
     // Maintenance passes run on the worker thread (#506); see `spawn_pass_worker` for why.
     let (pass_tx, pass_rx) = std::sync::mpsc::channel();
     let Some(pass_worker) = spawn_pass_worker(pass_rx, tx, {
@@ -198,13 +226,17 @@ fn watcher_main(
         rx,
         pass_tx: &pass_tx,
         scheduler: &mut scheduler,
+        papertrail_tx: papertrail_tx.as_ref(),
+        papertrail_interval,
         stop,
         fleet_trigger: &mut fire_fleet_trigger,
     }
     .run();
 
     // Let an in-flight pass finish (bounded by the pass itself, exactly as when passes ran
-    // inline), then release the worker.
+    // inline), then release the worker. The papertrail worker is only released (its channel
+    // closed), never joined — a mirror flight can be network-bound far past any shutdown grace.
+    drop(papertrail_tx);
     drop(pass_tx);
     let _ = pass_worker.join();
 
@@ -232,6 +264,9 @@ pub(crate) struct EventLoop<'a, W: notify::Watcher> {
     pub(crate) rx: Receiver<LoopMsg>,
     pub(crate) pass_tx: &'a Sender<PassRequest>,
     pub(crate) scheduler: &'a mut PassScheduler,
+    /// `None` disables the papertrail trigger (no tracker bindings, or no worker thread).
+    pub(crate) papertrail_tx: Option<&'a Sender<AutosyncRequest>>,
+    pub(crate) papertrail_interval: Option<Duration>,
     pub(crate) stop: &'a AtomicBool,
     /// Injected so tests can observe the fleet firing; production wires [`fleet::trigger`].
     pub(crate) fleet_trigger: &'a mut (dyn FnMut(&Path) + Send),
@@ -252,6 +287,11 @@ impl<W: notify::Watcher> EventLoop<'_, W> {
         let periodic = (self.config.watch.periodic_sweep_secs > 0)
             .then(|| Duration::from_secs(self.config.watch.periodic_sweep_secs));
         let mut sweep = SweepClock::new(periodic, Instant::now());
+        // The papertrail evaluation deadline (#592): fires even on a filesystem-idle watcher, so
+        // the freshness probe and the daily full-walk backstop run on time without any events.
+        let mut papertrail_clock =
+            PapertrailClock::new(self.papertrail_tx.and(self.papertrail_interval), Instant::now());
+        let mut papertrail_scheduler = PapertrailScheduler::new();
         // The overlay scope accumulated while the debounce is armed (#577): every firing event
         // merges its contribution, and the union rides the next dispatched pass. Cleared ONLY on
         // dispatch, like the debounce itself — mid-pass events keep accumulating for the
@@ -265,15 +305,26 @@ impl<W: notify::Watcher> EventLoop<'_, W> {
             // While a pass is in flight its fire condition stays due (the debounce only resets on
             // dispatch), so recomputing those deadlines would spin the loop — the `PassDone`
             // message is what wakes it. The fleet debounce still shapes the wait: the trigger
-            // must fire DURING a long pass, not after it (#506).
+            // must fire DURING a long pass, not after it (#506). The papertrail deadline shapes
+            // BOTH branches for the same reason: an in-flight maintenance pass must not postpone
+            // a due probe (#592).
             let wait = if self.scheduler.in_flight() {
-                fleet_debounce.due_in(now).unwrap_or(IDLE_WAIT)
-            } else {
-                [debounce.due_in(now), fleet_debounce.due_in(now), sweep.due_in(now)]
+                [fleet_debounce.due_in(now), papertrail_clock.due_in(now)]
                     .into_iter()
                     .flatten()
                     .min()
                     .unwrap_or(IDLE_WAIT)
+            } else {
+                [
+                    debounce.due_in(now),
+                    fleet_debounce.due_in(now),
+                    sweep.due_in(now),
+                    papertrail_clock.due_in(now),
+                ]
+                .into_iter()
+                .flatten()
+                .min()
+                .unwrap_or(IDLE_WAIT)
             };
             match self.rx.recv_timeout(wait) {
                 Ok(LoopMsg::Fs(Ok(event))) => {
@@ -350,11 +401,32 @@ impl<W: notify::Watcher> EventLoop<'_, W> {
                         self.linked_worktrees,
                     );
                 },
+                Ok(LoopMsg::PapertrailDone) => {
+                    if let Some(request_tx) = self.papertrail_tx
+                        && let Some(follow_up) = papertrail_scheduler.on_done()
+                    {
+                        let _ = request_tx.send(follow_up);
+                    }
+                },
                 Ok(LoopMsg::Wake) => {},
                 Err(RecvTimeoutError::Timeout) => {},
                 Err(RecvTimeoutError::Disconnected) => break,
             }
             let now = Instant::now();
+            // The papertrail tick enqueues a schedule EVALUATION, never an unconditional mirror:
+            // the per-binding policy decides skip / probe / incremental / full, and the daily
+            // full-walk backstop rides the same evaluation. Independent of the debounce and of
+            // `scheduler.in_flight()`, so ordinary maintenance never delays it; redundant ticks
+            // coalesce in `PapertrailScheduler` (and cross-process in the flight's pending
+            // marker).
+            if papertrail_clock.due(now) {
+                papertrail_clock.on_tick(now);
+                if let Some(request_tx) = self.papertrail_tx
+                    && let Some(request) = papertrail_scheduler.admit(AutosyncRequest::Evaluate)
+                {
+                    let _ = request_tx.send(request);
+                }
+            }
             let periodic_due = sweep.due(now);
             if debounce.should_fire(now) || periodic_due {
                 // The periodic sweep is the missed-event backstop, so it refreshes every overlay;

--- a/crates/rag-rat-core/src/watch/mod.rs
+++ b/crates/rag-rat-core/src/watch/mod.rs
@@ -14,9 +14,13 @@
 //!   (cold embedding backlog, clone-graph rebuild) or a blocked write-lock acquisition must not
 //!   stop events from classifying or the fleet hot-upgrade trigger from firing. One pass in flight
 //!   at a time; fire conditions that arrive mid-pass coalesce into the armed debounce.
+//! - Papertrail auto-sync (#592) runs on its OWN worker with its own periodic deadline: the
+//!   freshness probe and daily full-walk backstop fire even on a filesystem-idle watcher and are
+//!   never postponed by an in-flight maintenance pass.
 
 mod event_loop;
 mod overlay;
+mod papertrail;
 mod pass;
 mod placement;
 
@@ -26,6 +30,8 @@ pub(crate) use event_loop::{EventLoop, shutdown_discover};
 #[cfg(test)]
 pub(crate) use overlay::{OverlayBasisAction, overlay_basis_action, overlay_needs_embed};
 pub use overlay::{OverlayScope, ReconcileBudget, refresh_worktree_overlays};
+#[cfg(test)]
+pub(crate) use papertrail::{PapertrailClock, PapertrailScheduler, papertrail_tick_interval};
 pub use pass::{CLONE_GRAPH_QUIET_MS, maintenance_pass, maintenance_pass_or_skip};
 #[cfg(test)]
 pub(crate) use pass::{

--- a/crates/rag-rat-core/src/watch/papertrail.rs
+++ b/crates/rag-rat-core/src/watch/papertrail.rs
@@ -1,0 +1,113 @@
+//! The watcher's papertrail auto-sync trigger (#592): a periodic evaluation deadline that fires
+//! even when the filesystem is idle, and a dedicated worker thread that runs the coalesced
+//! cross-process flight. Deliberately SEPARATE from the maintenance pass worker — a mirror
+//! flight waits on the network (pages, rate-governor sleeps) and must neither delay index passes
+//! nor be delayed by them — and the deadline is computed independently of the debounce and the
+//! pass-in-flight state, so an in-flight maintenance pass never postpones a probe.
+
+use std::sync::mpsc::{Receiver, Sender};
+use std::thread::JoinHandle;
+use std::time::{Duration, Instant};
+
+use super::pass::LoopMsg;
+use crate::config::Config;
+use crate::index::papertrail::{AutosyncRequest, PapertrailContext};
+
+/// Clock for the periodic papertrail evaluation deadline, pure like `Debounce` / `SweepClock`
+/// (clock injected). `None` interval — no resolved tracker bindings, or a zeroed cadence —
+/// means never due. The first tick is one full interval after startup: the scheduling policy's
+/// persisted freshness makes an eager boot-time evaluation redundant, and startup already runs
+/// the catch-up index pass.
+#[derive(Debug)]
+pub(crate) struct PapertrailClock {
+    interval: Option<Duration>,
+    last_tick: Instant,
+}
+
+impl PapertrailClock {
+    pub(crate) fn new(interval: Option<Duration>, now: Instant) -> Self {
+        Self { interval, last_tick: now }
+    }
+
+    pub(crate) fn on_tick(&mut self, now: Instant) {
+        self.last_tick = now;
+    }
+
+    pub(crate) fn due(&self, now: Instant) -> bool {
+        self.interval.is_some_and(|interval| now >= self.last_tick + interval)
+    }
+
+    pub(crate) fn due_in(&self, now: Instant) -> Option<Duration> {
+        self.interval.map(|interval| (self.last_tick + interval).saturating_duration_since(now))
+    }
+}
+
+/// The watcher's evaluation cadence: the tightest configured deadline (the probe interval and
+/// the daily full-walk backstop share one wake-up), or `None` when the repo resolves no tracker
+/// bindings. Resolved ONCE at watcher startup — the config is fixed for the watcher's lifetime.
+pub(crate) fn papertrail_tick_interval(config: &Config) -> Option<Duration> {
+    if PapertrailContext::resolve(config).trackers.is_empty() {
+        return None;
+    }
+    let secs = config.papertrail.probe_interval_secs.min(config.papertrail.full_sync_interval_secs);
+    (secs > 0).then(|| Duration::from_secs(secs))
+}
+
+/// In-process single-flight for the papertrail worker: at most one request in the air per
+/// watcher; requests arriving mid-flight coalesce into ONE pending follow-up, merged max-wins so
+/// a queued full walk is never weakened by a later incremental tick. (Cross-process coalescing
+/// is the flight lock + pending marker inside `autosync::run`; this keeps THIS watcher from
+/// queueing redundant flights behind a slow one.)
+#[derive(Debug)]
+pub(crate) struct PapertrailScheduler {
+    inflight: bool,
+    pending: Option<AutosyncRequest>,
+}
+
+impl PapertrailScheduler {
+    pub(crate) fn new() -> Self {
+        Self { inflight: false, pending: None }
+    }
+
+    /// Admit a request: `Some` = send it to the worker now; `None` = coalesced into the pending
+    /// follow-up.
+    pub(crate) fn admit(&mut self, request: AutosyncRequest) -> Option<AutosyncRequest> {
+        if self.inflight {
+            self.pending = Some(self.pending.take().map_or(request, |queued| queued.max(request)));
+            return None;
+        }
+        self.inflight = true;
+        Some(request)
+    }
+
+    /// The flight finished; the caller sends the returned coalesced follow-up, if any.
+    pub(crate) fn on_done(&mut self) -> Option<AutosyncRequest> {
+        self.inflight = false;
+        let follow_up = self.pending.take()?;
+        self.admit(follow_up)
+    }
+}
+
+/// Spawn the papertrail worker. Each request runs OFF the event-loop thread and answers with
+/// [`LoopMsg::PapertrailDone`] so the loop dispatches the coalesced follow-up. The worker exits
+/// when the request channel closes — and is deliberately NOT joined on shutdown: a flight can be
+/// network-bound for minutes (rate-governor sleeps), the mirror cursor persists after every
+/// page, and the flight flock dies with the process, so detaching keeps shutdown bounded while
+/// an interrupted walk simply resumes on the next trigger.
+pub(crate) fn spawn_papertrail_worker(
+    request_rx: Receiver<AutosyncRequest>,
+    done_tx: Sender<LoopMsg>,
+    mut run_request: impl FnMut(AutosyncRequest) + Send + 'static,
+) -> Option<JoinHandle<()>> {
+    std::thread::Builder::new()
+        .name("rag-rat-papertrail".to_string())
+        .spawn(move || {
+            while let Ok(request) = request_rx.recv() {
+                run_request(request);
+                if done_tx.send(LoopMsg::PapertrailDone).is_err() {
+                    return;
+                }
+            }
+        })
+        .ok()
+}

--- a/crates/rag-rat-core/src/watch/papertrail.rs
+++ b/crates/rag-rat-core/src/watch/papertrail.rs
@@ -33,12 +33,19 @@ impl PapertrailClock {
         self.last_tick = now;
     }
 
+    /// `None` when disabled OR when the configured cadence overflows `Instant` arithmetic — a
+    /// deadline beyond the platform's monotonic range never arrives, and a bare `+` would panic
+    /// the watcher on its first wait computation.
+    fn deadline(&self) -> Option<Instant> {
+        self.interval.and_then(|interval| self.last_tick.checked_add(interval))
+    }
+
     pub(crate) fn due(&self, now: Instant) -> bool {
-        self.interval.is_some_and(|interval| now >= self.last_tick + interval)
+        self.deadline().is_some_and(|at| now >= at)
     }
 
     pub(crate) fn due_in(&self, now: Instant) -> Option<Duration> {
-        self.interval.map(|interval| (self.last_tick + interval).saturating_duration_since(now))
+        self.deadline().map(|at| at.saturating_duration_since(now))
     }
 }
 

--- a/crates/rag-rat-core/src/watch/pass.rs
+++ b/crates/rag-rat-core/src/watch/pass.rs
@@ -123,13 +123,15 @@ pub(crate) enum PassRequest {
     },
 }
 
-/// Everything that wakes the event loop: filesystem events from notify, pass completions from the
-/// worker thread, and the drop-time wake that makes `stop` observable immediately instead of at
-/// the next recv timeout (idle waits stretch to the periodic-sweep interval).
+/// Everything that wakes the event loop: filesystem events from notify, pass completions from
+/// the worker thread, papertrail flight completions from the auto-sync worker (#592), and the
+/// drop-time wake that makes `stop` observable immediately instead of at the next recv timeout
+/// (idle waits stretch to the periodic-sweep interval).
 #[derive(Debug)]
 pub(crate) enum LoopMsg {
     Fs(notify::Result<Event>),
     PassDone,
+    PapertrailDone,
     Wake,
 }
 

--- a/crates/rag-rat-core/src/watch/tests.rs
+++ b/crates/rag-rat-core/src/watch/tests.rs
@@ -2982,6 +2982,12 @@ fn papertrail_clock_is_never_due_without_an_interval_and_rearms_on_tick() {
     clock.on_tick(start + Duration::from_secs(900));
     assert!(!clock.due(start + Duration::from_secs(1_799)));
     assert!(clock.due(start + Duration::from_secs(1_800)));
+
+    // A cadence that overflows Instant arithmetic is a deadline that never arrives — it must
+    // not panic the watcher's wait computation.
+    let oversized = PapertrailClock::new(Some(Duration::from_secs(u64::MAX)), start);
+    assert!(!oversized.due(start + Duration::from_secs(86_400)));
+    assert_eq!(oversized.due_in(start), None);
 }
 
 #[test]

--- a/crates/rag-rat-core/src/watch/tests.rs
+++ b/crates/rag-rat-core/src/watch/tests.rs
@@ -2069,6 +2069,8 @@ fn a_pass_in_flight_does_not_starve_events_or_the_fleet_trigger() {
         rx,
         pass_tx: &pass_tx,
         scheduler: &mut scheduler,
+        papertrail_tx: None,
+        papertrail_interval: None,
         stop: &stop,
         fleet_trigger: &mut fleet_trigger,
     };
@@ -2859,6 +2861,8 @@ fn event_loop_ignores_fs_errors_and_exits_on_disconnect() {
         rx,
         pass_tx: &pass_tx_for_loop,
         scheduler: &mut scheduler,
+        papertrail_tx: None,
+        papertrail_interval: None,
         stop: &stop,
         fleet_trigger: &mut fleet_trigger,
     };
@@ -2908,6 +2912,8 @@ fn periodic_sweep_dispatches_all_overlay_scope() {
         rx,
         pass_tx: &pass_tx_for_loop,
         scheduler: &mut scheduler,
+        papertrail_tx: None,
+        papertrail_interval: None,
         stop: &stop,
         fleet_trigger: &mut fleet_trigger,
     };
@@ -2961,4 +2967,187 @@ fn shutdown_discover_skips_when_write_lock_is_held() {
     );
     release.store(true, Ordering::Relaxed);
     holder.join().unwrap();
+}
+
+#[test]
+fn papertrail_clock_is_never_due_without_an_interval_and_rearms_on_tick() {
+    let start = Instant::now();
+    let disabled = PapertrailClock::new(None, start);
+    assert!(!disabled.due(start + Duration::from_secs(86_400)));
+    assert_eq!(disabled.due_in(start), None);
+
+    let mut clock = PapertrailClock::new(Some(Duration::from_secs(900)), start);
+    assert!(!clock.due(start + Duration::from_secs(899)));
+    assert!(clock.due(start + Duration::from_secs(900)));
+    clock.on_tick(start + Duration::from_secs(900));
+    assert!(!clock.due(start + Duration::from_secs(1_799)));
+    assert!(clock.due(start + Duration::from_secs(1_800)));
+}
+
+#[test]
+fn papertrail_scheduler_single_flights_and_coalesces_max_wins() {
+    use crate::index::papertrail::AutosyncRequest;
+    let mut scheduler = PapertrailScheduler::new();
+    // Idle → dispatch immediately.
+    assert_eq!(scheduler.admit(AutosyncRequest::Evaluate), Some(AutosyncRequest::Evaluate));
+    // In flight → any number of requests coalesce into ONE pending follow-up, strongest wins —
+    // and a later weaker request must not weaken it.
+    assert_eq!(scheduler.admit(AutosyncRequest::Incremental), None);
+    assert_eq!(scheduler.admit(AutosyncRequest::Full), None);
+    assert_eq!(scheduler.admit(AutosyncRequest::Evaluate), None);
+    // Completion dispatches the coalesced follow-up (the scheduler is in flight again)...
+    assert_eq!(scheduler.on_done(), Some(AutosyncRequest::Full));
+    // ...and the next completion, with nothing queued, dispatches nothing.
+    assert_eq!(scheduler.on_done(), None);
+    assert_eq!(scheduler.admit(AutosyncRequest::Evaluate), Some(AutosyncRequest::Evaluate));
+}
+
+#[test]
+fn papertrail_tick_interval_requires_bindings_and_takes_the_tightest_cadence() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    // No `[[tracker]]` bindings and no git remote to auto-detect one from → disabled.
+    let mut config = whole_root_config(tmp.path(), &[PathBuf::from("src")]);
+    assert_eq!(papertrail_tick_interval(&config), None);
+
+    config.trackers = vec![crate::config::TrackerConfig {
+        provider: crate::config::Tracker::Github,
+        project: Some("o/r".to_string()),
+        remote: "origin".to_string(),
+        base_url: None,
+        auth: None,
+        tags: Vec::new(),
+    }];
+    assert_eq!(papertrail_tick_interval(&config), Some(Duration::from_secs(900)));
+    // The daily full-walk backstop shares the wake-up: a tighter full interval tightens it.
+    config.papertrail.full_sync_interval_secs = 600;
+    assert_eq!(papertrail_tick_interval(&config), Some(Duration::from_secs(600)));
+}
+
+#[test]
+fn idle_watcher_enqueues_papertrail_evaluation_without_filesystem_activity() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let root = tmp.path();
+    std::fs::create_dir_all(root.join("src")).unwrap();
+    std::fs::write(root.join("src/lib.rs"), "pub fn f() {}\n").unwrap();
+    let mut config = whole_root_config(root, &[PathBuf::from("src")]);
+    config.watch.debounce_ms = 60_000;
+    config.watch.max_latency_ms = 60_000;
+    config.watch.periodic_sweep_secs = 0;
+    let target_dirs = config.target_directories();
+    let mut ignore = IgnoreMatcher::compile(&config.root, &target_dirs);
+    let mut linked_worktrees = LinkedWorktreeWatches::default();
+    let mut notify_watcher =
+        <RecordingWatcher as notify::Watcher>::new(|_| {}, notify::Config::default()).unwrap();
+    let (tx, rx) = std::sync::mpsc::channel();
+    let (pass_tx, _pass_rx) = std::sync::mpsc::channel();
+    let (papertrail_tx, papertrail_rx) = std::sync::mpsc::channel();
+    let mut scheduler = PassScheduler::new();
+    let stop = AtomicBool::new(false);
+    let mut fleet_trigger = |_: &Path| {};
+
+    let event_loop = EventLoop {
+        config: &config,
+        target_dirs: &target_dirs,
+        fleet_bin: None,
+        notify_watcher: &mut notify_watcher,
+        ignore: &mut ignore,
+        linked_worktrees: &mut linked_worktrees,
+        worktree_registry: None,
+        rx,
+        pass_tx: &pass_tx,
+        scheduler: &mut scheduler,
+        papertrail_tx: Some(&papertrail_tx),
+        papertrail_interval: Some(Duration::from_millis(50)),
+        stop: &stop,
+        fleet_trigger: &mut fleet_trigger,
+    };
+    std::thread::scope(|scope| {
+        let handle = scope.spawn(move || event_loop.run());
+        // No filesystem events at all: the deadline alone must enqueue an evaluation.
+        assert_eq!(
+            papertrail_rx.recv_timeout(Duration::from_secs(5)),
+            Ok(crate::index::papertrail::AutosyncRequest::Evaluate),
+        );
+        stop.store(true, Ordering::Relaxed);
+        tx.send(LoopMsg::Wake).unwrap();
+        drop(tx);
+        let _ = handle.join();
+    });
+}
+
+#[test]
+fn papertrail_deadline_fires_during_an_in_flight_pass_and_ticks_coalesce() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let root = tmp.path();
+    std::fs::create_dir_all(root.join("src")).unwrap();
+    std::fs::write(root.join("src/lib.rs"), "pub fn f() {}\n").unwrap();
+    let mut config = whole_root_config(root, &[PathBuf::from("src")]);
+    config.watch.debounce_ms = 10;
+    config.watch.max_latency_ms = 50;
+    config.watch.periodic_sweep_secs = 0;
+    let target_dirs = config.target_directories();
+    let mut ignore = IgnoreMatcher::compile(&config.root, &target_dirs);
+    let mut linked_worktrees = LinkedWorktreeWatches::default();
+    let mut notify_watcher =
+        <RecordingWatcher as notify::Watcher>::new(|_| {}, notify::Config::default()).unwrap();
+    let (tx, rx) = std::sync::mpsc::channel();
+    let (pass_tx, pass_rx) = std::sync::mpsc::channel();
+    let pass_tx_for_loop = pass_tx.clone();
+    let (papertrail_tx, papertrail_rx) = std::sync::mpsc::channel();
+    let mut scheduler = PassScheduler::new();
+    let stop = AtomicBool::new(false);
+    let mut fleet_trigger = |_: &Path| {};
+
+    let event_loop = EventLoop {
+        config: &config,
+        target_dirs: &target_dirs,
+        fleet_bin: None,
+        notify_watcher: &mut notify_watcher,
+        ignore: &mut ignore,
+        linked_worktrees: &mut linked_worktrees,
+        worktree_registry: None,
+        rx,
+        pass_tx: &pass_tx_for_loop,
+        scheduler: &mut scheduler,
+        papertrail_tx: Some(&papertrail_tx),
+        papertrail_interval: Some(Duration::from_millis(100)),
+        stop: &stop,
+        fleet_trigger: &mut fleet_trigger,
+    };
+    std::thread::scope(|scope| {
+        let handle = scope.spawn(move || event_loop.run());
+
+        // Put an ordinary maintenance pass in flight (this test plays the worker and does NOT
+        // complete it).
+        tx.send(LoopMsg::Fs(Ok(mutation_event(root.join("src/lib.rs"))))).unwrap();
+        assert!(pass_rx.recv_timeout(Duration::from_secs(5)).is_ok());
+
+        // The papertrail deadline still fires — an in-flight pass must not postpone it.
+        assert_eq!(
+            papertrail_rx.recv_timeout(Duration::from_secs(5)),
+            Ok(crate::index::papertrail::AutosyncRequest::Evaluate),
+            "the papertrail deadline must fire during an in-flight maintenance pass",
+        );
+
+        // Several more deadline ticks elapse while the papertrail flight is in the air (no
+        // PapertrailDone): they must coalesce, not queue.
+        std::thread::sleep(Duration::from_millis(350));
+        assert!(
+            papertrail_rx.try_recv().is_err(),
+            "ticks during an in-flight papertrail run must coalesce into one follow-up",
+        );
+
+        // Completing the flight dispatches exactly the one coalesced follow-up.
+        tx.send(LoopMsg::PapertrailDone).unwrap();
+        assert_eq!(
+            papertrail_rx.recv_timeout(Duration::from_secs(5)),
+            Ok(crate::index::papertrail::AutosyncRequest::Evaluate),
+        );
+
+        stop.store(true, Ordering::Relaxed);
+        tx.send(LoopMsg::Wake).unwrap();
+        drop(tx);
+        drop(pass_tx);
+        let _ = handle.join();
+    });
 }

--- a/docs/config.md
+++ b/docs/config.md
@@ -634,3 +634,28 @@ probe_interval_secs = 900       # default: 15 minutes
 sync_min_interval_secs = 900    # default: 15 minutes between attempts
 full_sync_interval_secs = 86400 # default: daily healing walk
 ```
+
+Synchronization is **automatic** once an index exists — no cron entry and no manual sync command
+needed:
+
+- **Git hooks.** Every `rag-rat maintenance` trigger (post-commit, post-merge, …) finishes its
+  ordinary index pass, releases its coordination lock, then runs an incremental papertrail
+  evaluation. A broken or unreachable mirror never fails the hook; the outcome rides the
+  maintenance report's `papertrail` field.
+- **The watcher.** A live watcher (the MCP server) evaluates the schedule at the tightest
+  configured cadence above — every 15 minutes by default — even when the filesystem is idle, and
+  the daily full-walk backstop rides the same deadline. An in-flight index pass never postpones
+  the evaluation.
+- **One flight per repository.** All triggers — watcher ticks, hooks, concurrent processes —
+  coalesce on a per-repo flight lock: at most one mirror run is in the air, triggers arriving
+  mid-run queue at most one follow-up, and a queued full walk is never weakened by a later
+  incremental trigger.
+- **Failures stay per binding.** Due bindings sync concurrently under one shared quota governor;
+  a failed or rate-paused binding never cancels its siblings, its failure class is persisted on
+  the binding's health row (see `papertrail_sync_status`), and the cadence above retries it.
+  Auto-sync never holds the repository write lock, so mirror traffic cannot stall ordinary index
+  maintenance.
+
+Manual `rag-rat papertrail sync` remains the unconditional pass: it dispatches every binding
+regardless of cadence, reports provider-client-pending bindings explicitly, and also refreshes
+reference discovery (commit / file / branch refs), which the automatic path deliberately skips.

--- a/docs/config.md
+++ b/docs/config.md
@@ -657,7 +657,14 @@ needed:
   the binding's health row (see `papertrail_sync_status`), and the cadence above retries it.
   Auto-sync never holds the repository write lock, so mirror traffic cannot stall ordinary index
   maintenance.
+- **Indexed repos only.** Automatic sync starts after the repo's first index pass — a repo that
+  is merely registered in a shared database (read-only opens do that) is never mirrored
+  automatically.
 
 Manual `rag-rat papertrail sync` remains the unconditional pass: it dispatches every binding
 regardless of cadence, reports provider-client-pending bindings explicitly, and also refreshes
 reference discovery (commit / file / branch refs), which the automatic path deliberately skips.
+It shares the per-repo flight lock with automatic sync — two mirror runs over one binding would
+clobber each other's cursor — so a request issued while an automatic flight is running waits for
+that flight to finish (the wait is announced on stderr and can be interrupted) and then runs the
+full manual pass; it is never downgraded to a policy-gated follow-up.

--- a/docs/config.md
+++ b/docs/config.md
@@ -630,9 +630,9 @@ priority over these ordinary cadences.
 
 ```toml
 [papertrail]
-probe_interval_secs = 900       # default: 15 minutes
-sync_min_interval_secs = 900    # default: 15 minutes between attempts
-full_sync_interval_secs = 86400 # default: daily healing walk
+probe_interval_secs = 900       # default: 15 minutes; must be positive
+sync_min_interval_secs = 900    # default: 15 minutes between attempts; 0 = no attempt gate
+full_sync_interval_secs = 86400 # default: daily healing walk; must be positive
 ```
 
 Synchronization is **automatic** once an index exists — no cron entry and no manual sync command

--- a/docs/config.md
+++ b/docs/config.md
@@ -638,10 +638,12 @@ full_sync_interval_secs = 86400 # default: daily healing walk
 Synchronization is **automatic** once an index exists — no cron entry and no manual sync command
 needed:
 
-- **Git hooks.** Every `rag-rat maintenance` trigger (post-commit, post-merge, …) finishes its
-  ordinary index pass, releases its coordination lock, then runs an incremental papertrail
-  evaluation. A broken or unreachable mirror never fails the hook; the outcome rides the
-  maintenance report's `papertrail` field.
+- **Git hooks.** Every git-hook `rag-rat maintenance` trigger (post-commit, post-merge,
+  post-rewrite, post-checkout) finishes its ordinary index pass, releases its coordination lock,
+  then runs an incremental papertrail evaluation. Manual or scripted `maintenance` runs (no
+  `--trigger`, or a non-hook value) never start mirror work — they stay bounded by their index
+  budget. A broken or unreachable mirror never fails the hook; the outcome rides the maintenance
+  report's `papertrail` field.
 - **The watcher.** A live watcher (the MCP server) evaluates the schedule at the tightest
   configured cadence above — every 15 minutes by default — even when the filesystem is idle, and
   the daily full-walk backstop rides the same deadline. An in-flight index pass never postpones


### PR DESCRIPTION
Automatic papertrail synchronization on top of the #640 scheduling core: a coalesced, policy-driven orchestration triggered by git hooks and the watcher's periodic deadline. No new migration — #640's per-binding health rows and mirror cursors persist everything; trigger coalescing uses per-repository lock/pending files.

## Orchestration

- **One flight per repository** (`papertrail::autosync`). The first trigger to take the per-repo flight lock runs; concurrent triggers — threads, hooks, other processes — merge their request into a pending marker and exit. The marker carries the strongest coalesced request (`evaluate < incremental < full`, max-wins), and every read-modify-write of it runs under a short-lived update lock so contenders can never interleave the merge and lose a queued full walk. The runner absorbs the marker before each pass and runs at most one follow-up evaluation for triggers that arrived mid-flight.
- **Requests are coalescible urgencies**, not commands: `Evaluate` (timer tick — the policy decides per binding), `Incremental` (a git hook fired), `Full` (explicit healing walk). A `Full` request upgrades any allowed decision; `Skip` always wins — persisted pauses and `sync_min_interval_secs` gate even forced work.

## Mirror execution boundary

- Per-binding execution is extracted from `sync_mirror` into shared jobs; `sync_mirror_scheduled` evaluates every binding against ONE clock snapshot, filters `Skip` decisions and provider-client-pending bindings before dispatch (an automatic tick must not log the same capability gap every 15 minutes), and skips reference discovery (it re-reads every indexed file from disk; the annotation layer refreshes on manual sync).
- Due bindings run **concurrently** on the papertrail current-thread runtime under one shared quota governor: network waits (pages, rate-governor sleeps) overlap across bindings while every database commit stays a short synchronous transaction between awaits — commits are serialized by construction, and no SQLite transaction, connection guard, or repository write lock ever spans an await. The flight never takes the repository write lock at all.
- A run whose item probe answered not-modified and that stored nothing records `Probe` success (the #640 placeholder operation), so `last_successful_mirror_ms` keeps meaning "content actually moved".

## Triggers

- **Watcher**: a papertrail deadline at the tightest configured cadence (15 min default; the daily full-walk backstop rides the same evaluation) fires even on a filesystem-idle watcher and is included in the event loop's wait in BOTH branches — an in-flight maintenance pass never postpones a probe. Flights run on a dedicated worker thread, separate from the maintenance pass worker; ticks arriving mid-flight coalesce into one follow-up. The worker is released but never joined on shutdown: cursors persist after every page and the flight lock dies with the process, so an interrupted walk resumes on the next trigger while shutdown stays bounded.
- **Git hooks**: `rag-rat maintenance` finishes its coalesced index passes, releases the coordination lock, then runs an incremental evaluation. Best-effort: the outcome rides the report's `papertrail` field, failures are logged and persisted as binding health, and a broken mirror never fails the hook. The watcher-live skip path still triggers (the git action is a change signal either way; the flight lock coalesces with the watcher's worker); the coalesced-skip path does not (the in-flight runner fires one after its own passes).

## Failure isolation

A failed or rate-paused binding never cancels its siblings: each job records its own success / pause / failure health, and only a storage-layer error propagates. A database-open failure re-sets the pending marker so a later wake retries. With no resolved tracker bindings the trigger is a no-op before any lock or database open.

## Review-round hardening

- The pending-marker handoff is now fully atomic: contenders merge-and-try-acquire under one marker-lock hold, and the runner's final marker check releases the flight lock inside the same hold — an accepted trigger can no longer be orphaned in the marker. Verified by an 8-way trigger race and a multi-thread merge race.
- Papertrail auto-sync rides git-hook triggers only; manual/scripted `maintenance` runs stay bounded by their index budget and report the skip.
- Zero wake cadences are rejected at config load (an accepted zero would silently disable the watcher trigger, including the other positive timer), and oversized cadences no longer overflow the watcher's deadline arithmetic.
- New lifecycle tests exposed a pre-existing mirror bug: a backfill completing on a CHAINED empty provider leg left its consumed page cursor behind, making the scheduling policy misread every completed walk as interrupted work forever (perpetual incremental dispatches instead of probe cadence). Fixed in the done-branch; the resume test guards the regression. The same suite pins interruption-resume from the persisted low mark, quota-reserve pauses persisting a retry horizon that gates dispatches of any strength, and tag-filter changes re-dispatching despite fresh timestamps.

## Second review round

- **Indexed repos only**: automatic sync now checks the "an index pass ran here" signal after opening — a repo merely registered read-only in a shared database (or a deferred first-time-empty hook) is never mirrored automatically; the trigger reports `deferred` until the first index pass.
- **Manual sync shares the flight lock without degrading**: `rag-rat papertrail sync` now takes the same per-repo flight lock (two mirror runs over one binding would clobber each other's cursor). An explicit sync is never downgraded to a policy-gated follow-up — it waits out a running automatic flight (announced on stderr, interruptible) and then runs the full unconditional pass.
- **Hook-origin preserved through maintenance coalescing**: a hook trigger that coalesces behind an in-flight maintenance run fires its own papertrail request — the holder may be a manual/cron run that never triggers papertrail, which would have dropped the change signal.
- **Identity re-key guard**: marker-driven follow-ups re-check the resolved repo identity; a flight outliving an identity transition (shallow clone upgrading) steps aside rather than running concurrently with a fresh-keyed flight over one cursor.
- The scheduled and manual paths now share one drain loop, so the atomic acquire-or-coalesce and exit-handoff critical sections exist exactly once.

## Identity and pre-index hardening (later rounds)

- **Identity re-key on every pass**: both sync paths re-resolve the repo identity after opening, before any mirror work — a flight whose lock key went stale (e.g. a shallow clone upgrading to its portable id) never mirrors under it. The stranded request, plus anything in the old-key marker, is carried to fresh keys and retried (bounded); on pathological churn it is queued where fresh-keyed triggers absorb it. An `Incremental` change signal is not re-derivable from persisted cursor state, so accepted requests never strand.
- **Non-creating index gates**: opening a missing database creates the empty SQLite file before the schema check refuses, and that artifact defeats every later `database.exists()` "build the index first" hint. Automatic triggers and manual sync now refuse before any lock or open work; the CLI read commands and manual sync share one `ensure_index_exists` guard.

## Tests

Beyond unit coverage of the policy mapping, marker tokens, clock, and scheduler: a multi-thread race proves concurrent marker merges never lose the strongest request; a gated-stub test proves two due bindings' network requests overlap while commits serialize (serial dispatch would time out the gate); min-interval skips make zero network requests; the daily backstop dominates a fresh probe and completes a full walk; one binding's 500 persists its failure class while the sibling completes; idle-watcher ticks enqueue evaluation with no filesystem events; ticks during an in-flight pass coalesce into exactly one follow-up; and a CLI test drives `maintenance` end-to-end against an unreachable binding — hook success, `network` failure class persisted.

## Verified against the live GitHub API

A scratch index bound to this repository, driven through the real hook path (`maintenance --trigger post-commit`):

- run 1: full LIFO backfill started, **315 items + 1117 comments** mirrored, then a transient mid-body network failure — classified `network`, persisted, cursor left resumable;
- run 2 (immediate re-trigger): **zero dispatch** — the min-interval gate held;
- run 3 (attempt backdated past the interval): the interrupted descent **resumed** (+237 items → 537 items, 3047 comments), then the rate governor paused the binding — persisted as `rate_limited` with a retry horizon, reported as a paused binding (not an error), hook exit 0.

Closes #592



