### PR TITLE
feat(cli): rag-rat rm <path> — remove a repo from the global index (purge + VACUUM), config, and hooks

### DIFF
--- a/crates/rag-rat-base/src/config/load.rs
+++ b/crates/rag-rat-base/src/config/load.rs
@@ -4,8 +4,9 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
 use super::{
-    self as config, Config, ConfigError, LlmConfig, LogConfig, MemoryConfig, PapertrailConfig,
-    RawConfig, RawTarget, ResolvedTarget, TargetKind, TrackerConfig,
+    self as config, Config, ConfigError, DistillLlmConfig, DreamLlmConfig, EmbeddingConfig,
+    LlmConfig, LogConfig, MemoryConfig, OracleConfig, PapertrailConfig, RawConfig, RawTarget,
+    ResolvedTarget, SearchConfig, TargetKind, TrackerConfig, VersionCheckConfig, WatchConfig,
 };
 use crate::language::Language;
 
@@ -304,6 +305,35 @@ impl Config {
             source_root_reanchored_from,
             allow_empty: false,
         })
+    }
+
+    /// A minimal config for commands that only need a database path and a working root, used when
+    /// no `rag-rat.toml` is present (e.g., `rag-rat rm` on a deleted checkout). Most fields are set
+    /// to their defaults; the command is expected to only use `database`, `root`, and
+    /// `repo_id_override`.
+    pub fn minimal_for_database(database: PathBuf, root: PathBuf) -> Self {
+        Self {
+            root,
+            database,
+            targets: Vec::new(),
+            llm: LlmConfig {
+                embedding: EmbeddingConfig::default(),
+                dream: DreamLlmConfig::default(),
+                distill: DistillLlmConfig::default(),
+            },
+            watch: WatchConfig::default(),
+            log: LogConfig::default(),
+            version_check: VersionCheckConfig::default(),
+            oracle: OracleConfig::default(),
+            search: SearchConfig::default(),
+            memory: MemoryConfig::default(),
+            trackers: Vec::new(),
+            papertrail: PapertrailConfig::default(),
+            repo_id_override: None,
+            database_key_pinned: false,
+            source_root_reanchored_from: None,
+            allow_empty: false,
+        }
     }
 }
 

