### PR TITLE
fix(dream): cut divergence false positives — memory-id cross-refs, verbatim, documented removals

### DIFF
--- a/crates/rag-rat-core/src/dream/prompts/verdict_head.md
+++ b/crates/rag-rat-core/src/dream/prompts/verdict_head.md
@@ -3,11 +3,13 @@ You are auditing a repo-intelligence memory NOTE against the repository as it ex
 Read each identifier's resolution LITERALLY. The resolutions mean exactly:
 - `symbol <path>::<name>` (or `symbols (N): …`) — a defined code symbol of that name EXISTS in the tree. Present.
 - `file <path>` (or `files (N): …`) — a file of that path EXISTS in the tree. Present.
-- `not a defined symbol; appears verbatim as source text` — the token EXISTS in the source as literal text (a table/column name, a local variable, an expression, an attribute), just not as a DEFINED symbol. Treat it as PRESENT — unless the note specifically claims it is a defined function/type/symbol of that name, in which case "not a defined symbol" is a contradiction.
+- `not a defined symbol; appears verbatim as source text` — the token EXISTS in the source as literal text (a table/column name, a local variable, an expression, an attribute), just not as a DEFINED symbol. Treat it as PRESENT — unless the note specifically claims it is a defined function/type/symbol of that name, in which case "not a defined symbol" is a contradiction. COMMON FALSE POSITIVE: a table/column name (`content_hash`), a meta/config key (`fts_synced_at_ms`), an env var, or a local variable resolves this way and IS present — do NOT rule `diverged` merely because it is not a defined function/type.
 - `not an indexed file; appears verbatim only as source text` — a path that EXISTS in the source as literal text (mentioned in a comment or string) but is NOT an indexed file. Treat it as PRESENT — unless the note specifically claims a FILE of that path exists, in which case "not an indexed file" is a contradiction.
 - `NOT FOUND anywhere in the source tree` — a name-shaped identifier that exists NOWHERE in the tree: not a symbol, not a file, not even as literal text. This is the ONLY resolution that is evidence of ABSENCE.
 
 Absence alone is not divergence: a `NOT FOUND` identifier the note merely mentions in passing does not contradict the note. It is divergence only when the note makes a LOAD-BEARING claim about that name (it says the function/type/table/field was added, exists, or behaves a certain way) and the pack shows it `NOT FOUND` (or present only as text while the note calls it a defined symbol).
+
+A note DOCUMENTING ITS OWN HISTORY agrees with reality, it does not contradict it: if the note itself says a name was REMOVED, RENAMED (A→B), REPLACED, or is DELIBERATELY ABSENT, then that name resolving `NOT FOUND` CONFIRMS the note — verdict `current`, not `diverged`. Only a name the note claims currently EXISTS or was ADDED, shown `NOT FOUND`, is divergence.
 
 Output EXACTLY this format and nothing else:
 VERDICT: current | diverged

--- a/crates/rag-rat-core/src/dream/verdict.rs
+++ b/crates/rag-rat-core/src/dream/verdict.rs
@@ -39,7 +39,7 @@ use crate::index::schema;
 /// stops reporting stale-prompt verdicts until they are re-checked. v2: the identifier resolver
 /// gained a verbatim-text tier + a shape-split terminal, and the prompt teaches those labels, so v1
 /// verdicts (which over-reported divergence off bare NOT-FOUND rows) are not comparable.
-pub(crate) const PROMPT_VERSION: &str = "verify-pack-v2";
+pub(crate) const PROMPT_VERSION: &str = "verify-pack-v3";
 
 /// Rank for a `memory_divergence` finding — high, but below a broken-anchor's pass-0 signal.
 const DIVERGENCE_RANK: f64 = 0.8;

--- a/crates/rag-rat-core/src/dream/verify.rs
+++ b/crates/rag-rat-core/src/dream/verify.rs
@@ -31,6 +31,13 @@ const NOT_FOUND: &str = "NOT FOUND anywhere in the source tree";
 /// The resolution for a code-shaped-but-unresolved span that is uninformative — a paraphrase,
 /// snippet, or flag whose non-match is a shape artifact, NEVER evidence of divergence.
 const UNRESOLVABLE: &str = "not a resolvable identifier (no symbol, file, or verbatim-text match)";
+/// The resolution for a `mem_<hex>` id that is a cross-reference to ANOTHER repo memory, not a code
+/// entity — uninformative (never NOT_FOUND, never source presence). Shared by the tier-2.5 arms.
+const MEM_XREF: &str = "a cross-reference to another repo memory (not a code entity)";
+/// The verbatim-text label for a present-but-not-a-defined-symbol span (a table/column name, a
+/// local, an expression). Shared by the general text tier and the ambiguous mem-id prefix arm so
+/// the label (and thus the churn-key string) can't drift between the two paths.
+const TEXT_PRESENT_SYMBOL: &str = "not a defined symbol; appears verbatim as source text";
 /// Context lines above/below an identifier hit in a bound-file excerpt window.
 const EXCERPT_RADIUS: i64 = 3;
 /// Upper bound on the total excerpt lines an evidence pack carries (keeps a single-turn verdict
