### PR TITLE
feat(account): add the /3 local-content authoring seam + accepted→memory projection

### DIFF
--- a/crates/rag-rat-core/src/index/ai/providers/fastembed.rs
+++ b/crates/rag-rat-core/src/index/ai/providers/fastembed.rs
@@ -43,8 +43,9 @@ impl FastEmbedEmbedder {
             .with_show_download_progress(true);
         // `ort_threads` caps the ONNX Runtime intra-op thread pool. Microsoft's prebuilt ORT
         // binaries (what fastembed downloads) are OpenMP-based, where this has no effect and
-        // OMP_NUM_THREADS (set from `omp_threads`) is the lever instead — see docs/config/embedding.md.
-        // We still apply it so non-OpenMP builds honor the configured cap.
+        // OMP_NUM_THREADS (set from `omp_threads`) is the lever instead — see
+        // docs/config/embedding.md. We still apply it so non-OpenMP builds honor the
+        // configured cap.
         if let Some(threads) = intra_threads.filter(|threads| *threads > 0) {
             options = options.with_intra_threads(threads);
         }

--- a/crates/rag-rat-core/src/index/schema/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema/migrations.rs
@@ -1267,6 +1267,7 @@ pub(crate) fn known_version(migrations: &[AppliedMigration]) -> u32 {
             MIGRATION_067_ID => Some(67),
             MIGRATION_068_ID => Some(68),
             MIGRATION_069_ID => Some(69),
+            MIGRATION_070_ID => Some(70),
             _ => None,
         })
         .max()
@@ -1345,6 +1346,7 @@ pub(crate) fn known_migration(id: &str) -> bool {
             | MIGRATION_067_ID
             | MIGRATION_068_ID
             | MIGRATION_069_ID
+            | MIGRATION_070_ID
             | DIRTY_MIGRATION_ID
     )
 }
@@ -1420,6 +1422,7 @@ pub(crate) fn migration_checksum_mismatch(migration: &AppliedMigration) -> bool 
         MIGRATION_067_ID => migration.checksum != MIGRATION_067_CHECKSUM,
         MIGRATION_068_ID => migration.checksum != MIGRATION_068_CHECKSUM,
         MIGRATION_069_ID => migration.checksum != MIGRATION_069_CHECKSUM,
+        MIGRATION_070_ID => migration.checksum != MIGRATION_070_CHECKSUM,
         _ => false,
     }
 }
@@ -4485,6 +4488,39 @@ pub(crate) fn apply_oplog_local_account(conn: &Connection) -> rusqlite::Result<(
              id                 INTEGER PRIMARY KEY CHECK (id = 0),
              genesis_entry_hash BLOB NOT NULL CHECK (length(genesis_entry_hash) = 32),
              created_at_ms      INTEGER NOT NULL
+         ) STRICT;",
+    )
+}
+
+/// V070 (sync phase C3.4b-i): the accepted-`/3` → memory projection tables.
+/// `content_projected_nodes` / `content_projected_edges` mirror the `/1` shadow tables
+/// `oplog_projected_nodes` / `oplog_projected_edges` (stream-keyed since V053) but materialize the
+/// acceptance-gated `/3` DAG: [`crate::oplog::reproject_accepted_content_stream`] decodes each
+/// `content_entries` row where `accepted = 1`, folds via the shared memory projector, and rewrites
+/// the keyed rows for one `/2` stream. Kept SEPARATE from the `/1` tables on purpose (decision 7):
+/// the `/1` projector sweep (`store::reproject_all_streams`) `DELETE`s the `oplog_projected_*`
+/// tables wholesale and rebuilds only streams present in `oplog_entries`, so sharing them would let
+/// a projector-version bump wipe the `/3` projection and never rebuild it — mass duplicate
+/// re-authoring into the immutable `/3` log. These tables are owned by the memory layer and updated
+/// only when acceptance changes (the content refold), never by the `/1` sweep. Purely additive;
+/// `CREATE ... IF NOT EXISTS`, so a torn replay reconverges without a wrapping transaction; nothing
+/// pre-existing to backfill.
+pub(crate) fn apply_content_projected_tables(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS content_projected_nodes(
+             stream_id    BLOB NOT NULL,
+             node_id      TEXT NOT NULL,
+             content_json TEXT NOT NULL,
+             status       TEXT NOT NULL,
+             PRIMARY KEY(stream_id, node_id)
+         ) STRICT;
+
+         CREATE TABLE IF NOT EXISTS content_projected_edges(
+             stream_id     BLOB NOT NULL,
+             edge_key      TEXT NOT NULL,
+             spec_json     TEXT NOT NULL,
+             resolved_json TEXT,
+             PRIMARY KEY(stream_id, edge_key)
          ) STRICT;",
     )
 }

--- a/crates/rag-rat-core/src/index/schema/mod.rs
+++ b/crates/rag-rat-core/src/index/schema/mod.rs
@@ -19,7 +19,7 @@ pub use registry::{LEGACY_REPO_ID, RegisteredRepo, register_repo, register_repo_
 use rusqlite::{Connection, OptionalExtension, Transaction, TransactionBehavior, params};
 use serde::Serialize;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 69;
+pub const LATEST_SCHEMA_VERSION: u32 = 70;
 
 /// Every oracle-DERIVED persisted table — the outputs an `oracle run` writes that must OUTLIVE a
 /// reindex.
@@ -479,6 +479,14 @@ const MIGRATION_069_DESCRIPTION: &str =
      the genesis_entry_hash of this store's one local account, minted once by local_account and \
      reused so later C3.4 slices author owner-bound /3 content under a stable identity. \
      Store-global, not repo-scoped; purely additive, nothing pre-existing to backfill";
+const MIGRATION_070_ID: &str = "070_content_projected_tables";
+const MIGRATION_070_CHECKSUM: &str = "sha256:rag-rat-content-projected-tables-v70";
+const MIGRATION_070_DESCRIPTION: &str =
+    "Add content_projected_nodes/content_projected_edges (sync phase C3.4b-i): the stream-keyed \
+     memory projection of the accepted /3 content DAG, mirroring the /1 oplog_projected_* shadow \
+     tables but updated only when acceptance changes (the content refold), never by the /1 \
+     projector sweep — kept separate so a projector-version bump cannot wipe the /3 projection. \
+     Purely additive, nothing pre-existing to backfill";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -1054,6 +1062,12 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         checksum: MIGRATION_069_CHECKSUM,
         description: MIGRATION_069_DESCRIPTION,
         apply: apply_oplog_local_account,
+    },
+    Migration {
+        id: MIGRATION_070_ID,
+        checksum: MIGRATION_070_CHECKSUM,
+        description: MIGRATION_070_DESCRIPTION,
+        apply: apply_content_projected_tables,
     },
 ];
 

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
@@ -2076,10 +2076,16 @@ fn migration_068_hides_suppressed_edge_candidates() {
 }
 
 #[test]
