### PR TITLE
Fix #697: bind reconcile embed-stub accept loops to request count, not wall clock

### DIFF
--- a/crates/rag-rat-core/src/index/ai/reconcile/embed_loop.rs
+++ b/crates/rag-rat-core/src/index/ai/reconcile/embed_loop.rs
@@ -511,7 +511,7 @@ mod freshness_version_tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::{Arc, Mutex};
     use std::thread;
-    use std::time::{Duration, Instant};
+    use std::time::Duration;
 
     use rag_rat_base::config::RemoteEmbeddingConfig;
     use rag_rat_base::embedding_models::{FASTEMBED_MODEL_ID, HASH_MODEL_ID, spec};
@@ -657,13 +657,13 @@ mod freshness_version_tests {
     }
 
     fn read_request_body(stream: &mut TcpStream) -> String {
-        // The listener is non-blocking (poll-accept), and on macOS/BSD an accepted socket INHERITS
-        // the listener's `O_NONBLOCK` (Linux/Windows do not). On a non-blocking socket `read`
-        // returns `WouldBlock` the instant no bytes are buffered — which the body loop
-        // below treats as `Err → break`, TRUNCATING a request whose body spans multiple TCP
-        // segments (the 1005-item batch). Force the accepted stream back to blocking so
-        // `set_read_timeout` (SO_RCVTIMEO) governs the reads and a large body is drained in
-        // full.
+        // Force the accepted stream to blocking so `set_read_timeout` (SO_RCVTIMEO) governs the
+        // reads: on macOS/BSD an accepted socket INHERITS a non-blocking listener's `O_NONBLOCK`
+        // (Linux/Windows do not inherit), and on a non-blocking socket `read` returns
+        // `WouldBlock` the instant no bytes are buffered — which the body loop below treats as
+        // `Err → break`, TRUNCATING a request whose body spans multiple TCP segments (the
+        // 1005-item batch). The stubs' listeners have been blocking since #697; the reset stays
+        // as a guard.
         stream.set_nonblocking(false).ok();
         stream.set_read_timeout(Some(Duration::from_secs(2))).ok();
         let mut raw = Vec::new();
@@ -711,54 +711,44 @@ mod freshness_version_tests {
         delay: Duration,
     ) -> (String, thread::JoinHandle<()>, Arc<AtomicUsize>) {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
-        listener.set_nonblocking(true).unwrap();
         let port = listener.local_addr().unwrap().port();
         let in_flight = Arc::new(AtomicUsize::new(0));
         let max_in_flight = Arc::new(AtomicUsize::new(0));
         let max_seen = Arc::clone(&max_in_flight);
         let handle = thread::spawn(move || {
             let mut workers = Vec::new();
-            let mut accepted = 0usize;
-            let started = Instant::now();
-            let mut last_accept = started;
-            while accepted < max_conns
-                && started.elapsed() < Duration::from_secs(5)
-                && (accepted == 0 || last_accept.elapsed() < Duration::from_millis(500))
-            {
-                match listener.accept() {
-                    Ok((mut stream, _)) => {
-                        accepted += 1;
-                        last_accept = Instant::now();
-                        let in_flight = Arc::clone(&in_flight);
-                        let max_seen = Arc::clone(&max_seen);
-                        workers.push(thread::spawn(move || {
-                            let now = in_flight.fetch_add(1, Ordering::SeqCst) + 1;
-                            raise_max(&max_seen, now);
-                            let body = read_request_body(&mut stream);
-                            thread::sleep(delay);
-                            let inputs = body.matches("path: ").count().max(1);
-                            let vector = vec!["0.1"; dim].join(",");
-                            let rows = (0..inputs)
-                                .map(|i| format!("{{\"embedding\":[{vector}],\"index\":{i}}}"))
-                                .collect::<Vec<_>>()
-                                .join(",");
-                            let response_body = format!("{{\"data\":[{rows}]}}");
-                            let response = format!(
-                                "HTTP/1.1 200 OK\r\nContent-Type: \
-                                 application/json\r\nContent-Length: {}\r\nConnection: \
-                                 close\r\n\r\n{response_body}",
-                                response_body.len()
-                            );
-                            let _ = stream.write_all(response.as_bytes());
-                            let _ = stream.flush();
-                            in_flight.fetch_sub(1, Ordering::SeqCst);
-                        }));
-                    },
-                    Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {
-                        thread::sleep(Duration::from_millis(10));
-                    },
-                    Err(_) => break,
-                }
+            // Accept EXACTLY `max_conns` connections on a blocking listener — the stub's lifetime
+            // is bounded by the test's request count (an event), not by the wall clock. The
+            // previous loop polled a non-blocking listener under a 5s overall / 500ms idle cap:
+            // under host load the reconcile's pre-request work delayed its connect past those
+            // caps, the listener dropped, and every chunk failed (#697). A loaded box can only
+            // make this loop WAIT longer, never exit early. `handle.join()` in the test therefore
+            // guarantees every accepted request has fully drained before the assertions run.
+            for _ in 0..max_conns {
+                let Ok((mut stream, _)) = listener.accept() else { break };
+                let in_flight = Arc::clone(&in_flight);
+                let max_seen = Arc::clone(&max_seen);
+                workers.push(thread::spawn(move || {
+                    let now = in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+                    raise_max(&max_seen, now);
+                    let body = read_request_body(&mut stream);
+                    thread::sleep(delay);
+                    let inputs = body.matches("path: ").count().max(1);
+                    let vector = vec!["0.1"; dim].join(",");
+                    let rows = (0..inputs)
+                        .map(|i| format!("{{\"embedding\":[{vector}],\"index\":{i}}}"))
+                        .collect::<Vec<_>>()
+                        .join(",");
+                    let response_body = format!("{{\"data\":[{rows}]}}");
+                    let response = format!(
+                        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: \
+                         {}\r\nConnection: close\r\n\r\n{response_body}",
+                        response_body.len()
+                    );
+                    let _ = stream.write_all(response.as_bytes());
+                    let _ = stream.flush();
+                    in_flight.fetch_sub(1, Ordering::SeqCst);
+                }));
             }
             for worker in workers {
                 let _ = worker.join();
@@ -773,55 +763,42 @@ mod freshness_version_tests {
         fail_marker: &'static str,
     ) -> (String, thread::JoinHandle<()>) {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
-        listener.set_nonblocking(true).unwrap();
         let port = listener.local_addr().unwrap().port();
         let handle = thread::spawn(move || {
             let mut workers = Vec::new();
-            let mut accepted = 0usize;
-            let started = Instant::now();
-            let mut last_accept = started;
-            while accepted < max_conns
-                && started.elapsed() < Duration::from_secs(5)
-                && (accepted == 0 || last_accept.elapsed() < Duration::from_millis(500))
-            {
-                match listener.accept() {
-                    Ok((mut stream, _)) => {
-                        accepted += 1;
-                        last_accept = Instant::now();
-                        workers.push(thread::spawn(move || {
-                            let body = read_request_body(&mut stream);
-                            let response = if body.contains(fail_marker) {
-                                let response_body = "{\"error\":\"transient\"}";
-                                format!(
-                                    "HTTP/1.1 500 Internal Server Error\r\nContent-Type: \
-                                     application/json\r\nContent-Length: {}\r\nConnection: \
-                                     close\r\n\r\n{response_body}",
-                                    response_body.len()
-                                )
-                            } else {
-                                let inputs = body.matches("path: ").count().max(1);
-                                let vector = vec!["0.1"; dim].join(",");
-                                let rows = (0..inputs)
-                                    .map(|i| format!("{{\"embedding\":[{vector}],\"index\":{i}}}"))
-                                    .collect::<Vec<_>>()
-                                    .join(",");
-                                let response_body = format!("{{\"data\":[{rows}]}}");
-                                format!(
-                                    "HTTP/1.1 200 OK\r\nContent-Type: \
-                                     application/json\r\nContent-Length: {}\r\nConnection: \
-                                     close\r\n\r\n{response_body}",
-                                    response_body.len()
-                                )
-                            };
-                            let _ = stream.write_all(response.as_bytes());
-                            let _ = stream.flush();
-                        }));
-                    },
-                    Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {
-                        thread::sleep(Duration::from_millis(10));
-                    },
-                    Err(_) => break,
-                }
+            // Same event-bounded accept as `spawn_reconcile_embed_stub` (#697): block until each
+            // of the `max_conns` expected connections arrives; no wall-clock caps that a loaded
+            // host can beat. The retries the scoped-retry path makes are SEQUENTIAL, so the old
+            // 500ms idle cap could fire between one request and its follow-up.
+            for _ in 0..max_conns {
+                let Ok((mut stream, _)) = listener.accept() else { break };
+                workers.push(thread::spawn(move || {
+                    let body = read_request_body(&mut stream);
+                    let response = if body.contains(fail_marker) {
+                        let response_body = "{\"error\":\"transient\"}";
+                        format!(
+                            "HTTP/1.1 500 Internal Server Error\r\nContent-Type: \
+                             application/json\r\nContent-Length: {}\r\nConnection: \
+                             close\r\n\r\n{response_body}",
+                            response_body.len()
+                        )
+                    } else {
+                        let inputs = body.matches("path: ").count().max(1);
+                        let vector = vec!["0.1"; dim].join(",");
+                        let rows = (0..inputs)
+                            .map(|i| format!("{{\"embedding\":[{vector}],\"index\":{i}}}"))
+                            .collect::<Vec<_>>()
+                            .join(",");
+                        let response_body = format!("{{\"data\":[{rows}]}}");
+                        format!(
+                            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: \
+                             {}\r\nConnection: close\r\n\r\n{response_body}",
+                            response_body.len()
+                        )
+                    };
+                    let _ = stream.write_all(response.as_bytes());
+                    let _ = stream.flush();
+                }));
             }
             for worker in workers {
                 let _ = worker.join();


### PR DESCRIPTION
Fixes #697 with the deterministic direction you prescribed — but the mechanism turned out to be different from the issue's "in-flight requests don't complete before the join", and the fix follows the corrected diagnosis, so laying that out first:

## What's actually racing

The reconcile path is fully synchronous — blocking ureq in `embed_batch`, the multi-range fan-out joins its workers inside `thread::scope` before returning, writes land before the report assembles, and the test's `handle.join()` runs after the reconcile returns. Even the pre-fix stub joined accepted workers before exiting — so an accepted request always completed before the join, and "in-flight at the join" can't produce a failure. What can: **the stub dying early**. Its accept loop was a non-blocking poll under wall-clock caps (5s since spawn / 500ms idle), and the named test makes exactly **one** connection (`remote_reconcile_batch_size = max(64, 4096×32)` → one 1005-job window; `sub_batch_ranges` at ~42 chars/text → one range → one request). Under host load, the pre-connect work (skip-summary over 1005 compressed chunks, id-batched selection, cache lookups) pushes that single connect past the caps; the stub exits, the connect is refused, `write_remote_scoped_or_failed` classifies it `AbortImmediately`, and all 1005 chunks fail. The signature agrees: every observed failure is `left: 0, right: 1005` — never a partial count, which the in-flight mechanism would produce.

## The fix

Both stubs (`spawn_reconcile_embed_stub` and its sibling `spawn_selective_failure_embed_stub`, which has the same caps and whose sequential retry traffic could trip the 500ms idle cap between requests) now use the shape your own `spawn_parallel_counting_stub_with_waits` established in openai.rs: a **blocking listener accepting exactly `max_conns` connections** — event-bounded, no wall clock. Load can only make the stub wait longer, never exit early. Trade-off inherited from that precedent: if a stub user ever made fewer connections than `max_conns`, the join would hang until nextest's ci-profile slow-timeout kills it loudly — all four users' counts are exact by construction (1, 4, 1, 8; derived from the batching arithmetic, independently re-verified).

## Evidence (20-run tables, independently re-verified)

| scenario | result |
|---|---|
| before, quiet ×20 | 20/20 pass (matches the issue: quiet machines pass) |
| before, 5-core load wave ×20 | **5/20 pass** — all 15 failures `left: 0` |
| after, quiet ×20 | 20/20 |
| after, same load wave ×20 | **20/20** |
| mutation: wall-clock cap re-added (scratch, 500ms — tighter than the original, hence harsher than the 15/20) ×20 under load | 0/20, same assertion |

Full suite 3173/3173 before and after; the `freshness_version_tests` module (all four stub users) 28/28; nightly fmt clean; clippy clean core-scoped on 1.95 and full-workspace `--all-features` on 1.96 (the pre-existing `collapsible_match` at rag-rat-oplog/…/storage.rs:1452 under 1.95 is on main, untouched).

---
Generated by Claude Fable 5 (brief, review), Kimi K3 (implementation)