### PR TITLE
Add candidate-index anchor selection and the strict distill output ladder

### DIFF
--- a/crates/rag-rat-core/src/distill/extract.rs
+++ b/crates/rag-rat-core/src/distill/extract.rs
@@ -471,7 +471,8 @@ fn write_record(
 
     // --- Persist: rebuild this thread's mechanical junctions, upsert the skeleton row (clearing
     // model columns on regeneration), rewrite junctions, queue.
-    clear_mechanical_junctions(conn, repo_id, plan)?;
+    let rebuild_anchor_candidates = state != RecordState::Unchanged;
+    clear_mechanical_junctions(conn, repo_id, plan, rebuild_anchor_candidates)?;
     if regenerated {
         clear_model_junctions(conn, repo_id, plan)?;
     }
@@ -485,7 +486,9 @@ fn write_record(
     })?;
     write_commits(conn, repo_id, plan, &plan.fix_shas)?;
     write_coalesced_edges(conn, repo_id, now, plan)?;
-    write_anchors(conn, repo_id, plan, &anchors)?;
+    if rebuild_anchor_candidates {
+        write_anchors(conn, repo_id, plan, &anchors)?;
+    }
     let queued = if matches!(state, RecordState::New | RecordState::Regenerated) {
         enqueue_one(conn, repo_id, now, item, regenerated)?
     } else {
@@ -1006,20 +1009,25 @@ fn upsert_skeleton(
     Ok(())
 }
 
-/// Clear the MECHANICAL junctions this pass rebuilds deterministically (fixing commits, anchor
-/// candidates, thread-keyed edges), scoped to the full thread identity so a same-numbered thread in
-/// another project is untouched.
+/// Clear the MECHANICAL junctions this pass rebuilds deterministically, scoped to the full thread
+/// identity. Anchor candidates are rebuilt only for new/regenerated inputs: an unchanged rerun must
+/// preserve the model's `selected` flags because it is not requeued.
 fn clear_mechanical_junctions(
     conn: &Connection,
     repo_id: &str,
     plan: &RecordPlan,
+    clear_anchor_candidates: bool,
 ) -> anyhow::Result<()> {
-    for table in ["papertrail_distill_record_commits", "papertrail_distill_anchors"] {
+    conn.execute(
+        "DELETE FROM papertrail_distill_record_commits
+         WHERE repo_id = ?1 AND tracker = ?2 AND project = ?3 AND item_kind = ?4 AND item_key = ?5",
+        params![repo_id, plan.tracker, plan.project, plan.kind.as_db_str(), plan.key],
+    )?;
+    if clear_anchor_candidates {
         conn.execute(
-            &format!(
-                "DELETE FROM {table} WHERE repo_id = ?1 AND tracker = ?2 AND project = ?3 AND \
-                 item_kind = ?4 AND item_key = ?5"
-            ),
+            "DELETE FROM papertrail_distill_anchors
+             WHERE repo_id = ?1 AND tracker = ?2 AND project = ?3
+               AND item_kind = ?4 AND item_key = ?5",
             params![repo_id, plan.tracker, plan.project, plan.kind.as_db_str(), plan.key],
         )?;
     }
@@ -1104,12 +1112,12 @@ fn write_anchors(
     plan: &RecordPlan,
     anchors: &[candidates::AnchorCandidate],
 ) -> anyhow::Result<()> {
-    for anchor in anchors {
+    for (candidate_ordinal, anchor) in anchors.iter().enumerate() {
         conn.execute(
             "INSERT INTO papertrail_distill_anchors
                  (tracker, project, item_kind, item_key, anchor_kind, logical_symbol_id, file_path,
-                  name, resolved, repo_id)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+                   name, resolved, candidate_ordinal, selected, repo_id)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, 0, ?11)",
             params![
                 plan.tracker,
                 plan.project,
@@ -1120,6 +1128,7 @@ fn write_anchors(
                 anchor.file_path,
                 anchor.name,
                 anchor.resolved as i64,
+                candidate_ordinal as i64,
                 repo_id,
             ],
         )?;
@@ -1434,16 +1443,19 @@ mod tests {
             ),
             1
         );
-        let sym: (String, i64) = conn
+        let sym: (String, i64, i64, i64) = conn
             .query_row(
-                "SELECT logical_symbol_id, resolved FROM papertrail_distill_anchors
-                 WHERE anchor_kind='symbol' AND name='render_widget'",
+                "SELECT logical_symbol_id, resolved, candidate_ordinal, selected
+                 FROM papertrail_distill_anchors
+                  WHERE anchor_kind='symbol' AND name='render_widget'",
                 [],
-                |r| Ok((r.get(0)?, r.get(1)?)),
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?)),
             )
             .unwrap();
         assert_eq!(sym.0, "sym_3e7", "999 == 0x3e7"); // format_sym_handle(999)
         assert_eq!(sym.1, 1);
+        assert_eq!(sym.2, 1, "file A0 is followed deterministically by symbol A1");
+        assert_eq!(sym.3, 0, "extraction mines candidates; only the model selects them");
         // Queue holds the issue record (the coalesced PR is not its own record).
         assert_eq!(distill_count(&conn, "SELECT COUNT(*) FROM papertrail_distill_queue"), 1);
         assert_eq!(
@@ -2179,6 +2191,15 @@ mod tests {
             [],
         )
         .unwrap();
+        conn.execute(
+            "INSERT INTO papertrail_distill_anchors
+                 (tracker, project, item_kind, item_key, anchor_kind, file_path, name, resolved,
+                  candidate_ordinal, selected, repo_id)
+             VALUES ('github','o/r','change_request','9','file','src/lib.rs','src/lib.rs',1,
+                     0,1,'repoA')",
+            [],
+        )
+        .unwrap();
 
         // An IDENTICAL rerun preserves the model's work (same input hash + pipeline version).
         extract(&conn, None, &ExtractOptions::default()).unwrap();
@@ -2189,6 +2210,14 @@ mod tests {
             .unwrap();
         assert_eq!(cause.as_deref(), Some("the cause"), "identical rerun keeps model output");
         assert_eq!(distill_count(&conn, "SELECT COUNT(*) FROM papertrail_distill_evidence"), 1);
+        assert_eq!(
+            distill_count(
+                &conn,
+                "SELECT COUNT(*) FROM papertrail_distill_anchors WHERE selected = 1"
+            ),
+            1,
+            "identical rerun keeps model-selected anchors",
+        );
 
         // Changing the input (a new comment shifts the assembled units → a new hash) INVALIDATES
         // the model columns and clears the model junctions.
@@ -2209,6 +2238,14 @@ mod tests {
             distill_count(&conn, "SELECT COUNT(*) FROM papertrail_distill_alternatives"),
             0,
             "regeneration clears stale alternatives",
+        );
+        assert_eq!(
+            distill_count(
+                &conn,
+                "SELECT COUNT(*) FROM papertrail_distill_anchors WHERE selected = 1"
+            ),
+            0,
+            "regeneration clears stale anchor selections",
         );
     }
 }

--- a/crates/rag-rat-core/src/distill/mod.rs
+++ b/crates/rag-rat-core/src/distill/mod.rs
@@ -1,9 +1,7 @@
-//! Deterministic distillation substrate (#703): the model-free half of the distilled-record
-//! pipeline. It reads the papertrail mirror (items, comments, provider/text closing edges) and the
-//! git-history file changes, decides which threads are eligible, assembles their numbered text-unit
-//! input, mines mechanical fix commits / issue↔PR coalescing edges / anchor candidates, and
-//! enqueues the eligible threads for the later LLM pass (#704). Everything here is deterministic
-//! and testable without a model; the LLM never runs from this module.
+//! Distilled-record pipeline substrate. The deterministic extraction half (#703) reads the
+//! papertrail mirror and git history, assembles numbered units, mines mechanical fix/anchor data,
+//! and enqueues eligible threads. The model boundary (#704) is isolated behind a strict typed
+//! output contract and an explicit, observable response ladder; no queue drain runs implicitly.
 //!
 //! Crate placement: this lives in `rag-rat-core` (not `rag-rat-papertrail`) because anchor mining
 //! reads the symbol index, and `rag-rat-query` — where symbol reads live — depends on
@@ -13,9 +11,20 @@
 
 mod candidates;
 mod extract;
+// Registered ahead of the separate queue-drain slice, which will consume this contract.
+#[allow(dead_code)]
+mod output;
 mod prompts;
+#[allow(dead_code)] // Curated seam for the separate queue-drain slice.
+mod run_stats;
 mod units;
 mod validate;
 
 pub use extract::ExtractReport;
 pub(crate) use extract::{enqueue_eligible, extract};
+// This is the curated crate-internal seam for the separate queue-drain slice.
+#[allow(unused_imports)]
+pub(crate) use output::{
+    CitationId, DecisionOutput, LadderFailure, LadderResult, LadderStats, OutcomeOutput,
+    OutputRung, RecordOutput, RejectedAlternativeOutput, run_output_ladder,
+};

--- a/crates/rag-rat-core/src/distill/output.rs
+++ b/crates/rag-rat-core/src/distill/output.rs
@@ -1,0 +1,591 @@
+//! Strict model-output contract and the observable distill response ladder.
+
+use std::fmt;
+
+use rag_rat_llm::chat::{ChatModel, GuidedJson};
+use rag_rat_papertrail::OutcomeStatus;
+use serde::de::{self, Visitor};
+use serde::{Deserialize, Deserializer, Serialize};
+
+use super::prompts::{self, PromptBudget, PromptInput};
+
+const RECORD_SCHEMA_NAME: &str = "papertrail_distill_record";
+const MAX_ERROR_CHARS: usize = 240;
+
+/// A rendered evidence-unit id. Models commonly emit `12`, `"12"`, or `"U12"`; no other
+/// coercions are accepted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
+#[serde(transparent)]
+pub(crate) struct CitationId(usize);
+
+impl CitationId {
+    pub(crate) fn get(self) -> usize {
+        self.0
+    }
+}
+
+impl<'de> Deserialize<'de> for CitationId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_any(CitationIdVisitor)
+    }
+}
+
+struct CitationIdVisitor;
+
+impl Visitor<'_> for CitationIdVisitor {
+    type Value = CitationId;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("a non-negative integer, decimal string, or U-prefixed decimal string")
+    }
+
+    fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        usize::try_from(value).map(CitationId).map_err(|_| E::custom("citation id overflows usize"))
+    }
+
+    fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        let value =
+            u64::try_from(value).map_err(|_| E::custom("citation id must be non-negative"))?;
+        self.visit_u64(value)
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        let digits = value.strip_prefix('U').unwrap_or(value);
+        if digits.is_empty() || !digits.bytes().all(|byte| byte.is_ascii_digit()) {
+            return Err(E::custom("citation id string must be decimal or U-prefixed decimal"));
+        }
+        let value = digits.parse::<u64>().map_err(|_| E::custom("citation id overflows u64"))?;
+        self.visit_u64(value)
+    }
+}
+
+/// The typed counterpart of [`prompts::record_schema`]. Unknown fields are rejected at every
+/// object level before the semantic visibility, bounds, and claim/citation checks run.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct RecordOutput {
+    pub root_issue: Option<String>,
+    pub root_cause_units: Vec<CitationId>,
+    pub root_cause: Option<String>,
+    pub root_cause_class: Option<String>,
+    pub decision_units: Vec<CitationId>,
+    pub decision: DecisionOutput,
+    pub outcome_units: Vec<CitationId>,
+    pub anchor_indices: Vec<usize>,
+    pub outcome: OutcomeOutput,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct DecisionOutput {
+    pub chosen: Option<String>,
+    pub rejected: Vec<RejectedAlternativeOutput>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct RejectedAlternativeOutput {
+    pub alternative: String,
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct OutcomeOutput {
+    pub status: OutcomeStatus,
+    pub summary: Option<String>,
+}
+
+/// Stable output-ladder tokens. The names map directly to the `rung_*` run-counter columns.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum OutputRung {
+    /// A guided model call was attempted.
+    Guided,
+    /// The guided call's raw reply passed strict typed parsing and validation.
+    Serde,
+    /// The single unguided retry passed strict typed parsing and validation.
+    Unguided,
+    /// The retry passed only after stripping one whole-response JSON markdown fence.
+    Tolerant,
+}
+
+impl OutputRung {
+    pub(crate) const VARIANTS: [Self; 4] =
+        [Self::Guided, Self::Serde, Self::Unguided, Self::Tolerant];
+
+    pub(crate) const fn as_db_str(self) -> &'static str {
+        match self {
+            Self::Guided => "guided",
+            Self::Serde => "serde",
+            Self::Unguided => "unguided",
+            Self::Tolerant => "tolerant",
+        }
+    }
+
+    pub(crate) fn from_db_str(value: &str) -> anyhow::Result<Self> {
+        match value {
+            "guided" => Ok(Self::Guided),
+            "serde" => Ok(Self::Serde),
+            "unguided" => Ok(Self::Unguided),
+            "tolerant" => Ok(Self::Tolerant),
+            _ => Err(anyhow::anyhow!("unknown output-rung token `{value}`")),
+        }
+    }
+}
+
+/// Additive counters suitable for accumulation into one `papertrail_distill_runs` row.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize)]
+pub(crate) struct LadderStats {
+    pub rung_guided: u64,
+    pub rung_serde: u64,
+    pub rung_unguided: u64,
+    pub rung_tolerant: u64,
+    pub failed: u64,
+}
+
+impl LadderStats {
+    fn record(&mut self, rung: OutputRung) {
+        match rung {
+            OutputRung::Guided => self.rung_guided += 1,
+            OutputRung::Serde => self.rung_serde += 1,
+            OutputRung::Unguided => self.rung_unguided += 1,
+            OutputRung::Tolerant => self.rung_tolerant += 1,
+        }
+    }
+
+    pub(crate) fn accumulate(&mut self, other: Self) {
+        self.rung_guided += other.rung_guided;
+        self.rung_serde += other.rung_serde;
+        self.rung_unguided += other.rung_unguided;
+        self.rung_tolerant += other.rung_tolerant;
+        self.failed += other.failed;
+    }
+
+    pub(crate) fn terminal_count(self) -> u64 {
+        self.rung_serde + self.rung_unguided + self.rung_tolerant + self.failed
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct LadderResult {
+    pub output: RecordOutput,
+    /// Canonical JSON after tolerant citation ids have been normalized to integers.
+    pub value: serde_json::Value,
+    pub accepted_at: OutputRung,
+    /// The exact reply that produced `output`.
+    pub raw_reply: String,
+    pub stats: LadderStats,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct LadderFailure {
+    /// Latest reply received from the model, suitable for the queue's `raw_reply` column.
+    pub final_raw_reply: Option<String>,
+    /// Ordered, whitespace-normalized diagnostics, each bounded to [`MAX_ERROR_CHARS`].
+    pub errors: Vec<String>,
+    pub stats: LadderStats,
+}
+
+/// Run the observable response ladder: one guided call, then exactly one unguided retry after any
+/// guided call/parse/validation failure. Fence recovery applies only to the retry's whole response.
+pub(crate) fn run_output_ladder(
+    model: &dyn ChatModel,
+    rendered_prompt: &str,
+    schema: &serde_json::Value,
+    input: &PromptInput,
+    budget: &PromptBudget,
+) -> Result<LadderResult, LadderFailure> {
+    let mut stats = LadderStats::default();
+    let mut errors = Vec::new();
+    let mut latest_raw = None;
+
+    stats.record(OutputRung::Guided);
+    match model
+        .complete_guided(rendered_prompt, Some(GuidedJson { name: RECORD_SCHEMA_NAME, schema }))
+    {
+        Ok(raw) => {
+            latest_raw = Some(raw.clone());
+            match parse_and_validate(&raw, input, budget) {
+                Ok((output, value)) => {
+                    stats.record(OutputRung::Serde);
+                    return Ok(LadderResult {
+                        output,
+                        value,
+                        accepted_at: OutputRung::Serde,
+                        raw_reply: raw,
+                        stats,
+                    });
+                },
+                Err(error) => errors.push(bounded_error("guided reply", &error)),
+            }
+        },
+        Err(error) => errors.push(bounded_error("guided call", &error.to_string())),
+    }
+
+    let retry_raw = match model.complete(rendered_prompt) {
+        Ok(raw) => {
+            latest_raw = Some(raw.clone());
+            raw
+        },
+        Err(error) => {
+            errors.push(bounded_error("unguided call", &error.to_string()));
+            stats.failed = 1;
+            return Err(LadderFailure { final_raw_reply: latest_raw, errors, stats });
+        },
+    };
+
+    match parse_and_validate(&retry_raw, input, budget) {
+        Ok((output, value)) => {
+            stats.record(OutputRung::Unguided);
+            return Ok(LadderResult {
+                output,
+                value,
+                accepted_at: OutputRung::Unguided,
+                raw_reply: retry_raw,
+                stats,
+            });
+        },
+        Err(error) => errors.push(bounded_error("unguided reply", &error)),
+    }
+
+    if let Some(stripped) = strip_whole_json_fence(&retry_raw) {
+        match parse_and_validate(stripped, input, budget) {
+            Ok((output, value)) => {
+                stats.record(OutputRung::Tolerant);
+                return Ok(LadderResult {
+                    output,
+                    value,
+                    accepted_at: OutputRung::Tolerant,
+                    raw_reply: retry_raw,
+                    stats,
+                });
+            },
+            Err(error) => errors.push(bounded_error("fence-stripped reply", &error)),
+        }
+    } else {
+        errors
+            .push("fence recovery: reply is not one whole `json` or unlabelled fence".to_string());
+    }
+
+    stats.failed = 1;
+    Err(LadderFailure { final_raw_reply: latest_raw, errors, stats })
+}
+
+fn parse_and_validate(
+    raw: &str,
+    input: &PromptInput,
+    budget: &PromptBudget,
+) -> Result<(RecordOutput, serde_json::Value), String> {
+    let output: RecordOutput =
+        serde_json::from_str(raw).map_err(|error| format!("strict JSON parse failed: {error}"))?;
+    let value = serde_json::to_value(&output)
+        .map_err(|error| format!("typed output conversion failed: {error}"))?;
+    prompts::validate_record_output(&value, input, budget)
+        .map_err(|error| format!("record validation failed: {error}"))?;
+    Ok((output, value))
+}
+
+fn strip_whole_json_fence(raw: &str) -> Option<&str> {
+    let trimmed = raw.trim();
+    let body = trimmed
+        .strip_prefix("```json\n")
+        .or_else(|| trimmed.strip_prefix("```json\r\n"))
+        .or_else(|| trimmed.strip_prefix("```\n"))
+        .or_else(|| trimmed.strip_prefix("```\r\n"))?;
+    let body = body.strip_suffix("\n```").or_else(|| body.strip_suffix("\r\n```"))?;
+    (!body.contains("```")).then_some(body)
+}
+
+fn bounded_error(label: &str, detail: &str) -> String {
+    let normalized = detail.split_whitespace().collect::<Vec<_>>().join(" ");
+    let prefix = format!("{label}: ");
+    let remaining = MAX_ERROR_CHARS.saturating_sub(prefix.chars().count());
+    let mut bounded: String = normalized.chars().take(remaining).collect();
+    if normalized.chars().count() > remaining && remaining >= 3 {
+        for _ in 0..3 {
+            bounded.pop();
+        }
+        bounded.push_str("...");
+    }
+    prefix + &bounded
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::VecDeque;
+    use std::sync::Mutex;
+
+    use rag_rat_llm::chat::{ChatModel, GuidedJson};
+
+    use super::{LadderStats, OutputRung};
+    use crate::distill::prompts::{
+        AnchorContext, PromptBudget, PromptInput, PromptUnit, record_schema,
+    };
+
+    #[derive(Debug)]
+    enum ScriptedReply {
+        Ok(String),
+        Err(String),
+    }
+
+    #[derive(Debug)]
+    struct ScriptedChatModel {
+        replies: Mutex<VecDeque<ScriptedReply>>,
+        calls: Mutex<Vec<bool>>,
+    }
+
+    impl ScriptedChatModel {
+        fn new(replies: impl IntoIterator<Item = ScriptedReply>) -> Self {
+            Self {
+                replies: Mutex::new(replies.into_iter().collect()),
+                calls: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn guided_flags(&self) -> Vec<bool> {
+            self.calls.lock().unwrap().clone()
+        }
+    }
+
+    impl ChatModel for ScriptedChatModel {
+        fn complete_guided(
+            &self,
+            _prompt: &str,
+            guided: Option<GuidedJson<'_>>,
+        ) -> anyhow::Result<String> {
+            self.calls.lock().unwrap().push(guided.is_some());
+            match self.replies.lock().unwrap().pop_front() {
+                Some(ScriptedReply::Ok(reply)) => Ok(reply),
+                Some(ScriptedReply::Err(error)) => Err(anyhow::anyhow!(error)),
+                None => Err(anyhow::anyhow!("script exhausted")),
+            }
+        }
+
+        fn model_id(&self) -> &str {
+            "scripted"
+        }
+    }
+
+    fn input() -> PromptInput {
+        PromptInput {
+            kind: "issue".to_string(),
+            key: "1".to_string(),
+            merged: false,
+            title: "Title".to_string(),
+            opened: "Body".to_string(),
+            units: (0..=12)
+                .map(|index| PromptUnit {
+                    source: "issue".to_string(),
+                    text: format!("Evidence {index}"),
+                })
+                .collect(),
+            partner: None,
+            xrefs: vec![],
+            fix_commits: vec![],
+            symbols: vec![],
+            anchor_candidates: vec![AnchorContext {
+                index: 3,
+                kind: "file".to_string(),
+                name: "src/lib.rs".to_string(),
+                file: Some("src/lib.rs".to_string()),
+                logical_symbol_id: None,
+            }],
+            diff: None,
+        }
+    }
+
+    fn valid_json(citation: &str) -> String {
+        format!(
+            r#"{{"root_issue":null,"root_cause_units":[{citation}],"root_cause":"Cause","root_cause_class":"bug","decision_units":[{citation}],"decision":{{"chosen":"Fix","rejected":[]}},"outcome_units":[{citation}],"anchor_indices":[3],"outcome":{{"status":"landed","summary":"Landed"}}}}"#
+        )
+    }
+
+    fn run(model: &ScriptedChatModel) -> Result<super::LadderResult, super::LadderFailure> {
+        let input = input();
+        let budget = PromptBudget::default();
+        let schema = record_schema(&input, &budget);
+        super::run_output_ladder(model, "prompt", &schema, &input, &budget)
+    }
+
+    #[test]
+    fn citation_id_accepts_only_integer_decimal_and_u_decimal_forms() {
+        for accepted in ["12", r#""12""#, r#""U12""#] {
+            let parsed: super::CitationId = serde_json::from_str(accepted).unwrap();
+            assert_eq!(parsed.get(), 12, "accepted form {accepted}");
+            assert_eq!(serde_json::to_value(parsed).unwrap(), 12);
+        }
+        for rejected in [
+            "-1",
+            "1.0",
+            r#""-1""#,
+            r#"" 1""#,
+            r#""1 ""#,
+            r#""+1""#,
+            r#""u1""#,
+            r#""U""#,
+            r#""1.0""#,
+            r#""18446744073709551616""#,
+        ] {
+            assert!(
+                serde_json::from_str::<super::CitationId>(rejected).is_err(),
+                "rejected form {rejected}"
+            );
+        }
+    }
+
+    #[test]
+    fn guided_reply_is_strictly_parsed_validated_and_normalized() {
+        let model = ScriptedChatModel::new([ScriptedReply::Ok(valid_json(r#""U12""#))]);
+        let result = run(&model).unwrap();
+        assert_eq!(result.accepted_at, OutputRung::Serde);
+        assert_eq!(result.output.root_cause_units[0].get(), 12);
+        assert_eq!(result.value["root_cause_units"][0], 12);
+        assert_eq!(result.stats, LadderStats {
+            rung_guided: 1,
+            rung_serde: 1,
+            ..LadderStats::default()
+        });
+        assert_eq!(model.guided_flags(), [true]);
+    }
+
+    #[test]
+    fn guided_call_failure_gets_exactly_one_unguided_retry() {
+        let model = ScriptedChatModel::new([
+            ScriptedReply::Err("guided unavailable".to_string()),
+            ScriptedReply::Ok(valid_json("12")),
+        ]);
+        let result = run(&model).unwrap();
+        assert_eq!(result.accepted_at, OutputRung::Unguided);
+        assert_eq!(result.stats.rung_guided, 1);
+        assert_eq!(result.stats.rung_unguided, 1);
+        assert_eq!(model.guided_flags(), [true, false]);
+    }
+
+    #[test]
+    fn guided_validation_failure_gets_exactly_one_unguided_retry() {
+        let model = ScriptedChatModel::new([
+            ScriptedReply::Ok(valid_json("99")),
+            ScriptedReply::Ok(valid_json(r#""12""#)),
+        ]);
+        let result = run(&model).unwrap();
+        assert_eq!(result.accepted_at, OutputRung::Unguided);
+        assert_eq!(model.guided_flags(), [true, false]);
+    }
+
+    #[test]
+    fn whole_response_json_or_unlabelled_fence_is_the_only_tolerant_form() {
+        for opening in ["```json", "```"] {
+            let fenced = format!("{opening}\n{}\n```", valid_json("12"));
+            let model = ScriptedChatModel::new([
+                ScriptedReply::Ok("bad".to_string()),
+                ScriptedReply::Ok(fenced),
+            ]);
+            let result = run(&model).unwrap();
+            assert_eq!(result.accepted_at, OutputRung::Tolerant);
+            assert_eq!(result.stats.rung_tolerant, 1);
+            assert_eq!(model.guided_flags(), [true, false]);
+        }
+    }
+
+    #[test]
+    fn prose_language_and_multiple_fences_are_rejected_without_a_third_call() {
+        for reply in [
+            format!("prose\n```json\n{}\n```", valid_json("12")),
+            format!("```JSON\n{}\n```", valid_json("12")),
+            format!("```json\n{}\n```\nmore", valid_json("12")),
+            format!("```json\n{}\n```\n```", valid_json("12")),
+        ] {
+            let model = ScriptedChatModel::new([
+                ScriptedReply::Ok("bad guided".to_string()),
+                ScriptedReply::Ok(reply.clone()),
+                ScriptedReply::Ok(valid_json("12")),
+            ]);
+            let failure = run(&model).unwrap_err();
+            assert_eq!(failure.final_raw_reply.as_deref(), Some(reply.as_str()));
+            assert_eq!(failure.stats.failed, 1);
+            assert_eq!(model.guided_flags(), [true, false]);
+        }
+    }
+
+    #[test]
+    fn unknown_fields_are_rejected_at_every_object_level() {
+        let cases = [
+            valid_json("12").replace(r#""root_issue":null"#, r#""extra":1,"root_issue":null"#),
+            valid_json("12").replace(r#""chosen":"Fix""#, r#""extra":1,"chosen":"Fix""#),
+            valid_json("12").replace(
+                r#""rejected":[]"#,
+                r#""rejected":[{"alternative":"A","reason":null,"extra":1}]"#,
+            ),
+            valid_json("12").replace(r#""status":"landed""#, r#""extra":1,"status":"landed""#),
+        ];
+        for json in cases {
+            let input = input();
+            let error =
+                super::parse_and_validate(&json, &input, &PromptBudget::default()).unwrap_err();
+            assert!(error.contains("unknown field"), "{error}");
+        }
+    }
+
+    #[test]
+    fn final_failure_keeps_latest_raw_and_bounds_errors() {
+        let huge_error = "x".repeat(1_000);
+        let model = ScriptedChatModel::new([
+            ScriptedReply::Err(huge_error),
+            ScriptedReply::Ok("not json".to_string()),
+        ]);
+        let failure = run(&model).unwrap_err();
+        assert_eq!(failure.final_raw_reply.as_deref(), Some("not json"));
+        assert_eq!(failure.stats.failed, 1);
+        assert_eq!(model.guided_flags(), [true, false]);
+        assert!(failure.errors.iter().all(|error| error.chars().count() <= 240));
+    }
+
+    #[test]
+    fn retry_call_failure_keeps_the_guided_raw_reply() {
+        let guided_raw = "bad guided".to_string();
+        let model = ScriptedChatModel::new([
+            ScriptedReply::Ok(guided_raw.clone()),
+            ScriptedReply::Err("retry transport failed".to_string()),
+            ScriptedReply::Ok(valid_json("12")),
+        ]);
+        let failure = run(&model).unwrap_err();
+        assert_eq!(failure.final_raw_reply.as_deref(), Some(guided_raw.as_str()));
+        assert_eq!(failure.errors.len(), 2);
+        assert_eq!(failure.stats.failed, 1);
+        assert_eq!(model.guided_flags(), [true, false]);
+    }
+
+    #[test]
+    fn two_call_failures_have_no_raw_reply_and_never_make_a_third_call() {
+        let model = ScriptedChatModel::new([
+            ScriptedReply::Err("guided transport failed".to_string()),
+            ScriptedReply::Err("retry transport failed".to_string()),
+            ScriptedReply::Ok(valid_json("12")),
+        ]);
+        let failure = run(&model).unwrap_err();
+        assert_eq!(failure.final_raw_reply, None);
+        assert_eq!(failure.errors.len(), 2);
+        assert_eq!(failure.stats.failed, 1);
+        assert_eq!(model.guided_flags(), [true, false]);
+    }
+
+    #[test]
+    fn rung_tokens_are_closed_and_stable() {
+        for rung in OutputRung::VARIANTS {
+            assert_eq!(OutputRung::from_db_str(rung.as_db_str()).unwrap(), rung);
+        }
+        assert!(OutputRung::from_db_str("other").is_err());
+    }
+}

--- a/crates/rag-rat-core/src/distill/prompts.rs
+++ b/crates/rag-rat-core/src/distill/prompts.rs
@@ -20,7 +20,7 @@ use super::units::BudgetPlan;
 
 /// Bumped when the prompt text or schema changes in a way that should re-distill existing records.
 /// The drain folds this into the regeneration hash so a prompt edit re-runs the model. Start at 1.
-pub(crate) const PROMPT_VERSION: u32 = 1;
+pub(crate) const PROMPT_VERSION: u32 = 2;
 
 // Output bounds are shared contract constants so the later strict/fallback parser can enforce the
 // same limits as guided decoding rather than trusting the backend alone.
@@ -29,6 +29,7 @@ pub(crate) const MAX_NARRATIVE_CHARS: usize = 1_000;
 pub(crate) const MAX_CAUSE_CLASS_CHARS: usize = 100;
 pub(crate) const MAX_REJECTED_ALTERNATIVES: usize = 20;
 pub(crate) const MAX_ALTERNATIVE_CHARS: usize = 500;
+pub(crate) const MAX_ANCHOR_INDICES: usize = 40;
 
 /// The system instructions (role + plain-prose + cite-by-unit rules). Authored as markdown in
 /// `prompts/system.md` and embedded at build time (the dream passes use the same pattern) so prompt
@@ -54,6 +55,8 @@ pub(crate) struct PromptBudget {
     pub max_xrefs: usize,
     /// Max changed-file symbols rendered — the grounding list, capped as the spike did.
     pub max_symbols: usize,
+    /// Max mechanically mined anchor candidates exposed for model selection.
+    pub max_anchor_candidates: usize,
 }
 
 impl Default for PromptBudget {
@@ -65,6 +68,7 @@ impl Default for PromptBudget {
             commits: 8_000,
             max_xrefs: 20,
             max_symbols: 60,
+            max_anchor_candidates: MAX_ANCHOR_INDICES,
         }
     }
 }
@@ -104,12 +108,25 @@ pub(crate) struct FixCommit {
 }
 
 /// A symbol defined in the fix's changed files, from the index — grounds the model's prose in real
-/// identifiers. Presented as context; anchors themselves are mined mechanically, not selected here.
+/// identifiers. Presented as supplemental context; anchor selection uses the separately numbered
+/// mechanically mined candidates.
 #[derive(Debug, Clone)]
 pub(crate) struct SymbolContext {
     pub name: String,
     pub kind: String,
     pub file: String,
+}
+
+/// One mechanically mined anchor candidate. `index` is the persisted zero-based candidate ordinal;
+/// the model may select only indices that are rendered in the bounded candidate block.
+#[derive(Debug, Clone)]
+pub(crate) struct AnchorContext {
+    pub index: usize,
+    pub kind: String,
+    pub name: String,
+    pub file: Option<String>,
+    /// A resolved symbol's opaque `sym_<hex>` handle. It is display-only here and never parsed.
+    pub logical_symbol_id: Option<String>,
 }
 
 /// Everything the prompt renders, already assembled from the mirror + index by the drain pass.
@@ -126,6 +143,7 @@ pub(crate) struct PromptInput {
     pub xrefs: Vec<Xref>,
     pub fix_commits: Vec<FixCommit>,
     pub symbols: Vec<SymbolContext>,
+    pub anchor_candidates: Vec<AnchorContext>,
     pub diff: Option<String>,
 }
 
@@ -133,13 +151,15 @@ pub(crate) struct PromptInput {
 /// `$ref`s (best for backend guided decoding), `additionalProperties: false` everywhere. The
 /// `outcome.status` enum is built from [`OutcomeStatus`] so it can never drift from the persisted
 /// token set. Fields map to the model-owned `papertrail_distill` columns + junctions; mechanical
-/// facets (fixing commits, anchors, the status floors) are NOT model-emitted and are absent here.
+/// facets (fixing commits, mined anchor values, the status floors) are NOT model-emitted. The model
+/// emits only indices selecting from the bounded, mechanically mined anchor candidate list.
 /// Every caller MUST pass the decoded reply through [`validate_record_output`]: supported guided
 /// backends do not enforce cross-field dependencies or citation uniqueness.
 pub(crate) fn record_schema(input: &PromptInput, budget: &PromptBudget) -> serde_json::Value {
     let statuses: Vec<&'static str> =
         OutcomeStatus::VARIANTS.iter().map(|s| s.as_db_str()).collect();
     let visible_unit_ids = visible_unit_ids(input, budget);
+    let visible_anchor_indices = visible_anchor_indices(input, budget);
     serde_json::json!({
         "type": "object",
         "properties": {
@@ -194,6 +214,7 @@ pub(crate) fn record_schema(input: &PromptInput, budget: &PromptBudget) -> serde
                 "additionalProperties": false
             },
             "outcome_units": citation_array_schema(&visible_unit_ids),
+            "anchor_indices": anchor_array_schema(&visible_anchor_indices),
             "outcome": {
                 "type": "object",
                 "properties": {
@@ -210,9 +231,22 @@ pub(crate) fn record_schema(input: &PromptInput, budget: &PromptBudget) -> serde
         },
         "required": [
             "root_issue", "root_cause_units", "root_cause", "root_cause_class",
-            "decision_units", "decision", "outcome_units", "outcome"
+            "decision_units", "decision", "outcome_units", "anchor_indices", "outcome"
         ],
         "additionalProperties": false
+    })
+}
+
+fn anchor_array_schema(visible_anchor_indices: &[usize]) -> serde_json::Value {
+    let items = if visible_anchor_indices.is_empty() {
+        serde_json::json!({ "type": "integer" })
+    } else {
+        serde_json::json!({ "type": "integer", "enum": visible_anchor_indices })
+    };
+    serde_json::json!({
+        "type": "array",
+        "items": items,
+        "maxItems": visible_anchor_indices.len().min(MAX_ANCHOR_INDICES)
     })
 }
 
@@ -248,6 +282,7 @@ pub(crate) fn validate_record_output(
             "decision_units",
             "decision",
             "outcome_units",
+            "anchor_indices",
             "outcome",
         ],
         "record",
@@ -257,6 +292,7 @@ pub(crate) fn validate_record_output(
     let root_cause_units = validate_citations(object, "root_cause_units", &visible)?;
     let decision_units = validate_citations(object, "decision_units", &visible)?;
     validate_citations(object, "outcome_units", &visible)?;
+    validate_anchor_indices(object, input, budget)?;
 
     validate_nullable_text(object.get("root_issue"), "root_issue", MAX_NARRATIVE_CHARS)?;
     let has_root_cause =
@@ -323,6 +359,37 @@ pub(crate) fn validate_record_output(
         return Err(format!("outcome.status has unknown value `{status}`"));
     }
     validate_nullable_text(outcome.get("summary"), "outcome.summary", MAX_NARRATIVE_CHARS)?;
+    Ok(())
+}
+
+fn validate_anchor_indices(
+    object: &serde_json::Map<String, serde_json::Value>,
+    input: &PromptInput,
+    budget: &PromptBudget,
+) -> Result<(), String> {
+    let indices = object
+        .get("anchor_indices")
+        .and_then(serde_json::Value::as_array)
+        .ok_or_else(|| "anchor_indices must be an array".to_string())?;
+    if indices.len() > MAX_ANCHOR_INDICES {
+        return Err(format!("anchor_indices exceeds {MAX_ANCHOR_INDICES} items"));
+    }
+    let visible: std::collections::HashSet<usize> =
+        visible_anchor_indices(input, budget).into_iter().collect();
+    let mut seen = std::collections::HashSet::with_capacity(indices.len());
+    for value in indices {
+        let raw = value
+            .as_u64()
+            .ok_or_else(|| "anchor_indices must contain non-negative integers".to_string())?;
+        let index = usize::try_from(raw)
+            .map_err(|_| "anchor_indices contains an out-of-range index".to_string())?;
+        if !visible.contains(&index) {
+            return Err(format!("anchor index A{index} was not rendered"));
+        }
+        if !seen.insert(index) {
+            return Err(format!("anchor_indices contains duplicate index A{index}"));
+        }
+    }
     Ok(())
 }
 
@@ -398,7 +465,113 @@ fn validate_text(text: &str, field: &str, max_chars: usize) -> Result<(), String
     if text.chars().count() > max_chars {
         return Err(format!("{field} exceeds {max_chars} characters"));
     }
+    if let Some(markdown) = forbidden_markdown(text) {
+        return Err(format!("{field} must be plain prose (found {markdown})"));
+    }
     Ok(())
+}
+
+fn forbidden_markdown(text: &str) -> Option<&'static str> {
+    for line in text.lines() {
+        let line = line.trim_start();
+        if line.starts_with("```") || line.starts_with("~~~") {
+            return Some("a code fence");
+        }
+        if line.starts_with('#') && line.trim_start_matches('#').starts_with(char::is_whitespace) {
+            return Some("a heading");
+        }
+        if matches!(line.as_bytes(), [b'-' | b'*' | b'+', whitespace, ..] if whitespace.is_ascii_whitespace())
+            || line.split_once(char::is_whitespace).is_some_and(|(marker, _)| {
+                marker.strip_suffix('.').or_else(|| marker.strip_suffix(')')).is_some_and(
+                    |digits| !digits.is_empty() && digits.bytes().all(|byte| byte.is_ascii_digit()),
+                )
+            })
+        {
+            return Some("a list item");
+        }
+        if (line.starts_with('|') && line.ends_with('|')) || markdown_table_separator(line) {
+            return Some("a table");
+        }
+        if line.starts_with('>') {
+            return Some("a blockquote");
+        }
+        let Some(outside_code) = outside_inline_code(line) else {
+            return Some("an invalid inline-code span");
+        };
+        if outside_code.contains("**") || outside_code.contains("__") {
+            return Some("bold formatting");
+        }
+        if outside_code.contains("~~") {
+            return Some("strikethrough formatting");
+        }
+        if outside_code.contains("](") || outside_code.contains("![") {
+            return Some("a link or image");
+        }
+        if has_markdown_emphasis(&outside_code, b'*') || has_markdown_emphasis(&outside_code, b'_')
+        {
+            return Some("italic formatting");
+        }
+    }
+    None
+}
+
+fn outside_inline_code(line: &str) -> Option<String> {
+    let mut in_code = false;
+    let mut code_has_content = false;
+    let mut outside = String::with_capacity(line.len());
+    for character in line.chars() {
+        if character == '`' {
+            if in_code && !code_has_content {
+                return None;
+            }
+            in_code = !in_code;
+            code_has_content = false;
+            outside.push(' ');
+        } else if in_code {
+            if character.is_whitespace() || character.is_control() {
+                return None;
+            }
+            code_has_content = true;
+            outside.push(' ');
+        } else {
+            outside.push(character);
+        }
+    }
+    (!in_code).then_some(outside)
+}
+
+fn has_markdown_emphasis(text: &str, marker: u8) -> bool {
+    let bytes = text.as_bytes();
+    for start in 0..bytes.len() {
+        if bytes[start] != marker
+            || bytes.get(start + 1).is_none_or(u8::is_ascii_whitespace)
+            || start > 0 && !emphasis_boundary(bytes[start - 1])
+        {
+            continue;
+        }
+        for end in (start + 2)..bytes.len() {
+            if bytes[end] == marker
+                && !bytes[end - 1].is_ascii_whitespace()
+                && bytes.get(end + 1).is_none_or(|next| emphasis_boundary(*next))
+            {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+fn emphasis_boundary(byte: u8) -> bool {
+    byte.is_ascii_whitespace() || byte.is_ascii_punctuation()
+}
+
+fn markdown_table_separator(line: &str) -> bool {
+    let cells: Vec<&str> = line.split('|').map(str::trim).filter(|cell| !cell.is_empty()).collect();
+    cells.len() >= 2
+        && cells.iter().all(|cell| {
+            let cell = cell.trim_matches(':');
+            cell.len() >= 3 && cell.bytes().all(|byte| byte == b'-')
+        })
 }
 
 /// The TRUSTED instruction contract: system head + field rules. This is the only part authored by
@@ -447,6 +620,7 @@ pub(crate) fn render_context(input: &PromptInput, budget: &PromptBudget) -> Stri
     // block renders when its own data is present, so supplying a diff or symbols without a fix
     // commit still grounds the model.
     render_fix_context(&mut out, input, budget);
+    render_anchor_candidates(&mut out, input, budget);
     out
 }
 
@@ -596,6 +770,15 @@ fn visible_unit_ids(input: &PromptInput, budget: &PromptBudget) -> Vec<usize> {
     render_units(&mut rendered, &input.units, budget.units)
 }
 
+fn visible_anchor_indices(input: &PromptInput, budget: &PromptBudget) -> Vec<usize> {
+    input
+        .anchor_candidates
+        .iter()
+        .take(budget.max_anchor_candidates.min(MAX_ANCHOR_INDICES))
+        .map(|anchor| anchor.index)
+        .collect()
+}
+
 /// Append `s` to `out`, truncated so at most `*remaining` bytes are written, and debit `remaining`.
 /// The single point that enforces the units block's hard byte cap.
 fn push_capped(out: &mut String, remaining: &mut usize, s: &str) {
@@ -718,6 +901,28 @@ fn render_fix_context(out: &mut String, input: &PromptInput, budget: &PromptBudg
     }
 }
 
+fn render_anchor_candidates(out: &mut String, input: &PromptInput, budget: &PromptBudget) {
+    let visible =
+        input.anchor_candidates.iter().take(budget.max_anchor_candidates.min(MAX_ANCHOR_INDICES));
+    let mut rendered_heading = false;
+    for anchor in visible {
+        if !rendered_heading {
+            out.push_str("\nANCHOR CANDIDATES (select only these [A#] indices):\n");
+            rendered_heading = true;
+        }
+        let file = anchor.file.as_deref().unwrap_or("-");
+        let logical = anchor.logical_symbol_id.as_deref().unwrap_or("-");
+        out.push_str(&format!(
+            "  [A{}] {}  {}  (path: {}, symbol: {})\n",
+            anchor.index,
+            bounded_untrusted(&anchor.kind, 40),
+            bounded_untrusted(&anchor.name, 160),
+            bounded_untrusted(file, 240),
+            bounded_untrusted(logical, 80),
+        ));
+    }
+}
+
 /// First 12 characters of a sha for display, bounded and neutralized defensively because the
 /// prompt input boundary is stringly even though real provider SHAs are ASCII hex.
 fn short_sha(sha: &str) -> String {
@@ -738,6 +943,7 @@ const STRUCTURAL_MARKERS: &[&str] = &[
     "REFERENCED ITEMS:",
     "FIX COMMITS:",
     "SYMBOLS DEFINED",
+    "ANCHOR CANDIDATES",
     "DIFF:",
     "[... ",
     // The single-message trust-boundary delimiters — forged copies could prematurely close the
@@ -772,7 +978,9 @@ fn neutralized_len(s: &str) -> usize {
 fn forges_structural_line(line: &str) -> bool {
     let t = line.trim_start();
     STRUCTURAL_MARKERS.iter().any(|m| t.starts_with(m))
-        || (t.starts_with("[U") && t.as_bytes().get(2).is_some_and(u8::is_ascii_digit))
+        || (["[U", "[A"].iter().any(|prefix| {
+            t.starts_with(prefix) && t.as_bytes().get(2).is_some_and(u8::is_ascii_digit)
+        }))
 }
 
 fn bounded_untrusted(s: &str, max_chars: usize) -> String {
@@ -804,8 +1012,8 @@ mod tests {
     use rag_rat_papertrail::OutcomeStatus;
 
     use super::{
-        FixCommit, PartnerThread, PromptBudget, PromptInput, PromptUnit, SymbolContext, Xref,
-        record_schema, render_prompt,
+        AnchorContext, FixCommit, PartnerThread, PromptBudget, PromptInput, PromptUnit,
+        SymbolContext, Xref, record_schema, render_prompt,
     };
 
     fn unit(source: &str, text: &str) -> PromptUnit {
@@ -827,6 +1035,7 @@ mod tests {
             xrefs: vec![],
             fix_commits: vec![],
             symbols: vec![],
+            anchor_candidates: vec![],
             diff: None,
         }
     }
@@ -840,6 +1049,7 @@ mod tests {
             "decision_units": [1],
             "decision": { "chosen": "Guard the render path.", "rejected": [] },
             "outcome_units": [1],
+            "anchor_indices": [],
             "outcome": { "status": "landed", "summary": "The guard landed." }
         })
     }
@@ -849,7 +1059,7 @@ mod tests {
         // Starts at 1; the drain folds it into the record's regeneration hash so a prompt edit
         // re-distills. Bump it (and this expectation) whenever `system.md`/`rules.md`/the schema
         // change in a way that should invalidate existing model output.
-        assert_eq!(super::PROMPT_VERSION, 1);
+        assert_eq!(super::PROMPT_VERSION, 2);
     }
 
     #[test]
@@ -997,6 +1207,35 @@ mod tests {
     }
 
     #[test]
+    fn anchor_candidates_are_bounded_numbered_and_schema_constrained() {
+        let mut input = base_input();
+        input.anchor_candidates = (0..5)
+            .map(|index| AnchorContext {
+                index,
+                kind: "symbol".to_string(),
+                name: format!("symbol_{index}"),
+                file: Some(format!("src/{index}.rs")),
+                logical_symbol_id: Some(format!("sym_{index:x}")),
+            })
+            .collect();
+        let budget = PromptBudget { max_anchor_candidates: 2, ..PromptBudget::default() };
+        let context = super::render_context(&input, &budget);
+        assert!(context.contains("[A0] symbol  symbol_0"));
+        assert!(context.contains("[A1] symbol  symbol_1"));
+        assert!(!context.contains("[A2]"), "candidate block is count-bounded");
+
+        let schema = record_schema(&input, &budget);
+        let indices: Vec<u64> = schema["properties"]["anchor_indices"]["items"]["enum"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|value| value.as_u64().unwrap())
+            .collect();
+        assert_eq!(indices, [0, 1]);
+        assert_eq!(schema["properties"]["anchor_indices"]["maxItems"], 2);
+    }
+
+    #[test]
     fn output_validation_requires_unique_evidence_for_claims_and_nonempty_text() {
         let input = base_input();
         let budget = PromptBudget::default();
@@ -1044,6 +1283,41 @@ mod tests {
                 .contains("must not be empty")
         );
 
+        for markdown in [
+            "# Heading",
+            "- bullet",
+            "-\tbullet",
+            "1. numbered",
+            "**bold**",
+            "_italic_",
+            "Use *italic* text.",
+            "> quoted",
+            ">quoted",
+            ">\tquoted",
+            "[link](https://example.invalid)",
+            "![image](https://example.invalid/image.png)",
+            "~~removed~~",
+            "`an entire formatted sentence`",
+            "unclosed `identifier",
+            "```rust\ncode\n```",
+            "name | value\n--- | ---",
+        ] {
+            let mut record = valid_record();
+            record["root_issue"] = serde_json::json!(markdown);
+            assert!(
+                super::validate_record_output(&record, &input, &budget)
+                    .unwrap_err()
+                    .contains("plain prose"),
+                "reject markdown form {markdown:?}"
+            );
+        }
+        let mut code_identifier = valid_record();
+        code_identifier["root_issue"] = serde_json::json!("Call `foo_bar` with `Vec<T>`.");
+        assert!(
+            super::validate_record_output(&code_identifier, &input, &budget).is_ok(),
+            "inline code identifiers are the one permitted formatting form"
+        );
+
         let mut record = valid_record();
         record["outcome"]["status"] = serde_json::json!("bogus");
         assert!(
@@ -1059,17 +1333,49 @@ mod tests {
                 .unwrap_err()
                 .contains("unknown field")
         );
+
+        let mut input = base_input();
+        input.anchor_candidates = vec![AnchorContext {
+            index: 7,
+            kind: "file".to_string(),
+            name: "src/widget.rs".to_string(),
+            file: Some("src/widget.rs".to_string()),
+            logical_symbol_id: None,
+        }];
+        let mut record = valid_record();
+        record["anchor_indices"] = serde_json::json!(vec![7; super::MAX_ANCHOR_INDICES + 1]);
+        assert!(
+            super::validate_record_output(&record, &input, &budget)
+                .unwrap_err()
+                .contains("exceeds")
+        );
+        record["anchor_indices"] = serde_json::json!([7, 7]);
+        assert!(
+            super::validate_record_output(&record, &input, &budget)
+                .unwrap_err()
+                .contains("duplicate index")
+        );
+        record["anchor_indices"] = serde_json::json!([8]);
+        assert!(
+            super::validate_record_output(&record, &input, &budget)
+                .unwrap_err()
+                .contains("was not rendered")
+        );
     }
 
     #[test]
     fn schema_omits_mechanical_and_absent_fields() {
         let schema = record_schema(&base_input(), &PromptBudget::default());
         let props = schema["properties"].as_object().unwrap();
-        // Anchors + fixing commits are mechanical (#703); no `implementation_delta` column exists;
-        // `epistemic_status` is honest-NULL in v1 — none of these are model-emitted.
-        for absent in ["anchors", "anchor_indices", "implementation_delta", "epistemic_status"] {
+        // Anchor VALUES + fixing commits are mechanical (#703); only candidate indices are emitted.
+        // No `implementation_delta` column exists; `epistemic_status` is honest-NULL in v1.
+        for absent in ["anchors", "implementation_delta", "epistemic_status"] {
             assert!(!props.contains_key(absent), "schema must not ask the model for `{absent}`");
         }
+        assert!(
+            props.contains_key("anchor_indices"),
+            "the model selects mined candidates by index"
+        );
         assert!(
             schema["properties"]["outcome"]["properties"].get("commits").is_none(),
             "outcome.commits is mechanical, never model-emitted"

--- a/crates/rag-rat-core/src/distill/prompts/rules.md
+++ b/crates/rag-rat-core/src/distill/prompts/rules.md
@@ -7,6 +7,7 @@ Field rules:
 - decision.chosen: the CORE approach only, at most 2 sentences; exclude incidental changes (dependency bumps, test de-flaking). null if the thread settled no clear approach (e.g. a thin thread or a pure review stream).
 - decision.rejected: alternatives EXPLICITLY considered and not taken, as an array of {"alternative": ..., "reason": ...} objects; an item's reason is null when the thread gave no rationale (e.g. [{"alternative": "plan A", "reason": null}]). [] if none were discussed. The decision is what LANDED, not what a reviewer merely proposed.
 - outcome_units: the [U#] numbers of the units that establish what actually happened ([] if none, e.g. the outcome is known only from the fixing commit).
+- anchor_indices: the unique [A#] indices of the bounded ANCHOR CANDIDATES that identify the code most directly involved in the core decision and outcome. Select only visible candidate indices; use [] when none applies. Never invent a path, symbol, or index.
 - outcome.status: landed | descoped | superseded | reverted | unclear.
 - outcome.summary: what actually happened, 1-2 sentences, concrete, or null if the thread does not establish it. State measured results as results and projections as projections — never assert a projected improvement as a delivered result.
 

--- a/crates/rag-rat-core/src/distill/run_stats.rs
+++ b/crates/rag-rat-core/src/distill/run_stats.rs
@@ -1,0 +1,132 @@
+//! Durable counters for one distill ladder run.
+
+use rusqlite::{Connection, params};
+
+use super::LadderStats;
+
+/// Persist one completed run. `rung_guided` is cumulative (every thread starts guided); the other
+/// rung counters plus `failed` are mutually exclusive terminal outcomes.
+pub(crate) fn record_distill_run(
+    conn: &Connection,
+    repo_id: &str,
+    run_at_ms: i64,
+    threads: u64,
+    stats: LadderStats,
+) -> anyhow::Result<()> {
+    if stats.rung_guided != threads {
+        anyhow::bail!(
+            "distill run invariant: guided attempts {} != threads {threads}",
+            stats.rung_guided
+        );
+    }
+    if stats.terminal_count() != threads {
+        anyhow::bail!(
+            "distill run invariant: terminal outcomes {} != threads {threads}",
+            stats.terminal_count()
+        );
+    }
+    let threads = i64::try_from(threads)?;
+    let rung_guided = i64::try_from(stats.rung_guided)?;
+    let rung_serde = i64::try_from(stats.rung_serde)?;
+    let rung_unguided = i64::try_from(stats.rung_unguided)?;
+    let rung_tolerant = i64::try_from(stats.rung_tolerant)?;
+    let failed = i64::try_from(stats.failed)?;
+    let stats_json = serde_json::to_string(&stats)?;
+    conn.execute(
+        "INSERT INTO papertrail_distill_runs
+             (run_at_ms, threads, rung_guided, rung_serde, rung_unguided, rung_tolerant,
+              failed, stats_json, repo_id)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+        params![
+            run_at_ms,
+            threads,
+            rung_guided,
+            rung_serde,
+            rung_unguided,
+            rung_tolerant,
+            failed,
+            stats_json,
+            repo_id,
+        ],
+    )?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use rusqlite::Connection;
+
+    use super::record_distill_run;
+    use crate::distill::LadderStats;
+
+    fn fixture() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE papertrail_distill_runs(
+                 id INTEGER PRIMARY KEY,
+                 run_at_ms INTEGER NOT NULL,
+                 threads INTEGER NOT NULL,
+                 rung_guided INTEGER NOT NULL,
+                 rung_serde INTEGER NOT NULL,
+                 rung_unguided INTEGER NOT NULL,
+                 rung_tolerant INTEGER NOT NULL,
+                 failed INTEGER NOT NULL,
+                 stats_json TEXT,
+                 repo_id TEXT NOT NULL
+             ) STRICT;",
+        )
+        .unwrap();
+        conn
+    }
+
+    #[test]
+    fn records_cumulative_guided_and_exclusive_terminal_counters() {
+        let conn = fixture();
+        let stats = LadderStats {
+            rung_guided: 4,
+            rung_serde: 1,
+            rung_unguided: 1,
+            rung_tolerant: 1,
+            failed: 1,
+        };
+        record_distill_run(&conn, "repo", 42, 4, stats).unwrap();
+        let row: (i64, i64, i64, i64, i64, i64, String) = conn
+            .query_row(
+                "SELECT threads, rung_guided, rung_serde, rung_unguided, rung_tolerant, failed,
+                        stats_json
+                 FROM papertrail_distill_runs WHERE repo_id = 'repo'",
+                [],
+                |row| {
+                    Ok((
+                        row.get(0)?,
+                        row.get(1)?,
+                        row.get(2)?,
+                        row.get(3)?,
+                        row.get(4)?,
+                        row.get(5)?,
+                        row.get(6)?,
+                    ))
+                },
+            )
+            .unwrap();
+        assert_eq!((row.0, row.1, row.2, row.3, row.4, row.5), (4, 4, 1, 1, 1, 1));
+        assert_eq!(serde_json::from_str::<serde_json::Value>(&row.6).unwrap()["failed"], 1);
+    }
+
+    #[test]
+    fn rejects_incomplete_or_double_counted_runs() {
+        let conn = fixture();
+        let missing_guided = LadderStats { rung_guided: 1, rung_serde: 1, ..Default::default() };
+        assert!(record_distill_run(&conn, "repo", 42, 2, missing_guided).is_err());
+        let double_terminal =
+            LadderStats { rung_guided: 1, rung_serde: 1, failed: 1, ..Default::default() };
+        assert!(record_distill_run(&conn, "repo", 42, 1, double_terminal).is_err());
+        assert_eq!(
+            conn.query_row("SELECT COUNT(*) FROM papertrail_distill_runs", [], |row| {
+                row.get::<_, i64>(0)
+            })
+            .unwrap(),
+            0
+        );
+    }
+}

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
@@ -2912,8 +2912,7 @@ fn migration_076_adds_sync_security_events() {
 }
 
 #[test]
-fn migration_077_is_the_tip_and_builds_the_distill_record_store() {
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 77, "move this pin with the next schema migration");
+fn migration_077_builds_the_distill_record_store() {
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     schema::apply(&conn, &crate::index::migration_hooks()).unwrap();
     assert_eq!(
@@ -3003,4 +3002,116 @@ fn migration_077_is_the_tip_and_builds_the_distill_record_store() {
         )
         .unwrap();
     assert_eq!(v77_recorded, 1, "the forward migration records V077");
+}
+
+#[test]
+fn migration_078_is_the_tip_and_distinguishes_candidates_from_selections() {
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 78, "move this pin with the next schema migration");
+
+    // Exercise the real V077 -> V078 upgrade with existing rows. Row-id order is the deterministic
+    // tie-break within each thread; a second thread starts its own zero-based ordinal sequence.
+    let legacy = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply_distill_record_store(&legacy).unwrap();
+    legacy
+        .execute_batch(
+            "
+            INSERT INTO papertrail_distill_anchors
+                (tracker, project, item_kind, item_key, anchor_kind, logical_symbol_id, file_path,
+                 name, resolved, repo_id)
+            VALUES
+                ('github', 'o/r', 'issue', '5', 'file', NULL, 'src/widget.rs',
+                 'src/widget.rs', 1, 'r'),
+                ('github', 'o/r', 'issue', '5', 'symbol', 'sym_3e7', 'src/widget.rs',
+                 'render_widget', 1, 'r'),
+                ('github', 'o/r', 'issue', '6', 'file', NULL, 'src/other.rs',
+                 'src/other.rs', 1, 'r');
+            ",
+        )
+        .unwrap();
+    // Simulate a crash after V078's first ADD COLUMN but before its backfill/index. The migration
+    // must recognize the missing completion index and reconverge rather than keep three ordinal-0
+    // rows and fail unique-index creation forever.
+    legacy
+        .execute_batch(
+            "ALTER TABLE papertrail_distill_anchors ADD COLUMN candidate_ordinal
+                 INTEGER NOT NULL DEFAULT 0 CHECK(candidate_ordinal >= 0);",
+        )
+        .unwrap();
+    schema::apply_distill_anchor_selection(&legacy).unwrap();
+
+    let upgraded: Vec<(String, i64, i64, Option<String>, Option<String>)> = legacy
+        .prepare(
+            "SELECT item_key, candidate_ordinal, selected, logical_symbol_id, file_path
+             FROM papertrail_distill_anchors ORDER BY id",
+        )
+        .unwrap()
+        .query_map([], |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?, row.get(4)?)))
+        .unwrap()
+        .collect::<Result<_, _>>()
+        .unwrap();
+    assert_eq!(
+        upgraded,
+        vec![
+            ("5".into(), 0, 0, None, Some("src/widget.rs".into())),
+            ("5".into(), 1, 0, Some("sym_3e7".into()), Some("src/widget.rs".into()),),
+            ("6".into(), 0, 0, None, Some("src/other.rs".into())),
+        ],
+        "backfill is per-thread, deterministic, unselected, and preserves exact anchors",
+    );
+
+    assert!(
+        legacy
+            .execute_batch(
+                "UPDATE papertrail_distill_anchors SET candidate_ordinal = -1 WHERE id = 1",
+            )
+            .is_err(),
+        "candidate ordinals are non-negative",
+    );
+    assert!(
+        legacy
+            .execute("UPDATE papertrail_distill_anchors SET selected = 2 WHERE id = 1", [])
+            .is_err(),
+        "selected is a checked SQLite boolean",
+    );
+    assert!(
+        legacy
+            .execute(
+                "UPDATE papertrail_distill_anchors SET candidate_ordinal = 0 WHERE id = 2",
+                [],
+            )
+            .is_err(),
+        "candidate ordinals are unique within a thread",
+    );
+    legacy.execute("UPDATE papertrail_distill_anchors SET selected = 1 WHERE id = 2", []).unwrap();
+    schema::apply_distill_anchor_selection(&legacy).unwrap();
+    let selected: i64 = legacy
+        .query_row("SELECT selected FROM papertrail_distill_anchors WHERE id = 2", [], |row| {
+            row.get(0)
+        })
+        .unwrap();
+    assert_eq!(selected, 1, "replaying V078 does not erase a later model selection");
+
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn, &crate::index::migration_hooks()).unwrap();
+    assert_eq!(schema::status(&conn).unwrap().current_version, 78);
+    let v78_recorded: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM schema_version WHERE id = '078_distill_anchor_selection'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(v78_recorded, 1, "the forward migration records V078");
+    for index in
+        ["idx_papertrail_distill_anchors_candidate", "idx_papertrail_distill_anchors_selected"]
+    {
+        let present: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type = 'index' AND name = ?1",
+                [index],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(present, 1, "V078 index `{index}` exists");
+    }
 }

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
@@ -3006,6 +3006,15 @@ fn migration_077_builds_the_distill_record_store() {
 
 #[test]
 fn migration_078_is_the_tip_and_distinguishes_candidates_from_selections() {
+    #[derive(Debug, PartialEq, Eq)]
+    struct UpgradedAnchor {
+        item_key: String,
+        candidate_ordinal: i64,
+        selected: i64,
+        logical_symbol_id: Option<String>,
+        file_path: Option<String>,
+    }
+
     assert_eq!(schema::LATEST_SCHEMA_VERSION, 78, "move this pin with the next schema migration");
 
     // Exercise the real V077 -> V078 upgrade with existing rows. Row-id order is the deterministic
@@ -3039,22 +3048,48 @@ fn migration_078_is_the_tip_and_distinguishes_candidates_from_selections() {
         .unwrap();
     schema::apply_distill_anchor_selection(&legacy).unwrap();
 
-    let upgraded: Vec<(String, i64, i64, Option<String>, Option<String>)> = legacy
+    let upgraded: Vec<UpgradedAnchor> = legacy
         .prepare(
             "SELECT item_key, candidate_ordinal, selected, logical_symbol_id, file_path
              FROM papertrail_distill_anchors ORDER BY id",
         )
         .unwrap()
-        .query_map([], |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?, row.get(4)?)))
+        .query_map([], |row| {
+            Ok(UpgradedAnchor {
+                item_key: row.get(0)?,
+                candidate_ordinal: row.get(1)?,
+                selected: row.get(2)?,
+                logical_symbol_id: row.get(3)?,
+                file_path: row.get(4)?,
+            })
+        })
         .unwrap()
         .collect::<Result<_, _>>()
         .unwrap();
     assert_eq!(
         upgraded,
         vec![
-            ("5".into(), 0, 0, None, Some("src/widget.rs".into())),
-            ("5".into(), 1, 0, Some("sym_3e7".into()), Some("src/widget.rs".into()),),
-            ("6".into(), 0, 0, None, Some("src/other.rs".into())),
+            UpgradedAnchor {
+                item_key: "5".into(),
+                candidate_ordinal: 0,
+                selected: 0,
+                logical_symbol_id: None,
+                file_path: Some("src/widget.rs".into()),
+            },
+            UpgradedAnchor {
+                item_key: "5".into(),
+                candidate_ordinal: 1,
+                selected: 0,
+                logical_symbol_id: Some("sym_3e7".into()),
+                file_path: Some("src/widget.rs".into()),
+            },
+            UpgradedAnchor {
+                item_key: "6".into(),
+                candidate_ordinal: 0,
+                selected: 0,
+                logical_symbol_id: None,
+                file_path: Some("src/other.rs".into()),
+            },
         ],
         "backfill is per-thread, deterministic, unselected, and preserves exact anchors",
     );

--- a/crates/rag-rat-db/src/schema/migrations.rs
+++ b/crates/rag-rat-db/src/schema/migrations.rs
@@ -1326,6 +1326,7 @@ pub(crate) fn known_version(migrations: &[AppliedMigration]) -> u32 {
             MIGRATION_075_ID => Some(75),
             MIGRATION_076_ID => Some(76),
             MIGRATION_077_ID => Some(77),
+            MIGRATION_078_ID => Some(78),
             _ => None,
         })
         .max()
@@ -1412,6 +1413,7 @@ pub(crate) fn known_migration(id: &str) -> bool {
             | MIGRATION_075_ID
             | MIGRATION_076_ID
             | MIGRATION_077_ID
+            | MIGRATION_078_ID
             | DIRTY_MIGRATION_ID
     )
 }
@@ -1495,6 +1497,7 @@ pub(crate) fn migration_checksum_mismatch(migration: &AppliedMigration) -> bool 
         MIGRATION_075_ID => migration.checksum != MIGRATION_075_CHECKSUM,
         MIGRATION_076_ID => migration.checksum != MIGRATION_076_CHECKSUM,
         MIGRATION_077_ID => migration.checksum != MIGRATION_077_CHECKSUM,
+        MIGRATION_078_ID => migration.checksum != MIGRATION_078_CHECKSUM,
         _ => false,
     }
 }
@@ -5328,7 +5331,8 @@ pub fn apply_distill_record_store(conn: &Connection) -> rusqlite::Result<()> {
         CREATE INDEX IF NOT EXISTS idx_papertrail_distill_evidence_thread
             ON papertrail_distill_evidence(repo_id, tracker, project, item_kind, item_key);
 
-        -- Anchors: index-validated SELECTIONS, born as sym_<hex> bindings; EXACT file paths only.
+        -- Anchor candidates: index-validated, born as sym_<hex> bindings; EXACT file paths only.
+        -- V078 adds their stable candidate ordinals and model-selection state.
         CREATE TABLE IF NOT EXISTS papertrail_distill_anchors(
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             tracker TEXT NOT NULL, project TEXT NOT NULL,
@@ -5413,6 +5417,62 @@ pub fn apply_distill_record_store(conn: &Connection) -> rusqlite::Result<()> {
             stats_json TEXT,
             repo_id TEXT NOT NULL DEFAULT '__unassigned__'
         ) STRICT;
+        ",
+    )
+}
+
+/// V078 — separate mechanically mined anchor CANDIDATES from model SELECTED anchors (#704).
+/// Existing V077 rows receive deterministic zero-based ordinals in row-id order within each
+/// thread. The exact-path and `sym_<hex>` identity columns are deliberately untouched.
+pub fn apply_distill_anchor_selection(conn: &Connection) -> rusqlite::Result<()> {
+    // Key the backfill guard to its completion artifact, not merely column presence. If a process
+    // dies after ADD COLUMN (whose default makes every legacy row ordinal 0) but before the
+    // backfill/index, replay must backfill again rather than fail forever on duplicate ordinals.
+    let candidate_index_exists: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM sqlite_master
+         WHERE type = 'index' AND name = 'idx_papertrail_distill_anchors_candidate'",
+        [],
+        |row| row.get(0),
+    )?;
+    add_column_if_missing(
+        conn,
+        "papertrail_distill_anchors",
+        "candidate_ordinal",
+        "INTEGER NOT NULL DEFAULT 0 CHECK(candidate_ordinal >= 0)",
+    )?;
+    add_column_if_missing(
+        conn,
+        "papertrail_distill_anchors",
+        "selected",
+        "INTEGER NOT NULL DEFAULT 0 CHECK(selected IN (0, 1))",
+    )?;
+    if candidate_index_exists == 0 {
+        conn.execute_batch(
+            "
+        UPDATE papertrail_distill_anchors AS anchor
+        SET candidate_ordinal = (
+            SELECT COUNT(*)
+            FROM papertrail_distill_anchors AS earlier
+            WHERE earlier.repo_id = anchor.repo_id
+              AND earlier.tracker = anchor.tracker
+              AND earlier.project = anchor.project
+              AND earlier.item_kind = anchor.item_kind
+              AND earlier.item_key = anchor.item_key
+              AND earlier.id < anchor.id
+        );
+        ",
+        )?;
+    }
+    conn.execute_batch(
+        "
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_papertrail_distill_anchors_candidate
+            ON papertrail_distill_anchors(
+                repo_id, tracker, project, item_kind, item_key, candidate_ordinal
+            );
+        CREATE INDEX IF NOT EXISTS idx_papertrail_distill_anchors_selected
+            ON papertrail_distill_anchors(
+                repo_id, tracker, project, item_kind, item_key, candidate_ordinal
+            ) WHERE selected = 1;
         ",
     )
 }

--- a/crates/rag-rat-db/src/schema/mod.rs
+++ b/crates/rag-rat-db/src/schema/mod.rs
@@ -11,16 +11,17 @@ pub use migrations::{
     apply_account_candidate_dag, apply_clone_delta_maintenance, apply_clone_df_epoch,
     apply_clone_fingerprint_tables, apply_clone_graph_tables, apply_content_candidate_dag,
     apply_content_projected_tables, apply_content_streams_pending_refold,
-    apply_distill_record_store, apply_dream_findings, apply_edge_string_interning,
-    apply_edge_target_qname_index, apply_external_symbols, apply_files_generation,
-    apply_files_has_test_code, apply_git_change_couplings, apply_github_child_key_widening,
-    apply_github_repo_id_scoping, apply_memory_model_failures_table,
-    apply_memory_verification_tables, apply_move_per_repo_meta, apply_oplog_device_identity,
-    apply_oplog_device_x25519, apply_oplog_local_account, apply_oplog_storage,
-    apply_oplog_stream_scoping, apply_oracle_tables, apply_papertrail_binding_health,
-    apply_papertrail_distill_substrate, apply_papertrail_mirror_resume_state,
-    apply_papertrail_provider_neutral_schema, apply_repo_id_core_scoping,
-    apply_repo_id_periphery_scoping, apply_repos_registry, apply_scip_moniker_anchors,
+    apply_distill_anchor_selection, apply_distill_record_store, apply_dream_findings,
+    apply_edge_string_interning, apply_edge_target_qname_index, apply_external_symbols,
+    apply_files_generation, apply_files_has_test_code, apply_git_change_couplings,
+    apply_github_child_key_widening, apply_github_repo_id_scoping,
+    apply_memory_model_failures_table, apply_memory_verification_tables, apply_move_per_repo_meta,
+    apply_oplog_device_identity, apply_oplog_device_x25519, apply_oplog_local_account,
+    apply_oplog_storage, apply_oplog_stream_scoping, apply_oracle_tables,
+    apply_papertrail_binding_health, apply_papertrail_distill_substrate,
+    apply_papertrail_mirror_resume_state, apply_papertrail_provider_neutral_schema,
+    apply_repo_id_core_scoping, apply_repo_id_periphery_scoping, apply_repos_registry,
+    apply_scip_moniker_anchors,
 };
 pub use migrations::{column_exists, rebuild_repo_memory_fts_with_repo_id, table_exists};
 pub use purge::{RepoRowCounts, count_repo_rows, purge_repo_rows, repo_scoped_table_names};
@@ -43,7 +44,7 @@ use serde::Serialize;
 
 use crate::hooks::MigrationHooks;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 77;
+pub const LATEST_SCHEMA_VERSION: u32 = 78;
 
 /// Every oracle-DERIVED persisted table — the outputs an `oracle run` writes that must OUTLIVE a
 /// reindex.
@@ -567,6 +568,14 @@ const MIGRATION_077_DESCRIPTION: &str =
      alternatives, mechanical fixing-commits), thread-keyed edges (survive record regeneration), \
      the distill work queue, and per-run stats. Additive; CREATE IF NOT EXISTS, nothing \
      pre-existing to backfill";
+const MIGRATION_078_ID: &str = "078_distill_anchor_selection";
+const MIGRATION_078_CHECKSUM: &str = "sha256:rag-rat-distill-anchor-selection-v78";
+const MIGRATION_078_DESCRIPTION: &str =
+    "Distinguish mined anchor candidates from model selections (issue #704): add a stable, \
+     zero-based candidate ordinal and selected state to papertrail_distill_anchors; \
+     deterministically backfill V077 rows in insertion order per thread; enforce ordinal \
+     uniqueness and boolean selected values; index selected anchors. Additive; existing anchor \
+     identity/path columns are unchanged";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -1220,6 +1229,12 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         checksum: MIGRATION_077_CHECKSUM,
         description: MIGRATION_077_DESCRIPTION,
         apply: MigrationFn::Plain(apply_distill_record_store),
+    },
+    Migration {
+        id: MIGRATION_078_ID,
+        checksum: MIGRATION_078_CHECKSUM,
+        description: MIGRATION_078_DESCRIPTION,
+        apply: MigrationFn::Plain(apply_distill_anchor_selection),
     },
 ];
 


### PR DESCRIPTION
## Summary
- add V078 to distinguish mechanically mined anchor candidates from model-selected anchors with stable candidate ordinals
- expose bounded `[A#]` candidates in the prompt and validate selected anchor indices without permitting invented paths or symbols
- add strict typed model output, tolerant citation IDs, guided-to-unguided retry and narrow whole-fence recovery
- enforce output bounds, evidence coupling, visible citations, uniqueness, and the plain-prose contract at the post-generation boundary
- persist observable ladder run counters with cumulative-guided and exclusive-terminal invariants
- preserve selected anchors on unchanged extraction reruns and reset them only when regenerated input is requeued

Part of #704. Queue draining and atomic record persistence remain a separate slice.

## Verification
- `cargo nextest run -p rag-rat-core` (1,423 passed before rebase)
- `cargo nextest run -p rag-rat-core distill::` (85 passed after rebase)
- `cargo nextest run -p rag-rat-core schema_migrations` (58 passed)
- `cargo clippy -p rag-rat-db -p rag-rat-core --all-targets -- -D warnings`
- `cargo +nightly fmt`
- independent final review: no findings