### PR TITLE
feat(memory): author the live memory path onto owner-bound /2//3 streams

### DIFF
--- a/crates/rag-rat-core/src/index/consolidate.rs
+++ b/crates/rag-rat-core/src/index/consolidate.rs
@@ -2139,38 +2139,48 @@ mod tests {
     }
 
     /// Before #541 Task 5, consolidation's import never touched the op-log: the imported rows
-    /// landed in `repo_memories`/`repo_node_edges` but the per-CHAIN backfill gate saw the target's
-    /// owner stream was already non-empty (this test's seed rooted it) and skipped authoring them
-    /// entirely — a later `mark_obsolete` on such a row would author an inert `NodeStatus` with no
-    /// `NodeCreate` behind it. This test proves the reconcile call `run` now makes closes that gap:
-    /// an imported memory is present in the target's projection, and a follow-up `mark_obsolete` is
-    /// NOT inert.
+    /// landed in `repo_memories`/`repo_node_edges` but were skipped by the reconcile — a later
+    /// `mark_obsolete` on such a row would author an inert `NodeStatus` with no `NodeCreate` behind
+    /// it. This test proves the reconcile call `run` now makes closes that gap on the owner-bound
+    /// `/2`//3 substrate (#664): an imported memory is present in the target's accepted-`/3`
+    /// projection, and a follow-up `mark_obsolete` is NOT inert.
     #[test]
     fn consolidation_authors_imported_memories_into_target_owner_stream() {
         let source = seeded_source();
         let target = seeded_target_with_rooted_chain();
 
-        // PREMISE SELF-CHECK: the seed must have rooted a non-empty local chain for `global-repo`,
-        // or this test silently degrades to the (already-covered) genesis path and stops exercising
-        // the per-chain-gate bypass #541 fixes.
-        let device = crate::oplog::local_device(&target, 0).unwrap();
-        let stream = crate::oplog::owner_stream("global-repo").unwrap();
+        // The count of a projected node in the accepted-`/3` projection (a test target holds one
+        // repo/stream, so no stream filter is needed).
+        let projected_m1 = |target: &rusqlite::Connection| -> i64 {
+            target
+                .query_row(
+                    "SELECT COUNT(*) FROM content_projected_nodes WHERE node_id = 'm1'",
+                    [],
+                    |r| r.get(0),
+                )
+                .unwrap()
+        };
+
+        // PREMISE SELF-CHECK: the seed's real `create_memory` must have rooted a non-empty `/3`
+        // content chain for `global-repo`, or this test silently degrades to the (already-covered)
+        // genesis path and stops exercising the per-node reconcile bypass #541 fixes.
+        let content_entries: i64 =
+            target.query_row("SELECT COUNT(*) FROM content_entries", [], |r| r.get(0)).unwrap();
         assert!(
-            crate::oplog::chain_tail(&target, stream, device.fingerprint()).unwrap().is_some(),
-            "the seed must root a non-empty owner chain, or this test degrades to the genesis path"
+            content_entries > 0,
+            "the seed must root a non-empty /3 content chain, or this test degrades to genesis"
         );
 
         // The import itself does NOT touch the op-log (it predates #541's reconcile call) — only
         // `repo_memories`/`repo_node_edges` gain the imported rows.
         let counts = import_from_source(&source, &target, "global-repo").unwrap();
         assert_eq!(counts.memories, 3, "sanity: the import still carries all 3 source memories");
-        assert!(
-            !crate::oplog::load_projection(&target, stream)
-                .unwrap()
-                .nodes
-                .contains_key(&crate::oplog::NodeId::from("m1")),
-            "pre-reconcile: the imported memory m1 must NOT yet be projected (the per-chain gate \
-             skipped it, the bug #541 fixes) — only the seed memory should be projected here"
+        assert_eq!(
+            projected_m1(&target),
+            0,
+            "pre-reconcile: the imported memory m1 must NOT yet be projected (the per-node \
+             anti-join skipped it, the bug #541 fixes) — only the seed memory should be projected \
+             here"
         );
 
         // The call this task wires into `run`, immediately after `import_from_source` and before
@@ -2182,25 +2192,21 @@ mod tests {
         )
         .unwrap();
 
-        // An imported memory is now present in the target owner stream's projection.
-        let projected = crate::oplog::load_projection(&target, stream).unwrap();
-        assert!(
-            projected.nodes.contains_key(&crate::oplog::NodeId::from("m1")),
-            "the imported memory m1 must be present in the target owner stream's projection"
+        // An imported memory is now present in the target owner stream's accepted-`/3` projection.
+        assert_eq!(
+            projected_m1(&target),
+            1,
+            "the imported memory m1 must be present in the target owner stream's /3 projection"
         );
 
         // A follow-up `mark_obsolete` on the imported memory is NOT inert: it flips the projected
         // status (which requires the `NodeCreate` the reconcile just authored).
         crate::query::memory::mark_obsolete(&target, "m1").unwrap();
-        let projected = crate::oplog::load_projection(&target, stream).unwrap();
-        let node = projected
-            .nodes
-            .get(&crate::oplog::NodeId::from("m1"))
+        let status: String = target
+            .query_row("SELECT status FROM content_projected_nodes WHERE node_id = 'm1'", [], |r| {
+                r.get(0)
+            })
             .expect("m1 must still be projected after mark_obsolete");
-        assert_eq!(
-            node.status,
-            crate::oplog::NodeStatus::Obsolete,
-            "mark_obsolete on an imported memory must not be inert"
-        );
+        assert_eq!(status, "obsolete", "mark_obsolete on an imported memory must not be inert");
     }
 }

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/reconcile_embeddings.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/reconcile_embeddings.rs
@@ -1456,9 +1456,12 @@ fn reconcile_heals_an_op_log_ghost_in_an_idle_repo() {
     )
     .unwrap();
 
+    // The memory reconcile now authors owner-bound `/3` content (#664), so the healed ghost lands
+    // in the accepted-`/3` projection `content_projected_nodes`, not the retained `/1` shadow
+    // table.
     let ghost_in_projection = |conn: &rusqlite::Connection| -> i64 {
         conn.query_row(
-            "SELECT COUNT(*) FROM oplog_projected_nodes WHERE node_id = 'mem_ghost_583'",
+            "SELECT COUNT(*) FROM content_projected_nodes WHERE node_id = 'mem_ghost_583'",
             [],
             |row| row.get(0),
         )

--- a/crates/rag-rat-core/src/oplog/account/authoring.rs
+++ b/crates/rag-rat-core/src/oplog/account/authoring.rs
@@ -17,7 +17,7 @@
 //! gate serializes racers, so a duplicate `StreamOwn` is never authored at all.
 
 use anyhow::Context;
-use rusqlite::{OptionalExtension, Transaction, params};
+use rusqlite::{Connection, OptionalExtension, Transaction, params};
 
 use super::AuthorityQuery;
 use super::bootstrap::{self, LocalAccountRef};
@@ -85,6 +85,44 @@ pub(crate) fn ensure_owned_stream_v2_in_tx(
             "StreamOwn authored but the /2 stream did not fold owned (fact {other:?}); refusing \
              to report a stream that is not owned by the local account",
         ),
+    }
+}
+
+/// Derive the repo's owner-bound `/2` stream id under the store's local account, or `None` when no
+/// local account is minted yet. PURE derivation — resolves the account pointer and hashes the spec,
+/// opening NO nested transaction, so it is safe both in autocommit and inside an open IMMEDIATE txn
+/// (pass a `&Transaction`, which derefs to `&Connection`). The live authoring seam's stream
+/// resolver: a `None` means "no principal to author under yet", so the caller SKIPS authoring
+/// rather than forcing a mint — the exact analog of an unstable scope.
+pub(crate) fn owned_stream_v2_id(
+    conn: &Connection,
+    repo_id: &str,
+) -> anyhow::Result<Option<StreamId>> {
+    let Some(LocalAccountRef { account_id, .. }) = bootstrap::local_account_ref(conn)? else {
+        return Ok(None);
+    };
+    Ok(Some(stream::derive_v2(&stream::owner_stream_v2(repo_id, account_id))?))
+}
+
+/// The repo's `/2` owner stream, but ONLY once it is fully ESTABLISHED: the local account is minted
+/// AND its `StreamOwn` has folded `Effective` (the ownership fact is live), so an owner-authored
+/// `/3` batch on it would accept. `None` when no account is minted OR ownership has not folded
+/// effective yet — so a fresh repo whose anti-join is empty only because it has never published
+/// ownership resolves `None` here and is NOT mistaken for "nothing to do" (the caller establishes
+/// ownership rather than early-returning). AUTOCOMMIT-ONLY: [`storage::stream_owner_effective`]
+/// opens its OWN Deferred transaction, so this MUST NOT be called inside an open transaction (use
+/// [`owned_stream_v2_id`] there). The reconcile's fast-path probe.
+pub(crate) fn established_owned_stream_v2(
+    conn: &Connection,
+    repo_id: &str,
+) -> anyhow::Result<Option<StreamId>> {
+    let Some(LocalAccountRef { account_id, .. }) = bootstrap::local_account_ref(conn)? else {
+        return Ok(None);
+    };
+    let stream_id = stream::derive_v2(&stream::owner_stream_v2(repo_id, account_id))?;
+    match storage::stream_owner_effective(conn, account_id, stream_id)? {
+        AuthorityQuery::Effective(_) => Ok(Some(stream_id)),
+        AuthorityQuery::Unknown | AuthorityQuery::Invalid(_) => Ok(None),
     }
 }
 

--- a/crates/rag-rat-core/src/oplog/account/content/author.rs
+++ b/crates/rag-rat-core/src/oplog/account/content/author.rs
@@ -28,7 +28,7 @@
 //! minting from the plain candidate tail (below) is the accepted tail.
 
 use anyhow::Context;
