### PR TITLE
feat(account): wire the /3 acceptance refold into ingest and the account fold

### DIFF
--- a/crates/rag-rat-core/src/oplog/account/content/acceptance.rs
+++ b/crates/rag-rat-core/src/oplog/account/content/acceptance.rs
@@ -176,6 +176,42 @@ pub(crate) fn evaluate_content_acceptance<F>(
 where
     F: Fn(EntryHash, EntryHash) -> AncestryRelation,
 {
+    if let Some(verdict) = authority_verdict(input)? {
+        return Ok(verdict);
+    }
+    if !input.dense_predecessor_reachable {
+        return Ok(ContentAcceptance::Parked(ContentParkReason::MissingPredecessor));
+    }
+    if !input.branch_selected {
+        return Ok(ContentAcceptance::Forked);
+    }
+    // Freshness last (§13): an author citing control ops we have not folded parks for refetch, but
+    // only once every verdict the current fold CAN decide — condemnation, fork — has been ruled
+    // out.
+    if input.owner_freshness.state == AuthorityFreshness::Ahead {
+        return Ok(ContentAcceptance::Parked(ContentParkReason::OwnerAuthLenAhead));
+    }
+    if input.author_freshness.state == AuthorityFreshness::Ahead {
+        return Ok(ContentAcceptance::Parked(ContentParkReason::AuthorAuthLenAhead));
+    }
+    Ok(ContentAcceptance::Accepted)
+}
+
+/// Everything §13 decides BEFORE the content DAG has a say: the structural grant coupling, the
+/// authority citations, every applicable revocation register, and the subject holds. `None` means
+/// the entry is authorized — it is then eligible to contest a slot in branch selection, and the
+/// caller finishes the verdict with [`evaluate_content_acceptance`].
+///
+/// This is the phase split the refold needs: an entry that is condemned or rejected must NOT
+/// compete for its dense seq slot (a small-hash entry mined beyond a cut would otherwise fork an
+/// honest sibling off the accepted branch), so eligibility has to be decided before selection runs
+/// — and selection's output is itself an input to the full predicate.
+pub(crate) fn authority_verdict<F>(
+    input: &ContentAcceptanceInput<'_, F>,
+) -> Result<Option<ContentAcceptance>, ContentAcceptanceInputError>
+where
+    F: Fn(EntryHash, EntryHash) -> AncestryRelation,
+{
     // Provenance first: a freshness verdict computed for another account, or for a shorter
     // assertion than the header makes, decides nothing about THIS entry.
     if input.owner_freshness.account_id != input.owner_account_id
@@ -190,27 +226,29 @@ where
 
     let is_owner = input.header.author_account_id == input.owner_account_id;
     if is_owner && (input.header.grant_id.is_some() || input.grant.is_some()) {
-        return Ok(ContentAcceptance::Rejected(ContentRejectReason::UnexpectedGrant));
+        return Ok(Some(ContentAcceptance::Rejected(ContentRejectReason::UnexpectedGrant)));
     }
     if !is_owner && input.header.grant_id.is_none() {
-        return Ok(ContentAcceptance::Rejected(ContentRejectReason::GrantRequired));
+        return Ok(Some(ContentAcceptance::Rejected(ContentRejectReason::GrantRequired)));
     }
+    let rejected = |reason| Ok(Some(ContentAcceptance::Rejected(reason)));
+    let parked = |reason| Ok(Some(ContentAcceptance::Parked(reason)));
+
     match input.ownership {
         AuthorityQuery::Effective(fact)
             if fact.owner_account_id == input.owner_account_id
                 && fact.stream_id == input.header.stream_id => {},
-        AuthorityQuery::Unknown =>
-            return Ok(ContentAcceptance::Parked(ContentParkReason::UnknownOwner)),
+        AuthorityQuery::Unknown => return parked(ContentParkReason::UnknownOwner),
         // Ownership is minted in the OWNER's log, so the owner's freshness gates its rejection.
         AuthorityQuery::Invalid(reason) =>
-            return Ok(invalid_citation(
+            return Ok(Some(invalid_citation(
                 reason,
                 owner_freshness,
                 ContentRejectReason::OwnerReferenceInvalid,
                 ContentParkReason::OwnerAuthLenAhead,
-            )),
+            ))),
         AuthorityQuery::Effective(_) =>
-            return Ok(ContentAcceptance::Rejected(ContentRejectReason::OwnerReferenceInvalid)),
+            return rejected(ContentRejectReason::OwnerReferenceInvalid),
     }
     let roster = match input.roster {
         AuthorityQuery::Effective(fact)
@@ -219,18 +257,17 @@ where
                 && fact.stream_id == input.header.stream_id
                 && fact.authority.device_fingerprint == input.header.device_fingerprint =>
             fact,
-        AuthorityQuery::Unknown =>
-            return Ok(ContentAcceptance::Parked(ContentParkReason::UnknownRosterRef)),
+        AuthorityQuery::Unknown => return parked(ContentParkReason::UnknownRosterRef),
         // The roster enrollment lives in the AUTHOR's log — the author's freshness gates it.
         AuthorityQuery::Invalid(reason) =>
-            return Ok(invalid_citation(
+            return Ok(Some(invalid_citation(
                 reason,
                 author_freshness,
                 ContentRejectReason::RosterReferenceInvalid,
                 ContentParkReason::AuthorAuthLenAhead,
-            )),
+            ))),
         AuthorityQuery::Effective(_) =>
-            return Ok(ContentAcceptance::Rejected(ContentRejectReason::RosterReferenceInvalid)),
+            return rejected(ContentRejectReason::RosterReferenceInvalid),
     };
     let mut boundaries = vec![roster.authority.boundary];
 
@@ -243,21 +280,20 @@ where
                     && fact.authority.grant.grantee_account_id
                         == input.header.author_account_id =>
                 fact,
-            Some(AuthorityQuery::Unknown) | None =>
-                return Ok(ContentAcceptance::Parked(ContentParkReason::UnknownGrant)),
+            Some(AuthorityQuery::Unknown) | None => return parked(ContentParkReason::UnknownGrant),
             // The grant is minted in the OWNER's log — the owner's freshness gates it.
             Some(AuthorityQuery::Invalid(reason)) =>
-                return Ok(invalid_citation(
+                return Ok(Some(invalid_citation(
                     *reason,
                     owner_freshness,
                     ContentRejectReason::GrantReferenceInvalid,
                     ContentParkReason::OwnerAuthLenAhead,
-                )),
+                ))),
             Some(AuthorityQuery::Effective(_)) =>
-                return Ok(ContentAcceptance::Rejected(ContentRejectReason::GrantReferenceInvalid)),
+                return rejected(ContentRejectReason::GrantReferenceInvalid),
         };
         if grant.authority.grant.role != GrantRole::Writer {
-            return Ok(ContentAcceptance::Rejected(ContentRejectReason::GrantDoesNotPermitWrite));
+            return rejected(ContentRejectReason::GrantDoesNotPermitWrite);
         }
         boundaries.push(match &grant.authority.boundary {
             GrantDeviceBoundary::Open => AuthorityBoundary::Open,
@@ -265,7 +301,7 @@ where
                 if cut.device_fingerprint == input.header.device_fingerprint =>
                 AuthorityBoundary::Cut { seq: cut.seq, hash: cut.hash },
             GrantDeviceBoundary::Cut(_) =>
-                return Ok(ContentAcceptance::Rejected(ContentRejectReason::GrantReferenceInvalid)),
+                return rejected(ContentRejectReason::GrantReferenceInvalid),
             GrantDeviceBoundary::Closed => AuthorityBoundary::Closed,
         });
     }
@@ -273,34 +309,17 @@ where
     let boundary_decision =
         combine_boundaries(&boundaries, input.header.seq, input.entry_hash, &input.ancestry);
     if matches!(boundary_decision, Some(ContentAcceptance::Condemned(_))) {
-        return Ok(boundary_decision.expect("matched Some"));
+        return Ok(boundary_decision);
     }
     match input.subject_hold {
         SubjectAuthorityHold::UnknownCutTarget =>
-            return Ok(ContentAcceptance::Parked(ContentParkReason::UnknownCutTarget)),
-        SubjectAuthorityHold::Contested =>
-            return Ok(ContentAcceptance::Parked(ContentParkReason::ContestedSubject)),
+            return parked(ContentParkReason::UnknownCutTarget),
+        SubjectAuthorityHold::Contested => return parked(ContentParkReason::ContestedSubject),
         SubjectAuthorityHold::Clear => {},
     }
-    if let Some(decision) = boundary_decision {
-        return Ok(decision);
-    }
-    if !input.dense_predecessor_reachable {
-        return Ok(ContentAcceptance::Parked(ContentParkReason::MissingPredecessor));
-    }
-    if !input.branch_selected {
-        return Ok(ContentAcceptance::Forked);
-    }
-    // Freshness last (§13): an author citing control ops we have not folded parks for refetch, but
-    // only once every verdict the current fold CAN decide — condemnation, fork — has been ruled
-    // out.
-    if owner_freshness == AuthorityFreshness::Ahead {
-        return Ok(ContentAcceptance::Parked(ContentParkReason::OwnerAuthLenAhead));
-    }
-    if author_freshness == AuthorityFreshness::Ahead {
-        return Ok(ContentAcceptance::Parked(ContentParkReason::AuthorAuthLenAhead));
-    }
-    Ok(ContentAcceptance::Accepted)
+    // A boundary that could not be decided (a withheld watermark, an incomplete walk) parks here,
+    // after the holds — it is the weakest verdict the registers can produce.
+    Ok(boundary_decision)
 }
 
 /// Lower an `Invalid` citation into a verdict. `WrongSubject` is decided by bytes we already hold,

--- a/crates/rag-rat-core/src/oplog/account/content/mod.rs
+++ b/crates/rag-rat-core/src/oplog/account/content/mod.rs
@@ -16,6 +16,6 @@ pub(in crate::oplog) use envelope::{
     ContentEntryHeader, SignedContentEntry, VerifiedContentEntry, decode_content_signed,
     sign_content_entry, verify_content_signed,
 };
-pub(super) use storage::promote_pre_verify_for_account;
 #[allow(unused_imports, reason = "C2 storage seam is frozen before C3 wiring lands")]
 pub(in crate::oplog) use storage::{ContentCapacityScope, ContentIngestOutcome, content_ingest};
+pub(super) use storage::{promote_pre_verify_for_account, refold_streams_for_account};

--- a/crates/rag-rat-core/src/oplog/account/content/storage.rs
+++ b/crates/rag-rat-core/src/oplog/account/content/storage.rs
@@ -4,15 +4,28 @@
 //! coordinates. It deliberately never sets `accepted`: C3 must evaluate authority, cuts,
 //! freshness, and branch selection together before content can reach the live projection.
 
-use std::collections::VecDeque;
+use std::collections::{HashMap, HashSet, VecDeque};
 
 use rusqlite::{Connection, OptionalExtension, Transaction, TransactionBehavior, params};
 
-use super::super::envelope as account_envelope;
 use super::super::ops::{self, AccountOp, DecodedAccountOp};
