### PR TITLE
perf(graph): seed find_callers/trace_callees on indexed edge id columns (#682)

### DIFF
--- a/crates/rag-rat-core/src/index/oracle/tests/edge_view.rs
+++ b/crates/rag-rat-core/src/index/oracle/tests/edge_view.rs
@@ -215,3 +215,89 @@ fn or_branch_name_predicates_use_the_to_name_index() {
         "plain to_name equality must use the int index, got plan:\n{simple}"
     );
 }
+
+/// #682: the graph-traversal SEED predicate (behind `find_callers` / `trace_callees`) must drive the
+/// `edges_data` id indexes, not full-scan the ~1M-row edge table. Before the fix the Syntactic seed
+/// OR mixed the indexed `to_symbol_id` with value-joined columns (`to_qn.value`,
+/// `edges.target_qualified_name`), so the planner abandoned the indexes and scanned every edge
+/// (~1.8-2.2s/call on a real index). The fix compares the view's raw id columns against a constant,
+/// exactly like the caller-count predicate above — this pins that the reverse seed drives
+/// `idx_edges_to_symbol` + `idx_edges_target_qname` and the forward seed `idx_edges_from_symbol` +
+/// `idx_edges_from_name`, and that NO full `SCAN` of the edge rows (`SCAN d` / `SCAN edges_data`)
+/// survives. The `idx_edges_target_qname` index (V071) is required for the reverse unresolved
+/// branch.
+#[test]
+fn graph_traversal_seed_predicates_use_edge_id_indexes() {
+    let conn = Connection::open_in_memory().unwrap();
+    schema::apply(&conn).unwrap();
+
+    let plan = |sql: &str| -> String {
+        let mut stmt = conn.prepare(&format!("EXPLAIN QUERY PLAN {sql}")).unwrap();
+        stmt.query_map([], |row| row.get::<_, String>(3))
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap()
+            .join("\n")
+    };
+
+    // The V071 index the reverse unresolved-edge branch needs actually exists on edges_data.
+    let idx_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM sqlite_master
+             WHERE type = 'index' AND name = 'idx_edges_target_qname' AND tbl_name = 'edges_data'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(idx_count, 1, "V071 idx_edges_target_qname on edges_data");
+
+    // Reverse (find_callers) Syntactic seed shape — mirror of predicates::reverse_predicate.
+    let reverse = plan(
+        "SELECT id FROM edges
+         WHERE edge_kind IN ('calls_name', 'constructs')
+           AND (to_symbol_id = 5
+                OR to_symbol_id IN (
+                   SELECT id FROM symbols
+                   WHERE qualified_name_id = (SELECT id FROM name_strings WHERE value = 'x'))
+                OR ('true' = 'true' AND to_symbol_id IN (SELECT id FROM symbols WHERE name = 'y'))
+                OR target_qualified_name_id = (SELECT id FROM name_strings WHERE value = 'x'))",
+    );
+    assert!(
+        reverse.contains("idx_edges_to_symbol"),
+        "reverse seed must drive idx_edges_to_symbol, got plan:\n{reverse}"
+    );
+    assert!(
+        reverse.contains("idx_edges_target_qname"),
+        "reverse unresolved branch must drive idx_edges_target_qname (V071), got plan:\n{reverse}"
+    );
+    assert!(
+        !reverse.contains("SCAN d") && !reverse.contains("SCAN edges_data"),
+        "reverse seed must not full-scan the edge rows, got plan:\n{reverse}"
+    );
+
+    // Forward (trace_callees) Syntactic seed shape — mirror of
+    // predicates::forward_source_predicate.
+    let forward = plan(
+        "SELECT id FROM edges
+         WHERE edge_kind IN ('calls_name', 'constructs')
+           AND (from_symbol_id = 5
+                OR from_symbol_id IN (
+                   SELECT id FROM symbols
+                   WHERE qualified_name_id = (SELECT id FROM name_strings WHERE value = 'x'))
+                OR ('true' = 'true' AND from_symbol_id IN (SELECT id FROM symbols WHERE name = \
+         'y'))
+                OR from_name_id = (SELECT id FROM name_strings WHERE value = 'x'))",
+    );
+    assert!(
+        forward.contains("idx_edges_from_symbol"),
+        "forward seed must drive idx_edges_from_symbol, got plan:\n{forward}"
+    );
+    assert!(
+        forward.contains("idx_edges_from_name"),
+        "forward unresolved branch must drive idx_edges_from_name, got plan:\n{forward}"
+    );
+    assert!(
+        !forward.contains("SCAN d") && !forward.contains("SCAN edges_data"),
+        "forward seed must not full-scan the edge rows, got plan:\n{forward}"
+    );
+}

