### PR TITLE
chore: release v0.19.0

### DIFF
--- a/.agents/skills/init-rag-rat/SKILL.md
+++ b/.agents/skills/init-rag-rat/SKILL.md
@@ -32,7 +32,7 @@ hand-write a config blind, and let a real config load re-check it before indexin
    do **not** use `@latest`, and **don't blindly trust an on-`PATH` `rag-rat`**:
    - If `rag-rat` is on `PATH`, check `rag-rat --version` and use it **only if it matches** the
      plugin/MCP version — a stale global install would build the index with the wrong binary.
-   - Otherwise (or on a version mismatch) use `npx -y @rag-rat/bin@0.18.0 …` — the plugin pins
+   - Otherwise (or on a version mismatch) use `npx -y @rag-rat/bin@0.19.0 …` — the plugin pins
      `@rag-rat/bin` to its own version and caches the binary privately, so this is the
      version-matched CLI; `npx` runs it in the current directory.
 

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "rag-rat",
       "description": "Local repo-intelligence index + MCP server: semantic search, symbol/graph navigation, impact-surface preflight, git + GitHub papertrail, and a source-anchored memory graph.",
-      "version": "0.18.0",
+      "version": "0.19.0",
       "source": "./plugin",
       "category": "developer-tools",
       "license": "MIT",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-core-v0.18.0...rag-rat-core-v0.19.0) - 2026-07-16
