### PR TITLE
fix: Android/Termux support — flock via libc, static libc++ in the prebuilt

### DIFF
--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -20,8 +20,11 @@
 # the tag push and wait for cargo-dist to create the release + attach its assets before adding ours.
 #
 # The android binary ships the full feature set: fastembed statically links the pyke
-# aarch64-linux-android ONNX Runtime, so no libonnxruntime.so is needed at runtime (only bionic +
-# libc++_shared, both present on Termux). Requires the jemalloc-off-android gate (#615).
+# aarch64-linux-android ONNX Runtime, so no libonnxruntime.so is needed at runtime. libc++ is also
+# statically linked (CXXSTDLIB=c++_static, #708) — Termux ships libc++_shared.so in $PREFIX/lib, but
+# the bionic loader only searches there for Termux-built ELFs (DT_RUNPATH); a foreign NDK-built
+# binary gets the system search path, which has no libc++_shared, and fails to load. Static libc++
+# leaves bionic as the only runtime dependency. Requires the jemalloc-off-android gate (#615).
 name: release-android
 
 on:
@@ -63,7 +66,22 @@ jobs:
           # needed — the allocator's -lgcc link fails otherwise.
           export ANDROID_NDK_HOME="${ANDROID_NDK_LATEST_HOME:?no NDK on runner}"
           echo "Using NDK: $ANDROID_NDK_HOME"
+          # Static libc++ (#708): both the cc crate and ort-sys default to -lc++_shared on android
+          # targets, which Termux's loader can't resolve for a foreign binary. Both honor CXXSTDLIB.
+          export CXXSTDLIB=c++_static
+          # libc++_static.a needs libc++abi.a linked explicitly (the std exception vtables live
+          # there); the NDK clang driver adds it only when it owns the stdlib choice, and here the
+          # -lc++_static comes from cargo, so the link fails on undefined vtables without this.
+          export CARGO_TARGET_AARCH64_LINUX_ANDROID_RUSTFLAGS="-C link-arg=-lc++abi"
           cargo ndk -t "$ANDROID_ABI" --platform "$ANDROID_API" build --release -p rag-rat
+          # Fail the release here rather than ship a binary Termux can't load: the only DT_NEEDED
+          # entries a Termux-runnable binary may carry are bionic's own libraries.
+          "$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-readelf" -d \
+            "target/${ANDROID_TARGET}/release/rag-rat" | tee /tmp/dynamic-section
+          if grep -q 'libc++_shared' /tmp/dynamic-section; then
+            echo "::error::android binary still links libc++_shared.so — Termux cannot load it" >&2
+            exit 1
+          fi
       - name: Package + checksum (matches cargo-dist archive layout)
         run: |
           set -euo pipefail

--- a/crates/rag-rat-core/src/locks.rs
+++ b/crates/rag-rat-core/src/locks.rs
@@ -1,6 +1,6 @@
-//! Cross-platform file locks for the index file watcher, using std's native `File::{lock,
-//! try_lock, unlock}` (stable since Rust 1.89 — `flock` on Unix, `LockFileEx` on Windows, no
-//! external crate). Two distinct locks coordinate writers without an HTTP daemon:
+//! Cross-platform file locks for the index file watcher: `flock(2)` via libc on unix (see
+//! [`sys`] for why not std's `File::{lock, try_lock, unlock}`), std's `LockFileEx`-backed
+//! `File` locks on Windows. Two distinct locks coordinate writers without an HTTP daemon:
 //!
 //! - the **per-worktree election lock** (one watcher per worktree), keyed by the canonicalized
 //!   worktree root and living under the git common dir;
@@ -37,6 +37,70 @@ use sha2::{Digest, Sha256};
 
 use crate::config::Config;
 
