### PR TITLE
fix(cli): surface schema and writer lock waits

### DIFF
--- a/crates/rag-rat-cli/src/commands/index_ops.rs
+++ b/crates/rag-rat-cli/src/commands/index_ops.rs
@@ -13,7 +13,9 @@ use crate::commands::output_format;
 use crate::render::{
     print_output, print_reconcile_plan, render_index_progress, render_reconcile_progress,
 };
-use crate::{DEFAULT_MAINTENANCE_SECONDS, open_index};
+use crate::{
+    DEFAULT_MAINTENANCE_SECONDS, acquire_cli_write_lock, open_index, report_pending_schema_upgrade,
+};
 
 pub(crate) fn index(config: &Config, args: &IndexArgs) -> anyhow::Result<()> {
     // The empty-index refusal is enforced ONCE, in the core `rebuild_with_progress` (#427); the CLI
@@ -35,8 +37,8 @@ pub(crate) fn index(config: &Config, args: &IndexArgs) -> anyhow::Result<()> {
     // Serialize with the background watcher / other writers OF THIS REPO (busy_timeout backstops
     // any heal on the query path). The write lock is per-repo (A6), so a rebuild here never
     // blocks an unrelated repo's writer in a shared global DB.
-    let lock_repo = rag_rat_base::locks::write_lock_repo_id(config);
-    let _lock = rag_rat_base::locks::WriteLock::acquire_blocking(&config.database, &lock_repo)?;
+    let _lock = acquire_cli_write_lock(config, "index")?;
+    report_pending_schema_upgrade("index", config);
     // `--worktree`: index a linked worktree's branch overlay on top of the existing base index
     // (#219). A distinct mode — the delta vs the base, not a base (re)build — so handle it before
     // the full/discover/changed branches.

--- a/crates/rag-rat-cli/src/main.rs
+++ b/crates/rag-rat-cli/src/main.rs
@@ -143,9 +143,8 @@ fn main() -> anyhow::Result<()> {
             // abandoned, not in-progress — and every rebuild entry now takes the flock
             // too (batch 6), so a gc racing a mid-flight rebuild serializes with it
             // instead of sweeping the staged generation out from under it.
-            let lock_repo = rag_rat_base::locks::write_lock_repo_id(&config);
-            let _lock =
-                rag_rat_base::locks::WriteLock::acquire_blocking(&config.database, &lock_repo)?;
+            let _lock = acquire_cli_write_lock(&config, "gc")?;
+            report_pending_schema_upgrade("gc", &config);
             let db = open_index(&config)?;
             print_output(&db.garbage_collect()?)?;
         },
@@ -591,6 +590,44 @@ pub(crate) fn ensure_index_exists(config: &Config) -> anyhow::Result<()> {
 pub(crate) fn open_index(config: &Config) -> anyhow::Result<IndexDatabase> {
     ensure_index_exists(config)?;
     IndexDatabase::open_config(config)
+}
+
+/// Tell an interactive CLI user about the potentially long, one-time work that otherwise happens
+/// before a command can emit its normal progress. Best-effort: the real open still owns validation
+/// and error reporting, so a diagnostic probe must never make an otherwise-valid command fail.
+pub(crate) fn report_pending_schema_upgrade(operation: &str, config: &Config) {
+    // `migration_check` opens read-write and would create an absent DB. Leave first-time `index`
+    // creation to the rebuild path, which owns its empty-index checks and lock ordering.
+    if !config.database.exists() {
+        return;
+    }
+    let Ok(status) = IndexDatabase::migration_check(&config.database) else {
+        return;
+    };
+    if status.state == rag_rat_db::schema::SchemaState::Older {
+        eprintln!(
+            "{operation}: shared index schema upgrade v{} -> v{} required (may wait for another \
+             upgrader; large indexes may take several minutes)",
+            status.current_version, status.latest_version
+        );
+    }
+}
+
+/// Acquire a CLI writer lock without looking hung when a watcher or another command owns it.
+pub(crate) fn acquire_cli_write_lock(
+    config: &Config,
+    operation: &str,
+) -> anyhow::Result<rag_rat_base::locks::WriteLock> {
+    let lock_repo = rag_rat_base::locks::write_lock_repo_id(config);
+    if let Some(lock) = rag_rat_base::locks::WriteLock::acquire_timeout(
+        &config.database,
+        &lock_repo,
+        std::time::Duration::from_millis(250),
+    )? {
+        return Ok(lock);
+    }
+    eprintln!("{operation}: waiting for another rag-rat writer to finish");
+    rag_rat_base::locks::WriteLock::acquire_blocking(&config.database, &lock_repo)
 }
 
 pub(crate) const MANAGED_HOOKS: &[&str] =


### PR DESCRIPTION
## Summary
- report writer-lock contention for `index` and `gc` after 250 ms instead of appearing hung
- announce pending schema upgrades with current/target versions and a large-index duration warning
- preserve per-repo -> global schema lock ordering and avoid probing/creating an absent first-time database

## Context
The v0.20.0 upgrade runs the V075 `edges_data.hidden` backfill. On a 4.4 GB global store this held the schema lock for several minutes, while concurrent `npx @rag-rat/bin index` and `gc` commands produced no output before their normal progress callbacks.

## Verification
- `cargo +nightly fmt --check`
- `cargo check -p rag-rat`
- `cargo nextest run -p rag-rat --bin rag-rat` (243 passed)
- isolated older-schema smoke test confirmed the upgrade notice appears before normal index progress
- independent review found no remaining correctness issues