### PR TITLE
papertrail: provider-attested closing edges — the GraphQL lane (#702 stage 2)

### DIFF
--- a/crates/rag-rat-core/src/index/query_api/history.rs
+++ b/crates/rag-rat-core/src/index/query_api/history.rs
@@ -185,8 +185,17 @@ impl IndexDatabase {
         &self,
         request: papertrail::AutosyncRequest,
     ) -> anyhow::Result<PapertrailSyncReport> {
+        // The commit-closer rederive inspects the checkout's remotes; use the PROCESS-resolved
+        // active root (`storage.source_root()`, the reanchored `config.root` that memory
+        // validation also resolves against) — NOT the raw persisted `repo_meta("source_root")`,
+        // which goes stale under a shared DB across linked worktrees and would point the git
+        // inspection at another checkout. Bail when absent, matching the manual entry.
+        let Some(root) = self.storage.source_root() else {
+            anyhow::bail!("index has no source_root metadata; rebuild required");
+        };
         papertrail::block_on(papertrail::sync_mirror_scheduled(
             self.storage.connection(),
+            root,
             &self.papertrail,
             request,
         ))

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/papertrail_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/papertrail_tests.rs
@@ -46,6 +46,7 @@ fn manual_sync_validates_client_and_routes_only_the_requested_github_identity() 
 
     let invalid = papertrail::block_on(papertrail::sync_issue::<MockGitHubClient>(
         db.storage.connection(),
+        std::path::Path::new("."),
         "not-a-ref",
         None,
         false,
@@ -57,6 +58,7 @@ fn manual_sync_validates_client_and_routes_only_the_requested_github_identity() 
 
     let missing_client = papertrail::block_on(papertrail::sync_issue::<MockGitHubClient>(
         db.storage.connection(),
+        std::path::Path::new("."),
         "cq27-dev/rag-rat#42",
         None,
         false,
@@ -81,6 +83,7 @@ fn manual_sync_validates_client_and_routes_only_the_requested_github_identity() 
 
     let live = papertrail::block_on(papertrail::sync_issue(
         db.storage.connection(),
+        std::path::Path::new("."),
         "cq27-dev/rag-rat#42",
         Some(&MockGitHubClient),
         false,
@@ -103,6 +106,7 @@ fn manual_sync_validates_client_and_routes_only_the_requested_github_identity() 
     };
     let explicit_without_github_binding = papertrail::block_on(papertrail::sync_issue(
         db.storage.connection(),
+        std::path::Path::new("."),
         "cq27-dev/rag-rat#43",
         Some(&MockGitHubClient),
         false,
@@ -114,6 +118,7 @@ fn manual_sync_validates_client_and_routes_only_the_requested_github_identity() 
 
     let offline = papertrail::block_on(papertrail::sync_issue::<MockGitHubClient>(
         db.storage.connection(),
+        std::path::Path::new("."),
         "cq27-dev/rag-rat#43",
         None,
         true,

--- a/crates/rag-rat-db/src/meta.rs
+++ b/crates/rag-rat-db/src/meta.rs
@@ -220,6 +220,13 @@ pub fn set_meta(conn: &Connection, key: &str, value: &str) -> anyhow::Result<()>
     Ok(())
 }
 
+/// Remove an `index_meta` key (the global-scope companion to [`delete_repo_meta`]). Idempotent:
+/// deleting an absent key is a no-op.
+pub fn delete_meta(conn: &Connection, key: &str) -> anyhow::Result<()> {
+    conn.execute("DELETE FROM index_meta WHERE key = ?1", [key])?;
+    Ok(())
+}
+
 pub fn meta(conn: &Connection, key: &str) -> anyhow::Result<Option<String>> {
     Ok(conn
         .query_row("SELECT value FROM index_meta WHERE key = ?1", [key], |row| row.get(0))

--- a/crates/rag-rat-papertrail/src/api.rs
+++ b/crates/rag-rat-papertrail/src/api.rs
@@ -58,6 +58,7 @@ pub async fn sync_mirror(
 /// annotation layer refreshes on manual sync).
 pub async fn sync_mirror_scheduled(
     conn: &Connection,
+    root: &Path,
     ctx: &PapertrailContext,
     request: AutosyncRequest,
 ) -> anyhow::Result<PapertrailSyncReport> {
@@ -95,6 +96,11 @@ pub async fn sync_mirror_scheduled(
         }
     }
     if jobs.is_empty() && errors.is_empty() {
+        // Nothing was due — but a scheduled hook fires AFTER an index maintenance pass, so the
+        // indexed history may have just changed. The commit-closer rederive is purely local (no
+        // network dispatch), so run it even on the no-work path or a stale text closer from a
+        // commit no longer in `git_commits` lingers until some later provider job happens to run.
+        sync::rederive_commit_closers(conn, root, ctx)?;
         // Nothing was due: report current status without stamping a sync that never ran.
         return Ok(PapertrailSyncReport {
             offline: false,
@@ -108,6 +114,9 @@ pub async fn sync_mirror_scheduled(
         });
     }
     let outcomes = run_binding_jobs(conn, jobs).await?;
+    // This scheduled run may be the FIRST to cache a target an earlier commit ref needs for its
+    // kind check — re-derive on the way out like every other entry.
+    sync::rederive_commit_closers(conn, root, ctx)?;
     assemble_mirror_report(conn, ctx, 0, outcomes, errors)
 }
 
@@ -138,7 +147,9 @@ struct BindingJob<'a> {
 /// The native client for one binding, dispatched by provider. An enum rather than a trait object
 /// because [`PapertrailClient`]'s `async fn` methods are not dyn-compatible; each arm delegates.
 enum ProviderClient {
-    Github(GitHubClient),
+    // Boxed: the GitHub client carries three transport lanes (~400 bytes) vs GitLab's one;
+    // boxing keeps the enum pointer-sized instead of every variant paying the largest's spread.
+    Github(Box<GitHubClient>),
     Gitlab(GitLabClient),
 }
 
@@ -149,7 +160,8 @@ impl ProviderClient {
         options: transport::TransportOptions,
     ) -> anyhow::Result<Self> {
         match binding.provider {
-            Tracker::Github => GitHubClient::new(binding, registry, options).map(Self::Github),
+            Tracker::Github =>
+                GitHubClient::new(binding, registry, options).map(Box::new).map(Self::Github),
             Tracker::Gitlab => GitLabClient::new(binding, registry, options).map(Self::Gitlab),
             other => anyhow::bail!("no native papertrail client for {} yet", other.as_db_str()),
         }
@@ -243,6 +255,20 @@ impl PapertrailClient for ProviderClient {
             Self::Gitlab(client) => client.freshness_probe(project, probe).await,
         }
     }
+    async fn attested_closers_page(
+        &self,
+        project: &str,
+        cursor: Option<&str>,
+        since: Option<&str>,
+    ) -> anyhow::Result<Option<AttestedClosersPage>> {
+        // Delegation is MANDATORY here: the enum wrapper otherwise swallows a provider's
+        // override behind the trait's `Ok(None)` default and the attested lane silently
+        // degrades to the text tier.
+        match self {
+            Self::Github(client) => client.attested_closers_page(project, cursor, since).await,
+            Self::Gitlab(client) => client.attested_closers_page(project, cursor, since).await,
+        }
+    }
 }
 
 /// What one dispatched binding produced: a resumable report, or the error entry to surface.
@@ -304,7 +330,8 @@ async fn run_binding_job(conn: &Connection, job: BindingJob<'_>) -> anyhow::Resu
             } else if let Some(resume_at_ms) = report.paused_until_ms {
                 record_pause(conn, job.binding, resume_at_ms)?;
             }
-            Ok(BindingOutcome { report: Some(report), error: None })
+            let error = attested_walk_error(job.binding, &report);
+            Ok(BindingOutcome { report: Some(report), error })
         },
         Err(error) => {
             let class = classify_mirror_failure(&error);
@@ -315,6 +342,22 @@ async fn run_binding_job(conn: &Connection, job: BindingJob<'_>) -> anyhow::Resu
             })
         },
     }
+}
+
+/// Surface a non-fatal attested-closers walk failure as a binding-level report error. The item
+/// mirror still landed and recorded success, but the enrichment walk's watermark did not advance,
+/// so the next sync retries it. WITHOUT surfacing, a persistent non-pause attested failure (a
+/// truncation bail, a mid-walk capability trip, a malformed 200) re-runs the doomed walk every tick
+/// with the binding recorded healthy and no operator signal. A pause is NOT surfaced here — it
+/// rides `paused_until_ms` and `record_pause`.
+fn attested_walk_error(
+    binding: &ResolvedTracker,
+    report: &MirrorBindingReport,
+) -> Option<PapertrailSyncError> {
+    report
+        .attested_error
+        .as_ref()
+        .map(|detail| binding_error(binding, "attested_walk_failed", detail.clone()))
 }
 
 fn binding_error(binding: &ResolvedTracker, status: &str, error: String) -> PapertrailSyncError {
@@ -404,7 +447,13 @@ fn completed_mirror_operation(
     let probe_only = report.probe_not_modified
         && report.stored_items == 0
         && report.stored_comments == 0
-        && report.pruned_items == 0;
+        && report.pruned_items == 0
+        // The attested-closers pass mutates `papertrail_closing_edges` / `papertrail_items` even
+        // when the item probe was not-modified (the first #702 run against an already-cached
+        // project). A run that stored provider edges (`attested_edges`), reaped a stale edge, or
+        // stamped a resolution / merge sha (`attested_writes`) is real mirror work, not a probe.
+        && report.attested_edges == 0
+        && report.attested_writes == 0;
     Some(if probe_only {
         SuccessfulOperation::Probe
     } else {
@@ -484,6 +533,7 @@ pub async fn sync_from_refs_with_progress<C: PapertrailClient>(
 }
 pub async fn sync_issue<C: PapertrailClient>(
     conn: &Connection,
+    root: &Path,
     issue_ref: &str,
     client: Option<&C>,
     offline: bool,
@@ -527,7 +577,11 @@ pub async fn sync_issue<C: PapertrailClient>(
         synced_items: sync.synced_items,
         bindings: Vec::new(),
         errors: sync.errors,
-        status: status(conn, ctx)?,
+        status: {
+            // The just-synced item may be the target an earlier commit ref's kind check needed.
+            sync::rederive_commit_closers(conn, root, ctx)?;
+            status(conn, ctx)?
+        },
     })
 }
 pub fn status(conn: &Connection, ctx: &PapertrailContext) -> anyhow::Result<PapertrailStatus> {
@@ -564,6 +618,7 @@ pub fn status(conn: &Connection, ctx: &PapertrailContext) -> anyhow::Result<Pape
                 full_walk_in_progress: health.continuation == MirrorContinuation::Full,
                 error_class,
                 error_detail,
+                attested_error: mirror::read_attested_error(conn, binding)?,
                 overdue,
                 failed,
             })
@@ -885,6 +940,9 @@ mod capability_tests {
             stored_items: 1,
             stored_comments: 0,
             pruned_items: 0,
+            attested_edges: 0,
+            attested_writes: 0,
+            attested_error: None,
             paused_until_ms: Some(42),
             pause_reason: Some("rate_limited".to_string()),
             completed_full_walk: false,
@@ -912,6 +970,9 @@ mod capability_tests {
             stored_items: 1,
             stored_comments: 0,
             pruned_items: 0,
+            attested_edges: 0,
+            attested_writes: 0,
+            attested_error: None,
             paused_until_ms: None,
             pause_reason: None,
             completed_full_walk: true,
@@ -931,6 +992,9 @@ mod capability_tests {
             stored_items: 0,
             stored_comments: 0,
             pruned_items: 0,
+            attested_edges: 0,
+            attested_writes: 0,
+            attested_error: None,
             paused_until_ms: None,
             pause_reason: None,
             completed_full_walk: false,
@@ -944,8 +1008,57 @@ mod capability_tests {
             completed_mirror_operation(&stored_comments, false),
             Some(SuccessfulOperation::IncrementalMirror)
         );
+        // Attested provider edges mutate papertrail_closing_edges even under a not-modified item
+        // probe — that is real mirror work, not a probe (#727 review).
+        let attested = MirrorBindingReport { attested_edges: 3, ..quiet.clone() };
+        assert_eq!(
+            completed_mirror_operation(&attested, false),
+            Some(SuccessfulOperation::IncrementalMirror)
+        );
+        // Non-insert attested mutations also count: a run that only reaped a stale replace-set edge
+        // or stamped a resolution / merge sha (attested_writes) moved content — not a probe.
+        let attested_writes = MirrorBindingReport { attested_writes: 2, ..quiet.clone() };
+        assert_eq!(
+            completed_mirror_operation(&attested_writes, false),
+            Some(SuccessfulOperation::IncrementalMirror)
+        );
         // An explicitly requested full walk is never downgraded by a quiet probe.
         assert_eq!(completed_mirror_operation(&quiet, true), Some(SuccessfulOperation::FullMirror));
+    }
+
+    #[test]
+    fn a_non_pause_attested_error_surfaces_as_a_binding_error_but_a_clean_walk_does_not() {
+        let binding = github(None);
+        let clean = MirrorBindingReport {
+            tracker: Tracker::Github,
+            project: "o/r".to_string(),
+            stored_items: 1,
+            stored_comments: 0,
+            pruned_items: 0,
+            attested_edges: 0,
+            attested_writes: 0,
+            attested_error: None,
+            paused_until_ms: None,
+            pause_reason: None,
+            completed_full_walk: false,
+            probe_not_modified: false,
+        };
+        assert!(
+            attested_walk_error(&binding, &clean).is_none(),
+            "a clean (or merely paused) walk surfaces no binding error",
+        );
+
+        let failed = MirrorBindingReport {
+            attested_error: Some(
+                "attested-closers walk ended early: capability unavailable mid-walk".to_string(),
+            ),
+            ..clean
+        };
+        let surfaced = attested_walk_error(&binding, &failed)
+            .expect("a non-pause attested failure surfaces as a binding error");
+        assert_eq!(surfaced.status, "attested_walk_failed");
+        assert_eq!(surfaced.project, "o/r");
+        assert!(surfaced.error.contains("capability unavailable"));
     }
 
     #[test]
@@ -1204,13 +1317,88 @@ mod scheduled_tests {
         for request in
             [AutosyncRequest::Evaluate, AutosyncRequest::Incremental, AutosyncRequest::Full]
         {
-            let report = block_on(sync_mirror_scheduled(&conn, &ctx, request)).unwrap();
+            let report =
+                block_on(sync_mirror_scheduled(&conn, Path::new("."), &ctx, request)).unwrap();
             assert!(report.bindings.is_empty(), "{request:?} must not dispatch");
             assert!(report.errors.is_empty());
             assert_eq!(report.synced_items, 0);
         }
         // The recent attempt is untouched — a skipped binding records nothing.
         assert_eq!(persisted(&conn, &binding).last_attempt_ms, Some(now - 1_000));
+        assert!(handle.join().unwrap().is_empty(), "no network request may be made");
+    }
+
+    /// A scheduled hook fires AFTER an index maintenance pass, so even when NOTHING is due the
+    /// no-work early return must still run the local commit-closer rederive — otherwise a stale
+    /// text/commit closer (its commit rebased/reloaded out of `git_commits`) lingers until some
+    /// later provider job happens to run. The rederive is surgical: it reaps only text/commit
+    /// edges and leaves provider edges intact (#727 review).
+    #[test]
+    fn a_no_work_scheduled_run_still_rederives_commit_closers() {
+        let conn = open_schema();
+        let (url, handle) = spawn_script_stub(Vec::new());
+        let binding = github_binding("o/r", &url);
+        let now = now_ms();
+        // A just-attempted binding is inside the minimum interval, so nothing dispatches — the
+        // no-work early-return path.
+        seed_health(&conn, &binding, &SeededHealth {
+            attempt: now - 1_000,
+            probe: now - 2 * HOUR_MS,
+            mirror: now - 2 * HOUR_MS,
+            full: now - 2 * HOUR_MS,
+        });
+
+        // A stale text/commit closer (no matching `git_commits` row / ref re-mints it) must be
+        // reaped; a provider edge for a different issue must survive the surgical rederive.
+        crate::store::store_closing_edge(&conn, Tracker::Github, &crate::ClosingEdge {
+            project: "o/r".to_string(),
+            issue_kind: ItemKind::Issue,
+            issue_key: "5".to_string(),
+            closer_kind: crate::CloserKind::Commit,
+            closer_key: "deadbeef".to_string(),
+            closer_commit: Some("deadbeef".to_string()),
+            source: crate::ClosingEdgeSource::Text,
+        })
+        .unwrap();
+        crate::store::store_closing_edge(&conn, Tracker::Github, &crate::ClosingEdge {
+            project: "o/r".to_string(),
+            issue_kind: ItemKind::Issue,
+            issue_key: "6".to_string(),
+            closer_kind: crate::CloserKind::Commit,
+            closer_key: "cafef00d".to_string(),
+            closer_commit: Some("cafef00d".to_string()),
+            source: crate::ClosingEdgeSource::Provider,
+        })
+        .unwrap();
+
+        let ctx =
+            PapertrailContext { trackers: vec![binding.clone()], ..PapertrailContext::default() };
+        let report =
+            block_on(sync_mirror_scheduled(&conn, Path::new("."), &ctx, AutosyncRequest::Evaluate))
+                .unwrap();
+        assert!(report.bindings.is_empty(), "nothing was due");
+
+        let reaped = crate::store::closing_edges_for_item(
+            &conn,
+            Tracker::Github,
+            "o/r",
+            ItemKind::Issue,
+            "5",
+        )
+        .unwrap();
+        assert!(
+            reaped.is_empty(),
+            "the no-work path rederives, reaping the stale text/commit closer"
+        );
+        let kept = crate::store::closing_edges_for_item(
+            &conn,
+            Tracker::Github,
+            "o/r",
+            ItemKind::Issue,
+            "6",
+        )
+        .unwrap();
+        assert_eq!(kept.len(), 1, "the surgical rederive leaves the provider edge intact");
         assert!(handle.join().unwrap().is_empty(), "no network request may be made");
     }
 
@@ -1232,7 +1420,8 @@ mod scheduled_tests {
             PapertrailContext { trackers: vec![binding.clone()], ..PapertrailContext::default() };
 
         let report =
-            block_on(sync_mirror_scheduled(&conn, &ctx, AutosyncRequest::Evaluate)).unwrap();
+            block_on(sync_mirror_scheduled(&conn, Path::new("."), &ctx, AutosyncRequest::Evaluate))
+                .unwrap();
         assert!(report.errors.is_empty(), "{:?}", report.errors);
         assert_eq!(report.bindings.len(), 1);
         assert!(report.bindings[0].probe_not_modified);
@@ -1262,7 +1451,8 @@ mod scheduled_tests {
             PapertrailContext { trackers: vec![binding.clone()], ..PapertrailContext::default() };
 
         let report =
-            block_on(sync_mirror_scheduled(&conn, &ctx, AutosyncRequest::Evaluate)).unwrap();
+            block_on(sync_mirror_scheduled(&conn, Path::new("."), &ctx, AutosyncRequest::Evaluate))
+                .unwrap();
         assert!(report.errors.is_empty(), "{:?}", report.errors);
         assert_eq!(report.bindings.len(), 1);
         assert!(report.bindings[0].completed_full_walk, "the backstop runs a FULL walk");
@@ -1284,8 +1474,13 @@ mod scheduled_tests {
             ..PapertrailContext::default()
         };
 
-        let report =
-            block_on(sync_mirror_scheduled(&conn, &ctx, AutosyncRequest::Incremental)).unwrap();
+        let report = block_on(sync_mirror_scheduled(
+            &conn,
+            Path::new("."),
+            &ctx,
+            AutosyncRequest::Incremental,
+        ))
+        .unwrap();
         assert_eq!(report.errors.len(), 1);
         assert_eq!(report.errors[0].project, "a/one");
         assert_eq!(report.errors[0].status, "failed");
@@ -1317,7 +1512,9 @@ mod scheduled_tests {
         let ctx =
             PapertrailContext { trackers: vec![binding.clone()], ..PapertrailContext::default() };
 
-        let report = block_on(sync_mirror_scheduled(&conn, &ctx, AutosyncRequest::Full)).unwrap();
+        let report =
+            block_on(sync_mirror_scheduled(&conn, Path::new("."), &ctx, AutosyncRequest::Full))
+                .unwrap();
         assert!(report.errors.is_empty(), "an automatic tick must not log the capability gap");
         assert!(report.bindings.is_empty());
         // No attempt is recorded either — the binding was never evaluated for dispatch.
@@ -1354,7 +1551,8 @@ mod scheduled_tests {
         };
 
         let report =
-            block_on(sync_mirror_scheduled(&conn, &ctx, AutosyncRequest::Evaluate)).unwrap();
+            block_on(sync_mirror_scheduled(&conn, Path::new("."), &ctx, AutosyncRequest::Evaluate))
+                .unwrap();
         assert!(
             report.errors.is_empty(),
             "serial dispatch would gate-timeout: {:?}",
@@ -1389,8 +1587,13 @@ mod scheduled_tests {
         let binding = github_binding("o/r", &first_url);
         let ctx =
             PapertrailContext { trackers: vec![binding.clone()], ..PapertrailContext::default() };
-        let report =
-            block_on(sync_mirror_scheduled(&conn, &ctx, AutosyncRequest::Incremental)).unwrap();
+        let report = block_on(sync_mirror_scheduled(
+            &conn,
+            Path::new("."),
+            &ctx,
+            AutosyncRequest::Incremental,
+        ))
+        .unwrap();
         assert_eq!(report.errors.len(), 1, "the interruption surfaces as a binding error");
         let interrupted = persisted(&conn, &binding);
         // The first walk of a fresh binding is a FULL walk; its interruption must stay a Full
@@ -1399,8 +1602,13 @@ mod scheduled_tests {
         assert_eq!(first_handle.join().unwrap().len(), 4);
 
         // The minimum attempt interval gates the immediate retry...
-        let gated =
-            block_on(sync_mirror_scheduled(&conn, &ctx, AutosyncRequest::Incremental)).unwrap();
+        let gated = block_on(sync_mirror_scheduled(
+            &conn,
+            Path::new("."),
+            &ctx,
+            AutosyncRequest::Incremental,
+        ))
+        .unwrap();
         assert!(gated.bindings.is_empty() && gated.errors.is_empty());
 
         // ...and once it elapses, the next dispatch resumes the descent from the persisted
@@ -1425,7 +1633,8 @@ mod scheduled_tests {
             ..PapertrailContext::default()
         };
         let report =
-            block_on(sync_mirror_scheduled(&conn, &ctx, AutosyncRequest::Evaluate)).unwrap();
+            block_on(sync_mirror_scheduled(&conn, Path::new("."), &ctx, AutosyncRequest::Evaluate))
+                .unwrap();
         assert!(report.errors.is_empty(), "{:?}", report.errors);
         assert_eq!(report.bindings.len(), 1);
         assert!(report.bindings[0].completed_full_walk, "the resumed descent completes the walk");
@@ -1475,8 +1684,13 @@ mod scheduled_tests {
         let ctx =
             PapertrailContext { trackers: vec![binding.clone()], ..PapertrailContext::default() };
 
-        let report =
-            block_on(sync_mirror_scheduled(&conn, &ctx, AutosyncRequest::Incremental)).unwrap();
+        let report = block_on(sync_mirror_scheduled(
+            &conn,
+            Path::new("."),
+            &ctx,
+            AutosyncRequest::Incremental,
+        ))
+        .unwrap();
         assert!(report.errors.is_empty(), "a pause is not a failure: {:?}", report.errors);
         assert_eq!(report.bindings.len(), 1);
         assert_eq!(report.bindings[0].paused_until_ms, Some(reset_epoch_s * 1000));
@@ -1493,7 +1707,8 @@ mod scheduled_tests {
         )
         .unwrap();
         for request in [AutosyncRequest::Evaluate, AutosyncRequest::Full] {
-            let gated = block_on(sync_mirror_scheduled(&conn, &ctx, request)).unwrap();
+            let gated =
+                block_on(sync_mirror_scheduled(&conn, Path::new("."), &ctx, request)).unwrap();
             assert!(
                 gated.bindings.is_empty() && gated.errors.is_empty(),
                 "{request:?} must stay gated by the retry horizon"
@@ -1543,7 +1758,8 @@ mod scheduled_tests {
             PapertrailContext { trackers: vec![binding.clone()], ..PapertrailContext::default() };
 
         let report =
-            block_on(sync_mirror_scheduled(&conn, &ctx, AutosyncRequest::Evaluate)).unwrap();
+            block_on(sync_mirror_scheduled(&conn, Path::new("."), &ctx, AutosyncRequest::Evaluate))
+                .unwrap();
         assert!(report.errors.is_empty(), "{:?}", report.errors);
         assert_eq!(report.bindings.len(), 1, "the filter change alone must dispatch");
         assert!(

--- a/crates/rag-rat-papertrail/src/github.rs
+++ b/crates/rag-rat-papertrail/src/github.rs
@@ -47,6 +47,10 @@ pub(crate) struct GitHubClient {
     api_origin: String,
     core: Transport,
     search: Transport,
+    graphql: Transport,
+    /// Capability memo: set after a probe-shaped failure (404/400 from a GHE build without the
+    /// GraphQL endpoint) so a dead endpoint is not re-tried on every page of every sync.
+    graphql_unavailable: std::sync::atomic::AtomicBool,
 }
 
 impl GitHubClient {
@@ -76,7 +80,18 @@ impl GitHubClient {
                 token.as_deref(),
             )
         };
-        Ok(Self { api_origin, core: transport("core")?, search: transport("search")? })
+        Ok(Self {
+            api_origin,
+            core: transport("core")?,
+            search: transport("search")?,
+            // GraphQL is metered on its OWN points budget — a distinct governor lane so REST
+            // and GraphQL response headers can never corrupt each other's remaining-quota view.
+            graphql: transport("graphql")?,
+            // GitHub's GraphQL endpoint ALWAYS requires a token (unlike its public REST reads),
+            // so a token-less public binding has no attested supply — start the lane disabled
+            // rather than failing an unauthenticated GraphQL call on every sync.
+            graphql_unavailable: std::sync::atomic::AtomicBool::new(token.is_none()),
+        })
     }
 
     fn endpoint(&self, path: &str) -> String {
@@ -114,6 +129,97 @@ impl GitHubClient {
         Ok(url.into())
     }
 }
+
+impl GitHubClient {
+    /// The GraphQL endpoint for this binding's API origin: cloud `api.github.com` serves
+    /// `/graphql`; a GitHub Enterprise origin (`…/api/v3`) serves `…/api/graphql`.
+    fn graphql_endpoint(&self) -> String {
+        match self.api_origin.strip_suffix("/api/v3") {
+            Some(base) => format!("{base}/api/graphql"),
+            None => format!("{}/graphql", self.api_origin),
+        }
+    }
+
+    /// One GraphQL request through the dedicated lane. `Ok(None)` = capability unavailable
+    /// (memoized after a probe-shaped 400/404/410 — GHE builds without the endpoint).
+    async fn graphql_query(&self, query: &str, variables: Value) -> anyhow::Result<Option<Value>> {
+        use std::sync::atomic::Ordering;
+        if self.graphql_unavailable.load(Ordering::Relaxed) {
+            return Ok(None);
+        }
+        let body = serde_json::json!({ "query": query, "variables": variables });
+        let response =
+            self.graphql.post_json(&self.graphql_endpoint(), &github_headers(), &body).await?;
+        // 400/404/410 = no endpoint (GHE build without GraphQL); 401/403 = auth the lane can't
+        // satisfy (token lacks scope, or SSO not authorized). All are capability-unavailable:
+        // memoize and degrade to the text tier rather than retrying the impossible call.
+        if matches!(response.status, 400 | 401 | 403 | 404 | 410) {
+            self.graphql_unavailable.store(true, Ordering::Relaxed);
+            return Ok(None);
+        }
+        ensure_success(response.status, &response.body)?;
+        let value: Value = serde_json::from_str(&response.body)?;
+        if let Some(errors) = value.get("errors").and_then(Value::as_array)
+            && !errors.is_empty()
+        {
+            // GitHub GraphQL signals a primary/secondary rate limit as HTTP 200 + an errors
+            // payload of `type: RATE_LIMITED` (the transport's status-based limiter can't see
+            // it). Map it to a transport PAUSE so `run_binding_job` honors the reset time instead
+            // of recording the binding healthy with a stale watermark. `x-ratelimit-reset` is
+            // epoch seconds; without it there is no resume time, so fall through to a plain error.
+            let rate_limited = errors.iter().any(|error| {
+                error["type"].as_str() == Some("RATE_LIMITED")
+                    || error["message"]
+                        .as_str()
+                        .is_some_and(|message| message.to_ascii_lowercase().contains("rate limit"))
+            });
+            if rate_limited
+                && let Some(reset_ms) = response
+                    .headers
+                    .get("x-ratelimit-reset")
+                    .and_then(|value| value.to_str().ok())
+                    .and_then(|value| value.parse::<i64>().ok())
+                    .map(|reset_s| reset_s.saturating_mul(1000))
+            {
+                return Err(anyhow::Error::new(transport::TransportError::Paused {
+                    resume_at_ms: reset_ms,
+                    reason: transport::PauseReason::RetryAfter,
+                }));
+            }
+            anyhow::bail!("GraphQL errors: {}", serde_json::to_string(errors)?);
+        }
+        Ok(Some(value["data"].clone()))
+    }
+}
+
+/// The two-phase attested-closers walk, encoded in the page cursor: `prs[:<after>]` then
+/// `issues[:<after>]`.
+fn attested_phase(cursor: Option<&str>) -> (&'static str, Option<String>) {
+    match cursor {
+        None | Some("prs") => ("prs", None),
+        Some("issues") => ("issues", None),
+        Some(other) => match other.split_once(':') {
+            Some(("prs", after)) => ("prs", Some(after.to_string())),
+            Some(("issues", after)) => ("issues", Some(after.to_string())),
+            _ => ("prs", None),
+        },
+    }
+}
+
+const ATTESTED_PRS_QUERY: &str =
+    "query($owner: String!, $name: String!, $after: String) { repository(owner: $owner, name: \
+     $name) { pullRequests(states: [MERGED, CLOSED], first: 50, after: $after, orderBy: {field: \
+     UPDATED_AT, direction: DESC}) { pageInfo { hasNextPage endCursor } nodes { number updatedAt \
+     mergedAt mergeCommit { oid } closingIssuesReferences(first: 100) { pageInfo { hasNextPage } \
+     nodes { number repository { nameWithOwner } } } } } } }";
+
+const ATTESTED_ISSUES_QUERY: &str =
+    "query($owner: String!, $name: String!, $after: String) { repository(owner: $owner, name: \
+     $name) { issues(states: [CLOSED], first: 50, after: $after, orderBy: {field: UPDATED_AT, \
+     direction: DESC}) { pageInfo { hasNextPage endCursor } nodes { number updatedAt stateReason \
+     timelineItems(itemTypes: [CLOSED_EVENT], last: 1) { nodes { ... on ClosedEvent { closer { \
+     __typename ... on Commit { oid } ... on PullRequest { number mergeCommit { oid } repository \
+     { nameWithOwner } } } } } } } } } }";
 
 impl PapertrailClient for GitHubClient {
     fn comment_streams(&self) -> &'static [&'static str] {
@@ -461,6 +567,204 @@ impl PapertrailClient for GitHubClient {
             not_modified: false,
         })
     }
+    /// Provider-attested closure walk (#702 stage 2), two phases per project:
+    /// merged/closed PRs (`closingIssuesReferences` + the ATTESTED merge commit) then closed
+    /// issues (`ClosedEvent.closer` — direct-by-commit and UI-linked PR closures the
+    /// description's text never carried). ~1 rate point per 100 PRs, on the dedicated lane.
+    async fn attested_closers_page(
+        &self,
+        project: &str,
+        cursor: Option<&str>,
+        since: Option<&str>,
+    ) -> anyhow::Result<Option<AttestedClosersPage>> {
+        validate_github_project(project)?;
+        let (owner, name) = project
+            .split_once('/')
+            .ok_or_else(|| anyhow::anyhow!("GitHub project is owner/repo"))?;
+        let (phase, after) = attested_phase(cursor);
+        let query = if phase == "prs" { ATTESTED_PRS_QUERY } else { ATTESTED_ISSUES_QUERY };
+        let variables = serde_json::json!({ "owner": owner, "name": name, "after": after });
+        let Some(data) = self.graphql_query(query, variables).await? else {
+            return Ok(None);
+        };
+        let connection =
+            &data["repository"][if phase == "prs" { "pullRequests" } else { "issues" }];
+        parse_attested_page(connection, phase, project, after.as_deref(), since).map(Some)
+    }
+}
+
+/// Parse ONE already-fetched GraphQL connection page into an [`AttestedClosersPage`]. Pure over
+/// the JSON — no transport — so the producer's evidence rules are unit-testable directly (the
+/// `PapertrailClient` stubs bypass this function entirely, so its bugs are invisible to them).
+fn parse_attested_page(
+    connection: &Value,
+    phase: &str,
+    project: &str,
+    after: Option<&str>,
+    since: Option<&str>,
+) -> anyhow::Result<AttestedClosersPage> {
+    let mut page = AttestedClosersPage::default();
+    let mut reached_watermark = false;
+    for node in connection["nodes"].as_array().into_iter().flatten() {
+        let number = node["number"].as_u64().unwrap_or_default().to_string();
+        let updated_at = node["updatedAt"].as_str().unwrap_or_default();
+        if let Some(since) = since
+            && !updated_at.is_empty()
+            && updated_at < since
+        {
+            reached_watermark = true;
+            break;
+        }
+        if page.frontier.is_none() && after.is_none() && !updated_at.is_empty() {
+            // First page of THIS phase: the phase's own frontier. The mirror keeps the
+            // conservative MINIMUM across phases, so neither stream can skip updates.
+            page.frontier = Some(updated_at.to_string());
+        }
+        if phase == "prs" {
+            // MERGED-only: a closed-UNMERGED PR closes nothing, yet GitHub still lists its
+            // `closingIssuesReferences` — minting an edge for it would assert a false closer
+            // (the same trap the text tier and the item store guard against). An unmerged PR is
+            // a pure no-op here: it never had a provider edge of ours to replace, either.
+            let Some(merged_at) = node["mergedAt"].as_str() else {
+                continue;
+            };
+            let _ = merged_at;
+            let merge_commit =
+                node.pointer("/mergeCommit/oid").and_then(Value::as_str).map(str::to_string);
+            // The PR phase CREATES keyword edges but does NOT reap: reaping is issue-keyed (see
+            // `replaced_issue_closers`), because a closer-keyed replace-set would clobber the
+            // issue-phase UI-linked rows this PR's `closingIssuesReferences` never lists.
+            // No silent caps: a PR closing >100 issues is pathological, but its tail must surface
+            // as an explicit gap, not vanish past an unpaginated nested connection.
+            if node.pointer("/closingIssuesReferences/pageInfo/hasNextPage")
+                == Some(&Value::Bool(true))
+            {
+                anyhow::bail!(
+                    "PR #{number} carries more than 100 closing references; the nested connection \
+                     is not paginated"
+                );
+            }
+            for closed in node
+                .pointer("/closingIssuesReferences/nodes")
+                .and_then(Value::as_array)
+                .into_iter()
+                .flatten()
+            {
+                let issue_key = closed["number"].as_u64().unwrap_or_default().to_string();
+                let issue_project = closed
+                    .pointer("/repository/nameWithOwner")
+                    .and_then(Value::as_str)
+                    .unwrap_or(project);
+                // Cross-repository closures are SKIPPED: `closer_key` is same-project by the
+                // schema contract, so a bare PR number under the ISSUE's project would name an
+                // unrelated item. (A both-projects edge shape can lift this later.) GitHub repo
+                // names are CASE-INSENSITIVE: the binding may carry `owner/repo` while GraphQL
+                // returns the canonical `Owner/Repo`, so an exact compare would wrongly treat the
+                // repo's OWN issues as cross-repo and drop every edge — fold ASCII case.
+                if !issue_project.eq_ignore_ascii_case(project) {
+                    continue;
+                }
+                page.edges.push(ClosingEdge {
+                    project: project.to_string(),
+                    issue_kind: ItemKind::Issue,
+                    issue_key,
+                    closer_kind: CloserKind::ChangeRequest,
+                    closer_key: number.clone(),
+                    closer_commit: merge_commit.clone(),
+                    source: ClosingEdgeSource::Provider,
+                });
+            }
+            if let Some(sha) = merge_commit {
+                page.item_updates.push(AttestedItemUpdate {
+                    item_kind: ItemKind::ChangeRequest,
+                    item_key: number.clone(),
+                    resolution: None,
+                    merge_commit_sha: Some(sha),
+                });
+            }
+        } else {
+            if let Some(resolution) = parse::resolution_from_state_reason(
+                node["stateReason"]
+                    .as_str()
+                    .map(|reason| {
+                        // GraphQL enum tokens are UPPER_SNAKE; the REST mapper speaks lowercase.
+                        reason.to_ascii_lowercase()
+                    })
+                    .as_deref(),
+            ) {
+                page.item_updates.push(AttestedItemUpdate {
+                    item_kind: ItemKind::Issue,
+                    item_key: number.clone(),
+                    resolution: Some(resolution),
+                    merge_commit_sha: None,
+                });
+            }
+            page.replaced_issue_closers.push(number.clone());
+            let closer = node
+                .pointer("/timelineItems/nodes")
+                .and_then(Value::as_array)
+                .and_then(|nodes| nodes.last())
+                .map(|event| event["closer"].clone())
+                .unwrap_or(Value::Null);
+            match closer["__typename"].as_str() {
+                Some("Commit") =>
+                    if let Some(oid) = closer["oid"].as_str() {
+                        page.edges.push(ClosingEdge {
+                            project: project.to_string(),
+                            issue_kind: ItemKind::Issue,
+                            issue_key: number.clone(),
+                            closer_kind: CloserKind::Commit,
+                            closer_key: oid.to_string(),
+                            closer_commit: Some(oid.to_string()),
+                            source: ClosingEdgeSource::Provider,
+                        });
+                    },
+                Some("PullRequest") => {
+                    // Cross-repository PR closers are SKIPPED, symmetric to the PR phase:
+                    // `closer_key` is same-project, so a bare PR number under the ISSUE's project
+                    // would name an unrelated item. Case-insensitive like the PR phase — GitHub's
+                    // canonical `nameWithOwner` casing may differ from the binding's project.
+                    let closer_repo = closer
+                        .pointer("/repository/nameWithOwner")
+                        .and_then(Value::as_str)
+                        .unwrap_or(project);
+                    if let Some(pr) = closer["number"].as_u64()
+                        && closer_repo.eq_ignore_ascii_case(project)
+                    {
+                        page.edges.push(ClosingEdge {
+                            project: project.to_string(),
+                            issue_kind: ItemKind::Issue,
+                            issue_key: number.clone(),
+                            closer_kind: CloserKind::ChangeRequest,
+                            closer_key: pr.to_string(),
+                            // Preserve the attested merge commit for a UI-linked PR closure that
+                            // surfaces ONLY through ClosedEvent (no keyword-derived edge from the
+                            // PR phase) — GitHub exposes the closer PR's mergeCommit here.
+                            closer_commit: closer
+                                .pointer("/mergeCommit/oid")
+                                .and_then(Value::as_str)
+                                .map(str::to_string),
+                            source: ClosingEdgeSource::Provider,
+                        });
+                    }
+                },
+                _ => {},
+            }
+        }
+    }
+    let has_next = connection.pointer("/pageInfo/hasNextPage").and_then(Value::as_bool)
+        == Some(true)
+        && !reached_watermark;
+    let end_cursor =
+        connection.pointer("/pageInfo/endCursor").and_then(Value::as_str).unwrap_or_default();
+    page.next = if has_next {
+        Some(format!("{phase}:{end_cursor}"))
+    } else if phase == "prs" {
+        Some("issues".to_string())
+    } else {
+        None
+    };
+    Ok(page)
 }
 
 fn github_headers() -> Vec<(&'static str, &'static str)> {
@@ -1172,4 +1476,215 @@ mod tests {
     }
 
     const INITIAL_BOUNDARY: &str = "2970-12-31T23:59:59Z";
+    // Direct producer tests over hand-built GraphQL JSON — the `PapertrailClient` stubs bypass
+    // `parse_attested_page`, so its evidence rules (merged gate, cross-repo skip, CR replace-set,
+    // truncation bail) are ONLY covered here.
+    fn prs_connection(nodes: Value) -> Value {
+        serde_json::json!({ "pageInfo": { "hasNextPage": false, "endCursor": "c" }, "nodes": nodes })
+    }
+
+    #[test]
+    fn attested_prs_merged_mint_edge_and_update() {
+        let conn = prs_connection(serde_json::json!([{
+            "number": 9, "updatedAt": "2026-01-05T00:00:00Z", "mergedAt": "2026-01-05T00:00:00Z",
+            "mergeCommit": { "oid": "abc123" },
+            "closingIssuesReferences": { "pageInfo": { "hasNextPage": false },
+                "nodes": [{ "number": 5, "repository": { "nameWithOwner": "o/r" } }] }
+        }]));
+        let page = parse_attested_page(&conn, "prs", "o/r", None, None).unwrap();
+        assert_eq!(page.edges.len(), 1);
+        assert_eq!(page.edges[0].issue_key, "5");
+        assert_eq!(page.edges[0].closer_key, "9");
+        assert_eq!(page.edges[0].closer_commit.as_deref(), Some("abc123"));
+        // The PR phase mints keyword edges but owns NO replace-set — reaping is issue-keyed.
+        assert!(page.replaced_issue_closers.is_empty(), "the PR phase never reaps");
+        assert_eq!(page.item_updates.len(), 1);
+    }
+
+    #[test]
+    fn attested_prs_closed_unmerged_mints_nothing() {
+        let conn = prs_connection(serde_json::json!([{
+            "number": 9, "updatedAt": "2026-01-05T00:00:00Z", "mergedAt": Value::Null,
+            "mergeCommit": Value::Null,
+            "closingIssuesReferences": { "pageInfo": { "hasNextPage": false },
+                "nodes": [{ "number": 5, "repository": { "nameWithOwner": "o/r" } }] }
+        }]));
+        let page = parse_attested_page(&conn, "prs", "o/r", None, None).unwrap();
+        assert!(page.edges.is_empty(), "a closed-unmerged PR closes nothing");
+        assert!(page.item_updates.is_empty());
+    }
+
+    #[test]
+    fn attested_prs_cross_repo_reference_is_skipped() {
+        let conn = prs_connection(serde_json::json!([{
+            "number": 9, "updatedAt": "2026-01-05T00:00:00Z", "mergedAt": "2026-01-05T00:00:00Z",
+            "mergeCommit": { "oid": "abc" },
+            "closingIssuesReferences": { "pageInfo": { "hasNextPage": false }, "nodes": [
+                { "number": 5, "repository": { "nameWithOwner": "o/other" } },
+                { "number": 7, "repository": { "nameWithOwner": "o/r" } }
+            ] }
+        }]));
+        let page = parse_attested_page(&conn, "prs", "o/r", None, None).unwrap();
+        assert_eq!(page.edges.len(), 1, "the cross-repo o/other#5 is skipped");
+        assert_eq!(page.edges[0].issue_key, "7");
+        assert_eq!(page.edges[0].project, "o/r");
+    }
+
+    #[test]
+    fn attested_prs_truncated_nested_connection_fails_loudly() {
+        let conn = prs_connection(serde_json::json!([{
+            "number": 9, "updatedAt": "2026-01-05T00:00:00Z", "mergedAt": "2026-01-05T00:00:00Z",
+            "mergeCommit": { "oid": "abc" },
+            "closingIssuesReferences": { "pageInfo": { "hasNextPage": true }, "nodes": [] }
+        }]));
+        let err = parse_attested_page(&conn, "prs", "o/r", None, None).unwrap_err();
+        assert!(err.to_string().contains("closing references"), "silent truncation must bail");
+    }
+
+    #[test]
+    fn attested_issues_commit_and_pr_closers_and_resolution() {
+        let conn = serde_json::json!({ "pageInfo": { "hasNextPage": false, "endCursor": "c" },
+            "nodes": [
+                { "number": 5, "updatedAt": "2026-01-05T00:00:00Z", "stateReason": "COMPLETED",
+                  "timelineItems": { "nodes": [{ "closer": { "__typename": "Commit", "oid": "sha1" } }] } },
+                { "number": 6, "updatedAt": "2026-01-04T00:00:00Z", "stateReason": "NOT_PLANNED",
+                  "timelineItems": { "nodes": [{ "closer": { "__typename": "PullRequest", "number": 11 } }] } }
+            ] });
+        let page = parse_attested_page(&conn, "issues", "o/r", None, None).unwrap();
+        assert_eq!(page.replaced_issue_closers, vec!["5".to_string(), "6".to_string()]);
+        let commit_edge = page.edges.iter().find(|e| e.issue_key == "5").unwrap();
+        assert_eq!(commit_edge.closer_kind, CloserKind::Commit);
+        assert_eq!(commit_edge.closer_key, "sha1");
+        let pr_edge = page.edges.iter().find(|e| e.issue_key == "6").unwrap();
+        assert_eq!(pr_edge.closer_kind, CloserKind::ChangeRequest);
+        assert_eq!(pr_edge.closer_key, "11");
+        assert_eq!(page.item_updates.iter().filter(|u| u.resolution.is_some()).count(), 2);
+    }
+
+    #[test]
+    fn attested_since_watermark_cuts_the_scan_and_advances_the_phase() {
+        let conn = prs_connection(serde_json::json!([
+            { "number": 9, "updatedAt": "2026-01-05T00:00:00Z", "mergedAt": "2026-01-05T00:00:00Z",
+              "mergeCommit": { "oid": "a" }, "closingIssuesReferences": { "pageInfo": { "hasNextPage": false }, "nodes": [] } },
+            { "number": 8, "updatedAt": "2026-01-01T00:00:00Z", "mergedAt": "2026-01-01T00:00:00Z",
+              "mergeCommit": { "oid": "b" }, "closingIssuesReferences": { "pageInfo": { "hasNextPage": false }, "nodes": [] } }
+        ]));
+        // Watermark cuts at the second (older) node; the phase still advances to issues.
+        let page =
+            parse_attested_page(&conn, "prs", "o/r", None, Some("2026-01-03T00:00:00Z")).unwrap();
+        // Only the fresh PR #9 is processed (its merge sha becomes an item update); #8 is cut
+        // before it is reached.
+        assert_eq!(page.item_updates.len(), 1, "only the fresh PR is processed past the watermark");
+        assert_eq!(page.item_updates[0].item_key, "9");
+        assert_eq!(page.next.as_deref(), Some("issues"), "watermark cut still advances the phase");
+    }
+    #[test]
+    fn attested_issue_cross_repo_pr_closer_is_skipped() {
+        let conn = serde_json::json!({ "pageInfo": { "hasNextPage": false, "endCursor": "c" },
+            "nodes": [{ "number": 5, "updatedAt": "2026-01-05T00:00:00Z", "stateReason": "COMPLETED",
+                "timelineItems": { "nodes": [{ "closer": { "__typename": "PullRequest", "number": 9,
+                    "repository": { "nameWithOwner": "other/repo" } } }] } }] });
+        let page = parse_attested_page(&conn, "issues", "o/r", None, None).unwrap();
+        assert!(
+            page.edges.is_empty(),
+            "a PR closer in another repo names a bare number under the wrong project — skip it",
+        );
+        // The issue is still replace-set (its whole provider closer set is refreshed regardless).
+        assert_eq!(page.replaced_issue_closers, vec!["5".to_string()]);
+    }
+
+    /// GitHub repo names are CASE-INSENSITIVE: a binding `o/r` whose GraphQL response echoes the
+    /// canonical `O/R` in `nameWithOwner` must still mint the SAME-repo edge in both phases — an
+    /// exact compare would drop every attested edge for a mis-cased binding.
+    #[test]
+    fn attested_same_repo_name_matches_case_insensitively_in_both_phases() {
+        let prs = prs_connection(serde_json::json!([{
+            "number": 9, "updatedAt": "2026-01-05T00:00:00Z", "mergedAt": "2026-01-05T00:00:00Z",
+            "mergeCommit": { "oid": "abc" },
+            "closingIssuesReferences": { "pageInfo": { "hasNextPage": false },
+                "nodes": [{ "number": 5, "repository": { "nameWithOwner": "O/R" } }] }
+        }]));
+        let pr_page = parse_attested_page(&prs, "prs", "o/r", None, None).unwrap();
+        assert_eq!(pr_page.edges.len(), 1, "canonical-cased same repo is not cross-repo");
+        assert_eq!(pr_page.edges[0].issue_key, "5");
+
+        let issues = serde_json::json!({ "pageInfo": { "hasNextPage": false, "endCursor": "c" },
+            "nodes": [{ "number": 5, "updatedAt": "2026-01-05T00:00:00Z", "stateReason": "COMPLETED",
+                "timelineItems": { "nodes": [{ "closer": { "__typename": "PullRequest", "number": 9,
+                    "repository": { "nameWithOwner": "O/R" } } }] } }] });
+        let issue_page = parse_attested_page(&issues, "issues", "o/r", None, None).unwrap();
+        assert_eq!(issue_page.edges.len(), 1, "the issue-phase PR closer is same-repo too");
+        assert_eq!(issue_page.edges[0].closer_key, "9");
+    }
+    #[test]
+    fn a_token_less_binding_has_no_attested_supply_and_never_calls_graphql() {
+        // GitHub's GraphQL always requires a token; a public token-less binding must degrade to
+        // the text tier at construction, not fail an unauthenticated call every sync. `base` is
+        // unreachable — reaching it (a real POST) would error, so `Ok(None)` proves the memo
+        // short-circuited before any request.
+        let registry = GovernorRegistry::default();
+        let client = GitHubClient::new(
+            &binding("http://127.0.0.1:1".to_string()),
+            &registry,
+            TransportOptions::default(),
+        )
+        .unwrap();
+        let page = block_on(client.attested_closers_page("o/r", None, None)).unwrap();
+        assert!(page.is_none(), "no token ⇒ no attested supply, no GraphQL call");
+    }
+    #[test]
+    fn attested_issue_pr_closer_carries_the_merge_commit() {
+        let conn = serde_json::json!({ "pageInfo": { "hasNextPage": false, "endCursor": "c" },
+            "nodes": [{ "number": 5, "updatedAt": "2026-01-05T00:00:00Z", "stateReason": "COMPLETED",
+                "timelineItems": { "nodes": [{ "closer": { "__typename": "PullRequest", "number": 9,
+                    "mergeCommit": { "oid": "sha9" },
+                    "repository": { "nameWithOwner": "o/r" } } }] } }] });
+        let page = parse_attested_page(&conn, "issues", "o/r", None, None).unwrap();
+        let edge = page.edges.iter().find(|e| e.issue_key == "5").unwrap();
+        assert_eq!(edge.closer_kind, CloserKind::ChangeRequest);
+        assert_eq!(edge.closer_key, "9");
+        assert_eq!(
+            edge.closer_commit.as_deref(),
+            Some("sha9"),
+            "UI-linked PR closer keeps its merge commit"
+        );
+    }
+
+    #[test]
+    fn a_graphql_200_rate_limit_becomes_a_transport_pause() {
+        // GitHub GraphQL signals a rate limit as HTTP 200 + errors[RATE_LIMITED] + reset header;
+        // it must surface as a PAUSE so the scheduler honors the reset, not a swallowed error.
+        let mut limited = StubResponse::ok(
+            r#"{"data":null,"errors":[{"type":"RATE_LIMITED","message":"API rate limit exceeded"}]}"#,
+        );
+        limited.headers.push(("x-ratelimit-reset".to_string(), "1900000000".to_string()));
+        let (base, handle) = spawn_script_stub(vec![limited]);
+        let mut tracker = binding(base);
+        tracker.auth =
+            Some(rag_rat_base::config::TrackerAuth::TokenCommand("printf token".to_string()));
+        let registry = GovernorRegistry::default();
+        let client = GitHubClient::new(&tracker, &registry, TransportOptions::default()).unwrap();
+        let error = block_on(client.attested_closers_page("o/r", None, None)).unwrap_err();
+        let paused = error
+            .chain()
+            .find_map(|cause| cause.downcast_ref::<transport::TransportError>())
+            .and_then(|e| match e {
+                transport::TransportError::Paused { resume_at_ms, .. } => Some(*resume_at_ms),
+                _ => None,
+            });
+        assert_eq!(paused, Some(1_900_000_000_000), "the reset epoch becomes the resume time (ms)");
+        assert_eq!(handle.join().unwrap().len(), 1);
+    }
+    #[test]
+    fn attested_queries_request_every_field_the_parser_reads() {
+        // GUARD against the silent query/parser drift that bit this lane twice: the parser reads
+        // these paths, so the query strings MUST fetch them, or an edit that reflows the query
+        // silently drops a field and the parser only ever sees `None`.
+        for field in ["mergeCommit", "closingIssuesReferences", "hasNextPage", "mergedAt"] {
+            assert!(ATTESTED_PRS_QUERY.contains(field), "PRs query must request `{field}`");
+        }
+        for field in ["mergeCommit", "stateReason", "ClosedEvent", "PullRequest", "Commit"] {
+            assert!(ATTESTED_ISSUES_QUERY.contains(field), "issues query must request `{field}`");
+        }
+    }
 }

--- a/crates/rag-rat-papertrail/src/lib.rs
+++ b/crates/rag-rat-papertrail/src/lib.rs
@@ -144,6 +144,11 @@ pub struct PapertrailBindingStatus {
     pub full_walk_in_progress: bool,
     pub error_class: Option<PapertrailErrorClass>,
     pub error_detail: Option<String>,
+    /// The last HARD attested-closers walk failure, if any — the provider-closer ENRICHMENT lane
+    /// (#702 stage 2). Independent of `error_class`/`failed`: the item mirror can be healthy while
+    /// this lane fails every tick with a stalled watermark. `None` once a clean attested walk
+    /// runs.
+    pub attested_error: Option<String>,
     pub overdue: bool,
     pub failed: bool,
 }
@@ -454,6 +459,36 @@ impl ClosingEdgeSource {
     }
 }
 
+/// One page of PROVIDER-ATTESTED closure data (#702 stage 2): closing edges the tracker itself
+/// asserts (GraphQL closing references, closed-event closers) plus per-item outcome updates.
+#[derive(Debug, Clone, Default)]
+pub struct AttestedClosersPage {
+    pub edges: Vec<ClosingEdge>,
+    pub item_updates: Vec<AttestedItemUpdate>,
+    /// Issues whose ClosedEvent closer was re-read this page. Reaping is ISSUE-KEYED: an issue has
+    /// exactly ONE authoritative closer (its last ClosedEvent), so re-reading it lets the walk
+    /// replace EVERY provider closer edge targeting it (commit AND change-request), then reinsert
+    /// the current closer. This is why there is no closer-keyed (per-PR) replace-set: a PR closes
+    /// many issues, so reaping the PR's outgoing edges would clobber UI-linked rows the PR phase
+    /// (`closingIssuesReferences`) never sees — those live only on the issue's ClosedEvent.
+    pub replaced_issue_closers: Vec<String>,
+    /// Opaque continuation for the NEXT page; `None` when the walk is complete.
+    pub next: Option<String>,
+    /// The newest `updated_at` seen on the FIRST page — the next walk's `since` watermark once
+    /// this walk completes.
+    pub frontier: Option<String>,
+}
+
+/// A provider-attested outcome update for a CACHED item (never creates rows).
+#[derive(Debug, Clone)]
+pub struct AttestedItemUpdate {
+    pub item_kind: ItemKind,
+    pub item_key: String,
+    pub resolution: Option<ItemResolution>,
+    /// INVARIANT: applied only to items the store already normalized as merged.
+    pub merge_commit_sha: Option<String>,
+}
+
 /// One issue↔closer edge (`papertrail_closing_edges`). First-class — NOT a `papertrail_refs`
 /// row: the ref layer's identity coalesces on `source_text` and its contract is
 /// annotation-only, while a closing edge's identity is the (issue, closer) pair and its trust
@@ -689,6 +724,18 @@ pub trait PapertrailClient {
         project: &str,
         probe: &FreshnessProbe,
     ) -> anyhow::Result<FreshnessResult>;
+    /// One page of provider-attested closure data for `project`, `Ok(None)` when this provider
+    /// has no attested supply (or its capability probe failed — e.g. a GHE build without the
+    /// GraphQL endpoint). `cursor` is the previous page's `next`; `since` is the completed-walk
+    /// watermark — implementations stop paging once nodes fall behind it.
+    async fn attested_closers_page(
+        &self,
+        _project: &str,
+        _cursor: Option<&str>,
+        _since: Option<&str>,
+    ) -> anyhow::Result<Option<AttestedClosersPage>> {
+        Ok(None)
+    }
 }
 
 /// Drive a papertrail future to completion from the synchronous call paths (CLI, maintenance).

--- a/crates/rag-rat-papertrail/src/mirror.rs
+++ b/crates/rag-rat-papertrail/src/mirror.rs
@@ -121,6 +121,16 @@ pub struct MirrorBindingReport {
     /// this classifies the run as a successful PROBE — advancing probe freshness only, never the
     /// mirror or full-walk timestamps.
     pub probe_not_modified: bool,
+    /// Provider-attested closing edges stored by the attested-closers walk (#702 stage 2).
+    pub attested_edges: usize,
+    /// Rows the attested-closers walk MUTATED besides fresh edge inserts (counted separately in
+    /// `attested_edges`): per-closer replace-set DELETEs and item resolution / merge-sha UPDATEs.
+    /// A run that only reaped a stale edge or stamped a resolution moved content — this keeps such
+    /// a run from being misclassified as a probe when the item feed was not-modified.
+    pub attested_writes: usize,
+    /// The attested walk's failure, when it had one — EXPLICIT but non-fatal: the mirror data
+    /// this run landed is kept, the watermark does not advance, and the next sync retries.
+    pub attested_error: Option<String>,
 }
 
 pub(crate) async fn mirror_binding<C: PapertrailClient>(
@@ -176,6 +186,9 @@ pub(crate) async fn mirror_binding<C: PapertrailClient>(
         stored_items: 0,
         stored_comments: 0,
         pruned_items: 0,
+        attested_edges: 0,
+        attested_writes: 0,
+        attested_error: None,
         paused_until_ms: None,
         pause_reason: None,
         completed_full_walk: false,
@@ -183,6 +196,10 @@ pub(crate) async fn mirror_binding<C: PapertrailClient>(
     };
     if filter_changed {
         report.pruned_items += prune_unmatched(conn, binding)?;
+        // A widened filter caches newly-in-scope closed issues; a full-rewalk already ran the
+        // same clear above. (Narrowing is handled by edge deletion on prune, but clearing here
+        // covers both directions uniformly.) See `clear_attested_watermark` for the invariant.
+        clear_attested_watermark(conn, binding)?;
         save_cursor(conn, binding, &cursor, false)?;
     }
 
@@ -190,6 +207,30 @@ pub(crate) async fn mirror_binding<C: PapertrailClient>(
         mirror_binding_inner(conn, binding, trackers, client, &mut cursor, &mut report).await;
     match result {
         Ok(()) => {
+            // Stage 2 (#702): the attested-closers walk runs after the item/comment walk so its
+            // per-item outcome updates land on freshly-cached rows. Its failure is non-fatal —
+            // the walk is an enrichment over data the mirror already landed and its watermark
+            // stays put — BUT a rate-limit/pass-budget PAUSE must still surface as a pause, or
+            // `run_binding_job` records the binding healthy and clears retry state while the
+            // attested watermark is stale. Propagate the resume time; fold any other error into
+            // the explicit non-fatal `attested_error`.
+            if let Err(error) = sync_attested_closers(conn, binding, client, &mut report).await {
+                match pause(&error) {
+                    Some((resume_at_ms, reason)) => {
+                        report.paused_until_ms = Some(resume_at_ms);
+                        report.pause_reason = Some(reason.as_str().to_string());
+                    },
+                    None => report.attested_error = Some(error.to_string()),
+                }
+            }
+            // Persist the attested-walk health for the durable status snapshot: a HARD failure is
+            // stored, a clean completion clears it. A pause (retry clock already set) leaves the
+            // prior state untouched.
+            if let Some(detail) = &report.attested_error {
+                set_attested_error(conn, binding, detail)?;
+            } else if report.paused_until_ms.is_none() {
+                clear_attested_error(conn, binding)?;
+            }
             report.completed_full_walk = cursor.backfill_done
                 && (!had_completed_backfill
                     || starting_full_rewalk
@@ -884,6 +925,9 @@ fn reset_for_full_rewalk(
     cursor.backfill_processed_keys.clear();
     cursor.full_rewalk = true;
     reset_full_seen(conn, binding)?;
+    // A full rewalk re-caches every closed issue; clear the attested watermark so their
+    // provider closers get re-fetched from the top (the twin of the filter-change reset).
+    clear_attested_watermark(conn, binding)?;
     save_cursor(conn, binding, cursor, false)
 }
 
@@ -947,6 +991,227 @@ fn replace_tags(
                 repo_id
             ],
         )?;
+    }
+    Ok(())
+}
+
+/// A per-binding `index_meta` key for the attested-closers lane. `kind` is a stable machine token
+/// (`since` — the walk watermark; `error` — the last hard failure detail). Repo-scoped so a
+/// consolidated multi-repo DB keeps each binding's lane state separate.
+fn attested_meta_key(
+    binding: &ResolvedTracker,
+    conn: &Connection,
+    kind: &str,
+) -> anyhow::Result<String> {
+    let repo_id = rag_rat_db::schema::active_repo_id(conn)?;
+    Ok(format!(
+        "papertrail_attested_closers_{kind}:{repo_id}:{}:{}",
+        binding.provider.as_db_str(),
+        binding.project
+    ))
+}
+
+/// The `index_meta` key for a binding's attested-closers watermark — shared by the walk (read/
+/// stamp) and the reset seams so they can never drift.
+fn attested_since_key(binding: &ResolvedTracker, conn: &Connection) -> anyhow::Result<String> {
+    attested_meta_key(binding, conn, "since")
+}
+
+/// Persist a HARD attested-walk failure so it stays visible in `papertrail_sync_status`. This is
+/// SEPARATE from the item-mirror health (`error_class`/`error_detail`, owned by `record_success` /
+/// `record_failure`): the item walk can succeed — clearing its own error state and advancing
+/// freshness — while the enrichment walk fails every tick with a stale watermark. Without this the
+/// failure is invisible in the durable status snapshot. Detail is length-capped and stripped of
+/// control chars. A pause is NOT persisted here (it rides the retry clock); a clean walk clears it.
+pub(crate) fn set_attested_error(
+    conn: &Connection,
+    binding: &ResolvedTracker,
+    detail: &str,
+) -> anyhow::Result<()> {
+    let key = attested_meta_key(binding, conn, "error")?;
+    let sanitized: String =
+        detail.chars().map(|ch| if ch.is_control() { ' ' } else { ch }).take(512).collect();
+    rag_rat_db::meta::set_meta(conn, &key, sanitized.trim())
+}
+
+/// Clear a binding's persisted attested-walk failure — a clean completed attested walk.
+pub(crate) fn clear_attested_error(
+    conn: &Connection,
+    binding: &ResolvedTracker,
+) -> anyhow::Result<()> {
+    let key = attested_meta_key(binding, conn, "error")?;
+    rag_rat_db::meta::delete_meta(conn, &key)
+}
+
+/// Read a binding's persisted attested-walk failure, for the status snapshot.
+pub(crate) fn read_attested_error(
+    conn: &Connection,
+    binding: &ResolvedTracker,
+) -> anyhow::Result<Option<String>> {
+    let key = attested_meta_key(binding, conn, "error")?;
+    rag_rat_db::meta::read_meta(conn, &key)
+}
+
+/// Clear a binding's attested-closers `since` watermark. The INVARIANT: EVERY seam that forces a
+/// full item re-walk (a WIDENED filter, or a full rewalk) must call this. Such a re-walk re-caches
+/// closed issues whose provider-attested closers may PREDATE the stored `since`; a reused watermark
+/// would stop the attested walk before revisiting them, so those issues would silently never regain
+/// their provider edges. Clearing forces the next attested walk to re-scan from the top — its
+/// upserts and per-closer replace-sets make the redo idempotent. Two seams reset the item backfill
+/// (`filter_changed` and `reset_for_full_rewalk`); both route through here rather than each
+/// inlining the delete, so a third reset seam can't forget it.
+fn clear_attested_watermark(conn: &Connection, binding: &ResolvedTracker) -> anyhow::Result<()> {
+    let key = attested_since_key(binding, conn)?;
+    rag_rat_db::meta::delete_meta(conn, &key)
+}
+
+/// The provider-attested closers walk (#702 stage 2): pages `attested_closers_page` until the
+/// walk completes or falls behind the last completed walk's watermark, storing every attested
+/// edge (the upsert's trust ladder upgrades text-tier rows in place) and applying per-item
+/// outcome updates to CACHED rows. The watermark advances ONLY on a COMPLETED walk — an
+/// interrupted run redoes from the top next time (idempotent upserts, no cursor sub-state).
+async fn sync_attested_closers<C: PapertrailClient>(
+    conn: &Connection,
+    binding: &ResolvedTracker,
+    client: &C,
+    report: &mut MirrorBindingReport,
+) -> anyhow::Result<()> {
+    let repo_id = rag_rat_db::schema::active_repo_id(conn)?;
+    let key = attested_since_key(binding, conn)?;
+    let since = rag_rat_db::meta::read_meta(conn, &key)?;
+    let mut cursor: Option<String> = None;
+    let mut frontier: Option<String> = None;
+    let mut pages_seen = 0usize;
+    loop {
+        let Some(page) = client
+            .attested_closers_page(&binding.project, cursor.as_deref(), since.as_deref())
+            .await?
+        else {
+            // `None` on the FIRST page = no attested supply (provider without one, or the
+            // capability probe failed on the opening call): the text tier is the only local
+            // evidence and stage-2 storage is a clean no-op. `None` AFTER pages were stored is a
+            // mid-walk capability trip (a transient probe-shaped failure): the walk is PARTIAL,
+            // so surface it — the watermark stays put and the next sync redoes from the top.
+            if pages_seen > 0 {
+                report.attested_error = Some(
+                    "attested-closers walk ended early: capability unavailable mid-walk".into(),
+                );
+            }
+            return Ok(());
+        };
+        pages_seen += 1;
+        if let Some(page_frontier) = &page.frontier {
+            // Conservative MINIMUM across phases (ISO timestamps compare lexicographically):
+            // neither stream's later updates can be skipped by the other's newer frontier.
+            frontier = match frontier.take() {
+                Some(existing) if existing <= *page_frontier => Some(existing),
+                _ => Some(page_frontier.clone()),
+            };
+        }
+        let tx = conn.unchecked_transaction()?;
+        // ISSUE-KEYED REPLACE-SET: an issue has exactly one authoritative closer (its last
+        // ClosedEvent), so re-reading it lets the walk reap EVERY provider closer edge targeting
+        // it — any kind — before the current closer is reinserted below. A stale or changed
+        // closer (reopened-then-reclosed by a different PR/commit) dies with the refresh. Reaping
+        // is deliberately NOT closer-keyed (per-PR): a PR closes many issues, so deleting a PR's
+        // outgoing edges would clobber UI-linked rows created from another issue's ClosedEvent
+        // that the PR's `closingIssuesReferences` never lists. The PR phase only CREATES keyword
+        // edges (idempotent upserts); it never reaps.
+        for issue_key in &page.replaced_issue_closers {
+            report.attested_writes += tx.execute(
+                "DELETE FROM papertrail_closing_edges WHERE repo_id = ?1 AND tracker = ?2 AND \
+                 project = ?3 AND source = 'provider' AND issue_key = ?4",
+                params![repo_id, binding.provider.as_db_str(), binding.project, issue_key],
+            )?;
+        }
+        for edge in &page.edges {
+            // Store an attested edge ONLY when its target issue is a cached item that is NOT
+            // open. Cached ⇒ the item passed this binding's tag filter (the item walk prunes
+            // out-of-scope items), so a `tags = ["bug"]` binding never records closures for
+            // untracked issues. Not-open ⇒ no closure evidence for a reopened issue (the API
+            // may still list a merged PR's `closingIssuesReferences` for an issue that was
+            // reopened). An un-mirrored or reopened target is skipped; a later closed+in-scope
+            // walk records it. (`edge.project` is the issue's project — same-project after the
+            // cross-repo skips, i.e. `binding.project`.)
+            let target_closed = tx.query_row(
+                "SELECT EXISTS(SELECT 1 FROM papertrail_items WHERE repo_id = ?1 AND tracker = ?2 \
+                 AND project = ?3 AND item_kind = 'issue' AND item_key = ?4 AND state_normalized \
+                 != 'open')",
+                params![repo_id, binding.provider.as_db_str(), edge.project, edge.issue_key],
+                |row| row.get::<_, bool>(0),
+            )?;
+            if !target_closed {
+                continue;
+            }
+            // Defer to the issue's ONE authoritative closer: never store an edge that CONFLICTS
+            // with a provider closer already recorded for this issue (a different closer). The
+            // issue phase reaps all of a re-read issue's provider edges earlier in THIS tx, so its
+            // own fresh closer never conflicts; the PR phase does NOT reap, so without this a PR
+            // edited after the watermark would resurrect `#5←#9` once #5's ClosedEvent had already
+            // moved its closer elsewhere (and #5 sits below the watermark, never re-read). The
+            // same-closer case is not a conflict, so an idempotent re-store still passes.
+            let conflicting_closer = tx.query_row(
+                "SELECT EXISTS(SELECT 1 FROM papertrail_closing_edges WHERE repo_id = ?1 AND \
+                 tracker = ?2 AND project = ?3 AND issue_kind = ?4 AND issue_key = ?5 AND source \
+                 = 'provider' AND NOT (closer_kind = ?6 AND closer_key = ?7))",
+                params![
+                    repo_id,
+                    binding.provider.as_db_str(),
+                    edge.project,
+                    edge.issue_kind.as_db_str(),
+                    edge.issue_key,
+                    edge.closer_kind.as_db_str(),
+                    edge.closer_key,
+                ],
+                |row| row.get::<_, bool>(0),
+            )?;
+            if conflicting_closer {
+                continue;
+            }
+            store_closing_edge(&tx, binding.provider, edge)?;
+            report.attested_edges += 1;
+        }
+        for update in &page.item_updates {
+            if let Some(resolution) = update.resolution {
+                report.attested_writes += tx.execute(
+                    "UPDATE papertrail_items SET resolution = ?6 WHERE repo_id = ?1 AND tracker = \
+                     ?2 AND project = ?3 AND item_kind = ?4 AND item_key = ?5",
+                    params![
+                        repo_id,
+                        binding.provider.as_db_str(),
+                        binding.project,
+                        update.item_kind.as_db_str(),
+                        update.item_key,
+                        resolution.as_db_str(),
+                    ],
+                )?;
+            }
+            if let Some(sha) = &update.merge_commit_sha {
+                // The merged-only invariant, enforced in SQL: an attested sha lands only on rows
+                // the store already normalized as merged.
+                report.attested_writes += tx.execute(
+                    "UPDATE papertrail_items SET merge_commit_sha = ?6 WHERE repo_id = ?1 AND \
+                     tracker = ?2 AND project = ?3 AND item_kind = ?4 AND item_key = ?5 AND \
+                     state_normalized = 'merged'",
+                    params![
+                        repo_id,
+                        binding.provider.as_db_str(),
+                        binding.project,
+                        update.item_kind.as_db_str(),
+                        update.item_key,
+                        sha,
+                    ],
+                )?;
+            }
+        }
+        tx.commit()?;
+        match page.next {
+            Some(next) => cursor = Some(next),
+            None => break,
+        }
+    }
+    if let Some(frontier) = frontier {
+        rag_rat_db::meta::set_meta(conn, &key, &frontier)?;
     }
     Ok(())
 }
@@ -1057,6 +1322,18 @@ fn delete_item(
          item_kind=?4 AND item_key=?5",
         params![repo_id, binding.provider.as_db_str(), binding.project, kind.as_db_str(), key],
     )?;
+    // An issue leaving the cache (pruned out of scope, or deleted) takes its closing edges with
+    // it — of BOTH tiers. The attested walk stores an edge only for a cached issue, so the cache
+    // is the source of truth: no cached issue ⇒ no closing edges targeting it. Without this, a
+    // narrowed tag filter prunes the issue row but strands its provider closer, and the attested
+    // watermark won't revisit the closer to clean it (#727 review).
+    if kind == ItemKind::Issue {
+        conn.execute(
+            "DELETE FROM papertrail_closing_edges WHERE repo_id=?1 AND tracker=?2 AND project=?3 \
+             AND issue_kind=?4 AND issue_key=?5",
+            params![repo_id, binding.provider.as_db_str(), binding.project, kind.as_db_str(), key],
+        )?;
+    }
     Ok(conn.execute(
         "DELETE FROM papertrail_items WHERE repo_id=?1 AND tracker=?2 AND project=?3 AND \
          item_kind=?4 AND item_key=?5",
@@ -1312,6 +1589,9 @@ mod tests {
 
     struct ScriptClient {
         comment_streams: &'static [&'static str],
+        attested: RefCell<VecDeque<Option<AttestedClosersPage>>>,
+        attested_pause: std::cell::Cell<bool>,
+        attested_hard_error: std::cell::Cell<bool>,
         pages: RefCell<VecDeque<anyhow::Result<ItemsPage>>>,
         probes: RefCell<VecDeque<FreshnessResult>>,
         item_comments: RefCell<VecDeque<anyhow::Result<Vec<PapertrailComment>>>>,
@@ -1327,6 +1607,9 @@ mod tests {
         fn new(pages: Vec<anyhow::Result<ItemsPage>>) -> Self {
             Self {
                 comment_streams: &["default"],
+                attested: RefCell::new(VecDeque::new()),
+                attested_pause: std::cell::Cell::new(false),
+                attested_hard_error: std::cell::Cell::new(false),
                 pages: RefCell::new(pages.into()),
                 probes: RefCell::new(VecDeque::new()),
                 item_comments: RefCell::new(VecDeque::new()),
@@ -1458,6 +1741,24 @@ mod tests {
                 not_modified: true,
             }))
         }
+
+        async fn attested_closers_page(
+            &self,
+            _project: &str,
+            _cursor: Option<&str>,
+            _since: Option<&str>,
+        ) -> anyhow::Result<Option<AttestedClosersPage>> {
+            if self.attested_pause.get() {
+                return Err(anyhow::Error::new(TransportError::Paused {
+                    resume_at_ms: 999_000,
+                    reason: PauseReason::RetryAfter,
+                }));
+            }
+            if self.attested_hard_error.get() {
+                anyhow::bail!("attested walk boom");
+            }
+            Ok(self.attested.borrow_mut().pop_front().unwrap_or(None))
+        }
     }
 
     #[test]
@@ -1533,11 +1834,26 @@ mod tests {
             stored_items: 0,
             stored_comments: 0,
             pruned_items: 0,
+            attested_edges: 0,
+            attested_writes: 0,
+            attested_error: None,
             paused_until_ms: None,
             pause_reason: None,
             completed_full_walk: false,
             probe_not_modified: false,
         }
+    }
+
+    /// Cache a CLOSED in-scope issue so the attested-edge cached-closed gate admits its edges.
+    fn cache_closed_issue(conn: &Connection, key: &str) {
+        conn.execute(
+            "INSERT OR IGNORE INTO papertrail_items(tracker, project, item_kind, item_key, url, \
+             state, title, body, synced_at_ms, repo_id, state_normalized) VALUES ('github', \
+             'o/r', 'issue', ?1, 'u', 'closed', 't', 'b', 1, (SELECT COALESCE((SELECT repo_id \
+             FROM repos LIMIT 1), '__unassigned__')), 'closed')",
+            [key],
+        )
+        .unwrap();
     }
 
     fn db() -> Connection {
@@ -1610,6 +1926,72 @@ mod tests {
         let requests = quiet.item_page_requests.borrow();
         assert_eq!(requests.len(), 1, "the owed replay must run despite the quiet probe");
         assert!(requests[0].updated_since.is_some(), "the replay is a delta scan");
+    }
+
+    /// A filter change must RESET the attested-closers watermark: a widened filter caches
+    /// newly-in-scope closed issues whose PRs/issues predate the stored `since`, and a reused
+    /// watermark would stop the attested walk before ever visiting them. An unchanged filter must
+    /// leave the watermark intact so the incremental walk stays incremental (#727 review).
+    #[test]
+    fn a_filter_change_resets_the_attested_watermark_but_a_stable_filter_keeps_it() {
+        let conn = db();
+        let binding = binding(&[]);
+        let key = attested_since_key(&binding, &conn).unwrap();
+
+        // Persist a cursor whose stored fingerprint will NOT match the binding's, forcing the
+        // next sync onto the filter-changed path.
+        let mut cursor = load_cursor(&conn, &binding).unwrap();
+        cursor.filter_fingerprint = "stale-fingerprint".to_string();
+        save_cursor(&conn, &binding, &cursor, false).unwrap();
+        rag_rat_db::meta::set_meta(&conn, &key, "2020-01-01T00:00:00Z").unwrap();
+
+        let changed = ScriptClient::new(vec![page(Vec::new()), page(Vec::new())])
+            .with_repo_comments(Vec::new());
+        block_on(mirror_binding(&conn, &binding, std::slice::from_ref(&binding), &changed, false))
+            .unwrap();
+        assert!(
+            rag_rat_db::meta::read_meta(&conn, &key).unwrap().is_none(),
+            "the widened-filter path clears the attested watermark",
+        );
+
+        // The prior run stored the binding's own fingerprint, so a repeat sync sees no change:
+        // the freshly re-seeded watermark must survive.
+        rag_rat_db::meta::set_meta(&conn, &key, "2021-01-01T00:00:00Z").unwrap();
+        let stable = ScriptClient::new(vec![page(Vec::new()), page(Vec::new())])
+            .with_probe(FreshnessResult { latest: None, etag: None, not_modified: true })
+            .with_repo_comments(Vec::new());
+        block_on(mirror_binding(&conn, &binding, std::slice::from_ref(&binding), &stable, false))
+            .unwrap();
+        assert_eq!(
+            rag_rat_db::meta::read_meta(&conn, &key).unwrap().as_deref(),
+            Some("2021-01-01T00:00:00Z"),
+            "a stable filter leaves the attested watermark untouched",
+        );
+    }
+
+    /// A FULL rewalk re-caches every closed issue, so it must clear the attested watermark for the
+    /// same reason a widened filter does — otherwise the attested walk reads a stale `since` and
+    /// silently never re-fetches provider closers for issues whose closer predates it. This is the
+    /// full-rewalk seam in isolation: the filter is unchanged, so ONLY `reset_for_full_rewalk` can
+    /// do the clearing.
+    #[test]
+    fn a_full_rewalk_clears_the_attested_watermark_even_with_an_unchanged_filter() {
+        let conn = db();
+        let binding = binding(&[]);
+        let key = attested_since_key(&binding, &conn).unwrap();
+        rag_rat_db::meta::set_meta(&conn, &key, "2026-01-01T00:00:00Z").unwrap();
+
+        // full=true on a fresh cursor ⇒ starting_full_rewalk; tags=[] matches the stored empty
+        // fingerprint ⇒ filter_changed=false, so the filter-change clear cannot fire.
+        let full = ScriptClient::new(vec![page(Vec::new()), page(Vec::new())])
+            .with_repo_comments(Vec::new());
+        block_on(mirror_binding(&conn, &binding, std::slice::from_ref(&binding), &full, true))
+            .unwrap();
+
+        assert!(
+            rag_rat_db::meta::read_meta(&conn, &key).unwrap().is_none(),
+            "reset_for_full_rewalk must clear the attested watermark",
+        );
     }
 
     /// A comments page whose entries all map to no comment (GitLab events on commit/snippet
@@ -3045,5 +3427,472 @@ mod tests {
                 .unwrap();
         assert!(report.pruned_items >= 1);
         assert!(keys(&conn).is_empty());
+    }
+    #[test]
+    fn attested_closers_walk_stores_upgrades_and_watermarks() {
+        let conn = db();
+        let binding = binding(&[]);
+        // A pre-existing TEXT-tier edge for the same pair: the provider walk must upgrade it.
+        crate::store::store_closing_edge(&conn, Tracker::Github, &crate::ClosingEdge {
+            project: "o/r".into(),
+            issue_kind: ItemKind::Issue,
+            issue_key: "5".into(),
+            closer_kind: crate::CloserKind::ChangeRequest,
+            closer_key: "9".into(),
+            closer_commit: None,
+            source: crate::ClosingEdgeSource::Text,
+        })
+        .unwrap();
+        cache_closed_issue(&conn, "5");
+        let client = ScriptClient::new(vec![page(Vec::new())]);
+        client.attested.borrow_mut().push_back(Some(AttestedClosersPage {
+            edges: vec![crate::ClosingEdge {
+                project: "o/r".into(),
+                issue_kind: ItemKind::Issue,
+                issue_key: "5".into(),
+                closer_kind: crate::CloserKind::ChangeRequest,
+                closer_key: "9".into(),
+                closer_commit: Some("abc123".into()),
+                source: crate::ClosingEdgeSource::Provider,
+            }],
+            item_updates: Vec::new(),
+            replaced_issue_closers: Vec::new(),
+            next: Some("issues".into()),
+            frontier: Some("2026-01-05T00:00:00Z".into()),
+        }));
+        client.attested.borrow_mut().push_back(Some(AttestedClosersPage::default()));
+        let report = block_on(mirror_binding(
+            &conn,
+            &binding,
+            std::slice::from_ref(&binding),
+            &client,
+            false,
+        ))
+        .unwrap();
+        assert_eq!(report.attested_edges, 1);
+        let edges = crate::store::closing_edges_for_item(
+            &conn,
+            Tracker::Github,
+            "o/r",
+            ItemKind::Issue,
+            "5",
+        )
+        .unwrap();
+        assert_eq!(edges.len(), 1, "text and provider tiers converge on the pair");
+        assert_eq!(edges[0].source, crate::ClosingEdgeSource::Provider);
+        assert_eq!(edges[0].closer_commit.as_deref(), Some("abc123"));
+        // The COMPLETED walk stamped its watermark.
+        let repo_id = rag_rat_db::schema::active_repo_id(&conn).unwrap();
+        let since = rag_rat_db::meta::read_meta(
+            &conn,
+            &format!("papertrail_attested_closers_since:{repo_id}:github:o/r"),
+        )
+        .unwrap();
+        assert_eq!(since.as_deref(), Some("2026-01-05T00:00:00Z"));
+    }
+
+    #[test]
+    fn attested_item_updates_touch_only_cached_merged_rows() {
+        let conn = db();
+        let binding = binding(&[]);
+        // A cached CLOSED-UNMERGED change request: the attested sha must NOT land on it.
+        let mut unmerged = item("9", "2026-01-01T00:00:00Z", "t", &[]);
+        unmerged.item_kind = ItemKind::ChangeRequest;
+        unmerged.state = "closed".into();
+        crate::store::store_item(&conn, Tracker::Github, &unmerged).unwrap();
+        let client = ScriptClient::new(vec![page(Vec::new())]);
+        client.attested.borrow_mut().push_back(Some(AttestedClosersPage {
+            edges: Vec::new(),
+            item_updates: vec![crate::AttestedItemUpdate {
+                item_kind: ItemKind::ChangeRequest,
+                item_key: "9".into(),
+                resolution: None,
+                merge_commit_sha: Some("attested".into()),
+            }],
+            replaced_issue_closers: Vec::new(),
+            next: None,
+            frontier: None,
+        }));
+        block_on(mirror_binding(&conn, &binding, std::slice::from_ref(&binding), &client, false))
+            .unwrap();
+        let sha: Option<String> = conn
+            .query_row(
+                "SELECT merge_commit_sha FROM papertrail_items WHERE item_key = '9'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(sha, None, "merged-only invariant holds against attested updates too");
+    }
+    #[test]
+    fn issue_keyed_replace_set_drops_a_re_read_issues_stale_closer_of_any_kind() {
+        let conn = db();
+        let binding = binding(&[]);
+        cache_closed_issue(&conn, "5");
+        // Issue 5's PREVIOUS provider closer was commit `old`; this walk re-reads issue 5 and its
+        // ClosedEvent now names PR 9. The issue-keyed replace-set reaps EVERY provider closer for
+        // issue 5 (the commit included), so the stale commit closer dies and only the fresh PR
+        // closer remains — reaping is keyed by the issue, not by any one closer.
+        crate::store::store_closing_edge(&conn, Tracker::Github, &crate::ClosingEdge {
+            project: "o/r".into(),
+            issue_kind: ItemKind::Issue,
+            issue_key: "5".into(),
+            closer_kind: crate::CloserKind::Commit,
+            closer_key: "old".into(),
+            closer_commit: Some("old".into()),
+            source: crate::ClosingEdgeSource::Provider,
+        })
+        .unwrap();
+        let client = ScriptClient::new(vec![page(Vec::new())]);
+        client.attested.borrow_mut().push_back(Some(AttestedClosersPage {
+            edges: vec![crate::ClosingEdge {
+                project: "o/r".into(),
+                issue_kind: ItemKind::Issue,
+                issue_key: "5".into(),
+                closer_kind: crate::CloserKind::ChangeRequest,
+                closer_key: "9".into(),
+                closer_commit: None,
+                source: crate::ClosingEdgeSource::Provider,
+            }],
+            item_updates: Vec::new(),
+            replaced_issue_closers: vec!["5".into()],
+            next: None,
+            frontier: None,
+        }));
+        block_on(mirror_binding(&conn, &binding, std::slice::from_ref(&binding), &client, false))
+            .unwrap();
+        let edges = crate::store::closing_edges_for_item(
+            &conn,
+            Tracker::Github,
+            "o/r",
+            ItemKind::Issue,
+            "5",
+        )
+        .unwrap();
+        assert_eq!(edges.len(), 1, "the stale commit closer died with the refresh");
+        assert_eq!(edges[0].closer_kind, crate::CloserKind::ChangeRequest);
+        assert_eq!(edges[0].closer_key, "9", "only the fresh authoritative closer remains");
+    }
+
+    /// The reported hazard the issue-keyed model fixes: a UI-linked closure (issue 5 <- PR 9 from
+    /// ClosedEvent, NOT in PR 9's `closingIssuesReferences`) must SURVIVE a later PR-phase re-read
+    /// of PR 9. Under the old closer-keyed replace-set, re-reading PR 9 deleted every
+    /// `change_request` edge with closer 9 — including the issue-phase UI-linked row 5<-9, which
+    /// the PR phase never re-provides — and issue 5 (older than the watermark) was never revisited
+    /// to restore it, silently dropping attested closure evidence.
+    #[test]
+    fn a_pr_phase_re_read_does_not_clobber_an_issue_phase_ui_linked_edge() {
+        let conn = db();
+        let binding = binding(&[]);
+        cache_closed_issue(&conn, "5");
+        // Prior walk stored the UI-linked edge 5<-9 from issue 5's ClosedEvent.
+        crate::store::store_closing_edge(&conn, Tracker::Github, &crate::ClosingEdge {
+            project: "o/r".into(),
+            issue_kind: ItemKind::Issue,
+            issue_key: "5".into(),
+            closer_kind: crate::CloserKind::ChangeRequest,
+            closer_key: "9".into(),
+            closer_commit: Some("mergesha".into()),
+            source: crate::ClosingEdgeSource::Provider,
+        })
+        .unwrap();
+        // This incremental walk re-reads PR 9 in the PR phase (it edited after the watermark), but
+        // PR 9's closingIssuesReferences does NOT list issue 5 (the closure was UI-linked). Issue 5
+        // is older than the watermark, so the issue phase does NOT revisit it:
+        // `replaced_issue_closers` is empty and there are no fresh edges.
+        let client = ScriptClient::new(vec![page(Vec::new())]);
+        client.attested.borrow_mut().push_back(Some(AttestedClosersPage {
+            edges: Vec::new(),
+            item_updates: Vec::new(),
+            replaced_issue_closers: Vec::new(),
+            next: None,
+            frontier: None,
+        }));
+        block_on(mirror_binding(&conn, &binding, std::slice::from_ref(&binding), &client, false))
+            .unwrap();
+        let edges = crate::store::closing_edges_for_item(
+            &conn,
+            Tracker::Github,
+            "o/r",
+            ItemKind::Issue,
+            "5",
+        )
+        .unwrap();
+        assert_eq!(edges.len(), 1, "the UI-linked edge survives a PR-phase re-read of its closer");
+        assert_eq!(edges[0].closer_key, "9");
+    }
+
+    /// The PR phase must not RESURRECT a stale closer: if issue 5's authoritative provider closer
+    /// is already PR 7 (its ClosedEvent moved there after a reopen+reclose) and PR 9 — edited after
+    /// the watermark — still lists #5 in `closingIssuesReferences` while #5 sits below the
+    /// watermark (never re-read this walk, so no reap), storing `5<-9` would leave two
+    /// conflicting provider closers. The conflicting-closer gate suppresses it; the same-closer
+    /// idempotent case still passes.
+    #[test]
+    fn the_pr_phase_does_not_resurrect_a_closer_that_conflicts_with_the_authoritative_one() {
+        let conn = db();
+        let binding = binding(&[]);
+        cache_closed_issue(&conn, "5");
+        crate::store::store_closing_edge(&conn, Tracker::Github, &crate::ClosingEdge {
+            project: "o/r".into(),
+            issue_kind: ItemKind::Issue,
+            issue_key: "5".into(),
+            closer_kind: crate::CloserKind::ChangeRequest,
+            closer_key: "7".into(),
+            closer_commit: None,
+            source: crate::ClosingEdgeSource::Provider,
+        })
+        .unwrap();
+        // PR-phase page (no reap: replaced_issue_closers empty) re-adding the stale 5<-9.
+        let client = ScriptClient::new(vec![page(Vec::new())]);
+        client.attested.borrow_mut().push_back(Some(AttestedClosersPage {
+            edges: vec![crate::ClosingEdge {
+                project: "o/r".into(),
+                issue_kind: ItemKind::Issue,
+                issue_key: "5".into(),
+                closer_kind: crate::CloserKind::ChangeRequest,
+                closer_key: "9".into(),
+                closer_commit: None,
+                source: crate::ClosingEdgeSource::Provider,
+            }],
+            item_updates: Vec::new(),
+            replaced_issue_closers: Vec::new(),
+            next: None,
+            frontier: None,
+        }));
+        block_on(mirror_binding(&conn, &binding, std::slice::from_ref(&binding), &client, false))
+            .unwrap();
+        let edges = crate::store::closing_edges_for_item(
+            &conn,
+            Tracker::Github,
+            "o/r",
+            ItemKind::Issue,
+            "5",
+        )
+        .unwrap();
+        assert_eq!(edges.len(), 1, "the stale conflicting closer is not resurrected");
+        assert_eq!(edges[0].closer_key, "7", "only the authoritative closer remains");
+    }
+
+    #[test]
+    fn min_frontier_across_phases_cannot_skip_the_older_stream() {
+        let conn = db();
+        let binding = binding(&[]);
+        let client = ScriptClient::new(vec![page(Vec::new())]);
+        // PR phase frontier is NEWER than the issue phase's — the stored watermark must be the
+        // conservative minimum so the next walk cannot skip issue updates in between.
+        client.attested.borrow_mut().push_back(Some(AttestedClosersPage {
+            frontier: Some("2026-01-09T00:00:00Z".into()),
+            next: Some("issues".into()),
+            ..Default::default()
+        }));
+        client.attested.borrow_mut().push_back(Some(AttestedClosersPage {
+            frontier: Some("2026-01-03T00:00:00Z".into()),
+            ..Default::default()
+        }));
+        block_on(mirror_binding(&conn, &binding, std::slice::from_ref(&binding), &client, false))
+            .unwrap();
+        let repo_id = rag_rat_db::schema::active_repo_id(&conn).unwrap();
+        let since = rag_rat_db::meta::read_meta(
+            &conn,
+            &format!("papertrail_attested_closers_since:{repo_id}:github:o/r"),
+        )
+        .unwrap();
+        assert_eq!(since.as_deref(), Some("2026-01-03T00:00:00Z"));
+    }
+    #[test]
+    fn a_mid_walk_capability_trip_surfaces_a_partial_signal() {
+        let conn = db();
+        let binding = binding(&[]);
+        let client = ScriptClient::new(vec![page(Vec::new())]);
+        // First page stores work and advances to the issues phase; the SECOND call returns
+        // `None` (a mid-walk capability trip), so the walk is partial.
+        client.attested.borrow_mut().push_back(Some(AttestedClosersPage {
+            next: Some("issues".into()),
+            frontier: Some("2026-01-05T00:00:00Z".into()),
+            ..Default::default()
+        }));
+        client.attested.borrow_mut().push_back(None);
+        let report = block_on(mirror_binding(
+            &conn,
+            &binding,
+            std::slice::from_ref(&binding),
+            &client,
+            false,
+        ))
+        .unwrap();
+        assert!(
+            report.attested_error.is_some(),
+            "a mid-walk trip is reported, not folded into a clean no-supply result",
+        );
+        // The watermark did NOT advance: the partial walk redoes from the top next pass.
+        let repo_id = rag_rat_db::schema::active_repo_id(&conn).unwrap();
+        assert!(
+            rag_rat_db::meta::read_meta(
+                &conn,
+                &format!("papertrail_attested_closers_since:{repo_id}:github:o/r"),
+            )
+            .unwrap()
+            .is_none(),
+        );
+    }
+
+    #[test]
+    fn no_attested_supply_is_a_clean_no_op() {
+        let conn = db();
+        let binding = binding(&[]);
+        let client = ScriptClient::new(vec![page(Vec::new())]);
+        // FIRST page is `None` — the provider has no GraphQL supply.
+        client.attested.borrow_mut().push_back(None);
+        let report = block_on(mirror_binding(
+            &conn,
+            &binding,
+            std::slice::from_ref(&binding),
+            &client,
+            false,
+        ))
+        .unwrap();
+        assert!(report.attested_error.is_none(), "no supply is clean, not an error");
+        assert_eq!(report.attested_edges, 0);
+    }
+    #[test]
+    fn attested_edge_for_an_uncached_or_open_target_is_skipped() {
+        let conn = db();
+        let binding = binding(&[]);
+        // #5 is NOT cached (out of scope / not mirrored); #6 is cached but OPEN (reopened).
+        conn.execute(
+            "INSERT INTO papertrail_items(tracker, project, item_kind, item_key, url, state, \
+             title, body, synced_at_ms, repo_id, state_normalized) VALUES ('github', 'o/r', \
+             'issue', '6', 'u', 'open', 't', 'b', 1, '__unassigned__', 'open')",
+            [],
+        )
+        .unwrap();
+        let client = ScriptClient::new(vec![page(Vec::new())]);
+        client.attested.borrow_mut().push_back(Some(AttestedClosersPage {
+            edges: vec![
+                crate::ClosingEdge {
+                    project: "o/r".into(),
+                    issue_kind: ItemKind::Issue,
+                    issue_key: "5".into(),
+                    closer_kind: crate::CloserKind::Commit,
+                    closer_key: "a".into(),
+                    closer_commit: Some("a".into()),
+                    source: crate::ClosingEdgeSource::Provider,
+                },
+                crate::ClosingEdge {
+                    project: "o/r".into(),
+                    issue_kind: ItemKind::Issue,
+                    issue_key: "6".into(),
+                    closer_kind: crate::CloserKind::Commit,
+                    closer_key: "b".into(),
+                    closer_commit: Some("b".into()),
+                    source: crate::ClosingEdgeSource::Provider,
+                },
+            ],
+            ..Default::default()
+        }));
+        let report = block_on(mirror_binding(
+            &conn,
+            &binding,
+            std::slice::from_ref(&binding),
+            &client,
+            false,
+        ))
+        .unwrap();
+        assert_eq!(report.attested_edges, 0, "neither an uncached nor an open target gets an edge");
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM papertrail_closing_edges", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn an_attested_pause_propagates_the_resume_time_not_a_generic_error() {
+        let conn = db();
+        let binding = binding(&[]);
+        let client = ScriptClient::new(vec![page(Vec::new())]);
+        client.attested_pause.set(true);
+        let report = block_on(mirror_binding(
+            &conn,
+            &binding,
+            std::slice::from_ref(&binding),
+            &client,
+            false,
+        ))
+        .unwrap();
+        assert_eq!(
+            report.paused_until_ms,
+            Some(999_000),
+            "the scheduler must honor the resume time"
+        );
+        assert!(report.attested_error.is_none(), "a pause is a pause, not a swallowed error");
+    }
+
+    /// A HARD (non-pause) attested-walk failure must be PERSISTED so `papertrail_sync_status` shows
+    /// it — the item mirror records success and clears its own error state, so without a separate
+    /// persisted signal a doomed enrichment walk re-runs every tick looking healthy. A later clean
+    /// attested walk clears it.
+    #[test]
+    fn a_hard_attested_failure_is_persisted_then_cleared_by_a_clean_walk() {
+        let conn = db();
+        let binding = binding(&[]);
+
+        let failing = ScriptClient::new(vec![page(Vec::new())]).with_repo_comments(Vec::new());
+        failing.attested_hard_error.set(true);
+        let report = block_on(mirror_binding(
+            &conn,
+            &binding,
+            std::slice::from_ref(&binding),
+            &failing,
+            false,
+        ))
+        .unwrap();
+        assert!(report.attested_error.is_some(), "the hard error is surfaced on the report");
+        assert!(report.paused_until_ms.is_none(), "a hard error is not a pause");
+        assert_eq!(
+            read_attested_error(&conn, &binding).unwrap().as_deref(),
+            Some("attested walk boom"),
+            "the failure is persisted for the durable status snapshot",
+        );
+
+        // A subsequent clean attested walk (no supply, no error) clears the persisted failure.
+        let clean = ScriptClient::new(vec![page(Vec::new())]).with_repo_comments(Vec::new());
+        block_on(mirror_binding(&conn, &binding, std::slice::from_ref(&binding), &clean, false))
+            .unwrap();
+        assert!(
+            read_attested_error(&conn, &binding).unwrap().is_none(),
+            "a clean attested walk clears the persisted failure",
+        );
+    }
+
+    #[test]
+    fn pruning_an_out_of_scope_issue_takes_its_provider_closing_edges() {
+        let conn = db();
+        // A tag-scoped binding; the item walk stores a `docs`-labelled issue #5, then a filter
+        // narrowed to `bug` prunes it — its provider closing edge must go too.
+        cache_closed_issue(&conn, "5");
+        crate::store::store_closing_edge(&conn, Tracker::Github, &crate::ClosingEdge {
+            project: "o/r".into(),
+            issue_kind: ItemKind::Issue,
+            issue_key: "5".into(),
+            closer_kind: crate::CloserKind::Commit,
+            closer_key: "abc".into(),
+            closer_commit: Some("abc".into()),
+            source: crate::ClosingEdgeSource::Provider,
+        })
+        .unwrap();
+        delete_item_for_tests(&conn, &binding(&["bug"]), ItemKind::Issue, "5").unwrap();
+        assert!(
+            crate::store::closing_edges_for_item(
+                &conn,
+                Tracker::Github,
+                "o/r",
+                ItemKind::Issue,
+                "5"
+            )
+            .unwrap()
+            .is_empty(),
+            "a pruned issue's closing edges leave with it",
+        );
     }
 }

--- a/crates/rag-rat-papertrail/src/store.rs
+++ b/crates/rag-rat-papertrail/src/store.rs
@@ -20,9 +20,9 @@ use super::*;
 pub fn store_ref(conn: &Connection, reference: &PapertrailRef) -> anyhow::Result<()> {
     let repo_id = rag_rat_db::schema::active_repo_id(conn)?;
     // `idx_papertrail_refs_unique` leads with `repo_id`, so a conflict is always THIS repo
-    // re-discovering its OWN ref — keep the first-sighting row untouched (`DO NOTHING` preserves
-    // the original `discovered_at_ms`/`ref_kind`). A sibling repo referencing the same item gets
-    // its own distinct row rather than conflicting.
+    // re-discovering its OWN ref. The upsert PROMOTES `ref_kind` to the strongest claim (see the
+    // SQL comment) and preserves the first-sighting `discovered_at_ms`; a sibling repo
+    // referencing the same item gets its own distinct row rather than conflicting.
     conn.execute(
         "
         INSERT INTO papertrail_refs(
@@ -31,7 +31,17 @@ pub fn store_ref(conn: &Connection, reference: &PapertrailRef) -> anyhow::Result
         )
         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)
         ON CONFLICT(repo_id, tracker, project, COALESCE(item_kind, ''), item_key, source_kind, \
-         COALESCE(source_path, ''), COALESCE(source_commit, ''), source_text) DO NOTHING
+         COALESCE(source_path, ''), COALESCE(source_commit, ''), source_text) DO UPDATE SET
+            -- PROMOTE to the strongest claim, never demote: a re-discovery that now classifies
+            -- the same source as closing (new keyword, second mention in one body) upgrades the
+            -- row in place — an upgraded binary re-classifies old 'unknown' rows on its next
+            -- discovery pass with no migration. `discovered_at_ms` keeps the first sighting.
+            ref_kind = CASE WHEN
+                CASE excluded.ref_kind WHEN 'closing' THEN 0 WHEN 'reverts' THEN 1 WHEN \
+         'reference' THEN 2 ELSE 3 END
+                < CASE ref_kind WHEN 'closing' THEN 0 WHEN 'reverts' THEN 1 WHEN 'reference' THEN \
+         2 ELSE 3 END
+            THEN excluded.ref_kind ELSE ref_kind END
         ",
         params![
             reference.tracker.as_db_str(),
@@ -110,6 +120,22 @@ pub fn store_item(
             repo_id,
         ],
     )?;
+    // A REOPENED item has no closure: storing an item back in the open state voids every
+    // closing edge recorded for it (both tiers — the closed-issues walk can never see an open
+    // issue again, so this store-time rule is the only seam that observes the reopen).
+    if NormalizedState::derive(&item.state, item.merged_at.as_deref()) == NormalizedState::Open {
+        conn.execute(
+            "DELETE FROM papertrail_closing_edges WHERE repo_id = ?1 AND tracker = ?2 AND project \
+             = ?3 AND issue_kind = ?4 AND issue_key = ?5",
+            params![
+                repo_id,
+                tracker.as_db_str(),
+                item.project,
+                item.item_kind.as_db_str(),
+                item.item_key
+            ],
+        )?;
+    }
     conn.execute(
         "DELETE FROM papertrail_fts
          WHERE repo_id = ?1 AND tracker = ?2 AND project = ?3 AND item_kind = ?4
@@ -742,5 +768,53 @@ mod fts_mirror_tests {
         let edges =
             closing_edges_for_item(&conn, Tracker::Github, "o/r", ItemKind::Issue, "5").unwrap();
         assert_eq!(edges[0].closer_commit.as_deref(), Some("attested-sha-2"));
+    }
+    #[test]
+    fn store_ref_promotes_to_the_strongest_claim_and_never_demotes() {
+        let conn = Connection::open_in_memory().unwrap();
+        schema::apply(&conn, &crate::test_hooks()).unwrap();
+        let make = |kind: &str| crate::PapertrailRef {
+            tracker: Tracker::Github,
+            project: "o/r".into(),
+            item_key: "5".into(),
+            item_kind: None,
+            ref_kind: kind.into(),
+            source_kind: "commit".into(),
+            source_path: None,
+            source_commit: Some("abc".into()),
+            source_text: "fixes #5".into(),
+        };
+        // An old row classified before a keyword existed…
+        store_ref(&conn, &make("unknown")).unwrap();
+        // …is PROMOTED by re-discovery under the stronger classification (no migration needed:
+        // commit discovery re-parses every sync)…
+        store_ref(&conn, &make("closing")).unwrap();
+        let kind: String =
+            conn.query_row("SELECT ref_kind FROM papertrail_refs", [], |r| r.get(0)).unwrap();
+        assert_eq!(kind, "closing");
+        // …and a later weaker sighting never demotes it.
+        store_ref(&conn, &make("reference")).unwrap();
+        let kind: String =
+            conn.query_row("SELECT ref_kind FROM papertrail_refs", [], |r| r.get(0)).unwrap();
+        assert_eq!(kind, "closing");
+        let rows: i64 =
+            conn.query_row("SELECT COUNT(*) FROM papertrail_refs", [], |r| r.get(0)).unwrap();
+        assert_eq!(rows, 1, "one row per identity throughout");
+    }
+    #[test]
+    fn storing_a_reopened_item_voids_its_closing_edges() {
+        let conn = Connection::open_in_memory().unwrap();
+        schema::apply(&conn, &crate::test_hooks()).unwrap();
+        store_closing_edge(&conn, Tracker::Github, &edge("5", CloserKind::Commit, "abc")).unwrap();
+        let mut reopened = item(ItemKind::Issue, "5", "t", "b");
+        reopened.state = "open".into();
+        store_item(&conn, Tracker::Github, &reopened).unwrap();
+        assert!(
+            closing_edges_for_item(&conn, Tracker::Github, "o/r", ItemKind::Issue, "5")
+                .unwrap()
+                .is_empty(),
+            "an open item has no closure evidence — the store-time rule is the only seam that \
+             observes a reopen",
+        );
     }
 }

--- a/crates/rag-rat-papertrail/src/sync.rs
+++ b/crates/rag-rat-papertrail/src/sync.rs
@@ -526,50 +526,61 @@ pub(crate) fn rederive_commit_closers(
         .map(|name| name.shorten().to_string())
         .unwrap_or_default();
     let eligible = default_branch_checkout_projects(root, &branch, &ctx.trackers);
-    let refs = {
-        let repo_id = rag_rat_db::schema::active_repo_id(conn)?;
-        let mut stmt = conn.prepare(
-            "SELECT tracker, project, item_key, item_kind, ref_kind, source_commit, source_text \
-             FROM papertrail_refs WHERE repo_id = ?1 AND source_kind = 'commit' AND ref_kind = \
-             'closing'",
-        )?;
-        let rows = stmt.query_map([&repo_id], |row| {
-            Ok((
-                row.get::<_, String>(0)?,
-                row.get::<_, String>(1)?,
-                row.get::<_, String>(2)?,
-                row.get::<_, Option<String>>(3)?,
-                row.get::<_, String>(4)?,
-                row.get::<_, Option<String>>(5)?,
-                row.get::<_, String>(6)?,
-            ))
-        })?;
-        let mut refs = Vec::new();
-        for row in rows {
-            let (tracker, project, item_key, item_kind, ref_kind, source_commit, source_text) =
-                row?;
-            let Ok(tracker) = Tracker::from_db_str(&tracker) else { continue };
-            let item_kind = match item_kind.as_deref() {
-                Some(kind) => Some(ItemKind::from_db_str(kind).ok()).flatten(),
-                None => None,
-            };
-            refs.push(PapertrailRef {
-                tracker,
-                project,
-                item_key,
-                item_kind,
-                ref_kind,
-                source_kind: "commit".to_string(),
-                source_path: None,
-                source_commit,
-                source_text,
-            });
-        }
-        refs
-    };
+    let refs = current_commit_closing_refs(conn)?;
     store_text_closing_edges_from_commit_refs(conn, &refs, &eligible)
 }
 
+/// The stored closing COMMIT refs whose source commit STILL exists in the indexed history — the
+/// input to the commit-tier replace-set. Stored refs are the annotation layer and are never
+/// pruned, so this `git_commits` join keeps the derivation a pure function of CURRENT history (a
+/// rebased/reloaded-away commit's ref must not re-mint its closer). Extracted so the filter is
+/// unit-testable without a live checkout.
+pub(crate) fn current_commit_closing_refs(conn: &Connection) -> anyhow::Result<Vec<PapertrailRef>> {
+    let repo_id = rag_rat_db::schema::active_repo_id(conn)?;
+    // STALENESS GUARD: stored refs are the annotation layer and are never pruned, so a
+    // rebased/reloaded-away commit's closing ref survives here — require the source commit to
+    // STILL exist in the indexed history, so the derivation is a pure function of CURRENT
+    // history (an automatic scheduled sync must not re-mint a `Fixes #5` edge from a commit no
+    // longer in `git_commits`).
+    let mut stmt = conn.prepare(
+        "SELECT r.tracker, r.project, r.item_key, r.item_kind, r.ref_kind, r.source_commit, \
+         r.source_text FROM papertrail_refs r WHERE r.repo_id = ?1 AND r.source_kind = 'commit' \
+         AND r.ref_kind = 'closing' AND EXISTS (SELECT 1 FROM git_commits g WHERE g.repo_id = \
+         r.repo_id AND g.hash = r.source_commit)",
+    )?;
+    let rows = stmt.query_map([&repo_id], |row| {
+        Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, String>(1)?,
+            row.get::<_, String>(2)?,
+            row.get::<_, Option<String>>(3)?,
+            row.get::<_, String>(4)?,
+            row.get::<_, Option<String>>(5)?,
+            row.get::<_, String>(6)?,
+        ))
+    })?;
+    let mut refs = Vec::new();
+    for row in rows {
+        let (tracker, project, item_key, item_kind, ref_kind, source_commit, source_text) = row?;
+        let Ok(tracker) = Tracker::from_db_str(&tracker) else { continue };
+        let item_kind = match item_kind.as_deref() {
+            Some(kind) => ItemKind::from_db_str(kind).ok(),
+            None => None,
+        };
+        refs.push(PapertrailRef {
+            tracker,
+            project,
+            item_key,
+            item_kind,
+            ref_kind,
+            source_kind: "commit".to_string(),
+            source_path: None,
+            source_commit,
+            source_text,
+        });
+    }
+    Ok(refs)
+}
 /// The (provider, project) pairs for which the CURRENT checkout's HEAD is that remote's default
 /// branch — read locally from every remote's `HEAD` symref (`refs/remotes/<name>/HEAD`, set by
 /// clone / `git remote set-head`) and the remote URL's parsed project. Per-remote, NOT
@@ -607,6 +618,27 @@ fn default_branch_checkout_projects(
         if default != branch {
             continue;
         }
+        // Name equality is not enough: a local branch NAMED like the default can carry unpushed
+        // or divergent commits the provider has never seen on its default branch. The precise
+        // condition is ANCESTRY — every indexed commit must be default-branch-reachable, which
+        // holds exactly when HEAD is an ancestor-or-equal of the remote default tip. This
+        // ADMITS the common "behind a freshly-fetched tip" checkout (all its commits are on the
+        // default history), while still REJECTING an ahead/divergent local branch (whose unique
+        // commits the provider never saw on the default). Equality alone would false-negative
+        // the behind case and — via the unconditional text-closer replace below — wipe legit
+        // commit closers with nothing to re-derive offline.
+        let (Ok(head), Some(tip)) = (
+            repo.head_id(),
+            repo.find_reference(&target).ok().and_then(|mut r| r.peel_to_id().ok()),
+        ) else {
+            continue;
+        };
+        // HEAD is an ancestor-or-equal of the tip iff their merge base IS HEAD.
+        let head_reachable_from_tip = head == tip
+            || repo.merge_base(head, tip).ok().is_some_and(|base| base.detach() == head.detach());
+        if !head_reachable_from_tip {
+            continue;
+        }
         let key = format!("remote.{remote}.url");
         let Some(url) = repo.config_snapshot().string(key.as_str()).map(|url| url.to_string())
         else {
@@ -626,6 +658,9 @@ fn default_branch_checkout_projects(
                             .trim_start_matches("http://")
                             .split('/')
                             .next()
+                            // `parts.host` is port-stripped by the remote-URL parser; normalize
+                            // the configured authority the same way before comparing.
+                            .and_then(|authority| authority.split(':').next())
                             .is_some_and(|host| host.eq_ignore_ascii_case(&parts.host))
                     })
                 })
@@ -695,12 +730,16 @@ pub(crate) fn store_text_closing_edges_from_commit_refs(
         }
         // AFFIRMATIVE target verification: on shared-numbering providers a kind-less `#123`
         // can be a pull request, and closing keywords do nothing for PR targets — mint only
-        // when the cached mirror confirms the target IS an issue. (Un-mirrored targets stay
-        // annotations; the provider lane attests them.)
+        // when the cached mirror confirms the target IS an issue that is NOT open. The
+        // not-open clause is load-bearing: `store_item` voids a reopened issue's closing edges,
+        // but this rederive runs at sync END, so without it a reopened issue whose closing
+        // commit is still in history would have its text-tier closer re-minted every sync.
+        // (Un-mirrored targets stay annotations; the provider lane attests them.)
         let cached_kind: Option<String> = conn
             .query_row(
                 "SELECT item_kind FROM papertrail_items WHERE repo_id = ?1 AND tracker = ?2 AND \
-                 project = ?3 AND item_key = ?4 AND item_kind = 'issue'",
+                 project = ?3 AND item_key = ?4 AND item_kind = 'issue' AND state_normalized != \
+                 'open'",
                 params![
                     repo_id,
                     reference.tracker.as_db_str(),
@@ -711,6 +750,23 @@ pub(crate) fn store_text_closing_edges_from_commit_refs(
             )
             .optional()?;
         if cached_kind.as_deref() != Some(ItemKind::Issue.as_db_str()) {
+            continue;
+        }
+        // Defer to the provider tier. The text tier is the FALLBACK for issues the provider lane
+        // attested nothing for. If a provider closer already exists for this issue — the
+        // authoritative ClosedEvent set it, possibly to a DIFFERENT closer after a reopen+reclose
+        // the mirror caught — re-minting an old default-branch `Fixes #N` commit would strand a
+        // stale text edge beside the current provider one on EVERY sync (rederive is not
+        // watermarked). When the commit genuinely is the closer, the issue phase already stored it
+        // as a provider row (same sha), so skipping the text copy is harmless.
+        let has_provider_closer: bool = conn.query_row(
+            "SELECT EXISTS(SELECT 1 FROM papertrail_closing_edges WHERE repo_id = ?1 AND tracker \
+             = ?2 AND project = ?3 AND issue_kind = 'issue' AND issue_key = ?4 AND source = \
+             'provider')",
+            params![repo_id, reference.tracker.as_db_str(), reference.project, reference.item_key],
+            |row| row.get(0),
+        )?;
+        if has_provider_closer {
             continue;
         }
         let Some(commit) = reference.source_commit.as_deref() else {
@@ -761,12 +817,14 @@ mod mining_tests {
 
     /// Cache the TARGET as a mirrored issue — the strict kind check mints only for targets the
     /// mirror confirms are issues.
+    /// Cache the target as a CLOSED mirrored issue — the state a commit-closed issue is actually
+    /// in, and what the affirmative kind+not-open check the commit-closer mint requires.
     fn cache_issue(conn: &Connection, key: &str) {
         conn.execute(
             "INSERT OR IGNORE INTO papertrail_items(tracker, project, item_kind, item_key, url, \
              state, title, body, synced_at_ms, repo_id, state_normalized) VALUES ('github', \
-             'o/r', 'issue', ?1, 'u', 'open', 't', 'b', 1, (SELECT COALESCE((SELECT repo_id FROM \
-             repos LIMIT 1), '__unassigned__')), 'open')",
+             'o/r', 'issue', ?1, 'u', 'closed', 't', 'b', 1, (SELECT COALESCE((SELECT repo_id \
+             FROM repos LIMIT 1), '__unassigned__')), 'closed')",
             [key],
         )
         .unwrap();
@@ -1212,5 +1270,122 @@ mod mining_tests {
                 .unwrap()
                 .is_empty(),
         );
+    }
+    #[test]
+    fn rederive_does_not_resurrect_a_reopened_issues_commit_closer() {
+        // store_item voids a reopened issue's closing edges, but rederive runs at sync END and
+        // re-derives from every default-branch closing commit ref. Without the not-open clause
+        // on the cached-issue check, a reopened issue whose closing commit is still in history
+        // gets its text-tier closer re-minted every sync.
+        let conn = conn();
+        // Cache #5 as an OPEN issue (reopened).
+        let mut reopened = change_request("5", "b");
+        reopened.item_kind = ItemKind::Issue;
+        reopened.state = "open".into();
+        reopened.merged_at = None;
+        reopened.merge_commit_sha = None;
+        crate::store::store_item(&conn, Tracker::Github, &reopened).unwrap();
+        let reference = PapertrailRef {
+            tracker: Tracker::Github,
+            project: "o/r".into(),
+            item_key: "5".into(),
+            item_kind: Some(ItemKind::Issue),
+            ref_kind: "closing".into(),
+            source_kind: "commit".into(),
+            source_path: None,
+            source_commit: Some("abc".into()),
+            source_text: "fixes #5".into(),
+        };
+        store_text_closing_edges_from_commit_refs(
+            &conn,
+            &[reference],
+            &std::collections::BTreeSet::from([(Tracker::Github, "o/r".to_string())]),
+        )
+        .unwrap();
+        assert!(
+            closing_edges_for_item(&conn, Tracker::Github, "o/r", ItemKind::Issue, "5")
+                .unwrap()
+                .is_empty(),
+            "a reopened (open) issue's commit closer is not re-minted",
+        );
+    }
+
+    #[test]
+    fn rederive_defers_to_an_existing_provider_closer() {
+        // The text tier is the FALLBACK for issues the provider lane attested nothing for. When #5
+        // already carries a provider closer (its authoritative ClosedEvent — here PR 9, possibly
+        // moved there after a reopen+reclose the mirror caught), an old default-branch `Fixes #5`
+        // commit must NOT be re-minted as a stale text edge beside it on every sync.
+        let conn = conn();
+        let mut closed = change_request("5", "b");
+        closed.item_kind = ItemKind::Issue;
+        closed.state = "closed".into();
+        closed.merged_at = None;
+        closed.merge_commit_sha = None;
+        crate::store::store_item(&conn, Tracker::Github, &closed).unwrap();
+        crate::store::store_closing_edge(&conn, Tracker::Github, &crate::ClosingEdge {
+            project: "o/r".into(),
+            issue_kind: ItemKind::Issue,
+            issue_key: "5".into(),
+            closer_kind: crate::CloserKind::ChangeRequest,
+            closer_key: "9".into(),
+            closer_commit: None,
+            source: crate::ClosingEdgeSource::Provider,
+        })
+        .unwrap();
+        let reference = PapertrailRef {
+            tracker: Tracker::Github,
+            project: "o/r".into(),
+            item_key: "5".into(),
+            item_kind: Some(ItemKind::Issue),
+            ref_kind: "closing".into(),
+            source_kind: "commit".into(),
+            source_path: None,
+            source_commit: Some("abc".into()),
+            source_text: "fixes #5".into(),
+        };
+        store_text_closing_edges_from_commit_refs(
+            &conn,
+            &[reference],
+            &std::collections::BTreeSet::from([(Tracker::Github, "o/r".to_string())]),
+        )
+        .unwrap();
+        let edges =
+            closing_edges_for_item(&conn, Tracker::Github, "o/r", ItemKind::Issue, "5").unwrap();
+        assert_eq!(edges.len(), 1, "no stale text closer is minted beside the provider one");
+        assert_eq!(edges[0].source, crate::ClosingEdgeSource::Provider);
+        assert_eq!(edges[0].closer_key, "9");
+    }
+
+    #[test]
+    fn current_commit_closing_refs_excludes_commits_gone_from_history() {
+        let conn = conn();
+        // Seed a real git_commits row so the FK/EXISTS join has a live commit…
+        conn.execute(
+            "INSERT INTO git_commits(hash, author_name, author_email, authored_at_s, \
+             committed_at_s, subject, body, repo_id) VALUES ('live', 'a', 'a@x', 0, 0, 's', 'b', \
+             (SELECT COALESCE((SELECT repo_id FROM repos LIMIT 1), '__unassigned__')))",
+            [],
+        )
+        .unwrap();
+        let repo_id: String = conn
+            .query_row(
+                "SELECT COALESCE((SELECT repo_id FROM repos LIMIT 1), '__unassigned__')",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        for (key, commit) in [("5", "live"), ("6", "gone")] {
+            conn.execute(
+                "INSERT INTO papertrail_refs(tracker, project, item_key, item_kind, ref_kind, \
+                 source_kind, source_commit, source_text, discovered_at_ms, repo_id) VALUES \
+                 ('github', 'o/r', ?1, 'issue', 'closing', 'commit', ?2, 'fixes', 0, ?3)",
+                rusqlite::params![key, commit, repo_id],
+            )
+            .unwrap();
+        }
+        let refs = current_commit_closing_refs(&conn).unwrap();
+        let keys: Vec<&str> = refs.iter().map(|r| r.item_key.as_str()).collect();
+        assert_eq!(keys, vec!["5"], "only the ref whose commit is still in git_commits survives");
     }
 }

--- a/crates/rag-rat-papertrail/src/transport/client.rs
+++ b/crates/rag-rat-papertrail/src/transport/client.rs
@@ -203,6 +203,28 @@ impl Transport {
         url: &str,
         extra_headers: &[(&str, &str)],
     ) -> Result<TransportResponse, TransportError> {
+        self.request(url, extra_headers, None).await
+    }
+
+    /// POST a JSON body through the SAME admission/pause/backoff machinery as [`Self::get`] —
+    /// the GraphQL lane's requests count against their own governor lane but share every
+    /// transport discipline (deadline, retry holds, secondary-limit standdown).
+    pub(crate) async fn post_json(
+        &self,
+        url: &str,
+        extra_headers: &[(&str, &str)],
+        body: &serde_json::Value,
+    ) -> Result<TransportResponse, TransportError> {
+        let body = serde_json::to_string(body).unwrap_or_default();
+        self.request(url, extra_headers, Some(body)).await
+    }
+
+    async fn request(
+        &self,
+        url: &str,
+        extra_headers: &[(&str, &str)],
+        json_body: Option<String>,
+    ) -> Result<TransportResponse, TransportError> {
         self.validate_url(url)?;
         let mut attempt: u32 = 0;
         loop {
@@ -222,7 +244,15 @@ impl Transport {
             if let Admission::PausedUntil { resume_at_ms, reason } = self.governor.admit(now) {
                 return Err(TransportError::Paused { resume_at_ms, reason });
             }
-            let mut request = self.client.get(url).timeout(self.request_timeout(now));
+            let mut request = match &json_body {
+                Some(body) => self
+                    .client
+                    .post(url)
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(body.clone()),
+                None => self.client.get(url),
+            }
+            .timeout(self.request_timeout(now));
             if let Some(auth_header) = &self.auth_header {
                 request = request.header(header::AUTHORIZATION, auth_header);
             }


### PR DESCRIPTION
Stage 2 of #702 — the attestation tier the substrate was built for. GitHub's own closure data
replaces text heuristics as the source of truth for change-request closers.

**The lane.** A dedicated `graphql` governor lane on the GitHub client (GraphQL is metered on its
own points budget — REST and GraphQL headers can never corrupt each other's remaining-quota
view), over a new Transport `post_json` that shares every discipline of `get`: URL pinning to the
binding authority, pass-deadline pauses, retry holds, secondary-limit standdown, body drain. The
capability probe folds into the first real call — a GHE build without the endpoint answers
400/404/410, memoized, and the lane degrades to the text tier.

**The walk.** Two phases per project, watermarked: merged/closed PRs (`closingIssuesReferences` +
the attested merge commit) then closed issues (`ClosedEvent.closer` — direct by-commit closures
**and** UI-linked PR closures whose descriptions never carried a keyword; `stateReason` feeds
resolution). The watermark is the conservative **minimum** across the two phases and advances
only on a completed walk; an interrupted run redoes from the top with idempotent upserts.

**Evidence lifecycle on the provider tier too** (the class invariant this series is about):
per-closer replace-sets (a closing reference the provider no longer returns dies with the
closer's refresh), a store-time reopen rule (an item stored back open voids its closing edges),
attested per-item updates land only on cached rows under the merged-only `merge_commit_sha`
invariant, cross-repository references skipped, and a >100-reference nested connection fails
loudly rather than truncating.

**Post-merge substrate follow-ups, same commit:** `store_ref` promotes `ref_kind` to the
strongest claim (self-heals old `unknown` rows, no migration); commit-closer eligibility requires
HEAD to be **reachable from** the remote default tip (ancestry, not equality — admits a
behind-tip checkout, rejects an ahead/divergent one); `rederive_commit_closers` runs from every
entry (scheduled + single-issue included), resolving the checkout root from the process-active
`source_root`.

**Adversarially reviewed** by three independent Opus lenses (evidence integrity, transport/
security, lifecycle) plus Codex; every surviving finding is folded in. Notably the response
parsing was extracted into a pure `parse_attested_page` with direct JSON unit tests — the
`PapertrailClient` stubs bypass the producer, so its rules had had no coverage.

**Measured on this repo's own mirror:** provider edges 0 → 221 (199 change-request + 22 commit),
193 CR edges carrying the attested merge commit; items with an attested merge sha 131 → 331;
attested resolutions 137 → 287. Spot-checks (#707/#708 → PR #710 + its real merge commit; #708
also attested closed-by-commit) match git history. The incremental rerun cut at the watermark
after 2 GraphQL calls.

3037/3037 tests; all four CI clippy gates green.

Closes the #702 / #113 substrate. The distill record store (#703) builds on this as a pure SQL
consumer of attested data.