-use super::envelope::{self, SignedContentEntry, VerifiedContentEntry};
+use super::super::{envelope as account_envelope, storage as account_storage};
+use super::acceptance::{
+    self, CitedFreshness, CitedGrantAuthority, CitedOwnership, CitedRosterAuthority,
+    ContentAcceptance, ContentParkReason, SubjectAuthorityHold,
+};
+use super::candidate::{
+    self, BranchPin, ChainCoordinate, ContentCandidate, CutBinding, HeaderView,
+};
+use super::envelope::{self, ContentEntryHeader, SignedContentEntry, VerifiedContentEntry};
+use crate::oplog::account::{
+    AccountId, AuthorityBoundary, AuthorityFreshness, AuthorityQuery, GrantDeviceBoundary,
+    GrantRole,
+};
 use crate::oplog::cbor;
 use crate::oplog::device::DevicePublic;
+use crate::oplog::op::DeviceFingerprint;
+use crate::oplog::stream::StreamId;
 
 type EntryHash = [u8; 32];
 
@@ -104,6 +117,11 @@ pub(in crate::oplog) fn content_ingest(
     }
     insert_candidate(&tx, &verified, signed_bytes, now_ms)?;
     reclassify_chain(&tx, &verified)?;
+    // Structural classification is done; now fold authority + branch selection over the whole
+    // stream (§13) — the pass that can set `accepted`. With the owner's `StreamOwn` fact absent
+    // this is a no-op and the entry stays `retained_unfolded` until the account→content trigger
+    // refolds it; with authority present the entry lands on its real verdict in this same txn.
+    refold_content_stream(&tx, verified.header.stream_id)?;
     let status = status_for(&tx, &verified.entry_hash)?
         .unwrap_or_else(|| ContentStatus::RetainedUnfolded.as_db_str().to_string());
     tx.commit()?;
@@ -489,6 +507,685 @@ fn reclassify_chain(tx: &Transaction<'_>, entry: &VerifiedContentEntry) -> anyho
             set_status(tx, &child, ContentStatus::RetainedUnfolded)?;
             queue.push_back((child, child_seq));
         }