--- a/crates/rag-rat-core/src/index/schema/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema/migrations.rs
@@ -764,7 +764,23 @@ pub(crate) fn ensure_edges_data_indexes(conn: &Connection) -> rusqlite::Result<(
         CREATE INDEX IF NOT EXISTS idx_edges_source_file ON edges_data(source_file_id);
         CREATE INDEX IF NOT EXISTS idx_edges_from_name ON edges_data(from_name_id);
         CREATE INDEX IF NOT EXISTS idx_edges_to_name ON edges_data(to_name_id);
+        CREATE INDEX IF NOT EXISTS idx_edges_target_qname ON edges_data(target_qualified_name_id);
         ",
+    )
+}
+
+/// V071 (#682): index the edge-side interned target-qualified-name id. The graph-traversal seed
+/// predicate behind `find_callers` / `trace_callees` matches unresolved edges by
+/// `edges.target_qualified_name_id = (SELECT id FROM name_strings WHERE value = ?)`; without an
+/// index on that column the whole seed OR degrades to a full scan of `edges_data` (the other seed
+/// branches are on the already-indexed `to_symbol_id` / `from_symbol_id` / `from_name_id`). This
+/// index lets the planner drive a MULTI-INDEX OR instead. Purely additive and idempotent
+/// (`CREATE INDEX IF NOT EXISTS`); a fresh DB gets it from `ensure_edges_data_indexes`, an existing
+/// DB from this forward migration.
+pub(crate) fn apply_edge_target_qname_index(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "CREATE INDEX IF NOT EXISTS idx_edges_target_qname ON \
+         edges_data(target_qualified_name_id);",
     )
 }
 
@@ -1268,6 +1284,7 @@ pub(crate) fn known_version(migrations: &[AppliedMigration]) -> u32 {
             MIGRATION_068_ID => Some(68),
             MIGRATION_069_ID => Some(69),
             MIGRATION_070_ID => Some(70),
+            MIGRATION_071_ID => Some(71),
             _ => None,
         })
         .max()
@@ -1347,6 +1364,7 @@ pub(crate) fn known_migration(id: &str) -> bool {
             | MIGRATION_068_ID
             | MIGRATION_069_ID
             | MIGRATION_070_ID
+            | MIGRATION_071_ID
             | DIRTY_MIGRATION_ID
     )
 }
@@ -1423,6 +1441,7 @@ pub(crate) fn migration_checksum_mismatch(migration: &AppliedMigration) -> bool 
         MIGRATION_068_ID => migration.checksum != MIGRATION_068_CHECKSUM,
         MIGRATION_069_ID => migration.checksum != MIGRATION_069_CHECKSUM,
         MIGRATION_070_ID => migration.checksum != MIGRATION_070_CHECKSUM,
+        MIGRATION_071_ID => migration.checksum != MIGRATION_071_CHECKSUM,
         _ => false,
     }
 }

--- a/crates/rag-rat-core/src/index/schema/mod.rs
+++ b/crates/rag-rat-core/src/index/schema/mod.rs
@@ -19,7 +19,7 @@ pub use registry::{LEGACY_REPO_ID, RegisteredRepo, register_repo, register_repo_
 use rusqlite::{Connection, OptionalExtension, Transaction, TransactionBehavior, params};
 use serde::Serialize;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 70;
+pub const LATEST_SCHEMA_VERSION: u32 = 71;
 
 /// Every oracle-DERIVED persisted table — the outputs an `oracle run` writes that must OUTLIVE a
 /// reindex.
@@ -487,6 +487,14 @@ const MIGRATION_070_DESCRIPTION: &str =
      tables but updated only when acceptance changes (the content refold), never by the /1 \
      projector sweep — kept separate so a projector-version bump cannot wipe the /3 projection. \
      Purely additive, nothing pre-existing to backfill";
+const MIGRATION_071_ID: &str = "071_edge_target_qname_index";
+const MIGRATION_071_CHECKSUM: &str = "sha256:rag-rat-edge-target-qname-index-v71";
+const MIGRATION_071_DESCRIPTION: &str =
+    "Add idx_edges_target_qname on edges_data(target_qualified_name_id) so \
+     find_callers/trace_callees seed the graph traversal on an indexed id column (MULTI-INDEX OR) \
+     instead of full-scanning the edge table when matching unresolved edges by \
+     target_qualified_name. Purely additive; CREATE INDEX IF NOT EXISTS, nothing pre-existing to \
+     backfill";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -1068,6 +1076,12 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         checksum: MIGRATION_070_CHECKSUM,
         description: MIGRATION_070_DESCRIPTION,
         apply: apply_content_projected_tables,
+    },
+    Migration {
+        id: MIGRATION_071_ID,
+        checksum: MIGRATION_071_CHECKSUM,
+        description: MIGRATION_071_DESCRIPTION,
+        apply: apply_edge_target_qname_index,
     },
 ];
 

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
@@ -2165,10 +2165,16 @@ fn migration_069_adds_the_local_account_pointer() {
 }
 
 #[test]
