### PR TITLE
feat(account): mint the store's local account (C3.4a bootstrap)

### DIFF
--- a/crates/rag-rat-core/src/index/schema/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema/migrations.rs
@@ -1266,6 +1266,7 @@ pub(crate) fn known_version(migrations: &[AppliedMigration]) -> u32 {
             MIGRATION_066_ID => Some(66),
             MIGRATION_067_ID => Some(67),
             MIGRATION_068_ID => Some(68),
+            MIGRATION_069_ID => Some(69),
             _ => None,
         })
         .max()
@@ -1343,6 +1344,7 @@ pub(crate) fn known_migration(id: &str) -> bool {
             | MIGRATION_066_ID
             | MIGRATION_067_ID
             | MIGRATION_068_ID
+            | MIGRATION_069_ID
             | DIRTY_MIGRATION_ID
     )
 }
@@ -1417,6 +1419,7 @@ pub(crate) fn migration_checksum_mismatch(migration: &AppliedMigration) -> bool 
         MIGRATION_066_ID => migration.checksum != MIGRATION_066_CHECKSUM,
         MIGRATION_067_ID => migration.checksum != MIGRATION_067_CHECKSUM,
         MIGRATION_068_ID => migration.checksum != MIGRATION_068_CHECKSUM,
+        MIGRATION_069_ID => migration.checksum != MIGRATION_069_CHECKSUM,
         _ => false,
     }
 }
@@ -4463,6 +4466,26 @@ pub(crate) fn apply_content_candidate_dag(conn: &Connection) -> rusqlite::Result
          ) STRICT;
          CREATE INDEX IF NOT EXISTS content_pre_verify_author
              ON content_pre_verify(claimed_author_account_id, roster_ref);",
+    )
+}
+
+/// V069 (sync phase C3.4a): the store-global local-account pointer. `oplog_local_account` is a
+/// single-row (`CHECK (id = 0)`) STRICT table naming the `genesis_entry_hash` of THIS store's one
+/// local account — the seq-0, self-authorizing `AccountGenesis` minted once by
+/// [`crate::oplog::local_account`] and reused thereafter, so later C3.4 slices author owner-bound
+/// `/3` content under a stable account identity. The pointer is a 32-byte content address into
+/// `account_entries`, not the account_id itself: the id is resolved by looking the genesis up in
+/// the candidate DAG, so the pointer + genesis stay a single source of truth (one committed
+/// atomically with the other by the minting transaction). Store-global like
+/// `oplog_device_identity`, not repo-scoped. Purely additive; `CREATE ... IF NOT EXISTS`, so a torn
+/// replay reconverges without a wrapping transaction.
+pub(crate) fn apply_oplog_local_account(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS oplog_local_account(
+             id                 INTEGER PRIMARY KEY CHECK (id = 0),
+             genesis_entry_hash BLOB NOT NULL CHECK (length(genesis_entry_hash) = 32),
+             created_at_ms      INTEGER NOT NULL
+         ) STRICT;",
     )
 }
 

--- a/crates/rag-rat-core/src/index/schema/mod.rs
+++ b/crates/rag-rat-core/src/index/schema/mod.rs
@@ -19,7 +19,7 @@ pub use registry::{LEGACY_REPO_ID, RegisteredRepo, register_repo, register_repo_
 use rusqlite::{Connection, OptionalExtension, Transaction, TransactionBehavior, params};
 use serde::Serialize;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 68;
+pub const LATEST_SCHEMA_VERSION: u32 = 69;
 
 /// Every oracle-DERIVED persisted table — the outputs an `oracle run` writes that must OUTLIVE a
 /// reindex.
@@ -472,6 +472,13 @@ const MIGRATION_068_CHECKSUM: &str = "sha256:rag-rat-suppressed-edge-candidates-
 const MIGRATION_068_DESCRIPTION: &str = "Hide suppressed unresolved edge candidates from the \
                                          compatibility view while retaining them for later \
                                          incremental re-resolution";
+const MIGRATION_069_ID: &str = "069_oplog_local_account";
+const MIGRATION_069_CHECKSUM: &str = "sha256:rag-rat-oplog-local-account-v69";
+const MIGRATION_069_DESCRIPTION: &str =
+    "Add oplog_local_account (sync phase C3.4a): the single-row (id = 0) STRICT pointer naming \
+     the genesis_entry_hash of this store's one local account, minted once by local_account and \
+     reused so later C3.4 slices author owner-bound /3 content under a stable identity. \
+     Store-global, not repo-scoped; purely additive, nothing pre-existing to backfill";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -1041,6 +1048,12 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         checksum: MIGRATION_068_CHECKSUM,
         description: MIGRATION_068_DESCRIPTION,
         apply: apply_edges_view_refresh,
+    },
+    Migration {
+        id: MIGRATION_069_ID,
+        checksum: MIGRATION_069_CHECKSUM,
+        description: MIGRATION_069_DESCRIPTION,
+        apply: apply_oplog_local_account,
     },
 ];
 

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
@@ -2015,10 +2015,16 @@ fn migration_066_adds_the_content_candidate_dag() {
 }
 
 #[test]
