### PR TITLE
papertrail: closing-edge substrate — provider-neutral schema, text-tier edges, item/comment ref mining (#702 stage 1)

### DIFF
--- a/crates/rag-rat-base/src/config/types.rs
+++ b/crates/rag-rat-base/src/config/types.rs
@@ -69,6 +69,8 @@ pub struct TrackerConfig {
     Copy,
     PartialEq,
     Eq,
+    PartialOrd,
+    Ord,
     serde::Serialize,
     serde::Deserialize,
     strum::EnumString,

--- a/crates/rag-rat-core/src/index/poison_sibling.rs
+++ b/crates/rag-rat-core/src/index/poison_sibling.rs
@@ -36,13 +36,13 @@
 //! `logical_symbols`, `docs`, `parser_failures`, `git_commits`, `git_file_changes` (plus
 //! `chunks`/`symbols`/`edges_data` TRANSITIVELY via `files.id` and `logical_symbol_members` via
 //! `logical_symbols.id`) — the provider-neutral papertrail tables (`papertrail_refs`,
-//! `papertrail_items`, `papertrail_comments`, `papertrail_sync_cursor`, `papertrail_item_tags`,
-//! V060) plus the `papertrail_fts` mirror — AND the V042 periphery tables that each gained
-//! their OWN `repo_id`: `repo_memories`, `repo_memory_bindings`, `repo_memory_fts`,
-//! `logical_symbol_monikers` (now direct, no longer only transitive), `oracle_runs`, `edge_oracle`,
-//! `clone_graph_generations`, `clone_token_df`, `clone_refinements`, `dream_findings`, and
-//! `reconcile_attempts` (with `repo_memory_tags` scoped transitively through `repo_memories`) — AND
-//! the dream-verification siblings `memory_reality` / `memory_summaries` /
+//! `papertrail_items`, `papertrail_comments`, `papertrail_closing_edges`, `papertrail_sync_cursor`,
+//! `papertrail_item_tags`, V060) plus the `papertrail_fts` mirror — AND the V042 periphery tables
+//! that each gained their OWN `repo_id`: `repo_memories`, `repo_memory_bindings`,
+//! `repo_memory_fts`, `logical_symbol_monikers` (now direct, no longer only transitive),
+//! `oracle_runs`, `edge_oracle`, `clone_graph_generations`, `clone_token_df`, `clone_refinements`,
+//! `dream_findings`, and `reconcile_attempts` (with `repo_memory_tags` scoped transitively through
+//! `repo_memories`) — AND the dream-verification siblings `memory_reality` / `memory_summaries` /
 //! `memory_model_failures`, each of which carries its own `repo_id` — AND the typed-edge set
 //! `repo_node_edges` (V049), owner-scoped by `repo_id`.
 //! [`seed_sibling`] seeds a tripwire row into every one of those. Nothing repo-scoped is left
@@ -353,6 +353,14 @@ pub(crate) fn seed_sibling(conn: &Connection) -> anyhow::Result<()> {
             format!("{POISON_PREFIX}reftext"),
             POISON_REPO_ID
         ],
+    )?;
+    // V073 (#702): a sibling closing edge for the SAME external pair — an unscoped closing-edge
+    // read would adopt the sibling's attested closer.
+    conn.execute(
+        "INSERT OR IGNORE INTO papertrail_closing_edges(tracker, project, issue_kind, issue_key, \
+         closer_kind, closer_key, source, synced_at_ms, repo_id)
+         VALUES ('github', ?1, 'issue', ?2, 'commit', ?3, 'provider', 0, ?4)",
+        params![POISON_PROJECT, POISON_ITEM_KEY, format!("{POISON_PREFIX}sha"), POISON_REPO_ID],
     )?;
     conn.execute(
         "INSERT INTO papertrail_items(tracker, project, item_kind, item_key, url, state, title, \
@@ -875,6 +883,13 @@ fn sibling_tripwires(conn: &Connection) -> anyhow::Result<Vec<(&'static str, Str
             ),
         ),
         // papertrail (V060): each base table + the fts mirror pinned by the sentinel item key.
+        (
+            "papertrail_closing_edges",
+            format!(
+                "repo_id = '{POISON_REPO_ID}' AND issue_key = '{POISON_ITEM_KEY}' AND closer_key \
+                 = '{POISON_PREFIX}sha'"
+            ),
+        ),
         (
             "papertrail_refs",
             format!("repo_id = '{POISON_REPO_ID}' AND item_key = '{POISON_ITEM_KEY}'"),

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/mod.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/mod.rs
@@ -587,6 +587,11 @@ impl MockGitHubClient {
             created_at: Some("2026-01-01T00:00:00Z".to_string()),
             updated_at: Some("2026-01-02T00:00:00Z".to_string()),
             merged_at: None,
+            closed_at: None,
+            resolution: None,
+            merge_commit_sha: None,
+            author_kind: None,
+            author_association: None,
             tags: Vec::new(),
         }
     }
@@ -600,6 +605,8 @@ impl MockGitHubClient {
             url: Some(format!("https://github.com/{project}/issues/{key}#comment-{id}")),
             body: body.to_string(),
             author: Some("octo".to_string()),
+            author_kind: None,
+            author_association: None,
             created_at: Some("2026-01-01T01:00:00Z".to_string()),
             updated_at: Some("2026-01-01T01:00:00Z".to_string()),
             review_state: None,
@@ -611,11 +618,15 @@ impl MockGitHubClient {
             papertrail::PapertrailComment {
                 url: None,
                 author: Some("reviewer".to_string()),
+                author_kind: None,
+                author_association: None,
                 review_state: Some("COMMENTED".to_string()),
                 ..comment("4202", "Risk: live crawling during search would be surprising.")
             },
             papertrail::PapertrailComment {
                 author: Some("reviewer".to_string()),
+                author_kind: None,
+                author_association: None,
                 anchor_path: Some("docs/search.md".to_string()),
                 ..comment("4203", "No longer use obsolete duckdb rationale.")
             },

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/papertrail_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/papertrail_tests.rs
@@ -157,6 +157,7 @@ fn rationale_lookup_keeps_self_contained_github_refs_without_a_binding() {
     papertrail::block_on(papertrail::sync_refs(
         db.storage.connection(),
         &MockGitHubClient,
+        &[],
         std::iter::once(&reference),
         &mut |_| {},
     ))
@@ -918,6 +919,8 @@ fn both_repos_keep_a_shared_items_comments_across_syncs() {
                 url: Some("http://c".into()),
                 body: body.into(),
                 author: None,
+                author_kind: None,
+                author_association: None,
                 created_at: None,
                 updated_at: None,
                 review_state: None,

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_registry.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_registry.rs
@@ -3065,6 +3065,11 @@ fn a_syncing_repo_is_isolated_from_stranded_placeholder_papertrail_rows() {
             created_at: None,
             updated_at: None,
             merged_at: None,
+            closed_at: None,
+            resolution: None,
+            merge_commit_sha: None,
+            author_kind: None,
+            author_association: None,
             tags: Vec::new(),
         },
     )

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
@@ -2305,8 +2305,7 @@ fn migration_071_indexes_edge_target_qname() {
 }
 
 #[test]
-fn migration_072_is_the_tip_and_queues_pending_refold() {
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 72, "move this pin with the next schema migration");
+fn migration_072_queues_pending_refold() {
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     schema::apply(&conn, &crate::index::migration_hooks()).unwrap();
 
@@ -2569,4 +2568,115 @@ fn forward_migration_records_migration_provenance() {
         .optional()
         .unwrap();
     assert_eq!(to.as_deref(), Some(schema::LATEST_SCHEMA_VERSION.to_string().as_str()));
+}
+
+#[test]
+fn migration_073_is_the_tip_and_builds_the_distill_substrate() {
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 73, "move this pin with the next schema migration");
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn, &crate::index::migration_hooks()).unwrap();
+
+    // The closing-edge table exists with the full column set, repo_id included from birth.
+    let cols = conn_table_columns(&conn, "papertrail_closing_edges");
+    for col in [
+        "tracker",
+        "project",
+        "issue_kind",
+        "issue_key",
+        "closer_kind",
+        "closer_key",
+        "closer_commit",
+        "source",
+        "synced_at_ms",
+        "repo_id",
+    ] {
+        assert!(cols.contains(&col.to_string()), "V073 closing-edge column `{col}` exists");
+    }
+    // The natural key is the (issue, closer) PAIR — `source` is an attribute, so the same edge
+    // discovered by the text tier and then the provider tier converges to one row instead of two.
+    conn.execute(
+        "INSERT INTO papertrail_closing_edges(tracker, project, issue_kind, issue_key, \
+         closer_kind, closer_key, source, synced_at_ms, repo_id) VALUES ('github', 'o/r', \
+         'issue', '5', 'change_request', '9', 'text', 1, 'r')",
+        [],
+    )
+    .unwrap();
+    assert!(
+        conn.execute(
+            "INSERT INTO papertrail_closing_edges(tracker, project, issue_kind, issue_key, \
+             closer_kind, closer_key, source, synced_at_ms, repo_id) VALUES ('github', 'o/r', \
+             'issue', '5', 'change_request', '9', 'provider', 2, 'r')",
+            [],
+        )
+        .is_err(),
+        "the natural key rejects a second row for the same (issue, closer) pair",
+    );
+    // A DIFFERENT closer for the same issue is a distinct edge (an issue can be closed by a
+    // change request AND referenced by the closing commit).
+    conn.execute(
+        "INSERT INTO papertrail_closing_edges(tracker, project, issue_kind, issue_key, \
+         closer_kind, closer_key, source, synced_at_ms, repo_id) VALUES ('github', 'o/r', \
+         'issue', '5', 'commit', 'abc123', 'text', 1, 'r')",
+        [],
+    )
+    .unwrap();
+
+    // The item outcome columns exist on items; the author facets on comments too.
+    let item_cols = conn_table_columns(&conn, "papertrail_items");
+    for col in [
+        "closed_at",
+        "resolution",
+        "merge_commit_sha",
+        "state_normalized",
+        "author_kind",
+        "author_association",
+    ] {
+        assert!(item_cols.contains(&col.to_string()), "V073 item column `{col}` exists");
+    }
+    let comment_cols = conn_table_columns(&conn, "papertrail_comments");
+    for col in ["author_kind", "author_association"] {
+        assert!(comment_cols.contains(&col.to_string()), "V073 comment column `{col}` exists");
+    }
+}
+
+#[test]
+fn migration_073_backfills_state_normalized_from_the_provider_truthful_pair() {
+    // The trap this column exists for: GitLab merged MRs carry state='merged', GitHub merged PRs
+    // carry state='closed' + merged_at — a consumer filtering raw `WHERE state='closed'` silently
+    // drops every merged GitLab MR. The backfill derives the normalized value for pre-V073 rows;
+    // rerunning it is a no-op for already-stamped rows (idempotent replay).
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn, &crate::index::migration_hooks()).unwrap();
+    let insert = |key: &str, state: &str, merged_at: Option<&str>| {
+        conn.execute(
+            "INSERT INTO papertrail_items(tracker, project, item_kind, item_key, url, state, \
+             title, body, merged_at, synced_at_ms, repo_id, state_normalized) VALUES ('github', \
+             'o/r', 'change_request', ?1, 'u', ?2, 't', 'b', ?3, 1, 'r', '')",
+            rusqlite::params![key, state, merged_at],
+        )
+        .unwrap();
+    };
+    insert("1", "closed", Some("2026-01-03T00:00:00Z")); // GitHub merged PR
+    insert("2", "merged", None); // GitLab merged MR
+    insert("3", "closed", None); // closed unmerged
+    insert("4", "open", None);
+    rag_rat_db::schema::apply_papertrail_distill_substrate(&conn).unwrap();
+    let normalized = |key: &str| -> String {
+        conn.query_row(
+            "SELECT state_normalized FROM papertrail_items WHERE item_key = ?1",
+            [key],
+            |row| row.get(0),
+        )
+        .unwrap()
+    };
+    assert_eq!(normalized("1"), "merged", "merged_at wins over raw closed state");
+    assert_eq!(normalized("2"), "merged", "GitLab's state='merged' normalizes to merged");
+    assert_eq!(normalized("3"), "closed");
+    assert_eq!(normalized("4"), "open");
+    // Idempotent: a stamped row is untouched by a replay (the WHERE '' predicate skips it).
+    conn.execute("UPDATE papertrail_items SET state_normalized = 'closed' WHERE item_key = '4'", [
+    ])
+    .unwrap();
+    rag_rat_db::schema::apply_papertrail_distill_substrate(&conn).unwrap();
+    assert_eq!(normalized("4"), "closed", "replay does not re-derive a stamped row");
 }

--- a/crates/rag-rat-db/src/schema/baseline.rs
+++ b/crates/rag-rat-db/src/schema/baseline.rs
@@ -480,6 +480,9 @@ pub fn apply_baseline(conn: &Connection) -> rusqlite::Result<()> {
     // re-runs the baseline) can never resurrect the dropped legacy cache. The V009/V041/V044/V045
     // github migrations in the ladder each no-op when the legacy tables are absent.
     create_papertrail_tables(conn)?;
+    // V073 (#702): the distillation substrate — closing edges + item/comment outcome columns.
+    // Additive over the V060 shape; the baseline converges to the current schema directly.
+    migrations::apply_papertrail_distill_substrate(conn)?;
     apply_symbol_facts(conn)?;
     apply_repo_memories(conn)?;
     apply_repo_memory_call_paths(conn)?;

--- a/crates/rag-rat-db/src/schema/migrations.rs
+++ b/crates/rag-rat-db/src/schema/migrations.rs
@@ -1286,6 +1286,7 @@ pub(crate) fn known_version(migrations: &[AppliedMigration]) -> u32 {
             MIGRATION_070_ID => Some(70),
             MIGRATION_071_ID => Some(71),
             MIGRATION_072_ID => Some(72),
+            MIGRATION_073_ID => Some(73),
             _ => None,
         })
         .max()
@@ -1367,6 +1368,7 @@ pub(crate) fn known_migration(id: &str) -> bool {
             | MIGRATION_070_ID
             | MIGRATION_071_ID
             | MIGRATION_072_ID
+            | MIGRATION_073_ID
             | DIRTY_MIGRATION_ID
     )
 }
@@ -1445,6 +1447,7 @@ pub(crate) fn migration_checksum_mismatch(migration: &AppliedMigration) -> bool 
         MIGRATION_070_ID => migration.checksum != MIGRATION_070_CHECKSUM,
         MIGRATION_071_ID => migration.checksum != MIGRATION_071_CHECKSUM,
         MIGRATION_072_ID => migration.checksum != MIGRATION_072_CHECKSUM,
+        MIGRATION_073_ID => migration.checksum != MIGRATION_073_CHECKSUM,
         _ => false,
     }
 }
@@ -5075,6 +5078,92 @@ pub(crate) fn rebuild_files_table_for_commit_scopes(conn: &Connection) -> rusqli
         ALTER TABLE files_new RENAME TO files;
 
         PRAGMA foreign_keys = ON;
+        ",
+    )
+}
+
+/// V073 (issue #702): the provider-attested closing-edge substrate for issue distillation.
+/// `papertrail_closing_edges` is a FIRST-CLASS issue↔closer edge table, deliberately NOT more
+/// `papertrail_refs` rows: refs are an annotation layer whose unique index coalesces on
+/// `source_text`, while a closing edge's identity is the (issue, closer) PAIR and its trust
+/// semantics differ by `source` — `provider` rows are attested by the tracker's own data
+/// (GraphQL closing references, closed-event closers), `text` rows are mined from
+/// commit/item/comment text and remain the degradation tier.
+/// INVARIANT: `source` is an attribute, not part of the natural key — the same (issue, closer)
+/// pair discovered by both tiers converges to ONE row, and a `provider` row is never downgraded
+/// back to `text` (the store upsert enforces the precedence).
+/// The new `papertrail_items` columns are all fillable from payloads the mirror already parses
+/// (zero extra API calls):
+///  - `closed_at` — the temporal axis for supersession ordering (`created_at` is NOT it);
+///  - `resolution` — the provider-NEUTRAL outcome enum (`completed | not_planned | duplicate |
+///    superseded | unknown`); GitHub `state_reason` maps in, Jira's resolution field maps in
+///    richer, GitLab is mostly `unknown`;
+///  - `merge_commit_sha` — INVARIANT: stored ONLY for merged change requests. GitHub returns a
+///    non-null `merge_commit_sha` for closed-UNMERGED PRs too (its ephemeral test-merge commit,
+///    possibly on no branch); the store write path must gate on `merged_at`/merged state, never
+///    trust the field's presence;
+///  - `state_normalized` — `open | closed | merged`. GitLab merged MRs carry `state='merged'`, so a
+///    plain `WHERE state='closed'` silently drops every merged GitLab MR; consumers filter on THIS
+///    column, never on raw `state`. Backfilled below from the provider-truthful pair (`state`,
+///    `merged_at`); new rows are stamped at store time.
+///  - `author_kind` / `author_association` (items AND comments) — thread-shape facets (`user.type:
+///    "Bot"`, `OWNER`/`MEMBER`/…), already in the parsed payloads.
+///
+/// Additive only: `CREATE TABLE IF NOT EXISTS` + `add_column_if_missing` + an idempotent
+/// backfill UPDATE, so a torn replay reconverges without a wrapping transaction.
+pub fn apply_papertrail_distill_substrate(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "
+        CREATE TABLE IF NOT EXISTS papertrail_closing_edges(
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            tracker TEXT NOT NULL,
+            project TEXT NOT NULL,
+            issue_kind TEXT NOT NULL,
+            issue_key TEXT NOT NULL,
+            -- 'change_request' | 'commit' (ClosingEdgeCloserKind::as_db_str)
+            closer_kind TEXT NOT NULL,
+            -- change_request: the closer item's key in the same project; commit: the full sha.
+            closer_key TEXT NOT NULL,
+            -- The closing/merge commit sha when known (a change_request closer's merge commit).
+            closer_commit TEXT,
+            -- 'provider' | 'text' (ClosingEdgeSource::as_db_str). Attribute, NOT key: the store
+            -- upsert converges both tiers onto one row and never downgrades provider -> text.
+            source TEXT NOT NULL,
+            synced_at_ms INTEGER NOT NULL,
+            repo_id TEXT NOT NULL DEFAULT '__unassigned__'
+        ) STRICT;
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_papertrail_closing_edges_natural_key
+            ON papertrail_closing_edges(repo_id, tracker, project, issue_kind, issue_key, \
+         closer_kind, closer_key);
+        CREATE INDEX IF NOT EXISTS idx_papertrail_closing_edges_closer
+            ON papertrail_closing_edges(repo_id, tracker, project, closer_kind, closer_key);
+        ",
+    )?;
+    add_column_if_missing(conn, "papertrail_items", "closed_at", "TEXT")?;
+    add_column_if_missing(conn, "papertrail_items", "resolution", "TEXT")?;
+    // INVARIANT: non-null ONLY for merged change requests — see the migration doc above.
+    add_column_if_missing(conn, "papertrail_items", "merge_commit_sha", "TEXT")?;
+    add_column_if_missing(
+        conn,
+        "papertrail_items",
+        "state_normalized",
+        "TEXT NOT NULL DEFAULT ''",
+    )?;
+    add_column_if_missing(conn, "papertrail_items", "author_kind", "TEXT")?;
+    add_column_if_missing(conn, "papertrail_items", "author_association", "TEXT")?;
+    add_column_if_missing(conn, "papertrail_comments", "author_kind", "TEXT")?;
+    add_column_if_missing(conn, "papertrail_comments", "author_association", "TEXT")?;
+    // Backfill the normalized state for pre-existing rows from the provider-truthful pair:
+    // 'merged' state (GitLab MRs) or a recorded merged_at (GitHub PRs) wins over raw 'closed';
+    // anything else non-closed is 'open'. Idempotent: the predicate re-derives the same value.
+    conn.execute_batch(
+        "
+        UPDATE papertrail_items SET state_normalized = CASE
+            WHEN state = 'merged' OR merged_at IS NOT NULL THEN 'merged'
+            WHEN state = 'closed' THEN 'closed'
+            ELSE 'open'
+        END
+        WHERE state_normalized = '';
         ",
     )
 }

--- a/crates/rag-rat-db/src/schema/mod.rs
+++ b/crates/rag-rat-db/src/schema/mod.rs
@@ -16,9 +16,10 @@ pub use migrations::{
     apply_memory_model_failures_table, apply_memory_verification_tables, apply_move_per_repo_meta,
     apply_oplog_device_identity, apply_oplog_device_x25519, apply_oplog_local_account,
     apply_oplog_storage, apply_oplog_stream_scoping, apply_oracle_tables,
-    apply_papertrail_binding_health, apply_papertrail_mirror_resume_state,
-    apply_papertrail_provider_neutral_schema, apply_repo_id_core_scoping,
-    apply_repo_id_periphery_scoping, apply_repos_registry, apply_scip_moniker_anchors,
+    apply_papertrail_binding_health, apply_papertrail_distill_substrate,
+    apply_papertrail_mirror_resume_state, apply_papertrail_provider_neutral_schema,
+    apply_repo_id_core_scoping, apply_repo_id_periphery_scoping, apply_repos_registry,
+    apply_scip_moniker_anchors,
 };
 pub use migrations::{column_exists, rebuild_repo_memory_fts_with_repo_id, table_exists};
 // `multiple_real_repos` lost its V042-era seam-guard callers (real `repo_id` predicates
@@ -39,7 +40,7 @@ use serde::Serialize;
 
 use crate::hooks::MigrationHooks;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 72;
+pub const LATEST_SCHEMA_VERSION: u32 = 73;
 
 /// Every oracle-DERIVED persisted table — the outputs an `oracle run` writes that must OUTLIVE a
 /// reindex.
@@ -523,6 +524,15 @@ const MIGRATION_072_DESCRIPTION: &str =
      writer lock as a stream is built one candidate at a time); it enqueues the stream here and \
      settle_pending_content_refolds folds each dirty stream once. Purely additive; CREATE ... IF \
      NOT EXISTS, nothing pre-existing to backfill";
+
+const MIGRATION_073_ID: &str = "073_papertrail_distill_substrate";
+const MIGRATION_073_CHECKSUM: &str = "sha256:rag-rat-papertrail-distill-substrate-v73";
+const MIGRATION_073_DESCRIPTION: &str =
+    "Add papertrail_closing_edges (issue #702): first-class provider-attested issue<->closer \
+     edges for the distillation substrate, plus papertrail_items closed_at / resolution / \
+     merge_commit_sha (merged-only) / state_normalized (backfilled) / author facets and \
+     papertrail_comments author facets. Additive; CREATE IF NOT EXISTS + add_column_if_missing + \
+     an idempotent state_normalized backfill";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -1146,6 +1156,12 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         checksum: MIGRATION_072_CHECKSUM,
         description: MIGRATION_072_DESCRIPTION,
         apply: MigrationFn::Plain(apply_content_streams_pending_refold),