-fn migration_070_is_the_tip_and_adds_the_content_projected_tables() {
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 70, "move this pin with the next schema migration");
+fn migration_070_adds_the_content_projected_tables() {
+    // The absolute-tip pin moved to `migration_071_*` (V071 is the tip now); this drops to the
+    // symbolic `current_version == LATEST` freshness check, per the ladder convention.
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     schema::apply(&conn).unwrap();
+    assert_eq!(
+        schema::status(&conn).unwrap().current_version,
+        schema::LATEST_SCHEMA_VERSION,
+        "schema at LATEST after apply",
+    );
 
     // Both /3 projection tables exist with their full column set, mirroring the stream-keyed /1
     // shadow tables (V053).
@@ -2240,6 +2246,48 @@ fn migration_070_is_the_tip_and_adds_the_content_projected_tables() {
         )
         .unwrap();
     assert_eq!(v70_recorded, 1, "the forward migration records V070");
+}
+
+#[test]
+fn migration_071_is_the_tip_and_indexes_edge_target_qname() {
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 71, "move this pin with the next schema migration");
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn).unwrap();
+
+    let index_on = |conn: &rusqlite::Connection| -> i64 {
+        conn.query_row(
+            "SELECT COUNT(*) FROM sqlite_master
+             WHERE type = 'index' AND name = 'idx_edges_target_qname' AND tbl_name = 'edges_data'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap()
+    };
+    assert_eq!(index_on(&conn), 1, "V071 creates idx_edges_target_qname on edges_data");
+
+    // Idempotent applier: drop it, re-run twice — CREATE INDEX IF NOT EXISTS reconverges.
+    conn.execute("DROP INDEX idx_edges_target_qname", []).unwrap();
+    assert_eq!(index_on(&conn), 0, "index dropped");
+    schema::apply_edge_target_qname_index(&conn).unwrap();
+    schema::apply_edge_target_qname_index(&conn).expect("replay is a no-op");
+    assert_eq!(index_on(&conn), 1, "the isolated applier recreates the index");
+
+    // A forward migrate over a ledger truncated below V071 replays the step and records V071.
+    truncate_schema_to(&conn, 70);
+    schema::migrate_forward(&conn).unwrap();
+    assert_eq!(
+        schema::status(&conn).unwrap().current_version,
+        schema::LATEST_SCHEMA_VERSION,
+        "forward migrate reaches the tip",
+    );
+    let v71_recorded: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM schema_version WHERE id = '071_edge_target_qname_index'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(v71_recorded, 1, "the forward migration records V071");
 }
 
 #[test]

--- a/crates/rag-rat-core/src/query/graph/predicates.rs
+++ b/crates/rag-rat-core/src/query/graph/predicates.rs
@@ -79,7 +79,8 @@ pub(crate) fn reverse_predicate(mode: GraphResolutionMode, logical: bool) -> &'s
                     FROM logical_symbol_members
                     WHERE logical_symbol_id = ?8
                   )
-                  OR edges.target_qualified_name = ?1)",
+                  OR edges.target_qualified_name_id =
+                        (SELECT id FROM name_strings WHERE value = ?1))",
             GraphResolutionMode::Fuzzy =>
                 "edges.to_symbol_id IN (
                     SELECT symbol_id
