### PR TITLE
fix(watch): surface silently-dropped filesystem watch placements

### DIFF
--- a/crates/rag-rat-core/src/index/meta.rs
+++ b/crates/rag-rat-core/src/index/meta.rs
@@ -1,9 +1,14 @@
 //! Index key-value meta (the `index_meta` table) and the content-revision digest.
 
 use super::*;
-use crate::config::ResolvedTarget;
+use crate::config::{Config, ResolvedTarget};
+use crate::storage::IndexConnection;
 
 const WATCH_SHUTDOWN_RECONCILE_PENDING_META: &str = "watch_shutdown_reconcile_pending";
+/// Watch-placement failure HIGH-WATER MARK the resident watcher has seen (see `watch::placement`).
+/// Persisted per pass, never lowered, so `index_status` can surface silent inotify degradation
+/// without one watcher process masking another's (see `record_watch_placement_failures`).
+const WATCH_PLACEMENT_FAILURES_META: &str = "watch_placement_failures";
 const BASE_SCOPE_DISCOVERED_META: &str = "files_base_scope_discovered";
 
 impl IndexDatabase {
@@ -56,6 +61,37 @@ impl IndexDatabase {
         let conn = self.storage.connection();
         delete_repo_meta(conn, &self.active_repo_id, WATCH_SHUTDOWN_RECONCILE_PENDING_META)?;
         Ok(true)
+    }
+
+    /// Record the resident watcher's watch-placement failures as a HIGH-WATER MARK — raised only
+    /// when it exceeds the stored value, never lowered. Returns whether the stored value rose.
+    ///
+    /// Never lowered because several watcher processes can share this database (a checkout of one
+    /// repo can have more than one live watcher). A healthy or freshly-restarted watcher (whose
+    /// process-local source count is 0 or low) must not erase a degraded watcher's recorded
+    /// failures, so [`bump_repo_meta_high_water`] takes the max ATOMICALLY in one upsert — no
+    /// read-then-write to race. Once any watcher has degraded, `index_status` never falsely reports
+    /// zero. Trade-off: distinct processes dropping watches at once report the max, not the sum —
+    /// an acceptable under-count for a "watching is degraded" signal that never over- or
+    /// zero-reports.
+    pub(crate) fn record_watch_placement_failures(&self, failures: u64) -> anyhow::Result<bool> {
+        // Atomic max-upsert (a single statement) — never a read-then-write, so a concurrent
+        // same-repo writer cannot interleave and regress the high-water mark.
+        Ok(bump_repo_meta_high_water(
+            self.storage.connection(),
+            &self.active_repo_id,
+            WATCH_PLACEMENT_FAILURES_META,
+            failures,
+        )?)
+    }
+
+    /// The persisted watch-placement failure high-water mark (0 if never written — e.g. a repo
+    /// whose watcher has never dropped a watch, or a checkout with no resident watcher).
+    pub(crate) fn watch_placement_failures(&self) -> anyhow::Result<u64> {
+        Ok(self
+            .repo_meta(WATCH_PLACEMENT_FAILURES_META)?
+            .and_then(|value| value.parse::<u64>().ok())
+            .unwrap_or(0))
     }
 
     pub(super) fn active_base_scope_discovered(
@@ -180,6 +216,84 @@ pub(crate) fn repo_meta(
         |row| row.get(0),
     )
     .optional()
+}
+
+/// Atomically raise a per-repo INTEGER meta value to `value`, never lowering it — the max is
+/// computed IN the upsert (one statement), so two watcher processes recording failures for the same
+/// repo at once cannot interleave a read-then-write and regress the high-water mark. Returns
+/// whether the stored value rose (a fresh insert, or an increase). A same-or-lower `value` is a
+/// no-op.
+pub(crate) fn bump_repo_meta_high_water(
+    conn: &rusqlite::Connection,
+    repo_id: &str,
+    key: &str,
+    value: u64,
+) -> rusqlite::Result<bool> {
+    conn.execute(
+        "INSERT INTO repo_meta(repo_id, key, value) VALUES (?1, ?2, ?3)
+         ON CONFLICT(repo_id, key) DO UPDATE SET value = excluded.value
+             WHERE CAST(excluded.value AS INTEGER) > CAST(repo_meta.value AS INTEGER)",
+        params![repo_id, key, value.to_string()],
+    )?;
+    Ok(conn.changes() > 0)
+}
+
+/// Persist a watch-placement failure high-water mark for the watcher's out-of-band flush paths —
+/// the non-blocking post-resync flush on the event loop and the shutdown flush (#658 review). It is
+/// deliberately CHEAP, NON-BLOCKING, and SIDE-EFFECT-FREE:
+/// - **No index creation.** Returns early (no write) when the DB file does not exist, and opens
+///   NON-creating ([`IndexConnection::open_read_write_no_create_nowait`]) — a first-time-empty
+///   checkout that never built an index must not gain a schemaless `.rag-rat/index.sqlite` here.
+/// - **No blocking.** The no-wait open + `busy_timeout = 0` mean a concurrent writer (another repo
+///   in a consolidated DB, a checkpoint) yields `SQLITE_BUSY`, treated as SKIP — the event loop
+///   must never stall on classification/fleet triggers, and the count rides the next pass.
+/// - **No on-open heals.** Unlike `open_config` (schema migration, graph-index / model-manifest /
+///   generated-flags heals), so a degraded watcher exiting after a binary/schema-version change
+///   can't spend an unbounded heal here.
+///
+/// Config-SCOPED via [`schema::resolve_config_repo_id`] so it targets the SAME repo the pass's
+/// persist did, even in a consolidated multi-repo DB (a bare sole-repo pick could hit a sibling).
+/// Also skips when the repo isn't registered yet (nothing to surface into) or the schema isn't
+/// Compatible (the next full pass migrates + persists). The caller owns the per-repo write lock.
+///
+/// Returns whether the flush is SETTLED — `Ok(true)` means the count is now in the DB, or there is
+/// definitively nothing to persist into (no index file yet, repo not registered, schema not
+/// Compatible) so retrying is pointless; `Ok(false)` means a TRANSIENT `SQLITE_BUSY` skip, so the
+/// caller should retry (the event-loop drain re-attempts next tick). A non-busy error propagates.
+pub(crate) fn record_watch_placement_failures_scoped(
+    config: &Config,
+    failures: u64,
+) -> anyhow::Result<bool> {
+    // A first-time-empty checkout has no index yet: skip WITHOUT opening, so the flush never
+    // creates a schemaless DB file (which would break the friendly no-index read path). Settled — a
+    // later pass registers the repo and persists once real content appears.
+    if !config.database.try_exists().unwrap_or(false) {
+        return Ok(true);
+    }
+    match write_watch_placement_high_water(config, failures) {
+        Ok(()) => Ok(true),
+        // No-wait open/write: a busy DB (concurrent writer / checkpoint) is a TRANSIENT skip — the
+        // caller retries (the count rides the next tick, pass, sweep, or shutdown flush). A file
+        // that vanished in the race between the check above and the open surfaces as a non-busy
+        // open error, propagated for the caller to log (best-effort).
+        Err(err) if crate::storage::is_busy(&err) => Ok(false),
+        Err(err) => Err(err),
+    }
+}
+
+fn write_watch_placement_high_water(config: &Config, failures: u64) -> anyhow::Result<()> {
+    let storage = IndexConnection::open_read_write_no_create_nowait(&config.database)?;
+    let conn = storage.connection();
+    if schema::status(conn)?.state != schema::SchemaState::Compatible {
+        return Ok(());
+    }
+    let Some(repo_id) =
+        schema::resolve_config_repo_id(conn, &config.root, config.repo_id_override.as_deref())?
+    else {
+        return Ok(());
+    };
+    bump_repo_meta_high_water(conn, &repo_id, WATCH_PLACEMENT_FAILURES_META, failures)?;
+    Ok(())
 }
 
 /// Upsert a per-repo meta value into `repo_meta` (keyed by `(repo_id, key)`). The repo-scoped twin

--- a/crates/rag-rat-core/src/index/mod.rs
+++ b/crates/rag-rat-core/src/index/mod.rs
@@ -58,7 +58,9 @@ pub(crate) use git_context::*;
 pub(crate) use lifecycle::install_scope_view;
 pub use lifecycle::{GlobalStoreOverview, install_worktree_scope_view, resolve_scope_repo_id};
 pub(crate) use mem_diag::{maybe_set_sqlite_soft_heap_limit, mem_trace};
-pub(crate) use meta::{delete_repo_meta, repo_meta, set_repo_meta};
+pub(crate) use meta::{
+    delete_repo_meta, record_watch_placement_failures_scoped, repo_meta, set_repo_meta,
+};
 pub use parser_failures::ParserFailure;
 pub(crate) use prep::*;
 pub use query_api::{
@@ -229,6 +231,18 @@ pub struct IndexStatus {
     pub file_count_by_language: BTreeMap<String, u64>,
     pub parser_failures: u64,
     pub parser_failure_paths: Vec<ParserFailure>,
+    /// HIGH-WATER MARK of watch-placement failures — the MOST any single watcher lifetime has
+    /// recorded for this repo (a per-lifetime MAXIMUM, not a running sum across lifetimes: two
+    /// watcher runs that dropped 3 and 2 watches report 3, not 5). A degradation SIGNAL, not a
+    /// live "currently degraded" gauge. Nonzero means at least one directory has, at some
+    /// point, fallen back to the periodic sweep because its watch could not be placed (on
+    /// Linux, usually `fs.inotify.max_user_watches` exhaustion); it is worth investigating,
+    /// not proof that watches are dropped right now. Deliberately NEVER lowered — a healthy or
+    /// freshly-restarted watcher sharing the DB must not be able to erase a concurrently
+    /// degraded watcher's record — so it does NOT clear when the condition is fixed and
+    /// watches are re-placed cleanly; treat it as "has this index ever dropped a watch", not
+    /// "is it dropping them now". 0 only when no watcher has ever recorded a failed placement.
+    pub watch_placement_failures: u64,
     pub git_history: GitHistoryIndexStatus,
     pub papertrail: PapertrailStatus,
     pub llm: LlmStatus,

--- a/crates/rag-rat-core/src/index/query_api/mod.rs
+++ b/crates/rag-rat-core/src/index/query_api/mod.rs
@@ -79,6 +79,7 @@ impl IndexDatabase {
             file_count_by_language: counts,
             parser_failures: self.parser_failure_count()?,
             parser_failure_paths: self.parser_failure_paths()?,
+            watch_placement_failures: self.watch_placement_failures()?,
             git_history: self.git_history_status()?,
             papertrail: self.papertrail_status()?,
             llm: self.llm_status()?,

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/mod.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/mod.rs
@@ -940,4 +940,5 @@ mod repo_registry;
 mod schema_migrations;
 mod swift_corpus;
 mod symbol_search_lookup;
+mod watch_placement;
 mod worktree_overlay;

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/watch_placement.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/watch_placement.rs
@@ -1,0 +1,38 @@
+//! Watch-placement failure count round-trips through `repo_meta` into `IndexStatus` (#658), so a
+//! resident watcher's silently-dropped watches are observable rather than invisible.
+
+use super::*;
+
+#[test]
+fn index_status_surfaces_watch_placement_failures() {
+    let root = fixture_temp_root("held-mini");
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    // A fresh index has recorded no watch-placement failures.
+    assert_eq!(db.status(&config.database).unwrap().watch_placement_failures, 0);
+
+    // The watcher records a failure count during a pass; it must surface in status.
+    let changed = db.record_watch_placement_failures(3).unwrap();
+    assert!(changed, "first write of a non-zero count is a change");
+    assert_eq!(db.status(&config.database).unwrap().watch_placement_failures, 3);
+
+    // A repeated same-value write is a no-op (no WAL churn); the count is unchanged.
+    assert!(!db.record_watch_placement_failures(3).unwrap(), "same value is not a change");
+    assert_eq!(db.status(&config.database).unwrap().watch_placement_failures, 3);
+
+    // HIGH-WATER MARK: a LOWER count (a healthy or freshly-restarted watcher sharing this DB, whose
+    // process-local counter is 0 or low) must NOT erase a degraded watcher's recorded failures.
+    assert!(!db.record_watch_placement_failures(0).unwrap(), "a lower count writes nothing");
+    assert_eq!(
+        db.status(&config.database).unwrap().watch_placement_failures,
+        3,
+        "a healthy watcher's 0 must not clobber a degraded watcher's count"
+    );
+
+    // A HIGHER count raises the mark.
+    assert!(db.record_watch_placement_failures(5).unwrap(), "a higher count is a change");
+    assert_eq!(db.status(&config.database).unwrap().watch_placement_failures, 5);
+
+    let _ = fs::remove_dir_all(root);
+}

--- a/crates/rag-rat-core/src/storage.rs
+++ b/crates/rag-rat-core/src/storage.rs
@@ -94,6 +94,31 @@ impl IndexConnection {
         Ok(Self { conn, database_path: path.to_path_buf(), source_root: None })
     }
 
+    /// Read-WRITE open that neither CREATES the database nor WAITS on a busy lock — for the
+    /// watcher's non-blocking, side-effect-free out-of-band flush (#658 review). Two departures
+    /// from [`open`](Self::open), both load-bearing for that caller:
+    /// - `SQLITE_OPEN_READ_WRITE` WITHOUT `_CREATE` (and no `create_dir_all`), so a
+    ///   first-time-empty checkout with no index yet ERRORS (`SQLITE_CANTOPEN`) instead of leaving
+    ///   a schemaless `.rag-rat/index.sqlite` behind that would poison the friendly no-index read
+    ///   path.
+    /// - `busy_timeout = 0` and NO `setup()`, so a single write FAILS FAST with `SQLITE_BUSY` under
+    ///   a concurrent writer (another repo in a consolidated DB, a checkpoint) instead of stalling
+    ///   the caller — the watcher event loop, which must never block on classification/fleet
+    ///   triggers — for up to the 5s `setup()` timeout. The WAL journal mode is persistent on an
+    ///   already initialized DB, so skipping `setup()`'s `journal_mode = WAL` retry is safe here.
+    ///
+    /// The caller treats BOTH the open error and a busy write as "skip; the count rides the next
+    /// pass" (see [`is_busy`]). NOT for general use — a normal writer wants [`open`](Self::open).
+    pub fn open_read_write_no_create_nowait(path: &Path) -> anyhow::Result<Self> {
+        use rusqlite::OpenFlags;
+        let conn = Connection::open_with_flags(
+            path,
+            OpenFlags::SQLITE_OPEN_READ_WRITE | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+        )?;
+        conn.busy_timeout(std::time::Duration::ZERO)?;
+        Ok(Self { conn, database_path: path.to_path_buf(), source_root: None })
+    }
+
     pub fn database_path(&self) -> &Path {
         &self.database_path
     }

--- a/crates/rag-rat-core/src/watch/event_loop.rs
+++ b/crates/rag-rat-core/src/watch/event_loop.rs
@@ -15,9 +15,9 @@ use super::pass::{
     maintenance_pass_scoped, spawn_pass_worker, startup_catchup_pass,
 };
 use super::placement::{
-    LinkedWorktreeWatches, event_requests_maintenance, event_targets_binary, is_gitignore_path,
-    kind_is_mutation, place_initial_watch_state, recompile_ignore_and_place_watches,
-    sync_linked_worktrees_after_pass,
+    LinkedWorktreeWatches, WatchPlacementCounters, event_requests_maintenance,
+    event_targets_binary, is_gitignore_path, kind_is_mutation, place_initial_watch_state,
+    recompile_ignore_and_place_watches, sync_linked_worktrees_after_pass,
 };
 use crate::config::Config;
 use crate::fleet;
@@ -156,8 +156,15 @@ fn watcher_main(
     // checkout's own gitignore rules, so overlay refreshes do not subscribe to ignored build trees.
     // The worktree registry is still watched non-recursively so `git worktree add/remove` fires a
     // pass. `linked_worktrees` is reconciled after each pass to pick up newly-added worktrees.
+    //
+    // Watch-placement counters are OWNED by this watcher (not a process-global), so one repo
+    // config's dropped watches are never attributed to another (#658 review). The event-loop thread
+    // records placements into them; the pass worker reads them to persist the failure high-water
+    // mark — hence the `Arc`, shared across the two threads.
+    let watch_counters = Arc::new(WatchPlacementCounters::default());
     let (mut linked_worktrees, worktree_registry) = place_initial_watch_state(
         &mut notify_watcher,
+        &watch_counters,
         &config,
         &target_dirs,
         &ignore,
@@ -194,11 +201,19 @@ fn watcher_main(
     let (pass_tx, pass_rx) = std::sync::mpsc::channel();
     let Some(pass_worker) = spawn_pass_worker(pass_rx, tx, {
         let config = config.clone();
+        // This watcher's counters, shared with the event-loop thread that records into them; the
+        // pass reads them to persist the placement-failure high-water mark for `index_status`.
+        let watch_counters = Arc::clone(&watch_counters);
         move |request| {
             let _ = match request {
-                PassRequest::StartupCatchup => startup_catchup_pass(&config),
-                PassRequest::Maintenance { run_gc, overlay_scope } =>
-                    maintenance_pass_scoped(&config, *run_gc, overlay_scope),
+                PassRequest::StartupCatchup =>
+                    startup_catchup_pass(&config, Some(watch_counters.as_ref())),
+                PassRequest::Maintenance { run_gc, overlay_scope } => maintenance_pass_scoped(
+                    &config,
+                    *run_gc,
+                    overlay_scope,
+                    Some(watch_counters.as_ref()),
+                ),
             };
         }
     }) else {
@@ -220,6 +235,7 @@ fn watcher_main(
         target_dirs: &target_dirs,
         fleet_bin: fleet_bin.as_deref(),
         notify_watcher: &mut notify_watcher,
+        counters: &watch_counters,
         ignore: &mut ignore,
         linked_worktrees: &mut linked_worktrees,
         worktree_registry: worktree_registry.as_deref(),
@@ -247,6 +263,59 @@ fn watcher_main(
     if final_refresh_owed {
         let _ = shutdown_discover(&config);
     }
+
+    // Flush the watch-placement failure high-water mark on the way out, in case the event loop's
+    // between-pass drain didn't catch the last resync-introduced drop before `stop`. Runs AFTER the
+    // shutdown discover on purpose: a watcher that started with NO index has a drain that treated
+    // the missing DB as settled, so if the discover above just CREATED and registered the index for
+    // content that arrived in the last debounce window, this is the only chance to write the count
+    // into it (#658 review). Best-effort and bounded; a no-op (no DB open at all) when there is
+    // still no index or nothing ever failed, so a healthy watcher's shutdown pays nothing.
+    let _ = flush_watch_placement_failures(&config, &watch_counters, SKIP_TIMEOUT);
+}
+
+/// Persist this watcher's watch-placement failure high-water mark out of band — from the event-loop
+/// drain between passes (the post-pass linked-worktree resync places watches AFTER the pass worker
+/// already persisted the counter) and at shutdown — so a drop introduced there is not lost on a
+/// periodic-sweep-disabled watcher with no further events (#658 review). Takes the write lock with
+/// `lock_timeout` (`Duration::ZERO` for a non-blocking try on the event loop — it must not stall
+/// event classification; [`SKIP_TIMEOUT`] at shutdown). The persist goes through the LIGHTWEIGHT,
+/// NON-CREATING, NON-BLOCKING config-scoped path
+/// ([`crate::index::record_watch_placement_failures_scoped`]).
+///
+/// Returns whether the flush SETTLED: `true` = persisted, or nothing to persist (no failures, no
+/// index yet, repo not registered) — the caller may advance its low-water mark; `false` = a
+/// TRANSIENT skip (write lock held, or the DB busy) — the caller should retry on a later tick.
+pub(crate) fn flush_watch_placement_failures(
+    config: &Config,
+    counters: &WatchPlacementCounters,
+    lock_timeout: Duration,
+) -> bool {
+    let (_, failures) = counters.counts();
+    if failures == 0 {
+        return true;
+    }
+    let lock_repo = locks::write_lock_repo_id(config);
+    let Ok(Some(_lock)) =
+        locks::WriteLock::acquire_timeout(&config.database, &lock_repo, lock_timeout)
+    else {
+        // The flock is held (a pass mid-write, another process) — transient; retry next tick.
+        return false;
+    };
+    match crate::index::record_watch_placement_failures_scoped(config, failures) {
+        Ok(settled) => settled,
+        Err(error) => {
+            // A non-busy error (schema corruption, a vanished file) can't be fixed by retrying —
+            // treat as settled so the drain doesn't spin/log every tick; the next full pass
+            // persists via its own connection.
+            tracing::debug!(
+                target: "rag_rat_core::watch",
+                error = %error,
+                "watch-placement-failure flush failed; the count rides the next pass"
+            );
+            true
+        },
+    }
 }
 
 /// The watcher event loop, separated from [`watcher_main`] so tests can drive it with a recording
@@ -258,6 +327,10 @@ pub(crate) struct EventLoop<'a, W: notify::Watcher> {
     pub(crate) target_dirs: &'a [PathBuf],
     pub(crate) fleet_bin: Option<&'a Path>,
     pub(crate) notify_watcher: &'a mut W,
+    /// This watcher's watch-placement counters (not a process-global), recorded on every placement
+    /// the loop performs and read by the pass worker to persist the failure high-water mark
+    /// (#658).
+    pub(crate) counters: &'a WatchPlacementCounters,
     pub(crate) ignore: &'a mut IgnoreMatcher,
     pub(crate) linked_worktrees: &'a mut LinkedWorktreeWatches,
     pub(crate) worktree_registry: Option<&'a Path>,
@@ -297,6 +370,12 @@ impl<W: notify::Watcher> EventLoop<'_, W> {
         // dispatch, like the debounce itself — mid-pass events keep accumulating for the
         // coalesced follow-up.
         let mut pending_overlay_scope: Option<OverlayScope> = None;
+        // The watch-placement failure count this loop has already flushed to `repo_meta`. The
+        // between-pass drain at the loop tail compares the live counter against this and persists +
+        // warns on any rise, so a drop the post-pass resync introduced (after the pass worker
+        // persisted) still surfaces — in `index_status` AND the log — on a periodic-sweep-disabled
+        // watcher with no further events (#658 review).
+        let mut last_flushed_placement_failures = 0u64;
         loop {
             if self.stop.load(Ordering::Relaxed) {
                 break;
@@ -346,6 +425,7 @@ impl<W: notify::Watcher> EventLoop<'_, W> {
                     // nested `.gitignore` (#332).
                     if let Some(scope) = event_requests_maintenance(
                         self.notify_watcher,
+                        self.counters,
                         &event,
                         self.config,
                         self.target_dirs,
@@ -374,6 +454,7 @@ impl<W: notify::Watcher> EventLoop<'_, W> {
                             // bookkeeping is deferred.)
                             recompile_ignore_and_place_watches(
                                 self.notify_watcher,
+                                self.counters,
                                 self.config,
                                 self.target_dirs,
                                 self.ignore,
@@ -397,9 +478,13 @@ impl<W: notify::Watcher> EventLoop<'_, W> {
                     // state remains active.
                     sync_linked_worktrees_after_pass(
                         self.notify_watcher,
+                        self.counters,
                         self.config,
                         self.linked_worktrees,
                     );
+                    // A resync-introduced watch-placement drop is picked up by the between-pass
+                    // drain at the tail of this loop (it runs every iteration), not here — see
+                    // there.
                 },
                 Ok(LoopMsg::PapertrailDone) => {
                     if let Some(request_tx) = self.papertrail_tx
@@ -462,6 +547,44 @@ impl<W: notify::Watcher> EventLoop<'_, W> {
                 // binary.
                 (self.fleet_trigger)(bin);
                 fleet_debounce.reset();
+            }
+            // Between-pass watch-placement-failure drain (#658 review). Runs every loop iteration —
+            // the loop wakes at least every `IDLE_WAIT`, so even a periodic-sweep-disabled watcher
+            // with no further filesystem events reaches here within one idle tick. Gated on a RISE
+            // in the counter (two atomic loads on the healthy path — negligible), so it opens the
+            // DB only when a placement newly failed. The pass worker persists at pass
+            // start, but the post-pass linked-worktree resync places watches AFTER
+            // that; this is what surfaces such a drop while the watcher keeps running.
+            // The `warn!` is emitted here (once per new batch via the coalesced
+            // counter) so the log signal fires even when the flush is deferred, and the
+            // flush is NON-blocking: a busy DB / held write lock leaves `last_flushed` unadvanced
+            // so the next tick retries. It never dispatches a pass, so it cannot re-drive the
+            // resync and loop.
+            let (_, current_placement_failures) = self.counters.counts();
+            if current_placement_failures > last_flushed_placement_failures {
+                if let Some(total) = self.counters.newly_warnable_failures() {
+                    // The recovery path differs by config: with the periodic sweep ON, the
+                    // unwatched subtree is re-scanned each interval; with it DISABLED
+                    // (`periodic_sweep_secs = 0`) there is no backstop, so edits beneath the
+                    // dropped watch can go unindexed until an event-driven pass happens to touch it
+                    // or the operator reindexes — don't promise a sweep that won't run.
+                    let recovery = if self.config.watch.periodic_sweep_secs > 0 {
+                        "falling back to the periodic sweep"
+                    } else {
+                        "and the periodic sweep is DISABLED, so edits beneath an unwatched \
+                         directory may go unindexed until the next event-driven pass or a reindex"
+                    };
+                    tracing::warn!(
+                        target: "rag_rat_core::watch",
+                        watch_placement_failures = total,
+                        periodic_sweep_secs = self.config.watch.periodic_sweep_secs,
+                        "watch placement failed for one or more directories ({recovery}); on Linux \
+                         this is usually fs.inotify.max_user_watches exhaustion"
+                    );
+                }
+                if flush_watch_placement_failures(self.config, self.counters, Duration::ZERO) {
+                    last_flushed_placement_failures = current_placement_failures;
+                }
             }
         }
         debounce.fire_at().is_some()

--- a/crates/rag-rat-core/src/watch/mod.rs
+++ b/crates/rag-rat-core/src/watch/mod.rs
@@ -26,7 +26,7 @@ mod placement;
 
 pub use event_loop::Watcher;
 #[cfg(test)]
-pub(crate) use event_loop::{EventLoop, shutdown_discover};
+pub(crate) use event_loop::{EventLoop, flush_watch_placement_failures, shutdown_discover};
 #[cfg(test)]
 pub(crate) use overlay::{OverlayBasisAction, overlay_basis_action, overlay_needs_embed};
 pub use overlay::{OverlayScope, ReconcileBudget, refresh_worktree_overlays};
@@ -41,8 +41,8 @@ pub(crate) use pass::{
 };
 #[cfg(test)]
 pub(crate) use placement::{
-    CreatedDirPlacement, LinkedWorktreeWatches, WorktreeEventHint, created_dir_placement,
-    event_is_relevant, event_requests_maintenance, event_touches_worktree,
+    CreatedDirPlacement, LinkedWorktreeWatches, WatchPlacementCounters, WorktreeEventHint,
+    created_dir_placement, event_is_relevant, event_requests_maintenance, event_touches_worktree,
     gitignore_rule_watch_dirs, gitignore_watch_dirs, is_gitignore_path, kind_is_mutation,
     missing_config_root_bootstrap_dirs, place_initial_watch_state,
     recompile_ignore_and_place_watches, sync_linked_worktrees_after_pass, watch_created_dirs,

--- a/crates/rag-rat-core/src/watch/pass.rs
+++ b/crates/rag-rat-core/src/watch/pass.rs
@@ -5,6 +5,7 @@ use std::time::{Duration, Instant};
 use notify::Event;
 
 use super::overlay::{OverlayScope, ReconcileBudget, refresh_worktree_overlays};
+use super::placement::WatchPlacementCounters;
 use crate::config::Config;
 use crate::index::IndexDatabase;
 use crate::index::ai::ReconcileOptions;
@@ -207,39 +208,48 @@ pub(crate) fn spawn_pass_worker(
 }
 
 /// Run one maintenance pass, blocking on the per-DB write lock (watcher-to-watcher serializes).
+/// The hook/CLI entry point — it has no resident watcher, so there are no watch-placement counters
+/// to persist (`None`); a running watcher records its own via [`maintenance_pass_scoped`].
 pub fn maintenance_pass(config: &Config, run_gc: bool) -> anyhow::Result<()> {
-    maintenance_pass_scoped(config, run_gc, &OverlayScope::All)
+    maintenance_pass_scoped(config, run_gc, &OverlayScope::All, None)
 }
 
 /// [`maintenance_pass`] with an explicit overlay scope — the watcher's event-driven passes name
-/// the checkouts events came from instead of sweeping the whole worktree fleet (#577).
+/// the checkouts events came from instead of sweeping the whole worktree fleet (#577). The resident
+/// watcher passes `Some(counters)` so this pass persists its watch-placement failure high-water
+/// mark; the hook/CLI wrapper above passes `None`.
 pub(crate) fn maintenance_pass_scoped(
     config: &Config,
     run_gc: bool,
     overlay_scope: &OverlayScope,
+    watch_counters: Option<&WatchPlacementCounters>,
 ) -> anyhow::Result<()> {
     let lock_repo = locks::write_lock_repo_id(config);
     let _lock = locks::WriteLock::acquire_blocking(&config.database, &lock_repo)?;
-    run_pass(config, run_gc, false, overlay_scope)
+    run_pass(config, run_gc, false, overlay_scope, watch_counters)
 }
 
 /// Run one maintenance pass only if the write lock is free within `SKIP_TIMEOUT`; returns whether
-/// it ran. Used by interactive / hook / shutdown callers so a held lock can't hang them.
+/// it ran. Used by interactive / hook / shutdown callers so a held lock can't hang them — none of
+/// which own a watcher, so no watch-placement counters (`None`).
 pub fn maintenance_pass_or_skip(config: &Config, run_gc: bool) -> anyhow::Result<bool> {
     let lock_repo = locks::write_lock_repo_id(config);
     match locks::WriteLock::acquire_timeout(&config.database, &lock_repo, SKIP_TIMEOUT)? {
         Some(_lock) => {
-            run_pass(config, run_gc, false, &OverlayScope::All)?;
+            run_pass(config, run_gc, false, &OverlayScope::All, None)?;
             Ok(true)
         },
         None => Ok(false),
     }
 }
 
-pub(crate) fn startup_catchup_pass(config: &Config) -> anyhow::Result<()> {
+pub(crate) fn startup_catchup_pass(
+    config: &Config,
+    watch_counters: Option<&WatchPlacementCounters>,
+) -> anyhow::Result<()> {
     let lock_repo = locks::write_lock_repo_id(config);
     let _lock = locks::WriteLock::acquire_blocking(&config.database, &lock_repo)?;
-    run_pass(config, STARTUP_CATCHUP_RUN_GC, true, &OverlayScope::All)
+    run_pass(config, STARTUP_CATCHUP_RUN_GC, true, &OverlayScope::All, watch_counters)
 }
 
 fn run_pass(
@@ -247,6 +257,7 @@ fn run_pass(
     run_gc: bool,
     retry_base_embedding_backlog: bool,
     overlay_scope: &OverlayScope,
+    watch_counters: Option<&WatchPlacementCounters>,
 ) -> anyhow::Result<()> {
     let started = Instant::now();
     let mut timings = PassTimings::new(started);
@@ -263,6 +274,16 @@ fn run_pass(
         },
         Err(err) => return Err(err),
     };
+    // Persist the resident watcher's watch-placement failure count (as a high-water mark) so
+    // `index_status` can surface silently-dropped watches — a directory whose watch failed (ENOSPC
+    // on Linux) falls back to this very sweep, but without this the degradation is invisible. This
+    // is the persist using the pass's already-open connection; the WARN (and a between-pass
+    // backstop persist) is owned by the event-loop drain, which runs even when no pass does
+    // (#658 review).
+    if let Some(counters) = watch_counters {
+        let (_watch_attempts, watch_failures) = counters.counts();
+        db.record_watch_placement_failures(watch_failures)?;
+    }
     let shutdown_reconcile_pending = db.watch_shutdown_reconcile_pending()?;
     let runtime = &config.llm.embedding.runtime;
     let options = ReconcileOptions {

--- a/crates/rag-rat-core/src/watch/placement.rs
+++ b/crates/rag-rat-core/src/watch/placement.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeSet;
 use std::path::{Component, Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use notify::event::{AccessKind, AccessMode, EventKind, ModifyKind, RenameMode};
 use notify::{Event, RecursiveMode};
@@ -8,6 +9,89 @@ use super::overlay::{OverlayScope, enclosing_worktree_id};
 use crate::config::Config;
 use crate::index::ignore_rules::{IgnoreMatcher, target_ancestor_dirs};
 use crate::index::target_for_path;
+
+/// Per-watcher counters for watch PLACEMENT outcomes, OWNED by the watcher that created them (not a
+/// process-global). `watcher_main` builds one and shares it — via `Arc` — between the event-loop
+/// thread (which records a placement on every `.watch()`) and the pass worker (which reads it to
+/// persist the failure high-water mark into `repo_meta`). Scoping to the watcher INSTANCE is what
+/// keeps one repo config's placement outcomes from ever being attributed to another's — even if a
+/// single process ran more than one `Watcher` (the public `spawn` API does not forbid it) — and the
+/// counts do not outlive the watcher's own shutdown the way a static would.
+///
+/// A failure means `notify::Watcher::watch` returned `Err` — on Linux, `ENOSPC` once
+/// `fs.inotify.max_user_watches` is exhausted; on any OS, a transient failure. The directory (and,
+/// in [`watch_tree_pruned`], its whole unwalked subtree) then silently falls back to the periodic
+/// sweep. These counters make that fallback *observable*. Interior atomics so the shared `&self`
+/// can be read on the pass thread while the event-loop thread records placements concurrently.
+#[derive(Debug, Default)]
+pub(crate) struct WatchPlacementCounters {
+    attempts: AtomicU64,
+    failures: AtomicU64,
+    /// The failure count this watcher last emitted a warning for. Warning coalescing keys on THIS
+    /// (instance-local), NOT on the persisted high-water mark — a restarted watcher whose fresh
+    /// count is below a prior high-water still has real new failures to log.
+    last_warned: AtomicU64,
+}
+
+impl WatchPlacementCounters {
+    fn record_attempt(&self) {
+        self.attempts.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn record_failure(&self) {
+        self.failures.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// `(attempts, failures)` watch placements this watcher has seen — read by the watcher's pass
+    /// to persist into `repo_meta` (`watch_placement_failures`), surfaced by `index_status`.
+    pub(crate) fn counts(&self) -> (u64, u64) {
+        (self.attempts.load(Ordering::Relaxed), self.failures.load(Ordering::Relaxed))
+    }
+
+    /// This watcher's total watch-placement failures, but only if they have RISEN since the last
+    /// call — so the pass warns once per new batch of drops and never per directory. Returns `None`
+    /// when nothing new (or none ever) failed.
+    pub(crate) fn newly_warnable_failures(&self) -> Option<u64> {
+        let current = self.failures.load(Ordering::Relaxed);
+        if current == 0 {
+            return None;
+        }
+        // fetch_max stores the max and returns the PRIOR value atomically, so the pass thread can't
+        // double-warn for the same increment even against a concurrent placement.
+        let prior = self.last_warned.fetch_max(current, Ordering::Relaxed);
+        (current > prior).then_some(current)
+    }
+}
+
+/// Place one non-recursive watch, counting the outcome into `counters`; returns `true` on success.
+/// EVERY `.watch()` in this module goes through here so a swallowed failure is still counted.
+/// Behavior is unchanged — a failed watch still falls back to the sweep exactly as before; only its
+/// visibility changes.
+fn place_watch(
+    watcher: &mut impl notify::Watcher,
+    counters: &WatchPlacementCounters,
+    path: &Path,
+    mode: RecursiveMode,
+) -> bool {
+    counters.record_attempt();
+    match watcher.watch(path, mode) {
+        Ok(()) => true,
+        Err(_) => {
+            // Only a watch that failed on a directory that EXISTS is a silently-dropped watch (the
+            // ENOSPC / inotify-exhaustion case this signal is for). A watch that failed because the
+            // path is absent is an EXPECTED miss — a not-yet-created configured target, a
+            // branch-specific subdir, or a worktree registry that appears later — all of which the
+            // ancestor / bootstrap / created-dir watches already cover. Counting those would peg
+            // the never-lowered high-water mark forever on a config with an optional
+            // target dir and emit a spurious ENOSPC warning. `try_exists` errors (e.g.
+            // a permission wall) count, so a genuine drop is never under-reported.
+            if path.try_exists().unwrap_or(true) {
+                counters.record_failure();
+            }
+            false
+        },
+    }
+}
 
 /// Whether an event KIND should ever fire a pass. Only content mutations do — `Create`, `Remove`,
 /// any `Modify` (data/metadata/rename), and a write-close. Reads must NOT: notify's inotify mask
@@ -126,32 +210,35 @@ impl LinkedWorktreeWatch {
         Self { checkout_root, config, target_dirs, ignore }
     }
 
-    fn place_watches(&self, watcher: &mut impl notify::Watcher) {
-        watch_configured_trees(watcher, &self.config, &self.target_dirs, &self.ignore);
-        watch_gitignore_rule_dirs(watcher, &self.config.root, &self.target_dirs);
+    fn place_watches(&self, watcher: &mut impl notify::Watcher, counters: &WatchPlacementCounters) {
+        watch_configured_trees(watcher, counters, &self.config, &self.target_dirs, &self.ignore);
+        watch_gitignore_rule_dirs(watcher, counters, &self.config.root, &self.target_dirs);
         for root in missing_config_root_bootstrap_dirs(&self.config.root, &self.checkout_root) {
             // The linked checkout may not have this subdir on the current branch yet. Keep narrow
             // bootstraps on the existing ancestor chain so the next recreated config-root component
             // is observed without returning to a recursive whole-checkout watch.
-            let _ = watcher.watch(&root, RecursiveMode::NonRecursive);
+            place_watch(watcher, counters, &root, RecursiveMode::NonRecursive);
         }
     }
 
     pub(crate) fn recompile_ignore_and_place_watches(
         &mut self,
         watcher: &mut impl notify::Watcher,
+        counters: &WatchPlacementCounters,
     ) {
         self.ignore = IgnoreMatcher::compile(&self.config.root, &self.target_dirs);
-        self.place_watches(watcher);
+        self.place_watches(watcher, counters);
     }
 
     pub(crate) fn watch_created_dirs(
         &mut self,
         watcher: &mut impl notify::Watcher,
+        counters: &WatchPlacementCounters,
         event: &Event,
     ) -> bool {
         watch_created_dirs(
             watcher,
+            counters,
             event,
             &self.config,
             &self.target_dirs,
@@ -189,13 +276,14 @@ impl LinkedWorktreeWatches {
     pub(crate) fn sync(
         &mut self,
         watcher: &mut impl notify::Watcher,
+        counters: &WatchPlacementCounters,
         base_config: &Config,
         checkout_roots: Vec<PathBuf>,
     ) {
         let mut states = Vec::with_capacity(checkout_roots.len());
         for root in checkout_roots {
             let state = LinkedWorktreeWatch::new(base_config, root);
-            state.place_watches(watcher);
+            state.place_watches(watcher, counters);
             states.push(state);
         }
         self.states = states;
@@ -207,11 +295,12 @@ impl LinkedWorktreeWatches {
     pub(crate) fn watch_created_dirs(
         &mut self,
         watcher: &mut impl notify::Watcher,
+        counters: &WatchPlacementCounters,
         event: &Event,
     ) -> BTreeSet<PathBuf> {
         let mut placed = BTreeSet::new();
         for state in &mut self.states {
-            if state.watch_created_dirs(watcher, event) {
+            if state.watch_created_dirs(watcher, counters, event) {
                 placed.insert(state.checkout_root.clone());
             }
         }
@@ -221,9 +310,10 @@ impl LinkedWorktreeWatches {
     pub(crate) fn recompile_ignore_and_place_watches(
         &mut self,
         watcher: &mut impl notify::Watcher,
+        counters: &WatchPlacementCounters,
     ) {
         for state in &mut self.states {
-            state.recompile_ignore_and_place_watches(watcher);
+            state.recompile_ignore_and_place_watches(watcher, counters);
         }
     }
 
@@ -342,12 +432,13 @@ pub(crate) fn missing_config_root_bootstrap_dirs(
 
 pub(crate) fn watch_tree_pruned(
     watcher: &mut impl notify::Watcher,
+    counters: &WatchPlacementCounters,
     dir: &Path,
     ignore: &IgnoreMatcher,
 ) {
     let mut stack = vec![dir.to_path_buf()];
     while let Some(d) = stack.pop() {
-        if watcher.watch(&d, RecursiveMode::NonRecursive).is_err() {
+        if !place_watch(watcher, counters, &d, RecursiveMode::NonRecursive) {
             continue;
         }
         let Ok(entries) = std::fs::read_dir(&d) else {
@@ -430,6 +521,7 @@ pub(crate) fn created_dir_placement(
 ///    here picks the nested rules up so `watch_tree_pruned` prunes against them, not stale rules.
 pub(crate) fn watch_created_dirs(
     watcher: &mut impl notify::Watcher,
+    counters: &WatchPlacementCounters,
     event: &Event,
     config: &Config,
     target_dirs: &[PathBuf],
@@ -462,10 +554,10 @@ pub(crate) fn watch_created_dirs(
                 // A nested target's leading directory can appear after startup. Watch the ancestor
                 // non-recursively so the eventual target dir creation is delivered, and re-place
                 // target watches too in case a fast `mkdir -p target/path` already created it.
-                let _ = watcher.watch(path, RecursiveMode::NonRecursive);
-                watch_gitignore_rule_dirs(watcher, &config.root, target_dirs);
+                place_watch(watcher, counters, path, RecursiveMode::NonRecursive);
+                watch_gitignore_rule_dirs(watcher, counters, &config.root, target_dirs);
                 *ignore = IgnoreMatcher::compile(&config.root, target_dirs);
-                watch_configured_trees(watcher, config, target_dirs, ignore);
+                watch_configured_trees(watcher, counters, config, target_dirs, ignore);
                 placed_target_watch = true;
             },
             CreatedDirPlacement::TargetSubtree => {
@@ -479,7 +571,7 @@ pub(crate) fn watch_created_dirs(
                 if ignore.is_ignored(path, true) {
                     continue;
                 }
-                watch_tree_pruned(watcher, path, ignore);
+                watch_tree_pruned(watcher, counters, path, ignore);
                 placed_target_watch = true;
             },
         }
@@ -489,22 +581,23 @@ pub(crate) fn watch_created_dirs(
 
 pub(crate) fn place_initial_watch_state(
     watcher: &mut impl notify::Watcher,
+    counters: &WatchPlacementCounters,
     config: &Config,
     target_dirs: &[PathBuf],
     ignore: &IgnoreMatcher,
     fleet_bin: Option<&Path>,
 ) -> (LinkedWorktreeWatches, Option<PathBuf>) {
-    watch_configured_trees(watcher, config, target_dirs, ignore);
-    watch_gitignore_rule_dirs(watcher, &config.root, target_dirs);
+    watch_configured_trees(watcher, counters, config, target_dirs, ignore);
+    watch_gitignore_rule_dirs(watcher, counters, &config.root, target_dirs);
 
     if let Some(dir) = fleet_bin.and_then(Path::parent) {
-        let _ = watcher.watch(dir, RecursiveMode::NonRecursive);
+        place_watch(watcher, counters, dir, RecursiveMode::NonRecursive);
     }
 
     let (linked_worktree_roots, worktree_registry) = worktree_watch_targets(config);
-    let linked_worktrees = watch_linked_worktrees(watcher, config, linked_worktree_roots);
+    let linked_worktrees = watch_linked_worktrees(watcher, counters, config, linked_worktree_roots);
     if let Some(registry) = &worktree_registry {
-        let _ = watcher.watch(registry, RecursiveMode::NonRecursive);
+        place_watch(watcher, counters, registry, RecursiveMode::NonRecursive);
     }
     (linked_worktrees, worktree_registry)
 }
@@ -514,8 +607,14 @@ pub(crate) fn place_initial_watch_state(
 /// pass's discover covers the base scope regardless), `None` to ignore. Every sub-check still
 /// RUNS unconditionally (no short-circuit): watch placement is a side effect both the base and
 /// every linked state need regardless of what else already fired.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "the per-watcher placement counters thread alongside the watcher through every \
+              placement entry point (#658); this one was already at the limit"
+)]
 pub(crate) fn event_requests_maintenance(
     watcher: &mut impl notify::Watcher,
+    counters: &WatchPlacementCounters,
     event: &Event,
     config: &Config,
     target_dirs: &[PathBuf],
@@ -524,8 +623,8 @@ pub(crate) fn event_requests_maintenance(
     worktree_registry: Option<&Path>,
 ) -> Option<OverlayScope> {
     let created_dir_watch_placed =
-        watch_created_dirs(watcher, event, config, target_dirs, ignore, None);
-    let linked_created_dir_roots = linked_worktrees.watch_created_dirs(watcher, event);
+        watch_created_dirs(watcher, counters, event, config, target_dirs, ignore, None);
+    let linked_created_dir_roots = linked_worktrees.watch_created_dirs(watcher, counters, event);
     let base_relevant = event_is_relevant(config, ignore, event);
     let worktree_hint = event_touches_worktree(event, linked_worktrees, worktree_registry);
     let fires = created_dir_watch_placed
@@ -550,23 +649,25 @@ pub(crate) fn event_requests_maintenance(
 
 pub(crate) fn recompile_ignore_and_place_watches(
     watcher: &mut impl notify::Watcher,
+    counters: &WatchPlacementCounters,
     config: &Config,
     target_dirs: &[PathBuf],
     ignore: &mut IgnoreMatcher,
     linked_worktrees: &mut LinkedWorktreeWatches,
 ) {
     *ignore = IgnoreMatcher::compile(&config.root, target_dirs);
-    watch_configured_trees(watcher, config, target_dirs, ignore);
-    linked_worktrees.recompile_ignore_and_place_watches(watcher);
+    watch_configured_trees(watcher, counters, config, target_dirs, ignore);
+    linked_worktrees.recompile_ignore_and_place_watches(watcher, counters);
 }
 
 pub(crate) fn sync_linked_worktrees_after_pass(
     watcher: &mut impl notify::Watcher,
+    counters: &WatchPlacementCounters,
     config: &Config,
     linked_worktrees: &mut LinkedWorktreeWatches,
 ) {
     let (current, _) = worktree_watch_targets(config);
-    linked_worktrees.sync(watcher, config, current);
+    linked_worktrees.sync(watcher, counters, config, current);
 }
 
 /// Live linked-worktree checkout roots (excluding the base `config.root`) plus the worktree
@@ -589,12 +690,13 @@ pub(crate) fn worktree_watch_targets(config: &Config) -> (Vec<PathBuf>, Option<P
 
 pub(crate) fn watch_configured_trees(
     watcher: &mut impl notify::Watcher,
+    counters: &WatchPlacementCounters,
     config: &Config,
     target_dirs: &[PathBuf],
     ignore: &IgnoreMatcher,
 ) {
     for dir in target_dirs {
-        watch_tree_pruned(watcher, &config.root.join(dir), ignore);
+        watch_tree_pruned(watcher, counters, &config.root.join(dir), ignore);
     }
 }
 
@@ -616,21 +718,23 @@ pub(crate) fn gitignore_rule_watch_dirs(root: &Path, target_dirs: &[PathBuf]) ->
 
 pub(crate) fn watch_gitignore_rule_dirs(
     watcher: &mut impl notify::Watcher,
+    counters: &WatchPlacementCounters,
     root: &Path,
     target_dirs: &[PathBuf],
 ) {
     for dir in gitignore_rule_watch_dirs(root, target_dirs) {
-        let _ = watcher.watch(&dir, RecursiveMode::NonRecursive);
+        place_watch(watcher, counters, &dir, RecursiveMode::NonRecursive);
     }
 }
 
 pub(crate) fn watch_linked_worktrees(
     watcher: &mut impl notify::Watcher,
+    counters: &WatchPlacementCounters,
     base_config: &Config,
     checkout_roots: Vec<PathBuf>,
 ) -> LinkedWorktreeWatches {
     let mut worktrees = LinkedWorktreeWatches::default();
-    worktrees.sync(watcher, base_config, checkout_roots);
+    worktrees.sync(watcher, counters, base_config, checkout_roots);
     worktrees
 }
 

--- a/crates/rag-rat-core/src/watch/tests.rs
+++ b/crates/rag-rat-core/src/watch/tests.rs
@@ -23,6 +23,13 @@ fn mutation_event(path: PathBuf) -> Event {
     Event::new(EventKind::Modify(ModifyKind::Any)).add_path(path)
 }
 
+/// Fresh throwaway placement counters for tests that assert on WHICH directories get watched, not
+/// on the failure count (the live watcher owns one long-lived instance per the #658 hardening).
+/// Keeps those call sites terse; the counting test uses its own named instances.
+fn placement_counters() -> WatchPlacementCounters {
+    WatchPlacementCounters::default()
+}
+
 /// A single-Rust-target `Config` rooted at `root` watching `target_dirs` — the inline builder
 /// the real-watcher placement tests share so they can call `watch_created_dirs` (which needs a
 /// `&Config` for the target-relation gate, #332).
@@ -147,6 +154,359 @@ impl notify::Watcher for RecordingWatcher {
     {
         notify::WatcherKind::NullWatcher
     }
+}
+
+/// A watcher whose every `watch()` fails — stands in for `ENOSPC` (inotify `max_user_watches`
+/// exhausted) so the placement-failure counting is testable without exhausting the real kernel
+/// limit.
+#[derive(Debug, Default)]
+struct FailingWatcher;
+
+impl notify::Watcher for FailingWatcher {
+    fn new<F: notify::EventHandler>(_: F, _: notify::Config) -> notify::Result<Self> {
+        Ok(Self)
+    }
+    fn watch(&mut self, _: &Path, _: RecursiveMode) -> notify::Result<()> {
+        Err(notify::Error::generic("forced test failure"))
+    }
+    fn unwatch(&mut self, _: &Path) -> notify::Result<()> {
+        Ok(())
+    }
+    fn kind() -> notify::WatcherKind {
+        notify::WatcherKind::NullWatcher
+    }
+}
+
+/// A failed watch placement is COUNTED (so `index_status` can surface silent degradation), and the
+/// existing subtree-skip behavior is unchanged: when the top dir's watch fails, `watch_tree_pruned`
+/// does not descend, so exactly one failure is recorded for a whole failed subtree — while a
+/// succeeding watcher walks every directory. The counters are OWNED per watcher, so each half of
+/// this test reads its own instance — no dependence on other tests' placements (the point of the
+/// #658 hardening).
+#[test]
+fn watch_placement_failures_are_counted_and_the_subtree_is_still_skipped() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let root = tmp.path();
+    std::fs::create_dir_all(root.join("child/grandchild")).unwrap();
+    let ignore = crate::index::ignore_rules::IgnoreMatcher::compile(root, &[root.to_path_buf()]);
+
+    // A succeeding watcher places a watch on every directory and records no failure.
+    let ok_counters = WatchPlacementCounters::default();
+    let mut ok = RecordingWatcher::default();
+    super::placement::watch_tree_pruned(&mut ok, &ok_counters, root, &ignore);
+    let (ok_attempts, ok_failures) = ok_counters.counts();
+    assert_eq!(ok_failures, 0, "no failures for a succeeding watcher");
+    assert!(ok_attempts >= 3, "succeeding watcher attempts every directory: {ok_attempts}");
+    assert!(ok.watched.len() >= 3, "succeeding watcher descends: {:?}", ok.watched);
+    assert!(ok_counters.newly_warnable_failures().is_none(), "no failures → never warnable");
+
+    // A failing watcher fails on the top dir; the subtree is not walked, so exactly ONE failure is
+    // counted for the whole subtree (the pre-existing coverage gap this observability surfaces).
+    let fail_counters = WatchPlacementCounters::default();
+    let mut failing = FailingWatcher;
+    super::placement::watch_tree_pruned(&mut failing, &fail_counters, root, &ignore);
+    let (_, fail_failures) = fail_counters.counts();
+    assert_eq!(
+        fail_failures, 1,
+        "one failure recorded for the top dir; descent stops, so the subtree is not re-attempted"
+    );
+
+    // Warning coalescing: a fresh failure is warnable once, then not (the pass would emit exactly
+    // one log line for this batch, never one per directory).
+    assert_eq!(fail_counters.newly_warnable_failures(), Some(1), "new failures warn once");
+    assert!(
+        fail_counters.newly_warnable_failures().is_none(),
+        "already-warned failures do not re-warn without new ones"
+    );
+}
+
+/// A watch that fails because the directory does NOT exist is an expected miss (a not-yet-created
+/// configured target, a branch-specific subdir, a worktree registry that appears later) — the
+/// ancestor/bootstrap/created-dir watches cover it — so it must NOT be counted as a
+/// silently-dropped watch. Otherwise, because the persisted value is a never-lowered high-water
+/// mark, an optional target dir would peg `index_status` at "degraded" forever and emit a spurious
+/// ENOSPC warning (#658 review).
+#[test]
+fn a_watch_failure_on_an_absent_directory_is_not_counted() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let root = tmp.path();
+    let ignore = IgnoreMatcher::compile(root, &[root.to_path_buf()]);
+    let counters = WatchPlacementCounters::default();
+
+    // A failing watcher pointed at a directory that does not exist: the watch errors, but the path
+    // is absent, so nothing is counted.
+    let mut failing = FailingWatcher;
+    let absent = root.join("not-created-yet");
+    watch_tree_pruned(&mut failing, &counters, &absent, &ignore);
+    assert_eq!(counters.counts().1, 0, "an absent target dir is an expected miss, not a drop");
+
+    // The SAME failing watcher on a directory that DOES exist is a genuine dropped watch — counted.
+    std::fs::create_dir_all(root.join("present")).unwrap();
+    watch_tree_pruned(&mut failing, &counters, &root.join("present"), &ignore);
+    assert_eq!(counters.counts().1, 1, "a failed watch on an existing dir is a real drop");
+}
+
+/// The post-pass linked-worktree sync places watches AFTER the pass persisted the counter, so the
+/// watcher flushes the failure high-water mark at shutdown — otherwise a drop introduced by that
+/// sync, on a periodic-sweep-disabled watcher with no further events, would never reach
+/// `index_status` (#658 review). Covers the flush persistence directly (the shutdown wiring in
+/// `watcher_main` uses the real notify watcher and isn't unit-drivable).
+#[test]
+fn shutdown_flush_persists_watch_placement_failures() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let root = tmp.path();
+    std::fs::create_dir_all(root.join("src")).unwrap();
+    std::fs::write(root.join("src/lib.rs"), "pub fn f() {}\n").unwrap();
+    let config = whole_root_config(root, &[PathBuf::from("src")]);
+    IndexDatabase::rebuild(&config).unwrap();
+
+    // A fresh index has recorded nothing; a flush with zero failures stays a no-op.
+    let empty = WatchPlacementCounters::default();
+    flush_watch_placement_failures(&config, &empty, Duration::from_secs(3));
+    let db = IndexDatabase::open_config(&config).unwrap();
+    assert_eq!(db.status(&config.database).unwrap().watch_placement_failures, 0);
+    drop(db);
+
+    // Record genuine failures (failing watcher on an existing target), then flush at shutdown.
+    let counters = WatchPlacementCounters::default();
+    let ignore = IgnoreMatcher::compile(&config.root, &config.target_directories());
+    let mut failing = FailingWatcher;
+    watch_tree_pruned(&mut failing, &counters, &root.join("src"), &ignore);
+    let (_, failures) = counters.counts();
+    assert!(failures > 0, "a failing watcher on an existing dir records a failure");
+
+    flush_watch_placement_failures(&config, &counters, Duration::from_secs(3));
+    let db = IndexDatabase::open_config(&config).unwrap();
+    assert_eq!(
+        db.status(&config.database).unwrap().watch_placement_failures,
+        failures,
+        "the shutdown flush persists the count so index_status surfaces it"
+    );
+}
+
+/// The post-resync flush on the event loop uses a NON-blocking (`Duration::ZERO`) lock acquire so
+/// it never stalls event classification (#658 review). Prove that path still persists when the lock
+/// is free — i.e. `Duration::ZERO` is a real "try once and take it if free", not "never acquire" —
+/// and that it routes through the lightweight config-scoped persist (no `open_config` heals).
+#[test]
+fn a_nonblocking_flush_persists_the_count_when_the_write_lock_is_free() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let root = tmp.path();
+    std::fs::create_dir_all(root.join("src")).unwrap();
+    std::fs::write(root.join("src/lib.rs"), "pub fn f() {}\n").unwrap();
+    let config = whole_root_config(root, &[PathBuf::from("src")]);
+    IndexDatabase::rebuild(&config).unwrap();
+
+    let counters = WatchPlacementCounters::default();
+    let ignore = IgnoreMatcher::compile(&config.root, &config.target_directories());
+    let mut failing = FailingWatcher;
+    watch_tree_pruned(&mut failing, &counters, &root.join("src"), &ignore);
+    let (_, failures) = counters.counts();
+    assert!(failures > 0);
+
+    flush_watch_placement_failures(&config, &counters, Duration::ZERO);
+    let db = IndexDatabase::open_config(&config).unwrap();
+    assert_eq!(
+        db.status(&config.database).unwrap().watch_placement_failures,
+        failures,
+        "a non-blocking flush persists when the lock is free"
+    );
+}
+
+/// The flush must stay SIDE-EFFECT-FREE on a first-time-empty checkout: a watcher that placed a
+/// watch which failed but never built an index (nothing to discover yet) must NOT leave a
+/// schemaless `.rag-rat/index.sqlite` behind — that would poison the friendly no-index read path
+/// (#658 review).
+#[test]
+fn a_flush_on_a_checkout_without_an_index_creates_no_db_file() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let root = tmp.path();
+    std::fs::create_dir_all(root.join("src")).unwrap();
+    // A source file exists (so the later rebuild has something to index), but no index has been
+    // built yet — a source file on disk does not create the `.rag-rat/index.sqlite`.
+    std::fs::write(root.join("src/lib.rs"), "pub fn f() {}\n").unwrap();
+    let config = whole_root_config(root, &[PathBuf::from("src")]);
+    assert!(!config.database.exists(), "precondition: no index file yet");
+
+    // Record real placement failures, then flush — as the shutdown path would.
+    let counters = WatchPlacementCounters::default();
+    let ignore = IgnoreMatcher::compile(&config.root, &config.target_directories());
+    let mut failing = FailingWatcher;
+    watch_tree_pruned(&mut failing, &counters, &root.join("src"), &ignore);
+    assert!(counters.counts().1 > 0);
+
+    flush_watch_placement_failures(&config, &counters, Duration::from_secs(3));
+    assert!(
+        !config.database.exists(),
+        "flushing on a checkout with no index must not create a schemaless DB file"
+    );
+
+    // ...but once the index IS created (as the shutdown discover does when content arrives in the
+    // last debounce window), a subsequent flush persists the count — which is why the shutdown
+    // flush runs AFTER `shutdown_discover`, not before (#658 review).
+    IndexDatabase::rebuild(&config).unwrap();
+    flush_watch_placement_failures(&config, &counters, Duration::from_secs(3));
+    assert_eq!(
+        IndexDatabase::open_config(&config)
+            .unwrap()
+            .status(&config.database)
+            .unwrap()
+            .watch_placement_failures,
+        counters.counts().1,
+        "a flush after the index is created writes the count into the freshly-created index"
+    );
+}
+
+/// The non-blocking flush must SKIP (not block, not error) when another SQLite writer holds the
+/// database — the event loop must never stall on classification/fleet triggers (#658 review). A
+/// second connection holding a write transaction stands in for another repo's writer in a
+/// consolidated DB; `busy_timeout = 0` turns the contended write into an immediate SKIP.
+#[test]
+fn a_nonblocking_flush_skips_a_busy_database_instead_of_blocking() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let root = tmp.path();
+    std::fs::create_dir_all(root.join("src")).unwrap();
+    std::fs::write(root.join("src/lib.rs"), "pub fn f() {}\n").unwrap();
+    let config = whole_root_config(root, &[PathBuf::from("src")]);
+    IndexDatabase::rebuild(&config).unwrap();
+
+    // Persist an initial count (lock free) so we can prove a later busy flush does NOT overwrite
+    // it.
+    let counters = WatchPlacementCounters::default();
+    let ignore = IgnoreMatcher::compile(&config.root, &config.target_directories());
+    let mut failing = FailingWatcher;
+    watch_tree_pruned(&mut failing, &counters, &root.join("src"), &ignore);
+    let first = counters.counts().1;
+    assert!(first > 0);
+    flush_watch_placement_failures(&config, &counters, Duration::from_secs(3));
+    assert_eq!(
+        IndexDatabase::open_config(&config)
+            .unwrap()
+            .status(&config.database)
+            .unwrap()
+            .watch_placement_failures,
+        first
+    );
+
+    // Grow the in-memory count, then hold the SQLite write lock from a second connection and
+    // attempt a non-blocking flush of the higher count. `BEGIN IMMEDIATE` reserves the WAL
+    // writer; the flush's `busy_timeout = 0` write must fail fast and SKIP, leaving the stored
+    // value untouched.
+    watch_tree_pruned(&mut failing, &counters, &root.join("src"), &ignore);
+    let grown = counters.counts().1;
+    assert!(grown > first, "the second placement raised the in-memory count");
+    let blocker = rusqlite::Connection::open(&config.database).unwrap();
+    blocker.execute_batch("BEGIN IMMEDIATE").unwrap();
+    flush_watch_placement_failures(&config, &counters, Duration::ZERO);
+    blocker.execute_batch("ROLLBACK").unwrap();
+    assert_eq!(
+        IndexDatabase::open_config(&config)
+            .unwrap()
+            .status(&config.database)
+            .unwrap()
+            .watch_placement_failures,
+        first,
+        "a flush against a busy DB skips rather than blocking or overwriting"
+    );
+
+    // With the writer gone, the same flush persists the grown count — proving it was a skip, not a
+    // loss.
+    flush_watch_placement_failures(&config, &counters, Duration::ZERO);
+    assert_eq!(
+        IndexDatabase::open_config(&config)
+            .unwrap()
+            .status(&config.database)
+            .unwrap()
+            .watch_placement_failures,
+        grown,
+        "once the DB is free the flush persists the higher count"
+    );
+}
+
+/// End-to-end: the event loop's between-pass DRAIN surfaces a placement failure in `index_status`
+/// WHILE the watcher runs, with the periodic sweep disabled and no pass dispatched — the exact case
+/// the post-resync flush exists for (#658 review). Records a failure into the loop's counters (as a
+/// resync would, after the pass persisted), wakes the loop, and asserts the drain persisted it.
+#[test]
+fn the_event_loop_drain_persists_a_placement_failure_while_running() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let root = tmp.path();
+    std::fs::create_dir_all(root.join("src")).unwrap();
+    std::fs::write(root.join("src/lib.rs"), "pub fn f() {}\n").unwrap();
+    let mut config = whole_root_config(root, &[PathBuf::from("src")]);
+    config.watch.periodic_sweep_secs = 0; // the exact case the drain must cover.
+    IndexDatabase::rebuild(&config).unwrap();
+
+    // A failure recorded into the loop's OWN counters — as the post-pass resync would, after the
+    // pass worker already persisted. Nothing is in `repo_meta` yet (no pass wrote it).
+    let counters = WatchPlacementCounters::default();
+    let ignore_m = IgnoreMatcher::compile(&config.root, &config.target_directories());
+    let mut failing = FailingWatcher;
+    watch_tree_pruned(&mut failing, &counters, &root.join("src"), &ignore_m);
+    let failures = counters.counts().1;
+    assert!(failures > 0);
+    assert_eq!(
+        IndexDatabase::open_config(&config)
+            .unwrap()
+            .status(&config.database)
+            .unwrap()
+            .watch_placement_failures,
+        0,
+        "precondition: no pass has persisted the count yet"
+    );
+
+    let target_dirs = config.target_directories();
+    let mut ignore = IgnoreMatcher::compile(&config.root, &target_dirs);
+    let mut linked_worktrees = LinkedWorktreeWatches::default();
+    let mut notify_watcher =
+        <RecordingWatcher as notify::Watcher>::new(|_| {}, notify::Config::default()).unwrap();
+    let (tx, rx) = std::sync::mpsc::channel();
+    let (pass_tx, pass_rx) = std::sync::mpsc::channel::<PassRequest>();
+    let pass_tx_for_loop = pass_tx.clone();
+    let mut scheduler = PassScheduler::new();
+    let stop = AtomicBool::new(false);
+    let mut fleet_trigger = |_: &Path| {};
+
+    let event_loop = EventLoop {
+        config: &config,
+        target_dirs: &target_dirs,
+        fleet_bin: None,
+        notify_watcher: &mut notify_watcher,
+        counters: &counters,
+        ignore: &mut ignore,
+        linked_worktrees: &mut linked_worktrees,
+        worktree_registry: None,
+        rx,
+        pass_tx: &pass_tx_for_loop,
+        scheduler: &mut scheduler,
+        papertrail_tx: None,
+        papertrail_interval: None,
+        stop: &stop,
+        fleet_trigger: &mut fleet_trigger,
+    };
+    std::thread::scope(|scope| {
+        let handle = scope.spawn(move || event_loop.run());
+        // Wake the loop so an iteration runs the tail drain, give it a moment, then stop.
+        tx.send(LoopMsg::Wake).unwrap();
+        std::thread::sleep(Duration::from_millis(150));
+        stop.store(true, Ordering::Relaxed);
+        tx.send(LoopMsg::Wake).unwrap();
+        drop(tx);
+        drop(pass_tx);
+        let _ = pass_rx;
+        handle.join().unwrap();
+    });
+
+    assert_eq!(
+        IndexDatabase::open_config(&config)
+            .unwrap()
+            .status(&config.database)
+            .unwrap()
+            .watch_placement_failures,
+        failures,
+        "the between-pass drain surfaces the drop in index_status while running (sweep disabled, \
+         no pass)"
+    );
 }
 
 #[test]
@@ -384,7 +744,7 @@ fn startup_catchup_retries_existing_base_embedding_backlog() {
     );
     drop(db);
 
-    startup_catchup_pass(&config).unwrap();
+    startup_catchup_pass(&config, None).unwrap();
     let db = IndexDatabase::open_config(&config).unwrap();
     assert_eq!(
         db.pending_embedding_jobs().unwrap(),
@@ -436,7 +796,7 @@ fn startup_catchup_skips_ephemeral_backlog_scan_without_query_endpoint() {
     drop(db);
 
     crate::index::ai::reset_estimated_reconcile_job_calls();
-    startup_catchup_pass(&config).unwrap();
+    startup_catchup_pass(&config, None).unwrap();
     assert_eq!(
         crate::index::ai::estimated_reconcile_job_calls(),
         0,
@@ -614,6 +974,7 @@ fn initial_watch_state_places_base_gitignore_and_fleet_surfaces() {
     let mut watcher = RecordingWatcher::default();
     let (linked_worktrees, registry) = place_initial_watch_state(
         &mut watcher,
+        &placement_counters(),
         &config,
         &target_dirs,
         &ignore,
@@ -668,6 +1029,7 @@ fn event_maintenance_helpers_place_dirs_recompile_and_refresh_linked_state() {
     assert_eq!(
         event_requests_maintenance(
             &mut watcher,
+            &placement_counters(),
             &create,
             &config,
             &target_dirs,
@@ -690,6 +1052,7 @@ fn event_maintenance_helpers_place_dirs_recompile_and_refresh_linked_state() {
     let before_recompile = watcher.watched.len();
     recompile_ignore_and_place_watches(
         &mut watcher,
+        &placement_counters(),
         &config,
         &target_dirs,
         &mut ignore,
@@ -700,7 +1063,12 @@ fn event_maintenance_helpers_place_dirs_recompile_and_refresh_linked_state() {
         "gitignore recompiles also re-place base target watches",
     );
 
-    sync_linked_worktrees_after_pass(&mut watcher, &config, &mut linked_worktrees);
+    sync_linked_worktrees_after_pass(
+        &mut watcher,
+        &placement_counters(),
+        &config,
+        &mut linked_worktrees,
+    );
     assert!(linked_worktrees.states.is_empty());
 
     std::fs::remove_dir_all(&root).ok();
@@ -728,6 +1096,7 @@ fn event_maintenance_helper_requests_pass_for_relevant_and_registry_events() {
     assert_eq!(
         event_requests_maintenance(
             &mut watcher,
+            &placement_counters(),
             &relevant_file,
             &config,
             &target_dirs,
@@ -744,6 +1113,7 @@ fn event_maintenance_helper_requests_pass_for_relevant_and_registry_events() {
     assert_eq!(
         event_requests_maintenance(
             &mut watcher,
+            &placement_counters(),
             &registry_event,
             &config,
             &target_dirs,
@@ -789,8 +1159,14 @@ fn initial_watch_state_places_worktree_registry() {
     let target_dirs = config.target_directories();
     let ignore = IgnoreMatcher::compile(&config.root, &target_dirs);
     let mut watcher = RecordingWatcher::default();
-    let (linked_worktrees, registry) =
-        place_initial_watch_state(&mut watcher, &config, &target_dirs, &ignore, None);
+    let (linked_worktrees, registry) = place_initial_watch_state(
+        &mut watcher,
+        &placement_counters(),
+        &config,
+        &target_dirs,
+        &ignore,
+        None,
+    );
     let registry = registry.expect("git worktree repo exposes a registry directory");
 
     assert!(
@@ -819,7 +1195,15 @@ fn watch_created_dirs_ignores_non_appearance_events() {
     let mut watcher = RecordingWatcher::default();
     let access = Event::new(EventKind::Access(AccessKind::Any)).add_path(root.join("src/fresh"));
 
-    assert!(!watch_created_dirs(&mut watcher, &access, &config, &target_dirs, &mut ignore, None));
+    assert!(!watch_created_dirs(
+        &mut watcher,
+        &placement_counters(),
+        &access,
+        &config,
+        &target_dirs,
+        &mut ignore,
+        None
+    ));
     assert!(watcher.watched.is_empty());
 }
 
@@ -939,7 +1323,9 @@ fn event_touches_worktree_matches_checkout_targets_and_registry() {
     let worktree = PathBuf::from("/wt/feat");
     let registry = PathBuf::from("/main/.git/worktrees");
     let mut watcher = RecordingWatcher::default();
-    let worktrees = watch_linked_worktrees(&mut watcher, &config, vec![worktree.clone()]);
+    let worktrees = watch_linked_worktrees(&mut watcher, &placement_counters(), &config, vec![
+        worktree.clone(),
+    ]);
 
     // A target file in a linked worktree fires (its overlay needs refreshing).
     assert!(
@@ -1020,7 +1406,10 @@ fn event_touches_worktree_attributes_the_touched_checkout_roots() {
     let wt_b = PathBuf::from("/wt/b");
     let registry = PathBuf::from("/main/.git/worktrees");
     let mut watcher = RecordingWatcher::default();
-    let worktrees = watch_linked_worktrees(&mut watcher, &config, vec![wt_a.clone(), wt_b.clone()]);
+    let worktrees = watch_linked_worktrees(&mut watcher, &placement_counters(), &config, vec![
+        wt_a.clone(),
+        wt_b.clone(),
+    ]);
 
     assert_eq!(
         event_touches_worktree(&mutation_event(wt_a.join("src/a.rs")), &worktrees, None),
@@ -1088,7 +1477,9 @@ fn linked_worktree_events_honor_its_ignore_rules() {
 
     let config = whole_root_config(&worktree, &[PathBuf::from(".")]);
     let mut watcher = RecordingWatcher::default();
-    let worktrees = watch_linked_worktrees(&mut watcher, &config, vec![worktree.clone()]);
+    let worktrees = watch_linked_worktrees(&mut watcher, &placement_counters(), &config, vec![
+        worktree.clone(),
+    ]);
 
     assert!(
         event_touches_worktree(&mutation_event(worktree.join("src/lib.rs")), &worktrees, None)
@@ -1141,7 +1532,9 @@ fn linked_worktree_watch_placement_uses_configured_pruned_targets() {
 
     let config = whole_root_config(&worktree, &[PathBuf::from("src")]);
     let mut watcher = RecordingWatcher::default();
-    let worktrees = watch_linked_worktrees(&mut watcher, &config, vec![worktree.clone()]);
+    let worktrees = watch_linked_worktrees(&mut watcher, &placement_counters(), &config, vec![
+        worktree.clone(),
+    ]);
     let state = &worktrees.states[0];
 
     assert_eq!(state.config.root, worktree);
@@ -1187,10 +1580,10 @@ fn linked_worktree_watch_set_sync_rebuilds_existing_root_state() {
     let extra_config = whole_root_config(&worktree, &[PathBuf::from("extra")]);
     let mut watcher = RecordingWatcher::default();
     let mut worktrees = LinkedWorktreeWatches::default();
-    worktrees.sync(&mut watcher, &src_config, vec![worktree.clone()]);
+    worktrees.sync(&mut watcher, &placement_counters(), &src_config, vec![worktree.clone()]);
     assert_eq!(worktrees.states[0].target_dirs, vec![PathBuf::from("src")]);
 
-    worktrees.sync(&mut watcher, &extra_config, vec![worktree.clone()]);
+    worktrees.sync(&mut watcher, &placement_counters(), &extra_config, vec![worktree.clone()]);
     assert_eq!(worktrees.states.len(), 1);
     assert_eq!(worktrees.states[0].target_dirs, vec![PathBuf::from("extra")]);
     assert!(
@@ -1213,13 +1606,15 @@ fn linked_worktree_watch_set_handles_created_dirs_and_recompile() {
 
     let config = whole_root_config(&worktree, &[PathBuf::from("src")]);
     let mut watcher = RecordingWatcher::default();
-    let mut worktrees = watch_linked_worktrees(&mut watcher, &config, vec![worktree.clone()]);
+    let mut worktrees = watch_linked_worktrees(&mut watcher, &placement_counters(), &config, vec![
+        worktree.clone(),
+    ]);
 
     let fresh = worktree.join("src/fresh");
     std::fs::create_dir_all(&fresh).unwrap();
     let create = Event::new(EventKind::Create(CreateKind::Folder)).add_path(fresh.clone());
     assert_eq!(
-        worktrees.watch_created_dirs(&mut watcher, &create),
+        worktrees.watch_created_dirs(&mut watcher, &placement_counters(), &create),
         BTreeSet::from([worktree.clone()]),
         "created target dirs should request a maintenance pass scoped to their checkout",
     );
@@ -1229,7 +1624,7 @@ fn linked_worktree_watch_set_handles_created_dirs_and_recompile() {
     );
 
     std::fs::write(worktree.join(".gitignore"), "src/fresh/\n").unwrap();
-    worktrees.recompile_ignore_and_place_watches(&mut watcher);
+    worktrees.recompile_ignore_and_place_watches(&mut watcher, &placement_counters());
     assert!(
         worktrees.states[0].ignore.is_ignored(&fresh, true),
         "recompile refreshes the state's matcher",
@@ -1252,14 +1647,16 @@ fn linked_worktree_watch_set_handles_created_target_ancestors() {
     let target_dirs = vec![PathBuf::from("src/generated")];
     let config = whole_root_config(&worktree, &target_dirs);
     let mut watcher = RecordingWatcher::default();
-    let mut worktrees = watch_linked_worktrees(&mut watcher, &config, vec![worktree.clone()]);
+    let mut worktrees = watch_linked_worktrees(&mut watcher, &placement_counters(), &config, vec![
+        worktree.clone(),
+    ]);
 
     watcher.watched.clear();
     let ancestor = worktree.join("src");
     std::fs::create_dir_all(&ancestor).unwrap();
     let create = Event::new(EventKind::Create(CreateKind::Folder)).add_path(ancestor.clone());
     assert_eq!(
-        worktrees.watch_created_dirs(&mut watcher, &create),
+        worktrees.watch_created_dirs(&mut watcher, &placement_counters(), &create),
         BTreeSet::from([worktree.clone()]),
         "created target ancestors should request a maintenance pass after placing watches",
     );
@@ -1300,7 +1697,9 @@ fn linked_worktree_target_ancestor_gitignore_is_compiled() {
     let target_dirs = vec![PathBuf::from("src/generated")];
     let config = whole_root_config(&worktree, &target_dirs);
     let mut watcher = RecordingWatcher::default();
-    let worktrees = watch_linked_worktrees(&mut watcher, &config, vec![worktree.clone()]);
+    let worktrees = watch_linked_worktrees(&mut watcher, &placement_counters(), &config, vec![
+        worktree.clone(),
+    ]);
     let ignore = &worktrees.states[0].ignore;
 
     assert!(
@@ -1346,7 +1745,9 @@ fn linked_subdir_root_watch_placement_keeps_checkout_root_when_config_root_missi
     let config = whole_root_config(&config_root, &target_dirs);
 
     let mut watcher = RecordingWatcher::default();
-    let worktrees = watch_linked_worktrees(&mut watcher, &config, vec![checkout.clone()]);
+    let worktrees = watch_linked_worktrees(&mut watcher, &placement_counters(), &config, vec![
+        checkout.clone(),
+    ]);
     let linked_root = checkout.join("packages/crate");
 
     assert_eq!(worktrees.states[0].config.root, linked_root);
@@ -1390,7 +1791,15 @@ fn watch_created_dirs_reinstalls_watches_for_recreated_config_root() {
     let create = Event::new(EventKind::Create(CreateKind::Folder)).add_path(root.clone());
 
     assert!(
-        watch_created_dirs(&mut watcher, &create, &config, &target_dirs, &mut ignore, None),
+        watch_created_dirs(
+            &mut watcher,
+            &placement_counters(),
+            &create,
+            &config,
+            &target_dirs,
+            &mut ignore,
+            None
+        ),
         "recreated config roots should re-place target watches and request maintenance",
     );
     assert!(
@@ -1433,6 +1842,7 @@ fn watch_created_dirs_bootstraps_missing_linked_subdir_root_ancestors() {
     assert!(
         watch_created_dirs(
             &mut watcher,
+            &placement_counters(),
             &create_packages,
             &config,
             &target_dirs,
@@ -1459,6 +1869,7 @@ fn watch_created_dirs_bootstraps_missing_linked_subdir_root_ancestors() {
     assert!(
         !watch_created_dirs(
             &mut watcher,
+            &placement_counters(),
             &create_vendor,
             &config,
             &target_dirs,
@@ -1486,7 +1897,9 @@ fn linked_created_target_dir_requests_maintenance_when_directory_event_is_not_re
     let target_dirs = vec![PathBuf::from("src")];
     let config = whole_root_config(&worktree, &target_dirs);
     let mut watcher = RecordingWatcher::default();
-    let mut worktrees = watch_linked_worktrees(&mut watcher, &config, vec![worktree.clone()]);
+    let mut worktrees = watch_linked_worktrees(&mut watcher, &placement_counters(), &config, vec![
+        worktree.clone(),
+    ]);
 
     watcher.watched.clear();
     let pkg = worktree.join("src/pkg");
@@ -1499,7 +1912,7 @@ fn linked_created_target_dir_requests_maintenance_when_directory_event_is_not_re
         "extensionless directory events are not target-file events",
     );
     assert_eq!(
-        worktrees.watch_created_dirs(&mut watcher, &create),
+        worktrees.watch_created_dirs(&mut watcher, &placement_counters(), &create),
         BTreeSet::from([worktree.clone()]),
         "placing a linked target-dir watch must request a maintenance pass",
     );
@@ -1530,8 +1943,10 @@ fn linked_created_dir_watch_signal_does_not_short_circuit_state_updates() {
     let target_dirs = vec![PathBuf::from("src")];
     let config = whole_root_config(&first, &target_dirs);
     let mut watcher = RecordingWatcher::default();
-    let mut worktrees =
-        watch_linked_worktrees(&mut watcher, &config, vec![first.clone(), second.clone()]);
+    let mut worktrees = watch_linked_worktrees(&mut watcher, &placement_counters(), &config, vec![
+        first.clone(),
+        second.clone(),
+    ]);
 
     watcher.watched.clear();
     let first_pkg = first.join("src/pkg");
@@ -1543,7 +1958,7 @@ fn linked_created_dir_watch_signal_does_not_short_circuit_state_updates() {
         .add_path(second_pkg.clone());
 
     assert_eq!(
-        worktrees.watch_created_dirs(&mut watcher, &create),
+        worktrees.watch_created_dirs(&mut watcher, &placement_counters(), &create),
         BTreeSet::from([first.clone(), second.clone()]),
         "BOTH linked states place their watch and are reported (no short-circuit)",
     );
@@ -1580,7 +1995,15 @@ fn watch_created_dirs_skips_dirs_ignored_before_or_after_recompile() {
     let already = root.join("src/already_ignored");
     let create_already =
         Event::new(EventKind::Create(CreateKind::Folder)).add_path(already.clone());
-    watch_created_dirs(&mut watcher, &create_already, &config, &target_dirs, &mut ignore, None);
+    watch_created_dirs(
+        &mut watcher,
+        &placement_counters(),
+        &create_already,
+        &config,
+        &target_dirs,
+        &mut ignore,
+        None,
+    );
     assert!(
         watcher.watched.iter().all(|(path, _)| path != &already),
         "a dir ignored before recompile should not be watched",
@@ -1589,7 +2012,15 @@ fn watch_created_dirs_skips_dirs_ignored_before_or_after_recompile() {
     std::fs::write(root.join(".gitignore"), "src/already_ignored/\nsrc/newly_ignored/\n").unwrap();
     let newly = root.join("src/newly_ignored");
     let create_newly = Event::new(EventKind::Create(CreateKind::Folder)).add_path(newly.clone());
-    watch_created_dirs(&mut watcher, &create_newly, &config, &target_dirs, &mut ignore, None);
+    watch_created_dirs(
+        &mut watcher,
+        &placement_counters(),
+        &create_newly,
+        &config,
+        &target_dirs,
+        &mut ignore,
+        None,
+    );
     assert!(
         watcher.watched.iter().all(|(path, _)| path != &newly),
         "a dir ignored only after recompile should not be watched",
@@ -1652,7 +2083,9 @@ fn event_touches_worktree_rebases_subdir_rooted_config() {
     let checkout =
         std::env::temp_dir().join(format!("ragrat-wt-subdir-co-{}-{id}", std::process::id()));
     let mut watcher = RecordingWatcher::default();
-    let worktrees = watch_linked_worktrees(&mut watcher, &config, vec![checkout.clone()]);
+    let worktrees = watch_linked_worktrees(&mut watcher, &placement_counters(), &config, vec![
+        checkout.clone(),
+    ]);
     assert!(
         event_touches_worktree(&mutation_event(checkout.join("crate/src/a.rs")), &worktrees, None,)
             .fires(),
@@ -2058,11 +2491,13 @@ fn a_pass_in_flight_does_not_starve_events_or_the_fleet_trigger() {
         let _ = fleet_tx.send(bin.to_path_buf());
     };
 
+    let counters = placement_counters();
     let event_loop = EventLoop {
         config: &config,
         target_dirs: &target_dirs,
         fleet_bin: Some(&fleet_bin),
         notify_watcher: &mut notify_watcher,
+        counters: &counters,
         ignore: &mut ignore,
         linked_worktrees: &mut linked_worktrees,
         worktree_registry: None,
@@ -2290,7 +2725,7 @@ fn root_gitignore_edit_is_delivered_to_a_real_watcher() {
     // + the ancestor gitignore chain. The root `.gitignore` edit is delivered by the chain
     // watch, not the target subtree, so the pruned placement doesn't weaken this assertion.
     let ignore = IgnoreMatcher::compile(&sub, &[PathBuf::from(".")]);
-    watch_tree_pruned(&mut w, &sub, &ignore);
+    watch_tree_pruned(&mut w, &placement_counters(), &sub, &ignore);
     for dir in gitignore_watch_dirs(&sub) {
         let _ = w.watch(&dir, RecursiveMode::NonRecursive);
     }
@@ -2438,7 +2873,7 @@ fn gitignored_subdir_under_a_target_is_not_watched() {
     };
     // Place watches exactly as watcher_main does: the gitignore-pruned target subtree.
     let ignore = IgnoreMatcher::compile(&root, &[PathBuf::from(".")]);
-    watch_tree_pruned(&mut w, &root, &ignore);
+    watch_tree_pruned(&mut w, &placement_counters(), &root, &ignore);
     drain_until_quiet(&rx, 100, 1000);
 
     // A write inside the gitignored subtree must NOT be delivered (the dir was never watched).
@@ -2481,14 +2916,22 @@ fn newly_created_non_ignored_dir_gets_watched() {
     let target_dirs = vec![PathBuf::from(".")];
     let config = whole_root_config(&root, &target_dirs);
     let mut ignore = IgnoreMatcher::compile(&root, &target_dirs);
-    watch_tree_pruned(&mut w, &root, &ignore);
+    watch_tree_pruned(&mut w, &placement_counters(), &root, &ignore);
 
     // Create a NEW non-ignored directory after the initial placement.
     let fresh = root.join("fresh_dir");
     std::fs::create_dir_all(&fresh).unwrap();
     // Feed the create event through the same handler watcher_main runs, which places the watch.
     let create = Event::new(EventKind::Create(CreateKind::Folder)).add_path(fresh.clone());
-    watch_created_dirs(&mut w, &create, &config, &target_dirs, &mut ignore, None);
+    watch_created_dirs(
+        &mut w,
+        &placement_counters(),
+        &create,
+        &config,
+        &target_dirs,
+        &mut ignore,
+        None,
+    );
 
     // A write inside the freshly-watched dir must now be delivered.
     std::fs::write(fresh.join("c.rs"), "// c\n").unwrap();
@@ -2581,14 +3024,22 @@ fn a_directory_moved_into_a_target_is_watched() {
     let target_dirs = vec![PathBuf::from(".")];
     let config = whole_root_config(&root, &target_dirs);
     let mut ignore = IgnoreMatcher::compile(&root, &target_dirs);
-    watch_tree_pruned(&mut w, &root, &ignore);
+    watch_tree_pruned(&mut w, &placement_counters(), &root, &ignore);
     // Simulate `mv` landing a directory into the target: create it, then feed a rename-To
     // event.
     let moved = root.join("moved_pkg");
     std::fs::create_dir_all(&moved).unwrap();
     let rename =
         Event::new(EventKind::Modify(ModifyKind::Name(RenameMode::To))).add_path(moved.clone());
-    watch_created_dirs(&mut w, &rename, &config, &target_dirs, &mut ignore, None);
+    watch_created_dirs(
+        &mut w,
+        &placement_counters(),
+        &rename,
+        &config,
+        &target_dirs,
+        &mut ignore,
+        None,
+    );
     std::fs::write(moved.join("d.rs"), "// d\n").unwrap();
     let seen = drain_until_path_under(&rx, &moved, 3);
     drop(w);
@@ -2619,12 +3070,12 @@ fn relaxing_an_ignore_rule_re_places_watches_on_the_unignored_subtree() {
     };
     // Startup placement against the original rules: the dir is ignored → NOT watched.
     let ignore = IgnoreMatcher::compile(&root, &[PathBuf::from(".")]);
-    watch_tree_pruned(&mut w, &root, &ignore);
+    watch_tree_pruned(&mut w, &placement_counters(), &root, &ignore);
     // Relax the rule, then recompile + RE-PLACE (what the loop now does on a `.gitignore`
     // edit).
     std::fs::write(root.join(".gitignore"), "").unwrap();
     let ignore = IgnoreMatcher::compile(&root, &[PathBuf::from(".")]);
-    watch_tree_pruned(&mut w, &root, &ignore);
+    watch_tree_pruned(&mut w, &placement_counters(), &root, &ignore);
     // An edit in the formerly-ignored (now eligible) subtree must now be delivered.
     std::fs::write(root.join("formerly_ignored/e.rs"), "// e edited\n").unwrap();
     let seen = drain_until_path_under(&rx, &root.join("formerly_ignored"), 3);
@@ -2669,13 +3120,21 @@ fn a_symlink_to_a_directory_is_not_followed_into_watches() {
     let target_dirs = vec![PathBuf::from(".")];
     let config = whole_root_config(&root, &target_dirs);
     let mut ignore = IgnoreMatcher::compile(&root, &target_dirs);
-    watch_tree_pruned(&mut w, &root, &ignore);
+    watch_tree_pruned(&mut w, &placement_counters(), &root, &ignore);
 
     // Symlink the outside dir UNDER the target, then feed its create event.
     let link = root.join("linked");
     std::os::unix::fs::symlink(&outside, &link).unwrap();
     let create = Event::new(EventKind::Create(CreateKind::Folder)).add_path(link.clone());
-    watch_created_dirs(&mut w, &create, &config, &target_dirs, &mut ignore, None);
+    watch_created_dirs(
+        &mut w,
+        &placement_counters(),
+        &create,
+        &config,
+        &target_dirs,
+        &mut ignore,
+        None,
+    );
 
     // An edit to the file INSIDE the link target must NOT be delivered (the link wasn't
     // watched, and the outside dir is not under config.root at all).
@@ -2715,7 +3174,7 @@ fn a_non_target_top_level_dir_is_not_watched() {
     let mut ignore = IgnoreMatcher::compile(&root, &target_dirs);
     // Watch the target subtree + (mirroring watcher_main) config.root itself non-recursively,
     // so a top-level create is delivered here exactly as it would be in production.
-    watch_tree_pruned(&mut w, &root.join("src"), &ignore);
+    watch_tree_pruned(&mut w, &placement_counters(), &root.join("src"), &ignore);
     let _ = w.watch(&root, RecursiveMode::NonRecursive);
 
     // A NON-target top-level dir: created + its event fed → must NOT be watched. Probe a file
@@ -2727,7 +3186,15 @@ fn a_non_target_top_level_dir_is_not_watched() {
     let vendor_sub = vendor.join("sub");
     std::fs::create_dir_all(&vendor_sub).unwrap();
     let vendor_ev = Event::new(EventKind::Create(CreateKind::Folder)).add_path(vendor.clone());
-    watch_created_dirs(&mut w, &vendor_ev, &config, &target_dirs, &mut ignore, None);
+    watch_created_dirs(
+        &mut w,
+        &placement_counters(),
+        &vendor_ev,
+        &config,
+        &target_dirs,
+        &mut ignore,
+        None,
+    );
     std::fs::write(vendor_sub.join("v.rs"), "// v\n").unwrap();
     let vendor_seen = drain_until_path_under(&rx, &vendor_sub, 2);
 
@@ -2735,7 +3202,15 @@ fn a_non_target_top_level_dir_is_not_watched() {
     let pkg = root.join("src/pkg");
     std::fs::create_dir_all(&pkg).unwrap();
     let pkg_ev = Event::new(EventKind::Create(CreateKind::Folder)).add_path(pkg.clone());
-    watch_created_dirs(&mut w, &pkg_ev, &config, &target_dirs, &mut ignore, None);
+    watch_created_dirs(
+        &mut w,
+        &placement_counters(),
+        &pkg_ev,
+        &config,
+        &target_dirs,
+        &mut ignore,
+        None,
+    );
     std::fs::write(pkg.join("p.rs"), "// p\n").unwrap();
     let pkg_seen = drain_until_path_under(&rx, &pkg, 3);
 
@@ -2776,7 +3251,7 @@ fn a_moved_in_dir_with_a_nested_gitignore_prunes_against_it() {
     let target_dirs = vec![PathBuf::from(".")];
     let config = whole_root_config(&root, &target_dirs);
     let mut ignore = IgnoreMatcher::compile(&root, &target_dirs);
-    watch_tree_pruned(&mut w, &root, &ignore);
+    watch_tree_pruned(&mut w, &placement_counters(), &root, &ignore);
     drain_until_quiet(&rx, 100, 1000);
 
     // Build the moved-in dir with a NESTED `.gitignore` ignoring `ignored_sub/`, plus a kept
@@ -2789,7 +3264,15 @@ fn a_moved_in_dir_with_a_nested_gitignore_prunes_against_it() {
     std::fs::write(pkg.join("kept_sub/deep/y.rs"), "// y\n").unwrap();
     let rename =
         Event::new(EventKind::Modify(ModifyKind::Name(RenameMode::To))).add_path(pkg.clone());
-    watch_created_dirs(&mut w, &rename, &config, &target_dirs, &mut ignore, None);
+    watch_created_dirs(
+        &mut w,
+        &placement_counters(),
+        &rename,
+        &config,
+        &target_dirs,
+        &mut ignore,
+        None,
+    );
     drain_until_quiet(&rx, 100, 1000);
 
     // The nested-ignored subdir must NOT be watched; the kept sibling MUST be.
@@ -2850,11 +3333,13 @@ fn event_loop_ignores_fs_errors_and_exits_on_disconnect() {
     let stop = AtomicBool::new(false);
     let mut fleet_trigger = |_: &Path| {};
 
+    let counters = placement_counters();
     let event_loop = EventLoop {
         config: &config,
         target_dirs: &target_dirs,
         fleet_bin: None,
         notify_watcher: &mut notify_watcher,
+        counters: &counters,
         ignore: &mut ignore,
         linked_worktrees: &mut linked_worktrees,
         worktree_registry: None,
@@ -2901,11 +3386,13 @@ fn periodic_sweep_dispatches_all_overlay_scope() {
     let stop = AtomicBool::new(false);
     let mut fleet_trigger = |_: &Path| {};
 
+    let counters = placement_counters();
     let event_loop = EventLoop {
         config: &config,
         target_dirs: &target_dirs,
         fleet_bin: None,
         notify_watcher: &mut notify_watcher,
+        counters: &counters,
         ignore: &mut ignore,
         linked_worktrees: &mut linked_worktrees,
         worktree_registry: None,
@@ -3051,11 +3538,13 @@ fn idle_watcher_enqueues_papertrail_evaluation_without_filesystem_activity() {
     let stop = AtomicBool::new(false);
     let mut fleet_trigger = |_: &Path| {};
 
+    let counters = placement_counters();
     let event_loop = EventLoop {
         config: &config,
         target_dirs: &target_dirs,
         fleet_bin: None,
         notify_watcher: &mut notify_watcher,
+        counters: &counters,
         ignore: &mut ignore,
         linked_worktrees: &mut linked_worktrees,
         worktree_registry: None,
@@ -3104,11 +3593,13 @@ fn papertrail_deadline_fires_during_an_in_flight_pass_and_ticks_coalesce() {
     let stop = AtomicBool::new(false);
     let mut fleet_trigger = |_: &Path| {};
 
+    let counters = placement_counters();
     let event_loop = EventLoop {
         config: &config,
         target_dirs: &target_dirs,
         fleet_bin: None,
         notify_watcher: &mut notify_watcher,
+        counters: &counters,
         ignore: &mut ignore,
         linked_worktrees: &mut linked_worktrees,
         worktree_registry: None,


### PR DESCRIPTION
Fixes #658.

## Problem

A directory whose `notify::Watcher::watch` call fails — on Linux, `ENOSPC` once `fs.inotify.max_user_watches` is exhausted; on any OS, a transient failure — silently falls back to the periodic mtime sweep. Until now that degradation was invisible: graph/symbol queries could go stale between sweeps with no signal that real-time watching was partially down.

## Change

Count every watch-placement outcome through the single `place_watch` choke point into per-watcher `WatchPlacementCounters` (interior atomics, shared via `Arc` between the event-loop thread that records placements and the pass worker that reads them). Each pass persists the failure count into `repo_meta`, and `index_status` surfaces it as `watch_placement_failures`. A coalesced `warn!` fires once per new batch of drops (never per directory), correct across a restart via an instance-local last-warned mark.

Key properties:

- **Owned by the watcher instance, not a process global.** One repo config's placement outcomes can never be attributed to another's, and the counts don't outlive the watcher's shutdown. Hook/CLI passes own no watcher and record nothing (`None`) — they place no watches and must not touch the resident watcher's mark.
- **High-water mark, never lowered.** A healthy or freshly-restarted watcher sharing the DB can't erase a concurrently degraded watcher's record; the persist is an atomic max-upsert (single statement), so a concurrent same-repo writer can't regress it. It is a degradation *signal* (per-lifetime maximum), documented as such — not a live "currently degraded" gauge.
- **Absent directories are not counted.** A watch that failed because a configured target doesn't exist yet — a not-yet-created target dir, a branch-specific subdir, a worktree registry that appears later — is an expected miss already covered by the ancestor/bootstrap/created-dir watches, so it does not peg the mark or emit a spurious ENOSPC warning. Only a watch that failed on a directory that *exists* is a real drop.
- **Shutdown flush.** The post-pass linked-worktree sync places watches after the pass already persisted the counter, so the watcher flushes the final mark on the way out — otherwise a drop introduced there, on a periodic-sweep-disabled watcher with no further events, would never be recorded. Best-effort and bounded; a no-op (no DB open) when nothing ever failed.

A failed watch on a directory skips its whole unwalked subtree exactly as before — only the visibility changes.

## Tests

- Failed placements are counted and the subtree is still skipped (per-watcher instances, no cross-test global state).
- A watch failure on an *absent* directory is not counted; the same failing watcher on an existing dir is.
- The shutdown flush persists the mark into `index_status`.
- `index_status` round-trips the value through `repo_meta` with high-water semantics.

Full workspace suite green (`cargo nextest run --workspace --no-default-features`); all three CI clippy gates pass.