### PR TITLE
feat(agent-hook): PostToolUse edit trigger — scoped reindex, watcher-aware, detached

### DIFF
--- a/crates/rag-rat-base/src/locks.rs
+++ b/crates/rag-rat-base/src/locks.rs
@@ -327,6 +327,34 @@ pub fn papertrail_marker_lock_path(database: &Path, repo_id: &str) -> PathBuf {
         .join(format!("rag-rat-papertrail-{}.pending.lock", lock_discriminator(repo_id)))
 }
 
+/// Per-DB, PER-REPO edit-driven reindex flight lock (#661), held by the one detached
+/// `rag-rat edit-reindex` runner for its whole scoped pass so a burst of PostToolUse edit hooks
+/// coalesces into a single scoped reindex instead of N serialized multi-second processes. Keyed by
+/// `repo_id` (A6) like [`write_lock_path`]. Separate from [`maintenance_lock_path`] and the write
+/// lock — it only serializes the edit-hook runners; the scoped pass still takes the write lock
+/// (with a timeout, never blocking) internally.
+pub fn edit_reindex_lock_path(database: &Path, repo_id: &str) -> PathBuf {
+    lock_dir(database).join(format!("rag-rat-edit-reindex-{}.lock", lock_discriminator(repo_id)))
+}
+
+/// Marker into which a coalesced edit-reindex trigger merges its edited path(s), pairing with
+/// [`edit_reindex_lock_path`] under the shared [`crate::single_flight`] coordinator (#660/#661).
+/// The CONTENT is the newline-joined UNION of edited paths, merged set-union so a runner covers
+/// every path queued while it was mid-pass. Every read-modify-write runs under
+/// [`edit_reindex_marker_lock_path`].
+pub fn edit_reindex_pending_path(database: &Path, repo_id: &str) -> PathBuf {
+    lock_dir(database).join(format!("rag-rat-edit-reindex-{}.pending", lock_discriminator(repo_id)))
+}
+
+/// Serializes every read-modify-write of the edit-reindex pending marker, pairing with
+/// [`edit_reindex_pending_path`]. Distinct from [`edit_reindex_lock_path`] — the RUNNER holds that
+/// one for the whole scoped pass, while this lock is held only for the microseconds of one marker
+/// update (runner and contenders alike), so contenders never wait on the pass.
+pub fn edit_reindex_marker_lock_path(database: &Path, repo_id: &str) -> PathBuf {
+    lock_dir(database)
+        .join(format!("rag-rat-edit-reindex-{}.pending.lock", lock_discriminator(repo_id)))
+}
+
 /// Order two repo ids by the CANONICAL LOCK ORDER (see the module doc): lexicographic on the
 /// sanitized discriminator, i.e. the order of the lock FILE NAMES themselves. Multi-lock
 /// acquirers sort with this before acquiring. Ties (same discriminator — same repo) are the

