### PR TITLE
feat(oplog): annex log and the snapshot coverage-manifest wire (#609)

### DIFF
--- a/crates/rag-rat-oplog/src/account/fold.rs
+++ b/crates/rag-rat-oplog/src/account/fold.rs
@@ -36,6 +36,18 @@ pub(super) const CONTROL_LOG: u8 = 0;
 /// log, and a `CutExtend { chain_kind: Secrets }` raises it — the same register machinery the
 /// control chain uses, keyed at `log: SECRETS_LOG` instead of `log: CONTROL_LOG`.
 pub(super) const SECRETS_LOG: u8 = 1;
+/// The account ANNEX log — authority-inert bookkeeping artifacts (C6 snapshots, #609). It is 3, not
+/// 2: `ChainKind::Content = 2` already names the content chain on the register/cut axis, so a
+/// `CutExtend { chain_kind: Content }` means "log 2" and a second meaning for that number would be
+/// ambiguous.
+///
+/// Nothing here ever folds. Entries on this log are stored, retained header-only, and can never
+/// mint authority, shift `effective_count`, or enter control-chain branch selection — that
+/// inertness is TOPOLOGICAL (the `foldable` gate below short-circuits on `log_id`, before any tag
+/// dispatch), not a property some future arm has to remember to preserve. That is precisely why an
+/// authority-inert artifact must not ride the control log: a never-effective entry in a control
+/// chain orphans every later entry from that device (#809).
+pub(super) const ANNEX_LOG: u8 = 3;
 /// The account-op version this fold understands. A known `entry_type` at a different version may
 /// reuse the tag with new semantics, so it is retained-unfolded rather than folded as today's op.
 pub(super) const SUPPORTED_OP_VERSION: u32 = 1;

--- a/crates/rag-rat-oplog/src/account/limits.rs
+++ b/crates/rag-rat-oplog/src/account/limits.rs
@@ -37,6 +37,13 @@ pub(super) const CONTENT_CUTS_MAX: usize = 1024;
 /// §18a — max wrap recipients in a `StreamKeyWrap`. Consumed by C4 (key wraps); pinned here now so
 /// the whole §18a set is frozen together at C1.
 pub(super) const WRAP_RECIPIENTS_MAX: usize = 1024;
+/// §18a — max coverage targets in a snapshot manifest. Consumed by C6. A decoder bound has to be a
+/// VALIDITY limit, not a local quota: two implementations that bound the same array differently
+/// would accept different entries on the same signed log.
+pub(super) const SNAPSHOT_TARGETS_MAX: usize = 256;
+/// §18a — max covered watermarks within ONE snapshot target. Bounded by roster size, so it matches
+/// [`WRAP_RECIPIENTS_MAX`]; the 64 KiB envelope is the binding constraint in practice.
+pub(super) const SNAPSHOT_COVERED_MAX: usize = 1024;
 
 #[cfg(test)]
 mod tests {
@@ -58,6 +65,8 @@ mod tests {
         // §18a: a violation is a structural reject in every impl, and changing one of these is a
         // deliberate wire bump. Pin the exact values so a drift breaks the build, not a live peer.
         assert_eq!(ACCOUNT_ENVELOPE_MAX_BYTES, 65_536);
+        assert_eq!(SNAPSHOT_TARGETS_MAX, 256);
+        assert_eq!(SNAPSHOT_COVERED_MAX, 1024);
         assert_eq!(CONTENT_ENVELOPE_MAX_BYTES, 262_144);
         assert_eq!(DEVICE_CUTS_MAX, 256);
         assert_eq!(CONTENT_CUTS_MAX, 1_024);

--- a/crates/rag-rat-oplog/src/account/mod.rs
+++ b/crates/rag-rat-oplog/src/account/mod.rs
@@ -34,6 +34,7 @@ mod registers;
 // C4.2b: the account secrets log (`log_id = 1`) — the `StreamKeyWrap` op + owner-gated acceptance
 // evaluator, consuming the control fold's authority projection (#607).
 mod secrets;
+mod snapshot;
 mod storage;
 
 // The in-tx `/2`-ownership ensure seam + the two read-only `/2`-stream resolvers (C3.4b-ii, #676):

--- a/crates/rag-rat-oplog/src/account/ops.rs
+++ b/crates/rag-rat-oplog/src/account/ops.rs
@@ -749,7 +749,7 @@ fn decode_opt_str(d: &mut Decoder<'_>) -> Result<Option<String>, CborError> {
 }
 
 /// `Some(b32)` → a 32-byte bstr; `None` → CBOR `null`.
-fn encode_opt_b32(enc: &mut Encoder<&mut Vec<u8>>, value: Option<[u8; 32]>) {
+pub(in crate::account) fn encode_opt_b32(enc: &mut Encoder<&mut Vec<u8>>, value: Option<[u8; 32]>) {
     match value {
         Some(value) => {
             enc.bytes(&value).expect(INFALLIBLE);
@@ -760,7 +760,10 @@ fn encode_opt_b32(enc: &mut Encoder<&mut Vec<u8>>, value: Option<[u8; 32]>) {
     }
 }
 
-fn decode_opt_b32(d: &mut Decoder<'_>, field: &str) -> Result<Option<[u8; 32]>, CborError> {
+pub(in crate::account) fn decode_opt_b32(
+    d: &mut Decoder<'_>,
+    field: &str,
+) -> Result<Option<[u8; 32]>, CborError> {
     if d.datatype()? == Type::Null {
         d.null()?;
         Ok(None)

--- a/crates/rag-rat-oplog/src/account/snapshot/mod.rs
+++ b/crates/rag-rat-oplog/src/account/snapshot/mod.rs
@@ -1,0 +1,22 @@
+//! The account ANNEX log (`log_id = 3`) — authority-inert bookkeeping artifacts (C6, #609).
+//!
+//! Today it carries exactly one artifact class: the signed snapshot and its plaintext coverage
+//! manifest (§4.7). The log is named for the CLASS rather than the op because log 0's tag set is
+//! effectively closed — an added control type must be either effective (which shifts
+//! `effective_count` and parks later entries un-healably on binaries that do not know it) or
+//! ineffective (which orphans every later entry from that device, #809) — so every future
+//! authority-inert artifact belongs here rather than minting a fourth log.
+//!
+//! **Nothing on this log ever folds.** `fold_account`'s `log_id` gate short-circuits before any tag
+//! dispatch, so an annex entry is stored, retained header-only, and cannot mint authority, shift
+//! `effective_count`, or enter control-chain branch selection. That inertness is topological, not a
+//! property some future match arm must remember to preserve.
+//!
+//! Scope this slice is deliberately WIRE-ONLY: the payload wire, its canonical form, and the
+//! ingest-time structural gate. There is no acceptance lane — an annex entry is never "accepted",
+//! it is merely stored and structurally valid — and no verification. Whether a manifest's claim is
+//! TRUE (re-folding its covered prefix reproduces `folded_state_hash`) is a read-time question,
+//! because answering it requires holding the covered history and an acceptance rule that reads
+//! local inventory would make the verdict device-dependent, breaking convergence.
+
+pub(in crate::account) mod ops;

--- a/crates/rag-rat-oplog/src/account/snapshot/ops.rs
+++ b/crates/rag-rat-oplog/src/account/snapshot/ops.rs
@@ -117,11 +117,12 @@ pub(in crate::account) fn encode(op: &SnapshotOp) -> Result<Vec<u8>, CborError> 
 fn canonicalize(op: &SnapshotOp) -> Result<SnapshotOp, CborError> {
     match op {
         SnapshotOp::Snapshot { state_format_version, moderation_epoch, targets } => {
+            check_state_format(*state_format_version)?;
             check_reserved_epoch(*state_format_version, *moderation_epoch)?;
             Ok(SnapshotOp::Snapshot {
                 state_format_version: *state_format_version,
                 moderation_epoch: *moderation_epoch,
-                targets: canonical_targets(targets)?,
+                targets: canonical_targets(*state_format_version, targets)?,
             })
         },
     }
@@ -134,6 +135,17 @@ fn canonicalize(op: &SnapshotOp) -> Result<SnapshotOp, CborError> {
 /// Scoped to the version that reserves it: a future format version defines its own rules, and a
 /// binary that does not know that version must still be able to decode and retain the entry rather
 /// than hard-rejecting a legitimate future manifest.
+fn check_state_format(state_format_version: u32) -> Result<(), CborError> {
+    // Below the first defined format there are no projection semantics at all, so such a manifest
+    // could never be verified or refuted by any implementation, present or future. Reserve it.
+    // Versions ABOVE the current one are a different case entirely — they are legitimately newer
+    // and must be retained, not rejected.
+    if state_format_version < SNAPSHOT_STATE_FORMAT_V1 {
+        return Err(CborError::message("snapshot state_format_version 0 is reserved"));
+    }
+    Ok(())
+}
+
 fn check_reserved_epoch(state_format_version: u32, moderation_epoch: u64) -> Result<(), CborError> {
     if state_format_version == SNAPSHOT_STATE_FORMAT_V1 && moderation_epoch != 0 {
         return Err(CborError::message(
@@ -149,13 +161,17 @@ fn check_reserved_epoch(state_format_version: u32, moderation_epoch: u64) -> Res
 /// target may name a device once, and the target list may name a `(log_id, stream_id, account_id)`
 /// once. A byte-identical repeat is the SAME claim and canonicalizes away; two DIFFERENT claims
 /// about one coordinate are contradictory and are refused rather than silently resolved.
-fn canonical_targets(targets: &[SnapshotTarget]) -> Result<Vec<SnapshotTarget>, CborError> {
+fn canonical_targets(
+    state_format_version: u32,
+    targets: &[SnapshotTarget],
+) -> Result<Vec<SnapshotTarget>, CborError> {
     if targets.len() > SNAPSHOT_TARGETS_MAX {
         return Err(CborError::message("snapshot targets exceeds the §18a bound"));
     }
     let mut sorted = Vec::with_capacity(targets.len());
     for target in targets {
         check_qualification(
+            state_format_version,
             target.log_id,
             target.stream_id.is_some(),
             target.subject_account_id.is_some(),
@@ -185,7 +201,12 @@ fn canonical_targets(targets: &[SnapshotTarget]) -> Result<Vec<SnapshotTarget>, 
 /// here on purpose: an unknown log has no defined folded projection, so a manifest claiming one
 /// would be a coverage claim no implementation could ever verify or refute. Extending the set is a
 /// deliberate `state_format_version` change, not something a peer may assert into existence.
-fn check_qualification(log_id: u8, has_stream: bool, has_account: bool) -> Result<(), CborError> {
+fn check_qualification(
+    state_format_version: u32,
+    log_id: u8,
+    has_stream: bool,
+    has_account: bool,
+) -> Result<(), CborError> {
     match log_id {
         CONTROL_LOG_ID | SECRETS_LOG_ID =>
             if has_stream || has_account {
@@ -199,7 +220,16 @@ fn check_qualification(log_id: u8, has_stream: bool, has_account: bool) -> Resul
                     "snapshot target for the content log requires stream_id and account_id",
                 ));
             },
-        _ => return Err(CborError::message("snapshot target names an undefined log_id")),
+        // Closing the set is a rule OF FORMAT 1, not a structural one: a later format may define
+        // another targetable log, and an older binary must retain that manifest (it simply cannot
+        // verify it) rather than structurally reject a legitimate newer artifact. Same scoping as
+        // the reserved epoch above — applying it unconditionally here would contradict it.
+        _ =>
+            if state_format_version == SNAPSHOT_STATE_FORMAT_V1 {
+                return Err(CborError::message(
+                    "snapshot target names a log undefined at state format 1",
+                ));
+            },
     }
     Ok(())
 }
@@ -277,6 +307,7 @@ fn decode_snapshot(bytes: &[u8]) -> Result<SnapshotOp, CborError> {
     // Enforced on BOTH sides: `canonicalize` guards authoring, but decode reaches
     // `encode_canonical` (the raw writer) directly for its canonicity compare, so a peer's bytes
     // would otherwise slip past the reserved-field rule.
+    check_state_format(state_format_version)?;
     check_reserved_epoch(state_format_version, moderation_epoch)?;
     let len = cbor::expect_definite_len(&mut d)?;
     if len > SNAPSHOT_TARGETS_MAX as u64 {
@@ -291,7 +322,12 @@ fn decode_snapshot(bytes: &[u8]) -> Result<SnapshotOp, CborError> {
             decode_opt_b32(&mut d, "snapshot target stream_id")?.map(StreamId::from_bytes);
         let subject_account_id =
             decode_opt_b32(&mut d, "snapshot target account_id")?.map(AccountId::from_bytes);
-        check_qualification(log_id, stream_id.is_some(), subject_account_id.is_some())?;
+        check_qualification(
+            state_format_version,
+            log_id,
+            stream_id.is_some(),
+            subject_account_id.is_some(),
+        )?;
         let folded_state_hash = cbor::fixed_bytes::<32>(d.bytes()?, "folded_state_hash")?;
         let covered = decode_covered(&mut d)?;
         let target =
@@ -559,10 +595,10 @@ mod tests {
     }
 
     #[test]
-    fn a_target_naming_an_undefined_log_is_refused() {
-        // The log set is CLOSED: an unknown log has no defined folded projection, so a coverage
-        // claim about it could never be verified or refuted by any implementation. Notably this
-        // includes the annex log itself — a snapshot does not cover snapshots.
+    fn an_undefined_target_log_is_refused_at_format_1_but_retained_at_a_future_format() {
+        // At format 1 the log set is CLOSED: an unknown log has no defined folded projection, so a
+        // coverage claim about it could never be verified or refuted. That includes the annex log
+        // itself — a snapshot does not cover snapshots.
         for undefined in [fold_annex_log(), 4, 200] {
             let target = SnapshotTarget {
                 log_id: undefined,
@@ -572,9 +608,44 @@ mod tests {
             };
             assert!(
                 encode(&snapshot(vec![target])).is_err(),
-                "log {undefined} has no defined projection to claim coverage of",
+                "log {undefined} has no projection defined at format 1",
             );
         }
+
+        // But closing the set is a rule OF FORMAT 1. A later format may define another targetable
+        // log, and this binary must RETAIN that manifest rather than structurally reject a
+        // legitimate newer artifact it merely cannot verify — the same scoping as the reserved
+        // epoch. Rejecting here unconditionally would contradict that.
+        let future = SnapshotOp::Snapshot {
+            state_format_version: SNAPSHOT_STATE_FORMAT_V1 + 1,
+            moderation_epoch: 0,
+            targets: vec![SnapshotTarget {
+                log_id: 200,
+                stream_id: Some(stream(0x44)),
+                subject_account_id: Some(account(0x55)),
+                ..account_target(0, &[0x11])
+            }],
+        };
+        let bytes = encode(&future).expect("a future format may name a log this one does not know");
+        assert_eq!(decode(entry_type::SNAPSHOT, &bytes).unwrap(), DecodedSnapshotOp::Known(future));
+    }
+
+    #[test]
+    fn state_format_version_zero_is_reserved() {
+        // Below the first defined format there are no projection semantics at all, so a version-0
+        // manifest is a signed claim nothing could ever evaluate. Reserved on both paths — and
+        // distinct from a FUTURE version, which is legitimately newer and must be retained.
+        let undefined = SnapshotOp::Snapshot {
+            state_format_version: 0,
+            moderation_epoch: 0,
+            targets: vec![account_target(0, &[0x11])],
+        };
+        assert!(encode(&undefined).is_err(), "authoring refuses the reserved version");
+
+        let mut bytes = encode(&snapshot(vec![account_target(0, &[0x11])])).unwrap();
+        assert_eq!(bytes[1], 0x01, "state_format_version is the second header item");
+        bytes[1] = 0x00;
+        assert!(decode(entry_type::SNAPSHOT, &bytes).is_err(), "decoding refuses it too");
     }
 
     /// The annex log's own id, spelled locally so this module stays free of a `fold` dependency.

--- a/crates/rag-rat-oplog/src/account/snapshot/ops.rs
+++ b/crates/rag-rat-oplog/src/account/snapshot/ops.rs
@@ -259,9 +259,6 @@ mod format_v1 {
     /// canonicalizes away; two DIFFERENT claims about one coordinate are contradictory and are
     /// refused rather than silently resolved.
     fn canonical_targets(targets: &[SnapshotTarget]) -> Result<Vec<SnapshotTarget>, CborError> {
-        if targets.len() > SNAPSHOT_TARGETS_MAX {
-            return Err(CborError::message("snapshot targets exceeds the §18a bound"));
-        }
         let mut sorted = Vec::with_capacity(targets.len());
         for target in targets {
             check_qualification(
@@ -269,9 +266,6 @@ mod format_v1 {
                 target.stream_id.is_some(),
                 target.subject_account_id.is_some(),
             )?;
-            if target.covered.len() > SNAPSHOT_COVERED_MAX {
-                return Err(CborError::message("snapshot covered exceeds the §18a bound"));
-            }
             let mut covered = target.covered.clone();
             covered.sort_by_key(|w| w.device_fingerprint.to_bytes());
             covered.dedup();
@@ -283,12 +277,22 @@ mod format_v1 {
                     "snapshot covered has conflicting entries for one device_fingerprint",
                 ));
             }
+            // Bound the CANONICAL length, not the caller's input — the §18a limits constrain the
+            // wire, and only canonical content ever reaches it. Checking the raw input would refuse
+            // a caller whose duplicates collapse to a manifest well inside the bound. Same order as
+            // `canonical_content_cuts`: sort, dedup, conflict-check, then bound.
+            if covered.len() > SNAPSHOT_COVERED_MAX {
+                return Err(CborError::message("snapshot covered exceeds the §18a bound"));
+            }
             sorted.push(SnapshotTarget { covered, ..target.clone() });
         }
         sorted.sort_by_key(target_key);
         sorted.dedup();
         if sorted.windows(2).any(|pair| target_key(&pair[0]) == target_key(&pair[1])) {
             return Err(CborError::message("snapshot targets has conflicting entries for one log"));
+        }
+        if sorted.len() > SNAPSHOT_TARGETS_MAX {
+            return Err(CborError::message("snapshot targets exceeds the §18a bound"));
         }
         Ok(sorted)
     }
@@ -431,7 +435,7 @@ mod format_v1 {
 mod tests {
     use minicbor::Encoder;
 
-    use super::super::super::limits::SNAPSHOT_COVERED_MAX;
+    use super::super::super::limits::{SNAPSHOT_COVERED_MAX, SNAPSHOT_TARGETS_MAX};
     use super::*;
 
     fn stream(byte: u8) -> StreamId {
@@ -711,7 +715,8 @@ mod tests {
     }
 
     #[test]
-    fn snapshot_rejects_bounds_violations() {
+    fn the_18a_bounds_constrain_the_canonical_manifest_not_the_callers_input() {
+        // DISTINCT coordinates past the bound are a real violation: they all reach the wire.
         let too_many_covered = snapshot(vec![SnapshotTarget {
             covered: (0..=SNAPSHOT_COVERED_MAX)
                 .map(|i| CoveredWatermark {
@@ -723,6 +728,37 @@ mod tests {
             ..account_target(0, &[])
         }]);
         assert!(encode(&too_many_covered).is_err(), "§18a bounds the covered array");
+
+        // But §18a constrains the WIRE, and only canonical content reaches it. Byte-identical
+        // repeats are one claim (see `snapshot_rejects_conflicting_coverage_claims`), so a caller
+        // whose duplicates collapse well inside the bound must not be refused for the size of its
+        // input. Same order as `canonical_content_cuts`: dedup first, then bound.
+        let repeated = snapshot(vec![SnapshotTarget {
+            covered: vec![
+                CoveredWatermark {
+                    device_fingerprint: DeviceFingerprint::from_bytes([0x11; 32]),
+                    seq: 1,
+                    entry_hash: [0x1d; 32],
+                };
+                SNAPSHOT_COVERED_MAX + 50
+            ],
+            ..account_target(0, &[])
+        }]);
+        let once = snapshot(vec![account_target(0, &[0x11])]);
+        assert_eq!(
+            encode(&repeated).unwrap(),
+            encode(&once).unwrap(),
+            "identical repeats collapse to one claim rather than tripping the bound",
+        );
+
+        // The same rule one level up, for the target list itself.
+        let repeated_targets =
+            snapshot(vec![account_target(0, &[0x11]); SNAPSHOT_TARGETS_MAX + 50]);
+        assert_eq!(
+            encode(&repeated_targets).unwrap(),
+            encode(&once).unwrap(),
+            "identical targets collapse too",
+        );
     }
 
     #[test]

--- a/crates/rag-rat-oplog/src/account/snapshot/ops.rs
+++ b/crates/rag-rat-oplog/src/account/snapshot/ops.rs
@@ -14,25 +14,41 @@
 //! entry from that device (#809). The two requirements are only jointly satisfiable off the control
 //! chain, where inertness is topological.
 //!
-//! Like the control and secrets ops, this layer owns STRUCTURAL wire validity only: arity,
-//! canonicity (`encode(decode) == bytes`), the log/stream qualification coupling, sorted-unique
-//! coverage, and the §18a bounds. Whether a snapshot's claim is TRUE — whether re-folding its
-//! covered prefix reproduces `folded_state_hash` — is a read-time question and is deliberately not
-//! answerable here: it depends on what this device holds, and an acceptance rule that reads local
-//! inventory would make the verdict device-dependent.
+//! # The version boundary — read this before adding a rule
+//!
+//! Every validation rule on this wire belongs to exactly one of two categories, and putting a rule
+//! in the wrong one is a real bug in either direction: too broad silently breaks forward
+//! compatibility (an older binary hard-rejects a legitimate newer manifest), too narrow admits
+//! entries no implementation could ever evaluate.
+//!
+//! Rather than ask every future rule author to get that right, the boundary is STRUCTURAL and
+//! decided in exactly one place ([`decode`]):
+//!
+//! - **Class invariants** — true of the artifact at every format version — live in THIS module.
+//!   There are deliberately few: the framing (a definite-length array whose first element is the
+//!   format version) and that version 0 is reserved. Plus one in the ingest layer: a snapshot is
+//!   plaintext-signed.
+//! - **Everything else** is a rule of ONE format and lives in [`format_v1`]. An unknown format is
+//!   never decoded at all — it is retained opaque, exactly as an unknown `entry_type` is — so a
+//!   rule inside `format_v1` *cannot* be version-conditional: `format_v1::canonicalize` refuses
+//!   anything but format 1, making the version provably constant in there.
+//!
+//! Adding a manifest field? It is a `format_v1` rule unless you can argue it holds for formats that
+//! do not exist yet. The decision table is pinned by `the_version_decision_table_is_total` — extend
+//! that test rather than reasoning about it fresh.
+//!
+//! Like the control and secrets ops, this layer owns STRUCTURAL wire validity only. Whether a
+//! snapshot's claim is TRUE — whether re-folding its covered prefix reproduces `folded_state_hash`
+//! — is a read-time question and is deliberately not answerable here: it depends on what this
+//! device holds, and an acceptance rule that reads local inventory would make the verdict
+//! device-dependent.
 
-use minicbor::Encoder;
 use minicbor::decode::{Decoder, Error as CborError};
 
 use super::super::AccountId;
-use super::super::limits::{SNAPSHOT_COVERED_MAX, SNAPSHOT_TARGETS_MAX};
-use super::super::ops::{decode_opt_b32, encode_opt_b32};
 use crate::cbor;
 use crate::op::DeviceFingerprint;
 use crate::stream::StreamId;
-
-/// Writing CBOR into a `Vec` cannot fail (its `Write` impl is infallible) — mirrors `super::super`.
-const INFALLIBLE: &str = "encoding CBOR to a Vec is infallible";
 
 /// The frozen annex-log `entry_type` tag set (header part 7), a per-log namespace with fresh
 /// numbering. A tag is a wire constant — a renumber is a wire bump.
@@ -41,18 +57,11 @@ pub(in crate::account) mod entry_type {
     pub(in crate::account) const SNAPSHOT: u32 = 0;
 }
 
-/// The canonical-projection encoding a `folded_state_hash` is taken over. A snapshot authored under
-/// one version is unverifiable under another, so a change to what the fold projects (phase E's
-/// `fold_exclude` alters the effective set) bumps this rather than silently invalidating every
-/// stored manifest.
+/// The canonical-projection encoding a `folded_state_hash` is taken over, and the only format this
+/// binary can author or interpret. A snapshot authored under one version is unverifiable under
+/// another, so a change to what the fold projects (phase E's `fold_exclude` alters the effective
+/// set) bumps this rather than silently invalidating every stored manifest.
 pub(in crate::account) const SNAPSHOT_STATE_FORMAT_V1: u32 = 1;
-
-/// The account logs a snapshot target may name without stream/account qualification.
-const CONTROL_LOG_ID: u8 = 0;
-const SECRETS_LOG_ID: u8 = 1;
-/// The content chain (`ChainKind::Content`). A content target is expressible on this wire so #406
-/// adds content snapshots without a bump; nothing authors one this phase.
-const CONTENT_LOG_ID: u8 = 2;
 
 /// One `(device, seq, entry_hash)` coordinate a snapshot claims to cover.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -85,20 +94,32 @@ pub(in crate::account) struct SnapshotTarget {
 pub(in crate::account) enum SnapshotOp {
     Snapshot {
         state_format_version: u32,
-        /// Reserved for the §4.4 moderation epoch (#407); MUST be 0 until `fold_exclude` exists.
-        /// Reserved rather than omitted because the manifest is a signed wire and phase E is a
-        /// certainty — one integer now is cheaper than a bump later.
+        /// Reserved for the §4.4 moderation epoch (#407); MUST be 0 at format 1. Reserved rather
+        /// than omitted because the manifest is a signed wire and phase E is a certainty — one
+        /// integer now is cheaper than a bump later.
         moderation_epoch: u64,
         targets: Vec<SnapshotTarget>,
     },
 }
 
-/// The result of decoding an annex payload against its header `entry_type`: a known op or a
-/// retained opaque forward-version op (never an error for an unrecognized `entry_type`).
+/// The result of decoding an annex payload. Three outcomes, and only the first is interpreted:
+/// everything this binary cannot interpret is RETAINED rather than rejected, so it stays a valid,
+/// chainable entry for the peer or future binary that can.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(in crate::account) enum DecodedSnapshotOp {
     Known(SnapshotOp),
-    Unknown { entry_type: u32, bytes: Vec<u8> },
+    /// A tag this binary does not know (forward-compat within the annex log).
+    UnknownTag {
+        entry_type: u32,
+        bytes: Vec<u8>,
+    },
+    /// The snapshot tag at a format version this binary does not implement. Deliberately NOT
+    /// decoded: interpreting a newer format through this one's rules is how an older binary comes
+    /// to reject a manifest a newer one considers perfectly valid.
+    FutureFormat {
+        state_format_version: u32,
+        bytes: Vec<u8>,
+    },
 }
 
 pub(in crate::account) fn entry_type_of(op: &SnapshotOp) -> u32 {
@@ -107,269 +128,64 @@ pub(in crate::account) fn entry_type_of(op: &SnapshotOp) -> u32 {
     }
 }
 
+/// Author a payload. This binary authors only the format it implements — signing a version it
+/// cannot itself validate would be signing a claim it cannot check.
 pub(in crate::account) fn encode(op: &SnapshotOp) -> Result<Vec<u8>, CborError> {
-    Ok(encode_canonical(&canonicalize(op)?))
+    Ok(format_v1::encode_canonical(&format_v1::canonicalize(op)?))
 }
 
-/// Validate + canonicalize so the encoding ALWAYS round-trips through [`decode`] — the authoring
-/// path must never sign a payload the sorted-unique / bounded / self-consistent decoder (and peers)
-/// would reject.
-fn canonicalize(op: &SnapshotOp) -> Result<SnapshotOp, CborError> {
-    match op {
-        SnapshotOp::Snapshot { state_format_version, moderation_epoch, targets } => {
-            check_state_format(*state_format_version)?;
-            check_reserved_epoch(*state_format_version, *moderation_epoch)?;
-            Ok(SnapshotOp::Snapshot {
-                state_format_version: *state_format_version,
-                moderation_epoch: *moderation_epoch,
-                targets: canonical_targets(*state_format_version, targets)?,
-            })
-        },
-    }
-}
-
-/// `moderation_epoch` is RESERVED at this state-format version: `fold_exclude` does not exist
-/// (#407), so a non-zero epoch names coverage semantics nothing can evaluate. Enforced rather than
-/// merely documented — an unenforced "MUST be 0" is just a comment, and this is a signed wire.
+/// The framing every snapshot format shares, and the ONLY thing read before the version dispatch: a
+/// definite-length array whose first element is the format version.
 ///
-/// Scoped to the version that reserves it: a future format version defines its own rules, and a
-/// binary that does not know that version must still be able to decode and retain the entry rather
-/// than hard-rejecting a legitimate future manifest.
-fn check_state_format(state_format_version: u32) -> Result<(), CborError> {
-    // Below the first defined format there are no projection semantics at all, so such a manifest
-    // could never be verified or refuted by any implementation, present or future. Reserve it.
-    // Versions ABOVE the current one are a different case entirely — they are legitimately newer
-    // and must be retained, not rejected.
-    if state_format_version < SNAPSHOT_STATE_FORMAT_V1 {
-        return Err(CborError::message("snapshot state_format_version 0 is reserved"));
+/// Deliberately does not pin the arity — a later format may carry more fields, and freezing three
+/// here would be exactly the over-broad mistake this boundary exists to prevent.
+fn peek_state_format_version(bytes: &[u8]) -> Result<u32, CborError> {
+    cbor::require_canonical_cbor(bytes)?;
+    let mut d = Decoder::new(bytes);
+    if cbor::expect_definite_len(&mut d)? == 0 {
+        return Err(CborError::message("snapshot payload carries no state_format_version"));
     }
-    Ok(())
-}
-
-fn check_reserved_epoch(state_format_version: u32, moderation_epoch: u64) -> Result<(), CborError> {
-    if state_format_version == SNAPSHOT_STATE_FORMAT_V1 && moderation_epoch != 0 {
-        return Err(CborError::message(
-            "moderation_epoch is reserved and must be 0 at snapshot state format 1",
-        ));
-    }
-    Ok(())
-}
-
-/// Two couplings are enforced here and mirrored in the decoder. (1) The account logs carry no
-/// stream/account qualification and a content target MUST carry both — a bare `log_id` cannot name
-/// a `/3` coordinate, and a half-qualified target would be ambiguous. (2) Coverage is a SET: a
-/// target may name a device once, and the target list may name a `(log_id, stream_id, account_id)`
-/// once. A byte-identical repeat is the SAME claim and canonicalizes away; two DIFFERENT claims
-/// about one coordinate are contradictory and are refused rather than silently resolved.
-fn canonical_targets(
-    state_format_version: u32,
-    targets: &[SnapshotTarget],
-) -> Result<Vec<SnapshotTarget>, CborError> {
-    if targets.len() > SNAPSHOT_TARGETS_MAX {
-        return Err(CborError::message("snapshot targets exceeds the §18a bound"));
-    }
-    let mut sorted = Vec::with_capacity(targets.len());
-    for target in targets {
-        check_qualification(
-            state_format_version,
-            target.log_id,
-            target.stream_id.is_some(),
-            target.subject_account_id.is_some(),
-        )?;
-        if target.covered.len() > SNAPSHOT_COVERED_MAX {
-            return Err(CborError::message("snapshot covered exceeds the §18a bound"));
-        }
-        let mut covered = target.covered.clone();
-        covered.sort_by_key(|w| w.device_fingerprint.to_bytes());
-        covered.dedup();
-        if covered.windows(2).any(|pair| pair[0].device_fingerprint == pair[1].device_fingerprint) {
-            return Err(CborError::message(
-                "snapshot covered has conflicting entries for one device_fingerprint",
-            ));
-        }
-        sorted.push(SnapshotTarget { covered, ..target.clone() });
-    }
-    sorted.sort_by_key(target_key);
-    sorted.dedup();
-    if sorted.windows(2).any(|pair| target_key(&pair[0]) == target_key(&pair[1])) {
-        return Err(CborError::message("snapshot targets has conflicting entries for one log"));
-    }
-    Ok(sorted)
-}
-
-/// A target names exactly one of the three defined coordinate shapes. The `log_id` set is CLOSED
-/// here on purpose: an unknown log has no defined folded projection, so a manifest claiming one
-/// would be a coverage claim no implementation could ever verify or refute. Extending the set is a
-/// deliberate `state_format_version` change, not something a peer may assert into existence.
-fn check_qualification(
-    state_format_version: u32,
-    log_id: u8,
-    has_stream: bool,
-    has_account: bool,
-) -> Result<(), CborError> {
-    match log_id {
-        CONTROL_LOG_ID | SECRETS_LOG_ID =>
-            if has_stream || has_account {
-                return Err(CborError::message(
-                    "snapshot target for an account log must not carry stream_id/account_id",
-                ));
-            },
-        CONTENT_LOG_ID =>
-            if !has_stream || !has_account {
-                return Err(CborError::message(
-                    "snapshot target for the content log requires stream_id and account_id",
-                ));
-            },
-        // Closing the set is a rule OF FORMAT 1, not a structural one: a later format may define
-        // another targetable log, and an older binary must retain that manifest (it simply cannot
-        // verify it) rather than structurally reject a legitimate newer artifact. Same scoping as
-        // the reserved epoch above — applying it unconditionally here would contradict it.
-        _ =>
-            if state_format_version == SNAPSHOT_STATE_FORMAT_V1 {
-                return Err(CborError::message(
-                    "snapshot target names a log undefined at state format 1",
-                ));
-            },
-    }
-    Ok(())
-}
-
-/// The total order targets are sorted by — also their uniqueness key. Unqualified account logs sort
-/// before any content target for the same `log_id` because `None` maps to all-zero bytes.
-fn target_key(target: &SnapshotTarget) -> (u8, [u8; 32], [u8; 32]) {
-    (
-        target.log_id,
-        target.stream_id.map(StreamId::to_bytes).unwrap_or([0u8; 32]),
-        target.subject_account_id.map(AccountId::to_bytes).unwrap_or([0u8; 32]),
-    )
-}
-
-fn encode_canonical(op: &SnapshotOp) -> Vec<u8> {
-    let mut buf = Vec::with_capacity(128);
-    {
-        let mut enc = Encoder::new(&mut buf);
-        match op {
-            SnapshotOp::Snapshot { state_format_version, moderation_epoch, targets } => {
-                enc.array(3).expect(INFALLIBLE);
-                enc.u32(*state_format_version).expect(INFALLIBLE);
-                enc.u64(*moderation_epoch).expect(INFALLIBLE);
-                enc.array(targets.len() as u64).expect(INFALLIBLE);
-                for target in targets {
-                    enc.array(5).expect(INFALLIBLE);
-                    enc.u8(target.log_id).expect(INFALLIBLE);
-                    encode_opt_b32(&mut enc, target.stream_id.map(StreamId::to_bytes));
-                    encode_opt_b32(&mut enc, target.subject_account_id.map(AccountId::to_bytes));
-                    enc.bytes(&target.folded_state_hash).expect(INFALLIBLE);
-                    enc.array(target.covered.len() as u64).expect(INFALLIBLE);
-                    for w in &target.covered {
-                        enc.array(3).expect(INFALLIBLE);
-                        enc.bytes(&w.device_fingerprint.to_bytes()).expect(INFALLIBLE);
-                        enc.u64(w.seq).expect(INFALLIBLE);
-                        enc.bytes(&w.entry_hash).expect(INFALLIBLE);
-                    }
-                }
-            },
-        }
-    }
-    buf
+    d.u32()
 }
 
 pub(in crate::account) fn decode(
     entry_type: u32,
     bytes: &[u8],
 ) -> Result<DecodedSnapshotOp, CborError> {
-    let op = match entry_type {
-        entry_type::SNAPSHOT => decode_snapshot(bytes)?,
-        other => {
-            // A forward-version annex op is RETAINED opaque, but it must STILL be exactly one
-            // canonical CBOR array — otherwise a future binary that learns this tag would run the
-            // `encode(decode) == bytes` check below and reject bytes an older peer stored,
-            // splitting consensus on a signed log. Mirrors the control and secrets
-            // decoders.
-            cbor::require_canonical_cbor(bytes)?;
-            cbor::expect_definite_len(&mut Decoder::new(bytes))?;
-            return Ok(DecodedSnapshotOp::Unknown { entry_type: other, bytes: bytes.to_vec() });
-        },
-    };
-    // Canonicity guarantee for a KNOWN op: the decoded value must re-encode to the exact wire,
-    // which rejects non-minimal ints, unsorted coverage, and trailing bytes in one check.
-    if encode_canonical(&op) != bytes {
+    if entry_type != entry_type::SNAPSHOT {
+        // A forward-version annex op is RETAINED opaque, but it must STILL be exactly one canonical
+        // CBOR array — otherwise a future binary that learns this tag would run the
+        // `encode(decode) == bytes` check below and reject bytes an older peer stored, splitting
+        // consensus on a signed log. Mirrors the control and secrets decoders.
+        cbor::require_canonical_cbor(bytes)?;
+        cbor::expect_definite_len(&mut Decoder::new(bytes))?;
+        return Ok(DecodedSnapshotOp::UnknownTag { entry_type, bytes: bytes.to_vec() });
+    }
+
+    // ---- the entire version boundary, in one place ----
+    let state_format_version = peek_state_format_version(bytes)?;
+    if state_format_version < SNAPSHOT_STATE_FORMAT_V1 {
+        // Below the first defined format there are no projection semantics at all, so such a
+        // manifest is a signed claim nothing could ever evaluate. A class invariant, and the only
+        // rejecting one here: reserved, not "future".
+        return Err(CborError::message("snapshot state_format_version 0 is reserved"));
+    }
+    if state_format_version != SNAPSHOT_STATE_FORMAT_V1 {
+        return Ok(DecodedSnapshotOp::FutureFormat { state_format_version, bytes: bytes.to_vec() });
+    }
+
+    let op = format_v1::decode(bytes)?;
+    // Canonicity guarantee for an INTERPRETED op: the decoded value must re-encode to the exact
+    // wire, which rejects non-minimal ints, unsorted coverage, and trailing bytes in one check.
+    if format_v1::encode_canonical(&op) != bytes {
         return Err(CborError::message("annex op payload is not canonical"));
     }
     Ok(DecodedSnapshotOp::Known(op))
 }
 
-fn decode_snapshot(bytes: &[u8]) -> Result<SnapshotOp, CborError> {
-    let mut d = Decoder::new(bytes);
-    cbor::expect_array(&mut d, 3)?;
-    let state_format_version = d.u32()?;
-    let moderation_epoch = d.u64()?;
-    // Enforced on BOTH sides: `canonicalize` guards authoring, but decode reaches
-    // `encode_canonical` (the raw writer) directly for its canonicity compare, so a peer's bytes
-    // would otherwise slip past the reserved-field rule.
-    check_state_format(state_format_version)?;
-    check_reserved_epoch(state_format_version, moderation_epoch)?;
-    let len = cbor::expect_definite_len(&mut d)?;
-    if len > SNAPSHOT_TARGETS_MAX as u64 {
-        return Err(CborError::message("snapshot targets exceeds the §18a bound"));
-    }
-    let mut targets = Vec::with_capacity(len as usize);
-    let mut prev_key: Option<(u8, [u8; 32], [u8; 32])> = None;
-    for _ in 0..len {
-        cbor::expect_array(&mut d, 5)?;
-        let log_id = d.u8()?;
-        let stream_id =
-            decode_opt_b32(&mut d, "snapshot target stream_id")?.map(StreamId::from_bytes);
-        let subject_account_id =
-            decode_opt_b32(&mut d, "snapshot target account_id")?.map(AccountId::from_bytes);
-        check_qualification(
-            state_format_version,
-            log_id,
-            stream_id.is_some(),
-            subject_account_id.is_some(),
-        )?;
-        let folded_state_hash = cbor::fixed_bytes::<32>(d.bytes()?, "folded_state_hash")?;
-        let covered = decode_covered(&mut d)?;
-        let target =
-            SnapshotTarget { log_id, stream_id, subject_account_id, folded_state_hash, covered };
-        let key = target_key(&target);
-        // Strictly ascending ⇒ sorted AND unique in one check.
-        if prev_key.is_some_and(|p| key <= p) {
-            return Err(CborError::message("snapshot targets not sorted-unique"));
-        }
-        prev_key = Some(key);
-        targets.push(target);
-    }
-    Ok(SnapshotOp::Snapshot { state_format_version, moderation_epoch, targets })
-}
-
-fn decode_covered(d: &mut Decoder<'_>) -> Result<Vec<CoveredWatermark>, CborError> {
-    let len = cbor::expect_definite_len(d)?;
-    if len > SNAPSHOT_COVERED_MAX as u64 {
-        return Err(CborError::message("snapshot covered exceeds the §18a bound"));
-    }
-    let mut covered = Vec::with_capacity(len as usize);
-    let mut prev: Option<[u8; 32]> = None;
-    for _ in 0..len {
-        cbor::expect_array(d, 3)?;
-        let fp = cbor::fixed_bytes::<32>(d.bytes()?, "covered device_fingerprint")?;
-        if prev.is_some_and(|p| fp <= p) {
-            return Err(CborError::message("snapshot covered not sorted-unique by device"));
-        }
-        prev = Some(fp);
-        let seq = d.u64()?;
-        let entry_hash = cbor::fixed_bytes::<32>(d.bytes()?, "covered entry_hash")?;
-        covered.push(CoveredWatermark {
-            device_fingerprint: DeviceFingerprint::from_bytes(fp),
-            seq,
-            entry_hash,
-        });
-    }
-    Ok(covered)
-}
-
 /// The ingest-time structural gate for an annex payload (the per-log twin of the control and
-/// secrets validators): a known tag is fully decoded, an unknown tag is retained opaque.
+/// secrets validators): an interpretable payload is fully decoded, and anything else must still be
+/// well-framed to be storable.
 pub(in crate::account) fn validate_storable_snapshot_payload(
     entry_type: u32,
     payload: &[u8],
@@ -377,8 +193,245 @@ pub(in crate::account) fn validate_storable_snapshot_payload(
     decode(entry_type, payload).map(|_| ())
 }
 
+/// Format 1 of the snapshot manifest. Every rule in here is unconditional BY CONSTRUCTION: the
+/// module is only ever reached for format 1, and [`canonicalize`] refuses anything else, so
+/// `state_format_version` is provably constant within it. There is no scope for a rule here to
+/// choose, which is the point — see the version-boundary section in the module header.
+mod format_v1 {
+    use minicbor::Encoder;
+    use minicbor::decode::{Decoder, Error as CborError};
+
+    use super::super::super::AccountId;
+    use super::super::super::limits::{SNAPSHOT_COVERED_MAX, SNAPSHOT_TARGETS_MAX};
+    use super::super::super::ops::{decode_opt_b32, encode_opt_b32};
+    use super::{CoveredWatermark, SNAPSHOT_STATE_FORMAT_V1, SnapshotOp, SnapshotTarget};
+    use crate::cbor;
+    use crate::op::DeviceFingerprint;
+    use crate::stream::StreamId;
+
+    /// Writing CBOR into a `Vec` cannot fail (its `Write` impl is infallible).
+    const INFALLIBLE: &str = "encoding CBOR to a Vec is infallible";
+
+    /// The three coordinate shapes a format-1 target may name. The set is CLOSED: an undefined log
+    /// has no folded projection, so a coverage claim about it could never be verified or refuted. A
+    /// later format may define more — which is exactly why an unknown format never reaches here.
+    const CONTROL_LOG_ID: u8 = 0;
+    const SECRETS_LOG_ID: u8 = 1;
+    const CONTENT_LOG_ID: u8 = 2;
+
+    /// Validate + canonicalize so the encoding ALWAYS round-trips through [`decode`] — the
+    /// authoring path must never sign a payload the sorted-unique / bounded / self-consistent
+    /// decoder (and peers) would reject.
+    ///
+    /// The version check here is what makes every other rule in this module unconditional.
+    pub(super) fn canonicalize(op: &SnapshotOp) -> Result<SnapshotOp, CborError> {
+        match op {
+            SnapshotOp::Snapshot { state_format_version, moderation_epoch, targets } => {
+                if *state_format_version != SNAPSHOT_STATE_FORMAT_V1 {
+                    return Err(CborError::message(
+                        "this binary authors only snapshot state format 1",
+                    ));
+                }
+                check_reserved_epoch(*moderation_epoch)?;
+                Ok(SnapshotOp::Snapshot {
+                    state_format_version: *state_format_version,
+                    moderation_epoch: *moderation_epoch,
+                    targets: canonical_targets(targets)?,
+                })
+            },
+        }
+    }
+
+    /// `fold_exclude` does not exist (#407), so a non-zero epoch names coverage semantics nothing
+    /// can evaluate. Enforced on both the authoring and decoding paths — an unenforced "MUST be 0"
+    /// is just a comment, and this is a signed wire.
+    fn check_reserved_epoch(moderation_epoch: u64) -> Result<(), CborError> {
+        if moderation_epoch != 0 {
+            return Err(CborError::message(
+                "moderation_epoch is reserved and must be 0 at snapshot state format 1",
+            ));
+        }
+        Ok(())
+    }
+
+    /// Coverage is a SET: a target may name a device once, and the target list may name a
+    /// `(log_id, stream_id, account_id)` once. A byte-identical repeat is the SAME claim and
+    /// canonicalizes away; two DIFFERENT claims about one coordinate are contradictory and are
+    /// refused rather than silently resolved.
+    fn canonical_targets(targets: &[SnapshotTarget]) -> Result<Vec<SnapshotTarget>, CborError> {
+        if targets.len() > SNAPSHOT_TARGETS_MAX {
+            return Err(CborError::message("snapshot targets exceeds the §18a bound"));
+        }
+        let mut sorted = Vec::with_capacity(targets.len());
+        for target in targets {
+            check_qualification(
+                target.log_id,
+                target.stream_id.is_some(),
+                target.subject_account_id.is_some(),
+            )?;
+            if target.covered.len() > SNAPSHOT_COVERED_MAX {
+                return Err(CborError::message("snapshot covered exceeds the §18a bound"));
+            }
+            let mut covered = target.covered.clone();
+            covered.sort_by_key(|w| w.device_fingerprint.to_bytes());
+            covered.dedup();
+            if covered
+                .windows(2)
+                .any(|pair| pair[0].device_fingerprint == pair[1].device_fingerprint)
+            {
+                return Err(CborError::message(
+                    "snapshot covered has conflicting entries for one device_fingerprint",
+                ));
+            }
+            sorted.push(SnapshotTarget { covered, ..target.clone() });
+        }
+        sorted.sort_by_key(target_key);
+        sorted.dedup();
+        if sorted.windows(2).any(|pair| target_key(&pair[0]) == target_key(&pair[1])) {
+            return Err(CborError::message("snapshot targets has conflicting entries for one log"));
+        }
+        Ok(sorted)
+    }
+
+    /// The account logs carry no stream/account qualification; the content log requires both. A
+    /// half-qualified target would be ambiguous, and an undefined log is refused outright.
+    fn check_qualification(
+        log_id: u8,
+        has_stream: bool,
+        has_account: bool,
+    ) -> Result<(), CborError> {
+        match log_id {
+            CONTROL_LOG_ID | SECRETS_LOG_ID =>
+                if has_stream || has_account {
+                    return Err(CborError::message(
+                        "snapshot target for an account log must not carry stream_id/account_id",
+                    ));
+                },
+            CONTENT_LOG_ID =>
+                if !has_stream || !has_account {
+                    return Err(CborError::message(
+                        "snapshot target for the content log requires stream_id and account_id",
+                    ));
+                },
+            _ => return Err(CborError::message("snapshot target names an undefined log_id")),
+        }
+        Ok(())
+    }
+
+    /// The total order targets are sorted by — also their uniqueness key. Unqualified account logs
+    /// sort before any content target for the same `log_id` because `None` maps to all-zero bytes.
+    fn target_key(target: &SnapshotTarget) -> (u8, [u8; 32], [u8; 32]) {
+        (
+            target.log_id,
+            target.stream_id.map(StreamId::to_bytes).unwrap_or([0u8; 32]),
+            target.subject_account_id.map(AccountId::to_bytes).unwrap_or([0u8; 32]),
+        )
+    }
+
+    pub(super) fn encode_canonical(op: &SnapshotOp) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(128);
+        {
+            let mut enc = Encoder::new(&mut buf);
+            match op {
+                SnapshotOp::Snapshot { state_format_version, moderation_epoch, targets } => {
+                    enc.array(3).expect(INFALLIBLE);
+                    enc.u32(*state_format_version).expect(INFALLIBLE);
+                    enc.u64(*moderation_epoch).expect(INFALLIBLE);
+                    enc.array(targets.len() as u64).expect(INFALLIBLE);
+                    for target in targets {
+                        enc.array(5).expect(INFALLIBLE);
+                        enc.u8(target.log_id).expect(INFALLIBLE);
+                        encode_opt_b32(&mut enc, target.stream_id.map(StreamId::to_bytes));
+                        encode_opt_b32(
+                            &mut enc,
+                            target.subject_account_id.map(AccountId::to_bytes),
+                        );
+                        enc.bytes(&target.folded_state_hash).expect(INFALLIBLE);
+                        enc.array(target.covered.len() as u64).expect(INFALLIBLE);
+                        for w in &target.covered {
+                            enc.array(3).expect(INFALLIBLE);
+                            enc.bytes(&w.device_fingerprint.to_bytes()).expect(INFALLIBLE);
+                            enc.u64(w.seq).expect(INFALLIBLE);
+                            enc.bytes(&w.entry_hash).expect(INFALLIBLE);
+                        }
+                    }
+                },
+            }
+        }
+        buf
+    }
+
+    pub(super) fn decode(bytes: &[u8]) -> Result<SnapshotOp, CborError> {
+        let mut d = Decoder::new(bytes);
+        cbor::expect_array(&mut d, 3)?;
+        let state_format_version = d.u32()?;
+        let moderation_epoch = d.u64()?;
+        check_reserved_epoch(moderation_epoch)?;
+        let len = cbor::expect_definite_len(&mut d)?;
+        if len > SNAPSHOT_TARGETS_MAX as u64 {
+            return Err(CborError::message("snapshot targets exceeds the §18a bound"));
+        }
+        let mut targets = Vec::with_capacity(len as usize);
+        let mut prev_key: Option<(u8, [u8; 32], [u8; 32])> = None;
+        for _ in 0..len {
+            cbor::expect_array(&mut d, 5)?;
+            let log_id = d.u8()?;
+            let stream_id =
+                decode_opt_b32(&mut d, "snapshot target stream_id")?.map(StreamId::from_bytes);
+            let subject_account_id =
+                decode_opt_b32(&mut d, "snapshot target account_id")?.map(AccountId::from_bytes);
+            check_qualification(log_id, stream_id.is_some(), subject_account_id.is_some())?;
+            let folded_state_hash = cbor::fixed_bytes::<32>(d.bytes()?, "folded_state_hash")?;
+            let covered = decode_covered(&mut d)?;
+            let target = SnapshotTarget {
+                log_id,
+                stream_id,
+                subject_account_id,
+                folded_state_hash,
+                covered,
+            };
+            let key = target_key(&target);
+            // Strictly ascending ⇒ sorted AND unique in one check.
+            if prev_key.is_some_and(|p| key <= p) {
+                return Err(CborError::message("snapshot targets not sorted-unique"));
+            }
+            prev_key = Some(key);
+            targets.push(target);
+        }
+        Ok(SnapshotOp::Snapshot { state_format_version, moderation_epoch, targets })
+    }
+
+    fn decode_covered(d: &mut Decoder<'_>) -> Result<Vec<CoveredWatermark>, CborError> {
+        let len = cbor::expect_definite_len(d)?;
+        if len > SNAPSHOT_COVERED_MAX as u64 {
+            return Err(CborError::message("snapshot covered exceeds the §18a bound"));
+        }
+        let mut covered = Vec::with_capacity(len as usize);
+        let mut prev: Option<[u8; 32]> = None;
+        for _ in 0..len {
+            cbor::expect_array(d, 3)?;
+            let fp = cbor::fixed_bytes::<32>(d.bytes()?, "covered device_fingerprint")?;
+            if prev.is_some_and(|p| fp <= p) {
+                return Err(CborError::message("snapshot covered not sorted-unique by device"));
+            }
+            prev = Some(fp);
+            let seq = d.u64()?;
+            let entry_hash = cbor::fixed_bytes::<32>(d.bytes()?, "covered entry_hash")?;
+            covered.push(CoveredWatermark {
+                device_fingerprint: DeviceFingerprint::from_bytes(fp),
+                seq,
+                entry_hash,
+            });
+        }
+        Ok(covered)
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use minicbor::Encoder;
+
+    use super::super::super::limits::SNAPSHOT_COVERED_MAX;
     use super::*;
 
     fn stream(byte: u8) -> StreamId {
@@ -430,11 +483,99 @@ mod tests {
         }])
     }
 
+    /// A payload this binary CANNOT author: a peer's manifest at some other format version, with an
+    /// arbitrary field count. Hand-built precisely because `encode` refuses anything but format 1 —
+    /// simulating a newer peer is the only honest way to test retention.
+    fn peer_payload(state_format_version: u32, extra_fields: usize) -> Vec<u8> {
+        let mut buf = Vec::new();
+        let mut enc = Encoder::new(&mut buf);
+        enc.array(1 + extra_fields as u64).unwrap();
+        enc.u32(state_format_version).unwrap();
+        for field in 0..extra_fields {
+            enc.u64(field as u64).unwrap();
+        }
+        buf
+    }
+
     #[test]
     fn golden_snapshot() {
         // The coverage manifest is a signed wire: pin its exact bytes. A change here is a wire
         // bump, not a refactor.
         assert_eq!(hex(&encode(&sample()).unwrap()), "830100818500f6f658202a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a81835820bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb0c58201d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d");
+    }
+
+    /// THE TRIPWIRE for the version boundary. Every row is a decision the wire makes; the table is
+    /// exhaustive over the version axis, and it fails the moment a rule lands on the wrong side.
+    ///
+    /// A `format_v1` rule that leaks into the unconditional path breaks the RETAIN rows (an older
+    /// binary would start rejecting legitimate newer manifests). A class invariant mistakenly
+    /// scoped to format 1 breaks the REJECT row. Extend this table when adding a rule — do not
+    /// re-derive the boundary from scratch.
+    #[test]
+    fn the_version_decision_table_is_total() {
+        // version 0 — RESERVED: no projection semantics exist, so nothing could ever evaluate it.
+        assert!(
+            decode(entry_type::SNAPSHOT, &peer_payload(0, 2)).is_err(),
+            "format 0 is reserved, not future",
+        );
+
+        // version 1 — INTERPRETED, with every format-1 rule enforced.
+        let v1 = encode(&sample()).unwrap();
+        assert!(matches!(decode(entry_type::SNAPSHOT, &v1).unwrap(), DecodedSnapshotOp::Known(_)));
+
+        // versions 2.. — RETAINED, never interpreted and never rejected. Crucially this holds even
+        // when the payload would violate format-1 rules (different field count, a moderation epoch,
+        // an undefined target log): those are rules of format 1, and a newer format defines its
+        // own. If any of them ran unconditionally, these rows would fail.
+        for version in [2u32, 3, 17, u32::MAX] {
+            for extra_fields in [0usize, 1, 2, 5] {
+                let bytes = peer_payload(version, extra_fields);
+                match decode(entry_type::SNAPSHOT, &bytes).unwrap() {
+                    DecodedSnapshotOp::FutureFormat { state_format_version, bytes: retained } => {
+                        assert_eq!(state_format_version, version);
+                        assert_eq!(retained, bytes, "retained verbatim, never re-encoded");
+                    },
+                    other => panic!("format {version} must be retained, got {other:?}"),
+                }
+            }
+        }
+
+        // An unknown TAG is the other retention axis and behaves the same way.
+        assert!(matches!(decode(9, &[0x81, 0x01]).unwrap(), DecodedSnapshotOp::UnknownTag {
+            entry_type: 9,
+            ..
+        }));
+    }
+
+    #[test]
+    fn only_the_implemented_format_can_be_authored() {
+        // Signing a version this binary cannot validate would be signing a claim it cannot check.
+        // This is also what makes every rule inside `format_v1` provably unconditional.
+        let future = SnapshotOp::Snapshot {
+            state_format_version: SNAPSHOT_STATE_FORMAT_V1 + 1,
+            moderation_epoch: 0,
+            targets: vec![account_target(0, &[0x11])],
+        };
+        assert!(encode(&future).is_err(), "a future format is retained on read, never authored");
+
+        let reserved = SnapshotOp::Snapshot {
+            state_format_version: 0,
+            moderation_epoch: 0,
+            targets: vec![account_target(0, &[0x11])],
+        };
+        assert!(encode(&reserved).is_err(), "and version 0 is reserved");
+    }
+
+    #[test]
+    fn a_malformed_frame_is_refused_at_every_version() {
+        // The framing is the ONE class invariant: a definite-length array whose first element is
+        // the version. Without it there is nothing to dispatch on, so it cannot be version-scoped.
+        assert!(decode(entry_type::SNAPSHOT, &[0xa1, 0x01, 0x02]).is_err(), "a map is not a frame");
+        assert!(decode(entry_type::SNAPSHOT, &[0x80]).is_err(), "an empty array names no version");
+        assert!(decode(entry_type::SNAPSHOT, &[0x81, 0x40]).is_err(), "the version must be a uint");
+        let mut trailing = peer_payload(2, 1);
+        trailing.push(0xff);
+        assert!(decode(entry_type::SNAPSHOT, &trailing).is_err(), "trailing bytes are refused");
     }
 
     #[test]
@@ -518,6 +659,42 @@ mod tests {
     }
 
     #[test]
+    fn a_target_naming_an_undefined_log_is_refused_at_format_1() {
+        // At format 1 the log set is CLOSED — including the annex log itself, since a snapshot does
+        // not cover snapshots. That this is a FORMAT-1 rule (a later format may define more) is
+        // pinned by `the_version_decision_table_is_total`.
+        for undefined in [3u8, 4, 200] {
+            let target = SnapshotTarget {
+                log_id: undefined,
+                stream_id: Some(stream(0x44)),
+                subject_account_id: Some(account(0x55)),
+                ..account_target(0, &[0x11])
+            };
+            assert!(
+                encode(&snapshot(vec![target])).is_err(),
+                "log {undefined} has no projection defined at format 1",
+            );
+        }
+    }
+
+    #[test]
+    fn the_reserved_moderation_epoch_is_enforced_on_both_paths() {
+        // `fold_exclude` does not exist (#407), so a non-zero epoch names semantics nothing can
+        // evaluate. An unenforced "MUST be 0" is just a comment.
+        let nonzero = SnapshotOp::Snapshot {
+            state_format_version: SNAPSHOT_STATE_FORMAT_V1,
+            moderation_epoch: 1,
+            targets: vec![account_target(0, &[0x11])],
+        };
+        assert!(encode(&nonzero).is_err(), "authoring refuses a reserved-field value");
+
+        let mut bytes = encode(&snapshot(vec![account_target(0, &[0x11])])).unwrap();
+        assert_eq!(bytes[2], 0x00, "moderation_epoch is the third header item");
+        bytes[2] = 0x01;
+        assert!(decode(entry_type::SNAPSHOT, &bytes).is_err(), "decoding refuses it too");
+    }
+
+    #[test]
     fn snapshot_decoder_rejects_unsorted_wire_bytes() {
         // The sorted-unique rule must be enforced on DECODE, not just authoring: a peer may hand us
         // bytes our own encoder would never emit, and `encode(decode) == bytes` is what keeps a
@@ -550,9 +727,9 @@ mod tests {
 
     #[test]
     fn an_unknown_annex_tag_is_retained_not_rejected() {
-        // Forward-compat: an annex tag this binary does not know stays a valid, chainable entry.
+        // Forward-compat: an annex tag this binary does not know stays a valid, chainable entry...
         let payload = vec![0x81, 0x01];
-        assert_eq!(decode(7, &payload).unwrap(), DecodedSnapshotOp::Unknown {
+        assert_eq!(decode(7, &payload).unwrap(), DecodedSnapshotOp::UnknownTag {
             entry_type: 7,
             bytes: payload
         });
@@ -560,97 +737,6 @@ mod tests {
         // the tag would reject bytes this one stored.
         assert!(decode(7, &[0xa1, 0x01, 0x02]).is_err(), "a non-array annex payload is refused");
         assert!(decode(7, &[0x81, 0x01, 0xff]).is_err(), "trailing bytes are refused");
-    }
-
-    #[test]
-    fn the_reserved_moderation_epoch_is_enforced_not_merely_documented() {
-        // `fold_exclude` does not exist (#407), so a non-zero epoch at format 1 names coverage
-        // semantics nothing can evaluate. An unenforced "MUST be 0" is just a comment.
-        let nonzero = SnapshotOp::Snapshot {
-            state_format_version: SNAPSHOT_STATE_FORMAT_V1,
-            moderation_epoch: 1,
-            targets: vec![account_target(0, &[0x11])],
-        };
-        assert!(encode(&nonzero).is_err(), "authoring refuses a reserved-field value");
-
-        // Wire bytes a peer hands us are refused the same way...
-        let mut bytes = encode(&snapshot(vec![account_target(0, &[0x11])])).unwrap();
-        assert_eq!(bytes[2], 0x00, "moderation_epoch is the third header item");
-        bytes[2] = 0x01;
-        assert!(decode(entry_type::SNAPSHOT, &bytes).is_err(), "decoding refuses it too");
-
-        // ...but the rule is scoped to the version that reserves it: a FUTURE state format defines
-        // its own semantics, and this binary must retain such an entry rather than hard-reject a
-        // legitimate future manifest it simply cannot verify.
-        let future = SnapshotOp::Snapshot {
-            state_format_version: SNAPSHOT_STATE_FORMAT_V1 + 1,
-            moderation_epoch: 7,
-            targets: vec![account_target(0, &[0x11])],
-        };
-        let future_bytes = encode(&future).expect("a future format version still encodes");
-        assert_eq!(
-            decode(entry_type::SNAPSHOT, &future_bytes).unwrap(),
-            DecodedSnapshotOp::Known(future),
-        );
-    }
-
-    #[test]
-    fn an_undefined_target_log_is_refused_at_format_1_but_retained_at_a_future_format() {
-        // At format 1 the log set is CLOSED: an unknown log has no defined folded projection, so a
-        // coverage claim about it could never be verified or refuted. That includes the annex log
-        // itself — a snapshot does not cover snapshots.
-        for undefined in [fold_annex_log(), 4, 200] {
-            let target = SnapshotTarget {
-                log_id: undefined,
-                stream_id: Some(stream(0x44)),
-                subject_account_id: Some(account(0x55)),
-                ..account_target(0, &[0x11])
-            };
-            assert!(
-                encode(&snapshot(vec![target])).is_err(),
-                "log {undefined} has no projection defined at format 1",
-            );
-        }
-
-        // But closing the set is a rule OF FORMAT 1. A later format may define another targetable
-        // log, and this binary must RETAIN that manifest rather than structurally reject a
-        // legitimate newer artifact it merely cannot verify — the same scoping as the reserved
-        // epoch. Rejecting here unconditionally would contradict that.
-        let future = SnapshotOp::Snapshot {
-            state_format_version: SNAPSHOT_STATE_FORMAT_V1 + 1,
-            moderation_epoch: 0,
-            targets: vec![SnapshotTarget {
-                log_id: 200,
-                stream_id: Some(stream(0x44)),
-                subject_account_id: Some(account(0x55)),
-                ..account_target(0, &[0x11])
-            }],
-        };
-        let bytes = encode(&future).expect("a future format may name a log this one does not know");
-        assert_eq!(decode(entry_type::SNAPSHOT, &bytes).unwrap(), DecodedSnapshotOp::Known(future));
-    }
-
-    #[test]
-    fn state_format_version_zero_is_reserved() {
-        // Below the first defined format there are no projection semantics at all, so a version-0
-        // manifest is a signed claim nothing could ever evaluate. Reserved on both paths — and
-        // distinct from a FUTURE version, which is legitimately newer and must be retained.
-        let undefined = SnapshotOp::Snapshot {
-            state_format_version: 0,
-            moderation_epoch: 0,
-            targets: vec![account_target(0, &[0x11])],
-        };
-        assert!(encode(&undefined).is_err(), "authoring refuses the reserved version");
-
-        let mut bytes = encode(&snapshot(vec![account_target(0, &[0x11])])).unwrap();
-        assert_eq!(bytes[1], 0x01, "state_format_version is the second header item");
-        bytes[1] = 0x00;
-        assert!(decode(entry_type::SNAPSHOT, &bytes).is_err(), "decoding refuses it too");
-    }
-
-    /// The annex log's own id, spelled locally so this module stays free of a `fold` dependency.
-    fn fold_annex_log() -> u8 {
-        3
     }
 
     /// Distinct 32-byte fingerprints for bound tests.

--- a/crates/rag-rat-oplog/src/account/snapshot/ops.rs
+++ b/crates/rag-rat-oplog/src/account/snapshot/ops.rs
@@ -1,0 +1,591 @@
+//! The annex-log op payloads (`log_id = 3`) and their canonical-CBOR wire (C6, #609).
+//!
+//! The annex log is a THIRD account log at `log_id = ANNEX_LOG`, carrying authority-inert
+//! bookkeeping artifacts. It shares the account-entry envelope ([`super::super::envelope`]) — its
+//! ops ride as the opaque `payload` bstr, disambiguated by the header's `entry_type`, whose frozen
+//! tag set here is a SEPARATE per-log namespace ([`entry_type`]) with fresh numbering: an annex tag
+//! `0` is NOT control's `AccountGenesis`, and the log gate runs before any tag dispatch.
+//!
+//! **Why a separate log, not a control `entry_type`.** A snapshot must never be an EFFECTIVE op: an
+//! effective one shifts `effective_count`, and every later entry asserting the higher `auth_len`
+//! then parks `auth_len_ahead` un-healably on any binary that does not know the type. But a
+//! never-effective entry cannot ride the control log either — control branch selection walks
+//! EFFECTIVE entries with contiguous `seq`, so a non-effective entry mid-chain orphans every later
+//! entry from that device (#809). The two requirements are only jointly satisfiable off the control
+//! chain, where inertness is topological.
+//!
+//! Like the control and secrets ops, this layer owns STRUCTURAL wire validity only: arity,
+//! canonicity (`encode(decode) == bytes`), the log/stream qualification coupling, sorted-unique
+//! coverage, and the §18a bounds. Whether a snapshot's claim is TRUE — whether re-folding its
+//! covered prefix reproduces `folded_state_hash` — is a read-time question and is deliberately not
+//! answerable here: it depends on what this device holds, and an acceptance rule that reads local
+//! inventory would make the verdict device-dependent.
+
+use minicbor::Encoder;
+use minicbor::decode::{Decoder, Error as CborError};
+
+use super::super::AccountId;
+use super::super::limits::{SNAPSHOT_COVERED_MAX, SNAPSHOT_TARGETS_MAX};
+use super::super::ops::{decode_opt_b32, encode_opt_b32};
+use crate::cbor;
+use crate::op::DeviceFingerprint;
+use crate::stream::StreamId;
+
+/// Writing CBOR into a `Vec` cannot fail (its `Write` impl is infallible) — mirrors `super::super`.
+const INFALLIBLE: &str = "encoding CBOR to a Vec is infallible";
+
+/// The frozen annex-log `entry_type` tag set (header part 7), a per-log namespace with fresh
+/// numbering. A tag is a wire constant — a renumber is a wire bump.
+pub(in crate::account) mod entry_type {
+    /// A signed coverage claim over folded history (§4.7).
+    pub(in crate::account) const SNAPSHOT: u32 = 0;
+}
+
+/// The canonical-projection encoding a `folded_state_hash` is taken over. A snapshot authored under
+/// one version is unverifiable under another, so a change to what the fold projects (phase E's
+/// `fold_exclude` alters the effective set) bumps this rather than silently invalidating every
+/// stored manifest.
+pub(in crate::account) const SNAPSHOT_STATE_FORMAT_V1: u32 = 1;
+
+/// The account logs a snapshot target may name without stream/account qualification.
+const CONTROL_LOG_ID: u8 = 0;
+const SECRETS_LOG_ID: u8 = 1;
+/// The content chain (`ChainKind::Content`). A content target is expressible on this wire so #406
+/// adds content snapshots without a bump; nothing authors one this phase.
+const CONTENT_LOG_ID: u8 = 2;
+
+/// One `(device, seq, entry_hash)` coordinate a snapshot claims to cover.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(in crate::account) struct CoveredWatermark {
+    pub(in crate::account) device_fingerprint: DeviceFingerprint,
+    pub(in crate::account) seq: u64,
+    pub(in crate::account) entry_hash: [u8; 32],
+}
+
+/// One log (or, from #406, one content stream) a snapshot covers, with the hash of the canonical
+/// folded projection its author computed over exactly `covered`.
+///
+/// `stream_id` / `subject_account_id` are `None` for the account logs and `Some` for a content
+/// stream: `/3` chains are dense per `(stream, author_account, device)`, so a bare `log_id` cannot
+/// name a content coordinate. Carrying them now means #406 adds content snapshots without a wire
+/// bump. Per-target hashes exist for the same reason — one hash cannot bind heterogeneous
+/// projections (control authority state and content LWW state are not the same shape).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(in crate::account) struct SnapshotTarget {
+    pub(in crate::account) log_id: u8,
+    pub(in crate::account) stream_id: Option<StreamId>,
+    pub(in crate::account) subject_account_id: Option<AccountId>,
+    pub(in crate::account) folded_state_hash: [u8; 32],
+    pub(in crate::account) covered: Vec<CoveredWatermark>,
+}
+
+/// The annex ops. One today; the log is named for the CLASS (authority-inert bookkeeping) rather
+/// than the op, so the next inert artifact takes tag 1 instead of minting a fourth log.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(in crate::account) enum SnapshotOp {
+    Snapshot {
+        state_format_version: u32,
+        /// Reserved for the §4.4 moderation epoch (#407); MUST be 0 until `fold_exclude` exists.
+        /// Reserved rather than omitted because the manifest is a signed wire and phase E is a
+        /// certainty — one integer now is cheaper than a bump later.
+        moderation_epoch: u64,
+        targets: Vec<SnapshotTarget>,
+    },
+}
+
+/// The result of decoding an annex payload against its header `entry_type`: a known op or a
+/// retained opaque forward-version op (never an error for an unrecognized `entry_type`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(in crate::account) enum DecodedSnapshotOp {
+    Known(SnapshotOp),
+    Unknown { entry_type: u32, bytes: Vec<u8> },
+}
+
+pub(in crate::account) fn entry_type_of(op: &SnapshotOp) -> u32 {
+    match op {
+        SnapshotOp::Snapshot { .. } => entry_type::SNAPSHOT,
+    }
+}
+
+pub(in crate::account) fn encode(op: &SnapshotOp) -> Result<Vec<u8>, CborError> {
+    Ok(encode_canonical(&canonicalize(op)?))
+}
+
+/// Validate + canonicalize so the encoding ALWAYS round-trips through [`decode`] — the authoring
+/// path must never sign a payload the sorted-unique / bounded / self-consistent decoder (and peers)
+/// would reject.
+fn canonicalize(op: &SnapshotOp) -> Result<SnapshotOp, CborError> {
+    match op {
+        SnapshotOp::Snapshot { state_format_version, moderation_epoch, targets } => {
+            check_reserved_epoch(*state_format_version, *moderation_epoch)?;
+            Ok(SnapshotOp::Snapshot {
+                state_format_version: *state_format_version,
+                moderation_epoch: *moderation_epoch,
+                targets: canonical_targets(targets)?,
+            })
+        },
+    }
+}
+
+/// `moderation_epoch` is RESERVED at this state-format version: `fold_exclude` does not exist
+/// (#407), so a non-zero epoch names coverage semantics nothing can evaluate. Enforced rather than
+/// merely documented — an unenforced "MUST be 0" is just a comment, and this is a signed wire.
+///
+/// Scoped to the version that reserves it: a future format version defines its own rules, and a
+/// binary that does not know that version must still be able to decode and retain the entry rather
+/// than hard-rejecting a legitimate future manifest.
+fn check_reserved_epoch(state_format_version: u32, moderation_epoch: u64) -> Result<(), CborError> {
+    if state_format_version == SNAPSHOT_STATE_FORMAT_V1 && moderation_epoch != 0 {
+        return Err(CborError::message(
+            "moderation_epoch is reserved and must be 0 at snapshot state format 1",
+        ));
+    }
+    Ok(())
+}
+
+/// Two couplings are enforced here and mirrored in the decoder. (1) The account logs carry no
+/// stream/account qualification and a content target MUST carry both — a bare `log_id` cannot name
+/// a `/3` coordinate, and a half-qualified target would be ambiguous. (2) Coverage is a SET: a
+/// target may name a device once, and the target list may name a `(log_id, stream_id, account_id)`
+/// once. A byte-identical repeat is the SAME claim and canonicalizes away; two DIFFERENT claims
+/// about one coordinate are contradictory and are refused rather than silently resolved.
+fn canonical_targets(targets: &[SnapshotTarget]) -> Result<Vec<SnapshotTarget>, CborError> {
+    if targets.len() > SNAPSHOT_TARGETS_MAX {
+        return Err(CborError::message("snapshot targets exceeds the §18a bound"));
+    }
+    let mut sorted = Vec::with_capacity(targets.len());
+    for target in targets {
+        check_qualification(
+            target.log_id,
+            target.stream_id.is_some(),
+            target.subject_account_id.is_some(),
+        )?;
+        if target.covered.len() > SNAPSHOT_COVERED_MAX {
+            return Err(CborError::message("snapshot covered exceeds the §18a bound"));
+        }
+        let mut covered = target.covered.clone();
+        covered.sort_by_key(|w| w.device_fingerprint.to_bytes());
+        covered.dedup();
+        if covered.windows(2).any(|pair| pair[0].device_fingerprint == pair[1].device_fingerprint) {
+            return Err(CborError::message(
+                "snapshot covered has conflicting entries for one device_fingerprint",
+            ));
+        }
+        sorted.push(SnapshotTarget { covered, ..target.clone() });
+    }
+    sorted.sort_by_key(target_key);
+    sorted.dedup();
+    if sorted.windows(2).any(|pair| target_key(&pair[0]) == target_key(&pair[1])) {
+        return Err(CborError::message("snapshot targets has conflicting entries for one log"));
+    }
+    Ok(sorted)
+}
+
+/// A target names exactly one of the three defined coordinate shapes. The `log_id` set is CLOSED
+/// here on purpose: an unknown log has no defined folded projection, so a manifest claiming one
+/// would be a coverage claim no implementation could ever verify or refute. Extending the set is a
+/// deliberate `state_format_version` change, not something a peer may assert into existence.
+fn check_qualification(log_id: u8, has_stream: bool, has_account: bool) -> Result<(), CborError> {
+    match log_id {
+        CONTROL_LOG_ID | SECRETS_LOG_ID =>
+            if has_stream || has_account {
+                return Err(CborError::message(
+                    "snapshot target for an account log must not carry stream_id/account_id",
+                ));
+            },
+        CONTENT_LOG_ID =>
+            if !has_stream || !has_account {
+                return Err(CborError::message(
+                    "snapshot target for the content log requires stream_id and account_id",
+                ));
+            },
+        _ => return Err(CborError::message("snapshot target names an undefined log_id")),
+    }
+    Ok(())
+}
+
+/// The total order targets are sorted by — also their uniqueness key. Unqualified account logs sort
+/// before any content target for the same `log_id` because `None` maps to all-zero bytes.
+fn target_key(target: &SnapshotTarget) -> (u8, [u8; 32], [u8; 32]) {
+    (
+        target.log_id,
+        target.stream_id.map(StreamId::to_bytes).unwrap_or([0u8; 32]),
+        target.subject_account_id.map(AccountId::to_bytes).unwrap_or([0u8; 32]),
+    )
+}
+
+fn encode_canonical(op: &SnapshotOp) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(128);
+    {
+        let mut enc = Encoder::new(&mut buf);
+        match op {
+            SnapshotOp::Snapshot { state_format_version, moderation_epoch, targets } => {
+                enc.array(3).expect(INFALLIBLE);
+                enc.u32(*state_format_version).expect(INFALLIBLE);
+                enc.u64(*moderation_epoch).expect(INFALLIBLE);
+                enc.array(targets.len() as u64).expect(INFALLIBLE);
+                for target in targets {
+                    enc.array(5).expect(INFALLIBLE);
+                    enc.u8(target.log_id).expect(INFALLIBLE);
+                    encode_opt_b32(&mut enc, target.stream_id.map(StreamId::to_bytes));
+                    encode_opt_b32(&mut enc, target.subject_account_id.map(AccountId::to_bytes));
+                    enc.bytes(&target.folded_state_hash).expect(INFALLIBLE);
+                    enc.array(target.covered.len() as u64).expect(INFALLIBLE);
+                    for w in &target.covered {
+                        enc.array(3).expect(INFALLIBLE);
+                        enc.bytes(&w.device_fingerprint.to_bytes()).expect(INFALLIBLE);
+                        enc.u64(w.seq).expect(INFALLIBLE);
+                        enc.bytes(&w.entry_hash).expect(INFALLIBLE);
+                    }
+                }
+            },
+        }
+    }
+    buf
+}
+
+pub(in crate::account) fn decode(
+    entry_type: u32,
+    bytes: &[u8],
+) -> Result<DecodedSnapshotOp, CborError> {
+    let op = match entry_type {
+        entry_type::SNAPSHOT => decode_snapshot(bytes)?,
+        other => {
+            // A forward-version annex op is RETAINED opaque, but it must STILL be exactly one
+            // canonical CBOR array — otherwise a future binary that learns this tag would run the
+            // `encode(decode) == bytes` check below and reject bytes an older peer stored,
+            // splitting consensus on a signed log. Mirrors the control and secrets
+            // decoders.
+            cbor::require_canonical_cbor(bytes)?;
+            cbor::expect_definite_len(&mut Decoder::new(bytes))?;
+            return Ok(DecodedSnapshotOp::Unknown { entry_type: other, bytes: bytes.to_vec() });
+        },
+    };
+    // Canonicity guarantee for a KNOWN op: the decoded value must re-encode to the exact wire,
+    // which rejects non-minimal ints, unsorted coverage, and trailing bytes in one check.
+    if encode_canonical(&op) != bytes {
+        return Err(CborError::message("annex op payload is not canonical"));
+    }
+    Ok(DecodedSnapshotOp::Known(op))
+}
+
+fn decode_snapshot(bytes: &[u8]) -> Result<SnapshotOp, CborError> {
+    let mut d = Decoder::new(bytes);
+    cbor::expect_array(&mut d, 3)?;
+    let state_format_version = d.u32()?;
+    let moderation_epoch = d.u64()?;
+    // Enforced on BOTH sides: `canonicalize` guards authoring, but decode reaches
+    // `encode_canonical` (the raw writer) directly for its canonicity compare, so a peer's bytes
+    // would otherwise slip past the reserved-field rule.
+    check_reserved_epoch(state_format_version, moderation_epoch)?;
+    let len = cbor::expect_definite_len(&mut d)?;
+    if len > SNAPSHOT_TARGETS_MAX as u64 {
+        return Err(CborError::message("snapshot targets exceeds the §18a bound"));
+    }
+    let mut targets = Vec::with_capacity(len as usize);
+    let mut prev_key: Option<(u8, [u8; 32], [u8; 32])> = None;
+    for _ in 0..len {
+        cbor::expect_array(&mut d, 5)?;
+        let log_id = d.u8()?;
+        let stream_id =
+            decode_opt_b32(&mut d, "snapshot target stream_id")?.map(StreamId::from_bytes);
+        let subject_account_id =
+            decode_opt_b32(&mut d, "snapshot target account_id")?.map(AccountId::from_bytes);
+        check_qualification(log_id, stream_id.is_some(), subject_account_id.is_some())?;
+        let folded_state_hash = cbor::fixed_bytes::<32>(d.bytes()?, "folded_state_hash")?;
+        let covered = decode_covered(&mut d)?;
+        let target =
+            SnapshotTarget { log_id, stream_id, subject_account_id, folded_state_hash, covered };
+        let key = target_key(&target);
+        // Strictly ascending ⇒ sorted AND unique in one check.
+        if prev_key.is_some_and(|p| key <= p) {
+            return Err(CborError::message("snapshot targets not sorted-unique"));
+        }
+        prev_key = Some(key);
+        targets.push(target);
+    }
+    Ok(SnapshotOp::Snapshot { state_format_version, moderation_epoch, targets })
+}
+
+fn decode_covered(d: &mut Decoder<'_>) -> Result<Vec<CoveredWatermark>, CborError> {
+    let len = cbor::expect_definite_len(d)?;
+    if len > SNAPSHOT_COVERED_MAX as u64 {
+        return Err(CborError::message("snapshot covered exceeds the §18a bound"));
+    }
+    let mut covered = Vec::with_capacity(len as usize);
+    let mut prev: Option<[u8; 32]> = None;
+    for _ in 0..len {
+        cbor::expect_array(d, 3)?;
+        let fp = cbor::fixed_bytes::<32>(d.bytes()?, "covered device_fingerprint")?;
+        if prev.is_some_and(|p| fp <= p) {
+            return Err(CborError::message("snapshot covered not sorted-unique by device"));
+        }
+        prev = Some(fp);
+        let seq = d.u64()?;
+        let entry_hash = cbor::fixed_bytes::<32>(d.bytes()?, "covered entry_hash")?;
+        covered.push(CoveredWatermark {
+            device_fingerprint: DeviceFingerprint::from_bytes(fp),
+            seq,
+            entry_hash,
+        });
+    }
+    Ok(covered)
+}
+
+/// The ingest-time structural gate for an annex payload (the per-log twin of the control and
+/// secrets validators): a known tag is fully decoded, an unknown tag is retained opaque.
+pub(in crate::account) fn validate_storable_snapshot_payload(
+    entry_type: u32,
+    payload: &[u8],
+) -> Result<(), CborError> {
+    decode(entry_type, payload).map(|_| ())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn stream(byte: u8) -> StreamId {
+        StreamId::from_bytes([byte; 32])
+    }
+
+    fn account(byte: u8) -> AccountId {
+        AccountId::from_bytes([byte; 32])
+    }
+
+    fn hex(bytes: &[u8]) -> String {
+        bytes.iter().map(|b| format!("{b:02x}")).collect()
+    }
+
+    fn snapshot(targets: Vec<SnapshotTarget>) -> SnapshotOp {
+        SnapshotOp::Snapshot {
+            state_format_version: SNAPSHOT_STATE_FORMAT_V1,
+            moderation_epoch: 0,
+            targets,
+        }
+    }
+
+    fn account_target(log_id: u8, fps: &[u8]) -> SnapshotTarget {
+        SnapshotTarget {
+            log_id,
+            stream_id: None,
+            subject_account_id: None,
+            folded_state_hash: [0x2a; 32],
+            covered: fps
+                .iter()
+                .map(|fp| CoveredWatermark {
+                    device_fingerprint: DeviceFingerprint::from_bytes([*fp; 32]),
+                    seq: 1,
+                    entry_hash: [0x1d; 32],
+                })
+                .collect(),
+        }
+    }
+
+    fn sample() -> SnapshotOp {
+        snapshot(vec![SnapshotTarget {
+            folded_state_hash: [0x2a; 32],
+            covered: vec![CoveredWatermark {
+                device_fingerprint: DeviceFingerprint::from_bytes([0xbb; 32]),
+                seq: 12,
+                entry_hash: [0x1d; 32],
+            }],
+            ..account_target(0, &[])
+        }])
+    }
+
+    #[test]
+    fn golden_snapshot() {
+        // The coverage manifest is a signed wire: pin its exact bytes. A change here is a wire
+        // bump, not a refactor.
+        assert_eq!(hex(&encode(&sample()).unwrap()), "830100818500f6f658202a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a81835820bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb0c58201d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d");
+    }
+
+    #[test]
+    fn an_annex_tag_is_its_own_namespace() {
+        // Annex tag 0 is SNAPSHOT, not control's AccountGenesis. Decode is only ever reached with
+        // `log_id == ANNEX_LOG`, so the numbering cannot collide across logs.
+        assert_eq!(entry_type::SNAPSHOT, 0);
+        assert_eq!(entry_type_of(&sample()), entry_type::SNAPSHOT);
+    }
+
+    #[test]
+    fn snapshot_round_trips_every_target_shape() {
+        let op = snapshot(vec![
+            account_target(0, &[0x11, 0x22]),
+            account_target(1, &[0x33]),
+            SnapshotTarget {
+                log_id: 2,
+                stream_id: Some(stream(0x44)),
+                subject_account_id: Some(account(0x55)),
+                folded_state_hash: [0x66; 32],
+                covered: vec![CoveredWatermark {
+                    device_fingerprint: DeviceFingerprint::from_bytes([0x77; 32]),
+                    seq: 9,
+                    entry_hash: [0x88; 32],
+                }],
+            },
+        ]);
+        let bytes = encode(&op).unwrap();
+        assert_eq!(decode(entry_type::SNAPSHOT, &bytes).unwrap(), DecodedSnapshotOp::Known(op));
+    }
+
+    #[test]
+    fn snapshot_authoring_sorts_targets_and_covered() {
+        // `encode` canonicalizes, so a caller handing them in any order signs the same bytes.
+        let unsorted = snapshot(vec![account_target(1, &[0x33]), account_target(0, &[0x22, 0x11])]);
+        let sorted = snapshot(vec![account_target(0, &[0x11, 0x22]), account_target(1, &[0x33])]);
+        assert_eq!(encode(&unsorted).unwrap(), encode(&sorted).unwrap());
+    }
+
+    #[test]
+    fn snapshot_rejects_conflicting_coverage_claims() {
+        // Coverage is a SET, so a byte-identical repeat is the SAME claim and canonicalizes away.
+        let repeated = snapshot(vec![account_target(0, &[0x11, 0x11])]);
+        let once = snapshot(vec![account_target(0, &[0x11])]);
+        assert_eq!(
+            encode(&repeated).unwrap(),
+            encode(&once).unwrap(),
+            "an identical repeat is one claim, not a conflict",
+        );
+
+        // Two DIFFERENT watermarks for one device are contradictory claims about the same
+        // coordinate — never something to merge, and never something to silently pick between.
+        let mut conflicting = account_target(0, &[0x11]);
+        conflicting.covered.push(CoveredWatermark {
+            device_fingerprint: DeviceFingerprint::from_bytes([0x11; 32]),
+            seq: 99,
+            entry_hash: [0xee; 32],
+        });
+        assert!(
+            encode(&snapshot(vec![conflicting])).is_err(),
+            "one device may be covered at only one coordinate per target",
+        );
+
+        let dup_target = snapshot(vec![account_target(0, &[0x11]), account_target(0, &[0x22])]);
+        assert!(encode(&dup_target).is_err(), "one log may be claimed once per snapshot");
+    }
+
+    #[test]
+    fn snapshot_rejects_a_half_qualified_target() {
+        let account_log_with_stream = snapshot(vec![SnapshotTarget {
+            stream_id: Some(stream(0x44)),
+            ..account_target(0, &[0x11])
+        }]);
+        assert!(encode(&account_log_with_stream).is_err(), "an account log carries no stream_id");
+        let content_without_account = snapshot(vec![SnapshotTarget {
+            log_id: 2,
+            stream_id: Some(stream(0x44)),
+            ..account_target(2, &[0x11])
+        }]);
+        assert!(encode(&content_without_account).is_err(), "a content target needs both ids");
+    }
+
+    #[test]
+    fn snapshot_decoder_rejects_unsorted_wire_bytes() {
+        // The sorted-unique rule must be enforced on DECODE, not just authoring: a peer may hand us
+        // bytes our own encoder would never emit, and `encode(decode) == bytes` is what keeps a
+        // signed log from splitting on ordering.
+        let sorted = encode(&snapshot(vec![account_target(0, &[0x11, 0x22])])).unwrap();
+        let mut swapped = sorted.clone();
+        let first = swapped.iter().position(|b| *b == 0x11).expect("first covered fingerprint");
+        let second = swapped.iter().position(|b| *b == 0x22).expect("second covered fingerprint");
+        for offset in 0..32 {
+            swapped.swap(first + offset, second + offset);
+        }
+        assert_ne!(swapped, sorted);
+        assert!(decode(entry_type::SNAPSHOT, &swapped).is_err(), "descending order is rejected");
+    }
+
+    #[test]
+    fn snapshot_rejects_bounds_violations() {
+        let too_many_covered = snapshot(vec![SnapshotTarget {
+            covered: (0..=SNAPSHOT_COVERED_MAX)
+                .map(|i| CoveredWatermark {
+                    device_fingerprint: DeviceFingerprint::from_bytes(fp_bytes(i)),
+                    seq: 1,
+                    entry_hash: [0x1d; 32],
+                })
+                .collect(),
+            ..account_target(0, &[])
+        }]);
+        assert!(encode(&too_many_covered).is_err(), "§18a bounds the covered array");
+    }
+
+    #[test]
+    fn an_unknown_annex_tag_is_retained_not_rejected() {
+        // Forward-compat: an annex tag this binary does not know stays a valid, chainable entry.
+        let payload = vec![0x81, 0x01];
+        assert_eq!(decode(7, &payload).unwrap(), DecodedSnapshotOp::Unknown {
+            entry_type: 7,
+            bytes: payload
+        });
+        // ...but it must still be exactly one canonical CBOR array, or a future binary that learns
+        // the tag would reject bytes this one stored.
+        assert!(decode(7, &[0xa1, 0x01, 0x02]).is_err(), "a non-array annex payload is refused");
+        assert!(decode(7, &[0x81, 0x01, 0xff]).is_err(), "trailing bytes are refused");
+    }
+
+    #[test]
+    fn the_reserved_moderation_epoch_is_enforced_not_merely_documented() {
+        // `fold_exclude` does not exist (#407), so a non-zero epoch at format 1 names coverage
+        // semantics nothing can evaluate. An unenforced "MUST be 0" is just a comment.
+        let nonzero = SnapshotOp::Snapshot {
+            state_format_version: SNAPSHOT_STATE_FORMAT_V1,
+            moderation_epoch: 1,
+            targets: vec![account_target(0, &[0x11])],
+        };
+        assert!(encode(&nonzero).is_err(), "authoring refuses a reserved-field value");
+
+        // Wire bytes a peer hands us are refused the same way...
+        let mut bytes = encode(&snapshot(vec![account_target(0, &[0x11])])).unwrap();
+        assert_eq!(bytes[2], 0x00, "moderation_epoch is the third header item");
+        bytes[2] = 0x01;
+        assert!(decode(entry_type::SNAPSHOT, &bytes).is_err(), "decoding refuses it too");
+
+        // ...but the rule is scoped to the version that reserves it: a FUTURE state format defines
+        // its own semantics, and this binary must retain such an entry rather than hard-reject a
+        // legitimate future manifest it simply cannot verify.
+        let future = SnapshotOp::Snapshot {
+            state_format_version: SNAPSHOT_STATE_FORMAT_V1 + 1,
+            moderation_epoch: 7,
+            targets: vec![account_target(0, &[0x11])],
+        };
+        let future_bytes = encode(&future).expect("a future format version still encodes");
+        assert_eq!(
+            decode(entry_type::SNAPSHOT, &future_bytes).unwrap(),
+            DecodedSnapshotOp::Known(future),
+        );
+    }
+
+    #[test]
+    fn a_target_naming_an_undefined_log_is_refused() {
+        // The log set is CLOSED: an unknown log has no defined folded projection, so a coverage
+        // claim about it could never be verified or refuted by any implementation. Notably this
+        // includes the annex log itself — a snapshot does not cover snapshots.
+        for undefined in [fold_annex_log(), 4, 200] {
+            let target = SnapshotTarget {
+                log_id: undefined,
+                stream_id: Some(stream(0x44)),
+                subject_account_id: Some(account(0x55)),
+                ..account_target(0, &[0x11])
+            };
+            assert!(
+                encode(&snapshot(vec![target])).is_err(),
+                "log {undefined} has no defined projection to claim coverage of",
+            );
+        }
+    }
+
+    /// The annex log's own id, spelled locally so this module stays free of a `fold` dependency.
+    fn fold_annex_log() -> u8 {
+        3
+    }
+
+    /// Distinct 32-byte fingerprints for bound tests.
+    fn fp_bytes(i: usize) -> [u8; 32] {
+        let mut out = [0u8; 32];
+        out[..8].copy_from_slice(&(i as u64).to_be_bytes());
+        out
+    }
+}

--- a/crates/rag-rat-oplog/src/account/storage.rs
+++ b/crates/rag-rat-oplog/src/account/storage.rs
@@ -1882,9 +1882,14 @@ fn is_current_annex_plaintext(header: &AccountEntryHeader) -> bool {
 /// Scoped to the snapshot TAG, not the annex log: `crypto_suite` is in the clear header, and a
 /// later annex artifact class may legitimately be sealed. Blanket-rejecting every sealed annex
 /// entry would spend that option for nothing.
+///
+/// Deliberately NOT scoped to the current `op_version`. "A snapshot is plaintext" is a property of
+/// the artifact class, not of one version's encoding, so a future-version sealed snapshot is just
+/// as uninterpretable as a current one. If a later version ever wants a sealed coverage artifact it
+/// is a different class and takes a different annex tag — tags 1.. are free, and that is cheaper
+/// than leaving a grow-only hole here that no verifier could ever evaluate.
 fn is_sealed_snapshot(header: &AccountEntryHeader) -> bool {
     header.log_id == fold::ANNEX_LOG
-        && header.op_version == fold::SUPPORTED_OP_VERSION
         && header.entry_type == snapshot::ops::entry_type::SNAPSHOT
         && header.crypto_suite != 0
 }
@@ -3296,6 +3301,22 @@ mod tests {
         );
         assert_eq!(status(&conn, &sealed.entry_hash), None, "and never became a chain link");
 
+        // "A snapshot is plaintext" is a property of the artifact CLASS, not of one version's
+        // encoding, so a future-op_version sealed snapshot is refused just the same — it would be
+        // exactly as uninterpretable, and retaining it would leave a grow-only hole no verifier
+        // could ever evaluate.
+        let future_version = sign_account_entry(
+            &founder.secret,
+            &AccountEntryHeader { op_version: 2, ..header },
+            &[0x81, 0x01],
+        )
+        .unwrap();
+        let outcome = account_ingest(&conn, &future_version.signed_bytes, NOW + 2).unwrap();
+        assert!(
+            matches!(&outcome, IngestOutcome::Rejected(err) if err.contains("plaintext-signed")),
+            "a sealed snapshot at a future op_version is refused too: {outcome:?}",
+        );
+
         // The rejection is scoped to the SNAPSHOT tag, not the annex log: a future annex artifact
         // class may legitimately be sealed, and that option must survive this slice.
         let other_tag = sign_account_entry(
@@ -3305,7 +3326,7 @@ mod tests {
         )
         .unwrap();
         assert_eq!(
-            account_ingest(&conn, &other_tag.signed_bytes, NOW + 2).unwrap(),
+            account_ingest(&conn, &other_tag.signed_bytes, NOW + 3).unwrap(),
             IngestOutcome::Ingested { status: "retained_unfolded".into() },
             "a sealed NON-snapshot annex entry is still retained",
         );

--- a/crates/rag-rat-oplog/src/account/storage.rs
+++ b/crates/rag-rat-oplog/src/account/storage.rs
@@ -16,7 +16,7 @@ use rusqlite::{Connection, OptionalExtension, Transaction, TransactionBehavior, 
 use super::envelope::{self, AccountEntryHeader, VerifiedAccountEntry};
 use super::id::account_id_from_genesis_payload;
 use super::ops::{self, AccountOp, DecodedAccountOp, DeviceCut, DeviceRole, GrantRole};
-use super::{AccountId, content, fold, secrets};
+use super::{AccountId, content, fold, secrets, snapshot};
 use crate::cbor;
 use crate::device::{DevicePublic, DeviceX25519Public};
 use crate::op::DeviceFingerprint;
@@ -1867,6 +1867,28 @@ fn is_current_secrets_plaintext(header: &AccountEntryHeader) -> bool {
         && header.op_version == fold::SUPPORTED_OP_VERSION
 }
 
+/// The annex-plaintext predicate (C6): a current-version, plaintext entry on the annex log.
+fn is_current_annex_plaintext(header: &AccountEntryHeader) -> bool {
+    header.log_id == fold::ANNEX_LOG
+        && header.crypto_suite == 0
+        && header.op_version == fold::SUPPORTED_OP_VERSION
+}
+
+/// A SEALED snapshot is a contradiction, not a forward-version entry to retain: the manifest's
+/// entire §4.7 value is that a peer can verify coverage WITHOUT the plaintext, so a snapshot whose
+/// manifest is ciphertext can never serve its one purpose. Refuse it rather than storing opaque
+/// bytes that no binary — present or future — could interpret as a coverage claim.
+///
+/// Scoped to the snapshot TAG, not the annex log: `crypto_suite` is in the clear header, and a
+/// later annex artifact class may legitimately be sealed. Blanket-rejecting every sealed annex
+/// entry would spend that option for nothing.
+fn is_sealed_snapshot(header: &AccountEntryHeader) -> bool {
+    header.log_id == fold::ANNEX_LOG
+        && header.op_version == fold::SUPPORTED_OP_VERSION
+        && header.entry_type == snapshot::ops::entry_type::SNAPSHOT
+        && header.crypto_suite != 0
+}
+
 fn validate_storable_header_payload(
     header: &AccountEntryHeader,
     payload: &[u8],
@@ -1883,6 +1905,15 @@ fn validate_storable_header_payload(
         // unvalidated (it is slot-eligible, folded by a newer binary).
         secrets::validate_storable_secrets_payload(header.entry_type, payload)
             .map_err(|err| format!("secrets op payload decode failed: {err}"))?;
+    } else if is_sealed_snapshot(header) {
+        return Err("snapshot manifests must be plaintext-signed (crypto_suite 0)".to_string());
+    } else if is_current_annex_plaintext(header) {
+        // The annex-plaintext twin (C6): a known annex tag is fully validated so a garbage manifest
+        // can never chain; an unknown tag is retained opaque. This is STRUCTURAL only — whether the
+        // manifest's coverage claim is true is a read-time question, and asking it here would make
+        // storage depend on what this device happens to hold.
+        snapshot::ops::validate_storable_snapshot_payload(header.entry_type, payload)
+            .map_err(|err| format!("annex op payload decode failed: {err}"))?;
     }
     Ok(())
 }
@@ -3121,6 +3152,163 @@ mod tests {
             "the DeviceAdd runs the sweep exactly once",
         );
         assert_eq!(parked(&conn), 0, "the DeviceAdd promotes the parked content");
+    }
+
+    #[test]
+    fn an_annex_entry_is_stored_inert_and_never_touches_control_acceptance() {
+        // #609 C6: the annex log (3) exists so a bookkeeping artifact can be authority-INERT by
+        // topology. Two properties, and both must hold on a binary that knows nothing about it:
+        // it is stored and retained header-only, and the control chain is completely unaffected.
+        //
+        // `entry_type = 0` is deliberate: on log 0 that is `AccountGenesis`, so this also proves
+        // the log gate runs BEFORE any tag dispatch and an annex tag can never be misread as the
+        // control tag with the same number.
+        let conn = db();
+        let founder = Dev::new(0x81);
+        let (account_id, genesis_bytes, genesis_hash) = genesis(&founder);
+        account_ingest(&conn, &genesis_bytes, NOW).unwrap();
+
+        let manifest = snapshot::ops::encode(&snapshot::ops::SnapshotOp::Snapshot {
+            state_format_version: snapshot::ops::SNAPSHOT_STATE_FORMAT_V1,
+            moderation_epoch: 0,
+            targets: Vec::new(),
+        })
+        .unwrap();
+        let header = AccountEntryHeader {
+            account_id,
+            log_id: fold::ANNEX_LOG,
+            device_fingerprint: founder.fp,
+            seq: 0,
+            prev_hash: None,
+            parent_ref: None,
+            entry_type: snapshot::ops::entry_type::SNAPSHOT,
+            op_version: 1,
+            crypto_suite: 0,
+            auth_len: 1,
+            key_id: None,
+            authority_ref: Some(genesis_hash),
+        };
+        let annex = sign_account_entry(&founder.secret, &header, &manifest).unwrap();
+        assert_eq!(
+            account_ingest(&conn, &annex.signed_bytes, NOW + 1).unwrap(),
+            IngestOutcome::Ingested { status: "retained_unfolded".into() },
+            "an annex entry is stored and retained, never folded and never rejected",
+        );
+
+        // The control chain is untouched: a later control op still accepts at its own seq. This is
+        // the property a never-effective entry on log 0 would break (#809).
+        let member = Dev::new(0x82);
+        let (add_bytes, add_hash) = op(
+            account_id,
+            &founder,
+            1,
+            Some(genesis_hash),
+            Some(genesis_hash),
+            &device_add(&member, DeviceRole::Member),
+        );
+        account_ingest(&conn, &add_bytes, NOW + 2).unwrap();
+        assert_eq!(status(&conn, &genesis_hash).as_deref(), Some("accepted"));
+        assert_eq!(
+            status(&conn, &add_hash).as_deref(),
+            Some("accepted"),
+            "the annex entry did not orphan the control chain",
+        );
+        assert_eq!(status(&conn, &annex.entry_hash).as_deref(), Some("retained_unfolded"));
+    }
+
+    #[test]
+    fn a_garbage_annex_manifest_is_refused_at_ingest() {
+        // The manifest is structurally validated at ingest (the per-log twin of the control and
+        // secrets validators), so garbage can never chain — even though nothing folds this log.
+        let conn = db();
+        let founder = Dev::new(0x83);
+        let (account_id, genesis_bytes, genesis_hash) = genesis(&founder);
+        account_ingest(&conn, &genesis_bytes, NOW).unwrap();
+
+        let header = AccountEntryHeader {
+            account_id,
+            log_id: fold::ANNEX_LOG,
+            device_fingerprint: founder.fp,
+            seq: 0,
+            prev_hash: None,
+            parent_ref: None,
+            entry_type: snapshot::ops::entry_type::SNAPSHOT,
+            op_version: 1,
+            crypto_suite: 0,
+            auth_len: 1,
+            key_id: None,
+            authority_ref: Some(genesis_hash),
+        };
+        // A CBOR map where the manifest wire requires a 3-element array.
+        let garbage = sign_account_entry(&founder.secret, &header, &[0xa1, 0x01, 0x02]).unwrap();
+        let outcome = account_ingest(&conn, &garbage.signed_bytes, NOW + 1).unwrap();
+        assert!(
+            matches!(&outcome, IngestOutcome::Rejected(err) if err.contains("annex op payload")),
+            "a structurally invalid manifest is rejected, not stored: {outcome:?}",
+        );
+        assert_eq!(status(&conn, &garbage.entry_hash), None, "and it never became a chain link");
+
+        // An UNKNOWN annex tag is the forward-compat case and must still be stored — it is a valid
+        // chain link for a binary that does not know it, exactly like an unknown secrets tag.
+        let forward = sign_account_entry(
+            &founder.secret,
+            &AccountEntryHeader { entry_type: 7, ..header },
+            &[0x81, 0x01],
+        )
+        .unwrap();
+        assert_eq!(
+            account_ingest(&conn, &forward.signed_bytes, NOW + 2).unwrap(),
+            IngestOutcome::Ingested { status: "retained_unfolded".into() },
+            "an unknown annex tag is retained, never rejected",
+        );
+    }
+
+    #[test]
+    fn a_sealed_snapshot_is_refused_rather_than_retained() {
+        // A sealed manifest can never serve its purpose (§4.7's whole value is that a peer verifies
+        // coverage WITHOUT plaintext), so it is refused rather than stored as opaque bytes no
+        // binary could ever interpret. Contrast the control/secrets logs, where a sealed payload is
+        // deliberately retained for a newer binary to fold.
+        let conn = db();
+        let founder = Dev::new(0x84);
+        let (account_id, genesis_bytes, genesis_hash) = genesis(&founder);
+        account_ingest(&conn, &genesis_bytes, NOW).unwrap();
+
+        let header = AccountEntryHeader {
+            account_id,
+            log_id: fold::ANNEX_LOG,
+            device_fingerprint: founder.fp,
+            seq: 0,
+            prev_hash: None,
+            parent_ref: None,
+            entry_type: snapshot::ops::entry_type::SNAPSHOT,
+            op_version: 1,
+            crypto_suite: 1,
+            key_id: Some([0x77; 32]),
+            auth_len: 1,
+            authority_ref: Some(genesis_hash),
+        };
+        let sealed = sign_account_entry(&founder.secret, &header, &[0x81, 0x01]).unwrap();
+        let outcome = account_ingest(&conn, &sealed.signed_bytes, NOW + 1).unwrap();
+        assert!(
+            matches!(&outcome, IngestOutcome::Rejected(err) if err.contains("plaintext-signed")),
+            "a sealed snapshot is rejected: {outcome:?}",
+        );
+        assert_eq!(status(&conn, &sealed.entry_hash), None, "and never became a chain link");
+
+        // The rejection is scoped to the SNAPSHOT tag, not the annex log: a future annex artifact
+        // class may legitimately be sealed, and that option must survive this slice.
+        let other_tag = sign_account_entry(
+            &founder.secret,
+            &AccountEntryHeader { entry_type: 9, ..header },
+            &[0x81, 0x01],
+        )
+        .unwrap();
+        assert_eq!(
+            account_ingest(&conn, &other_tag.signed_bytes, NOW + 2).unwrap(),
+            IngestOutcome::Ingested { status: "retained_unfolded".into() },
+            "a sealed NON-snapshot annex entry is still retained",
+        );
     }
 
     #[test]


### PR DESCRIPTION
Part of #609 (phase C — C6). Wire only: nothing authors a snapshot and nothing verifies one yet.

## Why a new log rather than a control `entry_type`

A snapshot has to satisfy two requirements that turn out to be jointly unsatisfiable on the control log.

It must never be an **effective** op — an effective one shifts `effective_count`, so every later entry asserting the higher `auth_len` parks `auth_len_ahead` un-healably on any binary that doesn't know the type (the peer already holds the entry, so refetching fixes nothing).

But a never-effective entry can't ride the control log either: `select_coherent_branches` walks **effective** entries with contiguous `seq`, so a non-effective entry mid-chain orphans every later entry from that device. That is #809 — it reproduces on stock `main` with an unknown `entry_type` and is not introduced here.

On its own log the inertness is **topological**: `fold_account`'s `log_id` gate short-circuits before any tag dispatch, so no future match arm has to remember to preserve it. The first draft of this slice rode log 0 and defended the property with three never-reached match arms; the log move replaces defensive code with structure.

**Log 3, not 2** — `ChainKind::Content = 2` already names the content chain on the register/cut axis, so a second meaning for that number would be ambiguous. Named for the **class** (authority-inert bookkeeping) rather than the op, because log 0's tag set is effectively closed by the argument above: future inert artifacts take annex tags instead of minting a fourth log.

## The manifest

`state_format_version`, a reserved `moderation_epoch`, and targets of `(log_id, stream_id?, account_id?, folded_state_hash, covered[])`.

Targets carry stream/account qualification and **per-target** hashes so #406 adds content snapshots without a wire bump: a bare `log_id` cannot name a `/3` coordinate (those chains are dense per `(stream, author_account, device)`), and one hash cannot bind heterogeneous projections.

It carries **no folded state**. `ACCOUNT_ENVELOPE_MAX_BYTES` is 64 KiB — a §18a validity limit, so raising it is a deliberate wire bump — and a control log at the §18b fold cap cannot be assumed to fit. Peers re-fold the covered prefix locally and check the hash. Chunking across entries and a per-type §18a exception were both considered and rejected; the latter is how two implementations come to disagree.

## Enforcement, not documentation

Three rules that started as comments and are now checked, each with a test:

- **A sealed snapshot is refused**, not retained. A ciphertext manifest can never serve its §4.7 purpose. Scoped to the snapshot *tag*, not the annex log, so a future annex artifact class may still legitimately be sealed.
- **`moderation_epoch` must be 0** at state format 1 (`fold_exclude` is #407) — on both encode *and* decode, since decode reaches the raw writer for its canonicity compare and would otherwise skip the check. Scoped to the version that reserves it, so a future format is retained rather than hard-rejected.
- **The target `log_id` set is closed.** An undefined log has no projection a coverage claim could ever be verified or refuted against — including the annex log itself.

## Deliberately not here

Whether a manifest's claim is **true** is a read-time question. Answering it requires holding the covered history, so an acceptance rule that read local inventory would make the verdict device-dependent and break convergence. There is no acceptance lane at all: an annex entry is stored and structurally valid, never "accepted".

Also out of scope: the canonical projection that produces `folded_state_hash`, verification and snapshot selection, and the fold cap.

## Verification

- `cargo nextest run --workspace`: 3,508 passed.
- `cargo test -p rag-rat-oplog --lib --no-default-features --locked` (the coverage job's runner shape): 569 passed.
- Both CI clippy invocations with `-D warnings`: exit 0.
- Nightly rustfmt `--check` and `git diff --check`: clean.
- Codex review folded before push — it caught all three enforcement gaps above.