### PR TITLE
feat(distill): drain prepared snapshots through the configured chat model (#704)

### DIFF
--- a/crates/rag-rat-base/src/locks.rs
+++ b/crates/rag-rat-base/src/locks.rs
@@ -327,6 +327,14 @@ pub fn papertrail_marker_lock_path(database: &Path, repo_id: &str) -> PathBuf {
         .join(format!("rag-rat-papertrail-{}.pending.lock", lock_discriminator(repo_id)))
 }
 
+/// Per-DB, PER-REPO distill drain flight lock, held across one whole model-bound drain including
+/// ephemeral provisioning and inference. Separate from [`write_lock_path`]: the ordinary write
+/// lock covers only short extraction, preparation, and per-result persistence phases, so a model
+/// call never blocks unrelated repo writers.
+pub fn distill_lock_path(database: &Path, repo_id: &str) -> PathBuf {
+    lock_dir(database).join(format!("rag-rat-distill-{}.lock", lock_discriminator(repo_id)))
+}
+
 /// Per-DB, PER-REPO edit-driven reindex flight lock (#661), held by the one detached
 /// `rag-rat edit-reindex` runner for its whole scoped pass so a burst of PostToolUse edit hooks
 /// coalesces into a single scoped reindex instead of N serialized multi-second processes. Keyed by
@@ -810,6 +818,18 @@ mod tests {
         assert!(schema_lock_path(db).to_string_lossy().ends_with("rag-rat-schema.lock"));
         // A `local:`-prefixed id sanitizes to alphanumerics (the `:` is dropped), still per-repo.
         assert_eq!(write_lock_path(db, "local:abcdef01"), write_lock_path(db, "local:abcdef01"));
+    }
+
+    #[test]
+    fn distill_flight_lock_path_is_per_repo_and_distinct_from_sibling_locks() {
+        let db = Path::new("/repo/.rag-rat/index.sqlite");
+        let distill = distill_lock_path(db, "aaaa11112222");
+        assert_ne!(distill, distill_lock_path(db, "bbbb33334444"));
+        assert_eq!(distill, distill_lock_path(db, "aaaa11112222"));
+        assert!(distill.to_string_lossy().ends_with("rag-rat-distill-aaaa11112222.lock"));
+        assert_ne!(distill, write_lock_path(db, "aaaa11112222"));
+        assert_ne!(distill, papertrail_lock_path(db, "aaaa11112222"));
+        assert_ne!(distill, edit_reindex_lock_path(db, "aaaa11112222"));
     }
 
     #[cfg(unix)]

--- a/crates/rag-rat-cli/src/cli.rs
+++ b/crates/rag-rat-cli/src/cli.rs
@@ -732,6 +732,12 @@ pub(crate) enum DistillCommand {
     /// Run the deterministic extraction pass over the mirror: skeleton records, fixing commits,
     /// coalesced edges, anchor candidates, and the distill queue (model columns left for #704).
     Extract,
+    /// Run deterministic extraction, then drain prepared snapshots through the configured model.
+    Drain {
+        /// Maximum prepared threads to process in this run.
+        #[arg(long, default_value_t = 20, value_parser = clap::value_parser!(u32).range(1..))]
+        limit: u32,
+    },
 }
 
 #[derive(Debug, Args)]
@@ -873,6 +879,32 @@ mod tests {
             },
             other => panic!("expected hooks, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn distill_drain_limit_defaults_to_twenty_and_accepts_an_override() {
+        let default = Cli::try_parse_from(["rag-rat", "distill", "drain"]).expect("parse");
+        match default.command {
+            Command::Distill(DistillArgs { command: DistillCommand::Drain { limit } }) => {
+                assert_eq!(limit, 20);
+            },
+            other => panic!("expected distill drain, got {other:?}"),
+        }
+
+        let overridden =
+            Cli::try_parse_from(["rag-rat", "distill", "drain", "--limit", "7"]).expect("parse");
+        match overridden.command {
+            Command::Distill(DistillArgs { command: DistillCommand::Drain { limit } }) => {
+                assert_eq!(limit, 7);
+            },
+            other => panic!("expected distill drain, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn distill_drain_rejects_a_zero_limit() {
+        let err = Cli::try_parse_from(["rag-rat", "distill", "drain", "--limit", "0"]).unwrap_err();
+        assert_eq!(err.kind(), clap::error::ErrorKind::ValueValidation);
     }
 
     #[test]

--- a/crates/rag-rat-cli/src/commands/distill.rs
+++ b/crates/rag-rat-cli/src/commands/distill.rs
@@ -1,6 +1,4 @@
-//! `distill` command (#703): the deterministic, model-free distillation pass. Opens the index
-//! read-write (base-scoped, so anchor mining reads the correct symbol scope) and runs the
-//! extraction over the current mirror, reporting what it produced.
+//! Explicit distillation commands: deterministic extraction and the opt-in model queue drain.
 
 use rag_rat_base::config::Config;
 
@@ -24,5 +22,61 @@ pub(crate) fn distill(config: &Config, args: &DistillArgs) -> anyhow::Result<()>
             // is `Serialize`); TOON otherwise.
             print_output(&db.distill_extract()?)
         },
+        DistillCommand::Drain { limit } => drain(config, *limit),
     }
+}
+
+fn drain(config: &Config, limit: u32) -> anyhow::Result<()> {
+    let lock_repo = rag_rat_base::locks::write_lock_repo_id(config);
+    let _entry_flight_lock = rag_rat_base::locks::FileLock::acquire_blocking(
+        &rag_rat_base::locks::distill_lock_path(&config.database, &lock_repo),
+    )?;
+
+    // Keep the ordinary writer lock short: extraction and the prepared-work decision need it, but
+    // provisioning and inference can take minutes and are serialized by the flight lock instead.
+    let (pending, active_repo_id) = {
+        let _write_lock =
+            rag_rat_base::locks::WriteLock::acquire_blocking(&config.database, &lock_repo)?;
+        let db = open_index(config)?;
+        db.distill_extract()?;
+        let pending = db.distill_pending_count()?;
+        (pending, db.active_repo_id.clone())
+    };
+    // An identity upgrade during open can change the final repo discriminator. Retain both flight
+    // locks in that rare case so neither old-identity nor new-identity callers can overlap us.
+    let _resolved_flight_lock = (active_repo_id != lock_repo)
+        .then(|| {
+            rag_rat_base::locks::FileLock::acquire_blocking(
+                &rag_rat_base::locks::distill_lock_path(&config.database, &active_repo_id),
+            )
+        })
+        .transpose()?;
+
+    if pending == 0 {
+        return print_output(&rag_rat_core::distill::DistillDrainReport::default());
+    }
+    if !config.llm.distill.enabled {
+        anyhow::bail!(
+            "distill work is pending but `[llm.distill] enabled = false`; set `[llm.distill] \
+             enabled = true` to run the model drain"
+        );
+    }
+
+    // Reopen after dropping the short writer scope. In particular, do not retain an identity-
+    // upgrade WriteLock stored by the first config-bearing open across provisioning or inference.
+    let db = open_index(config)?;
+    anyhow::ensure!(
+        db.active_repo_id == active_repo_id,
+        "the repo identity changed while preparing the distill drain; re-run the command"
+    );
+    let remote = &config.llm.distill.remote;
+    let mut _provisioned = None;
+    let model = if remote.is_ephemeral() {
+        let (model, provisioned) = rag_rat_llm::chat::provision_chat_model(remote)?;
+        _provisioned = Some(provisioned);
+        model
+    } else {
+        rag_rat_llm::chat::HttpChatModel::from_config(remote)?
+    };
+    print_output(&db.distill_drain(&model, limit)?)
 }

