### PR TITLE
fix(fts): detect FTS5 shadow corruption at the query layer and self-heal from durable sources

### DIFF
--- a/crates/rag-rat-core/src/index/fts.rs
+++ b/crates/rag-rat-core/src/index/fts.rs
@@ -9,6 +9,8 @@
 //! pay a full FTS rebuild forever after a sibling synced (stale-dirty loop). Do NOT route these
 //! back through `self.repo_meta` / `self.set_repo_meta`.
 
+use anyhow::Context as _;
+
 use super::*;
 
 impl IndexDatabase {
@@ -144,5 +146,182 @@ impl IndexDatabase {
 
     pub(super) fn fts_dirty(&self) -> anyhow::Result<bool> {
         Ok(self.meta("fts_dirty")?.as_deref() == Some("true"))
+    }
+}
+
+impl IndexDatabase {
+    /// #582: rebuild EVERY FTS mirror from its durable source, THROUGH THIS CONNECTION — the
+    /// corruption-recovery path behind [`retry_once_on_fts_corruption`]. All-of-them because the
+    /// bare "database disk image is malformed" a corrupt read returns does not name the table
+    /// (the #582 incident burned three wrong theories on exactly that); every mirror rebuilds
+    /// losslessly (`chunk_fts`/`commit_fts` from the chunk/commit stores, `repo_memory_fts` from
+    /// `repo_memories`, `github_fts` from the papertrail tables), so over-healing costs one
+    /// re-tokenize, not data. Healing through the querying connection is what makes the fix
+    /// visible to a long-lived server: an out-of-band repair leaves the connection's cached
+    /// corrupt pages serving `SQLITE_CORRUPT` indefinitely.
+    pub(crate) fn heal_corrupt_fts(&self) -> anyhow::Result<()> {
+        let conn = self.storage.connection();
+        // ONE `BEGIN IMMEDIATE` transaction fences the whole heal. The mirrors are GLOBAL on a
+        // consolidated DB while write flocks are per-repo, so a flock cannot serialize sibling
+        // repos' writers — the DATABASE-wide write lock can, and it also makes the
+        // multi-statement rebuilds one atomic unit. An active writer makes the BEGIN fail
+        // (busy timeout) and a connection already inside a transaction (a heal firing from
+        // within a pass) cannot open one — both surface here and the caller returns the
+        // ORIGINAL corruption error; the next query (or explicit `heal_index`) retries.
+        let fence =
+            rusqlite::Transaction::new_unchecked(conn, rusqlite::TransactionBehavior::Immediate)?;
+        self.rebuild_fts()?;
+        crate::query::memory::heal_repo_memory_fts(conn)?;
+        crate::index::papertrail::rebuild_fts(conn)?;
+        fence.commit()?;
+        Ok(())
+    }
+}
+
+impl IndexDatabase {
+    /// `heal_index`'s FTS phase (#582): probe each mirror with a query that EXECUTES rank — only
+    /// rank/bm25 decodes docsize, the corruption class BOTH `PRAGMA integrity_check` and FTS5's
+    /// own `'integrity-check'` miss (a COUNT over the same MATCH passes; the ORDER BY is
+    /// optimized away) — and rebuild the mirrors whose probe returns SQLITE_CORRUPT. Returns the
+    /// rebuilt table names. The broad prefix disjunction matches essentially any text corpus; an
+    /// empty mirror matches nothing and probes clean, which is right (nothing ranks it).
+    pub(crate) fn heal_fts_if_corrupt(&self) -> anyhow::Result<Vec<String>> {
+        // Every a-z/0-9 prefix: any token leading with an ASCII alphanumeric matches, so the
+        // ranked probe reads docsize for essentially every row a real query could rank. (A corpus
+        // of exclusively non-ASCII-leading tokens would evade it; the query-layer retry still
+        // covers those.)
+        let probe_query =
+            ('a'..='z').chain('0'..='9').map(|c| format!("{c}*")).collect::<Vec<_>>().join(" OR ");
+        let conn = self.storage.connection();
+        let probe_corrupt = |table: &str| -> anyhow::Result<bool> {
+            let sql =
+                format!("SELECT rowid FROM {table} WHERE {table} MATCH ?1 ORDER BY rank LIMIT 1");
+            match conn.query_row(&sql, [probe_query.as_str()], |_| Ok(())) {
+                Ok(()) | Err(rusqlite::Error::QueryReturnedNoRows) => Ok(false),
+                Err(err) => {
+                    let err: anyhow::Error = err.into();
+                    if error_is_fts_corruption(&err) { Ok(true) } else { Err(err) }
+                },
+            }
+        };
+        let mut healed = Vec::new();
+        // chunk_fts and commit_fts share one recovery (`rebuild_fts` repopulates both).
+        let chunk_corrupt = probe_corrupt("chunk_fts")?;
+        let commit_corrupt = probe_corrupt("commit_fts")?;
+        let memory_corrupt = probe_corrupt("repo_memory_fts")?;
+        let github_corrupt = probe_corrupt("github_fts")?;
+        if !(chunk_corrupt || commit_corrupt || memory_corrupt || github_corrupt) {
+            return Ok(healed);
+        }
+        // Same database-wide fence as `heal_corrupt_fts`: the rebuilds are global and
+        // multi-statement, and per-repo flocks cannot serialize a consolidated DB's siblings.
+        let fence =
+            rusqlite::Transaction::new_unchecked(conn, rusqlite::TransactionBehavior::Immediate)?;
+        if chunk_corrupt || commit_corrupt {
+            self.rebuild_fts()?;
+            if chunk_corrupt {
+                healed.push("chunk_fts".to_string());
+            }
+            if commit_corrupt {
+                healed.push("commit_fts".to_string());
+            }
+        }
+        if memory_corrupt {
+            crate::query::memory::heal_repo_memory_fts(conn)?;
+            healed.push("repo_memory_fts".to_string());
+        }
+        if github_corrupt {
+            crate::index::papertrail::rebuild_fts(conn)?;
+            healed.push("github_fts".to_string());
+        }
+        fence.commit()?;
+        Ok(healed)
+    }
+}
+
+/// #582: whether `err`'s chain contains SQLITE_CORRUPT — the FTS5 shadow-table variant surfaces
+/// as extended `SQLITE_CORRUPT_VTAB` (267), whose primary code rusqlite maps to
+/// `DatabaseCorrupt`, rendered as the bare "database disk image is malformed".
+pub(crate) fn error_is_fts_corruption(err: &anyhow::Error) -> bool {
+    err.chain().any(|cause| {
+        matches!(
+            cause.downcast_ref::<rusqlite::Error>(),
+            Some(rusqlite::Error::SqliteFailure(e, _))
+                if e.code == rusqlite::ErrorCode::DatabaseCorrupt
+        )
+    })
+}
+
+/// Run `op`; when it fails with FTS corruption, run `heal` and retry ONCE. A non-corruption
+/// error, a heal failure, and corruption that survives the heal all surface unchanged — there is
+/// deliberately no loop (#582).
+pub(crate) fn retry_once_on_fts_corruption<T>(
+    mut op: impl FnMut() -> anyhow::Result<T>,
+    heal: impl FnOnce() -> anyhow::Result<()>,
+) -> anyhow::Result<T> {
+    match op() {
+        Ok(value) => Ok(value),
+        Err(err) if error_is_fts_corruption(&err) => {
+            heal().context("healing corrupt FTS indexes (#582)")?;
+            op()
+        },
+        Err(err) => Err(err),
+    }
+}
+
+#[cfg(test)]
+mod corruption_tests {
+    use super::*;
+
+    fn corrupt_error() -> anyhow::Error {
+        rusqlite::Error::SqliteFailure(
+            rusqlite::ffi::Error {
+                code: rusqlite::ErrorCode::DatabaseCorrupt,
+                extended_code: 267, // SQLITE_CORRUPT_VTAB — the FTS5 shadow variant
+            },
+            Some("database disk image is malformed".to_string()),
+        )
+        .into()
+    }
+
+    #[test]
+    fn corruption_retries_once_after_heal() {
+        let mut calls = 0;
+        let mut healed = false;
+        let result = retry_once_on_fts_corruption(
+            || {
+                calls += 1;
+                if calls == 1 { Err(corrupt_error()) } else { Ok(42) }
+            },
+            || {
+                healed = true;
+                Ok(())
+            },
+        );
+        assert_eq!(result.unwrap(), 42);
+        assert!(healed, "the heal ran between the attempts");
+    }
+
+    #[test]
+    fn non_corruption_errors_do_not_heal() {
+        let result: anyhow::Result<i32> = retry_once_on_fts_corruption(
+            || anyhow::bail!("some other failure"),
+            || panic!("a non-corruption error must not trigger the heal"),
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn corruption_that_survives_the_heal_surfaces_without_looping() {
+        let mut calls = 0;
+        let result: anyhow::Result<i32> = retry_once_on_fts_corruption(
+            || {
+                calls += 1;
+                Err(corrupt_error())
+            },
+            || Ok(()),
+        );
+        assert!(error_is_fts_corruption(&result.unwrap_err()));
+        assert_eq!(calls, 2, "exactly one retry, no loop");
     }
 }

--- a/crates/rag-rat-core/src/index/fts.rs
+++ b/crates/rag-rat-core/src/index/fts.rs
@@ -222,7 +222,7 @@ impl IndexDatabase {
     /// optimized away) — and rebuild the mirrors whose probe returns SQLITE_CORRUPT. Returns the
     /// rebuilt table names. The broad prefix disjunction matches essentially any text corpus; an
     /// empty mirror matches nothing and probes clean, which is right (nothing ranks it).
-    pub(crate) fn heal_fts_if_corrupt(&self) -> anyhow::Result<Vec<String>> {
+    pub(crate) fn heal_fts_if_corrupt(&self) -> anyhow::Result<FtsHealOutcome> {
         // Every a-z/0-9 prefix: any token leading with an ASCII alphanumeric matches, so the
         // ranked probe reads docsize for essentially every row a real query could rank. (A corpus
         // of exclusively non-ASCII-leading tokens would evade it; the query-layer retry still
@@ -241,14 +241,14 @@ impl IndexDatabase {
                 },
             }
         };
-        let mut healed = Vec::new();
+        let mut outcome = FtsHealOutcome::default();
         // chunk_fts and commit_fts share one recovery (`rebuild_fts` repopulates both).
         let chunk_corrupt = probe_corrupt("chunk_fts")?;
         let commit_corrupt = probe_corrupt("commit_fts")?;
         let memory_corrupt = probe_corrupt("repo_memory_fts")?;
         let papertrail_corrupt = probe_corrupt("papertrail_fts")?;
         if !(chunk_corrupt || commit_corrupt || memory_corrupt || papertrail_corrupt) {
-            return Ok(healed);
+            return Ok(outcome);
         }
         // Same database-wide fence as `heal_corrupt_fts`: the rebuilds are global and
         // multi-statement, and per-repo flocks cannot serialize a consolidated DB's siblings.
@@ -256,23 +256,36 @@ impl IndexDatabase {
             rusqlite::Transaction::new_unchecked(conn, rusqlite::TransactionBehavior::Immediate)?;
         // Same staged-rows refusal as `heal_corrupt_fts` — the memory/papertrail heals below are
         // unaffected (their sources are always complete).
-        if (chunk_corrupt || commit_corrupt) && !self.staged_files_generation_exists()? {
-            // The shared rebuild repopulates BOTH mirrors regardless of which probe failed —
-            // report both, so the heal report states what was actually rebuilt.
-            self.rebuild_fts()?;
-            healed.push("chunk_fts".to_string());
-            healed.push("commit_fts".to_string());
+        if chunk_corrupt || commit_corrupt {
+            if self.staged_files_generation_exists()? {
+                // A silent skip here would let the report read healthy while ranked queries
+                // still fail — surface the deferral so the caller reruns after the staged
+                // rebuild completes.
+                for (corrupt, table) in
+                    [(chunk_corrupt, "chunk_fts"), (commit_corrupt, "commit_fts")]
+                {
+                    if corrupt {
+                        outcome.deferred.push(table.to_string());
+                    }
+                }
+            } else {
+                // The shared rebuild repopulates BOTH mirrors regardless of which probe failed
+                // — report both, so the heal report states what was actually rebuilt.
+                self.rebuild_fts()?;
+                outcome.healed.push("chunk_fts".to_string());
+                outcome.healed.push("commit_fts".to_string());
+            }
         }
         if memory_corrupt {
             crate::query::memory::heal_repo_memory_fts(conn)?;
-            healed.push("repo_memory_fts".to_string());
+            outcome.healed.push("repo_memory_fts".to_string());
         }
         if papertrail_corrupt {
             crate::index::papertrail::rebuild_fts(conn)?;
-            healed.push("papertrail_fts".to_string());
+            outcome.healed.push("papertrail_fts".to_string());
         }
         fence.commit()?;
-        Ok(healed)
+        Ok(outcome)
     }
 }
 
@@ -294,6 +307,14 @@ pub(crate) fn fenced_when_autocommit(
     op()?;
     fence.commit()?;
     Ok(())
+}
+
+/// What one FTS corruption sweep did: the mirrors rebuilt, and the corrupt mirrors whose
+/// repair had to wait for an in-flight generation-staged rebuild (#582).
+#[derive(Debug, Default)]
+pub(crate) struct FtsHealOutcome {
+    pub(crate) healed: Vec<String>,
+    pub(crate) deferred: Vec<String>,
 }
 
 /// #582: whether `err`'s chain contains SQLITE_CORRUPT — the FTS5 shadow-table variant surfaces

--- a/crates/rag-rat-core/src/index/fts.rs
+++ b/crates/rag-rat-core/src/index/fts.rs
@@ -222,7 +222,7 @@ impl IndexDatabase {
     /// optimized away) — and rebuild the mirrors whose probe returns SQLITE_CORRUPT. Returns the
     /// rebuilt table names. The broad prefix disjunction matches essentially any text corpus; an
     /// empty mirror matches nothing and probes clean, which is right (nothing ranks it).
-    pub(crate) fn heal_fts_if_corrupt(&self) -> anyhow::Result<FtsHealOutcome> {
+    pub fn heal_fts_if_corrupt(&self) -> anyhow::Result<FtsHealOutcome> {
         // Every a-z/0-9 prefix: any token leading with an ASCII alphanumeric matches, so the
         // ranked probe reads docsize for essentially every row a real query could rank. (A corpus
         // of exclusively non-ASCII-leading tokens would evade it; the query-layer retry still
@@ -312,15 +312,15 @@ pub(crate) fn fenced_when_autocommit(
 /// What one FTS corruption sweep did: the mirrors rebuilt, and the corrupt mirrors whose
 /// repair had to wait for an in-flight generation-staged rebuild (#582).
 #[derive(Debug, Default)]
-pub(crate) struct FtsHealOutcome {
-    pub(crate) healed: Vec<String>,
-    pub(crate) deferred: Vec<String>,
+pub struct FtsHealOutcome {
+    pub healed: Vec<String>,
+    pub deferred: Vec<String>,
 }
 
 /// #582: whether `err`'s chain contains SQLITE_CORRUPT — the FTS5 shadow-table variant surfaces
 /// as extended `SQLITE_CORRUPT_VTAB` (267), whose primary code rusqlite maps to
 /// `DatabaseCorrupt`, rendered as the bare "database disk image is malformed".
-pub(crate) fn error_is_fts_corruption(err: &anyhow::Error) -> bool {
+pub fn error_is_fts_corruption(err: &anyhow::Error) -> bool {
     err.chain().any(|cause| {
         matches!(
             cause.downcast_ref::<rusqlite::Error>(),

--- a/crates/rag-rat-core/src/index/fts.rs
+++ b/crates/rag-rat-core/src/index/fts.rs
@@ -228,30 +228,13 @@ impl IndexDatabase {
     /// rebuilt table names. The broad prefix disjunction matches essentially any text corpus; an
     /// empty mirror matches nothing and probes clean, which is right (nothing ranks it).
     pub fn heal_fts_if_corrupt(&self) -> anyhow::Result<FtsHealOutcome> {
-        // Every a-z/0-9 prefix: any token leading with an ASCII alphanumeric matches, so the
-        // ranked probe reads docsize for essentially every row a real query could rank. (A corpus
-        // of exclusively non-ASCII-leading tokens would evade it; the query-layer retry still
-        // covers those.)
-        let probe_query =
-            ('a'..='z').chain('0'..='9').map(|c| format!("{c}*")).collect::<Vec<_>>().join(" OR ");
         let conn = self.storage.connection();
-        let probe_corrupt = |table: &str| -> anyhow::Result<bool> {
-            let sql =
-                format!("SELECT rowid FROM {table} WHERE {table} MATCH ?1 ORDER BY rank LIMIT 1");
-            match conn.query_row(&sql, [probe_query.as_str()], |_| Ok(())) {
-                Ok(()) | Err(rusqlite::Error::QueryReturnedNoRows) => Ok(false),
-                Err(err) => {
-                    let err: anyhow::Error = err.into();
-                    if error_is_fts_corruption(&err) { Ok(true) } else { Err(err) }
-                },
-            }
-        };
         let mut outcome = FtsHealOutcome::default();
         // chunk_fts and commit_fts share one recovery (`rebuild_fts` repopulates both).
-        let chunk_corrupt = probe_corrupt("chunk_fts")?;
-        let commit_corrupt = probe_corrupt("commit_fts")?;
-        let memory_corrupt = probe_corrupt("repo_memory_fts")?;
-        let papertrail_corrupt = probe_corrupt("papertrail_fts")?;
+        let chunk_corrupt = ranked_probe_is_corrupt(conn, "chunk_fts")?;
+        let commit_corrupt = ranked_probe_is_corrupt(conn, "commit_fts")?;
+        let memory_corrupt = ranked_probe_is_corrupt(conn, "repo_memory_fts")?;
+        let papertrail_corrupt = ranked_probe_is_corrupt(conn, "papertrail_fts")?;
         if !(chunk_corrupt || commit_corrupt || memory_corrupt || papertrail_corrupt) {
             return Ok(outcome);
         }
@@ -314,6 +297,44 @@ pub(crate) fn fenced_when_autocommit(
     op()?;
     fence.commit()?;
     Ok(())
+}
+
+/// Probe one FTS mirror for the docsize corruption class with a query that EXECUTES rank — only
+/// rank/bm25 decodes docsize, which both `PRAGMA integrity_check` and FTS5's own
+/// `'integrity-check'` miss. The probe term is a REAL term pulled from the mirror's own
+/// `fts5vocab`, so the ranked read matches at least one indexed row regardless of the corpus
+/// alphabet (an ASCII-prefix disjunction goes blind on a corpus of non-ASCII-leading tokens —
+/// review finding on #675). An empty mirror has no terms and probes clean, which is right
+/// (nothing ranks it); a vocab read that itself hits corruption counts as corrupt.
+fn ranked_probe_is_corrupt(conn: &rusqlite::Connection, table: &str) -> anyhow::Result<bool> {
+    let vocab = format!("probe_vocab_{table}");
+    let map_corrupt = |err: rusqlite::Error| -> anyhow::Result<bool> {
+        let err: anyhow::Error = err.into();
+        if error_is_fts_corruption(&err) { Ok(true) } else { Err(err) }
+    };
+    if let Err(err) = conn.execute_batch(&format!(
+        "CREATE VIRTUAL TABLE IF NOT EXISTS temp.{vocab} USING fts5vocab(main, '{table}', 'row')"
+    )) {
+        return map_corrupt(err);
+    }
+    let term = conn
+        .query_row(&format!("SELECT term FROM temp.{vocab} LIMIT 1"), [], |row| {
+            row.get::<_, String>(0)
+        })
+        .optional();
+    let _ = conn.execute_batch(&format!("DROP TABLE IF EXISTS temp.{vocab}"));
+    let term = match term {
+        Ok(Some(term)) => term,
+        Ok(None) => return Ok(false),
+        Err(err) => return map_corrupt(err),
+    };
+    // Exact-phrase match on the sampled term; internal quotes double per FTS5 phrase syntax.
+    let phrase = format!("\"{}\"", term.replace('"', "\"\""));
+    let sql = format!("SELECT rowid FROM {table} WHERE {table} MATCH ?1 ORDER BY rank LIMIT 1");
+    match conn.query_row(&sql, [phrase.as_str()], |_| Ok(())) {
+        Ok(()) | Err(rusqlite::Error::QueryReturnedNoRows) => Ok(false),
+        Err(err) => map_corrupt(err),
+    }
 }
 
 /// What one FTS corruption sweep did: the mirrors rebuilt, and the corrupt mirrors whose
@@ -430,6 +451,36 @@ mod corruption_tests {
         );
         assert!(error_is_fts_corruption(&result.unwrap_err()));
         assert_eq!(calls, 2, "exactly one retry, no loop");
+    }
+}
+
+#[cfg(test)]
+mod probe_tests {
+    use super::*;
+
+    #[test]
+    fn the_ranked_probe_sees_docsize_corruption_on_a_non_ascii_corpus() {
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE VIRTUAL TABLE probe_t USING fts5(body, content='', contentless_delete=1);
+             INSERT INTO probe_t(rowid, body) VALUES (1, '\u{7d22}\u{5f15} \u{640d}\u{58ca} \
+             \u{691c}\u{67fb}');",
+        )
+        .unwrap();
+        assert!(!ranked_probe_is_corrupt(&conn, "probe_t").unwrap(), "intact mirror probes clean");
+        conn.execute_batch("DELETE FROM probe_t_docsize").unwrap();
+        assert!(
+            ranked_probe_is_corrupt(&conn, "probe_t").unwrap(),
+            "a real vocab term ranks the corpus regardless of alphabet — an ASCII-prefix probe \
+             reports this corrupt mirror healthy"
+        );
+    }
+
+    #[test]
+    fn an_empty_mirror_probes_clean() {
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        conn.execute_batch("CREATE VIRTUAL TABLE probe_t USING fts5(body, content='')").unwrap();
+        assert!(!ranked_probe_is_corrupt(&conn, "probe_t").unwrap());
     }
 }
 

--- a/crates/rag-rat-core/src/index/fts.rs
+++ b/crates/rag-rat-core/src/index/fts.rs
@@ -365,19 +365,27 @@ fn docsize_shadow_is_corrupt(
     table: &str,
     index_rows_sql: Option<&str>,
 ) -> anyhow::Result<bool> {
+    // ANY read in this scan can itself land on a corrupt _docsize page (count, prepare, step,
+    // column get) — that IS a positive probe, not a probe failure: mapping it to an error would
+    // make the heal fail instead of rebuilding the mirror.
+    match docsize_shadow_scan(conn, table, index_rows_sql) {
+        Err(err) if error_is_fts_corruption(&err) => Ok(true),
+        other => other,
+    }
+}
+
+fn docsize_shadow_scan(
+    conn: &rusqlite::Connection,
+    table: &str,
+    index_rows_sql: Option<&str>,
+) -> anyhow::Result<bool> {
     let columns: usize =
         conn.query_row(&format!("SELECT count(*) FROM pragma_table_info('{table}')"), [], |row| {
             row.get::<_, i64>(0).map(|n| n as usize)
         })?;
     let count_sql =
         index_rows_sql.map_or_else(|| format!("SELECT count(*) FROM {table}"), String::from);
-    let index_rows: i64 = match conn.query_row(&count_sql, [], |row| row.get(0)) {
-        Ok(rows) => rows,
-        Err(err) => {
-            let err: anyhow::Error = err.into();
-            return if error_is_fts_corruption(&err) { Ok(true) } else { Err(err) };
-        },
-    };
+    let index_rows: i64 = conn.query_row(&count_sql, [], |row| row.get(0))?;
     let shadow_rows: i64 =
         conn.query_row(&format!("SELECT count(*) FROM {table}_docsize"), [], |row| row.get(0))?;
     if index_rows != shadow_rows {

--- a/crates/rag-rat-core/src/index/fts.rs
+++ b/crates/rag-rat-core/src/index/fts.rs
@@ -9,8 +9,6 @@
 //! pay a full FTS rebuild forever after a sibling synced (stale-dirty loop). Do NOT route these
 //! back through `self.repo_meta` / `self.set_repo_meta`.
 
-use anyhow::Context as _;
-
 use super::*;
 
 impl IndexDatabase {
@@ -18,12 +16,19 @@ impl IndexDatabase {
     /// store and rebuild the external-content `commit_fts`, then record freshness. The hot
     /// full-rebuild path uses [`finalize_full_rebuild_fts`] instead (chunk_fts is written inline).
     pub fn rebuild_fts(&self) -> anyhow::Result<()> {
-        self.rebuild_chunk_fts()?;
-        schema::rebuild_commit_fts(self.storage.connection())?;
-        self.record_content_revision()?;
-        self.record_fts_current()?;
-        self.set_meta("fts_dirty", "false")?;
-        Ok(())
+        // ONE transaction when standalone (#610): 'delete-all' + per-row reinserts + the
+        // freshness stamps are a multi-statement sequence — interrupted mid-way it leaves an
+        // EMPTY mirror silently missing from BM25 until the next refresh fires, and a
+        // concurrent reader sees the torn intermediate. Inside a caller's fence (the corruption
+        // heals) it runs bare; SQLite rejects nested BEGINs.
+        fenced_when_autocommit(self.storage.connection(), || {
+            self.rebuild_chunk_fts()?;
+            schema::rebuild_commit_fts(self.storage.connection())?;
+            self.record_content_revision()?;
+            self.record_fts_current()?;
+            self.set_meta("fts_dirty", "false")?;
+            Ok(())
+        })
     }
 
     /// Full-rebuild FTS finalize: `chunk_fts` was written inline during chunk
@@ -178,7 +183,7 @@ impl IndexDatabase {
     /// bare "database disk image is malformed" a corrupt read returns does not name the table
     /// (the #582 incident burned three wrong theories on exactly that); every mirror rebuilds
     /// losslessly (`chunk_fts`/`commit_fts` from the chunk/commit stores, `repo_memory_fts` from
-    /// `repo_memories`, `github_fts` from the papertrail tables), so over-healing costs one
+    /// `repo_memories`, `papertrail_fts` from the papertrail tables), so over-healing costs one
     /// re-tokenize, not data. Healing through the querying connection is what makes the fix
     /// visible to a long-lived server: an out-of-band repair leaves the connection's cached
     /// corrupt pages serving `SQLITE_CORRUPT` indefinitely.
@@ -241,8 +246,8 @@ impl IndexDatabase {
         let chunk_corrupt = probe_corrupt("chunk_fts")?;
         let commit_corrupt = probe_corrupt("commit_fts")?;
         let memory_corrupt = probe_corrupt("repo_memory_fts")?;
-        let github_corrupt = probe_corrupt("github_fts")?;
-        if !(chunk_corrupt || commit_corrupt || memory_corrupt || github_corrupt) {
+        let papertrail_corrupt = probe_corrupt("papertrail_fts")?;
+        if !(chunk_corrupt || commit_corrupt || memory_corrupt || papertrail_corrupt) {
             return Ok(healed);
         }
         // Same database-wide fence as `heal_corrupt_fts`: the rebuilds are global and
@@ -264,13 +269,33 @@ impl IndexDatabase {
             crate::query::memory::heal_repo_memory_fts(conn)?;
             healed.push("repo_memory_fts".to_string());
         }
-        if github_corrupt {
+        if papertrail_corrupt {
             crate::index::papertrail::rebuild_fts(conn)?;
-            healed.push("github_fts".to_string());
+            healed.push("papertrail_fts".to_string());
         }
         fence.commit()?;
         Ok(healed)
     }
+}
+
+/// Run `op` inside its own IMMEDIATE transaction when the connection is in autocommit, bare when
+/// a caller already holds one (SQLite rejects nested BEGINs). The atomicity seam for every
+/// multi-statement FTS mirror maintenance sequence (#610): standalone callers get all-or-nothing
+/// plus write serialization against sibling repos on a consolidated database (per-repo flocks
+/// cannot serialize a GLOBAL mirror; the database write lock can), and fenced callers (the
+/// corruption heals) keep their outer fence as the single atomic unit.
+pub(crate) fn fenced_when_autocommit(
+    conn: &rusqlite::Connection,
+    op: impl FnOnce() -> anyhow::Result<()>,
+) -> anyhow::Result<()> {
+    if !conn.is_autocommit() {
+        return op();
+    }
+    let fence =
+        rusqlite::Transaction::new_unchecked(conn, rusqlite::TransactionBehavior::Immediate)?;
+    op()?;
+    fence.commit()?;
+    Ok(())
 }
 
 /// #582: whether `err`'s chain contains SQLITE_CORRUPT — the FTS5 shadow-table variant surfaces
@@ -362,5 +387,55 @@ mod corruption_tests {
         );
         assert!(error_is_fts_corruption(&result.unwrap_err()));
         assert_eq!(calls, 2, "exactly one retry, no loop");
+    }
+}
+
+#[cfg(test)]
+mod fence_tests {
+    use super::*;
+
+    fn conn() -> rusqlite::Connection {
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        conn.execute_batch("CREATE TABLE t(x INTEGER)").unwrap();
+        conn
+    }
+
+    #[test]
+    fn standalone_callers_get_all_or_nothing() {
+        let conn = conn();
+        let error = fenced_when_autocommit(&conn, || {
+            conn.execute("INSERT INTO t(x) VALUES (1)", [])?;
+            anyhow::bail!("interrupted mid-sequence")
+        })
+        .unwrap_err();
+        assert!(error.to_string().contains("interrupted"), "{error:#}");
+        let rows: i64 = conn.query_row("SELECT COUNT(*) FROM t", [], |row| row.get(0)).unwrap();
+        assert_eq!(rows, 0, "the partial write must roll back — no torn mirror");
+        assert!(conn.is_autocommit(), "the failed fence must not leave a transaction open");
+
+        fenced_when_autocommit(&conn, || {
+            conn.execute("INSERT INTO t(x) VALUES (2)", [])?;
+            Ok(())
+        })
+        .unwrap();
+        let rows: i64 = conn.query_row("SELECT COUNT(*) FROM t", [], |row| row.get(0)).unwrap();
+        assert_eq!(rows, 1);
+    }
+
+    #[test]
+    fn fenced_callers_run_bare_inside_their_own_transaction() {
+        let conn = conn();
+        let outer =
+            rusqlite::Transaction::new_unchecked(&conn, rusqlite::TransactionBehavior::Immediate)
+                .unwrap();
+        fenced_when_autocommit(&conn, || {
+            conn.execute("INSERT INTO t(x) VALUES (1)", [])?;
+            Ok(())
+        })
+        .unwrap();
+        // The outer fence is still the single atomic unit: rolling it back drops the write.
+        outer.rollback().unwrap();
+        let rows: i64 = conn.query_row("SELECT COUNT(*) FROM t", [], |row| row.get(0)).unwrap();
+        assert_eq!(rows, 0, "no nested commit may escape the caller's fence");
     }
 }

--- a/crates/rag-rat-core/src/index/fts.rs
+++ b/crates/rag-rat-core/src/index/fts.rs
@@ -231,10 +231,15 @@ impl IndexDatabase {
         let conn = self.storage.connection();
         let mut outcome = FtsHealOutcome::default();
         // chunk_fts and commit_fts share one recovery (`rebuild_fts` repopulates both).
-        let chunk_corrupt = ranked_probe_is_corrupt(conn, "chunk_fts")?;
-        let commit_corrupt = ranked_probe_is_corrupt(conn, "commit_fts")?;
-        let memory_corrupt = ranked_probe_is_corrupt(conn, "repo_memory_fts")?;
-        let papertrail_corrupt = ranked_probe_is_corrupt(conn, "papertrail_fts")?;
+        // chunk_fts is CONTENTLESS: its own count(*) enumerates THROUGH docsize (measured), so
+        // row parity must come from the durable source the rebuild derives from. The other
+        // mirrors carry (or reference) their own content, where count(*) is docsize-independent.
+        let chunk_rows = "SELECT count(*) FROM main.chunks JOIN main.chunk_text ON \
+                          chunk_text.chunk_id = main.chunks.id";
+        let chunk_corrupt = ranked_probe_is_corrupt(conn, "chunk_fts", Some(chunk_rows))?;
+        let commit_corrupt = ranked_probe_is_corrupt(conn, "commit_fts", None)?;
+        let memory_corrupt = ranked_probe_is_corrupt(conn, "repo_memory_fts", None)?;
+        let papertrail_corrupt = ranked_probe_is_corrupt(conn, "papertrail_fts", None)?;
         if !(chunk_corrupt || commit_corrupt || memory_corrupt || papertrail_corrupt) {
             return Ok(outcome);
         }
@@ -299,14 +304,26 @@ pub(crate) fn fenced_when_autocommit(
     Ok(())
 }
 
-/// Probe one FTS mirror for the docsize corruption class with a query that EXECUTES rank — only
-/// rank/bm25 decodes docsize, which both `PRAGMA integrity_check` and FTS5's own
-/// `'integrity-check'` miss. The probe term is a REAL term pulled from the mirror's own
-/// `fts5vocab`, so the ranked read matches at least one indexed row regardless of the corpus
-/// alphabet (an ASCII-prefix disjunction goes blind on a corpus of non-ASCII-leading tokens —
-/// review finding on #675). An empty mirror has no terms and probes clean, which is right
-/// (nothing ranks it); a vocab read that itself hits corruption counts as corrupt.
-fn ranked_probe_is_corrupt(conn: &rusqlite::Connection, table: &str) -> anyhow::Result<bool> {
+/// Probe one FTS mirror for the docsize corruption class. Two complementary reads, both cheap
+/// relative to the explicit-heal/preflight contexts this runs in (never per-query):
+///
+/// 1. A query that EXECUTES rank on a REAL term sampled from the mirror's own `fts5vocab` — only
+///    rank/bm25 decodes docsize AND the shared averages record, and both `PRAGMA integrity_check`
+///    and FTS5's own `'integrity-check'` miss that class. A real term matches at least one indexed
+///    row regardless of the corpus alphabet (an ASCII-prefix disjunction goes blind on
+///    non-ASCII-leading tokens).
+/// 2. A full scan of the `<table>_docsize` shadow itself — docsize is PER ROW, so the sampled rank
+///    read proves only its matched row; the scan checks row-count parity with the index and varint
+///    well-formedness of every blob, catching corruption on rows the sample never ranks.
+///
+/// An empty mirror has no terms and probes clean, which is right (nothing ranks it); any probe
+/// read that itself hits corruption counts as corrupt. A false positive only costs one lossless
+/// rebuild.
+fn ranked_probe_is_corrupt(
+    conn: &rusqlite::Connection,
+    table: &str,
+    index_rows_sql: Option<&str>,
+) -> anyhow::Result<bool> {
     let vocab = format!("probe_vocab_{table}");
     let map_corrupt = |err: rusqlite::Error| -> anyhow::Result<bool> {
         let err: anyhow::Error = err.into();
@@ -332,9 +349,67 @@ fn ranked_probe_is_corrupt(conn: &rusqlite::Connection, table: &str) -> anyhow::
     let phrase = format!("\"{}\"", term.replace('"', "\"\""));
     let sql = format!("SELECT rowid FROM {table} WHERE {table} MATCH ?1 ORDER BY rank LIMIT 1");
     match conn.query_row(&sql, [phrase.as_str()], |_| Ok(())) {
-        Ok(()) | Err(rusqlite::Error::QueryReturnedNoRows) => Ok(false),
-        Err(err) => map_corrupt(err),
+        Ok(()) | Err(rusqlite::Error::QueryReturnedNoRows) => {},
+        Err(err) => return map_corrupt(err),
     }
+    docsize_shadow_is_corrupt(conn, table, index_rows_sql)
+}
+
+/// The per-row half of the probe: every `<table>_docsize` row must exist (count parity against
+/// `index_rows_sql` — the durable source for a CONTENTLESS mirror, whose own count(*) enumerates
+/// THROUGH docsize and would compare the shadow to itself; the mirror's own content-derived
+/// count otherwise) and hold exactly one well-formed varint per indexed column. bm25 decodes
+/// exactly this on demand, so a row failing here is a ranked query waiting to fail.
+fn docsize_shadow_is_corrupt(
+    conn: &rusqlite::Connection,
+    table: &str,
+    index_rows_sql: Option<&str>,
+) -> anyhow::Result<bool> {
+    let columns: usize =
+        conn.query_row(&format!("SELECT count(*) FROM pragma_table_info('{table}')"), [], |row| {
+            row.get::<_, i64>(0).map(|n| n as usize)
+        })?;
+    let count_sql =
+        index_rows_sql.map_or_else(|| format!("SELECT count(*) FROM {table}"), String::from);
+    let index_rows: i64 = match conn.query_row(&count_sql, [], |row| row.get(0)) {
+        Ok(rows) => rows,
+        Err(err) => {
+            let err: anyhow::Error = err.into();
+            return if error_is_fts_corruption(&err) { Ok(true) } else { Err(err) };
+        },
+    };
+    let shadow_rows: i64 =
+        conn.query_row(&format!("SELECT count(*) FROM {table}_docsize"), [], |row| row.get(0))?;
+    if index_rows != shadow_rows {
+        return Ok(true);
+    }
+    let mut stmt = conn.prepare(&format!("SELECT sz FROM {table}_docsize"))?;
+    let mut rows = stmt.query([])?;
+    while let Some(row) = rows.next()? {
+        let blob: Vec<u8> = row.get(0)?;
+        if !blob_is_exactly_n_varints(&blob, columns) {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+/// Whether `blob` is exactly `n` SQLite varints, no more, no less — the docsize row format (one
+/// per indexed column).
+fn blob_is_exactly_n_varints(blob: &[u8], n: usize) -> bool {
+    let mut offset = 0usize;
+    for _ in 0..n {
+        let mut len = 0usize;
+        loop {
+            let Some(byte) = blob.get(offset + len) else { return false };
+            len += 1;
+            if byte & 0x80 == 0 || len == 9 {
+                break;
+            }
+        }
+        offset += len;
+    }
+    offset == blob.len()
 }
 
 /// What one FTS corruption sweep did: the mirrors rebuilt, and the corrupt mirrors whose
@@ -467,20 +542,78 @@ mod probe_tests {
              \u{691c}\u{67fb}');",
         )
         .unwrap();
-        assert!(!ranked_probe_is_corrupt(&conn, "probe_t").unwrap(), "intact mirror probes clean");
+        assert!(
+            !ranked_probe_is_corrupt(&conn, "probe_t", None).unwrap(),
+            "intact mirror probes clean"
+        );
         conn.execute_batch("DELETE FROM probe_t_docsize").unwrap();
         assert!(
-            ranked_probe_is_corrupt(&conn, "probe_t").unwrap(),
+            ranked_probe_is_corrupt(&conn, "probe_t", None).unwrap(),
             "a real vocab term ranks the corpus regardless of alphabet — an ASCII-prefix probe \
              reports this corrupt mirror healthy"
         );
+    }
+
+    /// docsize is PER ROW: corrupting a row the sampled term never matches must still be
+    /// caught — this is the class the LIMIT-1 rank read alone cannot see.
+    #[test]
+    fn per_row_corruption_outside_the_sampled_row_is_still_detected() {
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE VIRTUAL TABLE probe_t USING fts5(body, content='', contentless_delete=1);
+             INSERT INTO probe_t(rowid, body) VALUES (1, 'aardvark aardvark aardvark');
+             INSERT INTO probe_t(rowid, body) VALUES (2, 'zebra');",
+        )
+        .unwrap();
+        assert!(!ranked_probe_is_corrupt(&conn, "probe_t", None).unwrap());
+        // Malform row 2's blob only: the vocab sample ('aardvark' sorts first) ranks row 1 and
+        // passes; the shadow scan must flag the truncated varint on row 2.
+        conn.execute("UPDATE probe_t_docsize SET sz = x'FF' WHERE id = 2", []).unwrap();
+        assert!(
+            ranked_probe_is_corrupt(&conn, "probe_t", None).unwrap(),
+            "a malformed blob on an unranked row is a ranked query waiting to fail"
+        );
+    }
+
+    /// Count parity needs a docsize-INDEPENDENT row source: a contentless mirror's own count(*)
+    /// enumerates through docsize (comparing the shadow to itself), so the caller supplies the
+    /// durable source; content-carrying mirrors use their own count.
+    #[test]
+    fn a_missing_single_docsize_row_is_detected_by_count_parity() {
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE src(id INTEGER PRIMARY KEY, body TEXT);
+             INSERT INTO src VALUES (1, 'alpha'), (2, 'beta');
+             CREATE VIRTUAL TABLE probe_t USING fts5(body, content='', contentless_delete=1);
+             INSERT INTO probe_t(rowid, body) SELECT id, body FROM src;",
+        )
+        .unwrap();
+        let rows = Some("SELECT count(*) FROM src");
+        assert!(!ranked_probe_is_corrupt(&conn, "probe_t", rows).unwrap());
+        conn.execute("DELETE FROM probe_t_docsize WHERE id = 2", []).unwrap();
+        assert!(
+            ranked_probe_is_corrupt(&conn, "probe_t", rows).unwrap(),
+            "a vanished docsize row (invisible to the mirror's own scans) fails parity against \
+             the durable source"
+        );
+    }
+
+    #[test]
+    fn varint_shape_validation_is_exact() {
+        assert!(blob_is_exactly_n_varints(&[0x05], 1), "one small varint");
+        assert!(blob_is_exactly_n_varints(&[0x81, 0x05], 1), "two-byte varint");
+        assert!(blob_is_exactly_n_varints(&[0x05, 0x07], 2), "two columns");
+        assert!(!blob_is_exactly_n_varints(&[0xFF], 1), "truncated continuation");
+        assert!(!blob_is_exactly_n_varints(&[0x05, 0x07], 1), "trailing bytes");
+        assert!(!blob_is_exactly_n_varints(&[], 1), "missing varint");
+        assert!(blob_is_exactly_n_varints(&[], 0), "zero columns, empty blob");
     }
 
     #[test]
     fn an_empty_mirror_probes_clean() {
         let conn = rusqlite::Connection::open_in_memory().unwrap();
         conn.execute_batch("CREATE VIRTUAL TABLE probe_t USING fts5(body, content='')").unwrap();
-        assert!(!ranked_probe_is_corrupt(&conn, "probe_t").unwrap());
+        assert!(!ranked_probe_is_corrupt(&conn, "probe_t", None).unwrap());
     }
 }
 

--- a/crates/rag-rat-core/src/index/fts.rs
+++ b/crates/rag-rat-core/src/index/fts.rs
@@ -187,7 +187,9 @@ impl IndexDatabase {
     /// re-tokenize, not data. Healing through the querying connection is what makes the fix
     /// visible to a long-lived server: an out-of-band repair leaves the connection's cached
     /// corrupt pages serving `SQLITE_CORRUPT` indefinitely.
-    pub(crate) fn heal_corrupt_fts(&self) -> anyhow::Result<()> {
+    /// Returns the mirrors whose repair was DEFERRED (today: only `chunk_fts`, behind a staged
+    /// rebuild); every other mirror is rebuilt unconditionally.
+    pub(crate) fn heal_corrupt_fts(&self) -> anyhow::Result<Vec<String>> {
         let conn = self.storage.connection();
         // ONE `BEGIN IMMEDIATE` transaction fences the whole heal. The mirrors are GLOBAL on a
         // consolidated DB while write flocks are per-repo, so a flock cannot serialize sibling
@@ -200,18 +202,21 @@ impl IndexDatabase {
             rusqlite::Transaction::new_unchecked(conn, rusqlite::TransactionBehavior::Immediate)?;
         // Between a staged rebuild's committed waves, chunk_fts rows exist whose text is not in
         // the durable store yet — 'delete-all' + re-derive would drop them permanently and stamp
-        // the loss clean (the same A6 guard `ensure_fts_fresh` applies). Refuse; the original
-        // error surfaces and the heal retries once the rebuild's text store is complete.
-        anyhow::ensure!(
-            !self.staged_files_generation_exists()?,
-            "FTS corruption heal deferred: a staged rebuild's chunk_fts rows are not yet \
-             re-derivable from the text store"
-        );
-        self.rebuild_fts()?;
+        // the loss clean (the same A6 guard `ensure_fts_fresh` applies). Defer ONLY that mirror:
+        // commit_fts (git_commits), repo_memory_fts (repo_memories), and papertrail_fts (the
+        // papertrail tables) rebuild from always-durable sources, so a staged window must not
+        // leave their ranked surfaces broken too.
+        let deferred = if self.staged_files_generation_exists()? {
+            schema::rebuild_commit_fts(conn)?;
+            vec!["chunk_fts".to_string()]
+        } else {
+            self.rebuild_fts()?;
+            Vec::new()
+        };
         crate::query::memory::heal_repo_memory_fts(conn)?;
         crate::index::papertrail::rebuild_fts(conn)?;
         fence.commit()?;
-        Ok(())
+        Ok(deferred)
     }
 }
 
@@ -258,15 +263,17 @@ impl IndexDatabase {
         // unaffected (their sources are always complete).
         if chunk_corrupt || commit_corrupt {
             if self.staged_files_generation_exists()? {
-                // A silent skip here would let the report read healthy while ranked queries
-                // still fail — surface the deferral so the caller reruns after the staged
-                // rebuild completes.
-                for (corrupt, table) in
-                    [(chunk_corrupt, "chunk_fts"), (commit_corrupt, "commit_fts")]
-                {
-                    if corrupt {
-                        outcome.deferred.push(table.to_string());
-                    }
+                // The staged-window hazard is CHUNK-only (chunk_fts re-derives from chunk_text,
+                // which lags the staged waves); commit_fts rebuilds from durable git_commits and
+                // must not stay broken behind unrelated staging. A silent skip of the deferred
+                // mirror would let the report read healthy while ranked queries still fail —
+                // surface it so the caller reruns after the staged rebuild completes.
+                if commit_corrupt {
+                    schema::rebuild_commit_fts(conn)?;
+                    outcome.healed.push("commit_fts".to_string());
+                }
+                if chunk_corrupt {
+                    outcome.deferred.push("chunk_fts".to_string());
                 }
             } else {
                 // The shared rebuild repopulates BOTH mirrors regardless of which probe failed
@@ -317,9 +324,13 @@ pub struct FtsHealOutcome {
     pub deferred: Vec<String>,
 }
 
-/// #582: whether `err`'s chain contains SQLITE_CORRUPT — the FTS5 shadow-table variant surfaces
-/// as extended `SQLITE_CORRUPT_VTAB` (267), whose primary code rusqlite maps to
-/// `DatabaseCorrupt`, rendered as the bare "database disk image is malformed".
+/// #582: whether `err`'s chain contains SQLITE_CORRUPT — matched on the PRIMARY code
+/// (`DatabaseCorrupt`), deliberately not the extended `SQLITE_CORRUPT_VTAB` (267): the incident
+/// class itself reports extended code 11 (measured by truncating `chunk_fts_docsize` and reading
+/// `sqlite3_extended_errcode` through the ranked probe), so requiring 267 would miss exactly the
+/// corruption this exists to catch. The cost of the broad match is bounded: a non-FTS corruption
+/// triggers one lossless mirror rebuild before the ORIGINAL error surfaces from the failed
+/// retry.
 pub fn error_is_fts_corruption(err: &anyhow::Error) -> bool {
     err.chain().any(|cause| {
         matches!(
@@ -335,18 +346,31 @@ pub fn error_is_fts_corruption(err: &anyhow::Error) -> bool {
 /// deliberately no loop (#582).
 pub(crate) fn retry_once_on_fts_corruption<T>(
     mut op: impl FnMut() -> anyhow::Result<T>,
-    heal: impl FnOnce() -> anyhow::Result<()>,
+    heal: impl FnOnce() -> anyhow::Result<Vec<String>>,
 ) -> anyhow::Result<T> {
     match op() {
         Ok(value) => Ok(value),
         Err(err) if error_is_fts_corruption(&err) => {
-            if let Err(heal_err) = heal() {
-                // Keep the ORIGINAL corruption error as the chain root (callers and tests match
-                // on it); the heal's own failure — e.g. the staged-rebuild deferral — rides
-                // along as context.
-                return Err(err.context(format!("FTS self-heal did not complete: {heal_err:#}")));
+            let deferred = match heal() {
+                Ok(deferred) => deferred,
+                Err(heal_err) => {
+                    // Keep the ORIGINAL corruption error as the chain root (callers and tests
+                    // match on it); the heal's own failure rides along as context.
+                    return Err(
+                        err.context(format!("FTS self-heal did not complete: {heal_err:#}"))
+                    );
+                },
+            };
+            match op() {
+                Ok(value) => Ok(value),
+                // The retry failing right after a heal that DEFERRED a mirror is the deferral
+                // biting: say so, instead of a bare "malformed" that reads like a fresh mystery.
+                Err(retry_err) if !deferred.is_empty() => Err(retry_err.context(format!(
+                    "FTS self-heal deferred {deferred:?} behind an in-flight staged rebuild; \
+                     rerun once it completes"
+                ))),
+                other => other,
             }
-            op()
         },
         Err(err) => Err(err),
     }
@@ -378,7 +402,7 @@ mod corruption_tests {
             },
             || {
                 healed = true;
-                Ok(())
+                Ok(Vec::new())
             },
         );
         assert_eq!(result.unwrap(), 42);
@@ -402,7 +426,7 @@ mod corruption_tests {
                 calls += 1;
                 Err(corrupt_error())
             },
-            || Ok(()),
+            || Ok(Vec::new()),
         );
         assert!(error_is_fts_corruption(&result.unwrap_err()));
         assert_eq!(calls, 2, "exactly one retry, no loop");

--- a/crates/rag-rat-core/src/index/fts.rs
+++ b/crates/rag-rat-core/src/index/fts.rs
@@ -107,29 +107,23 @@ impl IndexDatabase {
         if !self.fts_dirty()? && fts_source_revision.as_deref() == Some(content_revision.as_str()) {
             return Ok(());
         }
-        // NEVER rebuild while any SEARCHABLE chunk lacks its durable text row (A6, P2 review): a
+        // NEVER rebuild while any chunk lacks its durable text row (A6, P2 review): a
         // generation-staged full rebuild commits its waves BEFORE `build_chunk_text_store` runs,
-        // so on a FIRST index (no `chunk_text_dict` yet) the staged chunks carry inline
-        // `chunk_fts` rows whose text exists only in the REBUILDING connection's temp table.
-        // `rebuild_chunk_fts`'s 'delete-all' + re-derive from `chunk_text` would silently drop
-        // those rows from BM25 and the freshness stamp below would mark the loss clean —
-        // permanent missing rows in the published generation. Degrade instead: serve the current
-        // (possibly stale) FTS and leave the dirty/stale state in place, so the refresh re-fires
-        // once the text store is complete (the rebuild's own finalize records freshness for the
-        // fast path). The probe is deliberately "HAS an fts row we cannot re-derive" — not a bare
-        // "lacks text" — so a chunk with NEITHER row (never searchable; the re-derive would
-        // exclude it regardless) can never wedge freshness healing permanently. Runs only on the
-        // dirty/stale path, never steady-state.
-        let irreplaceable_fts_rows: bool = self.storage.connection().query_row(
-            "SELECT EXISTS(
-                 SELECT 1 FROM main.chunks
-                 WHERE id IN (SELECT rowid FROM chunk_fts)
-                   AND id NOT IN (SELECT chunk_id FROM main.chunk_text)
-             )",
-            [],
-            |row| row.get(0),
-        )?;
-        if irreplaceable_fts_rows {
+        // so mid-rebuild the staged chunks carry inline `chunk_fts` rows whose text exists only
+        // in the REBUILDING connection's temp table. `rebuild_chunk_fts`'s 'delete-all' +
+        // re-derive from `chunk_text` would silently drop those rows from BM25 and the freshness
+        // stamp below would mark the loss clean — permanent missing rows in the published
+        // generation. Degrade instead: serve the current (possibly stale) FTS and leave the
+        // dirty/stale state in place, so the refresh re-fires once the text store is complete.
+        //
+        // The probe reads the GENERATION LEDGER, never chunk/FTS shapes (#582 review): the A6
+        // guard used to check "HAS an fts row we cannot re-derive", but a docsize-corrupted
+        // mirror SCANS AS EMPTY, blinding that shape exactly when a stale stamp coincides with
+        // corruption — the rebuild then destroyed the staged rows the guard exists to protect.
+        // Staging-above-live is corruption-independent, true precisely during rebuild windows
+        // (an abandoned staging is swept by gc under the flock), so it cannot wedge freshness
+        // healing permanently.
+        if self.staged_files_generation_exists()? {
             return Ok(());
         }
         self.rebuild_fts()?;
@@ -142,6 +136,35 @@ impl IndexDatabase {
             );
         }
         Ok(())
+    }
+
+    /// The staging probe shared by `ensure_fts_fresh` and the corruption heals (#582 review): a
+    /// generation-staged rebuild is in flight (or abandoned, pending gc's flock-guarded sweep)
+    /// iff any repo carries `files` rows ABOVE its live generation pointer — the same ledger
+    /// signal the #492 torn-window guard reads. Deliberately consults the generation ledger and
+    /// never chunk/FTS shapes: a docsize-corrupted `chunk_fts` SCANS AS EMPTY (blinding any
+    /// FTS-membership probe exactly when it matters), and "chunk without durable text"
+    /// over-fires on never-searchable chunks that legitimately carry neither row. `chunk_fts` is
+    /// GLOBAL, so ANY repo's staging defers the rebuild.
+    fn staged_files_generation_exists(&self) -> anyhow::Result<bool> {
+        let conn = self.storage.connection();
+        let repos: Vec<String> = {
+            let mut stmt = conn.prepare("SELECT DISTINCT repo_id FROM main.files")?;
+            let rows = stmt.query_map([], |row| row.get(0))?;
+            rows.collect::<Result<_, _>>()?
+        };
+        for repo_id in repos {
+            let live = crate::index::schema::live_files_generation(conn, &repo_id)?;
+            let staged: bool = conn.query_row(
+                "SELECT EXISTS(SELECT 1 FROM main.files WHERE repo_id = ?1 AND generation > ?2)",
+                rusqlite::params![repo_id, live],
+                |row| row.get(0),
+            )?;
+            if staged {
+                return Ok(true);
+            }
+        }
+        Ok(false)
     }
 
     pub(super) fn fts_dirty(&self) -> anyhow::Result<bool> {
@@ -170,6 +193,15 @@ impl IndexDatabase {
         // ORIGINAL corruption error; the next query (or explicit `heal_index`) retries.
         let fence =
             rusqlite::Transaction::new_unchecked(conn, rusqlite::TransactionBehavior::Immediate)?;
+        // Between a staged rebuild's committed waves, chunk_fts rows exist whose text is not in
+        // the durable store yet — 'delete-all' + re-derive would drop them permanently and stamp
+        // the loss clean (the same A6 guard `ensure_fts_fresh` applies). Refuse; the original
+        // error surfaces and the heal retries once the rebuild's text store is complete.
+        anyhow::ensure!(
+            !self.staged_files_generation_exists()?,
+            "FTS corruption heal deferred: a staged rebuild's chunk_fts rows are not yet \
+             re-derivable from the text store"
+        );
         self.rebuild_fts()?;
         crate::query::memory::heal_repo_memory_fts(conn)?;
         crate::index::papertrail::rebuild_fts(conn)?;
@@ -217,7 +249,9 @@ impl IndexDatabase {
         // multi-statement, and per-repo flocks cannot serialize a consolidated DB's siblings.
         let fence =
             rusqlite::Transaction::new_unchecked(conn, rusqlite::TransactionBehavior::Immediate)?;
-        if chunk_corrupt || commit_corrupt {
+        // Same staged-rows refusal as `heal_corrupt_fts` — the memory/papertrail heals below are
+        // unaffected (their sources are always complete).
+        if (chunk_corrupt || commit_corrupt) && !self.staged_files_generation_exists()? {
             self.rebuild_fts()?;
             if chunk_corrupt {
                 healed.push("chunk_fts".to_string());
@@ -262,7 +296,12 @@ pub(crate) fn retry_once_on_fts_corruption<T>(
     match op() {
         Ok(value) => Ok(value),
         Err(err) if error_is_fts_corruption(&err) => {
-            heal().context("healing corrupt FTS indexes (#582)")?;
+            if let Err(heal_err) = heal() {
+                // Keep the ORIGINAL corruption error as the chain root (callers and tests match
+                // on it); the heal's own failure — e.g. the staged-rebuild deferral — rides
+                // along as context.
+                return Err(err.context(format!("FTS self-heal did not complete: {heal_err:#}")));
+            }
             op()
         },
         Err(err) => Err(err),

--- a/crates/rag-rat-core/src/index/fts.rs
+++ b/crates/rag-rat-core/src/index/fts.rs
@@ -257,13 +257,11 @@ impl IndexDatabase {
         // Same staged-rows refusal as `heal_corrupt_fts` — the memory/papertrail heals below are
         // unaffected (their sources are always complete).
         if (chunk_corrupt || commit_corrupt) && !self.staged_files_generation_exists()? {
+            // The shared rebuild repopulates BOTH mirrors regardless of which probe failed —
+            // report both, so the heal report states what was actually rebuilt.
             self.rebuild_fts()?;
-            if chunk_corrupt {
-                healed.push("chunk_fts".to_string());
-            }
-            if commit_corrupt {
-                healed.push("commit_fts".to_string());
-            }
+            healed.push("chunk_fts".to_string());
+            healed.push("commit_fts".to_string());
         }
         if memory_corrupt {
             crate::query::memory::heal_repo_memory_fts(conn)?;

--- a/crates/rag-rat-core/src/index/mod.rs
+++ b/crates/rag-rat-core/src/index/mod.rs
@@ -23,6 +23,7 @@ mod file_index;
 mod file_rows;
 mod fts;
 pub(crate) use fts::retry_once_on_fts_corruption;
+pub use fts::{FtsHealOutcome, error_is_fts_corruption};
 mod git_context;
 mod git_meta;
 mod graph_index;

--- a/crates/rag-rat-core/src/index/mod.rs
+++ b/crates/rag-rat-core/src/index/mod.rs
@@ -257,6 +257,11 @@ pub struct HealIndexReport {
     /// Ranked because only rank/bm25 decodes docsize — the corruption class both
     /// `PRAGMA integrity_check` and FTS5's own `'integrity-check'` miss.
     pub fts_healed: Vec<String>,
+    /// Mirrors whose probe hit corruption but whose repair was DEFERRED: a generation-staged
+    /// rebuild is in flight, and 'delete-all' + re-derive would drop its not-yet-durable rows.
+    /// Non-empty means ranked queries on these mirrors still fail — rerun `heal_index` once the
+    /// rebuild completes (or after gc sweeps an abandoned staging).
+    pub fts_deferred: Vec<String>,
     pub message: Option<String>,
 }
 

--- a/crates/rag-rat-core/src/index/mod.rs
+++ b/crates/rag-rat-core/src/index/mod.rs
@@ -22,6 +22,7 @@ mod discovery;
 mod file_index;
 mod file_rows;
 mod fts;
+pub(crate) use fts::retry_once_on_fts_corruption;
 mod git_context;
 mod git_meta;
 mod graph_index;
@@ -252,6 +253,10 @@ pub struct HealIndexReport {
     pub removed_files: u64,
     pub skipped_files: u64,
     pub fts_fresh: bool,
+    /// FTS mirrors whose RANKED probe hit SQLITE_CORRUPT and were rebuilt from source (#582).
+    /// Ranked because only rank/bm25 decodes docsize — the corruption class both
+    /// `PRAGMA integrity_check` and FTS5's own `'integrity-check'` miss.
+    pub fts_healed: Vec<String>,
     pub message: Option<String>,
 }
 

--- a/crates/rag-rat-core/src/index/papertrail/store.rs
+++ b/crates/rag-rat-core/src/index/papertrail/store.rs
@@ -191,12 +191,11 @@ pub(crate) fn rebuild_fts(conn: &Connection) -> rusqlite::Result<()> {
     // BEGINs, so the fence only wraps autocommit callers (the corruption heals hold their own).
     if conn.is_autocommit() {
         conn.execute_batch("BEGIN IMMEDIATE")?;
-        let result = rebuild_fts_inner(conn);
-        match &result {
-            Ok(()) => conn.execute_batch("COMMIT")?,
-            Err(_) => {
-                let _ = conn.execute_batch("ROLLBACK");
-            },
+        let result = rebuild_fts_inner(conn).and_then(|()| conn.execute_batch("COMMIT"));
+        // A failed COMMIT does not always auto-rollback (e.g. SQLITE_BUSY keeps the transaction
+        // open) — never leave this long-lived connection stuck inside one.
+        if result.is_err() && !conn.is_autocommit() {
+            let _ = conn.execute_batch("ROLLBACK");
         }
         return result;
     }

--- a/crates/rag-rat-core/src/index/papertrail/store.rs
+++ b/crates/rag-rat-core/src/index/papertrail/store.rs
@@ -186,6 +186,24 @@ pub(crate) fn store_comment(
 /// Every repo's rows are re-derived (each stamped its base row's `repo_id`), and `classification`
 /// is recomputed by [`insert_fts`].
 pub(crate) fn rebuild_fts(conn: &Connection) -> rusqlite::Result<()> {
+    // Whole-table delete + per-row reinserts must be one atomic unit when standalone (#610);
+    // the full-rewalk caller already runs inside its own transaction and SQLite rejects nested
+    // BEGINs, so the fence only wraps autocommit callers (the corruption heals hold their own).
+    if conn.is_autocommit() {
+        conn.execute_batch("BEGIN IMMEDIATE")?;
+        let result = rebuild_fts_inner(conn);
+        match &result {
+            Ok(()) => conn.execute_batch("COMMIT")?,
+            Err(_) => {
+                let _ = conn.execute_batch("ROLLBACK");
+            },
+        }
+        return result;
+    }
+    rebuild_fts_inner(conn)
+}
+
+fn rebuild_fts_inner(conn: &Connection) -> rusqlite::Result<()> {
     conn.execute("DELETE FROM papertrail_fts", [])?;
     {
         let mut stmt = conn.prepare(

--- a/crates/rag-rat-core/src/index/query_api/dream.rs
+++ b/crates/rag-rat-core/src/index/query_api/dream.rs
@@ -21,6 +21,11 @@ impl IndexDatabase {
         verdict_pass: Option<VerdictPass<'_>>,
         compact_pass: Option<CompactPass<'_>>,
     ) -> anyhow::Result<DreamReport> {
+        // #582 review: the verify/compact passes rank chunk_fts (evidence-pack probes) MID-RUN,
+        // after model side effects — a blanket retry would replay them. PRE-FLIGHT the
+        // probe-and-heal instead so the run starts on healthy mirrors; on a clean index the
+        // probe is four ranked LIMIT-1 reads.
+        self.heal_fts_if_corrupt()?;
         crate::dream::dream_run_with_passes(
             self.storage.connection(),
             opts,
@@ -41,13 +46,20 @@ impl IndexDatabase {
         compact: bool,
         model_id: &str,
     ) -> anyhow::Result<bool> {
-        crate::dream::model_work_pending(
-            self.storage.connection(),
-            opts,
-            budget,
-            verify,
-            compact,
-            model_id,
+        // #582 review: the zero-work guard ranks chunk_fts (`dream::verify::text_probe`) —
+        // read-only, so heal-and-retry is safe.
+        crate::index::retry_once_on_fts_corruption(
+            || {
+                crate::dream::model_work_pending(
+                    self.storage.connection(),
+                    opts.clone(),
+                    budget,
+                    verify,
+                    compact,
+                    model_id,
+                )
+            },
+            || self.heal_corrupt_fts(),
         )
     }
 

--- a/crates/rag-rat-core/src/index/query_api/dream.rs
+++ b/crates/rag-rat-core/src/index/query_api/dream.rs
@@ -21,18 +21,23 @@ impl IndexDatabase {
         verdict_pass: Option<VerdictPass<'_>>,
         compact_pass: Option<CompactPass<'_>>,
     ) -> anyhow::Result<DreamReport> {
-        // #582 review: the verify/compact passes rank chunk_fts (evidence-pack probes) MID-RUN,
-        // after model side effects — a blanket retry would replay them. PRE-FLIGHT the
-        // probe-and-heal instead so the run starts on healthy mirrors; on a clean index the
-        // probe is four ranked LIMIT-1 reads. A DEFERRED repair (staged rebuild in flight) must
-        // postpone the run: proceeding would pay the model/provisioning side effects only to
-        // hit the same corruption mid-pass — the exact failure this preflight exists to prevent.
-        let preflight = self.heal_fts_if_corrupt()?;
-        anyhow::ensure!(
-            preflight.deferred.is_empty(),
-            "dream postponed: FTS mirrors {:?} are corrupt and their repair is deferred behind              an in-flight staged rebuild; rerun once it completes (or after gc sweeps an              abandoned staging)",
-            preflight.deferred
-        );
+        // #582 review: the model passes rank chunk_fts (evidence-pack probes) MID-RUN, after
+        // model side effects — a blanket retry would replay them. PRE-FLIGHT the probe-and-heal
+        // instead so the run starts on healthy mirrors; on a clean index the probe is four
+        // ranked LIMIT-1 reads. A DEFERRED repair (staged rebuild in flight) must postpone the
+        // run: proceeding would pay the model/provisioning side effects only to hit the same
+        // corruption mid-pass. The plain worklist (no passes) stays byte-identical and
+        // write-free — it never ranks, so it gets no probe and no heal.
+        if verdict_pass.is_some() || compact_pass.is_some() {
+            let preflight = self.heal_fts_if_corrupt()?;
+            anyhow::ensure!(
+                preflight.deferred.is_empty(),
+                "dream postponed: FTS mirrors {:?} are corrupt and their repair is deferred \
+                 behind an in-flight staged rebuild; rerun once it completes (or after gc sweeps \
+                 an abandoned staging)",
+                preflight.deferred
+            );
+        }
         crate::dream::dream_run_with_passes(
             self.storage.connection(),
             opts,

--- a/crates/rag-rat-core/src/index/query_api/dream.rs
+++ b/crates/rag-rat-core/src/index/query_api/dream.rs
@@ -52,7 +52,7 @@ impl IndexDatabase {
             || {
                 crate::dream::model_work_pending(
                     self.storage.connection(),
-                    opts.clone(),
+                    opts,
                     budget,
                     verify,
                     compact,

--- a/crates/rag-rat-core/src/index/query_api/dream.rs
+++ b/crates/rag-rat-core/src/index/query_api/dream.rs
@@ -24,8 +24,15 @@ impl IndexDatabase {
         // #582 review: the verify/compact passes rank chunk_fts (evidence-pack probes) MID-RUN,
         // after model side effects — a blanket retry would replay them. PRE-FLIGHT the
         // probe-and-heal instead so the run starts on healthy mirrors; on a clean index the
-        // probe is four ranked LIMIT-1 reads.
-        self.heal_fts_if_corrupt()?;
+        // probe is four ranked LIMIT-1 reads. A DEFERRED repair (staged rebuild in flight) must
+        // postpone the run: proceeding would pay the model/provisioning side effects only to
+        // hit the same corruption mid-pass — the exact failure this preflight exists to prevent.
+        let preflight = self.heal_fts_if_corrupt()?;
+        anyhow::ensure!(
+            preflight.deferred.is_empty(),
+            "dream postponed: FTS mirrors {:?} are corrupt and their repair is deferred behind              an in-flight staged rebuild; rerun once it completes (or after gc sweeps an              abandoned staging)",
+            preflight.deferred
+        );
         crate::dream::dream_run_with_passes(
             self.storage.connection(),
             opts,

--- a/crates/rag-rat-core/src/index/query_api/graph.rs
+++ b/crates/rag-rat-core/src/index/query_api/graph.rs
@@ -709,8 +709,14 @@ impl IndexDatabase {
     ) -> anyhow::Result<Vec<crate::query::impact::ImpactItem>> {
         // impact's chunk-mention evidence runs `chunk_fts MATCH` (#77 Phase 1), so the FTS index
         // must be fresh first — same precondition search enforces before its MATCH queries.
-        self.ensure_fts_fresh()?;
-        crate::query::impact::impact_surface(self.storage.connection(), query, limit)
+        // #582: the papertrail-rationale section also ranks github_fts — heal-and-retry.
+        crate::index::retry_once_on_fts_corruption(
+            || {
+                self.ensure_fts_fresh()?;
+                crate::query::impact::impact_surface(self.storage.connection(), query, limit)
+            },
+            || self.heal_corrupt_fts(),
+        )
     }
 
     pub fn impact_surface_with_options(
@@ -719,12 +725,17 @@ impl IndexDatabase {
         limit: u32,
         resolution_mode: crate::query::graph::GraphResolutionMode,
     ) -> anyhow::Result<Vec<crate::query::impact::ImpactItem>> {
-        self.ensure_fts_fresh()?;
-        crate::query::impact::impact_surface_with_options(
-            self.storage.connection(),
-            query,
-            limit,
-            resolution_mode,
+        crate::index::retry_once_on_fts_corruption(
+            || {
+                self.ensure_fts_fresh()?;
+                crate::query::impact::impact_surface_with_options(
+                    self.storage.connection(),
+                    query,
+                    limit,
+                    resolution_mode,
+                )
+            },
+            || self.heal_corrupt_fts(),
         )
     }
 
@@ -734,12 +745,17 @@ impl IndexDatabase {
         limit: u32,
         resolution_mode: crate::query::graph::GraphResolutionMode,
     ) -> anyhow::Result<Vec<crate::query::impact::ImpactItem>> {
-        self.ensure_fts_fresh()?;
-        crate::query::impact::impact_surface_for_symbol(
-            self.storage.connection(),
-            symbol,
-            limit,
-            resolution_mode,
+        crate::index::retry_once_on_fts_corruption(
+            || {
+                self.ensure_fts_fresh()?;
+                crate::query::impact::impact_surface_for_symbol(
+                    self.storage.connection(),
+                    symbol,
+                    limit,
+                    resolution_mode,
+                )
+            },
+            || self.heal_corrupt_fts(),
         )
     }
 
@@ -771,12 +787,19 @@ impl IndexDatabase {
         // finding
         // 4) and before the memory-evidence edge-id collection — so a compiler-upgraded neighbor
         // can't be dropped by the heuristic limit, and downstream counts see the final window.
-        let mut report = crate::query::impact::impact_surface_report_for_symbol(
-            self.storage.connection(),
-            symbol,
-            limit,
-            options,
-            |hops| self.enrich_hops_with_oracle(hops),
+        // #582: the text sections rank chunk_fts and the papertrail sections rank github_fts —
+        // heal-and-retry the report build on shadow corruption.
+        let mut report = crate::index::retry_once_on_fts_corruption(
+            || {
+                crate::query::impact::impact_surface_report_for_symbol(
+                    self.storage.connection(),
+                    symbol,
+                    limit,
+                    options,
+                    |hops| self.enrich_hops_with_oracle(hops),
+                )
+            },
+            || self.heal_corrupt_fts(),
         )?;
         // Attach the LOCAL structural-load signal (scoped weighted fan-in — the third importance
         // scale, NOT PageRank) to the direct graph neighbors AFTER the oracle re-rank + truncate,

--- a/crates/rag-rat-core/src/index/query_api/history.rs
+++ b/crates/rag-rat-core/src/index/query_api/history.rs
@@ -80,7 +80,19 @@ impl IndexDatabase {
         limit: u32,
     ) -> anyhow::Result<Vec<QueryCommitHit>> {
         let current_hits = self.search(query, limit, true)?;
-        git_history::commits_touching_query(self.storage.connection(), query, limit, &current_hits)
+        // #582: an INDEPENDENT ranked commit_fts path — it calls git_history::commit_search
+        // internally, not the wrapped commit_search above, so it needs its own heal-and-retry.
+        crate::index::retry_once_on_fts_corruption(
+            || {
+                git_history::commits_touching_query(
+                    self.storage.connection(),
+                    query,
+                    limit,
+                    &current_hits,
+                )
+            },
+            || self.heal_corrupt_fts(),
+        )
     }
 
     pub fn git_blame_chunk(&self, chunk_id: i64) -> anyhow::Result<Option<ChunkBlameSummary>> {

--- a/crates/rag-rat-core/src/index/query_api/history.rs
+++ b/crates/rag-rat-core/src/index/query_api/history.rs
@@ -5,7 +5,11 @@ use super::*;
 
 impl IndexDatabase {
     pub fn commit_search(&self, query: &str, limit: u32) -> anyhow::Result<Vec<CommitSearchHit>> {
-        git_history::commit_search(self.storage.connection(), query, limit)
+        // #582: ranked commit_fts read — heal-and-retry on shadow corruption.
+        crate::index::retry_once_on_fts_corruption(
+            || git_history::commit_search(self.storage.connection(), query, limit),
+            || self.heal_corrupt_fts(),
+        )
     }
 
     /// Commit-replay eval cases (#120) from the indexed git history — commit message as query, the
@@ -179,7 +183,10 @@ impl IndexDatabase {
         query: &str,
         limit: u32,
     ) -> anyhow::Result<Vec<PapertrailEvidence>> {
-        papertrail::issue_search(self.storage.connection(), query, limit)
+        crate::index::retry_once_on_fts_corruption(
+            || papertrail::issue_search(self.storage.connection(), query, limit),
+            || self.heal_corrupt_fts(),
+        )
     }
 
     pub fn rationale_search(
@@ -187,7 +194,17 @@ impl IndexDatabase {
         query: &str,
         limit: u32,
     ) -> anyhow::Result<Vec<PapertrailEvidence>> {
-        papertrail::rationale_search(self.storage.connection(), query, limit, &self.papertrail)
+        crate::index::retry_once_on_fts_corruption(
+            || {
+                papertrail::rationale_search(
+                    self.storage.connection(),
+                    query,
+                    limit,
+                    &self.papertrail,
+                )
+            },
+            || self.heal_corrupt_fts(),
+        )
     }
 
     pub fn papertrail_refs_for_path(

--- a/crates/rag-rat-core/src/index/query_api/memory.rs
+++ b/crates/rag-rat-core/src/index/query_api/memory.rs
@@ -65,9 +65,17 @@ impl IndexDatabase {
         surface: crate::config::MemorySurface,
     ) -> anyhow::Result<Vec<crate::query::memory::RepoMemory>> {
         let conn = self.storage.connection();
-        let mut memories = crate::query::memory::memory_search(conn, query, limit)?;
-        crate::query::memory::apply_memory_surface(conn, &mut memories, surface)?;
-        Ok(memories)
+        // #582: both the MATCH and the surface hydration (whose Summary path runs a RANKED
+        // chunk_fts query) can hit FTS shadow corruption; heal-and-retry rather than surfacing
+        // a bare "database disk image is malformed" forever.
+        crate::index::retry_once_on_fts_corruption(
+            || {
+                let mut memories = crate::query::memory::memory_search(conn, query, limit)?;
+                crate::query::memory::apply_memory_surface(conn, &mut memories, surface)?;
+                Ok(memories)
+            },
+            || self.heal_corrupt_fts(),
+        )
     }
 
     pub fn memory_for_symbol(

--- a/crates/rag-rat-core/src/index/query_api/memory.rs
+++ b/crates/rag-rat-core/src/index/query_api/memory.rs
@@ -85,9 +85,15 @@ impl IndexDatabase {
         surface: crate::config::MemorySurface,
     ) -> anyhow::Result<Vec<crate::query::memory::RepoMemory>> {
         let conn = self.storage.connection();
-        let mut memories = crate::query::memory::memories_for_symbol(conn, symbol, limit)?;
-        crate::query::memory::apply_memory_surface(conn, &mut memories, surface)?;
-        Ok(memories)
+        // #582: the Summary surface hydration runs a RANKED chunk_fts query — heal-and-retry.
+        crate::index::retry_once_on_fts_corruption(
+            || {
+                let mut memories = crate::query::memory::memories_for_symbol(conn, symbol, limit)?;
+                crate::query::memory::apply_memory_surface(conn, &mut memories, surface)?;
+                Ok(memories)
+            },
+            || self.heal_corrupt_fts(),
+        )
     }
 
     pub fn memory_for_path(
@@ -97,9 +103,15 @@ impl IndexDatabase {
         surface: crate::config::MemorySurface,
     ) -> anyhow::Result<Vec<crate::query::memory::RepoMemory>> {
         let conn = self.storage.connection();
-        let mut memories = crate::query::memory::memories_for_path(conn, path, limit)?;
-        crate::query::memory::apply_memory_surface(conn, &mut memories, surface)?;
-        Ok(memories)
+        // #582: the Summary surface hydration runs a RANKED chunk_fts query — heal-and-retry.
+        crate::index::retry_once_on_fts_corruption(
+            || {
+                let mut memories = crate::query::memory::memories_for_path(conn, path, limit)?;
+                crate::query::memory::apply_memory_surface(conn, &mut memories, surface)?;
+                Ok(memories)
+            },
+            || self.heal_corrupt_fts(),
+        )
     }
 
     pub fn memory_for_edges(
@@ -109,9 +121,15 @@ impl IndexDatabase {
         surface: crate::config::MemorySurface,
     ) -> anyhow::Result<Vec<crate::query::memory::RepoMemory>> {
         let conn = self.storage.connection();
-        let mut memories = crate::query::memory::memories_for_edges(conn, edge_ids, limit)?;
-        crate::query::memory::apply_memory_surface(conn, &mut memories, surface)?;
-        Ok(memories)
+        // #582: the Summary surface hydration runs a RANKED chunk_fts query — heal-and-retry.
+        crate::index::retry_once_on_fts_corruption(
+            || {
+                let mut memories = crate::query::memory::memories_for_edges(conn, edge_ids, limit)?;
+                crate::query::memory::apply_memory_surface(conn, &mut memories, surface)?;
+                Ok(memories)
+            },
+            || self.heal_corrupt_fts(),
+        )
     }
 
     pub fn memory_evidence_for_symbol_and_edges(
@@ -127,16 +145,22 @@ impl IndexDatabase {
         // compact), so honor `[memory] surface` here by deferring each lane's bodies under
         // `Summary`.
         let conn = self.storage.connection();
-        let mut evidence = crate::query::memory::memory_evidence_for_symbol_and_edges(
-            conn,
-            symbol,
-            caller_edge_ids,
-            callee_edge_ids,
-            limit,
+        // #582: the Summary surface hydration runs a RANKED chunk_fts query — heal-and-retry.
+        crate::index::retry_once_on_fts_corruption(
+            || {
+                let mut evidence = crate::query::memory::memory_evidence_for_symbol_and_edges(
+                    conn,
+                    symbol,
+                    caller_edge_ids,
+                    callee_edge_ids,
+                    limit,
+                )
+                .map(|(evidence, _truncated)| evidence)?;
+                evidence.apply_surface(conn, surface)?;
+                Ok(evidence)
+            },
+            || self.heal_corrupt_fts(),
         )
-        .map(|(evidence, _truncated)| evidence)?;
-        evidence.apply_surface(conn, surface)?;
-        Ok(evidence)
     }
 
     pub fn memory_for_call_path_hash(
@@ -146,10 +170,19 @@ impl IndexDatabase {
         surface: crate::config::MemorySurface,
     ) -> anyhow::Result<Vec<crate::query::memory::RepoMemory>> {
         let conn = self.storage.connection();
-        let mut memories =
-            crate::query::memory::memories_for_call_path_hash(conn, edge_sequence_hash, limit)?;
-        crate::query::memory::apply_memory_surface(conn, &mut memories, surface)?;
-        Ok(memories)
+        // #582: the Summary surface hydration runs a RANKED chunk_fts query — heal-and-retry.
+        crate::index::retry_once_on_fts_corruption(
+            || {
+                let mut memories = crate::query::memory::memories_for_call_path_hash(
+                    conn,
+                    edge_sequence_hash,
+                    limit,
+                )?;
+                crate::query::memory::apply_memory_surface(conn, &mut memories, surface)?;
+                Ok(memories)
+            },
+            || self.heal_corrupt_fts(),
+        )
     }
 
     pub fn memory_rebind(

--- a/crates/rag-rat-core/src/index/query_api/mod.rs
+++ b/crates/rag-rat-core/src/index/query_api/mod.rs
@@ -446,11 +446,19 @@ impl IndexDatabase {
         )?;
         if include_memories {
             let conn = self.storage.connection();
-            chunk.memories = crate::query::memory::memories_for_chunk(conn, chunk_id, 20)?;
             // Drive-by chunk attachments honor `[memory] surface`: under `Summary` each memory's
             // body is deferred to `memory show`, leaving the summary + verdict marker
-            // (title-only fallback).
-            crate::query::memory::apply_memory_surface(conn, &mut chunk.memories, surface)?;
+            // (title-only fallback). #582: the Summary hydration runs a RANKED chunk_fts query —
+            // heal-and-retry.
+            chunk.memories = crate::index::retry_once_on_fts_corruption(
+                || {
+                    let mut memories =
+                        crate::query::memory::memories_for_chunk(conn, chunk_id, 20)?;
+                    crate::query::memory::apply_memory_surface(conn, &mut memories, surface)?;
+                    Ok(memories)
+                },
+                || self.heal_corrupt_fts(),
+            )?;
         }
         Ok(Some(chunk))
     }

--- a/crates/rag-rat-core/src/index/query_api/mod.rs
+++ b/crates/rag-rat-core/src/index/query_api/mod.rs
@@ -550,6 +550,7 @@ impl IndexDatabase {
                 skipped_files: 0,
                 fts_fresh: !self.fts_dirty()?,
                 fts_healed: Vec::new(),
+                fts_deferred: Vec::new(),
                 message: Some(
                     "skipped: heal does not run under a linked-worktree overlay scope".to_string(),
                 ),
@@ -567,6 +568,7 @@ impl IndexDatabase {
             skipped_files: 0,
             fts_fresh: false,
             fts_healed: Vec::new(),
+            fts_deferred: Vec::new(),
             message: None,
         };
 
@@ -604,7 +606,9 @@ impl IndexDatabase {
         // Probe for FTS shadow corruption BEFORE the freshness pass (#582): a dirty-flagged
         // index would otherwise be incidentally repaired by `ensure_fts_fresh`'s rebuild and the
         // report would under-attribute what was actually corrupt.
-        report.fts_healed = self.heal_fts_if_corrupt()?;
+        let fts_outcome = self.heal_fts_if_corrupt()?;
+        report.fts_healed = fts_outcome.healed;
+        report.fts_deferred = fts_outcome.deferred;
         if report.healed_files > 0 || report.removed_files > 0 {
             self.sync_fts()?;
         } else {

--- a/crates/rag-rat-core/src/index/query_api/mod.rs
+++ b/crates/rag-rat-core/src/index/query_api/mod.rs
@@ -614,7 +614,9 @@ impl IndexDatabase {
         } else {
             self.ensure_fts_fresh()?;
         }
-        report.fts_fresh = !self.fts_dirty()?;
+        // A deferred corrupt mirror is NOT fresh, whatever the dirty flag says — operators key
+        // health off this field.
+        report.fts_fresh = !self.fts_dirty()? && report.fts_deferred.is_empty();
         Ok(report)
     }
 

--- a/crates/rag-rat-core/src/index/query_api/mod.rs
+++ b/crates/rag-rat-core/src/index/query_api/mod.rs
@@ -549,6 +549,7 @@ impl IndexDatabase {
                 removed_files: 0,
                 skipped_files: 0,
                 fts_fresh: !self.fts_dirty()?,
+                fts_healed: Vec::new(),
                 message: Some(
                     "skipped: heal does not run under a linked-worktree overlay scope".to_string(),
                 ),
@@ -565,6 +566,7 @@ impl IndexDatabase {
             removed_files: 0,
             skipped_files: 0,
             fts_fresh: false,
+            fts_healed: Vec::new(),
             message: None,
         };
 
@@ -599,6 +601,10 @@ impl IndexDatabase {
             report.healed_files += 1;
         }
 
+        // Probe for FTS shadow corruption BEFORE the freshness pass (#582): a dirty-flagged
+        // index would otherwise be incidentally repaired by `ensure_fts_fresh`'s rebuild and the
+        // report would under-attribute what was actually corrupt.
+        report.fts_healed = self.heal_fts_if_corrupt()?;
         if report.healed_files > 0 || report.removed_files > 0 {
             self.sync_fts()?;
         } else {

--- a/crates/rag-rat-core/src/index/query_api/search.rs
+++ b/crates/rag-rat-core/src/index/query_api/search.rs
@@ -74,7 +74,13 @@ impl IndexDatabase {
             explain: request.explain,
             options: request.options,
         };
-        let mut hits = self.search_with_heal(&query, Heal::Allow)?;
+        // #582: a ranked chunk_fts read is the one path that decodes docsize — the corruption
+        // class every integrity check misses. Heal the mirrors and retry once instead of
+        // surfacing "database disk image is malformed" on every search until manual repair.
+        let mut hits = crate::index::retry_once_on_fts_corruption(
+            || self.search_with_heal(&query, Heal::Allow),
+            || self.heal_corrupt_fts(),
+        )?;
         graph_meta::attach_to_search_hits(
             self.storage.connection(),
             &mut hits,
@@ -92,13 +98,19 @@ impl IndexDatabase {
         include_generated: bool,
         graded_history: bool,
     ) -> anyhow::Result<Vec<SearchHit>> {
-        self.ensure_fts_fresh()?;
-        crate::search::lexical::search_hash_baseline(
-            self.storage.connection(),
-            query,
-            limit,
-            include_generated,
-            graded_history,
+        // #582: an independent ranked chunk_fts path — heal-and-retry like `search`.
+        crate::index::retry_once_on_fts_corruption(
+            || {
+                self.ensure_fts_fresh()?;
+                crate::search::lexical::search_hash_baseline(
+                    self.storage.connection(),
+                    query,
+                    limit,
+                    include_generated,
+                    graded_history,
+                )
+            },
+            || self.heal_corrupt_fts(),
         )
     }
 

--- a/crates/rag-rat-core/src/index/schema/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema/migrations.rs
@@ -4025,7 +4025,7 @@ fn rebuild_dream_findings_with_repo_id(conn: &Connection) -> rusqlite::Result<()
 /// `repo_id` come from each memory's freshly-added column and needs no FTS `RENAME` (which has
 /// historically been fragile on shadow tables); the DROP + CREATE keeps the canonical table name.
 /// `memory_search` then filters `repo_id` after the MATCH.
-fn rebuild_repo_memory_fts_with_repo_id(conn: &Connection) -> rusqlite::Result<()> {
+pub(crate) fn rebuild_repo_memory_fts_with_repo_id(conn: &Connection) -> rusqlite::Result<()> {
     conn.execute_batch(
         "
         DROP TABLE IF EXISTS repo_memory_fts;

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/fts_corruption.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/fts_corruption.rs
@@ -1,0 +1,193 @@
+//! #582: FTS5 shadow-table corruption is invisible to `PRAGMA integrity_check` (and, for
+//! contentless docsize damage, even to FTS5's own `'integrity-check'`) — only a query that
+//! actually EXECUTES rank/bm25 fails, with a bare "database disk image is malformed". These pin
+//! the query-layer self-heal (rebuild the FTS mirrors from durable sources through the SAME
+//! connection, retry once) and `heal_index`'s ranked-probe detection.
+
+use super::*;
+
+/// Mirror of the real incident's corruption class (#582): drop the mirror's docsize rows, so a
+/// RANKED match fails SQLITE_CORRUPT (bm25 requires a docsize row per matched rowid) while an
+/// unranked COUNT over the same MATCH passes (the ORDER BY is optimized away). This is the ONLY
+/// deterministic corruption shape for a small index: garbaging or zeroing `_data` pages degrades
+/// to a silent empty index (no match, no error) — the exact trap that burned the incident's
+/// wrong theories.
+fn corrupt_fts_docsize(db: &IndexDatabase, fts_table: &str) {
+    db.storage.connection().execute(&format!("DELETE FROM {fts_table}_docsize"), []).unwrap();
+}
+
+fn ranked_chunk_probe(db: &IndexDatabase, term: &str) -> anyhow::Result<Option<i64>> {
+    let out = db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT rowid FROM chunk_fts WHERE chunk_fts MATCH ?1 ORDER BY rank LIMIT 1",
+            [term],
+            |row| row.get::<_, i64>(0),
+        )
+        .map(Some);
+    match out {
+        Ok(v) => Ok(v),
+        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+        Err(err) => Err(err.into()),
+    }
+}
+
+#[test]
+fn ranked_chunk_search_self_heals_docsize_corruption() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), "pub fn corruption_witness_alpha() {}\n").unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    corrupt_fts_docsize(&db, "chunk_fts");
+    // Sanity, pinning the #582 diagnosis: the RANKED probe fails "malformed"; the same MATCH
+    // without rank passes (so integrity-check-style probes would miss this entirely).
+    let ranked = ranked_chunk_probe(&db, "corruption_witness_alpha");
+    assert!(
+        ranked.is_err_and(|e| e.to_string().contains("malformed")),
+        "docsize corruption must fail the ranked probe"
+    );
+    let unranked: i64 = db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT COUNT(*) FROM chunk_fts WHERE chunk_fts MATCH 'corruption_witness_alpha'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(unranked, 1, "the unranked MATCH still passes — corruption is rank-only");
+
+    // The public ranked search path self-heals and answers.
+    let hits = db.search("corruption_witness_alpha", 10, false).expect("search self-heals");
+    assert!(!hits.is_empty(), "the healed index serves the hit");
+    assert!(
+        ranked_chunk_probe(&db, "corruption_witness_alpha").is_ok(),
+        "the ranked probe passes after the self-heal"
+    );
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+#[test]
+fn memory_search_self_heals_fts_corruption() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), "pub fn memoried_fn() {}\n").unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    db.memory_create(crate::query::memory::RepoMemoryCreate {
+        kind: "Decision".to_string(),
+        title: "corruption witness memory".to_string(),
+        body: "Body of the corruption witness memory.".to_string(),
+        confidence: "high".to_string(),
+        created_by: Some("test".to_string()),
+        source: Some("agent".to_string()),
+        tags: vec![],
+        payload_json: None,
+        bind: dir_bind_target(Some("src".to_string())),
+    })
+    .unwrap();
+
+    corrupt_fts_docsize(&db, "repo_memory_fts");
+    // Sanity: the ranked memory MATCH is broken before the heal.
+    let direct = db.storage.connection().query_row(
+        "SELECT rowid FROM repo_memory_fts WHERE repo_memory_fts MATCH 'witness' ORDER BY rank \
+         LIMIT 1",
+        [],
+        |row| row.get::<_, i64>(0),
+    );
+    assert!(
+        matches!(&direct, Err(e) if e.to_string().contains("malformed")),
+        "the corrupted memory FTS must fail before the heal: {direct:?}"
+    );
+
+    let hits = db
+        .memory_search("witness", 10, crate::config::MemorySurface::Full)
+        .expect("memory_search self-heals");
+    assert_eq!(hits.len(), 1, "the healed FTS serves the memory");
+    assert_eq!(hits[0].title, "corruption witness memory");
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+#[test]
+fn heal_index_probes_and_repairs_corrupt_fts() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), "pub fn heal_probe_witness() {}\n").unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    db.memory_create(crate::query::memory::RepoMemoryCreate {
+        kind: "Decision".to_string(),
+        title: "heal probe memory".to_string(),
+        body: "Body of the heal probe memory.".to_string(),
+        confidence: "high".to_string(),
+        created_by: Some("test".to_string()),
+        source: Some("agent".to_string()),
+        tags: vec![],
+        payload_json: None,
+        bind: dir_bind_target(Some("src".to_string())),
+    })
+    .unwrap();
+
+    corrupt_fts_docsize(&db, "chunk_fts");
+    corrupt_fts_docsize(&db, "repo_memory_fts");
+
+    let report = db.heal_index(None).unwrap();
+    assert!(
+        report.fts_healed.iter().any(|t| t == "chunk_fts"),
+        "the ranked probe catches the docsize corruption (an integrity-check-style probe \
+         wouldn't): {report:?}"
+    );
+    assert!(
+        report.fts_healed.iter().any(|t| t == "repo_memory_fts"),
+        "the memory FTS corruption is caught and healed: {report:?}"
+    );
+    assert!(
+        ranked_chunk_probe(&db, "heal_probe_witness").is_ok(),
+        "ranked chunk queries pass after heal_index"
+    );
+
+    // A second heal on the now-clean index rebuilds nothing.
+    let clean = db.heal_index(None).unwrap();
+    assert!(clean.fts_healed.is_empty(), "no false-positive probe on a clean index: {clean:?}");
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+#[test]
+fn commit_search_self_heals_commit_fts_corruption() {
+    // #582 review: commit_fts is an independent ranked path (it was one of the initially
+    // uncovered seams) — same corruption shape, same heal-and-retry contract.
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), "pub fn committed_fn() {}\n").unwrap();
+    init_git_repo(&root);
+    run_git(&root, &["add", "."]);
+    run_git(&root, &["commit", "-q", "-m", "corruption witness commit subject"]);
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    corrupt_fts_docsize(&db, "commit_fts");
+    let direct = db.storage.connection().query_row(
+        "SELECT rowid FROM commit_fts WHERE commit_fts MATCH 'witness' ORDER BY rank LIMIT 1",
+        [],
+        |row| row.get::<_, i64>(0),
+    );
+    assert!(
+        matches!(&direct, Err(e) if e.to_string().contains("malformed")),
+        "the corrupted commit FTS must fail before the heal: {direct:?}"
+    );
+
+    let hits = db.commit_search("witness", 10).expect("commit_search self-heals");
+    assert!(!hits.is_empty(), "the healed commit index serves the hit");
+
+    let _ = fs::remove_dir_all(&root);
+}

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/fts_corruption.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/fts_corruption.rs
@@ -235,5 +235,11 @@ fn heal_refuses_while_staged_chunk_fts_rows_are_not_rederivable() {
         .unwrap();
     assert_eq!(fts_rows_before, fts_rows_after, "the staged fts rows were NOT deleted");
 
+    // The explicit heal surfaces the SAME window as a deferral, never as health: a silent skip
+    // would let heal_index report a clean index while ranked queries still fail.
+    let outcome = db.heal_fts_if_corrupt().unwrap();
+    assert!(outcome.healed.is_empty(), "{:?}", outcome.healed);
+    assert_eq!(outcome.deferred, vec!["chunk_fts".to_string()]);
+
     let _ = fs::remove_dir_all(&root);
 }

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/fts_corruption.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/fts_corruption.rs
@@ -241,5 +241,68 @@ fn heal_refuses_while_staged_chunk_fts_rows_are_not_rederivable() {
     assert!(outcome.healed.is_empty(), "{:?}", outcome.healed);
     assert_eq!(outcome.deferred, vec!["chunk_fts".to_string()]);
 
+    // And the health flag must not read fresh while a known-corrupt mirror waits: operators key
+    // off fts_fresh.
+    let report = db.heal_index(None).unwrap();
+    assert_eq!(report.fts_deferred, vec!["chunk_fts".to_string()]);
+    assert!(!report.fts_fresh, "a deferred corrupt mirror is not fresh");
+
+    // The plain dream worklist ranks nothing and must stay write-free and error-free under the
+    // exact same window (byte-identical contract): no probe, no heal, corruption untouched.
+    let worklist_opts =
+        crate::dream::DreamOptions { now_ms: 1, limit: 10, verify: false, include_reviewed: false };
+    db.dream_run_with_passes(worklist_opts, None, None)
+        .expect("the deterministic worklist never touches ranked FTS");
+    let docsize_rows: i64 = db
+        .storage
+        .connection()
+        .query_row("SELECT count(*) FROM chunk_fts_docsize", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(docsize_rows, 0, "no heal may run for the pass-less worklist");
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+/// The staged-window hazard is CHUNK-only: commit_fts rebuilds from durable git_commits and must
+/// heal even while a staged generation exists — deferring it would leave commit_search broken
+/// behind unrelated staging.
+#[test]
+fn commit_fts_heals_even_while_chunk_staging_exists() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), "pub fn staged_commit_witness() {}\n").unwrap();
+    // commit_fts indexes git history — the corruption probe needs a non-empty mirror.
+    let git = |args: &[&str]| {
+        let out =
+            std::process::Command::new("git").arg("-C").arg(&root).args(args).output().unwrap();
+        assert!(out.status.success(), "git {args:?}: {}", String::from_utf8_lossy(&out.stderr));
+    };
+    git(&["init", "-q"]);
+    git(&["add", "-A"]);
+    git(&[
+        "-c",
+        "user.email=t@example.invalid",
+        "-c",
+        "user.name=t",
+        "commit",
+        "-q",
+        "-m",
+        "commit witness message",
+    ]);
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    db.storage
+        .connection()
+        .execute("UPDATE main.files SET generation = generation + 1 WHERE path = 'src/lib.rs'", [])
+        .unwrap();
+    corrupt_fts_docsize(&db, "chunk_fts");
+    corrupt_fts_docsize(&db, "commit_fts");
+
+    let outcome = db.heal_fts_if_corrupt().unwrap();
+    assert_eq!(outcome.healed, vec!["commit_fts".to_string()]);
+    assert_eq!(outcome.deferred, vec!["chunk_fts".to_string()]);
+
     let _ = fs::remove_dir_all(&root);
 }

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/fts_corruption.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/fts_corruption.rs
@@ -191,3 +191,49 @@ fn commit_search_self_heals_commit_fts_corruption() {
 
     let _ = fs::remove_dir_all(&root);
 }
+
+#[test]
+fn heal_refuses_while_staged_chunk_fts_rows_are_not_rederivable() {
+    // #582 review: between a staged rebuild's committed waves, chunk_fts rows exist whose text
+    // is not in the durable store yet. A corruption heal firing in that window must REFUSE (the
+    // original error surfaces; the next query retries) rather than 'delete-all' + re-derive,
+    // which would silently drop the staged rows and stamp the loss clean.
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), "pub fn staged_witness_fn() {}\n").unwrap();
+    fs::write(root.join("src/other.rs"), "pub fn ranked_witness_fn() {}\n").unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    // Simulate the mid-rebuild window through the GENERATION LEDGER (the staging signal the
+    // guard reads — corruption-independent by design): one file's rows sit ABOVE the repo's live
+    // generation, exactly as a rebuild's committed-but-unpublished wave does.
+    db.storage
+        .connection()
+        .execute("UPDATE main.files SET generation = generation + 1 WHERE path = 'src/lib.rs'", [])
+        .unwrap();
+    corrupt_fts_docsize(&db, "chunk_fts");
+
+    let fts_rows_before: i64 = db
+        .storage
+        .connection()
+        .query_row("SELECT count(*) FROM chunk_fts", [], |row| row.get(0))
+        .unwrap();
+    let result = db.search("ranked_witness_fn", 10, false);
+    assert!(
+        result.is_err_and(|e| {
+            let chain = format!("{e:#}");
+            chain.contains("malformed") && chain.contains("heal")
+        }),
+        "the heal refuses: the ORIGINAL corruption error surfaces with the deferral as context"
+    );
+    let fts_rows_after: i64 = db
+        .storage
+        .connection()
+        .query_row("SELECT count(*) FROM chunk_fts", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(fts_rows_before, fts_rows_after, "the staged fts rows were NOT deleted");
+
+    let _ = fs::remove_dir_all(&root);
+}

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/mod.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/mod.rs
@@ -926,6 +926,7 @@ mod clones;
 mod dir_memory_tree;
 mod dispatch;
 mod embedding_policy_fast_path;
+mod fts_corruption;
 mod generation_rebuild;
 mod git_history_reload;
 mod graph_edges;

--- a/crates/rag-rat-core/src/query/memory/hydrate.rs
+++ b/crates/rag-rat-core/src/query/memory/hydrate.rs
@@ -128,6 +128,25 @@ pub(crate) fn upsert_memory_fts(conn: &Connection, memory_id: &str) -> anyhow::R
     }
     Ok(())
 }
+/// #582: recover `repo_memory_fts` after shadow-table corruption. Lossless first: FTS5
+/// `'rebuild'` re-derives the inverted index from the table's own content shadow. When the
+/// content shadow is torn too (the `'rebuild'` itself errors), fall back to the nuclear path —
+/// DROP + CREATE + repopulate from `repo_memories` (the FTS is derived; the memories table is
+/// the source of truth, so nothing is lost). The nuclear shape carries `repo_id` (post-A5);
+/// a pre-A5 store has no source `repo_id` to rebuild from, so it gets the lossless path only.
+pub(crate) fn heal_repo_memory_fts(conn: &Connection) -> anyhow::Result<()> {
+    if conn.execute("INSERT INTO repo_memory_fts(repo_memory_fts) VALUES('rebuild')", []).is_ok() {
+        return Ok(());
+    }
+    anyhow::ensure!(
+        memory_repo_scope(conn)?.is_some(),
+        "repo_memory_fts is corrupt beyond an in-place rebuild and this pre-A5 store cannot be \
+         repopulated from source"
+    );
+    crate::index::schema::rebuild_repo_memory_fts_with_repo_id(conn)?;
+    Ok(())
+}
+
 pub(crate) fn memory_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<RepoMemory> {
     Ok(RepoMemory {
         memory_id: row.get("memory_id")?,

--- a/crates/rag-rat-mcp/src/agent_hook.rs
+++ b/crates/rag-rat-mcp/src/agent_hook.rs
@@ -192,7 +192,10 @@ mod listener {
                         memory_surface,
                     )
                 })
-                .await??;
+                .await?;
+                let composed = super::degrade_when_fts_corrupt(composed, || {
+                    super::spawn_background_fts_heal(config.clone())
+                })?;
                 match composed {
                     Some(out) => {
                         // compose's returned IDs are exactly the items rendered, so the
@@ -377,8 +380,78 @@ mod listener_tests {
     }
 }
 
+/// A read-only hook connection cannot heal FTS corruption, and the hook is latency-critical —
+/// degrade to the hook's designed null-context reply and let `on_corrupt` kick recovery. Every
+/// other error propagates unchanged.
+fn degrade_when_fts_corrupt<T>(
+    result: anyhow::Result<Option<T>>,
+    on_corrupt: impl FnOnce(),
+) -> anyhow::Result<Option<T>> {
+    match result {
+        Err(error) if rag_rat_core::index::error_is_fts_corruption(&error) => {
+            on_corrupt();
+            Ok(None)
+        },
+        other => other,
+    }
+}
+
+/// One background FTS heal at a time, off the hook's hot path, on its own WRITABLE open — the
+/// listener's read-only connection cannot rebuild. Without this, a grep-hook-only session
+/// (no MCP queries to trigger the query-layer self-heal) would serve null context indefinitely
+/// after a torn write, even though the repair is one lossless rebuild away.
+fn spawn_background_fts_heal(config: rag_rat_core::Config) {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    static HEAL_IN_FLIGHT: AtomicBool = AtomicBool::new(false);
+    if HEAL_IN_FLIGHT.swap(true, Ordering::SeqCst) {
+        return;
+    }
+    tokio::task::spawn_blocking(move || {
+        let outcome = rag_rat_core::IndexDatabase::open_config(&config)
+            .and_then(|db| db.heal_fts_if_corrupt());
+        match outcome {
+            Ok(outcome) if !outcome.healed.is_empty() || !outcome.deferred.is_empty() => {
+                eprintln!(
+                    "agent-hook: FTS corruption heal — rebuilt {:?}, deferred {:?}",
+                    outcome.healed, outcome.deferred
+                );
+            },
+            Ok(_) => {},
+            Err(error) => eprintln!("agent-hook: FTS corruption heal failed: {error:#}"),
+        }
+        HEAL_IN_FLIGHT.store(false, Ordering::SeqCst);
+    });
+}
+
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn fts_corruption_degrades_to_null_context_and_kicks_recovery() {
+        let corrupt = rusqlite::Error::SqliteFailure(
+            rusqlite::ffi::Error {
+                code: rusqlite::ErrorCode::DatabaseCorrupt,
+                extended_code: 267, // SQLITE_CORRUPT_VTAB — the FTS5 shadow variant
+            },
+            Some("database disk image is malformed".to_string()),
+        );
+        let mut kicked = false;
+        let degraded = super::degrade_when_fts_corrupt::<()>(Err(corrupt.into()), || kicked = true)
+            .expect("corruption must not surface as a hook error");
+        assert!(degraded.is_none(), "the hook's designed degrade is a null context");
+        assert!(kicked, "recovery must be kicked exactly when corruption is seen");
+
+        let mut kicked = false;
+        let other = super::degrade_when_fts_corrupt::<()>(
+            Err(anyhow::anyhow!("unrelated failure")),
+            || kicked = true,
+        );
+        assert!(other.is_err(), "non-corruption errors propagate unchanged");
+        assert!(!kicked);
+
+        let value = super::degrade_when_fts_corrupt(Ok(Some(7)), || unreachable!()).unwrap();
+        assert_eq!(value, Some(7));
+    }
+
     use super::*;
 
     #[test]

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -437,7 +437,11 @@ row names its `tracker` (`github`), `project` (`owner/repo`), `item_kind` (`issu
 and each binding's authentication and native synchronization capability.
 `papertrail_sync_status` returns that cache section directly. `heal_index` repairs or removes
 already-indexed files whose current source no longer matches the stored SQLite index, then refreshes
-SQLite FTS. It does not discover brand-new files; run `rag-rat index` for discovery.
+SQLite FTS. It also probes every FTS mirror with a ranked query — the only read that decodes the
+docsize shadow, whose corruption every ordinary integrity check misses — and rebuilds corrupt
+mirrors from their durable sources, reporting them in `fts_healed` (or `fts_deferred` when a
+staged rebuild in flight makes the repair unsafe — rerun once it completes). It does not discover
+brand-new files; run `rag-rat index` for discovery.
 
 Embedding artifacts are explicit and current-only. `llm_status` reports embedding model state,
 artifact counts, FastEmbed build/cache/model details, and the last reconcile throughput summary when


### PR DESCRIPTION
FTS5 docsize corruption is invisible to `PRAGMA integrity_check` AND FTS5's own `'integrity-check'` — only a query that *executes* rank/bm25 decodes the shadow, and it then fails with a bare "database disk image is malformed" on every call, indefinitely, even after an out-of-band repair (the long-lived server keeps serving its cached corrupt pages). This PR makes every ranked surface detect that class and heal it **through the querying connection**, from durable sources, losslessly.

## What it does

- **Query-layer self-heal**: every independent ranked entry point (`search`, `memory_search`, `commit_search`, `commits_touching_query`, `impact_surface`'s rationale, dream's evidence probes) retries ONCE after `heal_corrupt_fts()` — a full rebuild of every mirror (`chunk_fts`/`commit_fts` from the chunk/commit stores, `repo_memory_fts` from `repo_memories`, `papertrail_fts` from the papertrail tables) inside one `BEGIN IMMEDIATE` fence. Corruption never names its table, so over-healing costs one re-tokenize, not data.
- **`heal_index` FTS phase**: probes each mirror with a ranked query (the only read that decodes docsize) and reports `fts_healed` — or `fts_deferred` when a generation-staged rebuild in flight makes 'delete-all' + re-derive unsafe (the report never reads healthy while ranked queries still fail; dream's preflight postpones the model run on the same signal instead of paying provisioning to hit corruption mid-pass).
- **Staging guard reads the generation ledger, not FTS shapes**: a corrupted mirror *scans as empty*, which blinded the old "irreplaceable fts rows" probe exactly when a stale freshness stamp coincided with corruption — the rebuild then destroyed the staged rows the guard exists to protect.
- **The grep-augment hook** (read-only connection, latency-critical — the one path that cannot heal in place) degrades corruption to its designed null-context reply and kicks ONE background heal on a writable open, so a grep-hook-only session recovers instead of staying dark.
- **Every mirror rebuild is atomic when standalone** (#610): `rebuild_fts` and papertrail's whole-table rebuild ran 'delete-all' + reinserts un-fenced — interruptible into an empty mirror silently missing from BM25. The fence engages only in autocommit (nested BEGINs are rejected; the heals' outer fence stays the single atomic unit) and doubles as cross-repo serialization for the GLOBAL mirrors, where per-repo flocks cannot serialize siblings on a consolidated store.

## #610 disposition

- Item 1 (SIGUSR1 must reopen connections): **resolved by the SIGUSR1 hot-upgrade** — the handler `exec`s unconditionally on signal (fresh process, fresh connections); with no upgrade target configured, SIGUSR1's default disposition terminates the process and the respawn reopens. The incident's "restart that reloads config but keeps the connection" no longer exists.
- Items 2 (torn-write hardening) and 3 (global mirrors vs per-repo flocks): this PR, per above.

## Review rounds

- **The probe is now complete for the docsize class**: a real term sampled from the mirror's own `fts5vocab` rank-matches regardless of corpus alphabet (the ASCII-prefix disjunction went blind on non-ASCII corpora), and a full shadow scan checks row-count parity plus per-blob varint shape — docsize is per-row, so the sampled read alone proved one row. Parity uses a docsize-independent row source: a contentless mirror's own `count(*)` enumerates *through* docsize (measured), so `chunk_fts` compares against its durable chunks-join. A corrupt read *inside* the scan counts as a positive probe, never a probe failure.
- **commit_fts heals under chunk staging** (its `git_commits` source is always durable), and the retry wrapper names the deferral when the retried query still fails.
- **`fts_fresh` accounts for `fts_deferred`** — the health flag never reads fresh while a known-corrupt mirror waits.
- **The pass-less dream worklist stays byte-identical and write-free** — the corruption preflight runs only for model passes.
- **Every summary-hydration path joined the retry** (`memory_for_symbol`/`_path`/`_edges`, the symbol+edges evidence, `memory_for_call_path_hash`, `read_chunk` attachments) — the Summary surface ranks `chunk_fts`, and only `memory_search` was covered.
- The corruption predicate deliberately stays on the primary code: measured via `sqlite3_extended_errcode`, the incident class reports **11**, not `SQLITE_CORRUPT_VTAB` (267) — requiring 267 would miss exactly what this catches.
- The papertrail rebuild's standalone COMMIT failure rolls back instead of stranding the connection in-transaction.

## Live incident replay (scratch repo, real injection)

Truncated `chunk_fts_docsize` via sqlite3 (`.dbconfig defensive off`): `PRAGMA integrity_check` → **ok**; FTS5 `'integrity-check'` → **ok**; ranked read → **"database disk image is malformed (11)"**; the same ranked query through this branch's binary **self-heals inline and returns its hits**; on disk afterward the shadow is repopulated and the ranked read is clean.

Fixes #582
Fixes #610