--- a/crates/rag-rat-cli/src/agent_hook/edit_reindex.rs
+++ b/crates/rag-rat-cli/src/agent_hook/edit_reindex.rs
@@ -1,0 +1,130 @@
+//! The detached edit-driven reindex runner (#661): the second half of the PostToolUse edit trigger.
+//!
+//! `posttooluse` (in the parent module) spawns `rag-rat edit-reindex --paths <edited files>` as a
+//! DETACHED child and returns immediately, so the agent's tool call is never blocked. This module
+//! is that child. It:
+//!
+//! - COALESCES a burst of concurrent edit hooks via the #660 single-flight — one runner holds the
+//!   flight lock and reindexes; the rest merge their edited path(s) into the marker and exit, and
+//!   the runner drains the union. A refactor firing many PostToolUse events runs ~one scoped pass,
+//!   not N serialized multi-second processes.
+//! - runs a STRUCTURAL-ONLY scoped pass ([`rag_rat_core::watch::reindex_paths`], the #659
+//!   substrate): discover / parse / graph / FTS for exactly the edited paths (a linked-worktree
+//!   edit routes through that checkout's overlay). It does NOT generate embeddings — the structural
+//!   pass only seeds the embedding-model row; embedding generation is a separate step (`rag-rat
+//!   reconcile` / the watcher / periodic), so there is no per-edit ONNX load or remote call.
+//! - takes the write lock with a poll-retry TIMEOUT (never blocking): a contending index /
+//!   maintenance pass is finite and may have ALREADY scanned the edited file, so the runner waits
+//!   it out and runs its OWN scoped pass rather than assume the holder covers the edit; only a
+//!   pathological over-budget hold defers the paths to the next trigger.
+//!
+//! Best-effort throughout: every path returns `Ok(())` so the (already-detached) process exits 0.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use rag_rat_base::config::Config;
+use rag_rat_base::locks::{self, WriteLock};
+use rag_rat_base::single_flight::{FlightPayload, SingleFlight, Step};
+
+/// How long the runner poll-retries the per-repo write lock before it defers. Generous on purpose:
+/// the contender is a FINITE index/maintenance pass (git-hook maintenance is itself capped at
+/// ~30s), not a network wait, and it may have ALREADY scanned the just-edited file before the edit
+/// landed — so the runner must wait out the (finite) hold and run its OWN scoped pass rather than
+/// assume the holder covers the edit. `acquire_timeout` polls (never blocks) for the whole budget;
+/// the runner is detached, so this wait never touches the agent. Only a pathological longer hold
+/// falls through to the leave-for-the-next-trigger deferral below.
+const WRITE_LOCK_RETRY_BUDGET: Duration = Duration::from_secs(60);
+
+/// The coalesced set of edited paths carried through the #660 single-flight marker.
+///
+/// `merge` is a set UNION so a runner draining the marker covers every path queued while it was
+/// mid-pass (never a lost edit). On the wire the paths are newline-joined: a hook-supplied
+/// `file_path` never contains a newline, and a pathological one merely splits into separate entries
+/// that [`rag_rat_core::watch::reindex_paths`] no-ops on (an unmatched path is a no-op).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct PathSet(BTreeSet<PathBuf>);
+
+impl FlightPayload for PathSet {
+    fn merge(mut self, other: Self) -> Self {
+        self.0.extend(other.0);
+        self
+    }
+
+    fn encode(&self) -> Vec<u8> {
+        self.0
+            .iter()
+            .map(|path| path.to_string_lossy().into_owned())
+            .collect::<Vec<_>>()
+            .join("\n")
+            .into_bytes()
+    }
+
+    fn decode(encoded: &[u8]) -> Self {
+        Self(
+            String::from_utf8_lossy(encoded)
+                .split('\n')
+                .filter(|token| !token.is_empty())
+                .map(PathBuf::from)
+                .collect(),
+        )
+    }
+}
+
+/// `rag-rat edit-reindex` entry: discover the repo config from the (inherited) session cwd and run
+/// the coalesced scoped reindex. `None` config ⇒ not a rag-rat repo ⇒ silent no-op, exactly like
+/// the hook that spawned this.
+pub fn run(cwd: &Path, paths: &[PathBuf]) -> anyhow::Result<()> {
+    let Some(config) = super::find_config(cwd) else { return Ok(()) };
+    run_with_config(&config, paths)
+}
+
+/// The coalescing runner, split out so tests drive it with a `Config` directly. Coalesced, ran, and
+/// requeued-on-contention are all success from the trigger's view — the point is never to block or
+/// error the agent.
+fn run_with_config(config: &Config, paths: &[PathBuf]) -> anyhow::Result<()> {
+    let initial: BTreeSet<PathBuf> = paths.iter().cloned().collect();
+    if initial.is_empty() {
+        return Ok(());
+    }
+    let lock_repo = locks::write_lock_repo_id(config);
+    let flight = SingleFlight::<PathSet>::new(
+        locks::edit_reindex_lock_path(&config.database, &lock_repo),
+        locks::edit_reindex_pending_path(&config.database, &lock_repo),
+        locks::edit_reindex_marker_lock_path(&config.database, &lock_repo),
+    );
+    flight.run(PathSet(initial), |paths| scoped_reindex(config, paths))?;
+    Ok(())
+}
+
+/// One scoped structural pass under the held flight lock, mapped to a single-flight [`Step`]:
+/// - the base index is not built yet (`EmptyIndexRefused`) → `Ran`: nothing to reconcile until the
+///   first `rag-rat index`, so drop it (a first index pass covers these files);
+/// - the write lock stays held past the whole retry budget → `StopRequeue`: leave the path union in
+///   the marker for the next trigger to fold in and drain (an active session's subsequent edits do
+///   this — the marker is never lost, only deferred);
+/// - otherwise run the structural-only scoped reindex over the union → `Ran`.
+fn scoped_reindex(config: &Config, paths: &PathSet) -> anyhow::Result<Step<()>> {
+    let lock_repo = locks::write_lock_repo_id(config);
+    // Poll-retry for the write lock across the whole budget (acquire_timeout never blocks). We do
+    // NOT assume a concurrent index/maintenance pass covers the edit — it may have scanned the file
+    // before the edit landed — so we wait out its finite hold and run our own scoped pass.
+    let Some(_lock) =
+        WriteLock::acquire_timeout(&config.database, &lock_repo, WRITE_LOCK_RETRY_BUDGET)?
+    else {
+        return Ok(Step::StopRequeue);
+    };
+    // Reentrant: `reindex_paths` re-acquires this same write lock (blocking) on this thread, which
+    // the registry resolves to an instant depth-increment — the timeout above is the only wait.
+    let paths: Vec<PathBuf> = paths.0.iter().cloned().collect();
+    match rag_rat_core::watch::reindex_paths(config, &paths, |_| {}) {
+        Ok(_) => Ok(Step::Ran(())),
+        Err(error) if error.downcast_ref::<rag_rat_core::index::EmptyIndexRefused>().is_some() =>
+            Ok(Step::Ran(())),
+        Err(error) => Err(error),
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/rag-rat-cli/src/agent_hook/edit_reindex.rs
+++ b/crates/rag-rat-cli/src/agent_hook/edit_reindex.rs
@@ -73,10 +73,11 @@ impl FlightPayload for PathSet {
 }
 
 /// `rag-rat edit-reindex` entry: discover the repo config from the (inherited) session cwd and run
-/// the coalesced scoped reindex. `None` config ⇒ not a rag-rat repo ⇒ silent no-op, exactly like
-/// the hook that spawned this.
+/// the coalesced scoped reindex. Uses GOVERNING discovery (the same as the hook that spawned this),
+/// so a linked-worktree edit with no branch-local config resolves the main config and routes
+/// through the overlay. `None` config ⇒ not a rag-rat repo ⇒ silent no-op.
 pub fn run(cwd: &Path, paths: &[PathBuf]) -> anyhow::Result<()> {
-    let Some(config) = super::find_config(cwd) else { return Ok(()) };
+    let Some(config) = super::find_governing_config(cwd) else { return Ok(()) };
     run_with_config(&config, paths)
 }
 

--- a/crates/rag-rat-cli/src/agent_hook/edit_reindex/tests.rs
+++ b/crates/rag-rat-cli/src/agent_hook/edit_reindex/tests.rs
@@ -1,0 +1,60 @@
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+
+use rag_rat_base::locks;
+use rag_rat_base::single_flight::SingleFlight;
+
+use super::*;
+
+fn path_set<const N: usize>(paths: [&str; N]) -> PathSet {
+    PathSet(paths.iter().map(PathBuf::from).collect())
+}
+
+#[test]
+fn path_set_round_trips_through_the_marker_encoding() {
+    let set = path_set(["/repo/src/a.rs", "/repo/src/b.rs", "/repo/x.ts"]);
+    assert_eq!(PathSet::decode(&set.encode()), set);
+    // Empty is well-defined (no queued paths).
+    assert_eq!(PathSet::decode(&PathSet::default().encode()), PathSet::default());
+    // Blank/trailing-newline tokens never become empty PathBuf entries.
+    assert_eq!(PathSet::decode(b"\n/repo/a.rs\n\n"), path_set(["/repo/a.rs"]));
+}
+
+#[test]
+fn path_set_merge_is_a_union() {
+    let merged =
+        path_set(["/repo/a.rs", "/repo/b.rs"]).merge(path_set(["/repo/b.rs", "/repo/c.rs"]));
+    assert_eq!(merged, path_set(["/repo/a.rs", "/repo/b.rs", "/repo/c.rs"]));
+}
+
+/// The #660 single-flight over a `PathSet` never loses an edited path under cross-"process"
+/// filesystem contention: many contenders storm the marker with distinct paths (the shape of a
+/// refactor firing a PostToolUse burst), and the surviving marker is the UNION of every path.
+#[test]
+fn concurrent_edit_triggers_coalesce_into_the_path_union() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let database = tmp.path().join("locks/index.sqlite");
+    let single_flight = || {
+        SingleFlight::<PathSet>::new(
+            locks::edit_reindex_lock_path(&database, "repo"),
+            locks::edit_reindex_pending_path(&database, "repo"),
+            locks::edit_reindex_marker_lock_path(&database, "repo"),
+        )
+    };
+    std::thread::scope(|scope| {
+        for contender in 0..8 {
+            let sf = single_flight();
+            scope.spawn(move || {
+                let path =
+                    PathSet(BTreeSet::from([PathBuf::from(format!("/repo/f{contender}.rs"))]));
+                for _ in 0..50 {
+                    sf.queue(path.clone()).unwrap();
+                }
+            });
+        }
+    });
+    let drained = single_flight().take().unwrap().unwrap();
+    let expected: PathSet =
+        PathSet((0..8).map(|contender| PathBuf::from(format!("/repo/f{contender}.rs"))).collect());
+    assert_eq!(drained, expected, "every contender's edited path survives the coalesce");
+}

--- a/crates/rag-rat-cli/src/agent_hook/mod.rs
+++ b/crates/rag-rat-cli/src/agent_hook/mod.rs
@@ -1,9 +1,14 @@
-//! `rag-rat agent-hook`: the coding-agent hook client (PreToolUse + SessionStart). Harness-neutral
-//! — Claude Code, Codex, and Cursor all use the same `hook_event_name` / `tool_name` / `tool_input`
-//! input and the same `hookSpecificOutput.additionalContext` output, so one entrypoint serves all.
+//! `rag-rat agent-hook`: the coding-agent hook client (PreToolUse + PostToolUse + SessionStart).
+//! Harness-neutral — Claude Code, Codex, and Cursor all use the same `hook_event_name` /
+//! `tool_name` / `tool_input` input and the same `hookSpecificOutput.additionalContext` output, so
+//! one entrypoint serves all.
 //!
 //! Reads the hook JSON from stdin and branches on `hook_event_name`:
 //! - `"SessionStart"`: injects a read-only repo orientation digest into the model context.
+//! - `"PostToolUse"`: after an edit tool completes, triggers a scoped reindex of the edited path(s)
+//!   in a DETACHED child (`edit_reindex`), watcher-aware — see [`posttooluse`]. Scoped to Claude
+//!   Code, whose PostToolUse carries the edited `file_path` (Codex's `apply_patch` PostToolUse
+//!   fires before the write lands, and Cursor's payload is unpinned, so neither is wired — #661).
 //! - PreToolUse (anything else, or absent): grep-augmentation on `Grep`/`Bash` (asks the elected
 //!   listener or falls back to a direct read-only query), and the write-time clone check on the
 //!   edit tools — `Write`/`Edit`/`MultiEdit` (Claude) and `apply_patch` (Codex/Cursor, whose V4A
@@ -12,10 +17,8 @@
 //! Exit 0 on every path — the hook must never block a tool call or session start.
 
 use std::io::Read as _;
-use std::path::Path;
-// PathBuf (socket_path) and Duration (SOCKET_BUDGET) back the unix-only listener path.
-#[cfg(unix)]
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+// Duration (SOCKET_BUDGET) backs the unix-only listener path.
 #[cfg(unix)]
 use std::time::Duration;
 
@@ -27,6 +30,8 @@ use rag_rat_core::query::grep_augment;
 use rag_rat_core::query::orientation::Orientation;
 use rag_rat_db::storage::IndexConnection;
 use serde::Deserialize;
+
+pub(crate) mod edit_reindex;
 
 /// Skip the write-time clone check above this many fingerprinted functions — but ONLY in the RAM
 /// FALLBACK mode, which builds an in-RAM inverted index over all of them (O(functions)) and so
@@ -296,6 +301,7 @@ fn run_inner() -> anyhow::Result<()> {
     let input: HookInput = serde_json::from_str(&raw).unwrap_or_default();
     match input.hook_event_name.as_deref() {
         Some("SessionStart") => session_start(&input),
+        Some("PostToolUse") => posttooluse(&input),
         _ => pretooluse(&input),
     }
 }
@@ -415,6 +421,112 @@ fn pretooluse(input: &HookInput) -> anyhow::Result<()> {
         );
     }
     Ok(())
