### PR TITLE
feat(plugin): opencode plugin bundle — @rag-rat/plugin-opencode (MCP + hooks)

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -13,6 +13,8 @@
 #                       workflow.)
 #   @rag-rat/skills   — the agent-skills installer (a thin wrapper; the skills are fetched from GitHub).
 #   @rag-rat/cookbook — the ephemeral-provisioning recipes.
+#   @rag-rat/plugin-opencode — the opencode plugin (plugin/opencode/); versions in lockstep with the
+#                       crate via tools/sync-plugin-version.mjs, like @rag-rat/bin.
 #
 # @rag-rat/skills and @rag-rat/cookbook are versioned INDEPENDENTLY of the crate, so each publishes
 # only when its package.json version is not already on npm — a re-run, or a release that didn't bump
@@ -113,6 +115,19 @@ jobs:
           fi
 
       # ── @rag-rat/skills + @rag-rat/cookbook: publish only when their version is new ───────────────
+      - name: Publish @rag-rat/plugin-opencode (only if this version is new)
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          set -euo pipefail
+          name="$(node -p "require('./plugin/opencode/package.json').name")"
+          ver="$(node -p "require('./plugin/opencode/package.json').version")"
+          if npm view "$name@$ver" version >/dev/null 2>&1; then
+            echo "$name@$ver already on npm — skipping"
+          else
+            echo "publishing $name@$ver"
+            (cd plugin/opencode && npm publish --access public)
+          fi
       - name: Publish @rag-rat/skills (only if this version is new)
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ sequenceDiagram
   symbols.
 - **History as evidence.** Git history, lazy chunk blame, and cached GitHub issue/PR/review
   rationale, all queryable.
-- **Rides your existing grep.** A [PreToolUse hook](docs/grep-augmentation.md) injects the memories
-  and symbols behind whatever you just searched for.
+- **Rides your existing grep.** A [grep-augmentation hook](docs/grep-augmentation.md) injects the
+  memories and symbols behind whatever you just searched for.
 - **Flags clones as you write them.** A PreToolUse hook on Write/Edit/MultiEdit fingerprints the
   functions you're writing and warns when they're exact or near-duplicates of code already in the
   repo — so an agent reuses instead of re-implementing. Read-only, and a silent no-op when the index
@@ -53,8 +53,8 @@ sequenceDiagram
 
 ## Quickstart
 
-For Claude Code and Codex, install the plugin. It registers the MCP server, adds the skills and
-hooks, and installs a version-matched `rag-rat` binary on first run:
+For Claude Code, Codex, and opencode, install the plugin. It registers the MCP server, adds the
+skills and hooks, and installs a version-matched `rag-rat` binary on first run:
 
 ```bash
 # Claude Code
@@ -66,7 +66,13 @@ codex plugin marketplace add cq27-dev/rag-rat
 codex plugin add rag-rat@rag-rat
 ```
 
-After installing, approve the plugin so its tools and hooks run:
+```jsonc
+// opencode — add to opencode.json
+{ "plugin": ["@rag-rat/plugin-opencode"] }
+```
+
+After installing, approve the plugin so its tools and hooks run (opencode loads plugins without an
+approval step — nothing to do there):
 
 - **Claude Code** asks before each rag-rat MCP tool the first time it runs — choose "Yes, don't ask
   again," or pre-allow them in `~/.claude/settings.json` with

--- a/README.md
+++ b/README.md
@@ -64,11 +64,9 @@ claude plugin install rag-rat@rag-rat
 # Codex
 codex plugin marketplace add cq27-dev/rag-rat
 codex plugin add rag-rat@rag-rat
-```
 
-```jsonc
-// opencode — add to opencode.json
-{ "plugin": ["@rag-rat/plugin-opencode"] }
+# opencode (add -g for a global install)
+opencode plugin @rag-rat/plugin-opencode
 ```
 
 After installing, approve the plugin so its tools and hooks run (opencode loads plugins without an

--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ sequenceDiagram
 ## Quickstart
 
 For Claude Code, Codex, and opencode, install the plugin. It registers the MCP server, adds the
-skills and hooks, and installs a version-matched `rag-rat` binary on first run:
+hooks, and installs a version-matched `rag-rat` binary on first run (the Claude Code and Codex
+bundles also add the skills; on opencode add them with `npx @rag-rat/skills`):
 
 ```bash
 # Claude Code

--- a/docs/grep-augmentation.md
+++ b/docs/grep-augmentation.md
@@ -37,11 +37,9 @@ claude plugin install rag-rat@rag-rat
 # Codex
 codex plugin marketplace add cq27-dev/rag-rat
 codex plugin add rag-rat@rag-rat
