### PR TITLE
test(memory): confirm the read path is unchanged under /3 + mark the foreign read projection phase-D

### DIFF
--- a/crates/rag-rat-core/src/oplog/account/content/storage.rs
+++ b/crates/rag-rat-core/src/oplog/account/content/storage.rs
@@ -122,6 +122,13 @@ pub(in crate::oplog) fn content_ingest(
     // this is a no-op and the entry stays `retained_unfolded` until the account→content trigger
     // refolds it; with authority present the entry lands on its real verdict in this same txn.
     refold_content_stream(&tx, verified.header.stream_id)?;
+    // TODO(phase D): project a newly-ACCEPTED FOREIGN entry into `repo_memories` /
+    // `repo_node_edges` here (and from the account→content retro-trigger that retro-accepts
+    // foreign content), so a remote memory surfaces in the local read APIs — those read ONLY
+    // the memory tables, never this `/3` stream or its projection. Deferrable until transport
+    // lands because no foreign entry can exist before then; the local author path needs no such
+    // write-back (it authors `/3` content FROM `repo_memories`, so the reader's row is already
+    // present). Tracked in #691.
     let status = status_for(&tx, &verified.entry_hash)?
         .unwrap_or_else(|| ContentStatus::RetainedUnfolded.as_db_str().to_string());
     tx.commit()?;

--- a/crates/rag-rat-core/src/query/memory/authoring.rs
+++ b/crates/rag-rat-core/src/query/memory/authoring.rs
@@ -1414,4 +1414,44 @@ mod tests {
         );
         assert_eq!(entry_count(&conn), 0, "the oversized batch rolled back — no /3 content stored");
     }
+
+    // --- read path is unchanged by the retarget (#665) ---
+
+    #[test]
+    fn local_reads_come_from_repo_memories_not_the_v3_stream() {
+        // The retarget moved AUTHORING onto /3, but local reads must be unchanged: they come from
+        // repo_memories, never the /3 stream or its content_projected_* shadow (whose only consumer
+        // is the reconcile's completeness anti-join). Prove it: author via the live path, then WIPE
+        // the entire /3 substrate and confirm a read returns the same memories. A read that
+        // consulted any /3 table would change here.
+        let conn = scoped_conn();
+        let created = create_concept(&conn, "readable").unwrap().memory.memory_id;
+
+        let read_ids = |c: &Connection| -> Vec<String> {
+            crate::query::memory::list_memories(c, None)
+                .unwrap()
+                .into_iter()
+                .map(|m| m.memory_id)
+                .collect()
+        };
+        let before = read_ids(&conn);
+        assert!(before.contains(&created), "the authored memory lists before the wipe");
+
+        // Wipe every /3 table the live path writes (FKs off so delete order is irrelevant).
+        conn.execute_batch(
+            "PRAGMA foreign_keys = OFF;
+             DELETE FROM content_projected_nodes;
+             DELETE FROM content_projected_edges;
+             DELETE FROM content_entry_status;
+             DELETE FROM content_entries;
+             PRAGMA foreign_keys = ON;",
+        )
+        .unwrap();
+
+        assert_eq!(
+            read_ids(&conn),
+            before,
+            "reads are identical with the whole /3 substrate wiped — they never consult it",
+        );
+    }
 }


### PR DESCRIPTION
Final slice of the C3.4 retarget (#664). The retarget moved memory authoring onto owner-bound `/3` content; this slice confirms the read side is unchanged and pins the one deferred piece.

## What lands

- **Read-path pin test.** Local reads come entirely from `repo_memories` / `repo_node_edges` — the read APIs (`list_memories`, `memories_for_*`, …) never consult the `/3` stream or its `content_projected_*` shadow (whose only consumer is the reconcile's completeness anti-join). `local_reads_come_from_repo_memories_not_the_v3_stream` authors via the live path, **wipes the entire `/3` substrate** (`content_entries`, `content_entry_status`, `content_projected_*`), and asserts reads are identical — so any future change that routed a read through `/3` breaks the test.
- **Foreign read-projection marker.** A `TODO(phase D)` at the `content_ingest` seam (right after the acceptance refold): a remote memory accepted into `/3` must be written back to `repo_memories` to surface in local reads. Deferrable today because no foreign entry can exist before transport, and the local author path needs no write-back (it authors `/3` content *from* `repo_memories`). Tracked in **#691**.

## Confirmed, no change needed

- **`AuthoredDurability` (#560).** The mint (`bootstrap::local_account`) and the retargeted reconcile each set `synchronous = FULL` for their own authored txn — both authored-class writes are already durable.

## Spec-conformance callout

The C3 requirement wires the acceptance predicate into the memory **write *and* read** path. Deferring the foreign-`/3` → `repo_memories` projection (#691) is a scope cut against the "read path" half — blessed for the pre-transport window because the *local* read path is complete and no foreign content exists yet. Flagged for the spec owner.

Gates: fmt, both CI clippy invocations, `cargo nextest run -p rag-rat-core` (2573 passed) all green. Codex-reviewed clean.

Closes #665