### PR TITLE
perf(symbol): trigram-index name_strings so bare-name fuzzy lookup stops full-scanning (#685)

### DIFF
--- a/crates/rag-rat-core/src/index/schema/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema/migrations.rs
@@ -784,6 +784,52 @@ pub(crate) fn apply_edge_target_qname_index(conn: &Connection) -> rusqlite::Resu
     )
 }
 
+/// V072 (#685): a trigram FTS index over the interned-name pool. `symbol_lookup`'s bare-name fuzzy
+/// arm matches `name_strings.value LIKE '%name%'` — a LEADING-wildcard LIKE that cannot use the
+/// UNIQUE value index, so it full-scans the whole pool on every bare-name lookup. An FTS5 `trigram`
+/// index accelerates that exact `LIKE` (identical substring-match set for patterns ≥3 chars;
+/// shorter patterns still resolve correctly via a scan). External content
+/// (`content='name_strings'`, `content_rowid='id'`) means the FTS stores only the index and reads
+/// values from name_strings; the insert/delete/update triggers keep it in sync as names are
+/// interned.
+///
+/// DROP-and-recreate (like `ensure_edges_view`) makes it fully idempotent and torn-replay safe: the
+/// backfill always reflects the current pool. It runs once per DB (recorded in schema_version); on
+/// a fresh DB name_strings is still empty here, so the backfill inserts nothing and the AFTER
+/// INSERT trigger indexes each interned name as indexing fills the pool.
+pub(crate) fn apply_name_strings_trigram_index(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "
+        DROP TRIGGER IF EXISTS name_strings_trgm_ai;
+        DROP TRIGGER IF EXISTS name_strings_trgm_ad;
+        DROP TRIGGER IF EXISTS name_strings_trgm_au;
+        DROP TABLE IF EXISTS name_strings_trgm;
+
+        CREATE VIRTUAL TABLE name_strings_trgm USING fts5(
+            value,
+            content='name_strings',
+            content_rowid='id',
+            tokenize='trigram'
+        );
+
+        CREATE TRIGGER name_strings_trgm_ai AFTER INSERT ON name_strings BEGIN
+            INSERT INTO name_strings_trgm(rowid, value) VALUES (new.id, new.value);
+        END;
+        CREATE TRIGGER name_strings_trgm_ad AFTER DELETE ON name_strings BEGIN
+            INSERT INTO name_strings_trgm(name_strings_trgm, rowid, value)
+                VALUES ('delete', old.id, old.value);
+        END;
+        CREATE TRIGGER name_strings_trgm_au AFTER UPDATE ON name_strings BEGIN
+            INSERT INTO name_strings_trgm(name_strings_trgm, rowid, value)
+                VALUES ('delete', old.id, old.value);
+            INSERT INTO name_strings_trgm(rowid, value) VALUES (new.id, new.value);
+        END;
+
+        INSERT INTO name_strings_trgm(rowid, value) SELECT id, value FROM name_strings;
+        ",
+    )
+}
+
 /// Create the `edges` compatibility VIEW + its INSTEAD OF triggers (#79) — but ONLY when no
 /// legacy `edges` TABLE is present (an INSTEAD OF trigger on a table is a hard error, and the
 /// legacy table must keep working until `apply_edge_string_interning` converts it).
@@ -1285,6 +1331,7 @@ pub(crate) fn known_version(migrations: &[AppliedMigration]) -> u32 {
             MIGRATION_069_ID => Some(69),
             MIGRATION_070_ID => Some(70),
             MIGRATION_071_ID => Some(71),
+            MIGRATION_072_ID => Some(72),
             _ => None,
         })
         .max()
@@ -1365,6 +1412,7 @@ pub(crate) fn known_migration(id: &str) -> bool {
             | MIGRATION_069_ID
             | MIGRATION_070_ID
             | MIGRATION_071_ID
+            | MIGRATION_072_ID
             | DIRTY_MIGRATION_ID
     )
 }
