### PR TITLE
feat(distill): enriched prompt context — fix diffs, outbound-ref xrefs, all coalesced partners (#800)

### DIFF
--- a/crates/rag-rat-core/src/distill/drain.rs
+++ b/crates/rag-rat-core/src/distill/drain.rs
@@ -1370,6 +1370,65 @@ mod tests {
     }
 
     #[test]
+    fn fix_diff_rows_concatenate_in_commit_path_order_with_newline_separators() {
+        // `load_fix_diff` re-sorts the persisted per-file patches by (commit_sha, path) and joins
+        // them, inserting a separating newline after any row that does not already end in one.
+        let conn = fixture();
+        seed(&conn, "first", 10);
+        // Inserted out of (commit_sha, path) order; the SECOND row (commit 'bbb') has no trailing
+        // newline, exercising the normalization branch.
+        conn.execute(
+            "INSERT INTO papertrail_distill_fix_diffs
+                 (tracker, project, item_kind, item_key, commit_sha, path, patch, repo_id)
+             VALUES ('github','org/repo','issue','first','bbb','src/z.rs','PATCH-Z-no-newline',
+                     'repo')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO papertrail_distill_fix_diffs
+                 (tracker, project, item_kind, item_key, commit_sha, path, patch, repo_id)
+             VALUES ('github','org/repo','issue','first','aaa','src/a.rs','PATCH-A' || char(10),
+                     'repo')",
+            [],
+        )
+        .unwrap();
+
+        let jobs = load_prepared_jobs(&conn, "repo", 1, &PromptBudget::default()).unwrap();
+        let prompt = &jobs[0].rendered_prompt;
+        let a_pos = prompt.find("PATCH-A").expect("patch A renders");
+        let z_pos = prompt.find("PATCH-Z-no-newline").expect("patch Z renders");
+        assert!(a_pos < z_pos, "rows render in (commit_sha, path) order: aaa before bbb: {prompt}");
+    }
+
+    #[test]
+    fn a_null_xref_target_kind_renders_an_empty_kind_label() {
+        // `load_xrefs` tolerates a NULL `target_item_kind` (defaulting it to an empty label) rather
+        // than dropping the row — the drain never fabricates a kind the snapshot did not resolve.
+        let conn = fixture();
+        seed(&conn, "first", 10);
+        conn.execute(
+            "INSERT INTO papertrail_distill_xrefs
+                 (tracker, project, item_kind, item_key, xref_ordinal, target_tracker,
+                  target_project, target_item_kind, target_item_key, ref_kind, title, opening,
+                  repo_id)
+             VALUES \
+             ('github','org/repo','issue','first',0,'github','org/repo',NULL,'9','reference',
+                     'Kindless target','','repo')",
+            [],
+        )
+        .unwrap();
+
+        let jobs = load_prepared_jobs(&conn, "repo", 1, &PromptBudget::default()).unwrap();
+        let prompt = &jobs[0].rendered_prompt;
+        assert!(prompt.contains("REFERENCED ITEMS:"), "{prompt}");
+        assert!(
+            prompt.contains("[] #9 (reference): Kindless target"),
+            "a NULL target kind renders as an empty kind label: {prompt}",
+        );
+    }
+
+    #[test]
     fn model_executes_after_the_read_transaction_is_released() {
         let path = tempfile::NamedTempFile::new().unwrap().into_temp_path();
         let conn = Connection::open(&path).unwrap();

--- a/crates/rag-rat-core/src/distill/drain.rs
+++ b/crates/rag-rat-core/src/distill/drain.rs
@@ -291,7 +291,9 @@ fn assemble_job(
     let units = load_units(conn, repo_id, &key, &sources)?;
     let anchors = load_anchors(conn, repo_id, &key)?;
     let commits = load_commits(conn, repo_id, &key)?;
-    let prompt_input = build_prompt_input(&key, &sources, &units, &anchors, commits)?;
+    let diff = load_fix_diff(conn, repo_id, &key)?;
+    let xrefs = load_xrefs(conn, repo_id, &key)?;
+    let prompt_input = build_prompt_input(&key, &sources, &units, &anchors, commits, xrefs, diff)?;
     let rendered_prompt = prompts::render_prompt(&prompt_input, budget);
     let schema = prompts::record_schema(&prompt_input, budget);
     let model_input_hash = compute_model_input_hash(&rendered_prompt, &schema)?;
@@ -476,12 +478,73 @@ fn load_commits(
     Ok(commits)
 }
 
+/// The snapshotted per-file patches (#800), concatenated in deterministic (commit, path) order —
+/// the extraction froze the diff, so the drain renders it without ever opening the repo.
+fn load_fix_diff(
+    conn: &Connection,
+    repo_id: &str,
+    key: &ThreadKey,
+) -> anyhow::Result<Option<String>> {
+    let mut stmt = conn.prepare(
+        "SELECT patch FROM papertrail_distill_fix_diffs
+         WHERE repo_id = ?1 AND tracker = ?2 AND project = ?3 AND item_kind = ?4
+           AND item_key = ?5
+         ORDER BY commit_sha, path",
+    )?;
+    let rows = stmt.query_map(
+        params![repo_id, key.tracker, key.project, key.item_kind, key.item_key],
+        |row| row.get::<_, String>(0),
+    )?;
+    let mut diff = String::new();
+    for row in rows {
+        diff.push_str(&row?);
+        if !diff.ends_with('\n') {
+            diff.push('\n');
+        }
+    }
+    Ok((!diff.is_empty()).then_some(diff))
+}
+
+/// The snapshotted cross-referenced items (#800), in extraction's durable ordinal order.
+fn load_xrefs(
+    conn: &Connection,
+    repo_id: &str,
+    key: &ThreadKey,
+) -> anyhow::Result<Vec<prompts::Xref>> {
+    let mut stmt = conn.prepare(
+        "SELECT target_item_kind, target_item_key, ref_kind, title, opening
+         FROM papertrail_distill_xrefs
+         WHERE repo_id = ?1 AND tracker = ?2 AND project = ?3 AND item_kind = ?4
+           AND item_key = ?5
+         ORDER BY xref_ordinal",
+    )?;
+    let rows = stmt.query_map(
+        params![repo_id, key.tracker, key.project, key.item_kind, key.item_key],
+        |row| {
+            Ok(prompts::Xref {
+                kind: row.get::<_, Option<String>>(0)?.unwrap_or_default(),
+                key: row.get(1)?,
+                ref_kind: row.get(2)?,
+                title: row.get(3)?,
+                opening: row.get(4)?,
+            })
+        },
+    )?;
+    let mut xrefs = Vec::new();
+    for row in rows {
+        xrefs.push(row?);
+    }
+    Ok(xrefs)
+}
+
 fn build_prompt_input(
     key: &ThreadKey,
     sources: &[SourceSnapshot],
     units: &[UnitSnapshot],
     anchors: &[AnchorSnapshot],
     commits: Vec<FixCommit>,
+    xrefs: Vec<prompts::Xref>,
+    diff: Option<String>,
 ) -> anyhow::Result<PromptInput> {
     let primary_title = sources
         .iter()
@@ -493,34 +556,36 @@ fn build_prompt_input(
         anyhow::ensure!(unit.ordinal == expected, "primary distill unit ids are not a prefix");
     }
 
-    // PromptInput currently has one partner slot. Extraction stores partner_ordinal explicitly, so
-    // choose the first partner by that durable order rather than row-id or query order.
-    let first_partner = sources
-        .iter()
-        .filter_map(|source| source.partner_ordinal.map(|ordinal| (ordinal, source)))
-        .map(|(ordinal, _)| ordinal)
-        .min();
-    let partner = first_partner.map(|partner_ordinal| {
-        let partner_sources: Vec<&SourceSnapshot> = sources
-            .iter()
-            .filter(|source| source.partner_ordinal == Some(partner_ordinal))
-            .collect();
-        let title = partner_sources
-            .iter()
-            .find(|source| source.source_part == "title")
-            .map_or("", |source| source.exact_text.as_str());
-        let identity = partner_sources.first().copied();
-        PartnerThread {
-            kind: identity.map_or("change_request", |source| source.item_kind.as_str()).to_string(),
-            key: identity.map_or("", |source| source.item_key.as_str()).to_string(),
-            title: title.to_string(),
-            units: units
+    // Every coalesced partner, in the extraction's durable partner_ordinal order — the persisted
+    // ordinal, not row-id or query order, defines the render sequence.
+    let partner_ordinals: std::collections::BTreeSet<usize> =
+        sources.iter().filter_map(|source| source.partner_ordinal).collect();
+    let partners = partner_ordinals
+        .into_iter()
+        .map(|partner_ordinal| {
+            let partner_sources: Vec<&SourceSnapshot> = sources
                 .iter()
-                .filter(|unit| unit.source.partner_ordinal == Some(partner_ordinal))
-                .map(prompt_unit)
-                .collect(),
-        }
-    });
+                .filter(|source| source.partner_ordinal == Some(partner_ordinal))
+                .collect();
+            let title = partner_sources
+                .iter()
+                .find(|source| source.source_part == "title")
+                .map_or("", |source| source.exact_text.as_str());
+            let identity = partner_sources.first().copied();
+            PartnerThread {
+                kind: identity
+                    .map_or("change_request", |source| source.item_kind.as_str())
+                    .to_string(),
+                key: identity.map_or("", |source| source.item_key.as_str()).to_string(),
+                title: title.to_string(),
+                units: units
+                    .iter()
+                    .filter(|unit| unit.source.partner_ordinal == Some(partner_ordinal))
+                    .map(prompt_unit)
+                    .collect(),
+            }
+        })
+        .collect();
     let anchor_candidates = anchors
         .iter()
         .map(|anchor| AnchorContext {
@@ -547,12 +612,12 @@ fn build_prompt_input(
         title: primary_title.exact_text.clone(),
         opened: primary_title.created_at_ms.map_or_else(String::new, |value| value.to_string()),
         units: primary_units,
-        partner,
-        xrefs: Vec::new(),
+        partners,
+        xrefs,
         fix_commits: commits,
         symbols,
         anchor_candidates,
-        diff: None,
+        diff,
     })
 }
 
@@ -909,7 +974,7 @@ mod tests {
     use std::sync::Mutex;
 
     use rag_rat_db::schema::{
-        apply_distill_anchor_selection, apply_distill_record_store,
+        apply_distill_anchor_selection, apply_distill_enriched_context, apply_distill_record_store,
         apply_distill_safe_input_snapshot,
     };
     use rag_rat_llm::chat::{ChatModel, GuidedJson};
@@ -961,6 +1026,7 @@ mod tests {
         apply_distill_record_store(&conn).unwrap();
         apply_distill_anchor_selection(&conn).unwrap();
         apply_distill_safe_input_snapshot(&conn).unwrap();
+        apply_distill_enriched_context(&conn).unwrap();
         conn.execute_batch(
             "CREATE TABLE git_commits(
                  hash TEXT NOT NULL, subject TEXT NOT NULL, body TEXT NOT NULL,
@@ -1181,6 +1247,7 @@ mod tests {
         apply_distill_record_store(&conn).unwrap();
         apply_distill_anchor_selection(&conn).unwrap();
         apply_distill_safe_input_snapshot(&conn).unwrap();
+        apply_distill_enriched_context(&conn).unwrap();
         conn.execute_batch(
             "CREATE TABLE git_commits(
                  hash TEXT NOT NULL, subject TEXT NOT NULL, body TEXT NOT NULL,
@@ -1220,7 +1287,7 @@ mod tests {
         seed(&conn, "later", 20);
         seed(&conn, "first", 10);
         // Insert partner rows out of row-id order. The persisted partner ordinal, not insertion
-        // order, chooses the one PromptInput can currently represent.
+        // order, defines the render sequence.
         conn.execute_batch(
             "INSERT INTO papertrail_distill_sources
                  (tracker, project, item_kind, item_key, source_ordinal, role, partner_ordinal,
@@ -1245,8 +1312,10 @@ mod tests {
         assert_eq!(jobs[0].key.item_key, "first");
         assert!(jobs[0].rendered_prompt.contains("Detailed fix."));
         assert!(jobs[0].rendered_prompt.contains("[A0]"));
-        assert!(jobs[0].rendered_prompt.contains("First partner"));
-        assert!(!jobs[0].rendered_prompt.contains("Later partner"));
+        // Every coalesced partner renders, lowest partner_ordinal first (#800).
+        let first_pos = jobs[0].rendered_prompt.find("First partner").expect("first partner");
+        let later_pos = jobs[0].rendered_prompt.find("Later partner").expect("later partner");
+        assert!(first_pos < later_pos, "partners render in durable ordinal order");
         assert_eq!(
             jobs[0].model_input_hash,
             compute_model_input_hash(&jobs[0].rendered_prompt, &jobs[0].schema).unwrap()
@@ -1263,12 +1332,51 @@ mod tests {
     }
 
     #[test]
+    fn enriched_context_renders_from_the_frozen_snapshots() {
+        let conn = fixture();
+        seed(&conn, "first", 10);
+        conn.execute(
+            "INSERT INTO papertrail_distill_fix_diffs
+                 (tracker, project, item_kind, item_key, commit_sha, path, patch, repo_id)
+             VALUES ('github', 'org/repo', 'issue', 'first', 'abc123', 'src/widget.rs',
+                     'diff --git a/src/widget.rs b/src/widget.rs\n--- a/src/widget.rs\n+++ \
+             b/src/widget.rs\n@@ -1 +1 @@\n-old\n+new\n',
+                     'repo')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO papertrail_distill_xrefs
+                 (tracker, project, item_kind, item_key, xref_ordinal, target_tracker,
+                  target_project, target_item_kind, target_item_key, ref_kind, title, opening,
+                  repo_id)
+             VALUES ('github', 'org/repo', 'issue', 'first', 0, 'github', 'org/repo', 'issue',
+                     '9', 'reference', 'Related refactor', 'We reworked the render path.', 'repo')",
+            [],
+        )
+        .unwrap();
+
+        let jobs = load_prepared_jobs(&conn, "repo", 1, &PromptBudget::default()).unwrap();
+        let prompt = &jobs[0].rendered_prompt;
+        assert!(prompt.contains("DIFF:"), "the diff block renders: {prompt}");
+        assert!(prompt.contains("+new"), "hunk content renders: {prompt}");
+        assert!(prompt.contains("REFERENCED ITEMS:"), "{prompt}");
+        assert!(
+            prompt.contains(
+                "[issue] #9 (reference): Related refactor — We reworked the render path."
+            ),
+            "{prompt}"
+        );
+    }
+
+    #[test]
     fn model_executes_after_the_read_transaction_is_released() {
         let path = tempfile::NamedTempFile::new().unwrap().into_temp_path();
         let conn = Connection::open(&path).unwrap();
         apply_distill_record_store(&conn).unwrap();
         apply_distill_anchor_selection(&conn).unwrap();
         apply_distill_safe_input_snapshot(&conn).unwrap();
+        apply_distill_enriched_context(&conn).unwrap();
         conn.execute_batch(
             "CREATE TABLE git_commits(
                  hash TEXT NOT NULL, subject TEXT NOT NULL, body TEXT NOT NULL,

--- a/crates/rag-rat-core/src/distill/extract.rs
+++ b/crates/rag-rat-core/src/distill/extract.rs
@@ -37,10 +37,6 @@ const FIX_DIFF_FILE_CAP: usize = 8_000;
 /// hostile 50MB minified file in memory inside the extraction write transaction.
 const FIX_DIFF_BLOB_CAP: u64 = 1_000_000;
 
-/// Byte cap for a snapshotted xref opening paragraph (#800): the prompt renders at most 200
-/// chars of it, so a giant single-paragraph body must not inflate the snapshot row.
-const XREF_OPENING_CAP: usize = 2_000;
-
 /// Max cross-referenced items snapshotted per record (#800). Matches the prompt's `max_xrefs`
 /// budget: refs beyond the cap are invisible to both the snapshot and the prompt.
 const XREF_SNAPSHOT_CAP: usize = 20;
@@ -1339,15 +1335,18 @@ fn xref_snapshots(
             if !seen.insert((tracker.clone(), project.clone(), kind.clone(), key.clone())) {
                 continue;
             }
+            // Cap the STORED (and therefore hashed) title/opening to exactly what the prompt
+            // renders (`XREF_TEXT_RENDER_CHARS`). Storing more would hash text the model never
+            // sees, so a referenced item's edit beyond the rendered width would regenerate the
+            // record and re-pay the model with identical visible input. `truncate_chars` is the
+            // same idempotent helper the render applies, so stored == rendered (pre-neutralize).
             let opening = units::segment_blocks(&body)
                 .first()
                 .map(|span| {
-                    let text = &body[span.start..span.end];
-                    let mut end = XREF_OPENING_CAP.min(text.len());
-                    while end > 0 && !text.is_char_boundary(end) {
-                        end -= 1;
-                    }
-                    text[..end].to_string()
+                    prompts::truncate_chars(
+                        body[span.start..span.end].trim(),
+                        prompts::XREF_TEXT_RENDER_CHARS,
+                    )
                 })
                 .unwrap_or_default();
             out.push(XrefSnapshot {
@@ -1357,7 +1356,7 @@ fn xref_snapshots(
                 target_item_kind: Some(kind),
                 target_item_key: key,
                 ref_kind,
-                title,
+                title: prompts::truncate_chars(title.trim(), prompts::XREF_TEXT_RENDER_CHARS),
                 opening,
             });
             if out.len() >= XREF_SNAPSHOT_CAP {
@@ -2630,8 +2629,9 @@ mod tests {
         seed_comment(&conn, "repoA", "issue", "5", "c1", false);
         seed_outbound_ref(&conn, "repoA", "github:o/r:issue:5:c1", "9", "reference");
         seed_outbound_ref(&conn, "repoA", "github:o/r:issue:5", "404", "reference");
-        // A giant single-paragraph body: the opening snapshot is capped (the prompt renders at
-        // most 200 chars of it — a multi-MB paragraph must not inflate the row).
+        // A giant single-paragraph body: the opening snapshot is capped to EXACTLY the prompt's
+        // render width, so a multi-MB paragraph neither inflates the row nor hashes text the model
+        // never sees.
         seed_item(&conn, "repoA", "issue", "10", &"x".repeat(5_000), "closed", None);
         seed_outbound_ref(&conn, "repoA", "github:o/r:issue:5", "10", "reference");
 
@@ -2653,7 +2653,12 @@ mod tests {
         assert_eq!(rows[0].2, "t", "seeded title is frozen");
         assert_eq!(rows[0].3, "Opening line.", "the opening paragraph only, not the body");
         assert_eq!(rows[1].0, "10");
-        assert_eq!(rows[1].3.len(), 2_000, "a giant paragraph's opening is capped");
+        assert_eq!(
+            rows[1].3.chars().count(),
+            crate::distill::prompts::XREF_TEXT_RENDER_CHARS + 1,
+            "a giant paragraph's opening is capped to the render width plus the ellipsis",
+        );
+        assert!(rows[1].3.ends_with('…'), "the truncated opening keeps the ellipsis marker");
 
         // The referenced records are eligible too, but their own records have no outbound refs.
         assert_eq!(distill_count(&conn, "SELECT COUNT(*) FROM papertrail_distill_xrefs"), 2);
@@ -2669,6 +2674,165 @@ mod tests {
             crate::distill::prompts::PromptBudget::default().max_xrefs,
             "the snapshot cap and the render budget must move together"
         );
+    }
+
+    #[test]
+    fn an_xref_edit_beyond_the_render_width_does_not_regenerate() {
+        // The length-dimension partner of `xref_snapshot_cap_matches_the_prompt_xref_budget`: a
+        // referenced item's title/opening are hashed at EXACTLY the width the prompt renders, so an
+        // edit past that width is invisible to the model and must NOT regenerate the record
+        // (re-paying the model with identical visible input). An edit WITHIN the width still does.
+        let width = crate::distill::prompts::XREF_TEXT_RENDER_CHARS;
+        let conn = scoped_conn("repoA");
+        seed_item(&conn, "repoA", "issue", "5", "A bug. See #9.", "closed", None);
+        seed_item(&conn, "repoA", "issue", "9", "Body.", "closed", None);
+        seed_outbound_ref(&conn, "repoA", "github:o/r:issue:5", "9", "reference");
+        let head = "a".repeat(width);
+        conn.execute("UPDATE papertrail_items SET title = ?1 WHERE item_key = '9'", [format!(
+            "{head}X"
+        )])
+        .unwrap();
+
+        extract(&conn, None, &ExtractOptions::default()).unwrap();
+        let baseline = input_hash(&conn, "5");
+        let stored: String = conn
+            .query_row("SELECT title FROM papertrail_distill_xrefs WHERE item_key='5'", [], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        assert_eq!(
+            stored.chars().count(),
+            width + 1,
+            "the stored title is capped to the render width (plus the ellipsis), not the source",
+        );
+
+        // Edit only the TAIL, past the rendered width — the first `width` chars are unchanged.
+        conn.execute("UPDATE papertrail_items SET title = ?1 WHERE item_key = '9'", [format!(
+            "{head}YYYY"
+        )])
+        .unwrap();
+        extract(&conn, None, &ExtractOptions::default()).unwrap();
+        assert_eq!(
+            input_hash(&conn, "5"),
+            baseline,
+            "a tail-only edit past the render width leaves the identity unchanged",
+        );
+
+        // Edit WITHIN the rendered width — now the model-visible text changes, so regenerate.
+        conn.execute("UPDATE papertrail_items SET title = ?1 WHERE item_key = '9'", [format!(
+            "z{head}"
+        )])
+        .unwrap();
+        extract(&conn, None, &ExtractOptions::default()).unwrap();
+        assert_ne!(
+            input_hash(&conn, "5"),
+            baseline,
+            "an edit within the render width regenerates the record",
+        );
+    }
+
+    #[test]
+    fn a_bare_ref_resolves_the_target_kind_by_fallback() {
+        // A kindless bare ref (`#N`, `papertrail_refs.item_kind` NULL) resolves down the fallback
+        // ladder: the source item's OWN kind first (parser namespace inheritance), then the
+        // deterministic kind order. A PR whose `#9` names an ISSUE resolves the issue even though
+        // the syntax could not disambiguate; a ref that resolves as NEITHER kind drops entirely.
+        let conn = scoped_conn("repoA");
+        seed_item(&conn, "repoA", "change_request", "5", "A PR. See #9 and #404.", "merged", None);
+        seed_item(&conn, "repoA", "issue", "9", "The referenced issue body.", "closed", None);
+        let kindless = |target: &str| {
+            conn.execute(
+                "INSERT INTO papertrail_refs
+                     (tracker, project, item_key, item_kind, ref_kind, source_kind, source_text,
+                      discovered_at_ms, repo_id)
+                 VALUES ('github','o/r',?1,NULL,'reference','item',
+                         'github:o/r:change_request:5',1,'repoA')",
+                [target],
+            )
+            .unwrap();
+        };
+        kindless("9"); // no change_request #9 exists, but issue #9 does → resolves via fallback
+        kindless("404"); // resolves as neither kind → dropped
+
+        extract(&conn, None, &ExtractOptions::default()).unwrap();
+
+        let rows: Vec<(String, String)> = conn
+            .prepare(
+                "SELECT target_item_key, target_item_kind FROM papertrail_distill_xrefs
+                 WHERE item_kind='change_request' AND item_key='5' ORDER BY xref_ordinal",
+            )
+            .unwrap()
+            .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+            .unwrap()
+            .collect::<Result<_, _>>()
+            .unwrap();
+        assert_eq!(
+            rows,
+            vec![("9".to_string(), "issue".to_string())],
+            "the kindless ref resolves to the issue by fallback; the unresolvable ref drops",
+        );
+    }
+
+    /// Build a throwaway repo whose HEAD fix commit DELETES `src/gone.rs` (added in the base
+    /// commit), returning `(root, fix_sha, path)`.
+    fn build_delete_repo() -> (std::path::PathBuf, String, String) {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let root =
+            std::env::temp_dir().join(format!("ragrat-distill-del-{}-{id}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        let git = |args: &[&str]| {
+            let status =
+                std::process::Command::new("git").current_dir(&root).args(args).status().unwrap();
+            assert!(status.success(), "git {args:?} failed");
+        };
+        git(&["init", "-q"]);
+        git(&["config", "user.name", "Rag Rat"]);
+        git(&["config", "user.email", "rag@example.com"]);
+        std::fs::write(root.join("src/gone.rs"), "fn gone() {}\n").unwrap();
+        git(&["add", "."]);
+        git(&["commit", "-q", "-m", "base"]);
+        std::fs::remove_file(root.join("src/gone.rs")).unwrap();
+        git(&["add", "-A"]);
+        git(&["commit", "-q", "-m", "fix: remove gone"]);
+        let out = std::process::Command::new("git")
+            .current_dir(&root)
+            .args(["rev-parse", "HEAD"])
+            .output()
+            .unwrap();
+        let fix_sha = String::from_utf8(out.stdout).unwrap().trim().to_string();
+        (root, fix_sha, "src/gone.rs".to_string())
+    }
+
+    #[test]
+    fn a_deleted_symbol_file_snapshots_a_deletion_patch() {
+        // The deletion arm of the file-patch header: a fixing commit that removes a
+        // symbol-candidate file diffs the old path TO /dev/null, not a bogus addition.
+        let (root, fix_sha, path) = build_delete_repo();
+        let conn = scoped_conn("repoA");
+        seed_item(&conn, "repoA", "change_request", "9", "Remove it.", "merged", Some(&fix_sha));
+        seed_commit(&conn, "repoA", &fix_sha, "fix: remove gone");
+        seed_changed_file(&conn, "repoA", &fix_sha, &path);
+
+        extract(&conn, Some(&root), &ExtractOptions::default()).unwrap();
+
+        let patch: String = conn
+            .query_row(
+                "SELECT patch FROM papertrail_distill_fix_diffs WHERE path = ?1",
+                [&path],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(
+            patch.contains(&format!("--- a/{path}")),
+            "a deletion diffs from the old path: {patch}"
+        );
+        assert!(patch.contains("+++ /dev/null"), "a deleted file diffs TO /dev/null: {patch}");
+        assert!(patch.contains("-fn gone() {}"), "the removed line renders: {patch}");
+
+        let _ = std::fs::remove_dir_all(root);
     }
 
     #[test]

--- a/crates/rag-rat-core/src/distill/extract.rs
+++ b/crates/rag-rat-core/src/distill/extract.rs
@@ -21,8 +21,29 @@ use crate::distill::candidates::{self, AnchorCaps};
 use crate::distill::{prompts, units, validate};
 
 /// Bumped whenever the extraction/prompt contract changes in a way that invalidates existing
-/// records — part of the regeneration identity alongside `distill_input_hash`.
-pub(crate) const PIPELINE_VERSION: i64 = 2;
+/// records — part of the regeneration identity alongside `distill_input_hash`. 2 → 3 (#800):
+/// cross-referenced-item snapshots joined the extraction identity, and the fix-diff renderer was
+/// added (its rows are regenerable and deliberately NOT hashed, so a renderer change also rides
+/// this bump).
+pub(crate) const PIPELINE_VERSION: i64 = 3;
+
+/// Byte cap for ONE snapshotted per-file patch (#800). The diff is a deterministic function of the
+/// (immutable) fixing commit, so truncation cannot hide a mutable edit; the cap bounds a single
+/// generated/vendored file's patch so one sprawling fix cannot inflate the snapshot table.
+const FIX_DIFF_FILE_CAP: usize = 8_000;
+
+/// Blob-size pre-filter for the fix-diff renderer (#800): a file whose old OR new side exceeds
+/// this is skipped entirely. The output cap truncates after a full render, which would diff a
+/// hostile 50MB minified file in memory inside the extraction write transaction.
+const FIX_DIFF_BLOB_CAP: u64 = 1_000_000;
+
+/// Byte cap for a snapshotted xref opening paragraph (#800): the prompt renders at most 200
+/// chars of it, so a giant single-paragraph body must not inflate the snapshot row.
+const XREF_OPENING_CAP: usize = 2_000;
+
+/// Max cross-referenced items snapshotted per record (#800). Matches the prompt's `max_xrefs`
+/// budget: refs beyond the cap are invisible to both the snapshot and the prompt.
+const XREF_SNAPSHOT_CAP: usize = 20;
 
 /// Knobs for one extraction pass.
 pub(crate) struct ExtractOptions {
@@ -516,6 +537,17 @@ fn write_record(
         .filter(|a| a.resolved && matches!(a.kind, candidates::AnchorKind::Symbol))
         .count();
 
+    // Enriched context (#800), snapshotted in this same transaction so the drain never reads
+    // mutable git/mirror state: the titles + opening paragraphs of items this thread's outbound
+    // refs name are MUTABLE mirror rows and must be frozen here. The fix diff is different: it is
+    // a pure function of the (already-hashed) fix SHAs and anchor candidates, so it is NOT part of
+    // the input identity — folding rendered patch bytes in would tie the identity to git object
+    // AVAILABILITY (a bare-index or shallow run would flip every hash, destroy good snapshots, and
+    // re-pay the model) and force a full re-render of every record's diffs on every pass inside
+    // this write transaction. It is rendered lazily below, only when the record's identity changed
+    // or its rows are missing.
+    let xrefs = xref_snapshots(conn, repo_id, plan, &snapshot)?;
+
     let thread_shape = validate::classify_thread_shape(total_comments, review_comments, body_len);
 
     // The mechanical effective status (model absent) — a floors-only preview for the report.
@@ -536,6 +568,7 @@ fn write_record(
         revert_override,
         closing_keyword,
         anchors: &anchors,
+        xrefs: &xrefs,
     });
 
     // Record state drives model invalidation + enqueue. New/regenerated records need inference; an
@@ -570,6 +603,22 @@ fn write_record(
     })?;
     if state != RecordState::Unchanged {
         replace_snapshot(conn, repo_id, plan, &snapshot)?;
+        replace_xrefs(conn, repo_id, plan, &xrefs)?;
+    }
+    // The fix-diff snapshot is rebuilt when the identity changed, and SELF-HEALED when an earlier
+    // pass ran without a usable repo handle (bare/copied index, shallow clone): the rows are a
+    // pure function of hashed inputs, so filling them late cannot invalidate anything. A record
+    // whose rendering legitimately yields zero rows (all binary/missing) re-attempts each pass —
+    // the cheap edge of this posture.
+    let diff_heal = state == RecordState::Unchanged
+        && repo.is_some()
+        && anchors
+            .iter()
+            .any(|a| matches!(a.kind, candidates::AnchorKind::Symbol) && a.file_path.is_some())
+        && !fix_diff_rows_exist(conn, repo_id, plan)?;
+    if state != RecordState::Unchanged || diff_heal {
+        let fix_diffs = fix_diff_snapshots(repo, &plan.fix_shas, &anchors);
+        replace_fix_diffs(conn, repo_id, plan, &fix_diffs)?;
     }
     write_commits(conn, repo_id, plan, &plan.fix_shas)?;
     write_coalesced_edges(conn, repo_id, now, plan)?;
@@ -611,6 +660,25 @@ fn queue_entry_exists(conn: &Connection, repo_id: &str, plan: &RecordPlan) -> an
     .map_err(Into::into)
 }
 
+/// Whether the thread already has snapshotted fix-diff rows (#800) — the self-heal probe for a
+/// record first extracted without a usable repo handle.
+fn fix_diff_rows_exist(
+    conn: &Connection,
+    repo_id: &str,
+    plan: &RecordPlan,
+) -> anyhow::Result<bool> {
+    conn.query_row(
+        "SELECT EXISTS(
+             SELECT 1 FROM papertrail_distill_fix_diffs
+             WHERE repo_id = ?1 AND tracker = ?2 AND project = ?3
+               AND item_kind = ?4 AND item_key = ?5
+         )",
+        params![repo_id, plan.tracker, plan.project, plan.kind.as_db_str(), plan.key],
+        |row| row.get(0),
+    )
+    .map_err(Into::into)
+}
+
 /// Everything that folds into a record's regeneration identity.
 struct HashInputs<'a> {
     pipeline_version: i64,
@@ -622,6 +690,7 @@ struct HashInputs<'a> {
     revert_override: bool,
     closing_keyword: Option<&'a str>,
     anchors: &'a [candidates::AnchorCandidate],
+    xrefs: &'a [XrefSnapshot],
 }
 
 /// The regeneration identity: pipeline version, full record identity, the complete exact source
@@ -639,9 +708,10 @@ fn compute_input_hash(inputs: &HashInputs<'_>) -> String {
         revert_override,
         closing_keyword,
         anchors,
+        xrefs,
     } = inputs;
     let mut hasher = Sha256::new();
-    hash_str(&mut hasher, "rag-rat-distill-input-v2");
+    hash_str(&mut hasher, "rag-rat-distill-input-v3");
     hasher.update(pipeline_version.to_le_bytes());
     hash_str(&mut hasher, repo_id);
     hash_str(&mut hasher, &plan.tracker);
@@ -706,6 +776,23 @@ fn compute_input_hash(inputs: &HashInputs<'_>) -> String {
         hash_optional_str(&mut hasher, anchor.file_path.as_deref());
         hash_str(&mut hasher, &anchor.name);
         hasher.update([anchor.resolved as u8]);
+    }
+    // Enriched-context snapshots (#800). The xref rows carry MUTABLE mirror text (a referenced
+    // item's edited title/opening) that must regenerate the record exactly like a primary-source
+    // edit. The fix diff is deliberately ABSENT: it is a pure function of the hashed fix SHAs and
+    // anchor candidates, so hashing rendered patches would only couple the identity to git object
+    // availability; renderer changes ride PIPELINE_VERSION instead.
+    hash_str(&mut hasher, "xrefs");
+    hasher.update((xrefs.len() as u64).to_le_bytes());
+    for xref in *xrefs {
+        hasher.update((xref.ordinal as u64).to_le_bytes());
+        hash_str(&mut hasher, &xref.target_tracker);
+        hash_str(&mut hasher, &xref.target_project);
+        hash_optional_str(&mut hasher, xref.target_item_kind.as_deref());
+        hash_str(&mut hasher, &xref.target_item_key);
+        hash_str(&mut hasher, &xref.ref_kind);
+        hash_str(&mut hasher, &xref.title);
+        hash_str(&mut hasher, &xref.opening);
     }
     let hex: String = hasher.finalize().iter().map(|byte| format!("{byte:02x}")).collect();
     format!("sha256:{hex}")
@@ -999,14 +1086,13 @@ fn merge_first_parent_paths(repo: &gix::Repository, sha: &str) -> anyhow::Result
         return Ok(Vec::new());
     };
     let new_tree = commit.tree()?;
+    // A parent id with a MISSING object is a shallow boundary, not a root commit — diffing against
+    // the empty tree would report every file in the repo as added. Skip the commit instead.
     let parent_tree = match commit.parent_ids().next() {
-        Some(parent) => repo
-            .find_commit(parent.detach())
-            .ok()
-            .and_then(|p| p.tree().ok())
-            .unwrap_or_else(|| repo.empty_tree()),
-        None => repo.empty_tree(),
+        Some(parent) => repo.find_commit(parent.detach()).ok().and_then(|p| p.tree().ok()),
+        None => Some(repo.empty_tree()),
     };
+    let Some(parent_tree) = parent_tree else { return Ok(Vec::new()) };
     let mut paths = Vec::new();
     parent_tree
         .changes()?
@@ -1025,6 +1111,307 @@ fn merge_first_parent_paths(repo: &gix::Repository, sha: &str) -> anyhow::Result
 struct CommitMeta {
     subject: String,
     body: String,
+}
+
+/// One snapshotted per-file patch of a fixing commit (#800): git-style headers plus the unified
+/// hunks, capped at [`FIX_DIFF_FILE_CAP`]. Rendered at extraction time and persisted; the drain
+/// never opens the repo.
+struct FixDiffSnapshot {
+    commit_sha: String,
+    path: String,
+    patch: String,
+}
+
+/// One snapshotted cross-referenced item (#800): the outbound ref's target identity (kind as
+/// RESOLVED against the mirror) plus the frozen title and opening paragraph the prompt shows.
+struct XrefSnapshot {
+    ordinal: usize,
+    target_tracker: String,
+    target_project: String,
+    target_item_kind: Option<String>,
+    target_item_key: String,
+    ref_kind: String,
+    title: String,
+    opening: String,
+}
+
+/// The fix diff, "capped by files with symbol candidates" (#800): per fixing commit, the unified
+/// patch of every changed file that yielded a SYMBOL anchor candidate (mining already excluded
+/// test/generated churn and unindexed paths). Git content is immutable, so this is a determinism
+/// snapshot (drain stays DB-only), not a mutability one — best-effort like the merge path
+/// recovery: an unresolvable sha, shallow clone, binary file, or driver-skipped diff contributes
+/// nothing rather than failing the pass.
+fn fix_diff_snapshots(
+    repo: Option<&gix::Repository>,
+    fix_shas: &[String],
+    anchors: &[candidates::AnchorCandidate],
+) -> Vec<FixDiffSnapshot> {
+    let Some(repo) = repo else { return Vec::new() };
+    let symbol_paths: BTreeSet<&str> = anchors
+        .iter()
+        .filter(|anchor| matches!(anchor.kind, candidates::AnchorKind::Symbol))
+        .filter_map(|anchor| anchor.file_path.as_deref())
+        .collect();
+    if symbol_paths.is_empty() {
+        return Vec::new();
+    }
+    let Ok(mut diff_cache) = repo.diff_resource_cache_for_tree_diff() else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for sha in fix_shas {
+        diff_cache.clear_resource_cache();
+        let _ = collect_commit_diffs(repo, sha, &symbol_paths, &mut diff_cache, &mut out);
+    }
+    out
+}
+
+/// Append one fixing commit's per-file patches (vs its FIRST parent) for the symbol-candidate
+/// paths. Best-effort at the call site: any gix error (unparseable sha, missing object on a
+/// shallow clone) yields no rows for this commit rather than failing the pass.
+fn collect_commit_diffs(
+    repo: &gix::Repository,
+    sha: &str,
+    symbol_paths: &BTreeSet<&str>,
+    diff_cache: &mut gix::diff::blob::Platform,
+    out: &mut Vec<FixDiffSnapshot>,
+) -> anyhow::Result<()> {
+    use gix::object::tree::diff::Action;
+
+    let id = gix::ObjectId::from_hex(sha.as_bytes())?;
+    let commit = repo.find_commit(id)?;
+    let new_tree = commit.tree()?;
+    // A parent id with a MISSING object is a shallow boundary, not a root commit — diffing against
+    // the empty tree would render a bogus full-tree addition. Skip the commit instead.
+    let parent_tree = match commit.parent_ids().next() {
+        Some(parent) => repo.find_commit(parent.detach()).ok().and_then(|p| p.tree().ok()),
+        None => Some(repo.empty_tree()),
+    };
+    let Some(parent_tree) = parent_tree else { return Ok(()) };
+    parent_tree
+        .changes()?
+        .options(|opts| {
+            opts.track_path();
+        })
+        .for_each_to_obtain_tree(&new_tree, |change| {
+            // Blobs only: a gitlink's submodule SHA is not diffable text, and a symlink's target
+            // path is not file content.
+            if change.entry_mode().is_blob() {
+                let path = change.location().to_string();
+                if symbol_paths.contains(path.as_str())
+                    && let Some(patch) = render_file_patch(repo, &change, &path, diff_cache)
+                {
+                    out.push(FixDiffSnapshot { commit_sha: sha.to_string(), path, patch });
+                }
+            }
+            Ok::<_, std::convert::Infallible>(Action::Continue(()))
+        })?;
+    Ok(())
+}
+
+/// Render one changed file's unified patch with git-style headers. `None` for binary/driver-
+/// skipped diffs, empty patches (a mode-only change), either side over [`FIX_DIFF_BLOB_CAP`]
+/// (the 8k output cap truncates AFTER a full render — a 50MB minified file would otherwise be
+/// diffed in memory inside the extraction write transaction), and paths carrying control chars
+/// (a newline-bearing filename would split the header lines the drain concatenates). Hunk text
+/// is lossy-decoded — deterministic, and the prompt treats it as untrusted display text only.
+fn render_file_patch(
+    repo: &gix::Repository,
+    change: &gix::object::tree::diff::Change<'_, '_, '_>,
+    path: &str,
+    diff_cache: &mut gix::diff::blob::Platform,
+) -> Option<String> {
+    use gix::diff::blob::platform::prepare_diff::Operation;
+    use gix::diff::blob::unified_diff::{ConsumeBinaryHunk, ContextSize};
+    use gix::objs::FindHeader;
+
+    if path.chars().any(char::is_control) {
+        return None;
+    }
+    let platform = change.diff(diff_cache).ok()?;
+    for resource in
+        platform.resource_cache.resources().into_iter().flat_map(|(old, new)| [old, new])
+    {
+        if resource.id.is_null() {
+            continue;
+        }
+        if let Ok(Some(header)) = repo.try_header(resource.id)
+            && header.size > FIX_DIFF_BLOB_CAP
+        {
+            return None;
+        }
+    }
+    platform.resource_cache.options.skip_internal_diff_if_external_is_configured = false;
+    let prep = platform.resource_cache.prepare_diff().ok()?;
+    let Operation::InternalDiff { algorithm } = prep.operation else { return None };
+    let input = prep.interned_input();
+    let diff = gix::diff::blob::diff_with_slider_heuristics(algorithm, &input);
+    let hunks = gix::diff::blob::UnifiedDiff::new(
+        &diff,
+        &input,
+        ConsumeBinaryHunk::new(Vec::new(), "\n"),
+        ContextSize::symmetrical(3),
+    )
+    .consume()
+    .ok()?;
+    let hunks = String::from_utf8_lossy(&hunks);
+    if hunks.trim().is_empty() {
+        return None;
+    }
+    let header = match change {
+        gix::object::tree::diff::Change::Addition { .. } =>
+            format!("diff --git a/{path} b/{path}\n--- /dev/null\n+++ b/{path}\n"),
+        gix::object::tree::diff::Change::Deletion { .. } =>
+            format!("diff --git a/{path} b/{path}\n--- a/{path}\n+++ /dev/null\n"),
+        _ => format!("diff --git a/{path} b/{path}\n--- a/{path}\n+++ b/{path}\n"),
+    };
+    let patch = format!("{header}{hunks}");
+    // The cap covers the WHOLE row, headers included; truncation is deterministic and the drain
+    // renders at a tighter budget anyway.
+    let mut end = FIX_DIFF_FILE_CAP.min(patch.len());
+    while end > 0 && !patch.is_char_boundary(end) {
+        end -= 1;
+    }
+    Some(patch[..end].to_string())
+}
+
+/// The thread's cross-referenced items (#800): outbound `papertrail_refs` rows keyed by the
+/// SNAPSHOT's own source identities (so the ref set a record sees is exactly the set derivable
+/// from its frozen sources), each target resolved against the mirror in this transaction and
+/// frozen as title + opening paragraph. Unmirrored targets (foreign projects, never-synced
+/// items) contribute nothing — there is no immutable text to freeze. Kind preference when the
+/// ref syntax left the kind ambiguous (bare `#N`): the source item's own kind first, matching
+/// the parser's namespace inheritance, then a deterministic kind order.
+fn xref_snapshots(
+    conn: &Connection,
+    repo_id: &str,
+    plan: &RecordPlan,
+    snapshot: &ThreadSnapshot,
+) -> anyhow::Result<Vec<XrefSnapshot>> {
+    let mut ref_stmt = conn.prepare(
+        "SELECT tracker, project, item_kind, item_key, ref_kind FROM papertrail_refs
+         WHERE repo_id = ?1 AND source_kind IN ('item', 'comment') AND source_text = ?2
+         ORDER BY id",
+    )?;
+    let mut seen: BTreeSet<(String, String, String, String)> = BTreeSet::new();
+    let mut out = Vec::new();
+    'sources: for source in &snapshot.sources {
+        let identity = match source.kind {
+            SourceKind::Item => format!(
+                "{}:{}:{}:{}",
+                plan.tracker,
+                plan.project,
+                source.item_kind.as_db_str(),
+                source.item_key
+            ),
+            SourceKind::Comment => format!(
+                "{}:{}:{}:{}:{}",
+                plan.tracker,
+                plan.project,
+                source.item_kind.as_db_str(),
+                source.item_key,
+                source.id
+            ),
+        };
+        let rows = ref_stmt.query_map(params![repo_id, identity], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, Option<String>>(2)?,
+                row.get::<_, String>(3)?,
+                row.get::<_, String>(4)?,
+            ))
+        })?;
+        for row in rows {
+            let (tracker, project, parsed_kind, key, ref_kind) = row?;
+            let Some((kind, title, body)) = resolve_xref_target(
+                conn,
+                repo_id,
+                &tracker,
+                &project,
+                parsed_kind.as_deref(),
+                source.item_kind.as_db_str(),
+                &key,
+            )?
+            else {
+                continue;
+            };
+            if !seen.insert((tracker.clone(), project.clone(), kind.clone(), key.clone())) {
+                continue;
+            }
+            let opening = units::segment_blocks(&body)
+                .first()
+                .map(|span| {
+                    let text = &body[span.start..span.end];
+                    let mut end = XREF_OPENING_CAP.min(text.len());
+                    while end > 0 && !text.is_char_boundary(end) {
+                        end -= 1;
+                    }
+                    text[..end].to_string()
+                })
+                .unwrap_or_default();
+            out.push(XrefSnapshot {
+                ordinal: out.len(),
+                target_tracker: tracker,
+                target_project: project,
+                target_item_kind: Some(kind),
+                target_item_key: key,
+                ref_kind,
+                title,
+                opening,
+            });
+            if out.len() >= XREF_SNAPSHOT_CAP {
+                break 'sources;
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// Resolve an outbound ref's target to a mirrored item: exact kind when the syntax named one,
+/// else the source item's kind (parser namespace inheritance), else the deterministically first
+/// kind. Returns `(item_kind, title, body)`.
+fn resolve_xref_target(
+    conn: &Connection,
+    repo_id: &str,
+    tracker: &str,
+    project: &str,
+    parsed_kind: Option<&str>,
+    source_kind: &str,
+    key: &str,
+) -> anyhow::Result<Option<(String, String, String)>> {
+    let mut candidates: Vec<&str> = Vec::new();
+    if let Some(kind) = parsed_kind {
+        candidates.push(kind);
+    } else {
+        candidates.push(source_kind);
+        for kind in [ItemKind::ChangeRequest.as_db_str(), ItemKind::Issue.as_db_str()] {
+            if kind != source_kind {
+                candidates.push(kind);
+            }
+        }
+    }
+    for kind in candidates {
+        let resolved = conn
+            .query_row(
+                "SELECT item_kind, title, body FROM papertrail_items
+                 WHERE repo_id = ?1 AND tracker = ?2 AND project = ?3 AND item_key = ?4
+                   AND item_kind = ?5",
+                params![repo_id, tracker, project, key, kind],
+                |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, String>(1)?,
+                        row.get::<_, String>(2)?,
+                    ))
+                },
+            )
+            .optional()?;
+        if resolved.is_some() {
+            return Ok(resolved);
+        }
+    }
+    Ok(None)
 }
 
 fn commit_message(
@@ -1130,6 +1517,8 @@ fn delete_record(conn: &Connection, repo_id: &str, record: &RecordKey) -> anyhow
         "papertrail_distill_queue",
         "papertrail_distill_sources",
         "papertrail_distill_units",
+        "papertrail_distill_fix_diffs",
+        "papertrail_distill_xrefs",
     ] {
         conn.execute(
             &format!(
@@ -1369,6 +1758,79 @@ fn replace_snapshot(
                 unit.source_ordinal as i64,
                 unit.span.start as i64,
                 unit.span.end as i64,
+                repo_id,
+            ],
+        )?;
+    }
+    Ok(())
+}
+
+/// Replace a thread's snapshotted fix-diff rows (#800). Same gating as [`replace_snapshot`]:
+/// rewritten only when the extraction identity changed.
+fn replace_fix_diffs(
+    conn: &Connection,
+    repo_id: &str,
+    plan: &RecordPlan,
+    diffs: &[FixDiffSnapshot],
+) -> anyhow::Result<()> {
+    conn.execute(
+        "DELETE FROM papertrail_distill_fix_diffs
+         WHERE repo_id = ?1 AND tracker = ?2 AND project = ?3 AND item_kind = ?4 AND item_key = ?5",
+        params![repo_id, plan.tracker, plan.project, plan.kind.as_db_str(), plan.key],
+    )?;
+    for diff in diffs {
+        conn.execute(
+            "INSERT INTO papertrail_distill_fix_diffs
+                 (tracker, project, item_kind, item_key, commit_sha, path, patch, repo_id)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            params![
+                plan.tracker,
+                plan.project,
+                plan.kind.as_db_str(),
+                plan.key,
+                diff.commit_sha,
+                diff.path,
+                diff.patch,
+                repo_id,
+            ],
+        )?;
+    }
+    Ok(())
+}
+
+/// Replace a thread's snapshotted cross-reference rows (#800). Same gating as
+/// [`replace_snapshot`].
+fn replace_xrefs(
+    conn: &Connection,
+    repo_id: &str,
+    plan: &RecordPlan,
+    xrefs: &[XrefSnapshot],
+) -> anyhow::Result<()> {
+    conn.execute(
+        "DELETE FROM papertrail_distill_xrefs
+         WHERE repo_id = ?1 AND tracker = ?2 AND project = ?3 AND item_kind = ?4 AND item_key = ?5",
+        params![repo_id, plan.tracker, plan.project, plan.kind.as_db_str(), plan.key],
+    )?;
+    for xref in xrefs {
+        conn.execute(
+            "INSERT INTO papertrail_distill_xrefs
+                 (tracker, project, item_kind, item_key, xref_ordinal, target_tracker,
+                  target_project, target_item_kind, target_item_key, ref_kind, title, opening,
+                  repo_id)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
+            params![
+                plan.tracker,
+                plan.project,
+                plan.kind.as_db_str(),
+                plan.key,
+                xref.ordinal as i64,
+                xref.target_tracker,
+                xref.target_project,
+                xref.target_item_kind,
+                xref.target_item_key,
+                xref.ref_kind,
+                xref.title,
+                xref.opening,
                 repo_id,
             ],
         )?;
@@ -1895,6 +2357,375 @@ mod tests {
         );
 
         let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn fix_diff_is_snapshotted_only_for_symbol_candidate_files() {
+        // The merge repo's first-parent diff adds `src/widget.rs`; the seeded index resolves its
+        // symbol, so the patch is snapshotted. The same commit's `README.md` change (no symbol
+        // candidate) must NOT appear — the cap is by symbol-candidate files, not by changed files.
+        let (root, merge_sha, path) = build_merge_repo();
+        let conn = scoped_conn("repoA");
+        seed_item(
+            &conn,
+            "repoA",
+            "change_request",
+            "9",
+            "A refactor PR.",
+            "merged",
+            Some(&merge_sha),
+        );
+        seed_commit(&conn, "repoA", &merge_sha, "Merge feature");
+        seed_indexed_source(&conn, "repoA", &path);
+
+        extract(&conn, Some(&root), &ExtractOptions::default()).unwrap();
+
+        let patches: Vec<(String, String)> = conn
+            .prepare("SELECT path, patch FROM papertrail_distill_fix_diffs ORDER BY path")
+            .unwrap()
+            .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+            .unwrap()
+            .collect::<Result<_, _>>()
+            .unwrap();
+        assert_eq!(patches.len(), 1, "only the symbol-candidate file's patch is snapshotted");
+        let (patch_path, patch) = &patches[0];
+        assert_eq!(patch_path, &path);
+        assert!(patch.contains("diff --git a/src/widget.rs b/src/widget.rs"), "{patch}");
+        assert!(patch.contains("--- /dev/null"), "an added file diffs from /dev/null: {patch}");
+        assert!(patch.contains("+++ b/src/widget.rs"), "{patch}");
+        assert!(patch.contains("+fn render_widget() {}"), "the hunk content renders: {patch}");
+
+        // Control: no repo handle → no diff rows (the drain never sees git state).
+        let conn2 = scoped_conn("repoB");
+        seed_item(
+            &conn2,
+            "repoB",
+            "change_request",
+            "9",
+            "A refactor PR.",
+            "merged",
+            Some(&merge_sha),
+        );
+        seed_commit(&conn2, "repoB", &merge_sha, "Merge feature");
+        seed_indexed_source(&conn2, "repoB", &path);
+        extract(&conn2, None, &ExtractOptions::default()).unwrap();
+        assert_eq!(
+            distill_count(&conn2, "SELECT COUNT(*) FROM papertrail_distill_fix_diffs"),
+            0,
+            "no repo handle → best-effort empty diff snapshot"
+        );
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn losing_the_repo_handle_preserves_diff_snapshots_and_the_identity() {
+        // The diff is a pure function of already-hashed inputs, so git AVAILABILITY must not be
+        // part of the record identity: extract with a repo, then again with `None` (the documented
+        // bare/copied-index path) — the hash holds, the good snapshot rows survive, nothing
+        // re-enqueues. The changed paths come from `git_file_changes` rows here (not the live-gix
+        // merge fallback), so the anchors and changed-path selection are repo-independent and ONLY
+        // the diff snapshot differs between the two passes.
+        let (root, merge_sha, path) = build_merge_repo();
+        let conn = scoped_conn("repoA");
+        seed_item(
+            &conn,
+            "repoA",
+            "change_request",
+            "9",
+            "A refactor PR.",
+            "merged",
+            Some(&merge_sha),
+        );
+        seed_commit(&conn, "repoA", &merge_sha, "Merge feature");
+        seed_changed_file(&conn, "repoA", &merge_sha, &path);
+
+        extract(&conn, Some(&root), &ExtractOptions::default()).unwrap();
+        let hash_with_repo: String = conn
+            .query_row("SELECT distill_input_hash FROM papertrail_distill", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(
+            distill_count(&conn, "SELECT COUNT(*) FROM papertrail_distill_fix_diffs"),
+            1,
+            "the repo-backed pass snapshots the diff"
+        );
+
+        extract(&conn, None, &ExtractOptions::default()).unwrap();
+        let hash_without_repo: String = conn
+            .query_row("SELECT distill_input_hash FROM papertrail_distill", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(hash_with_repo, hash_without_repo, "repo availability is not identity");
+        assert_eq!(
+            distill_count(&conn, "SELECT COUNT(*) FROM papertrail_distill_fix_diffs"),
+            1,
+            "a repo-less rerun preserves the snapshot"
+        );
+
+        // Self-heal: the mirror is reset to the repo-less state (record + no diff rows), then a
+        // repo-backed pass fills the missing rows WITHOUT any identity change.
+        let conn2 = scoped_conn("repoB");
+        seed_item(
+            &conn2,
+            "repoB",
+            "change_request",
+            "9",
+            "A refactor PR.",
+            "merged",
+            Some(&merge_sha),
+        );
+        seed_commit(&conn2, "repoB", &merge_sha, "Merge feature");
+        seed_changed_file(&conn2, "repoB", &merge_sha, &path);
+        extract(&conn2, None, &ExtractOptions::default()).unwrap();
+        assert_eq!(distill_count(&conn2, "SELECT COUNT(*) FROM papertrail_distill_fix_diffs"), 0);
+        extract(&conn2, Some(&root), &ExtractOptions::default()).unwrap();
+        assert_eq!(
+            distill_count(&conn2, "SELECT COUNT(*) FROM papertrail_distill_fix_diffs"),
+            1,
+            "a later repo-backed pass heals the missing diff rows"
+        );
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn a_shallow_clone_missing_the_parent_yields_no_bogus_full_tree_diff() {
+        // At a shallow boundary the parent id is recorded but the object is absent; that is NOT a
+        // root commit. Diffing against the empty tree would snapshot every repo file as added.
+        let (root, merge_sha, path) = build_merge_repo();
+        let shallow =
+            std::env::temp_dir().join(format!("ragrat-distill-shallow-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&shallow);
+        let status = std::process::Command::new("git")
+            .args([
+                "clone",
+                "-q",
+                "--depth",
+                "1",
+                &format!("file://{}", root.display()),
+                shallow.to_str().unwrap(),
+            ])
+            .status()
+            .unwrap();
+        assert!(status.success(), "shallow clone failed");
+
+        let conn = scoped_conn("repoA");
+        seed_item(
+            &conn,
+            "repoA",
+            "change_request",
+            "9",
+            "A refactor PR.",
+            "merged",
+            Some(&merge_sha),
+        );
+        seed_commit(&conn, "repoA", &merge_sha, "Merge feature");
+        // `git_file_changes` rows supply the anchors, so the symbol-candidate filter is non-empty
+        // even though the shallow repo cannot produce a first-parent diff.
+        seed_changed_file(&conn, "repoA", &merge_sha, &path);
+
+        extract(&conn, Some(&shallow), &ExtractOptions::default()).unwrap();
+        assert_eq!(
+            distill_count(&conn, "SELECT COUNT(*) FROM papertrail_distill_fix_diffs"),
+            0,
+            "a missing parent skips the commit — never a full-tree 'everything added' patch"
+        );
+
+        let _ = std::fs::remove_dir_all(root);
+        let _ = std::fs::remove_dir_all(shallow);
+    }
+
+    /// Build a throwaway repo whose HEAD fix commit modifies `src/widget.rs` and adds a >1MiB
+    /// `src/big.rs`, returning `(root, fix_sha)`.
+    fn build_big_blob_repo() -> (std::path::PathBuf, String) {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let root =
+            std::env::temp_dir().join(format!("ragrat-distill-big-{}-{id}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        let git = |args: &[&str]| {
+            let status =
+                std::process::Command::new("git").current_dir(&root).args(args).status().unwrap();
+            assert!(status.success(), "git {args:?} failed");
+        };
+        git(&["init", "-q"]);
+        git(&["config", "user.name", "Rag Rat"]);
+        git(&["config", "user.email", "rag@example.com"]);
+        std::fs::write(root.join("src/widget.rs"), "fn render_widget() {}\n").unwrap();
+        git(&["add", "."]);
+        git(&["commit", "-q", "-m", "base"]);
+        std::fs::write(root.join("src/widget.rs"), "fn render_widget() { todo!() }\n").unwrap();
+        std::fs::write(root.join("src/big.rs"), "x".repeat(1_200_000)).unwrap();
+        git(&["add", "."]);
+        git(&["commit", "-q", "-m", "fix: widget and a giant file"]);
+        let out = std::process::Command::new("git")
+            .current_dir(&root)
+            .args(["rev-parse", "HEAD"])
+            .output()
+            .unwrap();
+        let fix_sha = String::from_utf8(out.stdout).unwrap().trim().to_string();
+        (root, fix_sha)
+    }
+
+    #[test]
+    fn a_blob_over_the_size_cap_is_skipped_before_rendering() {
+        let (root, fix_sha) = build_big_blob_repo();
+        let conn = scoped_conn("repoA");
+        seed_item(&conn, "repoA", "change_request", "9", "The fix.", "merged", Some(&fix_sha));
+        seed_commit(&conn, "repoA", &fix_sha, "fix: widget and a giant file");
+        seed_changed_file(&conn, "repoA", &fix_sha, "src/widget.rs");
+        seed_changed_file(&conn, "repoA", &fix_sha, "src/big.rs");
+
+        extract(&conn, Some(&root), &ExtractOptions::default()).unwrap();
+        let paths: Vec<String> = conn
+            .prepare("SELECT path FROM papertrail_distill_fix_diffs ORDER BY path")
+            .unwrap()
+            .query_map([], |row| row.get(0))
+            .unwrap()
+            .collect::<Result<_, _>>()
+            .unwrap();
+        assert_eq!(
+            paths,
+            vec!["src/widget.rs".to_string()],
+            "the small patch renders; the >1MiB blob is skipped before any full diff"
+        );
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    /// Seed one outbound ref row the mirror sync would have mined from `source_text`'s item body.
+    fn seed_outbound_ref(
+        conn: &Connection,
+        repo: &str,
+        source_text: &str,
+        target_key: &str,
+        ref_kind: &str,
+    ) {
+        conn.execute(
+            "INSERT INTO papertrail_refs
+                 (tracker, project, item_key, item_kind, ref_kind, source_kind, source_text,
+                  discovered_at_ms, repo_id)
+             VALUES ('github','o/r',?1,'issue',?2,'item',?3,1,?4)",
+            params![target_key, ref_kind, source_text, repo],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn outbound_refs_snapshot_the_referenced_title_and_opening() {
+        let conn = scoped_conn("repoA");
+        seed_item(&conn, "repoA", "issue", "5", "A bug. See #9.", "closed", None);
+        seed_item(
+            &conn,
+            "repoA",
+            "issue",
+            "9",
+            "Opening line.\n\nSecond paragraph.",
+            "closed",
+            None,
+        );
+        seed_outbound_ref(&conn, "repoA", "github:o/r:issue:5", "9", "reference");
+        // A comment-sourced ref to the same target dedupes; a ref to an unmirrored item drops.
+        seed_comment(&conn, "repoA", "issue", "5", "c1", false);
+        seed_outbound_ref(&conn, "repoA", "github:o/r:issue:5:c1", "9", "reference");
+        seed_outbound_ref(&conn, "repoA", "github:o/r:issue:5", "404", "reference");
+        // A giant single-paragraph body: the opening snapshot is capped (the prompt renders at
+        // most 200 chars of it — a multi-MB paragraph must not inflate the row).
+        seed_item(&conn, "repoA", "issue", "10", &"x".repeat(5_000), "closed", None);
+        seed_outbound_ref(&conn, "repoA", "github:o/r:issue:5", "10", "reference");
+
+        extract(&conn, None, &ExtractOptions::default()).unwrap();
+
+        let rows: Vec<(String, String, String, String)> = conn
+            .prepare(
+                "SELECT target_item_key, ref_kind, title, opening FROM papertrail_distill_xrefs
+                 WHERE item_kind='issue' AND item_key='5' ORDER BY xref_ordinal",
+            )
+            .unwrap()
+            .query_map([], |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)))
+            .unwrap()
+            .collect::<Result<_, _>>()
+            .unwrap();
+        assert_eq!(rows.len(), 2, "comment-source dup and unmirrored target contribute nothing");
+        assert_eq!(rows[0].0, "9");
+        assert_eq!(rows[0].1, "reference");
+        assert_eq!(rows[0].2, "t", "seeded title is frozen");
+        assert_eq!(rows[0].3, "Opening line.", "the opening paragraph only, not the body");
+        assert_eq!(rows[1].0, "10");
+        assert_eq!(rows[1].3.len(), 2_000, "a giant paragraph's opening is capped");
+
+        // The referenced records are eligible too, but their own records have no outbound refs.
+        assert_eq!(distill_count(&conn, "SELECT COUNT(*) FROM papertrail_distill_xrefs"), 2);
+    }
+
+    #[test]
+    fn xref_snapshot_cap_matches_the_prompt_xref_budget() {
+        // Rows beyond the snapshot cap are invisible to the prompt; a budget below the cap would
+        // hash rows the model never sees (spurious regeneration on their edits). Keep the two
+        // equal.
+        assert_eq!(
+            super::XREF_SNAPSHOT_CAP,
+            crate::distill::prompts::PromptBudget::default().max_xrefs,
+            "the snapshot cap and the render budget must move together"
+        );
+    }
+
+    #[test]
+    fn an_xref_title_edit_regenerates_the_record() {
+        // The referenced item's title is MUTABLE mirror state folded into the prompt, so an edit
+        // must regenerate the record exactly like a primary-source edit.
+        let conn = scoped_conn("repoA");
+        seed_item(&conn, "repoA", "issue", "5", "A bug. See #9.", "closed", None);
+        seed_item(&conn, "repoA", "issue", "9", "Opening line.", "closed", None);
+        seed_outbound_ref(&conn, "repoA", "github:o/r:issue:5", "9", "reference");
+
+        extract(&conn, None, &ExtractOptions::default()).unwrap();
+        let hash_before: String = conn
+            .query_row(
+                "SELECT distill_input_hash FROM papertrail_distill WHERE item_key='5'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        conn.execute(
+            "UPDATE papertrail_items SET title='Renamed referenced item' WHERE item_key='9'",
+            [],
+        )
+        .unwrap();
+        extract(&conn, None, &ExtractOptions::default()).unwrap();
+        let hash_after: String = conn
+            .query_row(
+                "SELECT distill_input_hash FROM papertrail_distill WHERE item_key='5'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_ne!(hash_before, hash_after, "a referenced title edit changes the input identity");
+        let title: String = conn
+            .query_row("SELECT title FROM papertrail_distill_xrefs WHERE item_key='5'", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        assert_eq!(title, "Renamed referenced item", "the snapshot re-froze the edited title");
+
+        // An identical rerun is stable: no new queue rows for either record (the still-queued
+        // NULL-stamped rows keep their place — draining, not extraction, retires them).
+        let queue_before = distill_count(&conn, "SELECT COUNT(*) FROM papertrail_distill_queue");
+        extract(&conn, None, &ExtractOptions::default()).unwrap();
+        assert_eq!(
+            distill_count(&conn, "SELECT COUNT(*) FROM papertrail_distill_queue"),
+            queue_before,
+            "unchanged input does not re-enqueue"
+        );
+        let hash_stable: String = conn
+            .query_row(
+                "SELECT distill_input_hash FROM papertrail_distill WHERE item_key='5'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(hash_after, hash_stable, "an identical rerun recomputes the same identity");
     }
 
     #[test]

--- a/crates/rag-rat-core/src/distill/output.rs
+++ b/crates/rag-rat-core/src/distill/output.rs
@@ -391,7 +391,7 @@ mod tests {
                     text: format!("Evidence {index}"),
                 })
                 .collect(),
-            partner: None,
+            partners: vec![],
             xrefs: vec![],
             fix_commits: vec![],
             symbols: vec![],

--- a/crates/rag-rat-core/src/distill/prompts.rs
+++ b/crates/rag-rat-core/src/distill/prompts.rs
@@ -20,7 +20,9 @@ use super::units::BudgetPlan;
 
 /// Bumped when the prompt text or schema changes in a way that should re-distill existing records.
 /// The drain folds this into the regeneration hash so a prompt edit re-runs the model. Start at 1.
-pub(crate) const PROMPT_VERSION: u32 = 2;
+/// 2 → 3 (#800): every coalesced partner renders (was: only the first), and the diff/xref blocks
+/// are now hydrated from extraction snapshots.
+pub(crate) const PROMPT_VERSION: u32 = 3;
 
 // Output bounds are shared contract constants so the later strict/fallback parser can enforce the
 // same limits as guided decoding rather than trusting the backend alone.
@@ -91,10 +93,13 @@ pub(crate) struct PartnerThread {
     pub units: Vec<PromptUnit>,
 }
 
-/// A cross-referenced item: its title plus the opening of its body, for context only.
+/// A cross-referenced item: its kind, key, the outbound ref's kind (`reference`/`fixes`/`reverts`
+/// — load-bearing for `outcome.status`), title, and the opening of its body. Context only.
 #[derive(Debug, Clone)]
 pub(crate) struct Xref {
+    pub kind: String,
     pub key: String,
+    pub ref_kind: String,
     pub title: String,
     pub opening: String,
 }
@@ -139,7 +144,9 @@ pub(crate) struct PromptInput {
     pub title: String,
     pub opened: String,
     pub units: Vec<PromptUnit>,
-    pub partner: Option<PartnerThread>,
+    /// Every coalesced partner thread, in the extraction's durable partner order. Each renders as
+    /// CONTEXT that may inform the decision/outcome, but none of their units may be cited.
+    pub partners: Vec<PartnerThread>,
     pub xrefs: Vec<Xref>,
     pub fix_commits: Vec<FixCommit>,
     pub symbols: Vec<SymbolContext>,
@@ -598,15 +605,27 @@ pub(crate) fn render_context(input: &PromptInput, budget: &PromptBudget) -> Stri
     out.push_str("THREAD UNITS (cite these numbers as evidence):\n");
     render_units(&mut out, &input.units, budget.units);
 
-    if let Some(partner) = &input.partner {
-        render_partner(&mut out, partner, budget.partner);
+    // Every coalesced partner, charged against ONE shared partner budget in durable order: the
+    // block stays hard-capped no matter how many threads coalesced.
+    if !input.partners.is_empty() {
+        let mut remaining = budget.partner;
+        for partner in &input.partners {
+            if remaining == 0 {
+                break;
+            }
+            let before = out.len();
+            render_partner(&mut out, partner, remaining);
+            remaining -= out.len() - before;
+        }
     }
     if !input.xrefs.is_empty() && budget.max_xrefs > 0 {
         out.push_str("\nREFERENCED ITEMS:\n");
         for x in input.xrefs.iter().take(budget.max_xrefs) {
             out.push_str(&format!(
-                "  #{}: {}",
+                "  [{}] #{} ({}): {}",
+                bounded_untrusted(&x.kind, 50),
                 bounded_untrusted(&x.key, 100),
+                bounded_untrusted(&x.ref_kind, 50),
                 neutralize(&truncate_chars(x.title.trim(), 200))
             ));
             let opening = x.opening.trim();
@@ -1031,7 +1050,7 @@ mod tests {
                 unit("issue #5", "The widget crashes every time the page loads."),
                 unit("comment c1", "Looks like a null deref in the render path."),
             ],
-            partner: None,
+            partners: vec![],
             xrefs: vec![],
             fix_commits: vec![],
             symbols: vec![],
@@ -1059,7 +1078,7 @@ mod tests {
         // Starts at 1; the drain folds it into the record's regeneration hash so a prompt edit
         // re-distills. Bump it (and this expectation) whenever `system.md`/`rules.md`/the schema
         // change in a way that should invalidate existing model output.
-        assert_eq!(super::PROMPT_VERSION, 2);
+        assert_eq!(super::PROMPT_VERSION, 3);
     }
 
     #[test]
@@ -1152,7 +1171,7 @@ mod tests {
         // grounded in the numbered primary units (honest null/[] when only the partner
         // establishes it), or the drain cannot materialize evidence for a partner-derived claim.
         assert!(
-            super::RULES.contains("if only the partner thread establishes something"),
+            super::RULES.contains("if only a partner thread establishes something"),
             "rules ground claims in citeable primary units"
         );
     }
@@ -1672,7 +1691,9 @@ mod tests {
         let mut input = base_input();
         input.xrefs = (0..100)
             .map(|i| Xref {
+                kind: "issue".to_string(),
                 key: format!("{i}"),
+                ref_kind: "reference".to_string(),
                 title: format!("XREF{i}"),
                 opening: String::new(),
             })
@@ -1771,12 +1792,12 @@ mod tests {
     #[test]
     fn partner_heading_is_charged_to_the_partner_budget() {
         let mut input = base_input();
-        input.partner = Some(PartnerThread {
+        input.partners = vec![PartnerThread {
             kind: "issue".to_string(),
             key: "5".to_string(),
             title: "The widget crashes on load".to_string(),
             units: vec![unit("issue #5", "Original report text.")],
-        });
+        }];
         // A zero partner budget renders no partner block at all.
         let zero = PromptBudget { partner: 0, ..PromptBudget::default() };
         assert!(
@@ -1800,14 +1821,16 @@ mod tests {
         let mut input = base_input();
         input.merged = true;
         input.kind = "change_request".to_string();
-        input.partner = Some(PartnerThread {
+        input.partners = vec![PartnerThread {
             kind: "issue".to_string(),
             key: "5".to_string(),
             title: "The widget crashes on load".to_string(),
             units: vec![unit("issue #5", "Original report text.")],
-        });
+        }];
         input.xrefs = vec![Xref {
+            kind: "issue".to_string(),
             key: "9".to_string(),
+            ref_kind: "reference".to_string(),
             title: "Related refactor".to_string(),
             opening: "We reworked the render path.".to_string(),
         }];
@@ -1826,7 +1849,11 @@ mod tests {
         assert!(prompt.contains("(merged)"), "merged PR header");
         assert!(prompt.contains("PARTNER THREAD (#5, issue, do NOT cite its units)"), "{prompt}");
         assert!(prompt.contains("REFERENCED ITEMS:"));
-        assert!(prompt.contains("#9: Related refactor — We reworked the render path."));
+        assert!(
+            prompt.contains(
+                "[issue] #9 (reference): Related refactor — We reworked the render path."
+            )
+        );
         assert!(prompt.contains("FIX COMMITS:") && prompt.contains("deadbeefcafe"), "short sha");
         assert!(prompt.contains("guard the null render path"), "full commit message body");
         assert!(prompt.contains("render_widget  (function, src/widget.rs)"), "symbol grounding");

--- a/crates/rag-rat-core/src/distill/prompts.rs
+++ b/crates/rag-rat-core/src/distill/prompts.rs
@@ -33,6 +33,12 @@ pub(crate) const MAX_REJECTED_ALTERNATIVES: usize = 20;
 pub(crate) const MAX_ALTERNATIVE_CHARS: usize = 500;
 pub(crate) const MAX_ANCHOR_INDICES: usize = 40;
 
+/// Max chars of a cross-referenced item's title and opening the prompt renders. The extraction
+/// snapshot caps the STORED (and hashed) text to this same width, so a referenced item's edit
+/// beyond what the model can see never regenerates the record — the length-dimension partner of
+/// the `max_xrefs` count invariant (see `xref_snapshot_cap_matches_the_prompt_xref_budget`).
+pub(crate) const XREF_TEXT_RENDER_CHARS: usize = 200;
+
 /// The system instructions (role + plain-prose + cite-by-unit rules). Authored as markdown in
 /// `prompts/system.md` and embedded at build time (the dream passes use the same pattern) so prompt
 /// edits are a documentation-shaped diff, not a Rust string literal.
@@ -626,11 +632,14 @@ pub(crate) fn render_context(input: &PromptInput, budget: &PromptBudget) -> Stri
                 bounded_untrusted(&x.kind, 50),
                 bounded_untrusted(&x.key, 100),
                 bounded_untrusted(&x.ref_kind, 50),
-                neutralize(&truncate_chars(x.title.trim(), 200))
+                neutralize(&truncate_chars(x.title.trim(), XREF_TEXT_RENDER_CHARS))
             ));
             let opening = x.opening.trim();
             if !opening.is_empty() {
-                out.push_str(&format!(" — {}", neutralize(&truncate_chars(opening, 200))));
+                out.push_str(&format!(
+                    " — {}",
+                    neutralize(&truncate_chars(opening, XREF_TEXT_RENDER_CHARS))
+                ));
             }
             out.push('\n');
         }
@@ -1007,7 +1016,9 @@ fn bounded_untrusted(s: &str, max_chars: usize) -> String {
 }
 
 /// Truncate to at most `max` chars (not bytes) on a char boundary — for human-facing snippets.
-fn truncate_chars(s: &str, max: usize) -> String {
+/// Idempotent: re-truncating an already-truncated value returns the same string, so the extraction
+/// snapshot can store `truncate_chars(text, N)` and the render re-apply it without drift.
+pub(crate) fn truncate_chars(s: &str, max: usize) -> String {
     match s.char_indices().nth(max) {
         Some((byte_idx, _)) => format!("{}…", &s[..byte_idx]),
         None => s.to_string(),

--- a/crates/rag-rat-core/src/distill/prompts/rules.md
+++ b/crates/rag-rat-core/src/distill/prompts/rules.md
@@ -11,4 +11,4 @@ Field rules:
 - outcome.status: landed | descoped | superseded | reverted | unclear.
 - outcome.summary: what actually happened, 1-2 sentences, concrete, or null if the thread does not establish it. State measured results as results and projections as projections — never assert a projected improvement as a delivered result.
 
-A PARTNER THREAD (the paired issue or pull request) may inform how you READ the primary thread, but its units are not numbered and cannot be cited. Every claim must be grounded in the numbered THREAD UNITS: if only the partner thread establishes something, leave that field null (or its citations []) rather than assert it without evidence — the fixing commit may still establish the outcome.
+PARTNER THREADs (the paired issue(s) or pull request(s)) may inform how you READ the primary thread, but their units are not numbered and cannot be cited. Every claim must be grounded in the numbered THREAD UNITS: if only a partner thread establishes something, leave that field null (or its citations []) rather than assert it without evidence — the fixing commit may still establish the outcome.

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_registry.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_registry.rs
@@ -232,6 +232,22 @@ fn register_repo_repoints_distill_rows_from_the_placeholder() {
         [LEGACY_REPO_ID],
     )
     .unwrap();
+    conn.execute(
+        "INSERT INTO papertrail_distill_fix_diffs
+             (tracker, project, item_kind, item_key, commit_sha, path, patch, repo_id)
+         VALUES ('github','o/r','issue','5','abc123','src/lib.rs','patch',?1)",
+        [LEGACY_REPO_ID],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO papertrail_distill_xrefs
+             (tracker, project, item_kind, item_key, xref_ordinal, target_tracker,
+              target_project, target_item_kind, target_item_key, ref_kind, title, opening,
+              repo_id)
+         VALUES ('github','o/r','issue','5',0,'github','o/r','issue','9','reference','t','o',?1)",
+        [LEGACY_REPO_ID],
+    )
+    .unwrap();
 
     register_repo(
         &conn,
@@ -246,7 +262,12 @@ fn register_repo_repoints_distill_rows_from_the_placeholder() {
         .query_row("SELECT repo_id FROM papertrail_distill WHERE item_key='5'", [], |r| r.get(0))
         .unwrap();
     assert_eq!(repo_id, "repo-abc", "the distill row is re-pointed to the adopted repo id");
-    for table in ["papertrail_distill_sources", "papertrail_distill_units"] {
+    for table in [
+        "papertrail_distill_sources",
+        "papertrail_distill_units",
+        "papertrail_distill_fix_diffs",
+        "papertrail_distill_xrefs",
+    ] {
         let adopted: i64 = conn
             .query_row(
                 &format!("SELECT COUNT(*) FROM {table} WHERE repo_id='repo-abc'"),

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
@@ -3152,9 +3152,9 @@ fn migration_078_distinguishes_candidates_from_selections() {
 }
 
 #[test]
-fn migration_079_is_the_tip_and_builds_safe_input_snapshots() {
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 79, "move this pin with the next schema migration");
-
+fn migration_079_builds_safe_input_snapshots() {
+    // `LATEST_SCHEMA_VERSION` pin moved to `migration_080_*`, the new tip; this uses only the
+    // symbolic checks (the hardcoded-LATEST footgun).
     let legacy = rusqlite::Connection::open_in_memory().unwrap();
     schema::apply_distill_record_store(&legacy).unwrap();
     schema::apply_distill_anchor_selection(&legacy).unwrap();
@@ -3244,7 +3244,7 @@ fn migration_079_is_the_tip_and_builds_safe_input_snapshots() {
 
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     schema::apply(&conn, &crate::index::migration_hooks()).unwrap();
-    assert_eq!(schema::status(&conn).unwrap().current_version, 79);
+    assert_eq!(schema::status(&conn).unwrap().current_version, schema::LATEST_SCHEMA_VERSION);
     let recorded: i64 = conn
         .query_row(
             "SELECT COUNT(*) FROM schema_version WHERE id = '079_distill_safe_input_snapshot'",
@@ -3253,4 +3253,110 @@ fn migration_079_is_the_tip_and_builds_safe_input_snapshots() {
         )
         .unwrap();
     assert_eq!(recorded, 1, "the forward migration records V079");
+}
+
+#[test]
+fn migration_080_is_the_tip_and_builds_enriched_context_snapshots() {
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 80, "move this pin with the next schema migration");
+
+    let legacy = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply_distill_record_store(&legacy).unwrap();
+    schema::apply_distill_anchor_selection(&legacy).unwrap();
+    schema::apply_distill_safe_input_snapshot(&legacy).unwrap();
+    assert!(!schema::table_exists(&legacy, "papertrail_distill_fix_diffs").unwrap());
+    assert!(!schema::table_exists(&legacy, "papertrail_distill_xrefs").unwrap());
+
+    schema::apply_distill_enriched_context(&legacy).unwrap();
+    for table in ["papertrail_distill_fix_diffs", "papertrail_distill_xrefs"] {
+        assert!(schema::table_exists(&legacy, table).unwrap(), "V080 table `{table}` exists");
+    }
+
+    legacy
+        .execute(
+            "INSERT INTO papertrail_distill_fix_diffs
+                 (tracker, project, item_kind, item_key, commit_sha, path, patch, repo_id)
+             VALUES ('github','o/r','issue','5','abc123','src/lib.rs','patch A','repoA')",
+            [],
+        )
+        .unwrap();
+    legacy
+        .execute(
+            "INSERT INTO papertrail_distill_fix_diffs
+                 (tracker, project, item_kind, item_key, commit_sha, path, patch, repo_id)
+             VALUES ('github','o/r','issue','5','abc123','src/lib.rs','patch B','repoB')",
+            [],
+        )
+        .unwrap();
+    assert!(
+        legacy
+            .execute(
+                "INSERT INTO papertrail_distill_fix_diffs
+                     (tracker, project, item_kind, item_key, commit_sha, path, patch, repo_id)
+                 VALUES ('github','o/r','issue','5','abc123','src/lib.rs','dup','repoA')",
+                [],
+            )
+            .is_err(),
+        "one patch row per (record, commit, path) inside the full repo-scoped record identity",
+    );
+    assert!(
+        legacy
+            .execute(
+                "INSERT INTO papertrail_distill_xrefs
+                     (tracker, project, item_kind, item_key, xref_ordinal, target_tracker,
+                      target_project, target_item_kind, target_item_key, ref_kind, title, opening,
+                      repo_id)
+                 VALUES ('github','o/r','issue','5',-1,'github','o/r','issue','9','reference',
+                         't','o','repoA')",
+                [],
+            )
+            .is_err(),
+        "xref ordinals are non-negative",
+    );
+    legacy
+        .execute(
+            "INSERT INTO papertrail_distill_xrefs
+                 (tracker, project, item_kind, item_key, xref_ordinal, target_tracker,
+                  target_project, target_item_kind, target_item_key, ref_kind, title, opening,
+                  repo_id)
+             VALUES ('github','o/r','issue','5',0,'github','o/r','issue','9','reference','t','o',
+                     'repoA')",
+            [],
+        )
+        .unwrap();
+    assert!(
+        legacy
+            .execute(
+                "INSERT INTO papertrail_distill_xrefs
+                     (tracker, project, item_kind, item_key, xref_ordinal, target_tracker,
+                      target_project, target_item_kind, target_item_key, ref_kind, title, opening,
+                      repo_id)
+                 VALUES ('github','o/r','issue','5',0,'github','o/r','issue','10','reference',
+                         't','o','repoA')",
+                [],
+            )
+            .is_err(),
+        "xref ordinals are unique within a record",
+    );
+
+    // Torn replay: the diff table survived, the xref table did not. The additive applier must
+    // converge without touching existing rows.
+    legacy.execute_batch("DROP TABLE papertrail_distill_xrefs;").unwrap();
+    schema::apply_distill_enriched_context(&legacy).unwrap();
+    assert!(schema::table_exists(&legacy, "papertrail_distill_xrefs").unwrap());
+    let diffs: i64 = legacy
+        .query_row("SELECT COUNT(*) FROM papertrail_distill_fix_diffs", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(diffs, 2, "replay preserves existing diff snapshots");
+
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn, &crate::index::migration_hooks()).unwrap();
+    assert_eq!(schema::status(&conn).unwrap().current_version, 80);
+    let recorded: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM schema_version WHERE id = '080_distill_enriched_context'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(recorded, 1, "the forward migration records V080");
 }

--- a/crates/rag-rat-db/src/schema/migrations.rs
+++ b/crates/rag-rat-db/src/schema/migrations.rs
@@ -1328,6 +1328,7 @@ pub(crate) fn known_version(migrations: &[AppliedMigration]) -> u32 {
             MIGRATION_077_ID => Some(77),
             MIGRATION_078_ID => Some(78),
             MIGRATION_079_ID => Some(79),
+            MIGRATION_080_ID => Some(80),
             _ => None,
         })
         .max()
@@ -1416,6 +1417,7 @@ pub(crate) fn known_migration(id: &str) -> bool {
             | MIGRATION_077_ID
             | MIGRATION_078_ID
             | MIGRATION_079_ID
+            | MIGRATION_080_ID
             | DIRTY_MIGRATION_ID
     )
 }
@@ -1501,6 +1503,7 @@ pub(crate) fn migration_checksum_mismatch(migration: &AppliedMigration) -> bool 
         MIGRATION_077_ID => migration.checksum != MIGRATION_077_CHECKSUM,
         MIGRATION_078_ID => migration.checksum != MIGRATION_078_CHECKSUM,
         MIGRATION_079_ID => migration.checksum != MIGRATION_079_CHECKSUM,
+        MIGRATION_080_ID => migration.checksum != MIGRATION_080_CHECKSUM,
         _ => false,
     }
 }
@@ -5544,6 +5547,56 @@ pub fn apply_distill_safe_input_snapshot(conn: &Connection) -> rusqlite::Result<
         CREATE INDEX IF NOT EXISTS idx_papertrail_distill_units_source
             ON papertrail_distill_units(
                 repo_id, tracker, project, item_kind, item_key, source_ordinal, unit_ordinal
+            );
+        ",
+    )
+}
+
+/// V080 — extraction-owned enriched-context snapshots (#800): the fix diff (restricted to files
+/// with symbol anchor candidates) and the thread's cross-referenced item titles + opening
+/// paragraphs, snapshotted so the drain never reads mutable git/mirror state.
+///
+/// There is deliberately no SQL backfill, same doctrine as V079: old derived records must
+/// regenerate under the bumped extraction pipeline and snapshot the git/mirror state read in that
+/// same transaction.
+pub fn apply_distill_enriched_context(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "
+        CREATE TABLE IF NOT EXISTS papertrail_distill_fix_diffs(
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            tracker TEXT NOT NULL,
+            project TEXT NOT NULL,
+            item_kind TEXT NOT NULL,
+            item_key TEXT NOT NULL,
+            commit_sha TEXT NOT NULL,
+            path TEXT NOT NULL,
+            patch TEXT NOT NULL,
+            repo_id TEXT NOT NULL DEFAULT '__unassigned__'
+        ) STRICT;
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_papertrail_distill_fix_diffs_file
+            ON papertrail_distill_fix_diffs(
+                repo_id, tracker, project, item_kind, item_key, commit_sha, path
+            );
+
+        CREATE TABLE IF NOT EXISTS papertrail_distill_xrefs(
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            tracker TEXT NOT NULL,
+            project TEXT NOT NULL,
+            item_kind TEXT NOT NULL,
+            item_key TEXT NOT NULL,
+            xref_ordinal INTEGER NOT NULL CHECK(xref_ordinal >= 0),
+            target_tracker TEXT NOT NULL,
+            target_project TEXT NOT NULL,
+            target_item_kind TEXT,
+            target_item_key TEXT NOT NULL,
+            ref_kind TEXT NOT NULL,
+            title TEXT NOT NULL,
+            opening TEXT NOT NULL,
+            repo_id TEXT NOT NULL DEFAULT '__unassigned__'
+        ) STRICT;
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_papertrail_distill_xrefs_ordinal
+            ON papertrail_distill_xrefs(
+                repo_id, tracker, project, item_kind, item_key, xref_ordinal
             );
         ",
     )

--- a/crates/rag-rat-db/src/schema/mod.rs
+++ b/crates/rag-rat-db/src/schema/mod.rs
@@ -11,17 +11,17 @@ pub use migrations::{
     apply_account_candidate_dag, apply_clone_delta_maintenance, apply_clone_df_epoch,
     apply_clone_fingerprint_tables, apply_clone_graph_tables, apply_content_candidate_dag,
     apply_content_projected_tables, apply_content_streams_pending_refold,
-    apply_distill_anchor_selection, apply_distill_record_store, apply_distill_safe_input_snapshot,
-    apply_dream_findings, apply_edge_string_interning, apply_edge_target_qname_index,
-    apply_external_symbols, apply_files_generation, apply_files_has_test_code,
-    apply_git_change_couplings, apply_github_child_key_widening, apply_github_repo_id_scoping,
-    apply_memory_model_failures_table, apply_memory_verification_tables, apply_move_per_repo_meta,
-    apply_oplog_device_identity, apply_oplog_device_x25519, apply_oplog_local_account,
-    apply_oplog_storage, apply_oplog_stream_scoping, apply_oracle_tables,
-    apply_papertrail_binding_health, apply_papertrail_distill_substrate,
-    apply_papertrail_mirror_resume_state, apply_papertrail_provider_neutral_schema,
-    apply_repo_id_core_scoping, apply_repo_id_periphery_scoping, apply_repos_registry,
-    apply_scip_moniker_anchors,
+    apply_distill_anchor_selection, apply_distill_enriched_context, apply_distill_record_store,
+    apply_distill_safe_input_snapshot, apply_dream_findings, apply_edge_string_interning,
+    apply_edge_target_qname_index, apply_external_symbols, apply_files_generation,
+    apply_files_has_test_code, apply_git_change_couplings, apply_github_child_key_widening,
+    apply_github_repo_id_scoping, apply_memory_model_failures_table,
+    apply_memory_verification_tables, apply_move_per_repo_meta, apply_oplog_device_identity,
+    apply_oplog_device_x25519, apply_oplog_local_account, apply_oplog_storage,
+    apply_oplog_stream_scoping, apply_oracle_tables, apply_papertrail_binding_health,
+    apply_papertrail_distill_substrate, apply_papertrail_mirror_resume_state,
+    apply_papertrail_provider_neutral_schema, apply_repo_id_core_scoping,
+    apply_repo_id_periphery_scoping, apply_repos_registry, apply_scip_moniker_anchors,
 };
 pub use migrations::{column_exists, rebuild_repo_memory_fts_with_repo_id, table_exists};
 pub use purge::{RepoRowCounts, count_repo_rows, purge_repo_rows, repo_scoped_table_names};
@@ -44,7 +44,7 @@ use serde::Serialize;
 
 use crate::hooks::MigrationHooks;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 79;
+pub const LATEST_SCHEMA_VERSION: u32 = 80;
 
 /// Every oracle-DERIVED persisted table — the outputs an `oracle run` writes that must OUTLIVE a
 /// reindex.
@@ -584,6 +584,14 @@ const MIGRATION_079_DESCRIPTION: &str =
      and every deterministic block-unit byte span; add prompt_version/model_input_hash \
      model-output stamps. Additive and intentionally does not backfill snapshots from the mutable \
      mirror";
+
+const MIGRATION_080_ID: &str = "080_distill_enriched_context";
+const MIGRATION_080_CHECKSUM: &str = "sha256:rag-rat-distill-enriched-context-v80";
+const MIGRATION_080_DESCRIPTION: &str =
+    "Add extraction-owned enriched-context snapshots for distillation (issue #800): \
+     per-fix-commit unified diffs restricted to files with symbol anchor candidates, and \
+     cross-referenced item titles + opening paragraphs mined from the thread's outbound \
+     papertrail refs. Additive and intentionally does not backfill from mutable git/mirror state";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -1249,6 +1257,12 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         checksum: MIGRATION_079_CHECKSUM,
         description: MIGRATION_079_DESCRIPTION,
         apply: MigrationFn::Plain(apply_distill_safe_input_snapshot),
+    },
+    Migration {
+        id: MIGRATION_080_ID,
+        checksum: MIGRATION_080_CHECKSUM,
+        description: MIGRATION_080_DESCRIPTION,
+        apply: MigrationFn::Plain(apply_distill_enriched_context),
     },
 ];
 

--- a/crates/rag-rat-db/src/schema/registry.rs
+++ b/crates/rag-rat-db/src/schema/registry.rs
@@ -69,6 +69,8 @@ const DIRECT_SCOPED_ADOPTION_TABLES: &[&str] = &[
     "papertrail_distill_runs",
     "papertrail_distill_sources",
     "papertrail_distill_units",
+    "papertrail_distill_fix_diffs",
+    "papertrail_distill_xrefs",
     // V056 (#566) derived change-coupling table: standalone, direct `repo_id`, no FK children, so
     // a LocalOnly→Portable adoption re-points its rows here (moving them together with the
     // `git_coupling_stamp` repo_meta so the derived table stays consistent + fresh), and the


### PR DESCRIPTION
Closes the deferred enrichment slice of #704's prompt contract (#800). All three context blocks the first runtime (#799) shipped empty are now populated — snapshotted at **extraction** time, per the V079 doctrine, so the drain still never reads mutable git/mirror state.

## What ships

- **Fix diff, capped by files with symbol candidates** — new V080 table `papertrail_distill_fix_diffs`: per fixing commit, a gix first-parent tree diff renders unified patches (real `UnifiedDiff`/`ConsumeBinaryHunk`, 3-line context) for exactly the paths that yielded a SYMBOL anchor candidate. Best-effort like `merge_first_parent_paths` (bad sha/shallow/binary → no rows, never a failed pass); 8k per-file cap; merges work (the usual fixing SHA).
- **Cross-referenced item titles + opening paragraphs** — new V080 table `papertrail_distill_xrefs`: outbound `papertrail_refs` keyed by the snapshot's OWN source identities (same `item_source_text`/`comment_source_text` formats the sync mines), targets resolved in the extraction transaction with parser namespace inheritance (bare `#N` prefers the source item's kind, then deterministic kind order) and frozen as title + first body block. Unmirrored targets drop; comment/item dup sources dedupe on resolved identity.
- **All coalesced partners** — `PromptInput.partner` → `partners: Vec`, rendered in durable `partner_ordinal` order against ONE shared 14k partner budget (sequential remaining-bytes accounting, so the hard-cap invariant holds regardless of coalesce fan-out). `rules.md` pluralized.

## Identity/invalidation

Both snapshots fold into `distill_input_hash` (domain tag `v3`) with `PIPELINE_VERSION` 2→3; a referenced item's **title edit regenerates the record** exactly like a primary-source edit (test-pinned). No SQL backfill — old records regenerate under the new pipeline. `PROMPT_VERSION` 2→3 (partners Vec + hydrated blocks).

## Verification

- `cargo nextest run -p rag-rat-core`: **1456 passed** (new: V080 tip/DDL/torn-replay test, adoption re-point for both tables, fix-diff snapshot + no-repo control, xref snapshot/dedupe/unmirrored-drop, xref-title-edit regeneration, drain render test for DIFF:/REFERENCED ITEMS, multi-partner render order).
- `cargo clippy --workspace --all-targets -- -D warnings`: clean; `cargo +nightly fmt`: clean.

## Notes

- `neutralize()` quotes real `--- a/…` diff header lines (they start with the `--- ` structural marker), so rendered DIFF blocks show `> --- a/…`. Deliberate: safe, deterministic, hunks unaffected. Flagged for a future marker-precision tweak if we care.
- #801's evidence `source_part` migration must renumber to **V081** — V080 is taken here.