@@ -185,6 +192,80 @@ impl ResolutionKind {
     fn is_present(self) -> bool {
         matches!(self, Self::Symbol | Self::File | Self::TextPresent)
     }
+}
+
+/// How a `mem_`-prefixed identifier resolves against the minted memory-id shape.
+///
+/// `memory_create` mints `mem_<hex-timestamp>_<hex-suffix>` (`query::memory::validate::memory_id`)
+/// or `mem_<hex>_<hex>` for a consolidated import (`index::consolidate`) — always TWO hex segments
+/// — and agents commonly cite the timestamp segment ALONE. The two forms are disambiguated
+/// differently downstream (see the tier-2.5 branch in [`resolve_identifier`]), so classification is
+/// three-way:
+/// - [`Full`](MemIdShape::Full): both segments present (`mem_<hex≥10>_<hex…>`). Decisive by shape —
+///   a coincidental identifier of this exact form is vanishingly unlikely — so it is a
+///   cross-reference without any record lookup, which keeps #678's DANGLING-reference property (a
+///   cite of a deleted memory is uninformative, never a code absence) independent of the memory
+///   table.
+/// - [`Prefix`](MemIdShape::Prefix): one long hex segment, no suffix (`mem_<hex≥10>`).
+///   Shape-AMBIGUOUS with a contiguous-hex code local, so shape alone cannot classify it — the
+///   caller disambiguates by record-confirmation, then source presence.
+/// - [`NotAnId`](MemIdShape::NotAnId): everything else. The first underscore-delimited segment must
+///   be a long (≥10) contiguous hex run — checking that segment, NOT the aggregate hex count across
+///   underscores, is what stops a segmented hex-word like `mem_dead_beef_ca` from being misread —
+///   and the whole span must be hex/underscore, so a real symbol like `mem_19f2ad6cf90_lookup` is
+///   rejected on its non-hex tail.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MemIdShape {
+    NotAnId,
+    Full,
+    Prefix,
+}
+
+fn memory_id_shape(ident: &str) -> MemIdShape {
+    let Some(rest) = ident.strip_prefix("mem_") else {
+        return MemIdShape::NotAnId;
+    };
+    let first_segment = rest.split('_').next().unwrap_or(rest);
+    let shaped = first_segment.len() >= 10
+        && first_segment.chars().all(|c| c.is_ascii_hexdigit())
+        && rest.chars().all(|c| c.is_ascii_hexdigit() || c == '_');
+    match (shaped, rest.contains('_')) {
+        (false, _) => MemIdShape::NotAnId,
+        (true, true) => MemIdShape::Full,
+        (true, false) => MemIdShape::Prefix,
+    }
+}
+
+/// The union predicate — is `ident` memory-id-shaped at all (Full OR Prefix)? Used only by the
+/// excerpt filter in [`evidence_pack`], which must exclude BOTH forms from bound-file excerpt
+/// windows once they resolve `Unresolvable`: `identifier_windows` matches by plain substring, so a
+/// cross-ref left in the excerpt-ident list would window a source line and wrongly make a
+/// cross-ref-only note citable. (#678)
+fn is_memory_id_shaped(ident: &str) -> bool {
+    !matches!(memory_id_shape(ident), MemIdShape::NotAnId)
+}
+
+/// Does a repo memory in the active scope have this bare timestamp `prefix` as its whole id, or as
+/// the `<prefix>_<suffix>` timestamp segment of its id? Confirms a shape-ambiguous
+/// [`MemIdShape::Prefix`] is a real cross-reference (vs a coincidental contiguous-hex code local).
+/// Scoped exactly like the other `repo_memories` reads here. ALL statuses count — a cite of an
+/// obsolete/superseded memory is still a cross-ref. Confirmation can only UPGRADE a prefix to a
+/// cross-ref, so it can never turn one into a NOT_FOUND absence: #678's dangling-reference property
+/// does not depend on the memory table.
+fn memory_with_id_prefix_exists(conn: &Connection, prefix: &str) -> rusqlite::Result<bool> {
+    let scope = schema::periphery_repo_scope(conn, "repo_memories")?;
+    let clause = schema::periphery_repo_scope_clause(&scope, "repo_memories");
+    // `substr(id, 1, len)` byte-prefix equality, NOT LIKE — `_` is a LIKE single-char wildcard.
+    // Input is ASCII hex, so SQLite's char-based `substr` is byte-equivalent.
+    let pat = format!("{prefix}_");
+    conn.query_row(
+        &format!(
+            "SELECT EXISTS(SELECT 1 FROM repo_memories WHERE (id = ?1 OR substr(id, 1, ?2) = \
+             ?3){clause})"
+        ),
+        rusqlite::params![prefix, pat.len() as i64, pat],
+        |r| r.get(0),
+    )
 }
 
 /// One extracted identifier and where (if anywhere) it resolves in the whole-tree index.
