### PR TITLE
feat(distill): deterministic distilled-record store + extraction pass (#703)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3473,6 +3473,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulldown-cmark"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
+dependencies = [
+ "bitflags 2.13.0",
+ "memchr",
+ "unicase",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3644,6 +3655,7 @@ dependencies = [
  "notify",
  "path-slash",
  "protobuf",
+ "pulldown-cmark",
  "rag-rat-base",
  "rag-rat-clones",
  "rag-rat-db",
@@ -5283,6 +5295,12 @@ name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-bom"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,11 @@ libc = "0.2"
 # actual path SEPARATOR — so a literal backslash in a Unix filename is preserved. Used where a path
 # becomes a string for a non-filesystem consumer (a `node`/`npx` command arg, a TOML value).
 path-slash = "0.2"
+# CommonMark parser for distill unit segmentation (#703): `OffsetIter` yields each event with its
+# source byte range, so comment/body text splits into quotable units whose byte spans stay exact for
+# mechanical quote materialization. `default-features = false` drops the unused HTML renderer; only
+# the pull parser + `Options` are used. No `getrandom`/`simd` features.
+pulldown-cmark = { version = "0.13", default-features = false }
 # Async HTTP for the papertrail provider clients (#589). rustls (no system OpenSSL), no default
 # features — the transport is driven on the papertrail module's private runtime at the sync
 # boundary, so nothing else in the tree grows an async dependency.

--- a/crates/rag-rat-cli/src/cli.rs
+++ b/crates/rag-rat-cli/src/cli.rs
@@ -86,6 +86,11 @@ pub(crate) enum Command {
     /// Tracker papertrail sync.
     Papertrail(PapertrailArgs),
 
+    /// Deterministic distillation of tracker threads into records (#703). Model-free: builds the
+    /// skeleton records + fixing-commit / coalesce / anchor substrate and the work queue; the LLM
+    /// pass that fills root-cause/decision/outcome runs separately.
+    Distill(DistillArgs),
+
     /// Install / uninstall / inspect git hooks and Claude Code hooks.
     Hooks(HooksArgs),
 
@@ -665,6 +670,19 @@ pub(crate) enum PapertrailCommand {
         #[arg(long)]
         full: bool,
     },
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct DistillArgs {
+    #[command(subcommand)]
+    pub command: DistillCommand,
+}
+
+#[derive(Debug, Subcommand)]
+pub(crate) enum DistillCommand {
+    /// Run the deterministic extraction pass over the mirror: skeleton records, fixing commits,
+    /// coalesced edges, anchor candidates, and the distill queue (model columns left for #704).
+    Extract,
 }
 
 #[derive(Debug, Args)]

--- a/crates/rag-rat-cli/src/commands/distill.rs
+++ b/crates/rag-rat-cli/src/commands/distill.rs
@@ -1,0 +1,28 @@
+//! `distill` command (#703): the deterministic, model-free distillation pass. Opens the index
+//! read-write (base-scoped, so anchor mining reads the correct symbol scope) and runs the
+//! extraction over the current mirror, reporting what it produced.
+
+use rag_rat_base::config::Config;
+
+use crate::cli::{DistillArgs, DistillCommand};
+use crate::open_index;
+use crate::render::print_output;
+
+pub(crate) fn distill(config: &Config, args: &DistillArgs) -> anyhow::Result<()> {
+    match &args.command {
+        DistillCommand::Extract => {
+            // `extract` is a WRITER (skeleton records + junctions + queue) that also reads the
+            // symbol index for anchors, so it must serialize with indexing under the per-repo write
+            // lock like every other CLI writer — otherwise a concurrent generation switch can pin
+            // the scope views to a stale generation and mine anchors from stale symbols. Held for
+            // the whole pass.
+            let lock_repo = rag_rat_base::locks::write_lock_repo_id(config);
+            let _lock =
+                rag_rat_base::locks::WriteLock::acquire_blocking(&config.database, &lock_repo)?;
+            let db = open_index(config)?;
+            // Route through the shared renderer so the global `--json` flag is honored (the report
+            // is `Serialize`); TOON otherwise.
+            print_output(&db.distill_extract()?)
+        },
+    }
+}

--- a/crates/rag-rat-cli/src/commands/mod.rs
+++ b/crates/rag-rat-cli/src/commands/mod.rs
@@ -7,6 +7,7 @@
 mod clones;
 mod config_info;
 mod consolidate;
+mod distill;
 #[cfg(feature = "eval")]
 mod dump_verify_packs;
 mod format;
@@ -21,6 +22,7 @@ mod search;
 pub(crate) use clones::{clones, clones_for};
 pub(crate) use config_info::{dump_config, version_check};
 pub(crate) use consolidate::consolidate;
+pub(crate) use distill::distill;
 #[cfg(feature = "eval")]
 pub(crate) use dump_verify_packs::dump_verify_packs;
 pub(crate) use format::{output_format, set_output_format};

--- a/crates/rag-rat-cli/src/main.rs
+++ b/crates/rag-rat-cli/src/main.rs
@@ -115,6 +115,7 @@ fn main() -> anyhow::Result<()> {
         Cmd::Memory(args) => memory(&config, &args)?,
         Cmd::Dream(args) => dream(&config, &args)?,
         Cmd::Papertrail(args) => papertrail(&config, &args)?,
+        Cmd::Distill(args) => distill(&config, &args)?,
         Cmd::Hooks(args) => hooks(&config, &args)?,
         Cmd::Maintenance(args) => maintenance(&config, &args)?,
         Cmd::Models(args) => models(&config, &args)?,

--- a/crates/rag-rat-core/Cargo.toml
+++ b/crates/rag-rat-core/Cargo.toml
@@ -32,6 +32,7 @@ httpdate.workspace = true
 ignore = "0.4.26"
 model2vec-rs = { version = "0.2.1", default-features = false, features = ["hf-hub", "fancy-regex"], optional = true }
 notify = "8.2.0"
+pulldown-cmark.workspace = true
 rayon.workspace = true
 regex.workspace = true
 rusqlite.workspace = true

--- a/crates/rag-rat-core/src/distill/candidates.rs
+++ b/crates/rag-rat-core/src/distill/candidates.rs
@@ -1,0 +1,217 @@
+//! Anchor-candidate mining for distilled records (#703).
+//!
+//! Anchors bind a record to the code its fix touched. They are mined MECHANICALLY from the files a
+//! fixing commit changed and validated against the LIVE symbol index — never fuzzy-matched, never
+//! basename-guessed. A symbol anchor carries the `sym_<hex>` logical-symbol handle (relocation-
+//! compatible: it self-heals across cross-file moves) and its EXACT indexed path; a file anchor
+//! carries the exact indexed path. Test and generated files are excluded — a fix's test churn is
+//! not where its decision lives. #704's model selects from these candidates by index; it cannot
+//! invent an anchor that mining did not surface.
+
+use rag_rat_base::{path_class, serde_big_id};
+use rusqlite::{Connection, OptionalExtension};
+
+/// A single mined anchor. `resolved` means index-validated (a symbol with a logical id, or a path
+/// present in the `files` scope) — only resolved anchors count toward `anchors_qualified_count`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct AnchorCandidate {
+    pub kind: AnchorKind,
+    /// `sym_<hex>` for a resolved symbol anchor; `None` for file anchors or unresolved symbols.
+    pub logical_symbol_id: Option<String>,
+    /// The exact indexed path (source of the anchor); `None` only if a symbol lacks a path row.
+    pub file_path: Option<String>,
+    pub name: String,
+    pub resolved: bool,
+}
+
+pub(crate) use rag_rat_papertrail::AnchorKind;
+
+/// Caps that bound how much a single sprawling fixing commit can inflate the candidate pool.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct AnchorCaps {
+    pub max_files: usize,
+    pub max_symbols_per_file: usize,
+    pub max_total: usize,
+}
+
+impl Default for AnchorCaps {
+    fn default() -> Self {
+        Self { max_files: 15, max_symbols_per_file: 20, max_total: 40 }
+    }
+}
+
+/// Mine anchor candidates from the changed paths of a record's fixing commits. `changed_paths` is
+/// the deduped set of files those commits touched (from `git_file_changes`); this filters out test
+/// and generated files, emits a file anchor per surviving source path present in the index, and a
+/// symbol anchor per symbol defined in that path (logical id when the index has one). Symbol reads
+/// go through the per-connection `files`/`symbols` scope views, so they are already repo- and
+/// generation-scoped.
+pub(crate) fn mine_anchor_candidates(
+    conn: &Connection,
+    changed_paths: &[String],
+    caps: AnchorCaps,
+) -> anyhow::Result<Vec<AnchorCandidate>> {
+    let mut anchors = Vec::new();
+    let mut files_used = 0usize;
+    for path in changed_paths {
+        if anchors.len() >= caps.max_total || files_used >= caps.max_files {
+            break;
+        }
+        if path_class::is_test_path(path) || path_class::is_generated_path(path) {
+            continue;
+        }
+        // A file anchor only when the path is actually indexed in this scope AND is not generated
+        // (no basename fallback, no anchoring to a path the index has never seen).
+        // `files.generated` is the repo's canonical generated classification — it folds
+        // file kind + path heuristics, so it catches registry-classified generated files
+        // the path heuristic above misses.
+        let indexed = conn
+            .query_row(
+                "SELECT 1 FROM files WHERE path = ?1 AND generated = 0 LIMIT 1",
+                [path],
+                |_| Ok(()),
+            )
+            .optional()?
+            .is_some();
+        if !indexed {
+            continue;
+        }
+        files_used += 1;
+        anchors.push(AnchorCandidate {
+            kind: AnchorKind::File,
+            logical_symbol_id: None,
+            file_path: Some(path.clone()),
+            name: path.clone(),
+            resolved: true,
+        });
+        for (name, logical) in symbols_in_file(conn, path, caps.max_symbols_per_file)? {
+            if anchors.len() >= caps.max_total {
+                break;
+            }
+            let logical_symbol_id = logical.map(serde_big_id::format_sym_handle);
+            let resolved = logical_symbol_id.is_some();
+            anchors.push(AnchorCandidate {
+                kind: AnchorKind::Symbol,
+                logical_symbol_id,
+                file_path: Some(path.clone()),
+                name,
+                resolved,
+            });
+        }
+    }
+    Ok(anchors)
+}
+
+/// `(symbol_name, logical_symbol_id)` for the symbols defined in `path`, lowest symbol id first,
+/// capped. The `files`/`symbols` reads ride the per-connection scope views; the LEFT JOIN yields a
+/// `NULL` logical id for a symbol not yet folded into a logical group (an unresolved candidate).
+fn symbols_in_file(
+    conn: &Connection,
+    path: &str,
+    limit: usize,
+) -> anyhow::Result<Vec<(String, Option<i64>)>> {
+    let mut stmt = conn.prepare(
+        "SELECT symbols.name, members.logical_symbol_id
+         FROM symbols
+         JOIN files ON files.id = symbols.file_id
+         LEFT JOIN logical_symbol_members members ON members.symbol_id = symbols.id
+         WHERE files.path = ?1
+         ORDER BY symbols.id
+         LIMIT ?2",
+    )?;
+    let rows = stmt.query_map(rusqlite::params![path, limit as i64], |row| {
+        Ok((row.get::<_, String>(0)?, row.get::<_, Option<i64>>(1)?))
+    })?;
+    let mut out = Vec::new();
+    for row in rows {
+        out.push(row?);
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use rusqlite::Connection;
+
+    use super::{AnchorCaps, AnchorKind, mine_anchor_candidates};
+
+    /// Minimal `files` + `symbols` + `logical_symbol_members` fixture (real tables, not the scope
+    /// views — the test binds paths directly, which the `WHERE files.path = ?` query reads the
+    /// same).
+    fn fixture() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "
+            CREATE TABLE files(id INTEGER PRIMARY KEY, path TEXT, generated INTEGER NOT NULL \
+             DEFAULT 0);
+            CREATE TABLE symbols(id INTEGER PRIMARY KEY, file_id INTEGER, name TEXT);
+            CREATE TABLE logical_symbol_members(symbol_id INTEGER, logical_symbol_id INTEGER);
+            INSERT INTO files(id, path, generated) VALUES
+                (1, 'crates/core/src/engine.rs', 0),
+                (2, 'crates/core/tests/engine_test.rs', 0),
+                (3, 'crates/core/src/generated/wire.rs', 0),
+                -- a normal-looking source path the LANGUAGE REGISTRY flagged generated (the path
+                -- heuristic would miss it; the `files.generated` flag must exclude it).
+                (4, 'crates/core/src/bindings.rs', 1);
+            INSERT INTO symbols(id, file_id, name) VALUES
+                (10, 1, 'run_engine'),
+                (11, 1, 'EngineState'),
+                (20, 2, 'test_helper'),
+                (40, 4, 'GeneratedBinding');
+            -- run_engine is folded into a logical group; EngineState is not (unresolved \
+             candidate).
+            INSERT INTO logical_symbol_members(symbol_id, logical_symbol_id) VALUES (10, 123456);
+            ",
+        )
+        .unwrap();
+        conn
+    }
+
+    #[test]
+    fn mines_file_and_symbol_anchors_from_a_source_path() {
+        let conn = fixture();
+        let anchors = mine_anchor_candidates(
+            &conn,
+            &["crates/core/src/engine.rs".into()],
+            AnchorCaps::default(),
+        )
+        .unwrap();
+        // one file anchor + two symbol anchors.
+        assert_eq!(anchors.len(), 3);
+        assert_eq!(anchors[0].kind, AnchorKind::File);
+        assert!(anchors[0].resolved);
+        let run = anchors.iter().find(|a| a.name == "run_engine").unwrap();
+        assert_eq!(run.kind, AnchorKind::Symbol);
+        assert!(run.resolved, "a symbol with a logical id resolves");
+        assert_eq!(run.logical_symbol_id.as_deref(), Some("sym_1e240")); // 123456 == 0x1e240
+        let state = anchors.iter().find(|a| a.name == "EngineState").unwrap();
+        assert!(!state.resolved, "no logical id → unresolved candidate");
+        assert_eq!(state.logical_symbol_id, None);
+    }
+
+    #[test]
+    fn skips_test_and_generated_and_unindexed_paths() {
+        let conn = fixture();
+        let anchors = mine_anchor_candidates(
+            &conn,
+            &[
+                "crates/core/tests/engine_test.rs".into(), // test → skipped
+                "crates/core/src/generated/wire.rs".into(), // generated (path) → skipped
+                "crates/core/src/bindings.rs".into(),      // generated (files.generated) → skipped
+                "crates/core/src/absent.rs".into(),        // not indexed → skipped
+            ],
+            AnchorCaps::default(),
+        )
+        .unwrap();
+        assert!(anchors.is_empty(), "no anchors from test/generated/unindexed paths");
+    }
+
+    #[test]
+    fn respects_the_total_cap() {
+        let conn = fixture();
+        let caps = AnchorCaps { max_files: 15, max_symbols_per_file: 20, max_total: 2 };
+        let anchors =
+            mine_anchor_candidates(&conn, &["crates/core/src/engine.rs".into()], caps).unwrap();
+        assert_eq!(anchors.len(), 2, "capped at max_total");
+    }
+}

--- a/crates/rag-rat-core/src/distill/extract.rs
+++ b/crates/rag-rat-core/src/distill/extract.rs
@@ -1,0 +1,2214 @@
+//! Deterministic distill extraction (#703): the model-free pass that turns the papertrail mirror
+//! into skeleton distilled records ready for the LLM pass (#704).
+//!
+//! Eligibility is v1-narrow: CLOSED issues and MERGED change requests, filtered on
+//! `state_normalized` (never raw `state` — a merged GitLab MR carries `state='merged'`). An issue
+//! closed by a merged PR COALESCES: one record keyed to the ISSUE thread, the PR reachable through
+//! a `coalesced` edge, both threads' text folded into the input. Everything a model does not decide
+//! is computed here and stored raw: the fix edge's provenance, the mechanical fixing commits, the
+//! anchor candidates, the status floors. The LLM columns are left NULL — honest nulls the #704 pass
+//! fills by upsert on the same natural key.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use rag_rat_base::time::now_ms;
+use rag_rat_db::schema::active_repo_id;
+use rag_rat_papertrail::{FixEdgeSource, ItemKind, OutcomeStatus};
+use rusqlite::{Connection, OptionalExtension, params};
+use sha2::{Digest, Sha256};
+
+use crate::distill::candidates::{self, AnchorCaps};
+use crate::distill::{units, validate};
+
+/// Bumped whenever the extraction/prompt contract changes in a way that invalidates existing
+/// records — part of the regeneration identity alongside `distill_input_hash`.
+pub(crate) const PIPELINE_VERSION: i64 = 1;
+
+/// Default byte budget for a thread's assembled units (head+tail retained, middle dropped).
+const DEFAULT_MAX_THREAD_BYTES: usize = 26_000;
+
+/// Knobs for one extraction pass.
+pub(crate) struct ExtractOptions {
+    pub pipeline_version: i64,
+    pub max_thread_bytes: usize,
+    pub anchor_caps: AnchorCaps,
+}
+
+impl Default for ExtractOptions {
+    fn default() -> Self {
+        Self {
+            pipeline_version: PIPELINE_VERSION,
+            max_thread_bytes: DEFAULT_MAX_THREAD_BYTES,
+            anchor_caps: AnchorCaps::default(),
+        }
+    }
+}
+
+/// What one extraction pass did — enough to log an honest before/after without a second query.
+#[derive(Debug, Default, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct ExtractReport {
+    pub eligible: usize,
+    pub records_written: usize,
+    pub coalesced_pairs: usize,
+    pub queued: usize,
+    pub fix_edge_provider: usize,
+    pub fix_edge_text: usize,
+    pub fix_edge_none: usize,
+    /// The MECHANICAL effective status (floors only, model absent): how many records the
+    /// deterministic floors already resolve to `landed` (closing keyword) or `reverted` before the
+    /// model ever runs; the rest stay `unclear` pending #704.
+    pub mechanical_landed: usize,
+    pub mechanical_reverted: usize,
+    pub mechanical_unclear: usize,
+}
+
+/// Cheap enqueue that RIDES the mirror sync: insert every currently-eligible thread key into the
+/// distill queue, skipping keys already queued. No unit segmentation, no anchor mining, no LLM — a
+/// single INSERT…SELECT so it fits inside the sync's short serialized writes. The DRAIN (#704) is
+/// where the expensive work happens; it never runs here. Returns the number of newly queued
+/// threads.
+pub(crate) fn enqueue_eligible(conn: &Connection) -> anyhow::Result<usize> {
+    let repo_id = active_repo_id(conn)?;
+    let now = now_ms();
+    // Eligible = closed issues + merged change requests, on the normalized state — but only threads
+    // that have NOT already been distilled (no current record) and are NOT a PR already coalesced
+    // into an issue record. Without these guards, every drain (which removes the queue row) would
+    // be undone by the next sync re-inserting the completed thread, re-paying the LLM cost
+    // forever. A thread whose INPUT changed is re-detected by the heavy extraction pass (hash
+    // recompute), not the cheap enqueue. `DO NOTHING` keeps an already-queued thread's
+    // attempts/errors intact.
+    let queued = conn.execute(
+        "INSERT INTO papertrail_distill_queue
+             (tracker, project, item_kind, item_key, enqueued_at_ms, repo_id)
+         SELECT i.tracker, i.project, i.item_kind, i.item_key, ?2, i.repo_id
+         FROM papertrail_items i
+         WHERE i.repo_id = ?1
+           AND ( (i.item_kind = 'issue' AND i.state_normalized = 'closed')
+              OR (i.item_kind = 'change_request' AND i.state_normalized = 'merged') )
+           AND NOT EXISTS (
+               SELECT 1 FROM papertrail_distill d
+               WHERE d.repo_id = i.repo_id AND d.tracker = i.tracker AND d.project = i.project
+                 AND d.item_kind = i.item_kind AND d.item_key = i.item_key)
+           AND NOT EXISTS (
+               SELECT 1 FROM papertrail_distill_edges e
+               WHERE e.repo_id = i.repo_id AND e.tracker = i.tracker AND e.project = i.project
+                 AND e.dst_item_kind = i.item_kind AND e.dst_item_key = i.item_key
+                 AND e.edge_kind = 'coalesced')
+         ON CONFLICT(repo_id, tracker, project, item_kind, item_key) DO NOTHING",
+        params![repo_id, now],
+    )?;
+    Ok(queued)
+}
+
+/// Run the full deterministic extraction over the active repo's mirror. Writes a skeleton
+/// `papertrail_distill` row (mechanical columns populated, model columns NULL), its fixing commits,
+/// coalesced edges, and anchor candidates for every eligible thread, and enqueues each. Idempotent:
+/// a record's thread-keyed junction rows are cleared and rebuilt, and the record row upserts on its
+/// natural key.
+pub(crate) fn extract(
+    conn: &Connection,
+    root: Option<&std::path::Path>,
+    opts: &ExtractOptions,
+) -> anyhow::Result<ExtractReport> {
+    let repo_id = active_repo_id(conn)?;
+    let now = now_ms();
+    // Open the repo ONCE for the whole pass so anchor mining can fall back to a live gix
+    // first-parent diff for merge-commit fixes (which carry no `git_file_changes` rows). Absent /
+    // undiscoverable root → no fallback (indexed rows only).
+    let repo = root.and_then(|r| rag_rat_base::repo_discover::discover_repo(r).ok());
+    // The ENTIRE pass — mirror reads, planning, reconciliation, and writes — runs inside ONE
+    // IMMEDIATE transaction. Papertrail sync uses a separate flight lock and mutates these mirror
+    // tables concurrently; reading them outside the write txn would let a sync land between the
+    // reads and the reconciliation writes, planning off a stale/mixed snapshot (records/queue for
+    // threads that just reopened or coalesced). BEGIN IMMEDIATE takes the write lock up front, so
+    // the reads and writes see one consistent snapshot.
+    in_txn(conn, || {
+        let items = load_items(conn, &repo_id)?;
+        let edges = load_closing_edges(conn, &repo_id)?;
+
+        // Index items by their FULL thread identity (tracker, project, kind_token, key): within one
+        // repo, issue/PR numbers are only unique per (tracker, project) — a repo can mirror several
+        // tracker bindings — so keying by kind/key alone would collide same-numbered items across
+        // projects. `merged_prs` drops the kind (always change_request).
+        let mut by_key: BTreeMap<(String, String, &'static str, String), &ItemRow> =
+            BTreeMap::new();
+        let mut merged_prs: BTreeMap<(String, String, String), &ItemRow> = BTreeMap::new();
+        let mut closed_issues: Vec<&ItemRow> = Vec::new();
+        for item in &items {
+            by_key.insert(
+                (
+                    item.tracker.clone(),
+                    item.project.clone(),
+                    item.kind.as_db_str(),
+                    item.key.clone(),
+                ),
+                item,
+            );
+            match item.kind {
+                ItemKind::Issue if item.state_normalized == "closed" => closed_issues.push(item),
+                ItemKind::ChangeRequest if item.state_normalized == "merged" => {
+                    merged_prs.insert(
+                        (item.tracker.clone(), item.project.clone(), item.key.clone()),
+                        item,
+                    );
+                },
+                _ => {},
+            }
+        }
+
+        // Closing edges grouped by the (tracker, project, issue) they close.
+        let mut edges_by_issue: BTreeMap<(String, String, String), Vec<&ClosingEdgeRow>> =
+            BTreeMap::new();
+        for edge in &edges {
+            edges_by_issue
+                .entry((edge.tracker.clone(), edge.project.clone(), edge.issue_key.clone()))
+                .or_default()
+                .push(edge);
+        }
+
+        // Plan the records: closed issues (coalescing their merged-PR closers within the same
+        // project), then merged PRs that no issue coalesced away.
+        let mut coalesced_away: BTreeSet<(String, String, String)> = BTreeSet::new();
+        let mut plans: Vec<RecordPlan> = Vec::new();
+        for issue in &closed_issues {
+            let issue_edges = edges_by_issue
+                .get(&(issue.tracker.clone(), issue.project.clone(), issue.key.clone()))
+                .map(Vec::as_slice)
+                .unwrap_or(&[]);
+            let mut fix_shas: BTreeSet<String> = BTreeSet::new();
+            let mut partners: BTreeSet<String> = BTreeSet::new();
+            let mut source = FixEdgeSource::None;
+            // The closing-keyword floor is derived from the canonical parser's output, NOT a
+            // re-scan: a TEXT-tier closing edge on this ISSUE means the closer-minting tier matched
+            // a closing keyword (provider-aware — GitLab gerunds included — project-scoped, and
+            // issue-vs-PR kind-correct, none of which a hand-rolled text scan gets right).
+            let mut text_closing = false;
+            for edge in issue_edges {
+                match edge.closer_kind.as_str() {
+                    "commit" => {
+                        // A commit closer is an accepted fix edge; upgrade provenance and take the
+                        // sha.
+                        fix_shas.insert(edge.closer_key.clone());
+                        source = stronger_source(source, edge.source.as_str());
+                        text_closing |= edge.source == "text";
+                    },
+                    "change_request" => {
+                        // Only a MERGED PR in the SAME project is a real coalesce partner +
+                        // fix-commit source; a closed-unmerged PR's
+                        // merge_commit_sha is a trap (GitHub's ephemeral
+                        // test merge), so it never contributes a commit — and its edge must NOT
+                        // upgrade provenance, or the no-fix-edge floor
+                        // would wrongly not fire.
+                        let partner_id =
+                            (issue.tracker.clone(), issue.project.clone(), edge.closer_key.clone());
+                        if let Some(pr) = merged_prs.get(&partner_id) {
+                            partners.insert(edge.closer_key.clone());
+                            coalesced_away.insert(partner_id);
+                            source = stronger_source(source, edge.source.as_str());
+                            text_closing |= edge.source == "text";
+                            if let Some(commit) =
+                                edge.closer_commit.clone().or_else(|| pr.merge_commit_sha.clone())
+                            {
+                                fix_shas.insert(commit);
+                            }
+                        }
+                    },
+                    _ => {},
+                }
+            }
+            plans.push(RecordPlan {
+                tracker: issue.tracker.clone(),
+                project: issue.project.clone(),
+                kind: ItemKind::Issue,
+                key: issue.key.clone(),
+                partners: partners.into_iter().collect(),
+                fix_shas: fix_shas.into_iter().collect(),
+                fix_edge_source: source,
+                text_closing,
+            });
+        }
+        for pr in merged_prs.values() {
+            if coalesced_away.contains(&(pr.tracker.clone(), pr.project.clone(), pr.key.clone())) {
+                continue;
+            }
+            // A standalone merged PR is its own provider-attested closure; its merge commit is the
+            // fix.
+            let fix_shas = pr.merge_commit_sha.clone().into_iter().collect();
+            plans.push(RecordPlan {
+                tracker: pr.tracker.clone(),
+                project: pr.project.clone(),
+                kind: ItemKind::ChangeRequest,
+                key: pr.key.clone(),
+                partners: Vec::new(),
+                fix_shas,
+                fix_edge_source: FixEdgeSource::Provider,
+                // The closing-keyword floor is an issue concept; a standalone merged PR's
+                // landed-ness is carried by fix_edge_source, not a closing keyword.
+                text_closing: false,
+            });
+        }
+
+        // The full set of records that SHOULD exist after this pass.
+        let planned: BTreeSet<RecordKey> = plans
+            .iter()
+            .map(|p| {
+                (
+                    p.tracker.clone(),
+                    p.project.clone(),
+                    p.kind.as_db_str().to_string(),
+                    p.key.clone(),
+                )
+            })
+            .collect();
+
+        let mut report = ExtractReport { eligible: plans.len(), ..Default::default() };
+        // Reconcile against the planned set: any persisted record no longer planned — a reopened
+        // issue, an un-merged PR, or a PR now coalesced into an issue — loses its stale
+        // record/junctions/queue so consumers never see an ineligible or duplicate record.
+        for existing in load_record_keys(conn, &repo_id)? {
+            if !planned.contains(&existing) {
+                delete_record(conn, &repo_id, &existing)?;
+            }
+        }
+        // The cheap sync enqueue queues eligible PRs BEFORE extraction runs, so a thread queued but
+        // never recorded (a PR extraction now coalesces, or a thread that became ineligible first)
+        // leaves a queue row `delete_record` never touched. Drop any queue key not in the plan so a
+        // later drain never processes a duplicate coalesced PR or an ineligible thread.
+        for queued in load_queue_keys(conn, &repo_id)? {
+            if !planned.contains(&queued) {
+                let (tracker, project, kind, key) = &queued;
+                conn.execute(
+                    "DELETE FROM papertrail_distill_queue
+                     WHERE repo_id = ?1 AND tracker = ?2 AND project = ?3 AND item_kind = ?4
+                       AND item_key = ?5",
+                    params![repo_id, tracker, project, kind, key],
+                )?;
+            }
+        }
+        for plan in &plans {
+            let written = write_record(conn, &repo_id, now, opts, plan, &by_key, repo.as_ref())?;
+            report.records_written += 1;
+            report.coalesced_pairs += plan.partners.len();
+            report.queued += written.queued;
+            match plan.fix_edge_source {
+                FixEdgeSource::Provider => report.fix_edge_provider += 1,
+                FixEdgeSource::Text => report.fix_edge_text += 1,
+                FixEdgeSource::None => report.fix_edge_none += 1,
+            }
+            match written.mechanical_status {
+                OutcomeStatus::Landed => report.mechanical_landed += 1,
+                OutcomeStatus::Reverted => report.mechanical_reverted += 1,
+                _ => report.mechanical_unclear += 1,
+            }
+        }
+        Ok(report)
+    })
+}
+
+/// The stronger of the current fix-edge source and a newly seen closing-edge `source` token:
+/// provider outranks text outranks none. Unknown tokens are treated as text (a mined tier).
+fn stronger_source(current: FixEdgeSource, token: &str) -> FixEdgeSource {
+    let seen = if token == "provider" { FixEdgeSource::Provider } else { FixEdgeSource::Text };
+    match (current, seen) {
+        (FixEdgeSource::Provider, _) | (_, FixEdgeSource::Provider) => FixEdgeSource::Provider,
+        _ => FixEdgeSource::Text,
+    }
+}
+
+struct WriteOutcome {
+    queued: usize,
+    mechanical_status: OutcomeStatus,
+}
+
+/// Assemble and persist one record: units → hash, fixing commits, coalesced edges, anchor
+/// candidates, status floors, the skeleton row, and the queue entry.
+fn write_record(
+    conn: &Connection,
+    repo_id: &str,
+    now: i64,
+    opts: &ExtractOptions,
+    plan: &RecordPlan,
+    by_key: &BTreeMap<(String, String, &'static str, String), &ItemRow>,
+    repo: Option<&gix::Repository>,
+) -> anyhow::Result<WriteOutcome> {
+    let item = by_key
+        .get(&(plan.tracker.clone(), plan.project.clone(), plan.kind.as_db_str(), plan.key.clone()))
+        .copied()
+        .ok_or_else(|| {
+            anyhow::anyhow!("record item {}#{} vanished mid-pass", plan.kind.as_db_str(), plan.key)
+        })?;
+
+    // --- Text assembly: record TITLE + body + comments, then each partner's title + body +
+    // comments, in order. The title leads because for a thin/empty-body thread it IS the problem
+    // statement, and it must ride the regeneration hash so a title-only edit re-distills. Alongside
+    // the text we collect an ordered provenance stream (source id + author association): #704
+    // snapshots per-unit provenance and gates the decision floor on maintainer authorship, so a
+    // provenance-only change (a new comment, a re-associated author) must regenerate even when
+    // the text is identical.
+    let mut blobs: Vec<String> = vec![item.title.clone(), item.body.clone()];
+    let mut provenance: Vec<(String, Option<String>)> = vec![(
+        format!("{}/{}#item", plan.kind.as_db_str(), plan.key),
+        item.author_association.clone(),
+    )];
+    // Body length spans the whole coalesced thread (issue + partner PRs), so a thin issue body with
+    // a substantial partner PR is not misclassified `thin`.
+    let mut body_len = item.body.len();
+    let record_comments =
+        load_comments(conn, repo_id, &plan.tracker, &plan.project, plan.kind, &plan.key)?;
+    let mut total_comments = record_comments.len();
+    let mut review_comments = record_comments.iter().filter(|c| c.is_review).count();
+    for comment in &record_comments {
+        blobs.push(comment.body.clone());
+        provenance.push((comment.comment_id.clone(), comment.author_association.clone()));
+    }
+    for partner in &plan.partners {
+        let partner_id = (
+            plan.tracker.clone(),
+            plan.project.clone(),
+            ItemKind::ChangeRequest.as_db_str(),
+            partner.clone(),
+        );
+        if let Some(pr) = by_key.get(&partner_id) {
+            blobs.push(pr.title.clone());
+            blobs.push(pr.body.clone());
+            provenance.push((
+                format!("{}/{partner}#item", ItemKind::ChangeRequest.as_db_str()),
+                pr.author_association.clone(),
+            ));
+            body_len += pr.body.len();
+        }
+        let partner_comments = load_comments(
+            conn,
+            repo_id,
+            &plan.tracker,
+            &plan.project,
+            ItemKind::ChangeRequest,
+            partner,
+        )?;
+        total_comments += partner_comments.len();
+        review_comments += partner_comments.iter().filter(|c| c.is_review).count();
+        for comment in &partner_comments {
+            blobs.push(comment.body.clone());
+            provenance.push((comment.comment_id.clone(), comment.author_association.clone()));
+        }
+    }
+    // Segment every blob into units, budget the concatenation head+tail, keep the retained texts.
+    let unit_texts = budgeted_unit_texts(&blobs, opts.max_thread_bytes);
+
+    let changed_paths = changed_paths_for(conn, repo_id, repo, &plan.fix_shas)?;
+    // The closing-keyword floor comes from the canonical parser's text-tier closing edge
+    // (plan.text_closing), not a re-scan of commit text — a marker string, since the specific
+    // keyword isn't load-bearing.
+    let closing_keyword: Option<&str> = plan.text_closing.then_some("closing");
+    // Revert detection is causal, not timestamp-ordered, and NEVER keys on the fix commit itself
+    // being a `Revert` (that is intentional revert work that LANDED — not this record being
+    // reverted). The floor fires ONLY when a downstream landed commit reverts one of THIS record's
+    // CURRENT fixing commits: git's revert body names the reverted commit ("This reverts commit
+    // <sha>"), so a reopen→revert→re-fix leaves the stale revert pointing at the OLD (replaced) fix
+    // sha — not in `fix_shas` — and correctly does not flip. A revert can name the record's OWN
+    // thread OR a coalesced partner PR (GitHub's revert says "Reverts …#<pr>"), so gather from
+    // both.
+    let mut revert_shas =
+        revert_commit_shas(conn, repo_id, &plan.tracker, &plan.project, plan.kind, &plan.key)?;
+    for partner in &plan.partners {
+        revert_shas.extend(revert_commit_shas(
+            conn,
+            repo_id,
+            &plan.tracker,
+            &plan.project,
+            ItemKind::ChangeRequest,
+            partner,
+        )?);
+    }
+    let mut revert_override = false;
+    for revert_sha in &revert_shas {
+        if let Some(commit) = commit_message(conn, repo_id, revert_sha)? {
+            let text = format!("{}\n{}", commit.subject, commit.body);
+            if plan.fix_shas.iter().any(|fix| text.contains(fix.as_str())) {
+                revert_override = true;
+                break;
+            }
+        }
+    }
+
+    // --- Anchor candidates from the changed source files. "Qualified" counts resolved SYMBOL
+    // anchors (bound to a `sym_<hex>` logical id) — the precise, high-value bindings — separately
+    // from coarser file anchors (which are also resolved but tracked as their own rate).
+    let anchors = candidates::mine_anchor_candidates(conn, &changed_paths, opts.anchor_caps)?;
+    let anchors_qualified = anchors
+        .iter()
+        .filter(|a| a.resolved && matches!(a.kind, candidates::AnchorKind::Symbol))
+        .count();
+
+    let thread_shape = validate::classify_thread_shape(total_comments, review_comments, body_len);
+
+    // The mechanical effective status (model absent) — a floors-only preview for the report.
+    let mechanical_status = validate::effective_status(&validate::EffectiveStatusInputs {
+        revert_override,
+        closing_keyword: closing_keyword.is_some(),
+        fix_edge_source: plan.fix_edge_source,
+        model_status: None,
+    });
+
+    let input_hash = compute_input_hash(&HashInputs {
+        pipeline_version: opts.pipeline_version,
+        plan,
+        unit_texts: &unit_texts,
+        changed_paths: &changed_paths,
+        provenance: &provenance,
+        revert_override,
+        closing_keyword,
+        anchors: &anchors,
+    });
+
+    // Record state drives model-invalidation + enqueue: a New or Regenerated record is enqueued for
+    // #704; an Unchanged one is NOT (re-enqueuing after a drain would re-pay the LLM cost). On
+    // regeneration the model columns + model junctions (evidence, alternatives) are cleared so a
+    // consumer never sees an old decision/outcome pinned to new input; an identical rerun preserves
+    // the model's work.
+    let state = record_state(conn, repo_id, plan, &input_hash, opts.pipeline_version)?;
+    let regenerated = state == RecordState::Regenerated;
+
+    // --- Persist: rebuild this thread's mechanical junctions, upsert the skeleton row (clearing
+    // model columns on regeneration), rewrite junctions, queue.
+    clear_mechanical_junctions(conn, repo_id, plan)?;
+    if regenerated {
+        clear_model_junctions(conn, repo_id, plan)?;
+    }
+    upsert_skeleton(conn, repo_id, now, opts, plan, regenerated, &SkeletonFacets {
+        input_hash: &input_hash,
+        fix_edge_source: plan.fix_edge_source,
+        anchors_qualified,
+        thread_shape: thread_shape.as_db_str(),
+        revert_override,
+        closing_keyword,
+    })?;
+    write_commits(conn, repo_id, plan, &plan.fix_shas)?;
+    write_coalesced_edges(conn, repo_id, now, plan)?;
+    write_anchors(conn, repo_id, plan, &anchors)?;
+    let queued = if matches!(state, RecordState::New | RecordState::Regenerated) {
+        enqueue_one(conn, repo_id, now, item, regenerated)?
+    } else {
+        0
+    };
+    Ok(WriteOutcome { queued, mechanical_status })
+}
+
+/// Segment each blob into block units, then apply the tail-aware budget across the concatenation,
+/// returning the retained unit texts in source order.
+fn budgeted_unit_texts(blobs: &[String], max_total: usize) -> Vec<String> {
+    let mut texts: Vec<String> = Vec::new();
+    for blob in blobs {
+        for span in units::segment_blocks(blob) {
+            texts.push(span.slice(blob).to_string());
+        }
+    }
+    let spans: Vec<units::Span> = {
+        // Re-express the retained texts as contiguous spans purely to reuse the budget planner.
+        let mut offset = 0usize;
+        texts
+            .iter()
+            .map(|t| {
+                let s = units::Span { start: offset, end: offset + t.len() };
+                offset += t.len();
+                s
+            })
+            .collect()
+    };
+    let plan = units::tail_aware_budget(&spans, max_total);
+    plan.kept.into_iter().map(|i| texts[i].clone()).collect()
+}
+
+/// Everything that folds into a record's regeneration identity.
+struct HashInputs<'a> {
+    pipeline_version: i64,
+    plan: &'a RecordPlan,
+    unit_texts: &'a [String],
+    changed_paths: &'a [String],
+    provenance: &'a [(String, Option<String>)],
+    revert_override: bool,
+    closing_keyword: Option<&'a str>,
+    anchors: &'a [candidates::AnchorCandidate],
+}
+
+/// The regeneration identity: pipeline version, the record's kind/key, coalesce partners, retained
+/// unit texts, per-source provenance, sorted changed-file selection, fix-edge source + SHAs, and
+/// the computed mechanical status floors. Any change re-derives a new hash, which the natural-key
+/// upsert treats as a fresh record — so a floor that flips later (a landed revert ref arrives, or a
+/// fix commit's message becomes available and yields a closing keyword) re-queues the record for
+/// #704.
+fn compute_input_hash(inputs: &HashInputs<'_>) -> String {
+    let HashInputs {
+        pipeline_version,
+        plan,
+        unit_texts,
+        changed_paths,
+        provenance,
+        revert_override,
+        closing_keyword,
+        anchors,
+    } = inputs;
+    let mut hasher = Sha256::new();
+    hasher.update(pipeline_version.to_le_bytes());
+    hasher
+        .update([plan.kind.as_db_str().as_bytes(), b"\x1f", plan.key.as_bytes(), b"\x1e"].concat());
+    for partner in &plan.partners {
+        hasher.update(partner.as_bytes());
+        hasher.update(b"\x1f");
+    }
+    hasher.update(b"\x1e");
+    for text in *unit_texts {
+        hasher.update(text.as_bytes());
+        hasher.update(b"\x1f");
+    }
+    // Ordered source identity + author association: a new/removed comment or a re-associated author
+    // (which #704 snapshots and gates the decision floor on) regenerates even with identical text.
+    hasher.update(b"\x1e");
+    for (source_id, association) in *provenance {
+        hasher.update(source_id.as_bytes());
+        hasher.update(b"\x1f");
+        hasher.update(association.as_deref().unwrap_or("").as_bytes());
+        hasher.update(b"\x1f");
+    }
+    hasher.update(b"\x1e");
+    let mut sorted = changed_paths.to_vec();
+    sorted.sort();
+    for path in sorted {
+        hasher.update(path.as_bytes());
+        hasher.update(b"\x1f");
+    }
+    // Mechanical fix-edge inputs + computed status floors: a changed closing edge / merge SHA (same
+    // files), a flipped provenance tier, or a floor that flips later must invalidate the model's
+    // decision/outcome even when the thread text is identical.
+    hasher.update(b"\x1e");
+    hasher.update(plan.fix_edge_source.as_db_str().as_bytes());
+    hasher.update([*revert_override as u8]);
+    hasher.update(closing_keyword.unwrap_or("").as_bytes());
+    hasher.update(b"\x1e");
+    let mut shas = plan.fix_shas.clone();
+    shas.sort();
+    for sha in shas {
+        hasher.update(sha.as_bytes());
+        hasher.update(b"\x1f");
+    }
+    // Anchor candidate set: #704 selects anchors from this pool, so a reindex that resolves new
+    // logical symbols (candidates absent at first extraction, present after) must re-queue the
+    // record. Hash each candidate's identity; mining order is already deterministic.
+    hasher.update(b"\x1e");
+    for anchor in *anchors {
+        hasher.update(anchor.kind.as_db_str().as_bytes());
+        hasher.update(b"\x1f");
+        hasher.update(anchor.logical_symbol_id.as_deref().unwrap_or("").as_bytes());
+        hasher.update(b"\x1f");
+        hasher.update(anchor.name.as_bytes());
+        hasher.update(b"\x1f");
+    }
+    let hex: String = hasher.finalize().iter().map(|byte| format!("{byte:02x}")).collect();
+    format!("sha256:{hex}")
+}
+
+// ── Loaders ────────────────────────────────────────────────────────────────────────────────────
+
+struct ItemRow {
+    kind: ItemKind,
+    key: String,
+    tracker: String,
+    project: String,
+    title: String,
+    body: String,
+    state_normalized: String,
+    merge_commit_sha: Option<String>,
+    author_association: Option<String>,
+}
+
+fn load_items(conn: &Connection, repo_id: &str) -> anyhow::Result<Vec<ItemRow>> {
+    let mut stmt = conn.prepare(
+        "SELECT item_kind, item_key, tracker, project, title, body, state_normalized,
+                merge_commit_sha, author_association
+         FROM papertrail_items WHERE repo_id = ?1",
+    )?;
+    let rows = stmt.query_map([repo_id], |row| {
+        Ok(ItemRow {
+            kind: ItemKind::from_db_str(&row.get::<_, String>(0)?)
+                .map_err(|e| rusqlite::Error::ToSqlConversionFailure(e.into()))?,
+            key: row.get(1)?,
+            tracker: row.get(2)?,
+            project: row.get(3)?,
+            title: row.get(4)?,
+            body: row.get(5)?,
+            state_normalized: row.get(6)?,
+            merge_commit_sha: row.get(7)?,
+            author_association: row.get(8)?,
+        })
+    })?;
+    let mut out = Vec::new();
+    for row in rows {
+        out.push(row?);
+    }
+    Ok(out)
+}
+
+struct ClosingEdgeRow {
+    tracker: String,
+    project: String,
+    issue_key: String,
+    closer_kind: String,
+    closer_key: String,
+    closer_commit: Option<String>,
+    source: String,
+}
+
+fn load_closing_edges(conn: &Connection, repo_id: &str) -> anyhow::Result<Vec<ClosingEdgeRow>> {
+    let mut stmt = conn.prepare(
+        "SELECT tracker, project, issue_key, closer_kind, closer_key, closer_commit, source
+         FROM papertrail_closing_edges WHERE repo_id = ?1 AND issue_kind = 'issue'",
+    )?;
+    let rows = stmt.query_map([repo_id], |row| {
+        Ok(ClosingEdgeRow {
+            tracker: row.get(0)?,
+            project: row.get(1)?,
+            issue_key: row.get(2)?,
+            closer_kind: row.get(3)?,
+            closer_key: row.get(4)?,
+            closer_commit: row.get(5)?,
+            source: row.get(6)?,
+        })
+    })?;
+    let mut out = Vec::new();
+    for row in rows {
+        out.push(row?);
+    }
+    Ok(out)
+}
+
+struct CommentRow {
+    comment_id: String,
+    body: String,
+    is_review: bool,
+    author_association: Option<String>,
+}
+
+fn load_comments(
+    conn: &Connection,
+    repo_id: &str,
+    tracker: &str,
+    project: &str,
+    kind: ItemKind,
+    key: &str,
+) -> anyhow::Result<Vec<CommentRow>> {
+    let mut stmt = conn.prepare(
+        "SELECT comment_id, body, review_state, author_association FROM papertrail_comments
+         WHERE repo_id = ?1 AND tracker = ?2 AND project = ?3 AND item_kind = ?4 AND item_key = ?5
+         ORDER BY created_at, comment_id",
+    )?;
+    let rows =
+        stmt.query_map(params![repo_id, tracker, project, kind.as_db_str(), key], |row| {
+            Ok(CommentRow {
+                comment_id: row.get(0)?,
+                body: row.get(1)?,
+                is_review: row.get::<_, Option<String>>(2)?.is_some(),
+                author_association: row.get(3)?,
+            })
+        })?;
+    let mut out = Vec::new();
+    for row in rows {
+        out.push(row?);
+    }
+    Ok(out)
+}
+
+fn changed_paths_for(
+    conn: &Connection,
+    repo_id: &str,
+    repo: Option<&gix::Repository>,
+    shas: &[String],
+) -> anyhow::Result<Vec<String>> {
+    let mut paths: BTreeSet<String> = BTreeSet::new();
+    let mut stmt = conn.prepare(
+        "SELECT DISTINCT path FROM git_file_changes WHERE commit_hash = ?1 AND repo_id = ?2",
+    )?;
+    for sha in shas {
+        let mut found = false;
+        let rows = stmt.query_map(params![sha, repo_id], |row| row.get::<_, String>(0))?;
+        for row in rows {
+            paths.insert(row?);
+            found = true;
+        }
+        // A real MERGE commit carries NO `git_file_changes` rows (the history index records the
+        // first-parent diff only for scope, not per file — git numstat has no merge diff). But
+        // `merge_commit_sha` is the usual fixing SHA for merged PRs, so fall back to a live gix
+        // first-parent diff to recover its changed source files for anchor mining.
+        if !found && let Some(repo) = repo {
+            paths.extend(merge_first_parent_paths(repo, sha).unwrap_or_default());
+        }
+    }
+    Ok(paths.into_iter().collect())
+}
+
+/// The paths a commit changed vs its FIRST parent, via a live gix tree diff — the recovery path for
+/// merge commits (which the history index leaves out of `git_file_changes`). Best-effort: any gix
+/// error (unparseable sha, missing object on a shallow clone) yields no paths rather than failing
+/// the pass. Paths are worktree-root-relative, matching `files.path` for a full-repo index (a
+/// subtree index simply won't match them in the `files` lookup — same as before, never wrong).
+fn merge_first_parent_paths(repo: &gix::Repository, sha: &str) -> anyhow::Result<Vec<String>> {
+    use gix::object::tree::diff::Action;
+    let Ok(id) = gix::ObjectId::from_hex(sha.as_bytes()) else {
+        return Ok(Vec::new());
+    };
+    let Ok(commit) = repo.find_commit(id) else {
+        return Ok(Vec::new());
+    };
+    let new_tree = commit.tree()?;
+    let parent_tree = match commit.parent_ids().next() {
+        Some(parent) => repo
+            .find_commit(parent.detach())
+            .ok()
+            .and_then(|p| p.tree().ok())
+            .unwrap_or_else(|| repo.empty_tree()),
+        None => repo.empty_tree(),
+    };
+    let mut paths = Vec::new();
+    parent_tree
+        .changes()?
+        .options(|opts| {
+            opts.track_path();
+        })
+        .for_each_to_obtain_tree(&new_tree, |change| {
+            if !change.entry_mode().is_tree() {
+                paths.push(change.location().to_string());
+            }
+            Ok::<_, std::convert::Infallible>(Action::Continue(()))
+        })?;
+    Ok(paths)
+}
+
+struct CommitMeta {
+    subject: String,
+    body: String,
+}
+
+fn commit_message(
+    conn: &Connection,
+    repo_id: &str,
+    sha: &str,
+) -> anyhow::Result<Option<CommitMeta>> {
+    Ok(conn
+        .query_row(
+            "SELECT subject, body FROM git_commits WHERE hash = ?1 AND repo_id = ?2",
+            params![sha, repo_id],
+            |row| Ok(CommitMeta { subject: row.get(0)?, body: row.get(1)? }),
+        )
+        .optional()?)
+}
+
+/// The LANDED reverting-commit SHAs (`source_kind='commit'` reverts refs whose commit is still in
+/// git history) that name this thread. Kind-matched (a typed `/pull/5` revert must not flag issue
+/// #5; an UNKNOWN-kind ref is ambiguous and applies to either same-numbered item). A text claim in
+/// an item/comment body or an open PR is NOT here — only a landed commit. Callers confirm the
+/// commit actually reverts a CURRENT fix before flipping status (ordering is by ancestry-of-fix,
+/// not by unreliable commit timestamps).
+fn revert_commit_shas(
+    conn: &Connection,
+    repo_id: &str,
+    tracker: &str,
+    project: &str,
+    kind: ItemKind,
+    key: &str,
+) -> anyhow::Result<Vec<String>> {
+    let mut stmt = conn.prepare(
+        "SELECT r.source_commit FROM papertrail_refs r
+         WHERE r.repo_id = ?1 AND r.tracker = ?2 AND r.project = ?3 AND r.item_key = ?4
+           AND (r.item_kind = ?5 OR r.item_kind IS NULL)
+           AND r.ref_kind = 'reverts' AND r.source_kind = 'commit'
+           AND r.source_commit IS NOT NULL
+           AND EXISTS (
+               SELECT 1 FROM git_commits gc WHERE gc.repo_id = ?1 AND gc.hash = r.source_commit)",
+    )?;
+    let rows = stmt
+        .query_map(params![repo_id, tracker, project, key, kind.as_db_str()], |row| {
+            row.get::<_, String>(0)
+        })?;
+    let mut out = Vec::new();
+    for row in rows {
+        out.push(row?);
+    }
+    Ok(out)
+}
+
+/// The state of a thread's existing distill record relative to a freshly computed identity.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RecordState {
+    /// No record yet — a first distillation. Enqueue it.
+    New,
+    /// A record exists with the SAME (hash, pipeline version) — nothing changed. Do NOT re-enqueue
+    /// (that would undo the drain and re-pay the LLM cost) and preserve the model's output.
+    Unchanged,
+    /// A record exists with a DIFFERENT identity — the input regenerated. Enqueue it and invalidate
+    /// the stale model output.
+    Regenerated,
+}
+
+fn record_state(
+    conn: &Connection,
+    repo_id: &str,
+    plan: &RecordPlan,
+    new_hash: &str,
+    new_version: i64,
+) -> anyhow::Result<RecordState> {
+    let existing: Option<(String, i64)> = conn
+        .query_row(
+            "SELECT distill_input_hash, pipeline_version FROM papertrail_distill
+             WHERE repo_id = ?1 AND tracker = ?2 AND project = ?3 AND item_kind = ?4
+               AND item_key = ?5",
+            params![repo_id, plan.tracker, plan.project, plan.kind.as_db_str(), plan.key],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .optional()?;
+    Ok(match existing {
+        None => RecordState::New,
+        Some((hash, version)) if hash != new_hash || version != new_version =>
+            RecordState::Regenerated,
+        Some(_) => RecordState::Unchanged,
+    })
+}
+
+/// A persisted record's full thread identity: (tracker, project, kind_token, key).
+type RecordKey = (String, String, String, String);
+
+/// Delete a thread's distill record, all its junctions (mechanical AND model), and its queue entry
+/// — used to reconcile a record whose source thread is no longer eligible (reopened issue,
+/// un-merged PR) or that a later sync discovered is actually coalesced into another thread, so
+/// consumers never see a stale or duplicate record.
+fn delete_record(conn: &Connection, repo_id: &str, record: &RecordKey) -> anyhow::Result<()> {
+    let (tracker, project, kind, key) = record;
+    for table in [
+        "papertrail_distill",
+        "papertrail_distill_record_commits",
+        "papertrail_distill_anchors",
+        "papertrail_distill_evidence",
+        "papertrail_distill_alternatives",
+        "papertrail_distill_queue",
+    ] {
+        conn.execute(
+            &format!(
+                "DELETE FROM {table} WHERE repo_id = ?1 AND tracker = ?2 AND project = ?3 AND \
+                 item_kind = ?4 AND item_key = ?5"
+            ),
+            params![repo_id, tracker, project, kind, key],
+        )?;
+    }
+    // Delete every edge that TOUCHES this record — as SOURCE or DESTINATION — so no dangling
+    // relationship survives to a record that no longer exists (a `supersedes`/`promoted` edge from
+    // another record pointing here would otherwise linger). A `coalesced` edge whose destination
+    // this was is safely rebuilt by its surviving source issue record on the next pass.
+    conn.execute(
+        "DELETE FROM papertrail_distill_edges
+         WHERE repo_id = ?1 AND tracker = ?2 AND project = ?3
+           AND ( (src_item_kind = ?4 AND src_item_key = ?5)
+              OR (dst_item_kind = ?4 AND dst_item_key = ?5) )",
+        params![repo_id, tracker, project, kind, key],
+    )?;
+    Ok(())
+}
+
+/// Every distill record's full key currently persisted for `repo_id` — the reconciliation input.
+fn load_record_keys(conn: &Connection, repo_id: &str) -> anyhow::Result<Vec<RecordKey>> {
+    load_keys_from(conn, repo_id, "papertrail_distill")
+}
+
+/// Every queued thread's full key for `repo_id` — the queue-reconciliation input.
+fn load_queue_keys(conn: &Connection, repo_id: &str) -> anyhow::Result<Vec<RecordKey>> {
+    load_keys_from(conn, repo_id, "papertrail_distill_queue")
+}
+
+fn load_keys_from(conn: &Connection, repo_id: &str, table: &str) -> anyhow::Result<Vec<RecordKey>> {
+    let mut stmt = conn.prepare(&format!(
+        "SELECT tracker, project, item_kind, item_key FROM {table} WHERE repo_id = ?1"
+    ))?;
+    let rows =
+        stmt.query_map([repo_id], |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)))?;
+    let mut out = Vec::new();
+    for row in rows {
+        out.push(row?);
+    }
+    Ok(out)
+}
+
+// ── Writers ────────────────────────────────────────────────────────────────────────────────────
+
+struct SkeletonFacets<'a> {
+    input_hash: &'a str,
+    fix_edge_source: FixEdgeSource,
+    anchors_qualified: usize,
+    thread_shape: &'a str,
+    revert_override: bool,
+    closing_keyword: Option<&'a str>,
+}
+
+fn upsert_skeleton(
+    conn: &Connection,
+    repo_id: &str,
+    now: i64,
+    opts: &ExtractOptions,
+    plan: &RecordPlan,
+    regenerated: bool,
+    facets: &SkeletonFacets<'_>,
+) -> anyhow::Result<()> {
+    // A fresh row inserts the model columns as NULL (honest nulls) for #704 to fill on this natural
+    // key. On conflict the mechanical facets are always (re)written; the model columns are
+    // PRESERVED for an identical rerun and NULLED when the input regenerated (`?14`), so a
+    // stale decision/ outcome never rides new input.
+    conn.execute(
+        "INSERT INTO papertrail_distill
+             (tracker, project, item_kind, item_key, distill_input_hash, pipeline_version,
+              fix_edge_source, anchors_qualified_count, thread_shape, revert_override,
+              closing_keyword_floor, distilled_at_ms, repo_id)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
+         ON CONFLICT(repo_id, tracker, project, item_kind, item_key) DO UPDATE SET
+             distill_input_hash = excluded.distill_input_hash,
+             pipeline_version = excluded.pipeline_version,
+             fix_edge_source = excluded.fix_edge_source,
+             anchors_qualified_count = excluded.anchors_qualified_count,
+             thread_shape = excluded.thread_shape,
+             revert_override = excluded.revert_override,
+             closing_keyword_floor = excluded.closing_keyword_floor,
+             distilled_at_ms = excluded.distilled_at_ms,
+             root_issue = CASE WHEN ?14 THEN NULL ELSE root_issue END,
+             root_cause = CASE WHEN ?14 THEN NULL ELSE root_cause END,
+             root_cause_class = CASE WHEN ?14 THEN NULL ELSE root_cause_class END,
+             decision_chosen = CASE WHEN ?14 THEN NULL ELSE decision_chosen END,
+             outcome_summary = CASE WHEN ?14 THEN NULL ELSE outcome_summary END,
+             outcome_status_model = CASE WHEN ?14 THEN NULL ELSE outcome_status_model END,
+             epistemic_status_decision =
+                 CASE WHEN ?14 THEN NULL ELSE epistemic_status_decision END,
+             epistemic_status_outcome = CASE WHEN ?14 THEN NULL ELSE epistemic_status_outcome END,
+             quotes_materialized = CASE WHEN ?14 THEN 0 ELSE quotes_materialized END,
+             outcome_claim_verified = CASE WHEN ?14 THEN 0 ELSE outcome_claim_verified END,
+             decision_provenance_verified =
+                 CASE WHEN ?14 THEN 0 ELSE decision_provenance_verified END",
+        params![
+            plan.tracker,
+            plan.project,
+            plan.kind.as_db_str(),
+            plan.key,
+            facets.input_hash,
+            opts.pipeline_version,
+            facets.fix_edge_source.as_db_str(),
+            facets.anchors_qualified as i64,
+            facets.thread_shape,
+            facets.revert_override as i64,
+            facets.closing_keyword,
+            now,
+            repo_id,
+            regenerated,
+        ],
+    )?;
+    Ok(())
+}
+
+/// Clear the MECHANICAL junctions this pass rebuilds deterministically (fixing commits, anchor
+/// candidates, thread-keyed edges), scoped to the full thread identity so a same-numbered thread in
+/// another project is untouched.
+fn clear_mechanical_junctions(
+    conn: &Connection,
+    repo_id: &str,
+    plan: &RecordPlan,
+) -> anyhow::Result<()> {
+    for table in ["papertrail_distill_record_commits", "papertrail_distill_anchors"] {
+        conn.execute(
+            &format!(
+                "DELETE FROM {table} WHERE repo_id = ?1 AND tracker = ?2 AND project = ?3 AND \
+                 item_kind = ?4 AND item_key = ?5"
+            ),
+            params![repo_id, plan.tracker, plan.project, plan.kind.as_db_str(), plan.key],
+        )?;
+    }
+    // Edges key their SOURCE thread as (src_item_kind, src_item_key). Clear ONLY the `coalesced`
+    // edges this pass rebuilds — `supersedes` / `promoted` edges are reserved to survive record
+    // regeneration (later model/human relationships), so a routine rerun must not wipe them.
+    conn.execute(
+        "DELETE FROM papertrail_distill_edges
+         WHERE repo_id = ?1 AND tracker = ?2 AND project = ?3 AND src_item_kind = ?4
+           AND src_item_key = ?5 AND edge_kind = 'coalesced'",
+        params![repo_id, plan.tracker, plan.project, plan.kind.as_db_str(), plan.key],
+    )?;
+    Ok(())
+}
+
+/// Clear the MODEL junctions (#704 output: evidence units and rejected alternatives) — only on
+/// regeneration, so an identical rerun keeps the model's work but a changed input never leaves
+/// stale evidence pinned to a fresh record.
+fn clear_model_junctions(
+    conn: &Connection,
+    repo_id: &str,
+    plan: &RecordPlan,
+) -> anyhow::Result<()> {
+    for table in ["papertrail_distill_evidence", "papertrail_distill_alternatives"] {
+        conn.execute(
+            &format!(
+                "DELETE FROM {table} WHERE repo_id = ?1 AND tracker = ?2 AND project = ?3 AND \
+                 item_kind = ?4 AND item_key = ?5"
+            ),
+            params![repo_id, plan.tracker, plan.project, plan.kind.as_db_str(), plan.key],
+        )?;
+    }
+    Ok(())
+}
+
+fn write_commits(
+    conn: &Connection,
+    repo_id: &str,
+    plan: &RecordPlan,
+    shas: &[String],
+) -> anyhow::Result<()> {
+    for sha in shas {
+        conn.execute(
+            "INSERT OR IGNORE INTO papertrail_distill_record_commits
+                 (tracker, project, item_kind, item_key, commit_sha, repo_id)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            params![plan.tracker, plan.project, plan.kind.as_db_str(), plan.key, sha, repo_id],
+        )?;
+    }
+    Ok(())
+}
+
+fn write_coalesced_edges(
+    conn: &Connection,
+    repo_id: &str,
+    now: i64,
+    plan: &RecordPlan,
+) -> anyhow::Result<()> {
+    for partner in &plan.partners {
+        conn.execute(
+            "INSERT OR IGNORE INTO papertrail_distill_edges
+                 (tracker, project, src_item_kind, src_item_key, dst_item_kind, dst_item_key,
+                  edge_kind, created_at_ms, repo_id)
+             VALUES (?1, ?2, ?3, ?4, 'change_request', ?5, 'coalesced', ?6, ?7)",
+            params![
+                plan.tracker,
+                plan.project,
+                plan.kind.as_db_str(),
+                plan.key,
+                partner,
+                now,
+                repo_id,
+            ],
+        )?;
+    }
+    Ok(())
+}
+
+fn write_anchors(
+    conn: &Connection,
+    repo_id: &str,
+    plan: &RecordPlan,
+    anchors: &[candidates::AnchorCandidate],
+) -> anyhow::Result<()> {
+    for anchor in anchors {
+        conn.execute(
+            "INSERT INTO papertrail_distill_anchors
+                 (tracker, project, item_kind, item_key, anchor_kind, logical_symbol_id, file_path,
+                  name, resolved, repo_id)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+            params![
+                plan.tracker,
+                plan.project,
+                plan.kind.as_db_str(),
+                plan.key,
+                anchor.kind.as_db_str(),
+                anchor.logical_symbol_id,
+                anchor.file_path,
+                anchor.name,
+                anchor.resolved as i64,
+                repo_id,
+            ],
+        )?;
+    }
+    Ok(())
+}
+
+fn enqueue_one(
+    conn: &Connection,
+    repo_id: &str,
+    now: i64,
+    item: &ItemRow,
+    regenerated: bool,
+) -> anyhow::Result<usize> {
+    // On REGENERATION, RESET a surviving queue row's attempt state — the new input must not inherit
+    // the old input's exhausted attempts / stale error / stale raw reply, or the drain might skip
+    // it (retry budget spent) or report diagnostics against the wrong input. New/unchanged work
+    // keeps its state (`DO NOTHING`).
+    let sql = if regenerated {
+        "INSERT INTO papertrail_distill_queue
+             (tracker, project, item_kind, item_key, enqueued_at_ms, repo_id)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+         ON CONFLICT(repo_id, tracker, project, item_kind, item_key) DO UPDATE SET
+             enqueued_at_ms = excluded.enqueued_at_ms, attempts = 0, last_error = NULL,
+             raw_reply = NULL"
+    } else {
+        "INSERT INTO papertrail_distill_queue
+             (tracker, project, item_kind, item_key, enqueued_at_ms, repo_id)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+         ON CONFLICT(repo_id, tracker, project, item_kind, item_key) DO NOTHING"
+    };
+    Ok(conn.execute(sql, params![
+        item.tracker,
+        item.project,
+        item.kind.as_db_str(),
+        item.key,
+        now,
+        repo_id
+    ])?)
+}
+
+// ── Small helpers ──────────────────────────────────────────────────────────────────────────────
+
+/// A planned record: the thread identity (tracker/project/kind/key), its coalesce partners, and its
+/// mechanical fix commits + fix-edge source. Tracker/project are carried so the writers don't each
+/// re-look-up the row.
+struct RecordPlan {
+    tracker: String,
+    project: String,
+    kind: ItemKind,
+    key: String,
+    partners: Vec<String>,
+    fix_shas: Vec<String>,
+    fix_edge_source: FixEdgeSource,
+    /// A TEXT-tier closing edge links this issue — the canonical parser matched a closing keyword.
+    /// Drives the closing-keyword status floor (issue records only).
+    text_closing: bool,
+}
+
+/// Run `body` inside an IMMEDIATE transaction when the connection is in autocommit; otherwise run
+/// inline (the caller owns the transaction). Mirrors the store layer's fence.
+fn in_txn<T>(conn: &Connection, body: impl FnOnce() -> anyhow::Result<T>) -> anyhow::Result<T> {
+    if conn.is_autocommit() {
+        conn.execute_batch("BEGIN IMMEDIATE")?;
+        match body() {
+            Ok(value) => {
+                conn.execute_batch("COMMIT")?;
+                Ok(value)
+            },
+            Err(err) => {
+                let _ = conn.execute_batch("ROLLBACK");
+                Err(err)
+            },
+        }
+    } else {
+        body()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rag_rat_db::schema;
+    use rusqlite::{Connection, params};
+
+    use super::{ExtractOptions, enqueue_eligible, extract};
+
+    /// A fully-migrated in-memory DB scoped to `repo`, via the same `temp.connection_context` write
+    /// `install_scope_view` uses (the multi-repo-scope test convention).
+    fn scoped_conn(repo: &str) -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        schema::apply(&conn, &crate::index::migration_hooks()).unwrap();
+        conn.execute_batch(
+            "CREATE TEMP TABLE IF NOT EXISTS connection_context(key TEXT PRIMARY KEY, value TEXT);",
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT OR REPLACE INTO temp.connection_context(key, value) VALUES ('repo_id', ?1)",
+            [repo],
+        )
+        .unwrap();
+        conn
+    }
+
+    fn seed_item(
+        conn: &Connection,
+        repo: &str,
+        kind: &str,
+        key: &str,
+        body: &str,
+        state_normalized: &str,
+        merge_commit_sha: Option<&str>,
+    ) {
+        conn.execute(
+            "INSERT INTO papertrail_items
+                 (tracker, project, item_kind, item_key, url, state, title, body, synced_at_ms,
+                  repo_id, state_normalized, merge_commit_sha)
+             VALUES ('github','o/r',?1,?2,'u','closed','t',?3,1,?4,?5,?6)",
+            params![kind, key, body, repo, state_normalized, merge_commit_sha],
+        )
+        .unwrap();
+    }
+
+    fn seed_comment(conn: &Connection, repo: &str, kind: &str, key: &str, id: &str, review: bool) {
+        conn.execute(
+            "INSERT INTO papertrail_comments
+                 (tracker, project, item_kind, item_key, comment_id, body, synced_at_ms, repo_id,
+                  review_state, created_at)
+             VALUES ('github','o/r',?1,?2,?3,'a comment',1,?4,?5,'2026-01-01')",
+            params![kind, key, id, repo, if review { Some("approved") } else { None }],
+        )
+        .unwrap();
+    }
+
+    /// Project-parameterized item seed, for multi-binding isolation tests.
+    fn seed_item_in(
+        conn: &Connection,
+        repo: &str,
+        project: &str,
+        kind: &str,
+        key: &str,
+        body: &str,
+        state: &str,
+    ) {
+        conn.execute(
+            "INSERT INTO papertrail_items
+                 (tracker, project, item_kind, item_key, url, state, title, body, synced_at_ms,
+                  repo_id, state_normalized, merge_commit_sha)
+             VALUES ('github',?1,?2,?3,'u','closed','t',?4,1,?5,?6,NULL)",
+            params![project, kind, key, body, repo, state],
+        )
+        .unwrap();
+    }
+
+    fn seed_closing_edge(
+        conn: &Connection,
+        repo: &str,
+        issue: &str,
+        closer_key: &str,
+        commit: Option<&str>,
+        source: &str,
+    ) {
+        conn.execute(
+            "INSERT INTO papertrail_closing_edges
+                 (tracker, project, issue_kind, issue_key, closer_kind, closer_key, closer_commit,
+                  source, synced_at_ms, repo_id)
+             VALUES ('github','o/r','issue',?1,'change_request',?2,?3,?4,1,?5)",
+            params![issue, closer_key, commit, source, repo],
+        )
+        .unwrap();
+    }
+
+    fn seed_commit(conn: &Connection, repo: &str, sha: &str, subject: &str) {
+        seed_commit_with_body(conn, repo, sha, subject, "");
+    }
+
+    fn seed_commit_with_body(conn: &Connection, repo: &str, sha: &str, subject: &str, body: &str) {
+        conn.execute(
+            "INSERT INTO git_commits
+                 (hash, author_name, author_email, authored_at_s, committed_at_s, subject, body, \
+             repo_id)
+             VALUES (?1,'a','a@e',1,1,?2,?4,?3)",
+            params![sha, subject, repo, body],
+        )
+        .unwrap();
+    }
+
+    fn seed_changed_file(conn: &Connection, repo: &str, sha: &str, path: &str) {
+        conn.execute(
+            "INSERT INTO git_file_changes (commit_hash, path, change_kind, repo_id)
+             VALUES (?1, ?2, 'modified', ?3)",
+            params![sha, path, repo],
+        )
+        .unwrap();
+        seed_indexed_source(conn, repo, path);
+    }
+
+    /// The indexed `files` row + one logical/un-logical symbol at `path`, WITHOUT any
+    /// `git_file_changes` row — so anchor mining only resolves it via a live gix diff (the
+    /// merge-commit fallback path), not the `git_file_changes` lookup.
+    fn seed_indexed_source(conn: &Connection, repo: &str, path: &str) {
+        // A matching indexed file + one logical + one un-logical symbol, so anchor mining resolves.
+        conn.execute(
+            "INSERT INTO files (path, language, kind, sha256, modified_at_ms, indexed_at_ms, \
+             repo_id, generation)
+             VALUES (?1,'rust','source','s',1,1,?2,0)",
+            params![path, repo],
+        )
+        .unwrap();
+        let file_id = conn.last_insert_rowid();
+        conn.execute(
+            "INSERT INTO symbols (file_id, language, name, kind, start_byte, end_byte)
+             VALUES (?1,'rust','render_widget','function',0,10)",
+            [file_id],
+        )
+        .unwrap();
+        let symbol_id = conn.last_insert_rowid();
+        // The logical parent (FK target); id 999 is what the anchor's `sym_<hex>` encodes.
+        conn.execute(
+            "INSERT OR IGNORE INTO logical_symbols
+                 (id, language, path, logical_name, kind, variant_count, group_reason)
+             VALUES (999, 'rust', ?1, 'render_widget', 'function', 1, 'test')",
+            [path],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO logical_symbol_members (logical_symbol_id, symbol_id, start_line, \
+             end_line)
+             VALUES (999, ?1, 1, 2)",
+            [symbol_id],
+        )
+        .unwrap();
+    }
+
+    fn distill_count(conn: &Connection, sql: &str) -> i64 {
+        conn.query_row(sql, [], |row| row.get(0)).unwrap()
+    }
+
+    #[test]
+    fn full_flow_extracts_a_coalesced_record_with_floors_anchors_and_queue() {
+        let conn = scoped_conn("repoA");
+        // A closed issue #5 fixed by a merged PR #6, linked by a TEXT-tier closing edge (the
+        // closer-minting parser matched a closing keyword); the PR has a review comment.
+        seed_item(&conn, "repoA", "issue", "5", "The widget crashes on load.", "closed", None);
+        seed_item(
+            &conn,
+            "repoA",
+            "change_request",
+            "6",
+            "## Summary\nFixes it.",
+            "merged",
+            Some("deadbeef"),
+        );
+        seed_comment(&conn, "repoA", "issue", "5", "c1", false);
+        seed_comment(&conn, "repoA", "change_request", "6", "c2", true);
+        seed_closing_edge(&conn, "repoA", "5", "6", Some("deadbeef"), "text");
+        seed_commit(&conn, "repoA", "deadbeef", "fix: widget crash (fixes #5)");
+        seed_changed_file(&conn, "repoA", "deadbeef", "crates/core/src/widget.rs");
+
+        let report = extract(&conn, None, &ExtractOptions::default()).unwrap();
+        assert_eq!(report.eligible, 1, "issue #5 is the record; PR #6 coalesces into it");
+        assert_eq!(report.records_written, 1);
+        assert_eq!(report.coalesced_pairs, 1);
+        assert_eq!(report.fix_edge_text, 1);
+        assert_eq!(report.mechanical_landed, 1, "the text closing edge floors it to landed");
+
+        // The skeleton row: mechanical columns populated, model columns NULL.
+        let (fix_src, kw, revert, shape, qualified, model_status): (
+            String,
+            Option<String>,
+            i64,
+            String,
+            i64,
+            Option<String>,
+        ) = conn
+            .query_row(
+                "SELECT fix_edge_source, closing_keyword_floor, revert_override, thread_shape,
+                        anchors_qualified_count, outcome_status_model
+                 FROM papertrail_distill WHERE item_kind='issue' AND item_key='5'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?, r.get(4)?, r.get(5)?)),
+            )
+            .unwrap();
+        assert_eq!(fix_src, "text");
+        assert_eq!(kw.as_deref(), Some("closing"), "text closing edge sets the keyword floor");
+        assert_eq!(revert, 0);
+        assert!(!shape.is_empty());
+        assert_eq!(qualified, 1, "one resolved symbol anchor (render_widget)");
+        assert_eq!(model_status, None, "model column is an honest null in Phase 1");
+
+        // Mechanical junctions.
+        assert_eq!(
+            distill_count(
+                &conn,
+                "SELECT COUNT(*) FROM papertrail_distill_record_commits WHERE \
+                 commit_sha='deadbeef'"
+            ),
+            1,
+        );
+        assert_eq!(
+            distill_count(
+                &conn,
+                "SELECT COUNT(*) FROM papertrail_distill_edges WHERE edge_kind='coalesced' AND \
+                 src_item_key='5' AND dst_item_key='6'"
+            ),
+            1,
+        );
+        // File anchor + symbol anchor.
+        assert_eq!(
+            distill_count(
+                &conn,
+                "SELECT COUNT(*) FROM papertrail_distill_anchors WHERE anchor_kind='file'"
+            ),
+            1
+        );
+        let sym: (String, i64) = conn
+            .query_row(
+                "SELECT logical_symbol_id, resolved FROM papertrail_distill_anchors
+                 WHERE anchor_kind='symbol' AND name='render_widget'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(sym.0, "sym_3e7", "999 == 0x3e7"); // format_sym_handle(999)
+        assert_eq!(sym.1, 1);
+        // Queue holds the issue record (the coalesced PR is not its own record).
+        assert_eq!(distill_count(&conn, "SELECT COUNT(*) FROM papertrail_distill_queue"), 1);
+        assert_eq!(
+            distill_count(
+                &conn,
+                "SELECT COUNT(*) FROM papertrail_distill_queue WHERE item_kind='issue' AND \
+                 item_key='5'"
+            ),
+            1,
+        );
+    }
+
+    /// Build a throwaway git repo whose HEAD is a real MERGE commit, and return `(root, merge_sha,
+    /// changed_path)`. The merge's first-parent diff touches `changed_path` (added on the merged
+    /// branch), while a real merge carries NO per-file numstat — exactly the shape the history
+    /// index stores no `git_file_changes` rows for.
+    fn build_merge_repo() -> (std::path::PathBuf, String, String) {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let root =
+            std::env::temp_dir().join(format!("ragrat-distill-merge-{}-{id}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        let git = |args: &[&str]| {
+            let status =
+                std::process::Command::new("git").current_dir(&root).args(args).status().unwrap();
+            assert!(status.success(), "git {args:?} failed");
+        };
+        git(&["init", "-q"]);
+        git(&["config", "user.name", "Rag Rat"]);
+        git(&["config", "user.email", "rag@example.com"]);
+        std::fs::write(root.join("README.md"), "base\n").unwrap();
+        git(&["add", "."]);
+        git(&["commit", "-q", "-m", "base"]);
+        git(&["checkout", "-q", "-b", "feature"]);
+        std::fs::write(root.join("src/widget.rs"), "fn render_widget() {}\n").unwrap();
+        git(&["add", "."]);
+        git(&["commit", "-q", "-m", "feat: add widget"]);
+        git(&["checkout", "-q", "-"]);
+        // `--no-ff` forces a real merge commit (a fast-forward would carry no merge node).
+        git(&["merge", "--no-ff", "-q", "-m", "Merge feature", "feature"]);
+        let out = std::process::Command::new("git")
+            .current_dir(&root)
+            .args(["rev-parse", "HEAD"])
+            .output()
+            .unwrap();
+        let merge_sha = String::from_utf8(out.stdout).unwrap().trim().to_string();
+        (root, merge_sha, "src/widget.rs".to_string())
+    }
+
+    #[test]
+    fn merge_commit_fix_mines_anchors_via_gix_first_parent_diff() {
+        // A merge commit is the usual fixing SHA for a merged PR, but the history index records NO
+        // `git_file_changes` rows for real merges — so anchor mining must fall back to a live gix
+        // first-parent diff. This test seeds ONLY the indexed `files` row (no `git_file_changes`),
+        // so it passes ONLY through the fallback: drop the fallback and the anchor count goes to 0.
+        let (root, merge_sha, path) = build_merge_repo();
+        let conn = scoped_conn("repoA");
+        // A standalone merged PR, closed by its own merge commit (its own provider record).
+        seed_item(
+            &conn,
+            "repoA",
+            "change_request",
+            "9",
+            "A refactor PR.",
+            "merged",
+            Some(&merge_sha),
+        );
+        seed_commit(&conn, "repoA", &merge_sha, "Merge feature");
+        seed_indexed_source(&conn, "repoA", &path);
+
+        let report = extract(&conn, Some(&root), &ExtractOptions::default()).unwrap();
+        assert_eq!(report.records_written, 1);
+
+        // The file anchor + the resolved symbol anchor both come from the gix-recovered path.
+        assert_eq!(
+            distill_count(
+                &conn,
+                "SELECT COUNT(*) FROM papertrail_distill_anchors WHERE anchor_kind='file'"
+            ),
+            1,
+            "the merge's first-parent diff surfaces the changed source file"
+        );
+        assert_eq!(
+            distill_count(
+                &conn,
+                "SELECT COUNT(*) FROM papertrail_distill_anchors WHERE anchor_kind='symbol' AND \
+                 name='render_widget' AND resolved=1"
+            ),
+            1,
+            "and its symbol resolves"
+        );
+
+        // Control: with no repo handle the fallback cannot fire, so the same seed yields no anchors
+        // — proving the anchors above came from the gix diff, not a stray
+        // `git_file_changes` row.
+        let conn2 = scoped_conn("repoB");
+        seed_item(
+            &conn2,
+            "repoB",
+            "change_request",
+            "9",
+            "A refactor PR.",
+            "merged",
+            Some(&merge_sha),
+        );
+        seed_commit(&conn2, "repoB", &merge_sha, "Merge feature");
+        seed_indexed_source(&conn2, "repoB", &path);
+        extract(&conn2, None, &ExtractOptions::default()).unwrap();
+        assert_eq!(
+            distill_count(&conn2, "SELECT COUNT(*) FROM papertrail_distill_anchors"),
+            0,
+            "no repo handle → no fallback → no anchors from a merge with no git_file_changes rows"
+        );
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn a_provider_only_closing_edge_does_not_set_the_keyword_floor() {
+        // The closing-keyword floor is derived from a TEXT-tier closing edge (the parser matched a
+        // closing keyword), NOT a re-scan of commit text — so a same-numbered cross-project or MR
+        // URL in a commit can never force `landed`. A provider-attested closure carries no keyword,
+        // so the floor stays NULL and the effective status defers to the model (unclear here).
+        let conn = scoped_conn("repoA");
+        seed_item(&conn, "repoA", "issue", "5", "A bug.", "closed", None);
+        seed_item(&conn, "repoA", "change_request", "6", "The PR.", "merged", Some("m6"));
+        seed_closing_edge(&conn, "repoA", "5", "6", Some("m6"), "provider");
+        seed_commit(&conn, "repoA", "m6", "fix: crash. Fixes other/repo#5"); // cross-project ref
+
+        let report = extract(&conn, None, &ExtractOptions::default()).unwrap();
+        let kw: Option<String> = conn
+            .query_row(
+                "SELECT closing_keyword_floor FROM papertrail_distill WHERE item_kind='issue' AND \
+                 item_key='5'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(kw, None, "a provider-only closure sets no keyword floor");
+        assert_eq!(report.fix_edge_provider, 1);
+        assert_eq!(report.mechanical_landed, 0, "no keyword floor → not force-landed");
+    }
+
+    #[test]
+    fn standalone_merged_pr_is_its_own_provider_record() {
+        let conn = scoped_conn("repoA");
+        seed_item(&conn, "repoA", "change_request", "9", "A refactor PR.", "merged", Some("cafe"));
+        seed_commit(&conn, "repoA", "cafe", "refactor: tidy up");
+        let report = extract(&conn, None, &ExtractOptions::default()).unwrap();
+        assert_eq!(report.records_written, 1);
+        assert_eq!(report.fix_edge_provider, 1, "a merged PR is its own provider closure");
+        assert_eq!(
+            distill_count(
+                &conn,
+                "SELECT COUNT(*) FROM papertrail_distill WHERE item_kind='change_request' AND \
+                 item_key='9'"
+            ),
+            1,
+        );
+    }
+
+    #[test]
+    fn closed_issue_with_no_closing_edge_has_no_fix_edge() {
+        let conn = scoped_conn("repoA");
+        seed_item(&conn, "repoA", "issue", "7", "Closed as not planned.", "closed", None);
+        let report = extract(&conn, None, &ExtractOptions::default()).unwrap();
+        assert_eq!(report.fix_edge_none, 1);
+        let src: String = conn
+            .query_row(
+                "SELECT fix_edge_source FROM papertrail_distill WHERE item_key='7'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(src, "none");
+    }
+
+    #[test]
+    fn a_closing_edge_to_an_unmerged_pr_does_not_upgrade_fix_edge_provenance() {
+        // Issue #5 has a provider closing edge to PR #6, but PR #6 is CLOSED (not merged) — its
+        // merge_commit_sha is a trap. The edge must not be treated as a fix edge, so the
+        // no-fix-edge floor still fires (fix_edge_source = none, and no coalesce).
+        let conn = scoped_conn("repoA");
+        seed_item(&conn, "repoA", "issue", "5", "A bug.", "closed", None);
+        seed_item(
+            &conn,
+            "repoA",
+            "change_request",
+            "6",
+            "An abandoned PR.",
+            "closed",
+            Some("beef"),
+        );
+        seed_closing_edge(&conn, "repoA", "5", "6", Some("beef"), "provider");
+
+        let report = extract(&conn, None, &ExtractOptions::default()).unwrap();
+        assert_eq!(report.coalesced_pairs, 0, "an unmerged PR is not a coalesce partner");
+        let src: String = conn
+            .query_row(
+                "SELECT fix_edge_source FROM papertrail_distill WHERE item_kind='issue' AND \
+                 item_key='5'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(src, "none", "an unmerged-PR closing edge is not a fix edge");
+    }
+
+    #[test]
+    fn sibling_repo_items_never_leak_into_the_active_repos_records() {
+        let conn = scoped_conn("repoA");
+        // Active repo A has a closed issue #5; a SIBLING repo B has an identically-numbered closed
+        // issue #5. Extraction is scoped to A and must not produce a record for B's item.
+        seed_item(&conn, "repoA", "issue", "5", "A's bug.", "closed", None);
+        seed_item(&conn, "repoB", "issue", "5", "B's bug.", "closed", None);
+        seed_item(&conn, "repoB", "change_request", "6", "B's PR.", "merged", Some("beef"));
+
+        let report = extract(&conn, None, &ExtractOptions::default()).unwrap();
+        assert_eq!(report.records_written, 1, "only repo A's single item");
+        assert_eq!(distill_count(&conn, "SELECT COUNT(*) FROM papertrail_distill"), 1);
+        assert_eq!(
+            distill_count(&conn, "SELECT COUNT(*) FROM papertrail_distill WHERE repo_id='repoB'"),
+            0,
+            "no sibling-repo record",
+        );
+        assert_eq!(
+            distill_count(
+                &conn,
+                "SELECT COUNT(*) FROM papertrail_distill_queue WHERE repo_id='repoB'"
+            ),
+            0,
+        );
+    }
+
+    #[test]
+    fn cheap_enqueue_covers_every_eligible_thread_and_is_idempotent_and_scoped() {
+        let conn = scoped_conn("repoA");
+        seed_item(&conn, "repoA", "issue", "5", "closed issue", "closed", None);
+        seed_item(&conn, "repoA", "change_request", "6", "merged pr", "merged", Some("x"));
+        seed_item(&conn, "repoA", "issue", "8", "still open", "open", None); // not eligible
+        seed_item(&conn, "repoB", "issue", "5", "sibling", "closed", None); // wrong repo
+
+        let first = enqueue_eligible(&conn).unwrap();
+        assert_eq!(first, 2, "the closed issue + merged PR (not the open issue, not repo B)");
+        // Idempotent: a second pass adds nothing.
+        assert_eq!(enqueue_eligible(&conn).unwrap(), 0);
+        assert_eq!(distill_count(&conn, "SELECT COUNT(*) FROM papertrail_distill_queue"), 2);
+        assert_eq!(
+            distill_count(
+                &conn,
+                "SELECT COUNT(*) FROM papertrail_distill_queue WHERE repo_id='repoB'"
+            ),
+            0,
+        );
+
+        // Once a thread is distilled and its queue row is DRAINED, a later sync must NOT re-enqueue
+        // it — otherwise every completed thread is re-processed forever.
+        extract(&conn, None, &ExtractOptions::default()).unwrap();
+        conn.execute("DELETE FROM papertrail_distill_queue", []).unwrap();
+        assert_eq!(enqueue_eligible(&conn).unwrap(), 0, "distilled threads are not re-enqueued");
+        assert_eq!(distill_count(&conn, "SELECT COUNT(*) FROM papertrail_distill_queue"), 0);
+    }
+
+    #[test]
+    fn re_running_extraction_is_idempotent() {
+        let conn = scoped_conn("repoA");
+        seed_item(&conn, "repoA", "change_request", "9", "A PR.", "merged", Some("cafe"));
+        seed_commit(&conn, "repoA", "cafe", "refactor: x");
+        seed_changed_file(&conn, "repoA", "cafe", "crates/core/src/a.rs");
+        extract(&conn, None, &ExtractOptions::default()).unwrap();
+        extract(&conn, None, &ExtractOptions::default()).unwrap();
+        // No duplicate rows across the two passes (natural-key upsert + junction
+        // clear-and-rebuild).
+        assert_eq!(distill_count(&conn, "SELECT COUNT(*) FROM papertrail_distill"), 1);
+        assert_eq!(
+            distill_count(&conn, "SELECT COUNT(*) FROM papertrail_distill_record_commits"),
+            1
+        );
+        assert_eq!(
+            distill_count(
+                &conn,
+                "SELECT COUNT(*) FROM papertrail_distill_anchors WHERE anchor_kind='file'"
+            ),
+            1
+        );
+    }
+
+    #[test]
+    fn same_numbered_threads_in_different_projects_stay_isolated() {
+        // One repo, two tracker-binding projects, each with a closed issue #5. Only o/r's issue is
+        // closed by a merged PR #6. Records must not cross-contaminate on the shared number.
+        let conn = scoped_conn("repoA");
+        seed_item_in(&conn, "repoA", "o/r", "issue", "5", "Alpha bug body.", "closed");
+        seed_item_in(&conn, "repoA", "o/r2", "issue", "5", "Beta bug body.", "closed");
+        seed_item_in(&conn, "repoA", "o/r", "change_request", "6", "Alpha PR.", "merged");
+        seed_closing_edge(&conn, "repoA", "5", "6", Some("deadbeef"), "provider");
+
+        let report = extract(&conn, None, &ExtractOptions::default()).unwrap();
+        // Two issue records (one per project); o/r's PR #6 coalesced away.
+        assert_eq!(report.records_written, 2);
+        assert_eq!(report.coalesced_pairs, 1);
+
+        // Each project's record has its OWN fix edge and a DISTINCT input hash (distinct bodies).
+        let fix_a: String = conn
+            .query_row(
+                "SELECT fix_edge_source FROM papertrail_distill WHERE project='o/r' AND \
+                 item_key='5'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        let fix_b: String = conn
+            .query_row(
+                "SELECT fix_edge_source FROM papertrail_distill WHERE project='o/r2' AND \
+                 item_key='5'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(fix_a, "provider", "o/r#5 coalesces its merged PR closer");
+        assert_eq!(fix_b, "none", "o/r2#5 has no closer of its own");
+        let distinct_hashes: i64 = distill_count(
+            &conn,
+            "SELECT COUNT(DISTINCT distill_input_hash) FROM papertrail_distill WHERE item_key='5'",
+        );
+        assert_eq!(distinct_hashes, 2, "distinct bodies → distinct regeneration identities");
+
+        // The coalesced edge belongs to o/r only — o/r2 has none.
+        assert_eq!(
+            distill_count(
+                &conn,
+                "SELECT COUNT(*) FROM papertrail_distill_edges WHERE project='o/r' AND \
+                 src_item_key='5'"
+            ),
+            1,
+        );
+        assert_eq!(
+            distill_count(
+                &conn,
+                "SELECT COUNT(*) FROM papertrail_distill_edges WHERE project='o/r2'"
+            ),
+            0,
+        );
+    }
+
+    #[test]
+    fn a_pr_extracted_standalone_loses_its_record_once_it_becomes_coalesced() {
+        let conn = scoped_conn("repoA");
+        // Pass 1: PR #6 is merged with no known closing edge → a standalone record + queue entry.
+        seed_item(&conn, "repoA", "change_request", "6", "The fix PR.", "merged", Some("dead"));
+        extract(&conn, None, &ExtractOptions::default()).unwrap();
+        assert_eq!(
+            distill_count(
+                &conn,
+                "SELECT COUNT(*) FROM papertrail_distill WHERE item_kind='change_request' AND \
+                 item_key='6'"
+            ),
+            1,
+            "PR #6 starts as a standalone record",
+        );
+
+        // Pass 2: a closed issue #5 and a closing edge #5 -> #6 arrive; #6 now coalesces into #5.
+        seed_item(&conn, "repoA", "issue", "5", "The bug.", "closed", None);
+        seed_closing_edge(&conn, "repoA", "5", "6", Some("dead"), "provider");
+        extract(&conn, None, &ExtractOptions::default()).unwrap();
+
+        // The stale standalone PR record + its queue entry are gone; only the coalesced issue
+        // record remains, with the coalesce edge.
+        assert_eq!(
+            distill_count(
+                &conn,
+                "SELECT COUNT(*) FROM papertrail_distill WHERE item_kind='change_request' AND \
+                 item_key='6'"
+            ),
+            0,
+            "the coalesced PR's standalone record is reconciled away",
+        );
+        assert_eq!(
+            distill_count(
+                &conn,
+                "SELECT COUNT(*) FROM papertrail_distill_queue WHERE item_kind='change_request' \
+                 AND item_key='6'"
+            ),
+            0,
+            "the coalesced PR's queue entry is removed",
+        );
+        assert_eq!(
+            distill_count(
+                &conn,
+                "SELECT COUNT(*) FROM papertrail_distill WHERE item_kind='issue' AND item_key='5'"
+            ),
+            1,
+        );
+        assert_eq!(
+            distill_count(
+                &conn,
+                "SELECT COUNT(*) FROM papertrail_distill_edges WHERE edge_kind='coalesced' AND \
+                 dst_item_key='6'"
+            ),
+            1,
+        );
+    }
+
+    #[test]
+    fn a_record_whose_thread_becomes_ineligible_is_reconciled_away() {
+        let conn = scoped_conn("repoA");
+        seed_item(&conn, "repoA", "issue", "7", "A bug.", "closed", None);
+        extract(&conn, None, &ExtractOptions::default()).unwrap();
+        assert_eq!(distill_count(&conn, "SELECT COUNT(*) FROM papertrail_distill"), 1);
+
+        // The issue is reopened → no longer eligible. The next extraction must drop its record.
+        conn.execute("UPDATE papertrail_items SET state_normalized='open' WHERE item_key='7'", [])
+            .unwrap();
+        let report = extract(&conn, None, &ExtractOptions::default()).unwrap();
+        assert_eq!(report.records_written, 0, "the reopened issue is not eligible");
+        assert_eq!(
+            distill_count(&conn, "SELECT COUNT(*) FROM papertrail_distill"),
+            0,
+            "the ineligible record is reconciled away",
+        );
+        assert_eq!(distill_count(&conn, "SELECT COUNT(*) FROM papertrail_distill_queue"), 0);
+    }
+
+    #[test]
+    fn changing_the_fixing_commit_regenerates_even_with_identical_text() {
+        let conn = scoped_conn("repoA");
+        seed_item(&conn, "repoA", "issue", "5", "A bug.", "closed", None);
+        // A commit closing edge (its SHA is a fix input that never appears in the thread text).
+        let seed_commit_edge = |sha: &str| {
+            conn.execute(
+                "INSERT OR REPLACE INTO papertrail_closing_edges
+                     (tracker, project, issue_kind, issue_key, closer_kind, closer_key,
+                      closer_commit, source, synced_at_ms, repo_id)
+                 VALUES ('github','o/r','issue','5','commit',?1,NULL,'provider',1,'repoA')",
+                [sha],
+            )
+            .unwrap();
+        };
+        seed_commit_edge("c1");
+        extract(&conn, None, &ExtractOptions::default()).unwrap();
+        conn.execute("UPDATE papertrail_distill SET root_cause='x' WHERE item_key='5'", [])
+            .unwrap();
+
+        // A second fixing commit arrives (same thread text). The record must regenerate: model
+        // output cleared, because the fix SHA set rides the regeneration hash.
+        seed_commit_edge("c2");
+        extract(&conn, None, &ExtractOptions::default()).unwrap();
+        let cause: Option<String> = conn
+            .query_row("SELECT root_cause FROM papertrail_distill WHERE item_key='5'", [], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        assert_eq!(cause, None, "a changed fixing commit invalidates stale model output");
+    }
+
+    #[test]
+    fn a_pr_queued_before_extraction_is_dropped_from_the_queue_once_coalesced() {
+        let conn = scoped_conn("repoA");
+        seed_item(&conn, "repoA", "issue", "5", "The bug.", "closed", None);
+        seed_item(&conn, "repoA", "change_request", "6", "The fix PR.", "merged", Some("dead"));
+        seed_closing_edge(&conn, "repoA", "5", "6", Some("dead"), "provider");
+
+        // The cheap sync enqueue runs first (no records yet) → queues BOTH #5 and #6.
+        assert_eq!(enqueue_eligible(&conn).unwrap(), 2);
+        // Extraction coalesces #6 into #5. #6's queue row (never a record) must be reconciled away.
+        extract(&conn, None, &ExtractOptions::default()).unwrap();
+        assert_eq!(
+            distill_count(
+                &conn,
+                "SELECT COUNT(*) FROM papertrail_distill_queue WHERE item_kind='change_request' \
+                 AND item_key='6'"
+            ),
+            0,
+            "the coalesced PR's pre-extraction queue row is removed",
+        );
+        assert_eq!(
+            distill_count(
+                &conn,
+                "SELECT COUNT(*) FROM papertrail_distill_queue WHERE item_kind='issue' AND \
+                 item_key='5'"
+            ),
+            1,
+            "the coalesced issue record stays queued",
+        );
+    }
+
+    #[test]
+    fn an_unchanged_rerun_after_a_drain_does_not_requeue() {
+        let conn = scoped_conn("repoA");
+        seed_item(&conn, "repoA", "change_request", "9", "A PR.", "merged", Some("cafe"));
+        seed_commit(&conn, "repoA", "cafe", "refactor: x");
+        extract(&conn, None, &ExtractOptions::default()).unwrap();
+        // Simulate the #704 drain removing the completed queue row.
+        conn.execute("DELETE FROM papertrail_distill_queue", []).unwrap();
+        // An identical re-extract must NOT re-enqueue the completed, unchanged record.
+        extract(&conn, None, &ExtractOptions::default()).unwrap();
+        assert_eq!(
+            distill_count(&conn, "SELECT COUNT(*) FROM papertrail_distill_queue"),
+            0,
+            "an unchanged record is not re-queued after a drain",
+        );
+    }
+
+    #[test]
+    fn only_a_landed_commit_revert_flips_status_not_a_text_claim() {
+        let conn = scoped_conn("repoA");
+        seed_item(&conn, "repoA", "change_request", "9", "A PR.", "merged", Some("cafe"));
+        seed_commit(&conn, "repoA", "cafe", "feat: x"); // the fix (merge commit)
+        // A reverts ref, tagged by its source and (for commits) the reverting commit sha.
+        let seed_reverts = |source_kind: &str, source_commit: Option<&str>| {
+            conn.execute(
+                "INSERT INTO papertrail_refs
+                     (tracker, project, item_key, item_kind, ref_kind, source_kind, source_commit,
+                      source_text, discovered_at_ms, repo_id)
+                 VALUES ('github','o/r','9','change_request','reverts',?1,?2,'Reverts \
+                 #9',1,'repoA')",
+                rusqlite::params![source_kind, source_commit],
+            )
+            .unwrap();
+        };
+        // A text-tier `reverts` ref (an open PR body / comment claim) must NOT flip status.
+        seed_reverts("item", None);
+        extract(&conn, None, &ExtractOptions::default()).unwrap();
+        assert_eq!(
+            distill_count(
+                &conn,
+                "SELECT revert_override FROM papertrail_distill WHERE item_key='9'"
+            ),
+            0,
+            "a text-claim reverts ref does not flip status",
+        );
+
+        // A reverting commit that is NOT in git history (rebased away / stale annotation) also must
+        // not flip — the ref is a dangling annotation.
+        seed_reverts("commit", Some("nonexistent-sha"));
+        extract(&conn, None, &ExtractOptions::default()).unwrap();
+        assert_eq!(
+            distill_count(
+                &conn,
+                "SELECT revert_override FROM papertrail_distill WHERE item_key='9'"
+            ),
+            0,
+            "a reverts commit no longer in git history does not flip status",
+        );
+
+        // A landed revert commit that reverts a DIFFERENT (old, replaced) commit — the
+        // reopen→revert→re-fix case — must not flip the re-fixed record.
+        seed_commit_with_body(
+            &conn,
+            "repoA",
+            "stale-rev",
+            "Revert old",
+            "This reverts commit oldfix.",
+        );
+        seed_reverts("commit", Some("stale-rev"));
+        extract(&conn, None, &ExtractOptions::default()).unwrap();
+        assert_eq!(
+            distill_count(
+                &conn,
+                "SELECT revert_override FROM papertrail_distill WHERE item_key='9'"
+            ),
+            0,
+            "a revert of a non-current fix commit does not flip status",
+        );
+
+        // A landed revert whose body reverts the CURRENT fix commit does.
+        seed_commit_with_body(
+            &conn,
+            "repoA",
+            "real-rev",
+            "Revert the fix",
+            "This reverts commit cafe.",
+        );
+        seed_reverts("commit", Some("real-rev"));
+        extract(&conn, None, &ExtractOptions::default()).unwrap();
+        assert_eq!(
+            distill_count(
+                &conn,
+                "SELECT revert_override FROM papertrail_distill WHERE item_key='9'"
+            ),
+            1,
+            "a revert of the current fix commit flips status",
+        );
+    }
+
+    #[test]
+    fn a_fix_that_is_itself_a_revert_landed_it_is_not_marked_reverted() {
+        // A merged PR whose own fixing commit is a `Revert` (intentional revert work) LANDED — the
+        // record must not be marked reverted just because its subject starts with "Revert".
+        let conn = scoped_conn("repoA");
+        seed_item(
+            &conn,
+            "repoA",
+            "change_request",
+            "9",
+            "Revert the bad change.",
+            "merged",
+            Some("cafe"),
+        );
+        seed_commit(&conn, "repoA", "cafe", "Revert \"feat: bad change\" (#8)");
+        extract(&conn, None, &ExtractOptions::default()).unwrap();
+        assert_eq!(
+            distill_count(
+                &conn,
+                "SELECT revert_override FROM papertrail_distill WHERE item_key='9'"
+            ),
+            0,
+            "intentional revert work that landed is not itself reverted",
+        );
+    }
+
+    #[test]
+    fn a_revert_of_the_coalesced_partner_pr_flips_the_issue_record() {
+        // Issue #5 coalesces merged PR #6; the revert commit references the PR (#6), not the issue.
+        let conn = scoped_conn("repoA");
+        seed_item(&conn, "repoA", "issue", "5", "A bug.", "closed", None);
+        seed_item(&conn, "repoA", "change_request", "6", "The fix PR.", "merged", Some("m6"));
+        seed_closing_edge(&conn, "repoA", "5", "6", Some("m6"), "provider");
+        seed_commit(&conn, "repoA", "m6", "The fix"); // the coalesced fix (merge commit)
+        // the revert names the fix commit it reverts
+        seed_commit_with_body(&conn, "repoA", "rev6", "Revert the fix", "This reverts commit m6.");
+        conn.execute(
+            "INSERT INTO papertrail_refs
+                 (tracker, project, item_key, item_kind, ref_kind, source_kind, source_commit,
+                  source_text, discovered_at_ms, repo_id)
+             VALUES ('github','o/r','6','change_request','reverts','commit','rev6','Reverts \
+             #6',1,'repoA')",
+            [],
+        )
+        .unwrap();
+
+        extract(&conn, None, &ExtractOptions::default()).unwrap();
+        assert_eq!(
+            distill_count(
+                &conn,
+                "SELECT revert_override FROM papertrail_distill WHERE item_kind='issue' AND \
+                 item_key='5'"
+            ),
+            1,
+            "a revert of the coalesced partner PR flips the issue record",
+        );
+    }
+
+    #[test]
+    fn a_rerun_preserves_non_coalesced_edges() {
+        let conn = scoped_conn("repoA");
+        seed_item(&conn, "repoA", "change_request", "9", "A PR.", "merged", Some("cafe"));
+        seed_commit(&conn, "repoA", "cafe", "feat: x");
+        extract(&conn, None, &ExtractOptions::default()).unwrap();
+        // A later model/human `supersedes` edge authored by this record (reserved to survive
+        // regeneration).
+        conn.execute(
+            "INSERT INTO papertrail_distill_edges
+                 (tracker, project, src_item_kind, src_item_key, dst_item_kind, dst_item_key,
+                  edge_kind, created_at_ms, repo_id)
+             VALUES \
+             ('github','o/r','change_request','9','change_request','10','supersedes',1,'repoA')",
+            [],
+        )
+        .unwrap();
+
+        // Re-extract: the mechanical clear must NOT wipe the supersedes edge.
+        extract(&conn, None, &ExtractOptions::default()).unwrap();
+        assert_eq!(
+            distill_count(
+                &conn,
+                "SELECT COUNT(*) FROM papertrail_distill_edges WHERE edge_kind='supersedes' AND \
+                 src_item_key='9'"
+            ),
+            1,
+            "a rerun preserves supersedes/promoted edges",
+        );
+    }
+
+    #[test]
+    fn regeneration_resets_the_queue_attempt_state() {
+        let conn = scoped_conn("repoA");
+        seed_item(&conn, "repoA", "change_request", "9", "A PR.", "merged", Some("cafe"));
+        seed_commit(&conn, "repoA", "cafe", "feat: x");
+        extract(&conn, None, &ExtractOptions::default()).unwrap();
+        // The previous input exhausted the drain's retries and left an error on the queue row.
+        conn.execute(
+            "UPDATE papertrail_distill_queue SET attempts=5, last_error='boom', raw_reply='junk'
+             WHERE item_key='9'",
+            [],
+        )
+        .unwrap();
+
+        // The input changes (a new comment). The regenerated work must start with a fresh attempt.
+        seed_comment(&conn, "repoA", "change_request", "9", "c-new", false);
+        extract(&conn, None, &ExtractOptions::default()).unwrap();
+        let (attempts, err, reply): (i64, Option<String>, Option<String>) = conn
+            .query_row(
+                "SELECT attempts, last_error, raw_reply FROM papertrail_distill_queue WHERE \
+                 item_key='9'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(attempts, 0, "regeneration resets the attempt count");
+        assert_eq!(err, None);
+        assert_eq!(reply, None);
+    }
+
+    #[test]
+    fn regeneration_clears_stale_model_output_but_an_identical_rerun_preserves_it() {
+        let conn = scoped_conn("repoA");
+        seed_item(&conn, "repoA", "change_request", "9", "A PR body.", "merged", Some("cafe"));
+        seed_commit(&conn, "repoA", "cafe", "refactor: x");
+        extract(&conn, None, &ExtractOptions::default()).unwrap();
+
+        // Simulate the #704 pass filling model columns + model junctions on this record.
+        conn.execute(
+            "UPDATE papertrail_distill SET root_cause='the cause', outcome_status_model='landed',
+                 quotes_materialized=3 WHERE item_key='9'",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO papertrail_distill_evidence
+                 (tracker, project, item_kind, item_key, field, source_kind, source_id,
+                  byte_start, byte_end, quote, repo_id)
+             VALUES ('github','o/r','change_request','9','root_cause','item','9',0,3,'the','repoA')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO papertrail_distill_alternatives
+                 (tracker, project, item_kind, item_key, ordinal, alternative, repo_id)
+             VALUES ('github','o/r','change_request','9',0,'do nothing','repoA')",
+            [],
+        )
+        .unwrap();
+
+        // An IDENTICAL rerun preserves the model's work (same input hash + pipeline version).
+        extract(&conn, None, &ExtractOptions::default()).unwrap();
+        let cause: Option<String> = conn
+            .query_row("SELECT root_cause FROM papertrail_distill WHERE item_key='9'", [], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        assert_eq!(cause.as_deref(), Some("the cause"), "identical rerun keeps model output");
+        assert_eq!(distill_count(&conn, "SELECT COUNT(*) FROM papertrail_distill_evidence"), 1);
+
+        // Changing the input (a new comment shifts the assembled units → a new hash) INVALIDATES
+        // the model columns and clears the model junctions.
+        seed_comment(&conn, "repoA", "change_request", "9", "c-new", false);
+        extract(&conn, None, &ExtractOptions::default()).unwrap();
+        let cause_after: Option<String> = conn
+            .query_row("SELECT root_cause FROM papertrail_distill WHERE item_key='9'", [], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        assert_eq!(cause_after, None, "regeneration NULLs the stale model columns");
+        assert_eq!(
+            distill_count(&conn, "SELECT COUNT(*) FROM papertrail_distill_evidence"),
+            0,
+            "regeneration clears stale evidence",
+        );
+        assert_eq!(
+            distill_count(&conn, "SELECT COUNT(*) FROM papertrail_distill_alternatives"),
+            0,
+            "regeneration clears stale alternatives",
+        );
+    }
+}

--- a/crates/rag-rat-core/src/distill/mod.rs
+++ b/crates/rag-rat-core/src/distill/mod.rs
@@ -1,0 +1,20 @@
+//! Deterministic distillation substrate (#703): the model-free half of the distilled-record
+//! pipeline. It reads the papertrail mirror (items, comments, provider/text closing edges) and the
+//! git-history file changes, decides which threads are eligible, assembles their numbered text-unit
+//! input, mines mechanical fix commits / issue↔PR coalescing edges / anchor candidates, and
+//! enqueues the eligible threads for the later LLM pass (#704). Everything here is deterministic
+//! and testable without a model; the LLM never runs from this module.
+//!
+//! Crate placement: this lives in `rag-rat-core` (not `rag-rat-papertrail`) because anchor mining
+//! reads the symbol index, and `rag-rat-query` — where symbol reads live — depends on
+//! `rag-rat-papertrail`; a distill module in papertrail would be a dependency cycle. The persisted
+//! enums it writes live in `rag-rat-papertrail` (the lowest common crate the Phase-3 readers
+//! share).
+
+mod candidates;
+mod extract;
+mod units;
+mod validate;
+
+pub use extract::ExtractReport;
+pub(crate) use extract::{enqueue_eligible, extract};

--- a/crates/rag-rat-core/src/distill/units.rs
+++ b/crates/rag-rat-core/src/distill/units.rs
@@ -1,0 +1,270 @@
+//! Text-unit segmentation for the distill input substrate (#703).
+//!
+//! A distilled thread's body and comments are split into numbered UNITS the model cites by id;
+//! quotes then materialize MECHANICALLY as the exact source substring of the cited unit's byte span
+//! (never re-emitted by the model, so a quote can never drift from the source). Segmentation is
+//! block-level via pulldown-cmark's `OffsetIter`, which reports each event with its source byte
+//! range — so a fenced code block (which contains blank lines) stays ONE unit instead of shattering
+//! the way a naive blank-line split would.
+//!
+//! This module is deterministic and model-free: it is exercised in Phase 1 to compute the
+//! regeneration hash over ordered spans, and reused at drain time (#704) to build the LLM input.
+
+use pulldown_cmark::{Event, Options, Parser};
+
+/// A half-open byte range `[start, end)` into the segmented text. The materialized quote for a unit
+/// is exactly `&text[start..end]` — this is the whole point of carrying spans instead of copies.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct Span {
+    pub start: usize,
+    pub end: usize,
+}
+
+impl Span {
+    /// The exact source substring this span selects. Callers materialize quotes through here so the
+    /// "quote == source substring" invariant holds by construction.
+    pub(crate) fn slice(self, text: &str) -> &str {
+        &text[self.start..self.end]
+    }
+
+    fn len(self) -> usize {
+        self.end - self.start
+    }
+}
+
+/// Split one text blob into block-level units, in source order, dropping whitespace-only gaps.
+///
+/// Each top-level CommonMark block (paragraph, heading, list, block quote, fenced/indented code,
+/// table, …) becomes one unit spanning from its opening event to its closing event. Nested blocks
+/// (a list's items, a quote's paragraphs) stay folded into their enclosing top-level unit so a
+/// citation targets a coherent chunk, not a fragment. Text with no block structure (or a parser
+/// that yields nothing, e.g. empty input) yields no units.
+pub(crate) fn segment_blocks(text: &str) -> Vec<Span> {
+    let mut spans = Vec::new();
+    let mut depth: u32 = 0;
+    let mut open_start: Option<usize> = None;
+    // A run of consecutive TOP-LEVEL block-HTML events (`<details>`, HTML tables, generated
+    // reports). pulldown-cmark emits raw block HTML as `Event::Html` OUTSIDE any Start/End pair —
+    // one event per line — so without this it would contribute no unit, no hash content, and no
+    // model-visible evidence. Nested HTML (inside a block quote/list) rides its enclosing block's
+    // span, so only depth-0 HTML needs its own unit. Coalesce adjacent lines into one span.
+    let mut html_run: Option<(usize, usize)> = None;
+    // GFM tables / strikethrough / task lists appear in tracker markdown; enabling them keeps their
+    // ranges coherent instead of leaking table pipes into paragraph units.
+    let options =
+        Options::ENABLE_TABLES | Options::ENABLE_STRIKETHROUGH | Options::ENABLE_TASKLISTS;
+    for (event, range) in Parser::new_ext(text, options).into_offset_iter() {
+        if depth == 0 && matches!(event, Event::Html(_)) {
+            html_run = Some((html_run.map_or(range.start, |(start, _)| start), range.end));
+            continue;
+        }
+        // Any other event ends a pending top-level HTML run.
+        if let Some((start, end)) = html_run.take() {
+            push_trimmed(&mut spans, text, start, end);
+        }
+        match event {
+            Event::Start(_) => {
+                if depth == 0 {
+                    open_start = Some(range.start);
+                }
+                depth += 1;
+            },
+            Event::End(_) => {
+                // Saturating: a malformed stream cannot underflow us into a bogus wide span.
+                depth = depth.saturating_sub(1);
+                if depth == 0
+                    && let Some(start) = open_start.take()
+                {
+                    push_trimmed(&mut spans, text, start, range.end);
+                }
+            },
+            _ => {},
+        }
+    }
+    if let Some((start, end)) = html_run.take() {
+        push_trimmed(&mut spans, text, start, end);
+    }
+    spans
+}
+
+/// Record `[start, end)` with surrounding ASCII whitespace trimmed off the span itself, so the
+/// materialized quote has no leading/trailing blank lines. Empty-after-trim spans are dropped.
+fn push_trimmed(spans: &mut Vec<Span>, text: &str, start: usize, end: usize) {
+    let raw = &text[start..end];
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return;
+    }
+    let lead = raw.len() - raw.trim_start().len();
+    let trail = raw.len() - raw.trim_end().len();
+    spans.push(Span { start: start + lead, end: end - trail });
+}
+
+/// Tail-aware budget: keep whole units from the head and the tail, dropping a contiguous MIDDLE
+/// run, until the retained byte total fits `max_total`. Returns the retained unit indices in order
+/// plus a `dropped` count. The head+tail bias is deliberate — a thread's framing (the opening
+/// report) and its resolution (the closing decision) carry more signal than the middle churn.
+///
+/// Units already within budget are returned unchanged. Only a SINGLE indivisible over-budget unit
+/// is kept past the limit (we never split a unit — that would break the span→quote invariant); any
+/// other over-budget set is trimmed, so even a two-unit thread (a short title + a huge body) cannot
+/// smuggle an arbitrarily large input past the budget.
+pub(crate) fn tail_aware_budget(spans: &[Span], max_total: usize) -> BudgetPlan {
+    let total: usize = spans.iter().map(|s| s.len()).sum();
+    if total <= max_total {
+        return BudgetPlan { kept: (0..spans.len()).collect(), dropped: 0, kept_bytes: total };
+    }
+    // The first unit (the framing) is ALWAYS retained — even if it alone exceeds the budget — since
+    // it carries the problem statement. Then fill the remaining budget from the tail (the
+    // resolution) first, extending the head only after the tail can grow no further. On a miss at
+    // one end the other end is still tried, so an uneven thread (e.g. `[8, 8, 2]` under a 10-byte
+    // budget) keeps head+tail (`[0, 2]`) instead of stalling on the first over-budget middle unit.
+    let n = spans.len();
+    let mut head = 1usize;
+    let mut tail = 0usize;
+    let mut kept_bytes = spans[0].len();
+    while head + tail < n {
+        let head_idx = head;
+        let tail_idx = n - 1 - tail;
+        if try_grow(spans, tail_idx, &mut kept_bytes, max_total).is_some() {
+            tail += 1;
+        } else if head_idx != tail_idx
+            && try_grow(spans, head_idx, &mut kept_bytes, max_total).is_some()
+        {
+            head += 1;
+        } else {
+            break;
+        }
+    }
+    let mut kept: Vec<usize> = (0..head).collect();
+    kept.extend((n - tail)..n);
+    BudgetPlan { dropped: n - kept.len(), kept_bytes, kept }
+}
+
+fn try_grow(spans: &[Span], idx: usize, kept_bytes: &mut usize, max_total: usize) -> Option<()> {
+    let next = *kept_bytes + spans[idx].len();
+    if next <= max_total {
+        *kept_bytes = next;
+        Some(())
+    } else {
+        None
+    }
+}
+
+/// The retained-unit plan from [`tail_aware_budget`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct BudgetPlan {
+    /// Retained unit indices, in source order (a head prefix followed by a tail suffix).
+    pub kept: Vec<usize>,
+    /// Number of units dropped from the middle.
+    pub dropped: usize,
+    /// Total bytes across the retained units.
+    pub kept_bytes: usize,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Span, segment_blocks, tail_aware_budget};
+
+    #[test]
+    fn a_fenced_code_block_stays_one_unit_despite_its_blank_lines() {
+        let text = "Intro paragraph.\n\n```rust\nfn a() {}\n\nfn b() {}\n```\n\nClosing note.";
+        let spans = segment_blocks(text);
+        let quotes: Vec<&str> = spans.iter().map(|s| s.slice(text)).collect();
+        assert_eq!(quotes.len(), 3, "intro, whole code block, closing");
+        assert_eq!(quotes[0], "Intro paragraph.");
+        assert!(quotes[1].contains("fn a()") && quotes[1].contains("fn b()"), "code block whole");
+        assert_eq!(quotes[2], "Closing note.");
+    }
+
+    #[test]
+    fn every_span_slices_back_to_its_exact_source_substring() {
+        let text = "First para.\n\n- item one\n- item two\n\n> a quote line";
+        let text_bytes = text.as_bytes();
+        for span in segment_blocks(text) {
+            // The materialized quote is byte-exact and trimmed of surrounding whitespace.
+            let quote = span.slice(text);
+            assert_eq!(quote.as_bytes(), &text_bytes[span.start..span.end]);
+            assert_eq!(quote, quote.trim());
+        }
+    }
+
+    #[test]
+    fn top_level_raw_html_blocks_become_a_unit() {
+        // A contiguous raw-HTML block (GitHub `<details>`, HTML tables, generated reports) arrives
+        // as raw block HTML with no Start/End pair; its consecutive lines must coalesce into ONE
+        // captured unit instead of vanishing.
+        let text = "Intro.\n\n<div class=\"report\">\n<p>raw html body</p>\n</div>\n\nOutro.";
+        let quotes: Vec<String> =
+            segment_blocks(text).iter().map(|s| s.slice(text).to_string()).collect();
+        assert!(
+            quotes
+                .iter()
+                .any(|q| q.contains("<div") && q.contains("</div>") && q.contains("raw html body")),
+            "the html block is captured whole as one unit: {quotes:?}",
+        );
+        assert!(quotes.iter().any(|q| q == "Intro."));
+        assert!(quotes.iter().any(|q| q == "Outro."));
+    }
+
+    #[test]
+    fn empty_and_whitespace_only_text_yield_no_units() {
+        assert!(segment_blocks("").is_empty());
+        assert!(segment_blocks("   \n\n  \t\n").is_empty());
+    }
+
+    #[test]
+    fn budget_keeps_head_and_tail_dropping_the_middle() {
+        // Five 10-byte units; a 25-byte budget keeps two from the ends and drops the middle three.
+        let spans: Vec<Span> = (0..5).map(|i| Span { start: i * 10, end: i * 10 + 10 }).collect();
+        let plan = tail_aware_budget(&spans, 25);
+        assert_eq!(plan.kept_bytes, 20, "two 10-byte units fit under 25");
+        assert_eq!(plan.dropped, 3);
+        assert_eq!(plan.kept, vec![0, 4], "head unit 0 and tail unit 4 survive");
+    }
+
+    #[test]
+    fn budget_keeps_head_and_tail_on_an_uneven_thread_instead_of_stalling() {
+        // `[8, 8, 2]` under a 10-byte budget: the middle unit (index 1) does not fit after the
+        // head, but the 2-byte tail does — head+tail = 10. The old early-exit kept only
+        // `[0]`.
+        let spans = vec![Span { start: 0, end: 8 }, Span { start: 8, end: 16 }, Span {
+            start: 16,
+            end: 18,
+        }];
+        let plan = tail_aware_budget(&spans, 10);
+        assert_eq!(plan.kept, vec![0, 2], "head unit 0 and tail unit 2 both fit");
+        assert_eq!(plan.kept_bytes, 10);
+        assert_eq!(plan.dropped, 1);
+    }
+
+    #[test]
+    fn budget_trims_a_two_unit_thread_that_exceeds_the_limit() {
+        // A short title + a huge body must not slip past the budget just because there are two
+        // units: the framing survives, the over-budget body is dropped.
+        let spans = vec![Span { start: 0, end: 4 }, Span { start: 4, end: 1000 }];
+        let plan = tail_aware_budget(&spans, 10);
+        assert_eq!(plan.kept, vec![0], "the framing title is kept; the huge body is dropped");
+        assert_eq!(plan.kept_bytes, 4);
+        assert_eq!(plan.dropped, 1);
+    }
+
+    #[test]
+    fn budget_within_limit_keeps_everything_in_order() {
+        let spans: Vec<Span> = (0..4).map(|i| Span { start: i * 5, end: i * 5 + 5 }).collect();
+        let plan = tail_aware_budget(&spans, 1000);
+        assert_eq!(plan.kept, vec![0, 1, 2, 3]);
+        assert_eq!(plan.dropped, 0);
+    }
+
+    #[test]
+    fn budget_keeps_at_least_the_first_unit_when_it_alone_exceeds_the_limit() {
+        let spans = vec![Span { start: 0, end: 100 }, Span { start: 100, end: 110 }, Span {
+            start: 110,
+            end: 120,
+        }];
+        let plan = tail_aware_budget(&spans, 10);
+        assert_eq!(plan.kept, vec![0], "the framing unit always survives");
+        assert_eq!(plan.dropped, 2);
+    }
+}

--- a/crates/rag-rat-core/src/distill/validate.rs
+++ b/crates/rag-rat-core/src/distill/validate.rs
@@ -1,0 +1,227 @@
+//! Mechanical status floors and provenance checks for distilled records (#703).
+//!
+//! Every function here is PURE and deterministic — no DB, no model. The floors are the guardrails
+//! that keep a model's outcome/decision claims honest: the EFFECTIVE outcome status is computed
+//! from mechanical facts (was it reverted? does a closing keyword link the fix? is there any fix
+//! edge at all?) with fixed precedence, so the model can never over-claim "landed" on a thread that
+//! has no landing evidence. Phase 1 computes the mechanical inputs (revert / closing-keyword /
+//! fix-edge) and stores them raw; the LLM pass (#704) supplies `model_status` and the provenance
+//! evidence, and the read layer (#705) applies [`effective_status`]. All of it is implemented and
+//! tested here so the floor logic exists before either consumer does.
+
+use rag_rat_papertrail::{FixEdgeSource, OutcomeStatus, ThreadShape};
+
+// NOTE: the closing-keyword floor is NOT derived by re-scanning commit text here. Reproducing the
+// reference grammar (provider-aware keyword sets incl. GitLab gerunds, project scoping, issue-vs-PR
+// kind, URL forms) is exactly what the papertrail closer-minting tier already does — so the floor
+// is derived in `extract` from the presence of a TEXT-tier closing edge the canonical parser
+// minted.
+
+// NOTE: the `revert_override` floor is computed in `extract` (a downstream landed commit whose body
+// reverts one of the record's CURRENT fix SHAs), not here. It deliberately does NOT key on the fix
+// commit itself being a `Revert` — intentional revert work that landed is `landed`, not `reverted`.
+
+/// The `no-fix-edge` floor: no closing edge and no merge commit establish that anything landed.
+pub(crate) fn no_fix_edge(fix_edge_source: FixEdgeSource) -> bool {
+    fix_edge_source == FixEdgeSource::None
+}
+
+/// A commenter/author association that denotes a maintainer (repo owner, org member, or invited
+/// collaborator). Case-insensitive; anything else (CONTRIBUTOR / NONE / bots / unknown) is not.
+// Wired by the #704 LLM pass (decision-provenance floor over cited evidence); exercised now by the
+// floor tests so the logic ships and is verified before its consumer exists.
+#[cfg_attr(not(test), allow(dead_code))]
+pub(crate) fn is_maintainer_association(association: Option<&str>) -> bool {
+    matches!(
+        association.map(str::to_ascii_uppercase).as_deref(),
+        Some("OWNER" | "MEMBER" | "COLLABORATOR")
+    )
+}
+
+/// The decision-provenance floor (#704): a distilled DECISION is provenance-verified only when at
+/// least one of its cited evidence units was authored by a maintainer — a drive-by contributor's
+/// "we should do X" is a proposal, not a decision the project made.
+#[cfg_attr(not(test), allow(dead_code))]
+pub(crate) fn decision_provenance_verified(cited_evidence_associations: &[Option<String>]) -> bool {
+    cited_evidence_associations.iter().any(|a| is_maintainer_association(a.as_deref()))
+}
+
+/// The outcome-claim floor (#704, claimed-vs-measured): a model claim of `landed` is verified only
+/// when a mechanical fix edge or closing keyword corroborates it; any non-landed claim needs no
+/// corroboration (a thread can be honestly `unclear` / `descoped` with no fix edge).
+#[cfg_attr(not(test), allow(dead_code))]
+pub(crate) fn outcome_claim_verified(
+    model_status: OutcomeStatus,
+    has_fix_edge: bool,
+    has_closing_keyword: bool,
+) -> bool {
+    match model_status {
+        OutcomeStatus::Landed => has_fix_edge || has_closing_keyword,
+        _ => true,
+    }
+}
+
+/// Inputs to the effective-status resolver: the mechanical floors plus the (optional) model status.
+pub(crate) struct EffectiveStatusInputs {
+    pub revert_override: bool,
+    pub closing_keyword: bool,
+    pub fix_edge_source: FixEdgeSource,
+    pub model_status: Option<OutcomeStatus>,
+}
+
+/// Resolve the EFFECTIVE outcome status with fixed precedence: revert > closing-keyword >
+/// no-fix-edge > model. A revert wins outright; a closing keyword forces `landed` (the fix
+/// mechanically closed the work); with no fix edge the record can never be `landed` (a model
+/// `landed`/absent collapses to `unclear`, while an honest `descoped`/`superseded` stands);
+/// otherwise the model's status is authoritative, defaulting to `unclear` when the model is silent.
+pub(crate) fn effective_status(inputs: &EffectiveStatusInputs) -> OutcomeStatus {
+    if inputs.revert_override {
+        return OutcomeStatus::Reverted;
+    }
+    if inputs.closing_keyword {
+        return OutcomeStatus::Landed;
+    }
+    if no_fix_edge(inputs.fix_edge_source) {
+        return match inputs.model_status {
+            Some(OutcomeStatus::Landed) | None => OutcomeStatus::Unclear,
+            Some(other) => other,
+        };
+    }
+    inputs.model_status.unwrap_or(OutcomeStatus::Unclear)
+}
+
+/// Mechanical thread-shape classification from discussion structure. `Thin` = little discussion (a
+/// short body and at most one comment); `ReviewStream` = review-dominated back-and-forth (review
+/// events are at least half of a non-trivial comment set); otherwise `Investigation`.
+pub(crate) fn classify_thread_shape(
+    total_comments: usize,
+    review_comments: usize,
+    body_len: usize,
+) -> ThreadShape {
+    if total_comments <= 1 && body_len < 400 {
+        ThreadShape::Thin
+    } else if review_comments >= 2 && review_comments * 2 >= total_comments {
+        ThreadShape::ReviewStream
+    } else {
+        ThreadShape::Investigation
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rag_rat_papertrail::{FixEdgeSource, OutcomeStatus, ThreadShape};
+
+    use super::{
+        EffectiveStatusInputs, classify_thread_shape, decision_provenance_verified,
+        effective_status, is_maintainer_association, no_fix_edge, outcome_claim_verified,
+    };
+
+    #[test]
+    fn no_fix_edge_floor_fires_only_on_none() {
+        assert!(no_fix_edge(FixEdgeSource::None));
+        assert!(!no_fix_edge(FixEdgeSource::Provider));
+        assert!(!no_fix_edge(FixEdgeSource::Text));
+    }
+
+    #[test]
+    fn maintainer_and_decision_provenance() {
+        assert!(is_maintainer_association(Some("OWNER")));
+        assert!(is_maintainer_association(Some("member")));
+        assert!(is_maintainer_association(Some("Collaborator")));
+        assert!(!is_maintainer_association(Some("CONTRIBUTOR")));
+        assert!(!is_maintainer_association(Some("NONE")));
+        assert!(!is_maintainer_association(None));
+        // Synthesized positive: a maintainer-authored evidence unit verifies the decision.
+        assert!(decision_provenance_verified(&[Some("NONE".into()), Some("MEMBER".into())]));
+        // All drive-by → not verified.
+        assert!(!decision_provenance_verified(&[Some("CONTRIBUTOR".into()), None]));
+    }
+
+    #[test]
+    fn outcome_claim_needs_corroboration_only_for_landed() {
+        assert!(outcome_claim_verified(OutcomeStatus::Landed, true, false));
+        assert!(outcome_claim_verified(OutcomeStatus::Landed, false, true));
+        assert!(!outcome_claim_verified(OutcomeStatus::Landed, false, false));
+        // Non-landed claims are self-consistent without a fix edge.
+        assert!(outcome_claim_verified(OutcomeStatus::Descoped, false, false));
+        assert!(outcome_claim_verified(OutcomeStatus::Unclear, false, false));
+    }
+
+    #[test]
+    fn effective_status_precedence_revert_beats_everything() {
+        let status = effective_status(&EffectiveStatusInputs {
+            revert_override: true,
+            closing_keyword: true,
+            fix_edge_source: FixEdgeSource::Provider,
+            model_status: Some(OutcomeStatus::Landed),
+        });
+        assert_eq!(status, OutcomeStatus::Reverted);
+    }
+
+    #[test]
+    fn effective_status_closing_keyword_forces_landed_over_model() {
+        let status = effective_status(&EffectiveStatusInputs {
+            revert_override: false,
+            closing_keyword: true,
+            fix_edge_source: FixEdgeSource::Text,
+            model_status: Some(OutcomeStatus::Unclear),
+        });
+        assert_eq!(status, OutcomeStatus::Landed);
+    }
+
+    #[test]
+    fn effective_status_no_fix_edge_cannot_be_landed() {
+        // Model over-claims landed with no fix edge → collapses to unclear.
+        assert_eq!(
+            effective_status(&EffectiveStatusInputs {
+                revert_override: false,
+                closing_keyword: false,
+                fix_edge_source: FixEdgeSource::None,
+                model_status: Some(OutcomeStatus::Landed),
+            }),
+            OutcomeStatus::Unclear,
+        );
+        // An honest descoped stands.
+        assert_eq!(
+            effective_status(&EffectiveStatusInputs {
+                revert_override: false,
+                closing_keyword: false,
+                fix_edge_source: FixEdgeSource::None,
+                model_status: Some(OutcomeStatus::Descoped),
+            }),
+            OutcomeStatus::Descoped,
+        );
+    }
+
+    #[test]
+    fn effective_status_defers_to_model_when_a_fix_edge_exists() {
+        assert_eq!(
+            effective_status(&EffectiveStatusInputs {
+                revert_override: false,
+                closing_keyword: false,
+                fix_edge_source: FixEdgeSource::Provider,
+                model_status: Some(OutcomeStatus::Superseded),
+            }),
+            OutcomeStatus::Superseded,
+        );
+        // Silent model with a fix edge → unclear (not a fabricated landed).
+        assert_eq!(
+            effective_status(&EffectiveStatusInputs {
+                revert_override: false,
+                closing_keyword: false,
+                fix_edge_source: FixEdgeSource::Provider,
+                model_status: None,
+            }),
+            OutcomeStatus::Unclear,
+        );
+    }
+
+    #[test]
+    fn thread_shape_classification() {
+        assert_eq!(classify_thread_shape(0, 0, 120), ThreadShape::Thin);
+        assert_eq!(classify_thread_shape(6, 5, 2000), ThreadShape::ReviewStream);
+        assert_eq!(classify_thread_shape(8, 1, 2000), ThreadShape::Investigation);
+        // A long body with no comments is still worth distilling — not thin.
+        assert_eq!(classify_thread_shape(0, 0, 5000), ThreadShape::Investigation);
+    }
+}

--- a/crates/rag-rat-core/src/index/query_api/history.rs
+++ b/crates/rag-rat-core/src/index/query_api/history.rs
@@ -171,12 +171,14 @@ impl IndexDatabase {
         let Some(root) = self.storage.source_root() else {
             anyhow::bail!("index has no source_root metadata; rebuild required");
         };
-        papertrail::block_on(papertrail::sync_mirror(
+        let report = papertrail::block_on(papertrail::sync_mirror(
             self.storage.connection(),
             root,
             full,
             &self.papertrail,
-        ))
+        ))?;
+        self.distill_enqueue_after_sync();
+        Ok(report)
     }
 
     /// Mirror only the bindings the scheduling policy says are due (the automatic watcher / hook
@@ -193,12 +195,39 @@ impl IndexDatabase {
         let Some(root) = self.storage.source_root() else {
             anyhow::bail!("index has no source_root metadata; rebuild required");
         };
-        papertrail::block_on(papertrail::sync_mirror_scheduled(
+        let report = papertrail::block_on(papertrail::sync_mirror_scheduled(
             self.storage.connection(),
             root,
             &self.papertrail,
             request,
-        ))
+        ))?;
+        self.distill_enqueue_after_sync();
+        Ok(report)
+    }
+
+    /// Enqueue newly eligible threads into the distill work-list after a mirror pass. Cheap SQL
+    /// that RIDES sync; the expensive extraction + LLM DRAIN is the #704 dream-lane pass and
+    /// never runs here. Best-effort: a distill-enqueue failure must not fail the mirror sync
+    /// that succeeded, so it is logged and swallowed (the next sync re-enqueues; nothing is
+    /// lost).
+    fn distill_enqueue_after_sync(&self) {
+        if let Err(err) = crate::distill::enqueue_eligible(self.storage.connection()) {
+            tracing::warn!("distill enqueue after papertrail sync failed: {err:#}");
+        }
+    }
+
+    /// Run the deterministic distill extraction over the mirror (#703): skeleton records +
+    /// fixing-commit / coalesce / anchor junctions + queue entries, with the model columns left
+    /// NULL for the #704 pass to fill. Model-free and idempotent.
+    pub fn distill_extract(&self) -> anyhow::Result<crate::distill::ExtractReport> {
+        // The source root lets anchor mining fall back to a live gix first-parent diff for merge
+        // commits (the history index stores no `git_file_changes` rows for real merges). `None` (a
+        // bare/copied index) simply skips that fallback.
+        crate::distill::extract(
+            self.storage.connection(),
+            self.storage.source_root(),
+            &Default::default(),
+        )
     }
 
     pub fn papertrail_issue_search(

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_registry.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_registry.rs
@@ -199,6 +199,37 @@ fn register_repo_adopts_the_placeholder() {
     assert_eq!(root, "/src/myrepo");
 }
 
+/// Adoption re-points the distilled-record store (#703): a `papertrail_distill` row seeded under
+/// the `__unassigned__` placeholder must carry the real repo id after registration, or the record
+/// would strand under the retired id and vanish from the active scope.
+#[test]
+fn register_repo_repoints_distill_rows_from_the_placeholder() {
+    let conn = rusqlite::Connection::open_in_memory().expect("open");
+    schema::apply(&conn, &crate::index::migration_hooks()).expect("apply");
+    conn.execute(
+        "INSERT INTO papertrail_distill
+             (tracker, project, item_kind, item_key, distill_input_hash, pipeline_version,
+              fix_edge_source, thread_shape, distilled_at_ms, repo_id)
+         VALUES ('github','o/r','issue','5','h',1,'provider','investigation',1,?1)",
+        [LEGACY_REPO_ID],
+    )
+    .unwrap();
+
+    register_repo(
+        &conn,
+        &identity("repo-abc", "myrepo"),
+        Path::new("/src/myrepo"),
+        123,
+        &crate::index::migration_hooks(),
+    )
+    .expect("register");
+
+    let repo_id: String = conn
+        .query_row("SELECT repo_id FROM papertrail_distill WHERE item_key='5'", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(repo_id, "repo-abc", "the distill row is re-pointed to the adopted repo id");
+}
+
 /// Re-applying the full schema AFTER adoption must NOT resurrect the `__unassigned__` placeholder.
 /// `schema::apply` re-runs every additive migration (this is the exact path
 /// `IndexDatabase::rebuild` takes via `create_or_migrate` on an already-migrated DB), so the V038

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
@@ -2693,7 +2693,7 @@ fn migration_073_backfills_state_normalized_from_the_provider_truthful_pair() {
 
 #[test]
 fn migration_074_refreshes_the_edges_view() {
-    // The absolute-tip pin moved to `migration_075_*` (V075 is the tip now); this drops to the
+    // The absolute-tip pin moved to `migration_076_*` (V076 is the tip now); this drops to the
     // symbolic `current_version == LATEST` freshness check, per the ladder convention.
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     schema::apply(&conn, &crate::index::migration_hooks()).unwrap();
@@ -2873,7 +2873,6 @@ fn migration_075_materializes_edge_visibility() {
 
 #[test]
 fn migration_076_adds_sync_security_events() {
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 76, "move this pin with the next schema migration");
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     schema::apply(&conn, &crate::index::migration_hooks()).unwrap();
 
@@ -2910,4 +2909,98 @@ fn migration_076_adds_sync_security_events() {
         )
         .unwrap();
     assert_eq!(v76_recorded, 1, "the forward migration records V076");
+}
+
+#[test]
+fn migration_077_is_the_tip_and_builds_the_distill_record_store() {
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 77, "move this pin with the next schema migration");
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn, &crate::index::migration_hooks()).unwrap();
+    assert_eq!(
+        schema::status(&conn).unwrap().current_version,
+        schema::LATEST_SCHEMA_VERSION,
+        "schema at LATEST after apply",
+    );
+
+    // The record row carries the derived-facet columns + the raw status floors; repo_id from birth.
+    let cols = conn_table_columns(&conn, "papertrail_distill");
+    for col in [
+        "tracker",
+        "project",
+        "item_kind",
+        "item_key",
+        "distill_input_hash",
+        "pipeline_version",
+        "root_issue",
+        "root_cause",
+        "root_cause_class",
+        "decision_chosen",
+        "outcome_summary",
+        "outcome_status_model",
+        "epistemic_status_decision",
+        "epistemic_status_outcome",
+        "fix_edge_source",
+        "quotes_materialized",
+        "anchors_qualified_count",
+        "thread_shape",
+        "outcome_claim_verified",
+        "decision_provenance_verified",
+        "revert_override",
+        "closing_keyword_floor",
+        "distilled_at_ms",
+        "repo_id",
+    ] {
+        assert!(cols.contains(&col.to_string()), "V077 distill column `{col}` exists");
+    }
+
+    // The record is keyed to the coalesced work-unit thread: one row per
+    // (repo_id, tracker, project, item_kind, item_key). A regenerated body replaces in place.
+    conn.execute(
+        "INSERT INTO papertrail_distill(tracker, project, item_kind, item_key, \
+         distill_input_hash, pipeline_version, fix_edge_source, thread_shape, distilled_at_ms, \
+         repo_id) VALUES ('github', 'o/r', 'issue', '5', 'h1', 1, 'provider', 'investigation', 1, \
+         'r')",
+        [],
+    )
+    .unwrap();
+    assert!(
+        conn.execute(
+            "INSERT INTO papertrail_distill(tracker, project, item_kind, item_key, \
+             distill_input_hash, pipeline_version, fix_edge_source, thread_shape, \
+             distilled_at_ms, repo_id) VALUES ('github', 'o/r', 'issue', '5', 'h2', 2, 'text', \
+             'thin', 2, 'r')",
+            [],
+        )
+        .is_err(),
+        "the natural key holds one record per coalesced thread",
+    );
+
+    // The junction/companion tables all land in the same migration.
+    for table in [
+        "papertrail_distill_evidence",
+        "papertrail_distill_anchors",
+        "papertrail_distill_alternatives",
+        "papertrail_distill_record_commits",
+        "papertrail_distill_edges",
+        "papertrail_distill_queue",
+        "papertrail_distill_runs",
+    ] {
+        let present: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = ?1",
+                [table],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(present, 1, "V077 companion table `{table}` exists");
+    }
+
+    let v77_recorded: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM schema_version WHERE id = '077_distill_record_store'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(v77_recorded, 1, "the forward migration records V077");
 }

--- a/crates/rag-rat-core/src/lib.rs
+++ b/crates/rag-rat-core/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod distill;
 #[cfg(feature = "eval")]
 pub mod eval;
 pub mod fleet;

--- a/crates/rag-rat-db/src/schema/migrations.rs
+++ b/crates/rag-rat-db/src/schema/migrations.rs
@@ -1325,6 +1325,7 @@ pub(crate) fn known_version(migrations: &[AppliedMigration]) -> u32 {
             MIGRATION_074_ID => Some(74),
             MIGRATION_075_ID => Some(75),
             MIGRATION_076_ID => Some(76),
+            MIGRATION_077_ID => Some(77),
             _ => None,
         })
         .max()
@@ -1410,6 +1411,7 @@ pub(crate) fn known_migration(id: &str) -> bool {
             | MIGRATION_074_ID
             | MIGRATION_075_ID
             | MIGRATION_076_ID
+            | MIGRATION_077_ID
             | DIRTY_MIGRATION_ID
     )
 }
@@ -1492,6 +1494,7 @@ pub(crate) fn migration_checksum_mismatch(migration: &AppliedMigration) -> bool 
         MIGRATION_074_ID => migration.checksum != MIGRATION_074_CHECKSUM,
         MIGRATION_075_ID => migration.checksum != MIGRATION_075_CHECKSUM,
         MIGRATION_076_ID => migration.checksum != MIGRATION_076_CHECKSUM,
+        MIGRATION_077_ID => migration.checksum != MIGRATION_077_CHECKSUM,
         _ => false,
     }
 }
@@ -5237,6 +5240,179 @@ pub fn apply_papertrail_distill_substrate(conn: &Connection) -> rusqlite::Result
             ELSE 'open'
         END
         WHERE state_normalized = '';
+        ",
+    )
+}
+
+/// V077 — the distillation RECORD STORE (issue #703): the derived, regenerable
+/// `papertrail_distill` table plus its junction children, thread-keyed edges, work queue, and
+/// run-stats. Consumes the V073 substrate; produced by the #704 LLM pass.
+///
+/// DESIGN INVARIANTS (locked here because these are the costliest columns to change post-landing):
+/// - **Findings-not-facts.** Records are DERIVED and regenerable, never written into trusted
+///   memories. Regeneration identity is `(distill_input_hash, pipeline_version)`; the record row is
+///   replaced in place on its natural key `(repo_id, tracker, project, item_kind, item_key)`.
+/// - **Confidence is provenance FACETS, never a fused label** (a fused high/med/low label does not
+///   discriminate accuracy — measured). Any display label is computed in the read layer.
+/// - **Edges key to the THREAD, not the record row** (`papertrail_distill_edges`), so LWW body
+///   edits / regeneration replace the record while supersession/coalesce/promotion edges survive.
+/// - **Mechanical status floors kept raw** (`revert_override`, `closing_keyword_floor`, and the
+///   `fix_edge_source='none'` no-fix-edge floor); the EFFECTIVE status is computed read-layer with
+///   precedence revert > closing-keyword > no-fix-edge > `outcome_status_model`. Fixing commits are
+///   mechanical (`papertrail_distill_record_commits`), NEVER LLM-emitted.
+/// - **No CSV-in-TEXT**: alternatives / commits / anchors / evidence are junction tables.
+/// - **Anchors born as `sym_<hex>` bindings** (relocation-compatible) with EXACT file paths; no
+///   basename fallback. `epistemic_status_*` makes proposed-not-landed / projected representable.
+///
+/// Additive: CREATE ... IF NOT EXISTS; nothing pre-existing to backfill.
+pub fn apply_distill_record_store(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "
+        CREATE TABLE IF NOT EXISTS papertrail_distill(
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            tracker TEXT NOT NULL,
+            project TEXT NOT NULL,
+            -- the coalesced work-unit thread; the ISSUE side when an issue<->PR pair is coalesced.
+            item_kind TEXT NOT NULL,
+            item_key TEXT NOT NULL,
+            -- regeneration identity: the row is replaced on the natural key when either changes.
+            distill_input_hash TEXT NOT NULL,
+            pipeline_version INTEGER NOT NULL,
+            root_issue TEXT,
+            -- NULL is an HONEST null (no failure, or none established) — not missing data.
+            root_cause TEXT,
+            -- free-text detail in v1; the induced-taxonomy FK is deferred (#705 non-goal).
+            root_cause_class TEXT,
+            decision_chosen TEXT,
+            outcome_summary TEXT,
+            -- MODEL-emitted status (OutcomeStatus::as_db_str). The EFFECTIVE status is computed in
+            -- the read layer: revert_override > closing_keyword_floor > no-fix-edge > this.
+            outcome_status_model TEXT,
+            -- event-factuality (EpistemicStatus): \
+         asserted_landed|projected|proposed_not_landed|superseded.
+            epistemic_status_decision TEXT,
+            epistemic_status_outcome TEXT,
+            -- provenance FACETS (NOT a fused confidence label).
+            fix_edge_source TEXT NOT NULL,               -- FixEdgeSource: provider|text|none
+            quotes_materialized INTEGER NOT NULL DEFAULT 0,
+            anchors_qualified_count INTEGER NOT NULL DEFAULT 0,
+            thread_shape TEXT NOT NULL,                  -- ThreadShape: \
+         investigation|review_stream|thin
+            outcome_claim_verified INTEGER NOT NULL DEFAULT 0,
+            decision_provenance_verified INTEGER NOT NULL DEFAULT 0,
+            -- raw status-floor inputs (precedence applied in the read layer, never here).
+            revert_override INTEGER NOT NULL DEFAULT 0,
+            closing_keyword_floor TEXT,
+            distilled_at_ms INTEGER NOT NULL,
+            repo_id TEXT NOT NULL DEFAULT '__unassigned__'
+        ) STRICT;
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_papertrail_distill_natural_key
+            ON papertrail_distill(repo_id, tracker, project, item_kind, item_key);
+
+        -- Evidence units: byte-span SELECTIONS with SNAPSHOTTED provenance + a MATERIALIZED quote
+        -- (raw spans dangle under the mirror's per-row LWW body edits).
+        CREATE TABLE IF NOT EXISTS papertrail_distill_evidence(
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            tracker TEXT NOT NULL, project TEXT NOT NULL,
+            item_kind TEXT NOT NULL, item_key TEXT NOT NULL,
+            field TEXT NOT NULL,                 -- record field supported: \
+         root_cause|decision|outcome
+            source_kind TEXT NOT NULL,           -- 'item' | 'comment'
+            source_id TEXT NOT NULL,
+            byte_start INTEGER NOT NULL, byte_end INTEGER NOT NULL,
+            quote TEXT NOT NULL,
+            author TEXT, author_kind TEXT, author_association TEXT,
+            unit_created_at_ms INTEGER,
+            repo_id TEXT NOT NULL DEFAULT '__unassigned__'
+        ) STRICT;
+        CREATE INDEX IF NOT EXISTS idx_papertrail_distill_evidence_thread
+            ON papertrail_distill_evidence(repo_id, tracker, project, item_kind, item_key);
+
+        -- Anchors: index-validated SELECTIONS, born as sym_<hex> bindings; EXACT file paths only.
+        CREATE TABLE IF NOT EXISTS papertrail_distill_anchors(
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            tracker TEXT NOT NULL, project TEXT NOT NULL,
+            item_kind TEXT NOT NULL, item_key TEXT NOT NULL,
+            anchor_kind TEXT NOT NULL,           -- AnchorKind: \
+         symbol|file|schema_object|crate|config_key
+            logical_symbol_id TEXT,              -- sym_<hex> when anchor_kind='symbol' AND \
+         resolved
+            file_path TEXT,
+            name TEXT NOT NULL,
+            resolved INTEGER NOT NULL DEFAULT 0,
+            repo_id TEXT NOT NULL DEFAULT '__unassigned__'
+        ) STRICT;
+        CREATE INDEX IF NOT EXISTS idx_papertrail_distill_anchors_thread
+            ON papertrail_distill_anchors(repo_id, tracker, project, item_kind, item_key);
+        CREATE INDEX IF NOT EXISTS idx_papertrail_distill_anchors_symbol
+            ON papertrail_distill_anchors(repo_id, logical_symbol_id);
+
+        -- Rejected alternatives (junction; ordinal-stable, no CSV).
+        CREATE TABLE IF NOT EXISTS papertrail_distill_alternatives(
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            tracker TEXT NOT NULL, project TEXT NOT NULL,
+            item_kind TEXT NOT NULL, item_key TEXT NOT NULL,
+            ordinal INTEGER NOT NULL,
+            alternative TEXT NOT NULL, reason TEXT,
+            repo_id TEXT NOT NULL DEFAULT '__unassigned__'
+        ) STRICT;
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_papertrail_distill_alternatives_key
+            ON papertrail_distill_alternatives(repo_id, tracker, project, item_kind, item_key, \
+         ordinal);
+
+        -- Fixing commits: MECHANICAL, from the closing edge; outcome.commits is never LLM-emitted.
+        CREATE TABLE IF NOT EXISTS papertrail_distill_record_commits(
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            tracker TEXT NOT NULL, project TEXT NOT NULL,
+            item_kind TEXT NOT NULL, item_key TEXT NOT NULL,
+            commit_sha TEXT NOT NULL,
+            repo_id TEXT NOT NULL DEFAULT '__unassigned__'
+        ) STRICT;
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_papertrail_distill_record_commits_key
+            ON papertrail_distill_record_commits(repo_id, tracker, project, item_kind, item_key, \
+         commit_sha);
+
+        -- Thread-keyed edges: survive record regeneration.
+        CREATE TABLE IF NOT EXISTS papertrail_distill_edges(
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            tracker TEXT NOT NULL, project TEXT NOT NULL,
+            src_item_kind TEXT NOT NULL, src_item_key TEXT NOT NULL,
+            dst_item_kind TEXT NOT NULL, dst_item_key TEXT NOT NULL,
+            edge_kind TEXT NOT NULL,             -- DistillEdgeKind: coalesced|supersedes|promoted
+            created_at_ms INTEGER NOT NULL,
+            repo_id TEXT NOT NULL DEFAULT '__unassigned__'
+        ) STRICT;
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_papertrail_distill_edges_key
+            ON papertrail_distill_edges(repo_id, tracker, project, src_item_kind, src_item_key,
+                                        dst_item_kind, dst_item_key, edge_kind);
+
+        -- Work queue: enqueued at mirror sync (cheap SQL), DRAINED only by the dream-lane pass.
+        CREATE TABLE IF NOT EXISTS papertrail_distill_queue(
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            tracker TEXT NOT NULL, project TEXT NOT NULL,
+            item_kind TEXT NOT NULL, item_key TEXT NOT NULL,
+            enqueued_at_ms INTEGER NOT NULL,
+            attempts INTEGER NOT NULL DEFAULT 0,
+            last_error TEXT,
+            raw_reply TEXT,
+            repo_id TEXT NOT NULL DEFAULT '__unassigned__'
+        ) STRICT;
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_papertrail_distill_queue_key
+            ON papertrail_distill_queue(repo_id, tracker, project, item_kind, item_key);
+
+        -- Per-run stats: the #704 verification bar (output-ladder rung + gate counters).
+        CREATE TABLE IF NOT EXISTS papertrail_distill_runs(
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            run_at_ms INTEGER NOT NULL,
+            threads INTEGER NOT NULL DEFAULT 0,
+            rung_guided INTEGER NOT NULL DEFAULT 0,
+            rung_serde INTEGER NOT NULL DEFAULT 0,
+            rung_unguided INTEGER NOT NULL DEFAULT 0,
+            rung_tolerant INTEGER NOT NULL DEFAULT 0,
+            failed INTEGER NOT NULL DEFAULT 0,
+            stats_json TEXT,
+            repo_id TEXT NOT NULL DEFAULT '__unassigned__'
+        ) STRICT;
         ",
     )
 }

--- a/crates/rag-rat-db/src/schema/mod.rs
+++ b/crates/rag-rat-db/src/schema/mod.rs
@@ -9,17 +9,17 @@ pub use migrations::{
     apply_account_authority_boundaries, apply_account_authority_projection,
     apply_account_candidate_dag, apply_clone_delta_maintenance, apply_clone_df_epoch,
     apply_clone_fingerprint_tables, apply_clone_graph_tables, apply_content_candidate_dag,
-    apply_content_projected_tables, apply_content_streams_pending_refold, apply_dream_findings,
-    apply_edge_string_interning, apply_edge_target_qname_index, apply_external_symbols,
-    apply_files_generation, apply_files_has_test_code, apply_git_change_couplings,
-    apply_github_child_key_widening, apply_github_repo_id_scoping,
-    apply_memory_model_failures_table, apply_memory_verification_tables, apply_move_per_repo_meta,
-    apply_oplog_device_identity, apply_oplog_device_x25519, apply_oplog_local_account,
-    apply_oplog_storage, apply_oplog_stream_scoping, apply_oracle_tables,
-    apply_papertrail_binding_health, apply_papertrail_distill_substrate,
-    apply_papertrail_mirror_resume_state, apply_papertrail_provider_neutral_schema,
-    apply_repo_id_core_scoping, apply_repo_id_periphery_scoping, apply_repos_registry,
-    apply_scip_moniker_anchors,
+    apply_content_projected_tables, apply_content_streams_pending_refold,
+    apply_distill_record_store, apply_dream_findings, apply_edge_string_interning,
+    apply_edge_target_qname_index, apply_external_symbols, apply_files_generation,
+    apply_files_has_test_code, apply_git_change_couplings, apply_github_child_key_widening,
+    apply_github_repo_id_scoping, apply_memory_model_failures_table,
+    apply_memory_verification_tables, apply_move_per_repo_meta, apply_oplog_device_identity,
+    apply_oplog_device_x25519, apply_oplog_local_account, apply_oplog_storage,
+    apply_oplog_stream_scoping, apply_oracle_tables, apply_papertrail_binding_health,
+    apply_papertrail_distill_substrate, apply_papertrail_mirror_resume_state,
+    apply_papertrail_provider_neutral_schema, apply_repo_id_core_scoping,
+    apply_repo_id_periphery_scoping, apply_repos_registry, apply_scip_moniker_anchors,
 };
 pub use migrations::{column_exists, rebuild_repo_memory_fts_with_repo_id, table_exists};
 // `multiple_real_repos` lost its V042-era seam-guard callers (real `repo_id` predicates
@@ -40,7 +40,7 @@ use serde::Serialize;
 
 use crate::hooks::MigrationHooks;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 76;
+pub const LATEST_SCHEMA_VERSION: u32 = 77;
 
 /// Every oracle-DERIVED persisted table — the outputs an `oracle run` writes that must OUTLIVE a
 /// reindex.
@@ -555,6 +555,15 @@ const MIGRATION_076_DESCRIPTION: &str =
      unwrap (AEAD tag failure) or unwraps to a key whose key_id disagrees with the op's signed \
      key_id. Never on the wire, never a fold input. Additive; CREATE ... IF NOT EXISTS + a dedup \
      unique index, nothing pre-existing to backfill";
+const MIGRATION_077_ID: &str = "077_distill_record_store";
+const MIGRATION_077_CHECKSUM: &str = "sha256:rag-rat-distill-record-store-v77";
+const MIGRATION_077_DESCRIPTION: &str =
+    "Add the distillation record store (issue #703): papertrail_distill (derived, regenerable \
+     decision records with provenance-facet confidence, not a fused label), plus junction \
+     children (evidence with materialized quotes + snapshotted provenance, sym_<hex> anchors, \
+     alternatives, mechanical fixing-commits), thread-keyed edges (survive record regeneration), \
+     the distill work queue, and per-run stats. Additive; CREATE IF NOT EXISTS, nothing \
+     pre-existing to backfill";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -1202,6 +1211,12 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         checksum: MIGRATION_076_CHECKSUM,
         description: MIGRATION_076_DESCRIPTION,
         apply: MigrationFn::Plain(apply_sync_security_events),
+    },
+    Migration {
+        id: MIGRATION_077_ID,
+        checksum: MIGRATION_077_CHECKSUM,
+        description: MIGRATION_077_DESCRIPTION,
+        apply: MigrationFn::Plain(apply_distill_record_store),
     },
 ];
 

--- a/crates/rag-rat-db/src/schema/registry.rs
+++ b/crates/rag-rat-db/src/schema/registry.rs
@@ -55,6 +55,18 @@ const DIRECT_SCOPED_ADOPTION_TABLES: &[&str] = &[
     // natural key from birth, so a LocalOnly→Portable adoption re-points its rows with the
     // rest of the papertrail family.
     "papertrail_closing_edges",
+    // V076 (#703): the distilled-record store — record row + junction children + work queue +
+    // run stats, all with direct `repo_id` in their keys from birth (no FK children between them),
+    // so a LocalOnly→Portable adoption re-points every one with the papertrail family. Omitting
+    // any would strand its rows under the retired id, invisible through the active scope.
+    "papertrail_distill",
+    "papertrail_distill_evidence",
+    "papertrail_distill_anchors",
+    "papertrail_distill_alternatives",
+    "papertrail_distill_record_commits",
+    "papertrail_distill_edges",
+    "papertrail_distill_queue",
+    "papertrail_distill_runs",
     // V056 (#566) derived change-coupling table: standalone, direct `repo_id`, no FK children, so
     // a LocalOnly→Portable adoption re-points its rows here (moving them together with the
     // `git_coupling_stamp` repo_meta so the derived table stays consistent + fresh), and the

--- a/crates/rag-rat-papertrail/src/distill.rs
+++ b/crates/rag-rat-papertrail/src/distill.rs
@@ -1,0 +1,302 @@
+//! Closed, persisted enums for the distilled-record store (V075, #703).
+//!
+//! These are the machine tokens written into the `papertrail_distill*` tables and read back by the
+//! Phase-3 consumption layer. They live in `rag-rat-papertrail` (not the `rag-rat-core` extraction
+//! module) because they are the lowest common type both the writer (`rag-rat-core`, above
+//! papertrail in the crate DAG) and the readers (`papertrail::api`, `rag-rat-query`) share — an
+//! enum in core would be invisible to papertrail-side consumption.
+//!
+//! Every enum follows the repo's persisted-enum contract: a closed set with a stable `as_db_str`
+//! machine token and a `from_db_str` that rejects anything outside the set. The tokens ARE schema —
+//! changing one needs a migration + a token test, the same as a column rename.
+
+use serde::{Deserialize, Serialize};
+
+/// Provenance of the record's fix edge (`papertrail_distill.fix_edge_source`). This is a
+/// provenance FACET, not a fused confidence label: `provider` = the tracker attested the closing
+/// edge, `text` = it was mined from commit/item/comment text, `none` = no fix edge exists (the
+/// no-fix-edge status floor fires read-layer). The effective outcome status is computed downstream,
+/// never here.
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    strum::EnumString,
+    strum::IntoStaticStr,
+)]
+#[strum(serialize_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
+pub enum FixEdgeSource {
+    Provider,
+    Text,
+    None,
+}
+
+impl FixEdgeSource {
+    /// The exact persisted token (`papertrail_distill.fix_edge_source`).
+    pub fn as_db_str(self) -> &'static str {
+        self.into()
+    }
+
+    /// Parse a persisted token, rejecting anything outside the closed set.
+    pub fn from_db_str(value: &str) -> anyhow::Result<Self> {
+        value.parse().map_err(|_| anyhow::anyhow!("unknown fix-edge source token `{value}`"))
+    }
+}
+
+/// The conversational shape of the distilled thread (`papertrail_distill.thread_shape`), a
+/// provenance FACET used to gate consumption: `investigation` (a root-cause/decision thread worth
+/// surfacing), `review_stream` (PR review back-and-forth), `thin` (little discussion — the record
+/// is mostly mechanical).
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    strum::EnumString,
+    strum::IntoStaticStr,
+)]
+#[strum(serialize_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
+pub enum ThreadShape {
+    Investigation,
+    ReviewStream,
+    Thin,
+}
+
+impl ThreadShape {
+    /// The exact persisted token (`papertrail_distill.thread_shape`).
+    pub fn as_db_str(self) -> &'static str {
+        self.into()
+    }
+
+    /// Parse a persisted token, rejecting anything outside the closed set.
+    pub fn from_db_str(value: &str) -> anyhow::Result<Self> {
+        value.parse().map_err(|_| anyhow::anyhow!("unknown thread-shape token `{value}`"))
+    }
+}
+
+/// The MODEL-emitted outcome status (`papertrail_distill.outcome_status_model`). This is stored
+/// SEPARATELY from the mechanical floors (`revert_override`, `closing_keyword_floor`, no-fix-edge);
+/// the EFFECTIVE status is computed in the read layer with precedence
+/// revert > closing-keyword > no-fix-edge > this. Token set observed across the distillation spike.
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    strum::EnumString,
+    strum::IntoStaticStr,
+)]
+#[strum(serialize_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
+pub enum OutcomeStatus {
+    /// The decision was implemented and merged.
+    Landed,
+    /// The thread does not establish what happened.
+    Unclear,
+    /// The work was dropped / cut from scope without landing.
+    Descoped,
+    /// A later thread replaced this decision before it settled.
+    Superseded,
+    /// The change landed and was then reverted.
+    Reverted,
+}
+
+impl OutcomeStatus {
+    /// The exact persisted token (`papertrail_distill.outcome_status_model`).
+    pub fn as_db_str(self) -> &'static str {
+        self.into()
+    }
+
+    /// Parse a persisted token, rejecting anything outside the closed set.
+    pub fn from_db_str(value: &str) -> anyhow::Result<Self> {
+        value.parse().map_err(|_| anyhow::anyhow!("unknown outcome-status token `{value}`"))
+    }
+}
+
+/// Event-factuality of a distilled claim (`papertrail_distill.epistemic_status_decision` and
+/// `.epistemic_status_outcome`). Keeps a proposed-but-not-landed idea distinct from an
+/// asserted-and-landed one, so consumption never surfaces a projection as a settled result:
+/// `asserted_landed` (it happened), `projected` (a forward-looking claim), `proposed_not_landed`
+/// (suggested, never implemented), `superseded` (overtaken by a later thread).
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    strum::EnumString,
+    strum::IntoStaticStr,
+)]
+#[strum(serialize_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
+pub enum EpistemicStatus {
+    AssertedLanded,
+    Projected,
+    ProposedNotLanded,
+    Superseded,
+}
+
+impl EpistemicStatus {
+    /// The exact persisted token (`epistemic_status_decision` / `epistemic_status_outcome`).
+    pub fn as_db_str(self) -> &'static str {
+        self.into()
+    }
+
+    /// Parse a persisted token, rejecting anything outside the closed set.
+    pub fn from_db_str(value: &str) -> anyhow::Result<Self> {
+        value.parse().map_err(|_| anyhow::anyhow!("unknown epistemic-status token `{value}`"))
+    }
+}
+
+/// Kind of thread-keyed edge (`papertrail_distill_edges.edge_kind`). Edges key to the THREAD, not
+/// the record row, so they survive record regeneration: `coalesced` (issue↔PR, mechanical from the
+/// closing edge), `supersedes` (a later thread replaces an earlier decision), `promoted` (the
+/// deferred promotion lane, #113's later ask).
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    strum::EnumString,
+    strum::IntoStaticStr,
+)]
+#[strum(serialize_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
+pub enum DistillEdgeKind {
+    Coalesced,
+    Supersedes,
+    Promoted,
+}
+
+impl DistillEdgeKind {
+    /// The exact persisted token (`papertrail_distill_edges.edge_kind`).
+    pub fn as_db_str(self) -> &'static str {
+        self.into()
+    }
+
+    /// Parse a persisted token, rejecting anything outside the closed set.
+    pub fn from_db_str(value: &str) -> anyhow::Result<Self> {
+        value.parse().map_err(|_| anyhow::anyhow!("unknown distill-edge kind token `{value}`"))
+    }
+}
+
+/// Kind of code anchor bound to a record (`papertrail_distill_anchors.anchor_kind`). Anchors are
+/// born as index-validated selections with EXACT paths (no basename fallback): `symbol` (carries a
+/// `sym_<hex>` logical-symbol id when resolved), `file`, `schema_object` (a table/migration),
+/// `crate`, `config_key`.
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    strum::EnumString,
+    strum::IntoStaticStr,
+)]
+#[strum(serialize_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
+pub enum AnchorKind {
+    Symbol,
+    File,
+    SchemaObject,
+    Crate,
+    ConfigKey,
+}
+
+impl AnchorKind {
+    /// The exact persisted token (`papertrail_distill_anchors.anchor_kind`).
+    pub fn as_db_str(self) -> &'static str {
+        self.into()
+    }
+
+    /// Parse a persisted token, rejecting anything outside the closed set.
+    pub fn from_db_str(value: &str) -> anyhow::Result<Self> {
+        value.parse().map_err(|_| anyhow::anyhow!("unknown anchor-kind token `{value}`"))
+    }
+}
+
+#[cfg(test)]
+mod distill_enum_token_tests {
+    use super::{
+        AnchorKind, DistillEdgeKind, EpistemicStatus, FixEdgeSource, OutcomeStatus, ThreadShape,
+    };
+
+    #[test]
+    fn distill_enum_tokens_round_trip_and_pin_the_persisted_strings() {
+        for (v, token) in [
+            (FixEdgeSource::Provider, "provider"),
+            (FixEdgeSource::Text, "text"),
+            (FixEdgeSource::None, "none"),
+        ] {
+            assert_eq!(v.as_db_str(), token);
+            assert_eq!(FixEdgeSource::from_db_str(token).unwrap(), v);
+        }
+        for (v, token) in [
+            (ThreadShape::Investigation, "investigation"),
+            (ThreadShape::ReviewStream, "review_stream"),
+            (ThreadShape::Thin, "thin"),
+        ] {
+            assert_eq!(v.as_db_str(), token);
+            assert_eq!(ThreadShape::from_db_str(token).unwrap(), v);
+        }
+        for (v, token) in [
+            (OutcomeStatus::Landed, "landed"),
+            (OutcomeStatus::Unclear, "unclear"),
+            (OutcomeStatus::Descoped, "descoped"),
+            (OutcomeStatus::Superseded, "superseded"),
+            (OutcomeStatus::Reverted, "reverted"),
+        ] {
+            assert_eq!(v.as_db_str(), token);
+            assert_eq!(OutcomeStatus::from_db_str(token).unwrap(), v);
+        }
+        for (v, token) in [
+            (EpistemicStatus::AssertedLanded, "asserted_landed"),
+            (EpistemicStatus::Projected, "projected"),
+            (EpistemicStatus::ProposedNotLanded, "proposed_not_landed"),
+            (EpistemicStatus::Superseded, "superseded"),
+        ] {
+            assert_eq!(v.as_db_str(), token);
+            assert_eq!(EpistemicStatus::from_db_str(token).unwrap(), v);
+        }
+        for (v, token) in [
+            (DistillEdgeKind::Coalesced, "coalesced"),
+            (DistillEdgeKind::Supersedes, "supersedes"),
+            (DistillEdgeKind::Promoted, "promoted"),
+        ] {
+            assert_eq!(v.as_db_str(), token);
+            assert_eq!(DistillEdgeKind::from_db_str(token).unwrap(), v);
+        }
+        for (v, token) in [
+            (AnchorKind::Symbol, "symbol"),
+            (AnchorKind::File, "file"),
+            (AnchorKind::SchemaObject, "schema_object"),
+            (AnchorKind::Crate, "crate"),
+            (AnchorKind::ConfigKey, "config_key"),
+        ] {
+            assert_eq!(v.as_db_str(), token);
+            assert_eq!(AnchorKind::from_db_str(token).unwrap(), v);
+        }
+        assert!(FixEdgeSource::from_db_str("attested").is_err(), "outside the closed set");
+        assert!(OutcomeStatus::from_db_str("fixed").is_err(), "outside the closed set");
+        assert!(AnchorKind::from_db_str("module").is_err(), "outside the closed set");
+    }
+}

