### PR TITLE
perf(graph): index-seed the remaining edges-view readers — grep_augment + impact_surface (#692)

### DIFF
--- a/crates/rag-rat-core/src/index/oracle/tests/edge_view.rs
+++ b/crates/rag-rat-core/src/index/oracle/tests/edge_view.rs
@@ -301,3 +301,54 @@ fn graph_traversal_seed_predicates_use_edge_id_indexes() {
         "forward seed must not full-scan the edge rows, got plan:\n{forward}"
     );
 }
+
+/// #692: the same indexed-seed contract for the other hot edges-view readers #682 did not touch —
+/// `grep_augment::edge_counts`' caller-count (runs on every grep-augmented hit) and
+/// `impact_surface`'s Syntactic/Fuzzy neighbor predicates. Each seed must drive the edge id
+/// indexes, never full-scan `edges_data` through the view's value joins.
+#[test]
+fn impact_and_grep_augment_seeds_use_edge_id_indexes() {
+    let conn = Connection::open_in_memory().unwrap();
+    schema::apply(&conn).unwrap();
+
+    let plan = |sql: &str| -> String {
+        let mut stmt = conn.prepare(&format!("EXPLAIN QUERY PLAN {sql}")).unwrap();
+        stmt.query_map([], |row| row.get::<_, String>(3))
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap()
+            .join("\n")
+    };
+
+    // grep_augment::edge_counts caller-count shape (reverse: to_symbol_id OR
+    // target_qualified_name_id).
+    let callers = plan(
+        "SELECT COUNT(*) FROM edges JOIN files source_files ON source_files.id = \
+         edges.source_file_id
+         WHERE edges.to_symbol_id = 5
+            OR edges.target_qualified_name_id = (SELECT id FROM name_strings WHERE value = 'x')",
+    );
+    assert!(
+        callers.contains("idx_edges_to_symbol") && callers.contains("idx_edges_target_qname"),
+        "grep_augment caller-count must drive the edge id indexes, got:\n{callers}"
+    );
+    assert!(
+        !callers.contains("SCAN d") && !callers.contains("SCAN edges_data"),
+        "grep_augment caller-count must not full-scan the edge rows, got:\n{callers}"
+    );
+
+    // impact_surface forward Syntactic/Fuzzy neighbor shape (from_symbol_id OR from_name_id).
+    let fwd = plan(
+        "SELECT id FROM edges
+         WHERE edges.from_symbol_id = 5
+            OR edges.from_name_id = (SELECT id FROM name_strings WHERE value = 'x')",
+    );
+    assert!(
+        fwd.contains("idx_edges_from_symbol") && fwd.contains("idx_edges_from_name"),
+        "impact forward neighbor seed must drive the edge id indexes, got:\n{fwd}"
+    );
+    assert!(
+        !fwd.contains("SCAN d") && !fwd.contains("SCAN edges_data"),
+        "impact forward neighbor seed must not full-scan the edge rows, got:\n{fwd}"
+    );
+}