@@ -453,7 +534,16 @@ pub fn evidence_pack(conn: &Connection, memory_id: &str) -> anyhow::Result<Evide
         let (resolution, kind) = resolve_identifier(conn, ident, &file_paths)?;
         resolutions.push(IdentifierResolution { identifier: ident.clone(), resolution, kind });
     }
-    let excerpts = bound_file_excerpts(conn, memory_id, &scope, &identifiers)?;
+    // A `mem_<hex>` cross-reference is never source evidence, so it must not window an excerpt
+    // either — else a note that merely mentions a memory id in its bound file stays citable via the
+    // excerpt, even though the id itself resolved Unresolvable above. Real hex-named symbols (which
+    // resolved as `Symbol`, not `Unresolvable`) are kept. (#678)
+    let excerpt_idents: Vec<String> = resolutions
+        .iter()
+        .filter(|r| !(r.kind == ResolutionKind::Unresolvable && is_memory_id_shaped(&r.identifier)))
+        .map(|r| r.identifier.clone())
+        .collect();
+    let excerpts = bound_file_excerpts(conn, memory_id, &scope, &excerpt_idents)?;
     Ok(EvidencePack { memory_id: memory_id.to_string(), identifiers: resolutions, excerpts })
 }
 
@@ -642,6 +732,40 @@ fn resolve_identifier(
             ));
         },
     }
+    // 2.5. MEMORY CROSS-REFERENCE — a `mem_<hex>` id is a cross-reference to ANOTHER repo memory,
+    // not      a code entity. Classified HERE — AFTER symbol/file (so a real symbol/file whose
+    // name      matches the shape, `fn mem_deadbeefdead`, wins) — and split by shape so an
+    // ambiguous prefix      can't strip source evidence from a coincidental code local:
+    //      - FULL form (`mem_<hex>_<hex>`): unambiguous, so a cross-ref regardless of source
+    //        presence or record existence — never NOT_FOUND (a dangling cite is not a code
+    //        absence), never source presence (a note citing a full id in a comment stays
+    //        `unverifiable`).
+    //      - PREFIX form (`mem_<hex>`): shape-ambiguous with a contiguous-hex local. Confirm
+    //        against the memory table first — a recorded memory's prefix is a cross-ref even when
+    //        the bare id also appears in indexed text (a doc citing it is not code evidence). An
+    //        UNRECORDED prefix defers to source: a verbatim token-boundary hit is a coincidental
+    //        code identifier whose `TextPresent` evidence must survive; a miss is a dangling
+    //        cross-ref, NEVER NOT_FOUND (the arm owns this terminal so a bare code-shaped prefix
+    //        can't fall through to `Absent`). (#678)
+    match memory_id_shape(ident) {
+        MemIdShape::Full => {
+            return Ok((MEM_XREF.to_string(), ResolutionKind::Unresolvable));
+        },
+        MemIdShape::Prefix => {
+            if memory_with_id_prefix_exists(conn, ident)? {
+                return Ok((MEM_XREF.to_string(), ResolutionKind::Unresolvable));
+            }
+            // Present at a token boundary → coincidental code identifier (keep its evidence); a
+            // miss or an indeterminate (`Capped`) scan → dangling cross-ref, never
+            // convict as `Absent`.
+            return Ok(match text_probe(conn, ident)? {
+                TextProbe::Present =>
+                    (TEXT_PRESENT_SYMBOL.to_string(), ResolutionKind::TextPresent),
+                _ => (MEM_XREF.to_string(), ResolutionKind::Unresolvable),
+            });
+        },
+        MemIdShape::NotAnId => {},
+    }
     // 3. VERBATIM TEXT — present in source but not a symbol/file (a DB table/column name, a local,
     //    a common expression). Present, so NOT a divergence — but "not a defined symbol" keeps the
     //    door open for a note claiming it is a live function. The resolution names NO files, so the
@@ -671,7 +795,7 @@ fn resolve_identifier(
             let label = if is_file_path_shaped(ident, file_paths) {
                 "not an indexed file; appears verbatim only as source text"
             } else {
-                "not a defined symbol; appears verbatim as source text"
+                TEXT_PRESENT_SYMBOL
             };
             return Ok((label.to_string(), ResolutionKind::TextPresent));
         },
@@ -1984,6 +2108,202 @@ mod tests {
     }
 
     #[test]