@@ -95,15 +96,31 @@ pub(crate) fn reverse_predicate(mode: GraphResolutionMode, logical: bool) -> &'s
                         (SELECT id FROM name_strings WHERE value = ?3))",
         };
     }
+    // #682 INDEXED-SEED CONTRACT: the Exact/Syntactic seed branches compare the `edges` view's raw
+    // dictionary/id columns (`to_symbol_id`, `target_qualified_name_id`) against a constant — a
+    // bare id or a `(SELECT id FROM name_strings WHERE value = ?)` — so the planner drives a
+    // MULTI-INDEX OR over `idx_edges_to_symbol` + `idx_edges_target_qname` instead of
+    // full-scanning `edges_data` through the view's value joins (`to_qn.value`,
+    // `edges.target_qualified_name`). Faithful transform of the value-column forms:
+    // `to_qn.value = ?1` (the to-symbol's qualified name) is exactly the edges whose
+    // `to_symbol_id` is a symbol with that interned qualified name, and `to_symbols.name = ?3`
+    // those whose to-symbol has that short name. Fuzzy keeps the `LIKE` forms (opt-in,
+    // inherently non-sargable). See the raw-id note in `ensure_edges_view`.
     match mode {
         GraphResolutionMode::Exact =>
             "edges.to_symbol_id IS NOT NULL
-             AND (edges.to_symbol_id = ?6 OR to_qn.value = ?1)",
+             AND (edges.to_symbol_id = ?6
+                  OR edges.to_symbol_id IN (
+                     SELECT id FROM symbols
+                     WHERE qualified_name_id = (SELECT id FROM name_strings WHERE value = ?1)))",
         GraphResolutionMode::Syntactic =>
             "(edges.to_symbol_id = ?6
-              OR to_qn.value = ?1
-              OR (?7 = 'true' AND to_symbols.name = ?3)
-              OR edges.target_qualified_name = ?1)",
+              OR edges.to_symbol_id IN (
+                 SELECT id FROM symbols
+                 WHERE qualified_name_id = (SELECT id FROM name_strings WHERE value = ?1))
+              OR (?7 = 'true' AND edges.to_symbol_id IN (
+                 SELECT id FROM symbols WHERE name = ?3))
+              OR edges.target_qualified_name_id = (SELECT id FROM name_strings WHERE value = ?1))",
         GraphResolutionMode::Fuzzy =>
             "to_symbols.name = ?3
              OR to_qn.value = ?1
@@ -137,19 +154,19 @@ pub(crate) fn forward_source_predicate(mode: GraphResolutionMode, logical: bool)
     if logical {
         return match mode {
             GraphResolutionMode::Exact =>
-                "from_symbols.id IS NOT NULL
-                 AND from_symbols.id IN (
+                "edges.from_symbol_id IS NOT NULL
+                 AND edges.from_symbol_id IN (
                     SELECT symbol_id
                     FROM logical_symbol_members
                     WHERE logical_symbol_id = ?8
                  )",
             GraphResolutionMode::Syntactic =>
-                "from_symbols.id IN (
+                "edges.from_symbol_id IN (
                     SELECT symbol_id
                     FROM logical_symbol_members
                     WHERE logical_symbol_id = ?8
                  )
-                 OR edges.from_name = ?1",
+                 OR edges.from_name_id = (SELECT id FROM name_strings WHERE value = ?1)",
             GraphResolutionMode::Fuzzy =>
                 "from_symbols.id IN (
                     SELECT symbol_id
@@ -163,15 +180,26 @@ pub(crate) fn forward_source_predicate(mode: GraphResolutionMode, logical: bool)
                  OR edges.from_name LIKE ?2",
         };
     }