-fn migration_068_is_the_tip_and_hides_suppressed_edge_candidates() {
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 68, "move this pin with the next schema migration");
+fn migration_068_hides_suppressed_edge_candidates() {
+    // The absolute-tip pin moved to `migration_069_*` (V069 is the tip now); this drops to the
+    // symbolic `current_version == LATEST` freshness check, per the ladder convention.
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     schema::apply(&conn).unwrap();
+    assert_eq!(
+        schema::status(&conn).unwrap().current_version,
+        schema::LATEST_SCHEMA_VERSION,
+        "schema at LATEST after apply",
+    );
     conn.execute(
         "INSERT INTO files(path, language, kind, sha256, modified_at_ms, indexed_at_ms, \
          commit_sha, worktree_id) VALUES ('App.swift', 'swift', 'source', 'sha', 0, 0, 'head', '')",
@@ -2067,6 +2073,89 @@ fn migration_068_is_the_tip_and_hides_suppressed_edge_candidates() {
         )
         .unwrap();
     assert_eq!(v68_recorded, 1, "the forward migration records V068");
+}
+
+#[test]
+fn migration_069_is_the_tip_and_adds_the_local_account_pointer() {
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 69, "move this pin with the next schema migration");
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn).unwrap();
+
+    // The single-row pointer table exists with its full column set.
+    for column in ["id", "genesis_entry_hash", "created_at_ms"] {
+        assert!(
+            conn_table_columns(&conn, "oplog_local_account").contains(&column.to_string()),
+            "V069 gives oplog_local_account its {column} column",
+        );
+    }
+
+    // `CHECK (id = 0)` + the primary key make it a strict single-row table: id 0 inserts once; a
+    // non-zero id is refused by the CHECK; a second id-0 insert is refused by the PK. The
+    // `length(genesis_entry_hash) = 32` CHECK rejects a wrong-width pointer.
+    conn.execute(
+        "INSERT INTO oplog_local_account(id, genesis_entry_hash, created_at_ms)
+         VALUES (0, zeroblob(32), 0)",
+        [],
+    )
+    .expect("the sole id=0 pointer row inserts");
+    assert!(
+        conn.execute(
+            "INSERT INTO oplog_local_account(id, genesis_entry_hash, created_at_ms)
+             VALUES (1, zeroblob(32), 0)",
+            [],
+        )
+        .is_err(),
+        "CHECK (id = 0) rejects a second, non-zero pointer",
+    );
+    assert!(
+        conn.execute(
+            "INSERT INTO oplog_local_account(id, genesis_entry_hash, created_at_ms)
+             VALUES (0, zeroblob(32), 1)",
+            [],
+        )
+        .is_err(),
+        "the id=0 primary key rejects a second pointer",
+    );
+    assert!(
+        conn.execute(
+            "UPDATE oplog_local_account SET genesis_entry_hash = zeroblob(31) WHERE id = 0",
+            [],
+        )
+        .is_err(),
+        "the length(genesis_entry_hash) = 32 CHECK rejects a wrong-width hash",
+    );
+
+    // Deferred-absence in ISOLATION: a bare DB lacks the table until the V069 applier runs, and a
+    // replay is an idempotent no-op (CREATE ... IF NOT EXISTS).
+    let isolated = rusqlite::Connection::open_in_memory().unwrap();
+    assert!(
+        !conn_table_exists(&isolated, "oplog_local_account"),
+        "bare DB lacks oplog_local_account before the isolated apply",
+    );
+    schema::apply_oplog_local_account(&isolated).unwrap();
+    schema::apply_oplog_local_account(&isolated).expect("replay is a no-op");
+    assert!(
+        conn_table_columns(&isolated, "oplog_local_account")
+            .contains(&"genesis_entry_hash".to_string()),
+        "the isolated applier recreates the table",
+    );
+
+    // A forward migrate over a ledger truncated below V069 replays the step and records V069.
+    truncate_schema_to(&conn, 68);
+    schema::migrate_forward(&conn).unwrap();
+    assert_eq!(
+        schema::status(&conn).unwrap().current_version,
+        schema::LATEST_SCHEMA_VERSION,
+        "forward migrate reaches the tip",
+    );
+    let v69_recorded: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM schema_version WHERE id = '069_oplog_local_account'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(v69_recorded, 1, "the forward migration records V069");
 }
 
 #[test]