--- a/crates/rag-rat-papertrail/src/lib.rs
+++ b/crates/rag-rat-papertrail/src/lib.rs
@@ -5,6 +5,7 @@
 //! callers and query-surface integration.
 
 mod api;
+mod distill;
 mod evidence;
 mod github;
 mod gitlab;
@@ -21,6 +22,9 @@ use std::path::Path;
 use std::sync::OnceLock;
 
 pub use api::{sync_from_refs, sync_from_refs_with_progress, *};
+pub use distill::{
+    AnchorKind, DistillEdgeKind, EpistemicStatus, FixEdgeSource, OutcomeStatus, ThreadShape,
+};
 pub use evidence::{refs, *};
 pub(crate) use github::*;
 pub(crate) use gitlab::*;

--- a/crates/rag-rat-papertrail/src/parse.rs
+++ b/crates/rag-rat-papertrail/src/parse.rs
@@ -455,17 +455,19 @@ pub(crate) fn ref_kind_for(provider: Tracker, previous: &str) -> String {
     base
 }
 
+/// The full documented GitHub closing-keyword set, singular forms included ("Fix #5").
+/// DELIBERATELY the intersection semantics: GitLab additionally honors the gerunds
+/// ("Closing"/"Fixing"/"Resolving") and the Implement family — but this shared classifier feeds
+/// COMMIT-tier closer minting for BOTH hosts, and GitHub honors none of those, so widening here
+/// would mint false GitHub closers. Provider-specific keyword sets can ride the provider lane when
+/// it needs them. Exposed so the distill layer's closing-keyword status floor (#703) matches the
+/// exact set the closer-minting tier uses, rather than re-listing (and drifting from) it.
+pub const CLOSING_KEYWORDS: &[&str] =
+    &["fix", "fixes", "fixed", "close", "closes", "closed", "resolve", "resolves", "resolved"];
+
 pub(crate) fn ref_kind(previous: &str) -> String {
     let previous = previous.to_ascii_lowercase();
-    // The full documented GitHub closing-keyword set, singular forms included ("Fix #5").
-    // DELIBERATELY the intersection semantics: GitLab additionally honors the gerunds
-    // ("Closing"/"Fixing"/"Resolving") and the Implement family — but this shared classifier
-    // feeds COMMIT-tier closer minting for both hosts, and GitHub honors none of those, so
-    // widening here would mint false GitHub closers. Provider-specific keyword sets can ride
-    // the provider lane when it needs them.
-    if ["fix", "fixes", "fixed", "close", "closes", "closed", "resolve", "resolves", "resolved"]
-        .contains(&previous.as_str())
-    {
+    if CLOSING_KEYWORDS.contains(&previous.as_str()) {
         "closing".to_string()
     } else if ["reverts", "reverted"].contains(&previous.as_str()) {
         // "Reverts owner/repo#N" — the body GitHub writes into every revert PR: a free PR↔PR


### PR DESCRIPTION
Phase 1 of the distillation pipeline (#703): the deterministic, model-free half. It turns the tracker papertrail mirror into skeleton distilled records that the later LLM pass (#704) fills in.

## Schema
Additive migration V076 (`papertrail_distill` record store): the record row plus junction children — evidence (materialized quotes + snapshotted author provenance), `sym_<hex>` anchors, rejected alternatives, mechanical fixing-commits — thread-keyed edges (survive record regeneration), the distill work queue, and per-run stats. All STRICT, `_at_ms` timestamps, `repo_id` in every natural key, junction tables instead of CSV-in-TEXT. Six closed persisted enums (`FixEdgeSource`, `ThreadShape`, `OutcomeStatus`, `EpistemicStatus`, `DistillEdgeKind`, `AnchorKind`) with `as_db_str`/`from_db_str` round-trip token tests, in `rag-rat-papertrail` (the lowest crate both the writer and the readers share).

## Extraction (`rag-rat-core/src/distill/`)
A model-free pass over the mirror:

- **Eligibility** — closed issues + merged change requests, filtered on `state_normalized` (never raw `state`).
- **Coalescing** — an issue closed by a merged PR becomes one record keyed to the issue thread, the PR reachable through a `coalesced` edge; both threads' text folds into the input. All keyed on the full `(tracker, project, kind, key)` identity so same-numbered items across tracker bindings never collide.
- **Input assembly** — title + body + comments segmented into byte-span units via pulldown-cmark, tail-aware budgeted (head + tail retained, middle dropped, framing always kept).
- **Anchors** — mined from the fixing commits' changed files and validated against the live symbol index (`sym_<hex>` bindings, exact paths, no basename fallback; test/generated files excluded).
- **Status floors** — revert (landed commit reverts only), closing-keyword (matches the shared closer-minting grammar, including qualified refs), and no-fix-edge, with a read-layer effective-status resolver. Model columns are honest nulls for #704.
- **Regeneration identity** — a hash over ordered units, changed paths, fix SHAs, fix-edge source, and per-unit source provenance; a changed input clears stale model output and re-queues, while an identical rerun preserves it.
- **Reconciliation** — records and queue rows are reconciled against the planned set each pass, so reopened issues, un-merged PRs, and now-coalesced PRs never leave a stale or duplicate record behind.

Enqueue rides the mirror sync (cheap SQL, skipping already-distilled and coalesced threads); the expensive extraction and the LLM drain never do. A `rag-rat distill extract` CLI runs the full pass. Verified over the live mirror (640 eligible threads, correctly repo-scoped) and covered by unit + poison-sibling + reconciliation tests.

Follow-ups: #704 (LLM pass), #705 (consumption).

Fixes #703