-fn migration_069_is_the_tip_and_adds_the_local_account_pointer() {
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 69, "move this pin with the next schema migration");
+fn migration_069_adds_the_local_account_pointer() {
+    // The absolute-tip pin moved to `migration_070_*` (V070 is the tip now); this drops to the
+    // symbolic `current_version == LATEST` freshness check, per the ladder convention.
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     schema::apply(&conn).unwrap();
+    assert_eq!(
+        schema::status(&conn).unwrap().current_version,
+        schema::LATEST_SCHEMA_VERSION,
+        "schema at LATEST after apply",
+    );
 
     // The single-row pointer table exists with its full column set.
     for column in ["id", "genesis_entry_hash", "created_at_ms"] {
@@ -2156,6 +2162,84 @@ fn migration_069_is_the_tip_and_adds_the_local_account_pointer() {
         )
         .unwrap();
     assert_eq!(v69_recorded, 1, "the forward migration records V069");
+}
+
+#[test]
+fn migration_070_is_the_tip_and_adds_the_content_projected_tables() {
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 70, "move this pin with the next schema migration");
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn).unwrap();
+
+    // Both /3 projection tables exist with their full column set, mirroring the stream-keyed /1
+    // shadow tables (V053).
+    for column in ["stream_id", "node_id", "content_json", "status"] {
+        assert!(
+            conn_table_columns(&conn, "content_projected_nodes").contains(&column.to_string()),
+            "V070 gives content_projected_nodes its {column} column",
+        );
+    }
+    for column in ["stream_id", "edge_key", "spec_json", "resolved_json"] {
+        assert!(
+            conn_table_columns(&conn, "content_projected_edges").contains(&column.to_string()),
+            "V070 gives content_projected_edges its {column} column",
+        );
+    }
+
+    // The primary key is the composite (stream_id, node_id) / (stream_id, edge_key): the SAME
+    // (node_id / edge_key) may recur under a DIFFERENT stream, but a duplicate under one stream is
+    // refused — the stream-keying that keeps two /2 streams' projections from colliding.
+    conn.execute(
+        "INSERT INTO content_projected_nodes(stream_id, node_id, content_json, status)
+         VALUES (zeroblob(32), 'n1', '{}', 'active')",
+        [],
+    )
+    .expect("first node row inserts");
+    conn.execute(
+        "INSERT INTO content_projected_nodes(stream_id, node_id, content_json, status)
+         VALUES (randomblob(32), 'n1', '{}', 'active')",
+        [],
+    )
+    .expect("the same node_id under a different stream is a distinct row");
+    assert!(
+        conn.execute(
+            "INSERT INTO content_projected_nodes(stream_id, node_id, content_json, status)
+             VALUES (zeroblob(32), 'n1', '{}', 'active')",
+            [],
+        )
+        .is_err(),
+        "the (stream_id, node_id) primary key rejects a duplicate within one stream",
+    );
+
+    // Deferred-absence in ISOLATION: a bare DB lacks the tables until the V070 applier runs, and a
+    // replay is an idempotent no-op (CREATE ... IF NOT EXISTS).
+    let isolated = rusqlite::Connection::open_in_memory().unwrap();
+    assert!(
+        !conn_table_exists(&isolated, "content_projected_nodes"),
+        "bare DB lacks content_projected_nodes before the isolated apply",
+    );
+    schema::apply_content_projected_tables(&isolated).unwrap();
+    schema::apply_content_projected_tables(&isolated).expect("replay is a no-op");
+    assert!(
+        conn_table_columns(&isolated, "content_projected_edges").contains(&"spec_json".to_string()),
+        "the isolated applier recreates the tables",
+    );
+
+    // A forward migrate over a ledger truncated below V070 replays the step and records V070.
+    truncate_schema_to(&conn, 69);
+    schema::migrate_forward(&conn).unwrap();
+    assert_eq!(
+        schema::status(&conn).unwrap().current_version,
+        schema::LATEST_SCHEMA_VERSION,
+        "forward migrate reaches the tip",
+    );
+    let v70_recorded: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM schema_version WHERE id = '070_content_projected_tables'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(v70_recorded, 1, "the forward migration records V070");
 }
 
 #[test]

--- a/crates/rag-rat-core/src/oplog/account/bootstrap.rs
+++ b/crates/rag-rat-core/src/oplog/account/bootstrap.rs
@@ -158,6 +158,27 @@ fn mint_local_account_in_tx(tx: &Transaction<'_>, now_ms: i64) -> anyhow::Result
     }
 }
 
+/// This store's local account resolved from the pointer: its `account_id` and the `genesis_hash`
+/// that names its self-authorizing genesis (the roster_ref an owner-authored `/3` entry cites).
+pub(super) struct LocalAccountRef {
+    pub(super) account_id: AccountId,
+    pub(super) genesis_hash: [u8; 32],
+}
+
+/// Resolve the already-minted local account from the pointer WITHOUT minting — the in-tx content
+/// author seam needs both the `account_id` (the `/3` `author_account_id`) and the genesis entry
+/// hash (its `roster_ref`), reading whatever snapshot `conn` is already in. `None` when no account
+/// has been minted yet: [`local_account`] (which self-transacts and cannot nest) is the mint path,
+/// so a caller authoring `/3` content inside its own IMMEDIATE txn must have minted the account
+/// first.
+pub(super) fn local_account_ref(conn: &Connection) -> anyhow::Result<Option<LocalAccountRef>> {
+    let Some(genesis_hash) = read_pointer_hash(conn)? else {
+        return Ok(None);
+    };
+    let account_id = resolve_account_for_genesis(conn, &genesis_hash)?;
+    Ok(Some(LocalAccountRef { account_id, genesis_hash }))
+}
+
 /// Resolve this store's local account from the pointer, or `None` if none is minted yet. The
 /// pointer is a content address; the account_id is recovered by looking the genesis up in the
 /// candidate DAG (§4 commits the account_id inside the genesis payload, so this is the one true