+/// The lock syscall layer. On unix this calls `libc::flock` directly instead of std's
+/// `File::{lock, try_lock, unlock}`: std's unix implementation sits behind a cfg allowlist that
+/// omits `target_os = "android"`, so on android (Termux) the std methods compile to stubs that
+/// return `ErrorKind::Unsupported` ("lock() not supported") even though bionic fully supports
+/// `flock(2)` (#707). Implementing the flock path for ALL unix targets — byte-for-byte what std
+/// does on linux/macOS — keeps it exercised by every unix CI job rather than rotting in an
+/// android-only branch. Windows keeps std's `LockFileEx`-backed methods.
+mod sys {
+    use std::fs::{File, TryLockError};
+    use std::io;
+
+    #[cfg(unix)]
+    fn flock(file: &File, operation: libc::c_int) -> io::Result<()> {
+        use std::os::fd::AsRawFd as _;
+        // A blocking flock can be interrupted by any signal the process handles (EINTR);
+        // retrying keeps a stray SIGCHLD from surfacing as a spurious lock error.
+        loop {
+            if unsafe { libc::flock(file.as_raw_fd(), operation) } == 0 {
+                return Ok(());
+            }
+            let err = io::Error::last_os_error();
+            if err.raw_os_error() != Some(libc::EINTR) {
+                return Err(err);
+            }
+        }
+    }
+
+    #[cfg(unix)]
+    pub(super) fn lock_exclusive(file: &File) -> io::Result<()> {
+        flock(file, libc::LOCK_EX)
+    }
+
+    #[cfg(unix)]
+    pub(super) fn try_lock_exclusive(file: &File) -> Result<(), TryLockError> {
+        flock(file, libc::LOCK_EX | libc::LOCK_NB).map_err(|err| {
+            if err.kind() == io::ErrorKind::WouldBlock {
+                TryLockError::WouldBlock
+            } else {
+                TryLockError::Error(err)
+            }
+        })
+    }
+
+    #[cfg(unix)]
+    pub(super) fn unlock(file: &File) -> io::Result<()> {
+        flock(file, libc::LOCK_UN)
+    }
+
+    #[cfg(not(unix))]
+    pub(super) fn lock_exclusive(file: &File) -> io::Result<()> {
+        file.lock()
+    }
+
+    #[cfg(not(unix))]
+    pub(super) fn try_lock_exclusive(file: &File) -> Result<(), TryLockError> {
+        file.try_lock()
+    }
+
+    #[cfg(not(unix))]
+    pub(super) fn unlock(file: &File) -> io::Result<()> {
+        file.unlock()
+    }
+}
+
 /// A held exclusive file lock. Released on drop.
 #[derive(Debug)]
 pub struct FileLock {
@@ -60,7 +124,7 @@ impl FileLock {
     /// Non-blocking. `Ok(Some)` if acquired now, `Ok(None)` if another holder has it.
     pub fn try_acquire(path: &Path) -> anyhow::Result<Option<FileLock>> {
         let file = Self::open(path)?;
-        match file.try_lock() {
+        match sys::try_lock_exclusive(&file) {
             Ok(()) => Ok(Some(FileLock { _file: file })),
             Err(TryLockError::WouldBlock) => Ok(None),
             Err(TryLockError::Error(err)) =>
@@ -72,7 +136,7 @@ impl FileLock {
     /// [`FileLock::acquire_timeout`] so a hung holder can't hang `git checkout`.
     pub fn acquire_blocking(path: &Path) -> anyhow::Result<FileLock> {
         let file = Self::open(path)?;
-        file.lock().with_context(|| format!("locking {}", path.display()))?;
+        sys::lock_exclusive(&file).with_context(|| format!("locking {}", path.display()))?;
         Ok(FileLock { _file: file })
     }
 
@@ -101,7 +165,7 @@ impl Drop for FileLock {
         // releasing the lock until the child execs (#409). `unlock()` (flock `LOCK_UN`) drops the
         // lock now, regardless of surviving OFD references in pre-exec children. Best-effort: the
         // fd still closes right after, so ignore the error.
-        let _ = self._file.unlock();
+        let _ = sys::unlock(&self._file);
     }
 }
 

--- a/dist-android/README.md
+++ b/dist-android/README.md
@@ -19,6 +19,11 @@ both gaps on the same release cargo-dist publishes, using the scripts here:
 cargo-dist's own npm publisher is disabled (`publish-jobs = []` in `dist-workspace.toml`) so
 release-android.yml is the sole publisher of `@rag-rat/bin` — otherwise it would republish the
 android-less package under the same version. The android binary is the full build: FastEmbed's ONNX
-Runtime is statically linked (pyke ships an `aarch64-linux-android` prebuilt), so only bionic +
-`libc++_shared` are needed at runtime, both present on Termux. Requires the jemalloc-off-android gate
-(the allocator's `-lgcc` link fails on NDK r23+).
+Runtime is statically linked (pyke ships an `aarch64-linux-android` prebuilt), and libc++ is
+statically linked too (`CXXSTDLIB=c++_static`, honored by both the `cc` crate and `ort-sys`, plus
+an explicit `-lc++abi` — the NDK's `libc++_static.a` doesn't pull it in by itself), so bionic is
+the only runtime dependency. Termux does ship `libc++_shared.so`, but only in `$PREFIX/lib`,
+which the bionic loader searches for Termux-built ELFs (via their DT_RUNPATH) — never for a foreign
+NDK-built binary, so dynamic libc++ fails to load there (#708); the workflow greps the built binary's
+dynamic section and fails the release if `libc++_shared` sneaks back in. Requires the
+jemalloc-off-android gate (the allocator's `-lgcc` link fails on NDK r23+).


### PR DESCRIPTION
Two independent failures made both Termux install paths unusable; each alone still leaves the binary broken, so they land together.

## `lock() not supported` on any command (crate installs) — #707

std's `File::{lock, try_lock, unlock}` sit behind a cfg allowlist that omits `target_os = "android"` (verified through Rust 1.97's `library/std/src/sys/fs/unix.rs`), so on Termux they compile to stubs returning `ErrorKind::Unsupported` — even though bionic fully supports `flock(2)`. Every command acquires the write/schema/registry locks, so this was fatal.

The new `locks::sys` shim calls `libc::flock` directly on **all** unix targets — byte-for-byte what std does on linux/macOS — so the single code path is exercised by every unix CI job rather than rotting in an android-only branch. Windows keeps std's `LockFileEx`-backed methods. Explicit unlock-on-Drop (#409) unchanged.

## `library "libc++_shared.so" not found` (npm prebuilt) — #708

The shipped android binary carried `DT_NEEDED libc++_shared.so` with no DT_RUNPATH (`ort-sys` and the `cc` crate both default to `-lc++_shared` on android). Termux ships `libc++_shared.so` only in `$PREFIX/lib`, which the bionic loader searches for Termux-built ELFs via their DT_RUNPATH — never for a foreign NDK-built binary — so the prebuilt died at load.

`release-android.yml` now links libc++ statically: `CXXSTDLIB=c++_static` (honored by both `cc` and `ort-sys`) plus an explicit `-lc++abi` (the NDK's `libc++_static.a` doesn't pull in libc++abi; without it the link fails on undefined std exception vtables). A workflow tripwire readelfs the built binary and fails the release if `libc++_shared` ever reappears.

## Verification

- Full workspace suite: 2944/2944 pass (the lock tests, including the fork-inherited-fd #409 test and second-holder WouldBlock, now run through the flock shim).
- CI-exact clippy (`--no-default-features` and `--all-features`, `-D warnings`) and nightly fmt: clean.
- Local `cargo ndk -t arm64-v8a --platform 24 build --release -p rag-rat` with the exact workflow env (NDK r27.1): links successfully; `readelf -d` shows only bionic DT_NEEDED entries (`libdl`/`liblog`/`libm`/`libc`) and no RUNPATH — vs the v0.18.0 asset which needs `libc++_shared.so`.

Fixes #707
Fixes #708