+}
+
+/// PostToolUse path (#661): after an edit tool completes, trigger a scoped reindex of the edited
+/// path(s) so an agent-driven repo stays fresh without the FS watcher — precise, watch-free,
+/// cross-OS. Watcher-aware and detached; exits 0 on every path so it never blocks or fails the
+/// agent's tool call.
+fn posttooluse(input: &HookInput) -> anyhow::Result<()> {
+    let paths = extract_edited_paths(input);
+    if paths.is_empty() {
+        return Ok(());
+    }
+    let Some(config) = find_config(Path::new(&input.cwd)) else { return Ok(()) };
+    // The scoped `index --paths` mode requires an existing base index (#659/#427) — with no DB
+    // there is nothing to reconcile into yet; the first `rag-rat index` builds it. (Do NOT
+    // open/create it.)
+    if !config.database.is_file() {
+        return Ok(());
+    }
+    // Watcher-live ⇒ no-op: a live MCP watcher for this worktree receives the SAME inotify event
+    // and schedules a debounced pass, so reindexing here would just double the work. Mirrors
+    // the maintenance watcher-state deferral — and is what lets this trigger skip socket
+    // delegation entirely (the only listener that would matter is already handling the edit).
+    if watcher_state(&config).0 {
+        return Ok(());
+    }
+    // No listener ⇒ the hook does the job itself, but DETACHED: a fresh `rag-rat` process is
+    // seconds of fixed overhead, so it must not run inline. The child coalesces burst edits via
+    // the #660 single-flight and takes the write lock with a timeout (never blocking).
+    spawn_detached_reindex(&input.cwd, &paths);
+    Ok(())
+}
+
+/// The edited absolute path(s) to reindex, from a PostToolUse edit-tool payload. `Write` / `Edit` /
+/// `MultiEdit` (Claude Code) all carry a single `tool_input.file_path` (MultiEdit batches edits to
+/// ONE file). Any other tool — including `apply_patch`, whose Codex PostToolUse fires before the
+/// write lands — yields nothing, so the trigger stays scoped to the harness that delivers a usable
+/// post-edit event (#661).
+fn extract_edited_paths(input: &HookInput) -> Vec<PathBuf> {
+    match input.tool_name.as_str() {
+        "Write" | "Edit" | "MultiEdit" => input
+            .tool_input
+            .get("file_path")
+            .and_then(|value| value.as_str())
+            .map(|path| vec![PathBuf::from(path)])
+            .unwrap_or_default(),
+        _ => Vec::new(),
+    }
+}
+
+/// Spawn `rag-rat edit-reindex --cwd <cwd> --paths <paths…>` fully detached and return without
+/// waiting, so the agent's synchronous tool call is never blocked. The child's stdio goes to null
+/// so the harness's captured pipe gets EOF the moment this hook exits (otherwise the harness would
+/// wait on the child's inherited stdout). Detaching so the child OUTLIVES the hook's process tree
+/// is platform-specific: on unix `setsid` moves it into its own session; on Windows creation flags
+/// detach it from the console and, where the launching Job Object permits, break it out of a
+/// kill-on-close job. Best-effort — a spawn failure is swallowed (the next edit / periodic
+/// reconcile catches up).
+fn spawn_detached_reindex(cwd: &str, paths: &[PathBuf]) {
+    let Ok(exe) = std::env::current_exe() else { return };
+    let mut command = std::process::Command::new(exe);
+    command
+        .arg("edit-reindex")
+        .arg("--cwd")
+        .arg(cwd)
+        .arg("--paths")
+        .args(paths)
+        .current_dir(cwd)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null());
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt as _;
+        // SAFETY: the pre_exec closure calls only `setsid`, which is async-signal-safe and touches
+        // no inherited allocator/lock state — it just detaches the child into a new session.
+        unsafe {
+            command.pre_exec(|| {
+                libc::setsid();
+                Ok(())
+            });
+        }
+        // Fire and forget: the setsid'd child is reparented to init when this hook exits.
+        let _ = command.spawn();
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt as _;
+        // Nulled stdio + a dropped handle do NOT detach on Windows: the child stays attached to the
+        // hook's console and, if the harness launched the hook inside a kill-on-close Job Object,
+        // dies when that job closes. DETACHED_PROCESS + CREATE_NO_WINDOW drop the console;
+        // CREATE_BREAKAWAY_FROM_JOB escapes the job — but CreateProcess REFUSES it when the job
+        // forbids breakaway, so fall back to console-detached-but-in-job (most harness jobs are not
+        // kill-on-close) rather than not spawning at all.
+        const DETACHED_PROCESS: u32 = 0x0000_0008;
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        const CREATE_BREAKAWAY_FROM_JOB: u32 = 0x0100_0000;
+        command.creation_flags(DETACHED_PROCESS | CREATE_NO_WINDOW | CREATE_BREAKAWAY_FROM_JOB);
+        if command.spawn().is_err() {
+            command.creation_flags(DETACHED_PROCESS | CREATE_NO_WINDOW);
+            let _ = command.spawn();
+        }
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = command.spawn();
+    }
 }
 
 /// The write-time clone-check size guard, factored out for testing. Skip the check ONLY when the