@@ -1442,6 +1490,7 @@ pub(crate) fn migration_checksum_mismatch(migration: &AppliedMigration) -> bool 
         MIGRATION_069_ID => migration.checksum != MIGRATION_069_CHECKSUM,
         MIGRATION_070_ID => migration.checksum != MIGRATION_070_CHECKSUM,
         MIGRATION_071_ID => migration.checksum != MIGRATION_071_CHECKSUM,
+        MIGRATION_072_ID => migration.checksum != MIGRATION_072_CHECKSUM,
         _ => false,
     }
 }

--- a/crates/rag-rat-core/src/index/schema/mod.rs
+++ b/crates/rag-rat-core/src/index/schema/mod.rs
@@ -19,7 +19,7 @@ pub use registry::{LEGACY_REPO_ID, RegisteredRepo, register_repo, register_repo_
 use rusqlite::{Connection, OptionalExtension, Transaction, TransactionBehavior, params};
 use serde::Serialize;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 71;
+pub const LATEST_SCHEMA_VERSION: u32 = 72;
 
 /// Every oracle-DERIVED persisted table — the outputs an `oracle run` writes that must OUTLIVE a
 /// reindex.
@@ -495,6 +495,13 @@ const MIGRATION_071_DESCRIPTION: &str =
      instead of full-scanning the edge table when matching unresolved edges by \
      target_qualified_name. Purely additive; CREATE INDEX IF NOT EXISTS, nothing pre-existing to \
      backfill";
+const MIGRATION_072_ID: &str = "072_name_strings_trigram_index";
+const MIGRATION_072_CHECKSUM: &str = "sha256:rag-rat-name-strings-trigram-index-v72";
+const MIGRATION_072_DESCRIPTION: &str =
+    "Add the name_strings_trgm FTS5 trigram index over name_strings(value) so symbol_lookup's \
+     bare-name fuzzy arm (a leading-wildcard LIKE) stops full-scanning the interned-name pool. \
+     External-content FTS kept in sync by insert/delete/update triggers; existing rows backfilled \
+     once. Additive and idempotent; preserves the exact substring-match set of the old LIKE";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -1082,6 +1089,12 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         checksum: MIGRATION_071_CHECKSUM,
         description: MIGRATION_071_DESCRIPTION,
         apply: apply_edge_target_qname_index,
+    },
+    Migration {
+        id: MIGRATION_072_ID,
+        checksum: MIGRATION_072_CHECKSUM,
+        description: MIGRATION_072_DESCRIPTION,
+        apply: apply_name_strings_trigram_index,
     },
 ];
 

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
@@ -2249,10 +2249,15 @@ fn migration_070_adds_the_content_projected_tables() {
 }
 
 #[test]
