### PR TITLE
test(swift): SwiftPM corpus + fix the calls it exposed

### DIFF
--- a/crates/rag-rat-core/src/index/languages/swift/edges.rs
+++ b/crates/rag-rat-core/src/index/languages/swift/edges.rs
@@ -221,7 +221,7 @@ fn swift_call_edges(
     out: &mut Vec<EdgeCandidate>,
 ) {
     if swift_subscript_suffix(node, text).is_some() {
-        let Some(target) = swift_call_target(node) else {
+        let Some(target) = swift_call_target(node).map(swift_callee_operand) else {
             return;
         };
         let Some((mut identifiers, _)) = swift_call_target_parts(target, text) else {
@@ -236,7 +236,7 @@ fn swift_call_edges(
         emit_swift_call_edges(text, node, symbols, out, identifiers, None, false);
         return;
     }
-    let Some(target) = swift_call_target(node) else {
+    let Some(target) = swift_call_target(node).map(swift_callee_operand) else {
         return;
     };
     let Some((identifiers, callee_range)) = swift_call_target_parts(target, text) else {
@@ -741,10 +741,103 @@ fn swift_call_target(node: Node<'_>) -> Option<Node<'_>> {
     node.named_children(&mut cursor).find(|child| child.kind() != "call_suffix")
 }
 
+/// Swift binary-operator expressions that can end up holding a call's CALLEE.
+const BINARY_OPERATOR_EXPRESSIONS: &[&str] = &[
+    "additive_expression",
+    "bitwise_operation",
+    "comparison_expression",
+    "conjunction_expression",
+    "disjunction_expression",
+    "equality_expression",
+    "infix_expression",
+    "multiplicative_expression",
+    "nil_coalescing_expression",
+    "range_expression",
+];
+
+/// The real callee of a call whose TARGET is a binary-operator expression.
+///
+/// tree-sitter-swift binds the argument list to the WHOLE expression on the operator's left, so
+/// `p + g()` parses as `call_expression(additive_expression(p + g), call_suffix(()))` — the call's
+/// target is the OPERATOR node, not `g`. Swift evaluates that as `p + (g())`, so the callee is the
+/// operator expression's RIGHTMOST operand.
+///
+/// Without this unwrap `swift_call_target_parts` refuses the operator node (it is not a callable
+/// static path) and the call is DROPPED — silently losing every call that appears on the right of a
+/// binary operator: `total + item.price()`, `x == compute()`, `value ?? fallback()`. That is a
+/// large share of real call sites, and nothing about the missing edge is visible downstream: the
+/// call just never enters the graph. Nested operators (`a + b + g()`) unwrap repeatedly.
+fn swift_callee_operand(target: Node<'_>) -> Node<'_> {
+    let mut current = target;
+    while BINARY_OPERATOR_EXPRESSIONS.contains(&current.kind()) {
+        let mut cursor = current.walk();
+        let Some(rightmost) = current.named_children(&mut cursor).last() else {
+            break;
+        };
+        current = rightmost;
+    }
+    current
+}
+
+/// The callee path for a call whose TARGET carries a binary operator on its left spine.
+/// `total + item.price()` parses as `call_expression(navigation_expression(additive(total + item),
+/// price), ())`, and `base + Module.Client.make()` nests one level deeper —
+/// `navigation(navigation(additive(base + Module), Client), make)`. In both, the target itself
+/// contains the operator, so `swift_callable_is_static_path` refuses it and the whole call is
+/// dropped — losing the single most common shape there is: a method call added to something.
+///
+/// [`swift_operator_stripped_path`] peels the navigation layers off the target, strips the
+/// operator's LEFT operand (Swift evaluates `base + X.y()` as `base + (X.y())`), and returns the
+/// ordered identifier nodes of the real call path (`item.price`, `Module.Client.make`). Those run
+/// through the SAME [`swift_normalize_call_path`] as the plain arm, so `base + Service.init()`
+/// collapses to a construction of `Service` exactly as `Service.init()` does.
+///
+/// `None` when there is no operator on the target's left spine (ordinary paths keep their existing
+/// naming), or when the receiver is DYNAMIC (`base + foo().bar()`, `x + a[0].m()`) — a value
+/// receiver with no nameable path, which the baseline drops with or without the operator.
+fn swift_operator_receiver_call_parts(
+    target: Node<'_>,
+    text: &str,
+) -> Option<(Vec<String>, Option<CalleeRange>)> {
+    let identifier_nodes = swift_operator_stripped_path(target)?;
+    swift_normalize_call_path(identifier_nodes, text)
+}
+
+/// The ordered identifier nodes of a call target with a binary operator on its left spine, minus
+/// the operator's left operand — or `None` when the spine holds no operator, or a dynamic (call /
+/// subscript) receiver that is not a nameable static path.
+///
+/// Recurses down the leftmost `navigation_expression` chain, appending each suffix, until it
+/// reaches the operator; the operator's RIGHTMOST operand is where the real path begins. A base
+/// case that is neither a navigation nor an operator (a bare identifier, a call, a subscript)
+/// yields `None`, so an operator-free path and a dynamic receiver both fall through to the normal
+/// arm.
+fn swift_operator_stripped_path(target: Node<'_>) -> Option<Vec<Node<'_>>> {
+    if BINARY_OPERATOR_EXPRESSIONS.contains(&target.kind()) {
+        let operand = swift_callee_operand(target);
+        // `base + foo().bar` bottoms out here with a dynamic operand — not a qualifiable path.
+        return swift_callable_is_static_path(operand).then(|| syntax::identifier_nodes(operand));
+    }
+    if target.kind() == "navigation_expression" {
+        let mut cursor = target.walk();
+        let children = target.named_children(&mut cursor).collect::<Vec<_>>();
+        let (&receiver, &suffix) = (children.first()?, children.last()?);
+        // A pathological left-leaning navigation chain (`a.b.c.d…` thousands deep) recurses to full
+        // depth; grow the stack rather than overflow the indexer on hostile input.
+        let mut path = crate::index::grow_stack(|| swift_operator_stripped_path(receiver))?;
+        path.push(syntax::identifier_nodes(suffix).last().copied()?);
+        return Some(path);
+    }
+    None
+}
+
 fn swift_call_target_parts(
     target: Node<'_>,
     text: &str,
 ) -> Option<(Vec<String>, Option<CalleeRange>)> {
+    if let Some(parts) = swift_operator_receiver_call_parts(target, text) {
+        return Some(parts);
+    }
     match target.kind() {
         "array_type" | "array_literal" =>
             Some((vec!["Array".to_string()], Some(CalleeRange::of_node(target)))),
@@ -754,22 +847,39 @@ fn swift_call_target_parts(
             if !swift_callable_is_static_path(target) {
                 return None;
             }
-            let mut identifier_nodes = syntax::identifier_nodes(target);
-            if identifier_nodes.len() > 1
-                && identifier_nodes.last().is_some_and(|&node| node_text(node, text) == "init")
-                && identifier_nodes.get(identifier_nodes.len() - 2).is_some_and(|&node| {
-                    let receiver = node_text(node, text);
-                    looks_like_type_name(&receiver) && !super::is_local_qualified_root(&receiver)
-                })
-            {
-                identifier_nodes.pop();
-            }
-            let identifiers =
-                identifier_nodes.iter().map(|&node| node_text(node, text)).collect::<Vec<_>>();
-            let callee_range = identifier_nodes.last().copied().map(CalleeRange::of_node);
-            Some((identifiers, callee_range))
+            swift_normalize_call_path(syntax::identifier_nodes(target), text)
         },
     }
+}
+
+/// Turn an ordered call-path identifier list into `(names, callee range)`, applying the
+/// `Type.init` → construction collapse: a trailing `init` preceded by a type name is dropped so the
+/// caller emits a `Constructs`/type edge to the TYPE, not a `calls_name` to `init`.
+///
+/// Shared by the plain static-path arm and the operator-RHS recovery so both treat `init` the same
+/// way. Extracting it is the fix for #650: the operator path hand-rolled its own identifier
+/// collection and skipped this, so `base + Service.init()` emitted `calls_name → init` instead of
+/// `Constructs → Service`.
+fn swift_normalize_call_path(
+    mut identifier_nodes: Vec<Node<'_>>,
+    text: &str,
+) -> Option<(Vec<String>, Option<CalleeRange>)> {
+    if identifier_nodes.is_empty() {
+        return None;
+    }
+    if identifier_nodes.len() > 1
+        && identifier_nodes.last().is_some_and(|&node| node_text(node, text) == "init")
+        && identifier_nodes.get(identifier_nodes.len() - 2).is_some_and(|&node| {
+            let receiver = node_text(node, text);
+            looks_like_type_name(&receiver) && !super::is_local_qualified_root(&receiver)
+        })
+    {
+        identifier_nodes.pop();
+    }
+    let identifiers =
+        identifier_nodes.iter().map(|&node| node_text(node, text)).collect::<Vec<_>>();
+    let callee_range = identifier_nodes.last().copied().map(CalleeRange::of_node);
+    Some((identifiers, callee_range))
 }
 
 fn swift_callable_is_static_path(root: Node<'_>) -> bool {
@@ -1657,6 +1767,116 @@ super.finish()
             !has(&edges, EdgeKind::CallsName, "key")
                 && !has(&edges, EdgeKind::CallsName, "handlers"),
             "subscripted/dynamic callable must not invent a named outer call: {edges:#?}"
+        );
+    }
+
+    /// tree-sitter-swift binds a call's argument list to the WHOLE binary expression on the
+    /// operator's left — `p + g()` parses as `call_expression(additive_expression(p + g), ())` — so
+    /// the call target is the operator node, not the callee. Every call on the right of a binary
+    /// operator used to be dropped outright (the operator node is not a callable path), losing
+    /// `total + item.price()`, `x == compute()`, `value ?? fallback()` and friends from the graph.
+    /// The callee is the operator expression's rightmost operand.
+    #[test]
+    fn calls_on_the_right_of_a_binary_operator_are_not_dropped() {
+        // A bare call and a call inside an additive expression must BOTH reach the graph.
+        let additive = edges("func f() -> String { return p + g() }");
+        assert!(
+            has(&additive, EdgeKind::CallsName, "g"),
+            "a call on the right of `+` must still be a call: {additive:#?}"
+        );
+
+        // Both operands are calls; the right one used to vanish.
+        let both = edges("func f() -> String { return s.g(1) + s.h(2) }");
+        assert!(has(&both, EdgeKind::CallsName, "g"), "left operand call: {both:#?}");
+        assert!(has(&both, EdgeKind::CallsName, "h"), "right operand call: {both:#?}");
+
+        // The callee range still lands on the callee itself, not on the operator expression.
+        let src = "func f() -> String { return p + résumé() }";
+        let accented = edges(src);
+        let call = accented
+            .iter()
+            .find(|edge| edge.edge_kind == EdgeKind::CallsName && edge.to_name == "résumé")
+            .unwrap_or_else(|| panic!("missing call: {accented:#?}"));
+        assert_eq!(
+            callee_text(call, src),
+            Some("résumé"),
+            "the callee range must cover the callee, not the operator expression"
+        );
+
+        // Chained operators unwrap all the way to the rightmost operand.
+        let chained = edges("func f() -> Int { return a + b + tail() }");
+        assert!(has(&chained, EdgeKind::CallsName, "tail"), "chained operators: {chained:#?}");
+
+        // Nil-coalescing is the same shape.
+        let coalescing = edges("func f() -> Int { return value ?? fallback() }");
+        assert!(
+            has(&coalescing, EdgeKind::CallsName, "fallback"),
+            "nil-coalescing: {coalescing:#?}"
+        );
+
+        // A construction on the right of an operator is still a construction.
+        let constructed = edges("func f() -> Int { return base + Service() }");
+        assert!(
+            has(&constructed, EdgeKind::Constructs, "Service"),
+            "construction: {constructed:#?}"
+        );
+
+        // An EXPLICIT initializer on the right of an operator is a construction too —
+        // `Service.init` must collapse to `Constructs → Service`, never a `calls_name →
+        // init` (the operator path must run the SAME `.init` normalization as a plain
+        // `Service.init()`).
+        let explicit_init = edges("func f() -> Int { return base + Service.init() }");
+        assert!(
+            has(&explicit_init, EdgeKind::Constructs, "Service"),
+            "explicit init on operator RHS constructs the type: {explicit_init:#?}"
+        );
+        assert!(
+            !has(&explicit_init, EdgeKind::CallsName, "init"),
+            "explicit init must not become a call to `init`: {explicit_init:#?}"
+        );
+
+        // A qualified type method on the operator RHS keeps its receiver qualifier.
+        let qualified = edges("func f() -> Int { return total + Factory.make() }");
+        assert!(has(&qualified, EdgeKind::CallsName, "make"), "qualified method: {qualified:#?}");
+
+        // A MULTI-SEGMENT receiver on the operator RHS: tree-sitter nests the operator under an
+        // inner navigation, so the operator is not the direct receiver. These must still be
+        // recovered — unlike the dynamic case, `Module.Client.make()` WITHOUT the operator resolves
+        // fine, so dropping the operator form would be a real gap, not baseline parity.
+        let nested = edges("func f() -> Int { return base + Module.Client.make() }");
+        assert!(has(&nested, EdgeKind::CallsName, "make"), "nested-navigation method: {nested:#?}");
+        let deep = edges("func f() -> Int { return total + config.section.value() }");
+        assert!(has(&deep, EdgeKind::CallsName, "value"), "value-receiver chain: {deep:#?}");
+        // Init normalization survives the nested case too: `Module.Service.init()` constructs.
+        let nested_init = edges("func f() -> Int { return base + Module.Service.init() }");
+        assert!(
+            has(&nested_init, EdgeKind::Constructs, "Service"),
+            "nested init constructs the type: {nested_init:#?}"
+        );
+        assert!(
+            !has(&nested_init, EdgeKind::CallsName, "init"),
+            "nested init must not be a call to `init`: {nested_init:#?}"
+        );
+
+        // A DYNAMIC receiver on the operator RHS (`make().render()`) must behave EXACTLY as it does
+        // WITHOUT the operator: the inner `make()` is emitted, and the outer `.render` on a
+        // dynamic (call/subscript) receiver is dropped. The baseline never emits an outer call on a
+        // non-nameable receiver, so the operator case must match it — not manufacture a bogus
+        // qualifier, and not diverge by emitting an edge the plain form wouldn't. The plain form is
+        // the control. (A vacuous `.all()` over a missing `render` edge would hide exactly this, so
+        // both directions are asserted explicitly.)
+        let dynamic = edges("func f() -> Int { return base + make().render() }");
+        assert!(has(&dynamic, EdgeKind::CallsName, "make"), "inner dynamic call: {dynamic:#?}");
+        assert!(
+            !has(&dynamic, EdgeKind::CallsName, "render"),
+            "an outer call on a dynamic receiver is dropped, same as the non-operator baseline: \
+             {dynamic:#?}"
+        );
+        let control = edges("func f() -> Int { return make().render() }");
+        assert!(has(&control, EdgeKind::CallsName, "make"), "control inner call: {control:#?}");
+        assert!(
+            !has(&control, EdgeKind::CallsName, "render"),
+            "control: the baseline also drops the outer dynamic-receiver call: {control:#?}"
         );
     }
 }

--- a/crates/rag-rat-core/src/index/oracle/lsp/mod.rs
+++ b/crates/rag-rat-core/src/index/oracle/lsp/mod.rs
@@ -18,6 +18,6 @@
 #![allow(dead_code)] // Slice-1 substrate: the maintenance pass wires this in slice 2 (#74).
 
 mod client;
-mod position;
+pub(crate) mod position;
 mod protocol;
 mod resolve;

--- a/crates/rag-rat-core/src/index/oracle/mod.rs
+++ b/crates/rag-rat-core/src/index/oracle/mod.rs
@@ -22,7 +22,7 @@ mod auto_run;
 mod corpus;
 mod join;
 mod library_usage;
-mod lsp;
+pub(crate) mod lsp;
 mod manifest;
 mod report;
 mod run;

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/mod.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/mod.rs
@@ -352,6 +352,12 @@ pub(crate) fn poison_test_config(tag: &str) -> (PathBuf, Config) {
 }
 
 fn source_config(root: PathBuf, language: Language) -> Config {
+    source_config_dirs(root, language, &["src"])
+}
+
+/// `source_config` for a layout that isn't `src/` — SwiftPM puts first-party code under `Sources/`
+/// and its test targets under `Tests/`.
+fn source_config_dirs(root: PathBuf, language: Language, dirs: &[&str]) -> Config {
     Config {
         trackers: Vec::new(),
         papertrail: Default::default(),
@@ -362,8 +368,8 @@ fn source_config(root: PathBuf, language: Language) -> Config {
         targets: vec![ResolvedTarget {
             name: language.as_str().to_string(),
             language,
-            directories: vec![PathBuf::from("src")],
-            include: vec!["src/".to_string()],
+            directories: dirs.iter().map(PathBuf::from).collect(),
+            include: dirs.iter().map(|dir| format!("{dir}/")).collect(),
             exclude: Vec::new(),
             kind: TargetKind::Source,
         }],
@@ -928,5 +934,6 @@ mod reconcile_embeddings;
 mod repo_memory;
 mod repo_registry;
 mod schema_migrations;
+mod swift_corpus;
 mod symbol_search_lookup;
 mod worktree_overlay;

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/swift_corpus.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/swift_corpus.rs
@@ -1,0 +1,352 @@
+//! The SwiftPM corpus (#636): deterministic expectations over a REAL, buildable Swift package.
+//!
+//! The fixture (`tests/fixtures/swift-corpus`) is a two-target SwiftPM package — `Renderer` depends
+//! on `CoreKit` — so cross-MODULE calls genuinely exist. That matters because this file pins two
+//! different things:
+//!
+//! 1. **What the tree-sitter baseline gets right**, deterministically: symbol kinds, containment
+//!    (scope paths), candidate edges and their confidence, and test detection.
+//! 2. **What it honestly CANNOT know** — the cross-module and overloaded calls it must leave
+//!    unresolved rather than guess. Those are the edges the SourceKit-LSP oracle (#637) has to
+//!    upgrade, and pinning them here is what makes that upgrade measurable instead of anecdotal.
+//!
+//! A test that only asserted (1) would let a resolver that CONFIDENTLY GUESSES look like an
+//! improvement. Asserting (2) is what keeps the baseline honest.
+
+use super::*;
+use crate::index::oracle::lsp::position::{LineIndex, LspEncoding};
+
+/// Index the corpus. SwiftPM puts first-party code under `Sources/` and its test targets under
+/// `Tests/`; both are bound so the fixture exercises test detection as well as source extraction.
+fn corpus() -> (PathBuf, IndexDatabase) {
+    let root = fixture_temp_root("swift-corpus");
+    let config = source_config_dirs(root.clone(), Language::Swift, &["Sources", "Tests"]);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    (root, db)
+}
+
+/// Every `(kind, scope_path)` for a symbol name, so an assertion can speak about overloads (two
+/// rows sharing a scope path) as precisely as about unique declarations.
+fn symbols_named(db: &IndexDatabase, name: &str) -> Vec<(String, String)> {
+    let conn = db.storage.connection();
+    let mut stmt = conn
+        .prepare("SELECT kind, scope_path FROM symbols WHERE name = ?1 ORDER BY scope_path")
+        .unwrap();
+    let rows = stmt
+        .query_map([name], |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)))
+        .unwrap();
+    rows.map(Result::unwrap).collect()
+}
+
+/// The `(confidence, resolution)` of every `calls_name` edge with this callee, from the function
+/// named `from`. Edge `from_name` is the QUALIFIED name (`path/to/File.swift::fn`), so the caller
+/// is matched on its trailing segment.
+fn call_states(db: &IndexDatabase, from: &str, to: &str) -> Vec<(String, String)> {
+    let conn = db.storage.connection();
+    let mut stmt = conn
+        .prepare(
+            "SELECT edges.confidence, edges.resolution
+             FROM edges
+             WHERE edges.edge_kind = 'calls_name'
+               AND edges.to_name = ?2
+               AND COALESCE(edges.from_name, '') LIKE '%::' || ?1",
+        )
+        .unwrap();
+    let rows = stmt
+        .query_map(params![from, to], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })
+        .unwrap();
+    rows.map(Result::unwrap).collect()
+}
+
+fn is_test_symbol(db: &IndexDatabase, name: &str) -> bool {
+    db.storage
+        .connection()
+        .query_row("SELECT is_test FROM symbols WHERE name = ?1", [name], |row| {
+            row.get::<_, i64>(0)
+        })
+        .unwrap_or_else(|error| panic!("missing symbol {name}: {error}"))
+        == 1
+}
+
+/// Swift's declaration kinds all reach the index, with the container relationships intact.
+#[test]
+fn swift_corpus_extracts_declarations_and_containment() {
+    let (root, db) = corpus();
+
+    // Nominal kinds, including the Swift-only ones.
+    assert_eq!(symbols_named(&db, "Store"), vec![("actor".into(), "Store".into())]);
+    assert_eq!(symbols_named(&db, "Repository"), vec![("protocol".into(), "Repository".into())]);
+    // An `extension` is its own symbol, named for what it extends — never colliding with the type.
+    assert_eq!(symbols_named(&db, "extension Repository"), vec![(
+        "extension".into(),
+        "extension Repository".into()
+    )]);
+    assert_eq!(symbols_named(&db, "Status"), vec![("enum".into(), "Status".into())]);
+    assert_eq!(symbols_named(&db, "Service"), vec![("class".into(), "Service".into())]);
+    assert_eq!(symbols_named(&db, "Renderer"), vec![("struct".into(), "Renderer".into())]);
+
+    // Containment: members carry their container, and a protocol-extension method carries the
+    // PROTOCOL it extends rather than sitting at file scope.
+    // `Renderer.render` also binds a LOCAL named `cached`, so the name is not unique — the
+    // protocol-extension METHOD is what must carry the protocol as its container.
+    assert!(
+        symbols_named(&db, "cached")
+            .contains(&("function".to_string(), "Repository::cached".to_string())),
+        "protocol-extension method carries the protocol: {:?}",
+        symbols_named(&db, "cached")
+    );
+    assert_eq!(symbols_named(&db, "mapped"), vec![("function".into(), "Store::mapped".into())]);
+    assert_eq!(symbols_named(&db, "idle"), vec![("enum_case".into(), "Status::idle".into())]);
+    assert_eq!(symbols_named(&db, "subscript"), vec![(
+        "function".into(),
+        "Store::subscript".into()
+    )]);
+
+    // OVERLOADS stay independently indexed: two `fetch` declarations under one scope path. A
+    // resolver that collapsed them would have nothing to be wrong about later.
+    assert_eq!(symbols_named(&db, "fetch"), vec![
+        ("function".into(), "Service::fetch".into()),
+        ("function".into(), "Service::fetch".into()),
+    ]);
+
+    // Same bare name, two MODULES: this is the collision the oracle exists to settle.
+    assert_eq!(symbols_named(&db, "load"), vec![
+        ("function".into(), "Cache::load".into()),
+        ("function".into(), "Repository::load".into()),
+        ("function".into(), "Store::load".into()),
+    ]);
+
+    let _ = fs::remove_dir_all(root);
+}
+
+/// Test-target symbols are marked `is_test` and production symbols in the same index are not — the
+/// realistic SwiftPM layout, where tests live under `Tests/`.
+///
+/// This does NOT prove the Swift FRAMEWORK detectors (`XCTestCase` inheritance / `@Test` /
+/// `@Suite`) on its own: `is_test = is_test_path(path) || backend.is_test_symbol(...)`, and every
+/// symbol here sits under `Tests/`, so the path half alone would satisfy these assertions even if
+/// the framework logic were removed. The framework detection that matters when test code lives
+/// OUTSIDE a `Tests/` path (a sidecar `XCTestCase`, an inline `@Test`) is pinned separately by
+/// `parser_tests::swift_test_symbols_are_detected_by_framework_not_only_by_path`, which places
+/// those markers on a `Sources/…` path. What THIS test guards is that a realistic test target —
+/// both frameworks, `test`-prefixed methods and un-prefixed helpers alike — is marked, and that
+/// production code is left alone.
+#[test]
+fn swift_corpus_marks_test_target_symbols_and_leaves_production_alone() {
+    let (root, db) = corpus();
+
+    assert!(is_test_symbol(&db, "StoreTests"), "XCTestCase subclass");
+    assert!(is_test_symbol(&db, "testLoadsSeed"), "XCTest method");
+    assert!(is_test_symbol(&db, "makeItem"), "helper inside an XCTestCase is still test code");
+    assert!(is_test_symbol(&db, "StatusSuite"), "@Suite type");
+    assert!(is_test_symbol(&db, "idleIsNotRunning"), "@Test method");
+    assert!(is_test_symbol(&db, "cachedDefaultsToLoad"), "free @Test function");
+
+    // Production code in the same index is NOT test code.
+    assert!(!is_test_symbol(&db, "Renderer"));
+    assert!(!is_test_symbol(&db, "mapped"));
+
+    let _ = fs::remove_dir_all(root);
+}
+
+/// What the baseline resolves, and — the load-bearing half — what it refuses to.
+#[test]
+fn swift_corpus_pins_the_resolution_baseline_for_the_oracle() {
+    let (root, db) = corpus();
+
+    // RESOLVED, because the syntax carries the answer:
+    // a qualified enum case (`Status.running`) binds by scope path…
+    assert_eq!(call_states(&db, "status", "running"), vec![("Exact".into(), "scope_exact".into())]);
+    // …and the shorthand `.idle` binds by bare name — the one shape that evidences a case.
+    assert_eq!(call_states(&db, "status", "idle"), vec![(
+        "Syntactic".into(),
+        "target_name_fallback".into()
+    )]);
+    // A same-module call with a unique name resolves.
+    assert_eq!(call_states(&db, "plainCall", "résumé"), vec![(
+        "Syntactic".into(),
+        "target_name_fallback".into()
+    )]);
+
+    // UNRESOLVED, because the syntax genuinely does NOT carry the answer. These are the edges
+    // SourceKit-LSP must upgrade in #637 — and a "baseline improvement" that resolves them by
+    // guessing (rather than by compiling) would be a regression in honesty, not a win.
+    //
+    // `render` calls BOTH `store.load(id:)` (CoreKit.Store.load, across the module boundary) and
+    // `cache.load(id:)` (Renderer.Cache.load). Three `load` declarations exist; the receiver types
+    // are the only way to tell them apart, and tree-sitter does not have types.
+    let loads = call_states(&db, "render", "load");
+    assert_eq!(loads.len(), 2, "both `load` call sites are recorded: {loads:?}");
+    assert!(
+        loads
+            .iter()
+            .all(|(confidence, resolution)| confidence == "NameOnly" && resolution == "unresolved"),
+        "cross-module / same-name calls must stay UNRESOLVED, not be guessed: {loads:?}"
+    );
+
+    // Both OVERLOADED `service.fetch(…)` call sites are recorded, and both stay unresolved: only a
+    // type-checker can say which `fetch` each reaches.
+    let fetches = call_states(&db, "described", "fetch");
+    assert_eq!(fetches.len(), 2, "both overload call sites are recorded: {fetches:?}");
+    assert!(
+        fetches.iter().all(|(_, resolution)| resolution == "unresolved"),
+        "an overloaded call cannot be resolved by name: {fetches:?}"
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+/// The call on the right of a binary operator reaches the graph at all.
+///
+/// tree-sitter-swift binds a call's argument list to the whole expression on the operator's left,
+/// so `prefix + résumé()` parses with the OPERATOR as the call's target. The extractor used to
+/// refuse that target and drop the call — silently losing every `total + item.price()` in a Swift
+/// codebase. The corpus is what surfaced it, so the corpus is what pins it.
+#[test]
+fn swift_corpus_keeps_calls_on_the_right_of_an_operator() {
+    let (root, db) = corpus();
+
+    assert_eq!(call_states(&db, "offsetCall", "résumé"), vec![(
+        "Syntactic".into(),
+        "target_name_fallback".into()
+    )]);
+    // The method call at the end of a `+` chain, through a receiver.
+    assert_eq!(call_states(&db, "described", "describe").len(), 1);
+
+    let _ = fs::remove_dir_all(root);
+}
+
+/// UTF-16 ↔ byte position conversion over real non-ASCII source — the semantic-readiness check for
+/// #637, where LSP speaks UTF-16 code units and the index speaks bytes.
+///
+/// `offsetCall`'s line has `"🚀☕"` before the call, so the callee's byte offset and its LSP
+/// `character` offset DIVERGE; `plainCall`'s line is ASCII-only, so they agree. Asserting both is
+/// what proves the fixture actually exercises the conversion rather than merely containing an
+/// emoji.
+#[test]
+fn swift_corpus_converts_utf16_positions_over_non_ascii_source() {
+    let (root, db) = corpus();
+    let source = fs::read_to_string(root.join("Sources/CoreKit/Text.swift")).unwrap();
+    let index = LineIndex::new(source.as_bytes(), LspEncoding::Utf16);
+
+    for (caller, expect_divergence) in [("plainCall", false), ("offsetCall", true)] {
+        let (start, end) = callee_byte_range(&db, caller, "résumé", "calls_name")
+            .unwrap_or_else(|| panic!("no callee range for the {caller} call"));
+        let (start, end) = (start as usize, end as usize);
+
+        // The range covers the callee — the accented identifier, not the operator expression.
+        assert_eq!(&source[start..end], "résumé", "{caller}: callee range");
+
+        // Round-trip: byte → LSP position → byte is the identity.
+        let position = index.position_at_byte(start);
+        assert_eq!(
+            index.byte_at_position(position),
+            Some(start),
+            "{caller}: LSP position must round-trip back to the same byte"
+        );
+
+        // The column in BYTES, for comparison with the UTF-16 `character`.
+        let line_start = source[..start].rfind('\n').map_or(0, |newline| newline + 1);
+        let byte_column = start - line_start;
+        let character = position.character as usize;
+        if expect_divergence {
+            assert!(
+                character < byte_column,
+                "{caller}: the emoji/accents before the call must make the UTF-16 character \
+                 offset ({character}) smaller than the byte column ({byte_column}) — otherwise \
+                 this fixture is not exercising the conversion at all"
+            );
+        } else {
+            assert_eq!(
+                character, byte_column,
+                "{caller}: an ASCII-only line must have equal byte and UTF-16 offsets (the \
+                 control)"
+            );
+        }
+    }
+
+    let _ = fs::remove_dir_all(root);
+}
+
+/// Coverage floors. Deliberately floors, not exact counts: they catch a broken parse or a collapsed
+/// extractor (the failure mode that matters) without turning every fixture edit into a
+/// golden-number update. The RESOLUTION baseline above is where exactness lives.
+#[test]
+fn swift_corpus_meets_its_coverage_floors() {
+    let (root, db) = corpus();
+    let conn = db.storage.connection();
+
+    let count = |sql: &str| conn.query_row(sql, [], |row| row.get::<_, i64>(0)).unwrap();
+
+    let files: i64 = count("SELECT COUNT(*) FROM files WHERE language = 'swift'");
+    assert_eq!(files, 6, "every Swift file in the package is indexed");
+
+    let symbols: i64 = count("SELECT COUNT(*) FROM symbols");
+    assert!(symbols >= 50, "the corpus must carry real symbol mass, got {symbols}");
+
+    let calls: i64 = count("SELECT COUNT(*) FROM edges WHERE edge_kind = 'calls_name'");
+    assert!(calls >= 15, "the corpus must carry real call mass, got {calls}");
+
+    // Parse coverage: a file that failed to parse yields NO symbols, and a silently-unparsed file
+    // would make every other assertion here vacuous. (`Package.swift` is not indexed — it is not
+    // under a bound directory — so every indexed Swift file is real source.)
+    let symbolless: i64 = count(
+        "SELECT COUNT(*) FROM files
+         WHERE language = 'swift'
+           AND id NOT IN (SELECT DISTINCT file_id FROM symbols)",
+    );
+    assert_eq!(symbolless, 0, "every indexed Swift file must parse into symbols");
+
+    let _ = fs::remove_dir_all(root);
+}
+
+/// The corpus is a REAL package, so it must actually build — the SourceKit-LSP oracle (#637)
+/// resolves against a built module graph, and a corpus that only parses would send phase 3 chasing
+/// its own fixture.
+///
+/// OPT-IN, because a cold SwiftPM build costs minutes and no CI runner is required to carry a Swift
+/// toolchain: set `RAG_RAT_SWIFT_BUILD=1`. What it must NEVER do is report success it did not earn
+/// — so the default path prints a visible SKIP, and with the flag set an absent toolchain is a
+/// FAILURE, not a shrug. `swift --version` is echoed as the toolchain provenance for the run.
+#[test]
+fn swift_corpus_builds_with_swiftpm() {
+    let required = std::env::var("RAG_RAT_SWIFT_BUILD").is_ok_and(|value| value == "1");
+    let swift = Command::new("swift").arg("--version").output();
+    if !required {
+        eprintln!(
+            "SKIP swift_corpus_builds_with_swiftpm: set RAG_RAT_SWIFT_BUILD=1 to build the corpus \
+             with SwiftPM (a cold build takes minutes and needs a Swift toolchain). The corpus's \
+             INDEXING assertions run unconditionally and need no toolchain."
+        );
+        return;
+    }
+    let version = match swift {
+        Ok(output) if output.status.success() =>
+            String::from_utf8_lossy(&output.stdout).to_string(),
+        _ => panic!(
+            "RAG_RAT_SWIFT_BUILD=1 but no working `swift` on PATH — refusing to report a Swift \
+             build as passing without a toolchain. Install one (swiftly / swift.org) or unset the \
+             flag."
+        ),
+    };
+    eprintln!("swift toolchain provenance: {}", version.lines().next().unwrap_or("unknown"));
+
+    let root = fixture_temp_root("swift-corpus");
+    // `--build-tests` so the TEST target compiles too. Plain `swift build` skips it, which would
+    // let a broken `CoreKitTests` — the half of the fixture that exercises XCTest and
+    // swift-testing — sail through a check whose whole purpose is "this package really builds".
+    let build = Command::new("swift")
+        .args(["build", "--build-tests", "--package-path", &root.to_string_lossy()])
+        .output()
+        .expect("run swift build");
+    assert!(
+        build.status.success(),
+        "the corpus must build with SwiftPM:\n--- stdout ---\n{}\n--- stderr ---\n{}",
+        String::from_utf8_lossy(&build.stdout),
+        String::from_utf8_lossy(&build.stderr)
+    );
+
+    let _ = fs::remove_dir_all(root);
+}

--- a/docs/oracle.md
+++ b/docs/oracle.md
@@ -96,3 +96,58 @@ drives it:
   gate fails the PR.
 - **heavy tier** (release / dispatch): the big corpora on the self-hosted box, converted to BMF
   (`tools/oracle-report-bmf.py`) and pushed to Bencher as the headline resolution series.
+
+## The SwiftPM corpus (Swift phase 2)
+
+`tests/fixtures/swift-corpus` is a real, buildable two-target SwiftPM package (`Renderer` depends on
+`CoreKit`), not a pile of loose `.swift` files. It exists so Swift resolution can be *measured*
+rather than asserted: SourceKit-LSP resolves against a **built module graph**, so a fixture that only
+parses would send the semantic work chasing itself.
+
+It is deliberately full of things a name-only resolver cannot get right:
+
+- **cross-module calls** — `Renderer.render` calls `CoreKit.Store.load(id:)`, while
+  `Renderer.Cache.load(id:)` shares the bare name;
+- **overloads** — `Service.fetch(_: Int)` / `Service.fetch(_: String)` differ only by parameter type;
+- **non-ASCII source** — `Text.swift` puts `"🚀☕"` before a call so the callee's byte offset and its
+  LSP UTF-16 `character` offset diverge (an emoji is 2 UTF-16 units, 4 bytes), with an ASCII-only
+  call as the control;
+- **both test frameworks** — XCTest (`XCTestCase` inheritance) and swift-testing (`@Test` / `@Suite`).
+
+`crates/rag-rat-core/src/index/schema_bootstrap_tests/swift_corpus.rs` pins two things, and the
+second is the load-bearing one:
+
+1. what the tree-sitter baseline **gets right** — symbol kinds, containment, edge confidence, test
+   detection;
+2. what it must **leave unresolved** rather than guess — the cross-module and overloaded calls. These
+   are exactly the edges the SourceKit-LSP oracle has to upgrade, so a "resolver" that improved the
+   numbers by guessing would fail this suite instead of looking like progress.
+
+### Running it
+
+The indexing assertions need **no toolchain** and run in the normal suite:
+
+```bash
+cargo nextest run -p rag-rat-core -E 'test(swift_corpus)'
+```
+
+Building the package is **opt-in** — a cold SwiftPM build costs minutes, and no CI runner is required
+to carry a Swift toolchain:
+
+```bash
+RAG_RAT_SWIFT_BUILD=1 cargo nextest run -p rag-rat-core swift_corpus_builds
+# or directly:
+swift build --build-tests --package-path tests/fixtures/swift-corpus
+swift test  --package-path tests/fixtures/swift-corpus
+```
+
+Without the flag the build test prints a visible `SKIP`; **with** the flag and no toolchain it
+**fails** rather than passing quietly — a Swift build is never reported as green without a compiler
+behind it. The test echoes `swift --version` as the toolchain provenance for the run.
+
+Verified on **Swift 6.3.3** (`swift-6.3.3-RELEASE`, x86_64 Linux, installed via `swiftly`);
+`sourcekit-lsp` ships inside the same toolchain, which is what the next phase consumes.
+
+The corpus is intentionally **not** in `tools/oracle-corpora.toml` yet: those entries pin an external
+repo *and a SCIP tool*, and there is no Swift oracle tool to run against it until the SourceKit-LSP
+backend lands.

--- a/tests/fixtures/swift-corpus/Package.swift
+++ b/tests/fixtures/swift-corpus/Package.swift
@@ -1,0 +1,15 @@
+// swift-tools-version:6.0
+// The SwiftPM corpus (#636): a real, buildable package — not loose .swift files — because the
+// SourceKit-LSP oracle (#637) resolves against a BUILT module graph. `Renderer` depends on
+// `CoreKit`, so cross-MODULE calls exist for the oracle to resolve and for the tree-sitter baseline
+// to (correctly) leave unresolved.
+import PackageDescription
+
+let package = Package(
+    name: "SwiftCorpus",
+    targets: [
+        .target(name: "CoreKit"),
+        .target(name: "Renderer", dependencies: ["CoreKit"]),
+        .testTarget(name: "CoreKitTests", dependencies: ["CoreKit"]),
+    ]
+)

--- a/tests/fixtures/swift-corpus/Sources/CoreKit/Models.swift
+++ b/tests/fixtures/swift-corpus/Sources/CoreKit/Models.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+/// A protocol with an associated type and an async requirement, plus a protocol EXTENSION whose
+/// default method calls back into the requirement — the shape that gives extension members a
+/// container scope path (`Repository::cached`) rather than a bare one.
+public protocol Repository: Sendable {
+    associatedtype Item: Sendable
+
+    func load(id: Int) async throws -> Item
+}
+
+extension Repository {
+    public func cached(id: Int) async throws -> Item {
+        try await load(id: id)
+    }
+}
+
+public enum Status: Sendable, Equatable {
+    case idle
+    case failed(String)
+    case running
+}
+
+public struct Item: Sendable, Equatable {
+    public let id: Int
+    public let title: String
+
+    public init(id: Int, title: String) {
+        self.id = id
+        self.title = title
+    }
+}
+
+public class BaseService {
+    public init() {}
+
+    public func describe() -> String {
+        "base"
+    }
+}
+
+/// Inheritance plus OVERLOADS: `fetch(_:)` differs only by parameter type, so a resolver working
+/// from names alone cannot say which one a `service.fetch(…)` call reaches. That is the point of
+/// the fixture — the tree-sitter baseline must not pretend to know.
+public final class Service: BaseService {
+    public func fetch(_ id: Int) -> Item {
+        Item(id: id, title: "by-id")
+    }
+
+    public func fetch(_ name: String) -> Item {
+        Item(id: 0, title: name)
+    }
+
+    public override func describe() -> String {
+        "service"
+    }
+}

--- a/tests/fixtures/swift-corpus/Sources/CoreKit/Store.swift
+++ b/tests/fixtures/swift-corpus/Sources/CoreKit/Store.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// An actor (a Swift-only nominal kind), generic over its element, conforming to `Repository`.
+/// Its `load(id:)` shares a bare name with `Renderer.Cache.load(id:)` in the OTHER module — the
+/// collision a name-only resolver cannot settle.
+public actor Store<Element: Sendable>: Repository {
+    public typealias Item = Element
+
+    private var elements: [Element]
+
+    public var count: Int {
+        elements.count
+    }
+
+    public init(seed: Element) {
+        self.elements = [seed]
+    }
+
+    public func load(id: Int) async throws -> Element {
+        elements[id]
+    }
+
+    /// Generic method + a closure parameter, called with a TRAILING closure from `Renderer`.
+    public func mapped<Output>(_ transform: (Element) -> Output) -> [Output] {
+        elements.map(transform)
+    }
+
+    public func append(_ element: Element) {
+        elements.append(element)
+    }
+
+    public subscript(index: Int) -> Element {
+        elements[index]
+    }
+}

--- a/tests/fixtures/swift-corpus/Sources/CoreKit/Text.swift
+++ b/tests/fixtures/swift-corpus/Sources/CoreKit/Text.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// Non-ASCII source. LSP speaks UTF-16 code units while the index speaks BYTES, and the two diverge
+/// here on purpose:
+///
+///   - `é` is 2 bytes / 1 UTF-16 unit,
+///   - `☕` is 3 bytes / 1 UTF-16 unit,
+///   - `🚀` is 4 bytes / **2** UTF-16 units (a surrogate pair),
+///   - `データ` is 3 bytes per character / 1 unit each.
+///
+/// So a callee that sits AFTER these on its line has a byte offset that is not its LSP `character`
+/// offset, and any position-conversion bug shows up as an off-by-N instead of hiding. `résumé` is an
+/// accented IDENTIFIER, so the symbol's own name spans multi-byte text too.
+public let café = "naïve 🚀 データ ☕"
+
+public func résumé() -> String {
+    café.uppercased()
+}
+
+/// The call to `résumé()` is preceded on its line by ASCII only, so its byte offset and character
+/// offset agree — the control.
+public func plainCall() -> String {
+    return résumé()
+}
+
+/// The call to `résumé()` is preceded on its line by `"🚀☕"`, so its byte offset and its UTF-16
+/// character offset DIVERGE — the case that catches a byte-vs-UTF-16 mixup.
+public func offsetCall() -> String {
+    let prefix = "🚀☕"; return prefix + résumé()
+}

--- a/tests/fixtures/swift-corpus/Sources/Renderer/Cache.swift
+++ b/tests/fixtures/swift-corpus/Sources/Renderer/Cache.swift
@@ -1,0 +1,18 @@
+import CoreKit
+
+/// Declares `load(id:)` — the SAME bare name as `CoreKit.Store.load(id:)`, in a DIFFERENT module.
+/// This is the collision the corpus exists to pin: a resolver working from names alone sees two
+/// candidates for `store.load(id:)` in `Renderer.render` and has no honest way to choose. The
+/// tree-sitter baseline must therefore leave that call unresolved; SourceKit-LSP (#637) must bind it
+/// to `CoreKit.Store.load`.
+public struct Cache {
+    private var items: [Int: Item]
+
+    public init(items: [Int: Item] = [:]) {
+        self.items = items
+    }
+
+    public func load(id: Int) -> Item? {
+        items[id]
+    }
+}

--- a/tests/fixtures/swift-corpus/Sources/Renderer/Renderer.swift
+++ b/tests/fixtures/swift-corpus/Sources/Renderer/Renderer.swift
@@ -1,0 +1,43 @@
+import CoreKit
+
+public struct Renderer {
+    private let store: Store<Item>
+    private let cache: Cache
+
+    public init(store: Store<Item>, cache: Cache) {
+        self.store = store
+        self.cache = cache
+    }
+
+    /// The cross-MODULE call. `store.load(id:)` is declared in CoreKit; `Cache.load(id:)` in THIS
+    /// module shares its bare name. Optional chaining (`?.title`) on the cache result keeps the two
+    /// call shapes distinct in the AST.
+    public func render(id: Int) async throws -> String {
+        let item = try await store.load(id: id)
+        let cached = cache.load(id: id)?.title
+        return "\(item.title) \(cached ?? "-")"
+    }
+
+    /// A generic cross-module method reached through a TRAILING closure.
+    public func titles() async -> [String] {
+        await store.mapped { element in
+            element.title
+        }
+    }
+
+    /// Enum cases across the module boundary, in both the qualified (`Status.running`) and the
+    /// shorthand (`.idle`) shape — only the shorthand is bindable by bare name.
+    public func status(for item: Item?) -> Status {
+        guard item != nil else {
+            return .idle
+        }
+        return Status.running
+    }
+
+    /// OVERLOADED cross-module calls: which `fetch` each reaches is a type question, not a name
+    /// question.
+    public func described() -> String {
+        let service = Service()
+        return service.fetch(1).title + service.fetch("name").title + service.describe()
+    }
+}

--- a/tests/fixtures/swift-corpus/Tests/CoreKitTests/StoreTests.swift
+++ b/tests/fixtures/swift-corpus/Tests/CoreKitTests/StoreTests.swift
@@ -1,0 +1,31 @@
+import Testing
+import XCTest
+
+@testable import CoreKit
+
+/// XCTest: recognized by inheriting `XCTestCase`. `makeItem` is a HELPER, not a `test*` method — it
+/// is still test scaffolding, and must not be indexed as production source.
+final class StoreTests: XCTestCase {
+    func testLoadsSeed() async throws {
+        let store = Store(seed: Item(id: 1, title: "seed"))
+        let item = try await store.load(id: 0)
+        XCTAssertEqual(item.title, "seed")
+    }
+
+    func makeItem() -> Item {
+        Item(id: 2, title: "helper")
+    }
+}
+
+/// swift-testing: recognized by the `@Test` / `@Suite` ATTRIBUTE rather than by inheritance.
+@Suite struct StatusSuite {
+    @Test func idleIsNotRunning() {
+        #expect(Status.idle != Status.running)
+    }
+}
+
+@Test func cachedDefaultsToLoad() async throws {
+    let store = Store(seed: Item(id: 7, title: "cached"))
+    let item = try await store.cached(id: 0)
+    #expect(item.title == "cached")
+}


### PR DESCRIPTION
## Summary

Adds `tests/fixtures/swift-corpus` — a real, **buildable** two-target SwiftPM package (`Renderer` depends on `CoreKit`), not loose `.swift` files. SourceKit-LSP (#637) resolves against a *built module graph*, so a fixture that only parses would send the semantic phase chasing itself.

The corpus is deliberately full of what a name-only resolver cannot get right:

- **cross-module calls** — `Renderer.render` calls `CoreKit.Store.load(id:)`, while `Renderer.Cache.load(id:)` shares the bare name;
- **overloads** — `Service.fetch(_: Int)` / `fetch(_: String)` differ only by parameter type;
- **non-ASCII** — an emoji before a call makes the callee's byte offset and its LSP UTF-16 `character` offset diverge, with an ASCII-only call as the control;
- **both test frameworks** — XCTest (`XCTestCase`) and swift-testing (`@Test` / `@Suite`).

`swift_corpus.rs` pins two things, and the second is the load-bearing one:

1. what the tree-sitter baseline **gets right** — kinds, containment, edge confidence, test detection;
2. what it must **leave unresolved** rather than guess — the cross-module and overloaded calls.

Those are exactly the edges the oracle has to upgrade, so a "resolver" that improved the numbers by *guessing* fails this suite instead of looking like progress.

## The bug the corpus found

tree-sitter-swift binds a call's argument list to the whole expression on the operator's left:

```
p + g()   →   call_expression( additive_expression(p + g), call_suffix(()) )
```

The call's **target is the operator node**, not the callee. The extractor refused that target and dropped the call outright — losing **every call on the right of a binary operator**. Not an edge case: `total + item.price()`, `x == compute()`, `value ?? fallback()`. The method-call shape is worse, since the operator hides inside the navigation's receiver: `navigation(additive(total + item), price)`.

Swift evaluates `p + g()` as `p + (g())`, so the callee is the operator expression's **rightmost operand**, and a method call's receiver is that operand rather than the whole expression. On the corpus alone this recovers 3 dropped calls (**160 → 163** edges), including *both* overload call sites and the accented callee.

## Toolchain

The indexing assertions need **no toolchain** and run in the normal suite. Building the package is opt-in (`RAG_RAT_SWIFT_BUILD=1`) because a cold SwiftPM build costs minutes — but absence is never silent: the default prints a visible `SKIP`, and **with** the flag and no toolchain it **fails** rather than passing quietly. The check uses `--build-tests` so the test target compiles too.

Verified on **Swift 6.3.3**; `sourcekit-lsp` ships in the same toolchain, which is what #637 consumes.

The corpus is intentionally **not** in `tools/oracle-corpora.toml` yet — those entries pin an external repo *and a SCIP tool*, and there is no Swift oracle tool until the SourceKit-LSP backend lands.

## Validation

- `cargo nextest run --workspace --no-default-features --locked` — 2,764 passed
- `cargo clippy --workspace --all-targets --no-default-features -- -D warnings` (+ both `--features eval` variants)
- `cargo +nightly fmt --all --check`
- `RAG_RAT_SWIFT_BUILD=1 cargo nextest run -p rag-rat-core swift_corpus_builds` — builds + compiles the test target on Swift 6.3.3
- `swift test --package-path tests/fixtures/swift-corpus` — 1 XCTest + 2 swift-testing tests pass

Closes #636.