### PR TITLE
feat(oplog): lazy content-key rotation on device removal

### DIFF
--- a/crates/rag-rat-oplog/src/account/mod.rs
+++ b/crates/rag-rat-oplog/src/account/mod.rs
@@ -63,11 +63,13 @@ pub use id::AccountId;
 // payload C5's seal path consumes; `KeyId` is the selection identity (#607).
 pub use keywrap::{ContentKey, KeyId};
 pub use ops::{DeviceCut, DeviceRole, GrantRole};
-// The in-tx content-key mint + owner-gated `StreamKeyWrap` author seam (C4.3a) plus the C4.3b
-// READ side — derive-on-read sealing-key selection + the key_id adoption cross-check (#607).
+// The in-tx content-key mint + owner-gated `StreamKeyWrap` author seam (C4.3a), the C4.3b READ
+// side (derive-on-read sealing-key selection + the key_id adoption cross-check), and the C4.4
+// lazy rotation-on-removal entry points (#607).
 pub use secrets::{
-    SealingKeyOutcome, SelectedWrap, current_sealing_key, mint_and_author_stream_key_wrap_in_tx,
-    select_current_sealing_wrap,
+    RotationOutcome, SealingKeyOutcome, SelectedWrap, current_sealing_key,
+    ensure_stream_key_current_in_tx, mint_and_author_stream_key_wrap_in_tx,
+    rotate_stream_key_in_tx, select_current_sealing_wrap, stream_key_rotation_needed,
 };
 pub use storage::{
     CapacityScope, IngestOutcome, account_ingest, auth_len_freshness,

--- a/crates/rag-rat-oplog/src/account/secrets/author.rs
+++ b/crates/rag-rat-oplog/src/account/secrets/author.rs
@@ -8,6 +8,15 @@
 //! nothing consumes the key for content SEALING yet (that is C5), and the `key_id` adoption
 //! cross-check + the derived sealing-key projection + `sync enable` are C4.3b.
 //!
+//! C4.4 (#607) adds LAZY rotation on device removal: [`rotate_stream_key_in_tx`] mints a fresh key
+//! at a HIGHER epoch re-sealed only to the remaining effective devices — rotation is exactly a mint
+//! whose SOLE delta from the initial one is the epoch, so it reuses
+//! [`author_stream_key_wrap_in_tx`] unchanged. [`ensure_stream_key_current_in_tx`] is the lazy
+//! trigger the seal path calls: it rotates only when a removed device still holds the current key,
+//! and returns a typed [`RotationOutcome`] (never an error) so a MEMBER device — which cannot
+//! author a rotation but may legitimately seal — does not roll its seal txn back. Nothing calls the
+//! C4.4 entry points yet (machinery one slice ahead of its consumer).
+//!
 //! Three load-bearing invariants the fold alone does NOT enforce:
 //!
 //! - **The secrets chain is `(account, device)`-scoped across ALL streams, never per-stream.**
@@ -64,6 +73,108 @@ pub fn mint_and_author_stream_key_wrap_in_tx(
 ) -> anyhow::Result<EntryHash> {
     let key = ContentKey::generate()?;
     author_stream_key_wrap_in_tx(tx, stream_id, &key, INITIAL_KEY_EPOCH, now_ms)
+}
+
+/// The outcome of [`ensure_stream_key_current_in_tx`]. Every variant is a NON-error signal: `Err`
+/// from the ensure/rotate path is reserved for infra/DB failures, never a policy outcome (a member
+/// legitimately can't rotate, and that must not roll back a seal txn).
+#[derive(Debug)]
+pub enum RotationOutcome {
+    /// Rotation was needed and this (owner) device authored a fresh higher-epoch `StreamKeyWrap`.
+    Rotated(EntryHash),
+    /// No rotation needed — every recipient of the current wrap is still roster-effective (or the
+    /// stream has no current wrap at all, so there is nothing to rotate).
+    Current,
+    /// Rotation IS needed but this device holds no live owner incarnation, so it cannot author one.
+    /// A member device still seals under the CURRENT key — roster membership is READ access, not
+    /// authoring authority — so the caller must proceed with the seal, NOT fail it. (An additive
+    /// `CatchUp` arm belongs here when new-device catch-up ships.)
+    StaleButNotOwner,
+}
+
+/// Rotate `stream_id`'s content key: mint a FRESH key at `current_max_accepted_epoch + 1` and
+/// author it sealed to the roster-EFFECTIVE devices, WITHIN the caller's transaction
+/// (verify-accepted-or- rollback). Returns the authored entry hash. Neither opens nor commits the
+/// txn.
+///
+/// Rotation is a mint whose ONLY delta from the initial one is the epoch: recipients (which now
+/// EXCLUDE the removed device), the owner-only `authority_ref`, the self-unwrap round-trip, and
+/// verify-accepted all carry from [`author_stream_key_wrap_in_tx`] unchanged. It does NOT cite the
+/// triggering `DeviceRemove` — lazy rotation is local policy, not a chained authority act.
+///
+/// Errors if the stream has NO prior accepted wrap (nothing to rotate; the seal path mints an
+/// initial key via `current_sealing_key` → `NoCurrentKey` instead), or if the local device is not a
+/// current owner (the inherited owner-only gate bails). [`ensure_stream_key_current_in_tx`] never
+/// reaches either error — it returns `Current`/`StaleButNotOwner` first.
+pub fn rotate_stream_key_in_tx(
+    tx: &Transaction<'_>,
+    stream_id: StreamId,
+    now_ms: i64,
+) -> anyhow::Result<EntryHash> {
+    let account_id = bootstrap::local_account_ref(tx)?
+        .context(
+            "cannot rotate a StreamKeyWrap before the store's local account is minted (call \
+             local_account first)",
+        )?
+        .account_id;
+
+    // Epoch = accepted_max + 1 over EFFECTIVE ACCEPTED wraps only. `select_current_sealing_wrap`
+    // reads `accepted = 1` rows, so condemned wraps never feed the max — this is deliberate: taking
+    // the max over condemned wraps would let a removed owner author epoch `u64::MAX` (→ condemned)
+    // and DoS every future rotation by forcing the overflow error below.
+    let current = super::sealing::select_current_sealing_wrap(tx, account_id, stream_id)?.context(
+        "cannot rotate a stream with no prior accepted StreamKeyWrap (nothing to rotate)",
+    )?;
+    // `checked_add`: ERROR at `u64::MAX`, never wrap. A wrap-to-0 would silently lose the max-epoch
+    // selection and regress sealing to an old key — a confidentiality footgun. Re-stamping a
+    // numeric epoch that a condemned wrap once used is fine and deliberate (the condemned wrap
+    // is gone from the accepted set); we add NO high-water mark (sticky local state would
+    // diverge derive-on-read).
+    let next_epoch = current
+        .key_epoch
+        .checked_add(1)
+        .context("stream key epoch is at u64::MAX; cannot rotate")?;
+
+    let key = ContentKey::generate()?;
+    author_stream_key_wrap_in_tx(tx, stream_id, &key, next_epoch, now_ms)
+}
+
+/// The lazy rotation trigger the seal path (and a future CLI) calls before sealing `stream_id`:
+/// rotate the content key IF a removed device still holds the current key, otherwise noop. Returns
+/// a typed [`RotationOutcome`], never an error for a policy reason.
+///
+/// The rotation-NEEDED test ([`super::sealing::stream_key_rotation_needed`]) is device-independent
+/// (current-wrap recipients vs the roster). The owner gate is checked HERE, BEFORE calling
+/// [`rotate_stream_key_in_tx`]: a non-owner would make `rotate` bail (→ `Err` → the caller's seal
+/// txn rolls back), which a member's legitimate seal must not suffer — so a member sees
+/// `StaleButNotOwner` and seals under the current key instead.
+pub fn ensure_stream_key_current_in_tx(
+    tx: &Transaction<'_>,
+    stream_id: StreamId,
+    now_ms: i64,
+) -> anyhow::Result<RotationOutcome> {
+    let account_id = bootstrap::local_account_ref(tx)?
+        .context(
+            "cannot ensure a stream key is current before the store's local account is minted",
+        )?
+        .account_id;
+
+    if !super::sealing::stream_key_rotation_needed(tx, account_id, stream_id)? {
+        return Ok(RotationOutcome::Current);
+    }
+
+    // Rotation is needed — but only a current owner can author one. Gate on the live owner
+    // incarnation (exactly what `rotate` → `author_stream_key_wrap_in_tx` would require) so a
+    // member returns `StaleButNotOwner` rather than triggering a rollback-inducing `bail!` in
+    // `rotate`.
+    let device = local_device(tx, now_ms)?;
+    if storage::effective_owner_incarnation_for_device(tx, account_id, device.fingerprint())?
+        .is_none()
+    {
+        return Ok(RotationOutcome::StaleButNotOwner);
+    }
+
+    Ok(RotationOutcome::Rotated(rotate_stream_key_in_tx(tx, stream_id, now_ms)?))
 }
 
 /// The mint core with the content key and epoch injected, so a test can pin the key
@@ -240,6 +351,7 @@ mod tests {
     use crate::account::secrets::ops::{
         DecodedSecretsOp, decode, entry_type as secrets_entry_type,
     };
+    use crate::account::{select_current_sealing_wrap, stream_key_rotation_needed};
     use crate::device::DeviceX25519Secret;
 
     const NOW: i64 = 1_700_000_000_000;
@@ -592,6 +704,311 @@ mod tests {
             )
             .unwrap();
         assert_eq!(secrets_rows, 0, "the rolled-back mint stored no secrets entry");
+    }
+
+    // ── C4.4: lazy rotation on device removal ──
+
+    #[test]
+    fn removing_a_recipient_makes_rotation_needed_and_rotate_reseals_to_survivors() {
+        // The primary behavioral path, THROUGH THE REAL MINT SEAM (a hand-rolled wrap that omits
+        // self would mask that the predicate's soundness rests on wrap-to-self): mint to the full
+        // roster, remove a device, and rotate to a fresh higher-epoch key held only by the
+        // survivors — the removed device can no longer unwrap.
+        let conn = db();
+        let (account, stream) = account_with_owned_stream(&conn, "repo-x");
+        let member_x = DeviceX25519Secret::from_seed(&[0x5c; 32]);
+        let member = add_member_device(&conn, account, &member_x);
+
+        let mint = mint_committed(&conn, stream);
+        assert_eq!(stored_wrap(&conn, &mint).wraps.len(), 2, "founder + member are recipients");
+        assert!(
+            !stream_key_rotation_needed(&conn, account, stream).unwrap(),
+            "no rotation needed while every current-wrap recipient is effective",
+        );
+
+        // Remove the member: its wrap for the current key is now held by a non-effective device.
+        author_control_op(&conn, account, &AccountOp::DeviceRemove {
+            device_fingerprint: member,
+            control_cut: Cut::Empty,
+            secrets_cut: Cut::Empty,
+            content_cuts: Vec::new(),
+            reason: "revoked".to_string(),
+        });
+        assert!(
+            stream_key_rotation_needed(&conn, account, stream).unwrap(),
+            "a removed recipient of the current wrap triggers rotation",
+        );
+
+        // Rotate → a fresh key at epoch 1 sealed ONLY to the surviving founder.
+        let rotated = rotate_committed(&conn, stream);
+        assert_eq!(
+            status(&conn, &rotated),
+            Some(("accepted".to_string(), None)),
+            "the rotation wrap folds accepted",
+        );
+        let rot_wrap = stored_wrap(&conn, &rotated);
+        assert_eq!(rot_wrap.key_epoch, 1, "rotation stamps accepted_max + 1");
+        let device = local_device(&conn, NOW).unwrap();
+        assert_eq!(rot_wrap.wraps.len(), 1, "only the surviving founder is a recipient");
+        assert_eq!(rot_wrap.wraps[0].recipient_fp, device.fingerprint(), "sealed to the founder");
+        assert!(
+            !rot_wrap.wraps.iter().any(|w| w.recipient_fp == member),
+            "the removed member gets no wrap for the fresh key (it cannot unwrap the rotated key)",
+        );
+
+        // The C4.3b selection now returns epoch 1, and rotation is no longer needed (the current
+        // epoch-1 wrap names only effective devices — the stale epoch-0 wrap is not the selection).
+        let selected = select_current_sealing_wrap(&conn, account, stream).unwrap().unwrap();
+        assert_eq!(selected.key_epoch, 1, "the selection advances to the rotated epoch");
+        assert!(
+            !stream_key_rotation_needed(&conn, account, stream).unwrap(),
+            "after rotation the current wrap is held only by effective devices",
+        );
+    }
+
+    #[test]
+    fn ensure_rotates_for_an_owner_then_reports_current() {
+        // The lazy trigger end-to-end: an owner sees Current before a removal, Rotated after, and
+        // Current again once the fresh key is in place (idempotent).
+        let conn = db();
+        let (account, stream) = account_with_owned_stream(&conn, "repo-x");
+        let member_x = DeviceX25519Secret::from_seed(&[0x5c; 32]);
+        let member = add_member_device(&conn, account, &member_x);
+        mint_committed(&conn, stream);
+
+        assert!(
+            matches!(ensure_committed(&conn, stream), RotationOutcome::Current),
+            "nothing to rotate while every recipient is effective",
+        );
+
+        author_control_op(&conn, account, &AccountOp::DeviceRemove {
+            device_fingerprint: member,
+            control_cut: Cut::Empty,
+            secrets_cut: Cut::Empty,
+            content_cuts: Vec::new(),
+            reason: "revoked".to_string(),
+        });
+
+        let RotationOutcome::Rotated(rotated) = ensure_committed(&conn, stream) else {
+            panic!("an owner with a stale current-wrap recipient rotates");
+        };
+        assert_eq!(stored_wrap(&conn, &rotated).key_epoch, 1, "ensure rotated to epoch 1");
+        assert_eq!(status(&conn, &rotated), Some(("accepted".to_string(), None)));
+
+        assert!(
+            matches!(ensure_committed(&conn, stream), RotationOutcome::Current),
+            "a second ensure is a noop — the current wrap is fresh",
+        );
+    }
+
+    #[test]
+    fn rotating_a_stream_with_no_prior_wrap_errors() {
+        // Q6: rotate with no prior accepted wrap is an ERROR (not treat-as-mint, not no-op).
+        // `ensure` never reaches it — no wrap ⇒ predicate false ⇒ Current — but the raw
+        // entry point guards.
+        let conn = db();
+        let (_account, stream) = account_with_owned_stream(&conn, "repo-x");
+        let tx = Transaction::new_unchecked(&conn, TransactionBehavior::Immediate).unwrap();
+        let err = rotate_stream_key_in_tx(&tx, stream, NOW).unwrap_err();
+        drop(tx);
+        assert!(
+            err.to_string().contains("no prior accepted"),
+            "rotation with no prior wrap errors: {err}",
+        );
+    }
+
+    #[test]
+    fn rotation_errors_at_u64_max_epoch_instead_of_wrapping() {
+        // S3: `checked_add` the epoch; ERROR at u64::MAX, never wrap. A wrap-to-0 would silently
+        // lose the max-epoch selection and regress sealing to an old key. Drive an accepted
+        // wrap to the ceiling via the private core (the evaluator reads no key_epoch, so it
+        // folds accepted).
+        let conn = db();
+        let (_account, stream) = account_with_owned_stream(&conn, "repo-x");
+        let key = ContentKey::from_seed(&[0x9e; 32]);
+        let tx = Transaction::new_unchecked(&conn, TransactionBehavior::Immediate).unwrap();
+        author_stream_key_wrap_in_tx(&tx, stream, &key, u64::MAX, NOW).expect("author at u64::MAX");
+        tx.commit().unwrap();
+
+        let tx = Transaction::new_unchecked(&conn, TransactionBehavior::Immediate).unwrap();
+        let err = rotate_stream_key_in_tx(&tx, stream, NOW).unwrap_err();
+        drop(tx);
+        assert!(
+            err.to_string().contains("u64::MAX"),
+            "rotation refuses to overflow the epoch: {err}",
+        );
+    }
+
+    #[test]
+    fn a_member_device_with_rotation_needed_is_stale_but_not_owner() {
+        // B1: a device that is NOT a current owner cannot author a rotation, but must NOT error or
+        // roll back — a member legitimately seals under the current key. The local device founds
+        // the account, mints, then a SECOND owner demotes it to a plain member; a
+        // still-removed recipient keeps rotation needed, so `ensure` must return
+        // StaleButNotOwner (not Err, not Rotated).
+        let conn = db();
+        let (account, stream) = account_with_owned_stream(&conn, "repo-x");
+
+        // A second owner whose secret we control, so it can author the founder's demotion.
+        let owner_b_ed = crate::device::DeviceSecret::from_seed(&[0x2b; 32]);
+        let owner_b_x = DeviceX25519Secret::from_seed(&[0xb2; 32]);
+        let owner_id_b = author_control_op(&conn, account, &AccountOp::DeviceAdd {
+            device_fingerprint: owner_b_ed.public().fingerprint(),
+            ed25519_pubkey: owner_b_ed.public().to_bytes(),
+            x25519_pubkey: owner_b_x.public().to_bytes(),
+            role: DeviceRole::Owner,
+            label: None,
+        });
+
+        // A member that will be removed to make rotation needed.
+        let m_ed = crate::device::DeviceSecret::from_seed(&[0x3d; 32]);
+        let m_x = DeviceX25519Secret::from_seed(&[0xd3; 32]);
+        let m_fp = m_ed.public().fingerprint();
+        author_control_op(&conn, account, &AccountOp::DeviceAdd {
+            device_fingerprint: m_fp,
+            ed25519_pubkey: m_ed.public().to_bytes(),
+            x25519_pubkey: m_x.public().to_bytes(),
+            role: DeviceRole::Member,
+            label: None,
+        });
+
+        // Mint via the real seam while the founder is still an owner → seals to all three.
+        let mint = mint_committed(&conn, stream);
+        assert_eq!(stored_wrap(&conn, &mint).wraps.len(), 3, "founder + owner_b + member sealed");
+
+        // The founder (still owner) removes the member → rotation needed.
+        author_control_op(&conn, account, &AccountOp::DeviceRemove {
+            device_fingerprint: m_fp,
+            control_cut: Cut::Empty,
+            secrets_cut: Cut::Empty,
+            content_cuts: Vec::new(),
+            reason: "revoked".to_string(),
+        });
+        assert!(
+            stream_key_rotation_needed(&conn, account, stream).unwrap(),
+            "the removed member is still a recipient of the current wrap",
+        );
+
+        // owner_b demotes the founder, preserving the founder's whole history via cuts at its chain
+        // tails (the mint stays accepted; only the owner ROLE closes).
+        let founder = local_device(&conn, NOW).unwrap();
+        let founder_owner_id =
+            storage::effective_owner_incarnation_for_device(&conn, account, founder.fingerprint())
+                .unwrap()
+                .expect("the founder is an owner before the demotion");
+        let ctrl_tail = chain_tail(&conn, account, founder.fingerprint(), CONTROL_LOG)
+            .expect("the founder has a control chain");
+        let secrets_tail = chain_tail(&conn, account, founder.fingerprint(), SECRETS_LOG)
+            .expect("the founder authored the mint on its secrets chain");
+        author_control_op_as(&conn, account, &owner_b_ed, owner_id_b, &AccountOp::OwnerDemote {
+            device_fingerprint: founder.fingerprint(),
+            owner_id: founder_owner_id,
+            control_cut: Cut::At { seq: ctrl_tail.0, hash: ctrl_tail.1 },
+            secrets_cut: Cut::At { seq: secrets_tail.0, hash: secrets_tail.1 },
+            reason: "demote".to_string(),
+        });
+
+        // The founder is now a plain member: still a recipient (can seal), but not an owner.
+        assert!(
+            storage::effective_owner_incarnation_for_device(&conn, account, founder.fingerprint())
+                .unwrap()
+                .is_none(),
+            "the founder holds no live owner incarnation after the demotion",
+        );
+        assert!(
+            stream_key_rotation_needed(&conn, account, stream).unwrap(),
+            "rotation is still needed after the demotion (the mint survives, the member is gone)",
+        );
+        assert!(
+            matches!(ensure_committed(&conn, stream), RotationOutcome::StaleButNotOwner),
+            "a member that finds rotation needed is StaleButNotOwner — no rotate, no error",
+        );
+
+        // StaleButNotOwner authored nothing: only the original mint is on the secrets log.
+        let secrets_rows: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM account_entries WHERE log_id = ?1 AND accepted = 1",
+                [SECRETS_LOG],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(secrets_rows, 1, "StaleButNotOwner does not author a rotation");
+    }
+
+    /// Rotate the stream key in its own IMMEDIATE txn and commit — the shape a live caller uses.
+    fn rotate_committed(conn: &Connection, stream: StreamId) -> EntryHash {
+        let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate).unwrap();
+        let hash = rotate_stream_key_in_tx(&tx, stream, NOW).expect("rotate");
+        tx.commit().unwrap();
+        hash
+    }
+
+    /// Run the lazy rotation trigger in its own IMMEDIATE txn and commit.
+    fn ensure_committed(conn: &Connection, stream: StreamId) -> RotationOutcome {
+        let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate).unwrap();
+        let outcome = ensure_stream_key_current_in_tx(&tx, stream, NOW).expect("ensure");
+        tx.commit().unwrap();
+        outcome
+    }
+
+    /// The (seq, hash) tail of a device's `(account, device, log)` chain — used to place tight
+    /// cuts.
+    fn chain_tail(
+        conn: &Connection,
+        account: AccountId,
+        fp: crate::op::DeviceFingerprint,
+        log: u8,
+    ) -> Option<(u64, EntryHash)> {
+        let tx = conn.unchecked_transaction().unwrap();
+        authoring::account_chain_tail(&tx, account, fp, log).unwrap()
+    }
+
+    /// Author + refold a control op signed by an ARBITRARY device (not just the founder), citing
+    /// `authority_ref`, on that device's own dense control chain. The non-founder counterpart of
+    /// [`author_control_op`].
+    fn author_control_op_as(
+        conn: &Connection,
+        account: AccountId,
+        signer: &crate::device::DeviceSecret,
+        authority_ref: EntryHash,
+        op: &AccountOp,
+    ) -> EntryHash {
+        use crate::account::ops as control_ops;
+
+        let signer_fp = signer.public().fingerprint();
+        let LocalAccountRef { genesis_hash, .. } =
+            bootstrap::local_account_ref(conn).unwrap().unwrap();
+        let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate).unwrap();
+        let (seq, prev_hash) =
+            match authoring::account_chain_tail(&tx, account, signer_fp, CONTROL_LOG).unwrap() {
+                Some((tail_seq, tail_hash)) => (tail_seq + 1, Some(tail_hash)),
+                None => (0, None),
+            };
+        let header = AccountEntryHeader {
+            account_id: account,
+            log_id: CONTROL_LOG,
+            device_fingerprint: signer_fp,
+            seq,
+            prev_hash,
+            parent_ref: Some(genesis_hash),
+            entry_type: control_ops::entry_type_of(op),
+            op_version: 1,
+            crypto_suite: 0,
+            auth_len: storage::account_effective_count(&tx, account).unwrap(),
+            key_id: None,
+            authority_ref: Some(authority_ref),
+        };
+        let payload = control_ops::encode(op).unwrap();
+        let signed = sign_account_entry(signer, &header, &payload).unwrap();
+        let verified = VerifiedAccountEntry {
+            header: signed.header,
+            payload: signed.payload,
+            entry_hash: signed.entry_hash,
+        };
+        storage::insert_candidate(&tx, &verified, &signed.signed_bytes, NOW).unwrap();
+        storage::refold_in_tx(&tx, account).unwrap();
+        tx.commit().unwrap();
+        verified.entry_hash
     }
 
     /// Author a control op under the founder (the local device) citing its own genesis incarnation,

