### PR TITLE
feat(cookbook): persist Modal model caches

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -152,6 +152,6 @@ jobs:
             echo "$name@$ver already on npm — skipping"
           else
             echo "publishing $name@$ver"
-            # `npm ci` restores devDeps (typescript/tsx) so the prepack `tsc` can build dist/.
-            (cd cookbook && npm ci && npm publish --access public)
+            # Validate the recipe contract before prepack builds dist/ and publishes it.
+            (cd cookbook && npm ci && npm run typecheck && npm test && npm publish --access public)
           fi

--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -208,6 +208,27 @@ Provider gotchas baked into the recipe (each one cost real time to find):
 - **GPU is off by default for ollama/infinity** (and, for ollama, must attach before its discovery
   watchdog times out or the box dies exit 137 at cold start). vLLM's image is CUDA-only, so when the
   backend `requiresGpu` and the caller passed none, the recipe defaults a GPU in.
+- infinity and vLLM mount a persistent, model-scoped Modal Volume at `HF_HOME`. Later Sandboxes for
+  the same model reuse downloaded Hugging Face weights instead of paying the full cold-download cost.
+  Modal commits Volume changes in the background and on Sandbox shutdown. Because the Modal v1
+  Volume API has last-writer-wins semantics, the recipe excludes concurrent mounts of one model Volume.
+  infinity CPU boxes explicitly use the torch engine: the image's optimum/OpenVINO default writes
+  generated `infinity_onnx` artifacts into the Hub cache that are not safe to reuse across Sandboxes.
+- A successful load is published as an empty deterministic marker Volume only after verified serving
+  and termination is confirmed through a reattached polling handle, so a marker cannot outrun the
+  model Volume's final commit. Markers are advisory: Hugging Face keeps its normal metadata and cache
+  recovery behavior, so a moving `main` revision or damaged cache can still refresh.
+- vLLM's AOT/Inductor cache is persisted under a namespace keyed by model, pinned image digest, GPU,
+  capability, and launch args. A separately published compile marker records a completed cache; vLLM
+  still retains its normal recompile fallback so moving model revisions or damaged artifacts self-heal.
+  A deterministic, owner-tagged Sandbox name excludes concurrent writable mounts of the same model
+  Volume; a concurrent request fails with an explicit retry message instead of risking a v1 lost update.
+  Marker names include Modal's opaque Volume ID, so deleting and recreating a cache cannot leave a
+  stale marker attached to the replacement Volume.
+- The Sandbox main process's stdout/stderr is drained from creation through teardown. A bounded,
+  redacted prefix is forwarded as typed `log` events, and readiness failures include a bounded recent
+  tail plus the Sandbox exit code when available. Raw container output never bypasses the JSONL event
+  contract.
 - `timeoutMs: 1_800_000` (30 min) is the provider-side lifetime backstop.
 
 Auth comes from the ambient env (`MODAL_TOKEN_ID` / `MODAL_TOKEN_SECRET`) or `~/.modal.toml` —

--- a/cookbook/package-lock.json
+++ b/cookbook/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rag-rat/cookbook",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rag-rat/cookbook",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "modal": "^0.9.0"
@@ -15,6 +15,7 @@
         "cookbook": "dist/cli.mjs"
       },
       "devDependencies": {
+        "@types/node": "^24.13.3",
         "tsx": "^4.23.1",
         "typescript": "^7.0.2"
       },
