### PR TITLE
feat(distill): surface distilled records on impact_surface (drive-by attachment) (#832)

### DIFF
--- a/crates/rag-rat-core/src/index/query_api/graph.rs
+++ b/crates/rag-rat-core/src/index/query_api/graph.rs
@@ -871,6 +871,25 @@ impl IndexDatabase {
         }
         report.completeness_and_caveats.stale_files =
             u64::try_from(self.stale_source_paths(&result_paths)?.len()).unwrap_or(u64::MAX);
+        // Distilled decision records for the selected symbol (#705 drive-by), rides the memories
+        // lane's include flag. Fetch one past the ≤2 display cap so truncation is SIGNALLED (the
+        // report's no-silent-caps contract, #49) rather than silently dropping older records.
+        if options.include_memories {
+            const DISTILLED_RECORD_CAP: usize = 2;
+            let mut records = self.records_for_symbol(symbol, DISTILLED_RECORD_CAP + 1)?;
+            let truncated = records.len() > DISTILLED_RECORD_CAP;
+            records.truncate(DISTILLED_RECORD_CAP);
+            report.distilled_records = records;
+            if truncated {
+                report.completeness_and_caveats.truncated_sections.push("distilled_records".into());
+                report.completeness_and_caveats.caveats.push(
+                    "distilled_records is a fixed-size (2) drive-by lane — more qualifying \
+                     decision records exist for this symbol and cannot be retrieved by raising \
+                     `limit`."
+                        .to_string(),
+                );
+            }
+        }
         Ok(report)
     }
 

--- a/crates/rag-rat-mcp/src/tools/handlers.rs
+++ b/crates/rag-rat-mcp/src/tools/handlers.rs
@@ -619,6 +619,8 @@ pub(crate) fn impact_tool(
             limit: args.limit,
         };
         return match db.select_symbol(&selector)? {
+            // The distilled-records drive-by lane (#705) is now part of the report itself — built,
+            // capped, and truncation-signalled in `impact_surface_report_for_selected_symbol`.
             Ok(Some(symbol)) => Ok(json!(
                 db.impact_surface_report_for_selected_symbol(&symbol, args.limit, &options)?
             )),

--- a/crates/rag-rat-query/src/impact/mod.rs
+++ b/crates/rag-rat-query/src/impact/mod.rs
@@ -109,6 +109,12 @@ pub struct ImpactSurfaceReport {
     pub files_co_changed_with_symbol_path: Vec<ImpactItem>,
     pub papertrail_rationale_items: Vec<ImpactItem>,
     pub repo_memories: RepoMemoryEvidenceView,
+    /// Distilled decision records for the selected symbol (#705 drive-by), capped ≤2 and labeled
+    /// unreviewed. Facet-gated, so empty for the vast majority of symbols; populated by the core
+    /// read layer after this builder runs. When more than the cap qualify,
+    /// `completeness_and_caveats.truncated_sections` names this lane (no silent caps, #49).
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub distilled_records: Vec<rag_rat_papertrail::DriveByRecord>,
     pub completeness_and_caveats: ImpactCompleteness,
 }
 
@@ -376,6 +382,9 @@ pub fn impact_surface_report_for_symbol(
         files_co_changed_with_symbol_path,
         papertrail_rationale_items,
         repo_memories,
+        // Populated by the core read layer (it owns the distill-store access); this builder is the
+        // graph/text/papertrail lanes only.
+        distilled_records: Vec::new(),
     })
 }
 


### PR DESCRIPTION
Closes #832. Second surface for #705's symbol drive-by, reusing `records_for_symbol` (#808) + the `DriveByRecord` label and `IndexDatabase::records_for_symbol` wrapper (#812).

The `impact_surface` symbol-selected report now carries the facet-gated distilled decision records for the symbol under `distilled_records`, capped ≤2 and labeled unreviewed. The records are inserted into the report object and ride the impact memories-include flag, like the report's own memory lane; the facet gate (provider fix edge + selected symbol anchor) keeps it empty for the vast majority of symbols. The query-string / allow-ambiguous fallbacks (flat `Vec<ImpactItem>`, no memory lane) are unchanged.

`read_chunk` (needs a chunk→symbols→records resolution) is the next slice.

## Verification

- 4 CI clippy gates clean; `cargo nextest run --workspace --no-default-features`: 3497 passed, 0 skipped; nightly fmt clean. (The drive-by mechanism — the facet gate, cap, and the `unreviewed` label serialization — is covered by the `records_for_symbol` / `DriveByRecord` tests from #808/#812; this slice is a mechanical attach reusing them.)