-use rusqlite::{OptionalExtension, Transaction, params};
+use rusqlite::{Connection, OptionalExtension, Transaction, params};
 
 use super::super::bootstrap::{self, LocalAccountRef};
 use super::super::{AccountId, storage as account_storage};
@@ -138,6 +138,24 @@ pub(crate) fn author_content_batch_in_tx(
     content_projection::reproject_accepted_content_stream(tx, stream_id)?;
 
     Ok(authored)
+}
+
+/// Whether the `/2` stream's `/3` content chain is EMPTY — no `content_entries` row on it at all.
+/// Under the single local writer the store's own account+device are the only chain on the stream,
+/// so "no rows for this stream" is the whole chain: the genesis case where the memory reconcile
+/// elides a create-time `active` status (a fresh chain holds no stale status register to override).
+/// A pure read opening no transaction, so it is safe inside the caller's IMMEDIATE txn (a
+/// `&Transaction` derefs to `&Connection`).
+pub(crate) fn content_stream_is_empty(
+    conn: &Connection,
+    stream_id: StreamId,
+) -> anyhow::Result<bool> {
+    let has_row: bool = conn.query_row(
+        "SELECT EXISTS(SELECT 1 FROM content_entries WHERE stream_id = ?1)",
+        params![stream_id.to_bytes().as_slice()],
+        |row| row.get(0),
+    )?;
+    Ok(!has_row)
 }
 
 /// The `(stream, author, device)` chain's highest-`seq` `/3` candidate, or `None` for an empty

--- a/crates/rag-rat-core/src/oplog/account/content/mod.rs
+++ b/crates/rag-rat-core/src/oplog/account/content/mod.rs
@@ -15,11 +15,9 @@ pub(crate) use acceptance::{
     ContentParkReason, ContentRejectReason, SubjectAuthorityHold, UnknownAncestry,
     evaluate_content_acceptance,
 };
-#[allow(
-    unused_imports,
-    reason = "C3.4b-i content-author seam is frozen before its caller lands"
-)]
-pub(crate) use author::author_content_batch_in_tx;
+// The in-tx `/3` local-authoring seam + its genesis-detection reader (C3.4b-i, #663): live
+// callers in `query::memory` land with #664, so these are plain (un-frozen) re-exports.
+pub(crate) use author::{author_content_batch_in_tx, content_stream_is_empty};
 pub(in crate::oplog) use envelope::{
     ContentEntryHeader, SignedContentEntry, VerifiedContentEntry, decode_content_signed,
     sign_content_entry, verify_content_signed,

--- a/crates/rag-rat-core/src/oplog/account/content/storage.rs
+++ b/crates/rag-rat-core/src/oplog/account/content/storage.rs
@@ -581,6 +581,17 @@ pub(in crate::oplog::account) fn refold_streams_for_account(
             streams.insert(fixed::<32>(&stream_bytes)?);
         }
     }
+    // This re-derives `accepted` but deliberately does NOT refresh the accepted-`/3` → memory
+    // projection (`content_projected_*`). That is safe ONLY while no path here can FLIP an accepted
+    // set: pre-transport the reconcile publishes a stream's `StreamOwn` before authoring its
+    // content (no retro-accept) and there is no local revoke/demote op (no retro-condemn), so
+    // this loop re-derives the identical accepted set the authoring path already reprojected.
+    // When transport (or any retro-accept/declassify op) lands, a flip here would leave
+    // `content_projected_*` stale and the memory reconcile's anti-join would mass-duplicate or
+    // skip rows — so phase-D must call `content_projection::reproject_accepted_content_stream`
+    // for each stream below, GUARDED on the V070 `content_projected_*` tables existing (this fn
+    // also runs in the pre-V070 V064/V065 authority backfill; mirror the
+    // `content_entries_exists` guard above). Tracked in #683.
     for stream in streams {
         refold_content_stream(tx, StreamId::from_bytes(stream))?;
     }

--- a/crates/rag-rat-core/src/oplog/account/mod.rs
+++ b/crates/rag-rat-core/src/oplog/account/mod.rs
@@ -28,28 +28,23 @@ mod ops;
 mod registers;
 mod storage;
 
-// The in-tx `/2`-ownership ensure seam (C3.4b-ii, #676) — the idempotent
-// ensure-the-repo's-owner-stream-is-owned primitive #664 calls before authoring `/3` content.
-// Frozen until that caller lands.
-#[allow(
-    unused_imports,
-    reason = "C3.4b-ii /2-ownership ensure seam is frozen before its caller lands"
-)]
-pub(crate) use authoring::ensure_owned_stream_v2_in_tx;
+// The in-tx `/2`-ownership ensure seam + the two read-only `/2`-stream resolvers (C3.4b-ii, #676):
+// `owned_stream_v2_id` (pure derivation — the live seam's stream resolver) and
+// `established_owned_stream_v2` (derivation + effective-ownership fact — the reconcile's fast-path
+// probe). #664 wires all three into `query::memory`, so they are plain re-exports.
+pub(crate) use authoring::{
+    ensure_owned_stream_v2_in_tx, established_owned_stream_v2, owned_stream_v2_id,
+};
 pub(crate) use bootstrap::local_account;
-// The in-tx `/3` content-author seam (C3.4b-i, #663) — frozen until #664 retargets the live
-// path.
-#[allow(
-    unused_imports,
-    reason = "C3.4b-i content-author seam is frozen before its caller lands"
-)]
-pub(crate) use content::author_content_batch_in_tx;
 #[allow(unused_imports, reason = "C2 contract is frozen before transport wiring lands")]
 pub(in crate::oplog) use content::{
     ContentCapacityScope, ContentEntryHeader, ContentIngestOutcome, SignedContentEntry,
     VerifiedContentEntry, content_ingest, decode_content_signed, sign_content_entry,
     verify_content_signed,
 };
