### PR TITLE
perf(db): materialize edge visibility as edges_data.hidden — one integer compare per view row

### DIFF
--- a/crates/rag-rat-core/src/index/edges/helpers.rs
+++ b/crates/rag-rat-core/src/index/edges/helpers.rs
@@ -440,6 +440,7 @@ pub(crate) fn insert_candidates(
         let edge_kind_id = intern_edge_string(conn, candidate.edge_kind.as_str())?;
         let confidence_id = intern_edge_string(conn, candidate.confidence.as_str())?;
         let resolution_id = intern_edge_string(conn, "unresolved")?;
+        let hidden = super::edge_hidden_flag(candidate.edge_kind.as_str(), "unresolved");
         conn.prepare_cached(
             "
             INSERT INTO edges_data(
@@ -448,10 +449,10 @@ pub(crate) fn insert_candidates(
                 source_start_line, source_end_line, source_start_byte, source_end_byte,
                 callee_start_byte, callee_end_byte,
                 import_scope_start_byte, import_scope_end_byte, import_mod_id,
-                edge_kind_id, confidence_id, resolution_id
+                edge_kind_id, confidence_id, resolution_id, hidden
             )
             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, \
-             ?18, ?19)
+             ?18, ?19, ?20)
             ",
         )?
         .execute(params![
@@ -474,6 +475,7 @@ pub(crate) fn insert_candidates(
             edge_kind_id,
             confidence_id,
             resolution_id,
+            hidden,
         ])?;
     }
     Ok(())

--- a/crates/rag-rat-core/src/index/edges/mod.rs
+++ b/crates/rag-rat-core/src/index/edges/mod.rs
@@ -72,6 +72,43 @@ impl EdgeKind {
     }
 }
 
+/// The `edges_data.hidden` value for a row (#734): 1 exactly when the row is not a public graph
+/// edge — an internal dispatch FACT kind ([`EdgeKind::DispatchConstruct`] /
+/// [`EdgeKind::DispatchHandle`], #200) or a suppressed unresolved candidate. Every direct
+/// `edges_data` writer stamps the flag through this one helper so the `edges` view's
+/// `WHERE hidden = 0` — a single integer compare per row, the point of materializing
+/// visibility — can trust it. The view's INSTEAD OF triggers and the V075 backfill mirror the
+/// same predicate in SQL.
+pub(crate) fn edge_hidden_flag(edge_kind: &str, resolution: &str) -> i64 {
+    let dispatch_fact = edge_kind == EdgeKind::DispatchConstruct.as_str()
+        || edge_kind == EdgeKind::DispatchHandle.as_str();
+    i64::from(dispatch_fact || resolution == "suppressed")
+}
+
+/// #734 test tripwire: assert `edges_data.hidden` agrees with the visibility predicate it
+/// materializes ([`edge_hidden_flag`]) on EVERY row, whatever writer produced it. A disagreeing
+/// row either leaks an internal/suppressed row into every query-layer read or silently drops a
+/// real edge from the graph — call this after any test pass that inserts or re-resolves edges.
+#[cfg(test)]
+pub(crate) fn assert_hidden_agrees_with_visibility(conn: &rusqlite::Connection) {
+    let disagreeing: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM edges_data d
+             JOIN name_strings ek ON ek.id = d.edge_kind_id
+             JOIN name_strings r ON r.id = d.resolution_id
+             WHERE d.hidden <> CASE WHEN ek.value IN ('dispatch_construct', 'dispatch_handle')
+                                         OR r.value = 'suppressed'
+                                    THEN 1 ELSE 0 END",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        disagreeing, 0,
+        "edges_data.hidden must match the visibility predicate on every row"
+    );
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
 pub enum EdgeConfidence {
     Exact,

--- a/crates/rag-rat-core/src/index/edges/resolve/mod.rs
+++ b/crates/rag-rat-core/src/index/edges/resolve/mod.rs
@@ -330,10 +330,15 @@ fn resolve_edges_with_scope(conn: &Connection, write: EdgeWriteScope<'_>) -> any
             conn.prepare_cached(
                 "UPDATE edges_data
                  SET to_symbol_id = NULL, target_start_line = NULL, target_end_line = NULL,
-                     confidence_id = ?2, resolution_id = ?3
+                     confidence_id = ?2, resolution_id = ?3, hidden = ?4
                  WHERE id = ?1",
             )?
-            .execute(params![edge_id, confidence_id, resolution_id])?;
+            .execute(params![
+                edge_id,
+                confidence_id,
+                resolution_id,
+                edge_hidden_flag(&edge_kind, "unresolved"),
+            ])?;
             continue;
         }
         // The reference's byte position drives the module-aware covering test (#61).
@@ -390,19 +395,25 @@ fn resolve_edges_with_scope(conn: &Connection, write: EdgeWriteScope<'_>) -> any
             };
             // prepare_cached: one UPDATE per edge; cache the statement so the SQL compiles once per
             // connection instead of on every call.
+            let resolution = if suppressed { "suppressed" } else { "unresolved" };
             let confidence_id = interner.get(conn, confidence.as_str())?;
-            let resolution_id =
-                interner.get(conn, if suppressed { "suppressed" } else { "unresolved" })?;
+            let resolution_id = interner.get(conn, resolution)?;
             conn.prepare_cached(
                 "UPDATE edges_data
                  SET to_symbol_id = NULL,
                      target_start_line = NULL,
                      target_end_line = NULL,
                      confidence_id = ?2,
-                     resolution_id = ?3
+                     resolution_id = ?3,
+                     hidden = ?4
                  WHERE id = ?1",
             )?
-            .execute(params![edge_id, confidence_id, resolution_id])?;
+            .execute(params![
+                edge_id,
+                confidence_id,
+                resolution_id,
+                edge_hidden_flag(&edge_kind, resolution),
+            ])?;
             continue;
         };
         let confidence_id = interner.get(conn, confidence.as_str())?;
