### PR TITLE
feat(oplog): sealing-key selection + key_id adoption cross-check

### DIFF
--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
@@ -2775,7 +2775,6 @@ fn migration_074_refreshes_the_edges_view() {
 
 #[test]
 fn migration_075_materializes_edge_visibility() {
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 75, "move this pin with the next schema migration");
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     schema::apply(&conn, &crate::index::migration_hooks()).unwrap();
     conn.execute(
@@ -2870,4 +2869,45 @@ fn migration_075_materializes_edge_visibility() {
         )
         .unwrap();
     assert_eq!(v75_recorded, 1, "the forward migration records V075");
+}
+
+#[test]
+fn migration_076_adds_sync_security_events() {
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 76, "move this pin with the next schema migration");
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn, &crate::index::migration_hooks()).unwrap();
+
+    // Simulate a pre-V076 DB: the table's DDL is not part of truncate_schema_to (it rolls the
+    // ledger only), so drop it, then roll the ledger back to V075.
+    truncate_schema_to(&conn, 75);
+    conn.execute_batch("DROP TABLE sync_security_events;").unwrap();
+
+    schema::migrate_forward(&conn, &crate::index::migration_hooks()).unwrap();
+
+    let table_exists: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = \
+             'sync_security_events'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(table_exists, 1, "the forward migration re-creates sync_security_events");
+    let dedup_index: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type = 'index' AND name = \
+             'sync_security_events_dedup'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(dedup_index, 1, "the dedup unique index is installed");
+    let v76_recorded: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM schema_version WHERE id = '076_sync_security_events'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(v76_recorded, 1, "the forward migration records V076");
 }

--- a/crates/rag-rat-db/src/schema/migrations.rs
+++ b/crates/rag-rat-db/src/schema/migrations.rs
@@ -1324,6 +1324,7 @@ pub(crate) fn known_version(migrations: &[AppliedMigration]) -> u32 {
             MIGRATION_073_ID => Some(73),
             MIGRATION_074_ID => Some(74),
             MIGRATION_075_ID => Some(75),
+            MIGRATION_076_ID => Some(76),
             _ => None,
         })
         .max()
@@ -1408,6 +1409,7 @@ pub(crate) fn known_migration(id: &str) -> bool {
             | MIGRATION_073_ID
             | MIGRATION_074_ID
             | MIGRATION_075_ID
+            | MIGRATION_076_ID
             | DIRTY_MIGRATION_ID
     )
 }
@@ -1489,6 +1491,7 @@ pub(crate) fn migration_checksum_mismatch(migration: &AppliedMigration) -> bool 
         MIGRATION_073_ID => migration.checksum != MIGRATION_073_CHECKSUM,
         MIGRATION_074_ID => migration.checksum != MIGRATION_074_CHECKSUM,
         MIGRATION_075_ID => migration.checksum != MIGRATION_075_CHECKSUM,
+        MIGRATION_076_ID => migration.checksum != MIGRATION_076_CHECKSUM,
         _ => false,
     }
 }
@@ -4608,6 +4611,35 @@ pub fn apply_content_streams_pending_refold(conn: &Connection) -> rusqlite::Resu
     )
 }
 
+/// V076 (sync phase C4.3b, #607): the sealing-key adoption audit log. A recipient device records a
+/// row here when an accepted `StreamKeyWrap` naming it either fails to unwrap (AEAD tag failure —
+/// the primary manifestation of a substituted wrap) or unwraps to a key whose `key_id` disagrees
+/// with the op's signed `key_id`.
+///
+/// INVARIANT: local-only. These rows are never on the wire, never a fold input, and the adoption
+/// seam never mutates a fold verdict — the shared fold stays device-independent (convergent), so a
+/// recipient-only unwrap check can only ever be LOCAL evidence. `key_epoch` is stored as 8-byte BE
+/// (not INT) so a `u64` epoch round-trips without the `i64` narrowing hazard. `UNIQUE(kind,
+/// entry_hash)` + `INSERT OR IGNORE` (the write path) keep a hot seal-path retry from re-appending
+/// the same evidence for one op. Purely additive; CREATE ... IF NOT EXISTS, nothing to backfill.
+pub fn apply_sync_security_events(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS sync_security_events(
+             id              INTEGER PRIMARY KEY,
+             kind            TEXT NOT NULL,
+             account_id      BLOB NOT NULL,
+             stream_id       BLOB NOT NULL,
+             key_epoch       BLOB NOT NULL,
+             entry_hash      BLOB NOT NULL,
+             expected_key_id BLOB,
+             observed_key_id BLOB,
+             observed_at_ms  INT NOT NULL
+         ) STRICT;
+         CREATE UNIQUE INDEX IF NOT EXISTS sync_security_events_dedup
+             ON sync_security_events(kind, entry_hash);",
+    )
+}
+
 /// V064 (sync phase C1, §16): query-ready authority facts derived from the accepted account fold.
 /// These are shadow tables, never independent sources of truth: `refold_account` deletes and
 /// rewrites every row for one account inside the SAME IMMEDIATE transaction as accepted/status.
@@ -5238,5 +5270,72 @@ mod memory_model_failure_migration_tests {
         let blocker_rows: i64 =
             conn.query_row("SELECT COUNT(*) FROM blocker", [], |r| r.get(0)).unwrap();
         assert_eq!(blocker_rows, 0, "the preexisting blocker table/index is left intact");
+    }
+}
+
+#[cfg(test)]
+mod sync_security_events_migration_tests {
+    use super::*;
+
+    /// Insert one adoption-audit event via the write path (`INSERT OR IGNORE`); returns rows
+    /// changed so a dedup can be observed as `0`.
+    fn insert_event(conn: &Connection, kind: &str, entry_hash: &[u8]) -> usize {
+        conn.execute(
+            "INSERT OR IGNORE INTO sync_security_events(
+                 kind, account_id, stream_id, key_epoch, entry_hash,
+                 expected_key_id, observed_key_id, observed_at_ms)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            rusqlite::params![
+                kind,
+                [1u8; 32].as_slice(),
+                [2u8; 32].as_slice(),
+                0u64.to_be_bytes().as_slice(),
+                entry_hash,
+                Option::<Vec<u8>>::None,
+                Option::<Vec<u8>>::None,
+                123i64,
+            ],
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn table_dedupes_on_kind_and_entry_hash() {
+        let conn = Connection::open_in_memory().unwrap();
+        apply_sync_security_events(&conn).unwrap();
+        assert!(table_exists(&conn, "sync_security_events").unwrap(), "the table is created");
+
+        // A first event lands; a second with the SAME (kind, entry_hash) is IGNOREd (the hot
+        // seal-path-retry guard); a different kind for the same entry_hash is a distinct event.
+        assert_eq!(insert_event(&conn, "wrap_unwrap_failed", &[9u8; 32]), 1, "first event inserts");
+        assert_eq!(
+            insert_event(&conn, "wrap_unwrap_failed", &[9u8; 32]),
+            0,
+            "a duplicate (kind, entry_hash) is ignored, not re-appended",
+        );
+        assert_eq!(
+            insert_event(&conn, "wrap_key_id_mismatch", &[9u8; 32]),
+            1,
+            "a distinct kind for the same entry is its own event",
+        );
+        let rows: i64 = conn
+            .query_row("SELECT COUNT(*) FROM sync_security_events", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(rows, 2, "exactly the two distinct events survive");
+    }
+
+    #[test]
+    fn strict_typing_rejects_a_non_blob_account_id() {
+        let conn = Connection::open_in_memory().unwrap();
+        apply_sync_security_events(&conn).unwrap();
+        // STRICT: `account_id` is declared BLOB, so an INTEGER literal there is a datatype mismatch
+        // rather than a silently coerced value.
+        let inserted = conn.execute(
+            "INSERT INTO sync_security_events(
+                 kind, account_id, stream_id, key_epoch, entry_hash, observed_at_ms)
+             VALUES ('wrap_unwrap_failed', 5, x'02', x'0000000000000000', x'09', 1)",
+            [],
+        );
+        assert!(inserted.is_err(), "STRICT rejects an INTEGER in the BLOB account_id column");
     }
 }

--- a/crates/rag-rat-db/src/schema/mod.rs
+++ b/crates/rag-rat-db/src/schema/mod.rs
@@ -40,7 +40,7 @@ use serde::Serialize;
 
 use crate::hooks::MigrationHooks;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 75;
+pub const LATEST_SCHEMA_VERSION: u32 = 76;
 
 /// Every oracle-DERIVED persisted table — the outputs an `oracle run` writes that must OUTLIVE a
 /// reindex.
@@ -547,6 +547,14 @@ const MIGRATION_075_DESCRIPTION: &str =
      #734): visibility is decided once at write time instead of re-deriving the dispatch-fact + \
      suppressed-candidate predicates on every view row. Adds the column, backfills it from the \
      predicate the view WHERE used to evaluate, and refreshes the view via ensure_edges_view";
+const MIGRATION_076_ID: &str = "076_sync_security_events";
+const MIGRATION_076_CHECKSUM: &str = "sha256:rag-rat-sync-security-events-v76";
+const MIGRATION_076_DESCRIPTION: &str =
+    "Add sync_security_events (sync phase C4.3b, #607): the local-only audit log the sealing-key \
+     adoption cross-check writes when an accepted StreamKeyWrap naming this device fails to \
+     unwrap (AEAD tag failure) or unwraps to a key whose key_id disagrees with the op's signed \
+     key_id. Never on the wire, never a fold input. Additive; CREATE ... IF NOT EXISTS + a dedup \
+     unique index, nothing pre-existing to backfill";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -1188,6 +1196,12 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         checksum: MIGRATION_075_CHECKSUM,
         description: MIGRATION_075_DESCRIPTION,
         apply: MigrationFn::Plain(apply_edges_hidden_flag),
+    },
+    Migration {
+        id: MIGRATION_076_ID,
+        checksum: MIGRATION_076_CHECKSUM,
+        description: MIGRATION_076_DESCRIPTION,
+        apply: MigrationFn::Plain(apply_sync_security_events),
     },
 ];
 