+// The in-tx `/3` content-author seam + its genesis-detection reader (C3.4b-i, #663): #664
+// retargets the live memory path onto them, so they are plain re-exports.
+pub(crate) use content::{author_content_batch_in_tx, content_stream_is_empty};
 pub(crate) use fold::{
     AuthorityBoundary, AuthorityFreshness, AuthorityInvalidReason, AuthorityQuery, GrantAuthority,
     GrantDeviceAuthority, GrantDeviceBoundary, OwnerAuthority, OwnerChainAuthority,

--- a/crates/rag-rat-core/src/oplog/content_projection.rs
+++ b/crates/rag-rat-core/src/oplog/content_projection.rs
@@ -59,6 +59,13 @@ pub(in crate::oplog) fn reproject_accepted_content_stream(
     let entries = load_accepted_entries(tx, stream_id)?;
     let state = project::project(&entries);
     write_projection(tx, stream_id, &state)?;
+    // This stamps the STORE-GLOBAL version but rebuilt only THIS stream. Safe only while
+    // `CONTENT_PROJECTOR_VERSION` is never bumped: the stored version is then only ever unset or
+    // current, so there is no stale store to falsely mark done. BEFORE the first bump, add a
+    // store-global rebuild-on-upgrade (rebuild every `/3` stream, THEN stamp — mirroring `/1`'s
+    // `store::reproject_if_projector_stale`), or the first per-stream reproject on an
+    // old-version store would mark every OTHER (still-old) stream's projection current and the
+    // reconcile anti-join would trust a stale projection. Tracked in #688.
     stamp_content_projector_version(tx)?;
     Ok(())
 }

--- a/crates/rag-rat-core/src/oplog/content_projection.rs
+++ b/crates/rag-rat-core/src/oplog/content_projection.rs
@@ -22,7 +22,7 @@
 //! ([`crate::oplog::store::NodeContentRow`] et al.), so the two projections serialize identically.
 
 use anyhow::Context;
-use rusqlite::{Transaction, params};
+use rusqlite::{Connection, OptionalExtension, Transaction, params};
 
 use super::account::decode_content_signed;
 use super::op::{self, DecodedOp, Entry, OpMeta};
@@ -30,6 +30,17 @@ use super::project;
 use super::project::ProjectedState;
 use super::store::{EdgeSpecRow, NodeContentRow, ResolvedAnchorRow};
 use super::stream::StreamId;
+
+/// Bump when the accepted-`/3` → memory fold's projectable set or LWW semantics change (a new op
+/// kind becomes `Known`, a register is added). A `/3` projection stamped with an older version is
+/// rebuilt on the next content refold, never trusted incrementally; a NEWER stamp blocks this
+/// binary from reprojecting at all (see [`assert_content_projector_not_newer`]).
+const CONTENT_PROJECTOR_VERSION: i64 = 1;
+
+/// The `oplog_meta` key holding the `/3` projector version the content projection was last folded
+/// by. DISTINCT from the `/1` `projector_version` (they evolve independently and share one meta
+/// table): a `/1` projector bump must not silently invalidate the `/3` projection, or vice versa.
+const CONTENT_PROJECTOR_VERSION_KEY: &str = "content_projector_version";
 
 /// Re-derive the accepted-`/3` → memory projection for one `/2` stream from the CURRENT accepted
 /// set and rewrite its rows in both `/3` projection tables — another stream's rows are never
@@ -39,9 +50,54 @@ pub(in crate::oplog) fn reproject_accepted_content_stream(
     tx: &Transaction<'_>,
     stream_id: StreamId,
 ) -> anyhow::Result<()> {
+    // Refuse to reproject if a NEWER binary already owns this store's `/3` projection: the
+    // wholesale DELETE + rebuild below would drop ops the newer binary decodes as `Known` (this
+    // binary reads them as `Unknown` and skips them), leaving those nodes ABSENT from
+    // `content_projected_nodes`. The memory reconcile's anti-join would then read them as
+    // unauthored and mass-duplicate them into the immutable `/3` log. Guard BEFORE any write.
+    assert_content_projector_not_newer(tx)?;
     let entries = load_accepted_entries(tx, stream_id)?;
     let state = project::project(&entries);
-    write_projection(tx, stream_id, &state)
+    write_projection(tx, stream_id, &state)?;
+    stamp_content_projector_version(tx)?;
+    Ok(())
+}
+
+/// Error if a NEWER `/3` projector already folded this store's content projection — an older binary
+/// must not reproject (it would drop ops the newer binary knows) or stamp the version down. Mirrors
+/// the `/1` guard in [`crate::oplog::store`], at the `/3` projection layer (a projector bump need
+/// not carry a schema bump, so the schema guard does not cover it). Store-global, not per stream:
+/// one binary folds every stream it holds.
+fn assert_content_projector_not_newer(conn: &Connection) -> anyhow::Result<()> {
+    if let Some(stored) = stored_content_projector_version(conn)?
+        && stored > CONTENT_PROJECTOR_VERSION
+    {
+        anyhow::bail!(
+            "the /3 content projection was folded by a newer rag-rat (content projector v{stored} \
+             > v{CONTENT_PROJECTOR_VERSION}); upgrade to write this store"
+        );
+    }
+    Ok(())
+}
+
+fn stamp_content_projector_version(tx: &Transaction<'_>) -> rusqlite::Result<()> {
+    tx.execute(
+        "INSERT INTO oplog_meta(key, value) VALUES (?1, ?2)
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+        params![CONTENT_PROJECTOR_VERSION_KEY, CONTENT_PROJECTOR_VERSION.to_string()],
+    )?;
+    Ok(())
+}
+
+fn stored_content_projector_version(conn: &Connection) -> anyhow::Result<Option<i64>> {
+    conn.query_row(
+        "SELECT value FROM oplog_meta WHERE key = ?1",
+        params![CONTENT_PROJECTOR_VERSION_KEY],
+        |row| row.get::<_, String>(0),
+    )
+    .optional()?
+    .map(|value| value.parse::<i64>().context("oplog content_projector_version is not an integer"))
+    .transpose()
 }
 
 /// Rewrite one stream's rows in `content_projected_nodes` / `content_projected_edges` — clear the

--- a/crates/rag-rat-core/src/oplog/mod.rs
+++ b/crates/rag-rat-core/src/oplog/mod.rs
@@ -46,30 +46,17 @@ mod stream;
 // C1's curated authority seam for the C2 `/3` content envelope and candidate DAG. The account
 // implementation stays private; only typed ingest results and snapshot-consistent point queries
 // cross the phase boundary.
-// C3.4a's local-account mint (#662): the store-global principal later C3.4 slices author
-// owner-bound /3 content under. Unused until that caller lands, so the re-export is `expect`'d
-// like the seam above.
-// C3.4b-i's in-tx `/3` content-author seam (#663): the local writer that authors owner-bound
-// `/3` content on a `/2` stream, verify-accepted in the caller's txn. Frozen until #664
-// retargets the live memory path onto it.
-#[expect(
-    unused_imports,
-    reason = "C3.4b-i content-author seam is frozen before its caller lands"
-)]
-pub(crate) use account::author_content_batch_in_tx;
-// C3.4b-ii's in-tx `/2`-ownership ensure seam (#676): the idempotent
-// ensure-the-repo's-`/2`-stream-is-owned primitive #664 calls before authoring owner-bound
-// `/3` content. Frozen until that caller lands.
-#[expect(
-    unused_imports,
-    reason = "C3.4b-ii /2-ownership ensure seam is frozen before its caller lands"
-)]
-pub(crate) use account::ensure_owned_stream_v2_in_tx;
-#[expect(
-    unused_imports,
-    reason = "C3.4a local account mint is frozen before its caller lands"
-)]
-pub(crate) use account::local_account;
+//
+// The C3.4 local-authoring surface `query::memory` reaches for once #664 retargets the live memory
+// path onto the owner-bound `/2`//3 substrate:
+// - `local_account` (C3.4a, #662): the store-global principal owner-bound `/3` content authors
+//   under.
+// - `ensure_owned_stream_v2_in_tx` (C3.4b-ii, #676): publish + resolve a repo's owned `/2` stream.
+// - `owned_stream_v2_id` / `established_owned_stream_v2` (C3.4b-ii, #676): the pure stream resolver
+//   and the effective-ownership fast-path probe.
+// - `author_content_batch_in_tx` (C3.4b-i, #663): author a batch of ops as owner-authored `/3`
+//   content, verify-accepted in the caller's txn.
+// - `content_stream_is_empty` (C3.4b-i, #663): the `/3` genesis-detection reader.
 #[expect(unused_imports, reason = "C2 authority seam is frozen before its caller lands")]
 pub(crate) use account::{
     AccountId, AuthorityBoundary, AuthorityFreshness, AuthorityInvalidReason, AuthorityQuery,
@@ -79,27 +66,26 @@ pub(crate) use account::{
     grant_effective_for_device, owner_control_authority, owner_secrets_authority,
     roster_content_authority, stream_owner_effective,
 };
+pub(crate) use account::{
+    author_content_batch_in_tx, content_stream_is_empty, ensure_owned_stream_v2_in_tx,
+    established_owned_stream_v2, local_account, owned_stream_v2_id,
+};
 // The op-log's first crate-internal API surface (#524): the MINTING primitives + the op
 // vocabulary the memory subsystem needs to author + backfill entries. Every submodule above is
 // otherwise private, so this curated re-export is the ONE seam `query::memory` reaches through
 // — and the only direction of the dependency (`oplog` never depends back on `query::memory`).
 pub(crate) use identity::local_device;
 pub(crate) use op::{EdgeKey, EdgeSpec, MemoryOp, NodeContent, NodeId, NodeStatus};
-// The reconcile's tests read the materialized shadow projection as a `ProjectedState` via
-// `load_projection` (below) — test-only today (the live path folds in-txn), so `allow`'d.
+// The `/1` shadow-projection read seams (`ProjectedState` / `load_projection`) and the
+// standalone (own-txn) `/1` authoring wrappers (`author_batch` / `author_op`) — test-only
+// scaffolding for the retained `/1` store. The live memory path now authors owner-bound `/3`
+// content (#664), so these `/1` seams have no non-test caller; the re-exports stay `allow`'d
+// rather than removed because the `/1` store itself is retained (its history is not migrated,
+// per J1).
 #[allow(unused_imports)]
 pub(crate) use project::ProjectedState;
-// `author_batch_in_tx` is the gate-free batch-author primitive (#541) the reconcile authors
-// its ghost batch through (`query::memory::authoring::sync_owner_stream`).
-pub(crate) use store::author_batch_in_tx;
-// `load_projection` materializes a `ProjectedState` from the shadow tables — the
-// reconcile-test read seam above; only test-used for now, so `allow`'d.
 #[allow(unused_imports)]
 pub(crate) use store::load_projection;
-// `author_batch` / `author_op` are the standalone (own-txn) wrappers — `author_batch` is only
-// test-used and `author_op` is only reached from a test helper, so their re-export stays
-// `allow(unused_imports)`. The live write path uses the in-txn primitives.
 #[allow(unused_imports)]
 pub(crate) use store::{author_batch, author_op};
-pub(crate) use store::{author_in_tx, chain_tail};
-pub(crate) use stream::{StreamId, owner_stream};
+pub(crate) use stream::StreamId;

--- a/crates/rag-rat-core/src/query/memory/authoring.rs
+++ b/crates/rag-rat-core/src/query/memory/authoring.rs
@@ -1,21 +1,33 @@
 //! Translating persisted memories into signed op-log entries, and the per-node/edge reconcile that
-//! keeps the log a COMPLETE signed mirror of `repo_memories` / `repo_node_edges` (#524, #541).
+//! keeps the log a COMPLETE signed mirror of `repo_memories` / `repo_node_edges` (#524, #541,
+//! #664).
 //!
 //! This bridges `repo_memories` / `repo_node_edges` (owned by this module) and the op-log MINTING
 //! primitives ([`crate::oplog`]) — a ONE-WAY dependency, so `oplog` never depends back on the
 //! memory subsystem (a reverse call would cycle the build).
 //!
+//! OWNER-BOUND `/2`//3 substrate (#664). The live path authors owner-bound `/3` content on the
+//! repo's owner-bound `/2` stream, under the store's single local account (minted once, store-
+//! global). Each reconcile/mutation ensures the repo's `/2` stream is owned (publishing a
+//! `StreamOwn` account op) and authors its ops as owner-authored `/3` content
+//! ([`crate::oplog::author_content_batch_in_tx`]), which verify-accepts and reprojects into
+//! `content_projected_nodes` / `content_projected_edges`. The completeness predicate is an
+//! anti-join against that accepted-`/3` projection; the pre-existing `/1` history is retained but
+//! no longer written by the live path (existing `/1` rows are adopted into `/3` by the reconcile).
+//!
 //! WIRED into the live write path (#532): the memory mutations call [`backfill_memory_oplog`] once
 //! (before the first live entry) and the `author_*` seams below INSIDE their own transaction, so
 //! the op-append and the table write commit — or roll back — together (strict-atomic). Authoring is
-//! a NO-OP under an unstable scope ([`stable_owner_stream`]), leaving scope-less callers untouched.
+//! a NO-OP under an unstable scope ([`stable_owner_stream`]) or before the local account is minted,
+//! leaving scope-less callers untouched.
 //!
 //! [`backfill_memory_oplog`] is a per-node/edge RECONCILE (#541), not a per-chain gate: it authors
-//! every table row MISSING from the materialized shadow projection, so a row that entered the
-//! tables outside the wired path (a pre-#532 binary, a raw writer, a consolidation import) is
-//! signed on the next mutation and no later lifecycle op on it is ever inert. Genesis is just the
-//! empty-chain case where every row is missing.
+//! every table row MISSING from the accepted-`/3` projection, so a row that entered the tables
+//! outside the wired path (a pre-#532 binary, a raw writer, a consolidation import, or pre-existing
+//! `/1` history) is signed on the next mutation and no later lifecycle op on it is ever inert.
+//! Genesis is just the empty-`/3`-chain case where every row is missing.
 
+use anyhow::Context;
 use rusqlite::{Connection, Transaction, TransactionBehavior, params};
 
 use super::hydrate::tags_for_memory;
@@ -55,10 +67,7 @@ impl Drop for AuthoredDurability<'_> {
     }
 }
 use super::{EdgeRelation, NodeEdge, RepoMemory, memory_repo_scope};