--- a/crates/rag-rat-core/src/query/grep_augment.rs
+++ b/crates/rag-rat-core/src/query/grep_augment.rs
@@ -497,12 +497,17 @@ fn render(
 fn edge_counts(conn: &Connection, hit: &symbol::SymbolHit) -> anyhow::Result<(i64, i64)> {
     // GENERATION-SCOPED via the `files` view (batch 6, count-scoping class; `compose` installs the
     // worktree scope view before calling in). The `to_symbol_id = ?1` arm keys on a LIVE rowid, but
-    // the `OR target_qualified_name = ?2` arm matches callers purely by NAME and so double-counts
-    // dead-generation edges during a dead-generation window, inflating the "{N} callers" line.
+    // the interned-name arm matches callers purely by NAME and so double-counts dead-generation
+    // edges during a dead-generation window, inflating the "{N} callers" line.
+    // #692: the name arm compares the raw `target_qualified_name_id` against an interned-id lookup,
+    // not the value-joined `target_qualified_name`, so the planner drives idx_edges_to_symbol +
+    // idx_edges_target_qname (a MULTI-INDEX OR) instead of full-scanning edges_data — this count
+    // runs on every grep-augmented hit. Same matching semantics; same class as #682.
     let callers: i64 = conn.query_row(
         "SELECT COUNT(*) FROM edges
          JOIN files source_files ON source_files.id = edges.source_file_id
-         WHERE edges.to_symbol_id = ?1 OR edges.target_qualified_name = ?2",
+         WHERE edges.to_symbol_id = ?1
+            OR edges.target_qualified_name_id = (SELECT id FROM name_strings WHERE value = ?2)",
         rusqlite::params![hit.symbol_id, hit.qualified_name],
         |row| row.get(0),
     )?;

--- a/crates/rag-rat-core/src/query/impact/neighbors.rs
+++ b/crates/rag-rat-core/src/query/impact/neighbors.rs
@@ -137,15 +137,24 @@ pub(crate) fn impact_graph_predicate(reverse: bool, mode: GraphResolutionMode) -
         (true, GraphResolutionMode::Exact) => "edges.to_symbol_id = ?1",
         (false, GraphResolutionMode::Exact) =>
             "edges.from_symbol_id = ?1 AND edges.to_symbol_id IS NOT NULL",
+        // #692: seed on the `edges` view's raw id columns compared to an interned-id lookup, not
+        // the value-joined `target_qualified_name` / `from_name`, so the planner drives a
+        // MULTI-INDEX OR over idx_edges_to_symbol/idx_edges_target_qname (reverse) or
+        // idx_edges_from_symbol/idx_edges_from_name (forward) instead of full-scanning edges_data.
+        // Same class as #682; the Fuzzy REVERSE arm already used the id form.
         (true, GraphResolutionMode::Syntactic) =>
-            "edges.to_symbol_id = ?1 OR edges.target_qualified_name = ?2",
+            "edges.to_symbol_id = ?1 OR edges.target_qualified_name_id = (SELECT id FROM \
+             name_strings WHERE value = ?2)",
         (false, GraphResolutionMode::Syntactic) =>
-            "(edges.from_symbol_id = ?1 OR edges.from_name = ?2)
+            "(edges.from_symbol_id = ?1 OR edges.from_name_id = (SELECT id FROM name_strings WHERE \
+             value = ?2))
              AND (edges.to_symbol_id IS NOT NULL OR edges.target_qualified_name IS NOT NULL)",
         (true, GraphResolutionMode::Fuzzy) =>
             "edges.to_symbol_id = ?1 OR edges.to_name_id = (SELECT id FROM name_strings WHERE \
              value = ?2)",
-        (false, GraphResolutionMode::Fuzzy) => "edges.from_symbol_id = ?1 OR edges.from_name = ?2",
+        (false, GraphResolutionMode::Fuzzy) =>
+            "edges.from_symbol_id = ?1 OR edges.from_name_id = (SELECT id FROM name_strings WHERE \
+             value = ?2)",
     }
 }
 
@@ -307,4 +316,36 @@ pub(crate) fn textual_fallback(
         surface.push(ImpactCategory::ProbableTextual, file_symbol, "textual_fallback", evidence);
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// #692: pin the real predicate strings to the indexed-id form so a refactor cannot silently
+    /// reintroduce the value-joined `target_qualified_name` / `from_name` seed (which full-scans
+    /// edges_data — the plan is asserted in
+    /// `edge_view::impact_and_grep_augment_seeds_use_edge_id_indexes`).
+    #[test]
+    fn syntactic_and_fuzzy_predicates_seed_on_interned_ids() {
+        use GraphResolutionMode::{Fuzzy, Syntactic};
+        for (reverse, mode, id_col) in [
+            (true, Syntactic, "target_qualified_name_id"),
+            (false, Syntactic, "from_name_id"),
+            (false, Fuzzy, "from_name_id"),
+        ] {
+            let p = impact_graph_predicate(reverse, mode);
+            assert!(
+                p.contains(&format!("{id_col} = (SELECT id FROM name_strings WHERE value = ?2)")),
+                "({reverse}, {mode:?}) must seed on {id_col} via an interned-id lookup, got: {p}"
+            );
+            // The value-joined forms must never come back (they defeat the edge indexes).
+            assert!(
+                !p.contains("target_qualified_name = ?") && !p.contains("from_name = ?"),
+                "({reverse}, {mode:?}) must not compare a value-joined column, got: {p}"
+            );
+            // `?2` must stay present so `graph_neighbors`' `binds_name` name-pass still fires.
+            assert!(p.contains("?2"), "({reverse}, {mode:?}) must still bind ?2, got: {p}");
+        }
+    }
 }


