### PR TITLE
feat(distill): add extraction-owned source and unit snapshots

### DIFF
--- a/crates/rag-rat-core/src/distill/extract.rs
+++ b/crates/rag-rat-core/src/distill/extract.rs
@@ -22,25 +22,17 @@ use crate::distill::{units, validate};
 
 /// Bumped whenever the extraction/prompt contract changes in a way that invalidates existing
 /// records — part of the regeneration identity alongside `distill_input_hash`.
-pub(crate) const PIPELINE_VERSION: i64 = 1;
-
-/// Default byte budget for a thread's assembled units (head+tail retained, middle dropped).
-const DEFAULT_MAX_THREAD_BYTES: usize = 26_000;
+pub(crate) const PIPELINE_VERSION: i64 = 2;
 
 /// Knobs for one extraction pass.
 pub(crate) struct ExtractOptions {
     pub pipeline_version: i64,
-    pub max_thread_bytes: usize,
     pub anchor_caps: AnchorCaps,
 }
 
 impl Default for ExtractOptions {
     fn default() -> Self {
-        Self {
-            pipeline_version: PIPELINE_VERSION,
-            max_thread_bytes: DEFAULT_MAX_THREAD_BYTES,
-            anchor_caps: AnchorCaps::default(),
-        }
+        Self { pipeline_version: PIPELINE_VERSION, anchor_caps: AnchorCaps::default() }
     }
 }
 