+    }
+    Ok(())
+}
+
+/// Every authority fact one candidate is evaluated against, resolved once from the current fold so
+/// the two evaluator phases (eligibility, then the finished verdict) read one consistent snapshot.
+struct ResolvedEntry {
+    entry_hash: EntryHash,
+    header: ContentEntryHeader,
+    owner_account_id: AccountId,
+    dense_predecessor_reachable: bool,
+    ownership: AuthorityQuery<CitedOwnership>,
+    roster: AuthorityQuery<CitedRosterAuthority>,
+    grant: Option<AuthorityQuery<CitedGrantAuthority>>,
+    owner_freshness: CitedFreshness,
+    author_freshness: CitedFreshness,
+    subject_hold: SubjectAuthorityHold,
+}
+
+/// Re-derive `/3` acceptance for every candidate on `stream_id` from the CURRENT account fold and
+/// write each entry's `accepted` flag + status (§13). This is the only writer of `accepted = 1`.
+///
+/// Runs entirely inside the caller's `IMMEDIATE` transaction. §13 orders the passes structural →
+/// authority+registers → branch → freshness, and every authority fact is read in this one snapshot:
+/// a concurrent account refold committing mid-evaluation could otherwise pair an old grant with a
+/// new cut. Nothing is ever mutated in the log — a late control or ancestry arrival simply refolds
+/// the same candidates to a new classification (retro-condemn or re-bless), never rewrites history.
+/// Re-evaluate every content stream whose acceptance THIS account's authority can change, after its
+/// control fold rewrote the authority projection. This is the account→content trigger: a grant
+/// revocation, roster cut, ownership arrival, or contested flip retro-classifies already-stored
+/// content in the SAME account-refold txn — otherwise a revocation would not take effect until an
+/// unrelated content entry happened to land on the stream (L2/I5 would be unenforceable).
+///
+/// A stream is reachable from this account two ways: the account OWNS it (its ownership/grant/cut
+/// facts bound the stream), or the account AUTHORS content on it (its roster/contested state gates
+/// that content). The union covers every cross-account case — a `StreamRevoke` folds in the OWNER's
+/// log and reaches the grantee's content through the ownership branch; a roster change folds in the
+/// AUTHOR's log and reaches it through the author branch.
+pub(in crate::oplog::account) fn refold_streams_for_account(
+    tx: &Transaction<'_>,
+    account_id: AccountId,
+    previously_owned: &[[u8; 32]],
+) -> anyhow::Result<()> {
+    // The `/3` tables are created by a LATER migration than the account authority projection, and
+    // the V064/V065 authority backfill folds every existing account inside its own migration — so
+    // this runs before `content_entries` exists on an upgrading database. There is no content to
+    // classify then; skip until the table is present.
+    if !content_entries_exists(tx)? {
+        return Ok(());
+    }
+    // `previously_owned` is the account's owned-stream set captured BEFORE this fold rewrote the
+    // projection. A fold that DROPS a `StreamOwn` fact must still refold that stream (to declassify
+    // its now-authority-less content) — but the ownership row is already gone from the query below,
+    // so the caller passes the pre-rewrite set and we union it in.
+    let mut streams: HashSet<[u8; 32]> = previously_owned.iter().copied().collect();
+    {
+        let mut stmt = tx.prepare(
+            "SELECT stream_id FROM account_stream_ownership WHERE account_id = ?1
+             UNION
+             SELECT stream_id FROM content_entries WHERE author_account_id = ?1",
+        )?;
+        let rows = stmt
+            .query_map([account_id.to_bytes().as_slice()], |row| row.get::<_, Vec<u8>>(0))?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        for stream_bytes in rows {
+            streams.insert(fixed::<32>(&stream_bytes)?);
+        }
+    }
+    for stream in streams {
+        refold_content_stream(tx, StreamId::from_bytes(stream))?;
+    }
+    Ok(())
+}
+
+/// Whether `content_entries` exists yet — false while an upgrading DB is mid-migration, before the
+/// `/3` tables are created. `sqlite_master` is served from SQLite's in-memory schema, so this is a
+/// cheap guard, not a table scan.
+fn content_entries_exists(tx: &Transaction<'_>) -> rusqlite::Result<bool> {
+    tx.query_row(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'content_entries'",
+        [],
+        |_| Ok(()),
+    )
+    .optional()
+    .map(|row| row.is_some())
+}
+
+fn refold_content_stream(tx: &Transaction<'_>, stream_id: StreamId) -> anyhow::Result<()> {
+    // The owner is inside the stream identity (`stream_id = sha256(cbor([.., owner, ..]))`, §14)
+    // but not invertible, so it is resolved through the owner's `StreamOwn` fact. No fact ⇒
+    // authority cannot be evaluated: the entries revert to their structural state. This is a
+    // DECLASSIFY, not a skip — if ownership was dropped by a later fold (owner contested / branch
+    // reselection), previously accepted content must lose `accepted` here, or it would stay live
+    // with no current authority basis.
+    let Some(owner_account_id) = account_storage::stream_owner_account(tx, stream_id)? else {
+        declassify_stream_to_structural(tx, stream_id)?;
+        return Ok(());
+    };
+
+    let resolved = resolve_stream_authority(tx, stream_id, owner_account_id)?;
+
+    // Clear every `accepted` on the stream up front — so the `content_accepted_slot` partial-unique
+    // index never transiently sees two accepted rows at one `(stream, author, device, seq)` (I10a),
+    // and so a row we could NOT decode (absent from `resolved`) cannot keep a stale `accepted`. Its
+    // status is reset too, or a corrupt blob would retain a stale `accepted{…}` verdict.
+    tx.execute("UPDATE content_entries SET accepted = 0 WHERE stream_id = ?1", [stream_id
+        .to_bytes()
+        .as_slice()])?;
+    let handled: HashSet<EntryHash> = resolved.iter().map(|r| r.entry_hash).collect();
+    declassify_rows_absent_from(tx, stream_id, &handled)?;
+    if resolved.is_empty() {
+        return Ok(());
+    }
+    let view: HashMap<EntryHash, ContentEntryHeader> =
+        resolved.iter().map(|r| (r.entry_hash, r.header.clone())).collect();
+
+    // Phase 1 — eligibility. An entry the authority pass condemns or rejects must NOT compete for a
+    // dense seq slot (§16.2): a small-hash entry mined beyond a cut would otherwise win the
+    // unforced tiebreak and fork an honest sibling off the accepted branch.
+    let mut eligible = HashSet::new();
+    for r in &resolved {
+        if verdict_for(r, &view, false, EvaluatorPhase::Eligibility)?.is_none() {
+            eligible.insert(r.entry_hash);
+        }
+    }
+
+    // The register watermarks that pin a branch are the same cut boundaries the authority pass
+    // resolved: §16 pins the accepted branch to the highest admitted watermark. `pinned_branch`
+    // re-validates each against its coordinate, so over-collecting is safe.
+    let pins = branch_pins(&resolved);
+    let candidates: Vec<ContentCandidate> = resolved
+        .iter()
+        .map(|r| ContentCandidate { entry_hash: r.entry_hash, header: r.header.clone() })
+        .collect();
+    let selection = candidate::select_accepted_branch(&candidates, &eligible, &pins, &view);
+
+    // Phase 2 — the finished verdict, made prefix-closed, then the write (`accepted` was cleared
+    // above). The raw per-entry verdict needs two corrections before it is the truth:
+    //  - Freshness is evaluated AFTER branch selection (§13), so a selected entry can still park
+    //    `auth_len_ahead`. The accepted set is a contiguous prefix from seq 0 — a descendant must
+    //    not stay accepted over a parked ancestor — so each chain is truncated at its first
+    //    non-accepted winner. (An attacker varying cited `auth_len` down a chain is the trigger.)
+    //  - `select_accepted_branch` leaves an entry stranded above an ineligible/unselected parent in
+    //    NEITHER `accepted` nor `forked` — it lost no contest. Passing `branch_selected = false`
+    //    would make the evaluator call it `Forked`, a terminal loser state it is not; only the real
+    //    losers in `selection.forked` fork, and a stranded entry parks (recoverable).
+    let mut raw: HashMap<EntryHash, ContentAcceptance> = HashMap::with_capacity(resolved.len());
+    for r in &resolved {
+        let selected = selection.accepted.contains(&r.entry_hash);
+        let verdict = verdict_for(r, &view, selected, EvaluatorPhase::Finished)?
+            .expect("the finished evaluator always returns a verdict");
+        raw.insert(r.entry_hash, verdict);
+    }
+    let accepted = prefix_closed_accepted(&resolved, &selection, &raw);
+    for r in &resolved {
+        let hash = r.entry_hash;
+        let verdict = if accepted.contains(&hash) {
+            ContentAcceptance::Accepted
+        } else if selection.forked.contains(&hash) {
+            ContentAcceptance::Forked
+        } else {
+            match raw[&hash] {
+                // Selected + fresh, but truncated by a parked ancestor: blocked on that ancestor
+                // catching up, so it parks with the same freshness reason instead of accepting.
+                ContentAcceptance::Accepted =>
+                    ContentAcceptance::Parked(ContentParkReason::AuthorAuthLenAhead),
+                // Eligible but stranded above an unselected parent — recoverable, not a terminal
+                // fork. It has no accepted predecessor to build on, so it parks like one missing.
+                ContentAcceptance::Forked =>
+                    ContentAcceptance::Parked(ContentParkReason::MissingPredecessor),
+                other => other,
+            }
+        };
+        write_verdict(tx, &hash, verdict)?;
+    }
+    Ok(())
+}
+
+/// Narrow the branch-selected winners to a contiguous accepted prefix per coordinate.
+/// `select_accepted_branch` already returns one hash-linked chain per coordinate, but freshness
+/// (evaluated after selection) can park a mid-chain winner, and the accepted projection must stay
+/// prefix-closed — so keep only the run from seq 0 whose own finished verdict is `Accepted`.
+fn prefix_closed_accepted(
+    resolved: &[ResolvedEntry],
+    selection: &candidate::BranchSelection,
+    raw: &HashMap<EntryHash, ContentAcceptance>,
+) -> HashSet<EntryHash> {
+    let mut chains: HashMap<ChainCoordinate, Vec<(u64, EntryHash)>> = HashMap::new();
+    for r in resolved {
+        if selection.accepted.contains(&r.entry_hash) {
+            let coordinate = ChainCoordinate {
+                stream_id: r.header.stream_id,
+                author_account_id: r.header.author_account_id,
+                device_fingerprint: r.header.device_fingerprint,
+            };
+            chains.entry(coordinate).or_default().push((r.header.seq, r.entry_hash));
+        }
+    }
+    let mut accepted = HashSet::new();
+    for mut winners in chains.into_values() {
+        winners.sort_by_key(|(seq, _)| *seq);
+        for (_, hash) in winners {
+            if raw.get(&hash) == Some(&ContentAcceptance::Accepted) {
+                accepted.insert(hash);
+            } else {
+                break; // prefix broken: every later winner on this chain is not accepted
+            }
+        }
+    }
+    accepted
+}
+
+/// Reset the status of every stream row NOT in `handled` to the unclassified baseline. Those rows
+/// could not be decoded — they are absent from the refold's per-entry writes, so without this a
+/// corrupt blob (or a row written outside `content_ingest`) would keep whatever verdict a prior
+/// fold derived. `accepted` is cleared separately by the caller's blanket update.
+fn declassify_rows_absent_from(
+    tx: &Transaction<'_>,
+    stream_id: StreamId,
+    handled: &HashSet<EntryHash>,
+) -> anyhow::Result<()> {
+    let hashes: Vec<Vec<u8>> = {
+        let mut stmt = tx.prepare("SELECT entry_hash FROM content_entries WHERE stream_id = ?1")?;
+        stmt.query_map([stream_id.to_bytes().as_slice()], |row| row.get::<_, Vec<u8>>(0))?
+            .collect::<rusqlite::Result<Vec<_>>>()?
+    };
+    for bytes in hashes {
+        let hash = fixed::<32>(&bytes)?;
+        if !handled.contains(&hash) {
+            set_status(tx, &hash, ContentStatus::RetainedUnfolded)?;
+        }
+    }
+    Ok(())
+}
+
+enum EvaluatorPhase {
+    /// Only the authority pass: `Some` = decided pre-DAG (rejected/parked/condemned), `None` =
+    /// eligible to contest a slot.
+    Eligibility,
+    /// The whole predicate, including branch selection and freshness — always decides.
+    Finished,
+}
+
+/// Build the per-entry evaluator input from resolved facts and run the requested phase. The
+/// ancestry closure walks `view`, so the input never outlives it; both callers evaluate inline.
+fn verdict_for(
+    r: &ResolvedEntry,
+    view: &HashMap<EntryHash, ContentEntryHeader>,
+    branch_selected: bool,
+    phase: EvaluatorPhase,
+) -> anyhow::Result<Option<ContentAcceptance>> {
+    let input = acceptance::ContentAcceptanceInput {
+        header: &r.header,
+        entry_hash: r.entry_hash,
+        owner_account_id: r.owner_account_id,
+        dense_predecessor_reachable: r.dense_predecessor_reachable,
+        branch_selected,
+        ownership: r.ownership,
+        roster: r.roster,
+        grant: r.grant.clone(),
+        owner_freshness: r.owner_freshness,
+        author_freshness: r.author_freshness,
+        subject_hold: r.subject_hold,
+        ancestry: |target, watermark| {
+            candidate::ancestry(&target, &watermark, view as &dyn HeaderView)
+        },
+    };
+    let verdict = match phase {
+        EvaluatorPhase::Eligibility => acceptance::authority_verdict(&input),
+        EvaluatorPhase::Finished => acceptance::evaluate_content_acceptance(&input).map(Some),
+    };
+    verdict.map_err(|error| {
+        anyhow::anyhow!("content refold built inconsistent freshness provenance: {error:?}")
+    })
+}
+
+/// Read every candidate on the stream and resolve its authority facts against the current fold.
+fn resolve_stream_authority(
+    tx: &Transaction<'_>,
+    stream_id: StreamId,
+    owner_account_id: AccountId,
+) -> anyhow::Result<Vec<ResolvedEntry>> {
+    let headers = load_stream_headers(tx, stream_id)?;
+    let view: HashMap<EntryHash, ContentEntryHeader> =
+        headers.iter().map(|(hash, header)| (*hash, header.clone())).collect();
+    let reachable = reachable_entries(&view);
+
+    // Every entry on one author's chain shares its author/roster/device/grant and (usually) its
+    // cited `auth_len`s, so resolving the authority facts once per DISTINCT key instead of once per
+    // entry collapses O(n) authority queries to O(distinct keys) — near O(1) for a linear chain,
+    // the difference between a bounded and a quadratic refold cost. All caches are scoped to
+    // this one snapshot; nothing persists across refolds.
+    let mut caches = AuthorityCaches::default();
+    // The owner is the same for every entry on the stream, so resolve its contested state once. A
+    // contested OWNER fails content closed just as a contested author does (§12): a contributor's
+    // writer grant is minted in the owner's log, so if that account is compromised the grant can no
+    // longer be trusted — the content parks until the owner recovers.
+    let owner_contested = account_storage::account_is_contested(tx, owner_account_id)?;
+    let mut resolved = Vec::with_capacity(headers.len());
+    for (entry_hash, header) in headers {
+        let ownership = AuthorityQuery::Effective(CitedOwnership {
+            owner_account_id,
+            stream_id: header.stream_id,
+        });
+        let roster_key = (header.author_account_id, header.roster_ref, header.device_fingerprint);
+        let roster = match caches.roster.get(&roster_key) {
+            Some(cached) => *cached,
+            None => {
+                let resolved = map_roster(
+                    account_storage::roster_content_authority_in_snapshot(
+                        tx,
+                        header.author_account_id,
+                        header.roster_ref,
+                        header.device_fingerprint,
+                        header.stream_id,
+                    )?,
+                    &header,
+                );
+                caches.roster.insert(roster_key, resolved);
+                resolved
+            },
+        };
+        let grant = match header.grant_id {
+            None => None,
+            Some(grant_id) => {
+                let grant_key = (grant_id, header.author_account_id, header.device_fingerprint);
+                let resolved = match caches.grant.get(&grant_key) {
+                    Some(cached) => cached.clone(),
+                    None => {
+                        let resolved = map_grant(
+                            account_storage::grant_effective_for_device_in_snapshot(
+                                tx,
+                                owner_account_id,
+                                grant_id,
+                                header.stream_id,
+                                header.author_account_id,
+                                header.device_fingerprint,
+                            )?,
+                            owner_account_id,
+                            grant_id,
+                        );
+                        caches.grant.insert(grant_key, resolved.clone());
+                        resolved
+                    },
+                };
+                Some(resolved)
+            },
+        };
+        // A content cut's watermark is a CONTENT candidate the account fold could not validate (it
+        // only holds the account log), so bind it against the content DAG HERE, exactly as
+        // `pinned_branch` does — otherwise `combine_boundaries` would condemn `beyond_cut` off a
+        // watermark that names a foreign coordinate or is not held (§11.3 laundering). A cut naming
+        // a different coordinate is malformed → ignored (Open); an unheld watermark parks the whole
+        // coordinate (`unknown_cut_target`, I11) rather than condemning.
+        let coordinate = ChainCoordinate {
+            stream_id: header.stream_id,
+            author_account_id: header.author_account_id,
+            device_fingerprint: header.device_fingerprint,
+        };
+        let mut cut_target_unknown = false;
+        let roster = bind_roster_cut(roster, &coordinate, &view, &mut cut_target_unknown);
+        let grant = bind_grant_cut(grant, &coordinate, &view, &mut cut_target_unknown);
+        let owner_freshness = CitedFreshness {
+            account_id: owner_account_id,
+            asserted_auth_len: header.owner_auth_len,
+            state: caches.freshness(tx, owner_account_id, header.owner_auth_len)?,
+        };
+        let author_freshness = CitedFreshness {
+            account_id: header.author_account_id,
+            asserted_auth_len: header.author_auth_len,
+            state: caches.freshness(tx, header.author_account_id, header.author_auth_len)?,
+        };
+        // §12: a contested account halts authority mutation, so content that depends on it fails
+        // closed as `contested_subject` (quota-bounded, reclassified on recovery). Either the
+        // author (its roster enrollment) or the owner (its grant) being contested poisons
+        // the citation. This over-approximates the spec's "device is a subject of a residue
+        // cut" to the whole account — safe (fail-closed); the residue-subject precision is
+        // a tracked follow-up.
+        let subject_hold = if owner_contested || caches.contested(tx, header.author_account_id)? {
+            SubjectAuthorityHold::Contested
+        } else if cut_target_unknown {
+            SubjectAuthorityHold::UnknownCutTarget
+        } else {
+            SubjectAuthorityHold::Clear
+        };
+        let dense_predecessor_reachable = reachable.contains(&entry_hash);
+        resolved.push(ResolvedEntry {
+            entry_hash,
+            header,
+            owner_account_id,
+            dense_predecessor_reachable,
+            ownership,
+            roster,
+            grant,
+            owner_freshness,
+            author_freshness,
+            subject_hold,
+        });
+    }
+    Ok(resolved)
+}
+
+/// Per-refold memoization of the authority facts, keyed by exactly what each query depends on, so a
+/// stream of many entries sharing one author/roster/grant resolves each fact once. Snapshot-scoped:
+/// a fresh instance per `resolve_stream_authority`, never shared across refolds.
+#[derive(Default)]
+struct AuthorityCaches {
+    roster:
+        HashMap<(AccountId, EntryHash, DeviceFingerprint), AuthorityQuery<CitedRosterAuthority>>,
+    grant: HashMap<(EntryHash, AccountId, DeviceFingerprint), AuthorityQuery<CitedGrantAuthority>>,
+    freshness: HashMap<(AccountId, u64), AuthorityFreshness>,
+    contested: HashMap<AccountId, bool>,
+}
+
+impl AuthorityCaches {
+    fn freshness(
+        &mut self,
+        tx: &Transaction<'_>,
+        account_id: AccountId,
+        asserted_auth_len: u64,
+    ) -> anyhow::Result<AuthorityFreshness> {
+        if let Some(cached) = self.freshness.get(&(account_id, asserted_auth_len)) {
+            return Ok(*cached);
+        }
+        let state = account_storage::auth_len_freshness(tx, account_id, asserted_auth_len)?;
+        self.freshness.insert((account_id, asserted_auth_len), state);
+        Ok(state)
+    }
+
+    fn contested(&mut self, tx: &Transaction<'_>, account_id: AccountId) -> anyhow::Result<bool> {
+        if let Some(cached) = self.contested.get(&account_id) {
+            return Ok(*cached);
+        }
+        let contested = account_storage::account_is_contested(tx, account_id)?;
+        self.contested.insert(account_id, contested);
+        Ok(contested)
+    }
+}
+
+/// Load `(entry_hash, header)` for every candidate on the stream, decoding the header from the
+/// stored — already signature-verified — bytes. The refold re-derives authority, never re-verifies.
+fn load_stream_headers(
+    tx: &Transaction<'_>,
+    stream_id: StreamId,
+) -> anyhow::Result<Vec<(EntryHash, ContentEntryHeader)>> {
+    let mut stmt = tx.prepare(
+        "SELECT entry_hash, signed_bytes FROM content_entries WHERE stream_id = ?1
+         ORDER BY entry_hash", // deterministic load order (selection is order-free regardless)
+    )?;
+    let rows = stmt
+        .query_map([stream_id.to_bytes().as_slice()], |row| {
+            Ok((row.get::<_, Vec<u8>>(0)?, row.get::<_, Vec<u8>>(1)?))
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    let mut out = Vec::with_capacity(rows.len());
+    for (entry_hash, signed_bytes) in rows {
+        let entry_hash = fixed::<32>(&entry_hash)?;
+        // `content_ingest` only ever stores verified, decodable envelopes, so a decode failure here
+        // means the row was written by some other path (or the blob is corrupt). Skip it rather
+        // than abort the whole account fold on one bad row — an undecodable candidate cannot belong
+        // to any valid chain, so treating it as absent is the sanest handling.
+        let Ok(signed) = envelope::decode_content_signed(&signed_bytes) else {
+            continue;
+        };
+        // The decode recomputes `entry_hash = sha256(header body)`, so if it does not match the
+        // row's key the blob is not this row's entry — a
+        // swapped/corrupted-into-a-different-valid-envelope blob. The hash covers the whole
+        // coordinate (stream, author, device, seq), so this one check also pins the stream.
+        // Skip it too: the refold must never classify a row under a header that is not its
+        // own.
+        if signed.entry_hash != entry_hash {
+            continue;
+        }
+        out.push((entry_hash, signed.header));
+    }
+    Ok(out)
+}
+
+/// Revert every entry on a stream to its structural classification (`retained_unfolded` if its
+/// dense chain is held, else `parked{missing_predecessor}`) and clear `accepted`. Used when the
+/// stream has no resolvable owner: whatever a prior fold decided has lost its authority basis, so
+/// the entries return to "held, not yet folded" — the same status a fresh candidate carries.
+fn declassify_stream_to_structural(
+    tx: &Transaction<'_>,
+    stream_id: StreamId,
+) -> anyhow::Result<()> {
+    let headers = load_stream_headers(tx, stream_id)?;
+    let view: HashMap<EntryHash, ContentEntryHeader> =
+        headers.iter().map(|(hash, header)| (*hash, header.clone())).collect();
+    let reachable = reachable_entries(&view);
+    // Clear `accepted` for the WHOLE stream first — including any undecodable row absent from
+    // `headers`, which must lose acceptance too (an orphaned + corrupt stream is exactly the case a
+    // bare `headers.is_empty()` early return would leave stale).
+    tx.execute("UPDATE content_entries SET accepted = 0 WHERE stream_id = ?1", [stream_id
+        .to_bytes()
+        .as_slice()])?;
+    let mut handled = HashSet::with_capacity(headers.len());
+    for (entry_hash, _) in &headers {
+        let status = if reachable.contains(entry_hash) {
+            ContentStatus::RetainedUnfolded
+        } else {
+            ContentStatus::MissingPredecessor
+        };
+        set_status(tx, entry_hash, status)?;
+        handled.insert(*entry_hash);
+    }
+    declassify_rows_absent_from(tx, stream_id, &handled)?;
+    Ok(())
+}
+
+/// The entries whose dense chain is fully held back to seq 0, computed in ONE O(n) forward pass
+/// from the chain roots. A per-entry backward walk to seq 0 would make the whole refold O(n²), and
+/// at the per-author candidate cap (thousands) a long peer-supplied chain could burn tens of
+/// millions of lookups on a single ingest — an availability footgun. Here every entry is enqueued
+/// once and every `prev_hash` edge is followed once.
+fn reachable_entries(view: &HashMap<EntryHash, ContentEntryHeader>) -> HashSet<EntryHash> {
+    let mut by_prev: HashMap<EntryHash, Vec<&EntryHash>> = HashMap::new();
+    let mut queue: VecDeque<&EntryHash> = VecDeque::new();
+    for (hash, header) in view {
+        match header.prev_hash {
+            // A chain root: seq 0 with no predecessor. A `prev_hash`-less entry at seq > 0 is
+            // structurally impossible to reach and simply never gets enqueued.
+            None if header.seq == 0 => queue.push_back(hash),
+            None => {},
+            Some(prev) => by_prev.entry(prev).or_default().push(hash),
+        }
+    }
+    let mut reachable = HashSet::new();
+    while let Some(hash) = queue.pop_front() {
+        if !reachable.insert(*hash) {
+            continue;
+        }
+        let parent = &view[hash];
+        let Some(children) = by_prev.get(hash) else {
+            continue;
+        };
+        for child_hash in children {
+            let child = &view[*child_hash];
+            // Contiguous + same coordinate: a link that skips a slot or jumps chain is not a real
+            // predecessor. `seq` is peer-supplied, so guard the `+ 1` against a `u64::MAX` row.
+            if parent.seq.checked_add(1) == Some(child.seq)
+                && child.stream_id == parent.stream_id
+                && child.author_account_id == parent.author_account_id
+                && child.device_fingerprint == parent.device_fingerprint
+            {
+                queue.push_back(child_hash);
+            }
+        }
+    }
+    reachable
+}
+
+/// The register watermarks pinning a branch: the cut boundaries the authority pass already
+/// resolved.
+fn branch_pins(resolved: &[ResolvedEntry]) -> Vec<BranchPin> {
+    let mut pins = Vec::new();
+    for r in resolved {
+        let coordinate = ChainCoordinate {
+            stream_id: r.header.stream_id,
+            author_account_id: r.header.author_account_id,
+            device_fingerprint: r.header.device_fingerprint,
+        };
+        if let AuthorityQuery::Effective(roster) = &r.roster
+            && let AuthorityBoundary::Cut { seq, hash } = roster.authority.boundary
+        {
+            pins.push(BranchPin { coordinate, seq, watermark: hash });
+        }
+        // Only a WRITER grant's cut may pin content: a reader grant never authorizes a content
+        // write, so its revoke watermark must not steer the accepted branch for writer-grant
+        // content on the same coordinate (a peer could otherwise store a rejected
+        // reader-grant entry purely to hijack selection).
+        if let Some(AuthorityQuery::Effective(grant)) = &r.grant
+            && grant.authority.grant.role == GrantRole::Writer
+            && let GrantDeviceBoundary::Cut(cut) = &grant.authority.boundary
+        {
+            pins.push(BranchPin { coordinate, seq: cut.seq, watermark: cut.hash });
+        }
+    }
+    pins
+}
+
+/// Bind a roster content cut's watermark to this coordinate against the content DAG (§11.3). An
+/// `Ok` binding keeps the cut; a watermark naming a foreign coordinate is malformed and drops to
+/// `Open`; an unheld watermark drops to `Open` and flags `unknown_cut_target` so the caller parks
+/// the coordinate instead of condemning off an unverifiable cut.
+fn bind_roster_cut(
+    roster: AuthorityQuery<CitedRosterAuthority>,
+    coordinate: &ChainCoordinate,
+    view: &dyn HeaderView,
+    cut_target_unknown: &mut bool,
+) -> AuthorityQuery<CitedRosterAuthority> {
+    let AuthorityQuery::Effective(mut fact) = roster else {
+        return roster;
+    };
+    if let AuthorityBoundary::Cut { seq, hash } = fact.authority.boundary {
+        match candidate::validate_cut_target(seq, &hash, coordinate, view) {
+            CutBinding::Ok => {},
+            CutBinding::TargetNotHeld => {
+                *cut_target_unknown = true;
+                fact.authority.boundary = AuthorityBoundary::Open;
+            },
+            CutBinding::Mismatch => fact.authority.boundary = AuthorityBoundary::Open,
+        }
+    }
+    AuthorityQuery::Effective(fact)
+}
+
+/// Bind a grant device cut's watermark to this coordinate against the content DAG — the grant-side
+/// mirror of [`bind_roster_cut`].
+fn bind_grant_cut(
+    grant: Option<AuthorityQuery<CitedGrantAuthority>>,
+    coordinate: &ChainCoordinate,
+    view: &dyn HeaderView,
+    cut_target_unknown: &mut bool,
+) -> Option<AuthorityQuery<CitedGrantAuthority>> {
+    let Some(AuthorityQuery::Effective(mut fact)) = grant else {
+        return grant;
+    };
+    let cut = match &fact.authority.boundary {
+        GrantDeviceBoundary::Cut(cut) => Some((cut.seq, cut.hash)),
+        _ => None,
+    };
+    if let Some((seq, hash)) = cut {
+        match candidate::validate_cut_target(seq, &hash, coordinate, view) {
+            CutBinding::Ok => {},
+            CutBinding::TargetNotHeld => {
+                *cut_target_unknown = true;
+                fact.authority.boundary = GrantDeviceBoundary::Open;
+            },
+            CutBinding::Mismatch => fact.authority.boundary = GrantDeviceBoundary::Open,
+        }
+    }
+    Some(AuthorityQuery::Effective(fact))
+}
+
+fn map_roster(
+    query: AuthorityQuery<crate::oplog::account::RosterContentAuthority>,
+    header: &ContentEntryHeader,
+) -> AuthorityQuery<CitedRosterAuthority> {
+    match query {
+        AuthorityQuery::Effective(authority) => AuthorityQuery::Effective(CitedRosterAuthority {
+            account_id: header.author_account_id,
+            roster_ref: header.roster_ref,
+            stream_id: header.stream_id,
+            authority,
+        }),
+        AuthorityQuery::Unknown => AuthorityQuery::Unknown,
+        AuthorityQuery::Invalid(reason) => AuthorityQuery::Invalid(reason),
+    }
+}
+
+fn map_grant(
+    query: AuthorityQuery<crate::oplog::account::GrantDeviceAuthority>,
+    owner_account_id: AccountId,
+    grant_id: EntryHash,
+) -> AuthorityQuery<CitedGrantAuthority> {
+    match query {
+        AuthorityQuery::Effective(authority) =>
+            AuthorityQuery::Effective(CitedGrantAuthority { owner_account_id, grant_id, authority }),
+        AuthorityQuery::Unknown => AuthorityQuery::Unknown,
+        AuthorityQuery::Invalid(reason) => AuthorityQuery::Invalid(reason),
+    }
+}
+
+/// Write one entry's verdict: the taxonomy status string, and `accepted = 1` only for `Accepted`.
+fn write_verdict(
+    tx: &Transaction<'_>,
+    entry_hash: &EntryHash,
+    verdict: ContentAcceptance,
+) -> rusqlite::Result<()> {
+    tx.execute(
+        "INSERT INTO content_entry_status(entry_hash, status, detail) VALUES(?1, ?2, NULL)
+         ON CONFLICT(entry_hash) DO UPDATE SET status = excluded.status, detail = NULL",
+        params![entry_hash.as_slice(), verdict.as_db_str()],
+    )?;
+    if verdict == ContentAcceptance::Accepted {
+        tx.execute("UPDATE content_entries SET accepted = 1 WHERE entry_hash = ?1", [
+            entry_hash.as_slice()
+        ])?;
     }
     Ok(())
 }
@@ -1180,5 +1877,696 @@ mod tests {
                 .unwrap(),
             CANDIDATES_PER_AUTHOR_MAX
         );
+    }
+
+    // ---- C3.3: the acceptance refold wired into ingest ----
+
+    const STREAM: [u8; 32] = [0x44; 32];
+
+    /// The parts of a content entry that vary per test. Defaults are the common case: a seq-0 chain
+    /// root, no grant, `auth_len` 0 (freshness `CurrentOrBehind` — the frozen `content` helper pins
+    /// it at `u64::MAX`, always `Ahead`, which would park every accept path), body `0xf6`.
+    #[derive(Clone, Copy)]
+    struct ContentSpec {
+        grant_id: Option<EntryHash>,
+        seq: u64,
+        previous: Option<EntryHash>,
+        auth_len: u64,
+        body: u8,
+    }
+
+    impl Default for ContentSpec {
+        fn default() -> Self {
+            Self { grant_id: None, seq: 0, previous: None, auth_len: 0, body: 0xf6 }
+        }
+    }
+
+    /// Sign a content entry. `roster_ref` must name the author's real account genesis so the
+    /// signing device resolves (see [`resolve_roster_key`]).
+    fn authored(
+        secret: &DeviceSecret,
+        author: AccountId,
+        roster_ref: EntryHash,
+        spec: ContentSpec,
+    ) -> SignedContentEntry {
+        let header = ContentEntryHeader {
+            stream_id: StreamId::from_bytes(STREAM),
+            author_account_id: author,
+            device_fingerprint: secret.public().fingerprint(),
+            seq: spec.seq,
+            lamport: spec.seq.saturating_add(1),
+            prev_hash: spec.previous,
+            grant_id: spec.grant_id,
+            roster_ref,
+            owner_auth_len: spec.auth_len,
+            author_auth_len: spec.auth_len,
+            crypto_suite: 0,
+            key_id: None,
+        };
+        envelope::sign_content_entry(secret, &header, &[spec.body]).unwrap()
+    }
+
+    fn seed_ownership(conn: &Connection, owner: AccountId) {
+        conn.execute(
+            "INSERT INTO account_stream_ownership(stream_id, account_id, own_id, effective_at)
+             VALUES(?1, ?2, ?3, 1)",
+            params![STREAM.as_slice(), owner.to_bytes().as_slice(), [0x66_u8; 32].as_slice()],
+        )
+        .unwrap();
+    }
+
+    fn seed_roster_fact(
+        conn: &Connection,
+        roster_ref: EntryHash,
+        account: AccountId,
+        device: &DeviceSecret,
+        role: &str,
+    ) {
+        conn.execute(
+            "INSERT INTO account_roster_history(
+                 roster_ref, account_id, device_fingerprint, role, effective_at, closed_at)
+             VALUES(?1, ?2, ?3, ?4, 1, NULL)",
+            params![
+                roster_ref.as_slice(),
+                account.to_bytes().as_slice(),
+                device.public().fingerprint().to_bytes().as_slice(),
+                role,
+            ],
+        )
+        .unwrap();
+    }
+
+    fn seed_roster_content_cut(
+        conn: &Connection,
+        roster_ref: EntryHash,
+        account: AccountId,
+        seq: u64,
+        watermark: [u8; 32],
+    ) {
+        conn.execute(
+            "INSERT INTO account_roster_content_boundaries(
+                 roster_ref, account_id, stream_id, seq, entry_hash)
+             VALUES(?1, ?2, ?3, ?4, ?5)",
+            params![
+                roster_ref.as_slice(),
+                account.to_bytes().as_slice(),
+                STREAM.as_slice(),
+                seq.to_be_bytes().as_slice(),
+                watermark.as_slice(),
+            ],
+        )
+        .unwrap();
+    }
+
+    fn seed_grant(
+        conn: &Connection,
+        grant_id: EntryHash,
+        owner: AccountId,
+        grantee: AccountId,
+        role: &str,
+    ) {
+        conn.execute(
+            "INSERT INTO account_stream_grants(
+                 grant_id, owner_account_id, stream_id, grantee_account_id, role,
+                 effective_at, closed_at)
+             VALUES(?1, ?2, ?3, ?4, ?5, 1, NULL)",
+            params![
+                grant_id.as_slice(),
+                owner.to_bytes().as_slice(),
+                STREAM.as_slice(),
+                grantee.to_bytes().as_slice(),
+                role,
+            ],
+        )
+        .unwrap();
+    }
+
+    /// A revoked (closed) grant plus a device cut, so `grant_effective_for_device_in_snapshot`
+    /// resolves it to a `Cut` boundary — the shape whose watermark could be misused as a branch
+    /// pin.
+    fn seed_closed_grant_with_cut(
+        conn: &Connection,
+        grant_id: EntryHash,
+        owner: AccountId,
+        grantee: AccountId,
+        role: &str,
+        device: &DeviceSecret,
+        watermark: [u8; 32],
+    ) {
+        conn.execute(
+            "INSERT INTO account_stream_grants(
+                 grant_id, owner_account_id, stream_id, grantee_account_id, role,
+                 effective_at, closed_at)
+             VALUES(?1, ?2, ?3, ?4, ?5, 1, 2)",
+            params![
+                grant_id.as_slice(),
+                owner.to_bytes().as_slice(),
+                STREAM.as_slice(),
+                grantee.to_bytes().as_slice(),
+                role,
+            ],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO account_stream_grant_cuts(
+                 grant_id, owner_account_id, device_fingerprint, seq, entry_hash)
+             VALUES(?1, ?2, ?3, ?4, ?5)",
+            params![
+                grant_id.as_slice(),
+                owner.to_bytes().as_slice(),
+                device.public().fingerprint().to_bytes().as_slice(),
+                0_u64.to_be_bytes().as_slice(),
+                watermark.as_slice(),
+            ],
+        )
+        .unwrap();
+    }
+
+    fn seed_contested(conn: &Connection, account: AccountId) {
+        conn.execute(
+            "INSERT INTO account_auth_state(
+                 account_id, classification, contested_depth, successor_account_id, \
+             effective_count)
+             VALUES(?1, 'contested', 1, NULL, 3)",
+            [account.to_bytes().as_slice()],
+        )
+        .unwrap();
+    }
+
+    fn verdict(conn: &Connection, entry_hash: &EntryHash) -> (String, i64) {
+        conn.query_row(
+            "SELECT s.status, e.accepted FROM content_entries e
+             JOIN content_entry_status s ON s.entry_hash = e.entry_hash
+             WHERE e.entry_hash = ?1",
+            [entry_hash.as_slice()],
+            |row| Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?)),
+        )
+        .unwrap()
+    }
+
+    fn verdict_after_ingest(conn: &Connection, entry: &SignedContentEntry) -> (String, i64) {
+        content_ingest(conn, &entry.signed_bytes, 1).unwrap();
+        verdict(conn, &entry.entry_hash)
+    }
+
+    #[test]
+    fn an_owner_authored_entry_accepts_when_authority_and_branch_are_clear() {
+        let conn = db();
+        let secret = DeviceSecret::from_seed(&[0x21; 32]);
+        let (owner, genesis) = roster(&conn, &secret);
+        seed_ownership(&conn, owner);
+        seed_roster_fact(&conn, genesis, owner, &secret, "owner");
+
+        let entry = authored(&secret, owner, genesis, ContentSpec::default());
+        assert_eq!(
+            content_ingest(&conn, &entry.signed_bytes, 1).unwrap(),
+            ContentIngestOutcome::Ingested { status: "accepted".into() },
+        );
+        assert_eq!(verdict(&conn, &entry.entry_hash), ("accepted".into(), 1));
+    }
+
+    #[test]
+    fn a_contributor_with_a_writer_grant_accepts() {
+        let conn = db();
+        let owner_secret = DeviceSecret::from_seed(&[0x31; 32]);
+        let author_secret = DeviceSecret::from_seed(&[0x32; 32]);
+        let owner = roster(&conn, &owner_secret).0;
+        let (author, author_genesis) = roster(&conn, &author_secret);
+        let grant_id = [0x67; 32];
+        seed_ownership(&conn, owner);
+        seed_roster_fact(&conn, author_genesis, author, &author_secret, "member");
+        seed_grant(&conn, grant_id, owner, author, "writer");
+
+        let entry = authored(&author_secret, author, author_genesis, ContentSpec {
+            grant_id: Some(grant_id),
+            ..ContentSpec::default()
+        });
+        assert_eq!(verdict_after_ingest(&conn, &entry), ("accepted".into(), 1));
+    }
+
+    #[test]
+    fn a_contributor_whose_grant_only_reads_is_rejected() {
+        let conn = db();
+        let owner_secret = DeviceSecret::from_seed(&[0x41; 32]);
+        let author_secret = DeviceSecret::from_seed(&[0x42; 32]);
+        let owner = roster(&conn, &owner_secret).0;
+        let (author, author_genesis) = roster(&conn, &author_secret);
+        let grant_id = [0x68; 32];
+        seed_ownership(&conn, owner);
+        seed_roster_fact(&conn, author_genesis, author, &author_secret, "member");
+        seed_grant(&conn, grant_id, owner, author, "reader");
+
+        let entry = authored(&author_secret, author, author_genesis, ContentSpec {
+            grant_id: Some(grant_id),
+            ..ContentSpec::default()
+        });
+        assert_eq!(verdict_after_ingest(&conn, &entry), ("rejected{grant_not_writer}".into(), 0));
+    }
+
+    #[test]
+    fn an_equivocating_fork_accepts_the_smaller_hash_and_forks_the_loser() {
+        let conn = db();
+        let secret = DeviceSecret::from_seed(&[0x51; 32]);
+        let (owner, genesis) = roster(&conn, &secret);
+        seed_ownership(&conn, owner);
+        seed_roster_fact(&conn, genesis, owner, &secret, "owner");
+
+        // Two seq-0 entries on one coordinate — an equivocation. Both are authority-eligible, so
+        // branch selection resolves the unforced fork by the smaller entry_hash; the loser is
+        // terminal `forked`, never accepted.
+        let a = authored(&secret, owner, genesis, ContentSpec::default());
+        let b =
+            authored(&secret, owner, genesis, ContentSpec { body: 0xf7, ..ContentSpec::default() });
+        content_ingest(&conn, &a.signed_bytes, 1).unwrap();
+        content_ingest(&conn, &b.signed_bytes, 2).unwrap();
+
+        let (winner, loser) = if a.entry_hash < b.entry_hash { (&a, &b) } else { (&b, &a) };
+        assert_eq!(verdict(&conn, &winner.entry_hash), ("accepted".into(), 1));
+        assert_eq!(verdict(&conn, &loser.entry_hash), ("forked".into(), 0));
+    }
+
+    #[test]
+    fn a_register_cut_condemns_an_entry_beyond_its_bound_watermark() {
+        let conn = db();
+        let secret = DeviceSecret::from_seed(&[0x61; 32]);
+        let (owner, genesis) = roster(&conn, &secret);
+        seed_ownership(&conn, owner);
+        seed_roster_fact(&conn, genesis, owner, &secret, "owner");
+
+        // A real seq-0 entry, then a roster content cut bounding this coordinate AT that held
+        // watermark. seq 0 is on the cut (accepted); seq 1 is beyond it → condemned.
+        let s0 = authored(&secret, owner, genesis, ContentSpec::default());
+        content_ingest(&conn, &s0.signed_bytes, 1).unwrap();
+        seed_roster_content_cut(&conn, genesis, owner, 0, s0.entry_hash);
+        let s1 = authored(&secret, owner, genesis, ContentSpec {
+            seq: 1,
+            previous: Some(s0.entry_hash),
+            ..ContentSpec::default()
+        });
+        assert_eq!(verdict_after_ingest(&conn, &s1), ("condemned{beyond_cut}".into(), 0));
+        assert_eq!(verdict(&conn, &s0.entry_hash), ("accepted".into(), 1));
+    }
+
+    #[test]
+    fn a_cut_whose_watermark_is_not_held_parks_rather_than_condemning() {
+        let conn = db();
+        let secret = DeviceSecret::from_seed(&[0x62; 32]);
+        let (owner, genesis) = roster(&conn, &secret);
+        seed_ownership(&conn, owner);
+        seed_roster_fact(&conn, genesis, owner, &secret, "owner");
+        // A malformed/late cut names a watermark we do not hold. It must NOT condemn an honest
+        // beyond-`seq` entry (§11.3 / I11 — an unheld watermark parks, never flips a verdict); a
+        // later `CutExtend` or the watermark's arrival re-evaluates it.
+        seed_roster_content_cut(&conn, genesis, owner, 3, [0xcc; 32]);
+
+        let entry = authored(&secret, owner, genesis, ContentSpec {
+            seq: 5,
+            previous: Some([0xaa; 32]),
+            ..ContentSpec::default()
+        });
+        assert_eq!(verdict_after_ingest(&conn, &entry), ("parked{unknown_cut_target}".into(), 0));
+    }
+
+    #[test]
+    fn a_cut_whose_watermark_names_a_foreign_coordinate_is_ignored() {
+        let conn = db();
+        let secret = DeviceSecret::from_seed(&[0x63; 32]);
+        let (owner, genesis) = roster(&conn, &secret);
+        seed_ownership(&conn, owner);
+        seed_roster_fact(&conn, genesis, owner, &secret, "owner");
+
+        // A dense chain seq 0 → 1, both accepted. Then a cut claims to bound seq 0 but names the
+        // seq-1 entry as its watermark — a coordinate/seq mismatch. A malformed cut must not
+        // condemn honest content (the §11.3 laundering guard); both stay accepted.
+        let s0 = authored(&secret, owner, genesis, ContentSpec::default());
+        content_ingest(&conn, &s0.signed_bytes, 1).unwrap();
+        let s1 = authored(&secret, owner, genesis, ContentSpec {
+            seq: 1,
+            previous: Some(s0.entry_hash),
+            ..ContentSpec::default()
+        });
+        content_ingest(&conn, &s1.signed_bytes, 2).unwrap();
+        seed_roster_content_cut(&conn, genesis, owner, 0, s1.entry_hash);
+        run_account_trigger(&conn, owner);
+
+        assert_eq!(verdict(&conn, &s0.entry_hash), ("accepted".into(), 1));
+        assert_eq!(verdict(&conn, &s1.entry_hash), ("accepted".into(), 1));
+    }
+
+    #[test]
+    fn a_contested_author_parks_as_contested_subject() {
+        let conn = db();
+        let secret = DeviceSecret::from_seed(&[0x71; 32]);
+        let (owner, genesis) = roster(&conn, &secret);
+        seed_ownership(&conn, owner);
+        seed_roster_fact(&conn, genesis, owner, &secret, "owner");
+        seed_contested(&conn, owner);
+
+        let entry = authored(&secret, owner, genesis, ContentSpec::default());
+        assert_eq!(verdict_after_ingest(&conn, &entry), ("parked{contested_subject}".into(), 0));
+    }
+
+    #[test]
+    fn an_author_ahead_of_our_fold_parks_for_refetch_not_rejects() {
+        let conn = db();
+        let secret = DeviceSecret::from_seed(&[0x81; 32]);
+        let (owner, genesis) = roster(&conn, &secret);
+        seed_ownership(&conn, owner);
+        seed_roster_fact(&conn, genesis, owner, &secret, "owner");
+
+        // The author cites a control-fold length we have not reached (our effective_count is 0).
+        // Freshness is the LAST axis (§13): with authority and branch otherwise clear, this parks
+        // for refetch rather than hardening into a rejection we would later walk back.
+        let entry = authored(&secret, owner, genesis, ContentSpec {
+            auth_len: 9,
+            ..ContentSpec::default()
+        });
+        assert_eq!(verdict_after_ingest(&conn, &entry), ("parked{auth_len_ahead}".into(), 0));
+    }
+
+    /// Run the account→content trigger the way an account fold does — one IMMEDIATE txn.
+    fn run_account_trigger(conn: &Connection, account: AccountId) {
+        run_account_trigger_owning(conn, account, &[]);
+    }
+
+    /// The trigger with an explicit pre-rewrite owned-stream set (what the account fold captures
+    /// before it rewrites the projection).
+    fn run_account_trigger_owning(
+        conn: &Connection,
+        account: AccountId,
+        previously_owned: &[[u8; 32]],
+    ) {
+        let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate).unwrap();
+        refold_streams_for_account(&tx, account, previously_owned).unwrap();
+        tx.commit().unwrap();
+    }
+
+    #[test]
+    fn content_that_arrives_before_its_owner_fact_is_classified_when_the_trigger_runs() {
+        let conn = db();
+        let secret = DeviceSecret::from_seed(&[0x91; 32]);
+        let (owner, genesis) = roster(&conn, &secret);
+
+        // No `StreamOwn` fact yet: the ingest-time refold cannot evaluate authority, so the entry
+        // keeps its structural `retained_unfolded` status rather than being wrongly
+        // parked/rejected.
+        let entry = authored(&secret, owner, genesis, ContentSpec::default());
+        assert_eq!(verdict_after_ingest(&conn, &entry), ("retained_unfolded".into(), 0));
+
+        // The owner's ownership + roster facts fold; the account→content trigger reclassifies the
+        // stream in that account-refold txn, and the entry reaches its real verdict.
+        seed_ownership(&conn, owner);
+        seed_roster_fact(&conn, genesis, owner, &secret, "owner");
+        run_account_trigger(&conn, owner);
+        assert_eq!(verdict(&conn, &entry.entry_hash), ("accepted".into(), 1));
+    }
+
+    #[test]
+    fn a_cut_folding_later_retro_condemns_already_accepted_content() {
+        let conn = db();
+        let secret = DeviceSecret::from_seed(&[0xa1; 32]);
+        let (owner, genesis) = roster(&conn, &secret);
+        seed_ownership(&conn, owner);
+        seed_roster_fact(&conn, genesis, owner, &secret, "owner");
+
+        // A dense chain seq 0 → 1, both accepted at ingest.
+        let s0 = authored(&secret, owner, genesis, ContentSpec::default());
+        content_ingest(&conn, &s0.signed_bytes, 1).unwrap();
+        let s1 = authored(&secret, owner, genesis, ContentSpec {
+            seq: 1,
+            previous: Some(s0.entry_hash),
+            ..ContentSpec::default()
+        });
+        content_ingest(&conn, &s1.signed_bytes, 2).unwrap();
+        assert_eq!(verdict(&conn, &s0.entry_hash), ("accepted".into(), 1));
+        assert_eq!(verdict(&conn, &s1.entry_hash), ("accepted".into(), 1));
+
+        // A revocation bounds the coordinate at seq 0 (watermark = s0). On the next account fold
+        // the trigger retro-condemns seq 1 (beyond the cut) while seq 0 stays accepted —
+        // the revocation takes effect without any new content arriving (L2 enforceable).
+        seed_roster_content_cut(&conn, genesis, owner, 0, s0.entry_hash);
+        run_account_trigger(&conn, owner);
+        assert_eq!(verdict(&conn, &s0.entry_hash), ("accepted".into(), 1));
+        assert_eq!(verdict(&conn, &s1.entry_hash), ("condemned{beyond_cut}".into(), 0));
+    }
+
+    #[test]
+    fn losing_ownership_declassifies_previously_accepted_contributor_content() {
+        let conn = db();
+        let owner_secret = DeviceSecret::from_seed(&[0xb1; 32]);
+        let author_secret = DeviceSecret::from_seed(&[0xb2; 32]);
+        let owner = roster(&conn, &owner_secret).0;
+        let (author, author_genesis) = roster(&conn, &author_secret);
+        let grant_id = [0x69; 32];
+        seed_ownership(&conn, owner);
+        seed_roster_fact(&conn, author_genesis, author, &author_secret, "member");
+        seed_grant(&conn, grant_id, owner, author, "writer");
+
+        // A contributor's entry accepts. The owner neither authored it nor (after the next step)
+        // owns the stream, so only the pre-rewrite owned set can rediscover it.
+        let entry = authored(&author_secret, author, author_genesis, ContentSpec {
+            grant_id: Some(grant_id),
+            ..ContentSpec::default()
+        });
+        assert_eq!(verdict_after_ingest(&conn, &entry), ("accepted".into(), 1));
+
+        // The owner's `StreamOwn` fact is dropped (owner contested / branch reselection).
+        conn.execute("DELETE FROM account_stream_ownership WHERE account_id = ?1", [owner
+            .to_bytes()
+            .as_slice()])
+            .unwrap();
+
+        // Without the pre-rewrite owned set the orphaned stream is invisible to the trigger (the
+        // owner no longer owns it and never authored it), so the stale acceptance would survive —
+        // exactly the hole the captured set closes.
+        run_account_trigger_owning(&conn, owner, &[]);
+        assert_eq!(verdict(&conn, &entry.entry_hash), ("accepted".into(), 1));
+
+        // With it, the stream is refolded, finds no owner, and declassifies the entry.
+        run_account_trigger_owning(&conn, owner, &[StreamId::from_bytes(STREAM).to_bytes()]);
+        assert_eq!(verdict(&conn, &entry.entry_hash), ("retained_unfolded".into(), 0));
+    }
+
+    #[test]
+    fn a_contested_owner_parks_contributor_content_even_when_the_author_is_live() {
+        let conn = db();
+        let owner_secret = DeviceSecret::from_seed(&[0xc1; 32]);
+        let author_secret = DeviceSecret::from_seed(&[0xc2; 32]);
+        let owner = roster(&conn, &owner_secret).0;
+        let (author, author_genesis) = roster(&conn, &author_secret);
+        let grant_id = [0x6a; 32];
+        seed_ownership(&conn, owner);
+        seed_roster_fact(&conn, author_genesis, author, &author_secret, "member");
+        seed_grant(&conn, grant_id, owner, author, "writer");
+        // The OWNER is contested while the contributor stays live. The writer grant lives in the
+        // owner's log, so a compromised owner poisons it: the content must fail closed.
+        seed_contested(&conn, owner);
+
+        let entry = authored(&author_secret, author, author_genesis, ContentSpec {
+            grant_id: Some(grant_id),
+            ..ContentSpec::default()
+        });
+        assert_eq!(verdict_after_ingest(&conn, &entry), ("parked{contested_subject}".into(), 0));
+    }
+
+    #[test]
+    fn a_candidate_whose_stored_bytes_go_corrupt_is_declassified_not_left_accepted() {
+        let conn = db();
+        let secret = DeviceSecret::from_seed(&[0xd1; 32]);
+        let (owner, genesis) = roster(&conn, &secret);
+        seed_ownership(&conn, owner);
+        seed_roster_fact(&conn, genesis, owner, &secret, "owner");
+
+        let entry = authored(&secret, owner, genesis, ContentSpec::default());
+        assert_eq!(verdict_after_ingest(&conn, &entry), ("accepted".into(), 1));
+
+        // The stored envelope is corrupted (a torn write / bad blob). The next refold cannot decode
+        // it, so it must lose `accepted` and its status — a candidate with no readable authority
+        // basis must never stay live.
+        conn.execute(
+            "UPDATE content_entries SET signed_bytes = ?1 WHERE entry_hash = ?2",
+            params![[0_u8].as_slice(), entry.entry_hash.as_slice(),],
+        )
+        .unwrap();
+        run_account_trigger(&conn, owner);
+        assert_eq!(verdict(&conn, &entry.entry_hash), ("retained_unfolded".into(), 0));
+    }
+
+    #[test]
+    fn an_orphaned_stream_whose_only_candidate_is_corrupt_still_loses_acceptance() {
+        let conn = db();
+        let secret = DeviceSecret::from_seed(&[0xe1; 32]);
+        let (owner, genesis) = roster(&conn, &secret);
+        seed_ownership(&conn, owner);
+        seed_roster_fact(&conn, genesis, owner, &secret, "owner");
+
+        let entry = authored(&secret, owner, genesis, ContentSpec::default());
+        assert_eq!(verdict_after_ingest(&conn, &entry), ("accepted".into(), 1));
+
+        // Worst case: ownership disappears AND the sole stored envelope is corrupt, so the refold
+        // resolves no owner and decodes no headers. The declassify path must STILL clear acceptance
+        // — an empty header list must not early-return past the `accepted = 0` clear.
+        conn.execute("DELETE FROM account_stream_ownership WHERE account_id = ?1", [owner
+            .to_bytes()
+            .as_slice()])
+            .unwrap();
+        conn.execute(
+            "UPDATE content_entries SET signed_bytes = ?1 WHERE entry_hash = ?2",
+            params![[0_u8].as_slice(), entry.entry_hash.as_slice()],
+        )
+        .unwrap();
+        run_account_trigger_owning(&conn, owner, &[StreamId::from_bytes(STREAM).to_bytes()]);
+        assert_eq!(verdict(&conn, &entry.entry_hash), ("retained_unfolded".into(), 0));
+    }
+
+    #[test]
+    fn a_row_whose_blob_was_swapped_for_a_different_valid_envelope_is_not_classified() {
+        let conn = db();
+        let secret = DeviceSecret::from_seed(&[0xf1; 32]);
+        let (owner, genesis) = roster(&conn, &secret);
+        seed_ownership(&conn, owner);
+        seed_roster_fact(&conn, genesis, owner, &secret, "owner");
+
+        let a = authored(&secret, owner, genesis, ContentSpec::default());
+        assert_eq!(verdict_after_ingest(&conn, &a), ("accepted".into(), 1));
+
+        // Replace A's stored blob with a DIFFERENT (still valid) envelope, under A's row key. The
+        // refold must not classify A's row under B's header just because B decodes — the decoded
+        // `entry_hash` no longer matches the key, so the row is treated as absent and declassified.
+        let b =
+            authored(&secret, owner, genesis, ContentSpec { body: 0xf7, ..ContentSpec::default() });
+        assert_ne!(a.entry_hash, b.entry_hash);
+        conn.execute(
+            "UPDATE content_entries SET signed_bytes = ?1 WHERE entry_hash = ?2",
+            params![b.signed_bytes.as_slice(), a.entry_hash.as_slice()],
+        )
+        .unwrap();
+        run_account_trigger(&conn, owner);
+        assert_eq!(verdict(&conn, &a.entry_hash), ("retained_unfolded".into(), 0));
+    }
+
+    #[test]
+    fn a_descendant_of_a_freshness_parked_entry_does_not_accept_out_of_prefix() {
+        let conn = db();
+        let secret = DeviceSecret::from_seed(&[0xd2; 32]);
+        let (owner, genesis) = roster(&conn, &secret);
+        seed_ownership(&conn, owner);
+        seed_roster_fact(&conn, genesis, owner, &secret, "owner");
+
+        // seq 0 cites a control-fold length ahead of ours (parks on freshness); seq 1 cites a
+        // current length. An attacker varies `auth_len` DOWN the chain to try to slip seq 1 in as
+        // accepted over a parked seq 0. The accepted set must stay a prefix from seq 0, so neither
+        // accepts while seq 0 is parked.
+        let s0 = authored(&secret, owner, genesis, ContentSpec {
+            auth_len: 9,
+            ..ContentSpec::default()
+        });
+        content_ingest(&conn, &s0.signed_bytes, 1).unwrap();
+        let s1 = authored(&secret, owner, genesis, ContentSpec {
+            seq: 1,
+            previous: Some(s0.entry_hash),
+            auth_len: 0,
+            ..ContentSpec::default()
+        });
+        content_ingest(&conn, &s1.signed_bytes, 2).unwrap();
+
+        assert_eq!(verdict(&conn, &s0.entry_hash), ("parked{auth_len_ahead}".into(), 0));
+        assert_eq!(verdict(&conn, &s1.entry_hash), ("parked{auth_len_ahead}".into(), 0));
+    }
+
+    #[test]
+    fn an_eligible_child_of_an_ineligible_parent_parks_rather_than_forks() {
+        let conn = db();
+        let secret = DeviceSecret::from_seed(&[0xd3; 32]);
+        let (owner, genesis) = roster(&conn, &secret);
+        seed_ownership(&conn, owner);
+        seed_roster_fact(&conn, genesis, owner, &secret, "owner");
+
+        // seq 0 is the owner citing a grant it must not have → rejected (ineligible). seq 1 is a
+        // clean owner entry building on it: authority-eligible, but with no accepted parent to
+        // extend. It is stranded, not a contest loser, so it parks (recoverable) — never `forked`.
+        let s0 = authored(&secret, owner, genesis, ContentSpec {
+            grant_id: Some([0x6b; 32]),
+            ..ContentSpec::default()
+        });
+        content_ingest(&conn, &s0.signed_bytes, 1).unwrap();
+        let s1 = authored(&secret, owner, genesis, ContentSpec {
+            seq: 1,
+            previous: Some(s0.entry_hash),
+            ..ContentSpec::default()
+        });
+        content_ingest(&conn, &s1.signed_bytes, 2).unwrap();
+
+        assert_eq!(verdict(&conn, &s0.entry_hash), ("rejected{unexpected_grant}".into(), 0));
+        assert_eq!(verdict(&conn, &s1.entry_hash), ("parked{missing_predecessor}".into(), 0));
+    }
+
+    #[test]
+    fn the_account_trigger_is_a_noop_before_the_content_tables_exist() {
+        // Mid-migration: the V064/V065 authority backfill folds every existing account before the
+        // `/3` tables are created. The account→content trigger must not query `content_entries`
+        // (which does not exist yet) — otherwise a populated DB fails to upgrade.
+        let conn = Connection::open_in_memory().unwrap();
+        let owner = signed_roster(&DeviceSecret::from_seed(&[0xe2; 32])).0;
+        let tx = Transaction::new_unchecked(&conn, TransactionBehavior::Immediate).unwrap();
+        refold_streams_for_account(&tx, owner, &[]).unwrap();
+        tx.commit().unwrap();
+    }
+
+    #[test]
+    fn a_reader_grants_revoke_cut_cannot_steer_writer_content_branch_selection() {
+        let conn = db();
+        let owner_secret = DeviceSecret::from_seed(&[0xf3; 32]);
+        let author_secret = DeviceSecret::from_seed(&[0xf4; 32]);
+        let owner = roster(&conn, &owner_secret).0;
+        let (author, author_genesis) = roster(&conn, &author_secret);
+        let writer_grant = [0x71; 32];
+        let reader_grant = [0x72; 32];
+        seed_ownership(&conn, owner);
+        seed_roster_fact(&conn, author_genesis, author, &author_secret, "member");
+        seed_grant(&conn, writer_grant, owner, author, "writer");
+
+        // Two writer entries at seq 0 (equivocation): the smaller entry_hash wins the unforced
+        // fork.
+        let a = authored(&author_secret, author, author_genesis, ContentSpec {
+            grant_id: Some(writer_grant),
+            body: 0xf6,
+            ..ContentSpec::default()
+        });
+        let b = authored(&author_secret, author, author_genesis, ContentSpec {
+            grant_id: Some(writer_grant),
+            body: 0xf7,
+            ..ContentSpec::default()
+        });
+        content_ingest(&conn, &a.signed_bytes, 1).unwrap();
+        content_ingest(&conn, &b.signed_bytes, 2).unwrap();
+        let (winner, loser) = if a.entry_hash < b.entry_hash { (&a, &b) } else { (&b, &a) };
+
+        // A revoked READER grant on the same coordinate carries a cut naming the hash-order LOSER.
+        // A reader grant never authorizes a content write, so its cut must NOT pin selection — else
+        // a peer could hijack the accepted branch by storing a rejected reader-grant entry.
+        seed_closed_grant_with_cut(
+            &conn,
+            reader_grant,
+            owner,
+            author,
+            "reader",
+            &author_secret,
+            loser.entry_hash,
+        );
+        let reader_entry = authored(&author_secret, author, author_genesis, ContentSpec {
+            grant_id: Some(reader_grant),
+            body: 0xf5,
+            ..ContentSpec::default()
+        });
+        content_ingest(&conn, &reader_entry.signed_bytes, 3).unwrap();
+
+        assert_eq!(
+            verdict(&conn, &reader_entry.entry_hash),
+            ("rejected{grant_not_writer}".into(), 0)
+        );
+        // Hash order still decides — the reader cut did not steer the writers' branch.
+        assert_eq!(verdict(&conn, &winner.entry_hash), ("accepted".into(), 1));
+        assert_eq!(verdict(&conn, &loser.entry_hash), ("forked".into(), 0));
     }
 }