--- a/crates/rag-rat-oplog/src/account/secrets/mod.rs
+++ b/crates/rag-rat-oplog/src/account/secrets/mod.rs
@@ -17,10 +17,14 @@ mod sealing;
 mod security_event;
 mod storage;
 
-// The in-tx content-key mint + `StreamKeyWrap` author seam (C4.3a): re-exported up through
-// `account` and the crate root for the `sync enable` caller (C4.3b) to reach (`pub` here so
-// `account::mod` can re-export it — the private `mod secrets` keeps it crate-scoped regardless).
-pub use author::mint_and_author_stream_key_wrap_in_tx;
+// The in-tx content-key mint + `StreamKeyWrap` author seam (C4.3a) + the C4.4 lazy rotation entry
+// points (`rotate_stream_key_in_tx` / `ensure_stream_key_current_in_tx` / `RotationOutcome`):
+// re-exported up through `account` and the crate root for the seal path (C5) to reach (`pub` here
+// so `account::mod` can re-export it — the private `mod secrets` keeps it crate-scoped regardless).
+pub use author::{
+    RotationOutcome, ensure_stream_key_current_in_tx, mint_and_author_stream_key_wrap_in_tx,
+    rotate_stream_key_in_tx,
+};
 // The ingest-time structural validation twin (mirrors the control-plaintext arm) and the
 // refold pass wired into `refold_in_tx`.
 pub(in crate::account) use ops::validate_storable_secrets_payload;