@@ -320,6 +312,114 @@ struct WriteOutcome {
     mechanical_status: OutcomeStatus,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SourceRole {
+    Primary,
+    Partner,
+}
+
+impl SourceRole {
+    fn as_db_str(self) -> &'static str {
+        match self {
+            Self::Primary => "primary",
+            Self::Partner => "partner",
+        }
+    }
+
+    #[cfg_attr(not(test), allow(dead_code, reason = "the drain will hydrate persisted snapshots"))]
+    fn from_db_str(value: &str) -> anyhow::Result<Self> {
+        match value {
+            "primary" => Ok(Self::Primary),
+            "partner" => Ok(Self::Partner),
+            other => anyhow::bail!("unknown distill source role `{other}`"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SourceKind {
+    Item,
+    Comment,
+}
+
+impl SourceKind {
+    fn as_db_str(self) -> &'static str {
+        match self {
+            Self::Item => "item",
+            Self::Comment => "comment",
+        }
+    }
+
+    #[cfg_attr(not(test), allow(dead_code, reason = "the drain will hydrate persisted snapshots"))]
+    fn from_db_str(value: &str) -> anyhow::Result<Self> {
+        match value {
+            "item" => Ok(Self::Item),
+            "comment" => Ok(Self::Comment),
+            other => anyhow::bail!("unknown distill source kind `{other}`"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SourcePart {
+    Title,
+    Body,
+    Comment,
+}
+
+impl SourcePart {
+    fn as_db_str(self) -> &'static str {
+        match self {
+            Self::Title => "title",
+            Self::Body => "body",
+            Self::Comment => "comment",
+        }
+    }
+
+    #[cfg_attr(not(test), allow(dead_code, reason = "the drain will hydrate persisted snapshots"))]
+    fn from_db_str(value: &str) -> anyhow::Result<Self> {
+        match value {
+            "title" => Ok(Self::Title),
+            "body" => Ok(Self::Body),
+            "comment" => Ok(Self::Comment),
+            other => anyhow::bail!("unknown distill source part `{other}`"),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct ThreadSnapshot {
+    sources: Vec<SnapshotSource>,
+    units: Vec<SnapshotUnit>,
+}
+
+#[derive(Debug)]
+struct SnapshotSource {
+    ordinal: usize,
+    role: SourceRole,
+    partner_ordinal: Option<usize>,
+    item_kind: ItemKind,
+    item_key: String,
+    kind: SourceKind,
+    part: SourcePart,
+    /// Item sources use their item key; comment sources use the provider-qualified comment id.
+    /// Together with `(source_item_kind, source_item_key, source_kind, source_part)` this is an
+    /// unambiguous identity even when title and body text are byte-identical.
+    id: String,
+    exact_text: String,
+    author: Option<String>,
+    author_kind: Option<String>,
+    author_association: Option<String>,
+    created_at_ms: Option<i64>,
+}
+
+#[derive(Debug)]
+struct SnapshotUnit {
+    ordinal: usize,
+    source_ordinal: usize,
+    span: units::Span,
+}
+
 /// Assemble and persist one record: units → hash, fixing commits, coalesced edges, anchor
 /// candidates, status floors, the skeleton row, and the queue entry.
 fn write_record(
@@ -338,18 +438,10 @@ fn write_record(
             anyhow::anyhow!("record item {}#{} vanished mid-pass", plan.kind.as_db_str(), plan.key)
         })?;
 
-    // --- Text assembly: record TITLE + body + comments, then each partner's title + body +
-    // comments, in order. The title leads because for a thin/empty-body thread it IS the problem
-    // statement, and it must ride the regeneration hash so a title-only edit re-distills. Alongside
-    // the text we collect an ordered provenance stream (source id + author association): #704
-    // snapshots per-unit provenance and gates the decision floor on maintainer authorship, so a
-    // provenance-only change (a new comment, a re-associated author) must regenerate even when
-    // the text is identical.
-    let mut blobs: Vec<String> = vec![item.title.clone(), item.body.clone()];
-    let mut provenance: Vec<(String, Option<String>)> = vec![(
-        format!("{}/{}#item", plan.kind.as_db_str(), plan.key),
-        item.author_association.clone(),
-    )];
+    // Snapshot exact source rows before deriving anything lossy. The snapshot, its hash, and the
+    // skeleton are committed in this extraction transaction, so later mirror LWW edits cannot make
+    // a model citation point at different bytes.
+    let snapshot = build_thread_snapshot(conn, repo_id, plan, item, by_key)?;
     // Body length spans the whole coalesced thread (issue + partner PRs), so a thin issue body with
     // a substantial partner PR is not misclassified `thin`.
     let mut body_len = item.body.len();
@@ -357,10 +449,6 @@ fn write_record(
         load_comments(conn, repo_id, &plan.tracker, &plan.project, plan.kind, &plan.key)?;
     let mut total_comments = record_comments.len();
     let mut review_comments = record_comments.iter().filter(|c| c.is_review).count();
-    for comment in &record_comments {
-        blobs.push(comment.body.clone());
-        provenance.push((comment.comment_id.clone(), comment.author_association.clone()));
-    }
     for partner in &plan.partners {
         let partner_id = (
             plan.tracker.clone(),
@@ -369,12 +457,6 @@ fn write_record(
             partner.clone(),
         );
         if let Some(pr) = by_key.get(&partner_id) {
-            blobs.push(pr.title.clone());
-            blobs.push(pr.body.clone());
-            provenance.push((
-                format!("{}/{partner}#item", ItemKind::ChangeRequest.as_db_str()),
-                pr.author_association.clone(),
-            ));
             body_len += pr.body.len();
         }
         let partner_comments = load_comments(
@@ -387,13 +469,7 @@ fn write_record(
         )?;
         total_comments += partner_comments.len();
         review_comments += partner_comments.iter().filter(|c| c.is_review).count();
-        for comment in &partner_comments {
-            blobs.push(comment.body.clone());
-            provenance.push((comment.comment_id.clone(), comment.author_association.clone()));
-        }
     }
-    // Segment every blob into units, budget the concatenation head+tail, keep the retained texts.
-    let unit_texts = budgeted_unit_texts(&blobs, opts.max_thread_bytes);
 
     let changed_paths = changed_paths_for(conn, repo_id, repo, &plan.fix_shas)?;
     // The closing-keyword floor comes from the canonical parser's text-tier closing edge
@@ -452,10 +528,11 @@ fn write_record(
 
     let input_hash = compute_input_hash(&HashInputs {
         pipeline_version: opts.pipeline_version,
+        repo_id,
         plan,
-        unit_texts: &unit_texts,
+        snapshot: &snapshot,
         changed_paths: &changed_paths,
-        provenance: &provenance,
+        thread_shape: thread_shape.as_db_str(),
         revert_override,
         closing_keyword,
         anchors: &anchors,
@@ -484,6 +561,9 @@ fn write_record(
         revert_override,
         closing_keyword,
     })?;
+    if state != RecordState::Unchanged {
+        replace_snapshot(conn, repo_id, plan, &snapshot)?;
+    }
     write_commits(conn, repo_id, plan, &plan.fix_shas)?;
     write_coalesced_edges(conn, repo_id, now, plan)?;
     if rebuild_anchor_candidates {
@@ -497,117 +577,219 @@ fn write_record(
     Ok(WriteOutcome { queued, mechanical_status })
 }
 
-/// Segment each blob into block units, then apply the tail-aware budget across the concatenation,
-/// returning the retained unit texts in source order.
-fn budgeted_unit_texts(blobs: &[String], max_total: usize) -> Vec<String> {
-    let mut texts: Vec<String> = Vec::new();
-    for blob in blobs {
-        for span in units::segment_blocks(blob) {
-            texts.push(span.slice(blob).to_string());
-        }
-    }
-    let spans: Vec<units::Span> = {
-        // Re-express the retained texts as contiguous spans purely to reuse the budget planner.
-        let mut offset = 0usize;
-        texts
-            .iter()
-            .map(|t| {
-                let s = units::Span { start: offset, end: offset + t.len() };
-                offset += t.len();
-                s
-            })
-            .collect()
-    };
-    let plan = units::tail_aware_budget(&spans, max_total);
-    plan.kept.into_iter().map(|i| texts[i].clone()).collect()
-}
-
 /// Everything that folds into a record's regeneration identity.
 struct HashInputs<'a> {
     pipeline_version: i64,
+    repo_id: &'a str,
     plan: &'a RecordPlan,
-    unit_texts: &'a [String],
+    snapshot: &'a ThreadSnapshot,
     changed_paths: &'a [String],
-    provenance: &'a [(String, Option<String>)],
+    thread_shape: &'a str,
     revert_override: bool,
     closing_keyword: Option<&'a str>,
     anchors: &'a [candidates::AnchorCandidate],
 }
 
-/// The regeneration identity: pipeline version, the record's kind/key, coalesce partners, retained
-/// unit texts, per-source provenance, sorted changed-file selection, fix-edge source + SHAs, and
-/// the computed mechanical status floors. Any change re-derives a new hash, which the natural-key
-/// upsert treats as a fresh record — so a floor that flips later (a landed revert ref arrives, or a
-/// fix commit's message becomes available and yields a closing keyword) re-queues the record for
-/// #704.
+/// The regeneration identity: pipeline version, full record identity, the complete exact source
+/// snapshot and every unit span, sorted changed-file selection, fix-edge source + SHAs, and the
+/// computed mechanical status floors. Prompt budgeting is deliberately absent: truncation cannot
+/// hide a mutable source edit from regeneration.
 fn compute_input_hash(inputs: &HashInputs<'_>) -> String {
     let HashInputs {
         pipeline_version,
+        repo_id,
         plan,
-        unit_texts,
+        snapshot,
         changed_paths,
-        provenance,
+        thread_shape,
         revert_override,
         closing_keyword,
         anchors,
     } = inputs;
     let mut hasher = Sha256::new();
+    hash_str(&mut hasher, "rag-rat-distill-input-v2");
     hasher.update(pipeline_version.to_le_bytes());
-    hasher
-        .update([plan.kind.as_db_str().as_bytes(), b"\x1f", plan.key.as_bytes(), b"\x1e"].concat());
-    for partner in &plan.partners {
-        hasher.update(partner.as_bytes());
-        hasher.update(b"\x1f");
+    hash_str(&mut hasher, repo_id);
+    hash_str(&mut hasher, &plan.tracker);
+    hash_str(&mut hasher, &plan.project);
+    hash_str(&mut hasher, plan.kind.as_db_str());
+    hash_str(&mut hasher, &plan.key);
+    hash_str(&mut hasher, "sources");
+    hasher.update((snapshot.sources.len() as u64).to_le_bytes());
+    for source in &snapshot.sources {
+        hasher.update((source.ordinal as u64).to_le_bytes());
+        hash_str(&mut hasher, source.role.as_db_str());
+        hash_optional_u64(&mut hasher, source.partner_ordinal.map(|value| value as u64));
+        hash_str(&mut hasher, source.item_kind.as_db_str());
+        hash_str(&mut hasher, &source.item_key);
+        hash_str(&mut hasher, source.kind.as_db_str());
+        hash_str(&mut hasher, source.part.as_db_str());
+        hash_str(&mut hasher, &source.id);
+        hash_str(&mut hasher, &source.exact_text);
+        hash_optional_str(&mut hasher, source.author.as_deref());
+        hash_optional_str(&mut hasher, source.author_kind.as_deref());
+        hash_optional_str(&mut hasher, source.author_association.as_deref());
+        hash_optional_i64(&mut hasher, source.created_at_ms);
     }
-    hasher.update(b"\x1e");
-    for text in *unit_texts {
-        hasher.update(text.as_bytes());
-        hasher.update(b"\x1f");
+    hash_str(&mut hasher, "units");
+    hasher.update((snapshot.units.len() as u64).to_le_bytes());
+    for unit in &snapshot.units {
+        hasher.update((unit.ordinal as u64).to_le_bytes());
+        hasher.update((unit.source_ordinal as u64).to_le_bytes());
+        hasher.update((unit.span.start as u64).to_le_bytes());
+        hasher.update((unit.span.end as u64).to_le_bytes());
     }
-    // Ordered source identity + author association: a new/removed comment or a re-associated author
-    // (which #704 snapshots and gates the decision floor on) regenerates even with identical text.
-    hasher.update(b"\x1e");
-    for (source_id, association) in *provenance {
-        hasher.update(source_id.as_bytes());
-        hasher.update(b"\x1f");
-        hasher.update(association.as_deref().unwrap_or("").as_bytes());
-        hasher.update(b"\x1f");
-    }
-    hasher.update(b"\x1e");
+    hash_str(&mut hasher, "changed_paths");
     let mut sorted = changed_paths.to_vec();
     sorted.sort();
+    hasher.update((sorted.len() as u64).to_le_bytes());
     for path in sorted {
-        hasher.update(path.as_bytes());
-        hasher.update(b"\x1f");
+        hash_str(&mut hasher, &path);
     }
     // Mechanical fix-edge inputs + computed status floors: a changed closing edge / merge SHA (same
     // files), a flipped provenance tier, or a floor that flips later must invalidate the model's
     // decision/outcome even when the thread text is identical.
-    hasher.update(b"\x1e");
-    hasher.update(plan.fix_edge_source.as_db_str().as_bytes());
+    hash_str(&mut hasher, "status_inputs");
+    hash_str(&mut hasher, plan.fix_edge_source.as_db_str());
+    hash_str(&mut hasher, thread_shape);
     hasher.update([*revert_override as u8]);
-    hasher.update(closing_keyword.unwrap_or("").as_bytes());
-    hasher.update(b"\x1e");
+    hash_optional_str(&mut hasher, *closing_keyword);
+    hash_str(&mut hasher, "fix_commits");
     let mut shas = plan.fix_shas.clone();
     shas.sort();
+    hasher.update((shas.len() as u64).to_le_bytes());
     for sha in shas {
-        hasher.update(sha.as_bytes());
-        hasher.update(b"\x1f");
+        hash_str(&mut hasher, &sha);
     }
     // Anchor candidate set: #704 selects anchors from this pool, so a reindex that resolves new
     // logical symbols (candidates absent at first extraction, present after) must re-queue the
     // record. Hash each candidate's identity; mining order is already deterministic.
-    hasher.update(b"\x1e");
+    hash_str(&mut hasher, "anchors");
+    hasher.update((anchors.len() as u64).to_le_bytes());
     for anchor in *anchors {
-        hasher.update(anchor.kind.as_db_str().as_bytes());
-        hasher.update(b"\x1f");
-        hasher.update(anchor.logical_symbol_id.as_deref().unwrap_or("").as_bytes());
-        hasher.update(b"\x1f");
-        hasher.update(anchor.name.as_bytes());
-        hasher.update(b"\x1f");
+        hash_str(&mut hasher, anchor.kind.as_db_str());
+        hash_optional_str(&mut hasher, anchor.logical_symbol_id.as_deref());
+        hash_optional_str(&mut hasher, anchor.file_path.as_deref());
+        hash_str(&mut hasher, &anchor.name);
+        hasher.update([anchor.resolved as u8]);
     }
     let hex: String = hasher.finalize().iter().map(|byte| format!("{byte:02x}")).collect();
     format!("sha256:{hex}")
+}
+
+fn hash_str(hasher: &mut Sha256, value: &str) {
+    hasher.update((value.len() as u64).to_le_bytes());
+    hasher.update(value.as_bytes());
+}
+
+fn hash_optional_str(hasher: &mut Sha256, value: Option<&str>) {
+    hasher.update([u8::from(value.is_some())]);
+    if let Some(value) = value {
+        hash_str(hasher, value);
+    }
+}
+
+fn hash_optional_i64(hasher: &mut Sha256, value: Option<i64>) {
+    hasher.update([u8::from(value.is_some())]);
+    if let Some(value) = value {
+        hasher.update(value.to_le_bytes());
+    }
+}
+
+fn hash_optional_u64(hasher: &mut Sha256, value: Option<u64>) {
+    hasher.update([u8::from(value.is_some())]);
+    if let Some(value) = value {
+        hasher.update(value.to_le_bytes());
+    }
+}
+
+fn build_thread_snapshot(
+    conn: &Connection,
+    repo_id: &str,
+    plan: &RecordPlan,
+    primary: &ItemRow,
+    by_key: &BTreeMap<(String, String, &'static str, String), &ItemRow>,
+) -> anyhow::Result<ThreadSnapshot> {
+    let mut snapshot = ThreadSnapshot { sources: Vec::new(), units: Vec::new() };
+    append_item_snapshot(
+        &mut snapshot,
+        SourceRole::Primary,
+        None,
+        primary,
+        load_comments(conn, repo_id, &plan.tracker, &plan.project, primary.kind, &primary.key)?,
+    );
+    for (partner_ordinal, partner_key) in plan.partners.iter().enumerate() {
+        let partner_identity = (
+            plan.tracker.clone(),
+            plan.project.clone(),
+            ItemKind::ChangeRequest.as_db_str(),
+            partner_key.clone(),
+        );
+        let partner = by_key.get(&partner_identity).copied().ok_or_else(|| {
+            anyhow::anyhow!("coalesced partner change_request#{partner_key} vanished mid-pass")
+        })?;
+        append_item_snapshot(
+            &mut snapshot,
+            SourceRole::Partner,
+            Some(partner_ordinal),
+            partner,
+            load_comments(conn, repo_id, &plan.tracker, &plan.project, partner.kind, &partner.key)?,
+        );
+    }
+    Ok(snapshot)
+}
+
+fn append_item_snapshot(
+    snapshot: &mut ThreadSnapshot,
+    role: SourceRole,
+    partner_ordinal: Option<usize>,
+    item: &ItemRow,
+    comments: Vec<CommentRow>,
+) {
+    for (part, exact_text) in
+        [(SourcePart::Title, item.title.clone()), (SourcePart::Body, item.body.clone())]
+    {
+        append_snapshot_source(snapshot, SnapshotSource {
+            ordinal: snapshot.sources.len(),
+            role,
+            partner_ordinal,
+            item_kind: item.kind,
+            item_key: item.key.clone(),
+            kind: SourceKind::Item,
+            part,
+            id: item.key.clone(),
+            exact_text,
+            author: item.author.clone(),
+            author_kind: item.author_kind.clone(),
+            author_association: item.author_association.clone(),
+            created_at_ms: item.created_at_ms,
+        });
+    }
+    for comment in comments {
+        append_snapshot_source(snapshot, SnapshotSource {
+            ordinal: snapshot.sources.len(),
+            role,
+            partner_ordinal,
+            item_kind: item.kind,
+            item_key: item.key.clone(),
+            kind: SourceKind::Comment,
+            part: SourcePart::Comment,
+            id: comment.comment_id,
+            exact_text: comment.body,
+            author: comment.author,
+            author_kind: comment.author_kind,
+            author_association: comment.author_association,
+            created_at_ms: comment.created_at_ms,
+        });
+    }
+}
+
+fn append_snapshot_source(snapshot: &mut ThreadSnapshot, source: SnapshotSource) {
+    let source_ordinal = source.ordinal;
+    for span in units::segment_blocks(&source.exact_text) {
+        snapshot.units.push(SnapshotUnit { ordinal: snapshot.units.len(), source_ordinal, span });
+    }
+    snapshot.sources.push(source);
 }
 
 // ── Loaders ────────────────────────────────────────────────────────────────────────────────────
@@ -621,13 +803,20 @@ struct ItemRow {
     body: String,
     state_normalized: String,
     merge_commit_sha: Option<String>,
+    author: Option<String>,
+    author_kind: Option<String>,
     author_association: Option<String>,
+    created_at_ms: Option<i64>,
 }
 
 fn load_items(conn: &Connection, repo_id: &str) -> anyhow::Result<Vec<ItemRow>> {
     let mut stmt = conn.prepare(
         "SELECT item_kind, item_key, tracker, project, title, body, state_normalized,
-                merge_commit_sha, author_association
+                merge_commit_sha, author, author_kind, author_association,
+                CASE WHEN created_at IS NULL THEN NULL ELSE
+                    CAST(strftime('%s', created_at) AS INTEGER) * 1000 +
+                    CAST(substr(strftime('%f', created_at), 4, 3) AS INTEGER)
+                END
          FROM papertrail_items WHERE repo_id = ?1",
     )?;
     let rows = stmt.query_map([repo_id], |row| {
@@ -641,7 +830,10 @@ fn load_items(conn: &Connection, repo_id: &str) -> anyhow::Result<Vec<ItemRow>> 
             body: row.get(5)?,
             state_normalized: row.get(6)?,
             merge_commit_sha: row.get(7)?,
-            author_association: row.get(8)?,
+            author: row.get(8)?,
+            author_kind: row.get(9)?,
+            author_association: row.get(10)?,
+            created_at_ms: row.get(11)?,
         })
     })?;
     let mut out = Vec::new();
@@ -688,7 +880,10 @@ struct CommentRow {
     comment_id: String,
     body: String,
     is_review: bool,
+    author: Option<String>,
+    author_kind: Option<String>,
     author_association: Option<String>,
+    created_at_ms: Option<i64>,
 }
 
 fn load_comments(
@@ -700,7 +895,12 @@ fn load_comments(
     key: &str,
 ) -> anyhow::Result<Vec<CommentRow>> {
     let mut stmt = conn.prepare(
-        "SELECT comment_id, body, review_state, author_association FROM papertrail_comments
+        "SELECT comment_id, body, review_state, author, author_kind, author_association,
+                CASE WHEN created_at IS NULL THEN NULL ELSE
+                    CAST(strftime('%s', created_at) AS INTEGER) * 1000 +
+                    CAST(substr(strftime('%f', created_at), 4, 3) AS INTEGER)
+                END
+         FROM papertrail_comments
          WHERE repo_id = ?1 AND tracker = ?2 AND project = ?3 AND item_kind = ?4 AND item_key = ?5
          ORDER BY created_at, comment_id",
     )?;
@@ -710,7 +910,10 @@ fn load_comments(
                 comment_id: row.get(0)?,
                 body: row.get(1)?,
                 is_review: row.get::<_, Option<String>>(2)?.is_some(),
-                author_association: row.get(3)?,
+                author: row.get(3)?,
+                author_kind: row.get(4)?,
+                author_association: row.get(5)?,
+                created_at_ms: row.get(6)?,
             })
         })?;
     let mut out = Vec::new();
@@ -891,6 +1094,8 @@ fn delete_record(conn: &Connection, repo_id: &str, record: &RecordKey) -> anyhow
         "papertrail_distill_evidence",
         "papertrail_distill_alternatives",
         "papertrail_distill_queue",
+        "papertrail_distill_sources",
+        "papertrail_distill_units",
     ] {
         conn.execute(
             &format!(
@@ -987,8 +1192,10 @@ fn upsert_skeleton(
              epistemic_status_outcome = CASE WHEN ?14 THEN NULL ELSE epistemic_status_outcome END,
              quotes_materialized = CASE WHEN ?14 THEN 0 ELSE quotes_materialized END,
              outcome_claim_verified = CASE WHEN ?14 THEN 0 ELSE outcome_claim_verified END,
-             decision_provenance_verified =
-                 CASE WHEN ?14 THEN 0 ELSE decision_provenance_verified END",
+              decision_provenance_verified =
+                  CASE WHEN ?14 THEN 0 ELSE decision_provenance_verified END,
+              prompt_version = CASE WHEN ?14 THEN NULL ELSE prompt_version END,
+              model_input_hash = CASE WHEN ?14 THEN NULL ELSE model_input_hash END",
         params![
             plan.tracker,
             plan.project,
@@ -1058,6 +1265,73 @@ fn clear_model_junctions(
                  item_kind = ?4 AND item_key = ?5"
             ),
             params![repo_id, plan.tracker, plan.project, plan.kind.as_db_str(), plan.key],
+        )?;
+    }
+    Ok(())
+}
+
+fn replace_snapshot(
+    conn: &Connection,
+    repo_id: &str,
+    plan: &RecordPlan,
+    snapshot: &ThreadSnapshot,
+) -> anyhow::Result<()> {
+    for table in ["papertrail_distill_units", "papertrail_distill_sources"] {
+        conn.execute(
+            &format!(
+                "DELETE FROM {table} WHERE repo_id = ?1 AND tracker = ?2 AND project = ?3 AND \
+                 item_kind = ?4 AND item_key = ?5"
+            ),
+            params![repo_id, plan.tracker, plan.project, plan.kind.as_db_str(), plan.key],
+        )?;
+    }
+    for source in &snapshot.sources {
+        conn.execute(
+            "INSERT INTO papertrail_distill_sources
+                 (tracker, project, item_kind, item_key, source_ordinal, role, partner_ordinal,
+                  source_item_kind, source_item_key, source_kind, source_part, source_id,
+                  exact_text, author, author_kind, author_association, created_at_ms, repo_id)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15,
+                     ?16, ?17, ?18)",
+            params![
+                plan.tracker,
+                plan.project,
+                plan.kind.as_db_str(),
+                plan.key,
+                source.ordinal as i64,
+                source.role.as_db_str(),
+                source.partner_ordinal.map(|value| value as i64),
+                source.item_kind.as_db_str(),
+                source.item_key,
+                source.kind.as_db_str(),
+                source.part.as_db_str(),
+                source.id,
+                source.exact_text,
+                source.author,
+                source.author_kind,
+                source.author_association,
+                source.created_at_ms,
+                repo_id,
+            ],
+        )?;
+    }
+    for unit in &snapshot.units {
+        conn.execute(
+            "INSERT INTO papertrail_distill_units
+                 (tracker, project, item_kind, item_key, unit_ordinal, source_ordinal, byte_start,
+                  byte_end, repo_id)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+            params![
+                plan.tracker,
+                plan.project,
+                plan.kind.as_db_str(),
+                plan.key,
+                unit.ordinal as i64,
+                unit.source_ordinal as i64,
+                unit.span.start as i64,
+                unit.span.end as i64,
+                repo_id,
+            ],
         )?;
     }
     Ok(())
@@ -1213,7 +1487,7 @@ mod tests {
     use rag_rat_db::schema;
     use rusqlite::{Connection, params};
 
-    use super::{ExtractOptions, enqueue_eligible, extract};
+    use super::{ExtractOptions, SourceKind, SourcePart, SourceRole, enqueue_eligible, extract};
 
     /// A fully-migrated in-memory DB scoped to `repo`, via the same `temp.connection_context` write
     /// `install_scope_view` uses (the multi-repo-scope test convention).
@@ -1364,6 +1638,15 @@ mod tests {
 
     fn distill_count(conn: &Connection, sql: &str) -> i64 {
         conn.query_row(sql, [], |row| row.get(0)).unwrap()
+    }
+
+    fn input_hash(conn: &Connection, key: &str) -> String {
+        conn.query_row(
+            "SELECT distill_input_hash FROM papertrail_distill WHERE item_key = ?1",
+            [key],
+            |row| row.get(0),
+        )
+        .unwrap()
     }
 
     #[test]
@@ -1674,6 +1957,26 @@ mod tests {
         seed_item(&conn, "repoA", "issue", "5", "A's bug.", "closed", None);
         seed_item(&conn, "repoB", "issue", "5", "B's bug.", "closed", None);
         seed_item(&conn, "repoB", "change_request", "6", "B's PR.", "merged", Some("beef"));
+        // Poison an identically-keyed sibling snapshot: A's replacement/clear paths must scope by
+        // the complete record identity, not merely tracker/project/kind/key.
+        conn.execute(
+            "INSERT INTO papertrail_distill_sources
+                 (tracker, project, item_kind, item_key, source_ordinal, role, partner_ordinal,
+                  source_item_kind, source_item_key, source_kind, source_part, source_id,
+                  exact_text, repo_id)
+             VALUES ('github','o/r','issue','5',0,'primary',NULL,'issue','5','item','body','5',
+                     'B poison','repoB')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO papertrail_distill_units
+                 (tracker, project, item_kind, item_key, unit_ordinal, source_ordinal, byte_start,
+                  byte_end, repo_id)
+             VALUES ('github','o/r','issue','5',0,0,0,8,'repoB')",
+            [],
+        )
+        .unwrap();
 
         let report = extract(&conn, None, &ExtractOptions::default()).unwrap();
         assert_eq!(report.records_written, 1, "only repo A's single item");
@@ -1690,6 +1993,209 @@ mod tests {
             ),
             0,
         );
+        let sibling_text: String = conn
+            .query_row(
+                "SELECT exact_text FROM papertrail_distill_sources WHERE repo_id='repoB'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(sibling_text, "B poison", "the sibling snapshot survives A extraction");
+        assert_eq!(
+            distill_count(
+                &conn,
+                "SELECT COUNT(*) FROM papertrail_distill_units WHERE repo_id='repoB'"
+            ),
+            1,
+            "the sibling unit span survives A extraction",
+        );
+    }
+
+    #[test]
+    fn snapshot_source_enums_round_trip_only_their_closed_tokens() {
+        for role in [SourceRole::Primary, SourceRole::Partner] {
+            assert_eq!(SourceRole::from_db_str(role.as_db_str()).unwrap(), role);
+        }
+        for kind in [SourceKind::Item, SourceKind::Comment] {
+            assert_eq!(SourceKind::from_db_str(kind.as_db_str()).unwrap(), kind);
+        }
+        for part in [SourcePart::Title, SourcePart::Body, SourcePart::Comment] {
+            assert_eq!(SourcePart::from_db_str(part.as_db_str()).unwrap(), part);
+        }
+        assert!(SourcePart::from_db_str("summary").is_err());
+    }
+
+    #[test]
+    fn snapshots_distinguish_identical_title_and_body_and_unicode_units_quote_exact_bytes() {
+        let conn = scoped_conn("repoA");
+        let text = "Intro 🦀.\n\n尾 paragraph.";
+        seed_item(&conn, "repoA", "issue", "5", text, "closed", None);
+        conn.execute(
+            "UPDATE papertrail_items SET title=?1, author='alice', author_kind='user',
+                    author_association='member', created_at='2026-01-01T00:00:00.123Z'
+             WHERE repo_id='repoA' AND item_key='5'",
+            [text],
+        )
+        .unwrap();
+        extract(&conn, None, &ExtractOptions::default()).unwrap();
+
+        let sources: Vec<(i64, String, String, String)> = conn
+            .prepare(
+                "SELECT source_ordinal, source_part, source_id, exact_text
+                 FROM papertrail_distill_sources WHERE repo_id='repoA' ORDER BY source_ordinal",
+            )
+            .unwrap()
+            .query_map([], |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)))
+            .unwrap()
+            .collect::<Result<_, _>>()
+            .unwrap();
+        assert_eq!(sources.len(), 2);
+        assert_eq!(&sources[0], &(0, "title".into(), "5".into(), text.into()));
+        assert_eq!(&sources[1], &(1, "body".into(), "5".into(), text.into()));
+
+        let units: Vec<(i64, i64, i64)> = conn
+            .prepare(
+                "SELECT source_ordinal, byte_start, byte_end FROM papertrail_distill_units
+                 WHERE repo_id='repoA' ORDER BY unit_ordinal",
+            )
+            .unwrap()
+            .query_map([], |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)))
+            .unwrap()
+            .collect::<Result<_, _>>()
+            .unwrap();
+        assert_eq!(units.len(), 4, "two markdown blocks for each distinct source part");
+        for (source_ordinal, start, end) in units {
+            let source_ordinal = source_ordinal as usize;
+            let start = start as usize;
+            let end = end as usize;
+            let exact = &sources[source_ordinal].3;
+            let quote = &exact[start..end];
+            assert_eq!(quote.as_bytes(), &exact.as_bytes()[start..end]);
+            assert!(std::str::from_utf8(quote.as_bytes()).is_ok(), "span is on UTF-8 boundaries");
+        }
+    }
+
+    #[test]
+    fn every_source_text_or_provenance_edit_changes_the_full_snapshot_hash() {
+        let conn = scoped_conn("repoA");
+        seed_item(&conn, "repoA", "issue", "5", "body one", "closed", None);
+        extract(&conn, None, &ExtractOptions::default()).unwrap();
+        let initial = input_hash(&conn, "5");
+
+        conn.execute("UPDATE papertrail_items SET title='new title' WHERE item_key='5'", [])
+            .unwrap();
+        extract(&conn, None, &ExtractOptions::default()).unwrap();
+        let title_edit = input_hash(&conn, "5");
+        assert_ne!(initial, title_edit, "title-only edits regenerate");
+
+        conn.execute("UPDATE papertrail_items SET body='body two' WHERE item_key='5'", []).unwrap();
+        extract(&conn, None, &ExtractOptions::default()).unwrap();
+        let body_edit = input_hash(&conn, "5");
+        assert_ne!(title_edit, body_edit, "body-only edits regenerate");
+
+        seed_comment(&conn, "repoA", "issue", "5", "c1", false);
+        extract(&conn, None, &ExtractOptions::default()).unwrap();
+        let comment_added = input_hash(&conn, "5");
+        assert_ne!(body_edit, comment_added, "comments are full snapshot inputs");
+
+        conn.execute(
+            "UPDATE papertrail_comments SET body='edited comment' WHERE comment_id='c1'",
+            [],
+        )
+        .unwrap();
+        extract(&conn, None, &ExtractOptions::default()).unwrap();
+        let comment_edit = input_hash(&conn, "5");
+        assert_ne!(comment_added, comment_edit, "comment text edits regenerate");
+
+        conn.execute(
+            "UPDATE papertrail_comments SET author_association='maintainer' WHERE comment_id='c1'",
+            [],
+        )
+        .unwrap();
+        extract(&conn, None, &ExtractOptions::default()).unwrap();
+        let provenance_edit = input_hash(&conn, "5");
+        assert_ne!(comment_edit, provenance_edit, "provenance-only edits regenerate");
+    }
+
+    #[test]
+    fn all_partners_are_snapshotted_in_deterministic_key_order() {
+        let conn = scoped_conn("repoA");
+        seed_item(&conn, "repoA", "issue", "5", "issue", "closed", None);
+        seed_item(&conn, "repoA", "change_request", "8", "later", "merged", Some("m8"));
+        seed_item(&conn, "repoA", "change_request", "6", "earlier", "merged", Some("m6"));
+        seed_closing_edge(&conn, "repoA", "5", "8", Some("m8"), "provider");
+        seed_closing_edge(&conn, "repoA", "5", "6", Some("m6"), "provider");
+        extract(&conn, None, &ExtractOptions::default()).unwrap();
+
+        let partners: Vec<(i64, String)> = conn
+            .prepare(
+                "SELECT partner_ordinal, source_item_key FROM papertrail_distill_sources
+                 WHERE repo_id='repoA' AND role='partner' AND source_part='title'
+                 ORDER BY source_ordinal",
+            )
+            .unwrap()
+            .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+            .unwrap()
+            .collect::<Result<_, _>>()
+            .unwrap();
+        assert_eq!(partners, vec![(0, "6".into()), (1, "8".into())]);
+    }
+
+    #[test]
+    fn regeneration_replaces_snapshots_while_unchanged_reruns_leave_them_stable() {
+        let conn = scoped_conn("repoA");
+        seed_item(&conn, "repoA", "issue", "5", "first\n\nsecond", "closed", None);
+        extract(&conn, None, &ExtractOptions::default()).unwrap();
+        let first_ids: Vec<i64> = conn
+            .prepare("SELECT id FROM papertrail_distill_sources ORDER BY source_ordinal")
+            .unwrap()
+            .query_map([], |row| row.get(0))
+            .unwrap()
+            .collect::<Result<_, _>>()
+            .unwrap();
+        let first_hash = input_hash(&conn, "5");
+        extract(&conn, None, &ExtractOptions::default()).unwrap();
+        let unchanged_ids: Vec<i64> = conn
+            .prepare("SELECT id FROM papertrail_distill_sources ORDER BY source_ordinal")
+            .unwrap()
+            .query_map([], |row| row.get(0))
+            .unwrap()
+            .collect::<Result<_, _>>()
+            .unwrap();
+        assert_eq!(first_ids, unchanged_ids, "unchanged snapshots are left untouched");
+        assert_eq!(first_hash, input_hash(&conn, "5"));
+
+        conn.execute("UPDATE papertrail_items SET body='replacement' WHERE item_key='5'", [])
+            .unwrap();
+        extract(&conn, None, &ExtractOptions::default()).unwrap();
+        let body: String = conn
+            .query_row(
+                "SELECT exact_text FROM papertrail_distill_sources WHERE source_part='body'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(body, "replacement");
+        assert_ne!(first_hash, input_hash(&conn, "5"));
+        assert_eq!(
+            distill_count(
+                &conn,
+                "SELECT COUNT(*) FROM papertrail_distill_units WHERE source_ordinal=1"
+            ),
+            1,
+            "old body spans are replaced rather than appended",
+        );
+    }
+
+    #[test]
+    fn otherwise_identical_snapshots_have_repo_isolated_hashes() {
+        let conn_a = scoped_conn("repoA");
+        seed_item(&conn_a, "repoA", "issue", "5", "same", "closed", None);
+        extract(&conn_a, None, &ExtractOptions::default()).unwrap();
+        let conn_b = scoped_conn("repoB");
+        seed_item(&conn_b, "repoB", "issue", "5", "same", "closed", None);
+        extract(&conn_b, None, &ExtractOptions::default()).unwrap();
+        assert_ne!(input_hash(&conn_a, "5"), input_hash(&conn_b, "5"));
     }
 
     #[test]
@@ -2172,7 +2678,8 @@ mod tests {
         // Simulate the #704 pass filling model columns + model junctions on this record.
         conn.execute(
             "UPDATE papertrail_distill SET root_cause='the cause', outcome_status_model='landed',
-                 quotes_materialized=3 WHERE item_key='9'",
+                 quotes_materialized=3, prompt_version=7, model_input_hash='sha256:model'
+             WHERE item_key='9'",
             [],
         )
         .unwrap();
@@ -2209,6 +2716,15 @@ mod tests {
             })
             .unwrap();
         assert_eq!(cause.as_deref(), Some("the cause"), "identical rerun keeps model output");
+        let stamps: (Option<i64>, Option<String>) = conn
+            .query_row(
+                "SELECT prompt_version, model_input_hash FROM papertrail_distill WHERE \
+                 item_key='9'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(stamps, (Some(7), Some("sha256:model".into())));
         assert_eq!(distill_count(&conn, "SELECT COUNT(*) FROM papertrail_distill_evidence"), 1);
         assert_eq!(
             distill_count(
@@ -2229,6 +2745,15 @@ mod tests {
             })
             .unwrap();
         assert_eq!(cause_after, None, "regeneration NULLs the stale model columns");
+        let stamps_after: (Option<i64>, Option<String>) = conn
+            .query_row(
+                "SELECT prompt_version, model_input_hash FROM papertrail_distill WHERE \
+                 item_key='9'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(stamps_after, (None, None), "regeneration clears model-input stamps");
         assert_eq!(
             distill_count(&conn, "SELECT COUNT(*) FROM papertrail_distill_evidence"),
             0,

--- a/crates/rag-rat-core/src/distill/units.rs
+++ b/crates/rag-rat-core/src/distill/units.rs
@@ -7,8 +7,8 @@
 //! range — so a fenced code block (which contains blank lines) stays ONE unit instead of shattering
 //! the way a naive blank-line split would.
 //!
-//! This module is deterministic and model-free: it is exercised in Phase 1 to compute the
-//! regeneration hash over ordered spans, and reused at drain time (#704) to build the LLM input.
+//! This module is deterministic and model-free: extraction snapshots every ordered span, and drain
+//! time (#704) applies the prompt budget to those durable units.
 
 use pulldown_cmark::{Event, Options, Parser};
 
@@ -23,10 +23,12 @@ pub(crate) struct Span {
 impl Span {
     /// The exact source substring this span selects. Callers materialize quotes through here so the
     /// "quote == source substring" invariant holds by construction.
+    #[cfg_attr(not(test), allow(dead_code, reason = "the drain materializes snapshot quotes"))]
     pub(crate) fn slice(self, text: &str) -> &str {
         &text[self.start..self.end]
     }
 
+    #[cfg_attr(not(test), allow(dead_code, reason = "the drain applies the unit budget"))]
     fn len(self) -> usize {
         self.end - self.start
     }
@@ -109,6 +111,7 @@ fn push_trimmed(spans: &mut Vec<Span>, text: &str, start: usize, end: usize) {
 /// is kept past the limit (we never split a unit — that would break the span→quote invariant); any
 /// other over-budget set is trimmed, so even a two-unit thread (a short title + a huge body) cannot
 /// smuggle an arbitrarily large input past the budget.
+#[cfg_attr(not(test), allow(dead_code, reason = "the drain applies the unit budget"))]
 pub(crate) fn tail_aware_budget(spans: &[Span], max_total: usize) -> BudgetPlan {
     let total: usize = spans.iter().map(|s| s.len()).sum();
     if total <= max_total {
@@ -141,6 +144,7 @@ pub(crate) fn tail_aware_budget(spans: &[Span], max_total: usize) -> BudgetPlan 
     BudgetPlan { dropped: n - kept.len(), kept_bytes, kept }
 }
 
+#[cfg_attr(not(test), allow(dead_code, reason = "the drain applies the unit budget"))]
 fn try_grow(spans: &[Span], idx: usize, kept_bytes: &mut usize, max_total: usize) -> Option<()> {
     let next = *kept_bytes + spans[idx].len();
     if next <= max_total {

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_registry.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_registry.rs
@@ -214,6 +214,24 @@ fn register_repo_repoints_distill_rows_from_the_placeholder() {
         [LEGACY_REPO_ID],
     )
     .unwrap();
+    conn.execute(
+        "INSERT INTO papertrail_distill_sources
+             (tracker, project, item_kind, item_key, source_ordinal, role, partner_ordinal,
+              source_item_kind, source_item_key, source_kind, source_part, source_id, exact_text,
+              repo_id)
+         VALUES \
+         ('github','o/r','issue','5',0,'primary',NULL,'issue','5','item','body','5','body',?1)",
+        [LEGACY_REPO_ID],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO papertrail_distill_units
+             (tracker, project, item_kind, item_key, unit_ordinal, source_ordinal, byte_start,
+              byte_end, repo_id)
+         VALUES ('github','o/r','issue','5',0,0,0,4,?1)",
+        [LEGACY_REPO_ID],
+    )
+    .unwrap();
 
     register_repo(
         &conn,
@@ -228,6 +246,16 @@ fn register_repo_repoints_distill_rows_from_the_placeholder() {
         .query_row("SELECT repo_id FROM papertrail_distill WHERE item_key='5'", [], |r| r.get(0))
         .unwrap();
     assert_eq!(repo_id, "repo-abc", "the distill row is re-pointed to the adopted repo id");
+    for table in ["papertrail_distill_sources", "papertrail_distill_units"] {
+        let adopted: i64 = conn
+            .query_row(
+                &format!("SELECT COUNT(*) FROM {table} WHERE repo_id='repo-abc'"),
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(adopted, 1, "the snapshot table `{table}` is re-pointed too");
+    }
 }
 
 /// Re-applying the full schema AFTER adoption must NOT resurrect the `__unassigned__` placeholder.

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
@@ -2930,6 +2930,8 @@ fn migration_077_builds_the_distill_record_store() {
         "item_key",
         "distill_input_hash",
         "pipeline_version",
+        "prompt_version",
+        "model_input_hash",
         "root_issue",
         "root_cause",
         "root_cause_class",
@@ -3005,7 +3007,7 @@ fn migration_077_builds_the_distill_record_store() {
 }
 
 #[test]
-fn migration_078_is_the_tip_and_distinguishes_candidates_from_selections() {
+fn migration_078_distinguishes_candidates_from_selections() {
     #[derive(Debug, PartialEq, Eq)]
     struct UpgradedAnchor {
         item_key: String,
@@ -3014,8 +3016,6 @@ fn migration_078_is_the_tip_and_distinguishes_candidates_from_selections() {
         logical_symbol_id: Option<String>,
         file_path: Option<String>,
     }
-
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 78, "move this pin with the next schema migration");
 
     // Exercise the real V077 -> V078 upgrade with existing rows. Row-id order is the deterministic
     // tie-break within each thread; a second thread starts its own zero-based ordinal sequence.
@@ -3128,7 +3128,7 @@ fn migration_078_is_the_tip_and_distinguishes_candidates_from_selections() {
 
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     schema::apply(&conn, &crate::index::migration_hooks()).unwrap();
-    assert_eq!(schema::status(&conn).unwrap().current_version, 78);
+    assert_eq!(schema::status(&conn).unwrap().current_version, schema::LATEST_SCHEMA_VERSION);
     let v78_recorded: i64 = conn
         .query_row(
             "SELECT COUNT(*) FROM schema_version WHERE id = '078_distill_anchor_selection'",
@@ -3149,4 +3149,108 @@ fn migration_078_is_the_tip_and_distinguishes_candidates_from_selections() {
             .unwrap();
         assert_eq!(present, 1, "V078 index `{index}` exists");
     }
+}
+
+#[test]
+fn migration_079_is_the_tip_and_builds_safe_input_snapshots() {
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 79, "move this pin with the next schema migration");
+
+    let legacy = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply_distill_record_store(&legacy).unwrap();
+    schema::apply_distill_anchor_selection(&legacy).unwrap();
+    assert!(!conn_table_columns(&legacy, "papertrail_distill").contains(&"prompt_version".into()));
+    assert!(!schema::table_exists(&legacy, "papertrail_distill_sources").unwrap());
+
+    schema::apply_distill_safe_input_snapshot(&legacy).unwrap();
+    let distill_columns = conn_table_columns(&legacy, "papertrail_distill");
+    assert!(distill_columns.contains(&"prompt_version".into()));
+    assert!(distill_columns.contains(&"model_input_hash".into()));
+    for table in ["papertrail_distill_sources", "papertrail_distill_units"] {
+        assert!(schema::table_exists(&legacy, table).unwrap(), "V079 table `{table}` exists");
+    }
+
+    legacy
+        .execute(
+            "INSERT INTO papertrail_distill_sources
+                 (tracker, project, item_kind, item_key, source_ordinal, role, partner_ordinal,
+                  source_item_kind, source_item_key, source_kind, source_part, source_id,
+                  exact_text, repo_id)
+             VALUES ('github','o/r','issue','5',0,'primary',NULL,'issue','5','item','title','5',
+                     'same','repoA')",
+            [],
+        )
+        .unwrap();
+    legacy
+        .execute(
+            "INSERT INTO papertrail_distill_sources
+                 (tracker, project, item_kind, item_key, source_ordinal, role, partner_ordinal,
+                  source_item_kind, source_item_key, source_kind, source_part, source_id,
+                  exact_text, repo_id)
+             VALUES ('github','o/r','issue','5',0,'primary',NULL,'issue','5','item','title','5',
+                     'same','repoB')",
+            [],
+        )
+        .unwrap();
+    assert!(
+        legacy
+            .execute(
+                "INSERT INTO papertrail_distill_sources
+                     (tracker, project, item_kind, item_key, source_ordinal, role, partner_ordinal,
+                      source_item_kind, source_item_key, source_kind, source_part, source_id,
+                      exact_text, repo_id)
+                 VALUES ('github','o/r','issue','5',0,'primary',NULL,'issue','5','item','body','5',
+                         'same','repoA')",
+                [],
+            )
+            .is_err(),
+        "source ordinals are unique only inside the full repo-scoped record identity",
+    );
+    assert!(
+        legacy
+            .execute(
+                "INSERT INTO papertrail_distill_sources
+                     (tracker, project, item_kind, item_key, source_ordinal, role, partner_ordinal,
+                      source_item_kind, source_item_key, source_kind, source_part, source_id,
+                      exact_text, repo_id)
+                 VALUES ('github','o/r','issue','5',1,'partner',NULL,'change_request','6','item',
+                         'body','6','x','repoA')",
+                [],
+            )
+            .is_err(),
+        "partner sources require a partner ordinal",
+    );
+    assert!(
+        legacy
+            .execute(
+                "INSERT INTO papertrail_distill_units
+                     (tracker, project, item_kind, item_key, unit_ordinal, source_ordinal,
+                      byte_start, byte_end, repo_id)
+                 VALUES ('github','o/r','issue','5',0,0,4,4,'repoA')",
+                [],
+            )
+            .is_err(),
+        "unit spans are non-empty half-open byte ranges",
+    );
+
+    // Torn replay: both columns and the source table survived, while the unit table/index did not.
+    // The additive applier must converge without touching existing source rows.
+    legacy.execute_batch("DROP TABLE papertrail_distill_units;").unwrap();
+    schema::apply_distill_safe_input_snapshot(&legacy).unwrap();
+    assert!(schema::table_exists(&legacy, "papertrail_distill_units").unwrap());
+    let sources: i64 = legacy
+        .query_row("SELECT COUNT(*) FROM papertrail_distill_sources", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(sources, 2, "replay preserves existing snapshots");
+
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn, &crate::index::migration_hooks()).unwrap();
+    assert_eq!(schema::status(&conn).unwrap().current_version, 79);
+    let recorded: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM schema_version WHERE id = '079_distill_safe_input_snapshot'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(recorded, 1, "the forward migration records V079");
 }

--- a/crates/rag-rat-db/src/schema/migrations.rs
+++ b/crates/rag-rat-db/src/schema/migrations.rs
@@ -1327,6 +1327,7 @@ pub(crate) fn known_version(migrations: &[AppliedMigration]) -> u32 {
             MIGRATION_076_ID => Some(76),
             MIGRATION_077_ID => Some(77),
             MIGRATION_078_ID => Some(78),
+            MIGRATION_079_ID => Some(79),
             _ => None,
         })
         .max()
@@ -1414,6 +1415,7 @@ pub(crate) fn known_migration(id: &str) -> bool {
             | MIGRATION_076_ID
             | MIGRATION_077_ID
             | MIGRATION_078_ID
+            | MIGRATION_079_ID
             | DIRTY_MIGRATION_ID
     )
 }
@@ -1498,6 +1500,7 @@ pub(crate) fn migration_checksum_mismatch(migration: &AppliedMigration) -> bool 
         MIGRATION_076_ID => migration.checksum != MIGRATION_076_CHECKSUM,
         MIGRATION_077_ID => migration.checksum != MIGRATION_077_CHECKSUM,
         MIGRATION_078_ID => migration.checksum != MIGRATION_078_CHECKSUM,
+        MIGRATION_079_ID => migration.checksum != MIGRATION_079_CHECKSUM,
         _ => false,
     }
 }
@@ -5473,6 +5476,75 @@ pub fn apply_distill_anchor_selection(conn: &Connection) -> rusqlite::Result<()>
             ON papertrail_distill_anchors(
                 repo_id, tracker, project, item_kind, item_key, candidate_ordinal
             ) WHERE selected = 1;
+        ",
+    )
+}
+
+/// V079 — extraction-owned, immutable-for-one-input source and unit snapshots (#704).
+///
+/// There is deliberately no SQL backfill: old derived records must regenerate under the bumped
+/// extraction pipeline and snapshot the mirror rows read in that same transaction. Backfilling
+/// here would falsely attach today's mutable mirror text to an older `distill_input_hash`.
+pub fn apply_distill_safe_input_snapshot(conn: &Connection) -> rusqlite::Result<()> {
+    add_column_if_missing(conn, "papertrail_distill", "prompt_version", "INTEGER")?;
+    add_column_if_missing(conn, "papertrail_distill", "model_input_hash", "TEXT")?;
+    conn.execute_batch(
+        "
+        CREATE TABLE IF NOT EXISTS papertrail_distill_sources(
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            tracker TEXT NOT NULL,
+            project TEXT NOT NULL,
+            item_kind TEXT NOT NULL,
+            item_key TEXT NOT NULL,
+            source_ordinal INTEGER NOT NULL CHECK(source_ordinal >= 0),
+            role TEXT NOT NULL CHECK(role IN ('primary', 'partner')),
+            partner_ordinal INTEGER CHECK(partner_ordinal >= 0),
+            source_item_kind TEXT NOT NULL,
+            source_item_key TEXT NOT NULL,
+            source_kind TEXT NOT NULL CHECK(source_kind IN ('item', 'comment')),
+            source_part TEXT NOT NULL CHECK(source_part IN ('title', 'body', 'comment')),
+            source_id TEXT NOT NULL,
+            exact_text TEXT NOT NULL,
+            author TEXT,
+            author_kind TEXT,
+            author_association TEXT,
+            created_at_ms INTEGER,
+            repo_id TEXT NOT NULL DEFAULT '__unassigned__',
+            CHECK((role = 'primary' AND partner_ordinal IS NULL) OR
+                  (role = 'partner' AND partner_ordinal IS NOT NULL)),
+            CHECK((source_kind = 'item' AND source_part IN ('title', 'body')) OR
+                  (source_kind = 'comment' AND source_part = 'comment'))
+        ) STRICT;
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_papertrail_distill_sources_ordinal
+            ON papertrail_distill_sources(
+                repo_id, tracker, project, item_kind, item_key, source_ordinal
+            );
+        CREATE INDEX IF NOT EXISTS idx_papertrail_distill_sources_identity
+            ON papertrail_distill_sources(
+                repo_id, tracker, project, source_item_kind, source_item_key, source_kind, \
+         source_id
+            );
+
+        CREATE TABLE IF NOT EXISTS papertrail_distill_units(
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            tracker TEXT NOT NULL,
+            project TEXT NOT NULL,
+            item_kind TEXT NOT NULL,
+            item_key TEXT NOT NULL,
+            unit_ordinal INTEGER NOT NULL CHECK(unit_ordinal >= 0),
+            source_ordinal INTEGER NOT NULL CHECK(source_ordinal >= 0),
+            byte_start INTEGER NOT NULL CHECK(byte_start >= 0),
+            byte_end INTEGER NOT NULL CHECK(byte_end > byte_start),
+            repo_id TEXT NOT NULL DEFAULT '__unassigned__'
+        ) STRICT;
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_papertrail_distill_units_ordinal
+            ON papertrail_distill_units(
+                repo_id, tracker, project, item_kind, item_key, unit_ordinal
+            );
+        CREATE INDEX IF NOT EXISTS idx_papertrail_distill_units_source
+            ON papertrail_distill_units(
+                repo_id, tracker, project, item_kind, item_key, source_ordinal, unit_ordinal
+            );
         ",
     )
 }

--- a/crates/rag-rat-db/src/schema/mod.rs
+++ b/crates/rag-rat-db/src/schema/mod.rs
@@ -11,10 +11,10 @@ pub use migrations::{
     apply_account_candidate_dag, apply_clone_delta_maintenance, apply_clone_df_epoch,
     apply_clone_fingerprint_tables, apply_clone_graph_tables, apply_content_candidate_dag,
     apply_content_projected_tables, apply_content_streams_pending_refold,
-    apply_distill_anchor_selection, apply_distill_record_store, apply_dream_findings,
-    apply_edge_string_interning, apply_edge_target_qname_index, apply_external_symbols,
-    apply_files_generation, apply_files_has_test_code, apply_git_change_couplings,
-    apply_github_child_key_widening, apply_github_repo_id_scoping,
+    apply_distill_anchor_selection, apply_distill_record_store, apply_distill_safe_input_snapshot,
+    apply_dream_findings, apply_edge_string_interning, apply_edge_target_qname_index,
+    apply_external_symbols, apply_files_generation, apply_files_has_test_code,
+    apply_git_change_couplings, apply_github_child_key_widening, apply_github_repo_id_scoping,
     apply_memory_model_failures_table, apply_memory_verification_tables, apply_move_per_repo_meta,
     apply_oplog_device_identity, apply_oplog_device_x25519, apply_oplog_local_account,
     apply_oplog_storage, apply_oplog_stream_scoping, apply_oracle_tables,
@@ -44,7 +44,7 @@ use serde::Serialize;
 
 use crate::hooks::MigrationHooks;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 78;
+pub const LATEST_SCHEMA_VERSION: u32 = 79;
 
 /// Every oracle-DERIVED persisted table — the outputs an `oracle run` writes that must OUTLIVE a
 /// reindex.
@@ -576,6 +576,14 @@ const MIGRATION_078_DESCRIPTION: &str =
      deterministically backfill V077 rows in insertion order per thread; enforce ordinal \
      uniqueness and boolean selected values; index selected anchors. Additive; existing anchor \
      identity/path columns are unchanged";
+const MIGRATION_079_ID: &str = "079_distill_safe_input_snapshot";
+const MIGRATION_079_CHECKSUM: &str = "sha256:rag-rat-distill-safe-input-snapshot-v79";
+const MIGRATION_079_DESCRIPTION: &str =
+    "Add extraction-owned safe-input snapshots for distillation (issue #704): exact ordered \
+     title/body/comment sources with full thread and partner identity, provenance, timestamps, \
+     and every deterministic block-unit byte span; add prompt_version/model_input_hash \
+     model-output stamps. Additive and intentionally does not backfill snapshots from the mutable \
+     mirror";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -1235,6 +1243,12 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         checksum: MIGRATION_078_CHECKSUM,
         description: MIGRATION_078_DESCRIPTION,
         apply: MigrationFn::Plain(apply_distill_anchor_selection),
+    },
+    Migration {
+        id: MIGRATION_079_ID,
+        checksum: MIGRATION_079_CHECKSUM,
+        description: MIGRATION_079_DESCRIPTION,
+        apply: MigrationFn::Plain(apply_distill_safe_input_snapshot),
     },
 ];
 

--- a/crates/rag-rat-db/src/schema/registry.rs
+++ b/crates/rag-rat-db/src/schema/registry.rs
@@ -55,10 +55,10 @@ const DIRECT_SCOPED_ADOPTION_TABLES: &[&str] = &[
     // natural key from birth, so a LocalOnly→Portable adoption re-points its rows with the
     // rest of the papertrail family.
     "papertrail_closing_edges",
-    // V076 (#703): the distilled-record store — record row + junction children + work queue +
-    // run stats, all with direct `repo_id` in their keys from birth (no FK children between them),
-    // so a LocalOnly→Portable adoption re-points every one with the papertrail family. Omitting
-    // any would strand its rows under the retired id, invisible through the active scope.
+    // V077/V079 (#703/#704): the distilled-record store and safe-input snapshots — record row +
+    // junction children + work queue + run stats, all with direct `repo_id` in their keys from
+    // birth (no FK children between them), so a LocalOnly→Portable adoption re-points every one
+    // with the papertrail family. Omitting any would strand rows under the retired id.
     "papertrail_distill",
     "papertrail_distill_evidence",
     "papertrail_distill_anchors",
@@ -67,6 +67,8 @@ const DIRECT_SCOPED_ADOPTION_TABLES: &[&str] = &[
     "papertrail_distill_edges",
     "papertrail_distill_queue",
     "papertrail_distill_runs",
+    "papertrail_distill_sources",
+    "papertrail_distill_units",
     // V056 (#566) derived change-coupling table: standalone, direct `repo_id`, no FK children, so
     // a LocalOnly→Portable adoption re-points its rows here (moving them together with the
     // `git_coupling_stamp` repo_meta so the derived table stays consistent + fresh), and the


### PR DESCRIPTION
## Summary
- add V079 extraction-owned snapshots for exact title/body/comment text, provenance, partner identity, and deterministic unit byte spans
- distinguish title, body, and comment sources even when their text is identical
- hash the complete snapshot with length-prefixed framing and bump the extraction pipeline so pre-snapshot records regenerate
- persist snapshots atomically with the skeleton record and preserve unchanged snapshot row identity
- add prompt/model output stamps for the later model drain CAS boundary
- wire snapshot tables through repo adoption, reconciliation deletion, and repo-scoped purge coverage

Part of #704. This intentionally lands before model orchestration: the later drain will load these immutable snapshots, materialize quotes mechanically, and CAS the extraction hash/version after inference.

## Verification
- `cargo nextest run -p rag-rat-core` (1,442 passed before rebase)
- `cargo nextest run -p rag-rat-core distill::` (91 passed after rebase)
- schema/repo-registry focused suites (124 passed)
- `cargo clippy --workspace --all-targets --no-default-features --locked -- -D warnings`
- `cargo clippy -p rag-rat-db -p rag-rat-core --all-targets -- -D warnings`
- `cargo +nightly fmt`
- independent final review: no blockers