-use crate::oplog::{
-    EdgeKey, EdgeSpec, MemoryOp, NodeContent, NodeId, NodeStatus, StreamId, author_batch_in_tx,
-    author_in_tx, chain_tail, local_device, owner_stream,
-};
+use crate::oplog::{EdgeKey, EdgeSpec, MemoryOp, NodeContent, NodeId, NodeStatus, StreamId};
 
 /// One memory's projectable content — the columns the op model carries (NOT the identity / anchor /
 /// dedup bookkeeping). Read in bulk so the backfill makes one pass over `repo_memories`.
@@ -193,13 +202,15 @@ fn build_reconcile_ops(
     Ok(ops)
 }
 
-/// Reconcile the owner stream against the repo's tables: author every `repo_memories` /
-/// `repo_node_edges` row MISSING from the shadow projection. Genesis (empty chain) authors the full
-/// history; a populated chain authors only the ghosts. Idempotent and scope-gated (LEGACY /
-/// `local:` ids never root an immutable stream). Scope-EXPLICIT — `repo_id` is passed, and the
-/// readers + re-resolution are scope-independent, so the consolidation importer's unscoped
-/// connection can call it. Concurrency: two racing callers serialize on the IMMEDIATE lock; the
-/// loser re-reads under the lock and authors only what the winner left missing.
+/// Reconcile the repo's owner-bound `/2` stream against its tables: establish ownership (mint the
+/// local account + publish a `StreamOwn` if needed) and author every `repo_memories` /
+/// `repo_node_edges` row MISSING from the accepted-`/3` projection as owner-authored `/3` content.
+/// Genesis (empty `/3` chain) authors the full history; a populated chain authors only the ghosts.
+/// Idempotent and scope-gated (LEGACY / `local:` ids never root an immutable stream).
+/// Scope-EXPLICIT — `repo_id` is passed, and the readers + re-resolution are scope-independent, so
+/// the consolidation importer's unscoped connection can call it. Concurrency: two racing callers
+/// serialize on the IMMEDIATE lock; the loser re-reads under the lock and authors only what the
+/// winner left missing.
 fn sync_owner_stream(conn: &Connection, repo_id: &str, now_ms: i64) -> anyhow::Result<()> {
     // Only a STABLE id may root an IMMUTABLE owner stream. Two ids get re-pointed later, which
     // would strand a stream signed under the old id: the legacy `__unassigned__` placeholder
@@ -211,29 +222,62 @@ fn sync_owner_stream(conn: &Connection, repo_id: &str, now_ms: i64) -> anyhow::R
     {
         return Ok(());
     }
-    let stream = owner_stream(repo_id)?;
-    // Cheap autocommit probe: return WITHOUT a write lock when nothing is missing (steady state).
-    if read_unauthored_memory_rows(conn, repo_id, stream)?.is_empty()
+    // Cheap autocommit fast-path: return WITHOUT the write lock only when the `/3` log is fully
+    // ESTABLISHED (the local account is minted AND its `StreamOwn` folded effective) AND nothing is
+    // missing. `established_owned_stream_v2` returns `None` for a fresh repo that has never
+    // published ownership — even one with an empty anti-join — so such a repo FALLS THROUGH to
+    // the slow path to mint + publish ownership rather than early-returning on an empty set it
+    // could not yet author into. `established_owned_stream_v2` is autocommit-only (it opens its
+    // own read txn), so it runs here, not under the write lock.
+    if let Some(stream) = crate::oplog::established_owned_stream_v2(conn, repo_id)?
+        && read_unauthored_memory_rows(conn, repo_id, stream)?.is_empty()
         && crate::query::memory::edges::unauthored_edges(conn, repo_id, stream)?.is_empty()
     {
         return Ok(());
     }
-    let device = local_device(conn, now_ms)?;
+
+    // Slow path. Mint the store's local account BEFORE the durability guard: the mint
+    // self-transacts and holds its OWN durability guard that restores `synchronous = NORMAL` on
+    // drop — beginning our guard first would let the mint's drop downgrade our authored commit
+    // below NORMAL, silently losing the #560 durability. The mint is store-global and
+    // idempotent (a re-mint returns the same account).
+    crate::oplog::local_account(conn, now_ms)?;
     // Authored, irreplaceable data → durable (#560). FULL for this txn only, restored on drop; set
     // OUTSIDE the txn (SQLite applies a `synchronous` change to SUBSEQUENT transactions only).
     let _durability = AuthoredDurability::begin(conn)?;
     let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
+    // Publish ownership of the repo's `/2` stream and resolve its id. Idempotent +
+    // check-fact-first: a re-ensure (or a racer serialized on this IMMEDIATE lock) authors no
+    // second `StreamOwn`.
+    let stream = crate::oplog::ensure_owned_stream_v2_in_tx(&tx, repo_id, now_ms)?;
     // Authoritative re-read UNDER the write lock (TOCTOU): a concurrent author may have healed or
     // added rows between the probe and the lock, so re-read the missing set and re-derive `genesis`
-    // here. `genesis` decides the status-elision: an empty LOCAL chain ⇒ no stale registers ⇒ elide
-    // `active` (byte-identical to the pre-#541 genesis). This equivalence holds ONLY under the
-    // single-local-writer owner stream (see the module header); phase D (foreign devices can
-    // populate the stream) must revisit whether local-chain-empty still implies register-clean.
-    let genesis = chain_tail(&tx, stream, device.fingerprint())?.is_none();
+    // here. `genesis` decides the status-elision: an empty `/3` content chain ⇒ no stale registers
+    // ⇒ elide `active` (byte-identical to the pre-#541 genesis). This equivalence holds ONLY
+    // under the single-local-writer owner stream (see the module header); phase D (foreign
+    // devices can populate the stream) must revisit whether local-chain-empty still implies
+    // register-clean.
+    let genesis = crate::oplog::content_stream_is_empty(&tx, stream)?;
     let missing_nodes = read_unauthored_memory_rows(&tx, repo_id, stream)?;
     let missing_edges = crate::query::memory::edges::unauthored_edges(&tx, repo_id, stream)?;
     let ops = build_reconcile_ops(&missing_nodes, &missing_edges, repo_id, genesis)?;
-    author_batch_in_tx(&tx, stream, &device, &ops, now_ms)?;
+    // Skip the author when there is nothing to author: a fresh repo whose anti-join was empty only
+    // needed ownership established (done above), and authoring an empty batch would still refold +
+    // reproject for no change.
+    if !ops.is_empty() {
+        // Fail-loud on an oversized envelope (a raw/adversarial memory body over the §18a 256 KiB
+        // cap): the `/3` author `bail!`s rather than dropping irreplaceable data, and we surface
+        // the failure with the repo it belongs to instead of wedging the store silently. A
+        // normal rag-rat memory (body ≤ 8 KiB) can never hit this; it is an
+        // adversarial/raw-writer backstop.
+        crate::oplog::author_content_batch_in_tx(&tx, stream, &ops, now_ms).with_context(|| {
+            format!(
+                "reconciling the /3 owner log for repo `{repo_id}` failed while authoring {} \
+                 pre-existing memory op(s)",
+                ops.len()
+            )
+        })?;
+    }
     tx.commit()?;
     Ok(())
 }
@@ -263,11 +307,13 @@ pub(crate) fn reconcile_owner_stream_for_repo(
     sync_owner_stream(conn, repo_id, now_ms)
 }
 