@@ -641,12 +642,12 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@types/node": {
-      "version": "26.0.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.1.tgz",
-      "integrity": "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==",
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~8.3.0"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@typescript/typescript-aix-ppc64": {
@@ -1374,9 +1375,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
-      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "license": "MIT"
     },
     "node_modules/uuid": {

--- a/cookbook/package.json
+++ b/cookbook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rag-rat/cookbook",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Ephemeral remote-runtime provisioning recipes for rag-rat. rag-rat (Rust) spawns a recipe as a subprocess, reads a typed JSONL event stream from its stdout (status/log/ready/error), embeds against the endpoint, then signals teardown.",
   "license": "MIT",
   "repository": {
@@ -37,7 +37,8 @@
   ],
   "scripts": {
     "build": "tsc",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.test.json",
+    "test": "tsx --test test/*.test.mts",
     "prepare": "npm run build",
     "prepack": "npm run build",
     "recipe:modal": "node dist/recipes/modal.mjs",
@@ -47,6 +48,7 @@
     "modal": "^0.9.0"
   },
   "devDependencies": {
+    "@types/node": "^24.13.3",
     "tsx": "^4.23.1",
     "typescript": "^7.0.2"
   }

--- a/cookbook/recipes/backends.mts
+++ b/cookbook/recipes/backends.mts
@@ -186,7 +186,17 @@ const INFINITY_SPEC: BackendServerSpec = {
   // binds 0.0.0.0 by default, so no host flag is needed. server_concurrency is intentionally NOT
   // mapped: infinity's async engine batches dynamically, so there's no concurrent-request knob —
   // rag-rat's client-side fan-out tune still applies.
-  entrypointArgs: (input) => ["v2", "--model-id", input.model, "--port", String(INFINITY_PORT)],
+  entrypointArgs: (input) => [
+    "v2",
+    "--model-id",
+    input.model,
+    // The CPU image defaults to optimum/OpenVINO and writes generated `infinity_onnx` artifacts
+    // under HF_HUB_CACHE. Those artifacts can fail on the next Sandbox even when generation fell
+    // back successfully (#690 cold→warm test). Torch caches only the portable downloaded model.
+    ...(input.gpu == null ? ["--engine", "torch", "--device", "cpu"] : []),
+    "--port",
+    String(INFINITY_PORT),
+  ],
   env: () => ({}),
   // infinity's OpenAI shape lives at `/embeddings` (it also mounts `/v1/embeddings`, but `/embeddings`
   // is canonical and is what `RemoteBackend::embed_path` uses). Chat is unsupported → throw.

--- a/cookbook/recipes/modal-support.mts
+++ b/cookbook/recipes/modal-support.mts
@@ -1,0 +1,215 @@
+import { createHash } from "node:crypto";
+
+import type { LogLevel } from "../src/contract.js";
+
+export const HF_CACHE_MOUNT_PATH = "/cache/huggingface";
+const VLLM_CACHE_SCHEMA = "v1";
+
+const LOG_LINE_BYTES = 4 * 1024;
+const LOG_TAIL_BYTES = 8 * 1024;
+const LOG_FORWARD_BYTES = 32 * 1024;
+
+type LogSink = (level: LogLevel, message: string) => void;
+
+export interface SandboxOutputCapture {
+  failureTail(): string;
+  settle(delayMs: number): Promise<void>;
+  stop(): Promise<void>;
+}
+
+/** One model per Volume limits Modal v1's last-writer-wins conflict surface. */
+export function modalCacheVolumeName(model: string): string {
+  const modelKey = shortHash(model);
+  return `rag-rat-hf-${modelKey}`;
+}
+
+export function modalHfReadyMarkerName(model: string, volumeId: string): string {
+  return `rag-rat-hf-ready-${shortHash(JSON.stringify({ model, volumeId }))}`;
+}
+
+export function modalCacheSandboxName(volumeName: string): string {
+  return `rag-rat-cookbook-cache-${shortHash(volumeName)}`;
+}
+
+export interface VllmCachePlan {
+  readonly rootPath: string;
+  readonly markerName: string;
+}
+
+/** Namespace compiled code by every provider-level input vLLM's outer AOT key may omit. */
+export function vllmCachePlan(
+  model: string,
+  resolvedImage: string,
+  gpu: string,
+  capability: string,
+  entrypointArgs: readonly string[],
+  volumeId: string,
+): VllmCachePlan {
+  const key = shortHash(
+    JSON.stringify({
+      schema: VLLM_CACHE_SCHEMA,
+      model,
+      resolvedImage,
+      gpu,
+      capability,
+      entrypointArgs,
+      volumeId,
+    }),
+  );
+  return {
+    rootPath: `${HF_CACHE_MOUNT_PATH}/vllm/${key}`,
+    markerName: `rag-rat-vllm-ready-${key}`,
+  };
+}
+
+export function modalCacheEnvironment(vllm: VllmCachePlan | null): Record<string, string> {
+  return {
+    HF_HOME: HF_CACHE_MOUNT_PATH,
+    ...(vllm !== null
+      ? {
+          VLLM_CACHE_ROOT: vllm.rootPath,
+          VLLM_USE_AOT_COMPILE: "1",
+          VLLM_USE_MEGA_AOT_ARTIFACT: "0",
+        }
+      : {}),
+  };
+}
+
+/**
+ * Drain a Sandbox's long-lived main-process streams without ever writing raw bytes to local stdout.
+ * Forwarding and retained failure context are independently bounded; draining continues after the
+ * forwarding budget is exhausted so the remote process cannot block on a full output pipe.
+ */
+export function startSandboxOutputCapture(
+  stdout: ReadableStream<string>,
+  stderr: ReadableStream<string>,
+  sink: LogSink,
+): SandboxOutputCapture {
+  let tail = "";
+  let forwardedBytes = 0;
+  let suppressionLogged = false;
+  const readers: ReadableStreamDefaultReader<string>[] = [];
+
+  const appendTail = (message: string): void => {
+    tail = trimUtf8Tail(`${tail}${tail === "" ? "" : "\n"}${message}`, LOG_TAIL_BYTES);
+  };
+
+  const forward = (source: "stdout" | "stderr", rawLine: string, truncated: boolean): void => {
+    const prefix = `sandbox ${source}: `;
+    const cleaned = safeDiagnostic(rawLine, LOG_LINE_BYTES - Buffer.byteLength(prefix), truncated);
+    if (cleaned === "" && !truncated) return;
+    const message = `${prefix}${cleaned}`;
+    appendTail(message);
+
+    const bytes = Buffer.byteLength(message);
+    if (forwardedBytes + bytes <= LOG_FORWARD_BYTES) {
+      forwardedBytes += bytes;
+      sink("info", message);
+    } else if (!suppressionLogged) {
+      suppressionLogged = true;
+      sink("warn", "sandbox output forwarding limit reached; continuing to drain silently");
+    }
+  };
+
+  const pump = async (stream: ReadableStream<string>, source: "stdout" | "stderr"): Promise<void> => {
+    let reader: ReadableStreamDefaultReader<string> | undefined;
+    let line = "";
+    let lineBytes = 0;
+    let lineTruncated = false;
+
+    try {
+      reader = stream.getReader();
+      readers.push(reader);
+      while (true) {
+        const { done, value = "" } = await reader.read();
+        if (done) break;
+
+        let offset = 0;
+        while (offset < value.length) {
+          const newline = value.indexOf("\n", offset);
+          const end = newline === -1 ? value.length : newline;
+          const segment = value.slice(offset, end).replace(/\r$/, "");
+          if (!lineTruncated) {
+            const room = LOG_LINE_BYTES - lineBytes;
+            const kept = takeUtf8Prefix(segment, room);
+            line += kept;
+            lineBytes += Buffer.byteLength(kept);
+            lineTruncated = kept.length !== segment.length;
+          }
+
+          if (newline === -1) break;
+          forward(source, line, lineTruncated);
+          line = "";
+          lineBytes = 0;
+          lineTruncated = false;
+          offset = newline + 1;
+        }
+      }
+      if (line !== "" || lineTruncated) forward(source, line, lineTruncated);
+    } catch {
+      // Cancellation during teardown and SDK stream failures are both non-fatal diagnostics paths.
+    } finally {
+      reader?.releaseLock();
+    }
+  };
+
+  const pumps = [pump(stdout, "stdout"), pump(stderr, "stderr")];
+
+  return {
+    failureTail: () => tail,
+    settle: async (delayMs) => {
+      if (delayMs > 0) await new Promise((resolve) => setTimeout(resolve, delayMs));
+    },
+    stop: async () => {
+      // A terminated Sandbox normally closes both streams. Give already-buffered final diagnostics
+      // one event-loop turn to drain before cancellation, while still bounding a live stream.
+      await Promise.race([
+        Promise.allSettled(pumps),
+        new Promise((resolve) => setTimeout(resolve, 25)),
+      ]);
+      await Promise.allSettled(readers.map((reader) => reader.cancel()));
+      await Promise.allSettled(pumps);
+    },
+  };
+}
+
+/** Redact credentials and cap the final, post-redaction diagnostic by UTF-8 bytes. */
+export function safeDiagnostic(value: string, maxBytes = LOG_LINE_BYTES, forceTruncated = false): string {
+  const cleaned = value
+    .replace(/\x1B(?:[@-_][0-?]*[ -/]*[@-~]|\][^\x07]*(?:\x07|\x1B\\))/g, "")
+    .replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, "")
+    .replace(
+      /\b(Authorization|Proxy-Authorization|X-Api-Key|Api-Key):\s*.*$/gim,
+      "$1: [REDACTED]",
+    )
+    .replace(/\bBearer\s+[^\s]+/gi, "Bearer [REDACTED]")
+    .replace(/\bhf_[A-Za-z0-9]{8,}\b/g, "hf_[REDACTED]")
+    .replace(
+      /([?&](?:access_token|auth_token|token|X-Amz-Credential|X-Amz-Signature|X-Amz-Security-Token|X-Goog-Credential|X-Goog-Signature|Signature|Policy|Key-Pair-Id)=)[^&\s]+/gi,
+      "$1[REDACTED]",
+    )
+    .replace(/(\bhttps?:\/\/)[^/\s@]+@/gi, "$1[REDACTED]@").trimEnd();
+
+  const marker = " [truncated]";
+  if (!forceTruncated && Buffer.byteLength(cleaned) <= maxBytes) return cleaned;
+  const markerBytes = Buffer.byteLength(marker);
+  if (maxBytes <= markerBytes) return takeUtf8Prefix(marker, maxBytes);
+  return `${takeUtf8Prefix(cleaned, maxBytes - markerBytes)}${marker}`;
+}
+
+function takeUtf8Prefix(value: string, maxBytes: number): string {
+  if (maxBytes <= 0) return "";
+  const bytes = Buffer.from(value);
+  if (bytes.length <= maxBytes) return value;
+  return bytes.subarray(0, maxBytes).toString("utf8").replace(/\uFFFD$/, "");
+}
+
+function trimUtf8Tail(value: string, maxBytes: number): string {
+  const bytes = Buffer.from(value);
+  if (bytes.length <= maxBytes) return value;
+  return bytes.subarray(bytes.length - maxBytes).toString("utf8").replace(/^\uFFFD/, "");
+}
+
+function shortHash(value: string): string {
+  return createHash("sha256").update(value).digest("hex").slice(0, 24);
+}