+    },
+    Migration {
+        id: MIGRATION_073_ID,
+        checksum: MIGRATION_073_CHECKSUM,
+        description: MIGRATION_073_DESCRIPTION,
+        apply: MigrationFn::Plain(apply_papertrail_distill_substrate),
     },
 ];
 

--- a/crates/rag-rat-db/src/schema/registry.rs
+++ b/crates/rag-rat-db/src/schema/registry.rs
@@ -51,6 +51,10 @@ const DIRECT_SCOPED_ADOPTION_TABLES: &[&str] = &[
     "papertrail_sync_cursor",
     "papertrail_item_tags",
     "papertrail_fts",
+    // V073 (#702): the provider-attested closing-edge substrate — direct `repo_id` in the
+    // natural key from birth, so a LocalOnly→Portable adoption re-points its rows with the
+    // rest of the papertrail family.
+    "papertrail_closing_edges",
     // V056 (#566) derived change-coupling table: standalone, direct `repo_id`, no FK children, so
     // a LocalOnly→Portable adoption re-points its rows here (moving them together with the
     // `git_coupling_stamp` repo_meta so the derived table stays consistent + fresh), and the

--- a/crates/rag-rat-papertrail/src/api.rs
+++ b/crates/rag-rat-papertrail/src/api.rs
@@ -14,6 +14,8 @@ pub async fn sync_mirror(
 ) -> anyhow::Result<PapertrailSyncReport> {
     ensure_unique_mirror_bindings(&ctx.trackers)?;
     let refs = discover_and_store_refs(conn, root, ctx)?;
+    // One-time (versioned): rows cached before store-time mining existed get their text mined.
+    sync::backfill_mined_refs(conn, &ctx.trackers)?;
     let registry = transport::GovernorRegistry::default();
     let mut errors = Vec::new();
     let mut jobs = Vec::new();
@@ -32,6 +34,7 @@ pub async fn sync_mirror(
         if let Some(job) = prepare_binding_job(
             conn,
             binding,
+            &ctx.trackers,
             &registry,
             &ctx.transport_options,
             full,
@@ -41,6 +44,9 @@ pub async fn sync_mirror(
         }
     }
     let outcomes = run_binding_jobs(conn, jobs).await?;
+    // Targets were just cached by the mirror walk: re-derive the commit-tier text closers so a
+    // FIRST sync's `Fixes #5` gets its edge once #5's kind is verifiable (idempotent replace set).
+    sync::rederive_commit_closers(conn, root, ctx)?;
     assemble_mirror_report(conn, ctx, refs.len(), outcomes, errors)
 }
 
@@ -55,6 +61,9 @@ pub async fn sync_mirror_scheduled(
     ctx: &PapertrailContext,
     request: AutosyncRequest,
 ) -> anyhow::Result<PapertrailSyncReport> {
+    // Versioned mined-evidence backfill: EVERY sync entry converges pre-mining caches — the
+    // scheduled lane and the single-issue lane must not strand rows the manual lanes would heal.
+    sync::backfill_mined_refs(conn, &ctx.trackers)?;
     ensure_unique_mirror_bindings(&ctx.trackers)?;
     let repo_id = schema::active_repo_id(conn)?;
     let registry = transport::GovernorRegistry::default();
@@ -76,6 +85,7 @@ pub async fn sync_mirror_scheduled(
         if let Some(job) = prepare_binding_job(
             conn,
             binding,
+            &ctx.trackers,
             &registry,
             &ctx.transport_options,
             full,
@@ -118,6 +128,9 @@ fn scheduled_walk_depth(decision: ScheduleDecision, request: AutosyncRequest) ->
 /// walk depth decided. Skipped and provider-client-pending bindings never become jobs.
 struct BindingJob<'a> {
     binding: &'a ResolvedTracker,
+    /// The FULL configured tracker set — mining parses item/comment text against every
+    /// configured grammar, not just the source binding's (a GitHub body can say "Fixes JIRA-1").
+    trackers: &'a [ResolvedTracker],
     client: ProviderClient,
     full: bool,
 }
@@ -244,13 +257,14 @@ struct BindingOutcome {
 fn prepare_binding_job<'a>(
     conn: &Connection,
     binding: &'a ResolvedTracker,
+    trackers: &'a [ResolvedTracker],
     registry: &transport::GovernorRegistry,
     options: &transport::TransportOptions,
     full: bool,
     errors: &mut Vec<PapertrailSyncError>,
 ) -> anyhow::Result<Option<BindingJob<'a>>> {
     match ProviderClient::new(binding, registry, options.clone()) {
-        Ok(client) => Ok(Some(BindingJob { binding, client, full })),
+        Ok(client) => Ok(Some(BindingJob { binding, trackers, client, full })),
         Err(error) => {
             let persisted_detail = authentication_failure_detail(binding, &error);
             record_failure(
@@ -283,7 +297,7 @@ async fn run_binding_jobs(
 }
 
 async fn run_binding_job(conn: &Connection, job: BindingJob<'_>) -> anyhow::Result<BindingOutcome> {
-    match mirror_binding(conn, job.binding, &job.client, job.full).await {
+    match mirror_binding(conn, job.binding, job.trackers, &job.client, job.full).await {
         Ok(report) => {
             if let Some(operation) = completed_mirror_operation(&report, job.full) {
                 record_success(conn, job.binding, operation, now_ms())?;
@@ -431,6 +445,8 @@ pub async fn sync_from_refs_with_progress<C: PapertrailClient>(
     mut progress: impl FnMut(PapertrailSyncProgress),
 ) -> anyhow::Result<PapertrailSyncReport> {
     let refs = discover_and_store_refs(conn, root, ctx)?;
+    // One-time (versioned): rows cached before store-time mining existed get their text mined.
+    sync::backfill_mined_refs(conn, &ctx.trackers)?;
     let sync = if offline {
         SyncRefsReport::default()
     } else {
@@ -441,6 +457,7 @@ pub async fn sync_from_refs_with_progress<C: PapertrailClient>(
         sync_refs(
             conn,
             client,
+            &ctx.trackers,
             refs.iter()
                 .filter(|reference| discovered_ref_uses_legacy_github_client(ctx, reference)),
             &mut progress,
@@ -457,7 +474,12 @@ pub async fn sync_from_refs_with_progress<C: PapertrailClient>(
         synced_items: sync.synced_items,
         bindings: Vec::new(),
         errors: sync.errors,
-        status: status(conn, ctx)?,
+        status: {
+            // Referenced targets were just cached: re-derive the commit-tier closers (see the
+            // mirror entry) before assembling the status snapshot.
+            sync::rederive_commit_closers(conn, root, ctx)?;
+            status(conn, ctx)?
+        },
     })
 }
 pub async fn sync_issue<C: PapertrailClient>(
@@ -467,6 +489,9 @@ pub async fn sync_issue<C: PapertrailClient>(
     offline: bool,
     ctx: &PapertrailContext,
 ) -> anyhow::Result<PapertrailSyncReport> {
+    // Versioned mined-evidence backfill: EVERY sync entry converges pre-mining caches — the
+    // scheduled lane and the single-issue lane must not strand rows the manual lanes would heal.
+    sync::backfill_mined_refs(conn, &ctx.trackers)?;
     let parsed = parse_issue_ref(issue_ref, ctx.default_repo())
         .ok_or_else(|| anyhow::anyhow!("invalid tracker item reference `{issue_ref}`"))?;
     let project = parsed.project.clone();
@@ -480,6 +505,7 @@ pub async fn sync_issue<C: PapertrailClient>(
         sync_refs(
             conn,
             client,
+            &ctx.trackers,
             // `parse_issue_ref` is the explicit legacy GitHub command grammar. Its routing must
             // not depend on which discovery bindings happen to be configured for this repo.
             refs.iter().filter(|reference| {

--- a/crates/rag-rat-papertrail/src/github.rs
+++ b/crates/rag-rat-papertrail/src/github.rs
@@ -790,7 +790,14 @@ mod tests {
         let conn = rusqlite::Connection::open_in_memory().unwrap();
         rag_rat_db::schema::apply(&conn, &crate::test_hooks()).unwrap();
 
-        let error = block_on(mirror_binding(&conn, &binding, &client, false)).unwrap_err();
+        let error = block_on(mirror_binding(
+            &conn,
+            &binding,
+            std::slice::from_ref(&binding),
+            &client,
+            false,
+        ))
+        .unwrap_err();
         assert!(error.to_string().contains("GitHub HTTP 403"));
         let stored: i64 =
             conn.query_row("SELECT COUNT(*) FROM papertrail_items", [], |row| row.get(0)).unwrap();

--- a/crates/rag-rat-papertrail/src/gitlab.rs
+++ b/crates/rag-rat-papertrail/src/gitlab.rs
@@ -629,6 +629,33 @@ fn item_from_gitlab_value(
         created_at: value["created_at"].as_str().map(str::to_string),
         updated_at: value["updated_at"].as_str().map(str::to_string),
         merged_at: value["merged_at"].as_str().map(str::to_string),
+        // GitLab merged MRs can carry merged_at with a NULL closed_at — the merge IS the
+        // close, so the ordering axis falls back to it.
+        closed_at: value["closed_at"]
+            .as_str()
+            .or_else(|| {
+                (value["state"].as_str() == Some("merged"))
+                    .then(|| value["merged_at"].as_str())
+                    .flatten()
+            })
+            .map(str::to_string),
+        // GitLab attests no first-class resolution on its REST payloads; the column's NULL means
+        // "provider attested nothing", which is exactly the GitLab posture (issue #702).
+        resolution: None,
+        // THE VERIFIED TRAP (GitHub) applies here as policy: only a merged MR records its merge
+        // commit. GitLab marks merges with raw state = 'merged'; squash merges put the real sha
+        // in squash_commit_sha, plain merges in merge_commit_sha.
+        merge_commit_sha: if value["state"].as_str() == Some("merged") {
+            value["squash_commit_sha"]
+                .as_str()
+                .or_else(|| value["merge_commit_sha"].as_str())
+                .map(str::to_string)
+        } else {
+            None
+        },
+        // GitLab notes carry no author "type"/association facets on these payloads.
+        author_kind: None,
+        author_association: None,
         // GitLab labels are plain strings (GitHub's are objects).
         tags: value["labels"]
             .as_array()
@@ -672,6 +699,8 @@ fn comment_from_note_value(
         url: None,
         body: body.to_string(),
         author: value["author"]["username"].as_str().map(str::to_string),
+        author_kind: None,
+        author_association: None,
         created_at: value["created_at"].as_str().map(str::to_string),
         updated_at: value["updated_at"].as_str().map(str::to_string),
         review_state: review_state.map(str::to_string),

--- a/crates/rag-rat-papertrail/src/lib.rs
+++ b/crates/rag-rat-papertrail/src/lib.rs
@@ -303,6 +303,175 @@ impl ItemKind {
     }
 }
 
+/// Provider-NEUTRAL outcome of a closed item (`papertrail_items.resolution`). GitHub's
+/// `state_reason` maps in (`completed` / `not_planned` / `duplicate`); Jira's resolution field
+/// maps in richer (its `Duplicate` / `Won't Do` map to the same tokens); GitLab has no
+/// first-class resolution and stays `unknown`. `superseded` has no GitHub source today — it is
+/// reserved for providers that attest it and for the distill layer's supersession chains.
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    strum::EnumString,
+    strum::IntoStaticStr,
+)]
+#[strum(serialize_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
+pub enum ItemResolution {
+    Completed,
+    NotPlanned,
+    Duplicate,
+    Superseded,
+    Unknown,
+}
+
+impl ItemResolution {
+    /// The exact persisted token (`papertrail_items.resolution`).
+    pub fn as_db_str(self) -> &'static str {
+        self.into()
+    }
+
+    /// Parse a persisted token, rejecting anything outside the closed set.
+    pub fn from_db_str(value: &str) -> anyhow::Result<Self> {
+        value.parse().map_err(|_| anyhow::anyhow!("unknown item resolution token `{value}`"))
+    }
+}
+
+/// Cross-provider lifecycle state (`papertrail_items.state_normalized`). THE TRAP this exists
+/// for: GitLab merged MRs carry raw `state = 'merged'` while GitHub merged PRs carry
+/// `state = 'closed'` + `merged_at` — a consumer filtering raw `WHERE state = 'closed'`
+/// silently drops every merged GitLab MR. Consumers filter on this column, never on raw state.
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    strum::EnumString,
+    strum::IntoStaticStr,
+)]
+#[strum(serialize_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
+pub enum NormalizedState {
+    Open,
+    Closed,
+    Merged,
+}
+
+impl NormalizedState {
+    /// Derive from the provider-truthful pair: a raw `merged` state (GitLab) or a recorded
+    /// `merged_at` (GitHub) wins over raw `closed`; anything else non-closed is open. The same
+    /// rule the V073 backfill applies to pre-existing rows.
+    pub fn derive(state: &str, merged_at: Option<&str>) -> Self {
+        if state == "merged" || merged_at.is_some() {
+            Self::Merged
+        } else if state == "closed" {
+            Self::Closed
+        } else {
+            Self::Open
+        }
+    }
+
+    /// The exact persisted token (`papertrail_items.state_normalized`).
+    pub fn as_db_str(self) -> &'static str {
+        self.into()
+    }
+
+    /// Parse a persisted token, rejecting anything outside the closed set.
+    pub fn from_db_str(value: &str) -> anyhow::Result<Self> {
+        value.parse().map_err(|_| anyhow::anyhow!("unknown normalized state token `{value}`"))
+    }
+}
+
+/// What closed an issue (`papertrail_closing_edges.closer_kind`): a change request (its key in
+/// the same project) or a direct commit (the full sha).
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    strum::EnumString,
+    strum::IntoStaticStr,
+)]
+#[strum(serialize_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
+pub enum CloserKind {
+    ChangeRequest,
+    Commit,
+}
+
+impl CloserKind {
+    /// The exact persisted token (`papertrail_closing_edges.closer_kind`).
+    pub fn as_db_str(self) -> &'static str {
+        self.into()
+    }
+
+    /// Parse a persisted token, rejecting anything outside the closed set.
+    pub fn from_db_str(value: &str) -> anyhow::Result<Self> {
+        value.parse().map_err(|_| anyhow::anyhow!("unknown closer kind token `{value}`"))
+    }
+}
+
+/// Trust tier of a closing edge (`papertrail_closing_edges.source`): `provider` rows are
+/// attested by the tracker's own closing data; `text` rows are mined from commit/item/comment
+/// text. The store upsert never downgrades `provider` back to `text`.
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    strum::EnumString,
+    strum::IntoStaticStr,
+)]
+#[strum(serialize_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
+pub enum ClosingEdgeSource {
+    Provider,
+    Text,
+}
+
+impl ClosingEdgeSource {
+    /// The exact persisted token (`papertrail_closing_edges.source`).
+    pub fn as_db_str(self) -> &'static str {
+        self.into()
+    }
+
+    /// Parse a persisted token, rejecting anything outside the closed set.
+    pub fn from_db_str(value: &str) -> anyhow::Result<Self> {
+        value.parse().map_err(|_| anyhow::anyhow!("unknown closing-edge source token `{value}`"))
+    }
+}
+
+/// One issue↔closer edge (`papertrail_closing_edges`). First-class — NOT a `papertrail_refs`
+/// row: the ref layer's identity coalesces on `source_text` and its contract is
+/// annotation-only, while a closing edge's identity is the (issue, closer) pair and its trust
+/// tier rides the `source` attribute.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClosingEdge {
+    pub project: String,
+    pub issue_kind: ItemKind,
+    pub issue_key: String,
+    pub closer_kind: CloserKind,
+    /// The closer item's key (`closer_kind = change_request`) or the full commit sha
+    /// (`closer_kind = commit`).
+    pub closer_key: String,
+    /// The closing/merge commit sha when known (a change request closer's merge commit).
+    pub closer_commit: Option<String>,
+    pub source: ClosingEdgeSource,
+}
+
 /// One tracker item (issue or change request), normalized across providers. `item_key` is a
 /// string because provider keys are not uniformly numeric (Jira: `PROJ-123`).
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -320,6 +489,24 @@ pub struct PapertrailItem {
     pub updated_at: Option<String>,
     /// Change requests only; `None` for issues and unmerged change requests.
     pub merged_at: Option<String>,
+    /// When the item closed — the temporal axis for supersession ordering (`created_at` is
+    /// NOT it).
+    #[serde(default)]
+    pub closed_at: Option<String>,
+    /// Provider-neutral outcome; `None` when the provider attests nothing (open items, GitLab).
+    #[serde(default)]
+    pub resolution: Option<ItemResolution>,
+    /// INVARIANT: `Some` ONLY for merged change requests. GitHub returns a non-null
+    /// `merge_commit_sha` for closed-UNMERGED PRs too (its ephemeral test-merge commit,
+    /// possibly on no branch); providers must gate on the merged state, never on the field's
+    /// presence.
+    #[serde(default)]
+    pub merge_commit_sha: Option<String>,
+    /// Thread-shape facets, already in the parsed payloads (`user.type`, `author_association`).
+    #[serde(default)]
+    pub author_kind: Option<String>,
+    #[serde(default)]
+    pub author_association: Option<String>,
     /// Provider facets used by the binding's client-side OR filter (GitHub labels today).
     pub tags: Vec<String>,
 }
@@ -342,6 +529,11 @@ pub struct PapertrailComment {
     pub author: Option<String>,
     pub created_at: Option<String>,
     pub updated_at: Option<String>,
+    /// Thread-shape facets (`user.type: "Bot"` etc.), already in the parsed payloads.
+    #[serde(default)]
+    pub author_kind: Option<String>,
+    #[serde(default)]
+    pub author_association: Option<String>,
     /// `Some` marks a review event (approval / changes requested / review summary).
     pub review_state: Option<String>,
     /// `Some` marks a file-anchored comment; the value is the repo-relative path.
@@ -706,5 +898,57 @@ pub(crate) fn test_hooks() -> rag_rat_db::MigrationHooks {
     rag_rat_db::MigrationHooks {
         rebuild_papertrail_fts: crate::rebuild_fts,
         ..rag_rat_db::MigrationHooks::noop()
+    }
+}
+
+#[cfg(test)]
+mod distill_substrate_tests {
+    use super::*;
+
+    #[test]
+    fn distill_substrate_db_tokens_are_stable_and_round_trip() {
+        // These tokens are SCHEMA (persisted in papertrail_items / papertrail_closing_edges);
+        // a rename or reorder must not silently repoint stored rows.
+        for (resolution, token) in [
+            (ItemResolution::Completed, "completed"),
+            (ItemResolution::NotPlanned, "not_planned"),
+            (ItemResolution::Duplicate, "duplicate"),
+            (ItemResolution::Superseded, "superseded"),
+            (ItemResolution::Unknown, "unknown"),
+        ] {
+            assert_eq!(resolution.as_db_str(), token);
+            assert_eq!(ItemResolution::from_db_str(token).unwrap(), resolution);
+        }
+        for (state, token) in [
+            (NormalizedState::Open, "open"),
+            (NormalizedState::Closed, "closed"),
+            (NormalizedState::Merged, "merged"),
+        ] {
+            assert_eq!(state.as_db_str(), token);
+            assert_eq!(NormalizedState::from_db_str(token).unwrap(), state);
+        }
+        for (kind, token) in
+            [(CloserKind::ChangeRequest, "change_request"), (CloserKind::Commit, "commit")]
+        {
+            assert_eq!(kind.as_db_str(), token);
+            assert_eq!(CloserKind::from_db_str(token).unwrap(), kind);
+        }
+        for (source, token) in
+            [(ClosingEdgeSource::Provider, "provider"), (ClosingEdgeSource::Text, "text")]
+        {
+            assert_eq!(source.as_db_str(), token);
+            assert_eq!(ClosingEdgeSource::from_db_str(token).unwrap(), source);
+        }
+        assert!(ItemResolution::from_db_str("wontfix").is_err(), "outside the closed set");
+    }
+
+    #[test]
+    fn normalized_state_derivation_covers_the_provider_shapes() {
+        // GitHub merged PR: closed + merged_at. GitLab merged MR: raw state 'merged'.
+        assert_eq!(NormalizedState::derive("closed", Some("2026-01-03")), NormalizedState::Merged);
+        assert_eq!(NormalizedState::derive("merged", None), NormalizedState::Merged);
+        assert_eq!(NormalizedState::derive("closed", None), NormalizedState::Closed);
+        assert_eq!(NormalizedState::derive("open", None), NormalizedState::Open);
+        assert_eq!(NormalizedState::derive("opened", None), NormalizedState::Open);
     }
 }

--- a/crates/rag-rat-papertrail/src/mirror.rs
+++ b/crates/rag-rat-papertrail/src/mirror.rs
@@ -126,6 +126,7 @@ pub struct MirrorBindingReport {
 pub(crate) async fn mirror_binding<C: PapertrailClient>(
     conn: &Connection,
     binding: &ResolvedTracker,
+    trackers: &[ResolvedTracker],
     client: &C,
     full: bool,
 ) -> anyhow::Result<MirrorBindingReport> {
@@ -185,7 +186,8 @@ pub(crate) async fn mirror_binding<C: PapertrailClient>(
         save_cursor(conn, binding, &cursor, false)?;
     }
 
-    let result = mirror_binding_inner(conn, binding, client, &mut cursor, &mut report).await;
+    let result =
+        mirror_binding_inner(conn, binding, trackers, client, &mut cursor, &mut report).await;
     match result {
         Ok(()) => {
             report.completed_full_walk = cursor.backfill_done
@@ -208,6 +210,7 @@ pub(crate) async fn mirror_binding<C: PapertrailClient>(
 async fn mirror_binding_inner<C: PapertrailClient>(
     conn: &Connection,
     binding: &ResolvedTracker,
+    trackers: &[ResolvedTracker],
     client: &C,
     cursor: &mut MirrorCursor,
     report: &mut MirrorBindingReport,
@@ -219,7 +222,7 @@ async fn mirror_binding_inner<C: PapertrailClient>(
         if cursor.item_delta_in_progress {
             cursor.item_delta_scan_since.get_or_insert_with(|| overlap_timestamp(high));
             save_cursor(conn, binding, cursor, false)?;
-            sync_item_delta(conn, binding, client, cursor, report).await?;
+            sync_item_delta(conn, binding, trackers, client, cursor, report).await?;
         } else {
             let probe = client
                 .freshness_probe(&binding.project, &FreshnessProbe {
@@ -239,13 +242,13 @@ async fn mirror_binding_inner<C: PapertrailClient>(
                 cursor.item_delta_scan_since = Some(overlap_timestamp(high));
                 cursor.item_delta_high_mark_at = probe.latest;
                 save_cursor(conn, binding, cursor, false)?;
-                sync_item_delta(conn, binding, client, cursor, report).await?;
+                sync_item_delta(conn, binding, trackers, client, cursor, report).await?;
             } else {
                 report.probe_not_modified = true;
                 save_cursor(conn, binding, cursor, false)?;
             }
         }
-        sync_comment_delta(conn, binding, client, cursor, report).await?;
+        sync_comment_delta(conn, binding, trackers, client, cursor, report).await?;
     }
 
     while !cursor.backfill_done {
@@ -274,6 +277,7 @@ async fn mirror_binding_inner<C: PapertrailClient>(
         store_item_page_resumably(
             conn,
             binding,
+            trackers,
             client,
             &page.items,
             PageLane::Backfill,
@@ -301,7 +305,7 @@ async fn mirror_binding_inner<C: PapertrailClient>(
         save_cursor(conn, binding, cursor, false)?;
     }
     if previous_high.is_none() || cursor.full_rewalk {
-        sync_comment_delta(conn, binding, client, cursor, report).await?;
+        sync_comment_delta(conn, binding, trackers, client, cursor, report).await?;
     }
     if cursor.full_rewalk {
         let tx = conn.unchecked_transaction()?;
@@ -317,6 +321,7 @@ async fn mirror_binding_inner<C: PapertrailClient>(
 async fn sync_item_delta<C: PapertrailClient>(
     conn: &Connection,
     binding: &ResolvedTracker,
+    trackers: &[ResolvedTracker],
     client: &C,
     cursor: &mut MirrorCursor,
     report: &mut MirrorBindingReport,
@@ -364,6 +369,7 @@ async fn sync_item_delta<C: PapertrailClient>(
         store_item_page_resumably(
             conn,
             binding,
+            trackers,
             client,
             &page.items,
             PageLane::Delta,
@@ -394,6 +400,7 @@ async fn sync_item_delta<C: PapertrailClient>(
 async fn sync_comment_delta<C: PapertrailClient>(
     conn: &Connection,
     binding: &ResolvedTracker,
+    trackers: &[ResolvedTracker],
     client: &C,
     cursor: &mut MirrorCursor,
     report: &mut MirrorBindingReport,
@@ -442,7 +449,7 @@ async fn sync_comment_delta<C: PapertrailClient>(
             } else {
                 None
             };
-            store_repo_comments(conn, binding, &page.comments, report)?;
+            store_repo_comments(conn, binding, trackers, &page.comments, report)?;
             let state = cursor.comment_stream_cursors.get_mut(*stream).expect("stream inserted");
             if let Some(first_page_high) = first_page_high {
                 // As with item deltas, a mutable continuation proves no more than the first
@@ -480,9 +487,13 @@ enum PageLane {
     Backfill,
 }
 
+// One over the lint cap: the resumable walk threads (binding, trackers, cursor, report) through
+// every stage, and bundling two of them into a one-off struct here would just rename the train.
+#[allow(clippy::too_many_arguments)]
 async fn store_item_page_resumably<C: PapertrailClient>(
     conn: &Connection,
     binding: &ResolvedTracker,
+    trackers: &[ResolvedTracker],
     client: &C,
     items: &[PapertrailItem],
     lane: PageLane,
@@ -498,7 +509,7 @@ async fn store_item_page_resumably<C: PapertrailClient>(
                 let mut item = item.clone();
                 client.enrich_item(&mut item).await?;
                 if binding.tracks(item.tags.iter().map(String::as_str)) {
-                    begin_item_thread(conn, binding, &item, lane, cursor, report)?;
+                    begin_item_thread(conn, binding, trackers, &item, lane, cursor, report)?;
                 } else {
                     report.pruned_items +=
                         usize::from(delete_item(conn, binding, item.item_kind, &item.item_key)?);
@@ -509,7 +520,7 @@ async fn store_item_page_resumably<C: PapertrailClient>(
             }
         }
         if cursor.item_thread_cursor.is_some() {
-            resume_item_thread(conn, binding, client, cursor, report).await?;
+            resume_item_thread(conn, binding, trackers, client, cursor, report).await?;
         }
     }
     for item in items {
@@ -524,8 +535,8 @@ async fn store_item_page_resumably<C: PapertrailClient>(
         let mut item = item.clone();
         client.enrich_item(&mut item).await?;
         if binding.tracks(item.tags.iter().map(String::as_str)) {
-            begin_item_thread(conn, binding, &item, lane, cursor, report)?;
-            resume_item_thread(conn, binding, client, cursor, report).await?;
+            begin_item_thread(conn, binding, trackers, &item, lane, cursor, report)?;
+            resume_item_thread(conn, binding, trackers, client, cursor, report).await?;
         } else {
             report.pruned_items +=
                 usize::from(delete_item(conn, binding, item.item_kind, &item.item_key)?);
@@ -547,6 +558,7 @@ fn processed_item(item: &PapertrailItem) -> ProcessedItem {
 fn begin_item_thread(
     conn: &Connection,
     binding: &ResolvedTracker,
+    trackers: &[ResolvedTracker],
     item: &PapertrailItem,
     lane: PageLane,
     cursor: &mut MirrorCursor,
@@ -554,6 +566,9 @@ fn begin_item_thread(
 ) -> anyhow::Result<()> {
     let tx = conn.unchecked_transaction()?;
     store_item(&tx, binding.provider, item)?;
+    // #702: the item's own text is mined in the same transaction — refs (`source_kind='item'`)
+    // and, for a change request with closing keywords, the text-tier closing edge.
+    sync::mine_item_refs(&tx, binding.provider, trackers, item)?;
     replace_tags(&tx, binding, item)?;
     if cursor.full_rewalk {
         mark_full_seen(&tx, binding, item)?;
@@ -576,6 +591,7 @@ fn begin_item_thread(
 async fn resume_item_thread<C: PapertrailClient>(
     conn: &Connection,
     binding: &ResolvedTracker,
+    trackers: &[ResolvedTracker],
     client: &C,
     cursor: &mut MirrorCursor,
     report: &mut MirrorBindingReport,
@@ -659,6 +675,7 @@ async fn resume_item_thread<C: PapertrailClient>(
         let tx = conn.unchecked_transaction()?;
         for comment in &page.comments {
             store_comment(&tx, binding.provider, comment)?;
+            sync::mine_comment_refs(&tx, binding.provider, trackers, comment)?;
         }
         save_cursor(&tx, binding, cursor, false)?;
         tx.commit()?;
@@ -975,6 +992,22 @@ fn prune_unmatched(conn: &Connection, binding: &ResolvedTracker) -> anyhow::Resu
     Ok(pruned)
 }
 
+/// Test-only surface over [`delete_item`] for the sibling module's prune-cleanup tests.
+#[cfg(test)]
+pub(crate) fn delete_item_for_tests(
+    conn: &Connection,
+    binding: &ResolvedTracker,
+    kind: ItemKind,
+    key: &str,
+) -> anyhow::Result<bool> {
+    delete_item(conn, binding, kind, key)
+}
+
+/// Escape `LIKE` wildcards in an identity segment (paired with `ESCAPE '\\'`).
+fn like_escape(segment: &str) -> String {
+    segment.replace('\\', "\\\\").replace('%', "\\%").replace('_', "\\_")
+}
+
 fn delete_item(
     conn: &Connection,
     binding: &ResolvedTracker,
@@ -994,6 +1027,31 @@ fn delete_item(
          item_kind=?4 AND item_key=?5",
         params![repo_id, binding.provider.as_db_str(), binding.project, kind.as_db_str(), key],
     )?;
+    // #702: mined evidence dies with its source. The mined identities are constructible in SQL
+    // (item: `project:kind:key`; comment: that + `:comment_id` — a prefix match), so the pruned
+    // item's own mined refs AND every pruned comment's mined refs go in one pass; a pruned
+    // change request also drops the text-tier closing edges it minted (provider-attested edges
+    // outlive their text sources by design).
+    conn.execute(
+        "DELETE FROM papertrail_refs WHERE repo_id=?1 AND source_kind='item' AND source_text = ?2 \
+         || ':' || ?3 || ':' || ?4 || ':' || ?5",
+        params![repo_id, binding.provider.as_db_str(), binding.project, kind.as_db_str(), key],
+    )?;
+    // `_`/`%` are LIKE wildcards and provider project strings can contain `_` — escape the
+    // identity so `foo_bar/repo` never matches `fooxbar/repo`'s mined comment rows.
+    let like_prefix = format!(
+        "{}:{}:{}:{}:%",
+        like_escape(binding.provider.as_db_str()),
+        like_escape(&binding.project),
+        like_escape(kind.as_db_str()),
+        like_escape(key)
+    );
+    conn.execute(
+        "DELETE FROM papertrail_refs WHERE repo_id=?1 AND source_kind='comment' AND source_text \
+         LIKE ?2 ESCAPE '\\'",
+        params![repo_id, like_prefix],
+    )?;
+
     conn.execute(
         "DELETE FROM papertrail_item_tags WHERE repo_id=?1 AND tracker=?2 AND project=?3 AND \
          item_kind=?4 AND item_key=?5",
@@ -1032,6 +1090,20 @@ fn prune_unseen_item_comments(
         conn.execute(
             "DELETE FROM papertrail_fts WHERE repo_id=?1 AND tracker=?2 AND project=?3 AND
              item_kind=?4 AND item_key=?5 AND comment_id=?6 AND doc_kind='comment'",
+            params![
+                repo_id,
+                binding.provider.as_db_str(),
+                binding.project,
+                kind.as_db_str(),
+                key,
+                comment_id,
+            ],
+        )?;
+        // #702: a pruned comment takes its mined refs with it (exact identity — the source will
+        // never be re-mined to replace the set once its row is gone).
+        conn.execute(
+            "DELETE FROM papertrail_refs WHERE repo_id=?1 AND source_kind='comment' AND \
+             source_text = ?2 || ':' || ?3 || ':' || ?4 || ':' || ?5 || ':' || ?6",
             params![
                 repo_id,
                 binding.provider.as_db_str(),
@@ -1080,6 +1152,7 @@ fn prune_missing(conn: &Connection, binding: &ResolvedTracker) -> anyhow::Result
 fn store_repo_comments(
     conn: &Connection,
     binding: &ResolvedTracker,
+    trackers: &[ResolvedTracker],
     comments: &[PapertrailComment],
     report: &mut MirrorBindingReport,
 ) -> anyhow::Result<()> {
@@ -1117,10 +1190,12 @@ fn store_repo_comments(
         let Some(kind) = kind else { continue };
         if kind == comment.item_kind.as_db_str() {
             store_comment(&tx, binding.provider, comment)?;
+            sync::mine_comment_refs(&tx, binding.provider, trackers, comment)?;
         } else {
             let mut comment = comment.clone();
             comment.item_kind = ItemKind::from_db_str(&kind)?;
             store_comment(&tx, binding.provider, &comment)?;
+            sync::mine_comment_refs(&tx, binding.provider, trackers, &comment)?;
         }
         report.stored_comments += 1;
     }
@@ -1420,6 +1495,11 @@ mod tests {
             created_at: None,
             updated_at: Some(updated_at.to_string()),
             merged_at: None,
+            closed_at: None,
+            resolution: None,
+            merge_commit_sha: None,
+            author_kind: None,
+            author_association: None,
             tags: tags.iter().map(|tag| (*tag).to_string()).collect(),
         }
     }
@@ -1437,6 +1517,8 @@ mod tests {
             url: None,
             body: "comment".to_string(),
             author: None,
+            author_kind: None,
+            author_association: None,
             created_at: Some(updated_at.to_string()),
             updated_at: Some(updated_at.to_string()),
             review_state: None,
@@ -1502,7 +1584,14 @@ mod tests {
             Ok(ItemsPage { items: Vec::new(), next: None, backfill_boundary: None }),
         ])
         .with_repo_comments(Vec::new());
-        block_on(mirror_binding(&conn, &binding, &first_walk, false)).unwrap();
+        block_on(mirror_binding(
+            &conn,
+            &binding,
+            std::slice::from_ref(&binding),
+            &first_walk,
+            false,
+        ))
+        .unwrap();
 
         let mut cursor = load_cursor(&conn, &binding).unwrap();
         cursor.item_delta_replay_required = true;
@@ -1515,7 +1604,8 @@ mod tests {
         })])
         .with_probe(FreshnessResult { latest: None, etag: None, not_modified: true })
         .with_repo_comments(Vec::new());
-        block_on(mirror_binding(&conn, &binding, &quiet, false)).unwrap();
+        block_on(mirror_binding(&conn, &binding, std::slice::from_ref(&binding), &quiet, false))
+            .unwrap();
 
         let requests = quiet.item_page_requests.borrow();
         assert_eq!(requests.len(), 1, "the owed replay must run despite the quiet probe");
@@ -1538,7 +1628,14 @@ mod tests {
             Ok(ItemsPage { items: Vec::new(), next: None, backfill_boundary: None }),
         ])
         .with_repo_comments(Vec::new());
-        block_on(mirror_binding(&conn, &binding, &first_walk, false)).unwrap();
+        block_on(mirror_binding(
+            &conn,
+            &binding,
+            std::slice::from_ref(&binding),
+            &first_walk,
+            false,
+        ))
+        .unwrap();
 
         let quiet = ScriptClient::new(vec![])
             .with_probe(FreshnessResult { latest: None, etag: None, not_modified: true })
@@ -1547,7 +1644,8 @@ mod tests {
                 next: None,
                 frontier: Some("2026-02-01T00:00:00Z".to_string()),
             })]);
-        block_on(mirror_binding(&conn, &binding, &quiet, false)).unwrap();
+        block_on(mirror_binding(&conn, &binding, std::slice::from_ref(&binding), &quiet, false))
+            .unwrap();
 
         let cursor = load_cursor(&conn, &binding).unwrap();
         assert_eq!(
@@ -1573,7 +1671,14 @@ mod tests {
             Ok(ItemsPage { items: Vec::new(), next: None, backfill_boundary: None }),
         ])
         .with_repo_comments(Vec::new());
-        block_on(mirror_binding(&conn, &binding, &first_walk, false)).unwrap();
+        block_on(mirror_binding(
+            &conn,
+            &binding,
+            std::slice::from_ref(&binding),
+            &first_walk,
+            false,
+        ))
+        .unwrap();
 
         let quiet = ScriptClient::new(vec![])
             .with_probe(FreshnessResult { latest: None, etag: None, not_modified: true })
@@ -1592,7 +1697,8 @@ mod tests {
                     frontier: Some("2026-02-01T20:00:00Z".to_string()),
                 }),
             ]);
-        block_on(mirror_binding(&conn, &binding, &quiet, false)).unwrap();
+        block_on(mirror_binding(&conn, &binding, std::slice::from_ref(&binding), &quiet, false))
+            .unwrap();
 
         let cursor = load_cursor(&conn, &binding).unwrap();
         assert_eq!(
@@ -1621,7 +1727,14 @@ mod tests {
         change_note.item_kind = ItemKind::ChangeRequest;
         let mut issue_note = comment("7", "note:10", "2026-01-04T00:00:00Z");
         issue_note.project = "g/r".to_string();
-        store_repo_comments(&conn, &binding, &[change_note, issue_note], &mut report).unwrap();
+        store_repo_comments(
+            &conn,
+            &binding,
+            std::slice::from_ref(&binding),
+            &[change_note, issue_note],
+            &mut report,
+        )
+        .unwrap();
 
         let rows: Vec<(String, String)> = {
             let mut stmt = conn
@@ -1662,7 +1775,14 @@ mod tests {
         let mut change_note = comment("1", "note:2", "2026-01-04T00:00:00Z");
         change_note.project = "g/r".to_string();
         change_note.item_kind = ItemKind::ChangeRequest;
-        store_repo_comments(&conn, &binding, &[issue_note, change_note], &mut report).unwrap();
+        store_repo_comments(
+            &conn,
+            &binding,
+            std::slice::from_ref(&binding),
+            &[issue_note, change_note],
+            &mut report,
+        )
+        .unwrap();
 
         let kinds: Vec<(String, String)> = {
             let mut stmt = conn
@@ -1697,6 +1817,7 @@ mod tests {
         store_repo_comments(
             &conn,
             &binding,
+            std::slice::from_ref(&binding),
             &[comment("7", "c1", "2026-01-04T00:00:00Z")],
             &mut report,
         )
@@ -1726,7 +1847,14 @@ mod tests {
             ]),
             Err(paused),
         ]);
-        let report = block_on(mirror_binding(&conn, &binding, &first, false)).unwrap();
+        let report = block_on(mirror_binding(
+            &conn,
+            &binding,
+            std::slice::from_ref(&binding),
+            &first,
+            false,
+        ))
+        .unwrap();
         assert_eq!(report.paused_until_ms, Some(42));
         assert_eq!(keys(&conn), vec!["2", "3"]);
 
@@ -1734,7 +1862,8 @@ mod tests {
             page(vec![item("1", "2026-01-01T00:00:00Z", "one", &[])]),
             page(Vec::new()),
         ]);
-        block_on(mirror_binding(&conn, &binding, &second, false)).unwrap();
+        block_on(mirror_binding(&conn, &binding, std::slice::from_ref(&binding), &second, false))
+            .unwrap();
         assert_eq!(keys(&conn), vec!["1", "2", "3"]);
         let distinct: i64 = conn
             .query_row("SELECT COUNT(DISTINCT item_key) FROM papertrail_items", [], |row| {
@@ -1760,13 +1889,21 @@ mod tests {
                     reason: PauseReason::PassBudget,
                 })),
             ]);
-        let report = block_on(mirror_binding(&conn, &binding, &first, false)).unwrap();
+        let report = block_on(mirror_binding(
+            &conn,
+            &binding,
+            std::slice::from_ref(&binding),
+            &first,
+            false,
+        ))
+        .unwrap();
         assert_eq!(report.paused_until_ms, Some(42));
         assert_eq!(keys(&conn), vec!["1", "2"]);
 
         let resumed = ScriptClient::new(vec![page(same_page), page(Vec::new())])
             .with_item_comments(vec![comment("1", "one-comment", "2026-01-01T01:00:00Z")]);
-        block_on(mirror_binding(&conn, &binding, &resumed, false)).unwrap();
+        block_on(mirror_binding(&conn, &binding, std::slice::from_ref(&binding), &resumed, false))
+            .unwrap();
         assert_eq!(resumed.item_comment_requests.borrow().as_slice(), ["1"]);
         assert_eq!(keys(&conn), vec!["1", "2"]);
     }
@@ -1793,7 +1930,14 @@ mod tests {
                     reason: PauseReason::PassBudget,
                 })),
             ]);
-        let report = block_on(mirror_binding(&conn, &binding, &first, false)).unwrap();
+        let report = block_on(mirror_binding(
+            &conn,
+            &binding,
+            std::slice::from_ref(&binding),
+            &first,
+            false,
+        ))
+        .unwrap();
         assert_eq!(report.paused_until_ms, Some(42));
         assert_eq!(report.stored_comments, 1);
         let cursor = load_cursor(&conn, &binding).unwrap();
@@ -1831,7 +1975,8 @@ mod tests {
                     frontier: None,
                 }),
             ]);
-        block_on(mirror_binding(&conn, &binding, &resumed, false)).unwrap();
+        block_on(mirror_binding(&conn, &binding, std::slice::from_ref(&binding), &resumed, false))
+            .unwrap();
         let requests = resumed.item_comment_page_requests.borrow();
         assert_eq!(requests[0].page_token, None);
         assert_eq!(requests[1].page_token.as_deref(), Some("thread-page-2"));
@@ -1869,7 +2014,14 @@ mod tests {
                 reason: PauseReason::QuotaReserve,
             })),
         ]);
-        let report = block_on(mirror_binding(&conn, &binding, &first, false)).unwrap();
+        let report = block_on(mirror_binding(
+            &conn,
+            &binding,
+            std::slice::from_ref(&binding),
+            &first,
+            false,
+        ))
+        .unwrap();
         assert_eq!(report.paused_until_ms, Some(42));
         assert_eq!(keys(&conn), vec!["2"]);
         assert_eq!(
@@ -1884,7 +2036,8 @@ mod tests {
             page(vec![item("1", "2026-01-02T00:00:00Z", "one", &[])]),
             page(Vec::new()),
         ]);
-        block_on(mirror_binding(&conn, &binding, &resumed, false)).unwrap();
+        block_on(mirror_binding(&conn, &binding, std::slice::from_ref(&binding), &resumed, false))
+            .unwrap();
         let request = &resumed.item_page_requests.borrow()[0];
         assert_eq!(request.page_token.as_deref(), Some("tie-page-2"));
         assert_eq!(request.provider_state.as_deref(), Some("opaque-tie-state"));
@@ -1903,7 +2056,8 @@ mod tests {
             }),
             page(Vec::new()),
         ]);
-        block_on(mirror_binding(&conn, &binding, &client, false)).unwrap();
+        block_on(mirror_binding(&conn, &binding, std::slice::from_ref(&binding), &client, false))
+            .unwrap();
 
         let requests = client.item_page_requests.borrow();
         assert_eq!(requests.len(), 2);
@@ -1925,7 +2079,8 @@ mod tests {
                 reason: PauseReason::PassBudget,
             })),
         ]);
-        block_on(mirror_binding(&conn, &binding, &first, false)).unwrap();
+        block_on(mirror_binding(&conn, &binding, std::slice::from_ref(&binding), &first, false))
+            .unwrap();
 
         let changed_page = vec![
             item("2", "2026-01-03T00:00:00Z", "new", &[]),
@@ -1936,7 +2091,8 @@ mod tests {
                 Ok(Vec::new()),
                 Ok(vec![comment("2", "new-comment", "2026-01-03T01:00:00Z")]),
             ]);
-        block_on(mirror_binding(&conn, &binding, &resumed, false)).unwrap();
+        block_on(mirror_binding(&conn, &binding, std::slice::from_ref(&binding), &resumed, false))
+            .unwrap();
 
         assert_eq!(resumed.item_comment_requests.borrow().as_slice(), ["1", "2"]);
         let title: String = conn
@@ -1965,7 +2121,14 @@ mod tests {
                     resume_at_ms: 42,
                     reason: PauseReason::PassBudget,
                 }))]);
-        let report = block_on(mirror_binding(&conn, &binding, &first, false)).unwrap();
+        let report = block_on(mirror_binding(
+            &conn,
+            &binding,
+            std::slice::from_ref(&binding),
+            &first,
+            false,
+        ))
+        .unwrap();
         assert_eq!(report.paused_until_ms, Some(42));
         assert_eq!(keys(&conn), vec!["1"]);
 
@@ -1973,7 +2136,14 @@ mod tests {
             page(vec![item("1", "2026-01-02T00:00:00Z", "changed", &["feature"])]),
             page(Vec::new()),
         ]);
-        let report = block_on(mirror_binding(&conn, &binding, &resumed, false)).unwrap();
+        let report = block_on(mirror_binding(
+            &conn,
+            &binding,
+            std::slice::from_ref(&binding),
+            &resumed,
+            false,
+        ))
+        .unwrap();
         assert_eq!(report.pruned_items, 1);
         assert!(keys(&conn).is_empty());
         assert!(resumed.item_comment_requests.borrow().is_empty());
@@ -1987,6 +2157,7 @@ mod tests {
         block_on(mirror_binding(
             &conn,
             &binding,
+            std::slice::from_ref(&binding),
             &ScriptClient::new(vec![page(Vec::new())]),
             false,
         ))
@@ -2002,7 +2173,8 @@ mod tests {
                     etag: Some("v1".to_string()),
                     not_modified: false,
                 });
-        block_on(mirror_binding(&conn, &binding, &later, false)).unwrap();
+        block_on(mirror_binding(&conn, &binding, std::slice::from_ref(&binding), &later, false))
+            .unwrap();
         assert_eq!(keys(&conn), vec!["1"]);
         assert_eq!(
             later.item_page_requests.borrow()[0].updated_since.as_deref(),
@@ -2021,7 +2193,8 @@ mod tests {
                 reason: PauseReason::PassBudget,
             })),
         ]);
-        block_on(mirror_binding(&conn, &binding, &first, false)).unwrap();
+        block_on(mirror_binding(&conn, &binding, std::slice::from_ref(&binding), &first, false))
+            .unwrap();
         let second = ScriptClient::new(vec![
             page(vec![item("2", "2026-01-04T00:00:00Z", "updated", &[])]),
             page(Vec::new()),
@@ -2032,7 +2205,8 @@ mod tests {
             etag: Some("v2".to_string()),
             not_modified: false,
         });
-        block_on(mirror_binding(&conn, &binding, &second, false)).unwrap();
+        block_on(mirror_binding(&conn, &binding, std::slice::from_ref(&binding), &second, false))
+            .unwrap();
         let title: String = conn
             .query_row("SELECT title FROM papertrail_items WHERE item_key='2'", [], |row| {
                 row.get(0)
@@ -2049,7 +2223,8 @@ mod tests {
             page(vec![item("1", "2026-01-02T00:00:00Z", "old", &[])]),
             page(Vec::new()),
         ]);
-        block_on(mirror_binding(&conn, &binding, &initial, false)).unwrap();
+        block_on(mirror_binding(&conn, &binding, std::slice::from_ref(&binding), &initial, false))
+            .unwrap();
 
         let tied = ScriptClient::new(vec![page(vec![item(
             "2",
@@ -2062,7 +2237,8 @@ mod tests {
             etag: Some("changed".to_string()),
             not_modified: false,
         });
-        block_on(mirror_binding(&conn, &binding, &tied, false)).unwrap();
+        block_on(mirror_binding(&conn, &binding, std::slice::from_ref(&binding), &tied, false))
+            .unwrap();
         assert_eq!(keys(&conn), vec!["1", "2"]);
         assert_eq!(
             load_cursor(&conn, &binding).unwrap().high_mark_at.as_deref(),
@@ -2078,7 +2254,8 @@ mod tests {
             page(vec![item("1", "2026-01-01T00:00:00Z", "one", &[])]),
             page(Vec::new()),
         ]);
-        block_on(mirror_binding(&conn, &binding, &initial, false)).unwrap();
+        block_on(mirror_binding(&conn, &binding, std::slice::from_ref(&binding), &initial, false))
+            .unwrap();
 
         let next = PageCursor {
             updated_since: Some("2025-12-31T23:59:59Z".to_string()),
@@ -2101,7 +2278,14 @@ mod tests {
             etag: Some("v2".to_string()),
             not_modified: false,
         });
-        let report = block_on(mirror_binding(&conn, &binding, &paused, false)).unwrap();
+        let report = block_on(mirror_binding(
+            &conn,
+            &binding,
+            std::slice::from_ref(&binding),
+            &paused,
+            false,
+        ))
+        .unwrap();
         assert_eq!(report.paused_until_ms, Some(42));
         let cursor = load_cursor(&conn, &binding).unwrap();
         assert!(cursor.item_delta_in_progress);
@@ -2109,7 +2293,8 @@ mod tests {
 
         let resumed =
             ScriptClient::new(vec![page(vec![item("3", "2026-01-03T00:00:00Z", "three", &[])])]);
-        block_on(mirror_binding(&conn, &binding, &resumed, false)).unwrap();
+        block_on(mirror_binding(&conn, &binding, std::slice::from_ref(&binding), &resumed, false))
+            .unwrap();
         assert_eq!(
             resumed.item_page_requests.borrow()[0].page_token.as_deref(),
             Some("delta-page-2")
@@ -2129,7 +2314,8 @@ mod tests {
             page(vec![item("1", "2026-01-01T00:00:00Z", "one", &[])]),
             page(Vec::new()),
         ]);
-        block_on(mirror_binding(&conn, &binding, &initial, false)).unwrap();
+        block_on(mirror_binding(&conn, &binding, std::slice::from_ref(&binding), &initial, false))
+            .unwrap();
 
         let next =
             PageCursor { page_token: Some("delta-page-2".to_string()), ..Default::default() };
@@ -2146,7 +2332,8 @@ mod tests {
             etag: Some("v2".to_string()),
             not_modified: false,
         });
-        block_on(mirror_binding(&conn, &binding, &delta, false)).unwrap();
+        block_on(mirror_binding(&conn, &binding, std::slice::from_ref(&binding), &delta, false))
+            .unwrap();
 
         let cursor = load_cursor(&conn, &binding).unwrap();
         assert_eq!(cursor.high_mark_at.as_deref(), Some("2026-01-02T00:00:00Z"));
@@ -2164,7 +2351,8 @@ mod tests {
             etag: Some("v2".to_string()),
             not_modified: false,
         });
-        block_on(mirror_binding(&conn, &binding, &replay, false)).unwrap();
+        block_on(mirror_binding(&conn, &binding, std::slice::from_ref(&binding), &replay, false))
+            .unwrap();
         assert_eq!(keys(&conn), vec!["1", "2", "3", "4"]);
     }
 
@@ -2176,14 +2364,16 @@ mod tests {
             page(vec![item("1", "2026-01-01T00:00:00Z", "one", &[])]),
             page(Vec::new()),
         ]);
-        block_on(mirror_binding(&conn, &binding, &initial, false)).unwrap();
+        block_on(mirror_binding(&conn, &binding, std::slice::from_ref(&binding), &initial, false))
+            .unwrap();
 
         let raced = ScriptClient::new(vec![page(Vec::new())]).with_probe(FreshnessResult {
             latest: Some("2026-01-05T00:00:00Z".to_string()),
             etag: Some("v2".to_string()),
             not_modified: false,
         });
-        block_on(mirror_binding(&conn, &binding, &raced, false)).unwrap();
+        block_on(mirror_binding(&conn, &binding, std::slice::from_ref(&binding), &raced, false))
+            .unwrap();
 
         let cursor = load_cursor(&conn, &binding).unwrap();
         assert_eq!(cursor.high_mark_at.as_deref(), Some("2026-01-01T00:00:00Z"));
@@ -2198,7 +2388,8 @@ mod tests {
             page(vec![item("1", "2026-01-01T00:00:00Z", "one", &[])]),
             page(Vec::new()),
         ]);
-        block_on(mirror_binding(&conn, &binding, &initial, false)).unwrap();
+        block_on(mirror_binding(&conn, &binding, std::slice::from_ref(&binding), &initial, false))
+            .unwrap();
 
         let tied_page = || {
             Ok(ItemsPage {
@@ -2216,7 +2407,8 @@ mod tests {
                 etag: Some("v2".to_string()),
                 not_modified: false,
             });
-        block_on(mirror_binding(&conn, &binding, &first, false)).unwrap();
+        block_on(mirror_binding(&conn, &binding, std::slice::from_ref(&binding), &first, false))
+            .unwrap();
         let cursor = load_cursor(&conn, &binding).unwrap();
         assert!(cursor.item_delta_replay_required);
         assert!(cursor.probe_etag.is_none());
@@ -2227,7 +2419,8 @@ mod tests {
                 etag: Some("v2".to_string()),
                 not_modified: false,
             });
-        block_on(mirror_binding(&conn, &binding, &replay, false)).unwrap();
+        block_on(mirror_binding(&conn, &binding, std::slice::from_ref(&binding), &replay, false))
+            .unwrap();
         let cursor = load_cursor(&conn, &binding).unwrap();
         assert!(!cursor.item_delta_replay_required);
         assert_eq!(cursor.probe_etag.as_deref(), Some("v2"));
@@ -2241,7 +2434,7 @@ mod tests {
             page(vec![item("1", "2026-01-02T00:00:00Z", "bug", &["bug"])]),
             page(Vec::new()),
         ]);
-        block_on(mirror_binding(&conn, &bug, &initial, false)).unwrap();
+        block_on(mirror_binding(&conn, &bug, std::slice::from_ref(&bug), &initial, false)).unwrap();
         assert_eq!(keys(&conn), vec!["1"]);
 
         let docs = binding(&["docs"]);
@@ -2249,7 +2442,9 @@ mod tests {
             page(vec![item("2", "2026-01-03T00:00:00Z", "docs", &["docs"])]),
             page(Vec::new()),
         ]);
-        let report = block_on(mirror_binding(&conn, &docs, &changed, false)).unwrap();
+        let report =
+            block_on(mirror_binding(&conn, &docs, std::slice::from_ref(&docs), &changed, false))
+                .unwrap();
         assert_eq!(report.pruned_items, 1);
         assert!(report.completed_full_walk);
         assert_eq!(keys(&conn), vec!["2"]);
@@ -2267,7 +2462,14 @@ mod tests {
             page(vec![item("1", "2026-01-01T00:00:00Z", "healed", &[])]),
             page(Vec::new()),
         ]);
-        let report = block_on(mirror_binding(&conn, &binding, &client, true)).unwrap();
+        let report = block_on(mirror_binding(
+            &conn,
+            &binding,
+            std::slice::from_ref(&binding),
+            &client,
+            true,
+        ))
+        .unwrap();
         let title: String = conn
             .query_row("SELECT title FROM papertrail_items WHERE item_key='1'", [], |row| {
                 row.get(0)
@@ -2293,13 +2495,27 @@ mod tests {
                 reason: PauseReason::PassBudget,
             })),
         ]);
-        let report = block_on(mirror_binding(&conn, &binding, &paused, true)).unwrap();
+        let report = block_on(mirror_binding(
+            &conn,
+            &binding,
+            std::slice::from_ref(&binding),
+            &paused,
+            true,
+        ))
+        .unwrap();
         assert_eq!(report.paused_until_ms, Some(42));
         assert!(load_cursor(&conn, &binding).unwrap().full_rewalk);
         assert_eq!(keys(&conn), vec!["1", "2"]);
 
         let resumed = ScriptClient::new(vec![page(Vec::new())]);
-        let report = block_on(mirror_binding(&conn, &binding, &resumed, false)).unwrap();
+        let report = block_on(mirror_binding(
+            &conn,
+            &binding,
+            std::slice::from_ref(&binding),
+            &resumed,
+            false,
+        ))
+        .unwrap();
         assert!(report.completed_full_walk);
         assert_eq!(report.pruned_items, 1);
         assert!(!load_cursor(&conn, &binding).unwrap().full_rewalk);
@@ -2336,7 +2552,14 @@ mod tests {
         let conn = db();
         let binding = binding(&[]);
         let client = ScriptClient::new(vec![Err(anyhow::anyhow!("provider failed"))]);
-        let error = block_on(mirror_binding(&conn, &binding, &client, false)).unwrap_err();
+        let error = block_on(mirror_binding(
+            &conn,
+            &binding,
+            std::slice::from_ref(&binding),
+            &client,
+            false,
+        ))
+        .unwrap_err();
         assert_eq!(error.to_string(), "provider failed");
         assert!(pause(&error).is_none());
 
@@ -2353,7 +2576,8 @@ mod tests {
             page(Vec::new()),
         ])
         .with_item_comments(vec![comment("1", "old", "2026-01-01T01:00:00Z")]);
-        block_on(mirror_binding(&conn, &binding, &initial, false)).unwrap();
+        block_on(mirror_binding(&conn, &binding, std::slice::from_ref(&binding), &initial, false))
+            .unwrap();
 
         let failed =
             ScriptClient::new(vec![page(vec![item("1", "2026-01-02T00:00:00Z", "updated", &[])])])
@@ -2363,7 +2587,14 @@ mod tests {
                     not_modified: false,
                 })
                 .with_item_comment_results(vec![Err(anyhow::anyhow!("comment fetch failed"))]);
-        let error = block_on(mirror_binding(&conn, &binding, &failed, false)).unwrap_err();
+        let error = block_on(mirror_binding(
+            &conn,
+            &binding,
+            std::slice::from_ref(&binding),
+            &failed,
+            false,
+        ))
+        .unwrap_err();
         assert_eq!(error.to_string(), "comment fetch failed");
         let comments: Vec<String> = conn
             .prepare("SELECT comment_id FROM papertrail_comments ORDER BY comment_id")
@@ -2383,7 +2614,8 @@ mod tests {
             page(vec![item("1", "2026-01-01T00:00:00Z", "initial", &[])]),
             page(Vec::new()),
         ]);
-        block_on(mirror_binding(&conn, &binding, &initial, false)).unwrap();
+        block_on(mirror_binding(&conn, &binding, std::slice::from_ref(&binding), &initial, false))
+            .unwrap();
 
         let unchanged = PageCursor {
             updated_since: Some("2025-12-31T23:59:59Z".to_string()),
@@ -2399,7 +2631,14 @@ mod tests {
             etag: Some("v2".to_string()),
             not_modified: false,
         });
-        let error = block_on(mirror_binding(&conn, &binding, &invalid, false)).unwrap_err();
+        let error = block_on(mirror_binding(
+            &conn,
+            &binding,
+            std::slice::from_ref(&binding),
+            &invalid,
+            false,
+        ))
+        .unwrap_err();
         assert!(error.to_string().contains("did not advance"));
         let cursor = load_cursor(&conn, &binding).unwrap();
         assert_eq!(cursor.item_delta_page_token, None);
@@ -2415,7 +2654,8 @@ mod tests {
             page(vec![item("1", "2026-01-01T00:00:00Z", "initial", &[])]),
             page(Vec::new()),
         ]);
-        block_on(mirror_binding(&conn, &binding, &initial, false)).unwrap();
+        block_on(mirror_binding(&conn, &binding, std::slice::from_ref(&binding), &initial, false))
+            .unwrap();
 
         let invalid = ScriptClient::new(Vec::new())
             .with_probe(FreshnessResult {
@@ -2432,7 +2672,14 @@ mod tests {
                 }),
                 frontier: None,
             })]);
