### PR TITLE
test(llm): force deterministic completion order in the embed_batch out-of-order test (fixes #417)

### DIFF
--- a/crates/rag-rat-llm/src/openai.rs
+++ b/crates/rag-rat-llm/src/openai.rs
@@ -778,8 +778,8 @@ mod tests {
         std::sync::Arc<std::sync::atomic::AtomicUsize>,
         std::sync::Arc<std::sync::atomic::AtomicUsize>,
     ) {
-        use std::sync::Arc;
         use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::{Arc, Condvar, Mutex};
 
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let port = listener.local_addr().unwrap().port();
@@ -787,6 +787,9 @@ mod tests {
         let in_flight = Arc::new(AtomicUsize::new(0));
         let max_in_flight = Arc::new(AtomicUsize::new(0));
         let waits_satisfied = Arc::new(AtomicUsize::new(0));
+        // Count of requests that have FULLY written their response, paired with a condvar so a
+        // parked worker is released by an explicit completion signal rather than by polling.
+        let completions = Arc::new((Mutex::new(0usize), Condvar::new()));
         let counter = Arc::clone(&requests);
         let delays = Arc::new(delays);
         let wait_for_prior_response = Arc::new(wait_for_prior_response);
@@ -802,6 +805,7 @@ mod tests {
                 let delays = Arc::clone(&delays);
                 let wait_for_prior_response = Arc::clone(&wait_for_prior_response);
                 let waits_seen = Arc::clone(&waits_seen);
+                let completions = Arc::clone(&completions);
                 workers.push(thread::spawn(move || {
                     let now = in_flight.fetch_add(1, Ordering::SeqCst) + 1;
                     raise_max(&max_seen, now);
@@ -812,16 +816,32 @@ mod tests {
                     {
                         thread::sleep(*delay);
                     }
+                    // Deterministic "later request finishes first" ordering: a request whose first
+                    // text index is in `wait_for_prior_response` parks until ANOTHER request has
+                    // fully written its response and signalled completion via the condvar — no
+                    // scheduler timing, no busy-poll. The 30s cap is only a deadlock guard (if the
+                    // client never dispatches a concurrent second request the assertion fails
+                    // rather than hanging CI); on a healthy run the signal arrives in milliseconds,
+                    // so the release never depends on beating a deadline.
                     if let Some(first) = indices.first().copied()
                         && wait_for_prior_response.contains(&first)
                     {
+                        let (lock, cvar) = &*completions;
+                        let mut done = lock.lock().unwrap();
                         let started = std::time::Instant::now();
-                        while counter.load(Ordering::SeqCst) == 0
-                            && started.elapsed() < Duration::from_secs(2)
-                        {
-                            thread::sleep(Duration::from_millis(1));
+                        let deadline = Duration::from_secs(30);
+                        while *done == 0 {
+                            let remaining = deadline.saturating_sub(started.elapsed());
+                            if remaining.is_zero() {
+                                break;
+                            }
+                            let (guard, timeout) = cvar.wait_timeout(done, remaining).unwrap();
+                            done = guard;
+                            if timeout.timed_out() {
+                                break;
+                            }
                         }
-                        if counter.load(Ordering::SeqCst) > 0 {
+                        if *done > 0 {
                             waits_seen.fetch_add(1, Ordering::SeqCst);
                         }
                     }
@@ -843,6 +863,13 @@ mod tests {
                     let _ = stream.write_all(response.as_bytes());
                     let _ = stream.flush();
                     counter.fetch_add(1, Ordering::SeqCst);
+                    // Explicit completion signal: release any worker parked in
+                    // `wait_for_prior_response` above, forcing a deterministic completion order.
+                    {
+                        let (lock, cvar) = &*completions;
+                        *lock.lock().unwrap() += 1;
+                        cvar.notify_all();
+                    }
                     in_flight.fetch_sub(1, Ordering::SeqCst);
                 }));
             }


### PR DESCRIPTION
Fixes #417, with the fix shape the issue prescribes: the stub's parked request now blocks on a `Condvar` until another request has fully written its response and signalled — the "later request finishes first" ordering is forced by explicit completion signaling, not scheduler timing. The old 2s-bounded busy-poll is gone; a 30s cap remains purely as a deadlock guard. One file, +33/−6, entirely inside `mod tests` — production `embed_batch` reassembly is untouched. (Post-crate-split note: the test lives in `rag-rat-llm` now — the issue's `-p rag-rat-core` is the old name.)

## Honest repro disclosure

**The flake did not fire on this box**: 30/30 pinned runs (`taskset -c 0`) passed on unmodified main, because the current 2s poll is already robust on this hardware (the later response lands in ~ms). The issue's ~6/10 was presumably a more constrained/loaded runner. So the before/after counts here can't demonstrate the flake dying — the value of this change is removing the timing window *entirely*, which holds on any hardware.

## What proves the test still bites

Mutation check (implementer, then independently re-run before opening): breaking production reassembly to return sub-batch results out of request order fails the test **deterministically** (`left: [1.0, 0.0]` vs `right: [0.0, 1.0]` — 10/10 with an mpsc completion-order variant; my re-run used a reversed-iteration variant, same kill). The sibling test sharing the stub (`parallel_counting_stub_wait_branch_is_deterministic`) passes 20/20 pinned.

## Gates

`cargo +nightly fmt --check` (no diff; the `struct_lit_style` warnings are the pre-existing rustfmt.toml/nightly mismatch), clippy on default/all/no-default features (RC 0; the one warning anywhere is pre-existing in `rag-rat-core`), and `cargo test --workspace --no-default-features --locked` fully green (~3200 tests; nextest wasn't available here, plain `cargo test` used).

One incidental find worth passing on: `cargo test <bare-name> --exact` silently runs **zero** tests (it needs the module-qualified path) while printing `test result: ok` — a vacuous green that briefly fooled our own repro loop. Might be worth a note in your CONTRIBUTING if one ever lands.

---
🤖 This PR was written with AI assistance (Claude), directed and verified by a human-supervised workflow.