### PR TITLE
chore: release v0.20.0

### DIFF
--- a/.agents/skills/init-rag-rat/SKILL.md
+++ b/.agents/skills/init-rag-rat/SKILL.md
@@ -32,7 +32,7 @@ hand-write a config blind, and let a real config load re-check it before indexin
    do **not** use `@latest`, and **don't blindly trust an on-`PATH` `rag-rat`**:
    - If `rag-rat` is on `PATH`, check `rag-rat --version` and use it **only if it matches** the
      plugin/MCP version — a stale global install would build the index with the wrong binary.
-   - Otherwise (or on a version mismatch) use `npx -y @rag-rat/bin@0.19.0 …` — the plugin pins
+   - Otherwise (or on a version mismatch) use `npx -y @rag-rat/bin@0.20.0 …` — the plugin pins
      `@rag-rat/bin` to its own version and caches the binary privately, so this is the
      version-matched CLI; `npx` runs it in the current directory.
 

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "rag-rat",
       "description": "Local repo-intelligence index + MCP server: semantic search, symbol/graph navigation, impact-surface preflight, git + GitHub papertrail, and a source-anchored memory graph.",
-      "version": "0.19.0",
+      "version": "0.20.0",
       "source": "./plugin",
       "category": "developer-tools",
       "license": "MIT",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.19.0...rag-rat-base-v0.20.0) - 2026-07-20