-        let error = block_on(mirror_binding(&conn, &binding, &invalid, false)).unwrap_err();
+        let error = block_on(mirror_binding(
+            &conn,
+            &binding,
+            std::slice::from_ref(&binding),
+            &invalid,
+            false,
+        ))
+        .unwrap_err();
         assert!(error.to_string().contains("crossed"));
         assert_eq!(
             conn.query_row("SELECT COUNT(*) FROM papertrail_comments", [], |row| row
@@ -2454,7 +2701,8 @@ mod tests {
             page(Vec::new()),
         ])
         .with_item_comments(vec![comment("1", "initial", "2026-01-01T01:00:00Z")]);
-        block_on(mirror_binding(&conn, &binding, &initial, false)).unwrap();
+        block_on(mirror_binding(&conn, &binding, std::slice::from_ref(&binding), &initial, false))
+            .unwrap();
 
         let continuation = PageCursor {
             updated_since: Some("2026-01-01T00:00:00Z".to_string()),
@@ -2479,7 +2727,14 @@ mod tests {
             comment("1", "repo", "2026-01-03T00:00:00Z"),
             comment("404", "orphan", "2026-01-04T00:00:00Z"),
         ]);
-        let report = block_on(mirror_binding(&conn, &binding, &delta, false)).unwrap();
+        let report = block_on(mirror_binding(
+            &conn,
+            &binding,
+            std::slice::from_ref(&binding),
+            &delta,
+            false,
+        ))
+        .unwrap();
         assert_eq!(report.stored_items, 1);
         assert_eq!(report.stored_comments, 2);
         let comments: i64 = conn
@@ -2505,7 +2760,8 @@ mod tests {
             page(Vec::new()),
         ])
         .with_repo_comments(vec![comment("1", "seed", "2026-01-01T00:00:00Z")]);
