### PR TITLE
feat(distill): surface distilled records on symbol_lookup (drive-by attachment) (#812)

### DIFF
--- a/crates/rag-rat-core/src/index/query_api/memory.rs
+++ b/crates/rag-rat-core/src/index/query_api/memory.rs
@@ -132,6 +132,24 @@ impl IndexDatabase {
         )
     }
 
+    /// Distilled decision records worth surfacing on a symbol (#705 drive-by), labeled unreviewed.
+    /// Empty for a symbol with no resolved logical id (nothing to anchor a record to). Repo-scoped;
+    /// the facet gate + cap live in `rag_rat_papertrail::records_for_symbol`.
+    pub fn records_for_symbol(
+        &self,
+        symbol: &rag_rat_query::symbol::SymbolHit,
+        limit: usize,
+    ) -> anyhow::Result<Vec<rag_rat_papertrail::DriveByRecord>> {
+        let Some(logical_symbol_id) = symbol.logical_symbol_id else {
+            return Ok(Vec::new());
+        };
+        let conn = self.storage.connection();
+        let repo_id = rag_rat_db::schema::active_repo_id(conn)?;
+        let records =
+            rag_rat_papertrail::records_for_symbol(conn, &repo_id, logical_symbol_id, limit)?;
+        Ok(records.into_iter().map(rag_rat_papertrail::DriveByRecord::new).collect())
+    }
+
     pub fn memory_for_path(
         &self,
         path: &str,

--- a/crates/rag-rat-mcp/src/tools/handlers.rs
+++ b/crates/rag-rat-mcp/src/tools/handlers.rs
@@ -307,6 +307,13 @@ pub(crate) fn symbol_lookup_tool(
         if !memories.is_empty() {
             candidate["memories"] = json!(memories);
         }
+        // Distilled decision records for this symbol (#705 drive-by), capped ≤2 and labeled
+        // unreviewed. Facet-gated (provider fix edge + selected symbol anchor), so this is empty
+        // for the vast majority of symbols and never bloats the candidate.
+        let records = db.records_for_symbol(hit, 2)?;
+        if !records.is_empty() {
+            candidate["distilled_records"] = json!(records);
+        }
     }
     Ok(value)
 }

--- a/crates/rag-rat-papertrail/src/distill_read.rs
+++ b/crates/rag-rat-papertrail/src/distill_read.rs
@@ -87,6 +87,24 @@ pub struct DistilledRecord {
     pub coalesced: Vec<CoalescedThread>,
 }
 
+/// A distilled record surfaced on a drive-by (symbol / chunk) surface, LABELED so a consumer knows
+/// it is model-distilled and NOT human-reviewed. The record itself already carries its thread
+/// identity and fixing commits as provenance; this wrapper adds the `unreviewed` label the drive-by
+/// spec requires (a symbol's related decisions are best-effort context, not verified facts).
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct DriveByRecord {
+    /// Always `true`: the record is model-distilled, not human-reviewed.
+    pub unreviewed: bool,
+    #[serde(flatten)]
+    pub record: DistilledRecord,
+}
+
+impl DriveByRecord {
+    pub fn new(record: DistilledRecord) -> Self {
+        Self { unreviewed: true, record }
+    }
+}
+
 /// Load the canonical distilled record for a thread, following a `coalesced` edge when the thread
 /// was coalesced into a partner that owns the row. `None` when no record exists for the thread or
 /// its coalesce partner. `repo_id` is the active repo (mandatory: the store is one index over every