--- a/crates/rag-rat-oplog/src/account/mod.rs
+++ b/crates/rag-rat-oplog/src/account/mod.rs
@@ -59,9 +59,16 @@ pub use fold::{
     RosterContentAuthority,
 };
 pub use id::AccountId;
+// C4.1 content-key primitives the C4.3b sealing surface exposes: `ContentKey` is the `Ready`
+// payload C5's seal path consumes; `KeyId` is the selection identity (#607).
+pub use keywrap::{ContentKey, KeyId};
 pub use ops::{DeviceCut, DeviceRole, GrantRole};
-// The in-tx content-key mint + owner-gated `StreamKeyWrap` author seam (C4.3a, #607).
-pub use secrets::mint_and_author_stream_key_wrap_in_tx;
+// The in-tx content-key mint + owner-gated `StreamKeyWrap` author seam (C4.3a) plus the C4.3b
+// READ side — derive-on-read sealing-key selection + the key_id adoption cross-check (#607).
+pub use secrets::{
+    SealingKeyOutcome, SelectedWrap, current_sealing_key, mint_and_author_stream_key_wrap_in_tx,
+    select_current_sealing_wrap,
+};
 pub use storage::{
     CapacityScope, IngestOutcome, account_ingest, auth_len_freshness,
     backfill_authority_projection, grant_effective_for_device, owner_control_authority,

--- a/crates/rag-rat-oplog/src/account/secrets/mod.rs
+++ b/crates/rag-rat-oplog/src/account/secrets/mod.rs
@@ -13,6 +13,8 @@ mod acceptance;
 mod author;
 mod candidate;
 mod ops;
+mod sealing;
+mod security_event;
 mod storage;
 
 // The in-tx content-key mint + `StreamKeyWrap` author seam (C4.3a): re-exported up through
@@ -22,4 +24,11 @@ pub use author::mint_and_author_stream_key_wrap_in_tx;
 // The ingest-time structural validation twin (mirrors the control-plaintext arm) and the
 // refold pass wired into `refold_in_tx`.
 pub(in crate::account) use ops::validate_storable_secrets_payload;
+// The C4.3b READ side: derive-on-read sealing-key selection + the key_id adoption cross-check.
+// `current_sealing_key` is what C5's seal path calls; `select_current_sealing_wrap` is also
+// the CLI "what key is current" surface. Nothing calls them in C4.3b (machinery ships one
+// slice ahead of its consumer).
+pub use sealing::{
+    SealingKeyOutcome, SelectedWrap, current_sealing_key, select_current_sealing_wrap,
+};
 pub(in crate::account) use storage::refold_secrets_log;

--- a/crates/rag-rat-oplog/src/account/secrets/sealing.rs
+++ b/crates/rag-rat-oplog/src/account/secrets/sealing.rs
@@ -1,0 +1,917 @@
+//! Sealing-key selection + the key_id adoption cross-check (sync phase C4.3b, #607).
+//!
+//! The READ side of the secrets log: which content key a device would seal a stream under RIGHT
+//! NOW, and the device-local cross-check that guards it. Both are DERIVE-ON-READ — pure functions
+//! of the current accepted `StreamKeyWrap` set, recomputed on every call (no cached table, no
+//! refold pass). That is what makes eviction automatic and convergent: a refold that condemns the
+//! current wrap simply drops it from `accepted = 1`, and the next read selects the surviving max
+//! (possibly a LOWER epoch — by design; see [`current_sealing_key`]).
+//!
+//! FOLD FIREWALL (load-bearing): the adoption cross-check runs here, at read time, and NEVER in the
+//! fold. Its unwrap step is only runnable by a recipient, so it can never be a fold input without
+//! breaking convergence — the shared fold verdict (`accepted` / `account_entry_status`) must stay
+//! device-independent. A local mismatch / unwrap failure is therefore LOCAL evidence only, written
+//! to `sync_security_events` and nothing else.
+
+use rusqlite::{Connection, params};
+
+use super::super::keywrap::{self, ContentKey, KeyId, WrapContext};
+use super::super::{AccountId, envelope, fold};
+use super::ops::{self, DecodedSecretsOp, StreamKeyWrap};
+use super::security_event::{self, SyncSecurityEvent, SyncSecurityEventKind};
+use crate::identity::LocalDevice;
+use crate::stream::StreamId;
+
+/// The current sealing selection for a stream — the winning `(epoch, key_id)` over the accepted
+/// wrap set, plus the entry hash that decided the tiebreak. Carries the CLAIMED `key_id` (the op
+/// payload field); the cross-check against the actually-UNWRAPPED key is [`current_sealing_key`]'s
+/// job. Also the CLI "what key is current for this stream" surface.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SelectedWrap {
+    pub key_id: KeyId,
+    pub key_epoch: u64,
+    pub minting_entry_hash: [u8; 32],
+}
+
+/// The outcome of resolving the content key a device would seal a stream under right now. Every
+/// non-`Ready` is a do-not-seal signal (fail-closed); a `Result::Err` from [`current_sealing_key`]
+/// is reserved for infra/DB failures, never a crypto/authority outcome.
+pub enum SealingKeyOutcome {
+    /// The recovered content key, cross-checked to match the selected op's signed `key_id`.
+    Ready(ContentKey),
+    /// No accepted wrap exists for the stream — nothing to seal with. Also the contested-account
+    /// case (the fold keeps contested wraps out of `accepted`, so the selection is simply empty —
+    /// no special case here).
+    NoCurrentKey,
+    /// The stream has a current key, but this device is not a recipient of any wrap at the current
+    /// `(epoch, key_id)`. C4.4's added-after-mint catch-up / rotation trigger; C5 surfaces a
+    /// cross-account granted writer (no wrap in the owning account's roster) this way too.
+    NotRecipient,
+    /// This device IS a recipient, but no wrap naming it opened to the selected `key_id` — every
+    /// candidate failed the AEAD tag or the key_id cross-check. Fail closed; the failures were
+    /// recorded in `sync_security_events`.
+    FailedClosed,
+}
+
+/// One EFFECTIVE accepted `StreamKeyWrap` op for a stream, decoded from its stored bytes.
+struct AcceptedStreamWrap {
+    entry_hash: [u8; 32],
+    wrap: StreamKeyWrap,
+}
+
+/// The stream's current sealing selection, derived on read from the accepted wrap set — no cached
+/// table, no refold pass, convergent by construction. `None` when no accepted wrap exists. This is
+/// the CLI "what key is current" surface; the secret-recovering counterpart is
+/// [`current_sealing_key`].
+pub fn select_current_sealing_wrap(
+    conn: &Connection,
+    account_id: AccountId,
+    stream_id: StreamId,
+) -> anyhow::Result<Option<SelectedWrap>> {
+    Ok(select_from_wraps(&list_accepted_stream_key_wraps(conn, account_id, stream_id)?))
+}
+
+/// Resolve the content key THIS device would seal `stream_id` under right now, running the C4.3b
+/// adoption cross-check.
+///
+/// Selects the current `(epoch, key_id)` (derive-on-read), then collects every wrap naming this
+/// device at that `(epoch, key_id)` — INCLUDING same-`(epoch, key_id)` fan-out siblings across
+/// multiple ops (the tiebreak-winning op may not be one that names this device) — and tries each:
+/// - an unwrap FAILURE (AEAD tag / blocklisted epk / non-contributory DH — the primary
+///   manifestation of a substituted wrap) records `wrap_unwrap_failed` and moves on;
+/// - a clean unwrap whose `key_id` disagrees records `wrap_key_id_mismatch` and moves on;
+/// - the first wrap that unwraps to the selected `key_id` is the key (two distinct keys sharing a
+///   `key_id` is an HKDF-SHA256 second-preimage — excluded — so try-until-pass is
+///   deterministic-in-result).
+///
+/// Fails closed (`FailedClosed`) only when no candidate passes. NEVER mutates a fold verdict.
+///
+/// Takes `&LocalDevice`, NOT a bare secret: the my-wrap lookup needs the device fingerprint
+/// (`sha256(ed25519 pk)`), which is not derivable from the x25519 secret. Does NOT call
+/// `local_device` (which MINTS an identity on first call) — a read API must not mint, so the caller
+/// supplies the device.
+///
+/// DURABILITY: the `sync_security_events` INSERT autocommits on `&Connection`. C5 must call this
+/// PRE-txn (acquire the key, THEN open the authoring txn) or a caller that bails would roll the
+/// evidence back with it. `now_ms` stamps `observed_at_ms` (injected clock).
+pub fn current_sealing_key(
+    conn: &Connection,
+    account_id: AccountId,
+    stream_id: StreamId,
+    device: &LocalDevice,
+    now_ms: i64,
+) -> anyhow::Result<SealingKeyOutcome> {
+    let wraps = list_accepted_stream_key_wraps(conn, account_id, stream_id)?;
+    let Some(selected) = select_from_wraps(&wraps) else {
+        return Ok(SealingKeyOutcome::NoCurrentKey);
+    };
+
+    // Every wrap naming THIS device at the selected (epoch, key_id) — across fan-out sibling ops.
+    // Keying on the selected key_id (not the epoch alone) is load-bearing: two accepted wraps can
+    // share an epoch with DIFFERENT key_ids (concurrent owner mints), and trying the other key_id's
+    // wrap would either diverge or raise a spurious mismatch on an honest state.
+    let my_fingerprint = device.fingerprint();
+    let my_wraps: Vec<_> = wraps
+        .iter()
+        .filter(|w| {
+            w.wrap.key_epoch == selected.key_epoch
+                && KeyId::from_bytes(w.wrap.key_id) == selected.key_id
+        })
+        .filter_map(|w| {
+            w.wrap
+                .wraps
+                .iter()
+                .find(|entry| entry.recipient_fp == my_fingerprint)
+                .map(|entry| (w.entry_hash, &entry.sealed))
+        })
+        .collect();
+    if my_wraps.is_empty() {
+        return Ok(SealingKeyOutcome::NotRecipient);
+    }
+
+    // The AAD binds the exact sealing context byte-for-byte; the recipient_pub is this device's own
+    // roster x25519 bytes (wrap-to-self at mint sealed to exactly these).
+    let ctx = WrapContext {
+        account_id: account_id.to_bytes(),
+        stream_id: stream_id.to_bytes(),
+        key_epoch: selected.key_epoch,
+        recipient_pub: device.x25519_public().to_bytes(),
+    };
+    for (entry_hash, sealed) in my_wraps {
+        // An unwrap failure is fail-closed evidence, NOT `?`-propagated: `Err` is reserved for
+        // infra/DB failures, and propagating would record no evidence and return `Err` in violation
+        // of the `Ok(SealingKeyOutcome)` fail-closed contract.
+        let recovered = match keywrap::unwrap_content_key(sealed, device.x25519_secret(), &ctx) {
+            Ok(key) => key,
+            Err(_) => {
+                security_event::record_sync_security_event(conn, &SyncSecurityEvent {
+                    kind: SyncSecurityEventKind::WrapUnwrapFailed,
+                    account_id,
+                    stream_id,
+                    key_epoch: selected.key_epoch,
+                    entry_hash,
+                    expected_key_id: Some(selected.key_id),
+                    observed_key_id: None,
+                    observed_at_ms: now_ms,
+                })?;
+                continue;
+            },
+        };
+        let observed = recovered.key_id();
+        if observed == selected.key_id {
+            return Ok(SealingKeyOutcome::Ready(recovered));
+        }
+        // The residual the cross-check exists for: a wrong key inside a validly-signed accepted op
+        // (impl bug / a compromised-owner substitution the authority gate can't catch).
+        security_event::record_sync_security_event(conn, &SyncSecurityEvent {
+            kind: SyncSecurityEventKind::WrapKeyIdMismatch,
+            account_id,
+            stream_id,
+            key_epoch: selected.key_epoch,
+            entry_hash,
+            expected_key_id: Some(selected.key_id),
+            observed_key_id: Some(observed),
+            observed_at_ms: now_ms,
+        })?;
+    }
+    Ok(SealingKeyOutcome::FailedClosed)
+}
+
+/// The current sealing selection over an accepted-wrap set: MAX `key_epoch`, tiebreak MIN
+/// `entry_hash` (a total order — SET resolution, never LWW). `None` for an empty set. Pure so both
+/// public entry points share one selection rule.
+fn select_from_wraps(wraps: &[AcceptedStreamWrap]) -> Option<SelectedWrap> {
+    wraps
+        .iter()
+        .map(|w| SelectedWrap {
+            key_id: KeyId::from_bytes(w.wrap.key_id),
+            key_epoch: w.wrap.key_epoch,
+            minting_entry_hash: w.entry_hash,
+        })
+        .max_by(|a, b| {
+            // Max key_epoch wins; tiebreak MIN entry_hash (reverse the hash compare so the smaller
+            // hash sorts as the greater element for `max_by`).
+            a.key_epoch
+                .cmp(&b.key_epoch)
+                .then_with(|| b.minting_entry_hash.cmp(&a.minting_entry_hash))
+        })
+}
+
+/// Read every EFFECTIVE accepted (`accepted = 1`) `StreamKeyWrap` op on `account_id`'s secrets log
+/// naming `stream_id`, decoding each from the stored, already-signature-verified bytes. `accepted =
+/// 1` IS the effective marker (the C4.2b evaluator set it); B-2 slot-eligibility guarantees an
+/// accepted log-1 row decodes as a Known `StreamKeyWrap`, so an undecodable/unknown accepted row is
+/// corruption — skipped (fail-safe: it just can't contribute a key) rather than aborting the read,
+/// mirroring `storage::load_secrets_headers`.
+fn list_accepted_stream_key_wraps(
+    conn: &Connection,
+    account_id: AccountId,
+    stream_id: StreamId,
+) -> anyhow::Result<Vec<AcceptedStreamWrap>> {
+    let mut stmt = conn.prepare(
+        "SELECT entry_hash, signed_bytes FROM account_entries
+         WHERE account_id = ?1 AND log_id = ?2 AND accepted = 1
+         ORDER BY entry_hash", /* deterministic order; selection + try-until-pass are order-free
+                                * in RESULT */
+    )?;
+    let rows = stmt
+        .query_map(params![account_id.to_bytes().as_slice(), fold::SECRETS_LOG], |row| {
+            Ok((row.get::<_, Vec<u8>>(0)?, row.get::<_, Vec<u8>>(1)?))
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    let mut out = Vec::new();
+    for (entry_hash, signed_bytes) in rows {
+        let Ok(entry_hash) = <[u8; 32]>::try_from(entry_hash.as_slice()) else {
+            continue;
+        };
+        let Ok(signed) = envelope::decode_account_signed(&signed_bytes) else {
+            continue;
+        };
+        if signed.entry_hash != entry_hash {
+            continue;
+        }
+        match ops::decode(signed.header.entry_type, &signed.payload) {
+            Ok(DecodedSecretsOp::Known(wrap)) if wrap.stream_id == stream_id => {
+                out.push(AcceptedStreamWrap { entry_hash, wrap });
+            },
+            _ => continue,
+        }
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use rag_rat_db::schema;
+    use rusqlite::Connection;
+
+    use super::super::ops::{StreamKeyWrap, WrapEntry, entry_type as secrets_entry_type};
+    use super::{SealingKeyOutcome, current_sealing_key, select_current_sealing_wrap};
+    use crate::account::cut::Cut;
+    use crate::account::envelope::{AccountEntryHeader, sign_account_entry};
+    use crate::account::id::account_id_from_genesis_payload;
+    use crate::account::keywrap::{ContentKey, WrapContext, seal_content_key};
+    use crate::account::ops::{self as control_ops, AccountOp, DeviceRole};
+    use crate::account::storage::{IngestOutcome, account_ingest, account_is_contested};
+    use crate::account::{
+        AccountId, ensure_owned_stream_v2_in_tx, local_account,
+        mint_and_author_stream_key_wrap_in_tx,
+    };
+    use crate::device::{DeviceSecret, DeviceX25519Public, DeviceX25519Secret};
+    use crate::identity::local_device;
+    use crate::op::DeviceFingerprint;
+    use crate::stream::{self, StreamId, StreamSpec, StreamSpecV2};
+
+    const NOW: i64 = 1_700_000_000_000;
+    const CONTROL_LOG: u8 = 0;
+    const SECRETS_LOG: u8 = 1;
+
+    fn db() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        schema::apply(&conn, &crate::test_hooks()).unwrap();
+        conn
+    }
+
+    /// A test device (an ed25519 signer + a matching x25519 encryption key).
+    struct Dev {
+        secret: DeviceSecret,
+        fp: DeviceFingerprint,
+        ed: [u8; 32],
+        x: [u8; 32],
+    }
+
+    impl Dev {
+        fn new(seed: u8) -> Self {
+            let secret = DeviceSecret::from_seed(&[seed; 32]);
+            let public = secret.public();
+            let x =
+                DeviceX25519Secret::from_seed(&[seed.wrapping_add(0x80); 32]).public().to_bytes();
+            Dev { fp: public.fingerprint(), ed: public.to_bytes(), x, secret }
+        }
+    }
+
+    fn genesis(founder: &Dev) -> (AccountId, Vec<u8>, [u8; 32]) {
+        let op = AccountOp::AccountGenesis {
+            ed25519_pubkey: founder.ed,
+            x25519_pubkey: founder.x,
+            nonce16: [0u8; 16],
+            created_at_ms: NOW as u64,
+            label: None,
+        };
+        let payload = control_ops::encode(&op).unwrap();
+        let account_id = account_id_from_genesis_payload(&payload);
+        let header = AccountEntryHeader {
+            account_id,
+            log_id: CONTROL_LOG,
+            device_fingerprint: founder.fp,
+            seq: 0,
+            prev_hash: None,
+            parent_ref: None,
+            entry_type: control_ops::entry_type::ACCOUNT_GENESIS,
+            op_version: 1,
+            crypto_suite: 0,
+            auth_len: 0,
+            key_id: None,
+            authority_ref: None,
+        };
+        let signed = sign_account_entry(&founder.secret, &header, &payload).unwrap();
+        (account_id, signed.signed_bytes, signed.entry_hash)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn control_op(
+        account: AccountId,
+        signer: &Dev,
+        seq: u64,
+        prev: Option<[u8; 32]>,
+        authority_ref: Option<[u8; 32]>,
+        op: &AccountOp,
+    ) -> (Vec<u8>, [u8; 32]) {
+        let payload = control_ops::encode(op).unwrap();
+        let header = AccountEntryHeader {
+            account_id: account,
+            log_id: CONTROL_LOG,
+            device_fingerprint: signer.fp,
+            seq,
+            prev_hash: prev,
+            parent_ref: None,
+            entry_type: control_ops::entry_type_of(op),
+            op_version: 1,
+            crypto_suite: 0,
+            auth_len: 1,
+            key_id: None,
+            authority_ref,
+        };
+        let signed = sign_account_entry(&signer.secret, &header, &payload).unwrap();
+        (signed.signed_bytes, signed.entry_hash)
+    }
+
+    fn stream_own(account: AccountId) -> (StreamId, AccountOp) {
+        let spec = StreamSpecV2 {
+            owner_account_id: account,
+            policy: StreamSpec {
+                repo_set: vec!["repo-a".to_string()],
+                kind_allow_list: None,
+                relation_policy: None,
+                node_overrides: Vec::new(),
+            },
+        };
+        let stream_id = stream::derive_v2(&spec).unwrap();
+        let stream_spec_bytes = stream::canonical_spec_v2_bytes(&spec).unwrap();
+        (stream_id, AccountOp::StreamOwn { stream_id, stream_spec_bytes })
+    }
+
+    fn device_add(dev: &Dev, role: DeviceRole) -> AccountOp {
+        AccountOp::DeviceAdd {
+            device_fingerprint: dev.fp,
+            ed25519_pubkey: dev.ed,
+            x25519_pubkey: dev.x,
+            role,
+            label: None,
+        }
+    }
+
+    /// Build a `StreamKeyWrap` sealing `key` to `recipient` (its x25519 + fingerprint) under the
+    /// exact adoption `WrapContext`, with an explicit CLAIMED `key_id` (so a test can drive a
+    /// mismatch by claiming a `key_id` other than `key.key_id()`).
+    fn build_wrap(
+        account: AccountId,
+        stream_id: StreamId,
+        recipient_fp: DeviceFingerprint,
+        recipient_x: &DeviceX25519Public,
+        key: &ContentKey,
+        key_epoch: u64,
+        claimed_key_id: [u8; 32],
+    ) -> StreamKeyWrap {
+        let ctx = WrapContext {
+            account_id: account.to_bytes(),
+            stream_id: stream_id.to_bytes(),
+            key_epoch,
+            recipient_pub: recipient_x.to_bytes(),
+        };
+        let sealed = seal_content_key(key, &ctx, recipient_x).unwrap();
+        StreamKeyWrap {
+            stream_id,
+            key_id: claimed_key_id,
+            key_epoch,
+            wraps: vec![WrapEntry { recipient_fp, sealed }],
+        }
+    }
+
+    /// A wrap sealing a seed-derived key HONESTLY (claimed key_id == the key's key_id) to
+    /// `recipient`, at `key_epoch`.
+    fn honest_wrap(
+        account: AccountId,
+        stream_id: StreamId,
+        recipient_fp: DeviceFingerprint,
+        recipient_x: &DeviceX25519Public,
+        key: &ContentKey,
+        key_epoch: u64,
+    ) -> StreamKeyWrap {
+        build_wrap(
+            account,
+            stream_id,
+            recipient_fp,
+            recipient_x,
+            key,
+            key_epoch,
+            key.key_id().to_bytes(),
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn wrap_entry(
+        account: AccountId,
+        signer: &Dev,
+        seq: u64,
+        prev: Option<[u8; 32]>,
+        authority_ref: Option<[u8; 32]>,
+        wrap: &StreamKeyWrap,
+    ) -> (Vec<u8>, [u8; 32]) {
+        let payload = super::super::ops::encode(wrap).unwrap();
+        let header = AccountEntryHeader {
+            account_id: account,
+            log_id: SECRETS_LOG,
+            device_fingerprint: signer.fp,
+            seq,
+            prev_hash: prev,
+            parent_ref: Some([0u8; 32]),
+            entry_type: secrets_entry_type::STREAM_KEY_WRAP,
+            op_version: 1,
+            crypto_suite: 0,
+            auth_len: 0,
+            key_id: None,
+            authority_ref,
+        };
+        let signed = sign_account_entry(&signer.secret, &header, &payload).unwrap();
+        (signed.signed_bytes, signed.entry_hash)
+    }
+
+    fn ingest(conn: &Connection, bytes: &[u8]) -> IngestOutcome {
+        account_ingest(conn, bytes, NOW).unwrap()
+    }
+
+    fn security_event_count(conn: &Connection) -> i64 {
+        conn.query_row("SELECT COUNT(*) FROM sync_security_events", [], |row| row.get(0)).unwrap()
+    }
+
+    fn security_event_kinds(conn: &Connection) -> Vec<String> {
+        conn.prepare("SELECT kind FROM sync_security_events ORDER BY kind")
+            .unwrap()
+            .query_map([], |row| row.get(0))
+            .unwrap()
+            .collect::<rusqlite::Result<Vec<String>>>()
+            .unwrap()
+    }
+
+    fn expect_ready(outcome: SealingKeyOutcome) -> ContentKey {
+        match outcome {
+            SealingKeyOutcome::Ready(key) => key,
+            _ => panic!("expected SealingKeyOutcome::Ready"),
+        }
+    }
+
+    /// genesis(founder) + StreamOwn(founder) → account, founder, its owner-incarnation id (=
+    /// genesis hash), and the owned stream. `founder` is an owner, so wraps it authors accept.
+    fn account_with_owned_stream(conn: &Connection) -> (AccountId, Dev, [u8; 32], StreamId) {
+        let founder = Dev::new(1);
+        let (account, genesis_bytes, genesis_hash) = genesis(&founder);
+        ingest(conn, &genesis_bytes);
+        let (stream_id, own) = stream_own(account);
+        let (own_bytes, _) =
+            control_op(account, &founder, 1, Some(genesis_hash), Some(genesis_hash), &own);
+        ingest(conn, &own_bytes);
+        (account, founder, genesis_hash, stream_id)
+    }
+
+    // ── Happy path: the REAL C4.3a mint seam round-trips through the C4.3b reader ──
+
+    #[test]
+    fn a_freshly_minted_key_is_ready_and_matches_the_selection() {
+        let conn = db();
+        // local_account founds a genesis account whose owner IS the local device, so
+        // mint_and_author seals to it (wrap-to-self) and the wrap folds accepted.
+        let account = local_account(&conn, NOW).unwrap();
+        let device = local_device(&conn, NOW).unwrap();
+        let stream_id = {
+            let tx = conn.unchecked_transaction().unwrap();
+            let sid = ensure_owned_stream_v2_in_tx(&tx, "repo-a", NOW).unwrap();
+            mint_and_author_stream_key_wrap_in_tx(&tx, sid, NOW).unwrap();
+            tx.commit().unwrap();
+            sid
+        };
+
+        let selected =
+            select_current_sealing_wrap(&conn, account, stream_id).unwrap().expect("a current key");
+        let key =
+            expect_ready(current_sealing_key(&conn, account, stream_id, &device, NOW).unwrap());
+        // The recovered key is the one the header claims (the cross-check passed).
+        assert_eq!(key.key_id(), selected.key_id, "the recovered key matches the selected key_id");
+        assert_eq!(selected.key_epoch, 0, "the initial mint is epoch 0");
+        assert_eq!(security_event_count(&conn), 0, "an honest mint records no security events");
+    }
+
+    #[test]
+    fn no_accepted_wrap_is_no_current_key() {
+        let conn = db();
+        let (account, _founder, _genesis_hash, stream_id) = account_with_owned_stream(&conn);
+        let device = local_device(&conn, NOW).unwrap();
+        // The account owns the stream but no wrap was authored.
+        assert!(select_current_sealing_wrap(&conn, account, stream_id).unwrap().is_none());
+        assert!(matches!(
+            current_sealing_key(&conn, account, stream_id, &device, NOW).unwrap(),
+            SealingKeyOutcome::NoCurrentKey
+        ));
+    }
+
+    #[test]
+    fn a_device_with_no_wrap_is_not_a_recipient() {
+        let conn = db();
+        let (account, founder, genesis_hash, stream_id) = account_with_owned_stream(&conn);
+        let device = local_device(&conn, NOW).unwrap();
+        // The owner authors a wrap naming SOME OTHER device (not the local device).
+        let other = Dev::new(9);
+        let other_x = DeviceX25519Public::from_bytes(&other.x).unwrap();
+        let key = ContentKey::from_seed(&[0x20; 32]);
+        let wrap = honest_wrap(account, stream_id, other.fp, &other_x, &key, 0);
+        let (bytes, _) = wrap_entry(account, &founder, 0, None, Some(genesis_hash), &wrap);
+        ingest(&conn, &bytes);
+
+        // A current key exists (selection is Some) but this device is not a recipient.
+        assert!(select_current_sealing_wrap(&conn, account, stream_id).unwrap().is_some());
+        assert!(matches!(
+            current_sealing_key(&conn, account, stream_id, &device, NOW).unwrap(),
+            SealingKeyOutcome::NotRecipient
+        ));
+        assert_eq!(security_event_count(&conn), 0, "not-a-recipient records no security event");
+    }
+
+    #[test]
+    fn a_hand_authored_wrap_to_this_device_is_ready() {
+        let conn = db();
+        let (account, founder, genesis_hash, stream_id) = account_with_owned_stream(&conn);
+        let device = local_device(&conn, NOW).unwrap();
+        let key = ContentKey::from_seed(&[0x20; 32]);
+        let wrap =
+            honest_wrap(account, stream_id, device.fingerprint(), &device.x25519_public(), &key, 0);
+        let (bytes, _) = wrap_entry(account, &founder, 0, None, Some(genesis_hash), &wrap);
+        ingest(&conn, &bytes);
+
+        let recovered =
+            expect_ready(current_sealing_key(&conn, account, stream_id, &device, NOW).unwrap());
+        assert_eq!(recovered.as_slice(), key.as_slice(), "the recovered key is the sealed key");
+        assert_eq!(recovered.key_id(), key.key_id());
+        assert_eq!(security_event_count(&conn), 0);
+    }
+
+    // ── The adoption cross-check ──
+
+    #[test]
+    fn a_key_id_mismatch_fails_closed_and_records_one_event() {
+        let conn = db();
+        let (account, founder, genesis_hash, stream_id) = account_with_owned_stream(&conn);
+        let device = local_device(&conn, NOW).unwrap();
+        // Seal key K but CLAIM a different key_id in the op payload. The wrap unwraps cleanly (to
+        // K), but K.key_id() disagrees with the claimed key_id → mismatch.
+        let key = ContentKey::from_seed(&[0x20; 32]);
+        let lie = [0xcd; 32];
+        let wrap = build_wrap(
+            account,
+            stream_id,
+            device.fingerprint(),
+            &device.x25519_public(),
+            &key,
+            0,
+            lie,
+        );
+        let (bytes, entry_hash) = wrap_entry(account, &founder, 0, None, Some(genesis_hash), &wrap);
+        ingest(&conn, &bytes);
+
+        assert!(matches!(
+            current_sealing_key(&conn, account, stream_id, &device, NOW).unwrap(),
+            SealingKeyOutcome::FailedClosed
+        ));
+        assert_eq!(security_event_kinds(&conn), vec!["wrap_key_id_mismatch".to_string()]);
+        // The recorded event names the offending op + both key_ids.
+        let (recorded_hash, expected, observed): (Vec<u8>, Vec<u8>, Vec<u8>) = conn
+            .query_row(
+                "SELECT entry_hash, expected_key_id, observed_key_id FROM sync_security_events",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(recorded_hash, entry_hash.to_vec());
+        assert_eq!(expected, lie.to_vec(), "expected = the op's claimed key_id");
+        assert_eq!(observed, key.key_id().to_bytes().to_vec(), "observed = the unwrapped key's id");
+
+        // A second call re-inserts NO duplicate event (INSERT OR IGNORE on (kind, entry_hash)).
+        assert!(matches!(
+            current_sealing_key(&conn, account, stream_id, &device, NOW).unwrap(),
+            SealingKeyOutcome::FailedClosed
+        ));
+        assert_eq!(security_event_count(&conn), 1, "a retry does not re-append the same evidence");
+    }
+
+    #[test]
+    fn an_unwrap_failure_fails_closed_and_records_one_event() {
+        let conn = db();
+        let (account, founder, genesis_hash, stream_id) = account_with_owned_stream(&conn);
+        let device = local_device(&conn, NOW).unwrap();
+        // An HONEST wrap (claimed key_id == key.key_id()), but the ciphertext is corrupted after
+        // sealing — a substituted/garbage wrap presents as an AEAD TAG failure at unwrap, not a
+        // clean-unwrap-wrong-key_id.
+        let key = ContentKey::from_seed(&[0x20; 32]);
+        let mut wrap =
+            honest_wrap(account, stream_id, device.fingerprint(), &device.x25519_public(), &key, 0);
+        wrap.wraps[0].sealed.ciphertext[0] ^= 1; // still a structurally-valid SealedKeyWrap
+        let (bytes, entry_hash) = wrap_entry(account, &founder, 0, None, Some(genesis_hash), &wrap);
+        ingest(&conn, &bytes);
+
+        assert!(matches!(
+            current_sealing_key(&conn, account, stream_id, &device, NOW).unwrap(),
+            SealingKeyOutcome::FailedClosed
+        ));
+        assert_eq!(security_event_kinds(&conn), vec!["wrap_unwrap_failed".to_string()]);
+        // No observed key_id (no key was recovered).
+        let observed: Option<Vec<u8>> = conn
+            .query_row(
+                "SELECT observed_key_id FROM sync_security_events WHERE entry_hash = ?1",
+                [entry_hash.as_slice()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(observed, None, "an unwrap failure records no observed key_id");
+        // Idempotent on retry.
+        current_sealing_key(&conn, account, stream_id, &device, NOW).unwrap();
+        assert_eq!(security_event_count(&conn), 1);
+    }
+
+    #[test]
+    fn two_key_ids_at_one_epoch_selects_deterministically_with_no_spurious_event() {
+        // BLOCKER-1: two accepted wraps at epoch 0 with DIFFERENT key_ids, BOTH naming this device.
+        // Selection is deterministic (min entry_hash); the my-wrap lookup keys on the SELECTED
+        // key_id, so only the selected op's wrap is tried → Ready with no spurious mismatch event.
+        let conn = db();
+        let (account, founder, genesis_hash, stream_id) = account_with_owned_stream(&conn);
+        let device = local_device(&conn, NOW).unwrap();
+
+        let key_a = ContentKey::from_seed(&[0x20; 32]);
+        let key_b = ContentKey::from_seed(&[0x21; 32]);
+        assert_ne!(key_a.key_id(), key_b.key_id(), "the two mints have distinct key_ids");
+        let wrap_a = honest_wrap(
+            account,
+            stream_id,
+            device.fingerprint(),
+            &device.x25519_public(),
+            &key_a,
+            0,
+        );
+        let wrap_b = honest_wrap(
+            account,
+            stream_id,
+            device.fingerprint(),
+            &device.x25519_public(),
+            &key_b,
+            0,
+        );
+        // A dense chain: two ops at epoch 0, same (stream) — both accept (SET, never LWW).
+        let (a_bytes, ha) = wrap_entry(account, &founder, 0, None, Some(genesis_hash), &wrap_a);
+        ingest(&conn, &a_bytes);
+        let (b_bytes, hb) = wrap_entry(account, &founder, 1, Some(ha), Some(genesis_hash), &wrap_b);
+        ingest(&conn, &b_bytes);
+
+        // The tiebreak is MIN entry_hash; the recovered key must be that op's key.
+        let expected_key = if ha < hb { &key_a } else { &key_b };
+        let selected =
+            select_current_sealing_wrap(&conn, account, stream_id).unwrap().expect("a current key");
+        assert_eq!(selected.key_id, expected_key.key_id(), "min entry_hash decides the key_id");
+        assert_eq!(selected.minting_entry_hash, ha.min(hb));
+
+        let recovered =
+            expect_ready(current_sealing_key(&conn, account, stream_id, &device, NOW).unwrap());
+        assert_eq!(recovered.as_slice(), expected_key.as_slice(), "unwraps the SELECTED key_id");
+        assert_eq!(
+            security_event_count(&conn),
+            0,
+            "the other key_id's wrap is filtered out — no spurious mismatch event",
+        );
+    }
+
+    // ── Eviction (S-1): a retro-condemn can drop the selection to a LOWER epoch ──
+
+    /// genesis(founder) + DeviceAdd(owner_b, Owner) + StreamOwn(founder) → account, founder,
+    /// owner_b, owner_b's incarnation id, the owned stream, and the StreamOwn control-tail hash.
+    fn account_with_second_owner(
+        conn: &Connection,
+    ) -> (AccountId, Dev, Dev, [u8; 32], StreamId, [u8; 32], [u8; 32]) {
+        let founder = Dev::new(1);
+        let (account, genesis_bytes, genesis_hash) = genesis(&founder);
+        ingest(conn, &genesis_bytes);
+        let owner_b = Dev::new(2);
+        let (add_bytes, owner_id_b) = control_op(
+            account,
+            &founder,
+            1,
+            Some(genesis_hash),
+            Some(genesis_hash),
+            &device_add(&owner_b, DeviceRole::Owner),
+        );
+        ingest(conn, &add_bytes);
+        let (stream_id, own) = stream_own(account);
+        let (own_bytes, own_hash) =
+            control_op(account, &founder, 2, Some(owner_id_b), Some(genesis_hash), &own);
+        ingest(conn, &own_bytes);
+        (account, founder, owner_b, owner_id_b, stream_id, own_hash, genesis_hash)
+    }
+
+    #[test]
+    fn retro_condemning_the_max_epoch_wrap_falls_back_to_the_lower_epoch_key() {
+        let conn = db();
+        let (account, founder, owner_b, owner_id_b, stream_id, own_hash, genesis_hash) =
+            account_with_second_owner(&conn);
+        let device = local_device(&conn, NOW).unwrap();
+        let fp = device.fingerprint();
+        let x = device.x25519_public();
+
+        // owner_b authors epoch-0 (seq0) and epoch-1 (seq1) wraps, both naming this device.
+        let key0 = ContentKey::from_seed(&[0x30; 32]);
+        let key1 = ContentKey::from_seed(&[0x31; 32]);
+        let (w0_bytes, w0) = wrap_entry(
+            account,
+            &owner_b,
+            0,
+            None,
+            Some(owner_id_b),
+            &honest_wrap(account, stream_id, fp, &x, &key0, 0),
+        );
+        ingest(&conn, &w0_bytes);
+        let (w1_bytes, _w1) = wrap_entry(
+            account,
+            &owner_b,
+            1,
+            Some(w0),
+            Some(owner_id_b),
+            &honest_wrap(account, stream_id, fp, &x, &key1, 1),
+        );
+        ingest(&conn, &w1_bytes);
+
+        // Before condemnation: the max epoch (1) is current.
+        let recovered =
+            expect_ready(current_sealing_key(&conn, account, stream_id, &device, NOW).unwrap());
+        assert_eq!(recovered.as_slice(), key1.as_slice(), "epoch 1 is current pre-condemn");
+
+        // A demotes owner_b with a secrets cut at seq 0 → the epoch-1 wrap (seq 1) is
+        // retro-condemned, the epoch-0 wrap (seq 0, within the cut) survives. The selection
+        // reverts to the LOWER epoch.
+        let demote = AccountOp::OwnerDemote {
+            device_fingerprint: owner_b.fp,
+            owner_id: owner_id_b,
+            control_cut: Cut::Empty,
+            secrets_cut: Cut::At { seq: 0, hash: w0 },
+            reason: "demote".to_string(),
+        };
+        let (demote_bytes, _) =
+            control_op(account, &founder, 3, Some(own_hash), Some(genesis_hash), &demote);
+        ingest(&conn, &demote_bytes);
+
+        let recovered =
+            expect_ready(current_sealing_key(&conn, account, stream_id, &device, NOW).unwrap());
+        assert_eq!(
+            recovered.as_slice(),
+            key0.as_slice(),
+            "selection falls back to the epoch-0 key"
+        );
+        assert_eq!(security_event_count(&conn), 0, "an honest eviction records no event");
+    }
+
+    #[test]
+    fn condemning_every_accepted_wrap_yields_no_current_key() {
+        let conn = db();
+        let (account, founder, owner_b, owner_id_b, stream_id, own_hash, genesis_hash) =
+            account_with_second_owner(&conn);
+        let device = local_device(&conn, NOW).unwrap();
+        let fp = device.fingerprint();
+        let x = device.x25519_public();
+
+        let key0 = ContentKey::from_seed(&[0x30; 32]);
+        let key1 = ContentKey::from_seed(&[0x31; 32]);
+        let (w0_bytes, w0) = wrap_entry(
+            account,
+            &owner_b,
+            0,
+            None,
+            Some(owner_id_b),
+            &honest_wrap(account, stream_id, fp, &x, &key0, 0),
+        );
+        ingest(&conn, &w0_bytes);
+        let (w1_bytes, _w1) = wrap_entry(
+            account,
+            &owner_b,
+            1,
+            Some(w0),
+            Some(owner_id_b),
+            &honest_wrap(account, stream_id, fp, &x, &key1, 1),
+        );
+        ingest(&conn, &w1_bytes);
+        assert!(matches!(
+            current_sealing_key(&conn, account, stream_id, &device, NOW).unwrap(),
+            SealingKeyOutcome::Ready(_)
+        ));
+
+        // An Empty secrets cut condemns owner_b's WHOLE secrets chain → no accepted wrap remains.
+        let demote = AccountOp::OwnerDemote {
+            device_fingerprint: owner_b.fp,
+            owner_id: owner_id_b,
+            control_cut: Cut::Empty,
+            secrets_cut: Cut::Empty,
+            reason: "demote".to_string(),
+        };
+        let (demote_bytes, _) =
+            control_op(account, &founder, 3, Some(own_hash), Some(genesis_hash), &demote);
+        ingest(&conn, &demote_bytes);
+
+        assert!(select_current_sealing_wrap(&conn, account, stream_id).unwrap().is_none());
+        assert!(matches!(
+            current_sealing_key(&conn, account, stream_id, &device, NOW).unwrap(),
+            SealingKeyOutcome::NoCurrentKey
+        ));
+    }
+
+    // ── S-2: a contested account needs no special case ──
+
+    #[test]
+    fn a_contested_account_has_no_current_key() {
+        let conn = db();
+        let founder = Dev::new(1);
+        let (account, genesis_bytes, genesis_hash) = genesis(&founder);
+        ingest(&conn, &genesis_bytes);
+        let (stream_id, own) = stream_own(account);
+        let (own_bytes, own_hash) =
+            control_op(account, &founder, 1, Some(genesis_hash), Some(genesis_hash), &own);
+        ingest(&conn, &own_bytes);
+        // Two owner devices, added so the mutual removal below is a genuine owner-vs-owner contest.
+        let a = Dev::new(2);
+        let b = Dev::new(3);
+        let (add_a_bytes, add_a) = control_op(
+            account,
+            &founder,
+            2,
+            Some(own_hash),
+            Some(genesis_hash),
+            &device_add(&a, DeviceRole::Owner),
+        );
+        ingest(&conn, &add_a_bytes);
+        let (add_b_bytes, add_b) = control_op(
+            account,
+            &founder,
+            3,
+            Some(add_a),
+            Some(genesis_hash),
+            &device_add(&b, DeviceRole::Owner),
+        );
+        ingest(&conn, &add_b_bytes);
+
+        // The founder authors a wrap naming the local device — accepted while the account is LIVE.
+        let device = local_device(&conn, NOW).unwrap();
+        let key = ContentKey::from_seed(&[0x20; 32]);
+        let wrap =
+            honest_wrap(account, stream_id, device.fingerprint(), &device.x25519_public(), &key, 0);
+        let (wrap_bytes, _) = wrap_entry(account, &founder, 0, None, Some(genesis_hash), &wrap);
+        ingest(&conn, &wrap_bytes);
+        assert!(
+            matches!(
+                current_sealing_key(&conn, account, stream_id, &device, NOW).unwrap(),
+                SealingKeyOutcome::Ready(_)
+            ),
+            "the wrap is current while the account is live",
+        );
+
+        // a removes b and b removes a (incomparable) → the account folds contested; the contested
+        // hold keeps the wrap out of `accepted`, so the selection is empty. No special case here.
+        let remove_b = AccountOp::DeviceRemove {
+            device_fingerprint: b.fp,
+            control_cut: Cut::Empty,
+            secrets_cut: Cut::Empty,
+            content_cuts: Vec::new(),
+            reason: "revoked".to_string(),
+        };
+        let remove_a = AccountOp::DeviceRemove {
+            device_fingerprint: a.fp,
+            control_cut: Cut::Empty,
+            secrets_cut: Cut::Empty,
+            content_cuts: Vec::new(),
+            reason: "revoked".to_string(),
+        };
+        let (remove_b_bytes, _) = control_op(account, &a, 0, None, Some(add_a), &remove_b);
+        ingest(&conn, &remove_b_bytes);
+        let (remove_a_bytes, _) = control_op(account, &b, 0, None, Some(add_b), &remove_a);
+        ingest(&conn, &remove_a_bytes);
+
+        assert!(account_is_contested(&conn, account).unwrap(), "the account is contested");
+        assert!(select_current_sealing_wrap(&conn, account, stream_id).unwrap().is_none());
+        assert!(matches!(
+            current_sealing_key(&conn, account, stream_id, &device, NOW).unwrap(),
+            SealingKeyOutcome::NoCurrentKey
+        ));
+    }
+}

--- a/crates/rag-rat-oplog/src/account/secrets/security_event.rs
+++ b/crates/rag-rat-oplog/src/account/secrets/security_event.rs
@@ -1,0 +1,175 @@
+//! The local sealing-adoption audit log (`sync_security_events`, sync phase C4.3b, #607).
+//!
+//! When the read-time adoption cross-check ([`super::sealing::current_sealing_key`]) meets an
+//! accepted [`StreamKeyWrap`](super::ops::StreamKeyWrap) naming this device that either fails to
+//! unwrap (an AEAD tag failure — the primary manifestation of a substituted wrap) or unwraps to a
+//! key whose `key_id` disagrees with the op's signed `key_id`, it records the evidence here.
+//!
+//! INVARIANT: these rows are LOCAL-only. They are never replicated, never a fold input, and the
+//! adoption seam never mutates a fold verdict on their account — the shared fold stays
+//! device-independent (an unwrap check is only runnable by recipients, so it can never converge).
+//! The evidence is device-local, queryable by a later CLI surface.
+
+use rusqlite::{Connection, params};
+
+use super::super::AccountId;
+use super::super::keywrap::KeyId;
+use crate::stream::StreamId;
+
+/// The closed set of sealing-adoption audit event kinds, persisted as the `kind` TEXT column via
+/// [`as_db_str`](Self::as_db_str). The machine strings are stable schema — a rename is a migration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum SyncSecurityEventKind {
+    /// A wrap naming this device unwrapped cleanly, but the recovered key's `key_id` disagrees with
+    /// the op's signed `key_id` (the residual a valid authority gate can't catch: a wrong key
+    /// inside a validly-signed owner op / impl bug).
+    WrapKeyIdMismatch,
+    /// A wrap naming this device failed to unwrap — AEAD tag failure, blocklisted ephemeral key, or
+    /// non-contributory DH. The primary manifestation of a substituted/corrupt wrap, since the
+    /// key_id compare is only reachable after the tag already verified.
+    WrapUnwrapFailed,
+}
+
+impl SyncSecurityEventKind {
+    pub(super) fn as_db_str(self) -> &'static str {
+        match self {
+            Self::WrapKeyIdMismatch => "wrap_key_id_mismatch",
+            Self::WrapUnwrapFailed => "wrap_unwrap_failed",
+        }
+    }
+
+    pub(super) fn from_db_str(value: &str) -> Option<Self> {
+        match value {
+            "wrap_key_id_mismatch" => Some(Self::WrapKeyIdMismatch),
+            "wrap_unwrap_failed" => Some(Self::WrapUnwrapFailed),
+            _ => None,
+        }
+    }
+}
+
+/// One sealing-adoption audit event. The `key_epoch` is persisted as 8-byte BE (not INT) so a
+/// `u64` epoch round-trips without the `i64` narrowing hazard.
+pub(super) struct SyncSecurityEvent {
+    pub(super) kind: SyncSecurityEventKind,
+    pub(super) account_id: AccountId,
+    pub(super) stream_id: StreamId,
+    pub(super) key_epoch: u64,
+    /// The accepted wrap op whose wrap failed the cross-check — the dedup key with `kind`.
+    pub(super) entry_hash: [u8; 32],
+    /// The op's signed (claimed) `key_id` — the value the recovered key was required to match.
+    pub(super) expected_key_id: Option<KeyId>,
+    /// The `key_id` of the key actually recovered; `None` for an unwrap failure (no key
+    /// recovered).
+    pub(super) observed_key_id: Option<KeyId>,
+    pub(super) observed_at_ms: i64,
+}
+
+/// Append one audit event, `INSERT OR IGNORE` on the `UNIQUE(kind, entry_hash)` dedup key so a hot
+/// seal-path retry never re-appends the same evidence for one op. Autocommits on `&Connection` —
+/// see the durability note on [`super::sealing::current_sealing_key`].
+pub(super) fn record_sync_security_event(
+    conn: &Connection,
+    event: &SyncSecurityEvent,
+) -> rusqlite::Result<()> {
+    conn.execute(
+        "INSERT OR IGNORE INTO sync_security_events(
+             kind, account_id, stream_id, key_epoch, entry_hash,
+             expected_key_id, observed_key_id, observed_at_ms)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+        params![
+            event.kind.as_db_str(),
+            event.account_id.to_bytes().as_slice(),
+            event.stream_id.to_bytes().as_slice(),
+            event.key_epoch.to_be_bytes().as_slice(),
+            event.entry_hash.as_slice(),
+            event.expected_key_id.map(|k| k.to_bytes().to_vec()),
+            event.observed_key_id.map(|k| k.to_bytes().to_vec()),
+            event.observed_at_ms,
+        ],
+    )?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use rag_rat_db::schema;
+    use rusqlite::Connection;
+
+    use super::*;
+
+    fn db() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        schema::apply(&conn, &crate::test_hooks()).unwrap();
+        conn
+    }
+
+    #[test]
+    fn kind_round_trips_through_the_db_string() {
+        for kind in
+            [SyncSecurityEventKind::WrapKeyIdMismatch, SyncSecurityEventKind::WrapUnwrapFailed]
+        {
+            assert_eq!(SyncSecurityEventKind::from_db_str(kind.as_db_str()), Some(kind));
+        }
+        assert_eq!(SyncSecurityEventKind::from_db_str("something_else"), None);
+        // The persisted strings are schema — pin them.
+        assert_eq!(SyncSecurityEventKind::WrapKeyIdMismatch.as_db_str(), "wrap_key_id_mismatch");
+        assert_eq!(SyncSecurityEventKind::WrapUnwrapFailed.as_db_str(), "wrap_unwrap_failed");
+    }
+
+    #[test]
+    fn record_is_idempotent_per_kind_and_entry_hash() {
+        let conn = db();
+        let event = SyncSecurityEvent {
+            kind: SyncSecurityEventKind::WrapUnwrapFailed,
+            account_id: AccountId::from_bytes([1; 32]),
+            stream_id: StreamId::from_bytes([2; 32]),
+            key_epoch: 7,
+            entry_hash: [9; 32],
+            expected_key_id: Some(KeyId::from_bytes([3; 32])),
+            observed_key_id: None,
+            observed_at_ms: 111,
+        };
+        record_sync_security_event(&conn, &event).unwrap();
+        // A repeated (kind, entry_hash) is IGNOREd — the hot-path retry guard.
+        record_sync_security_event(&conn, &event).unwrap();
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM sync_security_events", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(count, 1, "the same (kind, entry_hash) does not re-append");
+
+        // A different kind for the SAME entry is a distinct event, and carries an observed key_id.
+        record_sync_security_event(&conn, &SyncSecurityEvent {
+            kind: SyncSecurityEventKind::WrapKeyIdMismatch,
+            observed_key_id: Some(KeyId::from_bytes([4; 32])),
+            ..event
+        })
+        .unwrap();
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM sync_security_events", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(count, 2, "a distinct kind for the same entry is its own event");
+
+        // The columns round-trip; key_epoch is 8-byte BE and the null/present key_ids persist.
+        let (epoch_be, expected, observed): (Vec<u8>, Vec<u8>, Option<Vec<u8>>) = conn
+            .query_row(
+                "SELECT key_epoch, expected_key_id, observed_key_id FROM sync_security_events
+                 WHERE kind = 'wrap_key_id_mismatch'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(epoch_be, 7u64.to_be_bytes().to_vec(), "key_epoch stored as 8-byte BE");
+        assert_eq!(expected, [3u8; 32].to_vec());
+        assert_eq!(observed, Some([4u8; 32].to_vec()));
+
+        let unwrap_failed_observed: Option<Vec<u8>> = conn
+            .query_row(
+                "SELECT observed_key_id FROM sync_security_events WHERE kind = \
+                 'wrap_unwrap_failed'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(unwrap_failed_observed, None, "an unwrap failure records no observed key_id");
+    }
+}

--- a/crates/rag-rat-oplog/src/lib.rs
+++ b/crates/rag-rat-oplog/src/lib.rs
@@ -81,19 +81,20 @@ mod stream;
 //   caller's txn.
 pub use account::{
     AccountId, AuthorityBoundary, AuthorityFreshness, AuthorityInvalidReason, AuthorityQuery,
-    CapacityScope, DeviceCut, DeviceRole, GrantAuthority, GrantDeviceAuthority,
-    GrantDeviceBoundary, GrantRole, IngestOutcome, OwnerAuthority, OwnerChainAuthority,
-    RosterContentAuthority, account_ingest, auth_len_freshness, author_content_batch_in_tx,
-    backfill_authority_projection, content_stream_is_empty, ensure_owned_stream_v2_in_tx,
-    established_owned_stream_v2, grant_effective_for_device, local_account,
-    mint_and_author_stream_key_wrap_in_tx, owned_stream_v2_id, owner_control_authority,
-    owner_secrets_authority, roster_content_authority, stream_owner_effective,
+    CapacityScope, ContentKey, DeviceCut, DeviceRole, GrantAuthority, GrantDeviceAuthority,
+    GrantDeviceBoundary, GrantRole, IngestOutcome, KeyId, OwnerAuthority, OwnerChainAuthority,
+    RosterContentAuthority, SealingKeyOutcome, SelectedWrap, account_ingest, auth_len_freshness,
+    author_content_batch_in_tx, backfill_authority_projection, content_stream_is_empty,
+    current_sealing_key, ensure_owned_stream_v2_in_tx, established_owned_stream_v2,
+    grant_effective_for_device, local_account, mint_and_author_stream_key_wrap_in_tx,
+    owned_stream_v2_id, owner_control_authority, owner_secrets_authority, roster_content_authority,
+    select_current_sealing_wrap, stream_owner_effective,
 };
 // The op-log's first crate-internal API surface (#524): the MINTING primitives + the op
 // vocabulary the memory subsystem needs to author + backfill entries. Every submodule above is
 // otherwise private, so this curated re-export is the ONE seam `query::memory` reaches through
 // — and the only direction of the dependency (`oplog` never depends back on `query::memory`).
-pub use identity::local_device;
+pub use identity::{LocalDevice, local_device};
 pub use op::{EdgeKey, EdgeSpec, MemoryOp, NodeContent, NodeId, NodeStatus};
 // The `/1` shadow-projection read seams (`ProjectedState` / `load_projection`) and the
 // standalone (own-txn) `/1` authoring wrappers (`author_batch` / `author_op`) — test-only


### PR DESCRIPTION
Adds the read side of the account secrets log: which content key a device would seal a stream under right now, and the device-local key_id adoption cross-check that guards it. Part of the account content-key sealing work (#607); consumes the wraps authored in #754. Nothing calls these yet — content-entry sealing (the consumer) is the next slice.

## What lands

- **Sealing-key selection, derive-on-read** (`account/secrets/sealing.rs`): `select_current_sealing_wrap(conn, account, stream)` is a pure function of the current accepted `StreamKeyWrap` set — max `key_epoch`, tiebreak min `entry_hash` — with no cached table and no refold pass. Eviction is automatic and convergent: a refold that condemns the current wrap drops it from `accepted`, and the next read selects the surviving max (possibly a *lower* epoch — by design; a compromised owner's condemned rotation reverts to the honest prior key). Also the CLI "what key is current" surface.
- **key_id adoption cross-check** (`current_sealing_key(conn, account, stream, &LocalDevice, now_ms)` → `SealingKeyOutcome`): collects every wrap naming this device at the selected `(epoch, key_id)` — including fan-out siblings across ops — and tries each. An unwrap failure (AEAD tag / blocklisted ephemeral key) records a `wrap_unwrap_failed` audit event and moves on; a clean unwrap whose `key_id` disagrees records `wrap_key_id_mismatch` and moves on; the first wrap that opens to the selected `key_id` is the key. Fails closed only when no candidate passes. The outcome is typed (`Ready | NoCurrentKey | NotRecipient | FailedClosed`) so a later caller can distinguish "no key" from "not a recipient" (a catch-up/rotation trigger) from a security failure.
- **Fold firewall:** the cross-check runs at read time and never in the fold — its unwrap step is recipient-only, so it can never be a fold input without breaking convergence. A local mismatch/failure is written to `sync_security_events` and nothing else; no fold verdict is ever mutated.
- **`sync_security_events`** (migration V076, STRICT): the local, never-replicated adoption audit log. `key_epoch` stored as 8-byte BE (no `i64` narrowing hazard), `UNIQUE(kind, entry_hash)` + `INSERT OR IGNORE` so a hot-path retry never re-appends the same evidence.

Keyed on the selected `key_id`, not the epoch alone: two accepted wraps can share an epoch with different key_ids (concurrent owner mints), and epoch-only keying would either diverge sealing across devices or raise a spurious mismatch on an honest state.

## Out of scope (follow-up)

Content-entry sealing and non-current-epoch decrypt; lazy rotation; the user-facing sync-enable surface.

## Tests / gates

Behavioral tests over the real mint seam and hand-authored wraps: ready / not-a-recipient / no-current-key; key_id mismatch and unwrap failure both fail closed and record exactly one (deduped) event; two key_ids at one epoch select deterministically with no spurious event; retro-condemning the max-epoch wrap falls back to the lower-epoch key; condemning every wrap yields no key; a contested account yields no key. Plus the migration and STRICT-typing tests. `cargo nextest run -p rag-rat-oplog -p rag-rat-db` → 462 passed; clippy (`-D warnings`, both feature sets on both crates) and nightly `fmt --check` clean.