+
+### Added
+
+- *(cli)* rag-rat rm <path> — remove a repo from the global index (purge + VACUUM), config, and hooks ([#778](https://github.com/cq27-dev/rag-rat/pull/778))
+- *(plugin)* opencode plugin bundle — @rag-rat/plugin-opencode (MCP + hooks) ([#785](https://github.com/cq27-dev/rag-rat/pull/785))
+- *(config)* add [llm.distill] config with a model-size-aware provision timeout ([#779](https://github.com/cq27-dev/rag-rat/pull/779))
+- *(agent-hook)* augment the Read tool with file/dir memories + load-bearing symbols ([#756](https://github.com/cq27-dev/rag-rat/pull/756)) ([#761](https://github.com/cq27-dev/rag-rat/pull/761))
+- *(agent-hook)* PostToolUse edit trigger — scoped reindex, watcher-aware, detached ([#738](https://github.com/cq27-dev/rag-rat/pull/738))
+- *(papertrail)* closing-edge substrate — provider-neutral schema, gated text tier, item/comment ref mining ([#702](https://github.com/cq27-dev/rag-rat/pull/702)) ([#722](https://github.com/cq27-dev/rag-rat/pull/722))
+
+### Fixed
+
+- *(tests)* route test scratch through a shared self-healing helper (fixes #726) ([#732](https://github.com/cq27-dev/rag-rat/pull/732))
+
+### Other
+
+- *(readme)* link the rag-rat.cq27.dev site ([#749](https://github.com/cq27-dev/rag-rat/pull/749))
+- *(locks)* shared content-carrying single-flight coalescing primitive ([#736](https://github.com/cq27-dev/rag-rat/pull/736))
+- *(workspace)* [**breaking**] extract rag-rat-query — the read layer: graph/impact/symbol/tree queries, memory reads + evidence, pagerank (#706 phase 6) ([#719](https://github.com/cq27-dev/rag-rat/pull/719))
+- *(workspace)* [**breaking**] extract the rag-rat-clones crate (#706 phase 4) ([#717](https://github.com/cq27-dev/rag-rat/pull/717))
+- *(workspace)* [**breaking**] extract rag-rat-papertrail — mirror, providers, transport, evidence (#706 phase 2) ([#715](https://github.com/cq27-dev/rag-rat/pull/715))
+- *(workspace)* [**breaking**] extract the rag-rat-db database layer with an explicit MigrationHooks seam (#706 phase 1) ([#714](https://github.com/cq27-dev/rag-rat/pull/714))
+
 ## [0.19.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-core-v0.18.0...rag-rat-core-v0.19.0) - 2026-07-16
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3653,7 +3653,7 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rag-rat"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3686,7 +3686,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-base"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "filetime",
@@ -3710,7 +3710,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-clones"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "rag-rat-base",
@@ -3726,7 +3726,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-core"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "chacha20poly1305",
@@ -3791,7 +3791,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-db"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "rag-rat-base",
@@ -3804,7 +3804,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-dream"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "rag-rat-base",
@@ -3823,7 +3823,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-llm"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "fastembed",
@@ -3844,7 +3844,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-mcp"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "libc",
@@ -3866,7 +3866,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-oplog"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "chacha20poly1305",
@@ -3888,7 +3888,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-oracle"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "protobuf",
@@ -3906,7 +3906,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-papertrail"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -3926,7 +3926,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-query"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "minicbor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ resolver = "3"
 # and the internal path deps below pin the same literal, so the three crates always publish in
 # lockstep. Bump this one line (and the two internal-dep `version`s under workspace.dependencies)
 # to release.
-version = "0.19.0"
+version = "0.20.0"
 authors = ["Kristaps Karlsons"]
 edition = "2024"
 # Bundled SQLite (rusqlite `bundled` -> libsqlite3-sys 0.38.1) compiles a build script that uses the
@@ -37,17 +37,17 @@ categories = ["command-line-utilities", "development-tools"]
 # Internal crates — declared once here so the version requirement is set in lockstep with
 # [workspace.package].version above. Members reference these via `{ workspace = true }` and add
 # their own feature toggles at the use site.
-rag-rat-base = { version = "0.19.0", path = "crates/rag-rat-base", default-features = false }
-rag-rat-clones = { version = "0.19.0", path = "crates/rag-rat-clones", default-features = false }
-rag-rat-db = { version = "0.19.0", path = "crates/rag-rat-db", default-features = false }
-rag-rat-dream = { version = "0.19.0", path = "crates/rag-rat-dream", default-features = false }
-rag-rat-llm = { version = "0.19.0", path = "crates/rag-rat-llm", default-features = false }
-rag-rat-oracle = { version = "0.19.0", path = "crates/rag-rat-oracle", default-features = false }
-rag-rat-oplog = { version = "0.19.0", path = "crates/rag-rat-oplog", default-features = false }
-rag-rat-papertrail = { version = "0.19.0", path = "crates/rag-rat-papertrail", default-features = false }
-rag-rat-query = { version = "0.19.0", path = "crates/rag-rat-query", default-features = false }
-rag-rat-core = { version = "0.19.0", path = "crates/rag-rat-core", default-features = false }
-rag-rat-mcp = { version = "0.19.0", path = "crates/rag-rat-mcp", default-features = false }
+rag-rat-base = { version = "0.20.0", path = "crates/rag-rat-base", default-features = false }
+rag-rat-clones = { version = "0.20.0", path = "crates/rag-rat-clones", default-features = false }
+rag-rat-db = { version = "0.20.0", path = "crates/rag-rat-db", default-features = false }
+rag-rat-dream = { version = "0.20.0", path = "crates/rag-rat-dream", default-features = false }
+rag-rat-llm = { version = "0.20.0", path = "crates/rag-rat-llm", default-features = false }
+rag-rat-oracle = { version = "0.20.0", path = "crates/rag-rat-oracle", default-features = false }
+rag-rat-oplog = { version = "0.20.0", path = "crates/rag-rat-oplog", default-features = false }
+rag-rat-papertrail = { version = "0.20.0", path = "crates/rag-rat-papertrail", default-features = false }
+rag-rat-query = { version = "0.20.0", path = "crates/rag-rat-query", default-features = false }
+rag-rat-core = { version = "0.20.0", path = "crates/rag-rat-core", default-features = false }
+rag-rat-mcp = { version = "0.20.0", path = "crates/rag-rat-mcp", default-features = false }
 anyhow = "1.0"
 # ed25519 device-identity signing for the op-log's signed entry envelope (§C4 layer-1). Default
 # features (incl. `zeroize`, which zeroizes a `SigningKey`'s seed on drop) are kept; the `rand_core`

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "rag-rat",
   "displayName": "rag-rat",
   "description": "Local repo-intelligence index + MCP server: semantic search, symbol/graph navigation, impact-surface preflight, git + GitHub papertrail, and a source-anchored memory graph.",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "author": { "name": "Kristaps Karlsons" },
   "homepage": "https://github.com/cq27-dev/rag-rat",
   "repository": "https://github.com/cq27-dev/rag-rat",
@@ -11,7 +11,7 @@
   "mcpServers": {
     "rag-rat": {
       "command": "npx",
-      "args": ["-y", "@rag-rat/bin@0.19.0", "mcp"]
+      "args": ["-y", "@rag-rat/bin@0.20.0", "mcp"]
     }
   }
 }

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rag-rat",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Local repo-intelligence index + MCP server: semantic search, symbol/graph navigation, impact-surface preflight, git + GitHub papertrail, and a source-anchored memory graph.",
   "author": { "name": "Kristaps Karlsons", "url": "https://github.com/cq27-dev/rag-rat" },
   "homepage": "https://github.com/cq27-dev/rag-rat",

--- a/plugin/.mcp.json
+++ b/plugin/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "rag-rat": {
       "command": "npx",
-      "args": ["-y", "@rag-rat/bin@0.19.0", "mcp"]
+      "args": ["-y", "@rag-rat/bin@0.20.0", "mcp"]
     }
   }
 }

--- a/plugin/opencode/package.json
+++ b/plugin/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rag-rat/plugin-opencode",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "opencode plugin for rag-rat: self-registers the rag-rat MCP server (semantic search, symbol/graph navigation, impact-surface preflight, repo memory) and wires session/grep/edit hooks through the shared agent-hook.",
   "license": "MIT",
   "type": "module",

--- a/plugin/opencode/rag-rat.ts
+++ b/plugin/opencode/rag-rat.ts
@@ -3,7 +3,7 @@
 // opencode's plugin shape differs from Claude Code / Codex (no hooks.json manifest, no
 // additionalContext channel on tool.execute.before), so this module is a thin shim over the same
 // shared pieces the other harnesses use:
-//   - MCP: registered via the `config` hook as `npx -y @rag-rat/bin@0.19.0<version> mcp` (pinned; kept
+//   - MCP: registered via the `config` hook as `npx -y @rag-rat/bin@0.20.0<version> mcp` (pinned; kept
 //     in lockstep with the release by tools/sync-plugin-version.mjs).
 //   - Hooks: routed through the shared launcher (`../scripts/launch.js --no-install agent-hook`)
 //     when this file lives in the repo's plugin bundle, or — for a standalone single-file install
@@ -35,7 +35,7 @@ const BUNDLED_LAUNCHER = path.join(PLUGIN_DIR, "..", "scripts", "launch.js");
 
 // Single source of truth for the version: the pinned npm package (kept in lockstep with the
 // release by tools/sync-plugin-version.mjs — do not hand-edit the pin).
-const MCP_PACKAGE = "@rag-rat/bin@0.19.0";
+const MCP_PACKAGE = "@rag-rat/bin@0.20.0";
 const VERSION = MCP_PACKAGE.split("@").pop()!;
 
 const TOOL_TIMEOUT_MS = 10_000;

--- a/plugin/skills/init-rag-rat/SKILL.md
+++ b/plugin/skills/init-rag-rat/SKILL.md
@@ -32,7 +32,7 @@ hand-write a config blind, and let a real config load re-check it before indexin
    do **not** use `@latest`, and **don't blindly trust an on-`PATH` `rag-rat`**:
    - If `rag-rat` is on `PATH`, check `rag-rat --version` and use it **only if it matches** the
      plugin/MCP version — a stale global install would build the index with the wrong binary.
-   - Otherwise (or on a version mismatch) use `npx -y @rag-rat/bin@0.19.0 …` — the plugin pins
+   - Otherwise (or on a version mismatch) use `npx -y @rag-rat/bin@0.20.0 …` — the plugin pins
      `@rag-rat/bin` to its own version and caches the binary privately, so this is the
      version-matched CLI; `npx` runs it in the current directory.
 


### PR DESCRIPTION



## 🤖 New release

* `rag-rat-base`: 0.19.0 -> 0.20.0 (⚠ API breaking changes)
* `rag-rat-db`: 0.19.0 -> 0.20.0
* `rag-rat-clones`: 0.19.0 -> 0.20.0
* `rag-rat-llm`: 0.19.0 -> 0.20.0
* `rag-rat-papertrail`: 0.19.0 -> 0.20.0
* `rag-rat-query`: 0.19.0 -> 0.20.0
* `rag-rat-dream`: 0.19.0 -> 0.20.0
* `rag-rat-oplog`: 0.19.0 -> 0.20.0
* `rag-rat-oracle`: 0.19.0 -> 0.20.0
* `rag-rat-core`: 0.19.0 -> 0.20.0 (⚠ API breaking changes)
* `rag-rat-mcp`: 0.19.0 -> 0.20.0 (⚠ API breaking changes)
* `rag-rat`: 0.19.0 -> 0.20.0

### ⚠ `rag-rat-base` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field LlmConfig.distill in /tmp/.tmpwKvizM/rag-rat/crates/rag-rat-base/src/config/types.rs:343
  field RemoteDreamConfig.provision_timeout_s in /tmp/.tmpwKvizM/rag-rat/crates/rag-rat-base/src/config/types.rs:811

--- failure enum_tuple_variant_changed_kind: An enum tuple variant changed kind ---

Description:
A public enum's exhaustive tuple variant has changed to a different kind of enum variant, breaking possible instantiations and patterns.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_tuple_variant_changed_kind.ron

Failed in:
  variant ConfigError::RemoteBackendUnknown in /tmp/.tmpwKvizM/rag-rat/crates/rag-rat-base/src/config/mod.rs:40
  variant ConfigError::DreamBackendCannotServeChat in /tmp/.tmpwKvizM/rag-rat/crates/rag-rat-base/src/config/mod.rs:97

--- failure enum_unit_variant_changed_kind: An enum unit variant changed kind ---

Description:
A public enum's exhaustive unit variant has changed to a different kind of enum variant, breaking possible instantiations and patterns.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_unit_variant_changed_kind.ron

Failed in:
  variant ConfigError::RemoteGpuEmpty in /tmp/.tmpwKvizM/rag-rat/crates/rag-rat-base/src/config/mod.rs:68
  variant ConfigError::DreamRemoteMissingModel in /tmp/.tmpwKvizM/rag-rat/crates/rag-rat-base/src/config/mod.rs:91
  variant ConfigError::DreamRemoteModeAmbiguous in /tmp/.tmpwKvizM/rag-rat/crates/rag-rat-base/src/config/mod.rs:102
  variant ConfigError::DreamRemoteEndpointHasCredentials in /tmp/.tmpwKvizM/rag-rat/crates/rag-rat-base/src/config/mod.rs:107
  variant ConfigError::DreamRemoteGpuRequiresCookbook in /tmp/.tmpwKvizM/rag-rat/crates/rag-rat-base/src/config/mod.rs:112

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_added.ron

Failed in:
  variant ConfigError:DreamRemoteProvisionTimeoutBelowFloor in /tmp/.tmpwKvizM/rag-rat/crates/rag-rat-base/src/config/mod.rs:118
```

### ⚠ `rag-rat-core` breaking changes

```text
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_missing.ron

Failed in:
  enum rag_rat_core::query::load_bearing::OracleTier, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/load_bearing.rs:94
  enum rag_rat_core::config::ConfigError, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/config/mod.rs:13
  enum rag_rat_core::query::pagerank::ImportanceMode, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/pagerank.rs:161
  enum rag_rat_core::query::pagerank::SeedKind, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/pagerank.rs:188
  enum rag_rat_core::query::memory::EdgeTarget, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/memory/edges.rs:49
  enum rag_rat_core::repo_identity::RepoIdentityClass, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/repo_identity.rs:29
  enum rag_rat_core::query::graph_meta::GraphMetaMode, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/graph_meta.rs:12
  enum rag_rat_core::index::oracle::ScipProduction, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/oracle/mod.rs:276
  enum rag_rat_core::index::oracle::AutoRunDecision, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/oracle/auto_run.rs:37
  enum rag_rat_core::index::papertrail::TrackerAuthentication, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/papertrail/mod.rs:163
  enum rag_rat_core::language::LanguageError, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/language.rs:200
  enum rag_rat_core::index::oracle::OracleResolutionKind, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/oracle/mod.rs:757
  enum rag_rat_core::config::LogLevel, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/config/types.rs:255
  enum rag_rat_core::embedding_models::Backend, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/embedding_models.rs:20
  enum rag_rat_core::index::papertrail::AutosyncRequest, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/papertrail/schedule.rs:116
  enum rag_rat_core::config::RemoteBackend, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/config/types.rs:497
  enum rag_rat_core::index::papertrail::TrackerSynchronization, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/papertrail/mod.rs:170
  enum rag_rat_core::index::schema::SchemaState, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/schema/mod.rs:509
  enum rag_rat_core::logging::Role, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/logging/mod.rs:24
  enum rag_rat_core::config::Tracker, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/config/types.rs:79
  enum rag_rat_core::index::papertrail::Tracker, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/config/types.rs:79
  enum rag_rat_core::query::load_bearing::LoadBearingBucket, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/load_bearing.rs:42
  enum rag_rat_core::query::memory::EdgeRelation, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/memory/edges.rs:22
  enum rag_rat_core::index::oracle::ToolAvailability, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/oracle/manifest.rs:34
  enum rag_rat_core::config::MemorySurface, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/config/types.rs:160
  enum rag_rat_core::dream::VerificationReason, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/dream/verify.rs:89
  enum rag_rat_core::config::TrackerAuth, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/config/types.rs:108
  enum rag_rat_core::query::repo_brief::RepoBriefMode, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/repo_brief.rs:10
  enum rag_rat_core::index::oracle::OracleRunOutcome, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/oracle/mod.rs:259
  enum rag_rat_core::index::oracle::OracleTool, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/oracle/mod.rs:677
  enum rag_rat_core::index::papertrail::autosync::AutosyncOutcome, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/papertrail/autosync.rs:22
  enum rag_rat_core::dream::ReviewVerdict, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/dream/findings.rs:485
  enum rag_rat_core::language::Language, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/language.rs:10
  enum rag_rat_core::config::LogFormat, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/config/types.rs:291
  enum rag_rat_core::repo_identity::RepoIdentityError, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/repo_identity.rs:73
  enum rag_rat_core::query::pagerank::EdgeOracleEffect, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/pagerank.rs:82
  enum rag_rat_core::query::impact::RepoMemoryEvidenceView, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/impact/mod.rs:69
  enum rag_rat_core::query::graph::GraphResolutionMode, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/graph/mod.rs:130
  enum rag_rat_core::config::TargetKind, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/config/types.rs:847
  enum rag_rat_core::TargetKind, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/config/types.rs:847
  enum rag_rat_core::index::oracle::LibraryUsageStatus, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/oracle/library_usage.rs:80
  enum rag_rat_core::index::papertrail::ItemKind, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/papertrail/mod.rs:290

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/function_missing.ron

Failed in:
  function rag_rat_core::locks::hook_socket_path_for, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/locks.rs:557
  function rag_rat_core::index::oracle::prune_external_symbols_outside_scope, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/oracle/mod.rs:597
  function rag_rat_core::repo_identity::identity_is_resolvable, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/repo_identity.rs:180
  function rag_rat_core::set_binary_version, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/lib.rs:40
  function rag_rat_core::index::ai::provision_box_for_benchmark, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/ai/providers/cookbook.rs:593
  function rag_rat_core::locks::papertrail_lock_path, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/locks.rs:296
  function rag_rat_core::query::symbol::lookup, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/symbol.rs:136
  function rag_rat_core::binary_version, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/lib.rs:45
  function rag_rat_core::query::symbol::logical_members, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/symbol.rs:420
  function rag_rat_core::serde_big_id::sym_handle::deserialize, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/serde_big_id.rs:83
  function rag_rat_core::index::oracle::probe_oracle_tool, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/oracle/mod.rs:515
  function rag_rat_core::index::papertrail::detect_tracker_from_remote_url, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/papertrail/trackers.rs:142
  function rag_rat_core::config::nearest_config_at_or_above, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/config/discovery.rs:54
  function rag_rat_core::index::schema::register_repo_read_only, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/schema/registry.rs:177
  function rag_rat_core::query::tree::dir_tree, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/tree.rs:70
  function rag_rat_core::index::ai::default_benchmark_budget_ms, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/ai/throughput_tune.rs:326
  function rag_rat_core::data_dir::global_database_path, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/data_dir.rs:46
  function rag_rat_core::locks::election_lock_path, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/locks.rs:535
  function rag_rat_core::index::oracle::oracle_eval_metrics, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/oracle/mod.rs:197
  function rag_rat_core::locks::thread_holds_any_repo_write_lock, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/locks.rs:342
  function rag_rat_core::query::symbol::lookup_by_id, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/symbol.rs:212
  function rag_rat_core::query::memory::memory_evidence_for_symbol, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/memory/api.rs:409
  function rag_rat_core::locks::socket_lock_path, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/locks.rs:541
  function rag_rat_core::config::default_legacy_database_path, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/config/discovery.rs:224
  function rag_rat_core::storage::is_readonly_violation, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/storage.rs:21
  function rag_rat_core::index::oracle::auto_run_decision, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/oracle/auto_run.rs:62
  function rag_rat_core::index::schema::apply, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/schema/mod.rs:626
  function rag_rat_core::query::repo_brief::repo_brief, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/repo_brief.rs:158
  function rag_rat_core::index::schema::status, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/schema/mod.rs:1150
  function rag_rat_core::locks::maintenance_lock_path, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/locks.rs:278
  function rag_rat_core::index::oracle::corpus_by_id, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/oracle/corpus.rs:34
  function rag_rat_core::query::symbol::lookup_logical_by_id, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/symbol.rs:379
  function rag_rat_core::version_check::cache_path, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/version_check.rs:52
  function rag_rat_core::index::oracle::latest_run_started_at, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/oracle/mod.rs:650
  function rag_rat_core::dream::render_evidence_pack, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/dream/mod.rs:66
  function rag_rat_core::index::ai::measure_remote_dim, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/ai/throughput_tune.rs:290
  function rag_rat_core::index::ai::verify_ephemeral_remote_cancellable, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/ai/providers/cookbook.rs:674
  function rag_rat_core::locks::write_lock_repo_id, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/locks.rs:365
  function rag_rat_core::index::oracle::run_oracle_report, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/oracle/mod.rs:147
  function rag_rat_core::locks::canonical_lock_order, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/locks.rs:324
  function rag_rat_core::query::symbol::select_one_for_bind, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/symbol.rs:187
  function rag_rat_core::dream::dream_run, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/dream/mod.rs:141
  function rag_rat_core::serde_big_id::sym_handle_opt::deserialize, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/serde_big_id.rs:96
  function rag_rat_core::index::schema::register_repo, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/schema/registry.rs:160
  function rag_rat_core::serde_big_id::parse_sym_handle, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/serde_big_id.rs:39
  function rag_rat_core::config::default_database_path, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/config/discovery.rs:124
  function rag_rat_core::locks::registry_lock_path, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/locks.rs:254
  function rag_rat_core::dream::provision_verdict_model, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/dream/model.rs:211
  function rag_rat_core::query::graph_meta::attach_to_read_chunk, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/graph_meta.rs:138
  function rag_rat_core::index::ai::install_provision_log_sink, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/ai/providers/cookbook.rs:128
  function rag_rat_core::dream::evidence_pack, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/dream/verify.rs:513
  function rag_rat_core::query::impact::impact_surface_for_symbol, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/impact/mod.rs:385
  function rag_rat_core::locks::hook_socket_lock_path_for, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/locks.rs:565
  function rag_rat_core::index::oracle::prune_edge_oracle_without_live_edge, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/oracle/mod.rs:610
  function rag_rat_core::index::papertrail::autosync::run, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/papertrail/autosync.rs:41
  function rag_rat_core::logging::init_logging, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/logging/mod.rs:64
  function rag_rat_core::index::oracle::run_oracle_at, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/oracle/mod.rs:109
  function rag_rat_core::locks::papertrail_marker_lock_path, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/locks.rs:315
  function rag_rat_core::query::symbol::lookup_candidates, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/symbol.rs:148
  function rag_rat_core::index::oracle::scip_content_fingerprint, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/oracle/mod.rs:524
  function rag_rat_core::config::linked_worktree_main_root, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/config/discovery.rs:93
  function rag_rat_core::index::ai::min_benchmark_budget_ms, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/ai/throughput_tune.rs:337
  function rag_rat_core::index::oracle::resolution_report, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/oracle/mod.rs:215
  function rag_rat_core::dream::model_work_pending, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/dream/mod.rs:251
  function rag_rat_core::index::oracle::check_corpus_health, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/oracle/corpus.rs:56
  function rag_rat_core::query::impact::impact_surface_report_for_symbol, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/impact/mod.rs:194
  function rag_rat_core::locks::hook_socket_path, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/locks.rs:549
  function rag_rat_core::index::oracle::prune_oracle_runs_outside_scope, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/oracle/mod.rs:585
  function rag_rat_core::storage::is_busy, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/storage.rs:35
  function rag_rat_core::index::ai::benchmark_remote_concurrency, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/ai/throughput_tune.rs:231
  function rag_rat_core::index::schema::migrate_forward, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/schema/mod.rs:1116
  function rag_rat_core::index::schema::ensure_compatible_or_migrate, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/schema/mod.rs:1252
  function rag_rat_core::query::read_chunk, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/mod.rs:42
  function rag_rat_core::locks::maintenance_pending_path, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/locks.rs:285
  function rag_rat_core::index::oracle::corpora_for_tier, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/oracle/corpus.rs:39
  function rag_rat_core::index::papertrail::normalized_tags, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/papertrail/trackers.rs:83
  function rag_rat_core::query::symbol::logical_for_symbol_id, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/symbol.rs:399
  function rag_rat_core::serde_big_id::sym_handle::serialize, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/serde_big_id.rs:79
  function rag_rat_core::index::oracle::run_oracle_with_tool, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/oracle/mod.rs:473
  function rag_rat_core::query::impact::ffi_surface, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/impact/mod.rs:490
  function rag_rat_core::index::papertrail::autosync::run_manual, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/papertrail/autosync.rs:107
  function rag_rat_core::index::ai::default_benchmark_candidates, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/ai/throughput_tune.rs:319
  function rag_rat_core::data_dir::data_dir, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/data_dir.rs:19
  function rag_rat_core::locks::write_lock_path, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/locks.rs:189
  function rag_rat_core::query::load_bearing::scoped_weighted_fan_in, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/load_bearing.rs:208
  function rag_rat_core::index::oracle::pre_spawn_snapshot, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/oracle/mod.rs:184
  function rag_rat_core::locks::thread_holds_write_lock, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/locks.rs:332
  function rag_rat_core::query::impact::impact_surface, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/impact/mod.rs:157
  function rag_rat_core::index::oracle::latest_run_tool_version, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/oracle/mod.rs:617
  function rag_rat_core::serde_big_id::format_sym_handle, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/serde_big_id.rs:33
  function rag_rat_core::index::papertrail::parse_tracker_refs, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/papertrail/parse.rs:139
  function rag_rat_core::query::pagerank::pagerank, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/pagerank.rs:103
  function rag_rat_core::locks::sync_session_lock_path, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/locks.rs:268
  function rag_rat_core::index::oracle::load_corpora, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/oracle/corpus.rs:24
  function rag_rat_core::config::endpoint_authority_has_userinfo, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/config/raw.rs:531
  function rag_rat_core::repo_identity::resolve_repo_identity, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/repo_identity.rs:121
  function rag_rat_core::index::oracle::latest_runs_in_scope, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/oracle/mod.rs:632
  function rag_rat_core::config::discover_config_path, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/config/discovery.rs:24
  function rag_rat_core::index::oracle::check_library_usage, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/oracle/library_usage.rs:202
  function rag_rat_core::index::ai::verify_ephemeral_remote, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/ai/providers/cookbook.rs:667
  function rag_rat_core::embedding_models::spec, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/embedding_models.rs:199
  function rag_rat_core::index::oracle::run_oracle, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/oracle/mod.rs:80
  function rag_rat_core::locks::papertrail_pending_path, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/locks.rs:306
  function rag_rat_core::query::symbol::select_one, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/symbol.rs:163
  function rag_rat_core::dream::dream_run_with_passes, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/dream/mod.rs:218
  function rag_rat_core::serde_big_id::sym_handle_opt::serialize, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/serde_big_id.rs:92
  function rag_rat_core::locks::schema_lock_path, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/locks.rs:239
  function rag_rat_core::index::ai::abort_active_provisioning, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/ai/providers/cookbook.rs:1043
  function rag_rat_core::index::oracle::oracle_status, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/oracle/mod.rs:244
  function rag_rat_core::index::is_root_already_indexed_conn, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/adoption_hints.rs:158
  function rag_rat_core::query::graph_meta::attach_to_search_hits, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/graph_meta.rs:122
  function rag_rat_core::dream::verification_queue, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/dream/verify.rs:302
  function rag_rat_core::index::oracle::produce_scip_with_tool, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/oracle/mod.rs:297
  function rag_rat_core::query::impact::impact_surface_with_options, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/impact/mod.rs:376
  function rag_rat_core::query::pagerank::important_symbols, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/pagerank.rs:315

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/module_missing.ron

Failed in:
  mod rag_rat_core::query::repo_brief, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/repo_brief.rs:1
  mod rag_rat_core::query::pagerank, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/pagerank.rs:1
  mod rag_rat_core::query::tree, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/tree.rs:1
  mod rag_rat_core::query::impact, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/impact/mod.rs:1
  mod rag_rat_core::index::papertrail, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/papertrail/mod.rs:1
  mod rag_rat_core::index::papertrail::autosync, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/papertrail/autosync.rs:1
  mod rag_rat_core::query::graph, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/graph/mod.rs:1
  mod rag_rat_core::config, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/config/mod.rs:1
  mod rag_rat_core::storage, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/storage.rs:1
  mod rag_rat_core::query::graph_meta, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/graph_meta.rs:1
  mod rag_rat_core::dream, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/dream/mod.rs:1
  mod rag_rat_core::serde_big_id::sym_handle, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/serde_big_id.rs:76
  mod rag_rat_core::query::symbol, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/symbol.rs:1
  mod rag_rat_core::logging, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/logging/mod.rs:1
  mod rag_rat_core::data_dir, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/data_dir.rs:1
  mod rag_rat_core::index::oracle, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/oracle/mod.rs:1
  mod rag_rat_core::serde_big_id, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/serde_big_id.rs:1
  mod rag_rat_core::query::memory, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/memory/mod.rs:1
  mod rag_rat_core::locks, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/locks.rs:1
  mod rag_rat_core::serde_big_id::sym_handle_opt, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/serde_big_id.rs:89
  mod rag_rat_core::index::schema, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/schema/mod.rs:1
  mod rag_rat_core::repo_identity, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/repo_identity.rs:1
  mod rag_rat_core::embedding_models, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/embedding_models.rs:1
  mod rag_rat_core::language, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/language.rs:1
  mod rag_rat_core::query::load_bearing, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/load_bearing.rs:1

--- failure pub_module_level_const_missing: pub module-level const is missing ---

Description:
A public const is missing or renamed
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/pub_module_level_const_missing.ron

Failed in:
  HASH_EMBEDDING_DIM in file /tmp/.tmpGCajF1/rag-rat-core/src/embedding_models.rs:105
  MODEL2VEC_EMBEDDING_DIM in file /tmp/.tmpGCajF1/rag-rat-core/src/embedding_models.rs:134
  DEFAULT_QUERY_ENDPOINT in file /tmp/.tmpGCajF1/rag-rat-core/src/config/types.rs:663
  MODEL2VEC_HF_REPO in file /tmp/.tmpGCajF1/rag-rat-core/src/index/ai/providers/model2vec.rs:9
  BGE_SMALL_DISPLAY_MODEL in file /tmp/.tmpGCajF1/rag-rat-core/src/embedding_models.rs:117
  RANKING_HINT_AUTO_RUN in file /tmp/.tmpGCajF1/rag-rat-core/src/query/pagerank.rs:263
  REPORT_SCHEMA_VERSION in file /tmp/.tmpGCajF1/rag-rat-core/src/index/oracle/report.rs:30
  MODEL2VEC_MODEL_ID in file /tmp/.tmpGCajF1/rag-rat-core/src/embedding_models.rs:132
  FASTEMBED_EMBEDDING_DIM in file /tmp/.tmpGCajF1/rag-rat-core/src/embedding_models.rs:111
  LOCAL_ONLY_ID_PREFIX in file /tmp/.tmpGCajF1/rag-rat-core/src/repo_identity.rs:23
  MAX_SOCKET_PATH_LEN in file /tmp/.tmpGCajF1/rag-rat-core/src/locks.rs:512
  JINA_CODE_DISPLAY_MODEL in file /tmp/.tmpGCajF1/rag-rat-core/src/embedding_models.rs:126
  FASTEMBED_MISSING_FEATURE_MESSAGE in file /tmp/.tmpGCajF1/rag-rat-core/src/index/ai/providers/mod.rs:60
  LATEST_SCHEMA_VERSION in file /tmp/.tmpGCajF1/rag-rat-core/src/index/schema/mod.rs:22
  FASTEMBED_MODEL_ID in file /tmp/.tmpGCajF1/rag-rat-core/src/embedding_models.rs:109
  EMBEDDING_MODELS in file /tmp/.tmpGCajF1/rag-rat-core/src/embedding_models.rs:144
  BGE_SMALL_EMBEDDING_DIM in file /tmp/.tmpGCajF1/rag-rat-core/src/embedding_models.rs:118
  RANKING_HINT_RUN_ORACLE in file /tmp/.tmpGCajF1/rag-rat-core/src/query/pagerank.rs:259
  HASH_MODEL_ID in file /tmp/.tmpGCajF1/rag-rat-core/src/embedding_models.rs:104
  MODEL2VEC_DISPLAY_MODEL in file /tmp/.tmpGCajF1/rag-rat-core/src/embedding_models.rs:133
  BGE_SMALL_MODEL_ID in file /tmp/.tmpGCajF1/rag-rat-core/src/embedding_models.rs:116
  MAX_REMOTE_EMBEDDING_CONCURRENCY in file /tmp/.tmpGCajF1/rag-rat-core/src/config/types.rs:670
  JINA_CODE_EMBEDDING_DIM in file /tmp/.tmpGCajF1/rag-rat-core/src/embedding_models.rs:127
  FASTEMBED_DISPLAY_MODEL in file /tmp/.tmpGCajF1/rag-rat-core/src/embedding_models.rs:110
  LEGACY_REPO_ID in file /tmp/.tmpGCajF1/rag-rat-core/src/index/schema/registry.rs:106
  JINA_CODE_MODEL_ID in file /tmp/.tmpGCajF1/rag-rat-core/src/embedding_models.rs:125
  MODEL2VEC_MISSING_FEATURE_MESSAGE in file /tmp/.tmpGCajF1/rag-rat-core/src/index/ai/providers/mod.rs:57

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_missing.ron

Failed in:
  struct rag_rat_core::query::symbol::SymbolHit, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/symbol.rs:16
  struct rag_rat_core::index::oracle::AutoRunInputs, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/oracle/auto_run.rs:17
  struct rag_rat_core::embedding_models::EmbeddingModelSpec, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/embedding_models.rs:54
  struct rag_rat_core::dream::ReviewedFinding, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/dream/findings.rs:493
  struct rag_rat_core::index::schema::SchemaStatus, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/schema/mod.rs:526
  struct rag_rat_core::query::impact::ImpactSurfaceQuery, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/impact/mod.rs:109
  struct rag_rat_core::dream::IdentifierResolution, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/dream/verify.rs:273
  struct rag_rat_core::index::oracle::ResolutionDelta, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/oracle/report.rs:123
  struct rag_rat_core::query::impact::ImpactCompleteness, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/impact/mod.rs:121
  struct rag_rat_core::index::oracle::CorpusHealth, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/oracle/report.rs:37
  struct rag_rat_core::index::oracle::OracleStatus, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/oracle/status.rs:13
  struct rag_rat_core::query::graph::MatchedGraphTextHit, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/graph/mod.rs:229
  struct rag_rat_core::query::graph::CompareGraphScipQuery, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/graph/mod.rs:326
  struct rag_rat_core::index::papertrail::PapertrailContext, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/papertrail/mod.rs:48
  struct rag_rat_core::config::EmbeddingConfig, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/config/types.rs:363
  struct rag_rat_core::index::papertrail::ItemsPage, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/papertrail/mod.rs:385
  struct rag_rat_core::index::ai::CookbookInput, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/ai/providers/cookbook.rs:136
  struct rag_rat_core::query::memory::RepoMemoryCallPath, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/memory/mod.rs:146
  struct rag_rat_core::query::graph_meta::CallerEvidence, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/graph_meta.rs:69
  struct rag_rat_core::query::impact::ImpactSurfaceOptions, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/impact/mod.rs:45
  struct rag_rat_core::index::oracle::OracleResolutionReport, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/oracle/report.rs:151
  struct rag_rat_core::index::ai::HashEmbedder, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/ai/providers/hash.rs:5
  struct rag_rat_core::query::graph_meta::GraphEvidence, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/graph_meta.rs:32
  struct rag_rat_core::query::graph::CompareGraphTextQuery, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/graph/mod.rs:197
  struct rag_rat_core::query::graph::GraphTraversalQuery, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/graph/mod.rs:57
  struct rag_rat_core::search::lexical::SearchHit, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/search/lexical.rs:47
  struct rag_rat_core::index::papertrail::Papertrail, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/papertrail/mod.rs:250
  struct rag_rat_core::query::pagerank::ImportanceOptions, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/pagerank.rs:299
  struct rag_rat_core::query::graph::GraphTraversalSummary, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/graph/mod.rs:91
  struct rag_rat_core::query::memory::RepoMemoryCreate, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/memory/mod.rs:173
  struct rag_rat_core::config::SearchConfig, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/config/types.rs:136
  struct rag_rat_core::query::tree::TreeNode, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/tree.rs:25
  struct rag_rat_core::query::memory::CompactRepoMemoryEvidence, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/memory/mod.rs:387
  struct rag_rat_core::index::oracle::RunProvenance, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/oracle/report.rs:105
  struct rag_rat_core::dream::EvidencePack, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/dream/verify.rs:133
  struct rag_rat_core::index::papertrail::PapertrailComment, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/papertrail/mod.rs:332
  struct rag_rat_core::query::graph::TextOnlyHit, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/graph/mod.rs:240
  struct rag_rat_core::index::papertrail::FreshnessResult, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/papertrail/mod.rs:378
  struct rag_rat_core::index::schema::RegisteredRepo, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/schema/registry.rs:1047
  struct rag_rat_core::index::RegisteredRepo, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/schema/registry.rs:1047
  struct rag_rat_core::query::repo_brief::RepoBriefMemoryCounts, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/repo_brief.rs:87
  struct rag_rat_core::dream::CompactPass, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/dream/compact.rs:39
  struct rag_rat_core::config::EmbeddingBackend, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/config/types.rs:395
  struct rag_rat_core::index::oracle::RecallCalls, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/oracle/run.rs:642
  struct rag_rat_core::index::oracle::LibraryUsageOptions, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/oracle/library_usage.rs:58
  struct rag_rat_core::query::memory::RepoMemoryEvidence, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/memory/mod.rs:276
  struct rag_rat_core::index::oracle::LibraryUsageCallSite, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/oracle/library_usage.rs:93
  struct rag_rat_core::query::memory::CompactRepoMemory, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/memory/mod.rs:407
  struct rag_rat_core::index::ai::ProvisionedBox, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/ai/providers/cookbook.rs:251
  struct rag_rat_core::index::papertrail::PapertrailSyncError, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/papertrail/mod.rs:189
  struct rag_rat_core::query::graph_meta::GraphTruncation, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/graph_meta.rs:113
  struct rag_rat_core::query::graph::GraphOnlyEdge, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/graph/mod.rs:249
  struct rag_rat_core::query::symbol::SymbolDisambiguation, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/symbol.rs:131
  struct rag_rat_core::locks::FileLock, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/locks.rs:106
  struct rag_rat_core::query::graph::GraphTraversalOptions, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/graph/mod.rs:33
  struct rag_rat_core::index::papertrail::PapertrailItem, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/papertrail/mod.rs:310
  struct rag_rat_core::query::pagerank::SkippedSeeds, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/pagerank.rs:197
  struct rag_rat_core::index::oracle::CorpusProfile, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/oracle/report.rs:68
  struct rag_rat_core::query::memory::RepoMemoryValidationReport, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/memory/mod.rs:262
  struct rag_rat_core::config::RemoteEmbeddingConfig, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/config/types.rs:591
  struct rag_rat_core::query::graph::LogicalSymbol, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/graph/mod.rs:71
  struct rag_rat_core::dream::VerdictPass, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/dream/verdict.rs:50
  struct rag_rat_core::index::oracle::LibraryUsageReport, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/oracle/library_usage.rs:125
  struct rag_rat_core::query::symbol::SymbolLookup, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/symbol.rs:57
  struct rag_rat_core::index::oracle::OracleReport, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/oracle/mod.rs:785
  struct rag_rat_core::index::ai::MeasuredCandidate, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/ai/throughput_tune.rs:200
  struct rag_rat_core::query::memory::RepoMemoryUpdate, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/memory/mod.rs:248
  struct rag_rat_core::index::oracle::ToolManifest, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/oracle/manifest.rs:20
  struct rag_rat_core::index::papertrail::ResolvedTracker, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/papertrail/trackers.rs:20
  struct rag_rat_core::query::repo_brief::RepoBriefCandidate, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/repo_brief.rs:95
  struct rag_rat_core::index::papertrail::PageCursor, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/papertrail/mod.rs:355
  struct rag_rat_core::query::graph_meta::GraphSymbol, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/graph_meta.rs:55
  struct rag_rat_core::index::papertrail::MirrorBindingReport, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/papertrail/mirror.rs:111
  struct rag_rat_core::query::graph_meta::TypeEvidence, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/graph_meta.rs:107
  struct rag_rat_core::query::load_bearing::ImportanceEnrichment, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/load_bearing.rs:110
  struct rag_rat_core::config::Config, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/config/types.rs:14
  struct rag_rat_core::Config, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/config/types.rs:14
  struct rag_rat_core::index::papertrail::PapertrailSyncReport, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/papertrail/mod.rs:176
  struct rag_rat_core::config::TrackerConfig, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/config/types.rs:54
  struct rag_rat_core::index::ai::CookbookProvisioner, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/ai/providers/cookbook.rs:274
  struct rag_rat_core::query::repo_brief::RepoBriefOptions, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/repo_brief.rs:48
  struct rag_rat_core::repo_identity::RepoIdentity, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/repo_identity.rs:43
  struct rag_rat_core::index::papertrail::PapertrailBindingStatus, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/papertrail/mod.rs:135
  struct rag_rat_core::query::memory::NodeEdge, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/memory/edges.rs:88
  struct rag_rat_core::index::ai::OpenAiEmbedder, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/ai/providers/openai.rs:64
  struct rag_rat_core::query::memory::RepoMemoryBindTarget, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/memory/mod.rs:191
  struct rag_rat_core::query::graph::CompareGraphScipReport, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/graph/mod.rs:318
  struct rag_rat_core::index::schema::AppliedMigration, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/schema/mod.rs:518
  struct rag_rat_core::query::impact::ImpactSurfaceReport, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/impact/mod.rs:93
  struct rag_rat_core::query::repo_brief::RepoBriefMetrics, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/repo_brief.rs:109
  struct rag_rat_core::index::papertrail::PapertrailStatus, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/papertrail/mod.rs:124
  struct rag_rat_core::config::LogConfig, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/config/types.rs:307
  struct rag_rat_core::config::DreamLlmConfig, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/config/types.rs:353
  struct rag_rat_core::index::oracle::ResolutionBefore, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/oracle/report.rs:241
  struct rag_rat_core::dream::DreamFinding, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/dream/mod.rs:75
  struct rag_rat_core::query::graph::GraphHop, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/graph/mod.rs:262
  struct rag_rat_core::query::memory::RepoMemoryCreateResult, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/memory/mod.rs:167
  struct rag_rat_core::query::symbol::LogicalSymbolHit, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/symbol.rs:68
  struct rag_rat_core::dream::WorklistFinding, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/dream/mod.rs:86
  struct rag_rat_core::query::repo_brief::RepoBriefSummary, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/repo_brief.rs:75
  struct rag_rat_core::config::LlmConfig, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/config/types.rs:338
  struct rag_rat_core::query::graph_meta::ImportEvidence, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/graph_meta.rs:101
  struct rag_rat_core::query::repo_brief::RepoBriefNextTool, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/repo_brief.rs:132
  struct rag_rat_core::index::papertrail::PapertrailEvidence, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/papertrail/mod.rs:231
  struct rag_rat_core::query::graph::Callsite, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/graph/mod.rs:306
  struct rag_rat_core::index::papertrail::TrackerCapability, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/papertrail/mod.rs:154
  struct rag_rat_core::query::pagerank::SeedSource, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/pagerank.rs:208
  struct rag_rat_core::query::impact::ImpactItem, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/impact/mod.rs:33
  struct rag_rat_core::dream::HttpVerdictModel, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/dream/model.rs:73
  struct rag_rat_core::index::oracle::OracleEvalMetrics, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/oracle/run.rs:605
  struct rag_rat_core::query::graph::CompareGraphTextReport, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/graph/mod.rs:181
  struct rag_rat_core::storage::IndexConnection, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/storage.rs:49
  struct rag_rat_core::query::pagerank::SymbolImportance, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/pagerank.rs:279
  struct rag_rat_core::query::graph::GraphCoverage, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/graph/mod.rs:111
  struct rag_rat_core::config::EmbeddingRuntimeConfig, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/config/types.rs:460
  struct rag_rat_core::index::ai::Model2VecEmbedder, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/ai/providers/model2vec.rs:17
  struct rag_rat_core::storage::StorageStatus, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/storage.rs:8
  struct rag_rat_core::query::ReadChunk, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/mod.rs:25
  struct rag_rat_core::query::pagerank::ImportantSymbolsResult, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/pagerank.rs:229
  struct rag_rat_core::config::RemoteDreamConfig, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/config/types.rs:758
  struct rag_rat_core::query::graph::GraphScipContradiction, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/graph/mod.rs:347
  struct rag_rat_core::query::memory::RepoMemoryBinding, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/memory/mod.rs:94
  struct rag_rat_core::config::ResolvedTarget, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/config/types.rs:817
  struct rag_rat_core::ResolvedTarget, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/config/types.rs:817
  struct rag_rat_core::locks::WriteLock, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/locks.rs:412
  struct rag_rat_core::dream::VerificationQueueEntry, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/dream/verify.rs:122
  struct rag_rat_core::query::graph::GraphPathCoverage, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/graph/mod.rs:120
  struct rag_rat_core::query::graph::LogicalSymbolVariant, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/graph/mod.rs:80
  struct rag_rat_core::index::papertrail::FreshnessProbe, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/papertrail/mod.rs:372
  struct rag_rat_core::query::impact::ImpactMemoryStatus, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/impact/mod.rs:136
  struct rag_rat_core::query::pagerank::RankedImportance, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/pagerank.rs:272
  struct rag_rat_core::dream::DreamOptions, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/dream/mod.rs:106
  struct rag_rat_core::query::repo_brief::RepoBriefSplitHint, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/repo_brief.rs:126
  struct rag_rat_core::query::graph::CompareGraphTextSummary, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/graph/mod.rs:211
  struct rag_rat_core::config::VersionCheckConfig, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/config/types.rs:219
  struct rag_rat_core::query::tree::DirTree, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/tree.rs:45
  struct rag_rat_core::query::graph_meta::CallsiteEvidence, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/graph_meta.rs:94
  struct rag_rat_core::logging::LogHandle, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/logging/mod.rs:55
  struct rag_rat_core::query::memory::RepoMemory, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/memory/mod.rs:48
  struct rag_rat_core::query::symbol::LogicalSymbolMember, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/symbol.rs:82
  struct rag_rat_core::config::MemoryConfig, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/config/types.rs:150
  struct rag_rat_core::index::papertrail::TrackerParsedRef, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/papertrail/parse.rs:101
  struct rag_rat_core::dream::FileExcerpt, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/dream/verify.rs:285
  struct rag_rat_core::query::graph::GraphTraversalReport, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/graph/mod.rs:45
  struct rag_rat_core::index::papertrail::CommentsPage, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/papertrail/mod.rs:395
  struct rag_rat_core::dream::DreamReport, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/dream/mod.rs:96
  struct rag_rat_core::search::lexical::ScoreComponents, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/search/lexical.rs:78
  struct rag_rat_core::index::oracle::HealthViolation, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/oracle/corpus.rs:46
  struct rag_rat_core::index::papertrail::CurrentSourceEvidence, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/papertrail/mod.rs:258
  struct rag_rat_core::index::AnchorHealth, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/mod.rs:277
  struct rag_rat_core::index::papertrail::PapertrailRef, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/papertrail/mod.rs:218
  struct rag_rat_core::config::PapertrailConfig, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/config/types.rs:115
  struct rag_rat_core::query::symbol::SymbolSelector, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/symbol.rs:94
  struct rag_rat_core::config::OracleConfig, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/config/types.rs:197
  struct rag_rat_core::query::graph::CompareGraphScipSummary, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/graph/mod.rs:334
  struct rag_rat_core::query::tree::TreeOpts, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/tree.rs:7
  struct rag_rat_core::query::repo_brief::RepoBrief, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/repo_brief.rs:67
  struct rag_rat_core::query::load_bearing::OracleContext, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/load_bearing.rs:135
  struct rag_rat_core::config::WatchConfig, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/config/types.rs:233
  struct rag_rat_core::WatchConfig, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/config/types.rs:233
  struct rag_rat_core::index::oracle::LibraryUsageEntry, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/oracle/library_usage.rs:101
  struct rag_rat_core::query::graph_meta::CalleeEvidence, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/query/graph_meta.rs:80
  struct rag_rat_core::index::ai::FastEmbedEmbedder, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/ai/providers/fastembed.rs:5

--- failure trait_missing: pub trait removed or renamed ---

Description:
A publicly-visible trait cannot be imported by its prior path. A `pub use` may have been removed, or the trait itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/trait_missing.ron

Failed in:
  trait rag_rat_core::dream::VerdictModel, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/dream/model.rs:15
  trait rag_rat_core::index::papertrail::PapertrailClient, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/papertrail/mod.rs:433
  trait rag_rat_core::index::ai::Embedder, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/ai/providers/mod.rs:64
  trait rag_rat_core::search::semantic::Embedder, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/ai/providers/mod.rs:64
  trait rag_rat_core::index::oracle::Oracle, previously in file /tmp/.tmpGCajF1/rag-rat-core/src/index/oracle/mod.rs:836
```

### ⚠ `rag-rat-mcp` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field HookRequest.path in /tmp/.tmpwKvizM/rag-rat/crates/rag-rat-mcp/src/agent_hook.rs:26
  field HookResponse.kind in /tmp/.tmpwKvizM/rag-rat/crates/rag-rat-mcp/src/agent_hook.rs:45
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `rag-rat-base`

<blockquote>

## [0.20.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.19.0...rag-rat-base-v0.20.0) - 2026-07-20

### Added

- *(cli)* rag-rat rm <path> — remove a repo from the global index (purge + VACUUM), config, and hooks ([#778](https://github.com/cq27-dev/rag-rat/pull/778))
- *(plugin)* opencode plugin bundle — @rag-rat/plugin-opencode (MCP + hooks) ([#785](https://github.com/cq27-dev/rag-rat/pull/785))
- *(config)* add [llm.distill] config with a model-size-aware provision timeout ([#779](https://github.com/cq27-dev/rag-rat/pull/779))
- *(agent-hook)* augment the Read tool with file/dir memories + load-bearing symbols ([#756](https://github.com/cq27-dev/rag-rat/pull/756)) ([#761](https://github.com/cq27-dev/rag-rat/pull/761))
- *(agent-hook)* PostToolUse edit trigger — scoped reindex, watcher-aware, detached ([#738](https://github.com/cq27-dev/rag-rat/pull/738))
- *(papertrail)* closing-edge substrate — provider-neutral schema, gated text tier, item/comment ref mining ([#702](https://github.com/cq27-dev/rag-rat/pull/702)) ([#722](https://github.com/cq27-dev/rag-rat/pull/722))

### Fixed

- *(tests)* route test scratch through a shared self-healing helper (fixes #726) ([#732](https://github.com/cq27-dev/rag-rat/pull/732))

### Other

- *(readme)* link the rag-rat.cq27.dev site ([#749](https://github.com/cq27-dev/rag-rat/pull/749))
- *(locks)* shared content-carrying single-flight coalescing primitive ([#736](https://github.com/cq27-dev/rag-rat/pull/736))
- *(workspace)* [**breaking**] extract rag-rat-query — the read layer: graph/impact/symbol/tree queries, memory reads + evidence, pagerank (#706 phase 6) ([#719](https://github.com/cq27-dev/rag-rat/pull/719))
- *(workspace)* [**breaking**] extract the rag-rat-clones crate (#706 phase 4) ([#717](https://github.com/cq27-dev/rag-rat/pull/717))
- *(workspace)* [**breaking**] extract rag-rat-papertrail — mirror, providers, transport, evidence (#706 phase 2) ([#715](https://github.com/cq27-dev/rag-rat/pull/715))
- *(workspace)* [**breaking**] extract the rag-rat-db database layer with an explicit MigrationHooks seam (#706 phase 1) ([#714](https://github.com/cq27-dev/rag-rat/pull/714))
</blockquote>

## `rag-rat-db`

<blockquote>

## [0.20.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.19.0...rag-rat-base-v0.20.0) - 2026-07-20

### Added

- *(cli)* rag-rat rm <path> — remove a repo from the global index (purge + VACUUM), config, and hooks ([#778](https://github.com/cq27-dev/rag-rat/pull/778))
- *(plugin)* opencode plugin bundle — @rag-rat/plugin-opencode (MCP + hooks) ([#785](https://github.com/cq27-dev/rag-rat/pull/785))
- *(config)* add [llm.distill] config with a model-size-aware provision timeout ([#779](https://github.com/cq27-dev/rag-rat/pull/779))
- *(agent-hook)* augment the Read tool with file/dir memories + load-bearing symbols ([#756](https://github.com/cq27-dev/rag-rat/pull/756)) ([#761](https://github.com/cq27-dev/rag-rat/pull/761))
- *(agent-hook)* PostToolUse edit trigger — scoped reindex, watcher-aware, detached ([#738](https://github.com/cq27-dev/rag-rat/pull/738))
- *(papertrail)* closing-edge substrate — provider-neutral schema, gated text tier, item/comment ref mining ([#702](https://github.com/cq27-dev/rag-rat/pull/702)) ([#722](https://github.com/cq27-dev/rag-rat/pull/722))

### Fixed

- *(tests)* route test scratch through a shared self-healing helper (fixes #726) ([#732](https://github.com/cq27-dev/rag-rat/pull/732))

### Other

- *(readme)* link the rag-rat.cq27.dev site ([#749](https://github.com/cq27-dev/rag-rat/pull/749))
- *(locks)* shared content-carrying single-flight coalescing primitive ([#736](https://github.com/cq27-dev/rag-rat/pull/736))
- *(workspace)* [**breaking**] extract rag-rat-query — the read layer: graph/impact/symbol/tree queries, memory reads + evidence, pagerank (#706 phase 6) ([#719](https://github.com/cq27-dev/rag-rat/pull/719))
- *(workspace)* [**breaking**] extract the rag-rat-clones crate (#706 phase 4) ([#717](https://github.com/cq27-dev/rag-rat/pull/717))
- *(workspace)* [**breaking**] extract rag-rat-papertrail — mirror, providers, transport, evidence (#706 phase 2) ([#715](https://github.com/cq27-dev/rag-rat/pull/715))
- *(workspace)* [**breaking**] extract the rag-rat-db database layer with an explicit MigrationHooks seam (#706 phase 1) ([#714](https://github.com/cq27-dev/rag-rat/pull/714))
</blockquote>

## `rag-rat-clones`

<blockquote>

## [0.20.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.19.0...rag-rat-base-v0.20.0) - 2026-07-20

### Added

- *(cli)* rag-rat rm <path> — remove a repo from the global index (purge + VACUUM), config, and hooks ([#778](https://github.com/cq27-dev/rag-rat/pull/778))
- *(plugin)* opencode plugin bundle — @rag-rat/plugin-opencode (MCP + hooks) ([#785](https://github.com/cq27-dev/rag-rat/pull/785))
- *(config)* add [llm.distill] config with a model-size-aware provision timeout ([#779](https://github.com/cq27-dev/rag-rat/pull/779))
- *(agent-hook)* augment the Read tool with file/dir memories + load-bearing symbols ([#756](https://github.com/cq27-dev/rag-rat/pull/756)) ([#761](https://github.com/cq27-dev/rag-rat/pull/761))
- *(agent-hook)* PostToolUse edit trigger — scoped reindex, watcher-aware, detached ([#738](https://github.com/cq27-dev/rag-rat/pull/738))
- *(papertrail)* closing-edge substrate — provider-neutral schema, gated text tier, item/comment ref mining ([#702](https://github.com/cq27-dev/rag-rat/pull/702)) ([#722](https://github.com/cq27-dev/rag-rat/pull/722))

### Fixed

- *(tests)* route test scratch through a shared self-healing helper (fixes #726) ([#732](https://github.com/cq27-dev/rag-rat/pull/732))

### Other

- *(readme)* link the rag-rat.cq27.dev site ([#749](https://github.com/cq27-dev/rag-rat/pull/749))
- *(locks)* shared content-carrying single-flight coalescing primitive ([#736](https://github.com/cq27-dev/rag-rat/pull/736))
- *(workspace)* [**breaking**] extract rag-rat-query — the read layer: graph/impact/symbol/tree queries, memory reads + evidence, pagerank (#706 phase 6) ([#719](https://github.com/cq27-dev/rag-rat/pull/719))
- *(workspace)* [**breaking**] extract the rag-rat-clones crate (#706 phase 4) ([#717](https://github.com/cq27-dev/rag-rat/pull/717))
- *(workspace)* [**breaking**] extract rag-rat-papertrail — mirror, providers, transport, evidence (#706 phase 2) ([#715](https://github.com/cq27-dev/rag-rat/pull/715))
- *(workspace)* [**breaking**] extract the rag-rat-db database layer with an explicit MigrationHooks seam (#706 phase 1) ([#714](https://github.com/cq27-dev/rag-rat/pull/714))
</blockquote>

## `rag-rat-llm`

<blockquote>

## [0.20.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.19.0...rag-rat-base-v0.20.0) - 2026-07-20

### Added

- *(cli)* rag-rat rm <path> — remove a repo from the global index (purge + VACUUM), config, and hooks ([#778](https://github.com/cq27-dev/rag-rat/pull/778))
- *(plugin)* opencode plugin bundle — @rag-rat/plugin-opencode (MCP + hooks) ([#785](https://github.com/cq27-dev/rag-rat/pull/785))
- *(config)* add [llm.distill] config with a model-size-aware provision timeout ([#779](https://github.com/cq27-dev/rag-rat/pull/779))
- *(agent-hook)* augment the Read tool with file/dir memories + load-bearing symbols ([#756](https://github.com/cq27-dev/rag-rat/pull/756)) ([#761](https://github.com/cq27-dev/rag-rat/pull/761))
- *(agent-hook)* PostToolUse edit trigger — scoped reindex, watcher-aware, detached ([#738](https://github.com/cq27-dev/rag-rat/pull/738))
- *(papertrail)* closing-edge substrate — provider-neutral schema, gated text tier, item/comment ref mining ([#702](https://github.com/cq27-dev/rag-rat/pull/702)) ([#722](https://github.com/cq27-dev/rag-rat/pull/722))

### Fixed

- *(tests)* route test scratch through a shared self-healing helper (fixes #726) ([#732](https://github.com/cq27-dev/rag-rat/pull/732))

### Other

- *(readme)* link the rag-rat.cq27.dev site ([#749](https://github.com/cq27-dev/rag-rat/pull/749))
- *(locks)* shared content-carrying single-flight coalescing primitive ([#736](https://github.com/cq27-dev/rag-rat/pull/736))
- *(workspace)* [**breaking**] extract rag-rat-query — the read layer: graph/impact/symbol/tree queries, memory reads + evidence, pagerank (#706 phase 6) ([#719](https://github.com/cq27-dev/rag-rat/pull/719))
- *(workspace)* [**breaking**] extract the rag-rat-clones crate (#706 phase 4) ([#717](https://github.com/cq27-dev/rag-rat/pull/717))
- *(workspace)* [**breaking**] extract rag-rat-papertrail — mirror, providers, transport, evidence (#706 phase 2) ([#715](https://github.com/cq27-dev/rag-rat/pull/715))
- *(workspace)* [**breaking**] extract the rag-rat-db database layer with an explicit MigrationHooks seam (#706 phase 1) ([#714](https://github.com/cq27-dev/rag-rat/pull/714))
</blockquote>

## `rag-rat-papertrail`

<blockquote>

## [0.20.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.19.0...rag-rat-base-v0.20.0) - 2026-07-20

### Added

- *(cli)* rag-rat rm <path> — remove a repo from the global index (purge + VACUUM), config, and hooks ([#778](https://github.com/cq27-dev/rag-rat/pull/778))
- *(plugin)* opencode plugin bundle — @rag-rat/plugin-opencode (MCP + hooks) ([#785](https://github.com/cq27-dev/rag-rat/pull/785))
- *(config)* add [llm.distill] config with a model-size-aware provision timeout ([#779](https://github.com/cq27-dev/rag-rat/pull/779))
- *(agent-hook)* augment the Read tool with file/dir memories + load-bearing symbols ([#756](https://github.com/cq27-dev/rag-rat/pull/756)) ([#761](https://github.com/cq27-dev/rag-rat/pull/761))
- *(agent-hook)* PostToolUse edit trigger — scoped reindex, watcher-aware, detached ([#738](https://github.com/cq27-dev/rag-rat/pull/738))
- *(papertrail)* closing-edge substrate — provider-neutral schema, gated text tier, item/comment ref mining ([#702](https://github.com/cq27-dev/rag-rat/pull/702)) ([#722](https://github.com/cq27-dev/rag-rat/pull/722))

### Fixed

- *(tests)* route test scratch through a shared self-healing helper (fixes #726) ([#732](https://github.com/cq27-dev/rag-rat/pull/732))

### Other

- *(readme)* link the rag-rat.cq27.dev site ([#749](https://github.com/cq27-dev/rag-rat/pull/749))
- *(locks)* shared content-carrying single-flight coalescing primitive ([#736](https://github.com/cq27-dev/rag-rat/pull/736))
- *(workspace)* [**breaking**] extract rag-rat-query — the read layer: graph/impact/symbol/tree queries, memory reads + evidence, pagerank (#706 phase 6) ([#719](https://github.com/cq27-dev/rag-rat/pull/719))
- *(workspace)* [**breaking**] extract the rag-rat-clones crate (#706 phase 4) ([#717](https://github.com/cq27-dev/rag-rat/pull/717))
- *(workspace)* [**breaking**] extract rag-rat-papertrail — mirror, providers, transport, evidence (#706 phase 2) ([#715](https://github.com/cq27-dev/rag-rat/pull/715))
- *(workspace)* [**breaking**] extract the rag-rat-db database layer with an explicit MigrationHooks seam (#706 phase 1) ([#714](https://github.com/cq27-dev/rag-rat/pull/714))
</blockquote>

## `rag-rat-query`

<blockquote>

## [0.20.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.19.0...rag-rat-base-v0.20.0) - 2026-07-20

### Added

- *(cli)* rag-rat rm <path> — remove a repo from the global index (purge + VACUUM), config, and hooks ([#778](https://github.com/cq27-dev/rag-rat/pull/778))
- *(plugin)* opencode plugin bundle — @ra