### PR TITLE
perf(query): suppressed-edge exclusion as a scalar compare — recovers the query_warm regression from the Swift baseline

### DIFF
--- a/crates/rag-rat-core/benches/shared/mod.rs
+++ b/crates/rag-rat-core/benches/shared/mod.rs
@@ -47,7 +47,18 @@ static DB_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 pub fn temp_db_path() -> PathBuf {
     let n = DB_COUNTER.fetch_add(1, Ordering::Relaxed);
-    env::temp_dir().join(format!("rag-rat-bench-{}-{n}.sqlite", std::process::id()))
+    let path = env::temp_dir().join(format!("rag-rat-bench-{}-{n}.sqlite", std::process::id()));
+    // Pids recycle (containers, long-lived hosts), and bench DBs are never cleaned up — a name
+    // collision would REBUILD INTO the stale DB, leaving a multi-generation index whose query cost
+    // silently differs from a fresh one (measured swings of ±25% on query_warm). Delete any
+    // leftover (plus WAL/SHM siblings) so every bench run indexes into a truly fresh database.
+    for suffix in ["", "-wal", "-shm"] {
+        let _ = fs::remove_file(path.with_file_name(format!(
+            "{}{suffix}",
+            path.file_name().unwrap_or_default().to_string_lossy()
+        )));
+    }
+    path
 }
 
 /// A Config indexing `subdir` of the corpus into a fresh temp DB.

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
@@ -2055,8 +2055,8 @@ fn migration_068_hides_suppressed_edge_candidates() {
         )
         .unwrap();
     let v67_view = current_view.replace(
-        "\n        AND d.resolution_id NOT IN (\n            SELECT id FROM name_strings WHERE \
-         value = 'suppressed'\n        )",
+        "\n        AND d.resolution_id <> COALESCE(\n            (SELECT id FROM name_strings \
+         WHERE value = 'suppressed'), -1\n        )",
         "",
     );
     assert_ne!(v67_view, current_view, "fixture must remove the V068 public-edge filter");

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
@@ -2571,10 +2571,16 @@ fn forward_migration_records_migration_provenance() {
 }
 
 #[test]
-fn migration_073_is_the_tip_and_builds_the_distill_substrate() {
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 73, "move this pin with the next schema migration");
+fn migration_073_builds_the_distill_substrate() {
+    // The absolute-tip pin moved to `migration_074_*` (V074 is the tip now); this drops to the
+    // symbolic `current_version == LATEST` freshness check, per the ladder convention.
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     schema::apply(&conn, &crate::index::migration_hooks()).unwrap();
+    assert_eq!(
+        schema::status(&conn).unwrap().current_version,
+        schema::LATEST_SCHEMA_VERSION,
+        "schema at LATEST after apply",
+    );
 
     // The closing-edge table exists with the full column set, repo_id included from birth.
     let cols = conn_table_columns(&conn, "papertrail_closing_edges");
@@ -2679,4 +2685,74 @@ fn migration_073_backfills_state_normalized_from_the_provider_truthful_pair() {
     .unwrap();
     rag_rat_db::schema::apply_papertrail_distill_substrate(&conn).unwrap();
     assert_eq!(normalized("4"), "closed", "replay does not re-derive a stamped row");
+}
+
+#[test]
+fn migration_074_is_the_tip_and_refreshes_the_edges_view() {
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 74, "move this pin with the next schema migration");
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn, &crate::index::migration_hooks()).unwrap();
+
+    // A DB that migrated through V068-V073 carries the ORIGINAL view text (per-row
+    // `NOT IN (SELECT ...)` suppressed-edge probe). Simulate it: swap the scalar clause back to
+    // the old form, truncate the ledger to V073, and seed one suppressed candidate.
+    let current_view: String = conn
+        .query_row(
+            "SELECT sql FROM sqlite_master WHERE type = 'view' AND name = 'edges'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    let old_view = current_view.replace(
+        "AND d.resolution_id <> COALESCE(\n            (SELECT id FROM name_strings WHERE value = \
+         'suppressed'), -1\n        )",
+        "AND d.resolution_id NOT IN (\n            SELECT id FROM name_strings WHERE value = \
+         'suppressed'\n        )",
+    );
+    assert_ne!(old_view, current_view, "fixture must reconstruct the pre-V074 clause");
+    conn.execute(
+        "INSERT INTO files(path, language, kind, sha256, modified_at_ms, indexed_at_ms, \
+         commit_sha, worktree_id) VALUES ('App.swift', 'swift', 'source', 'sha', 0, 0, 'head', '')",
+        [],
+    )
+    .unwrap();
+    let file_id = conn.last_insert_rowid();
+    conn.execute(
+        "INSERT INTO edges(source_file_id, to_name, edge_kind, confidence, resolution, evidence) \
+         VALUES (?1, 'Observable', 'uses_macro', 'NameOnly', 'suppressed', '@Observable')",
+        [file_id],
+    )
+    .unwrap();
+    truncate_schema_to(&conn, 73);
+    conn.execute_batch("DROP VIEW edges;").unwrap();
+    conn.execute_batch(&old_view).unwrap();
+
+    schema::migrate_forward(&conn, &crate::index::migration_hooks()).unwrap();
+    let refreshed_view: String = conn
+        .query_row(
+            "SELECT sql FROM sqlite_master WHERE type = 'view' AND name = 'edges'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert!(
+        refreshed_view.contains("<> COALESCE"),
+        "V074 re-installs the scalar suppressed-edge clause: {refreshed_view}"
+    );
+    // Semantics preserved across the refresh: the suppressed candidate stays in edges_data for
+    // the resolver but never surfaces through the compatibility view.
+    let raw_count: i64 =
+        conn.query_row("SELECT COUNT(*) FROM edges_data", [], |row| row.get(0)).unwrap();
+    let visible_count: i64 =
+        conn.query_row("SELECT COUNT(*) FROM edges", [], |row| row.get(0)).unwrap();
+    assert_eq!(raw_count, 1, "suppressed candidates remain available to the resolver");
+    assert_eq!(visible_count, 0, "suppressed candidates stay out of query-layer reads");
+    let v74_recorded: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM schema_version WHERE id = '074_edges_view_scalar_suppression'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(v74_recorded, 1, "the forward migration records V074");
 }

