### PR TITLE
feat(papertrail): native GitLab provider — namespaced ids, parallel list legs, events comment lane

### DIFF
--- a/crates/rag-rat-core/src/index/papertrail/api.rs
+++ b/crates/rag-rat-core/src/index/papertrail/api.rs
@@ -17,7 +17,9 @@ pub(crate) async fn sync_mirror(
     let mut jobs = Vec::new();
     for binding in &ctx.trackers {
         record_attempt(conn, binding, now_ms())?;
-        if binding.provider != Tracker::Github {
+        // One source of truth for native providers: the same capability the status surface and
+        // the scheduled filter report.
+        if tracker_synchronization(binding) != TrackerSynchronization::Native {
             errors.push(binding_error(
                 binding,
                 "provider_client_pending",
@@ -114,8 +116,118 @@ fn scheduled_walk_depth(decision: ScheduleDecision, request: AutosyncRequest) ->
 /// walk depth decided. Skipped and provider-client-pending bindings never become jobs.
 struct BindingJob<'a> {
     binding: &'a ResolvedTracker,
-    client: GitHubClient,
+    client: ProviderClient,
     full: bool,
+}
+
+/// The native client for one binding, dispatched by provider. An enum rather than a trait object
+/// because [`PapertrailClient`]'s `async fn` methods are not dyn-compatible; each arm delegates.
+enum ProviderClient {
+    Github(GitHubClient),
+    Gitlab(GitLabClient),
+}
+
+impl ProviderClient {
+    fn new(
+        binding: &ResolvedTracker,
+        registry: &transport::GovernorRegistry,
+        options: transport::TransportOptions,
+    ) -> anyhow::Result<Self> {
+        match binding.provider {
+            Tracker::Github => GitHubClient::new(binding, registry, options).map(Self::Github),
+            Tracker::Gitlab => GitLabClient::new(binding, registry, options).map(Self::Gitlab),
+            other => anyhow::bail!("no native papertrail client for {} yet", other.as_db_str()),
+        }
+    }
+}
+
+impl PapertrailClient for ProviderClient {
+    async fn item(
+        &self,
+        project: &str,
+        kind: ItemKind,
+        key: &str,
+    ) -> anyhow::Result<PapertrailItem> {
+        match self {
+            Self::Github(client) => client.item(project, kind, key).await,
+            Self::Gitlab(client) => client.item(project, kind, key).await,
+        }
+    }
+
+    async fn item_comments(
+        &self,
+        project: &str,
+        kind: ItemKind,
+        key: &str,
+    ) -> anyhow::Result<Vec<PapertrailComment>> {
+        match self {
+            Self::Github(client) => client.item_comments(project, kind, key).await,
+            Self::Gitlab(client) => client.item_comments(project, kind, key).await,
+        }
+    }
+
+    fn item_comment_streams(&self, kind: ItemKind) -> &'static [&'static str] {
+        match self {
+            Self::Github(client) => client.item_comment_streams(kind),
+            Self::Gitlab(client) => client.item_comment_streams(kind),
+        }
+    }
+
+    async fn item_comments_page(
+        &self,
+        project: &str,
+        kind: ItemKind,
+        key: &str,
+        cursor: &PageCursor,
+    ) -> anyhow::Result<CommentsPage> {
+        match self {
+            Self::Github(client) => client.item_comments_page(project, kind, key, cursor).await,
+            Self::Gitlab(client) => client.item_comments_page(project, kind, key, cursor).await,
+        }
+    }
+
+    async fn enrich_item(&self, item: &mut PapertrailItem) -> anyhow::Result<()> {
+        match self {
+            Self::Github(client) => client.enrich_item(item).await,
+            Self::Gitlab(client) => client.enrich_item(item).await,
+        }
+    }
+
+    async fn items_page(&self, project: &str, cursor: &PageCursor) -> anyhow::Result<ItemsPage> {
+        match self {
+            Self::Github(client) => client.items_page(project, cursor).await,
+            Self::Gitlab(client) => client.items_page(project, cursor).await,
+        }
+    }
+
+    fn comment_streams(&self) -> &'static [&'static str] {
+        match self {
+            Self::Github(client) => client.comment_streams(),
+            Self::Gitlab(client) => client.comment_streams(),
+        }
+    }
+
+    async fn comments_page(
+        &self,
+        project: &str,
+        cursor: &PageCursor,
+    ) -> anyhow::Result<CommentsPage> {
+        match self {
+            Self::Github(client) => client.comments_page(project, cursor).await,
+            Self::Gitlab(client) => client.comments_page(project, cursor).await,
+        }
+    }
+
+    async fn freshness_probe(
+        &self,
+        project: &str,
+        probe: &FreshnessProbe,
+    ) -> anyhow::Result<FreshnessResult> {
+        match self {
+            Self::Github(client) => client.freshness_probe(project, probe).await,
+            Self::Gitlab(client) => client.freshness_probe(project, probe).await,
+        }
+    }
 }
 
 /// What one dispatched binding produced: a resumable report, or the error entry to surface.
@@ -135,7 +247,7 @@ fn prepare_binding_job<'a>(
     full: bool,
     errors: &mut Vec<PapertrailSyncError>,
 ) -> anyhow::Result<Option<BindingJob<'a>>> {
-    match GitHubClient::new(binding, registry, options.clone()) {
+    match ProviderClient::new(binding, registry, options.clone()) {
         Ok(client) => Ok(Some(BindingJob { binding, client, full })),
         Err(error) => {
             let persisted_detail = authentication_failure_detail(binding, &error);
@@ -485,7 +597,7 @@ fn discovered_ref_uses_legacy_github_client(
 
 fn tracker_synchronization(binding: &ResolvedTracker) -> TrackerSynchronization {
     match binding.provider {
-        Tracker::Github => TrackerSynchronization::Native,
+        Tracker::Github | Tracker::Gitlab => TrackerSynchronization::Native,
         _ => TrackerSynchronization::ProviderClientPending,
     }
 }
@@ -916,7 +1028,7 @@ mod capability_tests {
         };
         let ctx = PapertrailContext {
             trackers: vec![
-                tracker(Tracker::Gitlab, "group/repo", Some("https://gitlab.com".to_string())),
+                tracker(Tracker::Bitbucket, "workspace/repo", None),
                 tracker(Tracker::Github, "bad/origin", Some("not an absolute URL".to_string())),
                 tracker(Tracker::Github, "fails/http", Some(failed_url)),
             ],
@@ -933,8 +1045,12 @@ mod capability_tests {
             vec!["provider_client_pending", "authentication_or_transport", "failed"]
         );
         assert_eq!(failed_handle.join().unwrap().len(), 1);
-        let pending =
-            report.status.bindings.iter().find(|binding| binding.project == "group/repo").unwrap();
+        let pending = report
+            .status
+            .bindings
+            .iter()
+            .find(|binding| binding.project == "workspace/repo")
+            .unwrap();
         assert!(!pending.failed);
         assert!(!pending.overdue);
         assert_eq!(pending.error_class, None);
@@ -1149,9 +1265,9 @@ mod scheduled_tests {
     fn provider_client_pending_bindings_are_silently_filtered_from_scheduled_runs() {
         let conn = open_schema();
         let binding = ResolvedTracker {
-            provider: Tracker::Gitlab,
-            project: "group/repo".to_string(),
-            base_url: Some("https://gitlab.com".to_string()),
+            provider: Tracker::Bitbucket,
+            project: "workspace/repo".to_string(),
+            base_url: None,
             auth: None,
             authentication: TrackerAuthentication::AuthMissing,
             tags: Vec::new(),

--- a/crates/rag-rat-core/src/index/papertrail/github.rs
+++ b/crates/rag-rat-core/src/index/papertrail/github.rs
@@ -235,7 +235,7 @@ impl PapertrailClient for GitHubClient {
             page_token: Some(page_token),
             ..PageCursor::default()
         });
-        Ok(CommentsPage { comments, next })
+        Ok(CommentsPage { comments, next, frontier: None })
     }
 
     async fn enrich_item(&self, item: &mut PapertrailItem) -> anyhow::Result<()> {
@@ -446,7 +446,7 @@ impl PapertrailClient for GitHubClient {
             page_token: Some(page_token),
             provider_state: None,
         });
-        Ok(CommentsPage { comments, next })
+        Ok(CommentsPage { comments, next, frontier: None })
     }
 
     async fn freshness_probe(

--- a/crates/rag-rat-core/src/index/papertrail/github.rs
+++ b/crates/rag-rat-core/src/index/papertrail/github.rs
@@ -2,7 +2,7 @@
 //! selection, and GitHub payload mapping live here; mirror policy stays in `mirror`.
 
 use reqwest::Url;
-use reqwest::header::{ETAG, IF_NONE_MATCH, LINK};
+use reqwest::header::{ETAG, IF_NONE_MATCH};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -490,14 +490,6 @@ impl PapertrailClient for GitHubClient {
     }
 }
 
-fn validate_positive_id(value: &Value, field: &str, resource: &str) -> anyhow::Result<()> {
-    anyhow::ensure!(
-        value[field].as_u64().is_some_and(|id| id > 0),
-        "{resource} has no valid {field}"
-    );
-    Ok(())
-}
-
 fn github_headers() -> Vec<(&'static str, &'static str)> {
     vec![("accept", ACCEPT), ("x-github-api-version", API_VERSION)]
 }
@@ -525,11 +517,7 @@ fn with_per_page(url: String) -> String {
 }
 
 fn ensure_success(status: u16, body: &str) -> anyhow::Result<()> {
-    if status == 404 {
-        return Err(PapertrailClientError::ItemNotFound.into());
-    }
-    anyhow::ensure!((200..300).contains(&status), "GitHub HTTP {status}: {body}");
-    Ok(())
+    ensure_provider_success("GitHub", status, body)
 }
 
 fn search_items(value: &Value) -> anyhow::Result<&[Value]> {
@@ -563,15 +551,6 @@ fn safe_search_boundary(left: Option<String>, right: Option<String>) -> Option<S
         (Some(left), Some(right)) => Some(left.max(right)),
         (left, right) => left.or(right),
     }
-}
-
-fn next_link(headers: &reqwest::header::HeaderMap) -> anyhow::Result<Option<String>> {
-    let Some(link) = headers.get(LINK) else { return Ok(None) };
-    let link = link.to_str()?;
-    Ok(link.split(',').find_map(|part| {
-        let (url, rel) = part.trim().split_once(';')?;
-        rel.trim().eq(r#"rel="next""#).then(|| url.trim().trim_matches(['<', '>']).to_string())
-    }))
 }
 
 #[cfg(test)]

--- a/crates/rag-rat-core/src/index/papertrail/github.rs
+++ b/crates/rag-rat-core/src/index/papertrail/github.rs
@@ -56,39 +56,12 @@ impl GitHubClient {
         options: TransportOptions,
     ) -> anyhow::Result<Self> {
         anyhow::ensure!(binding.provider == Tracker::Github, "not a GitHub binding");
-        let parsed = match binding.base_url.as_deref() {
-            None => Url::parse("https://api.github.com")?,
-            Some(base) => {
-                let mut base = Url::parse(base)?;
-                anyhow::ensure!(
-                    matches!(base.scheme(), "http" | "https"),
-                    "GitHub base URL must use http(s)"
-                );
-                anyhow::ensure!(
-                    base.username().is_empty() && base.password().is_none(),
-                    "GitHub base URL must not contain credentials"
-                );
-                anyhow::ensure!(
-                    matches!(base.path(), "" | "/")
-                        && base.query().is_none()
-                        && base.fragment().is_none(),
-                    "GitHub base URL must be an origin without a path, query, or fragment"
-                );
-                base.set_path("/api/v3");
-                base
-            },
-        };
-        let host =
-            parsed.host_str().ok_or_else(|| anyhow::anyhow!("GitHub API origin has no host"))?;
-        let authority_host = if host.contains(':') && !host.starts_with('[') {
-            format!("[{host}]")
-        } else {
-            host.to_string()
-        };
-        let authority = parsed
-            .port()
-            .map_or_else(|| authority_host.clone(), |port| format!("{authority_host}:{port}"));
-        let api_origin = parsed.as_str().trim_end_matches('/').to_string();
+        let (api_origin, authority) = resolve_api_origin(
+            "GitHub",
+            binding.base_url.as_deref(),
+            "https://api.github.com",
+            "/api/v3",
+        )?;
         let token = transport::resolve_token(binding.auth.as_ref())?;
         let transport = |lane| {
             Transport::new_with_token(

--- a/crates/rag-rat-core/src/index/papertrail/gitlab.rs
+++ b/crates/rag-rat-core/src/index/papertrail/gitlab.rs
@@ -284,7 +284,7 @@ impl PapertrailClient for GitLabClient {
             page_token: Some(page_token),
             ..PageCursor::default()
         });
-        Ok(CommentsPage { comments, next })
+        Ok(CommentsPage { comments, next, frontier: None })
     }
 
     async fn items_page(&self, project: &str, cursor: &PageCursor) -> anyhow::Result<ItemsPage> {
@@ -413,6 +413,14 @@ impl PapertrailClient for GitLabClient {
         let events = value
             .as_array()
             .ok_or_else(|| anyhow::anyhow!("GitLab events response is not an array"))?;
+        // The page watermark covers EVERY event on the page — including ones that map to no
+        // comment (commit/snippet notes) — so a page of only-skipped events still advances the
+        // stream instead of pinning it to the old date forever.
+        let frontier = events
+            .iter()
+            .filter_map(|event| event["created_at"].as_str())
+            .max()
+            .map(str::to_string);
         let mut comments = Vec::new();
         for event in events {
             // The feed is creation events for notes; each embeds the note's CURRENT state. The
@@ -457,7 +465,7 @@ impl PapertrailClient for GitLabClient {
             page_token: Some(page_token),
             ..PageCursor::default()
         });
-        Ok(CommentsPage { comments, next })
+        Ok(CommentsPage { comments, next, frontier })
     }
 
     async fn freshness_probe(
@@ -1166,6 +1174,26 @@ mod tests {
             ),
             "the day BEFORE the cursor's date keeps same-day events in scope: {}",
             heads[0]
+        );
+    }
+
+    /// Commit/snippet notes map to no comment; a page of only those must still carry the
+    /// events frontier so the mirror can advance instead of replaying the page forever.
+    #[test]
+    fn a_page_of_untracked_note_events_still_reports_its_frontier() {
+        let events = r#"[
+            {"target_type":"Note","created_at":"2026-01-14T00:00:00Z","note":{"id":50,"body":"commit words","system":false,"noteable_type":"Commit","author":{"username":"c"},"created_at":"2026-01-14T00:00:00Z"}},
+            {"target_type":"Note","created_at":"2026-01-15T00:00:00Z","note":{"id":51,"body":"snippet words","system":false,"noteable_type":"Snippet","author":{"username":"s"},"created_at":"2026-01-15T00:00:00Z"}}
+        ]"#;
+        let (base, _handle) = spawn_script_stub(vec![StubResponse::ok(events)]);
+        let registry = GovernorRegistry::default();
+        let client = client(base, &registry);
+        let page = block_on(client.comments_page("g/s/r", &PageCursor::default())).unwrap();
+        assert!(page.comments.is_empty());
+        assert_eq!(
+            page.frontier.as_deref(),
+            Some("2026-01-15T00:00:00Z"),
+            "the frontier covers skipped events so the stream never pins"
         );
     }
 

--- a/crates/rag-rat-core/src/index/papertrail/gitlab.rs
+++ b/crates/rag-rat-core/src/index/papertrail/gitlab.rs
@@ -1269,15 +1269,15 @@ mod tests {
     fn a_malformed_probe_payload_fails_instead_of_reading_as_quiet() {
         let (base, _handle) = spawn_script_stub(vec![StubResponse::ok("{}")]);
         let registry = GovernorRegistry::default();
-        let client = client(base, &registry);
+        let non_array = client(base, &registry);
         let error =
-            block_on(client.freshness_probe("g/s/r", &FreshnessProbe::default())).unwrap_err();
+            block_on(non_array.freshness_probe("g/s/r", &FreshnessProbe::default())).unwrap_err();
         assert!(error.to_string().contains("probe response is not an array"), "{error:#}");
 
         let (base, _handle) =
             spawn_script_stub(vec![StubResponse::ok(r#"[{"iid":1,"state":"opened"}]"#)]);
         let registry = GovernorRegistry::default();
-        let stampless = self::tests::client(base, &registry);
+        let stampless = client(base, &registry);
         let error =
             block_on(stampless.freshness_probe("g/s/r", &FreshnessProbe::default())).unwrap_err();
         assert!(error.to_string().contains("no valid updated_at"), "{error:#}");

--- a/crates/rag-rat-core/src/index/papertrail/gitlab.rs
+++ b/crates/rag-rat-core/src/index/papertrail/gitlab.rs
@@ -80,39 +80,12 @@ impl GitLabClient {
         options: TransportOptions,
     ) -> anyhow::Result<Self> {
         anyhow::ensure!(binding.provider == Tracker::Gitlab, "not a GitLab binding");
-        let parsed = match binding.base_url.as_deref() {
-            None => Url::parse("https://gitlab.com/api/v4")?,
-            Some(base) => {
-                let mut base = Url::parse(base)?;
-                anyhow::ensure!(
-                    matches!(base.scheme(), "http" | "https"),
-                    "GitLab base URL must use http(s)"
-                );
-                anyhow::ensure!(
-                    base.username().is_empty() && base.password().is_none(),
-                    "GitLab base URL must not contain credentials"
-                );
-                anyhow::ensure!(
-                    matches!(base.path(), "" | "/")
-                        && base.query().is_none()
-                        && base.fragment().is_none(),
-                    "GitLab base URL must be an origin without a path, query, or fragment"
-                );
-                base.set_path("/api/v4");
-                base
-            },
-        };
-        let host =
-            parsed.host_str().ok_or_else(|| anyhow::anyhow!("GitLab API origin has no host"))?;
-        let authority_host = if host.contains(':') && !host.starts_with('[') {
-            format!("[{host}]")
-        } else {
-            host.to_string()
-        };
-        let authority = parsed
-            .port()
-            .map_or_else(|| authority_host.clone(), |port| format!("{authority_host}:{port}"));
-        let api_origin = parsed.as_str().trim_end_matches('/').to_string();
+        let (api_origin, authority) = resolve_api_origin(
+            "GitLab",
+            binding.base_url.as_deref(),
+            "https://gitlab.com/api/v4",
+            "/api/v4",
+        )?;
         let token = transport::resolve_token(binding.auth.as_ref())?;
         // One lane: GitLab reports a single `RateLimit-*` quota bucket (the governor already
         // parses the IETF-draft header form), unlike GitHub's core/search split.
@@ -189,10 +162,8 @@ impl GitLabClient {
     /// previously mirrored item.
     async fn leg_page(&self, project: &str, url: &str, leg: ListLeg) -> anyhow::Result<LegOutcome> {
         let response = self.core.get(url, &gitlab_headers()).await?;
-        match response.status {
-            403 => return Ok(LegOutcome::Unavailable { missing: false }),
-            404 => return Ok(LegOutcome::Unavailable { missing: true }),
-            _ => {},
+        if matches!(response.status, 403 | 404) {
+            return Ok(LegOutcome::Unavailable);
         }
         ensure_success(response.status, &response.body)?;
         let next_url = next_link(&response.headers)?;
@@ -209,10 +180,12 @@ impl GitLabClient {
 }
 
 /// What one leg fetch produced: a page, or a 403/404 whose meaning the caller decides by walk
-/// phase (fresh open: disabled feature or missing project; mid-walk: an error).
+/// phase (fresh open: disabled feature or missing project; mid-walk: an error). Disabled
+/// features answer 403, HIDDEN features answer 404 — indistinguishable from a gone project at
+/// the leg level, which is why the project readability probe is the discriminator.
 enum LegOutcome {
     Page(Vec<PapertrailItem>, Option<String>),
-    Unavailable { missing: bool },
+    Unavailable,
 }
 
 impl PapertrailClient for GitLabClient {
@@ -330,7 +303,6 @@ impl PapertrailClient for GitLabClient {
             ),
         };
         let mut items = Vec::new();
-        let mut issues_missing = false;
         let mut issues_advanced = false;
         if let Some(url) = state.issues_next.take() {
             match self.leg_page(project, &url, ListLeg::Issues).await? {
@@ -340,8 +312,8 @@ impl PapertrailClient for GitLabClient {
                     issues_advanced = true;
                 },
                 // Only a FRESH open may map unavailability to an empty leg (see leg_page).
-                LegOutcome::Unavailable { missing } if fresh_open => issues_missing = missing,
-                LegOutcome::Unavailable { .. } => {
+                LegOutcome::Unavailable if fresh_open => {},
+                LegOutcome::Unavailable => {
                     anyhow::bail!("GitLab issues became unavailable mid-walk for {project}")
                 },
             }
@@ -352,21 +324,18 @@ impl PapertrailClient for GitLabClient {
                     items.extend(page);
                     state.merge_requests_next = next;
                 },
-                Ok(LegOutcome::Unavailable { missing }) if fresh_open => {
-                    // EVERY namespace unavailable on a fresh open: all-404 means the project is
-                    // missing — surface the typed not-found. Otherwise (403s involved) the
-                    // project must PROVE it is readable before the walk may treat the trackers
-                    // as disabled features and mirror quietly as empty — a token that lost
-                    // access also answers 403 on both lists, and completing that walk "empty"
-                    // would prune everything.
+                Ok(LegOutcome::Unavailable) if fresh_open => {
+                    // EVERY namespace unavailable on a fresh open: the project must PROVE it is
+                    // readable before the walk may treat the trackers as disabled/hidden
+                    // features and mirror quietly as empty. A token that lost access answers
+                    // 403 on both lists, a gone project answers 404 — and completing either
+                    // walk "empty" would prune everything. The readability probe maps its own
+                    // 404 to the typed not-found, so a gone project still surfaces as such.
                     if !issues_advanced {
-                        if missing && issues_missing {
-                            return Err(PapertrailClientError::ItemNotFound.into());
-                        }
                         self.project_is_readable(project).await?;
                     }
                 },
-                Ok(LegOutcome::Unavailable { .. }) => {
+                Ok(LegOutcome::Unavailable) => {
                     anyhow::bail!("GitLab merge requests became unavailable mid-walk for {project}")
                 },
                 // A rate/budget pause AFTER the issues leg already consumed a CONTINUATION page
@@ -527,7 +496,6 @@ impl PapertrailClient for GitLabClient {
         // the project's newest movement. No ETag: two responses cannot share one validator, and
         // `probe_advance` on timestamps suffices.
         let mut latest: Option<String> = None;
-        let mut missing = 0usize;
         let mut unavailable = 0usize;
         for leg in [ListLeg::Issues, ListLeg::MergeRequests] {
             let mut url = Url::parse(&self.project_path(project, leg.path_segment())?)?;
@@ -536,20 +504,12 @@ impl PapertrailClient for GitLabClient {
                 .append_pair("sort", "desc")
                 .append_pair("per_page", "1");
             let response = self.core.get(url.as_str(), &gitlab_headers()).await?;
-            // A disabled namespace is quiet, not fatal — the sibling still answers the probe.
-            // Both answering 404 = the project is gone; a 403 anywhere is a feature setting,
-            // and a project with BOTH features disabled probes as a quiet empty project.
-            match response.status {
-                403 => {
-                    unavailable += 1;
-                    continue;
-                },
-                404 => {
-                    missing += 1;
-                    unavailable += 1;
-                    continue;
-                },
-                _ => {},
+            // A disabled/hidden namespace (403/404) is quiet, not fatal — the sibling still
+            // answers the probe. Both unavailable = only the project readability probe can
+            // tell a docs-only project from a gone one.
+            if matches!(response.status, 403 | 404) {
+                unavailable += 1;
+                continue;
             }
             ensure_success(response.status, &response.body)?;
             let value: Value = serde_json::from_str(&response.body)?;
@@ -560,12 +520,10 @@ impl PapertrailClient for GitLabClient {
                 .map(str::to_string);
             latest = max_timestamp(latest.take(), leg_latest);
         }
-        if missing == 2 {
-            return Err(PapertrailClientError::ItemNotFound.into());
-        }
         if unavailable == 2 {
-            // Both lists unavailable with a 403 involved: disabled features and lost access
-            // look identical here — only a readable project may probe as quietly empty.
+            // Disabled/hidden features and lost access/deletion look identical at the list
+            // level — only a readable project may probe as quietly empty; the readability
+            // probe's own 404 surfaces a gone project as the typed not-found.
             self.project_is_readable(project).await?;
         }
         // GitLab has no probe validator (no shared ETag across the two namespace calls), so the
@@ -762,6 +720,9 @@ mod tests {
             ("https://user:pw@gitlab.example.com", "credentials"),
             ("ftp://gitlab.example.com", "http(s)"),
             ("https://gitlab.example.com?x=1", "without a path"),
+            // The transport refuses plaintext to non-loopback hosts per request; accepting it
+            // here would mint a "native" binding whose every sync fails.
+            ("http://gitlab.example.com:8080", "loopback-only"),
         ] {
             let error = GitLabClient::new(
                 &binding(base.to_string()),
@@ -1135,6 +1096,27 @@ mod tests {
         );
     }
 
+    /// HIDDEN features answer 404 like a gone project; a readable project with both trackers
+    /// hidden mirrors quietly as empty instead of failing as not-found on every sync.
+    #[test]
+    fn hidden_features_on_a_readable_project_mirror_as_quietly_empty() {
+        let (base, _handle) = spawn_script_stub(vec![
+            StubResponse::status("404 Not Found", "{}"),
+            StubResponse::status("404 Not Found", "{}"),
+            StubResponse::ok(r#"{"id":1,"path_with_namespace":"g/s/r"}"#),
+        ]);
+        let registry = GovernorRegistry::default();
+        let client = client(base, &registry);
+        let page = block_on(client.items_page("g/s/r", &PageCursor {
+            updated_before: Some("2026-02-01T00:00:00Z".to_string()),
+            ..PageCursor::default()
+        }))
+        .unwrap();
+        assert!(page.items.is_empty());
+        assert!(page.next.is_none());
+        assert!(page.backfill_boundary.is_none(), "the mirror's done shape");
+    }
+
     /// A token that lost access answers 403 on both lists too — the readability probe fails
     /// and the walk ERRORS instead of completing empty (which would prune everything).
     #[test]
@@ -1183,6 +1165,7 @@ mod tests {
         let (base, _handle) = spawn_script_stub(vec![
             StubResponse::status("404 Not Found", "{}"),
             StubResponse::status("404 Not Found", "{}"),
+            StubResponse::status("404 Not Found", "{}"),
         ]);
         let registry = GovernorRegistry::default();
         let client = client(base, &registry);
@@ -1205,6 +1188,7 @@ mod tests {
         let (base, _handle) = spawn_script_stub(vec![
             StubResponse::status("403 Forbidden", "{}"),
             StubResponse::ok(&format!("[{}]", merge_request(2, "2026-01-07T00:00:00Z"))),
+            StubResponse::status("404 Not Found", "{}"),
             StubResponse::status("404 Not Found", "{}"),
             StubResponse::status("404 Not Found", "{}"),
         ]);

--- a/crates/rag-rat-core/src/index/papertrail/gitlab.rs
+++ b/crates/rag-rat-core/src/index/papertrail/gitlab.rs
@@ -10,14 +10,20 @@
 //! - **No "notes updated since" feed**: there is no project-level notes endpoint, and note activity
 //!   does NOT bump the noteable's `updated_at` (verified live against GitLab CE). New comments
 //!   therefore arrive through the project EVENTS feed (`action=commented`, one event per note
-//!   CREATION, each embedding the note's CURRENT body); edits to old notes produce no event and no
-//!   timestamp movement anywhere, so edited bodies converge at the daily full re-walk.
+//!   CREATION, each embedding the note's CURRENT body); edits to old notes and approvals produce no
+//!   commented event and no timestamp movement anywhere, so both converge at the daily full
+//!   re-walk. The feed is offset-paginated: deleting a note/item mid-scan can shift an unread event
+//!   into an already-read offset, and the per-page frontier then advances past it — a bounded
+//!   staleness window (also healed by the daily full re-walk) accepted in exchange for not
+//!   replaying busy multi-page days on every poll forever.
 
 use reqwest::Url;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use super::transport::{GovernorRegistry, Transport, TransportOptions, TransportParams};
+use super::transport::{
+    GovernorRegistry, Transport, TransportError, TransportOptions, TransportParams,
+};
 use super::*;
 
 const LIST_BACKFILL_STREAM: &str = "list_backfill";
@@ -51,10 +57,7 @@ enum ListLeg {
 
 impl ListLeg {
     fn path_segment(self) -> &'static str {
-        match self {
-            Self::Issues => "issues",
-            Self::MergeRequests => "merge_requests",
-        }
+        resource_segment(self.item_kind())
     }
 
     fn item_kind(self) -> ItemKind {
@@ -167,19 +170,29 @@ impl GitLabClient {
         Ok(url.into())
     }
 
-    /// One page from one leg: the mapped items plus the leg's next-page URL, if any. `None` =
-    /// the namespace is unavailable (GitLab projects can disable issues or merge requests as a
-    /// feature, surfacing 403/404 on that list) — the caller treats it as an empty, drained leg
-    /// so one disabled tracker never aborts the sibling namespace's mirror.
-    async fn leg_page(
-        &self,
-        project: &str,
-        url: &str,
-        leg: ListLeg,
-    ) -> anyhow::Result<Option<(Vec<PapertrailItem>, Option<String>)>> {
+    /// Confirm the project itself is readable — the discriminator between "both tracker
+    /// features are disabled" (lists 403/404 but the project answers 200) and "the token lost
+    /// access / the project is gone" (the project answers 403/404 too). Trusting bare list
+    /// 403s as disabled features would let an auth loss complete a full re-walk "empty" and
+    /// prune every previously mirrored item.
+    async fn project_is_readable(&self, project: &str) -> anyhow::Result<()> {
+        let url = self.endpoint(&format!("projects/{}", project.replace('/', "%2F")));
+        let response = self.core.get(&url, &gitlab_headers()).await?;
+        ensure_success(response.status, &response.body)
+    }
+
+    /// One page from one leg. GitLab projects can disable issues or merge requests as a
+    /// feature: the list then answers 403 (or 404 when the feature is hidden), which is a
+    /// durable project setting, not a failure — but only a FRESH open may treat it that way.
+    /// Mid-walk unavailability (a deleted project, a token losing read_api) must stay an error:
+    /// mapping it to an empty leg would let a full re-walk complete "empty" and prune every
+    /// previously mirrored item.
+    async fn leg_page(&self, project: &str, url: &str, leg: ListLeg) -> anyhow::Result<LegOutcome> {
         let response = self.core.get(url, &gitlab_headers()).await?;
-        if matches!(response.status, 403 | 404) {
-            return Ok(None);
+        match response.status {
+            403 => return Ok(LegOutcome::Unavailable { missing: false }),
+            404 => return Ok(LegOutcome::Unavailable { missing: true }),
+            _ => {},
         }
         ensure_success(response.status, &response.body)?;
         let next_url = next_link(&response.headers)?;
@@ -191,8 +204,15 @@ impl GitLabClient {
         for value in values {
             items.push(item_from_gitlab_value(project, leg.item_kind(), value)?);
         }
-        Ok(Some((items, next_url)))
+        Ok(LegOutcome::Page(items, next_url))
     }
+}
+
+/// What one leg fetch produced: a page, or a 403/404 whose meaning the caller decides by walk
+/// phase (fresh open: disabled feature or missing project; mid-walk: an error).
+enum LegOutcome {
+    Page(Vec<PapertrailItem>, Option<String>),
+    Unavailable { missing: bool },
 }
 
 impl PapertrailClient for GitLabClient {
@@ -211,11 +231,7 @@ impl PapertrailClient for GitLabClient {
     ) -> anyhow::Result<PapertrailItem> {
         // Kind is BINDING: issues and merge requests live in separate iid namespaces.
         let iid = validate_iid(key)?;
-        let resource = match kind {
-            ItemKind::Issue => "issues",
-            ItemKind::ChangeRequest => "merge_requests",
-        };
-        let url = self.project_path(project, &format!("{resource}/{iid}"))?;
+        let url = self.project_path(project, &format!("{}/{iid}", resource_segment(kind)))?;
         let (value, _) = self.get_json(&url).await?;
         item_from_gitlab_value(project, kind, &value)
     }
@@ -252,15 +268,14 @@ impl PapertrailClient for GitLabClient {
         let iid = validate_iid(key)?;
         let stream = cursor.stream.as_deref().unwrap_or(NOTES_STREAM);
         anyhow::ensure!(stream == NOTES_STREAM, "unknown GitLab item-comment stream `{stream}`");
-        let resource = match kind {
-            ItemKind::Issue => "issues",
-            ItemKind::ChangeRequest => "merge_requests",
-        };
         let url = match cursor.page_token.clone() {
             Some(next) => next,
             None => {
                 let mut url =
-                    Url::parse(&self.project_path(project, &format!("{resource}/{iid}/notes"))?)?;
+                    Url::parse(&self.project_path(
+                        project,
+                        &format!("{}/{iid}/notes", resource_segment(kind)),
+                    )?)?;
                 url.query_pairs_mut()
                     .append_pair("order_by", "updated_at")
                     .append_pair("sort", "asc")
@@ -293,17 +308,14 @@ impl PapertrailClient for GitLabClient {
             anyhow::bail!("an item page cannot be both delta and backfill");
         }
         let backfill = cursor.updated_before.is_some();
-        // Resume from the persisted continuation, or open BOTH legs' first pages. The delta
-        // checkpoint persists only `page_token` and rebuilds its resume request WITHOUT
-        // provider_state (mirror sync_item_delta), so the continuation JSON must live in the
-        // page token itself — a resume that reopened both first pages would let a pause before
-        // the second logical page spend every run's budget replaying page one.
-        let continuation = cursor
-            .provider_state
-            .as_deref()
-            .or_else(|| cursor.page_token.as_deref().filter(|token| token.starts_with('{')));
-        let (mut state, fresh_open) = match continuation {
-            Some(state) => (serde_json::from_str::<ListContinuation>(state)?, false),
+        // Resume from the persisted continuation, or open BOTH legs' first pages. The
+        // continuation lives IN the page token (parsed unconditionally — a corrupt token fails
+        // loudly at serde): the mirror's delta checkpoint persists only page_token and rebuilds
+        // its resume request without provider_state, and a resume that reopened both first
+        // pages would let a pause before the second logical page spend every run's budget
+        // replaying page one.
+        let (mut state, fresh_open) = match cursor.page_token.as_deref() {
+            Some(token) => (serde_json::from_str::<ListContinuation>(token)?, false),
             None => (
                 ListContinuation {
                     issues_next: Some(self.list_url(project, ListLeg::Issues, cursor)?),
@@ -318,33 +330,66 @@ impl PapertrailClient for GitLabClient {
             ),
         };
         let mut items = Vec::new();
-        let mut unavailable = 0usize;
-        let mut fetched = 0usize;
+        let mut issues_missing = false;
+        let mut issues_advanced = false;
         if let Some(url) = state.issues_next.take() {
-            fetched += 1;
             match self.leg_page(project, &url, ListLeg::Issues).await? {
-                Some((page, next)) => {
+                LegOutcome::Page(page, next) => {
                     items.extend(page);
                     state.issues_next = next;
+                    issues_advanced = true;
                 },
-                None => unavailable += 1,
+                // Only a FRESH open may map unavailability to an empty leg (see leg_page).
+                LegOutcome::Unavailable { missing } if fresh_open => issues_missing = missing,
+                LegOutcome::Unavailable { .. } => {
+                    anyhow::bail!("GitLab issues became unavailable mid-walk for {project}")
+                },
             }
         }
         if let Some(url) = state.merge_requests_next.take() {
-            fetched += 1;
-            match self.leg_page(project, &url, ListLeg::MergeRequests).await? {
-                Some((page, next)) => {
+            match self.leg_page(project, &url, ListLeg::MergeRequests).await {
+                Ok(LegOutcome::Page(page, next)) => {
                     items.extend(page);
                     state.merge_requests_next = next;
                 },
-                None => unavailable += 1,
+                Ok(LegOutcome::Unavailable { missing }) if fresh_open => {
+                    // EVERY namespace unavailable on a fresh open: all-404 means the project is
+                    // missing — surface the typed not-found. Otherwise (403s involved) the
+                    // project must PROVE it is readable before the walk may treat the trackers
+                    // as disabled features and mirror quietly as empty — a token that lost
+                    // access also answers 403 on both lists, and completing that walk "empty"
+                    // would prune everything.
+                    if !issues_advanced {
+                        if missing && issues_missing {
+                            return Err(PapertrailClientError::ItemNotFound.into());
+                        }
+                        self.project_is_readable(project).await?;
+                    }
+                },
+                Ok(LegOutcome::Unavailable { .. }) => {
+                    anyhow::bail!("GitLab merge requests became unavailable mid-walk for {project}")
+                },
+                // A rate/budget pause AFTER the issues leg already consumed a CONTINUATION page
+                // must not discard that progress: return the partial page with the
+                // merge-request leg still pending at ITS CURRENT url (transport pauses never
+                // consume pagination cursors). On a FRESH open the pause propagates instead —
+                // the scan's first page must cover both namespaces (the mirror seeds its
+                // durable watermarks from it), and re-fetching one leg page on resume is
+                // cheaper than a watermark that misses a namespace.
+                Err(error)
+                    if !fresh_open
+                        && issues_advanced
+                        && error.chain().any(|cause| {
+                            matches!(
+                                cause.downcast_ref::<TransportError>(),
+                                Some(TransportError::Paused { .. })
+                            )
+                        }) =>
+                {
+                    state.merge_requests_next = Some(url);
+                },
+                Err(error) => return Err(error),
             }
-        }
-        // One unavailable namespace is a disabled feature; EVERY namespace unavailable on a
-        // fresh open means the project itself is missing or inaccessible — that must surface,
-        // not mirror as an empty project.
-        if fresh_open && unavailable == fetched {
-            return Err(PapertrailClientError::ItemNotFound.into());
         }
         // Keep the emitted page ordered like its legs (mirror correctness is order-agnostic;
         // ordering keeps pages legible in logs and tests).
@@ -363,16 +408,15 @@ impl PapertrailClient for GitLabClient {
         let stream = if backfill { LIST_BACKFILL_STREAM } else { LIST_DELTA_STREAM };
         let pending = state.issues_next.is_some() || state.merge_requests_next.is_some();
         let next = if pending {
-            let token = serde_json::to_string(&state)?;
             Some(PageCursor {
                 stream: Some(stream.to_string()),
                 updated_since: cursor.updated_since.clone(),
                 updated_before: cursor.updated_before.clone(),
-                // The full continuation IS the page token (see resume note above); its
+                // The continuation IS the page token (see the resume note above); its
                 // non-emptiness also marks every continuation page as NOT the scan's first page
                 // for the mirror's conservative-frontier logic.
-                page_token: Some(token.clone()),
-                provider_state: Some(token),
+                page_token: Some(serde_json::to_string(&state)?),
+                provider_state: None,
             })
         } else {
             None
@@ -440,7 +484,12 @@ impl PapertrailClient for GitLabClient {
             let Some(iid) = note["noteable_iid"].as_u64().filter(|iid| *iid > 0) else {
                 continue;
             };
-            validate_positive_id(note, "id", "GitLab note event")?;
+            // A malformed embedded note (permissions-redacted id, future payload shape) is
+            // SKIPPED like every sibling malformation: erroring here would pin the stream on
+            // this page forever — the page's frontier could never persist.
+            if note["id"].as_u64().is_none_or(|id| id == 0) {
+                continue;
+            }
             if let Some(mut comment) =
                 comment_from_note_value(project, kind, &iid.to_string(), note)
             {
@@ -478,6 +527,7 @@ impl PapertrailClient for GitLabClient {
         // the project's newest movement. No ETag: two responses cannot share one validator, and
         // `probe_advance` on timestamps suffices.
         let mut latest: Option<String> = None;
+        let mut missing = 0usize;
         let mut unavailable = 0usize;
         for leg in [ListLeg::Issues, ListLeg::MergeRequests] {
             let mut url = Url::parse(&self.project_path(project, leg.path_segment())?)?;
@@ -486,11 +536,20 @@ impl PapertrailClient for GitLabClient {
                 .append_pair("sort", "desc")
                 .append_pair("per_page", "1");
             let response = self.core.get(url.as_str(), &gitlab_headers()).await?;
-            // A disabled namespace (403/404 on its list) is quiet, not fatal — the sibling
-            // namespace still answers the probe. Both unavailable = the project is gone.
-            if matches!(response.status, 403 | 404) {
-                unavailable += 1;
-                continue;
+            // A disabled namespace is quiet, not fatal — the sibling still answers the probe.
+            // Both answering 404 = the project is gone; a 403 anywhere is a feature setting,
+            // and a project with BOTH features disabled probes as a quiet empty project.
+            match response.status {
+                403 => {
+                    unavailable += 1;
+                    continue;
+                },
+                404 => {
+                    missing += 1;
+                    unavailable += 1;
+                    continue;
+                },
+                _ => {},
             }
             ensure_success(response.status, &response.body)?;
             let value: Value = serde_json::from_str(&response.body)?;
@@ -499,13 +558,15 @@ impl PapertrailClient for GitLabClient {
                 .and_then(|items| items.first())
                 .and_then(|item| item["updated_at"].as_str())
                 .map(str::to_string);
-            latest = match (latest.take(), leg_latest) {
-                (Some(current), Some(new)) => Some(current.max(new)),
-                (current, new) => current.or(new),
-            };
+            latest = max_timestamp(latest.take(), leg_latest);
+        }
+        if missing == 2 {
+            return Err(PapertrailClientError::ItemNotFound.into());
         }
         if unavailable == 2 {
-            return Err(PapertrailClientError::ItemNotFound.into());
+            // Both lists unavailable with a 403 involved: disabled features and lost access
+            // look identical here — only a readable project may probe as quietly empty.
+            self.project_is_readable(project).await?;
         }
         // GitLab has no probe validator (no shared ETag across the two namespace calls), so the
         // timestamp comparison IS the quiet signal: the mirror keys the delta-scan decision off
@@ -519,33 +580,29 @@ impl PapertrailClient for GitLabClient {
 const NOTES_STREAM: &str = "notes";
 const EVENTS_STREAM: &str = "events";
 
-/// The civil date one day before `timestamp`'s date part (`YYYY-MM-DD…` → `YYYY-MM-DD`), via
-/// days-from-civil round-tripping (Howard Hinnant's algorithm) — no calendar dependency.
+/// The civil date one day before `timestamp`'s date part (`YYYY-MM-DD…` → `YYYY-MM-DD`),
+/// on the shared calendar helpers.
 fn day_before(timestamp: &str) -> anyhow::Result<String> {
     let date = timestamp.get(..10).unwrap_or_default();
-    let mut parts = date.split('-').map(|part| part.parse::<i64>());
-    let (year, month, day) = match (parts.next(), parts.next(), parts.next()) {
-        (Some(Ok(year)), Some(Ok(month)), Some(Ok(day)))
-            if (1..=12).contains(&month) && (1..=31).contains(&day) =>
-            (year, month, day),
-        _ => anyhow::bail!("timestamp `{timestamp}` has no leading YYYY-MM-DD date"),
+    let (year, month, day) = parse_date(date)
+        .filter(|(_, month, day)| (1..=12).contains(month) && (1..=31).contains(day))
+        .ok_or_else(|| anyhow::anyhow!("timestamp `{timestamp}` has no leading YYYY-MM-DD date"))?;
+    let (year, month, day) = if day > 1 {
+        (year, month, day - 1)
+    } else if month > 1 {
+        (year, month - 1, days_in_month(year, month - 1))
+    } else {
+        (year - 1, 12, 31)
     };
-    let shifted_year = if month <= 2 { year - 1 } else { year };
-    let era = shifted_year.div_euclid(400);
-    let year_of_era = shifted_year - era * 400;
-    let day_of_year = (153 * (if month > 2 { month - 3 } else { month + 9 }) + 2) / 5 + day - 1;
-    let day_of_era = year_of_era * 365 + year_of_era / 4 - year_of_era / 100 + day_of_year;
-    let days = era * 146_097 + day_of_era - 719_468 - 1; // one day earlier
-    let era = (days + 719_468).div_euclid(146_097);
-    let day_of_era = days + 719_468 - era * 146_097;
-    let year_of_era =
-        (day_of_era - day_of_era / 1460 + day_of_era / 36_524 - day_of_era / 146_096) / 365;
-    let day_of_year = day_of_era - (365 * year_of_era + year_of_era / 4 - year_of_era / 100);
-    let month_index = (5 * day_of_year + 2) / 153;
-    let day = day_of_year - (153 * month_index + 2) / 5 + 1;
-    let month = if month_index < 10 { month_index + 3 } else { month_index - 9 };
-    let year = year_of_era + era * 400 + i64::from(month <= 2);
     Ok(format!("{year:04}-{month:02}-{day:02}"))
+}
+
+/// The API resource segment for one iid namespace.
+fn resource_segment(kind: ItemKind) -> &'static str {
+    match kind {
+        ItemKind::Issue => "issues",
+        ItemKind::ChangeRequest => "merge_requests",
+    }
 }
 
 fn gitlab_headers() -> Vec<(&'static str, &'static str)> {
@@ -974,9 +1031,133 @@ mod tests {
         );
     }
 
-    /// GitLab projects can disable issues or merge requests as a feature; the unavailable leg
-    /// mirrors as empty instead of aborting the sibling namespace. EVERY leg unavailable on a
-    /// fresh open is a missing project and must surface as the typed not-found outcome.
+    /// A rate/budget pause between the two leg fetches of a CONTINUATION page must not discard
+    /// the first leg's progress: the partial page returns with the paused leg still pending at
+    /// its CURRENT url, so a one-request budget window advances one leg page per attempt
+    /// instead of replaying the first leg forever.
+    #[test]
+    fn a_pause_between_continuation_legs_checkpoints_the_first_legs_progress() {
+        let issues = format!("[{}]", issue(30, "2026-01-06T00:00:00Z"));
+        // Quota headers on the issues response leave the governor below its reserve, pausing
+        // the very next request (the merge-request leg).
+        let (base, _handle) =
+            spawn_script_stub(vec![StubResponse::ok_with_quota(&issues, 100, 5, 4_000_000_000)]);
+        let registry = GovernorRegistry::default();
+        let client = client(base.clone(), &registry);
+
+        let continuation = PageCursor {
+            updated_before: Some("2026-02-01T00:00:00Z".to_string()),
+            page_token: Some(format!(
+                r#"{{"issues_next":"{base}/api/v4/projects/g%2Fs%2Fr/issues?page=2","merge_requests_next":"{base}/api/v4/projects/g%2Fs%2Fr/merge_requests?page=2","oldest":null}}"#
+            )),
+            ..PageCursor::default()
+        };
+        let partial = block_on(client.items_page("g/s/r", &continuation)).unwrap();
+        assert_eq!(partial.items.len(), 1, "the fetched issues page must not be discarded");
+        assert_eq!(partial.items[0].item_key, "30");
+        let next = partial.next.expect("the merge-request leg is still pending");
+        let token = next.page_token.as_deref().unwrap();
+        assert!(token.contains("merge_requests"), "{token}");
+
+        // The immediate next fetch surfaces the pause, with the progress safely persisted
+        // behind it by the mirror.
+        let error = block_on(client.items_page("g/s/r", &next)).unwrap_err();
+        assert!(
+            matches!(error.downcast_ref::<TransportError>(), Some(TransportError::Paused { .. })),
+            "{error:#}"
+        );
+    }
+
+    /// On a FRESH open the pause propagates instead: the scan's first page must cover both
+    /// namespaces (the mirror seeds its durable watermarks from it), and re-fetching one leg
+    /// page on resume is cheaper than a watermark that misses a namespace.
+    #[test]
+    fn a_pause_on_a_fresh_open_propagates_rather_than_emitting_a_one_namespace_first_page() {
+        let issues = format!("[{}]", issue(31, "2026-01-06T00:00:00Z"));
+        let (base, _handle) =
+            spawn_script_stub(vec![StubResponse::ok_with_quota(&issues, 100, 5, 4_000_000_000)]);
+        let registry = GovernorRegistry::default();
+        let client = client(base, &registry);
+        let error = block_on(client.items_page("g/s/r", &PageCursor {
+            updated_since: Some("2026-01-01T00:00:00Z".to_string()),
+            ..PageCursor::default()
+        }))
+        .unwrap_err();
+        assert!(
+            matches!(error.downcast_ref::<TransportError>(), Some(TransportError::Paused { .. })),
+            "{error:#}"
+        );
+    }
+
+    /// Namespace unavailability MID-WALK is an error, never an empty leg: mapping it to empty
+    /// would let a full re-walk complete "empty" and prune every previously mirrored item when
+    /// a project is deleted or a token loses read_api mid-continuation.
+    #[test]
+    fn mid_walk_unavailability_is_an_error_not_an_empty_walk() {
+        let (base, _handle) = spawn_script_stub(vec![StubResponse::status("403 Forbidden", "{}")]);
+        let registry = GovernorRegistry::default();
+        let client = client(base.clone(), &registry);
+        let continuation = PageCursor {
+            updated_before: Some("2026-02-01T00:00:00Z".to_string()),
+            page_token: Some(format!(
+                r#"{{"issues_next":"{base}/api/v4/projects/g%2Fs%2Fr/issues?page=2","merge_requests_next":null,"oldest":"2026-01-03T00:00:00Z"}}"#
+            )),
+            ..PageCursor::default()
+        };
+        let error = block_on(client.items_page("g/s/r", &continuation)).unwrap_err();
+        assert!(error.to_string().contains("unavailable mid-walk"), "{error:#}");
+    }
+
+    /// BOTH features disabled (403s) is a legitimate docs-only project: once the project
+    /// itself proves readable, it mirrors quietly as empty — only all-404 means it is gone.
+    #[test]
+    fn a_project_with_both_features_disabled_mirrors_as_quietly_empty() {
+        let (base, handle) = spawn_script_stub(vec![
+            StubResponse::status("403 Forbidden", "{}"),
+            StubResponse::status("403 Forbidden", "{}"),
+            StubResponse::ok(r#"{"id":1,"path_with_namespace":"g/s/r"}"#),
+        ]);
+        let registry = GovernorRegistry::default();
+        let client = client(base, &registry);
+        let page = block_on(client.items_page("g/s/r", &PageCursor {
+            updated_before: Some("2026-02-01T00:00:00Z".to_string()),
+            ..PageCursor::default()
+        }))
+        .unwrap();
+        assert!(page.items.is_empty());
+        assert!(page.next.is_none());
+        assert!(page.backfill_boundary.is_none(), "the mirror's done shape");
+        let heads = handle.join().unwrap();
+        assert!(
+            heads[2].starts_with("GET /api/v4/projects/g%2Fs%2Fr "),
+            "the disabled-features mapping requires proof the project is readable: {}",
+            heads[2]
+        );
+    }
+
+    /// A token that lost access answers 403 on both lists too — the readability probe fails
+    /// and the walk ERRORS instead of completing empty (which would prune everything).
+    #[test]
+    fn lost_access_never_masquerades_as_a_disabled_feature_project() {
+        let (base, _handle) = spawn_script_stub(vec![
+            StubResponse::status("403 Forbidden", "{}"),
+            StubResponse::status("403 Forbidden", "{}"),
+            StubResponse::status("403 Forbidden", "{}"),
+        ]);
+        let registry = GovernorRegistry::default();
+        let client = client(base, &registry);
+        let error = block_on(client.items_page("g/s/r", &PageCursor {
+            updated_before: Some("2026-02-01T00:00:00Z".to_string()),
+            ..PageCursor::default()
+        }))
+        .unwrap_err();
+        assert!(error.to_string().contains("HTTP 403"), "{error:#}");
+    }
+
+    /// GitLab projects can disable issues or merge requests as a feature;    /// GitLab projects
+    /// can disable issues or merge requests as a feature; the unavailable leg mirrors as empty
+    /// instead of aborting the sibling namespace. EVERY leg unavailable on a fresh open is a
+    /// missing project and must surface as the typed not-found outcome.
     #[test]
     fn a_disabled_namespace_never_aborts_the_sibling_leg() {
         let changes = format!("[{}]", merge_request(9, "2026-01-05T00:00:00Z"));
@@ -1124,8 +1305,7 @@ mod tests {
         let foreign = "https://gitlab.com/api/v4/projects/g%2Fs%2Fr/issues?page=2";
         let cursor = PageCursor {
             updated_before: Some("2026-02-01T00:00:00Z".to_string()),
-            page_token: Some(foreign.to_string()),
-            provider_state: Some(format!(r#"{{"issues_next":"{foreign}"}}"#)),
+            page_token: Some(format!(r#"{{"issues_next":"{foreign}"}}"#)),
             ..PageCursor::default()
         };
         let error = block_on(client.items_page("g/s/r", &cursor)).unwrap_err();
@@ -1175,6 +1355,23 @@ mod tests {
             "the day BEFORE the cursor's date keeps same-day events in scope: {}",
             heads[0]
         );
+    }
+
+    /// One malformed embedded note (redacted/zero id) is skipped like every sibling
+    /// malformation — erroring would pin the stream on this page forever.
+    #[test]
+    fn a_malformed_note_event_is_skipped_not_fatal() {
+        let events = r#"[
+            {"target_type":"Note","created_at":"2026-01-16T00:00:00Z","note":{"id":0,"body":"redacted","system":false,"noteable_type":"Issue","noteable_iid":4,"author":{"username":"x"},"created_at":"2026-01-16T00:00:00Z"}},
+            {"target_type":"Note","created_at":"2026-01-17T00:00:00Z","note":{"id":60,"body":"fine","system":false,"noteable_type":"Issue","noteable_iid":4,"author":{"username":"y"},"created_at":"2026-01-17T00:00:00Z"}}
+        ]"#;
+        let (base, _handle) = spawn_script_stub(vec![StubResponse::ok(events)]);
+        let registry = GovernorRegistry::default();
+        let client = client(base, &registry);
+        let page = block_on(client.comments_page("g/s/r", &PageCursor::default())).unwrap();
+        assert_eq!(page.comments.len(), 1);
+        assert_eq!(page.comments[0].comment_id, "note:60");
+        assert_eq!(page.frontier.as_deref(), Some("2026-01-17T00:00:00Z"));
     }
 
     /// Commit/snippet notes map to no comment; a page of only those must still carry the

--- a/crates/rag-rat-core/src/index/papertrail/gitlab.rs
+++ b/crates/rag-rat-core/src/index/papertrail/gitlab.rs
@@ -1,0 +1,959 @@
+//! Native GitLab provider client. Endpoint construction, `Link`-header pagination decoding, and
+//! GitLab payload mapping live here; mirror policy stays in `mirror`.
+//!
+//! GitLab differs from GitHub in three load-bearing ways this module encodes:
+//! - **Separate iid namespaces**: issues and merge requests are distinct objects with independent
+//!   numbering, so [`ItemKind`] is BINDING on every item call — issue #5 and MR !5 coexist.
+//! - **Native LIFO descent**: the list endpoints accept `updated_before`/`updated_after` with
+//!   `order_by=updated_at` directly — no Search-API detour — so a backfill cycle is two chained
+//!   legs (issues, then merge requests) over ordinary lists.
+//! - **No "notes updated since" feed**: there is no project-level notes endpoint, and note activity
+//!   does NOT bump the noteable's `updated_at` (verified live against GitLab CE). New comments
+//!   therefore arrive through the project EVENTS feed (`action=commented`, one event per note
+//!   CREATION, each embedding the note's CURRENT body); edits to old notes produce no event and no
+//!   timestamp movement anywhere, so edited bodies converge at the daily full re-walk.
+
+use reqwest::Url;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use super::transport::{GovernorRegistry, Transport, TransportOptions, TransportParams};
+use super::*;
+
+const LIST_BACKFILL_STREAM: &str = "list_backfill";
+const LIST_DELTA_STREAM: &str = "list_delta";
+
+/// Continuation across the two chained list legs of one items request. Persisted opaquely inside
+/// [`PageCursor::provider_state`]; the mirror never interprets it.
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct ListContinuation {
+    #[serde(default)]
+    leg: ListLeg,
+    /// Oldest `updated_at` consumed across BOTH legs of this backfill cycle — the provider-
+    /// confirmed strict boundary reported when the cycle completes. Descending below the global
+    /// minimum (not the last page's) keeps the next cycle from re-walking the older leg's tail.
+    oldest: Option<String>,
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum ListLeg {
+    #[default]
+    Issues,
+    MergeRequests,
+}
+
+impl ListLeg {
+    fn path_segment(self) -> &'static str {
+        match self {
+            Self::Issues => "issues",
+            Self::MergeRequests => "merge_requests",
+        }
+    }
+
+    fn item_kind(self) -> ItemKind {
+        match self {
+            Self::Issues => ItemKind::Issue,
+            Self::MergeRequests => ItemKind::ChangeRequest,
+        }
+    }
+}
+
+pub(crate) struct GitLabClient {
+    api_origin: String,
+    core: Transport,
+}
+
+impl GitLabClient {
+    pub(crate) fn new(
+        binding: &ResolvedTracker,
+        registry: &GovernorRegistry,
+        options: TransportOptions,
+    ) -> anyhow::Result<Self> {
+        anyhow::ensure!(binding.provider == Tracker::Gitlab, "not a GitLab binding");
+        let parsed = match binding.base_url.as_deref() {
+            None => Url::parse("https://gitlab.com/api/v4")?,
+            Some(base) => {
+                let mut base = Url::parse(base)?;
+                anyhow::ensure!(
+                    matches!(base.scheme(), "http" | "https"),
+                    "GitLab base URL must use http(s)"
+                );
+                anyhow::ensure!(
+                    base.username().is_empty() && base.password().is_none(),
+                    "GitLab base URL must not contain credentials"
+                );
+                anyhow::ensure!(
+                    matches!(base.path(), "" | "/")
+                        && base.query().is_none()
+                        && base.fragment().is_none(),
+                    "GitLab base URL must be an origin without a path, query, or fragment"
+                );
+                base.set_path("/api/v4");
+                base
+            },
+        };
+        let host =
+            parsed.host_str().ok_or_else(|| anyhow::anyhow!("GitLab API origin has no host"))?;
+        let authority_host = if host.contains(':') && !host.starts_with('[') {
+            format!("[{host}]")
+        } else {
+            host.to_string()
+        };
+        let authority = parsed
+            .port()
+            .map_or_else(|| authority_host.clone(), |port| format!("{authority_host}:{port}"));
+        let api_origin = parsed.as_str().trim_end_matches('/').to_string();
+        let token = transport::resolve_token(binding.auth.as_ref())?;
+        // One lane: GitLab reports a single `RateLimit-*` quota bucket (the governor already
+        // parses the IETF-draft header form), unlike GitHub's core/search split.
+        let core = Transport::new_with_token(
+            TransportParams {
+                provider: "gitlab",
+                lane: "core",
+                host: &authority,
+                auth: None,
+                registry,
+                options,
+            },
+            token.as_deref(),
+        )?;
+        Ok(Self { api_origin, core })
+    }
+
+    fn endpoint(&self, path: &str) -> String {
+        format!("{}/{}", self.api_origin, path.trim_start_matches('/'))
+    }
+
+    /// `projects/:id` path prefix with the namespaced project percent-encoded as ONE segment
+    /// (`group%2Fsub%2Fproject`) — the subgroup-correct form. Sound because
+    /// [`validate_gitlab_project`] restricts segments to GitLab's path alphabet, leaving `/` the
+    /// only character needing escape.
+    fn project_path(&self, project: &str, tail: &str) -> anyhow::Result<String> {
+        validate_gitlab_project(project)?;
+        Ok(self.endpoint(&format!("projects/{}/{tail}", project.replace('/', "%2F"))))
+    }
+
+    async fn get_json(&self, url: &str) -> anyhow::Result<(Value, Option<String>)> {
+        let response = self.core.get(url, &gitlab_headers()).await?;
+        ensure_success(response.status, &response.body)?;
+        let next = next_link(&response.headers)?;
+        Ok((serde_json::from_str(&response.body)?, next))
+    }
+
+    fn list_url(&self, project: &str, leg: ListLeg, cursor: &PageCursor) -> anyhow::Result<String> {
+        let mut url = Url::parse(&self.project_path(project, leg.path_segment())?)?;
+        {
+            let mut query = url.query_pairs_mut();
+            query.append_pair("order_by", "updated_at").append_pair("per_page", "100");
+            if let Some(before) = cursor.updated_before.as_deref() {
+                // Newest-first historical descent, natively.
+                query.append_pair("sort", "desc").append_pair("updated_before", before);
+            } else {
+                // Delta ascends so the first page's inclusive upper timestamp is a conservative
+                // consumed frontier even though later page numbers are mutable.
+                query.append_pair("sort", "asc");
+                if let Some(since) = cursor.updated_since.as_deref() {
+                    query.append_pair("updated_after", since);
+                }
+            }
+        }
+        Ok(url.into())
+    }
+
+    /// The follow-up cursor entering `leg` of the same logical request, first page.
+    fn leg_entry_cursor(
+        &self,
+        project: &str,
+        leg: ListLeg,
+        cursor: &PageCursor,
+        state: &ListContinuation,
+    ) -> anyhow::Result<PageCursor> {
+        Ok(PageCursor {
+            stream: cursor.stream.clone(),
+            updated_since: cursor.updated_since.clone(),
+            updated_before: cursor.updated_before.clone(),
+            page_token: Some(self.list_url(project, leg, cursor)?),
+            provider_state: Some(serde_json::to_string(&ListContinuation {
+                leg,
+                oldest: state.oldest.clone(),
+            })?),
+        })
+    }
+}
+
+impl PapertrailClient for GitLabClient {
+    /// One lane over the project events feed. GitLab has no "notes updated since" endpoint and
+    /// note activity does not touch the noteable, so creation events are the only incremental
+    /// comment signal the provider offers (module docs have the full story).
+    fn comment_streams(&self) -> &'static [&'static str] {
+        &[EVENTS_STREAM]
+    }
+
+    async fn item(
+        &self,
+        project: &str,
+        kind: ItemKind,
+        key: &str,
+    ) -> anyhow::Result<PapertrailItem> {
+        // Kind is BINDING: issues and merge requests live in separate iid namespaces.
+        let iid = validate_iid(key)?;
+        let resource = match kind {
+            ItemKind::Issue => "issues",
+            ItemKind::ChangeRequest => "merge_requests",
+        };
+        let url = self.project_path(project, &format!("{resource}/{iid}"))?;
+        let (value, _) = self.get_json(&url).await?;
+        item_from_gitlab_value(project, kind, &value)
+    }
+
+    async fn item_comments(
+        &self,
+        project: &str,
+        kind: ItemKind,
+        key: &str,
+    ) -> anyhow::Result<Vec<PapertrailComment>> {
+        let mut comments = Vec::new();
+        let mut cursor =
+            PageCursor { stream: Some(NOTES_STREAM.to_string()), ..PageCursor::default() };
+        loop {
+            let page = self.item_comments_page(project, kind, key, &cursor).await?;
+            comments.extend(page.comments);
+            let Some(next) = page.next else { break };
+            cursor = next;
+        }
+        Ok(comments)
+    }
+
+    fn item_comment_streams(&self, _kind: ItemKind) -> &'static [&'static str] {
+        &[NOTES_STREAM]
+    }
+
+    async fn item_comments_page(
+        &self,
+        project: &str,
+        kind: ItemKind,
+        key: &str,
+        cursor: &PageCursor,
+    ) -> anyhow::Result<CommentsPage> {
+        let iid = validate_iid(key)?;
+        let stream = cursor.stream.as_deref().unwrap_or(NOTES_STREAM);
+        anyhow::ensure!(stream == NOTES_STREAM, "unknown GitLab item-comment stream `{stream}`");
+        let resource = match kind {
+            ItemKind::Issue => "issues",
+            ItemKind::ChangeRequest => "merge_requests",
+        };
+        let url = match cursor.page_token.clone() {
+            Some(next) => next,
+            None => {
+                let mut url =
+                    Url::parse(&self.project_path(project, &format!("{resource}/{iid}/notes"))?)?;
+                url.query_pairs_mut()
+                    .append_pair("order_by", "updated_at")
+                    .append_pair("sort", "asc")
+                    .append_pair("per_page", "100");
+                url.into()
+            },
+        };
+        let (value, next_url) = self.get_json(&url).await?;
+        let values = value
+            .as_array()
+            .ok_or_else(|| anyhow::anyhow!("GitLab notes returned a non-array page"))?;
+        let mut comments = Vec::new();
+        for value in values {
+            validate_positive_id(value, "id", "GitLab note")?;
+            if let Some(comment) = comment_from_note_value(project, kind, key, value) {
+                comments.push(comment);
+            }
+        }
+        let next = next_url.map(|page_token| PageCursor {
+            stream: Some(NOTES_STREAM.to_string()),
+            page_token: Some(page_token),
+            ..PageCursor::default()
+        });
+        Ok(CommentsPage { comments, next })
+    }
+
+    async fn items_page(&self, project: &str, cursor: &PageCursor) -> anyhow::Result<ItemsPage> {
+        validate_gitlab_project(project)?;
+        if cursor.updated_before.is_some() && cursor.updated_since.is_some() {
+            anyhow::bail!("an item page cannot be both delta and backfill");
+        }
+        let backfill = cursor.updated_before.is_some();
+        let mut state = match cursor.provider_state.as_deref() {
+            Some(state) => serde_json::from_str::<ListContinuation>(state)?,
+            None => ListContinuation::default(),
+        };
+        let url = match cursor.page_token.clone() {
+            Some(next) => next,
+            None => self.list_url(project, state.leg, cursor)?,
+        };
+        let (value, next_url) = self.get_json(&url).await?;
+        let values = value.as_array().ok_or_else(|| {
+            anyhow::anyhow!("GitLab {} response is not an array", state.leg.path_segment())
+        })?;
+        let kind = state.leg.item_kind();
+        let mut items = Vec::with_capacity(values.len());
+        for value in values {
+            items.push(item_from_gitlab_value(project, kind, value)?);
+        }
+        if backfill
+            && let Some(oldest) = items.iter().filter_map(|item| item.updated_at.clone()).min()
+        {
+            state.oldest = match state.oldest.take() {
+                Some(current) => Some(current.min(oldest)),
+                None => Some(oldest),
+            };
+        }
+        let stream = if backfill { LIST_BACKFILL_STREAM } else { LIST_DELTA_STREAM };
+        let next = if let Some(page_token) = next_url {
+            // More pages in the current leg.
+            Some(PageCursor {
+                stream: Some(stream.to_string()),
+                updated_since: cursor.updated_since.clone(),
+                updated_before: cursor.updated_before.clone(),
+                page_token: Some(page_token),
+                provider_state: Some(serde_json::to_string(&state)?),
+            })
+        } else if state.leg == ListLeg::Issues {
+            // Issues leg drained below the cutoff — chain into the merge-request leg of the SAME
+            // logical request. The consumed issues continuation dies here (a chained leg must
+            // never outlive its consumption).
+            let mut entry =
+                self.leg_entry_cursor(project, ListLeg::MergeRequests, cursor, &state)?;
+            entry.stream = Some(stream.to_string());
+            Some(entry)
+        } else {
+            None
+        };
+        // The cycle's provider-confirmed strict boundary: both legs drained fully below the
+        // cutoff, so the global oldest consumed timestamp bounds everything this cycle stored.
+        let backfill_boundary =
+            (backfill && next.is_none()).then(|| state.oldest.clone()).flatten();
+        Ok(ItemsPage { items, next, backfill_boundary })
+    }
+
+    async fn comments_page(
+        &self,
+        project: &str,
+        cursor: &PageCursor,
+    ) -> anyhow::Result<CommentsPage> {
+        let stream = cursor.stream.as_deref().unwrap_or(EVENTS_STREAM);
+        anyhow::ensure!(stream == EVENTS_STREAM, "unknown GitLab comment stream `{stream}`");
+        let url = match cursor.page_token.clone() {
+            Some(next) => next,
+            None => {
+                let mut url = Url::parse(&self.project_path(project, "events")?)?;
+                let mut query = url.query_pairs_mut();
+                query
+                    .append_pair("action", "commented")
+                    .append_pair("sort", "asc")
+                    .append_pair("per_page", "100");
+                // `after` is DATE-granular and excludes the named day; naming the day BEFORE the
+                // cursor's date keeps every same-day event in scope (the mirror dedups replays).
+                if let Some(since) = cursor.updated_since.as_deref() {
+                    query.append_pair("after", &day_before(since)?);
+                }
+                drop(query);
+                url.into()
+            },
+        };
+        let (value, next_url) = self.get_json(&url).await?;
+        let events = value
+            .as_array()
+            .ok_or_else(|| anyhow::anyhow!("GitLab events response is not an array"))?;
+        let mut comments = Vec::new();
+        for event in events {
+            // The feed is creation events for notes; each embeds the note's CURRENT state. Notes
+            // on untracked noteables (commits, snippets) carry no iid and are skipped.
+            if event["target_type"].as_str() != Some("Note") {
+                continue;
+            }
+            let note = &event["note"];
+            let kind = match note["noteable_type"].as_str() {
+                Some("Issue") => ItemKind::Issue,
+                Some("MergeRequest") => ItemKind::ChangeRequest,
+                _ => continue,
+            };
+            let Some(iid) = note["noteable_iid"].as_u64().filter(|iid| *iid > 0) else {
+                continue;
+            };
+            validate_positive_id(note, "id", "GitLab note event")?;
+            if let Some(comment) = comment_from_note_value(project, kind, &iid.to_string(), note) {
+                comments.push(comment);
+            }
+        }
+        let next = next_url.map(|page_token| PageCursor {
+            stream: Some(EVENTS_STREAM.to_string()),
+            updated_since: cursor.updated_since.clone(),
+            page_token: Some(page_token),
+            ..PageCursor::default()
+        });
+        Ok(CommentsPage { comments, next })
+    }
+
+    async fn freshness_probe(
+        &self,
+        project: &str,
+        probe: &FreshnessProbe,
+    ) -> anyhow::Result<FreshnessResult> {
+        validate_gitlab_project(project)?;
+        // Two 1-item calls (separate iid namespaces have separate lists); the max of the two is
+        // the project's newest movement. No ETag: two responses cannot share one validator, and
+        // `probe_advance` on timestamps suffices.
+        let mut latest: Option<String> = None;
+        for leg in [ListLeg::Issues, ListLeg::MergeRequests] {
+            let mut url = Url::parse(&self.project_path(project, leg.path_segment())?)?;
+            url.query_pairs_mut()
+                .append_pair("order_by", "updated_at")
+                .append_pair("sort", "desc")
+                .append_pair("per_page", "1");
+            let (value, _) = self.get_json(url.as_str()).await?;
+            let leg_latest = value
+                .as_array()
+                .and_then(|items| items.first())
+                .and_then(|item| item["updated_at"].as_str())
+                .map(str::to_string);
+            latest = match (latest.take(), leg_latest) {
+                (Some(current), Some(new)) => Some(current.max(new)),
+                (current, new) => current.or(new),
+            };
+        }
+        Ok(FreshnessResult {
+            latest: probe_advance(latest, probe.updated_since.as_deref()),
+            etag: probe.etag.clone(),
+            not_modified: false,
+        })
+    }
+}
+
+const NOTES_STREAM: &str = "notes";
+const EVENTS_STREAM: &str = "events";
+
+/// The civil date one day before `timestamp`'s date part (`YYYY-MM-DD…` → `YYYY-MM-DD`), via
+/// days-from-civil round-tripping (Howard Hinnant's algorithm) — no calendar dependency.
+fn day_before(timestamp: &str) -> anyhow::Result<String> {
+    let date = timestamp.get(..10).unwrap_or_default();
+    let mut parts = date.split('-').map(|part| part.parse::<i64>());
+    let (year, month, day) = match (parts.next(), parts.next(), parts.next()) {
+        (Some(Ok(year)), Some(Ok(month)), Some(Ok(day)))
+            if (1..=12).contains(&month) && (1..=31).contains(&day) =>
+            (year, month, day),
+        _ => anyhow::bail!("timestamp `{timestamp}` has no leading YYYY-MM-DD date"),
+    };
+    let shifted_year = if month <= 2 { year - 1 } else { year };
+    let era = shifted_year.div_euclid(400);
+    let year_of_era = shifted_year - era * 400;
+    let day_of_year = (153 * (if month > 2 { month - 3 } else { month + 9 }) + 2) / 5 + day - 1;
+    let day_of_era = year_of_era * 365 + year_of_era / 4 - year_of_era / 100 + day_of_year;
+    let days = era * 146_097 + day_of_era - 719_468 - 1; // one day earlier
+    let era = (days + 719_468).div_euclid(146_097);
+    let day_of_era = days + 719_468 - era * 146_097;
+    let year_of_era =
+        (day_of_era - day_of_era / 1460 + day_of_era / 36_524 - day_of_era / 146_096) / 365;
+    let day_of_year = day_of_era - (365 * year_of_era + year_of_era / 4 - year_of_era / 100);
+    let month_index = (5 * day_of_year + 2) / 153;
+    let day = day_of_year - (153 * month_index + 2) / 5 + 1;
+    let month = if month_index < 10 { month_index + 3 } else { month_index - 9 };
+    let year = year_of_era + era * 400 + i64::from(month <= 2);
+    Ok(format!("{year:04}-{month:02}-{day:02}"))
+}
+
+fn gitlab_headers() -> Vec<(&'static str, &'static str)> {
+    vec![("accept", "application/json")]
+}
+
+fn ensure_success(status: u16, body: &str) -> anyhow::Result<()> {
+    ensure_provider_success("GitLab", status, body)
+}
+
+/// GitLab project paths are `namespace(/subgroup)*/project` with segments drawn from GitLab's
+/// path alphabet (letters, digits, `-`, `_`, `.`). Enforcing the alphabet here is what makes the
+/// `%2F`-only encoding in [`GitLabClient::project_path`] sound.
+fn validate_gitlab_project(project: &str) -> anyhow::Result<()> {
+    let segments: Vec<&str> = project.split('/').collect();
+    let safe = |segment: &str| {
+        !segment.is_empty()
+            && !matches!(segment, "." | "..")
+            && segment.chars().all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.'))
+    };
+    anyhow::ensure!(
+        segments.len() >= 2 && segments.iter().all(|segment| safe(segment)),
+        "invalid GitLab project `{project}`"
+    );
+    Ok(())
+}
+
+/// GitLab item keys are iids — positive integers within their kind's namespace.
+fn validate_iid(key: &str) -> anyhow::Result<i64> {
+    key.parse::<i64>()
+        .ok()
+        .filter(|iid| *iid > 0)
+        .ok_or_else(|| anyhow::anyhow!("invalid GitLab iid `{key}`"))
+}
+
+fn item_from_gitlab_value(
+    project: &str,
+    kind: ItemKind,
+    value: &Value,
+) -> anyhow::Result<PapertrailItem> {
+    validate_positive_id(value, "iid", "GitLab item")?;
+    anyhow::ensure!(value["updated_at"].as_str().is_some(), "GitLab item has no valid updated_at");
+    Ok(PapertrailItem {
+        project: project.to_string(),
+        item_kind: kind,
+        item_key: value["iid"].as_u64().expect("validated").to_string(),
+        url: value["web_url"].as_str().unwrap_or_default().to_string(),
+        state: value["state"].as_str().unwrap_or_default().to_string(),
+        title: value["title"].as_str().unwrap_or_default().to_string(),
+        body: value["description"].as_str().unwrap_or_default().to_string(),
+        author: value["author"]["username"].as_str().map(str::to_string),
+        created_at: value["created_at"].as_str().map(str::to_string),
+        updated_at: value["updated_at"].as_str().map(str::to_string),
+        merged_at: value["merged_at"].as_str().map(str::to_string),
+        // GitLab labels are plain strings (GitHub's are objects).
+        tags: value["labels"]
+            .as_array()
+            .map(|labels| labels.iter().filter_map(Value::as_str).map(str::to_string).collect())
+            .unwrap_or_default(),
+    })
+}
+
+/// Map one note. `None` drops it: system noise ("added label …") never becomes a comment row.
+/// Approval events are the exception — they are system notes, and mapping them (instead of the
+/// `/approvals` endpoint, which has no per-event history) yields review comments with real
+/// authors and timestamps. Scoped to `system: true`, so a user comment cannot spoof
+/// `review_state`.
+fn comment_from_note_value(
+    project: &str,
+    kind: ItemKind,
+    key: &str,
+    value: &Value,
+) -> Option<PapertrailComment> {
+    let system = value["system"].as_bool().unwrap_or(false);
+    let body = value["body"].as_str().unwrap_or_default();
+    let review_state = if system {
+        match (kind, body) {
+            (ItemKind::ChangeRequest, "approved this merge request") => Some("APPROVED"),
+            (ItemKind::ChangeRequest, "unapproved this merge request") => Some("UNAPPROVED"),
+            (ItemKind::ChangeRequest, "requested changes") => Some("CHANGES_REQUESTED"),
+            _ => return None,
+        }
+    } else {
+        None
+    };
+    let anchor_path = value["position"]["new_path"]
+        .as_str()
+        .or_else(|| value["position"]["old_path"].as_str())
+        .map(str::to_string);
+    Some(PapertrailComment {
+        project: project.to_string(),
+        item_kind: kind,
+        item_key: key.to_string(),
+        comment_id: format!("note:{}", value["id"].as_u64().unwrap_or_default()),
+        url: None,
+        body: body.to_string(),
+        author: value["author"]["username"].as_str().map(str::to_string),
+        created_at: value["created_at"].as_str().map(str::to_string),
+        updated_at: value["updated_at"].as_str().map(str::to_string),
+        review_state: review_state.map(str::to_string),
+        anchor_path,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::transport::stub::{StubResponse, spawn_script_stub};
+    use super::*;
+
+    fn binding(base_url: String) -> ResolvedTracker {
+        ResolvedTracker {
+            provider: Tracker::Gitlab,
+            project: "g/s/r".to_string(),
+            base_url: Some(base_url),
+            auth: None,
+            authentication: TrackerAuthentication::AuthMissing,
+            tags: Vec::new(),
+        }
+    }
+
+    fn client(base: String, registry: &GovernorRegistry) -> GitLabClient {
+        GitLabClient::new(&binding(base), registry, TransportOptions::default()).unwrap()
+    }
+
+    fn issue(iid: i64, updated_at: &str) -> String {
+        format!(
+            r#"{{"iid":{iid},"web_url":"{{BASE}}/g/s/r/-/issues/{iid}","state":"opened","title":"item {iid}","description":"body","author":{{"username":"u"}},"created_at":"2026-01-01T00:00:00Z","updated_at":"{updated_at}","labels":["bug","ux"]}}"#
+        )
+    }
+
+    fn merge_request(iid: i64, updated_at: &str) -> String {
+        format!(
+            r#"{{"iid":{iid},"web_url":"{{BASE}}/g/s/r/-/merge_requests/{iid}","state":"merged","title":"mr {iid}","description":"change","author":{{"username":"m"}},"created_at":"2026-01-01T00:00:00Z","updated_at":"{updated_at}","merged_at":"2026-01-04T00:00:00Z","labels":[]}}"#
+        )
+    }
+
+    fn with_next_link(mut response: StubResponse, path_and_query: &str) -> StubResponse {
+        response
+            .headers
+            .push(("Link".to_string(), format!("<{{BASE}}{path_and_query}>; rel=\"next\"")));
+        response
+    }
+
+    #[test]
+    fn constructor_validates_provider_and_api_origin() {
+        let registry = GovernorRegistry::default();
+        let mut github = binding("http://127.0.0.1:1".to_string());
+        github.provider = Tracker::Github;
+        let error = GitLabClient::new(&github, &registry, TransportOptions::default())
+            .err()
+            .expect("provider mismatch must fail")
+            .to_string();
+        assert!(error.contains("not a GitLab binding"), "{error}");
+
+        for (base, expected) in [
+            ("https://gitlab.example.com/sub/path", "without a path"),
+            ("https://user:pw@gitlab.example.com", "credentials"),
+            ("ftp://gitlab.example.com", "http(s)"),
+            ("https://gitlab.example.com?x=1", "without a path"),
+        ] {
+            let error = GitLabClient::new(
+                &binding(base.to_string()),
+                &registry,
+                TransportOptions::default(),
+            )
+            .err()
+            .expect("malformed base URL must fail")
+            .to_string();
+            assert!(error.contains(expected), "`{base}`: {error}");
+        }
+    }
+
+    #[test]
+    fn iid_namespaces_are_binding_and_subgroups_encode_as_one_segment() {
+        let (base, handle) = spawn_script_stub(vec![
+            StubResponse::ok(&issue(5, "2026-01-02T00:00:00Z")),
+            StubResponse::ok(&merge_request(5, "2026-01-03T00:00:00Z")),
+        ]);
+        let registry = GovernorRegistry::default();
+        let client = client(base, &registry);
+
+        let issue_item = block_on(client.item("g/s/r", ItemKind::Issue, "5")).unwrap();
+        assert_eq!(issue_item.item_kind, ItemKind::Issue);
+        assert_eq!(issue_item.item_key, "5");
+        assert_eq!(issue_item.tags, vec!["bug".to_string(), "ux".to_string()]);
+        assert_eq!(issue_item.merged_at, None);
+
+        let change = block_on(client.item("g/s/r", ItemKind::ChangeRequest, "5")).unwrap();
+        assert_eq!(change.item_kind, ItemKind::ChangeRequest);
+        assert_eq!(change.merged_at.as_deref(), Some("2026-01-04T00:00:00Z"));
+        assert_eq!(change.state, "merged");
+
+        let heads = handle.join().unwrap();
+        assert!(heads[0].starts_with("GET /api/v4/projects/g%2Fs%2Fr/issues/5 "), "{}", heads[0]);
+        assert!(
+            heads[1].starts_with("GET /api/v4/projects/g%2Fs%2Fr/merge_requests/5 "),
+            "{}",
+            heads[1]
+        );
+    }
+
+    #[test]
+    fn notes_map_comments_anchors_and_approvals_and_drop_system_noise() {
+        let notes = r#"[
+            {"id":1,"body":"plain words","system":false,"author":{"username":"a"},"created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z"},
+            {"id":2,"body":"diff remark","system":false,"position":{"new_path":"src/lib.rs","old_path":"src/old.rs"},"author":{"username":"b"},"created_at":"2026-01-02T00:00:00Z","updated_at":"2026-01-02T00:00:00Z"},
+            {"id":3,"body":"approved this merge request","system":true,"author":{"username":"c"},"created_at":"2026-01-03T00:00:00Z","updated_at":"2026-01-03T00:00:00Z"},
+            {"id":4,"body":"added ~bug label","system":true,"author":{"username":"d"},"created_at":"2026-01-04T00:00:00Z","updated_at":"2026-01-04T00:00:00Z"}
+        ]"#;
+        let (base, handle) = spawn_script_stub(vec![StubResponse::ok(notes)]);
+        let registry = GovernorRegistry::default();
+        let client = client(base, &registry);
+
+        let comments =
+            block_on(client.item_comments("g/s/r", ItemKind::ChangeRequest, "9")).unwrap();
+        assert_eq!(comments.len(), 3, "system noise must be dropped");
+        assert_eq!(comments[0].comment_id, "note:1");
+        assert_eq!(comments[0].review_state, None);
+        assert_eq!(comments[0].anchor_path, None);
+        assert_eq!(comments[1].anchor_path.as_deref(), Some("src/lib.rs"));
+        assert_eq!(comments[2].review_state.as_deref(), Some("APPROVED"));
+        assert_eq!(comments[2].author.as_deref(), Some("c"));
+        assert_eq!(comments[2].item_kind, ItemKind::ChangeRequest);
+
+        let heads = handle.join().unwrap();
+        assert!(
+            heads[0].starts_with(
+                "GET /api/v4/projects/g%2Fs%2Fr/merge_requests/9/notes?order_by=updated_at&\
+                 sort=asc&per_page=100 "
+            ),
+            "{}",
+            heads[0]
+        );
+    }
+
+    #[test]
+    fn approval_words_from_a_user_comment_never_spoof_review_state() {
+        let notes = r#"[{"id":8,"body":"approved this merge request","system":false,"author":{"username":"prankster"},"created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z"}]"#;
+        let (base, _handle) = spawn_script_stub(vec![StubResponse::ok(notes)]);
+        let registry = GovernorRegistry::default();
+        let client = client(base, &registry);
+        let comments =
+            block_on(client.item_comments("g/s/r", ItemKind::ChangeRequest, "9")).unwrap();
+        assert_eq!(comments.len(), 1);
+        assert_eq!(comments[0].review_state, None, "a plain comment stays a plain comment");
+    }
+
+    #[test]
+    fn backfill_chains_issue_and_merge_request_legs_and_reports_the_global_boundary() {
+        let issues_page_one = format!(
+            "[{},{}]",
+            issue(20, "2026-01-10T00:00:00Z"),
+            issue(19, "2026-01-05T00:00:00Z")
+        );
+        let issues_page_two = format!("[{}]", issue(18, "2026-01-03T00:00:00Z"));
+        let change_page = format!("[{}]", merge_request(7, "2026-01-08T00:00:00Z"));
+        let (base, handle) = spawn_script_stub(vec![
+            with_next_link(
+                StubResponse::ok(&issues_page_one),
+                "/api/v4/projects/g%2Fs%2Fr/issues?page=2",
+            ),
+            StubResponse::ok(&issues_page_two),
+            StubResponse::ok(&change_page),
+        ]);
+        let registry = GovernorRegistry::default();
+        let client = client(base, &registry);
+
+        let mut cursor = PageCursor {
+            updated_before: Some("2026-02-01T00:00:00Z".to_string()),
+            ..PageCursor::default()
+        };
+        let first = block_on(client.items_page("g/s/r", &cursor)).unwrap();
+        assert_eq!(first.items.len(), 2);
+        assert!(first.items.iter().all(|item| item.item_kind == ItemKind::Issue));
+        assert_eq!(first.backfill_boundary, None, "mid-cycle pages report no boundary");
+        cursor = first.next.expect("issues page two pending");
+        assert!(cursor.page_token.as_deref().unwrap().contains("/issues?page=2"));
+
+        let second = block_on(client.items_page("g/s/r", &cursor)).unwrap();
+        assert_eq!(second.items.len(), 1);
+        assert_eq!(second.backfill_boundary, None, "the merge-request leg has not run yet");
+        cursor = second.next.expect("the merge-request leg must chain");
+        let entry = cursor.page_token.as_deref().unwrap();
+        assert!(entry.contains("/merge_requests?"), "{entry}");
+        assert!(
+            entry.contains("sort=desc") && entry.contains("updated_before=2026-02-01"),
+            "{entry}"
+        );
+
+        let third = block_on(client.items_page("g/s/r", &cursor)).unwrap();
+        assert_eq!(third.items.len(), 1);
+        assert_eq!(third.items[0].item_kind, ItemKind::ChangeRequest);
+        assert!(third.next.is_none(), "both legs drained");
+        assert_eq!(
+            third.backfill_boundary.as_deref(),
+            Some("2026-01-03T00:00:00Z"),
+            "the boundary is the GLOBAL oldest across both legs, not the last page's"
+        );
+
+        let heads = handle.join().unwrap();
+        assert!(
+            heads[0].contains("/issues?order_by=updated_at&per_page=100&sort=desc"),
+            "{}",
+            heads[0]
+        );
+        assert!(heads[0].contains("updated_before=2026-02-01"), "{}", heads[0]);
+        assert!(heads[2].contains("/merge_requests?"), "{}", heads[2]);
+    }
+
+    #[test]
+    fn an_empty_project_backfill_terminates_with_the_done_shape() {
+        let (base, _handle) =
+            spawn_script_stub(vec![StubResponse::ok("[]"), StubResponse::ok("[]")]);
+        let registry = GovernorRegistry::default();
+        let client = client(base, &registry);
+
+        let cursor = PageCursor {
+            updated_before: Some("2026-02-01T00:00:00Z".to_string()),
+            ..PageCursor::default()
+        };
+        let first = block_on(client.items_page("g/s/r", &cursor)).unwrap();
+        assert!(first.items.is_empty());
+        let chained = first.next.expect("the empty issues leg still chains to merge requests");
+
+        let second = block_on(client.items_page("g/s/r", &chained)).unwrap();
+        assert!(second.items.is_empty());
+        assert!(second.next.is_none());
+        assert!(second.backfill_boundary.is_none(), "nothing consumed = the mirror's done shape");
+    }
+
+    #[test]
+    fn delta_ascends_with_updated_after_and_chains_both_legs() {
+        let issues = format!("[{}]", issue(21, "2026-01-11T00:00:00Z"));
+        let changes = format!("[{}]", merge_request(8, "2026-01-12T00:00:00Z"));
+        let (base, handle) =
+            spawn_script_stub(vec![StubResponse::ok(&issues), StubResponse::ok(&changes)]);
+        let registry = GovernorRegistry::default();
+        let client = client(base, &registry);
+
+        let cursor = PageCursor {
+            updated_since: Some("2026-01-09T00:00:00Z".to_string()),
+            ..PageCursor::default()
+        };
+        let first = block_on(client.items_page("g/s/r", &cursor)).unwrap();
+        assert_eq!(first.items[0].item_kind, ItemKind::Issue);
+        let chained = first.next.expect("delta chains into merge requests too");
+        assert_eq!(chained.updated_since.as_deref(), Some("2026-01-09T00:00:00Z"));
+
+        let second = block_on(client.items_page("g/s/r", &chained)).unwrap();
+        assert_eq!(second.items[0].item_kind, ItemKind::ChangeRequest);
+        assert!(second.next.is_none());
+        assert!(second.backfill_boundary.is_none(), "delta never reports a backfill boundary");
+
+        let heads = handle.join().unwrap();
+        for head in &heads {
+            assert!(head.contains("sort=asc"), "{head}");
+            assert!(head.contains("updated_after=2026-01-09"), "{head}");
+        }
+    }
+
+    #[test]
+    fn freshness_probe_takes_the_max_of_both_namespaces_and_stays_quiet_at_the_cursor() {
+        let (base, handle) = spawn_script_stub(vec![
+            StubResponse::ok(&format!("[{}]", issue(1, "2026-01-05T00:00:00Z"))),
+            StubResponse::ok(&format!("[{}]", merge_request(2, "2026-01-07T00:00:00Z"))),
+            StubResponse::ok(&format!("[{}]", issue(1, "2026-01-05T00:00:00Z"))),
+            StubResponse::ok(&format!("[{}]", merge_request(2, "2026-01-07T00:00:00Z"))),
+        ]);
+        let registry = GovernorRegistry::default();
+        let client = client(base, &registry);
+
+        let moved = block_on(client.freshness_probe("g/s/r", &FreshnessProbe {
+            updated_since: Some("2026-01-06T00:00:00Z".to_string()),
+            etag: None,
+        }))
+        .unwrap();
+        assert_eq!(moved.latest.as_deref(), Some("2026-01-07T00:00:00Z"));
+        assert!(!moved.not_modified);
+
+        let quiet = block_on(client.freshness_probe("g/s/r", &FreshnessProbe {
+            updated_since: Some("2026-01-07T00:00:00Z".to_string()),
+            etag: None,
+        }))
+        .unwrap();
+        assert_eq!(quiet.latest, None, "at-or-before the cursor must stay quiet");
+
+        let heads = handle.join().unwrap();
+        assert!(heads[0].contains("per_page=1"), "{}", heads[0]);
+        assert!(heads[0].contains("sort=desc"), "{}", heads[0]);
+    }
+
+    #[test]
+    fn not_found_is_a_typed_item_outcome() {
+        let (base, _handle) = spawn_script_stub(vec![StubResponse::status("404 Not Found", "{}")]);
+        let registry = GovernorRegistry::default();
+        let client = client(base, &registry);
+        let error = block_on(client.item("g/s/r", ItemKind::Issue, "3")).unwrap_err();
+        assert!(
+            matches!(
+                error.downcast_ref::<PapertrailClientError>(),
+                Some(PapertrailClientError::ItemNotFound)
+            ),
+            "{error:#}"
+        );
+    }
+
+    #[test]
+    fn malformed_projects_and_iids_are_rejected_before_any_request() {
+        let (base, handle) = spawn_script_stub(Vec::new());
+        let registry = GovernorRegistry::default();
+        let client = client(base, &registry);
+
+        for project in ["solo", "g//r", "g/r r", "../r", "g/r%2Fx", "g/r?x"] {
+            let error = block_on(client.item(project, ItemKind::Issue, "1")).unwrap_err();
+            assert!(error.to_string().contains("invalid GitLab project"), "`{project}`: {error}");
+        }
+        for iid in ["0", "-3", "abc", "1.5", ""] {
+            let error = block_on(client.item("g/s/r", ItemKind::Issue, iid)).unwrap_err();
+            assert!(error.to_string().contains("invalid GitLab iid"), "`{iid}`: {error}");
+        }
+        assert!(handle.join().unwrap().is_empty(), "no request may leave the process");
+    }
+
+    #[test]
+    fn cross_origin_pagination_is_rejected_before_following_it() {
+        let (base, handle) = spawn_script_stub(vec![with_next_link(
+            StubResponse::ok(&format!("[{}]", issue(1, "2026-01-05T00:00:00Z"))),
+            "",
+        )]);
+        // Rewrite the next link to a foreign origin AFTER stub substitution.
+        let registry = GovernorRegistry::default();
+        let client = client(base, &registry);
+        let cursor = PageCursor {
+            updated_before: Some("2026-02-01T00:00:00Z".to_string()),
+            page_token: Some("https://gitlab.com/api/v4/projects/g%2Fs%2Fr/issues".to_string()),
+            ..PageCursor::default()
+        };
+        let error = block_on(client.items_page("g/s/r", &cursor)).unwrap_err();
+        assert!(error.to_string().contains("outside the binding"), "{error:#}");
+        assert!(handle.join().unwrap().is_empty(), "the foreign URL was never requested");
+    }
+
+    #[test]
+    fn comment_events_map_embedded_notes_and_skip_untracked_noteables() {
+        let events = r#"[
+            {"target_type":"Note","note":{"id":30,"body":"issue words","system":false,"noteable_type":"Issue","noteable_iid":4,"author":{"username":"a"},"created_at":"2026-01-10T00:00:00Z","updated_at":"2026-01-12T00:00:00Z"}},
+            {"target_type":"Note","note":{"id":31,"body":"mr words","system":false,"noteable_type":"MergeRequest","noteable_iid":4,"author":{"username":"b"},"created_at":"2026-01-11T00:00:00Z","updated_at":"2026-01-11T00:00:00Z"}},
+            {"target_type":"Note","note":{"id":32,"body":"commit words","system":false,"noteable_type":"Commit","author":{"username":"c"},"created_at":"2026-01-11T00:00:00Z","updated_at":"2026-01-11T00:00:00Z"}},
+            {"target_type":"Issue","target_iid":9}
+        ]"#;
+        let (base, handle) = spawn_script_stub(vec![StubResponse::ok(events)]);
+        let registry = GovernorRegistry::default();
+        let client = client(base, &registry);
+
+        let page = block_on(client.comments_page("g/s/r", &PageCursor {
+            stream: Some("events".to_string()),
+            updated_since: Some("2026-01-10T08:00:00Z".to_string()),
+            ..PageCursor::default()
+        }))
+        .unwrap();
+        assert_eq!(page.comments.len(), 2, "commit notes and non-note events are skipped");
+        assert_eq!(page.comments[0].item_kind, ItemKind::Issue);
+        assert_eq!(page.comments[0].item_key, "4");
+        assert_eq!(page.comments[0].comment_id, "note:30");
+        assert_eq!(
+            page.comments[0].updated_at.as_deref(),
+            Some("2026-01-12T00:00:00Z"),
+            "the embedded note carries its CURRENT state, edits included"
+        );
+        assert_eq!(page.comments[1].item_kind, ItemKind::ChangeRequest);
+        assert_eq!(page.comments[1].item_key, "4");
+        assert!(page.next.is_none());
+
+        let heads = handle.join().unwrap();
+        assert!(
+            heads[0].starts_with(
+                "GET /api/v4/projects/g%2Fs%2Fr/events?action=commented&sort=asc&per_page=100&\
+                 after=2026-01-09 "
+            ),
+            "the day BEFORE the cursor's date keeps same-day events in scope: {}",
+            heads[0]
+        );
+    }
+
+    #[test]
+    fn day_before_handles_month_year_and_leap_boundaries() {
+        for (timestamp, expected) in [
+            ("2026-07-15T13:16:18.443Z", "2026-07-14"),
+            ("2026-03-01T00:00:00Z", "2026-02-28"),
+            ("2024-03-01T00:00:00Z", "2024-02-29"),
+            ("2026-01-01T00:00:00Z", "2025-12-31"),
+            ("2026-05-01", "2026-04-30"),
+        ] {
+            assert_eq!(day_before(timestamp).unwrap(), expected, "{timestamp}");
+        }
+        for garbage in ["", "notadate", "2026-13-01T00:00:00Z", "2026-01"] {
+            assert!(day_before(garbage).is_err(), "`{garbage}` must be rejected");
+        }
+    }
+}

--- a/crates/rag-rat-core/src/index/papertrail/gitlab.rs
+++ b/crates/rag-rat-core/src/index/papertrail/gitlab.rs
@@ -167,14 +167,23 @@ impl GitLabClient {
         Ok(url.into())
     }
 
-    /// One page from one leg: the mapped items plus the leg's next-page URL, if any.
+    /// One page from one leg: the mapped items plus the leg's next-page URL, if any. `None` =
+    /// the namespace is unavailable (GitLab projects can disable issues or merge requests as a
+    /// feature, surfacing 403/404 on that list) — the caller treats it as an empty, drained leg
+    /// so one disabled tracker never aborts the sibling namespace's mirror.
     async fn leg_page(
         &self,
         project: &str,
         url: &str,
         leg: ListLeg,
-    ) -> anyhow::Result<(Vec<PapertrailItem>, Option<String>)> {
-        let (value, next_url) = self.get_json(url).await?;
+    ) -> anyhow::Result<Option<(Vec<PapertrailItem>, Option<String>)>> {
+        let response = self.core.get(url, &gitlab_headers()).await?;
+        if matches!(response.status, 403 | 404) {
+            return Ok(None);
+        }
+        ensure_success(response.status, &response.body)?;
+        let next_url = next_link(&response.headers)?;
+        let value: Value = serde_json::from_str(&response.body)?;
         let values = value.as_array().ok_or_else(|| {
             anyhow::anyhow!("GitLab {} response is not an array", leg.path_segment())
         })?;
@@ -182,7 +191,7 @@ impl GitLabClient {
         for value in values {
             items.push(item_from_gitlab_value(project, leg.item_kind(), value)?);
         }
-        Ok((items, next_url))
+        Ok(Some((items, next_url)))
     }
 }
 
@@ -284,29 +293,58 @@ impl PapertrailClient for GitLabClient {
             anyhow::bail!("an item page cannot be both delta and backfill");
         }
         let backfill = cursor.updated_before.is_some();
-        // Resume from the persisted continuation, or open BOTH legs' first pages.
-        let mut state = match cursor.provider_state.as_deref() {
-            Some(state) => serde_json::from_str::<ListContinuation>(state)?,
-            None => ListContinuation {
-                issues_next: Some(self.list_url(project, ListLeg::Issues, cursor)?),
-                merge_requests_next: Some(self.list_url(
-                    project,
-                    ListLeg::MergeRequests,
-                    cursor,
-                )?),
-                oldest: None,
-            },
+        // Resume from the persisted continuation, or open BOTH legs' first pages. The delta
+        // checkpoint persists only `page_token` and rebuilds its resume request WITHOUT
+        // provider_state (mirror sync_item_delta), so the continuation JSON must live in the
+        // page token itself — a resume that reopened both first pages would let a pause before
+        // the second logical page spend every run's budget replaying page one.
+        let continuation = cursor
+            .provider_state
+            .as_deref()
+            .or_else(|| cursor.page_token.as_deref().filter(|token| token.starts_with('{')));
+        let (mut state, fresh_open) = match continuation {
+            Some(state) => (serde_json::from_str::<ListContinuation>(state)?, false),
+            None => (
+                ListContinuation {
+                    issues_next: Some(self.list_url(project, ListLeg::Issues, cursor)?),
+                    merge_requests_next: Some(self.list_url(
+                        project,
+                        ListLeg::MergeRequests,
+                        cursor,
+                    )?),
+                    oldest: None,
+                },
+                true,
+            ),
         };
         let mut items = Vec::new();
+        let mut unavailable = 0usize;
+        let mut fetched = 0usize;
         if let Some(url) = state.issues_next.take() {
-            let (page, next) = self.leg_page(project, &url, ListLeg::Issues).await?;
-            items.extend(page);
-            state.issues_next = next;
+            fetched += 1;
+            match self.leg_page(project, &url, ListLeg::Issues).await? {
+                Some((page, next)) => {
+                    items.extend(page);
+                    state.issues_next = next;
+                },
+                None => unavailable += 1,
+            }
         }
         if let Some(url) = state.merge_requests_next.take() {
-            let (page, next) = self.leg_page(project, &url, ListLeg::MergeRequests).await?;
-            items.extend(page);
-            state.merge_requests_next = next;
+            fetched += 1;
+            match self.leg_page(project, &url, ListLeg::MergeRequests).await? {
+                Some((page, next)) => {
+                    items.extend(page);
+                    state.merge_requests_next = next;
+                },
+                None => unavailable += 1,
+            }
+        }
+        // One unavailable namespace is a disabled feature; EVERY namespace unavailable on a
+        // fresh open means the project itself is missing or inaccessible — that must surface,
+        // not mirror as an empty project.
+        if fresh_open && unavailable == fetched {
+            return Err(PapertrailClientError::ItemNotFound.into());
         }
         // Keep the emitted page ordered like its legs (mirror correctness is order-agnostic;
         // ordering keeps pages legible in logs and tests).
@@ -323,19 +361,21 @@ impl PapertrailClient for GitLabClient {
             };
         }
         let stream = if backfill { LIST_BACKFILL_STREAM } else { LIST_DELTA_STREAM };
-        let pending = [state.issues_next.as_deref(), state.merge_requests_next.as_deref()];
-        let next = match pending.iter().flatten().next() {
-            Some(token) => Some(PageCursor {
+        let pending = state.issues_next.is_some() || state.merge_requests_next.is_some();
+        let next = if pending {
+            let token = serde_json::to_string(&state)?;
+            Some(PageCursor {
                 stream: Some(stream.to_string()),
                 updated_since: cursor.updated_since.clone(),
                 updated_before: cursor.updated_before.clone(),
-                // A non-empty token marks every continuation page as NOT the scan's first page
-                // (the mirror's conservative-frontier logic keys off that); the authoritative
-                // state is the full per-leg continuation.
-                page_token: Some((*token).to_string()),
-                provider_state: Some(serde_json::to_string(&state)?),
-            }),
-            None => None,
+                // The full continuation IS the page token (see resume note above); its
+                // non-emptiness also marks every continuation page as NOT the scan's first page
+                // for the mirror's conservative-frontier logic.
+                page_token: Some(token.clone()),
+                provider_state: Some(token),
+            })
+        } else {
+            None
         };
         // The cycle's provider-confirmed strict boundary: both legs drained fully below the
         // cutoff, so the global oldest consumed timestamp bounds everything this cycle stored.
@@ -375,12 +415,15 @@ impl PapertrailClient for GitLabClient {
             .ok_or_else(|| anyhow::anyhow!("GitLab events response is not an array"))?;
         let mut comments = Vec::new();
         for event in events {
-            // The feed is creation events for notes; each embeds the note's CURRENT state. Notes
-            // on untracked noteables (commits, snippets) carry no iid and are skipped.
-            if event["target_type"].as_str() != Some("Note") {
+            // The feed is creation events for notes; each embeds the note's CURRENT state. The
+            // target_type varies by note subclass (`Note`, `DiscussionNote` for threaded MR
+            // discussions, `DiffNote` for positioned comments — verified live), so the gate is
+            // "carries a note on a tracked noteable", never a target_type list. Notes on
+            // untracked noteables (commits, snippets) carry no iid and are skipped.
+            let note = &event["note"];
+            if note.is_null() {
                 continue;
             }
-            let note = &event["note"];
             let kind = match note["noteable_type"].as_str() {
                 Some("Issue") => ItemKind::Issue,
                 Some("MergeRequest") => ItemKind::ChangeRequest,
@@ -390,7 +433,21 @@ impl PapertrailClient for GitLabClient {
                 continue;
             };
             validate_positive_id(note, "id", "GitLab note event")?;
-            if let Some(comment) = comment_from_note_value(project, kind, &iid.to_string(), note) {
+            if let Some(mut comment) =
+                comment_from_note_value(project, kind, &iid.to_string(), note)
+            {
+                // The mirror advances this stream's frontier from comment.updated_at, and the
+                // frontier must ride the feed's OWN ordering key — the event's created_at. An
+                // edited old note embeds a much newer note.updated_at in its old creation
+                // event; letting that inflate the first-page frontier shrinks the next scan's
+                // replay window and can strand events missed to offset shifts. The stored stamp
+                // therefore reflects event time until the next full walk's thread refetch
+                // repairs it — cursor correctness over a cosmetic timestamp.
+                comment.updated_at = event["created_at"]
+                    .as_str()
+                    .map(str::to_string)
+                    .or_else(|| comment.updated_at.take())
+                    .or_else(|| comment.created_at.clone());
                 comments.push(comment);
             }
         }
@@ -413,13 +470,22 @@ impl PapertrailClient for GitLabClient {
         // the project's newest movement. No ETag: two responses cannot share one validator, and
         // `probe_advance` on timestamps suffices.
         let mut latest: Option<String> = None;
+        let mut unavailable = 0usize;
         for leg in [ListLeg::Issues, ListLeg::MergeRequests] {
             let mut url = Url::parse(&self.project_path(project, leg.path_segment())?)?;
             url.query_pairs_mut()
                 .append_pair("order_by", "updated_at")
                 .append_pair("sort", "desc")
                 .append_pair("per_page", "1");
-            let (value, _) = self.get_json(url.as_str()).await?;
+            let response = self.core.get(url.as_str(), &gitlab_headers()).await?;
+            // A disabled namespace (403/404 on its list) is quiet, not fatal — the sibling
+            // namespace still answers the probe. Both unavailable = the project is gone.
+            if matches!(response.status, 403 | 404) {
+                unavailable += 1;
+                continue;
+            }
+            ensure_success(response.status, &response.body)?;
+            let value: Value = serde_json::from_str(&response.body)?;
             let leg_latest = value
                 .as_array()
                 .and_then(|items| items.first())
@@ -429,6 +495,9 @@ impl PapertrailClient for GitLabClient {
                 (Some(current), Some(new)) => Some(current.max(new)),
                 (current, new) => current.or(new),
             };
+        }
+        if unavailable == 2 {
+            return Err(PapertrailClientError::ItemNotFound.into());
         }
         // GitLab has no probe validator (no shared ETag across the two namespace calls), so the
         // timestamp comparison IS the quiet signal: the mirror keys the delta-scan decision off
@@ -833,6 +902,144 @@ mod tests {
         }
     }
 
+    /// The mirror's delta checkpoint persists ONLY `page_token` and rebuilds its resume
+    /// request without provider_state — a pause between logical pages must resume the saved
+    /// legs, not reopen both first pages (which would spend every run's budget on page one).
+    #[test]
+    fn delta_resumes_from_the_page_token_alone_like_the_mirror_checkpoint() {
+        let issues_page_one = format!("[{}]", issue(21, "2026-01-11T00:00:00Z"));
+        let issues_page_two = format!("[{}]", issue(22, "2026-01-13T00:00:00Z"));
+        let changes = format!("[{}]", merge_request(8, "2026-01-12T00:00:00Z"));
+        let (base, handle) = spawn_script_stub(vec![
+            with_next_link(
+                StubResponse::ok(&issues_page_one),
+                "/api/v4/projects/g%2Fs%2Fr/issues?page=2",
+            ),
+            StubResponse::ok(&changes),
+            StubResponse::ok(&issues_page_two),
+        ]);
+        let registry = GovernorRegistry::default();
+        let client = client(base, &registry);
+
+        let first = block_on(client.items_page("g/s/r", &PageCursor {
+            updated_since: Some("2026-01-09T00:00:00Z".to_string()),
+            ..PageCursor::default()
+        }))
+        .unwrap();
+        let next = first.next.expect("issues leg still pending");
+
+        // Rebuild the resume request the way sync_item_delta does: page_token ONLY.
+        let resumed = block_on(client.items_page("g/s/r", &PageCursor {
+            updated_since: Some("2026-01-09T00:00:00Z".to_string()),
+            page_token: next.page_token.clone(),
+            ..PageCursor::default()
+        }))
+        .unwrap();
+        assert_eq!(resumed.items.len(), 1);
+        assert_eq!(resumed.items[0].item_key, "22");
+        assert!(resumed.next.is_none());
+        let heads = handle.join().unwrap();
+        assert_eq!(heads.len(), 3, "the resume fetched ONE page, not two reopened legs");
+        assert!(heads[2].contains("/issues?page=2"), "{}", heads[2]);
+    }
+
+    /// Threaded MR discussions arrive as `target_type: "DiscussionNote"` events (verified
+    /// live); a `target_type == "Note"` gate silently drops them and quiet discussion comments
+    /// would never mirror incrementally. The frontier falls back to the event's created_at when
+    /// a payload omits the note's updated_at — a None frontier replays the feed every sync.
+    #[test]
+    fn comment_events_accept_discussion_notes_and_fall_back_to_event_timestamps() {
+        let events = r#"[
+            {"target_type":"DiscussionNote","created_at":"2026-01-13T00:00:00Z","note":{"id":40,"body":"threaded words","system":false,"type":"DiscussionNote","noteable_type":"MergeRequest","noteable_iid":6,"author":{"username":"t"},"created_at":"2026-01-12T23:59:00Z"}}
+        ]"#;
+        let (base, _handle) = spawn_script_stub(vec![StubResponse::ok(events)]);
+        let registry = GovernorRegistry::default();
+        let client = client(base, &registry);
+        let page = block_on(client.comments_page("g/s/r", &PageCursor::default())).unwrap();
+        assert_eq!(page.comments.len(), 1);
+        assert_eq!(page.comments[0].item_kind, ItemKind::ChangeRequest);
+        assert_eq!(page.comments[0].item_key, "6");
+        assert_eq!(
+            page.comments[0].updated_at.as_deref(),
+            Some("2026-01-13T00:00:00Z"),
+            "missing note updated_at falls back to the event's created_at"
+        );
+    }
+
+    /// GitLab projects can disable issues or merge requests as a feature; the unavailable leg
+    /// mirrors as empty instead of aborting the sibling namespace. EVERY leg unavailable on a
+    /// fresh open is a missing project and must surface as the typed not-found outcome.
+    #[test]
+    fn a_disabled_namespace_never_aborts_the_sibling_leg() {
+        let changes = format!("[{}]", merge_request(9, "2026-01-05T00:00:00Z"));
+        let (base, _handle) = spawn_script_stub(vec![
+            StubResponse::status("403 Forbidden", "{}"),
+            StubResponse::ok(&changes),
+        ]);
+        let registry = GovernorRegistry::default();
+        let client = client(base, &registry);
+        let page = block_on(client.items_page("g/s/r", &PageCursor {
+            updated_before: Some("2026-02-01T00:00:00Z".to_string()),
+            ..PageCursor::default()
+        }))
+        .unwrap();
+        assert_eq!(page.items.len(), 1);
+        assert_eq!(page.items[0].item_kind, ItemKind::ChangeRequest);
+        assert!(page.next.is_none());
+        assert_eq!(page.backfill_boundary.as_deref(), Some("2026-01-05T00:00:00Z"));
+    }
+
+    #[test]
+    fn a_fully_unavailable_project_surfaces_as_the_typed_not_found_outcome() {
+        let (base, _handle) = spawn_script_stub(vec![
+            StubResponse::status("404 Not Found", "{}"),
+            StubResponse::status("404 Not Found", "{}"),
+        ]);
+        let registry = GovernorRegistry::default();
+        let client = client(base, &registry);
+        let error = block_on(client.items_page("g/s/r", &PageCursor {
+            updated_before: Some("2026-02-01T00:00:00Z".to_string()),
+            ..PageCursor::default()
+        }))
+        .unwrap_err();
+        assert!(
+            matches!(
+                error.downcast_ref::<PapertrailClientError>(),
+                Some(PapertrailClientError::ItemNotFound)
+            ),
+            "{error:#}"
+        );
+    }
+
+    #[test]
+    fn the_probe_tolerates_one_disabled_namespace_and_fails_on_two() {
+        let (base, _handle) = spawn_script_stub(vec![
+            StubResponse::status("403 Forbidden", "{}"),
+            StubResponse::ok(&format!("[{}]", merge_request(2, "2026-01-07T00:00:00Z"))),
+            StubResponse::status("404 Not Found", "{}"),
+            StubResponse::status("404 Not Found", "{}"),
+        ]);
+        let registry = GovernorRegistry::default();
+        let client = client(base, &registry);
+
+        let probe = block_on(client.freshness_probe("g/s/r", &FreshnessProbe {
+            updated_since: Some("2026-01-06T00:00:00Z".to_string()),
+            etag: None,
+        }))
+        .unwrap();
+        assert_eq!(probe.latest.as_deref(), Some("2026-01-07T00:00:00Z"));
+
+        let error =
+            block_on(client.freshness_probe("g/s/r", &FreshnessProbe::default())).unwrap_err();
+        assert!(
+            matches!(
+                error.downcast_ref::<PapertrailClientError>(),
+                Some(PapertrailClientError::ItemNotFound)
+            ),
+            "{error:#}"
+        );
+    }
+
     #[test]
     fn freshness_probe_takes_the_max_of_both_namespaces_and_stays_quiet_at_the_cursor() {
         let (base, handle) = spawn_script_stub(vec![
@@ -921,9 +1128,9 @@ mod tests {
     #[test]
     fn comment_events_map_embedded_notes_and_skip_untracked_noteables() {
         let events = r#"[
-            {"target_type":"Note","note":{"id":30,"body":"issue words","system":false,"noteable_type":"Issue","noteable_iid":4,"author":{"username":"a"},"created_at":"2026-01-10T00:00:00Z","updated_at":"2026-01-12T00:00:00Z"}},
-            {"target_type":"Note","note":{"id":31,"body":"mr words","system":false,"noteable_type":"MergeRequest","noteable_iid":4,"author":{"username":"b"},"created_at":"2026-01-11T00:00:00Z","updated_at":"2026-01-11T00:00:00Z"}},
-            {"target_type":"Note","note":{"id":32,"body":"commit words","system":false,"noteable_type":"Commit","author":{"username":"c"},"created_at":"2026-01-11T00:00:00Z","updated_at":"2026-01-11T00:00:00Z"}},
+            {"target_type":"Note","created_at":"2026-01-10T00:00:30Z","note":{"id":30,"body":"issue words","system":false,"noteable_type":"Issue","noteable_iid":4,"author":{"username":"a"},"created_at":"2026-01-10T00:00:00Z","updated_at":"2026-01-12T00:00:00Z"}},
+            {"target_type":"Note","created_at":"2026-01-11T00:00:30Z","note":{"id":31,"body":"mr words","system":false,"noteable_type":"MergeRequest","noteable_iid":4,"author":{"username":"b"},"created_at":"2026-01-11T00:00:00Z","updated_at":"2026-01-11T00:00:00Z"}},
+            {"target_type":"Note","created_at":"2026-01-11T00:01:00Z","note":{"id":32,"body":"commit words","system":false,"noteable_type":"Commit","author":{"username":"c"},"created_at":"2026-01-11T00:00:00Z","updated_at":"2026-01-11T00:00:00Z"}},
             {"target_type":"Issue","target_iid":9}
         ]"#;
         let (base, handle) = spawn_script_stub(vec![StubResponse::ok(events)]);
@@ -940,10 +1147,12 @@ mod tests {
         assert_eq!(page.comments[0].item_kind, ItemKind::Issue);
         assert_eq!(page.comments[0].item_key, "4");
         assert_eq!(page.comments[0].comment_id, "note:30");
+        assert_eq!(page.comments[0].body, "issue words", "the embedded note body is current");
         assert_eq!(
             page.comments[0].updated_at.as_deref(),
-            Some("2026-01-12T00:00:00Z"),
-            "the embedded note carries its CURRENT state, edits included"
+            Some("2026-01-10T00:00:30Z"),
+            "the frontier stamp is the EVENT's created_at — an edited old note must not inflate \
+             the first-page frontier past the feed's ordering key"
         );
         assert_eq!(page.comments[1].item_kind, ItemKind::ChangeRequest);
         assert_eq!(page.comments[1].item_key, "4");

--- a/crates/rag-rat-core/src/index/papertrail/gitlab.rs
+++ b/crates/rag-rat-core/src/index/papertrail/gitlab.rs
@@ -513,11 +513,25 @@ impl PapertrailClient for GitLabClient {
             }
             ensure_success(response.status, &response.body)?;
             let value: Value = serde_json::from_str(&response.body)?;
-            let leg_latest = value
-                .as_array()
-                .and_then(|items| items.first())
-                .and_then(|item| item["updated_at"].as_str())
-                .map(str::to_string);
+            // Malformed 2xx payloads must FAIL, not read as quiet: `not_modified` derives from
+            // `latest`, so a silently-None probe would skip the delta scan indefinitely.
+            let items = value.as_array().ok_or_else(|| {
+                anyhow::anyhow!("GitLab {} probe response is not an array", leg.path_segment())
+            })?;
+            let leg_latest = match items.first() {
+                None => None,
+                Some(item) => Some(
+                    item["updated_at"]
+                        .as_str()
+                        .ok_or_else(|| {
+                            anyhow::anyhow!(
+                                "GitLab {} probe item has no valid updated_at",
+                                leg.path_segment()
+                            )
+                        })?
+                        .to_string(),
+                ),
+            };
             latest = max_timestamp(latest.take(), leg_latest);
         }
         if unavailable == 2 {
@@ -1247,6 +1261,26 @@ mod tests {
         let heads = handle.join().unwrap();
         assert!(heads[0].contains("per_page=1"), "{}", heads[0]);
         assert!(heads[0].contains("sort=desc"), "{}", heads[0]);
+    }
+
+    /// A malformed 2xx probe payload must surface as an error: `not_modified` derives from
+    /// `latest`, so silence here would skip the delta scan on every poll indefinitely.
+    #[test]
+    fn a_malformed_probe_payload_fails_instead_of_reading_as_quiet() {
+        let (base, _handle) = spawn_script_stub(vec![StubResponse::ok("{}")]);
+        let registry = GovernorRegistry::default();
+        let client = client(base, &registry);
+        let error =
+            block_on(client.freshness_probe("g/s/r", &FreshnessProbe::default())).unwrap_err();
+        assert!(error.to_string().contains("probe response is not an array"), "{error:#}");
+
+        let (base, _handle) =
+            spawn_script_stub(vec![StubResponse::ok(r#"[{"iid":1,"state":"opened"}]"#)]);
+        let registry = GovernorRegistry::default();
+        let stampless = self::tests::client(base, &registry);
+        let error =
+            block_on(stampless.freshness_probe("g/s/r", &FreshnessProbe::default())).unwrap_err();
+        assert!(error.to_string().contains("no valid updated_at"), "{error:#}");
     }
 
     #[test]

--- a/crates/rag-rat-core/src/index/papertrail/gitlab.rs
+++ b/crates/rag-rat-core/src/index/papertrail/gitlab.rs
@@ -23,22 +23,28 @@ use super::*;
 const LIST_BACKFILL_STREAM: &str = "list_backfill";
 const LIST_DELTA_STREAM: &str = "list_delta";
 
-/// Continuation across the two chained list legs of one items request. Persisted opaquely inside
+/// Continuation across the two PARALLEL list legs of one items stream. Persisted opaquely inside
 /// [`PageCursor::provider_state`]; the mirror never interprets it.
+///
+/// Both legs advance together — every page fetch pulls one page from EACH still-pending leg and
+/// emits the merged items — so the mirror's first-page frontier (`max updated_at` of the scan's
+/// first page) covers BOTH iid namespaces. Chaining the legs sequentially instead would leave
+/// the merge-request maximum out of the persisted high watermark and replay the same merge
+/// requests on every delta scan.
 #[derive(Debug, Default, Serialize, Deserialize)]
 struct ListContinuation {
-    #[serde(default)]
-    leg: ListLeg,
+    /// Next-page URL per leg; `None` = drained. (A continuation only exists after the first
+    /// fetch, so `None` never means "not started".)
+    issues_next: Option<String>,
+    merge_requests_next: Option<String>,
     /// Oldest `updated_at` consumed across BOTH legs of this backfill cycle — the provider-
     /// confirmed strict boundary reported when the cycle completes. Descending below the global
     /// minimum (not the last page's) keeps the next cycle from re-walking the older leg's tail.
     oldest: Option<String>,
 }
 
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ListLeg {
-    #[default]
     Issues,
     MergeRequests,
 }
@@ -161,24 +167,22 @@ impl GitLabClient {
         Ok(url.into())
     }
 
-    /// The follow-up cursor entering `leg` of the same logical request, first page.
-    fn leg_entry_cursor(
+    /// One page from one leg: the mapped items plus the leg's next-page URL, if any.
+    async fn leg_page(
         &self,
         project: &str,
+        url: &str,
         leg: ListLeg,
-        cursor: &PageCursor,
-        state: &ListContinuation,
-    ) -> anyhow::Result<PageCursor> {
-        Ok(PageCursor {
-            stream: cursor.stream.clone(),
-            updated_since: cursor.updated_since.clone(),
-            updated_before: cursor.updated_before.clone(),
-            page_token: Some(self.list_url(project, leg, cursor)?),
-            provider_state: Some(serde_json::to_string(&ListContinuation {
-                leg,
-                oldest: state.oldest.clone(),
-            })?),
-        })
+    ) -> anyhow::Result<(Vec<PapertrailItem>, Option<String>)> {
+        let (value, next_url) = self.get_json(url).await?;
+        let values = value.as_array().ok_or_else(|| {
+            anyhow::anyhow!("GitLab {} response is not an array", leg.path_segment())
+        })?;
+        let mut items = Vec::with_capacity(values.len());
+        for value in values {
+            items.push(item_from_gitlab_value(project, leg.item_kind(), value)?);
+        }
+        Ok((items, next_url))
     }
 }
 
@@ -280,23 +284,36 @@ impl PapertrailClient for GitLabClient {
             anyhow::bail!("an item page cannot be both delta and backfill");
         }
         let backfill = cursor.updated_before.is_some();
+        // Resume from the persisted continuation, or open BOTH legs' first pages.
         let mut state = match cursor.provider_state.as_deref() {
             Some(state) => serde_json::from_str::<ListContinuation>(state)?,
-            None => ListContinuation::default(),
+            None => ListContinuation {
+                issues_next: Some(self.list_url(project, ListLeg::Issues, cursor)?),
+                merge_requests_next: Some(self.list_url(
+                    project,
+                    ListLeg::MergeRequests,
+                    cursor,
+                )?),
+                oldest: None,
+            },
         };
-        let url = match cursor.page_token.clone() {
-            Some(next) => next,
-            None => self.list_url(project, state.leg, cursor)?,
-        };
-        let (value, next_url) = self.get_json(&url).await?;
-        let values = value.as_array().ok_or_else(|| {
-            anyhow::anyhow!("GitLab {} response is not an array", state.leg.path_segment())
-        })?;
-        let kind = state.leg.item_kind();
-        let mut items = Vec::with_capacity(values.len());
-        for value in values {
-            items.push(item_from_gitlab_value(project, kind, value)?);
+        let mut items = Vec::new();
+        if let Some(url) = state.issues_next.take() {
+            let (page, next) = self.leg_page(project, &url, ListLeg::Issues).await?;
+            items.extend(page);
+            state.issues_next = next;
         }
+        if let Some(url) = state.merge_requests_next.take() {
+            let (page, next) = self.leg_page(project, &url, ListLeg::MergeRequests).await?;
+            items.extend(page);
+            state.merge_requests_next = next;
+        }
+        // Keep the emitted page ordered like its legs (mirror correctness is order-agnostic;
+        // ordering keeps pages legible in logs and tests).
+        items.sort_by(|left, right| {
+            let ordering = left.updated_at.cmp(&right.updated_at);
+            if backfill { ordering.reverse() } else { ordering }
+        });
         if backfill
             && let Some(oldest) = items.iter().filter_map(|item| item.updated_at.clone()).min()
         {
@@ -306,25 +323,19 @@ impl PapertrailClient for GitLabClient {
             };
         }
         let stream = if backfill { LIST_BACKFILL_STREAM } else { LIST_DELTA_STREAM };
-        let next = if let Some(page_token) = next_url {
-            // More pages in the current leg.
-            Some(PageCursor {
+        let pending = [state.issues_next.as_deref(), state.merge_requests_next.as_deref()];
+        let next = match pending.iter().flatten().next() {
+            Some(token) => Some(PageCursor {
                 stream: Some(stream.to_string()),
                 updated_since: cursor.updated_since.clone(),
                 updated_before: cursor.updated_before.clone(),
-                page_token: Some(page_token),
+                // A non-empty token marks every continuation page as NOT the scan's first page
+                // (the mirror's conservative-frontier logic keys off that); the authoritative
+                // state is the full per-leg continuation.
+                page_token: Some((*token).to_string()),
                 provider_state: Some(serde_json::to_string(&state)?),
-            })
-        } else if state.leg == ListLeg::Issues {
-            // Issues leg drained below the cutoff — chain into the merge-request leg of the SAME
-            // logical request. The consumed issues continuation dies here (a chained leg must
-            // never outlive its consumption).
-            let mut entry =
-                self.leg_entry_cursor(project, ListLeg::MergeRequests, cursor, &state)?;
-            entry.stream = Some(stream.to_string());
-            Some(entry)
-        } else {
-            None
+            }),
+            None => None,
         };
         // The cycle's provider-confirmed strict boundary: both legs drained fully below the
         // cutoff, so the global oldest consumed timestamp bounds everything this cycle stored.
@@ -419,11 +430,12 @@ impl PapertrailClient for GitLabClient {
                 (current, new) => current.or(new),
             };
         }
-        Ok(FreshnessResult {
-            latest: probe_advance(latest, probe.updated_since.as_deref()),
-            etag: probe.etag.clone(),
-            not_modified: false,
-        })
+        // GitLab has no probe validator (no shared ETag across the two namespace calls), so the
+        // timestamp comparison IS the quiet signal: the mirror keys the delta-scan decision off
+        // `not_modified`, and reporting quiet here is what keeps an idle project's poll at two
+        // 1-item requests instead of two full delta legs.
+        let latest = probe_advance(latest, probe.updated_since.as_deref());
+        Ok(FreshnessResult { not_modified: latest.is_none(), latest, etag: probe.etag.clone() })
     }
 }
 
@@ -705,7 +717,7 @@ mod tests {
     }
 
     #[test]
-    fn backfill_chains_issue_and_merge_request_legs_and_reports_the_global_boundary() {
+    fn backfill_fetches_both_legs_in_parallel_and_reports_the_global_boundary() {
         let issues_page_one = format!(
             "[{},{}]",
             issue(20, "2026-01-10T00:00:00Z"),
@@ -718,8 +730,8 @@ mod tests {
                 StubResponse::ok(&issues_page_one),
                 "/api/v4/projects/g%2Fs%2Fr/issues?page=2",
             ),
-            StubResponse::ok(&issues_page_two),
             StubResponse::ok(&change_page),
+            StubResponse::ok(&issues_page_two),
         ]);
         let registry = GovernorRegistry::default();
         let client = client(base, &registry);
@@ -729,46 +741,46 @@ mod tests {
             ..PageCursor::default()
         };
         let first = block_on(client.items_page("g/s/r", &cursor)).unwrap();
-        assert_eq!(first.items.len(), 2);
-        assert!(first.items.iter().all(|item| item.item_kind == ItemKind::Issue));
+        // BOTH legs' first pages arrive in the scan's first page, merged newest-first, so the
+        // mirror's initial high mark covers both iid namespaces.
+        assert_eq!(
+            first
+                .items
+                .iter()
+                .map(|item| (item.item_kind, item.item_key.as_str()))
+                .collect::<Vec<_>>(),
+            vec![(ItemKind::Issue, "20"), (ItemKind::ChangeRequest, "7"), (ItemKind::Issue, "19"),]
+        );
         assert_eq!(first.backfill_boundary, None, "mid-cycle pages report no boundary");
-        cursor = first.next.expect("issues page two pending");
-        assert!(cursor.page_token.as_deref().unwrap().contains("/issues?page=2"));
+        cursor = first.next.expect("the issues leg still has a page");
+        assert!(cursor.page_token.is_some(), "continuations must not look like first pages");
 
         let second = block_on(client.items_page("g/s/r", &cursor)).unwrap();
         assert_eq!(second.items.len(), 1);
-        assert_eq!(second.backfill_boundary, None, "the merge-request leg has not run yet");
-        cursor = second.next.expect("the merge-request leg must chain");
-        let entry = cursor.page_token.as_deref().unwrap();
-        assert!(entry.contains("/merge_requests?"), "{entry}");
-        assert!(
-            entry.contains("sort=desc") && entry.contains("updated_before=2026-02-01"),
-            "{entry}"
-        );
-
-        let third = block_on(client.items_page("g/s/r", &cursor)).unwrap();
-        assert_eq!(third.items.len(), 1);
-        assert_eq!(third.items[0].item_kind, ItemKind::ChangeRequest);
-        assert!(third.next.is_none(), "both legs drained");
+        assert_eq!(second.items[0].item_key, "18");
+        assert!(second.next.is_none(), "both legs drained");
         assert_eq!(
-            third.backfill_boundary.as_deref(),
+            second.backfill_boundary.as_deref(),
             Some("2026-01-03T00:00:00Z"),
             "the boundary is the GLOBAL oldest across both legs, not the last page's"
         );
 
         let heads = handle.join().unwrap();
+        assert_eq!(heads.len(), 3);
         assert!(
             heads[0].contains("/issues?order_by=updated_at&per_page=100&sort=desc"),
             "{}",
             heads[0]
         );
         assert!(heads[0].contains("updated_before=2026-02-01"), "{}", heads[0]);
-        assert!(heads[2].contains("/merge_requests?"), "{}", heads[2]);
+        assert!(heads[1].contains("/merge_requests?"), "{}", heads[1]);
+        assert!(heads[1].contains("updated_before=2026-02-01"), "{}", heads[1]);
+        assert!(heads[2].contains("/issues?page=2"), "{}", heads[2]);
     }
 
     #[test]
     fn an_empty_project_backfill_terminates_with_the_done_shape() {
-        let (base, _handle) =
+        let (base, handle) =
             spawn_script_stub(vec![StubResponse::ok("[]"), StubResponse::ok("[]")]);
         let registry = GovernorRegistry::default();
         let client = client(base, &registry);
@@ -777,18 +789,18 @@ mod tests {
             updated_before: Some("2026-02-01T00:00:00Z".to_string()),
             ..PageCursor::default()
         };
-        let first = block_on(client.items_page("g/s/r", &cursor)).unwrap();
-        assert!(first.items.is_empty());
-        let chained = first.next.expect("the empty issues leg still chains to merge requests");
-
-        let second = block_on(client.items_page("g/s/r", &chained)).unwrap();
-        assert!(second.items.is_empty());
-        assert!(second.next.is_none());
-        assert!(second.backfill_boundary.is_none(), "nothing consumed = the mirror's done shape");
+        let page = block_on(client.items_page("g/s/r", &cursor)).unwrap();
+        assert!(page.items.is_empty());
+        assert!(page.next.is_none());
+        assert!(page.backfill_boundary.is_none(), "nothing consumed = the mirror's done shape");
+        assert_eq!(handle.join().unwrap().len(), 2, "one page per leg, no extra cycles");
     }
 
+    /// The high-watermark half of the parallel-leg contract: the delta scan's FIRST page must
+    /// contain both namespaces, or the persisted frontier misses whichever namespace is newer
+    /// and replays it on every scan.
     #[test]
-    fn delta_ascends_with_updated_after_and_chains_both_legs() {
+    fn delta_merges_both_namespaces_into_the_scan_first_page() {
         let issues = format!("[{}]", issue(21, "2026-01-11T00:00:00Z"));
         let changes = format!("[{}]", merge_request(8, "2026-01-12T00:00:00Z"));
         let (base, handle) =
@@ -800,15 +812,19 @@ mod tests {
             updated_since: Some("2026-01-09T00:00:00Z".to_string()),
             ..PageCursor::default()
         };
-        let first = block_on(client.items_page("g/s/r", &cursor)).unwrap();
-        assert_eq!(first.items[0].item_kind, ItemKind::Issue);
-        let chained = first.next.expect("delta chains into merge requests too");
-        assert_eq!(chained.updated_since.as_deref(), Some("2026-01-09T00:00:00Z"));
-
-        let second = block_on(client.items_page("g/s/r", &chained)).unwrap();
-        assert_eq!(second.items[0].item_kind, ItemKind::ChangeRequest);
-        assert!(second.next.is_none());
-        assert!(second.backfill_boundary.is_none(), "delta never reports a backfill boundary");
+        let page = block_on(client.items_page("g/s/r", &cursor)).unwrap();
+        assert_eq!(
+            page.items.iter().map(|item| item.item_kind).collect::<Vec<_>>(),
+            vec![ItemKind::Issue, ItemKind::ChangeRequest],
+            "ascending merge, both namespaces present"
+        );
+        assert_eq!(
+            page.items.iter().filter_map(|item| item.updated_at.as_deref()).max(),
+            Some("2026-01-12T00:00:00Z"),
+            "the first-page maximum covers the newer namespace"
+        );
+        assert!(page.next.is_none());
+        assert!(page.backfill_boundary.is_none(), "delta never reports a backfill boundary");
 
         let heads = handle.join().unwrap();
         for head in &heads {
@@ -842,6 +858,11 @@ mod tests {
         }))
         .unwrap();
         assert_eq!(quiet.latest, None, "at-or-before the cursor must stay quiet");
+        assert!(
+            quiet.not_modified,
+            "quiet must be reported in the flag the mirror keys the delta decision off, or an \
+             idle project pays two full delta legs every poll"
+        );
 
         let heads = handle.join().unwrap();
         assert!(heads[0].contains("per_page=1"), "{}", heads[0]);
@@ -882,16 +903,14 @@ mod tests {
 
     #[test]
     fn cross_origin_pagination_is_rejected_before_following_it() {
-        let (base, handle) = spawn_script_stub(vec![with_next_link(
-            StubResponse::ok(&format!("[{}]", issue(1, "2026-01-05T00:00:00Z"))),
-            "",
-        )]);
-        // Rewrite the next link to a foreign origin AFTER stub substitution.
+        let (base, handle) = spawn_script_stub(Vec::new());
         let registry = GovernorRegistry::default();
         let client = client(base, &registry);
+        let foreign = "https://gitlab.com/api/v4/projects/g%2Fs%2Fr/issues?page=2";
         let cursor = PageCursor {
             updated_before: Some("2026-02-01T00:00:00Z".to_string()),
-            page_token: Some("https://gitlab.com/api/v4/projects/g%2Fs%2Fr/issues".to_string()),
+            page_token: Some(foreign.to_string()),
+            provider_state: Some(format!(r#"{{"issues_next":"{foreign}"}}"#)),
             ..PageCursor::default()
         };
         let error = block_on(client.items_page("g/s/r", &cursor)).unwrap_err();

--- a/crates/rag-rat-core/src/index/papertrail/http.rs
+++ b/crates/rag-rat-core/src/index/papertrail/http.rs
@@ -2,7 +2,66 @@
 //! status-to-outcome mapping, and payload identity validation. Providers own their endpoints
 //! and payload mapping; the mechanics of "talk JSON to a paginated forge API" live here once.
 
+use reqwest::Url;
+
 use super::PapertrailClientError;
+use super::transport::is_loopback_host;
+
+/// Parse and validate a provider API origin: the provider's cloud default, or a self-hosted
+/// `base_url` that must be a bare http(s) origin — credentials-free, path/query/fragment-free,
+/// and plaintext ONLY to loopback. The transport enforces the loopback rule per request;
+/// accepting a non-loopback `http` origin here would mint a "native" binding whose every sync
+/// fails at the first request. Returns the trimmed API origin and the governor authority key.
+pub(crate) fn resolve_api_origin(
+    provider: &str,
+    base_url: Option<&str>,
+    default_origin: &str,
+    api_path: &str,
+) -> anyhow::Result<(String, String)> {
+    let parsed = match base_url {
+        None => Url::parse(default_origin)?,
+        Some(base) => {
+            let mut base = Url::parse(base)?;
+            anyhow::ensure!(
+                matches!(base.scheme(), "http" | "https"),
+                "{provider} base URL must use http(s)"
+            );
+            anyhow::ensure!(
+                base.username().is_empty() && base.password().is_none(),
+                "{provider} base URL must not contain credentials"
+            );
+            anyhow::ensure!(
+                matches!(base.path(), "" | "/")
+                    && base.query().is_none()
+                    && base.fragment().is_none(),
+                "{provider} base URL must be an origin without a path, query, or fragment"
+            );
+            // `Url::host_str` keeps IPv6 brackets (`[::1]`); the transport's predicate
+            // matches the bare host form.
+            anyhow::ensure!(
+                base.scheme() == "https"
+                    || base
+                        .host_str()
+                        .is_some_and(|host| is_loopback_host(host.trim_matches(['[', ']']))),
+                "{provider} base URL must use https (http is loopback-only)"
+            );
+            base.set_path(api_path);
+            base
+        },
+    };
+    let host =
+        parsed.host_str().ok_or_else(|| anyhow::anyhow!("{provider} API origin has no host"))?;
+    let authority_host = if host.contains(':') && !host.starts_with('[') {
+        format!("[{host}]")
+    } else {
+        host.to_string()
+    };
+    let authority = parsed
+        .port()
+        .map_or_else(|| authority_host.clone(), |port| format!("{authority_host}:{port}"));
+    let api_origin = parsed.as_str().trim_end_matches('/').to_string();
+    Ok((api_origin, authority))
+}
 
 /// Reject a non-2xx provider response, mapping 404 to the typed not-found outcome the mirror
 /// understands. `provider` labels the error ("GitHub", "GitLab").

--- a/crates/rag-rat-core/src/index/papertrail/http.rs
+++ b/crates/rag-rat-core/src/index/papertrail/http.rs
@@ -1,0 +1,43 @@
+//! Provider HTTP plumbing shared across the native clients: RFC-8288 pagination decoding,
+//! status-to-outcome mapping, and payload identity validation. Providers own their endpoints
+//! and payload mapping; the mechanics of "talk JSON to a paginated forge API" live here once.
+
+use super::PapertrailClientError;
+
+/// Reject a non-2xx provider response, mapping 404 to the typed not-found outcome the mirror
+/// understands. `provider` labels the error ("GitHub", "GitLab").
+pub(crate) fn ensure_provider_success(
+    provider: &str,
+    status: u16,
+    body: &str,
+) -> anyhow::Result<()> {
+    if status == 404 {
+        return Err(PapertrailClientError::ItemNotFound.into());
+    }
+    anyhow::ensure!((200..300).contains(&status), "{provider} HTTP {status}: {body}");
+    Ok(())
+}
+
+/// The `rel="next"` target from an RFC-8288 `Link` header — the pagination continuation both
+/// GitHub and GitLab emit.
+pub(crate) fn next_link(headers: &reqwest::header::HeaderMap) -> anyhow::Result<Option<String>> {
+    let Some(link) = headers.get(reqwest::header::LINK) else { return Ok(None) };
+    let link = link.to_str()?;
+    Ok(link.split(',').find_map(|part| {
+        let (url, rel) = part.trim().split_once(';')?;
+        rel.trim().eq(r#"rel="next""#).then(|| url.trim().trim_matches(['<', '>']).to_string())
+    }))
+}
+
+/// Provider payload rows must carry a positive numeric identity before they are trusted.
+pub(crate) fn validate_positive_id(
+    value: &serde_json::Value,
+    field: &str,
+    resource: &str,
+) -> anyhow::Result<()> {
+    anyhow::ensure!(
+        value[field].as_u64().is_some_and(|id| id > 0),
+        "{resource} has no valid {field}"
+    );
+    Ok(())
+}

--- a/crates/rag-rat-core/src/index/papertrail/mirror.rs
+++ b/crates/rag-rat-core/src/index/papertrail/mirror.rs
@@ -1072,11 +1072,23 @@ fn store_repo_comments(
     let repo_id = crate::index::schema::active_repo_id(conn)?;
     let tx = conn.unchecked_transaction()?;
     for comment in comments {
+        // Resolve the parent item, PREFERRING the kind the provider put on the comment: under
+        // namespaced numbering (GitLab) issue #N and change request !N coexist on one key, and
+        // a key-only lookup would hitch the comment to whichever twin the scan returns first —
+        // then rewrite the correctly-kinded row through the kind-less comment conflict key. The
+        // fallback to the other kind serves providers whose feed cannot name the kind (GitHub's
+        // issue-comment stream spans issues and pull requests), where the key alone IS unique.
         let kind = tx
             .query_row(
                 "SELECT item_kind FROM papertrail_items WHERE repo_id=?1 AND tracker=?2 AND \
-                 project=?3 AND item_key=?4 LIMIT 1",
-                params![repo_id, binding.provider.as_db_str(), binding.project, comment.item_key],
+                 project=?3 AND item_key=?4 ORDER BY (item_kind = ?5) DESC LIMIT 1",
+                params![
+                    repo_id,
+                    binding.provider.as_db_str(),
+                    binding.project,
+                    comment.item_key,
+                    comment.item_kind.as_db_str()
+                ],
                 |row| row.get::<_, String>(0),
             )
             .optional()?;
@@ -1401,6 +1413,99 @@ mod tests {
         let mut stmt =
             conn.prepare("SELECT item_key FROM papertrail_items ORDER BY item_key").unwrap();
         stmt.query_map([], |row| row.get(0)).unwrap().map(Result::unwrap).collect()
+    }
+
+    /// Namespaced numbering (GitLab): issue #N and change request !N share a key. The repo
+    /// comment lane must resolve the parent by the comment's OWN kind first — a key-only lookup
+    /// hitches the comment to whichever twin the scan returns first and then rewrites the
+    /// correctly-kinded row through the kind-less comment conflict key.
+    #[test]
+    fn repo_comments_resolve_namespaced_twins_by_their_own_kind() {
+        let conn = db();
+        let mut binding = binding(&[]);
+        binding.provider = Tracker::Gitlab;
+        binding.project = "g/r".to_string();
+        let mut issue = item("1", "2026-01-02T00:00:00Z", "issue one", &[]);
+        issue.project = "g/r".to_string();
+        let mut change = item("1", "2026-01-03T00:00:00Z", "mr one", &[]);
+        change.project = "g/r".to_string();
+        change.item_kind = ItemKind::ChangeRequest;
+        store_item(&conn, binding.provider, &issue).unwrap();
+        store_item(&conn, binding.provider, &change).unwrap();
+
+        let mut report = MirrorBindingReport {
+            tracker: binding.provider,
+            project: binding.project.clone(),
+            stored_items: 0,
+            stored_comments: 0,
+            pruned_items: 0,
+            paused_until_ms: None,
+            pause_reason: None,
+            completed_full_walk: false,
+            probe_not_modified: false,
+        };
+        let mut issue_note = comment("1", "note:1", "2026-01-04T00:00:00Z");
+        issue_note.project = "g/r".to_string();
+        let mut change_note = comment("1", "note:2", "2026-01-04T00:00:00Z");
+        change_note.project = "g/r".to_string();
+        change_note.item_kind = ItemKind::ChangeRequest;
+        store_repo_comments(&conn, &binding, &[issue_note, change_note], &mut report).unwrap();
+
+        let kinds: Vec<(String, String)> = {
+            let mut stmt = conn
+                .prepare(
+                    "SELECT comment_id, item_kind FROM papertrail_comments ORDER BY comment_id",
+                )
+                .unwrap();
+            stmt.query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+                .unwrap()
+                .map(Result::unwrap)
+                .collect()
+        };
+        assert_eq!(kinds, vec![
+            ("note:1".to_string(), "issue".to_string()),
+            ("note:2".to_string(), "change_request".to_string()),
+        ]);
+    }
+
+    /// The fallback half of the twin resolution: a provider whose feed cannot name the kind
+    /// (GitHub's issue-comment stream spans issues and pull requests) still resolves through the
+    /// key alone when no item of the claimed kind exists.
+    #[test]
+    fn repo_comments_fall_back_to_the_key_when_the_claimed_kind_has_no_item() {
+        let conn = db();
+        let binding = binding(&[]);
+        let mut pull = item("7", "2026-01-02T00:00:00Z", "pull seven", &[]);
+        pull.item_kind = ItemKind::ChangeRequest;
+        store_item(&conn, binding.provider, &pull).unwrap();
+
+        let mut report = MirrorBindingReport {
+            tracker: binding.provider,
+            project: binding.project.clone(),
+            stored_items: 0,
+            stored_comments: 0,
+            pruned_items: 0,
+            paused_until_ms: None,
+            pause_reason: None,
+            completed_full_walk: false,
+            probe_not_modified: false,
+        };
+        // The GitHub feed guesses Issue; only the pull exists.
+        store_repo_comments(
+            &conn,
+            &binding,
+            &[comment("7", "c1", "2026-01-04T00:00:00Z")],
+            &mut report,
+        )
+        .unwrap();
+        let kind: String = conn
+            .query_row(
+                "SELECT item_kind FROM papertrail_comments WHERE comment_id='c1'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(kind, "change_request");
     }
 
     #[test]

--- a/crates/rag-rat-core/src/index/papertrail/mirror.rs
+++ b/crates/rag-rat-core/src/index/papertrail/mirror.rs
@@ -428,10 +428,7 @@ async fn sync_comment_delta<C: PapertrailClient>(
         loop {
             let page = client.comments_page(&binding.project, &request).await?;
             let first_page_high = request.page_token.is_none().then(|| {
-                max_timestamp(
-                    page.comments.iter().filter_map(|comment| comment.updated_at.clone()).max(),
-                    page.frontier.clone(),
-                )
+                page.comments.iter().filter_map(|comment| comment.updated_at.clone()).max()
             });
             let next = if let Some(mut next) = page.next {
                 anyhow::ensure!(
@@ -452,6 +449,14 @@ async fn sync_comment_delta<C: PapertrailClient>(
                 // ascending page. Replaying its inclusive upper boundary prevents offset shifts
                 // from stranding an unseen or stale comment below the durable watermark.
                 state.scan_high_mark_at = first_page_high;
+            }
+            // The provider-confirmed frontier is trusted on EVERY page — providers only set it
+            // for immutable append-only feeds (see CommentsPage::frontier). Folding each page's
+            // frontier carries a drained multi-page window past its LAST page, where the
+            // first-page comment maximum alone would pin a busy window forever.
+            if page.frontier.is_some() {
+                state.scan_high_mark_at =
+                    max_timestamp(state.scan_high_mark_at.take(), page.frontier.clone());
             }
             state.page_token = next.as_ref().and_then(|next| next.page_token.clone());
             state.scan_since = next.as_ref().map(|_| scan_since.clone());
@@ -1079,6 +1084,7 @@ fn store_repo_comments(
     report: &mut MirrorBindingReport,
 ) -> anyhow::Result<()> {
     let repo_id = crate::index::schema::active_repo_id(conn)?;
+    let fallback = item_numbering_is_shared(binding.provider);
     let tx = conn.unchecked_transaction()?;
     for comment in comments {
         // Resolve the parent item, PREFERRING the kind the provider put on the comment: under
@@ -1090,12 +1096,13 @@ fn store_repo_comments(
         // IS unique. A namespaced provider names the kind authoritatively, so a missing
         // exact-kind parent (e.g. a merge request pruned by the tag filter while issue #N is
         // cached) means SKIP, never contaminate the twin namespace's evidence.
-        let fallback = if shared_item_numbering(binding.provider) { "1" } else { "0" };
         let kind = tx
-            .query_row(
+            .prepare_cached(
                 "SELECT item_kind FROM papertrail_items WHERE repo_id=?1 AND tracker=?2 AND \
                  project=?3 AND item_key=?4 AND (item_kind = ?5 OR ?6) ORDER BY (item_kind = ?5) \
                  DESC LIMIT 1",
+            )?
+            .query_row(
                 params![
                     repo_id,
                     binding.provider.as_db_str(),
@@ -1108,9 +1115,13 @@ fn store_repo_comments(
             )
             .optional()?;
         let Some(kind) = kind else { continue };
-        let mut comment = comment.clone();
-        comment.item_kind = ItemKind::from_db_str(&kind)?;
-        store_comment(&tx, binding.provider, &comment)?;
+        if kind == comment.item_kind.as_db_str() {
+            store_comment(&tx, binding.provider, comment)?;
+        } else {
+            let mut comment = comment.clone();
+            comment.item_kind = ItemKind::from_db_str(&kind)?;
+            store_comment(&tx, binding.provider, &comment)?;
+        }
         report.stored_comments += 1;
     }
     tx.commit()?;
@@ -1125,7 +1136,7 @@ fn max_item_updated_at(items: &[PapertrailItem]) -> Option<String> {
     items.iter().filter_map(|item| item.updated_at.clone()).max()
 }
 
-fn max_timestamp(left: Option<String>, right: Option<String>) -> Option<String> {
+pub(crate) fn max_timestamp(left: Option<String>, right: Option<String>) -> Option<String> {
     left.into_iter().chain(right).max()
 }
 
@@ -1175,7 +1186,7 @@ fn overlap_timestamp(timestamp: &str) -> String {
     format!("{year:04}-{month:02}-{day:02}T{hour:02}:{minute:02}:{second:02}Z")
 }
 
-fn parse_date(value: &str) -> Option<(i32, u32, u32)> {
+pub(crate) fn parse_date(value: &str) -> Option<(i32, u32, u32)> {
     let mut parts = value.split('-');
     let parsed =
         (parts.next()?.parse().ok()?, parts.next()?.parse().ok()?, parts.next()?.parse().ok()?);
@@ -1184,12 +1195,20 @@ fn parse_date(value: &str) -> Option<(i32, u32, u32)> {
 
 fn parse_time(value: &str) -> Option<(u32, u32, u32)> {
     let mut parts = value.split(':');
-    let parsed =
-        (parts.next()?.parse().ok()?, parts.next()?.parse().ok()?, parts.next()?.parse().ok()?);
+    // Fractional seconds (GitLab emits millisecond stamps) truncate: the rewound overlap
+    // timestamp compares lexicographically BELOW any fractional variant of the same second, so
+    // truncation only widens the replay window. Refusing to parse them instead silently
+    // returned the input unchanged — a ZERO overlap — and with a strict updated_after filter
+    // the boundary row became unreachable, so the replay convergence check could never pass.
+    let parsed = (
+        parts.next()?.parse().ok()?,
+        parts.next()?.parse().ok()?,
+        parts.next()?.split('.').next()?.parse().ok()?,
+    );
     parts.next().is_none().then_some(parsed)
 }
 
-fn days_in_month(year: i32, month: u32) -> u32 {
+pub(crate) fn days_in_month(year: i32, month: u32) -> u32 {
     match month {
         4 | 6 | 9 | 11 => 30,
         2 if year % 4 == 0 && (year % 100 != 0 || year % 400 == 0) => 29,
@@ -1424,6 +1443,20 @@ mod tests {
         }
     }
 
+    fn empty_report(binding: &ResolvedTracker) -> MirrorBindingReport {
+        MirrorBindingReport {
+            tracker: binding.provider,
+            project: binding.project.clone(),
+            stored_items: 0,
+            stored_comments: 0,
+            pruned_items: 0,
+            paused_until_ms: None,
+            pause_reason: None,
+            completed_full_walk: false,
+            probe_not_modified: false,
+        }
+    }
+
     fn db() -> Connection {
         let conn = Connection::open_in_memory().unwrap();
         schema::apply(&conn).unwrap();
@@ -1440,6 +1473,18 @@ mod tests {
     /// comment lane must resolve the parent by the comment's OWN kind first — a key-only lookup
     /// hitches the comment to whichever twin the scan returns first and then rewrites the
     /// correctly-kinded row through the kind-less comment conflict key.
+    /// GitLab emits millisecond timestamps; the overlap rewind must handle the fraction —
+    /// refusing to parse it silently returned the input unchanged (ZERO overlap), and with a
+    /// strict updated_after filter the boundary row became unreachable, so replay convergence
+    /// could never complete.
+    #[test]
+    fn overlap_timestamp_rewinds_fractional_second_stamps() {
+        assert_eq!(overlap_timestamp("2026-07-15T13:15:56.837Z"), "2026-07-15T13:15:55Z");
+        assert_eq!(overlap_timestamp("2026-01-01T00:00:00.001Z"), "2025-12-31T23:59:59Z");
+        // Non-fractional stamps keep their existing behavior.
+        assert_eq!(overlap_timestamp("2026-07-15T13:15:56Z"), "2026-07-15T13:15:55Z");
+    }
+
     /// A quiet probe must not starve an OWED boundary replay: providers without a probe
     /// validator (GitLab) report a timestamp tie as not_modified, and the conservative frontier
     /// left by an interrupted delta would otherwise wait for the daily full walk.
@@ -1511,6 +1556,51 @@ mod tests {
         );
     }
 
+    /// A drained multi-page comment window must advance past its LAST page's frontier: with a
+    /// date-granular provider filter (GitLab events `after`), a first-page-only frontier keeps
+    /// re-opening the same busy day and replays every later page on every poll, forever.
+    #[test]
+    fn a_drained_multi_page_window_advances_past_its_last_frontier() {
+        let conn = db();
+        let binding = binding(&[]);
+        let first_walk = ScriptClient::new(vec![
+            Ok(ItemsPage {
+                items: vec![item("1", "2026-01-02T00:00:00Z", "one", &[])],
+                next: None,
+                backfill_boundary: None,
+            }),
+            Ok(ItemsPage { items: Vec::new(), next: None, backfill_boundary: None }),
+        ])
+        .with_repo_comments(Vec::new());
+        block_on(mirror_binding(&conn, &binding, &first_walk, false)).unwrap();
+
+        let quiet = ScriptClient::new(vec![])
+            .with_probe(FreshnessResult { latest: None, etag: None, not_modified: true })
+            .with_repo_comment_pages(vec![
+                Ok(CommentsPage {
+                    comments: vec![comment("1", "early", "2026-02-01T08:00:00Z")],
+                    next: Some(PageCursor {
+                        page_token: Some("events-page-2".to_string()),
+                        ..PageCursor::default()
+                    }),
+                    frontier: Some("2026-02-01T08:00:00Z".to_string()),
+                }),
+                Ok(CommentsPage {
+                    comments: Vec::new(),
+                    next: None,
+                    frontier: Some("2026-02-01T20:00:00Z".to_string()),
+                }),
+            ]);
+        block_on(mirror_binding(&conn, &binding, &quiet, false)).unwrap();
+
+        let cursor = load_cursor(&conn, &binding).unwrap();
+        assert_eq!(
+            cursor.comment_stream_cursors.get("default").and_then(|s| s.high_mark_at.as_deref()),
+            Some("2026-02-01T20:00:00Z"),
+            "the stream must clear the drained window, not pin to the first page's maximum"
+        );
+    }
+
     /// Namespaced providers name the comment's kind authoritatively: a missing exact-kind
     /// parent (a merge request pruned by the tag filter while issue #N is cached) means SKIP —
     /// never attach the comment across namespaces.
@@ -1524,17 +1614,7 @@ mod tests {
         issue.project = "g/r".to_string();
         store_item(&conn, binding.provider, &issue).unwrap();
 
-        let mut report = MirrorBindingReport {
-            tracker: binding.provider,
-            project: binding.project.clone(),
-            stored_items: 0,
-            stored_comments: 0,
-            pruned_items: 0,
-            paused_until_ms: None,
-            pause_reason: None,
-            completed_full_walk: false,
-            probe_not_modified: false,
-        };
+        let mut report = empty_report(&binding);
         let mut change_note = comment("7", "note:9", "2026-01-04T00:00:00Z");
         change_note.project = "g/r".to_string();
         change_note.item_kind = ItemKind::ChangeRequest;
@@ -1575,17 +1655,7 @@ mod tests {
         store_item(&conn, binding.provider, &issue).unwrap();
         store_item(&conn, binding.provider, &change).unwrap();
 
-        let mut report = MirrorBindingReport {
-            tracker: binding.provider,
-            project: binding.project.clone(),
-            stored_items: 0,
-            stored_comments: 0,
-            pruned_items: 0,
-            paused_until_ms: None,
-            pause_reason: None,
-            completed_full_walk: false,
-            probe_not_modified: false,
-        };
+        let mut report = empty_report(&binding);
         let mut issue_note = comment("1", "note:1", "2026-01-04T00:00:00Z");
         issue_note.project = "g/r".to_string();
         let mut change_note = comment("1", "note:2", "2026-01-04T00:00:00Z");
@@ -1621,17 +1691,7 @@ mod tests {
         pull.item_kind = ItemKind::ChangeRequest;
         store_item(&conn, binding.provider, &pull).unwrap();
 
-        let mut report = MirrorBindingReport {
-            tracker: binding.provider,
-            project: binding.project.clone(),
-            stored_items: 0,
-            stored_comments: 0,
-            pruned_items: 0,
-            paused_until_ms: None,
-            pause_reason: None,
-            completed_full_walk: false,
-            probe_not_modified: false,
-        };
+        let mut report = empty_report(&binding);
         // The GitHub feed guesses Issue; only the pull exists.
         store_repo_comments(
             &conn,

--- a/crates/rag-rat-core/src/index/papertrail/mirror.rs
+++ b/crates/rag-rat-core/src/index/papertrail/mirror.rs
@@ -228,7 +228,13 @@ async fn mirror_binding_inner<C: PapertrailClient>(
                 })
                 .await?;
             cursor.probe_etag = probe.etag;
-            if !probe.not_modified {
+            // A quiet probe must not starve an OWED replay: when the prior delta left its
+            // conservative frontier below the probe target, the boundary replay has to run even
+            // if nothing new moved — some providers (GitLab) report a timestamp tie as
+            // not_modified, and the stranded boundary row would otherwise wait for the daily
+            // full walk. probe.latest is None on that path, which sync_item_delta already
+            // treats as "replay against the durable high mark".
+            if !probe.not_modified || cursor.item_delta_replay_required {
                 cursor.item_delta_in_progress = true;
                 cursor.item_delta_scan_since = Some(overlap_timestamp(high));
                 cursor.item_delta_high_mark_at = probe.latest;
@@ -422,7 +428,10 @@ async fn sync_comment_delta<C: PapertrailClient>(
         loop {
             let page = client.comments_page(&binding.project, &request).await?;
             let first_page_high = request.page_token.is_none().then(|| {
-                page.comments.iter().filter_map(|comment| comment.updated_at.clone()).max()
+                max_timestamp(
+                    page.comments.iter().filter_map(|comment| comment.updated_at.clone()).max(),
+                    page.frontier.clone(),
+                )
             });
             let next = if let Some(mut next) = page.next {
                 anyhow::ensure!(
@@ -1075,19 +1084,25 @@ fn store_repo_comments(
         // Resolve the parent item, PREFERRING the kind the provider put on the comment: under
         // namespaced numbering (GitLab) issue #N and change request !N coexist on one key, and
         // a key-only lookup would hitch the comment to whichever twin the scan returns first —
-        // then rewrite the correctly-kinded row through the kind-less comment conflict key. The
-        // fallback to the other kind serves providers whose feed cannot name the kind (GitHub's
-        // issue-comment stream spans issues and pull requests), where the key alone IS unique.
+        // then rewrite the correctly-kinded row through the kind-less comment conflict key.
+        // Falling back to the other kind is ONLY for providers whose feed cannot name the kind
+        // (GitHub's issue-comment stream spans issues and pull requests) — there the key alone
+        // IS unique. A namespaced provider names the kind authoritatively, so a missing
+        // exact-kind parent (e.g. a merge request pruned by the tag filter while issue #N is
+        // cached) means SKIP, never contaminate the twin namespace's evidence.
+        let fallback = if shared_item_numbering(binding.provider) { "1" } else { "0" };
         let kind = tx
             .query_row(
                 "SELECT item_kind FROM papertrail_items WHERE repo_id=?1 AND tracker=?2 AND \
-                 project=?3 AND item_key=?4 ORDER BY (item_kind = ?5) DESC LIMIT 1",
+                 project=?3 AND item_key=?4 AND (item_kind = ?5 OR ?6) ORDER BY (item_kind = ?5) \
+                 DESC LIMIT 1",
                 params![
                     repo_id,
                     binding.provider.as_db_str(),
                     binding.project,
                     comment.item_key,
-                    comment.item_kind.as_db_str()
+                    comment.item_kind.as_db_str(),
+                    fallback
                 ],
                 |row| row.get::<_, String>(0),
             )
@@ -1258,7 +1273,11 @@ mod tests {
         }
 
         fn with_repo_comments(self, comments: Vec<PapertrailComment>) -> Self {
-            self.repo_comments.borrow_mut().push_back(Ok(CommentsPage { comments, next: None }));
+            self.repo_comments.borrow_mut().push_back(Ok(CommentsPage {
+                comments,
+                next: None,
+                frontier: None,
+            }));
             self
         }
 
@@ -1307,6 +1326,7 @@ mod tests {
             Ok(CommentsPage {
                 comments: self.item_comments.borrow_mut().pop_front().unwrap_or(Ok(Vec::new()))?,
                 next: None,
+                frontier: None,
             })
         }
 
@@ -1325,10 +1345,11 @@ mod tests {
             cursor: &PageCursor,
         ) -> anyhow::Result<CommentsPage> {
             self.repo_comment_requests.borrow_mut().push(cursor.clone());
-            self.repo_comments
-                .borrow_mut()
-                .pop_front()
-                .unwrap_or(Ok(CommentsPage { comments: Vec::new(), next: None }))
+            self.repo_comments.borrow_mut().pop_front().unwrap_or(Ok(CommentsPage {
+                comments: Vec::new(),
+                next: None,
+                frontier: None,
+            }))
         }
 
         async fn freshness_probe(
@@ -1419,6 +1440,127 @@ mod tests {
     /// comment lane must resolve the parent by the comment's OWN kind first — a key-only lookup
     /// hitches the comment to whichever twin the scan returns first and then rewrites the
     /// correctly-kinded row through the kind-less comment conflict key.
+    /// A quiet probe must not starve an OWED boundary replay: providers without a probe
+    /// validator (GitLab) report a timestamp tie as not_modified, and the conservative frontier
+    /// left by an interrupted delta would otherwise wait for the daily full walk.
+    #[test]
+    fn a_quiet_probe_never_starves_an_owed_replay() {
+        let conn = db();
+        let binding = binding(&[]);
+        let first_walk = ScriptClient::new(vec![
+            Ok(ItemsPage {
+                items: vec![item("1", "2026-01-02T00:00:00Z", "one", &[])],
+                next: None,
+                backfill_boundary: None,
+            }),
+            Ok(ItemsPage { items: Vec::new(), next: None, backfill_boundary: None }),
+        ])
+        .with_repo_comments(Vec::new());
+        block_on(mirror_binding(&conn, &binding, &first_walk, false)).unwrap();
+
+        let mut cursor = load_cursor(&conn, &binding).unwrap();
+        cursor.item_delta_replay_required = true;
+        save_cursor(&conn, &binding, &cursor, false).unwrap();
+
+        let quiet = ScriptClient::new(vec![Ok(ItemsPage {
+            items: Vec::new(),
+            next: None,
+            backfill_boundary: None,
+        })])
+        .with_probe(FreshnessResult { latest: None, etag: None, not_modified: true })
+        .with_repo_comments(Vec::new());
+        block_on(mirror_binding(&conn, &binding, &quiet, false)).unwrap();
+
+        let requests = quiet.item_page_requests.borrow();
+        assert_eq!(requests.len(), 1, "the owed replay must run despite the quiet probe");
+        assert!(requests[0].updated_since.is_some(), "the replay is a delta scan");
+    }
+
+    /// A comments page whose entries all map to no comment (GitLab events on commit/snippet
+    /// notes) must still advance the stream through its `frontier`, or the scan replays the
+    /// same pages on every sync forever.
+    #[test]
+    fn a_page_of_only_skipped_comment_events_still_advances_the_stream() {
+        let conn = db();
+        let binding = binding(&[]);
+        let first_walk = ScriptClient::new(vec![
+            Ok(ItemsPage {
+                items: vec![item("1", "2026-01-02T00:00:00Z", "one", &[])],
+                next: None,
+                backfill_boundary: None,
+            }),
+            Ok(ItemsPage { items: Vec::new(), next: None, backfill_boundary: None }),
+        ])
+        .with_repo_comments(Vec::new());
+        block_on(mirror_binding(&conn, &binding, &first_walk, false)).unwrap();
+
+        let quiet = ScriptClient::new(vec![])
+            .with_probe(FreshnessResult { latest: None, etag: None, not_modified: true })
+            .with_repo_comment_pages(vec![Ok(CommentsPage {
+                comments: Vec::new(),
+                next: None,
+                frontier: Some("2026-02-01T00:00:00Z".to_string()),
+            })]);
+        block_on(mirror_binding(&conn, &binding, &quiet, false)).unwrap();
+
+        let cursor = load_cursor(&conn, &binding).unwrap();
+        assert_eq!(
+            cursor.comment_stream_cursors.get("default").and_then(|s| s.high_mark_at.as_deref()),
+            Some("2026-02-01T00:00:00Z"),
+            "the frontier advances the durable stream mark even with zero returned comments"
+        );
+    }
+
+    /// Namespaced providers name the comment's kind authoritatively: a missing exact-kind
+    /// parent (a merge request pruned by the tag filter while issue #N is cached) means SKIP —
+    /// never attach the comment across namespaces.
+    #[test]
+    fn namespaced_comments_never_fall_back_across_namespaces() {
+        let conn = db();
+        let mut binding = binding(&[]);
+        binding.provider = Tracker::Gitlab;
+        binding.project = "g/r".to_string();
+        let mut issue = item("7", "2026-01-02T00:00:00Z", "issue seven", &[]);
+        issue.project = "g/r".to_string();
+        store_item(&conn, binding.provider, &issue).unwrap();
+
+        let mut report = MirrorBindingReport {
+            tracker: binding.provider,
+            project: binding.project.clone(),
+            stored_items: 0,
+            stored_comments: 0,
+            pruned_items: 0,
+            paused_until_ms: None,
+            pause_reason: None,
+            completed_full_walk: false,
+            probe_not_modified: false,
+        };
+        let mut change_note = comment("7", "note:9", "2026-01-04T00:00:00Z");
+        change_note.project = "g/r".to_string();
+        change_note.item_kind = ItemKind::ChangeRequest;
+        let mut issue_note = comment("7", "note:10", "2026-01-04T00:00:00Z");
+        issue_note.project = "g/r".to_string();
+        store_repo_comments(&conn, &binding, &[change_note, issue_note], &mut report).unwrap();
+
+        let rows: Vec<(String, String)> = {
+            let mut stmt = conn
+                .prepare(
+                    "SELECT comment_id, item_kind FROM papertrail_comments ORDER BY comment_id",
+                )
+                .unwrap();
+            stmt.query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+                .unwrap()
+                .map(Result::unwrap)
+                .collect()
+        };
+        assert_eq!(
+            rows,
+            vec![("note:10".to_string(), "issue".to_string())],
+            "the merge-request note must be skipped, not attached to the issue"
+        );
+        assert_eq!(report.stored_comments, 1);
+    }
+
     #[test]
     fn repo_comments_resolve_namespaced_twins_by_their_own_kind() {
         let conn = db();
@@ -1583,6 +1725,7 @@ mod tests {
                 Ok(CommentsPage {
                     comments: vec![comment("1", "first", "2026-01-01T01:00:00Z")],
                     next: Some(next),
+                    frontier: None,
                 }),
                 Err(anyhow::Error::new(TransportError::Paused {
                     resume_at_ms: 42,
@@ -1612,16 +1755,19 @@ mod tests {
                         page_token: Some("thread-page-2".to_string()),
                         ..PageCursor::default()
                     }),
+                    frontier: None,
                 }),
                 Ok(CommentsPage {
                     comments: vec![comment("1", "second", "2026-01-01T02:00:00Z")],
                     next: None,
+                    frontier: None,
                 }),
                 // The confirming walk is identical, so absence of the deleted first comment is
                 // now safe to apply destructively.
                 Ok(CommentsPage {
                     comments: vec![comment("1", "second", "2026-01-01T02:00:00Z")],
                     next: None,
+                    frontier: None,
                 }),
             ]);
         block_on(mirror_binding(&conn, &binding, &resumed, false)).unwrap();
@@ -2223,6 +2369,7 @@ mod tests {
                     page_token: Some("page-2".to_string()),
                     ..PageCursor::default()
                 }),
+                frontier: None,
             })]);
         let error = block_on(mirror_binding(&conn, &binding, &invalid, false)).unwrap_err();
         assert!(error.to_string().contains("crossed"));
@@ -2310,6 +2457,7 @@ mod tests {
                 Ok(CommentsPage {
                     comments: vec![comment("1", "first", "2026-01-03T00:00:00Z")],
                     next: Some(next),
+                    frontier: None,
                 }),
                 Err(anyhow::Error::new(TransportError::Paused {
                     resume_at_ms: 42,
@@ -2364,10 +2512,12 @@ mod tests {
                 Ok(CommentsPage {
                     comments: vec![comment("1", "first", "2026-01-02T00:00:00Z")],
                     next: Some(next),
+                    frontier: None,
                 }),
                 Ok(CommentsPage {
                     comments: vec![comment("1", "later", "2026-01-04T00:00:00Z")],
                     next: None,
+                    frontier: None,
                 }),
             ]);
         block_on(mirror_binding(&conn, &binding, &delta, false)).unwrap();
@@ -2427,8 +2577,8 @@ mod tests {
                 not_modified: true,
             })
             .with_repo_comment_pages(vec![
-                Ok(CommentsPage { comments: Vec::new(), next: Some(next) }),
-                Ok(CommentsPage { comments: Vec::new(), next: None }),
+                Ok(CommentsPage { comments: Vec::new(), next: Some(next), frontier: None }),
+                Ok(CommentsPage { comments: Vec::new(), next: None, frontier: None }),
             ]);
         block_on(mirror_binding(&conn, &binding, &delta, false)).unwrap();
         let requests = delta.repo_comment_requests.borrow();
@@ -2449,10 +2599,12 @@ mod tests {
             Ok(CommentsPage {
                 comments: vec![comment("1", "issue", "2026-01-01T00:00:00Z")],
                 next: None,
+                frontier: None,
             }),
             Ok(CommentsPage {
                 comments: vec![comment("1", "review", "2026-01-03T00:00:00Z")],
                 next: None,
+                frontier: None,
             }),
         ]);
         block_on(mirror_binding(&conn, &binding, &initial, false)).unwrap();
@@ -2481,8 +2633,9 @@ mod tests {
                 Ok(CommentsPage {
                     comments: vec![comment("1", "late-issue", "2026-01-02T00:00:00Z")],
                     next: None,
+                    frontier: None,
                 }),
-                Ok(CommentsPage { comments: Vec::new(), next: None }),
+                Ok(CommentsPage { comments: Vec::new(), next: None, frontier: None }),
             ]);
         block_on(mirror_binding(&conn, &binding, &next, false)).unwrap();
         let requests = next.repo_comment_requests.borrow();

--- a/crates/rag-rat-core/src/index/papertrail/mod.rs
+++ b/crates/rag-rat-core/src/index/papertrail/mod.rs
@@ -258,6 +258,14 @@ pub struct CurrentSourceEvidence {
     pub symbol: Option<String>,
 }
 
+/// Whether a provider's item keys are unique across kinds. GitHub's shared issue/PR numbering
+/// is the exception (a key names at most one item, and its repo comment feed cannot always name
+/// the kind); namespaced providers (GitLab iids, Bitbucket, Jira) always name the kind on their
+/// comments, so a comment there must NEVER attach across namespaces.
+pub(crate) fn shared_item_numbering(tracker: Tracker) -> bool {
+    matches!(tracker, Tracker::Github)
+}
+
 /// Provider-neutral item kind. GitHub's shared issue/PR numbering is the exception, not the
 /// rule — GitLab issues and merge requests live in separate iid namespaces and Jira has no
 /// change requests at all — so the kind is part of an item's identity, never inferred.
@@ -382,6 +390,11 @@ pub struct ItemsPage {
 pub struct CommentsPage {
     pub comments: Vec<PapertrailComment>,
     pub next: Option<PageCursor>,
+    /// Provider-confirmed watermark for THIS page beyond the returned comments — set when the
+    /// provider's feed can contain entries that map to no comment (GitLab events on commit or
+    /// snippet notes). Without it, a first page of only-skipped entries returns no timestamps,
+    /// the stream's frontier cannot advance, and every scheduled sync replays the same pages.
+    pub frontier: Option<String>,
 }
 
 /// Provider outcomes that affect mirror control flow rather than representing a retryable
@@ -481,7 +494,11 @@ pub trait PapertrailClient {
         cursor: &PageCursor,
     ) -> anyhow::Result<CommentsPage> {
         anyhow::ensure!(cursor.page_token.is_none(), "legacy item comments cannot resume a page");
-        Ok(CommentsPage { comments: self.item_comments(project, kind, key).await?, next: None })
+        Ok(CommentsPage {
+            comments: self.item_comments(project, kind, key).await?,
+            next: None,
+            frontier: None,
+        })
     }
     /// Complete provider-specific item fields before the mirror starts the item's durable thread.
     /// The mirror invokes this one item at a time and checkpoints each completed item, so a

--- a/crates/rag-rat-core/src/index/papertrail/mod.rs
+++ b/crates/rag-rat-core/src/index/papertrail/mod.rs
@@ -2,6 +2,7 @@ mod api;
 pub mod autosync;
 mod evidence;
 mod github;
+mod gitlab;
 mod mirror;
 mod parse;
 mod schedule;
@@ -16,6 +17,7 @@ use std::sync::OnceLock;
 pub(crate) use api::*;
 pub(crate) use evidence::*;
 pub(crate) use github::*;
+pub(crate) use gitlab::*;
 pub use mirror::MirrorBindingReport;
 pub(crate) use mirror::{MirrorContinuation, load_mirror_continuation, mirror_binding};
 pub(crate) use parse::*;
@@ -388,6 +390,44 @@ pub struct CommentsPage {
 pub(crate) enum PapertrailClientError {
     #[error("tracker item not found")]
     ItemNotFound,
+}
+
+/// Reject a non-2xx provider response, mapping 404 to the typed not-found outcome the mirror
+/// understands. `provider` labels the error ("GitHub", "GitLab").
+pub(crate) fn ensure_provider_success(
+    provider: &str,
+    status: u16,
+    body: &str,
+) -> anyhow::Result<()> {
+    if status == 404 {
+        return Err(PapertrailClientError::ItemNotFound.into());
+    }
+    anyhow::ensure!((200..300).contains(&status), "{provider} HTTP {status}: {body}");
+    Ok(())
+}
+
+/// The `rel="next"` target from an RFC-8288 `Link` header — the pagination continuation both
+/// GitHub and GitLab emit.
+pub(crate) fn next_link(headers: &reqwest::header::HeaderMap) -> anyhow::Result<Option<String>> {
+    let Some(link) = headers.get(reqwest::header::LINK) else { return Ok(None) };
+    let link = link.to_str()?;
+    Ok(link.split(',').find_map(|part| {
+        let (url, rel) = part.trim().split_once(';')?;
+        rel.trim().eq(r#"rel="next""#).then(|| url.trim().trim_matches(['<', '>']).to_string())
+    }))
+}
+
+/// Provider payload rows must carry a positive numeric identity before they are trusted.
+pub(crate) fn validate_positive_id(
+    value: &serde_json::Value,
+    field: &str,
+    resource: &str,
+) -> anyhow::Result<()> {
+    anyhow::ensure!(
+        value[field].as_u64().is_some_and(|id| id > 0),
+        "{resource} has no valid {field}"
+    );
+    Ok(())
 }
 
 /// Advance decision for a freshness probe: the newest `updated_at` the provider reported vs the

--- a/crates/rag-rat-core/src/index/papertrail/mod.rs
+++ b/crates/rag-rat-core/src/index/papertrail/mod.rs
@@ -3,6 +3,7 @@ pub mod autosync;
 mod evidence;
 mod github;
 mod gitlab;
+mod http;
 mod mirror;
 mod parse;
 mod schedule;
@@ -18,8 +19,12 @@ pub(crate) use api::*;
 pub(crate) use evidence::*;
 pub(crate) use github::*;
 pub(crate) use gitlab::*;
+pub(crate) use http::*;
 pub use mirror::MirrorBindingReport;
-pub(crate) use mirror::{MirrorContinuation, load_mirror_continuation, mirror_binding};
+pub(crate) use mirror::{
+    MirrorContinuation, days_in_month, load_mirror_continuation, max_timestamp, mirror_binding,
+    parse_date,
+};
 pub(crate) use parse::*;
 pub use parse::{TrackerParsedRef, parse_tracker_refs};
 use rusqlite::{Connection, OptionalExtension, params};
@@ -262,7 +267,7 @@ pub struct CurrentSourceEvidence {
 /// is the exception (a key names at most one item, and its repo comment feed cannot always name
 /// the kind); namespaced providers (GitLab iids, Bitbucket, Jira) always name the kind on their
 /// comments, so a comment there must NEVER attach across namespaces.
-pub(crate) fn shared_item_numbering(tracker: Tracker) -> bool {
+pub(crate) fn item_numbering_is_shared(tracker: Tracker) -> bool {
     matches!(tracker, Tracker::Github)
 }
 
@@ -390,10 +395,13 @@ pub struct ItemsPage {
 pub struct CommentsPage {
     pub comments: Vec<PapertrailComment>,
     pub next: Option<PageCursor>,
-    /// Provider-confirmed watermark for THIS page beyond the returned comments — set when the
-    /// provider's feed can contain entries that map to no comment (GitLab events on commit or
-    /// snippet notes). Without it, a first page of only-skipped entries returns no timestamps,
-    /// the stream's frontier cannot advance, and every scheduled sync replays the same pages.
+    /// Provider-confirmed consumed watermark for THIS page: everything in the stream at or
+    /// before it has been returned or deliberately skipped. The mirror trusts it on EVERY page
+    /// (unlike the returned comments, whose maximum is trusted only on the scan's first page),
+    /// so only feeds with immutable append-only ordering may set it — GitLab's events feed,
+    /// ordered by creation. It carries a drained multi-page window past its LAST page (a
+    /// first-page-only frontier pins a busy day forever) and advances past entries that map to
+    /// no comment (commit/snippet notes). Mutable updated-order pages (GitHub) leave it None.
     pub frontier: Option<String>,
 }
 
@@ -403,44 +411,6 @@ pub struct CommentsPage {
 pub(crate) enum PapertrailClientError {
     #[error("tracker item not found")]
     ItemNotFound,
-}
-
-/// Reject a non-2xx provider response, mapping 404 to the typed not-found outcome the mirror
-/// understands. `provider` labels the error ("GitHub", "GitLab").
-pub(crate) fn ensure_provider_success(
-    provider: &str,
-    status: u16,
-    body: &str,
-) -> anyhow::Result<()> {
-    if status == 404 {
-        return Err(PapertrailClientError::ItemNotFound.into());
-    }
-    anyhow::ensure!((200..300).contains(&status), "{provider} HTTP {status}: {body}");
-    Ok(())
-}
-
-/// The `rel="next"` target from an RFC-8288 `Link` header — the pagination continuation both
-/// GitHub and GitLab emit.
-pub(crate) fn next_link(headers: &reqwest::header::HeaderMap) -> anyhow::Result<Option<String>> {
-    let Some(link) = headers.get(reqwest::header::LINK) else { return Ok(None) };
-    let link = link.to_str()?;
-    Ok(link.split(',').find_map(|part| {
-        let (url, rel) = part.trim().split_once(';')?;
-        rel.trim().eq(r#"rel="next""#).then(|| url.trim().trim_matches(['<', '>']).to_string())
-    }))
-}
-
-/// Provider payload rows must carry a positive numeric identity before they are trusted.
-pub(crate) fn validate_positive_id(
-    value: &serde_json::Value,
-    field: &str,
-    resource: &str,
-) -> anyhow::Result<()> {
-    anyhow::ensure!(
-        value[field].as_u64().is_some_and(|id| id > 0),
-        "{resource} has no valid {field}"
-    );
-    Ok(())
 }
 
 /// Advance decision for a freshness probe: the newest `updated_at` the provider reported vs the

--- a/crates/rag-rat-core/src/index/papertrail/transport/client.rs
+++ b/crates/rag-rat-core/src/index/papertrail/transport/client.rs
@@ -368,7 +368,7 @@ fn parse_bound_authority(authority: &str) -> anyhow::Result<(String, Option<u16>
 }
 
 /// Loopback spellings a binding/test can use; these allow plain http and arbitrary ports.
-fn is_loopback_host(host: &str) -> bool {
+pub(crate) fn is_loopback_host(host: &str) -> bool {
     matches!(host, "127.0.0.1" | "localhost" | "::1")
 }
 

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/mod.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/mod.rs
@@ -657,7 +657,11 @@ impl papertrail::PapertrailClient for MockGitHubClient {
         project: &str,
         _cursor: &papertrail::PageCursor,
     ) -> anyhow::Result<papertrail::CommentsPage> {
-        Ok(papertrail::CommentsPage { comments: Self::mock_comments(project, "42"), next: None })
+        Ok(papertrail::CommentsPage {
+            comments: Self::mock_comments(project, "42"),
+            next: None,
+            frontier: None,
+        })
     }
 
     async fn freshness_probe(

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/papertrail_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/papertrail_tests.rs
@@ -209,10 +209,7 @@ fn production_discovery_persists_refs_for_every_configured_tracker() {
         status.capabilities[0].authentication,
         papertrail::TrackerAuthentication::AuthConfigured
     );
-    assert_eq!(
-        status.capabilities[0].synchronization,
-        papertrail::TrackerSynchronization::ProviderClientPending
-    );
+    assert_eq!(status.capabilities[0].synchronization, papertrail::TrackerSynchronization::Native);
     assert_eq!(
         status.capabilities[1].authentication,
         papertrail::TrackerAuthentication::AuthMissing

--- a/docs/config.md
+++ b/docs/config.md
@@ -618,7 +618,10 @@ supported; issues `#N` and merge requests `!N` are separate numbering namespaces
 feed (GitLab has no "notes updated since" endpoint, and commenting does not touch the parent's
 `updated_at`); an EDIT to an old comment produces no event, so edited bodies converge at the
 daily full re-walk unless the comment's creation event is still inside the incremental replay
-window. Merge-request approvals mirror as review comments (`review_state`). The shared runner keeps every result, cursor, auth source, and quota governor scoped to its
+window. Merge-request approvals mirror as review comments (`review_state`) — approving emits no
+`commented` event either, so approvals also converge at the daily full re-walk. A comment whose
+parent item is excluded by the `tags` filter is skipped; if that item later gains a tracked tag,
+its earlier comments appear at the next full re-walk. The shared runner keeps every result, cursor, auth source, and quota governor scoped to its
 binding. A repository may have at most one resolved binding for a given `(provider, project)`:
 the mirror rejects duplicates before dispatch because API origin and tag filters are not part of
 the persisted item/cache cursor identity. Use one binding and one combined tag set for that

--- a/docs/config.md
+++ b/docs/config.md
@@ -588,8 +588,10 @@ Per-key notes:
   (the project key, e.g. `PROJ`): Jira is not a code host, so it is never auto-detected and has
   no remote to derive from.
 - `base_url` — self-hosted / enterprise instances (`https://gitlab.example.com`). Must be an
-  http(s) URL without inline credentials. Self-hosted GitHub Enterprise and Bitbucket instances
-  are configured this way — only the three cloud hosts auto-detect.
+  origin URL without inline credentials, and must use **https**: the transport never sends the
+  binding's token over plaintext, so `http` origins are accepted for loopback hosts only (local
+  testing). Self-hosted GitHub Enterprise and Bitbucket instances are configured this way —
+  only the three cloud hosts auto-detect.
 - `auth` — exactly one of `env` (the NAME of an env var holding the token — never the token
   itself) or `token_command` (a command printing the token to stdout). Omitted = anonymous /
   provider-native fallback.

--- a/docs/config.md
+++ b/docs/config.md
@@ -607,9 +607,18 @@ URLs; Bitbucket `#N` (issues) and `/issues/N` / `/pull-requests/N` URLs; Jira ba
 only. A self-hosted binding's URL grammar matches its own host, not the cloud host.
 
 All bindings participate in production reference discovery, annotation lookup, and manual mirror
-dispatch. GitHub bindings use the native client now; GitLab, Bitbucket, and Jira bindings report a
-provider-client-pending result until their provider PRs land, and are never sent through the GitHub
-client. The shared runner keeps every result, cursor, auth source, and quota governor scoped to its
+dispatch. GitHub and GitLab bindings use their native clients now; Bitbucket and Jira bindings
+report a provider-client-pending result until their provider PRs land, and are never sent through
+another provider's client.
+
+GitLab notes: auth is a personal access token with `read_api` (sent as a bearer token) via
+`auth = { env = "GITLAB_TOKEN" }` or a `token_command`; subgroup project paths are fully
+supported; issues `#N` and merge requests `!N` are separate numbering namespaces and mirror as
+`issue` / `change_request` items. New comments arrive incrementally through the project events
+feed (GitLab has no "notes updated since" endpoint, and commenting does not touch the parent's
+`updated_at`); an EDIT to an old comment produces no event, so edited bodies converge at the
+daily full re-walk unless the comment's creation event is still inside the incremental replay
+window. Merge-request approvals mirror as review comments (`review_state`). The shared runner keeps every result, cursor, auth source, and quota governor scoped to its
 binding. A repository may have at most one resolved binding for a given `(provider, project)`:
 the mirror rejects duplicates before dispatch because API origin and tag filters are not part of
 the persisted item/cache cursor identity. Use one binding and one combined tag set for that


### PR DESCRIPTION
`GitLabClient` implements `PapertrailClient` for gitlab.com and self-hosted instances (`base_url`), replacing the provider-client-pending stub for GitLab bindings. The rate governor (`RateLimit-*`), ref grammar (`#N` / `!N` / subgroups / `/-/` URLs), and remote auto-detect already shipped with the substrate waves, so this is client + dispatch.

## Provider mapping

- **Separate iid namespaces**: `ItemKind` is binding on every call — issue `#5` and MR `!5` coexist; issues map to `issue`, merge requests to `change_request` (with `merged_at`); labels → tags.
- **Native LIFO descent**: backfill uses `updated_before` on the ordinary list endpoints (no Search-API detour, no 1000-result cap). The two namespaces advance as **parallel legs** — every items page fetches one page from each still-pending leg and emits the merge — so the mirror's first-page frontier (initial high mark, delta watermark) covers both namespaces. The cycle's reported boundary is the *global* oldest across both legs, so the next cycle never re-walks the older leg's tail. `updated_before` is confirmed **strict** on GitLab CE, preserving the boundary-advance invariant.
- **Comments**: per-item notes map plain notes, DiffNote positions (`anchor_path`), and approval *system* notes (`review_state` with real authors/timestamps — the `/approvals` endpoint has no per-event history; scoping to system notes means a user comment can't spoof review state). Other system noise is dropped.
- **Events comment lane**: live verification against GitLab CE disproved the natural assumption — note creation/edit does **not** bump the noteable's `updated_at`, so no items-lane signal exists for comment activity. New comments arrive through the project events feed (`action=commented`): one event per note creation, each embedding the note's *current* body, so edits converge via event replay inside the incremental window and at the daily full re-walk beyond it. The date-granular `after` filter queries from the day before the cursor; the mirror dedups the replay.
- **Probe**: two 1-item calls (one per namespace), max wins; with no cross-call validator, the timestamp comparison is the quiet signal — an idle project's poll costs two 1-item requests, not two delta legs.
- Subgroup project paths are percent-encoded as one `/projects/:id` segment (sound because validation restricts segments to GitLab's path alphabet); verified against a real two-level subgroup project on gitlab.com.

## Pre-existing mirror bug found by the live smoke

`store_repo_comments` resolved a repo-lane comment's parent by `item_key` alone — sound under GitHub's shared numbering, wrong under namespaced numbering: with GitLab twins on one key, the lookup hitched issue comments to the MR and then *rewrote* the correctly-kinded rows through the kind-less comment conflict key. Fixed with kind-preference resolution (the comment's own kind first, key-only fallback for GitHub's unnamed-kind stream); regression tests pin both halves.

Both sync paths (manual and scheduled) now share `tracker_synchronization` as the single source of which providers are native — the manual path previously gated on the provider enum directly.

## Verification

- 16 stub-backed client tests (namespace binding, parallel-leg backfill/delta with global boundary, note/approval/anchor mapping, events lane, probe quiet flag, cross-origin rejection, malformed input rejection, typed 404) + 2 mirror regression tests for the twin resolution.
- End-to-end against a local GitLab CE instance: full walk (issue + MR + approval + labels), incremental sync picking up a new note on a **quiet** item through the events lane, edited-body convergence via replay, quiet re-sync reporting `probe_not_modified` with zero item traffic.
- Full workspace suite (2820), CI-exact clippy set, nightly fmt.

Fixes #593
