### PR TITLE
fix(tests): route test scratch through a shared self-healing helper (fixes #726)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3587,6 +3587,7 @@ name = "rag-rat-base"
 version = "0.19.0"
 dependencies = [
  "anyhow",
+ "filetime",
  "gix",
  "libc",
  "minicbor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,9 @@ chacha20poly1305 = { version = "0.11", default-features = false, features = ["al
 # links, so it adds NO second sha2/digest stack — `Hkdf::<sha2::Sha256>` reuses the existing hash.
 hkdf = "0.13"
 fastembed = { version = "5.17.2", default-features = false, features = ["hf-hub-rustls-tls", "ort-download-binaries-rustls-tls"] }
+# Cross-platform mtime setter, used only by `test_scratch`'s sweep test to age a fixture dir past
+# the sweep threshold (already in the tree transitively; a dev-dependency, not shipped).
+filetime = "0.2"
 # `join_all` drives the per-binding mirror jobs concurrently on the papertrail
 # current-thread runtime (reqwest already pulls futures-util transitively).
 futures-util = { version = "0.3", default-features = false, features = ["alloc"] }

--- a/crates/rag-rat-base/Cargo.toml
+++ b/crates/rag-rat-base/Cargo.toml
@@ -30,4 +30,5 @@ tracing-appender.workspace = true
 tracing-subscriber.workspace = true
 
 [dev-dependencies]
+filetime.workspace = true
 tempfile.workspace = true

--- a/crates/rag-rat-base/src/lib.rs
+++ b/crates/rag-rat-base/src/lib.rs
@@ -17,5 +17,6 @@ pub mod repo_discover;
 pub mod repo_identity;
 pub mod serde_big_id;
 pub mod stack;
+pub mod test_scratch;
 pub mod time;
 pub mod version;

--- a/crates/rag-rat-base/src/test_scratch.rs
+++ b/crates/rag-rat-base/src/test_scratch.rs
@@ -16,8 +16,9 @@
 //!
 //! So this module fixes the leak the other way the issue proposed — a self-healing sweep:
 //!   1. all scratch lives under ONE dedicated, namespaced sub-root of the system temp
-//!      ([`scratch_root`], `<temp>/rag-rat-test-scratch-<euid>`), so a stranded dir is trivially
-//!      found and the sweep below can never touch anything but this helper's own dirs;
+//!      ([`scratch_root`], `<temp>/rag-rat-test-scratch-<tag>` — the euid on Unix, the sanitized
+//!      username on Windows), so a stranded dir is trivially found and the sweep below can never
+//!      touch anything but this helper's own dirs;
 //!   2. the FIRST scratch request in each process sweeps sibling scratch dirs older than
 //!      [`SWEEP_MAX_AGE`] out of that root — self-healing after a `kill -9`, no external cron.
 //!
@@ -34,11 +35,14 @@
 //! [`SWEEP_MAX_AGE`] — attacker-directed deletion of arbitrary directories (#726 review, skakri).
 //!
 //! Two defences, both below:
-//!   * **per-euid namespace** — the root carries the effective uid (`…-<euid>`), so two users
-//!     sharing the temp get structurally distinct roots and a name collision is impossible;
+//!   * **per-user namespace** — the root carries a per-user tag (the effective uid on Unix, the
+//!     sanitized `%USERNAME%` on Windows: `…-<tag>`), so two users sharing the temp get
+//!     structurally distinct roots and a name collision is impossible;
 //!   * **verify before sweep** — [`ensure_secure_root`] re-inspects the created namespace with
-//!     symlink-aware metadata and panics unless it is a real directory (not a symlink) owned by our
-//!     euid, with mode `0700`. A poisoned namespace fails the suite loudly; it is never swept.
+//!     symlink-aware metadata and panics unless it is a real directory (not a symlink, and no
+//!     reparse point on Windows). On Unix it additionally requires ownership by our euid, with mode
+//!     `0700`; ownership verification is Unix-only (see the fn). A poisoned namespace fails the
+//!     suite loudly; it is never swept.
 //!
 //! Not `#[cfg(test)]`: that gate does not propagate across crates, and fixtures in sibling crates
 //! (`rag-rat-core`, `rag-rat-cli`, …) consume this helper. It is not part of the semver-stable API
@@ -50,10 +54,11 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, SystemTime};
 
 /// Prefix of the dedicated system-temp sub-directory under which ALL test scratch lives. The real
-/// namespace appends this process's effective uid ([`scratch_root`] →
-/// `rag-rat-test-scratch-<euid>`) so users sharing the temp never collide. A dedicated namespace
-/// keeps the sweep's blast radius to this helper's own dirs (never the shared temp root) and makes
-/// manual cleanup a one-liner: `rm -rf $TMPDIR/rag-rat-test-scratch-$(id -u)`.
+/// namespace appends a per-user tag ([`scratch_root`] → `rag-rat-test-scratch-<tag>`: the
+/// effective uid on Unix, the sanitized `%USERNAME%` on Windows) so users sharing the temp never
+/// collide. A dedicated namespace keeps the sweep's blast radius to this helper's own dirs (never
+/// the shared temp root) and makes manual cleanup a one-liner:
+/// `rm -rf $TMPDIR/rag-rat-test-scratch-$(id -u)`.
 pub const SCRATCH_NAMESPACE_PREFIX: &str = "rag-rat-test-scratch";
 
 /// Sweep scratch dirs older than this on first use per process. Two hours is far longer than any
@@ -69,17 +74,41 @@ static SEQ: AtomicU64 = AtomicU64::new(0);
 static SWEEP: Once = Once::new();
 
 /// The scratch root shared by every test in every crate: `<system
-/// temp>/rag-rat-test-scratch-<euid>`.
+/// temp>/rag-rat-test-scratch-<tag>` (per-user tag: euid on Unix, sanitized username on Windows).
 ///
 /// The system temp (not `target/tmp`) so `git init` fixtures have no ancestor `.git`; a dedicated,
-/// per-euid namespace so the sweep can only ever remove this helper's own dirs and two users
+/// per-user namespace so the sweep can only ever remove this helper's own dirs and two users
 /// sharing the temp can never collide.
 pub fn scratch_root() -> PathBuf {
-    std::env::temp_dir().join(format!("{SCRATCH_NAMESPACE_PREFIX}-{}", current_euid()))
+    std::env::temp_dir().join(format!("{SCRATCH_NAMESPACE_PREFIX}-{}", namespace_user_tag()))
+}
+
+/// The per-user tag that suffixes the scratch namespace (`rag-rat-test-scratch-<tag>`), so two
+/// local users sharing the system temp get structurally distinct roots and cannot collide on — or
+/// pre-plant — each other's namespace.
+///
+/// Unix: the effective uid — always present, stable for the process, and the same value the
+/// ownership verification in [`ensure_secure_root`] checks against.
+#[cfg(unix)]
+fn namespace_user_tag() -> String {
+    current_euid().to_string()
+}
+
+/// Windows: the sanitized `%USERNAME%` (`unknown` when unset) — the same collision-avoidance
+/// purpose as the euid, without new dependencies. Every char outside `[A-Za-z0-9_-]` becomes `_`
+/// so the tag is always a valid path component.
+#[cfg(windows)]
+fn namespace_user_tag() -> String {
+    let user = std::env::var("USERNAME").unwrap_or_else(|_| "unknown".to_string());
+    user.chars()
+        .map(|c| if c.is_ascii_alphanumeric() || c == '_' || c == '-' { c } else { '_' })
+        .collect()
 }
 
 /// This process's effective user id, used to make the scratch namespace per-user and to verify
-/// namespace ownership before sweeping.
+/// namespace ownership before sweeping. Unix-only: Windows has no `geteuid` (and no portable
+/// ownership check) — see [`namespace_user_tag`] and [`ensure_secure_root`] for the Windows story.
+#[cfg(unix)]
 fn current_euid() -> u32 {
     // SAFETY: `geteuid` takes no arguments, has no preconditions, and per POSIX always succeeds.
     // On Linux `uid_t` is `u32` (matching `MetadataExt::uid()`); this binding pins that, so a
@@ -88,8 +117,8 @@ fn current_euid() -> u32 {
 }
 
 /// Securely create the scratch namespace `root` and verify it is a real directory this process
-/// owns, panicking loudly otherwise. Run before every sweep so a poisoned namespace can never be
-/// swept.
+/// may sweep (euid ownership on Unix; reparse-point rejection on Windows), panicking loudly
+/// otherwise. Run before every sweep so a poisoned namespace can never be swept.
 ///
 /// # The attack (#726 review, skakri)
 ///
@@ -101,10 +130,14 @@ fn current_euid() -> u32 {
 ///
 /// # The defence
 ///
-/// Create the namespace with mode `0700`, then re-inspect it with **symlink-aware**
+/// Create the namespace (with mode `0700` on Unix), then re-inspect it with **symlink-aware**
 /// [`std::fs::symlink_metadata`] (which does NOT follow links) and require that it is (1) not a
-/// symlink, (2) a directory, and (3) owned by this process's effective uid. Any deviation is a
+/// symlink and (2) a directory — on Windows additionally that it carries no reparse point at
+/// all — and on Unix (3) that it is owned by this process's effective uid. Any deviation is a
 /// poisoned namespace: panic and fail the suite rather than sweep a directory we do not own.
+/// Windows ownership (SID/ACL) verification is deliberately NOT done: it would require
+/// `windows-sys`/`winapi`, and the per-user namespace plus reparse-point rejection is the
+/// Windows story (no new dependencies).
 ///
 /// # TOCTOU boundary (stated honestly)
 ///
@@ -113,19 +146,11 @@ fn current_euid() -> u32 {
 /// NOT close a racing swap performed by an attacker *between* this check and the sweep: closing
 /// that window would require dirfd-relative operations (an `O_NOFOLLOW`/`O_DIRECTORY` `openat` plus
 /// `fstatat`/`unlinkat` pinned to the verified inode) so every later op targets the same inode.
-/// That is out of scope for test scratch: the per-euid namespace already makes a collision
+/// That is out of scope for test scratch: the per-user namespace already makes a collision
 /// structurally irrelevant, and a same-user attacker racing our parent temp gains no privilege. The
 /// realistic, cheap attack — plant a symlink and wait — is fully closed.
 fn ensure_secure_root(root: &Path) {
-    use std::os::unix::fs::{DirBuilderExt, MetadataExt, PermissionsExt};
-
-    // Create only the namespace (its parent temp already exists) with 0700 from birth, so a freshly
-    // created namespace is never group/other-accessible even for an instant.
-    let mut builder = std::fs::DirBuilder::new();
-    builder.recursive(true).mode(0o700);
-    if let Err(err) = builder.create(root) {
-        panic!("test scratch: failed to create namespace {root:?}: {err}");
-    }
+    create_namespace(root);
 
     // Re-inspect with symlink-aware metadata: a pre-planted symlink is caught HERE, before any
     // sweep can traverse (and delete inside) its target.
@@ -143,6 +168,39 @@ fn ensure_secure_root(root: &Path) {
         file_type.is_dir(),
         "test scratch: namespace {root:?} exists but is not a directory (found {file_type:?})",
     );
+
+    verify_namespace_identity(root, &meta);
+}
+
+/// Create only the namespace (its parent temp already exists) with 0700 from birth, so a freshly
+/// created namespace is never group/other-accessible even for an instant. Unix-only: Windows has
+/// no mode bits, so there the create is a plain `create_dir_all` (below).
+#[cfg(unix)]
+fn create_namespace(root: &Path) {
+    use std::os::unix::fs::DirBuilderExt;
+
+    let mut builder = std::fs::DirBuilder::new();
+    builder.recursive(true).mode(0o700);
+    if let Err(err) = builder.create(root) {
+        panic!("test scratch: failed to create namespace {root:?}: {err}");
+    }
+}
+
+/// Windows namespace creation: no Unix mode bits exist, so a plain recursive create. Same
+/// panic-loud failure style as the Unix path.
+#[cfg(windows)]
+fn create_namespace(root: &Path) {
+    if let Err(err) = std::fs::create_dir_all(root) {
+        panic!("test scratch: failed to create namespace {root:?}: {err}");
+    }
+}
+
+/// Unix identity verification: the namespace must be owned by this process's euid, then tightened
+/// to mode `0700`.
+#[cfg(unix)]
+fn verify_namespace_identity(root: &Path, meta: &std::fs::Metadata) {
+    use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
     let owner = meta.uid();
     let euid = current_euid();
     assert_eq!(
@@ -158,6 +216,32 @@ fn ensure_secure_root(root: &Path) {
     {
         panic!("test scratch: cannot set 0700 on namespace {root:?}: {err}");
     }
+}
+
+/// Windows identity verification: reject ANY reparse point on the namespace.
+///
+/// The `is_symlink` assert above ALREADY refuses directory junctions on this toolchain's std
+/// (1.95): `FileType::is_symlink` is `FILE_ATTRIBUTE_REPARSE_POINT && reparse_tag & 0x20000000
+/// != 0` (the name-surrogate bit), and junctions (`IO_REPARSE_TAG_MOUNT_POINT = 0xA0000003`)
+/// carry that bit (see `library/std/src/sys/fs/windows.rs`, `FileType::new`). That junction
+/// coverage is an undocumented, std-version-specific implementation detail, so refuse every
+/// reparse point outright via `file_attributes()` — version-independent, and it also covers
+/// non-name-surrogate tags (e.g. cloud placeholders) that are likewise redirectors we must not
+/// sweep through.
+///
+/// Ownership verification stays Unix-only: Windows SID/ACL checks would need `windows-sys` /
+/// `winapi` (rejected — no new dependencies). The per-user namespace plus this reparse-point
+/// rejection is the Windows story.
+#[cfg(windows)]
+fn verify_namespace_identity(root: &Path, meta: &std::fs::Metadata) {
+    use std::os::windows::fs::MetadataExt;
+
+    const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x400;
+    assert!(
+        meta.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT == 0,
+        "test scratch: namespace {root:?} is a reparse point (symlink/junction/...) — refusing to \
+         sweep its target (possible temp redirector attack; see test_scratch.rs)",
+    );
 }
 
 /// Delete scratch dirs directly under `root` whose mtime is older than [`SWEEP_MAX_AGE`].
@@ -219,22 +303,23 @@ mod tests {
 
     use super::*;
 
-    /// New scratch dirs must land inside the ONE dedicated, PER-EUID namespace sub-root of the
+    /// New scratch dirs must land inside the ONE dedicated, PER-USER namespace sub-root of the
     /// system temp — never scattered directly across the shared temp root (which is what let 16k
-    /// dirs accumulate, and what would make the sweep unsafe). The per-euid suffix is what stops
-    /// two users sharing the temp from colliding on a fixed, attackable path. Bites if creation
-    /// is pointed back at the bare temp dir OR if the namespace is reverted to the un-suffixed
-    /// shared name.
+    /// dirs accumulate, and what would make the sweep unsafe). The per-user suffix (euid on Unix,
+    /// sanitized username on Windows) is what stops two users sharing the temp from colliding on
+    /// a fixed, attackable path. Bites if creation is pointed back at the bare temp dir OR if the
+    /// namespace is reverted to the un-suffixed shared name.
     #[test]
     fn scratch_dirs_live_under_the_dedicated_namespace() {
         let root = scratch_root();
-        // The namespace name carries this process's euid — a shared/un-suffixed name is attackable
-        // on a multi-user temp, so pin the exact per-euid form.
-        let expected = format!("{SCRATCH_NAMESPACE_PREFIX}-{}", current_euid());
+        // The namespace name carries this process's per-user tag (euid on Unix, sanitized
+        // username on Windows) — a shared/un-suffixed name is attackable on a multi-user temp, so
+        // pin the exact per-user form.
+        let expected = format!("{SCRATCH_NAMESPACE_PREFIX}-{}", namespace_user_tag());
         assert_eq!(
             root.file_name(),
             Some(OsStr::new(&expected)),
-            "scratch root should be the dedicated per-euid namespace {expected:?}, got {root:?}",
+            "scratch root should be the dedicated per-user namespace {expected:?}, got {root:?}",
         );
         // The namespace is a CHILD of the system temp, not the bare temp root itself (a bare-root
         // sweep could delete unrelated files).
@@ -275,6 +360,7 @@ mod tests {
     /// attack: without the `symlink_metadata` verification, `create_dir_all` accepts the symlink
     /// and the sweep traverses the target, deleting its aged subdirs. Bites if that
     /// verification is removed (no panic AND the victim's aged dir gets swept).
+    #[cfg(unix)] // plants a symlink via `std::os::unix::fs::symlink`
     #[test]
     fn refuses_symlinked_namespace_and_spares_victim() {
         use std::os::unix::fs::symlink;
@@ -315,6 +401,7 @@ mod tests {
     /// attacker cannot forge ownership, but a directory we do not own is exactly what we must never
     /// sweep. Creating a foreign-owned dir needs root (to `chown`), so this is a no-op when not run
     /// as root. Bites if the euid-ownership check is dropped.
+    #[cfg(unix)] // the ownership check itself is Unix-only; needs `libc::chown`
     #[test]
     fn refuses_foreign_owned_namespace() {
         use std::os::unix::ffi::OsStrExt;

--- a/crates/rag-rat-base/src/test_scratch.rs
+++ b/crates/rag-rat-base/src/test_scratch.rs
@@ -48,7 +48,7 @@
 //! (`rag-rat-core`, `rag-rat-cli`, …) consume this helper. It is not part of the semver-stable API
 //! surface. Matches the existing `rag_rat_oracle::test_support` convention.
 
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::sync::Once;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, SystemTime};
@@ -274,9 +274,30 @@ fn sweep_stale(root: &Path) {
     }
 }
 
+/// Refuse a caller-supplied scratch `tag` that is not exactly one normal path component (#732
+/// review, skakri).
+///
+/// [`scratch_dir`] embeds the tag in the scratch dir name it joins onto the namespace root and
+/// then `remove_dir_all`s — a tag carrying a separator, `.`/`..`, a root, or a Windows prefix
+/// would let that join escape the dedicated namespace and delete outside it. Requiring a single
+/// [`Component::Normal`] and nothing else rejects separators, absolute paths, `..`, `.`, the
+/// empty string, and Windows prefixes under both OS path grammars, so no `cfg` split is needed.
+/// Panic-loud, matching the module's other security checks ([`ensure_secure_root`]).
+fn validate_tag(tag: &str) {
+    let mut components = Path::new(tag).components();
+    assert!(
+        matches!(components.next(), Some(Component::Normal(_))) && components.next().is_none(),
+        "scratch tag must be a single path component: {tag:?}",
+    );
+}
+
 /// A unique scratch directory PATH under [`scratch_root`], keyed by `tag`, the PID, and a
 /// process-wide counter. The path is NOT created (callers create it, matching the fixtures this
 /// replaces); any pre-existing dir at the exact path is removed first.
+///
+/// `tag` must be exactly one normal path component — no separators, no `.`/`..`, not absolute,
+/// not empty — and anything else PANICS before any path is built or deleted, so a hostile tag can
+/// never steer the join/`remove_dir_all` pair outside the scratch namespace (#732 review).
 ///
 /// On the first call per process this also sweeps stale sibling scratch dirs out of the root (see
 /// module docs) — the self-healing backstop for `Drop` cleanup that a `kill -9` skips.
@@ -285,6 +306,8 @@ fn sweep_stale(root: &Path) {
 /// namespace an attacker pre-planted as a symlink (or that another user owns) panics the suite
 /// rather than being swept.
 pub fn scratch_dir(tag: &str) -> PathBuf {
+    validate_tag(tag);
+
     let root = scratch_root();
     ensure_secure_root(&root);
     SWEEP.call_once(|| sweep_stale(&root));
@@ -430,5 +453,95 @@ mod tests {
             result.is_err(),
             "ensure_secure_root must panic on a foreign-owned namespace {namespace:?}",
         );
+    }
+
+    /// Assert `scratch_dir` refuses `tag` by panicking with the single-component message —
+    /// `catch_unwind`, the module's expected-panic pattern. Checking the payload proves the panic
+    /// is the tag validation, not an unrelated filesystem failure.
+    fn assert_tag_refused(tag: &str) {
+        let result = std::panic::catch_unwind(|| scratch_dir(tag));
+        let Err(payload) = result else {
+            panic!("scratch_dir must refuse the non-single-component tag {tag:?}, but it returned");
+        };
+        let msg = payload
+            .downcast_ref::<String>()
+            .map(String::as_str)
+            .or_else(|| payload.downcast_ref::<&'static str>().copied())
+            .unwrap_or("<non-string panic payload>");
+        assert!(
+            msg.contains("scratch tag must be a single path component"),
+            "unexpected panic message for tag {tag:?}: {msg}",
+        );
+    }
+
+    /// A tag carrying a path separator must be refused (#732 review, skakri): joined onto the
+    /// namespace root it would nest the scratch dir below an attacker-chosen subdirectory, and the
+    /// `remove_dir_all` in `scratch_dir` would then delete outside the dedicated namespace.
+    #[test]
+    fn refuses_tag_with_separator() {
+        assert_tag_refused("nested/evil");
+    }
+
+    /// An absolute-path tag must be refused: `Path::join` with an absolute path REPLACES the
+    /// namespace root, so the scratch dir — and its deletion — would land anywhere on disk.
+    #[test]
+    fn refuses_absolute_tag() {
+        assert_tag_refused("/tmp/evil");
+    }
+
+    /// A `..` tag must be refused: it resolves the join to the namespace's PARENT (the shared
+    /// system temp), so `remove_dir_all` would aim at a sibling of the namespace.
+    #[test]
+    fn refuses_parent_dir_tag() {
+        assert_tag_refused("..");
+    }
+
+    /// An empty tag must be refused: it is zero path components, not one.
+    #[test]
+    fn refuses_empty_tag() {
+        assert_tag_refused("");
+    }
+
+    /// A normal single-component tag keeps its exact pre-validation behavior: a fresh path
+    /// directly under the namespace root, named `<tag>-<pid>-<seq>`.
+    #[test]
+    fn accepts_normal_single_component_tag() {
+        let dir = scratch_dir("normal-tag");
+        assert_eq!(dir.parent(), Some(scratch_root().as_path()));
+        let name = dir.file_name().and_then(|n| n.to_str()).unwrap_or_default();
+        assert!(name.starts_with("normal-tag-"), "unexpected scratch name {name:?}");
+    }
+
+    /// The exact #732-review attack: a `..` tag aims the join+delete at a victim OUTSIDE the
+    /// namespace. The victim is pre-created at the precise path the un-validated code would
+    /// delete — predicted from this process's PID and the next SEQ value (nextest runs each test
+    /// in its own process, so this test owns the counter) — so dropping the validation fails this
+    /// test by losing the victim, not just by returning. The call must REFUSE and the victim must
+    /// SURVIVE. Mirror of `refuses_symlinked_namespace_and_spares_victim`.
+    #[test]
+    fn refuses_escaping_tag_and_spares_victim() {
+        // Predict the exact name `scratch_dir` will build for the malicious call below:
+        // `{tag}-{pid}-{seq}`. The join resolves `root/../<predicted>` to a sibling of the
+        // namespace in the shared temp — plant the victim there so the attack has a real target.
+        let tag = "../victim-escape";
+        let predicted =
+            format!("victim-escape-{}-{}", std::process::id(), SEQ.load(Ordering::Relaxed));
+        let victim = std::env::temp_dir().join(predicted);
+        let victim_precious = victim.join("precious-data");
+        std::fs::create_dir_all(&victim_precious).unwrap();
+
+        let result = std::panic::catch_unwind(|| scratch_dir(tag));
+
+        assert!(
+            victim_precious.exists(),
+            "the escaping tag deleted the victim dir {victim:?} outside the scratch namespace",
+        );
+        assert!(
+            result.is_err(),
+            "scratch_dir must refuse the escaping tag {tag:?}, but it returned"
+        );
+
+        // The victim lives outside the swept namespace, so clean it up explicitly.
+        let _ = std::fs::remove_dir_all(&victim);
     }
 }

--- a/crates/rag-rat-base/src/test_scratch.rs
+++ b/crates/rag-rat-base/src/test_scratch.rs
@@ -1,0 +1,158 @@
+//! Shared scratch-directory helper for the workspace's test fixtures.
+//!
+//! Historically every fixture rolled its own `std::env::temp_dir().join(...)` scratch dir, cleaned
+//! only by a `Drop` impl. A panicking test, a killed `nextest` run, or a SIGKILL'd process bypasses
+//! `Drop` and strands the directory under the system temp — on the dev box 16k dirs / ~14 GB of
+//! tmpfs accumulated before a manual sweep (#726).
+//!
+//! # Why the system temp, not `target/tmp`
+//!
+//! The obvious "per-checkout, `cargo clean`-reclaimed" fix — relocate scratch under the build's
+//! `target/tmp/` — is UNSOUND for this codebase. Many fixtures `git init` a throwaway repo and rely
+//! on it having NO ancestor `.git`; `target/tmp/` is inside the project's own git working tree, so
+//! rag-rat's git-context discovery walks up and resolves the *outer* rag-rat repo's identity/commit
+//! (observed: 295 `schema_bootstrap_tests` / worktree-scope failures, panicking with the outer
+//! repo's HEAD sha). Scratch therefore MUST stay in the system temp, isolated from any repo.
+//!
+//! So this module fixes the leak the other way the issue proposed — a self-healing sweep:
+//!   1. all scratch lives under ONE dedicated, namespaced sub-root of the system temp
+//!      ([`SCRATCH_NAMESPACE`]), so a stranded dir is trivially found and the sweep below can never
+//!      touch anything but this helper's own dirs;
+//!   2. the FIRST scratch request in each process sweeps sibling scratch dirs older than
+//!      [`SWEEP_MAX_AGE`] out of that root — self-healing after a `kill -9`, no external cron.
+//!
+//! `Drop`-based cleanup stays the fast path; the age-bounded sweep is only the backstop for the
+//! cases where `Drop` never runs.
+//!
+//! Not `#[cfg(test)]`: that gate does not propagate across crates, and fixtures in sibling crates
+//! (`rag-rat-core`, `rag-rat-cli`, …) consume this helper. It is not part of the semver-stable API
+//! surface. Matches the existing `rag_rat_oracle::test_support` convention.
+
+use std::path::{Path, PathBuf};
+use std::sync::Once;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, SystemTime};
+
+/// The single dedicated sub-directory of the system temp under which ALL test scratch lives. A
+/// dedicated namespace keeps the sweep's blast radius to this helper's own dirs (never the shared
+/// temp root) and makes any manual cleanup a one-liner: `rm -rf $TMPDIR/rag-rat-test-scratch`.
+pub const SCRATCH_NAMESPACE: &str = "rag-rat-test-scratch";
+
+/// Sweep scratch dirs older than this on first use per process. Two hours is far longer than any
+/// single test or `nextest` run (CI caps a wedged test at 60s), so the threshold can never delete a
+/// LIVE parallel worker's fresh dir — only genuinely stranded ones from a crashed/killed run.
+pub const SWEEP_MAX_AGE: Duration = Duration::from_secs(2 * 60 * 60);
+
+/// Process-wide counter that makes scratch names unique WITHIN a process; the PID makes them unique
+/// ACROSS processes (nextest runs each test in its own process).
+static SEQ: AtomicU64 = AtomicU64::new(0);
+
+/// Guards the once-per-process startup sweep.
+static SWEEP: Once = Once::new();
+
+/// The scratch root shared by every test in every crate: `<system temp>/rag-rat-test-scratch`.
+///
+/// The system temp (not `target/tmp`) so `git init` fixtures have no ancestor `.git`; a dedicated
+/// namespace so the sweep can only ever remove this helper's own dirs.
+pub fn scratch_root() -> PathBuf {
+    std::env::temp_dir().join(SCRATCH_NAMESPACE)
+}
+
+/// Delete scratch dirs directly under `root` whose mtime is older than [`SWEEP_MAX_AGE`].
+/// Race-safe: every filesystem call tolerates a dir a parallel worker removed first (ENOENT and
+/// friends are ignored), and the age bound guarantees a fresh dir from a live worker is never
+/// touched.
+fn sweep_stale(root: &Path) {
+    let now = SystemTime::now();
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return; // root not created yet / vanished — nothing to sweep.
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Ok(metadata) = entry.metadata() else { continue };
+        if !metadata.is_dir() {
+            continue;
+        }
+        let old_enough = metadata
+            .modified()
+            .ok()
+            .and_then(|mtime| now.duration_since(mtime).ok())
+            .is_some_and(|age| age >= SWEEP_MAX_AGE);
+        if old_enough {
+            // Ignore errors: another worker may be removing the same stale dir concurrently.
+            let _ = std::fs::remove_dir_all(&path);
+        }
+    }
+}
+
+/// A unique scratch directory PATH under [`scratch_root`], keyed by `tag`, the PID, and a
+/// process-wide counter. The path is NOT created (callers create it, matching the fixtures this
+/// replaces); any pre-existing dir at the exact path is removed first.
+///
+/// On the first call per process this also sweeps stale sibling scratch dirs out of the root (see
+/// module docs) — the self-healing backstop for `Drop` cleanup that a `kill -9` skips.
+pub fn scratch_dir(tag: &str) -> PathBuf {
+    let root = scratch_root();
+    let _ = std::fs::create_dir_all(&root);
+    SWEEP.call_once(|| sweep_stale(&root));
+
+    let name = format!("{tag}-{}-{}", std::process::id(), SEQ.fetch_add(1, Ordering::Relaxed));
+    let dir = root.join(name);
+    let _ = std::fs::remove_dir_all(&dir);
+    dir
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::OsStr;
+
+    use filetime::{FileTime, set_file_mtime};
+
+    use super::*;
+
+    /// New scratch dirs must land inside the ONE dedicated namespace sub-root of the system temp —
+    /// never scattered directly across the shared temp root (which is what let 16k dirs accumulate,
+    /// and what would make the sweep unsafe). Bites if creation is pointed back at the bare temp
+    /// dir.
+    #[test]
+    fn scratch_dirs_live_under_the_dedicated_namespace() {
+        let root = scratch_root();
+        assert_eq!(
+            root.file_name(),
+            Some(OsStr::new(SCRATCH_NAMESPACE)),
+            "scratch root should be the dedicated namespace, got {root:?}",
+        );
+        // The namespace is a CHILD of the system temp, not the bare temp root itself (a bare-root
+        // sweep could delete unrelated files).
+        assert_eq!(root.parent(), Some(std::env::temp_dir().as_path()));
+        assert_ne!(root, std::env::temp_dir());
+
+        let dir = scratch_dir("location-probe");
+        assert!(dir.starts_with(&root), "{dir:?} is not under the scratch root {root:?}");
+    }
+
+    /// The startup sweep must delete a stranded (aged) sibling while sparing a fresh one — the
+    /// self-healing backstop for a `kill -9` that skipped `Drop`. Uses an isolated sub-root so
+    /// parallel test processes can't perturb the assertion. Bites if `sweep_stale` is neutered.
+    #[test]
+    fn sweep_removes_stale_dirs_but_spares_fresh_ones() {
+        // A private root for this test only (unique via `scratch_dir`), so no other worker's sweep
+        // or dirs interfere with what we assert.
+        let test_root = scratch_dir("sweep-probe-root");
+        std::fs::create_dir_all(&test_root).unwrap();
+
+        let stale = test_root.join("stranded-by-kill");
+        let fresh = test_root.join("live-worker");
+        std::fs::create_dir_all(&stale).unwrap();
+        std::fs::create_dir_all(&fresh).unwrap();
+
+        // Age the stale dir well past the threshold; leave `fresh` at its just-created mtime.
+        let aged = SystemTime::now() - (SWEEP_MAX_AGE + Duration::from_secs(3600));
+        set_file_mtime(&stale, FileTime::from_system_time(aged)).unwrap();
+
+        sweep_stale(&test_root);
+
+        assert!(!stale.exists(), "sweep should have removed the stale (aged) dir {stale:?}");
+        assert!(fresh.exists(), "sweep must NOT remove the fresh dir {fresh:?}");
+    }
+}

--- a/crates/rag-rat-base/src/test_scratch.rs
+++ b/crates/rag-rat-base/src/test_scratch.rs
@@ -16,13 +16,29 @@
 //!
 //! So this module fixes the leak the other way the issue proposed — a self-healing sweep:
 //!   1. all scratch lives under ONE dedicated, namespaced sub-root of the system temp
-//!      ([`SCRATCH_NAMESPACE`]), so a stranded dir is trivially found and the sweep below can never
-//!      touch anything but this helper's own dirs;
+//!      ([`scratch_root`], `<temp>/rag-rat-test-scratch-<euid>`), so a stranded dir is trivially
+//!      found and the sweep below can never touch anything but this helper's own dirs;
 //!   2. the FIRST scratch request in each process sweeps sibling scratch dirs older than
 //!      [`SWEEP_MAX_AGE`] out of that root — self-healing after a `kill -9`, no external cron.
 //!
 //! `Drop`-based cleanup stays the fast path; the age-bounded sweep is only the backstop for the
 //! cases where `Drop` never runs.
+//!
+//! # Security: the namespace is per-user and its identity is verified before any sweep
+//!
+//! The system temp is world-writable and shared between local users. A namespace at a *fixed*,
+//! predictable path (`<temp>/rag-rat-test-scratch`) is attackable: before our process starts,
+//! another local user can pre-create that path as a **symlink to any directory the test-running
+//! user can write**. `create_dir_all` accepts the symlink (its target already exists as a dir), and
+//! the startup sweep then traverses the *target*, deleting its subdirectories older than
+//! [`SWEEP_MAX_AGE`] — attacker-directed deletion of arbitrary directories (#726 review, skakri).
+//!
+//! Two defences, both below:
+//!   * **per-euid namespace** — the root carries the effective uid (`…-<euid>`), so two users
+//!     sharing the temp get structurally distinct roots and a name collision is impossible;
+//!   * **verify before sweep** — [`ensure_secure_root`] re-inspects the created namespace with
+//!     symlink-aware metadata and panics unless it is a real directory (not a symlink) owned by our
+//!     euid, with mode `0700`. A poisoned namespace fails the suite loudly; it is never swept.
 //!
 //! Not `#[cfg(test)]`: that gate does not propagate across crates, and fixtures in sibling crates
 //! (`rag-rat-core`, `rag-rat-cli`, …) consume this helper. It is not part of the semver-stable API
@@ -33,10 +49,12 @@ use std::sync::Once;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, SystemTime};
 
-/// The single dedicated sub-directory of the system temp under which ALL test scratch lives. A
-/// dedicated namespace keeps the sweep's blast radius to this helper's own dirs (never the shared
-/// temp root) and makes any manual cleanup a one-liner: `rm -rf $TMPDIR/rag-rat-test-scratch`.
-pub const SCRATCH_NAMESPACE: &str = "rag-rat-test-scratch";
+/// Prefix of the dedicated system-temp sub-directory under which ALL test scratch lives. The real
+/// namespace appends this process's effective uid ([`scratch_root`] →
+/// `rag-rat-test-scratch-<euid>`) so users sharing the temp never collide. A dedicated namespace
+/// keeps the sweep's blast radius to this helper's own dirs (never the shared temp root) and makes
+/// manual cleanup a one-liner: `rm -rf $TMPDIR/rag-rat-test-scratch-$(id -u)`.
+pub const SCRATCH_NAMESPACE_PREFIX: &str = "rag-rat-test-scratch";
 
 /// Sweep scratch dirs older than this on first use per process. Two hours is far longer than any
 /// single test or `nextest` run (CI caps a wedged test at 60s), so the threshold can never delete a
@@ -50,12 +68,96 @@ static SEQ: AtomicU64 = AtomicU64::new(0);
 /// Guards the once-per-process startup sweep.
 static SWEEP: Once = Once::new();
 
-/// The scratch root shared by every test in every crate: `<system temp>/rag-rat-test-scratch`.
+/// The scratch root shared by every test in every crate: `<system
+/// temp>/rag-rat-test-scratch-<euid>`.
 ///
-/// The system temp (not `target/tmp`) so `git init` fixtures have no ancestor `.git`; a dedicated
-/// namespace so the sweep can only ever remove this helper's own dirs.
+/// The system temp (not `target/tmp`) so `git init` fixtures have no ancestor `.git`; a dedicated,
+/// per-euid namespace so the sweep can only ever remove this helper's own dirs and two users
+/// sharing the temp can never collide.
 pub fn scratch_root() -> PathBuf {
-    std::env::temp_dir().join(SCRATCH_NAMESPACE)
+    std::env::temp_dir().join(format!("{SCRATCH_NAMESPACE_PREFIX}-{}", current_euid()))
+}
+
+/// This process's effective user id, used to make the scratch namespace per-user and to verify
+/// namespace ownership before sweeping.
+fn current_euid() -> u32 {
+    // SAFETY: `geteuid` takes no arguments, has no preconditions, and per POSIX always succeeds.
+    // On Linux `uid_t` is `u32` (matching `MetadataExt::uid()`); this binding pins that, so a
+    // platform with a differently-sized `uid_t` fails to compile here rather than truncating.
+    unsafe { libc::geteuid() }
+}
+
+/// Securely create the scratch namespace `root` and verify it is a real directory this process
+/// owns, panicking loudly otherwise. Run before every sweep so a poisoned namespace can never be
+/// swept.
+///
+/// # The attack (#726 review, skakri)
+///
+/// On a shared system temp, another local user can pre-create the namespace path as a **symlink to
+/// any directory the test-running user can write**. A plain `create_dir_all` accepts that symlink
+/// (its target already exists as a dir), after which the startup sweep traverses the *target* and
+/// removes its subdirectories older than [`SWEEP_MAX_AGE`] — arbitrary-directory deletion driven by
+/// an attacker's symlink.
+///
+/// # The defence
+///
+/// Create the namespace with mode `0700`, then re-inspect it with **symlink-aware**
+/// [`std::fs::symlink_metadata`] (which does NOT follow links) and require that it is (1) not a
+/// symlink, (2) a directory, and (3) owned by this process's effective uid. Any deviation is a
+/// poisoned namespace: panic and fail the suite rather than sweep a directory we do not own.
+///
+/// # TOCTOU boundary (stated honestly)
+///
+/// This verification defeats the *pre-created* symlink — a link planted before we look is caught by
+/// `symlink_metadata`, because we inspect the very path we created and are about to sweep. It does
+/// NOT close a racing swap performed by an attacker *between* this check and the sweep: closing
+/// that window would require dirfd-relative operations (an `O_NOFOLLOW`/`O_DIRECTORY` `openat` plus
+/// `fstatat`/`unlinkat` pinned to the verified inode) so every later op targets the same inode.
+/// That is out of scope for test scratch: the per-euid namespace already makes a collision
+/// structurally irrelevant, and a same-user attacker racing our parent temp gains no privilege. The
+/// realistic, cheap attack — plant a symlink and wait — is fully closed.
+fn ensure_secure_root(root: &Path) {
+    use std::os::unix::fs::{DirBuilderExt, MetadataExt, PermissionsExt};
+
+    // Create only the namespace (its parent temp already exists) with 0700 from birth, so a freshly
+    // created namespace is never group/other-accessible even for an instant.
+    let mut builder = std::fs::DirBuilder::new();
+    builder.recursive(true).mode(0o700);
+    if let Err(err) = builder.create(root) {
+        panic!("test scratch: failed to create namespace {root:?}: {err}");
+    }
+
+    // Re-inspect with symlink-aware metadata: a pre-planted symlink is caught HERE, before any
+    // sweep can traverse (and delete inside) its target.
+    let meta = match std::fs::symlink_metadata(root) {
+        Ok(meta) => meta,
+        Err(err) => panic!("test scratch: cannot stat namespace {root:?}: {err}"),
+    };
+    let file_type = meta.file_type();
+    assert!(
+        !file_type.is_symlink(),
+        "test scratch: namespace {root:?} is a symlink — refusing to sweep its target (possible \
+         tmp symlink-planting attack; see test_scratch.rs)",
+    );
+    assert!(
+        file_type.is_dir(),
+        "test scratch: namespace {root:?} exists but is not a directory (found {file_type:?})",
+    );
+    let owner = meta.uid();
+    let euid = current_euid();
+    assert_eq!(
+        owner, euid,
+        "test scratch: namespace {root:?} is owned by uid {owner}, not this process's euid {euid} \
+         — refusing to sweep a directory this user does not own",
+    );
+
+    // Defence in depth: a namespace left by an older build may have looser permissions. Tighten to
+    // 0700 (failing loudly if we cannot) so group/other can never plant siblings inside it.
+    if meta.mode() & 0o777 != 0o700
+        && let Err(err) = std::fs::set_permissions(root, std::fs::Permissions::from_mode(0o700))
+    {
+        panic!("test scratch: cannot set 0700 on namespace {root:?}: {err}");
+    }
 }
 
 /// Delete scratch dirs directly under `root` whose mtime is older than [`SWEEP_MAX_AGE`].
@@ -69,8 +171,11 @@ fn sweep_stale(root: &Path) {
     };
     for entry in entries.flatten() {
         let path = entry.path();
-        let Ok(metadata) = entry.metadata() else { continue };
-        if !metadata.is_dir() {
+        // Defence in depth: never follow a symlink. Even inside our own verified namespace, treat a
+        // symlink entry as hostile — `symlink_metadata` does NOT follow, so a link planted here can
+        // never redirect `remove_dir_all` at an unrelated target. Only real directories are swept.
+        let Ok(metadata) = std::fs::symlink_metadata(&path) else { continue };
+        if metadata.file_type().is_symlink() || !metadata.is_dir() {
             continue;
         }
         let old_enough = metadata
@@ -91,9 +196,13 @@ fn sweep_stale(root: &Path) {
 ///
 /// On the first call per process this also sweeps stale sibling scratch dirs out of the root (see
 /// module docs) — the self-healing backstop for `Drop` cleanup that a `kill -9` skips.
+///
+/// The root is created and its identity verified via [`ensure_secure_root`] before any sweep, so a
+/// namespace an attacker pre-planted as a symlink (or that another user owns) panics the suite
+/// rather than being swept.
 pub fn scratch_dir(tag: &str) -> PathBuf {
     let root = scratch_root();
-    let _ = std::fs::create_dir_all(&root);
+    ensure_secure_root(&root);
     SWEEP.call_once(|| sweep_stale(&root));
 
     let name = format!("{tag}-{}-{}", std::process::id(), SEQ.fetch_add(1, Ordering::Relaxed));
@@ -110,17 +219,22 @@ mod tests {
 
     use super::*;
 
-    /// New scratch dirs must land inside the ONE dedicated namespace sub-root of the system temp —
-    /// never scattered directly across the shared temp root (which is what let 16k dirs accumulate,
-    /// and what would make the sweep unsafe). Bites if creation is pointed back at the bare temp
-    /// dir.
+    /// New scratch dirs must land inside the ONE dedicated, PER-EUID namespace sub-root of the
+    /// system temp — never scattered directly across the shared temp root (which is what let 16k
+    /// dirs accumulate, and what would make the sweep unsafe). The per-euid suffix is what stops
+    /// two users sharing the temp from colliding on a fixed, attackable path. Bites if creation
+    /// is pointed back at the bare temp dir OR if the namespace is reverted to the un-suffixed
+    /// shared name.
     #[test]
     fn scratch_dirs_live_under_the_dedicated_namespace() {
         let root = scratch_root();
+        // The namespace name carries this process's euid — a shared/un-suffixed name is attackable
+        // on a multi-user temp, so pin the exact per-euid form.
+        let expected = format!("{SCRATCH_NAMESPACE_PREFIX}-{}", current_euid());
         assert_eq!(
             root.file_name(),
-            Some(OsStr::new(SCRATCH_NAMESPACE)),
-            "scratch root should be the dedicated namespace, got {root:?}",
+            Some(OsStr::new(&expected)),
+            "scratch root should be the dedicated per-euid namespace {expected:?}, got {root:?}",
         );
         // The namespace is a CHILD of the system temp, not the bare temp root itself (a bare-root
         // sweep could delete unrelated files).
@@ -154,5 +268,80 @@ mod tests {
 
         assert!(!stale.exists(), "sweep should have removed the stale (aged) dir {stale:?}");
         assert!(fresh.exists(), "sweep must NOT remove the fresh dir {fresh:?}");
+    }
+
+    /// A namespace an attacker pre-planted as a **symlink to a victim directory** must be REFUSED
+    /// (panic), and the victim's aged contents must SURVIVE — never swept. This is the exact #726
+    /// attack: without the `symlink_metadata` verification, `create_dir_all` accepts the symlink
+    /// and the sweep traverses the target, deleting its aged subdirs. Bites if that
+    /// verification is removed (no panic AND the victim's aged dir gets swept).
+    #[test]
+    fn refuses_symlinked_namespace_and_spares_victim() {
+        use std::os::unix::fs::symlink;
+
+        let parent = scratch_dir("symlink-attack-parent");
+        std::fs::create_dir_all(&parent).unwrap();
+
+        // The victim: a directory (owned by us) containing an aged subdir a naive sweep would nuke.
+        let victim = parent.join("victim");
+        let victim_aged = victim.join("precious-aged-data");
+        std::fs::create_dir_all(&victim_aged).unwrap();
+        let aged = SystemTime::now() - (SWEEP_MAX_AGE + Duration::from_secs(3600));
+        set_file_mtime(&victim_aged, FileTime::from_system_time(aged)).unwrap();
+
+        // The attacker pre-creates the namespace path as a symlink to the victim.
+        let planted = parent.join("planted-namespace");
+        symlink(&victim, &planted).unwrap();
+
+        // Drive the real startup sequence (create+verify, then sweep) against the planted path. The
+        // verification must panic before the sweep can touch the target.
+        let planted_for_closure = planted.clone();
+        let result = std::panic::catch_unwind(move || {
+            ensure_secure_root(&planted_for_closure);
+            sweep_stale(&planted_for_closure);
+        });
+
+        assert!(
+            result.is_err(),
+            "ensure_secure_root must panic on a symlinked namespace {planted:?}, but it returned",
+        );
+        assert!(
+            victim_aged.exists(),
+            "the symlink-planting attack deleted the victim's aged dir {victim_aged:?}",
+        );
+    }
+
+    /// A namespace that is a real directory but owned by ANOTHER user must be refused — a same-user
+    /// attacker cannot forge ownership, but a directory we do not own is exactly what we must never
+    /// sweep. Creating a foreign-owned dir needs root (to `chown`), so this is a no-op when not run
+    /// as root. Bites if the euid-ownership check is dropped.
+    #[test]
+    fn refuses_foreign_owned_namespace() {
+        use std::os::unix::ffi::OsStrExt;
+
+        // `chown` to another uid requires privilege; only root can set this up. Skip otherwise
+        // (CI here runs as root, where the check is exercised for real).
+        if current_euid() != 0 {
+            eprintln!("skipping foreign-owner test: not root (euid={})", current_euid());
+            return;
+        }
+
+        let parent = scratch_dir("foreign-owner-parent");
+        let namespace = parent.join("foreign-namespace");
+        std::fs::create_dir_all(&namespace).unwrap();
+
+        // Hand the namespace to `nobody` (65534) so it is a real dir we no longer own.
+        let c_path = std::ffi::CString::new(namespace.as_os_str().as_bytes()).unwrap();
+        // SAFETY: `c_path` is a valid NUL-terminated path for the duration of the call.
+        let rc = unsafe { libc::chown(c_path.as_ptr(), 65534, 65534) };
+        assert_eq!(rc, 0, "chown to nobody failed: {}", std::io::Error::last_os_error());
+
+        let namespace_for_closure = namespace.clone();
+        let result = std::panic::catch_unwind(move || ensure_secure_root(&namespace_for_closure));
+
+        assert!(
+            result.is_err(),
+            "ensure_secure_root must panic on a foreign-owned namespace {namespace:?}",
+        );
     }
 }

--- a/crates/rag-rat-cli/tests/common/mod.rs
+++ b/crates/rag-rat-cli/tests/common/mod.rs
@@ -14,7 +14,6 @@
 //! module warning-clean under `clippy --all-targets -D warnings`.
 #![allow(dead_code)]
 
-use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -31,13 +30,12 @@ fn next_seq() -> u64 {
     SEQ.fetch_add(1, Ordering::Relaxed)
 }
 
-/// A throwaway temp dir under the system temp root, keyed by `tag`, the process id, and a unique
-/// counter. Any stale dir at the path is removed first.
+/// A throwaway scratch dir under the shared, self-healing test-scratch root
+/// (see [`rag_rat_base::test_scratch`]), keyed by `tag`, the process id, and a unique counter. Any
+/// stale dir at the path is removed first, and the shared helper sweeps dirs stranded by a
+/// killed/panicking run so they can't accumulate in the system temp (#726).
 pub fn unique_dir(tag: &str) -> PathBuf {
-    let dir =
-        std::env::temp_dir().join(format!("rag-rat-{tag}-{}-{}", std::process::id(), next_seq()));
-    let _ = fs::remove_dir_all(&dir);
-    dir
+    rag_rat_base::test_scratch::scratch_dir(tag)
 }
 
 /// A filesystem path formatted for embedding inside a double-quoted TOML string value. On Windows a

--- a/crates/rag-rat-core/src/index/git_context.rs
+++ b/crates/rag-rat-core/src/index/git_context.rs
@@ -254,7 +254,6 @@ pub(crate) fn live_worktree_contexts(root: &Path) -> (Vec<String>, Vec<String>) 
 #[cfg(test)]
 mod worktree_scope_tests {
     use std::process::Command;
-    use std::sync::atomic::{AtomicU64, Ordering};
 
     use super::*;
 
@@ -272,12 +271,9 @@ mod worktree_scope_tests {
     }
 
     fn temp_dir(tag: &str) -> PathBuf {
-        static N: AtomicU64 = AtomicU64::new(0);
-        let n = N.fetch_add(1, Ordering::Relaxed);
-        let dir =
-            std::env::temp_dir().join(format!("ragrat-wtscope-{}-{tag}-{n}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&dir);
-        dir
+        // Shared, self-healing scratch root with a startup sweep, so a panicking/killed test can't
+        // strand this dir in the system temp (#726). See `rag_rat_base::test_scratch`.
+        rag_rat_base::test_scratch::scratch_dir(&format!("ragrat-wtscope-{tag}"))
     }
 
     fn init_repo(tag: &str) -> PathBuf {

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/mod.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/mod.rs
@@ -1,5 +1,4 @@
 use std::process::Command;
-use std::sync::atomic::{AtomicU64, Ordering};
 
 use rag_rat_base::config::ResolvedTarget;
 // The embedding-model constants moved from `index::ai` to the crate-root registry (#112).
@@ -9,11 +8,8 @@ use rag_rat_base::embedding_models::{
     FASTEMBED_DISPLAY_MODEL, FASTEMBED_EMBEDDING_DIM, FASTEMBED_MODEL_ID, HASH_EMBEDDING_DIM,
     HASH_MODEL_ID,
 };
-use rag_rat_base::time::now_ms;
 
 use super::*;
-
-static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 /// A recognizable bogus row that only a git-history full replacement would remove. Surviving the
 /// next incremental pass means the reload was skipped or appended; gone means the full path ran. It
@@ -162,10 +158,9 @@ fn hot_module_text(revision: usize) -> String {
 }
 
 fn unique_temp_root() -> PathBuf {
-    let mut root = std::env::temp_dir();
-    let suffix = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
-    root.push(format!("rag-rat-schema-test-{}-{}-{suffix}", std::process::id(), now_ms()));
-    root
+    // Shared, self-healing scratch root with a startup sweep, so a panicking/killed test can't
+    // strand this dir in the system temp (#726). See `rag_rat_base::test_scratch`.
+    rag_rat_base::test_scratch::scratch_dir("rag-rat-schema-test")
 }
 
 fn fixture_temp_root(fixture: &str) -> PathBuf {


### PR DESCRIPTION
Fixes #726 — with one deliberate divergence from the issue's first candidate, argued with a reproduction.

## Why NOT `target/tmp/`

Routing scratch under the working tree is unsound for this codebase: `repo_discover` → `gix::discover` searches **upward**, so a fixture root without its own `.git` inside the checkout resolves the **outer rag-rat repo's** identity (the doc-comment on `discover_repo` even names this limitation). Tried empirically: with scratch pointed inside the tree, schema tests slow ~100× and fail with *"this database holds multiple repos; a bare open cannot choose one"* — the DB picks up the outer repo (implementer's first run hit this across ~295 tests; the mechanism was independently re-demonstrated during verification). Many fixtures `git init` throwaway repos and require no ancestor `.git`, so the "reclaimed by cargo clean" property is unreachable here.

## What landed instead — the issue's other two candidates, combined

`rag_rat_base::test_scratch`: all routed scratch lives under one **dedicated namespace** (`$TMPDIR/rag-rat-test-scratch/`) — so manual cleanup is one `rm -rf` and the sweep's blast radius is only our own dirs — with a **once-per-process startup sweep** deleting namespace dirs older than 2h (self-healing after SIGKILL/panic; the age bound means a live parallel worker's fresh dirs are never touched; all fs calls tolerate concurrent-sweep ENOENT). Drop-based cleanup stays as the fast path.

Routed through it: the three fixture families the issue names — the CLI integration `unique_dir` (`rag-rat-*`), `git_context`'s `ragrat-wtscope-*`, and schema-bootstrap's `rag-rat-schema-test-*`. **Scope note:** ~30 further inline `temp_dir()` sites (config tests, oracle/db/mcp) still write to bare /tmp — the helper is in place for incremental adoption; happy to do the full mechanical sweep in this PR or a follow-up, your call.

## Verification (adversarially re-run in a separate pass, not self-reported)

- `cargo nextest run --workspace --no-default-features --locked --profile ci`: **3027 passed / 0 failed** (baseline 3025 — the +2 are the new tests).
- Mutations both bite on independent re-runs: neutered sweep → `sweep_removes_stale_dirs_but_spares_fresh_ones` fails; creation pointed at bare `temp_dir()` → `scratch_dirs_live_under_the_dedicated_namespace` fails.
- `cargo +nightly fmt --all --check` clean (note: your `rustfmt.toml` uses nightly-only options, so *stable* rustfmt shows a spurious whole-repo diff on main and branch alike).
- clippy `--no-default-features -D warnings`: zero new findings; the one error present (`collapsible_match`, `oplog/account/storage.rs:1395`) fires identically on clean main — pre-existing, untouched here.

---
Generated by Claude Fable 5 (brief, review), Claude Opus 4.8 (1M context) (implementation, adversarial verification)