@@ -166,6 +187,16 @@ fn read_local_account(conn: &Connection) -> anyhow::Result<Option<AccountId>> {
     let Some(genesis_hash) = read_pointer_hash(conn)? else {
         return Ok(None);
     };
+    Ok(Some(resolve_account_for_genesis(conn, &genesis_hash)?))
+}
+
+/// Recover the account_id the pointer names by looking its genesis up in the candidate DAG (§4
+/// commits the account_id inside the genesis payload, so this is the one true id). A pointer naming
+/// a genesis absent from `account_entries` is a corrupted pointer and errors.
+fn resolve_account_for_genesis(
+    conn: &Connection,
+    genesis_hash: &[u8; 32],
+) -> anyhow::Result<AccountId> {
     let account_bytes: Vec<u8> = conn
         .query_row(
             "SELECT account_id FROM account_entries WHERE entry_hash = ?1",
@@ -181,7 +212,7 @@ fn read_local_account(conn: &Connection) -> anyhow::Result<Option<AccountId>> {
         .as_slice()
         .try_into()
         .map_err(|_| anyhow::anyhow!("stored account_id is not exactly 32 bytes"))?;
-    Ok(Some(AccountId::from_bytes(account_id)))
+    Ok(AccountId::from_bytes(account_id))
 }
 
 /// Read the single-row pointer's genesis hash, or `None` when no account has been minted.

--- a/crates/rag-rat-core/src/oplog/account/content/author.rs
+++ b/crates/rag-rat-core/src/oplog/account/content/author.rs
@@ -1,0 +1,528 @@
+//! The in-tx `/3` content-author seam (sync phase C3.4b-i, #663).
+//!
+//! The local writer's counterpart to the `/1` trio in [`crate::oplog::store`]
+//! (`author_in_tx` / `author_batch_in_tx` / `author_genesis_in_tx`): it authors a batch of
+//! [`MemoryOp`]s as **owner-authored** `/3` content on one `/2` stream, inside the caller's
+//! IMMEDIATE transaction, minting each entry from the local chain tail. It is the LOCAL-authoring
+//! path, kept deliberately distinct from [`super::storage::content_ingest`] — the REMOTE-input path
+//! — which self-transacts, is §18b quota-capped, and refolds per entry. Local authoring stays
+//! linear (§16.2): a single local writer from the accepted tail, quota-free, one refold per batch.
+//!
+//! OWNER-AUTHORED. The store's local account (author) is also the owner of its `/2` streams, so
+//! every entry carries `grant_id = None` and `roster_ref` = the account's own genesis entry hash
+//! (the roster the founder device is enrolled under). `owner_auth_len == author_auth_len ==` the
+//! account's current control-fold `effective_count`, read in the SAME snapshot as authoring —
+//! citing our own current fold length means our entries never park `auth_len_ahead` against our own
+//! fold.
+//!
+//! `lamport = seq`. The seq is dense and monotone under the single local writer, and it IS the
+//! projection LWW key ([`crate::oplog::project`] orders on `(lamport, device)`); a non-monotone
+//! value would let a `NodeUpdate` lose to its own earlier `NodeCreate`.
+//!
+//! VERIFY-ACCEPTED. After the single batch refold, the seam reads back each authored entry's status
+//! and `bail!`s if any is not `accepted`, so the whole batch — and the mutation that triggered it —
+//! rolls back. A local entry CAN park/declassify (a missing `StreamOwn`, a stale `auth_len`, a
+//! contested account), and a silently-stored unaccepted entry would desync the candidate tail from
+//! the accepted tail and self-fork the next author's seq. Enforcing accept-or-rollback INDUCES the
+//! invariant that no unaccepted local candidate ever survives a commit — which is exactly why
+//! minting from the plain candidate tail (below) is the accepted tail.
+
+use anyhow::Context;
+use rusqlite::{OptionalExtension, Transaction, params};
+
+use super::super::bootstrap::{self, LocalAccountRef};
+use super::super::{AccountId, storage as account_storage};
+use super::envelope::{self, ContentEntryHeader, VerifiedContentEntry};
+use super::storage as content_storage;
+use crate::oplog::op::{self, DeviceFingerprint, MemoryOp};
+use crate::oplog::stream::StreamId;
+use crate::oplog::{content_projection, local_device};
+
+type EntryHash = [u8; 32];
+
+/// The `/3` chain tail for one `(stream, author, device)` coordinate: its highest-`seq` entry.
+struct ContentChainTail {
+    seq: u64,
+    entry_hash: EntryHash,
+}
+
+/// Author `ops` as owner-authored `/3` content on `stream_id` WITHIN the caller's transaction:
+/// chain each entry from the current tail (genesis when the chain is empty), insert it as a
+/// candidate, refold the stream ONCE, then verify every entry folded `accepted` — else `bail!` so
+/// the whole batch rolls back. Neither opens nor commits the txn. Returns the authored entry hashes
+/// in authoring order. Requires the store's local account to be minted already (see
+/// [`bootstrap::local_account`]); the caller mints it before opening this txn (that mint
+/// self-transacts and cannot nest here).
+pub(crate) fn author_content_batch_in_tx(
+    tx: &Transaction<'_>,
+    stream_id: StreamId,
+    ops: &[MemoryOp],
+    now_ms: i64,
+) -> anyhow::Result<Vec<EntryHash>> {
+    // Owner-authored: the store's single local account is both author and owner. Resolve it (and
+    // its genesis entry hash, the `roster_ref`) from the pointer WITHOUT minting — the account
+    // must already exist.
+    let LocalAccountRef { account_id, genesis_hash } = bootstrap::local_account_ref(tx)?.context(
+        "cannot author /3 content before the store's local account is minted (call local_account \
+         first)",
+    )?;
+    let device = local_device(tx, now_ms)?;
+    let fingerprint = device.fingerprint();
+    // The freshness seam, read in THIS snapshot (see the module header): cite our own current
+    // effective control-fold length as both auth_len fields.
+    let auth_len = account_storage::account_effective_count(tx, account_id)?;
+
+    let mut authored = Vec::with_capacity(ops.len());
+    for op in ops {
+        // Mint from the candidate tail. Under verify-accepted+rollback the candidate tail IS the
+        // accepted tail, so no separate accepted-tail read is needed; the in-txn read sees the
+        // entries this loop already inserted, so each op chains off the one before it.
+        let (seq, prev_hash) = match content_chain_tail(tx, stream_id, account_id, fingerprint)? {
+            Some(tail) => (
+                tail.seq
+                    .checked_add(1)
+                    .context("/3 content chain tail is at u64::MAX seq; cannot extend")?,
+                Some(tail.entry_hash),
+            ),
+            None => (0, None),
+        };
+        let header = ContentEntryHeader {
+            stream_id,
+            author_account_id: account_id,
+            device_fingerprint: fingerprint,
+            seq,
+            // Monotone with seq — it is the projection LWW key (see the module header).
+            lamport: seq,
+            prev_hash,
+            // Owner-authored: author == owner, so no delegated grant.
+            grant_id: None,
+            roster_ref: genesis_hash,
+            owner_auth_len: auth_len,
+            author_auth_len: auth_len,
+            crypto_suite: 0,
+            key_id: None,
+        };
+        // The `/3` body is the op's canonical CBOR verbatim (an opaque bstr the projection later
+        // `op::decode`s). No `candidate_capacity` check: that is the §18b remote-abuse budget, not
+        // a local-authoring bound.
+        let payload = op::encode(op);
+        let signed = envelope::sign_content_entry(device.secret(), &header, &payload)?;
+        let verified = VerifiedContentEntry {
+            header: signed.header,
+            payload: signed.payload,
+            header_bytes: signed.header_bytes,
+            entry_hash: signed.entry_hash,
+        };
+        content_storage::insert_candidate(tx, &verified, &signed.signed_bytes, now_ms)?;
+        authored.push(verified.entry_hash);
+    }
+
+    // ONE authority+branch refold for the whole batch (§16.2), the only writer of `accepted = 1`.
+    content_storage::refold_content_stream(tx, stream_id)?;
+
+    // verify-accepted: an owner authoring on its own stream accepts, so anything else means an
+    // authority gap (missing `StreamOwn`, stale `auth_len`, contested account). Roll the batch back
+    // rather than leave an unaccepted local candidate the next author's seq would collide with.
+    for entry_hash in &authored {
+        match content_status(tx, entry_hash)?.as_deref() {
+            Some("accepted") => {},
+            other => anyhow::bail!(
+                "authored /3 content entry did not fold accepted (status {other:?}); rolling back \
+                 the batch",
+            ),
+        }
+    }
+
+    // Acceptance changed on this stream → refresh its accepted-/3 → memory projection in the same
+    // txn (the memory-layer fold that decodes op bodies; the acceptance layer is body-agnostic).
+    content_projection::reproject_accepted_content_stream(tx, stream_id)?;
+
+    Ok(authored)
+}
+
+/// The `(stream, author, device)` chain's highest-`seq` `/3` candidate, or `None` for an empty
+/// chain (→ genesis: seq 0, no predecessor). `seq` is stored as an 8-byte big-endian blob, so a
+/// blob `ORDER BY seq DESC` compares byte-wise and is numerically correct for the fixed width.
+fn content_chain_tail(
+    tx: &Transaction<'_>,
+    stream_id: StreamId,
+    author_account_id: AccountId,
+    device_fingerprint: DeviceFingerprint,
+) -> anyhow::Result<Option<ContentChainTail>> {
+    let row: Option<(Vec<u8>, Vec<u8>)> = tx
+        .query_row(
+            "SELECT seq, entry_hash FROM content_entries
+             WHERE stream_id = ?1 AND author_account_id = ?2 AND device_fingerprint = ?3
+             ORDER BY seq DESC LIMIT 1",
+            params![
+                stream_id.to_bytes().as_slice(),
+                author_account_id.to_bytes().as_slice(),
+                device_fingerprint.to_bytes().as_slice(),
+            ],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .optional()?;
+    row.map(|(seq, entry_hash)| {
+        let seq = u64::from_be_bytes(fixed::<8>(&seq)?);
+        Ok(ContentChainTail { seq, entry_hash: fixed::<32>(&entry_hash)? })
+    })
+    .transpose()
+}
+
+/// The current `/3` status of one entry, or `None` if the refold wrote no status row for it.
+fn content_status(
+    tx: &Transaction<'_>,
+    entry_hash: &EntryHash,
+) -> rusqlite::Result<Option<String>> {
+    tx.query_row(
+        "SELECT status FROM content_entry_status WHERE entry_hash = ?1",
+        [entry_hash.as_slice()],
+        |row| row.get(0),
+    )
+    .optional()
+}
+
+fn fixed<const N: usize>(bytes: &[u8]) -> anyhow::Result<[u8; N]> {
+    bytes.try_into().map_err(|_| anyhow::anyhow!("expected {N} bytes, got {}", bytes.len()))
+}
+
+#[cfg(test)]
+mod tests {
+    use rusqlite::{Connection, TransactionBehavior};
+
+    use super::*;
+    use crate::index::schema;
+    use crate::oplog::op::{EdgeSpec, NodeContent, NodeId};
+    use crate::query::memory::EdgeRelation;
+
+    const NOW: i64 = 1_700_000_000_000;
+    const STREAM_A: [u8; 32] = [0x44; 32];
+    const STREAM_B: [u8; 32] = [0x55; 32];
+
+    fn db() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        schema::apply(&conn).unwrap();
+        conn
+    }
+
+    /// Mint the store's local account, then seed the `StreamOwn` fact for `stream` the way the C3.3
+    /// acceptance tests do — `local_account` already folds the founder's roster fact (role owner)
+    /// and the `account_auth_state` freshness row, so ownership is the only fact left to seed for
+    /// an owner-authored entry to accept. Returns the local `account_id`.
+    fn owned_stream_account(conn: &Connection, stream: StreamId) -> AccountId {
+        let account_id = bootstrap::local_account(conn, NOW).expect("mint local account");
+        seed_ownership(conn, stream, account_id);
+        account_id
+    }
+
+    fn seed_ownership(conn: &Connection, stream: StreamId, owner: AccountId) {
+        conn.execute(
+            "INSERT INTO account_stream_ownership(stream_id, account_id, own_id, effective_at)
+             VALUES(?1, ?2, ?3, 1)",
+            params![
+                stream.to_bytes().as_slice(),
+                owner.to_bytes().as_slice(),
+                [0x66_u8; 32].as_slice()
+            ],
+        )
+        .unwrap();
+    }
+
+    fn content(title: &str) -> NodeContent {
+        NodeContent {
+            kind: "Invariant".to_string(),
+            title: title.to_string(),
+            body: "body".to_string(),
+            confidence: "high".to_string(),
+            source: "agent".to_string(),
+            tags: Vec::new(),
+            payload: None,
+        }
+    }
+
+    fn node_create(id: &str, title: &str) -> MemoryOp {
+        MemoryOp::NodeCreate { node_id: NodeId::from(id), content: content(title) }
+    }
+
+    fn node_update(id: &str, title: &str) -> MemoryOp {
+        MemoryOp::NodeUpdate { node_id: NodeId::from(id), content: content(title) }
+    }
+
+    fn edge_add(source: &str, anchor: &str) -> MemoryOp {
+        MemoryOp::EdgeAdd {
+            edge: EdgeSpec {
+                source_node_id: NodeId::from(source),
+                relation: EdgeRelation::DependsOn,
+                target_repo_id: "repo".to_string(),
+                target_kind: "node".to_string(),
+                target_anchor: anchor.to_string(),
+                owner_repo_id: "repo".to_string(),
+            },
+        }
+    }
+
+    /// Run the in-tx seam in its own IMMEDIATE txn and commit — the shape a live mutation uses.
+    fn author_committed(conn: &Connection, stream: StreamId, ops: &[MemoryOp]) -> Vec<EntryHash> {
+        let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate).unwrap();
+        let hashes = author_content_batch_in_tx(&tx, stream, ops, NOW).expect("author batch");
+        tx.commit().unwrap();
+        hashes
+    }
+
+    fn genesis_ref(conn: &Connection) -> EntryHash {
+        conn.query_row(
+            "SELECT genesis_entry_hash FROM oplog_local_account WHERE id = 0",
+            [],
+            |row| row.get::<_, Vec<u8>>(0),
+        )
+        .map(|bytes| fixed::<32>(&bytes).unwrap())
+        .unwrap()
+    }
+
+    fn tail(conn: &Connection, stream: StreamId, account: AccountId) -> Option<ContentChainTail> {
+        let fingerprint = local_device(conn, NOW).unwrap().fingerprint();
+        let tx = conn.unchecked_transaction().unwrap();
+        content_chain_tail(&tx, stream, account, fingerprint).unwrap()
+    }
+
+    fn stored_status(conn: &Connection, entry_hash: &EntryHash) -> Option<String> {
+        conn.query_row(
+            "SELECT status FROM content_entry_status WHERE entry_hash = ?1",
+            [entry_hash.as_slice()],
+            |row| row.get(0),
+        )
+        .optional()
+        .unwrap()
+    }
+
+    fn header_of(conn: &Connection, entry_hash: &EntryHash) -> ContentEntryHeader {
+        let signed_bytes: Vec<u8> = conn
+            .query_row(
+                "SELECT signed_bytes FROM content_entries WHERE entry_hash = ?1",
+                [entry_hash.as_slice()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        envelope::decode_content_signed(&signed_bytes).unwrap().header
+    }
+
+    #[test]
+    fn a_batch_authors_owner_content_that_folds_accepted_with_dense_seqs_and_lamport_eq_seq() {
+        let conn = db();
+        let stream = StreamId::from_bytes(STREAM_A);
+        let account = owned_stream_account(&conn, stream);
+
+        let hashes = author_committed(&conn, stream, &[
+            node_create("n1", "first"),
+            node_update("n1", "second"),
+        ]);
+        assert_eq!(hashes.len(), 2, "two ops author two entries");
+
+        // Every authored entry folds accepted.
+        for entry_hash in &hashes {
+            assert_eq!(stored_status(&conn, entry_hash).as_deref(), Some("accepted"));
+            let (accepted,): (i64,) = conn
+                .query_row(
+                    "SELECT accepted FROM content_entries WHERE entry_hash = ?1",
+                    [entry_hash.as_slice()],
+                    |row| Ok((row.get(0)?,)),
+                )
+                .unwrap();
+            assert_eq!(accepted, 1, "the entry carries accepted = 1");
+        }
+
+        // Dense seqs 0, 1 with lamport == seq (the projection LWW key).
+        for (ordinal, entry_hash) in hashes.iter().enumerate() {
+            let header = header_of(&conn, entry_hash);
+            assert_eq!(header.seq, ordinal as u64, "seqs are dense from 0");
+            assert_eq!(header.lamport, header.seq, "lamport == seq");
+            assert_eq!(header.grant_id, None, "owner-authored: no grant");
+            assert_eq!(header.roster_ref, genesis_ref(&conn), "roster_ref is the genesis hash");
+            assert_eq!(header.author_account_id, account, "authored under the local account");
+        }
+
+        // The tail advanced to the highest seq.
+        let advanced = tail(&conn, stream, account).expect("non-empty chain has a tail");
+        assert_eq!(advanced.seq, 1, "the tail advanced to seq 1");
+        assert_eq!(advanced.entry_hash, hashes[1], "the tail names the last authored entry");
+    }
+
+    #[test]
+    fn the_projection_fold_materializes_the_accepted_dag_keyed_by_stream() {
+        let conn = db();
+        let stream_a = StreamId::from_bytes(STREAM_A);
+        let account = owned_stream_account(&conn, stream_a);
+
+        // A NodeCreate/NodeUpdate/EdgeAdd batch on stream A: the update (seq 1, higher lamport)
+        // wins the node content register over the create (seq 0).
+        author_committed(&conn, stream_a, &[
+            node_create("n1", "created"),
+            node_update("n1", "updated"),
+            edge_add("n1", "n2"),
+        ]);
+
+        let (content_json, status): (String, String) = conn
+            .query_row(
+                "SELECT content_json, status FROM content_projected_nodes
+                 WHERE stream_id = ?1 AND node_id = ?2",
+                params![stream_a.to_bytes().as_slice(), "n1"],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .expect("stream A projects node n1");
+        assert!(content_json.contains("updated"), "the NodeUpdate content wins the LWW register");
+        assert!(!content_json.contains("created"), "the superseded create content is gone");
+        assert_eq!(status, "active", "default node status");
+
+        let edge_rows: i64 = conn
+            .query_row(
+                "SELECT count(*) FROM content_projected_edges WHERE stream_id = ?1",
+                params![stream_a.to_bytes().as_slice()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(edge_rows, 1, "the EdgeAdd projects one present edge");
+
+        // A SECOND stream (same local owner) authors its own node n1 — the stream-keying must keep
+        // the two projections from colliding.
+        let stream_b = StreamId::from_bytes(STREAM_B);
+        seed_ownership(&conn, stream_b, account);
+        author_committed(&conn, stream_b, &[node_create("n1", "b-only")]);
+
+        let b_content: String = conn
+            .query_row(
+                "SELECT content_json FROM content_projected_nodes
+                 WHERE stream_id = ?1 AND node_id = ?2",
+                params![stream_b.to_bytes().as_slice(), "n1"],
+                |row| row.get(0),
+            )
+            .expect("stream B projects its own node n1");
+        assert!(b_content.contains("b-only"), "stream B keeps its own content");
+
+        // Stream A's node n1 is untouched by stream B's authoring, and stream B has no edge rows.
+        let a_content_after: String = conn
+            .query_row(
+                "SELECT content_json FROM content_projected_nodes
+                 WHERE stream_id = ?1 AND node_id = ?2",
+                params![stream_a.to_bytes().as_slice(), "n1"],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(
+            a_content_after.contains("updated"),
+            "stream A's projection did not collide with B"
+        );
+        let b_edges: i64 = conn
+            .query_row(
+                "SELECT count(*) FROM content_projected_edges WHERE stream_id = ?1",
+                params![stream_b.to_bytes().as_slice()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(b_edges, 0, "stream B authored no edges");
+    }
+
+    #[test]
+    fn a_withheld_stream_own_makes_the_batch_roll_back_with_no_content_stored() {
+        let conn = db();
+        let stream = StreamId::from_bytes(STREAM_A);
+        // Mint the account but DO NOT seed ownership: with no `StreamOwn` fact the stream
+        // declassifies, the entries never accept, and verify-accepted must roll the whole batch
+        // back. Without verify-accepted this would silently store unaccepted /3 candidates.
+        let _account = bootstrap::local_account(&conn, NOW).expect("mint local account");
+
+        let tx = Transaction::new_unchecked(&conn, TransactionBehavior::Immediate).unwrap();
+        let result = author_content_batch_in_tx(&tx, stream, &[node_create("n1", "first")], NOW);
+        assert!(result.is_err(), "verify-accepted rejects an unaccepted batch");
+        drop(tx); // no commit → the IMMEDIATE txn rolls back
+
+        let stored: i64 =
+            conn.query_row("SELECT count(*) FROM content_entries", [], |row| row.get(0)).unwrap();
+        assert_eq!(stored, 0, "the rolled-back batch stored no /3 entry");
+        let projected: i64 = conn
+            .query_row("SELECT count(*) FROM content_projected_nodes", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(projected, 0, "no projection row survives the rollback");
+    }
+
+    #[test]
+    fn the_projection_skips_an_accepted_row_whose_body_is_not_a_decodable_op() {
+        let conn = db();
+        let stream = StreamId::from_bytes(STREAM_A);
+        let account = owned_stream_account(&conn, stream);
+        // A good accepted entry via the seam.
+        author_committed(&conn, stream, &[node_create("n1", "good")]);
+
+        // Inject a second accepted /3 row on the same stream whose signed ENVELOPE is valid but
+        // whose BODY is canonical CBOR that is not a `MemoryOp` — the shape a foreign entry could
+        // take, since the acceptance layer (§8) never decodes the body. `content_ingest` would have
+        // accepted it; the projection must SKIP it, not `bail!` and crash every later local author.
+        let device = local_device(&conn, NOW).unwrap();
+        let header = ContentEntryHeader {
+            stream_id: stream,
+            author_account_id: account,
+            device_fingerprint: device.fingerprint(),
+            seq: 99,
+            lamport: 99,
+            prev_hash: Some([0xab; 32]),
+            grant_id: None,
+            roster_ref: genesis_ref(&conn),
+            owner_auth_len: 0,
+            author_auth_len: 0,
+            crypto_suite: 0,
+            key_id: None,
+        };
+        // A bare canonical CBOR integer: decodes as CBOR, but is not the op envelope ⇒ `op::decode`
+        // errors (the path the fix must tolerate).
+        let signed = envelope::sign_content_entry(device.secret(), &header, &[0x01]).unwrap();
+        conn.execute(
+            "INSERT INTO content_entries(
+                 entry_hash, stream_id, author_account_id, device_fingerprint, seq, prev_hash,
+                 grant_id, roster_ref, owner_auth_len, author_auth_len, accepted, signed_bytes,
+                 received_at_ms)
+             VALUES(?1, ?2, ?3, ?4, ?5, ?6, NULL, ?7, ?8, ?8, 1, ?9, 0)",
+            params![
+                signed.entry_hash.as_slice(),
+                stream.to_bytes().as_slice(),
+                account.to_bytes().as_slice(),
+                device.fingerprint().to_bytes().as_slice(),
+                99_u64.to_be_bytes().as_slice(),
+                [0xab_u8; 32].as_slice(),
+                genesis_ref(&conn).as_slice(),
+                0_u64.to_be_bytes().as_slice(),
+                signed.signed_bytes,
+            ],
+        )
+        .unwrap();
+
+        // Reproject the stream: it must NOT error, and only the good node projects.
+        let tx = conn.unchecked_transaction().unwrap();
+        content_projection::reproject_accepted_content_stream(&tx, stream)
+            .expect("an undecodable body is skipped, not fatal");
+        tx.commit().unwrap();
+        let node_count: i64 = conn
+            .query_row(
+                "SELECT count(*) FROM content_projected_nodes WHERE stream_id = ?1",
+                params![stream.to_bytes().as_slice()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(node_count, 1, "only the decodable node projects; the bad body is skipped");
+    }
+
+    #[test]
+    fn the_chain_tail_reader_reports_genesis_for_an_empty_chain_and_the_head_when_populated() {
+        let conn = db();
+        let stream = StreamId::from_bytes(STREAM_A);
+        let account = owned_stream_account(&conn, stream);
+
+        // Empty chain ⇒ None (the seam's genesis gate: seq 0, prev None).
+        assert!(tail(&conn, stream, account).is_none(), "empty chain has no tail");
+
+        let hashes =
+            author_committed(&conn, stream, &[node_create("n1", "a"), node_create("n2", "b")]);
+
+        let head = tail(&conn, stream, account).expect("populated chain has a tail");
+        assert_eq!(head.seq, 1, "the tail seq is the highest authored seq");
+        assert_eq!(head.entry_hash, hashes[1], "the tail names the highest-seq entry");
+    }
+}

--- a/crates/rag-rat-core/src/oplog/account/content/mod.rs
+++ b/crates/rag-rat-core/src/oplog/account/content/mod.rs
@@ -1,10 +1,13 @@
 //! Owner-bound `/3` content entries (sync phase C2).
 
 mod acceptance;
+mod author;
 mod candidate;
 mod envelope;
 mod storage;
 
+// The in-tx `/3` local-authoring seam (C3.4b-i, #663) — frozen until the live memory path retargets
+// onto it (#664).
 #[allow(unused_imports, reason = "C3.1 freezes the pure evaluator before C3.2 storage wiring")]
 pub(crate) use acceptance::{
     AncestryRelation, CitedFreshness, CitedGrantAuthority, CitedOwnership, CitedRosterAuthority,
@@ -12,6 +15,11 @@ pub(crate) use acceptance::{
     ContentParkReason, ContentRejectReason, SubjectAuthorityHold, UnknownAncestry,
     evaluate_content_acceptance,
 };
+#[allow(
+    unused_imports,
+    reason = "C3.4b-i content-author seam is frozen before its caller lands"
+)]
+pub(crate) use author::author_content_batch_in_tx;
 pub(in crate::oplog) use envelope::{
     ContentEntryHeader, SignedContentEntry, VerifiedContentEntry, decode_content_signed,
     sign_content_entry, verify_content_signed,

--- a/crates/rag-rat-core/src/oplog/account/content/storage.rs
+++ b/crates/rag-rat-core/src/oplog/account/content/storage.rs
@@ -410,7 +410,13 @@ fn candidate_capacity(
     Ok(None)
 }
 
-fn insert_candidate(
+/// Insert one verified `/3` entry into the candidate DAG under the caller's txn (`accepted = 0`;
+/// authority acceptance is the refold's job). `pub(super)` so the in-tx content-author seam
+/// [`super::author`] can store its freshly-signed owner-authored entries through the same seam the
+/// ingest path uses — it MUST NOT go through the self-transacting [`content_ingest`] (it authors
+/// inside the caller's IMMEDIATE txn) and it deliberately skips [`candidate_capacity`] (the §18b
+/// remote-abuse budget, not a local-authoring bound).
+pub(super) fn insert_candidate(
     tx: &Transaction<'_>,
     entry: &VerifiedContentEntry,
     signed_bytes: &[u8],
@@ -594,7 +600,14 @@ fn content_entries_exists(tx: &Transaction<'_>) -> rusqlite::Result<bool> {
     .map(|row| row.is_some())
 }
 
-fn refold_content_stream(tx: &Transaction<'_>, stream_id: StreamId) -> anyhow::Result<()> {
+/// Re-derive `/3` acceptance for one stream from the current fold (the only writer of
+/// `accepted = 1`). `pub(super)` so the in-tx content-author seam [`super::author`] can fold the
+/// batch of owner-authored entries it just inserted — ONE refold per batch, then it verifies each
+/// entry came back `accepted` inside the same txn or rolls the whole batch back.
+pub(super) fn refold_content_stream(
+    tx: &Transaction<'_>,
+    stream_id: StreamId,
+) -> anyhow::Result<()> {
     // The owner is inside the stream identity (`stream_id = sha256(cbor([.., owner, ..]))`, §14)
     // but not invertible, so it is resolved through the owner's `StreamOwn` fact. No fact ⇒
     // authority cannot be evaluated: the entries revert to their structural state. This is a

--- a/crates/rag-rat-core/src/oplog/account/mod.rs
+++ b/crates/rag-rat-core/src/oplog/account/mod.rs
@@ -28,6 +28,13 @@ mod registers;
 mod storage;
 
 pub(crate) use bootstrap::local_account;
+// The in-tx `/3` content-author seam (C3.4b-i, #663) — frozen until #664 retargets the live
+// path.
+#[allow(
+    unused_imports,
+    reason = "C3.4b-i content-author seam is frozen before its caller lands"
+)]
+pub(crate) use content::author_content_batch_in_tx;
 #[allow(unused_imports, reason = "C2 contract is frozen before transport wiring lands")]
 pub(in crate::oplog) use content::{
     ContentCapacityScope, ContentEntryHeader, ContentIngestOutcome, SignedContentEntry,

--- a/crates/rag-rat-core/src/oplog/account/storage.rs
+++ b/crates/rag-rat-core/src/oplog/account/storage.rs
@@ -792,6 +792,27 @@ pub(crate) fn auth_len_freshness(
     })
 }
 
+/// This account's current effective control-fold length — the raw `effective_count`
+/// [`auth_len_freshness`] compares against, read from whatever snapshot `conn` is already in. The
+/// in-tx content-author seam stamps it as the `owner_auth_len`/`author_auth_len` it cites so its
+/// own entries never park `auth_len_ahead` against its own fold; it MUST be read in the SAME
+/// snapshot as the authoring txn, or a concurrent control-fold advance would let the citation
+/// straddle two folds. Zero for an account we hold nothing for (its facts resolve `Unknown` long
+/// before freshness).
+pub(crate) fn account_effective_count(
+    conn: &Connection,
+    account_id: AccountId,
+) -> anyhow::Result<u64> {
+    let effective_count: Option<i64> = conn
+        .query_row(
+            "SELECT effective_count FROM account_auth_state WHERE account_id = ?1",
+            [account_id.to_bytes().as_slice()],
+            |row| row.get(0),
+        )
+        .optional()?;
+    Ok(effective_count.map(u64::try_from).transpose()?.unwrap_or_default())
+}
+
 fn missing_reference<T>(
     conn: &Connection,
     account_id: AccountId,

--- a/crates/rag-rat-core/src/oplog/content_projection.rs
+++ b/crates/rag-rat-core/src/oplog/content_projection.rs
@@ -1,0 +1,133 @@
+//! The accepted-`/3` → memory projection fold (sync phase C3.4b-i, #663).
+//!
+//! The `/3` acceptance layer classifies signed envelopes; it never decodes op payloads, so it has
+//! no analog of the `/1` shadow projection ([`crate::oplog::store::reproject`]) — no anti-join, no
+//! ghost detection. This module is that missing fold: for one `/2` stream it loads the ACCEPTED
+//! `/3` entries (`content_entries WHERE accepted = 1`), [`op::decode`]s each body, folds them
+//! through the shared memory projector ([`project::project`]), and materializes the result into
+//! `content_projected_nodes` / `content_projected_edges` (V070), keyed by the `/2` stream. It is a
+//! MEMORY-layer concern (it decodes op bodies) reading the acceptance-gated set, so it lives here
+//! in the op-log memory layer alongside `store`/`project`, not inside the body-agnostic
+//! `account::content`.
+//!
+//! SEPARATE TABLES (decision 7). The `/3` projection is NOT written to the `/1` shadow tables. The
+//! `/1` projector sweep ([`crate::oplog::store::reproject`]'s `reproject_all_streams`) `DELETE`s
+//! the `oplog_projected_*` tables wholesale and rebuilds only streams present in `oplog_entries`,
+//! so a projector-version bump would wipe a shared `/3` projection and never rebuild it — mass
+//! duplicate re-authoring into the immutable `/3` log. These tables are owned by the memory layer
+//! and updated only when acceptance changes (the content refold — the local author seam, and later
+//! the ingest / account→content retro-triggers), never by the `/1` sweep.
+//!
+//! The projected `content_json` / `spec_json` / `resolved_json` reuse the `/1` shadow-row DTOs
+//! ([`crate::oplog::store::NodeContentRow`] et al.), so the two projections serialize identically.
+
+use anyhow::Context;
+use rusqlite::{Transaction, params};
+
+use super::account::decode_content_signed;
+use super::op::{self, DecodedOp, Entry, OpMeta};
+use super::project;
+use super::project::ProjectedState;
+use super::store::{EdgeSpecRow, NodeContentRow, ResolvedAnchorRow};
+use super::stream::StreamId;
+
+/// Re-derive the accepted-`/3` → memory projection for one `/2` stream from the CURRENT accepted
+/// set and rewrite its rows in both `/3` projection tables — another stream's rows are never
+/// touched. Runs inside the caller's txn; called right after `refold_content_stream` (acceptance
+/// changed), so the projection always reflects the just-committed accepted DAG.
+pub(in crate::oplog) fn reproject_accepted_content_stream(
+    tx: &Transaction<'_>,
+    stream_id: StreamId,
+) -> anyhow::Result<()> {
+    let entries = load_accepted_entries(tx, stream_id)?;
+    let state = project::project(&entries);
+    write_projection(tx, stream_id, &state)
+}
+
+/// Rewrite one stream's rows in `content_projected_nodes` / `content_projected_edges` — clear the
+/// stream's prior rows, then insert the folded state (mirrors [`crate::oplog::store::reproject`]).
+fn write_projection(
+    tx: &Transaction<'_>,
+    stream_id: StreamId,
+    state: &ProjectedState,
+) -> anyhow::Result<()> {
+    let stream_bytes = stream_id.to_bytes();
+    tx.execute("DELETE FROM content_projected_nodes WHERE stream_id = ?1", params![
+        stream_bytes.as_slice()
+    ])?;
+    tx.execute("DELETE FROM content_projected_edges WHERE stream_id = ?1", params![
+        stream_bytes.as_slice()
+    ])?;
+    for (node_id, node) in &state.nodes {
+        let content_json = serde_json::to_string(&NodeContentRow::from(&node.content))
+            .context("serialize projected /3 node content")?;
+        tx.execute(
+            "INSERT INTO content_projected_nodes(stream_id, node_id, content_json, status)
+             VALUES (?1, ?2, ?3, ?4)",
+            params![
+                stream_bytes.as_slice(),
+                node_id.as_str(),
+                content_json,
+                node.status.as_db_str()
+            ],
+        )?;
+    }
+    for (edge_key, edge) in &state.edges {
+        let spec_json = serde_json::to_string(&EdgeSpecRow::from(&edge.spec))
+            .context("serialize projected /3 edge spec")?;
+        let resolved_json = edge
+            .resolved
+            .as_ref()
+            .map(|resolved| serde_json::to_string(&ResolvedAnchorRow::from(resolved)))
+            .transpose()
+            .context("serialize projected /3 edge resolved anchor")?;
+        tx.execute(
+            "INSERT INTO content_projected_edges(stream_id, edge_key, spec_json, resolved_json)
+             VALUES (?1, ?2, ?3, ?4)",
+            params![stream_bytes.as_slice(), edge_key.as_str(), spec_json, resolved_json],
+        )?;
+    }
+    Ok(())
+}
+
+/// Load one stream's ACCEPTED `/3` entries as projector [`Entry`]s: decode the content envelope for
+/// its `lamport` + `device_fingerprint` (the `(lamport, device)` LWW order), then [`op::decode`]
+/// the body. An `Unknown` op is retained in the log but skipped here (mirrors
+/// [`crate::oplog::store`]'s `load_known_entries`), so a forward-version op never breaks the fold.
+fn load_accepted_entries(tx: &Transaction<'_>, stream_id: StreamId) -> anyhow::Result<Vec<Entry>> {
+    let mut stmt = tx.prepare(
+        "SELECT signed_bytes FROM content_entries
+         WHERE stream_id = ?1 AND accepted = 1
+         ORDER BY entry_hash", /* deterministic load order (the projector sorts internally
+                                * regardless) */
+    )?;
+    let rows =
+        stmt.query_map(params![stream_id.to_bytes().as_slice()], |row| row.get::<_, Vec<u8>>(0))?;
+    let mut entries = Vec::new();
+    for row in rows {
+        let signed_bytes = row?;
+        // The signed ENVELOPE decoded at ingest to become a candidate, so a failure here is
+        // corruption at rest — surface it loudly.
+        let signed = decode_content_signed(&signed_bytes)
+            .context("stored accepted /3 entry failed to decode")?;
+        // The BODY is an opaque bstr the acceptance layer never decodes (§8, body-agnostic), so an
+        // authorized+accepted entry can carry a malformed or wrong-domain payload (a foreign entry
+        // that `content_ingest` accepted without a body check). Skip an undecodable/unknown body
+        // like the `/1` fold skips a non-projectable op — never `bail!`, which would crash every
+        // later local author on this stream over one bad row.
+        let Ok(decoded) = op::decode(&signed.payload) else {
+            continue;
+        };
+        match decoded {
+            DecodedOp::Known(op) => entries.push(Entry {
+                meta: OpMeta {
+                    lamport: signed.header.lamport,
+                    device: signed.header.device_fingerprint,
+                },
+                op,
+            }),
+            DecodedOp::Unknown { .. } => {}, // retained in the log, not projected
+        }
+    }
+    Ok(entries)
+}

--- a/crates/rag-rat-core/src/oplog/mod.rs
+++ b/crates/rag-rat-core/src/oplog/mod.rs
@@ -34,6 +34,7 @@
 
 mod account;
 mod cbor;
+mod content_projection;
 mod device;
 mod entry;
 mod identity;
@@ -48,6 +49,14 @@ mod stream;
 // C3.4a's local-account mint (#662): the store-global principal later C3.4 slices author
 // owner-bound /3 content under. Unused until that caller lands, so the re-export is `expect`'d
 // like the seam above.
+// C3.4b-i's in-tx `/3` content-author seam (#663): the local writer that authors owner-bound
+// `/3` content on a `/2` stream, verify-accepted in the caller's txn. Frozen until #664
+// retargets the live memory path onto it.
+#[expect(
+    unused_imports,
+    reason = "C3.4b-i content-author seam is frozen before its caller lands"
+)]
+pub(crate) use account::author_content_batch_in_tx;
 #[expect(
     unused_imports,
     reason = "C3.4a local account mint is frozen before its caller lands"

--- a/crates/rag-rat-core/src/oplog/store.rs
+++ b/crates/rag-rat-core/src/oplog/store.rs
@@ -735,9 +735,12 @@ fn hash_from_vec(bytes: Vec<u8>) -> anyhow::Result<[u8; 32]> {
 
 // The shadow-table serialization DTOs. serde lives HERE, never on the frozen op-wire types (whose
 // wire is minicbor via `op::encode`); these tables are local, derived, and rebuilt wholesale.
+// `pub(super)` (= `pub(in crate::oplog)`): the `/3` accepted-content projection
+// ([`super::content_projection`]) writes `content_projected_nodes`/`_edges` with the SAME JSON
+// shape, so it reuses these DTOs rather than duplicating the row schema.
 
 #[derive(Serialize, Deserialize)]
-struct NodeContentRow {
+pub(super) struct NodeContentRow {
     kind: String,
     title: String,
     body: String,
@@ -776,7 +779,7 @@ impl From<NodeContentRow> for NodeContent {
 }
 
 #[derive(Serialize, Deserialize)]
-struct EdgeSpecRow {
+pub(super) struct EdgeSpecRow {
     source_node_id: String,
     relation: String,
     target_repo_id: String,
@@ -814,7 +817,7 @@ impl TryFrom<EdgeSpecRow> for EdgeSpec {
 }
 
 #[derive(Serialize, Deserialize)]
-struct ResolvedAnchorRow {
+pub(super) struct ResolvedAnchorRow {
     target_repo_id: String,
     target_node_id: Option<String>,
     anchor_status: String,


### PR DESCRIPTION
The substrate a later slice (#664) retargets the live memory-authoring path onto (#663, milestone #19). Three pieces, nothing beyond scope — StreamOwn authoring and the live-path retarget stay in #664; tests seed account authority the way the acceptance tests do.

## 1. In-tx `/3` content-author seam
`author_content_batch_in_tx` — the local writer's counterpart to the `/1` `author_*_in_tx` trio, **not** `content_ingest` (self-transacting, quota-capped, the remote-input path). Per op it mints an **owner-authored** `/3` entry (author == owner: `grant_id` null, `roster_ref` = the account genesis hash), chained from the candidate tail, `owner_auth_len == author_auth_len ==` our own current `effective_count`, `lamport = seq` (the projection LWW key). §18b quotas skipped (remote-abuse budget, not a local bound). One `refold_content_stream` per batch, then **verify-accepted**: any entry not `accepted` `bail!`s and rolls the whole batch back — so no unaccepted local candidate survives a commit, which makes the candidate tail the accepted tail. **Mutation-verified**: disabling verify-accepted makes the poisoned test (StreamOwn withheld) store unaccepted entries.

## 2. `/3` chain-tail reader + genesis gate
Highest-`seq` entry per `(stream, author, device)` (`seq` is an 8-byte BE blob), or genesis. `u64::MAX`-guarded.

## 3. Accepted-`/3` → memory projection (SEPARATE tables)
`oplog/content_projection.rs` writes **new V070** `content_projected_nodes`/`_edges` (stream-keyed) — never the `/1` shadow tables (whose wholesale sweep would wipe a shared `/3` projection). Loads `accepted=1`, decodes bodies, materializes per stream. The body is an opaque bstr the acceptance layer never decodes, so the fold **skips** an undecodable/unknown body rather than crash the author path (mutation-verified).

## Review resolution (Codex, 5 × P2 — all about the `/3` projection lifecycle)
- **Fixed here:** the fold now SKIPS an undecodable/foreign body instead of `bail!`ing (the one standalone landmine).
- **Tracked on #664** (the slice that makes the projection load-bearing; all four are unreachable in this local-only substrate — nothing but this seam authors `/3`, and verify-accepted admits no unaccepted local candidate): read the branch-selected accepted tail (not raw candidate max); a projector-version guard for the `/3` projection; backfill/rebuild-on-stale; and reproject at the common refold boundary (so retro-condemn / ownership-drop don't leave stale rows). See the #664 checklist.

## Validation
`cargo nextest run -p rag-rat-core` — 2,500 passed. Clippy with CI's exact invocations on 1.96; `cargo +nightly fmt --all --check`. V070 migration ceremony (all three recognizers, tip pin moved). 5 seam/projection/tail tests + the V070 migration test.

Refs #606