### PR TITLE
perf(mcp): trim repeated meta from tool results to cut per-call tokens (#752)

### DIFF
--- a/crates/rag-rat-core/src/lib.rs
+++ b/crates/rag-rat-core/src/lib.rs
@@ -6,6 +6,7 @@ pub(crate) mod memory_write;
 pub mod output;
 pub mod query;
 pub mod search;
+pub mod sidecar_state;
 pub mod version_check;
 pub mod watch;
 

--- a/crates/rag-rat-core/src/sidecar_state.rs
+++ b/crates/rag-rat-core/src/sidecar_state.rs
@@ -1,0 +1,167 @@
+//! The MCP server's per-project sidecar state: a small JSON file next to the index DB (under the
+//! gitignored `.rag-rat/`) that persists low-frequency, cross-process signals which don't belong in
+//! the index. One file combines what used to be several: the crates.io version-check cache and the
+//! stale-memory rebind-nudge throttle (#752).
+//!
+//! Every access is best-effort and FAIL-OPEN — a missing/corrupt/unwritable file yields defaults,
+//! never an error. Writes are read-modify-write under a NON-BLOCKING [`FileLock`] so two MCP
+//! processes (one per session) updating DIFFERENT sections don't clobber each other; on contention
+//! the write is skipped rather than waited on (see [`update`]).
+
+use std::path::{Path, PathBuf};
+
+use rag_rat_base::locks::FileLock;
+use serde::{Deserialize, Serialize};
+
+use crate::version_check::CachedVersion;
+
+/// The combined sidecar file's shape. Every section is optional so an older/newer file (or a
+/// partial write) still deserializes; unknown fields are ignored by serde's default.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SidecarState {
+    /// The last crates.io version-check result (was `version-check.json`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version_check: Option<CachedVersion>,
+    /// The stale-memory rebind-nudge throttle (#752): when the fleet last showed the nudge.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub memory_nudge: Option<MemoryNudgeState>,
+}
+
+/// Throttle state for the stale-anchor rebind nudge (#752): the fleet shows it at most once per
+/// window (a memory `create`/`update` forces it regardless), so it never rides every tool call.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MemoryNudgeState {
+    pub last_shown_at_ms: i64,
+}
+
+/// Where the sidecar state lives: next to the index DB, per-project, never indexed.
+pub fn state_path(database: &Path) -> PathBuf {
+    sidecar_dir(database).join("mcp-state.json")
+}
+
+fn sidecar_dir(database: &Path) -> &Path {
+    database.parent().unwrap_or_else(|| Path::new("."))
+}
+
+/// The legacy pre-#752 version-check file. Read once as a migration fallback so an upgrade doesn't
+/// throw away a still-fresh version-check cache (which would force a spurious crates.io re-fetch).
+fn legacy_version_cache_path(database: &Path) -> PathBuf {
+    sidecar_dir(database).join("version-check.json")
+}
+
+/// Read the whole sidecar state, or defaults when absent/unreadable/corrupt (fail-open). Migrates a
+/// pre-#752 `version-check.json` into the `version_check` section when the combined file is absent.
+pub fn read(database: &Path) -> SidecarState {
+    if let Ok(text) = std::fs::read_to_string(state_path(database))
+        && let Ok(state) = serde_json::from_str::<SidecarState>(&text)
+    {
+        return state;
+    }
+    // Migration fallback: no combined file yet — salvage the legacy version-check cache if present.
+    let version_check = std::fs::read_to_string(legacy_version_cache_path(database))
+        .ok()
+        .and_then(|text| serde_json::from_str::<CachedVersion>(&text).ok());
+    SidecarState { version_check, memory_nudge: None }
+}
+
+/// Read-modify-write the sidecar state under the file lock, so a concurrent MCP process updating a
+/// different section can't clobber this write. Returns `Some(result)` when the update ran (lock
+/// held); `None` when the lock was CONTENDED and the update was skipped — the caller falls back to
+/// a safe default.
+///
+/// The lock is NON-BLOCKING (`try_acquire`), deliberately (#752 review): the stale-nudge path
+/// enters this on nearly every tool call, so a blocking wait would let one stuck/paused peer
+/// process freeze every MCP session for the repo. A single try-lock instead — on contention we
+/// skip. That's safe because this state is advisory and self-correcting: a skipped nudge claim
+/// re-evaluates on the next call, a skipped version-cache write re-persists on the next refresh.
+/// Never stalling a tool call is worth losing a rare, benign write.
+fn update<T>(database: &Path, mutate: impl FnOnce(&mut SidecarState) -> T) -> Option<T> {
+    let dir = sidecar_dir(database);
+    let _ = std::fs::create_dir_all(dir);
+    let _lock = FileLock::try_acquire(&dir.join("mcp-state.lock")).ok().flatten()?;
+    let mut state = read(database);
+    let out = mutate(&mut state);
+    if let Ok(json) = serde_json::to_string(&state) {
+        let _ = std::fs::write(state_path(database), json);
+    }
+    Some(out)
+}
+
+/// The cached crates.io result, or `None` when never checked (fail-open).
+pub fn read_version_cache(database: &Path) -> Option<CachedVersion> {
+    read(database).version_check
+}
+
+/// Persist a fresh crates.io result into the combined file (RMW, preserving other sections).
+/// Best-effort: a lock-contended skip just means the next refresh re-persists.
+pub fn write_version_cache(database: &Path, cached: &CachedVersion) {
+    let _ = update(database, |state| state.version_check = Some(cached.clone()));
+}
+
+/// Claim the rebind-nudge slot: return whether the nudge should show NOW and, if so, record it as
+/// shown (atomically under the lock, so concurrent processes don't both show). It shows when
+/// `force` (a memory create/update just ran) OR the throttle window has elapsed since the last
+/// show.
+pub fn take_memory_nudge_slot(database: &Path, now_ms: i64, ttl_ms: i64, force: bool) -> bool {
+    // On lock contention the slot can't be claimed atomically, so default to NOT showing: fewer
+    // tokens (the goal of #752) and the next call re-evaluates.
+    update(database, |state| {
+        let elapsed = state
+            .memory_nudge
+            .is_none_or(|nudge| now_ms.saturating_sub(nudge.last_shown_at_ms) >= ttl_ms);
+        let show = force || elapsed;
+        if show {
+            state.memory_nudge = Some(MemoryNudgeState { last_shown_at_ms: now_ms });
+        }
+        show
+    })
+    .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_db(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("rr-sidecar-{tag}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(dir.join(".rag-rat")).unwrap();
+        dir.join(".rag-rat").join("index.sqlite")
+    }
+
+    const TTL: i64 = 30 * 60 * 1000;
+
+    #[test]
+    fn nudge_slot_throttles_to_the_window_but_forces_on_demand() {
+        let db = temp_db("nudge");
+        // First ever show: nothing recorded → the window has "elapsed", so it shows and records.
+        assert!(take_memory_nudge_slot(&db, 1_000, TTL, false), "first show");
+        // Within the window, non-forced: throttled.
+        assert!(
+            !take_memory_nudge_slot(&db, 1_000 + TTL - 1, TTL, false),
+            "throttled inside window"
+        );
+        // Force (a memory create/update) shows regardless AND resets the window.
+        assert!(take_memory_nudge_slot(&db, 1_000 + TTL - 1, TTL, true), "forced show");
+        // Now the reset window throttles again just after the forced show.
+        assert!(!take_memory_nudge_slot(&db, 1_000 + TTL, TTL, false), "reset window throttles");
+        // Once the full window elapses from the last show, it shows again.
+        assert!(take_memory_nudge_slot(&db, 1_000 + 2 * TTL, TTL, false), "window elapsed → show");
+        let _ = std::fs::remove_dir_all(db.parent().unwrap().parent().unwrap());
+    }
+
+    #[test]
+    fn nudge_and_version_cache_coexist_in_one_file() {
+        let db = temp_db("coexist");
+        write_version_cache(&db, &CachedVersion {
+            latest_version: "9.9.9".into(),
+            checked_at_ms: 7,
+        });
+        // Claiming the nudge slot must PRESERVE the version-check section (RMW, not overwrite).
+        assert!(take_memory_nudge_slot(&db, 5_000, TTL, false));
+        let state = read(&db);
+        assert_eq!(state.version_check.unwrap().latest_version, "9.9.9");
+        assert_eq!(state.memory_nudge.unwrap().last_shown_at_ms, 5_000);
+        let _ = std::fs::remove_dir_all(db.parent().unwrap().parent().unwrap());
+    }
+}

--- a/crates/rag-rat-core/src/sidecar_state.rs
+++ b/crates/rag-rat-core/src/sidecar_state.rs
@@ -8,6 +8,7 @@
 //! processes (one per session) updating DIFFERENT sections don't clobber each other; on contention
 //! the write is skipped rather than waited on (see [`update`]).
 
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 use rag_rat_base::locks::FileLock;
@@ -19,16 +20,21 @@ use crate::version_check::CachedVersion;
 /// partial write) still deserializes; unknown fields are ignored by serde's default.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct SidecarState {
-    /// The last crates.io version-check result (was `version-check.json`).
+    /// The last crates.io version-check result (was `version-check.json`). A singleton — the
+    /// latest version of the rag-rat BINARY is machine-global, not per-repo, so a shared
+    /// global DB caches it once.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub version_check: Option<CachedVersion>,
-    /// The stale-memory rebind-nudge throttle (#752): when the fleet last showed the nudge.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub memory_nudge: Option<MemoryNudgeState>,
+    /// The stale-memory rebind-nudge throttle (#752), keyed by `repo_id`. On a shared global DB
+    /// many repos resolve to this one file, but the stale-anchor COUNT is repo-scoped — so the
+    /// throttle must be too, or repo A's tool call would consume the slot and mute repo B's
+    /// warning (#753 review). A `BTreeMap` for stable serialization.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub memory_nudge: BTreeMap<String, MemoryNudgeState>,
 }
 
