### PR TITLE
feat(sync): enable sealed /3 memory streams with decrypt-at-projection (#608)

### DIFF
--- a/crates/rag-rat-cli/src/cli.rs
+++ b/crates/rag-rat-cli/src/cli.rs
@@ -85,6 +85,9 @@ pub(crate) enum Command {
     /// Inspect and re-anchor source-anchored repo memories.
     Memory(MemoryArgs),
 
+    /// Configure local memory-stream authoring. This does not configure transport or peers.
+    Sync(SyncArgs),
+
     /// Dream-mode memory-maintenance worklist (#122): deterministic coverage-gap + stale-reference
     /// findings written to `dream_findings`. Surfaces findings ABOUT memories; never mutates them.
     Dream(DreamArgs),
@@ -178,6 +181,18 @@ pub(crate) struct InitArgs {
     /// leave `.git/hooks` untouched (e.g. an agent that asks for hook consent separately).
     #[arg(long)]
     pub no_hooks: bool,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct SyncArgs {
+    #[command(subcommand)]
+    pub command: SyncCommand,
+}
+
+#[derive(Debug, Subcommand)]
+pub(crate) enum SyncCommand {
+    /// Permanently enable sealed authoring for subsequent local memory changes.
+    Enable,
 }
 
 #[derive(Debug, Args)]

--- a/crates/rag-rat-cli/src/commands/mod.rs
+++ b/crates/rag-rat-cli/src/commands/mod.rs
@@ -20,6 +20,7 @@ mod remove;
 mod runtime_env;
 mod search;
 mod status;
+mod sync;
 
 pub(crate) use clones::{clones, clones_for};
 pub(crate) use config_info::{dump_config, version_check};
@@ -39,3 +40,4 @@ pub(crate) use remove::rm;
 pub(crate) use runtime_env::apply_embedding_runtime_env;
 pub(crate) use search::{brief, clusters, important_symbols, query};
 pub(crate) use status::status;
+pub(crate) use sync::sync;

--- a/crates/rag-rat-cli/src/commands/sync.rs
+++ b/crates/rag-rat-cli/src/commands/sync.rs
@@ -1,0 +1,24 @@
+//! Local memory-stream authoring configuration. No transport surface lives here.
+
+use rag_rat_base::config::Config;
+
+use crate::cli::{SyncArgs, SyncCommand};
+use crate::{open_index, print_output};
+
+pub(crate) fn sync(config: &Config, args: &SyncArgs) -> anyhow::Result<()> {
+    let lock_repo = rag_rat_base::locks::write_lock_repo_id(config);
+    let _lock = rag_rat_base::locks::WriteLock::acquire_blocking(&config.database, &lock_repo)?;
+    let db = open_index(config)?;
+    match args.command {
+        SyncCommand::Enable => {
+            let enabled = db.sync_enable()?;
+            print_output(&serde_json::json!({
+                "status": if enabled { "enabled" } else { "already_enabled" },
+                "repo_id": db.active_repo_id,
+                "sealed_local_authoring": true,
+                "transport_configured": false,
+                "note": "subsequent local memory changes are sealed; transport is not configured",
+            }))
+        },
+    }
+}

--- a/crates/rag-rat-cli/src/main.rs
+++ b/crates/rag-rat-cli/src/main.rs
@@ -127,6 +127,7 @@ fn main() -> anyhow::Result<()> {
         Cmd::Clones(args) => clones(&config, &args)?,
         Cmd::ClonesFor(args) => clones_for(&config, &args)?,
         Cmd::Memory(args) => memory(&config, &args)?,
+        Cmd::Sync(args) => sync(&config, &args)?,
         Cmd::Dream(args) => dream(&config, &args)?,
         Cmd::Papertrail(args) => papertrail(&config, &args)?,
         Cmd::Distill(args) => distill(&config, &args)?,

--- a/crates/rag-rat-cli/tests/consolidate.rs
+++ b/crates/rag-rat-cli/tests/consolidate.rs
@@ -663,7 +663,7 @@ fn consolidate_rebuilds_stale_content_projection_before_reconcile() {
             |row| row.get(0),
         )
         .unwrap();
-    assert_eq!(stamp, "1", "consolidate upgraded the store-global projector stamp");
+    assert_eq!(stamp, "2", "consolidate upgraded the store-global projector stamp");
 
     let _ = fs::remove_dir_all(&root);
     let _ = fs::remove_dir_all(&data_dir);

--- a/crates/rag-rat-cli/tests/multi_repo_e2e.rs
+++ b/crates/rag-rat-cli/tests/multi_repo_e2e.rs
@@ -128,6 +128,28 @@ fn run_ok(root: &Path, data_dir: &Path, model_cache: &Path, args: &[&str]) -> St
     String::from_utf8_lossy(&out.stdout).into_owned()
 }
 
+#[test]
+fn sync_enable_is_narrow_idempotent_and_help_is_honest() {
+    let root = keyless_repo("sync-enable", &[("lib.rs", "pub fn indexed() {}\n".to_string())]);
+    let data_dir = unique_dir("sync-enable-data");
+    let model_cache = unique_dir("sync-enable-models");
+    run_ok(&root, &data_dir, &model_cache, &["index"]);
+
+    let help = run_ok(&root, &data_dir, &model_cache, &["sync", "--help"]);
+    assert!(help.contains("enable"));
+    assert!(help.contains("does not configure transport or peers"));
+    assert!(!help.contains("disable"));
+    assert!(!help.contains("pair"));
+    assert!(!help.contains("push"));
+    assert!(!help.contains("pull"));
+
+    let enabled = run_ok(&root, &data_dir, &model_cache, &["--json", "sync", "enable"]);
+    assert!(enabled.contains("\"status\": \"enabled\""));
+    assert!(enabled.contains("\"transport_configured\": false"));
+    let repeated = run_ok(&root, &data_dir, &model_cache, &["--json", "sync", "enable"]);
+    assert!(repeated.contains("\"status\": \"already_enabled\""));
+}
+
 fn global_db(data_dir: &Path) -> PathBuf {
     data_dir.join("rag-rat.sqlite")
 }

--- a/crates/rag-rat-core/src/index/consolidate.rs
+++ b/crates/rag-rat-core/src/index/consolidate.rs
@@ -76,6 +76,9 @@ use crate::index::{IndexDatabase, schema};
 ///        CONVERT an auto-selected model into a confirmed one and `seed_active_embedding_model`
 ///        could no longer override/clear it from config. ABSENCE-HAS-MEANING keys like this need
 ///        the absent state classified too, not just the value.
+///      * `memory_stream_seal_policy` — the one-way privacy intent for the repo's owner stream.
+///        Unlike model-state keys it is MERGED monotonically: `sealed` on either side wins, absence
+///        never clears it, and unknown values abort consolidation before reconciliation.
 ///
 ///  (b) DB-LOCAL STATE — never copied; each entry states why:
 ///      * freshness/progress cursors that would make a fresh 0-row index falsely report itself
@@ -93,7 +96,10 @@ const CARRIED_META_KEYS: &[&str] = &[
     "embedding_active_model_version",
     "active_embedding_remote_config",
     "active_embedding_model_provisional",
+    "memory_stream_seal_policy",
 ];
+
+const MEMORY_STREAM_SEAL_POLICY_META_KEY: &str = "memory_stream_seal_policy";
 
 /// How long consolidate waits for the repo's per-repo write locks (global-side and legacy-side)
 /// before refusing — an in-flight index/maintenance pass finishes well within it, and an explicit
@@ -555,10 +561,12 @@ struct ImportCounts {
 ///  * `repo_memory_fts`                  — re-derived for the WHOLE repo at the end
 ///    ([`rebuild_memory_fts_for_repo`]); covers refreshed same-repo AND remapped rows alike (both
 ///    are stamped `repo_id` = ours by the copy).
-///  * `repo_meta` model-state unit       — per-key MIRROR ([`copy_model_state`]): value-gated
-///    upsert for keys present in the source, DELETE for carried keys absent there (a model switch
-///    in the window may legitimately remove a key, e.g. the remote config when moving to a local
-///    model — keeping it would tear the unit).
+///  * `repo_meta` portable state         — model-state keys use per-key MIRROR
+///    ([`copy_model_state`]); the seal policy uses a monotonic merge so privacy intent cannot be
+///    downgraded by an absent or unsafe source value.
+///  * model-state mirror details: upsert for keys present in the source, DELETE for carried keys
+///    absent there (a model switch in the window may legitimately remove a key, e.g. the remote
+///    config when moving to a local model — keeping it would tear the unit).
 ///  * `ai_models` readiness              — restore-style carry ([`carry_active_model_readiness`]),
 ///    re-derived from the SOURCE's active model each run, so a window model change restores the NEW
 ///    model's readiness on retry; an explicit machine-level `disabled` is never overridden.
@@ -1196,6 +1204,9 @@ fn copy_model_state(source: &Connection, tx: &Connection, repo_id: &str) -> anyh
     let mut count = 0u64;
     let mut active_model: Option<String> = None;
     for key in CARRIED_META_KEYS {
+        if *key == MEMORY_STREAM_SEAL_POLICY_META_KEY {
+            continue;
+        }
         let value: Option<String> = source
             .query_row("SELECT value FROM repo_meta WHERE key = ?1 LIMIT 1", [key], |row| {
                 row.get(0)
@@ -1223,10 +1234,60 @@ fn copy_model_state(source: &Connection, tx: &Connection, repo_id: &str) -> anyh
         };
         count += changed as u64;
     }
+    count += merge_stream_seal_policy(source, tx, repo_id)?;
     if let Some(model_id) = active_model {
         carry_active_model_readiness(source, tx, &model_id)?;
     }
     Ok(count)
+}
+
+/// Merge the owner-stream seal policy as a one-way ratchet. The only persisted value this binary
+/// understands is `sealed`; absence means no explicit intent. A sealed source must seal the target,
+/// while a target already sealed remains sealed across retries even if the legacy source is absent.
+/// Unknown values on either side fail closed before consolidation's reconciliation authoring.
+fn merge_stream_seal_policy(
+    source: &Connection,
+    tx: &Connection,
+    repo_id: &str,
+) -> anyhow::Result<u64> {
+    let source_value: Option<String> = source
+        .query_row(
+            "SELECT value FROM repo_meta WHERE key = ?1 LIMIT 1",
+            [MEMORY_STREAM_SEAL_POLICY_META_KEY],
+            |row| row.get(0),
+        )
+        .optional()?
+        .flatten();
+    let target_value: Option<String> = tx
+        .query_row(
+            "SELECT value FROM repo_meta WHERE repo_id = ?1 AND key = ?2",
+            params![repo_id, MEMORY_STREAM_SEAL_POLICY_META_KEY],
+            |row| row.get(0),
+        )
+        .optional()?
+        .flatten();
+
+    for (side, value) in
+        [("legacy source", source_value.as_deref()), ("target", target_value.as_deref())]
+    {
+        if let Some(value) = value
+            && value != "sealed"
+        {
+            anyhow::bail!(
+                "{side} repo `{repo_id}` has unknown memory stream seal policy `{value}`; \
+                 refusing to consolidate"
+            );
+        }
+    }
+
+    if source_value.is_some() && target_value.is_none() {
+        Ok(tx.execute(
+            "INSERT INTO repo_meta(repo_id, key, value) VALUES (?1, ?2, 'sealed')",
+            params![repo_id, MEMORY_STREAM_SEAL_POLICY_META_KEY],
+        )? as u64)
+    } else {
+        Ok(0)
+    }
 }
 
 /// Carry the active model's `ai_models` READINESS onto the target when the legacy DB holds it
@@ -1995,6 +2056,105 @@ mod tests {
             )
             .unwrap();
         assert_eq!(value, "model-a", "the authoritative legacy value replaces the stale copy");
+    }
+
+    #[test]
+    fn sealed_policy_survives_import_and_reconcile_authors_only_suite_1() {
+        let source = seeded_source();
+        source
+            .execute(
+                "INSERT INTO repo_meta(repo_id, key, value) VALUES ('__unassigned__', ?1, \
+                 'sealed')",
+                [MEMORY_STREAM_SEAL_POLICY_META_KEY],
+            )
+            .unwrap();
+        let target = fresh_target();
+
+        import_from_source(&source, &target, "global-repo").unwrap();
+        crate::memory_write::reconcile_owner_stream_for_repo(
+            &target,
+            "global-repo",
+            rag_rat_base::time::now_ms(),
+        )
+        .unwrap();
+
+        let policy: String = target
+            .query_row(
+                "SELECT value FROM repo_meta WHERE repo_id = 'global-repo' AND key = ?1",
+                [MEMORY_STREAM_SEAL_POLICY_META_KEY],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(policy, "sealed", "consolidation carries the explicit privacy intent");
+        let mut stmt = target.prepare("SELECT signed_bytes FROM content_entries").unwrap();
+        let signed: Vec<Vec<u8>> =
+            stmt.query_map([], |row| row.get(0)).unwrap().collect::<rusqlite::Result<_>>().unwrap();
+        assert!(!signed.is_empty(), "reconcile authored the imported memories");
+        assert!(
+            signed.iter().all(|bytes| {
+                rag_rat_oplog::decode_content_signed(bytes).unwrap().header.crypto_suite == 1
+            }),
+            "every reconciled content row is suite 1",
+        );
+    }
+
+    #[test]
+    fn unknown_source_seal_policy_aborts_import_before_any_authoring() {
+        let source = seeded_source();
+        source
+            .execute(
+                "INSERT INTO repo_meta(repo_id, key, value) VALUES ('__unassigned__', ?1, \
+                 'future-policy')",
+                [MEMORY_STREAM_SEAL_POLICY_META_KEY],
+            )
+            .unwrap();
+        let target = fresh_target();
+
+        let err = import_from_source(&source, &target, "global-repo")
+            .err()
+            .expect("an unknown policy must fail closed");
+        assert!(err.to_string().contains("unknown memory stream seal policy"));
+        assert_eq!(count(&target, "SELECT COUNT(*) FROM repo_memories"), 0);
+        assert_eq!(count(&target, "SELECT COUNT(*) FROM content_entries"), 0);
+    }
+
+    #[test]
+    fn sealed_target_wins_retries_and_rejects_a_conflicting_unsafe_source() {
+        let source = seeded_source();
+        let target = fresh_target();
+        target
+            .execute(
+                "INSERT INTO repo_meta(repo_id, key, value) VALUES ('global-repo', ?1, 'sealed')",
+                [MEMORY_STREAM_SEAL_POLICY_META_KEY],
+            )
+            .unwrap();
+
+        import_from_source(&source, &target, "global-repo").unwrap();
+        import_from_source(&source, &target, "global-repo").unwrap();
+        let policy = || -> String {
+            target
+                .query_row(
+                    "SELECT value FROM repo_meta WHERE repo_id = 'global-repo' AND key = ?1",
+                    [MEMORY_STREAM_SEAL_POLICY_META_KEY],
+                    |row| row.get(0),
+                )
+                .unwrap()
+        };
+        assert_eq!(policy(), "sealed", "an absent source never clears a sealed target");
+
+        source
+            .execute(
+                "INSERT INTO repo_meta(repo_id, key, value) VALUES ('__unassigned__', ?1, \
+                 'plaintext')",
+                [MEMORY_STREAM_SEAL_POLICY_META_KEY],
+            )
+            .unwrap();
+        let err = import_from_source(&source, &target, "global-repo")
+            .err()
+            .expect("plaintext must not override a sealed target");
+        assert!(err.to_string().contains("unknown memory stream seal policy"));
+        assert_eq!(policy(), "sealed", "the conflicting import cannot downgrade the target");
+        assert_eq!(count(&target, "SELECT COUNT(*) FROM content_entries"), 0);
     }
 
     /// The `repo_meta` classification (see [`CARRIED_META_KEYS`]): repo-PORTABLE configuration is

--- a/crates/rag-rat-core/src/index/query_api/memory.rs
+++ b/crates/rag-rat-core/src/index/query_api/memory.rs
@@ -4,6 +4,15 @@
 use super::*;
 
 impl IndexDatabase {
+    /// Permanently enable sealed local memory authoring for this repo. Existing suite-0 history is
+    /// retained; subsequent live and reconcile entries use suite 1.
+    pub fn sync_enable(&self) -> anyhow::Result<bool> {
+        crate::memory_write::enable_sealed_authoring(
+            self.storage.connection(),
+            rag_rat_base::time::now_ms(),
+        )
+    }
+
     pub fn memory_create(
         &self,
         request: rag_rat_query::memory::RepoMemoryCreate,

--- a/crates/rag-rat-core/src/memory_write/api.rs
+++ b/crates/rag-rat-core/src/memory_write/api.rs
@@ -70,6 +70,7 @@ pub(crate) fn create_memory(
     // chain exists), then do the table writes + the op-append in ONE transaction so they commit —
     // or roll back — together (strict-atomic). Writes via `conn` participate in the open txn.
     authoring::backfill_memory_oplog(conn, now)?;
+    let prepared = authoring::prepare_live_content_authoring(conn, now)?;
     // Authored write: commit durably so a `memory_create` that returned success survives power loss
     // (#560). FULL for this transaction only; the connection restores NORMAL on drop.
     let _durability = authoring::AuthoredDurability::begin(conn)?;
@@ -124,7 +125,7 @@ pub(crate) fn create_memory(
     let memory = memory_by_id(conn, &id)?
         .ok_or_else(|| anyhow::anyhow!("created memory `{id}` could not be read back"))?;
     // Author the NodeCreate in the SAME txn; an authoring error drops `tx` → the INSERT rolls back.
-    authoring::author_create(&tx, &memory, now)?;
+    authoring::author_create(&tx, &memory, prepared.as_ref(), now)?;
     tx.commit()?;
     Ok(RepoMemoryCreateResult { memory, duplicate: false })
 }
@@ -138,6 +139,7 @@ pub(crate) fn update_memory(
     // READ and the UPDATE are ONE atomic unit — a racing writer cannot flip the status between the
     // read and the write and desync the table from the op-log projection.
     authoring::backfill_memory_oplog(conn, now)?;
+    let prepared = authoring::prepare_live_content_authoring(conn, now)?;
     // Authored write (content / status / obsolete): commit durably (#560), NORMAL restored on drop.
     let _durability = authoring::AuthoredDurability::begin(conn)?;
     let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
@@ -230,7 +232,14 @@ pub(crate) fn update_memory(
     })?;
     // Author NodeUpdate (+ NodeStatus on a status change) in the SAME txn; an authoring error drops
     // `tx` → the UPDATE rolls back.
-    authoring::author_update(&tx, &memory, content_changed, status_changed, now)?;
+    authoring::author_update(
+        &tx,
+        &memory,
+        content_changed,
+        status_changed,
+        prepared.as_ref(),
+        now,
+    )?;
     tx.commit()?;
     Ok(memory)
 }

--- a/crates/rag-rat-core/src/memory_write/authoring.rs
+++ b/crates/rag-rat-core/src/memory_write/authoring.rs
@@ -10,8 +10,8 @@
 //! repo's owner-bound `/2` stream, under the store's single local account (minted once, store-
 //! global). Each reconcile/mutation ensures the repo's `/2` stream is owned (publishing a
 //! `StreamOwn` account op) and authors its ops as owner-authored `/3` content
-//! ([`rag_rat_oplog::author_content_batch_in_tx`]), which verify-accepts and reprojects into
-//! `content_projected_nodes` / `content_projected_edges`. The completeness predicate is an
+//! ([`rag_rat_oplog::author_prepared_content_batch_in_tx`]), which verify-accepts and reprojects
+//! into `content_projected_nodes` / `content_projected_edges`. The completeness predicate is an
 //! anti-join against that accepted-`/3` projection; the pre-existing `/1` history is retained but
 //! no longer written by the live path (existing `/1` rows are adopted into `/3` by the reconcile).
 //!
@@ -67,7 +67,10 @@ impl Drop for AuthoredDurability<'_> {
         let _ = self.conn.execute_batch("PRAGMA synchronous = NORMAL;");
     }
 }
-use rag_rat_oplog::{EdgeKey, EdgeSpec, MemoryOp, NodeContent, NodeId, NodeStatus, StreamId};
+use rag_rat_oplog::{
+    EdgeKey, EdgeSpec, MemoryOp, NodeContent, NodeId, NodeStatus, PreparedContentAuthoring,
+    SealPolicy, StreamId,
+};
 use rag_rat_query::memory::{EdgeRelation, NodeEdge, RepoMemory, memory_repo_scope};
 
 /// One memory's projectable content — the columns the op model carries (NOT the identity / anchor /
@@ -82,6 +85,57 @@ struct MemoryRow {
     source: String,
     payload_json: Option<String>,
     tags: Vec<String>,
+}
+
+const STREAM_SEAL_POLICY_META_KEY: &str = "memory_stream_seal_policy";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StreamSealPolicy {
+    Plaintext,
+    Sealed,
+}
+
+impl StreamSealPolicy {
+    fn seal_policy(self) -> SealPolicy {
+        match self {
+            Self::Plaintext => SealPolicy::Plaintext,
+            Self::Sealed => SealPolicy::Sealed,
+        }
+    }
+}
+
+pub(crate) struct PreparedOwnerAuthoring {
+    repo_id: String,
+    stream: StreamId,
+    policy: StreamSealPolicy,
+    prepared: PreparedContentAuthoring,
+}
+
+fn explicit_stream_seal_policy(
+    conn: &Connection,
+    repo_id: &str,
+) -> anyhow::Result<Option<StreamSealPolicy>> {
+    match rag_rat_db::meta::repo_meta(conn, repo_id, STREAM_SEAL_POLICY_META_KEY)?.as_deref() {
+        None => Ok(None),
+        Some("sealed") => Ok(Some(StreamSealPolicy::Sealed)),
+        Some(other) => anyhow::bail!(
+            "repo `{repo_id}` has unknown memory stream seal policy `{other}`; refusing to author"
+        ),
+    }
+}
+
+fn stream_seal_policy(
+    conn: &Connection,
+    repo_id: &str,
+    stream: StreamId,
+) -> anyhow::Result<StreamSealPolicy> {
+    if explicit_stream_seal_policy(conn, repo_id)? == Some(StreamSealPolicy::Sealed)
+        || rag_rat_oplog::content_stream_has_sealed_ratchet(conn, stream)?
+    {
+        Ok(StreamSealPolicy::Sealed)
+    } else {
+        Ok(StreamSealPolicy::Plaintext)
+    }
 }
 
 /// Build the op model's content register from a memory's projectable columns — shared by the
@@ -208,7 +262,7 @@ fn build_reconcile_ops(
 /// only a raw writer / import / pre-cap ghost with an oversized body or payload can fail this, and
 /// such a row is QUARANTINED rather than allowed to wedge the whole batch (#680). The status/edge
 /// ops are tiny and never oversized, so the `NodeCreate` alone decides a node's authorability.
-fn node_is_authorable(row: &MemoryRow) -> bool {
+fn node_is_authorable(row: &MemoryRow, policy: StreamSealPolicy) -> bool {
     let op = MemoryOp::NodeCreate {
         node_id: NodeId::from(row.memory_id.as_str()),
         content: node_content(
@@ -221,7 +275,7 @@ fn node_is_authorable(row: &MemoryRow) -> bool {
             row.payload_json.as_deref(),
         ),
     };
-    rag_rat_oplog::content_op_is_authorable(&op)
+    content_op_is_authorable(&op, policy)
 }
 
 /// Whether `edge`'s `EdgeAdd` fits the signed `/3` content envelope. The edge twin of
@@ -233,10 +287,17 @@ fn node_is_authorable(row: &MemoryRow) -> bool {
 /// DIFFERENT (forward-compat) failure — [`build_reconcile_ops`] surfaces it loudly via
 /// [`edge_add_op`], exactly as an unknown node status does — so a build error counts as authorable
 /// here and defers to that path rather than silently quarantining it.
-fn edge_is_authorable(edge: &NodeEdge, owner_repo_id: &str) -> bool {
+fn edge_is_authorable(edge: &NodeEdge, owner_repo_id: &str, policy: StreamSealPolicy) -> bool {
     match edge_add_op(edge, owner_repo_id) {
-        Ok(op) => rag_rat_oplog::content_op_is_authorable(&op),
+        Ok(op) => content_op_is_authorable(&op, policy),
         Err(_) => true,
+    }
+}
+
+fn content_op_is_authorable(op: &MemoryOp, policy: StreamSealPolicy) -> bool {
+    match policy {
+        StreamSealPolicy::Plaintext => rag_rat_oplog::content_op_is_authorable(op),
+        StreamSealPolicy::Sealed => rag_rat_oplog::content_op_is_sealed_authorable(op),
     }
 }
 
@@ -291,11 +352,12 @@ fn read_reconcile_work(
     conn: &Connection,
     repo_id: &str,
     stream: StreamId,
+    policy: StreamSealPolicy,
 ) -> anyhow::Result<ReconcileWork> {
     let (authorable_nodes, quarantined_nodes): (Vec<MemoryRow>, Vec<MemoryRow>) =
         read_unauthored_memory_rows(conn, repo_id, stream)?
             .into_iter()
-            .partition(node_is_authorable);
+            .partition(|row| node_is_authorable(row, policy));
     // An edge whose source node is quarantined has no authored `NodeCreate` to hang off, so drop it
     // WITH its source (the source node's quarantine warning is the actionable one — it never
     // reaches `quarantined_edges`).
@@ -310,7 +372,7 @@ fn read_reconcile_work(
         super::edges::unauthored_edges(conn, repo_id, stream)?
             .into_iter()
             .filter(|edge| !quarantined_node_ids.contains(edge.source_node_id.as_str()))
-            .partition(|edge| edge_is_authorable(edge, repo_id));
+            .partition(|edge| edge_is_authorable(edge, repo_id, policy));
     Ok(ReconcileWork { authorable_nodes, live_edges, quarantined_nodes, quarantined_edges })
 }
 
@@ -334,43 +396,34 @@ fn sync_owner_stream(conn: &Connection, repo_id: &str, now_ms: i64) -> anyhow::R
     {
         return Ok(());
     }
-    // Cheap autocommit fast-path: return WITHOUT the write lock only when the `/3` log is fully
-    // ESTABLISHED (the local account is minted AND its `StreamOwn` folded effective) AND nothing is
-    // missing. `established_owned_stream_v2` returns `None` for a fresh repo that has never
-    // published ownership — even one with an empty anti-join — so such a repo FALLS THROUGH to
-    // the slow path to mint + publish ownership rather than early-returning on an empty set it
-    // could not yet author into. `established_owned_stream_v2` is autocommit-only (it opens its
-    // own read txn), so it runs here, not under the write lock.
-    if let Some(stream) = rag_rat_oplog::established_owned_stream_v2(conn, repo_id)? {
-        let work = read_reconcile_work(conn, repo_id, stream)?;
-        if !work.has_authorable_work() {
-            // Nothing AUTHORABLE is missing. A quarantined (un-authorable) row can still be present
-            // here — it never becomes authorable on its own — so it is deliberately NOT "work":
-            // early-return on it too, or a single oversized ghost would force the write-locked slow
-            // path on every mutation forever (#680). Emit the per-row quarantine warning from the
-            // already-read work BEFORE returning (no write lock needed to warn) so a
-            // silently-skipped row surfaces its actionable warning on this cheap path
-            // exactly as the slow path does — otherwise the fast path skips the row on
-            // every reconcile with no signal at all.
-            work.warn_quarantined(repo_id);
-            return Ok(());
-        }
-    }
-
-    // Slow path. Mint the store's local account BEFORE the durability guard: the mint
+    // Mint the store's local account BEFORE the durability guard: the mint
     // self-transacts and holds its OWN durability guard that restores `synchronous = NORMAL` on
     // drop — beginning our guard first would let the mint's drop downgrade our authored commit
     // below NORMAL, silently losing the #560 durability. The mint is store-global and
     // idempotent (a re-mint returns the same account).
     rag_rat_oplog::local_account(conn, now_ms)?;
-    // Authored, irreplaceable data → durable (#560). FULL for this txn only, restored on drop; set
-    // OUTSIDE the txn (SQLite applies a `synchronous` change to SUBSEQUENT transactions only).
+    let stream = ensure_owner_stream(conn, repo_id, now_ms)?;
+    let policy = stream_seal_policy(conn, repo_id, stream)?;
+    let work = read_reconcile_work(conn, repo_id, stream, policy)?;
+    if !work.has_authorable_work() {
+        work.warn_quarantined(repo_id);
+        return Ok(());
+    }
+    let ops = build_reconcile_ops(
+        &work.authorable_nodes,
+        &work.live_edges,
+        repo_id,
+        rag_rat_oplog::content_stream_is_empty(conn, stream)?,
+    )?;
+    let prepared = prepare_owner_authoring(conn, repo_id, stream, policy, &ops, now_ms)?
+        .context("reconcile work unexpectedly prepared as an empty batch")?;
+
     let _durability = AuthoredDurability::begin(conn)?;
     let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
-    // Publish ownership of the repo's `/2` stream and resolve its id. Idempotent +
-    // check-fact-first: a re-ensure (or a racer serialized on this IMMEDIATE lock) authors no
-    // second `StreamOwn`.
-    let stream = rag_rat_oplog::ensure_owned_stream_v2_in_tx(&tx, repo_id, now_ms)?;
+    anyhow::ensure!(
+        stream_seal_policy(&tx, repo_id, stream)? == policy,
+        "memory stream seal policy changed while preparing reconcile; retry"
+    );
     // Authoritative re-read UNDER the write lock (TOCTOU): a concurrent author may have healed or
     // added rows between the probe and the lock, so re-read the missing set and re-derive `genesis`
     // here. `genesis` decides the status-elision: an empty `/3` content chain ⇒ no stale registers
@@ -383,7 +436,7 @@ fn sync_owner_stream(conn: &Connection, repo_id: &str, now_ms: i64) -> anyhow::R
     // signed `/3` envelope exceeds the §18a cap cannot make the whole batch `bail!` and wedge every
     // other memory write. The authorable rows are signed; the quarantined ones are logged and left
     // for the public API to shrink or delete.
-    let work = read_reconcile_work(&tx, repo_id, stream)?;
+    let work = read_reconcile_work(&tx, repo_id, stream, policy)?;
     work.warn_quarantined(repo_id);
     let ops = build_reconcile_ops(&work.authorable_nodes, &work.live_edges, repo_id, genesis)?;
     // Skip the author when there is nothing to author: a fresh repo whose anti-join was empty only
@@ -394,18 +447,142 @@ fn sync_owner_stream(conn: &Connection, repo_id: &str, now_ms: i64) -> anyhow::R
         // (#680), so the `/3` author's §18a size check cannot fire on this batch. `with_context`
         // still names the repo so any OTHER authoring failure (a stale `auth_len`, a contested
         // account) is attributable rather than surfacing as a bare rollback.
-        rag_rat_oplog::author_content_batch_in_tx(&tx, stream, &ops, now_ms).with_context(
-            || {
-                format!(
-                    "reconciling the /3 owner log for repo `{repo_id}` failed while authoring {} \
-                     pre-existing memory op(s)",
-                    ops.len()
-                )
-            },
-        )?;
+        rag_rat_oplog::author_prepared_content_batch_in_tx(
+            &tx,
+            stream,
+            &ops,
+            &prepared.prepared,
+            now_ms,
+        )
+        .with_context(|| {
+            format!(
+                "reconciling the /3 owner log for repo `{repo_id}` failed while authoring {} \
+                 pre-existing memory op(s)",
+                ops.len()
+            )
+        })?;
     }
     tx.commit()?;
     Ok(())
+}
+
+fn ensure_owner_stream(conn: &Connection, repo_id: &str, now_ms: i64) -> anyhow::Result<StreamId> {
+    if let Some(stream) = rag_rat_oplog::established_owned_stream_v2(conn, repo_id)? {
+        return Ok(stream);
+    }
+    let _durability = AuthoredDurability::begin(conn)?;
+    let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
+    let stream = rag_rat_oplog::ensure_owned_stream_v2_in_tx(&tx, repo_id, now_ms)?;
+    tx.commit()?;
+    Ok(stream)
+}
+
+fn prepare_owner_authoring(
+    conn: &Connection,
+    repo_id: &str,
+    stream: StreamId,
+    policy: StreamSealPolicy,
+    ops: &[MemoryOp],
+    now_ms: i64,
+) -> anyhow::Result<Option<PreparedOwnerAuthoring>> {
+    if ops.is_empty() {
+        return Ok(None);
+    }
+    for op in ops {
+        reject_unauthorable_content_op(op, policy)?;
+    }
+    let prepared =
+        rag_rat_oplog::prepare_content_authoring(conn, stream, policy.seal_policy(), now_ms)?;
+    Ok(Some(PreparedOwnerAuthoring { repo_id: repo_id.to_string(), stream, policy, prepared }))
+}
+
+pub(crate) fn prepare_live_authoring(
+    conn: &Connection,
+    ops: &[MemoryOp],
+    now_ms: i64,
+) -> anyhow::Result<Option<PreparedOwnerAuthoring>> {
+    if ops.is_empty() {
+        return Ok(None);
+    }
+    let Some(repo_id) = memory_repo_scope(conn)? else {
+        for op in ops {
+            reject_unauthorable_content_op(op, StreamSealPolicy::Plaintext)?;
+        }
+        return Ok(None);
+    };
+    let Some(stream) = stable_owner_stream_for_repo(conn, &repo_id)? else {
+        for op in ops {
+            reject_unauthorable_content_op(op, StreamSealPolicy::Plaintext)?;
+        }
+        return Ok(None);
+    };
+    let policy = stream_seal_policy(conn, &repo_id, stream)?;
+    prepare_owner_authoring(conn, &repo_id, stream, policy, ops, now_ms)
+}
+
+pub(crate) fn prepare_live_content_authoring(
+    conn: &Connection,
+    now_ms: i64,
+) -> anyhow::Result<Option<PreparedOwnerAuthoring>> {
+    let sentinel = MemoryOp::EdgeRemove { edge_key: EdgeKey::from("live-authoring-preparation") };
+    prepare_live_authoring(conn, &[sentinel], now_ms)
+}
+
+pub(crate) fn enable_sealed_authoring(conn: &Connection, now_ms: i64) -> anyhow::Result<bool> {
+    let repo_id = memory_repo_scope(conn)?.context("sync enable requires an active repo scope")?;
+    if repo_id == rag_rat_base::repo_identity::LEGACY_REPO_ID
+        || repo_id.starts_with(rag_rat_base::repo_identity::LOCAL_ONLY_ID_PREFIX)
+    {
+        anyhow::bail!("sync enable requires a stable repo identity (not legacy or local-only)");
+    }
+    rag_rat_oplog::local_account(conn, now_ms)?;
+    let stream = ensure_owner_stream(conn, &repo_id, now_ms)?;
+    let was_enabled =
+        explicit_stream_seal_policy(conn, &repo_id)? == Some(StreamSealPolicy::Sealed);
+
+    // A non-empty sentinel is required because preparation deliberately makes empty batches
+    // side-effect-free. The sentinel is never authored; it only drives the three-transaction key
+    // protocol before the final intent+reconcile transaction.
+    let sentinel = MemoryOp::EdgeRemove { edge_key: EdgeKey::from("sync-enable-key-preparation") };
+    let prepared = prepare_owner_authoring(
+        conn,
+        &repo_id,
+        stream,
+        StreamSealPolicy::Sealed,
+        &[sentinel],
+        now_ms,
+    )?
+    .context("sealed enable preparation unexpectedly returned empty")?;
+
+    let _durability = AuthoredDurability::begin(conn)?;
+    let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
+    // Unknown or malformed persisted policy was already rejected above. The only writable token is
+    // `sealed`; there is deliberately no plaintext writer, and the derived ratchet keeps this
+    // one-way even if external tooling deletes the intent row.
+    anyhow::ensure!(
+        stream_seal_policy(&tx, &repo_id, stream)? == StreamSealPolicy::Sealed,
+        "sealed enable key preparation did not arm the stream ratchet"
+    );
+    rag_rat_db::meta::set_repo_meta(&tx, &repo_id, STREAM_SEAL_POLICY_META_KEY, "sealed")?;
+    let work = read_reconcile_work(&tx, &repo_id, stream, StreamSealPolicy::Sealed)?;
+    work.warn_quarantined(&repo_id);
+    let ops = build_reconcile_ops(
+        &work.authorable_nodes,
+        &work.live_edges,
+        &repo_id,
+        rag_rat_oplog::content_stream_is_empty(&tx, stream)?,
+    )?;
+    if !ops.is_empty() {
+        rag_rat_oplog::author_prepared_content_batch_in_tx(
+            &tx,
+            stream,
+            &ops,
+            &prepared.prepared,
+            now_ms,
+        )?;
+    }
+    tx.commit()?;
+    Ok(!was_enabled)
 }
 
 /// Reconcile the ACTIVE repo's owner stream (scope read from the connection) — the idempotent call
@@ -444,12 +621,19 @@ fn stable_owner_stream(conn: &Connection) -> anyhow::Result<Option<StreamId>> {
     let Some(repo_id) = memory_repo_scope(conn)? else {
         return Ok(None);
     };
+    stable_owner_stream_for_repo(conn, &repo_id)
+}
+
+fn stable_owner_stream_for_repo(
+    conn: &Connection,
+    repo_id: &str,
+) -> anyhow::Result<Option<StreamId>> {
     if repo_id == rag_rat_base::repo_identity::LEGACY_REPO_ID
         || repo_id.starts_with(rag_rat_base::repo_identity::LOCAL_ONLY_ID_PREFIX)
     {
         return Ok(None);
     }
-    rag_rat_oplog::owned_stream_v2_id(conn, &repo_id)
+    rag_rat_oplog::owned_stream_v2_id(conn, repo_id)
 }
 
 /// Reject a live content op whose ASSEMBLED signed `/3` envelope would exceed the §18a 256 KiB cap
@@ -463,8 +647,8 @@ fn stable_owner_stream(conn: &Connection) -> anyhow::Result<Option<StreamId>> {
 /// reconcile can later author. Without it an "otherwise valid" create/update assembles an
 /// un-authorable op that the #680 reconcile quarantine then SILENTLY skips — the user never learns
 /// at write time.
-fn reject_unauthorable_content_op(op: &MemoryOp) -> anyhow::Result<()> {
-    if rag_rat_oplog::content_op_is_authorable(op) {
+fn reject_unauthorable_content_op(op: &MemoryOp, policy: StreamSealPolicy) -> anyhow::Result<()> {
+    if content_op_is_authorable(op, policy) {
         return Ok(());
     }
     // The per-field caps have already passed, so the culprit is an aggregate (or a future uncapped
@@ -493,7 +677,7 @@ fn reject_unauthorable_content_op(op: &MemoryOp) -> anyhow::Result<()> {
 
 /// Author `ops` as owner-authored `/3` content on the active repo's owner-bound `/2` stream WITHIN
 /// the caller's mutation txn — the strict-atomic live seam.
-/// [`rag_rat_oplog::author_content_batch_in_tx`] mints, inserts, refolds, and verify-accepts the
+/// [`rag_rat_oplog::author_prepared_content_batch_in_tx`] inserts, refolds, and verify-accepts the
 /// batch (no open/commit), so an authoring error propagates via `?` and the caller's txn rolls the
 /// table write back with it. A NO-OP under an unstable scope or before the local account is minted.
 /// The caller MUST have run `backfill_memory_oplog` first, so the store's account plus `StreamOwn`
@@ -502,6 +686,7 @@ fn reject_unauthorable_content_op(op: &MemoryOp) -> anyhow::Result<()> {
 fn author_in_owner_stream(
     tx: &Transaction<'_>,
     ops: &[MemoryOp],
+    prepared: Option<&PreparedOwnerAuthoring>,
     now_ms: i64,
 ) -> anyhow::Result<()> {
     // Whole-op write-boundary guard (#680): every live mutation
@@ -511,19 +696,35 @@ fn author_in_owner_stream(
     // individually-valid tags) and any future uncapped field. Runs BEFORE the scope gate so an
     // un-authorable op is rejected consistently even on a not-yet-owned stream (the reconcile does
     // NOT pass through here, so its pre-cap/imported-row quarantine is unaffected).
-    for op in ops {
-        reject_unauthorable_content_op(op)?;
-    }
-    let Some(stream) = stable_owner_stream(tx)? else {
-        return Ok(());
-    };
     // Skip a no-op mutation: an empty batch would still refold + reproject the whole stream for no
     // change. (The four live seams only reach here with non-empty ops today, but the guard keeps a
     // change-free `author_update` from doing O(chain) work.)
     if ops.is_empty() {
         return Ok(());
     }
-    rag_rat_oplog::author_content_batch_in_tx(tx, stream, ops, now_ms)?;
+    let Some(prepared) = prepared else {
+        // Scope-less and unstable-scope callers intentionally do not author.
+        anyhow::ensure!(stable_owner_stream(tx)?.is_none(), "missing prepared owner authoring");
+        return Ok(());
+    };
+    anyhow::ensure!(
+        memory_repo_scope(tx)?.as_deref() == Some(prepared.repo_id.as_str()),
+        "prepared /3 authoring belongs to a different repo scope"
+    );
+    anyhow::ensure!(
+        stream_seal_policy(tx, &prepared.repo_id, prepared.stream)? == prepared.policy,
+        "memory stream seal policy changed while preparing live authoring; retry"
+    );
+    for op in ops {
+        reject_unauthorable_content_op(op, prepared.policy)?;
+    }
+    rag_rat_oplog::author_prepared_content_batch_in_tx(
+        tx,
+        prepared.stream,
+        ops,
+        &prepared.prepared,
+        now_ms,
+    )?;
     Ok(())
 }
 
@@ -532,13 +733,14 @@ fn author_in_owner_stream(
 pub(crate) fn author_create(
     tx: &Transaction<'_>,
     memory: &RepoMemory,
+    prepared: Option<&PreparedOwnerAuthoring>,
     now_ms: i64,
 ) -> anyhow::Result<()> {
     let op = MemoryOp::NodeCreate {
         node_id: NodeId::from(memory.memory_id.as_str()),
         content: content_of(memory),
     };
-    author_in_owner_stream(tx, &[op], now_ms)
+    author_in_owner_stream(tx, &[op], prepared, now_ms)
 }
 
 /// Author a live memory UPDATE inside the caller's mutation txn: a `NodeUpdate` ONLY when the
@@ -553,6 +755,7 @@ pub(crate) fn author_update(
     memory: &RepoMemory,
     content_changed: bool,
     status_changed: bool,
+    prepared: Option<&PreparedOwnerAuthoring>,
     now_ms: i64,
 ) -> anyhow::Result<()> {
     let node_id = NodeId::from(memory.memory_id.as_str());
@@ -569,7 +772,7 @@ pub(crate) fn author_update(
         })?;
         ops.push(MemoryOp::NodeStatus { node_id, status });
     }
-    author_in_owner_stream(tx, &ops, now_ms)
+    author_in_owner_stream(tx, &ops, prepared, now_ms)
 }
 
 /// Author a live edge ADD (`EdgeAdd`) inside the caller's mutation txn — presence + the durable
@@ -583,6 +786,7 @@ pub(crate) fn author_edge_add(
     target_kind: &str,
     target_anchor: &str,
     owner_repo_id: &str,
+    prepared: Option<&PreparedOwnerAuthoring>,
     now_ms: i64,
 ) -> anyhow::Result<()> {
     let op = MemoryOp::EdgeAdd {
@@ -595,18 +799,20 @@ pub(crate) fn author_edge_add(
             owner_repo_id: owner_repo_id.to_string(),
         },
     };
-    author_in_owner_stream(tx, &[op], now_ms)
+    author_in_owner_stream(tx, &[op], prepared, now_ms)
 }
 
 /// Author a live edge REMOVE (`EdgeRemove` tombstone) inside the caller's mutation txn.
 pub(crate) fn author_edge_remove(
     tx: &Transaction<'_>,
     edge_key: &str,
+    prepared: Option<&PreparedOwnerAuthoring>,
     now_ms: i64,
 ) -> anyhow::Result<()> {
     author_in_owner_stream(
         tx,
         &[MemoryOp::EdgeRemove { edge_key: EdgeKey::from(edge_key) }],
+        prepared,
         now_ms,
     )
 }
@@ -806,6 +1012,18 @@ mod tests {
         conn.query_row("SELECT COUNT(*) FROM content_entries", [], |r| r.get(0)).unwrap()
     }
 
+    fn content_suites(conn: &Connection) -> Vec<u64> {
+        let mut stmt = conn
+            .prepare("SELECT signed_bytes FROM content_entries WHERE accepted = 1 ORDER BY rowid")
+            .unwrap();
+        stmt.query_map([], |row| row.get::<_, Vec<u8>>(0))
+            .unwrap()
+            .map(|bytes| {
+                rag_rat_oplog::decode_content_signed(&bytes.unwrap()).unwrap().header.crypto_suite
+            })
+            .collect()
+    }
+
     fn projected_node_count(conn: &Connection) -> i64 {
         conn.query_row("SELECT COUNT(*) FROM content_projected_nodes", [], |r| r.get(0)).unwrap()
     }
@@ -932,6 +1150,39 @@ mod tests {
         // default.
         let err = node_ops(&op_row("future_status_from_a_newer_binary"), true).unwrap_err();
         assert!(err.to_string().contains("unknown status"), "an unknown status fails authoring");
+    }
+
+    #[test]
+    fn sealed_authorability_reserves_the_aead_overhead() {
+        let mut row = op_row("active");
+        let mut found = false;
+        for len in 261_000..262_500 {
+            row.body = "x".repeat(len);
+            if node_is_authorable(&row, StreamSealPolicy::Plaintext)
+                && !node_is_authorable(&row, StreamSealPolicy::Sealed)
+            {
+                found = true;
+                break;
+            }
+        }
+        assert!(found, "the sealed policy rejects an op in the 40-byte AEAD overhead window");
+    }
+
+    #[test]
+    fn empty_preparation_mints_no_key_and_arms_no_policy() {
+        let conn = scoped_conn();
+        backfill_memory_oplog(&conn, 1_000).unwrap();
+        assert!(prepare_live_authoring(&conn, &[], 2_000).unwrap().is_none());
+        let secret_entries: i64 = conn
+            .query_row("SELECT COUNT(*) FROM account_entries WHERE log_id = 1", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        assert_eq!(secret_entries, 0);
+        assert_eq!(
+            rag_rat_db::meta::repo_meta(&conn, REPO, STREAM_SEAL_POLICY_META_KEY).unwrap(),
+            None
+        );
     }
 
     /// #541/#664: the reconcile's memory reader anti-joins `repo_memories` against the accepted-`/3`
@@ -1183,6 +1434,111 @@ mod tests {
             .unwrap();
         assert_eq!(n, 1, "the created memory is a projected /3 node");
         assert_eq!(projected_node_count(&conn), 1);
+        assert_eq!(content_suites(&conn), [0], "plaintext remains the default for existing repos");
+    }
+
+    #[test]
+    fn enable_is_idempotent_and_subsequent_live_authoring_is_sealed_and_projected() {
+        let conn = scoped_conn();
+        assert!(enable_sealed_authoring(&conn, 1_000).unwrap());
+        assert!(!enable_sealed_authoring(&conn, 2_000).unwrap());
+        assert_eq!(
+            rag_rat_db::meta::repo_meta(&conn, REPO, STREAM_SEAL_POLICY_META_KEY)
+                .unwrap()
+                .as_deref(),
+            Some("sealed")
+        );
+        let accepted_wraps: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM account_entries WHERE log_id = 1 AND accepted = 1",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(accepted_wraps, 1, "enable establishes exactly one accepted first-key wrap");
+
+        let first = create_concept(&conn, "sealed one").unwrap().memory.memory_id;
+        let second = create_concept(&conn, "sealed two").unwrap().memory.memory_id;
+        assert_eq!(content_suites(&conn), [1, 1]);
+        assert!(is_projected(&conn, &first));
+        assert!(is_projected(&conn, &second));
+
+        crate::memory_write::update_memory(&conn, rag_rat_query::memory::RepoMemoryUpdate {
+            memory_id: first.clone(),
+            kind: None,
+            title: None,
+            body: Some("sealed update".to_string()),
+            confidence: None,
+            status: Some("obsolete".to_string()),
+            tags: None,
+            payload_json: None,
+        })
+        .unwrap();
+        let edge = crate::memory_write::add_edge(
+            &conn,
+            &second,
+            EdgeRelation::RelatesTo,
+            &rag_rat_query::memory::EdgeTarget::Node { repo_id: None, node_id: first },
+        )
+        .unwrap();
+        crate::memory_write::remove_edge(&conn, &edge.edge_key).unwrap();
+        assert!(content_suites(&conn).into_iter().all(|suite| suite == 1));
+    }
+
+    #[test]
+    fn sealed_reconcile_authors_a_ghost_once() {
+        let conn = scoped_conn();
+        enable_sealed_authoring(&conn, 1_000).unwrap();
+        insert_memory(&conn, "sealed-ghost", "active", 100);
+        backfill_memory_oplog(&conn, 2_000).unwrap();
+        assert_eq!(content_suites(&conn), [1]);
+        assert!(is_projected(&conn, "sealed-ghost"));
+        backfill_memory_oplog(&conn, 3_000).unwrap();
+        assert_eq!(
+            content_suites(&conn),
+            [1],
+            "repeat reconcile does not duplicate sealed history"
+        );
+    }
+
+    #[test]
+    fn sealed_policy_is_repo_scoped_and_the_ratchet_survives_deleted_intent() {
+        let conn = scoped_conn();
+        enable_sealed_authoring(&conn, 1_000).unwrap();
+        conn.execute(
+            "INSERT INTO repos(repo_id, display_name, registered_at_ms) VALUES ('repo-b', \
+             'repo-b', 0)",
+            [],
+        )
+        .unwrap();
+        set_scope(&conn, "repo-b");
+        let b = create_concept(&conn, "repo b plaintext").unwrap().memory.memory_id;
+        assert!(is_projected(&conn, &b));
+        assert_eq!(content_suites(&conn), [0], "a sibling repo remains plaintext by default");
+
+        set_scope(&conn, REPO);
+        conn.execute("DELETE FROM repo_meta WHERE repo_id = ?1 AND key = ?2", params![
+            REPO,
+            STREAM_SEAL_POLICY_META_KEY
+        ])
+        .unwrap();
+        create_concept(&conn, "ratcheted sealed").unwrap();
+        assert_eq!(content_suites(&conn), [0, 1], "a wrap prevents plaintext downgrade");
+    }
+
+    #[test]
+    fn policy_revalidation_failure_rolls_back_the_table_mutation() {
+        let conn = scoped_conn();
+        backfill_memory_oplog(&conn, 1_000).unwrap();
+        let prepared = prepare_live_content_authoring(&conn, 2_000).unwrap().unwrap();
+        rag_rat_db::meta::set_repo_meta(&conn, REPO, STREAM_SEAL_POLICY_META_KEY, "sealed")
+            .unwrap();
+        let tx = conn.unchecked_transaction().unwrap();
+        insert_memory(&tx, "must-roll-back", "active", 100);
+        let memory = rag_rat_query::memory::memory_by_id(&tx, "must-roll-back").unwrap().unwrap();
+        assert!(author_create(&tx, &memory, Some(&prepared), 2_000).is_err());
+        drop(tx);
+        assert!(rag_rat_query::memory::memory_by_id(&conn, "must-roll-back").unwrap().is_none());
     }
 
     #[test]

--- a/crates/rag-rat-core/src/memory_write/edges.rs
+++ b/crates/rag-rat-core/src/memory_write/edges.rs
@@ -89,6 +89,7 @@ pub(crate) fn add_edge(
     // Backfill the pre-existing history (idempotent) + the edge INSERT + the EdgeAdd op in ONE
     // transaction (strict-atomic); the write via `conn` participates in the open txn.
     authoring::backfill_memory_oplog(conn, now)?;
+    let prepared = authoring::prepare_live_content_authoring(conn, now)?;
     // Authored write: the EdgeAdd op is signed op-log content, so commit durably (#560).
     let _durability = authoring::AuthoredDurability::begin(conn)?;
     let tx = conn.unchecked_transaction()?;
@@ -137,6 +138,7 @@ pub(crate) fn add_edge(
             target_kind,
             &target_anchor,
             &owner_repo_id,
+            prepared.as_ref(),
             now,
         )?;
     }
@@ -149,6 +151,7 @@ pub(crate) fn remove_edge(conn: &Connection, edge_key: &str) -> anyhow::Result<b
     let repo_clause = periphery_edge_scope_clause(&scope);
     let now = now_ms();
     authoring::backfill_memory_oplog(conn, now)?;
+    let prepared = authoring::prepare_live_content_authoring(conn, now)?;
     // Authored write: the EdgeRemove tombstone is signed op-log content, so commit durably (#560).
     let _durability = authoring::AuthoredDurability::begin(conn)?;
     let tx = conn.unchecked_transaction()?;
@@ -158,7 +161,7 @@ pub(crate) fn remove_edge(conn: &Connection, edge_key: &str) -> anyhow::Result<b
         ])?;
     if n > 0 {
         // Author an EdgeRemove tombstone ONLY when a row was actually removed, in the same txn.
-        authoring::author_edge_remove(&tx, edge_key, now)?;
+        authoring::author_edge_remove(&tx, edge_key, prepared.as_ref(), now)?;
     }
     tx.commit()?;
     Ok(n > 0)

--- a/crates/rag-rat-core/src/memory_write/mod.rs
+++ b/crates/rag-rat-core/src/memory_write/mod.rs
@@ -19,6 +19,7 @@ pub(crate) use api::{create_memory, mark_obsolete, rebind_memory, update_memory}
 // Re-exported so the index reconcile path (the idle-repo ghost backstop, #583) can name it
 // across the private module.
 pub(crate) use authoring::backfill_memory_oplog;
+pub(crate) use authoring::enable_sealed_authoring;
 // The scope-explicit reconcile entry (#541): `authoring` is a PRIVATE module, so
 // `index::consolidate` names this through this re-export (Task 5 of #541).
 pub(crate) use authoring::reconcile_owner_stream_for_repo;

--- a/crates/rag-rat-oplog/src/account/content/author.rs
+++ b/crates/rag-rat-oplog/src/account/content/author.rs
@@ -601,7 +601,7 @@ fn stream_has_sealed_ratchet(
     account_id: AccountId,
     stream_id: StreamId,
 ) -> anyhow::Result<bool> {
-    if secrets::select_current_sealing_wrap(conn, account_id, stream_id)?.is_some() {
+    if secrets::accepted_stream_key_wrap_exists_strict(conn, account_id, stream_id)? {
         return Ok(true);
     }
     stream_has_accepted_sealed_entry(conn, stream_id)
@@ -2109,6 +2109,52 @@ mod tests {
         let after: i64 =
             conn.query_row("SELECT count(*) FROM content_entries", [], |row| row.get(0)).unwrap();
         assert_eq!(before, after, "the failed plaintext batch leaked no content row");
+    }
+
+    #[test]
+    fn corrupt_accepted_wrap_aborts_prepared_plaintext_authoring_without_sealed_content() {
+        let conn = db();
+        let (_account, stream) = owned_v2(&conn);
+        let wrap_hash = {
+            let tx = Transaction::new_unchecked(&conn, TransactionBehavior::Immediate).unwrap();
+            let wrap_hash =
+                secrets::mint_and_author_stream_key_wrap_in_tx(&tx, stream, NOW).unwrap();
+            tx.commit().unwrap();
+            wrap_hash
+        };
+        conn.execute("UPDATE account_entries SET signed_bytes = X'00' WHERE entry_hash = ?1", [
+            wrap_hash.as_slice(),
+        ])
+        .unwrap();
+        assert_eq!(
+            conn.query_row("SELECT count(*) FROM content_entries", [], |row| row.get::<_, i64>(0))
+                .unwrap(),
+            0,
+            "the malformed accepted wrap is the only sealing evidence",
+        );
+
+        let prepared = prepare_content_authoring(&conn, stream, SealPolicy::Plaintext, NOW)
+            .expect("plaintext preparation defers the ratchet check to the authoring transaction");
+        let tx = Transaction::new_unchecked(&conn, TransactionBehavior::Immediate).unwrap();
+        let err = author_prepared_content_batch_in_tx(
+            &tx,
+            stream,
+            &[node_create("plaintext", "must-not-leak")],
+            &prepared,
+            NOW,
+        )
+        .expect_err("accepted wrap corruption must fail closed for downgrade evidence");
+        drop(tx);
+        assert!(
+            err.to_string().contains("sealed-ratchet wrap evidence"),
+            "unexpected error: {err:#}"
+        );
+        assert_eq!(
+            conn.query_row("SELECT count(*) FROM content_entries", [], |row| row.get::<_, i64>(0))
+                .unwrap(),
+            0,
+            "the failed plaintext authoring leaked no content row",
+        );
     }
 
     #[test]

--- a/crates/rag-rat-oplog/src/account/content/author.rs
+++ b/crates/rag-rat-oplog/src/account/content/author.rs
@@ -114,7 +114,7 @@ const CONTENT_SEALED_OP_BODY_MAX_BYTES: usize =
     CONTENT_OP_BODY_MAX_BYTES - CONTENT_SEALED_AEAD_OVERHEAD_BYTES;
 
 /// The sealed-path twin of [`content_op_is_authorable`]: whether `op` fits a signed suite-1 `/3`
-/// entry once the AEAD nonce + tag are added to its body (S2, #608). A future live reconcile uses
+/// entry once the AEAD nonce + tag are added to its body (S2, #608). The live reconcile uses
 /// this to QUARANTINE an un-authorable op on a sealed stream — exactly as the suite-0 predicate
 /// does on a plaintext one — instead of `bail!`ing the whole batch at sign time.
 pub fn content_op_is_sealed_authorable(op: &MemoryOp) -> bool {
@@ -225,10 +225,6 @@ pub fn author_content_batch_in_tx(
 /// EXPLICITLY — wrap presence is a downgrade-ratchet INPUT, never the privacy oracle: a private
 /// stream's accepted-wrap set can legitimately empty under sync lag or a retro-condemn, and
 /// treating "no wrap ⇒ public" would author plaintext on a private stream (a confidentiality leak).
-///
-/// UNWIRED: the live memory path still authors through [`author_content_batch_in_tx`] (suite 0).
-/// The read-side can project sealed entries, but no live intent source selects this policy-aware,
-/// self-transacting seam yet.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SealPolicy {
     /// Author plaintext suite-0 entries — REFUSED on a stream that has ratcheted to sealed.
@@ -334,8 +330,6 @@ pub fn author_prepared_content_batch_in_tx(
 /// [`author_prepared_content_batch_in_tx`] with an owned IMMEDIATE transaction. Returns the
 /// authored entry hashes in authoring order. Requires the store's local account to be minted
 /// already.
-///
-/// UNWIRED (C5a): nothing live calls this — see [`SealPolicy`].
 pub fn author_content_batch(
     conn: &Connection,
     stream_id: StreamId,
@@ -603,14 +597,27 @@ fn require_local_account_id(conn: &Connection) -> anyhow::Result<AccountId> {
 /// surviving sealed entries, and a re-minted wrap re-arms the gate. Wrap presence is one ratchet
 /// INPUT, never the sole privacy oracle.
 fn stream_has_sealed_ratchet(
-    tx: &Transaction<'_>,
+    conn: &Connection,
     account_id: AccountId,
     stream_id: StreamId,
 ) -> anyhow::Result<bool> {
-    if secrets::select_current_sealing_wrap(tx, account_id, stream_id)?.is_some() {
+    if secrets::select_current_sealing_wrap(conn, account_id, stream_id)?.is_some() {
         return Ok(true);
     }
-    stream_has_accepted_sealed_entry(tx, stream_id)
+    stream_has_accepted_sealed_entry(conn, stream_id)
+}
+
+/// Whether a stream has irreversibly ratcheted to sealed authoring through an accepted key wrap or
+/// accepted suite-1 content. This is a downgrade guard, not the privacy-intent source: callers must
+/// persist intent separately because a private stream can temporarily have no accepted wraps.
+pub fn content_stream_has_sealed_ratchet(
+    conn: &Connection,
+    stream_id: StreamId,
+) -> anyhow::Result<bool> {
+    let Some(local) = bootstrap::local_account_ref(conn)? else {
+        return Ok(false);
+    };
+    stream_has_sealed_ratchet(conn, local.account_id, stream_id)
 }
 
 /// Whether any accepted `/3` entry on `stream_id` is suite-1 (sealed). There is no `crypto_suite`
@@ -618,10 +625,10 @@ fn stream_has_sealed_ratchet(
 /// bytes fail to decode cannot be a valid suite-1 entry and is skipped. Early-returns on the first
 /// match.
 fn stream_has_accepted_sealed_entry(
-    tx: &Transaction<'_>,
+    conn: &Connection,
     stream_id: StreamId,
 ) -> anyhow::Result<bool> {
-    let mut stmt = tx.prepare(
+    let mut stmt = conn.prepare(
         "SELECT signed_bytes FROM content_entries WHERE stream_id = ?1 AND accepted = 1",
     )?;
     let mut rows = stmt.query(params![stream_id.to_bytes().as_slice()])?;
@@ -1378,7 +1385,7 @@ mod tests {
         assert_eq!(head.entry_hash, hashes[1], "the tail names the highest-seq entry");
     }
 
-    // ── C5a: the sealed suite-1 author seam (UNWIRED) ──
+    // ── C5a: the sealed suite-1 author seam ──
 
     /// Mint the store's local account and publish an owned `/2` stream via the REAL ownership seam
     /// (`ensure_owned_stream_v2_in_tx`) — the sealed mint needs a genuine effective `StreamOwn`,

--- a/crates/rag-rat-oplog/src/account/content/author.rs
+++ b/crates/rag-rat-oplog/src/account/content/author.rs
@@ -114,9 +114,9 @@ const CONTENT_SEALED_OP_BODY_MAX_BYTES: usize =
     CONTENT_OP_BODY_MAX_BYTES - CONTENT_SEALED_AEAD_OVERHEAD_BYTES;
 
 /// The sealed-path twin of [`content_op_is_authorable`]: whether `op` fits a signed suite-1 `/3`
-/// entry once the AEAD nonce + tag are added to its body (S2, #608). C5b's live reconcile uses this
-/// to QUARANTINE an un-authorable op on a sealed stream — exactly as the suite-0 predicate does on
-/// a plaintext one — instead of `bail!`ing the whole batch at sign time.
+/// entry once the AEAD nonce + tag are added to its body (S2, #608). A future live reconcile uses
+/// this to QUARANTINE an un-authorable op on a sealed stream — exactly as the suite-0 predicate
+/// does on a plaintext one — instead of `bail!`ing the whole batch at sign time.
 pub fn content_op_is_sealed_authorable(op: &MemoryOp) -> bool {
     op::encode(op).len() <= CONTENT_SEALED_OP_BODY_MAX_BYTES
 }
@@ -226,11 +226,9 @@ pub fn author_content_batch_in_tx(
 /// stream's accepted-wrap set can legitimately empty under sync lag or a retro-condemn, and
 /// treating "no wrap ⇒ public" would author plaintext on a private stream (a confidentiality leak).
 ///
-/// UNWIRED in C5a: the live memory path still authors through [`author_content_batch_in_tx`]
-/// (suite 0). This policy-aware, self-transacting seam is exercised only by tests until C5b lands
-/// decrypt-at-projection, the read-side keyring, and the `sync enable` intent source. Authoring a
-/// sealed entry into the live path before C5b's decrypt exists triggers the reconcile anti-join
-/// duplication loop `content_projection` documents, which is why nothing live calls this yet.
+/// UNWIRED: the live memory path still authors through [`author_content_batch_in_tx`] (suite 0).
+/// The read-side can project sealed entries, but no live intent source selects this policy-aware,
+/// self-transacting seam yet.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SealPolicy {
     /// Author plaintext suite-0 entries — REFUSED on a stream that has ratcheted to sealed.
@@ -458,12 +456,8 @@ fn mint_first_key_then_resolve(
 }
 
 /// The `SealPolicy::Sealed` txn B core — mirrors [`author_content_batch_in_tx`] but SEALS each op
-/// under `key` (suite 1). VERIFY-ACCEPTED reads `content_entry_status` ONLY, NEVER "the projection
-/// contains my nodes" (false for a sealed entry until C5b's decrypt-at-projection lands —
-/// `op::decode` fails on ciphertext). For the same reason the plaintext seam's
-/// `reproject_accepted_content_stream` call is INTENTIONALLY omitted: reprojecting a sealed stream
-/// pre-C5b would skip every sealed entry, and wiring that into the live reconcile is the anti-join
-/// duplication trap C5a avoids by staying unwired.
+/// under `key` (suite 1). VERIFY-ACCEPTED reads `content_entry_status` ONLY, never projection rows;
+/// after acceptance changes, the stream is reprojected in the same transaction just like suite 0.
 fn seal_and_author_in_tx(
     tx: &Transaction<'_>,
     stream_id: StreamId,
@@ -528,6 +522,7 @@ fn seal_and_author_in_tx(
             ),
         }
     }
+    content_projection::reproject_accepted_content_stream(tx, stream_id)?;
     Ok(authored)
 }
 
@@ -921,6 +916,31 @@ mod tests {
         envelope::decode_content_signed(&signed_bytes).unwrap().header
     }
 
+    fn insert_accepted_signed(conn: &Connection, signed: &envelope::SignedContentEntry) {
+        let header = &signed.header;
+        conn.execute(
+            "INSERT INTO content_entries(
+                 entry_hash, stream_id, author_account_id, device_fingerprint, seq, prev_hash,
+                 grant_id, roster_ref, owner_auth_len, author_auth_len, accepted, signed_bytes,
+                 received_at_ms)
+             VALUES(?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, 1, ?11, 0)",
+            params![
+                signed.entry_hash.as_slice(),
+                header.stream_id.to_bytes().as_slice(),
+                header.author_account_id.to_bytes().as_slice(),
+                header.device_fingerprint.to_bytes().as_slice(),
+                header.seq.to_be_bytes().as_slice(),
+                header.prev_hash.as_ref().map(|hash| hash.as_slice()),
+                header.grant_id.as_ref().map(|hash| hash.as_slice()),
+                header.roster_ref.as_slice(),
+                header.owner_auth_len.to_be_bytes().as_slice(),
+                header.author_auth_len.to_be_bytes().as_slice(),
+                signed.signed_bytes.as_slice(),
+            ],
+        )
+        .unwrap();
+    }
+
     #[test]
     fn a_batch_authors_owner_content_that_folds_accepted_with_dense_seqs_and_lamport_eq_seq() {
         let conn = db();
@@ -1165,7 +1185,7 @@ mod tests {
              DELETE FROM content_projected_edges;
              INSERT INTO content_projected_nodes(stream_id, node_id, content_json, status)
               VALUES(X'99', 'ghost', '{}', 'active');
-             INSERT INTO oplog_meta(key, value) VALUES ('content_projector_version', '0')
+             INSERT INTO oplog_meta(key, value) VALUES ('content_projector_version', '1')
               ON CONFLICT(key) DO UPDATE SET value = excluded.value;",
         )
         .unwrap();
@@ -1184,7 +1204,7 @@ mod tests {
             )
             .unwrap();
         assert_eq!(ghost, 0, "the wholesale clear dropped the row with no accepted content");
-        assert_eq!(stored_stamp(&conn).as_deref(), Some("1"), "the store-global stamp upgraded");
+        assert_eq!(stored_stamp(&conn).as_deref(), Some("2"), "the store-global stamp upgraded");
 
         assert!(
             !content_projection::rebuild_all_content_projections_if_stale(&conn).unwrap(),
@@ -1212,7 +1232,7 @@ mod tests {
         // An OLDER stamp is left untouched too: the per-stream path rebuilds this stream's rows
         // but does not mark the (possibly stale) store current.
         conn.execute(
-            "INSERT INTO oplog_meta(key, value) VALUES ('content_projector_version', '0')
+            "INSERT INTO oplog_meta(key, value) VALUES ('content_projector_version', '1')
              ON CONFLICT(key) DO UPDATE SET value = excluded.value",
             [],
         )
@@ -1222,14 +1242,14 @@ mod tests {
         content_projection::reproject_accepted_content_stream(&tx, stream).unwrap();
         tx.commit().unwrap();
         assert_eq!(projected_node_count(&conn, stream), 1, "the stream's rows are rebuilt");
-        assert_eq!(stored_stamp(&conn).as_deref(), Some("0"), "the stale stamp is NOT upgraded");
+        assert_eq!(stored_stamp(&conn).as_deref(), Some("1"), "the v1 stamp is NOT upgraded");
 
         // The upgrade re-fold makes the store current; from then on per-stream reprojects
         // maintain the stamp.
         assert!(content_projection::rebuild_all_content_projections_if_stale(&conn).unwrap());
-        assert_eq!(stored_stamp(&conn).as_deref(), Some("1"));
+        assert_eq!(stored_stamp(&conn).as_deref(), Some("2"));
         author_committed(&conn, stream, &[node_create("n2", "second")]);
-        assert_eq!(stored_stamp(&conn).as_deref(), Some("1"), "a current store stays current");
+        assert_eq!(stored_stamp(&conn).as_deref(), Some("2"), "a current store stays current");
         assert_eq!(projected_node_count(&conn, stream), 2);
     }
 
@@ -1474,6 +1494,253 @@ mod tests {
             secrets::select_current_sealing_wrap(&conn, account, stream).unwrap().is_some(),
             "a content key was minted for the stream",
         );
+        let projected: String = conn
+            .query_row(
+                "SELECT content_json FROM content_projected_nodes
+                 WHERE stream_id = ?1 AND node_id = 'n1'",
+                [stream.to_bytes().as_slice()],
+                |row| row.get(0),
+            )
+            .expect("suite-1 content decrypts during projection");
+        assert!(projected.contains("second"), "the decrypted update wins the LWW register");
+    }
+
+    #[test]
+    fn mixed_plaintext_and_sealed_entries_project_together() {
+        let conn = db();
+        let (_account, stream) = owned_v2(&conn);
+        author_committed(&conn, stream, &[node_create("public", "plain")]);
+        author_content_batch(
+            &conn,
+            stream,
+            &[node_create("private", "sealed")],
+            SealPolicy::Sealed,
+            NOW,
+        )
+        .unwrap();
+        let ids: Vec<String> = {
+            let mut stmt = conn
+                .prepare(
+                    "SELECT node_id FROM content_projected_nodes
+                     WHERE stream_id = ?1 ORDER BY node_id",
+                )
+                .unwrap();
+            stmt.query_map([stream.to_bytes().as_slice()], |row| row.get(0))
+                .unwrap()
+                .collect::<rusqlite::Result<_>>()
+                .unwrap()
+        };
+        assert_eq!(ids, vec!["private".to_string(), "public".to_string()]);
+    }
+
+    #[test]
+    fn projection_keeps_prior_epoch_content_after_rotation() {
+        let conn = db();
+        let (_account, stream) = owned_v2(&conn);
+        author_content_batch(
+            &conn,
+            stream,
+            &[node_create("old", "epoch zero")],
+            SealPolicy::Sealed,
+            NOW,
+        )
+        .unwrap();
+        let tx = Transaction::new_unchecked(&conn, TransactionBehavior::Immediate).unwrap();
+        secrets::rotate_stream_key_in_tx(&tx, stream, NOW + 1).unwrap();
+        tx.commit().unwrap();
+        author_content_batch(
+            &conn,
+            stream,
+            &[node_create("new", "epoch one")],
+            SealPolicy::Sealed,
+            NOW + 2,
+        )
+        .unwrap();
+        assert_eq!(projected_node_count(&conn, stream), 2, "both historical keys are available");
+    }
+
+    #[test]
+    fn decrypted_nodes_follow_retro_condemn_and_accept_reprojection() {
+        let conn = db();
+        let (_account, stream) = owned_v2(&conn);
+        let hashes = author_content_batch(
+            &conn,
+            stream,
+            &[node_create("sealed", "visible")],
+            SealPolicy::Sealed,
+            NOW,
+        )
+        .unwrap();
+        assert_eq!(projected_node_count(&conn, stream), 1);
+
+        conn.execute("UPDATE content_entries SET accepted = 0 WHERE entry_hash = ?1", [
+            hashes[0].as_slice()
+        ])
+        .unwrap();
+        let tx = conn.unchecked_transaction().unwrap();
+        content_projection::reproject_accepted_content_stream(&tx, stream).unwrap();
+        tx.commit().unwrap();
+        assert_eq!(projected_node_count(&conn, stream), 0, "retro-condemn removes decrypted state");
+
+        conn.execute("UPDATE content_entries SET accepted = 1 WHERE entry_hash = ?1", [
+            hashes[0].as_slice()
+        ])
+        .unwrap();
+        let tx = conn.unchecked_transaction().unwrap();
+        content_projection::reproject_accepted_content_stream(&tx, stream).unwrap();
+        tx.commit().unwrap();
+        assert_eq!(projected_node_count(&conn, stream), 1, "retro-accept restores decrypted state");
+    }
+
+    #[test]
+    fn projection_resolves_the_stream_owner_not_the_content_author() {
+        let conn = db();
+        let (owner, stream) = owned_v2(&conn);
+        let tx = Transaction::new_unchecked(&conn, TransactionBehavior::Immediate).unwrap();
+        secrets::mint_and_author_stream_key_wrap_in_tx(&tx, stream, NOW).unwrap();
+        tx.commit().unwrap();
+        let device = local_device(&conn, NOW).unwrap();
+        let key = match secrets::current_sealing_key(&conn, owner, stream, &device, NOW).unwrap() {
+            SealingKeyOutcome::Ready(key) => key,
+            _ => panic!("owner key must resolve"),
+        };
+        let granted_author = AccountId::from_bytes([0x91; 32]);
+        let header = ContentEntryHeader {
+            stream_id: stream,
+            author_account_id: granted_author,
+            device_fingerprint: device.fingerprint(),
+            seq: 0,
+            lamport: 0,
+            prev_hash: None,
+            grant_id: Some([0x92; 32]),
+            roster_ref: [0x93; 32],
+            owner_auth_len: 0,
+            author_auth_len: 0,
+            crypto_suite: 0,
+            key_id: None,
+        };
+        let signed = envelope::seal_and_sign_content_entry(
+            device.secret(),
+            &header,
+            &op::encode(&node_create("granted", "writer")),
+            &key,
+        )
+        .unwrap();
+        insert_accepted_signed(&conn, &signed);
+        let tx = conn.unchecked_transaction().unwrap();
+        content_projection::reproject_accepted_content_stream(&tx, stream).unwrap();
+        tx.commit().unwrap();
+        assert_eq!(projected_node_count(&conn, stream), 1);
+    }
+
+    #[test]
+    fn malformed_tampered_and_unknown_suite_entries_do_not_suppress_valid_content() {
+        let conn = db();
+        let (owner, stream) = owned_v2(&conn);
+        author_content_batch(
+            &conn,
+            stream,
+            &[node_create("good", "survives")],
+            SealPolicy::Sealed,
+            NOW,
+        )
+        .unwrap();
+        let device = local_device(&conn, NOW).unwrap();
+        let key = match secrets::current_sealing_key(&conn, owner, stream, &device, NOW).unwrap() {
+            SealingKeyOutcome::Ready(key) => key,
+            _ => panic!("owner key must resolve"),
+        };
+        let base = ContentEntryHeader {
+            stream_id: stream,
+            author_account_id: AccountId::from_bytes([0xa1; 32]),
+            device_fingerprint: device.fingerprint(),
+            seq: 0,
+            lamport: 1,
+            prev_hash: None,
+            grant_id: Some([0xa2; 32]),
+            roster_ref: [0xa3; 32],
+            owner_auth_len: 0,
+            author_auth_len: 0,
+            crypto_suite: 1,
+            key_id: Some(key.key_id().to_bytes()),
+        };
+        let short = envelope::sign_opaque_content_entry_for_test(
+            device.secret(),
+            &base,
+            &[0; envelope::SEALED_NONCE_LEN],
+        )
+        .unwrap();
+        insert_accepted_signed(&conn, &short);
+
+        let mut tampered = envelope::seal_and_sign_content_entry(
+            device.secret(),
+            &ContentEntryHeader {
+                author_account_id: AccountId::from_bytes([0xb1; 32]),
+                grant_id: Some([0xb2; 32]),
+                ..base.clone()
+            },
+            &op::encode(&node_create("bad", "tag")),
+            &key,
+        )
+        .unwrap();
+        *tampered.payload.last_mut().unwrap() ^= 1;
+        let tampered = envelope::sign_opaque_content_entry_for_test(
+            device.secret(),
+            &tampered.header,
+            &tampered.payload,
+        )
+        .unwrap();
+        insert_accepted_signed(&conn, &tampered);
+
+        let unknown = envelope::sign_opaque_content_entry_for_test(
+            device.secret(),
+            &ContentEntryHeader {
+                author_account_id: AccountId::from_bytes([0xc1; 32]),
+                grant_id: Some([0xc2; 32]),
+                crypto_suite: 99,
+                ..base
+            },
+            &[0xde, 0xad],
+        )
+        .unwrap();
+        insert_accepted_signed(&conn, &unknown);
+
+        let tx = conn.unchecked_transaction().unwrap();
+        content_projection::reproject_accepted_content_stream(&tx, stream)
+            .expect("bad local payloads skip without aborting the stream");
+        tx.commit().unwrap();
+        assert_eq!(projected_node_count(&conn, stream), 1, "the valid node remains projected");
+        let accepted: i64 = conn
+            .query_row(
+                "SELECT count(*) FROM content_entries WHERE stream_id = ?1 AND accepted = 1",
+                [stream.to_bytes().as_slice()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(accepted, 4, "all malformed/unknown entries remain accepted and retained");
+    }
+
+    #[test]
+    fn corrupt_stored_signed_envelope_is_a_loud_projection_error() {
+        let conn = db();
+        let (_account, stream) = owned_v2(&conn);
+        let hashes = author_content_batch(
+            &conn,
+            stream,
+            &[node_create("sealed", "valid")],
+            SealPolicy::Sealed,
+            NOW,
+        )
+        .unwrap();
+        conn.execute("UPDATE content_entries SET signed_bytes = X'00' WHERE entry_hash = ?1", [
+            hashes[0].as_slice(),
+        ])
+        .unwrap();
+        let tx = conn.unchecked_transaction().unwrap();
+        assert!(
+            content_projection::reproject_accepted_content_stream(&tx, stream).is_err(),
+            "corruption of the stored signed envelope must not be downgraded to a local skip",
+        );
     }
 
     #[test]
@@ -1549,6 +1816,15 @@ mod tests {
             ("accepted", 1),
             "the sealed entry folds accepted on a peer with no content key",
         );
+        assert_eq!(
+            projected_node_count(&peer, stream),
+            0,
+            "keyless accepted content is unprojected"
+        );
+        let identity_rows: i64 = peer
+            .query_row("SELECT count(*) FROM oplog_device_identity", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(identity_rows, 0, "projection must not mint a peer identity");
     }
 
     #[test]

--- a/crates/rag-rat-oplog/src/account/content/author.rs
+++ b/crates/rag-rat-oplog/src/account/content/author.rs
@@ -621,9 +621,10 @@ pub fn content_stream_has_sealed_ratchet(
 }
 
 /// Whether any accepted `/3` entry on `stream_id` is suite-1 (sealed). There is no `crypto_suite`
-/// column, so each accepted entry's header is decoded from its stored signed bytes; a row whose
-/// bytes fail to decode cannot be a valid suite-1 entry and is skipped. Early-returns on the first
-/// match.
+/// column, so each accepted entry's header is decoded from its stored signed bytes. Decode failure
+/// is corruption at rest and must abort the authoring decision: treating it as "not sealed" could
+/// downgrade a corrupt accepted suite-1 row to plaintext. Every row is decoded even after finding
+/// a sealed entry, so unrelated accepted-row corruption cannot be hidden by query order.
 fn stream_has_accepted_sealed_entry(
     conn: &Connection,
     stream_id: StreamId,
@@ -632,15 +633,16 @@ fn stream_has_accepted_sealed_entry(
         "SELECT signed_bytes FROM content_entries WHERE stream_id = ?1 AND accepted = 1",
     )?;
     let mut rows = stmt.query(params![stream_id.to_bytes().as_slice()])?;
+    let mut has_sealed_entry = false;
     while let Some(row) = rows.next()? {
         let signed_bytes: Vec<u8> = row.get(0)?;
-        if let Ok(signed) = envelope::decode_content_signed(&signed_bytes)
-            && signed.header.crypto_suite != 0
-        {
-            return Ok(true);
+        let signed = envelope::decode_content_signed(&signed_bytes)
+            .context("stored accepted /3 entry failed to decode while checking sealed ratchet")?;
+        if signed.header.crypto_suite != 0 {
+            has_sealed_entry = true;
         }
     }
-    Ok(false)
+    Ok(has_sealed_entry)
 }
 
 /// Whether the `/2` stream's `/3` content chain is EMPTY — no `content_entries` row on it at all.
@@ -1874,6 +1876,45 @@ mod tests {
     }
 
     #[test]
+    fn a_valid_envelope_substituted_into_another_accepted_row_is_a_loud_projection_error() {
+        let conn = db();
+        let stream_a = StreamId::from_bytes(STREAM_A);
+        let stream_b = StreamId::from_bytes(STREAM_B);
+        let account = owned_stream_account(&conn, stream_a);
+        seed_ownership(&conn, stream_b, account);
+        let hash_a = author_committed(&conn, stream_a, &[node_create("a", "stream-a")])[0];
+        let hash_b =
+            author_committed(&conn, stream_b, &[node_create("substituted", "stream-b")])[0];
+        let signed_b: Vec<u8> = conn
+            .query_row(
+                "SELECT signed_bytes FROM content_entries WHERE entry_hash = ?1",
+                [hash_b.as_slice()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        conn.execute(
+            "UPDATE content_entries SET signed_bytes = ?1 WHERE entry_hash = ?2",
+            params![signed_b, hash_a.as_slice()],
+        )
+        .unwrap();
+        conn.execute("DELETE FROM content_projected_nodes WHERE stream_id = ?1", [stream_a
+            .to_bytes()
+            .as_slice()])
+            .unwrap();
+
+        let tx = conn.unchecked_transaction().unwrap();
+        let err = content_projection::reproject_accepted_content_stream(&tx, stream_a)
+            .expect_err("a valid envelope from another row must not project");
+        drop(tx);
+        assert!(err.to_string().contains("entry_hash row"), "unexpected error: {err:#}");
+        assert_eq!(
+            projected_node_count(&conn, stream_a),
+            0,
+            "the substituted stream-b op was not projected under stream A",
+        );
+    }
+
+    #[test]
     fn a_sealed_entry_folds_accepted_through_content_ingest_on_a_keyless_peer() {
         // S3 FOLD-FIREWALL TRIPWIRE: acceptance of a sealed `/3` entry is header/citation-level, so
         // a peer that replicated the account roster but never received the content key still folds
@@ -2015,6 +2056,59 @@ mod tests {
             )
             .unwrap();
         assert_eq!(before, after, "the refused plaintext batch stored no row");
+    }
+
+    #[test]
+    fn corrupt_accepted_sealed_envelope_aborts_plaintext_authoring_without_a_wrap() {
+        let conn = db();
+        let stream = StreamId::from_bytes(STREAM_A);
+        let account = owned_stream_account(&conn, stream);
+        let device = local_device(&conn, NOW).unwrap();
+        let key = ContentKey::from_seed(&[0x40; 32]);
+        let signed = envelope::seal_and_sign_content_entry(
+            device.secret(),
+            &ContentEntryHeader {
+                stream_id: stream,
+                author_account_id: account,
+                device_fingerprint: device.fingerprint(),
+                seq: 0,
+                lamport: 0,
+                prev_hash: None,
+                grant_id: None,
+                roster_ref: genesis_ref(&conn),
+                owner_auth_len: 0,
+                author_auth_len: 0,
+                crypto_suite: 0,
+                key_id: None,
+            },
+            &op::encode(&node_create("sealed", "must-stay-private")),
+            &key,
+        )
+        .unwrap();
+        insert_accepted_signed(&conn, &signed);
+        conn.execute("UPDATE content_entries SET signed_bytes = X'00' WHERE entry_hash = ?1", [
+            signed.entry_hash.as_slice(),
+        ])
+        .unwrap();
+        assert!(
+            secrets::select_current_sealing_wrap(&conn, account, stream).unwrap().is_none(),
+            "the corrupt accepted suite-1 row is the only ratchet input",
+        );
+        let before: i64 =
+            conn.query_row("SELECT count(*) FROM content_entries", [], |row| row.get(0)).unwrap();
+
+        let err = author_content_batch(
+            &conn,
+            stream,
+            &[node_create("plaintext", "must-not-leak")],
+            SealPolicy::Plaintext,
+            NOW,
+        )
+        .expect_err("stored envelope corruption must abort plaintext authoring");
+        assert!(err.to_string().contains("sealed ratchet"), "unexpected error: {err:#}");
+        let after: i64 =
+            conn.query_row("SELECT count(*) FROM content_entries", [], |row| row.get(0)).unwrap();
+        assert_eq!(before, after, "the failed plaintext batch leaked no content row");
     }
 
     #[test]

--- a/crates/rag-rat-oplog/src/account/content/author.rs
+++ b/crates/rag-rat-oplog/src/account/content/author.rs
@@ -238,12 +238,102 @@ pub enum SealPolicy {
     Sealed,
 }
 
+/// Policy-aware `/3` authoring state prepared before a caller opens its write transaction.
+///
+/// The fields are deliberately opaque: sealed preparation owns the recovered content key and the
+/// local signing capability, but callers can only hand both back to
+/// [`author_prepared_content_batch_in_tx`]. [`ContentKey`] zeroizes its bytes on drop.
+pub struct PreparedContentAuthoring {
+    stream_id: StreamId,
+    account_id: AccountId,
+    kind: PreparedContentAuthoringKind,
+}
+
+enum PreparedContentAuthoringKind {
+    Plaintext,
+    Sealed(Box<PreparedSealedContentAuthoring>),
+}
+
+struct PreparedSealedContentAuthoring {
+    key: ContentKey,
+    device: LocalDevice,
+    resolved: secrets::SelectedWrap,
+    rotation: secrets::RotationOutcome,
+}
+
+/// Prepare policy-aware `/3` authoring before the caller opens its write transaction.
+///
+/// Plaintext preparation is read-only; the downgrade ratchet is checked later under the caller's
+/// write lock. Sealed preparation performs the existing pre-transaction key protocol: lazy
+/// rotation in its own transaction, key resolution outside a transaction so security events
+/// autocommit, and first-key minting when necessary. The returned value is bound to `stream_id` and
+/// the current local account and exposes no key material.
+pub fn prepare_content_authoring(
+    conn: &Connection,
+    stream_id: StreamId,
+    policy: SealPolicy,
+    now_ms: i64,
+) -> anyhow::Result<PreparedContentAuthoring> {
+    let account_id = require_local_account_id(conn)?;
+    let kind = match policy {
+        SealPolicy::Plaintext => PreparedContentAuthoringKind::Plaintext,
+        SealPolicy::Sealed =>
+            prepare_sealed_content_authoring(conn, stream_id, account_id, now_ms)?,
+    };
+    Ok(PreparedContentAuthoring { stream_id, account_id, kind })
+}
+
+/// Author a prepared policy-aware batch inside the caller's transaction. Neither opens nor commits
+/// the transaction. All ratchet and sealing-selection checks run under this write lock before any
+/// content row is inserted; authoring then refolds once, reprojects, and verifies every entry was
+/// accepted.
+pub fn author_prepared_content_batch_in_tx(
+    tx: &Transaction<'_>,
+    stream_id: StreamId,
+    ops: &[MemoryOp],
+    prepared: &PreparedContentAuthoring,
+    now_ms: i64,
+) -> anyhow::Result<Vec<EntryHash>> {
+    if ops.is_empty() {
+        return Ok(Vec::new());
+    }
+    anyhow::ensure!(
+        prepared.stream_id == stream_id,
+        "prepared /3 authoring belongs to a different stream"
+    );
+    anyhow::ensure!(
+        require_local_account_id(tx)? == prepared.account_id,
+        "prepared /3 authoring belongs to a different local account"
+    );
+
+    match &prepared.kind {
+        PreparedContentAuthoringKind::Plaintext => {
+            if stream_has_sealed_ratchet(tx, prepared.account_id, stream_id)? {
+                anyhow::bail!(
+                    "refusing plaintext /3 authoring on a stream that has ratcheted to sealed (an \
+                     accepted key wrap or a sealed entry exists)"
+                );
+            }
+            author_content_batch_in_tx(tx, stream_id, ops, now_ms)
+        },
+        PreparedContentAuthoringKind::Sealed(sealed) => {
+            revalidate_sealing_selection(
+                tx,
+                prepared.account_id,
+                stream_id,
+                &sealed.resolved,
+                &sealed.rotation,
+            )?;
+            seal_and_author_in_tx(tx, stream_id, ops, &sealed.key, &sealed.device, now_ms)
+        },
+    }
+}
+
 /// Author `ops` as owner-authored `/3` content on `stream_id` under an explicit [`SealPolicy`],
-/// managing its OWN transactions — unlike [`author_content_batch_in_tx`], which runs inside a
-/// caller's txn. `Sealed` acquires the stream's content key across THREE transactions (lazy
-/// rotation; then a key resolve whose security-event writes autocommit; then seal + author +
-/// verify-accepted), so it cannot nest inside a caller txn. Returns the authored entry hashes in
-/// authoring order. Requires the store's local account to be minted already.
+/// as a convenience composition of [`prepare_content_authoring`] and
+/// [`author_prepared_content_batch_in_tx`] with an owned IMMEDIATE transaction. Returns the
+/// authored entry hashes in authoring order. Requires the store's local account to be minted
+/// already.
 ///
 /// UNWIRED (C5a): nothing live calls this — see [`SealPolicy`].
 pub fn author_content_batch(
@@ -261,50 +351,24 @@ pub fn author_content_batch(
     if ops.is_empty() {
         return Ok(Vec::new());
     }
-    match policy {
-        SealPolicy::Plaintext => author_plaintext_batch_ratcheted(conn, stream_id, ops, now_ms),
-        SealPolicy::Sealed => author_sealed_batch(conn, stream_id, ops, now_ms),
-    }
-}
-
-/// The `SealPolicy::Plaintext` arm: refuse if the stream has ratcheted to sealed, then author
-/// suite-0 through the existing in-tx seam — all in ONE self-owned txn so the ratchet gate and the
-/// authoring commit atomically (a concurrent wrap/seal cannot slip between them).
-fn author_plaintext_batch_ratcheted(
-    conn: &Connection,
-    stream_id: StreamId,
-    ops: &[MemoryOp],
-    now_ms: i64,
-) -> anyhow::Result<Vec<EntryHash>> {
+    let prepared = prepare_content_authoring(conn, stream_id, policy, now_ms)?;
     let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
-    // Downgrade ratchet: once a stream carries an accepted StreamKeyWrap (any epoch) OR an accepted
-    // suite-1 entry, plaintext authoring is a silent downgrade — refuse it.
-    let account_id = require_local_account_id(&tx)?;
-    if stream_has_sealed_ratchet(&tx, account_id, stream_id)? {
-        anyhow::bail!(
-            "refusing plaintext /3 authoring on a stream that has ratcheted to sealed (an \
-             accepted key wrap or a sealed entry exists)"
-        );
-    }
-    let authored = author_content_batch_in_tx(&tx, stream_id, ops, now_ms)?;
+    let authored = author_prepared_content_batch_in_tx(&tx, stream_id, ops, &prepared, now_ms)?;
     tx.commit()?;
     Ok(authored)
 }
 
-/// The `SealPolicy::Sealed` arm: the S4 three-txn key acquisition, then seal + author. Fail-closed
-/// — if no content key resolves, the whole batch bails, NEVER plaintext-fallback and NEVER a
-/// plaintext park (the row simply never enters the tables; the reconcile anti-join is the retry
-/// once this device gains a key).
-fn author_sealed_batch(
+/// Prepare the sealed arm's pre-transaction key protocol. Fail closed if no content key resolves;
+/// plaintext fallback is never represented by the returned type.
+fn prepare_sealed_content_authoring(
     conn: &Connection,
     stream_id: StreamId,
-    ops: &[MemoryOp],
+    account_id: AccountId,
     now_ms: i64,
-) -> anyhow::Result<Vec<EntryHash>> {
+) -> anyhow::Result<PreparedContentAuthoringKind> {
     // Authoring needs a local device, so minting it here is fine; `current_sealing_key` must NOT
     // mint (a read API), so we resolve it once and hand it in.
     let device = local_device(conn, now_ms)?;
-    let account_id = require_local_account_id(conn)?;
 
     // (txn A) Lazy rotation on device removal, committed on its OWN txn so a rotation (a fresh
     // higher-epoch wrap) survives a later authoring failure. Every RotationOutcome is non-error —
@@ -348,20 +412,19 @@ fn author_sealed_batch(
         "sealed /3 authoring: the sealing selection changed during key resolution (retry)",
     );
 
-    // (txn B) Seal + author + verify-accepted, re-validating the selection under the write lock so
-    // a rotation that committed after resolution can never make us seal under the stale key.
-    let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
-    revalidate_sealing_selection(&tx, account_id, stream_id, &resolved, &rotation)?;
-    let authored = seal_and_author_in_tx(&tx, stream_id, ops, &key, &device, now_ms)?;
-    tx.commit()?;
-    Ok(authored)
+    Ok(PreparedContentAuthoringKind::Sealed(Box::new(PreparedSealedContentAuthoring {
+        key,
+        device,
+        resolved,
+        rotation,
+    })))
 }
 
 /// Re-confirm, under txn B's IMMEDIATE write lock, that `stream_id` is STILL safe to seal under the
 /// key the pre-txn resolution named — i.e. the selection is unchanged AND no rotation is now due.
 ///
 /// Two roster changes can commit in the autocommit window between resolving the key
-/// ([`author_sealed_batch`]) and opening this txn, and BOTH must abort the seal:
+/// ([`prepare_content_authoring`]) and opening this txn, and BOTH must abort the seal:
 ///
 /// - A `DeviceRemove` + rotation commits a fresh higher-epoch `StreamKeyWrap`, so the resolved
 ///   `(epoch, key_id)` no longer names the current selection — caught by the selection-unchanged
@@ -1506,6 +1569,66 @@ mod tests {
     }
 
     #[test]
+    fn prepared_sealed_authoring_runs_inside_and_commits_with_the_caller_transaction() {
+        let conn = db();
+        let (_account, stream) = owned_v2(&conn);
+        let prepared =
+            prepare_content_authoring(&conn, stream, SealPolicy::Sealed, NOW).expect("prepare");
+        let tx = Transaction::new_unchecked(&conn, TransactionBehavior::Immediate).unwrap();
+        let hashes = author_prepared_content_batch_in_tx(
+            &tx,
+            stream,
+            &[node_create("prepared", "secret")],
+            &prepared,
+            NOW,
+        )
+        .expect("author in caller transaction");
+        assert_eq!(
+            projected_node_count(&tx, stream),
+            1,
+            "projection is visible in the transaction"
+        );
+        assert_eq!(stored_status(&tx, &hashes[0]).as_deref(), Some("accepted"));
+        tx.commit().unwrap();
+
+        assert_eq!(
+            projected_node_count(&conn, stream),
+            1,
+            "content and projection commit together"
+        );
+        assert_eq!(header_of(&conn, &hashes[0]).crypto_suite, 1);
+    }
+
+    #[test]
+    fn rolling_back_prepared_sealed_authoring_leaves_no_content_or_projection() {
+        let conn = db();
+        let (_account, stream) = owned_v2(&conn);
+        let prepared =
+            prepare_content_authoring(&conn, stream, SealPolicy::Sealed, NOW).expect("prepare");
+        let tx = Transaction::new_unchecked(&conn, TransactionBehavior::Immediate).unwrap();
+        author_prepared_content_batch_in_tx(
+            &tx,
+            stream,
+            &[node_create("rolled-back", "secret")],
+            &prepared,
+            NOW,
+        )
+        .expect("author in caller transaction");
+        assert_eq!(projected_node_count(&tx, stream), 1, "projection is transactional");
+        tx.rollback().unwrap();
+
+        let content_rows: i64 = conn
+            .query_row(
+                "SELECT count(*) FROM content_entries WHERE stream_id = ?1",
+                [stream.to_bytes().as_slice()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(content_rows, 0, "rollback removes the authored content");
+        assert_eq!(projected_node_count(&conn, stream), 0, "rollback removes its projection");
+    }
+
+    #[test]
     fn mixed_plaintext_and_sealed_entries_project_together() {
         let conn = db();
         let (_account, stream) = owned_v2(&conn);
@@ -1888,6 +2011,35 @@ mod tests {
     }
 
     #[test]
+    fn prepared_plaintext_rechecks_the_downgrade_ratchet_in_the_caller_transaction() {
+        let conn = db();
+        let (_account, stream) = owned_v2(&conn);
+        let prepared = prepare_content_authoring(&conn, stream, SealPolicy::Plaintext, NOW)
+            .expect("prepare plaintext while the stream is fresh");
+        author_content_batch(
+            &conn,
+            stream,
+            &[node_create("sealed", "first")],
+            SealPolicy::Sealed,
+            NOW,
+        )
+        .expect("ratchet the stream after preparation");
+
+        let tx = Transaction::new_unchecked(&conn, TransactionBehavior::Immediate).unwrap();
+        let err = author_prepared_content_batch_in_tx(
+            &tx,
+            stream,
+            &[node_create("plaintext", "must-not-leak")],
+            &prepared,
+            NOW,
+        )
+        .unwrap_err();
+        drop(tx);
+        assert!(err.to_string().contains("ratcheted to sealed"));
+        assert_eq!(projected_node_count(&conn, stream), 1, "the plaintext op was not projected");
+    }
+
+    #[test]
     fn the_downgrade_ratchet_fires_on_an_accepted_wrap_or_an_accepted_sealed_entry() {
         let conn = db();
         let (account, stream) = owned_v2(&conn);
@@ -2099,6 +2251,76 @@ mod tests {
     }
 
     #[test]
+    fn prepared_sealed_authoring_rejects_a_rotation_before_the_caller_transaction() {
+        let conn = db();
+        let (_account, stream) = owned_v2(&conn);
+        author_content_batch(
+            &conn,
+            stream,
+            &[node_create("old", "epoch-zero")],
+            SealPolicy::Sealed,
+            NOW,
+        )
+        .unwrap();
+        let prepared =
+            prepare_content_authoring(&conn, stream, SealPolicy::Sealed, NOW).expect("prepare");
+        let tx = Transaction::new_unchecked(&conn, TransactionBehavior::Immediate).unwrap();
+        secrets::rotate_stream_key_in_tx(&tx, stream, NOW + 1).unwrap();
+        tx.commit().unwrap();
+
+        let tx = Transaction::new_unchecked(&conn, TransactionBehavior::Immediate).unwrap();
+        let err = author_prepared_content_batch_in_tx(
+            &tx,
+            stream,
+            &[node_create("stale", "must-not-leak")],
+            &prepared,
+            NOW + 2,
+        )
+        .unwrap_err();
+        drop(tx);
+        assert!(err.to_string().contains("rotated between resolution and sealing"));
+        assert_eq!(projected_node_count(&conn, stream), 1, "no stale-key content was projected");
+    }
+
+    #[test]
+    fn prepared_sealed_authoring_rejects_a_recipient_removal_before_the_caller_transaction() {
+        let conn = db();
+        let (account, stream) = owned_v2(&conn);
+        let member_x = crate::device::DeviceX25519Secret::from_seed(&[0x5d; 32]);
+        let member = add_member_device(&conn, account, &member_x);
+        author_content_batch(
+            &conn,
+            stream,
+            &[node_create("old", "before-removal")],
+            SealPolicy::Sealed,
+            NOW,
+        )
+        .unwrap();
+        let prepared =
+            prepare_content_authoring(&conn, stream, SealPolicy::Sealed, NOW).expect("prepare");
+
+        author_control_op(&conn, account, &crate::account::ops::AccountOp::DeviceRemove {
+            device_fingerprint: member,
+            control_cut: crate::account::cut::Cut::Empty,
+            secrets_cut: crate::account::cut::Cut::Empty,
+            content_cuts: Vec::new(),
+            reason: "revoked after preparation".to_string(),
+        });
+        let tx = Transaction::new_unchecked(&conn, TransactionBehavior::Immediate).unwrap();
+        let err = author_prepared_content_batch_in_tx(
+            &tx,
+            stream,
+            &[node_create("stale", "removed-recipient-must-not-decrypt")],
+            &prepared,
+            NOW + 1,
+        )
+        .unwrap_err();
+        drop(tx);
+        assert!(err.to_string().contains("rotation became needed under the authoring lock"));
+        assert_eq!(projected_node_count(&conn, stream), 1, "no post-removal content leaked");
+    }
+
+    #[test]
     fn a_device_removal_in_the_resolution_window_makes_txn_b_bail_not_seal_stale() {
         // P1: a BARE `DeviceRemove` of a wrap RECIPIENT — committed in the autocommit window
         // between txn A (rotation check) and txn B (seal), with NO rotation, so NO
@@ -2284,14 +2506,18 @@ mod tests {
         // StaleButNotOwner, and txn B's rotation-need re-check exempts that classified state.
         // (Before the exemption, this call bailed on "rotation became needed under the authoring
         // lock" on every retry — sealed authoring was permanently unavailable to the member.)
-        let hashes = author_content_batch(
-            &conn,
+        let prepared = prepare_content_authoring(&conn, stream, SealPolicy::Sealed, NOW)
+            .expect("a member prepares under the current key (StaleButNotOwner)");
+        let tx = Transaction::new_unchecked(&conn, TransactionBehavior::Immediate).unwrap();
+        let hashes = author_prepared_content_batch_in_tx(
+            &tx,
             stream,
             &[node_create("n2", "member-sealed")],
-            SealPolicy::Sealed,
+            &prepared,
             NOW,
         )
         .expect("a member seals under the current key (StaleButNotOwner must not fail txn B)");
+        tx.commit().unwrap();
         assert_eq!(hashes.len(), 1, "one op authors one sealed entry");
         let header = header_of(&conn, &hashes[0]);
         assert_eq!(header.crypto_suite, 1, "sealed as suite 1");

--- a/crates/rag-rat-oplog/src/account/content/envelope.rs
+++ b/crates/rag-rat-oplog/src/account/content/envelope.rs
@@ -4,11 +4,12 @@
 //! the future C5 AEAD AAD. The payload stays opaque here so plaintext and sealed entries have the
 //! same chain and signature semantics.
 
-use chacha20poly1305::aead::{Aead, Payload};
+use chacha20poly1305::aead::{Aead, AeadInOut, Payload};
 use chacha20poly1305::{KeyInit, XChaCha20Poly1305, XNonce};
 use minicbor::Encoder;
 use minicbor::data::Type;
 use minicbor::decode::{Decoder, Error as CborError};
+use zeroize::Zeroizing;
 
 use super::super::AccountId;
 use super::super::keywrap::ContentKey;
@@ -151,7 +152,7 @@ pub fn sign_sealed_content_entry(
 
     // The op body is the plaintext that becomes the ciphertext; require it canonical up front. The
     // suite-1 wire payload is opaque, so `decode_body`'s suite-0 payload-canonicity check cannot
-    // cover it — but the decrypt side (C5b) recovers exactly these bytes for `op::decode`, so a
+    // cover it — but decrypt-at-projection recovers exactly these bytes for `op::decode`, so a
     // non-canonical op body would round-trip into an un-decodable projection input.
     cbor::require_canonical_cbor(op_bytes)
         .map_err(|error| anyhow::anyhow!("sealed op payload is not canonical CBOR: {error}"))?;
@@ -207,6 +208,35 @@ pub fn seal_and_sign_content_entry(
     key: &ContentKey,
 ) -> anyhow::Result<SignedContentEntry> {
     sign_sealed_content_entry(secret, header, op_bytes, key, sample_wire_nonce()?)
+}
+
+/// Test-only constructor for structurally valid signed envelopes carrying arbitrary opaque suite
+/// payloads. Production authoring must use the suite-specific constructors above.
+#[cfg(test)]
+pub(super) fn sign_opaque_content_entry_for_test(
+    secret: &DeviceSecret,
+    header: &ContentEntryHeader,
+    payload: &[u8],
+) -> anyhow::Result<SignedContentEntry> {
+    let mut header = header.clone();
+    header.device_fingerprint = secret.public().fingerprint();
+    if let Some(message) = header_nullity_error(&header) {
+        anyhow::bail!(message);
+    }
+    let header_bytes = encode_header(&header);
+    let body_bytes = encode_body(&header_bytes, payload);
+    let signature = secret.sign(&body_bytes);
+    let signed_bytes = encode_signed(&body_bytes, &signature);
+    let entry_hash = cbor::sha256(&body_bytes);
+    Ok(SignedContentEntry {
+        header,
+        payload: payload.to_vec(),
+        signature,
+        header_bytes,
+        body_bytes,
+        signed_bytes,
+        entry_hash,
+    })
 }
 
 /// Sample a fresh 192-bit XChaCha wire nonce straight from the OS CSPRNG, returned BY VALUE. A
@@ -307,6 +337,29 @@ fn seal_op_bytes(
         .map_err(|_| anyhow::anyhow!("content AEAD sealing failed"))
 }
 
+/// Open a suite-1 `nonce[24] || ciphertext` payload under `key`, authenticating the exact retained
+/// signed header bytes as AAD. The plaintext buffer is scrubbed on drop.
+pub fn open_sealed_payload(
+    key: &ContentKey,
+    payload: &[u8],
+    aad: &[u8],
+) -> anyhow::Result<Zeroizing<Vec<u8>>> {
+    if payload.len() < SEALED_NONCE_LEN + SEALED_AEAD_TAG_LEN {
+        anyhow::bail!("sealed content payload is shorter than nonce + tag");
+    }
+    let (nonce, ciphertext) = payload.split_at(SEALED_NONCE_LEN);
+    let nonce: [u8; SEALED_NONCE_LEN] = nonce
+        .try_into()
+        .map_err(|_| anyhow::anyhow!("sealed content nonce has the wrong length"))?;
+    let cipher = XChaCha20Poly1305::new_from_slice(key.as_slice())
+        .map_err(|_| anyhow::anyhow!("content key has the wrong length"))?;
+    let mut plaintext = Zeroizing::new(ciphertext.to_vec());
+    cipher
+        .decrypt_in_place(&XNonce::from(nonce), aad, &mut *plaintext)
+        .map_err(|_| anyhow::anyhow!("sealed payload AEAD open failed"))?;
+    Ok(plaintext)
+}
+
 fn encode_opt_hash(encoder: &mut Encoder<&mut Vec<u8>>, hash: Option<[u8; 32]>) {
     match hash {
         Some(hash) => encoder.bytes(&hash).expect(INFALLIBLE),
@@ -400,9 +453,6 @@ fn decode_opt_hash(decoder: &mut Decoder<'_>, field: &str) -> Result<Option<[u8;
 
 #[cfg(test)]
 mod tests {
-    use chacha20poly1305::aead::{Aead, Payload};
-    use chacha20poly1305::{KeyInit, XChaCha20Poly1305, XNonce};
-
     use super::*;
 
     fn secret() -> DeviceSecret {
@@ -659,24 +709,6 @@ mod tests {
         ContentKey::from_seed(&[0x20; 32])
     }
 
-    /// Open a `nonce[24] || ciphertext` sealed payload under `key` with AAD `aad` — the read-side
-    /// inverse of the seal, kept in the test so C5a exposes only the seal side (the projection
-    /// decrypt is C5b). A genuine encrypt-then-decrypt round trip: the AEAD is a vetted library, so
-    /// recovering the original op bytes exercises the seal's key + nonce + AAD binding, not the
-    /// cipher.
-    fn open_sealed_payload(
-        key: &ContentKey,
-        payload: &[u8],
-        aad: &[u8],
-    ) -> anyhow::Result<Vec<u8>> {
-        let (nonce, ciphertext) = payload.split_at(SEALED_NONCE_LEN);
-        let nonce: [u8; SEALED_NONCE_LEN] = nonce.try_into().unwrap();
-        let cipher = XChaCha20Poly1305::new_from_slice(key.as_slice()).unwrap();
-        cipher
-            .decrypt(&XNonce::from(nonce), Payload { msg: ciphertext, aad })
-            .map_err(|_| anyhow::anyhow!("sealed payload AEAD open failed"))
-    }
-
     #[test]
     fn sealed_content_wire_is_golden_pinned_under_an_injected_nonce() {
         // Deterministic: a seed-fixed content key + an injected nonce freeze the suite-1 payload
@@ -720,7 +752,11 @@ mod tests {
         let signed = seal_and_sign_content_entry(&secret(), &header(), &op, &key).unwrap();
         // AAD = the FINAL signed header content bytes (`header_bytes`), never a re-encode.
         let recovered = open_sealed_payload(&key, &signed.payload, &signed.header_bytes).unwrap();
-        assert_eq!(recovered, op, "decrypt under the same key + header AAD recovers the op bytes");
+        assert_eq!(
+            recovered.as_slice(),
+            op,
+            "decrypt under the same key + header AAD recovers the op bytes"
+        );
     }
 
     #[test]
@@ -741,6 +777,17 @@ mod tests {
         let tampered_aad = encode_header(&tampered);
         assert_ne!(tampered_aad, signed.header_bytes);
         assert!(open_sealed_payload(&key, &signed.payload, &tampered_aad).is_err());
+    }
+
+    #[test]
+    fn sealed_open_rejects_a_short_or_tampered_payload() {
+        let key = content_key();
+        assert!(open_sealed_payload(&key, &[0; SEALED_NONCE_LEN], b"aad").is_err());
+        let signed =
+            seal_and_sign_content_entry(&secret(), &header(), &[0x81, 0x01], &key).unwrap();
+        let mut tampered = signed.payload.clone();
+        *tampered.last_mut().unwrap() ^= 1;
+        assert!(open_sealed_payload(&key, &tampered, &signed.header_bytes).is_err());
     }
 
     #[test]
@@ -766,15 +813,19 @@ mod tests {
             "a fresh nonce yields different ciphertext for the same op"
         );
         // Freshness must not cost recoverability: both open to the original op.
-        assert_eq!(open_sealed_payload(&key, &a.payload, &a.header_bytes).unwrap(), [0x81, 0x01]);
-        assert_eq!(open_sealed_payload(&key, &b.payload, &b.header_bytes).unwrap(), [0x81, 0x01]);
+        assert_eq!(open_sealed_payload(&key, &a.payload, &a.header_bytes).unwrap().as_slice(), [
+            0x81, 0x01
+        ],);
+        assert_eq!(open_sealed_payload(&key, &b.payload, &b.header_bytes).unwrap().as_slice(), [
+            0x81, 0x01
+        ],);
     }
 
     #[test]
     fn a_sealed_entry_decodes_and_verifies_with_an_opaque_suite_one_payload() {
         // The already-sealed-ready ingest/decode path treats a suite-1 payload as opaque: it
         // decodes + verifies (signature + fingerprint) without touching the ciphertext, and the AAD
-        // unit (`header_bytes`) round-trips for the eventual C5b decrypt.
+        // unit (`header_bytes`) round-trips for projection decrypt.
         let key = content_key();
         // The nonce value is not load-bearing here, so use the random-nonce production entry point.
         let signed =

--- a/crates/rag-rat-oplog/src/account/content/mod.rs
+++ b/crates/rag-rat-oplog/src/account/content/mod.rs
@@ -15,15 +15,19 @@ pub use acceptance::{
     ContentParkReason, ContentRejectReason, SubjectAuthorityHold, UnknownAncestry,
     evaluate_content_acceptance,
 };
-// The C5a sealed-authoring seam (#608): the policy-aware self-transacting author, its
-// sealed-op size predicate, and the seal policy. UNWIRED — tests consume it, but no live
-// privacy-intent source does.
+// The C5 sealed-authoring seam (#608): policy-aware preparation plus caller-owned-txn and
+// convenience authoring, the sealed-op size predicate, and the seal policy. UNWIRED — tests
+// consume it, but no live privacy-intent source does.
 #[allow(
     unused_imports,
     reason = "sealed authoring remains unwired until a live privacy-intent source consumes it \
               (#608)"
 )]
-pub use author::{SealPolicy, author_content_batch, content_op_is_sealed_authorable};
+pub use author::{
+    PreparedContentAuthoring, SealPolicy, author_content_batch,
+    author_prepared_content_batch_in_tx, content_op_is_sealed_authorable,
+    prepare_content_authoring,
+};
 // The in-tx `/3` local-authoring seam + its genesis-detection reader (C3.4b-i, #663): live
 // callers in `query::memory` land with #664, so these are plain (un-frozen) re-exports.
 pub use author::{author_content_batch_in_tx, content_op_is_authorable, content_stream_is_empty};

--- a/crates/rag-rat-oplog/src/account/content/mod.rs
+++ b/crates/rag-rat-oplog/src/account/content/mod.rs
@@ -16,25 +16,28 @@ pub use acceptance::{
     evaluate_content_acceptance,
 };
 // The C5a sealed-authoring seam (#608): the policy-aware self-transacting author, its
-// sealed-op size predicate, and the seal policy. UNWIRED — C5b + tests are the only consumers.
+// sealed-op size predicate, and the seal policy. UNWIRED — tests consume it, but no live
+// privacy-intent source does.
 #[allow(
     unused_imports,
-    reason = "C5a sealed authoring is unwired until C5b consumes it (#608)"
+    reason = "sealed authoring remains unwired until a live privacy-intent source consumes it \
+              (#608)"
 )]
 pub use author::{SealPolicy, author_content_batch, content_op_is_sealed_authorable};
 // The in-tx `/3` local-authoring seam + its genesis-detection reader (C3.4b-i, #663): live
 // callers in `query::memory` land with #664, so these are plain (un-frozen) re-exports.
 pub use author::{author_content_batch_in_tx, content_op_is_authorable, content_stream_is_empty};
+pub(crate) use envelope::open_sealed_payload;
 pub use envelope::{
     ContentEntryHeader, SignedContentEntry, VerifiedContentEntry, decode_content_signed,
     sign_content_entry, verify_content_signed,
 };
 // The C5a envelope-layer seal + sign (#608): the injected-nonce core (goldens) and the
-// OS-nonce production wrapper. UNWIRED — the sealed author seam and C5b's tests are the only
-// consumers.
+// OS-nonce production wrapper. The sealed author seam and projection tests consume these; no
+// live privacy-intent source does.
 #[allow(
     unused_imports,
-    reason = "C5a sealed envelope is unwired until C5b consumes it (#608)"
+    reason = "sealed envelope authoring remains unwired from the live memory path (#608)"
 )]
 pub use envelope::{seal_and_sign_content_entry, sign_sealed_content_entry};
 // The V070 `content_projected_*` table-existence guard: shared crate-wide with the `/3`

--- a/crates/rag-rat-oplog/src/account/content/mod.rs
+++ b/crates/rag-rat-oplog/src/account/content/mod.rs
@@ -16,17 +16,12 @@ pub use acceptance::{
     evaluate_content_acceptance,
 };
 // The C5 sealed-authoring seam (#608): policy-aware preparation plus caller-owned-txn and
-// convenience authoring, the sealed-op size predicate, and the seal policy. UNWIRED — tests
-// consume it, but no live privacy-intent source does.
-#[allow(
-    unused_imports,
-    reason = "sealed authoring remains unwired until a live privacy-intent source consumes it \
-              (#608)"
-)]
+// convenience authoring, the sealed-op size predicate, downgrade-ratchet reader, and seal
+// policy.
 pub use author::{
     PreparedContentAuthoring, SealPolicy, author_content_batch,
     author_prepared_content_batch_in_tx, content_op_is_sealed_authorable,
-    prepare_content_authoring,
+    content_stream_has_sealed_ratchet, prepare_content_authoring,
 };
 // The in-tx `/3` local-authoring seam + its genesis-detection reader (C3.4b-i, #663): live
 // callers in `query::memory` land with #664, so these are plain (un-frozen) re-exports.

--- a/crates/rag-rat-oplog/src/account/mod.rs
+++ b/crates/rag-rat-oplog/src/account/mod.rs
@@ -52,17 +52,18 @@ pub use content::{
 };
 // The C5a sealed-authoring surface (#608): the envelope-layer seal
 // (`sign_sealed_content_entry` + its OS-nonce wrapper `seal_and_sign_content_entry`), the
-// policy-aware self-transacting author (`author_content_batch` + `SealPolicy`), and the
-// sealed-op size predicate. UNWIRED — tests consume it, but no live privacy-intent source
-// does, so the group keeps the unused-import allowance.
+// policy-aware prepared authoring surface, and the sealed-op size predicate. UNWIRED — tests
+// consume it, but no live privacy-intent source does, so the group keeps the unused-import
+// allowance.
 #[allow(
     unused_imports,
     reason = "sealed authoring remains unwired until a live privacy-intent source consumes it \
               (#608)"
 )]
 pub use content::{
-    SealPolicy, author_content_batch, content_op_is_sealed_authorable, seal_and_sign_content_entry,
-    sign_sealed_content_entry,
+    PreparedContentAuthoring, SealPolicy, author_content_batch,
+    author_prepared_content_batch_in_tx, content_op_is_sealed_authorable,
+    prepare_content_authoring, seal_and_sign_content_entry, sign_sealed_content_entry,
 };
 // The in-tx `/3` content-author seam + its genesis-detection reader (C3.4b-i, #663): #664
 // retargets the live memory path onto them, so they are plain re-exports.

--- a/crates/rag-rat-oplog/src/account/mod.rs
+++ b/crates/rag-rat-oplog/src/account/mod.rs
@@ -52,18 +52,12 @@ pub use content::{
 };
 // The C5a sealed-authoring surface (#608): the envelope-layer seal
 // (`sign_sealed_content_entry` + its OS-nonce wrapper `seal_and_sign_content_entry`), the
-// policy-aware prepared authoring surface, and the sealed-op size predicate. UNWIRED — tests
-// consume it, but no live privacy-intent source does, so the group keeps the unused-import
-// allowance.
-#[allow(
-    unused_imports,
-    reason = "sealed authoring remains unwired until a live privacy-intent source consumes it \
-              (#608)"
-)]
+// policy-aware prepared authoring surface, sealed-op size predicate, and downgrade-ratchet
+// reader.
 pub use content::{
     PreparedContentAuthoring, SealPolicy, author_content_batch,
     author_prepared_content_batch_in_tx, content_op_is_sealed_authorable,
-    prepare_content_authoring, seal_and_sign_content_entry, sign_sealed_content_entry,
+    content_stream_has_sealed_ratchet, prepare_content_authoring,
 };
 // The in-tx `/3` content-author seam + its genesis-detection reader (C3.4b-i, #663): #664
 // retargets the live memory path onto them, so they are plain re-exports.
@@ -71,6 +65,8 @@ pub use content::{author_content_batch_in_tx, content_op_is_authorable, content_
 // The V070 projection-table guard, reused by the memory-layer content projection's upgrade
 // re-fold (#688).
 pub(crate) use content::{content_projected_tables_exist, open_sealed_payload};
+#[allow(unused_imports, reason = "envelope tests consume these crate-internal signing seams")]
+pub use content::{seal_and_sign_content_entry, sign_sealed_content_entry};
 pub use fold::{
     AuthorityBoundary, AuthorityFreshness, AuthorityInvalidReason, AuthorityQuery, GrantAuthority,
     GrantDeviceAuthority, GrantDeviceBoundary, OwnerAuthority, OwnerChainAuthority,

--- a/crates/rag-rat-oplog/src/account/mod.rs
+++ b/crates/rag-rat-oplog/src/account/mod.rs
@@ -44,9 +44,6 @@ pub use authoring::{
     ensure_owned_stream_v2_in_tx, established_owned_stream_v2, owned_stream_v2_id,
 };
 pub use bootstrap::local_account;
-// The V070 projection-table guard, reused by the memory-layer content projection's upgrade
-// re-fold (#688).
-pub(crate) use content::content_projected_tables_exist;
 #[allow(unused_imports, reason = "C2 contract is frozen before transport wiring lands")]
 pub use content::{
     ContentCapacityScope, ContentEntryHeader, ContentIngestOutcome, SignedContentEntry,
@@ -56,11 +53,12 @@ pub use content::{
 // The C5a sealed-authoring surface (#608): the envelope-layer seal
 // (`sign_sealed_content_entry` + its OS-nonce wrapper `seal_and_sign_content_entry`), the
 // policy-aware self-transacting author (`author_content_batch` + `SealPolicy`), and the
-// sealed-op size predicate. UNWIRED — C5b + tests are the only consumers, so the group keeps
-// the unused-import allowance.
+// sealed-op size predicate. UNWIRED — tests consume it, but no live privacy-intent source
+// does, so the group keeps the unused-import allowance.
 #[allow(
     unused_imports,
-    reason = "C5a sealed authoring is unwired until C5b consumes it (#608)"
+    reason = "sealed authoring remains unwired until a live privacy-intent source consumes it \
+              (#608)"
 )]
 pub use content::{
     SealPolicy, author_content_batch, content_op_is_sealed_authorable, seal_and_sign_content_entry,
@@ -69,6 +67,9 @@ pub use content::{
 // The in-tx `/3` content-author seam + its genesis-detection reader (C3.4b-i, #663): #664
 // retargets the live memory path onto them, so they are plain re-exports.
 pub use content::{author_content_batch_in_tx, content_op_is_authorable, content_stream_is_empty};
+// The V070 projection-table guard, reused by the memory-layer content projection's upgrade
+// re-fold (#688).
+pub(crate) use content::{content_projected_tables_exist, open_sealed_payload};
 pub use fold::{
     AuthorityBoundary, AuthorityFreshness, AuthorityInvalidReason, AuthorityQuery, GrantAuthority,
     GrantDeviceAuthority, GrantDeviceBoundary, OwnerAuthority, OwnerChainAuthority,
@@ -83,10 +84,12 @@ pub use ops::{DeviceCut, DeviceRole, GrantRole};
 // side (derive-on-read sealing-key selection + the key_id adoption cross-check), and the C4.4
 // lazy rotation-on-removal entry points (#607).
 pub use secrets::{
-    RotationOutcome, SealingKeyOutcome, SelectedWrap, current_sealing_key,
-    ensure_stream_key_current_in_tx, mint_and_author_stream_key_wrap_in_tx,
-    rotate_stream_key_in_tx, select_current_sealing_wrap, stream_key_rotation_needed,
+    ContentKeyring, RotationOutcome, SealingKeyOutcome, SelectedWrap, current_sealing_key,
+    ensure_stream_key_current_in_tx, historical_content_keyring,
+    mint_and_author_stream_key_wrap_in_tx, rotate_stream_key_in_tx, select_current_sealing_wrap,
+    stream_key_rotation_needed,
 };
+pub(crate) use storage::stream_owner_account;
 pub use storage::{
     CapacityScope, IngestOutcome, account_ingest, auth_len_freshness,
     backfill_authority_projection, grant_effective_for_device, owner_control_authority,

--- a/crates/rag-rat-oplog/src/account/secrets/mod.rs
+++ b/crates/rag-rat-oplog/src/account/secrets/mod.rs
@@ -33,7 +33,7 @@ pub(in crate::account) use ops::validate_storable_secrets_payload;
 // the CLI "what key is current" surface. Nothing calls them in C4.3b (machinery ships one
 // slice ahead of its consumer).
 pub use sealing::{
-    SealingKeyOutcome, SelectedWrap, current_sealing_key, select_current_sealing_wrap,
-    stream_key_rotation_needed,
+    ContentKeyring, SealingKeyOutcome, SelectedWrap, current_sealing_key,
+    historical_content_keyring, select_current_sealing_wrap, stream_key_rotation_needed,
 };
 pub(in crate::account) use storage::refold_secrets_log;

--- a/crates/rag-rat-oplog/src/account/secrets/mod.rs
+++ b/crates/rag-rat-oplog/src/account/secrets/mod.rs
@@ -28,6 +28,7 @@ pub use author::{
 // The ingest-time structural validation twin (mirrors the control-plaintext arm) and the
 // refold pass wired into `refold_in_tx`.
 pub(in crate::account) use ops::validate_storable_secrets_payload;
+pub(in crate::account) use sealing::accepted_stream_key_wrap_exists_strict;
 // The C4.3b READ side: derive-on-read sealing-key selection + the key_id adoption cross-check.
 // `current_sealing_key` is what C5's seal path calls; `select_current_sealing_wrap` is also
 // the CLI "what key is current" surface. Nothing calls them in C4.3b (machinery ships one

--- a/crates/rag-rat-oplog/src/account/secrets/sealing.rs
+++ b/crates/rag-rat-oplog/src/account/secrets/sealing.rs
@@ -13,6 +13,7 @@
 //! device-independent. A local mismatch / unwrap failure is therefore LOCAL evidence only, written
 //! to `sync_security_events` and nothing else.
 
+use anyhow::Context;
 use rusqlite::{Connection, params};
 
 use super::super::keywrap::{self, ContentKey, KeyId, WrapContext};
@@ -82,6 +83,12 @@ struct AcceptedStreamWrap {
     wrap: StreamKeyWrap,
 }
 
+#[derive(Clone, Copy)]
+enum AcceptedWrapDecodeMode {
+    Tolerant,
+    StrictEvidence,
+}
+
 /// The stream's current sealing selection, derived on read from the accepted wrap set — no cached
 /// table, no refold pass, convergent by construction. `None` when no accepted wrap exists. This is
 /// the CLI "what key is current" surface; the secret-recovering counterpart is
@@ -92,6 +99,24 @@ pub fn select_current_sealing_wrap(
     stream_id: StreamId,
 ) -> anyhow::Result<Option<SelectedWrap>> {
     Ok(select_from_wraps(&list_accepted_stream_key_wraps(conn, account_id, stream_id)?))
+}
+
+/// Whether an accepted `StreamKeyWrap` exists for `stream_id`. Unlike local key recovery, this is
+/// downgrade evidence: corruption of any accepted secrets row must fail closed rather than make a
+/// previously keyed stream appear eligible for plaintext. Presence does not require a local
+/// recipient wrap or a successful unwrap.
+pub(in crate::account) fn accepted_stream_key_wrap_exists_strict(
+    conn: &Connection,
+    account_id: AccountId,
+    stream_id: StreamId,
+) -> anyhow::Result<bool> {
+    Ok(!list_accepted_stream_key_wraps_with_mode(
+        conn,
+        account_id,
+        stream_id,
+        AcceptedWrapDecodeMode::StrictEvidence,
+    )?
+    .is_empty())
 }
 
 /// Whether `stream_id`'s content key must be ROTATED (sync phase C4.4, #607): TRUE iff some
@@ -302,12 +327,26 @@ fn select_from_wraps(wraps: &[AcceptedStreamWrap]) -> Option<SelectedWrap> {
 /// naming `stream_id`, decoding each from the stored, already-signature-verified bytes. `accepted =
 /// 1` IS the effective marker (the C4.2b evaluator set it); B-2 slot-eligibility guarantees an
 /// accepted log-1 row decodes as a Known `StreamKeyWrap`, so an undecodable/unknown accepted row is
-/// corruption — skipped (fail-safe: it just can't contribute a key) rather than aborting the read,
-/// mirroring `storage::load_secrets_headers`.
+/// corruption. Local key selection/recovery skips such rows (fail-safe: they cannot contribute a
+/// key), while downgrade evidence uses strict mode and fails closed.
 fn list_accepted_stream_key_wraps(
     conn: &Connection,
     account_id: AccountId,
     stream_id: StreamId,
+) -> anyhow::Result<Vec<AcceptedStreamWrap>> {
+    list_accepted_stream_key_wraps_with_mode(
+        conn,
+        account_id,
+        stream_id,
+        AcceptedWrapDecodeMode::Tolerant,
+    )
+}
+
+fn list_accepted_stream_key_wraps_with_mode(
+    conn: &Connection,
+    account_id: AccountId,
+    stream_id: StreamId,
+    mode: AcceptedWrapDecodeMode,
 ) -> anyhow::Result<Vec<AcceptedStreamWrap>> {
     let mut stmt = conn.prepare(
         "SELECT entry_hash, signed_bytes FROM account_entries
@@ -322,20 +361,43 @@ fn list_accepted_stream_key_wraps(
         .collect::<rusqlite::Result<Vec<_>>>()?;
     let mut out = Vec::new();
     for (entry_hash, signed_bytes) in rows {
-        let Ok(entry_hash) = <[u8; 32]>::try_from(entry_hash.as_slice()) else {
-            continue;
+        let entry_hash = match <[u8; 32]>::try_from(entry_hash.as_slice()) {
+            Ok(entry_hash) => entry_hash,
+            Err(_) if matches!(mode, AcceptedWrapDecodeMode::Tolerant) => continue,
+            Err(_) => anyhow::bail!(
+                "stored accepted secrets entry_hash is not 32 bytes while checking sealed-ratchet \
+                 wrap evidence"
+            ),
         };
-        let Ok(signed) = envelope::decode_account_signed(&signed_bytes) else {
-            continue;
+        let signed = match envelope::decode_account_signed(&signed_bytes) {
+            Ok(signed) => signed,
+            Err(_) if matches!(mode, AcceptedWrapDecodeMode::Tolerant) => continue,
+            Err(err) =>
+                return Err(err).context(
+                    "stored accepted secrets envelope failed to decode while checking \
+                     sealed-ratchet wrap evidence",
+                ),
         };
         if signed.entry_hash != entry_hash {
-            continue;
+            if matches!(mode, AcceptedWrapDecodeMode::Tolerant) {
+                continue;
+            }
+            anyhow::bail!(
+                "stored accepted secrets envelope does not match its entry_hash row while \
+                 checking sealed-ratchet wrap evidence"
+            );
         }
         match ops::decode(signed.header.entry_type, &signed.payload) {
             Ok(DecodedSecretsOp::Known(wrap)) if wrap.stream_id == stream_id => {
                 out.push(AcceptedStreamWrap { entry_hash, wrap });
             },
-            _ => continue,
+            Ok(_) => {},
+            Err(_) if matches!(mode, AcceptedWrapDecodeMode::Tolerant) => continue,
+            Err(err) =>
+                return Err(err).context(
+                    "stored accepted secrets payload failed to decode while checking \
+                     sealed-ratchet wrap evidence",
+                ),
         }
     }
     Ok(out)
@@ -747,6 +809,26 @@ mod tests {
         );
         assert!(keyring.get(claimed_id).is_none(), "unwrap/key-id mismatch fails closed");
         assert_eq!(security_event_count(&conn), 0, "projection recovery does not mutate evidence");
+    }
+
+    #[test]
+    fn historical_keyring_tolerates_a_corrupt_accepted_wrap() {
+        let conn = db();
+        let (account, founder, genesis_hash, stream_id) = account_with_owned_stream(&conn);
+        let device = local_device(&conn, NOW).unwrap();
+        let key = ContentKey::from_seed(&[0x20; 32]);
+        let wrap =
+            honest_wrap(account, stream_id, device.fingerprint(), &device.x25519_public(), &key, 0);
+        let (bytes, entry_hash) = wrap_entry(account, &founder, 0, None, Some(genesis_hash), &wrap);
+        ingest(&conn, &bytes);
+        conn.execute("UPDATE account_entries SET signed_bytes = X'00' WHERE entry_hash = ?1", [
+            entry_hash.as_slice(),
+        ])
+        .unwrap();
+
+        let keyring = historical_content_keyring(&conn, account, stream_id, &device)
+            .expect("projection key recovery remains tolerant of an unusable local wrap");
+        assert!(keyring.get(key.key_id()).is_none(), "a corrupt wrap recovers no key");
     }
 
     // ── The adoption cross-check ──

--- a/crates/rag-rat-oplog/src/account/secrets/sealing.rs
+++ b/crates/rag-rat-oplog/src/account/secrets/sealing.rs
@@ -53,6 +53,29 @@ pub enum SealingKeyOutcome {
     FailedClosed,
 }
 
+/// Every historical content key this device can recover for one stream, indexed by the exact
+/// signed `key_id`. Keys remain process-local, are never persisted, and zeroize on drop through
+/// [`ContentKey`].
+pub struct ContentKeyring(Vec<(KeyId, ContentKey)>);
+
+impl ContentKeyring {
+    /// Resolve exactly `key_id`; never substitute another key from the same epoch.
+    pub fn get(&self, key_id: KeyId) -> Option<&ContentKey> {
+        self.0.iter().find(|(candidate, _)| *candidate == key_id).map(|(_, key)| key)
+    }
+}
+
+enum KeyRecovery {
+    Ready(ContentKey),
+    NotRecipient,
+    Failed(Vec<WrapRecoveryFailure>),
+}
+
+struct WrapRecoveryFailure {
+    entry_hash: [u8; 32],
+    observed_key_id: Option<KeyId>,
+}
+
 /// One EFFECTIVE accepted `StreamKeyWrap` op for a stream, decoded from its stored bytes.
 struct AcceptedStreamWrap {
     entry_hash: [u8; 32],
@@ -148,75 +171,111 @@ pub fn current_sealing_key(
         return Ok(SealingKeyOutcome::NoCurrentKey);
     };
 
-    // Every wrap naming THIS device at the selected (epoch, key_id) — across fan-out sibling ops.
-    // Keying on the selected key_id (not the epoch alone) is load-bearing: two accepted wraps can
-    // share an epoch with DIFFERENT key_ids (concurrent owner mints), and trying the other key_id's
-    // wrap would either diverge or raise a spurious mismatch on an honest state.
-    let my_fingerprint = device.fingerprint();
-    let my_wraps: Vec<_> = wraps
-        .iter()
-        .filter(|w| {
-            w.wrap.key_epoch == selected.key_epoch
-                && KeyId::from_bytes(w.wrap.key_id) == selected.key_id
-        })
-        .filter_map(|w| {
-            w.wrap
-                .wraps
-                .iter()
-                .find(|entry| entry.recipient_fp == my_fingerprint)
-                .map(|entry| (w.entry_hash, &entry.sealed))
-        })
-        .collect();
-    if my_wraps.is_empty() {
-        return Ok(SealingKeyOutcome::NotRecipient);
-    }
-
-    // The AAD binds the exact sealing context byte-for-byte; the recipient_pub is this device's own
-    // roster x25519 bytes (wrap-to-self at mint sealed to exactly these).
-    let ctx = WrapContext {
-        account_id: account_id.to_bytes(),
-        stream_id: stream_id.to_bytes(),
-        key_epoch: selected.key_epoch,
-        recipient_pub: device.x25519_public().to_bytes(),
-    };
-    for (entry_hash, sealed) in my_wraps {
-        // An unwrap failure is fail-closed evidence, NOT `?`-propagated: `Err` is reserved for
-        // infra/DB failures, and propagating would record no evidence and return `Err` in violation
-        // of the `Ok(SealingKeyOutcome)` fail-closed contract.
-        let recovered = match keywrap::unwrap_content_key(sealed, device.x25519_secret(), &ctx) {
-            Ok(key) => key,
-            Err(_) => {
+    match recover_key(&wraps, account_id, stream_id, selected.key_epoch, selected.key_id, device) {
+        KeyRecovery::Ready(key) => Ok(SealingKeyOutcome::Ready(key)),
+        KeyRecovery::NotRecipient => Ok(SealingKeyOutcome::NotRecipient),
+        KeyRecovery::Failed(failures) => {
+            for failure in failures {
                 security_event::record_sync_security_event(conn, &SyncSecurityEvent {
-                    kind: SyncSecurityEventKind::WrapUnwrapFailed,
+                    kind: if failure.observed_key_id.is_some() {
+                        SyncSecurityEventKind::WrapKeyIdMismatch
+                    } else {
+                        SyncSecurityEventKind::WrapUnwrapFailed
+                    },
                     account_id,
                     stream_id,
                     key_epoch: selected.key_epoch,
-                    entry_hash,
+                    entry_hash: failure.entry_hash,
                     expected_key_id: Some(selected.key_id),
-                    observed_key_id: None,
+                    observed_key_id: failure.observed_key_id,
                     observed_at_ms: now_ms,
                 })?;
-                continue;
-            },
-        };
-        let observed = recovered.key_id();
-        if observed == selected.key_id {
-            return Ok(SealingKeyOutcome::Ready(recovered));
-        }
-        // The residual the cross-check exists for: a wrong key inside a validly-signed accepted op
-        // (impl bug / a compromised-owner substitution the authority gate can't catch).
-        security_event::record_sync_security_event(conn, &SyncSecurityEvent {
-            kind: SyncSecurityEventKind::WrapKeyIdMismatch,
-            account_id,
-            stream_id,
-            key_epoch: selected.key_epoch,
-            entry_hash,
-            expected_key_id: Some(selected.key_id),
-            observed_key_id: Some(observed),
-            observed_at_ms: now_ms,
-        })?;
+            }
+            Ok(SealingKeyOutcome::FailedClosed)
+        },
     }
-    Ok(SealingKeyOutcome::FailedClosed)
+}
+
+/// Recover every accepted historical stream key addressed to `device`. Each distinct
+/// `(key_epoch, key_id)` reconstructs its own wrap context, while all same-pair fan-out siblings
+/// are unioned before recovery. Different key IDs at one epoch are never mixed. Unopenable,
+/// mismatched, and other-recipient groups are omitted; their accepted log entries remain untouched.
+pub fn historical_content_keyring(
+    conn: &Connection,
+    account_id: AccountId,
+    stream_id: StreamId,
+    device: &LocalDevice,
+) -> anyhow::Result<ContentKeyring> {
+    let wraps = list_accepted_stream_key_wraps(conn, account_id, stream_id)?;
+    let mut groups = Vec::new();
+    for accepted in &wraps {
+        let group = (accepted.wrap.key_epoch, KeyId::from_bytes(accepted.wrap.key_id));
+        if !groups.contains(&group) {
+            groups.push(group);
+        }
+    }
+    let mut keys = Vec::new();
+    for (key_epoch, key_id) in groups {
+        if keys.iter().any(|(recovered_id, _)| *recovered_id == key_id) {
+            continue;
+        }
+        if let KeyRecovery::Ready(key) =
+            recover_key(&wraps, account_id, stream_id, key_epoch, key_id, device)
+        {
+            keys.push((key_id, key));
+        }
+    }
+    Ok(ContentKeyring(keys))
+}
+
+/// Shared cryptographic recovery for current sealing and historical projection reads.
+fn recover_key(
+    wraps: &[AcceptedStreamWrap],
+    account_id: AccountId,
+    stream_id: StreamId,
+    key_epoch: u64,
+    key_id: KeyId,
+    device: &LocalDevice,
+) -> KeyRecovery {
+    let my_fingerprint = device.fingerprint();
+    let my_wraps: Vec<_> = wraps
+        .iter()
+        .filter(|accepted| {
+            accepted.wrap.key_epoch == key_epoch
+                && KeyId::from_bytes(accepted.wrap.key_id) == key_id
+        })
+        .flat_map(|accepted| {
+            accepted
+                .wrap
+                .wraps
+                .iter()
+                .filter(move |entry| entry.recipient_fp == my_fingerprint)
+                .map(move |entry| (accepted.entry_hash, &entry.sealed))
+        })
+        .collect();
+    if my_wraps.is_empty() {
+        return KeyRecovery::NotRecipient;
+    }
+    let ctx = WrapContext {
+        account_id: account_id.to_bytes(),
+        stream_id: stream_id.to_bytes(),
+        key_epoch,
+        recipient_pub: device.x25519_public().to_bytes(),
+    };
+    let mut failures = Vec::new();
+    for (entry_hash, sealed) in my_wraps {
+        let Ok(recovered) = keywrap::unwrap_content_key(sealed, device.x25519_secret(), &ctx)
+        else {
+            failures.push(WrapRecoveryFailure { entry_hash, observed_key_id: None });
+            continue;
+        };
+        let observed_key_id = recovered.key_id();
+        if observed_key_id == key_id {
+            return KeyRecovery::Ready(recovered);
+        }
+        failures.push(WrapRecoveryFailure { entry_hash, observed_key_id: Some(observed_key_id) });
+    }
+    KeyRecovery::Failed(failures)
 }
 
 /// The current sealing selection over an accepted-wrap set: MAX `key_epoch`, tiebreak MIN
@@ -291,8 +350,8 @@ mod tests {
         DecodedSecretsOp, StreamKeyWrap, WrapEntry, decode, entry_type as secrets_entry_type,
     };
     use super::{
-        SealingKeyOutcome, SelectedWrap, current_sealing_key, select_current_sealing_wrap,
-        stream_key_rotation_needed,
+        SealingKeyOutcome, SelectedWrap, current_sealing_key, historical_content_keyring,
+        select_current_sealing_wrap, stream_key_rotation_needed,
     };
     use crate::account::cut::Cut;
     use crate::account::envelope::{AccountEntryHeader, sign_account_entry};
@@ -623,6 +682,71 @@ mod tests {
         assert_eq!(recovered.as_slice(), key.as_slice(), "the recovered key is the sealed key");
         assert_eq!(recovered.key_id(), key.key_id());
         assert_eq!(security_event_count(&conn), 0);
+    }
+
+    #[test]
+    fn historical_keyring_recovers_all_exact_keys_and_unions_fanout_siblings() {
+        let conn = db();
+        let (account, founder, genesis_hash, stream_id) = account_with_owned_stream(&conn);
+        let device = local_device(&conn, NOW).unwrap();
+        let other = Dev::new(9);
+        let other_x = DeviceX25519Public::from_bytes(&other.x).unwrap();
+        let local_x = device.x25519_public();
+
+        let prior = ContentKey::from_seed(&[0x20; 32]);
+        let fanned = ContentKey::from_seed(&[0x21; 32]);
+        let same_epoch_other_key = ContentKey::from_seed(&[0x22; 32]);
+        let other_device_only = ContentKey::from_seed(&[0x23; 32]);
+        let mismatched_plaintext = ContentKey::from_seed(&[0x24; 32]);
+        let claimed_id = ContentKey::from_seed(&[0x25; 32]).key_id();
+
+        let ops = [
+            honest_wrap(account, stream_id, device.fingerprint(), &local_x, &prior, 0),
+            // First fan-out sibling does not name this device.
+            honest_wrap(account, stream_id, other.fp, &other_x, &fanned, 1),
+            // A later sibling for the same (epoch, key_id) does.
+            honest_wrap(account, stream_id, device.fingerprint(), &local_x, &fanned, 1),
+            // A distinct key at the same epoch must remain independently addressable.
+            honest_wrap(
+                account,
+                stream_id,
+                device.fingerprint(),
+                &local_x,
+                &same_epoch_other_key,
+                1,
+            ),
+            honest_wrap(account, stream_id, other.fp, &other_x, &other_device_only, 2),
+            build_wrap(
+                account,
+                stream_id,
+                device.fingerprint(),
+                &local_x,
+                &mismatched_plaintext,
+                3,
+                claimed_id.to_bytes(),
+            ),
+        ];
+        let mut prev = None;
+        for (seq, op) in ops.iter().enumerate() {
+            let (bytes, hash) =
+                wrap_entry(account, &founder, seq as u64, prev, Some(genesis_hash), op);
+            ingest(&conn, &bytes);
+            prev = Some(hash);
+        }
+
+        let keyring = historical_content_keyring(&conn, account, stream_id, &device).unwrap();
+        assert_eq!(keyring.get(prior.key_id()).unwrap().as_slice(), prior.as_slice());
+        assert_eq!(keyring.get(fanned.key_id()).unwrap().as_slice(), fanned.as_slice());
+        assert_eq!(
+            keyring.get(same_epoch_other_key.key_id()).unwrap().as_slice(),
+            same_epoch_other_key.as_slice(),
+        );
+        assert!(
+            keyring.get(other_device_only.key_id()).is_none(),
+            "another device's wrap is not a key"
+        );
+        assert!(keyring.get(claimed_id).is_none(), "unwrap/key-id mismatch fails closed");
+        assert_eq!(security_event_count(&conn), 0, "projection recovery does not mutate evidence");
     }
 
     // ── The adoption cross-check ──

--- a/crates/rag-rat-oplog/src/content_projection.rs
+++ b/crates/rag-rat-oplog/src/content_projection.rs
@@ -259,20 +259,36 @@ fn load_accepted_entries(tx: &Transaction<'_>, stream_id: StreamId) -> anyhow::R
         _ => None,
     };
     let mut stmt = tx.prepare(
-        "SELECT signed_bytes FROM content_entries
+        "SELECT entry_hash, stream_id, signed_bytes FROM content_entries
          WHERE stream_id = ?1 AND accepted = 1
          ORDER BY entry_hash", /* deterministic load order (the projector sorts internally
                                 * regardless) */
     )?;
-    let rows =
-        stmt.query_map(params![stream_id.to_bytes().as_slice()], |row| row.get::<_, Vec<u8>>(0))?;
+    let rows = stmt.query_map(params![stream_id.to_bytes().as_slice()], |row| {
+        Ok((row.get::<_, Vec<u8>>(0)?, row.get::<_, Vec<u8>>(1)?, row.get::<_, Vec<u8>>(2)?))
+    })?;
     let mut entries = Vec::new();
     for row in rows {
-        let signed_bytes = row?;
+        let (stored_entry_hash, stored_stream_id, signed_bytes) = row?;
+        let stored_entry_hash: [u8; 32] = stored_entry_hash
+            .try_into()
+            .map_err(|_| anyhow::anyhow!("stored accepted /3 entry_hash is not 32 bytes"))?;
+        let stored_stream_id: [u8; 32] = stored_stream_id
+            .try_into()
+            .map_err(|_| anyhow::anyhow!("stored accepted /3 stream_id is not 32 bytes"))?;
         // The signed ENVELOPE decoded at ingest to become a candidate, so a failure here is
         // corruption at rest — surface it loudly.
         let signed = decode_content_signed(&signed_bytes)
             .context("stored accepted /3 entry failed to decode")?;
+        anyhow::ensure!(
+            signed.entry_hash == stored_entry_hash,
+            "stored accepted /3 signed envelope does not match its entry_hash row"
+        );
+        anyhow::ensure!(
+            signed.header.stream_id.to_bytes() == stored_stream_id
+                && signed.header.stream_id == stream_id,
+            "stored accepted /3 signed envelope does not match its stream_id row"
+        );
         // Payload/key failures are LOCAL projection failures, not acceptance failures. Unknown
         // suites, absent exact keys, malformed sealed payloads, tag failures, and undecodable
         // plaintext all remain retained+accepted and skip only this entry.

--- a/crates/rag-rat-oplog/src/content_projection.rs
+++ b/crates/rag-rat-oplog/src/content_projection.rs
@@ -24,7 +24,11 @@
 use anyhow::Context;
 use rusqlite::{Connection, OptionalExtension, Transaction, TransactionBehavior, params};
 
-use super::account::{content_projected_tables_exist, decode_content_signed};
+use super::account::{
+    KeyId, content_projected_tables_exist, decode_content_signed, historical_content_keyring,
+    open_sealed_payload, stream_owner_account,
+};
+use super::identity::load_local_device;
 use super::op::{self, DecodedOp, Entry, OpMeta};
 use super::project;
 use super::project::ProjectedState;
@@ -37,7 +41,7 @@ use super::stream::StreamId;
 /// the open/migrate seam and re-folds every stream before stamping — never trusted incrementally;
 /// a NEWER stamp blocks this binary from reprojecting at all (see
 /// [`assert_content_projector_not_newer`]).
-const CONTENT_PROJECTOR_VERSION: i64 = 1;
+const CONTENT_PROJECTOR_VERSION: i64 = 2;
 
 /// The `oplog_meta` key holding the `/3` projector version the content projection was last folded
 /// by. DISTINCT from the `/1` `projector_version` (they evolve independently and share one meta
@@ -243,6 +247,17 @@ fn write_projection(
 /// the body. An `Unknown` op is retained in the log but skipped here (mirrors
 /// [`crate::store`]'s `load_known_entries`), so a forward-version op never breaks the fold.
 fn load_accepted_entries(tx: &Transaction<'_>, stream_id: StreamId) -> anyhow::Result<Vec<Entry>> {
+    // Key wraps live in the immutable stream OWNER's secrets log. A granted writer's account is
+    // only the content author and may have no copy of those wraps.
+    let owner_account = stream_owner_account(tx, stream_id)?;
+    // Projection reads never mint or backfill a local identity. A keyless peer still retains and
+    // accepts suite-1 entries; it simply cannot project them locally yet.
+    let device = load_local_device(tx)?;
+    let keyring = match (owner_account, device.as_ref()) {
+        (Some(owner), Some(device)) =>
+            Some(historical_content_keyring(tx, owner, stream_id, device)?),
+        _ => None,
+    };
     let mut stmt = tx.prepare(
         "SELECT signed_bytes FROM content_entries
          WHERE stream_id = ?1 AND accepted = 1
@@ -258,12 +273,31 @@ fn load_accepted_entries(tx: &Transaction<'_>, stream_id: StreamId) -> anyhow::R
         // corruption at rest — surface it loudly.
         let signed = decode_content_signed(&signed_bytes)
             .context("stored accepted /3 entry failed to decode")?;
-        // The BODY is an opaque bstr the acceptance layer never decodes (§8, body-agnostic), so an
-        // authorized+accepted entry can carry a malformed or wrong-domain payload (a foreign entry
-        // that `content_ingest` accepted without a body check). Skip an undecodable/unknown body
-        // like the `/1` fold skips a non-projectable op — never `bail!`, which would crash every
-        // later local author on this stream over one bad row.
-        let Ok(decoded) = op::decode(&signed.payload) else {
+        // Payload/key failures are LOCAL projection failures, not acceptance failures. Unknown
+        // suites, absent exact keys, malformed sealed payloads, tag failures, and undecodable
+        // plaintext all remain retained+accepted and skip only this entry.
+        let plaintext;
+        let op_bytes = match signed.header.crypto_suite {
+            0 => signed.payload.as_slice(),
+            1 => {
+                let Some(key_id) = signed.header.key_id else {
+                    continue;
+                };
+                let Some(key) =
+                    keyring.as_ref().and_then(|keyring| keyring.get(KeyId::from_bytes(key_id)))
+                else {
+                    continue;
+                };
+                let Ok(opened) = open_sealed_payload(key, &signed.payload, &signed.header_bytes)
+                else {
+                    continue;
+                };
+                plaintext = opened;
+                plaintext.as_slice()
+            },
+            _ => continue,
+        };
+        let Ok(decoded) = op::decode(op_bytes) else {
             continue;
         };
         match decoded {

--- a/crates/rag-rat-oplog/src/identity.rs
+++ b/crates/rag-rat-oplog/src/identity.rs
@@ -97,6 +97,15 @@ pub fn local_device_fingerprint(conn: &Connection) -> anyhow::Result<Option<Devi
         .transpose()
 }
 
+/// Load this store's complete persisted device identity WITHOUT minting a row or backfilling a
+/// pre-V058 row. Projection is a read-side operation: merely opening accepted sealed content must
+/// never create cryptographic identity state. `None` therefore means either no identity has been
+/// persisted or the persisted legacy identity has no X25519 key yet. Corrupt stored key material
+/// remains a loud error.
+pub fn load_local_device(conn: &Connection) -> anyhow::Result<Option<LocalDevice>> {
+    Ok(read_identity(conn)?.and_then(StoredIdentity::into_local))
+}
+
 /// The identity row as stored: the ed25519 device (always present) plus the X25519 encryption key
 /// IF it has been minted/backfilled yet (a pre-V058 row carries neither X25519 column).
 struct StoredIdentity {
@@ -323,6 +332,39 @@ mod tests {
             .query_row("SELECT COUNT(*) FROM oplog_device_identity", [], |r| r.get(0))
             .expect("count rows");
         assert_eq!(rows, 1, "re-reading must not mint a second identity");
+    }
+
+    #[test]
+    fn read_only_load_neither_mints_nor_backfills_an_identity() {
+        let conn = conn();
+        assert!(load_local_device(&conn).unwrap().is_none());
+        let rows: i64 =
+            conn.query_row("SELECT COUNT(*) FROM oplog_device_identity", [], |r| r.get(0)).unwrap();
+        assert_eq!(rows, 0, "a projection read must not mint an identity");
+
+        let ed = DeviceSecret::from_seed(&[0x31; 32]);
+        let public = ed.public();
+        conn.execute(
+            "INSERT INTO oplog_device_identity(
+                 id, seed, public_key, fingerprint, created_at_ms, x25519_secret, x25519_public)
+             VALUES(0, ?1, ?2, ?3, ?4, NULL, NULL)",
+            params![
+                ed.seed().as_slice(),
+                public.to_bytes().as_slice(),
+                public.fingerprint().to_bytes().as_slice(),
+                now(),
+            ],
+        )
+        .unwrap();
+        assert!(load_local_device(&conn).unwrap().is_none());
+        let x25519: (Option<Vec<u8>>, Option<Vec<u8>>) = conn
+            .query_row(
+                "SELECT x25519_secret, x25519_public FROM oplog_device_identity WHERE id = 0",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(x25519, (None, None), "a projection read must not backfill X25519");
     }
 
     #[test]

--- a/crates/rag-rat-oplog/src/lib.rs
+++ b/crates/rag-rat-oplog/src/lib.rs
@@ -84,24 +84,25 @@ mod stream;
 //   the remaining roster when a removed device still holds the current key.
 // `author_content_batch` / `SealPolicy` / `content_op_is_sealed_authorable` (C5a, #608): the
 // sealed-authoring seam — a policy-aware, self-transacting `/3` author that seals under the
-// stream's content key. UNWIRED: nothing live calls it until C5b lands decrypt-at-projection; the
-// live memory path stays on `author_content_batch_in_tx` (suite 0). The envelope-layer seal
+// stream's content key. UNWIRED: decrypt-at-projection is available, but no live privacy-intent
+// source calls it yet; the live memory path stays on `author_content_batch_in_tx` (suite 0). The
+// envelope-layer seal
 // primitives (`sign_sealed_content_entry` / `seal_and_sign_content_entry`) take a `&DeviceSecret`,
 // so — like `sign_content_entry` — they stay account-crate-internal (never re-exported at the crate
 // root, or they would leak the `pub(crate)` `DeviceSecret` past its visibility).
 pub use account::{
     AccountId, AuthorityBoundary, AuthorityFreshness, AuthorityInvalidReason, AuthorityQuery,
-    CapacityScope, ContentKey, DeviceCut, DeviceRole, GrantAuthority, GrantDeviceAuthority,
-    GrantDeviceBoundary, GrantRole, IngestOutcome, KeyId, OwnerAuthority, OwnerChainAuthority,
-    RosterContentAuthority, RotationOutcome, SealPolicy, SealingKeyOutcome, SelectedWrap,
-    account_ingest, auth_len_freshness, author_content_batch, author_content_batch_in_tx,
-    backfill_authority_projection, content_op_is_authorable, content_op_is_sealed_authorable,
-    content_stream_is_empty, current_sealing_key, ensure_owned_stream_v2_in_tx,
-    ensure_stream_key_current_in_tx, established_owned_stream_v2, grant_effective_for_device,
-    local_account, mint_and_author_stream_key_wrap_in_tx, owned_stream_v2_id,
-    owner_control_authority, owner_secrets_authority, roster_content_authority,
-    rotate_stream_key_in_tx, select_current_sealing_wrap, stream_key_rotation_needed,
-    stream_owner_effective,
+    CapacityScope, ContentKey, ContentKeyring, DeviceCut, DeviceRole, GrantAuthority,
+    GrantDeviceAuthority, GrantDeviceBoundary, GrantRole, IngestOutcome, KeyId, OwnerAuthority,
+    OwnerChainAuthority, RosterContentAuthority, RotationOutcome, SealPolicy, SealingKeyOutcome,
+    SelectedWrap, account_ingest, auth_len_freshness, author_content_batch,
+    author_content_batch_in_tx, backfill_authority_projection, content_op_is_authorable,
+    content_op_is_sealed_authorable, content_stream_is_empty, current_sealing_key,
+    ensure_owned_stream_v2_in_tx, ensure_stream_key_current_in_tx, established_owned_stream_v2,
+    grant_effective_for_device, historical_content_keyring, local_account,
+    mint_and_author_stream_key_wrap_in_tx, owned_stream_v2_id, owner_control_authority,
+    owner_secrets_authority, roster_content_authority, rotate_stream_key_in_tx,
+    select_current_sealing_wrap, stream_key_rotation_needed, stream_owner_effective,
 };
 // The `/3` content projection's store-global upgrade re-fold (#688): wired into the index
 // open/migrate seam by rag-rat-core, so a stale store is rebuilt (every stream, then the one
@@ -111,7 +112,7 @@ pub use content_projection::rebuild_all_content_projections_if_stale;
 // vocabulary the memory subsystem needs to author + backfill entries. Every submodule above is
 // otherwise private, so this curated re-export is the ONE seam `query::memory` reaches through
 // — and the only direction of the dependency (`oplog` never depends back on `query::memory`).
-pub use identity::{LocalDevice, local_device};
+pub use identity::{LocalDevice, load_local_device, local_device};
 pub use op::{EdgeKey, EdgeSpec, MemoryOp, NodeContent, NodeId, NodeStatus};
 // The `/1` shadow-projection read seams (`ProjectedState` / `load_projection`) and the
 // standalone (own-txn) `/1` authoring wrappers (`author_batch` / `author_op`) — test-only

--- a/crates/rag-rat-oplog/src/lib.rs
+++ b/crates/rag-rat-oplog/src/lib.rs
@@ -82,10 +82,11 @@ mod stream;
 // - `rotate_stream_key_in_tx` / `ensure_stream_key_current_in_tx` / `stream_key_rotation_needed`
 //   (C4.4, #607): lazy content-key rotation on device removal — re-seal a fresh higher-epoch key to
 //   the remaining roster when a removed device still holds the current key.
-// `author_content_batch` / `SealPolicy` / `content_op_is_sealed_authorable` (C5a, #608): the
-// sealed-authoring seam — a policy-aware, self-transacting `/3` author that seals under the
-// stream's content key. UNWIRED: decrypt-at-projection is available, but no live privacy-intent
-// source calls it yet; the live memory path stays on `author_content_batch_in_tx` (suite 0). The
+// `prepare_content_authoring` / `author_prepared_content_batch_in_tx` / `SealPolicy` (C5, #608):
+// policy-aware `/3` authoring prepared before, then executed inside, a caller-owned transaction;
+// `author_content_batch` is the self-transacting convenience composition. UNWIRED: no live
+// privacy-intent source calls it yet; the live memory path stays on `author_content_batch_in_tx`
+// (suite 0). The
 // envelope-layer seal
 // primitives (`sign_sealed_content_entry` / `seal_and_sign_content_entry`) take a `&DeviceSecret`,
 // so — like `sign_content_entry` — they stay account-crate-internal (never re-exported at the crate
@@ -94,14 +95,15 @@ pub use account::{
     AccountId, AuthorityBoundary, AuthorityFreshness, AuthorityInvalidReason, AuthorityQuery,
     CapacityScope, ContentKey, ContentKeyring, DeviceCut, DeviceRole, GrantAuthority,
     GrantDeviceAuthority, GrantDeviceBoundary, GrantRole, IngestOutcome, KeyId, OwnerAuthority,
-    OwnerChainAuthority, RosterContentAuthority, RotationOutcome, SealPolicy, SealingKeyOutcome,
-    SelectedWrap, account_ingest, auth_len_freshness, author_content_batch,
-    author_content_batch_in_tx, backfill_authority_projection, content_op_is_authorable,
-    content_op_is_sealed_authorable, content_stream_is_empty, current_sealing_key,
-    ensure_owned_stream_v2_in_tx, ensure_stream_key_current_in_tx, established_owned_stream_v2,
-    grant_effective_for_device, historical_content_keyring, local_account,
-    mint_and_author_stream_key_wrap_in_tx, owned_stream_v2_id, owner_control_authority,
-    owner_secrets_authority, roster_content_authority, rotate_stream_key_in_tx,
+    OwnerChainAuthority, PreparedContentAuthoring, RosterContentAuthority, RotationOutcome,
+    SealPolicy, SealingKeyOutcome, SelectedWrap, account_ingest, auth_len_freshness,
+    author_content_batch, author_content_batch_in_tx, author_prepared_content_batch_in_tx,
+    backfill_authority_projection, content_op_is_authorable, content_op_is_sealed_authorable,
+    content_stream_is_empty, current_sealing_key, ensure_owned_stream_v2_in_tx,
+    ensure_stream_key_current_in_tx, established_owned_stream_v2, grant_effective_for_device,
+    historical_content_keyring, local_account, mint_and_author_stream_key_wrap_in_tx,
+    owned_stream_v2_id, owner_control_authority, owner_secrets_authority,
+    prepare_content_authoring, roster_content_authority, rotate_stream_key_in_tx,
     select_current_sealing_wrap, stream_key_rotation_needed, stream_owner_effective,
 };
 // The `/3` content projection's store-global upgrade re-fold (#688): wired into the index

--- a/crates/rag-rat-oplog/src/lib.rs
+++ b/crates/rag-rat-oplog/src/lib.rs
@@ -84,9 +84,7 @@ mod stream;
 //   the remaining roster when a removed device still holds the current key.
 // `prepare_content_authoring` / `author_prepared_content_batch_in_tx` / `SealPolicy` (C5, #608):
 // policy-aware `/3` authoring prepared before, then executed inside, a caller-owned transaction;
-// `author_content_batch` is the self-transacting convenience composition. UNWIRED: no live
-// privacy-intent source calls it yet; the live memory path stays on `author_content_batch_in_tx`
-// (suite 0). The
+// `author_content_batch` is the self-transacting convenience composition. The
 // envelope-layer seal
 // primitives (`sign_sealed_content_entry` / `seal_and_sign_content_entry`) take a `&DeviceSecret`,
 // so — like `sign_content_entry` — they stay account-crate-internal (never re-exported at the crate
@@ -99,12 +97,13 @@ pub use account::{
     SealPolicy, SealingKeyOutcome, SelectedWrap, account_ingest, auth_len_freshness,
     author_content_batch, author_content_batch_in_tx, author_prepared_content_batch_in_tx,
     backfill_authority_projection, content_op_is_authorable, content_op_is_sealed_authorable,
-    content_stream_is_empty, current_sealing_key, ensure_owned_stream_v2_in_tx,
-    ensure_stream_key_current_in_tx, established_owned_stream_v2, grant_effective_for_device,
-    historical_content_keyring, local_account, mint_and_author_stream_key_wrap_in_tx,
-    owned_stream_v2_id, owner_control_authority, owner_secrets_authority,
-    prepare_content_authoring, roster_content_authority, rotate_stream_key_in_tx,
-    select_current_sealing_wrap, stream_key_rotation_needed, stream_owner_effective,
+    content_stream_has_sealed_ratchet, content_stream_is_empty, current_sealing_key,
+    decode_content_signed, ensure_owned_stream_v2_in_tx, ensure_stream_key_current_in_tx,
+    established_owned_stream_v2, grant_effective_for_device, historical_content_keyring,
+    local_account, mint_and_author_stream_key_wrap_in_tx, owned_stream_v2_id,
+    owner_control_authority, owner_secrets_authority, prepare_content_authoring,
+    roster_content_authority, rotate_stream_key_in_tx, select_current_sealing_wrap,
+    stream_key_rotation_needed, stream_owner_effective,
 };
 // The `/3` content projection's store-global upgrade re-fold (#688): wired into the index
 // open/migrate seam by rag-rat-core, so a stale store is rebuilt (every stream, then the one


### PR DESCRIPTION
Closes #608.

Completes C5 after the unwired sealed-authoring machinery from #783. Private memory streams can now be enabled explicitly, decrypt at the accepted-/3 projection boundary, and author suite-1 entries through every live mutation/reconcile path without breaking table+oplog atomicity.

## Read side

- Historical stream keyring recovers exact requested `key_id`s from all accepted wraps, including same-key fan-out siblings and prior epochs; projection reads never mint identity state.
- Suite 1 decrypts with XChaCha20-Poly1305 using the retained signed header bytes as AAD; missing local keys or invalid ciphertext remain accepted but unprojected, while stored-envelope corruption fails loudly.
- Projector version bumps to v2. The #787 rebuild-all discipline upgrades every stream before stamping; per-stream reprojection only maintains a current stamp.
- Projection validates decoded envelope hash/stream identity against the stored row to reject valid-envelope substitution.

## Live authoring

- Opaque prepared authoring separates key acquisition from the caller-owned IMMEDIATE transaction; txn B revalidates rotation/key selection before sealing.
- Create/update/status, edge add/remove, backfill, reconcile, and consolidation all use policy-aware prepared authoring.
- Strict table+oplog rollback atomicity, `StaleButNotOwner`, downgrade ratchet, sealed size overhead, and fail-closed no-plaintext-fallback behavior are preserved.
- Corrupt accepted content or key-wrap evidence fails closed for plaintext downgrade; tolerant historical key recovery remains keyless-peer safe.

## Enable surface

- `rag-rat sync enable` establishes ownership/key material and persists repo-scoped one-way sealed intent, then reconciles sealed content.
- Default remains plaintext. Enable is idempotent; accepted wraps/suite-1 history form an irreversible derived downgrade ratchet.
- Consolidation monotonically carries sealed intent and refuses unknown/unsafe policy values before reconciliation.
- Command output explicitly states that transport is not configured.

## Out of scope

Transport/serve/pair/push/pull (#406), snapshots, and new-device historical key re-wrap catch-up (#763). A newly added device without old wraps still accepts sealed history but leaves it unprojected.

## Verification

- `cargo nextest run -p rag-rat-oplog -p rag-rat-core -p rag-rat`: 2,240 passed
- `cargo clippy --all-targets -- -D warnings`
- `cargo +nightly fmt --check`
- `git diff --check origin/main...HEAD`
- Three independent security review passes; all medium+ findings resolved with regressions