--- a/crates/rag-rat-cli/src/cli.rs
+++ b/crates/rag-rat-cli/src/cli.rs
@@ -136,12 +136,31 @@ pub(crate) enum Command {
     /// the legacy `.rag-rat/index.sqlite` so the repo uses the global store from then on.
     Consolidate,
 
+    /// Remove a repo from the consolidated global index: purge all of its rows, then delete its
+    /// `rag-rat.toml` and uninstall its git hooks. Returning the repo needs `rag-rat init`.
+    Rm(RmArgs),
+
     /// Print the resolved configuration as JSON.
     DumpConfig,
 
     /// Check crates.io for a newer published rag-rat, refresh the cache, and print current vs
     /// latest.
     VersionCheck,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct RmArgs {
+    /// The repo to remove, by path: `.`, a relative path, or an absolute path. Resolved to a
+    /// registered repo by identity → recorded root → sole; an exact recorded-root match also
+    /// resolves a repo whose working tree was deleted or moved.
+    #[arg(value_name = "PATH", default_value = ".")]
+    pub path: PathBuf,
+    /// Skip the confirmation prompt (non-interactive).
+    #[arg(long, short = 'y')]
+    pub yes: bool,
+    /// Preview what would be deleted (per-table row counts) and exit without changing anything.
+    #[arg(long)]
+    pub dry_run: bool,
 }
 
 #[derive(Debug, Args)]

--- a/crates/rag-rat-cli/src/commands/consolidate.rs
+++ b/crates/rag-rat-cli/src/commands/consolidate.rs
@@ -2,13 +2,15 @@
 //! (memory-sync phase A7). The logic lives in `rag_rat_core::index::consolidate`; this is the thin
 //! CLI shim that renders the outcome (a pinned `database` key is refused inside `run` with the
 //! remove-the-key remedy, so every rendered import is a completed import + rename).
+use std::path::Path;
+
 use rag_rat_base::config::Config;
 use rag_rat_core::index::consolidate::{self, ConsolidateOutcome};
 
 use crate::render::print_output;
 
-pub(crate) fn consolidate(config: &Config) -> anyhow::Result<()> {
-    let outcome = consolidate::run(config)?;
+pub(crate) fn consolidate(config: &Config, config_path: &Path) -> anyhow::Result<()> {
+    let outcome = consolidate::run_with_config_path(config, config_path)?;
     match &outcome {
         ConsolidateOutcome::AlreadyGlobal { database } => print_output(&serde_json::json!({
             "status": "already_global",

--- a/crates/rag-rat-cli/src/commands/mod.rs
+++ b/crates/rag-rat-cli/src/commands/mod.rs
@@ -16,6 +16,7 @@ mod index_ops;
 mod memory;
 mod models;
 mod oracle;
+mod remove;
 mod runtime_env;
 mod search;
 mod status;
@@ -34,6 +35,7 @@ pub(crate) use models::models;
 #[cfg(feature = "eval")]
 pub(crate) use models::{benchmark_embedding, eval};
 pub(crate) use oracle::{oracle, with_oracle_write_lock};
+pub(crate) use remove::rm;
 pub(crate) use runtime_env::apply_embedding_runtime_env;
 pub(crate) use search::{brief, clusters, important_symbols, query};
 pub(crate) use status::status;

--- a/crates/rag-rat-cli/src/commands/remove.rs
+++ b/crates/rag-rat-cli/src/commands/remove.rs
@@ -24,18 +24,10 @@ pub(crate) fn rm(config: &Config, args: &RmArgs) -> anyhow::Result<()> {
     // Nothing to remove without an index — the friendly hint before any open.
     ensure_index_exists(config)?;
 
-    // Bring the store to the CURRENT schema before querying purge tables. `count_repo_rows` reads a
-    // hand-listed set of transitive tables (e.g. `clone_df_epoch`, V051), so a database written by
-    // an OLDER rag-rat that predates one of them would otherwise fail with `no such table`.
-    // Schema-only + additive; the purge then runs on the current schema. (The write commands `init`
-    // / `consolidate` migrate first for the same reason.)
-    let migration = rag_rat_core::index::IndexDatabase::migrate_schema_only(&config.database)?;
-    if migration.state != schema::SchemaState::Compatible {
-        anyhow::bail!("{}", migration.message);
-    }
-
     // Resolve the path to a registered repo + count what removal would delete, on a read
-    // connection.
+    // connection. NOTE: the store is NOT migrated yet — `count_repo_rows` tolerates a table an
+    // older schema lacks, so the preview / `--dry-run` reads an old DB without writing to it.
+    // The schema migration happens only on the destructive path below.
     let plan = {
         let storage = IndexConnection::open(&config.database)?;
         let conn = storage.connection();
@@ -67,6 +59,14 @@ pub(crate) fn rm(config: &Config, args: &RmArgs) -> anyhow::Result<()> {
             "status": "aborted",
             "repo_id": plan.repo.repo_id,
         }));
+    }
+
+    // Bring the store to the CURRENT schema before the destructive purge — an older DB may lack a
+    // transitive table `purge_repo_rows` deletes (e.g. `clone_df_epoch`, V051). AFTER the
+    // `--dry-run` / abort returns above, so a preview never writes. Schema-only + additive.
+    let migration = rag_rat_core::index::IndexDatabase::migrate_schema_only(&config.database)?;
+    if migration.state != schema::SchemaState::Compatible {
+        anyhow::bail!("{}", migration.message);
     }
 
     // The destructive step, all under the repo's write lock: purge in one transaction, deconfigure
@@ -278,16 +278,32 @@ fn clean_on_disk_footprint(roots: &[String], removed_repo_id: &str) -> CleanupRe
     result
 }
 
-/// Whether `dir` is a PRESENT git worktree whose content-derived identity is the repo being
-/// removed — the ownership gate for [`clean_on_disk_footprint`]. A gone / reused / foreign /
-/// non-git dir returns false and is left untouched (an under-deletion the removal tombstone
-/// backstops). `None` override: identity comes purely from the git content at `dir`, never a pinned
-/// id.
+/// Whether `dir` is a PRESENT checkout whose effective repo identity equals the repo being removed
+/// — the ownership gate for [`clean_on_disk_footprint`]. A gone / reused / foreign / non-git dir
+/// returns false and is left untouched (an under-deletion the removal tombstone backstops). The
+/// GOVERNING config's `[index] repo_id` pin is honored: the removed repo_id may be a pinned id, so
+/// a present checkout of the same repo resolves through its discovered config rather than the raw
+/// content-derived identity (which would differ). If config discovery/loading fails, we fall back
+/// to the content-derived identity.
 fn dir_belongs_to_removed_repo(dir: &Path, removed_repo_id: &str) -> bool {
-    dir.is_dir()
-        && rag_rat_base::repo_identity::resolve_repo_identity(dir, None)
-            .map(|identity| identity.repo_id == removed_repo_id)
-            .unwrap_or(false)
+    if !dir.is_dir() {
+        return false;
+    }
+
+    // Honor pinned repo IDs: discover the governing config for this dir and use its override, so a
+    // pinned repo's checkout still passes the ownership gate. A config load failure is not fatal —
+    // we fall back to the content-derived identity, which is correct for non-pinned repos and for
+    // a reused path whose config is gone.
+    let config_path = rag_rat_base::config::discover_config_path(dir);
+    let override_id = rag_rat_base::config::Config::load(&config_path)
+        .ok()
+        .and_then(|config| config.repo_id_override);
+    let identity = match override_id.as_deref() {
+        Some(override_id) =>
+            rag_rat_base::repo_identity::resolve_repo_identity(dir, Some(override_id)),
+        None => rag_rat_base::repo_identity::resolve_repo_identity(dir, None),
+    };
+    identity.map(|identity| identity.repo_id == removed_repo_id).unwrap_or(false)
 }
 
 /// `root` itself plus every git worktree linked to it (`git worktree list --porcelain`).

--- a/crates/rag-rat-cli/src/commands/remove.rs
+++ b/crates/rag-rat-cli/src/commands/remove.rs
@@ -24,12 +24,15 @@ pub(crate) fn rm(config: &Config, args: &RmArgs) -> anyhow::Result<()> {
     // Nothing to remove without an index — the friendly hint before any open.
     ensure_index_exists(config)?;
 
-    // Resolve the path to a registered repo + count what removal would delete, on a read
-    // connection. NOTE: the store is NOT migrated yet — `count_repo_rows` tolerates a table an
-    // older schema lacks, so the preview / `--dry-run` reads an old DB without writing to it.
-    // The schema migration happens only on the destructive path below.
+    // Resolve the path to a registered repo + count what removal would delete on a GENUINELY
+    // read-only connection. `IndexConnection::open` is not read-only: setup persists
+    // `journal_mode=WAL` and may create WAL sidecars, violating `--dry-run` (and an aborted
+    // prompt's "nothing was deleted" promise) on an older DELETE-journal store. The blocking RO
+    // seam skips setup, pragma writes, directory/file creation, and migration. `count_repo_rows`
+    // tolerates tables an older schema lacks, so planning stays compatible without writing; the
+    // migration happens only on the destructive path below.
     let plan = {
-        let storage = IndexConnection::open(&config.database)?;
+        let storage = IndexConnection::open_read_only_blocking(&config.database)?;
         let conn = storage.connection();
         let Some(repo) = remove::resolve_removable_repo(conn, &args.path)? else {
             anyhow::bail!("{}", unregistered_path_message(&storage, &args.path)?);

--- a/crates/rag-rat-cli/src/commands/remove.rs
+++ b/crates/rag-rat-cli/src/commands/remove.rs
@@ -86,6 +86,7 @@ pub(crate) fn rm(config: &Config, args: &RmArgs) -> anyhow::Result<()> {
     let (outcome, cleanup) = remove::purge_and_vacuum(
         &config.database,
         &plan.repo.repo_id,
+        plan.repo.removal_generation,
         rag_rat_base::time::now_ms(),
         || clean_on_disk_footprint(&cleanup_dirs, &plan.repo.repo_id),
     )?;

--- a/crates/rag-rat-cli/src/commands/remove.rs
+++ b/crates/rag-rat-cli/src/commands/remove.rs
@@ -1,0 +1,378 @@
+//! `rm`: remove a repo from the consolidated global index and clean its on-disk footprint. The
+//! database purge (which rows, under which lock, in one transaction, then VACUUM) lives in
+//! `rag_rat_core::index::remove`; this shim resolves the path argument to a registered repo,
+//! renders the confirmation summary, prompts (unless `--yes`), and passes the on-disk deconfigure
+//! closure (delete `rag-rat.toml` + uninstall git hooks over the repo's governing roots) that
+//! `purge_and_vacuum` runs UNDER the write lock — best-effort: a missing file/hook is a no-op, and
+//! a cleanup failure WARNS rather than failing an already-committed purge.
+
+use std::collections::BTreeMap;
+use std::io::IsTerminal;
+use std::path::{Path, PathBuf};
+
+use dialoguer::Confirm;
+use rag_rat_base::config::Config;
+use rag_rat_core::index::remove::{self, RemovePlan};
+use rag_rat_db::schema;
+use rag_rat_db::storage::IndexConnection;
+
+use crate::cli::RmArgs;
+use crate::render::print_output;
+use crate::{MANAGED_HOOKS, ensure_index_exists, git_paths, is_rag_rat_hook};
+
+pub(crate) fn rm(config: &Config, args: &RmArgs) -> anyhow::Result<()> {
+    // Nothing to remove without an index — the friendly hint before any open.
+    ensure_index_exists(config)?;
+
+    // Bring the store to the CURRENT schema before querying purge tables. `count_repo_rows` reads a
+    // hand-listed set of transitive tables (e.g. `clone_df_epoch`, V051), so a database written by
+    // an OLDER rag-rat that predates one of them would otherwise fail with `no such table`.
+    // Schema-only + additive; the purge then runs on the current schema. (The write commands `init`
+    // / `consolidate` migrate first for the same reason.)
+    let migration = rag_rat_core::index::IndexDatabase::migrate_schema_only(&config.database)?;
+    if migration.state != schema::SchemaState::Compatible {
+        anyhow::bail!("{}", migration.message);
+    }
+
+    // Resolve the path to a registered repo + count what removal would delete, on a read
+    // connection.
+    let plan = {
+        let storage = IndexConnection::open(&config.database)?;
+        let conn = storage.connection();
+        let Some(repo) = remove::resolve_removable_repo(conn, &args.path)? else {
+            anyhow::bail!("{}", unregistered_path_message(&storage, &args.path)?);
+        };
+        remove::plan_remove(conn, repo)?
+    };
+
+    // Human-readable per-category summary to stderr; the structured plan/outcome goes to stdout.
+    eprint!("{}", render_plan_summary(&plan));
+
+    if args.dry_run {
+        eprintln!("rm: --dry-run — nothing was deleted.");
+        return print_output(&serde_json::json!({
+            "status": "dry_run",
+            "repo_id": plan.repo.repo_id,
+            "display_name": plan.repo.display_name,
+            "roots": plan.repo.roots,
+            "resolved_root": plan.repo.resolved_root,
+            "total_rows": plan.counts.total_rows,
+            "by_table": plan.counts.by_table,
+        }));
+    }
+
+    if !args.yes && !confirm_removal(&plan)? {
+        eprintln!("rm: aborted — nothing was deleted.");
+        return print_output(&serde_json::json!({
+            "status": "aborted",
+            "repo_id": plan.repo.repo_id,
+        }));
+    }
+
+    // The destructive step, all under the repo's write lock: purge in one transaction, deconfigure
+    // the repo on disk (delete rag-rat.toml + uninstall hooks over its recorded governing roots),
+    // then VACUUM. The deconfiguration runs INSIDE the lock, before it is released, so a writer
+    // waiting on the lock cannot re-register the repo before it is made un-re-indexable.
+    // Cleanup candidates: the recorded governing roots PLUS the checkout the removal resolved
+    // through. `resolved_root` matters when the repo was registered ONLY via the read-only path
+    // (no `repo_roots` entry, so `roots` is empty) — without it `rm` would report success while
+    // deleting nothing on disk. It is deduped against `roots` and still passes the ownership guard,
+    // so adding it never widens what gets deleted to a foreign repo.
+    let mut cleanup_dirs = plan.repo.roots.clone();
+    cleanup_dirs.push(plan.repo.resolved_root.to_string_lossy().into_owned());
+    let (outcome, cleanup) = remove::purge_and_vacuum(
+        &config.database,
+        &plan.repo.repo_id,
+        rag_rat_base::time::now_ms(),
+        || clean_on_disk_footprint(&cleanup_dirs, &plan.repo.repo_id),
+    )?;
+
+    print_output(&serde_json::json!({
+        "status": "removed",
+        "repo_id": outcome.repo_id,
+        "display_name": outcome.display_name,
+        "purged_rows": outcome.purged_rows,
+        "vacuum": outcome.vacuum,
+        "vacuum_skipped": outcome.vacuum_skipped,
+        "configs_removed": cleanup.configs_removed,
+        "hooks_removed": cleanup.hooks_removed,
+        "cleanup_warnings": cleanup.warnings,
+        "next": "run `rag-rat init` in the repo to index it again",
+    }))
+}
+
+/// Group the per-table counts into a small set of human categories and render a summary block. The
+/// grouping is display-only (by table-name family) — the authoritative figure is `total_rows`, so a
+/// table the grouping does not recognize still lands in `other` and is still counted.
+fn render_plan_summary(plan: &RemovePlan) -> String {
+    let mut categories: BTreeMap<&'static str, i64> = BTreeMap::new();
+    for (table, count) in &plan.counts.by_table {
+        *categories.entry(category_of(table)).or_insert(0) += count;
+    }
+    let mut out = String::new();
+    let name = plan.repo.display_name.as_deref().unwrap_or("(unnamed)");
+    out.push_str(&format!("rm: about to remove `{name}` [{}]\n", plan.repo.repo_id));
+    for root in &plan.repo.roots {
+        out.push_str(&format!("      root: {root}\n"));
+    }
+    if plan.counts.total_rows == 0 {
+        out.push_str("      (no rows in the index — registry entry only)\n");
+    } else {
+        for (category, count) in &categories {
+            out.push_str(&format!("      {category:<20} {count:>8}\n"));
+        }
+    }
+    out.push_str(&format!("      {:<20} {:>8}\n", "TOTAL rows", plan.counts.total_rows));
+    out
+}
+
+/// The display category for a table name, by family prefix. Order matters: `repo_memory*` /
+/// `repo_node_edges` are memory tables and must be matched before the `repos` / `repo_roots` /
+/// `repo_meta` registry check.
+fn category_of(table: &str) -> &'static str {
+    if table.starts_with("papertrail") {
+        "papertrail"
+    } else if table.starts_with("clone") {
+        "clones"
+    } else if table.starts_with("git") {
+        "git history"
+    } else if table.starts_with("repo_memory")
+        || table.starts_with("memory_")
+        || table == "repo_node_edges"
+    {
+        "memories"
+    } else if table == "repos" || table == "repo_roots" || table == "repo_meta" {
+        "registry"
+    } else if table.starts_with("chunk") {
+        "text & embeddings"
+    } else if table.starts_with("oracle") || table == "edge_oracle" || table == "external_symbols" {
+        "oracle"
+    } else if table.starts_with("dream") || table.starts_with("reconcile") {
+        "dream & reconcile"
+    } else {
+        // files, symbols, chunks, edges_data, logical_symbols/_members/_monikers, docs, packages,
+        // parser_failures — the tree-sitter code graph.
+        "code graph"
+    }
+}
+
+/// Prompt for confirmation, defaulting to NO (a destructive op must not proceed on a bare Enter).
+/// Refuses non-interactively with an actionable hint to pass `--yes` rather than erroring obscurely
+/// inside dialoguer.
+fn confirm_removal(plan: &RemovePlan) -> anyhow::Result<bool> {
+    if !std::io::stdin().is_terminal() {
+        anyhow::bail!(
+            "refusing to remove `{}` without confirmation on a non-interactive stdin — re-run \
+             with --yes (or --dry-run to preview)",
+            plan.repo.repo_id
+        );
+    }
+    Ok(Confirm::new()
+        .with_prompt(format!(
+            "Permanently remove this repo ({} rows) from the global index?",
+            plan.counts.total_rows
+        ))
+        .default(false)
+        .interact()?)
+}
+
+/// The outcome of the best-effort on-disk cleanup: the config/hook PATHS actually deleted, and any
+/// non-fatal failures as warnings.
+#[derive(Default)]
+struct CleanupResult {
+    configs_removed: Vec<String>,
+    hooks_removed: Vec<String>,
+    warnings: Vec<String>,
+}
+
+/// Delete the repo's GOVERNING `rag-rat.toml`(s) and uninstall its rag-rat-managed git hooks across
+/// every directory whose config governs — or could govern — the repo: each recorded root (from
+/// `repo_roots`, where the repo was indexed from) PLUS every git worktree linked to it, with each
+/// dir's config resolved via `discover_config_path` (the same seam `Config::load` uses). Resolving
+/// the config rather than assuming `<dir>/rag-rat.toml` matters three ways: (1) `rm` from a
+/// subdirectory / linked worktree resolves the repo by git identity, but that path is not where the
+/// governing config sits; (2) an `[index] root = "src"` layout keeps the toml at the worktree top
+/// while `repo_roots` records `<top>/src`; (3) a linked worktree can carry its OWN branch-local
+/// `rag-rat.toml`, which `Config::load`'s config-less-main fallback would promote to governing once
+/// the main config is gone — re-adopting the repo on the next keyless `rag-rat index`. Every step
+/// is best-effort: a missing file/hook is a silent no-op, and any error is a warning rather than a
+/// failure — the database purge has already committed (and tombstoned the repo, the durable stop
+/// against re-registration), so the repo is removed regardless of whether its on-disk config could
+/// be cleaned.
+fn clean_on_disk_footprint(roots: &[String], removed_repo_id: &str) -> CleanupResult {
+    let mut result = CleanupResult::default();
+
+    // Candidate dirs: each recorded root plus every git worktree linked to it, deduplicated…
+    let mut seen_dirs = std::collections::BTreeSet::new();
+    let dirs: Vec<PathBuf> = roots
+        .iter()
+        .flat_map(|root| worktree_dirs_for(Path::new(root)))
+        .filter(|dir| seen_dirs.insert(dir.clone()))
+        // …then the OWNERSHIP GUARD: only touch a dir that STILL belongs to the repo being removed —
+        // a PRESENT git worktree whose content-derived identity equals `removed_repo_id`. This is
+        // what makes the config discovery safe:
+        //  * a GONE tree (the recorded root was deleted — rm's own use case) is skipped, so
+        //    `discover_config_path`'s upward walk can never climb out of the missing git boundary
+        //    into an UNRELATED parent repo and delete ITS governing config;
+        //  * a recorded root now REUSED by a different repo derives a different id and is skipped, so
+        //    rm never deletes the new occupant's config/hooks.
+        // Skipping only UNDER-deletes (a stray config/hook left behind), which is harmless: the
+        // removal tombstone refuses re-registration regardless of a surviving config.
+        .filter(|dir| dir_belongs_to_removed_repo(dir, removed_repo_id))
+        .collect();
+
+    // The GOVERNING config file for each dir — resolved the way `Config::load` does
+    // (`discover_config_path`): an `[index] root = "src"` layout keeps the toml at the worktree top
+    // while `repo_roots` records `<top>/src`, and a linked worktree may carry a branch-local config
+    // or defer to main's. A blind `<dir>/rag-rat.toml` would miss the first and mis-handle the
+    // second; discovery lands on the file that actually governs. Deduped: several dirs can resolve
+    // to one config.
+    let mut seen_configs = std::collections::BTreeSet::new();
+    for dir in &dirs {
+        let config_path = rag_rat_base::config::discover_config_path(dir);
+        if !seen_configs.insert(config_path.clone()) {
+            continue;
+        }
+        match std::fs::remove_file(&config_path) {
+            Ok(()) => result.configs_removed.push(config_path.display().to_string()),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {},
+            Err(err) =>
+                result.warnings.push(format!("could not delete {}: {err}", config_path.display())),
+        }
+    }
+
+    // Hooks live in the SHARED git dir (one `.git/hooks` across all worktrees), so dedup hook paths
+    // across dirs and remove each managed hook once.
+    let mut seen_hooks = std::collections::BTreeSet::new();
+    for dir in &dirs {
+        // Git hooks — uninstall exactly the rag-rat-managed ones (never a user's own hook),
+        // mirroring `hooks uninstall`. `git_paths` fails when `dir` is not a git worktree
+        // (deleted / non-git), in which case there is nothing to uninstall (a
+        // non-git-worktree `Err` is a silent no-op).
+        if let Ok(git) = git_paths(dir) {
+            for hook in MANAGED_HOOKS {
+                let path = git.hooks_dir.join(hook);
+                if !seen_hooks.insert(path.clone()) {
+                    continue;
+                }
+                match is_rag_rat_hook(&path) {
+                    Ok(true) => match std::fs::remove_file(&path) {
+                        Ok(()) => result.hooks_removed.push(path.display().to_string()),
+                        Err(err) => result
+                            .warnings
+                            .push(format!("could not remove hook {}: {err}", path.display())),
+                    },
+                    // Absent or not rag-rat-managed: leave it.
+                    Ok(false) => {},
+                    Err(err) => result
+                        .warnings
+                        .push(format!("could not inspect hook {}: {err}", path.display())),
+                }
+            }
+        }
+    }
+
+    for warning in &result.warnings {
+        eprintln!("rm: warning: {warning}");
+    }
+    result
+}
+
+/// Whether `dir` is a PRESENT git worktree whose content-derived identity is the repo being
+/// removed — the ownership gate for [`clean_on_disk_footprint`]. A gone / reused / foreign /
+/// non-git dir returns false and is left untouched (an under-deletion the removal tombstone
+/// backstops). `None` override: identity comes purely from the git content at `dir`, never a pinned
+/// id.
+fn dir_belongs_to_removed_repo(dir: &Path, removed_repo_id: &str) -> bool {
+    dir.is_dir()
+        && rag_rat_base::repo_identity::resolve_repo_identity(dir, None)
+            .map(|identity| identity.repo_id == removed_repo_id)
+            .unwrap_or(false)
+}
+
+/// `root` itself plus every git worktree linked to it (`git worktree list --porcelain`).
+/// Best-effort: a non-git / missing / erroring `root` yields just `[root]`. Deconfiguration walks
+/// these so a linked worktree's branch-local `rag-rat.toml` is removed too, not only the main
+/// worktree's.
+fn worktree_dirs_for(root: &Path) -> Vec<PathBuf> {
+    let mut dirs = vec![root.to_path_buf()];
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(["worktree", "list", "--porcelain"])
+        .output();
+    if let Ok(out) = output
+        && out.status.success()
+    {
+        for line in String::from_utf8_lossy(&out.stdout).lines() {
+            if let Some(path) = line.strip_prefix("worktree ") {
+                dirs.push(PathBuf::from(path));
+            }
+        }
+    }
+    dirs
+}
+
+/// The actionable error when a path resolves to no registered repo: name the path and list the
+/// repos that ARE registered, so the operator can pick a valid one.
+fn unregistered_path_message(storage: &IndexConnection, path: &Path) -> anyhow::Result<String> {
+    let registered = schema::registered_repos(storage.connection())?;
+    let mut message = format!(
+        "`{}` is not a registered rag-rat repo in the global index — nothing to remove.",
+        path.display()
+    );
+    if registered.is_empty() {
+        message.push_str("\nThe global index has no registered repos.");
+    } else {
+        message.push_str("\nRegistered repos (remove one by its path):");
+        for repo in registered {
+            let roots = if repo.roots.is_empty() {
+                "(no recorded root)".to_string()
+            } else {
+                repo.roots.join(", ")
+            };
+            message.push_str(&format!("\n  {} [{}] — {roots}", repo.display_name, repo.repo_id));
+        }
+    }
+    Ok(message)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The P1 data-loss guard: removing a repo whose tree is GONE must NOT let
+    /// `discover_config_path` climb out of the missing git boundary and delete an UNRELATED
+    /// parent project's `rag-rat.toml`. The ownership gate skips the gone dir before any
+    /// discovery runs. Without the guard, the old code discovered and deleted the parent
+    /// config, so this test fails on a regression.
+    #[test]
+    fn cleanup_of_a_gone_tree_does_not_climb_into_a_parent_repos_config() {
+        let base = std::env::temp_dir().join(format!(
+            "ragrat-rm-guard-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        let parent = base.join("parent");
+        std::fs::create_dir_all(&parent).unwrap();
+        let parent_config = parent.join("rag-rat.toml");
+        std::fs::write(&parent_config, "# unrelated parent project config\n").unwrap();
+        // A removed child repo nested under the parent, whose working tree no longer exists.
+        let gone_child = parent.join("vendor").join("gone-child");
+
+        let result = clean_on_disk_footprint(
+            &[gone_child.to_string_lossy().to_string()],
+            "removed-child-id",
+        );
+
+        assert!(
+            parent_config.exists(),
+            "removing a gone child must NOT delete the parent project's governing config"
+        );
+        assert!(
+            result.configs_removed.is_empty(),
+            "a gone tree owns no reachable config to remove"
+        );
+        let _ = std::fs::remove_dir_all(&base);
+    }
+}

--- a/crates/rag-rat-cli/src/init/run.rs
+++ b/crates/rag-rat-cli/src/init/run.rs
@@ -74,7 +74,7 @@ fn run_non_interactive(
 
     let config = Config::load(&options.config_path)?;
     apply_embedding_runtime_env(&config.llm.embedding.runtime);
-    let db = setup_index(&config)?;
+    let db = setup_index(&config, &options.config_path)?;
     setup_model_and_reconcile(&config, &db, options.yes)?;
     if !options.no_hooks {
         offer_hooks_install(&config, options.yes)?;
@@ -117,7 +117,7 @@ fn run_interactive(options: &InitOptions) -> anyhow::Result<()> {
 
     let config = Config::load(&options.config_path)?;
     apply_embedding_runtime_env(&config.llm.embedding.runtime);
-    let db = setup_index(&config)?;
+    let db = setup_index(&config, &options.config_path)?;
     setup_model_and_reconcile(&config, &db, false)?;
     apply_wizard_hooks(&config, &result)?;
     eprintln!("init: complete");
@@ -310,7 +310,7 @@ pub(crate) fn default_plan(root_value: String, scan: &RepoScan) -> InitPlan {
     // Non-interactive default mirrors `OracleConfig`'s default: off until explicitly enabled.
     InitPlan { root_value, languages, bindings, backend, oracle_auto_run: false }
 }
-pub(crate) fn setup_index(config: &Config) -> anyhow::Result<IndexDatabase> {
+pub(crate) fn setup_index(config: &Config, config_path: &Path) -> anyhow::Result<IndexDatabase> {
     eprintln!("init: migrating SQLite schema");
     // SCHEMA-ONLY: init's subject repo is NOT registered yet (this is its very first index), so on
     // a global DB that already holds another repo the healing `migrate`'s open-time healers would
@@ -326,7 +326,7 @@ pub(crate) fn setup_index(config: &Config) -> anyhow::Result<IndexDatabase> {
     // The returned lock is held across `index_discover_with_progress` so the clear and the re-
     // registration stay under ONE serialization boundary; otherwise another `rm` could acquire the
     // lock in the gap and remove the repo init is about to re-register.
-    let tombstone_lock = clear_removal_tombstone(config)?;
+    let tombstone_lock = clear_removal_tombstone(config, config_path)?;
     eprintln!("init: indexing discovered files");
     let db = IndexDatabase::index_discover_with_progress(config, render_index_progress)?;
     // The lock, if held, is released here AFTER the indexing pass that re-registers the repo.
@@ -343,6 +343,7 @@ pub(crate) fn setup_index(config: &Config) -> anyhow::Result<IndexDatabase> {
 /// quiet.
 fn clear_removal_tombstone(
     config: &Config,
+    config_path: &Path,
 ) -> anyhow::Result<Option<rag_rat_base::locks::WriteLock>> {
     let Ok(identity) = rag_rat_base::repo_identity::resolve_repo_identity(
         &config.root,
@@ -368,6 +369,21 @@ fn clear_removal_tombstone(
              — a removal or index pass is running; retry `rag-rat init` once it finishes"
         );
     };
+    // RE-CHECK the config init wrote BEFORE clearing: if rm acquired the lock between init's
+    // `fs::write` and this acquisition, it deleted that config while holding the lock (its
+    // deconfigure step) and released it — this wait then resumes with a STALE in-memory `Config`.
+    // Clearing the tombstone now would let `index_discover_with_progress` re-register from that
+    // stale config after rm reported `removed`, with no `rag-rat.toml` left for maintenance. The
+    // lock alone cannot close this: rm's deconfigure already ran INSIDE it. Abort instead — the
+    // tombstone stays, and the operator re-runs `init` to deliberately re-add.
+    if !config_path.exists() {
+        anyhow::bail!(
+            "the config init wrote ({}) was removed while init waited for the repo write lock — a \
+             concurrent `rag-rat rm` deleted it; aborting without clearing the removal tombstone. \
+             Re-run `rag-rat init` to re-add the repo.",
+            config_path.display()
+        );
+    }
     let storage = rag_rat_db::storage::IndexConnection::open(&config.database)?;
     rag_rat_db::schema::clear_repo_removed(storage.connection(), &identity.repo_id)?;
     Ok(Some(lock))
@@ -630,6 +646,60 @@ mod default_plan_tests {
         }
         let plan = default_plan(".".to_string(), &scan);
         assert_eq!(plan.bindings.get(&Language::Python), Some(&vec![PathBuf::from("myapp")]));
+    }
+
+    /// #767 review: after acquiring the repo write lock, init must RE-CHECK that the config it
+    /// loaded still exists before clearing the removal tombstone — a concurrent `rag-rat rm` may
+    /// have deleted it (its deconfigure step) while init waited on the lock. Clearing anyway would
+    /// let the re-registration repopulate the repo after rm reported `removed`, with no
+    /// `rag-rat.toml` left.
+    #[test]
+    fn clear_removal_tombstone_aborts_when_rm_deleted_the_config_while_init_waited() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(root.path().join("src")).unwrap();
+        let db_path = root.path().join("index.sqlite");
+        let config_path = root.path().join("rag-rat.toml");
+        std::fs::write(
+            &config_path,
+            format!(
+                "[index]\nroot = \".\"\nrepo_id = \"rm-victim\"\ndatabase = \
+                 \"{}\"\n[target_bindings]\nrust = [\"src\"]\n",
+                db_path.display()
+            ),
+        )
+        .unwrap();
+        let config = Config::load(&config_path).unwrap();
+        // The store must exist at the current schema for the tombstone read/write.
+        IndexDatabase::migrate_schema_only(&config.database).unwrap();
+
+        let mark_removed = || {
+            let storage = rag_rat_db::storage::IndexConnection::open(&config.database).unwrap();
+            rag_rat_db::schema::mark_repo_removed(storage.connection(), "rm-victim", 1).unwrap();
+        };
+        let is_removed = || {
+            let storage = rag_rat_db::storage::IndexConnection::open(&config.database).unwrap();
+            rag_rat_db::schema::is_repo_removed(storage.connection(), "rm-victim").unwrap()
+        };
+
+        // Baseline: tombstoned, config present → the clear lifts the tombstone and returns the
+        // held lock.
+        mark_removed();
+        let lock = clear_removal_tombstone(&config, &config_path).unwrap();
+        assert!(lock.is_some(), "a resolvable identity takes the lock");
+        drop(lock);
+        assert!(!is_removed(), "the baseline clear lifts the tombstone");
+
+        // The race: rm deleted the config while init waited for the lock → the clear ABORTS and
+        // the tombstone STAYS, so no re-registration can follow from the stale in-memory config.
+        mark_removed();
+        std::fs::remove_file(&config_path).unwrap();
+        let err = clear_removal_tombstone(&config, &config_path)
+            .expect_err("a config removed mid-wait must abort the tombstone clear");
+        assert!(
+            err.to_string().contains("rag-rat rm"),
+            "the abort must name the concurrent removal, got: {err}"
+        );
+        assert!(is_removed(), "the tombstone must survive the aborted clear");
     }
 
     #[test]

--- a/crates/rag-rat-cli/src/init/run.rs
+++ b/crates/rag-rat-cli/src/init/run.rs
@@ -321,8 +321,46 @@ pub(crate) fn setup_index(config: &Config) -> anyhow::Result<IndexDatabase> {
     if migration.state != rag_rat_db::schema::SchemaState::Compatible {
         anyhow::bail!("{}", migration.message);
     }
+    // #767: init is the deliberate re-add a `rag-rat rm` removal tombstone allows — lift it before
+    // the config-bearing index open below calls `register_repo`, which refuses a tombstoned repo.
+    clear_removal_tombstone(config)?;
     eprintln!("init: indexing discovered files");
     IndexDatabase::index_discover_with_progress(config, render_index_progress)
+}
+
+/// Lift any `rag-rat rm` removal tombstone for the repo `init` is (re-)initializing, so the ensuing
+/// `register_repo` is allowed. An unresolvable identity is a no-op (a never-removed fresh init has
+/// no tombstone and no derivable id to clear). But once the identity resolves, an open / clear
+/// FAILURE is PROPAGATED, not swallowed: otherwise init would proceed to `register_repo`, be
+/// refused for the still-tombstoned repo, and print the confusing "run `rag-rat init`" remedy while
+/// the user is already running init. Surfacing the clear failure lets them retry once the store is
+/// quiet.
+fn clear_removal_tombstone(config: &Config) -> anyhow::Result<()> {
+    let Ok(identity) = rag_rat_base::repo_identity::resolve_repo_identity(
+        &config.root,
+        config.repo_id_override.as_deref(),
+    ) else {
+        return Ok(());
+    };
+    // Clear UNDER the repo write lock so it SERIALIZES with a concurrent `rag-rat rm`: without the
+    // lock, init could lift the tombstone in the window between rm's committed purge and rm's lock
+    // release, and the ensuing index register would repopulate the just-removed repo after rm
+    // reported success. rm holds this lock across its whole purge→deconfigure→VACUUM sequence, so
+    // the clear waits for rm to fully finish before lifting the marker.
+    let Some(_lock) = rag_rat_base::locks::WriteLock::acquire_timeout(
+        &config.database,
+        &identity.repo_id,
+        std::time::Duration::from_secs(30),
+    )?
+    else {
+        anyhow::bail!(
+            "timed out waiting for the repo write lock to lift the `rag-rat rm` removal tombstone \
+             — a removal or index pass is running; retry `rag-rat init` once it finishes"
+        );
+    };
+    let storage = rag_rat_db::storage::IndexConnection::open(&config.database)?;
+    rag_rat_db::schema::clear_repo_removed(storage.connection(), &identity.repo_id)?;
+    Ok(())
 }
 pub(crate) fn setup_model_and_reconcile(
     config: &Config,

--- a/crates/rag-rat-cli/src/init/run.rs
+++ b/crates/rag-rat-cli/src/init/run.rs
@@ -323,9 +323,15 @@ pub(crate) fn setup_index(config: &Config) -> anyhow::Result<IndexDatabase> {
     }
     // #767: init is the deliberate re-add a `rag-rat rm` removal tombstone allows — lift it before
     // the config-bearing index open below calls `register_repo`, which refuses a tombstoned repo.
-    clear_removal_tombstone(config)?;
+    // The returned lock is held across `index_discover_with_progress` so the clear and the re-
+    // registration stay under ONE serialization boundary; otherwise another `rm` could acquire the
+    // lock in the gap and remove the repo init is about to re-register.
+    let tombstone_lock = clear_removal_tombstone(config)?;
     eprintln!("init: indexing discovered files");
-    IndexDatabase::index_discover_with_progress(config, render_index_progress)
+    let db = IndexDatabase::index_discover_with_progress(config, render_index_progress)?;
+    // The lock, if held, is released here AFTER the indexing pass that re-registers the repo.
+    drop(tombstone_lock);
+    Ok(db)
 }
 
 /// Lift any `rag-rat rm` removal tombstone for the repo `init` is (re-)initializing, so the ensuing
@@ -335,19 +341,23 @@ pub(crate) fn setup_index(config: &Config) -> anyhow::Result<IndexDatabase> {
 /// refused for the still-tombstoned repo, and print the confusing "run `rag-rat init`" remedy while
 /// the user is already running init. Surfacing the clear failure lets them retry once the store is
 /// quiet.
-fn clear_removal_tombstone(config: &Config) -> anyhow::Result<()> {
+fn clear_removal_tombstone(
+    config: &Config,
+) -> anyhow::Result<Option<rag_rat_base::locks::WriteLock>> {
     let Ok(identity) = rag_rat_base::repo_identity::resolve_repo_identity(
         &config.root,
         config.repo_id_override.as_deref(),
     ) else {
-        return Ok(());
+        return Ok(None);
     };
     // Clear UNDER the repo write lock so it SERIALIZES with a concurrent `rag-rat rm`: without the
     // lock, init could lift the tombstone in the window between rm's committed purge and rm's lock
     // release, and the ensuing index register would repopulate the just-removed repo after rm
     // reported success. rm holds this lock across its whole purge→deconfigure→VACUUM sequence, so
-    // the clear waits for rm to fully finish before lifting the marker.
-    let Some(_lock) = rag_rat_base::locks::WriteLock::acquire_timeout(
+    // the clear waits for rm to fully finish before lifting the marker. RETURN the guard so the
+    // caller can keep the lock through the re-registration, closing the gap between clear and
+    // index.
+    let Some(lock) = rag_rat_base::locks::WriteLock::acquire_timeout(
         &config.database,
         &identity.repo_id,
         std::time::Duration::from_secs(30),
@@ -360,7 +370,7 @@ fn clear_removal_tombstone(config: &Config) -> anyhow::Result<()> {
     };
     let storage = rag_rat_db::storage::IndexConnection::open(&config.database)?;
     rag_rat_db::schema::clear_repo_removed(storage.connection(), &identity.repo_id)?;
-    Ok(())
+    Ok(Some(lock))
 }
 pub(crate) fn setup_model_and_reconcile(
     config: &Config,

--- a/crates/rag-rat-cli/src/main.rs
+++ b/crates/rag-rat-cli/src/main.rs
@@ -155,7 +155,14 @@ fn main() -> anyhow::Result<()> {
         #[cfg(feature = "eval")]
         Cmd::DumpVerifyPacks(args) => dump_verify_packs(&config, &args)?,
         Cmd::Oracle(args) => oracle(&config, &args)?,
-        Cmd::Consolidate => consolidate(&config)?,
+        Cmd::Consolidate => {
+            let config_path = cli
+                .config
+                .as_deref()
+                .map(PathBuf::from)
+                .unwrap_or_else(|| rag_rat_base::config::discover_config_path(Path::new(".")));
+            consolidate(&config, &config_path)?;
+        },
         Cmd::DumpConfig => dump_config(&config)?,
         Cmd::VersionCheck => version_check(&config)?,
     }
@@ -495,24 +502,20 @@ fn run_status(explicit: Option<&str>) -> anyhow::Result<()> {
 
 /// Run `rm`, tolerating the ABSENCE of a live config: `rm` targets the consolidated global store by
 /// the path argument, so a deleted/moved checkout that was the only configured one can still be
-/// purged. With a discovered config we use its `database` and any `repo_id` override; without one
-/// we fall back to the machine-global store. Only when this platform resolves no data dir at all do
-/// we fall back to the friendly "run `rag-rat init`" hint.
+/// purged. Config precedence is explicit `--config`, then the cwd's governing config, then the
+/// EXISTING target checkout's governing config (so `rm /repos/foo` from `/tmp` honors foo's custom
+/// `[index] database`), then the machine-global store. A gone target cannot safely discover upward
+/// — it may cross into an unrelated parent checkout — so it goes directly to the global fallback.
+/// Only when this platform resolves no data dir at all do we fall back to the friendly "run
+/// `rag-rat init`" hint.
 fn run_rm(args: &crate::cli::RmArgs, explicit: Option<&str>) -> anyhow::Result<()> {
     let config = match discover_config_optional(explicit)? {
         Some(config) => config,
-        None => {
-            let database = rag_rat_base::data_dir::global_database_path().ok_or_else(|| {
-                anyhow::anyhow!(
-                    "No rag-rat config found at `{}`, and this platform has no data directory for \
-                     a machine-global store.\nRun `rag-rat init` to create a config, or pass \
-                     --config <path>.",
-                    rag_rat_base::config::discover_config_path(Path::new(".")).display()
-                )
-            })?;
-            let root = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-            Config::minimal_for_database(database, root)
+        None if args.path.is_dir() => match discover_target_config_optional(&args.path)? {
+            Some(config) => config,
+            None => configless_rm_config()?,
         },
+        None => configless_rm_config()?,
     };
 
     apply_embedding_runtime_env(&config.llm.embedding.runtime);
@@ -522,6 +525,27 @@ fn run_rm(args: &crate::cli::RmArgs, explicit: Option<&str>) -> anyhow::Result<(
     );
 
     rm(&config, args)
+}
+
+fn discover_target_config_optional(target: &Path) -> anyhow::Result<Option<Config>> {
+    let config_path = rag_rat_base::config::discover_config_path(target);
+    if !config_path.exists() {
+        return Ok(None);
+    }
+    Ok(Some(Config::load(config_path)?))
+}
+
+fn configless_rm_config() -> anyhow::Result<Config> {
+    let database = rag_rat_base::data_dir::global_database_path().ok_or_else(|| {
+        anyhow::anyhow!(
+            "No rag-rat config found at `{}`, and this platform has no data directory for a \
+             machine-global store.\nRun `rag-rat init` to create a config, or pass --config \
+             <path>.",
+            rag_rat_base::config::discover_config_path(Path::new(".")).display()
+        )
+    })?;
+    let root = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    Ok(Config::minimal_for_database(database, root))
 }
 
 /// Map the invoked subcommand to a debug-log [`Role`](rag_rat_base::logging::Role) (drives the log
@@ -585,7 +609,7 @@ pub(crate) struct GitPaths {
 mod tests {
     use std::sync::atomic::{AtomicU64, Ordering};
 
-    use super::{load_config_or_hint, progress_percent};
+    use super::{discover_target_config_optional, load_config_or_hint, progress_percent};
 
     static TMP: AtomicU64 = AtomicU64::new(0);
 
@@ -605,5 +629,25 @@ mod tests {
         let err = load_config_or_hint(Some(missing.to_str().unwrap())).unwrap_err();
         let message = err.to_string();
         assert!(message.contains("rag-rat init"), "expected init hint, got: {message}");
+    }
+
+    #[test]
+    fn rm_target_config_discovery_honors_its_custom_database() {
+        let n = TMP.fetch_add(1, Ordering::Relaxed);
+        let root = std::env::temp_dir()
+            .join(format!("rag-rat-rm-target-config-{}-{n}", std::process::id()));
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::write(
+            root.join("rag-rat.toml"),
+            "[index]\nroot = \".\"\ndatabase = \"custom/index.sqlite\"\nrepo_id = \
+             \"target-config-test\"\n[target_bindings]\nrust = [\"src\"]\n",
+        )
+        .unwrap();
+
+        let config = discover_target_config_optional(&root)
+            .unwrap()
+            .expect("the existing target checkout's governing config should load");
+        assert_eq!(config.database, root.join("custom/index.sqlite"));
+        let _ = std::fs::remove_dir_all(root);
     }
 }

--- a/crates/rag-rat-cli/src/main.rs
+++ b/crates/rag-rat-cli/src/main.rs
@@ -78,8 +78,10 @@ fn main() -> anyhow::Result<()> {
 
     // These commands must tolerate the ABSENCE of a config: `init` creates one; `agent-hook`
     // reads its event from stdin; `mcp` serves a dormant server so a globally-registered MCP stays
-    // alive outside a rag-rat repo (#603); `doctor` reports the machine-global store. Everything
-    // else needs a resolved config and fails with a friendly hint when there isn't one.
+    // alive outside a rag-rat repo (#603); `doctor` reports the machine-global store; `rm` targets
+    // the global store by path and must work even when the checkout it removes was the only
+    // configured one. Everything else needs a resolved config and fails with a friendly hint when
+    // there isn't one.
     match &cli.command {
         Cmd::Init(args) => return init::run(args, cli.config.as_deref().unwrap_or("rag-rat.toml")),
         Cmd::AgentHook => return agent_hook::run(),
@@ -93,6 +95,9 @@ fn main() -> anyhow::Result<()> {
         // tolerates config absence: outside a rag-rat repo it still reports the machine-global
         // store.
         Cmd::Status => return run_status(cli.config.as_deref()),
+        // `rm` is a global-store writer keyed by the path argument; it must tolerate the absence of
+        // a live config so a deleted/moved last checkout can still be purged.
+        Cmd::Rm(args) => return run_rm(args, cli.config.as_deref()),
         _ => {},
     }
 
@@ -112,7 +117,8 @@ fn main() -> anyhow::Result<()> {
         | Cmd::EditReindex(_)
         | Cmd::Mcp
         | Cmd::Doctor(_)
-        | Cmd::Status => unreachable!("handled before the config load above"),
+        | Cmd::Status
+        | Cmd::Rm(_) => unreachable!("handled before the config load above"),
         Cmd::Index(args) => index(&config, &args)?,
         Cmd::Query(args) => query(&config, &args)?,
         Cmd::Brief(args) => brief(&config, &args)?,
@@ -150,7 +156,6 @@ fn main() -> anyhow::Result<()> {
         Cmd::DumpVerifyPacks(args) => dump_verify_packs(&config, &args)?,
         Cmd::Oracle(args) => oracle(&config, &args)?,
         Cmd::Consolidate => consolidate(&config)?,
-        Cmd::Rm(args) => rm(&config, &args)?,
         Cmd::DumpConfig => dump_config(&config)?,
         Cmd::VersionCheck => version_check(&config)?,
     }
@@ -486,6 +491,37 @@ fn run_status(explicit: Option<&str>) -> anyhow::Result<()> {
         },
     };
     status(&database)
+}
+
+/// Run `rm`, tolerating the ABSENCE of a live config: `rm` targets the consolidated global store by
+/// the path argument, so a deleted/moved checkout that was the only configured one can still be
+/// purged. With a discovered config we use its `database` and any `repo_id` override; without one
+/// we fall back to the machine-global store. Only when this platform resolves no data dir at all do
+/// we fall back to the friendly "run `rag-rat init`" hint.
+fn run_rm(args: &crate::cli::RmArgs, explicit: Option<&str>) -> anyhow::Result<()> {
+    let config = match discover_config_optional(explicit)? {
+        Some(config) => config,
+        None => {
+            let database = rag_rat_base::data_dir::global_database_path().ok_or_else(|| {
+                anyhow::anyhow!(
+                    "No rag-rat config found at `{}`, and this platform has no data directory for \
+                     a machine-global store.\nRun `rag-rat init` to create a config, or pass \
+                     --config <path>.",
+                    rag_rat_base::config::discover_config_path(Path::new(".")).display()
+                )
+            })?;
+            let root = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+            Config::minimal_for_database(database, root)
+        },
+    };
+
+    apply_embedding_runtime_env(&config.llm.embedding.runtime);
+    let _log = rag_rat_base::logging::init_logging(
+        &config,
+        rag_rat_base::logging::Role::Cli("rm".to_string()),
+    );
+
+    rm(&config, args)
 }
 
 /// Map the invoked subcommand to a debug-log [`Role`](rag_rat_base::logging::Role) (drives the log

--- a/crates/rag-rat-cli/src/main.rs
+++ b/crates/rag-rat-cli/src/main.rs
@@ -150,6 +150,7 @@ fn main() -> anyhow::Result<()> {
         Cmd::DumpVerifyPacks(args) => dump_verify_packs(&config, &args)?,
         Cmd::Oracle(args) => oracle(&config, &args)?,
         Cmd::Consolidate => consolidate(&config)?,
+        Cmd::Rm(args) => rm(&config, &args)?,
         Cmd::DumpConfig => dump_config(&config)?,
         Cmd::VersionCheck => version_check(&config)?,
     }

--- a/crates/rag-rat-core/src/index/consolidate.rs
+++ b/crates/rag-rat-core/src/index/consolidate.rs
@@ -140,6 +140,21 @@ pub struct ImportSummary {
 /// `Config::load` already made — so the refusal and the `database` resolution can never disagree (a
 /// linked worktree's branch-local toml is not authoritative for either).
 pub fn run(config: &Config) -> anyhow::Result<ConsolidateOutcome> {
+    run_inner(config, None)
+}
+
+/// CLI consolidation with the EXACT config path that produced `config`. Unlike [`run`] (the
+/// programmatic/test seam, whose callers may construct a Config without a file), this rechecks the
+/// file after acquiring the source-side repo locks so a concurrent `rag-rat rm` that deleted it
+/// wins cleanly rather than letting consolidation continue from stale in-memory configuration.
+pub fn run_with_config_path(
+    config: &Config,
+    config_path: &Path,
+) -> anyhow::Result<ConsolidateOutcome> {
+    run_inner(config, Some(config_path))
+}
+
+fn run_inner(config: &Config, config_path: Option<&Path>) -> anyhow::Result<ConsolidateOutcome> {
     let target = data_dir::global_database_path().context(
         "cannot resolve the global database path: no data directory is available (set \
          RAG_RAT_DATA_DIR, XDG_DATA_HOME, or HOME)",
@@ -231,6 +246,22 @@ pub fn run(config: &Config) -> anyhow::Result<ConsolidateOutcome> {
     let mut _source_locks = Vec::with_capacity(source_side_ids.len());
     for id in &source_side_ids {
         _source_locks.push(acquire_consolidate_lock(&source, id, "legacy")?);
+    }
+
+    // #767 review: `rm` holds this same source-side repo lock while deleting the governing config.
+    // If consolidate loaded Config first and then waited here, it would otherwise resume from that
+    // stale clone, clear/register in the global DB, and import the now-empty legacy source AFTER rm
+    // reported success. Recheck the exact path the CLI loaded only after all source locks are held;
+    // if rm won, abort before migrating/clearing/registering anything. The lock keeps it present
+    // for the rest of this run once observed.
+    if let Some(config_path) = config_path
+        && !config_path.is_file()
+    {
+        anyhow::bail!(
+            "the governing config ({}) was removed while consolidate waited for the repo write \
+             lock — a concurrent `rag-rat rm` won; aborting without re-registering the repo",
+            config_path.display()
+        );
     }
 
     // Bring the global DB to current schema (creating it under the shared schema lock), then open

--- a/crates/rag-rat-core/src/index/consolidate.rs
+++ b/crates/rag-rat-core/src/index/consolidate.rs
@@ -245,6 +245,11 @@ pub fn run(config: &Config) -> anyhow::Result<ConsolidateOutcome> {
     let target_storage = IndexConnection::open(&target)?;
     let target_conn = target_storage.connection();
 
+    // #767: consolidate is a DELIBERATE re-add, like `init` — lift any `rag-rat rm` removal
+    // tombstone for this repo first, or `register_repo` below would refuse the import with a "run
+    // init" remedy that does not fit consolidate. Under the target lock already held.
+    schema::clear_repo_removed(target_conn, &identity.repo_id)?;
+
     // Register (or adopt/extend) this repo in the global DB. The returned id is what every imported
     // row is stamped with — the legacy DB's own `repo_id` (placeholder or otherwise) is discarded.
     // Consolidation IMPORTS an indexed repo, so `register_repo` records the working-tree root

--- a/crates/rag-rat-core/src/index/file_index.rs
+++ b/crates/rag-rat-core/src/index/file_index.rs
@@ -31,32 +31,45 @@ impl IndexDatabase {
         if self.active_scope_is_linked_overlay() {
             return Ok(());
         }
-        // #767 review: fail closed when the active repo was `rag-rat rm`-removed after this
-        // connection resolved its scope (a stale MCP `heal_index` / lazy-heal writer). Otherwise
-        // the reindex below inserts fresh `files`/chunk/graph rows stamped with the removed
-        // `repo_id` — `files.repo_id` has no FK to `repos`, so they would survive a removal that
-        // already reported success.
-        let conn = self.storage.connection();
-        let active_repo_id = rag_rat_db::schema::active_repo_id(conn)?;
-        super::remove::assert_repo_not_removed(conn, &active_repo_id)?;
         let Some(root) = self.storage.source_root() else {
             anyhow::bail!("index has no source_root metadata; rebuild required");
         };
         let row = self.file_row(path)?;
         let full_path = root.join(path);
+        // Read the file bytes + git status BEFORE opening the mutation transaction: pure I/O
+        // holds no SQLite write lock, keeping the write window short.
         let text = match fs::read_to_string(&full_path) {
-            Ok(text) => text,
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                // File deleted on disk since indexing — drop it from the index rather than
-                // hard-erroring the whole search. The caller (search_with_heal) re-runs
-                // search without it. Mirrors read_chunk_current's deletion handling.
-                self.mark_file_deleted(path)?;
-                return Ok(());
-            },
+            Ok(text) => Some(text),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => None,
             Err(e) => return Err(e.into()),
         };
-
         let changes = git_changed_paths(root).unwrap_or_default();
+
+        // #767 review: run the whole heal mutation in ONE IMMEDIATE transaction with the removal
+        // tombstone re-checked INSIDE it. A preflight-only check leaves a gap between the check
+        // and the delete/reinsert below in which `rag-rat rm` could purge + tombstone, letting a
+        // stale MCP/lazy heal recreate `files`/chunk/graph rows for the removed `repo_id` after
+        // rm reported success (`files.repo_id` has no FK to `repos`). This transaction and rm's
+        // purge are both IMMEDIATE, so they serialize on the SQLite write lock and the tombstone
+        // state read here is stable for the whole heal: set → rm committed first, fail closed;
+        // unset → rm's purge waits for this commit and sweeps the re-inserted rows itself. The
+        // heal deliberately stays LOCKLESS at the flock level — it must run alongside a
+        // mid-flight rebuild (`a_lockless_heal_mid_rebuild_does_not_remove_the_staged_row`).
+        let conn = self.storage.connection();
+        let tx =
+            rusqlite::Transaction::new_unchecked(conn, rusqlite::TransactionBehavior::Immediate)?;
+        let active_repo_id = rag_rat_db::schema::active_repo_id(&tx)?;
+        super::remove::assert_repo_not_removed(&tx, &active_repo_id)?;
+
+        let Some(text) = text else {
+            // File deleted on disk since indexing — drop it from the index rather than
+            // hard-erroring the whole search. The caller (search_with_heal) re-runs
+            // search without it. Mirrors read_chunk_current's deletion handling.
+            self.mark_file_deleted(path)?;
+            tx.commit()?;
+            return Ok(());
+        };
+
         let is_dirty = changes.changed.contains(path);
         let has_base_commit = !self.active_commit_sha.is_empty();
         let scope = if !has_base_commit || is_dirty {
@@ -77,7 +90,25 @@ impl IndexDatabase {
         // Defer: a single-file heal must not stamp the logical-key version — every other file's
         // drift is still in the future (#493).
         self.rebuild_logical_symbols(graph_index::KeyVersionStamp::Defer)?;
-        self.resolve_edges()
+        self.resolve_edges()?;
+        tx.commit()?;
+        Ok(())
+    }
+
+    /// The deletion half of a heal, gated exactly like [`Self::heal_file`] (#767 review): the
+    /// `kind='deleted'` tombstone is itself an INSERT stamped with the active `repo_id`, so a
+    /// stale writer must not write it for a repo `rag-rat rm` already purged. Wraps the deletion
+    /// in an IMMEDIATE transaction with the removal tombstone re-checked inside (the transaction
+    /// serializes with rm's purge on the SQLite write lock — see `heal_file`).
+    pub(crate) fn mark_file_deleted_if_not_removed(&self, path: &Path) -> anyhow::Result<()> {
+        let conn = self.storage.connection();
+        let tx =
+            rusqlite::Transaction::new_unchecked(conn, rusqlite::TransactionBehavior::Immediate)?;
+        let active_repo_id = rag_rat_db::schema::active_repo_id(&tx)?;
+        super::remove::assert_repo_not_removed(&tx, &active_repo_id)?;
+        self.mark_file_deleted(path)?;
+        tx.commit()?;
+        Ok(())
     }
 
     fn index_file(

--- a/crates/rag-rat-core/src/index/file_index.rs
+++ b/crates/rag-rat-core/src/index/file_index.rs
@@ -31,6 +31,14 @@ impl IndexDatabase {
         if self.active_scope_is_linked_overlay() {
             return Ok(());
         }
+        // #767 review: fail closed when the active repo was `rag-rat rm`-removed after this
+        // connection resolved its scope (a stale MCP `heal_index` / lazy-heal writer). Otherwise
+        // the reindex below inserts fresh `files`/chunk/graph rows stamped with the removed
+        // `repo_id` — `files.repo_id` has no FK to `repos`, so they would survive a removal that
+        // already reported success.
+        let conn = self.storage.connection();
+        let active_repo_id = rag_rat_db::schema::active_repo_id(conn)?;
+        super::remove::assert_repo_not_removed(conn, &active_repo_id)?;
         let Some(root) = self.storage.source_root() else {
             anyhow::bail!("index has no source_root metadata; rebuild required");
         };

--- a/crates/rag-rat-core/src/index/mod.rs
+++ b/crates/rag-rat-core/src/index/mod.rs
@@ -11,6 +11,7 @@ pub mod symbols;
 pub mod walker;
 
 pub mod consolidate;
+pub mod remove;
 
 mod adoption_hints;
 pub(crate) mod change_coupling;
@@ -74,10 +75,11 @@ pub use query_api::{
     CLONE_DELTA_MAX_FILES, CandidateCloneClass, CloneCheckInput, CloneCompleteness,
     CloneDeltaReport, CloneEdgeReport, CloneEligibility, CloneFingerprintHealth,
     CloneIneligibilityReason, CloneMember, CloneSymbolSelector, ClonesForSymbolResult,
-    DatabaseFileHealth, FindClonesOptions, FindClonesResult, GcReport, GlobalFtsStatus,
-    GlobalStatus, ImportantSymbolsRequest, MemoryCounts, MemoryKindCounts, OracleShaSnapshots,
-    PapertrailCursor, RepoContent, RepoFreshness, RepoPapertrail, RepoStatus, RoiFactors,
-    SearchRequest, TextCloneMatch, WAL_CHECKPOINT_MIN_BYTES, WalCheckpointReport, WorktreeOverlay,
+    DatabaseFileHealth, FindClonesOptions, FindClonesResult, FreelistReclaim,
+    FreelistReclaimReport, GcReport, GlobalFtsStatus, GlobalStatus, ImportantSymbolsRequest,
+    MemoryCounts, MemoryKindCounts, OracleShaSnapshots, PapertrailCursor, RepoContent,
+    RepoFreshness, RepoPapertrail, RepoStatus, RoiFactors, SearchRequest, TextCloneMatch,
+    WAL_CHECKPOINT_MIN_BYTES, WalCheckpointReport, WorktreeOverlay, reclaim_freelist_at,
 };
 pub use schema::RegisteredRepo;
 pub(crate) use util::*;

--- a/crates/rag-rat-core/src/index/query_api/db_file_health.rs
+++ b/crates/rag-rat-core/src/index/query_api/db_file_health.rs
@@ -117,65 +117,12 @@ impl IndexDatabase {
     /// operator to quiesce agents and retry. An explicit operator action (`doctor --vacuum`),
     /// never automatic: it can rewrite hundreds of MB.
     pub fn reclaim_freelist(&self) -> anyhow::Result<FreelistReclaimReport> {
-        let path = self.storage.database_path().to_path_buf();
-        let _lock =
-            rag_rat_base::locks::WriteLock::acquire_schema_timeout(&path, VACUUM_LOCK_TIMEOUT)?
-                .ok_or_else(|| {
-                    anyhow::anyhow!(
-                        "timed out waiting for the schema lock to VACUUM the database — another \
-                         rag-rat writer is active; stop agents/watchers and retry"
-                    )
-                })?;
-        // Snapshot under the lock so `before` can't drift against a concurrent writer.
-        let before = self.database_file_health()?;
-        // VACUUM on a FRESH bare connection, not `self`: a scoped `IndexDatabase` installs a
-        // `temp.files` TEMP VIEW (`install_scope_view`), and VACUUM rejects a connection carrying a
-        // temp view ("views may not be indexed"). A pragma'd bare open matches the manual
-        // `sqlite3 <db> VACUUM` remedy and rewrites the same file; `self` sees the compacted result
-        // on its next read.
-        let vacuum_conn = rag_rat_db::storage::IndexConnection::open(&path)?;
-        // A concurrent writer (any repo's watcher/index, or a reader holding a txn) makes VACUUM
-        // fail busy — the schema lock doesn't hold those off. Turn a raw SQLITE_BUSY into an
-        // actionable refusal (no corruption, just retry once quiet).
-        if let Err(err) = vacuum_conn.connection().execute_batch("VACUUM") {
-            let err = anyhow::Error::from(err);
-            return Err(if rag_rat_db::storage::is_busy(&err) {
-                anyhow::anyhow!(
-                    "VACUUM could not get exclusive access to the database — a rag-rat writer (a \
-                     watcher/index for any repo, or an active reader) is running. Stop \
-                     agents/watchers/MCP servers and re-run `rag-rat doctor --vacuum`."
-                )
-            } else {
-                err.context("VACUUM failed")
-            });
+        // `doctor --vacuum` surfaces a busy refusal as an error (quiesce and retry) — the behavior
+        // before the outcome split. Only the removal purge treats a busy VACUUM as a benign skip.
+        match reclaim_freelist_at(self.storage.database_path())? {
+            FreelistReclaim::Reclaimed(report) => Ok(report),
+            FreelistReclaim::BusySkipped(message) => Err(anyhow::anyhow!("{message}")),
         }
-        // VACUUM may RENUMBER git_commits' rowids — it has no explicit INTEGER PRIMARY KEY (keyed
-        // by `hash` / `(repo_id, hash)`), and SQLite documents that VACUUM can change
-        // rowids for such tables. That desyncs the external-content `commit_fts`
-        // (content='git_commits', content_rowid='rowid'), so `commit_search` would return
-        // wrong/missing commits. Rebuild it against the post-VACUUM rowids. It is the ONLY
-        // at-risk FTS: `chunk_fts` is contentless and `github_fts`/`repo_memory_fts` are
-        // standalone (not rowid-linked).
-        rag_rat_db::schema::rebuild_commit_fts(vacuum_conn.connection())?;
-        // In WAL mode VACUUM's compaction lands in the `-wal`; fold it back and truncate the
-        // sidecar so the main file physically shrinks (and doesn't just move dead space to the
-        // WAL). The checkpoint returns (busy, log, checkpointed): busy = 1 means a reader
-        // pinned frames and the truncate could not complete — surface it (`wal_truncated`)
-        // rather than swallow it, or `doctor --vacuum` would report success while the file
-        // never shrank on disk.
-        let busy =
-            vacuum_conn
-                .connection()
-                .query_row("PRAGMA wal_checkpoint(TRUNCATE)", [], |row| row.get::<_, i64>(0))?;
-        drop(vacuum_conn);
-        let after = self.database_file_health()?;
-        Ok(FreelistReclaimReport {
-            main_bytes_before: before.main_bytes,
-            main_bytes_after: after.main_bytes,
-            freelist_pages_before: before.freelist_pages,
-            freelist_pages_after: after.freelist_pages,
-            wal_truncated: busy == 0,
-        })
     }
 
     /// Size and dead-space facts about the database file, with warning flags at the default
@@ -271,6 +218,109 @@ fn compute_database_file_health(
         freelist_excessive,
         note,
     })
+}
+
+/// The result of a [`reclaim_freelist_at`] attempt. `BusySkipped` is the ONE benign failure a
+/// best-effort caller may swallow: VACUUM could not acquire exclusive access and — VACUUM being
+/// transactional — mutated NOTHING, so the file is exactly as it was. EVERY other failure is a hard
+/// `Err`, including a post-VACUUM `commit_fts` rebuild / checkpoint error: those run AFTER VACUUM
+/// may have renumbered `git_commits`' rowids, so swallowing one would leave the shared commit FTS
+/// desynced while the caller reports success.
+pub enum FreelistReclaim {
+    /// VACUUM ran and the file was rewritten; the report carries the before/after figures.
+    Reclaimed(FreelistReclaimReport),
+    /// VACUUM could not get exclusive access (a writer/reader held the file busy) and changed
+    /// nothing — safe to skip and retry later. Carries the operator-facing reason.
+    BusySkipped(String),
+}
+
+/// Reclaim dead space in the database file by running `VACUUM`, path-based — the core of
+/// [`IndexDatabase::reclaim_freelist`], also called by the repo-removal purge (which cannot hold a
+/// scoped `IndexDatabase` for a repo it may have just de-registered). Takes the GLOBAL schema lock
+/// (serializing against migrations and other VACUUMs), VACUUMs on a FRESH bare connection,
+/// re-derives the external-content `commit_fts`, and folds the WAL back. See
+/// [`IndexDatabase::reclaim_freelist`] for the concurrency contract (it relies on SQLite's own file
+/// locking and refuses busy). A busy refusal returns [`FreelistReclaim::BusySkipped`] (nothing
+/// mutated); a failure AFTER a committed VACUUM propagates as `Err` (the index must not be left
+/// half-repaired under a clean-looking result).
+pub fn reclaim_freelist_at(database: &Path) -> anyhow::Result<FreelistReclaim> {
+    let Some(_lock) =
+        rag_rat_base::locks::WriteLock::acquire_schema_timeout(database, VACUUM_LOCK_TIMEOUT)?
+    else {
+        // A schema-lock timeout means another whole-file rewriter (a VACUUM or a migration) holds
+        // it — the SAME "a writer is busy, retry later" condition as a busy VACUUM, and one where
+        // VACUUM likewise mutated NOTHING. Downgrade it to `BusySkipped` (symmetric with the
+        // busy-VACUUM case below) so a best-effort caller (the removal purge) reports
+        // `vacuum_skipped` instead of a hard failure over an already-committed removal.
+        return Ok(FreelistReclaim::BusySkipped(
+            "VACUUM could not acquire the schema lock — another whole-file rewriter (a VACUUM or \
+             migration) is active; stop agents/watchers/MCP servers and re-run `rag-rat doctor \
+             --vacuum`."
+                .to_string(),
+        ));
+    };
+    // VACUUM on a FRESH bare connection: a scoped `IndexDatabase` installs a `temp.files` TEMP VIEW
+    // (`install_scope_view`), and VACUUM rejects a connection carrying a temp view ("views may not
+    // be indexed"). A pragma'd bare open matches the manual `sqlite3 <db> VACUUM` remedy and
+    // rewrites the same file. The same connection reads the before/after freelist snapshot, so the
+    // `before` read is under the schema lock and cannot drift against a concurrent writer.
+    let vacuum_conn = rag_rat_db::storage::IndexConnection::open(database)?;
+    let (main_bytes_before, freelist_pages_before) = freelist_snapshot(&vacuum_conn, database)?;
+    // A concurrent writer (any repo's watcher/index, or a reader holding a txn) makes VACUUM
+    // fail busy — the schema lock doesn't hold those off. Turn a raw SQLITE_BUSY into an
+    // actionable refusal (no corruption, just retry once quiet).
+    if let Err(err) = vacuum_conn.connection().execute_batch("VACUUM") {
+        let err = anyhow::Error::from(err);
+        // A busy refusal is the ONLY skippable failure: VACUUM is transactional, so a failed START
+        // mutated nothing and the file is unchanged. Everything below runs AFTER a committed
+        // VACUUM, so any failure there must propagate, not downgrade to a benign skip.
+        if rag_rat_db::storage::is_busy(&err) {
+            return Ok(FreelistReclaim::BusySkipped(
+                "VACUUM could not get exclusive access to the database — a rag-rat writer (a \
+                 watcher/index for any repo, or an active reader) is running. Stop \
+                 agents/watchers/MCP servers and re-run `rag-rat doctor --vacuum`."
+                    .to_string(),
+            ));
+        }
+        return Err(err.context("VACUUM failed"));
+    }
+    // VACUUM may RENUMBER git_commits' rowids — it has no explicit INTEGER PRIMARY KEY (keyed
+    // by `hash` / `(repo_id, hash)`), and SQLite documents that VACUUM can change rowids for such
+    // tables. That desyncs the external-content `commit_fts` (content='git_commits',
+    // content_rowid='rowid'), so `commit_search` would return wrong/missing commits. Rebuild it
+    // against the post-VACUUM rowids. It is the ONLY at-risk FTS: `chunk_fts` is contentless and
+    // `papertrail_fts`/`repo_memory_fts` are standalone (not rowid-linked).
+    rag_rat_db::schema::rebuild_commit_fts(vacuum_conn.connection())?;
+    // In WAL mode VACUUM's compaction lands in the `-wal`; fold it back and truncate the sidecar so
+    // the main file physically shrinks (and doesn't just move dead space to the WAL). The
+    // checkpoint returns (busy, log, checkpointed): busy = 1 means a reader pinned frames and
+    // the truncate could not complete — surface it (`wal_truncated`) rather than swallow it, or
+    // a caller would report success while the file never shrank on disk.
+    let busy =
+        vacuum_conn
+            .connection()
+            .query_row("PRAGMA wal_checkpoint(TRUNCATE)", [], |row| row.get::<_, i64>(0))?;
+    let (main_bytes_after, freelist_pages_after) = freelist_snapshot(&vacuum_conn, database)?;
+    drop(vacuum_conn);
+    Ok(FreelistReclaim::Reclaimed(FreelistReclaimReport {
+        main_bytes_before,
+        main_bytes_after,
+        freelist_pages_before,
+        freelist_pages_after,
+        wal_truncated: busy == 0,
+    }))
+}
+
+/// `(main_bytes, freelist_pages)` for the file — the two figures a VACUUM before/after report
+/// needs. `main_bytes` is the on-disk size; `freelist_pages` is `PRAGMA freelist_count`.
+fn freelist_snapshot(
+    conn: &rag_rat_db::storage::IndexConnection,
+    database: &Path,
+) -> anyhow::Result<(u64, i64)> {
+    let freelist_pages: i64 =
+        conn.connection().query_row("PRAGMA freelist_count", [], |row| row.get(0))?;
+    let main_bytes = std::fs::metadata(database).map(|meta| meta.len()).unwrap_or(0);
+    Ok((main_bytes, freelist_pages))
 }
 
 /// Size of the `-wal` sidecar, 0 when absent. SQLite derives the sidecar name by appending

--- a/crates/rag-rat-core/src/index/query_api/dream.rs
+++ b/crates/rag-rat-core/src/index/query_api/dream.rs
@@ -9,7 +9,14 @@ use super::*;
 
 impl IndexDatabase {
     pub fn dream_run(&self, opts: DreamOptions) -> anyhow::Result<DreamReport> {
-        rag_rat_dream::dream_run(self.storage.connection(), opts)
+        let conn = self.storage.connection();
+        // #767 review: fail closed when the active repo was `rag-rat rm`-removed after this
+        // connection resolved its scope (a stale MCP `dream` writer). The findings sync below
+        // would otherwise INSERT fresh `dream_findings` rows for the removed `repo_id` after the
+        // purge reported success — the table intentionally carries no FK to `repos`.
+        let active_repo_id = rag_rat_db::schema::active_repo_id(conn)?;
+        crate::index::remove::assert_repo_not_removed(conn, &active_repo_id)?;
+        rag_rat_dream::dream_run(conn, opts)
     }
 
     /// [`Self::dream_run`] plus the phase-B model verdict pass and the phase-C model compaction

--- a/crates/rag-rat-core/src/index/query_api/dream.rs
+++ b/crates/rag-rat-core/src/index/query_api/dream.rs
@@ -12,8 +12,7 @@ impl IndexDatabase {
         let conn = self.storage.connection();
         // #767 review: fail closed when the active repo was `rag-rat rm`-removed after this
         // connection resolved its scope (a stale MCP `dream` writer). This is the PREFLIGHT — it
-        // keeps a removed repo from paying the finding computation (and, in
-        // `dream_run_with_passes`, the model/provisioning side effects); the AUTHORITATIVE check
+        // keeps a removed repo from paying the finding computation; the AUTHORITATIVE check
         // lives inside the findings sync's IMMEDIATE transaction (`findings::sync`), which
         // serializes with rm's purge on the SQLite write lock so a removal landing mid-run cannot
         // let the sync re-insert `dream_findings` rows for the removed `repo_id`.
@@ -32,6 +31,15 @@ impl IndexDatabase {
         verdict_pass: Option<VerdictPass<'_>>,
         compact_pass: Option<CompactPass<'_>>,
     ) -> anyhow::Result<DreamReport> {
+        let conn = self.storage.connection();
+        // #767 review: this entry point does NOT route through `Self::dream_run` until AFTER the
+        // verdict/compaction passes. Fail early before FTS healing, model provisioning/inference,
+        // and derived writes. The authoritative per-entry checks live inside each model-pass
+        // IMMEDIATE write transaction (`rag_rat_dream::removal_guarded_write_tx`), so a removal
+        // landing after this preflight still cannot leave `memory_reality`, `memory_summaries`, or
+        // `memory_model_failures` rows behind.
+        let active_repo_id = rag_rat_db::schema::active_repo_id(conn)?;
+        crate::index::remove::assert_repo_not_removed(conn, &active_repo_id)?;
         // #582 review: the model passes rank chunk_fts (evidence-pack probes) MID-RUN, after
         // model side effects — a blanket retry would replay them. PRE-FLIGHT the probe-and-heal
         // instead so the run starts on healthy mirrors; on a clean index the probe is four
@@ -49,12 +57,7 @@ impl IndexDatabase {
                 preflight.deferred
             );
         }
-        rag_rat_dream::dream_run_with_passes(
-            self.storage.connection(),
-            opts,
-            verdict_pass,
-            compact_pass,
-        )
+        rag_rat_dream::dream_run_with_passes(conn, opts, verdict_pass, compact_pass)
     }
 
     /// Whether the model passes have pending work (the zero-work guard for ephemeral

--- a/crates/rag-rat-core/src/index/query_api/dream.rs
+++ b/crates/rag-rat-core/src/index/query_api/dream.rs
@@ -11,9 +11,12 @@ impl IndexDatabase {
     pub fn dream_run(&self, opts: DreamOptions) -> anyhow::Result<DreamReport> {
         let conn = self.storage.connection();
         // #767 review: fail closed when the active repo was `rag-rat rm`-removed after this
-        // connection resolved its scope (a stale MCP `dream` writer). The findings sync below
-        // would otherwise INSERT fresh `dream_findings` rows for the removed `repo_id` after the
-        // purge reported success — the table intentionally carries no FK to `repos`.
+        // connection resolved its scope (a stale MCP `dream` writer). This is the PREFLIGHT — it
+        // keeps a removed repo from paying the finding computation (and, in
+        // `dream_run_with_passes`, the model/provisioning side effects); the AUTHORITATIVE check
+        // lives inside the findings sync's IMMEDIATE transaction (`findings::sync`), which
+        // serializes with rm's purge on the SQLite write lock so a removal landing mid-run cannot
+        // let the sync re-insert `dream_findings` rows for the removed `repo_id`.
         let active_repo_id = rag_rat_db::schema::active_repo_id(conn)?;
         crate::index::remove::assert_repo_not_removed(conn, &active_repo_id)?;
         rag_rat_dream::dream_run(conn, opts)

--- a/crates/rag-rat-core/src/index/query_api/mod.rs
+++ b/crates/rag-rat-core/src/index/query_api/mod.rs
@@ -36,7 +36,10 @@ pub use clones::{
 };
 #[cfg(test)]
 pub(crate) use clones::{MAX_MEMBERS, MEMBER_VALUE_CAP};
-pub use db_file_health::{DatabaseFileHealth, WAL_CHECKPOINT_MIN_BYTES, WalCheckpointReport};
+pub use db_file_health::{
+    DatabaseFileHealth, FreelistReclaim, FreelistReclaimReport, WAL_CHECKPOINT_MIN_BYTES,
+    WalCheckpointReport, reclaim_freelist_at,
+};
 pub use gc::GcReport;
 pub use global_status::{
     GlobalFtsStatus, GlobalStatus, MemoryCounts, MemoryKindCounts, PapertrailCursor, RepoContent,

--- a/crates/rag-rat-core/src/index/query_api/mod.rs
+++ b/crates/rag-rat-core/src/index/query_api/mod.rs
@@ -521,7 +521,9 @@ impl IndexDatabase {
             Ok(text) => text,
             Err(_) => {
                 let path = chunk.path.clone();
-                self.mark_file_deleted(Path::new(&path))?;
+                // #767 review: the gated variant — a stale-scope read path must not stamp a
+                // `kind='deleted'` row for a repo `rag-rat rm` already purged.
+                self.mark_file_deleted_if_not_removed(Path::new(&path))?;
                 self.sync_fts()?;
                 anyhow::bail!(IndexError::Gone { chunk_id });
             },
@@ -586,10 +588,12 @@ impl IndexDatabase {
             anyhow::bail!("heal_index requires source_root metadata; run `rag-rat index` first");
         };
         // #767 review: fail closed when the active repo was `rag-rat rm`-removed after this
-        // connection resolved its scope (a stale MCP `heal_index` writer) — the per-file heals /
-        // deletions below would otherwise re-insert rows for the purged `repo_id` after the
-        // removal reported success. (`heal_file` gates the single-file path too; this stops the
-        // batch before any per-file work.)
+        // connection resolved its scope (a stale MCP `heal_index` writer). This is the PREFLIGHT
+        // that stops the batch before any per-file work; the AUTHORITATIVE checks live at each
+        // per-file write boundary — `heal_file` and `mark_file_deleted_if_not_removed` re-check
+        // the tombstone inside their IMMEDIATE mutation transactions, which serialize with rm's
+        // purge on the SQLite write lock (the heal path deliberately stays flock-free so it can
+        // run alongside a mid-flight rebuild).
         let conn = self.storage.connection();
         let active_repo_id = rag_rat_db::schema::active_repo_id(conn)?;
         crate::index::remove::assert_repo_not_removed(conn, &active_repo_id)?;
@@ -618,7 +622,7 @@ impl IndexDatabase {
                         Some("limit reached; rerun heal_index to continue".to_string());
                     break;
                 }
-                self.mark_file_deleted(path)?;
+                self.mark_file_deleted_if_not_removed(path)?;
                 report.removed_files += 1;
                 continue;
             };

--- a/crates/rag-rat-core/src/index/query_api/mod.rs
+++ b/crates/rag-rat-core/src/index/query_api/mod.rs
@@ -585,6 +585,14 @@ impl IndexDatabase {
         let Some(root) = self.storage.source_root() else {
             anyhow::bail!("heal_index requires source_root metadata; run `rag-rat index` first");
         };
+        // #767 review: fail closed when the active repo was `rag-rat rm`-removed after this
+        // connection resolved its scope (a stale MCP `heal_index` writer) — the per-file heals /
+        // deletions below would otherwise re-insert rows for the purged `repo_id` after the
+        // removal reported success. (`heal_file` gates the single-file path too; this stops the
+        // batch before any per-file work.)
+        let conn = self.storage.connection();
+        let active_repo_id = rag_rat_db::schema::active_repo_id(conn)?;
+        crate::index::remove::assert_repo_not_removed(conn, &active_repo_id)?;
         let indexed_files = self.indexed_files()?;
         let max_repairs = limit.map(usize::try_from).transpose()?.unwrap_or(usize::MAX);
         let mut report = HealIndexReport {

--- a/crates/rag-rat-core/src/index/remove.rs
+++ b/crates/rag-rat-core/src/index/remove.rs
@@ -35,6 +35,9 @@ pub struct ResolvedRepo {
     /// Every recorded working-tree root for the repo (a repo can be checked out in several
     /// worktrees), so the caller can report exactly what it is about to remove.
     pub roots: Vec<String>,
+    /// Monotonic count of completed removals for this id at planning time. Revalidated under the
+    /// write lock before purge so an intervening remove → init cycle invalidates a stale plan.
+    pub removal_generation: i64,
     /// The path the removal resolved through — canonicalized when it exists, else the path as
     /// given (a deleted / moved working tree resolved by its recorded root). Informational only
     /// (reported in `--dry-run`); the on-disk deconfigure targets `roots` (the recorded governing
@@ -178,7 +181,7 @@ fn load_resolved_repo(
     conn: &Connection,
     repo_id: String,
     resolved_root: PathBuf,
-) -> rusqlite::Result<ResolvedRepo> {
+) -> anyhow::Result<ResolvedRepo> {
     let display_name: Option<String> = conn
         .query_row("SELECT display_name FROM repos WHERE repo_id = ?1", [&repo_id], |row| {
             row.get::<_, String>(0)
@@ -189,7 +192,8 @@ fn load_resolved_repo(
     let roots = roots_stmt
         .query_map([&repo_id], |row| row.get::<_, String>(0))?
         .collect::<rusqlite::Result<Vec<_>>>()?;
-    Ok(ResolvedRepo { repo_id, display_name, roots, resolved_root })
+    let removal_generation = schema::repo_removal_generation(conn, &repo_id)?;
+    Ok(ResolvedRepo { repo_id, display_name, roots, removal_generation, resolved_root })
 }
 
 /// Build the read-only removal plan: the resolved repo + the per-table count of what the purge
@@ -220,6 +224,7 @@ pub fn plan_remove(conn: &Connection, repo: ResolvedRepo) -> anyhow::Result<Remo
 pub fn purge_and_vacuum<C>(
     database: &Path,
     repo_id: &str,
+    expected_removal_generation: i64,
     now_ms: i64,
     deconfigure: impl FnOnce() -> C,
 ) -> anyhow::Result<(RemoveOutcome, C)> {
@@ -257,6 +262,14 @@ pub fn purge_and_vacuum<C>(
     let (purged_rows, display_name) = {
         let storage = IndexConnection::open(database)?;
         let conn = storage.connection();
+        let current_removal_generation = schema::repo_removal_generation(conn, repo_id)?;
+        anyhow::ensure!(
+            current_removal_generation == expected_removal_generation,
+            "the removal plan for repo {repo_id} is stale: another `rag-rat rm` completed after \
+             planning (expected generation {expected_removal_generation}, current generation \
+             {current_removal_generation}). Re-run `rag-rat rm` to review the newly registered \
+             repo before deleting it"
+        );
         let display_name: Option<String> = conn
             .query_row("SELECT display_name FROM repos WHERE repo_id = ?1", [repo_id], |row| {
                 row.get::<_, String>(0)
@@ -768,15 +781,20 @@ mod tests {
         let db = IndexDatabase::rebuild(&config).unwrap();
         // Read the fixture repo id, then DROP the rebuilt db so it releases the repo's write lock
         // before `purge_and_vacuum` tries to acquire it.
-        let repo_a = {
+        let (repo_a, removal_generation) = {
             let storage = IndexConnection::open(&config.database).unwrap();
-            fixture_repo_id(storage.connection())
+            let repo_id = fixture_repo_id(storage.connection());
+            let generation =
+                schema::repo_removal_generation(storage.connection(), &repo_id).unwrap();
+            (repo_id, generation)
         };
         drop(db);
 
         let (outcome, cleanup) =
-            purge_and_vacuum(&config.database, &repo_a, 12_345, || "deconfigured".to_string())
-                .unwrap();
+            purge_and_vacuum(&config.database, &repo_a, removal_generation, 12_345, || {
+                "deconfigured".to_string()
+            })
+            .unwrap();
         assert!(outcome.purged_rows > 0, "the fixture repo had rows to purge");
         assert_eq!(cleanup, "deconfigured", "the deconfigure closure result must thread back");
 
@@ -796,6 +814,11 @@ mod tests {
             schema::is_repo_removed(conn, &repo_a).unwrap(),
             "the removed repo must be tombstoned"
         );
+        assert_eq!(
+            schema::repo_removal_generation(conn, &repo_a).unwrap(),
+            removal_generation + 1,
+            "a completed purge advances the durable removal generation"
+        );
         for table in repo_scoped_table_names(conn).unwrap() {
             let count: i64 = conn
                 .query_row(
@@ -806,6 +829,47 @@ mod tests {
                 .unwrap();
             assert_eq!(count, 0, "rows for the purged repo remain in `{table}`");
         }
+    }
+
+    #[test]
+    fn purge_refuses_a_plan_from_before_an_intervening_remove_and_readd() {
+        use std::cell::Cell;
+
+        let (root, config) = poison_test_config("rm_stale_plan");
+        let db = IndexDatabase::rebuild(&config).unwrap();
+        let (repo_id, planned_generation) = {
+            let storage = IndexConnection::open(&config.database).unwrap();
+            let repo_id = fixture_repo_id(storage.connection());
+            let generation =
+                schema::repo_removal_generation(storage.connection(), &repo_id).unwrap();
+            (repo_id, generation)
+        };
+        drop(db);
+
+        purge_and_vacuum(&config.database, &repo_id, planned_generation, 10, || ()).unwrap();
+        {
+            let storage = IndexConnection::open(&config.database).unwrap();
+            let conn = storage.connection();
+            schema::clear_repo_removed(conn, &repo_id).unwrap();
+            let identity = rag_rat_base::repo_identity::resolve_repo_identity(&root, None).unwrap();
+            schema::register_repo(conn, &identity, &root, 11, &crate::index::migration_hooks())
+                .unwrap();
+        }
+
+        let deconfigured = Cell::new(false);
+        let err = purge_and_vacuum(&config.database, &repo_id, planned_generation, 12, || {
+            deconfigured.set(true);
+        })
+        .expect_err("a plan from before remove/re-add must be rejected");
+        assert!(err.to_string().contains("stale"), "unexpected refusal: {err}");
+        assert!(!deconfigured.get(), "stale removal must not deconfigure the re-added repo");
+        let storage = IndexConnection::open(&config.database).unwrap();
+        assert!(
+            schema::repo_id_is_registered(storage.connection(), &repo_id).unwrap(),
+            "the newly re-added repo must survive the stale removal attempt"
+        );
+        drop(storage);
+        let _ = std::fs::remove_dir_all(root);
     }
 
     /// The removal tombstone gates re-registration: once a repo is marked removed, the indexing

--- a/crates/rag-rat-core/src/index/remove.rs
+++ b/crates/rag-rat-core/src/index/remove.rs
@@ -70,9 +70,11 @@ pub struct RemoveOutcome {
 /// repo" the way the read-path resolver does: for a destructive `rm <path>`, resolving an arbitrary
 /// unregistered path to the only registered repo would offer to delete the wrong repo. Routes, in
 /// order:
-///  1. by derived git IDENTITY — if `path` is a git worktree whose content-derived id is a
-///     registered repo, that id (this also resolves a LINKED worktree, whose path is not the
-///     recorded root but derives the same id);
+///  1. by derived git IDENTITY — only when `path` is the discovered WORKTREE TOP and its
+///     content-derived id is a registered repo (this also resolves a LINKED worktree top, whose
+///     path is not the recorded root but derives the same id). Restricting identity discovery to
+///     the top is the destructive-target guard: git discovery walks upward, so an arbitrary child
+///     (`repo/src`) must not silently select the enclosing repo under `--yes`;
 ///  2. by EXACT `repo_roots` match on the canonical path, then the path as given — so a repo whose
 ///     working tree was DELETED / moved / is non-git (identity underivable), or was registered
 ///     under a pinned `[index] repo_id`, still resolves by its recorded root.
@@ -91,12 +93,14 @@ pub fn resolve_removable_repo(
         .or_else(|_| std::path::absolute(path).map(|path| lexically_normalize(&path)))
         .unwrap_or_else(|_| path.to_path_buf());
 
-    // Route 1: a derivable git identity that is a REGISTERED repo. Try the GOVERNING config's
-    // `[index] repo_id` override first when the path is a live checkout with a config, so pinned
-    // repos with `[index] root = "src"` resolve from the checkout top (not only the indexed
-    // subdir). Fall back to the content-derived identity when no override applies or it does not
-    // match a registered repo.
-    if canonical.is_dir() {
+    // Route 1: a derivable git identity that is a REGISTERED repo, but ONLY when the argument is
+    // the discovered worktree top. `discover_repo` walks upward, so running `rm --yes repo/src`
+    // must not silently select and deconfigure `repo`; an exact configured subroot remains valid
+    // through route 2's recorded-root match. Try the GOVERNING config's `[index] repo_id` override
+    // first, so pinned repos with `[index] root = "src"` resolve from the checkout top (not only
+    // the indexed subdir). Fall back to the content-derived identity when no override applies or
+    // it does not match a registered repo.
+    if path_is_worktree_top(&canonical) {
         let config_path = rag_rat_base::config::discover_config_path(&canonical);
         if let Ok(config) = rag_rat_base::config::Config::load(&config_path)
             && let Some(override_id) = config.repo_id_override.as_deref()
@@ -106,14 +110,13 @@ pub fn resolve_removable_repo(
         {
             return Ok(Some(load_resolved_repo(conn, identity.repo_id, canonical)?));
         }
-    }
-
-    // Route 1b: content-derived identity for the path itself. Still unambiguous because it is
-    // derived from the git content AT this path; no sole-repo guessing.
-    if let Ok(identity) = rag_rat_base::repo_identity::resolve_repo_identity(&canonical, None)
-        && schema::repo_id_is_registered(conn, &identity.repo_id)?
-    {
-        return Ok(Some(load_resolved_repo(conn, identity.repo_id, canonical)?));
+        // Route 1b: content-derived identity for the worktree top itself. Still unambiguous
+        // because it is derived from the git content AT this worktree; no sole-repo guessing.
+        if let Ok(identity) = rag_rat_base::repo_identity::resolve_repo_identity(&canonical, None)
+            && schema::repo_id_is_registered(conn, &identity.repo_id)?
+        {
+            return Ok(Some(load_resolved_repo(conn, identity.repo_id, canonical)?));
+        }
     }
 
     // Route 2: an exact recorded-root match — a physical path belongs to exactly one repo, and
@@ -129,6 +132,18 @@ pub fn resolve_removable_repo(
         }
     }
     Ok(None)
+}
+
+/// Whether `path` is exactly the worktree top discovered from it, not merely a child for which git
+/// discovery walked upward. Both sides are canonicalized because gix may return a symlinked or
+/// relative work directory while the removal argument was canonicalized above. Bare repositories
+/// have no work directory and therefore use only the exact recorded-root route.
+fn path_is_worktree_top(path: &Path) -> bool {
+    rag_rat_base::repo_discover::discover_repo(path)
+        .ok()
+        .and_then(|repo| repo.workdir().map(Path::to_path_buf))
+        .and_then(|work_dir| work_dir.canonicalize().ok())
+        .is_some_and(|work_dir| work_dir == path)
 }
 
 /// Remove `.` / `..` components WITHOUT touching the filesystem. Used only after
@@ -349,6 +364,39 @@ mod tests {
         );
     }
 
+    #[test]
+    fn identity_resolution_accepts_the_worktree_top_but_rejects_an_arbitrary_child() {
+        let (root, config) = poison_test_config("rm_identity_target");
+        let db = IndexDatabase::rebuild(&config).unwrap();
+        drop(db);
+        let storage = IndexConnection::open(&config.database).unwrap();
+        let conn = storage.connection();
+
+        let top = super::resolve_removable_repo(conn, &root)
+            .unwrap()
+            .expect("the worktree top resolves by identity");
+        let child = root.join("src");
+        assert!(
+            super::resolve_removable_repo(conn, &child).unwrap().is_none(),
+            "an arbitrary existing child must not select its enclosing repo"
+        );
+
+        // A configured `[index] root = "src"` records that exact subroot. Route 2 must continue to
+        // accept it even though route 1 correctly rejects child-path identity discovery.
+        conn.execute("UPDATE repo_roots SET root = ?1 WHERE repo_id = ?2", rusqlite::params![
+            child.to_string_lossy(),
+            top.repo_id
+        ])
+        .unwrap();
+        assert_eq!(
+            super::resolve_removable_repo(conn, &child).unwrap().unwrap().repo_id,
+            top.repo_id,
+            "an exact recorded config root remains a valid destructive target"
+        );
+        drop(storage);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
     /// The one REAL fixture repo (neither the `__unassigned__` placeholder nor the poison sibling).
     fn fixture_repo_id(conn: &rusqlite::Connection) -> String {
         conn.query_row(
@@ -377,7 +425,7 @@ mod tests {
         tag: &str,
         chunk_id: i64,
         symbol_id: i64,
-    ) {
+    ) -> i64 {
         // OR IGNORE: a real fixture chunk already carries a chunk_text row (leave it); the poison
         // chunk carries none (seed one so the purge has a chunk_text row to remove).
         conn.execute(
@@ -421,6 +469,19 @@ mod tests {
             params![symbol_id, format!("baseline_{tag}")],
         )
         .unwrap();
+        // #782: a legacy/malformed edge with no source_file_id. Normal index writers stamp the
+        // source file, but the nullable schema permits this shape; purge must reach it through a
+        // victim symbol endpoint. Reusing the symbol's interned qualified-name id satisfies every
+        // required interned-id column without adding unrelated fixture state.
+        conn.execute(
+            "INSERT INTO edges_data(source_file_id, from_symbol_id, to_symbol_id, from_name_id, \
+             to_name_id, edge_kind_id, confidence_id, resolution_id) SELECT NULL, s.id, s.id, \
+             n.id, n.id, n.id, n.id, n.id FROM symbols s CROSS JOIN (SELECT id FROM name_strings \
+             ORDER BY id LIMIT 1) n WHERE s.id = ?1",
+            params![symbol_id],
+        )
+        .unwrap();
+        conn.last_insert_rowid()
     }
 
     /// Seed the memory- and clone-generation transitive children the poison harness does not seed,
@@ -479,6 +540,7 @@ mod tests {
         let file_in = in_clause(files);
         let chunk_in = in_clause(chunks);
         let symbol_in = in_clause(symbols);
+        let null_edge_symbol_in = symbol_in.clone();
         let generation_in = generation.map(|g| g.to_string()).unwrap_or_else(|| "NULL".to_string());
         // (table, keyed column, IN-body) for every transitive child + the contentless chunk_fts.
         let checks: Vec<(&str, &str, String)> = vec![
@@ -514,6 +576,21 @@ mod tests {
                  IN the removed repo's ids) — add it to TRANSITIVE_SCOPED_TABLES",
             );
         }
+        let null_source_edges: i64 = conn
+            .query_row(
+                &format!(
+                    "SELECT COUNT(*) FROM edges_data WHERE source_file_id IS NULL AND \
+                     (from_symbol_id IN ({null_edge_symbol_in}) OR to_symbol_id IN \
+                     ({null_edge_symbol_in}))"
+                ),
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            null_source_edges, 0,
+            "purge left NULL-source edge row(s) attached to the removed repo's symbols"
+        );
     }
 
     #[test]
@@ -564,7 +641,7 @@ mod tests {
 
         // Seed B's derived + memory + clone transitive children (the ones the poison harness does
         // not seed) so purging B exercises — and the orphan check pins — every transitive child.
-        seed_chunk_symbol_children(conn, "b", b_chunk, b_symbol);
+        let b_null_source_edge = seed_chunk_symbol_children(conn, "b", b_chunk, b_symbol);
         seed_memory_and_clone_children(conn, &b_memory, b_generation);
 
         // Seed the fixture A's chunk/symbol children too, so A HAS rows in those transitive tables
@@ -586,7 +663,7 @@ mod tests {
                 |row| row.get(0),
             )
             .unwrap();
-        seed_chunk_symbol_children(conn, "a", a_chunk, a_symbol);
+        let a_null_source_edge = seed_chunk_symbol_children(conn, "a", a_chunk, a_symbol);
 
         // The full class-level table set, captured from the LIVE schema. A subset here would
         // silently narrow the guarantee, so pin a floor on its breadth.
@@ -637,6 +714,20 @@ mod tests {
             &b_symbols,
             &b_memory,
             Some(b_generation),
+        );
+        let edge_exists = |id: i64| -> bool {
+            conn.query_row("SELECT EXISTS(SELECT 1 FROM edges_data WHERE id = ?1)", [id], |row| {
+                row.get(0)
+            })
+            .unwrap()
+        };
+        assert!(
+            !edge_exists(b_null_source_edge),
+            "the victim's exact NULL-source edge row must be deleted, not merely endpoint-nulled"
+        );
+        assert!(
+            edge_exists(a_null_source_edge),
+            "the sibling's NULL-source edge row must survive the scoped purge"
         );
         // The read-side counter agrees: nothing left for B.
         assert_eq!(schema::count_repo_rows(conn, POISON_REPO_ID).unwrap().total_rows, 0);

--- a/crates/rag-rat-core/src/index/remove.rs
+++ b/crates/rag-rat-core/src/index/remove.rs
@@ -1,0 +1,693 @@
+//! `rag-rat rm <path>`: fully de-index a repo from the consolidated global store. The row-level
+//! purge (which tables, in which order) lives in `rag_rat_db::schema::purge`; this module is the
+//! ORCHESTRATION — resolve a filesystem path to a registered repo, count what would be deleted (the
+//! confirmation preview + `--dry-run`), and drive the destructive sequence: purge in one IMMEDIATE
+//! transaction, run the caller's on-disk deconfigure step, then VACUUM. The deconfigure step itself
+//! (delete `rag-rat.toml`, uninstall git hooks) is a filesystem closure the CLI shim passes in;
+//! [`purge_and_vacuum`] runs it at the right point in the locked sequence.
+//!
+//! LOCK + ATOMICITY: the repo's [`write_lock_path`](rag_rat_base::locks) flock (the same lock
+//! `index` / `gc` / `consolidate` take) is held across the WHOLE sequence — purge, deconfigure, and
+//! VACUUM — so no watcher/index pass can append to (or re-register) the repo mid-removal. The purge
+//! is a single IMMEDIATE transaction so a failure rolls the store back rather than leaving it
+//! half-removed; VACUUM runs on a fresh connection (it cannot run inside the purge transaction) but
+//! still under the flock, so the repo is fully de-indexed AND deconfigured before any writer
+//! resumes.
+
+use std::path::{Path, PathBuf};
+
+use rag_rat_base::locks::{self, WriteLock};
+use rag_rat_db::schema::{self, RepoRowCounts};
+use rag_rat_db::storage::IndexConnection;
+use rusqlite::{Connection, OptionalExtension, TransactionBehavior};
+
+use crate::index::{FreelistReclaim, FreelistReclaimReport, reclaim_freelist_at};
+
+/// How long the purge waits for the repo's write lock before giving up. `rm` is interactive, so a
+/// bounded wait surfaces an actionable "a writer is busy" error rather than blocking forever.
+const REMOVE_LOCK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
+/// A registered repo resolved from a filesystem path — the target of a removal.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ResolvedRepo {
+    pub repo_id: String,
+    pub display_name: Option<String>,
+    /// Every recorded working-tree root for the repo (a repo can be checked out in several
+    /// worktrees), so the caller can report exactly what it is about to remove.
+    pub roots: Vec<String>,
+    /// The path the removal resolved through — canonicalized when it exists, else the path as
+    /// given (a deleted / moved working tree resolved by its recorded root). Informational only
+    /// (reported in `--dry-run`); the on-disk deconfigure targets `roots` (the recorded governing
+    /// roots), not this — the arg path may be a subdirectory / linked worktree without the config.
+    pub resolved_root: PathBuf,
+}
+
+/// The read-only preview of a removal: the resolved repo plus a per-table count of everything the
+/// purge would delete. Drives both the confirmation summary and `--dry-run` (which stops here).
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct RemovePlan {
+    pub repo: ResolvedRepo,
+    pub counts: RepoRowCounts,
+}
+
+/// The result of an executed removal: what was purged and what VACUUM reclaimed.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct RemoveOutcome {
+    pub repo_id: String,
+    pub display_name: Option<String>,
+    /// Exact rows deleted (recounted under the write lock immediately before the purge).
+    pub purged_rows: i64,
+    /// The VACUUM reclaim report, or `None` when VACUUM did not complete (see `vacuum_skipped`).
+    pub vacuum: Option<FreelistReclaimReport>,
+    /// Why VACUUM did not run (a concurrent writer held the file busy) — the purge is still fully
+    /// committed; this is a best-effort space reclaim the operator can retry with `doctor
+    /// --vacuum`.
+    pub vacuum_skipped: Option<String>,
+}
+
+/// Resolve a filesystem `path` to a REGISTERED repo that can be removed, or `None` when the path
+/// maps to no registered repo. Resolution is DELIBERATELY STRICT — it never falls back to "the sole
+/// repo" the way the read-path resolver does: for a destructive `rm <path>`, resolving an arbitrary
+/// unregistered path to the only registered repo would offer to delete the wrong repo. Routes, in
+/// order:
+///  1. by derived git IDENTITY — if `path` is a git worktree whose content-derived id is a
+///     registered repo, that id (this also resolves a LINKED worktree, whose path is not the
+///     recorded root but derives the same id);
+///  2. by EXACT `repo_roots` match on the canonical path, then the path as given — so a repo whose
+///     working tree was DELETED / moved / is non-git (identity underivable), or was registered
+///     under a pinned `[index] repo_id`, still resolves by its recorded root.
+///
+/// Read-only. `path` is canonicalized when it exists on disk; a non-existent path (a deleted /
+/// moved working tree) falls back to its ABSOLUTE lexically-normalized form
+/// ([`std::path::absolute`], CWD-relative, filesystem-free) so a RELATIVE argument to a gone tree
+/// (e.g. `./old-repo`) still matches the absolute root `repo_roots` recorded — not the relative
+/// string, which never would.
+pub fn resolve_removable_repo(
+    conn: &Connection,
+    path: &Path,
+) -> anyhow::Result<Option<ResolvedRepo>> {
+    let canonical = path
+        .canonicalize()
+        .or_else(|_| std::path::absolute(path))
+        .unwrap_or_else(|_| path.to_path_buf());
+
+    // Route 1: a derivable git identity that is a REGISTERED repo. The identity is content-derived
+    // from the git repo AT this path, so a match is unambiguous — no sole-repo guessing. A pinned
+    // `[index] repo_id` is intentionally NOT read here (we have no config for an arbitrary path);
+    // route 2's recorded-root match covers a pinned registration.
+    if let Ok(identity) = rag_rat_base::repo_identity::resolve_repo_identity(&canonical, None)
+        && schema::repo_id_is_registered(conn, &identity.repo_id)?
+    {
+        return Ok(Some(load_resolved_repo(conn, identity.repo_id, canonical)?));
+    }
+
+    // Route 2: an exact recorded-root match — a physical path belongs to exactly one repo, and
+    // registration always records the root (#427). Try the canonical form first (registration
+    // records the canonicalized root), then the raw path as a courtesy.
+    let mut seen = std::collections::BTreeSet::new();
+    for candidate in [canonical.to_string_lossy().to_string(), path.to_string_lossy().to_string()] {
+        if !seen.insert(candidate.clone()) {
+            continue;
+        }
+        if let Some(repo_id) = recorded_root_owner(conn, &candidate)? {
+            return Ok(Some(load_resolved_repo(conn, repo_id, canonical)?));
+        }
+    }
+    Ok(None)
+}
+
+/// The repo that recorded `root` in `repo_roots` (a physical path belongs to exactly one repo), or
+/// `None`. Read-only.
+fn recorded_root_owner(conn: &Connection, root: &str) -> rusqlite::Result<Option<String>> {
+    conn.query_row("SELECT repo_id FROM repo_roots WHERE root = ?1 LIMIT 1", [root], |row| {
+        row.get::<_, String>(0)
+    })
+    .optional()
+}
+
+/// Load the registry facts (display name + recorded roots) for a resolved `repo_id`.
+fn load_resolved_repo(
+    conn: &Connection,
+    repo_id: String,
+    resolved_root: PathBuf,
+) -> rusqlite::Result<ResolvedRepo> {
+    let display_name: Option<String> = conn
+        .query_row("SELECT display_name FROM repos WHERE repo_id = ?1", [&repo_id], |row| {
+            row.get::<_, String>(0)
+        })
+        .optional()?;
+    let mut roots_stmt =
+        conn.prepare("SELECT root FROM repo_roots WHERE repo_id = ?1 ORDER BY root")?;
+    let roots = roots_stmt
+        .query_map([&repo_id], |row| row.get::<_, String>(0))?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    Ok(ResolvedRepo { repo_id, display_name, roots, resolved_root })
+}
+
+/// Build the read-only removal plan: the resolved repo + the per-table count of what the purge
+/// would delete. Read-only, so it is safe to run for `--dry-run` and to render before prompting.
+pub fn plan_remove(conn: &Connection, repo: ResolvedRepo) -> anyhow::Result<RemovePlan> {
+    let counts = schema::count_repo_rows(conn, &repo.repo_id)?;
+    Ok(RemovePlan { repo, counts })
+}
+
+/// Execute the removal: purge every row `repo_id` owns in ONE IMMEDIATE transaction, run the
+/// caller's `deconfigure` step (delete `rag-rat.toml` / uninstall hooks), then VACUUM — the WHOLE
+/// sequence under the repo's per-repo write lock. DESTRUCTIVE — the caller has already confirmed
+/// (or passed `--yes`). Returns the outcome plus whatever `deconfigure` produced (the CLI's cleanup
+/// report).
+///
+/// LOCK SPAN (the re-registration guard): the write lock is held across purge → deconfigure →
+/// VACUUM, not just the purge. Deconfiguration is what makes the repo un-re-indexable (a keyless
+/// `rag-rat index` needs a `rag-rat.toml`), so it must land BEFORE any writer waiting on the lock
+/// can resume — otherwise a concurrent index/maintenance pass could re-register and repopulate the
+/// just-purged repo during the (seconds-long) VACUUM window. Holding the lock through VACUUM also
+/// keeps that window closed.
+///
+/// ORDER (`deconfigure` before VACUUM): the purge has already committed, so the on-disk
+/// deconfiguration must run regardless of the VACUUM outcome. A busy VACUUM mutated nothing and
+/// downgrades to `vacuum_skipped`; a post-VACUUM failure (commit_fts rebuild / checkpoint)
+/// propagates as `Err` — but by then the purge AND the deconfiguration have both happened, so the
+/// operator just reclaims/repairs later with `doctor --vacuum`.
+pub fn purge_and_vacuum<C>(
+    database: &Path,
+    repo_id: &str,
+    now_ms: i64,
+    deconfigure: impl FnOnce() -> C,
+) -> anyhow::Result<(RemoveOutcome, C)> {
+    // One lock for the whole operation. Acquired FIRST (per-repo before the global schema lock the
+    // VACUUM takes — the per-repo → global ordering rule).
+    let _lock =
+        WriteLock::acquire_timeout(database, repo_id, REMOVE_LOCK_TIMEOUT)?.ok_or_else(|| {
+            anyhow::anyhow!(
+                "timed out waiting for the repo's write lock — an index or maintenance pass is \
+                 running; re-run `rag-rat rm` once it finishes"
+            )
+        })?;
+
+    // ALSO exclude a concurrent papertrail autosync flight. Autosync deliberately does NOT take the
+    // repo write lock (its commits are short lockless transactions serialized by SQLite), so
+    // without this a flight in progress could commit `papertrail_*` rows AFTER the purge
+    // deletes them — rows keyed by the removed `repo_id` that survive a "removed" result. Its
+    // own flight lock waits for any in-flight sync to drain and blocks a new one; combined with
+    // the deconfigure below (a new flight can't reload a deleted config), the repo's papertrail
+    // stays purged. The two lock sets are disjoint (autosync never takes the write lock;
+    // index/rm never take the flight lock), so acquiring both cannot deadlock.
+    let _papertrail_lock = locks::FileLock::acquire_timeout(
+        &locks::papertrail_lock_path(database, repo_id),
+        REMOVE_LOCK_TIMEOUT,
+    )?
+    .ok_or_else(|| {
+        anyhow::anyhow!(
+            "timed out waiting for a papertrail sync flight to finish — re-run `rag-rat rm` once \
+             it drains"
+        )
+    })?;
+
+    // Recount + purge under the lock so the reported `purged_rows` is exact and nothing appends to
+    // the repo between the count and the delete.
+    let (purged_rows, display_name) = {
+        let storage = IndexConnection::open(database)?;
+        let conn = storage.connection();
+        let display_name: Option<String> = conn
+            .query_row("SELECT display_name FROM repos WHERE repo_id = ?1", [repo_id], |row| {
+                row.get::<_, String>(0)
+            })
+            .optional()?;
+        let purged_rows = schema::count_repo_rows(conn, repo_id)?.total_rows;
+        // ONE IMMEDIATE transaction: all-or-nothing. The write lock is already held, and IMMEDIATE
+        // takes the SQLite write lock up front rather than upgrading mid-transaction.
+        let tx = rusqlite::Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
+        schema::purge_repo_rows(&tx, repo_id)?;
+        // Tombstone the repo in the SAME transaction. The marker lives in `index_meta` (which the
+        // purge sweep never touches), so it survives the removal that writes it and lets
+        // `register_repo` refuse a writer that resumes after the lock releases with a stale
+        // in-memory config. Only `rag-rat init` clears it.
+        schema::mark_repo_removed(&tx, repo_id, now_ms)?;
+        tx.commit()?;
+        (purged_rows, display_name)
+        // `storage` (the purge connection) drops here, releasing its SQLite handles before VACUUM
+        // opens its own fresh connection — but the write lock is STILL held below.
+    };
+
+    // Deconfigure UNDER the lock, after the committed purge and BEFORE the VACUUM: this is the step
+    // that makes the repo un-re-indexable, so it must land before any writer can resume, and it
+    // must run regardless of the VACUUM outcome.
+    let deconfigured = deconfigure();
+
+    // VACUUM last, still under the write lock, on a fresh connection under the schema lock. A busy
+    // VACUUM mutated nothing → `vacuum_skipped`; a post-VACUUM failure propagates (`?`) — the purge
+    // and deconfiguration already committed, so the operator repairs/reclaims later with `doctor
+    // --vacuum`.
+    let (vacuum, vacuum_skipped) = match reclaim_freelist_at(database)? {
+        FreelistReclaim::Reclaimed(report) => (Some(report), None),
+        FreelistReclaim::BusySkipped(message) => (None, Some(message)),
+    };
+
+    Ok((
+        RemoveOutcome {
+            repo_id: repo_id.to_string(),
+            display_name,
+            purged_rows,
+            vacuum,
+            vacuum_skipped,
+        },
+        deconfigured,
+    ))
+}
+
+/// The per-repo write-lock file for `repo_id` beside `database` — exposed so a caller can report
+/// the lock path in a timeout diagnostic if it needs to.
+pub fn remove_write_lock_path(database: &Path, repo_id: &str) -> PathBuf {
+    locks::write_lock_path(database, repo_id)
+}
+
+#[cfg(test)]
+mod tests {
+    //! The purge-completeness TRIPWIRE. It builds a real fixture repo A alongside the
+    //! poison-sibling repo B (seeded across every repo-scoped table by the rebuild-tail harness),
+    //! seeds A's derived transitive children too, then purges A and asserts — at the CLASS level,
+    //! by enumerating the schema rather than a hand-listed subset — that (a) ZERO rows remain for A
+    //! in every `repo_id`-bearing table and no orphan survives in any transitive child, and (b) the
+    //! poison sibling B is byte-for-byte untouched. A future migration that adds a new repo-scoped
+    //! table is swept automatically (the class-level `repo_id` enumeration), and this test proves
+    //! an unscoped purge would wipe B (via `assert_sibling_intact`) — so a scoping regression
+    //! fails here instead of in production.
+
+    use rag_rat_base::repo_identity::LEGACY_REPO_ID;
+    use rag_rat_db::schema::{self, purge_repo_rows, repo_scoped_table_names};
+    use rag_rat_db::storage::IndexConnection;
+    use rusqlite::params;
+
+    use super::purge_and_vacuum;
+    use crate::index::IndexDatabase;
+    use crate::index::poison_sibling::{POISON_REPO_ID, assert_sibling_intact};
+    use crate::index::schema_bootstrap_tests::poison_test_config;
+
+    /// The one REAL fixture repo (neither the `__unassigned__` placeholder nor the poison sibling).
+    fn fixture_repo_id(conn: &rusqlite::Connection) -> String {
+        conn.query_row(
+            "SELECT repo_id FROM repos WHERE repo_id != ?1 AND repo_id != ?2",
+            params![LEGACY_REPO_ID, POISON_REPO_ID],
+            |row| row.get(0),
+        )
+        .expect("a real fixture repo is registered on a git fixture")
+    }
+
+    /// A comma-joined `IN (...)` body for a captured id set (empty → `NULL`, matching nothing).
+    fn in_clause(ids: &[i64]) -> String {
+        if ids.is_empty() {
+            "NULL".to_string()
+        } else {
+            ids.iter().map(i64::to_string).collect::<Vec<_>>().join(",")
+        }
+    }
+
+    /// Seed one sentinel row into each DERIVED chunk/symbol transitive child the poison harness
+    /// does not itself seed, hung off the given chunk + symbol. `tag` keeps rows for two
+    /// different repos (the removed repo and the sibling) collision-free. So purging has
+    /// something to delete in those tables and the orphan check is not vacuous.
+    fn seed_chunk_symbol_children(
+        conn: &rusqlite::Connection,
+        tag: &str,
+        chunk_id: i64,
+        symbol_id: i64,
+    ) {
+        // OR IGNORE: a real fixture chunk already carries a chunk_text row (leave it); the poison
+        // chunk carries none (seed one so the purge has a chunk_text row to remove).
+        conn.execute(
+            "INSERT OR IGNORE INTO chunk_text(chunk_id, blob, raw_len, dict_version) VALUES (?1, \
+             x'00', 1, 0)",
+            params![chunk_id],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO chunk_embeddings(chunk_id, model_id, model_version, source_text_hash, \
+             input_hash, embedding_text_version, embedding_policy, embedding_priority, \
+             input_chars, input_truncated, embedding_dim, vector_blob, status, attempt_count, \
+             created_at_ms)
+             VALUES (?1, 'm', 'v', ?2, ?2, 'etv', 'eligible', 0, 1, 0, 1, x'00', 'ready', 0, 0)",
+            params![chunk_id, format!("sth_{tag}")],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO chunk_summaries(chunk_id, model_id, prompt_version, input_hash, \
+             text_hash, summary, status, attempt_count)
+             VALUES (?1, 'm', 'pv', ?2, 'th', 'summary', 'ready', 0)",
+            params![chunk_id, format!("ih_{tag}")],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO git_chunk_blame(chunk_id, source_text_hash, path, start_line, end_line, \
+             line_count, dominant_commit_lines, commit_counts_json, computed_at_ms)
+             VALUES (?1, ?2, 'src/a.rs', 0, 0, 1, 0, '{}', 0)",
+            params![chunk_id, format!("sth_{tag}")],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO symbol_facts(symbol_id, fact_kind, fact_value) VALUES (?1, ?2, 'test')",
+            params![symbol_id, format!("attr_{tag}")],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO symbol_fingerprints(symbol_id, normalizer_kind, normalizer_version, \
+             struct_hash, token_len, created_at_ms)
+             VALUES (?1, ?2, 1, 'sh', 1, 0)",
+            params![symbol_id, format!("baseline_{tag}")],
+        )
+        .unwrap();
+    }
+
+    /// Seed the memory- and clone-generation transitive children the poison harness does not seed,
+    /// hung off the poison sibling's memory + clone generation, so purging the sibling exercises
+    /// (and the orphan check pins) every transitive child.
+    fn seed_memory_and_clone_children(
+        conn: &rusqlite::Connection,
+        memory_id: &str,
+        generation: i64,
+    ) {
+        conn.execute(
+            "INSERT INTO repo_memory_call_paths(memory_id, edge_sequence_hash, path_summary, \
+             created_at_ms) VALUES (?1, 'esh', 'summary', 0)",
+            params![memory_id],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO repo_memory_call_path_edges(memory_id, edge_sequence_hash, ordinal, \
+             edge_fingerprint, to_name, edge_kind) VALUES (?1, 'esh', 0, 'fp', 'callee', 'calls')",
+            params![memory_id],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO clone_edges(build_generation, a_path, a_start_byte, a_file_sha, b_path, \
+             b_start_byte, b_file_sha, overlap, a_token_len, b_token_len, similarity, edge_source)
+             VALUES (?1, 'a.rs', 0, 'sa', 'b.rs', 0, 'sb', 1, 1, 1, 1.0, 'exact')",
+            params![generation],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO clone_subblock_postings(build_generation, token_hash, path, start_byte, \
+             file_sha) VALUES (?1, 1, 'a.rs', 0, 'sa')",
+            params![generation],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO clone_df_epoch(build_generation, token_hash, df) VALUES (?1, 1, 1)",
+            params![generation],
+        )
+        .unwrap();
+    }
+
+    /// Assert NO orphan survives the purge in ANY transitive child — checked against the parent id
+    /// sets CAPTURED BEFORE the purge, so a row whose parent was deleted but which itself was
+    /// missed (the exact escape a hand-list allows) is still caught. `NULL` id sets match
+    /// nothing (a repo with no memory / clone generation).
+    #[allow(clippy::too_many_arguments)]
+    fn assert_no_transitive_orphans(
+        conn: &rusqlite::Connection,
+        files: &[i64],
+        chunks: &[i64],
+        symbols: &[i64],
+        memory_id: &str,
+        generation: Option<i64>,
+    ) {
+        let file_in = in_clause(files);
+        let chunk_in = in_clause(chunks);
+        let symbol_in = in_clause(symbols);
+        let generation_in = generation.map(|g| g.to_string()).unwrap_or_else(|| "NULL".to_string());
+        // (table, keyed column, IN-body) for every transitive child + the contentless chunk_fts.
+        let checks: Vec<(&str, &str, String)> = vec![
+            ("symbols", "file_id", file_in.clone()),
+            ("chunks", "file_id", file_in.clone()),
+            ("edges_data", "source_file_id", file_in),
+            ("chunk_fts", "rowid", chunk_in.clone()),
+            ("chunk_text", "chunk_id", chunk_in.clone()),
+            ("chunk_embeddings", "chunk_id", chunk_in.clone()),
+            ("chunk_summaries", "chunk_id", chunk_in.clone()),
+            ("git_chunk_blame", "chunk_id", chunk_in),
+            ("symbol_facts", "symbol_id", symbol_in.clone()),
+            ("symbol_fingerprints", "symbol_id", symbol_in.clone()),
+            ("logical_symbol_members", "symbol_id", symbol_in),
+            ("repo_memory_tags", "memory_id", format!("'{memory_id}'")),
+            ("repo_memory_call_paths", "memory_id", format!("'{memory_id}'")),
+            ("repo_memory_call_path_edges", "memory_id", format!("'{memory_id}'")),
+            ("clone_edges", "build_generation", generation_in.clone()),
+            ("clone_subblock_postings", "build_generation", generation_in.clone()),
+            ("clone_df_epoch", "build_generation", generation_in),
+        ];
+        for (table, column, in_body) in checks {
+            let count: i64 = conn
+                .query_row(
+                    &format!("SELECT COUNT(*) FROM {table} WHERE {column} IN ({in_body})"),
+                    [],
+                    |row| row.get(0),
+                )
+                .unwrap();
+            assert_eq!(
+                count, 0,
+                "purge left {count} orphaned row(s) in transitive child `{table}` (WHERE {column} \
+                 IN the removed repo's ids) — add it to TRANSITIVE_SCOPED_TABLES",
+            );
+        }
+    }
+
+    #[test]
+    fn purge_removes_every_scoped_row_for_the_repo_and_leaves_the_sibling_intact() {
+        let (_root, config) = poison_test_config("rm_purge_tripwire");
+        // Rebuild the fixture (indexes repo A, seeds the poison sibling B across ~37 tables), then
+        // operate through a BARE connection exactly as the production purge does — the scoped
+        // `IndexDatabase` connection installs a `temp.files` view that hides `repo_id` and shadows
+        // the base tables.
+        let _db = IndexDatabase::rebuild(&config).unwrap();
+        let storage = IndexConnection::open(&config.database).unwrap();
+        let conn = storage.connection();
+
+        // We PURGE the poison sibling B (seeded across ~37 repo_id tables — far broader than the
+        // fixture, so a table the sweep misses is caught) and PROTECT the real fixture A.
+        let repo_a = fixture_repo_id(conn);
+        let scalar_i64 = |sql: &str, param: i64| -> i64 {
+            conn.query_row(sql, params![param], |row| row.get(0)).unwrap()
+        };
+
+        // B's poison ids (captured BEFORE any delete so the orphan check is exact).
+        let b_file: i64 = conn
+            .query_row(
+                "SELECT id FROM files WHERE repo_id = ?1 AND path LIKE 'zz_poison_file%' LIMIT 1",
+                params![POISON_REPO_ID],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let b_chunk = scalar_i64("SELECT id FROM chunks WHERE file_id = ?1 LIMIT 1", b_file);
+        let b_symbol = scalar_i64("SELECT id FROM symbols WHERE file_id = ?1 LIMIT 1", b_file);
+        let b_memory: String = conn
+            .query_row(
+                "SELECT id FROM repo_memories WHERE repo_id = ?1 LIMIT 1",
+                params![POISON_REPO_ID],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let b_generation: i64 = conn
+            .query_row(
+                "SELECT generation FROM clone_graph_generations WHERE repo_id = ?1 LIMIT 1",
+                params![POISON_REPO_ID],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let b_files = vec![b_file];
+        let b_chunks = vec![b_chunk];
+        let b_symbols = vec![b_symbol];
+
+        // Seed B's derived + memory + clone transitive children (the ones the poison harness does
+        // not seed) so purging B exercises — and the orphan check pins — every transitive child.
+        seed_chunk_symbol_children(conn, "b", b_chunk, b_symbol);
+        seed_memory_and_clone_children(conn, &b_memory, b_generation);
+
+        // Seed the fixture A's chunk/symbol children too, so A HAS rows in those transitive tables
+        // — then a scoping bug that deletes them (keyed by A's ids, which the B purge must
+        // not touch) would drop A's counts and fail the sibling-integrity check below.
+        let a_chunk: i64 = conn
+            .query_row(
+                "SELECT id FROM chunks WHERE file_id IN (SELECT id FROM files WHERE repo_id = ?1) \
+                 LIMIT 1",
+                params![&repo_a],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let a_symbol: i64 = conn
+            .query_row(
+                "SELECT id FROM symbols WHERE file_id IN (SELECT id FROM files WHERE repo_id = \
+                 ?1) LIMIT 1",
+                params![&repo_a],
+                |row| row.get(0),
+            )
+            .unwrap();
+        seed_chunk_symbol_children(conn, "a", a_chunk, a_symbol);
+
+        // The full class-level table set, captured from the LIVE schema. A subset here would
+        // silently narrow the guarantee, so pin a floor on its breadth.
+        let repo_id_tables = repo_scoped_table_names(conn).unwrap();
+        assert!(
+            repo_id_tables.len() >= 40,
+            "expected the class-level sweep to see the whole schema (>= 40 repo_id tables), saw {}",
+            repo_id_tables.len()
+        );
+
+        // Pre-purge fact base: B is seeded across many tables; A has real rows.
+        let a_before = schema::count_repo_rows(conn, &repo_a).unwrap();
+        let b_before = schema::count_repo_rows(conn, POISON_REPO_ID).unwrap();
+        assert!(a_before.total_rows > 0, "the fixture sibling must have rows to protect");
+        assert!(
+            b_before.by_table.len() >= 30,
+            "the poison sibling must be seeded across ~37 tables (saw {})",
+            b_before.by_table.len()
+        );
+
+        // Purge B inside one IMMEDIATE transaction, exactly as production does.
+        let tx =
+            rusqlite::Transaction::new_unchecked(conn, rusqlite::TransactionBehavior::Immediate)
+                .unwrap();
+        purge_repo_rows(&tx, POISON_REPO_ID).unwrap();
+        tx.commit().unwrap();
+
+        // (a) CLASS-LEVEL COMPLETENESS: zero rows remain for B in EVERY repo_id-bearing table.
+        for table in &repo_id_tables {
+            let count: i64 = conn
+                .query_row(
+                    &format!("SELECT COUNT(*) FROM \"{table}\" WHERE repo_id = ?1"),
+                    params![POISON_REPO_ID],
+                    |row| row.get(0),
+                )
+                .unwrap();
+            assert_eq!(
+                count, 0,
+                "purge left {count} row(s) for the removed repo in `{table}` — the class-level \
+                 repo_id sweep must reach it",
+            );
+        }
+        // …and no orphan in any transitive child (checked against the ids captured before purge).
+        assert_no_transitive_orphans(
+            conn,
+            &b_files,
+            &b_chunks,
+            &b_symbols,
+            &b_memory,
+            Some(b_generation),
+        );
+        // The read-side counter agrees: nothing left for B.
+        assert_eq!(schema::count_repo_rows(conn, POISON_REPO_ID).unwrap().total_rows, 0);
+
+        // (b) SIBLING INTEGRITY: the fixture A is untouched — same rows in every table, before and
+        // after (the purge only DELETEs, so a per-table row-count parity catches any leak).
+        let a_after = schema::count_repo_rows(conn, &repo_a).unwrap();
+        assert_eq!(
+            a_before.by_table, a_after.by_table,
+            "the purge changed the fixture sibling's row counts — an unscoped delete leaked",
+        );
+    }
+
+    #[test]
+    fn dry_run_style_count_does_not_mutate_the_store() {
+        let (_root, config) = poison_test_config("rm_count_readonly");
+        let _db = IndexDatabase::rebuild(&config).unwrap();
+        let storage = IndexConnection::open(&config.database).unwrap();
+        let conn = storage.connection();
+        let repo_a = fixture_repo_id(conn);
+
+        let before = schema::count_repo_rows(conn, &repo_a).unwrap();
+        // Counting twice must be a pure read: identical result, sibling untouched.
+        let again = schema::count_repo_rows(conn, &repo_a).unwrap();
+        assert_eq!(before.by_table, again.by_table);
+        assert_eq!(before.total_rows, again.total_rows);
+        assert!(before.total_rows > 0);
+        assert_sibling_intact(conn);
+    }
+
+    /// The public entry point removes the repo AND threads the deconfigure closure's result back:
+    /// after `purge_and_vacuum`, the repo is unregistered, no `repo_id` row survives, and the
+    /// closure ran (its value is returned). Exercises the restructured lock → purge → deconfigure →
+    /// VACUUM flow end to end.
+    #[test]
+    fn purge_and_vacuum_removes_the_repo_and_threads_the_deconfigure_result() {
+        let (_root, config) = poison_test_config("rm_purge_and_vacuum");
+        let db = IndexDatabase::rebuild(&config).unwrap();
+        // Read the fixture repo id, then DROP the rebuilt db so it releases the repo's write lock
+        // before `purge_and_vacuum` tries to acquire it.
+        let repo_a = {
+            let storage = IndexConnection::open(&config.database).unwrap();
+            fixture_repo_id(storage.connection())
+        };
+        drop(db);
+
+        let (outcome, cleanup) =
+            purge_and_vacuum(&config.database, &repo_a, 12_345, || "deconfigured".to_string())
+                .unwrap();
+        assert!(outcome.purged_rows > 0, "the fixture repo had rows to purge");
+        assert_eq!(cleanup, "deconfigured", "the deconfigure closure result must thread back");
+
+        // The repo is gone from the registry and every repo_id table.
+        let storage = IndexConnection::open(&config.database).unwrap();
+        let conn = storage.connection();
+        let still_registered: bool = conn
+            .query_row(
+                "SELECT EXISTS(SELECT 1 FROM repos WHERE repo_id = ?1)",
+                params![&repo_a],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(!still_registered, "the purged repo must be unregistered");
+        // …and it is TOMBSTONED so a stale-config writer can't silently re-register it.
+        assert!(
+            schema::is_repo_removed(conn, &repo_a).unwrap(),
+            "the removed repo must be tombstoned"
+        );
+        for table in repo_scoped_table_names(conn).unwrap() {
+            let count: i64 = conn
+                .query_row(
+                    &format!("SELECT COUNT(*) FROM \"{table}\" WHERE repo_id = ?1"),
+                    params![&repo_a],
+                    |row| row.get(0),
+                )
+                .unwrap();
+            assert_eq!(count, 0, "rows for the purged repo remain in `{table}`");
+        }
+    }
+
+    /// The removal tombstone gates re-registration: once a repo is marked removed, the indexing
+    /// (root-recording) path refuses it — the durable stop for a stale-config writer that queued
+    /// behind the lock — while the read-only adoption path stays open, and `rag-rat init`'s clear
+    /// lifts the gate.
+    #[test]
+    fn register_refuses_a_removed_repo_until_it_is_cleared() {
+        use rag_rat_base::repo_identity::{RepoIdentity, RepoIdentityClass};
+
+        let (_root, config) = poison_test_config("rm_tombstone_register");
+        let _db = IndexDatabase::rebuild(&config).unwrap();
+        let storage = IndexConnection::open(&config.database).unwrap();
+        let conn = storage.connection();
+        let hooks = crate::index::migration_hooks();
+        let identity = RepoIdentity {
+            repo_id: "tombstone-victim".to_string(),
+            display_name: "tombstone-victim".to_string(),
+            class: RepoIdentityClass::Portable,
+            shallow_boundary: Vec::new(),
+        };
+        let tv_root = std::path::Path::new("/src/tombstone-victim");
+
+        // A fresh registration works.
+        schema::register_repo(conn, &identity, tv_root, 1, &hooks).unwrap();
+        // Tombstone it → the indexing (root-recording) path refuses.
+        schema::mark_repo_removed(conn, &identity.repo_id, 2).unwrap();
+        let err = schema::register_repo(conn, &identity, tv_root, 3, &hooks)
+            .expect_err("a tombstoned repo must refuse re-registration");
+        assert!(
+            format!("{err}").contains("rag-rat rm") || format!("{err}").contains("removed"),
+            "the refusal must name the removal remedy, got: {err}"
+        );
+        // The READ-ONLY adoption path is NOT gated (a read of a now-empty repo is harmless).
+        schema::register_repo_read_only(conn, &identity, tv_root, 4, &hooks).unwrap();
+        // `rag-rat init`'s clear lifts the tombstone → the indexing path works again.
+        schema::clear_repo_removed(conn, &identity.repo_id).unwrap();
+        assert!(!schema::is_repo_removed(conn, &identity.repo_id).unwrap());
+        schema::register_repo(conn, &identity, tv_root, 5, &hooks).unwrap();
+    }
+}

--- a/crates/rag-rat-core/src/index/remove.rs
+++ b/crates/rag-rat-core/src/index/remove.rs
@@ -88,7 +88,7 @@ pub fn resolve_removable_repo(
 ) -> anyhow::Result<Option<ResolvedRepo>> {
     let canonical = path
         .canonicalize()
-        .or_else(|_| std::path::absolute(path))
+        .or_else(|_| std::path::absolute(path).map(|path| lexically_normalize(&path)))
         .unwrap_or_else(|_| path.to_path_buf());
 
     // Route 1: a derivable git identity that is a REGISTERED repo. Try the GOVERNING config's
@@ -129,6 +129,24 @@ pub fn resolve_removable_repo(
         }
     }
     Ok(None)
+}
+
+/// Remove `.` / `..` components WITHOUT touching the filesystem. Used only after
+/// [`std::path::absolute`] when `canonicalize` failed because the target checkout is gone: absolute
+/// deliberately preserves lexical parents (`gone/../old`), but `repo_roots` records the canonical
+/// normalized root (`/cwd/old`). At an absolute root, extra `..` components stay pinned at root.
+fn lexically_normalize(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            std::path::Component::CurDir => {},
+            std::path::Component::ParentDir => {
+                normalized.pop();
+            },
+            component => normalized.push(component.as_os_str()),
+        }
+    }
+    normalized
 }
 
 /// The repo that recorded `root` in `repo_roots` (a physical path belongs to exactly one repo), or
@@ -319,6 +337,17 @@ mod tests {
     use crate::index::IndexDatabase;
     use crate::index::poison_sibling::{POISON_REPO_ID, assert_sibling_intact};
     use crate::index::schema_bootstrap_tests::poison_test_config;
+
+    #[test]
+    fn missing_path_fallback_lexically_normalizes_parent_components() {
+        let base = std::path::absolute(".").unwrap();
+        let spelled_with_parent = base.join("gone").join("..").join("old");
+        assert_eq!(
+            super::lexically_normalize(&spelled_with_parent),
+            base.join("old"),
+            "a missing checkout path must match the canonical repo_roots spelling"
+        );
+    }
 
     /// The one REAL fixture repo (neither the `__unassigned__` placeholder nor the poison sibling).
     fn fixture_repo_id(conn: &rusqlite::Connection) -> String {

--- a/crates/rag-rat-core/src/index/remove.rs
+++ b/crates/rag-rat-core/src/index/remove.rs
@@ -277,6 +277,27 @@ pub fn remove_write_lock_path(database: &Path, repo_id: &str) -> PathBuf {
     locks::write_lock_path(database, repo_id)
 }
 
+/// #767 review: fail a repo-scoped write CLOSED when the active repo was removed by `rag-rat rm`.
+/// The removal tombstone is normally enforced at connection-registration time, but a connection
+/// that opened (and resolved its active repo scope) BEFORE `rm` acquired the repo lock keeps that
+/// stale scope; without this re-check its write would INSERT fresh rows stamped with the removed
+/// `repo_id` AFTER `rm`'s purge committed and reported success (the repo-scoped tables
+/// intentionally carry no FK to `repos`). The guarded paths: the MCP memory mutations
+/// (`memory_write`), the dream findings sync (`dream_run`), and the MCP/lazy heal writers
+/// (`heal_file` / `heal_index`). Call INSIDE the write transaction (or immediately before the
+/// write) so the tombstone read shares the transaction's snapshot: an `rm` that committed first is
+/// seen (fail closed); an `rm` that commits after purges the just-written rows itself (also
+/// consistent). The reverse-order hazard is the one this closes.
+pub(crate) fn assert_repo_not_removed(conn: &Connection, repo_id: &str) -> anyhow::Result<()> {
+    if schema::is_repo_removed(conn, repo_id)? {
+        anyhow::bail!(
+            "repo {repo_id} was removed with `rag-rat rm` — refusing the write; run `rag-rat \
+             init` in the repo to re-add it"
+        );
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     //! The purge-completeness TRIPWIRE. It builds a real fixture repo A alongside the

--- a/crates/rag-rat-core/src/index/remove.rs
+++ b/crates/rag-rat-core/src/index/remove.rs
@@ -91,10 +91,25 @@ pub fn resolve_removable_repo(
         .or_else(|_| std::path::absolute(path))
         .unwrap_or_else(|_| path.to_path_buf());
 
-    // Route 1: a derivable git identity that is a REGISTERED repo. The identity is content-derived
-    // from the git repo AT this path, so a match is unambiguous — no sole-repo guessing. A pinned
-    // `[index] repo_id` is intentionally NOT read here (we have no config for an arbitrary path);
-    // route 2's recorded-root match covers a pinned registration.
+    // Route 1: a derivable git identity that is a REGISTERED repo. Try the GOVERNING config's
+    // `[index] repo_id` override first when the path is a live checkout with a config, so pinned
+    // repos with `[index] root = "src"` resolve from the checkout top (not only the indexed
+    // subdir). Fall back to the content-derived identity when no override applies or it does not
+    // match a registered repo.
+    if canonical.is_dir() {
+        let config_path = rag_rat_base::config::discover_config_path(&canonical);
+        if let Ok(config) = rag_rat_base::config::Config::load(&config_path)
+            && let Some(override_id) = config.repo_id_override.as_deref()
+            && let Ok(identity) =
+                rag_rat_base::repo_identity::resolve_repo_identity(&canonical, Some(override_id))
+            && schema::repo_id_is_registered(conn, &identity.repo_id)?
+        {
+            return Ok(Some(load_resolved_repo(conn, identity.repo_id, canonical)?));
+        }
+    }
+
+    // Route 1b: content-derived identity for the path itself. Still unambiguous because it is
+    // derived from the git content AT this path; no sole-repo guessing.
     if let Ok(identity) = rag_rat_base::repo_identity::resolve_repo_identity(&canonical, None)
         && schema::repo_id_is_registered(conn, &identity.repo_id)?
     {
@@ -683,8 +698,10 @@ mod tests {
             format!("{err}").contains("rag-rat rm") || format!("{err}").contains("removed"),
             "the refusal must name the removal remedy, got: {err}"
         );
-        // The READ-ONLY adoption path is NOT gated (a read of a now-empty repo is harmless).
-        schema::register_repo_read_only(conn, &identity, tv_root, 4, &hooks).unwrap();
+        // The read-only adoption path is ALSO gated: it is write-capable (a stale `papertrail sync`
+        // registers read-only, then commits rows), so a tombstoned repo must refuse there too.
+        schema::register_repo_read_only(conn, &identity, tv_root, 4, &hooks)
+            .expect_err("a tombstoned repo must refuse read-only re-registration too");
         // `rag-rat init`'s clear lifts the tombstone → the indexing path works again.
         schema::clear_repo_removed(conn, &identity.repo_id).unwrap();
         assert!(!schema::is_repo_removed(conn, &identity.repo_id).unwrap());

--- a/crates/rag-rat-core/src/memory_write/api.rs
+++ b/crates/rag-rat-core/src/memory_write/api.rs
@@ -74,6 +74,12 @@ pub(crate) fn create_memory(
     // (#560). FULL for this transaction only; the connection restores NORMAL on drop.
     let _durability = authoring::AuthoredDurability::begin(conn)?;
     let tx = conn.unchecked_transaction()?;
+    // #767: revalidate the removal tombstone INSIDE the write txn — a connection that resolved its
+    // active scope before `rm` ran must fail closed here rather than stamp the removed `repo_id`
+    // onto a fresh row after the purge.
+    if let Some(repo_id) = &scope {
+        super::assert_repo_not_removed(conn, repo_id)?;
+    }
     conn.execute(
         "
         INSERT INTO repo_memories(
@@ -281,4 +287,113 @@ pub(crate) fn rebind_memory(
     tx.commit()?;
     memory_by_id(conn, memory_id)?
         .ok_or_else(|| anyhow::anyhow!("rebound memory `{memory_id}` could not be read back"))
+}
+
+#[cfg(test)]
+mod tests {
+    use rag_rat_query::memory::{EdgeRelation, EdgeTarget, RepoMemoryBindTarget, RepoMemoryCreate};
+    use rusqlite::Connection;
+
+    use super::{create_memory, rebind_memory};
+    use crate::memory_write::add_edge;
+
+    const REPO: &str = "repo-a";
+
+    /// A DB with the memory schema, one registered repo, and the connection scoped to it — the
+    /// minimal setup `memory_repo_scope` needs to resolve an active repo. Mirrors
+    /// `authoring::tests::scoped_conn` (each module's test scaffolding is self-contained).
+    fn scoped_conn() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("PRAGMA foreign_keys = ON;").unwrap();
+        rag_rat_db::schema::apply(&conn, &crate::index::migration_hooks()).unwrap();
+        conn.execute(
+            "INSERT INTO repos(repo_id, display_name, registered_at_ms) VALUES (?1, ?1, 0)",
+            [REPO],
+        )
+        .unwrap();
+        conn.execute_batch(
+            "CREATE TEMP TABLE IF NOT EXISTS connection_context(key TEXT PRIMARY KEY, value TEXT);",
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT OR REPLACE INTO temp.connection_context(key, value) VALUES ('repo_id', ?1)",
+            [REPO],
+        )
+        .unwrap();
+        conn
+    }
+
+    /// Create an unanchored `Concept` (needs no code binding) through the LIVE `create_memory`.
+    fn create_concept(conn: &Connection, title: &str) -> anyhow::Result<String> {
+        Ok(create_memory(conn, RepoMemoryCreate {
+            kind: "Concept".to_string(),
+            title: title.to_string(),
+            body: "body".to_string(),
+            confidence: "high".to_string(),
+            created_by: None,
+            source: None,
+            tags: Vec::new(),
+            payload_json: None,
+            bind: RepoMemoryBindTarget::default(),
+        })?
+        .memory
+        .memory_id)
+    }
+
+    /// #767 review: a connection that resolved its active repo scope BEFORE `rag-rat rm` ran must
+    /// fail closed at write time — the removal tombstone is revalidated inside the write
+    /// transaction, so a post-purge `create_memory` cannot stamp the removed `repo_id` onto a fresh
+    /// row (and its op-log entry) after `rm` reported success.
+    #[test]
+    fn create_memory_refuses_a_tombstoned_repo_until_it_is_cleared() {
+        let conn = scoped_conn();
+        create_concept(&conn, "before removal").unwrap();
+
+        rag_rat_db::schema::mark_repo_removed(&conn, REPO, 1).unwrap();
+        let err = create_concept(&conn, "after removal")
+            .expect_err("a tombstoned repo must refuse a memory create");
+        assert!(
+            err.to_string().contains("rag-rat rm"),
+            "the refusal must name the removal remedy, got: {err}"
+        );
+
+        rag_rat_db::schema::clear_repo_removed(&conn, REPO).unwrap();
+        create_concept(&conn, "after re-add").unwrap();
+    }
+
+    /// The same gate covers the edge INSERT path: `add_edge` stamps the source node's owner
+    /// `repo_id` onto the new row, so it revalidates the tombstone in-transaction too.
+    #[test]
+    fn add_edge_refuses_a_tombstoned_repo() {
+        let conn = scoped_conn();
+        let source = create_concept(&conn, "source").unwrap();
+        let target = create_concept(&conn, "target").unwrap();
+
+        rag_rat_db::schema::mark_repo_removed(&conn, REPO, 1).unwrap();
+        let err = add_edge(&conn, &source, EdgeRelation::RelatesTo, &EdgeTarget::Node {
+            repo_id: None,
+            node_id: target,
+        })
+        .expect_err("a tombstoned repo must refuse an edge add");
+        assert!(
+            err.to_string().contains("rag-rat rm"),
+            "the refusal must name the removal remedy, got: {err}"
+        );
+    }
+
+    /// A NON-insert mutation is unaffected by the gate: `rebind_memory` writes no new repo-stamped
+    /// rows (and post-purge it has no row to find anyway), so it must not trip the tombstone check
+    /// on a still-populated store.
+    #[test]
+    fn rebind_memory_is_not_blocked_by_the_tombstone_gate() {
+        let conn = scoped_conn();
+        let id = create_concept(&conn, "rebind me").unwrap();
+
+        rag_rat_db::schema::mark_repo_removed(&conn, REPO, 1).unwrap();
+        rebind_memory(&conn, &id, RepoMemoryBindTarget {
+            path: Some("src/lib.rs".to_string()),
+            ..Default::default()
+        })
+        .unwrap();
+    }
 }

--- a/crates/rag-rat-core/src/memory_write/edges.rs
+++ b/crates/rag-rat-core/src/memory_write/edges.rs
@@ -92,6 +92,10 @@ pub(crate) fn add_edge(
     // Authored write: the EdgeAdd op is signed op-log content, so commit durably (#560).
     let _durability = authoring::AuthoredDurability::begin(conn)?;
     let tx = conn.unchecked_transaction()?;
+    // #767: revalidate the removal tombstone INSIDE the write txn — a connection that resolved the
+    // source node's owner before `rm` ran must fail closed here rather than INSERT an edge row
+    // stamped with the removed `repo_id` after the purge.
+    super::assert_repo_not_removed(conn, &owner_repo_id)?;
     // Whether this is a GENUINELY new edge vs an idempotent re-add: the INSERT below is
     // `ON CONFLICT DO UPDATE` refreshing ONLY the per-device resolution columns
     // (`target_repo_id`/`target_node_id`/`anchor_status`) — state the log deliberately excludes (no

--- a/crates/rag-rat-core/src/memory_write/mod.rs
+++ b/crates/rag-rat-core/src/memory_write/mod.rs
@@ -23,3 +23,25 @@ pub(crate) use authoring::backfill_memory_oplog;
 // `index::consolidate` names this through this re-export (Task 5 of #541).
 pub(crate) use authoring::reconcile_owner_stream_for_repo;
 pub(crate) use edges::{add_edge, remove_edge};
+
+/// #767 review: fail a repo-scoped memory mutation CLOSED when the active repo was removed by
+/// `rag-rat rm`. The removal tombstone is normally enforced at connection-registration time, but
+/// an MCP connection that opened (and resolved its active repo scope) BEFORE `rm` acquired the
+/// repo lock keeps that stale scope; without this re-check its `create_memory` / `add_edge` would
+/// INSERT fresh `repo_memories` / `repo_node_edges` rows stamped with the removed `repo_id` (and
+/// author op-log state) AFTER `rm`'s purge committed and reported success. Call INSIDE the write
+/// transaction, immediately before the INSERT, so the tombstone read shares the transaction's
+/// snapshot: an `rm` that committed first is seen (fail closed); an `rm` that commits after purges
+/// the just-written row itself (also consistent). The reverse-order hazard is the one this closes.
+pub(crate) fn assert_repo_not_removed(
+    conn: &rusqlite::Connection,
+    repo_id: &str,
+) -> anyhow::Result<()> {
+    if rag_rat_db::schema::is_repo_removed(conn, repo_id)? {
+        anyhow::bail!(
+            "repo {repo_id} was removed with `rag-rat rm` — refusing the write; run `rag-rat \
+             init` in the repo to re-add it"
+        );
+    }
+    Ok(())
+}

--- a/crates/rag-rat-core/src/memory_write/mod.rs
+++ b/crates/rag-rat-core/src/memory_write/mod.rs
@@ -24,24 +24,8 @@ pub(crate) use authoring::backfill_memory_oplog;
 pub(crate) use authoring::reconcile_owner_stream_for_repo;
 pub(crate) use edges::{add_edge, remove_edge};
 
-/// #767 review: fail a repo-scoped memory mutation CLOSED when the active repo was removed by
-/// `rag-rat rm`. The removal tombstone is normally enforced at connection-registration time, but
-/// an MCP connection that opened (and resolved its active repo scope) BEFORE `rm` acquired the
-/// repo lock keeps that stale scope; without this re-check its `create_memory` / `add_edge` would
-/// INSERT fresh `repo_memories` / `repo_node_edges` rows stamped with the removed `repo_id` (and
-/// author op-log state) AFTER `rm`'s purge committed and reported success. Call INSIDE the write
-/// transaction, immediately before the INSERT, so the tombstone read shares the transaction's
-/// snapshot: an `rm` that committed first is seen (fail closed); an `rm` that commits after purges
-/// the just-written row itself (also consistent). The reverse-order hazard is the one this closes.
-pub(crate) fn assert_repo_not_removed(
-    conn: &rusqlite::Connection,
-    repo_id: &str,
-) -> anyhow::Result<()> {
-    if rag_rat_db::schema::is_repo_removed(conn, repo_id)? {
-        anyhow::bail!(
-            "repo {repo_id} was removed with `rag-rat rm` — refusing the write; run `rag-rat \
-             init` in the repo to re-add it"
-        );
-    }
-    Ok(())
-}
+// The `rag-rat rm` removal-tombstone guard (#767 review) the memory mutations call inside
+// their write transactions, immediately before the INSERT — defined beside the removal
+// orchestration in `index::remove` (the dream + heal writers gate on it too), re-exported here
+// so the `super::` call sites read unchanged.
+pub(crate) use crate::index::remove::assert_repo_not_removed;

--- a/crates/rag-rat-db/src/schema/mod.rs
+++ b/crates/rag-rat-db/src/schema/mod.rs
@@ -1,5 +1,6 @@
 mod baseline;
 mod migrations;
+mod purge;
 mod registry;
 // The schema surface the engine crates consume (everything else stays crate-internal):
 pub use baseline::{apply_baseline, rebuild_commit_fts};
@@ -22,6 +23,7 @@ pub use migrations::{
     apply_repo_id_periphery_scoping, apply_repos_registry, apply_scip_moniker_anchors,
 };
 pub use migrations::{column_exists, rebuild_repo_memory_fts_with_repo_id, table_exists};
+pub use purge::{RepoRowCounts, count_repo_rows, purge_repo_rows, repo_scoped_table_names};
 // `multiple_real_repos` lost its V042-era seam-guard callers (real `repo_id` predicates
 // superseded them, A5), but A7's bare-open fail-fast made it production again: a config-less
 // `IndexDatabase::open` refuses a multi-repo DB rather than silently scoping to the
@@ -29,10 +31,11 @@ pub use migrations::{column_exists, rebuild_repo_memory_fts_with_repo_id, table_
 pub use registry::multiple_real_repos;
 pub use registry::{
     CONNECTION_CONTEXT_GENERATION_KEY, CONNECTION_CONTEXT_REPO_KEY, LIVE_FILES_GENERATION_META_KEY,
-    RegisteredRepo, active_generation, active_repo_id, connection_context_value,
-    earliest_recorded_root, is_root_already_indexed_conn, live_files_generation,
-    periphery_repo_scope, periphery_repo_scope_clause, register_repo, register_repo_read_only,
-    registered_repos, repo_has_recorded_root, repo_id_is_registered, repo_indexed_at_this_root,
+    RegisteredRepo, active_generation, active_repo_id, clear_repo_removed,
+    connection_context_value, earliest_recorded_root, is_repo_removed,
+    is_root_already_indexed_conn, live_files_generation, mark_repo_removed, periphery_repo_scope,
+    periphery_repo_scope_clause, register_repo, register_repo_read_only, registered_repos,
+    repo_has_recorded_root, repo_id_is_registered, repo_indexed_at_this_root,
     resolve_config_repo_id, scope_context_repo_id, sole_repo_id,
 };
 use rusqlite::{Connection, OptionalExtension, Transaction, TransactionBehavior, params};

--- a/crates/rag-rat-db/src/schema/mod.rs
+++ b/crates/rag-rat-db/src/schema/mod.rs
@@ -36,7 +36,7 @@ pub use registry::{
     is_root_already_indexed_conn, live_files_generation, mark_repo_removed, periphery_repo_scope,
     periphery_repo_scope_clause, register_repo, register_repo_read_only, registered_repos,
     repo_has_recorded_root, repo_id_is_registered, repo_indexed_at_this_root,
-    resolve_config_repo_id, scope_context_repo_id, sole_repo_id,
+    repo_removal_generation, resolve_config_repo_id, scope_context_repo_id, sole_repo_id,
 };
 use rusqlite::{Connection, OptionalExtension, Transaction, TransactionBehavior, params};
 use serde::Serialize;

--- a/crates/rag-rat-db/src/schema/purge.rs
+++ b/crates/rag-rat-db/src/schema/purge.rs
@@ -1,0 +1,357 @@
+//! De-index a whole repo from the consolidated global store: delete EVERY row it owns, across every
+//! repo-scoped table, in one place. The read-side counterpart is [`count_repo_rows`] (the
+//! confirmation summary + `--dry-run` preview); the write side is [`purge_repo_rows`].
+//!
+//! COMPLETENESS is the whole job — a missed table strands orphaned rows that a later reindex of a
+//! DIFFERENT repo can never reach, and (worse) a missed DELETE on a shared cache would corrupt a
+//! sibling. The purge is built from three disjoint mechanisms, in ascending trust:
+//!
+//!  1. **Class-level `repo_id` sweep** ([`repo_scoped_table_names`]) — the BACKSTOP. Enumerate
+//!     every base table that carries a `repo_id` column straight from `sqlite_master`/`PRAGMA
+//!     table_info` and `DELETE FROM <t> WHERE repo_id = ?`. This is deliberately NOT a
+//!     hand-maintained list: a future migration that adds a `repo_id`-bearing table is swept
+//!     automatically, and the poison-sibling tripwire proves it. Regular FTS5 tables that carry
+//!     `repo_id` (`repo_memory_fts`, `papertrail_fts`) support `DELETE ... WHERE repo_id = ?` and
+//!     are swept the same way; their shadow tables never carry `repo_id`, so they are never
+//!     enumerated.
+//!  2. **Transitively-scoped children** ([`TRANSITIVE_SCOPED_TABLES`]) — the tables with NO
+//!     `repo_id` column that are nonetheless owned by a repo, reached only through a
+//!     `repo_id`-bearing parent (`files.id` → `chunks`/`symbols`, `chunks.id` → the chunk-child +
+//!     FTS rows, `repo_memories.id` → the memory children, `clone_graph_generations.generation` →
+//!     the clone postings). Every child is also `ON DELETE CASCADE` from its parent, so the sweep
+//!     would reach them with `foreign_keys = ON` — but they are purged EXPLICITLY here (id sets
+//!     captured up front) so the purge is correct even with FK enforcement off, and so the tripwire
+//!     can assert each is emptied by name.
+//!  3. **FTS / external-content fixups** — `chunk_fts` is a contentless FTS5 index keyed by
+//!     `chunk.id` (no FK, no `repo_id`): its rows are deleted by rowid from the captured chunk set.
+//!     `commit_fts` is external-content on `git_commits`, so deleting the repo's commits desyncs
+//!     it; it is re-derived once at the end with [`rebuild_commit_fts`] (the desync-safe
+//!     'rebuild').
+//!
+//! DELIBERATELY NOT PURGED (content-addressed / store-global shared state — deleting a repo's slice
+//! would either be meaningless or damage siblings): `name_strings` / `chunk_text_dict` (shared
+//! interning pools), `embedding_cache` (content-addressed vectors, keyed by `(input_hash,
+//! model_id)`; a stale entry is harmless cache the importer itself carries with `INSERT OR
+//! IGNORE`), `ai_models` (the machine model registry), `index_meta` / `reconcile_meta` (global
+//! singletons), and the sync substrate `oplog_*` / `account_*` / `content_*` /
+//! `sync_security_events` (a device's machine identity + crypto-stream-derived cross-device sync
+//! log — no `repo_id`, keyed by device/account/`stream_id`, and excluded from the per-repo
+//! consolidate import for the same reason). None of these carry a `repo_id` column, so the
+//! class-level sweep leaves them untouched.
+
+use rusqlite::{Connection, params};
+
+use crate::schema::rebuild_commit_fts;
+
+/// A transitively-scoped child table: no `repo_id` column of its own, reached through a
+/// `repo_id`-bearing parent. `(table, id_column, parent_id_temp)` — the purge deletes
+/// `table` rows whose `id_column` is in the captured `parent_id_temp` id set.
+struct TransitiveTable {
+    table: &'static str,
+    id_column: &'static str,
+    /// The temp table (one of the [`PurgeIds`] captures) holding the parent id set this child
+    /// scopes through.
+    parent_ids: &'static str,
+}
+
+/// The captured id sets a purge scopes its transitively-owned children through. Each is a
+/// single-column temp table of the repo's ids, snapshotted BEFORE any delete so a child delete is
+/// correct regardless of ordering (and regardless of FK cascade firing).
+mod purge_ids {
+    pub const FILES: &str = "temp.rmp_file_ids";
+    pub const CHUNKS: &str = "temp.rmp_chunk_ids";
+    pub const SYMBOLS: &str = "temp.rmp_symbol_ids";
+    pub const MEMORIES: &str = "temp.rmp_memory_ids";
+    pub const GENERATIONS: &str = "temp.rmp_generation_ids";
+}
+
+/// Every transitively-scoped child, child-first (a child appears before the parent whose id set it
+/// scopes through). LOAD-BEARING completeness: the poison-sibling tripwire enumerates these plus
+/// the `repo_id` tables and asserts the purge empties every one for the removed repo — so a NEW
+/// transitive child that forgets to register here fails the tripwire rather than leaking in
+/// production. `chunk_fts` is handled separately (it is an FTS5 virtual table deleted by rowid, not
+/// a plain `DELETE ... WHERE id_column IN`).
+const TRANSITIVE_SCOPED_TABLES: &[TransitiveTable] = &[
+    // chunk children (chunks.id → chunk_id)
+    TransitiveTable { table: "chunk_text", id_column: "chunk_id", parent_ids: purge_ids::CHUNKS },
+    TransitiveTable {
+        table: "chunk_embeddings",
+        id_column: "chunk_id",
+        parent_ids: purge_ids::CHUNKS,
+    },
+    TransitiveTable {
+        table: "chunk_summaries",
+        id_column: "chunk_id",
+        parent_ids: purge_ids::CHUNKS,
+    },
+    TransitiveTable {
+        table: "git_chunk_blame",
+        id_column: "chunk_id",
+        parent_ids: purge_ids::CHUNKS,
+    },
+    // symbol children (symbols.id → symbol_id)
+    TransitiveTable {
+        table: "symbol_facts",
+        id_column: "symbol_id",
+        parent_ids: purge_ids::SYMBOLS,
+    },
+    TransitiveTable {
+        table: "symbol_fingerprints",
+        id_column: "symbol_id",
+        parent_ids: purge_ids::SYMBOLS,
+    },
+    TransitiveTable {
+        table: "logical_symbol_members",
+        id_column: "symbol_id",
+        parent_ids: purge_ids::SYMBOLS,
+    },
+    // file children (files.id → source_file_id / file_id)
+    TransitiveTable {
+        table: "edges_data",
+        id_column: "source_file_id",
+        parent_ids: purge_ids::FILES,
+    },
+    TransitiveTable { table: "symbols", id_column: "file_id", parent_ids: purge_ids::FILES },
+    TransitiveTable { table: "chunks", id_column: "file_id", parent_ids: purge_ids::FILES },
+    // memory children (repo_memories.id → memory_id)
+    TransitiveTable {
+        table: "repo_memory_tags",
+        id_column: "memory_id",
+        parent_ids: purge_ids::MEMORIES,
+    },
+    TransitiveTable {
+        table: "repo_memory_call_paths",
+        id_column: "memory_id",
+        parent_ids: purge_ids::MEMORIES,
+    },
+    TransitiveTable {
+        table: "repo_memory_call_path_edges",
+        id_column: "memory_id",
+        parent_ids: purge_ids::MEMORIES,
+    },
+    // clone postings (clone_graph_generations.generation → build_generation)
+    TransitiveTable {
+        table: "clone_edges",
+        id_column: "build_generation",
+        parent_ids: purge_ids::GENERATIONS,
+    },
+    TransitiveTable {
+        table: "clone_subblock_postings",
+        id_column: "build_generation",
+        parent_ids: purge_ids::GENERATIONS,
+    },
+    TransitiveTable {
+        table: "clone_df_epoch",
+        id_column: "build_generation",
+        parent_ids: purge_ids::GENERATIONS,
+    },
+];
+
+/// Every base table (never a view, never an FTS shadow table) that carries a `repo_id` column, in
+/// deterministic name order — the class-level backstop the purge sweeps and the tripwire
+/// enumerates. An FTS5 virtual table that carries a `repo_id` column (`repo_memory_fts`,
+/// `papertrail_fts`) is INCLUDED (it supports `DELETE ... WHERE repo_id = ?`); its shadow tables
+/// carry no `repo_id`, so `PRAGMA table_info` never reports them here.
+pub fn repo_scoped_table_names(conn: &Connection) -> rusqlite::Result<Vec<String>> {
+    let mut stmt = conn.prepare(
+        "SELECT m.name FROM sqlite_master m
+         WHERE m.type = 'table'
+           AND m.name NOT LIKE 'sqlite_%'
+           AND EXISTS (SELECT 1 FROM pragma_table_info(m.name) p WHERE p.name = 'repo_id')
+         ORDER BY m.name",
+    )?;
+    let names = stmt.query_map([], |row| row.get::<_, String>(0))?;
+    names.collect()
+}
+
+/// A per-table row count for the repo being removed — the confirmation summary + `--dry-run`
+/// preview. `by_table` is dynamic (every `repo_id` table via [`repo_scoped_table_names`] plus the
+/// transitively-scoped children), so a new scoped table is counted without a code change; only
+/// non-zero entries are worth showing. `total_rows` is their exact sum.
+#[derive(Debug, Clone, Default, serde::Serialize)]
+pub struct RepoRowCounts {
+    pub by_table: std::collections::BTreeMap<String, i64>,
+    pub total_rows: i64,
+}
+
+impl RepoRowCounts {
+    fn record(&mut self, table: &str, count: i64) {
+        if count > 0 {
+            *self.by_table.entry(table.to_string()).or_insert(0) += count;
+            self.total_rows += count;
+        }
+    }
+}
+
+/// Count every row `repo_id` owns, across the class-level `repo_id` tables AND the transitively
+/// scoped children — read-only, so it drives both the confirmation prompt and `--dry-run` without
+/// mutating anything. The counts mirror exactly what [`purge_repo_rows`] deletes.
+pub fn count_repo_rows(conn: &Connection, repo_id: &str) -> anyhow::Result<RepoRowCounts> {
+    let mut counts = RepoRowCounts::default();
+    for table in repo_scoped_table_names(conn)? {
+        // `table` comes from `sqlite_master`, never user input.
+        let count: i64 = conn.query_row(
+            &format!("SELECT COUNT(*) FROM \"{table}\" WHERE repo_id = ?1"),
+            params![repo_id],
+            |row| row.get(0),
+        )?;
+        counts.record(&table, count);
+    }
+    // Transitive children: count through the live parent scope (the parents still exist at count
+    // time — this is the read path).
+    for transitive in TRANSITIVE_SCOPED_TABLES {
+        let count: i64 = conn.query_row(
+            &format!(
+                "SELECT COUNT(*) FROM \"{}\" WHERE {} IN ({})",
+                transitive.table,
+                transitive.id_column,
+                parent_id_select(transitive.parent_ids)
+            ),
+            params![repo_id],
+            |row| row.get(0),
+        )?;
+        counts.record(transitive.table, count);
+    }
+    // chunk_fts (contentless FTS, keyed by chunk.id) — counted like the other chunk children.
+    let chunk_fts: i64 = conn.query_row(
+        &format!(
+            "SELECT COUNT(*) FROM chunk_fts WHERE rowid IN ({})",
+            parent_id_select(purge_ids::CHUNKS)
+        ),
+        params![repo_id],
+        |row| row.get(0),
+    )?;
+    counts.record("chunk_fts", chunk_fts);
+    Ok(counts)
+}
+
+/// The live read-path subquery for a transitive parent's id set, mirroring the temp-table capture
+/// in [`capture_purge_ids`] but evaluated inline against the current rows (used only by
+/// [`count_repo_rows`], which runs before any delete).
+fn parent_id_select(parent_ids: &str) -> &'static str {
+    match parent_ids {
+        purge_ids::FILES => "SELECT id FROM files WHERE repo_id = ?1",
+        purge_ids::CHUNKS =>
+            "SELECT id FROM chunks WHERE file_id IN (SELECT id FROM files WHERE repo_id = ?1)",
+        purge_ids::SYMBOLS =>
+            "SELECT id FROM symbols WHERE file_id IN (SELECT id FROM files WHERE repo_id = ?1)",
+        purge_ids::MEMORIES => "SELECT id FROM repo_memories WHERE repo_id = ?1",
+        purge_ids::GENERATIONS =>
+            "SELECT generation FROM clone_graph_generations WHERE repo_id = ?1",
+        other => unreachable!("unknown purge id set {other}"),
+    }
+}
+
+/// Purge EVERY row `repo_id` owns. MUST run inside an IMMEDIATE transaction the caller opened
+/// (all-or-nothing; a partial purge would leave the store internally inconsistent). Steps, in
+/// order:
+///  1. Capture the repo's file / chunk / symbol / memory / clone-generation id sets into temp
+///     tables — snapshotted up front so every subsequent delete is correct regardless of ordering.
+///  2. Delete the transitively-scoped children (including the contentless `chunk_fts` by rowid).
+///  3. Sweep every `repo_id`-bearing table (the class-level backstop) with `DELETE ... WHERE
+///     repo_id = ?` — reaches the direct tables plus, with `foreign_keys = ON`, cascades any child
+///     not listed above.
+///  4. Re-derive `commit_fts` (external-content on `git_commits`, desynced by the git-commit
+///     delete).
+///  5. Drop the temp id tables.
+pub fn purge_repo_rows(conn: &Connection, repo_id: &str) -> anyhow::Result<()> {
+    capture_purge_ids(conn, repo_id)?;
+
+    // Transitive children first (each keyed by a captured id set, so ordering vs. the sweep is
+    // irrelevant — the temp tables decouple them from whether the parent rows still exist).
+    for transitive in TRANSITIVE_SCOPED_TABLES {
+        conn.execute(
+            &format!(
+                "DELETE FROM \"{}\" WHERE {} IN (SELECT id FROM {})",
+                transitive.table, transitive.id_column, transitive.parent_ids
+            ),
+            [],
+        )?;
+    }
+    // chunk_fts is contentless FTS5 keyed by chunk.id: delete by rowid from the captured chunk set
+    // (it carries no repo_id and no FK, so neither the sweep nor a cascade would ever reach it).
+    conn.execute(
+        &format!("DELETE FROM chunk_fts WHERE rowid IN (SELECT id FROM {})", purge_ids::CHUNKS),
+        [],
+    )?;
+
+    // Class-level sweep: every repo_id table, DELETE WHERE repo_id = ?. This is the backstop that
+    // makes a NEW scoped table purge automatically (the tripwire enforces coverage).
+    for table in repo_scoped_table_names(conn)? {
+        conn.execute(&format!("DELETE FROM \"{table}\" WHERE repo_id = ?1"), params![repo_id])?;
+    }
+
+    // commit_fts is external-content on git_commits, now desynced by the git-commit delete above.
+    // 'rebuild' re-derives it from the remaining commits (all repos) — the desync-safe fixup.
+    rebuild_commit_fts(conn)?;
+
+    drop_purge_ids(conn)?;
+    Ok(())
+}
+
+/// Snapshot the repo's id sets into temp tables (see [`purge_ids`]). Captured BEFORE any delete so
+/// the transitive-child deletes are correct no matter the order or FK cascade behavior.
+fn capture_purge_ids(conn: &Connection, repo_id: &str) -> anyhow::Result<()> {
+    // Dropped first so a reused connection (a second purge on one process) starts clean.
+    drop_purge_ids(conn)?;
+    conn.execute(
+        &format!(
+            "CREATE TEMP TABLE {} AS SELECT id FROM files WHERE repo_id = ?1",
+            temp_name(purge_ids::FILES)
+        ),
+        params![repo_id],
+    )?;
+    conn.execute(
+        &format!(
+            "CREATE TEMP TABLE {} AS SELECT id FROM chunks WHERE file_id IN (SELECT id FROM {})",
+            temp_name(purge_ids::CHUNKS),
+            purge_ids::FILES
+        ),
+        [],
+    )?;
+    conn.execute(
+        &format!(
+            "CREATE TEMP TABLE {} AS SELECT id FROM symbols WHERE file_id IN (SELECT id FROM {})",
+            temp_name(purge_ids::SYMBOLS),
+            purge_ids::FILES
+        ),
+        [],
+    )?;
+    conn.execute(
+        &format!(
+            "CREATE TEMP TABLE {} AS SELECT id FROM repo_memories WHERE repo_id = ?1",
+            temp_name(purge_ids::MEMORIES)
+        ),
+        params![repo_id],
+    )?;
+    // The clone-generation id set uses the column name `id` in the temp table for a uniform
+    // `SELECT id FROM <temp>` in the child deletes, even though the source column is `generation`.
+    conn.execute(
+        &format!(
+            "CREATE TEMP TABLE {} AS SELECT generation AS id FROM clone_graph_generations WHERE \
+             repo_id = ?1",
+            temp_name(purge_ids::GENERATIONS)
+        ),
+        params![repo_id],
+    )?;
+    Ok(())
+}
+
+fn drop_purge_ids(conn: &Connection) -> anyhow::Result<()> {
+    for temp in [
+        purge_ids::FILES,
+        purge_ids::CHUNKS,
+        purge_ids::SYMBOLS,
+        purge_ids::MEMORIES,
+        purge_ids::GENERATIONS,
+    ] {
+        conn.execute(&format!("DROP TABLE IF EXISTS {temp}"), [])?;
+    }
+    Ok(())
+}
+
+/// The bare table name (without the `temp.` schema qualifier) for a `CREATE TEMP TABLE`, which
+/// names the table unqualified while later reads qualify it `temp.<name>`.
+fn temp_name(qualified: &str) -> &str {
+    qualified.strip_prefix("temp.").unwrap_or(qualified)
+}

--- a/crates/rag-rat-db/src/schema/purge.rs
+++ b/crates/rag-rat-db/src/schema/purge.rs
@@ -18,10 +18,12 @@
 //!     `repo_id` column that are nonetheless owned by a repo, reached only through a
 //!     `repo_id`-bearing parent (`files.id` → `chunks`/`symbols`, `chunks.id` → the chunk-child +
 //!     FTS rows, `repo_memories.id` → the memory children, `clone_graph_generations.generation` →
-//!     the clone postings). Every child is also `ON DELETE CASCADE` from its parent, so the sweep
-//!     would reach them with `foreign_keys = ON` — but they are purged EXPLICITLY here (id sets
-//!     captured up front) so the purge is correct even with FK enforcement off, and so the tripwire
-//!     can assert each is emptied by name.
+//!     the clone postings). `edges_data` also has a legacy/malformed NULL-source escape hatch:
+//!     those rows are reached by either symbol endpoint in the captured victim-symbol set. Every
+//!     child is also `ON DELETE CASCADE` from its parent, so the sweep would reach them with
+//!     `foreign_keys = ON` — but they are purged EXPLICITLY here (id sets captured up front) so the
+//!     purge is correct even with FK enforcement off, and so the tripwire can assert each is
+//!     emptied by name.
 //!  3. **FTS / external-content fixups** — `chunk_fts` is a contentless FTS5 index keyed by
 //!     `chunk.id` (no FK, no `repo_id`): its rows are deleted by rowid from the captured chunk set.
 //!     `commit_fts` is external-content on `git_commits`, so deleting the repo's commits desyncs
@@ -218,6 +220,22 @@ pub fn count_repo_rows(conn: &Connection, repo_id: &str) -> anyhow::Result<RepoR
         )?;
         counts.record(transitive.table, count);
     }
+    // `edges_data.source_file_id` is nullable. Normal index writers always stamp it, but legacy /
+    // manually-created rows can carry NULL and therefore evade `NULL IN (victim file ids)`. Count
+    // exactly the NULL-source rows whose FROM or TO endpoint is a captured victim symbol; a
+    // non-NULL sibling-source cross-repo edge remains owned by that sibling and is not included.
+    if crate::schema::table_exists(conn, "edges_data")? {
+        let null_source_edges: i64 = conn.query_row(
+            &format!(
+                "SELECT COUNT(*) FROM edges_data WHERE source_file_id IS NULL AND (from_symbol_id \
+                 IN ({symbols}) OR to_symbol_id IN ({symbols}))",
+                symbols = parent_id_select(purge_ids::SYMBOLS),
+            ),
+            params![repo_id],
+            |row| row.get(0),
+        )?;
+        counts.record("edges_data", null_source_edges);
+    }
     // chunk_fts (contentless FTS, keyed by chunk.id) — counted like the other chunk children.
     if crate::schema::table_exists(conn, "chunk_fts")? {
         let chunk_fts: i64 = conn.query_row(
@@ -264,6 +282,19 @@ fn parent_id_select(parent_ids: &str) -> &'static str {
 ///  5. Drop the temp id tables.
 pub fn purge_repo_rows(conn: &Connection, repo_id: &str) -> anyhow::Result<()> {
     capture_purge_ids(conn, repo_id)?;
+
+    // #782: `source_file_id` is nullable. Delete legacy / malformed NULL-source edges by either
+    // endpoint BEFORE symbols are removed (the captured set makes this correct with foreign keys
+    // both ON and OFF). Restricting this special case to NULL preserves a valid cross-repo edge
+    // whose non-NULL source file belongs to a sibling.
+    conn.execute(
+        &format!(
+            "DELETE FROM edges_data WHERE source_file_id IS NULL AND (from_symbol_id IN (SELECT \
+             id FROM {symbols}) OR to_symbol_id IN (SELECT id FROM {symbols}))",
+            symbols = purge_ids::SYMBOLS,
+        ),
+        [],
+    )?;
 
     // Transitive children first (each keyed by a captured id set, so ordering vs. the sweep is
     // irrelevant — the temp tables decouple them from whether the parent rows still exist).

--- a/crates/rag-rat-db/src/schema/purge.rs
+++ b/crates/rag-rat-db/src/schema/purge.rs
@@ -198,8 +198,14 @@ pub fn count_repo_rows(conn: &Connection, repo_id: &str) -> anyhow::Result<RepoR
         counts.record(&table, count);
     }
     // Transitive children: count through the live parent scope (the parents still exist at count
-    // time — this is the read path).
+    // time — this is the read path). An older schema may predate a table (e.g. `clone_df_epoch`,
+    // V051); this count runs BEFORE `rm` migrates (so `--dry-run` never writes), so a table that
+    // does not exist is skipped — its row count is 0, and the destructive purge runs post-migration
+    // where every listed table exists.
     for transitive in TRANSITIVE_SCOPED_TABLES {
+        if !crate::schema::table_exists(conn, transitive.table)? {
+            continue;
+        }
         let count: i64 = conn.query_row(
             &format!(
                 "SELECT COUNT(*) FROM \"{}\" WHERE {} IN ({})",
@@ -213,15 +219,17 @@ pub fn count_repo_rows(conn: &Connection, repo_id: &str) -> anyhow::Result<RepoR
         counts.record(transitive.table, count);
     }
     // chunk_fts (contentless FTS, keyed by chunk.id) — counted like the other chunk children.
-    let chunk_fts: i64 = conn.query_row(
-        &format!(
-            "SELECT COUNT(*) FROM chunk_fts WHERE rowid IN ({})",
-            parent_id_select(purge_ids::CHUNKS)
-        ),
-        params![repo_id],
-        |row| row.get(0),
-    )?;
-    counts.record("chunk_fts", chunk_fts);
+    if crate::schema::table_exists(conn, "chunk_fts")? {
+        let chunk_fts: i64 = conn.query_row(
+            &format!(
+                "SELECT COUNT(*) FROM chunk_fts WHERE rowid IN ({})",
+                parent_id_select(purge_ids::CHUNKS)
+            ),
+            params![repo_id],
+            |row| row.get(0),
+        )?;
+        counts.record("chunk_fts", chunk_fts);
+    }
     Ok(counts)
 }
 

--- a/crates/rag-rat-db/src/schema/registry.rs
+++ b/crates/rag-rat-db/src/schema/registry.rs
@@ -262,15 +262,17 @@ fn register_repo_inner(
         )));
     }
 
-    // #767: refuse to re-register a repo tombstoned by `rag-rat rm`. ONLY the root-recording
-    // (indexing) path is gated — a writer that queued behind the removal lock resumes with a stale
-    // in-memory config and would otherwise silently repopulate the just-purged repo. A read-only
-    // adoption (`register_repo_read_only`) of the now-empty repo is harmless and stays allowed;
-    // `rag-rat init` clears the tombstone for a deliberate re-add.
-    if record_root && is_repo_removed(conn, trimmed_id)? {
+    // #767: refuse to (re-)register a repo tombstoned by `rag-rat rm`, on BOTH the indexing
+    // (`record_root`) AND the read-only adoption paths. A writer that queued behind the removal
+    // lock resumes with a stale in-memory config and would otherwise repopulate the just-purged
+    // repo — and a read-only open is NOT harmless when it is write-capable: a manual
+    // `papertrail sync` registers read-only, then commits `papertrail_*` rows. A
+    // genuinely-removed repo has no surviving config to reach here (rm deletes it); `rag-rat
+    // init` / `consolidate` clear the tombstone for a deliberate re-add.
+    if is_repo_removed(conn, trimmed_id)? {
         return Err(registry_refusal(format!(
             "repo {trimmed_id} was removed with `rag-rat rm` — run `rag-rat init` in the repo to \
-             re-add it before indexing"
+             re-add it"
         )));
     }
 

--- a/crates/rag-rat-db/src/schema/registry.rs
+++ b/crates/rag-rat-db/src/schema/registry.rs
@@ -268,7 +268,9 @@ fn register_repo_inner(
     // repo — and a read-only open is NOT harmless when it is write-capable: a manual
     // `papertrail sync` registers read-only, then commits `papertrail_*` rows. A
     // genuinely-removed repo has no surviving config to reach here (rm deletes it); `rag-rat
-    // init` / `consolidate` clear the tombstone for a deliberate re-add.
+    // init` / `consolidate` clear the tombstone for a deliberate re-add. This is the cheap
+    // PRE-FILTER; the AUTHORITATIVE check re-runs inside the adoption transaction below (this
+    // read races rm's tombstone commit — the in-transaction one cannot).
     if is_repo_removed(conn, trimmed_id)? {
         return Err(registry_refusal(format!(
             "repo {trimmed_id} was removed with `rag-rat rm` — run `rag-rat init` in the repo to \
@@ -435,6 +437,20 @@ fn register_repo_inner(
     // serializes registrations against each other; IMMEDIATE covers contention with NON-registry
     // writers (an index pass on a sibling repo).
     let tx = rusqlite::Transaction::new_unchecked(conn, rusqlite::TransactionBehavior::Immediate)?;
+    // #767 review: re-check the removal tombstone INSIDE the adoption transaction. The pre-filter
+    // above reads the tombstone BEFORE the registry lock and any transaction, and `rm` takes
+    // neither — so without this re-check a stale (preloaded-config) registration could pass the
+    // pre-filter, have rm purge + tombstone in the gap, and then INSERT the `repos` row after rm
+    // reported success. This transaction and rm's purge are both IMMEDIATE, so they serialize on
+    // the SQLite write lock and the tombstone state read here is stable for the whole adoption:
+    // set → rm committed first, refuse; unset → rm's purge waits for this commit and removes the
+    // just-registered repo itself.
+    if is_repo_removed(&tx, trimmed_id)? {
+        return Err(registry_refusal(format!(
+            "repo {trimmed_id} was removed with `rag-rat rm` — run `rag-rat init` in the repo to \
+             re-add it"
+        )));
+    }
     let placeholder_present = tx
         .query_row("SELECT 1 FROM repos WHERE repo_id = ?1", [LEGACY_REPO_ID], |_| Ok(()))
         .optional()?

--- a/crates/rag-rat-db/src/schema/registry.rs
+++ b/crates/rag-rat-db/src/schema/registry.rs
@@ -181,6 +181,43 @@ pub fn register_repo(
     register_repo_inner(conn, identity, root, now_ms, true, hooks)
 }
 
+/// The `index_meta` key that TOMBSTONES a repo removed via `rag-rat rm` (#767). GLOBAL scope on
+/// purpose: the removal purge deletes every repo-scoped row, so a marker meant to OUTLIVE the
+/// removal must live outside that sweep — `index_meta` carries no `repo_id` column and is never
+/// swept.
+fn removed_repo_key(repo_id: &str) -> String {
+    format!("removed_repo:{repo_id}")
+}
+
+/// Tombstone `repo_id` as removed-via-`rm` at `removed_at_ms`. Written INSIDE the purge transaction
+/// so it commits atomically with the deletion; [`register_repo`] then refuses to re-register the id
+/// until [`clear_repo_removed`] (via `rag-rat init`) lifts it — the durable guard against a writer
+/// that queued behind the removal lock with a STALE in-memory config silently repopulating the repo
+/// after the purge (a lock alone cannot stop a process that already cloned its `Config`).
+pub fn mark_repo_removed(
+    conn: &Connection,
+    repo_id: &str,
+    removed_at_ms: i64,
+) -> anyhow::Result<()> {
+    crate::meta::set_meta(conn, &removed_repo_key(repo_id), &removed_at_ms.to_string())
+}
+
+/// Whether `repo_id` is tombstoned as removed-via-`rm`. A direct `index_meta` read (rusqlite-typed
+/// so [`register_repo_inner`] can gate on it without an error-type conversion).
+pub fn is_repo_removed(conn: &Connection, repo_id: &str) -> rusqlite::Result<bool> {
+    conn.query_row(
+        "SELECT EXISTS(SELECT 1 FROM index_meta WHERE key = ?1)",
+        [removed_repo_key(repo_id).as_str()],
+        |row| row.get(0),
+    )
+}
+
+/// Lift the removed-via-`rm` tombstone for `repo_id` — `rag-rat init`'s deliberate re-add, the ONE
+/// path allowed to bring a removed repo back. Idempotent (clearing an absent tombstone is a no-op).
+pub fn clear_repo_removed(conn: &Connection, repo_id: &str) -> anyhow::Result<()> {
+    crate::meta::delete_meta(conn, &removed_repo_key(repo_id))
+}
+
 /// Register/adopt `identity` WITHOUT recording the working-tree `root` in `repo_roots` — the
 /// read-only open path (`open_config`: doctor / MCP / query, #427). A recorded root is the "this
 /// checkout was INDEXED here" signal `is_root_already_indexed` / `same_identity_join_note` key on,
@@ -222,6 +259,18 @@ fn register_repo_inner(
             "refusing to register the reserved or empty repo_id {:?}: `{LEGACY_REPO_ID}` is the \
              pre-adoption placeholder and an empty id cannot scope rows",
             identity.repo_id
+        )));
+    }
+
+    // #767: refuse to re-register a repo tombstoned by `rag-rat rm`. ONLY the root-recording
+    // (indexing) path is gated — a writer that queued behind the removal lock resumes with a stale
+    // in-memory config and would otherwise silently repopulate the just-purged repo. A read-only
+    // adoption (`register_repo_read_only`) of the now-empty repo is harmless and stays allowed;
+    // `rag-rat init` clears the tombstone for a deliberate re-add.
+    if record_root && is_repo_removed(conn, trimmed_id)? {
+        return Err(registry_refusal(format!(
+            "repo {trimmed_id} was removed with `rag-rat rm` — run `rag-rat init` in the repo to \
+             re-add it before indexing"
         )));
     }
 

--- a/crates/rag-rat-db/src/schema/registry.rs
+++ b/crates/rag-rat-db/src/schema/registry.rs
@@ -189,6 +189,23 @@ fn removed_repo_key(repo_id: &str) -> String {
     format!("removed_repo:{repo_id}")
 }
 
+fn repo_removal_generation_key(repo_id: &str) -> String {
+    format!("removed_repo_generation:{repo_id}")
+}
+
+/// Monotonic count of completed `rag-rat rm` purges for `repo_id`. Unlike the active removal
+/// tombstone, this is NEVER cleared by `init`: a removal plan captures it before confirmation and
+/// rechecks it under the repo write lock, so an intervening remove → deliberate re-init cycle makes
+/// the stale plan fail closed instead of deleting the newly re-added repo. Missing means generation
+/// zero for stores created before #767.
+pub fn repo_removal_generation(conn: &Connection, repo_id: &str) -> rusqlite::Result<i64> {
+    conn.query_row(
+        "SELECT COALESCE((SELECT CAST(value AS INTEGER) FROM index_meta WHERE key = ?1), 0)",
+        [repo_removal_generation_key(repo_id)],
+        |row| row.get(0),
+    )
+}
+
 /// Tombstone `repo_id` as removed-via-`rm` at `removed_at_ms`. Written INSIDE the purge transaction
 /// so it commits atomically with the deletion; [`register_repo`] then refuses to re-register the id
 /// until [`clear_repo_removed`] (via `rag-rat init`) lifts it — the durable guard against a writer
@@ -199,7 +216,13 @@ pub fn mark_repo_removed(
     repo_id: &str,
     removed_at_ms: i64,
 ) -> anyhow::Result<()> {
-    crate::meta::set_meta(conn, &removed_repo_key(repo_id), &removed_at_ms.to_string())
+    crate::meta::set_meta(conn, &removed_repo_key(repo_id), &removed_at_ms.to_string())?;
+    conn.execute(
+        "INSERT INTO index_meta(key, value) VALUES (?1, '1') ON CONFLICT(key) DO UPDATE SET value \
+         = CAST(CAST(index_meta.value AS INTEGER) + 1 AS TEXT)",
+        [repo_removal_generation_key(repo_id)],
+    )?;
+    Ok(())
 }
 
 /// Whether `repo_id` is tombstoned as removed-via-`rm`. A direct `index_meta` read (rusqlite-typed

--- a/crates/rag-rat-db/src/storage.rs
+++ b/crates/rag-rat-db/src/storage.rs
@@ -232,6 +232,36 @@ mod tests {
     }
 
     #[test]
+    fn open_read_only_blocking_does_not_persist_wal_mode_or_create_sidecars() {
+        let dir = std::env::temp_dir().join(format!(
+            "ragrat-ro-journal-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let db = dir.join("index.db");
+        {
+            let conn = Connection::open(&db).unwrap();
+            conn.execute_batch("PRAGMA journal_mode = DELETE; CREATE TABLE t(v INTEGER);").unwrap();
+        }
+
+        {
+            let ro = IndexConnection::open_read_only_blocking(&db).unwrap();
+            let mode: String =
+                ro.connection().query_row("PRAGMA journal_mode", [], |row| row.get(0)).unwrap();
+            assert_eq!(mode, "delete", "a planning read must not switch the DB to WAL");
+        }
+        let mode: String = Connection::open(&db)
+            .unwrap()
+            .query_row("PRAGMA journal_mode", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(mode, "delete", "journal mode must remain DELETE after the RO open");
+        assert!(!db.with_extension("db-wal").exists(), "RO planning must not create a WAL file");
+        assert!(!db.with_extension("db-shm").exists(), "RO planning must not create a SHM file");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
     fn is_readonly_violation_flags_only_sqlite_readonly_errors() {
         let dir = std::env::temp_dir().join(format!("ragrat-roviol-{}", std::process::id()));
         std::fs::create_dir_all(&dir).unwrap();

--- a/crates/rag-rat-dream/src/compact.rs
+++ b/crates/rag-rat-dream/src/compact.rs
@@ -91,33 +91,40 @@ pub(super) fn run_compact_pass(
         let summary = match obtain_summary(conn, pass.model, &prompt)? {
             Ok(summary) => summary,
             Err(failure) => {
-                failure::record_failure(conn, RecordFailure {
-                    stamp: failure_stamp,
-                    failure: &failure,
-                    now_ms,
+                super::removal_guarded_write_tx(conn, &scope, |tx| {
+                    failure::record_failure(tx, RecordFailure {
+                        stamp: failure_stamp,
+                        failure: &failure,
+                        now_ms,
+                    })?;
+                    Ok(())
                 })?;
                 continue;
             },
         };
-        record_summary(conn, RecordSummary {
-            memory_id: &entry.memory_id,
-            repo_id,
-            title: &entry.title,
-            body: &entry.body,
-            summary: &summary,
-            model_id: pass.model.model_id(),
-            now_ms,
+        // #767 review: summary prune/UPSERT + failure clear commit in ONE guarded transaction.
+        super::removal_guarded_write_tx(conn, &scope, |tx| {
+            record_summary(tx, RecordSummary {
+                memory_id: &entry.memory_id,
+                repo_id,
+                title: &entry.title,
+                body: &entry.body,
+                summary: &summary,
+                model_id: pass.model.model_id(),
+                now_ms,
+            })?;
+            let failure_stamp = FailureStamp {
+                memory_id: &entry.memory_id,
+                repo_id,
+                pass: DreamModelPass::Compact,
+                content_hash: &content_hash,
+                checked_inputs_hash: None,
+                prompt_version: COMPACT_PROMPT_VERSION,
+                model_id: pass.model.model_id(),
+            };
+            failure::clear_failure(tx, &failure_stamp)?;
+            Ok(())
         })?;
-        let failure_stamp = FailureStamp {
-            memory_id: &entry.memory_id,
-            repo_id,
-            pass: DreamModelPass::Compact,
-            content_hash: &content_hash,
-            checked_inputs_hash: None,
-            prompt_version: COMPACT_PROMPT_VERSION,
-            model_id: pass.model.model_id(),
-        };
-        failure::clear_failure(conn, &failure_stamp)?;
     }
     Ok(())
 }
@@ -284,21 +291,21 @@ struct RecordSummary<'a> {
 }
 
 /// UPSERT the accepted summary into `memory_summaries` (PK `(repo_id, memory_id, content_hash)`)
-/// AND prune every superseded row (same memory, a DIFFERENT content_hash) in ONE transaction. That
-/// prune is the invariant: in steady state `memory_summaries` holds exactly ONE row per memory —
+/// AND prune every superseded row (same memory, a DIFFERENT content_hash). The caller runs both
+/// statements in ONE [`super::removal_guarded_write_tx`] transaction. That prune is the invariant:
+/// in steady state `memory_summaries` holds exactly ONE row per memory —
 /// the summary of its current note. Without it a churny memory would accrete a stale summary per
 /// past content_hash, and the surfacing LEFT JOIN (keyed on the current content_hash) would still
 /// be correct but the table would grow unboundedly. NEVER writes a `repo_memories` column.
 fn record_summary(conn: &Connection, r: RecordSummary<'_>) -> rusqlite::Result<()> {
     let content_hash = super::verify::note_content_hash(r.title, r.body);
-    let tx = conn.unchecked_transaction()?;
     // Prune superseded summaries (older content_hash) FIRST, so the memory is left with only its
     // current-note summary after the UPSERT.
-    tx.execute(
+    conn.execute(
         "DELETE FROM memory_summaries WHERE repo_id = ?1 AND memory_id = ?2 AND content_hash != ?3",
         rusqlite::params![r.repo_id, r.memory_id, content_hash],
     )?;
-    tx.execute(
+    conn.execute(
         "INSERT INTO memory_summaries(memory_id, repo_id, content_hash, summary, model_id, \
          prompt_version, generated_at_ms) VALUES (?1,?2,?3,?4,?5,?6,?7) ON CONFLICT(repo_id, \
          memory_id, content_hash) DO UPDATE SET summary = excluded.summary, model_id = \
@@ -314,7 +321,7 @@ fn record_summary(conn: &Connection, r: RecordSummary<'_>) -> rusqlite::Result<(
             r.now_ms,
         ],
     )?;
-    tx.commit()
+    Ok(())
 }
 
 // ── Deterministic acceptance guards ──────────────────────────────────────────────────────────

--- a/crates/rag-rat-dream/src/findings.rs
+++ b/crates/rag-rat-dream/src/findings.rs
@@ -337,6 +337,26 @@ pub(super) fn sync(
     // (busy_timeout, then the MCP call-level busy-retry) until the first commits, after which
     // its SELECT sees the row and refreshes — no duplicate insert.
     let tx = rusqlite::Transaction::new_unchecked(conn, rusqlite::TransactionBehavior::Immediate)?;
+    // #767 review: re-check the `rag-rat rm` removal tombstone AT the write boundary, inside this
+    // IMMEDIATE transaction. The preflight in `IndexDatabase::dream_run` runs BEFORE the finding
+    // computation; a removal committing in that gap would otherwise let this sync INSERT fresh
+    // `dream_findings` rows for the removed repo after rm reported success (the table has no FK
+    // to `repos`). This transaction and rm's purge are both IMMEDIATE, so they serialize on the
+    // SQLite write lock and the tombstone state read here is stable for the whole sync: set → rm
+    // committed first, refuse; unset → rm's purge waits for this commit and sweeps the
+    // just-written rows itself. Unscoped (legacy single-repo) connections have no repo scope to
+    // guard — the check skips them.
+    if let Some(repo_id) = dream_repo_scope(&tx)?
+        && rag_rat_db::schema::is_repo_removed(&tx, &repo_id)?
+    {
+        return Err(rusqlite::Error::SqliteFailure(
+            rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_CONSTRAINT),
+            Some(format!(
+                "repo {repo_id} was removed with `rag-rat rm` — refusing the dream findings sync; \
+                 run `rag-rat init` in the repo to re-add it"
+            )),
+        ));
+    }
     let counts = sync_in_tx(&tx, findings, now_ms, resolve_kinds)?;
     tx.commit()?;
     Ok(counts)

--- a/crates/rag-rat-dream/src/lib.rs
+++ b/crates/rag-rat-dream/src/lib.rs
@@ -227,6 +227,37 @@ pub fn dream_run_with_passes(
     dream_run(conn, opts)
 }
 
+/// #767 review: run ONE model-pass entry's writes in ONE IMMEDIATE transaction with the `rag-rat
+/// rm` removal tombstone re-checked INSIDE it. A `dream --verify/--compact` process that opened
+/// its scoped connection before `rm` keeps that stale scope; the passes UPSERT `memory_reality` /
+/// `memory_summaries` / `memory_model_failures` (all repo-scoped, no FK to `repos`) per entry in
+/// autocommit, so without this a post-purge write survives a removal that reported success — the
+/// findings sync's own guard then refuses, but the already-written rows remain. This transaction
+/// and rm's purge are both IMMEDIATE, so they serialize on the SQLite write lock and the tombstone
+/// state read here is stable for the wrapped writes: set → rm committed first, fail closed; unset
+/// → rm's purge waits for the commit and sweeps the rows itself. The model call stays OUTSIDE the
+/// transaction (minutes-long inference must not hold the write lock); only the per-entry writes
+/// are wrapped. `scope` is the pass's repo_memories periphery scope — `None` (unscoped legacy
+/// connection) skips the check; there is no repo to tombstone.
+pub(crate) fn removal_guarded_write_tx(
+    conn: &Connection,
+    scope: &Option<String>,
+    write: impl FnOnce(&Connection) -> anyhow::Result<()>,
+) -> anyhow::Result<()> {
+    let tx = rusqlite::Transaction::new_unchecked(conn, rusqlite::TransactionBehavior::Immediate)?;
+    if let Some(repo_id) = scope
+        && rag_rat_db::schema::is_repo_removed(&tx, repo_id)?
+    {
+        anyhow::bail!(
+            "repo {repo_id} was removed with `rag-rat rm` — refusing the dream model-pass write; \
+             run `rag-rat init` in the repo to re-add it"
+        );
+    }
+    write(&tx)?;
+    tx.commit()?;
+    Ok(())
+}
+
 /// Whether the model passes would call the model AT ALL this run — the zero-work guard for
 /// EPHEMERAL `[llm.dream.remote]`. A fully churn-skipped (or all-uncitable) repo returns `false`,
 /// so `rag-rat dream --verify/--compact` never cold-starts a paid GPU box that would then do zero
@@ -309,6 +340,26 @@ pub(crate) mod tests {
             [repo_id],
         )
         .unwrap();
+    }
+
+    #[test]
+    fn model_pass_write_transaction_refuses_a_removed_repo_before_running_the_write() {
+        let c = mem_db();
+        set_repo(&c, "r");
+        rag_rat_db::schema::mark_repo_removed(&c, "r", 1).unwrap();
+        let called = std::cell::Cell::new(false);
+
+        let err = super::removal_guarded_write_tx(&c, &Some("r".to_string()), |_| {
+            called.set(true);
+            Ok(())
+        })
+        .expect_err("a tombstoned repo must refuse a model-pass write transaction");
+
+        assert!(!called.get(), "the guarded write closure must not run");
+        assert!(
+            err.to_string().contains("rag-rat rm"),
+            "the refusal should identify removal as the cause: {err}"
+        );
     }
 
     #[test]

--- a/crates/rag-rat-dream/src/verdict.rs
+++ b/crates/rag-rat-dream/src/verdict.rs
@@ -177,16 +177,21 @@ pub(super) fn run_verdict_pass(
         // NULL verdict stays inert for verdict markers and divergence findings. A
         // body/inputs/prompt change re-queues it exactly like any other row.
         if !pack.is_citable() {
-            record_uncitable(conn, Uncitable {
-                memory_id: &entry.memory_id,
-                repo_id,
-                title: &entry.title,
-                body: &entry.body,
-                checked_inputs_hash: &inputs_hash,
-                checked_against_commit: checked_against_commit.as_deref(),
-                now_ms,
+            // #767 review: the entry's writes commit under the removal-tombstone guard (the
+            // model itself is never called for an uncitable entry, so the whole step is a write).
+            super::removal_guarded_write_tx(conn, &scope, |tx| {
+                record_uncitable(tx, Uncitable {
+                    memory_id: &entry.memory_id,
+                    repo_id,
+                    title: &entry.title,
+                    body: &entry.body,
+                    checked_inputs_hash: &inputs_hash,
+                    checked_against_commit: checked_against_commit.as_deref(),
+                    now_ms,
+                })?;
+                failure::clear_failure(tx, &failure_stamp)?;
+                Ok(())
             })?;
-            failure::clear_failure(conn, &failure_stamp)?;
             continue;
         }
         let pack_text = render_pack(&pack);
@@ -195,35 +200,44 @@ pub(super) fn run_verdict_pass(
         let accepted = match obtain_verdict(pass.model, &prompt, &pack_text) {
             Ok(accepted) => accepted,
             Err(failure) => {
-                failure::record_failure(conn, RecordFailure {
-                    stamp: failure_stamp,
-                    failure: &failure,
-                    now_ms,
+                super::removal_guarded_write_tx(conn, &scope, |tx| {
+                    failure::record_failure(tx, RecordFailure {
+                        stamp: failure_stamp,
+                        failure: &failure,
+                        now_ms,
+                    })?;
+                    Ok(())
                 })?;
                 continue;
             },
         };
-        record_verdict(conn, RecordVerdict {
-            memory_id: &entry.memory_id,
-            repo_id,
-            title: &entry.title,
-            body: &entry.body,
-            accepted: &accepted,
-            checked_inputs_hash: &inputs_hash,
-            checked_against_commit: checked_against_commit.as_deref(),
-            model_id: pass.model.model_id(),
-            now_ms,
+        // #767 review: the verdict UPSERT + failure clear commit in ONE guarded transaction — the
+        // tombstone re-check inside serializes with `rag-rat rm`'s purge, so a removal landing
+        // mid-pass cannot leave this repo-scoped `memory_reality` row behind.
+        super::removal_guarded_write_tx(conn, &scope, |tx| {
+            record_verdict(tx, RecordVerdict {
+                memory_id: &entry.memory_id,
+                repo_id,
+                title: &entry.title,
+                body: &entry.body,
+                accepted: &accepted,
+                checked_inputs_hash: &inputs_hash,
+                checked_against_commit: checked_against_commit.as_deref(),
+                model_id: pass.model.model_id(),
+                now_ms,
+            })?;
+            let failure_stamp = FailureStamp {
+                memory_id: &entry.memory_id,
+                repo_id,
+                pass: DreamModelPass::Verify,
+                content_hash: &content_hash,
+                checked_inputs_hash: Some(&inputs_hash),
+                prompt_version: PROMPT_VERSION,
+                model_id: pass.model.model_id(),
+            };
+            failure::clear_failure(tx, &failure_stamp)?;
+            Ok(())
         })?;
-        let failure_stamp = FailureStamp {
-            memory_id: &entry.memory_id,
-            repo_id,
-            pass: DreamModelPass::Verify,
-            content_hash: &content_hash,
-            checked_inputs_hash: Some(&inputs_hash),
-            prompt_version: PROMPT_VERSION,
-            model_id: pass.model.model_id(),
-        };
-        failure::clear_failure(conn, &failure_stamp)?;
     }
     Ok(())
 }


### PR DESCRIPTION
## `rag-rat rm <path>` — remove a repo from the global index

Adds `rag-rat rm <path>` to fully de-index a repository from the consolidated global database and clean up its on-disk footprint. The global store accrues repos over time and there was no supported way to remove one.

Closes #767.

### Behaviour
- **Path resolution** (strict): accepts `.`, `./relative`, or `/absolute`; resolves to a registered repo by derived git identity, else an exact recorded-root match (canonical then raw). It deliberately never falls back to "the sole repo" the read path allows — resolving an arbitrary unregistered path to the only registered repo would offer to delete the wrong one. An unregistered path is refused with a message listing the registered repos.
- **Database purge**: deletes every row the repo owns, then VACUUMs. Purge = three disjoint mechanisms:
  - a class-level sweep of every base table carrying a `repo_id` column, enumerated dynamically from `sqlite_master` — so a future migration that adds a `repo_id` table is covered automatically;
  - the transitively-scoped children (no `repo_id`, reached through a `repo_id`-bearing parent), captured into temp id sets up front and deleted explicitly (correct even with foreign keys off);
  - FTS fixups (`chunk_fts` by rowid; `commit_fts` rebuilt after the git-commit delete).
  - Deliberately untouched: content-addressed / store-global shared state (interning pools, `embedding_cache`, the machine model registry, global meta) and the device/account/op-log sync substrate — none carry a `repo_id`, and the signed log is grow-only.
- **On-disk cleanup**: deletes the repo's `rag-rat.toml` and uninstalls only the rag-rat-managed git hooks. Best-effort — a purge that committed but couldn't remove the config warns rather than failing. After `rm`, returning the repo needs `rag-rat init`.
- **Safety**: prints a per-category summary of what will be deleted and prompts (default: no); `--yes` skips the prompt, `--dry-run` previews and deletes nothing; a non-interactive stdin without `--yes` is refused.

### Atomicity
The recount + purge run under the repo's per-repo write lock in one IMMEDIATE transaction (all-or-nothing). VACUUM runs after the commit on a fresh connection and is best-effort: a busy database leaves the purge committed and reports `vacuum_skipped`.

### Completeness tripwire
A test purges a poison sibling seeded across ~37 `repo_id` tables (plus every transitive child) and asserts — by enumerating the live schema, not a hand-listed subset — that zero rows remain for the removed repo in every `repo_id` table and every transitive child, while a real fixture sibling stays byte-for-byte intact. So a scoping regression (an unscoped delete, or a new table the purge misses) fails here instead of in production.

No schema change.