-fn migration_071_is_the_tip_and_indexes_edge_target_qname() {
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 71, "move this pin with the next schema migration");
+fn migration_071_indexes_edge_target_qname() {
+    // The absolute-tip pin moved to `migration_072_*`; this drops to the symbolic freshness check.
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     schema::apply(&conn).unwrap();
+    assert_eq!(
+        schema::status(&conn).unwrap().current_version,
+        schema::LATEST_SCHEMA_VERSION,
+        "schema at LATEST after apply",
+    );
 
     let index_on = |conn: &rusqlite::Connection| -> i64 {
         conn.query_row(
@@ -2288,6 +2293,74 @@ fn migration_071_is_the_tip_and_indexes_edge_target_qname() {
         )
         .unwrap();
     assert_eq!(v71_recorded, 1, "the forward migration records V071");
+}
+
+#[test]
+fn migration_072_is_the_tip_and_trigram_indexes_name_strings() {
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 72, "move this pin with the next schema migration");
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn).unwrap();
+
+    // The FTS5 trigram table and its three sync triggers exist.
+    let object_kind = |name: &str| -> Option<String> {
+        conn.query_row("SELECT type FROM sqlite_master WHERE name = ?1", [name], |row| {
+            row.get::<_, String>(0)
+        })
+        .ok()
+    };
+    assert_eq!(object_kind("name_strings_trgm").as_deref(), Some("table"), "trigram FTS exists");
+    for trig in ["name_strings_trgm_ai", "name_strings_trgm_ad", "name_strings_trgm_au"] {
+        assert_eq!(object_kind(trig).as_deref(), Some("trigger"), "{trig} exists");
+    }
+
+    // # of indexed docs, read from the FTS docsize shadow (a plain SELECT on an external-content
+    // FTS reads the base table, so it cannot report the index's own population).
+    let indexed = |conn: &rusqlite::Connection| -> i64 {
+        conn.query_row("SELECT COUNT(*) FROM name_strings_trgm_docsize", [], |r| r.get(0)).unwrap()
+    };
+
+    // AFTER INSERT trigger indexes newly interned names; the trigram LIKE finds them and agrees
+    // with the base pool's LIKE (identical substring-match set).
+    for v in ["reconcile_edges", "embed_chunk", "TargetQualifiedName"] {
+        conn.execute("INSERT OR IGNORE INTO name_strings(value) VALUES (?1)", [v]).unwrap();
+    }
+    let via_fts: Vec<i64> = {
+        let mut stmt = conn
+            .prepare("SELECT rowid FROM name_strings_trgm WHERE value LIKE ?1 ORDER BY rowid")
+            .unwrap();
+        stmt.query_map(["%oncile%"], |r| r.get(0)).unwrap().collect::<Result<_, _>>().unwrap()
+    };
+    let via_base: Vec<i64> = {
+        let mut stmt =
+            conn.prepare("SELECT id FROM name_strings WHERE value LIKE ?1 ORDER BY id").unwrap();
+        stmt.query_map(["%oncile%"], |r| r.get(0)).unwrap().collect::<Result<_, _>>().unwrap()
+    };
+    assert_eq!(via_fts, via_base, "trigram LIKE returns the same ids as the base pool LIKE");
+    assert!(!via_fts.is_empty(), "the substring actually matched a seeded name");
+    assert_eq!(indexed(&conn), 3, "each interned name is indexed exactly once");
+
+    // Backfill + idempotency: the DROP-and-recreate applier rebuilds from the current pool, and a
+    // replay does not double-index (count stays equal to the pool size).
+    schema::apply_name_strings_trigram_index(&conn).unwrap();
+    schema::apply_name_strings_trigram_index(&conn).expect("replay reconverges");
+    assert_eq!(indexed(&conn), 3, "backfill re-indexes every existing name exactly once");
+
+    // A forward migrate over a ledger truncated below V072 replays the step and records V072.
+    truncate_schema_to(&conn, 71);
+    schema::migrate_forward(&conn).unwrap();
+    assert_eq!(
+        schema::status(&conn).unwrap().current_version,
+        schema::LATEST_SCHEMA_VERSION,
+        "forward migrate reaches the tip",
+    );
+    let v72_recorded: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM schema_version WHERE id = '072_name_strings_trigram_index'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(v72_recorded, 1, "the forward migration records V072");
 }
 
 #[test]

