### PR TITLE
fix(mcp): preserve title tool arguments in schemas

### DIFF
--- a/crates/rag-rat-mcp/src/tools/defaults.rs
+++ b/crates/rag-rat-mcp/src/tools/defaults.rs
@@ -11,7 +11,9 @@ pub(crate) fn strip_schema_metadata(value: &mut Value) {
     match value {
         Value::Object(map) => {
             map.remove("$schema");
-            map.remove("title");
+            if map.get("title").is_some_and(Value::is_string) {
+                map.remove("title");
+            }
             for child in map.values_mut() {
                 strip_schema_metadata(child);
             }

--- a/crates/rag-rat-mcp/src/tools/tests.rs
+++ b/crates/rag-rat-mcp/src/tools/tests.rs
@@ -177,6 +177,19 @@ fn list_tools_exposes_complete_typed_schemas() {
         assert!(names.contains(&expected), "missing MCP tool {expected}");
     }
 
+    for tool in tools {
+        let name = tool["name"].as_str().expect("tool name");
+        let schema = tool_schema(tools, name);
+        let properties = schema["properties"].as_object();
+        for required in schema["required"].as_array().into_iter().flatten() {
+            let required = required.as_str().expect("required property name");
+            assert!(
+                properties.is_some_and(|properties| properties.contains_key(required)),
+                "{name} requires `{required}` but does not define it"
+            );
+        }
+    }
+
     assert_schema_requires(tools, "semantic_search", "query");
     assert_schema_has_property(tools, "semantic_search", "include_graph");
     assert_schema_property_enum(tools, "semantic_search", "include_graph", &[
@@ -292,6 +305,7 @@ fn list_tools_exposes_complete_typed_schemas() {
     ]);
     assert_schema_has_property(tools, "heal_index", "limit");
     assert_schema_requires(tools, "memory_create", "kind");
+    assert_schema_has_property(tools, "memory_create", "title");
     // `bind` is OPTIONAL (#463): omitting it creates an unanchored Concept/Task node.
     assert_schema_has_property(tools, "memory_create", "bind");
     assert_schema_has_property(tools, "memory_create", "confidence");


### PR DESCRIPTION
## Summary
- preserve object-valued `title` argument schemas while stripping string-valued schema title metadata
- assert every required MCP root field has a matching property definition
- explicitly cover `memory_create.title`

## Root cause
`strip_schema_metadata` recursively removed every key named `title`. For `memory_create`, that deleted `properties.title` while leaving `title` in `required`, so strict OpenAI function-schema validation rejected the tool catalog with a misleading top-level schema error.

## Verification
- `cargo test -p rag-rat-mcp` (70 passed)
- `cargo +nightly fmt --check -- crates/rag-rat-mcp/src/tools/defaults.rs crates/rag-rat-mcp/src/tools/tests.rs`
- independent review: no findings