--- a/cookbook/recipes/modal.mts
+++ b/cookbook/recipes/modal.mts
@@ -37,8 +37,8 @@
  */
 
 import { randomUUID } from "node:crypto";
-import { ModalClient, Probe } from "modal";
-import type { Sandbox } from "modal";
+import { AlreadyExistsError, ModalClient, NotFoundError, Probe } from "modal";
+import type { Logger as ModalLogger, Sandbox } from "modal";
 
 import {
   type ProvisionContext,
@@ -54,6 +54,17 @@ import {
   withBudget,
 } from "../src/contract.js";
 import { assertCapabilitySupported, selectBackendSpec } from "./backends.mjs";
+import {
+  HF_CACHE_MOUNT_PATH,
+  type SandboxOutputCapture,
+  modalCacheEnvironment,
+  modalCacheSandboxName,
+  modalCacheVolumeName,
+  modalHfReadyMarkerName,
+  safeDiagnostic,
+  startSandboxOutputCapture,
+  vllmCachePlan,
+} from "./modal-support.mjs";
 
 /** Provider-side max-lifetime backstop in ms — a leaked box self-destructs after this. */
 const BOX_MAX_LIFETIME_MS = 1_800_000; // 30 minutes
@@ -102,9 +113,31 @@ const MODAL_DEFAULT_GPU = "A10G";
  * hung terminate would otherwise leak a billed box until Modal's `timeoutMs` backstop fires.
  */
 const TEARDOWN_TIMEOUT_MS = 8_000;
+/** Briefly allow final startup diagnostics to arrive after readiness rejects. */
+const FAILURE_LOG_SETTLE_MS = 250;
+/** Keeps the complete JSON-escaped error event below Rust's 16 KiB line cap. */
+const READINESS_DIAGNOSTIC_BYTES = 7 * 1024;
+/** Bound stream cancellation after the remote box has terminated. */
+const OUTPUT_STOP_TIMEOUT_MS = 500;
+/** Marker publication is metadata-only and must not consume the Rust teardown grace. */
+const CACHE_MARKER_TIMEOUT_MS = 1_000;
+const OWNER_TAG = "rag-rat-owner";
+
+interface CachePublication {
+  readonly modal: ModalClient;
+  readonly markerNames: readonly string[];
+  verified: boolean;
+}
+
+interface ModalHandle {
+  readonly modal: ModalClient;
+  readonly sandbox: Sandbox;
+  readonly output: SandboxOutputCapture;
+  readonly cachePublication: CachePublication | null;
+}
 
 /** Provision an embedding box serving `input.model` on the selected backend; return its endpoint. */
-async function provision(ctx: ProvisionContext<Sandbox>): Promise<Provisioned<Sandbox>> {
+async function provision(ctx: ProvisionContext<ModalHandle>): Promise<Provisioned<ModalHandle>> {
   const { input, provisionTimeoutMs } = ctx;
   const spec = selectBackendSpec(input.backend ?? "ollama");
   // What the box should SERVE (embeddings vs chat). Absent → embed (back-compat). Fail loudly NOW,
@@ -128,7 +161,9 @@ async function provision(ctx: ProvisionContext<Sandbox>): Promise<Provisioned<Sa
   );
 
   // Creds resolve from env (MODAL_TOKEN_ID/MODAL_TOKEN_SECRET) or ~/.modal.toml.
-  const modal = new ModalClient();
+  // Modal's default logger writes non-JSON text to stdout/stderr and honors ambient config. Route
+  // SDK warnings through typed cookbook events instead so the JSONL wire contract cannot be broken.
+  const modal = new ModalClient({ logger: modalSdkLogger(), logLevel: "warn" });
   const app = await withBudget(deadline, "apps.fromName", () =>
     modal.apps.fromName(APP_NAME, { createIfMissing: true }),
   );
@@ -143,23 +178,76 @@ async function provision(ctx: ProvisionContext<Sandbox>): Promise<Provisioned<Sa
   // is `withBudget`-bounded, but Modal can REACH the backend and CREATE the sandbox and then have the
   // SDK call stall past the budget — `withBudget` throws BEFORE `ctx.onBox(sb)`, so `runRecipe` tears
   // down "nothing" while the created sandbox bills until Modal's `timeoutMs` backstop (30 min). We
-  // give the sandbox a recoverable UNIQUE name; on ANY create throw, look it up by name and terminate
-  // it before rethrowing. (Unlike RunPod, Modal HAS a provider backstop, so this only shortens the
-  // worst case — but a leaked GPU box for up to 30 min is still real money.)
-  const sandboxName = `${APP_NAME}-${Date.now()}-${randomUUID().slice(0, 8)}`;
-
+  // give the sandbox a recoverable name and owner tag; on ANY create throw, look it up by name and
+  // terminate it only when that tag proves this invocation created it. (Unlike RunPod, Modal HAS a
+  // provider backstop, so this only shortens the worst case — but a leaked GPU box for up to 30 min
+  // is still real money.)
   // The backend spec supplies the entrypoint ARGS (never the entrypoint) + env + the served port.
   // Resolve the args first — the vLLM chat path is async (it sizes --max-model-len from the model's
   // HF context).
-  const entrypointArgs = await spec.entrypointArgs(input);
+  const entrypointArgs = await withBudget(deadline, "entrypointArgs", () =>
+    Promise.resolve(spec.entrypointArgs(input)),
+  );
+  const cacheVolumeName = modalCacheVolumeName(input.model);
+  const cacheVolume =
+    spec.modelLoad === "in-launch"
+      ? await withBudget(deadline, "volumes.fromName", () =>
+          modal.volumes.fromName(cacheVolumeName, { createIfMissing: true }),
+        )
+      : null;
+  if (cacheVolume !== null) {
+    log("info", `using persistent Hugging Face cache volume at ${HF_CACHE_MOUNT_PATH}`);
+  }
+  const hfMarkerName = modalHfReadyMarkerName(input.model, cacheVolume?.volumeId ?? "uncached");
+  const hfReady =
+    cacheVolume !== null && (await cacheMarkerExists(modal, hfMarkerName, deadline, "Hugging Face"));
+  const compilePlan =
+    spec.backend === "vllm"
+      ? vllmCachePlan(
+          input.model,
+          resolvedImage,
+          gpu ?? "cpu",
+          capability,
+          entrypointArgs,
+          cacheVolume?.volumeId ?? "uncached",
+        )
+      : null;
+  const compileReady =
+    compilePlan !== null &&
+    (await cacheMarkerExists(modal, compilePlan.markerName, deadline, "vLLM compile"));
+  const cachePublication: CachePublication | null =
+    cacheVolume === null
+      ? null
+      : {
+          modal,
+          markerNames: [
+            ...(!hfReady ? [hfMarkerName] : []),
+            ...(compilePlan !== null && !compileReady ? [compilePlan.markerName] : []),
+          ],
+          verified: false,
+        };
+  const cacheEnv = cacheVolume === null ? {} : modalCacheEnvironment(compilePlan);
+  // Every cache-backed Sandbox can update HF metadata or compiler artifacts. Modal v1 commits are
+  // last-writer-wins across the whole Volume, so exclude concurrent mounts for this model even after
+  // markers exist. The owner tag makes timeout cleanup safe despite the shared deterministic name.
+  const ownerId = randomUUID();
+  const sandboxName =
+    cacheVolume === null
+      ? `${APP_NAME}-${Date.now()}-${randomUUID().slice(0, 8)}`
+      : modalCacheSandboxName(cacheVolumeName);
   let sb: Sandbox;
   const createRef: { promise?: Promise<Sandbox> } = {};
   try {
     sb = await withBudget(deadline, "sandboxes.create", () => {
       createRef.promise = modal.sandboxes.create(app, image, {
         name: sandboxName,
+        tags: { [OWNER_TAG]: ownerId },
         command: [...entrypointArgs],
-        env: spec.env(input),
+        env: {
+          ...spec.env(input),
+          ...cacheEnv,
+        },
+        ...(cacheVolume !== null ? { volumes: { [HF_CACHE_MOUNT_PATH]: cacheVolume } } : {}),
         encryptedPorts: [port],
         readinessProbe: Probe.withTcp(port, { intervalMs: 1000 }),
         timeoutMs: BOX_MAX_LIFETIME_MS,
@@ -169,10 +257,16 @@ async function provision(ctx: ProvisionContext<Sandbox>): Promise<Provisioned<Sa
       return createRef.promise;
     });
   } catch (cause) {
+    if (cacheVolume !== null && cause instanceof AlreadyExistsError) {
+      throw new Error(
+        `model cache ${cacheVolumeName} is already mounted by another cookbook Sandbox; retry after it finishes`,
+        { cause },
+      );
+    }
     const pendingCreate = createRef.promise;
     if (pendingCreate !== undefined) {
       void pendingCreate.then(
-        (lateSandbox: Sandbox) => terminateOrphanSandbox(lateSandbox, sandboxName, "late create"),
+        (lateSandbox: Sandbox) => terminateOrphanSandbox(modal, lateSandbox, sandboxName, "late create"),
         (lateCause: unknown) => {
           log(
             "info",
@@ -181,20 +275,44 @@ async function provision(ctx: ProvisionContext<Sandbox>): Promise<Provisioned<Sa
         },
       );
     }
-    await sweepOrphanByName(modal, sandboxName);
+    await sweepOrphanByName(modal, sandboxName, ownerId);
     throw cause;
   }
+  // Start draining before readiness: model-download failures are emitted by the main process, and
+  // waiting to attach until after readiness would lose the exact diagnostics needed when boot fails.
+  const output = startSandboxOutputCapture(sb.stdout, sb.stderr, log);
+  const handle = { modal, sandbox: sb, output, cachePublication };
   // Report the box NOW so runRecipe tears it down if readiness, pull, or verify throws.
-  ctx.onBox(sb);
+  ctx.onBox(handle);
   log("info", `sandbox created: ${sb.sandboxId ?? "(id unavailable)"}`);
 
   ctx.status("provisioning", `waiting for ${spec.backend} to listen on port ${port}`);
   const readinessTimeoutMs = assertBudgetRemaining(deadline, "sandbox readiness");
-  await raceWithTimeout(
-    () => sb.waitUntilReady(readinessTimeoutMs),
-    readinessTimeoutMs,
-    "sandbox.waitUntilReady",
-  );
+  try {
+    await raceWithTimeout(
+      () => sb.waitUntilReady(readinessTimeoutMs),
+      readinessTimeoutMs,
+      "sandbox.waitUntilReady",
+    );
+  } catch (cause) {
+    const diagnosticMs = Math.min(FAILURE_LOG_SETTLE_MS, Math.max(0, deadline - Date.now()));
+    const [, exitCode] = await Promise.all([
+      output.settle(diagnosticMs),
+      diagnosticMs > 0
+        ? raceWithTimeout(() => sb.poll(), diagnosticMs, "sandbox.poll").catch(() => undefined)
+        : Promise.resolve(undefined),
+    ]);
+    const tail = output.failureTail();
+    const diagnostic = safeDiagnostic(
+      `${errorMessage(cause)}${tail === "" ? "" : `\nrecent sandbox output:\n${tail}`}`,
+      READINESS_DIAGNOSTIC_BYTES,
+    );
+    throw new Error(
+      `sandbox readiness failed (exit code ${exitCode === undefined ? "unavailable" : exitCode ?? "not exited"}): ` +
+        diagnostic,
+      { cause },
+    );
+  }
   log("info", `${spec.backend} is listening`);
 
   // Load the model. infinity/vLLM auto-download on boot (nothing to do); ollama boots empty, so pull
@@ -225,9 +343,10 @@ async function provision(ctx: ProvisionContext<Sandbox>): Promise<Provisioned<Sa
     await verifyEmbed(endpoint, { model: input.model, embedPath: servePath, budgetMs: verifyBudgetMs });
   }
   log("info", `${capability} verification passed; box is serving`);
+  if (cachePublication !== null) cachePublication.verified = true;
 
   // Open tunnel via encryptedPorts → no per-request token needed. auth_token stays null.
-  return { handle: sb, endpoint, auth_token: null };
+  return { handle, endpoint, auth_token: null };
 }
 
 /**
@@ -239,7 +358,7 @@ async function pullOllamaModel(
   sb: Sandbox,
   model: string,
   deadline: number,
-  ctx: ProvisionContext<Sandbox>,
+  ctx: ProvisionContext<ModalHandle>,
 ): Promise<void> {
   ctx.status("pulling", `pulling model "${model}" (cold-start cost)`);
   const pull = await withBudget(deadline, "exec(ollama pull)", () =>
@@ -257,26 +376,90 @@ async function pullOllamaModel(
  * Destroy the box, bounded so a hung `terminate()` can't run past the Rust teardown grace and leak
  * a billed box. Idempotent enough — terminate on an already-gone box is a no-op/soft error.
  */
-async function teardown(sb: Sandbox): Promise<void> {
-  await raceWithTimeout(() => sb.terminate(), TEARDOWN_TIMEOUT_MS, "sb.terminate");
+async function teardown(handle: ModalHandle): Promise<void> {
+  try {
+    await terminateAndWait(handle.modal, handle.sandbox, "sb.terminate");
+    await publishCacheMarkers(handle.cachePublication);
+  } finally {
+    await raceWithTimeout(() => handle.output.stop(), OUTPUT_STOP_TIMEOUT_MS, "sandbox output stop").catch(
+      (cause) => log("warn", `sandbox output cleanup did not finish: ${errorMessage(cause)}`),
+    );
+  }
+}
+
+async function cacheMarkerExists(
+  modal: ModalClient,
+  markerName: string,
+  deadline: number,
+  label: string,
+): Promise<boolean> {
+  try {
+    await withBudget(deadline, `volumes.fromName(${label} marker)`, () =>
+      modal.volumes.fromName(markerName),
+    );
+    log("info", `${label} cache marker found: ${markerName}`);
+    return true;
+  } catch (cause) {
+    if (cause instanceof NotFoundError || /not\s*found/i.test(errorMessage(cause))) {
+      log("info", `${label} cache marker absent; this run will publish it after verified teardown`);
+      return false;
+    }
+    throw cause;
+  }
+}
+
+async function publishCacheMarkers(publication: CachePublication | null): Promise<void> {
+  if (publication === null || !publication.verified || publication.markerNames.length === 0) return;
+  try {
+    await raceWithTimeout(
+      () =>
+        Promise.all(
+          publication.markerNames.map((name) =>
+            publication.modal.volumes.fromName(name, { createIfMissing: true }),
+          ),
+        ),
+      CACHE_MARKER_TIMEOUT_MS,
+      "cache marker publication",
+    );
+    log("info", `published cache markers: ${publication.markerNames.join(", ")}`);
+  } catch (cause) {
+    // The billed box is already gone. A missing marker only costs another conservative warmup;
+    // never turn successful teardown into a process failure for optional metadata publication.
+    log("warn", `cache marker publication failed; cache remains conservative: ${errorMessage(cause)}`);
+  }
 }
 
 /**
  * Best-effort orphan sweep for the create-timeout race (#330-1): if `sandboxes.create` threw but
- * Modal actually created the sandbox, that sandbox carries our unique `sandboxName`. Look it up by
- * name within the cookbook App and terminate it. Bounded (`TEARDOWN_TIMEOUT_MS`) and fully swallowed
- * — it must NEVER throw (the caller is about to rethrow the original create error, which is the
- * signal rag-rat acts on); it only logs. A `NotFoundError` from `fromName` is the EXPECTED happy
- * case (create never actually made a box) and is logged as info, not an error.
+ * Modal actually created the sandbox, that sandbox carries our `sandboxName` and owner tag. Look it
+ * up by name within the cookbook App and terminate it only when the tag matches this invocation.
+ * This matters for deterministic cache-lock names: an unrelated active owner must survive our
+ * failed create. The sweep is bounded (`TEARDOWN_TIMEOUT_MS`) and fully swallowed — it must NEVER
+ * throw (the caller is about to rethrow the original create error, which is the signal rag-rat acts
+ * on); it only logs. A `NotFoundError` from `fromName` is the EXPECTED happy case (create never
+ * actually made a box) and is logged as info, not an error.
  */
-async function sweepOrphanByName(modal: ModalClient, sandboxName: string): Promise<void> {
+async function sweepOrphanByName(
+  modal: ModalClient,
+  sandboxName: string,
+  expectedOwnerId: string,
+): Promise<void> {
   try {
     const orphan = await raceWithTimeout(
       () => modal.sandboxes.fromName(APP_NAME, sandboxName),
       TEARDOWN_TIMEOUT_MS,
       "sandboxes.fromName(orphan sweep)",
     );
-    await terminateOrphanSandbox(orphan, sandboxName, "orphan sweep");
+    const tags = await raceWithTimeout(
+      () => orphan.getTags(),
+      TEARDOWN_TIMEOUT_MS,
+      "orphan.getTags",
+    );
+    if (tags[OWNER_TAG] !== expectedOwnerId) {
+      log("info", `orphan sweep: sandbox "${sandboxName}" belongs to another invocation; leaving it running`);
+      return;
+    }
+    await terminateOrphanSandbox(modal, orphan, sandboxName, "orphan sweep");
   } catch (cause) {
     // fromName raises NotFoundError when no sandbox with that name exists — the common case (create
     // never made one). Distinguish it from a real failure so the log isn't alarming.
@@ -290,23 +473,46 @@ async function sweepOrphanByName(modal: ModalClient, sandboxName: string): Promi
 }
 
 async function terminateOrphanSandbox(
+  modal: ModalClient,
   orphan: Sandbox,
   sandboxName: string,
   source: string,
 ): Promise<void> {
   try {
-    await raceWithTimeout(
-      () => orphan.terminate(),
-      TEARDOWN_TIMEOUT_MS,
-      `${source}.terminate`,
-    );
+    await terminateAndWait(modal, orphan, `${source}.terminate`);
     log("warn", `${source}: terminated leaked sandbox "${sandboxName}" (${orphan.sandboxId})`);
   } catch (cause) {
     log("error", `${source}: could not terminate leaked sandbox "${sandboxName}": ${errorMessage(cause)}`);
   }
 }
 
-const recipe: Recipe<Sandbox> = {
+async function terminateAndWait(modal: ModalClient, sandbox: Sandbox, label: string): Promise<void> {
+  const deadline = Date.now() + TEARDOWN_TIMEOUT_MS;
+  const sandboxId = sandbox.sandboxId;
+  await withBudget(deadline, label, () => sandbox.terminate());
+  const attached = await withBudget(deadline, `${label}.reattach`, () => modal.sandboxes.fromId(sandboxId));
+  while ((await withBudget(deadline, `${label}.poll`, () => attached.poll())) === null) {
+    await new Promise((resolve) => setTimeout(resolve, Math.min(250, assertBudgetRemaining(deadline, label))));
+  }
+}
+
+function modalSdkLogger(): ModalLogger {
+  const emit = (level: "info" | "warn" | "error", message: string, args: unknown[]): void => {
+    const details = args
+      .slice(0, 8)
+      .map((value) => (value instanceof Error ? value.message : String(value)))
+      .join(" ");
+    log(level, safeDiagnostic(`Modal SDK: ${message}${details === "" ? "" : ` ${details}`}`));
+  };
+  return {
+    debug: (message, ...args) => emit("info", message, args),
+    info: (message, ...args) => emit("info", message, args),
+    warn: (message, ...args) => emit("warn", message, args),
+    error: (message, ...args) => emit("error", message, args),
+  };
+}
+
+const recipe: Recipe<ModalHandle> = {
   provider: "modal",
   defaultProvisionTimeoutS: DEFAULT_PROVISION_TIMEOUT_S,
   provision,

--- a/cookbook/recipes/modal.mts
+++ b/cookbook/recipes/modal.mts
@@ -48,6 +48,7 @@ import {
   errorMessage,
   log,
   raceWithTimeout,
+  remainingBudgetMs,
   runRecipe,
   verifyChat,
   verifyEmbed,
@@ -108,19 +109,19 @@ const APP_NAME = "rag-rat-cookbook";
 /** GPU attached when a backend REQUIRES one (vLLM) and the caller passed no `gpu`. */
 const MODAL_DEFAULT_GPU = "A10G";
 /**
- * Bound on the teardown `sb.terminate()` — kept under the Rust side's ~10s teardown grace (like
- * RunPod's `TEARDOWN_TIMEOUT_MS`) so terminate completes-or-aborts BEFORE rag-rat SIGKILLs us; a
- * hung terminate would otherwise leak a billed box until Modal's `timeoutMs` backstop fires.
+ * Bound on the recipe-side teardown path (terminate + shutdown poll + optional marker publication +
+ * stream cleanup), kept under Rust's 10s SIGTERM→SIGKILL grace so all of it completes-or-aborts
+ * before the process group is killed.
  */
-const TEARDOWN_TIMEOUT_MS = 8_000;
+const TEARDOWN_TIMEOUT_MS = 9_000;
 /** Briefly allow final startup diagnostics to arrive after readiness rejects. */
 const FAILURE_LOG_SETTLE_MS = 250;
 /** Keeps the complete JSON-escaped error event below Rust's 16 KiB line cap. */
 const READINESS_DIAGNOSTIC_BYTES = 7 * 1024;
 /** Bound stream cancellation after the remote box has terminated. */
-const OUTPUT_STOP_TIMEOUT_MS = 500;
-/** Marker publication is metadata-only and must not consume the Rust teardown grace. */
-const CACHE_MARKER_TIMEOUT_MS = 1_000;
+const OUTPUT_STOP_TIMEOUT_MS = 250;
+/** Marker publication is metadata-only and must fit in the post-termination teardown remainder. */
+const CACHE_MARKER_TIMEOUT_MS = 500;
 const OWNER_TAG = "rag-rat-owner";
 
 interface CachePublication {
@@ -377,13 +378,17 @@ async function pullOllamaModel(
  * a billed box. Idempotent enough — terminate on an already-gone box is a no-op/soft error.
  */
 async function teardown(handle: ModalHandle): Promise<void> {
+  const deadline = Date.now() + TEARDOWN_TIMEOUT_MS;
   try {
-    await terminateAndWait(handle.modal, handle.sandbox, "sb.terminate");
-    await publishCacheMarkers(handle.cachePublication);
+    await terminateAndWait(handle.modal, handle.sandbox, "sb.terminate", deadline);
+    await publishCacheMarkers(handle.cachePublication, deadline);
   } finally {
-    await raceWithTimeout(() => handle.output.stop(), OUTPUT_STOP_TIMEOUT_MS, "sandbox output stop").catch(
-      (cause) => log("warn", `sandbox output cleanup did not finish: ${errorMessage(cause)}`),
-    );
+    const stopMs = Math.min(OUTPUT_STOP_TIMEOUT_MS, remainingBudgetMs(deadline));
+    if (stopMs > 0) {
+      await raceWithTimeout(() => handle.output.stop(), stopMs, "sandbox output stop").catch(
+        (cause) => log("warn", `sandbox output cleanup did not finish: ${errorMessage(cause)}`),
+      );
+    }
   }
 }
 
@@ -408,8 +413,16 @@ async function cacheMarkerExists(
   }
 }
 
-async function publishCacheMarkers(publication: CachePublication | null): Promise<void> {
+async function publishCacheMarkers(
+  publication: CachePublication | null,
+  deadline: number,
+): Promise<void> {
   if (publication === null || !publication.verified || publication.markerNames.length === 0) return;
+  const budgetMs = Math.min(CACHE_MARKER_TIMEOUT_MS, remainingBudgetMs(deadline));
+  if (budgetMs === 0) {
+    log("warn", "cache marker publication skipped: teardown grace exhausted");
+    return;
+  }
   try {
     await raceWithTimeout(
       () =>
@@ -418,7 +431,7 @@ async function publishCacheMarkers(publication: CachePublication | null): Promis
             publication.modal.volumes.fromName(name, { createIfMissing: true }),
           ),
         ),
-      CACHE_MARKER_TIMEOUT_MS,
+      budgetMs,
       "cache marker publication",
     );
     log("info", `published cache markers: ${publication.markerNames.join(", ")}`);
@@ -486,8 +499,12 @@ async function terminateOrphanSandbox(
   }
 }
 
-async function terminateAndWait(modal: ModalClient, sandbox: Sandbox, label: string): Promise<void> {
-  const deadline = Date.now() + TEARDOWN_TIMEOUT_MS;
+async function terminateAndWait(
+  modal: ModalClient,
+  sandbox: Sandbox,
+  label: string,
+  deadline = Date.now() + TEARDOWN_TIMEOUT_MS,
+): Promise<void> {
   const sandboxId = sandbox.sandboxId;
   await withBudget(deadline, label, () => sandbox.terminate());
   const attached = await withBudget(deadline, `${label}.reattach`, () => modal.sandboxes.fromId(sandboxId));

--- a/cookbook/recipes/modal.mts
+++ b/cookbook/recipes/modal.mts
@@ -267,7 +267,14 @@ async function provision(ctx: ProvisionContext<ModalHandle>): Promise<Provisione
     const pendingCreate = createRef.promise;
     if (pendingCreate !== undefined) {
       void pendingCreate.then(
-        (lateSandbox: Sandbox) => terminateOrphanSandbox(modal, lateSandbox, sandboxName, "late create"),
+        (lateSandbox: Sandbox) =>
+          terminateOrphanSandbox(
+            modal,
+            lateSandbox,
+            sandboxName,
+            "late create",
+            Date.now() + TEARDOWN_TIMEOUT_MS,
+          ),
         (lateCause: unknown) => {
           log(
             "info",
@@ -457,22 +464,23 @@ async function sweepOrphanByName(
   sandboxName: string,
   expectedOwnerId: string,
 ): Promise<void> {
+  const deadline = Date.now() + TEARDOWN_TIMEOUT_MS;
   try {
     const orphan = await raceWithTimeout(
       () => modal.sandboxes.fromName(APP_NAME, sandboxName),
-      TEARDOWN_TIMEOUT_MS,
+      remainingBudgetMs(deadline),
       "sandboxes.fromName(orphan sweep)",
     );
     const tags = await raceWithTimeout(
       () => orphan.getTags(),
-      TEARDOWN_TIMEOUT_MS,
+      remainingBudgetMs(deadline),
       "orphan.getTags",
     );
     if (tags[OWNER_TAG] !== expectedOwnerId) {
       log("info", `orphan sweep: sandbox "${sandboxName}" belongs to another invocation; leaving it running`);
       return;
     }
-    await terminateOrphanSandbox(modal, orphan, sandboxName, "orphan sweep");
+    await terminateOrphanSandbox(modal, orphan, sandboxName, "orphan sweep", deadline);
   } catch (cause) {
     // fromName raises NotFoundError when no sandbox with that name exists — the common case (create
     // never made one). Distinguish it from a real failure so the log isn't alarming.
@@ -490,9 +498,10 @@ async function terminateOrphanSandbox(
   orphan: Sandbox,
   sandboxName: string,
   source: string,
+  deadline: number,
 ): Promise<void> {
   try {
-    await terminateAndWait(modal, orphan, `${source}.terminate`);
+    await terminateAndWait(modal, orphan, `${source}.terminate`, deadline);
     log("warn", `${source}: terminated leaked sandbox "${sandboxName}" (${orphan.sandboxId})`);
   } catch (cause) {
     log("error", `${source}: could not terminate leaked sandbox "${sandboxName}": ${errorMessage(cause)}`);
@@ -506,10 +515,17 @@ async function terminateAndWait(
   deadline = Date.now() + TEARDOWN_TIMEOUT_MS,
 ): Promise<void> {
   const sandboxId = sandbox.sandboxId;
-  await withBudget(deadline, label, () => sandbox.terminate());
-  const attached = await withBudget(deadline, `${label}.reattach`, () => modal.sandboxes.fromId(sandboxId));
-  while ((await withBudget(deadline, `${label}.poll`, () => attached.poll())) === null) {
-    await new Promise((resolve) => setTimeout(resolve, Math.min(250, assertBudgetRemaining(deadline, label))));
+  await withBudget(deadline, label, () => sandbox.terminate(), 1);
+  const attached = await withBudget(
+    deadline,
+    `${label}.reattach`,
+    () => modal.sandboxes.fromId(sandboxId),
+    1,
+  );
+  while ((await withBudget(deadline, `${label}.poll`, () => attached.poll(), 1)) === null) {
+    const remainingMs = remainingBudgetMs(deadline);
+    if (remainingMs <= 0) throw new Error(`"${label}" exceeded its teardown budget while polling`);
+    await new Promise((resolve) => setTimeout(resolve, Math.min(250, remainingMs)));
   }
 }
 

--- a/cookbook/test/modal-support.test.mts
+++ b/cookbook/test/modal-support.test.mts
@@ -1,0 +1,169 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { LogLevel } from "../src/contract.js";
+import { selectBackendSpec } from "../recipes/backends.mjs";
+import {
+  HF_CACHE_MOUNT_PATH,
+  modalCacheEnvironment,
+  modalCacheSandboxName,
+  modalCacheVolumeName,
+  modalHfReadyMarkerName,
+  safeDiagnostic,
+  startSandboxOutputCapture,
+  vllmCachePlan,
+} from "../recipes/modal-support.mjs";
+
+function stream(chunks: readonly string[], stayOpen = false): ReadableStream<string> {
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(chunk);
+      if (!stayOpen) controller.close();
+    },
+  });
+}
+
+test("cache names are stable, model-scoped, and do not expose model ids", () => {
+  const model = "private-org/secret-model";
+  const name = modalCacheVolumeName(model);
+  assert.equal(name, modalCacheVolumeName(model));
+  assert.notEqual(name, modalCacheVolumeName("other/model"));
+  assert.equal(name.includes(model), false);
+  assert.match(name, /^rag-rat-hf-[a-f0-9]{24}$/);
+  assert.match(modalHfReadyMarkerName(model, "vo-123"), /^rag-rat-hf-ready-[a-f0-9]{24}$/);
+  assert.notEqual(modalHfReadyMarkerName(model, "vo-123"), modalHfReadyMarkerName(model, "vo-456"));
+  assert.match(
+    modalCacheSandboxName(modalCacheVolumeName(model)),
+    /^rag-rat-cookbook-cache-[a-f0-9]{24}$/,
+  );
+  assert.equal(HF_CACHE_MOUNT_PATH, "/cache/huggingface");
+});
+
+test("vLLM cache plans include provider compatibility inputs", () => {
+  const args = ["org/model", "--runner", "pooling"];
+  const plan = vllmCachePlan("org/model", "image@sha256:one", "A10G", "embed", args, "vo-1");
+  assert.deepEqual(
+    plan,
+    vllmCachePlan("org/model", "image@sha256:one", "A10G", "embed", args, "vo-1"),
+  );
+  assert.match(plan.rootPath, /^\/cache\/huggingface\/vllm\/[a-f0-9]{24}$/);
+  assert.match(plan.markerName, /^rag-rat-vllm-ready-[a-f0-9]{24}$/);
+  assert.notEqual(
+    plan.markerName,
+    vllmCachePlan("org/model", "image@sha256:one", "L4", "embed", ["org/model"], "vo-1")
+      .markerName,
+  );
+  assert.notEqual(
+    plan.markerName,
+    vllmCachePlan("org/model", "image@sha256:one", "A10G", "embed", args, "vo-2").markerName,
+  );
+});
+
+test("cache environment enables persistent AOT reuse with normal fallback", () => {
+  const plan = vllmCachePlan(
+    "org/model",
+    "image@sha256:one",
+    "A10G",
+    "embed",
+    ["org/model"],
+    "vo-1",
+  );
+  assert.deepEqual(modalCacheEnvironment(plan), {
+    HF_HOME: "/cache/huggingface",
+    VLLM_CACHE_ROOT: plan.rootPath,
+    VLLM_USE_AOT_COMPILE: "1",
+    VLLM_USE_MEGA_AOT_ARTIFACT: "0",
+  });
+  assert.equal("VLLM_FORCE_AOT_LOAD" in modalCacheEnvironment(plan), false);
+});
+
+test("infinity CPU avoids persisting non-portable optimum artifacts", async () => {
+  const spec = selectBackendSpec("infinity");
+  const cpuArgs = await spec.entrypointArgs({ model: "org/model", backend: "infinity" });
+  assert.deepEqual(cpuArgs, [
+    "v2",
+    "--model-id",
+    "org/model",
+    "--engine",
+    "torch",
+    "--device",
+    "cpu",
+    "--port",
+    "7997",
+  ]);
+
+  const gpuArgs = await spec.entrypointArgs({ model: "org/model", backend: "infinity", gpu: "A10G" });
+  assert.equal(gpuArgs.includes("--engine"), false);
+});
+
+test("capture joins chunks, redacts secrets, and retains useful failure context", async () => {
+  const events: { level: LogLevel; message: string }[] = [];
+  const capture = startSandboxOutputCapture(
+    stream(["loading hf_abcd", "efgh1234\nready\n"]),
+    stream(["Authorization: Bearer secret-value\n"]),
+    (level, message) => events.push({ level, message }),
+  );
+  await capture.stop();
+
+  assert.deepEqual(
+    events.map((event) => event.message).sort(),
+    [
+      "sandbox stderr: Authorization: [REDACTED]",
+      "sandbox stdout: loading hf_[REDACTED]",
+      "sandbox stdout: ready",
+    ].sort(),
+  );
+  assert.ok(events.every((event) => event.level === "info"));
+  assert.match(capture.failureTail(), /loading hf_\[REDACTED\]/);
+  assert.doesNotMatch(capture.failureTail(), /secret-value|hf_abcdefgh1234/);
+});
+
+test("capture bounds long lines and forwarding while continuing to drain", async () => {
+  const events: { level: LogLevel; message: string }[] = [];
+  const chunks = Array.from({ length: 20 }, (_, index) => `${index}:${"x".repeat(5000)}\n`);
+  const capture = startSandboxOutputCapture(stream(chunks), stream([]), (level, message) =>
+    events.push({ level, message }),
+  );
+  await capture.stop();
+
+  assert.equal(events.filter((event) => event.level === "warn").length, 1);
+  assert.match(events.at(-1)?.message ?? "", /continuing to drain silently/);
+  assert.ok(Buffer.byteLength(capture.failureTail()) <= 8 * 1024);
+  assert.ok(events.every((event) => Buffer.byteLength(event.message) < 5 * 1024));
+});
+
+test("post-redaction diagnostics remain bounded and redact signed URLs", () => {
+  const repeatedTokens = Array.from({ length: 300 }, () => "Bearer x").join(" ");
+  const bounded = safeDiagnostic(repeatedTokens, 1024);
+  assert.ok(Buffer.byteLength(bounded) <= 1024);
+  assert.match(bounded, /\[truncated\]$/);
+  assert.doesNotMatch(bounded, /Bearer x/);
+
+  const signed = safeDiagnostic(
+    "https://user:pass@example.com/model?X-Amz-Credential=abc&X-Amz-Signature=secret Authorization: Basic abc",
+  );
+  assert.doesNotMatch(signed, /user:pass|=abc|=secret|Basic abc/);
+  assert.match(signed, /\[REDACTED\]/);
+
+  const diagnostic = safeDiagnostic(`failure ${"\\\"\t".repeat(5000)}`, 7 * 1024);
+  const event = JSON.stringify({ type: "error", message: `sandbox readiness failed: ${diagnostic}`, ts: 0 });
+  assert.ok(Buffer.byteLength(event) < 16 * 1024);
+});
+
+test("capture can be stopped while long-lived sandbox streams remain open", async () => {
+  const capture = startSandboxOutputCapture(stream(["booted\n"], true), stream([], true), () => {});
+  await capture.settle(0);
+  await capture.stop();
+  assert.equal(capture.failureTail(), "sandbox stdout: booted");
+});
+
+test("a locked stream cannot create an unhandled pump rejection", async () => {
+  const locked = stream([], true);
+  const owner = locked.getReader();
+  const capture = startSandboxOutputCapture(locked, stream([]), () => {});
+  await capture.settle(0);
+  await capture.stop();
+  await owner.cancel();
+  owner.releaseLock();
+  assert.equal(capture.failureTail(), "");
+});

--- a/cookbook/tsconfig.test.json
+++ b/cookbook/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["test/**/*.mts", "recipes/backends.mts", "recipes/modal-support.mts", "src/contract.ts"]
+}


### PR DESCRIPTION
## Summary
- persist model-scoped Hugging Face caches for Modal infinity and vLLM Sandboxes
- persist namespaced vLLM AOT/Inductor artifacts with advisory completion markers and normal recompilation fallback
- harden bounded JSONL diagnostics, owner-safe concurrency exclusion, and teardown-before-marker publication
- force infinity CPU onto portable torch artifacts, add cookbook tests to npm release validation, and bump `@rag-rat/cookbook` to `0.8.0`

## Verification
- `npm run typecheck`
- `npm test` (9 passed)
- `npm run build`
- `npm pack --dry-run`
- `cargo nextest run -p rag-rat-llm -E 'test(cookbook)'` (29 passed)\n- `git diff --check`\n- live Modal infinity producer and marker-backed consumer runs\n- live Modal vLLM producer and marker-backed consumer runs; consumer loaded the compiled graph and AOT artifact\n- confirmed no Modal containers remained after teardown\n\nCloses #690