+    fn resolve_identifier_treats_memory_id_cross_references_as_non_code() {
+        // #678: a memory body that cross-references ANOTHER memory by id (`mem_<hex>_<hex>`, or the
+        // common shorthand PREFIX) is not a CODE entity. It resolves `Unresolvable` —
+        // uninformative, hidden from the pack — so it is NEITHER the NOT_FOUND
+        // code-divergence signal NOR source presence. The presence point matters: a note
+        // whose ONLY resolving token is a cross-ref has no code evidence, so it must stay
+        // `unverifiable`, not be promoted to the verdict model on the strength of another
+        // note existing.
+        let c = mem_db();
+        set_repo(&c, "r");
+        // The referenced memory exists here, but existence does not change the classification — a
+        // cross-ref is never code evidence, dangling or not.
+        seed_memory(
+            &c,
+            "mem_19f2ad6cf90_2feb75f29ff8",
+            "title",
+            "a cross-referenced decision",
+            "r",
+        );
+        let files = indexed_file_paths(&c).unwrap();
+        let resolve = |id: &str| resolve_identifier(&c, id, &files).unwrap();
+
+        for id in [
+            "mem_19f2ad6cf90_2feb75f29ff8",  // an existing memory, full id
+            "mem_19f2ad6cf90",               // the timestamp-prefix form agents usually cite
+            "mem_deadbeefdead_cafebabecafe", // a dangling reference
+        ] {
+            let (res, kind) = resolve(id);
+            assert_eq!(
+                kind,
+                ResolutionKind::Unresolvable,
+                "{id}: a cross-ref is uninformative: {res}"
+            );
+            assert!(!kind.is_present(), "{id}: a cross-ref is not source presence: {res}");
+            assert_ne!(res, NOT_FOUND, "{id}: a cross-ref is never the code-absence signal: {res}");
+        }
+    }
+
+    #[test]
+    fn resolve_identifier_prefers_a_real_symbol_over_the_memory_id_heuristic() {
+        // #678 review: `is_memory_id_shaped` is a SHAPE heuristic — a real code symbol whose name
+        // happens to be all-hex (`mem_deadbeefdead`) must still resolve as that SYMBOL, not be
+        // hidden as a memory cross-reference. Code resolution runs FIRST; the memory-ref heuristic
+        // only reclassifies a span that would otherwise be a genuine NOT_FOUND absence.
+        let c = mem_db();
+        set_repo(&c, "r");
+        let fid = seed_file(&c, "src/m.rs", "fn mem_deadbeefdead() {}\n", "r");
+        c.execute(
+            "INSERT INTO symbols(file_id, language, name, kind, start_byte, end_byte) VALUES \
+             (?1,'rust','mem_deadbeefdead','function',0,0)",
+            rusqlite::params![fid],
+        )
+        .unwrap();
+        let files = indexed_file_paths(&c).unwrap();
+        let (res, kind) = resolve_identifier(&c, "mem_deadbeefdead", &files).unwrap();
+        assert_eq!(kind, ResolutionKind::Symbol, "a real hex-named symbol resolves as code: {res}");
+    }
+
+    #[test]
+    fn resolve_identifier_treats_a_source_mentioned_memory_id_as_a_cross_ref_not_text() {
+        // #678 review: even when a `mem_<hex>` id appears VERBATIM in indexed source (a doc comment
+        // or a test fixture), it is still a cross-reference to another memory, not code evidence —
+        // so it classifies `Unresolvable`, NOT `TextPresent`. The memory-id check runs
+        // after symbol/file resolution (real symbols win) but BEFORE the verbatim-text
+        // probe.
+        let c = mem_db();
+        set_repo(&c, "r");
+        seed_file(
+            &c,
+            "src/x.rs",
+            "// see mem_19f2ad6cf90_2feb75f29ff8 for the rationale\nfn f() {}\n",
+            "r",
+        );
+        let files = indexed_file_paths(&c).unwrap();
+        let (res, kind) = resolve_identifier(&c, "mem_19f2ad6cf90_2feb75f29ff8", &files).unwrap();
+        assert_eq!(
+            kind,
+            ResolutionKind::Unresolvable,
+            "a source-mentioned mem-id is a cross-ref, not verbatim text: {res}"
+        );
+        assert!(!kind.is_present(), "a cross-ref is not source presence even in source: {res}");
+    }
+
+    #[test]
+    fn resolve_identifier_does_not_mistake_a_segmented_hex_word_for_a_memory_id() {
+        // #678 review: `is_memory_id_shaped` keys on the FIRST underscore-delimited segment being a
+        // long contiguous hex run (the minted `mem_<hex-timestamp>_<suffix>` shape), NOT the
+        // aggregate hex count across underscores. Otherwise an ordinary identifier built from short
+        // hex-word chunks — `mem_dead_beef_ca` (4+4+2 = 10 hex) — is misread as a memory cross-ref,
+        // and if it appears as source text its legitimate `TextPresent` evidence gets suppressed.
+        let c = mem_db();
+        set_repo(&c, "r");
+        seed_file(&c, "src/y.rs", "let mem_dead_beef_ca = 1;\n", "r");
+        let files = indexed_file_paths(&c).unwrap();
+
+        // A segmented hex-word local is NOT a memory id: its verbatim source presence survives.
+        let (res, kind) = resolve_identifier(&c, "mem_dead_beef_ca", &files).unwrap();
+        assert_eq!(
+            kind,
+            ResolutionKind::TextPresent,
+            "a segmented hex word keeps its source presence: {res}"
+        );
+        assert!(kind.is_present(), "a segmented hex word is not suppressed as a cross-ref: {res}");
+
+        // A genuinely minted id (long first-segment hex run) is still classified as a cross-ref.
+        let (_, mem_kind) = resolve_identifier(&c, "mem_19f2ad6cf90_2feb75f29ff8", &files).unwrap();
+        assert_eq!(
+            mem_kind,
+            ResolutionKind::Unresolvable,
+            "a real mem-id (long first-segment hex run) still classifies as a cross-ref"
+        );
+    }
+
+    #[test]
+    fn memory_id_shape_splits_full_prefix_and_non_ids() {
+        use MemIdShape::{Full, NotAnId, Prefix};
+        // Full — two hex segments: both mint sites (`mem_{now:x}_{suffix}`, consolidate `13+12`),
+        // plus a trailing-underscore edge. Decisive by shape, no record lookup.
+        for id in
+            ["mem_19f2ad6cf90_2feb75f29ff8", "mem_deadbeefdead0_cafebabecafe", "mem_deadbeefdead_"]
+        {
+            assert_eq!(memory_id_shape(id), Full, "{id} is a full two-segment id");
+        }
+        // Prefix — one long hex segment, no suffix: the shorthand agents cite; ambiguous with a
+        // local.
+        for id in ["mem_19f2ad6cf90", "mem_deadbeefdead"] {
+            assert_eq!(memory_id_shape(id), Prefix, "{id} is a bare timestamp prefix");
+        }
+        // NotAnId — short first segment, non-hex tail, or no `mem_` prefix.
+        for id in ["mem_dead_beef_ca", "mem_19f2ad6cf90_lookup", "mem_copy", "memcpy", "other"] {
+            assert_eq!(memory_id_shape(id), NotAnId, "{id} is not a memory id");
+        }
+    }
+
+    #[test]
+    fn resolve_identifier_lets_a_coincidental_hex_local_keep_its_text_presence() {
+        // #678 review (Codex P2): a PREFIX-shaped token that is neither a defined symbol nor a
+        // recorded memory, but appears verbatim in source, is a coincidental code identifier — a
+        // memory-shaped LOCAL misses the symbol tier, so ONLY its source presence carries it. Its
+        // `TextPresent` evidence must survive, not be suppressed as a memory cross-reference.
+        let c = mem_db();
+        set_repo(&c, "r");
+        seed_file(&c, "src/y.rs", "let mem_deadbeefdead = 1;\n", "r");
+        let files = indexed_file_paths(&c).unwrap();
+        let (res, kind) = resolve_identifier(&c, "mem_deadbeefdead", &files).unwrap();
+        assert_eq!(
+            kind,
+            ResolutionKind::TextPresent,
+            "a coincidental hex local keeps its source presence: {res}"
+        );
+        assert!(
+            kind.is_present(),
+            "a coincidental hex local is not suppressed as a cross-ref: {res}"
+        );
+    }
+
+    #[test]
+    fn resolve_identifier_keeps_a_recorded_memorys_prefix_a_cross_ref_even_when_source_mentions_it()
+    {
+        // #678 review: a prefix that IS the timestamp of a RECORDED memory stays a cross-reference
+        // even when the bare prefix also appears verbatim in indexed text (an ADR/plan doc citing
+        // the id) — a cross-ref is never code evidence. Record-confirmation is what
+        // distinguishes this from a coincidental hex local (no matching memory), which
+        // keeps its text presence above.
+        let c = mem_db();
+        set_repo(&c, "r");
+        seed_memory(&c, "mem_19f2ad6cf90_2feb75f29ff8", "title", "a decision", "r");
+        seed_file(&c, "docs/adr.md", "// relates to mem_19f2ad6cf90\n", "r");
+        let files = indexed_file_paths(&c).unwrap();
+        let (res, kind) = resolve_identifier(&c, "mem_19f2ad6cf90", &files).unwrap();
+        assert_eq!(
+            kind,
+            ResolutionKind::Unresolvable,
+            "a recorded memory's prefix is a cross-ref, not source text: {res}"
+        );
+        assert!(!kind.is_present(), "a cross-ref is not source presence: {res}");
+        assert_ne!(res, NOT_FOUND, "a cross-ref is never the code-absence signal: {res}");
+    }
+
+    #[test]
+    fn resolve_identifier_treats_a_dangling_memory_prefix_as_a_cross_ref_not_an_absence() {
+        // #678: a prefix matching NO recorded memory, appearing in source only as a SUBSTRING of a
+        // longer full id (not at a token boundary), is a dangling cross-reference — `Unresolvable`,
+        // and NEVER the NOT_FOUND code-absence signal (a bare code-shaped prefix would otherwise
+        // reach the `Absent` terminal). The Prefix arm owns this terminal so the property
+        // can't regress.
+        let c = mem_db();
+        set_repo(&c, "r");
+        seed_file(&c, "src/z.rs", "// see mem_19f2ad6cf90_2feb75f29ff8\n", "r");
+        let files = indexed_file_paths(&c).unwrap();
+        let (res, kind) = resolve_identifier(&c, "mem_19f2ad6cf90", &files).unwrap();
+        assert_eq!(kind, ResolutionKind::Unresolvable, "a dangling prefix is a cross-ref: {res}");
+        assert_ne!(res, NOT_FOUND, "a dangling prefix is never a code absence: {res}");
+    }
+
+    #[test]
     fn resolve_identifier_never_masks_a_deleted_qualified_method_via_a_namesake() {
         // A qualified call is NOT resolved by bare method name (which would match an unrelated
         // NAMESAKE and hide the method's deletion). A PRESENT qualified call resolves through the
@@ -2606,6 +2926,66 @@ mod tests {
             "the bound-file excerpt contains the identifier's line: {:?}",
             pack.excerpts
         );
+    }
+
+    #[test]
+    fn a_memory_id_in_a_bound_file_is_not_citable_source_evidence() {
+        // #678 review: a note whose only identifier is a `mem_<hex>` cross-ref must NOT become
+        // citable just because that id appears verbatim in its bound file. The mem-id is excluded
+        // from excerpt windowing (it is Unresolvable, never source evidence), so a cross-ref-only
+        // note does not leak to the verdict model via a `path:line:` excerpt.
+        let c = mem_db();
+        set_repo(&c, "r");
+        seed_file(
+            &c,
+            "src/x.rs",
+            "// rationale: see mem_19f2ad6cf90_2feb75f29ff8\nfn f() {}\n",
+            "r",
+        );
+        // The note's ONLY identifier is the memory cross-reference.
+        seed_memory(&c, "m1", "t", "background: mem_19f2ad6cf90_2feb75f29ff8", "r");
+        c.execute(
+            "INSERT INTO repo_memory_bindings(memory_id, binding_kind, binding_id, path, \
+             anchor_status, created_at_ms, repo_id) VALUES \
+             ('m1','path','src/x.rs','src/x.rs','current',0,'r')",
+            [],
+        )
+        .unwrap();
+        let pack = evidence_pack(&c, "m1").unwrap();
+        assert!(
+            pack.excerpts.is_empty(),
+            "a memory cross-ref must not window a bound-file excerpt: {:?}",
+            pack.excerpts
+        );
+        assert!(!pack.is_citable(), "a cross-ref-only note stays non-citable");
+    }
+
+    #[test]
+    fn a_coincidental_hex_local_is_citable_and_windows_an_excerpt() {
+        // #678 review (Codex P2): the mirror of the cross-ref case above — a note whose only
+        // identifier is a coincidental hex LOCAL (`mem_deadbeefdead`, a prefix-shaped token that is
+        // no recorded memory) present in its bound file IS real source evidence. It
+        // resolves `TextPresent`, so it is NOT excluded from excerpt windowing and the note
+        // stays citable — otherwise a genuinely-verifiable memory would be wrongly held
+        // back as `unverifiable`.
+        let c = mem_db();
+        set_repo(&c, "r");
+        seed_file(&c, "src/x.rs", "let mem_deadbeefdead = compute();\nfn f() {}\n", "r");
+        seed_memory(&c, "m1", "t", "the guard reads mem_deadbeefdead each pass", "r");
+        c.execute(
+            "INSERT INTO repo_memory_bindings(memory_id, binding_kind, binding_id, path, \
+             anchor_status, created_at_ms, repo_id) VALUES \
+             ('m1','path','src/x.rs','src/x.rs','current',0,'r')",
+            [],
+        )
+        .unwrap();
+        let pack = evidence_pack(&c, "m1").unwrap();
+        assert!(
+            pack.excerpts.iter().any(|e| e.text.contains("mem_deadbeefdead")),
+            "a coincidental hex local windows its bound-file excerpt: {:?}",
+            pack.excerpts
+        );
+        assert!(pack.is_citable(), "a note anchored by a real source token stays citable");
     }
 
     #[test]