-/// The active repo's owner stream, but ONLY when the scope is a STABLE identity to root an
-/// IMMUTABLE stream on — the SAME gate the backfill uses: `Some`, not the `__unassigned__`
-/// placeholder, not a `local:` shallow-clone id (both get re-pointed later). `None` otherwise, and
-/// the `author_*` seams SKIP authoring on `None`, so a scope-less mutation (most tests) never
-/// touches the log.
+/// The active repo's owner-bound `/2` stream, but ONLY when the scope is a STABLE identity to root
+/// an IMMUTABLE stream on — the SAME gate the backfill uses: `Some`, not the `__unassigned__`
+/// placeholder, not a `local:` shallow-clone id (both get re-pointed later) — AND the store's local
+/// account is minted (the `/2` id is derived under it). `None` otherwise, and the `author_*` seams
+/// SKIP authoring on `None`, so a scope-less mutation (most tests) or a store whose account is not
+/// yet minted never touches the log. Derivation-only (no fact check), so it is safe inside the
+/// caller's open txn — unlike the reconcile's autocommit `established_owned_stream_v2` probe.
 fn stable_owner_stream(conn: &Connection) -> anyhow::Result<Option<StreamId>> {
     let Some(repo_id) = memory_repo_scope(conn)? else {
         return Ok(None);
@@ -277,14 +323,17 @@ fn stable_owner_stream(conn: &Connection) -> anyhow::Result<Option<StreamId>> {
     {
         return Ok(None);
     }
-    Ok(Some(owner_stream(&repo_id)?))
+    crate::oplog::owned_stream_v2_id(conn, &repo_id)
 }
 
-/// Author `ops` onto the active repo's owner stream WITHIN the caller's mutation txn — the strict-
-/// atomic live seam. Each op is minted + inserted + folded by `author_in_tx` (no open/commit), so
-/// an authoring error propagates via `?` and the caller's txn rolls the table write back with it. A
-/// NO-OP under an unstable scope. The caller MUST have run [`backfill_memory_oplog`] first (so the
-/// pre-existing history precedes this live entry).
+/// Author `ops` as owner-authored `/3` content on the active repo's owner-bound `/2` stream WITHIN
+/// the caller's mutation txn — the strict-atomic live seam.
+/// [`crate::oplog::author_content_batch_in_tx`] mints, inserts, refolds, and verify-accepts the
+/// batch (no open/commit), so an authoring error propagates via `?` and the caller's txn rolls the
+/// table write back with it. A NO-OP under an unstable scope or before the local account is minted.
+/// The caller MUST have run `backfill_memory_oplog` first, so the store's account plus `StreamOwn`
+/// are established (else the batch's verify-accepted rolls back) and the pre-existing history
+/// precedes this live entry.
 fn author_in_owner_stream(
     tx: &Transaction<'_>,
     ops: &[MemoryOp],
@@ -293,10 +342,13 @@ fn author_in_owner_stream(
     let Some(stream) = stable_owner_stream(tx)? else {
         return Ok(());
     };
-    let device = local_device(tx, now_ms)?;
-    for op in ops {
-        author_in_tx(tx, stream, &device, op, now_ms)?;
+    // Skip a no-op mutation: an empty batch would still refold + reproject the whole stream for no
+    // change. (The four live seams only reach here with non-empty ops today, but the guard keeps a
+    // change-free `author_update` from doing O(chain) work.)
+    if ops.is_empty() {
+        return Ok(());
     }
+    crate::oplog::author_content_batch_in_tx(tx, stream, ops, now_ms)?;
     Ok(())
 }
 
@@ -397,11 +449,11 @@ fn content_of(memory: &RepoMemory) -> NodeContent {
     )
 }
 
-/// The repo's memories with NO projected node on `stream` — the rows the signed log is MISSING —
-/// in deterministic `(created_at_ms, id)` order, tags attached. On an EMPTY projection this is
-/// every memory (genesis); on a populated one, the ghosts a raw writer or an old binary left
-/// behind (#541). Reuses the memory subsystem's own tag reader (the op encoder sorts + dedupes
-/// anyway).
+/// The repo's memories with NO projected node on `stream` in the accepted-`/3` projection — the
+/// rows the signed log is MISSING — in deterministic `(created_at_ms, id)` order, tags attached. On
+/// an EMPTY projection this is every memory (genesis); on a populated one, the ghosts a raw writer,
+/// an old binary, or pre-existing `/1` history left behind (#541, #664). Reuses the memory
+/// subsystem's own tag reader (the op encoder sorts + dedupes anyway).
 fn read_unauthored_memory_rows(
     conn: &Connection,
     repo_id: &str,
@@ -412,7 +464,7 @@ fn read_unauthored_memory_rows(
          FROM repo_memories m
          WHERE m.repo_id = ?1
            AND NOT EXISTS (
-                 SELECT 1 FROM oplog_projected_nodes p
+                 SELECT 1 FROM content_projected_nodes p
                  WHERE p.stream_id = ?2 AND p.node_id = m.id)
          ORDER BY m.created_at_ms, m.id",
     )?;
@@ -478,10 +530,44 @@ mod tests {
         .unwrap();
     }
 
-    /// Read the materialized shadow projection for `stream` — the completeness mirror the reconcile
-    /// heals into.
-    fn projected_state(conn: &Connection, stream: StreamId) -> crate::oplog::ProjectedState {
-        crate::oplog::load_projection(conn, stream).unwrap()
+    /// Insert an active memory with a CUSTOM body — used to plant an adversarial oversized body
+    /// that a normal rag-rat memory (body ≤ 8 KiB) could never carry.
+    fn insert_memory_with_body(conn: &Connection, id: &str, body: &str) {
+        conn.execute(
+            "INSERT INTO repo_memories(
+                 id, kind, title, body, confidence, status, created_by, created_at_ms,
+                 updated_at_ms, source, input_hash, memory_version, repo_id)
+             VALUES (?1, 'Invariant', ?1, ?2, 'high', 'active', 'agent', 100, 100, 'agent', 'h',
+                 'v1', ?3)",
+            params![id, body, REPO],
+        )
+        .unwrap();
+    }
+
+    /// Point a freshly-opened connection at `repo` via the per-connection TEMP `connection_context`
+    /// (temp tables are connection-local, so each thread of the race test scopes its own).
+    fn set_scope(conn: &Connection, repo: &str) {
+        conn.execute_batch(
+            "CREATE TEMP TABLE IF NOT EXISTS connection_context(key TEXT PRIMARY KEY, value TEXT);",
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT OR REPLACE INTO temp.connection_context(key, value) VALUES ('repo_id', ?1)",
+            [repo],
+        )
+        .unwrap();
+    }
+
+    /// The projected `/3` status of `node_id` on the store's owner stream — the completeness mirror
+    /// the reconcile heals into. A test DB holds one repo/stream, so no stream filter is needed;
+    /// panics if the node is not projected (callers assert presence).
+    fn projected_node_status(conn: &Connection, node_id: &str) -> String {
+        conn.query_row(
+            "SELECT status FROM content_projected_nodes WHERE node_id = ?1",
+            [node_id],
+            |r| r.get(0),
+        )
+        .unwrap()
     }
 
     /// Insert a node-edge by RAW SQL, bypassing the wired `add_edge` author — a "ghost edge" that
@@ -498,28 +584,46 @@ mod tests {
         .unwrap();
     }
 
-    /// Author a BARE `NodeStatus` for a node with NO `NodeCreate` — simulates the INERT op a
-    /// pre-fix (#532) binary authored when it `mark_obsolete`'d a still-ghost memory. Leaves a
-    /// stale status register with no projected node.
+    /// Author a BARE `/3` NodeStatus for a node with NO `NodeCreate` — the `/3` analog of the INERT
+    /// op a pre-fix (#532) binary authored when it `mark_obsolete`'d a still-ghost memory. The
+    /// shared projector emits no node without content, so this leaves a stale status register
+    /// with no projected node. Requires the store's account + owner stream already established
+    /// (via a prior live create); it authors through the real `/3` seam so the register truly
+    /// lands.
     fn author_inert_status_op(conn: &Connection, node_id: &str, status: NodeStatus) {
-        let device = crate::oplog::local_device(conn, 0).unwrap();
-        let stream = crate::oplog::owner_stream(REPO).unwrap();
-        crate::oplog::author_op(
-            conn,
+        let stream = crate::oplog::owned_stream_v2_id(conn, REPO)
+            .unwrap()
+            .expect("account minted by a prior live create");
+        let tx = conn.unchecked_transaction().unwrap();
+        crate::oplog::author_content_batch_in_tx(
+            &tx,
             stream,
-            &device,
-            &MemoryOp::NodeStatus { node_id: NodeId::from(node_id), status },
+            &[MemoryOp::NodeStatus { node_id: NodeId::from(node_id), status }],
             100,
         )
         .unwrap();
+        tx.commit().unwrap();
     }
 
+    /// The `/3` content chain length — one entry per authored op, the retarget's signed op-log
+    /// (account genesis + `StreamOwn` live in `account_entries`, not counted here).
     fn entry_count(conn: &Connection) -> i64 {
-        conn.query_row("SELECT COUNT(*) FROM oplog_entries", [], |r| r.get(0)).unwrap()
+        conn.query_row("SELECT COUNT(*) FROM content_entries", [], |r| r.get(0)).unwrap()
     }
 
     fn projected_node_count(conn: &Connection) -> i64 {
-        conn.query_row("SELECT COUNT(*) FROM oplog_projected_nodes", [], |r| r.get(0)).unwrap()
+        conn.query_row("SELECT COUNT(*) FROM content_projected_nodes", [], |r| r.get(0)).unwrap()
+    }
+
+    /// The number of local accounts minted (the single-row pointer table): 0 before any established
+    /// reconcile, 1 after — proves a no-op / scope-gated path mints NO account.
+    fn local_account_count(conn: &Connection) -> i64 {
+        conn.query_row("SELECT COUNT(*) FROM oplog_local_account", [], |r| r.get(0)).unwrap()
+    }
+
+    /// The number of folded `StreamOwn` ownership facts — one per owned `/2` stream.
+    fn owned_stream_count(conn: &Connection) -> i64 {
+        conn.query_row("SELECT COUNT(*) FROM account_stream_ownership", [], |r| r.get(0)).unwrap()
     }
 
     /// #560 durability split: an authored write commits under `synchronous = FULL`, and the guard
@@ -635,16 +739,18 @@ mod tests {
         assert!(err.to_string().contains("unknown status"), "an unknown status fails authoring");
     }
 
-    /// #541: the reconcile's memory reader anti-joins `repo_memories` against
-    /// `oplog_projected_nodes` — only a row with no projected node (never signed) comes back.
+    /// #541/#664: the reconcile's memory reader anti-joins `repo_memories` against the accepted-`/3`
+    /// projection `content_projected_nodes` — only a row with no projected node (never signed)
+    /// comes back. `stream` is an opaque `StreamId` here (the anti-join only needs seed/query
+    /// agreement).
     #[test]
     fn read_unauthored_memory_rows_returns_only_rows_absent_from_the_projection() {
         let conn = scoped_conn();
         insert_memory(&conn, "mem_live", "active", 100);
         insert_memory(&conn, "mem_ghost", "active", 200);
-        let stream = crate::oplog::owner_stream(REPO).unwrap();
+        let stream = StreamId::from_bytes([0x11; 32]);
         conn.execute(
-            "INSERT INTO oplog_projected_nodes(stream_id, node_id, content_json, status)
+            "INSERT INTO content_projected_nodes(stream_id, node_id, content_json, status)
              VALUES (?1, 'mem_live', '{}', 'active')",
             params![stream.to_bytes().as_slice()],
         )
@@ -661,13 +767,11 @@ mod tests {
         create_concept(&conn, "seed").unwrap(); // roots the chain via genesis
         insert_memory(&conn, "mem_ghost", "obsolete", 500); // raw, un-authored ghost
         backfill_memory_oplog(&conn, 9_000).unwrap();
-        let stream = crate::oplog::owner_stream(REPO).unwrap();
-        let g = projected_state(&conn, stream)
-            .nodes
-            .get(&NodeId::from("mem_ghost"))
-            .cloned()
-            .expect("ghost is now authored");
-        assert_eq!(g.status, NodeStatus::Obsolete, "create-time status carried");
+        assert_eq!(
+            projected_node_status(&conn, "mem_ghost"),
+            NodeStatus::Obsolete.as_db_str(),
+            "the ghost is now authored with its create-time status",
+        );
     }
 
     #[test]
@@ -675,24 +779,18 @@ mod tests {
         // The decision-6 divergence: an inert NodeStatus{obsolete} exists, the row is now active,
         // the heal must author an explicit NodeStatus{active} so the projection matches the table.
         let conn = scoped_conn();
-        let id = create_concept(&conn, "seed").unwrap().memory.memory_id;
-        // Author an inert NodeStatus for a NOT-yet-created ghost by hand (simulate the old binary):
+        create_concept(&conn, "seed").unwrap(); // establishes the account + owner stream
+        // Author an inert `/3` NodeStatus for a NOT-yet-created ghost (the /3 analog of the old
+        // binary's inert op): a bare status register with no projected node.
         let ghost = "mem_ghost";
         author_inert_status_op(&conn, ghost, NodeStatus::Obsolete);
         insert_memory(&conn, ghost, "active", 500); // the table says active
         backfill_memory_oplog(&conn, 9_000).unwrap();
-        let stream = crate::oplog::owner_stream(REPO).unwrap();
-        let node = projected_state(&conn, stream)
-            .nodes
-            .get(&NodeId::from(ghost))
-            .cloned()
-            .expect("ghost healed");
         assert_eq!(
-            node.status,
-            NodeStatus::Active,
-            "explicit NodeStatus{{active}} overrode the stale register"
+            projected_node_status(&conn, ghost),
+            NodeStatus::Active.as_db_str(),
+            "explicit NodeStatus{{active}} overrode the stale register",
         );
-        let _ = id;
     }
 
     #[test]
@@ -702,23 +800,16 @@ mod tests {
         let b = create_concept(&conn, "b").unwrap().memory.memory_id;
         insert_raw_node_edge(&conn, &a, "relates_to", &b); // writes repo_node_edges directly
         backfill_memory_oplog(&conn, 9_000).unwrap();
-        let stream = crate::oplog::owner_stream(REPO).unwrap();
-        assert_eq!(projected_state(&conn, stream).edges.len(), 1, "ghost edge now signed");
+        assert_eq!(projected_edge_count(&conn), 1, "ghost edge now signed");
     }
 
     #[test]
     fn reconcile_is_idempotent_and_a_clean_repo_authors_nothing() {
         let conn = scoped_conn();
         create_concept(&conn, "seed").unwrap();
-        let stream = crate::oplog::owner_stream(REPO).unwrap();
-        let fp = crate::oplog::local_device(&conn, 0).unwrap().fingerprint();
-        let before = crate::oplog::chain_tail(&conn, stream, fp).unwrap();
+        let before = entry_count(&conn);
         backfill_memory_oplog(&conn, 9_000).unwrap();
-        assert_eq!(
-            crate::oplog::chain_tail(&conn, stream, fp).unwrap(),
-            before,
-            "no ghost → no new op"
-        );
+        assert_eq!(entry_count(&conn), before, "no ghost → no new /3 entry");
     }
 
     #[test]
@@ -755,20 +846,14 @@ mod tests {
             .unwrap();
 
         backfill_memory_oplog(&conn, 1_000).unwrap();
-        // 3 NodeCreate + 1 NodeStatus (mem_b obsolete) + 1 EdgeAdd (from obsolete mem_b) = 5
-        // entries; 3 projected nodes.
+        // 3 NodeCreate + 1 NodeStatus (mem_b obsolete) + 1 EdgeAdd (from obsolete mem_b) = 5 `/3`
+        // content entries; 3 projected nodes.
         assert_eq!(entry_count(&conn), 5);
         assert_eq!(projected_node_count(&conn), 3);
-        let status: String = conn
-            .query_row(
-                "SELECT status FROM oplog_projected_nodes WHERE node_id = 'mem_b'",
-                [],
-                |r| r.get(0),
-            )
+        assert_eq!(projected_node_status(&conn, "mem_b"), "obsolete");
+        let edges: i64 = conn
+            .query_row("SELECT COUNT(*) FROM content_projected_edges", [], |r| r.get(0))
             .unwrap();
-        assert_eq!(status, "obsolete");
-        let edges: i64 =
-            conn.query_row("SELECT COUNT(*) FROM oplog_projected_edges", [], |r| r.get(0)).unwrap();
         assert_eq!(edges, 1);
 
         // A second backfill is a no-op — the atomic batch already completed (chain non-empty).
@@ -804,6 +889,11 @@ mod tests {
 
         backfill_memory_oplog(&conn, 1_000).unwrap();
         assert_eq!(entry_count(&conn), 0, "the placeholder repo is not backfilled");
+        assert_eq!(
+            local_account_count(&conn),
+            0,
+            "the scope gate no-ops BEFORE the mint — a placeholder repo mints no account",
+        );
     }
 
     #[test]
@@ -834,6 +924,7 @@ mod tests {
 
         backfill_memory_oplog(&conn, 1_000).unwrap();
         assert_eq!(entry_count(&conn), 0, "a local: repo is not backfilled");
+        assert_eq!(local_account_count(&conn), 0, "a local: repo mints no account");
     }
 
     #[test]
@@ -843,19 +934,27 @@ mod tests {
         crate::index::schema::apply(&conn).unwrap();
         backfill_memory_oplog(&conn, 1_000).unwrap();
         assert_eq!(entry_count(&conn), 0);
+        assert_eq!(local_account_count(&conn), 0, "an unscoped DB mints no account");
     }
 
     #[test]
-    fn backfill_of_an_empty_repo_leaves_the_chain_empty() {
+    fn backfill_of_an_empty_scoped_repo_establishes_ownership_but_authors_no_content() {
+        // A fresh scoped repo with no memories: the reconcile falls through the fast-path probe
+        // (ownership not yet established), mints the account, and publishes the `/2` StreamOwn —
+        // but authors NO `/3` content (nothing is missing). So the content chain stays
+        // empty while ownership is now live (the first live op will chain off an empty
+        // content chain = genesis).
         let conn = scoped_conn();
         backfill_memory_oplog(&conn, 1_000).unwrap();
-        assert_eq!(entry_count(&conn), 0, "no memories ⇒ no entries; the first live op is genesis");
+        assert_eq!(entry_count(&conn), 0, "no memories ⇒ no /3 content entries");
+        assert_eq!(local_account_count(&conn), 1, "a scoped repo mints the store's local account");
+        assert_eq!(owned_stream_count(&conn), 1, "and publishes exactly one /2 StreamOwn");
     }
 
     // --- live write-path wiring (#532) ---
 
     fn projected_edge_count(conn: &Connection) -> i64 {
-        conn.query_row("SELECT COUNT(*) FROM oplog_projected_edges", [], |r| r.get(0)).unwrap()
+        conn.query_row("SELECT COUNT(*) FROM content_projected_edges", [], |r| r.get(0)).unwrap()
     }
 
     /// Create an unanchored `Concept` (needs no code binding) through the LIVE `create_memory`.
@@ -882,12 +981,12 @@ mod tests {
         let r = create_concept(&conn, "t1").unwrap();
         let n: i64 = conn
             .query_row(
-                "SELECT COUNT(*) FROM oplog_projected_nodes WHERE node_id = ?1",
+                "SELECT COUNT(*) FROM content_projected_nodes WHERE node_id = ?1",
                 [&r.memory.memory_id],
                 |row| row.get(0),
             )
             .unwrap();
-        assert_eq!(n, 1, "the created memory is a projected node");
+        assert_eq!(n, 1, "the created memory is a projected /3 node");
         assert_eq!(projected_node_count(&conn), 1);
     }
 
@@ -898,6 +997,7 @@ mod tests {
         crate::index::schema::apply(&conn).unwrap();
         create_concept(&conn, "t1").unwrap();
         assert_eq!(entry_count(&conn), 0, "a scope-less create never touches the log");
+        assert_eq!(local_account_count(&conn), 0, "a scope-less create mints no account");
     }
 
     #[test]
@@ -917,7 +1017,7 @@ mod tests {
         .unwrap();
         let (content_json, status): (String, String) = conn
             .query_row(
-                "SELECT content_json, status FROM oplog_projected_nodes WHERE node_id = ?1",
+                "SELECT content_json, status FROM content_projected_nodes WHERE node_id = ?1",
                 [&id],
                 |row| Ok((row.get(0)?, row.get(1)?)),
             )
@@ -933,12 +1033,7 @@ mod tests {
         // The NodeCreate is the sole entry so far.
         assert_eq!(entry_count(&conn), 1);
         crate::query::memory::mark_obsolete(&conn, &id).unwrap();
-        let status: String = conn
-            .query_row("SELECT status FROM oplog_projected_nodes WHERE node_id = ?1", [&id], |r| {
-                r.get(0)
-            })
-            .unwrap();
-        assert_eq!(status, "obsolete");
+        assert_eq!(projected_node_status(&conn, &id), "obsolete");
         // A status-only change authors EXACTLY ONE op (a NodeStatus) — NOT a NodeUpdate, which in a
         // synced stream could revert a concurrent content edit (content/status are independent
         // LWW).
@@ -993,13 +1088,11 @@ mod tests {
         // mark_obsolete reconciles first (heals NodeCreate + NodeStatus{active}), THEN authors the
         // obsolete NodeStatus — so it is NOT inert and the node projects obsolete.
         crate::query::memory::mark_obsolete(&conn, "mem_ghost").unwrap();
-        let stream = crate::oplog::owner_stream(REPO).unwrap();
-        let node = projected_state(&conn, stream)
-            .nodes
-            .get(&NodeId::from("mem_ghost"))
-            .cloned()
-            .expect("ghost healed then obsoleted");
-        assert_eq!(node.status, NodeStatus::Obsolete);
+        assert_eq!(
+            projected_node_status(&conn, "mem_ghost"),
+            NodeStatus::Obsolete.as_db_str(),
+            "ghost healed then obsoleted",
+        );
     }
 
     #[test]
@@ -1028,25 +1121,27 @@ mod tests {
             before + 2,
             "the heal's EdgeAdd + remove_edge's own EdgeRemove — not a bare, inert tombstone"
         );
-        let stream = crate::oplog::owner_stream(REPO).unwrap();
-        assert!(
-            projected_state(&conn, stream).edges.is_empty(),
-            "healed then tombstoned → edge absent"
-        );
+        assert_eq!(projected_edge_count(&conn), 0, "healed then tombstoned → edge absent");
     }
 
     #[test]
     fn a_failed_author_rolls_back_the_memory_write() {
         let conn = scoped_conn();
-        // One good create so the owner chain is non-empty (the second create's backfill fast-paths,
-        // isolating the failure to the live author).
+        // One good create so the account + owner stream are established and the first create
+        // stamped the `/3` content projector version (the second create's backfill
+        // fast-paths, isolating the failure to the live author's reproject).
         create_concept(&conn, "first").unwrap();
         let before: i64 =
             conn.query_row("SELECT COUNT(*) FROM repo_memories", [], |r| r.get(0)).unwrap();
-        // Poison: pretend a NEWER projector owns the store — `author_in_tx`'s
-        // `assert_projector_not_newer` now errors, so the second create's op-append fails.
-        conn.execute("UPDATE oplog_meta SET value = '999' WHERE key = 'projector_version'", [])
-            .unwrap();
+        // Poison the `/3` projector guard: pretend a NEWER binary already folded this store's `/3`
+        // projection, so `reproject_accepted_content_stream`'s `assert_content_projector_not_newer`
+        // errors and the second create's `/3` author fails (this doubles as the #664 `/3`
+        // projector-stamp poison test).
+        conn.execute(
+            "UPDATE oplog_meta SET value = '999' WHERE key = 'content_projector_version'",
+            [],
+        )
+        .unwrap();
         assert!(create_concept(&conn, "second").is_err(), "the authoring failure fails the create");
         let after: i64 =
             conn.query_row("SELECT COUNT(*) FROM repo_memories", [], |r| r.get(0)).unwrap();
@@ -1067,7 +1162,7 @@ mod tests {
         );
         let old_present: i64 = conn
             .query_row(
-                "SELECT COUNT(*) FROM oplog_projected_nodes WHERE node_id = 'old'",
+                "SELECT COUNT(*) FROM content_projected_nodes WHERE node_id = 'old'",
                 [],
                 |r| r.get(0),
             )
@@ -1152,5 +1247,165 @@ mod tests {
             "an idempotent edge re-add authors no duplicate EdgeAdd"
         );
         assert_eq!(projected_edge_count(&conn), 1);
+    }
+
+    // --- owner-bound /2//3 retarget (#664) ---
+
+    #[test]
+    fn a_fresh_repo_first_create_mints_the_account_publishes_ownership_and_projects_the_node() {
+        let conn = scoped_conn();
+        let id = create_concept(&conn, "first").unwrap().memory.memory_id;
+        // The first create on a fresh scoped repo mints exactly one local account and folds exactly
+        // one `/2` StreamOwn effective — the ownership the owner-authored `/3` content accepts
+        // under.
+        assert_eq!(local_account_count(&conn), 1, "the first create mints one local account");
+        assert_eq!(owned_stream_count(&conn), 1, "exactly one /2 StreamOwn folds effective");
+        // And the memory is an accepted, projected `/3` node.
+        assert_eq!(projected_node_count(&conn), 1, "the created memory is a projected /3 node");
+        assert_eq!(projected_node_status(&conn, &id), "active", "a fresh create projects active");
+    }
+
+    #[test]
+    fn a_second_repo_first_create_establishes_its_own_ownership_despite_the_shared_account() {
+        // Multi-repo store, the distinguishing case for the fast-path probe: repo A's create mints
+        // the STORE-GLOBAL account and establishes A's ownership. Repo B is then fresh with ZERO
+        // memories. B's first create must STILL publish B's own `/2` StreamOwn — the account
+        // already being minted is NOT enough. This is why the probe checks
+        // `established_owned_stream_v2` (StreamOwn folded EFFECTIVE) and not merely
+        // "account minted": with the weaker check, B's empty anti-join would early-return,
+        // B would author `/3` content under an unowned stream, and verify-accepted would
+        // roll the create back (Risk trap #1). A single-repo test cannot catch this — there
+        // the account is unminted, so both checks agree.
+        let conn = scoped_conn(); // repo-a: registered + scoped
+        create_concept(&conn, "a1").unwrap();
+        assert_eq!(local_account_count(&conn), 1, "repo-a's create mints the store account");
+        assert_eq!(owned_stream_count(&conn), 1, "repo-a owns its /2 stream");
+
+        // Register a SECOND repo in the same store and scope the connection to it.
+        const REPO_B: &str = "repo-b";
+        conn.execute(
+            "INSERT INTO repos(repo_id, display_name, registered_at_ms) VALUES (?1, ?1, 0)",
+            [REPO_B],
+        )
+        .unwrap();
+        set_scope(&conn, REPO_B);
+
+        // B's first create: the account is already minted, B has no StreamOwn and no memories.
+        let id_b = create_concept(&conn, "b1").unwrap().memory.memory_id;
+        assert_eq!(
+            local_account_count(&conn),
+            1,
+            "the account is store-global — still exactly one"
+        );
+        assert_eq!(
+            owned_stream_count(&conn),
+            2,
+            "repo-b established its OWN /2 StreamOwn rather than riding repo-a's",
+        );
+        assert_eq!(
+            projected_node_status(&conn, &id_b),
+            "active",
+            "b1 accepted under repo-b's freshly-published ownership",
+        );
+    }
+
+    #[test]
+    fn pre_existing_memories_are_adopted_into_v3_and_the_v1_tables_are_left_untouched() {
+        let conn = scoped_conn();
+        // Pre-existing history a pre-#664 binary / raw writer left in the tables (never signed).
+        insert_memory(&conn, "old_a", "active", 100);
+        insert_memory(&conn, "old_b", "obsolete", 200);
+        insert_memory(&conn, "old_c", "active", 300);
+        // One live mutation triggers the reconcile: the three pre-existing rows are authored into
+        // `/3` as the genesis batch, then the new memory is authored live.
+        create_concept(&conn, "trigger").unwrap();
+        for id in ["old_a", "old_b", "old_c"] {
+            let projected: i64 = conn
+                .query_row(
+                    "SELECT COUNT(*) FROM content_projected_nodes WHERE node_id = ?1",
+                    [id],
+                    |r| r.get(0),
+                )
+                .unwrap();
+            assert_eq!(projected, 1, "pre-existing memory {id} was adopted into /3");
+        }
+        assert_eq!(projected_node_status(&conn, "old_b"), "obsolete", "the adopted status carried");
+        // The retained `/1` tables are UNTOUCHED — the live path no longer writes them (issue J1).
+        let v1_entries: i64 =
+            conn.query_row("SELECT COUNT(*) FROM oplog_entries", [], |r| r.get(0)).unwrap();
+        let v1_nodes: i64 =
+            conn.query_row("SELECT COUNT(*) FROM oplog_projected_nodes", [], |r| r.get(0)).unwrap();
+        assert_eq!(v1_entries, 0, "the /1 entry log is not written by the retargeted live path");
+        assert_eq!(v1_nodes, 0, "the /1 shadow projection is not written by the retarget");
+    }
+
+    #[test]
+    fn racing_backfills_converge_on_one_stream_own_and_no_duplicate_content() {
+        use std::sync::{Arc, Barrier};
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("race.db");
+        // Setup once: schema, the registered repo, and one pre-existing memory so there is content
+        // for the reconcile to author (the racers must converge on authoring it exactly once).
+        let setup = Connection::open(&path).unwrap();
+        setup.execute_batch("PRAGMA foreign_keys = ON;").unwrap();
+        crate::index::schema::apply(&setup).unwrap();
+        setup
+            .execute(
+                "INSERT INTO repos(repo_id, display_name, registered_at_ms) VALUES (?1, ?1, 0)",
+                [REPO],
+            )
+            .unwrap();
+        set_scope(&setup, REPO);
+        insert_memory(&setup, "old", "active", 100);
+        drop(setup);
+
+        let barrier = Arc::new(Barrier::new(2));
+        let spawn = || {
+            let path = path.clone();
+            let barrier = Arc::clone(&barrier);
+            std::thread::spawn(move || {
+                let conn = Connection::open(path).unwrap();
+                conn.busy_timeout(std::time::Duration::from_secs(5)).unwrap();
+                set_scope(&conn, REPO);
+                barrier.wait();
+                backfill_memory_oplog(&conn, 9_000).unwrap();
+            })
+        };
+        let a = spawn();
+        let b = spawn();
+        a.join().unwrap();
+        b.join().unwrap();
+
+        let conn = Connection::open(&path).unwrap();
+        assert_eq!(local_account_count(&conn), 1, "the racers converge on one local account");
+        assert_eq!(owned_stream_count(&conn), 1, "exactly one /2 StreamOwn survives the race");
+        assert_eq!(entry_count(&conn), 1, "the pre-existing memory is authored exactly once");
+        let old_nodes: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM content_projected_nodes WHERE node_id = 'old'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(old_nodes, 1, "the adopted memory projects exactly once, no duplicate");
+    }
+
+    #[test]
+    fn an_oversized_memory_body_fails_the_reconcile_loudly_and_surfaces_the_repo() {
+        // Fail-loud posture (#664): a raw/adversarial memory body over the §18a 256 KiB envelope
+        // cap makes the `/3` author bail rather than drop irreplaceable data, and the
+        // reconcile surfaces the failure (naming the repo) instead of silently skipping it.
+        // A normal rag-rat memory (body ≤ 8 KiB) can never reach this; it is an
+        // adversarial/raw-writer backstop.
+        let conn = scoped_conn();
+        let oversized = "x".repeat(300 * 1024); // > 256 KiB ⇒ the signed envelope exceeds the cap
+        insert_memory_with_body(&conn, "mem_big", &oversized);
+        let err = backfill_memory_oplog(&conn, 1_000).unwrap_err();
+        assert!(
+            format!("{err:#}").contains(REPO),
+            "the fail-loud error surfaces the reconcile failure for the repo, not a silent skip",
+        );
+        assert_eq!(entry_count(&conn), 0, "the oversized batch rolled back — no /3 content stored");
     }
 }

--- a/crates/rag-rat-core/src/query/memory/authoring.rs
+++ b/crates/rag-rat-core/src/query/memory/authoring.rs
@@ -454,6 +454,12 @@ fn content_of(memory: &RepoMemory) -> NodeContent {
 /// an EMPTY projection this is every memory (genesis); on a populated one, the ghosts a raw writer,
 /// an old binary, or pre-existing `/1` history left behind (#541, #664). Reuses the memory
 /// subsystem's own tag reader (the op encoder sorts + dedupes anyway).
+///
+/// This trusts `content_projected_nodes` to mirror the `accepted` flag exactly. That holds
+/// pre-transport because no path flips an accepted set without reprojecting: the authoring seam
+/// reprojects, and the account refold (`refold_streams_for_account`) only re-derives an unchanged
+/// accepted set locally (StreamOwn precedes content; no local revoke). Phase-D transport must keep
+/// that projection fresh at the refold boundary or this anti-join re-authors/skips rows — #683.
 fn read_unauthored_memory_rows(
     conn: &Connection,
     repo_id: &str,

--- a/crates/rag-rat-core/src/query/memory/edges.rs
+++ b/crates/rag-rat-core/src/query/memory/edges.rs
@@ -307,12 +307,12 @@ pub(crate) fn edge_by_key(conn: &Connection, edge_key: &str) -> anyhow::Result<O
         .map_err(Into::into)
 }
 
-/// The repo's node-edges with NO projected edge on `stream` — the `EdgeAdd`s the signed log is
-/// MISSING — in `edge_key` order. Run through [`reresolve_on_read`] so a node target's
-/// `target_repo_id` is repaired to CURRENT before the reconcile signs it (the stored column is
-/// only an add-time snapshot; a signed op cannot be corrected later — see decision 5 of #541).
-/// Scope-INDEPENDENT: filters on the explicit `repo_id`, and re-resolution is a global by-node-id
-/// lookup, so consolidation's unscoped connection may call it directly. The reconcile
+/// The repo's node-edges with NO projected edge on `stream` in the accepted-`/3` projection — the
+/// `EdgeAdd`s the signed log is MISSING — in `edge_key` order. Run through [`reresolve_on_read`] so
+/// a node target's `target_repo_id` is repaired to CURRENT before the reconcile signs it (the
+/// stored column is only an add-time snapshot; a signed op cannot be corrected later — see decision
+/// 5 of #541). Scope-INDEPENDENT: filters on the explicit `repo_id`, and re-resolution is a global
+/// by-node-id lookup, so consolidation's unscoped connection may call it directly. The reconcile
 /// (`authoring::sync_owner_stream`) authors what this returns.
 pub(crate) fn unauthored_edges(
     conn: &Connection,
@@ -323,7 +323,7 @@ pub(crate) fn unauthored_edges(
         "{EDGE_SELECT} e
          WHERE e.repo_id = ?1
            AND NOT EXISTS (
-                 SELECT 1 FROM oplog_projected_edges p
+                 SELECT 1 FROM content_projected_edges p
                  WHERE p.stream_id = ?2 AND p.edge_key = e.edge_key)
          ORDER BY e.edge_key"
     ))?;
@@ -531,12 +531,12 @@ mod tests {
         assert!(EdgeRelation::from_db_str("bogus").is_err(), "an unknown token must not resolve");
     }
 
-    /// #541: the reconcile's edge reader anti-joins `repo_node_edges` against
-    /// `oplog_projected_edges` and re-resolves what it returns. Proves BOTH halves of the
-    /// correctness crux: (a) only the edge absent from the projection comes back, and (b) its
-    /// `target_repo_id` — deliberately stale on the stored row, simulating an add-time snapshot
-    /// left behind by a repo-id re-point — is repaired to the CURRENT owner before it would be
-    /// signed.
+    /// #541/#664: the reconcile's edge reader anti-joins `repo_node_edges` against the accepted-`/3`
+    /// projection `content_projected_edges` and re-resolves what it returns. Proves BOTH halves of
+    /// the correctness crux: (a) only the edge absent from the projection comes back, and (b)
+    /// its `target_repo_id` — deliberately stale on the stored row, simulating an add-time
+    /// snapshot left behind by a repo-id re-point — is repaired to the CURRENT owner before it
+    /// would be signed.
     #[test]
     fn unauthored_edges_returns_only_edges_absent_from_the_projection_reresolved() {
         let conn = scoped_conn();
@@ -546,10 +546,12 @@ mod tests {
         let authored_key = insert_raw_node_edge(&conn, "mem_a", "relates_to", "mem_b");
         let ghost_key = insert_raw_node_edge(&conn, "mem_a", "depends_on", "mem_c");
 
-        let stream = crate::oplog::owner_stream(REPO).unwrap();
-        // Seed the projection with the `relates_to` edge only — it is already authored.
+        // `stream` is an opaque `StreamId` here — the anti-join only needs seed/query agreement.
+        let stream = StreamId::from_bytes([0x11; 32]);
+        // Seed the accepted-`/3` projection with the `relates_to` edge only — it is already
+        // authored.
         conn.execute(
-            "INSERT INTO oplog_projected_edges(stream_id, edge_key, spec_json, resolved_json)
+            "INSERT INTO content_projected_edges(stream_id, edge_key, spec_json, resolved_json)
              VALUES (?1, ?2, '{}', NULL)",
             params![stream.to_bytes().as_slice(), authored_key],
         )


### PR DESCRIPTION
Retargets the strict-atomic authoring path of every memory mutation from the `/1` owner stream to the account's owner-bound `/2` stream, authoring memory ops as accepted `/3` content and adopting existing `/1` history. This is the live-path switch for the `/1`→`/2` adoption slice; it builds on the account mint (#662/#666), the `/3` content-author + projection substrate (#663/#668), and the `StreamOwn` ensure seam (#676/#677).

## What lands

- **Reconcile (`sync_owner_stream`)** — mints the store-global account (idempotent, **before** the durability guard so the mint's own guard can't downgrade the authored commit), publishes the repo's `/2` `StreamOwn` once (check-fact-first), and authors the memories missing from the accepted-`/3` projection. Its fast-path probe returns early **only** when ownership is fully established (account minted **and** `StreamOwn` effective) **and** nothing is missing — a fresh repo with an empty anti-join falls through to establish ownership rather than authoring content it cannot accept.
- **Live per-mutation seams** (`author_create` / `author_update` / `author_edge_add` / `author_edge_remove`) — derive the `/2` stream and author through the batch `/3` seam, skipping empty batches.
- **Anti-joins** swap from the `/1` shadow tables to `content_projected_nodes` / `content_projected_edges` (identical columns — a clean table swap).
- **New read-only account seams**: `owned_stream_v2_id` (pure derivation, the live seam's resolver), `established_owned_stream_v2` (derivation + `StreamOwn`-effective fact, the reconcile probe), and `content_stream_is_empty` (the `/3` genesis reader).
- **`/3` projector-version guard** — the retarget removes the `/1` guard from the live path, so the `/3` projection gains its own: a distinct `content_projector_version` in `oplog_meta`, refused-on-newer before reproject, so an older binary can't silently mass-duplicate into the immutable `/3` log.
- **Adoption falls out**: an empty `/3` chain authors the full memory history as the genesis batch; the retained `/1` rows are left untouched (J1).

## Data-safety posture

An oversized memory body (over the 256 KiB envelope cap — near-unreachable through the normal API, only a raw/legacy writer can produce it) **fails the reconcile loudly with the repo surfaced**, rather than dropping irreplaceable data. The residual wedge (a wedged repo needs SQL repair) is tracked in #680 with mitigation options.

## Tests

Fresh-repo end-to-end (account minted, `StreamOwn` effective, node projected); **multi-repo** store (a second repo establishes its own ownership despite the shared account — the discriminating guard for the probe's `established`-vs-`derive` precondition, mutation-verified); existing-`/1` adoption with `/1` tables asserted untouched; idempotent + **racing** re-reconcile (file-backed, converges on one account / one `StreamOwn` / no duplicate content); every scope-gate no-op now also asserts **no account is minted**; oversized-body fail-loud + repo surfaced; and the `/3` projector-stamp poison (repointed rollback test). All migrated tests preserve their original invariant on the `/3` tables.

Gates: `cargo +nightly fmt --check`, both CI clippy invocations (`--no-default-features` and `--features eval`, `-D warnings`), and `cargo nextest run -p rag-rat-core` (2570 passed) all green on latest main. Codex-reviewed.

Closes #664