### PR TITLE
Add [llm.distill] config with a model-size-aware provision timeout

### DIFF
--- a/crates/rag-rat-base/src/config/load.rs
+++ b/crates/rag-rat-base/src/config/load.rs
@@ -259,6 +259,13 @@ impl Config {
         {
             llm.dream.remote.cookbook = Some(resolved);
         }
+        // Same relative-cookbook resolution for the distill remote (#704) — it rides the same
+        // `RemoteDreamConfig` and hands its recipe to `node`/`npx` too.
+        if let Some(cookbook) = llm.distill.remote.cookbook.as_ref()
+            && let Some(resolved) = config::resolve_relative_cookbook_path(cookbook, &config_dir)
+        {
+            llm.distill.remote.cookbook = Some(resolved);
+        }
         let watch = raw.watch.into();
         let version_check = raw.version_check.into();
         let oracle = raw.oracle.into();

--- a/crates/rag-rat-base/src/config/mod.rs
+++ b/crates/rag-rat-base/src/config/mod.rs
@@ -36,11 +36,8 @@ pub enum ConfigError {
          `all-minilm`)"
     )]
     RemoteEmbeddingMissingModel,
-    #[error(
-        "[llm.embedding.remote] `backend` must be one of `ollama`, `infinity`, or `vllm` (got \
-         `{0}`)"
-    )]
-    RemoteBackendUnknown(String),
+    #[error("{section} `backend` must be one of `ollama`, `infinity`, or `vllm` (got `{got}`)")]
+    RemoteBackendUnknown { section: &'static str, got: String },
     #[error(
         "[llm.embedding.remote] `backend = \"{backend}\"` with an ephemeral `cookbook` requires \
          an explicit `query_endpoint` — queries embed against a LOCAL server after the box is \
@@ -65,11 +62,10 @@ pub enum ConfigError {
     )]
     RemoteGpuRequiresCookbook,
     #[error(
-        "[llm.embedding.remote] `gpu` is set but empty — give it a provider-specific value (a \
-         Modal GPU class like `A10G`, or a RunPod `gpuTypeId`), or remove the key to use the \
-         recipe default"
+        "{section} `gpu` is set but empty — give it a provider-specific value (a Modal GPU class \
+         like `A10G`, or a RunPod `gpuTypeId`), or remove the key to use the recipe default"
     )]
-    RemoteGpuEmpty,
+    RemoteGpuEmpty { section: &'static str },
     #[error(
         "[llm.embedding.remote] `num_ctx` must be greater than zero when set — remove it to use \
          Ollama's default context, or set a positive context window such as 4096"
@@ -88,32 +84,43 @@ pub enum ConfigError {
     )]
     RemoteEmbeddingNonTransformerModel(String),
     #[error(
-        "[llm.dream.remote] requires a non-empty `model` (the server-side chat model name — an \
-         ollama model like `qwen3:8b`, or the HuggingFace id vLLM was launched with, e.g. \
+        "{section} requires a non-empty `model` (the server-side chat model name — an ollama \
+         model like `qwen3:8b`, or the HuggingFace id vLLM was launched with, e.g. \
          `Qwen/Qwen3-4B-Instruct-2507`)"
     )]
-    DreamRemoteMissingModel,
+    DreamRemoteMissingModel { section: &'static str },
     #[error(
-        "[llm.dream.remote] `backend = \"{0}\"` cannot serve chat completions — dream needs a \
+        "{section} `backend = \"{backend}\"` cannot serve chat completions — a chat model needs a \
          chat-capable backend (`ollama` or `vllm`); `infinity` is embed-only. Switch the backend, \
-         or point the dream model at an ollama/vLLM server"
+         or point it at an ollama/vLLM server"
     )]
-    DreamBackendCannotServeChat(String),
+    DreamBackendCannotServeChat { section: &'static str, backend: String },
     #[error(
-        "[llm.dream.remote] requires EXACTLY ONE of `endpoint` (connect to a running chat server) \
-         or `cookbook` (provision an ephemeral box) — set neither both nor zero"
+        "{section} requires EXACTLY ONE of `endpoint` (connect to a running chat server) or \
+         `cookbook` (provision an ephemeral box) — set neither both nor zero"
     )]
-    DreamRemoteModeAmbiguous,
+    DreamRemoteModeAmbiguous { section: &'static str },
     #[error(
-        "[llm.dream.remote] `endpoint` must not embed credentials in the URL (no \
-         `user:pass@host`) — put any token in an env var and name it via `auth_env` instead"
+        "{section} `endpoint` must not embed credentials in the URL (no `user:pass@host`) — put \
+         any token in an env var and name it via `auth_env` instead"
     )]
-    DreamRemoteEndpointHasCredentials,
+    DreamRemoteEndpointHasCredentials { section: &'static str },
     #[error(
-        "[llm.dream.remote] `gpu` applies only to ephemeral `cookbook` provisioning, not a \
-         connect `endpoint` — remove `gpu`, or switch the remote block to a `cookbook` recipe"
+        "{section} `gpu` applies only to ephemeral `cookbook` provisioning, not a connect \
+         `endpoint` — remove `gpu`, or switch the remote block to a `cookbook` recipe"
     )]