--- a/crates/rag-rat-cli/src/agent_hook/mod.rs
+++ b/crates/rag-rat-cli/src/agent_hook/mod.rs
@@ -432,24 +432,23 @@ fn posttooluse(input: &HookInput) -> anyhow::Result<()> {
     if paths.is_empty() {
         return Ok(());
     }
-    let Some(config) = find_config(Path::new(&input.cwd)) else { return Ok(()) };
+    // Governing discovery (not bare `find_config`): a linked-worktree edit with no branch-local
+    // config must still resolve the main config so `reindex_paths` routes it through the overlay.
+    let Some(config) = find_governing_config(Path::new(&input.cwd)) else { return Ok(()) };
     // The scoped `index --paths` mode requires an existing base index (#659/#427) — with no DB
     // there is nothing to reconcile into yet; the first `rag-rat index` builds it. (Do NOT
     // open/create it.)
     if !config.database.is_file() {
         return Ok(());
     }
-    // Watcher-live ⇒ no-op: a live MCP watcher for this worktree receives the SAME inotify event
-    // and schedules a debounced pass, so reindexing here would just double the work. Mirrors
-    // the maintenance watcher-state deferral — and is what lets this trigger skip socket
-    // delegation entirely (the only listener that would matter is already handling the edit).
-    if watcher_state(&config).0 {
+    let to_reindex = paths_to_reindex(watcher_state(&config).0, &paths);
+    if to_reindex.is_empty() {
         return Ok(());
     }
-    // No listener ⇒ the hook does the job itself, but DETACHED: a fresh `rag-rat` process is
-    // seconds of fixed overhead, so it must not run inline. The child coalesces burst edits via
-    // the #660 single-flight and takes the write lock with a timeout (never blocking).
-    spawn_detached_reindex(&input.cwd, &paths);
+    // The hook does the job itself, DETACHED: a fresh `rag-rat` process is seconds of fixed
+    // overhead, so it must not run inline. The child coalesces burst edits via the #660
+    // single-flight and takes the write lock with a timeout (never blocking).
+    spawn_detached_reindex(&input.cwd, &to_reindex);
     Ok(())
 }
 
@@ -468,6 +467,19 @@ fn extract_edited_paths(input: &HookInput) -> Vec<PathBuf> {
             .unwrap_or_default(),
         _ => Vec::new(),
     }
+}
+
+/// Which of the edited paths this hook must reindex, given whether a watcher is live. No watcher ⇒
+/// the hook covers everything. A live watcher covers the SOURCE edits (it gets the same inotify
+/// event and schedules a debounced pass), so nothing needs the hook — EXCEPT manifests
+/// (`Cargo.toml`): the watcher's event filter fires only for configured targets + `.gitignore`,
+/// never a manifest, yet the scoped pass refreshes the package map for one, so the watcher would
+/// silently miss it. Pure so the watcher-deferral decision is unit-tested without a live watcher.
+fn paths_to_reindex(watcher_live: bool, paths: &[PathBuf]) -> Vec<PathBuf> {
+    if !watcher_live {
+        return paths.to_vec();
+    }
+    paths.iter().filter(|path| rag_rat_core::watch::is_manifest_path(path)).cloned().collect()
 }
 
 /// Spawn `rag-rat edit-reindex --cwd <cwd> --paths <paths…>` fully detached and return without