-/// Throttle state for the stale-anchor rebind nudge (#752): the fleet shows it at most once per
-/// window (a memory `create`/`update` forces it regardless), so it never rides every tool call.
+/// Throttle state for the stale-anchor rebind nudge (#752): a repo shows it at most once per window
+/// (a memory `create`/`update` forces it regardless), so it never rides every tool call.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MemoryNudgeState {
     pub last_shown_at_ms: i64,
@@ -61,7 +67,7 @@ pub fn read(database: &Path) -> SidecarState {
     let version_check = std::fs::read_to_string(legacy_version_cache_path(database))
         .ok()
         .and_then(|text| serde_json::from_str::<CachedVersion>(&text).ok());
-    SidecarState { version_check, memory_nudge: None }
+    SidecarState { version_check, memory_nudge: BTreeMap::new() }
 }
 
 /// Read-modify-write the sidecar state under the file lock, so a concurrent MCP process updating a
@@ -98,20 +104,29 @@ pub fn write_version_cache(database: &Path, cached: &CachedVersion) {
     let _ = update(database, |state| state.version_check = Some(cached.clone()));
 }
 
-/// Claim the rebind-nudge slot: return whether the nudge should show NOW and, if so, record it as
-/// shown (atomically under the lock, so concurrent processes don't both show). It shows when
-/// `force` (a memory create/update just ran) OR the throttle window has elapsed since the last
-/// show.
-pub fn take_memory_nudge_slot(database: &Path, now_ms: i64, ttl_ms: i64, force: bool) -> bool {
+/// Claim `repo_id`'s rebind-nudge slot: return whether the nudge should show NOW and, if so, record
+/// it as shown for that repo (atomically under the lock, so concurrent processes don't both show).
+/// It shows when `force` (a memory create/update just ran) OR the throttle window has elapsed since
+/// this repo's last show. Keyed by `repo_id` so repos sharing a global DB throttle independently.
+pub fn take_memory_nudge_slot(
+    database: &Path,
+    repo_id: &str,
+    now_ms: i64,
+    ttl_ms: i64,
+    force: bool,
+) -> bool {
     // On lock contention the slot can't be claimed atomically, so default to NOT showing: fewer
     // tokens (the goal of #752) and the next call re-evaluates.
     update(database, |state| {
         let elapsed = state
             .memory_nudge
+            .get(repo_id)
             .is_none_or(|nudge| now_ms.saturating_sub(nudge.last_shown_at_ms) >= ttl_ms);
         let show = force || elapsed;
         if show {
-            state.memory_nudge = Some(MemoryNudgeState { last_shown_at_ms: now_ms });
+            state
+                .memory_nudge
+                .insert(repo_id.to_string(), MemoryNudgeState { last_shown_at_ms: now_ms });
         }
         show
     })
@@ -130,23 +145,47 @@ mod tests {
     }
 
     const TTL: i64 = 30 * 60 * 1000;
+    const REPO: &str = "repoA";
 
     #[test]
     fn nudge_slot_throttles_to_the_window_but_forces_on_demand() {
         let db = temp_db("nudge");
         // First ever show: nothing recorded → the window has "elapsed", so it shows and records.
-        assert!(take_memory_nudge_slot(&db, 1_000, TTL, false), "first show");
+        assert!(take_memory_nudge_slot(&db, REPO, 1_000, TTL, false), "first show");
         // Within the window, non-forced: throttled.
         assert!(
-            !take_memory_nudge_slot(&db, 1_000 + TTL - 1, TTL, false),
+            !take_memory_nudge_slot(&db, REPO, 1_000 + TTL - 1, TTL, false),
             "throttled inside window"
         );
         // Force (a memory create/update) shows regardless AND resets the window.
-        assert!(take_memory_nudge_slot(&db, 1_000 + TTL - 1, TTL, true), "forced show");
+        assert!(take_memory_nudge_slot(&db, REPO, 1_000 + TTL - 1, TTL, true), "forced show");
         // Now the reset window throttles again just after the forced show.
-        assert!(!take_memory_nudge_slot(&db, 1_000 + TTL, TTL, false), "reset window throttles");
+        assert!(
+            !take_memory_nudge_slot(&db, REPO, 1_000 + TTL, TTL, false),
+            "reset window throttles"
+        );
         // Once the full window elapses from the last show, it shows again.
-        assert!(take_memory_nudge_slot(&db, 1_000 + 2 * TTL, TTL, false), "window elapsed → show");
+        assert!(
+            take_memory_nudge_slot(&db, REPO, 1_000 + 2 * TTL, TTL, false),
+            "window elapsed → show"
+        );
+        let _ = std::fs::remove_dir_all(db.parent().unwrap().parent().unwrap());
+    }
+
+    #[test]
+    fn repos_sharing_one_db_throttle_independently() {
+        let db = temp_db("multi-repo");
+        // repoA claims its slot and is then throttled inside the window.
+        assert!(take_memory_nudge_slot(&db, "repoA", 1_000, TTL, false), "repoA first show");
+        assert!(
+            !take_memory_nudge_slot(&db, "repoA", 1_500, TTL, false),
+            "repoA throttled inside window"
+        );
+        // repoB (same shared DB) has its OWN window — it must still show, not inherit repoA's slot.
+        assert!(
+            take_memory_nudge_slot(&db, "repoB", 1_500, TTL, false),
+            "repoB shows despite repoA having claimed its own slot",
+        );
         let _ = std::fs::remove_dir_all(db.parent().unwrap().parent().unwrap());
     }
 
@@ -158,10 +197,10 @@ mod tests {
             checked_at_ms: 7,
         });
         // Claiming the nudge slot must PRESERVE the version-check section (RMW, not overwrite).
-        assert!(take_memory_nudge_slot(&db, 5_000, TTL, false));
+        assert!(take_memory_nudge_slot(&db, REPO, 5_000, TTL, false));
         let state = read(&db);
         assert_eq!(state.version_check.unwrap().latest_version, "9.9.9");
-        assert_eq!(state.memory_nudge.unwrap().last_shown_at_ms, 5_000);
+        assert_eq!(state.memory_nudge.get(REPO).unwrap().last_shown_at_ms, 5_000);
         let _ = std::fs::remove_dir_all(db.parent().unwrap().parent().unwrap());
     }
 }

