### PR TITLE
feat(index): path-scoped overlay reconcile for linked-worktree edits

### DIFF
--- a/crates/rag-rat-core/src/index/prep.rs
+++ b/crates/rag-rat-core/src/index/prep.rs
@@ -254,11 +254,7 @@ pub(crate) fn explicit_index_files_and_changes(
         // a symlinked component; a missing leaf simply isn't a symlink. `relative` is
         // lexically normalized (Normal components only), so walking it from the root
         // reconstructs the real ancestor chain (#659 review).
-        let mut probe = config.root.clone();
-        let crosses_symlink = relative.components().any(|component| {
-            probe.push(component);
-            probe.symlink_metadata().is_ok_and(|meta| meta.file_type().is_symlink())
-        });
+        let crosses_symlink = path_crosses_symlink(&config.root, &relative);
         // A path that ESCAPES the root, CROSSES a symlink, or is not a regular file is NOT
         // indexable; an existing indexed row for one (a regular file since replaced by a
         // symlink, in- or out-of-repo) still falls through to the deletion branch below and
@@ -322,7 +318,7 @@ pub(crate) fn explicit_index_files_and_changes(
 /// produce the CANONICAL RELATIVE SPELLING used for target/dirty/persistence so `src/../src/a.rs`
 /// collapses to `src/a.rs` and `src/../outside.rs` to `outside.rs` (then dropped by the target
 /// filter).
-fn lexically_normalized_within_root(relative: &Path) -> Option<PathBuf> {
+pub(crate) fn lexically_normalized_within_root(relative: &Path) -> Option<PathBuf> {
     let mut out = PathBuf::new();
     for component in relative.components() {
         match component {
@@ -341,9 +337,23 @@ fn lexically_normalized_within_root(relative: &Path) -> Option<PathBuf> {
 /// Whether `full_path` stays under `canonical_root` after resolving `..` and symlinks. Rejects both
 /// `..`-escapes and in-repo-symlink escapes; the lexical prefix check alone would accept both.
 /// Rejects a path where nothing on the chain resolves (containment unverifiable).
-fn resolves_within_root(full_path: &Path, canonical_root: &Path) -> bool {
+pub(crate) fn resolves_within_root(full_path: &Path, canonical_root: &Path) -> bool {
     canonicalize_nearest_ancestor(full_path)
         .is_some_and(|canonical| canonical.starts_with(canonical_root))
+}
+
+/// Whether walking `relative` (a lexically-normalized, root-relative path) from `root` crosses a
+/// SYMLINK at any component — the leaf (`src/link.rs`) OR an ancestor directory (`src/link/a.rs`).
+/// `symlink_metadata` per ancestor does NOT follow, so it catches a symlinked component. A supplied
+/// path that crosses a symlink is not indexable: it would write an index row under a spelling the
+/// full/discover walker (which skips symlink entries) never produces. Shared by the base explicit
+/// flow and the linked path-scoped overlay so both reject the same symlink spellings (#659/#679).
+pub(crate) fn path_crosses_symlink(root: &Path, relative: &Path) -> bool {
+    let mut probe = root.to_path_buf();
+    relative.components().any(|component| {
+        probe.push(component);
+        probe.symlink_metadata().is_ok_and(|meta| meta.file_type().is_symlink())
+    })
 }
 
 /// Canonicalize `path` by canonicalizing its nearest EXISTING ancestor (the file — or even its

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/index_paths.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/index_paths.rs
@@ -135,15 +135,251 @@ fn reindex_paths_routes_a_linked_worktree_path_to_its_overlay_not_the_base() {
         "only the base-checkout path is a base path — the linked path must NOT fall through to \
          the base pass (which would drop it)",
     );
-    assert_eq!(
-        partition.linked_roots.len(),
-        1,
-        "the linked path routes to exactly its checkout overlay",
-    );
-    let root = partition.linked_roots.iter().next().unwrap();
+    assert_eq!(partition.linked.len(), 1, "the linked path routes to exactly its checkout overlay",);
+    let (root, root_paths) = partition.linked.iter().next().unwrap();
     assert!(
         linked.canonicalize().is_ok_and(|canonical| *root == canonical),
         "the routed root is the canonical linked checkout: {root:?}",
+    );
+    assert_eq!(
+        root_paths,
+        &vec![linked.join("src/a.rs")],
+        "the checkout's supplied paths are bucketed under it for a path-scoped overlay pass (#679)",
+    );
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}
+
+/// #679: a linked-worktree `index --paths` reconciles EXACTLY the supplied path's overlay row — a
+/// single-file edit does NOT pull in the OTHER in-flight changes in the same worktree (path-scoped,
+/// mirroring the base `Paths` semantics on the linked route). Row-count assertions only: no
+/// `symbol_present`, which lazily heals a zero-hit and would mask the b.rs absence.
+#[test]
+fn reindex_paths_scopes_a_linked_edit_to_just_the_supplied_path() {
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(main.join("src/a.rs"), "pub fn a_base() {}\n").unwrap();
+    fs::write(main.join("src/b.rs"), "pub fn b_base() {}\n").unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let config = source_config(main.clone(), Language::Rust);
+    let _ = IndexDatabase::rebuild(&config).unwrap();
+
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    // BOTH files are dirty in the linked checkout, but only a.rs is supplied.
+    fs::write(linked.join("src/a.rs"), "pub fn a_branch() {}\n").unwrap();
+    fs::write(linked.join("src/b.rs"), "pub fn b_branch() {}\n").unwrap();
+
+    crate::watch::reindex_paths(&config, &[linked.join("src/a.rs")], |_| {}).unwrap();
+
+    assert_eq!(
+        overlay_rows(&config, "src/a.rs"),
+        1,
+        "the supplied linked path gets its overlay row (its edit is reflected)",
+    );
+    assert_eq!(
+        overlay_rows(&config, "src/b.rs"),
+        0,
+        "the OTHER in-flight linked edit is NOT pulled in — the pass is path-scoped (#679)",
+    );
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}
+
+/// #679: a DELETED supplied linked path tombstones exactly that path's overlay row (shadowing the
+/// base row), still without touching the other in-flight change.
+#[test]
+fn reindex_paths_tombstones_only_the_supplied_deleted_linked_path() {
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(main.join("src/a.rs"), "pub fn a_base() {}\n").unwrap();
+    fs::write(main.join("src/b.rs"), "pub fn b_base() {}\n").unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let config = source_config(main.clone(), Language::Rust);
+    let _ = IndexDatabase::rebuild(&config).unwrap();
+
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    fs::remove_file(linked.join("src/a.rs")).unwrap(); // delete the supplied path
+    fs::write(linked.join("src/b.rs"), "pub fn b_branch() {}\n").unwrap(); // other dirty edit, not supplied
+
+    crate::watch::reindex_paths(&config, &[linked.join("src/a.rs")], |_| {}).unwrap();
+
+    assert_eq!(
+        deleted_overlay_rows(&config, "src/a.rs"),
+        1,
+        "the deleted supplied path is tombstoned in the overlay (shadows the base row)",
+    );
+    assert_eq!(
+        overlay_rows(&config, "src/b.rs"),
+        0,
+        "the other in-flight linked edit is untouched — still path-scoped (#679)",
+    );
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}
+
+/// #679 review: a supplied linked path the branch `.gitignore` IGNORES must not be indexed into the
+/// overlay — the path-scoped route honors the linked checkout's ignore rules, exactly like the base
+/// walker and the whole-delta overlay (else `index --paths` could create an overlay row for a file
+/// discovery would never index).
+#[test]
+fn reindex_paths_does_not_index_an_ignored_linked_path() {
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(main.join("src/a.rs"), "pub fn a_base() {}\n").unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let config = source_config(main.clone(), Language::Rust);
+    let _ = IndexDatabase::rebuild(&config).unwrap();
+
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    // The branch ignores `gen.rs`; the file sits in a target dir but is gitignored.
+    fs::write(linked.join(".gitignore"), "gen.rs\n").unwrap();
+    fs::write(linked.join("src/gen.rs"), "pub fn generated() {}\n").unwrap();
+
+    crate::watch::reindex_paths(&config, &[linked.join("src/gen.rs")], |_| {}).unwrap();
+
+    assert_eq!(
+        overlay_rows(&config, "src/gen.rs"),
+        0,
+        "an ignored linked path is not indexed into the overlay (#679 review)",
+    );
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}
+
+/// #679 review: a supplied linked path that CROSSES A SYMLINK (the leaf is a symlink) must not be
+/// indexed — the walker skips symlink entries, so indexing one would write an overlay row under a
+/// spelling a full/discover pass never produces (and could read content outside the checkout).
+#[cfg(unix)]
+#[test]
+fn reindex_paths_does_not_index_a_symlinked_linked_path() {
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(main.join("src/a.rs"), "pub fn a_base() {}\n").unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let config = source_config(main.clone(), Language::Rust);
+    let _ = IndexDatabase::rebuild(&config).unwrap();
+
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    fs::write(linked.join("src/real.rs"), "pub fn real_target() {}\n").unwrap();
+    std::os::unix::fs::symlink(linked.join("src/real.rs"), linked.join("src/link.rs")).unwrap();
+
+    crate::watch::reindex_paths(&config, &[linked.join("src/link.rs")], |_| {}).unwrap();
+
+    assert_eq!(
+        overlay_rows(&config, "src/link.rs"),
+        0,
+        "a symlink-crossing linked path is not indexed into the overlay (#679 review)",
+    );
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}
+
+/// #679 review: a BRANCH-ONLY file (absent from base) that was overlay-indexed and is then deleted
+/// must have its stale overlay row REMOVED by a path-scoped pass — there is no base row to shadow
+/// (so a tombstone is wrong) and this pass skips the global prune, so it must remove the row per
+/// supplied path or the dead row + its symbols would linger indefinitely.
+#[test]
+fn reindex_paths_removes_a_stale_branch_only_overlay_row() {
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(main.join("src/a.rs"), "pub fn a_base() {}\n").unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let config = source_config(main.clone(), Language::Rust);
+    let _ = IndexDatabase::rebuild(&config).unwrap();
+
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    // A branch-only file (never in base), overlay-indexed by a scoped pass.
+    fs::write(linked.join("src/only.rs"), "pub fn only_branch() {}\n").unwrap();
+    crate::watch::reindex_paths(&config, &[linked.join("src/only.rs")], |_| {}).unwrap();
+    assert_eq!(overlay_rows(&config, "src/only.rs"), 1, "the branch-only file is overlay-indexed");
+
+    // Delete it and reindex the SAME path — the stale overlay row must be removed, not tombstoned.
+    fs::remove_file(linked.join("src/only.rs")).unwrap();
+    crate::watch::reindex_paths(&config, &[linked.join("src/only.rs")], |_| {}).unwrap();
+    assert_eq!(
+        overlay_rows(&config, "src/only.rs"),
+        0,
+        "the stale branch-only overlay row is removed"
+    );
+    assert_eq!(
+        deleted_overlay_rows(&config, "src/only.rs"),
+        0,
+        "and NOT tombstoned — there is no base row to shadow (#679 review)",
+    );
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}
+
+/// #679 review: a supplied linked `rag-rat.toml` edit routes to the WHOLE-delta overlay pass (not
+/// the path-scoped one), so a branch target-config change is reconciled immediately — a file the
+/// branch now targets (but the base never indexed) appears in the overlay. The path-scoped route
+/// alone would no-op on the config file (not a source target) and leave the drift for a later
+/// sweep.
+#[test]
+fn reindex_paths_reconciles_target_drift_on_a_linked_config_edit() {
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::create_dir_all(main.join("extra")).unwrap();
+    fs::write(main.join("src/lib.rs"), "pub fn lib() {}\n").unwrap();
+    fs::write(main.join("extra/tool.rs"), "pub fn tool_marker() {}\n").unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    // Base config targets ONLY `src`, so extra/tool.rs is never base-indexed.
+    let base_config = source_config_dirs(main.clone(), Language::Rust, &["src"]);
+    let _ = IndexDatabase::rebuild(&base_config).unwrap();
+    assert_eq!(overlay_rows(&base_config, "extra/tool.rs"), 0, "extra/ is not a base target");
+
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    // The branch edits its config to ADD `extra` as a target (read on-disk by the overlay pass).
+    fs::write(
+        linked.join("rag-rat.toml"),
+        "[index]\nroot = \".\"\ndatabase = \".rag-rat/index.sqlite\"\n\n[target_bindings]\nrust = \
+         [\"src\", \"extra\"]\n",
+    )
+    .unwrap();
+
+    // Supply the CONFIG file — must route to the whole-delta drift reconcile, not the path-scoped
+    // route (which would no-op on rag-rat.toml).
+    crate::watch::reindex_paths(&base_config, &[linked.join("rag-rat.toml")], |_| {}).unwrap();
+
+    assert!(
+        overlay_rows(&base_config, "extra/tool.rs") >= 1,
+        "a branch config edit that re-targets extra/ is reconciled in the overlay (#679 review)",
     );
 
     let _ = fs::remove_dir_all(&main);
@@ -218,7 +454,7 @@ fn reindex_paths_routes_a_deleted_linked_path_whose_parent_dir_is_also_gone() {
         "the deleted linked path must not fall through to the base pass"
     );
     assert_eq!(
-        partition.linked_roots.len(),
+        partition.linked.len(),
         1,
         "it routes to the linked overlay via the surviving ancestor",
     );
@@ -237,6 +473,17 @@ fn file_rows(config: &Config, path: &str, commit_sha_pred: &str) -> i64 {
         |row| row.get::<_, i64>(0),
     )
     .unwrap()
+}
+
+/// Count non-deleted OVERLAY rows (`worktree_id != ''`) for `path` — a linked worktree's overlay
+/// scope. Zero ⇒ the base row shows through (the path was not shadowed).
+fn overlay_rows(config: &Config, path: &str) -> i64 {
+    file_rows(config, path, "worktree_id != '' AND kind != 'deleted'")
+}
+
+/// Count OVERLAY tombstone rows (`worktree_id != ''`, `kind = 'deleted'`) for `path`.
+fn deleted_overlay_rows(config: &Config, path: &str) -> i64 {
+    file_rows(config, path, "worktree_id != '' AND kind = 'deleted'")
 }
 
 #[test]

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/index_paths.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/index_paths.rs
@@ -386,6 +386,40 @@ fn reindex_paths_reconciles_target_drift_on_a_linked_config_edit() {
     let _ = fs::remove_dir_all(&linked);
 }
 
+/// #679 review: a supplied linked `.gitignore` edit routes to the WHOLE-delta overlay pass, so an
+/// ignore-rule change is reconciled immediately — a base file the branch now ignores is tombstoned
+/// in the overlay. The path-scoped route alone would no-op on `.gitignore` (not a source target)
+/// and leave the flipped files stale until a later sweep.
+#[test]
+fn reindex_paths_reconciles_an_ignore_flip_on_a_linked_gitignore_edit() {
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(main.join("src/a.rs"), "pub fn a_base() {}\n").unwrap();
+    fs::write(main.join("src/gen.rs"), "pub fn gen_base() {}\n").unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let config = source_config(main.clone(), Language::Rust);
+    let _ = IndexDatabase::rebuild(&config).unwrap();
+
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    // The branch adds a `.gitignore` that now ignores the base-indexed gen.rs.
+    fs::write(linked.join(".gitignore"), "gen.rs\n").unwrap();
+
+    crate::watch::reindex_paths(&config, &[linked.join(".gitignore")], |_| {}).unwrap();
+
+    assert!(
+        deleted_overlay_rows(&config, "src/gen.rs") >= 1,
+        "a base file the branch newly ignores is tombstoned in the overlay (#679 review)",
+    );
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}
+
 #[test]
 fn index_paths_rejects_a_path_that_escapes_the_repo_root() {
     let root = unique_temp_root();

--- a/crates/rag-rat-core/src/index/worktree_overlay.rs
+++ b/crates/rag-rat-core/src/index/worktree_overlay.rs
@@ -523,22 +523,7 @@ impl IndexDatabase {
             // worktree writes nothing (idle-safety, like the readable sha-skip).
             let mut tombstoned = 0;
             for path in &delta.tombstones {
-                let exists: bool = self.storage.connection().query_row(
-                    // Direct `main.files` probe → explicit `repo_id` (A3) + `generation` (A6)
-                    // predicates: only a tombstone at THIS connection's live generation suppresses
-                    // the write — a superseded generation's copy does not hide the path.
-                    "SELECT EXISTS(SELECT 1 FROM main.files WHERE repo_id = ?1 AND path = ?2 AND \
-                     commit_sha = '' AND worktree_id = ?3 AND kind = 'deleted' AND generation = \
-                     ?4)",
-                    params![
-                        self.active_repo_id,
-                        path_string(path),
-                        worktree_id,
-                        self.active_generation
-                    ],
-                    |row| row.get(0),
-                )?;
-                if !exists {
+                if !self.overlay_tombstone_exists(path, &worktree_id)? {
                     self.write_tombstone_in_scope(path, &worktree_id)?;
                     tombstoned += 1;
                 }
@@ -581,6 +566,213 @@ impl IndexDatabase {
             pruned,
             status_complete: delta.status_complete,
         })
+    }
+
+    /// Index EXACTLY the supplied `paths` of a linked worktree as overlay rows — the PATH-SCOPED
+    /// twin of [`Self::index_worktree_overlay`] (#679), so a linked-worktree `index --paths`
+    /// (the edit hook) refreshes just those paths' overlay rows instead of the checkout's WHOLE
+    /// base↔branch delta. Mirrors the base `IndexMode::Paths` exact-path semantics on the
+    /// linked route: a single-file edit no longer pulls in unrelated in-flight changes
+    /// elsewhere in the same worktree, and pays no full tree-diff / status walk.
+    ///
+    /// Each supplied path is categorized against the LINKED checkout + branch config: present +
+    /// target-matching → readable (indexed with the branch identity; the identity-skip in
+    /// [`Self::index_explicit_paths_from_root`] keeps an unchanged file write-free); absent, OR
+    /// present but no longer targeted by the branch config, while the BASE scope still has a live
+    /// row → tombstone (shadow that base row); nothing to shadow otherwise.
+    ///
+    /// Does NOT prune (a partial path set is not authoritative over the whole overlay — pruning
+    /// would delete valid rows for the paths it didn't inspect) and reports `status_complete =
+    /// false`, so the caller ([`crate::watch::reindex_paths`]) clears the overlay basis and the
+    /// next full sweep reconciles anything else in the worktree. The supplied-manifest
+    /// package-map refresh stays the caller's job (via `refresh_worktree_overlay_packages`),
+    /// exactly as on the whole-delta route. No-op (empty `worktree_id`) when `linked_path` is
+    /// not a valid linked sibling. Leaves the connection scoped to the overlay.
+    pub fn index_worktree_overlay_paths<F>(
+        &mut self,
+        config: &Config,
+        linked_path: &Path,
+        paths: &[PathBuf],
+        progress: &mut F,
+    ) -> anyhow::Result<WorktreeOverlayReport>
+    where
+        F: FnMut(IndexProgress),
+    {
+        let Some((base_sha, worktree_id, source_root)) =
+            resolve_overlay_scope(config, linked_path)?
+        else {
+            return Ok(WorktreeOverlayReport::default());
+        };
+        self.set_context(&base_sha, &worktree_id)?;
+        // Classify each supplied path with the SAME symlink-safe, ignore-aware guards the base
+        // `IndexMode::Paths` walker applies (#659), since a supplied path may be arbitrary (a
+        // crafted `..`-escape, a symlink-crossing spelling, or an ignored file) — reuse the
+        // shared primitives (`lexically_normalized_within_root` / `resolves_within_root` /
+        // `path_crosses_symlink`) rather than a naive `is_file()`, so this route can't
+        // drift from the base one. `ignore` is the LINKED checkout's matcher (a branch
+        // `.gitignore` governs the overlay's indexable set), recompiled per call so a
+        // branch ignore edit takes effect immediately.
+        let canonical_source = source_root.canonicalize().unwrap_or_else(|_| source_root.clone());
+        let ignore =
+            ignore_rules::IgnoreMatcher::compile(&source_root, &config.target_directories());
+        // Present + indexable = a regular, in-root, non-symlink-crossed, NON-ignored file the
+        // branch config targets — the base walker's exact set. A closure so the same check
+        // RE-VALIDATES a removal inside the transaction (below), where the write lock is
+        // held.
+        let is_present_indexable = |rel: &Path, full: &Path| {
+            resolves_within_root(full, &canonical_source)
+                && !path_crosses_symlink(&source_root, rel)
+                && full.is_file()
+                && !ignore.is_ignored(full, false)
+                && target_for_path(config, rel).is_some()
+        };
+        let mut readable = Vec::new();
+        let mut tombstones = Vec::new();
+        let mut removal_candidates = Vec::new();
+        for path in paths {
+            // Rebase to the config-root-relative key (the spelling every overlay row + target match
+            // uses), retrying against the CANONICAL source root for a symlinked spelling; then
+            // reject a `..`-escape. A path not under the source root is dropped
+            // (defensive).
+            let raw = match path.strip_prefix(&source_root) {
+                Ok(rel) => rel.to_path_buf(),
+                Err(_) => {
+                    let Some(rel) = canonicalize_nearest_ancestor(path).and_then(|canonical| {
+                        canonical.strip_prefix(&canonical_source).ok().map(Path::to_path_buf)
+                    }) else {
+                        continue;
+                    };
+                    rel
+                },
+            };
+            let Some(rel) = lexically_normalized_within_root(&raw) else { continue };
+            let full = source_root.join(&rel);
+            if is_present_indexable(&rel, &full) {
+                readable.push(rel);
+            } else if self.base_scope_has_path(&base_sha, &rel)? {
+                // Non-indexable (delete / ignored-now / de-targeted / symlink-replaced) but the
+                // base still has a row → shadow it with a tombstone (mirrors the whole-delta
+                // overlay). Carry `full` so the write RE-VALIDATES under the write lock, like
+                // removals.
+                tombstones.push((rel, full));
+            } else {
+                // Non-indexable AND no base row to shadow: a BRANCH-ONLY file. If it was overlay-
+                // indexed, its stale row must be REMOVED (the whole-delta prune does this; a
+                // path-scoped pass skips the prune). Deferred to the transaction, where existence +
+                // non-indexability are RE-VALIDATED under the write lock (#679 review).
+                removal_candidates.push((rel, full));
+            }
+        }
+        let scope = FileScope::worktree(worktree_id.clone());
+        // ONE transaction (see `index_worktree_overlay` for the rationale): index the readable set,
+        // write tombstones, then the gated logical-symbol/edge/FTS refresh. BEGIN IMMEDIATE up
+        // front; ROLLBACK on any error.
+        self.storage.execute_batch("BEGIN IMMEDIATE")?;
+        let result = (|| -> anyhow::Result<(usize, usize, usize)> {
+            let indexed = self.index_explicit_paths_from_root(
+                config,
+                &source_root,
+                &readable,
+                &scope,
+                progress,
+            )?;
+            let mut tombstoned = 0;
+            for (rel, full) in &tombstones {
+                // RE-VALIDATE under the write lock (like removals): if the file was recreated /
+                // became indexable after classification, do NOT write a tombstone that would hide
+                // the now-valid content — `BEGIN IMMEDIATE` freezes DB writers, not
+                // the filesystem. The next full sweep reconciles the recreated file
+                // (#679 review).
+                if !is_present_indexable(rel, full)
+                    && !self.overlay_tombstone_exists(rel, &worktree_id)?
+                {
+                    self.write_tombstone_in_scope(rel, &worktree_id)?;
+                    tombstoned += 1;
+                }
+            }
+            // Targeted removal of stale branch-only overlay rows — the per-path equivalent of the
+            // whole-delta prune this scoped pass skips. RE-VALIDATED here under the write lock
+            // (BEGIN IMMEDIATE froze other writers): only remove a still-non-indexable path whose
+            // overlay row still exists, so a concurrent heal that re-indexed the path (it
+            // reappeared) between classification and now can't have its fresh row
+            // deleted (#679 review).
+            let mut pruned = 0;
+            for (rel, full) in &removal_candidates {
+                if !is_present_indexable(rel, full)
+                    && self.overlay_source_row_exists(rel, &worktree_id)?
+                {
+                    self.remove_file_in_scope(rel, "", &worktree_id)?;
+                    pruned += 1;
+                }
+            }
+            // No global prune: a partial path set is not authoritative over the whole overlay. The
+            // supplied-manifest package refresh is the caller's job, so `manifest_changed = false`.
+            self.finalize_overlay_refresh(
+                &source_root,
+                &worktree_id,
+                indexed,
+                tombstoned,
+                pruned,
+                false,
+            )?;
+            Ok((indexed, tombstoned, pruned))
+        })();
+        let (indexed, tombstoned, pruned) = match result {
+            Ok(counts) => {
+                self.storage.execute_batch("COMMIT")?;
+                counts
+            },
+            Err(err) => {
+                let _ = self.storage.execute_batch("ROLLBACK");
+                return Err(err);
+            },
+        };
+        Ok(WorktreeOverlayReport {
+            worktree_id,
+            indexed,
+            tombstoned,
+            pruned,
+            // A path-scoped pass never fully reconciles the overlay — signal incomplete so the
+            // caller clears the basis and the next full sweep reconciles the rest
+            // (#679).
+            status_complete: false,
+        })
+    }
+
+    /// Whether a live (non-deleted) OVERLAY source row for `path` exists in `worktree_id`'s scope —
+    /// the gate for removing a now-non-indexable BRANCH-ONLY overlay row that has no base row to
+    /// shadow (#679). Distinct from [`Self::base_scope_has_path`] (which probes the base scope).
+    fn overlay_source_row_exists(&self, path: &Path, worktree_id: &str) -> anyhow::Result<bool> {
+        Ok(self.storage.connection().query_row(
+            "SELECT EXISTS(SELECT 1 FROM main.files WHERE repo_id = ?1 AND path = ?2 AND \
+             commit_sha = '' AND worktree_id = ?3 AND kind != 'deleted' AND generation = ?4)",
+            params![self.active_repo_id, path_string(path), worktree_id, self.active_generation],
+            |row| row.get(0),
+        )?)
+    }
+
+    /// Whether a live-generation tombstone for `path` already exists in `worktree_id`'s overlay
+    /// scope — the idle-safe guard before writing one, so a re-run on a static worktree writes
+    /// nothing. A direct `main.files` probe with explicit `repo_id` (A3) + `generation` (A6)
+    /// predicates: only a tombstone at THIS connection's live generation suppresses the write.
+    fn overlay_tombstone_exists(&self, path: &Path, worktree_id: &str) -> anyhow::Result<bool> {
+        Ok(self.storage.connection().query_row(
+            "SELECT EXISTS(SELECT 1 FROM main.files WHERE repo_id = ?1 AND path = ?2 AND \
+             commit_sha = '' AND worktree_id = ?3 AND kind = 'deleted' AND generation = ?4)",
+            params![self.active_repo_id, path_string(path), worktree_id, self.active_generation],
+            |row| row.get(0),
+        )?)
+    }
+
+    /// Whether the BASE scope has a live (non-deleted) row for `path` at `base_sha` — the gate for
+    /// shadowing a base row with an overlay tombstone (there is nothing to shadow otherwise).
+    fn base_scope_has_path(&self, base_sha: &str, path: &Path) -> anyhow::Result<bool> {
+        Ok(self.storage.connection().query_row(
+            "SELECT EXISTS(SELECT 1 FROM main.files WHERE repo_id = ?1 AND path = ?2 AND \
+             commit_sha = ?3 AND worktree_id = '' AND kind != 'deleted' AND generation = ?4)",
+            params![self.active_repo_id, path_string(path), base_sha, self.active_generation],
+            |row| row.get(0),
+        )?)
     }
 
     /// Refresh JUST the linked overlay's package/import scope (and re-resolve its edges against the

--- a/crates/rag-rat-core/src/watch/overlay.rs
+++ b/crates/rag-rat-core/src/watch/overlay.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 use std::time::Instant;
 
@@ -304,22 +304,41 @@ where
     let lock_repo = rag_rat_base::locks::write_lock_repo_id(config);
     let _lock = rag_rat_base::locks::WriteLock::acquire_blocking(&config.database, &lock_repo)?;
 
-    let WorktreePartition { base_paths, linked_roots, manifest_roots } =
+    let WorktreePartition { base_paths, linked, manifest_roots } =
         partition_paths_by_worktree(config, paths);
     // Always run the base pass: it opens the db (returned for status + the overlay refresh) and
     // enforces #427. With no base paths it is a no-op scoped pass over an empty change set.
     let mut db = IndexDatabase::index_paths_with_progress(config, &base_paths, &mut progress)?;
-    for checkout in &linked_roots {
-        // Index each touched checkout's overlay with the LINKED branch's OWN targets (a branch that
-        // adds/narrows targets must be indexed by its own config). `?` PROPAGATES a failure — the
-        // caller (an edit hook) must be able to tell the reindex did not land and retry.
+    for (checkout, checkout_paths) in &linked {
+        // Index EXACTLY the supplied paths of each touched checkout's overlay (#679), with the
+        // LINKED branch's OWN targets (a branch that adds/narrows targets must be indexed
+        // by its own config). Path-scoped, not the whole base↔branch delta: a single-file
+        // linked edit no longer pulls in unrelated in-flight changes in the same worktree —
+        // the base `Paths` exact-path semantics on the linked route. `?` PROPAGATES a
+        // failure — the caller (an edit hook) must be able to tell the reindex did not land
+        // and retry.
+        //
+        // EXCEPT a branch `rag-rat.toml` edit: a config change can re-language / add / drop targets
+        // across the WHOLE overlay (not just the supplied file, which is not itself a source
+        // target), so it is inherently NOT path-scopable — run the whole-delta pass, which includes
+        // the target-fingerprint-gated `overlay_target_config_reconcile` (#679 review). Config
+        // edits are rare, so paying the full tree-diff there is fine.
         let overlay_config = config.for_linked_worktree_overlay(checkout);
-        let report = db.index_worktree_overlay(&overlay_config, checkout, &mut progress)?;
-        // A PARTIAL status read (`status_complete = false`) may have missed the supplied
-        // uncommitted edit, yet returns Ok — so, like the watcher, CLEAR this worktree's overlay
-        // basis so a later scoped pass re-refreshes it instead of skipping on a still-matching
-        // basis. Otherwise `index --paths` would report success while leaving the branch stale
-        // (#659 review).
+        let touches_config = checkout_paths.iter().any(|path| is_config_path(path));
+        let report = if touches_config {
+            db.index_worktree_overlay(&overlay_config, checkout, &mut progress)?
+        } else {
+            db.index_worktree_overlay_paths(
+                &overlay_config,
+                checkout,
+                checkout_paths,
+                &mut progress,
+            )?
+        };
+        // A path-scoped pass is never a complete overlay refresh (`status_complete = false`), so —
+        // like the watcher on a partial read — CLEAR this worktree's overlay basis so the next full
+        // sweep re-refreshes anything else in the branch instead of skipping on a still-matching
+        // basis (#659/#679).
         if !report.status_complete && !report.worktree_id.is_empty() {
             let _ = db.clear_worktree_overlay_basis(&report.worktree_id);
         }
@@ -331,22 +350,37 @@ where
             db.refresh_worktree_overlay_packages(&overlay_config, checkout)?;
         }
     }
-    // `index_worktree_overlay` / the manifest refresh leave the connection scoped to the LAST
-    // overlay; restore the base scope so the returned db reads base-scoped status.
-    if !linked_roots.is_empty() {
+    // The overlay passes / the manifest refresh leave the connection scoped to the LAST overlay;
+    // restore the base scope so the returned db reads base-scoped status.
+    if !linked.is_empty() {
         let (base_sha, base_id) = crate::index::resolve_git_context(&config.root);
         db.set_context(&base_sha, &base_id)?;
     }
     Ok(db)
 }
 
+/// Whether `path` is a package manifest (`Cargo.toml`) — a file the scoped reindex refreshes the
+/// package map for (see [`reindex_paths`]'s manifest handling), but that the file watcher's event
+/// filter (configured targets + `.gitignore`) never fires on. The PostToolUse edit hook uses this
+/// to still reindex a manifest edit when a watcher is live — the watcher would silently miss it.
+pub fn is_manifest_path(path: &Path) -> bool {
+    path.file_name() == Some(std::ffi::OsStr::new("Cargo.toml"))
+}
+
+/// Whether `path` is a `rag-rat.toml` config file. A branch config edit can re-language / add /
+/// drop targets across the whole overlay, so `reindex_paths` routes it to the WHOLE-delta overlay
+/// pass (which runs the target-drift reconcile) rather than the path-scoped one (#679).
+fn is_config_path(path: &Path) -> bool {
+    path.file_name() == Some(std::ffi::OsStr::new("rag-rat.toml"))
+}
+
 /// Candidate paths split by which checkout owns them (see [`partition_paths_by_worktree`]).
 pub(crate) struct WorktreePartition {
     /// Paths under the base checkout (and non-git trees) — the scoped base pass reconciles these.
     pub(crate) base_paths: Vec<PathBuf>,
-    /// Live linked-worktree checkout roots any supplied path lives under — each gets an overlay
-    /// pass.
-    pub(crate) linked_roots: BTreeSet<PathBuf>,
+    /// Live linked-worktree checkout root → the supplied paths under it. Each root gets a
+    /// PATH-SCOPED overlay pass over exactly its paths (#679), not the whole checkout delta.
+    pub(crate) linked: BTreeMap<PathBuf, Vec<PathBuf>>,
     /// Linked checkout roots that had a supplied `Cargo.toml`. Their overlay package map must be
     /// refreshed even for a CLEAN/committed manifest — the overlay's own signal is status-derived
     /// (dirty-only), so this carries the base flow's supplied-manifest signal to the linked route.
@@ -358,14 +392,7 @@ pub(crate) struct WorktreePartition {
 /// non-git trees and paths already under the base checkout — is a base path. The linked roots are
 /// the [`crate::index::live_worktree_contexts`] spellings (canonicalized, base excluded), so the
 /// base pass and the overlay refresh key on the exact same identities the rest of the engine uses.
-/// Whether `path` is a package manifest (`Cargo.toml`) — a file the scoped reindex refreshes the
-/// package map for (see [`reindex_paths`]'s manifest handling), but that the file watcher's event
-/// filter (configured targets + `.gitignore`) never fires on. The PostToolUse edit hook uses this
-/// to still reindex a manifest edit when a watcher is live — the watcher would silently miss it.
-pub fn is_manifest_path(path: &Path) -> bool {
-    path.file_name() == Some(std::ffi::OsStr::new("Cargo.toml"))
-}
-
+/// Each linked path is bucketed under its root so the overlay pass reconciles exactly those paths.
 pub(crate) fn partition_paths_by_worktree(config: &Config, paths: &[PathBuf]) -> WorktreePartition {
     let (_, worktrees) = crate::index::live_worktree_contexts(&config.root);
     let base = enclosing_worktree_id(&config.root);
@@ -373,7 +400,7 @@ pub(crate) fn partition_paths_by_worktree(config: &Config, paths: &[PathBuf]) ->
         worktrees.into_iter().filter(|w| *w != base).map(PathBuf::from).collect();
     let mut partition = WorktreePartition {
         base_paths: Vec::new(),
-        linked_roots: BTreeSet::new(),
+        linked: BTreeMap::new(),
         manifest_roots: BTreeSet::new(),
     };
     for path in paths {
@@ -382,7 +409,7 @@ pub(crate) fn partition_paths_by_worktree(config: &Config, paths: &[PathBuf]) ->
                 if is_manifest_path(path) {
                     partition.manifest_roots.insert(root.clone());
                 }
-                partition.linked_roots.insert(root);
+                partition.linked.entry(root).or_default().push(path.clone());
             },
             None => partition.base_paths.push(path.clone()),
         }

--- a/crates/rag-rat-core/src/watch/overlay.rs
+++ b/crates/rag-rat-core/src/watch/overlay.rs
@@ -318,14 +318,19 @@ where
         // failure — the caller (an edit hook) must be able to tell the reindex did not land
         // and retry.
         //
-        // EXCEPT a branch `rag-rat.toml` edit: a config change can re-language / add / drop targets
-        // across the WHOLE overlay (not just the supplied file, which is not itself a source
-        // target), so it is inherently NOT path-scopable — run the whole-delta pass, which includes
-        // the target-fingerprint-gated `overlay_target_config_reconcile` (#679 review). Config
+        // EXCEPT a branch `rag-rat.toml` or `.gitignore` edit: both change the indexable set across
+        // the WHOLE overlay — a config edit re-languages / adds / drops targets; a `.gitignore`
+        // edit flips OTHER files' ignore status — and neither is itself a source target, so
+        // the path-scoped route would no-op on them and leave the drift for a later sweep.
+        // Run the whole-delta pass, which reconciles both
+        // (`overlay_target_config_reconcile` for target
+        // drift, `expand_candidates_for_ignore_only_flips` for ignore flips) (#679 review). Such
         // edits are rare, so paying the full tree-diff there is fine.
         let overlay_config = config.for_linked_worktree_overlay(checkout);
-        let touches_config = checkout_paths.iter().any(|path| is_config_path(path));
-        let report = if touches_config {
+        let overlay_wide_edit = checkout_paths
+            .iter()
+            .any(|path| is_config_path(path) || super::placement::is_gitignore_path(path));
+        let report = if overlay_wide_edit {
             db.index_worktree_overlay(&overlay_config, checkout, &mut progress)?
         } else {
             db.index_worktree_overlay_paths(


### PR DESCRIPTION
## What

`reindex_paths` (#659) routed a linked-worktree edit through
`index_worktree_overlay`, which reindexes that checkout's **whole** base↔branch
delta — so a single-file edit also pulled in any *other* in-flight change in the
same worktree, which matters for the edit-hook use (#661). This gives the
overlay route the same exact-path scoping the base `IndexMode::Paths` pass has:
a new `index_worktree_overlay_paths` reconciles exactly the supplied paths'
overlay rows.

## Classification (mirrors the base walker, shared guards)

Each supplied path is classified with the **same** symlink-safe, ignore-aware
guards the base `IndexMode::Paths` walker uses. The
`lexically_normalized_within_root` / `resolves_within_root` /
`path_crosses_symlink` primitives are **extracted and shared** so the two routes
can't drift, plus the linked checkout's own `IgnoreMatcher`:

- present + target-matching → **readable** (indexed with the branch identity);
- deleted / ignored-now / de-targeted / symlink-replaced while a base row exists
  → **tombstone** (shadow the base row);
- a branch-only file gone non-indexable → its **stale overlay row is removed**
  (the per-path equivalent of the whole-delta prune this pass skips).

Removals and tombstones are **re-validated inside the write transaction**, so a
concurrent writer that re-indexed a path between classification and the txn
can't have its fresh row deleted or hidden (`BEGIN IMMEDIATE` freezes DB
writers, not the filesystem).

## Basis + config edits

The pass reports `status_complete = false`, so `reindex_paths` clears the overlay
basis and the next full sweep reconciles anything else in the branch.

**Except** a branch `rag-rat.toml` edit: a config change can re-language / add /
drop targets across the whole overlay, so it is not path-scopable — it routes to
the whole-delta pass (which runs the target-fingerprint-gated drift reconcile),
as before.

## Tests

New end-to-end `reindex_paths` tests: a linked edit scopes to just the supplied
path (b.rs not pulled in); a deleted supplied path tombstones only itself; an
ignored / symlink-crossing supplied path is not indexed; a stale branch-only
overlay row is removed; a `rag-rat.toml` edit reconciles target drift via the
whole-delta route. Existing base-flow symlink/escape tests still pass (the
extracted `path_crosses_symlink` is behavior-preserving).

Full workspace suite green (3090 tests); four CI clippy gates clean
(`-D warnings`); nightly rustfmt clean.

Fixes #679