### PR DESCRIPTION
## Summary

#682 fixed the graph-traversal seed predicate, but the same footgun — a hot query over the `edges` view seeding on a **value-joined** column instead of the raw indexed id column — survives in a few more read paths. Each full-**SCAN**s the ~1M-row `edges_data` table on every call. An audit of all `edges`-view consumers bounds the remaining class to **4 sites**; the fix is the same mechanical `value → id` rewrite the view already exposes the id columns for.

## Confirmed sites (EXPLAIN QUERY PLAN on a real ~1M-edge snapshot: all `SCAN d` today → `MULTI-INDEX OR` after)

1. **`query/grep_augment.rs` `edge_counts` (caller count)** — *hottest*: runs on every agent `Grep`/`rg` that surfaces symbol context.
   `WHERE edges.to_symbol_id = ?1 OR edges.target_qualified_name = ?2`
2. **`query/impact/neighbors.rs` `impact_graph_predicate` (true, Syntactic)**
   `edges.to_symbol_id = ?1 OR edges.target_qualified_name = ?2`
3. **`query/impact/neighbors.rs` `impact_graph_predicate` (false, Syntactic)**
   `(edges.from_symbol_id = ?1 OR edges.from_name = ?2) AND (...)`
4. **`query/impact/neighbors.rs` `impact_graph_predicate` (false, Fuzzy)**
   `edges.from_symbol_id = ?1 OR edges.from_name = ?2`

## Fix (per site)

- `edges.target_qualified_name = ?N` → `edges.target_qualified_name_id = (SELECT id FROM name_strings WHERE value = ?N)` (uses `idx_edges_target_qname`, added in #682).
- `edges.from_name = ?N` → `edges.from_name_id = (SELECT id FROM name_strings WHERE value = ?N)` (uses the existing `idx_edges_from_name`).

Matching semantics are identical (a faithful transform of `<value-col> = ?` into `<id-col> = (interned-id lookup)`); only the access path changes. No new index needed (#682 already added the one that was missing). The queries keep referencing the scoped `edges` view, so worktree-overlay scoping is unaffected.

## Verified already-clean (no change)

- `query/graph_meta.rs` — `caller_count` / `callers` / `count_*` already seed on `to_name_id` / `from_symbol_id`; the `edge_kind IN (...)` / `confidence = ...` are secondary AND-filters on an index-narrowed set.
- `query/impact/items.rs` `import_export_items` and `neighbors.rs` `import_export_dependents` — already seed on `(to_symbol_id OR to_name_id = …)`.
- The traversal **Fuzzy** arms and the `reverse_tier` / `match_tier` `CASE` expressions (`query/graph/predicates.rs`, `traverse.rs`) are left as-is: Fuzzy is opt-in and already `LIKE`-scans (id-form gives no benefit), and the tier `CASE` runs only on rows that already passed the WHERE.

## Acceptance criteria

- `EXPLAIN QUERY PLAN` for the 4 sites shows `MULTI-INDEX OR` / `SEARCH ... USING INDEX`, no `SCAN` of the edge rows.
- Plan-pinning regression tests for `grep_augment` `edge_counts` and the `impact_graph_predicate` Syntactic/Fuzzy arms.
- Returned counts/rows unchanged; impact + grep-augment tests pass.

Follows #682.
