### PR TITLE
ci: lint feature-gated code with an all-features clippy job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,25 @@ jobs:
           components: clippy
       - uses: Swatinem/rust-cache@v2
       # --no-default-features = hash-only build: no ONNX/model downloads, fast and network-free.
-      # The full feature set is compile-checked by the build-full job below.
+      # This lints the cfg(not(feature = ...)) branches; the feature-gated code is linted by the
+      # clippy-all-features job below.
       - run: cargo clippy --workspace --all-targets --no-default-features --locked -- -D warnings
+
+  clippy-all-features:
+    name: clippy (all features)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      # The all-features graph compiles ort/fastembed, which downloads the ONNX runtime; force
+      # ort-sys to re-emit its link metadata for the current cache location (matches build-full).
+      - run: cargo clean -p ort-sys
+      # Lints fastembed, model2vec, and eval — the feature-gated code the --no-default-features
+      # clippy job never compiles.
+      - run: cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
 
   test:
     name: test


### PR DESCRIPTION
Lints the feature-gated code that CI currently never compiles.

## What

- **`clippy (all features)` job** — a new CI job running `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`. The existing `clippy` job runs `--no-default-features` (a fast, network-free hash-only build), so the feature-gated code — `fastembed`, `model2vec`, and `eval` — was never linted. The new job compiles the full graph (ort/fastembed pulls the ONNX runtime, cached via rust-cache with the same `ort-sys` handling as `build-full`) and lints it under `-D warnings`. Together the two jobs cover both the `cfg(feature = …)` and `cfg(not(feature = …))` branches.

## Verification

- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` → clean (the feature-gated code is already lint-clean)
- `cargo clippy --workspace --all-targets --no-default-features --locked -- -D warnings` → clean
- The job passed on the initial CI run (`clippy (all features)` green, ~3 min cold ONNX compile).