@@ -850,10 +862,26 @@ pub fn format_digest(o: &Orientation, live: bool, enabled: bool) -> String {
 
 /// Walk up from the hook's cwd to the nearest rag-rat.toml and load it. `None` ⇒ not a rag-rat repo
 /// ⇒ silent no-op (what makes `--global` install safe). Shares the upward-walk primitive with
-/// `Config::load`'s discovery seam ([`rag_rat_base::config::nearest_config_at_or_above`]).
+/// `Config::load`'s discovery seam ([`rag_rat_base::config::nearest_config_at_or_above`]). Used by
+/// the READ paths (SessionStart / grep-augment / clone-check): cheaper than governing discovery,
+/// and a linked worktree with no branch-local config merely loses context there (not an incorrect
+/// index). The edit-reindex path instead uses [`find_governing_config`].
 fn find_config(start: &Path) -> Option<Config> {
     rag_rat_base::config::nearest_config_at_or_above(start)
         .and_then(|path| Config::load(&path).ok())
+}
+
+/// Resolve the GOVERNING config for the edit hook's cwd and load it, falling back to the MAIN
+/// worktree's config for a linked worktree with no branch-local `rag-rat.toml` (the documented
+/// main-governed setup) — the same governing discovery the CLI's own entry uses. Unlike
+/// [`find_config`], the edit-reindex path MUST resolve this: bare `nearest_config_at_or_above`
+/// stops at the linked worktree root and returns `None` there, so the hook would exit before
+/// reindexing a linked-checkout edit and leave that worktree stale. `Config::load`'s seam then
+/// re-anchors root to main and `reindex_paths` routes the edit through the overlay.
+/// `discover_config_path` returns a path even when none exists; `Config::load` then fails → `None`,
+/// preserving the no-config no-op.
+fn find_governing_config(start: &Path) -> Option<Config> {
+    Config::load(rag_rat_base::config::discover_config_path(start)).ok()
 }
 
 /// Outer Option: did the listener answer at all (None ⇒ fall back). Inner Option: did it

--- a/crates/rag-rat-cli/src/agent_hook/tests.rs
+++ b/crates/rag-rat-cli/src/agent_hook/tests.rs
@@ -133,6 +133,41 @@ fn extract_search_ignores_other_tools() {
     assert!(extract_search(&input).is_none());
 }
 
+// ─── PostToolUse edited-path extraction (#661) ──────────────────────────────
+
+#[test]
+fn extract_edited_paths_pulls_file_path_from_the_edit_tools() {
+    for tool in ["Write", "Edit", "MultiEdit"] {
+        let json = format!(
+            r#"{{"hook_event_name":"PostToolUse","tool_name":"{tool}",
+                "tool_input":{{"file_path":"/repo/src/lib.rs"}}}}"#,
+        );
+        let input: HookInput = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            extract_edited_paths(&input),
+            vec![PathBuf::from("/repo/src/lib.rs")],
+            "{tool} edited path",
+        );
+    }
+}
+
+#[test]
+fn extract_edited_paths_ignores_non_edit_tools_and_missing_paths() {
+    // A non-edit tool yields nothing — including `apply_patch`, deliberately unscoped (#661).
+    for tool in ["Read", "Grep", "Bash", "apply_patch"] {
+        let json = format!(
+            r#"{{"hook_event_name":"PostToolUse","tool_name":"{tool}",
+                "tool_input":{{"file_path":"/repo/x.rs"}}}}"#,
+        );
+        let input: HookInput = serde_json::from_str(&json).unwrap();
+        assert!(extract_edited_paths(&input).is_empty(), "{tool} must not trigger a reindex");
+    }
+    // An edit tool with no file_path (malformed payload) is a silent no-op, not a panic.
+    let json = r#"{"hook_event_name":"PostToolUse","tool_name":"Write","tool_input":{}}"#;
+    let input: HookInput = serde_json::from_str(json).unwrap();
+    assert!(extract_edited_paths(&input).is_empty());
+}
+
 // ─── format_digest ────────────────────────────────────────────────────────
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/rag-rat-cli/src/agent_hook/tests.rs
+++ b/crates/rag-rat-cli/src/agent_hook/tests.rs
@@ -168,6 +168,20 @@ fn extract_edited_paths_ignores_non_edit_tools_and_missing_paths() {
     assert!(extract_edited_paths(&input).is_empty());
 }
 