-```
 
-```jsonc
-// opencode — opencode.json
-{ "plugin": ["@rag-rat/plugin-opencode"] }
+# opencode (add -g for a global install)
+opencode plugin @rag-rat/plugin-opencode
 ```
 
 The plugin routes every search through `rag-rat agent-hook` with a 10-second timeout:

--- a/docs/grep-augmentation.md
+++ b/docs/grep-augmentation.md
@@ -1,9 +1,10 @@
-# Claude Code grep augmentation
+# Grep augmentation
 
-`rag-rat` augments Claude Code's `Grep` tool calls and `grep`/`rg`/`ag` Bash commands with symbol
-and repo-memory context via the PreToolUse hook mechanism. When a grep pattern matches a known
-symbol or a bound repo memory, the hook injects an `additionalContext` digest before the tool runs.
-The hook never blocks a grep — it always exits 0.
+`rag-rat` augments an agent's search calls — Claude Code's `Grep` tool and `grep`/`rg`/`ag` Bash
+commands, Codex's `^Bash$`, opencode's `grep`/`bash` tools — with symbol and repo-memory context
+via the coding-agent hook mechanism. When a grep pattern matches a known symbol or a bound repo
+memory, the hook injects an `additionalContext` digest. The hook never blocks a grep — it always
+exits 0.
 
 ## What gets injected
 
@@ -38,14 +39,22 @@ codex plugin marketplace add cq27-dev/rag-rat
 codex plugin add rag-rat@rag-rat
 ```
 
-The plugin registers `PreToolUse` hooks on `Grep`/`Bash` (Claude Code) / `^Bash$` (Codex), each
-invoking `rag-rat agent-hook` with a 10-second timeout. When invoked, `agent-hook` walks up from the
-reported `cwd` looking for a `rag-rat.toml`. If none is found, the hook exits immediately without
-printing anything — a silent no-op for repositories that are not indexed by rag-rat.
+```jsonc
+// opencode — opencode.json
+{ "plugin": ["@rag-rat/plugin-opencode"] }
+```
+
+The plugin routes every search through `rag-rat agent-hook` with a 10-second timeout:
+`PreToolUse` on `Grep`/`Bash` (Claude Code), `PreToolUse` on `^Bash$` (Codex), and
+`tool.execute.after` on `grep`/`bash` (opencode, whose pre-tool hook has no context channel — the
+digest rides **on the tool result** there instead of preceding it). When invoked, `agent-hook`
+walks up from the reported `cwd` looking for a `rag-rat.toml`. If none is found, the hook exits
+immediately without printing anything — a silent no-op for repositories that are not indexed by
+rag-rat.
 
 ## How it serves
 
-When `rag-rat mcp` is running (the normal configuration for Claude Code), its process also holds the
+When `rag-rat mcp` is running (the normal plugin configuration), its process also holds the
 socket election for the current worktree. One listener wins per worktree and binds a Unix domain
 socket. The hook client connects to that socket, sends the pattern and session ID in a
 newline-delimited JSON request, and gets a reply within its 250 ms budget.
@@ -56,8 +65,8 @@ without per-session dedupe.
 
 ## Dedupe
 
-The listener tracks per-session state: once a memory or symbol has been injected for a given Claude
-Code session ID, it will not be injected again for the same session. The session map is in-memory;
+The listener tracks per-session state: once a memory or symbol has been injected for a given agent
+session ID, it will not be injected again for the same session. The session map is in-memory;
 dedupe resets when the listener restarts. The fallback path is stateless — the same content can be
 injected on every grep when no listener is running.
 

--- a/docs/grep-augmentation.md
+++ b/docs/grep-augmentation.md
@@ -26,8 +26,8 @@ through the symbol lane.
 ## Install
 
 The grep-augmentation hook ships with the **rag-rat plugin** — installing the plugin registers it in
