### PR TITLE
feat(distill): coalesced record read-model + relocate the effective-status resolver (#804)

### DIFF
--- a/crates/rag-rat-core/src/distill/extract.rs
+++ b/crates/rag-rat-core/src/distill/extract.rs
@@ -546,13 +546,15 @@ fn write_record(
 
     let thread_shape = validate::classify_thread_shape(total_comments, review_comments, body_len);
 
-    // The mechanical effective status (model absent) — a floors-only preview for the report.
-    let mechanical_status = validate::effective_status(&validate::EffectiveStatusInputs {
-        revert_override,
-        closing_keyword: closing_keyword.is_some(),
-        fix_edge_source: plan.fix_edge_source,
-        model_status: None,
-    });
+    // The mechanical effective status (model absent) — a floors-only preview for the report. The
+    // resolver lives in the read layer (`rag_rat_papertrail`, #705); extraction reuses it here.
+    let mechanical_status =
+        rag_rat_papertrail::effective_status(&rag_rat_papertrail::EffectiveStatusInputs {
+            revert_override,
+            closing_keyword: closing_keyword.is_some(),
+            fix_edge_source: plan.fix_edge_source,
+            model_status: None,
+        });
 
     let input_hash = compute_input_hash(&HashInputs {
         pipeline_version: opts.pipeline_version,

--- a/crates/rag-rat-core/src/distill/validate.rs
+++ b/crates/rag-rat-core/src/distill/validate.rs
@@ -1,15 +1,13 @@
 //! Mechanical status floors and provenance checks for distilled records (#703).
 //!
-//! Every function here is PURE and deterministic — no DB, no model. The floors are the guardrails
-//! that keep a model's outcome/decision claims honest: the EFFECTIVE outcome status is computed
-//! from mechanical facts (was it reverted? does a closing keyword link the fix? is there any fix
-//! edge at all?) with fixed precedence, so the model can never over-claim "landed" on a thread that
-//! has no landing evidence. Phase 1 computes the mechanical inputs (revert / closing-keyword /
-//! fix-edge) and stores them raw; the LLM pass (#704) supplies `model_status` and the provenance
-//! evidence, and the read layer (#705) applies [`effective_status`]. All of it is implemented and
-//! tested here so the floor logic exists before either consumer does.
+//! Every function here is PURE and deterministic — no DB, no model. These are the WRITE-side
+//! guardrails: the extraction pass stores the raw mechanical floors (revert / closing-keyword /
+//! fix-edge) and the provenance verdicts, so a later model claim can be checked against them. The
+//! EFFECTIVE outcome status is resolved READ-side, over those floors, in
+//! `rag_rat_papertrail::effective_status` (#705) — it lives there because the read layer sits below
+//! `rag-rat-core` and cannot reach into it.
 
-use rag_rat_papertrail::{FixEdgeSource, OutcomeStatus, ThreadShape};
+use rag_rat_papertrail::{OutcomeStatus, ThreadShape};
 
 // NOTE: the closing-keyword floor is NOT derived by re-scanning commit text here. Reproducing the
 // reference grammar (provider-aware keyword sets incl. GitLab gerunds, project scoping, issue-vs-PR
@@ -20,11 +18,6 @@ use rag_rat_papertrail::{FixEdgeSource, OutcomeStatus, ThreadShape};
 // NOTE: the `revert_override` floor is computed in `extract` (a downstream landed commit whose body
 // reverts one of the record's CURRENT fix SHAs), not here. It deliberately does NOT key on the fix
 // commit itself being a `Revert` — intentional revert work that landed is `landed`, not `reverted`.
-
-/// The `no-fix-edge` floor: no closing edge and no merge commit establish that anything landed.
-pub(crate) fn no_fix_edge(fix_edge_source: FixEdgeSource) -> bool {
-    fix_edge_source == FixEdgeSource::None
-}
 
 /// A commenter/author association that denotes a maintainer (repo owner, org member, or invited
 /// collaborator). Case-insensitive; anything else (CONTRIBUTOR / NONE / bots / unknown) is not.
@@ -61,35 +54,6 @@ pub(crate) fn outcome_claim_verified(
     }
 }
 
-/// Inputs to the effective-status resolver: the mechanical floors plus the (optional) model status.
-pub(crate) struct EffectiveStatusInputs {
-    pub revert_override: bool,
-    pub closing_keyword: bool,
-    pub fix_edge_source: FixEdgeSource,
-    pub model_status: Option<OutcomeStatus>,
-}
-
-/// Resolve the EFFECTIVE outcome status with fixed precedence: revert > closing-keyword >
-/// no-fix-edge > model. A revert wins outright; a closing keyword forces `landed` (the fix
-/// mechanically closed the work); with no fix edge the record can never be `landed` (a model
-/// `landed`/absent collapses to `unclear`, while an honest `descoped`/`superseded` stands);
-/// otherwise the model's status is authoritative, defaulting to `unclear` when the model is silent.
-pub(crate) fn effective_status(inputs: &EffectiveStatusInputs) -> OutcomeStatus {
-    if inputs.revert_override {
-        return OutcomeStatus::Reverted;
-    }
-    if inputs.closing_keyword {
-        return OutcomeStatus::Landed;
-    }
-    if no_fix_edge(inputs.fix_edge_source) {
-        return match inputs.model_status {
-            Some(OutcomeStatus::Landed) | None => OutcomeStatus::Unclear,
-            Some(other) => other,
-        };
-    }
-    inputs.model_status.unwrap_or(OutcomeStatus::Unclear)
-}
-
 /// Mechanical thread-shape classification from discussion structure. `Thin` = little discussion (a
 /// short body and at most one comment); `ReviewStream` = review-dominated back-and-forth (review
 /// events are at least half of a non-trivial comment set); otherwise `Investigation`.
@@ -109,19 +73,12 @@ pub(crate) fn classify_thread_shape(
 
 #[cfg(test)]
 mod tests {
-    use rag_rat_papertrail::{FixEdgeSource, OutcomeStatus, ThreadShape};
+    use rag_rat_papertrail::{OutcomeStatus, ThreadShape};
 
     use super::{
-        EffectiveStatusInputs, classify_thread_shape, decision_provenance_verified,
-        effective_status, is_maintainer_association, no_fix_edge, outcome_claim_verified,
+        classify_thread_shape, decision_provenance_verified, is_maintainer_association,
+        outcome_claim_verified,
     };
-
-    #[test]
-    fn no_fix_edge_floor_fires_only_on_none() {
-        assert!(no_fix_edge(FixEdgeSource::None));
-        assert!(!no_fix_edge(FixEdgeSource::Provider));
-        assert!(!no_fix_edge(FixEdgeSource::Text));
-    }
 
     #[test]
     fn maintainer_and_decision_provenance() {
@@ -145,75 +102,6 @@ mod tests {
         // Non-landed claims are self-consistent without a fix edge.
         assert!(outcome_claim_verified(OutcomeStatus::Descoped, false, false));
         assert!(outcome_claim_verified(OutcomeStatus::Unclear, false, false));
-    }
-
-    #[test]
-    fn effective_status_precedence_revert_beats_everything() {
-        let status = effective_status(&EffectiveStatusInputs {
-            revert_override: true,
-            closing_keyword: true,
-            fix_edge_source: FixEdgeSource::Provider,
-            model_status: Some(OutcomeStatus::Landed),
-        });
-        assert_eq!(status, OutcomeStatus::Reverted);
-    }
-
-    #[test]
-    fn effective_status_closing_keyword_forces_landed_over_model() {
-        let status = effective_status(&EffectiveStatusInputs {
-            revert_override: false,
-            closing_keyword: true,
-            fix_edge_source: FixEdgeSource::Text,
-            model_status: Some(OutcomeStatus::Unclear),
-        });
-        assert_eq!(status, OutcomeStatus::Landed);
-    }
-
-    #[test]
-    fn effective_status_no_fix_edge_cannot_be_landed() {
-        // Model over-claims landed with no fix edge → collapses to unclear.
-        assert_eq!(
-            effective_status(&EffectiveStatusInputs {
-                revert_override: false,
-                closing_keyword: false,
-                fix_edge_source: FixEdgeSource::None,
-                model_status: Some(OutcomeStatus::Landed),
-            }),
-            OutcomeStatus::Unclear,
-        );
-        // An honest descoped stands.
-        assert_eq!(
-            effective_status(&EffectiveStatusInputs {
-                revert_override: false,
-                closing_keyword: false,
-                fix_edge_source: FixEdgeSource::None,
-                model_status: Some(OutcomeStatus::Descoped),
-            }),
-            OutcomeStatus::Descoped,
-        );
-    }
-
-    #[test]
-    fn effective_status_defers_to_model_when_a_fix_edge_exists() {
-        assert_eq!(
-            effective_status(&EffectiveStatusInputs {
-                revert_override: false,
-                closing_keyword: false,
-                fix_edge_source: FixEdgeSource::Provider,
-                model_status: Some(OutcomeStatus::Superseded),
-            }),
-            OutcomeStatus::Superseded,
-        );
-        // Silent model with a fix edge → unclear (not a fabricated landed).
-        assert_eq!(
-            effective_status(&EffectiveStatusInputs {
-                revert_override: false,
-                closing_keyword: false,
-                fix_edge_source: FixEdgeSource::Provider,
-                model_status: None,
-            }),
-            OutcomeStatus::Unclear,
-        );
     }
 
     #[test]

--- a/crates/rag-rat-papertrail/src/distill_read.rs
+++ b/crates/rag-rat-papertrail/src/distill_read.rs
@@ -99,6 +99,9 @@ fn coalesced_partners(
     repo_id: &str,
     key: &RecordKey,
 ) -> anyhow::Result<Vec<CoalescedThread>> {
+    // ORDER BY the combined UNION so the partner list is DETERMINISTIC: when one PR closes several
+    // issues (`Closes #5, Closes #7`), both are valid owners, so the redirect target and the
+    // rendered `coalesced` order must not depend on SQLite's unspecified UNION order.
     let mut stmt = conn.prepare(
         "SELECT dst_item_kind, dst_item_key FROM papertrail_distill_edges
          WHERE repo_id = ?1 AND tracker = ?2 AND project = ?3 AND edge_kind = ?4
@@ -106,7 +109,8 @@ fn coalesced_partners(
          UNION
          SELECT src_item_kind, src_item_key FROM papertrail_distill_edges
          WHERE repo_id = ?1 AND tracker = ?2 AND project = ?3 AND edge_kind = ?4
-           AND dst_item_kind = ?5 AND dst_item_key = ?6",
+           AND dst_item_kind = ?5 AND dst_item_key = ?6
+         ORDER BY 1, 2",
     )?;
     let rows = stmt.query_map(
         params![
@@ -484,6 +488,36 @@ mod tests {
         let via_issue =
             distilled_record_for_thread(&conn, "repoA", &key("issue", "5")).unwrap().unwrap();
         assert_eq!(via_issue.item_key, "5");
+    }
+
+    #[test]
+    fn a_pr_closing_several_issues_redirects_deterministically() {
+        // One merged PR closing issue #5 AND issue #7 (`Closes #5, Closes #7`) yields two coalesced
+        // edges to the same PR; both issues own records. The PR lookup must resolve to the SAME
+        // issue every time (lowest by (kind, key)), not an arbitrary one in SQLite's UNION order.
+        let conn = conn();
+        for issue in ["5", "7"] {
+            seed_record(&conn, &Seed {
+                repo: "repoA",
+                kind: "issue",
+                key: issue,
+                root_issue: Some(issue),
+                model_status: Some("landed"),
+                fix_edge_source: "provider",
+                revert_override: false,
+                closing_keyword: Some("closes"),
+            });
+            seed_coalesced_edge(&conn, "repoA", ("issue", issue), ("change_request", "6"));
+        }
+        for _ in 0..5 {
+            let record = distilled_record_for_thread(&conn, "repoA", &key("change_request", "6"))
+                .unwrap()
+                .unwrap();
+            assert_eq!(
+                record.item_key, "5",
+                "the PR redirects to the ordinally-first owning issue"
+            );
+        }
     }
 
     #[test]

--- a/crates/rag-rat-papertrail/src/distill_read.rs
+++ b/crates/rag-rat-papertrail/src/distill_read.rs
@@ -1,0 +1,519 @@
+//! Read model for distilled decision records (#705).
+//!
+//! The distilled record store (#703) is written by `rag-rat-core`'s extraction + LLM passes and,
+//! until now, read by nothing. This is the read side: [`distilled_record_for_thread`] loads a
+//! record (main row + junctions) by thread identity and resolves the EFFECTIVE outcome status
+//! ([`crate::distill_status::effective_status`]) — never the raw `outcome_status_model`, which the
+//! mechanical floors can override.
+//!
+//! Coalescing: a merged PR that closed an issue does NOT get its own record — the issue's row owns
+//! the pair (the extraction coalesces via a `coalesced` edge). So a lookup keyed by such a PR
+//! follows the edge to the issue that holds the record, and every record carries the identities of
+//! the threads coalesced into it so a caller can present an issue↔PR pair as one result.
+
+use rusqlite::{Connection, OptionalExtension, params};
+
+use crate::distill_status::{EffectiveStatusInputs, effective_status};
+use crate::{DistillEdgeKind, EpistemicStatus, FixEdgeSource, OutcomeStatus, ThreadShape};
+
+/// A thread's natural identity — the key of a `papertrail_distill` row.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RecordKey {
+    pub tracker: String,
+    pub project: String,
+    pub item_kind: String,
+    pub item_key: String,
+}
+
+/// A thread coalesced into a record (the paired issue or PR), for issue↔PR dedup at the call site.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CoalescedThread {
+    pub item_kind: String,
+    pub item_key: String,
+}
+
+/// An alternative the thread explicitly considered and did not take.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RejectedAlternative {
+    pub alternative: String,
+    pub reason: Option<String>,
+}
+
+/// A distilled decision record as the consumption surfaces see it: the model-owned narrative
+/// fields, the mechanically resolved effective status, the rejected alternatives, the fixing
+/// commits, the provenance facets, and the coalesced partner identities.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DistilledRecord {
+    pub tracker: String,
+    pub project: String,
+    pub item_kind: String,
+    pub item_key: String,
+    pub root_issue: Option<String>,
+    pub root_cause: Option<String>,
+    pub root_cause_class: Option<String>,
+    pub decision_chosen: Option<String>,
+    pub rejected_alternatives: Vec<RejectedAlternative>,
+    /// The EFFECTIVE outcome status (floors resolved over the model status) — surface this, never
+    /// [`outcome_status_model`](Self::outcome_status_model) alone.
+    pub outcome_status: OutcomeStatus,
+    /// The raw model-emitted status, kept for provenance/debugging; may differ from
+    /// [`outcome_status`](Self::outcome_status) when a mechanical floor overrode it.
+    pub outcome_status_model: Option<OutcomeStatus>,
+    pub outcome_summary: Option<String>,
+    pub epistemic_status_decision: Option<EpistemicStatus>,
+    pub epistemic_status_outcome: Option<EpistemicStatus>,
+    pub fix_edge_source: FixEdgeSource,
+    pub thread_shape: ThreadShape,
+    pub outcome_claim_verified: bool,
+    pub decision_provenance_verified: bool,
+    pub anchors_qualified_count: i64,
+    pub fixing_commits: Vec<String>,
+    /// The issue/PR threads coalesced into this record — present so a caller can answer an
+    /// issue↔PR pair as one result.
+    pub coalesced: Vec<CoalescedThread>,
+}
+
+/// Load the canonical distilled record for a thread, following a `coalesced` edge when the thread
+/// was coalesced into a partner that owns the row. `None` when no record exists for the thread or
+/// its coalesce partner. `repo_id` is the active repo (mandatory: the store is one index over every
+/// repo in a consolidated DB), passed by the caller so a per-hit loop resolves it once.
+pub fn distilled_record_for_thread(
+    conn: &Connection,
+    repo_id: &str,
+    key: &RecordKey,
+) -> anyhow::Result<Option<DistilledRecord>> {
+    if let Some(record) = load_record(conn, repo_id, key)? {
+        return Ok(Some(record));
+    }
+    // No own row: the thread may be a merged PR coalesced into the issue that owns the record.
+    if let Some(partner) = coalesced_partner_owning_a_record(conn, repo_id, key)? {
+        return load_record(conn, repo_id, &partner);
+    }
+    Ok(None)
+}
+
+/// The threads a `coalesced` edge connects to `key`, in either direction (the edge is thread-keyed
+/// and survives record regeneration).
+fn coalesced_partners(
+    conn: &Connection,
+    repo_id: &str,
+    key: &RecordKey,
+) -> anyhow::Result<Vec<CoalescedThread>> {
+    let mut stmt = conn.prepare(
+        "SELECT dst_item_kind, dst_item_key FROM papertrail_distill_edges
+         WHERE repo_id = ?1 AND tracker = ?2 AND project = ?3 AND edge_kind = ?4
+           AND src_item_kind = ?5 AND src_item_key = ?6
+         UNION
+         SELECT src_item_kind, src_item_key FROM papertrail_distill_edges
+         WHERE repo_id = ?1 AND tracker = ?2 AND project = ?3 AND edge_kind = ?4
+           AND dst_item_kind = ?5 AND dst_item_key = ?6",
+    )?;
+    let rows = stmt.query_map(
+        params![
+            repo_id,
+            key.tracker,
+            key.project,
+            DistillEdgeKind::Coalesced.as_db_str(),
+            key.item_kind,
+            key.item_key,
+        ],
+        |row| Ok(CoalescedThread { item_kind: row.get(0)?, item_key: row.get(1)? }),
+    )?;
+    let mut partners = Vec::new();
+    for row in rows {
+        partners.push(row?);
+    }
+    Ok(partners)
+}
+
+/// The first coalesce partner of `key` that actually owns a `papertrail_distill` row — the redirect
+/// target for a thread (a coalesced-away merged PR) with no record of its own.
+fn coalesced_partner_owning_a_record(
+    conn: &Connection,
+    repo_id: &str,
+    key: &RecordKey,
+) -> anyhow::Result<Option<RecordKey>> {
+    for partner in coalesced_partners(conn, repo_id, key)? {
+        let partner_key = RecordKey {
+            tracker: key.tracker.clone(),
+            project: key.project.clone(),
+            item_kind: partner.item_kind,
+            item_key: partner.item_key,
+        };
+        if record_exists(conn, repo_id, &partner_key)? {
+            return Ok(Some(partner_key));
+        }
+    }
+    Ok(None)
+}
+
+fn record_exists(conn: &Connection, repo_id: &str, key: &RecordKey) -> anyhow::Result<bool> {
+    conn.query_row(
+        "SELECT EXISTS(
+             SELECT 1 FROM papertrail_distill
+             WHERE repo_id = ?1 AND tracker = ?2 AND project = ?3 AND item_kind = ?4
+               AND item_key = ?5
+         )",
+        params![repo_id, key.tracker, key.project, key.item_kind, key.item_key],
+        |row| row.get(0),
+    )
+    .map_err(Into::into)
+}
+
+/// Load the full record for a thread that owns a row (no coalesce redirect). `None` if absent.
+fn load_record(
+    conn: &Connection,
+    repo_id: &str,
+    key: &RecordKey,
+) -> anyhow::Result<Option<DistilledRecord>> {
+    let row = conn
+        .query_row(
+            "SELECT root_issue, root_cause, root_cause_class, decision_chosen, outcome_summary,
+                    outcome_status_model, epistemic_status_decision, epistemic_status_outcome,
+                    fix_edge_source, thread_shape, outcome_claim_verified,
+                    decision_provenance_verified, anchors_qualified_count, revert_override,
+                    closing_keyword_floor
+             FROM papertrail_distill
+             WHERE repo_id = ?1 AND tracker = ?2 AND project = ?3 AND item_kind = ?4
+               AND item_key = ?5",
+            params![repo_id, key.tracker, key.project, key.item_kind, key.item_key],
+            |row| {
+                Ok(MainRow {
+                    root_issue: row.get(0)?,
+                    root_cause: row.get(1)?,
+                    root_cause_class: row.get(2)?,
+                    decision_chosen: row.get(3)?,
+                    outcome_summary: row.get(4)?,
+                    outcome_status_model: row.get(5)?,
+                    epistemic_status_decision: row.get(6)?,
+                    epistemic_status_outcome: row.get(7)?,
+                    fix_edge_source: row.get(8)?,
+                    thread_shape: row.get(9)?,
+                    outcome_claim_verified: row.get(10)?,
+                    decision_provenance_verified: row.get(11)?,
+                    anchors_qualified_count: row.get(12)?,
+                    revert_override: row.get(13)?,
+                    closing_keyword_floor: row.get(14)?,
+                })
+            },
+        )
+        .optional()?;
+    let Some(row) = row else { return Ok(None) };
+
+    let fix_edge_source = FixEdgeSource::from_db_str(&row.fix_edge_source)?;
+    let outcome_status_model =
+        row.outcome_status_model.as_deref().map(OutcomeStatus::from_db_str).transpose()?;
+    let outcome_status = effective_status(&EffectiveStatusInputs {
+        revert_override: row.revert_override,
+        closing_keyword: row.closing_keyword_floor.is_some(),
+        fix_edge_source,
+        model_status: outcome_status_model,
+    });
+
+    Ok(Some(DistilledRecord {
+        tracker: key.tracker.clone(),
+        project: key.project.clone(),
+        item_kind: key.item_kind.clone(),
+        item_key: key.item_key.clone(),
+        root_issue: row.root_issue,
+        root_cause: row.root_cause,
+        root_cause_class: row.root_cause_class,
+        decision_chosen: row.decision_chosen,
+        rejected_alternatives: rejected_alternatives(conn, repo_id, key)?,
+        outcome_status,
+        outcome_status_model,
+        outcome_summary: row.outcome_summary,
+        epistemic_status_decision: row
+            .epistemic_status_decision
+            .as_deref()
+            .map(EpistemicStatus::from_db_str)
+            .transpose()?,
+        epistemic_status_outcome: row
+            .epistemic_status_outcome
+            .as_deref()
+            .map(EpistemicStatus::from_db_str)
+            .transpose()?,
+        fix_edge_source,
+        thread_shape: ThreadShape::from_db_str(&row.thread_shape)?,
+        outcome_claim_verified: row.outcome_claim_verified,
+        decision_provenance_verified: row.decision_provenance_verified,
+        anchors_qualified_count: row.anchors_qualified_count,
+        fixing_commits: fixing_commits(conn, repo_id, key)?,
+        coalesced: coalesced_partners(conn, repo_id, key)?,
+    }))
+}
+
+/// The raw `papertrail_distill` columns the read model needs, before enum parsing.
+struct MainRow {
+    root_issue: Option<String>,
+    root_cause: Option<String>,
+    root_cause_class: Option<String>,
+    decision_chosen: Option<String>,
+    outcome_summary: Option<String>,
+    outcome_status_model: Option<String>,
+    epistemic_status_decision: Option<String>,
+    epistemic_status_outcome: Option<String>,
+    fix_edge_source: String,
+    thread_shape: String,
+    outcome_claim_verified: bool,
+    decision_provenance_verified: bool,
+    anchors_qualified_count: i64,
+    revert_override: bool,
+    closing_keyword_floor: Option<String>,
+}
+
+fn rejected_alternatives(
+    conn: &Connection,
+    repo_id: &str,
+    key: &RecordKey,
+) -> anyhow::Result<Vec<RejectedAlternative>> {
+    let mut stmt = conn.prepare(
+        "SELECT alternative, reason FROM papertrail_distill_alternatives
+         WHERE repo_id = ?1 AND tracker = ?2 AND project = ?3 AND item_kind = ?4 AND item_key = ?5
+         ORDER BY ordinal",
+    )?;
+    let rows = stmt.query_map(
+        params![repo_id, key.tracker, key.project, key.item_kind, key.item_key],
+        |row| Ok(RejectedAlternative { alternative: row.get(0)?, reason: row.get(1)? }),
+    )?;
+    let mut out = Vec::new();
+    for row in rows {
+        out.push(row?);
+    }
+    Ok(out)
+}
+
+fn fixing_commits(
+    conn: &Connection,
+    repo_id: &str,
+    key: &RecordKey,
+) -> anyhow::Result<Vec<String>> {
+    let mut stmt = conn.prepare(
+        "SELECT commit_sha FROM papertrail_distill_record_commits
+         WHERE repo_id = ?1 AND tracker = ?2 AND project = ?3 AND item_kind = ?4 AND item_key = ?5
+         ORDER BY commit_sha",
+    )?;
+    let rows = stmt.query_map(
+        params![repo_id, key.tracker, key.project, key.item_kind, key.item_key],
+        |row| row.get::<_, String>(0),
+    )?;
+    let mut out = Vec::new();
+    for row in rows {
+        out.push(row?);
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use rusqlite::{Connection, params};
+
+    use super::{RecordKey, distilled_record_for_thread};
+    use crate::{FixEdgeSource, OutcomeStatus, ThreadShape};
+
+    fn conn() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        rag_rat_db::schema::apply_distill_record_store(&conn).unwrap();
+        conn
+    }
+
+    fn key(kind: &str, k: &str) -> RecordKey {
+        RecordKey {
+            tracker: "github".into(),
+            project: "o/r".into(),
+            item_kind: kind.into(),
+            item_key: k.into(),
+        }
+    }
+
+    /// A seed for one `papertrail_distill` row; nullable fields as `Option`, booleans as `bool`.
+    struct Seed<'a> {
+        repo: &'a str,
+        kind: &'a str,
+        key: &'a str,
+        root_issue: Option<&'a str>,
+        model_status: Option<&'a str>,
+        fix_edge_source: &'a str,
+        revert_override: bool,
+        closing_keyword: Option<&'a str>,
+    }
+
+    fn seed_record(conn: &Connection, s: &Seed) {
+        conn.execute(
+            "INSERT INTO papertrail_distill
+                 (tracker, project, item_kind, item_key, distill_input_hash, pipeline_version,
+                  root_issue, outcome_status_model, fix_edge_source, thread_shape, revert_override,
+                  closing_keyword_floor, anchors_qualified_count, distilled_at_ms, repo_id)
+             VALUES ('github','o/r',?1,?2,'sha256:h',3,?3,?4,?5,'investigation',?6,?7,2,1,?8)",
+            params![
+                s.kind,
+                s.key,
+                s.root_issue,
+                s.model_status,
+                s.fix_edge_source,
+                s.revert_override as i64,
+                s.closing_keyword,
+                s.repo,
+            ],
+        )
+        .unwrap();
+    }
+
+    fn seed_coalesced_edge(conn: &Connection, repo: &str, src: (&str, &str), dst: (&str, &str)) {
+        conn.execute(
+            "INSERT INTO papertrail_distill_edges
+                 (tracker, project, src_item_kind, src_item_key, dst_item_kind, dst_item_key,
+                  edge_kind, created_at_ms, repo_id)
+             VALUES ('github','o/r',?1,?2,?3,?4,'coalesced',1,?5)",
+            params![src.0, src.1, dst.0, dst.1, repo],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn loads_the_record_fields_alternatives_and_commits_in_order() {
+        let conn = conn();
+        seed_record(&conn, &Seed {
+            repo: "repoA",
+            kind: "issue",
+            key: "5",
+            root_issue: Some("The widget crashes."),
+            model_status: Some("superseded"),
+            fix_edge_source: "provider",
+            revert_override: false,
+            closing_keyword: None,
+        });
+        // Alternatives out of ordinal order; the read model returns them by ordinal.
+        conn.execute(
+            "INSERT INTO papertrail_distill_alternatives
+                 (tracker, project, item_kind, item_key, ordinal, alternative, reason, repo_id)
+             VALUES ('github','o/r','issue','5',1,'Retry','Too slow','repoA'),
+                    ('github','o/r','issue','5',0,'Cache',NULL,'repoA')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO papertrail_distill_record_commits
+                 (tracker, project, item_kind, item_key, commit_sha, repo_id)
+             VALUES ('github','o/r','issue','5','bbb','repoA'),
+                    ('github','o/r','issue','5','aaa','repoA')",
+            [],
+        )
+        .unwrap();
+
+        let record =
+            distilled_record_for_thread(&conn, "repoA", &key("issue", "5")).unwrap().unwrap();
+        assert_eq!(record.item_key, "5");
+        assert_eq!(record.root_issue.as_deref(), Some("The widget crashes."));
+        assert_eq!(record.fix_edge_source, FixEdgeSource::Provider);
+        assert_eq!(record.thread_shape, ThreadShape::Investigation);
+        assert_eq!(record.anchors_qualified_count, 2);
+        // A fix edge exists and no floor overrides → the effective status defers to the model.
+        assert_eq!(record.outcome_status, OutcomeStatus::Superseded);
+        assert_eq!(record.outcome_status_model, Some(OutcomeStatus::Superseded));
+        assert_eq!(
+            record.rejected_alternatives.iter().map(|a| a.alternative.as_str()).collect::<Vec<_>>(),
+            vec!["Cache", "Retry"],
+            "alternatives come back in ordinal order",
+        );
+        assert_eq!(record.rejected_alternatives[0].reason, None);
+        assert_eq!(record.rejected_alternatives[1].reason.as_deref(), Some("Too slow"));
+        assert_eq!(record.fixing_commits, vec!["aaa".to_string(), "bbb".to_string()]);
+        assert!(record.coalesced.is_empty());
+    }
+
+    #[test]
+    fn a_mechanical_floor_overrides_the_model_status() {
+        // The read model must apply the effective-status resolver, never the raw model column: a
+        // revert override beats a model claim of `landed`.
+        let conn = conn();
+        seed_record(&conn, &Seed {
+            repo: "repoA",
+            kind: "issue",
+            key: "5",
+            root_issue: None,
+            model_status: Some("landed"),
+            fix_edge_source: "provider",
+            revert_override: true,
+            closing_keyword: None,
+        });
+        let record =
+            distilled_record_for_thread(&conn, "repoA", &key("issue", "5")).unwrap().unwrap();
+        assert_eq!(record.outcome_status, OutcomeStatus::Reverted, "the floor wins");
+        assert_eq!(
+            record.outcome_status_model,
+            Some(OutcomeStatus::Landed),
+            "the raw claim is kept"
+        );
+    }
+
+    #[test]
+    fn a_coalesced_pr_hit_redirects_to_the_issue_record() {
+        // A merged PR coalesced into an issue has no record of its own; a lookup by the PR follows
+        // the `coalesced` edge to the issue that owns the record, which carries the PR as a
+        // partner.
+        let conn = conn();
+        seed_record(&conn, &Seed {
+            repo: "repoA",
+            kind: "issue",
+            key: "5",
+            root_issue: Some("Owned by the issue."),
+            model_status: Some("landed"),
+            fix_edge_source: "provider",
+            revert_override: false,
+            closing_keyword: Some("closes"),
+        });
+        seed_coalesced_edge(&conn, "repoA", ("issue", "5"), ("change_request", "6"));
+
+        let via_pr = distilled_record_for_thread(&conn, "repoA", &key("change_request", "6"))
+            .unwrap()
+            .unwrap();
+        assert_eq!(via_pr.item_kind, "issue");
+        assert_eq!(via_pr.item_key, "5", "the PR hit resolves to the issue's record");
+        assert_eq!(via_pr.root_issue.as_deref(), Some("Owned by the issue."));
+        assert_eq!(
+            via_pr
+                .coalesced
+                .iter()
+                .map(|c| (c.item_kind.as_str(), c.item_key.as_str()))
+                .collect::<Vec<_>>(),
+            vec![("change_request", "6")],
+            "the record names the PR coalesced into it",
+        );
+        // A direct lookup by the issue key returns the same record.
+        let via_issue =
+            distilled_record_for_thread(&conn, "repoA", &key("issue", "5")).unwrap().unwrap();
+        assert_eq!(via_issue.item_key, "5");
+    }
+
+    #[test]
+    fn no_record_and_no_coalesce_partner_returns_none() {
+        let conn = conn();
+        assert!(
+            distilled_record_for_thread(&conn, "repoA", &key("issue", "99")).unwrap().is_none()
+        );
+    }
+
+    #[test]
+    fn reads_are_repo_scoped() {
+        // The same natural key exists in two repos of a consolidated DB; the read must not cross.
+        let conn = conn();
+        for (repo, root) in [("repoA", "A's issue"), ("repoB", "B's issue")] {
+            seed_record(&conn, &Seed {
+                repo,
+                kind: "issue",
+                key: "5",
+                root_issue: Some(root),
+                model_status: Some("landed"),
+                fix_edge_source: "provider",
+                revert_override: false,
+                closing_keyword: None,
+            });
+        }
+        let a = distilled_record_for_thread(&conn, "repoA", &key("issue", "5")).unwrap().unwrap();
+        assert_eq!(a.root_issue.as_deref(), Some("A's issue"));
+        let b = distilled_record_for_thread(&conn, "repoB", &key("issue", "5")).unwrap().unwrap();
+        assert_eq!(b.root_issue.as_deref(), Some("B's issue"));
+        assert!(distilled_record_for_thread(&conn, "repoC", &key("issue", "5")).unwrap().is_none());
+    }
+}

--- a/crates/rag-rat-papertrail/src/distill_status.rs
+++ b/crates/rag-rat-papertrail/src/distill_status.rs
@@ -1,0 +1,131 @@
+//! Effective outcome-status resolution for distilled records (#703 floors, #705 read layer).
+//!
+//! These functions are PURE and deterministic — no DB, no model. The EFFECTIVE outcome status is
+//! computed from mechanical facts (was it reverted? does a closing keyword link the fix? is there
+//! any fix edge at all?) with fixed precedence, so a model's `landed` claim can never survive on a
+//! thread with no landing evidence. The extraction pass (#703) stores the raw floors
+//! (`revert_override`, `closing_keyword_floor`, `fix_edge_source`) and the LLM pass (#704) stores
+//! `outcome_status_model`; the read layer (#705) resolves them here.
+//!
+//! This lives in `rag-rat-papertrail` — not the `rag-rat-core` extraction module — because the
+//! resolver is READ-side: `rag-rat-query` and this crate's own record reader both apply it, and
+//! `rag-rat-query` is above `rag-rat-papertrail` but below `rag-rat-core`. The persisted enums it
+//! consumes ([`OutcomeStatus`] etc.) already live here.
+
+use crate::{FixEdgeSource, OutcomeStatus};
+
+/// The `no-fix-edge` floor: no closing edge and no merge commit establish that anything landed.
+pub fn no_fix_edge(fix_edge_source: FixEdgeSource) -> bool {
+    fix_edge_source == FixEdgeSource::None
+}
+
+/// Inputs to the effective-status resolver: the mechanical floors plus the (optional) model status.
+pub struct EffectiveStatusInputs {
+    pub revert_override: bool,
+    pub closing_keyword: bool,
+    pub fix_edge_source: FixEdgeSource,
+    pub model_status: Option<OutcomeStatus>,
+}
+
+/// Resolve the EFFECTIVE outcome status with fixed precedence: revert > closing-keyword >
+/// no-fix-edge > model. A revert wins outright; a closing keyword forces `landed` (the fix
+/// mechanically closed the work); with no fix edge the record can never be `landed` (a model
+/// `landed`/absent collapses to `unclear`, while an honest `descoped`/`superseded` stands);
+/// otherwise the model's status is authoritative, defaulting to `unclear` when the model is silent.
+pub fn effective_status(inputs: &EffectiveStatusInputs) -> OutcomeStatus {
+    if inputs.revert_override {
+        return OutcomeStatus::Reverted;
+    }
+    if inputs.closing_keyword {
+        return OutcomeStatus::Landed;
+    }
+    if no_fix_edge(inputs.fix_edge_source) {
+        return match inputs.model_status {
+            Some(OutcomeStatus::Landed) | None => OutcomeStatus::Unclear,
+            Some(other) => other,
+        };
+    }
+    inputs.model_status.unwrap_or(OutcomeStatus::Unclear)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{EffectiveStatusInputs, effective_status, no_fix_edge};
+    use crate::{FixEdgeSource, OutcomeStatus};
+
+    #[test]
+    fn no_fix_edge_floor_fires_only_on_none() {
+        assert!(no_fix_edge(FixEdgeSource::None));
+        assert!(!no_fix_edge(FixEdgeSource::Provider));
+        assert!(!no_fix_edge(FixEdgeSource::Text));
+    }
+
+    #[test]
+    fn effective_status_precedence_revert_beats_everything() {
+        let status = effective_status(&EffectiveStatusInputs {
+            revert_override: true,
+            closing_keyword: true,
+            fix_edge_source: FixEdgeSource::Provider,
+            model_status: Some(OutcomeStatus::Landed),
+        });
+        assert_eq!(status, OutcomeStatus::Reverted);
+    }
+
+    #[test]
+    fn effective_status_closing_keyword_forces_landed_over_model() {
+        let status = effective_status(&EffectiveStatusInputs {
+            revert_override: false,
+            closing_keyword: true,
+            fix_edge_source: FixEdgeSource::Text,
+            model_status: Some(OutcomeStatus::Unclear),
+        });
+        assert_eq!(status, OutcomeStatus::Landed);
+    }
+
+    #[test]
+    fn effective_status_no_fix_edge_cannot_be_landed() {
+        // Model over-claims landed with no fix edge → collapses to unclear.
+        assert_eq!(
+            effective_status(&EffectiveStatusInputs {
+                revert_override: false,
+                closing_keyword: false,
+                fix_edge_source: FixEdgeSource::None,
+                model_status: Some(OutcomeStatus::Landed),
+            }),
+            OutcomeStatus::Unclear,
+        );
+        // An honest descoped stands.
+        assert_eq!(
+            effective_status(&EffectiveStatusInputs {
+                revert_override: false,
+                closing_keyword: false,
+                fix_edge_source: FixEdgeSource::None,
+                model_status: Some(OutcomeStatus::Descoped),
+            }),
+            OutcomeStatus::Descoped,
+        );
+    }
+
+    #[test]
+    fn effective_status_defers_to_model_when_a_fix_edge_exists() {
+        assert_eq!(
+            effective_status(&EffectiveStatusInputs {
+                revert_override: false,
+                closing_keyword: false,
+                fix_edge_source: FixEdgeSource::Provider,
+                model_status: Some(OutcomeStatus::Superseded),
+            }),
+            OutcomeStatus::Superseded,
+        );
+        // Silent model with a fix edge → unclear (not a fabricated landed).
+        assert_eq!(
+            effective_status(&EffectiveStatusInputs {
+                revert_override: false,
+                closing_keyword: false,
+                fix_edge_source: FixEdgeSource::Provider,
+                model_status: None,
+            }),
+            OutcomeStatus::Unclear,
+        );
+    }
+}

--- a/crates/rag-rat-papertrail/src/lib.rs
+++ b/crates/rag-rat-papertrail/src/lib.rs
@@ -6,6 +6,8 @@
 
 mod api;
 mod distill;
+mod distill_read;
+mod distill_status;
 mod evidence;
 mod github;
 mod gitlab;
@@ -25,6 +27,10 @@ pub use api::{sync_from_refs, sync_from_refs_with_progress, *};
 pub use distill::{
     AnchorKind, DistillEdgeKind, EpistemicStatus, FixEdgeSource, OutcomeStatus, ThreadShape,
 };
+pub use distill_read::{
+    CoalescedThread, DistilledRecord, RecordKey, RejectedAlternative, distilled_record_for_thread,
+};
+pub use distill_status::{EffectiveStatusInputs, effective_status, no_fix_edge};
 pub use evidence::{refs, *};
 pub(crate) use github::*;
 pub(crate) use gitlab::*;


### PR DESCRIPTION
Closes #804. First consumption slice of #705 (part of #113).

The distilled record store (#703) has been write-only — nothing outside the extraction/LLM passes reads it, and the effective-status resolver was trapped `pub(crate)` in `rag-rat-core`, below which the read layer can't reach.

## What ships (read model only — no consumer wiring)

- **Relocated the effective-status resolver** (`effective_status`, `EffectiveStatusInputs`, `no_fix_edge` + their 5 tests) from `core/distill/validate.rs` to `rag-rat-papertrail/src/distill_status.rs`. The read layer (`rag-rat-query` + papertrail's own `api.rs`) sits below core in the crate DAG; the persisted `OutcomeStatus`/`FixEdgeSource`/etc. enums already live in papertrail. Core still uses it (the mechanical-status preview) — core depends on papertrail. **No re-export shim** — the one call site is migrated.
- **`DistilledRecord` read model** in `rag-rat-papertrail/src/distill_read.rs`: `distilled_record_for_thread(conn, repo_id, key)` loads the main row + rejected alternatives (by ordinal) + fixing commits + coalesced partners.

## Correctness constraints baked in

- **Effective status is computed, never read raw.** `outcome_status` runs the resolver (precedence revert > closing-keyword > no-fix-edge > model) over the raw floor columns; the raw `outcome_status_model` is kept separately for provenance but is not the surfaced status.
- **Coalescing redirect.** A merged PR coalesced into an issue has no record of its own — a lookup by the PR follows the `coalesced` edge to the issue that owns the record, and the record lists its coalesced partners so a caller answers an issue↔PR pair as one result.
- **Repo-scoped reads** (mandatory: one index over every repo in a consolidated DB).

## Verification

- New: 5 read-model tests (field/ordinal load, floor-override-beats-model, coalesced-PR redirect, none, repo scoping) + the 5 relocated resolver tests.
- 4 CI clippy gates (`-D warnings --locked`) clean; `cargo nextest run --workspace --no-default-features`: 3448 passed, 0 skipped; nightly fmt clean.

## Follow-on slices of #705

Retrieval payload on `rationale_search`/`papertrail_issue_search`; facet-gated capped drive-by on symbol surfaces; deprecate the surfaced `classification` column; MCP docs + CLI `--json`.