@@ -413,7 +424,8 @@ fn resolve_edges_with_scope(conn: &Connection, write: EdgeWriteScope<'_>) -> any
                  confidence_id = ?3,
                  target_start_line = ?4,
                  target_end_line = ?5,
-                 resolution_id = ?6
+                 resolution_id = ?6,
+                 hidden = ?7
              WHERE id = ?1",
         )?
         .execute(params![
@@ -423,6 +435,9 @@ fn resolve_edges_with_scope(conn: &Connection, write: EdgeWriteScope<'_>) -> any
             to_symbol_id.start_line,
             to_symbol_id.end_line,
             resolution_id,
+            // A re-resolved candidate un-hides (a previously suppressed Swift macro candidate
+            // whose target appears later); a resolved dispatch_handle FACT stays hidden.
+            edge_hidden_flag(&edge_kind, reason),
         ])?;
     }
     // #200: now that the dispatch FACT rows are resolved (handlers bound to symbols), synthesize
@@ -648,10 +663,10 @@ pub(crate) fn resolve_and_insert_edges(
                 callee_start_byte, callee_end_byte,
                 import_scope_start_byte, import_scope_end_byte, import_mod_id,
                 edge_kind_id, confidence_id,
-                to_symbol_id, target_start_line, target_end_line, resolution_id
+                to_symbol_id, target_start_line, target_end_line, resolution_id, hidden
             )
             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, \
-             ?18, ?19, ?20, ?21, ?22)
+             ?18, ?19, ?20, ?21, ?22, ?23)
             ",
         )?
         .execute(params![
@@ -677,6 +692,7 @@ pub(crate) fn resolve_and_insert_edges(
             target_start_line,
             target_end_line,
             resolution_id,
+            edge_hidden_flag(candidate.edge_kind.as_str(), reason),
         ])?;
     }
     crate::index::mem_trace("edges: inserted, before index rebuild");

--- a/crates/rag-rat-core/src/index/edges/resolve/tests.rs
+++ b/crates/rag-rat-core/src/index/edges/resolve/tests.rs
@@ -419,6 +419,7 @@ fn swift_suppresses_and_re_resolves_attached_macro_candidates() {
         .query_row("SELECT COUNT(*) FROM edges WHERE to_name = 'external'", [], |row| row.get(0))
         .unwrap();
     assert_eq!(freestanding_count, 1, "unresolved freestanding macros remain graph evidence");
+    assert_hidden_agrees_with_visibility(&conn);
 
     let observable = add_symbol_kind_language(
         &conn,
@@ -435,6 +436,7 @@ fn swift_suppresses_and_re_resolves_attached_macro_candidates() {
         })
         .unwrap();
     assert_eq!(resolved_macro, Some(observable), "a later macro definition must heal the edge");
+    assert_hidden_agrees_with_visibility(&conn);
 
     conn.execute("DELETE FROM symbols WHERE id = ?1", [observable]).unwrap();
     resolve_all_edges(&conn).unwrap();
@@ -442,6 +444,7 @@ fn swift_suppresses_and_re_resolves_attached_macro_candidates() {
         .query_row("SELECT COUNT(*) FROM edges WHERE to_name = 'Observable'", [], |row| row.get(0))
         .unwrap();
     assert_eq!(visible_after_removal, 0, "removing the macro must suppress the candidate again");
+    assert_hidden_agrees_with_visibility(&conn);
 }
 
 #[test]

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/dispatch.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/dispatch.rs
@@ -134,6 +134,9 @@ pub fn upsert(_id: i64) {}
     assert_eq!(view_count("dispatch_handle"), 0, "handle fact must be hidden from the view");
     // The synthesized real edge is visible through the view.
     assert!(view_count("dispatches") > 0, "the synthesized dispatches edge must stay visible");
+    // #734: the full-rebuild writers + dispatch synthesis stamped `hidden` consistently with the
+    // visibility predicate the view enforces.
+    crate::index::edges::assert_hidden_agrees_with_visibility(conn);
 
     let _ = fs::remove_dir_all(root);
 }

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
@@ -2054,10 +2054,14 @@ fn migration_068_hides_suppressed_edge_candidates() {
             |row| row.get(0),
         )
         .unwrap();
+    // The current view filters on the materialized `hidden` flag (V075); the pre-V068 view had
+    // only the dispatch-fact exclusion, evaluated inline. Reconstruct that shape so the row (a
+    // suppressed `uses_macro` candidate) is visible before the upgrade.
     let v67_view = current_view.replace(
-        "\n        AND d.resolution_id <> COALESCE(\n            (SELECT id FROM name_strings \
-         WHERE value = 'suppressed'), -1\n        )",
-        "",
+        "WHERE d.hidden = 0",
+        "WHERE d.edge_kind_id NOT IN (
+            SELECT id FROM name_strings WHERE value IN ('dispatch_construct', 'dispatch_handle')
+        )",
     );
     assert_ne!(v67_view, current_view, "fixture must remove the V068 public-edge filter");
     conn.execute_batch("DROP VIEW edges;").unwrap();
