### PR TITLE
feat(agent-hook): augment the Read tool with file/dir memories + load-bearing symbols (#756)

### DIFF
--- a/crates/rag-rat-base/src/config/discovery.rs
+++ b/crates/rag-rat-base/src/config/discovery.rs
@@ -98,6 +98,16 @@ pub fn linked_worktree_main_root(root: &Path) -> Option<PathBuf> {
     (main != workdir).then_some(main)
 }
 
+/// The git WORKDIR root (checkout top) containing `path`, canonicalized — `None` for a non-git
+/// `path`. The SESSION-side counterpart to [`linked_worktree_main_root`] (which returns the MAIN
+/// checkout's top): both are needed to rebase a main-anchored `config.root` onto the checkout a
+/// session is actually in. Canonicalized so it compares equal to the other topology roots.
+pub fn worktree_root(path: &Path) -> Option<PathBuf> {
+    let repo = crate::repo_discover::discover_repo(path).ok()?;
+    let workdir = repo.workdir()?;
+    Some(workdir.canonicalize().unwrap_or_else(|_| workdir.to_path_buf()))
+}
+
 pub(crate) fn main_worktree_root(root: &Path) -> Option<PathBuf> {
     let repo = crate::repo_discover::discover_repo(root).ok()?;
     let common_dir = repo.common_dir().canonicalize().ok()?;

--- a/crates/rag-rat-base/src/config/mod.rs
+++ b/crates/rag-rat-base/src/config/mod.rs
@@ -171,7 +171,7 @@ pub enum ConfigError {
 
 pub use discovery::{
     default_database_path, default_legacy_database_path, discover_config_path,
-    linked_worktree_main_root, nearest_config_at_or_above,
+    linked_worktree_main_root, nearest_config_at_or_above, worktree_root,
 };
 pub(crate) use discovery::{main_worktree_root, normalize_existing_dir, resolve_default_database};
 #[cfg(test)]

--- a/crates/rag-rat-cli/src/agent_hook/mod.rs
+++ b/crates/rag-rat-cli/src/agent_hook/mod.rs
@@ -435,28 +435,31 @@ fn read_augment_hook(input: &HookInput) -> anyhow::Result<()> {
 }
 
 /// The absolute directory that indexed `files.path` are relative to, IN THE SESSION'S checkout.
-/// `config.root` is main-anchored (`Config::load`, #219) and already folds in `[index] root`, so
-/// rebase it: swap its MAIN-worktree-top prefix for the SESSION worktree top (the dir holding the
-/// nearest `rag-rat.toml` at/above cwd). This resolves BOTH a linked-worktree read (main→linked
-/// top) and an `[index] root = "<subdir>"` layout — the subdir survives the rebase (#756 review).
-/// Falls back to `config.root` when either worktree top can't be discovered.
+/// `config.root` is main-anchored (`Config::load`, #219) and already folds in the config's position
+/// under the git root plus `[index] root`.
+///
+/// - In the MAIN worktree (or when no main resolves) `config.root` already IS the session's indexed
+///   root — return it, so `[index] root` and a git-root-nested config are both honored as-is.
+/// - In a LINKED worktree, rebase `config.root` from the MAIN git-worktree root onto the SESSION
+///   git-worktree root. BOTH anchors are git WORKDIR roots (git topology, NOT `rag-rat.toml`
+///   directories), so the whole config-relative suffix — a nested config dir AND `[index] root` —
+///   is preserved exactly once, and a branch-only-config linked worktree (whose main has no config)
+///   still resolves (#756 review).
 fn session_indexed_root(config: &Config, cwd: &str) -> PathBuf {
-    let toml_dir = |p: &Path| {
-        rag_rat_base::config::nearest_config_at_or_above(p)
-            .and_then(|toml| toml.parent().map(Path::to_path_buf))
-    };
-    // `main_top` governs `config.root` (its own toml sits at the main worktree top); `session_top`
-    // is where the session actually is. `config.root = main_top / [index].root`.
-    match (toml_dir(&config.root), toml_dir(Path::new(cwd))) {
-        (Some(main_top), Some(session_top)) => rebase_root(&config.root, &main_top, &session_top),
-        _ => config.root.clone(),
+    let cwd = Path::new(cwd);
+    match rag_rat_base::config::linked_worktree_main_root(cwd) {
+        Some(main_git_root) => match rag_rat_base::config::worktree_root(cwd) {
+            Some(session_git_root) => rebase_root(&config.root, &main_git_root, &session_git_root),
+            None => config.root.clone(),
+        },
+        None => config.root.clone(),
     }
 }
 
-/// Rebase `config_root` from `main_top` onto `session_top`, preserving the `[index] root` subdir
-/// (the part of `config_root` below `main_top`). Pure, so the linked-worktree + subdir-root matrix
-/// is unit-tested without a filesystem. Returns `config_root` unchanged when it isn't under
-/// `main_top` (an unexpected topology — never guess a wrong prefix).
+/// Rebase `config_root` from `main_top` onto `session_top`, preserving the whole suffix below
+/// `main_top` (a git-root-nested config dir AND `[index] root`). Pure, so the linked-worktree ×
+/// nested-config × subdir-root matrix is unit-tested without a filesystem. Returns `config_root`
+/// unchanged when it isn't under `main_top` (an unexpected topology — never guess a wrong prefix).
 fn rebase_root(config_root: &Path, main_top: &Path, session_top: &Path) -> PathBuf {
     match config_root.strip_prefix(main_top) {
         Ok(subdir) => session_top.join(subdir),

--- a/crates/rag-rat-cli/src/agent_hook/mod.rs
+++ b/crates/rag-rat-cli/src/agent_hook/mod.rs
@@ -26,8 +26,8 @@ use rag_rat_base::config::Config;
 use rag_rat_base::language::Language;
 use rag_rat_base::locks;
 use rag_rat_core::index::{CloneCheckInput, IndexDatabase, TextCloneMatch};
-use rag_rat_core::query::grep_augment;
 use rag_rat_core::query::orientation::Orientation;
+use rag_rat_core::query::{grep_augment, read_augment};
 use rag_rat_db::storage::IndexConnection;
 use serde::Deserialize;
 
@@ -392,11 +392,14 @@ fn version_line(status: &rag_rat_core::version_check::VersionStatus) -> Option<S
     }
 }
 
-/// PreToolUse path: the write-time clone check (#287) on the edit tools, grep augmentation
-/// otherwise.
+/// PreToolUse path: the write-time clone check (#287) on the edit tools, read augmentation on
+/// `Read` (#756), grep augmentation on a code search otherwise.
 fn pretooluse(input: &HookInput) -> anyhow::Result<()> {
     if matches!(input.tool_name.as_str(), "Write" | "Edit" | "MultiEdit" | "apply_patch") {
         return clone_check(input);
+    }
+    if input.tool_name == "Read" {
+        return read_augment_hook(input);
     }
     let Some(search) = extract_search(input) else { return Ok(()) };
     let Some(config) = find_config(Path::new(&input.cwd)) else { return Ok(()) };
@@ -407,20 +410,70 @@ fn pretooluse(input: &HookInput) -> anyhow::Result<()> {
     let context = ask_listener(&config, &input.session_id, &input.cwd, &search)
         .unwrap_or_else(|| fallback_compose(&config, &input.cwd, &search));
     if let Some(context) = context {
-        // PreToolUse contract: additionalContext only — no `permissionDecision` (Codex rejects the
-        // "allow" value, and we only inject context, never gate the tool). Plain stdout is
-        // debug-only.
-        println!(
-            "{}",
-            serde_json::json!({
-                "hookSpecificOutput": {
-                    "hookEventName": "PreToolUse",
-                    "additionalContext": context,
-                }
-            })
-        );
+        print_additional_context(&context);
     }
     Ok(())
+}
+
+/// Read-augmentation path (#756): when the agent opens a file, inject the repo memories bound to it
+/// (+ its directory) and the load-bearing symbols defined in it. Silent no-op unless the file is a
+/// tracked, root-relative path with something to say. Prefers the warm listener (per-session
+/// dedup); falls back to a direct read-only compose.
+fn read_augment_hook(input: &HookInput) -> anyhow::Result<()> {
+    let Some(config) = find_config(Path::new(&input.cwd)) else { return Ok(()) };
+    let Some(file_path) = input.tool_input.get("file_path").and_then(|v| v.as_str()) else {
+        return Ok(());
+    };
+    // Relativize against the SESSION's worktree root — the directory holding the nearest
+    // `rag-rat.toml` at/above cwd — NOT `config.root`. `Config::load` deliberately anchors
+    // `config.root` to the MAIN worktree, but a linked-worktree `Read` targets a file under the
+    // LINKED root, so stripping `config.root` would fail and silently drop every augmentation (#756
+    // review). The main worktree is the fallback when discovery somehow finds nothing.
+    let worktree_root = rag_rat_base::config::nearest_config_at_or_above(Path::new(&input.cwd))
+        .and_then(|toml| toml.parent().map(Path::to_path_buf))
+        .unwrap_or_else(|| config.root.clone());
+    let Some(rel_path) = worktree_rel_path(file_path, &worktree_root) else { return Ok(()) };
+    let context = ask_listener_read(&config, &input.session_id, &input.cwd, &rel_path)
+        .unwrap_or_else(|| fallback_compose_read(&config, &input.cwd, &rel_path));
+    if let Some(context) = context {
+        print_additional_context(&context);
+    }
+    Ok(())
+}
+
+/// The worktree-root-relative, SLASH-separated path for `file_path`, or `None` when it's OUTSIDE
+/// `worktree_root` (nothing indexed to augment it with). Indexed bindings and symbols are keyed by
+/// a forward-slash root-relative path on every OS, so join the stripped components with `/` rather
+/// than `to_string_lossy` (which would leave Windows backslashes that never match) (#756 review).
+fn worktree_rel_path(file_path: &str, worktree_root: &Path) -> Option<String> {
+    let file = Path::new(file_path);
+    // `worktree_root` comes back canonicalized from discovery while the hook's `file_path` is raw,
+    // so canonicalize BOTH (when they exist) to survive a symlinked/`..`-laden checkout path;
+    // fall back to a raw strip when either can't be resolved (keeps this unit-testable with
+    // synthetic paths).
+    let file_c = file.canonicalize();
+    let root_c = worktree_root.canonicalize();
+    let (f, r): (&Path, &Path) = match (file_c.as_deref(), root_c.as_deref()) {
+        (Ok(f), Ok(r)) => (f, r),
+        _ => (file, worktree_root),
+    };
+    let rel = f.strip_prefix(r).ok()?;
+    Some(rel.components().map(|c| c.as_os_str().to_string_lossy()).collect::<Vec<_>>().join("/"))
+}
+
+/// Emit an `additionalContext` block for a PreToolUse hook. PreToolUse contract: additionalContext
+/// only — no `permissionDecision` (Codex rejects the "allow" value, and we only inject context,
+/// never gate the tool). Plain stdout is debug-only.
+fn print_additional_context(context: &str) {
+    println!(
+        "{}",
+        serde_json::json!({
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "additionalContext": context,
+            }
+        })
+    );
 }
 
 /// PostToolUse path (#661): after an edit tool completes, trigger a scoped reindex of the edited
@@ -894,15 +947,6 @@ fn ask_listener(
 ) -> Option<Option<String>> {
     #[cfg(unix)]
     {
-        use std::io::{BufRead, BufReader, Write as _};
-        use std::os::unix::net::UnixStream;
-        let socket = socket_path(config);
-        // SOCKET_BUDGET covers both read and write. Unix-domain connect() completes into
-        // the listener's backlog immediately (no network round-trip), so no separate connect
-        // timeout is needed.
-        let stream = UnixStream::connect(&socket).ok()?;
-        stream.set_read_timeout(Some(SOCKET_BUDGET)).ok()?;
-        stream.set_write_timeout(Some(SOCKET_BUDGET)).ok()?;
         // `cwd` lets the listener scope the augmentation to the session's worktree overlay (#219);
         // an older listener without the field just ignores it (lenient deserialize) → base scope.
         let request = serde_json::json!({
@@ -911,21 +955,81 @@ fn ask_listener(
             "pattern": search.pattern, "search_path": search.search_path,
             "source": search.source,
         });
-        let mut writer = stream.try_clone().ok()?;
-        writeln!(writer, "{request}").ok()?;
-        let mut line = String::new();
-        BufReader::new(stream).read_line(&mut line).ok()?;
-        let reply: serde_json::Value = serde_json::from_str(&line).ok()?;
-        if reply.get("v")?.as_u64()? != 1 {
-            return None;
-        }
-        Some(reply.get("context")?.as_str().map(str::to_string))
+        // grep_augment predates the `kind` echo, so any v1 reply is authoritative — trust it and
+        // don't consult the handled-kind marker (older listeners never send it).
+        send_to_listener(config, &request).map(|reply| reply.context)
     }
     #[cfg(not(unix))]
     {
         let _ = (config, session_id, cwd, search);
         None
     }
+}
+
+/// Read-augmentation counterpart of [`ask_listener`] (#756): ask the warm listener for the digest
+/// of a file being opened, so the per-session dedup applies. `path` is repo-root-relative.
+fn ask_listener_read(
+    config: &Config,
+    session_id: &str,
+    cwd: &str,
+    path: &str,
+) -> Option<Option<String>> {
+    #[cfg(unix)]
+    {
+        let request = serde_json::json!({
+            "v": 1, "kind": "read_augment", "session_id": session_id,
+            "cwd": cwd, "path": path,
+        });
+        // Treat the reply as authoritative ONLY when the listener CONFIRMS it handled read_augment
+        // (echoes the kind). An older listener that predates this feature returns a v1 null-context
+        // reply with no handled kind — return outer `None` so the caller runs the direct fallback
+        // instead of silently disabling read augmentation until the server restarts (#756 review).
+        match send_to_listener(config, &request) {
+            Some(reply) if reply.handled_kind.as_deref() == Some("read_augment") =>
+                Some(reply.context),
+            _ => None,
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = (config, session_id, cwd, path);
+        None
+    }
+}
+
+/// A parsed listener reply: the injectable `context` (None ⇒ nothing new) and the request `kind`
+/// the listener reported handling (None ⇒ an older listener that didn't understand the request).
+#[cfg(unix)]
+struct ListenerReply {
+    context: Option<String>,
+    handled_kind: Option<String>,
+}
+
+/// One request/response round-trip to the warm listener socket. `None` ⇒ the listener didn't answer
+/// (no socket, timeout, protocol skew) so the caller falls back; `Some(reply)` carries the context
+/// plus the handled-kind marker.
+#[cfg(unix)]
+fn send_to_listener(config: &Config, request: &serde_json::Value) -> Option<ListenerReply> {
+    use std::io::{BufRead, BufReader, Write as _};
+    use std::os::unix::net::UnixStream;
+    let socket = socket_path(config);
+    // SOCKET_BUDGET covers both read and write. Unix-domain connect() completes into the listener's
+    // backlog immediately (no network round-trip), so no separate connect timeout is needed.
+    let stream = UnixStream::connect(&socket).ok()?;
+    stream.set_read_timeout(Some(SOCKET_BUDGET)).ok()?;
+    stream.set_write_timeout(Some(SOCKET_BUDGET)).ok()?;
+    let mut writer = stream.try_clone().ok()?;
+    writeln!(writer, "{request}").ok()?;
+    let mut line = String::new();
+    BufReader::new(stream).read_line(&mut line).ok()?;
+    let reply: serde_json::Value = serde_json::from_str(&line).ok()?;
+    if reply.get("v")?.as_u64()? != 1 {
+        return None;
+    }
+    Some(ListenerReply {
+        context: reply.get("context").and_then(|c| c.as_str()).map(str::to_string),
+        handled_kind: reply.get("kind").and_then(|k| k.as_str()).map(str::to_string),
+    })
 }
 
 /// Single source of truth via `locks::hook_socket_path_for`; same computation as the MCP
@@ -938,13 +1042,45 @@ fn socket_path(config: &Config) -> PathBuf {
 
 /// Stateless direct read (no dedupe — spec: fallback path). Any error ⇒ silence.
 fn fallback_compose(config: &Config, cwd: &str, search: &Search) -> Option<String> {
+    let conn = scoped_read_conn(config, cwd)?;
+    grep_augment::compose(
+        conn.connection(),
+        &search.pattern,
+        search.search_path.as_deref(),
+        &grep_augment::DedupeFilter::default(),
+        config.memory.surface,
+    )
+    .ok()
+    .flatten()
+    .map(|out| out.context)
+}
+
+/// Read-augmentation fallback (#756): the stateless direct compose for a file being opened, used
+/// when the warm listener didn't answer. No session dedup on this path (spec: fallback is
+/// stateless). `rel_path` is repo-root-relative. Any error ⇒ silence.
+fn fallback_compose_read(config: &Config, cwd: &str, rel_path: &str) -> Option<String> {
+    let conn = scoped_read_conn(config, cwd)?;
+    read_augment::compose(
+        conn.connection(),
+        rel_path,
+        &grep_augment::DedupeFilter::default(),
+        config.memory.surface,
+    )
+    .ok()
+    .flatten()
+    .map(|out| out.context)
+}
+
+/// Open a read-only connection scoped to the session's worktree overlay, ready for a compose call.
+/// Shared by the grep- and read-augment fallbacks. `compose` queries the `files` view, so without
+/// the scope install it would read raw (unscoped) rows. `config.root` is the anchored main
+/// worktree; `cwd` is the session dir (a linked worktree → its overlay, else base) (#219). The repo
+/// dimension is resolved from this config (identity + override) so the scope binds the config's
+/// repo, not the config-blind sole repo (a sibling in a consolidated DB); an unprovable repo →
+/// empty scope, never a sibling's rows. `None` on any not-ready condition, so the caller stays
+/// silent.
+fn scoped_read_conn(config: &Config, cwd: &str) -> Option<IndexConnection> {
     let conn = IndexConnection::open_read_only(&config.database).ok()?;
-    // Scope to the session's worktree overlay before composing — `compose` queries the `files`
-    // view, so without this it would read raw (unscoped) rows. config.root is the anchored main
-    // worktree; cwd is the session dir (a linked worktree → its overlay, else base) (#219). Resolve
-    // the repo dimension from this config (identity + override) so the scope binds the config's
-    // repo, not the config-blind sole repo (a sibling in a consolidated DB); an unprovable repo →
-    // empty scope, never a sibling's rows.
     let repo_id = rag_rat_core::index::resolve_scope_repo_id(
         conn.connection(),
         &config.root,
@@ -959,16 +1095,7 @@ fn fallback_compose(config: &Config, cwd: &str, search: &Search) -> Option<Strin
         Path::new(cwd),
     )
     .ok()?;
-    grep_augment::compose(
-        conn.connection(),
-        &search.pattern,
-        search.search_path.as_deref(),
-        &grep_augment::DedupeFilter::default(),
-        config.memory.surface,
-    )
-    .ok()
-    .flatten()
-    .map(|out| out.context)
+    Some(conn)
 }
 
 #[cfg(test)]

--- a/crates/rag-rat-cli/src/agent_hook/mod.rs
+++ b/crates/rag-rat-cli/src/agent_hook/mod.rs
@@ -424,21 +424,44 @@ fn read_augment_hook(input: &HookInput) -> anyhow::Result<()> {
     let Some(file_path) = input.tool_input.get("file_path").and_then(|v| v.as_str()) else {
         return Ok(());
     };
-    // Relativize against the SESSION's worktree root — the directory holding the nearest
-    // `rag-rat.toml` at/above cwd — NOT `config.root`. `Config::load` deliberately anchors
-    // `config.root` to the MAIN worktree, but a linked-worktree `Read` targets a file under the
-    // LINKED root, so stripping `config.root` would fail and silently drop every augmentation (#756
-    // review). The main worktree is the fallback when discovery somehow finds nothing.
-    let worktree_root = rag_rat_base::config::nearest_config_at_or_above(Path::new(&input.cwd))
-        .and_then(|toml| toml.parent().map(Path::to_path_buf))
-        .unwrap_or_else(|| config.root.clone());
-    let Some(rel_path) = worktree_rel_path(file_path, &worktree_root) else { return Ok(()) };
+    let indexed_root = session_indexed_root(&config, &input.cwd);
+    let Some(rel_path) = worktree_rel_path(file_path, &indexed_root) else { return Ok(()) };
     let context = ask_listener_read(&config, &input.session_id, &input.cwd, &rel_path)
         .unwrap_or_else(|| fallback_compose_read(&config, &input.cwd, &rel_path));
     if let Some(context) = context {
         print_additional_context(&context);
     }
     Ok(())
+}
+
+/// The absolute directory that indexed `files.path` are relative to, IN THE SESSION'S checkout.
+/// `config.root` is main-anchored (`Config::load`, #219) and already folds in `[index] root`, so
+/// rebase it: swap its MAIN-worktree-top prefix for the SESSION worktree top (the dir holding the
+/// nearest `rag-rat.toml` at/above cwd). This resolves BOTH a linked-worktree read (main→linked
+/// top) and an `[index] root = "<subdir>"` layout — the subdir survives the rebase (#756 review).
+/// Falls back to `config.root` when either worktree top can't be discovered.
+fn session_indexed_root(config: &Config, cwd: &str) -> PathBuf {
+    let toml_dir = |p: &Path| {
+        rag_rat_base::config::nearest_config_at_or_above(p)
+            .and_then(|toml| toml.parent().map(Path::to_path_buf))
+    };
+    // `main_top` governs `config.root` (its own toml sits at the main worktree top); `session_top`
+    // is where the session actually is. `config.root = main_top / [index].root`.
+    match (toml_dir(&config.root), toml_dir(Path::new(cwd))) {
+        (Some(main_top), Some(session_top)) => rebase_root(&config.root, &main_top, &session_top),
+        _ => config.root.clone(),
+    }
+}
+
+/// Rebase `config_root` from `main_top` onto `session_top`, preserving the `[index] root` subdir
+/// (the part of `config_root` below `main_top`). Pure, so the linked-worktree + subdir-root matrix
+/// is unit-tested without a filesystem. Returns `config_root` unchanged when it isn't under
+/// `main_top` (an unexpected topology — never guess a wrong prefix).
+fn rebase_root(config_root: &Path, main_top: &Path, session_top: &Path) -> PathBuf {
+    match config_root.strip_prefix(main_top) {
+        Ok(subdir) => session_top.join(subdir),
+        Err(_) => config_root.to_path_buf(),
+    }
 }
 
 /// The worktree-root-relative, SLASH-separated path for `file_path`, or `None` when it's OUTSIDE

--- a/crates/rag-rat-cli/src/agent_hook/tests.rs
+++ b/crates/rag-rat-cli/src/agent_hook/tests.rs
@@ -133,6 +133,31 @@ fn extract_search_ignores_other_tools() {
     assert!(extract_search(&input).is_none());
 }
 
+// ─── Read-augmentation path resolution (#756) ───────────────────────────────
+
+#[test]
+fn worktree_rel_path_relativizes_an_in_worktree_file_with_slashes() {
+    // Relativized against the SESSION worktree root — for a linked worktree that is NOT the
+    // main-anchored config.root, so a file under the linked root still resolves (#756).
+    assert_eq!(
+        worktree_rel_path(
+            "/repo/.wt/branch-x/crates/rag-rat-core/src/lib.rs",
+            Path::new("/repo/.wt/branch-x"),
+        )
+        .as_deref(),
+        Some("crates/rag-rat-core/src/lib.rs"),
+    );
+}
+
+#[test]
+fn worktree_rel_path_is_none_outside_the_worktree() {
+    // A file outside the worktree root has nothing indexed to augment it with.
+    assert!(
+        worktree_rel_path("/etc/hosts", Path::new("/repo")).is_none(),
+        "outside the worktree → None",
+    );
+}
+
 // ─── PostToolUse edited-path extraction (#661) ──────────────────────────────
 
 #[test]

--- a/crates/rag-rat-cli/src/agent_hook/tests.rs
+++ b/crates/rag-rat-cli/src/agent_hook/tests.rs
@@ -158,6 +158,35 @@ fn worktree_rel_path_is_none_outside_the_worktree() {
     );
 }
 
+#[test]
+fn rebase_root_swaps_the_worktree_top_and_preserves_the_index_subdir() {
+    // root = "." on the main worktree: identity.
+    assert_eq!(
+        rebase_root(Path::new("/main"), Path::new("/main"), Path::new("/main")),
+        Path::new("/main")
+    );
+    // root = "." in a linked worktree: main top → linked top.
+    assert_eq!(
+        rebase_root(Path::new("/main"), Path::new("/main"), Path::new("/linked")),
+        Path::new("/linked"),
+    );
+    // [index] root = "crates" on the main worktree: the subdir is preserved.
+    assert_eq!(
+        rebase_root(Path::new("/main/crates"), Path::new("/main"), Path::new("/main")),
+        Path::new("/main/crates"),
+    );
+    // [index] root = "crates" in a linked worktree: swap the top AND keep the subdir.
+    assert_eq!(
+        rebase_root(Path::new("/main/crates"), Path::new("/main"), Path::new("/linked")),
+        Path::new("/linked/crates"),
+    );
+    // config_root not under main_top (unexpected topology): unchanged, never a wrong prefix.
+    assert_eq!(
+        rebase_root(Path::new("/elsewhere"), Path::new("/main"), Path::new("/linked")),
+        Path::new("/elsewhere"),
+    );
+}
+
 // ─── PostToolUse edited-path extraction (#661) ──────────────────────────────
 
 #[test]

--- a/crates/rag-rat-cli/src/agent_hook/tests.rs
+++ b/crates/rag-rat-cli/src/agent_hook/tests.rs
@@ -180,6 +180,12 @@ fn rebase_root_swaps_the_worktree_top_and_preserves_the_index_subdir() {
         rebase_root(Path::new("/main/crates"), Path::new("/main"), Path::new("/linked")),
         Path::new("/linked/crates"),
     );
+    // Config nested below the git root (`/main/project/rag-rat.toml`) + `[index] root = "src"`, in
+    // a linked worktree: the WHOLE suffix (`project/src`) is preserved once, no double-count.
+    assert_eq!(
+        rebase_root(Path::new("/main/project/src"), Path::new("/main"), Path::new("/linked")),
+        Path::new("/linked/project/src"),
+    );
     // config_root not under main_top (unexpected topology): unchanged, never a wrong prefix.
     assert_eq!(
         rebase_root(Path::new("/elsewhere"), Path::new("/main"), Path::new("/linked")),

--- a/crates/rag-rat-core/src/query/grep_augment.rs
+++ b/crates/rag-rat-core/src/query/grep_augment.rs
@@ -15,7 +15,7 @@ use crate::search::lexical;
 /// Hard cap on rendered context. Truncation drops whole items, never mid-item.
 pub const MAX_CONTEXT_CHARS: usize = 1500;
 const MAX_SYMBOLS: u32 = 3;
-const MAX_MEMORIES: u32 = 4;
+pub(crate) const MAX_MEMORIES: u32 = 4;
 const MAX_LEXICAL_HITS: u32 = 3;
 /// Lexical hits below this fraction of the best hit's score are dropped as low-relevance noise.
 const LEXICAL_RELATIVE_FLOOR: f64 = 0.6;
@@ -344,25 +344,47 @@ struct SymbolItem {
     key: String,
 }
 
-/// A single renderable item in a section, with optional bookkeeping IDs.
-struct RenderItem {
-    line: String,
-    memory_id: Option<String>,
-    symbol_key: Option<String>,
+/// A single renderable item in a section, with optional bookkeeping IDs. Shared with `read_augment`
+/// via [`pack_sections`].
+pub(crate) struct RenderItem {
+    pub(crate) line: String,
+    pub(crate) memory_id: Option<String>,
+    pub(crate) symbol_key: Option<String>,
 }
 
 /// A section is a header line + a list of items. Header is only committed when at least one
-/// item fits; the caller's ID is only appended to the output IDs when the item's line lands.
-struct Section {
-    header: String,
-    items: Vec<RenderItem>,
+/// item fits; the caller's ID is only appended to the output IDs when the item's line lands. Shared
+/// with `read_augment` via [`pack_sections`].
+pub(crate) struct Section {
+    pub(crate) header: String,
+    pub(crate) items: Vec<RenderItem>,
     /// An optional closing/footer line (not associated with an ID).
-    footer: Option<String>,
+    pub(crate) footer: Option<String>,
+}
+
+/// Build the shared memory `RenderItem` (`- [Kind | status] title — gist verdict (rag-rat:
+/// memory_search)`), so grep- and read-augment render bound memories identically. The gist is the
+/// dream summary under `surface = "summary"`, else the clamped body; both empty → title-only.
+pub(crate) fn memory_render_item(m: memory::RepoMemory) -> RenderItem {
+    let gist = match &m.summary {
+        Some(summary) => summary.clone(),
+        None => clamp_body(&m.body),
+    };
+    let gist_part = if gist.is_empty() { String::new() } else { format!(" — {gist}") };
+    let verdict_part = m.verdict.as_deref().map(|v| format!(" {v}")).unwrap_or_default();
+    RenderItem {
+        line: format!(
+            "- [{} | {}] {}{}{} (rag-rat: memory_search)",
+            m.kind, m.status, m.title, gist_part, verdict_part,
+        ),
+        memory_id: Some(m.memory_id),
+        symbol_key: None,
+    }
 }
 
 /// Collapse all whitespace runs (including newlines) to single spaces and truncate to
 /// `MAX_MEMORY_BODY_CHARS`, appending `…` when truncated.
-fn clamp_body(body: &str) -> String {
+pub(crate) fn clamp_body(body: &str) -> String {
     let collapsed: String = body.split_whitespace().collect::<Vec<_>>().join(" ");
     // Compare char count (not byte length) so multibyte bodies don't get `…` with nothing removed.
     if collapsed.chars().count() <= MAX_MEMORY_BODY_CHARS {
@@ -385,29 +407,7 @@ fn render(
     let mut sections: Vec<Section> = Vec::new();
 
     if !memories.is_empty() {
-        let items = memories
-            .into_iter()
-            .map(|m| {
-                // The gist: the summary under `surface = "summary"`, else the clamped body. Both
-                // empty (a summary-surface memory with no summary) → title-only, no `— …`.
-                let gist = match &m.summary {
-                    Some(summary) => summary.clone(),
-                    None => clamp_body(&m.body),
-                };
-                let gist_part =
-                    if gist.is_empty() { String::new() } else { format!(" — {gist}") };
-                let verdict_part =
-                    m.verdict.as_deref().map(|v| format!(" {v}")).unwrap_or_default();
-                RenderItem {
-                    line: format!(
-                        "- [{} | {}] {}{}{} (rag-rat: memory_search)",
-                        m.kind, m.status, m.title, gist_part, verdict_part,
-                    ),
-                    memory_id: Some(m.memory_id),
-                    symbol_key: None,
-                }
-            })
-            .collect();
+        let items = memories.into_iter().map(memory_render_item).collect();
         sections.push(Section {
             header: "**Repo memories bound to this code:**".to_string(),
             items,
@@ -439,7 +439,15 @@ fn render(
         });
     }
 
-    let mut context = String::from("rag-rat index context for this search:\n");
+    pack_sections("rag-rat index context for this search:", sections)
+}
+
+/// Pack `sections` under `intro` into a char-budget-bounded digest (whole-item truncation against
+/// [`MAX_CONTEXT_CHARS`]; a section header is committed only with its first fitting item; an item's
+/// bookkeeping id is recorded only when its line lands). Shared by grep- and read-augment so both
+/// obey the same budget and dedup-bookkeeping rules.
+pub(crate) fn pack_sections(intro: &str, sections: Vec<Section>) -> GrepAugment {
+    let mut context = format!("{intro}\n");
     let mut memory_ids: Vec<String> = Vec::new();
     let mut symbol_keys: Vec<String> = Vec::new();
 
@@ -494,7 +502,10 @@ fn render(
 
 /// Caller/callee edge counts. Callers resolve by `to_symbol_id` or qualified-name match;
 /// callees are edges leaving any of the symbol's concrete rows.
-fn edge_counts(conn: &Connection, hit: &symbol::SymbolHit) -> anyhow::Result<(i64, i64)> {
+pub(crate) fn edge_counts(
+    conn: &Connection,
+    hit: &symbol::SymbolHit,
+) -> anyhow::Result<(i64, i64)> {
     // GENERATION-SCOPED via the `files` view (batch 6, count-scoping class; `compose` installs the
     // worktree scope view before calling in). The `to_symbol_id = ?1` arm keys on a LIVE rowid, but
     // the interned-name arm matches callers purely by NAME and so double-counts dead-generation
@@ -522,7 +533,10 @@ fn edge_counts(conn: &Connection, hit: &symbol::SymbolHit) -> anyhow::Result<(i6
 /// Start line for a symbol hit (line spans live on chunks).
 /// Returns `None` when no matching chunk is found; callers render `{path}` without `:{line}`
 /// rather than a confidently-wrong `:1`.
-fn line_for_symbol(conn: &Connection, hit: &symbol::SymbolHit) -> anyhow::Result<Option<i64>> {
+pub(crate) fn line_for_symbol(
+    conn: &Connection,
+    hit: &symbol::SymbolHit,
+) -> anyhow::Result<Option<i64>> {
     conn.query_row(
         "SELECT start_line FROM chunks
          WHERE file_id = ?1 AND start_byte <= ?2 AND end_byte >= ?2

--- a/crates/rag-rat-core/src/query/mod.rs
+++ b/crates/rag-rat-core/src/query/mod.rs
@@ -6,3 +6,4 @@
 pub mod clusters;
 pub mod grep_augment;
 pub mod orientation;
+pub mod read_augment;

--- a/crates/rag-rat-core/src/query/read_augment.rs
+++ b/crates/rag-rat-core/src/query/read_augment.rs
@@ -1,0 +1,327 @@
+//! Payload composition for the `Read`-augmentation PreToolUse hook (#756).
+//!
+//! When an agent opens a file, inject the repo memories bound to that file and its directory, plus
+//! the load-bearing symbols DEFINED in the file (ranked by caller fan-in) — the drive-by context
+//! that grep-augment surfaces on a pattern search, extended to the read path. Shares grep-augment's
+//! renderer, dedup filter, and per-symbol helpers so the two hooks stay consistent; like it, this
+//! NEVER loads the embedding model — memory + symbol lanes only.
+//!
+//! `path` is REPO-ROOT-RELATIVE (the hook client relativizes the absolute `file_path` against the
+//! config root before composing / sending), matching how indexed bindings and symbols are keyed.
+
+use std::collections::HashSet;
+
+use rag_rat_query::{memory, symbol};
+use rusqlite::Connection;
+
+use crate::query::grep_augment::{
+    self, DedupeFilter, GrepAugment, MAX_MEMORIES, RenderItem, Section,
+};
+
+/// Symbols in the file to actually surface, after ranking by caller fan-in. A file being opened
+/// usually has a small handful of genuinely load-bearing definitions; more is noise.
+const MAX_FILE_SYMBOLS: usize = 3;
+/// Upper bound on the symbols whose caller counts we compute for ranking. Bounds the per-`Read`
+/// cost on a huge file (each candidate is a pair of indexed COUNT queries); a symbol past the cap
+/// is simply not considered.
+const CANDIDATE_CAP: u32 = 80;
+
+/// Compose the read-augmentation digest for `path` (root-relative), or `None` when nothing (new) is
+/// worth injecting. Memory lane: file-bound + directory-bound memories, plus memories on the file's
+/// load-bearing symbols. Symbol lane: those load-bearing symbols with caller/callee counts.
+pub fn compose(
+    conn: &Connection,
+    path: &str,
+    dedupe: &DedupeFilter,
+    surface: rag_rat_base::config::MemorySurface,
+) -> anyhow::Result<Option<GrepAugment>> {
+    // Rank the file's symbols by caller fan-in first: the top few are the symbol lane, and their
+    // bound memories join the memory lane at the front (highest-priority signal, like
+    // grep-augment).
+    let ranked = rank_file_symbols(conn, path)?;
+
+    let mut memories = Vec::new();
+    let mut seen: HashSet<String> = HashSet::new();
+    // Symbol-bound memories first (the load-bearing symbols the agent is about to touch).
+    for (hit, _, _) in &ranked {
+        for m in memory::memories_for_symbol(conn, hit, MAX_MEMORIES)? {
+            if seen.insert(m.memory_id.clone()) {
+                memories.push(m);
+            }
+        }
+    }
+    // Then the file's own path-bound memories, then its directory memories.
+    for m in memory::memories_for_path(conn, path, MAX_MEMORIES)? {
+        if seen.insert(m.memory_id.clone()) {
+            memories.push(m);
+        }
+    }
+    if let Some(dir) = parent_dir(path) {
+        for m in memory::memories_for_path(conn, dir, MAX_MEMORIES)? {
+            if seen.insert(m.memory_id.clone()) {
+                memories.push(m);
+            }
+        }
+    }
+    // Session-level dedupe (what this agent was already shown), then the memory-surface projection.
+    memories.retain(|m| !dedupe.memory_ids.contains(&m.memory_id));
+    memory::apply_memory_surface(conn, &mut memories, surface)?;
+
+    // Symbol lane items, minus anything this session already saw (shared key with grep-augment).
+    let symbol_items: Vec<RenderItem> = ranked
+        .iter()
+        .map(|(hit, callers, callees)| symbol_render_item(conn, hit, *callers, *callees))
+        .collect::<anyhow::Result<Vec<_>>>()?
+        .into_iter()
+        .filter(|item| item.symbol_key.as_ref().is_none_or(|k| !dedupe.symbol_keys.contains(k)))
+        .collect();
+
+    if memories.is_empty() && symbol_items.is_empty() {
+        return Ok(None);
+    }
+
+    let mut sections: Vec<Section> = Vec::new();
+    if !memories.is_empty() {
+        sections.push(Section {
+            header: "**Repo memories bound to this file:**".to_string(),
+            items: memories.into_iter().map(grep_augment::memory_render_item).collect(),
+            footer: None,
+        });
+    }
+    if !symbol_items.is_empty() {
+        sections.push(Section {
+            header: "**Load-bearing symbols in this file:**".to_string(),
+            items: symbol_items,
+            footer: Some("(rag-rat: impact_surface <name> before editing)".to_string()),
+        });
+    }
+    Ok(Some(grep_augment::pack_sections("rag-rat index context for this file:", sections)))
+}
+
+/// The file's symbols ranked by caller fan-in, top [`MAX_FILE_SYMBOLS`], callers > 0 only. Reuses
+/// grep-augment's exact `edge_counts` (both caller arms, index-driven) so the counts shown here
+/// agree with `impact_surface`; a symbol with no in-repo callers is not "load-bearing" and is
+/// dropped rather than shown as a zero.
+fn rank_file_symbols(
+    conn: &Connection,
+    path: &str,
+) -> anyhow::Result<Vec<(symbol::SymbolHit, i64, i64)>> {
+    let mut ranked = Vec::new();
+    for id in symbol::symbol_ids_in_file(conn, path, CANDIDATE_CAP)? {
+        let Some(hit) = symbol::lookup_by_id(conn, id)? else { continue };
+        let (callers, callees) = grep_augment::edge_counts(conn, &hit)?;
+        if callers > 0 {
+            ranked.push((hit, callers, callees));
+        }
+    }
+    // Most-depended-on first; a stable tie-break on the qualified name keeps output deterministic.
+    ranked.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.qualified_name.cmp(&b.0.qualified_name)));
+    ranked.truncate(MAX_FILE_SYMBOLS);
+    Ok(ranked)
+}
+
+/// Render one load-bearing-symbol line: `- \`name\` (kind) at line L — C callers / C callees —
+/// \`sig\``. The symbol key matches grep-augment's (`path:qualified_name`) so a symbol surfaced via
+/// a read and a grep dedups against one shared session filter.
+fn symbol_render_item(
+    conn: &Connection,
+    hit: &symbol::SymbolHit,
+    callers: i64,
+    callees: i64,
+) -> anyhow::Result<RenderItem> {
+    let line_suffix = match grep_augment::line_for_symbol(conn, hit)? {
+        Some(l) => format!(" at line {l}"),
+        None => String::new(),
+    };
+    let sig = hit.signature.as_deref().map(|s| format!(" — `{s}`")).unwrap_or_default();
+    let line = format!(
+        "- `{}` ({}){} — {} callers / {} callees{}",
+        hit.qualified_name, hit.kind, line_suffix, callers, callees, sig,
+    );
+    Ok(RenderItem {
+        line,
+        memory_id: None,
+        symbol_key: Some(format!("{}:{}", hit.path, hit.qualified_name)),
+    })
+}
+
+/// The immediate parent directory of a root-relative file path, or `None` for a top-level file (no
+/// `/`). Directory memories are bound to the directory path, so this is the key to look them up by.
+fn parent_dir(path: &str) -> Option<&str> {
+    path.rfind('/').map(|i| &path[..i])
+}
+
+#[cfg(test)]
+mod tests {
+    use rag_rat_db::schema;
+    use rag_rat_query::memory::{RepoMemoryBindTarget, RepoMemoryCreate};
+    use rusqlite::Connection;
+
+    use super::*;
+
+    #[test]
+    fn parent_dir_is_the_immediate_directory_or_none_at_top_level() {
+        assert_eq!(
+            parent_dir("crates/rag-rat-core/src/query/read_augment.rs"),
+            Some("crates/rag-rat-core/src/query")
+        );
+        assert_eq!(parent_dir("README.md"), None);
+        assert_eq!(parent_dir("src/lib.rs"), Some("src"));
+    }
+
+    fn empty_bind() -> RepoMemoryBindTarget {
+        RepoMemoryBindTarget {
+            symbol_id: None,
+            logical_symbol_id: None,
+            chunk_id: None,
+            edge_id: None,
+            path: None,
+            start_line: None,
+            end_line: None,
+            commit_hash: None,
+            tracker: None,
+            project: None,
+            item_key: None,
+            start_logical_symbol_id: None,
+            end_logical_symbol_id: None,
+            edge_sequence_hash: None,
+            path_summary: None,
+            edge_path: None,
+            dir: None,
+        }
+    }
+
+    fn create(conn: &Connection, title: &str, target: RepoMemoryBindTarget) {
+        crate::memory_write::create_memory(conn, RepoMemoryCreate {
+            kind: "Invariant".to_string(),
+            title: title.to_string(),
+            body: format!("body of {title}"),
+            confidence: "high".to_string(),
+            created_by: Some("test".to_string()),
+            source: None,
+            tags: vec![],
+            payload_json: None,
+            bind: target,
+        })
+        .unwrap();
+    }
+
+    /// A file `src/watch.rs` with a load-bearing `watcher_main` (id 1, one caller) and a leaf
+    /// `helper` (id 2, no callers), a path-bound memory, and a directory memory on `src`.
+    fn seeded_conn() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        schema::apply(&conn, &crate::index::migration_hooks()).unwrap();
+        conn.execute(
+            "INSERT INTO files(path, language, kind, sha256, modified_at_ms, indexed_at_ms)
+             VALUES ('src/watch.rs', 'rust', 'source', 'abc', 0, 0)",
+            [],
+        )
+        .unwrap();
+        for (name, qn) in [("watcher_main", "watch::watcher_main"), ("helper", "watch::helper")] {
+            conn.execute(
+                "INSERT OR IGNORE INTO name_strings(value) VALUES (?1)",
+                rusqlite::params![qn],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO symbols(file_id, language, name, qualified_name_id, kind, start_byte,
+                                     end_byte, signature, docs)
+                 VALUES (1, 'rust', ?1, (SELECT id FROM name_strings WHERE value = ?2),
+                         'function', 0, 10, NULL, NULL)",
+                rusqlite::params![name, qn],
+            )
+            .unwrap();
+        }
+        // One caller of watcher_main (symbol id 1) → callers=1; helper (id 2) has none.
+        conn.execute(
+            "INSERT INTO edges(source_file_id, from_symbol_id, to_symbol_id, to_name,
+                               target_qualified_name, edge_kind, confidence)
+             VALUES (1, NULL, 1, 'watcher_main', 'watch::watcher_main', 'calls_name', 'exact')",
+            [],
+        )
+        .unwrap();
+        create(&conn, "Watch invariant", RepoMemoryBindTarget {
+            path: Some("src/watch.rs".to_string()),
+            ..empty_bind()
+        });
+        create(&conn, "Src directory note", RepoMemoryBindTarget {
+            dir: Some("src".to_string()),
+            ..empty_bind()
+        });
+        conn
+    }
+
+    #[test]
+    fn read_augment_surfaces_file_and_dir_memories_plus_load_bearing_symbols() {
+        let conn = seeded_conn();
+        let out = compose(
+            &conn,
+            "src/watch.rs",
+            &DedupeFilter::default(),
+            rag_rat_base::config::MemorySurface::Full,
+        )
+        .unwrap()
+        .expect("a file with memories + a load-bearing symbol augments");
+
+        assert!(
+            out.context.contains("Watch invariant"),
+            "path-bound memory surfaces:\n{}",
+            out.context
+        );
+        assert!(
+            out.context.contains("Src directory note"),
+            "directory memory surfaces:\n{}",
+            out.context
+        );
+        assert!(
+            out.context.contains("`watch::watcher_main`") && out.context.contains("1 callers"),
+            "the load-bearing symbol surfaces with its caller count:\n{}",
+            out.context
+        );
+        assert!(
+            !out.context.contains("watch::helper"),
+            "a symbol with no callers is not load-bearing and is omitted:\n{}",
+            out.context
+        );
+    }
+
+    #[test]
+    fn read_augment_dedups_against_the_session_filter() {
+        let conn = seeded_conn();
+        // First surface records ids; feed them back as the dedupe filter — nothing new remains.
+        let first = compose(
+            &conn,
+            "src/watch.rs",
+            &DedupeFilter::default(),
+            rag_rat_base::config::MemorySurface::Full,
+        )
+        .unwrap()
+        .expect("first surface augments");
+        let filter = DedupeFilter {
+            memory_ids: first.memory_ids.iter().cloned().collect(),
+            symbol_keys: first.symbol_keys.iter().cloned().collect(),
+        };
+        let second =
+            compose(&conn, "src/watch.rs", &filter, rag_rat_base::config::MemorySurface::Full)
+                .unwrap();
+        assert!(
+            second.is_none(),
+            "everything already surfaced this session → nothing new to inject"
+        );
+    }
+
+    #[test]
+    fn read_augment_is_silent_for_a_file_with_nothing_indexed() {
+        let conn = seeded_conn();
+        // A file in a directory with no memory of its own — no path/dir memory, no indexed symbols.
+        // (`src/…` would still pick up the `src` directory memory, which is the feature working.)
+        let out = compose(
+            &conn,
+            "docs/unknown.md",
+            &DedupeFilter::default(),
+            rag_rat_base::config::MemorySurface::Full,
+        )
+        .unwrap();
+        assert!(out.is_none(), "a file with no memories and no symbols yields no context");
+    }
+}

--- a/crates/rag-rat-core/src/query/read_augment.rs
+++ b/crates/rag-rat-core/src/query/read_augment.rs
@@ -56,11 +56,9 @@ pub fn compose(
             memories.push(m);
         }
     }
-    if let Some(dir) = parent_dir(path) {
-        for m in memory::memories_for_path(conn, dir, MAX_MEMORIES)? {
-            if seen.insert(m.memory_id.clone()) {
-                memories.push(m);
-            }
+    for m in memory::memories_for_path(conn, parent_dir(path), MAX_MEMORIES)? {
+        if seen.insert(m.memory_id.clone()) {
+            memories.push(m);
         }
     }
     // Session-level dedupe (what this agent was already shown), then the memory-surface projection.
@@ -107,8 +105,17 @@ fn rank_file_symbols(
     path: &str,
 ) -> anyhow::Result<Vec<(symbol::SymbolHit, i64, i64)>> {
     let mut ranked = Vec::new();
+    // Dedup by qualified name: a file can hold many concrete rows for one logical symbol —
+    // overloads, cfg variants, re-exports, or Python's per-class `__init__` (thousands in one
+    // dummy-objects file) — and without this the three slots fill with repeats of one symbol,
+    // hiding the rest (#756 review; the same defect grep-augment dedups). All rows here share
+    // the queried path, so the qualified name alone keys the logical symbol.
+    let mut seen: HashSet<String> = HashSet::new();
     for id in symbol::symbol_ids_in_file(conn, path, CANDIDATE_CAP)? {
         let Some(hit) = symbol::lookup_by_id(conn, id)? else { continue };
+        if !seen.insert(hit.qualified_name.clone()) {
+            continue;
+        }
         let (callers, callees) = grep_augment::edge_counts(conn, &hit)?;
         if callers > 0 {
             ranked.push((hit, callers, callees));
@@ -145,10 +152,14 @@ fn symbol_render_item(
     })
 }
 
-/// The immediate parent directory of a root-relative file path, or `None` for a top-level file (no
-/// `/`). Directory memories are bound to the directory path, so this is the key to look them up by.
-fn parent_dir(path: &str) -> Option<&str> {
-    path.rfind('/').map(|i| &path[..i])
+/// The immediate parent directory of a root-relative file path, to look up its directory memories.
+/// A top-level file's directory is the REPO ROOT, anchored as the empty path — the memory API's
+/// `dir = ""` repo-root binding — so return `""` there rather than skipping it (#756 review).
+fn parent_dir(path: &str) -> &str {
+    match path.rfind('/') {
+        Some(i) => &path[..i],
+        None => "",
+    }
 }
 
 #[cfg(test)]
@@ -160,13 +171,14 @@ mod tests {
     use super::*;
 
     #[test]
-    fn parent_dir_is_the_immediate_directory_or_none_at_top_level() {
+    fn parent_dir_is_the_immediate_directory_or_the_repo_root_at_top_level() {
         assert_eq!(
             parent_dir("crates/rag-rat-core/src/query/read_augment.rs"),
-            Some("crates/rag-rat-core/src/query")
+            "crates/rag-rat-core/src/query"
         );
-        assert_eq!(parent_dir("README.md"), None);
-        assert_eq!(parent_dir("src/lib.rs"), Some("src"));
+        // A top-level file's directory is the repo root, keyed as the empty path.
+        assert_eq!(parent_dir("README.md"), "");
+        assert_eq!(parent_dir("src/lib.rs"), "src");
     }
 
     fn empty_bind() -> RepoMemoryBindTarget {
@@ -232,6 +244,17 @@ mod tests {
             )
             .unwrap();
         }
+        // A SECOND concrete row for the SAME `watch::watcher_main` (a re-export/overload). The
+        // ranker must fold it into one line, not spend two slots on it.
+        conn.execute(
+            "INSERT INTO symbols(file_id, language, name, qualified_name_id, kind, start_byte,
+                                 end_byte, signature, docs)
+             VALUES (1, 'rust', 'watcher_main',
+                     (SELECT id FROM name_strings WHERE value = 'watch::watcher_main'),
+                     'function', 20, 30, NULL, NULL)",
+            [],
+        )
+        .unwrap();
         // One caller of watcher_main (symbol id 1) → callers=1; helper (id 2) has none.
         conn.execute(
             "INSERT INTO edges(source_file_id, from_symbol_id, to_symbol_id, to_name,
@@ -246,6 +269,11 @@ mod tests {
         });
         create(&conn, "Src directory note", RepoMemoryBindTarget {
             dir: Some("src".to_string()),
+            ..empty_bind()
+        });
+        // A repo-root directory memory (`dir = ""`), surfaced only for TOP-LEVEL reads.
+        create(&conn, "Repo root note", RepoMemoryBindTarget {
+            dir: Some(String::new()),
             ..empty_bind()
         });
         conn
@@ -283,6 +311,33 @@ mod tests {
             "a symbol with no callers is not load-bearing and is omitted:\n{}",
             out.context
         );
+        assert_eq!(
+            out.context.matches("`watch::watcher_main`").count(),
+            1,
+            "duplicate concrete rows of one symbol render once, not once per row:\n{}",
+            out.context
+        );
+    }
+
+    #[test]
+    fn read_augment_surfaces_the_repo_root_directory_memory_for_a_top_level_file() {
+        let conn = seeded_conn();
+        // A top-level file's directory is the repo root (`dir = ""`) — that memory must surface.
+        let out = compose(
+            &conn,
+            "README.md",
+            &DedupeFilter::default(),
+            rag_rat_base::config::MemorySurface::Full,
+        )
+        .unwrap()
+        .expect("a top-level file with a repo-root directory memory augments");
+        assert!(
+            out.context.contains("Repo root note"),
+            "the repo-root (dir = \"\") memory surfaces for a top-level read:\n{}",
+            out.context
+        );
+        // The `src` directory memory must NOT leak into a top-level read.
+        assert!(!out.context.contains("Src directory note"), "src-dir memory stays scoped to src/");
     }
 
     #[test]

--- a/crates/rag-rat-mcp/src/agent_hook.rs
+++ b/crates/rag-rat-mcp/src/agent_hook.rs
@@ -7,16 +7,23 @@ use serde::{Deserialize, Serialize};
 
 pub const PROTOCOL_VERSION: u32 = 1;
 
-/// One grep-augment query from a hook client. Unknown fields are ignored (forward compat);
-/// unknown `v`/`kind` get a null-context reply rather than an error.
+/// One augmentation query from a hook client. `kind` selects the lane: `"grep_augment"` uses
+/// `pattern` (+ `search_path`), `"read_augment"` uses `path` (#756). Unknown fields are ignored
+/// (forward compat); unknown `v`/`kind` get a null-context reply rather than an error.
 #[derive(Debug, Deserialize)]
 pub struct HookRequest {
     pub v: u32,
     pub kind: String,
     pub session_id: String,
+    /// The grep pattern (`grep_augment` only). Defaulted so a `read_augment` request without it
+    /// still deserializes.
+    #[serde(default)]
     pub pattern: String,
     #[serde(default)]
     pub search_path: Option<String>,
+    /// The root-relative file path being read (`read_augment` only).
+    #[serde(default)]
+    pub path: Option<String>,
     #[serde(default)]
     pub source: String,
     /// The session's working directory, so the listener scopes the augmentation to that worktree's
@@ -29,6 +36,13 @@ pub struct HookRequest {
 pub struct HookResponse {
     pub v: u32,
     pub context: Option<String>,
+    /// The request `kind` this listener actually HANDLED, echoed so a newer client can tell a
+    /// genuine "nothing new to inject" (`context: null`, `kind: Some(...)`) from an OLDER listener
+    /// that didn't understand the kind and fell through to the null catch-all (`kind: None`). The
+    /// latter must trigger the client's direct fallback instead of silently disabling the feature
+    /// across a hot upgrade (#756 review). Absent on the unknown-kind / malformed reply.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
 }
 
 #[cfg(unix)]
@@ -218,7 +232,10 @@ mod listener {
             }, // propagate real I/O errors as before
         }
         let reply = match serde_json::from_str::<HookRequest>(&line) {
-            Ok(req) if req.v == PROTOCOL_VERSION && req.kind == "grep_augment" => {
+            Ok(req)
+                if req.v == PROTOCOL_VERSION
+                    && matches!(req.kind.as_str(), "grep_augment" | "read_augment") =>
+            {
                 let filter = {
                     let state = sessions.entry(req.session_id.clone()).or_default();
                     state.last_used = Some(Instant::now());
@@ -234,8 +251,13 @@ mod listener {
                 // prior lack of ANY scope install: compose queries the `files` view, so without
                 // this it read raw, unscoped rows.
                 let cwd = req.cwd.clone().map(PathBuf::from).unwrap_or_else(|| config_root.clone());
+                let kind = req.kind.clone();
+                // Echoed on the reply so a newer client can distinguish "handled, nothing new" from
+                // an older listener's unknown-kind null (#756 review).
+                let handled_kind = req.kind.clone();
                 let pattern = req.pattern.clone();
                 let search_path = req.search_path.clone();
+                let read_path = req.path.clone();
                 // rusqlite is sync; one short read off the runtime threads.
                 let composed = tokio::task::spawn_blocking(move || {
                     let conn = IndexConnection::open_read_only(&database)?;
@@ -255,13 +277,25 @@ mod listener {
                         &config_root,
                         &cwd,
                     )?;
-                    grep_augment::compose(
-                        conn.connection(),
-                        &pattern,
-                        search_path.as_deref(),
-                        &filter,
-                        memory_surface,
-                    )
+                    match kind.as_str() {
+                        // read_augment with no path resolves to nothing to inject.
+                        "read_augment" => match read_path.as_deref() {
+                            Some(path) => rag_rat_core::query::read_augment::compose(
+                                conn.connection(),
+                                path,
+                                &filter,
+                                memory_surface,
+                            ),
+                            None => Ok(None),
+                        },
+                        _ => grep_augment::compose(
+                            conn.connection(),
+                            &pattern,
+                            search_path.as_deref(),
+                            &filter,
+                            memory_surface,
+                        ),
+                    }
                 })
                 .await?;
                 let composed = super::degrade_when_fts_corrupt(composed, || {
@@ -274,13 +308,23 @@ mod listener {
                         let state = sessions.entry(req.session_id).or_default();
                         state.filter.memory_ids.extend(out.memory_ids.iter().cloned());
                         state.filter.symbol_keys.extend(out.symbol_keys.iter().cloned());
-                        HookResponse { v: PROTOCOL_VERSION, context: Some(out.context) }
+                        HookResponse {
+                            v: PROTOCOL_VERSION,
+                            context: Some(out.context),
+                            kind: Some(handled_kind),
+                        }
                     },
-                    None => HookResponse { v: PROTOCOL_VERSION, context: None },
+                    None => HookResponse {
+                        v: PROTOCOL_VERSION,
+                        context: None,
+                        kind: Some(handled_kind),
+                    },
                 }
             },
-            // Unknown v/kind or malformed JSON: answer null-context, never error back.
-            _ => HookResponse { v: PROTOCOL_VERSION, context: None },
+            // Unknown v/kind or malformed JSON: answer null-context with NO handled `kind`, never
+            // error back. The absent `kind` tells a newer client this listener didn't handle the
+            // request so it should fall back (#756 review).
+            _ => HookResponse { v: PROTOCOL_VERSION, context: None, kind: None },
         };
         let mut payload = serde_json::to_string(&reply)?;
         payload.push('\n');
@@ -345,6 +389,16 @@ mod listener_tests {
                 [],
             )
             .unwrap();
+        // One caller of frobnicate (symbol id 1), so it ranks as load-bearing for the read-augment
+        // lane. Harmless to the grep test, which only asserts the symbol name is present.
+        rw.connection()
+            .execute(
+                "INSERT INTO edges(source_file_id, from_symbol_id, to_symbol_id, to_name,
+                                   target_qualified_name, edge_kind, confidence)
+                 VALUES (1, NULL, 1, 'frobnicate', 'lib::frobnicate', 'calls_name', 'exact')",
+                [],
+            )
+            .unwrap();
         // No rebuild_fts here: external-content FTS5 rebuilds corrupt when out of sync with
         // direct seeding, and the symbol lane needs no FTS rows.
         config
@@ -386,6 +440,48 @@ mod listener_tests {
         );
         let bad = request(&socket, serde_json::json!({"v": 99, "kind": "nope"})).await;
         assert!(bad["context"].is_null(), "unknown version answered, not errored");
+        assert!(
+            bad.get("kind").map(|k| k.is_null()).unwrap_or(true),
+            "an unhandled request echoes NO kind, so a newer client falls back (#756): {bad}",
+        );
+    }
+
+    /// #756: a `read_augment` request for a file surfaces its load-bearing symbols (here
+    /// `frobnicate`, which has a caller), and dedups per session like grep-augment does.
+    #[tokio::test]
+    async fn listener_serves_read_augment_and_dedupes_per_session() {
+        let config = test_config();
+        let _listener = spawn_listener(config.clone());
+        let socket = socket_path_for(&config);
+        let deadline = std::time::Instant::now() + Duration::from_secs(10);
+        while !socket.exists() && std::time::Instant::now() < deadline {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        let req = |sid: &str| {
+            serde_json::json!({"v": 1, "kind": "read_augment", "session_id": sid,
+                               "path": "src/lib.rs"})
+        };
+        let first = request(&socket, req("r1")).await;
+        assert!(
+            first["context"].as_str().unwrap().contains("lib::frobnicate"),
+            "read-augment surfaces the file's load-bearing symbol: {first}",
+        );
+        assert_eq!(
+            first["kind"], "read_augment",
+            "the reply echoes the handled kind so a newer client trusts it (#756): {first}",
+        );
+        let second = request(&socket, req("r1")).await;
+        assert!(second["context"].is_null(), "same session deduped");
+        assert_eq!(
+            second["kind"], "read_augment",
+            "a genuine dedup-null still echoes the kind, so the client does NOT spuriously fall \
+             back",
+        );
+        let other = request(&socket, req("r2")).await;
+        assert!(
+            other["context"].as_str().unwrap().contains("lib::frobnicate"),
+            "a fresh session is not deduped",
+        );
     }
 
     #[tokio::test]
@@ -525,7 +621,15 @@ mod tests {
 
     #[test]
     fn response_serializes_null_context_explicitly() {
-        let resp = HookResponse { v: 1, context: None };
+        // An unhandled reply (no kind) serializes without the field — the wire shape older clients
+        // parse is unchanged; the `kind` echo is purely additive.
+        let resp = HookResponse { v: 1, context: None, kind: None };
         assert_eq!(serde_json::to_string(&resp).unwrap(), r#"{"v":1,"context":null}"#);
+        // A handled reply carries the echoed kind.
+        let handled = HookResponse { v: 1, context: None, kind: Some("read_augment".to_string()) };
+        assert_eq!(
+            serde_json::to_string(&handled).unwrap(),
+            r#"{"v":1,"context":null,"kind":"read_augment"}"#,
+        );
     }
 }

--- a/crates/rag-rat-query/src/symbol.rs
+++ b/crates/rag-rat-query/src/symbol.rs
@@ -231,6 +231,26 @@ pub fn lookup_by_id(conn: &Connection, symbol_id: i64) -> anyhow::Result<Option<
     Ok(hit)
 }
 
+/// Symbol ids DEFINED in `path`, in source order, capped at `limit`. Scoped to the active checkout
+/// via the `files` view. The read-augmentation hook ranks these by caller fan-in to surface the
+/// load-bearing symbols in a file being opened; source order + the cap bound the candidate set so a
+/// large file can't make the per-symbol count sweep unbounded (a symbol past the cap is simply not
+/// considered — a hint, not an authority).
+pub fn symbol_ids_in_file(conn: &Connection, path: &str, limit: u32) -> anyhow::Result<Vec<i64>> {
+    let mut stmt = conn.prepare(
+        "SELECT symbols.id
+         FROM symbols
+         JOIN files ON files.id = symbols.file_id
+         WHERE files.path = ?1
+         ORDER BY symbols.start_byte ASC
+         LIMIT ?2",
+    )?;
+    let ids = stmt
+        .query_map(params![path, i64::from(limit)], |row| row.get::<_, i64>(0))?
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(ids)
+}
+
 fn candidates_for_selector(
     conn: &Connection,
     selector: &SymbolSelector,

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -8,6 +8,12 @@
         ]
       },
       {
+        "matcher": "Read",
+        "hooks": [
+          { "type": "command", "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/launch.js\" --no-install agent-hook", "timeout": 10 }
+        ]
+      },
+      {
         "matcher": "Bash",
         "hooks": [
           { "type": "command", "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/launch.js\" --no-install agent-hook", "timeout": 10 }


### PR DESCRIPTION
Closes #756. First of the augmentation-hook improvements (siblings: #757 warm semantic lane, #758 mid-grep staleness note, #759 unified dedup window).

## Problem

The PreToolUse augmentation fired on `Grep`/`Bash` (grep-augment) and the edit tools (clone-check), but **not on `Read`** — the most common "understand this before I touch it" moment, and exactly where drive-by repo memories matter most. Until now an agent only saw a path/directory memory for a file if it *greped* in it or called an MCP tool explicitly; most file opens go through `Read`, so most of the memory layer never reached the agent at the point of use.

## What it does

A PreToolUse `Read` matcher composes, for the opened file:

- **Memory lane** — the repo memories bound to the file and to its directory, plus memories on the file's load-bearing symbols.
- **Symbol lane** — the load-bearing symbols *defined* in the file, ranked by caller fan-in, with caller/callee counts.

Wired exactly like grep-augment: the warm socket listener (per-session dedup) with a stateless read-only fallback. The two hooks now share one renderer, dedup filter, and per-symbol helpers (extracted `pub(crate)` from `grep_augment`), so their output stays consistent and a symbol/memory surfaced by a read and a grep dedups against one session filter. Ranking uses a **bounded per-symbol caller count** (capped candidate set), not whole-graph PageRank, to stay cheap on every `Read`; like grep-augment it never loads the embedder.

### Real-index output

Reading `crates/rag-rat-core/src/index/mod.rs`:
```
**Load-bearing symbols in this file:**
- `…::IndexDatabase` (struct) at line 91 — 1749 callers / 26 callees — `pub struct IndexDatabase {`
- `…::migration_hooks` (function) at line 54 — 281 callers / 4 callees — …
- `…::IndexFile` (struct) at line 379 — 31 callers / 7 callees — …
```
Reading `crates/rag-rat-mcp/src/server.rs` surfaces its bound `Decision`/`Risk` memories.

## Cross-cutting correctness (from review)

- **Version-skew guard.** The listener now echoes the handled request `kind`. A pre-existing listener that doesn't understand `read_augment` returns a null context with no `kind`, which the new client treats as "unsupported" and falls back — instead of the null being read as "handled, nothing new" and silently disabling the feature until the MCP server restarts. grep-augment predates the echo and still trusts any v1 reply.
- **Linked-worktree paths.** `Config::load` anchors `config.root` to the main worktree, but a linked-worktree `Read` targets a file under the linked root. Reads are relativized against the **session** worktree root (nearest `rag-rat.toml`'s directory), and the relative path is component-joined with `/` so it matches the index's slash-separated keys on every OS.

## Tests

- `read_augment`: file + directory memories and load-bearing symbols surface; a zero-caller symbol is omitted; session dedup; silence when nothing is indexed.
- `symbol_ids_in_file`; `worktree_rel_path` (linked-root relativization + slash-join + outside-worktree → None).
- listener: a `read_augment` round-trip surfaces + dedups per session, echoes the handled `kind`, and an unhandled request echoes no `kind` (so a newer client falls back).
- Full workspace green (3165 tests); all four CI clippy gates + nightly fmt clean. Verified end-to-end against the real index in a linked worktree, including the fallback past a stale listener.

A Codex review flag about querying a `repo_memory_bindings.dir` column was investigated and is a false positive — dir bindings store the directory in the `path` column, which `memories_for_path` matches (confirmed against the schema and the passing dir-memory test).