-one step (along with the MCP server, the agent skills, and the write-time clone-check and
-session-digest hooks):
+one step (along with the MCP server and the write-time clone-check and session-digest hooks; the
+Claude Code and Codex bundles also add the agent skills):
 
 ```bash
 # Claude Code

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -91,7 +91,15 @@ output.
 
 ### Installing in opencode
 
-Two options:
+Three options:
+- **npm (recommended):** the plugin ships as `@rag-rat/plugin-opencode` (source of truth:
+  `plugin/opencode/`, version synced with the release). Add it to `opencode.json`:
+  ```json
+  { "plugin": ["@rag-rat/plugin-opencode"] }
+  ```
+  opencode installs it with bun at startup. The entry is the TS source itself (`main:
+  rag-rat.ts`) — opencode's bun runtime loads TS directly, so no build step can drift; the
+  type-only `@opencode-ai/plugin` import is erased at compile time.
 - **Whole bundle** (keeps the shared launcher): copy or symlink the repo's `plugin/` tree
   somewhere stable and symlink `plugin/opencode/rag-rat.ts` into `~/.config/opencode/plugins/`
   (global) or `.opencode/plugins/` (project). The shim finds `../scripts/launch.js` relative to
@@ -99,8 +107,7 @@ Two options:
 - **Single file**: drop `opencode/rag-rat.ts` alone into the plugins dir. The shim then resolves
   the binary itself with the launcher's `--no-install` policy (`$RAG_RAT_BIN` → managed cache →
   npx cache → version-matched `PATH`); hooks no-op until the MCP server's first `npx` run has
-  installed the binary. Its type-only `@opencode-ai/plugin` import is erased at compile time, so
-  no `node_modules` is needed.
+  installed the binary.
 
 ### Still to verify on-device
 

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -93,13 +93,14 @@ output.
 
 Three options:
 - **npm (recommended):** the plugin ships as `@rag-rat/plugin-opencode` (source of truth:
-  `plugin/opencode/`, version synced with the release). Add it to `opencode.json`:
-  ```json
-  { "plugin": ["@rag-rat/plugin-opencode"] }
+  `plugin/opencode/`, version synced with the release). Install with the opencode CLI, which adds
+  it to the config for you (`-g` targets the global config instead of the project):
+  ```bash
+  opencode plugin @rag-rat/plugin-opencode    # add -g for a global install
   ```
-  opencode installs it with bun at startup. The entry is the TS source itself (`main:
-  rag-rat.ts`) — opencode's bun runtime loads TS directly, so no build step can drift; the
-  type-only `@opencode-ai/plugin` import is erased at compile time.
+  The entry is the TS source itself (`main: rag-rat.ts`) — opencode's bun runtime loads TS
+  directly, so no build step can drift; the type-only `@opencode-ai/plugin` import is erased at
+  compile time.
 - **Whole bundle** (keeps the shared launcher): copy or symlink the repo's `plugin/` tree
   somewhere stable and symlink `plugin/opencode/rag-rat.ts` into `~/.config/opencode/plugins/`
   (global) or `.opencode/plugins/` (project). The shim finds `../scripts/launch.js` relative to

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -101,6 +101,9 @@ Three options:
   The entry is the TS source itself (`main: rag-rat.ts`) — opencode's bun runtime loads TS
   directly, so no build step can drift; the type-only `@opencode-ai/plugin` import is erased at
   compile time.
+  The package registers the MCP server and the hooks; it does **not** carry the agent skills
+  (opencode has no plugin-bundled-skills mechanism — they live in `.opencode/skills/` /
+  `~/.config/opencode/skills/`). Add them with the shared installer: `npx @rag-rat/skills`.
 - **Whole bundle** (keeps the shared launcher): copy or symlink the repo's `plugin/` tree
   somewhere stable and symlink `plugin/opencode/rag-rat.ts` into `~/.config/opencode/plugins/`
   (global) or `.opencode/plugins/` (project). The shim finds `../scripts/launch.js` relative to

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,9 +1,9 @@
 # rag-rat plugin (prototype)
 
-A coding-agent plugin — for **Claude Code and Codex** (and any other harness with the same plugin
-shape) — that bundles rag-rat's MCP server, skills, and hooks, and **installs a version-matched
-rag-rat binary on first run**. Installing the plugin is one step: the user does not need to
-`cargo install` / `brew install` / put `rag-rat` on `PATH` first.
+A coding-agent plugin — for **Claude Code, Codex, and opencode** (and any other harness with the
+same plugin shape) — that bundles rag-rat's MCP server, skills, and hooks, and **installs a
+version-matched rag-rat binary on first run**. Installing the plugin is one step: the user does
+not need to `cargo install` / `brew install` / put `rag-rat` on `PATH` first.
 
 ## Layout (single source, shared across harnesses)
 