-        block_on(mirror_binding(&conn, &binding, &initial, false)).unwrap();
+        block_on(mirror_binding(&conn, &binding, std::slice::from_ref(&binding), &initial, false))
+            .unwrap();
 
         let next = PageCursor { page_token: Some("page-2".to_string()), ..PageCursor::default() };
         let paused = ScriptClient::new(Vec::new())
@@ -2525,7 +2781,14 @@ mod tests {
                     reason: PauseReason::PassBudget,
                 })),
             ]);
-        let report = block_on(mirror_binding(&conn, &binding, &paused, false)).unwrap();
+        let report = block_on(mirror_binding(
+            &conn,
+            &binding,
+            std::slice::from_ref(&binding),
+            &paused,
+            false,
+        ))
+        .unwrap();
         assert_eq!(report.paused_until_ms, Some(42));
         let cursor = load_cursor(&conn, &binding).unwrap();
         let stream = &cursor.comment_stream_cursors["default"];
@@ -2540,7 +2803,8 @@ mod tests {
                 not_modified: true,
             })
             .with_repo_comments(vec![comment("1", "second", "2026-01-02T00:00:00Z")]);
-        block_on(mirror_binding(&conn, &binding, &resumed, false)).unwrap();
+        block_on(mirror_binding(&conn, &binding, std::slice::from_ref(&binding), &resumed, false))
+            .unwrap();
         let cursor = load_cursor(&conn, &binding).unwrap();
         assert!(cursor.comment_stream_cursors["default"].page_token.is_none());
         assert_eq!(cursor.comment_high_mark_at.as_deref(), Some("2026-01-03T00:00:00Z"));
@@ -2559,7 +2823,8 @@ mod tests {
             page(Vec::new()),
         ])
         .with_repo_comments(vec![comment("1", "seed", "2026-01-01T00:00:00Z")]);
-        block_on(mirror_binding(&conn, &binding, &initial, false)).unwrap();
+        block_on(mirror_binding(&conn, &binding, std::slice::from_ref(&binding), &initial, false))
+            .unwrap();
 
         let next =
             PageCursor { page_token: Some("comments-page-2".to_string()), ..Default::default() };
@@ -2581,7 +2846,8 @@ mod tests {
                     frontier: None,
                 }),
             ]);
-        block_on(mirror_binding(&conn, &binding, &delta, false)).unwrap();
+        block_on(mirror_binding(&conn, &binding, std::slice::from_ref(&binding), &delta, false))
+            .unwrap();
 
         let cursor = load_cursor(&conn, &binding).unwrap();
         assert_eq!(
@@ -2599,7 +2865,8 @@ mod tests {
             page(Vec::new()),
         ])
         .with_item_comments(vec![comment("1", "seed", "2026-01-01T01:00:00Z")]);
-        block_on(mirror_binding(&conn, &binding, &initial, false)).unwrap();
+        block_on(mirror_binding(&conn, &binding, std::slice::from_ref(&binding), &initial, false))
+            .unwrap();
 
         let missing =
             ScriptClient::new(vec![page(vec![item("1", "2026-01-02T00:00:00Z", "updated", &[])])])
@@ -2609,7 +2876,14 @@ mod tests {
                     not_modified: false,
                 })
                 .with_item_comment_results(vec![Err(PapertrailClientError::ItemNotFound.into())]);
-        let report = block_on(mirror_binding(&conn, &binding, &missing, false)).unwrap();
+        let report = block_on(mirror_binding(
+            &conn,
+            &binding,
+            std::slice::from_ref(&binding),
+            &missing,
+            false,
+        ))
+        .unwrap();
 
         assert_eq!(report.pruned_items, 0);
         assert_eq!(keys(&conn), vec!["1"]);
@@ -2627,7 +2901,8 @@ mod tests {
             page(Vec::new()),
         ])
         .with_repo_comments(vec![comment("1", "first", "2026-01-02T00:00:00Z")]);
-        block_on(mirror_binding(&conn, &binding, &initial, false)).unwrap();
+        block_on(mirror_binding(&conn, &binding, std::slice::from_ref(&binding), &initial, false))
+            .unwrap();
 
         let next =
             PageCursor { page_token: Some("comments-page-2".to_string()), ..Default::default() };
@@ -2641,7 +2916,8 @@ mod tests {
                 Ok(CommentsPage { comments: Vec::new(), next: Some(next), frontier: None }),
                 Ok(CommentsPage { comments: Vec::new(), next: None, frontier: None }),
             ]);
-        block_on(mirror_binding(&conn, &binding, &delta, false)).unwrap();
+        block_on(mirror_binding(&conn, &binding, std::slice::from_ref(&binding), &delta, false))
+            .unwrap();
         let requests = delta.repo_comment_requests.borrow();
         assert_eq!(requests[0].updated_since.as_deref(), Some("2026-01-01T23:59:59Z"));
         assert_eq!(requests[1].updated_since, requests[0].updated_since);
@@ -2668,7 +2944,8 @@ mod tests {
                 frontier: None,
             }),
         ]);
-        block_on(mirror_binding(&conn, &binding, &initial, false)).unwrap();
+        block_on(mirror_binding(&conn, &binding, std::slice::from_ref(&binding), &initial, false))
+            .unwrap();
 
         let cursor = load_cursor(&conn, &binding).unwrap();
         assert_eq!(
@@ -2698,7 +2975,8 @@ mod tests {
                 }),
                 Ok(CommentsPage { comments: Vec::new(), next: None, frontier: None }),
             ]);