@@ -30,5 +34,6 @@ pub(in crate::account) use ops::validate_storable_secrets_payload;
 // slice ahead of its consumer).
 pub use sealing::{
     SealingKeyOutcome, SelectedWrap, current_sealing_key, select_current_sealing_wrap,
+    stream_key_rotation_needed,
 };
 pub(in crate::account) use storage::refold_secrets_log;

--- a/crates/rag-rat-oplog/src/account/secrets/sealing.rs
+++ b/crates/rag-rat-oplog/src/account/secrets/sealing.rs
@@ -16,7 +16,7 @@
 use rusqlite::{Connection, params};
 
 use super::super::keywrap::{self, ContentKey, KeyId, WrapContext};
-use super::super::{AccountId, envelope, fold};
+use super::super::{AccountId, envelope, fold, storage};
 use super::ops::{self, DecodedSecretsOp, StreamKeyWrap};
 use super::security_event::{self, SyncSecurityEvent, SyncSecurityEventKind};
 use crate::identity::LocalDevice;
@@ -69,6 +69,48 @@ pub fn select_current_sealing_wrap(
     stream_id: StreamId,
 ) -> anyhow::Result<Option<SelectedWrap>> {
     Ok(select_from_wraps(&list_accepted_stream_key_wraps(conn, account_id, stream_id)?))
+}
+
+/// Whether `stream_id`'s content key must be ROTATED (sync phase C4.4, #607): TRUE iff some
+/// recipient of the CURRENT sealing wrap is no longer roster-effective — i.e. a removed device
+/// still holds a wrap for the key this stream seals under right now. DEVICE-INDEPENDENT (it
+/// compares the wrap's recipients against the roster, never the local device), so every peer
+/// computes the same answer; the owner-only authoring gate lives in
+/// [`super::ensure_stream_key_current_in_tx`], not here.
+///
+/// Unions recipients across ALL accepted sibling ops at the SELECTED `(epoch, key_id)`, not just
+/// the tiebreak-winner op: same-`(epoch, key_id)` fan-out siblings can each name a different
+/// recipient subset (the C4.3b BLOCKER-1 class), so a removed device named only by a non-winner
+/// sibling must still trigger. Keying on `(epoch, key_id)` mirrors [`current_sealing_key`]'s
+/// my-wrap lookup.
+///
+/// SOUND ONLY because of wrap-to-self: the predicate sees a wrap's RECIPIENTS, never its author, so
+/// a removed minting owner is caught only because it sealed to itself and thus appears as a
+/// recipient of its own surviving wraps. ONE-DIRECTIONAL: a newly-effective device that is ABSENT
+/// from the current wrap does NOT trigger (that is deferred new-device catch-up, not rotation).
+///
+/// `false` when the stream has no accepted wrap (nothing to rotate — the seal path mints an initial
+/// key instead). A contested account needs no special case: the fold keeps contested wraps out of
+/// `accepted`, so the selection is simply empty.
+pub fn stream_key_rotation_needed(
+    conn: &Connection,
+    account_id: AccountId,
+    stream_id: StreamId,
+) -> anyhow::Result<bool> {
+    let wraps = list_accepted_stream_key_wraps(conn, account_id, stream_id)?;
+    let Some(selected) = select_from_wraps(&wraps) else {
+        return Ok(false);
+    };
+    let effective = storage::list_effective_roster_fingerprints(conn, account_id)?;
+    let stale_recipient = wraps
+        .iter()
+        .filter(|w| {
+            w.wrap.key_epoch == selected.key_epoch
+                && KeyId::from_bytes(w.wrap.key_id) == selected.key_id
+        })
+        .flat_map(|w| w.wrap.wraps.iter())
+        .any(|entry| !effective.contains(&entry.recipient_fp));
+    Ok(stale_recipient)
 }
 
 /// Resolve the content key THIS device would seal `stream_id` under right now, running the C4.3b
