### PR TITLE
feat(distill): attach the distilled-record payload to rationale_search and papertrail_issue_search (#806)

### DIFF
--- a/crates/rag-rat-papertrail/src/api.rs
+++ b/crates/rag-rat-papertrail/src/api.rs
@@ -698,7 +698,21 @@ pub fn issue_search(
     limit: u32,
 ) -> anyhow::Result<Vec<PapertrailEvidence>> {
     // Item rows only (issues AND change requests — their titles/bodies), not comment rows.
-    search_fts(conn, query, Some("item"), limit)
+    // Over-fetch so collapsing a coalesced issue↔PR pair (both are item rows and both match) does
+    // not shrink the result below `limit` when lower-ranked unique matches exist; truncate after.
+    // Bounded 2× covers the common single-PR pair; a thread with many coalesced PRs may still
+    // under-fill (rare, and the corpus may genuinely have fewer distinct threads).
+    let mut evidence = search_fts(conn, query, Some("item"), coalesce_overfetch(limit))?;
+    attach_records(conn, &mut evidence)?;
+    coalesce_pairs(&mut evidence);
+    evidence.truncate(usize::try_from(limit).unwrap_or(usize::MAX));
+    Ok(evidence)
+}
+
+/// Fetch headroom for the FTS scan so [`coalesce_pairs`] can drop coalesced issue↔PR duplicates and
+/// still fill `limit` from lower-ranked unique matches. Bounded (2×) — not a guarantee.
+fn coalesce_overfetch(limit: u32) -> u32 {
+    limit.saturating_mul(2)
 }
 pub fn rationale_search(
     conn: &Connection,
@@ -729,8 +743,13 @@ pub fn rationale_search(
             )?);
         }
     }
-    evidence.extend(search_fts(conn, query, None, limit)?);
+    // Over-fetch the FTS lane so collapsing a coalesced issue↔PR pair still leaves `limit` unique
+    // records after truncation, rather than shrinking the result (the FTS `LIMIT` is applied before
+    // coalescing, so without headroom there is no lower-ranked hit to promote into the freed slot).
+    evidence.extend(search_fts(conn, query, None, coalesce_overfetch(limit))?);
     dedupe_evidence(&mut evidence);
+    attach_records(conn, &mut evidence)?;
+    coalesce_pairs(&mut evidence);
     evidence.truncate(usize::try_from(limit).unwrap_or(usize::MAX));
     Ok(evidence)
 }

--- a/crates/rag-rat-papertrail/src/distill_read.rs
+++ b/crates/rag-rat-papertrail/src/distill_read.rs
@@ -17,7 +17,7 @@ use crate::distill_status::{EffectiveStatusInputs, effective_status};
 use crate::{DistillEdgeKind, EpistemicStatus, FixEdgeSource, OutcomeStatus, ThreadShape};
 
 /// A thread's natural identity — the key of a `papertrail_distill` row.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct RecordKey {
     pub tracker: String,
     pub project: String,
@@ -26,50 +26,64 @@ pub struct RecordKey {
 }
 
 /// A thread coalesced into a record (the paired issue or PR), for issue↔PR dedup at the call site.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 pub struct CoalescedThread {
     pub item_kind: String,
     pub item_key: String,
 }
 
 /// An alternative the thread explicitly considered and did not take.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 pub struct RejectedAlternative {
     pub alternative: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub reason: Option<String>,
 }
 
 /// A distilled decision record as the consumption surfaces see it: the model-owned narrative
 /// fields, the mechanically resolved effective status, the rejected alternatives, the fixing
 /// commits, the provenance facets, and the coalesced partner identities.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 pub struct DistilledRecord {
     pub tracker: String,
     pub project: String,
     pub item_kind: String,
     pub item_key: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub root_issue: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub root_cause: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub root_cause_class: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub decision_chosen: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub rejected_alternatives: Vec<RejectedAlternative>,
     /// The EFFECTIVE outcome status (floors resolved over the model status) — surface this, never
     /// [`outcome_status_model`](Self::outcome_status_model) alone.
     pub outcome_status: OutcomeStatus,
