### PR TITLE
chore: add cargo-audit + cargo-deny supply-chain CI

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,72 @@
+name: Supply chain
+
+# Two complementary supply-chain gates:
+#   cargo-deny  — advisories + licenses + bans + sources, config in deny.toml
+#   cargo-audit — the canonical RustSec vulnerability scan over Cargo.lock
+# They overlap on advisories by design (belt and suspenders); cargo-deny additionally enforces the
+# license allow-list and source/registry policy, while cargo-audit is the reference RustSec tool.
+#
+# On PR/push these only need to run when the dependency set or policy changes, so they are
+# path-filtered. The scheduled run has no such filter: it catches advisories newly published against
+# dependencies that did not otherwise change.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '**/Cargo.toml'
+      - 'Cargo.lock'
+      # All files cargo-deny loads as policy: deny.toml plus the optional exception files it also
+      # reads (deny.exceptions.toml, .deny.exceptions.toml, .cargo/deny.exceptions.toml). We do not
+      # ship exception files today, but if one is added it must trip this gate on the PR that adds it.
+      - 'deny.toml'
+      - 'deny.exceptions.toml'
+      - '.deny.exceptions.toml'
+      - '.cargo/deny.exceptions.toml'
+      - '.github/workflows/security.yml'
+  pull_request:
+    paths:
+      - '**/Cargo.toml'
+      - 'Cargo.lock'
+      # All files cargo-deny loads as policy: deny.toml plus the optional exception files it also
+      # reads (deny.exceptions.toml, .deny.exceptions.toml, .cargo/deny.exceptions.toml). We do not
+      # ship exception files today, but if one is added it must trip this gate on the PR that adds it.
+      - 'deny.toml'
+      - 'deny.exceptions.toml'
+      - '.deny.exceptions.toml'
+      - '.cargo/deny.exceptions.toml'
+      - '.github/workflows/security.yml'
+  schedule:
+    # Daily at 07:13 UTC — new RustSec advisories land against an unchanged Cargo.lock.
+    - cron: '13 7 * * *'
+  workflow_dispatch:
+
+# Least privilege: these jobs only read the repo.
+permissions:
+  contents: read
+
+concurrency:
+  group: security-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  cargo-deny:
+    name: cargo-deny
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: taiki-e/install-action@cargo-deny
+      # Runs all four checks (advisories, bans, licenses, sources) per deny.toml.
+      - run: cargo deny check
+
+  cargo-audit:
+    name: cargo-audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: taiki-e/install-action@cargo-audit
+      # Fails only on vulnerabilities; unmaintained/unsound advisories surface as warnings.
+      - run: cargo audit

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,9 +113,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "approx"
@@ -312,6 +312,17 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "chrono"
@@ -584,9 +595,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1266,11 +1277,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1280,8 +1289,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2176,7 +2188,7 @@ dependencies = [
  "indicatif 0.17.11",
  "libc",
  "log",
- "rand",
+ "rand 0.9.4",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -2195,7 +2207,7 @@ dependencies = [
  "indicatif 0.18.4",
  "libc",
  "log",
- "rand",
+ "rand 0.9.4",
  "reqwest",
  "serde",
  "serde_json",
@@ -2880,9 +2892,9 @@ checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]
@@ -3393,14 +3405,15 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "lru-slab",
- "rand",
+ "rand 0.10.2",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3553,6 +3566,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3578,6 +3602,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -4556,7 +4595,7 @@ dependencies = [
  "macro_rules_attribute",
  "monostate",
  "paste",
- "rand",
+ "rand 0.9.4",
  "rayon",
  "rayon-cond",
  "regex",
@@ -4589,7 +4628,7 @@ dependencies = [
  "monostate",
  "onig",
  "paste",
- "rand",
+ "rand 0.9.4",
  "rayon",
  "rayon-cond",
  "regex",

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,77 @@
+# cargo-deny configuration — supply-chain gate for the rag-rat workspace.
+#
+# Checks (see `.github/workflows/security.yml`):
+#   advisories — RustSec vulnerabilities / unsound / unmaintained against Cargo.lock
+#   licenses   — every crate in the graph resolves to a license on the allow list below
+#   bans       — no wildcard version requirements; duplicate versions are surfaced (warn)
+#   sources    — crates come only from crates.io (no unknown registries or git deps)
+#
+# Run locally with: cargo deny check
+# Lint levels: deny = error/fail, warn = surfaced but non-fatal, allow = silent.
+
+[graph]
+# Check every target triple (no `targets` filter): a platform-specific dependency can carry a
+# platform-specific advisory, and we would rather see all of them than narrow to one host.
+# `all-features` pulls every optional/feature-gated crate into the graph so cargo-deny sees the same
+# full dependency set `cargo audit` reads from Cargo.lock (e.g. quinn-proto, gated behind a feature).
+all-features = true
+
+[advisories]
+version = 2
+# `unsound` and `unmaintained` are advisory SCOPES (all/workspace/transitive/none), not lint levels.
+# unsound = "all": fail on an unsound advisory anywhere in the graph, transitive included — the
+# default "workspace" scope would let a transitive unsound advisory stay green. Vulnerabilities
+# always fail in the version-2 format; there is no `vulnerability` scope to set.
+unsound = "all"
+# unmaintained = "workspace": fail only on unmaintained crates the workspace depends on DIRECTLY
+# (actionable). Transitive unmaintained crates — which we cannot upgrade away — are surfaced by
+# `cargo audit` on the scheduled run but do not break CI. This deliberately avoids per-advisory
+# `ignore` entries, whose narrow rationale (e.g. "dev-only") silently goes stale if the crate later
+# becomes reachable from a runtime dependency and the global ignore keeps suppressing it.
+unmaintained = "workspace"
+
+[licenses]
+version = 2
+# Confidence required when matching a crate's license text to an SPDX id. 0.8 is the cargo-deny
+# default and tolerates the minor header reformatting some crates ship.
+confidence-threshold = 0.8
+# Check dev- and build-dependencies too, not just the crates that ship in the binary — the gate is
+# meant to cover every crate in the graph, and cargo-deny excludes both of these by default.
+include-dev = true
+include-build = true
+# Every license below is either the sole license of at least one crate in the tree, or the branch a
+# dual-/multi-licensed crate resolves to. All are OSI-permissive or public-domain-equivalent. No
+# strong-copyleft (GPL/AGPL/LGPL) license is accepted — the LGPL-tagged crates in the tree (r-efi)
+# are `MIT OR Apache-2.0 OR LGPL` and resolve to MIT. MPL-2.0 is handled as a scoped exception below.
+allow = [
+  "MIT",
+  "Apache-2.0",
+  "Apache-2.0 WITH LLVM-exception",
+  "BSD-2-Clause",
+  "BSD-3-Clause",
+  "ISC",
+  "Zlib",
+  "Unicode-3.0",
+  "CC0-1.0",
+  "CDLA-Permissive-2.0",
+  "BlueOak-1.0.0",
+]
+
+# MPL-2.0 is weak, file-level copyleft. It is accepted for exactly one crate — option-ext (a
+# transitive dep via dirs) — as a scoped exception rather than a workspace-wide allow, so a future
+# MPL-licensed dependency is forced through review instead of satisfying the gate silently.
+[[licenses.exceptions]]
+crate = "option-ext"
+allow = ["MPL-2.0"]
+
+[bans]
+# The tree carries several duplicate major versions (windows-sys, hashbrown, thiserror, tokenizers,
+# ureq, …) that we do not control from here; surface them without failing CI.
+multiple-versions = "warn"
+# A `version = "*"` requirement in one of our own manifests is a supply-chain footgun — deny it.
+wildcards = "deny"
+
+[sources]
+# crates.io only. An unknown registry or a git dependency must be a deliberate, reviewed choice.
+unknown-registry = "deny"
+unknown-git = "deny"


### PR DESCRIPTION
Adds two supply-chain gates to CI and brings the dependency tree to a clean advisory baseline.

## What

- **`deny.toml`** — cargo-deny policy covering advisories, licenses, bans, and sources:
  - License allow-list derived from the actual dependency tree (all permissive / public-domain-equivalent). `MPL-2.0` is accepted for the single `option-ext` crate — weak, file-level copyleft; no strong copyleft is allowed. The `LGPL`-tagged crates in the tree (`r-efi`) are `MIT OR Apache-2.0 OR LGPL` and resolve to MIT.
  - `all-features` graph so cargo-deny checks the same full dependency set cargo-audit reads from `Cargo.lock` (e.g. feature-gated `quinn-proto`).
  - Wildcard version requirements, unknown registries, and git sources are denied.
  - Four transitive `unmaintained` advisories are ignored with a documented reason each (no upstream fix; two are dev-only via the bench harness).
- **`.github/workflows/security.yml`** — a "Supply chain" workflow with `cargo-deny` and `cargo-audit` jobs, installed via `taiki-e/install-action` (matching the existing CI style). Runs on dependency/policy-touching PRs and pushes, a **daily schedule** (catches new advisories against an unchanged lock), and manual dispatch. Least-privilege `contents: read`.
- **`Cargo.lock`** — fixes the advisories the tools surfaced, upgrading within semver:
  - `crossbeam-epoch` 0.9.18 → 0.9.20 (RUSTSEC-2026-0204)
  - `quinn-proto` 0.11.14 → 0.11.16 (RUSTSEC-2026-0185, high)
  - `anyhow` 1.0.102 → 1.0.103 (RUSTSEC-2026-0190, unsound)
  - `memmap2` 0.9.10 → 0.9.11 (RUSTSEC-2026-0186, unsound)

## Verification

- `cargo deny check` → advisories / bans / licenses / sources all ok (exit 0)
- `cargo audit` → 0 vulnerabilities (4 non-fatal `unmaintained` warnings)
- `cargo check --workspace --no-default-features --locked` → clean build on the bumped lock

## Note

The PR/push triggers are path-filtered to dependency/policy changes. If these should become **required** branch-protection checks, that filter needs removing — GitHub leaves a skipped required check pending and blocks the merge.