@@ -2688,14 +2692,21 @@ fn migration_073_backfills_state_normalized_from_the_provider_truthful_pair() {
 }
 
 #[test]
-fn migration_074_is_the_tip_and_refreshes_the_edges_view() {
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 74, "move this pin with the next schema migration");
+fn migration_074_refreshes_the_edges_view() {
+    // The absolute-tip pin moved to `migration_075_*` (V075 is the tip now); this drops to the
+    // symbolic `current_version == LATEST` freshness check, per the ladder convention.
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     schema::apply(&conn, &crate::index::migration_hooks()).unwrap();
+    assert_eq!(
+        schema::status(&conn).unwrap().current_version,
+        schema::LATEST_SCHEMA_VERSION,
+        "schema at LATEST after apply",
+    );
 
     // A DB that migrated through V068-V073 carries the ORIGINAL view text (per-row
-    // `NOT IN (SELECT ...)` suppressed-edge probe). Simulate it: swap the scalar clause back to
-    // the old form, truncate the ledger to V073, and seed one suppressed candidate.
+    // `NOT IN (SELECT ...)` suppressed-edge probe). Simulate it: swap the current materialized
+    // WHERE back to the historical inline predicates, truncate the ledger to V073, and seed one
+    // suppressed candidate.
     let current_view: String = conn
         .query_row(
             "SELECT sql FROM sqlite_master WHERE type = 'view' AND name = 'edges'",
@@ -2704,10 +2715,13 @@ fn migration_074_is_the_tip_and_refreshes_the_edges_view() {
         )
         .unwrap();
     let old_view = current_view.replace(
-        "AND d.resolution_id <> COALESCE(\n            (SELECT id FROM name_strings WHERE value = \
-         'suppressed'), -1\n        )",
-        "AND d.resolution_id NOT IN (\n            SELECT id FROM name_strings WHERE value = \
-         'suppressed'\n        )",
+        "WHERE d.hidden = 0",
+        "WHERE d.edge_kind_id NOT IN (
+            SELECT id FROM name_strings WHERE value IN ('dispatch_construct', 'dispatch_handle')
+        )
+        AND d.resolution_id NOT IN (
+            SELECT id FROM name_strings WHERE value = 'suppressed'
+        )",
     );
     assert_ne!(old_view, current_view, "fixture must reconstruct the pre-V074 clause");
     conn.execute(
@@ -2735,9 +2749,11 @@ fn migration_074_is_the_tip_and_refreshes_the_edges_view() {
             |row| row.get(0),
         )
         .unwrap();
+    // The V074 refresh runs inside the same forward pass as V075, so the re-installed view is
+    // the current shape: the materialized flag, no inline membership probes.
     assert!(
-        refreshed_view.contains("<> COALESCE"),
-        "V074 re-installs the scalar suppressed-edge clause: {refreshed_view}"
+        refreshed_view.contains("WHERE d.hidden = 0"),
+        "the forward pass re-installs the materialized-visibility view: {refreshed_view}"
     );
     // Semantics preserved across the refresh: the suppressed candidate stays in edges_data for
     // the resolver but never surfaces through the compatibility view.
@@ -2755,4 +2771,103 @@ fn migration_074_is_the_tip_and_refreshes_the_edges_view() {
         )
         .unwrap();
     assert_eq!(v74_recorded, 1, "the forward migration records V074");
+}
+
+#[test]
+fn migration_075_materializes_edge_visibility() {
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 75, "move this pin with the next schema migration");
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn, &crate::index::migration_hooks()).unwrap();
+    conn.execute(
+        "INSERT INTO files(path, language, kind, sha256, modified_at_ms, indexed_at_ms, \
+         commit_sha, worktree_id) VALUES ('App.swift', 'swift', 'source', 'sha', 0, 0, 'head', '')",
+        [],
+    )
+    .unwrap();
+    let file_id = conn.last_insert_rowid();
+    // One row per visibility class: a suppressed candidate, an internal dispatch FACT, and a
+    // public edge.
+    for (to_name, edge_kind, resolution) in [
+        ("Observable", "uses_macro", "suppressed"),
+        ("Msg::Start", "dispatch_construct", "unresolved"),
+        ("spawn_worker", "calls_name", "unresolved"),
+    ] {
+        conn.execute(
+            "INSERT INTO edges(source_file_id, to_name, edge_kind, confidence, resolution) VALUES \
+             (?1, ?2, ?3, 'NameOnly', ?4)",
+            rusqlite::params![file_id, to_name, edge_kind, resolution],
+        )
+        .unwrap();
+    }
+
+    // Simulate a pre-V075 DB: rows never carried the flag (zero it under the writers' backs) and
+    // the view still evaluates the V074 scalar clause inline. The backfill — not the insert
+    // trigger that already stamped these rows — must be what restores visibility.
+    conn.execute("UPDATE edges_data SET hidden = 0", []).unwrap();
+    let current_view: String = conn
+        .query_row(
+            "SELECT sql FROM sqlite_master WHERE type = 'view' AND name = 'edges'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    let v74_view = current_view.replace(
+        "WHERE d.hidden = 0",
+        "WHERE d.edge_kind_id NOT IN (
+            SELECT id FROM name_strings WHERE value IN ('dispatch_construct', 'dispatch_handle')
+        )
+        AND d.resolution_id <> COALESCE(
+            (SELECT id FROM name_strings WHERE value = 'suppressed'), -1
+        )",
+    );
+    assert_ne!(v74_view, current_view, "fixture must reconstruct the V074 view shape");
+    truncate_schema_to(&conn, 74);
+    conn.execute_batch("DROP VIEW edges;").unwrap();
+    conn.execute_batch(&v74_view).unwrap();
+
+    schema::migrate_forward(&conn, &crate::index::migration_hooks()).unwrap();
+
+    // The backfill re-derives the flag from the kind/resolution predicates.
+    let hidden_for = |to_name: &str| -> i64 {
+        conn.query_row(
+            "SELECT hidden FROM edges_data
+             WHERE to_name_id = (SELECT id FROM name_strings WHERE value = ?1)",
+            [to_name],
+            |row| row.get(0),
+        )
+        .unwrap()
+    };
+    assert_eq!(hidden_for("Observable"), 1, "suppressed candidates backfill hidden");
+    assert_eq!(hidden_for("Msg::Start"), 1, "dispatch FACT rows backfill hidden");
+    assert_eq!(hidden_for("spawn_worker"), 0, "public edges stay visible");
+
+    // The refreshed view filters on the flag alone — the per-row kind/resolution machinery is
+    // gone from the read path (the point of the migration).
+    let refreshed_view: String = conn
+        .query_row(
+            "SELECT sql FROM sqlite_master WHERE type = 'view' AND name = 'edges'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert!(
+        refreshed_view.contains("WHERE d.hidden = 0"),
+        "V075 installs the materialized-visibility filter: {refreshed_view}"
+    );
+    let visible: Vec<String> = conn
+        .prepare("SELECT to_name FROM edges ORDER BY to_name")
+        .unwrap()
+        .query_map([], |row| row.get(0))
+        .unwrap()
+        .collect::<Result<_, _>>()
+        .unwrap();
+    assert_eq!(visible, ["spawn_worker"], "only the public edge surfaces through the view");
+    let v75_recorded: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM schema_version WHERE id = '075_edges_hidden_flag'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(v75_recorded, 1, "the forward migration records V075");
 }

