### PR TITLE
perf(watch): stop overlay-only passes from forcing the base reconcile and clone delta

### DIFF
--- a/crates/rag-rat-core/src/index/query_api/clones/precompute.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/precompute.rs
@@ -253,6 +253,14 @@ impl IndexDatabase {
         }
     }
 
+    /// Whether the #472 quiet gate holds an armed candidate. Watch-level tests assert the #817
+    /// posture through this (an overlay-only pass neither probes nor arms) — `repo_meta` is not
+    /// reachable from outside the `index` module tree.
+    #[cfg(test)]
+    pub(crate) fn clone_graph_quiet_candidate_armed(&self) -> bool {
+        self.clone_graph_quiet_candidate().ok().flatten().is_some()
+    }
+
     /// The armed quiet-window candidate, if any: the stale revision under observation and when it
     /// was first seen. A torn/corrupt pair reads as absent (the next probe re-arms it).
     fn clone_graph_quiet_candidate(&self) -> anyhow::Result<Option<(String, i64)>> {
@@ -1432,6 +1440,23 @@ pub(super) mod tests {
             "the probing call after a cold one arms fresh"
         );
         assert!(db.clone_graph_rebuild_due_at(50_000_000 + 300_000, 300_000, true).unwrap());
+    }
+
+    /// An ARMED candidate bypasses `probe_without_candidate = false`: an overlay-only or idle
+    /// pass — which carries no probe permission since #817 — still fires a quiet-elapsed owed
+    /// rebuild. Arming is what needs permission (a content/gc/backlog pass); firing is not.
+    #[test]
+    fn clone_graph_quiet_gate_fires_an_armed_candidate_without_probe_permission() {
+        let db = build_clone_fixture("quiet-gate-armed-fires");
+        assert!(!db.clone_graph_rebuild_due_at(1_000, 300_000, true).unwrap(), "arm");
+        assert!(
+            !db.clone_graph_rebuild_due_at(2_000, 300_000, false).unwrap(),
+            "armed but not quiet-elapsed: not due"
+        );
+        assert!(
+            db.clone_graph_rebuild_due_at(1_000 + 300_000, 300_000, false).unwrap(),
+            "a quiet-elapsed armed candidate fires on a pass with no probe permission"
+        );
     }
 
     /// Once the graph is current the gate reports not-due and drops the armed candidate, so idle

--- a/crates/rag-rat-core/src/watch/mod.rs
+++ b/crates/rag-rat-core/src/watch/mod.rs
@@ -9,7 +9,9 @@
 //!   Classifies events through the target globs to decide whether to fire, and debounces bursts
 //!   with a max-latency cap so sustained writes can't starve a pass.
 //! - Each pass runs the existing pipeline: discover → reconcile → (rate-limited) gc →
-//!   memory_validate. Discover handles additions/edits/deletions; the pass is idempotent.
+//!   memory_validate. Discover handles additions/edits/deletions; the pass is idempotent. A pass
+//!   whose only change is a linked-worktree overlay skips the base reconcile / clone stages and
+//!   runs just memory_validate (#817).
 //! - Passes execute on a dedicated worker thread, never on the event loop (#506): a long stage
 //!   (cold embedding backlog, clone-graph rebuild) or a blocked write-lock acquisition must not
 //!   stop events from classifying or the fleet hot-upgrade trigger from firing. One pass in flight
