### PR TITLE
test(oplog): bound-invariant coverage (lamport-i64, ed25519 strict, fold firewall, wrap cap)

### DIFF
--- a/crates/rag-rat-oplog/src/account/secrets/ops.rs
+++ b/crates/rag-rat-oplog/src/account/secrets/ops.rs
@@ -333,6 +333,32 @@ mod tests {
     }
 
     #[test]
+    fn an_over_bound_wrap_recipient_set_is_rejected() {
+        // §18a bound guard at the WIRE: authoring an op whose wrap fan-out exceeds
+        // `WRAP_RECIPIENTS_MAX` must FAIL in `encode` (the cap is enforced in `canonical_wraps`),
+        // so the signer can never emit a payload the bounded decoder — and every peer — would
+        // structurally reject. `WRAP_RECIPIENTS_MAX + 1` DISTINCT recipients (distinct so neither
+        // the exact-duplicate dedup nor the conflicting-recipient check consumes them before the
+        // bound check) is over the line by exactly one.
+        let sealed = sealed_for(0x10); // one valid SealedKeyWrap reused; the cap is on COUNT
+        let wraps: Vec<WrapEntry> = (0..=WRAP_RECIPIENTS_MAX as u32)
+            .map(|i| {
+                let mut fp = [0u8; 32];
+                fp[..4].copy_from_slice(&i.to_be_bytes()); // distinct recipient_fp per entry
+                WrapEntry {
+                    recipient_fp: DeviceFingerprint::from_bytes(fp),
+                    sealed: sealed.clone(),
+                }
+            })
+            .collect();
+        assert_eq!(wraps.len(), WRAP_RECIPIENTS_MAX + 1, "one over the bound");
+        assert!(
+            encode(&op(wraps)).is_err(),
+            "encode must reject a wrap set over WRAP_RECIPIENTS_MAX",
+        );
+    }
+
+    #[test]
     fn non_canonical_known_wire_is_rejected_by_re_encode() {
         // A trailing byte after a valid StreamKeyWrap fails the encode(decode) == bytes check.
         let good = encode(&op(vec![wrap_entry(0x10)])).unwrap();

--- a/crates/rag-rat-oplog/src/account/secrets/sealing.rs
+++ b/crates/rag-rat-oplog/src/account/secrets/sealing.rs
@@ -511,6 +511,20 @@ mod tests {
             .unwrap()
     }
 
+    /// The SHARED fold verdict for one entry: its `accepted` flag plus the persisted §16.3
+    /// `(status, detail)` taxonomy. This is exactly the device-independent state the read-time
+    /// cross-check must NEVER touch (the fold firewall).
+    fn fold_verdict(conn: &Connection, entry_hash: [u8; 32]) -> (i64, String, Option<String>) {
+        conn.query_row(
+            "SELECT e.accepted, s.status, s.detail
+             FROM account_entries e JOIN account_entry_status s ON s.entry_hash = e.entry_hash
+             WHERE e.entry_hash = ?1",
+            [entry_hash.as_slice()],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .unwrap()
+    }
+
     fn expect_ready(outcome: SealingKeyOutcome) -> ContentKey {
         match outcome {
             SealingKeyOutcome::Ready(key) => key,
@@ -634,11 +648,28 @@ mod tests {
         let (bytes, entry_hash) = wrap_entry(account, &founder, 0, None, Some(genesis_hash), &wrap);
         ingest(&conn, &bytes);
 
+        // FOLD FIREWALL: the wrap is validly signed by an owner, so the shared fold ACCEPTS it
+        // (device-independent). The read-time cross-check below must leave that verdict untouched.
+        let verdict_before = fold_verdict(&conn, entry_hash);
+        assert_eq!(
+            verdict_before,
+            (1, "accepted".to_string(), None),
+            "the offending wrap folds accepted before the cross-check",
+        );
+
         assert!(matches!(
             current_sealing_key(&conn, account, stream_id, &device, NOW).unwrap(),
             SealingKeyOutcome::FailedClosed
         ));
         assert_eq!(security_event_kinds(&conn), vec!["wrap_key_id_mismatch".to_string()]);
+        // The cross-check wrote ONLY sync_security_events — the fold verdict (accepted flag +
+        // persisted status/detail) is byte-for-byte unchanged. A regression that let the read path
+        // condemn/unaccept the offending wrap would break fold device-independence and fail here.
+        assert_eq!(
+            fold_verdict(&conn, entry_hash),
+            verdict_before,
+            "a key_id mismatch must NOT mutate the shared fold verdict",
+        );
         // The recorded event names the offending op + both key_ids.
         let (recorded_hash, expected, observed): (Vec<u8>, Vec<u8>, Vec<u8>) = conn
             .query_row(
@@ -674,11 +705,27 @@ mod tests {
         let (bytes, entry_hash) = wrap_entry(account, &founder, 0, None, Some(genesis_hash), &wrap);
         ingest(&conn, &bytes);
 
+        // FOLD FIREWALL: the corrupted-ciphertext wrap is still a validly-signed owner op, so the
+        // shared fold ACCEPTS it (the AEAD failure is a device-LOCAL read-time fact, not a fold
+        // input). Capture the accepted verdict so the cross-check below can be proven inert on it.
+        let verdict_before = fold_verdict(&conn, entry_hash);
+        assert_eq!(
+            verdict_before,
+            (1, "accepted".to_string(), None),
+            "the offending wrap folds accepted before the cross-check",
+        );
+
         assert!(matches!(
             current_sealing_key(&conn, account, stream_id, &device, NOW).unwrap(),
             SealingKeyOutcome::FailedClosed
         ));
         assert_eq!(security_event_kinds(&conn), vec!["wrap_unwrap_failed".to_string()]);
+        // The unwrap failure recorded LOCAL evidence only; the shared fold verdict is unchanged.
+        assert_eq!(
+            fold_verdict(&conn, entry_hash),
+            verdict_before,
+            "an unwrap failure must NOT mutate the shared fold verdict",
+        );
         // No observed key_id (no key was recovered).
         let observed: Option<Vec<u8>> = conn
             .query_row(

--- a/crates/rag-rat-oplog/src/device.rs
+++ b/crates/rag-rat-oplog/src/device.rs
@@ -248,6 +248,61 @@ fn is_small_order(bytes: &[u8; 32]) -> bool {
 mod tests {
     use super::*;
 
+    #[test]
+    fn verify_rejects_small_order_signature() {
+        // The module doc pins the CHOICE of `verify_strict` precisely BECAUSE it rejects
+        // malleable / small-order signatures a plain `verify` would accept. Guard that choice with
+        // a genuine small-order vector: the pubkey A and the signature's R are both the curve
+        // IDENTITY point (compressed `01 00..00`), with S = 0.
+        //
+        // Why this vector isolates the strict check:
+        //   - `DevicePublic::from_bytes` ACCEPTS A: `from_bytes` only rejects encodings that fail
+        //     to decompress, and the identity decompresses (y = 1, x = 0). Small-order points are
+        //     deliberately NOT refused there — that is verification's job.
+        //   - a plain (cofactorless) `verify` ACCEPTS this signature: with A = identity, `[k]A` is
+        //     the identity for any k, so the group equation `[S]B == R + [k]A` reduces to `[0]B ==
+        //     R`, i.e. `identity == identity`. (Asserted below, so the vector genuinely DISAGREES
+        //     with the strict path — a regression to non-strict `verify` would start ACCEPTING it
+        //     and fail this test.)
+        //   - `verify_strict` REJECTS it: `R.is_small_order() || A.is_small_order()` fires.
+        //
+        // This is NOT the S+L malleability transform: S here is the canonical scalar 0, not a
+        // non-canonical `s + L`. A non-canonical S is rejected by plain `verify` too, so it would
+        // pass this assertion even after a regression to non-strict verify and would NOT guard the
+        // documented choice. A small-order component is the only property that separates the two.
+        let identity = {
+            let mut a = [0u8; 32];
+            a[0] = 1; // compressed Edwards identity: y = 1, sign bit 0
+            a
+        };
+        let sig_bytes = {
+            let mut s = [0u8; 64];
+            s[0] = 1; // R = compressed identity; the S half stays all-zero (the scalar 0)
+            s
+        };
+        let msg = b"small-order rejection vector";
+
+        // Premise: the plain, non-strict cofactorless verify ACCEPTS this signature — the
+        // disagreement that makes the strict assertion below load-bearing.
+        {
+            use ed25519_dalek::Verifier;
+            let vk = VerifyingKey::from_bytes(&identity).expect("identity decompresses");
+            let sig = Signature::from_bytes(&sig_bytes);
+            assert!(
+                vk.verify(msg, &sig).is_ok(),
+                "premise: plain verify accepts the small-order vector (so only strict rejects it)",
+            );
+        }
+
+        // `from_bytes` accepts the small-order/identity pubkey (it is a well-formed curve point)…
+        let public = DevicePublic::from_bytes(&identity).expect("identity is a valid curve point");
+        // …but the module's `verify` (verify_strict) rejects the small-order signature.
+        assert!(
+            public.verify(msg, &sig_bytes).is_err(),
+            "verify_strict must reject a small-order R / identity-key signature",
+        );
+    }
+
     /// Two distinct fixed seeds → two distinct devices; deterministic across calls.
     fn seed_a() -> [u8; 32] {
         [7u8; 32]

--- a/crates/rag-rat-oplog/src/store.rs
+++ b/crates/rag-rat-oplog/src/store.rs
@@ -952,6 +952,22 @@ mod tests {
     }
 
     #[test]
+    fn append_rejects_lamport_overflowing_i64() {
+        // Phase-B bound guard: `append` narrows the u64 lamport via `i64::try_from`. A regression
+        // to `as i64` would wrap a lamport >= 2^63 to a NEGATIVE i64 and durably poison the
+        // (stream, device) chain order (it stores + orders by the signed INTEGER). A genesis signed
+        // at exactly 2^63 must be a hard `Err` (NOT an `AppendOutcome`), and nothing may enter the
+        // log — the reject-don't-trust posture the comment at the `try_from` pins.
+        let conn = db();
+        let s = secret(7);
+        let g = entry::sign_entry(&s, stream_a(), None, 1u64 << 63, &create("mem_a", "overflow"));
+        let err = append(&conn, stream_a(), &g.signed_bytes, &s.public(), 1_000)
+            .expect_err("a lamport that overflows i64 is a hard error, not an outcome");
+        assert!(err.to_string().contains("exceeds i64"), "unexpected error: {err}");
+        assert_eq!(entry_count(&conn), 0, "the overflowing entry never entered the log");
+    }
+
+    #[test]
     fn author_op_mints_a_genesis_chain_and_projects() {
         let conn = db();
         let device = crate::local_device(&conn, 0).unwrap();


### PR DESCRIPTION
Adds regression coverage for four load-bearing bound/safety invariants that were tested only at the pure-predicate level (or not at all), never at the seam where the graceful-fail behavior matters.

- **Phase-B lamport i64-overflow guard:** `append` rejects a lamport ≥ 2^63 (guards `i64::try_from` against a regression to `as i64`, which would wrap negative and durably poison a chain).
- **ed25519 `verify_strict` small-order rejection:** a genuine small-order vector (identity pubkey + identity R) that plain cofactorless `verify` accepts but `verify_strict` rejects — pins the documented malleability-resistance choice (deliberately *not* an S+L transform, which plain verify also rejects and so wouldn't guard the choice).
- **Fold firewall:** the read-time key_id adoption cross-check records only `sync_security_events` and never mutates a fold verdict — asserts the offending wrap's `accepted` flag and status are unchanged across the call (device-independence of the shared fold).
- **WRAP_RECIPIENTS_MAX:** an over-cap recipient set is rejected at encode.

Test-only, no production change. `cargo nextest run -p rag-rat-oplog` → 461 passed; clippy (`-D warnings`, both feature sets) and nightly `fmt --check` clean.
