### PR TITLE
feat(oplog): owner-gated secrets-log acceptance evaluator + StreamKeyWrap op

### DIFF
--- a/crates/rag-rat-oplog/src/account/authoring.rs
+++ b/crates/rag-rat-oplog/src/account/authoring.rs
@@ -246,11 +246,13 @@ mod tests {
         conn
     }
 
-    /// Count the account's `StreamOwn` candidate rows — the idempotency witness.
+    /// Count the account's `StreamOwn` candidate rows — the idempotency witness. Gated on
+    /// `log_id == CONTROL_LOG` (S-f): a fresh-numbered secrets tag colliding with the 6 number must
+    /// not inflate this witness.
     fn stream_own_count(conn: &Connection) -> i64 {
         conn.query_row(
-            "SELECT COUNT(*) FROM account_entries WHERE entry_type = ?1",
-            params![ops::entry_type::STREAM_OWN],
+            "SELECT COUNT(*) FROM account_entries WHERE entry_type = ?1 AND log_id = ?2",
+            params![ops::entry_type::STREAM_OWN, crate::account::fold::CONTROL_LOG],
             |row| row.get(0),
         )
         .unwrap()

--- a/crates/rag-rat-oplog/src/account/bootstrap.rs
+++ b/crates/rag-rat-oplog/src/account/bootstrap.rs
@@ -277,9 +277,11 @@ mod tests {
     }
 
     fn genesis_row_count(conn: &Connection) -> i64 {
+        // Gated on `log_id == CONTROL_LOG` (S-f): a fresh-numbered secrets tag colliding with the 0
+        // number must not inflate this witness.
         conn.query_row(
-            "SELECT COUNT(*) FROM account_entries WHERE entry_type = ?1",
-            params![ops::entry_type::ACCOUNT_GENESIS],
+            "SELECT COUNT(*) FROM account_entries WHERE entry_type = ?1 AND log_id = ?2",
+            params![ops::entry_type::ACCOUNT_GENESIS, crate::account::fold::CONTROL_LOG],
             |row| row.get(0),
         )
         .unwrap()

--- a/crates/rag-rat-oplog/src/account/mod.rs
+++ b/crates/rag-rat-oplog/src/account/mod.rs
@@ -30,6 +30,9 @@ mod keywrap;
 mod limits;
 mod ops;
 mod registers;
+// C4.2b: the account secrets log (`log_id = 1`) — the `StreamKeyWrap` op + owner-gated acceptance
+// evaluator, consuming the control fold's authority projection (#607).
+mod secrets;
 mod storage;
 
 // The in-tx `/2`-ownership ensure seam + the two read-only `/2`-stream resolvers (C3.4b-ii, #676):

--- a/crates/rag-rat-oplog/src/account/secrets/acceptance.rs
+++ b/crates/rag-rat-oplog/src/account/secrets/acceptance.rs
@@ -1,0 +1,613 @@
+//! Pure secrets-log (`log_id = 1`) acceptance predicate for `StreamKeyWrap` (§15, C4.2b).
+//!
+//! The mirror of the `/3` content predicate ([`super::super::content::acceptance`]), reduced to the
+//! secrets authority model: a wrap is authorized only by a **live owner incarnation of the stream's
+//! owning account** (the owner-only gate, B3), cited in the header's `authority_ref`, with the
+//! account's own `StreamOwn{stream}` effective first. There is a SINGLE account here — the owning
+//! account — so ONE freshness axis, not the content predicate's owner+author pair.
+//!
+//! Every authority fact is resolved against the CURRENT fold (§7) in ONE snapshot, so a refold
+//! committing mid-evaluation cannot pair an old incarnation with a new cut. Freshness is applied
+//! LAST (a separate axis), with its one reach backward being the citation-invalidity gate: an
+//! incarnation our fold reads as ineffective is fold-dependent (a `CutExtend` we have not folded
+//! re-blesses it, §11.4), so while we are behind the author that parks rather than hardening into a
+//! rejection.
+
+use super::super::{
+    AccountId, AuthorityBoundary, AuthorityFreshness, AuthorityInvalidReason, AuthorityQuery,
+    OwnerChainAuthority,
+};
+
+type EntryHash = [u8; 32];
+
+/// Why an ancestry walk against a cut watermark could not be decided (mirrors the account fold's
+/// `UnknownCause`: a withheld watermark parks, and never flips a verdict — I11).
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(in crate::account) enum UnknownAncestry {
+    /// The cut's watermark entry itself is not held.
+    UnknownCutTarget,
+    /// A link on the walk from the watermark toward the entry is missing.
+    IncompleteCutAncestry,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(in crate::account) enum AncestryRelation {
+    OnBranch,
+    OffBranch,
+    Unknown(UnknownAncestry),
+}
+
+/// One freshness observation, bound to the exact query it answers. The pair (account, asserted
+/// length) is carried so a result computed for another account, or for a shorter assertion than the
+/// header makes, decides nothing about THIS entry.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(in crate::account) struct CitedFreshness {
+    pub(in crate::account) account_id: AccountId,
+    pub(in crate::account) asserted_auth_len: u64,
+    pub(in crate::account) state: AuthorityFreshness,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(in crate::account) enum SecretsParkReason {
+    MissingPredecessor,
+    /// The cited owner incarnation is not held yet.
+    UnknownOwnerRef,
+    /// The account's `StreamOwn{stream}` fact is not folded yet — the owner-only gate cannot
+    /// resolve.
+    UnknownStreamOwner,
+    AuthLenAhead,
+    IncompleteCutAncestry,
+    UnknownCutTarget,
+    ContestedSubject,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(in crate::account) enum SecretsCondemnReason {
+    BeyondCut,
+    OffBranch,
+    ClosedIncarnation,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(in crate::account) enum SecretsRejectReason {
+    /// The `authority_ref` is null, names a different-subject entry, or an incarnation our fold
+    /// reads as ineffective while we are level with the author (the owner-only gate, B3).
+    OwnerReferenceInvalid,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(in crate::account) enum SecretsAcceptanceInputError {
+    FreshnessProvenance,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(in crate::account) enum SecretsAcceptance {
+    Accepted,
+    Forked,
+    Parked(SecretsParkReason),
+    Condemned(SecretsCondemnReason),
+    Rejected(SecretsRejectReason),
+}
+
+impl SecretsAcceptance {
+    /// The persisted `(status, detail)` PAIR (§16.3) — account rows store status + detail columns,
+    /// NOT the content predicate's combined `status{detail}` strings (S-b).
+    pub(in crate::account) fn as_db_pair(self) -> (&'static str, Option<&'static str>) {
+        match self {
+            Self::Accepted => ("accepted", None),
+            Self::Forked => ("forked", None),
+            Self::Parked(SecretsParkReason::MissingPredecessor) =>
+                ("parked", Some("missing_predecessor")),
+            Self::Parked(SecretsParkReason::UnknownOwnerRef) =>
+                ("parked", Some("unknown_owner_ref")),
+            Self::Parked(SecretsParkReason::UnknownStreamOwner) =>
+                ("parked", Some("unknown_account")),
+            Self::Parked(SecretsParkReason::AuthLenAhead) => ("parked", Some("auth_len_ahead")),
+            Self::Parked(SecretsParkReason::IncompleteCutAncestry) =>
+                ("parked", Some("incomplete_cut_ancestry")),
+            Self::Parked(SecretsParkReason::UnknownCutTarget) =>
+                ("parked", Some("unknown_cut_target")),
+            Self::Parked(SecretsParkReason::ContestedSubject) =>
+                ("parked", Some("contested_subject")),
+            Self::Condemned(SecretsCondemnReason::BeyondCut) => ("condemned", Some("beyond_cut")),
+            Self::Condemned(SecretsCondemnReason::OffBranch) => ("condemned", Some("off_branch")),
+            Self::Condemned(SecretsCondemnReason::ClosedIncarnation) =>
+                ("condemned", Some("closed_incarnation")),
+            Self::Rejected(SecretsRejectReason::OwnerReferenceInvalid) =>
+                ("rejected", Some("invalid_owner")),
+        }
+    }
+}
+
+/// The resolved facts for one evaluable `StreamKeyWrap`, all read from ONE fold snapshot.
+#[derive(Clone)]
+pub(in crate::account) struct SecretsAcceptanceInput<F>
+where
+    F: Fn(EntryHash, EntryHash) -> AncestryRelation,
+{
+    /// The owning account — the account whose secrets log carries this wrap.
+    pub(in crate::account) account_id: AccountId,
+    pub(in crate::account) entry_hash: EntryHash,
+    pub(in crate::account) seq: u64,
+    /// The header's `authority_ref` — the cited owner incarnation id (null ⇒ reject).
+    pub(in crate::account) authority_ref: Option<EntryHash>,
+    /// The cited owner incarnation resolved via `owner_secrets_authority` (the two secrets
+    /// boundaries).
+    pub(in crate::account) owner_authority: AuthorityQuery<OwnerChainAuthority>,
+    /// The account's ownership of the wrap's stream (`stream_owner_effective`).
+    pub(in crate::account) ownership: AuthorityQuery<EntryHash>,
+    /// The header's asserted control-fold length (`auth_len`) — the value `freshness` must have
+    /// been computed against (provenance).
+    pub(in crate::account) asserted_auth_len: u64,
+    pub(in crate::account) dense_predecessor_reachable: bool,
+    pub(in crate::account) branch_selected: bool,
+    pub(in crate::account) freshness: CitedFreshness,
+    pub(in crate::account) contested: bool,
+    pub(in crate::account) ancestry: F,
+}
+
+/// The full predicate: authority + registers, then the dense predecessor, then branch selection,
+/// then freshness LAST (§13/§15).
+pub(in crate::account) fn evaluate_secrets_acceptance<F>(
+    input: &SecretsAcceptanceInput<F>,
+) -> Result<SecretsAcceptance, SecretsAcceptanceInputError>
+where
+    F: Fn(EntryHash, EntryHash) -> AncestryRelation,
+{
+    if let Some(verdict) = authority_verdict(input)? {
+        return Ok(verdict);
+    }
+    if !input.dense_predecessor_reachable {
+        return Ok(SecretsAcceptance::Parked(SecretsParkReason::MissingPredecessor));
+    }
+    if !input.branch_selected {
+        return Ok(SecretsAcceptance::Forked);
+    }
+    // Freshness last (§13): a wrap citing control ops we have not folded parks for refetch, but
+    // only once every verdict the current fold CAN decide — condemnation, fork — has been ruled
+    // out.
+    if input.freshness.state == AuthorityFreshness::Ahead {
+        return Ok(SecretsAcceptance::Parked(SecretsParkReason::AuthLenAhead));
+    }
+    Ok(SecretsAcceptance::Accepted)
+}
+
+/// Everything §15 decides BEFORE the secrets DAG has a say: the owner-only citation, the account's
+/// stream ownership, the two secrets-boundary registers, and the contested hold. `None` means the
+/// wrap is authorized — it is then eligible to contest a slot in branch selection, and the caller
+/// finishes the verdict with [`evaluate_secrets_acceptance`].
+///
+/// This is the phase split the refold needs: a wrap that is condemned or rejected must NOT compete
+/// for its dense seq slot (a small-hash wrap mined beyond a cut would otherwise fork an honest
+/// sibling off the accepted branch), so eligibility is decided before selection runs — and
+/// selection's output is itself an input to the full predicate.
+pub(in crate::account) fn authority_verdict<F>(
+    input: &SecretsAcceptanceInput<F>,
+) -> Result<Option<SecretsAcceptance>, SecretsAcceptanceInputError>
+where
+    F: Fn(EntryHash, EntryHash) -> AncestryRelation,
+{
+    // Provenance first: a freshness verdict computed for another account, or against a different
+    // asserted length than this header makes, decides nothing about THIS entry. Both components are
+    // enforced (mirrors the content predicate) so a future refactor cannot silently pair the wrong
+    // freshness — even though today's single account keeps them equal.
+    if input.freshness.account_id != input.account_id
+        || input.freshness.asserted_auth_len != input.asserted_auth_len
+    {
+        return Err(SecretsAcceptanceInputError::FreshnessProvenance);
+    }
+    let freshness = input.freshness.state;
+    let rejected = |reason| Ok(Some(SecretsAcceptance::Rejected(reason)));
+    let parked = |reason| Ok(Some(SecretsAcceptance::Parked(reason)));
+
+    // A wrap with no owner citation can never be authorized (the owner-only gate, B3 / freeze #3):
+    // decided by bytes we hold, so it rejects outright regardless of freshness.
+    if input.authority_ref.is_none() {
+        return rejected(SecretsRejectReason::OwnerReferenceInvalid);
+    }
+
+    // The owner-only gate: the wrap is admitted only under a live owner incarnation of the OWNING
+    // account, and the incarnation's device is the wrap's signer (enforced by
+    // `owner_secrets_authority` resolving the queried device — a WrongSubject means the signer
+    // is not that owner). A writer-grant or member device therefore rejects here (B3).
+    let owner = match input.owner_authority {
+        AuthorityQuery::Effective(owner) => owner,
+        AuthorityQuery::Unknown => return parked(SecretsParkReason::UnknownOwnerRef),
+        AuthorityQuery::Invalid(reason) =>
+            return Ok(Some(invalid_owner_citation(reason, freshness))),
+    };
+
+    // The stream must be OWNED by this account (a prior effective `StreamOwn{stream}`), or the
+    // owner-only authorization has no basis. §14 makes the true owner unprovable-absent locally, so
+    // a not-yet-folded ownership fact PARKS (recoverable) — never a rejection.
+    match input.ownership {
+        AuthorityQuery::Effective(_) => {},
+        AuthorityQuery::Unknown => return parked(SecretsParkReason::UnknownStreamOwner),
+        // `stream_owner_effective` only ever answers Effective / Unknown; an Invalid is treated as
+        // an unresolved ownership (fail-closed park), never an acceptance.
+        AuthorityQuery::Invalid(_) => return parked(SecretsParkReason::UnknownStreamOwner),
+    }
+
+    // The two secrets boundaries (device register + owner-incarnation register) are the conjunction
+    // that bounds the wrap's own `(account, log:1, device)` chain. A definite condemnation outranks
+    // any park (an incomplete ancestry on one register can never mask a `beyond_cut` on the other).
+    let boundaries = [owner.device_boundary, owner.incarnation_boundary];
+    let boundary_decision =
+        combine_boundaries(&boundaries, input.seq, input.entry_hash, &input.ancestry);
+    if matches!(boundary_decision, Some(SecretsAcceptance::Condemned(_))) {
+        return Ok(boundary_decision);
+    }
+    // §12: a contested account halts authority mutation, so a wrap it authorizes fails closed
+    // (quota-bounded, reclassified on recovery). Checked after a definite condemnation but before a
+    // boundary that could not be decided.
+    if input.contested {
+        return parked(SecretsParkReason::ContestedSubject);
+    }
+    // A boundary that could not be decided (a withheld watermark, an incomplete walk) parks here,
+    // after the hold — it is the weakest verdict the registers can produce.
+    Ok(boundary_decision)
+}
+
+/// Lower an `Invalid` owner citation into a verdict. `WrongSubject` is decided by bytes we already
+/// hold (the incarnation names a different device than the signer), so it rejects outright;
+/// `ReferencedEntryNotEffective` is a verdict of OUR fold, and a fold behind the author's may be
+/// missing the `CutExtend` that re-blesses it (§11.4) — so while the account's control log is ahead
+/// of us it parks for refetch (S-a #3) rather than hardening into a rejection we would walk back.
+fn invalid_owner_citation(
+    reason: AuthorityInvalidReason,
+    freshness: AuthorityFreshness,
+) -> SecretsAcceptance {
+    match (reason, freshness) {
+        (AuthorityInvalidReason::WrongSubject, _)
+        | (
+            AuthorityInvalidReason::ReferencedEntryNotEffective,
+            AuthorityFreshness::CurrentOrBehind,
+        ) => SecretsAcceptance::Rejected(SecretsRejectReason::OwnerReferenceInvalid),
+        (AuthorityInvalidReason::ReferencedEntryNotEffective, AuthorityFreshness::Ahead) =>
+            SecretsAcceptance::Parked(SecretsParkReason::AuthLenAhead),
+    }
+}
+
+/// Combine the two secrets registers into one verdict with the account fold's frozen precedence: a
+/// definite condemnation outranks any park, so incomplete ancestry on one register can never mask a
+/// `beyond_cut` (which needs no ancestry at all) on the other; a withheld watermark outranks a
+/// missing mid-chain link; `Open`/on-branch is clear. (Ported from `content::acceptance`.)
+fn combine_boundaries<F>(
+    boundaries: &[AuthorityBoundary],
+    seq: u64,
+    entry_hash: EntryHash,
+    ancestry: &F,
+) -> Option<SecretsAcceptance>
+where
+    F: Fn(EntryHash, EntryHash) -> AncestryRelation,
+{
+    let rank = boundaries.iter().fold(0, |rank, boundary| {
+        let candidate = match *boundary {
+            AuthorityBoundary::Open => 0,
+            AuthorityBoundary::Closed => 5,
+            AuthorityBoundary::Cut { seq: cut_seq, .. } if seq > cut_seq => 3,
+            AuthorityBoundary::Cut { hash, .. } => match ancestry(entry_hash, hash) {
+                AncestryRelation::OnBranch => 0,
+                AncestryRelation::Unknown(UnknownAncestry::IncompleteCutAncestry) => 1,
+                AncestryRelation::Unknown(UnknownAncestry::UnknownCutTarget) => 2,
+                AncestryRelation::OffBranch => 4,
+            },
+        };
+        rank.max(candidate)
+    });
+    match rank {
+        0 => None,
+        1 => Some(SecretsAcceptance::Parked(SecretsParkReason::IncompleteCutAncestry)),
+        2 => Some(SecretsAcceptance::Parked(SecretsParkReason::UnknownCutTarget)),
+        3 => Some(SecretsAcceptance::Condemned(SecretsCondemnReason::BeyondCut)),
+        4 => Some(SecretsAcceptance::Condemned(SecretsCondemnReason::OffBranch)),
+        5 => Some(SecretsAcceptance::Condemned(SecretsCondemnReason::ClosedIncarnation)),
+        _ => unreachable!("boundary ranks are closed"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ENTRY_HASH: EntryHash = [9; 32];
+    const OWNER_ID: EntryHash = [7; 32];
+
+    fn account() -> AccountId {
+        AccountId::from_bytes([5; 32])
+    }
+
+    fn owner_chain(
+        device_boundary: AuthorityBoundary,
+        incarnation_boundary: AuthorityBoundary,
+    ) -> AuthorityQuery<OwnerChainAuthority> {
+        AuthorityQuery::Effective(OwnerChainAuthority {
+            owner: super::super::super::OwnerAuthority {
+                device_fingerprint: crate::op::DeviceFingerprint::from_bytes([2; 32]),
+            },
+            device_boundary,
+            incarnation_boundary,
+        })
+    }
+
+    fn base(
+        owner_authority: AuthorityQuery<OwnerChainAuthority>,
+        relation: AncestryRelation,
+    ) -> SecretsAcceptanceInput<impl Fn(EntryHash, EntryHash) -> AncestryRelation> {
+        SecretsAcceptanceInput {
+            account_id: account(),
+            entry_hash: ENTRY_HASH,
+            seq: 0,
+            authority_ref: Some(OWNER_ID),
+            owner_authority,
+            ownership: AuthorityQuery::Effective([1; 32]),
+            asserted_auth_len: 3,
+            dense_predecessor_reachable: true,
+            branch_selected: true,
+            freshness: CitedFreshness {
+                account_id: account(),
+                asserted_auth_len: 3,
+                state: AuthorityFreshness::CurrentOrBehind,
+            },
+            contested: false,
+            ancestry: move |_, _| relation,
+        }
+    }
+
+    #[test]
+    fn an_owner_wrap_with_clear_authority_accepts() {
+        let input = base(
+            owner_chain(AuthorityBoundary::Open, AuthorityBoundary::Open),
+            AncestryRelation::OnBranch,
+        );
+        assert_eq!(evaluate_secrets_acceptance(&input), Ok(SecretsAcceptance::Accepted));
+    }
+
+    #[test]
+    fn a_null_authority_ref_rejects_and_a_non_owner_signer_rejects() {
+        let mut null_ref = base(
+            owner_chain(AuthorityBoundary::Open, AuthorityBoundary::Open),
+            AncestryRelation::OnBranch,
+        );
+        null_ref.authority_ref = None;
+        assert_eq!(
+            evaluate_secrets_acceptance(&null_ref),
+            Ok(SecretsAcceptance::Rejected(SecretsRejectReason::OwnerReferenceInvalid))
+        );
+        // A signer that is not the cited incarnation's device (WrongSubject) rejects regardless of
+        // freshness — the owner-only gate (B3).
+        let mut wrong_subject = base(
+            AuthorityQuery::Invalid(AuthorityInvalidReason::WrongSubject),
+            AncestryRelation::OnBranch,
+        );
+        wrong_subject.freshness.state = AuthorityFreshness::Ahead;
+        assert_eq!(
+            evaluate_secrets_acceptance(&wrong_subject),
+            Ok(SecretsAcceptance::Rejected(SecretsRejectReason::OwnerReferenceInvalid))
+        );
+    }
+
+    #[test]
+    fn an_ineffective_incarnation_parks_while_behind_and_rejects_once_level() {
+        let mut ahead = base(
+            AuthorityQuery::Invalid(AuthorityInvalidReason::ReferencedEntryNotEffective),
+            AncestryRelation::OnBranch,
+        );
+        ahead.freshness.state = AuthorityFreshness::Ahead;
+        assert_eq!(
+            evaluate_secrets_acceptance(&ahead),
+            Ok(SecretsAcceptance::Parked(SecretsParkReason::AuthLenAhead))
+        );
+        let level = base(
+            AuthorityQuery::Invalid(AuthorityInvalidReason::ReferencedEntryNotEffective),
+            AncestryRelation::OnBranch,
+        );
+        assert_eq!(
+            evaluate_secrets_acceptance(&level),
+            Ok(SecretsAcceptance::Rejected(SecretsRejectReason::OwnerReferenceInvalid))
+        );
+    }
+
+    #[test]
+    fn a_wrap_before_its_stream_own_parks_recoverably() {
+        let mut input = base(
+            owner_chain(AuthorityBoundary::Open, AuthorityBoundary::Open),
+            AncestryRelation::OnBranch,
+        );
+        input.ownership = AuthorityQuery::Unknown;
+        assert_eq!(
+            evaluate_secrets_acceptance(&input),
+            Ok(SecretsAcceptance::Parked(SecretsParkReason::UnknownStreamOwner))
+        );
+    }
+
+    #[test]
+    fn an_unheld_incarnation_parks_unknown_owner_ref() {
+        let input = base(AuthorityQuery::Unknown, AncestryRelation::OnBranch);
+        assert_eq!(
+            evaluate_secrets_acceptance(&input),
+            Ok(SecretsAcceptance::Parked(SecretsParkReason::UnknownOwnerRef))
+        );
+    }
+
+    #[test]
+    fn a_beyond_cut_wrap_is_condemned_without_consulting_ancestry() {
+        use std::cell::Cell;
+        let calls = Cell::new(0);
+        let input = SecretsAcceptanceInput {
+            account_id: account(),
+            entry_hash: ENTRY_HASH,
+            seq: 5,
+            authority_ref: Some(OWNER_ID),
+            owner_authority: owner_chain(
+                AuthorityBoundary::Cut { seq: 2, hash: [1; 32] },
+                AuthorityBoundary::Open,
+            ),
+            ownership: AuthorityQuery::Effective([1; 32]),
+            asserted_auth_len: 3,
+            dense_predecessor_reachable: true,
+            branch_selected: true,
+            freshness: CitedFreshness {
+                account_id: account(),
+                asserted_auth_len: 3,
+                state: AuthorityFreshness::CurrentOrBehind,
+            },
+            contested: false,
+            ancestry: |_, _| {
+                calls.set(calls.get() + 1);
+                AncestryRelation::Unknown(UnknownAncestry::UnknownCutTarget)
+            },
+        };
+        assert_eq!(
+            evaluate_secrets_acceptance(&input),
+            Ok(SecretsAcceptance::Condemned(SecretsCondemnReason::BeyondCut))
+        );
+        assert_eq!(calls.get(), 0, "beyond-cut is seq-only, never consults ancestry");
+    }
+
+    #[test]
+    fn an_off_branch_wrap_is_condemned_and_a_within_cut_on_branch_accepts() {
+        let off = base(
+            owner_chain(AuthorityBoundary::Cut { seq: 5, hash: [1; 32] }, AuthorityBoundary::Open),
+            AncestryRelation::OffBranch,
+        );
+        assert_eq!(
+            evaluate_secrets_acceptance(&off),
+            Ok(SecretsAcceptance::Condemned(SecretsCondemnReason::OffBranch))
+        );
+        let on = base(
+            owner_chain(AuthorityBoundary::Cut { seq: 5, hash: [1; 32] }, AuthorityBoundary::Open),
+            AncestryRelation::OnBranch,
+        );
+        assert_eq!(evaluate_secrets_acceptance(&on), Ok(SecretsAcceptance::Accepted));
+    }
+
+    #[test]
+    fn a_definite_condemnation_outranks_a_contested_hold_and_an_incomplete_boundary() {
+        // Closed incarnation + contested: the condemnation wins (a hold cannot mask a definite
+        // condemnation).
+        let input = SecretsAcceptanceInput {
+            contested: true,
+            ..base(
+                owner_chain(AuthorityBoundary::Open, AuthorityBoundary::Closed),
+                AncestryRelation::OnBranch,
+            )
+        };
+        assert_eq!(
+            evaluate_secrets_acceptance(&input),
+            Ok(SecretsAcceptance::Condemned(SecretsCondemnReason::ClosedIncarnation))
+        );
+        // Contested outranks an undecided boundary park.
+        let held = SecretsAcceptanceInput {
+            contested: true,
+            ..base(
+                owner_chain(
+                    AuthorityBoundary::Cut { seq: 5, hash: [1; 32] },
+                    AuthorityBoundary::Open,
+                ),
+                AncestryRelation::Unknown(UnknownAncestry::UnknownCutTarget),
+            )
+        };
+        assert_eq!(
+            evaluate_secrets_acceptance(&held),
+            Ok(SecretsAcceptance::Parked(SecretsParkReason::ContestedSubject))
+        );
+    }
+
+    #[test]
+    fn freshness_provenance_is_a_precondition_and_freshness_runs_last() {
+        let mut wrong_account = base(
+            owner_chain(AuthorityBoundary::Open, AuthorityBoundary::Open),
+            AncestryRelation::OnBranch,
+        );
+        wrong_account.freshness.account_id = AccountId::from_bytes([0xaa; 32]);
+        assert_eq!(
+            evaluate_secrets_acceptance(&wrong_account),
+            Err(SecretsAcceptanceInputError::FreshnessProvenance)
+        );
+        // Same account, but the freshness was computed against a DIFFERENT asserted length than the
+        // header makes — provenance fails on that component too (mirrors the content predicate).
+        let mut wrong_len = base(
+            owner_chain(AuthorityBoundary::Open, AuthorityBoundary::Open),
+            AncestryRelation::OnBranch,
+        );
+        wrong_len.freshness.asserted_auth_len = wrong_len.asserted_auth_len + 1;
+        assert_eq!(
+            evaluate_secrets_acceptance(&wrong_len),
+            Err(SecretsAcceptanceInputError::FreshnessProvenance)
+        );
+        // A fork is decided by the DAG, so an ahead counter cannot mask it (freshness runs after
+        // branch selection).
+        let mut forked = base(
+            owner_chain(AuthorityBoundary::Open, AuthorityBoundary::Open),
+            AncestryRelation::OnBranch,
+        );
+        forked.branch_selected = false;
+        forked.freshness.state = AuthorityFreshness::Ahead;
+        assert_eq!(evaluate_secrets_acceptance(&forked), Ok(SecretsAcceptance::Forked));
+        // Selected + ahead ⇒ park auth_len_ahead (freshness last).
+        let mut ahead = base(
+            owner_chain(AuthorityBoundary::Open, AuthorityBoundary::Open),
+            AncestryRelation::OnBranch,
+        );
+        ahead.freshness.state = AuthorityFreshness::Ahead;
+        assert_eq!(
+            evaluate_secrets_acceptance(&ahead),
+            Ok(SecretsAcceptance::Parked(SecretsParkReason::AuthLenAhead))
+        );
+    }
+
+    #[test]
+    fn status_pairs_cover_every_frozen_state() {
+        for (verdict, pair) in [
+            (SecretsAcceptance::Accepted, ("accepted", None)),
+            (SecretsAcceptance::Forked, ("forked", None)),
+            (
+                SecretsAcceptance::Parked(SecretsParkReason::MissingPredecessor),
+                ("parked", Some("missing_predecessor")),
+            ),
+            (
+                SecretsAcceptance::Parked(SecretsParkReason::UnknownOwnerRef),
+                ("parked", Some("unknown_owner_ref")),
+            ),
+            (
+                SecretsAcceptance::Parked(SecretsParkReason::UnknownStreamOwner),
+                ("parked", Some("unknown_account")),
+            ),
+            (
+                SecretsAcceptance::Parked(SecretsParkReason::AuthLenAhead),
+                ("parked", Some("auth_len_ahead")),
+            ),
+            (
+                SecretsAcceptance::Parked(SecretsParkReason::IncompleteCutAncestry),
+                ("parked", Some("incomplete_cut_ancestry")),
+            ),
+            (
+                SecretsAcceptance::Parked(SecretsParkReason::UnknownCutTarget),
+                ("parked", Some("unknown_cut_target")),
+            ),
+            (
+                SecretsAcceptance::Parked(SecretsParkReason::ContestedSubject),
+                ("parked", Some("contested_subject")),
+            ),
+            (
+                SecretsAcceptance::Condemned(SecretsCondemnReason::BeyondCut),
+                ("condemned", Some("beyond_cut")),
+            ),
+            (
+                SecretsAcceptance::Condemned(SecretsCondemnReason::OffBranch),
+                ("condemned", Some("off_branch")),
+            ),
+            (
+                SecretsAcceptance::Condemned(SecretsCondemnReason::ClosedIncarnation),
+                ("condemned", Some("closed_incarnation")),
+            ),
+            (
+                SecretsAcceptance::Rejected(SecretsRejectReason::OwnerReferenceInvalid),
+                ("rejected", Some("invalid_owner")),
+            ),
+        ] {
+            assert_eq!(verdict.as_db_pair(), pair);
+        }
+    }
+}

--- a/crates/rag-rat-oplog/src/account/secrets/candidate.rs
+++ b/crates/rag-rat-oplog/src/account/secrets/candidate.rs
@@ -1,0 +1,352 @@
+//! Pin-aware branch selection for the secrets log (`log_id = 1`, §16.2, C4.2b, B-1).
+//!
+//! The account-side [`super::super::candidate`] primitives (`ancestry`, `validate_cut_target`,
+//! `HeaderView`) are log-generic, but `select_coherent_branches` in [`super::super::storage`] has
+//! NO watermark-pin mechanism — the control fold never needs one. The secrets acceptance loop DOES:
+//! a compromised-then-removed owner device can fork its secrets chain BELOW its `DeviceRemove`
+//! secrets cut, and a pin-less min-hash tiebreak would select the attacker fork (deterministic,
+//! convergent, WRONG), forking the honest cut-preserved wraps off the accepted branch. So this
+//! module ports the CONTENT selection's pin logic (`content::candidate`) onto `AccountEntryHeader`
+//! rows: a register pin promotes the branch its watermark names over the hash order, which is what
+//! makes the off-branch condemnation of the other fork enforceable.
+//!
+//! Pins are sourced from BOTH secrets boundaries of a wrap's cited owner incarnation (the device
+//! register AND the owner-incarnation register — two registers can bound one chain), revalidated
+//! here via [`super::super::candidate::validate_cut_target`] at the secrets coordinate.
+
+use std::collections::{HashMap, HashSet};
+
+use super::super::AccountId;
+use super::super::candidate::{self, CutCoordinate, HeaderView};
+use super::super::cut::Cut;
+use super::super::envelope::AccountEntryHeader;
+use super::super::fold::SECRETS_LOG;
+use crate::op::DeviceFingerprint;
+
+type EntryHash = [u8; 32];
+
+/// The chain one secrets cut bounds: `(account, device)` on `log: SECRETS_LOG`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(super) struct SecretsCoordinate {
+    pub(super) account_id: AccountId,
+    pub(super) device_fingerprint: DeviceFingerprint,
+}
+
+impl SecretsCoordinate {
+    fn of(header: &AccountEntryHeader) -> Self {
+        Self { account_id: header.account_id, device_fingerprint: header.device_fingerprint }
+    }
+
+    fn cut_coordinate(&self) -> CutCoordinate {
+        CutCoordinate {
+            account: self.account_id,
+            log: SECRETS_LOG,
+            device: self.device_fingerprint,
+        }
+    }
+}
+
+/// One log-1 candidate the refold classifies: its hash plus the header the walks read.
+#[derive(Debug, Clone)]
+pub(super) struct SecretsCandidate {
+    pub(super) entry_hash: EntryHash,
+    pub(super) header: AccountEntryHeader,
+}
+
+/// A register watermark that pins one secrets chain's accepted branch (§16.2). Sourced from a
+/// wrap's cited owner-incarnation secrets boundaries; a cut naming a currently-`forked` branch
+/// PROMOTES it, which is what makes an off-branch condemnation of the other fork enforceable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct BranchPin {
+    pub(super) coordinate: SecretsCoordinate,
+    pub(super) seq: u64,
+    pub(super) watermark: EntryHash,
+}
+
+/// Eligible entries indexed by the `(chain, prev_hash)` parent slot they extend; a chain root keys
+/// on `None`. Several entries under one key are an equivocation — the slot selection resolves them.
+type BranchChildren = HashMap<(SecretsCoordinate, Option<EntryHash>), Vec<(u64, EntryHash)>>;
+
+/// The branch-selection verdict for one refold. The two sets do NOT partition the eligible
+/// candidates: an entry stranded above a gap in the dense chain is in NEITHER (it lost nothing).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(super) struct BranchSelection {
+    pub(super) accepted: HashSet<EntryHash>,
+    pub(super) forked: HashSet<EntryHash>,
+}
+
+/// Select one contiguous accepted chain per `(account, device)` on the secrets log from the
+/// eligible candidates (§16.2). `eligible` is the caller's authority verdict + the slot-eligible
+/// non-evaluable entries; a condemned/rejected entry must not compete for a slot. At a slot with
+/// several eligible children the winner is (1) the child on a pinning watermark's branch, if a
+/// register pins this chain — the register decides, not hash order — else (2) the lexicographically
+/// smallest `entry_hash`.
+pub(super) fn select_accepted_branch(
+    candidates: &[SecretsCandidate],
+    eligible: &HashSet<EntryHash>,
+    pins: &[BranchPin],
+    view: &dyn HeaderView,
+) -> BranchSelection {
+    let mut children = BranchChildren::new();
+    let mut chains: HashSet<SecretsCoordinate> = HashSet::new();
+    for candidate in candidates.iter().filter(|c| eligible.contains(&c.entry_hash)) {
+        let coordinate = SecretsCoordinate::of(&candidate.header);
+        children
+            .entry((coordinate, candidate.header.prev_hash))
+            .or_default()
+            .push((candidate.header.seq, candidate.entry_hash));
+        chains.insert(coordinate);
+    }
+
+    let mut accepted = HashSet::new();
+    let mut rooted = HashSet::new();
+    for chain in chains {
+        let pinned = pinned_branch(chain, pins, view);
+        let mut parent: Option<EntryHash> = None;
+        // A secrets seq is dense from 0, so the chain ends at the first slot no eligible child
+        // fills.
+        for slot in 0..candidates.len() as u64 {
+            let Some(winner) = children.get(&(chain, parent)).and_then(|kids| {
+                let at_slot = kids.iter().filter(|(seq, _)| *seq == slot);
+                at_slot
+                    .clone()
+                    .find(|(_, hash)| pinned.contains(hash))
+                    .or_else(|| at_slot.min_by_key(|(_, hash)| *hash))
+                    .map(|(_, hash)| *hash)
+            }) else {
+                break;
+            };
+            accepted.insert(winner);
+            parent = Some(winner);
+        }
+        collect_rooted(chain, &children, &mut rooted);
+    }
+
+    // Only an entry that reaches its chain root through held entries can have LOST anything. One
+    // stranded above a gap never entered a contest, so it is not a loser — leave it out of both
+    // sets and let the caller park it until its predecessor arrives.
+    let forked = rooted.difference(&accepted).copied().collect();
+    BranchSelection { accepted, forked }
+}
+
+/// Every eligible entry reachable from a chain root by contiguous `prev_hash` links.
+fn collect_rooted(
+    chain: SecretsCoordinate,
+    children: &BranchChildren,
+    rooted: &mut HashSet<EntryHash>,
+) {
+    let mut frontier: Vec<(Option<EntryHash>, u64)> = vec![(None, 0)];
+    while let Some((parent, slot)) = frontier.pop() {
+        let Some(kids) = children.get(&(chain, parent)) else {
+            continue;
+        };
+        for (seq, hash) in kids.iter().filter(|(seq, _)| *seq == slot) {
+            if !rooted.insert(*hash) {
+                continue;
+            }
+            if let Some(next) = seq.checked_add(1) {
+                frontier.push((Some(*hash), next));
+            }
+        }
+    }
+}
+
+/// The entries on the branch a register pins for `chain` — empty when no cut pins it, or when the
+/// pinning watermark is withheld or names a foreign coordinate (neither may steer selection). The
+/// HIGHEST admitted watermark wins, ordered by `(seq, watermark)` (a total order) so the winner
+/// never depends on the order the pins were assembled in — two registers can name the SAME seq once
+/// a device equivocates.
+fn pinned_branch(
+    chain: SecretsCoordinate,
+    pins: &[BranchPin],
+    view: &dyn HeaderView,
+) -> HashSet<EntryHash> {
+    let coordinate = chain.cut_coordinate();
+    let Some(pin) = pins
+        .iter()
+        .filter(|pin| pin.coordinate == chain)
+        .filter(|pin| {
+            candidate::validate_cut_target(
+                &Cut::At { seq: pin.seq, hash: pin.watermark },
+                &coordinate,
+                view,
+            ) == candidate::CutBinding::Ok
+        })
+        .max_by_key(|pin| (pin.seq, pin.watermark))
+    else {
+        return HashSet::new();
+    };
+    // Walk `prev_hash` back from the watermark, collecting the branch it heads. A withheld/forged
+    // link simply ends the walk — validate_cut_target already confirmed the watermark is held and
+    // names this coordinate.
+    let mut branch = HashSet::from([pin.watermark]);
+    let mut visited: HashSet<EntryHash> = HashSet::new();
+    let mut current = pin.watermark;
+    while let Some(header) = view.header(&current) {
+        if SecretsCoordinate::of(header) != chain {
+            break; // a forged cross-coordinate link is not a real predecessor
+        }
+        branch.insert(current);
+        if !visited.insert(current) {
+            break;
+        }
+        let Some(prev) = header.prev_hash else {
+            break; // reached the chain origin
+        };
+        // A dense chain is contiguous — a held predecessor must be the exactly-preceding slot.
+        if let Some(prev_header) = view.header(&prev)
+            && prev_header.seq.checked_add(1) != Some(header.seq)
+        {
+            break;
+        }
+        current = prev;
+    }
+    branch
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ACCOUNT: [u8; 32] = [0xaa; 32];
+    const DEVICE: [u8; 32] = [0xbb; 32];
+
+    fn chain() -> SecretsCoordinate {
+        SecretsCoordinate {
+            account_id: AccountId::from_bytes(ACCOUNT),
+            device_fingerprint: DeviceFingerprint::from_bytes(DEVICE),
+        }
+    }
+
+    fn header(seq: u64, prev_hash: Option<EntryHash>) -> AccountEntryHeader {
+        AccountEntryHeader {
+            account_id: AccountId::from_bytes(ACCOUNT),
+            log_id: SECRETS_LOG,
+            device_fingerprint: DeviceFingerprint::from_bytes(DEVICE),
+            seq,
+            prev_hash,
+            parent_ref: None,
+            entry_type: 0,
+            op_version: 1,
+            crypto_suite: 0,
+            auth_len: seq,
+            key_id: None,
+            authority_ref: Some([1; 32]),
+        }
+    }
+
+    fn linear() -> HashMap<EntryHash, AccountEntryHeader> {
+        HashMap::from([
+            ([0x0a; 32], header(0, None)),
+            ([0x0b; 32], header(1, Some([0x0a; 32]))),
+            ([0x0c; 32], header(2, Some([0x0b; 32]))),
+        ])
+    }
+
+    fn candidates(view: &HashMap<EntryHash, AccountEntryHeader>) -> Vec<SecretsCandidate> {
+        let mut rows: Vec<SecretsCandidate> = view
+            .iter()
+            .map(|(entry_hash, header)| SecretsCandidate {
+                entry_hash: *entry_hash,
+                header: header.clone(),
+            })
+            .collect();
+        rows.sort_by_key(|row| row.entry_hash);
+        rows
+    }
+
+    fn all(view: &HashMap<EntryHash, AccountEntryHeader>) -> HashSet<EntryHash> {
+        view.keys().copied().collect()
+    }
+
+    #[test]
+    fn a_linear_chain_is_accepted_in_full() {
+        let view = linear();
+        let rows = candidates(&view);
+        let selection = select_accepted_branch(&rows, &all(&view), &[], &view);
+        assert_eq!(selection.accepted, HashSet::from([[0x0a; 32], [0x0b; 32], [0x0c; 32]]));
+        assert!(selection.forked.is_empty());
+    }
+
+    #[test]
+    fn an_unforced_fork_resolves_to_the_smaller_hash_and_the_loser_is_terminal() {
+        let mut view = linear();
+        view.insert([0x1b; 32], header(1, Some([0x0a; 32]))); // sibling of 0x0b, larger hash
+        view.insert([0x1c; 32], header(2, Some([0x1b; 32])));
+        let rows = candidates(&view);
+        let selection = select_accepted_branch(&rows, &all(&view), &[], &view);
+        assert_eq!(selection.accepted, HashSet::from([[0x0a; 32], [0x0b; 32], [0x0c; 32]]));
+        assert_eq!(selection.forked, HashSet::from([[0x1b; 32], [0x1c; 32]]));
+    }
+
+    #[test]
+    fn a_register_watermark_promotes_the_branch_it_names_over_the_hash_order() {
+        let mut view = linear();
+        // The equivocating sibling has the LARGER hash, so the unforced rule would fork it out.
+        view.insert([0x1b; 32], header(1, Some([0x0a; 32])));
+        view.insert([0x1c; 32], header(2, Some([0x1b; 32])));
+        let rows = candidates(&view);
+        let pin = BranchPin { coordinate: chain(), seq: 2, watermark: [0x1c; 32] };
+        let selection = select_accepted_branch(&rows, &all(&view), &[pin], &view);
+        assert_eq!(selection.accepted, HashSet::from([[0x0a; 32], [0x1b; 32], [0x1c; 32]]));
+        assert_eq!(selection.forked, HashSet::from([[0x0b; 32], [0x0c; 32]]));
+    }
+
+    #[test]
+    fn a_withheld_or_foreign_pin_cannot_steer_selection() {
+        let mut view = linear();
+        view.insert([0x1b; 32], header(1, Some([0x0a; 32])));
+        view.insert([0x1c; 32], header(2, Some([0x1b; 32])));
+        let rows = candidates(&view);
+        // A watermark we do not hold cannot pin.
+        let withheld = BranchPin { coordinate: chain(), seq: 2, watermark: [0x99; 32] };
+        let selection = select_accepted_branch(&rows, &all(&view), &[withheld], &view);
+        assert_eq!(selection.accepted, HashSet::from([[0x0a; 32], [0x0b; 32], [0x0c; 32]]));
+        // Nor a pin whose watermark names a foreign coordinate.
+        let foreign = BranchPin {
+            coordinate: SecretsCoordinate {
+                device_fingerprint: DeviceFingerprint::from_bytes([0xcc; 32]),
+                ..chain()
+            },
+            seq: 2,
+            watermark: [0x1c; 32],
+        };
+        let selection = select_accepted_branch(&rows, &all(&view), &[foreign], &view);
+        assert_eq!(selection.accepted, HashSet::from([[0x0a; 32], [0x0b; 32], [0x0c; 32]]));
+    }
+
+    #[test]
+    fn a_condemned_entry_never_competes_for_a_slot() {
+        let mut view = linear();
+        // A smaller-hash equivocating sibling that WOULD win the tiebreak, but is ineligible.
+        view.insert([0x00; 32], header(1, Some([0x0a; 32])));
+        let rows = candidates(&view);
+        let mut eligible = all(&view);
+        eligible.remove(&[0x00; 32]);
+        let selection = select_accepted_branch(&rows, &eligible, &[], &view);
+        assert_eq!(selection.accepted, HashSet::from([[0x0a; 32], [0x0b; 32], [0x0c; 32]]));
+    }
+
+    #[test]
+    fn selection_is_independent_of_row_order() {
+        let mut view = linear();
+        view.insert([0x1b; 32], header(1, Some([0x0a; 32])));
+        view.insert([0x1c; 32], header(2, Some([0x1b; 32])));
+        let mut rows = candidates(&view);
+        let expected = select_accepted_branch(&rows, &all(&view), &[], &view);
+        for rotation in 1..rows.len() {
+            rows.rotate_left(rotation);
+            assert_eq!(select_accepted_branch(&rows, &all(&view), &[], &view), expected);
+        }
+    }
+
+    #[test]
+    fn an_entry_stranded_above_a_gap_is_neither_accepted_nor_forked() {
+        let mut view = linear();
+        view.insert([0x0e; 32], header(4, Some([0x0d; 32]))); // seq-3 predecessor absent
+        let rows = candidates(&view);
+        let selection = select_accepted_branch(&rows, &all(&view), &[], &view);
+        assert_eq!(selection.accepted, HashSet::from([[0x0a; 32], [0x0b; 32], [0x0c; 32]]));
+        assert!(!selection.forked.contains(&[0x0e; 32]));
+    }
+}

--- a/crates/rag-rat-oplog/src/account/secrets/mod.rs
+++ b/crates/rag-rat-oplog/src/account/secrets/mod.rs
@@ -1,0 +1,19 @@
+//! The account secrets log (`log_id = 1`, sync phase C4.2b): the `StreamKeyWrap` op wire and the
+//! owner-gated acceptance evaluator that classifies it.
+//!
+//! The secrets log is a SECOND roster-only account log on the shared account-entry envelope. Its
+//! ops ride as the opaque `payload` bstr; the fold ([`super::fold`]) is CONTROL-only, so secrets
+//! entries are CONSUMERS of the authority projection (like `/3` content), classified here by a
+//! content-style acceptance loop over the log-generic candidate primitives. C4.2b ships
+//! `StreamKeyWrap` ACCEPTANCE only — content-key minting + wrap AUTHORING + the `key_id` adoption
+//! cross-check are C4.3.
+
+mod acceptance;
+mod candidate;
+mod ops;
+mod storage;
+
+// The ingest-time structural validation twin (mirrors the control-plaintext arm) and the refold
+// pass wired into `refold_in_tx`.
+pub(in crate::account) use ops::validate_storable_secrets_payload;
+pub(in crate::account) use storage::refold_secrets_log;

--- a/crates/rag-rat-oplog/src/account/secrets/ops.rs
+++ b/crates/rag-rat-oplog/src/account/secrets/ops.rs
@@ -1,0 +1,343 @@
+//! The secrets-log op payloads (`log_id = 1`) and their canonical-CBOR wire (§15).
+//!
+//! The secrets log is a SECOND account log at `log_id = SECRETS_LOG`. It shares the account-entry
+//! envelope ([`super::super::envelope`]) — its ops ride as the opaque `payload` bstr, disambiguated
+//! by the header's `entry_type`, whose frozen tag set here is a SEPARATE per-log namespace
+//! ([`entry_type`]) with fresh numbering: a secrets tag `0` is NOT control's `AccountGenesis`. An
+//! UNKNOWN secrets `entry_type` is retained opaque (forward-compat), never rejected — it stays a
+//! valid chain link for its descendants (the slot-eligibility rule).
+//!
+//! Like the control ops, this layer owns STRUCTURAL wire validity only: arity, canonicity
+//! (`encode(decode) == bytes`), sorted-unique recipients, the §18a `WRAP_RECIPIENTS_MAX` bound, and
+//! that each `wrapped_key` decodes as a C4.1 [`SealedKeyWrap`]. Every authority/acceptance rule is
+//! the secrets evaluator's ([`super::acceptance`]).
+
+use minicbor::Encoder;
+use minicbor::decode::{Decoder, Error as CborError};
+
+use super::super::keywrap::SealedKeyWrap;
+use super::super::limits::WRAP_RECIPIENTS_MAX;
+use crate::cbor;
+use crate::op::DeviceFingerprint;
+use crate::stream::StreamId;
+
+/// Writing CBOR into a `Vec` cannot fail (its `Write` impl is infallible) — mirrors `super::super`.
+const INFALLIBLE: &str = "encoding CBOR to a Vec is infallible";
+
+/// The frozen secrets-log `entry_type` tag set (header part 7), a per-log namespace with fresh
+/// numbering. A tag is a wire constant — a renumber is a wire bump. Decode of these tags is gated
+/// on `log_id == SECRETS_LOG` so a secrets tag can never be misread as the control tag with the
+/// same number.
+pub(in crate::account) mod entry_type {
+    /// A per-`(stream, key_id)` fan-out of content-key wraps (§15).
+    pub(in crate::account) const STREAM_KEY_WRAP: u32 = 0;
+}
+
+/// One recipient's wrap inside a [`StreamKeyWrap`]: the recipient device and the C4.1 sealed key.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(in crate::account) struct WrapEntry {
+    pub(in crate::account) recipient_fp: DeviceFingerprint,
+    pub(in crate::account) sealed: SealedKeyWrap,
+}
+
+/// The one secrets-log op today (§15): a per-`(stream, key_id)` fan-out of a content key sealed to
+/// each granted device. `key_epoch` is a rotation-lag hint (not a header field). Wire order is
+/// frozen; goldens pin the bytes. NO leading domain element — account-op payloads are bare
+/// fixed-arity arrays, disambiguated by `entry_type`/envelope (mirrors the control ops).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(in crate::account) struct StreamKeyWrap {
+    pub(in crate::account) stream_id: StreamId,
+    pub(in crate::account) key_id: [u8; 32],
+    pub(in crate::account) key_epoch: u64,
+    pub(in crate::account) wraps: Vec<WrapEntry>,
+}
+
+/// The result of decoding a secrets-op payload against its header `entry_type`: a known op or a
+/// retained opaque forward-version op (never an error for an unrecognized `entry_type`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(in crate::account) enum DecodedSecretsOp {
+    Known(StreamKeyWrap),
+    Unknown { entry_type: u32, bytes: Vec<u8> },
+}
+
+/// The `entry_type` tag a secrets op carries in its header (§15). One op today, so it is a
+/// constant; takes the op by ref for symmetry with the control `entry_type_of` (and to stay total
+/// as ops grow).
+pub(in crate::account) fn entry_type_of(_op: &StreamKeyWrap) -> u32 {
+    entry_type::STREAM_KEY_WRAP
+}
+
+/// The ingest-time structural-validation twin (the secrets mirror of the control-plaintext arm of
+/// `validate_storable_header_payload`): a KNOWN secrets tag is fully validated (arity,
+/// sorted-unique recipients, `WRAP_RECIPIENTS_MAX`, each `wrapped_key` decodes), an unknown tag is
+/// checked only as one canonical CBOR array (retained opaque). The caller gates this on `log_id ==
+/// SECRETS_LOG && crypto_suite == 0 && op_version == 1`, so it auto-covers the pre-verify promotion
+/// path.
+pub(in crate::account) fn validate_storable_secrets_payload(
+    entry_type: u32,
+    payload: &[u8],
+) -> Result<(), CborError> {
+    decode(entry_type, payload).map(|_| ())
+}
+
+/// Encode a secrets op to its canonical-CBOR payload (§15). Sorted wraps are emitted in
+/// recipient-fingerprint order (the decoder rejects an unsorted wire, so `encode(decode) ==
+/// bytes`).
+pub(in crate::account) fn encode(op: &StreamKeyWrap) -> Result<Vec<u8>, CborError> {
+    Ok(encode_canonical(&canonicalize(op)?))
+}
+
+/// Validate + canonicalize a secrets op so its encoding ALWAYS round-trips through [`decode`] — the
+/// authoring path must never sign a payload the sorted-unique / bounded decoder (and peers) would
+/// reject. Sorts + dedups + reject-conflicting + bound-checks the wrap fan-out. Everything decode
+/// enforces at the op level is enforced here too, so `encode` cannot emit dead bytes.
+fn canonicalize(op: &StreamKeyWrap) -> Result<StreamKeyWrap, CborError> {
+    Ok(StreamKeyWrap { wraps: canonical_wraps(&op.wraps)?, ..op.clone() })
+}
+
+/// Serialize an ALREADY-canonical op (see [`canonicalize`]) to CBOR. Infallible — the wrap array is
+/// already sorted, deduped, and bounded.
+fn encode_canonical(op: &StreamKeyWrap) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(128);
+    {
+        let mut enc = Encoder::new(&mut buf);
+        enc.array(4).expect(INFALLIBLE);
+        enc.bytes(&op.stream_id.to_bytes()).expect(INFALLIBLE);
+        enc.bytes(&op.key_id).expect(INFALLIBLE);
+        enc.u64(op.key_epoch).expect(INFALLIBLE);
+        write_wraps(&mut enc, &op.wraps);
+    }
+    buf
+}
+
+/// Decode a secrets-op payload against its header `entry_type`. A known type is fully validated
+/// (structure, canonicity via re-encode, sorted-unique recipients, bounds, each wrap decodes); an
+/// unknown type is retained opaque (mirrors the control-op decoder).
+pub(in crate::account) fn decode(
+    entry_type: u32,
+    bytes: &[u8],
+) -> Result<DecodedSecretsOp, CborError> {
+    let op = match entry_type {
+        entry_type::STREAM_KEY_WRAP => decode_stream_key_wrap(bytes)?,
+        other => {
+            // A forward-version secrets op is RETAINED opaque (we can't re-encode it), but it must
+            // STILL be exactly one canonical CBOR array — otherwise a future binary that learns
+            // this entry_type would run the `encode(decode) == bytes` check below and
+            // REJECT an entry an older peer accepted + chained, splitting consensus on
+            // a signed log. The envelope validates the payload only as an opaque bstr,
+            // so this is the ONLY place the interior is checked. (Mirrors the
+            // control-op decoder.)
+            cbor::require_canonical_cbor(bytes)?;
+            cbor::expect_definite_len(&mut Decoder::new(bytes))?;
+            return Ok(DecodedSecretsOp::Unknown { entry_type: other, bytes: bytes.to_vec() });
+        },
+    };
+    // Canonicity guarantee for a KNOWN op: the decoded value must re-encode to the exact wire (this
+    // rejects non-minimal ints, unsorted wraps, trailing bytes, a non-canonical inner wrap, etc. in
+    // one check). A decoded op already satisfies every invariant `canonicalize` checks, so the
+    // re-encode cannot fail.
+    if encode(&op)? != bytes {
+        return Err(CborError::message("secrets op payload is not canonical (re-encode differs)"));
+    }
+    Ok(DecodedSecretsOp::Known(op))
+}
+
+fn decode_stream_key_wrap(bytes: &[u8]) -> Result<StreamKeyWrap, CborError> {
+    let mut d = Decoder::new(bytes);
+    cbor::expect_array(&mut d, 4)?;
+    let stream_id = StreamId::from_bytes(cbor::fixed_bytes::<32>(d.bytes()?, "stream_id")?);
+    let key_id = cbor::fixed_bytes::<32>(d.bytes()?, "key_id")?;
+    let key_epoch = d.u64()?;
+    let wraps = decode_wraps(&mut d)?;
+    Ok(StreamKeyWrap { stream_id, key_id, key_epoch, wraps })
+}
+
+/// Validate + canonicalize the wrap fan-out (mirrors the control cut arrays): sort by recipient
+/// fingerprint, drop EXACT duplicates, reject two CONFLICTING wraps for one recipient (a silent
+/// drop would lose a wrap, so this errors), enforce the §18a `WRAP_RECIPIENTS_MAX` bound, and
+/// require each `wrapped_key` be a valid canonical [`SealedKeyWrap`].
+fn canonical_wraps(wraps: &[WrapEntry]) -> Result<Vec<WrapEntry>, CborError> {
+    let mut sorted = wraps.to_vec();
+    sorted.sort_by_key(|wrap| wrap.recipient_fp.to_bytes());
+    sorted.dedup();
+    if sorted.windows(2).any(|pair| pair[0].recipient_fp == pair[1].recipient_fp) {
+        return Err(CborError::message("wraps has conflicting entries for one recipient"));
+    }
+    if sorted.len() > WRAP_RECIPIENTS_MAX {
+        return Err(CborError::message("wraps exceeds the §18a WRAP_RECIPIENTS_MAX bound"));
+    }
+    Ok(sorted)
+}
+
+/// Emit an ALREADY-canonical wrap array (see [`canonical_wraps`]). Each `wrapped_key` is the opaque
+/// canonical [`SealedKeyWrap::to_cbor`] bstr — NOT an inline array (§15 S-c).
+fn write_wraps(enc: &mut Encoder<&mut Vec<u8>>, wraps: &[WrapEntry]) {
+    enc.array(wraps.len() as u64).expect(INFALLIBLE);
+    for wrap in wraps {
+        enc.array(2).expect(INFALLIBLE);
+        enc.bytes(&wrap.recipient_fp.to_bytes()).expect(INFALLIBLE);
+        enc.bytes(&wrap.sealed.to_cbor()).expect(INFALLIBLE);
+    }
+}
+
+fn decode_wraps(d: &mut Decoder<'_>) -> Result<Vec<WrapEntry>, CborError> {
+    let len = cbor::expect_definite_len(d)?;
+    if len > WRAP_RECIPIENTS_MAX as u64 {
+        return Err(CborError::message("wraps exceeds the §18a WRAP_RECIPIENTS_MAX bound"));
+    }
+    let mut wraps = Vec::with_capacity(len as usize);
+    let mut prev: Option<[u8; 32]> = None;
+    for _ in 0..len {
+        cbor::expect_array(d, 2)?;
+        let recipient = cbor::fixed_bytes::<32>(d.bytes()?, "wrap recipient_fp")?;
+        // Strictly ascending by recipient ⇒ sorted AND unique in one check.
+        if prev.is_some_and(|p| recipient <= p) {
+            return Err(CborError::message("wraps not sorted-unique by recipient_fp"));
+        }
+        prev = Some(recipient);
+        // The wrapped_key is an opaque bstr carrying C4.1 SealedKeyWrap CBOR; `from_cbor` re-checks
+        // canonicity + width, so a non-canonical inner wrap is a structural reject here.
+        let sealed = SealedKeyWrap::from_cbor(d.bytes()?).map_err(|err| {
+            CborError::message(format!("wrapped_key is not a SealedKeyWrap: {err}"))
+        })?;
+        wraps.push(WrapEntry { recipient_fp: DeviceFingerprint::from_bytes(recipient), sealed });
+    }
+    Ok(wraps)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::account::keywrap::{ContentKey, WrapContext, seal_content_key};
+    use crate::device::{DeviceX25519Public, DeviceX25519Secret};
+
+    fn recipient(seed: u8) -> DeviceX25519Public {
+        DeviceX25519Secret::from_seed(&[seed; 32]).public()
+    }
+
+    fn sealed_for(seed: u8) -> SealedKeyWrap {
+        let key = ContentKey::from_seed(&[1; 32]);
+        let recipient = recipient(seed);
+        let ctx = WrapContext {
+            account_id: [2; 32],
+            stream_id: [3; 32],
+            key_epoch: 0,
+            recipient_pub: recipient.to_bytes(),
+        };
+        seal_content_key(&key, &ctx, &recipient).unwrap()
+    }
+
+    fn wrap_entry(seed: u8) -> WrapEntry {
+        WrapEntry {
+            recipient_fp: DeviceFingerprint::from_bytes([seed; 32]),
+            sealed: sealed_for(seed),
+        }
+    }
+
+    fn op(wraps: Vec<WrapEntry>) -> StreamKeyWrap {
+        StreamKeyWrap {
+            stream_id: StreamId::from_bytes([9; 32]),
+            key_id: [8; 32],
+            key_epoch: 4,
+            wraps,
+        }
+    }
+
+    #[test]
+    fn round_trips_and_sorts_recipients() {
+        // Author out of order; canonical encode sorts by recipient, and decode round-trips.
+        let authored = op(vec![wrap_entry(0x30), wrap_entry(0x10), wrap_entry(0x20)]);
+        let bytes = encode(&authored).unwrap();
+        let DecodedSecretsOp::Known(decoded) = decode(entry_type::STREAM_KEY_WRAP, &bytes).unwrap()
+        else {
+            panic!("known op");
+        };
+        let recipients: Vec<[u8; 32]> =
+            decoded.wraps.iter().map(|w| w.recipient_fp.to_bytes()).collect();
+        assert_eq!(recipients, vec![[0x10; 32], [0x20; 32], [0x30; 32]], "sorted by recipient_fp");
+        assert_eq!(decoded.stream_id, authored.stream_id);
+        assert_eq!(decoded.key_id, authored.key_id);
+        assert_eq!(decoded.key_epoch, authored.key_epoch);
+        assert_eq!(entry_type_of(&decoded), entry_type::STREAM_KEY_WRAP);
+    }
+
+    #[test]
+    fn unsorted_and_duplicate_recipients_are_rejected_on_the_wire() {
+        // A hand-built unsorted wire (encode always sorts, so build it manually).
+        let mut buf = Vec::new();
+        {
+            let mut enc = Encoder::new(&mut buf);
+            enc.array(4).unwrap();
+            enc.bytes(&[9; 32]).unwrap();
+            enc.bytes(&[8; 32]).unwrap();
+            enc.u64(4).unwrap();
+            enc.array(2).unwrap();
+            enc.array(2).unwrap();
+            enc.bytes(&[0x30; 32]).unwrap();
+            enc.bytes(&sealed_for(0x30).to_cbor()).unwrap();
+            enc.array(2).unwrap();
+            enc.bytes(&[0x10; 32]).unwrap(); // out of order
+            enc.bytes(&sealed_for(0x10).to_cbor()).unwrap();
+        }
+        assert!(decode(entry_type::STREAM_KEY_WRAP, &buf).is_err(), "unsorted recipients rejected");
+
+        // A duplicate recipient is likewise not sorted-unique.
+        let mut dup = Vec::new();
+        {
+            let mut enc = Encoder::new(&mut dup);
+            enc.array(4).unwrap();
+            enc.bytes(&[9; 32]).unwrap();
+            enc.bytes(&[8; 32]).unwrap();
+            enc.u64(4).unwrap();
+            enc.array(2).unwrap();
+            enc.array(2).unwrap();
+            enc.bytes(&[0x10; 32]).unwrap();
+            enc.bytes(&sealed_for(0x10).to_cbor()).unwrap();
+            enc.array(2).unwrap();
+            enc.bytes(&[0x10; 32]).unwrap();
+            enc.bytes(&sealed_for(0x11).to_cbor()).unwrap();
+        }
+        assert!(decode(entry_type::STREAM_KEY_WRAP, &dup).is_err(), "duplicate recipient rejected");
+    }
+
+    #[test]
+    fn an_undecodable_wrapped_key_is_a_structural_reject() {
+        let mut buf = Vec::new();
+        {
+            let mut enc = Encoder::new(&mut buf);
+            enc.array(4).unwrap();
+            enc.bytes(&[9; 32]).unwrap();
+            enc.bytes(&[8; 32]).unwrap();
+            enc.u64(4).unwrap();
+            enc.array(1).unwrap();
+            enc.array(2).unwrap();
+            enc.bytes(&[0x10; 32]).unwrap();
+            enc.bytes(&[0xde, 0xad, 0xbe, 0xef]).unwrap(); // not a SealedKeyWrap
+        }
+        assert!(decode(entry_type::STREAM_KEY_WRAP, &buf).is_err(), "bad wrapped_key rejected");
+    }
+
+    #[test]
+    fn an_unknown_secrets_tag_is_retained_opaque_when_canonical() {
+        // A single canonical CBOR array under an unknown tag is retained, not rejected.
+        let mut buf = Vec::new();
+        Encoder::new(&mut buf).array(0).unwrap();
+        let decoded = decode(7, &buf).unwrap();
+        assert_eq!(decoded, DecodedSecretsOp::Unknown { entry_type: 7, bytes: buf.clone() });
+        // A non-canonical / non-array payload under an unknown tag is still a structural reject —
+        // else an older peer would accept bytes a newer peer (which learns the tag) cannot fold.
+        assert!(decode(7, &[0x00]).is_err(), "a non-array unknown payload is rejected");
+        let mut trailing = buf.clone();
+        trailing.push(0x00);
+        assert!(decode(7, &trailing).is_err(), "trailing bytes under an unknown tag rejected");
+    }
+
+    #[test]
+    fn non_canonical_known_wire_is_rejected_by_re_encode() {
+        // A trailing byte after a valid StreamKeyWrap fails the encode(decode) == bytes check.
+        let good = encode(&op(vec![wrap_entry(0x10)])).unwrap();
+        let mut trailing = good.clone();
+        trailing.push(0x00);
+        assert!(decode(entry_type::STREAM_KEY_WRAP, &trailing).is_err(), "trailing bytes rejected");
+    }
+}

--- a/crates/rag-rat-oplog/src/account/secrets/storage.rs
+++ b/crates/rag-rat-oplog/src/account/secrets/storage.rs
@@ -1,0 +1,1001 @@
+//! The secrets-log (`log_id = 1`) acceptance refold pass (§13/§15, C4.2b).
+//!
+//! Mirrors `content::storage::refold_content_stream` — a content-style orchestration loop over the
+//! log-generic candidate primitives, NOT `derive_account_projection` (whose `effective` input is
+//! `fold_account` outcomes that log-1 entries never get). It is wired into
+//! [`super::super::storage::refold_in_tx`] between the authority-projection rewrite and the content
+//! trigger, in the SAME IMMEDIATE txn, so a control fold that condemns a device's secrets chain
+//! retro-condemns its wraps atomically (the retro-condemn cascade, §16.3).
+//!
+//! The main refold loop writes `retained_unfolded` for every log-1 row (the declassify baseline);
+//! this pass OVERWRITES that for the wraps it classifies (S-b/S4), in both `account_entry_status`
+//! and the returned status map. A structurally-valid-but-non-evaluable log-1 entry (unknown tag,
+//! future `op_version`, sealed `crypto_suite != 0`) is SLOT-ELIGIBLE (it occupies its dense seq
+//! slot and extends the chain for descendants) but its own verdict STAYS `retained_unfolded` —
+//! never `accepted` (B-2, the frozen convergence rule).
+
+use std::collections::{HashMap, HashSet, VecDeque};
+
+use rusqlite::{Transaction, params};
+
+use super::super::candidate::{self as account_candidate, Ancestry, HeaderView, UnknownCause};
+use super::super::cut::Cut;
+use super::super::envelope::{self, AccountEntryHeader};
+use super::super::fold::{SECRETS_LOG, SUPPORTED_OP_VERSION};
+use super::super::{
+    AccountId, AuthorityBoundary, AuthorityFreshness, AuthorityQuery, OwnerChainAuthority, storage,
+};
+use super::acceptance::{
+    self, AncestryRelation, CitedFreshness, SecretsAcceptance, SecretsAcceptanceInput,
+    SecretsParkReason, UnknownAncestry,
+};
+use super::candidate::{self, BranchPin, BranchSelection, SecretsCandidate, SecretsCoordinate};
+use super::ops::{self, DecodedSecretsOp};
+
+type EntryHash = [u8; 32];
+
+/// One log-1 candidate resolved against the current fold. A non-evaluable entry carries no facts —
+/// it is slot-eligible but its verdict is fixed at `retained_unfolded`.
+struct ResolvedSecretsEntry {
+    entry_hash: EntryHash,
+    header: AccountEntryHeader,
+    dense_predecessor_reachable: bool,
+    facts: Option<WrapFacts>,
+}
+
+impl ResolvedSecretsEntry {
+    /// A non-evaluable entry (`facts` absent) is slot-eligible but never accepted (B-2).
+    fn is_evaluable(&self) -> bool {
+        self.facts.is_some()
+    }
+}
+
+/// The authority facts for one evaluable `StreamKeyWrap`, all read from ONE fold snapshot.
+struct WrapFacts {
+    authority_ref: Option<EntryHash>,
+    owner_authority: AuthorityQuery<OwnerChainAuthority>,
+    ownership: AuthorityQuery<EntryHash>,
+    freshness: CitedFreshness,
+    /// The owning account's contested state (§12) — identical for every entry this refold.
+    contested: bool,
+}
+
+/// Which pass [`verdict_for`] runs.
+#[derive(Clone, Copy)]
+enum Phase {
+    /// The authority pass only: `Some` = decided pre-DAG (rejected/parked/condemned), `None` =
+    /// eligible to contest a slot.
+    Eligibility,
+    /// The whole predicate, including branch selection + freshness — always decides.
+    Finished,
+}
+
+/// Re-derive secrets-log acceptance for every candidate on `account_id`'s secrets chain from the
+/// CURRENT fold, overwriting `account_entry_status` + `accepted` and the caller's `statuses` map
+/// (§13/§15, S4). `accepted` was already cleared for the whole account by [`refold_in_tx`]; this
+/// pass re-sets `accepted = 1` for its winners (the `account_accepted_slot` index keys on `log_id`,
+/// so log-1 winners never collide with the control winners the main loop set).
+pub(in crate::account) fn refold_secrets_log(
+    tx: &Transaction<'_>,
+    account_id: AccountId,
+    statuses: &mut HashMap<EntryHash, String>,
+) -> anyhow::Result<()> {
+    let headers = load_secrets_headers(tx, account_id)?;
+    if headers.is_empty() {
+        return Ok(());
+    }
+    let view: HashMap<EntryHash, AccountEntryHeader> =
+        headers.iter().map(|(hash, header, _)| (*hash, header.clone())).collect();
+    let reachable = reachable_entries(&view);
+    let resolved = resolve_secrets_entries(tx, account_id, &headers, &reachable)?;
+
+    // Phase 1 — eligibility. A wrap the authority pass condemns or rejects must NOT compete for a
+    // dense seq slot; a non-evaluable entry is always slot-eligible (B-2), occupying its slot and
+    // extending the chain for its descendants.
+    let mut eligible = HashSet::new();
+    for r in &resolved {
+        if !r.is_evaluable() || verdict_for(r, &view, false, Phase::Eligibility)?.is_none() {
+            eligible.insert(r.entry_hash);
+        }
+    }
+
+    // Pins from BOTH secrets boundaries of each wrap's cited owner incarnation (B-1): the register
+    // decides which branch is real, not hash order.
+    let pins = branch_pins(&resolved);
+    let candidates: Vec<SecretsCandidate> = resolved
+        .iter()
+        .map(|r| SecretsCandidate { entry_hash: r.entry_hash, header: r.header.clone() })
+        .collect();
+    let selection = candidate::select_accepted_branch(&candidates, &eligible, &pins, &view);
+
+    // Phase 2 — the finished verdict, made prefix-closed, then the write. A non-evaluable winner is
+    // prefix-TRANSPARENT: it does not accept itself but does not break the accepted prefix for its
+    // descendants (B-2).
+    let mut raw: HashMap<EntryHash, SecretsAcceptance> = HashMap::new();
+    for r in &resolved {
+        if r.is_evaluable() {
+            let selected = selection.accepted.contains(&r.entry_hash);
+            raw.insert(
+                r.entry_hash,
+                verdict_for(r, &view, selected, Phase::Finished)?
+                    .expect("the finished evaluator always returns a verdict for a wrap"),
+            );
+        }
+    }
+    let accepted = prefix_closed_accepted(&resolved, &selection, &raw);
+    for r in &resolved {
+        // A non-evaluable entry keeps the main loop's `retained_unfolded` baseline (B-2) — its
+        // status is not one this pass owns.
+        let Some(verdict) = raw.get(&r.entry_hash).copied() else {
+            continue;
+        };
+        let hash = r.entry_hash;
+        let verdict = if accepted.contains(&hash) {
+            SecretsAcceptance::Accepted
+        } else if selection.forked.contains(&hash) {
+            SecretsAcceptance::Forked
+        } else {
+            match verdict {
+                // Selected + fresh, but truncated by a parked ancestor — parks on that ancestor
+                // catching up (S-a #1).
+                SecretsAcceptance::Accepted =>
+                    SecretsAcceptance::Parked(SecretsParkReason::AuthLenAhead),
+                // Eligible but stranded above an unselected parent — recoverable, not a terminal
+                // fork (S-a #2).
+                SecretsAcceptance::Forked =>
+                    SecretsAcceptance::Parked(SecretsParkReason::MissingPredecessor),
+                other => other,
+            }
+        };
+        write_secrets_verdict(tx, &hash, verdict, statuses)?;
+    }
+    Ok(())
+}
+
+/// Build the per-entry evaluator input from resolved facts and run the requested phase. `None`
+/// (from the eligibility phase) means the wrap is authorized and eligible to contest a slot. The
+/// ancestry closure walks `view`, so the input never outlives it. Only ever called for an evaluable
+/// wrap.
+fn verdict_for(
+    r: &ResolvedSecretsEntry,
+    view: &HashMap<EntryHash, AccountEntryHeader>,
+    branch_selected: bool,
+    phase: Phase,
+) -> anyhow::Result<Option<SecretsAcceptance>> {
+    let facts = r.facts.as_ref().expect("verdict_for is only called for evaluable wraps");
+    let input = SecretsAcceptanceInput {
+        account_id: facts.freshness.account_id,
+        entry_hash: r.entry_hash,
+        seq: r.header.seq,
+        authority_ref: facts.authority_ref,
+        owner_authority: facts.owner_authority,
+        ownership: facts.ownership,
+        asserted_auth_len: r.header.auth_len,
+        dense_predecessor_reachable: r.dense_predecessor_reachable,
+        branch_selected,
+        freshness: facts.freshness,
+        contested: facts.contested,
+        ancestry: |target: EntryHash, watermark: EntryHash| {
+            ancestry_relation(target, watermark, view)
+        },
+    };
+    let verdict = match phase {
+        Phase::Eligibility => acceptance::authority_verdict(&input),
+        Phase::Finished => acceptance::evaluate_secrets_acceptance(&input).map(Some),
+    };
+    verdict.map_err(|error| {
+        anyhow::anyhow!("secrets refold built inconsistent freshness provenance: {error:?}")
+    })
+}
+
+/// Read every candidate on the account's secrets chain, decoding the header + payload from the
+/// stored (already signature-verified) bytes. The refold re-derives authority, never re-verifies.
+fn load_secrets_headers(
+    tx: &Transaction<'_>,
+    account_id: AccountId,
+) -> anyhow::Result<Vec<(EntryHash, AccountEntryHeader, Vec<u8>)>> {
+    let mut stmt = tx.prepare(
+        "SELECT entry_hash, signed_bytes FROM account_entries
+         WHERE account_id = ?1 AND log_id = ?2
+         ORDER BY entry_hash", // deterministic load order (selection is order-free regardless)
+    )?;
+    let rows = stmt
+        .query_map(params![account_id.to_bytes().as_slice(), SECRETS_LOG], |row| {
+            Ok((row.get::<_, Vec<u8>>(0)?, row.get::<_, Vec<u8>>(1)?))
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    let mut out = Vec::with_capacity(rows.len());
+    for (entry_hash, signed_bytes) in rows {
+        let entry_hash = fixed::<32>(&entry_hash)?;
+        // A row stored outside `account_ingest` (or a corrupt blob) that no longer decodes / hashes
+        // to its key cannot belong to any valid chain — treat it as absent (it keeps the main
+        // loop's `retained_unfolded` baseline), rather than aborting the whole account fold
+        // on one bad row.
+        let Ok(signed) = envelope::decode_account_signed(&signed_bytes) else {
+            continue;
+        };
+        if signed.entry_hash != entry_hash {
+            continue;
+        }
+        out.push((entry_hash, signed.header, signed.payload));
+    }
+    Ok(out)
+}
+
+/// The entries whose dense secrets chain is fully held back to seq 0, in ONE O(n) forward pass from
+/// the chain roots (mirrors `content::storage::reachable_entries`). A secrets chain is dense per
+/// `(account, device)` on `log: SECRETS_LOG`.
+fn reachable_entries(view: &HashMap<EntryHash, AccountEntryHeader>) -> HashSet<EntryHash> {
+    let mut by_prev: HashMap<EntryHash, Vec<&EntryHash>> = HashMap::new();
+    let mut queue: VecDeque<&EntryHash> = VecDeque::new();
+    for (hash, header) in view {
+        match header.prev_hash {
+            None if header.seq == 0 => queue.push_back(hash),
+            None => {},
+            Some(prev) => by_prev.entry(prev).or_default().push(hash),
+        }
+    }
+    let mut reachable = HashSet::new();
+    while let Some(hash) = queue.pop_front() {
+        if !reachable.insert(*hash) {
+            continue;
+        }
+        let parent = &view[hash];
+        let Some(children) = by_prev.get(hash) else {
+            continue;
+        };
+        for child_hash in children {
+            let child = &view[*child_hash];
+            // Contiguous + same coordinate (a link that skips a slot or jumps chain is not a real
+            // predecessor). `seq` is peer-supplied, so guard `+ 1` against a `u64::MAX` row.
+            if parent.seq.checked_add(1) == Some(child.seq)
+                && child.account_id == parent.account_id
+                && child.device_fingerprint == parent.device_fingerprint
+            {
+                queue.push_back(child_hash);
+            }
+        }
+    }
+    reachable
+}
+
+/// Resolve every log-1 candidate's authority facts against the current fold. A non-evaluable entry
+/// (unknown tag / future version / sealed) resolves NO facts — it is slot-eligible, never
+/// evaluated.
+fn resolve_secrets_entries(
+    tx: &Transaction<'_>,
+    account_id: AccountId,
+    headers: &[(EntryHash, AccountEntryHeader, Vec<u8>)],
+    reachable: &HashSet<EntryHash>,
+) -> anyhow::Result<Vec<ResolvedSecretsEntry>> {
+    // The account's contested state is the same for every entry — read it once (§12).
+    let contested = storage::account_is_contested(tx, account_id)?;
+    let mut caches = Caches::default();
+    let mut resolved = Vec::with_capacity(headers.len());
+    for (entry_hash, header, payload) in headers {
+        let facts = wrap_facts(tx, account_id, header, payload, contested, &mut caches)?;
+        resolved.push(ResolvedSecretsEntry {
+            entry_hash: *entry_hash,
+            header: header.clone(),
+            dense_predecessor_reachable: reachable.contains(entry_hash),
+            facts,
+        });
+    }
+    Ok(resolved)
+}
+
+/// Per-refold memoization of the authority facts, scoped to this snapshot — a chain of many wraps
+/// sharing one owner incarnation resolves each fact once.
+#[derive(Default)]
+struct Caches {
+    owner: HashMap<(EntryHash, crate::op::DeviceFingerprint), AuthorityQuery<OwnerChainAuthority>>,
+    ownership: HashMap<crate::stream::StreamId, AuthorityQuery<EntryHash>>,
+    freshness: HashMap<u64, AuthorityFreshness>,
+}
+
+/// Resolve one entry to its `WrapFacts` — `None` when the entry is NOT an evaluable `StreamKeyWrap`
+/// (unknown tag, future `op_version`, or sealed `crypto_suite != 0`), which makes it slot-eligible.
+fn wrap_facts(
+    tx: &Transaction<'_>,
+    account_id: AccountId,
+    header: &AccountEntryHeader,
+    payload: &[u8],
+    contested: bool,
+    caches: &mut Caches,
+) -> anyhow::Result<Option<WrapFacts>> {
+    // Evaluable ⇔ a KNOWN secrets op at the supported version with a plaintext payload — mirrors
+    // the control fold's `foldable` gate. Everything else is slot-eligible (B-2).
+    if header.op_version != SUPPORTED_OP_VERSION || header.crypto_suite != 0 {
+        return Ok(None);
+    }
+    let stream_id = match ops::decode(header.entry_type, payload) {
+        Ok(DecodedSecretsOp::Known(wrap)) => wrap.stream_id,
+        Ok(DecodedSecretsOp::Unknown { .. }) | Err(_) => return Ok(None),
+    };
+    let owner_authority = match header.authority_ref {
+        Some(owner_id) => {
+            let key = (owner_id, header.device_fingerprint);
+            match caches.owner.get(&key) {
+                Some(cached) => *cached,
+                None => {
+                    let resolved = storage::owner_secrets_authority_in_snapshot(
+                        tx,
+                        account_id,
+                        owner_id,
+                        header.device_fingerprint,
+                    )?;
+                    caches.owner.insert(key, resolved);
+                    resolved
+                },
+            }
+        },
+        // A null authority_ref is rejected by the evaluator on its own check; the owner value is
+        // unused, so a placeholder Unknown is correct.
+        None => AuthorityQuery::Unknown,
+    };
+    let ownership = match caches.ownership.get(&stream_id) {
+        Some(cached) => *cached,
+        None => {
+            let resolved = storage::stream_owner_effective_in_snapshot(tx, account_id, stream_id)?;
+            caches.ownership.insert(stream_id, resolved);
+            resolved
+        },
+    };
+    let state = match caches.freshness.get(&header.auth_len) {
+        Some(cached) => *cached,
+        None => {
+            let state = storage::auth_len_freshness(tx, account_id, header.auth_len)?;
+            caches.freshness.insert(header.auth_len, state);
+            state
+        },
+    };
+    Ok(Some(WrapFacts {
+        authority_ref: header.authority_ref,
+        owner_authority,
+        ownership,
+        freshness: CitedFreshness { account_id, asserted_auth_len: header.auth_len, state },
+        contested,
+    }))
+}
+
+/// The register watermarks pinning a branch: BOTH secrets boundaries of each wrap's cited owner
+/// incarnation (device register + owner-incarnation register), keyed to the wrap's `(account,
+/// device)` secrets coordinate. `pinned_branch` re-validates each against its coordinate, so
+/// over-collecting is safe.
+fn branch_pins(resolved: &[ResolvedSecretsEntry]) -> Vec<BranchPin> {
+    let mut pins = Vec::new();
+    for r in resolved {
+        let Some(facts) = &r.facts else {
+            continue;
+        };
+        let AuthorityQuery::Effective(owner) = facts.owner_authority else {
+            continue;
+        };
+        let coordinate = SecretsCoordinate {
+            account_id: r.header.account_id,
+            device_fingerprint: r.header.device_fingerprint,
+        };
+        for boundary in [owner.device_boundary, owner.incarnation_boundary] {
+            if let AuthorityBoundary::Cut { seq, hash } = boundary {
+                pins.push(BranchPin { coordinate, seq, watermark: hash });
+            }
+        }
+    }
+    pins
+}
+
+/// Narrow the branch-selected winners to a contiguous accepted prefix per coordinate. A
+/// non-evaluable selected winner is prefix-TRANSPARENT (it does not accept itself but does not
+/// break the prefix for its descendants — B-2); an evaluable winner whose finished verdict is not
+/// `Accepted` breaks it.
+fn prefix_closed_accepted(
+    resolved: &[ResolvedSecretsEntry],
+    selection: &BranchSelection,
+    raw: &HashMap<EntryHash, SecretsAcceptance>,
+) -> HashSet<EntryHash> {
+    let mut chains: HashMap<SecretsCoordinate, Vec<(u64, EntryHash, bool)>> = HashMap::new();
+    for r in resolved {
+        if selection.accepted.contains(&r.entry_hash) {
+            let coordinate = SecretsCoordinate {
+                account_id: r.header.account_id,
+                device_fingerprint: r.header.device_fingerprint,
+            };
+            chains.entry(coordinate).or_default().push((
+                r.header.seq,
+                r.entry_hash,
+                r.is_evaluable(),
+            ));
+        }
+    }
+    let mut accepted = HashSet::new();
+    for mut winners in chains.into_values() {
+        winners.sort_by_key(|(seq, _, _)| *seq);
+        for (_, hash, evaluable) in winners {
+            if !evaluable {
+                continue; // a slot-eligible winner is transparent — never accepted, never a break
+            }
+            if raw.get(&hash) == Some(&SecretsAcceptance::Accepted) {
+                accepted.insert(hash);
+            } else {
+                break; // prefix broken: every later winner on this chain is not accepted
+            }
+        }
+    }
+    accepted
+}
+
+/// Write one wrap's verdict: the `(status, detail)` pair (§16.3), `accepted = 1` only for
+/// `Accepted`, and OVERWRITE the caller's status map (S4).
+fn write_secrets_verdict(
+    tx: &Transaction<'_>,
+    entry_hash: &EntryHash,
+    verdict: SecretsAcceptance,
+    statuses: &mut HashMap<EntryHash, String>,
+) -> rusqlite::Result<()> {
+    let (status, detail) = verdict.as_db_pair();
+    tx.execute(
+        "INSERT INTO account_entry_status(entry_hash, status, detail) VALUES (?1, ?2, ?3)
+         ON CONFLICT(entry_hash) DO UPDATE SET status = excluded.status, detail = excluded.detail",
+        params![entry_hash.as_slice(), status, detail],
+    )?;
+    if verdict == SecretsAcceptance::Accepted {
+        tx.execute("UPDATE account_entries SET accepted = 1 WHERE entry_hash = ?1", [
+            entry_hash.as_slice()
+        ])?;
+    }
+    statuses.insert(*entry_hash, status.to_string());
+    Ok(())
+}
+
+/// Map the account-log ancestry verdict into the evaluator's `AncestryRelation` (both name a
+/// withheld watermark and a missing mid-chain link apart — I11).
+fn ancestry_relation(
+    target: EntryHash,
+    watermark: EntryHash,
+    view: &dyn HeaderView,
+) -> AncestryRelation {
+    // The seq is unused by the ancestry walk (it follows `prev_hash` from the watermark hash), so a
+    // placeholder 0 is correct here.
+    match account_candidate::ancestry(&target, &Cut::At { seq: 0, hash: watermark }, view) {
+        Ancestry::OnBranch => AncestryRelation::OnBranch,
+        Ancestry::OffBranch => AncestryRelation::OffBranch,
+        Ancestry::Unknown(UnknownCause::UnknownCutTarget) =>
+            AncestryRelation::Unknown(UnknownAncestry::UnknownCutTarget),
+        Ancestry::Unknown(UnknownCause::IncompleteCutAncestry) =>
+            AncestryRelation::Unknown(UnknownAncestry::IncompleteCutAncestry),
+    }
+}
+
+fn fixed<const N: usize>(bytes: &[u8]) -> anyhow::Result<[u8; N]> {
+    bytes.try_into().map_err(|_| anyhow::anyhow!("stored blob is {} bytes, not {N}", bytes.len()))
+}
+
+#[cfg(test)]
+mod tests {
+    use minicbor::Encoder;
+    use rag_rat_db::schema;
+    use rusqlite::Connection;
+
+    use super::super::ops::{StreamKeyWrap, WrapEntry, entry_type as secrets_entry_type};
+    use super::*;
+    use crate::account::envelope::sign_account_entry;
+    use crate::account::id::account_id_from_genesis_payload;
+    use crate::account::keywrap::{ContentKey, WrapContext, seal_content_key};
+    use crate::account::ops::{self as control_ops, AccountOp, DeviceRole};
+    use crate::account::storage::{IngestOutcome, account_ingest, entry_status};
+    use crate::device::{DeviceSecret, DeviceX25519Public, DeviceX25519Secret};
+    use crate::op::DeviceFingerprint;
+    use crate::stream::{self, StreamId, StreamSpec, StreamSpecV2};
+
+    const NOW: i64 = 1_700_000_000_000;
+
+    fn db() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        schema::apply(&conn, &crate::test_hooks()).unwrap();
+        conn
+    }
+
+    struct Dev {
+        secret: DeviceSecret,
+        fp: DeviceFingerprint,
+        ed: [u8; 32],
+        x: [u8; 32],
+    }
+
+    impl Dev {
+        fn new(seed: u8) -> Self {
+            let secret = DeviceSecret::from_seed(&[seed; 32]);
+            let public = secret.public();
+            let x =
+                DeviceX25519Secret::from_seed(&[seed.wrapping_add(0x80); 32]).public().to_bytes();
+            Dev { fp: public.fingerprint(), ed: public.to_bytes(), x, secret }
+        }
+    }
+
+    fn genesis(founder: &Dev) -> (AccountId, Vec<u8>, [u8; 32]) {
+        let op = AccountOp::AccountGenesis {
+            ed25519_pubkey: founder.ed,
+            x25519_pubkey: founder.x,
+            nonce16: [0u8; 16],
+            created_at_ms: NOW as u64,
+            label: None,
+        };
+        let payload = control_ops::encode(&op).unwrap();
+        let account_id = account_id_from_genesis_payload(&payload);
+        let header = AccountEntryHeader {
+            account_id,
+            log_id: super::super::super::fold::CONTROL_LOG,
+            device_fingerprint: founder.fp,
+            seq: 0,
+            prev_hash: None,
+            parent_ref: None,
+            entry_type: control_ops::entry_type::ACCOUNT_GENESIS,
+            op_version: 1,
+            crypto_suite: 0,
+            auth_len: 0,
+            key_id: None,
+            authority_ref: None,
+        };
+        let signed = sign_account_entry(&founder.secret, &header, &payload).unwrap();
+        (account_id, signed.signed_bytes, signed.entry_hash)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn control_op(
+        account: AccountId,
+        signer: &Dev,
+        seq: u64,
+        prev: Option<[u8; 32]>,
+        authority_ref: Option<[u8; 32]>,
+        op: &AccountOp,
+    ) -> (Vec<u8>, [u8; 32]) {
+        let payload = control_ops::encode(op).unwrap();
+        let header = AccountEntryHeader {
+            account_id: account,
+            log_id: super::super::super::fold::CONTROL_LOG,
+            device_fingerprint: signer.fp,
+            seq,
+            prev_hash: prev,
+            parent_ref: None,
+            entry_type: control_ops::entry_type_of(op),
+            op_version: 1,
+            crypto_suite: 0,
+            auth_len: 1,
+            key_id: None,
+            authority_ref,
+        };
+        let signed = sign_account_entry(&signer.secret, &header, &payload).unwrap();
+        (signed.signed_bytes, signed.entry_hash)
+    }
+
+    fn stream_own(account: AccountId) -> (StreamId, AccountOp) {
+        let spec = StreamSpecV2 {
+            owner_account_id: account,
+            policy: StreamSpec {
+                repo_set: vec!["repo-a".to_string()],
+                kind_allow_list: None,
+                relation_policy: None,
+                node_overrides: Vec::new(),
+            },
+        };
+        let stream_id = stream::derive_v2(&spec).unwrap();
+        let stream_spec_bytes = stream::canonical_spec_v2_bytes(&spec).unwrap();
+        (stream_id, AccountOp::StreamOwn { stream_id, stream_spec_bytes })
+    }
+
+    /// Build a `StreamKeyWrap` op sealing a seed-derived content key to `recipient`.
+    fn wrap_op(
+        account: AccountId,
+        stream_id: StreamId,
+        recipient: &Dev,
+        seed: u8,
+    ) -> StreamKeyWrap {
+        let key = ContentKey::from_seed(&[seed; 32]);
+        let recipient_pub = DeviceX25519Public::from_bytes(&recipient.x).unwrap();
+        let ctx = WrapContext {
+            account_id: account.to_bytes(),
+            stream_id: stream_id.to_bytes(),
+            key_epoch: 0,
+            recipient_pub: recipient.x,
+        };
+        let sealed = seal_content_key(&key, &ctx, &recipient_pub).unwrap();
+        StreamKeyWrap {
+            stream_id,
+            key_id: key.key_id().to_bytes(),
+            key_epoch: 0,
+            wraps: vec![WrapEntry { recipient_fp: recipient.fp, sealed }],
+        }
+    }
+
+    /// Author a signed secrets-log (`log_id = 1`) `StreamKeyWrap` entry.
+    #[allow(clippy::too_many_arguments)]
+    fn wrap_entry(
+        account: AccountId,
+        signer: &Dev,
+        seq: u64,
+        prev: Option<[u8; 32]>,
+        authority_ref: Option<[u8; 32]>,
+        wrap: &StreamKeyWrap,
+    ) -> (Vec<u8>, [u8; 32]) {
+        let payload = super::super::ops::encode(wrap).unwrap();
+        secrets_entry(
+            account,
+            signer,
+            seq,
+            prev,
+            authority_ref,
+            secrets_entry_type::STREAM_KEY_WRAP,
+            &payload,
+        )
+    }
+
+    /// Author a signed secrets-log entry with an arbitrary `entry_type` + payload.
+    #[allow(clippy::too_many_arguments)]
+    fn secrets_entry(
+        account: AccountId,
+        signer: &Dev,
+        seq: u64,
+        prev: Option<[u8; 32]>,
+        authority_ref: Option<[u8; 32]>,
+        entry_type: u32,
+        payload: &[u8],
+    ) -> (Vec<u8>, [u8; 32]) {
+        let header = AccountEntryHeader {
+            account_id: account,
+            log_id: SECRETS_LOG,
+            device_fingerprint: signer.fp,
+            seq,
+            prev_hash: prev,
+            parent_ref: Some([0u8; 32]),
+            entry_type,
+            op_version: 1,
+            crypto_suite: 0,
+            auth_len: 0,
+            key_id: None,
+            authority_ref,
+        };
+        let signed = sign_account_entry(&signer.secret, &header, payload).unwrap();
+        (signed.signed_bytes, signed.entry_hash)
+    }
+
+    fn ingest(conn: &Connection, bytes: &[u8]) -> IngestOutcome {
+        account_ingest(conn, bytes, NOW).unwrap()
+    }
+
+    fn status(conn: &Connection, hash: &[u8; 32]) -> (String, Option<String>) {
+        entry_status(conn, hash).unwrap().expect("entry is stored")
+    }
+
+    fn accepted_flag(conn: &Connection, hash: &[u8; 32]) -> i64 {
+        conn.query_row(
+            "SELECT accepted FROM account_entries WHERE entry_hash = ?1",
+            [hash.as_slice()],
+            |row| row.get(0),
+        )
+        .unwrap()
+    }
+
+    /// genesis(A) + StreamOwn(A) → the account, the founder owner-incarnation id (= genesis hash),
+    /// and the owned stream.
+    fn account_with_owned_stream(conn: &Connection) -> (AccountId, Dev, [u8; 32], StreamId) {
+        let founder = Dev::new(1);
+        let (account, genesis_bytes, genesis_hash) = genesis(&founder);
+        ingest(conn, &genesis_bytes);
+        let (stream_id, own) = stream_own(account);
+        let (own_bytes, _) =
+            control_op(account, &founder, 1, Some(genesis_hash), Some(genesis_hash), &own);
+        ingest(conn, &own_bytes);
+        (account, founder, genesis_hash, stream_id)
+    }
+
+    #[test]
+    fn a_fresh_owner_wrap_accepts_and_ingest_reports_accepted() {
+        let conn = db();
+        let (account, founder, genesis_hash, stream_id) = account_with_owned_stream(&conn);
+        let wrap = wrap_op(account, stream_id, &founder, 0x20);
+        let (bytes, hash) = wrap_entry(account, &founder, 0, None, Some(genesis_hash), &wrap);
+        // S4: the ingest-returned status is the secrets pass's verdict, not the `retained_unfolded`
+        // baseline the main loop wrote.
+        let outcome = ingest(&conn, &bytes);
+        assert_eq!(outcome, IngestOutcome::Ingested { status: "accepted".to_string() });
+        assert_eq!(status(&conn, &hash), ("accepted".to_string(), None));
+        assert_eq!(accepted_flag(&conn, &hash), 1);
+    }
+
+    #[test]
+    fn a_non_owner_wrap_is_rejected_by_the_owner_only_gate() {
+        let conn = db();
+        let founder = Dev::new(1);
+        let (account, genesis_bytes, genesis_hash) = genesis(&founder);
+        ingest(&conn, &genesis_bytes);
+        // A member device, added to the roster (so it is signature-resolvable).
+        let member = Dev::new(2);
+        let add = AccountOp::DeviceAdd {
+            device_fingerprint: member.fp,
+            ed25519_pubkey: member.ed,
+            x25519_pubkey: member.x,
+            role: DeviceRole::Member,
+            label: None,
+        };
+        let (add_bytes, _) =
+            control_op(account, &founder, 1, Some(genesis_hash), Some(genesis_hash), &add);
+        ingest(&conn, &add_bytes);
+        let (stream_id, own) = stream_own(account);
+        let (own_bytes, _) =
+            control_op(account, &founder, 2, Some(genesis_hash), Some(genesis_hash), &own);
+        ingest(&conn, &own_bytes);
+        // The member signs a wrap citing the founder's owner incarnation — a device mismatch, so
+        // the owner-only gate rejects it (WrongSubject → invalid_owner).
+        let wrap = wrap_op(account, stream_id, &member, 0x20);
+        let (bytes, hash) = wrap_entry(account, &member, 0, None, Some(genesis_hash), &wrap);
+        assert_eq!(ingest(&conn, &bytes), IngestOutcome::Ingested {
+            status: "rejected".to_string()
+        });
+        assert_eq!(
+            status(&conn, &hash),
+            ("rejected".to_string(), Some("invalid_owner".to_string()))
+        );
+        assert_eq!(accepted_flag(&conn, &hash), 0);
+    }
+
+    #[test]
+    fn a_null_authority_ref_wrap_is_rejected() {
+        let conn = db();
+        let (account, founder, _genesis_hash, stream_id) = account_with_owned_stream(&conn);
+        let wrap = wrap_op(account, stream_id, &founder, 0x20);
+        let (bytes, hash) = wrap_entry(account, &founder, 0, None, None, &wrap);
+        ingest(&conn, &bytes);
+        assert_eq!(
+            status(&conn, &hash),
+            ("rejected".to_string(), Some("invalid_owner".to_string()))
+        );
+    }
+
+    #[test]
+    fn a_wrap_before_its_stream_own_parks_then_accepts_when_ownership_folds() {
+        let conn = db();
+        let founder = Dev::new(1);
+        let (account, genesis_bytes, genesis_hash) = genesis(&founder);
+        ingest(&conn, &genesis_bytes);
+        let (stream_id, own) = stream_own(account);
+        // The wrap arrives BEFORE the StreamOwn: the account does not yet own the stream, so it
+        // parks (recoverable), never rejects (§14).
+        let wrap = wrap_op(account, stream_id, &founder, 0x20);
+        let (bytes, hash) = wrap_entry(account, &founder, 0, None, Some(genesis_hash), &wrap);
+        ingest(&conn, &bytes);
+        assert_eq!(
+            status(&conn, &hash),
+            ("parked".to_string(), Some("unknown_account".to_string()))
+        );
+        // The StreamOwn folds in the same account → the secrets pass re-classifies the wrap as
+        // accepted in that same refold (the account→content retro-trigger analog).
+        let (own_bytes, _) =
+            control_op(account, &founder, 1, Some(genesis_hash), Some(genesis_hash), &own);
+        ingest(&conn, &own_bytes);
+        assert_eq!(status(&conn, &hash), ("accepted".to_string(), None));
+        assert_eq!(accepted_flag(&conn, &hash), 1);
+    }
+
+    #[test]
+    fn an_unsorted_or_undecodable_wrap_payload_is_structurally_rejected_at_ingest() {
+        let conn = db();
+        let (account, founder, genesis_hash, _stream_id) = account_with_owned_stream(&conn);
+        // A hand-built payload whose wrapped_key is not a SealedKeyWrap — the secrets twin decodes
+        // it at ingest and rejects, so it is NEVER stored.
+        let mut payload = Vec::new();
+        {
+            let mut enc = Encoder::new(&mut payload);
+            enc.array(4).unwrap();
+            enc.bytes(&[9; 32]).unwrap();
+            enc.bytes(&[8; 32]).unwrap();
+            enc.u64(0).unwrap();
+            enc.array(1).unwrap();
+            enc.array(2).unwrap();
+            enc.bytes(&[0x10; 32]).unwrap();
+            enc.bytes(&[0xde, 0xad]).unwrap();
+        }
+        let (bytes, hash) = secrets_entry(
+            account,
+            &founder,
+            0,
+            None,
+            Some(genesis_hash),
+            secrets_entry_type::STREAM_KEY_WRAP,
+            &payload,
+        );
+        assert!(
+            matches!(ingest(&conn, &bytes), IngestOutcome::Rejected(_)),
+            "twin rejects at ingest"
+        );
+        assert!(entry_status(&conn, &hash).unwrap().is_none(), "a rejected entry is not stored");
+    }
+
+    #[test]
+    fn a_slot_eligible_unknown_tag_is_transparent_and_chained_wraps_accept() {
+        // B-2: [wrap@0, unknown-tag@1, wrap@2] → both wraps accepted, the middle retained_unfolded.
+        let conn = db();
+        let (account, founder, genesis_hash, stream_id) = account_with_owned_stream(&conn);
+        let wrap0 = wrap_op(account, stream_id, &founder, 0x20);
+        let (w0_bytes, w0) = wrap_entry(account, &founder, 0, None, Some(genesis_hash), &wrap0);
+        ingest(&conn, &w0_bytes);
+        // An unknown secrets tag with a canonical (empty-array) payload: storable, slot-eligible.
+        let mut unknown_payload = Vec::new();
+        Encoder::new(&mut unknown_payload).array(0).unwrap();
+        let (u_bytes, u1) =
+            secrets_entry(account, &founder, 1, Some(w0), Some(genesis_hash), 99, &unknown_payload);
+        ingest(&conn, &u_bytes);
+        let wrap2 = wrap_op(account, stream_id, &founder, 0x21);
+        let (w2_bytes, w2) = wrap_entry(account, &founder, 2, Some(u1), Some(genesis_hash), &wrap2);
+        ingest(&conn, &w2_bytes);
+
+        assert_eq!(status(&conn, &w0), ("accepted".to_string(), None), "wrap@0 accepts");
+        assert_eq!(
+            status(&conn, &u1),
+            ("retained_unfolded".to_string(), None),
+            "the unknown tag is slot-eligible but never accepted (B-2)",
+        );
+        assert_eq!(accepted_flag(&conn, &u1), 0, "a slot-eligible entry is never accepted");
+        assert_eq!(
+            status(&conn, &w2),
+            ("accepted".to_string(), None),
+            "the wrap chained PAST the unknown tag still accepts (slot-eligible is transparent)",
+        );
+    }
+
+    #[test]
+    fn multiple_wrap_ops_for_one_stream_and_key_all_accept() {
+        // A dense chain of wraps for the same (stream, key_id) — the SET resolution, never LWW.
+        let conn = db();
+        let (account, founder, genesis_hash, stream_id) = account_with_owned_stream(&conn);
+        let mut prev = None;
+        let mut hashes = Vec::new();
+        for (seq, seed) in [(0u64, 0x20u8), (1, 0x21), (2, 0x22)] {
+            let wrap = wrap_op(account, stream_id, &founder, seed);
+            let (bytes, hash) = wrap_entry(account, &founder, seq, prev, Some(genesis_hash), &wrap);
+            ingest(&conn, &bytes);
+            prev = Some(hash);
+            hashes.push(hash);
+        }
+        for hash in hashes {
+            assert_eq!(
+                status(&conn, &hash),
+                ("accepted".to_string(), None),
+                "every wrap op accepts"
+            );
+        }
+    }
+
+    /// genesis(A owner) + DeviceAdd(B owner) + StreamOwn(A) → the account, both devices, B's owner
+    /// incarnation id, the owned stream, and the StreamOwn hash (the control tail a later demote
+    /// chains from). A's control chain: genesis(0) ← DeviceAdd(1) ← StreamOwn(2).
+    fn account_with_second_owner(
+        conn: &Connection,
+    ) -> (AccountId, Dev, Dev, [u8; 32], StreamId, [u8; 32]) {
+        let founder = Dev::new(1);
+        let (account, genesis_bytes, genesis_hash) = genesis(&founder);
+        ingest(conn, &genesis_bytes);
+        let owner_b = Dev::new(2);
+        let add = AccountOp::DeviceAdd {
+            device_fingerprint: owner_b.fp,
+            ed25519_pubkey: owner_b.ed,
+            x25519_pubkey: owner_b.x,
+            role: DeviceRole::Owner,
+            label: None,
+        };
+        let (add_bytes, owner_id_b) =
+            control_op(account, &founder, 1, Some(genesis_hash), Some(genesis_hash), &add);
+        ingest(conn, &add_bytes);
+        let (stream_id, own) = stream_own(account);
+        let (own_bytes, own_hash) =
+            control_op(account, &founder, 2, Some(owner_id_b), Some(genesis_hash), &own);
+        ingest(conn, &own_bytes);
+        (account, founder, owner_b, owner_id_b, stream_id, own_hash)
+    }
+
+    #[test]
+    fn a_later_owner_demote_secrets_cut_retro_condemns_a_beyond_cut_wrap() {
+        let conn = db();
+        let (account, founder, owner_b, owner_id_b, stream_id, own_hash) =
+            account_with_second_owner(&conn);
+        // B authors two wraps on its secrets chain; both accept while B is a live owner.
+        let w0op = wrap_op(account, stream_id, &owner_b, 0x30);
+        let (w0_bytes, w0) = wrap_entry(account, &owner_b, 0, None, Some(owner_id_b), &w0op);
+        ingest(&conn, &w0_bytes);
+        let w1op = wrap_op(account, stream_id, &owner_b, 0x31);
+        let (w1_bytes, w1) = wrap_entry(account, &owner_b, 1, Some(w0), Some(owner_id_b), &w1op);
+        ingest(&conn, &w1_bytes);
+        assert_eq!(status(&conn, &w0), ("accepted".to_string(), None), "wrap@0 accepts pre-cut");
+        assert_eq!(status(&conn, &w1), ("accepted".to_string(), None), "wrap@1 accepts pre-cut");
+
+        // A demotes B, bounding B's secrets incarnation at seq 0 (h0). The cut retro-condemns the
+        // beyond-cut wrap@1 in the SAME refold — wrap@0 (within the cut, on-branch) stays accepted.
+        let demote = AccountOp::OwnerDemote {
+            device_fingerprint: owner_b.fp,
+            owner_id: owner_id_b,
+            control_cut: super::super::super::cut::Cut::Empty,
+            secrets_cut: super::super::super::cut::Cut::At { seq: 0, hash: w0 },
+            reason: "demote".to_string(),
+        };
+        let genesis_hash = owner_id_of_founder(&conn, account);
+        let (demote_bytes, _) =
+            control_op(account, &founder, 3, Some(own_hash), Some(genesis_hash), &demote);
+        ingest(&conn, &demote_bytes);
+        assert_eq!(
+            status(&conn, &w0),
+            ("accepted".to_string(), None),
+            "the within-cut wrap stays accepted",
+        );
+        assert_eq!(
+            status(&conn, &w1),
+            ("condemned".to_string(), Some("beyond_cut".to_string())),
+            "the beyond-cut wrap is retro-condemned in the same refold",
+        );
+        assert_eq!(accepted_flag(&conn, &w1), 0);
+    }
+
+    #[test]
+    fn equivocation_below_a_secrets_cut_condemns_the_attacker_fork_off_branch() {
+        // B-1: B equivocates its secrets chain below a demotion cut; the cut names the honest
+        // branch, so the honest on-watermark wraps accept and the attacker fork is
+        // condemned off_branch.
+        let conn = db();
+        let (account, founder, owner_b, owner_id_b, stream_id, own_hash) =
+            account_with_second_owner(&conn);
+        let w0op = wrap_op(account, stream_id, &owner_b, 0x30);
+        let (w0_bytes, w0) = wrap_entry(account, &owner_b, 0, None, Some(owner_id_b), &w0op);
+        ingest(&conn, &w0_bytes);
+        // Two DIFFERENT seq-1 entries off w0 — an equivocation with distinct payloads (distinct
+        // hashes).
+        let honest_op = wrap_op(account, stream_id, &owner_b, 0x31);
+        let (honest_bytes, honest) =
+            wrap_entry(account, &owner_b, 1, Some(w0), Some(owner_id_b), &honest_op);
+        ingest(&conn, &honest_bytes);
+        let attacker_op = wrap_op(account, stream_id, &owner_b, 0x41);
+        let (attacker_bytes, attacker) =
+            wrap_entry(account, &owner_b, 1, Some(w0), Some(owner_id_b), &attacker_op);
+        ingest(&conn, &attacker_bytes);
+
+        // A demotes B with a secrets cut naming the HONEST seq-1 head. The register pins the honest
+        // branch; the attacker fork is off it.
+        let genesis_hash = owner_id_of_founder(&conn, account);
+        let demote = AccountOp::OwnerDemote {
+            device_fingerprint: owner_b.fp,
+            owner_id: owner_id_b,
+            control_cut: super::super::super::cut::Cut::Empty,
+            secrets_cut: super::super::super::cut::Cut::At { seq: 1, hash: honest },
+            reason: "demote".to_string(),
+        };
+        let (demote_bytes, _) =
+            control_op(account, &founder, 3, Some(own_hash), Some(genesis_hash), &demote);
+        ingest(&conn, &demote_bytes);
+
+        assert_eq!(status(&conn, &w0), ("accepted".to_string(), None), "the shared root accepts");
+        assert_eq!(
+            status(&conn, &honest),
+            ("accepted".to_string(), None),
+            "the honest on-watermark wrap accepts",
+        );
+        assert_eq!(
+            status(&conn, &attacker),
+            ("condemned".to_string(), Some("off_branch".to_string())),
+            "the equivocated-below-cut attacker fork is condemned off_branch",
+        );
+        assert_eq!(accepted_flag(&conn, &attacker), 0);
+    }
+
+    /// The founder's owner incarnation id is the genesis entry hash (§ the founder's origin slot).
+    fn owner_id_of_founder(conn: &Connection, account: AccountId) -> [u8; 32] {
+        conn.query_row(
+            "SELECT entry_hash FROM account_entries
+             WHERE account_id = ?1 AND entry_type = ?2 AND log_id = ?3",
+            rusqlite::params![
+                account.to_bytes().as_slice(),
+                control_ops::entry_type::ACCOUNT_GENESIS,
+                super::super::super::fold::CONTROL_LOG,
+            ],
+            |row| row.get::<_, Vec<u8>>(0),
+        )
+        .map(|bytes| fixed::<32>(&bytes).unwrap())
+        .unwrap()
+    }
+}

--- a/crates/rag-rat-oplog/src/account/storage.rs
+++ b/crates/rag-rat-oplog/src/account/storage.rs
@@ -16,7 +16,7 @@ use rusqlite::{Connection, OptionalExtension, Transaction, TransactionBehavior, 
 use super::envelope::{self, AccountEntryHeader, VerifiedAccountEntry};
 use super::id::account_id_from_genesis_payload;
 use super::ops::{self, AccountOp, DecodedAccountOp, DeviceCut, DeviceRole, GrantRole};
-use super::{AccountId, content, fold};
+use super::{AccountId, content, fold, secrets};
 use crate::cbor;
 use crate::device::DevicePublic;
 use crate::op::DeviceFingerprint;
@@ -426,6 +426,19 @@ pub fn owner_secrets_authority(
     owner_chain_authority(conn, account_id, owner_id, device_fingerprint, "secrets")
 }
 
+/// The body of [`owner_secrets_authority`], reading whatever snapshot `conn` is already in — the
+/// secrets refold (C4.2b) resolves every wrap's owner-incarnation authority inside its own txn and
+/// cannot call the wrapper above, which would try to `BEGIN` a second one (S1; mirrors
+/// [`stream_owner_effective_in_snapshot`]).
+pub fn owner_secrets_authority_in_snapshot(
+    conn: &Connection,
+    account_id: AccountId,
+    owner_id: EntryHash,
+    device_fingerprint: DeviceFingerprint,
+) -> anyhow::Result<fold::AuthorityQuery<fold::OwnerChainAuthority>> {
+    owner_chain_authority_in_snapshot(conn, account_id, owner_id, device_fingerprint, "secrets")
+}
+
 fn owner_chain_authority(
     conn: &Connection,
     account_id: AccountId,
@@ -434,7 +447,17 @@ fn owner_chain_authority(
     chain: &str,
 ) -> anyhow::Result<fold::AuthorityQuery<fold::OwnerChainAuthority>> {
     let read_tx = Transaction::new_unchecked(conn, TransactionBehavior::Deferred)?;
-    let conn: &Connection = &read_tx;
+    owner_chain_authority_in_snapshot(&read_tx, account_id, owner_id, device_fingerprint, chain)
+}
+
+/// The body of [`owner_chain_authority`], reading whatever snapshot `conn` is already in.
+fn owner_chain_authority_in_snapshot(
+    conn: &Connection,
+    account_id: AccountId,
+    owner_id: EntryHash,
+    device_fingerprint: DeviceFingerprint,
+    chain: &str,
+) -> anyhow::Result<fold::AuthorityQuery<fold::OwnerChainAuthority>> {
     let sql = format!(
         "SELECT o.device_fingerprint, o.effective_at, o.closed_at,
                 o.{chain}_boundary, o.{chain}_seq, o.{chain}_hash,
@@ -940,6 +963,13 @@ pub(super) fn refold_in_tx(
         statuses.insert(row.entry_hash, status);
     }
     rewrite_authority_projection(tx, account_id, &projection.history)?;
+    // Re-derive secrets-log (log 1) acceptance from the just-rewritten authority projection, in
+    // this SAME txn (§15, C4.2b). The main loop above wrote `retained_unfolded` for every log-1
+    // row (the declassify baseline); this pass OVERWRITES that — in both `account_entry_status`
+    // and the returned `statuses` map (S4) — for the wraps it classifies. Same-txn placement is
+    // what makes a control fold that condemns a device's secrets chain retro-condemn its wraps
+    // atomically.
+    super::secrets::refold_secrets_log(tx, account_id, &mut statuses)?;
     // Authority just changed, so content acceptance can change with it: re-evaluate every stream
     // this account's authority reaches (§13). Same txn as the projection rewrite ⇒ a revocation
     // retro-condemns accepted content atomically, and content that arrived before its owner's
@@ -1349,13 +1379,18 @@ fn stored_device_pubkeys(
     conn: &Connection,
     account_id: AccountId,
 ) -> anyhow::Result<HashMap<DeviceFingerprint, [u8; 32]>> {
+    // Gated on `log_id == CONTROL_LOG` (S3): only control-log genesis / DeviceAdd carry device
+    // keys. A secrets-log tag reusing the 0/1 numbers must not be decoded here as a key
+    // certificate.
     let mut stmt = conn.prepare(
-        "SELECT signed_bytes FROM account_entries WHERE account_id = ?1 AND entry_type IN (?2, ?3)",
+        "SELECT signed_bytes FROM account_entries
+         WHERE account_id = ?1 AND log_id = ?2 AND entry_type IN (?3, ?4)",
     )?;
     let rows = stmt
         .query_map(
             params![
                 account_id.to_bytes().as_slice(),
+                fold::CONTROL_LOG,
                 ops::entry_type::ACCOUNT_GENESIS,
                 ops::entry_type::DEVICE_ADD,
             ],
@@ -1569,12 +1604,23 @@ fn delete_pre_verify(conn: &Connection, signed_hash: &[u8]) -> rusqlite::Result<
     Ok(())
 }
 
+/// A genesis op — gated on `log_id == CONTROL_LOG` (S3) so a secrets-log tag reusing the 0 number
+/// can never be mistaken for `AccountGenesis` (pre-verify / device-key promotion).
 fn is_genesis(header: &AccountEntryHeader) -> bool {
-    header.entry_type == ops::entry_type::ACCOUNT_GENESIS
+    header.log_id == fold::CONTROL_LOG && header.entry_type == ops::entry_type::ACCOUNT_GENESIS
 }
 
 fn is_current_control_plaintext(header: &AccountEntryHeader) -> bool {
     header.log_id == fold::CONTROL_LOG
+        && header.crypto_suite == 0
+        && header.op_version == fold::SUPPORTED_OP_VERSION
+}
+
+/// The secrets-log analog of [`is_current_control_plaintext`]: a current-version plaintext entry on
+/// `log_id == SECRETS_LOG`. Its payload is a secrets op, structurally validated by the secrets
+/// twin.
+fn is_current_secrets_plaintext(header: &AccountEntryHeader) -> bool {
+    header.log_id == fold::SECRETS_LOG
         && header.crypto_suite == 0
         && header.op_version == fold::SUPPORTED_OP_VERSION
 }
@@ -1589,6 +1635,12 @@ fn validate_storable_header_payload(
         ops::decode(header.entry_type, payload)
             .map_err(|err| format!("op payload decode failed: {err}"))?;
         validate_genesis_binding(header, payload)?;
+    } else if is_current_secrets_plaintext(header) {
+        // The secrets-plaintext twin (C4.2b): a known secrets tag is fully validated, an unknown
+        // tag is retained opaque. A future-version / sealed secrets entry falls through
+        // unvalidated (it is slot-eligible, folded by a newer binary).
+        secrets::validate_storable_secrets_payload(header.entry_type, payload)
+            .map_err(|err| format!("secrets op payload decode failed: {err}"))?;
     }
     Ok(())
 }
@@ -1613,8 +1665,11 @@ fn validate_genesis_binding(header: &AccountEntryHeader, payload: &[u8]) -> Resu
     }
 }
 
+/// A DeviceAdd op — gated on `log_id == CONTROL_LOG` (S3) so a secrets-log tag reusing the 1 number
+/// can never spuriously trigger the device-key promotion path.
 fn is_device_add(verified: &VerifiedAccountEntry) -> bool {
-    verified.header.entry_type == ops::entry_type::DEVICE_ADD
+    verified.header.log_id == fold::CONTROL_LOG
+        && verified.header.entry_type == ops::entry_type::DEVICE_ADD
 }
 
 /// A stored fixed-width blob as an array (errors, never panics, on a wrong-length value).
@@ -3970,6 +4025,42 @@ mod tests {
         let founder = Dev::new(1);
         let (acct, gbytes, gh) = genesis(&founder);
         account_ingest(&conn, &gbytes, NOW).unwrap();
+        // A log-1 entry carrying the control DEVICE_ADD tag: on the SECRETS log that number is an
+        // unknown secrets tag, so the control DEVICE_ADD schema is never applied. C4.2b's secrets
+        // twin DOES validate log-1 plaintext at ingest, but only as one canonical CBOR item (the
+        // same opaque-retention rule as an unknown control tag) — a canonical payload is retained
+        // `retained_unfolded`, never decoded against any op schema.
+        let header = AccountEntryHeader {
+            account_id: acct,
+            log_id: 1,
+            device_fingerprint: founder.fp,
+            seq: 1,
+            prev_hash: Some(gh),
+            parent_ref: None,
+            entry_type: ops::entry_type::DEVICE_ADD,
+            op_version: 1,
+            crypto_suite: 0,
+            auth_len: 1,
+            key_id: None,
+            authority_ref: Some(gh),
+        };
+        let signed = sign_account_entry(&founder.secret, &header, &[0x80]).unwrap();
+        assert_eq!(
+            account_ingest(&conn, &signed.signed_bytes, NOW).unwrap(),
+            IngestOutcome::Ingested { status: "retained_unfolded".into() },
+        );
+    }
+
+    #[test]
+    fn a_non_canonical_secrets_plaintext_payload_is_rejected_at_ingest() {
+        // The secrets twin (C4.2b) rejects a non-canonical log-1 plaintext payload at ingest,
+        // exactly as an unknown control tag with a non-canonical payload is rejected — a
+        // cross-version consensus split on a signed log is the hazard the canonicity rule
+        // closes.
+        let conn = db();
+        let founder = Dev::new(1);
+        let (acct, gbytes, gh) = genesis(&founder);
+        account_ingest(&conn, &gbytes, NOW).unwrap();
         let header = AccountEntryHeader {
             account_id: acct,
             log_id: 1,
@@ -3985,10 +4076,14 @@ mod tests {
             authority_ref: Some(gh),
         };
         let signed = sign_account_entry(&founder.secret, &header, &[0xff, 0x00]).unwrap();
-        assert_eq!(
-            account_ingest(&conn, &signed.signed_bytes, NOW).unwrap(),
-            IngestOutcome::Ingested { status: "retained_unfolded".into() },
+        assert!(
+            matches!(
+                account_ingest(&conn, &signed.signed_bytes, NOW).unwrap(),
+                IngestOutcome::Rejected(_)
+            ),
+            "a non-canonical secrets plaintext payload is a structural reject",
         );
+        assert_eq!(status(&conn, &signed.entry_hash), None, "a rejected entry is not stored");
     }
 
     #[test]


### PR DESCRIPTION
Adds the account secrets-log (log 1) acceptance evaluator and the `StreamKeyWrap` op, so a device's wrapped content keys become first-class, owner-gated entries the fold accepts / forks / parks / condemns alongside the control log. Part of the account content-key sealing work (#607); builds on the secrets-chain cut registers.

## What lands

- **`StreamKeyWrap` op** (secrets log, plaintext-signed): canonical CBOR `[stream_id, key_id, key_epoch, wraps: sorted-unique [(recipient_fp, wrapped_key)]]`, each `wrapped_key` an opaque `SealedKeyWrap`. Multiple ops per `(stream, key_id)` are legal — resolution is a SET by branch selection + effectiveness, never LWW. Structural ingest validation covers arity, sorted-unique recipients, decodable wraps, and canonicity.
- **Owner-gated acceptance evaluator** (`account/secrets/`): a new content-style loop over the log-generic candidate primitives (not the control projection, whose effective set log-1 entries never enter). A wrap is authorized only under a live owner incarnation of the stream's owning account — a writer-grant or non-owner device is rejected — with the account's `StreamOwn` effective first, the two secrets-boundary registers applied, the contested hold respected, and freshness checked last.
- **Pin-aware branch selection**: the secrets loop selects its accepted branch using register watermark pins sourced from *both* secrets boundaries of the cited owner incarnation, so a device that equivocates *below* its own removal cut resolves to the honest branch rather than the smaller-hash fork.
- **Retro-condemn cascade**: wired into `refold_in_tx` in the same immediate txn as the authority-projection rewrite, so a control fold that revokes a device retro-condemns its accepted wraps atomically; the secrets pass overwrites the log-1 status rows and the returned status map.
- **Forward-compatible acceptance**: a structurally- and signature-valid but non-evaluable secrets entry (unknown tag, future op-version, sealed suite) is slot-eligible — it holds its place in the dense chain for later entries but is never itself accepted — so a newer peer's ops cannot strand an older binary's acceptance of the wraps that chain past them.

## Out of scope (follow-up)

Content-key minting, `key_wrap` authoring, the `key_id` adoption cross-check, and `sync enable`; `PrivateStreamConfig` / `DeviceName` secrets ops.

## Tests / gates

31 tests in the new secrets module — wire round-trip and structural rejects; the pure predicate across every authority / boundary / freshness path (including the account+auth_len freshness-provenance precondition); pin-aware selection including equivocation-below-a-cut; and DB-integration refold covering before-ownership park→accept, a later removal cut retro-condemning an accepted wrap, multi-op SET acceptance, and slot-eligible transparency. `cargo nextest run -p rag-rat-oplog` → 428 passed; clippy (`-D warnings`, both feature sets) and nightly `fmt --check` clean.