--- a/crates/rag-rat-core/src/version_check.rs
+++ b/crates/rag-rat-core/src/version_check.rs
@@ -7,7 +7,7 @@
 //! Versions are reported as opaque strings; comparison is a lenient numeric semver (`major.minor.
 //! patch`, pre-release/build stripped) — if either side won't parse, no update is claimed.
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
@@ -47,28 +47,16 @@ pub struct CachedVersion {
     pub checked_at_ms: i64,
 }
 
-/// Where the version-check cache lives: next to the index DB (under the gitignored, floor-skipped
-/// `.rag-rat/`), so it's per-project and never indexed.
-pub fn cache_path(database: &Path) -> PathBuf {
-    database.parent().unwrap_or_else(|| Path::new(".")).join("version-check.json")
-}
-
-/// Read the cached crates.io result, or `None` when absent/unreadable/corrupt (all fail-open).
+/// Read the cached crates.io result, or `None` when never checked (fail-open). The value lives in
+/// the combined sidecar store (#752), `.rag-rat/mcp-state.json`, alongside other MCP signals.
 pub fn read_cache(database: &Path) -> Option<CachedVersion> {
-    let text = std::fs::read_to_string(cache_path(database)).ok()?;
-    serde_json::from_str(&text).ok()
+    crate::sidecar_state::read_version_cache(database)
 }
 
-/// Persist a fresh crates.io result. Best-effort: a write error is swallowed (the next refresh
-/// retries), never surfaced.
+/// Persist a fresh crates.io result into the combined sidecar store (preserving other sections).
+/// Best-effort: a write error is swallowed (the next refresh retries), never surfaced.
 fn write_cache(database: &Path, cached: &CachedVersion) {
-    let path = cache_path(database);
-    if let Some(parent) = path.parent() {
-        let _ = std::fs::create_dir_all(parent);
-    }
-    if let Ok(json) = serde_json::to_string(cached) {
-        let _ = std::fs::write(path, json);
-    }
+    crate::sidecar_state::write_version_cache(database, cached);
 }
 
 /// Build the agent/operator-facing status from the current version and the last cached check.
@@ -290,7 +278,10 @@ mod tests {
             read_cache(&database),
             Some(CachedVersion { latest_version: "0.7.1".into(), checked_at_ms: 42 })
         );
-        assert_eq!(cache_path(&database), dir.join(".rag-rat").join("version-check.json"));
+        assert_eq!(
+            crate::sidecar_state::state_path(&database),
+            dir.join(".rag-rat").join("mcp-state.json")
+        );
         let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/crates/rag-rat-mcp/src/lib.rs
+++ b/crates/rag-rat-mcp/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod agent_hook;
 mod blocking;
+mod output_trim;
 pub mod server;
 pub mod tools;
 #[cfg(unix)]

