### PR TITLE
bench: report the kernel DB size as a split — structure+FTS+graph+git vs +vectors (#78)

### DIFF
--- a/.github/workflows/bench-release.yml
+++ b/.github/workflows/bench-release.yml
@@ -20,6 +20,10 @@ on:
         description: 'Full-rebuild wave size (RAG_RAT_INDEX_WAVE) — the memory/speed knob (default 2000)'
         required: false
         default: '2000'
+      vectors:
+        description: 'Set to 1 to add the +vectors pass (RAG_RAT_KERNEL_VECTORS) — reports db_size_with_vectors / db_size_vectors_delta on top of the structure-only headline (#78)'
+        required: false
+        default: ''
       mem_trace:
         description: 'Set to 1 to emit per-phase MEMTRACE (RSS + sqlite_memory) to the log for peak diagnosis'
         required: false
@@ -48,8 +52,8 @@ env:
 
 jobs:
   kernel:
-    # Self-hosted runner (62 GB RAM): the whole-kernel index peaks at ~5.5 GiB RSS (the embedding
-    # reconcile; see docs/benchmarks.md) plus the OS page cache over a ~10 GB index DB — runnable on
+    # Self-hosted runner (62 GB RAM): the whole-kernel index peaks at ~5.5 GiB RSS (a post-COMMIT
+    # plateau; see docs/benchmarks.md) plus the OS page cache over a multi-GB index DB — runnable on
     # a hosted box but with a noisy, contended wall-clock, which defeats the point of a headline
     # number. Only the release / workflow_dispatch triggers land here (never PRs), so a public-repo
     # self-hosted runner is safe. See docs/bencher.md.
@@ -68,6 +72,7 @@ jobs:
         env:
           RAG_RAT_KERNEL_SUBDIRS: ${{ github.event.inputs.kernel_subdirs || '.' }}
           RAG_RAT_INDEX_WAVE: ${{ github.event.inputs.wave_size || '2000' }}
+          RAG_RAT_KERNEL_VECTORS: ${{ github.event.inputs.vectors }}
           RAG_RAT_MEM_TRACE: ${{ github.event.inputs.mem_trace }}
           RAG_RAT_SQLITE_SOFT_HEAP_LIMIT_MB: ${{ github.event.inputs.soft_heap_limit_mb }}
           RAG_RAT_WAL_AUTOCHECKPOINT: ${{ github.event.inputs.wal_autocheckpoint }}
@@ -83,6 +88,7 @@ jobs:
             -v rag-rat-target:/repo/target \
             -e RAG_RAT_KERNEL_SUBDIRS="$RAG_RAT_KERNEL_SUBDIRS" \
             -e RAG_RAT_INDEX_WAVE="$RAG_RAT_INDEX_WAVE" \
+            -e RAG_RAT_KERNEL_VECTORS="$RAG_RAT_KERNEL_VECTORS" \
             -e RAG_RAT_MEM_TRACE="$RAG_RAT_MEM_TRACE" \
             -e RAG_RAT_SQLITE_SOFT_HEAP_LIMIT_MB="$RAG_RAT_SQLITE_SOFT_HEAP_LIMIT_MB" \
             -e RAG_RAT_WAL_AUTOCHECKPOINT="$RAG_RAT_WAL_AUTOCHECKPOINT" \

--- a/docs/bencher.md
+++ b/docs/bencher.md
@@ -144,11 +144,13 @@ with nine measures:
 - `db_size` — on-disk index size in bytes, post-WAL-checkpoint. The **structure-only** half of the
   size split (#78): no vectors.
 
-Setting `RAG_RAT_KERNEL_VECTORS=1` runs a second pass that installs the hash embedder and reconciles
-every chunk, adding two more measures — `db_size_with_vectors` and `db_size_vectors_delta` (the
-marginal bytes the embedding tier costs). Off by default: at kernel scale it embeds ~1.6M chunks, and
-hash-embedder vectors over the kernel are plumbing-validation, not retrieval value. When the pass
-doesn't run, both measures are **omitted** rather than reported as zero. See
+Setting `RAG_RAT_KERNEL_VECTORS=1` runs a second pass that installs the hash embedder and embeds
+every chunk the embedding policy admits (not every chunk yields a vector — the policy skips e.g.
+generated and low-signal chunks), adding two more measures — `db_size_with_vectors` and
+`db_size_vectors_delta` (the marginal bytes the embedding tier costs). Off by default: at kernel
+scale it sweeps ~1.6M chunks, and hash-embedder vectors over the kernel are plumbing-validation, not
+retrieval value. When the pass doesn't run, both measures are **omitted** rather than reported as
+zero. See
 [`benchmarks.md`](./benchmarks.md#db-size-structure-vs-vectors).
 
 It's a **single cold rebuild**, not a criterion loop: the whole kernel is ~63k C/H files and takes

--- a/docs/bencher.md
+++ b/docs/bencher.md
@@ -129,8 +129,9 @@ holds the API token. PR runs use `--start-point main --start-point-clone-thresho
 
 `tools/bench-kernel.sh` (run by `bench-release.yml`) is the "indexes the Linux kernel in X seconds"
 benchmark. It shallow-clones a pinned kernel tag (`KERNEL_TAG`, default `v7.0`), indexes its C/H
-sources **once** with the release `rag-rat` binary (`index --full`, `--no-default-features` =
-hash embedder, no model download), and writes a Bencher Metric Format JSON file with eight measures:
+sources **once** with the release `rag-rat` binary (`index --full`, `model = "none"`, built
+`--no-default-features` so there is no model download), and writes a Bencher Metric Format JSON file
+with nine measures:
 
 - `latency` — wall-clock seconds to index, in nanoseconds (Bencher's built-in Latency measure).
 - `throughput` — indexed files per second.
@@ -140,6 +141,15 @@ hash embedder, no model download), and writes a Bencher Metric Format JSON file 
   `kernel_rss_samples.csv` as the before/after curve).
 - `symbols`, `edges`, `resolved_edges`, `chunks` — extracted-fact counts, so a run is comparable
   per fact and not just per file (the unresolved-edge taxonomy goes to `kernel_unresolved_by_kind.csv`).
+- `db_size` — on-disk index size in bytes, post-WAL-checkpoint. The **structure-only** half of the
+  size split (#78): no vectors.
+
+Setting `RAG_RAT_KERNEL_VECTORS=1` runs a second pass that installs the hash embedder and reconciles
+every chunk, adding two more measures — `db_size_with_vectors` and `db_size_vectors_delta` (the
+marginal bytes the embedding tier costs). Off by default: at kernel scale it embeds ~1.6M chunks, and
+hash-embedder vectors over the kernel are plumbing-validation, not retrieval value. When the pass
+doesn't run, both measures are **omitted** rather than reported as zero. See
+[`benchmarks.md`](./benchmarks.md#db-size-structure-vs-vectors).
 
 It's a **single cold rebuild**, not a criterion loop: the whole kernel is ~63k C/H files and takes
 tens of minutes, so criterion's 10-sample minimum (×10) is a non-starter. One run is also exactly

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -33,8 +33,10 @@ dominates wall-clock more than core count does. Peak RSS is governed by the grap
 ## Headline: indexing the Linux kernel
 
 Linux kernel **v7.0** (pinned at commit `028ef9c96e96197026887c0f092424679298aae8`, shallow-cloned),
-full index (`index --full`), whole tree (`RAG_RAT_KERNEL_SUBDIRS=.`), hash embedder
-(`--no-default-features`, no model download), release build, `RAG_RAT_INDEX_WAVE=2000`.
+full index (`index --full`), whole tree (`RAG_RAT_KERNEL_SUBDIRS=.`), no embedding model
+(`model = "none"`; built `--no-default-features`, so no model download), release build,
+`RAG_RAT_INDEX_WAVE=2000`. The on-disk size below is the structure-only half of the
+[size split](#db-size-structure-vs-vectors).
 
 | Metric | Value |
 |---|---|
@@ -63,6 +65,51 @@ Unresolved-edge taxonomy (the 41.8% / 3,823,653 edges the syntactic graph leaves
 bind without a compilation database; `references_type` is dominated by references whose type
 *definition* lives in an uncompiled or external header — both are exactly what the SCIP oracle
 recovers (below).
+
+### DB size: structure vs vectors
+
+"Indexing the kernel costs N GB" is only an honest number if it says what's *in* the N. The bench
+reports the size as a **split** (#78), because the two halves are bought separately:
+
+| Half | What it is | BMF measure |
+|---|---|---|
+| **Structure** (the headline) | files + symbols + graph + chunks + FTS + git history. `model = "none"` — zero vectors. What a base install actually builds. | `db_size` |
+| **+ Vectors** | every chunk embedded, on top of the same index. Opt-in second pass. | `db_size_with_vectors`, `db_size_vectors_delta` |
+
+The headline pass runs `model = "none"`, which is the honest config for this corpus: nobody does
+vector recall over the Linux kernel with a hash embedder, so those baseline vectors would be
+plumbing-validation, not retrieval value. `index --full` computes no embeddings regardless — the
+reconcile is a separate, explicit pass that refuses to embed under a model that was never installed
+— so the structure-only headline is what the run has always measured; the config now *says* so, and
+the vector tier gets priced instead of assumed.
+
+This is what makes the degradability claim ("base install ships zero AI; add what you use") a
+**measured** number rather than an assertion: `db_size_vectors_delta` is exactly the disk you avoid
+by not adding the embedding tier.
+
+The `+vectors` pass is off by default (at kernel scale it embeds ~1.6M chunks). Turn it on with:
+
+```bash
+RAG_RAT_KERNEL_VECTORS=1 RAG_RAT_BIN=target/release/rag-rat bash tools/bench-kernel.sh
+```
+
+**Kernel-scale `+Y` is not measured yet** — no whole-tree run with `RAG_RAT_KERNEL_VECTORS=1` has
+been published, so no number is quoted here. It lands from the next `bench-release` dispatch with
+the flag set, and is tracked as its own Bencher series from then on.
+
+For the *shape* of the split, one scope-bounded run — **`RAG_RAT_KERNEL_SUBDIRS=lib`, 673 files, not
+the headline**, on a 5-core / 15 GB box rather than the bench runner:
+
+| | Bytes | |
+|---|---|---|
+| structure + FTS + graph + git | 64,815,104 | 62 MiB |
+| add vectors (13,793 chunks → 10,151 embedded) | +13,271,040 | +13 MiB |
+| total | 78,086,144 | 74 MiB |
+
+So on that subtree the embedding tier is ~17% of the full DB. Vectors are stored int8-quantized
+(#112: a 4-byte scale + one byte per dim, ~4× smaller than the f32 blob), which is why the tier is a
+modest fraction rather than the dominant one. Whether the whole-tree ratio holds is exactly what the
+measured run will answer — don't extrapolate this row to the headline.
 
 ### v0.5.0 rebaseline: why the kernel got ~2.7× faster
 
@@ -206,19 +253,27 @@ higher one is missed by the named per-phase probes:
 1. **The edge-resolution window** (inside the rebuild transaction). The whole symbol + edge graph is
    held in memory until the single resolve-and-insert pass; once `index_targets` frees it, RSS drops
    to a flat resident baseline through logical-symbol building, FTS, and COMMIT.
-2. **The embedding reconcile** (after COMMIT, where the true peak lives). `index --full` runs the
-   embedding reconcile once the rebuild commits; the hash embedder is always ready, so embeddings are
-   actually computed. The reconcile materializes chunk rows to embed them, adding a few GiB on top of
-   the resident baseline for a sustained plateau — this is the process peak, and it is **not**
-   covered by the `RAG_RAT_MEM_TRACE=1` per-phase probes (which instrument the rebuild transaction and
-   stop at COMMIT). Only the whole-process sampler catches it.
+2. **A post-COMMIT plateau** (where the true peak lives), **cause not yet attributed**. A few GiB
+   land on top of the resident baseline after COMMIT for a sustained plateau — the process peak —
+   and it is **not** covered by the `RAG_RAT_MEM_TRACE=1` per-phase probes (which instrument the
+   rebuild transaction and stop at COMMIT). Only the whole-process sampler catches it.
 
-Both humps shrank from v0.4.x with the #61 symbol/chunk reduction: a smaller in-memory graph lowers
-the edge window, and ~62% fewer chunks lower the reconcile's materialization — together taking the
-peak from 5.60 GiB (v0.4.x) to 4.15 GiB (v0.5.0), and lower still to 3.49 GiB by v0.15.0. To
-regenerate the per-phase curve on your own run, set
-`RAG_RAT_MEM_TRACE=1` (rebuild transaction phases, to stderr) plus the sampler CSV the bench writes
-(`RSS_CSV`, the post-COMMIT reconcile the MEM_TRACE probes miss).
+   This plateau used to be attributed to the embedding reconcile. That attribution is **wrong**:
+   `index --full` never runs one. The CLI `index` path calls `rebuild_with_progress` and stops
+   (`crates/rag-rat-cli/src/commands/index_ops.rs:89`); neither it nor the core rebuild
+   (`crates/rag-rat-core/src/index/rebuild.rs`) ever reaches an embedder, and `reconcile` refuses to
+   embed under a model that was never explicitly installed — which the bench never does. A bench DB
+   accordingly contains **zero** rows in `chunk_embeddings`, which is why the headline `db_size` is
+   the structure-only number above. So whatever the plateau is, it is not chunk-embedding
+   materialization; the real cause is open (the pinned kernel's full-history `git log --numstat`
+   walk is the obvious suspect, since it is the other post-rebuild bulk pass — unverified).
+
+Both humps shrank from v0.4.x with the #61 symbol/chunk reduction — the peak went from 5.60 GiB
+(v0.4.x) to 4.15 GiB (v0.5.0), and lower still to 3.49 GiB by v0.15.0. A smaller in-memory graph
+lowers the edge window; why the post-COMMIT plateau also fell is part of the open attribution above.
+To regenerate the per-phase curve on your own run, set `RAG_RAT_MEM_TRACE=1` (rebuild transaction
+phases, to stderr) plus the sampler CSV the bench writes (`RSS_CSV`, the post-COMMIT plateau the
+MEM_TRACE probes miss).
 
 ### How the peak got here
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -74,7 +74,7 @@ reports the size as a **split** (#78), because the two halves are bought separat
 | Half | What it is | BMF measure |
 |---|---|---|
 | **Structure** (the headline) | files + symbols + graph + chunks + FTS + git history. `model = "none"` — zero vectors. What a base install actually builds. | `db_size` |
-| **+ Vectors** | every chunk embedded, on top of the same index. Opt-in second pass. | `db_size_with_vectors`, `db_size_vectors_delta` |
+| **+ Vectors** | every chunk the embedding policy admits, embedded on top of the same index. Opt-in second pass. | `db_size_with_vectors`, `db_size_vectors_delta` |
 
 The headline pass runs `model = "none"`, which is the honest config for this corpus: nobody does
 vector recall over the Linux kernel with a hash embedder, so those baseline vectors would be

--- a/tools/bench-kernel.sh
+++ b/tools/bench-kernel.sh
@@ -3,8 +3,16 @@
 #
 # Clones a pinned Linux kernel tag, indexes its C/H sources once with the *release* rag-rat binary
 # (dogfooding the shipped `index` command), and writes a Bencher Metric Format (BMF) JSON file with
-# three measures: latency (ns), throughput (files/s), and peak memory (bytes). The release workflow
-# (.github/workflows/bench_release.yml) feeds that file to `bencher run --adapter json`.
+# the run's measures: latency (ns), throughput (files/s), peak memory (bytes), the extracted-fact
+# counts, and on-disk size. The release workflow (.github/workflows/bench-release.yml) feeds that
+# file to `bencher run --adapter json`.
+#
+# DB size is reported as a SPLIT (#78), because "10 GB to index the kernel" is only honest if you say
+# what's in it. The headline `db_size` is the STRUCTURE-only index — files + symbols + graph + chunks
+# + FTS + git history, `model = "none"`, zero vectors — which is what a base install actually builds.
+# Vectors are a separate, opt-in pass (RAG_RAT_KERNEL_VECTORS=1) reported as `db_size_with_vectors`
+# and the `db_size_vectors_delta` on top. That makes the degradability claim ("base install ships
+# zero AI; add what you use") a measured number instead of an assertion.
 #
 # Single-shot on purpose: a full kernel index is ~tens of minutes, so criterion's 10-sample loop
 # isn't viable — this is one cold rebuild, the number a user actually sees. Runs only on release
@@ -18,6 +26,9 @@
 #   RAG_RAT_INDEX_WAVE       full-rebuild wave size (files prepared/inserted per wave before the
 #                            wave's prepared form is dropped) — the memory/speed knob. Read by the
 #                            binary; passed through this script's environment. (binary default: 2000)
+#   RAG_RAT_KERNEL_VECTORS   set to 1 to run the second, +vectors pass (default: 0 = headline only):
+#                            installs the hash embedder and reconciles every chunk, so the run also
+#                            reports db_size_with_vectors / db_size_vectors_delta
 #   BMF_OUT                  output BMF JSON path           (default: kernel_bmf.json)
 #   TAXONOMY_CSV             unresolved-edge-by-kind CSV    (default: kernel_unresolved_by_kind.csv)
 #   KERNEL_WORK              working dir                    (default: a fresh mktemp dir)
@@ -30,6 +41,7 @@ RSS_CSV="${RSS_CSV:-kernel_rss_samples.csv}"
 TAXONOMY_CSV="${TAXONOMY_CSV:-kernel_unresolved_by_kind.csv}"
 RAG_RAT_BIN="${RAG_RAT_BIN:-target/release/rag-rat}"
 RAG_RAT_KERNEL_SUBDIRS="${RAG_RAT_KERNEL_SUBDIRS:-.}"
+RAG_RAT_KERNEL_VECTORS="${RAG_RAT_KERNEL_VECTORS:-0}"
 BMF_OUT="${BMF_OUT:-kernel_bmf.json}"
 WORK="${KERNEL_WORK:-$(mktemp -d)}"
 mkdir -p "$WORK"
@@ -52,15 +64,41 @@ git -C "$WORK/linux" -c protocol.version=2 fetch -q --depth 1 origin "$KERNEL_SH
 git -C "$WORK/linux" checkout -q "$KERNEL_SHA"
 
 # Render a C-language config over the requested subtree(s). `c = [...]` maps to **/*.c + **/*.h.
+#
+# `model = "none"` is the HONEST headline config (#78), stated explicitly rather than left to the
+# default: nobody runs vector recall over the kernel with a hash embedder, so the baseline vectors
+# would be plumbing-validation, not retrieval value. It also pins what the headline measures — the
+# default selector would seed all-MiniLM as the provisional active model, which is not a model this
+# `--no-default-features` build can even load. `index --full` computes no embeddings either way
+# (the reconcile is a separate, explicit pass and refuses without an installed model), so this
+# names the run's real semantics instead of relying on that.
 subdirs_toml="$(printf '"%s", ' $RAG_RAT_KERNEL_SUBDIRS)"
 cat > "$WORK/rag-rat.toml" <<EOF
 [index]
 root = "$WORK/linux"
 database = "$WORK/kernel-index.sqlite"
 
+[llm.embedding]
+model = "none"
+
 [target_bindings]
 c = [${subdirs_toml%, }]
 EOF
+
+# Checkpoint the WAL into the main file, then print the DB's durable size in bytes. Called once per
+# size measurement (structure-only, then again after the +vectors pass), so each number is the real
+# on-disk footprint at that point and not a pre-checkpoint undercount.
+db_size_bytes() {
+  python3 - "$1" <<'PY'
+import os, sqlite3, sys
+
+db = sys.argv[1]
+conn = sqlite3.connect(db)
+conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+conn.close()
+print(os.path.getsize(db))
+PY
+}
 
 # Single cold full index, measured. We capture TWO memory numbers:
 #   - maxrss: getrusage(RUSAGE_CHILDREN).ru_maxrss — the kernel-true peak (catches sub-sample spikes),
@@ -111,18 +149,53 @@ if [ "${rc:-1}" -ne 0 ]; then
   exit 1
 fi
 
+# PASS 1 SIZE — the headline (#78): structure + FTS + graph + git, zero vectors. Measured HERE,
+# before the optional vectors pass below can grow the file.
+structure_db_size="$(db_size_bytes "$WORK/kernel-index.sqlite")"
+
+# PASS 2 (opt-in) — add vectors on top of the SAME index and re-measure, so the reported delta is
+# the marginal cost of the embedding tier over the structure this run already built, not two
+# independent indexes differenced. Off by default: at kernel scale it embeds ~1.6M chunks, and the
+# hash embedder's vectors are plumbing-validation rather than retrieval value — the point is to
+# price the tier, not to ship a recall claim. `models install` is required because `reconcile`
+# refuses to embed under a model that was never explicitly installed.
+vectors_db_size=""
+if [ "$RAG_RAT_KERNEL_VECTORS" = "1" ]; then
+  # The same index + config, with the embeddings-off selector swapped for the hash embedder. The
+  # selector must be a model this `--no-default-features` build can actually construct, so it is
+  # `embedding-hash` (the dependency-free tier) and not a transformer that needs a download.
+  cat > "$WORK/rag-rat-vectors.toml" <<EOF
+[index]
+root = "$WORK/linux"
+database = "$WORK/kernel-index.sqlite"
+
+[llm.embedding]
+model = "embedding-hash"
+
+[target_bindings]
+c = [${subdirs_toml%, }]
+EOF
+  echo "bench-kernel: +vectors pass — installing the hash embedder and reconciling every chunk…" >&2
+  "$RAG_RAT_BIN" --config "$WORK/rag-rat-vectors.toml" models install embedding-hash >/dev/null
+  "$RAG_RAT_BIN" --config "$WORK/rag-rat-vectors.toml" reconcile --until-clean >/dev/null
+  vectors_db_size="$(db_size_bytes "$WORK/kernel-index.sqlite")"
+fi
+
 # Read the extracted-fact counts from the DB and emit the BMF. Capturing symbols/edges/chunks (not
 # just files/s) makes the run comparable per extracted fact, not just per file — different tools
 # compute different products, so throughput alone is mush.
-python3 - "$WORK/kernel-index.sqlite" "$seconds" "$maxrss_kb" "$sampled_peak_kb" "$BMF_OUT" "$KERNEL_TAG" "$TAXONOMY_CSV" <<'PY'
+python3 - "$WORK/kernel-index.sqlite" "$seconds" "$maxrss_kb" "$sampled_peak_kb" "$BMF_OUT" "$KERNEL_TAG" "$TAXONOMY_CSV" "$structure_db_size" "$vectors_db_size" <<'PY'
 import json, os, sqlite3, sys
 db, seconds = sys.argv[1], float(sys.argv[2])
 maxrss_kb, sampled_peak_kb = int(sys.argv[3]), int(sys.argv[4])
 out, tag, taxonomy_csv = sys.argv[5], sys.argv[6], sys.argv[7]
+# Both sizes are measured by the shell (each right after its own WAL checkpoint, at the point in the
+# run where it is true); this step only reports them. An empty `vectors_db_size` = the +vectors pass
+# was not run, so the vector measures are OMITTED rather than reported as zero — a missing
+# measurement and a measured zero are different claims.
+structure_db_size = int(sys.argv[8])
+vectors_db_size = int(sys.argv[9]) if sys.argv[9] else None
 conn = sqlite3.connect(db)
-# Checkpoint the WAL into the main file first so db_size measures the real durable footprint.
-conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
-db_size = os.path.getsize(db)
 count = lambda table: conn.execute(f"select count(*) from {table}").fetchone()[0]
 files, symbols, edges, chunks = count("files"), count("symbols"), count("edges"), count("chunks")
 resolved = conn.execute("select count(*) from edges where to_symbol_id is not null").fetchone()[0]
@@ -157,10 +230,20 @@ bmf = {
         "resolved_edges": {"value": resolved},
         "chunks": {"value": chunks},
         # On-disk index size, bytes (post-checkpoint) — the #79 interning headline at kernel
-        # scale; tracked so size regressions surface alongside latency/memory.
-        "db_size": {"value": db_size},
+        # scale; tracked so size regressions surface alongside latency/memory. This is the
+        # STRUCTURE-only index (#78): no vectors, `model = "none"`. It stays named `db_size` so the
+        # existing Bencher series keeps its history — the number's meaning is unchanged (the run
+        # never embedded), only now stated.
+        "db_size": {"value": structure_db_size},
     }
 }
+if vectors_db_size is not None:
+    # The +Y half of the split: the same index with every chunk embedded, and the marginal cost of
+    # the vector tier on top of the structure above.
+    bmf[f"linux-kernel-{tag}/full-index"]["db_size_with_vectors"] = {"value": vectors_db_size}
+    bmf[f"linux-kernel-{tag}/full-index"]["db_size_vectors_delta"] = {
+        "value": vectors_db_size - structure_db_size
+    }
 with open(out, "w") as f:
     json.dump(bmf, f, indent=2)
 
@@ -168,10 +251,27 @@ taxonomy = " ".join(f"{kind}={n}" for kind, n in unresolved_by_kind)
 print(
     f"bench-kernel: indexed {files} files of Linux {tag} in {seconds:.1f}s "
     f"({files/seconds:.1f} files/s, wave={wave}) — peak {maxrss_kb/1024:.0f} MiB maxrss "
-    f"(sampled {sampled_peak_kb/1024:.0f} MiB) — db {db_size/1024/1024:.0f} MiB — "
+    f"(sampled {sampled_peak_kb/1024:.0f} MiB) — db {structure_db_size/1024/1024:.0f} MiB — "
     f"{symbols} symbols, {edges} edges ({resolved} resolved, {resolved_pct:.1f}%), {chunks} chunks → {out}",
     file=sys.stderr,
 )
+# The #78 headline sentence, in the shape the docs quote it: structure X, add vectors +Y.
+if vectors_db_size is None:
+    print(
+        f"bench-kernel: db size — structure + FTS + graph + git: "
+        f"{structure_db_size/1024/1024:.0f} MiB (model=none, 0 vectors); "
+        f"add vectors: NOT MEASURED (set RAG_RAT_KERNEL_VECTORS=1 for the +vectors pass)",
+        file=sys.stderr,
+    )
+else:
+    delta = vectors_db_size - structure_db_size
+    print(
+        f"bench-kernel: db size — structure + FTS + graph + git: "
+        f"{structure_db_size/1024/1024:.0f} MiB; add vectors: +{delta/1024/1024:.0f} MiB "
+        f"= {vectors_db_size/1024/1024:.0f} MiB total "
+        f"({100.0*delta/vectors_db_size:.0f}% of the full DB is the embedding tier)",
+        file=sys.stderr,
+    )
 print(
     f"bench-kernel: {unresolved_total} unresolved edges by kind → {taxonomy} (full breakdown in {taxonomy_csv})",
     file=sys.stderr,

--- a/tools/bench-kernel.sh
+++ b/tools/bench-kernel.sh
@@ -27,8 +27,8 @@
 #                            wave's prepared form is dropped) — the memory/speed knob. Read by the
 #                            binary; passed through this script's environment. (binary default: 2000)
 #   RAG_RAT_KERNEL_VECTORS   set to 1 to run the second, +vectors pass (default: 0 = headline only):
-#                            installs the hash embedder and reconciles every chunk, so the run also
-#                            reports db_size_with_vectors / db_size_vectors_delta
+#                            installs the hash embedder and embeds every policy-admitted chunk, so
+#                            the run also reports db_size_with_vectors / db_size_vectors_delta
 #   BMF_OUT                  output BMF JSON path           (default: kernel_bmf.json)
 #   TAXONOMY_CSV             unresolved-edge-by-kind CSV    (default: kernel_unresolved_by_kind.csv)
 #   KERNEL_WORK              working dir                    (default: a fresh mktemp dir)
@@ -64,7 +64,25 @@ git -C "$WORK/linux" -c protocol.version=2 fetch -q --depth 1 origin "$KERNEL_SH
 git -C "$WORK/linux" checkout -q "$KERNEL_SHA"
 
 # Render a C-language config over the requested subtree(s). `c = [...]` maps to **/*.c + **/*.h.
-#
+# Both passes render their config through this one helper — identical [index] + [target_bindings],
+# differing ONLY in the embedding selector — so the two configs cannot drift apart in any other
+# dimension.
+subdirs_toml="$(printf '"%s", ' $RAG_RAT_KERNEL_SUBDIRS)"
+write_config() {
+  local path="$1" model="$2"
+  cat > "$path" <<EOF
+[index]
+root = "$WORK/linux"
+database = "$WORK/kernel-index.sqlite"
+
+[llm.embedding]
+model = "$model"
+
+[target_bindings]
+c = [${subdirs_toml%, }]
+EOF
+}
+
 # `model = "none"` is the HONEST headline config (#78), stated explicitly rather than left to the
 # default: nobody runs vector recall over the kernel with a hash embedder, so the baseline vectors
 # would be plumbing-validation, not retrieval value. It also pins what the headline measures — the
@@ -72,18 +90,7 @@ git -C "$WORK/linux" checkout -q "$KERNEL_SHA"
 # `--no-default-features` build can even load. `index --full` computes no embeddings either way
 # (the reconcile is a separate, explicit pass and refuses without an installed model), so this
 # names the run's real semantics instead of relying on that.
-subdirs_toml="$(printf '"%s", ' $RAG_RAT_KERNEL_SUBDIRS)"
-cat > "$WORK/rag-rat.toml" <<EOF
-[index]
-root = "$WORK/linux"
-database = "$WORK/kernel-index.sqlite"
-
-[llm.embedding]
-model = "none"
-
-[target_bindings]
-c = [${subdirs_toml%, }]
-EOF
+write_config "$WORK/rag-rat.toml" "none"
 
 # Checkpoint the WAL into the main file, then print the DB's durable size in bytes. Called once per
 # size measurement (structure-only, then again after the +vectors pass), so each number is the real
@@ -155,7 +162,7 @@ structure_db_size="$(db_size_bytes "$WORK/kernel-index.sqlite")"
 
 # PASS 2 (opt-in) — add vectors on top of the SAME index and re-measure, so the reported delta is
 # the marginal cost of the embedding tier over the structure this run already built, not two
-# independent indexes differenced. Off by default: at kernel scale it embeds ~1.6M chunks, and the
+# independent indexes differenced. Off by default: at kernel scale it sweeps ~1.6M chunks, and the
 # hash embedder's vectors are plumbing-validation rather than retrieval value — the point is to
 # price the tier, not to ship a recall claim. `models install` is required because `reconcile`
 # refuses to embed under a model that was never explicitly installed.
@@ -164,18 +171,8 @@ if [ "$RAG_RAT_KERNEL_VECTORS" = "1" ]; then
   # The same index + config, with the embeddings-off selector swapped for the hash embedder. The
   # selector must be a model this `--no-default-features` build can actually construct, so it is
   # `embedding-hash` (the dependency-free tier) and not a transformer that needs a download.
-  cat > "$WORK/rag-rat-vectors.toml" <<EOF
-[index]
-root = "$WORK/linux"
-database = "$WORK/kernel-index.sqlite"
-
-[llm.embedding]
-model = "embedding-hash"
-
-[target_bindings]
-c = [${subdirs_toml%, }]
-EOF
-  echo "bench-kernel: +vectors pass — installing the hash embedder and reconciling every chunk…" >&2
+  write_config "$WORK/rag-rat-vectors.toml" "embedding-hash"
+  echo "bench-kernel: +vectors pass — installing the hash embedder and reconciling chunk embeddings…" >&2
   "$RAG_RAT_BIN" --config "$WORK/rag-rat-vectors.toml" models install embedding-hash >/dev/null
   "$RAG_RAT_BIN" --config "$WORK/rag-rat-vectors.toml" reconcile --until-clean >/dev/null
   vectors_db_size="$(db_size_bytes "$WORK/kernel-index.sqlite")"
@@ -238,7 +235,7 @@ bmf = {
     }
 }
 if vectors_db_size is not None:
-    # The +Y half of the split: the same index with every chunk embedded, and the marginal cost of
+    # The +Y half of the split: the same index with embeddings reconciled, and the marginal cost of
     # the vector tier on top of the structure above.
     bmf[f"linux-kernel-{tag}/full-index"]["db_size_with_vectors"] = {"value": vectors_db_size}
     bmf[f"linux-kernel-{tag}/full-index"]["db_size_vectors_delta"] = {


### PR DESCRIPTION
## Benchmark honesty: report the kernel DB size as a split (#78)

"Indexing the kernel costs N GB" is only honest if it says what is in the N. This reports it as `structure + FTS + graph + git: X; add vectors: +Y`, which turns the degradability claim ("base install ships zero AI; add what you use") into a measured number — `db_size_vectors_delta` is exactly the disk you avoid by not installing a model.

- `model = "none"` stated explicitly in the headline config rather than left to the default.
- Opt-in `RAG_RAT_KERNEL_VECTORS=1` second pass (installs the hash embedder, reconciles, re-measures). Off by default; exposed as a `vectors` dispatch input on `bench-release.yml` so +Y is producible from CI.
- BMF: `db_size` keeps its name and meaning (structure-only) so the Bencher series keeps its history; adds `db_size_with_vectors` + `db_size_vectors_delta`, **omitted** (not zeroed) when the pass does not run.
- Each size is taken after a `wal_checkpoint(TRUNCATE)`, so it is the durable on-disk footprint rather than a pre-checkpoint undercount.

## One correction to the issue premise — please read this before merging

The issue (mine) says the bench produces "~1.6M deterministic baseline vectors… potentially 2+ GB of the ~10". **It produces zero vectors.** `index --full` never runs an embedding reconcile:

- CLI `index` stops at `rebuild_with_progress` (`crates/rag-rat-cli/src/commands/index_ops.rs:89`); `reconcile` is a separate command
- neither it nor `crates/rag-rat-core/src/index/rebuild.rs` reaches an embedder — a full rebuild in fact *deletes* from `chunk_embeddings`
- `reconcile` refuses to embed under a never-installed model, and the bench never installs one

Verified empirically (indexed rag-rat itself twice → `chunk_embeddings = 0`) and across **every tag v0.4.0 → HEAD**. So past `db_size` figures were **already** structure-only: the X half needed *stating*, not changing, and only the +Y half was genuinely missing. The PR is correspondingly smaller than the issue implies.

## A pre-existing docs bug this surfaced

Because that pass never runs, `docs/benchmarks.md` attributed the post-COMMIT RSS plateau to "the embedding reconcile… embeddings are actually computed" — **a mechanism that does not exist**. I marked the cause **open** rather than inventing a replacement.

Corroborating datum: a **56-file** index peaked at 3429 MiB and a **673-file** index at 3495 MiB — near-identical across 12× the files, so the peak is not chunk-driven. The kernel full-history `git log --numstat` walk is my suspect, but I did **not** verify it and have not claimed it. Happy to split this hunk into its own PR or file it as an issue if you would rather keep this one narrow.

## Measurement honesty — what was NOT run

**I could not run the kernel at scale here, so no kernel X/Y GB number is quoted anywhere** — not in the docs, not in this description. The docs say explicitly that kernel-scale +Y is unmeasured and lands from your next `bench-release` dispatch.

What I did run: the **real** `bench-kernel.sh` against the **real** pinned kernel commit (`028ef9c…`), scope-bounded with the script own `RAG_RAT_KERNEL_SUBDIRS=lib` (673 files):

| | Bytes | |
|---|---|---|
| structure + FTS + graph + git | 64,815,104 | 62 MiB |
| add vectors (13,793 chunks → 10,151 embedded) | +13,271,040 | +13 MiB |
| total | 78,086,144 | 74 MiB |

~17% embedding tier on that subset — **do not extrapolate that ratio to the whole tree.** Note the vectors are int8 (388 B/row), so the issue "f32 at a few hundred dims → 2+ GB" sizing was off in two ways.

## Verification

There is no test harness for `bench-kernel.sh` anywhere in the repo, so rather than invent one I mutation-tested the real script: moving the structure measurement *after* the vectors pass drove `db_size_vectors_delta` **1,904,640 → 0** and silently made the headline the with-vectors size — **while still exiting 0**. That silent-wrong-number failure is exactly why the ordering is load-bearing, and it is commented as such. Restoring reproduced the baseline byte-identically. Both `RAG_RAT_KERNEL_VECTORS` branches were exercised (off → measures omitted + "NOT MEASURED"; on → all three).

Gates: `cargo build --no-default-features` → 0 · `cargo test --workspace --no-default-features` → 0 (**2,544 passed**) · `bash -n` → 0 · `shellcheck` → 1 on **one pre-existing SC2086 that is byte-identical on `upstream/main`** (I diffed the finding sets to confirm it is not mine; the word-splitting is intentional). Zero Rust files changed.

## Scope note

Beyond the two files the issue names, I touched `docs/bencher.md` (its measure list said "eight measures" and already omitted `db_size`) and `.github/workflows/bench-release.yml` (the input is what makes the docs "lands from the next dispatch" true). Both are minimal glue — say the word and I will drop either.

One environment caveat that is **not** in the diff: this box python links sqlite 3.34.1, which cannot open the `STRICT` schema (needs ≥3.37), so I injected `pysqlite3` via a `sitecustomize.py` outside the repo. Your `debian:trixie-slim` bench container is new enough that CI needs nothing — but the script does silently require sqlite ≥3.37 in its python, which is undocumented. Worth a line in the docs if you agree.

---
*Implemented with AI assistance (Claude Opus 4.8); the zero-vectors finding and the pre-existing-shellcheck claim were independently re-verified by me against the source before submitting.*