### PR TITLE
feat(index): scoped reconcile over an explicit path set (index --paths)

### DIFF
--- a/crates/rag-rat-cli/src/cli.rs
+++ b/crates/rag-rat-cli/src/cli.rs
@@ -153,6 +153,19 @@ pub(crate) struct IndexArgs {
     /// only the delta vs the base; does not rebuild the base.
     #[arg(long, value_name = "PATH")]
     pub worktree: Option<std::path::PathBuf>,
+    /// Reconcile exactly these paths (the edit-driven-reindex substrate): index the supplied files
+    /// (content-hash decides staleness), tombstone any that no longer exist, and leave everything
+    /// else untouched. Ignored / out-of-target / unchanged paths are no-ops; an edit under a
+    /// linked worktree is routed to that worktree's overlay. Unlike the default changed-file
+    /// mode this also sees committed changes, since the caller — not git status — names the
+    /// paths.
+    #[arg(
+        long,
+        value_name = "PATH",
+        num_args = 1..,
+        conflicts_with_all = ["full", "discover", "changed", "worktree", "watch"]
+    )]
+    pub paths: Vec<std::path::PathBuf>,
     /// Run the background file watcher in the foreground until interrupted.
     #[arg(long)]
     pub watch: bool,

--- a/crates/rag-rat-cli/src/commands/index_ops.rs
+++ b/crates/rag-rat-cli/src/commands/index_ops.rs
@@ -61,6 +61,31 @@ pub(crate) fn index(config: &Config, args: &IndexArgs) -> anyhow::Result<()> {
         );
         return Ok(());
     }