+    // #682 INDEXED-SEED CONTRACT (mirror of reverse_predicate): Exact/Syntactic seed on the raw
+    // `edges` id columns (`from_symbol_id`, `from_name_id`) against a constant so the planner
+    // drives `idx_edges_from_symbol` + `idx_edges_from_name` instead of scanning `edges_data`
+    // through the view's `from_qn.value` / `edges.from_name` value joins. Fuzzy keeps the
+    // `LIKE` forms.
     match mode {
         GraphResolutionMode::Exact =>
-            "from_symbols.id IS NOT NULL
-             AND (from_symbols.id = ?6 OR from_qn.value = ?1)",
+            "edges.from_symbol_id IS NOT NULL
+             AND (edges.from_symbol_id = ?6
+                  OR edges.from_symbol_id IN (
+                     SELECT id FROM symbols
+                     WHERE qualified_name_id = (SELECT id FROM name_strings WHERE value = ?1)))",
         GraphResolutionMode::Syntactic =>
-            "from_symbols.id = ?6
-             OR from_qn.value = ?1
-             OR (?7 = 'true' AND from_symbols.name = ?3)
-             OR edges.from_name = ?1",
+            "edges.from_symbol_id = ?6
+             OR edges.from_symbol_id IN (
+                SELECT id FROM symbols
+                WHERE qualified_name_id = (SELECT id FROM name_strings WHERE value = ?1))
+             OR (?7 = 'true' AND edges.from_symbol_id IN (
+                SELECT id FROM symbols WHERE name = ?3))
+             OR edges.from_name_id = (SELECT id FROM name_strings WHERE value = ?1)",
         GraphResolutionMode::Fuzzy =>
             "from_symbols.name = ?3
              OR from_qn.value = ?1


### PR DESCRIPTION
## Problem

`find_callers` / `trace_callees` full-**SCAN** the whole `edges` view (~1M `edges_data` rows) on every call. The reverse/forward traversal seed predicate OR-mixed the indexed `edges.to_symbol_id` / `from_symbol_id` with **value-joined view columns** (`to_qn.value`, `edges.target_qualified_name`, `edges.from_name`), which SQLite cannot push into an edge-index seek — so it abandoned the indexes and scanned every edge, then sorted.

Measured on a real ~1M-edge index (warm cache): reverse traversal **~760 ms** (up to ~2.2 s for heavier seeds), plan `SCAN d` + `USE TEMP B-TREE FOR ORDER BY`. `impact_surface` traverses the *same* view in ~0.2 ms because it already seeds on raw indexed id columns.

## Fix

Rewrite the **Exact** and **Syntactic** arms of `reverse_predicate` / `forward_source_predicate` (`query/graph/predicates.rs`) to compare the `edges` view's **raw interned id columns** against a constant instead of the value-joined columns — the pattern the view already exposes those `*_id` columns for (see the `ensure_edges_view` raw-id note) and that `impact_surface`'s `graph_neighbors` already uses:

- `to_qn.value = ?` → `edges.to_symbol_id IN (SELECT id FROM symbols WHERE qualified_name_id = (SELECT id FROM name_strings WHERE value = ?))`
- `edges.target_qualified_name = ?` → `edges.target_qualified_name_id = (SELECT id FROM name_strings WHERE value = ?)`
- forward mirrors this with `from_symbol_id` / `from_name_id`.

Fuzzy arms (opt-in, inherently non-sargable `LIKE`) are unchanged. Matching semantics and returned rows/order are identical. The predicates keep referencing the scoped `edges` / `symbols` / `name_strings` views, so worktree-overlay scoping is unaffected.

### Migration V071

Adds `idx_edges_target_qname` on `edges_data(target_qualified_name_id)` — the one seeded column that was not yet indexed (the reverse unresolved-edge branch needs it; the forward branch uses the existing `idx_edges_from_name`). Purely additive, `CREATE INDEX IF NOT EXISTS`; fresh DBs get it from `ensure_edges_data_indexes`, existing DBs from the forward migration.

## Result

On the same ~1M-edge index, reverse traversal **760 ms → 7.5 ms** (~100×); the plan flips from a full `SCAN` to a `MULTI-INDEX OR` over `idx_edges_to_symbol` + `idx_edges_target_qname` (plus `idx_symbols_qualified_name_id` / `idx_symbols_name` for the branch subqueries).

## Tests

- New plan-pinning regression test `graph_traversal_seed_predicates_use_edge_id_indexes` (asserts the reverse/forward seed shapes drive the id indexes and never full-scan the edge rows).
- New migration test `migration_071_is_the_tip_and_indexes_edge_target_qname`; the former tip test drops to the symbolic version check.
- Full `rag-rat-core` suite green (2567 tests), including the graph/impact/oracle, poison-sibling isolation, and worktree-overlay tests — semantics unchanged.

## Out of scope

`symbol_lookup` bare-name fuzzy (`lookup_name`) full-scans `name_strings` via a leading-wildcard `LIKE '%x%'`; exact whole-word lookup already uses the indexed `symbols.name` arm and is unaffected. Tracked separately (trigram-FTS decision to preserve substring semantics).

Fixes #682
