### PR TITLE
refactor(locks): shared content-carrying single-flight coalescing primitive

### DIFF
--- a/crates/rag-rat-base/src/lib.rs
+++ b/crates/rag-rat-base/src/lib.rs
@@ -16,6 +16,7 @@ pub mod paths;
 pub mod repo_discover;
 pub mod repo_identity;
 pub mod serde_big_id;
+pub mod single_flight;
 pub mod stack;
 pub mod time;
 pub mod version;

--- a/crates/rag-rat-base/src/locks.rs
+++ b/crates/rag-rat-base/src/locks.rs
@@ -286,6 +286,16 @@ pub fn maintenance_pending_path(database: &Path, repo_id: &str) -> PathBuf {
     lock_dir(database).join(format!("rag-rat-maintenance-{}.pending", lock_discriminator(repo_id)))
 }
 
+/// Serializes every read-modify-write of the maintenance pending marker, pairing with
+/// [`maintenance_pending_path`] under the shared [`crate::single_flight`] coordinator (#660). The
+/// pre-#660 empty-file marker used only touch/remove/exists and needed no lock; the generic
+/// coordinator serializes the marker so its exit handoff can release the flight lock under the same
+/// hold that observed an empty marker (closing the mid-pass-trigger race the empty-file loop had).
+pub fn maintenance_marker_lock_path(database: &Path, repo_id: &str) -> PathBuf {
+    lock_dir(database)
+        .join(format!("rag-rat-maintenance-{}.pending.lock", lock_discriminator(repo_id)))
+}
+
 /// Per-DB, PER-REPO papertrail auto-sync flight lock (#592), held for one whole coalesced
 /// papertrail run so at most ONE mirror flight per repository is in the air across every trigger
 /// source — watcher timer ticks, git-hook maintenance, other processes. Separate from