--- a/crates/rag-rat-core/src/oplog/account/storage.rs
+++ b/crates/rag-rat-core/src/oplog/account/storage.rs
@@ -338,7 +338,28 @@ pub(crate) fn roster_content_authority(
     stream_id: StreamId,
 ) -> anyhow::Result<fold::AuthorityQuery<fold::RosterContentAuthority>> {
     let read_tx = Transaction::new_unchecked(conn, TransactionBehavior::Deferred)?;
-    let conn: &Connection = &read_tx;
+    roster_content_authority_in_snapshot(
+        &read_tx,
+        account_id,
+        roster_ref,
+        device_fingerprint,
+        stream_id,
+    )
+}
+
+/// The body of [`roster_content_authority`], reading whatever snapshot `conn` is already in.
+///
+/// The `/3` refold resolves EVERY authority fact for an entry — ownership, roster, grant, both
+/// freshness verdicts — and must see one consistent snapshot across all of them, or a refold
+/// committing mid-evaluation could pair an old grant with a new cut. It therefore reads inside its
+/// own transaction and cannot call the wrapper above, which would try to `BEGIN` a second one.
+pub(crate) fn roster_content_authority_in_snapshot(
+    conn: &Connection,
+    account_id: AccountId,
+    roster_ref: EntryHash,
+    device_fingerprint: DeviceFingerprint,
+    stream_id: StreamId,
+) -> anyhow::Result<fold::AuthorityQuery<fold::RosterContentAuthority>> {
     let row: Option<(Vec<u8>, String, i64, Option<i64>)> = conn
         .query_row(
             "SELECT device_fingerprint, role, effective_at, closed_at
@@ -579,7 +600,9 @@ pub(crate) fn grant_effective_for_device(
     )
 }
 
-fn grant_effective_for_device_in_snapshot(
+/// The body of [`grant_effective_for_device`], reading whatever snapshot `conn` is already in — see
+/// [`roster_content_authority_in_snapshot`] for why the `/3` refold needs this shape.
+pub(crate) fn grant_effective_for_device_in_snapshot(
     conn: &Connection,
     owner_account_id: AccountId,
     grant_id: EntryHash,
@@ -625,7 +648,16 @@ pub(crate) fn stream_owner_effective(
     stream_id: StreamId,
 ) -> anyhow::Result<fold::AuthorityQuery<EntryHash>> {
     let read_tx = Transaction::new_unchecked(conn, TransactionBehavior::Deferred)?;
-    let conn: &Connection = &read_tx;
+    stream_owner_effective_in_snapshot(&read_tx, account_id, stream_id)
+}
+
+/// The body of [`stream_owner_effective`], reading whatever snapshot `conn` is already in — see
+/// [`roster_content_authority_in_snapshot`] for why the `/3` refold needs this shape.
+pub(crate) fn stream_owner_effective_in_snapshot(
+    conn: &Connection,
+    account_id: AccountId,
+    stream_id: StreamId,
+) -> anyhow::Result<fold::AuthorityQuery<EntryHash>> {
     let row: Option<(Vec<u8>, i64)> = conn
         .query_row(
             "SELECT own_id, effective_at FROM account_stream_ownership
@@ -691,6 +723,44 @@ fn load_grant_device_cut(
         })
     })
     .transpose()
+}
+
+/// The account that owns `stream_id`, per the current fold.
+///
+/// A `/3` header never names its owner: `stream_id` is `sha256(cbor([..., owner_account_id,
+/// ...]))`, so ownership is INSIDE the identity and two accounts claiming one stream is
+/// cryptographically impossible (§14). The preimage is not invertible, though, so the owner is
+/// resolved through the `StreamOwn` fact the owner published. No fact ⇒ we do not know who owns
+/// this stream yet, and nothing on it can be authorized — that is recoverable, never a rejection.
+pub(crate) fn stream_owner_account(
+    conn: &Connection,
+    stream_id: StreamId,
+) -> anyhow::Result<Option<AccountId>> {
+    let owner: Option<Vec<u8>> = conn
+        .query_row(
+            "SELECT account_id FROM account_stream_ownership WHERE stream_id = ?1",
+            [stream_id.to_bytes().as_slice()],
+            |row| row.get(0),
+        )
+        .optional()?;
+    owner.map(|bytes| Ok(AccountId::from_bytes(fixed(&bytes)?))).transpose()
+}
+
+/// Whether an account has folded to `contested` — a genuine owner-key-compromise / equivocation
+/// event (§12), which HALTS authority mutation. Content authorized by a contested account is
+/// fail-closed: parked (quota-bounded), never accepted, and reclassified if the account recovers.
+pub(crate) fn account_is_contested(
+    conn: &Connection,
+    account_id: AccountId,
+) -> anyhow::Result<bool> {
+    let classification: Option<String> = conn
+        .query_row(
+            "SELECT classification FROM account_auth_state WHERE account_id = ?1",
+            [account_id.to_bytes().as_slice()],
+            |row| row.get(0),
+        )
+        .optional()?;
+    Ok(classification.is_some_and(|state| state == "contested"))
 }
 
 /// Measure an asserted control-fold length against our own folded view (§7) — the ONE seam that
@@ -809,6 +879,11 @@ fn refold_in_tx(
     let rows = load_candidates(tx, account_id)?;
     let projection = derive_account_projection(&rows);
 
+    // Streams this account owns BEFORE the projection rewrite: a fold that drops a `StreamOwn` fact
+    // must still refold that stream so its content is declassified, but the ownership row is gone
+    // after the rewrite — so capture it now and hand it to the content trigger below.
+    let previously_owned = owned_streams(tx, account_id)?;
+
     // Rewrite atomically so the partial unique index never observes two accepted rows at a slot.
     tx.execute("UPDATE account_entries SET accepted = 0 WHERE account_id = ?1", params![
         account_id.to_bytes().as_slice()
@@ -845,7 +920,23 @@ fn refold_in_tx(
         statuses.insert(row.entry_hash, status);
     }
     rewrite_authority_projection(tx, account_id, &projection.history)?;
+    // Authority just changed, so content acceptance can change with it: re-evaluate every stream
+    // this account's authority reaches (§13). Same txn as the projection rewrite ⇒ a revocation
+    // retro-condemns accepted content atomically, and content that arrived before its owner's
+    // `StreamOwn` is classified the moment that fact folds.
+    super::content::refold_streams_for_account(tx, account_id, &previously_owned)?;
     Ok(statuses)
+}
+
+/// The streams this account currently owns, per the projection — captured before a refold rewrites
+/// it so a dropped `StreamOwn` still triggers its stream's content declassification.
+fn owned_streams(tx: &Transaction<'_>, account_id: AccountId) -> anyhow::Result<Vec<[u8; 32]>> {
+    let mut stmt =
+        tx.prepare("SELECT stream_id FROM account_stream_ownership WHERE account_id = ?1")?;
+    let rows = stmt
+        .query_map([account_id.to_bytes().as_slice()], |row| row.get::<_, Vec<u8>>(0))?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    rows.iter().map(|bytes| fixed(bytes)).collect()
 }
 
 /// Replace every query-ready authority fact for this account. The caller's IMMEDIATE refold txn


### PR DESCRIPTION
## Summary

Third C3 slice, on top of the pure evaluator (#645) and the candidate substrate (#647). Those froze the logic; neither could set `accepted`. This is the refold that does — the bridge from stored `/3` candidates to the live projection (§13).

`refold_content_stream` re-derives every candidate on a stream from the **current** account fold, in one snapshot (a concurrent account refold must not pair an old grant with a new cut):

1. resolve the stream owner via its `StreamOwn` fact;
2. assemble each entry's authority citations (ownership / roster / grant) + both freshness verdicts;
3. run the two evaluator phases — **eligibility** (`authority_verdict`), then branch selection over the eligible set, then the **finished** verdict;
4. write `accepted` + the taxonomy status.

Register pins for branch selection are the same cut watermarks the authority pass resolves (§16). Clear-then-set inside the txn keeps the `content_accepted_slot` partial-unique index from ever seeing two accepted rows at one `(stream, author, device, seq)` (I10a).

## Two triggers, both in an IMMEDIATE txn

- **`content_ingest`**, after structural classification — a new entry lands on its real verdict immediately, or stays `retained_unfolded` if its owner is not yet known.
- **`refold_account`**, after it rewrites the authority projection — a grant revocation, roster cut, ownership arrival, or contested flip retro-classifies already-stored content, so **a revocation takes effect without waiting for new content** (L2/I5 enforceable). A fold that *drops* ownership still refolds the orphaned stream — the pre-rewrite owned set is captured before the projection is overwritten — and declassifies its now-authority-less content.

## Fail-closed edges (all tested)

- content depending on a contested **author or owner** parks `contested_subject`;
- a stream whose owner is unknown is declassified (not left holding a stale verdict) — this is the "ownership dropped by a later fold" case;
- a candidate whose stored bytes won't decode, **or decode to a different entry than the row key**, is treated as absent and declassified — a swapped/corrupt blob can never be classified under a header that isn't its own.

## Cost, and what's deferred

Within a single refold: reachability is one O(n) forward pass (not a per-entry backward walk), and authority facts are memoized per refold by the exact key each query depends on, so an honest stream sharing one author/roster/grant resolves each fact once. A full refold still runs *per ingest*, so building a stream is O(n²) cumulative (an attacker can vary cited `auth_len` to bypass the freshness cache) — the **same posture the account fold already carries**, bounded by the 4,096/author candidate cap. Making the ingest path incremental is **#652**, to land before ingest is wired to untrusted peers.

## Tests

15 new tests covering the acceptance matrix and the trigger/edge cases: owner-accept, contributor-writer-accept, reader-reject, equivocation-fork, register-cut-condemn, contested-author/owner-park, auth-len-ahead-park, retro-classify-on-late-ownership, retro-condemn-on-later-cut, declassify-on-ownership-loss, and three corruption cases (undecodable, orphaned+corrupt, swapped-valid-envelope). Each load-bearing rule was mutation-checked (no-op refold, author-only contested, early-return declassify, missing entry_hash guard) — every mutation fails exactly the test that covers it.

`cargo nextest run -p rag-rat-core` — 2,472 passed. Clippy with CI's exact invocations on the 1.96 toolchain CI runs; `cargo +nightly fmt --all --check`.

Refs #606