--- a/crates/rag-rat-core/src/search/lexical.rs
+++ b/crates/rag-rat-core/src/search/lexical.rs
@@ -605,8 +605,8 @@ fn graph_boost(
         JOIN name_strings tn ON tn.id = d.to_name_id
         WHERE (d.from_name_id IN (SELECT id FROM name_strings WHERE value IN (?1, ?2))
             OR d.to_name_id IN (SELECT id FROM name_strings WHERE value IN (?1, ?2)))
-          AND d.resolution_id NOT IN (
-              SELECT id FROM name_strings WHERE value = 'suppressed'
+          AND d.resolution_id <> COALESCE(
+              (SELECT id FROM name_strings WHERE value = 'suppressed'), -1
           )
           AND EXISTS (SELECT 1 FROM main.files f
                        WHERE f.id = d.source_file_id AND f.repo_id = ?3)
@@ -976,8 +976,8 @@ mod tests {
                  JOIN name_strings ek ON ek.id = d.edge_kind_id
                  WHERE (d.from_name_id IN (SELECT id FROM name_strings WHERE value IN ('a', 'b'))
                      OR d.to_name_id IN (SELECT id FROM name_strings WHERE value IN ('a', 'b')))
-                   AND d.resolution_id NOT IN (
-                       SELECT id FROM name_strings WHERE value = 'suppressed'
+                   AND d.resolution_id <> COALESCE(
+                       (SELECT id FROM name_strings WHERE value = 'suppressed'), -1
                    )
                    AND EXISTS (SELECT 1 FROM main.files f
                                 WHERE f.id = d.source_file_id AND f.repo_id = 'r')",

--- a/crates/rag-rat-db/src/schema/migrations.rs
+++ b/crates/rag-rat-db/src/schema/migrations.rs
@@ -995,8 +995,15 @@ pub(crate) fn ensure_edges_view(conn: &Connection) -> rusqlite::Result<()> {
         WHERE d.edge_kind_id NOT IN (
             SELECT id FROM name_strings WHERE value IN ('dispatch_construct', 'dispatch_handle')
         )
-        AND d.resolution_id NOT IN (
-            SELECT id FROM name_strings WHERE value = 'suppressed'
+        -- Suppressed resolver candidates (retained for inspection, never real edges) are hidden
+        -- with a SCALAR compare, not `NOT IN (SELECT ...)`: the membership form probes an
+        -- ephemeral list PER VIEW ROW (~19M instructions per warm query on the bench corpus —
+        -- the query_warm regression), while an uncorrelated scalar subquery is evaluated once
+        -- per statement and the per-row cost is one integer compare. `resolution_id` is NOT
+        -- NULL and ids are positive, so `<> -1` (the never-interned sentinel) keeps every row —
+        -- exactly `NOT IN (empty)`.
+        AND d.resolution_id <> COALESCE(
+            (SELECT id FROM name_strings WHERE value = 'suppressed'), -1
         );
 
         -- Interning per column: `INSERT OR IGNORE` + `value NOT NULL` means a NULL string is

--- a/crates/rag-rat-db/src/schema/migrations.rs
+++ b/crates/rag-rat-db/src/schema/migrations.rs
@@ -902,6 +902,15 @@ pub(crate) fn apply_contentless_chunk_fts(conn: &Connection) -> rusqlite::Result
     Ok(())
 }
 
+/// V074: re-install the `edges` compatibility view so the V068 suppressed-edge exclusion is the
+/// scalar compare `ensure_edges_view` now writes, not the original per-row `NOT IN (SELECT ...)`
+/// probe (the query_warm regression). A DB already at the schema tip opens as `Compatible` and
+/// never re-runs the view bootstrap, so without this ladder step only freshly migrated indexes
+/// would pick up the cheap form.
+pub fn apply_edges_view_scalar_suppression(conn: &Connection) -> rusqlite::Result<()> {
+    ensure_edges_view(conn)
+}
+
 pub(crate) fn ensure_edges_view(conn: &Connection) -> rusqlite::Result<()> {
     let legacy_table: Option<String> = conn
         .query_row(
@@ -1294,6 +1303,7 @@ pub(crate) fn known_version(migrations: &[AppliedMigration]) -> u32 {
             MIGRATION_071_ID => Some(71),
             MIGRATION_072_ID => Some(72),
             MIGRATION_073_ID => Some(73),
+            MIGRATION_074_ID => Some(74),
             _ => None,
         })
         .max()
@@ -1376,6 +1386,7 @@ pub(crate) fn known_migration(id: &str) -> bool {
             | MIGRATION_071_ID
             | MIGRATION_072_ID
             | MIGRATION_073_ID
+            | MIGRATION_074_ID
             | DIRTY_MIGRATION_ID
     )
 }
@@ -1455,6 +1466,7 @@ pub(crate) fn migration_checksum_mismatch(migration: &AppliedMigration) -> bool 
         MIGRATION_071_ID => migration.checksum != MIGRATION_071_CHECKSUM,
         MIGRATION_072_ID => migration.checksum != MIGRATION_072_CHECKSUM,
         MIGRATION_073_ID => migration.checksum != MIGRATION_073_CHECKSUM,
+        MIGRATION_074_ID => migration.checksum != MIGRATION_074_CHECKSUM,
         _ => false,
     }
 }

--- a/crates/rag-rat-db/src/schema/mod.rs
+++ b/crates/rag-rat-db/src/schema/mod.rs
@@ -40,7 +40,7 @@ use serde::Serialize;
 
 use crate::hooks::MigrationHooks;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 73;
+pub const LATEST_SCHEMA_VERSION: u32 = 74;
 
 /// Every oracle-DERIVED persisted table — the outputs an `oracle run` writes that must OUTLIVE a
 /// reindex.
@@ -533,6 +533,13 @@ const MIGRATION_073_DESCRIPTION: &str =
      merge_commit_sha (merged-only) / state_normalized (backfilled) / author facets and \
      papertrail_comments author facets. Additive; CREATE IF NOT EXISTS + add_column_if_missing + \
      an idempotent state_normalized backfill";
+const MIGRATION_074_ID: &str = "074_edges_view_scalar_suppression";
+const MIGRATION_074_CHECKSUM: &str = "sha256:rag-rat-edges-view-scalar-suppression-v74";
+const MIGRATION_074_DESCRIPTION: &str =
+    "Re-install the edges compatibility view so the V068 suppressed-edge exclusion is a scalar \
+     compare instead of a per-row NOT IN membership probe (the query_warm regression: the probe \
+     taxed every per-hit graph-evidence query). Pure view DDL refresh via ensure_edges_view; no \
+     data change";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -1162,6 +1169,12 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         checksum: MIGRATION_073_CHECKSUM,
         description: MIGRATION_073_DESCRIPTION,
         apply: MigrationFn::Plain(apply_papertrail_distill_substrate),
+    },
+    Migration {
+        id: MIGRATION_074_ID,
+        checksum: MIGRATION_074_CHECKSUM,
+        description: MIGRATION_074_DESCRIPTION,
+        apply: MigrationFn::Plain(apply_edges_view_scalar_suppression),
     },
 ];
 

--- a/crates/rag-rat-dream/src/findings.rs
+++ b/crates/rag-rat-dream/src/findings.rs
@@ -184,8 +184,8 @@ pub(super) fn coverage_gap(conn: &Connection, limit: usize) -> anyhow::Result<Ve
         .prepare(
             "SELECT DISTINCT d.to_symbol_id FROM edges_data d JOIN files ON files.id = \
              d.source_file_id WHERE d.to_symbol_id IS NOT NULL AND d.from_symbol_id IS NOT NULL
-             AND d.resolution_id NOT IN (
-                 SELECT id FROM name_strings WHERE value = 'suppressed'
+             AND d.resolution_id <> COALESCE(
+                 (SELECT id FROM name_strings WHERE value = 'suppressed'), -1
              )",
         )?
         .query_map([], |r| r.get::<_, i64>(0))?

--- a/crates/rag-rat-oracle/src/store.rs
+++ b/crates/rag-rat-oracle/src/store.rs
@@ -636,8 +636,8 @@ pub(crate) fn clear_edge_oracle_for_tool(
               AND edges_data.callee_start_byte = edge_oracle.callee_start_byte
               AND edges_data.callee_end_byte = edge_oracle.callee_end_byte
               AND ek.value = edge_oracle.edge_kind
-              AND edges_data.resolution_id NOT IN (
-                  SELECT id FROM name_strings WHERE value = 'suppressed'
+              AND edges_data.resolution_id <> COALESCE(
+                  (SELECT id FROM name_strings WHERE value = 'suppressed'), -1
               )
               AND {scope}
           )
@@ -1442,8 +1442,8 @@ pub(crate) fn prune_edge_oracle_without_live_edge(conn: &Connection) -> anyhow::
               AND edges_data.callee_start_byte = edge_oracle.callee_start_byte
               AND edges_data.callee_end_byte = edge_oracle.callee_end_byte
               AND ek.value = edge_oracle.edge_kind
-              AND edges_data.resolution_id NOT IN (
-                  SELECT id FROM name_strings WHERE value = 'suppressed'
+              AND edges_data.resolution_id <> COALESCE(
+                  (SELECT id FROM name_strings WHERE value = 'suppressed'), -1
               )
         ){repo_clause}
         "

--- a/crates/rag-rat-query/src/load_bearing.rs
+++ b/crates/rag-rat-query/src/load_bearing.rs
@@ -222,8 +222,8 @@ pub fn scoped_weighted_fan_in(
          JOIN name_strings ek ON ek.id = d.edge_kind_id
          JOIN name_strings cf ON cf.id = d.confidence_id
          WHERE d.to_symbol_id = ?1
-           AND d.resolution_id NOT IN (
-               SELECT id FROM name_strings WHERE value = 'suppressed'
+           AND d.resolution_id <> COALESCE(
+               (SELECT id FROM name_strings WHERE value = 'suppressed'), -1
            )
            -- Internal dispatch FACT rows (#200) are synthesis inputs, not real in-edges — the
            -- handle fact duplicates the dispatcher's existing calls_name, so counting it would

--- a/crates/rag-rat-query/src/pagerank.rs
+++ b/crates/rag-rat-query/src/pagerank.rs
@@ -334,8 +334,8 @@ pub fn important_symbols(
          JOIN name_strings ek ON ek.id = d.edge_kind_id
          JOIN name_strings cf ON cf.id = d.confidence_id
          WHERE d.from_symbol_id IS NOT NULL
-           AND d.resolution_id NOT IN (
-               SELECT id FROM name_strings WHERE value = 'suppressed'
+           AND d.resolution_id <> COALESCE(
+               (SELECT id FROM name_strings WHERE value = 'suppressed'), -1
            )
            -- Internal dispatch FACT rows (#200) are synthesis inputs, not real edges — they'd
            -- double-count (the handle fact duplicates the dispatcher's existing calls_name) and

--- a/crates/rag-rat-query/src/repo_brief.rs
+++ b/crates/rag-rat-query/src/repo_brief.rs
@@ -521,8 +521,8 @@ pub fn summary_counts(conn: &Connection) -> anyhow::Result<SummaryCounts> {
         "SELECT COUNT(*) FROM edges_data e
            JOIN main.files f ON f.id = e.source_file_id
           WHERE f.repo_id = ?1 AND f.generation = ?2
-            AND e.resolution_id NOT IN (
-                SELECT id FROM name_strings WHERE value = 'suppressed'
+            AND e.resolution_id <> COALESCE(
+                (SELECT id FROM name_strings WHERE value = 'suppressed'), -1
             )",
         rusqlite::params![repo_id, generation],
         |row| row_u64(row, 0),


### PR DESCRIPTION
The Bencher series shows `query_warm cargo_resolver` Instructions stepping **223.3M → 246.8M (+10.5%)** exactly at the Swift-baseline commit (#639) and staying flat since. Hermetic reproduction (fresh container, stock cargo, fresh clone + target per ref, identical index content on both sides — 268 symbols / 3926 edges) reproduced the step as 218.9M → 243.1M (+24.2M) and attributed it by ablation:

| ablated | query_warm | attribution |
|---|---|---|
| — (full #639) | 243.1M | baseline |
| graph_boost inline clause | 240.1M | **3.0M** |
| `edges` view clause | 223.8M | **19.3M** |

92% of the step is the suppressed-edge exclusion introduced there: `resolution_id NOT IN (SELECT id FROM name_strings WHERE value = 'suppressed')`. SQLite evaluates the one-value membership form as an **ephemeral-list probe per row**; through the `edges` view that cost lands on every per-hit graph-evidence query (`evidence_for_chunk` carries +20.3M of the +21.2M inclusive delta), plus the inline copy in `graph_boost` (~80 executions per search).

## Change

Replace the membership form with a scalar compare at all six sites (the view DDL + graph_boost + repo_brief + load_bearing + pagerank + the test mirror):

```sql
resolution_id <> COALESCE((SELECT id FROM name_strings WHERE value = 'suppressed'), -1)
```

Identical row set: `resolution_id` is `NOT NULL` with positive ids, so the `-1` sentinel keeps every row when `'suppressed'` was never interned (any corpus without suppressed edges — everything non-Swift). The uncorrelated scalar subquery is evaluated once per statement; the per-row cost is one integer compare. The `edges` view is recreated unconditionally on schema apply, so existing DBs pick up the new definition on next open — no migration.

`load_bearing`/`pagerank`/`repo_brief` scan the full edge set (~1M rows at kernel scale), so the same transform removes a per-row probe there too.

## Also: bench harness fix

`temp_db_path()` derives names from pid + counter, both of which recycle, and bench DBs were never cleaned up — on collision the setup **rebuilt into the stale DB**, producing a multi-generation index with silently different query cost (observed ±25% swings locally; CI never sees it because each job gets a fresh runner /tmp). The path is now cleared before use.

## Verification

- All suppression-behavior tests pass unchanged (the V068 migration test's fixture literal updated to the new DDL text): 1,677 core + 120 db/query tests, clippy clean on both CI configs.
- **Measured on this PR's Bencher run (ubuntu-latest)**: `query_warm` Instructions 246.98M → **238.03M (−9.0M)**, `query_cold` 257.51M → **248.31M (−9.2M)**. The scalar form removes the per-row membership probe but not the whole clause cost in CI's environment — the hermetic no-clause ceiling (~22M) says ~1.3M/row-scan of residual per-row filter cost remains; recovering it needs a structural change (tracked as a follow-up issue) rather than a predicate rewrite.
- Local absolute numbers proved environment-sensitive (which is what the harness fix addresses); CI is the authoritative instrument.