-    DreamRemoteGpuRequiresCookbook,
+    DreamRemoteGpuRequiresCookbook { section: &'static str },
+    #[error(
+        "{section} `provision_timeout_s = {got}` is below the `{backend}` backend's {floor}s \
+         provisioning floor — the override may only LENGTHEN the boot budget (e.g. a large model \
+         whose weight pull exceeds the default), never shorten it below what a cold start needs"
+    )]
+    DreamRemoteProvisionTimeoutBelowFloor {
+        section: &'static str,
+        backend: &'static str,
+        got: u64,
+        floor: u64,
+    },
     #[error(
         "the `[local_ai]` table was renamed to `[llm]` (#317). Update your rag-rat.toml: rename \
          `[local_ai.embedding]` → `[llm.embedding]` (and any `[local_ai.embedding.remote]` / \
@@ -181,8 +188,8 @@ pub(crate) use raw::{RawConfig, RawTarget, resolve_relative_cookbook_path};
 #[cfg(test)]
 pub(crate) use raw::{RawMemory, RawOracle, RawSearch, RawVersionCheck, RawWatch};
 pub use types::{
-    Config, DEFAULT_QUERY_ENDPOINT, DreamLlmConfig, EmbeddingBackend, EmbeddingConfig,
-    EmbeddingRuntimeConfig, LlmConfig, LogConfig, LogFormat, LogLevel,
+    Config, DEFAULT_QUERY_ENDPOINT, DistillLlmConfig, DreamLlmConfig, EmbeddingBackend,
+    EmbeddingConfig, EmbeddingRuntimeConfig, LlmConfig, LogConfig, LogFormat, LogLevel,
     MAX_REMOTE_EMBEDDING_CONCURRENCY, MemoryConfig, MemorySurface, OracleConfig, PapertrailConfig,
     RemoteBackend, RemoteDreamConfig, RemoteEmbeddingConfig, ResolvedTarget, SearchConfig,
     TargetKind, Tracker, TrackerAuth, TrackerConfig, VersionCheckConfig, WatchConfig,

--- a/crates/rag-rat-base/src/config/raw.rs
+++ b/crates/rag-rat-base/src/config/raw.rs
@@ -4,8 +4,8 @@ use std::path::{Path, PathBuf};
 use serde::Deserialize;
 
 use super::{
-    ConfigError, DEFAULT_QUERY_ENDPOINT, DreamLlmConfig, EmbeddingBackend, EmbeddingConfig,
-    EmbeddingRuntimeConfig, LlmConfig, LogConfig, LogFormat, LogLevel,
+    ConfigError, DEFAULT_QUERY_ENDPOINT, DistillLlmConfig, DreamLlmConfig, EmbeddingBackend,
+    EmbeddingConfig, EmbeddingRuntimeConfig, LlmConfig, LogConfig, LogFormat, LogLevel,
     MAX_REMOTE_EMBEDDING_CONCURRENCY, MemoryConfig, MemorySurface, OracleConfig, PapertrailConfig,
     RemoteBackend, RemoteDreamConfig, RemoteEmbeddingConfig, SearchConfig, Tracker, TrackerAuth,
     TrackerConfig, VersionCheckConfig, WatchConfig,
@@ -348,39 +348,50 @@ pub(crate) struct RawLlm {
     #[serde(default)]
     embedding: RawEmbedding,
     #[serde(default)]
-    pub(crate) dream: RawDreamLlm,
+    pub(crate) dream: RawChatLlm,
+    /// `[llm.distill]` — the distill LLM pass (#704). Same shape as `[llm.dream]` (an `enabled`
+    /// gate plus a chat-serving block); both ride [`RemoteDreamConfig`].
+    #[serde(default)]
+    pub(crate) distill: RawChatLlm,
 }
 
 impl TryFrom<RawLlm> for LlmConfig {
     type Error = ConfigError;
 
     fn try_from(raw: RawLlm) -> Result<Self, Self::Error> {
+        let (dream_enabled, dream_remote) = resolve_chat_gate(raw.dream, "[llm.dream.remote]")?;
+        let (distill_enabled, distill_remote) =
+            resolve_chat_gate(raw.distill, "[llm.distill.remote]")?;
         Ok(Self {
             embedding: EmbeddingConfig::try_from(raw.embedding)?,
-            dream: DreamLlmConfig::try_from(raw.dream)?,
+            dream: DreamLlmConfig { enabled: dream_enabled, remote: dream_remote },
+            distill: DistillLlmConfig { enabled: distill_enabled, remote: distill_remote },
         })
     }
 }
 
+/// A `[llm.dream]` / `[llm.distill]` gate block: an `enabled` flag plus an optional chat-serving
+/// block. Identical shape for both passes, so one raw type serves both.
 #[derive(Debug, Default, Deserialize, PartialEq)]
-pub(crate) struct RawDreamLlm {
+pub(crate) struct RawChatLlm {
     enabled: Option<bool>,
-    /// `[llm.dream.remote]` — absent → [`RemoteDreamConfig::default`] (a local-Ollama connect).
-    /// Unlike embeddings there is no in-process fallback, so a missing block still yields a
-    /// serving config rather than `None`.
+    /// The `.remote` chat-serving block — absent → [`RemoteDreamConfig::default`] (a local-Ollama
+    /// connect). Unlike embeddings there is no in-process fallback, so a missing block still
+    /// yields a serving config rather than `None`.
     remote: Option<RawRemoteDream>,
 }
 
-impl TryFrom<RawDreamLlm> for DreamLlmConfig {
-    type Error = ConfigError;
-
-    fn try_from(raw: RawDreamLlm) -> Result<Self, Self::Error> {
-        let remote = match raw.remote {
-            Some(remote) => RemoteDreamConfig::try_from(remote)?,
-            None => RemoteDreamConfig::default(),
-        };
-        Ok(Self { enabled: raw.enabled.unwrap_or_default(), remote })
-    }
+/// Resolve a chat gate to `(enabled, remote)`. `section` names the TOML block (e.g.
+/// `"[llm.distill.remote]"`) so validation errors point at the block the operator actually wrote.
+fn resolve_chat_gate(
+    raw: RawChatLlm,
+    section: &'static str,
+) -> Result<(bool, RemoteDreamConfig), ConfigError> {
+    let remote = match raw.remote {
+        Some(remote) => resolve_remote_dream(remote, section)?,
+        None => RemoteDreamConfig::default(),
+    };
+    Ok((raw.enabled.unwrap_or_default(), remote))
 }
 
 #[derive(Debug, Default, Deserialize, PartialEq)]
@@ -392,79 +403,105 @@ pub(crate) struct RawRemoteDream {
     gpu: Option<String>,
     auth_env: Option<String>,
     request_timeout_s: Option<u64>,
+    provision_timeout_s: Option<u64>,
 }
 
-impl TryFrom<RawRemoteDream> for RemoteDreamConfig {
-    type Error = ConfigError;
-
-    fn try_from(raw: RawRemoteDream) -> Result<Self, Self::Error> {
-        let default = RemoteDreamConfig::default();
-        let trimmed = |s: Option<String>| s.map(|v| v.trim().to_string()).filter(|v| !v.is_empty());
-        // The SERVER-side chat model name — required, non-empty. For ollama the ollama model name;
-        // for vLLM the HF id the server was launched with.
-        let model = raw.model.unwrap_or_default();
-        let model = model.trim();
-        if model.is_empty() {
-            return Err(ConfigError::DreamRemoteMissingModel);
-        }
-        // Which OpenAI-compatible server serves this block. Omitted → `ollama`.
-        let backend = match trimmed(raw.backend) {
-            None => RemoteBackend::default(),
-            Some(raw_backend) => RemoteBackend::from_db_str(&raw_backend)
-                .ok_or(ConfigError::RemoteBackendUnknown(raw_backend))?,
-        };
-        // Dream requests the CHAT capability; `infinity` is embed-only. Reject it at parse time so
-        // a misrouted backend never reaches the verdict client.
-        if !backend.supports_chat() {
-            return Err(ConfigError::DreamBackendCannotServeChat(backend.as_db_str().to_string()));
-        }
-        // The MODE is INFERRED from which URL field is set (mirrors embeddings): EXACTLY ONE of
-        // `endpoint` (connect) / `cookbook` (ephemeral). Both → ambiguous; neither → no server.
-        let endpoint = trimmed(raw.endpoint);
-        let cookbook = trimmed(raw.cookbook);
-        match (endpoint.is_some(), cookbook.is_some()) {
-            (true, true) | (false, false) => {
-                return Err(ConfigError::DreamRemoteModeAmbiguous);
-            },
-            _ => {},
-        }
-        // SECRET HYGIENE: reject a `user:pass@host` endpoint and direct the user to `auth_env`
-        // instead. Checked against the URL authority only, so an `@` in a path/query is fine.
-        // `cookbook` is a recipe spec, not a URL, so it is not checked.
-        if let Some(url) = endpoint.as_deref()
-            && endpoint_authority_has_userinfo(url)
-        {
-            return Err(ConfigError::DreamRemoteEndpointHasCredentials);
-        }
-        // EPHEMERAL-only: the GPU to provision. A PRESENT-but-empty value is a config error
-        // (clearer than silently dropping a meant-to-be-set key). Set with a connect
-        // `endpoint` it is meaningless → rejected. The VALUE is provider-specific and
-        // validated at provision time.
-        let gpu = match raw.gpu {
-            Some(g) => {
-                let g = g.trim();
-                if g.is_empty() {
-                    return Err(ConfigError::RemoteGpuEmpty);
-                }
-                if endpoint.is_some() {
-                    return Err(ConfigError::DreamRemoteGpuRequiresCookbook);
-                }
-                Some(g.to_string())
-            },
-            None => None,
-        };
-        // Optional — local Ollama needs no auth; trim if present.
-        let auth_env = trimmed(raw.auth_env);
-        Ok(Self {
-            backend,
-            endpoint,
-            cookbook,
-            model: model.to_string(),
-            gpu,
-            auth_env,
-            request_timeout_s: raw.request_timeout_s.unwrap_or(default.request_timeout_s),
-        })
+/// Resolve a `[llm.*.remote]` chat-serving block. `section` names the block for error messages so a
+/// bad `[llm.distill.remote]` never surfaces a `[llm.dream.remote]`-worded error.
+fn resolve_remote_dream(
+    raw: RawRemoteDream,
+    section: &'static str,
+) -> Result<RemoteDreamConfig, ConfigError> {
+    let default = RemoteDreamConfig::default();
+    let trimmed = |s: Option<String>| s.map(|v| v.trim().to_string()).filter(|v| !v.is_empty());
+    // The SERVER-side chat model name — required, non-empty. For ollama the ollama model name;
+    // for vLLM the HF id the server was launched with.
+    let model = raw.model.unwrap_or_default();
+    let model = model.trim();
+    if model.is_empty() {
+        return Err(ConfigError::DreamRemoteMissingModel { section });
     }
+    // Which OpenAI-compatible server serves this block. Omitted → `ollama`.
+    let backend = match trimmed(raw.backend) {
+        None => RemoteBackend::default(),
+        Some(raw_backend) => RemoteBackend::from_db_str(&raw_backend)
+            .ok_or(ConfigError::RemoteBackendUnknown { section, got: raw_backend })?,
+    };
+    // A chat pass requests the CHAT capability; `infinity` is embed-only. Reject it at parse
+    // time so a misrouted backend never reaches the chat client.
+    if !backend.supports_chat() {
+        return Err(ConfigError::DreamBackendCannotServeChat {
+            section,
+            backend: backend.as_db_str().to_string(),
+        });
+    }
+    // The MODE is INFERRED from which URL field is set (mirrors embeddings): EXACTLY ONE of
+    // `endpoint` (connect) / `cookbook` (ephemeral). Both → ambiguous; neither → no server.
+    let endpoint = trimmed(raw.endpoint);
+    let cookbook = trimmed(raw.cookbook);
+    match (endpoint.is_some(), cookbook.is_some()) {
+        (true, true) | (false, false) => {
+            return Err(ConfigError::DreamRemoteModeAmbiguous { section });
+        },
+        _ => {},
+    }
+    // SECRET HYGIENE: reject a `user:pass@host` endpoint and direct the user to `auth_env`
+    // instead. Checked against the URL authority only, so an `@` in a path/query is fine.
+    // `cookbook` is a recipe spec, not a URL, so it is not checked.
+    if let Some(url) = endpoint.as_deref()
+        && endpoint_authority_has_userinfo(url)
+    {
+        return Err(ConfigError::DreamRemoteEndpointHasCredentials { section });
+    }
+    // EPHEMERAL-only: the GPU to provision. A PRESENT-but-empty value is a config error
+    // (clearer than silently dropping a meant-to-be-set key). Set with a connect
+    // `endpoint` it is meaningless → rejected. The VALUE is provider-specific and
+    // validated at provision time.
+    let gpu = match raw.gpu {
+        Some(g) => {
+            let g = g.trim();
+            if g.is_empty() {
+                return Err(ConfigError::RemoteGpuEmpty { section });
+            }
+            if endpoint.is_some() {
+                return Err(ConfigError::DreamRemoteGpuRequiresCookbook { section });
+            }
+            Some(g.to_string())
+        },
+        None => None,
+    };
+    // Optional — local Ollama needs no auth; trim if present.
+    let auth_env = trimmed(raw.auth_env);
+    // EPHEMERAL-only boot-budget override: it may only LENGTHEN past the backend's provisioning
+    // floor (the distill 30B case). A value below the floor would starve the recipe — its budget
+    // (this value minus the teardown margin) collapses toward zero and provisioning gives up
+    // immediately — so reject it at parse time. Ignored (not validated) in connect mode, where
+    // nothing is provisioned.
+    if cookbook.is_some()
+        && let Some(got) = raw.provision_timeout_s
+    {
+        let floor = backend.provision_timeout().as_secs();
+        if got < floor {
+            return Err(ConfigError::DreamRemoteProvisionTimeoutBelowFloor {
+                section,
+                backend: backend.as_db_str(),
+                got,
+                floor,
+            });
+        }
+    }
+    Ok(RemoteDreamConfig {
+        backend,
+        endpoint,
+        cookbook,
+        model: model.to_string(),
+        gpu,
+        auth_env,
+        request_timeout_s: raw.request_timeout_s.unwrap_or(default.request_timeout_s),
+        // Optional model-size-aware boot budget override (a 30B-class weight pull can exceed the
+        // backend default); `None` → the backend's default at provision time.
+        provision_timeout_s: raw.provision_timeout_s,
+    })
 }
 
 #[derive(Debug, Default, Deserialize, PartialEq)]
@@ -588,8 +625,12 @@ impl TryFrom<RawRemoteEmbedding> for RemoteEmbeddingConfig {
         // Which OpenAI-compatible server serves this block. Omitted → `ollama` (back-compat).
         let backend = match trimmed(raw.backend) {
             None => RemoteBackend::default(),
-            Some(raw_backend) => RemoteBackend::from_db_str(&raw_backend)
-                .ok_or(ConfigError::RemoteBackendUnknown(raw_backend))?,
+            Some(raw_backend) => RemoteBackend::from_db_str(&raw_backend).ok_or(
+                ConfigError::RemoteBackendUnknown {
+                    section: "[llm.embedding.remote]",
+                    got: raw_backend,
+                },
+            )?,
         };
         // The MODE is INFERRED from which URL field is set (#318): EXACTLY ONE of `endpoint`
         // (connect) / `cookbook` (ephemeral). Both → ambiguous; neither → no server to reach.
@@ -645,7 +686,7 @@ impl TryFrom<RawRemoteEmbedding> for RemoteEmbeddingConfig {
             Some(g) => {
                 let g = g.trim();
                 if g.is_empty() {
-                    return Err(ConfigError::RemoteGpuEmpty);
+                    return Err(ConfigError::RemoteGpuEmpty { section: "[llm.embedding.remote]" });
                 }
                 if endpoint.is_some() {
                     return Err(ConfigError::RemoteGpuRequiresCookbook);

--- a/crates/rag-rat-base/src/config/tests.rs
+++ b/crates/rag-rat-base/src/config/tests.rs
@@ -1676,7 +1676,7 @@ fn remote_embedding_empty_gpu_is_rejected() {
         .unwrap();
         let err = LlmConfig::try_from(raw.llm).unwrap_err();
         assert!(
-            matches!(err, ConfigError::RemoteGpuEmpty),
+            matches!(err, ConfigError::RemoteGpuEmpty { .. }),
             "gpu={value} → RemoteGpuEmpty, got {err:?}",
         );
     }
@@ -2042,7 +2042,10 @@ fn remote_backend_parses_defaults_to_ollama_and_rejects_unknown() {
     assert_eq!(parse(r#"backend = "VLLM""#).unwrap().backend, RemoteBackend::Vllm);
     // Unknown → a clear config error naming the bad value.
     let err = parse(r#"backend = "tgi""#).unwrap_err();
-    assert!(matches!(&err, ConfigError::RemoteBackendUnknown(v) if v == "tgi"), "got {err:?}");
+    assert!(
+        matches!(&err, ConfigError::RemoteBackendUnknown { got, .. } if got == "tgi"),
+        "got {err:?}"
+    );
 }
 
 #[test]
@@ -2289,8 +2292,211 @@ fn dream_remote_connect_happy_path_applies_defaults() {
         gpu: None,
         auth_env: Some("OLLAMA_TOKEN".to_string()),
         request_timeout_s: 60,
+        provision_timeout_s: None,
     });
     assert!(dream.remote.is_connect() && !dream.remote.is_ephemeral());
+}
+
+#[test]
+fn distill_absent_defaults_to_off_and_local_ollama_connect() {
+    // No `[llm.distill]` → disabled, with the same local-Ollama CONNECT default dream carries
+    // (the distill pass rides `RemoteDreamConfig`).
+    let raw: RawConfig = toml::from_str(
+        r#"
+            [index]
+            root = "."
+            "#,
+    )
+    .unwrap();
+    let distill = LlmConfig::try_from(raw.llm).unwrap().distill;
+    assert!(!distill.enabled, "the distill model pass is OFF by default");
+    assert_eq!(distill.remote, RemoteDreamConfig::default());
+    assert!(distill.remote.is_connect() && !distill.remote.is_ephemeral());
+}
+
+#[test]
+fn distill_and_dream_are_independent_gates() {
+    // Enabling one pass must not enable the other — they are separate `[llm.*]` blocks.
+    let raw: RawConfig = toml::from_str(
+        r#"
+            [index]
+            root = "."
+
+            [llm.distill]
+            enabled = true
+            "#,
+    )
+    .unwrap();
+    let llm = LlmConfig::try_from(raw.llm).unwrap();
+    assert!(llm.distill.enabled, "[llm.distill] enabled = true opts in");
+    assert!(!llm.dream.enabled, "distill's gate does not enable dream");
+}
+
+#[test]
+fn distill_remote_ephemeral_parses_and_honors_the_provision_timeout_override() {
+    // The distill default model is a 30B-class box whose weight pull can exceed the vLLM default
+    // boot budget, so `[llm.distill.remote]` carries a `provision_timeout_s` override.
+    let raw: RawConfig = toml::from_str(
+        r#"
+            [index]
+            root = "."
+
+            [llm.distill]
+            enabled = true
+
+            [llm.distill.remote]
+            backend = "vllm"
+            cookbook = "@rag-rat/cookbook modal"
+            model = "Qwen/Qwen3-30B-A3B-Instruct-2507-FP8"
+            gpu = "L40S"
+            provision_timeout_s = 1500
+            "#,
+    )
+    .unwrap();
+    let remote = LlmConfig::try_from(raw.llm).unwrap().distill.remote;
+    assert!(remote.is_ephemeral() && !remote.is_connect());
+    assert_eq!(remote.backend, RemoteBackend::Vllm);
+    assert_eq!(remote.model, "Qwen/Qwen3-30B-A3B-Instruct-2507-FP8");
+    assert_eq!(remote.gpu.as_deref(), Some("L40S"));
+    assert_eq!(remote.provision_timeout_s, Some(1500));
+    // The override wins over the backend default (vLLM = 900s).
+    assert_eq!(remote.resolved_provision_timeout(), std::time::Duration::from_secs(1500));
+}
+
+#[test]
+fn distill_provision_timeout_below_the_backend_floor_is_rejected() {
+    // An ephemeral override may only LENGTHEN the boot budget — a value under the vLLM floor (900s)
+    // would starve the recipe, so it is rejected at parse time, naming the distill section.
+    let raw: RawConfig = toml::from_str(
+        r#"
+            [index]
+            root = "."
+
+            [llm.distill.remote]
+            backend = "vllm"
+            cookbook = "@rag-rat/cookbook modal"
+            model = "Qwen/Qwen3-8B"
+            provision_timeout_s = 60
+            "#,
+    )
+    .unwrap();
+    let err = LlmConfig::try_from(raw.llm).unwrap_err();
+    assert!(
+        matches!(
+            &err,
+            ConfigError::DreamRemoteProvisionTimeoutBelowFloor { section, got: 60, floor: 900, .. }
+                if *section == "[llm.distill.remote]"
+        ),
+        "too-small override → below-floor error naming the distill section, got {err:?}",
+    );
+}
+
+#[test]
+fn distill_provision_timeout_override_is_ignored_in_connect_mode() {
+    // Connect mode provisions nothing, so a small `provision_timeout_s` is simply unused, not
+    // rejected — the floor check applies to ephemeral provisioning only.
+    let raw: RawConfig = toml::from_str(
+        r#"
+            [index]
+            root = "."
+
+            [llm.distill.remote]
+            backend = "ollama"
+            endpoint = "http://localhost:11434"
+            model = "qwen3:8b"
+            provision_timeout_s = 5
+            "#,
+    )
+    .unwrap();
+    let remote = LlmConfig::try_from(raw.llm).unwrap().distill.remote;
+    assert_eq!(remote.provision_timeout_s, Some(5), "connect mode keeps the value, unused");
+}
+
+#[test]
+fn the_shared_backend_and_gpu_errors_name_the_distill_section() {
+    // `RemoteBackendUnknown` / `RemoteGpuEmpty` are shared with the embedding parser; a distill
+    // misconfig must still name `[llm.distill.remote]`, not the embedding block.
+    let unknown_backend: RawConfig = toml::from_str(
+        r#"
+            [index]
+            root = "."
+
+            [llm.distill.remote]
+            backend = "tgi"
+            endpoint = "http://localhost:8080"
+            model = "some-model"
+            "#,
+    )
+    .unwrap();
+    let err = LlmConfig::try_from(unknown_backend.llm).unwrap_err().to_string();
+    assert!(err.contains("[llm.distill.remote]"), "unknown-backend names the distill block: {err}");
+    assert!(!err.contains("[llm.embedding.remote]"), "not the embedding block: {err}");
+
+    let empty_gpu: RawConfig = toml::from_str(
+        r#"
+            [index]
+            root = "."
+
+            [llm.distill.remote]
+            backend = "vllm"
+            cookbook = "@rag-rat/cookbook modal"
+            model = "some-model"
+            gpu = "   "
+            "#,
+    )
+    .unwrap();
+    let err = LlmConfig::try_from(empty_gpu.llm).unwrap_err().to_string();
+    assert!(err.contains("[llm.distill.remote]"), "empty-gpu names the distill block: {err}");
+}
+
+#[test]
+fn resolved_provision_timeout_falls_back_to_the_backend_default() {
+    // No override → the backend's own provision ceiling (vLLM = 900s here).
+    let remote = RemoteDreamConfig {
+        backend: RemoteBackend::Vllm,
+        endpoint: None,
+        cookbook: Some("@rag-rat/cookbook modal".to_string()),
+        model: "Qwen/Qwen3-8B".to_string(),
+        provision_timeout_s: None,
+        ..RemoteDreamConfig::default()
+    };
+    assert_eq!(remote.resolved_provision_timeout(), RemoteBackend::Vllm.provision_timeout());
+}
+
+#[test]
+fn a_bad_distill_remote_error_names_the_distill_section_not_dream() {
+    // The shared `RemoteDreamConfig` validation is section-aware: a `[llm.distill.remote]`
+    // misconfig must point at THAT block, never the `[llm.dream.remote]` the same parser serves
+    // for dream.
+    let distill_bad: RawConfig = toml::from_str(
+        r#"
+            [index]
+            root = "."
+
+            [llm.distill.remote]
+            endpoint = "http://localhost:11434"
+            model = ""
+            "#,
+    )
+    .unwrap();
+    let err = LlmConfig::try_from(distill_bad.llm).unwrap_err().to_string();
+    assert!(err.contains("[llm.distill.remote]"), "distill error names its own section: {err}");
+    assert!(!err.contains("[llm.dream.remote]"), "and not dream's: {err}");
+
+    // Symmetry: the dream block still names `[llm.dream.remote]`.
+    let dream_bad: RawConfig = toml::from_str(
+        r#"
+            [index]
+            root = "."
+
+            [llm.dream.remote]
+            endpoint = "http://localhost:11434"
+            model = ""
+            "#,
+    )
+    .unwrap();
+    let err = LlmConfig::try_from(dream_bad.llm).unwrap_err().to_string();
+    assert!(err.contains("[llm.dream.remote]"), "dream error names its own section: {err}");
 }
 
 #[test]
@@ -2339,7 +2545,7 @@ fn dream_remote_requires_a_non_empty_model() {
         .unwrap();
         let err = LlmConfig::try_from(raw.llm).unwrap_err();
         assert!(
-            matches!(err, ConfigError::DreamRemoteMissingModel),
+            matches!(err, ConfigError::DreamRemoteMissingModel { .. }),
             "model={model_line:?} → DreamRemoteMissingModel, got {err:?}",
         );
     }
@@ -2362,7 +2568,7 @@ fn dream_remote_infinity_backend_cannot_serve_chat() {
     .unwrap();
     let err = LlmConfig::try_from(raw.llm).unwrap_err();
     assert!(
-        matches!(&err, ConfigError::DreamBackendCannotServeChat(b) if b.as_str() == "infinity"),
+        matches!(&err, ConfigError::DreamBackendCannotServeChat { backend, .. } if backend == "infinity"),
         "infinity → DreamBackendCannotServeChat, got {err:?}",
     );
 }
@@ -2391,7 +2597,7 @@ fn dream_remote_requires_exactly_one_of_endpoint_or_cookbook() {
         let raw: RawConfig = toml::from_str(toml_str).unwrap();
         let err = LlmConfig::try_from(raw.llm).unwrap_err();
         assert!(
-            matches!(err, ConfigError::DreamRemoteModeAmbiguous),
+            matches!(err, ConfigError::DreamRemoteModeAmbiguous { .. }),
             "{label} endpoint/cookbook → DreamRemoteModeAmbiguous, got {err:?}",
         );
     }
@@ -2415,7 +2621,7 @@ fn dream_remote_gpu_with_connect_endpoint_is_rejected() {
     .unwrap();
     let err = LlmConfig::try_from(raw.llm).unwrap_err();
     assert!(
-        matches!(err, ConfigError::DreamRemoteGpuRequiresCookbook),
+        matches!(err, ConfigError::DreamRemoteGpuRequiresCookbook { .. }),
         "gpu + endpoint → DreamRemoteGpuRequiresCookbook, got {err:?}",
     );
 }
@@ -2438,7 +2644,7 @@ fn dream_remote_empty_gpu_is_rejected() {
         .unwrap();
         let err = LlmConfig::try_from(raw.llm).unwrap_err();
         assert!(
-            matches!(err, ConfigError::RemoteGpuEmpty),
+            matches!(err, ConfigError::RemoteGpuEmpty { .. }),
             "gpu={value} → RemoteGpuEmpty, got {err:?}",
         );
     }
@@ -2459,7 +2665,7 @@ fn dream_remote_endpoint_with_credentials_is_rejected() {
     .unwrap();
     let err = LlmConfig::try_from(raw.llm).unwrap_err();
     assert!(
-        matches!(err, ConfigError::DreamRemoteEndpointHasCredentials),
+        matches!(err, ConfigError::DreamRemoteEndpointHasCredentials { .. }),
         "endpoint with userinfo → DreamRemoteEndpointHasCredentials, got {err:?}",
     );
 }
@@ -2480,7 +2686,7 @@ fn dream_remote_unknown_backend_is_rejected() {
     .unwrap();
     let err = LlmConfig::try_from(raw.llm).unwrap_err();
     assert!(
-        matches!(&err, ConfigError::RemoteBackendUnknown(b) if b.as_str() == "tgi"),
+        matches!(&err, ConfigError::RemoteBackendUnknown { got, .. } if got == "tgi"),
         "unknown backend → RemoteBackendUnknown, got {err:?}",
     );
 }

--- a/crates/rag-rat-base/src/config/types.rs
+++ b/crates/rag-rat-base/src/config/types.rs
@@ -340,6 +340,7 @@ impl Default for LogConfig {
 pub struct LlmConfig {
     pub embedding: EmbeddingConfig,
     pub dream: DreamLlmConfig,
+    pub distill: DistillLlmConfig,
 }
 
 /// Dream-mode model pass (`[llm.dream]`) — rag-rat's first generative-model dependency (#122),
@@ -358,6 +359,23 @@ pub struct DreamLlmConfig {
     pub enabled: bool,
     /// Which chat server serves the dream turns (connect XOR ephemeral). Absent
     /// `[llm.dream.remote]` → [`RemoteDreamConfig::default`] (a local-Ollama connect).
+    pub remote: RemoteDreamConfig,
+}
+
+/// Distill LLM pass (`[llm.distill]`, #704) — the model half of issue distillation, filling the
+/// distilled-record store's model columns. Same shape as [`DreamLlmConfig`]: an `enabled` gate plus
+/// a [`RemoteDreamConfig`] chat-serving block (connect XOR ephemeral), default OFF so the
+/// extraction layer stays 100% deterministic unless the operator opts in. Rides
+/// [`RemoteDreamConfig`] rather than a bespoke type — the distill pass is another single-turn chat
+/// consumer; the only difference from dream is a typically larger model (hence the
+/// `provision_timeout_s` override on the remote block, for a 30B-class weight pull).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct DistillLlmConfig {
+    /// Run the distill model pass at all (default false — opt in explicitly). When false, the
+    /// deterministic extraction still runs; only the model columns stay unfilled.
+    pub enabled: bool,
+    /// Which chat server serves the distill turns (connect XOR ephemeral). Absent
+    /// `[llm.distill.remote]` → [`RemoteDreamConfig::default`] (a local-Ollama connect).
     pub remote: RemoteDreamConfig,
 }
 
@@ -784,6 +802,13 @@ pub struct RemoteDreamConfig {
     /// Per-request HTTP timeout, in seconds. A dense evidence pack against a remote model can take
     /// a while, so the default is generous.
     pub request_timeout_s: u64,
+    /// EPHEMERAL-only: override the box's boot/provision budget, in seconds. `None` → the backend
+    /// default ([`RemoteBackend::provision_timeout`]). A large model (30B-class) re-downloads its
+    /// weights from HuggingFace at cold start and can exceed the vLLM default (~15 min) — the
+    /// distill pass sets this higher (~25 min) so provisioning does not time out before the
+    /// weights land. Meaningless for a connect `endpoint` (no box is provisioned); simply
+    /// unused there.
+    pub provision_timeout_s: Option<u64>,
 }
 
 impl Default for RemoteDreamConfig {
@@ -798,6 +823,7 @@ impl Default for RemoteDreamConfig {
             gpu: None,
             auth_env: None,
             request_timeout_s: 300,
+            provision_timeout_s: None,
         }
     }
 }
@@ -809,9 +835,18 @@ impl RemoteDreamConfig {
         self.endpoint.is_some()
     }
 
-    /// EPHEMERAL mode: provision an on-demand box via `cookbook` for the dream pass.
+    /// EPHEMERAL mode: provision an on-demand box via `cookbook` for the pass.
     pub fn is_ephemeral(&self) -> bool {
         self.cookbook.is_some()
+    }
+
+    /// The box boot/provision budget: the configured `provision_timeout_s` override, else the
+    /// backend default ([`RemoteBackend::provision_timeout`]). The provisioning driver subtracts
+    /// its own safety margin from this before handing it to the recipe.
+    pub fn resolved_provision_timeout(&self) -> Duration {
+        self.provision_timeout_s
+            .map(Duration::from_secs)
+            .unwrap_or_else(|| self.backend.provision_timeout())
     }
 }
 

--- a/crates/rag-rat-llm/src/chat.rs
+++ b/crates/rag-rat-llm/src/chat.rs
@@ -312,7 +312,10 @@ fn chat_cookbook_input(remote: &RemoteDreamConfig) -> crate::CookbookInput {
         backend: remote.backend.as_db_str(),
         capability: "chat",
         request_timeout_s: remote.request_timeout_s,
-        provision_timeout_s: remote.backend.provision_timeout().as_secs().saturating_sub(20),
+        provision_timeout_s: remote
+            .resolved_provision_timeout()
+            .as_secs()
+            .saturating_sub(crate::cookbook::PROVISION_TEARDOWN_MARGIN_SECS),
         gpu: remote.gpu.clone(),
         num_ctx: None,
         server_concurrency: 1,
@@ -527,5 +530,21 @@ mod http_tests {
             input.provision_timeout_s,
             RemoteBackend::Vllm.provision_timeout().as_secs() - 20
         );
+    }
+
+    #[test]
+    fn chat_cookbook_input_honors_the_provision_timeout_override() {
+        // A `provision_timeout_s` override (the distill 30B-box knob) flows into the cookbook boot
+        // budget instead of the backend default, minus the same safety margin.
+        let remote = RemoteDreamConfig {
+            backend: RemoteBackend::Vllm,
+            endpoint: None,
+            cookbook: Some("@rag-rat/cookbook modal".to_string()),
+            model: "Qwen/Qwen3-30B-A3B-Instruct-2507-FP8".to_string(),
+            provision_timeout_s: Some(1500),
+            ..RemoteDreamConfig::default()
+        };
+        let input = chat_cookbook_input(&remote);
+        assert_eq!(input.provision_timeout_s, 1500 - 20, "override wins over the backend default");
     }
 }

--- a/crates/rag-rat-llm/src/cookbook.rs
+++ b/crates/rag-rat-llm/src/cookbook.rs
@@ -56,6 +56,13 @@ pub const COOKBOOK_INPUT_ENV: &str = "RAG_RAT_COOKBOOK_INPUT";
 /// + pulling a model can take a couple of minutes; 5 minutes is a generous ceiling.
 const PROVISION_TIMEOUT: Duration = Duration::from_secs(300);
 
+/// The gap between the RECIPE's own provisioning budget ([`CookbookInput::provision_timeout_s`])
+/// and the Rust-side handshake deadline: the input builders set the recipe budget this far UNDER
+/// the deadline so the recipe times out (clean provider-side teardown) BEFORE the Rust SIGKILL
+/// backstop fires. One source of truth so the builders' `- margin` and `provision`'s `+ margin`
+/// never drift.
+pub(crate) const PROVISION_TEARDOWN_MARGIN_SECS: u64 = 20;
+
 /// How long to wait after SIGTERM before escalating to SIGKILL during teardown. Unix-only: the
 /// SIGTERM→SIGKILL escalation (`teardown_group`, the signal handler, `abort_active_provisioning`)
 /// is all `#[cfg(unix)]`, so on Windows this const is dead (`-D dead-code` in CI).
@@ -283,10 +290,7 @@ impl CookbookProvisioner {
     /// `cookbook` resolution: a `.mjs`/`.js` path → `node <path>`; a `.ts` path → `npx tsx <path>`;
     /// anything else → `npx -y <cookbook>` (an npm package spec).
     pub fn provision(cookbook: &str, input: &CookbookInput) -> anyhow::Result<ProvisionedBox> {
-        // Backend-aware handshake deadline (vLLM's huge image needs longer than ollama/infinity);
-        // fall back to the default if `input.backend` is somehow unrecognized.
-        let timeout = RemoteBackend::from_db_str(input.backend)
-            .map_or(PROVISION_TIMEOUT, RemoteBackend::provision_timeout);
+        let timeout = provision_deadline(input);
         Self::provision_with_command(cookbook_command(cookbook), cookbook, input, timeout)
     }
 
@@ -521,6 +525,20 @@ impl CookbookProvisioner {
 /// Build the `CookbookInput` (the env-passed provisioning request) from an ephemeral remote config.
 /// Split out from `provision_and_build` so the config→input mapping — notably that the configured
 /// `backend`, `gpu`, and `num_ctx` are forwarded — is unit-testable without spawning a real recipe.
+/// The Rust-side handshake deadline for [`CookbookProvisioner::provision`]. The floor is
+/// backend-aware (vLLM's huge image needs longer than ollama/infinity; the default covers an
+/// unrecognized backend). A larger `provision_timeout_s` (the distill 30B box, whose weight pull
+/// exceeds the vLLM default) EXTENDS the deadline past that floor — we add back the teardown margin
+/// the input builder subtracted, so the recipe budget still expires ~20s first (clean provider
+/// teardown before the Rust SIGKILL backstop). The override can only lengthen the deadline, never
+/// starve a box below its backend floor.
+fn provision_deadline(input: &CookbookInput) -> Duration {
+    let backend_floor = RemoteBackend::from_db_str(input.backend)
+        .map_or(PROVISION_TIMEOUT, RemoteBackend::provision_timeout);
+    Duration::from_secs(input.provision_timeout_s + PROVISION_TEARDOWN_MARGIN_SECS)
+        .max(backend_floor)
+}
+
 fn cookbook_input_for(remote: &RemoteEmbeddingConfig) -> CookbookInput {
     CookbookInput {
         model: remote.model.trim().to_string(),
@@ -534,7 +552,11 @@ fn cookbook_input_for(remote: &RemoteEmbeddingConfig) -> CookbookInput {
         // Give the recipe a provisioning budget just under the Rust hard ceiling (backend-aware:
         // vLLM's large image needs longer), so ITS budget runs out first (clean provider-side
         // teardown) before the Rust SIGKILL backstop fires.
-        provision_timeout_s: remote.backend.provision_timeout().as_secs().saturating_sub(20),
+        provision_timeout_s: remote
+            .backend
+            .provision_timeout()
+            .as_secs()
+            .saturating_sub(PROVISION_TEARDOWN_MARGIN_SECS),
         // The configured GPU (provider-specific; validated by the provider at provision time). The
         // recipe picks its own default when `None`. Config validation guarantees `gpu` is only set
         // in ephemeral mode, which is the only mode reaching this function.
@@ -1232,6 +1254,32 @@ mod tests {
             num_ctx: None,
             server_concurrency: 32,
         }
+    }
+
+    #[test]
+    fn provision_deadline_extends_for_a_larger_override_but_floors_at_the_backend_default() {
+        // No override baseline: an ollama box (recipe budget 280 = 300 - margin) gets exactly the
+        // backend floor, so the recipe still expires the margin before this deadline.
+        assert_eq!(provision_deadline(&input()), Duration::from_secs(300));
+
+        // The distill 30B case: a `provision_timeout_s` recipe budget of 1480 (= 1500 - margin)
+        // must EXTEND the Rust deadline to 1500s — otherwise the box is SIGKILLed at the vLLM
+        // default (900s) long before the 30B weights finish pulling.
+        let big = CookbookInput {
+            backend: "vllm",
+            provision_timeout_s: 1500 - PROVISION_TEARDOWN_MARGIN_SECS,
+            ..input()
+        };
+        assert_eq!(provision_deadline(&big), Duration::from_secs(1500));
+        // The recipe budget stays the margin under the Rust deadline (recipe tears down first).
+        assert_eq!(
+            provision_deadline(&big).as_secs() - big.provision_timeout_s,
+            PROVISION_TEARDOWN_MARGIN_SECS,
+        );
+
+        // A too-small override cannot starve a box below its backend floor (vLLM = 900s).
+        let tiny = CookbookInput { backend: "vllm", provision_timeout_s: 10, ..input() };
+        assert_eq!(provision_deadline(&tiny), RemoteBackend::Vllm.provision_timeout());
     }
 
     #[test]


### PR DESCRIPTION
Adds the `[llm.distill]` configuration block — the config half of the distill LLM pass (#704). No runtime consumer yet; the drain scheduler wires it up in a later slice.

## What changed

- **`[llm.distill]` block.** Same shape as `[llm.dream]` — an `enabled` gate plus a chat-serving block — riding `RemoteDreamConfig`. Default OFF, so the deterministic extraction is unchanged until an operator opts in. Independent of dream's gate. Relative cookbook recipe paths resolve against the config dir, matching dream.
- **`provision_timeout_s` override.** A model-size-aware boot budget on the remote chat config: a 30B-class model re-downloads its weights at cold start and can exceed the vLLM default (~15 min), so the distill box needs ~25 min. The override flows into **both** the recipe budget **and** the Rust-side handshake deadline — previously the deadline was fixed at the backend default, so a large box would be SIGKILLed before its weights landed. It may only *lengthen* past the backend floor; a value below the floor is rejected at parse time so it can't starve the recipe. The teardown margin between recipe budget and Rust deadline is now one shared constant.
- **Section-aware shared validation.** `RemoteDreamConfig` is now parsed for both `[llm.dream.remote]` and `[llm.distill.remote]`, so its validation errors (missing model, ambiguous mode, unknown backend, empty gpu, below-floor timeout, …) name the block the operator actually wrote instead of hardcoding one section.

## Verification

- Full workspace `cargo nextest run --workspace --no-default-features --locked`: 3247 passed (incl. new distill config + provision-deadline tests).
- All four CI clippy gates green (`-D warnings --locked`); `cargo +nightly fmt` clean.
- New tests cover: default-off + serving default, independent gates, ephemeral parse + override honored, the override extending the Rust deadline (and flooring at the backend default), below-floor rejection, connect-mode passthrough, and section-aware error wording for both the dream-specific and the embedding-shared error variants.

Part of #704.