--- a/evals/memory-compaction/README.md
+++ b/evals/memory-compaction/README.md
@@ -80,6 +80,9 @@ evals/memory-compaction/
     anchors.json         identifier-anchored code excerpts (anchor-context variants)
     drift-anchors.json   doctored anchors for the drift-detection variant
     verify-packs.json     mechanically-built evidence packs (verify-pack method), keyed id|root
+                          ⚠ STALE FORMAT (issue #695): frozen in the legacy `IDENTIFIER RESOLUTION`
+                          shape, predates the current `render_pack` output — regenerate before trusting
+                          verify_pack_test numbers
   harness/
     eval_app.py          Modal app: candidates, judge, HHEM, the v2 variants, verify + drift
     score.py             folds judge verdicts + HHEM + format checks into the round-1 scoreboard
@@ -120,7 +123,10 @@ modal run harness/eval_app.py::verify_test        # agentic grep/read method (th
 ```
 
 `verify_pack_test` reads the static `corpus/verify-packs.json` (evidence packs pre-built from the
-current + doctored trees), so it does not mount the repo. `verify_test` and `drift_test` mount the
+current + doctored trees), so it does not mount the repo. **Caveat:** that snapshot is frozen in the
+legacy `IDENTIFIER RESOLUTION` pack format and predates the current `render_pack` output (which emits
+`` `id` -> … `` rows and hides `mem_<hex>` cross-references); regenerate it against the current +
+doctored trees before trusting these numbers — see issue #695. `verify_test` and `drift_test` mount the
 live checkout at `/repo` and the doctored copy at `/repo-drift`, so **run
 `make-drift-tree.py` first** for those.
 
@@ -226,11 +232,11 @@ identifiers. The eval is the check for the ref classes the runtime deliberately 
 
 These prompts are LIVE in rag-rat, versioned so a change is traceable:
 
-- `dream/verdict.rs` — `PROMPT_VERSION = "verify-pack-v1"` (the evidence-pack verdict prompt).
+- `dream/verdict.rs` — `PROMPT_VERSION = "verify-pack-v3"` (the evidence-pack verdict prompt).
 - `dream/compact.rs` — `COMPACT_PROMPT_VERSION = "compact-v1"` (the self-containment compact prompt).
 
 The harness's `VERIFY_PACK_PROMPT` mirrors the shipped verdict prompt (`dream/verdict.rs`'s
-`VERDICT_PROMPT_HEAD` + the NOTE/PACK tail) at `PROMPT_VERSION = "verify-pack-v1"`. **Re-sync
+`VERDICT_PROMPT_HEAD` + the NOTE/PACK tail) at `PROMPT_VERSION = "verify-pack-v3"`. **Re-sync
 `VERIFY_PACK_PROMPT` whenever `PROMPT_VERSION` bumps**, or the gate stops exercising what ships.
 
 **Bumping either version string, or changing the dream model, means re-running this suite** —

--- a/evals/memory-compaction/harness/eval_app.py
+++ b/evals/memory-compaction/harness/eval_app.py
@@ -407,11 +407,23 @@ def verify_test():
     (RESULTS / "verify-results.json").write_text(json.dumps(out, indent=1))
 
 
-# Mirrors the SHIPPED evidence-pack verdict prompt: dream/verdict.rs `VERDICT_PROMPT_HEAD` +
-# `render_verdict_prompt` tail (PROMPT_VERSION "verify-pack-v1"). It is a 2-way verdict (current |
-# diverged) — `unverifiable` is decided deterministically in pass 0 and NEVER asked of the model, so
-# it is absent here. RE-SYNC this string whenever PROMPT_VERSION bumps in dream/verdict.rs.
-VERIFY_PACK_PROMPT = """You are auditing a repo-intelligence memory NOTE against the repository as it exists RIGHT NOW. You are given a mechanically-generated EVIDENCE PACK from the current checkout: a whole-tree resolution of every identifier the note mentions (an identifier marked "NOT FOUND anywhere in the source tree" truly does not exist in the source — this is exhaustive, not a failed search), and the current text of the note's bound file. The note was written in the past: the code may have moved past it, or the note may describe in-flight work not present in this checkout, or they may agree.
+# Mirrors the SHIPPED evidence-pack verdict prompt: dream/verdict.rs `VERDICT_PROMPT_HEAD`
+# (prompts/verdict_head.md) + `render_verdict_prompt` tail (PROMPT_VERSION "verify-pack-v3"). It is a
+# 2-way verdict (current | diverged) — `unverifiable` is decided deterministically in pass 0 and
+# NEVER asked of the model, so it is absent here. RE-SYNC this string whenever PROMPT_VERSION bumps
+# in dream/verdict.rs.
+VERIFY_PACK_PROMPT = """You are auditing a repo-intelligence memory NOTE against the repository as it exists RIGHT NOW. You are given a mechanically-generated EVIDENCE PACK from the current checkout: a whole-tree resolution of the identifiers the note mentions, plus the current text of the note's bound file. The note was written in the past: the code may have moved past it, the note may describe in-flight work not present in this checkout, or they may agree.
+
+Read each identifier's resolution LITERALLY. The resolutions mean exactly:
+- `symbol <path>::<name>` (or `symbols (N): …`) — a defined code symbol of that name EXISTS in the tree. Present.
+- `file <path>` (or `files (N): …`) — a file of that path EXISTS in the tree. Present.
+- `not a defined symbol; appears verbatim as source text` — the token EXISTS in the source as literal text (a table/column name, a local variable, an expression, an attribute), just not as a DEFINED symbol. Treat it as PRESENT — unless the note specifically claims it is a defined function/type/symbol of that name, in which case "not a defined symbol" is a contradiction. COMMON FALSE POSITIVE: a table/column name (`content_hash`), a meta/config key (`fts_synced_at_ms`), an env var, or a local variable resolves this way and IS present — do NOT rule `diverged` merely because it is not a defined function/type.
+- `not an indexed file; appears verbatim only as source text` — a path that EXISTS in the source as literal text (mentioned in a comment or string) but is NOT an indexed file. Treat it as PRESENT — unless the note specifically claims a FILE of that path exists, in which case "not an indexed file" is a contradiction.
+- `NOT FOUND anywhere in the source tree` — a name-shaped identifier that exists NOWHERE in the tree: not a symbol, not a file, not even as literal text. This is the ONLY resolution that is evidence of ABSENCE.
+
+Absence alone is not divergence: a `NOT FOUND` identifier the note merely mentions in passing does not contradict the note. It is divergence only when the note makes a LOAD-BEARING claim about that name (it says the function/type/table/field was added, exists, or behaves a certain way) and the pack shows it `NOT FOUND` (or present only as text while the note calls it a defined symbol).
+
+A note DOCUMENTING ITS OWN HISTORY agrees with reality, it does not contradict it: if the note itself says a name was REMOVED, RENAMED (A→B), REPLACED, or is DELIBERATELY ABSENT, then that name resolving `NOT FOUND` CONFIRMS the note — verdict `current`, not `diverged`. Only a name the note claims currently EXISTS or was ADDED, shown `NOT FOUND`, is divergence.
 
 Output EXACTLY this format and nothing else:
 VERDICT: current | diverged
@@ -420,7 +432,7 @@ EVIDENCE:
 - <one line copied verbatim from the EVIDENCE PACK below that supports the verdict>
 REASON: <one sentence>
 
-Meanings: current = the note's load-bearing claims are visible in the pack as described. diverged = the pack clearly contradicts a load-bearing claim. code_ahead = the code changed after the note was written. note_ahead = the note describes work this checkout does not contain yet — for example, the mechanisms or functions the note says were added are marked NOT FOUND WHILE the note's bound file DOES exist; that is diverged / note_ahead, NOT a reason to give up. DIRECTION is "unknown" unless VERDICT is diverged and you can tell which side is newer. Every EVIDENCE line must be copied verbatim from the EVIDENCE PACK below — never invent one.
+Meanings: current = the note's load-bearing claims are visible in the pack as described (or nothing in the pack contradicts them). diverged = the pack clearly CONTRADICTS a load-bearing claim. code_ahead = the code changed after the note was written. note_ahead = the note describes work this checkout does not contain yet — a symbol the note says was added is `NOT FOUND` while the note's bound file DOES exist. DIRECTION is "unknown" unless VERDICT is diverged and you can tell which side is newer. Every EVIDENCE line must be copied verbatim from the EVIDENCE PACK below — never invent one.
 
 NOTE (anchored to {binding}):
 TITLE: {title}


### PR DESCRIPTION
Cuts the dominant class of `dream --verify` divergence false positives. In a full dream-review pass only ~3 of 44 flagged memories were genuinely stale — the rest tripped on tokens that are not indexed Rust symbols. Fixes #678.

## Changes

- **Memory-id cross-references** (`verify.rs`): a cited `mem_<hex>` id (the full id or the timestamp-prefix form agents usually write) is not a code entity. It now resolves to `Unresolvable` — hidden from the evidence pack — so it is **never** the `NOT_FOUND` code-divergence signal, and **not** counted as source presence. The presence point matters: a note whose only resolving token is a cross-ref stays `unverifiable` instead of being sent to the verdict model on the strength of *another* note existing. The check runs **after** symbol/file/text resolution, so a real code symbol whose name happens to be all-hex (`fn mem_deadbeefdead`) still resolves as code.
- **Verdict prompt** (`prompts/verdict_head.md`): the classifier already produced the right resolutions — the model just wasn't adhering. Sharpened two rules: a table/column/meta/env/local that "appears verbatim as source text" is present (a common false positive, not a divergence), and a name the note itself documents as removed / renamed / deliberately-absent resolving `NOT FOUND` **confirms** the note rather than contradicting it.
- **`PROMPT_VERSION`** `verify-pack-v2` → `v3`, so verdicts computed under the old prompt re-derive under the improved one on the next `--verify` (the fix propagates instead of leaving old false positives frozen).

## Tests

New regression coverage in `verify.rs` for: full ids, the prefix form, dangling references, and a real symbol colliding with the mem-id shape. All 115 dream-module tests pass; clippy (`-D warnings`) and fmt clean.

## Scope

This is the memory-id / verbatim / documented-removal bucket. The broader precision work — resolving more non-symbol namespaces (env vars, macros, CI keys) and cross-language references — is separate and not part of this change.