--- a/crates/rag-rat-core/src/distill/drain.rs
+++ b/crates/rag-rat-core/src/distill/drain.rs
@@ -1,0 +1,1295 @@
+//! Queue drain for prepared distill snapshots.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use rag_rat_base::locks::WriteLock;
+use rag_rat_llm::chat::ChatModel;
+use rag_rat_papertrail::FixEdgeSource;
+use rusqlite::{Connection, OptionalExtension, params};
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+
+use super::output::{self, LadderFailure, LadderResult, LadderStats, RecordOutput};
+use super::prompts::{
+    self, AnchorContext, FixCommit, PartnerThread, PromptBudget, PromptInput, PromptUnit,
+    SymbolContext,
+};
+use super::{run_stats, validate};
+
+const MAX_STORED_ERROR_CHARS: usize = 2_000;
+const MAX_STORED_REPLY_CHARS: usize = 64_000;
+
+/// Aggregate result from one bounded queue drain.
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize)]
+pub struct DistillDrainReport {
+    pub threads: usize,
+    pub succeeded: usize,
+    pub failed: usize,
+    /// Model results rejected because extraction or queue identity changed during inference.
+    pub stale: usize,
+    pub rung_guided: u64,
+    pub rung_serde: u64,
+    pub rung_unguided: u64,
+    pub rung_tolerant: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ThreadKey {
+    tracker: String,
+    project: String,
+    item_kind: String,
+    item_key: String,
+}
+
+#[derive(Debug, Clone)]
+struct PreparedJob {
+    queue_id: i64,
+    enqueued_at_ms: i64,
+    attempts: i64,
+    key: ThreadKey,
+    distill_input_hash: String,
+    pipeline_version: i64,
+    prompt_version: u32,
+    fix_edge_source: FixEdgeSource,
+    closing_keyword: bool,
+    prompt_input: PromptInput,
+    units: Vec<UnitSnapshot>,
+    rendered_prompt: String,
+    schema: serde_json::Value,
+    model_input_hash: String,
+}
+
+struct PreparedIdentity {
+    queue_id: i64,
+    enqueued_at_ms: i64,
+    attempts: i64,
+    key: ThreadKey,
+    distill_input_hash: String,
+    pipeline_version: i64,
+    prompt_version: u32,
+    fix_edge_source: FixEdgeSource,
+    closing_keyword: bool,
+}
+
+#[derive(Debug, Clone)]
+struct SourceSnapshot {
+    ordinal: usize,
+    role: String,
+    partner_ordinal: Option<usize>,
+    item_kind: String,
+    item_key: String,
+    source_kind: String,
+    source_part: String,
+    source_id: String,
+    exact_text: String,
+    author: Option<String>,
+    author_kind: Option<String>,
+    author_association: Option<String>,
+    created_at_ms: Option<i64>,
+}
+
+#[derive(Debug, Clone)]
+struct UnitSnapshot {
+    ordinal: usize,
+    byte_start: usize,
+    byte_end: usize,
+    source: SourceSnapshot,
+}
+
+#[derive(Debug, Clone)]
+struct AnchorSnapshot {
+    ordinal: usize,
+    kind: String,
+    logical_symbol_id: Option<String>,
+    file_path: Option<String>,
+    name: String,
+    resolved: bool,
+}
+
+pub(crate) fn drain(
+    conn: &Connection,
+    database_path: &Path,
+    repo_id: &str,
+    model: &dyn ChatModel,
+    limit: usize,
+    run_at_ms: i64,
+) -> anyhow::Result<DistillDrainReport> {
+    let budget = PromptBudget::default();
+    // This read transaction ends before the first model call. Every job crossing that boundary is
+    // fully owned, including the exact source text used to materialize evidence later.
+    let jobs =
+        in_transaction(conn, "DEFERRED", || load_prepared_jobs(conn, repo_id, limit, &budget))?;
+    let mut report = DistillDrainReport { threads: jobs.len(), ..Default::default() };
+    let mut aggregate_stats = LadderStats::default();
+
+    for job in jobs {
+        let outcome = output::run_output_ladder(
+            model,
+            &job.rendered_prompt,
+            &job.schema,
+            &job.prompt_input,
+            &budget,
+        );
+        let stats = match &outcome {
+            Ok(result) => result.stats,
+            Err(failure) => failure.stats,
+        };
+        aggregate_stats.accumulate(stats);
+
+        // The flight lock excludes another drain. The ordinary writer lock serializes only this
+        // short state transition with extraction, indexing, and maintenance.
+        let _write_lock = WriteLock::acquire_blocking(database_path, repo_id)?;
+        let applied = match outcome {
+            Ok(result) => in_transaction(conn, "IMMEDIATE", || {
+                persist_success(conn, repo_id, &job, &result, &budget, run_at_ms)
+            })?,
+            Err(failure) => in_transaction(conn, "IMMEDIATE", || {
+                persist_failure(conn, repo_id, &job, &failure, &budget)
+            })?,
+        };
+        if !applied {
+            report.stale += 1;
+        } else if stats.failed == 1 {
+            report.failed += 1;
+        } else {
+            report.succeeded += 1;
+        }
+    }
+
+    report.rung_guided = aggregate_stats.rung_guided;
+    report.rung_serde = aggregate_stats.rung_serde;
+    report.rung_unguided = aggregate_stats.rung_unguided;
+    report.rung_tolerant = aggregate_stats.rung_tolerant;
+    let _write_lock = WriteLock::acquire_blocking(database_path, repo_id)?;
+    in_transaction(conn, "IMMEDIATE", || {
+        run_stats::record_distill_run(
+            conn,
+            repo_id,
+            run_at_ms,
+            u64::try_from(report.threads)?,
+            aggregate_stats,
+        )
+    })?;
+    Ok(report)
+}
+
+pub(crate) fn pending_count(conn: &Connection, repo_id: &str) -> anyhow::Result<u64> {
+    let count = conn.query_row(
+        "SELECT COUNT(*)
+         FROM papertrail_distill_queue q
+         JOIN papertrail_distill d
+           ON d.repo_id = q.repo_id AND d.tracker = q.tracker AND d.project = q.project
+          AND d.item_kind = q.item_kind AND d.item_key = q.item_key
+         WHERE q.repo_id = ?1
+           AND EXISTS (
+               SELECT 1 FROM papertrail_distill_sources s
+               WHERE s.repo_id = q.repo_id AND s.tracker = q.tracker AND s.project = q.project
+                 AND s.item_kind = q.item_kind AND s.item_key = q.item_key)",
+        [repo_id],
+        |row| row.get::<_, i64>(0),
+    )?;
+    Ok(u64::try_from(count)?)
+}
+
+fn load_prepared_jobs(
+    conn: &Connection,
+    repo_id: &str,
+    limit: usize,
+    budget: &PromptBudget,
+) -> anyhow::Result<Vec<PreparedJob>> {
+    let limit = i64::try_from(limit)?;
+    let mut stmt = conn.prepare(
+        "SELECT q.id, q.enqueued_at_ms, q.attempts, q.tracker, q.project, q.item_kind,
+                q.item_key, d.distill_input_hash, d.pipeline_version, d.fix_edge_source,
+                d.closing_keyword_floor
+         FROM papertrail_distill_queue q
+         JOIN papertrail_distill d
+           ON d.repo_id = q.repo_id AND d.tracker = q.tracker AND d.project = q.project
+          AND d.item_kind = q.item_kind AND d.item_key = q.item_key
+         WHERE q.repo_id = ?1
+           AND EXISTS (
+               SELECT 1 FROM papertrail_distill_sources s
+               WHERE s.repo_id = q.repo_id AND s.tracker = q.tracker AND s.project = q.project
+                 AND s.item_kind = q.item_kind AND s.item_key = q.item_key)
+         ORDER BY q.enqueued_at_ms, q.id
+         LIMIT ?2",
+    )?;
+    let rows = stmt.query_map(params![repo_id, limit], |row| {
+        Ok((
+            row.get::<_, i64>(0)?,
+            row.get::<_, i64>(1)?,
+            row.get::<_, i64>(2)?,
+            ThreadKey {
+                tracker: row.get(3)?,
+                project: row.get(4)?,
+                item_kind: row.get(5)?,
+                item_key: row.get(6)?,
+            },
+            row.get::<_, String>(7)?,
+            row.get::<_, i64>(8)?,
+            row.get::<_, String>(9)?,
+            row.get::<_, Option<String>>(10)?,
+        ))
+    })?;
+    let mut identities = Vec::new();
+    for row in rows {
+        identities.push(row?);
+    }
+
+    identities
+        .into_iter()
+        .map(|row| {
+            let (
+                queue_id,
+                enqueued_at_ms,
+                attempts,
+                key,
+                input_hash,
+                pipeline,
+                fix_source,
+                closing,
+            ) = row;
+            assemble_job(
+                conn,
+                repo_id,
+                PreparedIdentity {
+                    queue_id,
+                    enqueued_at_ms,
+                    attempts,
+                    key,
+                    distill_input_hash: input_hash,
+                    pipeline_version: pipeline,
+                    prompt_version: prompts::PROMPT_VERSION,
+                    fix_edge_source: FixEdgeSource::from_db_str(&fix_source)?,
+                    closing_keyword: closing.is_some(),
+                },
+                budget,
+            )
+        })
+        .collect()
+}
+
+fn assemble_job(
+    conn: &Connection,
+    repo_id: &str,
+    identity: PreparedIdentity,
+    budget: &PromptBudget,
+) -> anyhow::Result<PreparedJob> {
+    let PreparedIdentity {
+        queue_id,
+        enqueued_at_ms,
+        attempts,
+        key,
+        distill_input_hash,
+        pipeline_version,
+        prompt_version,
+        fix_edge_source,
+        closing_keyword,
+    } = identity;
+    let sources = load_sources(conn, repo_id, &key)?;
+    let units = load_units(conn, repo_id, &key, &sources)?;
+    let anchors = load_anchors(conn, repo_id, &key)?;
+    let commits = load_commits(conn, repo_id, &key)?;
+    let prompt_input = build_prompt_input(&key, &sources, &units, &anchors, commits)?;
+    let rendered_prompt = prompts::render_prompt(&prompt_input, budget);
+    let schema = prompts::record_schema(&prompt_input, budget);
+    let model_input_hash = compute_model_input_hash(&rendered_prompt, &schema)?;
+    Ok(PreparedJob {
+        queue_id,
+        enqueued_at_ms,
+        attempts,
+        key,
+        distill_input_hash,
+        pipeline_version,
+        prompt_version,
+        fix_edge_source,
+        closing_keyword,
+        prompt_input,
+        units,
+        rendered_prompt,
+        schema,
+        model_input_hash,
+    })
+}
+
+fn load_sources(
+    conn: &Connection,
+    repo_id: &str,
+    key: &ThreadKey,
+) -> anyhow::Result<Vec<SourceSnapshot>> {
+    let mut stmt = conn.prepare(
+        "SELECT source_ordinal, role, partner_ordinal, source_item_kind, source_item_key,
+                source_kind, source_part, source_id, exact_text, author, author_kind,
+                author_association, created_at_ms
+         FROM papertrail_distill_sources
+         WHERE repo_id = ?1 AND tracker = ?2 AND project = ?3 AND item_kind = ?4
+           AND item_key = ?5
+         ORDER BY source_ordinal",
+    )?;
+    let rows = stmt.query_map(
+        params![repo_id, key.tracker, key.project, key.item_kind, key.item_key],
+        |row| {
+            Ok(SourceSnapshot {
+                ordinal: usize_from_sql(row.get::<_, i64>(0)?, 0)?,
+                role: row.get(1)?,
+                partner_ordinal: row
+                    .get::<_, Option<i64>>(2)?
+                    .map(|value| usize_from_sql(value, 2))
+                    .transpose()?,
+                item_kind: row.get(3)?,
+                item_key: row.get(4)?,
+                source_kind: row.get(5)?,
+                source_part: row.get(6)?,
+                source_id: row.get(7)?,
+                exact_text: row.get(8)?,
+                author: row.get(9)?,
+                author_kind: row.get(10)?,
+                author_association: row.get(11)?,
+                created_at_ms: row.get(12)?,
+            })
+        },
+    )?;
+    let mut sources = Vec::new();
+    for row in rows {
+        sources.push(row?);
+    }
+    for (expected, source) in sources.iter().enumerate() {
+        anyhow::ensure!(source.ordinal == expected, "distill source ordinals are not contiguous");
+    }
+    Ok(sources)
+}
+
+fn load_units(
+    conn: &Connection,
+    repo_id: &str,
+    key: &ThreadKey,
+    sources: &[SourceSnapshot],
+) -> anyhow::Result<Vec<UnitSnapshot>> {
+    let by_ordinal: BTreeMap<usize, &SourceSnapshot> =
+        sources.iter().map(|source| (source.ordinal, source)).collect();
+    let mut stmt = conn.prepare(
+        "SELECT unit_ordinal, source_ordinal, byte_start, byte_end
+         FROM papertrail_distill_units
+         WHERE repo_id = ?1 AND tracker = ?2 AND project = ?3 AND item_kind = ?4
+           AND item_key = ?5
+         ORDER BY unit_ordinal",
+    )?;
+    let rows = stmt.query_map(
+        params![repo_id, key.tracker, key.project, key.item_kind, key.item_key],
+        |row| {
+            Ok((
+                row.get::<_, i64>(0)?,
+                row.get::<_, i64>(1)?,
+                row.get::<_, i64>(2)?,
+                row.get::<_, i64>(3)?,
+            ))
+        },
+    )?;
+    let mut units = Vec::new();
+    for row in rows {
+        let (ordinal, source_ordinal, byte_start, byte_end) = row?;
+        let ordinal = usize::try_from(ordinal)?;
+        let source_ordinal = usize::try_from(source_ordinal)?;
+        let byte_start = usize::try_from(byte_start)?;
+        let byte_end = usize::try_from(byte_end)?;
+        let source = (*by_ordinal
+            .get(&source_ordinal)
+            .ok_or_else(|| anyhow::anyhow!("distill unit references missing source ordinal"))?)
+        .clone();
+        anyhow::ensure!(
+            byte_start < byte_end
+                && source.exact_text.is_char_boundary(byte_start)
+                && source.exact_text.is_char_boundary(byte_end)
+                && byte_end <= source.exact_text.len(),
+            "distill unit has an invalid source byte span"
+        );
+        anyhow::ensure!(ordinal == units.len(), "distill unit ordinals are not contiguous");
+        units.push(UnitSnapshot { ordinal, byte_start, byte_end, source });
+    }
+    Ok(units)
+}
+
+fn load_anchors(
+    conn: &Connection,
+    repo_id: &str,
+    key: &ThreadKey,
+) -> anyhow::Result<Vec<AnchorSnapshot>> {
+    let mut stmt = conn.prepare(
+        "SELECT candidate_ordinal, anchor_kind, logical_symbol_id, file_path, name, resolved
+         FROM papertrail_distill_anchors
+         WHERE repo_id = ?1 AND tracker = ?2 AND project = ?3 AND item_kind = ?4
+           AND item_key = ?5
+         ORDER BY candidate_ordinal",
+    )?;
+    let rows = stmt.query_map(
+        params![repo_id, key.tracker, key.project, key.item_kind, key.item_key],
+        |row| {
+            Ok(AnchorSnapshot {
+                ordinal: usize_from_sql(row.get::<_, i64>(0)?, 0)?,
+                kind: row.get(1)?,
+                logical_symbol_id: row.get(2)?,
+                file_path: row.get(3)?,
+                name: row.get(4)?,
+                resolved: row.get::<_, i64>(5)? != 0,
+            })
+        },
+    )?;
+    let mut anchors = Vec::new();
+    for row in rows {
+        anchors.push(row?);
+    }
+    Ok(anchors)
+}
+
+fn load_commits(
+    conn: &Connection,
+    repo_id: &str,
+    key: &ThreadKey,
+) -> anyhow::Result<Vec<FixCommit>> {
+    let mut stmt = conn.prepare(
+        "SELECT rc.commit_sha, gc.subject, gc.body
+         FROM papertrail_distill_record_commits rc
+         LEFT JOIN git_commits gc ON gc.repo_id = rc.repo_id AND gc.hash = rc.commit_sha
+         WHERE rc.repo_id = ?1 AND rc.tracker = ?2 AND rc.project = ?3 AND rc.item_kind = ?4
+           AND rc.item_key = ?5
+         ORDER BY rc.commit_sha",
+    )?;
+    let rows = stmt.query_map(
+        params![repo_id, key.tracker, key.project, key.item_kind, key.item_key],
+        |row| {
+            let sha: String = row.get(0)?;
+            let subject: Option<String> = row.get(1)?;
+            let body: Option<String> = row.get(2)?;
+            let message = match (subject, body) {
+                (Some(subject), Some(body)) if !body.is_empty() => format!("{subject}\n\n{body}"),
+                (Some(subject), _) => subject,
+                _ => String::new(),
+            };
+            Ok(FixCommit { sha, message })
+        },
+    )?;
+    let mut commits = Vec::new();
+    for row in rows {
+        commits.push(row?);
+    }
+    Ok(commits)
+}
+
+fn build_prompt_input(
+    key: &ThreadKey,
+    sources: &[SourceSnapshot],
+    units: &[UnitSnapshot],
+    anchors: &[AnchorSnapshot],
+    commits: Vec<FixCommit>,
+) -> anyhow::Result<PromptInput> {
+    let primary_title = sources
+        .iter()
+        .find(|source| source.role == "primary" && source.source_part == "title")
+        .ok_or_else(|| anyhow::anyhow!("prepared distill snapshot has no primary title"))?;
+    let primary_units: Vec<PromptUnit> =
+        units.iter().filter(|unit| unit.source.role == "primary").map(prompt_unit).collect();
+    for (expected, unit) in units.iter().filter(|unit| unit.source.role == "primary").enumerate() {
+        anyhow::ensure!(unit.ordinal == expected, "primary distill unit ids are not a prefix");
+    }
+
+    // PromptInput currently has one partner slot. Extraction stores partner_ordinal explicitly, so
+    // choose the first partner by that durable order rather than row-id or query order.
+    let first_partner = sources
+        .iter()
+        .filter_map(|source| source.partner_ordinal.map(|ordinal| (ordinal, source)))
+        .map(|(ordinal, _)| ordinal)
+        .min();
+    let partner = first_partner.map(|partner_ordinal| {
+        let partner_sources: Vec<&SourceSnapshot> = sources
+            .iter()
+            .filter(|source| source.partner_ordinal == Some(partner_ordinal))
+            .collect();
+        let title = partner_sources
+            .iter()
+            .find(|source| source.source_part == "title")
+            .map_or("", |source| source.exact_text.as_str());
+        let identity = partner_sources.first().copied();
+        PartnerThread {
+            kind: identity.map_or("change_request", |source| source.item_kind.as_str()).to_string(),
+            key: identity.map_or("", |source| source.item_key.as_str()).to_string(),
+            title: title.to_string(),
+            units: units
+                .iter()
+                .filter(|unit| unit.source.partner_ordinal == Some(partner_ordinal))
+                .map(prompt_unit)
+                .collect(),
+        }
+    });
+    let anchor_candidates = anchors
+        .iter()
+        .map(|anchor| AnchorContext {
+            index: anchor.ordinal,
+            kind: anchor.kind.clone(),
+            name: anchor.name.clone(),
+            file: anchor.file_path.clone(),
+            logical_symbol_id: anchor.logical_symbol_id.clone(),
+        })
+        .collect();
+    let symbols = anchors
+        .iter()
+        .filter(|anchor| anchor.kind == "symbol" && anchor.resolved)
+        .map(|anchor| SymbolContext {
+            name: anchor.name.clone(),
+            kind: anchor.kind.clone(),
+            file: anchor.file_path.clone().unwrap_or_default(),
+        })
+        .collect();
+    Ok(PromptInput {
+        kind: key.item_kind.clone(),
+        key: key.item_key.clone(),
+        merged: key.item_kind == "change_request",
+        title: primary_title.exact_text.clone(),
+        opened: primary_title.created_at_ms.map_or_else(String::new, |value| value.to_string()),
+        units: primary_units,
+        partner,
+        xrefs: Vec::new(),
+        fix_commits: commits,
+        symbols,
+        anchor_candidates,
+        diff: None,
+    })
+}
+
+fn prompt_unit(unit: &UnitSnapshot) -> PromptUnit {
+    PromptUnit {
+        text: unit.source.exact_text[unit.byte_start..unit.byte_end].to_string(),
+        source: if unit.source.source_kind == "comment" {
+            format!("comment {}", unit.source.source_id)
+        } else {
+            format!(
+                "{} #{} {}",
+                unit.source.item_kind, unit.source.item_key, unit.source.source_part
+            )
+        },
+    }
+}
+
+fn compute_model_input_hash(
+    rendered_prompt: &str,
+    schema: &serde_json::Value,
+) -> anyhow::Result<String> {
+    let schema = serde_json::to_vec(schema)?;
+    let mut hasher = Sha256::new();
+    hash_bytes(&mut hasher, b"rag-rat-distill-model-input-v1");
+    hash_bytes(&mut hasher, rendered_prompt.as_bytes());
+    hash_bytes(&mut hasher, &schema);
+    let hex: String = hasher.finalize().iter().map(|byte| format!("{byte:02x}")).collect();
+    Ok(format!("sha256:{hex}"))
+}
+
+fn hash_bytes(hasher: &mut Sha256, value: &[u8]) {
+    hasher.update((value.len() as u64).to_le_bytes());
+    hasher.update(value);
+}
+
+fn current_job_matches(
+    conn: &Connection,
+    repo_id: &str,
+    expected: &PreparedJob,
+    budget: &PromptBudget,
+) -> anyhow::Result<bool> {
+    let current = load_job_by_queue_id(conn, repo_id, expected.queue_id, budget)?;
+    Ok(current.is_some_and(|current| {
+        current.enqueued_at_ms == expected.enqueued_at_ms
+            && current.attempts == expected.attempts
+            && current.key == expected.key
+            && current.distill_input_hash == expected.distill_input_hash
+            && current.pipeline_version == expected.pipeline_version
+            && current.prompt_version == expected.prompt_version
+            && current.model_input_hash == expected.model_input_hash
+    }))
+}
+
+fn load_job_by_queue_id(
+    conn: &Connection,
+    repo_id: &str,
+    queue_id: i64,
+    budget: &PromptBudget,
+) -> anyhow::Result<Option<PreparedJob>> {
+    let row = conn
+        .query_row(
+            "SELECT q.enqueued_at_ms, q.attempts, q.tracker, q.project, q.item_kind, q.item_key,
+                    d.distill_input_hash, d.pipeline_version, d.fix_edge_source,
+                    d.closing_keyword_floor
+             FROM papertrail_distill_queue q
+             JOIN papertrail_distill d
+               ON d.repo_id = q.repo_id AND d.tracker = q.tracker AND d.project = q.project
+              AND d.item_kind = q.item_kind AND d.item_key = q.item_key
+             WHERE q.repo_id = ?1 AND q.id = ?2",
+            params![repo_id, queue_id],
+            |row| {
+                Ok((
+                    row.get::<_, i64>(0)?,
+                    row.get::<_, i64>(1)?,
+                    ThreadKey {
+                        tracker: row.get(2)?,
+                        project: row.get(3)?,
+                        item_kind: row.get(4)?,
+                        item_key: row.get(5)?,
+                    },
+                    row.get::<_, String>(6)?,
+                    row.get::<_, i64>(7)?,
+                    row.get::<_, String>(8)?,
+                    row.get::<_, Option<String>>(9)?,
+                ))
+            },
+        )
+        .optional()?;
+    row.map(|(enqueued, attempts, key, hash, pipeline, fix_source, closing)| {
+        assemble_job(
+            conn,
+            repo_id,
+            PreparedIdentity {
+                queue_id,
+                enqueued_at_ms: enqueued,
+                attempts,
+                key,
+                distill_input_hash: hash,
+                pipeline_version: pipeline,
+                prompt_version: prompts::PROMPT_VERSION,
+                fix_edge_source: FixEdgeSource::from_db_str(&fix_source)?,
+                closing_keyword: closing.is_some(),
+            },
+            budget,
+        )
+    })
+    .transpose()
+}
+
+fn persist_success(
+    conn: &Connection,
+    repo_id: &str,
+    job: &PreparedJob,
+    result: &LadderResult,
+    budget: &PromptBudget,
+    distilled_at_ms: i64,
+) -> anyhow::Result<bool> {
+    if !current_job_matches(conn, repo_id, job, budget)? {
+        return Ok(false);
+    }
+    let output = &result.output;
+    let evidence = collect_evidence(job, output)?;
+    let decision_associations: Vec<Option<String>> = evidence
+        .iter()
+        .filter(|evidence| evidence.field == "decision")
+        .map(|evidence| evidence.source.author_association.clone())
+        .collect();
+    let outcome_verified = validate::outcome_claim_verified(
+        output.outcome.status,
+        job.fix_edge_source != FixEdgeSource::None,
+        job.closing_keyword,
+    );
+    let updated = conn.execute(
+        "UPDATE papertrail_distill SET
+             root_issue = ?1, root_cause = ?2, root_cause_class = ?3, decision_chosen = ?4,
+             outcome_summary = ?5, outcome_status_model = ?6,
+             epistemic_status_decision = NULL, epistemic_status_outcome = NULL,
+             quotes_materialized = ?7, outcome_claim_verified = ?8,
+             decision_provenance_verified = ?9, prompt_version = ?10, model_input_hash = ?11,
+             distilled_at_ms = ?12
+         WHERE repo_id = ?13 AND tracker = ?14 AND project = ?15 AND item_kind = ?16
+           AND item_key = ?17 AND distill_input_hash = ?18 AND pipeline_version = ?19",
+        params![
+            output.root_issue,
+            output.root_cause,
+            output.root_cause_class,
+            output.decision.chosen,
+            output.outcome.summary,
+            output.outcome.status.as_db_str(),
+            i64::try_from(evidence.len())?,
+            outcome_verified,
+            validate::decision_provenance_verified(&decision_associations),
+            i64::from(job.prompt_version),
+            job.model_input_hash,
+            distilled_at_ms,
+            repo_id,
+            job.key.tracker,
+            job.key.project,
+            job.key.item_kind,
+            job.key.item_key,
+            job.distill_input_hash,
+            job.pipeline_version,
+        ],
+    )?;
+    if updated != 1 {
+        return Ok(false);
+    }
+    clear_model_junctions(conn, repo_id, &job.key)?;
+    for evidence in evidence {
+        insert_evidence(conn, repo_id, &job.key, &evidence)?;
+    }
+    for (ordinal, rejected) in output.decision.rejected.iter().enumerate() {
+        conn.execute(
+            "INSERT INTO papertrail_distill_alternatives
+                 (tracker, project, item_kind, item_key, ordinal, alternative, reason, repo_id)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            params![
+                job.key.tracker,
+                job.key.project,
+                job.key.item_kind,
+                job.key.item_key,
+                i64::try_from(ordinal)?,
+                rejected.alternative,
+                rejected.reason,
+                repo_id,
+            ],
+        )?;
+    }
+    conn.execute(
+        "UPDATE papertrail_distill_anchors SET selected = 0
+         WHERE repo_id = ?1 AND tracker = ?2 AND project = ?3 AND item_kind = ?4 AND item_key = ?5",
+        params![repo_id, job.key.tracker, job.key.project, job.key.item_kind, job.key.item_key],
+    )?;
+    for ordinal in &output.anchor_indices {
+        let selected = conn.execute(
+            "UPDATE papertrail_distill_anchors SET selected = 1
+             WHERE repo_id = ?1 AND tracker = ?2 AND project = ?3 AND item_kind = ?4
+               AND item_key = ?5 AND candidate_ordinal = ?6",
+            params![
+                repo_id,
+                job.key.tracker,
+                job.key.project,
+                job.key.item_kind,
+                job.key.item_key,
+                i64::try_from(*ordinal)?,
+            ],
+        )?;
+        anyhow::ensure!(selected == 1, "validated anchor candidate vanished during persistence");
+    }
+    let deleted = conn.execute(
+        "DELETE FROM papertrail_distill_queue
+         WHERE repo_id = ?1 AND id = ?2 AND enqueued_at_ms = ?3 AND attempts = ?4",
+        params![repo_id, job.queue_id, job.enqueued_at_ms, job.attempts],
+    )?;
+    anyhow::ensure!(deleted == 1, "distill queue identity changed inside success transaction");
+    Ok(true)
+}
+
+fn persist_failure(
+    conn: &Connection,
+    repo_id: &str,
+    job: &PreparedJob,
+    failure: &LadderFailure,
+    budget: &PromptBudget,
+) -> anyhow::Result<bool> {
+    if !current_job_matches(conn, repo_id, job, budget)? {
+        return Ok(false);
+    }
+    let error = bound_chars(&failure.errors.join("; "), MAX_STORED_ERROR_CHARS);
+    let raw_reply =
+        failure.final_raw_reply.as_deref().map(|reply| bound_chars(reply, MAX_STORED_REPLY_CHARS));
+    let updated = conn.execute(
+        "UPDATE papertrail_distill_queue
+         SET attempts = attempts + 1, last_error = ?1, raw_reply = ?2
+         WHERE repo_id = ?3 AND id = ?4 AND enqueued_at_ms = ?5 AND attempts = ?6",
+        params![error, raw_reply, repo_id, job.queue_id, job.enqueued_at_ms, job.attempts],
+    )?;
+    Ok(updated == 1)
+}
+
+struct EvidenceRow<'a> {
+    field: &'static str,
+    unit: &'a UnitSnapshot,
+    source: &'a SourceSnapshot,
+}
+
+fn collect_evidence<'a>(
+    job: &'a PreparedJob,
+    output: &RecordOutput,
+) -> anyhow::Result<Vec<EvidenceRow<'a>>> {
+    let mut evidence = Vec::new();
+    for (field, citations) in [
+        ("root_cause", &output.root_cause_units),
+        ("decision", &output.decision_units),
+        ("outcome", &output.outcome_units),
+    ] {
+        for citation in citations {
+            let unit = job
+                .units
+                .get(citation.get())
+                .ok_or_else(|| anyhow::anyhow!("validated citation has no snapshot unit"))?;
+            anyhow::ensure!(unit.source.role == "primary", "partner unit cannot be evidence");
+            evidence.push(EvidenceRow { field, unit, source: &unit.source });
+        }
+    }
+    Ok(evidence)
+}
+
+fn insert_evidence(
+    conn: &Connection,
+    repo_id: &str,
+    key: &ThreadKey,
+    evidence: &EvidenceRow<'_>,
+) -> anyhow::Result<()> {
+    let quote = &evidence.source.exact_text[evidence.unit.byte_start..evidence.unit.byte_end];
+    conn.execute(
+        "INSERT INTO papertrail_distill_evidence
+             (tracker, project, item_kind, item_key, field, source_kind, source_id, byte_start,
+              byte_end, quote, author, author_kind, author_association, unit_created_at_ms, \
+         repo_id)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)",
+        params![
+            key.tracker,
+            key.project,
+            key.item_kind,
+            key.item_key,
+            evidence.field,
+            evidence.source.source_kind,
+            evidence.source.source_id,
+            i64::try_from(evidence.unit.byte_start)?,
+            i64::try_from(evidence.unit.byte_end)?,
+            quote,
+            evidence.source.author,
+            evidence.source.author_kind,
+            evidence.source.author_association,
+            evidence.source.created_at_ms,
+            repo_id,
+        ],
+    )?;
+    Ok(())
+}
+
+fn clear_model_junctions(conn: &Connection, repo_id: &str, key: &ThreadKey) -> anyhow::Result<()> {
+    for table in ["papertrail_distill_evidence", "papertrail_distill_alternatives"] {
+        conn.execute(
+            &format!(
+                "DELETE FROM {table} WHERE repo_id = ?1 AND tracker = ?2 AND project = ?3
+                 AND item_kind = ?4 AND item_key = ?5"
+            ),
+            params![repo_id, key.tracker, key.project, key.item_kind, key.item_key],
+        )?;
+    }
+    Ok(())
+}
+
+fn usize_from_sql(value: i64, column: usize) -> rusqlite::Result<usize> {
+    usize::try_from(value).map_err(|error| {
+        rusqlite::Error::FromSqlConversionFailure(
+            column,
+            rusqlite::types::Type::Integer,
+            Box::new(error),
+        )
+    })
+}
+
+fn bound_chars(value: &str, max_chars: usize) -> String {
+    value.chars().take(max_chars).collect()
+}
+
+fn in_transaction<T>(
+    conn: &Connection,
+    mode: &str,
+    f: impl FnOnce() -> anyhow::Result<T>,
+) -> anyhow::Result<T> {
+    conn.execute_batch(&format!("BEGIN {mode}"))?;
+    match f() {
+        Ok(value) =>
+            if let Err(error) = conn.execute_batch("COMMIT") {
+                let _ = conn.execute_batch("ROLLBACK");
+                Err(error.into())
+            } else {
+                Ok(value)
+            },
+        Err(error) => {
+            let _ = conn.execute_batch("ROLLBACK");
+            Err(error)
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::VecDeque;
+    use std::sync::Mutex;
+
+    use rag_rat_db::schema::{
+        apply_distill_anchor_selection, apply_distill_record_store,
+        apply_distill_safe_input_snapshot,
+    };
+    use rag_rat_llm::chat::{ChatModel, GuidedJson};
+    use rusqlite::Connection;
+
+    use super::{PromptBudget, compute_model_input_hash, drain, load_prepared_jobs, pending_count};
+    use crate::distill::prompts;
+
+    struct ScriptedModel {
+        replies: Mutex<VecDeque<anyhow::Result<String>>>,
+        before_first: Option<Box<dyn Fn() + Send + Sync>>,
+        calls: Mutex<usize>,
+    }
+
+    impl ScriptedModel {
+        fn new(replies: Vec<anyhow::Result<String>>) -> Self {
+            Self { replies: Mutex::new(replies.into()), before_first: None, calls: Mutex::new(0) }
+        }
+
+        fn before_first(mut self, action: impl Fn() + Send + Sync + 'static) -> Self {
+            self.before_first = Some(Box::new(action));
+            self
+        }
+    }
+
+    impl ChatModel for ScriptedModel {
+        fn complete_guided(
+            &self,
+            _prompt: &str,
+            _guided: Option<GuidedJson<'_>>,
+        ) -> anyhow::Result<String> {
+            let mut calls = self.calls.lock().unwrap();
+            if *calls == 0
+                && let Some(action) = &self.before_first
+            {
+                action();
+            }
+            *calls += 1;
+            self.replies.lock().unwrap().pop_front().unwrap()
+        }
+
+        fn model_id(&self) -> &str {
+            "scripted"
+        }
+    }
+
+    fn fixture() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        apply_distill_record_store(&conn).unwrap();
+        apply_distill_anchor_selection(&conn).unwrap();
+        apply_distill_safe_input_snapshot(&conn).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE git_commits(
+                 hash TEXT NOT NULL, subject TEXT NOT NULL, body TEXT NOT NULL,
+                 repo_id TEXT NOT NULL, PRIMARY KEY(repo_id, hash)
+             ) STRICT;",
+        )
+        .unwrap();
+        conn
+    }
+
+    fn seed(conn: &Connection, key: &str, enqueued_at_ms: i64) {
+        conn.execute(
+            "INSERT INTO papertrail_distill
+                 (tracker, project, item_kind, item_key, distill_input_hash, pipeline_version,
+                  fix_edge_source, thread_shape, distilled_at_ms, repo_id)
+             VALUES ('github', 'org/repo', 'issue', ?1, ?2, 2, 'provider', 'investigation', 1,
+                     'repo')",
+            rusqlite::params![key, format!("sha256:input-{key}")],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO papertrail_distill_queue
+                 (tracker, project, item_kind, item_key, enqueued_at_ms, repo_id)
+             VALUES ('github', 'org/repo', 'issue', ?1, ?2, 'repo')",
+            rusqlite::params![key, enqueued_at_ms],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO papertrail_distill_sources
+                 (tracker, project, item_kind, item_key, source_ordinal, role, partner_ordinal,
+                  source_item_kind, source_item_key, source_kind, source_part, source_id,
+                  exact_text, author, author_association, created_at_ms, repo_id)
+             VALUES ('github', 'org/repo', 'issue', ?1, 0, 'primary', NULL, 'issue', ?1, 'item',
+                     'title', ?1, 'A title', 'owner', 'OWNER', 10, 'repo'),
+                    ('github', 'org/repo', 'issue', ?1, 1, 'primary', NULL, 'issue', ?1, 'item',
+                     'body', ?1, 'Cause and decision landed.', 'owner', 'OWNER', 10, 'repo')",
+            [key],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO papertrail_distill_units
+                 (tracker, project, item_kind, item_key, unit_ordinal, source_ordinal, byte_start,
+                  byte_end, repo_id)
+             VALUES ('github', 'org/repo', 'issue', ?1, 0, 1, 0, 26, 'repo')",
+            [key],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO papertrail_distill_anchors
+                 (tracker, project, item_kind, item_key, anchor_kind, logical_symbol_id, file_path,
+                  name, resolved, candidate_ordinal, selected, repo_id)
+             VALUES ('github', 'org/repo', 'issue', ?1, 'symbol', 'sym_1', 'src/lib.rs', 'run', 1,
+                     0, 0, 'repo')",
+            [key],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT OR IGNORE INTO git_commits(hash, subject, body, repo_id)
+             VALUES ('abc', 'Fix it', 'Detailed fix.', 'repo')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO papertrail_distill_record_commits
+                 (tracker, project, item_kind, item_key, commit_sha, repo_id)
+             VALUES ('github', 'org/repo', 'issue', ?1, 'abc', 'repo')",
+            [key],
+        )
+        .unwrap();
+    }
+
+    fn valid_reply() -> String {
+        serde_json::json!({
+            "root_issue": "The operation failed.",
+            "root_cause_units": [0],
+            "root_cause": "A stale decision caused the failure.",
+            "root_cause_class": "stale decision",
+            "decision_units": [0],
+            "decision": {
+                "chosen": "Use the current decision.",
+                "rejected": [{"alternative": "Keep stale state", "reason": "It fails."}]
+            },
+            "outcome_units": [0],
+            "anchor_indices": [0],
+            "outcome": {"status": "landed", "summary": "The fix landed."}
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn successful_drain_persists_the_complete_model_transition() {
+        let conn = fixture();
+        let lock_db = tempfile::NamedTempFile::new().unwrap();
+        seed(&conn, "2", 20);
+        let report = drain(
+            &conn,
+            lock_db.path(),
+            "repo",
+            &ScriptedModel::new(vec![Ok(valid_reply())]),
+            10,
+            99,
+        )
+        .unwrap();
+        assert_eq!((report.threads, report.succeeded, report.failed, report.stale), (1, 1, 0, 0));
+        let row: (String, String, i64, i64, i64, i64, String) = conn
+            .query_row(
+                "SELECT root_cause, outcome_status_model, quotes_materialized,
+                        decision_provenance_verified, outcome_claim_verified, prompt_version,
+                        model_input_hash
+                 FROM papertrail_distill WHERE repo_id = 'repo' AND item_key = '2'",
+                [],
+                |row| {
+                    Ok((
+                        row.get(0)?,
+                        row.get(1)?,
+                        row.get(2)?,
+                        row.get(3)?,
+                        row.get(4)?,
+                        row.get(5)?,
+                        row.get(6)?,
+                    ))
+                },
+            )
+            .unwrap();
+        assert_eq!(row.0, "A stale decision caused the failure.");
+        assert_eq!(row.1, "landed");
+        assert_eq!((row.2, row.3, row.4, row.5), (3, 1, 1, i64::from(prompts::PROMPT_VERSION)));
+        assert!(row.6.starts_with("sha256:"));
+        assert_eq!(
+            conn.query_row("SELECT COUNT(*) FROM papertrail_distill_queue", [], |row| row
+                .get::<_, i64>(0))
+                .unwrap(),
+            0
+        );
+        assert_eq!(
+            conn.query_row("SELECT COUNT(*) FROM papertrail_distill_evidence", [], |row| row
+                .get::<_, i64>(0))
+                .unwrap(),
+            3
+        );
+        assert_eq!(
+            conn.query_row("SELECT quote FROM papertrail_distill_evidence LIMIT 1", [], |row| {
+                row.get::<_, String>(0)
+            })
+            .unwrap(),
+            "Cause and decision landed."
+        );
+        assert_eq!(
+            conn.query_row("SELECT selected FROM papertrail_distill_anchors", [], |row| row
+                .get::<_, i64>(0))
+                .unwrap(),
+            1
+        );
+        assert_eq!(
+            conn.query_row(
+                "SELECT threads, rung_guided, rung_serde, failed
+                 FROM papertrail_distill_runs WHERE repo_id = 'repo'",
+                [],
+                |row| Ok((row.get::<_, i64>(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .unwrap(),
+            (1, 1, 1, 0)
+        );
+        assert_eq!(
+            conn.query_row("SELECT COUNT(*) FROM papertrail_distill_record_commits", [], |row| {
+                row.get::<_, i64>(0)
+            })
+            .unwrap(),
+            1,
+            "the drain never rewrites mechanical fixing commits"
+        );
+    }
+
+    #[test]
+    fn pending_count_includes_only_prepared_work_for_the_requested_repo() {
+        let conn = fixture();
+        assert_eq!(pending_count(&conn, "repo").unwrap(), 0);
+        seed(&conn, "2", 20);
+        assert_eq!(pending_count(&conn, "repo").unwrap(), 1);
+        assert_eq!(pending_count(&conn, "other").unwrap(), 0);
+
+        conn.execute("DELETE FROM papertrail_distill_sources WHERE repo_id = 'repo'", []).unwrap();
+        assert_eq!(pending_count(&conn, "repo").unwrap(), 0);
+    }
+
+    #[test]
+    fn failed_ladder_increments_attempt_and_bounds_diagnostics() {
+        let conn = fixture();
+        let lock_db = tempfile::NamedTempFile::new().unwrap();
+        seed(&conn, "2", 20);
+        let huge = "x".repeat(70_000);
+        let report = drain(
+            &conn,
+            lock_db.path(),
+            "repo",
+            &ScriptedModel::new(vec![Ok("not json".into()), Ok(huge)]),
+            10,
+            99,
+        )
+        .unwrap();
+        assert_eq!((report.failed, report.stale), (1, 0));
+        let (attempts, error, raw): (i64, String, String) = conn
+            .query_row(
+                "SELECT attempts, last_error, raw_reply FROM papertrail_distill_queue",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(attempts, 1);
+        assert!(error.chars().count() <= 2_000);
+        assert_eq!(raw.chars().count(), 64_000);
+    }
+
+    #[test]
+    fn stale_success_does_not_delete_or_poison_new_work() {
+        let path = tempfile::NamedTempFile::new().unwrap().into_temp_path();
+        let conn = Connection::open(&path).unwrap();
+        apply_distill_record_store(&conn).unwrap();
+        apply_distill_anchor_selection(&conn).unwrap();
+        apply_distill_safe_input_snapshot(&conn).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE git_commits(
+                 hash TEXT NOT NULL, subject TEXT NOT NULL, body TEXT NOT NULL,
+                 repo_id TEXT NOT NULL, PRIMARY KEY(repo_id, hash)
+             ) STRICT; PRAGMA journal_mode = WAL;",
+        )
+        .unwrap();
+        seed(&conn, "2", 20);
+        let path_for_model = path.to_path_buf();
+        let model = ScriptedModel::new(vec![Ok(valid_reply())]).before_first(move || {
+            let other = Connection::open(&path_for_model).unwrap();
+            other
+                .execute(
+                    "UPDATE papertrail_distill SET distill_input_hash = 'sha256:new-input'
+                     WHERE repo_id = 'repo' AND item_key = '2'",
+                    [],
+                )
+                .unwrap();
+        });
+        let report = drain(&conn, path.as_ref(), "repo", &model, 10, 99).unwrap();
+        assert_eq!((report.succeeded, report.stale), (0, 1));
+        let (root_cause, attempts): (Option<String>, i64) = conn
+            .query_row(
+                "SELECT d.root_cause, q.attempts FROM papertrail_distill d
+                 JOIN papertrail_distill_queue q USING(repo_id, tracker, project, item_kind, \
+                 item_key)",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!((root_cause, attempts), (None, 0));
+    }
+
+    #[test]
+    fn loading_is_ordered_limited_and_hashes_exact_visible_input() {
+        let conn = fixture();
+        seed(&conn, "later", 20);
+        seed(&conn, "first", 10);
+        // Insert partner rows out of row-id order. The persisted partner ordinal, not insertion
+        // order, chooses the one PromptInput can currently represent.
+        conn.execute_batch(
+            "INSERT INTO papertrail_distill_sources
+                 (tracker, project, item_kind, item_key, source_ordinal, role, partner_ordinal,
+                  source_item_kind, source_item_key, source_kind, source_part, source_id,
+                  exact_text, repo_id)
+             VALUES ('github', 'org/repo', 'issue', 'first', 4, 'partner', 1,
+                     'change_request', 'later-partner', 'item', 'title', 'later-partner',
+                     'Later partner', 'repo'),
+                    ('github', 'org/repo', 'issue', 'first', 5, 'partner', 1,
+                     'change_request', 'later-partner', 'item', 'body', 'later-partner',
+                     'Later partner body', 'repo'),
+                    ('github', 'org/repo', 'issue', 'first', 2, 'partner', 0,
+                     'change_request', 'first-partner', 'item', 'title', 'first-partner',
+                     'First partner', 'repo'),
+                    ('github', 'org/repo', 'issue', 'first', 3, 'partner', 0,
+                     'change_request', 'first-partner', 'item', 'body', 'first-partner',
+                     'First partner body', 'repo');",
+        )
+        .unwrap();
+        let budget = PromptBudget::default();
+        let jobs = load_prepared_jobs(&conn, "repo", 1, &budget).unwrap();
+        assert_eq!(jobs[0].key.item_key, "first");
+        assert!(jobs[0].rendered_prompt.contains("Detailed fix."));
+        assert!(jobs[0].rendered_prompt.contains("[A0]"));
+        assert!(jobs[0].rendered_prompt.contains("First partner"));
+        assert!(!jobs[0].rendered_prompt.contains("Later partner"));
+        assert_eq!(
+            jobs[0].model_input_hash,
+            compute_model_input_hash(&jobs[0].rendered_prompt, &jobs[0].schema).unwrap()
+        );
+        let again = load_prepared_jobs(&conn, "repo", 1, &budget).unwrap();
+        assert_eq!(jobs[0].model_input_hash, again[0].model_input_hash);
+        conn.execute(
+            "UPDATE git_commits SET body = 'Changed model-visible body' WHERE repo_id = 'repo'",
+            [],
+        )
+        .unwrap();
+        let changed = load_prepared_jobs(&conn, "repo", 1, &budget).unwrap();
+        assert_ne!(jobs[0].model_input_hash, changed[0].model_input_hash);
+    }
+
+    #[test]
+    fn model_executes_after_the_read_transaction_is_released() {
+        let path = tempfile::NamedTempFile::new().unwrap().into_temp_path();
+        let conn = Connection::open(&path).unwrap();
+        apply_distill_record_store(&conn).unwrap();
+        apply_distill_anchor_selection(&conn).unwrap();
+        apply_distill_safe_input_snapshot(&conn).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE git_commits(
+                 hash TEXT NOT NULL, subject TEXT NOT NULL, body TEXT NOT NULL,
+                 repo_id TEXT NOT NULL, PRIMARY KEY(repo_id, hash)
+             ) STRICT;
+             CREATE TABLE model_probe(value INTEGER NOT NULL);
+             PRAGMA journal_mode = WAL;",
+        )
+        .unwrap();
+        seed(&conn, "2", 20);
+        let path_for_model = path.to_path_buf();
+        let model = ScriptedModel::new(vec![Ok(valid_reply())]).before_first(move || {
+            let other = Connection::open(&path_for_model).unwrap();
+            other.execute("INSERT INTO model_probe VALUES (1)", []).unwrap();
+        });
+        let report = drain(&conn, path.as_ref(), "repo", &model, 10, 99).unwrap();
+        assert_eq!(report.succeeded, 1);
+        assert_eq!(
+            conn.query_row("SELECT COUNT(*) FROM model_probe", [], |row| row.get::<_, i64>(0))
+                .unwrap(),
+            1
+        );
+    }
+}

--- a/crates/rag-rat-core/src/distill/extract.rs
+++ b/crates/rag-rat-core/src/distill/extract.rs
@@ -18,7 +18,7 @@ use rusqlite::{Connection, OptionalExtension, params};
 use sha2::{Digest, Sha256};
 
 use crate::distill::candidates::{self, AnchorCaps};
-use crate::distill::{units, validate};
+use crate::distill::{prompts, units, validate};
 
 /// Bumped whenever the extraction/prompt contract changes in a way that invalidates existing
 /// records — part of the regeneration identity alongside `distill_input_hash`.
@@ -538,22 +538,29 @@ fn write_record(
         anchors: &anchors,
     });
 
-    // Record state drives model-invalidation + enqueue: a New or Regenerated record is enqueued for
-    // #704; an Unchanged one is NOT (re-enqueuing after a drain would re-pay the LLM cost). On
-    // regeneration the model columns + model junctions (evidence, alternatives) are cleared so a
-    // consumer never sees an old decision/outcome pinned to new input; an identical rerun preserves
-    // the model's work.
+    // Record state drives model invalidation + enqueue. New/regenerated records need inference; an
+    // unchanged record keeps its result unless the prompt contract changed. Input or prompt changes
+    // clear every model-owned field before requeueing so stale findings never remain visible.
     let state = record_state(conn, repo_id, plan, &input_hash, opts.pipeline_version)?;
     let regenerated = state == RecordState::Regenerated;
+    let prompt_changed = state == RecordState::Unchanged
+        && match stored_prompt_version(conn, repo_id, plan)? {
+            Some(version) => version != prompts::PROMPT_VERSION,
+            // A queued NULL-stamped row is pending or previously failed, not legacy completed
+            // output. Preserve its attempt diagnostics; the drain always renders the current
+            // prompt. A NULL-stamped row with no queue entry needs recovery/reprocessing.
+            None => !queue_entry_exists(conn, repo_id, plan)?,
+        };
+    let invalidate_model = regenerated || prompt_changed;
 
     // --- Persist: rebuild this thread's mechanical junctions, upsert the skeleton row (clearing
     // model columns on regeneration), rewrite junctions, queue.
     let rebuild_anchor_candidates = state != RecordState::Unchanged;
     clear_mechanical_junctions(conn, repo_id, plan, rebuild_anchor_candidates)?;
-    if regenerated {
+    if invalidate_model {
         clear_model_junctions(conn, repo_id, plan)?;
     }
-    upsert_skeleton(conn, repo_id, now, opts, plan, regenerated, &SkeletonFacets {
+    upsert_skeleton(conn, repo_id, now, opts, plan, invalidate_model, &SkeletonFacets {
         input_hash: &input_hash,
         fix_edge_source: plan.fix_edge_source,
         anchors_qualified,
@@ -569,12 +576,39 @@ fn write_record(
     if rebuild_anchor_candidates {
         write_anchors(conn, repo_id, plan, &anchors)?;
     }
-    let queued = if matches!(state, RecordState::New | RecordState::Regenerated) {
-        enqueue_one(conn, repo_id, now, item, regenerated)?
+    let queued = if matches!(state, RecordState::New | RecordState::Regenerated) || prompt_changed {
+        enqueue_one(conn, repo_id, now, item, invalidate_model)?
     } else {
         0
     };
     Ok(WriteOutcome { queued, mechanical_status })
+}
+
+fn stored_prompt_version(
+    conn: &Connection,
+    repo_id: &str,
+    plan: &RecordPlan,
+) -> anyhow::Result<Option<u32>> {
+    let version = conn.query_row(
+        "SELECT prompt_version FROM papertrail_distill
+         WHERE repo_id = ?1 AND tracker = ?2 AND project = ?3 AND item_kind = ?4 AND item_key = ?5",
+        params![repo_id, plan.tracker, plan.project, plan.kind.as_db_str(), plan.key],
+        |row| row.get::<_, Option<i64>>(0),
+    )?;
+    version.map(u32::try_from).transpose().map_err(Into::into)
+}
+
+fn queue_entry_exists(conn: &Connection, repo_id: &str, plan: &RecordPlan) -> anyhow::Result<bool> {
+    conn.query_row(
+        "SELECT EXISTS(
+             SELECT 1 FROM papertrail_distill_queue
+             WHERE repo_id = ?1 AND tracker = ?2 AND project = ?3
+               AND item_kind = ?4 AND item_key = ?5
+         )",
+        params![repo_id, plan.tracker, plan.project, plan.kind.as_db_str(), plan.key],
+        |row| row.get(0),
+    )
+    .map_err(Into::into)
 }
 
 /// Everything that folds into a record's regeneration identity.
@@ -1159,13 +1193,13 @@ fn upsert_skeleton(
     now: i64,
     opts: &ExtractOptions,
     plan: &RecordPlan,
-    regenerated: bool,
+    invalidate_model: bool,
     facets: &SkeletonFacets<'_>,
 ) -> anyhow::Result<()> {
     // A fresh row inserts the model columns as NULL (honest nulls) for #704 to fill on this natural
     // key. On conflict the mechanical facets are always (re)written; the model columns are
-    // PRESERVED for an identical rerun and NULLED when the input regenerated (`?14`), so a
-    // stale decision/ outcome never rides new input.
+    // PRESERVED for an identical rerun and NULLED when input or prompt identity changed (`?14`), so
+    // a stale decision/outcome never rides current model inputs.
     conn.execute(
         "INSERT INTO papertrail_distill
              (tracker, project, item_kind, item_key, distill_input_hash, pipeline_version,
@@ -1210,7 +1244,7 @@ fn upsert_skeleton(
             facets.closing_keyword,
             now,
             repo_id,
-            regenerated,
+            invalidate_model,
         ],
     )?;
     Ok(())
@@ -1250,9 +1284,9 @@ fn clear_mechanical_junctions(
     Ok(())
 }
 
-/// Clear the MODEL junctions (#704 output: evidence units and rejected alternatives) — only on
-/// regeneration, so an identical rerun keeps the model's work but a changed input never leaves
-/// stale evidence pinned to a fresh record.
+/// Clear model-owned junction state when extraction or prompt identity changes. An identical rerun
+/// keeps the model's work; a requeued record exposes no stale evidence, alternatives, or
+/// selections.
 fn clear_model_junctions(
     conn: &Connection,
     repo_id: &str,
@@ -1267,6 +1301,11 @@ fn clear_model_junctions(
             params![repo_id, plan.tracker, plan.project, plan.kind.as_db_str(), plan.key],
         )?;
     }
+    conn.execute(
+        "UPDATE papertrail_distill_anchors SET selected = 0
+         WHERE repo_id = ?1 AND tracker = ?2 AND project = ?3 AND item_kind = ?4 AND item_key = ?5",
+        params![repo_id, plan.tracker, plan.project, plan.kind.as_db_str(), plan.key],
+    )?;
     Ok(())
 }
 
@@ -2457,6 +2496,11 @@ mod tests {
         seed_commit(&conn, "repoA", "cafe", "refactor: x");
         extract(&conn, None, &ExtractOptions::default()).unwrap();
         // Simulate the #704 drain removing the completed queue row.
+        conn.execute(
+            "UPDATE papertrail_distill SET prompt_version = ?1, model_input_hash = 'sha256:model'",
+            [i64::from(crate::distill::prompts::PROMPT_VERSION)],
+        )
+        .unwrap();
         conn.execute("DELETE FROM papertrail_distill_queue", []).unwrap();
         // An identical re-extract must NOT re-enqueue the completed, unchanged record.
         extract(&conn, None, &ExtractOptions::default()).unwrap();
@@ -2464,6 +2508,41 @@ mod tests {
             distill_count(&conn, "SELECT COUNT(*) FROM papertrail_distill_queue"),
             0,
             "an unchanged record is not re-queued after a drain",
+        );
+    }
+
+    #[test]
+    fn a_prompt_version_change_invalidates_model_output_and_requeues() {
+        let conn = scoped_conn("repoA");
+        seed_item(&conn, "repoA", "change_request", "9", "A PR.", "merged", Some("cafe"));
+        seed_commit(&conn, "repoA", "cafe", "refactor: x");
+        extract(&conn, None, &ExtractOptions::default()).unwrap();
+        conn.execute_batch(
+            "UPDATE papertrail_distill SET
+                 root_cause = 'old result', prompt_version = 0, model_input_hash = 'sha256:old';
+             UPDATE papertrail_distill_anchors SET selected = 1;
+             DELETE FROM papertrail_distill_queue;",
+        )
+        .unwrap();
+
+        extract(&conn, None, &ExtractOptions::default()).unwrap();
+
+        let row: (Option<String>, Option<i64>, Option<String>, i64) = conn
+            .query_row(
+                "SELECT root_cause, prompt_version, model_input_hash,
+                        (SELECT COUNT(*) FROM papertrail_distill_queue)
+                 FROM papertrail_distill WHERE repo_id = 'repoA' AND item_key = '9'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .unwrap();
+        assert_eq!(row, (None, None, None, 1));
+        assert_eq!(
+            distill_count(
+                &conn,
+                "SELECT COUNT(*) FROM papertrail_distill_anchors WHERE selected=1"
+            ),
+            0,
         );
     }
 
@@ -2669,6 +2748,33 @@ mod tests {
     }
 
     #[test]
+    fn unchanged_pending_work_preserves_failure_attempt_state() {
+        let conn = scoped_conn("repoA");
+        seed_item(&conn, "repoA", "change_request", "9", "A PR.", "merged", Some("cafe"));
+        seed_commit(&conn, "repoA", "cafe", "feat: x");
+        extract(&conn, None, &ExtractOptions::default()).unwrap();
+        conn.execute(
+            "UPDATE papertrail_distill_queue
+             SET attempts = 2, last_error = 'bad reply', raw_reply = 'raw', enqueued_at_ms = 7
+             WHERE item_key = '9'",
+            [],
+        )
+        .unwrap();
+
+        extract(&conn, None, &ExtractOptions::default()).unwrap();
+
+        let row: (i64, Option<String>, Option<String>, i64) = conn
+            .query_row(
+                "SELECT attempts, last_error, raw_reply, enqueued_at_ms
+                 FROM papertrail_distill_queue WHERE item_key = '9'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .unwrap();
+        assert_eq!(row, (2, Some("bad reply".into()), Some("raw".into()), 7));
+    }
+
+    #[test]
     fn regeneration_clears_stale_model_output_but_an_identical_rerun_preserves_it() {
         let conn = scoped_conn("repoA");
         seed_item(&conn, "repoA", "change_request", "9", "A PR body.", "merged", Some("cafe"));
@@ -2678,9 +2784,9 @@ mod tests {
         // Simulate the #704 pass filling model columns + model junctions on this record.
         conn.execute(
             "UPDATE papertrail_distill SET root_cause='the cause', outcome_status_model='landed',
-                 quotes_materialized=3, prompt_version=7, model_input_hash='sha256:model'
+                 quotes_materialized=3, prompt_version=?1, model_input_hash='sha256:model'
              WHERE item_key='9'",
-            [],
+            [i64::from(crate::distill::prompts::PROMPT_VERSION)],
         )
         .unwrap();
         conn.execute(
@@ -2724,7 +2830,10 @@ mod tests {
                 |row| Ok((row.get(0)?, row.get(1)?)),
             )
             .unwrap();
-        assert_eq!(stamps, (Some(7), Some("sha256:model".into())));
+        assert_eq!(
+            stamps,
+            (Some(i64::from(crate::distill::prompts::PROMPT_VERSION)), Some("sha256:model".into()))
+        );
         assert_eq!(distill_count(&conn, "SELECT COUNT(*) FROM papertrail_distill_evidence"), 1);
         assert_eq!(
             distill_count(

--- a/crates/rag-rat-core/src/distill/mod.rs
+++ b/crates/rag-rat-core/src/distill/mod.rs
@@ -10,21 +10,18 @@
 //! share).
 
 mod candidates;
+mod drain;
 mod extract;
-// Registered ahead of the separate queue-drain slice, which will consume this contract.
+// Stable rung tokens are also the durable run-column vocabulary; not every conversion is needed by
+// the runtime yet, but the round-trip contract remains tested.
 #[allow(dead_code)]
 mod output;
 mod prompts;
-#[allow(dead_code)] // Curated seam for the separate queue-drain slice.
 mod run_stats;
 mod units;
 mod validate;
 
+pub use drain::DistillDrainReport;
+pub(crate) use drain::{drain, pending_count};
 pub use extract::ExtractReport;
 pub(crate) use extract::{enqueue_eligible, extract};
-// This is the curated crate-internal seam for the separate queue-drain slice.
-#[allow(unused_imports)]
-pub(crate) use output::{
-    CitationId, DecisionOutput, LadderFailure, LadderResult, LadderStats, OutcomeOutput,
-    OutputRung, RecordOutput, RejectedAlternativeOutput, run_output_ladder,
-};

--- a/crates/rag-rat-core/src/distill/run_stats.rs
+++ b/crates/rag-rat-core/src/distill/run_stats.rs
@@ -2,7 +2,7 @@
 
 use rusqlite::{Connection, params};
 
-use super::LadderStats;
+use super::output::LadderStats;
 
 /// Persist one completed run. `rung_guided` is cumulative (every thread starts guided); the other
 /// rung counters plus `failed` are mutually exclusive terminal outcomes.
@@ -57,7 +57,7 @@ mod tests {
     use rusqlite::Connection;
 
     use super::record_distill_run;
-    use crate::distill::LadderStats;
+    use crate::distill::output::LadderStats;
 
     fn fixture() -> Connection {
         let conn = Connection::open_in_memory().unwrap();

--- a/crates/rag-rat-core/src/index/query_api/history.rs
+++ b/crates/rag-rat-core/src/index/query_api/history.rs
@@ -230,6 +230,28 @@ impl IndexDatabase {
         )
     }
 
+    /// Drain up to `limit` prepared distill snapshots through `model`. Database reads and writes
+    /// are separate from model calls, so no SQLite transaction spans inference.
+    pub fn distill_drain(
+        &self,
+        model: &dyn rag_rat_llm::chat::ChatModel,
+        limit: u32,
+    ) -> anyhow::Result<crate::distill::DistillDrainReport> {
+        crate::distill::drain(
+            self.storage.connection(),
+            self.storage.database_path(),
+            &self.active_repo_id,
+            model,
+            usize::try_from(limit)?,
+            rag_rat_base::time::now_ms(),
+        )
+    }
+
+    /// Count queue rows whose deterministic source snapshot is prepared for model inference.
+    pub fn distill_pending_count(&self) -> anyhow::Result<u64> {
+        crate::distill::pending_count(self.storage.connection(), &self.active_repo_id)
+    }
+
     pub fn papertrail_issue_search(
         &self,
         query: &str,


### PR DESCRIPTION
## Summary

Completes issue #704's end-to-end distill runtime on top of the merged prompt contract (#781), anchor/output ladder (#794), and V079 safe-input snapshots (#797).

**Core runtime** (`distill/drain.rs`):
- Deterministic queue load by full identity `(repo_id, tracker, project, item_kind, item_key)`, ordered by enqueue time with a bounded limit.
- Immutable snapshot hydration: exact V079 source/unit text, anchor candidates, and fixing commits assembled into `PromptInput`; the rendered prompt + guided schema are hashed as `model_input_hash` (multiple partner snapshots deterministically pick the lowest `partner_ordinal` for the singular partner slot; all partners stay inside the extraction identity hash).
- Model execution runs entirely outside DB guards/transactions/write locks.
- Success persistence is one short writer-locked transaction: CAS against queue identity + `distill_input_hash`/`pipeline_version`/prompt + model-input identity, then atomically writes model columns, materialized evidence quotes, alternatives, selected anchors, verification facets, prompt/model stamps, and deletes the queue row. Fixing-commit junctions are never touched (mechanical).
- Failure CAS increments `attempts` and stores bounded `last_error`/`raw_reply` only while identity still matches; stale results change nothing.
- Aggregate run stats keep the existing contract (`rung_guided` cumulative, other rungs + `failed` exclusive terminal outcomes).

**Extraction invalidation**:
- A stored `prompt_version` different from current clears model fields/junctions/anchor selections and requeues the record — prompt bumps reach already-drained records.
- A NULL prompt stamp with an existing queue row is pending/failed work: attempts, diagnostics, and enqueue time are preserved across unchanged reruns (regression test included).

**CLI `rag-rat distill drain --limit 20`**:
1. Dedicated per-repo `rag-rat-distill-<id>.lock` flight lock for the whole run (both old and new discriminators retained after a rare identity upgrade).
2. Short per-repo WriteLock: open, extraction, prepared-work count.
3. Zero work → zero-work report before any capability check or provisioning.
4. Work exists + `[llm.distill] enabled = false` → clear error naming the config key.
5. Connect (HttpChatModel) or ephemeral (`provision_chat_model`, box held via `ProvisionedBox`) only when work exists.

## Verification
- `cargo nextest run -p rag-rat-core`: 1451 passed
- Full CLI binary tests: 246 passed
- Distill tests: 99 passed (incl. concurrent-write probe, stale-CAS, retry-state preservation, prompt-version requeue)
- `cargo clippy` core (no-default-features) + CLI, `-D warnings`: clean
- Independent review: no release-blocking findings