--- a/crates/rag-rat-core/src/search/lexical.rs
+++ b/crates/rag-rat-core/src/search/lexical.rs
@@ -605,9 +605,9 @@ fn graph_boost(
         JOIN name_strings tn ON tn.id = d.to_name_id
         WHERE (d.from_name_id IN (SELECT id FROM name_strings WHERE value IN (?1, ?2))
             OR d.to_name_id IN (SELECT id FROM name_strings WHERE value IN (?1, ?2)))
-          AND d.resolution_id <> COALESCE(
-              (SELECT id FROM name_strings WHERE value = 'suppressed'), -1
-          )
+          -- Materialized visibility (#734): excludes suppressed candidates and internal
+          -- dispatch FACT rows in one integer compare (the predicate the edges view enforces).
+          AND d.hidden = 0
           AND EXISTS (SELECT 1 FROM main.files f
                        WHERE f.id = d.source_file_id AND f.repo_id = ?3)
         ORDER BY
@@ -976,9 +976,7 @@ mod tests {
                  JOIN name_strings ek ON ek.id = d.edge_kind_id
                  WHERE (d.from_name_id IN (SELECT id FROM name_strings WHERE value IN ('a', 'b'))
                      OR d.to_name_id IN (SELECT id FROM name_strings WHERE value IN ('a', 'b')))
-                   AND d.resolution_id <> COALESCE(
-                       (SELECT id FROM name_strings WHERE value = 'suppressed'), -1
-                   )
+                   AND d.hidden = 0
                    AND EXISTS (SELECT 1 FROM main.files f
                                 WHERE f.id = d.source_file_id AND f.repo_id = 'r')",
             )

--- a/crates/rag-rat-db/src/schema/baseline.rs
+++ b/crates/rag-rat-db/src/schema/baseline.rs
@@ -212,6 +212,11 @@ pub fn apply_baseline(conn: &Connection) -> rusqlite::Result<()> {
             import_mod_id INTEGER,
             edge_kind_id INTEGER NOT NULL,
             confidence_id INTEGER NOT NULL,
+            -- Materialized visibility (#734): 1 exactly when the row is not a public graph edge —
+            -- an internal dispatch FACT kind (#200) or a suppressed unresolved candidate (V068).
+            -- The `edges` view filters on `hidden = 0` (one integer compare per row); every
+            -- writer keeps the flag in lockstep with that predicate (see `edge_hidden_flag`).
+            hidden INTEGER NOT NULL DEFAULT 0,
             FOREIGN KEY(source_file_id) REFERENCES files(id) ON DELETE CASCADE,
             FOREIGN KEY(from_symbol_id) REFERENCES symbols(id) ON DELETE SET NULL,
             FOREIGN KEY(to_symbol_id) REFERENCES symbols(id) ON DELETE SET NULL

--- a/crates/rag-rat-db/src/schema/migrations.rs
+++ b/crates/rag-rat-db/src/schema/migrations.rs
@@ -911,6 +911,27 @@ pub fn apply_edges_view_scalar_suppression(conn: &Connection) -> rusqlite::Resul
     ensure_edges_view(conn)
 }
 
+/// V075: materialize edge visibility as `edges_data.hidden` and filter the `edges` view on it.
+/// V074's scalar compare removed the per-row membership probe but still charged every view row a
+/// resolution-id comparison — measurable on the per-hit graph-evidence queries because they run
+/// per search hit. A stamped flag moves the classification to write time (each row's visibility
+/// is decided once, by the writer that knows it) and leaves the read side a single integer
+/// compare. The backfill mirrors the predicate the view WHERE used to evaluate: dispatch FACT
+/// kinds (#200) and suppressed unresolved candidates (V068). Idempotent — the ADD is guarded, the
+/// UPDATE only ever promotes `hidden = 0` rows the predicate says are invisible, and the view
+/// refresh is DROP + CREATE.
+pub fn apply_edges_hidden_flag(conn: &Connection) -> rusqlite::Result<()> {
+    add_column_if_missing(conn, "edges_data", "hidden", "INTEGER NOT NULL DEFAULT 0")?;
+    conn.execute_batch(
+        "UPDATE edges_data SET hidden = 1
+         WHERE hidden = 0
+           AND (edge_kind_id IN (SELECT id FROM name_strings
+                                 WHERE value IN ('dispatch_construct', 'dispatch_handle'))
+                OR resolution_id IN (SELECT id FROM name_strings WHERE value = 'suppressed'));",
+    )?;
+    ensure_edges_view(conn)
+}
+
 pub(crate) fn ensure_edges_view(conn: &Connection) -> rusqlite::Result<()> {
     let legacy_table: Option<String> = conn
         .query_row(
@@ -930,6 +951,10 @@ pub(crate) fn ensure_edges_view(conn: &Connection) -> rusqlite::Result<()> {
     add_column_if_missing(conn, "edges_data", "import_scope_start_byte", "INTEGER")?;
     add_column_if_missing(conn, "edges_data", "import_scope_end_byte", "INTEGER")?;
     add_column_if_missing(conn, "edges_data", "import_mod_id", "INTEGER")?;
+    // Same guarantee for the materialized visibility flag (V075): the view WHERE below references
+    // `d.hidden`, and this function runs at V020 — before V075 adds the column in the linear
+    // ladder. The V075 backfill then hides any pre-existing dispatch-fact/suppressed rows.
+    add_column_if_missing(conn, "edges_data", "hidden", "INTEGER NOT NULL DEFAULT 0")?;
     conn.execute_batch(
         "
         -- Recreate unconditionally: the view's definition evolves (e.g. the appended *_id
@@ -989,21 +1014,17 @@ pub(crate) fn ensure_edges_view(conn: &Connection) -> rusqlite::Result<()> {
         LEFT JOIN name_strings res ON res.id = d.resolution_id
         LEFT JOIN name_strings ek ON ek.id = d.edge_kind_id
         LEFT JOIN name_strings conf ON conf.id = d.confidence_id
-        -- #200: the internal dispatch FACT rows (`dispatch_construct`/`dispatch_handle`) are \
-         inputs
-        -- to `synthesize_dispatch_edges`, NOT real edges — the handle fact duplicates the
-        -- dispatcher's existing `calls_name`. Hide them at the compatibility view so EVERY \
-         query-layer
-        -- reader (graph traversal, repo_brief, clusters, grep-augment, orientation, …) is
-        -- structurally safe without each remembering an exclusion; the synthesized `dispatches` \
-         edge
-        -- (a real edge) stays visible. Resolution + synthesis read `edges_data` directly, so they
-        -- still see the facts. Filter on the raw `edge_kind_id` (a one-time constant subselect) \
-         so the
-        -- planner keeps the indexed-id predicates, not a value-join string compare.
-        WHERE d.edge_kind_id NOT IN (
-            SELECT id FROM name_strings WHERE value IN ('dispatch_construct', 'dispatch_handle')
-        );
+        -- Visibility is MATERIALIZED (#734): the writers stamp `hidden = 1` on every row that is
+        -- not a public graph edge — the internal dispatch FACT kinds (#200: inputs to
+        -- `synthesize_dispatch_edges`, where the handle fact duplicates the dispatcher's existing
+        -- `calls_name`) and the suppressed unresolved candidates (V068). Filtering here keeps
+        -- EVERY query-layer reader (graph traversal, repo_brief, clusters, grep-augment,
+        -- orientation, …) structurally safe without each remembering an exclusion; the
+        -- synthesized `dispatches` edge (a real edge) stays visible, and resolution + synthesis
+        -- read `edges_data` directly so they still see the facts. A single integer compare per
+        -- row is the point: evaluating the kind/resolution predicates inline — even as scalar
+        -- subselects — taxed every per-hit graph-evidence query (the query_warm regression).
+        WHERE d.hidden = 0;
 
         -- Interning per column: `INSERT OR IGNORE` + `value NOT NULL` means a NULL string is
         -- silently skipped and its id subselect yields NULL — exactly the legacy nullability.
@@ -1023,7 +1044,7 @@ pub(crate) fn ensure_edges_view(conn: &Connection) -> rusqlite::Result<()> {
                 target_start_line, target_end_line, target_qualified_name_id, evidence,
                 receiver_hint_id, resolution_id, callee_start_byte, callee_end_byte,
                 import_scope_start_byte, import_scope_end_byte, import_mod_id,
-                edge_kind_id, confidence_id
+                edge_kind_id, confidence_id, hidden
             )
             VALUES (
                 NEW.id, NEW.source_file_id, NEW.from_symbol_id, NEW.to_symbol_id,
@@ -1040,7 +1061,11 @@ pub(crate) fn ensure_edges_view(conn: &Connection) -> rusqlite::Result<()> {
                 NEW.callee_start_byte, NEW.callee_end_byte,
                 NEW.import_scope_start_byte, NEW.import_scope_end_byte, NEW.import_mod_id,
                 (SELECT id FROM name_strings WHERE value = NEW.edge_kind),
-                (SELECT id FROM name_strings WHERE value = NEW.confidence)
+                (SELECT id FROM name_strings WHERE value = NEW.confidence),
+                -- The same visibility predicate the direct writers stamp (see the view WHERE).
+                CASE WHEN NEW.edge_kind IN ('dispatch_construct', 'dispatch_handle')
+                          OR COALESCE(NEW.resolution, 'unresolved') = 'suppressed'
+                     THEN 1 ELSE 0 END
             );
         END;
 
@@ -1075,7 +1100,11 @@ pub(crate) fn ensure_edges_view(conn: &Connection) -> rusqlite::Result<()> {
                 import_scope_end_byte = NEW.import_scope_end_byte,
                 import_mod_id = NEW.import_mod_id,
                 edge_kind_id = (SELECT id FROM name_strings WHERE value = NEW.edge_kind),
-                confidence_id = (SELECT id FROM name_strings WHERE value = NEW.confidence)
+                confidence_id = (SELECT id FROM name_strings WHERE value = NEW.confidence),
+                -- Recompute visibility from the updated kind/resolution (see the view WHERE).
+                hidden = CASE WHEN NEW.edge_kind IN ('dispatch_construct', 'dispatch_handle')
+                                   OR NEW.resolution = 'suppressed'
+                              THEN 1 ELSE 0 END
             WHERE id = OLD.id;
         END;
 
@@ -1294,6 +1323,7 @@ pub(crate) fn known_version(migrations: &[AppliedMigration]) -> u32 {
             MIGRATION_072_ID => Some(72),
             MIGRATION_073_ID => Some(73),
             MIGRATION_074_ID => Some(74),
+            MIGRATION_075_ID => Some(75),
             _ => None,
         })
         .max()
@@ -1377,6 +1407,7 @@ pub(crate) fn known_migration(id: &str) -> bool {
             | MIGRATION_072_ID
             | MIGRATION_073_ID
             | MIGRATION_074_ID
+            | MIGRATION_075_ID
             | DIRTY_MIGRATION_ID
     )
 }
@@ -1457,6 +1488,7 @@ pub(crate) fn migration_checksum_mismatch(migration: &AppliedMigration) -> bool 
         MIGRATION_072_ID => migration.checksum != MIGRATION_072_CHECKSUM,
         MIGRATION_073_ID => migration.checksum != MIGRATION_073_CHECKSUM,
         MIGRATION_074_ID => migration.checksum != MIGRATION_074_CHECKSUM,
+        MIGRATION_075_ID => migration.checksum != MIGRATION_075_CHECKSUM,
         _ => false,
     }
 }

--- a/crates/rag-rat-db/src/schema/migrations.rs
+++ b/crates/rag-rat-db/src/schema/migrations.rs
@@ -1003,16 +1003,6 @@ pub(crate) fn ensure_edges_view(conn: &Connection) -> rusqlite::Result<()> {
         -- planner keeps the indexed-id predicates, not a value-join string compare.
         WHERE d.edge_kind_id NOT IN (
             SELECT id FROM name_strings WHERE value IN ('dispatch_construct', 'dispatch_handle')
-        )
-        -- Suppressed resolver candidates (retained for inspection, never real edges) are hidden
-        -- with a SCALAR compare, not `NOT IN (SELECT ...)`: the membership form probes an
-        -- ephemeral list PER VIEW ROW (~19M instructions per warm query on the bench corpus —
-        -- the query_warm regression), while an uncorrelated scalar subquery is evaluated once
-        -- per statement and the per-row cost is one integer compare. `resolution_id` is NOT
-        -- NULL and ids are positive, so `<> -1` (the never-interned sentinel) keeps every row —
-        -- exactly `NOT IN (empty)`.
-        AND d.resolution_id <> COALESCE(
-            (SELECT id FROM name_strings WHERE value = 'suppressed'), -1
         );
 
         -- Interning per column: `INSERT OR IGNORE` + `value NOT NULL` means a NULL string is

--- a/crates/rag-rat-db/src/schema/mod.rs
+++ b/crates/rag-rat-db/src/schema/mod.rs
@@ -40,7 +40,7 @@ use serde::Serialize;
 
 use crate::hooks::MigrationHooks;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 74;
+pub const LATEST_SCHEMA_VERSION: u32 = 75;
 
 /// Every oracle-DERIVED persisted table — the outputs an `oracle run` writes that must OUTLIVE a
 /// reindex.
@@ -540,6 +540,13 @@ const MIGRATION_074_DESCRIPTION: &str =
      compare instead of a per-row NOT IN membership probe (the query_warm regression: the probe \
      taxed every per-hit graph-evidence query). Pure view DDL refresh via ensure_edges_view; no \
      data change";
+const MIGRATION_075_ID: &str = "075_edges_hidden_flag";
+const MIGRATION_075_CHECKSUM: &str = "sha256:rag-rat-edges-hidden-flag-v75";
+const MIGRATION_075_DESCRIPTION: &str =
+    "Materialize edge visibility as edges_data.hidden and filter the edges view on it (issue \
+     #734): visibility is decided once at write time instead of re-deriving the dispatch-fact + \
+     suppressed-candidate predicates on every view row. Adds the column, backfills it from the \
+     predicate the view WHERE used to evaluate, and refreshes the view via ensure_edges_view";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -1175,6 +1182,12 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         checksum: MIGRATION_074_CHECKSUM,
         description: MIGRATION_074_DESCRIPTION,
         apply: MigrationFn::Plain(apply_edges_view_scalar_suppression),
+    },
+    Migration {
+        id: MIGRATION_075_ID,
+        checksum: MIGRATION_075_CHECKSUM,
+        description: MIGRATION_075_DESCRIPTION,
+        apply: MigrationFn::Plain(apply_edges_hidden_flag),
     },
 ];
 

--- a/crates/rag-rat-dream/src/findings.rs
+++ b/crates/rag-rat-dream/src/findings.rs
@@ -184,9 +184,9 @@ pub(super) fn coverage_gap(conn: &Connection, limit: usize) -> anyhow::Result<Ve
         .prepare(
             "SELECT DISTINCT d.to_symbol_id FROM edges_data d JOIN files ON files.id = \
              d.source_file_id WHERE d.to_symbol_id IS NOT NULL AND d.from_symbol_id IS NOT NULL
-             AND d.resolution_id <> COALESCE(
-                 (SELECT id FROM name_strings WHERE value = 'suppressed'), -1
-             )",
+             -- Materialized visibility (#734): only public graph edges mark a symbol as
+             -- depended-upon; suppressed candidates and dispatch FACT rows are not evidence.
+             AND d.hidden = 0",
         )?
         .query_map([], |r| r.get::<_, i64>(0))?
         .collect::<rusqlite::Result<_>>()?;

--- a/crates/rag-rat-oracle/src/store.rs
+++ b/crates/rag-rat-oracle/src/store.rs
@@ -636,9 +636,9 @@ pub(crate) fn clear_edge_oracle_for_tool(
               AND edges_data.callee_start_byte = edge_oracle.callee_start_byte
               AND edges_data.callee_end_byte = edge_oracle.callee_end_byte
               AND ek.value = edge_oracle.edge_kind
-              AND edges_data.resolution_id <> COALESCE(
-                  (SELECT id FROM name_strings WHERE value = 'suppressed'), -1
-              )
+              -- Materialized visibility (#734): a suppressed candidate is not a live oracle
+              -- edge, so its content twin must not anchor a verdict here.
+              AND edges_data.hidden = 0
               AND {scope}
           )
         ",
@@ -1442,9 +1442,9 @@ pub(crate) fn prune_edge_oracle_without_live_edge(conn: &Connection) -> anyhow::
               AND edges_data.callee_start_byte = edge_oracle.callee_start_byte
               AND edges_data.callee_end_byte = edge_oracle.callee_end_byte
               AND ek.value = edge_oracle.edge_kind
-              AND edges_data.resolution_id <> COALESCE(
-                  (SELECT id FROM name_strings WHERE value = 'suppressed'), -1
-              )
+              -- Materialized visibility (#734): a suppressed candidate does not keep a
+              -- dangling verdict alive.
+              AND edges_data.hidden = 0
         ){repo_clause}
         "
         ),

--- a/crates/rag-rat-query/src/load_bearing.rs
+++ b/crates/rag-rat-query/src/load_bearing.rs
@@ -222,13 +222,11 @@ pub fn scoped_weighted_fan_in(
          JOIN name_strings ek ON ek.id = d.edge_kind_id
          JOIN name_strings cf ON cf.id = d.confidence_id
          WHERE d.to_symbol_id = ?1
-           AND d.resolution_id <> COALESCE(
-               (SELECT id FROM name_strings WHERE value = 'suppressed'), -1
-           )
-           -- Internal dispatch FACT rows (#200) are synthesis inputs, not real in-edges — the
-           -- handle fact duplicates the dispatcher's existing calls_name, so counting it would
-           -- double-weight the handler. The synthesized `dispatches` edge IS counted.
-           AND ek.value NOT IN ('dispatch_construct', 'dispatch_handle')",
+           -- Materialized visibility (#734): excludes suppressed candidates and the internal
+           -- dispatch FACT rows (#200 — the handle fact duplicates the dispatcher's existing
+           -- calls_name, so counting it would double-weight the handler). The synthesized
+           -- `dispatches` edge IS counted.
+           AND d.hidden = 0",
     )?;
     let rows = stmt
         .query_map([to_symbol_id], |row| {

--- a/crates/rag-rat-query/src/pagerank.rs
+++ b/crates/rag-rat-query/src/pagerank.rs
@@ -334,13 +334,11 @@ pub fn important_symbols(
          JOIN name_strings ek ON ek.id = d.edge_kind_id
          JOIN name_strings cf ON cf.id = d.confidence_id
          WHERE d.from_symbol_id IS NOT NULL
-           AND d.resolution_id <> COALESCE(
-               (SELECT id FROM name_strings WHERE value = 'suppressed'), -1
-           )
-           -- Internal dispatch FACT rows (#200) are synthesis inputs, not real edges — they'd
-           -- double-count (the handle fact duplicates the dispatcher's existing calls_name) and
-           -- inflate rank. The synthesized `dispatches` edge IS counted (it's a real dependency).
-           AND ek.value NOT IN ('dispatch_construct', 'dispatch_handle')",
+           -- Materialized visibility (#734): excludes suppressed candidates and the internal
+           -- dispatch FACT rows (#200 — synthesis inputs whose handle fact duplicates the
+           -- dispatcher's existing calls_name; counting them would inflate rank). The
+           -- synthesized `dispatches` edge IS counted (it's a real dependency).
+           AND d.hidden = 0",
     )?;
     let rows = stmt
         .query_map([], |row| {

--- a/crates/rag-rat-query/src/repo_brief.rs
+++ b/crates/rag-rat-query/src/repo_brief.rs
@@ -521,9 +521,9 @@ pub fn summary_counts(conn: &Connection) -> anyhow::Result<SummaryCounts> {
         "SELECT COUNT(*) FROM edges_data e
            JOIN main.files f ON f.id = e.source_file_id
           WHERE f.repo_id = ?1 AND f.generation = ?2
-            AND e.resolution_id <> COALESCE(
-                (SELECT id FROM name_strings WHERE value = 'suppressed'), -1
-            )",
+            -- Materialized visibility (#734): count only public graph edges — suppressed
+            -- candidates and internal dispatch FACT rows are not edges the brief describes.
+            AND e.hidden = 0",
         rusqlite::params![repo_id, generation],
         |row| row_u64(row, 0),
     )?;


### PR DESCRIPTION
Fixes #734.

## Problem

The `edges` compatibility view evaluated visibility per row: the dispatch-fact `NOT IN (SELECT ...)` plus (since #731) a scalar suppressed-resolution compare. Every per-hit graph-evidence query pays the view WHERE, so the residual of the #639 `query_warm` regression (238.0M vs 223.4M instructions pre-regression) lived in exactly this machinery. A probe run on this branch (view at its pre-suppression WHERE) measured the ceiling: **225.76M** instructions on `query_warm` (−12.3M vs main's 238.02M), −12.2M on `query_cold`.

## Change

Visibility is decided once, at write time, and the view reads one integer:

- **V075** adds `edges_data.hidden INTEGER NOT NULL DEFAULT 0`, backfills it from the predicate the view used to evaluate (dispatch FACT kinds #200 + suppressed candidates V068), and reinstalls the view with `WHERE d.hidden = 0` — no subqueries at all. This also folds the dispatch `NOT IN`, which the probe still paid, so the final shape should land at or below the probe's number.
- Every direct `edges_data` writer stamps the flag through one helper, `edge_hidden_flag`: the candidate insert, all three resolve arms (a suppressed candidate that later re-resolves un-hides; a resolved `dispatch_handle` fact stays hidden), and the full-rebuild bulk insert. The view's INSTEAD OF triggers mirror the predicate for ad-hoc writes through the view.
- Direct `edges_data` readers wanting public-edge semantics — `graph_boost`, PageRank, load-bearing fan-in, repo-brief counts, dream findings, oracle store (×2) — drop their per-query suppressed/dispatch predicates for `hidden = 0`.

## Tests

- `migration_075_materializes_edge_visibility` zeroes the flags under the writers' backs before migrating forward, so the **backfill** (not the insert triggers) is what restores visibility; it pins the tip at 75 and asserts the view text carries no inline predicates.
- `assert_hidden_agrees_with_visibility` — a tripwire asserting `hidden` matches the visibility predicate on **every** row — runs after a real `IndexDatabase::rebuild` (dispatch fixture) and after each resolve pass in the Swift suppress/re-resolve/re-suppress lifecycle test.
- The suppression-behavior tests that were expectedly red on the probe commit are green again; 3098/3098 workspace tests pass.

## Measured (Bencher, ubuntu-latest, instructions)

| benchmark | main (90e7a15f) | this PR (9630934e) | Δ |
|---|--:|--:|--:|
| `query_warm` | 238.02M | **197.66M** | **−17.0%** |
| `query_cold` | 248.40M | **207.89M** | **−16.3%** |
| `index` | 1746.76M | 1751.50M | +0.27% |

`query_warm` lands 11.5% below even the pre-regression baseline (223.4M): the direct readers had carried per-row dispatch/suppression predicates since before the regression, and dropping those (graph_boost runs ~limit×8 per search) is worth more than the view WHERE alone — the probe's ceiling was 225.76M, the final shape beats it by another 28M. The +0.27% on `index` is the write-time stamping cost (one extra integer column per edge insert/update).