-    /// The raw model-emitted status, kept for provenance/debugging; may differ from
-    /// [`outcome_status`](Self::outcome_status) when a mechanical floor overrode it.
+    /// The raw model-emitted status, retained for internal provenance; may differ from
+    /// [`outcome_status`](Self::outcome_status) when a mechanical floor overrode it. NOT
+    /// serialized into the payload, so a consumer cannot read the pre-floor status instead of
+    /// the resolved one.
+    #[serde(skip_serializing)]
     pub outcome_status_model: Option<OutcomeStatus>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub outcome_summary: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub epistemic_status_decision: Option<EpistemicStatus>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub epistemic_status_outcome: Option<EpistemicStatus>,
     pub fix_edge_source: FixEdgeSource,
     pub thread_shape: ThreadShape,
     pub outcome_claim_verified: bool,
     pub decision_provenance_verified: bool,
     pub anchors_qualified_count: i64,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub fixing_commits: Vec<String>,
     /// The issue/PR threads coalesced into this record — present so a caller can answer an
     /// issue↔PR pair as one result.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub coalesced: Vec<CoalescedThread>,
 }
 

--- a/crates/rag-rat-papertrail/src/evidence.rs
+++ b/crates/rag-rat-papertrail/src/evidence.rs
@@ -202,7 +202,81 @@ pub(crate) fn evidence_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<Papertra
         classification: row.get(9)?,
         evidence_kind: "historical_tracker",
         score: row.get(10)?,
+        // Populated by `attach_records` after the hit set is built; a bare match carries none.
+        record: None,
     })
