### PR TITLE
docs(benchmarks): condense to the current run; drop cross-version history

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -6,17 +6,16 @@ profile that workload exposes and how syntactic resolution compares to a real co
 workflows, and `tools/bench-kernel.sh`). Numbers here are single cold runs, not statistically-gated
 CI signals; treat them as "what one run looks like," not a regression gate.
 
-These numbers are a fresh **v0.15.0** run. The extracted-fact counts — symbols, edges, chunks — are
-byte-identical to v0.5.0 (the indexing work is unchanged); peak RSS is lower. v0.5.0 itself indexes
-the kernel ~2.7× faster than v0.4.x, a *correctness* change, not lost coverage: see
-[v0.5.0 rebaseline](#v050-rebaseline-why-the-kernel-got-27-faster).
+This file stores only the **current** numbers — one recent release-tier run, identified where it is
+quoted. The history (every release run, every measure) lives in the Bencher series `bench-release`
+feeds; comparisons across versions belong there, not here.
 
 ## Test harness
 
 The kernel index runs on a self-hosted big-memory box (the `bench-release` workflow's
 `[self-hosted, bigmem]` runner), inside the pinned bench container so the toolchain and SCIP indexers
 are reproducible. It runs here rather than on a hosted runner for a stable wall-clock — not because
-it no longer fits a hosted box (the peak is 3.49 GiB; see below).
+it no longer fits a hosted box (see the peak below).
 
 | | |
 |---|---|
@@ -35,182 +34,111 @@ dominates wall-clock more than core count does. Peak RSS is governed by the grap
 Linux kernel **v7.0** (pinned at commit `028ef9c96e96197026887c0f092424679298aae8`, shallow-cloned),
 full index (`index --full`), whole tree (`RAG_RAT_KERNEL_SUBDIRS=.`), no embedding model
 (`model = "none"`; built `--no-default-features`, so no model download), release build,
-`RAG_RAT_INDEX_WAVE=2000`. The on-disk size below is the structure-only half of the
-[size split](#db-size-structure-vs-vectors).
+`RAG_RAT_INDEX_WAVE=2000`. Run: one **v0.19.0** release run (`bench-release`, self-hosted bigmem box), single cold rebuild.
 
 | Metric | Value |
 |---|---|
 | Files indexed (C/H) | 62,903 |
-| **Wall-clock** | **319.1 s** (5.32 min) — median of 3 cold runs (range 310.1–325.1 s) |
-| Throughput | 197.1 files/s |
-| **Peak RSS** | **3.49 GiB** (3,570 MiB maxrss; 1 Hz sampler caught 3,370 MiB) |
-| On-disk index DB | 4.65 GiB (4,758 MiB, post-checkpoint) |
+| **Wall-clock** | **412.1 s** (6.87 min) |
+| Throughput | 152.6 files/s |
+| **Peak RSS** | **3.40 GiB** maxrss (3,321 MiB caught by the 1 Hz sampler) |
+| On-disk index DB (structure) | 4.72 GiB (post-checkpoint; the structure half of the [size split](#db-size-structure-vs-vectors)) |
 | Symbols | 1,057,527 |
 | Edges (call graph) | 9,144,061 |
-| Edges resolved | 5,320,408 (58.2%) |
+| Edges resolved | 5,320,333 (58.2%) |
 | Chunks | 1,611,390 |
 
-Each wall-clock figure is one cold rebuild on a shared box (the runner also hosts unrelated
-services); the headline **319.1 s is the median of three** back-to-back cold rebuilds that clustered
-tightly at 310.1–325.1 s (±2.4%), so it is a stable figure, not transient contention — but it is
-~50 s above v0.5.0's 269 s single-run number. The extracted-fact counts (symbols, edges, chunks) are
-byte-identical to v0.5.0, so the indexing *work* is unchanged; the gap is execution time on identical
-work, which a cold wall-clock on a shared box can't cleanly split between pipeline changes across
-0.6→0.15 and heavier background load at measurement time. Peak RSS moved the other way
-(4.15 → 3.49 GiB).
+Wall-clock is one cold rebuild on a shared box (the runner also hosts unrelated services), so any
+single run carries tens of seconds of noise; the Bencher series is the trend, one run is a sample.
+The extracted-fact counts (symbols, edges, chunks) are deterministic for the pinned kernel commit.
 
-Unresolved-edge taxonomy (the 41.8% / 3,823,653 edges the syntactic graph leaves dangling, by kind):
-`calls_name` 1,861,753 (48.7%), `references_type` 1,560,047 (40.8%), `imports` 401,853 (10.5%). The
-`calls_name` bucket is extern / macro / function-pointer call targets the syntactic resolver can't
-bind without a compilation database; `references_type` is dominated by references whose type
-*definition* lives in an uncompiled or external header — both are exactly what the SCIP oracle
-recovers (below).
+Unresolved-edge taxonomy (the 41.8% / 3,823,728 edges the syntactic graph leaves
+dangling, by kind): `calls_name` 1,861,733 (48.7%), `references_type` 1,560,142 (40.8%),
+`imports` 401,853 (10.5%). The `calls_name` bucket is extern / macro / function-pointer call
+targets the syntactic resolver can't bind without a compilation database; `references_type` is
+dominated by references whose type *definition* lives in an uncompiled or external header — both are
+exactly what the SCIP oracle recovers (below).
 
 ### DB size: structure vs vectors
 
 "Indexing the kernel costs N GB" is only an honest number if it says what's *in* the N. The bench
 reports the size as a **split** (#78), because the two halves are bought separately:
 
-| Half | What it is | BMF measure |
-|---|---|---|
-| **Structure** (the headline) | files + symbols + graph + chunks + FTS + git history. `model = "none"` — zero vectors. What a base install actually builds. | `db_size` |
-| **+ Vectors** | every chunk the embedding policy admits, embedded on top of the same index. Opt-in second pass. | `db_size_with_vectors`, `db_size_vectors_delta` |
+| Half | What it is | BMF measure | Measured |
+|---|---|---|---|
+| **Structure** (the headline) | files + symbols + graph + chunks + FTS + git history. `model = "none"` — zero vectors. What a base install actually builds. | `db_size` | 4.72 GiB |
+| **+ Vectors** | every chunk the embedding policy admits, embedded on top of the same index. Opt-in second pass. | `db_size_with_vectors`, `db_size_vectors_delta` | +1.54 GiB (24.6% of the full DB) |
 
-The headline pass runs `model = "none"`, which is the honest config for this corpus: nobody does
-vector recall over the Linux kernel with a hash embedder, so those baseline vectors would be
-plumbing-validation, not retrieval value. `index --full` computes no embeddings regardless — the
-reconcile is a separate, explicit pass that refuses to embed under a model that was never installed
-— so the structure-only headline is what the run has always measured; the config now *says* so, and
-the vector tier gets priced instead of assumed.
+The headline pass runs `model = "none"` — the honest config for this corpus (nobody does vector
+recall over the Linux kernel with a hash embedder), and `index --full` computes no embeddings
+regardless: the reconcile is a separate, explicit pass that refuses to embed under a model that was
+never installed. The split is what makes the degradability claim ("base install ships zero AI; add
+what you use") a **measured** number: `db_size_vectors_delta` is exactly the disk you avoid by not
+adding the embedding tier. Vectors are stored int8-quantized (#112: a 4-byte scale + one byte per
+dim, ~4× smaller than the f32 blob), which is why the tier is a modest fraction rather than the
+dominant one.
 
-This is what makes the degradability claim ("base install ships zero AI; add what you use") a
-**measured** number rather than an assertion: `db_size_vectors_delta` is exactly the disk you avoid
-by not adding the embedding tier.
-
-The `+vectors` pass is off by default (at kernel scale it embeds ~1.6M chunks). Turn it on with:
+The `+vectors` pass is off by default. Turn it on with:
 
 ```bash
 RAG_RAT_KERNEL_VECTORS=1 RAG_RAT_BIN=target/release/rag-rat bash tools/bench-kernel.sh
 ```
 
-**Kernel-scale `+Y` is not measured yet** — no whole-tree run with `RAG_RAT_KERNEL_VECTORS=1` has
-been published, so no number is quoted here. It lands from the next `bench-release` dispatch with
-the flag set, and is tracked as its own Bencher series from then on.
-
-For the *shape* of the split, one scope-bounded run — **`RAG_RAT_KERNEL_SUBDIRS=lib`, 673 files, not
-the headline**, on a 5-core / 15 GB box rather than the bench runner:
-
-| | Bytes | |
-|---|---|---|
-| structure + FTS + graph + git | 64,815,104 | 62 MiB |
-| add vectors (13,793 chunks → 10,151 embedded) | +13,271,040 | +13 MiB |
-| total | 78,086,144 | 74 MiB |
-
-So on that subtree the embedding tier is ~17% of the full DB. Vectors are stored int8-quantized
-(#112: a 4-byte scale + one byte per dim, ~4× smaller than the f32 blob), which is why the tier is a
-modest fraction rather than the dominant one. Whether the whole-tree ratio holds is exactly what the
-measured run will answer — don't extrapolate this row to the headline.
-
-### v0.5.0 rebaseline: why the kernel got ~2.7× faster
-
-v0.4.x indexed the same 62,903 files in **~724 s**; v0.5.0 does it in **269 s**. Nothing is being
-skipped at the file level — the file count is identical. The difference is the **#61 C/C++
-definitions-only** extraction change: the parser now emits a symbol for a struct/union/enum/function
-only when it carries its **body** (a definition), not for forward declarations (`struct X;`), bare
-type uses (`struct X *p`), or function prototypes. The kernel's headers repeat those prototypes and
-forward-decls across thousands of includes, so dropping them as "symbols" removes most of the work:
-
-| Metric | v0.4.x (pre-#61) | v0.5.0 | Δ |
-|---|---|---|---|
-| Files indexed | 62,903 | 62,903 | — (no scope loss) |
-| Wall-clock | 723.6 s | 269.1 s | **−63%** |
-| Symbols | 3,536,897 | 1,057,527 | −70% |
-| Chunks | 4,246,140 | 1,611,390 | −62% |
-| Edges | 11,213,107 | 9,144,061 | −18% |
-| Resolved | 67.4% | 58.7% | −8.7 pp |
-| Peak RSS | 5.60 GiB | 4.15 GiB | −26% |
-| On-disk DB | 8.01 GiB | 4.98 GiB | −38% |
-
-The two numbers that look *worse* are both improvements:
-
-- **Fewer symbols/chunks** is the point — a forward declaration is not a definition, and the dropped
-  ~2.5M symbols were bodyless prototype/forward-decl/use occurrences, not real code. Real
-  definitions are still indexed.
-- **Lower resolved rate** (67.4% → 58.7%) reflects *higher* precision, not lost resolution. The old
-  rate was inflated by edges binding to declaration pseudo-symbols — frequently the wrong target
-  (`references_type` would land on a 14-byte forward-decl of `pt_regs` instead of the real
-  1556-byte definition). The same change took measured C `references_type` precision from **18% →
-  91%** (see below). Lower rate, far higher correctness.
-
-So the #61 definitions-only change is what makes "indexes the Linux kernel" fast — a correctness-
-driven speedup, not a coverage regression. v0.15.0 carries the identical symbol, edge, and chunk
-counts (the headline table above is the current run; wall-clock, peak RSS, on-disk size, and the
-resolved rate shifted).
-
 ## C edge resolution: heuristic vs compiler (SCIP oracle)
 
-The headline resolves 58.2% of edges *syntactically* — by name, no compiler. The SCIP oracle (#61)
-measures how good that syntactic resolution actually is: it replays a real compilation through
-`scip-clang` (a clang-based SCIP indexer) and diffs its ground-truth bindings against the heuristic's.
-Numbers below are one heavy-tier `scip-clang` oracle run (`oracle.yml`, `scip-clang 0.4.0`, kernel `defconfig`, containerized
-bench image on the self-hosted bigmem box), so they cover the **compiled subset** — the translation
-units `defconfig` actually compiles — not the whole 62,903-file tree the headline indexes. Resolution
-*quality* and tree-wide *coverage* are different populations, reported side by side, not merged.
+The headline resolves 58.2% of edges *syntactically* — by name, no compiler. The SCIP
+oracle (#61) measures how good that syntactic resolution actually is: it replays a real compilation
+through `scip-clang` (a clang-based SCIP indexer) and diffs its ground-truth bindings against the
+heuristic's. Numbers below are one heavy-tier `scip-clang` oracle run (`oracle.yml`, `scip-clang
+0.4.0`, kernel `defconfig`, containerized bench image on the self-hosted bigmem box), so they cover
+the **compiled subset** — the translation units `defconfig` actually compiles — not the whole
+62,903-file tree the headline indexes. Resolution *quality* and tree-wide *coverage* are different
+populations, reported side by side, not merged.
 
 | Metric | Value | Meaning |
 |---|---|---|
 | Compiled TUs | 2,956 | the `defconfig` compilation database scip-clang consumes |
 | **Compiler precision (blended)** | **92.8%** | confirmed / (confirmed + contradicted), over every judged edge kind |
 | — `calls_name` | **91.8%** | function-call resolution (315,205 confirm / 28,071 contradict) |
-| — `references_type` | **94.2%** | type references (211,868 / 13,122) — after the definitions-only fix |
+| — `references_type` | **94.2%** | type references (211,868 / 13,122) |
 | Call recall | 32.0% | covered / (covered + oracle-only) — of calls the compiler saw, the share the graph had a `calls_name` edge for |
 | Confirmed | 527,073 | heuristic target matched the compiler's |
 | Contradicted | 41,193 | heuristic bound a different target than the compiler |
 | Upgraded | 346,091 | edges promoted to `Compiler`-tier confidence |
 | Resolved-external | 29,535 | dangling refs the compiler bound to a cross-TU / external symbol the heuristic couldn't reach |
 
-The headline: on the compiled subset, name-based resolution agrees with the compiler **~93% of the
-time** on the edges it commits to — and that's after the oracle caught a real indexing bug. Getting
-here is the instructive part, and it is the same change that rebaselined the kernel headline above:
+On the compiled subset, name-based resolution agrees with the compiler **~93% of the time** on the
+edges it commits to — and that figure exists because the oracle first caught a real indexing bug.
+The first oracle read was an alarming 50.1% blended; splitting by edge kind exposed
+`references_type` at 18% while `calls_name` was already 85%. The root cause: the C/C++ parser
+emitted a symbol for *every* `struct`/`union`/`enum` specifier — forward declarations and bare uses
+included — so type references bound to tiny bodyless pseudo-symbols instead of real definitions.
+The **definitions-only** fix (#61) — a specifier must carry its body; bare prototypes are dropped —
+moved both kinds into the 90s, and as a side effect removed ~⅔ of the kernel's "symbols" and chunks
+(bodyless prototype/forward-decl occurrences, not real code), which is also what made whole-kernel
+indexing fast. Lower symbol counts and a lower resolved *rate* than pre-#61 both reflect higher
+precision, not lost coverage.
 
-- **The first measurement read 50.1% blended** — alarming, and it looked like "C resolution is a
-  coin flip." It wasn't a measurement artifact (a `#93` logical-symbol comparison fix moved it <1 pt),
-  so the number was real — but it was a *blend* hiding two very different populations.
-- **Splitting by edge kind exposed the culprit:** `calls_name` was already **85%**, while
-  `references_type` was **18%**. Type references, not call resolution, dragged the headline down.
-- **Root cause (#61):** the C/C++ parser emitted a symbol for *every* `struct`/`union`/`enum`
-  specifier — definitions, forward declarations (`struct X;`), *and* bare uses (`struct X *p`) — plus
-  function prototypes. A `references_type` edge then bound to a tiny bodyless forward-decl/use
-  occurrence instead of the real definition.
-- **The fix:** index **definitions only** — a specifier must carry its body, and bare prototypes are
-  dropped. `references_type` precision jumped from **18%** into the 90s (**94.2%** in this v0.15.0
-  run), `calls_name` rose from **85%** to **91.8%** (the same change removed mis-resolutions to
-  prototypes), and the blend went from **50.1%** to the low 90s (**92.8%** here). This is also what
-  cut the kernel-index symbol/chunk counts above.
-
-So the honest story is the opposite of the first read: C heuristic resolution is **~93% precise**,
-and the SCIP oracle's value showed up twice — it *found* the forward-declaration bug, then quantified
-the fix. Beyond precision, this run **upgraded 346k** unresolved/low-confidence edges to
-compiler-grade confidence and recovered **29.5k cross-TU externals** the heuristic couldn't bind.
-("committed to": the resolver leaves `NameOnly`/`Ambiguous` when it can't pick a target, so precision
-is over edges where the graph made a definite claim. The bulk of edges are `no_occurrence` — call
-sites outside the compiled subset or with no SCIP occurrence at their byte range — expected, since the
-index spans the whole tree while the compilation database spans `defconfig`.)
+("committed to": the resolver leaves `NameOnly`/`Ambiguous` when it can't pick a target, so
+precision is over edges where the graph made a definite claim. The bulk of edges are
+`no_occurrence` — call sites outside the compiled subset or with no SCIP occurrence at their byte
+range — expected, since the index spans the whole tree while the compilation database spans
+`defconfig`.)
 
 ## Rust edge resolution: heuristic vs compiler (rust-analyzer SCIP oracle)
 
-The Rust sibling, and the contrast that matters: one heavy-tier `rust-analyzer` oracle run over **rust-lang/cargo**
-(tag 0.97.1, `rust-analyzer 0.3.2929`). The corpus binds the `src` + `crates` workspace paths — **355**
-`.rs` files, cargo's library and workspace-member sources (not its large `tests/` tree). Unlike
-scip-clang's compiled subset, rust-analyzer analyzes the whole workspace, so the oracle covers every
-one of those indexed `.rs` files — no compiled-subset gap like C.
+The Rust sibling, and the contrast that matters: one heavy-tier `rust-analyzer` oracle run over
+**rust-lang/cargo** (tag 0.97.1, `rust-analyzer 0.3.2929`). The corpus binds the `src` + `crates`
+workspace paths — **355** `.rs` files, cargo's library and workspace-member sources (not its large
+`tests/` tree). Unlike scip-clang's compiled subset, rust-analyzer analyzes the whole workspace, so
+the oracle covers every one of those indexed `.rs` files — no compiled-subset gap like C.
 
 | Metric | Value | Meaning |
 |---|---|---|
 | Rust files indexed | 355 | the `src` + `crates` workspace paths |
 | **Compiler precision (blended)** | **81.7%** | confirmed / (confirmed + contradicted), over every judged edge kind |
 | — `calls_name` | **83.1%** | function-call resolution (5,378 / 1,096) |
-| — `references_type` | **80.9%** | type references (10,743 / 2,536) — after the resolution fixes below |
+| — `references_type` | **80.9%** | type references (10,743 / 2,536) |
 | **Call recall** | **93.2%** | covered / (covered + oracle-only) — the graph had a `calls_name` edge for ~all calls the compiler saw |
 | Confirmed | 16,348 | heuristic target matched the compiler's |
 | Contradicted | 3,668 | heuristic bound a different target than the compiler |
@@ -218,8 +146,8 @@ one of those indexed `.rs` files — no compiled-subset gap like C.
 | Resolved-external | 51,201 | calls/refs the compiler bound to std / a dependency crate (the bulk of cargo's) |
 
 Read the two side by side: **call resolution `calls_name` — C 91.8% vs Rust 83.1%**; blended C 92.8%
-vs Rust 81.7%. Rust's lower blend is spread across both kinds (`calls_name` 83.1%, `references_type`
-80.9%), each a few points under C's. Three resolution fixes got the Rust blend to where it is:
+vs Rust 81.7%. Rust's lower blend is spread across both kinds, each a few points under C's. Three
+resolution fixes got the Rust blend to where it is:
 
 - **type-only resolution** — a `references_type` reference no longer binds to a non-type symbol (an
   `impl` block, module, etc.) in Rust/C/C++.
@@ -230,13 +158,13 @@ vs Rust 81.7%. Rust's lower blend is spread across both kinds (`calls_name` 83.1
   Cargo.toml manifests, per package.
 
 Part of what keeps `references_type` shy of C's is **not a resolver bug**: a share is **cross-crate
-workspace references** — a type defined in one workspace crate but referenced from a sibling member is
-emitted by rust-analyzer as an external moniker with no local definition, so the oracle can't credit
-rag-rat's *correct* in-corpus binding. That's a measurement floor; real `references_type` precision is
-somewhat above the reported number. Recall: C 32.0% (oracle sees only the compiled `defconfig`
-subset) vs Rust 93.2% (rust-analyzer sees the whole workspace). The low in-corpus call rate is not a
-weakness: cargo calls overwhelmingly into `std`/dependency crates, and the oracle correctly bins
-**51k** of those as `resolved-external` rather than forcing a wrong in-corpus target.
+workspace references** — a type defined in one workspace crate but referenced from a sibling member
+is emitted by rust-analyzer as an external moniker with no local definition, so the oracle can't
+credit rag-rat's *correct* in-corpus binding. That's a measurement floor; real `references_type`
+precision is somewhat above the reported number. Recall: C 32.0% (oracle sees only the compiled
+`defconfig` subset) vs Rust 93.2% (rust-analyzer sees the whole workspace). The low in-corpus call
+rate is not a weakness: cargo calls overwhelmingly into `std`/dependency crates, and the oracle
+correctly bins **51k** of those as `resolved-external` rather than forcing a wrong in-corpus target.
 
 Run them yourself via the unified runner: `CORPUS=linux-kernel bash tools/oracle-run.sh` (C) and
 `CORPUS=rust-cargo bash tools/oracle-run.sh` (Rust), or dispatch `oracle.yml` with `tier=heavy` to
@@ -246,9 +174,9 @@ every verdict is reproducible.
 
 ## Memory profile: where the peak lives
 
-The v0.15.0 kernel index peaks at **3.49 GiB** (3,570 MiB maxrss; a 1 Hz `/proc` VmRSS sampler caught
-3,370 MiB — sampling undershoots the instantaneous peak). The run has **two** memory humps, and the
-higher one is missed by the named per-phase probes:
+The kernel index peaks at **3.40 GiB** maxrss (the 1 Hz `/proc` VmRSS sampler undershoots
+the instantaneous peak slightly). The run has **two** memory humps, and the higher one is missed by
+the named per-phase probes:
 
 1. **The edge-resolution window** (inside the rebuild transaction). The whole symbol + edge graph is
    held in memory until the single resolve-and-insert pass; once `index_targets` frees it, RSS drops
@@ -256,43 +184,19 @@ higher one is missed by the named per-phase probes:
 2. **A post-COMMIT plateau** (where the true peak lives), **cause not yet attributed**. A few GiB
    land on top of the resident baseline after COMMIT for a sustained plateau — the process peak —
    and it is **not** covered by the `RAG_RAT_MEM_TRACE=1` per-phase probes (which instrument the
-   rebuild transaction and stop at COMMIT). Only the whole-process sampler catches it.
+   rebuild transaction and stop at COMMIT). Only the whole-process sampler catches it. It is **not**
+   embedding work — `index --full` computes no embeddings (a bench DB holds zero vector rows) — so
+   the open suspect is the pinned kernel's full-history `git log --numstat` walk, the other
+   post-rebuild bulk pass (unverified).
 
-   This plateau used to be attributed to the embedding reconcile. That attribution is **wrong**:
-   `index --full` never runs one. The CLI `index` path calls `rebuild_with_progress` and stops
-   (`crates/rag-rat-cli/src/commands/index_ops.rs:89`); neither it nor the core rebuild
-   (`crates/rag-rat-core/src/index/rebuild.rs`) ever reaches an embedder, and `reconcile` refuses to
-   embed under a model that was never explicitly installed — which the bench never does. A bench DB
-   accordingly contains **zero** rows in `chunk_embeddings`, which is why the headline `db_size` is
-   the structure-only number above. So whatever the plateau is, it is not chunk-embedding
-   materialization; the real cause is open (the pinned kernel's full-history `git log --numstat`
-   walk is the obvious suspect, since it is the other post-rebuild bulk pass — unverified).
+Ruled out as the peak, each checked on the real artifact rather than by reasoning: the **SQLite
+checkpoint is flat at ~28 MB** (shown with the default cache, a 256 MB cache, and
+`synchronous=OFF`, replaying the real multi-GB WAL; `mmap_size=0`, no hooks), and **glibc arenas**
+account for only ~1.2 GiB (`MALLOC_ARENA_MAX=1`, a live-process malloc setting).
 
-Both humps shrank from v0.4.x with the #61 symbol/chunk reduction — the peak went from 5.60 GiB
-(v0.4.x) to 4.15 GiB (v0.5.0), and lower still to 3.49 GiB by v0.15.0. A smaller in-memory graph
-lowers the edge window; why the post-COMMIT plateau also fell is part of the open attribution above.
 To regenerate the per-phase curve on your own run, set `RAG_RAT_MEM_TRACE=1` (rebuild transaction
 phases, to stderr) plus the sampler CSV the bench writes (`RSS_CSV`, the post-COMMIT plateau the
 MEM_TRACE probes miss).
-
-### How the peak got here
-
-Two earlier fixes set the pre-#61 ceiling that #61 then lowered further:
-
-- **Streaming reconcile fix** (`d5b834e`, ~9.3 GiB → 5.5 GiB). The reconcile used to count
-  policy-skipped chunks by materializing *every* chunk row — including each chunk's full `text` — into
-  a `Vec`, ~4 GiB resident purely for a count, even when zero chunks end up embedded. Streaming the
-  count row-by-row removed that ~4 GiB (the isolated skip-summary dropped 3950 MB → 11 MB, counts
-  identical).
-- **Interned edge accumulator** (`#79`/`#92`). The rebuild's edge phase was made ~4 GiB cheaper by
-  interning the edge accumulator to `Sym(u32)` ids (`CompactEdge` ≈ 64 B vs 176 B), verified
-  byte-identical against a golden index.
-
-Ruled out as the peak, each checked on the real artifact rather than by reasoning:
-
-- The **SQLite checkpoint is flat at ~28 MB**, shown three ways (default cache, 256 MB cache,
-  `synchronous=OFF`) replaying the real multi-GB WAL. `mmap_size=0`, no hooks.
-- **glibc arenas** account for only ~1.2 GiB (`MALLOC_ARENA_MAX=1`, a live-process malloc setting).
 
 ## Knobs
 
@@ -300,9 +204,11 @@ Ruled out as the peak, each checked on the real artifact rather than by reasonin
   waves, so the rebuild peak ≈ one wave of prepared files + the accumulating graph. Lower it to
   trade speed for peak RSS on a memory-constrained box.
 - `RAG_RAT_MEM_TRACE=1` — emit the per-phase rebuild RSS + sqlite-memory curve to stderr. (Note: it
-  does not instrument the post-COMMIT reconcile — use the sampler CSV for that.)
+  does not instrument the post-COMMIT phases — use the sampler CSV for those.)
 - `RAG_RAT_KERNEL_SUBDIRS` (bench only) — bound the indexed subtree (e.g. `"kernel mm fs net lib"`)
   to go faster while iterating; `.` is the whole tree (the headline).
+- `RAG_RAT_KERNEL_VECTORS=1` (bench only) — add the opt-in `+vectors` pass to the run, reporting
+  `db_size_with_vectors` / `db_size_vectors_delta` on top of the structure-only headline.
 
 See [`bencher.md`](./bencher.md) and `tools/bench-kernel.sh` for running it yourself or in CI.
 


### PR DESCRIPTION
`benchmarks.md` carried per-version comparison tables (v0.4.x / v0.5.0 / v0.15.0) and a "how the peak got here" changelog. That history is the Bencher series' job — the doc should show the current picture, not a version log.

- Keep one release-tier run: headline table, the #78 DB-size split, and the C + Rust SCIP-oracle sections (condensed prose, same numbers).
- Drop the v0.5.0 rebaseline section and the peak-history "earlier fixes" section (all old-version numbers).
- Fold the **measured** +vectors delta into the size split: structure **4.72 GiB**, +vectors **1.54 GiB** (24.6% of the full DB) — from a whole-kernel `RAG_RAT_KERNEL_VECTORS=1` run on the bigmem box.
- The `+vectors`/`db_size` framing now matches what the bench actually emits post-#78.

Net −184 / +90 lines. No harness or number changes beyond the added +vectors row.