--- a/crates/rag-rat-core/src/oplog/account/bootstrap.rs
+++ b/crates/rag-rat-core/src/oplog/account/bootstrap.rs
@@ -1,0 +1,382 @@
+//! The store's persisted local account — its ONE self-authorizing `AccountGenesis`, minted once and
+//! reused (sync phase C3.4a, #662).
+//!
+//! Where [`crate::oplog::local_device`] is the machine's signing identity, the local account is the
+//! *principal* this install authors under: a seq-0, self-authorizing account genesis whose founder
+//! is the local device. It is minted from OS entropy on first use and pinned by the single-row
+//! `oplog_local_account` pointer table (`CHECK (id = 0)`), so later C3.4 slices author owner-bound
+//! `/3` content under a stable account identity instead of a fresh genesis per call. Store-global,
+//! not repo-scoped — the exact analog of the device identity.
+//!
+//! [`local_account`] is the single accessor. The pointer stores the genesis entry's content hash,
+//! NOT the account_id: the id is recovered by resolving that hash in the candidate DAG (§4 commits
+//! the account_id inside the genesis payload), so the pointer and the stored genesis stay one
+//! source of truth — the mint transaction commits both, or neither.
+//!
+//! GENESIS ONLY (this slice): the general non-genesis account-op seam (StreamOwn, DeviceAdd, …) is
+//! a later slice. This mint reuses the account layer's own [`super::storage::insert_candidate`] +
+//! [`super::storage::refold_in_tx`] seams directly; it MUST NOT go through
+//! [`super::storage::account_ingest`], which self-transacts with its own `BEGIN IMMEDIATE` and
+//! cannot be nested inside the mint transaction.
+//!
+//! RACE SAFETY. Each mint attempt draws a fresh nonce, so two racing first-callers propose DISTINCT
+//! accounts; convergence comes from the pointer. A concurrent first-open therefore behaves exactly
+//! like the device path: the process that loses the single-row insert adopts the winner's account
+//! and discards its own proposal — the loser NEVER authors a second genesis, because a second
+//! genesis is a second permanent, unrecoverable account identity. The pointer insert is the FIRST
+//! write and gates the genesis insert; the genesis is authored only if our hash won the pointer,
+//! and it is authored in the SAME transaction, so a durably-committed pointer always names an
+//! accepted genesis.
+
+use anyhow::Context;
+use rusqlite::{Connection, OptionalExtension, Transaction, TransactionBehavior, params};
+
+use super::AccountId;
+use super::envelope::{AccountEntryHeader, VerifiedAccountEntry, sign_account_entry};
+use super::id::account_id_from_genesis_payload;
+use super::ops::{self, AccountOp};
+use super::storage::{self, CandidateInsert};
+use crate::oplog::local_device;
+
+/// Return this store's persisted local account, minting its self-authorizing genesis on the first
+/// call and returning the SAME account stably thereafter. `now_ms` stamps a freshly-minted genesis
+/// and its pointer row (injected, matching the op-log store convention); it is ignored once an
+/// account exists.
+///
+/// The account_id is the §4 content-commitment of the genesis payload, resolved through the
+/// pointer: idempotent, and a concurrent first-open converges on one account (the loser of the
+/// pointer race adopts the winner's genesis — see the module header).
+pub(crate) fn local_account(conn: &Connection, now_ms: i64) -> anyhow::Result<AccountId> {
+    // Fast path: the pointer is already minted — adopt it WITHOUT taking the writer lock.
+    // Candidates are grow-only, so a genesis this read resolves can never disappear underneath
+    // us.
+    if let Some(account_id) = read_local_account(conn)? {
+        return Ok(account_id);
+    }
+    // First mint: an authored, irreplaceable identity write → durable (#560). Raise `synchronous =
+    // FULL` for this txn only, restored on drop; set OUTSIDE the txn (SQLite applies a
+    // `synchronous` change to SUBSEQUENT transactions only).
+    let _durability = AuthoredDurability::begin(conn)?;
+    let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
+    mint_local_account_in_tx(&tx, now_ms)?;
+    tx.commit()?;
+    // Mandatory re-read (mirrors the device path): a concurrent first-caller that WON the pointer
+    // race committed its genesis before us, so adopt whichever genesis the pointer now names — ours
+    // if we won, the incumbent's if we lost.
+    read_local_account(conn)?
+        .context("local account pointer missing immediately after mint (single-row insert lost?)")
+}
+
+/// Mint the local account inside the caller's IMMEDIATE transaction, or adopt an incumbent and
+/// author nothing. See the module header for the race-safety contract.
+fn mint_local_account_in_tx(tx: &Transaction<'_>, now_ms: i64) -> anyhow::Result<()> {
+    // Re-check UNDER the writer lock: a racer may have minted between the lock-free fast path and
+    // our IMMEDIATE acquire. If the pointer already exists, adopt it and author NOTHING — a second
+    // genesis would be a second permanent account identity (unrecoverable).
+    if read_pointer_hash(tx)?.is_some() {
+        return Ok(());
+    }
+    let device = local_device(tx, now_ms)?;
+
+    // A fresh 16-byte nonce from OS entropy makes each mint attempt derive a DISTINCT account_id,
+    // so two racing first-callers propose different accounts; the pointer insert below is what
+    // forces them to converge on exactly one.
+    let mut nonce16 = [0u8; 16];
+    getrandom::fill(&mut nonce16)
+        .map_err(|e| anyhow::anyhow!("OS CSPRNG failed to seed the account genesis nonce: {e}"))?;
+
+    let op = AccountOp::AccountGenesis {
+        ed25519_pubkey: device.public().to_bytes(),
+        x25519_pubkey: device.x25519_public().to_bytes(),
+        nonce16,
+        created_at_ms: u64::try_from(now_ms)
+            .map_err(|_| anyhow::anyhow!("now_ms is negative; cannot stamp a genesis"))?,
+        label: None,
+    };
+    let payload = ops::encode(&op)
+        .map_err(|err| anyhow::anyhow!("encoding the account genesis op failed: {err}"))?;
+    let account_id = account_id_from_genesis_payload(&payload);
+    let header = AccountEntryHeader {
+        account_id,
+        log_id: 0,
+        device_fingerprint: device.fingerprint(),
+        seq: 0,
+        prev_hash: None,
+        parent_ref: None,
+        entry_type: ops::entry_type::ACCOUNT_GENESIS,
+        op_version: 1,
+        crypto_suite: 0,
+        auth_len: 0,
+        key_id: None,
+        authority_ref: None,
+    };
+    let signed = sign_account_entry(device.secret(), &header, &payload)?;
+
+    // The pointer insert is the FIRST write and the race gate. `ON CONFLICT DO NOTHING` lets a
+    // racer that already minted keep its row; we then re-read and author OUR genesis only if
+    // OUR hash won the pointer. (Belt-and-suspenders under IMMEDIATE — the re-check above
+    // already adopts a committed incumbent — but it keeps "one committed pointer ⇒ exactly one
+    // genesis" true regardless of isolation, since the genesis insert cannot precede a lost
+    // pointer race.)
+    tx.execute(
+        "INSERT INTO oplog_local_account(id, genesis_entry_hash, created_at_ms)
+         VALUES (0, ?1, ?2) ON CONFLICT(id) DO NOTHING",
+        params![signed.entry_hash.as_slice(), now_ms],
+    )?;
+    let pointer = read_pointer_hash(tx)?
+        .context("local account pointer missing immediately after its own insert")?;
+    if pointer != signed.entry_hash {
+        // Lost the pointer race: adopt the incumbent, author no genesis.
+        return Ok(());
+    }
+
+    // We won the pointer — author the genesis candidate and fold it in THIS transaction. Because
+    // the pointer insert and the genesis insert share one transaction, any failure below
+    // (including a genesis that does not fold effective) rolls BOTH back, so a
+    // durably-committed pointer always names an accepted genesis and incumbent adoption is
+    // unconditionally safe.
+    let verified = VerifiedAccountEntry {
+        header: signed.header,
+        payload: signed.payload,
+        entry_hash: signed.entry_hash,
+    };
+    match storage::insert_candidate(tx, &verified, &signed.signed_bytes, now_ms)? {
+        CandidateInsert::Inserted | CandidateInsert::AlreadyPresent => {},
+        CandidateInsert::AtCapacity(scope) => anyhow::bail!(
+            "the account candidate store is at capacity ({scope:?}); cannot mint the local account",
+        ),
+    }
+    let statuses = storage::refold_in_tx(tx, account_id)?;
+    // Verify the genesis folded EFFECTIVE (accepted), not merely inserted — never return a wedged
+    // account.
+    match statuses.get(&verified.entry_hash).map(String::as_str) {
+        Some("accepted") => Ok(()),
+        other => anyhow::bail!(
+            "the local account genesis did not fold effective (status {other:?}); refusing to \
+             mint a wedged account",
+        ),
+    }
+}
+
+/// Resolve this store's local account from the pointer, or `None` if none is minted yet. The
+/// pointer is a content address; the account_id is recovered by looking the genesis up in the
+/// candidate DAG (§4 commits the account_id inside the genesis payload, so this is the one true
+/// id).
+fn read_local_account(conn: &Connection) -> anyhow::Result<Option<AccountId>> {
+    let Some(genesis_hash) = read_pointer_hash(conn)? else {
+        return Ok(None);
+    };
+    let account_bytes: Vec<u8> = conn
+        .query_row(
+            "SELECT account_id FROM account_entries WHERE entry_hash = ?1",
+            params![genesis_hash.as_slice()],
+            |row| row.get(0),
+        )
+        .optional()?
+        .context(
+            "oplog_local_account points at a genesis absent from account_entries (corrupted \
+             pointer)",
+        )?;
+    let account_id: [u8; 32] = account_bytes
+        .as_slice()
+        .try_into()
+        .map_err(|_| anyhow::anyhow!("stored account_id is not exactly 32 bytes"))?;
+    Ok(Some(AccountId::from_bytes(account_id)))
+}
+
+/// Read the single-row pointer's genesis hash, or `None` when no account has been minted.
+fn read_pointer_hash(conn: &Connection) -> anyhow::Result<Option<[u8; 32]>> {
+    let hash: Option<Vec<u8>> = conn
+        .query_row("SELECT genesis_entry_hash FROM oplog_local_account WHERE id = 0", [], |row| {
+            row.get(0)
+        })
+        .optional()?;
+    hash.map(|bytes| {
+        <[u8; 32]>::try_from(bytes.as_slice())
+            .map_err(|_| anyhow::anyhow!("stored genesis_entry_hash is not exactly 32 bytes"))
+    })
+    .transpose()
+}
+
+/// Raise SQLite `synchronous = FULL` for the duration of an authored write, restoring `NORMAL` on
+/// drop (#560). The index connection defaults to `NORMAL` (the right policy for high-frequency,
+/// fully reconstructable derived-index writes); an authored identity mint is the opposite class —
+/// irreplaceable and it returns success to the caller, so it must fsync the WAL on commit. `begin`
+/// MUST run OUTSIDE the transaction (SQLite applies a `synchronous` change to SUBSEQUENT
+/// transactions only); the guard is held across the mint `BEGIN .. COMMIT` and restores on every
+/// path (including error/panic), so a shared connection is never stranded at FULL. Mirrors
+/// `query::memory::authoring::AuthoredDurability`, which the account layer cannot reach up into
+/// (the dependency is one-way).
+struct AuthoredDurability<'a> {
+    conn: &'a Connection,
+}
+
+impl<'a> AuthoredDurability<'a> {
+    fn begin(conn: &'a Connection) -> anyhow::Result<Self> {
+        conn.execute_batch("PRAGMA synchronous = FULL;")?;
+        Ok(Self { conn })
+    }
+}
+
+impl Drop for AuthoredDurability<'_> {
+    fn drop(&mut self) {
+        // Best-effort restore of the connection default; runs after the mint txn committed/rolled
+        // back, so no transaction is open. A stray failure could only leave the connection on the
+        // *safer*, slower setting, never a less durable one.
+        let _ = self.conn.execute_batch("PRAGMA synchronous = NORMAL;");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Barrier};
+    use std::thread;
+    use std::time::Duration;
+
+    use super::*;
+    use crate::index::schema;
+
+    const NOW: i64 = 1_700_000_000_000;
+
+    fn db() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        schema::apply(&conn).unwrap();
+        conn
+    }
+
+    fn genesis_row_count(conn: &Connection) -> i64 {
+        conn.query_row(
+            "SELECT COUNT(*) FROM account_entries WHERE entry_type = ?1",
+            params![ops::entry_type::ACCOUNT_GENESIS],
+            |row| row.get(0),
+        )
+        .unwrap()
+    }
+
+    fn pointer_row_count(conn: &Connection) -> i64 {
+        conn.query_row("SELECT COUNT(*) FROM oplog_local_account", [], |row| row.get(0)).unwrap()
+    }
+
+    #[test]
+    fn mint_once_then_reuse_returns_the_same_account_and_one_genesis() {
+        let conn = db();
+        let first = local_account(&conn, NOW).expect("mint");
+        // A later call (a different `now_ms`, as a reopen would have) returns the SAME account and
+        // mints no second genesis or pointer.
+        let second = local_account(&conn, NOW + 5_000).expect("reuse");
+        assert_eq!(first, second, "the local account is stable across calls");
+        assert_eq!(genesis_row_count(&conn), 1, "re-calling does not mint a second genesis");
+        assert_eq!(pointer_row_count(&conn), 1, "exactly one pointer row");
+    }
+
+    #[test]
+    fn the_genesis_folds_effective_and_the_account_is_live() {
+        let conn = db();
+        let account_id = local_account(&conn, NOW).expect("mint");
+        // The pointer names an ACCEPTED genesis (folded effective, not merely inserted).
+        let genesis_hash: Vec<u8> = conn
+            .query_row(
+                "SELECT genesis_entry_hash FROM oplog_local_account WHERE id = 0",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let status: String = conn
+            .query_row(
+                "SELECT status FROM account_entry_status WHERE entry_hash = ?1",
+                params![genesis_hash.as_slice()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(status, "accepted", "the local account genesis folds effective");
+        // The account projects LIVE with a positive effective control-fold length.
+        let (classification, effective_count): (String, i64) = conn
+            .query_row(
+                "SELECT classification, effective_count FROM account_auth_state
+                 WHERE account_id = ?1",
+                params![account_id.to_bytes().as_slice()],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(classification, "live", "the account is live");
+        assert!(effective_count > 0, "the genesis counts toward the effective fold");
+    }
+
+    #[test]
+    fn the_pointer_resolves_to_the_genesis_committed_account_id() {
+        let conn = db();
+        let account_id = local_account(&conn, NOW).expect("mint");
+        // The stored account_id is exactly the §4 commitment of the stored genesis payload.
+        let signed_bytes: Vec<u8> = conn
+            .query_row(
+                "SELECT e.signed_bytes
+                 FROM oplog_local_account p
+                 JOIN account_entries e ON e.entry_hash = p.genesis_entry_hash
+                 WHERE p.id = 0",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let signed = super::super::envelope::decode_account_signed(&signed_bytes).unwrap();
+        assert_eq!(
+            account_id_from_genesis_payload(&signed.payload),
+            account_id,
+            "the resolved account_id is the genesis commitment",
+        );
+    }
+
+    #[test]
+    fn the_in_tx_mint_adopts_an_incumbent_pointer_without_a_second_genesis() {
+        let conn = db();
+        // An incumbent is already minted (the "pre-inserted pointer + genesis").
+        let incumbent = local_account(&conn, NOW).expect("incumbent mint");
+        // Drive the in-txn mint body directly with the pointer already present: it must adopt (the
+        // under-lock re-check short-circuits) rather than author a second, distinct genesis.
+        let tx = Transaction::new_unchecked(&conn, TransactionBehavior::Immediate).unwrap();
+        mint_local_account_in_tx(&tx, NOW + 1).expect("adopt");
+        tx.commit().unwrap();
+        assert_eq!(
+            genesis_row_count(&conn),
+            1,
+            "the in-txn adopt short-circuit authors no second genesis",
+        );
+        assert_eq!(
+            local_account(&conn, NOW + 2).expect("reuse"),
+            incumbent,
+            "the incumbent account survives",
+        );
+    }
+
+    #[test]
+    fn concurrent_first_callers_converge_on_one_account_and_one_genesis() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("local-account.db");
+        let setup = Connection::open(&path).unwrap();
+        schema::apply(&setup).unwrap();
+        drop(setup);
+
+        // Two first-callers race from a fresh DB: each proposes a DISTINCT account (fresh nonce),
+        // so convergence can only come from the pointer race — the loser must adopt the
+        // winner.
+        let barrier = Arc::new(Barrier::new(2));
+        let spawn = || {
+            let path = path.clone();
+            let barrier = Arc::clone(&barrier);
+            thread::spawn(move || {
+                let conn = Connection::open(path).unwrap();
+                conn.busy_timeout(Duration::from_secs(5)).unwrap();
+                barrier.wait();
+                local_account(&conn, NOW).expect("mint")
+            })
+        };
+        let first = spawn();
+        let second = spawn();
+        let a = first.join().unwrap();
+        let b = second.join().unwrap();
+        assert_eq!(a, b, "both first-callers converge on one account");
+
+        let conn = Connection::open(&path).unwrap();
+        assert_eq!(genesis_row_count(&conn), 1, "the pointer race admits exactly one genesis");
+        assert_eq!(pointer_row_count(&conn), 1, "exactly one pointer row");
+    }
+}

--- a/crates/rag-rat-core/src/oplog/account/mod.rs
+++ b/crates/rag-rat-core/src/oplog/account/mod.rs
@@ -15,6 +15,7 @@
 //! - [`id`]: [`AccountId`] + the §4 genesis commitment.
 //! - [`limits`]: §18a protocol-validity constants + the account-layer domain strings.
 //! - [`envelope`]: the 13-part signed account-entry envelope (§6).
+mod bootstrap;
 mod candidate;
 mod content;
 mod cut;
@@ -26,6 +27,7 @@ mod ops;
 mod registers;
 mod storage;
 
+pub(crate) use bootstrap::local_account;
 #[allow(unused_imports, reason = "C2 contract is frozen before transport wiring lands")]
 pub(in crate::oplog) use content::{
     ContentCapacityScope, ContentEntryHeader, ContentIngestOutcome, SignedContentEntry,

--- a/crates/rag-rat-core/src/oplog/account/storage.rs
+++ b/crates/rag-rat-core/src/oplog/account/storage.rs
@@ -45,8 +45,11 @@ struct AccountProjection {
     forked: HashSet<EntryHash>,
 }
 
+/// The outcome of an `INSERT OR IGNORE` into the candidate DAG. `pub(super)` so the account
+/// [`super::bootstrap`] seam can reuse [`insert_candidate`] directly when minting the local-account
+/// genesis (it MUST NOT go through the self-transacting [`account_ingest`]).
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum CandidateInsert {
+pub(super) enum CandidateInsert {
     Inserted,
     AlreadyPresent,
     AtCapacity(CapacityScope),
@@ -872,7 +875,9 @@ fn decode_stored_boundary(
 }
 
 /// The refold body (caller owns the txn). Returns each entry_hash → its projected status.
-fn refold_in_tx(
+/// `pub(super)` so [`super::bootstrap`] can fold its freshly-inserted local-account genesis inside
+/// the same mint transaction, rather than nesting the self-transacting [`refold_account`].
+pub(super) fn refold_in_tx(
     tx: &Transaction<'_>,
     account_id: AccountId,
 ) -> anyhow::Result<HashMap<[u8; 32], String>> {
@@ -1246,7 +1251,10 @@ fn load_candidates(conn: &Connection, account_id: AccountId) -> anyhow::Result<V
     Ok(out)
 }
 
-fn insert_candidate(
+/// Insert one verified entry into the candidate DAG under the caller's txn, enforcing the
+/// operational admission budgets. `pub(super)` so [`super::bootstrap`] can store its local-account
+/// genesis through the same seam the ingest path uses.
+pub(super) fn insert_candidate(
     tx: &Transaction<'_>,
     verified: &VerifiedAccountEntry,
     signed_bytes: &[u8],

--- a/crates/rag-rat-core/src/oplog/mod.rs
+++ b/crates/rag-rat-core/src/oplog/mod.rs
@@ -45,6 +45,14 @@ mod stream;
 // C1's curated authority seam for the C2 `/3` content envelope and candidate DAG. The account
 // implementation stays private; only typed ingest results and snapshot-consistent point queries
 // cross the phase boundary.
+// C3.4a's local-account mint (#662): the store-global principal later C3.4 slices author
+// owner-bound /3 content under. Unused until that caller lands, so the re-export is `expect`'d
+// like the seam above.
+#[expect(
+    unused_imports,
+    reason = "C3.4a local account mint is frozen before its caller lands"
+)]
+pub(crate) use account::local_account;
 #[expect(unused_imports, reason = "C2 authority seam is frozen before its caller lands")]
 pub(crate) use account::{
     AccountId, AuthorityBoundary, AuthorityFreshness, AuthorityInvalidReason, AuthorityQuery,


### PR DESCRIPTION
First slice of C3.4 (#662, milestone #19). Turns on the account machinery in the live path for the first time.

## What

`local_account(conn, now_ms) -> AccountId` — the store-global principal this install authors under. Mints ONE self-authorizing seq-0 `AccountGenesis` (founder = the local device) on first use, pinned by a new single-row `oplog_local_account` pointer table (migration **V069**), and returns it stably thereafter. Genesis-only, as scoped — the general non-genesis account-op seam (StreamOwn, …) is #664.

It reuses the account layer's own `insert_candidate` + `refold_in_tx` seams (widened to `pub(super)`) inside one IMMEDIATE txn — **not** `account_ingest`, which self-transacts (its own `BEGIN IMMEDIATE`) and can't nest.

## Race safety (the load-bearing part)

Two geneses = two permanent, unrecoverable account identities. Each mint draws a fresh nonce, so racing first-callers propose **distinct** accounts; convergence comes only from the pointer:

- Under the writer lock, the pointer is re-checked and adopted if present (author nothing).
- Otherwise the pointer insert **gates** the genesis insert (author only if our hash won), and pointer + genesis commit in **one txn** — so a durably-committed pointer always names an accepted genesis, and incumbent adoption is unconditionally safe.
- The genesis is verified to fold **effective** (not merely inserted) or the whole txn rolls back — never a wedged account.

A threaded two-connection convergence test proves two first-callers land on one account with exactly one genesis row; **mutation-verified** — disabling both race gates makes that test fail with two geneses.

## Migration V069

`oplog_local_account` single-row STRICT table (`CHECK(id=0)`, 32-byte hash). Full ceremony: all three recognizers armed, `LATEST_SCHEMA_VERSION` 68→69, `ADDITIVE_MIGRATIONS` + consts, tip pin moved onto the new V069 test.

## Validation

`cargo nextest run -p rag-rat-core` — 2,494 passed. Clippy with CI's exact invocations on the 1.96 toolchain; `cargo +nightly fmt --all --check`. 5 new bootstrap tests (idempotency, effective-fold, id resolution, in-tx adopt gate, threaded convergence) + V068/V069 migration tests. Codex review clean.

Refs #606