+}
+
+/// Attach the distilled decision record (#705) to every hit whose thread has one, resolving the
+/// active repo once and caching per thread so many comment hits on one item load the record once.
+/// A hit for a merged PR coalesced into an issue picks up the ISSUE's record (redirect-aware).
+pub(crate) fn attach_records(
+    conn: &Connection,
+    evidence: &mut [PapertrailEvidence],
+) -> anyhow::Result<()> {
+    if evidence.is_empty() {
+        return Ok(());
+    }
+    // The distilled-record store is OPTIONAL enrichment: an index built before the distill schema
+    // (or a partial-migration state — e.g. a legacy backfill that has `papertrail_fts` but not yet
+    // the distill tables) must still serve bare search hits. Attaching is a no-op there rather than
+    // erroring the whole search on a missing table.
+    if !rag_rat_db::schema::table_exists(conn, "papertrail_distill")? {
+        return Ok(());
+    }
+    let repo_id = rag_rat_db::schema::active_repo_id(conn)?;
+    let mut cache: std::collections::HashMap<RecordKey, Option<DistilledRecord>> =
+        std::collections::HashMap::new();
+    for hit in evidence.iter_mut() {
+        let key = RecordKey {
+            tracker: hit.tracker.clone(),
+            project: hit.project.clone(),
+            item_kind: hit.item_kind.clone(),
+            item_key: hit.item_key.clone(),
+        };
+        let record = match cache.get(&key) {
+            Some(cached) => cached.clone(),
+            None => {
+                let loaded = distilled_record_for_thread(conn, &repo_id, &key)?;
+                cache.insert(key, loaded.clone());
+                loaded
+            },
+        };
+        hit.record = record;
+    }
+    Ok(())
+}
+
+/// Collapse coalesced hits so one distilled record answers as ONE result (#705): all hits sharing a
+/// canonical record (an issue and the merged PR(s) coalesced into it) reduce to the BEST-RANKED
+/// thread that carried it — keeping the strongest textual match's position and snippet, since the
+/// same record is attached whichever thread survives. Hits keyed to that chosen thread survive (so
+/// a comment and its item, which share a thread identity, both stay); hits keyed to a DIFFERENT
+/// thread that resolved to the same record collapse away. Hits with no record are distinct bare
+/// matches and are never touched. The canonical/thread identity is the FULL key
+/// (tracker + project + item_kind + item_key) so records with the same number in different projects
+/// a single repo mirrors never collide. Call after [`attach_records`]; input is in rank order.
+pub(crate) fn coalesce_pairs(evidence: &mut Vec<PapertrailEvidence>) {
+    type ThreadKey = (String, String, String, String);
+    let raw_key = |e: &PapertrailEvidence| -> ThreadKey {
+        (e.tracker.clone(), e.project.clone(), e.item_kind.clone(), e.item_key.clone())
+    };
+    let canonical_key = |r: &DistilledRecord| -> ThreadKey {
+        (r.tracker.clone(), r.project.clone(), r.item_kind.clone(), r.item_key.clone())
+    };
+    // The representative thread for each record is the FIRST (best-ranked) hit that carried it.
+    let mut representative: std::collections::HashMap<ThreadKey, ThreadKey> =
+        std::collections::HashMap::new();
+    for hit in evidence.iter() {
+        if let Some(record) = &hit.record {
+            representative.entry(canonical_key(record)).or_insert_with(|| raw_key(hit));
+        }
+    }
+    evidence.retain(|hit| match &hit.record {
+        Some(record) =>
+            representative.get(&canonical_key(record)).is_none_or(|rep| *rep == raw_key(hit)),
+        None => true,
+    });
 }
 pub(crate) fn ref_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<PapertrailRef> {
     let tracker: String = row.get(0)?;
@@ -243,4 +317,191 @@ pub fn refs(conn: &Connection) -> anyhow::Result<Vec<PapertrailRef>> {
     )?;
     let rows = stmt.query_map([repo_id], ref_row)?;
     collect_rows(rows)
+}
+
+#[cfg(test)]
+mod payload_tests {
+    use rusqlite::Connection;
+
+    use super::{attach_records, coalesce_pairs};
+    use crate::{DistilledRecord, FixEdgeSource, OutcomeStatus, PapertrailEvidence, ThreadShape};
+
+    fn ev(kind: &str, key: &str, record: Option<DistilledRecord>) -> PapertrailEvidence {
+        ev_in("o/r", kind, key, record)
+    }
+
+    fn ev_in(
+        project: &str,
+        kind: &str,
+        key: &str,
+        record: Option<DistilledRecord>,
+    ) -> PapertrailEvidence {
+        PapertrailEvidence {
+            tracker: "github".into(),
+            project: project.into(),
+            item_kind: kind.into(),
+            item_key: key.into(),
+            doc_kind: "item".into(),
+            comment_id: None,
+            url: String::new(),
+            title: String::new(),
+            snippet: String::new(),
+            classification: String::new(),
+            evidence_kind: "historical_tracker",
+            score: 1.0,
+            record,
+        }
+    }
+
+    fn record_for(kind: &str, key: &str) -> DistilledRecord {
+        record_in("o/r", kind, key)
+    }
+
+    fn record_in(project: &str, kind: &str, key: &str) -> DistilledRecord {
+        DistilledRecord {
+            tracker: "github".into(),
+            project: project.into(),
+            item_kind: kind.into(),
+            item_key: key.into(),
+            root_issue: None,
+            root_cause: None,
+            root_cause_class: None,
+            decision_chosen: None,
+            rejected_alternatives: vec![],
+            outcome_status: OutcomeStatus::Landed,
+            outcome_status_model: None,
+            outcome_summary: None,
+            epistemic_status_decision: None,
+            epistemic_status_outcome: None,
+            fix_edge_source: FixEdgeSource::Provider,
+            thread_shape: ThreadShape::Investigation,
+            outcome_claim_verified: false,
+            decision_provenance_verified: false,
+            anchors_qualified_count: 0,
+            fixing_commits: vec![],
+            coalesced: vec![],
+        }
+    }
+
+    #[test]
+    fn coalesce_pairs_drops_a_redirected_pr_when_its_issue_also_matched() {
+        // issue#5 owns the record; PR#6 was redirected to #5's record; issue#9 is unrelated.
+        let mut hits = vec![
+            ev("issue", "5", Some(record_for("issue", "5"))),
+            ev("change_request", "6", Some(record_for("issue", "5"))),
+            ev("issue", "9", Some(record_for("issue", "9"))),
+        ];
+        coalesce_pairs(&mut hits);
+        let keys: Vec<_> =
+            hits.iter().map(|h| (h.item_kind.as_str(), h.item_key.as_str())).collect();
+        assert_eq!(
+            keys,
+            vec![("issue", "5"), ("issue", "9")],
+            "the coalesced PR collapses into the issue that owns the record",
+        );
+    }
+
+    #[test]
+    fn coalesce_pairs_collapses_two_prs_of_one_issue_when_the_issue_is_absent() {
+        // Two merged PRs closed issue #5 and both matched, but the issue itself did not. Both
+        // resolve to #5's record — they must still answer as ONE result (the best-ranked PR), not
+        // two rows for the same record.
+        let mut hits = vec![
+            ev("change_request", "6", Some(record_for("issue", "5"))),
+            ev("change_request", "8", Some(record_for("issue", "5"))),
+        ];
+        coalesce_pairs(&mut hits);
+        assert_eq!(hits.len(), 1, "the two PRs collapse to one result");
+        assert_eq!(hits[0].item_key, "6", "the best-ranked PR represents the record");
+    }
+
+    #[test]
+    fn coalesce_pairs_keeps_the_best_ranked_hit_even_when_it_is_the_pr() {
+        // PR#6 (redirects to issue#5's record) ranks ABOVE issue#5. The strong PR match must
+        // survive — carrying the record — and the lower-ranked issue collapses away, so the record
+        // answers at the strongest match's position rather than being demoted to the issue's rank.
+        let mut hits = vec![
+            ev("change_request", "6", Some(record_for("issue", "5"))),
+            ev("issue", "5", Some(record_for("issue", "5"))),
+        ];
+        coalesce_pairs(&mut hits);
+        assert_eq!(hits.len(), 1);
+        assert_eq!(
+            (hits[0].item_kind.as_str(), hits[0].item_key.as_str()),
+            ("change_request", "6")
+        );
+        assert_eq!(
+            hits[0].record.as_ref().unwrap().item_key,
+            "5",
+            "still carries the issue record"
+        );
+    }
+
+    #[test]
+    fn coalesce_pairs_does_not_collapse_the_same_number_across_projects() {
+        // A single repo mirrors two projects; issue #5 exists in each with its own record. They
+        // share (item_kind, item_key) but differ by project — the full thread key must keep them
+        // as two distinct results.
+        let mut hits = vec![
+            ev_in("proj/a", "issue", "5", Some(record_in("proj/a", "issue", "5"))),
+            ev_in("proj/b", "issue", "5", Some(record_in("proj/b", "issue", "5"))),
+        ];
+        coalesce_pairs(&mut hits);
+        assert_eq!(hits.len(), 2, "same number in different projects stays two results");
+    }
+
+    #[test]
+    fn coalesce_pairs_keeps_a_lone_pr_carrying_its_issue_record() {
+        // Only the PR matched; its owning issue is not a separate hit → keep the PR hit, which
+        // still carries the issue's record via the redirect.
+        let mut hits = vec![ev("change_request", "6", Some(record_for("issue", "5")))];
+        coalesce_pairs(&mut hits);
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].item_key, "6");
+        assert_eq!(hits[0].record.as_ref().unwrap().item_key, "5");
+    }
+
+    #[test]
+    fn attach_records_populates_hits_from_the_store_and_leaves_bare_hits_bare() {
+        let conn = Connection::open_in_memory().unwrap();
+        rag_rat_db::schema::apply_distill_record_store(&conn).unwrap();
+        conn.execute_batch(
+            "CREATE TEMP TABLE IF NOT EXISTS connection_context(key TEXT PRIMARY KEY, value TEXT);",
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT OR REPLACE INTO temp.connection_context(key, value) VALUES ('repo_id', \
+             'repoA')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO papertrail_distill
+                 (tracker, project, item_kind, item_key, distill_input_hash, pipeline_version,
+                  root_issue, fix_edge_source, thread_shape, distilled_at_ms, repo_id)
+             VALUES ('github','o/r','issue','5','sha256:h',3,'The bug.','provider','investigation',
+                     1,'repoA')",
+            [],
+        )
+        .unwrap();
+
+        let mut hits = vec![ev("issue", "5", None), ev("issue", "404", None)];
+        attach_records(&conn, &mut hits).unwrap();
+        assert_eq!(
+            hits[0].record.as_ref().unwrap().root_issue.as_deref(),
+            Some("The bug."),
+            "a distilled thread's hit carries the record",
+        );
+        assert!(hits[1].record.is_none(), "a thread without a record stays a bare match");
+    }
+
+    #[test]
+    fn attach_records_is_a_no_op_when_the_distill_store_is_absent() {
+        // A pre-distill or partially-migrated index has papertrail_fts but no papertrail_distill;
+        // search must still serve bare hits rather than erroring on the missing table.
+        let conn = Connection::open_in_memory().unwrap();
+        let mut hits = vec![ev("issue", "5", None)];
+        attach_records(&conn, &mut hits).unwrap();
+        assert!(hits[0].record.is_none(), "no distill store → bare hit, no error");
+    }
 }

