### PR TITLE
Fix #689: pin backend images by digest; bump deliberately

### DIFF
--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -32,11 +32,15 @@ All three backends speak the **OpenAI-compatible embeddings API** (`POST <embedP
 input:[…], encoding_format:"float"}` → `{data:[{embedding,index}]}`), so the embed call and the
 readiness probe are backend-independent. Only the **route** differs:
 
-| Backend | Image | Port | Embeddings route | GPU | Model load |
+| Backend | Image (pinned, `#689`) | Port | Embeddings route | GPU | Model load |
 |---|---|---|---|---|---|
-| `ollama` | `ollama/ollama:latest` | 11434 | `/v1/embeddings` | optional | `ollama pull` after boot |
-| `infinity` | `michaelf34/infinity:latest[-cpu]` | 7997 | `/embeddings` | optional | auto-download on boot |
-| `vllm` | `vllm/vllm-openai:latest` | 8000 | `/v1/embeddings` | **required** | auto-download on boot |
+| `ollama` | `ollama/ollama:0.32.1@sha256:6345fbc18bd73a1e16404be681dbc6fd291a027cab43ed541abe78c4c81051b0` | 11434 | `/v1/embeddings` | optional | `ollama pull` after boot |
+| `infinity` | `michaelf34/infinity:0.0.77@sha256:11e8b3921b9f1a58965afaad4a844c435c9807cbc82c51e47cb147b7d977fc88` (GPU) / `michaelf34/infinity:latest-cpu@sha256:161ef2dd48ba050ad29a413d671270502acb4ad67759d695eb0d325c033a935d` (CPU) | 7997 | `/embeddings` | optional | auto-download on boot |
+| `vllm` | `vllm/vllm-openai:v0.25.1@sha256:e4f88a835143cd22aee2397a26ec6bb80b3a4a6fe0c882bcbc63822904766089` | 8000 | `/v1/embeddings` | **required** | auto-download on boot |
+
+Images are pinned `tag@digest` (see `recipes/backends.mts`) — an unpinned `:latest` let upstream image
+bumps change server behavior with no change on our side; bump the pin deliberately, never revert to
+`:latest`.
 
 `model` is backend-specific: an **ollama model name** (`all-minilm`) for ollama, a **HuggingFace
 model id** (`sentence-transformers/all-MiniLM-L6-v2`) for infinity/vLLM (which download it from HF on

--- a/cookbook/package-lock.json
+++ b/cookbook/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rag-rat/cookbook",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rag-rat/cookbook",
-      "version": "0.6.3",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "modal": "^0.8.1"

--- a/cookbook/package.json
+++ b/cookbook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rag-rat/cookbook",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "description": "Ephemeral remote-runtime provisioning recipes for rag-rat. rag-rat (Rust) spawns a recipe as a subprocess, reads a typed JSONL event stream from its stdout (status/log/ready/error), embeds against the endpoint, then signals teardown.",
   "license": "MIT",
   "repository": {

--- a/cookbook/recipes/backends.mts
+++ b/cookbook/recipes/backends.mts
@@ -23,6 +23,12 @@
  *   - vLLM      `vllm/vllm-openai:latest`      entrypoint `vllm serve`
  *               → `<hf> --runner pooling --host 0.0.0.0 --port 8000`; auto-downloads on boot; serves
  *               `/v1/embeddings`; port 8000; GPU-REQUIRED (no official CPU image).
+ *
+ * #689: all three images below are pinned `tag@digest` rather than tracking `:latest` — an unpinned
+ * `:latest` lets an upstream image bump change engine behavior under us with no change on our side
+ * (the original vLLM regression this issue reports). Each pin is the digest `:latest` resolved to on
+ * 2026-07-18 (via the Docker Hub registry API — see the PR/commit for the exact `curl` evidence);
+ * bump deliberately by re-resolving and updating the pin, never by reverting to `:latest`.
  */
 
 import type { Backend, Capability, CookbookInput } from "../src/contract.js";
@@ -139,7 +145,8 @@ const OLLAMA_SPEC: BackendServerSpec = {
   capabilities: ["embed", "chat"],
   requiresGpu: false,
   modelLoad: "ollama-pull",
-  image: () => "ollama/ollama:latest",
+  // #689: pinned to ollama 0.32.1 (resolved from `:latest` 2026-07-18) — bump deliberately.
+  image: () => "ollama/ollama:0.32.1@sha256:6345fbc18bd73a1e16404be681dbc6fd291a027cab43ed541abe78c4c81051b0",
   // `serve` boots an empty server regardless of capability; the model (embed or chat) is pulled after.
   entrypointArgs: () => ["serve"],
   servePath: (capability) => (capability === "chat" ? "/v1/chat/completions" : "/v1/embeddings"),
@@ -165,7 +172,16 @@ const INFINITY_SPEC: BackendServerSpec = {
   requiresGpu: false,
   modelLoad: "in-launch",
   // CPU image unless a GPU was explicitly requested (infinity is CPU-capable; the CPU tag is slimmer).
-  image: (input) => (input.gpu != null ? "michaelf34/infinity:latest" : "michaelf34/infinity:latest-cpu"),
+  // #689: pinned (resolved from `:latest`/`:latest-cpu` 2026-07-18) — bump deliberately.
+  //   - GPU variant resolves to infinity 0.0.77.
+  //   - CPU variant: `latest-cpu`'s current digest does NOT match any published semver tag (incl.
+  //     `0.0.77-cpu`) as of 2026-07-18 — upstream's `latest-cpu` appears stale/out of step with
+  //     `latest`. Pinning the digest anyway (freezes exactly what `latest-cpu` serves today); the
+  //     tag name is kept as the human-readable label since no matching version could be verified.
+  image: (input) =>
+    input.gpu != null
+      ? "michaelf34/infinity:0.0.77@sha256:11e8b3921b9f1a58965afaad4a844c435c9807cbc82c51e47cb147b7d977fc88"
+      : "michaelf34/infinity:latest-cpu@sha256:161ef2dd48ba050ad29a413d671270502acb4ad67759d695eb0d325c033a935d",
   // `infinity_emb` is the entrypoint; `v2` is the subcommand. `--model-id` is the HF id. infinity
   // binds 0.0.0.0 by default, so no host flag is needed. server_concurrency is intentionally NOT
   // mapped: infinity's async engine batches dynamically, so there's no concurrent-request knob —
@@ -193,7 +209,10 @@ const VLLM_SPEC: BackendServerSpec = {
   // vLLM's published image (`vllm/vllm-openai`) is CUDA-only — a provider must attach a GPU.
   requiresGpu: true,
   modelLoad: "in-launch",
-  image: () => "vllm/vllm-openai:latest",
+  // #689: pinned to vLLM v0.25.1 (resolved from `:latest` 2026-07-18) — bump deliberately. This is
+  // the exact issue's motivating case: an unpinned `:latest` let an upstream vLLM regression change
+  // engine behavior under every ephemeral chat/embed box with no change on our side.
+  image: () => "vllm/vllm-openai:v0.25.1@sha256:e4f88a835143cd22aee2397a26ec6bb80b3a4a6fe0c882bcbc63822904766089",
   // Entrypoint is `vllm serve`, so the model id is the first positional. vLLM binds loopback unless
   // `--host 0.0.0.0` is passed — the classic "up but unreachable" trap. The RUNNER is capability-
   // dependent: `--runner pooling` puts vLLM in embedding mode (current flag; the old `--task embed`

--- a/cookbook/recipes/modal.mts
+++ b/cookbook/recipes/modal.mts
@@ -133,7 +133,11 @@ async function provision(ctx: ProvisionContext<Sandbox>): Promise<Provisioned<Sa
     modal.apps.fromName(APP_NAME, { createIfMissing: true }),
   );
 
-  const image = modal.images.fromRegistry(spec.image(input));
+  // #689: name the resolved image in the event stream so an image-related boot failure is
+  // attributable from the log view instead of surfacing as an opaque `SandboxWaitUntilReady` error.
+  const resolvedImage = spec.image(input);
+  log("info", `using ${spec.backend} image: ${resolvedImage}`);
+  const image = modal.images.fromRegistry(resolvedImage);
 
   // CREATE-TIMEOUT ORPHAN (#330-1, the Modal analog of RunPod's N3 deploy-orphan sweep): the create
   // is `withBudget`-bounded, but Modal can REACH the backend and CREATE the sandbox and then have the

--- a/cookbook/recipes/runpod.mts
+++ b/cookbook/recipes/runpod.mts
@@ -132,6 +132,11 @@ async function provision(ctx: ProvisionContext<PodHandle>): Promise<Provisioned<
   // the model's HF context).
   const dockerArgs = (await spec.entrypointArgs(input)).join(" ");
 
+  // #689: name the resolved image in the event stream so an image-related boot failure is
+  // attributable from the log view instead of surfacing as an opaque deploy/readiness error.
+  const resolvedImage = spec.image(input);
+  log("info", `using ${spec.backend} image: ${resolvedImage}`);
+
   // Deploy the pod. The backend spec supplies the image, the dockerArgs (entrypoint args joined),
   // and the container env; `ports "<port>/http"` exposes the proxy. No persistent volume (ephemeral).
   //
@@ -151,7 +156,7 @@ async function provision(ctx: ProvisionContext<PodHandle>): Promise<Provisioned<
           gpuCount: 1,
           gpuTypeId,
           name: podName,
-          imageName: spec.image(input),
+          imageName: resolvedImage,
           dockerArgs,
           ports: `${port}/http`,
           containerDiskInGb: CONTAINER_DISK_GB,


### PR DESCRIPTION
Read your assignment-without-a-tag as "baseline the present" — every pin below freezes exactly what its tag serves today (registry-API `docker-content-digest`, cross-referenced against Docker Hub's tag list for the human-readable version), and the code comment at each names the version + date + "bump deliberately, #689". All three backends folded in per the issue's "while at it":

| image | pinned to |
|---|---|
| vLLM | `v0.25.1@sha256:e4f88a83…` (latest == v0.25.1, 2026-07-13) |
| ollama | `0.32.1@sha256:6345fbc1…` (latest == 0.32.1, 2026-07-16) |
| infinity (GPU) | `0.0.77@sha256:11e8b392…` |
| infinity (CPU) | `latest-cpu@sha256:161ef2dd…` — **see caveat** |

**The caveat worth your eyes:** `infinity:latest-cpu`'s current digest matches *no* published semver tag — including `0.0.77-cpu`, which is a different digest — so the CPU image looks stale relative to `latest`/`0.0.77` upstream. The pin still stops silent drift (that's the goal), but there's no truthful version label to attach; called out in the code comment and README rather than inventing one.

**The third ask** (provision-time log event): done in the existing `log("info", ...)` idiom from `contract.ts` — one line in each provider recipe (`modal.mts`, `runpod.mts`) naming the resolved image right where the box is created, so image-related boot failures are attributable from the event stream. (runpod's duplicate `spec.image(input)` call collapsed into the captured value while there — no behavior change.)

Cookbook `tsc --noEmit` clean; no Rust touched, so no suite run — cookbook/docs-only. Two other `:latest` mentions deliberately left (the local-dev compose snippets in the skills references and a doc-comment in `types.rs`) — outside the provisioning path this issue is about.

---
Generated by Claude Fable 5 (brief, review), Claude Sonnet 4.6 (implementation)