--- a/crates/rag-rat-mcp/src/output_trim.rs
+++ b/crates/rag-rat-mcp/src/output_trim.rs
@@ -38,17 +38,29 @@ pub(crate) struct AgentSeen {
 }
 
 impl AgentSeen {
-    /// Record `key` as surfaced NOW; return whether it was ALREADY surfaced within the TTL (so the
-    /// caller elides it). Prunes expired entries opportunistically once over the cap.
-    fn seen_then_touch(&self, key: &str) -> bool {
+    /// Whether `key` was surfaced in full within the TTL, so the caller should ELIDE it now.
+    fn should_suppress(&self, key: &str) -> bool {
+        self.should_suppress_at(key, Instant::now())
+    }
+
+    /// As [`Self::should_suppress`], with the clock injected for tests. On a HIT (surfaced within
+    /// the TTL) returns `true` and leaves the recorded surface time UNTOUCHED — so the window
+    /// measures time between FULL surfaces, not between encounters. Without that, an item seen
+    /// at least once per TTL would slide its own window forward and be suppressed forever (#753
+    /// review). On a MISS (first sighting, or the window elapsed since the last surface)
+    /// records `now` and returns `false`, so the caller shows it and the next window starts
+    /// here.
+    fn should_suppress_at(&self, key: &str, now: Instant) -> bool {
         // Recover from a poisoned lock rather than panic — trimming is best-effort meta, never a
         // reason to fail a tool call.
         let mut map = self.inner.lock().unwrap_or_else(|poison| poison.into_inner());
-        let now = Instant::now();
-        let recent = map.get(key).is_some_and(|seen| now.duration_since(*seen) < SEEN_TTL);
+        if map.get(key).is_some_and(|surfaced| now.duration_since(*surfaced) < SEEN_TTL) {
+            return true;
+        }
+        // We're about to SHOW it → stamp this surface (and only here, so repeats don't slide it).
         map.insert(key.to_string(), now);
         if map.len() > SEEN_CAP {
-            map.retain(|_, seen| now.duration_since(*seen) < SEEN_TTL);
+            map.retain(|_, surfaced| now.duration_since(*surfaced) < SEEN_TTL);
             // Still over cap after dropping expired (a burst of fresh keys): shed arbitrary entries
             // to hold the bound. A shed key just re-surfaces once more later — harmless.
             while map.len() > SEEN_CAP {
@@ -56,7 +68,7 @@ impl AgentSeen {
                 map.remove(&key);
             }
         }
-        recent
+        false
     }
 }
 
@@ -70,7 +82,7 @@ pub(crate) fn trim_result(value: &mut Value, seen: &AgentSeen) {
     // (#753 review) — a plain id key would stub the detail the agent explicitly asked for.
     if let Some((id, title)) = memory_identity(value) {
         let key = format!("{id}:{:016x}", content_fingerprint(value));
-        if seen.seen_then_touch(&key) {
+        if seen.should_suppress(&key) {
             *value = stub(&id, &title);
         }
         return;
@@ -146,14 +158,14 @@ fn throttle_static_caveats(map: &mut Map<String, Value>, seen: &AgentSeen) {
     // `caveats: [String]` (impact_surface): drop static entries seen recently, keep the rest.
     if let Some(Value::Array(caveats)) = map.get_mut("caveats") {
         caveats.retain(|caveat| match caveat.as_str() {
-            Some(text) if is_static_caveat(text) => !seen.seen_then_touch(text),
+            Some(text) if is_static_caveat(text) => !seen.should_suppress(text),
             _ => true,
         });
     }
     // `completeness_note: String` (graph tools): drop when it's the static note and seen recently.
     if let Some(Value::String(note)) = map.get("completeness_note")
         && is_static_caveat(note)
-        && seen.seen_then_touch(note)
+        && seen.should_suppress(note)
     {
         map.remove("completeness_note");
     }
@@ -228,6 +240,32 @@ mod tests {
         trim_result(&mut again, &seen);
         assert!(again["memories"][0]["body"].is_null(), "an identical re-surface is stubbed");
         assert!(again["memories"][0]["elided"].is_string());
+    }
+
+    #[test]
+    fn suppression_window_measures_between_full_surfaces_not_encounters() {
+        let seen = AgentSeen::default();
+        let t0 = Instant::now();
+        // First surface shows and stamps t0.
+        assert!(!seen.should_suppress_at("k", t0), "first surface shows");
+        // Repeated encounters inside the window are suppressed — and must NOT slide the window.
+        assert!(seen.should_suppress_at("k", t0 + SEEN_TTL / 2), "within window → suppressed");
+        assert!(
+            seen.should_suppress_at("k", t0 + SEEN_TTL - Duration::from_secs(1)),
+            "still within the original window → suppressed",
+        );
+        // Just past the window measured from the FIRST surface (the encounters above did not reset
+        // it) → shows again, contrary to a sliding window that would suppress forever (#753
+        // review).
+        assert!(
+            !seen.should_suppress_at("k", t0 + SEEN_TTL + Duration::from_secs(1)),
+            "window elapsed since the last full surface → shows again",
+        );
+        // That fresh surface re-stamps, so the next encounter is suppressed once more.
+        assert!(
+            seen.should_suppress_at("k", t0 + SEEN_TTL + Duration::from_secs(2)),
+            "the fresh surface starts a new window",
+        );
     }
 
     #[test]

--- a/crates/rag-rat-mcp/src/output_trim.rs
+++ b/crates/rag-rat-mcp/src/output_trim.rs
@@ -1,0 +1,272 @@
+//! Trim repeated, low-signal meta from MCP tool results to cut per-call tokens (#752). The MCP
+//! server is one process per Claude Code session, so "this agent" = this process; the per-agent
+//! throttles below live in-process (a TTL seen-set, like `agent_hook`'s session dedup).
+//!
+//! Three trims, applied to every non-`memory_*` tool result before rendering:
+//! - DRIVE-BY MEMORY DEDUP: a repo memory riding ALONG a result this agent already saw is replaced
+//!   with a tiny stub — the agent still learns it's relevant here and can `memory_show` it, without
+//!   re-reading the body. (Explicit `memory_*` tools are never trimmed — the agent asked.)
+//! - STATIC CAVEAT THROTTLE: the always-identical disclaimers (`GRAPH_SYNTACTIC_CAVEAT`,
+//!   `NO_STATIC_CALLERS_NOTE`) are elided after the agent has seen them within the window; dynamic
+//!   caveats (truncation, gap counts) always pass.
+//! - REDUNDANT EDGE FLAGS (stateless): per-edge `shown_by_default` / `verified_target_symbol` are
+//!   dropped when `true` (interesting only when false), and `edge_confidence` when it equals the
+//!   displayed `confidence` (redundant unless an oracle upgrade split them). The struct / CLI stay
+//!   fully explicit; only the LLM-facing MCP output is trimmed.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use serde_json::{Map, Value, json};
+
+/// How long a surfaced signal (a memory id, a static caveat) stays "recently seen" for this agent
+/// before it may ride a drive-by result in full again.
+const SEEN_TTL: Duration = Duration::from_secs(30 * 60);
+/// Bound on the tracked set so a long session can't grow it without limit.
+const SEEN_CAP: usize = 4096;
+
+/// Per-agent (= per MCP process) record of which signals were surfaced in full recently, keyed by
+/// an opaque string (a memory id, or a static-caveat text). Shared across service clones via an
+/// `Arc`, so every tool call on the session sees the same set.
+#[derive(Default)]
+pub(crate) struct AgentSeen {
+    inner: Mutex<HashMap<String, Instant>>,
+}
+
+impl AgentSeen {
+    /// Record `key` as surfaced NOW; return whether it was ALREADY surfaced within the TTL (so the
+    /// caller elides it). Prunes expired entries opportunistically once over the cap.
+    fn seen_then_touch(&self, key: &str) -> bool {
+        // Recover from a poisoned lock rather than panic — trimming is best-effort meta, never a
+        // reason to fail a tool call.
+        let mut map = self.inner.lock().unwrap_or_else(|poison| poison.into_inner());
+        let now = Instant::now();
+        let recent = map.get(key).is_some_and(|seen| now.duration_since(*seen) < SEEN_TTL);
+        map.insert(key.to_string(), now);
+        if map.len() > SEEN_CAP {
+            map.retain(|_, seen| now.duration_since(*seen) < SEEN_TTL);
+            // Still over cap after dropping expired (a burst of fresh keys): shed arbitrary entries
+            // to hold the bound. A shed key just re-surfaces once more later — harmless.
+            while map.len() > SEEN_CAP {
+                let Some(key) = map.keys().next().cloned() else { break };
+                map.remove(&key);
+            }
+        }
+        recent
+    }
+}
+
+/// Trim a tool-result payload in place: dedup drive-by memories, throttle static caveats, and drop
+/// redundant per-edge flags. Idempotent on payloads that carry none of these.
+pub(crate) fn trim_result(value: &mut Value, seen: &AgentSeen) {
+    // A memory object → replace with a tiny stub if recently seen; never descend into it (its
+    // bindings carry `memory_id` but no `title`, and a full unseen memory must stay intact).
+    if let Some((id, title)) = memory_identity(value) {
+        if seen.seen_then_touch(&id) {
+            *value = stub(&id, &title);
+        }
+        return;
+    }
+    match value {
+        Value::Object(map) => {
+            drop_redundant_edge_flags(map);
+            throttle_static_caveats(map, seen);
+            map.values_mut().for_each(|v| trim_result(v, seen));
+        },
+        Value::Array(items) => items.iter_mut().for_each(|item| trim_result(item, seen)),
+        _ => {},
+    }
+}
+
+/// `(memory_id, title)` when `value` is a memory object — an object with BOTH as non-empty strings.
+/// A binding carries `memory_id` but no `title`, so it is not matched. Both the full `RepoMemory`
+/// and the compact `CompactRepoMemory` serialize both fields.
+fn memory_identity(value: &Value) -> Option<(String, String)> {
+    let obj = value.as_object()?;
+    let id = obj.get("memory_id")?.as_str()?;
+    let title = obj.get("title")?.as_str()?;
+    (!id.is_empty() && !title.is_empty()).then(|| (id.to_string(), title.to_string()))
+}
+
+/// The tiny replacement for a re-surfaced memory: enough to recognize it and fetch detail, none of
+/// the token-heavy body / bindings / summary.
+fn stub(id: &str, title: &str) -> Value {
+    json!({
+        "memory_id": id,
+        "title": title,
+        "elided": "already surfaced this session — memory_show for detail",
+    })
+}
+
+/// Drop always-default / redundant per-edge flags (stateless): the agent reads absence as the
+/// default value.
+fn drop_redundant_edge_flags(map: &mut Map<String, Value>) {
+    // Interesting only when FALSE (a hidden-by-default edge, an unverified target).
+    for flag in ["shown_by_default", "verified_target_symbol"] {
+        if map.get(flag) == Some(&Value::Bool(true)) {
+            map.remove(flag);
+        }
+    }
+    // `edge_confidence` is the underlying heuristic tier; it duplicates the displayed `confidence`
+    // unless an oracle upgrade split them (then it stays, showing what tree-sitter alone
+    // concluded).
+    if let (Some(Value::String(confidence)), Some(Value::String(edge))) =
+        (map.get("confidence"), map.get("edge_confidence"))
+        && confidence == edge
+    {
+        map.remove("edge_confidence");
+    }
+}
+
+/// Throttle KNOWN-STATIC caveats/notes per agent (#752): the same disclaimer every call is elided
+/// after the agent has seen it within the window. Dynamic caveats (truncation, gap counts) are not
+/// in the static set, so they always pass.
+fn throttle_static_caveats(map: &mut Map<String, Value>, seen: &AgentSeen) {
+    // `caveats: [String]` (impact_surface): drop static entries seen recently, keep the rest.
+    if let Some(Value::Array(caveats)) = map.get_mut("caveats") {
+        caveats.retain(|caveat| match caveat.as_str() {
+            Some(text) if is_static_caveat(text) => !seen.seen_then_touch(text),
+            _ => true,
+        });
+    }
+    // `completeness_note: String` (graph tools): drop when it's the static note and seen recently.
+    if let Some(Value::String(note)) = map.get("completeness_note")
+        && is_static_caveat(note)
+        && seen.seen_then_touch(note)
+    {
+        map.remove("completeness_note");
+    }
+}
+
+/// Whether `text` is one of the always-identical disclaimers (as opposed to a dynamic, per-call
+/// caveat). Matched against the query layer's own consts so the two can't drift.
+fn is_static_caveat(text: &str) -> bool {
+    text == rag_rat_query::impact::GRAPH_SYNTACTIC_CAVEAT
+        || text == rag_rat_query::graph::NO_STATIC_CALLERS_NOTE
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn memory(id: &str) -> Value {
+        json!({
+            "memory_id": id, "kind": "Invariant", "title": format!("t-{id}"),
+            "body": "a long body ".repeat(50),
+            "bindings": [{"memory_id": id, "path": "src/x.rs"}],
+        })
+    }
+
+    #[test]
+    fn first_show_is_full_then_re_show_is_stubbed() {
+        let seen = AgentSeen::default();
+        let mut result = json!({ "hit": "x", "memories": [memory("m1"), memory("m2")] });
+        trim_result(&mut result, &seen);
+        assert!(result["memories"][0]["body"].is_string(), "unseen memory keeps its body");
+        assert!(result["memories"][1]["body"].is_string());
+
+        let mut again = json!({ "memories": [memory("m1"), memory("m3")] });
+        trim_result(&mut again, &seen);
+        assert!(again["memories"][0]["body"].is_null(), "re-shown memory drops its body");
+        assert_eq!(again["memories"][0]["memory_id"], "m1", "stub keeps the id");
+        assert_eq!(again["memories"][0]["title"], "t-m1", "stub keeps the title");
+        assert!(again["memories"][0]["elided"].is_string(), "stub explains how to fetch detail");
+        assert!(again["memories"][1]["body"].is_string(), "a NEW memory is still full");
+    }
+
+    #[test]
+    fn a_binding_is_not_mistaken_for_a_memory() {
+        let seen = AgentSeen::default();
+        let mut result = json!({ "edges": [{"memory_id": "m9", "path": "src/y.rs"}] });
+        trim_result(&mut result, &seen);
+        assert_eq!(result["edges"][0]["path"], "src/y.rs", "a binding is not stubbed");
+        let mut real = json!({ "memories": [memory("m9")] });
+        trim_result(&mut real, &seen);
+        assert!(real["memories"][0]["body"].is_string(), "the memory m9 surfaces in full");
+    }
+
+    #[test]
+    fn nested_repo_memories_lanes_are_deduped() {
+        let seen = AgentSeen::default();
+        let mut first = json!({
+            "repo_memories": { "direct": [memory("d1")], "path_crossed": [memory("p1")] }
+        });
+        trim_result(&mut first, &seen);
+        let mut second = json!({ "repo_memories": { "direct": [memory("d1")] } });
+        trim_result(&mut second, &seen);
+        assert!(
+            second["repo_memories"]["direct"][0]["body"].is_null(),
+            "nested re-show is stubbed"
+        );
+    }
+
+    #[test]
+    fn static_caveats_throttle_but_dynamic_ones_always_pass() {
+        let seen = AgentSeen::default();
+        let dynamic = "Sections truncated at limit=50: direct_semantic_callers.";
+        let make = || {
+            json!({ "completeness_and_caveats": {
+                "caveats": [rag_rat_query::impact::GRAPH_SYNTACTIC_CAVEAT, dynamic]
+            }})
+        };
+        // First surface: BOTH caveats present.
+        let mut first = make();
+        trim_result(&mut first, &seen);
+        let c1 = first["completeness_and_caveats"]["caveats"].as_array().unwrap();
+        assert_eq!(c1.len(), 2, "first surface keeps both the static and dynamic caveat");
+
+        // Second surface: the static one is dropped, the dynamic one stays.
+        let mut second = make();
+        trim_result(&mut second, &seen);
+        let c2 = second["completeness_and_caveats"]["caveats"].as_array().unwrap();
+        assert_eq!(c2.len(), 1, "static caveat throttled on re-show");
+        assert_eq!(c2[0], dynamic, "the dynamic caveat always passes");
+    }
+
+    #[test]
+    fn static_completeness_note_is_throttled() {
+        let seen = AgentSeen::default();
+        let make = || json!({ "summary": { "completeness_note": rag_rat_query::graph::NO_STATIC_CALLERS_NOTE } });
+        let mut first = make();
+        trim_result(&mut first, &seen);
+        assert!(first["summary"]["completeness_note"].is_string(), "first surface keeps the note");
+        let mut second = make();
+        trim_result(&mut second, &seen);
+        assert!(
+            second["summary"]["completeness_note"].is_null(),
+            "re-shown static note is dropped"
+        );
+    }
+
+    #[test]
+    fn redundant_edge_flags_are_dropped() {
+        let seen = AgentSeen::default();
+        let mut result = json!({ "direct_semantic_callers": [{
+            "from_symbol": "a", "to_symbol": "b",
+            "confidence": "syntactic", "edge_confidence": "syntactic",
+            "verified_target_symbol": true, "shown_by_default": true
+        }]});
+        trim_result(&mut result, &seen);
+        let edge = &result["direct_semantic_callers"][0];
+        assert!(edge["shown_by_default"].is_null(), "shown_by_default:true is dropped");
+        assert!(edge["verified_target_symbol"].is_null(), "verified_target_symbol:true is dropped");
+        assert!(edge["edge_confidence"].is_null(), "edge_confidence == confidence is dropped");
+        assert_eq!(edge["confidence"], "syntactic", "the displayed confidence stays");
+    }
+
+    #[test]
+    fn edge_flags_kept_when_informative() {
+        let seen = AgentSeen::default();
+        // A hidden/unverified edge, and an oracle upgrade that split confidence — all kept.
+        let mut result = json!({ "hops": [{
+            "confidence": "compiler", "edge_confidence": "syntactic",
+            "verified_target_symbol": false, "shown_by_default": false
+        }]});
+        trim_result(&mut result, &seen);
+        let edge = &result["hops"][0];
+        assert_eq!(edge["shown_by_default"], false, "false is informative — kept");
+        assert_eq!(edge["verified_target_symbol"], false, "false is informative — kept");
+        assert_eq!(edge["edge_confidence"], "syntactic", "an upgraded tier keeps edge_confidence");
+    }
+}

--- a/crates/rag-rat-mcp/src/output_trim.rs
+++ b/crates/rag-rat-mcp/src/output_trim.rs
@@ -3,9 +3,12 @@
 //! throttles below live in-process (a TTL seen-set, like `agent_hook`'s session dedup).
 //!
 //! Three trims, applied to every non-`memory_*` tool result before rendering:
-//! - DRIVE-BY MEMORY DEDUP: a repo memory riding ALONG a result this agent already saw is replaced
-//!   with a tiny stub — the agent still learns it's relevant here and can `memory_show` it, without
-//!   re-reading the body. (Explicit `memory_*` tools are never trimmed — the agent asked.)
+//! - DRIVE-BY MEMORY DEDUP: a repo memory riding ALONG a result whose exact content this agent
+//!   already saw is replaced with a tiny stub — the agent still learns it's relevant here and can
+//!   `memory_show` it, without re-reading the body. Keyed by CONTENT, not just id, so a later,
+//!   richer view (e.g. `impact_surface full_memories:true` after a compact `symbol_lookup`) is
+//!   shown in full rather than stubbed down. (Explicit `memory_*` tools are never trimmed — the
+//!   agent asked.)
 //! - STATIC CAVEAT THROTTLE: the always-identical disclaimers (`GRAPH_SYNTACTIC_CAVEAT`,
 //!   `NO_STATIC_CALLERS_NOTE`) are elided after the agent has seen them within the window; dynamic
 //!   caveats (truncation, gap counts) always pass.
@@ -60,10 +63,14 @@ impl AgentSeen {
 /// Trim a tool-result payload in place: dedup drive-by memories, throttle static caveats, and drop
 /// redundant per-edge flags. Idempotent on payloads that carry none of these.
 pub(crate) fn trim_result(value: &mut Value, seen: &AgentSeen) {
-    // A memory object → replace with a tiny stub if recently seen; never descend into it (its
-    // bindings carry `memory_id` but no `title`, and a full unseen memory must stay intact).
+    // A memory object → replace with a tiny stub if this EXACT content was already surfaced; never
+    // descend into it (its bindings carry `memory_id` but no `title`, and a full unseen memory must
+    // stay intact). The seen-key folds in a fingerprint of the whole object, so a richer view of a
+    // memory whose compact header was already shown gets a fresh key and passes through in full
+    // (#753 review) — a plain id key would stub the detail the agent explicitly asked for.
     if let Some((id, title)) = memory_identity(value) {
-        if seen.seen_then_touch(&id) {
+        let key = format!("{id}:{:016x}", content_fingerprint(value));
+        if seen.seen_then_touch(&key) {
             *value = stub(&id, &title);
         }
         return;
@@ -87,6 +94,19 @@ fn memory_identity(value: &Value) -> Option<(String, String)> {
     let id = obj.get("memory_id")?.as_str()?;
     let title = obj.get("title")?.as_str()?;
     (!id.is_empty() && !title.is_empty()).then(|| (id.to_string(), title.to_string()))
+}
+
+/// A process-stable fingerprint of a memory object's SURFACED content, so the dedup key
+/// distinguishes views of the same memory (a compact header vs the full body+bindings serialize
+/// differently). In-process only — `DefaultHasher` is deterministic within this run, which is all
+/// the per-session seen-set needs; the value is never persisted or compared across processes.
+fn content_fingerprint(value: &Value) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    // Serde serializes an object's keys in a stable order, so the same view hashes identically
+    // across calls while a richer view hashes differently.
+    serde_json::to_string(value).unwrap_or_default().hash(&mut hasher);
+    hasher.finish()
 }
 
 /// The tiny replacement for a re-surfaced memory: enough to recognize it and fetch detail, none of
@@ -173,6 +193,41 @@ mod tests {
         assert_eq!(again["memories"][0]["title"], "t-m1", "stub keeps the title");
         assert!(again["memories"][0]["elided"].is_string(), "stub explains how to fetch detail");
         assert!(again["memories"][1]["body"].is_string(), "a NEW memory is still full");
+    }
+
+    #[test]
+    fn a_richer_view_of_a_seen_memory_is_shown_not_stubbed() {
+        let seen = AgentSeen::default();
+        // A compact drive-by header (symbol_lookup / default impact_surface): no body/bindings.
+        let compact =
+            || json!({"memory_id": "m1", "kind": "Invariant", "title": "t", "confidence": "high"});
+        // The full view (impact_surface `full_memories: true`, or a `memory_*` shape): adds the
+        // body.
+        let full = || {
+            json!({
+                "memory_id": "m1", "kind": "Invariant", "title": "t", "confidence": "high",
+                "body": "the full prose", "bindings": [{"memory_id": "m1", "path": "src/x.rs"}]
+            })
+        };
+
+        let mut header = json!({ "memories": [compact()] });
+        trim_result(&mut header, &seen);
+        assert_eq!(header["memories"][0]["title"], "t", "the compact header surfaces first");
+
+        // A FULLER view of the SAME memory must still surface in full, not be stubbed down to the
+        // header the agent already saw (#753 review).
+        let mut richer = json!({ "memories": [full()] });
+        trim_result(&mut richer, &seen);
+        assert_eq!(
+            richer["memories"][0]["body"], "the full prose",
+            "a richer view of a seen memory is shown, not stubbed",
+        );
+
+        // The IDENTICAL full view a second time IS stubbed (same content already surfaced).
+        let mut again = json!({ "memories": [full()] });
+        trim_result(&mut again, &seen);
+        assert!(again["memories"][0]["body"].is_null(), "an identical re-surface is stubbed");
+        assert!(again["memories"][0]["elided"].is_string());
     }
 
     #[test]

--- a/crates/rag-rat-mcp/src/server.rs
+++ b/crates/rag-rat-mcp/src/server.rs
@@ -14,6 +14,11 @@ use tokio::sync::Semaphore;
 
 use crate::blocking::{self, ToolTimeoutPolicy};
 
+/// How often the stale-anchor rebind nudge may ride a tool result across the fleet (#752): once per
+/// 30 minutes, unless a `memory_create`/`memory_update` forces it. Keeps the nudge off the vast
+/// majority of tool calls so it stops inflating per-call tokens.
+const NUDGE_TTL_MS: i64 = 30 * 60 * 1000;
+
 #[derive(Clone)]
 pub struct RagRatService {
     /// `None` ⇒ DORMANT: the server was launched outside any rag-rat repo (no `rag-rat.toml` at or
@@ -30,6 +35,10 @@ pub struct RagRatService {
     #[cfg(unix)]
     inflight: std::sync::Arc<crate::upgrade::Inflight>,
     tool_workers: Arc<Semaphore>,
+    /// Per-agent (= per process) record of meta this session already saw — drive-by memories and
+    /// static caveats — so re-surfacing them can be trimmed (#752). An `Arc` so every `Clone` of
+    /// the service (each tool call clones it) shares one seen-set for the whole session.
+    agent_seen: Arc<crate::output_trim::AgentSeen>,
 }
 
 impl RagRatService {
@@ -57,6 +66,7 @@ impl RagRatService {
             #[cfg(unix)]
             inflight: crate::upgrade::Inflight::new(),
             tool_workers: Arc::new(Semaphore::new(blocking::tool_workers())),
+            agent_seen: Arc::new(crate::output_trim::AgentSeen::default()),
         }
     }
 
@@ -82,8 +92,17 @@ impl RagRatService {
             }
             return Ok(self.dormant_tool_result());
         };
-        let value = crate::tools::call_tool_for_config(config, name, value)
+        let mut value = crate::tools::call_tool_for_config(config, name, value)
             .map_err(|err| ErrorData::internal_error(err.to_string(), None))?;
+        // Trim repeated meta to cut per-call tokens (#752): dedup drive-by memories this agent
+        // already saw (to a tiny stub), throttle the static caveats, drop redundant per-edge flags.
+        // TOON-only — it is a lossy transform (stubs a memory, drops default-valued fields), so it
+        // stays off `--json` mode, whose whole purpose is stable, complete shapes for programmatic
+        // clients (same reason the prose nudge is JSON-suppressed). And NEVER on the explicit
+        // `memory_*` tools — there the agent asked for the memory, so it gets it in full.
+        if self.output_format != rag_rat_core::OutputFormat::Json && !name.starts_with("memory_") {
+            crate::output_trim::trim_result(&mut value, &self.agent_seen);
+        }
         // MCP tool results are text content read by an LLM, so render TOON by default — it is
         // materially denser than JSON on the uniform-row payloads that dominate these tools, and
         // ties JSON on nested ones. `render` falls back to compact JSON on a TOON encode error, so
@@ -91,7 +110,7 @@ impl RagRatService {
         // (the format is chosen once at launch; MCP has no per-call flag).
         let text = rag_rat_core::render(&value, self.output_format);
         let mut content = vec![Content::text(text)];
-        if let Some(nudge) = self.stale_memory_nudge() {
+        if let Some(nudge) = self.stale_memory_nudge(name) {
             content.push(Content::text(nudge));
         }
         Ok(CallToolResult::success(content))
@@ -121,12 +140,17 @@ impl RagRatService {
     /// the UI/logs but NOT the model's context (anthropics/claude-code#3174) — so a tool result is
     /// the one MCP-native channel that puts an actionable signal in front of the model. The nudge
     /// self-limits: once the agent runs `memory_rebind`, the count drops to 0 and it stops showing.
-    /// Best-effort + lock-free (a bare read-only count), so it never slows or fails a tool call.
+    ///
+    /// THROTTLED (#752) to cut per-call tokens: it rides at most once per [`NUDGE_TTL_MS`] across
+    /// the fleet (a shared last-shown timestamp in the sidecar store, claimed atomically so
+    /// concurrent sessions don't both show), EXCEPT right after a `memory_create` /
+    /// `memory_update` — the agent just touched memory, so a freshly-needed rebind is worth
+    /// surfacing on that call regardless.
     ///
     /// Suppressed in `--json` mode: that mode exists for clients that parse the tool text AS JSON
     /// (or concatenate all text blocks), and a prose block would break them. The nudge is
     /// agent-directed prose, meaningful only in the default TOON (LLM-facing) mode.
-    fn stale_memory_nudge(&self) -> Option<String> {
+    fn stale_memory_nudge(&self, tool: &str) -> Option<String> {
         // No nudge in dormant mode (no index to read) or in `--json` mode (prose breaks JSON
         // clients).
         let config = self.config.as_ref()?;
@@ -134,14 +158,27 @@ impl RagRatService {
             return None;
         }
         let n = rag_rat_core::memory_attention_count(&config.database);
-        (n > 0).then(|| {
-            let noun = if n == 1 { "memory" } else { "memories" };
-            format!(
-                "rag-rat: {n} active repo {noun} have stale/gone anchors. Call `memory_doctor` to \
-                 list them with suggested re-anchor targets, then `memory_rebind` to fix — so \
-                 source-anchored memory stays trustworthy for the next agent."
-            )
-        })
+        if n == 0 {
+            return None;
+        }
+        // A memory create/update forces the nudge (and resets the window); everything else is gated
+        // on the shared throttle. The slot is claimed atomically — a `false` return means either
+        // throttled or another session just claimed it, so this call stays silent.
+        let force = matches!(tool, "memory_create" | "memory_update");
+        if !rag_rat_core::sidecar_state::take_memory_nudge_slot(
+            &config.database,
+            rag_rat_base::time::now_ms(),
+            NUDGE_TTL_MS,
+            force,
+        ) {
+            return None;
+        }
+        let noun = if n == 1 { "memory" } else { "memories" };
+        Some(format!(
+            "rag-rat: {n} active repo {noun} have stale/gone anchors. Call `memory_doctor` to \
+             list them with suggested re-anchor targets, then `memory_rebind` to fix — so \
+             source-anchored memory stays trustworthy for the next agent."
+        ))
     }
 
     /// The result every tool call returns while the server is DORMANT (launched outside any rag-rat
@@ -613,10 +650,11 @@ mod tests {
         );
     }
 
-    /// The staleness nudge (#160) rides a TOON tool result as a second content block, but is
-    /// SUPPRESSED in `--json` mode so JSON-parsing clients aren't broken (Codex #160 review).
+    /// The staleness nudge (#160) rides a TOON tool result as a second content block, SUPPRESSED in
+    /// `--json` mode (Codex #160 review), and THROTTLED (#752) to at most once per window across
+    /// the fleet — except a `memory_create`/`memory_update` forces it (and resets the window).
     #[test]
-    fn stale_memory_nudge_rides_toon_but_not_json() {
+    fn stale_memory_nudge_throttles_forces_and_suppresses_json() {
         let (root, config) = config_over_temp_repo();
         // A memory bound to an unindexed/absent path resolves `gone` → drift the nudge reports.
         let toon = RagRatService::new(config.clone(), OutputFormat::Toon);
@@ -636,14 +674,95 @@ mod tests {
         toon.call("memory_validate", json!({})).unwrap();
         toon.call("memory_validate", json!({})).unwrap();
 
-        // TOON (default, LLM-facing): nudge present as a second block.
-        let toon_result = toon.call("index_status", json!({})).unwrap();
-        assert_eq!(toon_result.content.len(), 2, "TOON result carries the nudge block");
-
-        // JSON mode: suppressed (single parseable block).
+        // JSON mode NEVER shows the prose nudge (would break JSON-parsing clients).
         let json_svc = RagRatService::new(config, OutputFormat::Json);
-        let json_result = json_svc.call("index_status", json!({})).unwrap();
-        assert_eq!(json_result.content.len(), 1, "JSON result omits the prose nudge");
+        assert!(json_svc.stale_memory_nudge("index_status").is_none(), "JSON suppresses the nudge");
+
+        // A memory_create FORCES the nudge regardless of the throttle window, and proves it rides a
+        // real TOON tool result as a second content block. (n stays > 0 — this new binding is
+        // `current`, the original one is still `gone`.)
+        let forced = toon
+            .call(
+                "memory_create",
+                json!({
+                    "kind": "Decision", "title": "another", "body": "b", "confidence": "high",
+                    "bind": {"path": "also/absent.rs"}
+                }),
+            )
+            .unwrap();
+        assert_eq!(forced.content.len(), 2, "a forced nudge rides the tool result as a 2nd block");
+
+        // Immediately after — within the window — a plain read tool is THROTTLED (nudge
+        // suppressed).
+        assert!(
+            toon.stale_memory_nudge("semantic_search").is_none(),
+            "throttled inside the window",
+        );
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    /// #752 end-to-end: in TOON (LLM-facing) mode a repo memory riding a DRIVE-BY result
+    /// (symbol_lookup) is full on first surface and STUBBED on re-show within the session, while an
+    /// EXPLICIT `memory_*` tool is never trimmed. JSON mode is UNTRIMMED even on repeat, so
+    /// programmatic clients keep stable, complete shapes (Codex #752 review).
+    #[test]
+    fn drive_by_memories_dedup_in_toon_but_json_mode_is_untrimmed() {
+        fn text_of(result: &CallToolResult) -> String {
+            result.content[0].as_text().unwrap().text.clone()
+        }
+        fn call_json(svc: &RagRatService, tool: &str, args: Value) -> Value {
+            serde_json::from_str(&text_of(&svc.call(tool, args).unwrap())).unwrap()
+        }
+
+        let (root, config) = config_over_temp_repo(); // indexes `open_database`
+        let lookup_args = json!({"symbol": "open_database", "allow_ambiguous": true});
+        const ELIDED: &str = "already surfaced this session";
+
+        // Setup on a JSON service (results parse cleanly): resolve the symbol, bind a memory to it
+        // so it rides drive-by results. The anchor is `current` (real indexed symbol) → no nudge.
+        let json_svc = RagRatService::new(config.clone(), OutputFormat::Json);
+        let lookup = call_json(&json_svc, "symbol_lookup", lookup_args.clone());
+        let sym_id = lookup["candidates"][0]["id"].as_str().unwrap().to_string();
+        let created = call_json(
+            &json_svc,
+            "memory_create",
+            json!({
+                "kind": "Invariant", "title": "db open invariant",
+                "body": "a distinctive memory body", "confidence": "high",
+                "bind": {"id": sym_id.clone()}
+            }),
+        );
+        let mem_id = created["memory"]["memory_id"].as_str().unwrap().to_string();
+
+        // TOON: first surface carries the full memory (no stub marker); the re-show is stubbed —
+        // the `elided` marker appears, id + title stay. (A fresh service = a fresh per-agent
+        // seen-set.)
+        let toon = RagRatService::new(config.clone(), OutputFormat::Toon);
+        let first = text_of(&toon.call("symbol_lookup", lookup_args.clone()).unwrap());
+        assert!(first.contains(&mem_id), "the memory rides the first drive-by result");
+        assert!(!first.contains(ELIDED), "first TOON surface is the full memory, not a stub");
+        let second = text_of(&toon.call("symbol_lookup", lookup_args.clone()).unwrap());
+        assert!(second.contains(ELIDED), "re-shown drive-by memory is stubbed with a fetch hint");
+        assert!(
+            second.contains(&mem_id) && second.contains("db open invariant"),
+            "the stub keeps the id and title",
+        );
+
+        // An EXPLICIT memory tool is NEVER trimmed — even though this agent already saw the memory
+        // via the drive-by surfaces above, `memory_for_symbol` returns it in full, not a stub.
+        let explicit =
+            text_of(&toon.call("memory_for_symbol", json!({"id": sym_id.clone()})).unwrap());
+        assert!(explicit.contains(&mem_id), "the explicit memory tool returns the memory");
+        assert!(!explicit.contains(ELIDED), "the explicit memory tool is not stubbed");
+
+        // JSON mode is UNTRIMMED even on repeat: the drive-by memory keeps its full shape, no stub.
+        for _ in 0..2 {
+            let v = call_json(&json_svc, "symbol_lookup", lookup_args.clone());
+            let m = &v["candidates"][0]["memories"][0];
+            assert_eq!(m["memory_id"].as_str(), Some(mem_id.as_str()));
+            assert!(m["elided"].is_null(), "JSON mode never stubs a drive-by memory");
+        }
 
         let _ = std::fs::remove_dir_all(root);
     }

--- a/crates/rag-rat-mcp/src/server.rs
+++ b/crates/rag-rat-mcp/src/server.rs
@@ -162,11 +162,15 @@ impl RagRatService {
             return None;
         }
         // A memory create/update forces the nudge (and resets the window); everything else is gated
-        // on the shared throttle. The slot is claimed atomically — a `false` return means either
-        // throttled or another session just claimed it, so this call stays silent.
+        // on the throttle. The slot is claimed atomically — a `false` return means throttled or
+        // another session just claimed it, so this call stays silent. Keyed by `repo_id` (the same
+        // identity the per-repo write lock uses) so repos sharing a global DB don't mute each other
+        // (#753 review); resolving it here, gated behind `n > 0`, keeps it off the common path.
         let force = matches!(tool, "memory_create" | "memory_update");
+        let repo_id = rag_rat_base::locks::write_lock_repo_id(config);
         if !rag_rat_core::sidecar_state::take_memory_nudge_slot(
             &config.database,
+            &repo_id,
             rag_rat_base::time::now_ms(),
             NUDGE_TTL_MS,
             force,

--- a/crates/rag-rat-mcp/src/tools/tests.rs
+++ b/crates/rag-rat-mcp/src/tools/tests.rs
@@ -346,10 +346,15 @@ fn enum_like_tool_args_reject_unknown_values_during_decoding() {
 fn index_status_surfaces_version_when_cached_and_enabled() {
     let (root, config) = mixed_config();
     IndexDatabase::rebuild(&config).unwrap();
-    // Seed a clearly-newer cached crates.io result next to the index (cache_path is public; the
-    // network refresh that normally writes this is out of band).
-    let cache = rag_rat_core::version_check::cache_path(&config.database);
-    std::fs::write(&cache, r#"{"latest_version":"99.0.0","checked_at_ms":1}"#).unwrap();
+    // Seed a clearly-newer cached crates.io result into the combined sidecar store (the network
+    // refresh that normally writes this is out of band).
+    rag_rat_core::sidecar_state::write_version_cache(
+        &config.database,
+        &rag_rat_core::version_check::CachedVersion {
+            latest_version: "99.0.0".into(),
+            checked_at_ms: 1,
+        },
+    );
 
     let status = call_tool_for_config(&config, "index_status", json!({})).unwrap();
     let version = status.get("version").expect("index_status surfaces a version field");

--- a/crates/rag-rat-query/src/graph/mod.rs
+++ b/crates/rag-rat-query/src/graph/mod.rs
@@ -110,6 +110,13 @@ pub struct GraphTraversalSummary {
     pub completeness_note: Option<String>,
 }
 
+/// The `find_callers`-found-zero completeness note (#200). A const so the MCP output layer can
+/// recognize this always-identical string and throttle the repeat per agent (#752).
+pub const NO_STATIC_CALLERS_NOTE: &str = "no static callers found; a static call graph can't see \
+                                          callers reached via message/enum dispatch, dynamic \
+                                          dispatch, trait objects, FFI, or reflection, nor \
+                                          external/entry-point callers — 0 may be incomplete";
+
 #[derive(Debug, Default, Serialize)]
 pub struct GraphCoverage {
     pub indexed_files: u64,

--- a/crates/rag-rat-query/src/graph/traverse.rs
+++ b/crates/rag-rat-query/src/graph/traverse.rs
@@ -285,12 +285,7 @@ pub fn traversal_summary(
         if summary.completeness_risk == "low" {
             summary.completeness_risk = "medium".to_string();
         }
-        summary.completeness_note = Some(
-            "no static callers found; a static call graph can't see callers reached via \
-             message/enum dispatch, dynamic dispatch, trait objects, FFI, or reflection, nor \
-             external/entry-point callers — 0 may be incomplete"
-                .to_string(),
-        );
+        summary.completeness_note = Some(super::NO_STATIC_CALLERS_NOTE.to_string());
     }
     Ok(summary)
 }

--- a/crates/rag-rat-query/src/impact/mod.rs
+++ b/crates/rag-rat-query/src/impact/mod.rs
@@ -15,6 +15,13 @@ use crate::graph::{self, GraphHop, GraphResolutionMode, GraphTraversalOptions};
 use crate::memory::{self, CompactRepoMemoryEvidence, RepoMemoryEvidence};
 use crate::symbol::SymbolHit;
 
+/// The always-present impact/graph disclaimer: tree-sitter evidence is syntactic, not
+/// compiler-grade. Exposed as a const so the MCP output layer can recognize it and throttle the
+/// repeat per agent (#752) — it is the same string every call, so an agent only needs it once in a
+/// while.
+pub const GRAPH_SYNTACTIC_CAVEAT: &str =
+    "Graph evidence is tree-sitter/syntactic, not compiler-grade name resolution.";
+
 /// An FTS5 phrase query for `needle` (a symbol name / qualified name / path), or `None` when it has
 /// no alphanumeric token. Used to find chunks that MENTION the needle through the `chunk_fts` index
 /// instead of a raw `chunks.text LIKE '%needle%'` full-table scan — same intent, but tokenized +
@@ -279,9 +286,7 @@ pub fn impact_surface_report_for_symbol(
             false,
         )
     };
-    let mut caveats = vec![
-        "Graph evidence is tree-sitter/syntactic, not compiler-grade name resolution.".to_string(),
-    ];
+    let mut caveats = vec![GRAPH_SYNTACTIC_CAVEAT.to_string()];
     if options.resolution_mode == GraphResolutionMode::Exact
         && direct_semantic_callers.is_empty()
         && !text_fallback_hits.is_empty()


### PR DESCRIPTION
Closes #752.

Every non-memory MCP tool result carried the same meta on **every** call — the stale-anchor rebind nudge, the always-identical graph caveats, and per-edge flags that only matter when false. That inflated the token cost for the LLM reading the results. This trims the repeats.

## What changed

- **Rebind nudge throttled.** It rode nearly every tool call; now it shows at most once per 30 min across the fleet (a shared last-shown timestamp), *except* a `memory_create`/`memory_update` forces it (and resets the window). The timestamp lives in a new combined sidecar `.rag-rat/mcp-state.json` that also absorbs the old `version-check.json` cache — migrated on first read, so a still-fresh version check isn't thrown away.
- **Drive-by repo memories deduped per agent.** A memory riding a result the agent already saw this session collapses to a tiny `{memory_id, title, elided}` stub (id + title kept, `memory_show` for detail). Explicit `memory_*` tools are never trimmed — there the agent asked for the memory, so it gets it in full.
- **Static caveats throttled.** The two always-identical disclaimers (the syntactic-evidence caveat on `impact_surface`, the no-static-callers note on `find_callers`) show once per agent, then are elided. Dynamic caveats (truncation, gap counts) always pass.
- **Redundant per-edge flags dropped.** `shown_by_default` / `verified_target_symbol` when `true` (interesting only when false), `edge_confidence` when it equals the displayed `confidence`.

## Invariants

- **Trimming is TOON-only.** It's a lossy transform (stubs a memory, drops fields), so it stays off `--json` mode, whose purpose is stable, complete shapes for programmatic clients — the same reason the prose nudge is JSON-suppressed. The query structs and CLI stay fully explicit; only the LLM-facing output is trimmed.
- **Per-agent dedup state is in-process.** One MCP process = one session = "this agent"; a TTL seen-set in an `Arc`, mirroring the existing `agent_hook` session dedup. Not shared across processes.
- **The sidecar RMW lock is non-blocking** (`try_acquire`, skip-on-contention). The nudge path runs on nearly every tool call, so a blocking wait would let one stuck peer process freeze all sessions; the state is advisory and self-correcting, so a skipped write is safe.

## Tests

- `sidecar_state`: nudge throttle/force/window + version-cache coexistence in one file.
- `output_trim`: memory dedup (full → stub, bindings not mistaken for memories, nested lanes), static-caveat throttle vs dynamic pass-through, static completeness-note throttle, edge-flag drop vs kept-when-informative.
- `server`: nudge throttles/forces/JSON-suppresses; drive-by dedup e2e in TOON with JSON mode proven untrimmed.
- Full workspace: `cargo nextest run --workspace --no-default-features` green (3112 tests); all four CI clippy gates + nightly fmt clean.