@@ -17,6 +17,7 @@ plugin/                          plugin root (CLAUDE_PLUGIN_ROOT / CODEX_PLUGIN_
   .claude-plugin/marketplace.json
   .codex-plugin/plugin.json        Codex manifest: mcpServers → ./.mcp.json, skills → ./skills/
   .codex-plugin/hooks/hooks.json   Codex hooks
+  opencode/rag-rat.ts              opencode plugin (TS module; MCP self-registration + hooks)
 ```
 
 Both harnesses treat `plugin/` as the plugin root, so `scripts/`, `skills/`, and the launcher are
@@ -72,6 +73,34 @@ output.
 - `PreToolUse` on `^Bash$` → grep-augmentation.
 - `PreToolUse` on `^apply_patch$` → write-time clone check. The handler parses the V4A diff in
   `tool_input.command` for added lines (Codex/Cursor edit via `apply_patch`, not `Write`/`Edit`).
+
+**opencode** (`opencode/rag-rat.ts`, a TS plugin module — no hooks manifest exists there):
+- `config` hook → self-registers the `rag-rat` MCP server (`npx -y @rag-rat/bin@<version> mcp`)
+  unless the user's `opencode.json` already defines one.
+- `session.created` event → orientation digest, injected into the system prompt via
+  `experimental.chat.system.transform`; `experimental.session.compacting` re-injects a fresh
+  digest into the compaction prompt (parity with Claude's `SessionStart(compact)`).
+- `tool.execute.after` on `grep`/`bash`/`read` → grep/read augmentation. opencode's
+  `tool.execute.before` has no additionalContext channel, so the context rides **on the tool
+  result** instead of preceding it.
+- `tool.execute.after` on `write`/`edit` → PostToolUse scoped reindex + write-time clone check.
+- The shim translates opencode's lowercase/camelCase tool calls (`grep`, `filePath`, `newString`)
+  to the harness-neutral `agent-hook` payload (`Grep`, `file_path`, `new_string`) — the Rust hook
+  handler is unchanged. Every path fails silent (never blocks a tool call), mirroring the
+  `--no-install` contract.
+
+### Installing in opencode
+
+Two options:
+- **Whole bundle** (keeps the shared launcher): copy or symlink the repo's `plugin/` tree
+  somewhere stable and symlink `plugin/opencode/rag-rat.ts` into `~/.config/opencode/plugins/`
+  (global) or `.opencode/plugins/` (project). The shim finds `../scripts/launch.js` relative to
+  its real path.
+- **Single file**: drop `opencode/rag-rat.ts` alone into the plugins dir. The shim then resolves
+  the binary itself with the launcher's `--no-install` policy (`$RAG_RAT_BIN` → managed cache →
+  npx cache → version-matched `PATH`); hooks no-op until the MCP server's first `npx` run has
+  installed the binary. Its type-only `@opencode-ai/plugin` import is erased at compile time, so
+  no `node_modules` is needed.
 
 ### Still to verify on-device
 

--- a/plugin/opencode/package.json
+++ b/plugin/opencode/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@rag-rat/plugin-opencode",
+  "version": "0.19.0",
+  "description": "opencode plugin for rag-rat: self-registers the rag-rat MCP server (semantic search, symbol/graph navigation, impact-surface preflight, repo memory) and wires session/grep/edit hooks through the shared agent-hook.",
+  "license": "MIT",
+  "type": "module",
+  "main": "rag-rat.ts",
+  "exports": {
+    ".": "./rag-rat.ts"
+  },
+  "files": [
+    "rag-rat.ts"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/cq27-dev/rag-rat.git",
+    "directory": "plugin/opencode"
+  },
+  "homepage": "https://github.com/cq27-dev/rag-rat",
+  "keywords": [
+    "opencode",
+    "opencode-plugin",
+    "mcp",
+    "code-intelligence",
+    "semantic-search",
+    "code-graph",
+    "repo-memory"
+  ],
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/plugin/opencode/rag-rat.ts
+++ b/plugin/opencode/rag-rat.ts
@@ -1,0 +1,305 @@
+// rag-rat opencode plugin: bundles the rag-rat MCP server + hook integrations.
+//
+// opencode's plugin shape differs from Claude Code / Codex (no hooks.json manifest, no
+// additionalContext channel on tool.execute.before), so this module is a thin shim over the same
+// shared pieces the other harnesses use:
+//   - MCP: registered via the `config` hook as `npx -y @rag-rat/bin@0.19.0<version> mcp` (pinned; kept
+//     in lockstep with the release by tools/sync-plugin-version.mjs).
+//   - Hooks: routed through the shared launcher (`../scripts/launch.js --no-install agent-hook`)
+//     when this file lives in the repo's plugin bundle, or — for a standalone single-file install
+//     — through the same resolve-only policy inline ($RAG_RAT_BIN → managed cache → npx cache →
+//     version-matched PATH). Either way a hook NEVER blocks on an install or a network fetch: it
+//     is a fast no-op until the MCP server's first npx run has installed the binary.
+//   - Payload translation: opencode tool names/args are lowercase/camelCase; the harness-neutral
+//     `agent-hook` contract expects Claude-style `tool_name` / `tool_input`, so the shim maps
+//     bash→Bash, grep→Grep, read→Read, write→Write, edit→Edit.
+//   - Context injection: Claude's PreToolUse additionalContext becomes (a) appended text on the
+//     tool result in `tool.execute.after` and (b) a system-prompt entry via
+//     `experimental.chat.system.transform` for the SessionStart orientation digest.
+//
+// Every path fails silent: a missing binary, a slow launcher, or a bad payload must never break
+// or delay an opencode tool call.
+
+import { spawn, spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+// Type-only import: erased at compile time, so a standalone install needs no node_modules.
+import type { Plugin } from "@opencode-ai/plugin";
+
+// realpath: when the plugin is symlinked into ~/.config/opencode/plugins/ from the repo bundle,
+// the launcher must resolve relative to the REAL location, not the symlink's dir.
+const PLUGIN_DIR = fs.realpathSync(path.dirname(fileURLToPath(import.meta.url)));
+const BUNDLED_LAUNCHER = path.join(PLUGIN_DIR, "..", "scripts", "launch.js");
+
+// Single source of truth for the version: the pinned npm package (kept in lockstep with the
+// release by tools/sync-plugin-version.mjs — do not hand-edit the pin).
+const MCP_PACKAGE = "@rag-rat/bin@0.19.0";
+const VERSION = MCP_PACKAGE.split("@").pop()!;
+
+const TOOL_TIMEOUT_MS = 10_000;
+const SESSION_TIMEOUT_MS = 5_000;
+
+// ---- binary resolution (standalone fallback — mirrors scripts/launch.js --no-install) ----------
+
+const BIN = os.platform() === "win32" ? "rag-rat.exe" : "rag-rat";
+
+function isExecutable(p: string): boolean {
+  try {
+    fs.accessSync(p, fs.constants.X_OK);
+    return fs.statSync(p).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function readBinVersion(p: string): string {
+  const r = spawnSync(p, ["--version"], { encoding: "utf8" });
+  return r.status === 0
+    ? (r.stdout.match(/rag-rat\s+([0-9][^\s]*)/) || [])[1] || ""
+    : "";
+}
+
+function whichVersioned(): string | null {
+  const exts =
+    process.platform === "win32" ? (process.env.PATHEXT || ".EXE").split(";") : [""];
+  for (const dir of (process.env.PATH || "").split(path.delimiter)) {
+    for (const e of exts) {
+      const full = path.join(dir, BIN.endsWith(".exe") ? BIN : BIN + e);
+      if (isExecutable(full) && readBinVersion(full) === VERSION) return full;
+    }
+  }
+  return null;
+}
+
+function npxCachedBin(): string | null {
+  const npmCache =
+    process.env.npm_config_cache ||
+    (process.platform === "win32"
+      ? path.join(
+          process.env.LOCALAPPDATA || path.join(os.homedir(), "AppData", "Local"),
+          "npm-cache",
+        )
+      : path.join(os.homedir(), ".npm"));
+  let hashes: string[];
+  try {
+    hashes = fs.readdirSync(path.join(npmCache, "_npx"));
+  } catch {
+    return null;
+  }
+  for (const h of hashes) {
+    const p = path.join(
+      npmCache,
+      "_npx",
+      h,
+      "node_modules",
+      "@rag-rat",
+      "bin",
+      "node_modules",
+      ".bin_real",
+      BIN,
+    );
+    if (isExecutable(p) && readBinVersion(p) === VERSION) return p;
+  }
+  return null;
+}
+
+type HookCommand = { cmd: string; args: string[] };
+
+// The command + args to invoke for one hook call, or null when nothing resolvable exists yet
+// (the hook no-op path). Prefers the bundled launcher; falls back to direct binary resolution so
+// a lone `rag-rat.ts` dropped into ~/.config/opencode/plugins/ still works.
+function resolveHookCommand(): HookCommand | null {
+  if (process.env.RAG_RAT_BIN) {
+    return isExecutable(process.env.RAG_RAT_BIN)
+      ? { cmd: process.env.RAG_RAT_BIN, args: ["agent-hook"] }
+      : null;
+  }
+  if (fs.existsSync(BUNDLED_LAUNCHER)) {
+    return { cmd: "node", args: [BUNDLED_LAUNCHER, "--no-install", "agent-hook"] };
+  }
+  const cacheHome = process.env.XDG_CACHE_HOME || path.join(os.homedir(), ".cache");
+  const managed = path.join(cacheHome, "rag-rat", "bin", VERSION, BIN);
+  const bin = isExecutable(managed) ? managed : npxCachedBin() || whichVersioned();
+  return bin ? { cmd: bin, args: ["agent-hook"] } : null;
+}
+
+// ---- hook invocation ----------------------------------------------------------------------------
+
+// Run one hook payload; resolve stdout ("" on any failure or timeout — silence is the contract).
+function runHook(payload: Record<string, unknown>, timeoutMs: number): Promise<string> {
+  const resolved = resolveHookCommand();
+  if (!resolved) return Promise.resolve("");
+  return new Promise((resolve) => {
+    let child;
+    try {
+      child = spawn(resolved.cmd, resolved.args, { stdio: ["pipe", "pipe", "ignore"] });
+    } catch {
+      return resolve("");
+    }
+    let out = "";
+    let settled = false;
+    const finish = (v: string) => {
+      if (!settled) {
+        settled = true;
+        clearTimeout(timer);
+        resolve(v);
+      }
+    };
+    const timer = setTimeout(() => {
+      try {
+        child.kill();
+      } catch {}
+      finish("");
+    }, timeoutMs);
+    child.stdout.on("data", (d) => {
+      out += d;
+    });
+    child.on("error", () => finish(""));
+    child.on("close", () => finish(out));
+    child.stdin.on("error", () => finish(out));
+    child.stdin.end(JSON.stringify(payload));
+  });
+}
+
+// PreToolUse events emit `{"hookSpecificOutput":{"additionalContext": ...}}` on one JSON line;
+// tolerate any surrounding noise by scanning lines. SessionStart emits the digest as PLAIN
+// stdout — that path uses the raw output, not this extractor.
+function extractAdditionalContext(stdout: string): string | null {
+  for (const line of stdout.split("\n")) {
+    const t = line.trim();
+    if (!t.startsWith("{")) continue;
+    try {
+      const c = JSON.parse(t)?.hookSpecificOutput?.additionalContext;
+      if (typeof c === "string" && c.trim()) return c;
+    } catch {}
+  }
+  return null;
+}
+
+// ---- opencode → harness-neutral payload translation ----------------------------------------------
+
+type Translated = { tool_name: string; tool_input: Record<string, unknown> };
+
+// Map an opencode tool call to the harness-neutral agent-hook payload, or null when the tool
+// carries no searchable/editable intent the hook understands.
+function translate(tool: string, args: any): Translated | null {
+  switch (tool) {
+    case "bash":
+      if (typeof args?.command !== "string") return null;
+      return { tool_name: "Bash", tool_input: { command: args.command } };
+    case "grep":
+      if (typeof args?.pattern !== "string") return null;
+      return { tool_name: "Grep", tool_input: { pattern: args.pattern, path: args.path } };
+    case "read":
+      if (typeof args?.filePath !== "string") return null;
+      return { tool_name: "Read", tool_input: { file_path: args.filePath } };
+    case "write":
+      if (typeof args?.filePath !== "string") return null;
+      return {
+        tool_name: "Write",
+        tool_input: { file_path: args.filePath, content: args.content ?? "" },
+      };
+    case "edit":
+      if (typeof args?.filePath !== "string") return null;
+      return {
+        tool_name: "Edit",
+        tool_input: { file_path: args.filePath, new_string: args.newString ?? "" },
+      };
+    default:
+      return null;
+  }
+}
+
+function isEditTool(tool: string): boolean {
+  return tool === "write" || tool === "edit";
+}
+
+function sessionIdOf(event: any): string {
+  return event?.properties?.info?.id ?? event?.properties?.sessionID ?? "";
+}
+
+// ---- the plugin -----------------------------------------------------------------------------------
+
+export const RagRat: Plugin = async ({ directory }) => {
+  // sessionID → SessionStart orientation digest, consumed once by system.transform. Key "" holds
+  // a digest whose session could not be identified (consumed by the first transform call).
+  const digests = new Map<string, string>();
+
+  const takeDigest = (sessionID: string): string | undefined => {
+    const key = digests.has(sessionID) ? sessionID : "";
+    const d = digests.get(key);
+    if (d !== undefined) digests.delete(key);
+    return d;
+  };
+
+  const sessionStart = async (source: string, sessionID: string) => {
+    const out = await runHook(
+      { hook_event_name: "SessionStart", source, session_id: sessionID, cwd: directory },
+      SESSION_TIMEOUT_MS,
+    );
+    const digest = out.trim();
+    if (digest) digests.set(sessionID, digest);
+  };
+
+  return {
+    // Self-register the rag-rat MCP server unless the user already configured one.
+    config: async (cfg) => {
+      cfg.mcp ??= {};
+      cfg.mcp["rag-rat"] ??= {
+        type: "local",
+        command: ["npx", "-y", MCP_PACKAGE, "mcp"],
+        enabled: true,
+      };
+    },
+
+    event: async ({ event }) => {
+      if (event?.type === "session.created") {
+        await sessionStart("startup", sessionIdOf(event));
+      }
+    },
+
+    // Inject the orientation digest into the system prompt on the session's first LLM call.
+    "experimental.chat.system.transform": async (input, output) => {
+      const digest = takeDigest(input.sessionID ?? "");
+      if (digest) output.system.push(digest);
+    },
+
+    // Compaction parity with Claude's SessionStart(compact): re-inject a fresh digest into the
+    // compaction prompt so orientation survives context truncation.
+    "experimental.session.compacting": async (input, output) => {
+      const out = await runHook(
+        {
+          hook_event_name: "SessionStart",
+          source: "compact",
+          session_id: input.sessionID ?? "",
+          cwd: directory,
+        },
+        SESSION_TIMEOUT_MS,
+      );
+      const digest = out.trim();
+      if (digest) output.context.push(digest);
+    },
+
+    "tool.execute.after": async (input, output) => {
+      const translated = translate(input.tool, input.args);
+      if (!translated) return;
+      const base = { session_id: input.sessionID ?? "", cwd: directory };
+      // Edits: fire the PostToolUse scoped reindex first (detached server-side; no stdout), then
+      // the write-time clone check, which reports via additionalContext.
+      if (isEditTool(input.tool)) {
+        await runHook(
+          { ...base, hook_event_name: "PostToolUse", ...translated },
+          TOOL_TIMEOUT_MS,
+        );
+      }
+      const out = await runHook(
+        { ...base, hook_event_name: "PreToolUse", ...translated },
+        TOOL_TIMEOUT_MS,
+      );
+      const context = extractAdditionalContext(out);
+      if (context) output.output += `\n\n${context}`;
+    },
+  };
+};

--- a/plugin/test/verify-opencode-install.sh
+++ b/plugin/test/verify-opencode-install.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Non-interactive opencode plugin verification. opencode has no plugin-install CLI — a plugin is
+# a TS/JS file in a plugins dir — so this verifies the shim itself end-to-end against a local
+# rag-rat binary: MCP self-registration, grep augmentation, SessionStart digest injection, and
+# the compaction hook. Set RAG_RAT_BIN to a built binary (e.g. target/debug/rag-rat).
+set -u
+PLUGIN_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+step() { echo; echo "### $*"; }
+fail() { echo "FAIL: $*" >&2; exit 1; }
+pass() { echo "PASS: $*"; }
+
+command -v bun >/dev/null 2>&1 || fail "bun not found (opencode's plugin runtime)"
+[ -n "${RAG_RAT_BIN:-}" ] || fail "set RAG_RAT_BIN to a built rag-rat binary"
+[ -x "$RAG_RAT_BIN" ] || fail "RAG_RAT_BIN=$RAG_RAT_BIN is not executable"
+echo "bun: $(bun --version)"; echo "rag-rat: $("$RAG_RAT_BIN" --version)"
+
+step "drive the plugin hooks through bun"
+# Run from an indexed repo so the hooks have something to augment. Session id is randomized —
+# agent-hook dedups repeated searches per session, so a fixed id would make reruns report nothing.
+out="$(cd "$PLUGIN_DIR/.." && RAG_RAT_BIN="$RAG_RAT_BIN" bun -e '
+import("./plugin/opencode/rag-rat.ts").then(async (m) => {
+  const sid = "verify-" + Date.now();
+  const hooks = await m.RagRat({ directory: process.cwd() });
+  const result = {};
+  const cfg = {};
+  await hooks.config(cfg);
+  result.mcp = cfg.mcp?.["rag-rat"]?.command?.join(" ") ?? "";
+  const grepOut = { title: "t", output: "RESULT", metadata: {} };
+  await hooks["tool.execute.after"](
+    { tool: "grep", sessionID: sid, callID: "c1", args: { pattern: "HookInput" } }, grepOut);
+  result.grep = grepOut.output;
+  await hooks.event({ event: { type: "session.created", properties: { info: { id: sid } } } });
+  const sys = { system: [] };
+  await hooks["experimental.chat.system.transform"]({ sessionID: sid }, sys);
+  result.system = sys.system.join(" ");
+  const comp = { context: [] };
+  await hooks["experimental.session.compacting"]({ sessionID: sid }, comp);
+  result.compact = comp.context.join(" ");
+  console.log(JSON.stringify(result));
+})' 2>&1)" || fail "bun run failed: $out"
+echo "$out" | head -c 400; echo
+
+echo "$out" | grep -q '@rag-rat/bin@[0-9][^"]* mcp' || fail "config hook did not register the pinned MCP server"
+pass "config hook registers the pinned MCP server"
+echo "$out" | grep -q "rag-rat index context" || fail "grep augmentation missing from tool.execute.after output"
+pass "grep augmentation appended to the tool result"
+echo "$out" | grep -q "repo intelligence" || fail "SessionStart digest missing from system.transform"
+pass "SessionStart digest injected via system.transform"
+echo "$out" | grep -q "repo intelligence" || fail "compaction digest missing"
+pass "compaction digest injected"
+
+step "cold-cache no-op (the --no-install contract)"
+# An unresolvable RAG_RAT_BIN must make every hook a silent no-op, never an error.
+noop="$(cd "$PLUGIN_DIR/.." && RAG_RAT_BIN=/nonexistent/rag-rat bun -e '
+import("./plugin/opencode/rag-rat.ts").then(async (m) => {
+  const hooks = await m.RagRat({ directory: process.cwd() });
+  const out = { title: "t", output: "RESULT", metadata: {} };
+  await hooks["tool.execute.after"](
+    { tool: "grep", sessionID: "s", callID: "c", args: { pattern: "x" } }, out);
+  const sys = { system: [] };
+  await hooks["experimental.chat.system.transform"]({ sessionID: "s" }, sys);
+  console.log(JSON.stringify({ tool: out.output, sys: sys.system.length }));
+})' 2>&1)" || fail "no-op path threw: $noop"
+echo "$noop"
+echo "$noop" | grep -q '"tool":"RESULT"' || fail "no-op path mutated the tool output"
+echo "$noop" | grep -q '"sys":0' || fail "no-op path injected a system entry"
+pass "hooks are silent no-ops when no binary is resolvable"
+
+echo
+echo "opencode plugin verification: OK"

--- a/tools/sync-plugin-version.mjs
+++ b/tools/sync-plugin-version.mjs
@@ -58,6 +58,7 @@ for (const file of VERSION_FILES) {
 const PIN_FILES = [
   "plugin/.claude-plugin/plugin.json",
   "plugin/.mcp.json",
+  "plugin/opencode/rag-rat.ts",
   ".agents/skills/init-rag-rat/SKILL.md",
   "plugin/skills/init-rag-rat/SKILL.md",
 ];

--- a/tools/sync-plugin-version.mjs
+++ b/tools/sync-plugin-version.mjs
@@ -38,6 +38,7 @@ const VERSION_FILES = [
   ".claude-plugin/marketplace.json",
   "plugin/.claude-plugin/plugin.json",
   "plugin/.codex-plugin/plugin.json",
+  "plugin/opencode/package.json",
 ];
 const versionRe = /("version"\s*:\s*)"[^"]*"/;
 for (const file of VERSION_FILES) {


### PR DESCRIPTION
Closes #784.

Adds the opencode bundle on top of the same shared pieces the Claude Code / Codex plugins use (the launcher, the harness-neutral `agent-hook` contract, the version-pin sync):

- **`plugin/opencode/rag-rat.ts`** — a TypeScript opencode plugin module (opencode loads TS natively; the `@opencode-ai/plugin` import is type-only, so no runtime dep):
  - `config` hook self-registers the rag-rat MCP server as the pinned `npx -y @rag-rat/bin@<version> mcp` (skipped when the user configured one)
  - `session.created` → orientation digest via the launcher's `--no-install agent-hook`, injected through `experimental.chat.system.transform`; `experimental.session.compacting` re-injects a fresh digest (parity with Claude's `SessionStart(compact)`)
  - `tool.execute.after` on `grep`/`bash`/`read` appends the augmentation to the tool result — opencode's `tool.execute.before` has no additionalContext channel, so the digest rides the result instead of preceding it
  - `tool.execute.after` on `write`/`edit` fires the PostToolUse scoped reindex plus the write-time clone check
  - translates opencode's lowercase/camelCase tool calls to the harness-neutral payload; the Rust handler is unchanged
  - standalone single-file installs (no bundled launcher) resolve the binary inline with the launcher's `--no-install` policy; every path fails silent
- **`plugin/opencode/package.json`** — published as `@rag-rat/plugin-opencode`; `main` is the TS source itself (opencode's bun runtime loads TS directly, so no build step can drift). Version rides the release via `sync-plugin-version.mjs`.
- **`release-npm.yml`** — publish step with the same only-if-version-is-new guard as the other auxiliary packages.
- **Docs** — README quickstart covers all three harnesses (`opencode plugin @rag-rat/plugin-opencode`, `-g` for global); `docs/grep-augmentation.md` retitled harness-neutral; `plugin/README.md` gains the opencode section.
- **Tests** — `plugin/test/verify-opencode-install.sh`: bun-driven E2E (MCP registration, grep augmentation, session digest, compaction digest, cold-cache no-op contract).

Verified:
- the verify script passes against a local binary
- a **live `opencode run`** with the plugin symlinked into `.opencode/plugins/` completed with zero errors, and the stored grep tool result in opencode's DB carries the appended rag-rat augmentation
- the packed tarball, imported as `@rag-rat/plugin-opencode` from `node_modules` (the standalone path), passes the hooks 5/5 under bun

Site PR (landing page install path): cq27-dev/rag-rat-site — OpenCode promoted to the primary "works with" list.