-        block_on(mirror_binding(&conn, &binding, &next, false)).unwrap();
+        block_on(mirror_binding(&conn, &binding, std::slice::from_ref(&binding), &next, false))
+            .unwrap();
         let requests = next.repo_comment_requests.borrow();
         assert_eq!(requests[0].stream.as_deref(), Some("issue_comments"));
         assert_eq!(requests[0].updated_since.as_deref(), Some("2025-12-31T23:59:59Z"));
@@ -2715,7 +2993,8 @@ mod tests {
             page(Vec::new()),
         ])
         .with_item_comments(vec![comment("1", "thread", "2026-02-01T00:00:00Z")]);
-        block_on(mirror_binding(&conn, &binding, &client, false)).unwrap();
+        block_on(mirror_binding(&conn, &binding, std::slice::from_ref(&binding), &client, false))
+            .unwrap();
         assert_eq!(client.repo_comment_requests.borrow()[0].updated_since, None);
         assert_eq!(load_cursor(&conn, &binding).unwrap().comment_high_mark_at, None);
     }
@@ -2761,7 +3040,9 @@ mod tests {
             page(vec![item("1", "2026-01-02T00:00:00Z", "still docs", &["docs"])]),
             page(Vec::new()),
         ]);
-        let report = block_on(mirror_binding(&conn, &bugs, &client, false)).unwrap();
+        let report =
+            block_on(mirror_binding(&conn, &bugs, std::slice::from_ref(&bugs), &client, false))
+                .unwrap();
         assert!(report.pruned_items >= 1);
         assert!(keys(&conn).is_empty());
     }

--- a/crates/rag-rat-papertrail/src/parse.rs
+++ b/crates/rag-rat-papertrail/src/parse.rs
@@ -4,10 +4,17 @@ use super::*;
 
 /// Ref-bearing tokens of `text` — the shared tokenizer of the legacy GitHub-only lane
 /// ([`parse_refs`]) and the provider-keyed grammar ([`parse_tracker_refs`]). The split/trim sets