+    // `--paths`: reconcile exactly the supplied paths (#659), routing linked-worktree edits to
+    // their overlay. A distinct scoped mode — handle before the full/discover/changed branches.
+    // #427: like the hook-driven maintenance pass, a scoped pass on a not-yet-registered repo
+    // DEFERS (there is nothing to reconcile into yet) rather than erroring, since this is the
+    // edit-hook substrate.
+    if !args.paths.is_empty() {
+        surface_adoption_warnings(config)?;
+        let cwd = std::env::current_dir()?;
+        let paths: Vec<std::path::PathBuf> = args
+            .paths
+            .iter()
+            .map(|path| if path.is_absolute() { path.clone() } else { cwd.join(path) })
+            .collect();
+        match rag_rat_core::watch::reindex_paths(config, &paths, render_index_progress) {
+            Ok(db) => return report_indexed(&db, config),
+            Err(err) if err.downcast_ref::<rag_rat_core::index::EmptyIndexRefused>().is_some() => {
+                eprintln!(
+                    "index --paths: deferred — no index yet; nothing to reconcile until content \
+                     is indexed (run 'rag-rat index' first)"
+                );
+                return Ok(());
+            },
+            Err(err) => return Err(err),
+        }
+    }
     surface_adoption_warnings(config)?;
     let db = if args.full {
         IndexDatabase::rebuild_with_progress(config, render_index_progress)?
@@ -69,9 +94,13 @@ pub(crate) fn index(config: &Config, args: &IndexArgs) -> anyhow::Result<()> {
     } else {
         IndexDatabase::index_changed_with_progress(config, render_index_progress)?
     };
-    // Re-anchor repo memories against the freshly indexed symbols/chunks so a moved or renamed
-    // binding relocates (or is flagged) instead of silently pointing at a stale row. Memory rows
-    // themselves are never deleted by indexing.
+    report_indexed(&db, config)
+}
+
+/// Shared `index` tail: re-anchor repo memories against the freshly indexed symbols/chunks (so a
+/// moved/renamed binding relocates or is flagged instead of pointing at a stale row — memory rows
+/// are never deleted by indexing), warn about anchors still needing attention, then print status.
+fn report_indexed(db: &IndexDatabase, config: &Config) -> anyhow::Result<()> {
     if let Err(err) = db.memory_validate() {
         eprintln!("warning: repo-memory re-validation failed: {err}");
     }

--- a/crates/rag-rat-core/src/index/file_rows.rs
+++ b/crates/rag-rat-core/src/index/file_rows.rs
@@ -239,6 +239,64 @@ impl IndexDatabase {
             .map_err(Into::into)
     }
 
+    /// The `(sha256, language, kind)` identity of the row for this exact scope key (`None` when no
+    /// such row exists) — the no-op-skip signal for the explicit-path flow: an `index --paths` over
+    /// a CLEAN/reverted file prepares a row whose identity matches the existing one, and
+    /// `write_prepared_incremental_files` skips the remove+insert so the row id and its chunk
+    /// embeddings are not needlessly churned (#659 review). Includes `language`/`kind` so a TARGET
+    /// identity change with UNCHANGED bytes (an extension-precedence upgrade re-languages a path
+    /// without touching its content) is NOT skipped — mirroring discovery's `(sha256, language,
+    /// kind)` staleness ([`super::discovery::target_for_path`] drift). Sibling of
+    /// [`Self::scope_row_modified_at_ms`].
+    pub(super) fn scope_row_identity(
+        &self,
+        path: &Path,
+        commit_sha: &str,
+        worktree_id: &str,
+    ) -> anyhow::Result<Option<(String, String, String)>> {
+        self.storage
+            .connection()
+            .query_row(
+                "SELECT sha256, language, kind FROM main.files
+                 WHERE repo_id = ?1 AND path = ?2 AND commit_sha = ?3 AND worktree_id = ?4
+                   AND generation = ?5",
+                params![
+                    self.active_repo_id,
+                    path_string(path),
+                    commit_sha,
+                    worktree_id,
+                    self.active_generation
+                ],
+                |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, String>(1)?,
+                        row.get::<_, String>(2)?,
+                    ))
+                },
+            )
+            .optional()
+            .map_err(Into::into)
+    }
+
+    /// Whether the ACTIVE scope (any commit/worktree at the live generation) has a row for `path` —
+    /// used by the explicit-path flow to tombstone a vanished supplied path ONLY when it was really
+    /// indexed, never a never-indexed typo / out-of-target file (a spurious `kind='deleted'`
+    /// overlay row would shadow any real committed file later appearing at that path) (#659
+    /// review).
+    pub(super) fn path_has_indexed_row(&self, path: &Path) -> anyhow::Result<bool> {
+        self.storage
+            .connection()
+            .query_row(
+                "SELECT 1 FROM files WHERE path = ?1 LIMIT 1",
+                params![path_string(path)],
+                |_| Ok(()),
+            )
+            .optional()
+            .map(|row| row.is_some())
+            .map_err(Into::into)
+    }
+
     pub(super) fn file_row(&self, path: &Path) -> anyhow::Result<FileRow> {
         self.storage
             .connection()

--- a/crates/rag-rat-core/src/index/incremental.rs
+++ b/crates/rag-rat-core/src/index/incremental.rs
@@ -34,7 +34,31 @@ impl IndexDatabase {
     where
         F: FnMut(IndexProgress),
     {
-        Self::index_incremental_with_progress(config, IndexMode::Changed, &mut progress)
+        Self::index_incremental_with_progress(config, IndexMode::Changed, None, &mut progress)
+            .map(|(db, _)| db)
+    }
+
+    /// Reconcile exactly the supplied candidate `paths` (#659) — the edit-driven-reindex substrate.
+    /// Like [`Self::index_changed`], but the change set is the explicit list rather than a
+    /// git-status walk (so it also sees committed changes), filtered through the same
+    /// ignore/target rules and content-hash staleness; ignored / out-of-target / unchanged
+    /// paths are no-ops, and a supplied path that no longer exists is tombstoned. Same per-repo
+    /// `WriteLock` and #427 first-time-empty deferral as the other modes. Paths must be under
+    /// `config.root`; a linked-worktree edit is routed to the overlay path by the caller (see
+    /// the CLI `index --paths`).
+    pub fn index_paths(config: &Config, paths: &[PathBuf]) -> anyhow::Result<Self> {
+        Self::index_paths_with_progress(config, paths, |_| {})
+    }
+
+    pub fn index_paths_with_progress<F>(
+        config: &Config,
+        paths: &[PathBuf],
+        mut progress: F,
+    ) -> anyhow::Result<Self>
+    where
+        F: FnMut(IndexProgress),
+    {
+        Self::index_incremental_with_progress(config, IndexMode::Paths, Some(paths), &mut progress)
             .map(|(db, _)| db)
     }
 
@@ -46,7 +70,7 @@ impl IndexDatabase {
     where
         F: FnMut(IndexProgress),
     {
-        Self::index_incremental_with_progress(config, IndexMode::Discover, &mut progress)
+        Self::index_incremental_with_progress(config, IndexMode::Discover, None, &mut progress)
             .map(|(db, _)| db)
     }
 
@@ -54,21 +78,33 @@ impl IndexDatabase {
     /// (a file was added / edited / removed). The watch loop uses this to skip the
     /// reconcile / memory-validate tail on an idle no-change sweep (issue #63).
     pub fn index_discover_reporting(config: &Config) -> anyhow::Result<(Self, bool)> {
-        Self::index_incremental_with_progress(config, IndexMode::Discover, &mut |_| {})
+        Self::index_incremental_with_progress(config, IndexMode::Discover, None, &mut |_| {})
     }
 
     fn index_incremental_with_progress<F>(
         config: &Config,
         mode: IndexMode,
+        explicit_paths: Option<&[PathBuf]>,
         progress: &mut F,
     ) -> anyhow::Result<(Self, bool)>
     where
         F: FnMut(IndexProgress),
     {
-        if !config.database.exists() {
-            return Self::rebuild_with_progress(config, progress).map(|db| (db, true));
-        }
-        if Self::migration_check(&config.database)?.state == schema::SchemaState::Missing {
+        // An absent / schemaless DB is bootstrapped by a FULL rebuild for the sweep-style modes
+        // (Changed / Discover) — but NOT for Paths (#659). `Paths` is a scoped reconcile whose
+        // whole contract is "touch exactly the supplied paths"; a full rebuild would index
+        // the entire repository instead, so a scoped pass on a not-yet-initialized index
+        // DEFERS (its caller — the CLI / an edit hook — surfaces `EmptyIndexRefused` as
+        // "run `rag-rat index` first"), exactly like the #427 first-time-empty deferral.
+        let uninitialized = !config.database.exists()
+            || Self::migration_check(&config.database)?.state == schema::SchemaState::Missing;
+        if uninitialized {
+            if mode == IndexMode::Paths {
+                return Err(crate::index::EmptyIndexRefused {
+                    root: config.root.display().to_string(),
+                }
+                .into());
+            }
             return Self::rebuild_with_progress(config, progress).map(|db| (db, true));
         }
 
@@ -162,6 +198,19 @@ impl IndexDatabase {
         let repo_generation_file_count =
             db.repo_generation_file_count(!active_base_scope_discovered)?;
         if repo_generation_file_count == 0 && !active_base_scope_discovered {
+            // A repo registered in a SHARED/global DB but not yet indexed reaches here with zero
+            // rows: another repo created the DB file (so the missing-DB/schema guard above passed)
+            // and this repo has files on disk (so the #427 first-time-empty check let it through).
+            // For the sweep modes that means "bootstrap it" — a full rebuild. But `Paths` must
+            // NEVER rebuild the WHOLE repository for a command like `index --paths
+            // src/a.rs`; it DEFERS exactly like the missing-DB case above, so the
+            // caller surfaces "run `rag-rat index` first" (#659 review).
+            if mode == IndexMode::Paths {
+                return Err(crate::index::EmptyIndexRefused {
+                    root: config.root.display().to_string(),
+                }
+                .into());
+            }
             return Self::rebuild_with_progress(config, progress).map(|db| (db, true));
         }
         // A commit advances HEAD before committed-scope rows have been stamped for it. Likewise, a
@@ -170,11 +219,21 @@ impl IndexDatabase {
         // and restamp the generation for the active HEAD/target fingerprint (#459 review).
         let active_scope_incomplete =
             !active_base_scope_discovered || scoped_file_count < repo_generation_file_count;
-        let effective_mode = if active_scope_incomplete && mode == IndexMode::Changed {
-            IndexMode::Discover
-        } else {
-            mode
-        };
+        // Both the git-status `Changed` mode AND the explicit-path `Paths` mode (#659) index only a
+        // subset; when the active base scope is INCOMPLETE — a commit advanced HEAD but the
+        // existing committed rows are still keyed to the old sha, or a target-set change
+        // staled the marker — that subset alone would leave every UNCHANGED file absent
+        // from the new scope, so queries would suddenly lose most of the repository.
+        // Promote to `Discover` (which restamps/carries the committed rows onto the current
+        // HEAD/target fingerprint, #459) to complete the scope; the named paths are a
+        // subset discovery already covers. On a COMPLETE scope, `Paths` keeps its scoped
+        // behavior.
+        let effective_mode =
+            if active_scope_incomplete && matches!(mode, IndexMode::Changed | IndexMode::Paths) {
+                IndexMode::Discover
+            } else {
+                mode
+            };
         progress(IndexProgress::Started {
             database: config.database.clone(),
             mode: effective_mode,
@@ -198,19 +257,21 @@ impl IndexDatabase {
         // is the work the audit found holding the writer lock for time proportional to repo
         // size (unbounded in Discover mode); hoisting it is the entire point of the patch.
         let prepare_started = std::time::Instant::now();
-        let prepared = match db.prepare_incremental_pass(config, effective_mode, progress) {
-            Ok(prepared) => prepared,
-            Err(err) => {
-                // Prepare failed off the lock (e.g. an unreadable changed file). JOIN the pending
-                // git-history worker before bailing, so its (possibly full `git log`) scan does not
-                // detach and keep burning CPU/IO after the failed pass — matching the pre-hoist
-                // error path, which joined the handle before returning.
-                if let Some(handle) = git_history_handle {
-                    let _ = join_git_history_prepare(handle);
-                }
-                return Err(err);
-            },
-        };
+        let prepared =
+            match db.prepare_incremental_pass(config, effective_mode, explicit_paths, progress) {
+                Ok(prepared) => prepared,
+                Err(err) => {
+                    // Prepare failed off the lock (e.g. an unreadable changed file). JOIN the
+                    // pending git-history worker before bailing, so its
+                    // (possibly full `git log`) scan does not detach and keep
+                    // burning CPU/IO after the failed pass — matching the pre-hoist
+                    // error path, which joined the handle before returning.
+                    if let Some(handle) = git_history_handle {
+                        let _ = join_git_history_prepare(handle);
+                    }
+                    return Err(err);
+                },
+            };
         // Join the git-history prepare thread OUTSIDE the write lock too — a thread `join()` must
         // not sit inside `BEGIN IMMEDIATE`. The apply below still revalidates the append plan under
         // the lock, preserving the git-history freshness invariant.
@@ -572,6 +633,7 @@ impl IndexDatabase {
         &self,
         config: &Config,
         mode: IndexMode,
+        explicit_paths: Option<&[PathBuf]>,
         progress: &mut F,
     ) -> anyhow::Result<PreparedIncrementalPass>
     where
@@ -580,23 +642,36 @@ impl IndexDatabase {
         progress(IndexProgress::Discovering);
         match mode {
             // Changed mode never carries: it only sees working-tree dirt, and a stale base-scope
-            // marker promotes a HEAD move to Discover (#459), where the carry lives.
+            // marker promotes a HEAD move to Discover (#459), where the carry lives. Its change set
+            // is the git-status walk; `Paths` mode reuses the SAME preparation over an explicit
+            // caller-supplied list instead (#659), and likewise never carries.
             IndexMode::Changed => {
                 let changes = git_changed_paths(&config.root)?;
+                // `changes.changed` IS the full dirty set (git status), so a dirty `Cargo.toml` is
+                // already in it; `files` ⊆ `changes.changed`, so this is complete for Changed.
                 let manifest_in_change_set =
                     paths_include_cargo_toml(changes.changed.iter().map(PathBuf::as_path))
                         || paths_include_cargo_toml(changes.deleted.iter().map(PathBuf::as_path));
                 let files = collect_changed_index_files(config, &changes)?;
-                let files = self.assign_file_scopes(files, &changes);
-                let deleted = changes.deleted.clone();
-                progress(IndexProgress::Discovered { files: files.len() });
-                let prepared_files = prepare_files_with_progress(&files, progress, 0, files.len())?;
-                Ok(PreparedIncrementalPass {
+                self.prepare_from_files_and_changes(
+                    files,
+                    changes,
                     manifest_in_change_set,
-                    carried_ids: Vec::new(),
-                    prepared_files,
-                    deleted,
-                })
+                    progress,
+                )
+            },
+            IndexMode::Paths => {
+                // The builder reports whether a supplied path is a `Cargo.toml` — a non-target file
+                // dropped from `files`, but still a package-map refresh signal even when CLEAN /
+                // committed (this mode reconciles committed changes) (#659 review).
+                let (files, changes, manifest_in_change_set) =
+                    explicit_index_files_and_changes(self, config, explicit_paths.unwrap_or(&[]))?;
+                self.prepare_from_files_and_changes(
+                    files,
+                    changes,
+                    manifest_in_change_set,
+                    progress,
+                )
             },
             // The manifest flag also consults the discovery plan's file list, so a NEW (untracked,
             // not-yet-committed) `Cargo.toml` is caught even though git status would not list it as
@@ -629,6 +704,35 @@ impl IndexDatabase {
             },
             IndexMode::Full => unreachable!("full mode is handled by rebuild_with_progress"),
         }
+    }
+
+    /// Prepare a no-carry incremental pass from an already-collected `files` list and its
+    /// dirty/deleted `changes` — shared by `Changed` (git-status walk → collect) and `Paths`
+    /// (explicit list) (#659). `changes.changed` classifies which of `files` are working-tree DIRT
+    /// for [`Self::assign_file_scopes`]; a file present in `files` but ABSENT from
+    /// `changes.changed` is committed-scoped (how `Paths` keeps a clean/committed supplied file
+    /// out of an overlay row). Content-hash staleness is decided later (an unchanged file
+    /// prepares but writes nothing); `deleted` paths are tombstoned at apply time.
+    fn prepare_from_files_and_changes<F>(
+        &self,
+        files: Vec<IndexFile>,
+        changes: GitChangedPaths,
+        manifest_in_change_set: bool,
+        progress: &mut F,
+    ) -> anyhow::Result<PreparedIncrementalPass>
+    where
+        F: FnMut(IndexProgress),
+    {
+        let files = self.assign_file_scopes(files, &changes);
+        let deleted = changes.deleted.clone();
+        progress(IndexProgress::Discovered { files: files.len() });
+        let prepared_files = prepare_files_with_progress(&files, progress, 0, files.len())?;
+        Ok(PreparedIncrementalPass {
+            manifest_in_change_set,
+            carried_ids: Vec::new(),
+            prepared_files,
+            deleted,
+        })
     }
 
     /// APPLY phase (#560): the WRITE half of an incremental/discover pass, run inside the caller's
@@ -837,28 +941,31 @@ impl IndexDatabase {
         // and skip both guards below. The mtime guard (changed-file overwrites) applies in
         // either hoisted mode.
         let guard_concurrent_writes = mode_guard.is_some();
-        // The fs-deletion restore recheck applies ONLY in Changed mode. There, `deleted` is purely
-        // git file-deletions and the target/ignore set is stable within the pass, so "exists on
-        // disk" means "restored AND still in scope". Discover's `deleted` also carries
-        // SEMANTIC deletions (a path that left the target set or became gitignored but
-        // still exists on disk) which MUST be tombstoned regardless of disk existence — and
-        // a genuine fs-restore in Discover self-heals on the next discover pass anyway.
-        let revalidate_fs_deletions = mode_guard == Some(IndexMode::Changed);
+        // The fs-deletion restore recheck applies only to the fs-deletion modes (Changed and
+        // Paths). There, `deleted` is purely file-deletions and the target/ignore set is
+        // stable within the pass, so "exists on disk" means "restored AND still in scope".
+        // Discover's `deleted` also carries SEMANTIC deletions (a path that left the target
+        // set or became gitignored but still exists on disk) which MUST be tombstoned
+        // regardless of disk existence — and a genuine fs-restore in Discover self-heals on
+        // the next discover pass anyway.
+        let revalidate_fs_deletions = mode_guard.is_some_and(IndexMode::revalidates_fs_deletions);
         let mut deleted_count = 0usize;
         for path in deleted {
             // A git-deleted path may have been RESTORED on disk during the off-lock window (#561).
             // Tombstoning it would HIDE it — and a file restored to HEAD-clean content is in no
             // later CHANGED set and the stale-overlay heal skips `kind='deleted'` rows,
             // so it would not self-heal until a discover pass. Skip the tombstone only when the
-            // path is a regular FILE on disk again: a directory (or other non-file)
-            // recreated at that path is not a restored source file and would never be
-            // re-indexed, so it must still tombstone.
+            // path is a regular FILE on disk again — via `symlink_metadata` (does NOT follow), so a
+            // SYMLINK or a directory recreated at that path is NOT treated as a restored source
+            // file (the walker skips both and would never re-index them), and its stale
+            // row still tombstones (#659 review).
             if revalidate_fs_deletions
                 && self
                     .storage
                     .source_root()
                     .map(|root| root.join(path))
-                    .is_some_and(|full| full.is_file())
+                    .and_then(|full| full.symlink_metadata().ok())
+                    .is_some_and(|meta| meta.is_file())
             {
                 continue;
             }
@@ -895,6 +1002,32 @@ impl IndexDatabase {
                     &prepared_file.file.worktree_id,
                 )?
                 && row_modified_at_ms > content.modified_at_ms
+            {
+                continue;
+            }
+            // True no-op skip for the explicit-path flow ONLY (#659 review): `index --paths`
+            // prepares EVERY supplied file — including clean/reverted ones — to scope
+            // them, so without this an unchanged file would be needlessly
+            // removed+reinserted, churning its id and cascade-dropping its chunk
+            // embeddings. Compares the FULL `(sha256, language, kind)` identity, not sha alone: a
+            // TARGET-identity drift with unchanged bytes (an extension-precedence change
+            // re-languages the path) must still reindex, exactly as discovery's
+            // staleness does — a sha-only skip would strand the old parse. Gated to
+            // `Paths`: the heal / worktree-overlay callers (`mode_guard = None`)
+            // deliberately re-index UNCHANGED content to upgrade a stale anchor/schema
+            // format the sha doesn't capture, and Changed/Discover never prepare an
+            // unchanged file — so neither wants this skip.
+            if mode_guard == Some(IndexMode::Paths)
+                && let Ok(content) = &prepared_file.prepared
+                && self.scope_row_identity(
+                    &prepared_file.file.relative_path,
+                    &prepared_file.file.commit_sha,
+                    &prepared_file.file.worktree_id,
+                )? == Some((
+                    content.sha256.clone(),
+                    prepared_file.file.language.as_str().to_string(),
+                    prepared_file.file.kind.as_str().to_string(),
+                ))
             {
                 continue;
             }

--- a/crates/rag-rat-core/src/index/meta.rs
+++ b/crates/rag-rat-core/src/index/meta.rs
@@ -114,6 +114,26 @@ impl IndexDatabase {
         self.set_repo_meta_if_changed(BASE_SCOPE_DISCOVERED_META, &marker)
     }
 
+    /// Whether `branch_targets` (a linked overlay's config targets) MAY differ from the config the
+    /// base scope was indexed with — the cheap gate for the per-file target-identity drift scan
+    /// ([`Self::base_scope_target_drift`]). The base scope's discovery marker embeds its target
+    /// fingerprint; when it equals the branch's, no file can re-language, so the O(base-files) scan
+    /// is skipped — the common no-divergent-branch-config case that would otherwise re-scan every
+    /// base file on every overlay refresh × worktree, undoing the #577 event-scoping win.
+    /// Conservatively returns `true` when the marker is absent (a match can't be proven).
+    pub(super) fn overlay_targets_may_drift(
+        &self,
+        branch_targets: &[ResolvedTarget],
+    ) -> anyhow::Result<bool> {
+        let Some(marker) = self.repo_meta(BASE_SCOPE_DISCOVERED_META)? else {
+            return Ok(true);
+        };
+        // Marker layout: `generation=…;<scope>;targets=<hex fingerprint>` — the fingerprint is the
+        // trailing segment (a hex sha256, so it holds no `;targets=`).
+        let base_fingerprint = marker.rsplit_once(";targets=").map(|(_, fingerprint)| fingerprint);
+        Ok(base_fingerprint != Some(target_scope_fingerprint(branch_targets).as_str()))
+    }
+
     fn base_scope_discovery_marker(&self, targets: &[ResolvedTarget]) -> Option<String> {
         let scope = if self.active_commit_sha.is_empty() {
             if self.active_worktree_id.is_empty() {

--- a/crates/rag-rat-core/src/index/mod.rs
+++ b/crates/rag-rat-core/src/index/mod.rs
@@ -203,6 +203,14 @@ pub enum IndexProgress {
 #[serde(rename_all = "snake_case")]
 pub enum IndexMode {
     Changed,
+    /// Reconcile exactly an explicitly-supplied set of candidate paths (#659) — the substrate for
+    /// edit-driven reindex. Like `Changed` (working-tree-scoped, content-hash decides staleness, no
+    /// carry), but the change set comes from the caller's path list rather than a git-status walk,
+    /// so it also sees committed changes the status walk would not. The path list is threaded
+    /// alongside the mode (`explicit_paths`) rather than carried in the variant, so `IndexMode`
+    /// stays `Copy` (it is copied at several hot sites in the pass). Unlike `Changed`, it never
+    /// promotes to `Discover` on an incomplete base scope — it is deliberately scoped.
+    Paths,
     Discover,
     Full,
 }
@@ -211,9 +219,21 @@ impl IndexMode {
     pub fn label(self) -> &'static str {
         match self {
             Self::Changed => "changed files",
+            Self::Paths => "explicit paths",
             Self::Discover => "discovery",
             Self::Full => "full rebuild",
         }
+    }
+
+    /// Whether a tombstone in this mode's `deleted` set is a pure FILESYSTEM deletion (the path
+    /// left the tree) rather than a SEMANTIC one (the path left the target set / became ignored
+    /// but still exists). Only fs-deletion modes get the #561 restore recheck at apply time —
+    /// see `write_prepared_incremental_files`. `Changed` and `Paths` both derive `deleted`
+    /// purely from "the file is not on disk", so both revalidate; `Discover`'s plan also
+    /// tombstones semantic deletions that must land regardless of disk existence, so it does
+    /// not.
+    pub(crate) fn revalidates_fs_deletions(self) -> bool {
+        matches!(self, Self::Changed | Self::Paths)
     }
 }
 

--- a/crates/rag-rat-core/src/index/prep.rs
+++ b/crates/rag-rat-core/src/index/prep.rs
@@ -149,6 +149,220 @@ pub(crate) fn collect_changed_index_files(
     Ok(files)
 }
 
+/// Build the `(files, changes)` for an EXPLICIT candidate path list — the `index --paths` entry
+/// point (#659). Unlike [`collect_changed_index_files`] + a raw [`GitChangedPaths`], the explicit
+/// list can name CLEAN / already-committed files (a caller — a git hook, an agent edit hook — knows
+/// what it touched, so this "also sees committed changes" the git-status walk misses). So it does
+/// NOT put every supplied file in `changed`: it builds an `IndexFile` for every supplied indexable
+/// path, but `changed` holds ONLY the DIRTY subset (cross-referenced against the actual git
+/// status), because [`IndexDatabase::assign_file_scopes`] reads `changed` as "working-tree dirt" —
+/// a clean file left OUT of `changed` is correctly scoped to the COMMITTED scope, not shadowed by
+/// an overlay row. Each supplied path (absolute, or already `config.root`-relative) is:
+///  1. normalized to a `config.root`-relative path — dropped if NOT under `config.root` (a
+///     linked-worktree edit is routed to the overlay path by the caller, not fed here) or if it
+///     escapes the tree once symlinks and `..` are resolved (see [`resolves_within_root`] — a
+///     lexical check alone accepts both `<root>/src/../../outside.rs` and a path through an in-repo
+///     symlink pointing outside);
+///  2. dropped if ignored by the repo's `.gitignore` rules + floor, or not a configured target;
+///  3. an existing target FILE becomes an `IndexFile` (content hash decides staleness downstream,
+///     so an unchanged path is a no-op), added to `changed` ONLY if git status reports it dirty; a
+///     path that no longer exists goes to `deleted` (tombstoned, keyed by path+scope — a no-op if
+///     it was never indexed).
+pub(crate) fn explicit_index_files_and_changes(
+    db: &IndexDatabase,
+    config: &Config,
+    paths: &[PathBuf],
+) -> anyhow::Result<(Vec<IndexFile>, GitChangedPaths, bool)> {
+    let has_base_commit = !db.active_commit_sha.is_empty();
+    let target_dirs = config.target_directories();
+    let ignore = crate::index::ignore_rules::IgnoreMatcher::compile(&config.root, &target_dirs);
+    // The actual working-tree-dirty set: a supplied path is overlay-scoped ONLY if it is genuinely
+    // dirt here; a supplied CLEAN/committed path is left out of `changed` → committed-scoped.
+    //
+    // Whether a git-status FAILURE is fatal depends on whether a base commit exists. WITH a base
+    // commit, `assign_file_scopes` uses this set to split dirty vs committed, so an empty set from
+    // a swallowed error would misclassify a DIRTY supplied file as clean and write its
+    // uncommitted bytes into the committed scope — corruption; PROPAGATE (`?`). WITHOUT a base
+    // commit (a non-git or unborn checkout, where `git_changed_paths` errors on discovery),
+    // `assign_file_scopes` scopes EVERY file as working-tree dirt regardless of this set, so
+    // the classification is moot — tolerate the error.
+    let dirty = if has_base_commit {
+        crate::index::git_changed_paths(&config.root)?
+    } else {
+        crate::index::git_changed_paths(&config.root).unwrap_or_default()
+    };
+    let canonical_root = config.root.canonicalize().unwrap_or_else(|_| config.root.clone());
+    let mut files = Vec::new();
+    let mut changes = GitChangedPaths::default();
+    // Whether a supplied path is a `Cargo.toml` (present, or a real deletion) — the package-map
+    // refresh signal. A manifest is not itself a target file, so it never reaches `files`; the
+    // signal must be carried out separately (crate names / path-deps must refresh even for a
+    // CLEAN/committed manifest named on the command line — #659 review).
+    let mut manifest_in_change_set = false;
+    for path in paths {
+        let raw_relative = if path.is_absolute() {
+            match path.strip_prefix(&config.root) {
+                Ok(relative) => relative.to_path_buf(),
+                // A LEXICAL strip fails when the caller spells the path (or the checkout root)
+                // through a DIFFERENT symlink than `config.root` (macOS `/tmp` vs `/private/tmp`,
+                // a symlinked editor `$PWD`), even for a file genuinely inside the checkout. Retry
+                // against the CANONICAL root before giving up, so the valid edit is not silently
+                // dropped; a strip that still fails is a real outside / linked-worktree path the
+                // caller routes elsewhere (#659 review).
+                Err(_) => {
+                    let Some(relative) =
+                        canonicalize_nearest_ancestor(path).and_then(|canonical| {
+                            canonical.strip_prefix(&canonical_root).ok().map(Path::to_path_buf)
+                        })
+                    else {
+                        continue;
+                    };
+                    relative
+                },
+            }
+        } else {
+            path.clone()
+        };
+        // NORMALIZE the relative path (resolve `.` / `..` lexically) BEFORE it is used for target
+        // matching, dirty-status lookup, and the persisted `files.path` key — the raw spelling
+        // would otherwise let `src/../outside.rs` match the `src` target while resolving
+        // elsewhere, or `src/../src/a.rs` miss its `dirty.changed` entry and write under a
+        // duplicate key. `None` means the path escaped the root via `..`; skip it.
+        let Some(relative) = lexically_normalized_within_root(&raw_relative) else {
+            continue;
+        };
+        let full_path = config.root.join(&relative);
+        // Containment: the path must stay under the root after resolving SYMLINKS (lexical
+        // normalization can't see them) — a path through an in-repo symlink pointing outside
+        // (`src/link/foo.rs`, `link` → /outside) resolves outside and would make `prepare_files`
+        // read an external file. Like the symlink/ignore skips below, an out-of-root path must NOT
+        // be INDEXED, but must NOT short-circuit the deletion branch either: a regular file
+        // REPLACED by an outside-pointing symlink must still TOMBSTONE its stale row (a
+        // discover pass would drop it). So fold containment into `is_present` rather than
+        // `continue`ing; a never-indexed outside path stays a no-op (#659 review).
+        let within_root = resolves_within_root(&full_path, &canonical_root);
+        // Match the walker (`walker::walk_dir`), which SKIPS a symlink ENTRY and never descends
+        // into it: a supplied path that crosses a symlink at ANY component — the leaf
+        // (`src/link.rs`) OR an ancestor directory (`src/link/a.rs`, `src/link` → another
+        // in-repo dir) — is likewise not indexable, or `index --paths` writes an index row
+        // under a symlink spelling a full/discover pass never produces (a duplicate of the
+        // real file's row). `symlink_metadata` per ancestor does NOT follow, so it catches
+        // a symlinked component; a missing leaf simply isn't a symlink. `relative` is
+        // lexically normalized (Normal components only), so walking it from the root
+        // reconstructs the real ancestor chain (#659 review).
+        let mut probe = config.root.clone();
+        let crosses_symlink = relative.components().any(|component| {
+            probe.push(component);
+            probe.symlink_metadata().is_ok_and(|meta| meta.file_type().is_symlink())
+        });
+        // A path that ESCAPES the root, CROSSES a symlink, or is not a regular file is NOT
+        // indexable; an existing indexed row for one (a regular file since replaced by a
+        // symlink, in- or out-of-repo) still falls through to the deletion branch below and
+        // is TOMBSTONED, while an unindexed such path stays a no-op. `within_root`
+        // short-circuits before `is_file` (which follows symlinks), so an escaping
+        // symlink's external target is never even stat'd.
+        let is_present = within_root && !crosses_symlink && full_path.is_file();
+        // Gate ignore on PRESENCE (dir-ness `false` is sound for the floor's component-name check
+        // and for file globs — matches the watcher's classifier). An IGNORED path is never INDEXED
+        // (the walker skips it), but a MISSING, previously-indexed path must still fall through to
+        // the deletion branch below and be TOMBSTONED even if its path now matches an ignore rule:
+        // the file is gone, so a discover pass would remove the stale row, and the ignore rule does
+        // not resurrect it (`index --paths src/gen/a.rs` after deleting an indexed file under a
+        // now-ignored dir). A PRESENT file that just became ignored is a SEMANTIC deletion Paths
+        // defers to discovery — a `.gitignore` edit fires a discover pass — matching Changed's
+        // fs-deletion-only posture (#659 review).
+        if is_present && ignore.is_ignored(&full_path, false) {
+            continue;
+        }
+        // A supplied `Cargo.toml` signals a package-map refresh whether it is present
+        // (added/edited) or MISSING (deleted) — it is not a source target, so it flows no
+        // further than this signal. NOT gated on a git-confirmed deletion: an UNTRACKED or
+        // NON-GIT manifest that was scanned into `packages` and then deleted is reported by
+        // neither git status nor a `files` row, yet the caller explicitly NAMED it, so its
+        // stale package/import rows must still be re-scanned (#659 review). Harmless for a
+        // typo'd nonexistent path — `refresh_packages` just re-scans and writes back the
+        // same rows; this is the one-shot `index --paths` CLI path (never the
+        // idle watcher), so an occasional redundant refresh is fine.
+        if relative.file_name() == Some(std::ffi::OsStr::new("Cargo.toml")) {
+            manifest_in_change_set = true;
+        }
+        if is_present {
+            let Some((language, kind)) = target_for_path(config, &relative) else {
+                continue; // wrong extension / outside a configured target directory
+            };
+            if dirty.changed.contains(&relative) {
+                changes.changed.insert(relative.clone());
+            }
+            files.push(IndexFile {
+                full_path,
+                relative_path: relative,
+                language,
+                kind,
+                commit_sha: String::new(),
+                worktree_id: String::new(),
+            });
+        } else if dirty.deleted.contains(&relative) || db.path_has_indexed_row(&relative)? {
+            // Tombstone a vanished path ONLY when it was really indexed (git-confirmed deletion, or
+            // an existing indexed row). A never-indexed typo / out-of-target temp file must not get
+            // a spurious `kind='deleted'` overlay row, which would shadow a real
+            // committed file that later appears at that path (#659 review).
+            changes.deleted.insert(relative);
+        }
+    }
+    Ok((files, changes, manifest_in_change_set))
+}
+
+/// Lexically resolve `.` / `..` in a `config.root`-relative path, returning `None` if it escapes
+/// the root (a leading/interior `..` that pops above the root) or is not relative. This is
+/// symlink-blind (a symlink escape is caught separately by [`resolves_within_root`]); its job is to
+/// produce the CANONICAL RELATIVE SPELLING used for target/dirty/persistence so `src/../src/a.rs`
+/// collapses to `src/a.rs` and `src/../outside.rs` to `outside.rs` (then dropped by the target
+/// filter).
+fn lexically_normalized_within_root(relative: &Path) -> Option<PathBuf> {
+    let mut out = PathBuf::new();
+    for component in relative.components() {
+        match component {
+            std::path::Component::Normal(name) => out.push(name),
+            std::path::Component::CurDir => {},
+            std::path::Component::ParentDir =>
+                if !out.pop() {
+                    return None; // escaped above the root
+                },
+            std::path::Component::RootDir | std::path::Component::Prefix(_) => return None,
+        }
+    }
+    Some(out)
+}
+
+/// Whether `full_path` stays under `canonical_root` after resolving `..` and symlinks. Rejects both
+/// `..`-escapes and in-repo-symlink escapes; the lexical prefix check alone would accept both.
+/// Rejects a path where nothing on the chain resolves (containment unverifiable).
+fn resolves_within_root(full_path: &Path, canonical_root: &Path) -> bool {
+    canonicalize_nearest_ancestor(full_path)
+        .is_some_and(|canonical| canonical.starts_with(canonical_root))
+}
+
+/// Canonicalize `path` by canonicalizing its nearest EXISTING ancestor (the file — or even its
+/// parent dir — may be gone in a deletion, or not yet created) and re-appending the missing suffix,
+/// so the result is SYMLINK-RESOLVED even for a path that doesn't exist. `None` when nothing on the
+/// ancestor chain canonicalizes (effectively unreachable for a real absolute path — the filesystem
+/// root always resolves). Shared by containment ([`resolves_within_root`]), the absolute-path
+/// rebase in [`explicit_index_files_and_changes`] (a symlinked checkout-root spelling must compare
+/// canonically or a valid in-repo edit is dropped), and the worktree routing in `watch::overlay`.
+pub(crate) fn canonicalize_nearest_ancestor(path: &Path) -> Option<PathBuf> {
+    let mut ancestor = path;
+    loop {
+        if let Ok(canonical) = ancestor.canonicalize() {
+            let suffix = path.strip_prefix(ancestor).unwrap_or_else(|_| Path::new(""));
+            return Some(canonical.join(suffix));
+        }
+        match ancestor.parent() {
+            Some(parent) if parent != ancestor => ancestor = parent,
+            _ => return None,
+        }
+    }
+}
+
 pub(crate) fn spawn_git_history_prepare(
     root: &Path,
 ) -> JoinHandle<anyhow::Result<git_history::PreparedGitHistory>> {

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/index_paths.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/index_paths.rs
@@ -1,0 +1,1017 @@
+//! `index --paths` — the explicit-path scoped reconcile (#659). Reconciles exactly the supplied
+//! candidate paths (content-hash decides staleness), leaving everything else untouched; ignored /
+//! out-of-target / unchanged paths are no-ops; a supplied path that no longer exists is tombstoned;
+//! and a first-time-empty repo defers (#427) exactly like the other modes.
+
+use super::*;
+
+/// Whether a symbol with `name` is currently indexed. POSITIVE queries only — `symbol_candidates`
+/// lazily heals a zero-hit, so a test that asserted a symbol's ABSENCE could self-heal it into
+/// existence and pass vacuously. Every assertion below checks a symbol that SHOULD be present.
+fn symbol_present(db: &IndexDatabase, name: &str) -> bool {
+    let selector = crate::query::symbol::SymbolSelector {
+        logical_symbol_id: None,
+        symbol_id: None,
+        symbol_path: None,
+        symbol: Some(name.to_string()),
+        language: None,
+        allow_ambiguous: true,
+        limit: 10,
+    };
+    !db.symbol_candidates(&selector, false).unwrap().candidates.is_empty()
+}
+
+#[test]
+fn index_paths_reconciles_only_the_supplied_path() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/a.rs"), "pub fn alpha_v1() {}\n").unwrap();
+    fs::write(root.join("src/b.rs"), "pub fn beta_v1() {}\n").unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let _ = IndexDatabase::rebuild(&config).unwrap();
+    assert_eq!(IndexDatabase::open(&config.database).unwrap().indexed_file_count().unwrap(), 2);
+
+    // Edit the supplied file AND drop a brand-new target file that is NOT supplied. Reconciling
+    // only a.rs must re-index it while leaving c.rs undiscovered — proving the pass touches
+    // EXACTLY the supplied set, not "whatever is on disk". (Heal-proof: `indexed_file_count` is
+    // a plain count, and the alpha_v2 lookup is a positive hit on a now-clean file, so no
+    // lazy/stale heal fires.)
+    fs::write(root.join("src/a.rs"), "pub fn alpha_v2() {}\n").unwrap();
+    fs::write(root.join("src/c.rs"), "pub fn gamma_v1() {}\n").unwrap();
+    let db = IndexDatabase::index_paths(&config, &[root.join("src/a.rs")]).unwrap();
+
+    assert!(symbol_present(&db, "alpha_v2"), "the supplied path was reconciled to its new content");
+    assert_eq!(
+        db.indexed_file_count().unwrap(),
+        2,
+        "a new file that was NOT supplied is not indexed — only the supplied path is touched",
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn index_paths_is_a_noop_for_ignored_out_of_target_and_unchanged_paths() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/a.rs"), "pub fn alpha_v1() {}\n").unwrap();
+    // `secret.rs` is gitignored (the `ignore` crate honors `.gitignore` without a git repo), so the
+    // rebuild never indexes it; `README.md` is outside the `src` target.
+    fs::write(root.join(".gitignore"), "secret.rs\n").unwrap();
+    fs::write(root.join("src/secret.rs"), "pub fn secret_v1() {}\n").unwrap();
+    fs::write(root.join("README.md"), "# readme\n").unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let _ = IndexDatabase::rebuild(&config).unwrap();
+    let files_before = IndexDatabase::open(&config.database).unwrap().indexed_file_count().unwrap();
+
+    // Supply an unchanged target file, an ignored file, and an out-of-target file — all no-ops.
+    let db = IndexDatabase::index_paths(&config, &[
+        root.join("src/a.rs"),      // unchanged
+        root.join("src/secret.rs"), // ignored
+        root.join("README.md"),     // out of target
+    ])
+    .unwrap();
+
+    assert_eq!(
+        db.indexed_file_count().unwrap(),
+        files_before,
+        "ignored / out-of-target / unchanged paths add nothing",
+    );
+    assert!(symbol_present(&db, "alpha_v1"), "the unchanged target file is intact");
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn index_paths_tombstones_a_supplied_path_that_no_longer_exists() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/a.rs"), "pub fn alpha_v1() {}\n").unwrap();
+    fs::write(root.join("src/b.rs"), "pub fn beta_v1() {}\n").unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let _ = IndexDatabase::rebuild(&config).unwrap();
+    assert_eq!(IndexDatabase::open(&config.database).unwrap().indexed_file_count().unwrap(), 2);
+
+    // Delete b.rs on disk, then supply it — a vanished path is tombstoned.
+    fs::remove_file(root.join("src/b.rs")).unwrap();
+    let db = IndexDatabase::index_paths(&config, &[root.join("src/b.rs")]).unwrap();
+
+    assert_eq!(db.indexed_file_count().unwrap(), 1, "the deleted supplied path is tombstoned");
+    assert!(symbol_present(&db, "alpha_v1"), "the un-supplied file is untouched by the tombstone");
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn reindex_paths_routes_a_linked_worktree_path_to_its_overlay_not_the_base() {
+    // The routing decision (#659): a path under the base checkout stays a base path; a path under a
+    // LINKED worktree routes to that checkout's overlay. This is load-bearing — `config.root` is
+    // the main checkout, so a base pass would `strip_prefix` the linked path away and silently
+    // drop the edit. White-boxes the partition the `reindex_paths` orchestration drives.
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(main.join("src/a.rs"), "pub fn base_marker() {}\n").unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let config = source_config(main.clone(), Language::Rust);
+
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    fs::write(linked.join("src/a.rs"), "pub fn branch_marker() {}\n").unwrap();
+
+    let partition = crate::watch::partition_paths_by_worktree(&config, &[
+        main.join("src/a.rs"),
+        linked.join("src/a.rs"),
+    ]);
+    assert_eq!(
+        partition.base_paths,
+        vec![main.join("src/a.rs")],
+        "only the base-checkout path is a base path — the linked path must NOT fall through to \
+         the base pass (which would drop it)",
+    );
+    assert_eq!(
+        partition.linked_roots.len(),
+        1,
+        "the linked path routes to exactly its checkout overlay",
+    );
+    let root = partition.linked_roots.iter().next().unwrap();
+    assert!(
+        linked.canonicalize().is_ok_and(|canonical| *root == canonical),
+        "the routed root is the canonical linked checkout: {root:?}",
+    );
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}
+
+#[test]
+fn index_paths_rejects_a_path_that_escapes_the_repo_root() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/a.rs"), "pub fn alpha_v1() {}\n").unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let _ = IndexDatabase::rebuild(&config).unwrap();
+    let before = IndexDatabase::open(&config.database).unwrap().indexed_file_count().unwrap();
+
+    // A file OUTSIDE the repo, reached by `..` traversal that STARTS with a configured target dir
+    // (`src/`) so the lexical target filter would accept the spelling — the exact escape #659's
+    // review flagged. `<root>/src/../../<sibling>/outside.rs` normalizes to the intruder, but the
+    // `..` guard rejects it before anything outside `config.root` is read or tombstoned.
+    let intruder_dir = root
+        .parent()
+        .unwrap()
+        .join(format!("{}-intruder", root.file_name().unwrap().to_string_lossy()));
+    fs::create_dir_all(&intruder_dir).unwrap();
+    fs::write(intruder_dir.join("outside.rs"), "pub fn intruder() {}\n").unwrap();
+    let escaping = root
+        .join("src")
+        .join("..")
+        .join("..")
+        .join(intruder_dir.file_name().unwrap())
+        .join("outside.rs");
+    assert!(escaping.is_file(), "the escaping spelling really does resolve to the outside file");
+
+    let db = IndexDatabase::index_paths(&config, &[escaping]).unwrap();
+    assert_eq!(
+        db.indexed_file_count().unwrap(),
+        before,
+        "a path escaping the root via `..` is dropped — nothing outside config.root is indexed",
+    );
+
+    let _ = fs::remove_dir_all(&root);
+    let _ = fs::remove_dir_all(&intruder_dir);
+}
+
+#[test]
+fn reindex_paths_routes_a_deleted_linked_path_whose_parent_dir_is_also_gone() {
+    // A linked-worktree DELETION may remove the file AND its parent directory in one edit. Routing
+    // must still send it to the linked overlay (to tombstone), which means canonicalizing the
+    // NEAREST SURVIVING ancestor — not the immediate (now-absent) parent, whose lexical spelling
+    // could mis-compare against the canonical checkout root and drop the tombstone (#659 review).
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(main.join("src/keep.rs"), "pub fn keep() {}\n").unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let config = source_config(main.clone(), Language::Rust);
+
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    // `linked/src/gone/` never existed on disk, so a deleted file under it has BOTH its file and
+    // its immediate parent absent; only `linked/src` (and up) survive.
+    let deleted = linked.join("src/gone/x.rs");
+    assert!(!deleted.parent().unwrap().exists(), "the deleted file's parent is absent");
+
+    let partition = crate::watch::partition_paths_by_worktree(&config, &[deleted]);
+    assert!(
+        partition.base_paths.is_empty(),
+        "the deleted linked path must not fall through to the base pass"
+    );
+    assert_eq!(
+        partition.linked_roots.len(),
+        1,
+        "it routes to the linked overlay via the surviving ancestor",
+    );
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}
+
+/// Count `main.files` rows for `path` matching a `commit_sha` predicate — `commit_sha = ''` is a
+/// working-tree/overlay (dirty) row; `commit_sha != ''` is a committed-scope row.
+fn file_rows(config: &Config, path: &str, commit_sha_pred: &str) -> i64 {
+    let conn = rusqlite::Connection::open(&config.database).unwrap();
+    conn.query_row(
+        &format!("SELECT COUNT(*) FROM main.files WHERE path = ?1 AND {commit_sha_pred}"),
+        [path],
+        |row| row.get::<_, i64>(0),
+    )
+    .unwrap()
+}
+
+#[test]
+fn index_paths_completes_the_base_scope_after_a_commit_advances_head() {
+    // A commit advances HEAD but the committed rows are still keyed to the OLD sha, so the active
+    // (new-HEAD) scope is incomplete. A scoped Paths pass over one file must NOT leave every
+    // unchanged file orphaned at the old sha (queries would lose most of the repo) — it promotes to
+    // a discovery that restamps the committed rows onto the new HEAD (#659 review, mirrors
+    // Changed).
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/a.rs"), "pub fn alpha_v1() {}\n").unwrap();
+    fs::write(root.join("src/b.rs"), "pub fn beta() {}\n").unwrap();
+    fs::write(root.join("src/c.rs"), "pub fn gamma() {}\n").unwrap();
+    init_git_repo(&root);
+    run_git(&root, &["add", "."]);
+    run_git(&root, &["commit", "-q", "-m", "A"]);
+    let config = source_config(root.clone(), Language::Rust);
+    let _ = IndexDatabase::rebuild(&config).unwrap(); // indexed at commit A (3 committed files)
+
+    // Advance HEAD: edit a.rs and commit. The committed rows are now stale (keyed to A).
+    fs::write(root.join("src/a.rs"), "pub fn alpha_v2() {}\n").unwrap();
+    run_git(&root, &["add", "."]);
+    run_git(&root, &["commit", "-q", "-m", "B"]);
+
+    let db = IndexDatabase::index_paths(&config, &[root.join("src/a.rs")]).unwrap();
+    assert_eq!(
+        db.indexed_file_count().unwrap(),
+        3,
+        "a HEAD move promotes the scoped pass to complete the scope — b.rs and c.rs are NOT \
+         orphaned",
+    );
+    assert!(symbol_present(&db, "alpha_v2"), "the committed edit is indexed at the new HEAD");
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn index_paths_keeps_a_clean_committed_file_in_the_committed_scope() {
+    // Supplying a CLEAN committed file (scope complete, HEAD unchanged) must reindex it in the
+    // COMMITTED scope, not shadow it with a working-tree overlay row —
+    // `explicit_index_files_and_changes` cross-references git status so a non-dirty path is
+    // left out of the dirty set (#659 review).
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/a.rs"), "pub fn alpha() {}\n").unwrap();
+    init_git_repo(&root);
+    run_git(&root, &["add", "."]);
+    run_git(&root, &["commit", "-q", "-m", "A"]);
+    let config = source_config(root.clone(), Language::Rust);
+    let _ = IndexDatabase::rebuild(&config).unwrap();
+    assert_eq!(
+        file_rows(&config, "src/a.rs", "commit_sha = ''"),
+        0,
+        "clean baseline: no overlay row"
+    );
+
+    // a.rs is clean and committed; supplying it must not create a dirty overlay shadow.
+    let _ = IndexDatabase::index_paths(&config, &[root.join("src/a.rs")]).unwrap();
+    assert_eq!(
+        file_rows(&config, "src/a.rs", "commit_sha = ''"),
+        0,
+        "a clean committed file must NOT gain a working-tree overlay row",
+    );
+    assert!(
+        file_rows(&config, "src/a.rs", "commit_sha != ''") >= 1,
+        "the clean file stays committed-scoped",
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+#[cfg(unix)]
+fn index_paths_rejects_a_path_through_a_symlink_that_escapes_the_root() {
+    // A supplied path can also escape the checkout through an IN-REPO SYMLINK — `src/link/x.rs`
+    // where `link` points OUTSIDE — which a lexical prefix/`..` check accepts but resolves outside.
+    // The canonicalized containment check rejects it, so nothing external is read or indexed (#659
+    // review).
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/a.rs"), "pub fn alpha() {}\n").unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let _ = IndexDatabase::rebuild(&config).unwrap();
+    let before = IndexDatabase::open(&config.database).unwrap().indexed_file_count().unwrap();
+
+    let outside = root
+        .parent()
+        .unwrap()
+        .join(format!("{}-escape", root.file_name().unwrap().to_string_lossy()));
+    fs::create_dir_all(&outside).unwrap();
+    fs::write(outside.join("intruder.rs"), "pub fn intruder() {}\n").unwrap();
+    std::os::unix::fs::symlink(&outside, root.join("src/link")).unwrap();
+    let escaping = root.join("src/link/intruder.rs");
+    assert!(escaping.is_file(), "the symlink really does resolve to the external file");
+
+    let db = IndexDatabase::index_paths(&config, &[escaping]).unwrap();
+    assert_eq!(
+        db.indexed_file_count().unwrap(),
+        before,
+        "a path escaping the root through a symlink indexes nothing outside the checkout",
+    );
+
+    let _ = fs::remove_dir_all(&root);
+    let _ = fs::remove_dir_all(&outside);
+}
+
+/// The `id` of the (single) committed row for `path`, for churn assertions.
+fn committed_row_id(config: &Config, path: &str) -> i64 {
+    let conn = rusqlite::Connection::open(&config.database).unwrap();
+    conn.query_row(
+        "SELECT id FROM main.files WHERE path = ?1 AND commit_sha != '' LIMIT 1",
+        [path],
+        |row| row.get::<_, i64>(0),
+    )
+    .unwrap()
+}
+
+#[test]
+fn index_paths_does_not_churn_an_unchanged_files_row() {
+    // Reconciling a CLEAN/unchanged supplied file must be a true no-op — not a remove+reinsert that
+    // churns the row id and cascade-drops its chunk embeddings (#659 review). The row id is stable.
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/a.rs"), "pub fn alpha() {}\n").unwrap();
+    init_git_repo(&root);
+    run_git(&root, &["add", "."]);
+    run_git(&root, &["commit", "-q", "-m", "A"]);
+    let config = source_config(root.clone(), Language::Rust);
+    let _ = IndexDatabase::rebuild(&config).unwrap();
+    let id_before = committed_row_id(&config, "src/a.rs");
+
+    // a.rs is clean; reconciling it changes nothing.
+    let _ = IndexDatabase::index_paths(&config, &[root.join("src/a.rs")]).unwrap();
+    assert_eq!(
+        committed_row_id(&config, "src/a.rs"),
+        id_before,
+        "an unchanged supplied file keeps its row id — no remove+reinsert churn",
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn index_paths_normalizes_internal_parent_dir_components() {
+    // A supplied path with an INTERNAL `..` must be normalized before target/dirty/persistence use:
+    // `src/../src/a.rs` collapses to `src/a.rs` (reindexed under the real key, not a duplicate),
+    // and `src/../outside.rs` collapses to `outside.rs` and is dropped as out-of-target (#659
+    // review).
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/a.rs"), "pub fn alpha_v1() {}\n").unwrap();
+    fs::write(root.join("outside.rs"), "pub fn outsider() {}\n").unwrap(); // root-level, out of `src`
+    let config = source_config(root.clone(), Language::Rust);
+    let _ = IndexDatabase::rebuild(&config).unwrap();
+    let files_before = IndexDatabase::open(&config.database).unwrap().indexed_file_count().unwrap();
+
+    fs::write(root.join("src/a.rs"), "pub fn alpha_v2() {}\n").unwrap();
+    let db = IndexDatabase::index_paths(&config, &[
+        root.join("src/../src/a.rs"),   // → src/a.rs
+        root.join("src/../outside.rs"), // → outside.rs (out of target)
+    ])
+    .unwrap();
+
+    assert!(symbol_present(&db, "alpha_v2"), "the collapsed src/a.rs path was reconciled");
+    assert_eq!(
+        file_rows(&config, "src/../src/a.rs", "1 = 1"),
+        0,
+        "no row is persisted under the un-normalized `src/../src/a.rs` key",
+    );
+    assert_eq!(
+        db.indexed_file_count().unwrap(),
+        files_before,
+        "the out-of-target `outside.rs` (via `src/../`) is not indexed",
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn index_paths_does_not_tombstone_a_never_indexed_missing_path() {
+    // A missing supplied path that was NEVER indexed (a typo, an out-of-target temp file) must not
+    // get a spurious `kind='deleted'` overlay row — that row would shadow a real committed file
+    // that later appears at the path (#659 review). Only indexed / git-deleted paths are
+    // tombstoned.
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/a.rs"), "pub fn alpha() {}\n").unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let _ = IndexDatabase::rebuild(&config).unwrap();
+
+    // `src/typo.rs` never existed and was never indexed.
+    let _ = IndexDatabase::index_paths(&config, &[root.join("src/typo.rs")]).unwrap();
+    assert_eq!(
+        file_rows(&config, "src/typo.rs", "1 = 1"),
+        0,
+        "a never-indexed missing path gets no tombstone row",
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn index_paths_signals_a_package_refresh_for_a_supplied_cargo_toml() {
+    // A `Cargo.toml` is not itself a target file, so it never reaches `files`; but naming it on the
+    // command line must still SIGNAL a package-map refresh (crate names / path-deps must update
+    // even for a clean/committed manifest) — the builder carries that signal out separately
+    // (#659 review).
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), "pub fn f() {}\n").unwrap();
+    fs::write(root.join("Cargo.toml"), "[package]\nname = \"widget\"\n").unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let (files, _changes, manifest_signal) =
+        crate::index::explicit_index_files_and_changes(&db, &config, &[root.join("Cargo.toml")])
+            .unwrap();
+    assert!(manifest_signal, "a supplied Cargo.toml sets the package-refresh signal");
+    assert!(files.is_empty(), "the manifest is not a target file, so it is not itself indexed");
+
+    // A supplied source file alone does not signal a package refresh.
+    let (_, _, no_signal) =
+        crate::index::explicit_index_files_and_changes(&db, &config, &[root.join("src/lib.rs")])
+            .unwrap();
+    assert!(!no_signal, "a supplied source file alone does not signal a package refresh");
+
+    // A DELETED manifest still signals — a non-git / untracked `Cargo.toml` that was scanned into
+    // `packages` and then removed is reported by neither git status nor a `files` row, but naming
+    // it must still refresh the package map (drop its stale rows). Not gated on a git-confirmed
+    // deletion (#659 review).
+    fs::remove_file(root.join("Cargo.toml")).unwrap();
+    let (_, _, deleted_signal) =
+        crate::index::explicit_index_files_and_changes(&db, &config, &[root.join("Cargo.toml")])
+            .unwrap();
+    assert!(deleted_signal, "a supplied but DELETED Cargo.toml still signals a package refresh");
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn index_paths_defers_on_a_first_time_empty_repo() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    // A `src` target with no matching files → first-time-empty.
+    fs::create_dir_all(root.join("src")).unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+
+    let result = IndexDatabase::index_paths(&config, &[root.join("src/new.rs")]);
+    assert!(
+        result
+            .as_ref()
+            .err()
+            .is_some_and(|err| err.downcast_ref::<crate::index::EmptyIndexRefused>().is_some()),
+        "a scoped pass on a not-yet-registered repo surfaces #427 (the CLI defers on it): \
+         {result:?}",
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn index_paths_defers_instead_of_rebuilding_an_uninitialized_non_empty_repo() {
+    // A scoped Paths pass must NEVER fall through to a full rebuild: on a repo with content but no
+    // index yet, `index --paths a.rs` would otherwise index the WHOLE repository instead of the one
+    // supplied path. It defers (`EmptyIndexRefused`) — the CLI reports "run `rag-rat index` first".
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/a.rs"), "pub fn alpha() {}\n").unwrap();
+    fs::write(root.join("src/b.rs"), "pub fn beta() {}\n").unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    assert!(!config.database.exists(), "precondition: no index built yet");
+
+    let result = IndexDatabase::index_paths(&config, &[root.join("src/a.rs")]);
+    assert!(
+        result
+            .as_ref()
+            .err()
+            .is_some_and(|err| err.downcast_ref::<crate::index::EmptyIndexRefused>().is_some()),
+        "an uninitialized index DEFERS a scoped pass rather than full-rebuilding: {result:?}",
+    );
+    assert!(!config.database.exists(), "deferring must not build any index");
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn index_paths_defers_for_a_repo_with_files_but_no_rows_in_a_shared_db() {
+    // On a SHARED/global DB, the DB file + schema already exist (another repo created them), so the
+    // missing-DB guard is false; and this repo has files on disk, so the #427 first-time-empty
+    // check lets it through. A scoped pass then reaches the `repo_generation_file_count == 0`
+    // bootstrap fallback — which for the sweep modes is a FULL rebuild. `Paths` must DEFER there
+    // instead, or `index --paths src/a.rs` would index the WHOLE unindexed repo (#659 review).
+    let repo_b = unique_temp_root();
+    let _ = fs::remove_dir_all(&repo_b);
+    fs::create_dir_all(repo_b.join("src")).unwrap();
+    fs::write(repo_b.join("src/lib.rs"), "pub fn beta() {}\n").unwrap();
+    let config_b = source_config(repo_b.clone(), Language::Rust);
+    let _ = IndexDatabase::rebuild(&config_b).unwrap(); // owns the shared DB
+
+    // repo A: files on disk, never indexed, sharing B's database.
+    let repo_a = unique_temp_root();
+    let _ = fs::remove_dir_all(&repo_a);
+    fs::create_dir_all(repo_a.join("src")).unwrap();
+    fs::write(repo_a.join("src/a.rs"), "pub fn alpha() {}\n").unwrap();
+    fs::write(repo_a.join("src/extra.rs"), "pub fn extra() {}\n").unwrap();
+    let mut config_a = source_config(repo_a.clone(), Language::Rust);
+    config_a.database = config_b.database.clone();
+
+    let result = IndexDatabase::index_paths(&config_a, &[repo_a.join("src/a.rs")]);
+    assert!(
+        result
+            .as_ref()
+            .err()
+            .is_some_and(|err| err.downcast_ref::<crate::index::EmptyIndexRefused>().is_some()),
+        "a scoped pass on an unindexed repo in a shared DB DEFERS rather than full-rebuilding it: \
+         {result:?}",
+    );
+
+    let _ = fs::remove_dir_all(&repo_a);
+    let _ = fs::remove_dir_all(&repo_b);
+}
+
+#[test]
+#[cfg(unix)]
+fn index_paths_skips_a_supplied_symlink_to_an_in_repo_file() {
+    // The base walker (`walker::walk_dir`) SKIPS symlinks, so a supplied path that is itself a
+    // symlink — even to an in-repo source file — must be skipped too. Otherwise `index --paths
+    // src/link.rs` writes an index row under the symlink path that a full/discover pass would never
+    // produce: a duplicate of the real file's row (#659 review).
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/a.rs"), "pub fn alpha_v1() {}\n").unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let _ = IndexDatabase::rebuild(&config).unwrap();
+    assert_eq!(IndexDatabase::open(&config.database).unwrap().indexed_file_count().unwrap(), 1);
+
+    // `src/link.rs` is a symlink to the real `src/a.rs`; supplying it must not add a second row.
+    std::os::unix::fs::symlink(root.join("src/a.rs"), root.join("src/link.rs")).unwrap();
+    let db = IndexDatabase::index_paths(&config, &[root.join("src/link.rs")]).unwrap();
+    assert_eq!(
+        db.indexed_file_count().unwrap(),
+        1,
+        "a supplied symlink is skipped — no duplicate index row under the symlink path",
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+#[cfg(unix)]
+fn index_paths_skips_a_path_through_a_symlinked_ancestor_dir() {
+    // The symlink skip must reject a symlink at ANY component, not just the leaf: `src/link/b.rs`
+    // where `src/link` is a symlink to an in-repo dir has a REGULAR leaf, but the walker skips the
+    // `src/link` entry and never descends, so indexing it by path writes a row under a spelling a
+    // full/discover pass never produces (#659 review).
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/a.rs"), "pub fn alpha_v1() {}\n").unwrap();
+    // `other/` is OUTSIDE the `src` target, so its file is never indexed under its real spelling —
+    // isolating the symlink-spelling row as the only thing that could appear.
+    fs::create_dir_all(root.join("other")).unwrap();
+    fs::write(root.join("other/b.rs"), "pub fn beta_v1() {}\n").unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let _ = IndexDatabase::rebuild(&config).unwrap();
+    assert_eq!(IndexDatabase::open(&config.database).unwrap().indexed_file_count().unwrap(), 1);
+
+    // `src/link` → `other`, so `src/link/b.rs` resolves to the real (regular) `other/b.rs`.
+    std::os::unix::fs::symlink(root.join("other"), root.join("src/link")).unwrap();
+    let db = IndexDatabase::index_paths(&config, &[root.join("src/link/b.rs")]).unwrap();
+    assert_eq!(
+        db.indexed_file_count().unwrap(),
+        1,
+        "a path crossing a symlinked ANCESTOR dir is skipped — no row under the symlink spelling",
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+#[cfg(unix)]
+fn index_paths_indexes_an_absolute_path_through_a_symlinked_root_spelling() {
+    // An editor/git hook may hand `--paths` an absolute path spelled through a DIFFERENT symlink
+    // than the canonical checkout root (macOS `/tmp` vs `/private/tmp`, a symlinked `$PWD`). A
+    // LEXICAL `strip_prefix(config.root)` fails on that spelling; the builder must canonicalize
+    // before giving up, or the valid in-repo edit is silently dropped (#659 review).
+    let realroot = unique_temp_root();
+    let _ = fs::remove_dir_all(&realroot);
+    fs::create_dir_all(realroot.join("src")).unwrap();
+    fs::write(realroot.join("src/a.rs"), "pub fn alpha_v1() {}\n").unwrap();
+    // config.root is the CANONICAL root (as `Config::load` would normalize it).
+    let canonical_root = realroot.canonicalize().unwrap();
+    let config = source_config(canonical_root.clone(), Language::Rust);
+    let _ = IndexDatabase::rebuild(&config).unwrap();
+
+    // A sibling symlink that is an alias of the canonical root.
+    let link_root = realroot
+        .parent()
+        .unwrap()
+        .join(format!("{}-alias", realroot.file_name().unwrap().to_string_lossy()));
+    std::os::unix::fs::symlink(&canonical_root, &link_root).unwrap();
+
+    // Edit the file, then reindex it via the SYMLINKED root spelling.
+    fs::write(realroot.join("src/a.rs"), "pub fn alpha_v2() {}\n").unwrap();
+    let db = IndexDatabase::index_paths(&config, &[link_root.join("src/a.rs")]).unwrap();
+    assert!(
+        symbol_present(&db, "alpha_v2"),
+        "an absolute path through a symlinked root spelling is rebased canonically and indexed, \
+         not dropped",
+    );
+
+    let _ = fs::remove_dir_all(&realroot);
+    let _ = fs::remove_file(&link_root);
+}
+
+/// Total `packages` rows across all scopes — a manifest refresh in a fresh overlay scope adds one.
+fn package_count(config: &Config) -> i64 {
+    rusqlite::Connection::open(&config.database)
+        .unwrap()
+        .query_row("SELECT COUNT(*) FROM packages", [], |row| row.get::<_, i64>(0))
+        .unwrap()
+}
+
+#[test]
+fn reindex_paths_refreshes_linked_overlay_packages_for_a_dirty_manifest() {
+    // A manifest-only edit in a LINKED worktree (dirty `Cargo.toml`, no source-row change) routes
+    // to `index_worktree_overlay`, whose refresh is delta-gated on indexed/tombstoned/pruned counts
+    // — all zero here. The base `Paths` flow refreshes packages on its manifest signal even with
+    // zero indexed files, and the overlay must match, or the branch resolves imports against a
+    // stale package map (#659 review). Observable: the overlay scope gains its own `packages` row.
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(main.join("Cargo.toml"), "[package]\nname = \"widget\"\n").unwrap();
+    fs::write(main.join("src/lib.rs"), "pub fn lib() {}\n").unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let config = source_config(main.clone(), Language::Rust);
+    let _ = IndexDatabase::rebuild(&config).unwrap();
+    let base_packages = package_count(&config);
+    assert!(base_packages >= 1, "base rebuild wrote the widget package row");
+
+    // Linked worktree; dirty its Cargo.toml with NO source change (so only the manifest signal can
+    // drive a package refresh).
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    fs::write(linked.join("Cargo.toml"), "[package]\nname = \"widget\"\n# edited\n").unwrap();
+
+    let _ = crate::watch::reindex_paths(&config, &[linked.join("Cargo.toml")], |_| {}).unwrap();
+    assert_eq!(
+        package_count(&config),
+        base_packages + 1,
+        "the manifest-only linked edit refreshes the overlay scope's package map (a new row)",
+    );
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}
+
+#[test]
+fn reindex_paths_refreshes_linked_overlay_packages_for_a_committed_manifest() {
+    // The overlay's own `manifest_changed` is status-derived (dirty-only), so a CLEAN/committed
+    // linked `Cargo.toml` produces no source rows and no dirty signal. The SUPPLIED-manifest signal
+    // (routed via `WorktreePartition.manifest_roots` → `refresh_worktree_overlay_packages`) must
+    // still refresh the overlay package map, so `index --paths` honors "also sees committed
+    // changes" for the linked route (#659 review).
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(main.join("Cargo.toml"), "[package]\nname = \"widget\"\n").unwrap();
+    fs::write(main.join("src/lib.rs"), "pub fn lib() {}\n").unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let config = source_config(main.clone(), Language::Rust);
+    let _ = IndexDatabase::rebuild(&config).unwrap();
+    let base_packages = package_count(&config);
+
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    // Edit AND COMMIT the manifest on the branch → clean working tree, a committed manifest change.
+    fs::write(linked.join("Cargo.toml"), "[package]\nname = \"widget\"\n# committed\n").unwrap();
+    run_git(&linked, &["add", "Cargo.toml"]);
+    run_git(&linked, &["commit", "-q", "-m", "manifest"]);
+
+    let _ = crate::watch::reindex_paths(&config, &[linked.join("Cargo.toml")], |_| {}).unwrap();
+    assert_eq!(
+        package_count(&config),
+        base_packages + 1,
+        "a supplied CLEAN/committed linked manifest still refreshes the overlay package map",
+    );
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}
+
+#[test]
+fn index_paths_tombstones_a_deleted_indexed_file_under_a_now_ignored_dir() {
+    // A previously-indexed path that is now BOTH deleted AND under a newly-ignored directory must
+    // still be tombstoned by `index --paths` — the early ignore filter used to `continue` before
+    // the deletion branch, leaving the stale row visible until a full discover pass (#659 review).
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src/generated")).unwrap();
+    fs::write(root.join("src/a.rs"), "pub fn alpha_v1() {}\n").unwrap();
+    fs::write(root.join("src/generated/gen.rs"), "pub fn gen_v1() {}\n").unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let _ = IndexDatabase::rebuild(&config).unwrap(); // gen.rs indexed (no ignore rule yet)
+    assert_eq!(IndexDatabase::open(&config.database).unwrap().indexed_file_count().unwrap(), 2);
+
+    // Now ignore `generated/` AND delete the indexed file under it.
+    fs::write(root.join(".gitignore"), "generated/\n").unwrap();
+    fs::remove_file(root.join("src/generated/gen.rs")).unwrap();
+    let db = IndexDatabase::index_paths(&config, &[root.join("src/generated/gen.rs")]).unwrap();
+    assert_eq!(
+        db.indexed_file_count().unwrap(),
+        1,
+        "a deleted indexed file under a now-ignored dir is tombstoned, not skipped by the filter",
+    );
+    assert!(symbol_present(&db, "alpha_v1"), "the un-supplied file is untouched");
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn index_paths_reindexes_on_stored_target_identity_drift_with_unchanged_bytes() {
+    // The no-op skip must compare (sha256, language, kind), not sha alone: a target-identity change
+    // with UNCHANGED bytes (e.g. an extension-precedence upgrade re-languages a path) must still
+    // reindex, matching discovery's staleness. Simulate the drift by POISONING the stored row's
+    // `language` — the config/target fingerprint is unchanged, so the pass stays in Paths mode (not
+    // promoted to Discover) and the fix must be what triggers the reindex (#659 review).
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/a.rs"), "pub fn alpha_v1() {}\n").unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let _ = IndexDatabase::rebuild(&config).unwrap();
+
+    // Read the LIVE row (max generation) — the schema-bootstrap harness seeds a dead poison-sibling
+    // row at generation 0 that scoped queries must never observe.
+    let stored_language = |config: &Config| -> String {
+        rusqlite::Connection::open(&config.database)
+            .unwrap()
+            .query_row(
+                "SELECT language FROM main.files WHERE path = 'src/a.rs' AND kind != 'deleted' \
+                 ORDER BY generation DESC LIMIT 1",
+                [],
+                |row| row.get::<_, String>(0),
+            )
+            .unwrap()
+    };
+    assert_eq!(stored_language(&config), "rust", "baseline: indexed as rust");
+
+    // Poison the LIVE row's language to simulate a target-identity drift with identical bytes.
+    rusqlite::Connection::open(&config.database)
+        .unwrap()
+        .execute(
+            "UPDATE main.files SET language = 'python' WHERE path = 'src/a.rs' AND generation = \
+             (SELECT MAX(generation) FROM main.files WHERE path = 'src/a.rs')",
+            [],
+        )
+        .unwrap();
+
+    // Reconcile the (byte-identical) path: a sha-only skip would leave the poisoned language; the
+    // identity comparison must reindex it back to rust.
+    let _ = IndexDatabase::index_paths(&config, &[root.join("src/a.rs")]).unwrap();
+    assert_eq!(
+        stored_language(&config),
+        "rust",
+        "a stored target-identity drift is reindexed, not sha-skipped",
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn worktree_overlay_shadows_a_byte_identical_file_re_languaged_by_branch_config() {
+    // A branch whose config RE-LANGUAGES a byte-identical file — a `.h` header the base indexes as
+    // C and the branch, via a `cpp` target, indexes as C++ (both bindings claim `.h`) — is
+    // invisible to the content delta (same bytes, clean tree). The overlay must still shadow
+    // the base row with the branch's (language, kind): target-identity drift, mirroring
+    // discovery's staleness (#659 review). Without it queries fall through to the stale base C
+    // parse.
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(main.join("src/widget.h"), "int widget(void);\n").unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let base_config = source_config_dirs(main.clone(), Language::C, &["src"]);
+    let mut db = IndexDatabase::rebuild(&base_config).unwrap(); // widget.h indexed as C
+
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    // widget.h is byte-identical on the branch; only the branch CONFIG re-languages it to C++. The
+    // overlay config keeps the base (main) root and swaps in the branch's targets, exactly as
+    // `for_linked_worktree_overlay` produces.
+    let branch_config = source_config_dirs(main.clone(), Language::Cpp, &["src"]);
+    db.index_worktree_overlay(&branch_config, &linked, &mut |_| {}).unwrap();
+
+    let cpp_overlay_rows: i64 = db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT COUNT(*) FROM main.files
+             WHERE path = 'src/widget.h' AND language = 'cpp' AND kind != 'deleted'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert!(
+        cpp_overlay_rows >= 1,
+        "the overlay shadows the base C row with the branch's C++ parse of the identical header",
+    );
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}
+
+#[test]
+fn overlay_target_drift_scan_is_gated_on_the_config_fingerprint() {
+    // The per-file drift scan is O(base-files); it must be SKIPPED when the branch config's targets
+    // match the base's (fingerprint equal → no file can re-language), so a no-divergent-config
+    // worktree does not re-scan every base file on every overlay refresh (#577 event-scoping). Only
+    // a genuinely divergent branch config may drift (#659 review).
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/widget.h"), "int widget(void);\n").unwrap();
+    init_git_repo(&root);
+    run_git(&root, &["add", "."]);
+    run_git(&root, &["commit", "-q", "-m", "base"]);
+    let base_config = source_config_dirs(root.clone(), Language::C, &["src"]);
+    let db = IndexDatabase::rebuild(&base_config).unwrap(); // records the base-scope target marker
+
+    assert!(
+        !db.overlay_targets_may_drift(&base_config.targets).unwrap(),
+        "matching targets → the drift scan is skipped",
+    );
+    let cpp_config = source_config_dirs(root.clone(), Language::Cpp, &["src"]);
+    assert!(
+        db.overlay_targets_may_drift(&cpp_config.targets).unwrap(),
+        "a divergent branch config (C→C++) → the drift scan runs",
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+#[cfg(unix)]
+fn index_paths_tombstones_a_regular_file_replaced_by_a_symlink() {
+    // An indexed regular file that is then REPLACED by a symlink must be tombstoned by `index
+    // --paths`, not left as a stale no-op — the walker skips the symlink, so its row must go. This
+    // needs BOTH the prep-side routing (symlink → deletion branch) and the fs-deletion revalidation
+    // using `symlink_metadata` (a symlink is not a "restored" regular file) (#659 review).
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/a.rs"), "pub fn alpha_v1() {}\n").unwrap();
+    fs::write(root.join("src/b.rs"), "pub fn beta_v1() {}\n").unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let _ = IndexDatabase::rebuild(&config).unwrap();
+    assert_eq!(IndexDatabase::open(&config.database).unwrap().indexed_file_count().unwrap(), 2);
+
+    // Replace the indexed src/a.rs with a symlink (its target b.rs IS a file, so `is_file` follows
+    // to true — the exact case a sha/is_file check would mis-treat as "restored").
+    fs::remove_file(root.join("src/a.rs")).unwrap();
+    std::os::unix::fs::symlink(root.join("src/b.rs"), root.join("src/a.rs")).unwrap();
+    let db = IndexDatabase::index_paths(&config, &[root.join("src/a.rs")]).unwrap();
+
+    assert_eq!(
+        db.indexed_file_count().unwrap(),
+        1,
+        "the symlink-replaced file's stale row is tombstoned, not left as a no-op",
+    );
+    assert!(symbol_present(&db, "beta_v1"), "the un-supplied file is untouched");
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn worktree_overlay_indexes_a_file_newly_targeted_by_the_branch_config() {
+    // A branch that ADDS a target dir (via its config) for files that already exist in the base
+    // tree but were never base-indexed must index them in the overlay. The content delta never
+    // sees them (unchanged bytes), and a base-rows scan can't (no base row) — the config-aware
+    // walk covers it (#659 review).
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::create_dir_all(main.join("extra")).unwrap();
+    fs::write(main.join("src/lib.rs"), "pub fn lib() {}\n").unwrap();
+    fs::write(main.join("extra/tool.rs"), "pub fn tool() {}\n").unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    // Base config targets ONLY `src`, so extra/tool.rs is never base-indexed.
+    let base_config = source_config_dirs(main.clone(), Language::Rust, &["src"]);
+    let mut db = IndexDatabase::rebuild(&base_config).unwrap();
+    let rows_for = |db: &IndexDatabase, path: &str| -> i64 {
+        db.storage
+            .connection()
+            .query_row(
+                "SELECT COUNT(*) FROM main.files WHERE path = ?1 AND kind != 'deleted'",
+                [path],
+                |row| row.get(0),
+            )
+            .unwrap()
+    };
+    assert_eq!(rows_for(&db, "extra/tool.rs"), 0, "extra/ is not a base target — no base row");
+
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    // Branch config ADDS `extra` as a target (same root, superset targets).
+    let branch_config = source_config_dirs(main.clone(), Language::Rust, &["src", "extra"]);
+    db.index_worktree_overlay(&branch_config, &linked, &mut |_| {}).unwrap();
+
+    assert!(
+        rows_for(&db, "extra/tool.rs") >= 1,
+        "a file newly targeted by the branch config is indexed in the overlay",
+    );
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}
+
+#[test]
+#[cfg(unix)]
+fn index_paths_tombstones_a_regular_file_replaced_by_an_escaping_symlink() {
+    // A regular file that was indexed and is then replaced by a symlink pointing OUTSIDE the repo
+    // must STILL be tombstoned — the containment check must not short-circuit the deletion branch —
+    // and (critically) the external target is NEVER read/indexed (#659 review).
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/a.rs"), "pub fn alpha_v1() {}\n").unwrap();
+    fs::write(root.join("src/b.rs"), "pub fn beta_v1() {}\n").unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let _ = IndexDatabase::rebuild(&config).unwrap();
+    assert_eq!(IndexDatabase::open(&config.database).unwrap().indexed_file_count().unwrap(), 2);
+
+    // Replace the indexed src/a.rs with a symlink to an EXTERNAL file (outside the repo root).
+    let outside =
+        root.parent().unwrap().join(format!("{}-ext", root.file_name().unwrap().to_string_lossy()));
+    let _ = fs::remove_dir_all(&outside);
+    fs::create_dir_all(&outside).unwrap();
+    fs::write(outside.join("evil.rs"), "pub fn evil_marker() {}\n").unwrap();
+    fs::remove_file(root.join("src/a.rs")).unwrap();
+    std::os::unix::fs::symlink(outside.join("evil.rs"), root.join("src/a.rs")).unwrap();
+
+    let db = IndexDatabase::index_paths(&config, &[root.join("src/a.rs")]).unwrap();
+    // Count 1 proves BOTH: a.rs's stale row is tombstoned AND the external evil.rs is not indexed
+    // (an external read would have reindexed src/a.rs, keeping the count at 2).
+    assert_eq!(
+        db.indexed_file_count().unwrap(),
+        1,
+        "the stale row is tombstoned and the escaping symlink's external target is not indexed",
+    );
+    assert!(symbol_present(&db, "beta_v1"), "the un-supplied file is untouched");
+
+    let _ = fs::remove_dir_all(&root);
+    let _ = fs::remove_dir_all(&outside);
+}

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/mod.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/mod.rs
@@ -931,6 +931,7 @@ mod generation_rebuild;
 mod git_history_reload;
 mod graph_edges;
 mod head_move_carry;
+mod index_paths;
 mod migration_gate_wiring;
 mod multi_repo_scope;
 mod orientation_healing;

--- a/crates/rag-rat-core/src/index/worktree_overlay.rs
+++ b/crates/rag-rat-core/src/index/worktree_overlay.rs
@@ -30,6 +30,15 @@ pub(crate) struct WorktreeOverlayDelta {
     /// prune — pruning against a partial `shadowing_paths` would delete valid overlay rows (#219
     /// review). The committed-diff portion is always complete (it errors hard).
     pub(crate) status_complete: bool,
+    /// Whether a `Cargo.toml` appeared in the linked WORKING-TREE STATUS (a dirty manifest edit).
+    /// A manifest is not a target file, so it never lands in `readable`/`tombstones` and
+    /// produces no source-row change — but the branch's package/import scope must still
+    /// refresh for it, so the overlay's finalize refreshes packages on this signal alone (#659
+    /// review). Derived from STATUS (not the committed base↔branch diff) so it SELF-CLEARS on
+    /// commit, matching the base flow's git-status manifest signal and keeping idle overlay
+    /// passes write-free — a committed branch manifest persists in the tree-diff and would
+    /// otherwise rewrite `packages` every pass.
+    pub(crate) manifest_changed: bool,
 }
 
 impl WorktreeOverlayDelta {
@@ -84,6 +93,27 @@ fn linked_config_subdir_and_root(
         .unwrap_or_default();
     let linked_config_root = linked_workdir.join(&config_subdir);
     (config_subdir, linked_config_root)
+}
+
+/// Resolve the `(base_sha, worktree_id, source_root)` for a linked-worktree overlay, or `None` when
+/// `linked_path` is not a valid linked sibling of `config.root`'s repo (its scope fell back to
+/// base). Shared by [`IndexDatabase::index_worktree_overlay`] and
+/// [`IndexDatabase::refresh_worktree_overlay_packages`] so both derive the SAME scope + source
+/// root.
+fn resolve_overlay_scope(
+    config: &Config,
+    linked_path: &Path,
+) -> anyhow::Result<Option<(String, String, PathBuf)>> {
+    let (base_sha, worktree_id) =
+        git_context::resolve_worktree_scope(&config.root, Some(linked_path));
+    if worktree_id == git_context::worktree_id_of(&config.root) {
+        return Ok(None);
+    }
+    let base_repo = git_context::discover_repo(&config.root)?;
+    let linked_repo = git_context::discover_repo(linked_path)?;
+    let (_, source_root) =
+        linked_config_subdir_and_root(config, &base_repo, &linked_repo, linked_path);
+    Ok(Some((base_sha, worktree_id, source_root)))
 }
 
 /// Compute the overlay delta of `linked_path` (a linked worktree of `config.root`'s repo) against
@@ -144,12 +174,21 @@ pub(crate) fn compute_linked_worktree_delta(
     // untracked / working-tree-deleted paths), and the caller must skip the prune on a partial
     // delta or it would delete valid overlay rows (#219 review).
     let mut status_complete = false;
+    // A `Cargo.toml` among the STATUS entries (a DIRTY manifest edit) must refresh the package/
+    // import scope even though a manifest is not a target file (so it never reaches the delta's
+    // readable set). Detect it DURING the fold — status is a one-shot iterator. `Cell` because
+    // `fold_status_candidates` takes an `Fn` locator, not `FnMut`.
+    let manifest_in_status = std::cell::Cell::new(false);
     if let Ok(platform) = linked_repo.status(gix::progress::Discard)
         && let Ok(items) =
             platform.untracked_files(UntrackedFiles::Files).into_iter(None::<gix::bstr::BString>)
     {
         status_complete = fold_status_candidates(&mut candidates, items, |item| {
-            PathBuf::from(item.location().to_str_lossy().as_ref())
+            let path = PathBuf::from(item.location().to_str_lossy().as_ref());
+            if path_is_manifest_under_subdir(&path, &config_subdir) {
+                manifest_in_status.set(true);
+            }
+            path
         });
     }
 
@@ -183,7 +222,11 @@ pub(crate) fn compute_linked_worktree_delta(
         config,
     );
 
-    let mut delta = WorktreeOverlayDelta { status_complete, ..Default::default() };
+    let mut delta = WorktreeOverlayDelta {
+        status_complete,
+        manifest_changed: manifest_in_status.get(),
+        ..Default::default()
+    };
     for repo_rel in candidates {
         // Candidates are repo-relative; the overlay keys rows config-root-relative (matching the
         // base rows + `target_for_path`). A candidate OUTSIDE the config subdir has no base row to
@@ -312,6 +355,16 @@ fn fold_status_candidates<T, E>(
     true
 }
 
+/// Whether `repo_rel` (a repo-relative status path) is a `Cargo.toml` under `config_subdir` — i.e.
+/// a manifest whose change should refresh THIS config's package map. A manifest outside the config
+/// subdir belongs to a different part of the repo (when `config.root` is a subdir) and is not this
+/// overlay's concern; `refresh_packages` scans manifests under the config's source root only.
+fn path_is_manifest_under_subdir(repo_rel: &Path, config_subdir: &Path) -> bool {
+    repo_rel
+        .strip_prefix(config_subdir)
+        .is_ok_and(|rel| rel.file_name() == Some(std::ffi::OsStr::new("Cargo.toml")))
+}
+
 fn change_location_path(change: &gix::object::tree::diff::Change<'_, '_, '_>) -> PathBuf {
     use gix::object::tree::diff::Change;
     let location = match change {
@@ -413,25 +466,38 @@ impl IndexDatabase {
     where
         F: FnMut(IndexProgress),
     {
-        let (base_sha, worktree_id) =
-            git_context::resolve_worktree_scope(&config.root, Some(linked_path));
-        // Fell back to base → not a valid linked sibling; nothing to overlay.
-        if worktree_id == git_context::worktree_id_of(&config.root) {
+        // `source_root` is the LINKED checkout's equivalent of `config.root` — bytes are read from
+        // there, not the raw `linked_path` (which may be a subdir of the checkout, e.g. `--worktree
+        // .` from `/wt/src`, or the git dir from a hook) (#219 review).
+        let Some((base_sha, worktree_id, source_root)) =
+            resolve_overlay_scope(config, linked_path)?
+        else {
+            // Fell back to base → not a valid linked sibling; nothing to overlay.
             return Ok(WorktreeOverlayReport::default());
-        }
+        };
         // Scope the connection to the overlay (base commit + linked worktree id) so context-
         // dependent steps (tombstones, FTS, edge resolution) operate in the linked scope.
         self.set_context(&base_sha, &worktree_id)?;
 
-        let delta = compute_linked_worktree_delta(config, linked_path)?;
-        // `delta.readable` is config-root-relative, so the bytes are read from the LINKED
-        // checkout's equivalent of `config.root` — not the raw `linked_path` (which may be
-        // a subdir of the checkout, e.g. `--worktree .` from `/wt/src`, or the git dir from
-        // a hook) (#219 review).
-        let base_repo = git_context::discover_repo(&config.root)?;
-        let linked_repo = git_context::discover_repo(linked_path)?;
-        let (_, source_root) =
-            linked_config_subdir_and_root(config, &base_repo, &linked_repo, linked_path);
+        let mut delta = compute_linked_worktree_delta(config, linked_path)?;
+        // Fold in TARGET-IDENTITY drift: a branch config change that re-languages or drops a
+        // byte-identical file is invisible to the content delta, but the overlay's (language, kind)
+        // must still track the branch config, like discovery's staleness (#659 review). This also
+        // covers the `index --paths <linked>/foo.rs` case for a clean re-languaged file without
+        // threading the supplied paths — the scan sees every base-scope file. GATED on the branch
+        // config's targets differing from the base's (fingerprint match → no file can re-language),
+        // so the common no-divergent-config worktree does NOT pay an O(base-files) scan on every
+        // overlay refresh (#577 event-scoping).
+        if self.overlay_targets_may_drift(&config.targets)? {
+            let (drift_readable, drift_tombstones) = self.overlay_target_config_reconcile(
+                &base_sha,
+                config,
+                &source_root,
+                &delta.shadowing_paths(),
+            )?;
+            delta.readable.extend(drift_readable);
+            delta.tombstones.extend(drift_tombstones);
+        }
         let scope = FileScope::worktree(worktree_id.clone());
         // ONE transaction around the whole overlay update — incremental file replacement, tombstone
         // writes, the prune, AND the global logical-symbol/package/edge/FTS refresh — mirroring the
@@ -484,7 +550,14 @@ impl IndexDatabase {
             } else {
                 0
             };
-            self.finalize_overlay_refresh(&source_root, &worktree_id, indexed, tombstoned, pruned)?;
+            self.finalize_overlay_refresh(
+                &source_root,
+                &worktree_id,
+                indexed,
+                tombstoned,
+                pruned,
+                delta.manifest_changed,
+            )?;
             Ok((indexed, tombstoned, pruned))
         })();
         let (indexed, tombstoned, pruned) = match result {
@@ -505,6 +578,44 @@ impl IndexDatabase {
             pruned,
             status_complete: delta.status_complete,
         })
+    }
+
+    /// Refresh JUST the linked overlay's package/import scope (and re-resolve its edges against the
+    /// new map) — the `index --paths <linked>/Cargo.toml` entry point when the supplied manifest is
+    /// CLEAN/committed. `index_worktree_overlay` derives its manifest signal from the WORKING-TREE
+    /// STATUS (dirty-only, for idle-safety), so a supplied but clean manifest produces no indexed
+    /// rows and would leave the package map stale — this honors the base `Paths` flow's
+    /// supplied-manifest signal for the linked route (#659 review). Its own `BEGIN IMMEDIATE` (the
+    /// caller is not mid-transaction) and idempotent, so re-running it after a dirty-status refresh
+    /// is harmless. No-op when `linked_path` is not a valid linked sibling. Leaves the connection
+    /// scoped to the overlay.
+    pub fn refresh_worktree_overlay_packages(
+        &mut self,
+        config: &Config,
+        linked_path: &Path,
+    ) -> anyhow::Result<()> {
+        let Some((base_sha, worktree_id, source_root)) =
+            resolve_overlay_scope(config, linked_path)?
+        else {
+            return Ok(());
+        };
+        self.set_context(&base_sha, &worktree_id)?;
+        self.storage.execute_batch("BEGIN IMMEDIATE")?;
+        let result = (|| -> anyhow::Result<()> {
+            self.refresh_packages(&source_root)?;
+            self.resolve_overlay_edges(&worktree_id)?;
+            Ok(())
+        })();
+        match result {
+            Ok(()) => {
+                self.storage.execute_batch("COMMIT")?;
+                Ok(())
+            },
+            Err(err) => {
+                let _ = self.storage.execute_batch("ROLLBACK");
+                Err(err)
+            },
+        }
     }
 
     /// The post-write finalize tail of `index_worktree_overlay`, run INSIDE its transaction — ONLY
@@ -529,6 +640,10 @@ impl IndexDatabase {
     ///   must not be rewritten or base `find_callers`/impact would corrupt until a base pass
     ///   resolved it back, flipping by whichever worktree refreshed last (#219 P1).
     /// - sync_fts: so semantic_search (BM25) sees the overlay's chunks.
+    ///
+    /// A manifest-only change (`manifest_changed`, no source rows) refreshes JUST the package scope
+    /// — the logical-symbol/edge/FTS steps depend on source-row changes, so they stay gated on the
+    /// counts (#659 review).
     fn finalize_overlay_refresh(
         &self,
         source_root: &Path,
@@ -536,6 +651,7 @@ impl IndexDatabase {
         indexed: usize,
         tombstoned: usize,
         pruned: usize,
+        manifest_changed: bool,
     ) -> anyhow::Result<()> {
         if indexed > 0 || tombstoned > 0 || pruned > 0 {
             // Defer: an overlay refresh re-parsed only the worktree's own files, so it must not
@@ -545,6 +661,18 @@ impl IndexDatabase {
             self.refresh_packages(source_root)?;
             self.resolve_overlay_edges(worktree_id)?;
             self.sync_fts()?;
+        } else if manifest_changed {
+            // A dirty `Cargo.toml` with no source-row change: the base flow's manifest signal
+            // refreshes the package map even with zero indexed files, and the overlay must match so
+            // the branch resolves imports against its own manifest. `manifest_changed` is
+            // status-derived (self-clears on commit), so this does not rewrite `packages` on every
+            // idle overlay pass (#659 review).
+            self.refresh_packages(source_root)?;
+            // Overlay EDGES resolve THROUGH the package/import scope, so a package-map change must
+            // re-resolve them too — otherwise callers/callees keep returning targets resolved
+            // against the OLD manifest until an unrelated source change triggers a resolve (#659
+            // review).
+            self.resolve_overlay_edges(worktree_id)?;
         }
         Ok(())
     }
@@ -567,23 +695,32 @@ impl IndexDatabase {
     where
         F: FnMut(IndexProgress),
     {
-        // Existing rows in this scope (path → sha) so an UNCHANGED file is skipped: re-running the
-        // overlay on a static worktree then writes nothing, so the watcher can refresh overlays
+        // Existing rows in this scope (path → identity) so an UNCHANGED file is skipped: re-running
+        // the overlay on a static worktree then writes nothing, so the watcher can refresh overlays
         // every maintenance pass without churn — preserving the idle backstop (#63) and not
-        // tripping the self-sustaining re-index loop.
-        let existing = self.scope_file_shas(&scope.commit_sha, &scope.worktree_id)?;
+        // tripping the self-sustaining re-index loop. The identity is `(sha256, language, kind)`,
+        // not sha alone: a branch config change that RE-LANGUAGES a byte-identical file
+        // must still rewrite the overlay row, mirroring discovery / the base `Paths` flow's
+        // staleness (#659).
+        let existing = self.scope_file_identities(&scope.commit_sha, &scope.worktree_id)?;
         let mut files = Vec::new();
         for rel in paths {
             let full_path = source_root.join(rel);
             let Ok(bytes) = std::fs::read(&full_path) else {
                 continue; // not a readable regular file
             };
-            if existing.get(path_string(rel).as_str()) == Some(&hex_sha256(&bytes)) {
-                continue; // unchanged since the last overlay index
-            }
             let Some((language, kind)) = target_for_path(config, rel) else {
                 continue;
             };
+            if existing.get(path_string(rel).as_str())
+                == Some(&(
+                    hex_sha256(&bytes),
+                    language.as_str().to_string(),
+                    kind.as_str().to_string(),
+                ))
+            {
+                continue; // unchanged since the last overlay index (content AND target identity)
+            }
             files.push(IndexFile {
                 full_path,
                 relative_path: rel.clone(),
@@ -596,26 +733,105 @@ impl IndexDatabase {
         self.apply_incremental_file_plan(files, BTreeSet::new(), progress)
     }
 
-    /// Existing file rows in a scope as `path → sha256` — for the idle-safe skip above. A direct
-    /// `main.files` probe (bypasses the repo-scoped view), so it carries the `repo_id` predicate
-    /// explicitly (A3): today's sole caller passes a non-empty (path-derived, globally unique)
-    /// `worktree_id`, but this is the documented reusable primitive — a base-scope caller
-    /// (`commit_sha`, `''`) would otherwise skip files on the strength of a fork sibling's sha.
-    fn scope_file_shas(
+    /// Existing file rows in a scope as `path → (sha256, language, kind)` — for the identity-aware
+    /// idle-safe skip above. A direct `main.files` probe (bypasses the repo-scoped view), so it
+    /// carries the `repo_id` predicate explicitly (A3): today's sole caller passes a non-empty
+    /// (path-derived, globally unique) `worktree_id`, but this is the documented reusable primitive
+    /// — a base-scope caller (`commit_sha`, `''`) would otherwise skip files on the strength of a
+    /// fork sibling's sha.
+    fn scope_file_identities(
         &self,
         commit_sha: &str,
         worktree_id: &str,
-    ) -> anyhow::Result<HashMap<String, String>> {
+    ) -> anyhow::Result<HashMap<String, (String, String, String)>> {
         let conn = self.storage.connection();
         let mut stmt = conn.prepare(
-            "SELECT path, sha256 FROM main.files
+            "SELECT path, sha256, language, kind FROM main.files
              WHERE repo_id = ?1 AND commit_sha = ?2 AND worktree_id = ?3",
         )?;
-        let rows = stmt
-            .query_map(params![self.active_repo_id, commit_sha, worktree_id], |row| {
-                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        let rows =
+            stmt.query_map(params![self.active_repo_id, commit_sha, worktree_id], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    (row.get::<_, String>(1)?, row.get::<_, String>(2)?, row.get::<_, String>(3)?),
+                ))
             })?;
         rows.collect::<Result<HashMap<_, _>, _>>().map_err(Into::into)
+    }
+
+    /// Config-aware overlay reconcile: extra `(readable, tombstone)` candidates for files whose
+    /// overlay state under `config` (the BRANCH overlay config) differs from the base index for a
+    /// reason the content-based delta (`compute_linked_worktree_delta`, tree-diff + status) cannot
+    /// see — a branch config change that RE-LANGUAGES, newly TARGETS, or DROPS a byte-identical
+    /// file. Mirrors discovery's `(language, kind)` staleness for the overlay (#659 review). Two
+    /// directions, both EXCLUDING `covered` (paths the content delta already reconciles):
+    ///  - walk the branch checkout's target files (the branch config over `source_root`): a file
+    ///    the base index LACKS (newly-targetable) or whose stored base identity DIFFERS
+    ///    (re-languaged) → readable, so the overlay row carries the branch identity; a file whose
+    ///    base identity already matches shows through the base row and needs no overlay;
+    ///  - base rows the branch config NO LONGER targets → tombstone, so the stale base row is
+    ///    shadowed instead of showing through.
+    ///
+    /// Read-only unless there is REAL divergence; on a later pass the row already exists in the
+    /// overlay scope, so the identity-aware skip in `index_explicit_paths_from_root` makes it
+    /// write-free. The caller GATES this on the branch target fingerprint differing from the base's
+    /// ([`IndexDatabase::overlay_targets_may_drift`]), so a no-divergent-config worktree never runs
+    /// the walk (#577 event-scoping).
+    fn overlay_target_config_reconcile(
+        &self,
+        base_sha: &str,
+        config: &Config,
+        source_root: &Path,
+        covered: &BTreeSet<PathBuf>,
+    ) -> anyhow::Result<(Vec<PathBuf>, Vec<PathBuf>)> {
+        // Base-scope identity: path → (language, kind).
+        let base_identity: HashMap<PathBuf, (String, String)> = {
+            let conn = self.storage.connection();
+            let mut stmt = conn.prepare(
+                "SELECT path, language, kind FROM main.files
+                 WHERE repo_id = ?1 AND commit_sha = ?2 AND worktree_id = '' AND generation = ?3
+                   AND kind != 'deleted'",
+            )?;
+            stmt.query_map(params![self.active_repo_id, base_sha, self.active_generation], |row| {
+                Ok((
+                    PathBuf::from(row.get::<_, String>(0)?),
+                    (row.get::<_, String>(1)?, row.get::<_, String>(2)?),
+                ))
+            })?
+            .collect::<Result<_, _>>()?
+        };
+        let mut readable = Vec::new();
+        let mut visited = BTreeSet::new();
+        // Direction 1 — every file the BRANCH config targets in the checkout. `collect_index_files`
+        // walks the branch config's targets over `source_root` (the linked checkout), honoring its
+        // `.gitignore`, exactly like the base walker.
+        let walk_config = Config { root: source_root.to_path_buf(), ..config.clone() };
+        for file in collect_index_files(&walk_config)? {
+            let rel = file.relative_path;
+            if covered.contains(&rel) {
+                continue;
+            }
+            visited.insert(rel.clone());
+            let branch_identity =
+                (file.language.as_str().to_string(), file.kind.as_str().to_string());
+            if base_identity.get(&rel) == Some(&branch_identity) {
+                continue; // the base row already carries the branch identity → it shows through
+            }
+            readable.push(rel); // newly-targetable OR re-languaged → shadow with the branch parse
+        }
+        // Direction 2 — base rows the branch config NO LONGER targets (the walk never reached them,
+        // and the branch config doesn't claim them) → shadow the stale base row. A base row still
+        // targeted but absent in the checkout is a content deletion the delta covers.
+        let mut tombstones = Vec::new();
+        for rel in base_identity.keys() {
+            if covered.contains(rel) || visited.contains(rel) {
+                continue;
+            }
+            if target_for_path(config, rel).is_none() {
+                tombstones.push(rel.clone());
+            }
+        }
+        Ok((readable, tombstones))
     }
 
     /// Remove overlay rows of `worktree_id` whose path is no longer in the delta (the file matches

--- a/crates/rag-rat-core/src/watch/mod.rs
+++ b/crates/rag-rat-core/src/watch/mod.rs
@@ -28,8 +28,10 @@ pub use event_loop::Watcher;
 #[cfg(test)]
 pub(crate) use event_loop::{EventLoop, flush_watch_placement_failures, shutdown_discover};
 #[cfg(test)]
-pub(crate) use overlay::{OverlayBasisAction, overlay_basis_action, overlay_needs_embed};
-pub use overlay::{OverlayScope, ReconcileBudget, refresh_worktree_overlays};
+pub(crate) use overlay::{
+    OverlayBasisAction, overlay_basis_action, overlay_needs_embed, partition_paths_by_worktree,
+};
+pub use overlay::{OverlayScope, ReconcileBudget, refresh_worktree_overlays, reindex_paths};
 #[cfg(test)]
 pub(crate) use papertrail::{PapertrailClock, PapertrailScheduler, papertrail_tick_interval};
 pub use pass::{CLONE_GRAPH_QUIET_MS, maintenance_pass, maintenance_pass_or_skip};

--- a/crates/rag-rat-core/src/watch/overlay.rs
+++ b/crates/rag-rat-core/src/watch/overlay.rs
@@ -3,8 +3,8 @@ use std::path::{Path, PathBuf};
 use std::time::Instant;
 
 use crate::config::Config;
-use crate::index::IndexDatabase;
 use crate::index::ai::ReconcileOptions;
+use crate::index::{IndexDatabase, IndexProgress};
 
 /// The canonical worktree id string [`crate::index::live_worktree_contexts`] reports. When `root`
 /// is a repo SUBDIR (`<repo>/crate`), the enclosing worktree root is `<repo>` — which is the
@@ -272,6 +272,134 @@ impl ReconcileBudget {
     }
 }
 
+/// The `index --paths` orchestration (#659) — the edit-driven-reindex substrate. Reconciles exactly
+/// the supplied candidate `paths`, ROUTING each to the index that owns it:
+/// - a path under `config.root`'s own checkout goes through a scoped base
+///   [`IndexDatabase::index_paths_with_progress`] pass, which reconciles EXACTLY those paths
+///   (content-hash decides staleness; ignored / out-of-target / unchanged paths are no-ops; a
+///   vanished path is tombstoned);
+/// - a path under a LINKED worktree goes through that checkout's OVERLAY instead. This is
+///   load-bearing: `find_config` re-anchors `config.root` to the MAIN checkout, so a linked edit is
+///   not in the base tree — a base pass would `strip_prefix` it away and silently drop it. NOTE the
+///   overlay pass is per-CHECKOUT, not per-path: [`IndexDatabase::index_worktree_overlay`]
+///   reindexes the worktree's whole base↔branch delta (there is no path-scoped overlay primitive
+///   today — see #679), so a linked `index --paths` also refreshes any OTHER pending change in that
+///   checkout. A failure PROPAGATES (unlike the best-effort watcher/maintenance sweep), so an edit
+///   hook can retry instead of exiting 0 on a drop.
+///
+/// The per-repo `WriteLock` is held across BOTH halves (the base pass re-acquires it reentrantly),
+/// mirroring the maintenance path. Returns the base db so the caller can read base-scoped status.
+/// #427 first-time-empty deferral is inherited from the base pass — an unregistered base surfaces
+/// `EmptyIndexRefused` for the caller to defer on (a linked overlay is a delta vs the base, so the
+/// base must exist first).
+pub fn reindex_paths<F>(
+    config: &Config,
+    paths: &[PathBuf],
+    mut progress: F,
+) -> anyhow::Result<IndexDatabase>
+where
+    F: FnMut(IndexProgress),
+{
+    let lock_repo = crate::locks::write_lock_repo_id(config);
+    let _lock = crate::locks::WriteLock::acquire_blocking(&config.database, &lock_repo)?;
+
+    let WorktreePartition { base_paths, linked_roots, manifest_roots } =
+        partition_paths_by_worktree(config, paths);
+    // Always run the base pass: it opens the db (returned for status + the overlay refresh) and
+    // enforces #427. With no base paths it is a no-op scoped pass over an empty change set.
+    let mut db = IndexDatabase::index_paths_with_progress(config, &base_paths, &mut progress)?;
+    for checkout in &linked_roots {
+        // Index each touched checkout's overlay with the LINKED branch's OWN targets (a branch that
+        // adds/narrows targets must be indexed by its own config). `?` PROPAGATES a failure — the
+        // caller (an edit hook) must be able to tell the reindex did not land and retry.
+        let overlay_config = config.for_linked_worktree_overlay(checkout);
+        let report = db.index_worktree_overlay(&overlay_config, checkout, &mut progress)?;
+        // A PARTIAL status read (`status_complete = false`) may have missed the supplied
+        // uncommitted edit, yet returns Ok — so, like the watcher, CLEAR this worktree's overlay
+        // basis so a later scoped pass re-refreshes it instead of skipping on a still-matching
+        // basis. Otherwise `index --paths` would report success while leaving the branch stale
+        // (#659 review).
+        if !report.status_complete && !report.worktree_id.is_empty() {
+            let _ = db.clear_worktree_overlay_basis(&report.worktree_id);
+        }
+        // A SUPPLIED `Cargo.toml` must refresh the overlay's package map even when it is CLEAN/
+        // committed (so it produced no source rows and the overlay's status-derived signal missed
+        // it) — the base flow refreshes on a named manifest regardless of dirtiness, and the linked
+        // route must honor the same "also sees committed changes" contract (#659 review).
+        if manifest_roots.contains(checkout) {
+            db.refresh_worktree_overlay_packages(&overlay_config, checkout)?;
+        }
+    }
+    // `index_worktree_overlay` / the manifest refresh leave the connection scoped to the LAST
+    // overlay; restore the base scope so the returned db reads base-scoped status.
+    if !linked_roots.is_empty() {
+        let (base_sha, base_id) = crate::index::resolve_git_context(&config.root);
+        db.set_context(&base_sha, &base_id)?;
+    }
+    Ok(db)
+}
+
+/// Candidate paths split by which checkout owns them (see [`partition_paths_by_worktree`]).
+pub(crate) struct WorktreePartition {
+    /// Paths under the base checkout (and non-git trees) — the scoped base pass reconciles these.
+    pub(crate) base_paths: Vec<PathBuf>,
+    /// Live linked-worktree checkout roots any supplied path lives under — each gets an overlay
+    /// pass.
+    pub(crate) linked_roots: BTreeSet<PathBuf>,
+    /// Linked checkout roots that had a supplied `Cargo.toml`. Their overlay package map must be
+    /// refreshed even for a CLEAN/committed manifest — the overlay's own signal is status-derived
+    /// (dirty-only), so this carries the base flow's supplied-manifest signal to the linked route.
+    pub(crate) manifest_roots: BTreeSet<PathBuf>,
+}
+
+/// Split absolute candidate paths by owning checkout. A path is a linked-worktree path when its
+/// (canonicalized) location lives under a live linked checkout root; everything else — including
+/// non-git trees and paths already under the base checkout — is a base path. The linked roots are
+/// the [`crate::index::live_worktree_contexts`] spellings (canonicalized, base excluded), so the
+/// base pass and the overlay refresh key on the exact same identities the rest of the engine uses.
+pub(crate) fn partition_paths_by_worktree(config: &Config, paths: &[PathBuf]) -> WorktreePartition {
+    let (_, worktrees) = crate::index::live_worktree_contexts(&config.root);
+    let base = enclosing_worktree_id(&config.root);
+    let linked: Vec<PathBuf> =
+        worktrees.into_iter().filter(|w| *w != base).map(PathBuf::from).collect();
+    let mut partition = WorktreePartition {
+        base_paths: Vec::new(),
+        linked_roots: BTreeSet::new(),
+        manifest_roots: BTreeSet::new(),
+    };
+    for path in paths {
+        match enclosing_linked_root(path, &linked) {
+            Some(root) => {
+                if path.file_name() == Some(std::ffi::OsStr::new("Cargo.toml")) {
+                    partition.manifest_roots.insert(root.clone());
+                }
+                partition.linked_roots.insert(root);
+            },
+            None => partition.base_paths.push(path.clone()),
+        }
+    }
+    partition
+}
+
+/// The live linked checkout root `path` lives under, or `None` if it is under the base checkout (or
+/// no linked worktree). Compares against the canonicalized `linked` roots after canonicalizing
+/// `path` itself — via the shared [`crate::index::canonicalize_nearest_ancestor`], which walks up
+/// to the nearest EXISTING ancestor (a deletion may have removed the file AND its parent dir, e.g.
+/// `rm -rf wt/src`) so a symlinked checkout dir (`/tmp` → `/private/tmp`) is never misrouted to the
+/// base. Falls back to the lexical path only when nothing on the chain resolves. Picks the MOST
+/// SPECIFIC (longest) matching root, not the first: a worktree NESTED under another worktree's dir
+/// makes `path` a prefix-match of BOTH, and the nested checkout is the real owner — a first-match
+/// would refresh the outer overlay and leave the nested one stale.
+fn enclosing_linked_root(path: &Path, linked: &[PathBuf]) -> Option<PathBuf> {
+    let canonical =
+        crate::index::canonicalize_nearest_ancestor(path).unwrap_or_else(|| path.to_path_buf());
+    linked
+        .iter()
+        .filter(|root| canonical.starts_with(root))
+        .max_by_key(|root| root.components().count())
+        .cloned()
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeSet;
@@ -288,6 +416,33 @@ mod tests {
         assert!(OverlayScope::All.lists(&id));
         assert!(linked.lists(&id));
         assert!(!linked.lists("some-other-worktree"));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn enclosing_linked_root_picks_the_most_specific_nested_worktree() {
+        // A worktree NESTED under another worktree's dir makes a path a prefix-match of BOTH roots;
+        // the nested checkout is the real owner. Longest match must win regardless of the order
+        // `live_worktree_contexts` returns the roots in (#659 review). (Non-existent paths → the
+        // canonicalize fallback is the lexical path, so this white-boxes the selection.)
+        let outer = PathBuf::from("/wt/outer");
+        let inner = PathBuf::from("/wt/outer/inner");
+        let path = PathBuf::from("/wt/outer/inner/src/x.rs");
+        assert_eq!(
+            enclosing_linked_root(&path, &[outer.clone(), inner.clone()]),
+            Some(inner.clone()),
+            "outer-first: the nested root still wins",
+        );
+        assert_eq!(
+            enclosing_linked_root(&path, &[inner.clone(), outer.clone()]),
+            Some(inner.clone()),
+            "inner-first: the nested root still wins",
+        );
+        // A path under only the outer root routes to the outer.
+        assert_eq!(
+            enclosing_linked_root(Path::new("/wt/outer/top.rs"), &[outer.clone(), inner]),
+            Some(outer),
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes #659.

## What

`rag-rat index --paths <p1> <p2> …` — reconcile exactly a caller-supplied set of files, the substrate for edit-driven reindex. A git hook or a coding-agent edit hook knows precisely which paths it touched, and — unlike the default changed-file mode, which reads git **status** — an explicit list also sees committed changes.

## Core

- **`IndexMode::Paths`** — a `Copy` unit marker; the path list is threaded alongside as `explicit_paths` (the mode is copied at several hot sites in the pass, so it stays `Copy`).
- **Change set** (`explicit_index_files_and_changes`): normalize each path to config-root-relative, drop it if it escapes the tree once `..`/symlinks are resolved (`resolves_within_root`) or is ignored / not a configured target, then build an `IndexFile` for every supplied indexable path. Crucially it does **not** treat every supplied file as working-tree dirt — it cross-references the actual git status, so a clean/committed supplied file is scoped to the **committed** scope (not shadowed by an overlay row), while a dirty one is overlay-scoped.
- **HEAD-move completeness**: like Changed, Paths promotes to a discovery when the active base scope is incomplete (a commit advanced HEAD) — otherwise the unchanged files would be orphaned at the old sha and queries would lose most of the repo.
- **Deferral**: a scoped pass on an uninitialized index (no DB / schemaless) **defers** (`EmptyIndexRefused`) rather than full-rebuilding the repo, and inherits the #427 first-time-empty deferral.
- Public entries `IndexDatabase::index_paths[_with_progress]`.

## Linked-worktree routing

`find_config` re-anchors `config.root` to the MAIN checkout, so a linked-worktree edit is not in the base tree — a base pass would `strip_prefix` it away and silently drop it. `reindex_paths` partitions supplied paths by enclosing worktree (canonicalizing the nearest surviving ancestor so a deleted file whose parent is also gone still routes correctly): base-checkout paths run the scoped base pass; linked-worktree paths go through `index_worktree_overlay` per checkout, **propagating** overlay failures so an edit hook can retry. The per-repo write lock is held across both halves. (The overlay pass is per-checkout whole-delta, not per-path — a path-scoped overlay reconcile is tracked as #679.)

## CLI

`index --paths` (conflicts with the other index modes). Defers gracefully on an uninitialized repo.

## Tests

Reconciles exactly the supplied paths; ignored / out-of-target / unchanged are no-ops; a vanished path is tombstoned; a clean committed file stays committed-scoped; a HEAD move completes the scope; a `..`- or symlink-escaping path is rejected; an uninitialized repo defers instead of rebuilding; linked-worktree paths (incl. a deleted-parent deletion) route to the overlay.

Full workspace suite green; all four CI clippy gates pass (incl. `--all-features`).