--- a/crates/rag-rat-core/src/query/symbol.rs
+++ b/crates/rag-rat-core/src/query/symbol.rs
@@ -326,11 +326,14 @@ fn lookup_name(
     limit: u32,
     include_generated: bool,
 ) -> anyhow::Result<Vec<SymbolHit>> {
-    // Fuzzy qualified-name match is interned (#224): match against the shared `name_strings` pool
-    // (`qualified_name_id IN (SELECT id FROM name_strings WHERE value LIKE ?2)`) then scope back to
-    // `symbols` via the join. The `name = ?1` exact arm is unaffected and stays on
-    // `idx_symbols_name` — keep it first so a bare-name hit is indexed. The projection reads
-    // the value back through the `qn` join so the output `qualified_name` field is unchanged.
+    // Fuzzy qualified-name match is interned (#224) and trigram-indexed (#685): match the leading-
+    // wildcard `value LIKE ?2` against the `name_strings_trgm` FTS5 trigram index (rowid = the
+    // name_strings id) instead of the base pool — the plain `name_strings WHERE value LIKE '%x%'`
+    // form full-scans the whole pool on every bare-name lookup, the trigram index accelerates the
+    // exact same `LIKE` (identical substring-match set). Then scope back to `symbols` via the join.
+    // The `name = ?1` exact arm is unaffected and stays on `idx_symbols_name` — keep it first so a
+    // bare-name hit is indexed. The projection reads the value back through the `qn` join so the
+    // output `qualified_name` field is unchanged.
     let mut sql = "
         SELECT symbols.id, files.id, files.path, files.kind, symbols.language, symbols.name, \
                    qn.value,
@@ -339,7 +342,8 @@ fn lookup_name(
         JOIN files ON files.id = symbols.file_id
         LEFT JOIN name_strings qn ON qn.id = symbols.qualified_name_id
         WHERE (symbols.name = ?1
-               OR symbols.qualified_name_id IN (SELECT id FROM name_strings WHERE value LIKE ?2))
+               OR symbols.qualified_name_id IN (SELECT rowid FROM name_strings_trgm WHERE value \
+                   LIKE ?2))
     "
     .to_string();
     if !include_generated {


### PR DESCRIPTION
## Problem

`symbol_lookup`'s bare-name **fuzzy** arm matches `name_strings.value LIKE '%name%'` — a leading-wildcard LIKE that cannot use the UNIQUE `value` index, so it full-**SCAN**s the ~116k-row interned-name pool on every bare-name lookup (~40 ms measured). The exact whole-word arm (`symbols.name = ?1`) is separate, already indexed, and unaffected.

## Fix

**V72 migration** adds `name_strings_trgm`, an FTS5 **`trigram`** index over `name_strings(value)`:
- External content (`content='name_strings'`, `content_rowid='id'`) — the FTS stores only the index and reads values from the base pool.
- Kept in sync by AFTER INSERT/DELETE/UPDATE triggers (the documented FTS5 external-content pattern); each interned name is indexed as the pool fills.
- One-time backfill of existing names. DROP-and-recreate applier (like `ensure_edges_view`) → fully idempotent and torn-replay safe.

`lookup_name`'s fuzzy subquery changes from `SELECT id FROM name_strings WHERE value LIKE ?2` to `SELECT rowid FROM name_strings_trgm WHERE value LIKE ?2` — the **same `LIKE`**, just resolved through the trigram index. The trigram tokenizer accelerates arbitrary-substring LIKE (≥3 literal chars; shorter patterns still resolve correctly), preserving the exact match set — so substring search (e.g. `str` → `as_str`, `to_string`) is unchanged, not narrowed to whole-token.

## Result

Measured on a real ~116k-name index (identical result rows in every case):

| bare name | old | new | speedup |
|---|---|---|---|
| `reconcile` | 42.3 ms | 5.9 ms | ~7× |
| `embed` | 45.4 ms | 8.8 ms | ~5× |
| `new` | 39.1 ms | 7.8 ms | ~5× |
| `as_str` | 36.6 ms | 20.1 ms | ~2× |
| `str` (9.5k matches) | 51.1 ms | 31.0 ms | ~2× |

(Common substrings retain a floor cost from the outer symbol join + rank `ORDER BY` over the larger match set, which the index can't reduce.) Trigram index overhead ≈ 19 MB for 116k names (~1% of a 1.6 GB store).

## Tests

- `migration_072_is_the_tip_and_trigram_indexes_name_strings` — asserts the FTS table + 3 triggers exist, the AFTER INSERT trigger indexes newly interned names, the trigram `LIKE` returns the **same ids as the base pool `LIKE`**, backfill re-indexes every existing name exactly once, replay is idempotent, and forward-migrate records V72.
- Existing `symbol_lookup` behavior tests pass unchanged (they exercise `lookup_name` end-to-end through the new trigram path).

Fixes #685
