### PR TITLE
ci: make bench-pr-track's instruction gate tracking-only, matching bench.yml (fixes #648)

### DIFF
--- a/.github/workflows/bench-pr-track.yml
+++ b/.github/workflows/bench-pr-track.yml
@@ -51,7 +51,14 @@ jobs:
 
       - uses: bencherdev/bencher@main
 
-      # Instruction counts (iai-callgrind) — deterministic, tight percentage threshold.
+      # Instruction counts (iai-callgrind) — TRACKING ONLY, no `--err`. iai is *mostly*
+      # deterministic, but the search path iterates `HashMap`s seeded by `RandomState`, so
+      # instruction counts jitter a few percent run-to-run; a 2% `--err` gate (cloned from main's
+      # threshold via --start-point-clone-thresholds) red-failed PRs on noise that main's own
+      # bench.yml deliberately stopped gating for the same reason (see its "Track instruction
+      # counts" comment). Track + alert in Bencher instead of hard-failing the PR check — same
+      # "headline signal, not a gate" stance as bench.yml. See #648. Re-arm `--err` once the
+      # start-point baseline is current and the query benches are deterministically seeded.
       - name: Track instruction counts (iai-callgrind)
         run: |
           bencher run \
@@ -64,7 +71,6 @@ jobs:
             --adapter rust_iai_callgrind \
             --github-actions '${{ secrets.GITHUB_TOKEN }}' \
             --ci-number "$PR_NUMBER" \
-            --err \
             --file benchmark_results_iai.txt
 
       # Wall-clock index time (criterion) — noisier, statistical threshold lives on the main branch.


### PR DESCRIPTION
Your suggested fix, first clause: `--err` dropped from bench-pr-track's iai-callgrind step, so PR instruction counts are tracked and alerted in Bencher but never hard-fail the check — the same "headline signal, not a gate" stance bench.yml already documents for the identical tool. The rationale now lives at the site: the step's comment (adapted from bench.yml's) explains the `HashMap`/`RandomState` jitter, the stale-baseline zero-signal history, cites #648, and states the re-arm condition (current start-point + deterministically-seeded query benches).

Deliberately untouched, flagged rather than silently decided:
- **The criterion step's `--err` stays.** Your fix section and the claimed scope named only the iai-callgrind step; latency is a different measure class. It does share the "noisy metric hard-gated on a PR" shape (bench.yml calls criterion noisy too), so parity there is a natural fast-follow if you want it — say the word.
- **The stale start-point** (index baseline 1.26e9 vs ~1.63e9 reality — the thing that made even the deterministic bench alert on my test-only #768 merge) is bencher.dev dashboard-side; no workflow edit can fix it, so it's noted, not faked.
- The restrict-threshold-to-index variant isn't a trivial flag in this `bencher run` shape — the simple drop matches your first clause.

One file, one flag removed, one comment block; YAML parses clean. This PR's own run exercises the changed workflow directly.

---
Generated by Claude Fable 5 (brief, review), Claude Sonnet 4.6 (implementation)