### PR TITLE
perf(reconcile): ~75× faster kernel-scale reconcile — snapshot the scope view, read the certified policy column (#725)

### DIFF
--- a/crates/rag-rat-core/src/index/ai/mod.rs
+++ b/crates/rag-rat-core/src/index/ai/mod.rs
@@ -363,6 +363,10 @@ pub(crate) struct CurrentChunk {
     input_hash: Option<String>,
     embedding_text_version: Option<String>,
     next_retry_after_ms: Option<i64>,
+    /// The stamped index-time policy columns (`chunks.embedding_policy` / `embedding_priority`),
+    /// trusted as the policy source only under `EmbeddingScan::stamped_policy` (#530 certification).
+    embedding_policy: String,
+    embedding_priority: i64,
     reason: ReconcileReason,
 }
 
@@ -428,6 +432,12 @@ pub(crate) struct EmbeddingScan<'a> {
     model_version: &'a str,
     dim: usize,
     max_embedding_chars: usize,
+    /// #530 certification (`stamped_policy_certified`), resolved ONCE per scan: when true, the
+    /// embed/estimate paths take each candidate's policy from the stamped
+    /// `chunks.embedding_policy`/`embedding_priority` columns instead of re-deriving it FromText —
+    /// which tree-sitter-parses every candidate and dominates large reconciles (#725). When false
+    /// (stale/absent stamp, or a non-default cap) they recompute exactly as before.
+    stamped_policy: bool,
 }
 
 pub(crate) struct EmbeddingInput {

--- a/crates/rag-rat-core/src/index/ai/mod.rs
+++ b/crates/rag-rat-core/src/index/ai/mod.rs
@@ -364,7 +364,8 @@ pub(crate) struct CurrentChunk {
     embedding_text_version: Option<String>,
     next_retry_after_ms: Option<i64>,
     /// The stamped index-time policy columns (`chunks.embedding_policy` / `embedding_priority`),
-    /// trusted as the policy source only under `EmbeddingScan::stamped_policy` (#530 certification).
+    /// trusted as the policy source only under `EmbeddingScan::stamped_policy` (#530
+    /// certification).
     embedding_policy: String,
     embedding_priority: i64,
     reason: ReconcileReason,

--- a/crates/rag-rat-core/src/index/ai/policy.rs
+++ b/crates/rag-rat-core/src/index/ai/policy.rs
@@ -166,6 +166,26 @@ pub(crate) fn policy_for_job(
     )
 }
 
+/// One embed-path candidate's policy. Under `stamped_policy` (#530: the stamps certify the column
+/// at this run's cap) the decision comes straight from the stamped
+/// `chunks.embedding_policy`/`embedding_priority` — the index-time FromSpan truth, no per-chunk
+/// tree-sitter re-parse (#725; `Embed` is the sole eligible policy). Otherwise re-derive FromText
+/// via [`policy_for_job`], the pre-certification behavior.
+pub(crate) fn job_policy(
+    chunk: &CurrentChunk,
+    max_embedding_chars: usize,
+    stamped_policy: bool,
+) -> EmbeddingPolicyDecision {
+    if stamped_policy {
+        return policy(
+            &chunk.embedding_policy,
+            chunk.embedding_priority,
+            chunk.embedding_policy == "Embed",
+        );
+    }
+    policy_for_job(chunk, max_embedding_chars)
+}
+
 /// Embedding budget order: source symbols (0) before docs (1) before tests (2).
 ///
 /// Test detection is the CANONICAL [`rag_rat_base::path_class::is_test_path`], not a local list.

--- a/crates/rag-rat-core/src/index/ai/policy.rs
+++ b/crates/rag-rat-core/src/index/ai/policy.rs
@@ -1,5 +1,26 @@
 use super::*;
 
+#[cfg(test)]
+thread_local! {
+    /// Counts embed-path FromText re-classifications ([`policy_for_job`]) since the last reset — the
+    /// tree-sitter re-parse the #530 stamped-column fast path exists to avoid. A test resets it,
+    /// runs a reconcile, and asserts 0 (fast path: read the stamped column) vs > 0 (fallback: the
+    /// FromText recompute). This is what lets the fast-path tests DISAGREE with the fallback instead
+    /// of passing via identical output.
+    pub(crate) static POLICY_FROMTEXT_CALLS: std::cell::Cell<usize> =
+        const { std::cell::Cell::new(0) };
+}
+
+#[cfg(test)]
+pub(crate) fn reset_policy_fromtext_calls() {
+    POLICY_FROMTEXT_CALLS.with(|calls| calls.set(0));
+}
+
+#[cfg(test)]
+pub(crate) fn policy_fromtext_calls() -> usize {
+    POLICY_FROMTEXT_CALLS.with(std::cell::Cell::get)
+}
+
 /// Behavior version of the embedding-policy classifier. It certifies that a persisted
 /// `chunks.embedding_policy` value reflects the CURRENT classifier — the reconcile skip-summary
 /// reads the column via `GROUP BY` (the always-fast path, #530) only when a full rebuild has
@@ -154,6 +175,8 @@ pub(crate) fn policy_for_job(
     chunk: &CurrentChunk,
     max_embedding_chars: usize,
 ) -> EmbeddingPolicyDecision {
+    #[cfg(test)]
+    POLICY_FROMTEXT_CALLS.with(|calls| calls.set(calls.get().saturating_add(1)));
     embedding_policy_for_chunk(
         Path::new(&chunk.path),
         &chunk.language,

--- a/crates/rag-rat-core/src/index/ai/reconcile/embed_loop.rs
+++ b/crates/rag-rat-core/src/index/ai/reconcile/embed_loop.rs
@@ -286,6 +286,10 @@ pub(crate) fn reconcile_with_options_progress(
         if options.force { "" } else { scan.model_id },
         options.changed_first,
     )?;
+    // Snapshot the scoped file metadata ONCE for the whole loop, alongside `candidate_ids`. The
+    // per-batch chunk query joins this indexed temp table instead of probing the live `UNION ALL`
+    // scope view per chunk row (which is O(files) each) — see `snapshot_reconcile_scope_files`.
+    snapshot_reconcile_scope_files(conn)?;
     // One dict decoder for the whole run: each `select_reconcile_batch` loads text for its batch
     // from the compressed `chunk_text` store (#77 Phase 2), and reusing this decoder keeps the dict
     // SELECT + dictionary prep to once per run rather than once per batch.

--- a/crates/rag-rat-core/src/index/ai/reconcile/embed_loop.rs
+++ b/crates/rag-rat-core/src/index/ai/reconcile/embed_loop.rs
@@ -54,6 +54,7 @@ pub(crate) fn reconcile_with_options_progress(
         model_version: &model_version,
         dim: embedding_dim,
         max_embedding_chars,
+        stamped_policy: policy_scan::stamped_policy_certified(conn, max_embedding_chars)?,
     };
     let preflight_estimated_jobs = if batch_write::automatic_reconcile_can_skip_noop(conn, &options)
     {
@@ -1676,6 +1677,7 @@ mod freshness_version_tests {
             model_version: &version,
             dim,
             max_embedding_chars: 4000,
+            stamped_policy: false,
         };
         acquire_chunk_embedder(conn, None, &scan, &ReconcileOptions {
             provision_remote: false,

--- a/crates/rag-rat-core/src/index/ai/reconcile/embed_loop.rs
+++ b/crates/rag-rat-core/src/index/ai/reconcile/embed_loop.rs
@@ -49,7 +49,9 @@ pub(crate) fn reconcile_with_options_progress(
     // The reconcile scan identity (model id/version/dim + char cap), built ONCE up front so the
     // ephemeral pending-work check inside `acquire_chunk_embedder` sizes candidates exactly like
     // the embed loop below (which reuses this same `scan`).
-    let scan = EmbeddingScan {
+    // `stamped_policy` is re-derived AFTER the self-heal below (a stale/absent stamp is repaired +
+    // re-certified there); this initial value only governs the pre-heal preflight estimate.
+    let mut scan = EmbeddingScan {
         model_id: &active_model_id,
         model_version: &model_version,
         dim: embedding_dim,
@@ -198,6 +200,11 @@ pub(crate) fn reconcile_with_options_progress(
     // now. (SkipEphemeral already returned above without paying it.) Self-heal the policy column
     // first so this summary and every later reconcile/plan take the fast GROUP BY path.
     policy_scan::maybe_heal_embedding_policy(conn, max_embedding_chars);
+    // The heal may have just repaired + re-certified the stamp (the stale/absent-stamp upgrade
+    // path). Re-derive certification NOW so the embed loop below reads the healed columns instead
+    // of re-parsing every candidate FromText for the whole run — the first post-upgrade reconcile
+    // is exactly the large-repo case this fast path targets (#725).
+    scan.stamped_policy = policy_scan::stamped_policy_certified(conn, max_embedding_chars)?;
     let skipped_by_policy = policy_scan::embedding_policy_skip_summary(conn, max_embedding_chars)?;
     let skipped_chunks = skipped_by_policy.values().sum();
     let mut report = ReconcileReport {

--- a/crates/rag-rat-core/src/index/ai/reconcile/policy_scan.rs
+++ b/crates/rag-rat-core/src/index/ai/reconcile/policy_scan.rs
@@ -6,6 +6,7 @@ use super::super::*;
 pub(crate) struct ChunkForPolicy {
     id: i64,
     current_policy: String,
+    current_priority: i64,
     chunk_kind: String,
     symbol_path: Option<String>,
     start_byte: usize,
@@ -235,7 +236,7 @@ fn for_each_recomputed_chunk_policy(
         SELECT files.id, files.path, files.language, files.kind, files.sha256, chunks.id,
                chunks.chunk_kind, chunks.symbol_path, chunks.start_byte, chunks.end_byte,
                chunk_text.blob, chunk_text.raw_len, chunk_text.dict_version, \
-         chunks.embedding_policy
+         chunks.embedding_policy, chunks.embedding_priority
         FROM chunks
         JOIN files ON files.id = chunks.file_id
         JOIN chunk_text ON chunk_text.chunk_id = chunks.id
@@ -287,6 +288,7 @@ fn for_each_recomputed_chunk_policy(
             }
             .resolve(&mut decoder)?,
             current_policy: row.get(13)?,
+            current_priority: row.get(14)?,
         };
         // A structural file (has a grammar, not generated) within the parse cap classifies from its
         // shared tree; anything else streams per-chunk text, bounding memory for huge files.
@@ -430,7 +432,7 @@ pub(crate) fn ensure_embedding_policy_current(conn: &Connection) -> anyhow::Resu
     // leaves it to be reused/dropped, not half-created.
     conn.execute_batch(
         "CREATE TEMP TABLE IF NOT EXISTS embedding_policy_heal(id INTEGER PRIMARY KEY, policy \
-         TEXT NOT NULL);",
+         TEXT NOT NULL, priority INTEGER NOT NULL);",
     )?;
     conn.execute_batch("BEGIN IMMEDIATE;")?;
     // NEVER return with an open transaction: the caller (`maybe_heal_embedding_policy`) swallows
@@ -462,11 +464,17 @@ fn heal_embedding_policy_locked(conn: &Connection, repo_id: &str) -> anyhow::Res
     }
     {
         let mut stage = conn.prepare(
-            "INSERT OR REPLACE INTO temp.embedding_policy_heal(id, policy) VALUES (?1, ?2)",
+            "INSERT OR REPLACE INTO temp.embedding_policy_heal(id, policy, priority) VALUES (?1, \
+             ?2, ?3)",
         )?;
+        // Stage on EITHER column differing: the stamp certifies policy AND priority (the embed
+        // path's `job_policy` trusts both, #725), and a classifier change can move priority while
+        // the policy name stays the same — healing only policy would re-certify stale priorities.
         for_each_recomputed_chunk_policy(conn, DEFAULT_MAX_EMBEDDING_CHARS, |chunk, decision| {
-            if decision.policy != chunk.current_policy {
-                stage.execute(params![chunk.id, decision.policy])?;
+            if decision.policy != chunk.current_policy
+                || decision.priority != chunk.current_priority
+            {
+                stage.execute(params![chunk.id, decision.policy, decision.priority])?;
             }
             Ok(())
         })?;
@@ -474,6 +482,8 @@ fn heal_embedding_policy_locked(conn: &Connection, repo_id: &str) -> anyhow::Res
     conn.execute(
         "UPDATE main.chunks
          SET embedding_policy = (SELECT policy FROM temp.embedding_policy_heal WHERE id = \
+         main.chunks.id),
+             embedding_priority = (SELECT priority FROM temp.embedding_policy_heal WHERE id = \
          main.chunks.id)
          WHERE id IN (SELECT id FROM temp.embedding_policy_heal)",
         [],
@@ -501,6 +511,7 @@ mod reconstruct_file_text_tests {
         ChunkForPolicy {
             id: 0,
             current_policy: "Embed".to_string(),
+            current_priority: 1,
             chunk_kind: "code".to_string(),
             symbol_path: None,
             start_byte,

--- a/crates/rag-rat-core/src/index/ai/reconcile/policy_scan.rs
+++ b/crates/rag-rat-core/src/index/ai/reconcile/policy_scan.rs
@@ -135,23 +135,31 @@ pub(crate) fn embedding_policy_skip_summary(
     recompute_policy_skip_summary(conn, max_embedding_chars)
 }
 
+/// TRUE when the #530 stamps certify `chunks.embedding_policy` (+ `embedding_priority`) for this
+/// repo at `max_embedding_chars`: the CURRENT classifier stamped the column (version) AND at the
+/// cap the caller wants — a different cap re-buckets SkipTooLarge/truncation, which the
+/// default-stamped column can't reflect. Shared by the skip-summary fast path and the embed-path
+/// policy source ([`job_policy`](super::super::policy::job_policy)); every miss fails SAFE — the
+/// caller just recomputes from source.
+pub(crate) fn stamped_policy_certified(
+    conn: &Connection,
+    max_embedding_chars: usize,
+) -> anyhow::Result<bool> {
+    let repo_id = rag_rat_db::schema::active_repo_id(conn)?;
+    let version = rag_rat_db::meta::repo_meta(conn, &repo_id, EMBEDDING_POLICY_VERSION_KEY)?;
+    let cap = rag_rat_db::meta::repo_meta(conn, &repo_id, EMBEDDING_POLICY_CAP_KEY)?;
+    Ok(version.as_deref() == Some(EMBEDDING_POLICY_VERSION)
+        && cap.as_deref() == Some(max_embedding_chars.to_string().as_str()))
+}
+
 /// Read the per-policy counts straight from the persisted `chunks.embedding_policy` column, but
-/// ONLY when a full rebuild has stamped it current for this repo (`EMBEDDING_POLICY_VERSION`) at
-/// the requested cap. `None` — stamp absent/stale, or a different cap — tells the caller to
-/// recompute.
+/// ONLY when [`stamped_policy_certified`] holds. `None` — stamp absent/stale, or a different cap —
+/// tells the caller to recompute.
 fn policy_skip_summary_from_column(
     conn: &Connection,
     max_embedding_chars: usize,
 ) -> anyhow::Result<Option<BTreeMap<String, u64>>> {
-    let repo_id = rag_rat_db::schema::active_repo_id(conn)?;
-    let version = rag_rat_db::meta::repo_meta(conn, &repo_id, EMBEDDING_POLICY_VERSION_KEY)?;
-    let cap = rag_rat_db::meta::repo_meta(conn, &repo_id, EMBEDDING_POLICY_CAP_KEY)?;
-    // Trust the column ONLY when the CURRENT classifier stamped it (version) AND at the cap the
-    // caller wants: a different cap re-buckets SkipTooLarge/truncation, which the
-    // default-stamped column can't reflect. Both gates fail SAFE — a miss just recomputes.
-    if version.as_deref() != Some(EMBEDDING_POLICY_VERSION)
-        || cap.as_deref() != Some(max_embedding_chars.to_string().as_str())
-    {
+    if !stamped_policy_certified(conn, max_embedding_chars)? {
         return Ok(None);
     }
     // BYTE-IDENTICAL FROM/JOIN to the recompute (scope view + chunk_text presence) so the counted

--- a/crates/rag-rat-core/src/index/ai/reconcile/status.rs
+++ b/crates/rag-rat-core/src/index/ai/reconcile/status.rs
@@ -57,6 +57,7 @@ pub(crate) fn pending_embedding_jobs_with_options(
         model_version: &model_version,
         dim,
         max_embedding_chars,
+        stamped_policy: super::policy_scan::stamped_policy_certified(conn, max_embedding_chars)?,
     };
     estimated_reconcile_jobs(conn, &scan, options)
 }
@@ -84,6 +85,7 @@ pub(crate) fn pending_embedding_jobs_with_available_incremental_embedder(
         model_version: &model_version,
         dim,
         max_embedding_chars,
+        stamped_policy: super::policy_scan::stamped_policy_certified(conn, max_embedding_chars)?,
     };
     let mut light_options = options.clone();
     light_options.provision_remote = false;

--- a/crates/rag-rat-core/src/index/ai/reconcile/status.rs
+++ b/crates/rag-rat-core/src/index/ai/reconcile/status.rs
@@ -155,6 +155,12 @@ pub(crate) fn embedding_reconcile_plan(
     max_embedding_chars: usize,
 ) -> anyhow::Result<EmbeddingReconcilePlan> {
     let skipped_by_policy = embedding_policy_skip_summary(conn, max_embedding_chars)?;
+    // The plan must classify candidates from the SAME source the reconcile embed loop will (#725):
+    // the #530-certified stamped column when it holds, else the FromText recompute. Otherwise a
+    // certified index whose FromSpan column and FromText recompute legitimately disagree (a chunk
+    // slicing a long comment/string) would make `--plan` preview eligibility/priority the actual
+    // reconcile won't act on. Resolved ONCE, like the embed loop's scan.
+    let stamped_policy = super::policy_scan::stamped_policy_certified(conn, max_embedding_chars)?;
     let mut missing_by_priority = BTreeMap::new();
     let mut current = 0_u64;
     let mut missing = 0_u64;
@@ -169,7 +175,7 @@ pub(crate) fn embedding_reconcile_plan(
     // over `embedding_job_candidates(None)`, so the counts are identical; only the peak memory
     // drops.
     for_each_embedding_candidate(conn, &model.model_id, model_version, dim, None, false, |job| {
-        let policy = policy_for_job(&job, max_embedding_chars);
+        let policy = job_policy(&job, max_embedding_chars, stamped_policy);
         if !policy.eligible {
             return Ok(());
         }

--- a/crates/rag-rat-core/src/index/ai/store.rs
+++ b/crates/rag-rat-core/src/index/ai/store.rs
@@ -23,7 +23,7 @@ pub(crate) fn estimated_reconcile_job_calls() -> usize {
 /// the `chunks.text` column is gone, so the SELECT INNER JOINs `chunk_text`). The real `text` is
 /// filled in a post-loop via [`ChunkTextRow::resolve`] — decompress returns `anyhow::Result`, which
 /// can't cross this rusqlite closure (#77 Phase 2). The SELECT order is: 0-5 identity, 6-13
-/// embedding metadata, 14 blob, 15 raw_len, 16 dict_version.
+/// embedding metadata, 14 blob, 15 raw_len, 16 dict_version, 17-18 stamped policy columns.
 pub(crate) fn current_chunk_row(
     row: &rusqlite::Row<'_>,
 ) -> rusqlite::Result<(CurrentChunk, ChunkTextRow)> {
@@ -43,6 +43,8 @@ pub(crate) fn current_chunk_row(
         input_hash: row.get(11)?,
         embedding_text_version: row.get(12)?,
         next_retry_after_ms: row.get(13)?,
+        embedding_policy: row.get(17)?,
+        embedding_priority: row.get(18)?,
         reason: ReconcileReason::Forced,
     };
     let text_row =
@@ -90,7 +92,9 @@ pub(crate) fn for_each_embedding_candidate(
                chunk_embeddings.next_retry_after_ms,
                chunk_text.blob,
                chunk_text.raw_len,
-               chunk_text.dict_version
+               chunk_text.dict_version,
+               chunks.embedding_policy,
+               chunks.embedding_priority
         FROM chunks
         JOIN files ON files.id = chunks.file_id
         LEFT JOIN chunk_embeddings
@@ -202,7 +206,8 @@ pub(crate) fn current_chunks_by_ids(
                chunk_embeddings.model_version, chunk_embeddings.embedding_dim,
                chunk_embeddings.input_hash, chunk_embeddings.embedding_text_version,
                chunk_embeddings.next_retry_after_ms,
-               chunk_text.blob, chunk_text.raw_len, chunk_text.dict_version
+               chunk_text.blob, chunk_text.raw_len, chunk_text.dict_version,
+               chunks.embedding_policy, chunks.embedding_priority
         FROM chunks
         JOIN files ON files.id = chunks.file_id
         LEFT JOIN chunk_embeddings
@@ -283,7 +288,7 @@ pub(crate) fn estimated_reconcile_jobs(
                     scan.dim,
                     scan.max_embedding_chars,
                 ))
-                && policy_for_job(&candidate, scan.max_embedding_chars).eligible;
+                && job_policy(&candidate, scan.max_embedding_chars, scan.stamped_policy).eligible;
             if eligible {
                 count = count.saturating_add(1);
             }
@@ -309,7 +314,7 @@ pub(crate) fn select_reconcile_batch(
     let candidates = current_chunks_by_ids(conn, model_id, ids, decoder)?;
     let mut jobs = Vec::new();
     for candidate in candidates {
-        let policy = policy_for_job(&candidate, scan.max_embedding_chars);
+        let policy = job_policy(&candidate, scan.max_embedding_chars, scan.stamped_policy);
         if !policy.eligible {
             continue;
         }

--- a/crates/rag-rat-core/src/index/ai/store.rs
+++ b/crates/rag-rat-core/src/index/ai/store.rs
@@ -182,8 +182,39 @@ pub(crate) fn embedding_candidate_ids(
     Ok(ids)
 }
 
+/// Snapshot the scoped `files` metadata (id/path/language/kind) into an indexed temp table for one
+/// reconcile run. The per-batch chunk query ([`current_chunks_by_ids`]) joins THIS table, not the
+/// live `files` view: that view is a repo-/generation-scoped `UNION ALL` compound (see
+/// `lifecycle.rs`), and SQLite re-evaluates it for EACH correlated `files.id = chunks.file_id`
+/// probe — so the per-batch join was O(chunks × files), ~15 ms/chunk and hours of wall-clock at
+/// kernel scale (#725). A plain indexed temp table probes in O(log files). Full-scan queries (the
+/// candidate-id list, the estimate) are unaffected — the planner materializes the view once for a
+/// scan — so only the per-id batch path reads the snapshot.
+///
+/// Built FROM the view, so the snapshot carries exactly this run's scope, frozen at loop start like
+/// `candidate_ids`; per-chunk freshness is still validated against `chunks`/`chunk_embeddings` at
+/// selection and write time, so a mid-run file change cannot embed stale text. Refreshed (DROP +
+/// CREATE) on every call and left on the connection between runs — nothing outside the embed loop
+/// references it. The embed loop MUST call this before its batch loop; the two batch readers are
+/// reachable only through that loop (no direct callers), so the table is always present.
+pub(crate) fn snapshot_reconcile_scope_files(conn: &Connection) -> anyhow::Result<()> {
+    conn.execute_batch(
+        "DROP TABLE IF EXISTS temp.reconcile_scope_files;
+         CREATE TEMP TABLE reconcile_scope_files(
+             id INTEGER PRIMARY KEY,
+             path TEXT NOT NULL,
+             language TEXT NOT NULL,
+             kind TEXT NOT NULL
+         );
+         INSERT INTO temp.reconcile_scope_files SELECT id, path, language, kind FROM files;",
+    )?;
+    Ok(())
+}
+
 /// Load full chunk rows (with text + embedding metadata) for a specific set of ids, in the given
-/// order. Used per batch so only the chunks about to be considered are materialized.
+/// order. Used per batch so only the chunks about to be considered are materialized. Joins the
+/// [`snapshot_reconcile_scope_files`] temp table, NOT the live `files` view — see that helper for
+/// the O(chunks × files) scope-view trap this avoids.
 pub(crate) fn current_chunks_by_ids(
     conn: &Connection,
     model_id: &str,
@@ -209,7 +240,7 @@ pub(crate) fn current_chunks_by_ids(
                chunk_text.blob, chunk_text.raw_len, chunk_text.dict_version,
                chunks.embedding_policy, chunks.embedding_priority
         FROM chunks
-        JOIN files ON files.id = chunks.file_id
+        JOIN temp.reconcile_scope_files AS files ON files.id = chunks.file_id
         LEFT JOIN chunk_embeddings
           ON chunk_embeddings.chunk_id = chunks.id
          AND chunk_embeddings.model_id = ?1

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/embedding_policy_fast_path.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/embedding_policy_fast_path.rs
@@ -268,6 +268,7 @@ fn reconcile_embed_path_reads_the_stamped_policy_column() {
     // would classify the fn chunk Embed and write it.
     let root = unique_temp_root();
     let db = poisoned_embed_fixture(&root);
+    ai::reset_policy_fromtext_calls();
     let report = db.reconcile(None, Some(8)).unwrap();
     assert_eq!(
         report.embeddings_written, 0,
@@ -275,25 +276,42 @@ fn reconcile_embed_path_reads_the_stamped_policy_column() {
          the embed path re-derived policy from text"
     );
     assert_eq!(db.current_embedding_count(HASH_MODEL_ID).unwrap(), 0);
+    // Directly: the embed path took the stamped column, never the FromText re-parse — the cost
+    // #725 removes. This is the counter half of the fast-path/fallback disagreement.
+    assert_eq!(
+        ai::policy_fromtext_calls(),
+        0,
+        "a certified-stamp embed path must not re-classify any candidate FromText"
+    );
     let _ = fs::remove_dir_all(root);
 }
 
 #[test]
-fn reconcile_embed_path_recomputes_on_a_stale_stamp() {
-    // A STALE stamp fails certification, so the embed path re-derives FromText (and the
-    // default-cap self-heal may rewrite the column first) — either way the poison is ignored and
-    // the Embed-classified chunk gets its embedding. Paired with
-    // `reconcile_embed_path_reads_the_stamped_policy_column`, the two outcomes DISAGREE on the
-    // same poisoned index — the proof the fast path is real rather than a no-op.
+fn stale_stamp_reconcile_heals_then_takes_the_fast_path() {
+    // The first reconcile after a classifier/version bump: the stamp is stale, so the self-heal
+    // recomputes + re-certifies the column ONCE up front. The embed loop must then re-derive its
+    // certification from the HEALED stamp and read the column — NOT re-parse every candidate
+    // FromText for the whole run (the regression Codex caught: `stamped_policy` captured before the
+    // heal stayed false). Prove it with the counter: zero FromText calls despite the stale start,
+    // and the stamp ends certified. (The poison is erased by the heal — the fn chunk classifies
+    // Embed from source — so it still embeds; the counter, not the output, is the fast-path proof.)
     let root = unique_temp_root();
     let db = poisoned_embed_fixture(&root);
     stale_the_stamp(&db);
+    ai::reset_policy_fromtext_calls();
     let report = db.reconcile(None, Some(8)).unwrap();
-    assert!(
-        report.embeddings_written >= 1,
-        "a stale stamp must fall back to the FromText recompute, which ignores the poisoned \
-         column: {report:?}"
+    assert_eq!(
+        ai::policy_fromtext_calls(),
+        0,
+        "after the heal re-certifies the stamp, the embed loop must read the column, not \
+         re-parse: {report:?}"
     );
+    assert_eq!(
+        policy_version(&db).as_deref(),
+        Some(ai::EMBEDDING_POLICY_VERSION),
+        "the stale-stamp reconcile heals and re-certifies"
+    );
+    assert!(report.embeddings_written >= 1, "the healed Embed chunk still embeds: {report:?}");
     let _ = fs::remove_dir_all(root);
 }
 
@@ -339,10 +357,13 @@ fn self_heal_refreshes_stale_priorities_under_an_unchanged_policy() {
 #[test]
 fn reconcile_embed_path_recomputes_at_a_non_default_cap() {
     // A CURRENT stamp at a NON-DEFAULT cap also fails certification (the column is stamped at the
-    // DEFAULT cap, and a different cap re-buckets SkipTooLarge) — the embed path recomputes and
-    // ignores the poison.
+    // DEFAULT cap, and a different cap re-buckets SkipTooLarge), and the self-heal is skipped at a
+    // non-default cap too — so the embed path genuinely re-derives FromText and ignores the poison.
+    // This is the fallback that must DISAGREE with the certified fast path: the FromText counter is
+    // positive here, zero in `reconcile_embed_path_reads_the_stamped_policy_column`.
     let root = unique_temp_root();
     let db = poisoned_embed_fixture(&root);
+    ai::reset_policy_fromtext_calls();
     let report = db
         .reconcile_with_options_progress(
             ai::ReconcileOptions {
@@ -356,6 +377,11 @@ fn reconcile_embed_path_recomputes_at_a_non_default_cap() {
     assert!(
         report.embeddings_written >= 1,
         "a non-default-cap reconcile must not trust the DEFAULT-cap column: {report:?}"
+    );
+    assert!(
+        ai::policy_fromtext_calls() > 0,
+        "the uncertified embed path must re-derive policy FromText (the fallback the fast path \
+         avoids)"
     );
     let _ = fs::remove_dir_all(root);
 }

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/embedding_policy_fast_path.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/embedding_policy_fast_path.rs
@@ -316,6 +316,32 @@ fn stale_stamp_reconcile_heals_then_takes_the_fast_path() {
 }
 
 #[test]
+fn reconcile_plan_classifies_from_the_stamped_column_like_the_embed_path() {
+    // `reconcile --plan` must preview exactly what `reconcile` will do — so under a certified stamp
+    // it classifies candidates from the stamped column, not FromText (which can legitimately
+    // disagree on a chunk slicing a long comment/string). Poison every Embed chunk to SkipLowSignal
+    // under a current stamp: the plan must report zero eligible work (it read the column) and take
+    // no FromText re-parse, matching the embed path on the same index. A FromText recompute would
+    // classify the fn chunk Embed and count it missing.
+    let root = unique_temp_root();
+    let db = poisoned_embed_fixture(&root);
+    ai::reset_policy_fromtext_calls();
+    let plan = db.reconcile_plan().unwrap();
+    assert_eq!(
+        ai::policy_fromtext_calls(),
+        0,
+        "a certified-stamp plan must read the column, not re-classify FromText"
+    );
+    assert_eq!(
+        plan.embeddings.missing, 0,
+        "the plan reads the poisoned (SkipLowSignal) column, so nothing is eligible — matching \
+         the embed path: {:?}",
+        plan.embeddings
+    );
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
 fn self_heal_refreshes_stale_priorities_under_an_unchanged_policy() {
     // The stamp certifies policy AND priority (the embed path trusts both, #725), and a classifier
     // change can move priority while the policy name stays the same. A heal that rewrote only

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/embedding_policy_fast_path.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/embedding_policy_fast_path.rs
@@ -298,6 +298,45 @@ fn reconcile_embed_path_recomputes_on_a_stale_stamp() {
 }
 
 #[test]
+fn self_heal_refreshes_stale_priorities_under_an_unchanged_policy() {
+    // The stamp certifies policy AND priority (the embed path trusts both, #725), and a classifier
+    // change can move priority while the policy name stays the same. A heal that rewrote only
+    // `embedding_policy` would re-certify stale priorities — so the heal must stage on either
+    // column differing and write both back. Poison the fn chunk's priority (policy untouched),
+    // stale the stamp, and let the default-cap reconcile self-heal: the priority must be restored
+    // and the stamp current again.
+    let root = unique_temp_root();
+    rust_fixture(&root);
+    let db = IndexDatabase::rebuild(&source_config(root.clone(), Language::Rust)).unwrap();
+    let conn = db.storage.connection();
+    let poisoned = conn
+        .execute(
+            "UPDATE main.chunks SET embedding_priority = 7 WHERE embedding_policy = 'Embed'",
+            [],
+        )
+        .unwrap();
+    assert!(poisoned >= 1, "the fixture must have an Embed chunk whose priority can be poisoned");
+    stale_the_stamp(&db);
+
+    db.reconcile_with_options_progress(
+        ai::ReconcileOptions { batch_size: Some(8), ..Default::default() },
+        |_| {},
+    )
+    .unwrap();
+
+    let still_poisoned: i64 = conn
+        .query_row("SELECT COUNT(*) FROM chunks WHERE embedding_priority = 7", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(still_poisoned, 0, "the heal must recompute priorities, not just policy names");
+    assert_eq!(
+        policy_version(&db).as_deref(),
+        Some(ai::EMBEDDING_POLICY_VERSION),
+        "the heal re-certifies after writing BOTH columns"
+    );
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
 fn reconcile_embed_path_recomputes_at_a_non_default_cap() {
     // A CURRENT stamp at a NON-DEFAULT cap also fails certification (the column is stamped at the
     // DEFAULT cap, and a different cap re-buckets SkipTooLarge) — the embed path recomputes and

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/embedding_policy_fast_path.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/embedding_policy_fast_path.rs
@@ -233,6 +233,94 @@ fn incremental_edit_keeps_the_certified_column_fresh() {
     let _ = fs::remove_dir_all(root);
 }
 
+/// Shared setup for the embed-path policy-source tests (#725): a rebuild whose fn chunk classifies
+/// Embed, the deterministic hash embedder installed, and every Embed row poisoned to
+/// `SkipLowSignal` in the column. Whether a reconcile then embeds is exactly the question of which
+/// policy source it read: the column (obeys the poison → nothing embedded) or a FromText recompute
+/// (ignores it → the fn chunk is embedded).
+fn poisoned_embed_fixture(root: &std::path::Path) -> IndexDatabase {
+    rust_fixture(root);
+    let mut config = source_config(root.to_path_buf(), Language::Rust);
+    // Select the hash embedder explicitly: a fresh index adopts the CONFIGURED model (#394), and
+    // the default all-MiniLM would leave the reconcile Blocked before it reads any policy.
+    config.llm.embedding.backend = HASH_MODEL_ID.parse().unwrap();
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    db.install_model(HASH_MODEL_ID, None).unwrap();
+    let poisoned = db
+        .storage
+        .connection()
+        .execute(
+            "UPDATE main.chunks SET embedding_policy = 'SkipLowSignal'
+             WHERE embedding_policy = 'Embed'",
+            [],
+        )
+        .unwrap();
+    assert!(poisoned >= 1, "the fixture must stamp at least one Embed chunk to poison");
+    db
+}
+
+#[test]
+fn reconcile_embed_path_reads_the_stamped_policy_column() {
+    // The embed path takes each candidate's policy from the CERTIFIED stamped column instead of
+    // re-deriving it FromText — the per-candidate tree-sitter re-parse that dominated large
+    // reconciles (#725). Under a current stamp at the default cap, the poisoned column must be
+    // OBEYED: zero embeddings written. Only the column read produces that outcome — a recompute
+    // would classify the fn chunk Embed and write it.
+    let root = unique_temp_root();
+    let db = poisoned_embed_fixture(&root);
+    let report = db.reconcile(None, Some(8)).unwrap();
+    assert_eq!(
+        report.embeddings_written, 0,
+        "a certified-stamp reconcile must serve the poisoned column; an embedding written means \
+         the embed path re-derived policy from text"
+    );
+    assert_eq!(db.current_embedding_count(HASH_MODEL_ID).unwrap(), 0);
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn reconcile_embed_path_recomputes_on_a_stale_stamp() {
+    // A STALE stamp fails certification, so the embed path re-derives FromText (and the
+    // default-cap self-heal may rewrite the column first) — either way the poison is ignored and
+    // the Embed-classified chunk gets its embedding. Paired with
+    // `reconcile_embed_path_reads_the_stamped_policy_column`, the two outcomes DISAGREE on the
+    // same poisoned index — the proof the fast path is real rather than a no-op.
+    let root = unique_temp_root();
+    let db = poisoned_embed_fixture(&root);
+    stale_the_stamp(&db);
+    let report = db.reconcile(None, Some(8)).unwrap();
+    assert!(
+        report.embeddings_written >= 1,
+        "a stale stamp must fall back to the FromText recompute, which ignores the poisoned \
+         column: {report:?}"
+    );
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn reconcile_embed_path_recomputes_at_a_non_default_cap() {
+    // A CURRENT stamp at a NON-DEFAULT cap also fails certification (the column is stamped at the
+    // DEFAULT cap, and a different cap re-buckets SkipTooLarge) — the embed path recomputes and
+    // ignores the poison.
+    let root = unique_temp_root();
+    let db = poisoned_embed_fixture(&root);
+    let report = db
+        .reconcile_with_options_progress(
+            ai::ReconcileOptions {
+                batch_size: Some(8),
+                max_embedding_chars: ai::DEFAULT_MAX_EMBEDDING_CHARS + 1_000,
+                ..Default::default()
+            },
+            |_| {},
+        )
+        .unwrap();
+    assert!(
+        report.embeddings_written >= 1,
+        "a non-default-cap reconcile must not trust the DEFAULT-cap column: {report:?}"
+    );
+    let _ = fs::remove_dir_all(root);
+}
+
 #[test]
 fn absent_stamp_takes_the_recompute_path() {
     // A never-stamped index (a pre-#530 DB, or one never fully rebuilt with this binary) has NO


### PR DESCRIPTION
Closes #725.

Whole-kernel `reconcile` (1.26M chunks, hash embedder) ran at a dead-steady **66 chunks/s** — ~5.3 h projected, model cost ~zero. Per-phase timing on the real kernel index isolated two independent costs; the parse I first suspected was the smaller one.

| Per-chunk cost | Before | After |
|---|---|---|
| Per-batch chunk SQL (join against the live `files` view) | **~15 ms** | ~7 µs |
| Policy classification (FromText tree-sitter re-parse) | ~234 µs | ~1.7 µs |

## Primary: don't join the live scope view per chunk row

`current_chunks_by_ids` (the per-batch chunk load) joined the live `files` view — a repo/generation-scoped `UNION ALL` compound (`lifecycle.rs`) that SQLite re-evaluates for **each** correlated `files.id = chunks.file_id` probe. That made the embed loop O(chunks × files); the ~15 ms/chunk was essentially the entire 66 chunks/s.

Fix: `snapshot_reconcile_scope_files` materializes the scoped file metadata (id/path/language/kind) into an indexed temp table once per run, alongside the candidate-id list; the per-batch query joins that. Probe drops to O(log files). Full-scan queries (the candidate list, the estimate) were never affected — the planner materializes the view once for a scan.

## Secondary: read the certified stamped policy column

`select_reconcile_batch` re-derived each candidate's policy `FromText`, whose low-signal gate tree-sitter-parses the chunk. `chunks.embedding_policy`/`embedding_priority` already carry the index-time FromSpan truth, certified per-repo by the #530 version+cap stamps. `job_policy` now reads the certified columns; any miss (stale/absent stamp, non-default cap) falls back to the FromText recompute unchanged. Negligible before, but ~70% of the remaining per-chunk cost once the SQL join is fixed.

Two correctness follow-ons (both from review):
- The self-heal now writes **both** `embedding_policy` and `embedding_priority` before re-stamping (it wrote only policy, which would re-certify stale priorities the embed path trusts).
- `stamped_policy` is re-derived **after** the self-heal, so the first reconcile post-classifier-upgrade takes the fast path instead of re-parsing the whole run while the heal had already repaired the column.

## Measured (whole kernel, self-hosted bigmem box, hash embedder)

**Reconcile: 66 → 4,983 chunks/s (~75×).** 1,260,723 chunks in **253 s** (4.2 min), vs the ~5.3 h projection (a prior run was killed at the 120-min CI cap at 33%). `written=1,260,723 failed=0 blocked=0`.

## Tests

The three embed-path tests now make the fast path *measurably disagree* with the fallback via a test-only FromText-call counter: **0** re-parses on a certified stamp and on a freshly-healed stale stamp (the post-upgrade regression guard), **> 0** at a non-default cap (genuine fallback). Plus a heal test pinning that a poisoned `embedding_priority` under an unchanged policy is restored.

Gates on the reference box (self-hosted bigmem, rustc 1.96.0): `clippy --workspace --all-targets --no-default-features -D warnings` clean; `--all-features` clean; `cargo test -p rag-rat-core --no-default-features` — fast-path + reconcile suites pass. Codex read-only review folded (the two correctness follow-ons above are its P2s).

Also fixes #729 (the `--plan`/status count path now shares the certified `job_policy` gate).