--- a/crates/rag-rat-papertrail/src/lib.rs
+++ b/crates/rag-rat-papertrail/src/lib.rs
@@ -258,6 +258,11 @@ pub struct PapertrailEvidence {
     pub classification: String,
     pub evidence_kind: &'static str,
     pub score: f64,
+    /// The distilled decision record for this thread (#705), when one exists — the model's
+    /// root-cause/decision/outcome over the thread, replacing a bare item/comment match with the
+    /// resolved rationale. `None` until the thread is distilled.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub record: Option<DistilledRecord>,
 }
 
 #[derive(Debug, Clone, Serialize)]


### PR DESCRIPTION
Closes #806. Second consumption slice of #705 (part of #113), on the read model from #804.

When a search hit's thread has a distilled record, the result now carries it (root cause + class, decision incl. rejected alternatives, effective outcome status + fixing commits, provenance facets) instead of only the raw item/comment match.

## What ships

- `PapertrailEvidence` gains `record: Option<DistilledRecord>` (serde-skipped when absent). `DistilledRecord`/`CoalescedThread`/`RejectedAlternative` are now `Serialize` with lean skips.
- `attach_records` (in `evidence.rs`): resolves the active repo once, loads a record per hit via the redirect-aware `distilled_record_for_thread`, cached per thread. **Optional-store aware**: a pre-distill or partially-migrated index (has `papertrail_fts`, not `papertrail_distill`) serves bare hits rather than erroring.
- `coalesce_pairs`: collapses hits that resolve to the same record to the **best-ranked** thread that carried it — one result per record, keeping the strongest match's position and snippet. The canonical/thread key is the full `(tracker, project, item_kind, item_key)`, so the same number in different projects a repo mirrors never collides.
- `issue_search` / `rationale_search`: bounded 2× over-fetch before coalescing so an issue↔PR pair collapsing doesn't shrink the result below `limit`, then truncate.
- Raw `outcome_status_model` is retained internally but NOT serialized, so a consumer can't read the pre-floor status instead of the resolved `outcome_status`.

Symbol-surface producers (`evidence_for_path`/`evidence_for_commit_refs`) are deliberately left bare — the facet-gated drive-by is PR-3.

## Verification

- New tests: attach-from-store, no-op-when-store-absent, coalesce (drops-redirected, two-PRs-no-issue, lone-PR, **best-ranked-wins**, **cross-project-no-collapse**).
- 4 CI clippy gates (`-D warnings --locked`) clean; `cargo nextest run --workspace --no-default-features`: 3492 passed, 0 skipped; nightly fmt clean.