+#[test]
+fn paths_to_reindex_defers_to_the_watcher_except_for_manifests() {
+    let src = PathBuf::from("/repo/src/lib.rs");
+    let manifest = PathBuf::from("/repo/Cargo.toml");
+    let paths = vec![src.clone(), manifest.clone()];
+
+    // No watcher: the hook reindexes everything.
+    assert_eq!(paths_to_reindex(false, &paths), paths);
+
+    // Watcher live: source edits defer to the watcher, but a manifest it never sees does not.
+    assert_eq!(paths_to_reindex(true, &paths), vec![manifest]);
+    assert!(paths_to_reindex(true, &[src]).is_empty(), "a lone source edit fully defers");
+}
+
 // ─── format_digest ────────────────────────────────────────────────────────
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/rag-rat-cli/src/cli.rs
+++ b/crates/rag-rat-cli/src/cli.rs
@@ -43,6 +43,12 @@ pub(crate) enum Command {
     #[command(hide = true)]
     AgentHook,
 
+    /// Internal: the detached edit-driven reindex runner (#661), spawned by the PostToolUse edit
+    /// hook. Coalesces a burst of edits via the single-flight and runs one scoped structural
+    /// reindex of the supplied paths. Not for direct use — the hook backgrounds it.
+    #[command(hide = true)]
+    EditReindex(EditReindexArgs),
+
     /// Index the repository (default: changed files only).
     Index(IndexArgs),
 
@@ -180,6 +186,17 @@ pub(crate) struct IndexArgs {
     /// registering the repo with empty content instead of erroring. Default: refuse (#427).
     #[arg(long)]
     pub allow_empty: bool,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct EditReindexArgs {
+    /// The edited absolute path(s) to reconcile (the PostToolUse hook supplies these).
+    #[arg(long, value_name = "PATH", num_args = 1..)]
+    pub paths: Vec<std::path::PathBuf>,
+    /// The session working directory to discover the repo config from (the hook's `cwd`, so a
+    /// linked-worktree edit resolves the same config the hook gated on).
+    #[arg(long, value_name = "DIR")]
+    pub cwd: std::path::PathBuf,
 }
 
 #[derive(Debug, Args)]

--- a/crates/rag-rat-cli/src/main.rs
+++ b/crates/rag-rat-cli/src/main.rs
@@ -83,6 +83,10 @@ fn main() -> anyhow::Result<()> {
     match &cli.command {
         Cmd::Init(args) => return init::run(args, cli.config.as_deref().unwrap_or("rag-rat.toml")),
         Cmd::AgentHook => return agent_hook::run(),
+        // The detached edit-reindex runner discovers its own config from the hook's cwd (a
+        // not-a-rag-rat-repo cwd is a silent no-op), so it tolerates config absence like
+        // agent-hook.
+        Cmd::EditReindex(args) => return agent_hook::edit_reindex::run(&args.cwd, &args.paths),
         Cmd::Mcp => return run_mcp(cli.config.as_deref(), cli.json),
         Cmd::Doctor(args) => return run_doctor(args, cli.config.as_deref()),
         _ => {},
@@ -99,7 +103,7 @@ fn main() -> anyhow::Result<()> {
     let _log = rag_rat_base::logging::init_logging(&config, log_role(&cli.command));
 
     match cli.command {
-        Cmd::Init(_) | Cmd::AgentHook | Cmd::Mcp | Cmd::Doctor(_) =>
+        Cmd::Init(_) | Cmd::AgentHook | Cmd::EditReindex(_) | Cmd::Mcp | Cmd::Doctor(_) =>
             unreachable!("handled before the config load above"),
         Cmd::Index(args) => index(&config, &args)?,
         Cmd::Query(args) => query(&config, &args)?,

--- a/crates/rag-rat-cli/tests/agent_hook_e2e.rs
+++ b/crates/rag-rat-cli/tests/agent_hook_e2e.rs
@@ -62,6 +62,31 @@ fn non_search_tool_means_silent_exit_zero() {
     assert!(stdout.is_empty());
 }
 
+/// #661: a PostToolUse edit with a config but no built index must no-op silently AND must not
+/// create the index (the non-creating DB-absent gate — a stray empty DB would defeat later
+/// `database.exists()` hints).
+#[test]
+fn posttooluse_without_an_index_is_silent_and_non_creating() {
+    let dir = std::env::temp_dir().join(format!("ragrat-hook-post-noindex-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(dir.join("src")).unwrap();
+    std::fs::write(
+        dir.join("rag-rat.toml"),
+        "[index]\nroot = \".\"\ndatabase = \".rag-rat/index.sqlite\"\n\n[target_bindings]\nrust = \
+         [\"src\"]\n",
+    )
+    .unwrap();
+    let input = serde_json::json!({
+        "session_id": "s1", "cwd": dir, "hook_event_name": "PostToolUse",
+        "tool_name": "Write", "tool_input": {"file_path": dir.join("src/new.rs")}
+    });
+    let (stdout, status) = run_hook(&input.to_string(), &dir);
+    assert!(status.success(), "PostToolUse must exit 0 even with no index");
+    assert!(stdout.is_empty(), "PostToolUse prints nothing, got: {stdout}");
+    assert!(!dir.join(".rag-rat/index.sqlite").is_file(), "the hook must not create the index");
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
 /// Full path: a live `rag-rat mcp` elects the hook listener, the `agent-hook` client reaches it
 /// over the Unix socket and gets the indexed symbol, a repeat in the same session is deduped to
 /// nothing, a fresh session sees it again, and once the server dies the client falls back to a
@@ -270,6 +295,76 @@ fn assert_symbol_indexed(config: &rag_rat_base::config::Config, symbol: &str) {
         .query_row("SELECT COUNT(*) FROM symbols WHERE name = ?1", [symbol], |row| row.get(0))
         .unwrap();
     assert!(count > 0, "index must contain the `{symbol}` symbol or the e2e is vacuous");
+}
+
+#[cfg(unix)]
+fn symbol_indexed(config: &rag_rat_base::config::Config, symbol: &str) -> bool {
+    use rag_rat_db::storage::IndexConnection;
+    let Ok(conn) = IndexConnection::open_read_only(&config.database) else { return false };
+    let count: i64 = conn
+        .connection()
+        .query_row("SELECT COUNT(*) FROM symbols WHERE name = ?1", [symbol], |row| row.get(0))
+        .unwrap_or(0);
+    count > 0
+}
+
+#[cfg(unix)]
+fn wait_for_symbol(config: &rag_rat_base::config::Config, symbol: &str, timeout: Duration) {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if symbol_indexed(config, symbol) {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    panic!("edited symbol `{symbol}` not indexed within {timeout:?}");
+}
+
+/// #661: the `edit-reindex` runner reconciles exactly the edited file — a deterministic check of the
+/// scoped pass (run to completion, no detach) so the edit provably lands (new symbol in, old out).
+#[cfg(unix)]
+#[test]
+fn edit_reindex_reconciles_the_edited_file() {
+    let repo = TestRepo::indexed_with_symbol();
+    fs::write(repo.root.join("src/lib.rs"), "pub fn added_after_edit_qrs() {}\n").unwrap();
+    let status = Command::new(env!("CARGO_BIN_EXE_rag-rat"))
+        .arg("edit-reindex")
+        .arg("--cwd")
+        .arg(&repo.root)
+        .arg("--paths")
+        .arg(repo.root.join("src/lib.rs"))
+        .current_dir(&repo.root)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .unwrap();
+    assert!(status.success());
+    assert!(
+        symbol_indexed(&repo.config, "added_after_edit_qrs"),
+        "the edit's new symbol is indexed"
+    );
+    assert!(!symbol_indexed(&repo.config, "frobnicate_xyz"), "the replaced symbol is gone");
+    repo.cleanup();
+}
+
+/// #661 end-to-end: a PostToolUse edit hook returns immediately (exit 0, silent) and backgrounds a
+/// DETACHED scoped reindex that eventually lands the edit. No watcher is live, so the hook does the
+/// job itself.
+#[cfg(unix)]
+#[test]
+fn posttooluse_backgrounds_a_scoped_reindex() {
+    let repo = TestRepo::indexed_with_symbol();
+    fs::write(repo.root.join("src/lib.rs"), "pub fn added_via_hook_tuv() {}\n").unwrap();
+    let input = serde_json::json!({
+        "session_id": "s-post", "cwd": repo.root, "hook_event_name": "PostToolUse",
+        "tool_name": "Edit", "tool_input": {"file_path": repo.root.join("src/lib.rs")}
+    });
+    let (stdout, status) = run_hook(&input.to_string(), &repo.root);
+    assert!(status.success(), "the hook must exit 0");
+    assert!(stdout.is_empty(), "PostToolUse prints nothing, got: {stdout}");
+    // The reindex runs in a detached child; poll until the edit lands.
+    wait_for_symbol(&repo.config, "added_via_hook_tuv", Duration::from_secs(30));
+    repo.cleanup();
 }
 
 #[cfg(unix)]

--- a/crates/rag-rat-core/src/watch/mod.rs
+++ b/crates/rag-rat-core/src/watch/mod.rs
@@ -31,7 +31,9 @@ pub(crate) use event_loop::{EventLoop, flush_watch_placement_failures, shutdown_
 pub(crate) use overlay::{
     OverlayBasisAction, overlay_basis_action, overlay_needs_embed, partition_paths_by_worktree,
 };
-pub use overlay::{OverlayScope, ReconcileBudget, refresh_worktree_overlays, reindex_paths};
+pub use overlay::{
+    OverlayScope, ReconcileBudget, is_manifest_path, refresh_worktree_overlays, reindex_paths,
+};
 #[cfg(test)]
 pub(crate) use papertrail::{PapertrailClock, PapertrailScheduler, papertrail_tick_interval};
 pub use pass::{CLONE_GRAPH_QUIET_MS, maintenance_pass, maintenance_pass_or_skip};

--- a/crates/rag-rat-core/src/watch/overlay.rs
+++ b/crates/rag-rat-core/src/watch/overlay.rs
@@ -358,6 +358,14 @@ pub(crate) struct WorktreePartition {
 /// non-git trees and paths already under the base checkout — is a base path. The linked roots are
 /// the [`crate::index::live_worktree_contexts`] spellings (canonicalized, base excluded), so the
 /// base pass and the overlay refresh key on the exact same identities the rest of the engine uses.
+/// Whether `path` is a package manifest (`Cargo.toml`) — a file the scoped reindex refreshes the
+/// package map for (see [`reindex_paths`]'s manifest handling), but that the file watcher's event
+/// filter (configured targets + `.gitignore`) never fires on. The PostToolUse edit hook uses this
+/// to still reindex a manifest edit when a watcher is live — the watcher would silently miss it.
+pub fn is_manifest_path(path: &Path) -> bool {
+    path.file_name() == Some(std::ffi::OsStr::new("Cargo.toml"))
+}
+
 pub(crate) fn partition_paths_by_worktree(config: &Config, paths: &[PathBuf]) -> WorktreePartition {
     let (_, worktrees) = crate::index::live_worktree_contexts(&config.root);
     let base = enclosing_worktree_id(&config.root);
@@ -371,7 +379,7 @@ pub(crate) fn partition_paths_by_worktree(config: &Config, paths: &[PathBuf]) ->
     for path in paths {
         match enclosing_linked_root(path, &linked) {
             Some(root) => {
-                if path.file_name() == Some(std::ffi::OsStr::new("Cargo.toml")) {
+                if is_manifest_path(path) {
                     partition.manifest_roots.insert(root.clone());
                 }
                 partition.linked_roots.insert(root);

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -32,6 +32,26 @@
         ]
       }
     ],
+    "PostToolUse": [
+      {
+        "matcher": "Write",
+        "hooks": [
+          { "type": "command", "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/launch.js\" --no-install agent-hook", "timeout": 5 }
+        ]
+      },
+      {
+        "matcher": "Edit",
+        "hooks": [
+          { "type": "command", "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/launch.js\" --no-install agent-hook", "timeout": 5 }
+        ]
+      },
+      {
+        "matcher": "MultiEdit",
+        "hooks": [
+          { "type": "command", "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/launch.js\" --no-install agent-hook", "timeout": 5 }
+        ]
+      }
+    ],
     "SessionStart": [
       {
         "matcher": "startup|clear|compact",


### PR DESCRIPTION
## What

When a Claude Code edit tool (`Write`/`Edit`/`MultiEdit`) completes, trigger a
scoped reindex of exactly the edited path(s) so an agent-driven repo stays fresh
without relying on the filesystem watcher — precise, watch-free, cross-OS.
Consumes the #659 `index --paths` substrate and the #660 single-flight.

## Blocking prerequisite (verified)

The issue gated this on confirming which harnesses deliver PostToolUse with the
edited path:

- **Claude Code** — ✅ fires for Write/Edit/MultiEdit; edited path in
  `tool_input.file_path`; documented + stable.
- **Codex** — ⚠️ `apply_patch` PostToolUse fires *before* the patch is written
  to disk (a reindex would see stale content), plus its plugin-hook schema is
  `deny_unknown_fields`. Out.
- **Cursor** — payload doesn't pin the edited-path field, and no Cursor plugin
  manifest exists in-repo. Out.

So the trigger is **scoped to Claude Code**, exactly as the issue permits. The
Rust handler stays harness-neutral (it yields nothing for `apply_patch`, so a
stray PostToolUse from another harness no-ops), but only Claude's
`plugin/hooks/hooks.json` wires PostToolUse.

## How

- **Hook** (`agent-hook`'s new PostToolUse branch): extract `file_path`, then
  no-op when there's no config, no built index (non-creating), or a **live
  watcher** for the worktree (it already gets the same inotify event — mirrors
  the maintenance `watcher_state` deferral, which is what lets this skip socket
  delegation entirely). Otherwise spawn a **detached** `rag-rat edit-reindex`
  child and return immediately. Exit 0 on every path.
- **Detached runner** (`edit_reindex`): coalesces edit bursts via the #660
  single-flight over a path-union payload (one pass over the union, not N serial
  multi-second processes), and runs a **structural-only** scoped `reindex_paths`
  — linked-worktree edits route through the overlay (#659).
- **Detach** is platform-specific: `setsid` on unix; console-detach +
  job-breakaway creation flags (with a fallback) on Windows, since a bare
  dropped `Child` + null stdio does not detach there.
- **Write lock**: poll-retry with `acquire_timeout` (never `acquire_blocking`) —
  it lands its own scoped pass rather than assume a concurrent index/maintenance
  pass covers the edit (that pass may have scanned the file before the edit
  landed); an over-budget hold defers the union to the next trigger.

## Embedding posture

The scoped pass is structural only (discover/parse/graph/FTS) — it seeds the
embedding-model row but generates **no** embeddings, so there's no per-edit ONNX
load or remote call. Embedding stays deferred to `rag-rat reconcile` / the
watcher / periodic.

## Tests

- Unit: `PathSet` encode/decode + union merge, cross-"process" coalescing over
  the path union, edited-path extraction (Write/Edit/MultiEdit; nothing for
  other tools incl. `apply_patch`).
- E2e: the `edit-reindex` runner reconciles the edited file (new symbol in, old
  out); a PostToolUse edit backgrounds a detached reindex that lands (polled);
  a PostToolUse with no index is silent and non-creating.

Full workspace suite green (3073 tests); four CI clippy gates clean
(`-D warnings`); nightly rustfmt clean.

Fixes #661