@@ -133,6 +151,12 @@ pub fn records_for_symbol(
     limit: usize,
 ) -> anyhow::Result<Vec<DistilledRecord>> {
     if limit == 0 {
+        return Ok(Vec::new());
+    }
+    // The distill store is OPTIONAL enrichment: a pre-distill or partially-migrated index has the
+    // symbol index but not the distill tables (V077). Serve nothing rather than error the whole
+    // surface that attaches the drive-by (symbol_lookup etc.) on a missing table.
+    if !rag_rat_db::schema::table_exists(conn, "papertrail_distill")? {
         return Ok(Vec::new());
     }
     let token = rag_rat_base::serde_big_id::format_sym_handle(logical_symbol_id);
@@ -396,7 +420,7 @@ fn fixing_commits(
 mod tests {
     use rusqlite::{Connection, params};
 
-    use super::{RecordKey, distilled_record_for_thread, records_for_symbol};
+    use super::{DriveByRecord, RecordKey, distilled_record_for_thread, records_for_symbol};
     use crate::{FixEdgeSource, OutcomeStatus, ThreadShape};
 
     fn conn() -> Connection {
@@ -487,6 +511,50 @@ mod tests {
         seed_symbol_anchor(&conn, "5", SYM_A, true);
         assert!(records_for_symbol(&conn, "repoA", SYM_UNANCHORED, 10).unwrap().is_empty());
         assert!(records_for_symbol(&conn, "repoA", SYM_A, 0).unwrap().is_empty(), "limit 0");
+    }
+
+    #[test]
+    fn drive_by_record_labels_the_serialized_record_unreviewed() {
+        let conn = conn();
+        // Seed a NON-null model status so this test can actually FAIL if the raw field ever
+        // regresses from unconditional `skip_serializing` to a conditional skip: it must be absent
+        // from the wire even when the record carries it.
+        seed_record(&conn, &Seed {
+            repo: "repoA",
+            kind: "issue",
+            key: "5",
+            root_issue: None,
+            model_status: Some("landed"),
+            fix_edge_source: "provider",
+            revert_override: false,
+            closing_keyword: None,
+        });
+        let record =
+            distilled_record_for_thread(&conn, "repoA", &key("issue", "5")).unwrap().unwrap();
+        assert_eq!(
+            record.outcome_status_model,
+            Some(OutcomeStatus::Landed),
+            "precondition: the record carries a raw model status",
+        );
+        let json = serde_json::to_value(DriveByRecord::new(record)).unwrap();
+        assert_eq!(
+            json["unreviewed"],
+            serde_json::json!(true),
+            "labeled model-distilled, unreviewed"
+        );
+        assert_eq!(json["item_key"], serde_json::json!("5"), "the record fields flatten alongside");
+        assert!(
+            json.get("outcome_status_model").is_none(),
+            "the raw model status is UNCONDITIONALLY off the wire, even when present",
+        );
+    }
+
+    #[test]
+    fn records_for_symbol_is_a_no_op_when_the_distill_store_is_absent() {
+        // A pre-distill / partially-migrated index has the symbol index but no distill tables; the
+        // drive-by must return nothing rather than erroring on the missing table.
+        let conn = Connection::open_in_memory().unwrap();
+        assert!(records_for_symbol(&conn, "repoA", SYM_A, 10).unwrap().is_empty());
     }
 
     fn key(kind: &str, k: &str) -> RecordKey {

--- a/crates/rag-rat-papertrail/src/lib.rs
+++ b/crates/rag-rat-papertrail/src/lib.rs
@@ -28,8 +28,8 @@ pub use distill::{
     AnchorKind, DistillEdgeKind, EpistemicStatus, FixEdgeSource, OutcomeStatus, ThreadShape,
 };
 pub use distill_read::{
-    CoalescedThread, DistilledRecord, RecordKey, RejectedAlternative, distilled_record_for_thread,
-    records_for_symbol,
+    CoalescedThread, DistilledRecord, DriveByRecord, RecordKey, RejectedAlternative,
+    distilled_record_for_thread, records_for_symbol,
 };
 pub use distill_status::{EffectiveStatusInputs, effective_status, no_fix_edge};
 pub use evidence::{refs, *};


### PR DESCRIPTION
Closes #812. First surface for #705's symbol drive-by, on `records_for_symbol` (#808).

`symbol_lookup` candidates now carry the facet-gated distilled decision records for the symbol under `distilled_records`, labeled unreviewed.

## What ships

- **`DriveByRecord`** (in `rag-rat-papertrail`) — a thin wrapper that adds an `unreviewed: true` label and flattens the `DistilledRecord` (which already carries the thread identity + fixing commits as provenance). The drive-by is best-effort context, not verified fact, so the label is required.
- **`IndexDatabase::records_for_symbol`** — mirrors `memory_for_symbol`: empty for a symbol with no resolved logical id, else resolves the active repo, calls the facet-gated helper, and maps to the labeled type.
- **`symbol_lookup_tool`** — attaches the records per candidate inside the existing drive-by loop, capped ≤2/symbol.
- **Optional-store guard** on `records_for_symbol`: a pre-distill or partially-migrated index (has the symbol index, not the distill tables) serves nothing rather than erroring the surface.

## Notes

- Records ride the `symbol_lookup` memories-include gate on this first surface (no separate `include` variant yet); a caller excluding memories also excludes records. `impact_surface` + `read_chunk` are the next slices.
- Response-size guard is the ≤2 cap plus the record's already-bounded narrative fields; a real before/after payload measurement rides the eventual full-corpus drain (no records exist in the index until then).

## Verification

- New tests: `DriveByRecord` serialization (label present, raw model status unconditionally off the wire, fields flattened), and the optional-store no-op. The existing `records_for_symbol` facet-gate/cap/empty tests still cover the read.
- 4 CI clippy gates clean; `cargo nextest run --workspace --no-default-features`: 3497 passed, 0 skipped; nightly fmt clean.