@@ -245,8 +287,13 @@ mod tests {
     use rag_rat_db::schema;
     use rusqlite::Connection;
 
-    use super::super::ops::{StreamKeyWrap, WrapEntry, entry_type as secrets_entry_type};
-    use super::{SealingKeyOutcome, current_sealing_key, select_current_sealing_wrap};
+    use super::super::ops::{
+        DecodedSecretsOp, StreamKeyWrap, WrapEntry, decode, entry_type as secrets_entry_type,
+    };
+    use super::{
+        SealingKeyOutcome, current_sealing_key, select_current_sealing_wrap,
+        stream_key_rotation_needed,
+    };
     use crate::account::cut::Cut;
     use crate::account::envelope::{AccountEntryHeader, sign_account_entry};
     use crate::account::id::account_id_from_genesis_payload;
@@ -913,5 +960,228 @@ mod tests {
             current_sealing_key(&conn, account, stream_id, &device, NOW).unwrap(),
             SealingKeyOutcome::NoCurrentKey
         ));
+    }
+
+    // ── C4.4: the rotation-needed predicate ──
+
+    /// Decode the stored `StreamKeyWrap` op for one entry hash.
+    fn stored_wrap_by_hash(conn: &Connection, hash: [u8; 32]) -> StreamKeyWrap {
+        let signed_bytes: Vec<u8> = conn
+            .query_row(
+                "SELECT signed_bytes FROM account_entries WHERE entry_hash = ?1",
+                [hash.as_slice()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let signed = crate::account::envelope::decode_account_signed(&signed_bytes).unwrap();
+        match decode(signed.header.entry_type, &signed.payload).unwrap() {
+            DecodedSecretsOp::Known(wrap) => wrap,
+            _ => panic!("stored entry is a known StreamKeyWrap"),
+        }
+    }
+
+    #[test]
+    fn rotation_needed_unions_recipients_across_fanout_siblings() {
+        // S1: the predicate unions recipients across ALL accepted sibling ops at the selected
+        // (epoch, key_id), not just the tiebreak-winner op. Two epoch-0 siblings share ONE key_id,
+        // each naming a DIFFERENT member; removing the member named ONLY by the LOSER op must still
+        // trigger — a winner-only predicate would miss it.
+        let conn = db();
+        let founder = Dev::new(1);
+        let (account, genesis_bytes, genesis_hash) = genesis(&founder);
+        ingest(&conn, &genesis_bytes);
+        let (stream_id, own) = stream_own(account);
+        let (own_bytes, own_hash) =
+            control_op(account, &founder, 1, Some(genesis_hash), Some(genesis_hash), &own);
+        ingest(&conn, &own_bytes);
+
+        let m1 = Dev::new(4);
+        let m2 = Dev::new(5);
+        let (add1_bytes, add1) = control_op(
+            account,
+            &founder,
+            2,
+            Some(own_hash),
+            Some(genesis_hash),
+            &device_add(&m1, DeviceRole::Member),
+        );
+        ingest(&conn, &add1_bytes);
+        let (add2_bytes, add2) = control_op(
+            account,
+            &founder,
+            3,
+            Some(add1),
+            Some(genesis_hash),
+            &device_add(&m2, DeviceRole::Member),
+        );
+        ingest(&conn, &add2_bytes);
+
+        // Two ops share ONE key (⇒ one key_id) at epoch 0 — a fan-out across ops (SET, never LWW);
+        // each names a different member.
+        let key = ContentKey::from_seed(&[0x40; 32]);
+        let m1_x = DeviceX25519Public::from_bytes(&m1.x).unwrap();
+        let m2_x = DeviceX25519Public::from_bytes(&m2.x).unwrap();
+        let (w1_bytes, h1) = wrap_entry(
+            account,
+            &founder,
+            0,
+            None,
+            Some(genesis_hash),
+            &honest_wrap(account, stream_id, m1.fp, &m1_x, &key, 0),
+        );
+        ingest(&conn, &w1_bytes);
+        let (w2_bytes, h2) = wrap_entry(
+            account,
+            &founder,
+            1,
+            Some(h1),
+            Some(genesis_hash),
+            &honest_wrap(account, stream_id, m2.fp, &m2_x, &key, 0),
+        );
+        ingest(&conn, &w2_bytes);
+
+        // The winner op is min entry_hash; remove the member named by the LOSER op so the winner
+        // names only a still-effective member.
+        let (winner_hash, loser_member) = if h1 < h2 { (h1, &m2) } else { (h2, &m1) };
+        let remove = AccountOp::DeviceRemove {
+            device_fingerprint: loser_member.fp,
+            control_cut: Cut::Empty,
+            secrets_cut: Cut::Empty,
+            content_cuts: Vec::new(),
+            reason: "revoked".to_string(),
+        };
+        let (rem_bytes, _) =
+            control_op(account, &founder, 4, Some(add2), Some(genesis_hash), &remove);
+        ingest(&conn, &rem_bytes);
+
+        assert!(
+            stream_key_rotation_needed(&conn, account, stream_id).unwrap(),
+            "a removed recipient named only by a non-winner sibling still triggers rotation",
+        );
+        // Prove the UNION is doing the work: the winning op does NOT name the removed member.
+        let winner = stored_wrap_by_hash(&conn, winner_hash);
+        assert!(
+            !winner.wraps.iter().any(|w| w.recipient_fp == loser_member.fp),
+            "the tiebreak-winner op names only the still-effective member",
+        );
+    }
+
+    #[test]
+    fn a_current_wrap_with_only_effective_recipients_needs_no_rotation() {
+        // The negative case + ONE-DIRECTIONAL: a wrap whose recipients are all still effective is
+        // not stale, and a newly-added member ABSENT from the wrap is deferred catch-up,
+        // never a rotation trigger. Built inline so the StreamOwn tail hash is in hand to
+        // chain the later DeviceAdd.
+        let conn = db();
+        let founder = Dev::new(1);
+        let (account, genesis_bytes, genesis_hash) = genesis(&founder);
+        ingest(&conn, &genesis_bytes);
+        let (stream_id, own) = stream_own(account);
+        let (own_bytes, own_hash) =
+            control_op(account, &founder, 1, Some(genesis_hash), Some(genesis_hash), &own);
+        ingest(&conn, &own_bytes);
+
+        // A wrap sealed to the founder only (an effective device).
+        let founder_x = DeviceX25519Public::from_bytes(&founder.x).unwrap();
+        let key = ContentKey::from_seed(&[0x41; 32]);
+        let (bytes, _) = wrap_entry(
+            account,
+            &founder,
+            0,
+            None,
+            Some(genesis_hash),
+            &honest_wrap(account, stream_id, founder.fp, &founder_x, &key, 0),
+        );
+        ingest(&conn, &bytes);
+        assert!(
+            !stream_key_rotation_needed(&conn, account, stream_id).unwrap(),
+            "the sole recipient is effective — no rotation needed",
+        );
+
+        // A newly-added member is absent from the existing wrap; deferred catch-up, NOT rotation.
+        let newcomer = Dev::new(7);
+        let (add_bytes, _) = control_op(
+            account,
+            &founder,
+            2,
+            Some(own_hash),
+            Some(genesis_hash),
+            &device_add(&newcomer, DeviceRole::Member),
+        );
+        ingest(&conn, &add_bytes);
+        assert!(
+            !stream_key_rotation_needed(&conn, account, stream_id).unwrap(),
+            "a newly-effective device absent from the wrap does NOT trigger rotation \
+             (one-directional)",
+        );
+    }
+
+    #[test]
+    fn concurrent_epoch_one_rotations_both_accept_and_select_deterministically() {
+        // Two owners independently rotate epoch 0 → epoch 1 with DIFFERENT fresh keys. Both epoch-1
+        // wraps accept (SET, never LWW); the selection converges on the min-entry_hash op — the
+        // loser wrap is harmless. This is the shape two concurrent
+        // `rotate_stream_key_in_tx` calls produce.
+        let conn = db();
+        let (account, founder, owner_b, owner_id_b, stream_id, _own_hash, genesis_hash) =
+            account_with_second_owner(&conn);
+        let device = local_device(&conn, NOW).unwrap();
+        let fp = device.fingerprint();
+        let x = device.x25519_public();
+
+        // Baseline epoch-0 wrap by the founder.
+        let key0 = ContentKey::from_seed(&[0x50; 32]);
+        let (w0_bytes, w0) = wrap_entry(
+            account,
+            &founder,
+            0,
+            None,
+            Some(genesis_hash),
+            &honest_wrap(account, stream_id, fp, &x, &key0, 0),
+        );
+        ingest(&conn, &w0_bytes);
+
+        // Two epoch-1 rotations, one per owner, different fresh keys.
+        let key1_founder = ContentKey::from_seed(&[0x51; 32]);
+        let key1_owner_b = ContentKey::from_seed(&[0x52; 32]);
+        let (wf_bytes, wf) = wrap_entry(
+            account,
+            &founder,
+            1,
+            Some(w0),
+            Some(genesis_hash),
+            &honest_wrap(account, stream_id, fp, &x, &key1_founder, 1),
+        );
+        ingest(&conn, &wf_bytes);
+        let (wb_bytes, wb) = wrap_entry(
+            account,
+            &owner_b,
+            0,
+            None,
+            Some(owner_id_b),
+            &honest_wrap(account, stream_id, fp, &x, &key1_owner_b, 1),
+        );
+        ingest(&conn, &wb_bytes);
+
+        // Both epoch-1 wraps accepted; selection = epoch 1, tiebreak min entry_hash.
+        let selected =
+            select_current_sealing_wrap(&conn, account, stream_id).unwrap().expect("a current key");
+        assert_eq!(selected.key_epoch, 1, "the max accepted epoch is the rotated one");
+        assert_eq!(
+            selected.minting_entry_hash,
+            wf.min(wb),
+            "min entry_hash tiebreaks the two concurrent rotations",
+        );
+
+        // The recovered key is the winning op's key — deterministic across peers.
+        let winner_key = if wf < wb { &key1_founder } else { &key1_owner_b };
+        let recovered =
+            expect_ready(current_sealing_key(&conn, account, stream_id, &device, NOW).unwrap());
+        assert_eq!(
+            recovered.as_slice(),
+            winner_key.as_slice(),
+            "seals under the deterministic winner",
+        );
+        assert_eq!(security_event_count(&conn), 0, "honest concurrent rotations record no events");
     }
 }

--- a/crates/rag-rat-oplog/src/account/storage.rs
+++ b/crates/rag-rat-oplog/src/account/storage.rs
@@ -1505,6 +1505,28 @@ pub(super) fn list_effective_roster_x25519_pubkeys(
     Ok(out)
 }
 
+/// The FINGERPRINTS of every roster-effective device on `account_id` — the cheap counterpart to
+/// [`list_effective_roster_x25519_pubkeys`] for a per-seal boolean (the C4.4 rotation-needed
+/// predicate in `secrets::sealing`). `DISTINCT` because one device can key more than one open
+/// `roster_ref` row. Unlike the x25519 reader it decodes NO enrollment (no `signed_bytes` fetch, no
+/// small-order blocklist) and does NOT fail loud on a corrupt projection: the predicate only asks
+/// "is this fingerprint still effective?", so the per-recipient enrollment cross-checks are dead
+/// weight here.
+pub(super) fn list_effective_roster_fingerprints(
+    conn: &Connection,
+    account_id: AccountId,
+) -> anyhow::Result<Vec<DeviceFingerprint>> {
+    let mut stmt = conn.prepare(
+        "SELECT DISTINCT device_fingerprint FROM account_roster_history
+         WHERE account_id = ?1 AND closed_at IS NULL
+         ORDER BY device_fingerprint",
+    )?;
+    let rows = stmt
+        .query_map([account_id.to_bytes().as_slice()], |row| row.get::<_, Vec<u8>>(0))?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    rows.into_iter().map(|fp| Ok(DeviceFingerprint::from_bytes(fixed(&fp)?))).collect()
+}
+
 /// The x25519 key the ONE accepted enrollment entry at `roster_ref` certifies for `fingerprint`
 /// (genesis → its founder / header device; DeviceAdd → the ADDED device), routed through the
 /// small-order / identity blocklist. Bound to that exact `entry_hash`, so a rejected/forked sibling

--- a/crates/rag-rat-oplog/src/lib.rs
+++ b/crates/rag-rat-oplog/src/lib.rs
@@ -79,16 +79,21 @@ mod stream;
 // - `mint_and_author_stream_key_wrap_in_tx` (C4.3a, #607): mint a per-stream content key and author
 //   an owner-gated `StreamKeyWrap` sealing it to every effective device, verify-accepted in the
 //   caller's txn.
+// - `rotate_stream_key_in_tx` / `ensure_stream_key_current_in_tx` / `stream_key_rotation_needed`
+//   (C4.4, #607): lazy content-key rotation on device removal — re-seal a fresh higher-epoch key to
+//   the remaining roster when a removed device still holds the current key.
 pub use account::{
     AccountId, AuthorityBoundary, AuthorityFreshness, AuthorityInvalidReason, AuthorityQuery,
     CapacityScope, ContentKey, DeviceCut, DeviceRole, GrantAuthority, GrantDeviceAuthority,
     GrantDeviceBoundary, GrantRole, IngestOutcome, KeyId, OwnerAuthority, OwnerChainAuthority,
-    RosterContentAuthority, SealingKeyOutcome, SelectedWrap, account_ingest, auth_len_freshness,
-    author_content_batch_in_tx, backfill_authority_projection, content_stream_is_empty,
-    current_sealing_key, ensure_owned_stream_v2_in_tx, established_owned_stream_v2,
-    grant_effective_for_device, local_account, mint_and_author_stream_key_wrap_in_tx,
-    owned_stream_v2_id, owner_control_authority, owner_secrets_authority, roster_content_authority,
-    select_current_sealing_wrap, stream_owner_effective,
+    RosterContentAuthority, RotationOutcome, SealingKeyOutcome, SelectedWrap, account_ingest,
+    auth_len_freshness, author_content_batch_in_tx, backfill_authority_projection,
+    content_stream_is_empty, current_sealing_key, ensure_owned_stream_v2_in_tx,
+    ensure_stream_key_current_in_tx, established_owned_stream_v2, grant_effective_for_device,
+    local_account, mint_and_author_stream_key_wrap_in_tx, owned_stream_v2_id,
+    owner_control_authority, owner_secrets_authority, roster_content_authority,
+    rotate_stream_key_in_tx, select_current_sealing_wrap, stream_key_rotation_needed,
+    stream_owner_effective,
 };
 // The op-log's first crate-internal API surface (#524): the MINTING primitives + the op
 // vocabulary the memory subsystem needs to author + backfill entries. Every submodule above is


### PR DESCRIPTION
Adds lazy content-key rotation on device removal — the last piece of the account content-key sealing work (#607). When a device is removed, the owner mints a fresh content key at a higher epoch, re-wrapped only to the remaining effective devices; the derive-on-read selection then adopts the higher epoch and the removed device loses future read access. Nothing calls the new entry points yet — C5's seal path is the consumer.

## What lands

- **`rotate_stream_key_in_tx`** (`account/secrets/author.rs`): rotation is exactly "mint at a higher epoch" — it reuses the C4.3a mint core unchanged (effective-roster recipients, owner-only authority, self-unwrap round-trip, verify-accepted-or-rollback), differing only in the stamped epoch. `epoch = max(accepted key_epoch) + 1` over the effective accepted wraps (condemned wraps never feed the max), via `checked_add` — it errors at `u64::MAX` rather than wrapping (a wrap to 0 would silently regress sealing to an old key). Rotating a stream with no prior wrap is an error, not a silent mint.
- **`ensure_stream_key_current_in_tx` → `RotationOutcome`** (`Rotated | Current | StaleButNotOwner`): the lazy entry point a seal path calls. A member device — a legitimate sealer, since roster membership is read access, not authoring authority — that finds rotation needed returns `StaleButNotOwner` (never an error, never a rollback) and proceeds to seal under the current key; only an owner authors the rotation. `Err` is reserved for infra failures.
- **`stream_key_rotation_needed`** (`account/secrets/sealing.rs`): true iff some recipient of the current sealing wrap is no longer roster-effective, unioning recipients across all accepted sibling ops at the selected `(epoch, key_id)`. Device-independent and one-directional — a newly-added device absent from the wrap does not trigger rotation (that catch-up is a separate later flow). Uses a fingerprint-only roster reader (no per-call enrollment decode).

Epoch re-use after a condemned wrap is deliberate: if a rotation is retro-condemned, the selection falls back to the surviving lower epoch and the next rotation re-stamps that epoch number — convergent, with no sticky local state. The forward-secrecy window (already-synced older-epoch content stays readable, bounded by owner sync lag) is the documented, accepted boundary.

## Out of scope (follow-up)

New-device catch-up (re-wrapping live epochs to a freshly-added device); content-entry sealing and the auto-rotate-on-seal wiring; an eager "rotate all streams" command.

## Tests / gates

Behavioral tests through the real mint seam: removing a recipient makes rotation needed and re-seals to survivors only (the removed device can't unwrap); `ensure` rotates for an owner then reports `Current`; a member with rotation needed is `StaleButNotOwner`; the predicate unions across fan-out siblings; a current wrap with only effective recipients needs no rotation; concurrent epoch-1 rotations both accept and select deterministically; rotating with no prior wrap errors; the epoch bump errors at `u64::MAX`. `cargo nextest run -p rag-rat-oplog` → 458 passed; clippy (`-D warnings`, both feature sets) and nightly `fmt --check` clean.
