### PR TITLE
feat(oplog): rebuild-all /3 content projections on projector-version staleness (#688)

### DIFF
--- a/crates/rag-rat-cli/tests/consolidate.rs
+++ b/crates/rag-rat-cli/tests/consolidate.rs
@@ -575,3 +575,97 @@ fn consolidate_from_a_linked_worktree_uses_the_main_config_and_legacy() {
     let _ = fs::remove_dir_all(&data_dir);
     let _ = fs::remove_dir_all(&model_cache);
 }
+
+/// Consolidation opens its target through the schema-only path, so it must explicitly run the
+/// store-global `/3` projector upgrade before reconcile's projection anti-join. A retry after the
+/// import committed but the legacy rename did not is the dangerous shape: the immutable content
+/// op already exists, and stale/missing projection rows would make reconcile append it again.
+#[test]
+fn consolidate_rebuilds_stale_content_projection_before_reconcile() {
+    let root = fixture_repo();
+    let data_dir = unique_dir("projectordata");
+    let model_cache = unique_dir("projectorcache");
+    let legacy = root.join(".rag-rat/index.sqlite");
+    let imported = root.join(".rag-rat/index.sqlite.imported");
+    let global = data_dir.join("rag-rat.sqlite");
+
+    let out = run(&root, &data_dir, &model_cache, &["index", "--full"]);
+    assert!(out.status.success(), "index --full failed: {}", String::from_utf8_lossy(&out.stderr));
+    {
+        let conn = rusqlite::Connection::open(&legacy).unwrap();
+        let repo_id: String = conn
+            .query_row(
+                "SELECT repo_id FROM repos WHERE repo_id != '__unassigned__' LIMIT 1",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        conn.execute(
+            "INSERT INTO repo_memories(id, kind, title, body, confidence, status, created_at_ms, \
+             updated_at_ms, source, memory_version, repo_id) VALUES ('projector-memory', \
+             'Invariant', 'projector', 'body', 'high', 'active', 0, 0, 'test', 'v1', ?1)",
+            [&repo_id],
+        )
+        .unwrap();
+    }
+
+    fs::write(
+        root.join("rag-rat.toml"),
+        "[index]\nroot = \".\"\n\n[llm.embedding]\nmodel = \"none\"\n\n[target_bindings]\nrust = \
+         [\"src\"]\n",
+    )
+    .unwrap();
+    let out = run(&root, &data_dir, &model_cache, &["consolidate"]);
+    assert!(
+        out.status.success(),
+        "first consolidate failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // Emulate the import-committed/rename-not-landed retry window, then doctor the target into an
+    // old projector's state: accepted content remains authoritative, but its projection and stamp
+    // are missing. Without the pre-reconcile rebuild, the anti-join authors a second NodeCreate.
+    fs::rename(&imported, &legacy).unwrap();
+    {
+        let conn = rusqlite::Connection::open(&global).unwrap();
+        let before: i64 =
+            conn.query_row("SELECT COUNT(*) FROM content_entries", [], |row| row.get(0)).unwrap();
+        assert_eq!(before, 1, "the first consolidate authored exactly one content op");
+        conn.execute_batch(
+            "DELETE FROM content_projected_nodes WHERE node_id = 'projector-memory';
+             DELETE FROM oplog_meta WHERE key = 'content_projector_version';",
+        )
+        .unwrap();
+    }
+
+    let out = run(&root, &data_dir, &model_cache, &["consolidate"]);
+    assert!(
+        out.status.success(),
+        "retry consolidate failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let conn = rusqlite::Connection::open(&global).unwrap();
+    let content_entries: i64 =
+        conn.query_row("SELECT COUNT(*) FROM content_entries", [], |row| row.get(0)).unwrap();
+    assert_eq!(content_entries, 1, "stale projection must not cause duplicate content authoring");
+    let projected: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM content_projected_nodes WHERE node_id = 'projector-memory'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(projected, 1, "consolidate rebuilt the missing content projection");
+    let stamp: String = conn
+        .query_row(
+            "SELECT value FROM oplog_meta WHERE key = 'content_projector_version'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(stamp, "1", "consolidate upgraded the store-global projector stamp");
+
+    let _ = fs::remove_dir_all(&root);
+    let _ = fs::remove_dir_all(&data_dir);
+    let _ = fs::remove_dir_all(&model_cache);
+}

--- a/crates/rag-rat-core/src/index/consolidate.rs
+++ b/crates/rag-rat-core/src/index/consolidate.rs
@@ -282,6 +282,12 @@ pub fn run(config: &Config) -> anyhow::Result<ConsolidateOutcome> {
     let counts = import_from_source(source_storage.connection(), target_conn, &repo_id)?;
     drop(source_storage);
 
+    // The schema-only open above deliberately bypasses the normal open/migrate hook. Bring the
+    // store-global `/3` projection current before reconcile's anti-join trusts it; otherwise a
+    // missing/older projector stamp can make already-authored rows look absent and append duplicate
+    // immutable content ops. This uses the existing connection and the rebuild's own IMMEDIATE txn.
+    rag_rat_oplog::rebuild_all_content_projections_if_stale(target_conn)?;
+
     // Author the freshly-imported (remapped) rows into the TARGET's owner stream so the
     // consolidated store's signed history is complete under its OWN device identity (#541). The
     // per-chain backfill gate would otherwise skip them (the target chain is already

--- a/crates/rag-rat-core/src/index/lifecycle.rs
+++ b/crates/rag-rat-core/src/index/lifecycle.rs
@@ -111,6 +111,14 @@ impl IndexDatabase {
                 &crate::index::migration_hooks(),
             )?;
         }
+        // #688: the `/3` content projection's two-part projector-version discipline. Its
+        // per-stream reproject only ever MAINTAINS an already-current store-global stamp, so a
+        // store folded by an older `/3` projector is rebuilt HERE — the open/migrate seam, after
+        // migrations, so a store that just gained the V070 tables has them — BEFORE any
+        // per-stream write. A no-op when the stamp is current or the store is pre-V070 (the
+        // V070-tables guard inside skips cleanly); idempotent and serialized by its own
+        // IMMEDIATE txn, so racing openers converge.
+        rag_rat_oplog::rebuild_all_content_projections_if_stale(storage.connection())?;
         Ok(storage)
     }
 

--- a/crates/rag-rat-core/src/memory_write/authoring.rs
+++ b/crates/rag-rat-core/src/memory_write/authoring.rs
@@ -1447,18 +1447,20 @@ mod tests {
     #[test]
     fn a_failed_author_rolls_back_the_memory_write() {
         let conn = scoped_conn();
-        // One good create so the account + owner stream are established and the first create
-        // stamped the `/3` content projector version (the second create's backfill
-        // fast-paths, isolating the failure to the live author's reproject).
+        // One good create so the account + owner stream are established and the second create's
+        // backfill fast-paths, isolating the failure to the live author's reproject.
         create_concept(&conn, "first").unwrap();
         let before: i64 =
             conn.query_row("SELECT COUNT(*) FROM repo_memories", [], |r| r.get(0)).unwrap();
         // Poison the `/3` projector guard: pretend a NEWER binary already folded this store's `/3`
         // projection, so `reproject_accepted_content_stream`'s `assert_content_projector_not_newer`
         // errors and the second create's `/3` author fails (this doubles as the #664 `/3`
-        // projector-stamp poison test).
+        // projector-stamp poison test). UPSERT: on this raw-connection store the stamp may be
+        // absent — the per-stream reproject only MAINTAINS an already-current stamp (#688); the
+        // open-path trigger (`rebuild_all_content_projections_if_stale`) is what writes it first.
         conn.execute(
-            "UPDATE oplog_meta SET value = '999' WHERE key = 'content_projector_version'",
+            "INSERT INTO oplog_meta(key, value) VALUES ('content_projector_version', '999')
+             ON CONFLICT(key) DO UPDATE SET value = excluded.value",
             [],
         )
         .unwrap();

--- a/crates/rag-rat-oplog/src/account/content/author.rs
+++ b/crates/rag-rat-oplog/src/account/content/author.rs
@@ -1124,6 +1124,160 @@ mod tests {
         assert_eq!(node_count, 1, "only the decodable node projects; the bad body is skipped");
     }
 
+    // ── #688: the /3 projector-version two-part discipline ──
+
+    /// The stored `/3` content-projector stamp, as the raw string `oplog_meta` holds.
+    fn stored_stamp(conn: &Connection) -> Option<String> {
+        conn.query_row(
+            "SELECT value FROM oplog_meta WHERE key = 'content_projector_version'",
+            [],
+            |row| row.get(0),
+        )
+        .optional()
+        .unwrap()
+    }
+
+    fn projected_node_count(conn: &Connection, stream: StreamId) -> i64 {
+        conn.query_row(
+            "SELECT count(*) FROM content_projected_nodes WHERE stream_id = ?1",
+            params![stream.to_bytes().as_slice()],
+            |row| row.get(0),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn the_upgrade_refold_rebuilds_every_stream_then_stamps_once() {
+        let conn = db();
+        let stream_a = StreamId::from_bytes(STREAM_A);
+        let stream_b = StreamId::from_bytes(STREAM_B);
+        let account = owned_stream_account(&conn, stream_a);
+        author_committed(&conn, stream_a, &[node_create("na", "on a")]);
+        seed_ownership(&conn, stream_b, account);
+        author_committed(&conn, stream_b, &[node_create("nb", "on b")]);
+        assert_eq!(projected_node_count(&conn, stream_a), 1);
+        assert_eq!(projected_node_count(&conn, stream_b), 1);
+
+        // Simulate an old binary's fold: stale projection rows everywhere, an older stamp, plus a
+        // stray row on a stream whose accepted set is now empty (it must not linger).
+        conn.execute_batch(
+            "DELETE FROM content_projected_nodes;
+             DELETE FROM content_projected_edges;
+             INSERT INTO content_projected_nodes(stream_id, node_id, content_json, status)
+              VALUES(X'99', 'ghost', '{}', 'active');
+             INSERT INTO oplog_meta(key, value) VALUES ('content_projector_version', '0')
+              ON CONFLICT(key) DO UPDATE SET value = excluded.value;",
+        )
+        .unwrap();
+
+        assert!(
+            content_projection::rebuild_all_content_projections_if_stale(&conn).unwrap(),
+            "a stale stamp re-folds"
+        );
+        assert_eq!(projected_node_count(&conn, stream_a), 1, "stream A rebuilt");
+        assert_eq!(projected_node_count(&conn, stream_b), 1, "stream B rebuilt");
+        let ghost: i64 = conn
+            .query_row(
+                "SELECT count(*) FROM content_projected_nodes WHERE node_id = 'ghost'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(ghost, 0, "the wholesale clear dropped the row with no accepted content");
+        assert_eq!(stored_stamp(&conn).as_deref(), Some("1"), "the store-global stamp upgraded");
+
+        assert!(
+            !content_projection::rebuild_all_content_projections_if_stale(&conn).unwrap(),
+            "a current stamp is a no-op"
+        );
+    }
+
+    #[test]
+    fn the_per_stream_reproject_maintains_but_never_upgrades_the_stamp() {
+        let conn = db();
+        let stream = StreamId::from_bytes(STREAM_A);
+        owned_stream_account(&conn, stream);
+
+        // On a store the open-path trigger never ran (a raw connection), authoring reprojects the
+        // stream but leaves the MISSING stamp untouched — the rebuild-all path is the only
+        // upgrader.
+        author_committed(&conn, stream, &[node_create("n1", "first")]);
+        assert_eq!(projected_node_count(&conn, stream), 1);
+        assert_eq!(
+            stored_stamp(&conn),
+            None,
+            "a per-stream reproject never writes the first stamp"
+        );
+
+        // An OLDER stamp is left untouched too: the per-stream path rebuilds this stream's rows
+        // but does not mark the (possibly stale) store current.
+        conn.execute(
+            "INSERT INTO oplog_meta(key, value) VALUES ('content_projector_version', '0')
+             ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            [],
+        )
+        .unwrap();
+        conn.execute_batch("DELETE FROM content_projected_nodes;").unwrap();
+        let tx = conn.unchecked_transaction().unwrap();
+        content_projection::reproject_accepted_content_stream(&tx, stream).unwrap();
+        tx.commit().unwrap();
+        assert_eq!(projected_node_count(&conn, stream), 1, "the stream's rows are rebuilt");
+        assert_eq!(stored_stamp(&conn).as_deref(), Some("0"), "the stale stamp is NOT upgraded");
+
+        // The upgrade re-fold makes the store current; from then on per-stream reprojects
+        // maintain the stamp.
+        assert!(content_projection::rebuild_all_content_projections_if_stale(&conn).unwrap());
+        assert_eq!(stored_stamp(&conn).as_deref(), Some("1"));
+        author_committed(&conn, stream, &[node_create("n2", "second")]);
+        assert_eq!(stored_stamp(&conn).as_deref(), Some("1"), "a current store stays current");
+        assert_eq!(projected_node_count(&conn, stream), 2);
+    }
+
+    #[test]
+    fn the_per_stream_reproject_still_refuses_a_newer_stamp() {
+        let conn = db();
+        let stream = StreamId::from_bytes(STREAM_A);
+        owned_stream_account(&conn, stream);
+        author_committed(&conn, stream, &[node_create("n1", "first")]);
+
+        // Simulate a NEWER binary having folded + stamped a higher content-projector version.
+        conn.execute(
+            "INSERT INTO oplog_meta(key, value) VALUES ('content_projector_version', '999')
+             ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            [],
+        )
+        .unwrap();
+
+        let tx = conn.unchecked_transaction().unwrap();
+        assert!(
+            content_projection::reproject_accepted_content_stream(&tx, stream).is_err(),
+            "an older projector must not reproject a newer-folded store"
+        );
+        drop(tx);
+        // The upgrade re-fold also leaves the newer projection intact (never downgrades).
+        assert!(
+            !content_projection::rebuild_all_content_projections_if_stale(&conn).unwrap(),
+            "a newer stamp is not re-folded"
+        );
+        assert_eq!(stored_stamp(&conn).as_deref(), Some("999"), "the newer stamp stands");
+    }
+
+    #[test]
+    fn the_upgrade_refold_skips_a_store_before_the_projected_tables_exist() {
+        // The pre-V070 mid-migration window: `content_projected_*` do not exist yet, so there is
+        // nothing to rebuild and nothing to stamp against — skip cleanly (the #683 guard, reused).
+        let conn = db();
+        conn.execute_batch(
+            "DROP TABLE content_projected_nodes; DROP TABLE content_projected_edges;",
+        )
+        .unwrap();
+        assert!(
+            !content_projection::rebuild_all_content_projections_if_stale(&conn).unwrap(),
+            "a pre-V070 store is skipped"
+        );
+        assert_eq!(stored_stamp(&conn), None, "no stamp is written against absent tables");
+    }
+
     #[test]
     fn the_chain_tail_reader_reports_genesis_for_an_empty_chain_and_the_head_when_populated() {
         let conn = db();

--- a/crates/rag-rat-oplog/src/account/content/mod.rs
+++ b/crates/rag-rat-oplog/src/account/content/mod.rs
@@ -37,6 +37,10 @@ pub use envelope::{
     reason = "C5a sealed envelope is unwired until C5b consumes it (#608)"
 )]
 pub use envelope::{seal_and_sign_content_entry, sign_sealed_content_entry};
+// The V070 `content_projected_*` table-existence guard: shared crate-wide with the `/3`
+// projection's open-path upgrade re-fold (#688) so there is ONE guard, reused per the #683
+// doctrine.
+pub(crate) use storage::content_projected_tables_exist;
 #[allow(unused_imports, reason = "C2 storage seam is frozen before C3 wiring lands")]
 pub use storage::{
     ContentCapacityScope, ContentIngestOutcome, content_ingest, settle_pending_content_refolds,

--- a/crates/rag-rat-oplog/src/account/content/storage.rs
+++ b/crates/rag-rat-oplog/src/account/content/storage.rs
@@ -800,9 +800,11 @@ fn list_streams_pending_refold(conn: &Connection) -> anyhow::Result<Vec<[u8; 32]
 
 /// Whether the V070 `content_projected_*` tables exist yet — false on a DB upgrading past a
 /// pre-V070 ledger, where the reproject would target absent tables. `sqlite_master` is served from
-/// SQLite's in-memory schema, so this is cheap; mirrors [`content_entries_exists`].
-fn content_projected_tables_exist(tx: &Transaction<'_>) -> rusqlite::Result<bool> {
-    tx.query_row(
+/// SQLite's in-memory schema, so this is cheap; mirrors [`content_entries_exists`]. Takes a
+/// `&Connection` (a `&Transaction` derefs to it) so the open-path upgrade re-fold
+/// ([`content_projection::rebuild_all_content_projections_if_stale`], #688) shares the one guard.
+pub(crate) fn content_projected_tables_exist(conn: &Connection) -> rusqlite::Result<bool> {
+    conn.query_row(
         "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'content_projected_nodes'",
         [],
         |_| Ok(()),

--- a/crates/rag-rat-oplog/src/account/mod.rs
+++ b/crates/rag-rat-oplog/src/account/mod.rs
@@ -44,6 +44,9 @@ pub use authoring::{
     ensure_owned_stream_v2_in_tx, established_owned_stream_v2, owned_stream_v2_id,
 };
 pub use bootstrap::local_account;
+// The V070 projection-table guard, reused by the memory-layer content projection's upgrade
+// re-fold (#688).
+pub(crate) use content::content_projected_tables_exist;
 #[allow(unused_imports, reason = "C2 contract is frozen before transport wiring lands")]
 pub use content::{
     ContentCapacityScope, ContentEntryHeader, ContentIngestOutcome, SignedContentEntry,

--- a/crates/rag-rat-oplog/src/content_projection.rs
+++ b/crates/rag-rat-oplog/src/content_projection.rs
@@ -22,9 +22,9 @@
 //! ([`crate::store::NodeContentRow`] et al.), so the two projections serialize identically.
 
 use anyhow::Context;
-use rusqlite::{Connection, OptionalExtension, Transaction, params};
+use rusqlite::{Connection, OptionalExtension, Transaction, TransactionBehavior, params};
 
-use super::account::decode_content_signed;
+use super::account::{content_projected_tables_exist, decode_content_signed};
 use super::op::{self, DecodedOp, Entry, OpMeta};
 use super::project;
 use super::project::ProjectedState;
@@ -33,8 +33,10 @@ use super::stream::StreamId;
 
 /// Bump when the accepted-`/3` → memory fold's projectable set or LWW semantics change (a new op
 /// kind becomes `Known`, a register is added). A `/3` projection stamped with an older version is
-/// rebuilt on the next content refold, never trusted incrementally; a NEWER stamp blocks this
-/// binary from reprojecting at all (see [`assert_content_projector_not_newer`]).
+/// rebuilt WHOLESALE on the next store open — [`rebuild_all_content_projections_if_stale`] runs at
+/// the open/migrate seam and re-folds every stream before stamping — never trusted incrementally;
+/// a NEWER stamp blocks this binary from reprojecting at all (see
+/// [`assert_content_projector_not_newer`]).
 const CONTENT_PROJECTOR_VERSION: i64 = 1;
 
 /// The `oplog_meta` key holding the `/3` projector version the content projection was last folded
@@ -46,6 +48,16 @@ const CONTENT_PROJECTOR_VERSION_KEY: &str = "content_projector_version";
 /// set and rewrite its rows in both `/3` projection tables — another stream's rows are never
 /// touched. Runs inside the caller's txn; called right after `refold_content_stream` (acceptance
 /// changed), so the projection always reflects the just-committed accepted DAG.
+///
+/// VERSION DISCIPLINE (#688), mirroring the `/1` two-part design
+/// ([`crate::store::reproject_if_projector_stale`] + the per-write stamp): this per-stream path
+/// only ever MAINTAINS an already-current store-global stamp. The store-global version is upgraded
+/// EXCLUSIVELY by [`rebuild_all_content_projections_if_stale`], which rebuilds EVERY stream before
+/// the one stamp — so the stamp can never come to cover another stream's stale projection (which
+/// the memory reconcile's anti-join would then trust, mass-duplicating or skipping rows against
+/// it). A missing or older stamp is therefore left UNTOUCHED here: the open-path trigger stays
+/// owed its rebuild-all, and this stream's just-written rows are simply rebuilt again there (the
+/// fold is idempotent).
 pub fn reproject_accepted_content_stream(
     tx: &Transaction<'_>,
     stream_id: StreamId,
@@ -56,18 +68,87 @@ pub fn reproject_accepted_content_stream(
     // `content_projected_nodes`. The memory reconcile's anti-join would then read them as
     // unauthored and mass-duplicate them into the immutable `/3` log. Guard BEFORE any write.
     assert_content_projector_not_newer(tx)?;
+    reproject_stream_projection(tx, stream_id)?;
+    // Stamp only when the store is already current (see the fn doc): this maintains the stamp, it
+    // never upgrades it.
+    if stored_content_projector_version(tx)? == Some(CONTENT_PROJECTOR_VERSION) {
+        stamp_content_projector_version(tx)?;
+    }
+    Ok(())
+}
+
+/// The store-global upgrade re-fold for the `/3` projection (#688) — the `/3` analog of the `/1`
+/// [`crate::store::reproject_if_projector_stale`], wired into the index open/migrate seam (after
+/// migrations, so a store that just gained V070 has its tables). When the stored content-projector
+/// stamp is MISSING or STRICTLY OLDER than this binary's projector, re-fold EVERY `/2` stream
+/// holding accepted content, then stamp the store-global version ONCE; a current or NEWER stamp is
+/// left intact (never downgraded, never re-folded). Returns whether it rebuilt.
+///
+/// This is the ONLY path allowed to raise the stored version: running before any per-stream write,
+/// it makes the store current so [`reproject_accepted_content_stream`]'s stamp only ever maintains
+/// an already-current store. The rebuild is idempotent and serialized by its own `IMMEDIATE` txn,
+/// so racing openers converge without an extra lock (the loser either observes the winner's
+/// current stamp and no-ops, or rebuilds the same state again).
+pub fn rebuild_all_content_projections_if_stale(conn: &Connection) -> anyhow::Result<bool> {
+    // Guard FIRST on the V070 `content_projected_*` tables existing: on a pre-V070 store
+    // mid-migration there is no projection to rebuild (and nothing to stamp against). Reuses the
+    // #683 guard the refold/settle reprojects carry. It also runs before the `oplog_meta` read,
+    // so a bare mid-migration DB missing both never errors here.
+    if !content_projected_tables_exist(conn)? {
+        return Ok(false);
+    }
+    match stored_content_projector_version(conn)? {
+        Some(version) if version >= CONTENT_PROJECTOR_VERSION => Ok(false),
+        _ => {
+            let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
+            // The stale check above already excludes a newer stamp; assert again inside the write
+            // txn so this fn stays honest if the arm above ever changes (mirrors
+            // [`crate::store::rebuild_projection`]).
+            assert_content_projector_not_newer(&tx)?;
+            reproject_all_accepted_content_streams(&tx)?;
+            stamp_content_projector_version(&tx)?;
+            tx.commit()?;
+            Ok(true)
+        },
+    }
+}
+
+/// Re-fold EVERY `/2` stream holding accepted `/3` content wholesale: clear BOTH projection tables
+/// first so a row whose stream's accepted set emptied since its last reproject (a full
+/// retro-condemn) cannot linger, then fold each stream (mirrors [`crate::store`]'s
+/// `reproject_all_streams`). Runs inside the caller's txn; the caller stamps after.
+fn reproject_all_accepted_content_streams(tx: &Transaction<'_>) -> anyhow::Result<()> {
+    tx.execute("DELETE FROM content_projected_nodes", [])?;
+    tx.execute("DELETE FROM content_projected_edges", [])?;
+    for stream_id in accepted_content_streams(tx)? {
+        reproject_stream_projection(tx, stream_id)?;
+    }
+    Ok(())
+}
+
+/// Every distinct `/2` stream the log currently holds ACCEPTED `/3` content for — the rebuild set
+/// for a projector upgrade (mirrors [`crate::store`]'s `streams_present`).
+fn accepted_content_streams(conn: &Connection) -> anyhow::Result<Vec<StreamId>> {
+    let mut stmt =
+        conn.prepare("SELECT DISTINCT stream_id FROM content_entries WHERE accepted = 1")?;
+    let rows = stmt.query_map([], |row| row.get::<_, Vec<u8>>(0))?;
+    let mut streams = Vec::new();
+    for row in rows {
+        let bytes = row?;
+        let hash: [u8; 32] =
+            bytes.try_into().map_err(|_| anyhow::anyhow!("stored /3 stream_id is not 32 bytes"))?;
+        streams.push(StreamId::from_bytes(hash));
+    }
+    Ok(streams)
+}
+
+/// The full-replay fold for ONE stream: load its accepted entries, `project`, and rewrite its rows
+/// in BOTH `/3` projection tables — another stream's projection is never touched. Carries NO
+/// version logic; the callers own the stamp discipline.
+fn reproject_stream_projection(tx: &Transaction<'_>, stream_id: StreamId) -> anyhow::Result<()> {
     let entries = load_accepted_entries(tx, stream_id)?;
     let state = project::project(&entries);
-    write_projection(tx, stream_id, &state)?;
-    // This stamps the STORE-GLOBAL version but rebuilt only THIS stream. Safe only while
-    // `CONTENT_PROJECTOR_VERSION` is never bumped: the stored version is then only ever unset or
-    // current, so there is no stale store to falsely mark done. BEFORE the first bump, add a
-    // store-global rebuild-on-upgrade (rebuild every `/3` stream, THEN stamp — mirroring `/1`'s
-    // `store::reproject_if_projector_stale`), or the first per-stream reproject on an
-    // old-version store would mark every OTHER (still-old) stream's projection current and the
-    // reconcile anti-join would trust a stale projection. Tracked in #688.
-    stamp_content_projector_version(tx)?;
-    Ok(())
+    write_projection(tx, stream_id, &state)
 }
 
 /// Error if a NEWER `/3` projector already folded this store's content projection — an older binary
@@ -87,6 +168,10 @@ fn assert_content_projector_not_newer(conn: &Connection) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Write the store-global `/3` projector stamp. Two callers, two roles (#688):
+/// [`rebuild_all_content_projections_if_stale`] UPGRADES it (after rebuilding every stream), and
+/// [`reproject_accepted_content_stream`] only MAINTAINS it (called solely when the stored stamp
+/// is already current).
 fn stamp_content_projector_version(tx: &Transaction<'_>) -> rusqlite::Result<()> {
     tx.execute(
         "INSERT INTO oplog_meta(key, value) VALUES (?1, ?2)

--- a/crates/rag-rat-oplog/src/lib.rs
+++ b/crates/rag-rat-oplog/src/lib.rs
@@ -103,6 +103,10 @@ pub use account::{
     rotate_stream_key_in_tx, select_current_sealing_wrap, stream_key_rotation_needed,
     stream_owner_effective,
 };
+// The `/3` content projection's store-global upgrade re-fold (#688): wired into the index
+// open/migrate seam by rag-rat-core, so a stale store is rebuilt (every stream, then the one
+// stamp) before any per-stream write.
+pub use content_projection::rebuild_all_content_projections_if_stale;
 // The op-log's first crate-internal API surface (#524): the MINTING primitives + the op
 // vocabulary the memory subsystem needs to author + backfill entries. Every submodule above is
 // otherwise private, so this curated re-export is the ONE seam `query::memory` reaches through


### PR DESCRIPTION
Closes #688.

`reproject_accepted_content_stream` rebuilt ONE stream but stamped the STORE-GLOBAL `content_projector_version` — harmless while the version is never bumped, but the first bump would have let a per-stream rebuild mark every other stream's stale projection as current, and the memory reconcile's anti-join would then mass-duplicate or skip rows against stale projections.

## Fix — /1's two-part discipline, mirrored for /3

- `rebuild_all_content_projections_if_stale` is the ONLY version upgrader: guarded on the V070 tables existing (reuses #683's guard), it wholesale-clears both projection tables, re-folds every stream with accepted content, and stamps once. Current/newer stamps are left alone.
- `reproject_accepted_content_stream` now stamps only when stored == current (maintains, never upgrades); the not-newer assert is unchanged.
- Trigger wired at `IndexDatabase::open_and_migrate` after `ensure_compatible_or_migrate` — before any per-stream write; idempotent under its own IMMEDIATE txn.

## Tests
- stale store: every stream rebuilt, stamp upgraded once
- per-stream reproject still refuses a newer stamp
- pre-V070 store skips cleanly
- per-stream reproject maintains but never upgrades

`cargo nextest run -p rag-rat-oplog` 498/498; `-p rag-rat-core` 1368/1368; clippy clean.

Hard prerequisite for any /3 op-vocabulary change (C5 read-side).