--- a/crates/rag-rat-base/src/single_flight.rs
+++ b/crates/rag-rat-base/src/single_flight.rs
@@ -1,0 +1,438 @@
+//! Cross-process single-flight coalescing: one runner per key does the work while concurrent
+//! triggers merge their payload into a shared marker and return, and the runner reruns until the
+//! marker drains. Generalizes the papertrail-autosync / maintenance (#267) pattern into one
+//! payload-generic primitive (#660).
+//!
+//! Three files per flight, all beside the index database:
+//! - the **flight lock** — held by the one runner for the whole (possibly long, network-bound)
+//!   pass;
+//! - the **marker** — carries the coalesced [`FlightPayload`] queued for the runner;
+//! - the **marker lock** — serializes every marker access, held for microseconds per section.
+//!
+//! LOCK ORDERING (deadlock-free): a runner holding the FLIGHT lock may block on the marker lock; a
+//! contender holding the marker lock only ever TRY-acquires the flight lock. The non-blocking edge
+//! is what makes the pair safe.
+//!
+//! THE EXIT HANDOFF is the whole correctness argument. A contender's "merge my payload, then
+//! try-acquire the flight lock" section ([`SingleFlight::run`]) is serialized by the marker lock
+//! either BEFORE the runner's final check (its payload is seen and earns a rerun) or AFTER the
+//! flight lock is already free (its own try-acquire wins and IT becomes the runner). The runner
+//! therefore releases the flight lock ONLY under the same marker-lock hold that observed an empty
+//! marker — checking without the lock, or releasing outside it, reopens the window where a
+//! coalesced payload is written into the void and never runs.
+//!
+//! CRASH SAFETY: a marker left by a killed runner is just a file; the next trigger becomes the
+//! runner (its try-acquire wins the abandoned flight lock) and drains it. Nothing wedges.
+
+use std::fs;
+use std::marker::PhantomData;
+use std::path::{Path, PathBuf};
+
+use crate::locks::FileLock;
+
+/// A payload coalesced across concurrent single-flight triggers, and serialized to the marker file.
+///
+/// `merge` must be associative and commutative (the marker is folded in whatever order contenders
+/// and the runner interleave): a max over an ordered signal (papertrail), a set union (a
+/// changed-path set), or a no-op (`()` — the marker's mere existence is the "rerun pending"
+/// signal).
+pub trait FlightPayload: Sized {
+    /// Fold `other` into `self`, yielding a payload that covers both triggers.
+    fn merge(self, other: Self) -> Self;
+    /// Serialize to the marker file body (bytes, so a path payload need not be UTF-8).
+    fn encode(&self) -> Vec<u8>;
+    /// Reconstruct from a marker file body written by [`Self::encode`].
+    fn decode(encoded: &[u8]) -> Self;
+}
+
+/// The maintenance case (#267): the marker's presence is the whole signal, the body is empty.
+impl FlightPayload for () {
+    fn merge(self, (): Self) {}
+    fn encode(&self) -> Vec<u8> {
+        Vec::new()
+    }
+    fn decode(_: &[u8]) {}
+}
+
+/// What one `run_fn` pass decided (returned to [`SingleFlight::drain`]).
+pub enum Step<R> {
+    /// The pass ran. Keep draining the marker; `R` is this pass's result (the last one is
+    /// returned).
+    Ran(R),
+    /// Stop the flight, LEAVING the payload in the marker for a future trigger to pick up (e.g. the
+    /// repo is not indexed yet — nothing can run, but the signal must not drop). The payload is
+    /// merged back under the exit-handoff hold; the outcome is [`FlightOutcome::Stopped`]`(None)`.
+    StopRequeue,
+    /// Stop the flight, ABSORBING any queued marker into the payload and handing it back to the
+    /// caller (e.g. the flight lock's identity key went stale — the caller re-keys and requeues
+    /// elsewhere). The outcome is [`FlightOutcome::Stopped`]`(Some(payload))`.
+    StopCarry,
+}
+
+/// What a whole flight did.
+pub enum FlightOutcome<R, P> {
+    /// A runner already held the flight lock; this caller merged its payload into the marker and
+    /// returned. The holder's drain covers it.
+    Coalesced,
+    /// This caller ran the flight (absorbing any coalesced follow-ups). The LAST pass's result, or
+    /// `None` when the drain started empty (a follow-up drain with no queued work).
+    Ran(Option<R>),
+    /// A `run_fn` stopped the flight early: `Some(payload)` for [`Step::StopCarry`] (handed back),
+    /// `None` for [`Step::StopRequeue`] (left in the marker).
+    Stopped(Option<P>),
+}
+
+/// A single-flight coordinator for one key (per-repo, per-purpose). Cheap to construct from the
+/// three file paths; holds no OS resources itself.
+pub struct SingleFlight<P> {
+    flight_lock: PathBuf,
+    marker: PathBuf,
+    marker_lock: PathBuf,
+    _payload: PhantomData<fn() -> P>,
+}
+
+impl<P: FlightPayload> SingleFlight<P> {
+    /// Construct from the three flight paths (see the module docs). Use the `*_lock_path` /
+    /// `*_pending_path` / `*_marker_lock_path` helpers in [`crate::locks`] to derive them.
+    pub fn new(flight_lock: PathBuf, marker: PathBuf, marker_lock: PathBuf) -> Self {
+        Self { flight_lock, marker, marker_lock, _payload: PhantomData }
+    }
+
+    /// The flight lock path — for a caller (e.g. an explicit foreground command) that acquires the
+    /// flight lock itself (blocking, with a wait announcement) and then drives [`Self::drain`].
+    pub fn flight_lock_path(&self) -> &Path {
+        &self.flight_lock
+    }
+
+    /// Merge `payload` into the marker under the marker lock (the queue-without-running primitive):
+    /// a trigger that cannot run yet (no index built, an identity re-key) parks its signal here for
+    /// the next runner.
+    pub fn queue(&self, payload: P) -> anyhow::Result<()> {
+        self.lock_marker()?.merge(payload)
+    }
+
+    /// Consume and return the marker's queued payload under the marker lock (`None` when empty) —
+    /// for a runner that must abandon its flight and CARRY the queued work elsewhere itself (e.g.
+    /// an identity re-key: the stale-keyed marker is unreachable for fresh-keyed triggers).
+    /// This does NOT provide the exit-handoff guarantee (a concurrent merge after the take,
+    /// while the flight lock is still held, defers to the next trigger) — use it only on an
+    /// abnormal abort where the caller re-parks the carried payload.
+    pub fn take(&self) -> anyhow::Result<Option<P>> {
+        self.lock_marker()?.take()
+    }
+
+    /// Run — or coalesce into — this key's single flight. If a runner already holds the flight
+    /// lock, `payload` is merged into the marker and [`FlightOutcome::Coalesced`] returns
+    /// immediately; otherwise this caller takes the flight lock and drains, starting with
+    /// `payload`.
+    pub fn run<R>(
+        &self,
+        payload: P,
+        run_fn: impl FnMut(&P) -> anyhow::Result<Step<R>>,
+    ) -> anyhow::Result<FlightOutcome<R, P>> {
+        // Merge-then-try-acquire under ONE marker-lock hold — the contender half of the exit
+        // handoff: a payload only lands in the marker while some runner is still obligated to check
+        // it, and if no runner holds the flight lock THIS caller wins it and becomes the runner.
+        let flight = {
+            let guard = self.lock_marker()?;
+            match FileLock::try_acquire(&self.flight_lock)? {
+                Some(flight) => flight,
+                None => {
+                    guard.merge(payload)?;
+                    return Ok(FlightOutcome::Coalesced);
+                },
+            }
+        };
+        self.drain(flight, Some(payload), run_fn)
+    }
+
+    /// Drive passes while holding `flight`: `initial` first (when given), then any payload
+    /// coalesced into the marker mid-pass, until the exit handoff — absorbing the marker and
+    /// releasing the flight lock under ONE marker-lock hold — finds nothing queued. `initial =
+    /// None` drains only the follow-ups (a foreground command that already ran its own pass
+    /// under the lock).
+    pub fn drain<R>(
+        &self,
+        flight: FileLock,
+        initial: Option<P>,
+        mut run_fn: impl FnMut(&P) -> anyhow::Result<Step<R>>,
+    ) -> anyhow::Result<FlightOutcome<R, P>> {
+        let mut flight = Some(flight);
+        let mut next = initial;
+        let mut last = None;
+        loop {
+            // Fold the queued marker into `next`. On (None, None) this is the EXIT HANDOFF: release
+            // the flight lock under the same hold that observed the empty marker (the `return`
+            // unwinds `guard` after `flight` — flight is dropped first, marker lock still held).
+            {
+                let guard = self.lock_marker()?;
+                match (guard.take()?, next.take()) {
+                    (Some(queued), Some(current)) => next = Some(current.merge(queued)),
+                    (Some(queued), None) => next = Some(queued),
+                    (None, Some(current)) => next = Some(current),
+                    (None, None) => {
+                        drop(flight.take());
+                        return Ok(FlightOutcome::Ran(last));
+                    },
+                }
+            }
+            let payload = next.take().expect("the loop is only entered with a payload");
+            match run_fn(&payload) {
+                Ok(Step::Ran(result)) => last = Some(result),
+                Ok(Step::StopRequeue) => {
+                    // Leave the payload set for a future runner, under a hold that then releases
+                    // the flight lock — the one deliberate "marker without an
+                    // obligated runner" exception (a not-indexed repo's inert
+                    // signal).
+                    let guard = self.lock_marker()?;
+                    guard.merge(payload)?;
+                    drop(flight.take());
+                    return Ok(FlightOutcome::Stopped(None));
+                },
+                Ok(Step::StopCarry) => {
+                    // Consume any queued marker into the payload and hand it back (the caller
+                    // requeues it elsewhere — e.g. a fresh identity key).
+                    let guard = self.lock_marker()?;
+                    let queued = guard.take()?;
+                    drop(flight.take());
+                    drop(guard);
+                    let carried = match queued {
+                        Some(queued) => payload.merge(queued),
+                        None => payload,
+                    };
+                    return Ok(FlightOutcome::Stopped(Some(carried)));
+                },
+                Err(error) => {
+                    // Best-effort requeue so the failed pass's signal survives; the marker write
+                    // must not shadow the error the caller is about to log. Release the flight lock
+                    // UNDER THE SAME marker-lock hold (the exit handoff, exactly as the stop paths
+                    // do): an errored runner bails without draining, so a contender arriving in the
+                    // release window must win the flight lock and become the runner itself, never
+                    // merge into a marker no live runner will drain. Dropping the lock outside the
+                    // hold (at the `return`) reopens that window.
+                    if let Ok(guard) = self.lock_marker() {
+                        let _ = guard.merge(payload);
+                        drop(flight.take());
+                    }
+                    return Err(error);
+                },
+            }
+        }
+    }
+
+    fn lock_marker(&self) -> anyhow::Result<MarkerGuard<'_, P>> {
+        Ok(MarkerGuard {
+            marker: &self.marker,
+            _update: FileLock::acquire_blocking(&self.marker_lock)?,
+            _payload: PhantomData,
+        })
+    }
+}
+
+/// One held marker-lock section. Every marker read/write flows through here so no path can touch
+/// the file outside the lock (see the module's lock-ordering + exit-handoff notes).
+struct MarkerGuard<'a, P> {
+    marker: &'a Path,
+    _update: FileLock,
+    _payload: PhantomData<fn() -> P>,
+}
+
+impl<P: FlightPayload> MarkerGuard<'_, P> {
+    /// Record `payload` into the marker, merged with whatever is already queued there.
+    fn merge(&self, payload: P) -> anyhow::Result<()> {
+        let merged = match fs::read(self.marker) {
+            Ok(existing) => payload.merge(P::decode(&existing)),
+            Err(_) => payload,
+        };
+        fs::write(self.marker, merged.encode())?;
+        Ok(())
+    }
+
+    /// Consume the marker. A payload merged concurrently is either absorbed into the returned value
+    /// or lands after the removal and survives for the next check.
+    fn take(&self) -> anyhow::Result<Option<P>> {
+        let Ok(content) = fs::read(self.marker) else {
+            return Ok(None);
+        };
+        let _ = fs::remove_file(self.marker);
+        Ok(Some(P::decode(&content)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::{Cell, RefCell};
+    use std::collections::BTreeSet;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    use super::*;
+
+    /// A set payload — the shape the #661 changed-path trigger needs: union-merge, so a coalesced
+    /// rerun must cover the UNION of everything queued (never lose a payload).
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    struct Ids(BTreeSet<u32>);
+
+    impl Ids {
+        fn of<const N: usize>(ids: [u32; N]) -> Self {
+            Self(ids.into_iter().collect())
+        }
+    }
+
+    impl FlightPayload for Ids {
+        fn merge(mut self, other: Self) -> Self {
+            self.0.extend(other.0);
+            self
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.0.iter().map(u32::to_string).collect::<Vec<_>>().join(",").into_bytes()
+        }
+        fn decode(encoded: &[u8]) -> Self {
+            Self(
+                String::from_utf8_lossy(encoded)
+                    .split(',')
+                    .filter_map(|token| token.parse().ok())
+                    .collect(),
+            )
+        }
+    }
+
+    /// A fresh flight coordinator over a unique temp key (unique across threads AND processes — the
+    /// coverage runner shares one process, so pid+millis alone collides).
+    fn flight<P: FlightPayload>() -> (SingleFlight<P>, PathBuf) {
+        static NEXT: AtomicU64 = AtomicU64::new(0);
+        let dir = std::env::temp_dir().join(format!(
+            "rag-rat-single-flight-{}-{}",
+            std::process::id(),
+            NEXT.fetch_add(1, Ordering::Relaxed),
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let sf =
+            SingleFlight::new(dir.join("flight.lock"), dir.join("marker"), dir.join("marker.lock"));
+        (sf, dir)
+    }
+
+    #[test]
+    fn a_lone_trigger_runs_once() {
+        let (sf, dir) = flight::<Ids>();
+        let passes = RefCell::new(Vec::new());
+        let outcome = sf
+            .run(Ids::of([1]), |p| {
+                passes.borrow_mut().push(p.clone());
+                Ok(Step::Ran(()))
+            })
+            .unwrap();
+        assert!(matches!(outcome, FlightOutcome::Ran(Some(()))));
+        assert_eq!(*passes.borrow(), vec![Ids::of([1])]);
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn a_mid_flight_trigger_earns_a_rerun_over_the_union() {
+        // A trigger that coalesces WHILE the runner is mid-pass must earn one more pass covering
+        // the union — never a lost payload. Simulated inline: the first pass queues a
+        // second payload (as a concurrent trigger's `merge` would), and the drain must
+        // rerun with it.
+        let (sf, dir) = flight::<Ids>();
+        let passes = RefCell::new(Vec::new());
+        let first = Cell::new(true);
+        let outcome = sf
+            .run(Ids::of([1]), |p| {
+                passes.borrow_mut().push(p.clone());
+                if first.replace(false) {
+                    sf.queue(Ids::of([2, 3])).unwrap(); // a concurrent trigger coalesces mid-pass
+                }
+                Ok(Step::Ran(()))
+            })
+            .unwrap();
+        assert!(matches!(outcome, FlightOutcome::Ran(Some(()))));
+        assert_eq!(*passes.borrow(), vec![Ids::of([1]), Ids::of([2, 3])]);
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn a_trigger_coalesces_when_a_runner_holds_the_flight_lock() {
+        // Holding the flight lock stands in for an in-flight runner: a fresh trigger must merge
+        // into the marker and return Coalesced, not run.
+        let (sf, dir) = flight::<Ids>();
+        let _held = FileLock::acquire_blocking(sf.flight_lock_path()).unwrap();
+        let outcome = sf
+            .run(Ids::of([7]), |_| -> anyhow::Result<Step<()>> {
+                panic!("must not run while the flight lock is held")
+            })
+            .unwrap();
+        assert!(matches!(outcome, FlightOutcome::Coalesced));
+        // The payload is queued for the (simulated) holder's drain.
+        assert_eq!(
+            std::fs::read(dir.join("marker")).map(|b| Ids::decode(&b)).unwrap(),
+            Ids::of([7])
+        );
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn a_stale_marker_is_drained_not_wedged() {
+        // A marker left by a killed runner must be absorbed by the next runner's first pass, never
+        // strand it. Written directly, as a crashed process would leave it.
+        let (sf, dir) = flight::<Ids>();
+        std::fs::write(dir.join("marker"), Ids::of([4]).encode()).unwrap();
+        let passes = RefCell::new(Vec::new());
+        sf.run(Ids::of([5]), |p| {
+            passes.borrow_mut().push(p.clone());
+            Ok(Step::Ran(()))
+        })
+        .unwrap();
+        assert_eq!(*passes.borrow(), vec![Ids::of([4, 5])], "the stale marker is folded in, once");
+        assert!(!dir.join("marker").exists(), "and the marker is drained, not left wedged");
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn stop_requeue_leaves_the_marker_set() {
+        let (sf, dir) = flight::<Ids>();
+        let outcome = sf
+            .run(Ids::of([9]), |_| -> anyhow::Result<Step<()>> { Ok(Step::StopRequeue) })
+            .unwrap();
+        assert!(matches!(outcome, FlightOutcome::Stopped(None)));
+        assert_eq!(
+            std::fs::read(dir.join("marker")).map(|b| Ids::decode(&b)).unwrap(),
+            Ids::of([9]),
+            "the payload is left for a future runner",
+        );
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn stop_carry_hands_the_payload_back_and_clears_the_marker() {
+        let (sf, dir) = flight::<Ids>();
+        // A payload also queued mid-marker must be absorbed into the carried value.
+        sf.queue(Ids::of([2])).unwrap();
+        let outcome =
+            sf.run(Ids::of([1]), |_| -> anyhow::Result<Step<()>> { Ok(Step::StopCarry) }).unwrap();
+        match outcome {
+            FlightOutcome::Stopped(Some(carried)) => assert_eq!(carried, Ids::of([1, 2])),
+            other =>
+                panic!("expected Stopped(Some), got {:?}", matches!(other, FlightOutcome::Ran(_))),
+        }
+        assert!(!dir.join("marker").exists(), "the marker is consumed into the carried payload");
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn the_unit_payload_reruns_on_a_bare_marker() {
+        // The maintenance (#267) case: `()` carries nothing; the marker's mere existence is the
+        // rerun signal.
+        let (sf, dir) = flight::<()>();
+        let count = Cell::new(0u32);
+        let first = Cell::new(true);
+        sf.run((), |()| {
+            count.set(count.get() + 1);
+            if first.replace(false) {
+                sf.queue(()).unwrap();
+            }
+            Ok(Step::Ran(()))
+        })
+        .unwrap();
+        assert_eq!(count.get(), 2, "a bare marker set mid-pass earns exactly one rerun");
+        let _ = std::fs::remove_dir_all(dir);
+    }
+}

--- a/crates/rag-rat-cli/src/commands/index_ops.rs
+++ b/crates/rag-rat-cli/src/commands/index_ops.rs
@@ -2,7 +2,6 @@
 //! changed / worktree-overlay build + watch), `reconcile` (embedding backfill, plan, vector
 //! re-encode), `maintenance` (the git-hook pass, coalesced), `doctor` (health snapshot), and the
 //! `run_watch` / `run_maintenance_pass` helpers they drive.
-use std::fs;
 use std::path::Path;
 use std::time::Instant;
 
@@ -397,12 +396,19 @@ pub(crate) fn maintenance(config: &Config, args: &MaintenanceArgs) -> anyhow::Re
     // and runs once more to cover a change that arrived mid-pass. The pass still takes the write
     // lock internally, so serialization with the watcher is unchanged.
     let lock_repo = rag_rat_base::locks::write_lock_repo_id(config);
-    let pending = rag_rat_base::locks::maintenance_pending_path(&config.database, &lock_repo);
-    let lock_path = rag_rat_base::locks::maintenance_lock_path(&config.database, &lock_repo);
-    let mut report;
-    {
-        let Some(_maint) = rag_rat_base::locks::FileLock::try_acquire(&lock_path)? else {
-            let _ = fs::File::create(&pending);
+    // #267 coalescing on the shared single-flight primitive (#660): the runner drains any triggers
+    // that coalesce mid-pass and releases the flight lock (via the exit handoff) BEFORE this call
+    // returns — so the papertrail trigger below runs UNLOCKED, as before (a network-bound mirror
+    // flight must not make concurrent git triggers coalesce-skip their ordinary index passes).
+    let flight = rag_rat_base::single_flight::SingleFlight::<()>::new(
+        rag_rat_base::locks::maintenance_lock_path(&config.database, &lock_repo),
+        rag_rat_base::locks::maintenance_pending_path(&config.database, &lock_repo),
+        rag_rat_base::locks::maintenance_marker_lock_path(&config.database, &lock_repo),
+    );
+    let mut report = match flight.run((), |()| {
+        Ok(rag_rat_base::single_flight::Step::Ran(run_maintenance_pass(config, args, &trigger)?))
+    })? {
+        rag_rat_base::single_flight::FlightOutcome::Coalesced => {
             let mut skip_report = serde_json::json!({
                 "trigger": trigger,
                 "status": "skipped",
@@ -418,20 +424,15 @@ pub(crate) fn maintenance(config: &Config, args: &MaintenanceArgs) -> anyhow::Re
                 skip_report["papertrail"] = papertrail_hook_trigger(config);
             }
             return print_output(&skip_report);
-        };
-        loop {
-            // This pass covers the current state, so clear any prior rerun request first; a
-            // trigger that fires after this point re-sets it and earns the rerun below.
-            let _ = fs::remove_file(&pending);
-            report = run_maintenance_pass(config, args, &trigger)?;
-            if !pending.exists() {
-                break;
-            }
-        }
-        // The maintenance coordination lock is released HERE, before the papertrail trigger: a
-        // network-bound mirror flight must not make concurrent git triggers coalesce-skip their
-        // ordinary index passes.
-    }
+        },
+        rag_rat_base::single_flight::FlightOutcome::Ran(Some(report)) => report,
+        // `run` was given an initial payload, so it runs at least one pass; maintenance never stops
+        // the flight (its run_fn only ever returns `Ran`).
+        rag_rat_base::single_flight::FlightOutcome::Ran(None)
+        | rag_rat_base::single_flight::FlightOutcome::Stopped(_) => {
+            unreachable!("maintenance runs at least one pass and never stops the flight")
+        },
+    };
     let papertrail = if hook_trigger {
         papertrail_hook_trigger(config)
     } else {

--- a/crates/rag-rat-core/src/index/meta.rs
+++ b/crates/rag-rat-core/src/index/meta.rs
@@ -112,11 +112,12 @@ impl IndexDatabase {
 
     /// Whether `branch_targets` (a linked overlay's config targets) MAY differ from the config the
     /// base scope was indexed with — the cheap gate for the per-file target-identity drift scan
-    /// ([`Self::base_scope_target_drift`]). The base scope's discovery marker embeds its target
-    /// fingerprint; when it equals the branch's, no file can re-language, so the O(base-files) scan
-    /// is skipped — the common no-divergent-branch-config case that would otherwise re-scan every
-    /// base file on every overlay refresh × worktree, undoing the #577 event-scoping win.
-    /// Conservatively returns `true` when the marker is absent (a match can't be proven).
+    /// ([`Self::overlay_target_config_reconcile`]). The base scope's discovery marker embeds its
+    /// target fingerprint; when it equals the branch's, no file can re-language, so the
+    /// O(base-files) scan is skipped — the common no-divergent-branch-config case that would
+    /// otherwise re-scan every base file on every overlay refresh × worktree, undoing the #577
+    /// event-scoping win. Conservatively returns `true` when the marker is absent (a match
+    /// can't be proven).
     pub(super) fn overlay_targets_may_drift(
         &self,
         branch_targets: &[ResolvedTarget],

--- a/crates/rag-rat-core/src/index/papertrail_autosync.rs
+++ b/crates/rag-rat-core/src/index/papertrail_autosync.rs
@@ -9,11 +9,9 @@
 //! a short synchronous transaction serialized by SQLite itself. Ordinary index maintenance and
 //! this flight therefore proceed independently.
 
-use std::fs;
-use std::path::{Path, PathBuf};
-
 use rag_rat_base::config::Config;
 use rag_rat_base::locks::{self, FileLock};
+use rag_rat_base::single_flight::{FlightOutcome, SingleFlight, Step};
 use rag_rat_papertrail::{AutosyncRequest, PapertrailContext, PapertrailSyncReport};
 
 use crate::index::IndexDatabase;
@@ -49,32 +47,33 @@ pub fn run(config: &Config, request: AutosyncRequest) -> anyhow::Result<Autosync
     // database creates the (empty) file first and only then refuses on the missing schema, and
     // that artifact defeats every later `database.exists()` "build the index first" hint. A
     // repo with no store at all is trivially not indexed — but the accepted signal is queued
-    // (see the NotIndexed drain arm) so a first index pass racing this trigger cannot lose it.
+    // (the first post-index trigger absorbs it) so a first index pass racing this trigger can't
+    // lose it.
     if !config.database.exists() {
         let lock_repo = locks::write_lock_repo_id(config);
-        PendingMarker::new(&config.database, &lock_repo).lock()?.merge(request)?;
+        flight(config, &lock_repo).queue(request)?;
         return Ok(AutosyncOutcome::NotIndexed);
     }
     // Identity re-key retry: when a pass discovers its flight lock was keyed from a
-    // since-upgraded identity, the stranded request (max-merged with anything consumed from the
-    // old-key marker) is carried to fresh keys and re-run — an `Incremental` change signal is
-    // not re-derivable from persisted cursor state, so it must not be dropped. Transitions are
-    // one-time per repo; the cap only bounds pathological churn.
+    // since-upgraded identity, the stranded request (absorbed from the old-key marker) is carried
+    // to fresh keys and re-run — an `Incremental` change signal is not re-derivable from persisted
+    // cursor state, so it must not be dropped. Transitions are one-time per repo; the cap only
+    // bounds pathological churn.
     let mut request = request;
     for _ in 0..3 {
         let lock_repo = locks::write_lock_repo_id(config);
-        let lock_path = locks::papertrail_lock_path(&config.database, &lock_repo);
-        let pending = PendingMarker::new(&config.database, &lock_repo);
-        let Some(flight) = acquire_or_coalesce(&lock_path, &pending, request)? else {
-            return Ok(AutosyncOutcome::Coalesced);
-        };
-        match drain(config, &lock_repo, &pending, flight, Some(request))? {
-            Drained::NotIndexed => return Ok(AutosyncOutcome::NotIndexed),
-            Drained::Ran(Some(report)) => return Ok(AutosyncOutcome::Ran(report)),
-            // Defensive: unreachable with `initial = Some` (the first pass reports, defers,
+        match flight(config, &lock_repo)
+            .run(request, |queued| run_pass(config, &lock_repo, *queued))?
+        {
+            FlightOutcome::Coalesced => return Ok(AutosyncOutcome::Coalesced),
+            FlightOutcome::Ran(Some(report)) => return Ok(AutosyncOutcome::Ran(report)),
+            // Defensive: unreachable with a non-`None` initial (the first pass reports, defers,
             // re-keys, or errors before the drain can exit empty-handed).
-            Drained::Ran(None) => return Ok(AutosyncOutcome::Coalesced),
-            Drained::Rekeyed(stranded) => request = stranded,
+            FlightOutcome::Ran(None) => return Ok(AutosyncOutcome::Coalesced),
+            // `StopRequeue` (NotIndexed) left the signal in the marker for a future trigger.
+            FlightOutcome::Stopped(None) => return Ok(AutosyncOutcome::NotIndexed),
+            // `StopCarry` (Rekeyed) handed the stranded request (+ absorbed marker) back to re-key.
+            FlightOutcome::Stopped(Some(stranded)) => request = stranded,
         }
     }
     // Pathological identity churn: preserve the signal where fresh-keyed triggers will find it,
@@ -86,16 +85,53 @@ pub fn run(config: &Config, request: AutosyncRequest) -> anyhow::Result<Autosync
     )
 }
 
+/// This repo's papertrail single-flight coordinator, keyed to `lock_repo` (the currently-resolved
+/// identity). Rebuilt per attempt: the identity can upgrade mid-flight (a shallow clone resolving
+/// its portable id), which re-keys every flight path.
+fn flight(config: &Config, lock_repo: &str) -> SingleFlight<AutosyncRequest> {
+    SingleFlight::new(
+        locks::papertrail_lock_path(&config.database, lock_repo),
+        locks::papertrail_pending_path(&config.database, lock_repo),
+        locks::papertrail_marker_lock_path(&config.database, lock_repo),
+    )
+}
+
+/// One scheduled flight pass under the held flight lock, mapped to a single-flight [`Step`]:
+/// - the repo's identity key went stale since the lock was taken → `StopCarry` (a fresh-keyed
+///   flight is now possible; re-key and retry rather than mirror twice over one cursor);
+/// - the repo is not indexed yet → `StopRequeue` (automatic sync serves indexed repos only; leave
+///   the accepted signal for the first post-index trigger — the deliberate marker-without-a-runner
+///   exception);
+/// - otherwise the scheduled pass runs → `Ran`.
+fn run_pass(
+    config: &Config,
+    lock_repo: &str,
+    request: AutosyncRequest,
+) -> anyhow::Result<Step<Box<PapertrailSyncReport>>> {
+    let db = IndexDatabase::open_config(config)?;
+    // Identity re-key guard on EVERY pass at the latest pre-walk moment: the flight lock was keyed
+    // from the identity resolved at entry, and both the wait for the slot and `open_config`'s own
+    // git reads take real time. A fresh resolution here is exactly what a future trigger keys its
+    // lock from, so a mismatch means a concurrent fresh-keyed flight is possible.
+    if locks::write_lock_repo_id(config) != lock_repo {
+        return Ok(Step::StopCarry);
+    }
+    // `open_config` registers read-only (it never creates an index), so on a shared database this
+    // repo can be registered yet never indexed; the #427 "an index pass ran here" signal separates
+    // the two.
+    if !rag_rat_db::schema::is_root_already_indexed_conn(db.storage.connection(), config)? {
+        return Ok(Step::StopRequeue);
+    }
+    Ok(Step::Ran(Box::new(db.papertrail_sync_scheduled(request)?)))
+}
+
 /// Best-effort: queue a request stranded by an identity re-key into the CURRENT identity's
 /// pending marker, where fresh-keyed triggers absorb it. The marker sits until the next trigger
 /// (the watcher deadline bounds the wait) — the same bounded staleness every error-path marker
 /// accepts.
 fn preserve_for_fresh_key(config: &Config, request: AutosyncRequest) {
     let lock_repo = locks::write_lock_repo_id(config);
-    let pending = PendingMarker::new(&config.database, &lock_repo);
-    if let Ok(guard) = pending.lock() {
-        let _ = guard.merge(request);
-    }
+    let _ = flight(config, &lock_repo).queue(request);
 }
 
 /// The explicit `papertrail sync` command: unconditional manual semantics (every binding
@@ -117,7 +153,7 @@ pub fn run_manual(
         config.database.exists(),
         "no index at this path yet; build one with `rag-rat index` or `rag-rat index --full`"
     );
-    // The same identity re-key guard as `run_flight`, with manual semantics: the identity can
+    // The same identity re-key guard as `run_pass`, with manual semantics: the identity can
     // move between resolving the lock key and the post-open re-check (the wait for the flight
     // slot and `open_config`'s own git reads take real time, and the open can itself upgrade
     // the identity). An automatic runner steps aside; an explicit command instead RE-KEYS and
@@ -125,17 +161,16 @@ pub fn run_manual(
     // transition is one-time per repo — the cap only bounds pathological churn.
     for _ in 0..3 {
         let lock_repo = locks::write_lock_repo_id(config);
-        let lock_path = locks::papertrail_lock_path(&config.database, &lock_repo);
-        let pending = PendingMarker::new(&config.database, &lock_repo);
-        // No marker lock is held while blocking here (a contender holding the marker lock must
-        // never block on the flight lock — see [`MarkerGuard`]); the runner's exit handoff
-        // releases the flight lock only with an empty marker, so this wait ends at a clean
+        let sf = flight(config, &lock_repo);
+        // No marker lock is held while blocking here (a contender holding the marker lock only
+        // TRY-acquires the flight lock — see the single-flight lock ordering); the runner's exit
+        // handoff releases the flight lock only with an empty marker, so this wait ends at a clean
         // boundary.
-        let flight = match FileLock::try_acquire(&lock_path)? {
-            Some(flight) => flight,
+        let flight_lock = match FileLock::try_acquire(sf.flight_lock_path())? {
+            Some(flight_lock) => flight_lock,
             None => {
                 on_wait();
-                FileLock::acquire_blocking(&lock_path)?
+                FileLock::acquire_blocking(sf.flight_lock_path())?
             },
         };
         let db = IndexDatabase::open_config(config)?;
@@ -143,21 +178,23 @@ pub fn run_manual(
             // Never mirror under a stale-keyed flight lock: a trigger resolving the upgraded
             // identity keys a DIFFERENT lock and could run concurrently over the same cursor.
             // A follow-up that coalesced into the OLD-key marker while this runner held the
-            // stale lock is unreachable for fresh-keyed triggers — carry it forward (the
-            // automatic path's `Rekeyed` carry, manual flavor) before releasing.
+            // stale lock is unreachable for fresh-keyed triggers — carry it forward before
+            // releasing.
             drop(db);
-            if let Some(stranded) = pending.lock()?.take()? {
+            if let Some(stranded) = sf.take()? {
                 preserve_for_fresh_key(config, stranded);
             }
-            drop(flight);
+            drop(flight_lock);
             continue;
         }
         let manual_report = db.papertrail_sync(full)?;
         drop(db);
-        // Triggers that coalesced behind the manual pass still get their follow-up (and the
-        // exit handoff) before the flight lock releases. A follow-up stranded by an identity
+        // Triggers that coalesced behind the manual pass still get their (scheduled) follow-up and
+        // the exit handoff before the flight lock releases. A follow-up stranded by an identity
         // transition mid-drain is queued for fresh-keyed triggers instead of dropped.
-        if let Drained::Rekeyed(stranded) = drain(config, &lock_repo, &pending, flight, None)? {
+        if let FlightOutcome::Stopped(Some(stranded)) =
+            sf.drain(flight_lock, None, |queued| run_pass(config, &lock_repo, *queued))?
+        {
             preserve_for_fresh_key(config, stranded);
         }
         return Ok(manual_report);
@@ -168,201 +205,11 @@ pub fn run_manual(
     )
 }
 
-/// Take the flight lock, or coalesce `request` into the pending marker — atomically under the
-/// marker lock, so a request only ever lands in the marker while some runner is still obligated
-/// to check it (one half of the exit handoff in [`drain`]).
-fn acquire_or_coalesce(
-    lock_path: &Path,
-    pending: &PendingMarker,
-    request: AutosyncRequest,
-) -> anyhow::Result<Option<FileLock>> {
-    let guard = pending.lock()?;
-    match FileLock::try_acquire(lock_path)? {
-        Some(flight) => Ok(Some(flight)),
-        None => {
-            guard.merge(request)?;
-            Ok(None)
-        },
-    }
-}
-
-enum Drained {
-    Ran(Option<Box<PapertrailSyncReport>>),
-    NotIndexed,
-    /// The flight lock's key no longer matches the resolved identity; the stranded request
-    /// (max-merged with anything consumed from the old-key marker) must be carried to fresh
-    /// keys by the caller.
-    Rekeyed(AutosyncRequest),
-}
-
-/// Drive scheduled passes while holding the flight lock: `initial` first (when given), then any
-/// follow-ups coalesced into the marker mid-pass, until the EXIT HANDOFF — absorbing the marker
-/// and releasing the flight lock under ONE marker-lock hold — finds nothing queued. A
-/// contender's merge-and-try-acquire section ([`acquire_or_coalesce`]) is serialized either
-/// before that hold (its request is seen here and earns the follow-up) or after the flight lock
-/// is already free (its own try-acquire wins and IT becomes the runner); checking without the
-/// lock, or releasing the flight lock outside it, reopens the window where a coalesced request
-/// is written into the void and never runs.
-fn drain(
-    config: &Config,
-    lock_repo: &str,
-    pending: &PendingMarker,
-    flight: FileLock,
-    initial: Option<AutosyncRequest>,
-) -> anyhow::Result<Drained> {
-    let mut flight = Some(flight);
-    let mut next = initial;
-    let mut last_report = None;
-    loop {
-        {
-            let guard = pending.lock()?;
-            match (guard.take()?, next.take()) {
-                (Some(queued), current) =>
-                    next = Some(current.map_or(queued, |request| request.max(queued))),
-                (None, Some(current)) => next = Some(current),
-                (None, None) => {
-                    // The exit handoff: release under the same hold that observed the empty
-                    // marker.
-                    drop(flight.take());
-                    return Ok(Drained::Ran(last_report));
-                },
-            }
-        }
-        let request = next.take().expect("the loop is only entered with a request");
-        match run_flight(config, lock_repo, request) {
-            Ok(FlightPass::Report(report)) => last_report = Some(report),
-            Ok(FlightPass::NotIndexed) => {
-                // Nothing can run until the first index pass — but the accepted signal must
-                // not drop: a hook can lose the maintenance lock to a manual run that is
-                // CREATING the first index and will never fire papertrail itself. Queue the
-                // request instead. This is the one deliberate "marker without an obligated
-                // runner" exception to the exit-handoff rule: the first post-index trigger
-                // absorbs it, and on a never-indexed repo it is an inert one-word file.
-                let guard = pending.lock()?;
-                guard.merge(request)?;
-                drop(flight.take());
-                return Ok(Drained::NotIndexed);
-            },
-            Ok(FlightPass::Rekeyed) => {
-                // The identity this open resolved no longer matches the held lock's key (a
-                // shallow clone upgrading to its portable id mid-flight). Triggers arriving
-                // under the NEW identity key their own flight lock, so mirroring under the
-                // stale key would run two concurrent flights over one cursor — stop here. The
-                // old-key marker is unreachable for new-key triggers: fold it into the
-                // stranded request the caller re-keys and retries with.
-                let guard = pending.lock()?;
-                let queued = guard.take()?;
-                drop(flight.take());
-                drop(guard);
-                let stranded = queued.map_or(request, |carried| request.max(carried));
-                return Ok(Drained::Rekeyed(stranded));
-            },
-            Err(error) => {
-                // Best-effort retry signal: a failing marker write must not shadow the flight
-                // error the caller is about to log.
-                if let Ok(guard) = pending.lock() {
-                    let _ = guard.merge(request);
-                }
-                return Err(error);
-            },
-        }
-    }
-}
-
-enum FlightPass {
-    Report(Box<PapertrailSyncReport>),
-    NotIndexed,
-    Rekeyed,
-}
-
-fn run_flight(
-    config: &Config,
-    lock_repo: &str,
-    request: AutosyncRequest,
-) -> anyhow::Result<FlightPass> {
-    let db = IndexDatabase::open_config(config)?;
-    // Identity re-key guard, on EVERY pass (the first included) at the latest pre-walk moment:
-    // the flight lock was keyed from the identity resolved at entry, and both the wait for this
-    // slot and `open_config`'s own git reads take real time. A fresh resolution here is exactly
-    // what a future trigger would key its lock from, so a mismatch means a concurrent
-    // fresh-keyed flight is possible and this runner must not start the walk.
-    if locks::write_lock_repo_id(config) != lock_repo {
-        return Ok(FlightPass::Rekeyed);
-    }
-    // Automatic sync serves already-INDEXED repos only. `open_config` registers read-only (it
-    // never creates an index), so on a shared database this repo can be registered yet never
-    // indexed; the #427 "an index pass ran here" signal (a recorded root, or the source_root
-    // meta an identity-less root gets) is what separates the two.
-    if !rag_rat_db::schema::is_root_already_indexed_conn(db.storage.connection(), config)? {
-        return Ok(FlightPass::NotIndexed);
-    }
-    Ok(FlightPass::Report(Box::new(db.papertrail_sync_scheduled(request)?)))
-}
-
-/// The pending-marker pair: the marker file carrying the strongest coalesced request, and the
-/// lock serializing every access to it. All reads and writes flow through a held [`MarkerGuard`]
-/// so no path can touch the file outside the lock — without it, two coalescing contenders can
-/// interleave their max-merge (a weaker request overwrites a queued `full`), and a runner's exit
-/// check can miss a marker written just before its flight lock releases. Distinct from the
-/// flight lock, which the runner holds for the whole network-bound run; this one is held for
-/// microseconds per section, so contenders never wait on a flight.
-struct PendingMarker {
-    path: PathBuf,
-    update_lock: PathBuf,
-}
-
-impl PendingMarker {
-    fn new(database: &Path, repo_id: &str) -> Self {
-        Self {
-            path: locks::papertrail_pending_path(database, repo_id),
-            update_lock: locks::papertrail_marker_lock_path(database, repo_id),
-        }
-    }
-
-    fn lock(&self) -> anyhow::Result<MarkerGuard<'_>> {
-        Ok(MarkerGuard { marker: self, _update: FileLock::acquire_blocking(&self.update_lock)? })
-    }
-}
-
-/// One held marker-lock section. Lock ordering: a runner holding the FLIGHT lock may block on
-/// this lock; a contender holding this lock only ever TRY-acquires the flight lock — the
-/// non-blocking edge is what makes the pair deadlock-free.
-struct MarkerGuard<'a> {
-    marker: &'a PendingMarker,
-    _update: FileLock,
-}
-
-impl MarkerGuard<'_> {
-    /// Record `request` into the marker, max-merged with whatever is already queued there.
-    fn merge(&self, request: AutosyncRequest) -> anyhow::Result<()> {
-        let merged = match fs::read_to_string(&self.marker.path) {
-            Ok(existing) => request.max(AutosyncRequest::from_marker_str(&existing)),
-            Err(_) => request,
-        };
-        fs::write(&self.marker.path, merged.as_marker_str())?;
-        Ok(())
-    }
-
-    /// Consume the marker. A request merged concurrently is either absorbed into the returned
-    /// value or lands after the removal and survives for the next check.
-    fn take(&self) -> anyhow::Result<Option<AutosyncRequest>> {
-        let Ok(content) = fs::read_to_string(&self.marker.path) else {
-            return Ok(None);
-        };
-        let _ = fs::remove_file(&self.marker.path);
-        Ok(Some(AutosyncRequest::from_marker_str(&content)))
-    }
-
-    /// Test-only visibility into the marker's presence; production paths decide through
-    /// [`Self::take`] so the decision and the consumption share one hold.
-    #[cfg(test)]
-    fn is_set(&self) -> bool {
-        self.marker.path.exists()
-    }
-}
-
 #[cfg(test)]
 mod tests {
+    use std::fs;
+    use std::path::Path;
+
     use super::*;
 
     #[test]
@@ -383,52 +230,39 @@ mod tests {
         assert_eq!(AutosyncRequest::from_marker_str(""), AutosyncRequest::Evaluate);
     }
 
-    #[test]
-    fn pending_marker_merges_max_wins_and_is_consumed_once() {
-        let tmp = tempfile::TempDir::new().unwrap();
-        let marker = PendingMarker::new(&tmp.path().join("locks/index.sqlite"), "repo");
-
-        marker.lock().unwrap().merge(AutosyncRequest::Full).unwrap();
-        // A later, weaker trigger must not weaken the queued full walk.
-        marker.lock().unwrap().merge(AutosyncRequest::Incremental).unwrap();
-        assert_eq!(fs::read_to_string(&marker.path).unwrap(), "full");
-
-        assert_eq!(marker.lock().unwrap().take().unwrap(), Some(AutosyncRequest::Full));
-        assert!(!marker.lock().unwrap().is_set());
-        assert_eq!(marker.lock().unwrap().take().unwrap(), None);
-
-        // And the upgrade direction: a stronger trigger replaces a weaker queued one.
-        marker.lock().unwrap().merge(AutosyncRequest::Evaluate).unwrap();
-        marker.lock().unwrap().merge(AutosyncRequest::Incremental).unwrap();
-        assert_eq!(marker.lock().unwrap().take().unwrap(), Some(AutosyncRequest::Incremental));
-    }
-
+    /// The `AutosyncRequest` payload's max-wins merge holds under cross-"process" filesystem
+    /// contention. Threads share no state but the marker files (the exact shape of concurrent hook
+    /// invocations): one queues a FULL walk while weaker contenders storm the marker. The generic's
+    /// marker lock makes every read-modify-write atomic, so the surviving marker must be `full` no
+    /// matter the interleaving. (The generic's own tests cover the coalescing mechanism; this pins
+    /// the domain payload's merge direction end-to-end.)
     #[test]
     fn concurrent_marker_merges_never_lose_the_strongest_request() {
-        // Race many cross-"process" contenders (threads sharing no state but the filesystem, the
-        // exact shape of concurrent hook invocations): one queues a FULL walk while weaker
-        // contenders storm the marker. The update lock makes every read-modify-write atomic, so
-        // the surviving marker must be `full` no matter the interleaving.
         let tmp = tempfile::TempDir::new().unwrap();
         let database = tmp.path().join("locks/index.sqlite");
+        let single_flight = || {
+            SingleFlight::<AutosyncRequest>::new(
+                locks::papertrail_lock_path(&database, "repo"),
+                locks::papertrail_pending_path(&database, "repo"),
+                locks::papertrail_marker_lock_path(&database, "repo"),
+            )
+        };
         std::thread::scope(|scope| {
             for contender in 0..8 {
-                let database = database.clone();
+                let sf = single_flight();
                 scope.spawn(move || {
-                    let marker = PendingMarker::new(&database, "repo");
                     let request = if contender == 3 {
                         AutosyncRequest::Full
                     } else {
                         AutosyncRequest::Incremental
                     };
                     for _ in 0..50 {
-                        marker.lock().unwrap().merge(request).unwrap();
+                        sf.queue(request).unwrap();
                     }
                 });
             }
         });
-        let marker = PendingMarker::new(&database, "repo");
-        assert_eq!(marker.lock().unwrap().take().unwrap(), Some(AutosyncRequest::Full));
+        assert_eq!(single_flight().take().unwrap(), Some(AutosyncRequest::Full));
     }
 
     /// The exit handoff under contention: any trigger accepted as `Coalesced` must eventually be
@@ -744,11 +578,7 @@ mod tests {
         // A request queued before the manual pass rides its drain: the manual walk covers it
         // (the follow-up evaluation lands inside the attempt interval and settles to a skip).
         let lock_repo = locks::write_lock_repo_id(&config);
-        PendingMarker::new(&config.database, &lock_repo)
-            .lock()
-            .unwrap()
-            .merge(AutosyncRequest::Incremental)
-            .unwrap();
+        flight(&config, &lock_repo).queue(AutosyncRequest::Incremental).unwrap();
 
         let report = run_manual(&config, false, || panic!("the lock is free; no wait")).unwrap();
         assert!(report.errors.is_empty(), "{:?}", report.errors);
@@ -786,18 +616,20 @@ mod tests {
         // the OLD identity, while the config now resolves to a different id.
         let stale_repo = "stale-pre-upgrade-id";
         assert_ne!(locks::write_lock_repo_id(&config), stale_repo);
-        let stale_lock_path = locks::papertrail_lock_path(&config.database, stale_repo);
-        let flight = FileLock::try_acquire(&stale_lock_path).unwrap().unwrap();
-        let pending = PendingMarker::new(&config.database, stale_repo);
-        pending.lock().unwrap().merge(AutosyncRequest::Full).unwrap();
+        let sf = flight(&config, stale_repo);
+        let stale_lock_path = sf.flight_lock_path().to_path_buf();
+        let flight_lock = FileLock::try_acquire(&stale_lock_path).unwrap().unwrap();
+        sf.queue(AutosyncRequest::Full).unwrap();
 
-        let drained =
-            drain(&config, stale_repo, &pending, flight, Some(AutosyncRequest::Incremental))
-                .unwrap();
+        let drained = sf
+            .drain(flight_lock, Some(AutosyncRequest::Incremental), |queued| {
+                run_pass(&config, stale_repo, *queued)
+            })
+            .unwrap();
         // The stranded request carries the strongest of the trigger and the old-key marker, so
         // the caller's re-key retry loses nothing.
         assert!(
-            matches!(drained, Drained::Rekeyed(AutosyncRequest::Full)),
+            matches!(drained, FlightOutcome::Stopped(Some(AutosyncRequest::Full))),
             "no pass may run under the stale key"
         );
         // No mirror work happened, the stranded old-key marker was consumed, and the stale

--- a/crates/rag-rat-papertrail/src/schedule.rs
+++ b/crates/rag-rat-papertrail/src/schedule.rs
@@ -141,6 +141,20 @@ impl AutosyncRequest {
     }
 }
 
+/// Coalesce papertrail flights through the shared single-flight primitive (#660): the marker
+/// carries the STRONGEST queued request so a full walk is never weakened by a later incremental.
+impl rag_rat_base::single_flight::FlightPayload for AutosyncRequest {
+    fn merge(self, other: Self) -> Self {
+        self.max(other)
+    }
+    fn encode(&self) -> Vec<u8> {
+        self.as_marker_str().as_bytes().to_vec()
+    }
+    fn decode(encoded: &[u8]) -> Self {
+        Self::from_marker_str(&String::from_utf8_lossy(encoded))
+    }
+}
+
 pub(crate) fn record_attempt(
     conn: &Connection,
     binding: &ResolvedTracker,


### PR DESCRIPTION
## What

Extracts the papertrail-autosync / maintenance (#267) coalescing pattern into one
payload-generic primitive, `SingleFlight<P>`, in `rag-rat-base`, and rewires both
existing callers onto it.

## Why

Two subsystems had grown near-identical hand-rolled "one runner does the work,
concurrent triggers coalesce into a marker" machinery. Autosync's is the subtle one
(content-carrying marker, exit handoff, identity re-key, not-indexed defer);
maintenance's is a racier empty-file variant. Unifying them puts the deadlock-free
lock ordering and the exit-handoff invariant in one tested place — and is the
substrate #661 (the PostToolUse edit-trigger hook) consumes.

## The primitive

- One runner per key holds the **flight lock** for the whole pass; concurrent
  triggers merge their `FlightPayload` into a **marker** (serialized by a **marker
  lock**) and return `Coalesced`; the runner reruns until the marker drains.
- **Exit handoff:** the flight lock is released only under the same marker-lock hold
  that observed an empty marker — the guarantee that no coalesced trigger is
  orphaned. Every exit path (including the error path) releases under the hold, so a
  trigger arriving while a runner is bailing wins the lock rather than
  false-coalescing into a marker no live runner will drain.
- **Lock ordering (deadlock-free):** a runner holding the flight lock may block on
  the marker lock; a contender holding the marker lock only try-acquires the flight
  lock.
- `FlightPayload::merge` models the coalesced signal (a max over an ordered request;
  `()` where the marker's presence is the whole signal). `Step::{StopRequeue,
  StopCarry}` let a pass stop early — leave the payload for a future trigger, or hand
  the absorbed marker back to the caller.

## Callers rewired

- **papertrail_autosync** drives `SingleFlight<AutosyncRequest>`; the identity re-key
  and not-indexed control lives in a `run_pass` → `Step` mapping. Removes the
  module's bespoke `PendingMarker` / `drain` / `run_flight` machinery.
- **maintenance** (CLI `index_ops`) uses `SingleFlight<()>`, adding the marker lock
  that closes the pre-existing window between the final pending-file check and the
  flight-lock release — behavior-preserving and stricter.

## Verification

Full workspace suite green (3065 tests); all four CI clippy gates clean
(`-D warnings`); nightly rustfmt clean.

Fixes #660
