### PR TITLE
feat(distill): persist source-part identity on evidence rows (#801)

### DIFF
--- a/crates/rag-rat-core/src/distill/drain.rs
+++ b/crates/rag-rat-core/src/distill/drain.rs
@@ -895,10 +895,10 @@ fn insert_evidence(
     let quote = &evidence.source.exact_text[evidence.unit.byte_start..evidence.unit.byte_end];
     conn.execute(
         "INSERT INTO papertrail_distill_evidence
-             (tracker, project, item_kind, item_key, field, source_kind, source_id, byte_start,
-              byte_end, quote, author, author_kind, author_association, unit_created_at_ms, \
-         repo_id)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)",
+             (tracker, project, item_kind, item_key, field, source_kind, source_part, source_id,
+              byte_start, byte_end, quote, author, author_kind, author_association,
+              unit_created_at_ms, repo_id)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)",
         params![
             key.tracker,
             key.project,
@@ -906,6 +906,9 @@ fn insert_evidence(
             key.item_key,
             evidence.field,
             evidence.source.source_kind,
+            // source_part (#801) distinguishes a title citation from a body citation on the same
+            // item — both carry the item key as source_id, so this is the only discriminator.
+            evidence.source.source_part,
             evidence.source.source_id,
             i64::try_from(evidence.unit.byte_start)?,
             i64::try_from(evidence.unit.byte_end)?,
@@ -974,7 +977,8 @@ mod tests {
     use std::sync::Mutex;
 
     use rag_rat_db::schema::{
-        apply_distill_anchor_selection, apply_distill_enriched_context, apply_distill_record_store,
+        apply_distill_anchor_selection, apply_distill_enriched_context,
+        apply_distill_evidence_source_part, apply_distill_record_store,
         apply_distill_safe_input_snapshot,
     };
     use rag_rat_llm::chat::{ChatModel, GuidedJson};
@@ -1027,6 +1031,7 @@ mod tests {
         apply_distill_anchor_selection(&conn).unwrap();
         apply_distill_safe_input_snapshot(&conn).unwrap();
         apply_distill_enriched_context(&conn).unwrap();
+        apply_distill_evidence_source_part(&conn).unwrap();
         conn.execute_batch(
             "CREATE TABLE git_commits(
                  hash TEXT NOT NULL, subject TEXT NOT NULL, body TEXT NOT NULL,
@@ -1117,6 +1122,64 @@ mod tests {
     }
 
     #[test]
+    fn evidence_records_the_part_each_citation_came_from() {
+        // #801: an item's title and body share the same source_id (the item key). A citation to the
+        // title and one to the body must be distinguishable in the persisted evidence — the only
+        // discriminator is source_part.
+        let conn = fixture();
+        let lock_db = tempfile::NamedTempFile::new().unwrap();
+        seed(&conn, "7", 20);
+        // seed() gives unit 0 → the body source (ordinal 1). Add unit 1 → the title source
+        // (ordinal 0), so the model can cite both parts of the same item.
+        conn.execute(
+            "INSERT INTO papertrail_distill_units
+                 (tracker, project, item_kind, item_key, unit_ordinal, source_ordinal, byte_start,
+                  byte_end, repo_id)
+             VALUES ('github', 'org/repo', 'issue', '7', 1, 0, 0, 7, 'repo')",
+            [],
+        )
+        .unwrap();
+        // root_cause cites the TITLE unit (1); decision and outcome cite the BODY unit (0).
+        let reply = serde_json::json!({
+            "root_issue": "The operation failed.",
+            "root_cause_units": [1],
+            "root_cause": "A stale decision caused the failure.",
+            "root_cause_class": "stale decision",
+            "decision_units": [0],
+            "decision": {"chosen": "Use the current decision.", "rejected": []},
+            "outcome_units": [0],
+            "anchor_indices": [0],
+            "outcome": {"status": "landed", "summary": "The fix landed."}
+        })
+        .to_string();
+
+        let report =
+            drain(&conn, lock_db.path(), "repo", &ScriptedModel::new(vec![Ok(reply)]), 10, 99)
+                .unwrap();
+        assert_eq!((report.threads, report.succeeded), (1, 1));
+
+        let rows: Vec<(String, String, String)> = conn
+            .prepare(
+                "SELECT field, source_part, source_id FROM papertrail_distill_evidence
+                 ORDER BY field",
+            )
+            .unwrap()
+            .query_map([], |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)))
+            .unwrap()
+            .collect::<Result<_, _>>()
+            .unwrap();
+        assert_eq!(
+            rows,
+            vec![
+                ("decision".to_string(), "body".to_string(), "7".to_string()),
+                ("outcome".to_string(), "body".to_string(), "7".to_string()),
+                ("root_cause".to_string(), "title".to_string(), "7".to_string()),
+            ],
+            "the title citation and the body citations share a source_id but differ by source_part",
+        );
+    }
+
+    #[test]
     fn successful_drain_persists_the_complete_model_transition() {
         let conn = fixture();
         let lock_db = tempfile::NamedTempFile::new().unwrap();
@@ -1173,6 +1236,16 @@ mod tests {
             })
             .unwrap(),
             "Cause and decision landed."
+        );
+        // Every citation here is the body unit, so the persisted evidence records its part (#801).
+        assert_eq!(
+            conn.query_row(
+                "SELECT DISTINCT source_part FROM papertrail_distill_evidence",
+                [],
+                |row| row.get::<_, String>(0)
+            )
+            .unwrap(),
+            "body",
         );
         assert_eq!(
             conn.query_row("SELECT selected FROM papertrail_distill_anchors", [], |row| row
@@ -1248,6 +1321,7 @@ mod tests {
         apply_distill_anchor_selection(&conn).unwrap();
         apply_distill_safe_input_snapshot(&conn).unwrap();
         apply_distill_enriched_context(&conn).unwrap();
+        apply_distill_evidence_source_part(&conn).unwrap();
         conn.execute_batch(
             "CREATE TABLE git_commits(
                  hash TEXT NOT NULL, subject TEXT NOT NULL, body TEXT NOT NULL,
@@ -1436,6 +1510,7 @@ mod tests {
         apply_distill_anchor_selection(&conn).unwrap();
         apply_distill_safe_input_snapshot(&conn).unwrap();
         apply_distill_enriched_context(&conn).unwrap();
+        apply_distill_evidence_source_part(&conn).unwrap();
         conn.execute_batch(
             "CREATE TABLE git_commits(
                  hash TEXT NOT NULL, subject TEXT NOT NULL, body TEXT NOT NULL,

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
@@ -3256,9 +3256,9 @@ fn migration_079_builds_safe_input_snapshots() {
 }
 
 #[test]
-fn migration_080_is_the_tip_and_builds_enriched_context_snapshots() {
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 80, "move this pin with the next schema migration");
-
+fn migration_080_builds_enriched_context_snapshots() {
+    // `LATEST_SCHEMA_VERSION` pin moved to `migration_081_*`, the new tip; this uses only the
+    // symbolic checks (the hardcoded-LATEST footgun).
     let legacy = rusqlite::Connection::open_in_memory().unwrap();
     schema::apply_distill_record_store(&legacy).unwrap();
     schema::apply_distill_anchor_selection(&legacy).unwrap();
@@ -3350,7 +3350,7 @@ fn migration_080_is_the_tip_and_builds_enriched_context_snapshots() {
 
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     schema::apply(&conn, &crate::index::migration_hooks()).unwrap();
-    assert_eq!(schema::status(&conn).unwrap().current_version, 80);
+    assert_eq!(schema::status(&conn).unwrap().current_version, schema::LATEST_SCHEMA_VERSION);
     let recorded: i64 = conn
         .query_row(
             "SELECT COUNT(*) FROM schema_version WHERE id = '080_distill_enriched_context'",
@@ -3359,4 +3359,78 @@ fn migration_080_is_the_tip_and_builds_enriched_context_snapshots() {
         )
         .unwrap();
     assert_eq!(recorded, 1, "the forward migration records V080");
+}
+
+#[test]
+fn migration_081_is_the_tip_and_adds_evidence_source_part() {
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 81, "move this pin with the next schema migration");
+
+    // The evidence table predates the column: build the record store (V077) without V081, then
+    // apply V081 and confirm the column appears.
+    let legacy = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply_distill_record_store(&legacy).unwrap();
+    assert!(
+        !schema::column_exists(&legacy, "papertrail_distill_evidence", "source_part").unwrap(),
+        "V077 evidence has no source_part",
+    );
+
+    schema::apply_distill_evidence_source_part(&legacy).unwrap();
+    assert!(
+        schema::column_exists(&legacy, "papertrail_distill_evidence", "source_part").unwrap(),
+        "V081 adds the source_part column",
+    );
+
+    // A pre-V081 row is representable with NULL source_part (the value CHECK passes NULL).
+    legacy
+        .execute(
+            "INSERT INTO papertrail_distill_evidence
+                 (tracker, project, item_kind, item_key, field, source_kind, source_id,
+                  byte_start, byte_end, quote, repo_id)
+             VALUES ('github','o/r','issue','5','root_cause','item','5',0,4,'quot','repoA')",
+            [],
+        )
+        .unwrap();
+    // A new row must carry one of title|body|comment.
+    legacy
+        .execute(
+            "INSERT INTO papertrail_distill_evidence
+                 (tracker, project, item_kind, item_key, field, source_kind, source_part,
+                  source_id, byte_start, byte_end, quote, repo_id)
+             VALUES ('github','o/r','issue','5','decision','item','title','5',0,4,'quot','repoA')",
+            [],
+        )
+        .unwrap();
+    assert!(
+        legacy
+            .execute(
+                "INSERT INTO papertrail_distill_evidence
+                     (tracker, project, item_kind, item_key, field, source_kind, source_part,
+                      source_id, byte_start, byte_end, quote, repo_id)
+                 VALUES ('github','o/r','issue','5','decision','item','headline','5',0,4,'q',
+                         'repoA')",
+                [],
+            )
+            .is_err(),
+        "source_part is CHECK-constrained to title|body|comment",
+    );
+
+    // Torn replay: the column already exists, so re-applying is a no-op, not a duplicate-column
+    // error, and existing rows survive.
+    schema::apply_distill_evidence_source_part(&legacy).unwrap();
+    let rows: i64 = legacy
+        .query_row("SELECT COUNT(*) FROM papertrail_distill_evidence", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(rows, 2, "an idempotent re-apply preserves existing evidence rows");
+
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn, &crate::index::migration_hooks()).unwrap();
+    assert_eq!(schema::status(&conn).unwrap().current_version, 81);
+    let recorded: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM schema_version WHERE id = '081_distill_evidence_source_part'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(recorded, 1, "the forward migration records V081");
 }

--- a/crates/rag-rat-db/src/schema/migrations.rs
+++ b/crates/rag-rat-db/src/schema/migrations.rs
@@ -1329,6 +1329,7 @@ pub(crate) fn known_version(migrations: &[AppliedMigration]) -> u32 {
             MIGRATION_078_ID => Some(78),
             MIGRATION_079_ID => Some(79),
             MIGRATION_080_ID => Some(80),
+            MIGRATION_081_ID => Some(81),
             _ => None,
         })
         .max()
@@ -1418,6 +1419,7 @@ pub(crate) fn known_migration(id: &str) -> bool {
             | MIGRATION_078_ID
             | MIGRATION_079_ID
             | MIGRATION_080_ID
+            | MIGRATION_081_ID
             | DIRTY_MIGRATION_ID
     )
 }
@@ -1504,6 +1506,7 @@ pub(crate) fn migration_checksum_mismatch(migration: &AppliedMigration) -> bool 
         MIGRATION_078_ID => migration.checksum != MIGRATION_078_CHECKSUM,
         MIGRATION_079_ID => migration.checksum != MIGRATION_079_CHECKSUM,
         MIGRATION_080_ID => migration.checksum != MIGRATION_080_CHECKSUM,
+        MIGRATION_081_ID => migration.checksum != MIGRATION_081_CHECKSUM,
         _ => false,
     }
 }
@@ -5599,6 +5602,30 @@ pub fn apply_distill_enriched_context(conn: &Connection) -> rusqlite::Result<()>
                 repo_id, tracker, project, item_kind, item_key, xref_ordinal
             );
         ",
+    )
+}
+
+/// V081 — persist source-part identity on distilled evidence rows (#801). V077's
+/// `papertrail_distill_evidence` stores `source_kind`/`source_id` but not WHICH part of an item a
+/// citation came from: an item's title and body share the same `source_id` (the item key), so two
+/// citations with identical or overlapping spans were indistinguishable in the persisted record —
+/// even though the V079 snapshot substrate keeps full identity at drain time. Add `source_part`
+/// (title|body|comment, matching the V079 CHECK), populated by the drain from its `SourceSnapshot`.
+///
+/// Nullable: existing rows predate the column and keep NULL (which passes the value CHECK). No SQL
+/// backfill — evidence is derived and rewritten wholesale on every drain, so a re-drain repopulates
+/// it (the derived-data doctrine of V079/V080). The source ITEM identity is deliberately NOT added:
+/// distilled evidence is primary-only (the drain rejects partner units), so the source item is
+/// always the record's own `(item_kind, item_key)` already stored on the row. Guarded by
+/// `column_exists` so a torn replay (column added, migration row not yet recorded) is a no-op
+/// rather than a duplicate-column error.
+pub fn apply_distill_evidence_source_part(conn: &Connection) -> rusqlite::Result<()> {
+    if column_exists(conn, "papertrail_distill_evidence", "source_part")? {
+        return Ok(());
+    }
+    conn.execute_batch(
+        "ALTER TABLE papertrail_distill_evidence
+             ADD COLUMN source_part TEXT CHECK(source_part IN ('title', 'body', 'comment'));",
     )
 }
 

--- a/crates/rag-rat-db/src/schema/mod.rs
+++ b/crates/rag-rat-db/src/schema/mod.rs
@@ -11,7 +11,8 @@ pub use migrations::{
     apply_account_candidate_dag, apply_clone_delta_maintenance, apply_clone_df_epoch,
     apply_clone_fingerprint_tables, apply_clone_graph_tables, apply_content_candidate_dag,
     apply_content_projected_tables, apply_content_streams_pending_refold,
-    apply_distill_anchor_selection, apply_distill_enriched_context, apply_distill_record_store,
+    apply_distill_anchor_selection, apply_distill_enriched_context,
+    apply_distill_evidence_source_part, apply_distill_record_store,
     apply_distill_safe_input_snapshot, apply_dream_findings, apply_edge_string_interning,
     apply_edge_target_qname_index, apply_external_symbols, apply_files_generation,
     apply_files_has_test_code, apply_git_change_couplings, apply_github_child_key_widening,
@@ -44,7 +45,7 @@ use serde::Serialize;
 
 use crate::hooks::MigrationHooks;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 80;
+pub const LATEST_SCHEMA_VERSION: u32 = 81;
 
 /// Every oracle-DERIVED persisted table — the outputs an `oracle run` writes that must OUTLIVE a
 /// reindex.
@@ -592,6 +593,14 @@ const MIGRATION_080_DESCRIPTION: &str =
      per-fix-commit unified diffs restricted to files with symbol anchor candidates, and \
      cross-referenced item titles + opening paragraphs mined from the thread's outbound \
      papertrail refs. Additive and intentionally does not backfill from mutable git/mirror state";
+
+const MIGRATION_081_ID: &str = "081_distill_evidence_source_part";
+const MIGRATION_081_CHECKSUM: &str = "sha256:rag-rat-distill-evidence-source-part-v81";
+const MIGRATION_081_DESCRIPTION: &str =
+    "Persist source-part identity (title|body|comment) on distilled evidence rows (issue #801) so \
+     a citation from an item's title is distinguishable from one in its body (both share the item \
+     key as source_id). Nullable and additive: existing rows keep NULL, the drain populates new \
+     rows from its snapshot, and no SQL backfill is performed (a re-drain rewrites evidence)";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -1263,6 +1272,12 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         checksum: MIGRATION_080_CHECKSUM,
         description: MIGRATION_080_DESCRIPTION,
         apply: MigrationFn::Plain(apply_distill_enriched_context),
+    },
+    Migration {
+        id: MIGRATION_081_ID,
+        checksum: MIGRATION_081_CHECKSUM,
+        description: MIGRATION_081_DESCRIPTION,
+        apply: MigrationFn::Plain(apply_distill_evidence_source_part),
     },
 ];
 


### PR DESCRIPTION
Closes #801.

V077's `papertrail_distill_evidence` stored `source_kind`/`source_id` but not **which part** of an item a citation came from. An item's title and body share the item key as `source_id`, so two citations from different parts with identical or overlapping spans were indistinguishable in the persisted record — even though the drain's `SourceSnapshot` (V079) keeps full identity.

## What ships

- **V081** `apply_distill_evidence_source_part`: `ALTER TABLE papertrail_distill_evidence ADD COLUMN source_part TEXT CHECK(source_part IN ('title','body','comment'))` — matching the V079 CHECK. Guarded by `column_exists` so a torn replay is a no-op, not a duplicate-column error.
- The drain's `insert_evidence` now writes `source_part` from its `SourceSnapshot`, so a title citation and a body citation on the same item are distinguishable by `source_part` (they still share `source_id`).

## Design decisions

- **Only `source_part`, not `source_item_kind`/`source_item_key`** (the issue's "consider"): distilled evidence is **primary-only** (`collect_evidence` rejects partner units), so the source item is always the record's own `(item_kind, item_key)` already on the row — the extra columns would be dead.
- **Nullable + additive, no SQL backfill, no version bump**: existing rows keep NULL (which passes the value CHECK); evidence is rewritten wholesale on every drain (`clear_model_junctions`), so a re-drain repopulates `source_part` natively. The full-corpus drain hasn't run, so nothing is stranded; a forced re-drain would re-run the model for a value derivable without it. This is the V079/V080 derived-data doctrine.

## Verification

- `migration_081_is_the_tip_and_adds_evidence_source_part`: column appears, NULL allowed for pre-V081 rows, CHECK rejects a bad value, torn-replay idempotency, full apply → v81 recorded. The old `migration_080_*` tip test de-pinned off the hardcoded LATEST.
- `evidence_records_the_part_each_citation_came_from`: a root_cause citation to the title and decision/outcome citations to the body persist as `source_part` `title` vs `body` with the same `source_id`.
- 4 CI clippy gates (`-D warnings --locked`) clean; `cargo nextest run --workspace --no-default-features`: 3443 passed, 0 skipped; nightly fmt clean.