+
+### Added
+
+- *(index)* scoped reconcile over an explicit path set (index --paths) ([#687](https://github.com/cq27-dev/rag-rat/pull/687))
+- *(oplog)* content-key crypto primitives — content keys, key_id, X25519 sealed-box wrap (C4.1) ([#709](https://github.com/cq27-dev/rag-rat/pull/709))
+- *(evals)* regenerate memory-compaction verify-packs corpus + add a committed generator ([#695](https://github.com/cq27-dev/rag-rat/pull/695)) ([#700](https://github.com/cq27-dev/rag-rat/pull/700))
+- *(oplog)* defer the /3 content-ingest refold + exclude local authoring from the remote budget ([#699](https://github.com/cq27-dev/rag-rat/pull/699))
+- *(memory)* author the live memory path onto owner-bound /2//3 streams ([#681](https://github.com/cq27-dev/rag-rat/pull/681))
+- *(watch)* surface silently-dropped filesystem watches in index_status ([#670](https://github.com/cq27-dev/rag-rat/pull/670))
+- *(account)* add the in-tx owner-stream ownership ensure seam ([#677](https://github.com/cq27-dev/rag-rat/pull/677))
+- *(account)* add the /3 local-content authoring seam + accepted→memory projection ([#668](https://github.com/cq27-dev/rag-rat/pull/668))
+- *(papertrail)* native GitLab provider — namespaced ids, parallel list legs, events comment lane ([#654](https://github.com/cq27-dev/rag-rat/pull/654))
+- *(account)* mint the store's local account (C3.4a bootstrap) ([#666](https://github.com/cq27-dev/rag-rat/pull/666))
+- *(account)* wire the /3 acceptance refold into ingest and the account fold ([#653](https://github.com/cq27-dev/rag-rat/pull/653))
+- *(swift)* add the SwiftPM corpus, and fix the calls it exposed ([#650](https://github.com/cq27-dev/rag-rat/pull/650))
+- *(papertrail)* automatic sync orchestration — watcher deadline, hook trigger, coalesced single-flight ([#646](https://github.com/cq27-dev/rag-rat/pull/646))
+
+### Fixed
+
+- Android/Termux support — flock via libc, static libc++ in the prebuilt ([#710](https://github.com/cq27-dev/rag-rat/pull/710))
+- *(dream)* cut divergence false positives — memory-id cross-refs, verbatim, documented removals ([#686](https://github.com/cq27-dev/rag-rat/pull/686))
+- *(fts)* detect FTS5 shadow corruption at the query layer and self-heal from durable sources ([#675](https://github.com/cq27-dev/rag-rat/pull/675))
+- *(account)* guard the ancestry contiguity check against a u64::MAX seq ([#657](https://github.com/cq27-dev/rag-rat/pull/657))
+- *(swift)* recover force-unwrapped receiver method calls ([#656](https://github.com/cq27-dev/rag-rat/pull/656))
+
+### Other
+
+- *(memory)* pin the read path unchanged under /3 + mark the foreign read projection phase-D ([#693](https://github.com/cq27-dev/rag-rat/pull/693))
+- *(graph)* index-seed the remaining edges-view readers — grep_augment + impact_surface ([#692](https://github.com/cq27-dev/rag-rat/pull/692)) ([#694](https://github.com/cq27-dev/rag-rat/pull/694))
+- *(graph)* seed find_callers/trace_callees on indexed edge id columns ([#682](https://github.com/cq27-dev/rag-rat/pull/682)) ([#684](https://github.com/cq27-dev/rag-rat/pull/684))
+- neutral wording for the sync feature in repo_identity docs ([#674](https://github.com/cq27-dev/rag-rat/pull/674))
+- split config.md into per-topic pages under docs/config/ ([#669](https://github.com/cq27-dev/rag-rat/pull/669))
+
 ## [0.18.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-core-v0.17.0...rag-rat-core-v0.18.0) - 2026-07-14
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3551,7 +3551,7 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rag-rat"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3577,7 +3577,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-core"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "chacha20poly1305",
@@ -3632,7 +3632,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-mcp"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "3"
 # and the internal path deps below pin the same literal, so the three crates always publish in
 # lockstep. Bump this one line (and the two internal-dep `version`s under workspace.dependencies)
 # to release.
-version = "0.18.0"
+version = "0.19.0"
 authors = ["Kristaps Karlsons"]
 edition = "2024"
 # Bundled SQLite (rusqlite `bundled` -> libsqlite3-sys 0.38.1) compiles a build script that uses the
@@ -28,8 +28,8 @@ categories = ["command-line-utilities", "development-tools"]
 # Internal crates — declared once here so the version requirement is set in lockstep with
 # [workspace.package].version above. Members reference these via `{ workspace = true }` and add
 # their own feature toggles at the use site.
-rag-rat-core = { version = "0.18.0", path = "crates/rag-rat-core", default-features = false }
-rag-rat-mcp = { version = "0.18.0", path = "crates/rag-rat-mcp", default-features = false }
+rag-rat-core = { version = "0.19.0", path = "crates/rag-rat-core", default-features = false }
+rag-rat-mcp = { version = "0.19.0", path = "crates/rag-rat-mcp", default-features = false }
 anyhow = "1.0"
 # ed25519 device-identity signing for the op-log's signed entry envelope (§C4 layer-1). Default
 # features (incl. `zeroize`, which zeroizes a `SigningKey`'s seed on drop) are kept; the `rand_core`

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "rag-rat",
   "displayName": "rag-rat",
   "description": "Local repo-intelligence index + MCP server: semantic search, symbol/graph navigation, impact-surface preflight, git + GitHub papertrail, and a source-anchored memory graph.",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "author": { "name": "Kristaps Karlsons" },
   "homepage": "https://github.com/cq27-dev/rag-rat",
   "repository": "https://github.com/cq27-dev/rag-rat",
@@ -11,7 +11,7 @@
   "mcpServers": {
     "rag-rat": {
       "command": "npx",
-      "args": ["-y", "@rag-rat/bin@0.18.0", "mcp"]
+      "args": ["-y", "@rag-rat/bin@0.19.0", "mcp"]
     }
   }
 }

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rag-rat",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "Local repo-intelligence index + MCP server: semantic search, symbol/graph navigation, impact-surface preflight, git + GitHub papertrail, and a source-anchored memory graph.",
   "author": { "name": "Kristaps Karlsons", "url": "https://github.com/cq27-dev/rag-rat" },
   "homepage": "https://github.com/cq27-dev/rag-rat",

--- a/plugin/.mcp.json
+++ b/plugin/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "rag-rat": {
       "command": "npx",
-      "args": ["-y", "@rag-rat/bin@0.18.0", "mcp"]
+      "args": ["-y", "@rag-rat/bin@0.19.0", "mcp"]
     }
   }
 }

--- a/plugin/skills/init-rag-rat/SKILL.md
+++ b/plugin/skills/init-rag-rat/SKILL.md
@@ -32,7 +32,7 @@ hand-write a config blind, and let a real config load re-check it before indexin
    do **not** use `@latest`, and **don't blindly trust an on-`PATH` `rag-rat`**:
    - If `rag-rat` is on `PATH`, check `rag-rat --version` and use it **only if it matches** the
      plugin/MCP version — a stale global install would build the index with the wrong binary.
-   - Otherwise (or on a version mismatch) use `npx -y @rag-rat/bin@0.18.0 …` — the plugin pins
+   - Otherwise (or on a version mismatch) use `npx -y @rag-rat/bin@0.19.0 …` — the plugin pins
      `@rag-rat/bin` to its own version and caches the binary privately, so this is the
      version-matched CLI; `npx` runs it in the current directory.
 


### PR DESCRIPTION



## 🤖 New release

* `rag-rat-core`: 0.18.0 -> 0.19.0 (⚠ API breaking changes)
* `rag-rat-mcp`: 0.18.0 -> 0.19.0 (✓ API compatible changes)
* `rag-rat`: 0.18.0 -> 0.19.0

### ⚠ `rag-rat-core` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field IndexStatus.watch_placement_failures in /tmp/.tmpZCol9U/rag-rat/crates/rag-rat-core/src/index/mod.rs:267
  field IndexStatus.watch_placement_failures in /tmp/.tmpZCol9U/rag-rat/crates/rag-rat-core/src/index/mod.rs:267
  field MirrorBindingReport.probe_not_modified in /tmp/.tmpZCol9U/rag-rat/crates/rag-rat-core/src/index/papertrail/mirror.rs:123
  field HealIndexReport.fts_healed in /tmp/.tmpZCol9U/rag-rat/crates/rag-rat-core/src/index/mod.rs:294
  field HealIndexReport.fts_deferred in /tmp/.tmpZCol9U/rag-rat/crates/rag-rat-core/src/index/mod.rs:299
  field CommentsPage.frontier in /tmp/.tmpZCol9U/rag-rat/crates/rag-rat-core/src/index/papertrail/mod.rs:405

--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant IndexMode::Discover 1 -> 2 in /tmp/.tmpZCol9U/rag-rat/crates/rag-rat-core/src/index/mod.rs:214
  variant IndexMode::Full 2 -> 3 in /tmp/.tmpZCol9U/rag-rat/crates/rag-rat-core/src/index/mod.rs:215

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_added.ron

Failed in:
  variant IndexMode:Paths in /tmp/.tmpZCol9U/rag-rat/crates/rag-rat-core/src/index/mod.rs:213
  variant ConfigError:PapertrailIntervalZero in /tmp/.tmpZCol9U/rag-rat/crates/rag-rat-core/src/config/mod.rs:169
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `rag-rat-core`

<blockquote>

## [0.19.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-core-v0.18.0...rag-rat-core-v0.19.0) - 2026-07-16

### Added

- *(index)* scoped reconcile over an explicit path set (index --paths) ([#687](https://github.com/cq27-dev/rag-rat/pull/687))
- *(oplog)* content-key crypto primitives — content keys, key_id, X25519 sealed-box wrap (C4.1) ([#709](https://github.com/cq27-dev/rag-rat/pull/709))
- *(evals)* regenerate memory-compaction verify-packs corpus + add a committed generator ([#695](https://github.com/cq27-dev/rag-rat/pull/695)) ([#700](https://github.com/cq27-dev/rag-rat/pull/700))
- *(oplog)* defer the /3 content-ingest refold + exclude local authoring from the remote budget ([#699](https://github.com/cq27-dev/rag-rat/pull/699))
- *(memory)* author the live memory path onto owner-bound /2//3 streams ([#681](https://github.com/cq27-dev/rag-rat/pull/681))
- *(watch)* surface silently-dropped filesystem watches in index_status ([#670](https://github.com/cq27-dev/rag-rat/pull/670))
- *(account)* add the in-tx owner-stream ownership ensure seam ([#677](https://github.com/cq27-dev/rag-rat/pull/677))
- *(account)* add the /3 local-content authoring seam + accepted→memory projection ([#668](https://github.com/cq27-dev/rag-rat/pull/668))
- *(papertrail)* native GitLab provider — namespaced ids, parallel list legs, events comment lane ([#654](https://github.com/cq27-dev/rag-rat/pull/654))
- *(account)* mint the store's local account (C3.4a bootstrap) ([#666](https://github.com/cq27-dev/rag-rat/pull/666))
- *(account)* wire the /3 acceptance refold into ingest and the account fold ([#653](https://github.com/cq27-dev/rag-rat/pull/653))
- *(swift)* add the SwiftPM corpus, and fix the calls it exposed ([#650](https://github.com/cq27-dev/rag-rat/pull/650))
- *(papertrail)* automatic sync orchestration — watcher deadline, hook trigger, coalesced single-flight ([#646](https://github.com/cq27-dev/rag-rat/pull/646))

### Fixed

- Android/Termux support — flock via libc, static libc++ in the prebuilt ([#710](https://github.com/cq27-dev/rag-rat/pull/710))
- *(dream)* cut divergence false positives — memory-id cross-refs, verbatim, documented removals ([#686](https://github.com/cq27-dev/rag-rat/pull/686))
- *(fts)* detect FTS5 shadow corruption at the query layer and self-heal from durable sources ([#675](https://github.com/cq27-dev/rag-rat/pull/675))
- *(account)* guard the ancestry contiguity check against a u64::MAX seq ([#657](https://github.com/cq27-dev/rag-rat/pull/657))
- *(swift)* recover force-unwrapped receiver method calls ([#656](https://github.com/cq27-dev/rag-rat/pull/656))

### Other

- *(memory)* pin the read path unchanged under /3 + mark the foreign read projection phase-D ([#693](https://github.com/cq27-dev/rag-rat/pull/693))
- *(graph)* index-seed the remaining edges-view readers — grep_augment + impact_surface ([#692](https://github.com/cq27-dev/rag-rat/pull/692)) ([#694](https://github.com/cq27-dev/rag-rat/pull/694))
- *(graph)* seed find_callers/trace_callees on indexed edge id columns ([#682](https://github.com/cq27-dev/rag-rat/pull/682)) ([#684](https://github.com/cq27-dev/rag-rat/pull/684))
- neutral wording for the sync feature in repo_identity docs ([#674](https://github.com/cq27-dev/rag-rat/pull/674))
- split config.md into per-topic pages under docs/config/ ([#669](https://github.com/cq27-dev/rag-rat/pull/669))
</blockquote>

## `rag-rat-mcp`

<blockquote>

## [0.19.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-core-v0.18.0...rag-rat-core-v0.19.0) - 2026-07-16

### Added

- *(index)* scoped reconcile over an explicit path set (index --paths) ([#687](https://github.com/cq27-dev/rag-rat/pull/687))
- *(oplog)* content-key crypto primitives — content keys, key_id, X25519 sealed-box wrap (C4.1) ([#709](https://github.com/cq27-dev/rag-rat/pull/709))
- *(evals)* regenerate memory-compaction verify-packs corpus + add a committed generator ([#695](https://github.com/cq27-dev/rag-rat/pull/695)) ([#700](https://github.com/cq27-dev/rag-rat/pull/700))
- *(oplog)* defer the /3 content-ingest refold + exclude local authoring from the remote budget ([#699](https://github.com/cq27-dev/rag-rat/pull/699))
- *(memory)* author the live memory path onto owner-bound /2//3 streams ([#681](https://github.com/cq27-dev/rag-rat/pull/681))
- *(watch)* surface silently-dropped filesystem watches in index_status ([#670](https://github.com/cq27-dev/rag-rat/pull/670))
- *(account)* add the in-tx owner-stream ownership ensure seam ([#677](https://github.com/cq27-dev/rag-rat/pull/677))
- *(account)* add the /3 local-content authoring seam + accepted→memory projection ([#668](https://github.com/cq27-dev/rag-rat/pull/668))
- *(papertrail)* native GitLab provider — namespaced ids, parallel list legs, events comment lane ([#654](https://github.com/cq27-dev/rag-rat/pull/654))
- *(account)* mint the store's local account (C3.4a bootstrap) ([#666](https://github.com/cq27-dev/rag-rat/pull/666))
- *(account)* wire the /3 acceptance refold into ingest and the account fold ([#653](https://github.com/cq27-dev/rag-rat/pull/653))
- *(swift)* add the SwiftPM corpus, and fix the calls it exposed ([#650](https://github.com/cq27-dev/rag-rat/pull/650))
- *(papertrail)* automatic sync orchestration — watcher deadline, hook trigger, coalesced single-flight ([#646](https://github.com/cq27-dev/rag-rat/pull/646))

### Fixed

- Android/Termux support — flock via libc, static libc++ in the prebuilt ([#710](https://github.com/cq27-dev/rag-rat/pull/710))
- *(dream)* cut divergence false positives — memory-id cross-refs, verbatim, documented removals ([#686](https://github.com/cq27-dev/rag-rat/pull/686))
- *(fts)* detect FTS5 shadow corruption at the query layer and self-heal from durable sources ([#675](https://github.com/cq27-dev/rag-rat/pull/675))
- *(account)* guard the ancestry contiguity check against a u64::MAX seq ([#657](https://github.com/cq27-dev/rag-rat/pull/657))
- *(swift)* recover force-unwrapped receiver method calls ([#656](https://github.com/cq27-dev/rag-rat/pull/656))

### Other

- *(memory)* pin the read path unchanged under /3 + mark the foreign read projection phase-D ([#693](https://github.com/cq27-dev/rag-rat/pull/693))
- *(graph)* index-seed the remaining edges-view readers — grep_augment + impact_surface ([#692](https://github.com/cq27-dev/rag-rat/pull/692)) ([#694](https://github.com/cq27-dev/rag-rat/pull/694))
- *(graph)* seed find_callers/trace_callees on indexed edge id columns ([#682](https://github.com/cq27-dev/rag-rat/pull/682)) ([#684](https://github.com/cq27-dev/rag-rat/pull/684))
- neutral wording for the sync feature in repo_identity docs ([#674](https://github.com/cq27-dev/rag-rat/pull/674))
- split config.md into per-topic pages under docs/config/ ([#669](https://github.com/cq27-dev/rag-rat/pull/669))
</blockquote>

## `rag-rat`

<blockquote>

## [0.19.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-core-v0.18.0...rag-rat-core-v0.19.0) - 2026-07-16

### Added

- *(index)* scoped reconcile over an explicit path set (index --paths) ([#687](https://github.com/cq27-dev/rag-rat/pull/687))
- *(oplog)* content-key crypto primitives — content keys, key_id, X25519 sealed-box wrap (C4.1) ([#709](https://github.com/cq27-dev/rag-rat/pull/709))
- *(evals)* regenerate memory-compaction verify-packs corpus + add a committed generator ([#695](https://github.com/cq27-dev/rag-rat/pull/695)) ([#700](https://github.com/cq27-dev/rag-rat/pull/700))
- *(oplog)* defer the /3 content-ingest refold + exclude local authoring from the remote budget ([#699](https://github.com/cq27-dev/rag-rat/pull/699))
- *(memory)* author the live memory path onto owner-bound /2//3 streams ([#681](https://github.com/cq27-dev/rag-rat/pull/681))
- *(watch)* surface silently-dropped filesystem watches in index_status ([#670](https://github.com/cq27-dev/rag-rat/pull/670))
- *(account)* add the in-tx owner-stream ownership ensure seam ([#677](https://github.com/cq27-dev/rag-rat/pull/677))
- *(account)* add the /3 local-content authoring seam + accepted→memory projection ([#668](https://github.com/cq27-dev/rag-rat/pull/668))
- *(papertrail)* native GitLab provider — namespaced ids, parallel list legs, events comment lane ([#654](https://github.com/cq27-dev/rag-rat/pull/654))
- *(account)* mint the store's local account (C3.4a bootstrap) ([#666](https://github.com/cq27-dev/rag-rat/pull/666))
- *(account)* wire the /3 acceptance refold into ingest and the account fold ([#653](https://github.com/cq27-dev/rag-rat/pull/653))
- *(swift)* add the SwiftPM corpus, and fix the calls it exposed ([#650](https://github.com/cq27-dev/rag-rat/pull/650))
- *(papertrail)* automatic sync orchestration — watcher deadline, hook trigger, coalesced single-flight ([#646](https://github.com/cq27-dev/rag-rat/pull/646))

### Fixed

- Android/Termux support — flock via libc, static libc++ in the prebuilt ([#710](https://github.com/cq27-dev/rag-rat/pull/710))
- *(dream)* cut divergence false positives — memory-id cross-refs, verbatim, documented removals ([#686](https://github.com/cq27-dev/rag-rat/pull/686))
- *(fts)* detect FTS5 shadow corruption at the query layer and self-heal from durable sources ([#675](https://github.com/cq27-dev/rag-rat/pull/675))
- *(account)* guard the ancestry contiguity check against a u64::MAX seq ([#657](https://github.com/cq27-dev/rag-rat/pull/657))
- *(swift)* recover force-unwrapped receiver method calls ([#656](https://github.com/cq27-dev/rag-rat/pull/656))

### Other

- *(memory)* pin the read path unchanged under /3 + mark the foreign read projection phase-D ([#693](https://github.com/cq27-dev/rag-rat/pull/693))
- *(graph)* index-seed the remaining edges-view readers — grep_augment + impact_surface ([#692](https://github.com/cq27-dev/rag-rat/pull/692)) ([#694](https://github.com/cq27-dev/rag-rat/pull/694))
- *(graph)* seed find_callers/trace_callees on indexed edge id columns ([#682](https://github.com/cq27-dev/rag-rat/pull/682)) ([#684](https://github.com/cq27-dev/rag-rat/pull/684))
- neutral wording for the sync feature in repo_identity docs ([#674](https://github.com/cq27-dev/rag-rat/pull/674))
- split config.md into per-topic pages under docs/config/ ([#669](https://github.com/cq27-dev/rag-rat/pull/669))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).