### PR TITLE
feat(oplog): sealed /3 content authoring (unwired) — XChaCha20-Poly1305 with a random wire nonce (#608)

### DIFF
--- a/crates/rag-rat-oplog/src/account/content/author.rs
+++ b/crates/rag-rat-oplog/src/account/content/author.rs
@@ -28,16 +28,18 @@
 //! minting from the plain candidate tail (below) is the accepted tail.
 
 use anyhow::Context;
-use rusqlite::{Connection, OptionalExtension, Transaction, params};
+use rusqlite::{Connection, OptionalExtension, Transaction, TransactionBehavior, params};
 
 use super::super::bootstrap::{self, LocalAccountRef};
+use super::super::keywrap::ContentKey;
 use super::super::limits::CONTENT_ENVELOPE_MAX_BYTES;
+use super::super::secrets::{self, SealingKeyOutcome};
 use super::super::{AccountId, storage as account_storage};
 use super::envelope::{self, ContentEntryHeader, VerifiedContentEntry};
 use super::storage as content_storage;
 use crate::op::{self, DeviceFingerprint, MemoryOp};
 use crate::stream::StreamId;
-use crate::{content_projection, local_device};
+use crate::{LocalDevice, content_projection, local_device};
 
 type EntryHash = [u8; 32];
 
@@ -95,6 +97,28 @@ const CONTENT_OP_BODY_MAX_BYTES: usize =
 /// already reserves for.
 pub fn content_op_is_authorable(op: &MemoryOp) -> bool {
     op::encode(op).len() <= CONTENT_OP_BODY_MAX_BYTES
+}
+
+/// The AEAD expansion a suite-1 seal adds to the op body on the wire: the 24-byte XChaCha nonce +
+/// the 16-byte Poly1305 tag ([`envelope::SEALED_NONCE_LEN`] + [`envelope::SEALED_AEAD_TAG_LEN`]).
+/// [`CONTENT_OP_BODY_MAX_BYTES`] reserves ZERO AEAD overhead (it mirrors the suite-0 sign check),
+/// so the sealed body bound subtracts this — otherwise a sealed op between the two bounds would
+/// pass [`content_op_is_sealed_authorable`] yet `bail!` the batch at sign time (the #680 wedge, on
+/// sealed streams).
+const CONTENT_SEALED_AEAD_OVERHEAD_BYTES: usize =
+    envelope::SEALED_NONCE_LEN + envelope::SEALED_AEAD_TAG_LEN;
+
+/// The largest op BODY (canonical CBOR) that always fits inside a signed SUITE-1 `/3` entry: the
+/// plaintext body bound ([`CONTENT_OP_BODY_MAX_BYTES`]) minus the sealed AEAD expansion.
+const CONTENT_SEALED_OP_BODY_MAX_BYTES: usize =
+    CONTENT_OP_BODY_MAX_BYTES - CONTENT_SEALED_AEAD_OVERHEAD_BYTES;
+
+/// The sealed-path twin of [`content_op_is_authorable`]: whether `op` fits a signed suite-1 `/3`
+/// entry once the AEAD nonce + tag are added to its body (S2, #608). C5b's live reconcile uses this
+/// to QUARANTINE an un-authorable op on a sealed stream — exactly as the suite-0 predicate does on
+/// a plaintext one — instead of `bail!`ing the whole batch at sign time.
+pub fn content_op_is_sealed_authorable(op: &MemoryOp) -> bool {
+    op::encode(op).len() <= CONTENT_SEALED_OP_BODY_MAX_BYTES
 }
 
 /// The `/3` chain tail for one `(stream, author, device)` coordinate: its highest-`seq` entry.
@@ -197,6 +221,316 @@ pub fn author_content_batch_in_tx(
     Ok(authored)
 }
 
+/// The privacy intent for a `/3` content batch (sync phase C5, #608). The caller states it
+/// EXPLICITLY — wrap presence is a downgrade-ratchet INPUT, never the privacy oracle: a private
+/// stream's accepted-wrap set can legitimately empty under sync lag or a retro-condemn, and
+/// treating "no wrap ⇒ public" would author plaintext on a private stream (a confidentiality leak).
+///
+/// UNWIRED in C5a: the live memory path still authors through [`author_content_batch_in_tx`]
+/// (suite 0). This policy-aware, self-transacting seam is exercised only by tests until C5b lands
+/// decrypt-at-projection, the read-side keyring, and the `sync enable` intent source. Authoring a
+/// sealed entry into the live path before C5b's decrypt exists triggers the reconcile anti-join
+/// duplication loop `content_projection` documents, which is why nothing live calls this yet.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SealPolicy {
+    /// Author plaintext suite-0 entries — REFUSED on a stream that has ratcheted to sealed.
+    Plaintext,
+    /// Author sealed suite-1 entries under the stream's current content key; fail closed (bail the
+    /// whole batch) if no key can be resolved — never plaintext-fallback, never a plaintext park.
+    Sealed,
+}
+
+/// Author `ops` as owner-authored `/3` content on `stream_id` under an explicit [`SealPolicy`],
+/// managing its OWN transactions — unlike [`author_content_batch_in_tx`], which runs inside a
+/// caller's txn. `Sealed` acquires the stream's content key across THREE transactions (lazy
+/// rotation; then a key resolve whose security-event writes autocommit; then seal + author +
+/// verify-accepted), so it cannot nest inside a caller txn. Returns the authored entry hashes in
+/// authoring order. Requires the store's local account to be minted already.
+///
+/// UNWIRED (C5a): nothing live calls this — see [`SealPolicy`].
+pub fn author_content_batch(
+    conn: &Connection,
+    stream_id: StreamId,
+    ops: &[MemoryOp],
+    policy: SealPolicy,
+    now_ms: i64,
+) -> anyhow::Result<Vec<EntryHash>> {
+    // An empty batch authors nothing, so it must run NO key management: the `Sealed` arm would
+    // otherwise rotate or mint + commit the stream's first `StreamKeyWrap`, and on an unkeyed owned
+    // stream that committed wrap arms the downgrade ratchet — permanently blocking later plaintext
+    // authoring after a call that looked like a no-op. Short-circuit before EITHER arm's
+    // ratchet-affecting side effects.
+    if ops.is_empty() {
+        return Ok(Vec::new());
+    }
+    match policy {
+        SealPolicy::Plaintext => author_plaintext_batch_ratcheted(conn, stream_id, ops, now_ms),
+        SealPolicy::Sealed => author_sealed_batch(conn, stream_id, ops, now_ms),
+    }
+}
+
+/// The `SealPolicy::Plaintext` arm: refuse if the stream has ratcheted to sealed, then author
+/// suite-0 through the existing in-tx seam — all in ONE self-owned txn so the ratchet gate and the
+/// authoring commit atomically (a concurrent wrap/seal cannot slip between them).
+fn author_plaintext_batch_ratcheted(
+    conn: &Connection,
+    stream_id: StreamId,
+    ops: &[MemoryOp],
+    now_ms: i64,
+) -> anyhow::Result<Vec<EntryHash>> {
+    let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
+    // Downgrade ratchet: once a stream carries an accepted StreamKeyWrap (any epoch) OR an accepted
+    // suite-1 entry, plaintext authoring is a silent downgrade — refuse it.
+    let account_id = require_local_account_id(&tx)?;
+    if stream_has_sealed_ratchet(&tx, account_id, stream_id)? {
+        anyhow::bail!(
+            "refusing plaintext /3 authoring on a stream that has ratcheted to sealed (an \
+             accepted key wrap or a sealed entry exists)"
+        );
+    }
+    let authored = author_content_batch_in_tx(&tx, stream_id, ops, now_ms)?;
+    tx.commit()?;
+    Ok(authored)
+}
+
+/// The `SealPolicy::Sealed` arm: the S4 three-txn key acquisition, then seal + author. Fail-closed
+/// — if no content key resolves, the whole batch bails, NEVER plaintext-fallback and NEVER a
+/// plaintext park (the row simply never enters the tables; the reconcile anti-join is the retry
+/// once this device gains a key).
+fn author_sealed_batch(
+    conn: &Connection,
+    stream_id: StreamId,
+    ops: &[MemoryOp],
+    now_ms: i64,
+) -> anyhow::Result<Vec<EntryHash>> {
+    // Authoring needs a local device, so minting it here is fine; `current_sealing_key` must NOT
+    // mint (a read API), so we resolve it once and hand it in.
+    let device = local_device(conn, now_ms)?;
+    let account_id = require_local_account_id(conn)?;
+
+    // (txn A) Lazy rotation on device removal, committed on its OWN txn so a rotation (a fresh
+    // higher-epoch wrap) survives a later authoring failure. Every RotationOutcome is non-error: an
+    // owner rotates, a member sees StaleButNotOwner and seals under the current key — only an
+    // infra/DB failure is `Err`, so the outcome is intentionally discarded.
+    {
+        let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
+        secrets::ensure_stream_key_current_in_tx(&tx, stream_id, now_ms)?;
+        tx.commit()?;
+    }
+
+    // (autocommit) Resolve the content key. `current_sealing_key`'s `sync_security_events` INSERTs
+    // autocommit on `&Connection`, so it MUST run outside any txn that could roll back.
+    let key = match secrets::current_sealing_key(conn, account_id, stream_id, &device, now_ms)? {
+        SealingKeyOutcome::Ready(key) => key,
+        // Never keyed: an owner mints the first key (its own txn) and re-resolves; a non-owner's
+        // mint bails (owner-gated), fail-closing the whole mutation.
+        SealingKeyOutcome::NoCurrentKey =>
+            mint_first_key_then_resolve(conn, stream_id, account_id, &device, now_ms)?,
+        // Fail closed on a Sealed-intent stream: bail, never author plaintext.
+        SealingKeyOutcome::NotRecipient | SealingKeyOutcome::FailedClosed => anyhow::bail!(
+            "cannot seal /3 content: no resolvable content key for this device (fail-closed)"
+        ),
+    };
+
+    // The `(key_epoch, key_id)` the resolved key names — the baseline txn B re-validates under its
+    // write lock. Read via `select_current_sealing_wrap` (a PURE read), never `current_sealing_key`
+    // (whose adoption cross-check autocommits a security-event row and so must stay here, pre-txn).
+    let resolved = secrets::select_current_sealing_wrap(conn, account_id, stream_id)?.context(
+        "sealed /3 authoring: a content key resolved but the current sealing wrap is empty",
+    )?;
+    // Close the resolution window itself: a rotation committed between `current_sealing_key` and
+    // this read would leave `resolved` naming a key this device did NOT recover, so require the
+    // selection to still name the resolved key before adopting it as the baseline.
+    anyhow::ensure!(
+        resolved.key_id == key.key_id(),
+        "sealed /3 authoring: the sealing selection changed during key resolution (retry)",
+    );
+
+    // (txn B) Seal + author + verify-accepted, re-validating the selection under the write lock so
+    // a rotation that committed after resolution can never make us seal under the stale key.
+    let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
+    revalidate_sealing_selection(&tx, account_id, stream_id, &resolved)?;
+    let authored = seal_and_author_in_tx(&tx, stream_id, ops, &key, &device, now_ms)?;
+    tx.commit()?;
+    Ok(authored)
+}
+
+/// Re-confirm, under txn B's IMMEDIATE write lock, that `stream_id`'s current sealing selection is
+/// STILL the `(key_epoch, key_id)` the pre-txn resolution named.
+///
+/// A `DeviceRemove` + rotation can commit a fresh higher-epoch `StreamKeyWrap` in the autocommit
+/// window between resolving the key ([`author_sealed_batch`]) and opening this txn. Sealing under
+/// the now-stale key would let a device that rotation revoked decrypt this post-removal entry — a
+/// confidentiality regression, and NOT the §15 sync-lag window, because the removal is LOCALLY
+/// committed. Because txn B holds the write lock, no rotation can commit until it ends, so a
+/// selection that still matches here is authoritative for the seal that follows. On mismatch, bail
+/// so the caller retries under the fresh key. A PURE read (never `current_sealing_key`).
+fn revalidate_sealing_selection(
+    tx: &Transaction<'_>,
+    account_id: AccountId,
+    stream_id: StreamId,
+    resolved: &secrets::SelectedWrap,
+) -> anyhow::Result<()> {
+    let current = secrets::select_current_sealing_wrap(tx, account_id, stream_id)?.context(
+        "sealed /3 authoring: the stream's sealing wrap vanished under the authoring lock (a \
+         concurrent condemn); retry",
+    )?;
+    anyhow::ensure!(
+        current.key_epoch == resolved.key_epoch && current.key_id == resolved.key_id,
+        "sealed /3 authoring: the stream's sealing key rotated between resolution and sealing \
+         (was epoch {}, now epoch {}); retry with the fresh key",
+        resolved.key_epoch,
+        current.key_epoch,
+    );
+    Ok(())
+}
+
+/// A stream that has never been keyed: mint the first content key in its OWN txn, then re-resolve.
+/// `mint_and_author_stream_key_wrap_in_tx` is owner-gated + verify-accepted, so a non-owner (or a
+/// stream this account does not own) makes it `Err` here — which fail-closes the sealed mutation (a
+/// non-owner `NoCurrentKey` bails, never plaintext).
+fn mint_first_key_then_resolve(
+    conn: &Connection,
+    stream_id: StreamId,
+    account_id: AccountId,
+    device: &LocalDevice,
+    now_ms: i64,
+) -> anyhow::Result<ContentKey> {
+    {
+        let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
+        secrets::mint_and_author_stream_key_wrap_in_tx(&tx, stream_id, now_ms)?;
+        tx.commit()?;
+    }
+    match secrets::current_sealing_key(conn, account_id, stream_id, device, now_ms)? {
+        SealingKeyOutcome::Ready(key) => Ok(key),
+        _ => anyhow::bail!(
+            "sealed /3 authoring: the freshly minted content key did not resolve to Ready \
+             (fail-closed)"
+        ),
+    }
+}
+
+/// The `SealPolicy::Sealed` txn B core — mirrors [`author_content_batch_in_tx`] but SEALS each op
+/// under `key` (suite 1). VERIFY-ACCEPTED reads `content_entry_status` ONLY, NEVER "the projection
+/// contains my nodes" (false for a sealed entry until C5b's decrypt-at-projection lands —
+/// `op::decode` fails on ciphertext). For the same reason the plaintext seam's
+/// `reproject_accepted_content_stream` call is INTENTIONALLY omitted: reprojecting a sealed stream
+/// pre-C5b would skip every sealed entry, and wiring that into the live reconcile is the anti-join
+/// duplication trap C5a avoids by staying unwired.
+fn seal_and_author_in_tx(
+    tx: &Transaction<'_>,
+    stream_id: StreamId,
+    ops: &[MemoryOp],
+    key: &ContentKey,
+    device: &LocalDevice,
+    now_ms: i64,
+) -> anyhow::Result<Vec<EntryHash>> {
+    let LocalAccountRef { account_id, genesis_hash } = bootstrap::local_account_ref(tx)?
+        .context("cannot author sealed /3 content before the store's local account is minted")?;
+    let fingerprint = device.fingerprint();
+    let auth_len = account_storage::account_effective_count(tx, account_id)?;
+
+    let mut authored = Vec::with_capacity(ops.len());
+    for op in ops {
+        let (seq, prev_hash) = match content_chain_tail(tx, stream_id, account_id, fingerprint)? {
+            Some(tail) => (
+                tail.seq
+                    .checked_add(1)
+                    .context("/3 content chain tail is at u64::MAX seq; cannot extend")?,
+                Some(tail.entry_hash),
+            ),
+            None => (0, None),
+        };
+        // `crypto_suite`/`key_id` stay 0/None here — `seal_and_sign_content_entry` finalizes them
+        // to suite 1 + the key's id, so a suite-1-over-plaintext header is unconstructible.
+        let header = ContentEntryHeader {
+            stream_id,
+            author_account_id: account_id,
+            device_fingerprint: fingerprint,
+            seq,
+            lamport: seq,
+            prev_hash,
+            grant_id: None,
+            roster_ref: genesis_hash,
+            owner_auth_len: auth_len,
+            author_auth_len: auth_len,
+            crypto_suite: 0,
+            key_id: None,
+        };
+        let op_bytes = op::encode(op);
+        let signed =
+            envelope::seal_and_sign_content_entry(device.secret(), &header, &op_bytes, key)?;
+        let verified = VerifiedContentEntry {
+            header: signed.header,
+            payload: signed.payload,
+            header_bytes: signed.header_bytes,
+            entry_hash: signed.entry_hash,
+        };
+        content_storage::insert_candidate(tx, &verified, &signed.signed_bytes, now_ms)?;
+        authored.push(verified.entry_hash);
+    }
+
+    content_storage::refold_content_stream(tx, stream_id)?;
+
+    for entry_hash in &authored {
+        match content_status(tx, entry_hash)?.as_deref() {
+            Some("accepted") => {},
+            other => anyhow::bail!(
+                "sealed /3 content entry did not fold accepted (status {other:?}); rolling back \
+                 the batch",
+            ),
+        }
+    }
+    Ok(authored)
+}
+
+/// The store's local account id, resolved WITHOUT minting — it must already exist (the caller mints
+/// it before the sealed author path, exactly as [`author_content_batch_in_tx`] requires).
+fn require_local_account_id(conn: &Connection) -> anyhow::Result<AccountId> {
+    Ok(bootstrap::local_account_ref(conn)?
+        .context("cannot author /3 content before the store's local account is minted")?
+        .account_id)
+}
+
+/// Whether `stream_id` has ratcheted to sealed: it has an accepted `StreamKeyWrap` (any epoch) OR
+/// an accepted suite-1 `/3` entry. Either makes plaintext authoring a silent downgrade. DERIVED ON
+/// READ (no sticky flag), so it converges: a retro-condemn that empties the wrap set still sees
+/// surviving sealed entries, and a re-minted wrap re-arms the gate. Wrap presence is one ratchet
+/// INPUT, never the sole privacy oracle.
+fn stream_has_sealed_ratchet(
+    tx: &Transaction<'_>,
+    account_id: AccountId,
+    stream_id: StreamId,
+) -> anyhow::Result<bool> {
+    if secrets::select_current_sealing_wrap(tx, account_id, stream_id)?.is_some() {
+        return Ok(true);
+    }
+    stream_has_accepted_sealed_entry(tx, stream_id)
+}
+
+/// Whether any accepted `/3` entry on `stream_id` is suite-1 (sealed). There is no `crypto_suite`
+/// column, so each accepted entry's header is decoded from its stored signed bytes; a row whose
+/// bytes fail to decode cannot be a valid suite-1 entry and is skipped. Early-returns on the first
+/// match.
+fn stream_has_accepted_sealed_entry(
+    tx: &Transaction<'_>,
+    stream_id: StreamId,
+) -> anyhow::Result<bool> {
+    let mut stmt = tx.prepare(
+        "SELECT signed_bytes FROM content_entries WHERE stream_id = ?1 AND accepted = 1",
+    )?;
+    let mut rows = stmt.query(params![stream_id.to_bytes().as_slice()])?;
+    while let Some(row) = rows.next()? {
+        let signed_bytes: Vec<u8> = row.get(0)?;
+        if let Ok(signed) = envelope::decode_content_signed(&signed_bytes)
+            && signed.header.crypto_suite != 0
+        {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
 /// Whether the `/2` stream's `/3` content chain is EMPTY — no `content_entries` row on it at all.
 /// Under the single local writer the store's own account+device are the only chain on the stream,
 /// so "no rows for this stream" is the whole chain: the genesis case where the memory reconcile
@@ -265,6 +599,7 @@ mod tests {
     use rusqlite::{Connection, TransactionBehavior};
 
     use super::*;
+    use crate::account::{account_ingest, ensure_owned_stream_v2_in_tx, local_account};
     use crate::op::{EdgeSpec, NodeContent, NodeId};
 
     const NOW: i64 = 1_700_000_000_000;
@@ -757,5 +1092,410 @@ mod tests {
         let head = tail(&conn, stream, account).expect("populated chain has a tail");
         assert_eq!(head.seq, 1, "the tail seq is the highest authored seq");
         assert_eq!(head.entry_hash, hashes[1], "the tail names the highest-seq entry");
+    }
+
+    // ── C5a: the sealed suite-1 author seam (UNWIRED) ──
+
+    /// Mint the store's local account and publish an owned `/2` stream via the REAL ownership seam
+    /// (`ensure_owned_stream_v2_in_tx`) — the sealed mint needs a genuine effective `StreamOwn`,
+    /// not the direct-seeded `account_stream_ownership` shortcut the plaintext acceptance tests
+    /// use.
+    fn owned_v2(conn: &Connection) -> (AccountId, StreamId) {
+        let account = local_account(conn, NOW).expect("mint local account");
+        let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate).unwrap();
+        let stream =
+            ensure_owned_stream_v2_in_tx(&tx, "repo-a", NOW).expect("publish owned /2 stream");
+        tx.commit().unwrap();
+        (account, stream)
+    }
+
+    #[test]
+    fn a_sealed_batch_authors_suite_1_entries_that_fold_accepted_locally() {
+        let conn = db();
+        let (account, stream) = owned_v2(&conn);
+        let hashes = author_content_batch(
+            &conn,
+            stream,
+            &[node_create("n1", "first"), node_update("n1", "second")],
+            SealPolicy::Sealed,
+            NOW,
+        )
+        .expect("seal + author");
+        assert_eq!(hashes.len(), 2, "two ops author two sealed entries");
+        for entry_hash in &hashes {
+            assert_eq!(
+                stored_status(&conn, entry_hash).as_deref(),
+                Some("accepted"),
+                "a sealed entry folds accepted locally (acceptance is key-independent)",
+            );
+            let header = header_of(&conn, entry_hash);
+            assert_eq!(header.crypto_suite, 1, "authored as suite 1");
+            assert!(header.key_id.is_some(), "a sealed entry carries a key_id");
+        }
+        // The first-key mint left an accepted content-key wrap on the secrets log.
+        assert!(
+            secrets::select_current_sealing_wrap(&conn, account, stream).unwrap().is_some(),
+            "a content key was minted for the stream",
+        );
+    }
+
+    #[test]
+    fn a_sealed_entry_folds_accepted_through_content_ingest_on_a_keyless_peer() {
+        // S3 FOLD-FIREWALL TRIPWIRE: acceptance of a sealed `/3` entry is header/citation-level, so
+        // a peer that replicated the account roster but never received the content key still folds
+        // it `accepted`. This is the coverage the account-log and decode-only sealed tests don't
+        // provide — a suite-1 entry driven through `content_ingest` + refold.
+        let author = db();
+        let (account, stream) = owned_v2(&author);
+        let hashes = author_content_batch(
+            &author,
+            stream,
+            &[node_create("n1", "secret")],
+            SealPolicy::Sealed,
+            NOW,
+        )
+        .expect("seal + author");
+        let sealed_bytes: Vec<u8> = author
+            .query_row(
+                "SELECT signed_bytes FROM content_entries WHERE entry_hash = ?1",
+                [hashes[0].as_slice()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            envelope::decode_content_signed(&sealed_bytes).unwrap().header.crypto_suite,
+            1,
+            "the authored entry is sealed",
+        );
+
+        // The author's CONTROL log (genesis + StreamOwn) is the public roster a peer replicates.
+        // The secrets-log StreamKeyWrap is deliberately NOT replicated: the peer holds no
+        // content key.
+        let control: Vec<Vec<u8>> = {
+            let mut stmt = author
+                .prepare(
+                    "SELECT signed_bytes FROM account_entries
+                     WHERE account_id = ?1 AND log_id = 0 ORDER BY seq",
+                )
+                .unwrap();
+            stmt.query_map([account.to_bytes().as_slice()], |row| row.get(0))
+                .unwrap()
+                .collect::<rusqlite::Result<Vec<_>>>()
+                .unwrap()
+        };
+
+        let peer = db();
+        for bytes in &control {
+            account_ingest(&peer, bytes, NOW).expect("replicate the account control log");
+        }
+        // The peer cannot resolve the content key — no wrap was replicated.
+        assert!(
+            secrets::select_current_sealing_wrap(&peer, account, stream).unwrap().is_none(),
+            "the keyless peer has no content key for the stream",
+        );
+
+        // Ingest the sealed content entry and settle its deferred acceptance fold.
+        content_storage::content_ingest(&peer, &sealed_bytes, NOW).expect("ingest sealed entry");
+        content_storage::settle_pending_content_refolds(&peer).expect("settle the refold");
+
+        let (status, accepted): (String, i64) = peer
+            .query_row(
+                "SELECT s.status, e.accepted FROM content_entries e
+                 JOIN content_entry_status s ON s.entry_hash = e.entry_hash
+                 WHERE e.entry_hash = ?1",
+                [hashes[0].as_slice()],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(
+            (status.as_str(), accepted),
+            ("accepted", 1),
+            "the sealed entry folds accepted on a peer with no content key",
+        );
+    }
+
+    #[test]
+    fn sealing_a_stream_the_account_does_not_own_bails_and_leaks_no_row() {
+        // A Sealed-intent stream the account does NOT own: NoCurrentKey → try to mint the first
+        // key, but the mint is owner-gated on an effective StreamOwn, so it bails → the
+        // whole sealed batch fails closed. NO plaintext-fallback, and no row leaked into
+        // any projectable state.
+        let conn = db();
+        local_account(&conn, NOW).expect("mint local account");
+        let unowned = StreamId::from_bytes([0x99; 32]);
+        let result = author_content_batch(
+            &conn,
+            unowned,
+            &[node_create("n1", "x")],
+            SealPolicy::Sealed,
+            NOW,
+        );
+        assert!(result.is_err(), "a keyless Sealed stream fails closed");
+        let entries: i64 =
+            conn.query_row("SELECT count(*) FROM content_entries", [], |row| row.get(0)).unwrap();
+        assert_eq!(entries, 0, "no /3 content row survives the fail-closed bail");
+        let projected: i64 = conn
+            .query_row("SELECT count(*) FROM content_projected_nodes", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(projected, 0, "no projection row leaks from the bailed sealed batch");
+    }
+
+    #[test]
+    fn plaintext_authoring_is_refused_after_a_stream_has_sealed() {
+        let conn = db();
+        let (_account, stream) = owned_v2(&conn);
+        // Sealing mints a wrap AND authors a suite-1 entry — both downgrade-ratchet inputs.
+        author_content_batch(&conn, stream, &[node_create("n1", "x")], SealPolicy::Sealed, NOW)
+            .expect("seal");
+        let before: i64 = conn
+            .query_row(
+                "SELECT count(*) FROM content_entries WHERE stream_id = ?1",
+                [stream.to_bytes().as_slice()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        // Plaintext authoring on the now-sealed stream is refused — no silent downgrade to
+        // cleartext.
+        let result = author_content_batch(
+            &conn,
+            stream,
+            &[node_create("n2", "y")],
+            SealPolicy::Plaintext,
+            NOW,
+        );
+        assert!(result.is_err(), "plaintext authoring is refused after the stream sealed");
+        let after: i64 = conn
+            .query_row(
+                "SELECT count(*) FROM content_entries WHERE stream_id = ?1",
+                [stream.to_bytes().as_slice()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(before, after, "the refused plaintext batch stored no row");
+    }
+
+    #[test]
+    fn the_downgrade_ratchet_fires_on_an_accepted_wrap_or_an_accepted_sealed_entry() {
+        let conn = db();
+        let (account, stream) = owned_v2(&conn);
+
+        // A fresh owned stream (plaintext-only) does not ratchet.
+        {
+            let tx = conn.unchecked_transaction().unwrap();
+            assert!(
+                !stream_has_sealed_ratchet(&tx, account, stream).unwrap(),
+                "a fresh owned stream is not sealed",
+            );
+        }
+
+        // The WRAP branch: mint a wrap only (no content) → the ratchet fires on wrap presence.
+        {
+            let tx = Transaction::new_unchecked(&conn, TransactionBehavior::Immediate).unwrap();
+            secrets::mint_and_author_stream_key_wrap_in_tx(&tx, stream, NOW).unwrap();
+            tx.commit().unwrap();
+        }
+        {
+            let tx = conn.unchecked_transaction().unwrap();
+            assert!(
+                stream_has_sealed_ratchet(&tx, account, stream).unwrap(),
+                "an accepted StreamKeyWrap ratchets the stream",
+            );
+        }
+
+        // The SEALED-ENTRY branch, independent of any wrap: a different stream with an accepted
+        // suite-1 row but NO wrap still ratchets (proves the OR clause, not just wrap-presence).
+        let other = StreamId::from_bytes([0x7a; 32]);
+        let device = local_device(&conn, NOW).unwrap();
+        let key = ContentKey::from_seed(&[0x40; 32]);
+        let header = ContentEntryHeader {
+            stream_id: other,
+            author_account_id: account,
+            device_fingerprint: device.fingerprint(),
+            seq: 0,
+            lamport: 0,
+            prev_hash: None,
+            grant_id: None,
+            roster_ref: genesis_ref(&conn),
+            owner_auth_len: 0,
+            author_auth_len: 0,
+            crypto_suite: 0,
+            key_id: None,
+        };
+        // The nonce value is not load-bearing here (only suite-1 presence arms the ratchet), so
+        // seal via the random-nonce production entry point rather than a fixed injected
+        // nonce.
+        let signed =
+            envelope::seal_and_sign_content_entry(device.secret(), &header, &[0x01], &key).unwrap();
+        conn.execute(
+            "INSERT INTO content_entries(
+                 entry_hash, stream_id, author_account_id, device_fingerprint, seq, prev_hash,
+                 grant_id, roster_ref, owner_auth_len, author_auth_len, accepted, signed_bytes,
+                 received_at_ms)
+             VALUES(?1, ?2, ?3, ?4, ?5, NULL, NULL, ?6, ?7, ?7, 1, ?8, 0)",
+            params![
+                signed.entry_hash.as_slice(),
+                other.to_bytes().as_slice(),
+                account.to_bytes().as_slice(),
+                device.fingerprint().to_bytes().as_slice(),
+                0_u64.to_be_bytes().as_slice(),
+                genesis_ref(&conn).as_slice(),
+                0_u64.to_be_bytes().as_slice(),
+                signed.signed_bytes,
+            ],
+        )
+        .unwrap();
+        let tx = conn.unchecked_transaction().unwrap();
+        assert!(
+            secrets::select_current_sealing_wrap(&tx, account, other).unwrap().is_none(),
+            "the other stream has no wrap",
+        );
+        assert!(
+            stream_has_sealed_ratchet(&tx, account, other).unwrap(),
+            "an accepted sealed entry ratchets the stream even with no wrap",
+        );
+    }
+
+    #[test]
+    fn plaintext_policy_authors_suite_0_on_a_fresh_stream_unchanged() {
+        // `SealPolicy::Plaintext` on a never-sealed owned stream authors suite-0 through the
+        // existing in-tx seam — public authoring is unchanged.
+        let conn = db();
+        let stream = StreamId::from_bytes(STREAM_A);
+        owned_stream_account(&conn, stream);
+        let hashes = author_content_batch(
+            &conn,
+            stream,
+            &[node_create("n1", "x")],
+            SealPolicy::Plaintext,
+            NOW,
+        )
+        .expect("plaintext author");
+        assert_eq!(stored_status(&conn, &hashes[0]).as_deref(), Some("accepted"));
+        let header = header_of(&conn, &hashes[0]);
+        assert_eq!(header.crypto_suite, 0, "the Plaintext policy authors suite 0");
+        assert!(header.key_id.is_none(), "a suite-0 entry has no key_id");
+    }
+
+    #[test]
+    fn content_op_is_sealed_authorable_reserves_the_aead_overhead() {
+        // The sealed body bound is exactly 40 bytes (24 nonce + 16 tag) tighter than the plaintext
+        // one, so a sealed op can never mint an un-signable entry.
+        assert_eq!(CONTENT_SEALED_OP_BODY_MAX_BYTES, CONTENT_OP_BODY_MAX_BYTES - 40);
+        let at = node_create_sized("mem_at", CONTENT_SEALED_OP_BODY_MAX_BYTES);
+        assert_eq!(op::encode(&at).len(), CONTENT_SEALED_OP_BODY_MAX_BYTES, "sized on the nose");
+        assert!(content_op_is_sealed_authorable(&at), "an op at the sealed bound is authorable");
+        let over = node_create_sized("mem_over", CONTENT_SEALED_OP_BODY_MAX_BYTES + 1);
+        assert!(
+            !content_op_is_sealed_authorable(&over),
+            "one byte over the sealed bound is quarantined",
+        );
+
+        // Drift guard: a body at the sealed bound, sealed under the WIDEST header, signs at or
+        // under the §18a envelope cap — the reserve is enough (mirrors the plaintext
+        // overhead guard).
+        let secret = crate::device::DeviceSecret::from_seed(&[9; 32]);
+        let key = ContentKey::from_seed(&[0x20; 32]);
+        let header = ContentEntryHeader {
+            stream_id: StreamId::from_bytes([0x11; 32]),
+            author_account_id: AccountId::from_bytes([0x22; 32]),
+            device_fingerprint: secret.public().fingerprint(),
+            seq: u64::MAX,
+            lamport: u64::MAX,
+            prev_hash: Some([0x33; 32]),
+            grant_id: Some([0x44; 32]),
+            roster_ref: [0x55; 32],
+            owner_auth_len: u64::MAX,
+            author_auth_len: u64::MAX,
+            crypto_suite: 0,
+            key_id: None,
+        };
+        let mut op_body = vec![0x5a];
+        op_body.extend_from_slice(&((CONTENT_SEALED_OP_BODY_MAX_BYTES - 5) as u32).to_be_bytes());
+        op_body.resize(CONTENT_SEALED_OP_BODY_MAX_BYTES, 0);
+        // The nonce value is not load-bearing here (the size is nonce-width-independent), so seal
+        // via the random-nonce production entry point rather than a fixed injected nonce.
+        let signed =
+            envelope::seal_and_sign_content_entry(&secret, &header, &op_body, &key).unwrap();
+        assert!(
+            signed.signed_bytes.len() <= CONTENT_ENVELOPE_MAX_BYTES,
+            "the sealed reserve keeps the signed envelope within the §18a cap ({} > {})",
+            signed.signed_bytes.len(),
+            CONTENT_ENVELOPE_MAX_BYTES,
+        );
+    }
+
+    #[test]
+    fn a_rotation_in_the_resolution_window_makes_txn_b_bail_not_seal_stale() {
+        // P1: the sealed author resolves the content key in an autocommit window between txn A and
+        // txn B. A DeviceRemove + rotation committing a fresh higher-epoch wrap in that window
+        // would otherwise let txn B seal under the STALE key — acceptance is
+        // key-independent, so it folds accepted — and a device the rotation revoked could
+        // decrypt this post-removal entry. `revalidate_sealing_selection` re-reads the
+        // selection under txn B's write lock and bails when it no longer names the resolved
+        // key. Simulated directly: resolve, rotate the accepted wrap set to a higher epoch,
+        // then assert the re-validation bails on the stale baseline.
+        let conn = db();
+        let (account, stream) = owned_v2(&conn);
+        // Establish the epoch-0 sealing wrap the resolution would name (the stale baseline).
+        author_content_batch(&conn, stream, &[node_create("n1", "first")], SealPolicy::Sealed, NOW)
+            .expect("mint the initial key + author");
+        let baseline = secrets::select_current_sealing_wrap(&conn, account, stream)
+            .unwrap()
+            .expect("an epoch-0 selection");
+        assert_eq!(baseline.key_epoch, 0, "the initial mint is epoch 0");
+
+        // The concurrent rotation: commit a fresh epoch-1 wrap (what a DeviceRemove-driven rotation
+        // authors), so the current selection no longer names the resolved epoch-0 key.
+        {
+            let tx = Transaction::new_unchecked(&conn, TransactionBehavior::Immediate).unwrap();
+            secrets::rotate_stream_key_in_tx(&tx, stream, NOW).expect("rotate to epoch 1");
+            tx.commit().unwrap();
+        }
+        let rotated = secrets::select_current_sealing_wrap(&conn, account, stream)
+            .unwrap()
+            .expect("an epoch-1 selection");
+        assert_eq!(rotated.key_epoch, 1, "the rotation advanced the selection to epoch 1");
+
+        // Under txn B's write lock the stale epoch-0 baseline no longer matches → bail (retry).
+        let tx = Transaction::new_unchecked(&conn, TransactionBehavior::Immediate).unwrap();
+        let err = revalidate_sealing_selection(&tx, account, stream, &baseline).unwrap_err();
+        drop(tx);
+        assert!(
+            err.to_string().contains("rotated between resolution and sealing"),
+            "the re-validation bails on a rotation in the resolution window: {err}",
+        );
+
+        // The guard is not a blanket refusal: the fresh selection still validates.
+        let tx = Transaction::new_unchecked(&conn, TransactionBehavior::Immediate).unwrap();
+        revalidate_sealing_selection(&tx, account, stream, &rotated)
+            .expect("the current selection re-validates");
+        tx.commit().unwrap();
+    }
+
+    #[test]
+    fn an_empty_sealed_batch_is_a_noop_and_does_not_arm_the_ratchet() {
+        // P2: an empty Sealed batch must run NO key management. Minting the stream's first
+        // StreamKeyWrap would arm the downgrade ratchet, permanently refusing later plaintext
+        // authoring after a call that authored nothing.
+        let conn = db();
+        let (account, stream) = owned_v2(&conn);
+        let hashes = author_content_batch(&conn, stream, &[], SealPolicy::Sealed, NOW)
+            .expect("an empty sealed batch is a no-op");
+        assert!(hashes.is_empty(), "an empty batch authors no entries");
+        // No wrap was minted → the stream never sealed.
+        assert!(
+            secrets::select_current_sealing_wrap(&conn, account, stream).unwrap().is_none(),
+            "the empty sealed batch minted no content key",
+        );
+        // Plaintext authoring still works — the downgrade ratchet was never armed.
+        let authored = author_content_batch(
+            &conn,
+            stream,
+            &[node_create("n1", "x")],
+            SealPolicy::Plaintext,
+            NOW,
+        )
+        .expect("plaintext authoring still works after an empty sealed batch");
+        assert_eq!(authored.len(), 1, "the empty sealed batch did not arm the downgrade ratchet");
     }
 }

--- a/crates/rag-rat-oplog/src/account/content/author.rs
+++ b/crates/rag-rat-oplog/src/account/content/author.rs
@@ -309,14 +309,18 @@ fn author_sealed_batch(
     let account_id = require_local_account_id(conn)?;
 
     // (txn A) Lazy rotation on device removal, committed on its OWN txn so a rotation (a fresh
-    // higher-epoch wrap) survives a later authoring failure. Every RotationOutcome is non-error: an
-    // owner rotates, a member sees StaleButNotOwner and seals under the current key — only an
-    // infra/DB failure is `Err`, so the outcome is intentionally discarded.
-    {
+    // higher-epoch wrap) survives a later authoring failure. Every RotationOutcome is non-error —
+    // an owner rotates, a member sees StaleButNotOwner and seals under the current key; only an
+    // infra/DB failure is `Err`. The outcome is CARRIED INTO txn B: a member that saw
+    // StaleButNotOwner cannot rotate, so txn B's rotation-need re-check must not re-fail the state
+    // txn A already classified — retrying can never change it, and sealed authoring would stay
+    // permanently unavailable to the member until an owner happened to rotate.
+    let rotation = {
         let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
-        secrets::ensure_stream_key_current_in_tx(&tx, stream_id, now_ms)?;
+        let outcome = secrets::ensure_stream_key_current_in_tx(&tx, stream_id, now_ms)?;
         tx.commit()?;
-    }
+        outcome
+    };
 
     // (autocommit) Resolve the content key. `current_sealing_key`'s `sync_security_events` INSERTs
     // autocommit on `&Connection`, so it MUST run outside any txn that could roll back.
@@ -349,7 +353,7 @@ fn author_sealed_batch(
     // (txn B) Seal + author + verify-accepted, re-validating the selection under the write lock so
     // a rotation that committed after resolution can never make us seal under the stale key.
     let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
-    revalidate_sealing_selection(&tx, account_id, stream_id, &resolved)?;
+    revalidate_sealing_selection(&tx, account_id, stream_id, &resolved, &rotation)?;
     let authored = seal_and_author_in_tx(&tx, stream_id, ops, &key, &device, now_ms)?;
     tx.commit()?;
     Ok(authored)
@@ -378,11 +382,25 @@ fn author_sealed_batch(
 /// either failure, bail so the caller retries: the retry's txn A `ensure_stream_key_current_in_tx`
 /// rotates to a fresh key excluding the removed device, and txn B then seals under that. A PURE
 /// read (both predicates derive on read; neither is `current_sealing_key`, which autocommits).
+///
+/// The rotation-need re-check is EXEMPT when `txn_a_outcome` is
+/// [`secrets::RotationOutcome::StaleButNotOwner`]: txn A already classified this exact state
+/// (rotation needed, but this device is a member and CANNOT rotate) under its own IMMEDIATE lock,
+/// and `ensure_stream_key_current_in_tx`'s contract is that the member proceeds to seal under the
+/// current key — roster membership is READ access, not authoring authority. Re-failing here would
+/// make sealed authoring permanently unavailable to the member (a retry can never change a
+/// non-owner into an owner). The exemption is safe because the selection-unchanged check above
+/// still guards the member: an owner rotating in the resolution window changes the selection, so
+/// the member bails and its retry seals under the FRESH key. What the exemption gives up — a
+/// SECOND bare removal committing between txn A and txn B while we are a member — is
+/// indistinguishable from the state txn A already accepted, and the member has no remedy for it
+/// either way.
 fn revalidate_sealing_selection(
     tx: &Transaction<'_>,
     account_id: AccountId,
     stream_id: StreamId,
     resolved: &secrets::SelectedWrap,
+    txn_a_outcome: &secrets::RotationOutcome,
 ) -> anyhow::Result<()> {
     let current = secrets::select_current_sealing_wrap(tx, account_id, stream_id)?.context(
         "sealed /3 authoring: the stream's sealing wrap vanished under the authoring lock (a \
@@ -402,12 +420,15 @@ fn revalidate_sealing_selection(
     // this txn leaves the selection unchanged (no higher-epoch wrap) yet makes a recipient of
     // the current sealing key no-longer-effective. Re-checking the rotation-need predicate here
     // — authoritative under the write lock — bails so the retry rotates to a key that excludes
-    // the removed device.
-    anyhow::ensure!(
-        !secrets::stream_key_rotation_needed(tx, account_id, stream_id)?,
-        "sealed /3 authoring: rotation became needed under the authoring lock (a recipient of the \
-         current sealing key was removed from the roster); retry with the rotated key",
-    );
+    // the removed device. SKIPPED when txn A already returned StaleButNotOwner: a member cannot
+    // rotate, so this state is the one it is contracted to seal under (see the fn doc).
+    if !matches!(txn_a_outcome, secrets::RotationOutcome::StaleButNotOwner) {
+        anyhow::ensure!(
+            !secrets::stream_key_rotation_needed(tx, account_id, stream_id)?,
+            "sealed /3 authoring: rotation became needed under the authoring lock (a recipient of \
+             the current sealing key was removed from the roster); retry with the rotated key",
+        );
+    }
     Ok(())
 }
 
@@ -1137,12 +1158,13 @@ mod tests {
 
     /// Author a founder-signed control op (`DeviceAdd` / `DeviceRemove`) on the account's control
     /// chain in its own IMMEDIATE txn, then refold — the roster-mutation shape the C4.4 rotation
-    /// tests use (mirrors `secrets::author`'s test helper).
+    /// tests use (mirrors `secrets::author`'s test helper). Returns the authored entry hash (a
+    /// `DeviceAdd`'s hash IS the added device's owner incarnation id).
     fn author_control_op(
         conn: &Connection,
         account: AccountId,
         op: &crate::account::ops::AccountOp,
-    ) {
+    ) -> EntryHash {
         use crate::account::envelope::{
             AccountEntryHeader, VerifiedAccountEntry, sign_account_entry,
         };
@@ -1180,6 +1202,72 @@ mod tests {
         account_storage::insert_candidate(&tx, &verified, &signed.signed_bytes, NOW).unwrap();
         account_storage::refold_in_tx(&tx, account).unwrap();
         tx.commit().unwrap();
+        verified.entry_hash
+    }
+
+    /// Author + refold a control op signed by an ARBITRARY device (not just the founder), citing
+    /// `authority_ref`, on that device's own dense control chain. The non-founder counterpart of
+    /// [`author_control_op`] (mirrors `secrets::author`'s test helper) — needed to drive an
+    /// `OwnerDemote` of the local founder by a second owner.
+    fn author_control_op_as(
+        conn: &Connection,
+        account: AccountId,
+        signer: &crate::device::DeviceSecret,
+        authority_ref: EntryHash,
+        op: &crate::account::ops::AccountOp,
+    ) -> EntryHash {
+        use crate::account::envelope::{
+            AccountEntryHeader, VerifiedAccountEntry, sign_account_entry,
+        };
+        use crate::account::fold::CONTROL_LOG;
+        use crate::account::{authoring, ops as control_ops};
+
+        let signer_fp = signer.public().fingerprint();
+        let LocalAccountRef { genesis_hash, .. } =
+            bootstrap::local_account_ref(conn).unwrap().unwrap();
+        let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate).unwrap();
+        let (seq, prev_hash) =
+            match authoring::account_chain_tail(&tx, account, signer_fp, CONTROL_LOG).unwrap() {
+                Some((tail_seq, tail_hash)) => (tail_seq + 1, Some(tail_hash)),
+                None => (0, None),
+            };
+        let header = AccountEntryHeader {
+            account_id: account,
+            log_id: CONTROL_LOG,
+            device_fingerprint: signer_fp,
+            seq,
+            prev_hash,
+            parent_ref: Some(genesis_hash),
+            entry_type: control_ops::entry_type_of(op),
+            op_version: 1,
+            crypto_suite: 0,
+            auth_len: account_storage::account_effective_count(&tx, account).unwrap(),
+            key_id: None,
+            authority_ref: Some(authority_ref),
+        };
+        let payload = control_ops::encode(op).unwrap();
+        let signed = sign_account_entry(signer, &header, &payload).unwrap();
+        let verified = VerifiedAccountEntry {
+            header: signed.header,
+            payload: signed.payload,
+            entry_hash: signed.entry_hash,
+        };
+        account_storage::insert_candidate(&tx, &verified, &signed.signed_bytes, NOW).unwrap();
+        account_storage::refold_in_tx(&tx, account).unwrap();
+        tx.commit().unwrap();
+        verified.entry_hash
+    }
+
+    /// The (seq, hash) tail of a device's `(account, device, log)` chain — used to place tight
+    /// cuts (mirrors `secrets::author`'s test helper).
+    fn chain_tail(
+        conn: &Connection,
+        account: AccountId,
+        fp: DeviceFingerprint,
+        log: u8,
+    ) -> Option<(u64, EntryHash)> {
+        let tx = conn.unchecked_transaction().unwrap();
+        crate::account::authoring::account_chain_tail(&tx, account, fp, log).unwrap()
     }
 
     /// Add a member device to the roster (folds effective) and return its fingerprint — so a mint
@@ -1553,7 +1641,14 @@ mod tests {
 
         // Under txn B's write lock the stale epoch-0 baseline no longer matches → bail (retry).
         let tx = Transaction::new_unchecked(&conn, TransactionBehavior::Immediate).unwrap();
-        let err = revalidate_sealing_selection(&tx, account, stream, &baseline).unwrap_err();
+        let err = revalidate_sealing_selection(
+            &tx,
+            account,
+            stream,
+            &baseline,
+            &secrets::RotationOutcome::Current,
+        )
+        .unwrap_err();
         drop(tx);
         assert!(
             err.to_string().contains("rotated between resolution and sealing"),
@@ -1562,8 +1657,14 @@ mod tests {
 
         // The guard is not a blanket refusal: the fresh selection still validates.
         let tx = Transaction::new_unchecked(&conn, TransactionBehavior::Immediate).unwrap();
-        revalidate_sealing_selection(&tx, account, stream, &rotated)
-            .expect("the current selection re-validates");
+        revalidate_sealing_selection(
+            &tx,
+            account,
+            stream,
+            &rotated,
+            &secrets::RotationOutcome::Current,
+        )
+        .expect("the current selection re-validates");
         tx.commit().unwrap();
     }
 
@@ -1598,8 +1699,14 @@ mod tests {
         // not spuriously bail the normal case.
         {
             let tx = Transaction::new_unchecked(&conn, TransactionBehavior::Immediate).unwrap();
-            revalidate_sealing_selection(&tx, account, stream, &baseline)
-                .expect("no removal ⇒ rotation not needed ⇒ the baseline re-validates");
+            revalidate_sealing_selection(
+                &tx,
+                account,
+                stream,
+                &baseline,
+                &secrets::RotationOutcome::Current,
+            )
+            .expect("no removal ⇒ rotation not needed ⇒ the baseline re-validates");
             tx.commit().unwrap();
         }
 
@@ -1627,14 +1734,152 @@ mod tests {
 
         // Under txn B's write lock the re-validation must now BAIL on rotation-need, not seal
         // stale. (Without the rotation-need re-check this passes and txn B seals under the
-        // stale key.)
+        // stale key.) The simulated txn A ran BEFORE the removal, so its outcome is `Current`
+        // — an owner's retry rotates; only a StaleButNotOwner txn A exempts this check.
         let tx = Transaction::new_unchecked(&conn, TransactionBehavior::Immediate).unwrap();
-        let err = revalidate_sealing_selection(&tx, account, stream, &baseline).unwrap_err();
+        let err = revalidate_sealing_selection(
+            &tx,
+            account,
+            stream,
+            &baseline,
+            &secrets::RotationOutcome::Current,
+        )
+        .unwrap_err();
         drop(tx);
         assert!(
             err.to_string().contains("rotation became needed under the authoring lock"),
             "the re-validation bails on a bare removal in the resolution window: {err}",
         );
+    }
+
+    #[test]
+    fn a_non_owner_member_seals_under_the_current_key_when_rotation_is_needed() {
+        // P2: when a remaining MEMBER (not an owner) calls SealPolicy::Sealed after a recipient
+        // was removed, txn A deliberately returns StaleButNotOwner and leaves the old key
+        // selected — the member cannot rotate, and `ensure_stream_key_current_in_tx`'s contract
+        // is that it proceeds to seal under the current key. An UNCONDITIONAL rotation-need
+        // re-check in txn B would fail that intended path forever (a retry can never make a
+        // member an owner), so the txn-A outcome is carried into txn B and exempts the
+        // re-check. The selection-unchanged check still guards the member against a concurrent
+        // rotation.
+        let conn = db();
+        let (account, stream) = owned_v2(&conn);
+
+        // A second owner whose secret we control, so it can author the founder's demotion (the
+        // rotation machinery only operates on the LOCAL self-founded account, so the local
+        // device must be demoted by a second owner to become a member).
+        let owner_b_ed = crate::device::DeviceSecret::from_seed(&[0x2b; 32]);
+        let owner_b_x = crate::device::DeviceX25519Secret::from_seed(&[0xb2; 32]);
+        let owner_id_b =
+            author_control_op(&conn, account, &crate::account::ops::AccountOp::DeviceAdd {
+                device_fingerprint: owner_b_ed.public().fingerprint(),
+                ed25519_pubkey: owner_b_ed.public().to_bytes(),
+                x25519_pubkey: owner_b_x.public().to_bytes(),
+                role: crate::account::ops::DeviceRole::Owner,
+                label: None,
+            });
+
+        // A member that will be removed to make rotation needed.
+        let member_x = crate::device::DeviceX25519Secret::from_seed(&[0x5c; 32]);
+        let member = add_member_device(&conn, account, &member_x);
+
+        // Mint the initial key via a sealed batch (the wrap seals to founder + owner_b + member).
+        author_content_batch(&conn, stream, &[node_create("n1", "first")], SealPolicy::Sealed, NOW)
+            .expect("mint the initial key + author");
+        let baseline = secrets::select_current_sealing_wrap(&conn, account, stream)
+            .unwrap()
+            .expect("an epoch-0 selection");
+
+        // The founder (still an owner) removes the member → rotation needed.
+        author_control_op(&conn, account, &crate::account::ops::AccountOp::DeviceRemove {
+            device_fingerprint: member,
+            control_cut: crate::account::cut::Cut::Empty,
+            secrets_cut: crate::account::cut::Cut::Empty,
+            content_cuts: Vec::new(),
+            reason: "revoked".to_string(),
+        });
+        assert!(
+            secrets::stream_key_rotation_needed(&conn, account, stream).unwrap(),
+            "the removed member is still a recipient of the current wrap",
+        );
+
+        // owner_b demotes the founder, preserving the founder's whole history via cuts at its
+        // chain tails (the mint stays accepted; only the owner ROLE closes).
+        let founder = local_device(&conn, NOW).unwrap();
+        let founder_owner_id = account_storage::effective_owner_incarnation_for_device(
+            &conn,
+            account,
+            founder.fingerprint(),
+        )
+        .unwrap()
+        .expect("the founder is an owner before the demotion");
+        let ctrl_tail =
+            chain_tail(&conn, account, founder.fingerprint(), crate::account::fold::CONTROL_LOG)
+                .expect("the founder has a control chain");
+        let secrets_tail =
+            chain_tail(&conn, account, founder.fingerprint(), crate::account::fold::SECRETS_LOG)
+                .expect("the founder authored the mint on its secrets chain");
+        author_control_op_as(
+            &conn,
+            account,
+            &owner_b_ed,
+            owner_id_b,
+            &crate::account::ops::AccountOp::OwnerDemote {
+                device_fingerprint: founder.fingerprint(),
+                owner_id: founder_owner_id,
+                control_cut: crate::account::cut::Cut::At { seq: ctrl_tail.0, hash: ctrl_tail.1 },
+                secrets_cut: crate::account::cut::Cut::At {
+                    seq: secrets_tail.0,
+                    hash: secrets_tail.1,
+                },
+                reason: "demote".to_string(),
+            },
+        );
+        assert!(
+            account_storage::effective_owner_incarnation_for_device(
+                &conn,
+                account,
+                founder.fingerprint(),
+            )
+            .unwrap()
+            .is_none(),
+            "the founder is now a plain member",
+        );
+        assert!(
+            secrets::stream_key_rotation_needed(&conn, account, stream).unwrap(),
+            "rotation is still needed (the member is gone, no rotation happened)",
+        );
+
+        // The member's sealed batch SUCCEEDS under the current (stale) key: txn A returns
+        // StaleButNotOwner, and txn B's rotation-need re-check exempts that classified state.
+        // (Before the exemption, this call bailed on "rotation became needed under the authoring
+        // lock" on every retry — sealed authoring was permanently unavailable to the member.)
+        let hashes = author_content_batch(
+            &conn,
+            stream,
+            &[node_create("n2", "member-sealed")],
+            SealPolicy::Sealed,
+            NOW,
+        )
+        .expect("a member seals under the current key (StaleButNotOwner must not fail txn B)");
+        assert_eq!(hashes.len(), 1, "one op authors one sealed entry");
+        let header = header_of(&conn, &hashes[0]);
+        assert_eq!(header.crypto_suite, 1, "sealed as suite 1");
+        assert_eq!(
+            header.key_id,
+            Some(baseline.key_id.to_bytes()),
+            "sealed under the CURRENT key — the member cannot rotate to a fresh one",
+        );
+        assert_eq!(
+            stored_status(&conn, &hashes[0]).as_deref(),
+            Some("accepted"),
+            "the member's sealed entry folds accepted",
+        );
+        // And no rotation was authored: the selection is unchanged.
+        let after = secrets::select_current_sealing_wrap(&conn, account, stream)
+            .unwrap()
+            .expect("a selection still exists");
+        assert_eq!(after.key_epoch, baseline.key_epoch, "a member authored no rotation");
     }
 
     #[test]

--- a/crates/rag-rat-oplog/src/account/content/author.rs
+++ b/crates/rag-rat-oplog/src/account/content/author.rs
@@ -355,16 +355,29 @@ fn author_sealed_batch(
     Ok(authored)
 }
 
-/// Re-confirm, under txn B's IMMEDIATE write lock, that `stream_id`'s current sealing selection is
-/// STILL the `(key_epoch, key_id)` the pre-txn resolution named.
+/// Re-confirm, under txn B's IMMEDIATE write lock, that `stream_id` is STILL safe to seal under the
+/// key the pre-txn resolution named — i.e. the selection is unchanged AND no rotation is now due.
 ///
-/// A `DeviceRemove` + rotation can commit a fresh higher-epoch `StreamKeyWrap` in the autocommit
-/// window between resolving the key ([`author_sealed_batch`]) and opening this txn. Sealing under
-/// the now-stale key would let a device that rotation revoked decrypt this post-removal entry — a
-/// confidentiality regression, and NOT the §15 sync-lag window, because the removal is LOCALLY
-/// committed. Because txn B holds the write lock, no rotation can commit until it ends, so a
-/// selection that still matches here is authoritative for the seal that follows. On mismatch, bail
-/// so the caller retries under the fresh key. A PURE read (never `current_sealing_key`).
+/// Two roster changes can commit in the autocommit window between resolving the key
+/// ([`author_sealed_batch`]) and opening this txn, and BOTH must abort the seal:
+///
+/// - A `DeviceRemove` + rotation commits a fresh higher-epoch `StreamKeyWrap`, so the resolved
+///   `(epoch, key_id)` no longer names the current selection — caught by the selection-unchanged
+///   check.
+/// - A BARE `DeviceRemove` (no rotation yet) makes a recipient of the current wrap no longer
+///   roster-effective WITHOUT minting a higher-epoch wrap. No rotation has happened, so the
+///   selection is UNCHANGED and the check above passes — yet sealing under this key would let the
+///   just-removed device decrypt this post-removal entry. The real invariant is "rotation is not
+///   NOW needed", not merely "the selection did not change", so we also re-check the C4.4
+///   rotation-need predicate.
+///
+/// Either way, sealing under the now-stale key is a confidentiality regression (NOT the §15
+/// sync-lag window, because the removal is LOCALLY committed) — acceptance is key-independent, so
+/// the batch would fold accepted anyway. Because txn B holds the write lock, no removal/rotation
+/// can commit until it ends, so both checks here are authoritative for the seal that follows. On
+/// either failure, bail so the caller retries: the retry's txn A `ensure_stream_key_current_in_tx`
+/// rotates to a fresh key excluding the removed device, and txn B then seals under that. A PURE
+/// read (both predicates derive on read; neither is `current_sealing_key`, which autocommits).
 fn revalidate_sealing_selection(
     tx: &Transaction<'_>,
     account_id: AccountId,
@@ -375,12 +388,25 @@ fn revalidate_sealing_selection(
         "sealed /3 authoring: the stream's sealing wrap vanished under the authoring lock (a \
          concurrent condemn); retry",
     )?;
+    // The rotation-already-happened case: a fresh higher-epoch wrap advanced the selection off the
+    // resolved key (defense in depth — the bare-removal check below covers the not-yet-rotated
+    // case).
     anyhow::ensure!(
         current.key_epoch == resolved.key_epoch && current.key_id == resolved.key_id,
         "sealed /3 authoring: the stream's sealing key rotated between resolution and sealing \
          (was epoch {}, now epoch {}); retry with the fresh key",
         resolved.key_epoch,
         current.key_epoch,
+    );
+    // The bare-removal case: a `DeviceRemove` committed after txn A's rotation check and before
+    // this txn leaves the selection unchanged (no higher-epoch wrap) yet makes a recipient of
+    // the current sealing key no-longer-effective. Re-checking the rotation-need predicate here
+    // — authoritative under the write lock — bails so the retry rotates to a key that excludes
+    // the removed device.
+    anyhow::ensure!(
+        !secrets::stream_key_rotation_needed(tx, account_id, stream_id)?,
+        "sealed /3 authoring: rotation became needed under the authoring lock (a recipient of the \
+         current sealing key was removed from the roster); retry with the rotated key",
     );
     Ok(())
 }
@@ -1109,6 +1135,75 @@ mod tests {
         (account, stream)
     }
 
+    /// Author a founder-signed control op (`DeviceAdd` / `DeviceRemove`) on the account's control
+    /// chain in its own IMMEDIATE txn, then refold — the roster-mutation shape the C4.4 rotation
+    /// tests use (mirrors `secrets::author`'s test helper).
+    fn author_control_op(
+        conn: &Connection,
+        account: AccountId,
+        op: &crate::account::ops::AccountOp,
+    ) {
+        use crate::account::envelope::{
+            AccountEntryHeader, VerifiedAccountEntry, sign_account_entry,
+        };
+        use crate::account::fold::CONTROL_LOG;
+        use crate::account::{authoring, ops as control_ops};
+
+        let founder = local_device(conn, NOW).unwrap();
+        let LocalAccountRef { genesis_hash, .. } =
+            bootstrap::local_account_ref(conn).unwrap().unwrap();
+        let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate).unwrap();
+        let tail = authoring::account_chain_tail(&tx, account, founder.fingerprint(), CONTROL_LOG)
+            .unwrap()
+            .expect("control chain is non-empty post-genesis");
+        let header = AccountEntryHeader {
+            account_id: account,
+            log_id: CONTROL_LOG,
+            device_fingerprint: founder.fingerprint(),
+            seq: tail.0 + 1,
+            prev_hash: Some(tail.1),
+            parent_ref: Some(genesis_hash),
+            entry_type: control_ops::entry_type_of(op),
+            op_version: 1,
+            crypto_suite: 0,
+            auth_len: account_storage::account_effective_count(&tx, account).unwrap(),
+            key_id: None,
+            authority_ref: Some(genesis_hash),
+        };
+        let payload = control_ops::encode(op).unwrap();
+        let signed = sign_account_entry(founder.secret(), &header, &payload).unwrap();
+        let verified = VerifiedAccountEntry {
+            header: signed.header,
+            payload: signed.payload,
+            entry_hash: signed.entry_hash,
+        };
+        account_storage::insert_candidate(&tx, &verified, &signed.signed_bytes, NOW).unwrap();
+        account_storage::refold_in_tx(&tx, account).unwrap();
+        tx.commit().unwrap();
+    }
+
+    /// Add a member device to the roster (folds effective) and return its fingerprint — so a mint
+    /// seals the current wrap to a recipient the test can later remove.
+    fn add_member_device(
+        conn: &Connection,
+        account: AccountId,
+        member_x: &crate::device::DeviceX25519Secret,
+    ) -> DeviceFingerprint {
+        use crate::account::ops::{AccountOp, DeviceRole};
+        use crate::device::DeviceSecret;
+
+        let member_pub = DeviceSecret::from_seed(&[0x2c; 32]).public();
+        let member_fp = member_pub.fingerprint();
+        author_control_op(conn, account, &AccountOp::DeviceAdd {
+            device_fingerprint: member_fp,
+            ed25519_pubkey: member_pub.to_bytes(),
+            x25519_pubkey: member_x.public().to_bytes(),
+            role: DeviceRole::Member,
+            label: None,
+        });
+        member_fp
+    }
+
     #[test]
     fn a_sealed_batch_authors_suite_1_entries_that_fold_accepted_locally() {
         let conn = db();
@@ -1470,6 +1565,76 @@ mod tests {
         revalidate_sealing_selection(&tx, account, stream, &rotated)
             .expect("the current selection re-validates");
         tx.commit().unwrap();
+    }
+
+    #[test]
+    fn a_device_removal_in_the_resolution_window_makes_txn_b_bail_not_seal_stale() {
+        // P1: a BARE `DeviceRemove` of a wrap RECIPIENT — committed in the autocommit window
+        // between txn A (rotation check) and txn B (seal), with NO rotation, so NO
+        // higher-epoch wrap exists — leaves the current sealing selection UNCHANGED:
+        // `select_current_sealing_wrap` still returns the old `(epoch, key_id)`. The
+        // selection-unchanged check alone therefore PASSES, and txn B would seal under the
+        // key the just-removed device still holds — a device revoked by that removal could
+        // decrypt this post-removal entry (acceptance is key-independent, so
+        // the batch folds accepted regardless). The rotation-need re-check under txn B's write lock
+        // catches it. Contrast with `a_rotation_in_the_resolution_window_...`, which mints a
+        // HIGHER-epoch wrap so the selection-unchanged check alone already bails.
+        let conn = db();
+        let (account, stream) = owned_v2(&conn);
+        // A second roster device so the initial mint seals to ≥2 recipients — one we can remove.
+        let member_x = crate::device::DeviceX25519Secret::from_seed(&[0x5c; 32]);
+        let member = add_member_device(&conn, account, &member_x);
+
+        // Establish the epoch-0 sealing wrap (sealed to founder + member) the resolution would
+        // name.
+        author_content_batch(&conn, stream, &[node_create("n1", "first")], SealPolicy::Sealed, NOW)
+            .expect("mint the initial key + author");
+        let baseline = secrets::select_current_sealing_wrap(&conn, account, stream)
+            .unwrap()
+            .expect("an epoch-0 selection");
+        assert_eq!(baseline.key_epoch, 0, "the initial mint is epoch 0");
+
+        // No removal yet ⇒ rotation is not needed ⇒ the baseline re-validates. Proves the fix does
+        // not spuriously bail the normal case.
+        {
+            let tx = Transaction::new_unchecked(&conn, TransactionBehavior::Immediate).unwrap();
+            revalidate_sealing_selection(&tx, account, stream, &baseline)
+                .expect("no removal ⇒ rotation not needed ⇒ the baseline re-validates");
+            tx.commit().unwrap();
+        }
+
+        // The concurrent BARE removal: revoke the member WITHOUT rotating (mint no higher-epoch
+        // wrap).
+        author_control_op(&conn, account, &crate::account::ops::AccountOp::DeviceRemove {
+            device_fingerprint: member,
+            control_cut: crate::account::cut::Cut::Empty,
+            secrets_cut: crate::account::cut::Cut::Empty,
+            content_cuts: Vec::new(),
+            reason: "revoked".to_string(),
+        });
+        // The selection is UNCHANGED (no rotation happened) — the stale-baseline check would
+        // pass...
+        let after = secrets::select_current_sealing_wrap(&conn, account, stream)
+            .unwrap()
+            .expect("a still-epoch-0 selection");
+        assert_eq!(after.key_epoch, 0, "no rotation happened — the epoch is unchanged");
+        assert_eq!(after.key_id, baseline.key_id, "the bare removal did not change the key_id");
+        // ...yet rotation is now DUE (the removed member still holds the current wrap).
+        assert!(
+            secrets::stream_key_rotation_needed(&conn, account, stream).unwrap(),
+            "the bare removal makes rotation needed without changing the selection",
+        );
+
+        // Under txn B's write lock the re-validation must now BAIL on rotation-need, not seal
+        // stale. (Without the rotation-need re-check this passes and txn B seals under the
+        // stale key.)
+        let tx = Transaction::new_unchecked(&conn, TransactionBehavior::Immediate).unwrap();
+        let err = revalidate_sealing_selection(&tx, account, stream, &baseline).unwrap_err();
+        drop(tx);
+        assert!(
+            err.to_string().contains("rotation became needed under the authoring lock"),
+            "the re-validation bails on a bare removal in the resolution window: {err}",
+        );
     }
 
     #[test]

--- a/crates/rag-rat-oplog/src/account/content/envelope.rs
+++ b/crates/rag-rat-oplog/src/account/content/envelope.rs
@@ -4,11 +4,14 @@
 //! the future C5 AEAD AAD. The payload stays opaque here so plaintext and sealed entries have the
 //! same chain and signature semantics.
 
+use chacha20poly1305::aead::{Aead, Payload};
+use chacha20poly1305::{KeyInit, XChaCha20Poly1305, XNonce};
 use minicbor::Encoder;
 use minicbor::data::Type;
 use minicbor::decode::{Decoder, Error as CborError};
 
 use super::super::AccountId;
+use super::super::keywrap::ContentKey;
 use super::super::limits::{
     CONTENT_ENTRY_DOMAIN, CONTENT_ENVELOPE_MAX_BYTES, CONTENT_SIGNED_DOMAIN,
 };
@@ -18,6 +21,21 @@ use crate::op::DeviceFingerprint;
 use crate::stream::StreamId;
 
 const INFALLIBLE: &str = "encoding CBOR to a Vec is infallible";
+
+/// The suite-1 (XChaCha20-Poly1305 sealed) crypto-suite id a sealed `/3` header carries. The
+/// suite-0 sibling [`sign_content_entry`] never authors this; [`sign_sealed_content_entry`] is the
+/// ONLY suite-1 authoring path (sync phase C5a, #608).
+const SEALED_CRYPTO_SUITE: u64 = 1;
+
+/// The XChaCha20-Poly1305 wire nonce width (192 bits) prepended to every suite-1 payload:
+/// `payload = nonce[24] || ciphertext`. A FRESH RANDOM nonce per seal — a content key is
+/// long-lived, so unlike the keywrap there is no per-seal secret to derive a nonce from — is what
+/// keeps `(key, nonce)` unique regardless of author-seam refactors. Freezing this width freezes the
+/// suite-1 payload layout.
+pub(super) const SEALED_NONCE_LEN: usize = 24;
+
+/// The Poly1305 tag width XChaCha20-Poly1305 appends to the ciphertext.
+pub(super) const SEALED_AEAD_TAG_LEN: usize = 16;
 
 /// The fixed 13-part `/3` header. The domain is encoded as part 0 and therefore is not stored.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -98,6 +116,112 @@ pub fn sign_content_entry(
     })
 }
 
+/// Encode, SEAL, and sign one suite-1 `/3` content entry (sync phase C5a, #608). The op body is
+/// encrypted under `key` with XChaCha20-Poly1305; the wire payload is
+/// `nonce[24] || ciphertext(op_bytes + 16-byte Poly1305 tag)`, and the AEAD AAD is the FINAL signed
+/// header content bytes.
+///
+/// The header is finalized BEFORE it is encoded — the signing key sets `device_fingerprint`, and
+/// this path (never the caller) sets `crypto_suite = 1` + `key_id = key.key_id()` — so the AAD
+/// binds exactly the header bytes the signature covers. Sealing against a pre-finalization header
+/// encode would brick decrypt on an entry that still folds `accepted` (an un-recoverable accepted
+/// entry).
+///
+/// `nonce` is injected so golden vectors are byte-reproducible; production authoring samples it
+/// from the OS CSPRNG via [`seal_and_sign_content_entry`]. The suite-0 sibling
+/// [`sign_content_entry`] keeps its `crypto_suite != 0` bail, so a suite-1-over-plaintext header is
+/// unconstructible.
+pub fn sign_sealed_content_entry(
+    secret: &DeviceSecret,
+    header: &ContentEntryHeader,
+    op_bytes: &[u8],
+    key: &ContentKey,
+    nonce: [u8; SEALED_NONCE_LEN],
+) -> anyhow::Result<SignedContentEntry> {
+    // §18a cap BEFORE the AEAD encrypt/allocate (mirrors `sign_content_entry`'s up-front payload
+    // check): the sealed wire payload is `nonce[24] || ciphertext(op_bytes + tag[16])`, so bound
+    // the op body plus that fixed 40-byte AEAD expansion against the cap here. Rejecting up
+    // front means an oversized op is never encrypted or buffered — this is the exact bound
+    // `content_op_is_sealed_authorable` reserves against. `saturating_add` cannot overflow the cap.
+    if op_bytes.len().saturating_add(SEALED_NONCE_LEN + SEALED_AEAD_TAG_LEN)
+        > CONTENT_ENVELOPE_MAX_BYTES
+    {
+        anyhow::bail!("sealed content payload exceeds the §18a envelope limit");
+    }
+
+    // The op body is the plaintext that becomes the ciphertext; require it canonical up front. The
+    // suite-1 wire payload is opaque, so `decode_body`'s suite-0 payload-canonicity check cannot
+    // cover it — but the decrypt side (C5b) recovers exactly these bytes for `op::decode`, so a
+    // non-canonical op body would round-trip into an un-decodable projection input.
+    cbor::require_canonical_cbor(op_bytes)
+        .map_err(|error| anyhow::anyhow!("sealed op payload is not canonical CBOR: {error}"))?;
+
+    // Finalize the header FIRST (device_fingerprint + suite/key_id), then encode — the AAD below is
+    // those FINAL bytes, never a pre-finalization encode.
+    let mut header = header.clone();
+    header.device_fingerprint = secret.public().fingerprint();
+    header.crypto_suite = SEALED_CRYPTO_SUITE;
+    header.key_id = Some(key.key_id().to_bytes());
+    if let Some(message) = header_nullity_error(&header) {
+        anyhow::bail!(message);
+    }
+    let header_bytes = encode_header(&header);
+
+    // AEAD-seal the op body with AAD = the final header content bytes; prepend the wire nonce.
+    let ciphertext = seal_op_bytes(key, &nonce, op_bytes, &header_bytes)?;
+    let mut payload = Vec::with_capacity(SEALED_NONCE_LEN + ciphertext.len());
+    payload.extend_from_slice(&nonce);
+    payload.extend_from_slice(&ciphertext);
+
+    let body_bytes = encode_body(&header_bytes, &payload);
+    let signature = secret.sign(&body_bytes);
+    let signed_bytes = encode_signed(&body_bytes, &signature);
+    // The framed signed envelope must still fit the §18a cap — the header + CBOR framing sit on top
+    // of the sealed payload the pre-seal check already bounded.
+    if signed_bytes.len() > CONTENT_ENVELOPE_MAX_BYTES {
+        anyhow::bail!(
+            "sealed content entry is {} bytes, over the {CONTENT_ENVELOPE_MAX_BYTES}-byte §18a \
+             limit",
+            signed_bytes.len(),
+        );
+    }
+    let entry_hash = cbor::sha256(&body_bytes);
+    Ok(SignedContentEntry {
+        header,
+        payload,
+        signature,
+        header_bytes,
+        body_bytes,
+        signed_bytes,
+        entry_hash,
+    })
+}
+
+/// Sample a fresh OS-CSPRNG wire nonce, then [`sign_sealed_content_entry`] — the production sealing
+/// entry point. A fresh 192-bit XChaCha nonce per seal makes each ciphertext unique with no
+/// per-seal secret; golden tests inject the nonce directly instead.
+pub fn seal_and_sign_content_entry(
+    secret: &DeviceSecret,
+    header: &ContentEntryHeader,
+    op_bytes: &[u8],
+    key: &ContentKey,
+) -> anyhow::Result<SignedContentEntry> {
+    sign_sealed_content_entry(secret, header, op_bytes, key, sample_wire_nonce()?)
+}
+
+/// Sample a fresh 192-bit XChaCha wire nonce straight from the OS CSPRNG, returned BY VALUE. A
+/// content key is long-lived, so a fresh random nonce per seal is what keeps `(key, nonce)` unique;
+/// the value the seal receives is the CSPRNG output — there is no reused or hard-coded nonce
+/// constant in its provenance.
+fn sample_wire_nonce() -> anyhow::Result<[u8; SEALED_NONCE_LEN]> {
+    let mut nonce = [0u8; SEALED_NONCE_LEN];
+    // `getrandom::Error` only implements `std::error::Error` behind getrandom's `std` feature (off
+    // under `--no-default-features`), so format via `Display` rather than `.context`.
+    getrandom::fill(&mut nonce)
+        .map_err(|e| anyhow::anyhow!("OS CSPRNG failed to sample a content-seal nonce: {e}"))?;
+    Ok(nonce)
+}
+
 /// Decode structure and canonical CBOR only. Signature verification is separate.
 pub fn decode_content_signed(bytes: &[u8]) -> anyhow::Result<SignedContentEntry> {
     if bytes.len() > CONTENT_ENVELOPE_MAX_BYTES {
@@ -165,6 +289,22 @@ fn encode_signed(body_bytes: &[u8], signature: &[u8; 64]) -> Vec<u8> {
     encoder.bytes(body_bytes).expect(INFALLIBLE);
     encoder.bytes(signature).expect(INFALLIBLE);
     bytes
+}
+
+/// XChaCha20-Poly1305-seal `op_bytes` under `key` with `nonce`, binding `aad`. Returns the tagged
+/// ciphertext (`op_bytes.len() + 16` bytes); the caller prepends the nonce to form the wire
+/// payload.
+fn seal_op_bytes(
+    key: &ContentKey,
+    nonce: &[u8; SEALED_NONCE_LEN],
+    op_bytes: &[u8],
+    aad: &[u8],
+) -> anyhow::Result<Vec<u8>> {
+    let cipher = XChaCha20Poly1305::new_from_slice(key.as_slice())
+        .map_err(|_| anyhow::anyhow!("content key has the wrong length"))?;
+    cipher
+        .encrypt(&XNonce::from(*nonce), Payload { msg: op_bytes, aad })
+        .map_err(|_| anyhow::anyhow!("content AEAD sealing failed"))
 }
 
 fn encode_opt_hash(encoder: &mut Encoder<&mut Vec<u8>>, hash: Option<[u8; 32]>) {
@@ -260,6 +400,9 @@ fn decode_opt_hash(decoder: &mut Decoder<'_>, field: &str) -> Result<Option<[u8;
 
 #[cfg(test)]
 mod tests {
+    use chacha20poly1305::aead::{Aead, Payload};
+    use chacha20poly1305::{KeyInit, XChaCha20Poly1305, XNonce};
+
     use super::*;
 
     fn secret() -> DeviceSecret {
@@ -508,5 +651,170 @@ mod tests {
         near_limit.resize(CONTENT_ENVELOPE_MAX_BYTES, 0);
         assert!(cbor::require_canonical_cbor(&near_limit).is_ok());
         assert!(sign_content_entry(&secret(), &header(), &near_limit).is_err());
+    }
+
+    // ── C5a: sealed suite-1 authoring (XChaCha20-Poly1305, random wire nonce) ──
+
+    fn content_key() -> ContentKey {
+        ContentKey::from_seed(&[0x20; 32])
+    }
+
+    /// Open a `nonce[24] || ciphertext` sealed payload under `key` with AAD `aad` — the read-side
+    /// inverse of the seal, kept in the test so C5a exposes only the seal side (the projection
+    /// decrypt is C5b). A genuine encrypt-then-decrypt round trip: the AEAD is a vetted library, so
+    /// recovering the original op bytes exercises the seal's key + nonce + AAD binding, not the
+    /// cipher.
+    fn open_sealed_payload(
+        key: &ContentKey,
+        payload: &[u8],
+        aad: &[u8],
+    ) -> anyhow::Result<Vec<u8>> {
+        let (nonce, ciphertext) = payload.split_at(SEALED_NONCE_LEN);
+        let nonce: [u8; SEALED_NONCE_LEN] = nonce.try_into().unwrap();
+        let cipher = XChaCha20Poly1305::new_from_slice(key.as_slice()).unwrap();
+        cipher
+            .decrypt(&XNonce::from(nonce), Payload { msg: ciphertext, aad })
+            .map_err(|_| anyhow::anyhow!("sealed payload AEAD open failed"))
+    }
+
+    #[test]
+    fn sealed_content_wire_is_golden_pinned_under_an_injected_nonce() {
+        // Deterministic: a seed-fixed content key + an injected nonce freeze the suite-1 payload
+        // layout (nonce || ciphertext(op + tag)) and the signed envelope. A regression that moves
+        // the nonce, changes the AAD, or drops the tag reddens here.
+        //
+        // The fixed nonce below is a golden-vector requirement — a static analyzer may flag it as a
+        // hard-coded cryptographic value, but it is a deterministic TEST vector for the injectable
+        // API; production seals via `seal_and_sign_content_entry`, which samples a random nonce.
+        let key = content_key();
+        let signed =
+            sign_sealed_content_entry(&secret(), &header(), &[0x81, 0x01], &key, [0x5c; 24])
+                .unwrap();
+        // The sealed signer sets suite 1 + the key's id itself, overwriting the plaintext input.
+        assert_eq!(signed.header.crypto_suite, 1);
+        assert_eq!(signed.header.key_id, Some(key.key_id().to_bytes()));
+        // payload = nonce[24] || ciphertext(op_bytes[2] + tag[16]) = 42 bytes.
+        assert_eq!(signed.payload.len(), SEALED_NONCE_LEN + 2 + SEALED_AEAD_TAG_LEN);
+        assert_eq!(&signed.payload[..SEALED_NONCE_LEN], &[0x5c; 24]);
+        assert_eq!(
+            hex(&signed.payload),
+            "5c5c5c5c5c5c5c5c5c5c5c5c5c5c5c5c5c5c5c5c5c5c5c5cd28d288c5c101ae99a532ea8621a1487e26f",
+        );
+        assert_eq!(
+            hex(&signed.entry_hash),
+            "dd019c5639f96b715d0e1c9254b175e8d98a890e5e49e2dcdcb997f2c9e7438a",
+        );
+        // Byte-reproducible under the same key + nonce.
+        let again =
+            sign_sealed_content_entry(&secret(), &header(), &[0x81, 0x01], &key, [0x5c; 24])
+                .unwrap();
+        assert_eq!(signed.signed_bytes, again.signed_bytes);
+    }
+
+    #[test]
+    fn a_sealed_payload_round_trips_under_the_content_key_and_header_aad() {
+        let key = content_key();
+        let op = [0x82, 0x01, 0x02];
+        // The nonce value is not load-bearing here (round-trip holds for any nonce), so exercise
+        // the random-nonce production entry point rather than a fixed injected nonce.
+        let signed = seal_and_sign_content_entry(&secret(), &header(), &op, &key).unwrap();
+        // AAD = the FINAL signed header content bytes (`header_bytes`), never a re-encode.
+        let recovered = open_sealed_payload(&key, &signed.payload, &signed.header_bytes).unwrap();
+        assert_eq!(recovered, op, "decrypt under the same key + header AAD recovers the op bytes");
+    }
+
+    #[test]
+    fn a_wrong_key_or_a_tampered_aad_fails_the_sealed_tag() {
+        let key = content_key();
+        // The nonce value is not load-bearing here, so use the random-nonce production entry point.
+        let signed =
+            seal_and_sign_content_entry(&secret(), &header(), &[0x81, 0x01], &key).unwrap();
+        // The right key + AAD opens (control).
+        assert!(open_sealed_payload(&key, &signed.payload, &signed.header_bytes).is_ok());
+        // A different content key cannot open.
+        let wrong = ContentKey::from_seed(&[0x21; 32]);
+        assert!(open_sealed_payload(&wrong, &signed.payload, &signed.header_bytes).is_err());
+        // Tampering ANY header field flips the AAD and fails the tag even under the right key — the
+        // seal authenticates the whole signed header.
+        let mut tampered = signed.header.clone();
+        tampered.author_auth_len ^= 1;
+        let tampered_aad = encode_header(&tampered);
+        assert_ne!(tampered_aad, signed.header_bytes);
+        assert!(open_sealed_payload(&key, &signed.payload, &tampered_aad).is_err());
+    }
+
+    #[test]
+    fn each_os_nonce_seal_yields_a_fresh_nonce_and_ciphertext() {
+        // The wire carries the nonce, and security rests on it being FRESH per seal. Two seals of
+        // the SAME op under the SAME key + header must differ in BOTH the nonce and the ciphertext;
+        // a regression to a fixed/derived nonce would reuse (key, nonce) — a classic AEAD break —
+        // yet still pass the injected-nonce golden above, so this is the only freshness guard.
+        let key = content_key();
+        let a = seal_and_sign_content_entry(&secret(), &header(), &[0x81, 0x01], &key).unwrap();
+        let b = seal_and_sign_content_entry(&secret(), &header(), &[0x81, 0x01], &key).unwrap();
+        assert_eq!(
+            a.header_bytes, b.header_bytes,
+            "same header ⇒ same AAD; only the nonce differs"
+        );
+        assert_ne!(
+            &a.payload[..SEALED_NONCE_LEN],
+            &b.payload[..SEALED_NONCE_LEN],
+            "each seal samples a fresh 24-byte wire nonce",
+        );
+        assert_ne!(
+            a.payload, b.payload,
+            "a fresh nonce yields different ciphertext for the same op"
+        );
+        // Freshness must not cost recoverability: both open to the original op.
+        assert_eq!(open_sealed_payload(&key, &a.payload, &a.header_bytes).unwrap(), [0x81, 0x01]);
+        assert_eq!(open_sealed_payload(&key, &b.payload, &b.header_bytes).unwrap(), [0x81, 0x01]);
+    }
+
+    #[test]
+    fn a_sealed_entry_decodes_and_verifies_with_an_opaque_suite_one_payload() {
+        // The already-sealed-ready ingest/decode path treats a suite-1 payload as opaque: it
+        // decodes + verifies (signature + fingerprint) without touching the ciphertext, and the AAD
+        // unit (`header_bytes`) round-trips for the eventual C5b decrypt.
+        let key = content_key();
+        // The nonce value is not load-bearing here, so use the random-nonce production entry point.
+        let signed =
+            seal_and_sign_content_entry(&secret(), &header(), &[0x82, 0x01, 0x02], &key).unwrap();
+        let decoded = decode_content_signed(&signed.signed_bytes).unwrap();
+        assert_eq!(decoded.header.crypto_suite, 1);
+        assert_eq!(decoded.payload, signed.payload, "the sealed payload is retained opaque");
+        let verified = verify_content_signed(&signed.signed_bytes, &secret().public()).unwrap();
+        assert_eq!(verified.header_bytes, signed.header_bytes, "the AAD unit round-trips");
+    }
+
+    #[test]
+    fn sealing_rejects_a_non_canonical_op_body() {
+        // The op body is the plaintext that becomes ciphertext; a non-canonical body is refused up
+        // front (the opaque suite-1 payload can't be canonicity-checked at decode).
+        let key = content_key();
+        // `0x18 0x00` is a non-minimal (non-canonical) encoding of 0.
+        assert!(
+            sign_sealed_content_entry(&secret(), &header(), &[0x18, 0x00], &key, [0x44; 24])
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn sealing_refuses_an_over_size_op_before_the_aead() {
+        // The sealed wire payload adds a fixed 40 bytes (24-byte nonce + 16-byte tag), so an op
+        // body over `CONTENT_ENVELOPE_MAX_BYTES - 40` can never fit the §18a envelope. The
+        // bound is enforced BEFORE the AEAD encrypt/allocate; drive it through the
+        // random-nonce production entry point so no fixed nonce is involved. The sealed
+        // twin of `authoring_refuses_an_over_size_entry`.
+        let key = content_key();
+        let sealed_body_max = CONTENT_ENVELOPE_MAX_BYTES - (SEALED_NONCE_LEN + SEALED_AEAD_TAG_LEN);
+        // A canonical bstr one byte past the sealed body bound (`0x5a` + 4-byte length + content).
+        let mut over = vec![0x5a];
+        over.extend_from_slice(&((sealed_body_max + 1 - 5) as u32).to_be_bytes());
+        over.resize(sealed_body_max + 1, 0);
+        assert!(cbor::require_canonical_cbor(&over).is_ok(), "the op body is canonical CBOR");
+        assert!(
+            seal_and_sign_content_entry(&secret(), &header(), &over, &key).is_err(),
+            "an op body over CAP - 40 is refused before the AEAD seal",
+        );
     }
 }

--- a/crates/rag-rat-oplog/src/account/content/mod.rs
+++ b/crates/rag-rat-oplog/src/account/content/mod.rs
@@ -15,6 +15,13 @@ pub use acceptance::{
     ContentParkReason, ContentRejectReason, SubjectAuthorityHold, UnknownAncestry,
     evaluate_content_acceptance,
 };
+// The C5a sealed-authoring seam (#608): the policy-aware self-transacting author, its
+// sealed-op size predicate, and the seal policy. UNWIRED — C5b + tests are the only consumers.
+#[allow(
+    unused_imports,
+    reason = "C5a sealed authoring is unwired until C5b consumes it (#608)"
+)]
+pub use author::{SealPolicy, author_content_batch, content_op_is_sealed_authorable};
 // The in-tx `/3` local-authoring seam + its genesis-detection reader (C3.4b-i, #663): live
 // callers in `query::memory` land with #664, so these are plain (un-frozen) re-exports.
 pub use author::{author_content_batch_in_tx, content_op_is_authorable, content_stream_is_empty};
@@ -22,6 +29,14 @@ pub use envelope::{
     ContentEntryHeader, SignedContentEntry, VerifiedContentEntry, decode_content_signed,
     sign_content_entry, verify_content_signed,
 };
+// The C5a envelope-layer seal + sign (#608): the injected-nonce core (goldens) and the
+// OS-nonce production wrapper. UNWIRED — the sealed author seam and C5b's tests are the only
+// consumers.
+#[allow(
+    unused_imports,
+    reason = "C5a sealed envelope is unwired until C5b consumes it (#608)"
+)]
+pub use envelope::{seal_and_sign_content_entry, sign_sealed_content_entry};
 #[allow(unused_imports, reason = "C2 storage seam is frozen before C3 wiring lands")]
 pub use storage::{
     ContentCapacityScope, ContentIngestOutcome, content_ingest, settle_pending_content_refolds,

--- a/crates/rag-rat-oplog/src/account/mod.rs
+++ b/crates/rag-rat-oplog/src/account/mod.rs
@@ -50,6 +50,19 @@ pub use content::{
     VerifiedContentEntry, content_ingest, decode_content_signed, settle_pending_content_refolds,
     sign_content_entry, verify_content_signed,
 };
+// The C5a sealed-authoring surface (#608): the envelope-layer seal
+// (`sign_sealed_content_entry` + its OS-nonce wrapper `seal_and_sign_content_entry`), the
+// policy-aware self-transacting author (`author_content_batch` + `SealPolicy`), and the
+// sealed-op size predicate. UNWIRED — C5b + tests are the only consumers, so the group keeps
+// the unused-import allowance.
+#[allow(
+    unused_imports,
+    reason = "C5a sealed authoring is unwired until C5b consumes it (#608)"
+)]
+pub use content::{
+    SealPolicy, author_content_batch, content_op_is_sealed_authorable, seal_and_sign_content_entry,
+    sign_sealed_content_entry,
+};
 // The in-tx `/3` content-author seam + its genesis-detection reader (C3.4b-i, #663): #664
 // retargets the live memory path onto them, so they are plain re-exports.
 pub use content::{author_content_batch_in_tx, content_op_is_authorable, content_stream_is_empty};

--- a/crates/rag-rat-oplog/src/lib.rs
+++ b/crates/rag-rat-oplog/src/lib.rs
@@ -82,16 +82,24 @@ mod stream;
 // - `rotate_stream_key_in_tx` / `ensure_stream_key_current_in_tx` / `stream_key_rotation_needed`
 //   (C4.4, #607): lazy content-key rotation on device removal — re-seal a fresh higher-epoch key to
 //   the remaining roster when a removed device still holds the current key.
+// `author_content_batch` / `SealPolicy` / `content_op_is_sealed_authorable` (C5a, #608): the
+// sealed-authoring seam — a policy-aware, self-transacting `/3` author that seals under the
+// stream's content key. UNWIRED: nothing live calls it until C5b lands decrypt-at-projection; the
+// live memory path stays on `author_content_batch_in_tx` (suite 0). The envelope-layer seal
+// primitives (`sign_sealed_content_entry` / `seal_and_sign_content_entry`) take a `&DeviceSecret`,
+// so — like `sign_content_entry` — they stay account-crate-internal (never re-exported at the crate
+// root, or they would leak the `pub(crate)` `DeviceSecret` past its visibility).
 pub use account::{
     AccountId, AuthorityBoundary, AuthorityFreshness, AuthorityInvalidReason, AuthorityQuery,
     CapacityScope, ContentKey, DeviceCut, DeviceRole, GrantAuthority, GrantDeviceAuthority,
     GrantDeviceBoundary, GrantRole, IngestOutcome, KeyId, OwnerAuthority, OwnerChainAuthority,
-    RosterContentAuthority, RotationOutcome, SealingKeyOutcome, SelectedWrap, account_ingest,
-    auth_len_freshness, author_content_batch_in_tx, backfill_authority_projection,
-    content_op_is_authorable, content_stream_is_empty, current_sealing_key,
-    ensure_owned_stream_v2_in_tx, ensure_stream_key_current_in_tx, established_owned_stream_v2,
-    grant_effective_for_device, local_account, mint_and_author_stream_key_wrap_in_tx,
-    owned_stream_v2_id, owner_control_authority, owner_secrets_authority, roster_content_authority,
+    RosterContentAuthority, RotationOutcome, SealPolicy, SealingKeyOutcome, SelectedWrap,
+    account_ingest, auth_len_freshness, author_content_batch, author_content_batch_in_tx,
+    backfill_authority_projection, content_op_is_authorable, content_op_is_sealed_authorable,
+    content_stream_is_empty, current_sealing_key, ensure_owned_stream_v2_in_tx,
+    ensure_stream_key_current_in_tx, established_owned_stream_v2, grant_effective_for_device,
+    local_account, mint_and_author_stream_key_wrap_in_tx, owned_stream_v2_id,
+    owner_control_authority, owner_secrets_authority, roster_content_authority,
     rotate_stream_key_in_tx, select_current_sealing_wrap, stream_key_rotation_needed,
     stream_owner_effective,
 };


### PR DESCRIPTION
Adds the sealed `/3` content authoring machinery — **unwired**. It composes the sealed author seam, the suite-1 envelope, and the content AEAD, exercised only by tests; the live `sync_owner_stream` / `author_content_batch_in_tx` path is untouched and stays `crypto_suite = 0` (plaintext). Part of phase-C sealed content (#608); consumes the C4 content-key machinery. The read/decrypt side (keyring + decrypt-at-projection + #683) is the follow-up that flips a live stream to sealed.

**Why unwired:** authoring a sealed entry into the live path before the decrypt side exists would trigger a mass-duplication loop — ciphertext fails `op::decode` in reprojection, the entry is skipped from the projection, and the reconcile's completeness anti-join re-authors the whole history on every mutation. So the machinery lands one slice ahead of its consumer.

## What lands
- **`sign_sealed_content_entry` / `seal_and_sign_content_entry`** (`content/envelope.rs`): finalizes the header (device fingerprint, `crypto_suite = 1`, `key_id`) *before* encoding, uses those final header content bytes as the AEAD AAD, and writes `payload (bstr) = nonce[24] || ciphertext(op_bytes + 16-byte Poly1305 tag)`. XChaCha20-Poly1305 under the content key with a **random 24-byte wire nonce** per seal (a content key is long-lived, so a fresh random nonce — not a derived one — is what guarantees no (key, nonce) reuse). `sign_content_entry` keeps its suite-0-only bail (the sealed sibling is the only suite-1 path, so a suite-1-over-plaintext header is unconstructible).
- **`author_content_batch` + `SealPolicy {Plaintext | Sealed}`** (`content/author.rs`): the Sealed arm does the three-txn key acquisition (ensure-rotation → resolve key → seal+author+verify-accepted), fails **closed** if the key can't resolve on a private stream (never plaintext-fallback, never a plaintext park). A derived **downgrade ratchet** refuses plaintext authoring on any stream that has an accepted key wrap (any epoch) or an accepted sealed entry — wrap-presence is a ratchet *input*, never the privacy oracle (a private stream's wrap set can legitimately empty under sync lag / retro-condemn).
- **Size accounting:** `content_op_is_sealed_authorable` reserves the +40-byte AEAD overhead (nonce + tag) so the #680 boundary doesn't wedge sealed streams.

## Out of scope (follow-up)
The read side: `content_key_for(key_id)` keyring, decrypt-at-projection, the #683 reprojection-on-acceptance-flip trigger, and the live wiring / enable surface. New-device catch-up. Snapshots, transport.

## Tests / gates
The fold-firewall tripwire — a sealed entry authored via the seam ingests + folds `accepted` on a keyless peer (no wrap/key) — plus round-trip decrypt, wrong-key/tampered-AAD tag failure, per-seal nonce freshness, the downgrade ratchet refusing plaintext, keyless-seal bailing with no row leaked, and unchanged suite-0 public authoring. A golden pins the sealed wire under an injected nonce. `cargo nextest run -p rag-rat-oplog` → 486 passed; clippy (`-D warnings`, both feature sets) and nightly `fmt --check` clean.