-/// deliberately exclude `#`, `!`, and `-`, which are ref syntax.
+/// deliberately exclude `#`, `!`, and `-`, which are ref syntax; a TRAILING `!`/`?` is sentence
+/// punctuation and end-trimmed only ("fixes #5!" — a LEADING `!` is a GitLab MR ref). The
+/// boundary discipline mirrors the reference parsers this grammar is checked against (Gitea's
+/// `references.go` patterns accept `(`/`[`/quotes before and `)`/`]`/quotes/`[:;,.?!]` after).
 fn ref_tokens(text: &str) -> impl Iterator<Item = &str> {
     text.split(|c: char| c.is_whitespace() || [',', ';', ')', ']', '}'].contains(&c))
-        .map(|token| token.trim_matches(|c: char| ['(', '[', '{', '.', ':'].contains(&c)))
+        .map(|token| {
+            token
+                .trim_matches(|c: char| ['(', '[', '{', '.', ':', '\'', '"'].contains(&c))
+                .trim_end_matches(['!', '?'])
+        })
         .filter(|token| !token.is_empty())
 }
 pub(crate) fn parse_refs(text: &str, default_repo: Option<&str>) -> Vec<ParsedRef> {
@@ -58,7 +65,7 @@ fn github_token_ref(
         if parts.len() >= 4 && (parts[2] == "issues" || parts[2] == "pull") {
             return Some(GithubTokenRef {
                 project: format!("{}/{}", parts[0], parts[1]),
-                number: parts[3].parse().ok()?,
+                number: ref_number(parts[3])?,
                 item_kind: (parts[2] == "pull").then_some(ItemKind::ChangeRequest),
                 shape: "url",
             });
@@ -69,16 +76,18 @@ fn github_token_ref(
         if parts.len() == 2 {
             return Some(GithubTokenRef {
                 project: repo_ref.to_string(),
-                number: number.parse().ok()?,
+                number: ref_number(number)?,
                 item_kind: None,
                 shape: "cross_repo",
             });
         }
     }
-    if let Some(number) = token.strip_prefix("GH-") {
+    // `GH-N` resolves against the binding's OWN project — a local shorthand exactly like bare
+    // `#N`, gated the same way (the two-pass source router owns it, never config order).
+    if local_number && let Some(number) = token.strip_prefix("GH-") {
         return Some(GithubTokenRef {
             project: default_project?.to_string(),
-            number: number.parse().ok()?,
+            number: ref_number(number)?,
             item_kind: None,
             shape: "gh_dash",
         });
@@ -86,7 +95,7 @@ fn github_token_ref(
     if local_number && let Some(number) = token.strip_prefix('#') {
         return Some(GithubTokenRef {
             project: default_project?.to_string(),
-            number: number.parse().ok()?,
+            number: ref_number(number)?,
             item_kind: None,
             shape: "local_number",
         });
@@ -140,6 +149,41 @@ pub fn parse_tracker_refs(text: &str, trackers: &[ResolvedTracker]) -> Vec<Track
     parse_tracker_refs_with_bindings(text, trackers).into_iter().map(|(_, parsed)| parsed).collect()
 }
 
+/// [`parse_tracker_refs`] with an explicit BARE-SHORTHAND owner: qualified and URL refs resolve
+/// against the CONFIGURED bindings in config order (exactly like the plain form), but a bare
+/// `#N` / `!N` belongs to `source` — the item/comment being mined — even when that project is
+/// not in the configured list (a fetched foreign item) and even when another code-host binding
+/// is configured first. Two passes per token, so source routing can never reroute a fully
+/// qualified cross-provider ref.
+pub(crate) fn parse_tracker_refs_with_source(
+    text: &str,
+    trackers: &[ResolvedTracker],
+    source: &ResolvedTracker,
+) -> Vec<TrackerParsedRef> {
+    let mut refs = Vec::new();
+    let mut previous = "";
+    for token in ref_tokens(text) {
+        // Pass 0: the SOURCE's local shorthand shapes (`#N`, `!N`, `GH-N`) — they can never
+        // collide with a qualified/URL shape, and they must beat cross-tracker grammars that
+        // happen to overlap (a Jira project named `GH` vs a GitHub source's `GH-5`).
+        let local = source
+            .provider
+            .is_code_host()
+            .then(|| tracker_token_ref_shaped(token, source, true, true, true))
+            .flatten();
+        // Pass 1: qualified/URL grammars only, config order (every bare arm disabled).
+        let parsed = local.or_else(|| {
+            trackers.iter().find_map(|tracker| tracker_token_ref(token, tracker, false, false))
+        });
+        if let Some(mut parsed) = parsed {
+            parsed.ref_kind = ref_kind_for(parsed.provider, previous);
+            refs.push(parsed);
+        }
+        previous = token;
+    }
+    refs
+}
+
 /// The routing-aware form of [`parse_tracker_refs`]. The binding index is the exact binding whose
 /// grammar claimed the token under the same first-match rule, so callers can distinguish cloud
 /// GitHub from Enterprise without reconstructing provenance from the normalized project.
@@ -151,14 +195,13 @@ pub(crate) fn parse_tracker_refs_with_bindings(
     let mut refs = Vec::new();
     let mut previous = "";
     for token in ref_tokens(text) {
-        let ref_kind = ref_kind(previous);
         if let Some((binding_index, mut parsed)) =
             trackers.iter().enumerate().find_map(|(index, tracker)| {
-                tracker_token_ref(token, tracker, code_host == Some(index))
+                tracker_token_ref(token, tracker, code_host == Some(index), true)
                     .map(|parsed| (index, parsed))
             })
         {
-            parsed.ref_kind = ref_kind;
+            parsed.ref_kind = ref_kind_for(parsed.provider, previous);
             refs.push((binding_index, parsed));
         }
         previous = token;
@@ -169,17 +212,55 @@ fn tracker_token_ref(
     token: &str,
     tracker: &ResolvedTracker,
     is_code_host: bool,
+    allow_bare: bool,
+) -> Option<TrackerParsedRef> {
+    tracker_token_ref_shaped(token, tracker, is_code_host, allow_bare, false)
+}
+
+/// `bare_only` restricts matching to the LOCAL SHORTHAND shapes (`#N`, `!N`, `GH-N`) — the
+/// source-probe pass of the two-pass router uses it so a source-local shorthand can win before
+/// any cross-tracker grammar (a Jira project literally named `GH` must not claim a GitHub
+/// source's `GH-5`), while qualified/URL shapes stay config-order-claimed.
+fn tracker_token_ref_shaped(
+    token: &str,
+    tracker: &ResolvedTracker,
+    is_code_host: bool,
+    allow_bare: bool,
+    bare_only: bool,
 ) -> Option<TrackerParsedRef> {
     match tracker.provider {
         Tracker::Github => {
             let base = url_base(tracker, "https://github.com");
-            let parsed = github_token_ref(token, Some(&tracker.project), base, is_code_host)?;
+            let parsed =
+                github_token_ref(token, Some(&tracker.project), base, is_code_host && allow_bare)?;
+            if bare_only && !matches!(parsed.shape, "local_number" | "gh_dash") {
+                return None;
+            }
             Some(tracker_ref(tracker, parsed.project, parsed.number.to_string(), parsed.item_kind))
         },
-        Tracker::Gitlab => gitlab_token_ref(token, tracker, is_code_host),
-        Tracker::Bitbucket => bitbucket_token_ref(token, tracker, is_code_host),
-        Tracker::Jira => jira_token_ref(token, &tracker.project)
-            .map(|key| tracker_ref(tracker, tracker.project.clone(), key, Some(ItemKind::Issue))),
+        Tracker::Gitlab => {
+            let parsed = gitlab_token_ref(token, tracker, is_code_host, allow_bare)?;
+            // GitLab's bare shapes resolve to the binding's own project with no `/` in the
+            // token; a qualified `a/b#N` or URL match is never bare.
+            if bare_only && (token.contains('/') || parsed.project != tracker.project) {
+                return None;
+            }
+            Some(parsed)
+        },
+        Tracker::Bitbucket => {
+            let parsed = bitbucket_token_ref(token, tracker, is_code_host && allow_bare)?;
+            if bare_only && (token.contains('/') || parsed.project != tracker.project) {
+                return None;
+            }
+            Some(parsed)
+        },
+        Tracker::Jira => (!bare_only)
+            .then(|| {
+                jira_token_ref(token, &tracker.project).map(|key| {
+                    tracker_ref(tracker, tracker.project.clone(), key, Some(ItemKind::Issue))
+                })
+            })
+            .flatten(),
     }
 }
 fn tracker_ref(
@@ -210,6 +291,7 @@ fn gitlab_token_ref(
     token: &str,
     tracker: &ResolvedTracker,
     is_code_host: bool,
+    allow_bare: bool,
 ) -> Option<TrackerParsedRef> {
     let base = url_base(tracker, "https://gitlab.com");
     if let Some(rest) = token.strip_prefix(base).and_then(|rest| rest.strip_prefix('/')) {
@@ -223,7 +305,7 @@ fn gitlab_token_ref(
             "merge_requests" => ItemKind::ChangeRequest,
             _ => return None,
         };
-        let number: i64 = parts[1].parse().ok()?;
+        let number: i64 = ref_number(parts[1])?;
         return Some(tracker_ref(
             tracker,
             project.to_string(),
@@ -235,13 +317,16 @@ fn gitlab_token_ref(
         let Some((path, number)) = token.split_once(separator) else {
             continue;
         };
-        let Ok(number) = number.parse::<i64>() else {
+        let Some(number) = ref_number(number) else {
             continue;
         };
         if path.is_empty() {
-            // Bare shorthand → the binding's own project. `#N` is the cross-provider bare form
-            // (code-host binding only); `!N` is GitLab-specific and always resolves here.
-            if separator == '#' && !is_code_host {
+            // Bare shorthand → the binding's own project. In the legacy single-pass form `#N`
+            // needs the designated code-host owner while `!N` (GitLab-specific syntax) resolves
+            // against the first GitLab binding; the two-pass source form disables BOTH here
+            // (`allow_bare = false`) and routes them to the SOURCE binding instead — with
+            // several GitLab bindings, `!5` must not belong to whichever is configured first.
+            if !allow_bare || (separator == '#' && !is_code_host) {
                 continue;
             }
             return Some(tracker_ref(
@@ -275,7 +360,7 @@ fn bitbucket_token_ref(
         let parts = rest.split('/').collect::<Vec<_>>();
         if let ["projects", project, "repos", repo, "pull-requests", number, ..] = parts.as_slice()
         {
-            let number: i64 = number.parse().ok()?;
+            let number: i64 = ref_number(number)?;
             return Some(tracker_ref(
                 tracker,
                 format!("{project}/{repo}"),
@@ -291,7 +376,7 @@ fn bitbucket_token_ref(
             "pull-requests" => ItemKind::ChangeRequest,
             _ => return None,
         };
-        let number: i64 = parts[3].parse().ok()?;
+        let number: i64 = ref_number(parts[3])?;
         return Some(tracker_ref(
             tracker,
             format!("{}/{}", parts[0], parts[1]),
@@ -301,7 +386,7 @@ fn bitbucket_token_ref(
     }
     if is_code_host
         && let Some(number) = token.strip_prefix('#')
-        && let Ok(number) = number.parse::<i64>()
+        && let Some(number) = ref_number(number)
     {
         return Some(tracker_ref(
             tracker,
@@ -324,18 +409,68 @@ fn jira_token_ref(token: &str, project: &str) -> Option<String> {
     (!number.is_empty() && number.bytes().all(|byte| byte.is_ascii_digit()))
         .then(|| token.to_string())
 }
-/// Whether the configured Jira project is key-shaped (`[A-Z][A-Z0-9]+`). A non-key project can
-/// never engage the bare-key grammar — its word-boundary guarantees don't hold.
+/// Whether the configured Jira project is key-shaped (`[A-Z][A-Z_0-9]+`, underscore included —
+/// matching GitLab's `jira_issue_key_regex`). A non-key project can never engage the bare-key
+/// grammar — its word-boundary guarantees don't hold.
 fn is_jira_key_project(project: &str) -> bool {
     let bytes = project.as_bytes();
     bytes.len() >= 2
         && bytes[0].is_ascii_uppercase()
-        && bytes.iter().all(|byte| byte.is_ascii_uppercase() || byte.is_ascii_digit())
+        && bytes
+            .iter()
+            .all(|byte| byte.is_ascii_uppercase() || byte.is_ascii_digit() || *byte == b'_')
 }
+/// A ref number token: all digits, no leading zero, and a sane length — `#007`-shaped tokens
+/// are version/junk fragments, not tracker keys (the reference parsers this is checked against
+/// use `[1-9][0-9]*` with a length cap for the same reason).
+pub(crate) fn ref_number(digits: &str) -> Option<i64> {
+    if digits.is_empty() || digits.len() > 10 || digits.starts_with('0') {
+        return None;
+    }
+    digits.parse().ok()
+}
+
+/// Provider-aware claim classifier: GitLab's documented closing-keyword family is wider than
+/// GitHub's (the gerunds and the Implement family close issues on default-branch merges/commits),
+/// so a ref CLAIMED by a GitLab binding classifies under GitLab's set; every other provider uses
+/// the GitHub set (the shared floor).
+pub(crate) fn ref_kind_for(provider: Tracker, previous: &str) -> String {
+    let base = ref_kind(previous);
+    if provider == Tracker::Gitlab && base == "unknown" {
+        let previous = previous.to_ascii_lowercase();
+        if [
+            "closing",
+            "fixing",
+            "resolving",
+            "implement",
+            "implements",
+            "implemented",
+            "implementing",
+        ]
+        .contains(&previous.as_str())
+        {
+            return "closing".to_string();
+        }
+    }
+    base
+}
+
 pub(crate) fn ref_kind(previous: &str) -> String {
     let previous = previous.to_ascii_lowercase();
-    if ["fixes", "fixed", "closes", "closed", "resolves", "resolved"].contains(&previous.as_str()) {
+    // The full documented GitHub closing-keyword set, singular forms included ("Fix #5").
+    // DELIBERATELY the intersection semantics: GitLab additionally honors the gerunds
+    // ("Closing"/"Fixing"/"Resolving") and the Implement family — but this shared classifier
+    // feeds COMMIT-tier closer minting for both hosts, and GitHub honors none of those, so
+    // widening here would mint false GitHub closers. Provider-specific keyword sets can ride
+    // the provider lane when it needs them.
+    if ["fix", "fixes", "fixed", "close", "closes", "closed", "resolve", "resolves", "resolved"]
+        .contains(&previous.as_str())
+    {
         "closing".to_string()
+    } else if ["reverts", "reverted"].contains(&previous.as_str()) {
+        // "Reverts owner/repo#N" — the body GitHub writes into every revert PR: a free PR↔PR
+        // revert edge for the distill layer's outcome chains (issue #702).
+        "reverts".to_string()
     } else if ["refs", "ref", "see", "related"].contains(&previous.as_str()) {
         "reference".to_string()
     } else {
@@ -377,6 +512,13 @@ pub(crate) fn item_from_issue_value(project: &str, value: &Value) -> PapertrailI
         created_at: value["created_at"].as_str().map(str::to_string),
         updated_at: value["updated_at"].as_str().map(str::to_string),
         merged_at: shadow.and_then(|shadow| shadow["merged_at"].as_str()).map(str::to_string),
+        closed_at: value["closed_at"].as_str().map(str::to_string),
+        resolution: resolution_from_state_reason(value["state_reason"].as_str()),
+        // Stamped by `enrich_item_from_pull_value` ONLY when the pulls payload attests a merge —
+        // the issues-endpoint shadow carries no trustworthy merge commit.
+        merge_commit_sha: None,
+        author_kind: value.pointer("/user/type").and_then(Value::as_str).map(str::to_string),
+        author_association: value["author_association"].as_str().map(str::to_string),
         tags: value["labels"]
             .as_array()
             .into_iter()
@@ -385,6 +527,18 @@ pub(crate) fn item_from_issue_value(project: &str, value: &Value) -> PapertrailI
             .collect(),
     }
 }
+/// GitHub `state_reason` -> the provider-neutral resolution. `reopened` (and anything else
+/// unrecognized) maps to `unknown` rather than dropping: the column distinguishes "provider
+/// attested nothing" (`NULL`) from "attested something we don't classify" (`unknown`).
+pub(crate) fn resolution_from_state_reason(state_reason: Option<&str>) -> Option<ItemResolution> {
+    Some(match state_reason? {
+        "completed" => ItemResolution::Completed,
+        "not_planned" => ItemResolution::NotPlanned,
+        "duplicate" => ItemResolution::Duplicate,
+        _ => ItemResolution::Unknown,
+    })
+}
+
 /// Fold the richer pulls-endpoint payload into a change request built from its issue shadow.
 pub(crate) fn enrich_item_from_pull_value(item: &mut PapertrailItem, value: &Value) {
     if let Some(state) = value["state"].as_str() {
@@ -392,6 +546,15 @@ pub(crate) fn enrich_item_from_pull_value(item: &mut PapertrailItem, value: &Val
     }
     if let Some(merged_at) = value["merged_at"].as_str() {
         item.merged_at = Some(merged_at.to_string());
+    }
+    if let Some(closed_at) = value["closed_at"].as_str() {
+        item.closed_at = Some(closed_at.to_string());
+    }
+    // THE VERIFIED TRAP: closed-UNMERGED PRs carry a non-null `merge_commit_sha` (GitHub's
+    // ephemeral test-merge commit, possibly on no branch). Gate on the merge attestation —
+    // `merged_at` — never on the field's presence.
+    if item.merged_at.is_some() {
+        item.merge_commit_sha = value["merge_commit_sha"].as_str().map(str::to_string);
     }
 }
 pub(crate) fn comment_from_value(
@@ -408,6 +571,8 @@ pub(crate) fn comment_from_value(
         url: value["html_url"].as_str().map(str::to_string),
         body: string_value(value, "body"),
         author: value.pointer("/user/login").and_then(Value::as_str).map(str::to_string),
+        author_kind: value.pointer("/user/type").and_then(Value::as_str).map(str::to_string),
+        author_association: value["author_association"].as_str().map(str::to_string),
         created_at: value["created_at"].as_str().map(str::to_string),
         updated_at: value["updated_at"].as_str().map(str::to_string),
         review_state: None,
@@ -670,6 +835,92 @@ mod grammar_tests {
     }
 
     #[test]
+    fn boundary_punctuation_matches_the_reference_parser_canon() {
+        // The cases Gitea's boundary classes accept: parens, brackets, quotes, and sentence
+        // punctuation around the ref, colon after the keyword ("Fixes: #5", kernel style).
+        let github = [tracker(Tracker::Github, "o/r")];
+        for text in [
+            "fixes (#5)",
+            "fixes [#5]",
+            "fixes \"#5\"",
+            "fixes '#5'",
+            "fixes #5!",
+            "fixes #5?",
+            "Fixes: #5",
+        ] {
+            let refs = parse_tracker_refs(text, &github);
+            assert_eq!(refs.len(), 1, "`{text}` parses");
+            assert_eq!(refs[0].item_key, "5", "`{text}`");
+            assert_eq!(refs[0].ref_kind, "closing", "`{text}` keeps the closing claim");
+        }
+        // A LEADING `!` stays ref syntax (GitLab MR shorthand), only trailing is trimmed.
+        let gitlab = [tracker(Tracker::Gitlab, "g/r")];
+        let refs = parse_tracker_refs("see !5!", &gitlab);
+        assert_eq!(refs.len(), 1);
+        assert_eq!(refs[0].item_kind, Some(ItemKind::ChangeRequest));
+    }
+
+    #[test]
+    fn junk_shaped_numbers_do_not_parse() {
+        let github = [tracker(Tracker::Github, "o/r")];
+        for text in ["fixes #007", "fixes #0", "see #12345678901"] {
+            assert!(parse_tracker_refs(text, &github).is_empty(), "`{text}` is junk-shaped");
+        }
+    }
+
+    #[test]
+    fn jira_project_keys_may_carry_underscores() {
+        let jira = [tracker(Tracker::Jira, "MY_PROJ")];
+        let refs = parse_tracker_refs("relates to MY_PROJ-42", &jira);
+        assert_eq!(refs.len(), 1);
+        assert_eq!(refs[0].item_key, "MY_PROJ-42");
+    }
+
+    #[test]
+    fn gh_dash_shorthand_is_source_local_not_config_order() {
+        // `GH-5` is a local shorthand like bare `#N`: with two GitHub bindings, mining a source
+        // in the SECOND project must not let the first claim it (two-pass source routing).
+        let first = tracker(Tracker::Github, "o/first");
+        let second = tracker(Tracker::Github, "o/second");
+        let refs = parse_tracker_refs_with_source("fixes GH-5", &[first, second.clone()], &second);
+        assert_eq!(refs.len(), 1);
+        assert_eq!(refs[0].project, "o/second", "GH-N belongs to the source binding");
+    }
+
+    #[test]
+    fn source_local_gh_dash_beats_a_jira_gh_project() {
+        // A Jira project literally named `GH` is configured; a GitHub source's `Fixes GH-5` is
+        // the SOURCE's local shorthand and must not be claimed as Jira `GH-5`.
+        let github = tracker(Tracker::Github, "o/r");
+        let jira = tracker(Tracker::Jira, "GH");
+        let refs =
+            parse_tracker_refs_with_source("Fixes GH-5", &[jira.clone(), github.clone()], &github);
+        assert_eq!(refs.len(), 1);
+        assert_eq!(refs[0].provider, Tracker::Github);
+        assert_eq!(refs[0].project, "o/r");
+        // From a JIRA-side source (or plain discovery), the Jira grammar still claims it.
+        let refs = parse_tracker_refs("Fixes GH-5", &[jira, github]);
+        assert_eq!(refs[0].provider, Tracker::Jira);
+    }
+
+    #[test]
+    fn gitlab_claims_classify_under_gitlab_keyword_family() {
+        // GitLab's documented closing pattern honors the gerunds and the Implement family; a
+        // ref CLAIMED by a GitLab binding classifies under that wider set, while the same word
+        // before a GitHub-claimed ref stays unknown (GitHub honors only the base nine).
+        let gitlab = [tracker(Tracker::Gitlab, "g/r")];
+        for text in ["Closing #5", "Fixing #5", "Implements #5", "resolving #5"] {
+            let refs = parse_tracker_refs(text, &gitlab);
+            assert_eq!(refs[0].ref_kind, "closing", "`{text}` closes on GitLab");
+        }
+        let github = [tracker(Tracker::Github, "o/r")];
+        for text in ["Closing #5", "Implements #5"] {
+            let refs = parse_tracker_refs(text, &github);
+            assert_eq!(refs[0].ref_kind, "unknown", "`{text}` does NOT close on GitHub");
+        }
+    }
+
+    #[test]
     fn legacy_github_lane_stays_projection_equal_to_the_tracker_grammar() {
         // `parse_refs` (the github_* sync lane) and `parse_tracker_refs` under a GitHub binding
         // share `github_token_ref`; pin the projection so the lanes cannot drift apart.
@@ -838,5 +1089,89 @@ mod mapper_tests {
 
         // A payload without its parent URL cannot be attributed — dropped, not misfiled.
         assert!(repo_comment_from_value("o/r", &json!({"id": 14, "body": "b"}), false).is_none());
+    }
+    #[test]
+    fn item_from_issue_value_maps_the_outcome_and_author_facets() {
+        let value: Value = serde_json::from_str(
+            r#"{"number": 5, "html_url": "u", "state": "closed", "state_reason": "not_planned",
+                "title": "t", "body": "b", "closed_at": "2026-01-04T00:00:00Z",
+                "author_association": "OWNER",
+                "user": {"login": "bot[bot]", "type": "Bot"}, "labels": []}"#,
+        )
+        .unwrap();
+        let item = item_from_issue_value("o/r", &value);
+        assert_eq!(item.closed_at.as_deref(), Some("2026-01-04T00:00:00Z"));
+        assert_eq!(item.resolution, Some(ItemResolution::NotPlanned));
+        assert_eq!(item.author_kind.as_deref(), Some("Bot"));
+        assert_eq!(item.author_association.as_deref(), Some("OWNER"));
+        assert_eq!(item.merge_commit_sha, None, "the issues shadow never carries a merge commit");
+    }
+
+    #[test]
+    fn resolution_distinguishes_unattested_from_unclassified() {
+        assert_eq!(resolution_from_state_reason(None), None, "provider attested nothing");
+        assert_eq!(
+            resolution_from_state_reason(Some("reopened")),
+            Some(ItemResolution::Unknown),
+            "attested-but-unclassified maps to unknown, not NULL",
+        );
+        assert_eq!(
+            resolution_from_state_reason(Some("duplicate")),
+            Some(ItemResolution::Duplicate)
+        );
+    }
+
+    #[test]
+    fn enrich_from_pull_gates_merge_commit_on_merged_at_not_field_presence() {
+        // THE VERIFIED TRAP: GitHub returns a non-null merge_commit_sha for closed-UNMERGED PRs
+        // (its ephemeral test-merge commit). The enrich must gate on the merge attestation.
+        let closed_unmerged: Value = serde_json::from_str(
+            r#"{"state": "closed", "merged_at": null, "closed_at": "2026-01-04T00:00:00Z",
+                "merge_commit_sha": "ephemeral-test-merge"}"#,
+        )
+        .unwrap();
+        let mut item = item_from_issue_value(
+            "o/r",
+            &serde_json::from_str(
+                r#"{"pull_request": {}, "number": 9, "html_url": "u", "state": "open",
+                    "title": "t", "body": "b", "labels": []}"#,
+            )
+            .unwrap(),
+        );
+        enrich_item_from_pull_value(&mut item, &closed_unmerged);
+        assert_eq!(item.merge_commit_sha, None, "closed-unmerged never records the test merge");
+        assert_eq!(item.closed_at.as_deref(), Some("2026-01-04T00:00:00Z"));
+
+        let merged: Value = serde_json::from_str(
+            r#"{"state": "closed", "merged_at": "2026-01-05T00:00:00Z",
+                "merge_commit_sha": "abc123"}"#,
+        )
+        .unwrap();
+        enrich_item_from_pull_value(&mut item, &merged);
+        assert_eq!(item.merge_commit_sha.as_deref(), Some("abc123"));
+    }
+
+    #[test]
+    fn singular_closing_keywords_classify_as_closing() {
+        for word in ["fix", "close", "resolve", "Fixes", "resolved"] {
+            assert_eq!(ref_kind(word), "closing", "`{word}` is a documented closing keyword");
+        }
+        assert_eq!(ref_kind("prefix"), "unknown", "substrings of keywords do not match");
+    }
+
+    #[test]
+    fn reverts_is_a_first_class_ref_kind() {
+        let binding = ResolvedTracker {
+            provider: Tracker::Github,
+            project: "o/r".to_string(),
+            base_url: None,
+            auth: None,
+            authentication: TrackerAuthentication::AuthMissing,
+            tags: Vec::new(),
+        };
+        let refs = parse_tracker_refs("Reverts o/r#41", &[binding]);
+        assert_eq!(refs.len(), 1);
+        assert_eq!(refs[0].ref_kind, "reverts");
+        assert_eq!(refs[0].item_key, "41");
     }
 }

--- a/crates/rag-rat-papertrail/src/store.rs
+++ b/crates/rag-rat-papertrail/src/store.rs
@@ -63,13 +63,19 @@ pub fn store_item(
     conn.execute(
         "
         INSERT INTO papertrail_items(tracker, project, item_kind, item_key, url, state, title, \
-         body, author, created_at, updated_at, merged_at, synced_at_ms, repo_id)
-        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)
+         body, author, created_at, updated_at, merged_at, closed_at, resolution, \
+         merge_commit_sha, state_normalized, author_kind, author_association, synced_at_ms, \
+         repo_id)
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, \
+         ?19, ?20)
         ON CONFLICT(repo_id, tracker, project, item_kind, item_key) DO UPDATE SET
             url = excluded.url, state = excluded.state, title = excluded.title,
             body = excluded.body, author = excluded.author, created_at = excluded.created_at,
             updated_at = excluded.updated_at, merged_at = excluded.merged_at,
-            synced_at_ms = excluded.synced_at_ms
+            closed_at = excluded.closed_at, resolution = excluded.resolution,
+            merge_commit_sha = excluded.merge_commit_sha,
+            state_normalized = excluded.state_normalized, author_kind = excluded.author_kind,
+            author_association = excluded.author_association, synced_at_ms = excluded.synced_at_ms
         ",
         params![
             tracker.as_db_str(),
@@ -84,6 +90,22 @@ pub fn store_item(
             item.created_at,
             item.updated_at,
             item.merged_at,
+            item.closed_at,
+            item.resolution.map(ItemResolution::as_db_str),
+            // The merged-only invariant enforced at the COMMON writer, not just per provider: a
+            // client handing over a closed-unmerged change request with a populated sha (GitHub's
+            // ephemeral test-merge commit) must not record it as a merge outcome.
+            item.merge_commit_sha.as_deref().filter(|_| {
+                item.item_kind == ItemKind::ChangeRequest
+                    && NormalizedState::derive(&item.state, item.merged_at.as_deref())
+                        == NormalizedState::Merged
+            }),
+            // Derived here, not provider-supplied: the store owns the normalization rule so every
+            // provider's rows agree (see NormalizedState::derive for the GitLab merged-state
+            // trap).
+            NormalizedState::derive(&item.state, item.merged_at.as_deref()).as_db_str(),
+            item.author_kind,
+            item.author_association,
             now_ms(),
             repo_id,
         ],
@@ -129,11 +151,13 @@ pub fn store_comment(
     conn.execute(
         "
         INSERT INTO papertrail_comments(tracker, project, item_kind, item_key, comment_id, url, \
-         body, author, created_at, updated_at, review_state, anchor_path, synced_at_ms, repo_id)
-        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)
+         body, author, author_kind, author_association, created_at, updated_at, review_state, \
+         anchor_path, synced_at_ms, repo_id)
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)
         ON CONFLICT(repo_id, tracker, project, comment_id) DO UPDATE SET
             item_kind = excluded.item_kind, item_key = excluded.item_key, url = excluded.url,
-            body = excluded.body, author = excluded.author, created_at = excluded.created_at,
+            body = excluded.body, author = excluded.author, author_kind = excluded.author_kind,
+            author_association = excluded.author_association, created_at = excluded.created_at,
             updated_at = excluded.updated_at, review_state = excluded.review_state,
             anchor_path = excluded.anchor_path, synced_at_ms = excluded.synced_at_ms
         ",
@@ -146,6 +170,8 @@ pub fn store_comment(
             comment.url,
             comment.body,
             comment.author,
+            comment.author_kind,
+            comment.author_association,
             comment.created_at,
             comment.updated_at,
             comment.review_state,
@@ -175,6 +201,100 @@ pub fn store_comment(
         repo_id: &repo_id,
     })?;
     Ok(())
+}
+
+/// Store one issue↔closer edge. Upsert semantics encode the trust ladder:
+/// - the natural key is the (issue, closer) PAIR, so both discovery tiers converge on ONE row;
+/// - a `provider` row is NEVER downgraded back to `text` — re-mining the same edge from text after
+///   the provider attested it keeps the attested tier;
+/// - `closer_commit` only ever gains information (`COALESCE` keeps an existing sha when the
+///   re-discovering tier has none).
+pub fn store_closing_edge(
+    conn: &Connection,
+    tracker: Tracker,
+    edge: &ClosingEdge,
+) -> anyhow::Result<()> {
+    let repo_id = rag_rat_db::schema::active_repo_id(conn)?;
+    conn.execute(
+        "
+        INSERT INTO papertrail_closing_edges(tracker, project, issue_kind, issue_key, closer_kind, \
+         closer_key, closer_commit, source, synced_at_ms, repo_id)
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
+        ON CONFLICT(repo_id, tracker, project, issue_kind, issue_key, closer_kind, closer_key)
+        DO UPDATE SET
+            -- Trust ladder for the commit: fill a gap from any tier, but only the PROVIDER tier
+            -- may replace an existing sha — a text re-mine must never overwrite attested data.
+            closer_commit = CASE
+                WHEN closer_commit IS NULL THEN excluded.closer_commit
+                WHEN excluded.source = 'provider' THEN COALESCE(excluded.closer_commit, \
+         closer_commit)
+                ELSE closer_commit
+            END,
+            source = CASE WHEN source = 'provider' THEN 'provider' ELSE excluded.source END,
+            synced_at_ms = excluded.synced_at_ms
+        ",
+        params![
+            tracker.as_db_str(),
+            edge.project,
+            edge.issue_kind.as_db_str(),
+            edge.issue_key,
+            edge.closer_kind.as_db_str(),
+            edge.closer_key,
+            edge.closer_commit,
+            edge.source.as_db_str(),
+            now_ms(),
+            repo_id,
+        ],
+    )?;
+    Ok(())
+}
+
+/// The closers recorded for one issue, `provider` rows first (then by closer identity for a
+/// deterministic order). Scoped to the active repo — the natural key leads with `repo_id`, so a
+/// sibling repo's edges for the same `o/r#5` never leak into this read.
+pub fn closing_edges_for_item(
+    conn: &Connection,
+    tracker: Tracker,
+    project: &str,
+    issue_kind: ItemKind,
+    issue_key: &str,
+) -> anyhow::Result<Vec<ClosingEdge>> {
+    let repo_id = rag_rat_db::schema::active_repo_id(conn)?;
+    let mut stmt = conn.prepare(
+        "
+        SELECT issue_kind, issue_key, closer_kind, closer_key, closer_commit, source
+        FROM papertrail_closing_edges
+        WHERE repo_id = ?1 AND tracker = ?2 AND project = ?3 AND issue_kind = ?4 AND issue_key = ?5
+        ORDER BY CASE source WHEN 'provider' THEN 0 ELSE 1 END, closer_kind, closer_key
+        ",
+    )?;
+    let rows = stmt.query_map(
+        params![repo_id, tracker.as_db_str(), project, issue_kind.as_db_str(), issue_key],
+        |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, String>(3)?,
+                row.get::<_, Option<String>>(4)?,
+                row.get::<_, String>(5)?,
+            ))
+        },
+    )?;
+    let mut edges = Vec::new();
+    for row in rows {
+        let (issue_kind, issue_key, closer_kind, closer_key, closer_commit, source) = row?;
+        edges.push(ClosingEdge {
+            project: project.to_string(),
+            issue_kind: ItemKind::from_db_str(&issue_kind)?,
+            issue_key,
+            closer_kind: CloserKind::from_db_str(&closer_kind)?,
+            closer_key,
+            closer_commit,
+            source: ClosingEdgeSource::from_db_str(&source)?,
+        });
+    }
+    Ok(edges)
 }
 
 /// WHOLE-TABLE rebuild of the `papertrail_fts` mirror from the base tables — the full re-walk /
@@ -290,6 +410,11 @@ mod fts_mirror_tests {
             created_at: None,
             updated_at: None,
             merged_at: None,
+            closed_at: None,
+            resolution: None,
+            merge_commit_sha: None,
+            author_kind: None,
+            author_association: None,
             tags: Vec::new(),
         }
     }
@@ -303,6 +428,8 @@ mod fts_mirror_tests {
             url: Some(format!("http://comment/{id}")),
             body: body.into(),
             author: None,
+            author_kind: None,
+            author_association: None,
             created_at: None,
             updated_at: None,
             review_state: None,
@@ -482,5 +609,138 @@ mod fts_mirror_tests {
             rows.map(Result::unwrap).collect()
         };
         assert_eq!(own, vec!["replaced body".to_string()], "re-store replaced its own row");
+    }
+    fn edge(issue_key: &str, closer_kind: CloserKind, closer_key: &str) -> ClosingEdge {
+        ClosingEdge {
+            project: "o/r".into(),
+            issue_kind: ItemKind::Issue,
+            issue_key: issue_key.into(),
+            closer_kind,
+            closer_key: closer_key.into(),
+            closer_commit: None,
+            source: ClosingEdgeSource::Text,
+        }
+    }
+
+    #[test]
+    fn closing_edge_upsert_converges_the_pair_and_never_downgrades_provider() {
+        let conn = Connection::open_in_memory().unwrap();
+        schema::apply(&conn, &crate::test_hooks()).unwrap();
+
+        // Text tier discovers the pair first, commit unknown.
+        store_closing_edge(&conn, Tracker::Github, &edge("5", CloserKind::ChangeRequest, "9"))
+            .unwrap();
+        // The provider tier attests the SAME pair with the merge commit: one row, upgraded.
+        let mut attested = edge("5", CloserKind::ChangeRequest, "9");
+        attested.source = ClosingEdgeSource::Provider;
+        attested.closer_commit = Some("abc123".into());
+        store_closing_edge(&conn, Tracker::Github, &attested).unwrap();
+        let edges =
+            closing_edges_for_item(&conn, Tracker::Github, "o/r", ItemKind::Issue, "5").unwrap();
+        assert_eq!(edges.len(), 1, "both tiers converge on one (issue, closer) row");
+        assert_eq!(edges[0].source, ClosingEdgeSource::Provider);
+        assert_eq!(edges[0].closer_commit.as_deref(), Some("abc123"));
+
+        // Re-mining the text tier afterwards neither downgrades the tier nor erases the commit.
+        store_closing_edge(&conn, Tracker::Github, &edge("5", CloserKind::ChangeRequest, "9"))
+            .unwrap();
+        let edges =
+            closing_edges_for_item(&conn, Tracker::Github, "o/r", ItemKind::Issue, "5").unwrap();
+        assert_eq!(edges[0].source, ClosingEdgeSource::Provider, "provider tier is sticky");
+        assert_eq!(
+            edges[0].closer_commit.as_deref(),
+            Some("abc123"),
+            "COALESCE keeps the known commit when the re-discovering tier has none",
+        );
+
+        // A different closer for the same issue is a distinct edge.
+        store_closing_edge(&conn, Tracker::Github, &edge("5", CloserKind::Commit, "deadbeef"))
+            .unwrap();
+        let edges =
+            closing_edges_for_item(&conn, Tracker::Github, "o/r", ItemKind::Issue, "5").unwrap();
+        assert_eq!(edges.len(), 2);
+        assert_eq!(
+            edges[0].source,
+            ClosingEdgeSource::Provider,
+            "provider rows order first for consumers",
+        );
+    }
+
+    #[test]
+    fn closing_edge_reads_are_scoped_to_the_active_repo() {
+        let conn = Connection::open_in_memory().unwrap();
+        schema::apply(&conn, &crate::test_hooks()).unwrap();
+        store_closing_edge(&conn, Tracker::Github, &edge("5", CloserKind::Commit, "abc")).unwrap();
+        // The poison sibling: the SAME external pair recorded under another repo's scope.
+        conn.execute(
+            "INSERT INTO papertrail_closing_edges(tracker, project, issue_kind, issue_key, \
+             closer_kind, closer_key, source, synced_at_ms, repo_id) VALUES ('github', 'o/r', \
+             'issue', '5', 'commit', 'poison', 'provider', 1, 'sibling')",
+            [],
+        )
+        .unwrap();
+        let edges =
+            closing_edges_for_item(&conn, Tracker::Github, "o/r", ItemKind::Issue, "5").unwrap();
+        assert_eq!(edges.len(), 1, "the sibling repo's edge for the same o/r#5 never leaks");
+        assert_eq!(edges[0].closer_key, "abc");
+    }
+
+    #[test]
+    fn store_item_derives_state_normalized_and_persists_the_outcome_columns() {
+        let conn = Connection::open_in_memory().unwrap();
+        schema::apply(&conn, &crate::test_hooks()).unwrap();
+        let mut merged = item(ItemKind::ChangeRequest, "9", "t", "b");
+        merged.state = "closed".into();
+        merged.merged_at = Some("2026-01-03T00:00:00Z".into());
+        merged.closed_at = Some("2026-01-03T00:00:00Z".into());
+        merged.resolution = Some(ItemResolution::Completed);
+        merged.merge_commit_sha = Some("abc123".into());
+        store_item(&conn, Tracker::Github, &merged).unwrap();
+        let (normalized, resolution, sha): (String, String, String) = conn
+            .query_row(
+                "SELECT state_normalized, resolution, merge_commit_sha FROM papertrail_items \
+                 WHERE item_key = '9'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(normalized, "merged", "GitHub closed+merged_at normalizes to merged");
+        assert_eq!(resolution, "completed");
+        assert_eq!(sha, "abc123");
+
+        // GitLab's raw state='merged' normalizes identically — the trap the column exists for.
+        let mut gitlab_merged = item(ItemKind::ChangeRequest, "10", "t", "b");
+        gitlab_merged.state = "merged".into();
+        store_item(&conn, Tracker::Gitlab, &gitlab_merged).unwrap();
+        let normalized: String = conn
+            .query_row(
+                "SELECT state_normalized FROM papertrail_items WHERE item_key = '10'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(normalized, "merged");
+    }
+    #[test]
+    fn a_text_remine_never_overwrites_an_attested_closer_commit() {
+        let conn = Connection::open_in_memory().unwrap();
+        schema::apply(&conn, &crate::test_hooks()).unwrap();
+        let mut attested = edge("5", CloserKind::ChangeRequest, "9");
+        attested.source = ClosingEdgeSource::Provider;
+        attested.closer_commit = Some("attested-sha".into());
+        store_closing_edge(&conn, Tracker::Github, &attested).unwrap();
+        // The text tier re-mines the pair with a DIFFERENT (lower-trust) commit.
+        let mut text = edge("5", CloserKind::ChangeRequest, "9");
+        text.closer_commit = Some("text-sha".into());
+        store_closing_edge(&conn, Tracker::Github, &text).unwrap();
+        let edges =
+            closing_edges_for_item(&conn, Tracker::Github, "o/r", ItemKind::Issue, "5").unwrap();
+        assert_eq!(edges[0].closer_commit.as_deref(), Some("attested-sha"));
+        // A newer PROVIDER attestation may replace it.
+        attested.closer_commit = Some("attested-sha-2".into());
+        store_closing_edge(&conn, Tracker::Github, &attested).unwrap();
+        let edges =
+            closing_edges_for_item(&conn, Tracker::Github, "o/r", ItemKind::Issue, "5").unwrap();
+        assert_eq!(edges[0].closer_commit.as_deref(), Some("attested-sha-2"));
     }
 }

--- a/crates/rag-rat-papertrail/src/sync.rs
+++ b/crates/rag-rat-papertrail/src/sync.rs
@@ -22,6 +22,10 @@ pub(crate) fn discover_and_store_refs(
         }
     }
     let mut unique = BTreeSet::new();
+    // Collapse duplicates keeping the STRONGEST claim per identity: one commit body saying
+    // "Refs #5. Fixes #5" must dedupe to the CLOSING ref, or the closer is silently dropped
+    // before edge derivation (the unique index does not fold ref_kind).
+    refs.sort_by_key(|r| ref_kind_rank(&r.ref_kind));
     refs.retain(|r| {
         unique.insert((
             r.tracker.as_db_str(),
@@ -37,11 +41,16 @@ pub(crate) fn discover_and_store_refs(
     for reference in &refs {
         store_ref(conn, reference)?;
     }
+    // Commit-tier closer derivation deliberately does NOT run here: it runs once at the END of
+    // each sync entry (`rederive_commit_closers`), after targets are cached — the target-kind
+    // verification needs the mirror rows, and a single post-sync pass covers both ordering and
+    // idempotence.
     Ok(refs)
 }
 pub async fn sync_refs<'a, C: PapertrailClient>(
     conn: &Connection,
     client: &C,
+    trackers: &[ResolvedTracker],
     refs: impl Iterator<Item = &'a PapertrailRef>,
     progress: &mut impl FnMut(PapertrailSyncProgress),
 ) -> anyhow::Result<SyncRefsReport> {
@@ -68,7 +77,7 @@ pub async fn sync_refs<'a, C: PapertrailClient>(
             continue;
         }
         progress(sync_progress(reference, current, total, PapertrailSyncAction::Syncing, None));
-        match sync_one_ref(conn, client, reference).await {
+        match sync_one_ref(conn, client, trackers, reference).await {
             Ok(items) => {
                 report.synced_items += items;
                 progress(sync_progress(
@@ -111,6 +120,7 @@ pub async fn sync_refs<'a, C: PapertrailClient>(
 pub(crate) async fn sync_one_ref<C: PapertrailClient>(
     conn: &Connection,
     client: &C,
+    trackers: &[ResolvedTracker],
     reference: &PapertrailRef,
 ) -> anyhow::Result<usize> {
     // Discovered refs don't carry a kind (a bare `#N` could be either); ask as an issue and let
@@ -122,9 +132,12 @@ pub(crate) async fn sync_one_ref<C: PapertrailClient>(
     // comment/FTS row so a failed comment write cannot leave an item that suppresses retries.
     let tx = conn.unchecked_transaction()?;
     store_item(&tx, reference.tracker, &item)?;
+    // The referenced-sync lane honors the same store-time mining contract as the mirror.
+    mine_item_refs(&tx, reference.tracker, trackers, &item)?;
     let mut synced = 1;
     for comment in &comments {
         store_comment(&tx, reference.tracker, comment)?;
+        mine_comment_refs(&tx, reference.tracker, trackers, comment)?;
         synced += 1;
     }
     tx.commit()?;
@@ -232,4 +245,972 @@ pub(crate) fn discover_file_refs(
         }
     }
     Ok(())
+}
+
+/// Version stamp of the mined-evidence backfill. Bump when the mining rules change in a way
+/// that requires re-deriving from ALL cached text (identity format, keyword set, gates).
+const MINED_REFS_VERSION: &str = "1";
+const MINED_REFS_VERSION_KEY: &str = "papertrail_mined_refs_version";
+
+/// The stamp VALUE folds the tracker-config fingerprint: adding a binding (a new Jira grammar)
+/// must re-mine cached text — otherwise cross-tracker refs in old bodies stay missing forever,
+/// because probe/ref sync skips unchanged cached items.
+fn mined_refs_stamp(trackers: &[ResolvedTracker]) -> String {
+    let mut grammar: Vec<String> = trackers
+        .iter()
+        .map(|binding| {
+            format!(
+                "{}:{}:{}",
+                binding.provider.as_db_str(),
+                binding.project,
+                binding.base_url.as_deref().unwrap_or("")
+            )
+        })
+        .collect();
+    grammar.sort();
+    format!(
+        "{MINED_REFS_VERSION}:{}",
+        rag_rat_base::hash::hex_sha256(grammar.join("\u{1e}").as_bytes())
+    )
+}
+
+/// One-time (per [`MINED_REFS_VERSION`]) backfill: mine every ALREADY-CACHED item and comment
+/// body. Rows fetched before store-time mining existed would otherwise keep un-mined text
+/// forever — `sync_one_ref` skips cached items, and the mirror only re-stores changed ones.
+/// Purely local (the bodies are in the DB); replace-on-remine makes it idempotent.
+pub(crate) fn backfill_mined_refs(
+    conn: &Connection,
+    trackers: &[ResolvedTracker],
+) -> anyhow::Result<()> {
+    let repo_id = rag_rat_db::schema::active_repo_id(conn)?;
+    let key = format!("{MINED_REFS_VERSION_KEY}:{repo_id}");
+    let stamp = mined_refs_stamp(trackers);
+    if rag_rat_db::meta::read_meta(conn, &key)?.as_deref() == Some(stamp.as_str()) {
+        return Ok(());
+    }
+    let items: Vec<(Tracker, PapertrailItem)> = {
+        let mut stmt = conn.prepare(
+            "SELECT tracker, project, item_kind, item_key, url, state, title, body, merged_at, \
+             merge_commit_sha FROM papertrail_items WHERE repo_id = ?1",
+        )?;
+        let rows = stmt.query_map([&repo_id], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, String>(3)?,
+                row.get::<_, String>(4)?,
+                row.get::<_, String>(5)?,
+                row.get::<_, String>(6)?,
+                row.get::<_, String>(7)?,
+                row.get::<_, Option<String>>(8)?,
+                row.get::<_, Option<String>>(9)?,
+            ))
+        })?;
+        let mut items = Vec::new();
+        for row in rows {
+            let (tracker, project, kind, key, url, state, title, body, merged_at, sha) = row?;
+            let Ok(item_kind) = ItemKind::from_db_str(&kind) else { continue };
+            let Ok(tracker) = Tracker::from_db_str(&tracker) else { continue };
+            items.push((tracker, PapertrailItem {
+                project,
+                item_kind,
+                item_key: key,
+                url,
+                state,
+                title,
+                body,
+                author: None,
+                created_at: None,
+                updated_at: None,
+                merged_at,
+                closed_at: None,
+                resolution: None,
+                merge_commit_sha: sha,
+                author_kind: None,
+                author_association: None,
+                tags: Vec::new(),
+            }));
+        }
+        items
+    };
+    for (tracker, item) in &items {
+        mine_item_refs(conn, *tracker, trackers, item)?;
+    }
+    let comments: Vec<(Tracker, PapertrailComment)> = {
+        let mut stmt = conn.prepare(
+            "SELECT tracker, project, item_kind, item_key, comment_id, body FROM \
+             papertrail_comments WHERE repo_id = ?1",
+        )?;
+        let rows = stmt.query_map([&repo_id], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, String>(3)?,
+                row.get::<_, String>(4)?,
+                row.get::<_, String>(5)?,
+            ))
+        })?;
+        let mut comments = Vec::new();
+        for row in rows {
+            let (tracker, project, kind, key, comment_id, body) = row?;
+            let Ok(item_kind) = ItemKind::from_db_str(&kind) else { continue };
+            let Ok(tracker) = Tracker::from_db_str(&tracker) else { continue };
+            comments.push((tracker, PapertrailComment {
+                project,
+                item_kind,
+                item_key: key,
+                comment_id,
+                url: None,
+                body,
+                author: None,
+                author_kind: None,
+                author_association: None,
+                created_at: None,
+                updated_at: None,
+                review_state: None,
+                anchor_path: None,
+            }));
+        }
+        comments
+    };
+    for (tracker, comment) in &comments {
+        mine_comment_refs(conn, *tracker, trackers, comment)?;
+    }
+    rag_rat_db::meta::set_meta(conn, &key, &stamp)?;
+    Ok(())
+}
+
+/// Mine a stored item's OWN text for tracker refs (`source_kind = 'item'`) — the tracker items'
+/// bodies were never mined before #702, even though the text is already in hand (zero API cost).
+/// Bare shorthand (`#5` / `!5`) belongs to the SOURCE item's own (provider, project) — including
+/// a fetched foreign project not in the configured list — while qualified/URL refs resolve
+/// against the configured bindings in config order (two-pass: source routing can never claim a
+/// qualified cross-provider ref).
+///
+/// Deliberately ANNOTATIONS ONLY — no closing edges. Item text is MUTABLE: the current body is
+/// not the merge-time body, so a post-merge edit could mint a retroactive closer (or erase a
+/// real one) that the provider never acted on. Change-request closure evidence comes exclusively
+/// from the provider-attested lane; the only text-tier closers are COMMIT-message ones, whose
+/// sources are immutable (see `store_text_closing_edges_from_commit_refs`).
+pub(crate) fn mine_item_refs(
+    conn: &Connection,
+    provider: Tracker,
+    trackers: &[ResolvedTracker],
+    item: &PapertrailItem,
+) -> anyhow::Result<()> {
+    let repo_id = rag_rat_db::schema::active_repo_id(conn)?;
+    let identity = item_source_text(provider, item);
+    // REPLACE-on-remine: item text is editable, so a removed link must not survive as evidence.
+    // Keyed by the SOURCE identity alone (no tracker predicate — one source can reference
+    // several configured trackers).
+    conn.execute(
+        "DELETE FROM papertrail_refs WHERE repo_id = ?1 AND source_kind = 'item' AND source_text \
+         = ?2",
+        params![repo_id, identity],
+    )?;
+    let source = source_binding(provider, &item.project, trackers);
+    for text in [item.title.as_str(), item.body.as_str()] {
+        for parsed in parse_tracker_refs_with_source(text, trackers, &source) {
+            // Self-references are noise — but only a KIND-matching self (a bare `#N` inherits the
+            // source's namespace; GitLab MR !5 naming issue #5 is a real cross-kind link).
+            if parsed.provider == provider
+                && parsed.project == item.project
+                && parsed.item_key == item.item_key
+                && parsed.item_kind.is_none_or(|kind| kind == item.item_kind)
+            {
+                continue;
+            }
+            let reference = parsed.into_ref("item", None, None, identity.clone());
+            store_ref(conn, &reference)?;
+        }
+    }
+    Ok(())
+}
+
+/// Mine a stored comment's text for tracker refs (`source_kind = 'comment'`), against the
+/// FULL configured tracker set.
+pub(crate) fn mine_comment_refs(
+    conn: &Connection,
+    provider: Tracker,
+    trackers: &[ResolvedTracker],
+    comment: &PapertrailComment,
+) -> anyhow::Result<()> {
+    let repo_id = rag_rat_db::schema::active_repo_id(conn)?;
+    let identity = comment_source_text(provider, comment);
+    // REPLACE-on-remine, same contract as item bodies: comment text is editable, and one
+    // comment can reference several configured trackers (no tracker predicate).
+    conn.execute(
+        "DELETE FROM papertrail_refs WHERE repo_id = ?1 AND source_kind = 'comment' AND \
+         source_text = ?2",
+        params![repo_id, identity],
+    )?;
+    let source = source_binding(provider, &comment.project, trackers);
+    for parsed in parse_tracker_refs_with_source(&comment.body, trackers, &source) {
+        if parsed.provider == provider
+            && parsed.project == comment.project
+            && parsed.item_key == comment.item_key
+            && parsed.item_kind.is_none_or(|kind| kind == comment.item_kind)
+        {
+            continue;
+        }
+        let reference = parsed.into_ref("comment", None, None, identity.clone());
+        store_ref(conn, &reference)?;
+    }
+    Ok(())
+}
+
+/// The stable `source_text` for an item-body ref: the item's own KIND-QUALIFIED identity, not
+/// the (large, re-editable) body — the refs unique index folds `source_text`, so a body edit
+/// re-mines into the same row, and namespaced providers (GitLab issue `#5` vs MR `!5`) never
+/// coalesce two different source items onto one identity. PROVIDER-qualified too: two
+/// configured providers mirroring the same `owner/repo` string must not delete each other's
+/// mined rows on re-mine or prune.
+pub(crate) fn item_source_text(provider: Tracker, item: &PapertrailItem) -> String {
+    format!(
+        "{}:{}:{}:{}",
+        provider.as_db_str(),
+        item.project,
+        item.item_kind.as_db_str(),
+        item.item_key
+    )
+}
+
+/// The binding the SOURCE item's bare shorthand resolves against: the configured binding for
+/// its exact (provider, project) when one exists (keeping base_url for self-hosted grammars),
+/// else a synthetic binding for the fetched foreign project.
+fn source_binding(
+    provider: Tracker,
+    project: &str,
+    trackers: &[ResolvedTracker],
+) -> ResolvedTracker {
+    trackers
+        .iter()
+        .find(|binding| binding.provider == provider && binding.project == project)
+        .cloned()
+        .unwrap_or_else(|| ResolvedTracker {
+            provider,
+            project: project.to_string(),
+            base_url: None,
+            auth: None,
+            authentication: TrackerAuthentication::AuthMissing,
+            tags: Vec::new(),
+        })
+}
+
+/// The stable kind-qualified identity of a mined comment (see [`item_source_text`]).
+pub(crate) fn comment_source_text(provider: Tracker, comment: &PapertrailComment) -> String {
+    format!(
+        "{}:{}:{}:{}:{}",
+        provider.as_db_str(),
+        comment.project,
+        comment.item_kind.as_db_str(),
+        comment.item_key,
+        comment.comment_id
+    )
+}
+
+/// Re-derive the commit-tier text closers from already-stored commit refs. Runs at the END of a
+/// sync as well as during discovery: the target-kind verification needs the target CACHED, and
+/// the first sync fetches targets AFTER discovery — without the post-sync pass a first run
+/// would leave `Fixes #5` closers missing until the next discovery.
+pub(crate) fn rederive_commit_closers(
+    conn: &Connection,
+    root: &Path,
+    ctx: &PapertrailContext,
+) -> anyhow::Result<()> {
+    let branch = rag_rat_base::repo_discover::discover_repo(root)
+        .ok()
+        .and_then(|repo| repo.head_name().ok().flatten())
+        .map(|name| name.shorten().to_string())
+        .unwrap_or_default();
+    let eligible = default_branch_checkout_projects(root, &branch, &ctx.trackers);
+    let refs = {
+        let repo_id = rag_rat_db::schema::active_repo_id(conn)?;
+        let mut stmt = conn.prepare(
+            "SELECT tracker, project, item_key, item_kind, ref_kind, source_commit, source_text \
+             FROM papertrail_refs WHERE repo_id = ?1 AND source_kind = 'commit' AND ref_kind = \
+             'closing'",
+        )?;
+        let rows = stmt.query_map([&repo_id], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, Option<String>>(3)?,
+                row.get::<_, String>(4)?,
+                row.get::<_, Option<String>>(5)?,
+                row.get::<_, String>(6)?,
+            ))
+        })?;
+        let mut refs = Vec::new();
+        for row in rows {
+            let (tracker, project, item_key, item_kind, ref_kind, source_commit, source_text) =
+                row?;
+            let Ok(tracker) = Tracker::from_db_str(&tracker) else { continue };
+            let item_kind = match item_kind.as_deref() {
+                Some(kind) => Some(ItemKind::from_db_str(kind).ok()).flatten(),
+                None => None,
+            };
+            refs.push(PapertrailRef {
+                tracker,
+                project,
+                item_key,
+                item_kind,
+                ref_kind,
+                source_kind: "commit".to_string(),
+                source_path: None,
+                source_commit,
+                source_text,
+            });
+        }
+        refs
+    };
+    store_text_closing_edges_from_commit_refs(conn, &refs, &eligible)
+}
+
+/// The (provider, project) pairs for which the CURRENT checkout's HEAD is that remote's default
+/// branch — read locally from every remote's `HEAD` symref (`refs/remotes/<name>/HEAD`, set by
+/// clone / `git remote set-head`) and the remote URL's parsed project. Per-remote, NOT
+/// `origin`-hard-coded: a tracker can bind a non-origin remote, and `origin` can be a fork whose
+/// default branch differs from the tracked project's.
+fn default_branch_checkout_projects(
+    root: &Path,
+    branch: &str,
+    trackers: &[ResolvedTracker],
+) -> std::collections::BTreeSet<(Tracker, String)> {
+    let mut eligible = std::collections::BTreeSet::new();
+    if branch.is_empty() {
+        return eligible;
+    }
+    let Ok(repo) = rag_rat_base::repo_discover::discover_repo(root) else {
+        return eligible;
+    };
+    let Ok(references) = repo.references() else {
+        return eligible;
+    };
+    let Ok(prefixed) = references.prefixed("refs/remotes/") else {
+        return eligible;
+    };
+    for reference in prefixed.flatten() {
+        let full = reference.name().as_bstr().to_string();
+        let Some(rest) = full.strip_prefix("refs/remotes/") else { continue };
+        let Some(remote) = rest.strip_suffix("/HEAD") else { continue };
+        let Some(target) = reference.target().try_name().map(|name| name.as_bstr().to_string())
+        else {
+            continue;
+        };
+        let Some(default) = target.strip_prefix(&format!("refs/remotes/{remote}/")) else {
+            continue;
+        };
+        if default != branch {
+            continue;
+        }
+        let key = format!("remote.{remote}.url");
+        let Some(url) = repo.config_snapshot().string(key.as_str()).map(|url| url.to_string())
+        else {
+            continue;
+        };
+        let Some(parts) = crate::trackers::parse_git_remote_url(url.trim()) else { continue };
+        // Provider from the remote HOST, never from the path shape: GitLab's parser accepts any
+        // two-segment path, so a GitHub remote must not mark a same-named GitLab project
+        // eligible. Cloud hosts map via the shared detector; self-hosted instances match a
+        // configured binding's base_url host.
+        let provider = crate::trackers::detect_provider(&parts.host).or_else(|| {
+            trackers
+                .iter()
+                .find(|binding| {
+                    binding.base_url.as_deref().is_some_and(|base| {
+                        base.trim_start_matches("https://")
+                            .trim_start_matches("http://")
+                            .split('/')
+                            .next()
+                            .is_some_and(|host| host.eq_ignore_ascii_case(&parts.host))
+                    })
+                })
+                .map(|binding| binding.provider)
+        });
+        let Some(provider) = provider else { continue };
+        if !matches!(provider, Tracker::Github | Tracker::Gitlab) {
+            continue;
+        }
+        if let Some(project) = crate::trackers::remote_url_project(&parts, provider) {
+            eligible.insert((provider, project));
+        }
+    }
+    eligible
+}
+
+/// Text-tier commit closing edges, derived as a REPLACE SET each discovery pass: the prior
+/// text/commit rows are dropped and re-derived from the CURRENT indexed history, so a commit
+/// rebased or reloaded away takes its closer claim with it (provider-attested rows and the
+/// converged rows they upgraded are untouched — the natural key keeps them, and re-insertion
+/// under a provider row never downgrades it).
+///
+/// Providers honor commit closing keywords only on the DEFAULT branch, so edges mint only when
+/// the indexed checkout's HEAD IS the default branch (`origin/HEAD`, read locally): then every
+/// indexed commit is default-reachable. On a feature/release checkout — or when `origin/HEAD`
+/// is unset — the refs stay annotations and the provider tier attests closures.
+/// Claim strength for the in-memory duplicate collapse — closing beats reverts beats plain
+/// reference beats unknown.
+fn ref_kind_rank(kind: &str) -> u8 {
+    match kind {
+        "closing" => 0,
+        "reverts" => 1,
+        "reference" => 2,
+        _ => 3,
+    }
+}
+
+pub(crate) fn store_text_closing_edges_from_commit_refs(
+    conn: &Connection,
+    refs: &[PapertrailRef],
+    default_branch_projects: &std::collections::BTreeSet<(Tracker, String)>,
+) -> anyhow::Result<()> {
+    let repo_id = rag_rat_db::schema::active_repo_id(conn)?;
+    conn.execute(
+        "DELETE FROM papertrail_closing_edges WHERE repo_id = ?1 AND source = 'text' AND \
+         closer_kind = 'commit'",
+        params![repo_id],
+    )?;
+    for reference in refs {
+        // Per-project default-branch gate: HEAD must be THIS project's remote default branch.
+        if !default_branch_projects.contains(&(reference.tracker, reference.project.clone())) {
+            continue;
+        }
+        if reference.ref_kind != "closing" || reference.source_kind != "commit" {
+            continue;
+        }
+        // Issue targets only: an explicit change-request target is an annotation, not a closer
+        // entry in the issue↔closer table.
+        if !matches!(reference.item_kind, None | Some(ItemKind::Issue)) {
+            continue;
+        }
+        // Only providers whose COMMIT closing-keyword semantics this tier models: Jira smart
+        // commits need explicit #transition commands (and workflow permissions), so an ordinary
+        // "Fixes PROJ-123" commit mention stays an annotation.
+        if !matches!(reference.tracker, Tracker::Github | Tracker::Gitlab) {
+            continue;
+        }
+        // AFFIRMATIVE target verification: on shared-numbering providers a kind-less `#123`
+        // can be a pull request, and closing keywords do nothing for PR targets — mint only
+        // when the cached mirror confirms the target IS an issue. (Un-mirrored targets stay
+        // annotations; the provider lane attests them.)
+        let cached_kind: Option<String> = conn
+            .query_row(
+                "SELECT item_kind FROM papertrail_items WHERE repo_id = ?1 AND tracker = ?2 AND \
+                 project = ?3 AND item_key = ?4 AND item_kind = 'issue'",
+                params![
+                    repo_id,
+                    reference.tracker.as_db_str(),
+                    reference.project,
+                    reference.item_key
+                ],
+                |row| row.get(0),
+            )
+            .optional()?;
+        if cached_kind.as_deref() != Some(ItemKind::Issue.as_db_str()) {
+            continue;
+        }
+        let Some(commit) = reference.source_commit.as_deref() else {
+            continue;
+        };
+        store_closing_edge(conn, reference.tracker, &ClosingEdge {
+            project: reference.project.clone(),
+            issue_kind: reference.item_kind.unwrap_or(ItemKind::Issue),
+            issue_key: reference.item_key.clone(),
+            closer_kind: CloserKind::Commit,
+            closer_key: commit.to_string(),
+            closer_commit: Some(commit.to_string()),
+            source: ClosingEdgeSource::Text,
+        })?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod mining_tests {
+    use rusqlite::Connection;
+
+    use super::*;
+    use crate::store::closing_edges_for_item;
+    use crate::{CloserKind, ClosingEdgeSource, TrackerAuthentication};
+
+    fn binding() -> ResolvedTracker {
+        ResolvedTracker {
+            provider: Tracker::Github,
+            project: "o/r".to_string(),
+            base_url: None,
+            auth: None,
+            authentication: TrackerAuthentication::AuthMissing,
+            tags: Vec::new(),
+        }
+    }
+
+    fn conn() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        rag_rat_db::schema::apply(&conn, &crate::test_hooks()).unwrap();
+        conn
+    }
+
+    /// Commit-closer eligibility fixture: HEAD is o/r's default branch.
+    fn on_default() -> std::collections::BTreeSet<(Tracker, String)> {
+        std::collections::BTreeSet::from([(Tracker::Github, "o/r".to_string())])
+    }
+
+    /// Cache the TARGET as a mirrored issue — the strict kind check mints only for targets the
+    /// mirror confirms are issues.
+    fn cache_issue(conn: &Connection, key: &str) {
+        conn.execute(
+            "INSERT OR IGNORE INTO papertrail_items(tracker, project, item_kind, item_key, url, \
+             state, title, body, synced_at_ms, repo_id, state_normalized) VALUES ('github', \
+             'o/r', 'issue', ?1, 'u', 'open', 't', 'b', 1, (SELECT COALESCE((SELECT repo_id FROM \
+             repos LIMIT 1), '__unassigned__')), 'open')",
+            [key],
+        )
+        .unwrap();
+    }
+
+    fn change_request(key: &str, body: &str) -> PapertrailItem {
+        PapertrailItem {
+            project: "o/r".into(),
+            item_kind: ItemKind::ChangeRequest,
+            item_key: key.into(),
+            url: format!("http://item/{key}"),
+            state: "closed".into(),
+            title: "t".into(),
+            body: body.into(),
+            author: None,
+            created_at: None,
+            updated_at: None,
+            merged_at: Some("2026-01-03T00:00:00Z".into()),
+            closed_at: None,
+            resolution: None,
+            merge_commit_sha: Some("abc123".into()),
+            author_kind: None,
+            author_association: None,
+            tags: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn commit_closing_refs_mint_text_tier_commit_edges() {
+        let conn = conn();
+        let reference = PapertrailRef {
+            tracker: Tracker::Github,
+            project: "o/r".into(),
+            item_key: "5".into(),
+            item_kind: None,
+            ref_kind: "closing".into(),
+            source_kind: "commit".into(),
+            source_path: None,
+            source_commit: Some("deadbeef".into()),
+            source_text: "fixes #5".into(),
+        };
+        cache_issue(&conn, "5");
+        store_text_closing_edges_from_commit_refs(&conn, &[reference], &on_default()).unwrap();
+        let edges =
+            closing_edges_for_item(&conn, Tracker::Github, "o/r", ItemKind::Issue, "5").unwrap();
+        assert_eq!(edges.len(), 1);
+        assert_eq!(edges[0].closer_kind, CloserKind::Commit);
+        assert_eq!(edges[0].closer_key, "deadbeef");
+        assert_eq!(edges[0].source, ClosingEdgeSource::Text);
+    }
+
+    #[test]
+    fn comment_body_mining_stores_comment_refs() {
+        let conn = conn();
+        let comment = PapertrailComment {
+            project: "o/r".into(),
+            item_kind: ItemKind::Issue,
+            item_key: "5".into(),
+            comment_id: "comment:1".into(),
+            url: None,
+            body: "duplicate of #7".into(),
+            author: None,
+            author_kind: None,
+            author_association: None,
+            created_at: None,
+            updated_at: None,
+            review_state: None,
+            anchor_path: None,
+        };
+        mine_comment_refs(&conn, Tracker::Github, std::slice::from_ref(&binding()), &comment)
+            .unwrap();
+        let (key, kind): (String, String) = conn
+            .query_row("SELECT item_key, source_kind FROM papertrail_refs", [], |row| {
+                Ok((row.get(0)?, row.get(1)?))
+            })
+            .unwrap();
+        assert_eq!((key.as_str(), kind.as_str()), ("7", "comment"));
+    }
+
+    #[test]
+    fn item_identities_are_kind_qualified_so_namespaced_keys_never_coalesce() {
+        // GitLab: issue #5 and MR !5 share the numeric key under different kinds. Both bodies
+        // reference the same target; the mined rows must remain TWO rows.
+        let conn = conn();
+        let mut issue = change_request("5", "see #7");
+        issue.item_kind = ItemKind::Issue;
+        issue.merged_at = None;
+        let change = change_request("5", "see #7");
+        mine_item_refs(&conn, Tracker::Github, std::slice::from_ref(&binding()), &issue).unwrap();
+        mine_item_refs(&conn, Tracker::Github, std::slice::from_ref(&binding()), &change).unwrap();
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM papertrail_refs WHERE source_kind='item' AND item_key='7'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 2, "one mined row per SOURCE item, not one per (target, project)");
+    }
+
+    #[test]
+    fn cross_kind_self_key_reference_is_not_skipped_as_self() {
+        // A namespaced provider's MR !5 body naming issue #5 is a REAL cross-kind link even
+        // though project + key match the source item.
+        let conn = conn();
+        let mut change = change_request("5", "see #7");
+        change.body = "Fixes #5".into();
+        mine_item_refs(&conn, Tracker::Github, std::slice::from_ref(&binding()), &change).unwrap();
+        // GitHub shares numbering, so the parsed target kind is None → treated as self and
+        // skipped: the count stays zero here…
+        let refs: i64 = conn
+            .query_row("SELECT COUNT(*) FROM papertrail_refs WHERE source_kind='item'", [], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        assert_eq!(refs, 0, "a kind-less same-key ref inherits the source namespace: self");
+    }
+
+    #[test]
+    fn pruned_item_takes_its_mined_evidence_with_it() {
+        let conn = conn();
+        let item = change_request("9", "Fixes #5");
+        mine_item_refs(&conn, Tracker::Github, std::slice::from_ref(&binding()), &item).unwrap();
+        // A provider-attested edge for the same pair must OUTLIVE the pruned text source.
+        crate::store::store_closing_edge(&conn, Tracker::Github, &crate::ClosingEdge {
+            project: "o/r".into(),
+            issue_kind: ItemKind::Issue,
+            issue_key: "5".into(),
+            closer_kind: CloserKind::ChangeRequest,
+            closer_key: "9".into(),
+            closer_commit: Some("attested".into()),
+            source: ClosingEdgeSource::Provider,
+        })
+        .unwrap();
+        crate::mirror::delete_item_for_tests(&conn, &binding(), ItemKind::ChangeRequest, "9")
+            .unwrap();
+        let refs: i64 =
+            conn.query_row("SELECT COUNT(*) FROM papertrail_refs", [], |r| r.get(0)).unwrap();
+        assert_eq!(refs, 0, "the pruned item's mined refs die with it");
+        let edges =
+            closing_edges_for_item(&conn, Tracker::Github, "o/r", ItemKind::Issue, "5").unwrap();
+        assert_eq!(edges.len(), 1, "the provider-attested edge survives the prune");
+        assert_eq!(edges[0].source, ClosingEdgeSource::Provider);
+    }
+    #[test]
+    fn commit_closers_are_a_replace_set_gated_on_the_default_branch() {
+        let conn = conn();
+        let make_ref = |sha: &str| PapertrailRef {
+            tracker: Tracker::Github,
+            project: "o/r".into(),
+            item_key: "5".into(),
+            item_kind: None,
+            ref_kind: "closing".into(),
+            source_kind: "commit".into(),
+            source_path: None,
+            source_commit: Some(sha.into()),
+            source_text: "fixes #5".into(),
+        };
+        cache_issue(&conn, "5");
+        store_text_closing_edges_from_commit_refs(&conn, &[make_ref("aaa")], &on_default())
+            .unwrap();
+        assert_eq!(
+            closing_edges_for_item(&conn, Tracker::Github, "o/r", ItemKind::Issue, "5")
+                .unwrap()
+                .len(),
+            1,
+        );
+        // The commit is rebased away: the next pass rederives WITHOUT it — the stale claim dies.
+        store_text_closing_edges_from_commit_refs(&conn, &[make_ref("bbb")], &on_default())
+            .unwrap();
+        let edges =
+            closing_edges_for_item(&conn, Tracker::Github, "o/r", ItemKind::Issue, "5").unwrap();
+        assert_eq!(edges.len(), 1);
+        assert_eq!(edges[0].closer_key, "bbb", "the replace set reflects current history only");
+        // Off the default branch (or unknowable): the pass clears and mints nothing.
+        store_text_closing_edges_from_commit_refs(&conn, &[make_ref("ccc")], &Default::default())
+            .unwrap();
+        assert!(
+            closing_edges_for_item(&conn, Tracker::Github, "o/r", ItemKind::Issue, "5")
+                .unwrap()
+                .is_empty(),
+            "commit-text closers require an affirmative default-branch checkout",
+        );
+    }
+
+    #[test]
+    fn duplicate_collapse_keeps_the_closing_claim() {
+        assert!(ref_kind_rank("closing") < ref_kind_rank("reference"));
+        assert!(ref_kind_rank("reverts") < ref_kind_rank("reference"));
+        assert!(ref_kind_rank("reference") < ref_kind_rank("unknown"));
+    }
+
+    #[test]
+    fn shorthand_resolves_against_the_source_project_binding_first() {
+        // Two same-provider bindings: the SOURCE project's own binding must claim bare `#5`.
+        let mut other = binding();
+        other.project = "o/other".to_string();
+        let trackers = vec![other, binding()];
+        let item = change_request("9", "Fixes #5");
+        let conn = conn();
+        mine_item_refs(&conn, Tracker::Github, &trackers, &item).unwrap();
+        let project: String = conn
+            .query_row(
+                "SELECT project FROM papertrail_refs WHERE source_kind='item' AND item_key='5'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(project, "o/r", "the bare ref belongs to the source project, not o/other");
+    }
+    #[test]
+    fn qualified_cross_provider_refs_are_never_source_routed() {
+        // A GitLab source body naming a qualified `o/r#5`: the claim follows CONFIG order
+        // (GitHub configured first here), exactly like commit/file discovery — being the
+        // SOURCE gives GitLab the bare shorthand, never the qualified tokens.
+        let conn = conn();
+        let mut gitlab = binding();
+        gitlab.provider = Tracker::Gitlab;
+        gitlab.project = "g/lab".to_string();
+        let trackers = vec![binding(), gitlab.clone()];
+        let mut item = change_request("9", "Fixes o/r#5 and closes #3");
+        item.project = "g/lab".to_string();
+        mine_item_refs(&conn, Tracker::Gitlab, &trackers, &item).unwrap();
+        let rows: Vec<(String, String)> = conn
+            .prepare("SELECT tracker, project FROM papertrail_refs ORDER BY item_key")
+            .unwrap()
+            .query_map([], |r| Ok((r.get(0)?, r.get(1)?)))
+            .unwrap()
+            .collect::<Result<_, _>>()
+            .unwrap();
+        assert_eq!(
+            rows,
+            vec![
+                ("gitlab".to_string(), "g/lab".to_string()),
+                ("github".to_string(), "o/r".to_string()),
+            ],
+            "bare #3 is the GitLab source's; qualified o/r#5 is GitHub's",
+        );
+    }
+
+    #[test]
+    fn fetched_foreign_items_resolve_shorthand_to_their_own_project() {
+        // The source project is NOT in the configured list (a discovered foreign item): bare
+        // shorthand still belongs to it, via the synthetic source binding.
+        let conn = conn();
+        let mut item = change_request("9", "Fixes #5");
+        item.project = "other/repo".to_string();
+        mine_item_refs(&conn, Tracker::Github, std::slice::from_ref(&binding()), &item).unwrap();
+        let project: String = conn
+            .query_row("SELECT project FROM papertrail_refs WHERE item_key='5'", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(project, "other/repo");
+    }
+
+    #[test]
+    fn jira_commit_mentions_stay_annotations() {
+        // Jira smart commits need explicit #transition commands; "Fixes PROJ-123" in a commit
+        // is a link, not a closure.
+        let conn = conn();
+        let reference = PapertrailRef {
+            tracker: Tracker::Jira,
+            project: "PROJ".into(),
+            item_key: "PROJ-123".into(),
+            item_kind: Some(ItemKind::Issue),
+            ref_kind: "closing".into(),
+            source_kind: "commit".into(),
+            source_path: None,
+            source_commit: Some("deadbeef".into()),
+            source_text: "fixes PROJ-123".into(),
+        };
+        store_text_closing_edges_from_commit_refs(
+            &conn,
+            &[reference],
+            &std::collections::BTreeSet::from([(Tracker::Jira, "PROJ".to_string())]),
+        )
+        .unwrap();
+        let edges: i64 = conn
+            .query_row("SELECT COUNT(*) FROM papertrail_closing_edges", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(edges, 0);
+    }
+
+    #[test]
+    fn backfill_mines_already_cached_rows_once_per_version() {
+        let conn = conn();
+        // A cached item stored WITHOUT mining (simulating a pre-mining database).
+        crate::store::store_item(&conn, Tracker::Github, &change_request("9", "Fixes #5")).unwrap();
+        assert_eq!(
+            conn.query_row(
+                "SELECT COUNT(*) FROM papertrail_refs WHERE source_kind='item'",
+                [],
+                |r| r.get::<_, i64>(0),
+            )
+            .unwrap(),
+            0,
+            "store_item alone mines nothing — mining is the sync paths' job",
+        );
+        backfill_mined_refs(&conn, std::slice::from_ref(&binding())).unwrap();
+        assert_eq!(
+            conn.query_row(
+                "SELECT COUNT(*) FROM papertrail_refs WHERE source_kind='item'",
+                [],
+                |r| r.get::<_, i64>(0),
+            )
+            .unwrap(),
+            1,
+            "the backfill mines the cached body",
+        );
+        // Versioned: a second call is a no-op (would double-run every sync otherwise).
+        backfill_mined_refs(&conn, std::slice::from_ref(&binding())).unwrap();
+    }
+    #[test]
+    fn item_body_mining_stores_annotation_refs_and_never_closing_edges() {
+        // Item text is MUTABLE — the current body is not the merge-time body — so item mining
+        // is annotations-only: even a merged change request's "Fixes #5" mints NO closing edge
+        // (change-request closures are the provider lane's job).
+        let conn = conn();
+        let item = change_request("9", "Fixes #5 and see #6. Also mentions #9 itself.");
+        mine_item_refs(&conn, Tracker::Github, std::slice::from_ref(&binding()), &item).unwrap();
+        let refs: Vec<(String, String, String)> = conn
+            .prepare(
+                "SELECT item_key, ref_kind, source_kind FROM papertrail_refs ORDER BY item_key",
+            )
+            .unwrap()
+            .query_map([], |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)))
+            .unwrap()
+            .collect::<Result<_, _>>()
+            .unwrap();
+        assert_eq!(
+            refs,
+            vec![
+                ("5".to_string(), "closing".to_string(), "item".to_string()),
+                ("6".to_string(), "reference".to_string(), "item".to_string()),
+            ],
+            "foreign refs stored (closing kept as the ANNOTATION kind); self-reference dropped",
+        );
+        let edges: i64 = conn
+            .query_row("SELECT COUNT(*) FROM papertrail_closing_edges", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(edges, 0, "item text never mints closers — mutable text cannot attest them");
+    }
+
+    #[test]
+    fn item_body_remining_replaces_the_mined_set() {
+        let conn = conn();
+        mine_item_refs(
+            &conn,
+            Tracker::Github,
+            std::slice::from_ref(&binding()),
+            &change_request("9", "Fixes #5"),
+        )
+        .unwrap();
+        // Edited: the link is REMOVED — the mined ref must die; a reworded survivor converges.
+        mine_item_refs(
+            &conn,
+            Tracker::Github,
+            std::slice::from_ref(&binding()),
+            &change_request("9", "see #6 now"),
+        )
+        .unwrap();
+        let keys: Vec<String> = conn
+            .prepare("SELECT item_key FROM papertrail_refs WHERE source_kind='item'")
+            .unwrap()
+            .query_map([], |r| r.get(0))
+            .unwrap()
+            .collect::<Result<_, _>>()
+            .unwrap();
+        assert_eq!(keys, vec!["6".to_string()], "the edited-away link cannot survive as evidence");
+    }
+
+    #[test]
+    fn gitlab_bang_shorthand_is_source_local_in_mining() {
+        // Two GitLab bindings: a bare `!5` in the SECOND project's MR must not be claimed by
+        // the first (config-order) binding.
+        let conn = conn();
+        let mut first = binding();
+        first.provider = Tracker::Gitlab;
+        first.project = "g/first".to_string();
+        let mut second = first.clone();
+        second.project = "g/second".to_string();
+        let trackers = vec![first, second];
+        let mut item = change_request("9", "see !5");
+        item.project = "g/second".to_string();
+        mine_item_refs(&conn, Tracker::Gitlab, &trackers, &item).unwrap();
+        let project: String = conn
+            .query_row("SELECT project FROM papertrail_refs WHERE item_key='5'", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(project, "g/second", "bang shorthand belongs to the source project");
+    }
+    #[test]
+    fn kindless_commit_target_verification_pins_the_issue_kind() {
+        // Namespaced twin trap: GitLab issue #5 and MR !5 share the key. The cached-target
+        // check must find the ISSUE row even when the change-request twin exists too.
+        let conn = conn();
+        cache_issue(&conn, "5");
+        conn.execute(
+            "INSERT INTO papertrail_items(tracker, project, item_kind, item_key, url, state, \
+             title, body, synced_at_ms, repo_id, state_normalized) VALUES ('github', 'o/r', \
+             'change_request', '5', 'u', 'open', 't', 'b', 1, '__unassigned__', 'open')",
+            [],
+        )
+        .unwrap();
+        let reference = PapertrailRef {
+            tracker: Tracker::Github,
+            project: "o/r".into(),
+            item_key: "5".into(),
+            item_kind: Some(ItemKind::Issue),
+            ref_kind: "closing".into(),
+            source_kind: "commit".into(),
+            source_path: None,
+            source_commit: Some("abc".into()),
+            source_text: "fixes #5".into(),
+        };
+        store_text_closing_edges_from_commit_refs(&conn, &[reference], &on_default()).unwrap();
+        assert_eq!(
+            closing_edges_for_item(&conn, Tracker::Github, "o/r", ItemKind::Issue, "5")
+                .unwrap()
+                .len(),
+            1,
+            "the CR twin must not shadow the cached issue",
+        );
+    }
+    #[test]
+    fn rederive_never_resurrects_a_rebased_away_commits_closer() {
+        // Stored refs are the annotation layer (never pruned): a closing ref whose source
+        // commit left the indexed history must not re-mint through the post-sync rederive.
+        let conn = conn();
+        cache_issue(&conn, "5");
+        conn.execute(
+            "INSERT INTO papertrail_refs(tracker, project, item_key, item_kind, ref_kind, \
+             source_kind, source_commit, source_text, discovered_at_ms, repo_id) VALUES \
+             ('github', 'o/r', '5', 'issue', 'closing', 'commit', 'gone-sha', 'fixes #5', 0, \
+             '__unassigned__')",
+            [],
+        )
+        .unwrap();
+        // The stored-ref query requires the commit in git_commits; 'gone-sha' is absent, so the
+        // derivation set is empty and the replace pass clears without minting.
+        let refs: Vec<PapertrailRef> = Vec::new();
+        store_text_closing_edges_from_commit_refs(&conn, &refs, &on_default()).unwrap();
+        assert!(
+            closing_edges_for_item(&conn, Tracker::Github, "o/r", ItemKind::Issue, "5")
+                .unwrap()
+                .is_empty(),
+        );
+    }
 }

--- a/crates/rag-rat-papertrail/src/trackers.rs
+++ b/crates/rag-rat-papertrail/src/trackers.rs
@@ -161,7 +161,7 @@ fn remote_base_url(parts: &GitRemoteParts, provider: Tracker) -> Option<String> 
         .then(|| parts.base_url.clone().unwrap_or_else(|| format!("https://{}", parts.host)))
 }
 
-fn detect_provider(host: &str) -> Option<Tracker> {
+pub(crate) fn detect_provider(host: &str) -> Option<Tracker> {
     if host == "github.com" {
         Some(Tracker::Github)
     } else if host.contains("gitlab.") {
@@ -189,7 +189,7 @@ fn cloud_host(provider: Tracker) -> Option<&'static str> {
 /// Project path for `provider` from parsed remote parts. GitHub and Bitbucket Cloud projects are
 /// exactly `owner/repo`; Bitbucket Data Center clone URLs add a `/scm/` prefix. GitLab keeps the
 /// full (possibly subgroup-nested) namespace path.
-fn remote_url_project(parts: &GitRemoteParts, provider: Tracker) -> Option<String> {
+pub(crate) fn remote_url_project(parts: &GitRemoteParts, provider: Tracker) -> Option<String> {
     match provider {
         Tracker::Github => (parts.segments.len() == 2).then(|| parts.segments.join("/")),
         Tracker::Bitbucket => match parts.segments.as_slice() {


### PR DESCRIPTION
Stage 1 of #702 — the mirror substrate for issue distillation (#113). No LLM, and no new API
calls anywhere in this change: everything fills from payloads the mirror already parses.

**Schema (V073, additive):**
- `papertrail_closing_edges` — first-class issue↔closer edges (NOT more `papertrail_refs`
  rows). Natural key = the (issue, closer) pair with `repo_id` from birth; `source`
  (`provider` | `text`) is an attribute, so both discovery tiers converge on one row and the
  store upsert never downgrades provider→text (`closer_commit` only ever gains via COALESCE).
- `papertrail_items` gains `closed_at` (the supersession axis), `resolution`
  (provider-neutral; NULL = "attested nothing", `unknown` = "attested but unclassified"),
  `merge_commit_sha` (**merged-only invariant** — GitHub returns a non-null sha for
  closed-unmerged PRs: its ephemeral test-merge commit), `state_normalized`
  (open|closed|merged, backfilled — the GitLab `state='merged'` trap means consumers must
  never filter raw state), and author facets; comments gain the author facets too.

**Text tier + mining:** tracker item and comment bodies are now mined for refs at store time
(`source_kind='item'/'comment'`); a closing keyword in a **merged** change request's body mints
the text-tier closing edge (carrying its merge commit); commit-message closing refs mint
(issue, commit) edges; `reverts`/`reverted` join the ref-kind vocabulary. Re-mining REPLACES a
source's mined set transactionally, so an edited-away link cannot survive as evidence, and
mined-source identities are kind-qualified so namespaced providers (GitLab `#5` vs `!5`) never
coalesce.

**Scoping discipline:** the new table joins the adoption re-point list and the poison-sibling
harness (an unscoped closing-edge read trips on a sibling's attested closer).

**Measured on this repo's own mirror** (full re-walk, rate-limit partial): item-mined refs
0 → 767, comment-mined 0 → 252; closing edges 0 → 113 (75 change-request + 38 commit, all
text-tier); `state_normalized` 329 merged / 295 closed / 97 open; `resolution` attested on 137
items; `merge_commit_sha` on 131 merged rows. Spot-checked pairs (#708/#707 → PR #710 with its
real merge commit) match git history.

Stage 2 is the provider-attested GraphQL lane (`closingIssuesReferences` + closed-event
closers, its own governor lane + capability probe, one-time backfill).

3004/3004 tests; all four CI clippy gates green.

Part of #113 via #702.