@@ -40,8 +42,8 @@ pub use pass::{CLONE_GRAPH_QUIET_MS, maintenance_pass, maintenance_pass_or_skip}
 #[cfg(test)]
 pub(crate) use pass::{
     Debounce, GC_EVERY_PASSES, LoopMsg, PassRequest, PassScheduler, STARTUP_CATCHUP_RUN_GC,
-    SweepClock, base_embedding_backlog_needs_tail, maybe_checkpoint_wal, should_run_pass_tail,
-    spawn_pass_worker, startup_catchup_pass,
+    SweepClock, base_embedding_backlog_needs_tail, base_tail_forced_by_state, maybe_checkpoint_wal,
+    should_run_base_tail, spawn_pass_worker, startup_catchup_pass,
 };
 #[cfg(test)]
 pub(crate) use placement::{

--- a/crates/rag-rat-core/src/watch/pass.rs
+++ b/crates/rag-rat-core/src/watch/pass.rs
@@ -307,14 +307,10 @@ fn run_pass(
     let overlays_changed = timings.stage("overlays", || {
         refresh_worktree_overlays(&mut db, config, Some(&budget), overlay_scope)
     });
-    let tail_already_forced = pass_tail_forced_by_state(
-        content_changed,
-        overlays_changed,
-        run_gc,
-        shutdown_reconcile_pending,
-    );
+    let base_tail_forced =
+        base_tail_forced_by_state(content_changed, run_gc, shutdown_reconcile_pending);
     let base_embedding_backlog = base_embedding_backlog_needs_tail(
-        tail_already_forced,
+        base_tail_forced,
         retry_base_embedding_backlog,
         &budget,
         |options| {
@@ -322,78 +318,93 @@ fn run_pass(
                 .is_ok_and(|pending| pending > 0)
         },
     );
-    // Clone-graph quiet gate (#472): one probe serves two roles. Inside the tail it REPLACES the
-    // bare `pending_clone_graph` check — a pass during active editing arms/re-arms the quiet
+    // Clone-graph quiet gate (#472): one probe serves two roles. Inside the base tail it REPLACES
+    // the bare `pending_clone_graph` check — a pass during active editing arms/re-arms the quiet
     // window instead of discarding the in-flight generation and rebuilding the whole graph — and
-    // on an otherwise-idle pass a quiet-elapsed backlog FORCES the tail (like the embedding
+    // on an otherwise-idle pass a quiet-elapsed armed backlog FORCES the tail (like the embedding
     // backlog above) so the owed rebuild lands right after the churn pauses rather than waiting
-    // for a gc pass. Unlike the embedding probe it must also run whenever the tail will run —
-    // including a startup embedding-backlog tail, which doesn't flip `tail_already_forced` — so
-    // every tail pass can at least ARM an unarmed pending graph (else it rides until a content
-    // change or gc pass). When nothing runs the tail the probe stays cheap: without an armed
-    // candidate it skips the content-revision digest entirely.
+    // for a gc pass. Probe permission is "the base tail already runs" — including a startup
+    // embedding-backlog tail, which doesn't flip `base_tail_forced` — so every base-tail pass can
+    // at least ARM an unarmed pending graph. Overlay-only passes deliberately carry NO permission
+    // (#817): overlay churn never moves `content_revision()` (it digests base files only), so an
+    // unarmed probe there could only re-observe the same base staleness while paying the
+    // corpus-scale revision digest every pass. An unarmed pending graph therefore rides overlay
+    // churn until a content, gc, or backlog pass arms it; an ALREADY-ARMED candidate still probes
+    // on every pass — candidate presence bypasses the permission — so a quiet-elapsed owed
+    // rebuild lands even mid-churn. When nothing is armed and nothing grants permission the gate
+    // costs one meta read.
     let clone_graph_due = db
-        .clone_graph_rebuild_due(
-            CLONE_GRAPH_QUIET_MS,
-            tail_already_forced || base_embedding_backlog,
-        )
+        .clone_graph_rebuild_due(CLONE_GRAPH_QUIET_MS, base_tail_forced || base_embedding_backlog)
         .unwrap_or(false);
-    // Idle backstop (issue #63, facet 2): when the sweep changed no content, skip the reconcile /
-    // gc / memory-validate tail — an idle server should do no work past discovery. `run_gc` (every
-    // GC_EVERY_PASSES) still forces a full tail, so the cases that DON'T flip content_changed are
-    // still caught within that bound: a freshly-installed embedder, an embedding backlog left by a
-    // time-capped reconcile (PASS_RECONCILE_MAX_SECONDS), and drifted memory anchors. Any real
-    // content change runs the full tail immediately. Startup has two discover-only exceptions:
-    // a prior bounded shutdown discover that marked base reconcile owed, and an already-indexed
-    // base embedding backlog left by a time-capped or blocked prior pass.
+    // Idle backstop (issue #63, facet 2): when the sweep changed nothing, skip everything past
+    // discovery — an idle server should do no work. `run_gc` (every GC_EVERY_PASSES) still forces
+    // a full tail, so the cases that DON'T flip content_changed are still caught within that
+    // bound: a freshly-installed embedder, an embedding backlog left by a time-capped reconcile
+    // (PASS_RECONCILE_MAX_SECONDS), and drifted memory anchors. Any real content change runs the
+    // full tail immediately. Startup has two discover-only exceptions: a prior bounded shutdown
+    // discover that marked base reconcile owed, and an already-indexed base embedding backlog
+    // left by a time-capped or blocked prior pass.
     // A pass with no content/overlay change is the quiet moment WAL hygiene waits for (#482) —
     // whether or not something else (gc, a backlog, the clone gate) still forces the tail below.
     let quiet_pass = !content_changed && !overlays_changed;
-    if !should_run_pass_tail(
+    // Overlay changes do NOT force the base tail (#817): the overlay stage above already
+    // reconciled a changed overlay's embeddings inline, and every base stage keys off
+    // `content_revision()` (base files only) — on an overlay-only pass the base reconcile is
+    // already Current and the clone delta is a guaranteed no-op that still pays two revision
+    // scans plus a corpus-scale `delta_paths` sweep (measured 66–94 s per pass under worktree
+    // churn). Such a pass runs only `memory_validate` below — cheap next to the base stages, and
+    // overlay edits can move memory anchors.
+    let run_base_tail = should_run_base_tail(
         content_changed,
-        overlays_changed,
         run_gc,
         shutdown_reconcile_pending,
         base_embedding_backlog,
         clone_graph_due,
-    ) {
+    );
+    if !run_base_tail && !overlays_changed {
         timings.stage("wal", || {
             maybe_checkpoint_wal(&db, quiet_pass, crate::index::WAL_CHECKPOINT_MIN_BYTES)
         });
         timings.emit(false, content_changed, overlays_changed);
         return Ok(());
     }
-    // The base reconcile gets only the budget the overlays left behind; `None` → already exhausted,
-    // so skip it (the embedding backlog rides the next pass) rather than spend a fresh full budget.
     let mut base_reconcile_status = None;
-    if let Some(options) = budget.next_options() {
-        let report =
-            timings.stage("reconcile", || db.reconcile_with_options_progress(options, |_| {}))?;
-        base_reconcile_status = Some(report.status);
-    }
-    // Clone-edge graph (#286/#473): try the cheap IN-PLACE delta first — it settles an ordinary
-    // edit on this very pass (freshness is the point; no quiet window) and reports whether a FULL
-    // rebuild is still owed (accumulated df drift). The full rebuild runs only when the delta
-    // could not settle freshness (absent generation, normalizer bump, cap crossing, huge delta,
-    // error) or a drift refresh is owed — and it stays behind the #472 quiet window
-    // (`clone_graph_due`) so sustained editing defers it instead of treadmilling. Best-effort +
-    // resumable, with whatever budget the embedding reconcile left (shared
-    // PASS_RECONCILE_MAX_SECONDS so a pass can't overrun); `None` budget → rides the next pass.
-    let clone_full_rebuild_owed = match timings
-        .stage("clone_delta", || db.apply_clone_graph_delta(crate::index::CLONE_DELTA_MAX_FILES))
-    {
-        Ok(delta) if delta.status == "Applied" || delta.status == "Noop" => delta.full_rebuild_owed,
-        _ => true,
-    };
-    if clone_full_rebuild_owed
-        && clone_graph_due
-        && let Some(options) = budget.next_options()
-    {
-        let _ = timings
-            .stage("clone_rebuild", || db.reconcile_clone_edges_with_budget(options.max_seconds));
-    }
-    if run_gc {
-        let _ = timings.stage("gc", || db.garbage_collect());
+    if run_base_tail {
+        // The base reconcile gets only the budget the overlays left behind; `None` → already
+        // exhausted, so skip it (the embedding backlog rides the next pass) rather than spend a
+        // fresh full budget.
+        if let Some(options) = budget.next_options() {
+            let report = timings
+                .stage("reconcile", || db.reconcile_with_options_progress(options, |_| {}))?;
+            base_reconcile_status = Some(report.status);
+        }
+        // Clone-edge graph (#286/#473): try the cheap IN-PLACE delta first — it settles an
+        // ordinary edit on this very pass (freshness is the point; no quiet window) and reports
+        // whether a FULL rebuild is still owed (accumulated df drift). The full rebuild runs only
+        // when the delta could not settle freshness (absent generation, normalizer bump, cap
+        // crossing, huge delta, error) or a drift refresh is owed — and it stays behind the #472
+        // quiet window (`clone_graph_due`) so sustained editing defers it instead of
+        // treadmilling. Best-effort + resumable, with whatever budget the embedding reconcile
+        // left (shared PASS_RECONCILE_MAX_SECONDS so a pass can't overrun); `None` budget → rides
+        // the next pass.
+        let clone_full_rebuild_owed = match timings.stage("clone_delta", || {
+            db.apply_clone_graph_delta(crate::index::CLONE_DELTA_MAX_FILES)
+        }) {
+            Ok(delta) if delta.status == "Applied" || delta.status == "Noop" =>
+                delta.full_rebuild_owed,
+            _ => true,
+        };
+        if clone_full_rebuild_owed
+            && clone_graph_due
+            && let Some(options) = budget.next_options()
+        {
+            let _ = timings.stage("clone_rebuild", || {
+                db.reconcile_clone_edges_with_budget(options.max_seconds)
+            });
+        }
+        if run_gc {
+            let _ = timings.stage("gc", || db.garbage_collect());
+        }
     }
     let _ = timings.stage("memory_validate", || db.memory_validate());
     if shutdown_reconcile_pending && base_reconcile_status.as_deref() == Some("Current") {
@@ -484,38 +495,41 @@ pub(crate) fn maybe_checkpoint_wal(db: &IndexDatabase, quiet_pass: bool, min_byt
     }
 }
 
-pub(crate) fn should_run_pass_tail(
+/// Whether the base-scope tail runs: reconcile → clone delta / rebuild → gc. Overlay changes are
+/// deliberately absent from this set (#817): the overlay stage reconciles a changed overlay's
+/// embeddings inline, and every base stage keys off `content_revision()` (base files only), so an
+/// overlay-only pass could only pay corpus-scale scans to discover there is nothing to do. An
+/// overlay-only pass still runs `memory_validate` — see `run_pass`.
+pub(crate) fn should_run_base_tail(
     content_changed: bool,
-    overlays_changed: bool,
     run_gc: bool,
     shutdown_reconcile_pending: bool,
     base_embedding_backlog: bool,
     clone_graph_due: bool,
 ) -> bool {
-    content_changed
-        || overlays_changed
-        || run_gc
-        || shutdown_reconcile_pending
+    base_tail_forced_by_state(content_changed, run_gc, shutdown_reconcile_pending)
         || base_embedding_backlog
         || clone_graph_due
 }
 
-pub(crate) fn pass_tail_forced_by_state(
+/// The state that forces the base tail before any probe runs. The backlog probe SKIPS when one of
+/// these holds (the forced tail inspects the backlog anyway, #459), and the clone quiet gate takes
+/// it as probe permission (#472) — see the call sites in `run_pass`.
+pub(crate) fn base_tail_forced_by_state(
     content_changed: bool,
-    overlays_changed: bool,
     run_gc: bool,
     shutdown_reconcile_pending: bool,
 ) -> bool {
-    content_changed || overlays_changed || run_gc || shutdown_reconcile_pending
+    content_changed || run_gc || shutdown_reconcile_pending
 }
 
 pub(crate) fn base_embedding_backlog_needs_tail(
-    tail_already_forced: bool,
+    base_tail_forced: bool,
     retry_base_embedding_backlog: bool,
     budget: &ReconcileBudget,
     pending_embedding_jobs: impl FnOnce(&ReconcileOptions) -> bool,
 ) -> bool {
-    if tail_already_forced || !retry_base_embedding_backlog {
+    if base_tail_forced || !retry_base_embedding_backlog {
         return false;
     }
     budget.next_options().is_some_and(|options| pending_embedding_jobs(&options))

--- a/crates/rag-rat-core/src/watch/tests.rs
+++ b/crates/rag-rat-core/src/watch/tests.rs
@@ -548,32 +548,50 @@ fn recording_watcher_trait_methods_are_covered() {
 #[test]
 fn startup_catchup_does_not_force_the_expensive_tail() {
     assert!(
-        !should_run_pass_tail(false, false, STARTUP_CATCHUP_RUN_GC, false, false, false),
+        !should_run_base_tail(false, STARTUP_CATCHUP_RUN_GC, false, false, false),
         "an unchanged startup catch-up must not run reconcile/gc/memory validation",
     );
     assert!(
-        should_run_pass_tail(true, false, STARTUP_CATCHUP_RUN_GC, false, false, false),
+        should_run_base_tail(true, STARTUP_CATCHUP_RUN_GC, false, false, false),
         "real base content changes still run the maintenance tail",
     );
     assert!(
-        should_run_pass_tail(false, true, STARTUP_CATCHUP_RUN_GC, false, false, false),
-        "linked-worktree overlay changes still run the maintenance tail",
-    );
-    assert!(
-        should_run_pass_tail(false, false, true, false, false, false),
+        should_run_base_tail(false, true, false, false, false),
         "scheduled GC passes still force the maintenance tail",
     );
     assert!(
-        should_run_pass_tail(false, false, STARTUP_CATCHUP_RUN_GC, true, false, false),
+        should_run_base_tail(false, STARTUP_CATCHUP_RUN_GC, true, false, false),
         "a bounded shutdown discover marks base reconcile owed for the next startup pass",
     );
     assert!(
-        should_run_pass_tail(false, false, STARTUP_CATCHUP_RUN_GC, false, true, false),
+        should_run_base_tail(false, STARTUP_CATCHUP_RUN_GC, false, true, false),
         "startup catch-up retries an already-indexed base embedding backlog",
     );
     assert!(
-        should_run_pass_tail(false, false, STARTUP_CATCHUP_RUN_GC, false, false, true),
+        should_run_base_tail(false, STARTUP_CATCHUP_RUN_GC, false, false, true),
         "a quiet-elapsed clone-graph backlog forces the otherwise-idle tail (#472)",
+    );
+}
+
+#[test]
+fn overlay_changes_do_not_force_the_base_tail() {
+    // #817: a changed overlay's embeddings are reconciled inline by the overlay stage, and every
+    // base-tail stage keys off `content_revision()` (base files only) — so overlay churn must not
+    // buy the corpus-scale reconcile/clone scans that are guaranteed no-ops there. The base tail
+    // is forced by base-side state only; `run_pass` still runs memory_validate on overlay-changed
+    // passes (covered by `overlay_only_pass_skips_base_tail_but_still_validates_memories`).
+    assert!(
+        !base_tail_forced_by_state(false, false, false),
+        "no base-side state forces the base tail — overlay changes are not in the force set",
+    );
+    assert!(
+        base_tail_forced_by_state(true, false, false),
+        "a base content change forces the base tail",
+    );
+    assert!(base_tail_forced_by_state(false, true, false), "the gc cadence forces the base tail");
+    assert!(
+        base_tail_forced_by_state(false, false, true),
+        "a shutdown-owed base reconcile forces the base tail",
     );
 }
 
@@ -759,6 +777,109 @@ fn startup_catchup_retries_existing_base_embedding_backlog() {
     );
 
     let _ = std::fs::remove_dir_all(root);
+}
+
+/// #817 end-to-end: a maintenance pass whose only change is a dirty LINKED worktree skips the
+/// base tail (reconcile / clone delta / clone rebuild) but still validates memory anchors.
+/// Two persisted traces pin the split:
+/// - the clone quiet gate stays UNARMED across overlay-only passes (the pass carries no probe
+///   permission, so the pending-forever clone graph is neither probed nor armed — the intended
+///   trade-off: it rides overlay churn until a content, gc, or backlog pass), and a base content
+///   change then arms it on its own pass (#472 arming preserved);
+/// - a memory bound to a path that exists nowhere reaches `anchor_status = "gone"`, which the #492
+///   hysteresis only permits after TWO consecutive `memory_validate` passes — proof that both
+///   overlay-only passes ran the validate stage.
+#[test]
+fn overlay_only_pass_skips_base_tail_but_still_validates_memories() {
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    use rag_rat_query::memory::{RepoMemoryBindTarget, RepoMemoryCreate};
+    static N: AtomicU64 = AtomicU64::new(0);
+    let id = N.fetch_add(1, Ordering::Relaxed);
+    let main =
+        std::env::temp_dir().join(format!("ragrat-watch-overlay-only-{}-{id}", std::process::id()));
+    let linked = std::env::temp_dir()
+        .join(format!("ragrat-watch-overlay-only-linked-{}-{id}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&main);
+    let _ = std::fs::remove_dir_all(&linked);
+    std::fs::create_dir_all(main.join("src")).unwrap();
+    let git = |dir: &Path, args: &[&str]| {
+        let status =
+            std::process::Command::new("git").arg("-C").arg(dir).args(args).status().unwrap();
+        assert!(status.success(), "git {args:?} failed in {}", dir.display());
+    };
+    git(&main, &["init", "-q"]);
+    git(&main, &["config", "user.email", "t@e"]);
+    git(&main, &["config", "user.name", "t"]);
+    std::fs::write(main.join("src/lib.rs"), "pub fn base_target(x: i32) -> i32 { x + 1 }\n")
+        .unwrap();
+    git(&main, &["add", "-A"]);
+    git(&main, &["commit", "-qm", "seed"]);
+    let linked_arg = linked.to_string_lossy().into_owned();
+    git(&main, &["worktree", "add", "-q", "-b", "feature", &linked_arg]);
+
+    let main_root = main.canonicalize().unwrap();
+    let config = whole_root_config(&main_root, &[PathBuf::from("src")]);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let created = db
+        .memory_create(RepoMemoryCreate {
+            kind: "Risk".to_string(),
+            title: "ghost anchor".to_string(),
+            body: "observed gone by each memory_validate pass".to_string(),
+            confidence: "low".to_string(),
+            created_by: None,
+            source: None,
+            tags: Vec::new(),
+            payload_json: None,
+            bind: RepoMemoryBindTarget {
+                path: Some("src/ghost.rs".to_string()),
+                ..Default::default()
+            },
+        })
+        .unwrap();
+    let memory_id = created.memory.memory_id.clone();
+    drop(db);
+
+    // Two overlay-only passes: only the linked worktree is dirtied, base content never changes.
+    std::fs::write(linked.join("src/lib.rs"), "pub fn base_target(x: i32) -> i32 { x + 2 }\n")
+        .unwrap();
+    maintenance_pass(&config, false).unwrap();
+    std::fs::write(linked.join("src/lib.rs"), "pub fn base_target(x: i32) -> i32 { x + 3 }\n")
+        .unwrap();
+    maintenance_pass(&config, false).unwrap();
+    {
+        let db = IndexDatabase::open_config(&config).unwrap();
+        assert!(
+            !db.clone_graph_quiet_candidate_armed(),
+            "overlay-only passes neither probe nor arm the clone quiet gate — the pending clone \
+             graph rides overlay churn until a content, gc, or backlog pass (#817)"
+        );
+        let memory = db.memory_get(&memory_id).unwrap().expect("memory persists");
+        let path_binding =
+            memory.bindings.iter().find(|b| b.binding_kind == "path").expect("path binding");
+        assert_eq!(
+            path_binding.anchor_status, "gone",
+            "memory_validate ran on both overlay-only passes: the #492 hysteresis needs two \
+             consecutive gone observations to persist the downgrade"
+        );
+    }
+
+    // A base content change carries probe permission, so its pass ARMS the quiet window for the
+    // (still absent) clone graph — the #472 arming path is untouched by #817.
+    std::fs::write(main_root.join("src/lib.rs"), "pub fn base_target(x: i32) -> i32 { x + 4 }\n")
+        .unwrap();
+    maintenance_pass(&config, false).unwrap();
+    {
+        let db = IndexDatabase::open_config(&config).unwrap();
+        assert!(
+            db.clone_graph_quiet_candidate_armed(),
+            "a base content change arms the clone quiet gate on its own pass"
+        );
+    }
+
+    git(&main_root, &["worktree", "remove", "-f", &linked_arg]);
+    std::fs::remove_dir_all(&main_root).ok();
+    std::fs::remove_dir_all(&linked).ok();
 }
 
 #[test]


### PR DESCRIPTION
## Problem

An overlay-only maintenance pass (`content_changed=false`, `overlays_changed=true`) ran the full base tail. But a changed overlay's embeddings are already reconciled **inline** during the overlay stage, and `content_revision()` digests base files only — so on such a pass the base reconcile is already Current and `apply_clone_graph_delta` is a guaranteed no-op that still pays two full content-revision scans, two corpus-scale `delta_paths` scans, and a full `COUNT(*)`. Measured on a live watcher: 67 of 107 passes over ~5 h were overlay-only, each spending 66–94 s in `clone_delta` without writing anything.

## Change

- The base-tail force set becomes `content_changed || run_gc || shutdown_reconcile_pending` (`base_tail_forced_by_state`); `base_embedding_backlog` and `clone_graph_due` stay as independent OR-terms (`should_run_base_tail`).
- An overlay-only pass now runs: overlay stage → `memory_validate` → WAL hygiene. It skips the base reconcile, `clone_delta`, `clone_rebuild`, and gc. `memory_validate` is kept because it is cheap next to the base stages and overlay edits can move memory anchors.
- `quiet_pass` (WAL truncation eligibility, #482) is untouched: still `!content_changed && !overlays_changed`.

## The clone quiet-gate probe argument (#472)

`clone_graph_rebuild_due`'s `probe_without_candidate` argument becomes `base_tail_forced || base_embedding_backlog` — probe permission is exactly "the base tail already runs". Rationale: overlay churn never moves `content_revision()`, so an unarmed probe on an overlay-only pass could only re-observe the same base staleness while paying the corpus-scale revision digest every pass. The #472 arming semantics are preserved:

- every base-tail pass (content change, gc, shutdown-owed reconcile, startup backlog) can still ARM an unarmed pending graph;
- an **already-armed** candidate bypasses the permission and probes on every pass, so a quiet-elapsed owed rebuild still forces the tail and lands even during overlay churn.

Intended trade-off (per the issue): an **unarmed** pending clone graph rides pure overlay churn until a content, gc, or backlog pass arms it.

## Verification

- New truth-table tests for the force set (`overlay_changes_do_not_force_the_base_tail`, updated `startup_catchup_does_not_force_the_expensive_tail`).
- New quiet-gate unit test: `clone_graph_quiet_gate_fires_an_armed_candidate_without_probe_permission`.
- New end-to-end watch test `overlay_only_pass_skips_base_tail_but_still_validates_memories` (real git repo + linked worktree): two overlay-only passes leave the quiet gate unarmed while `memory_validate` runs on both (proven via the #492 two-consecutive-gone downgrade), and a subsequent base content change arms the gate on its own pass. The test fails against the previous force set (verified by temporarily restoring it).
- `cargo nextest run -p rag-rat-core`: 1470 passed. Plain `cargo test -p rag-rat-core`: 1470 passed.
- All four CI clippy legs exit 0 (`--workspace --no-default-features`, `--workspace --all-features`, `-p rag-rat-core -p rag-rat --no-default-features --features eval`, `--features eval`), each with `--all-targets --locked -- -D warnings`; `cargo +nightly fmt --check` clean.

Fixes #817