### PR TITLE
perf(reconcile): unordered, lazy-text candidate stream for the count-only paths

### DIFF
--- a/crates/rag-rat-core/src/index/ai/policy.rs
+++ b/crates/rag-rat-core/src/index/ai/policy.rs
@@ -43,6 +43,19 @@ pub(crate) const EMBEDDING_POLICY_VERSION: &str = "c426172dd063e4c0";
 pub(crate) const EMBEDDING_POLICY_VERSION_KEY: &str = "embedding_policy_version";
 pub(crate) const EMBEDDING_POLICY_CAP_KEY: &str = "embedding_policy_cap";
 
+/// The staleness clauses decidable WITHOUT the chunk text: missing (no embedding row → status !=
+/// "Current"), re-hashed, model-/dim-/text-version-shifted. [`needs_embedding`]'s first gate, and
+/// what lets the count path (`estimated_reconcile_jobs`) defer fetching a candidate's text until a
+/// metadata-fresh chunk actually reaches the input-hash clause — the only staleness signal that
+/// reads the text.
+pub(crate) fn is_stale_without_text(chunk: &CurrentChunk, model_version: &str, dim: usize) -> bool {
+    chunk.embedding_status.as_deref() != Some("Current")
+        || chunk.source_text_hash.as_deref() != Some(chunk.text_hash.as_str())
+        || chunk.model_version.as_deref() != Some(model_version)
+        || chunk.embedding_dim != Some(i64::try_from(dim).unwrap_or(i64::MAX))
+        || chunk.embedding_text_version.as_deref() != Some(EMBEDDING_TEXT_VERSION)
+}
+
 pub(crate) fn needs_embedding(
     chunk: &CurrentChunk,
     model_id: &str,
@@ -52,19 +65,14 @@ pub(crate) fn needs_embedding(
 ) -> bool {
     // Evaluate the CHEAP staleness signals first. The only clause that needs the (O(text))
     // embedding input + its hash is the `input_hash` comparison, so defer building them until
-    // every cheaper signal has said "fresh" — a chunk that is missing (no embedding row →
-    // status != "Current"), re-hashed, model-/dim-/text-version-shifted is decided here without
-    // touching the text. This is a pure reordering of an OR chain (`build_embedding_input` is
+    // every cheaper signal has said "fresh" — a chunk that is missing, re-hashed,
+    // model-/dim-/text-version-shifted is decided by `is_stale_without_text` without touching the
+    // text. This is a pure reordering of an OR chain (`build_embedding_input` is
     // side-effect-free), so the boolean is byte-identical; it matters because
     // `estimated_reconcile_jobs` runs this per candidate on the idle watcher/maintenance gate,
     // where a repo full of policy-skipped chunks (all missing, so decided by the first clause)
     // must not pay a build+hash each pass.
-    if chunk.embedding_status.as_deref() != Some("Current")
-        || chunk.source_text_hash.as_deref() != Some(chunk.text_hash.as_str())
-        || chunk.model_version.as_deref() != Some(model_version)
-        || chunk.embedding_dim != Some(i64::try_from(dim).unwrap_or(i64::MAX))
-        || chunk.embedding_text_version.as_deref() != Some(EMBEDDING_TEXT_VERSION)
-    {
+    if is_stale_without_text(chunk, model_version, dim) {
         return true;
     }
     let input = build_embedding_input(chunk, max_embedding_chars);

--- a/crates/rag-rat-core/src/index/ai/reconcile/status.rs
+++ b/crates/rag-rat-core/src/index/ai/reconcile/status.rs
@@ -170,28 +170,44 @@ pub(crate) fn embedding_reconcile_plan(
     let mut failed_retryable = 0_u64;
     let mut failed_waiting = 0_u64;
     let mut blocked = 0_u64;
-    // STREAM the candidates (need-first) and count — never materialize every candidate's
-    // decompressed text at once (#379). Same per-job classification as the old `for job in jobs`
-    // over `embedding_job_candidates(None)`, so the counts are identical; only the peak memory
-    // drops.
-    for_each_embedding_candidate(conn, &model.model_id, model_version, dim, None, false, |job| {
-        let policy = job_policy(&job, max_embedding_chars, stamped_policy);
+    // STREAM the candidates and count — never materialize every candidate's decompressed text at
+    // once (#379); the stream is unordered because these counts are order-independent (#816).
+    // Same per-job classification as the old `for job in jobs` over
+    // `embedding_job_candidates(None)`, so the counts are identical; only the peak memory and the
+    // per-row text work drop.
+    for_each_embedding_candidate(conn, &model.model_id, None, false, |candidate| {
+        // The certified stamped column decides policy without the chunk text (#530); only the
+        // FromText fallback needs it fetched up front (#816).
+        if !stamped_policy {
+            candidate.ensure_text()?;
+        }
+        let policy = job_policy(&candidate.chunk, max_embedding_chars, stamped_policy);
         if !policy.eligible {
             return Ok(());
         }
-        let current_artifact = job.embedding_status.as_deref() == Some("Current")
-            && job.source_text_hash.as_deref() == Some(job.text_hash.as_str())
-            && job.model_version.as_deref() == Some(model_version)
-            && job.embedding_dim == Some(i64::try_from(dim).unwrap_or(i64::MAX))
-            && job.embedding_text_version.as_deref() == Some(EMBEDDING_TEXT_VERSION)
-            && job.input_hash.as_deref().is_some_and(|input_hash| {
-                let input = build_embedding_input(&job, max_embedding_chars);
+        let metadata_current = {
+            let job = &candidate.chunk;
+            job.embedding_status.as_deref() == Some("Current")
+                && job.source_text_hash.as_deref() == Some(job.text_hash.as_str())
+                && job.model_version.as_deref() == Some(model_version)
+                && job.embedding_dim == Some(i64::try_from(dim).unwrap_or(i64::MAX))
+                && job.embedding_text_version.as_deref() == Some(EMBEDDING_TEXT_VERSION)
+        };
+        // Only a metadata-current artifact reaches the input-hash recompute — the one clause
+        // that reads the text, fetched lazily (#816).
+        let current_artifact = metadata_current && {
+            candidate.ensure_text()?;
+            let job = &candidate.chunk;
+            job.input_hash.as_deref().is_some_and(|input_hash| {
+                let input = build_embedding_input(job, max_embedding_chars);
                 input_hash == embedding_input_hash(&model.model_id, model_version, &input.text)
-            });
+            })
+        };
         if current_artifact {
             current += 1;
             return Ok(());
         }
+        let job = &candidate.chunk;
         let reason = job.reason(model_version, dim, now_ms(), max_embedding_chars);
         match reason {
             ReconcileReason::Missing => missing += 1,

--- a/crates/rag-rat-core/src/index/ai/store.rs
+++ b/crates/rag-rat-core/src/index/ai/store.rs
@@ -52,29 +52,101 @@ pub(crate) fn current_chunk_row(
     Ok((chunk, text_row))
 }
 
-/// Stream ordered embedding candidates one at a time (need-first), decompressing each chunk's text
-/// on the fly and handing the owned [`CurrentChunk`] to `f` — WITHOUT collecting the whole set into
-/// a `Vec`. This bounds the resident memory of a full-index pass to one chunk's text at a time.
-/// `embedding_reconcile_plan` counts over it so a plan on a kernel-scale index never materializes
-/// every candidate's decompressed text at once (#379). `limit == None` walks every candidate.
-pub(crate) fn for_each_embedding_candidate(
-    conn: &Connection,
-    model_id: &str,
-    model_version: &str,
-    dim: usize,
-    limit: Option<u32>,
-    changed_first: bool,
-    mut f: impl FnMut(CurrentChunk) -> anyhow::Result<()>,
-) -> anyhow::Result<()> {
-    let changed_order = if changed_first {
-        "chunks.source_revision DESC,"
+/// Metadata-only row mapper for the streamed count path ([`for_each_embedding_candidate`]): the
+/// same identity + embedding-metadata columns as [`current_chunk_row`], but no `chunk_text`
+/// payload — `text` stays empty until [`EmbeddingCandidate::ensure_text`] fetches it. The SELECT
+/// order is: 0-5 identity, 6-13 embedding metadata, 14-15 stamped policy columns.
+fn candidate_metadata_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<CurrentChunk> {
+    Ok(CurrentChunk {
+        id: row.get(0)?,
+        path: row.get(1)?,
+        language: row.get(2)?,
+        file_kind: row.get(3)?,
+        chunk_kind: row.get(4)?,
+        symbol_path: row.get(5)?,
+        text: String::new(),
+        text_hash: row.get(6)?,
+        embedding_status: row.get(7)?,
+        source_text_hash: row.get(8)?,
+        model_version: row.get(9)?,
+        embedding_dim: row.get(10)?,
+        input_hash: row.get(11)?,
+        embedding_text_version: row.get(12)?,
+        next_retry_after_ms: row.get(13)?,
+        embedding_policy: row.get(14)?,
+        embedding_priority: row.get(15)?,
+        reason: ReconcileReason::Forced,
+    })
+}
+
+/// One streamed candidate row: chunk metadata up front, text on demand. The count-only callers
+/// decide most rows from metadata alone (`is_stale_without_text`, the certified stamped policy
+/// column), so the text fetch + decompression runs only for rows that reach a text gate — the
+/// input-hash recompute on a metadata-fresh chunk, or the FromText policy fallback when the
+/// stamped column isn't certified (#816).
+pub(crate) struct EmbeddingCandidate<'run, 'conn, 'dicts> {
+    pub(crate) chunk: CurrentChunk,
+    text_loaded: bool,
+    text_stmt: &'run mut rusqlite::Statement<'conn>,
+    decoder: &'run mut ChunkTextDecoder<'dicts>,
+}
+
+impl EmbeddingCandidate<'_, '_, '_> {
+    /// Fetch + decompress this chunk's text on first call (no-op after); `chunk.text` is empty
+    /// until then. Callers MUST call this before any text-reading classifier — `needs_embedding`
+    /// past its cheap clauses, `job_policy` without a certified stamp, `build_embedding_input`.
+    pub(crate) fn ensure_text(&mut self) -> anyhow::Result<()> {
+        if self.text_loaded {
+            return Ok(());
+        }
+        // The streamed SELECT INNER JOINs `chunk_text`, so every yielded row has exactly one text
+        // row here; the outer statement stays live across the loop, so both reads share one
+        // implicit read transaction and cannot diverge.
+        let text_row = self.text_stmt.query_row(params![self.chunk.id], |row| {
+            Ok(ChunkTextRow { blob: row.get(0)?, raw_len: row.get(1)?, dict_version: row.get(2)? })
+        })?;
+        self.chunk.text = text_row.resolve(self.decoder)?;
+        self.text_loaded = true;
+        Ok(())
+    }
+}
+
+/// The streamed candidate SELECT for [`for_each_embedding_candidate`]. `chunk_text` stays INNER
+/// JOINed so the row set is exactly "live chunks with stored text" (#77 Phase 2 — every live chunk
+/// has one blob; the old `WHERE chunks.text IS NOT NULL` was dropped as vacuous), but its payload
+/// columns are NOT selected: the count-only callers decide most rows from metadata alone, so the
+/// text is point-fetched lazily per row ([`EmbeddingCandidate::ensure_text`]) instead of carried
+/// through the whole stream (#816).
+///
+/// Need-first ORDER BY only when a `limit` truncates the walk: the CASE reads LEFT-JOINed
+/// `chunk_embeddings` columns, which no index can serve, so SQLite external-sorts the ENTIRE
+/// candidate set into a temp b-tree before yielding row 1 — ~210 MB of temp writes in under half
+/// an hour of watcher/reconcile passes on a kernel-scale index (#816). An exhaustive
+/// (`limit == None`) walk feeds order-independent counts, so the sort bought nothing there; a
+/// limited walk keeps it because the order then decides WHICH rows are counted. The real embed
+/// ordering lives in [`embedding_candidate_ids`].
+pub(crate) fn embedding_candidate_stream_sql(limit: Option<u32>, changed_first: bool) -> String {
+    let order_clause = if limit.is_some() {
+        let changed_order = if changed_first {
+            "chunks.source_revision DESC,"
+        } else {
+            "chunks.embedding_priority ASC,"
+        };
+        format!(
+            "ORDER BY
+          CASE
+            WHEN chunk_embeddings.chunk_id IS NULL THEN 0
+            WHEN chunk_embeddings.source_text_hash != chunks.text_hash THEN 1
+            WHEN chunk_embeddings.status = 'Failed' THEN 2
+            ELSE 3
+          END,
+          {changed_order}
+          chunks.id"
+        )
     } else {
-        "chunks.embedding_priority ASC,"
+        String::new()
     };
-    // Chunk text comes from the compressed `chunk_text` store (#77 Phase 2); the `chunks.text`
-    // column is gone, so INNER JOIN `chunk_text` (every live chunk has exactly one blob). The old
-    // `WHERE chunks.text IS NOT NULL` was already dropped as vacuous.
-    let sql = format!(
+    format!(
         "
         SELECT chunks.id,
                files.path,
@@ -90,9 +162,6 @@ pub(crate) fn for_each_embedding_candidate(
                chunk_embeddings.input_hash,
                chunk_embeddings.embedding_text_version,
                chunk_embeddings.next_retry_after_ms,
-               chunk_text.blob,
-               chunk_text.raw_len,
-               chunk_text.dict_version,
                chunks.embedding_policy,
                chunks.embedding_priority
         FROM chunks
@@ -101,42 +170,52 @@ pub(crate) fn for_each_embedding_candidate(
           ON chunk_embeddings.chunk_id = chunks.id
          AND chunk_embeddings.model_id = ?1
         JOIN chunk_text ON chunk_text.chunk_id = chunks.id
-        ORDER BY
-          CASE
-            WHEN chunk_embeddings.chunk_id IS NULL THEN 0
-            WHEN chunk_embeddings.source_text_hash != chunks.text_hash THEN 1
-            WHEN chunk_embeddings.status = 'Failed' THEN 2
-            ELSE 3
-          END,
-          {changed_order}
-          chunks.id
-        LIMIT ?5
+        {order_clause}
+        LIMIT ?2
     "
-    );
-    // One dict decoder for the whole stream (dict versions loaded once, reused per row). Loaded
-    // BEFORE the candidate statement so no second query runs while that statement is mid-iteration.
+    )
+}
+
+/// Stream embedding candidates one at a time WITHOUT collecting the set into a `Vec`, handing each
+/// row to `f` as an [`EmbeddingCandidate`] — metadata up front, text on demand. This bounds the
+/// resident memory of a full-index pass to one row (plus one chunk's text when a row reaches a
+/// text gate), so a count on a kernel-scale index never materializes every candidate's
+/// decompressed text at once (#379, #816). Both callers are count-only
+/// ([`estimated_reconcile_jobs`], `embedding_reconcile_plan`); the stream is unordered unless a
+/// `limit` makes order part of the count's meaning — see [`embedding_candidate_stream_sql`].
+/// `limit == None` walks every candidate.
+pub(crate) fn for_each_embedding_candidate(
+    conn: &Connection,
+    model_id: &str,
+    limit: Option<u32>,
+    changed_first: bool,
+    mut f: impl FnMut(&mut EmbeddingCandidate<'_, '_, '_>) -> anyhow::Result<()>,
+) -> anyhow::Result<()> {
+    // One dict decoder for the whole stream (dict versions loaded once, reused across rows),
+    // loaded before the candidate statement starts iterating.
     let dicts = rag_rat_query::chunk_text_dicts(conn)?;
     let mut decoder = ChunkTextDecoder::new(&dicts);
-    let mut stmt = conn.prepare(&sql)?;
+    // The lazy per-row text fetch ([`EmbeddingCandidate::ensure_text`]): a point lookup by
+    // chunk_id, prepared once. The unordered stream arrives in chunks.id-adjacent order, so the
+    // probes stay near-sequential.
+    let mut text_stmt =
+        conn.prepare("SELECT blob, raw_len, dict_version FROM chunk_text WHERE chunk_id = ?1")?;
+    let mut stmt = conn.prepare(&embedding_candidate_stream_sql(limit, changed_first))?;
     let rows = stmt.query_map(
-        params![
-            model_id,
-            model_version,
-            i64::try_from(dim).unwrap_or(i64::MAX),
-            now_ms(),
-            limit.map(i64::from).unwrap_or(i64::MAX)
-        ],
-        current_chunk_row,
+        params![model_id, limit.map(i64::from).unwrap_or(i64::MAX)],
+        candidate_metadata_row,
     )?;
-    // Decompress per row in the loop body (not inside the rusqlite closure above — decompress's
-    // `anyhow::Result` can't cross it), so only one chunk's text is resident at a time.
     for row in rows {
-        let (mut chunk, text_row) = row?;
-        chunk.text = text_row.resolve(&mut decoder)?;
+        let mut chunk = row?;
         if !model_id.is_empty() {
             chunk.reason = ReconcileReason::Missing;
         }
-        f(chunk)?;
+        f(&mut EmbeddingCandidate {
+            chunk,
+            text_loaded: false,
+            text_stmt: &mut text_stmt,
+            decoder: &mut decoder,
+        })?;
     }
     Ok(())
 }
@@ -283,49 +362,52 @@ pub(crate) fn estimated_reconcile_jobs(
     // (`pending_embedding_jobs`), so materializing the whole index here was a per-pass memory
     // peak. The `force` branch queries with an empty model_id (no embedding rows join, so every
     // chunk is a candidate — matching the old `current_chunks`); otherwise use the active model
-    // so `needs_embedding` sees each chunk's embedding row. Text is still decompressed per row
-    // (`needs_embedding`'s input hash reads it; `policy_for_job` reads it only for the stale
-    // chunks that reach the policy gate after the #522 reorder), but only ONE chunk is resident
-    // at a time now.
-    let (model_id, model_version, dim, changed_first) = if options.force {
-        ("", "", 0, false)
-    } else {
-        (scan.model_id, scan.model_version, scan.dim, options.changed_first)
-    };
+    // so `needs_embedding` sees each chunk's embedding row. Text is fetched lazily (#816): a
+    // metadata-stale chunk is decided without it, and under a certified stamp so is its policy —
+    // only a metadata-fresh chunk's input-hash recompute (or the FromText policy fallback) reads
+    // the text.
+    let (model_id, changed_first) =
+        if options.force { ("", false) } else { (scan.model_id, options.changed_first) };
     let mut count = 0_u64;
-    for_each_embedding_candidate(
-        conn,
-        model_id,
-        model_version,
-        dim,
-        options.limit,
-        changed_first,
-        |candidate| {
-            // Freshness FIRST, policy second (#522). Both operands are pure, so `&&` commutes and
-            // the count is byte-identical to the old policy-first order — but in steady state most
-            // chunks are already `Current`, so `needs_embedding` returns false and short-circuits
-            // BEFORE `policy_for_job`, whose low-signal gate would otherwise re-parse the chunk
-            // with tree-sitter. The parse now runs only for genuinely stale chunks (about to be
-            // embedded anyway) or under `--force` (where `options.force` short-circuits
-            // `needs_embedding`). Policy-skipped chunks (generated/tiny/fixture) are always
-            // missing, so `needs_embedding` decides them on its first (cheap) clause
-            // without building or hashing the text — the idle gate does not pay an
-            // O(text) pass per skipped chunk.
-            let eligible = (options.force
-                || needs_embedding(
-                    &candidate,
+    for_each_embedding_candidate(conn, model_id, options.limit, changed_first, |candidate| {
+        // Freshness FIRST, policy second (#522). Both operands are pure, so `&&` commutes and
+        // the count is byte-identical to the old policy-first order — but in steady state most
+        // chunks are already `Current`, so the freshness gate resolves false and short-circuits
+        // BEFORE `policy_for_job`, whose low-signal gate would otherwise re-parse the chunk
+        // with tree-sitter. The parse now runs only for genuinely stale chunks (about to be
+        // embedded anyway) or under `--force` (where `options.force` short-circuits the
+        // freshness gate). Policy-skipped chunks (generated/tiny/fixture) are always missing,
+        // so `is_stale_without_text` decides them on its first (cheap) clause without fetching,
+        // building, or hashing the text — the idle gate does not pay an O(text) pass per
+        // skipped chunk.
+        let stale = options.force
+            || is_stale_without_text(&candidate.chunk, scan.model_version, scan.dim)
+            || {
+                // Metadata-fresh: only the input-hash recompute is left, the one staleness
+                // clause that reads the text (#816). `needs_embedding` re-runs the cheap
+                // clauses (all false here), so the boolean is byte-identical to the eager path.
+                candidate.ensure_text()?;
+                needs_embedding(
+                    &candidate.chunk,
                     scan.model_id,
                     scan.model_version,
                     scan.dim,
                     scan.max_embedding_chars,
-                ))
-                && job_policy(&candidate, scan.max_embedding_chars, scan.stamped_policy).eligible;
-            if eligible {
-                count = count.saturating_add(1);
-            }
-            Ok(())
-        },
-    )?;
+                )
+            };
+        if !stale {
+            return Ok(());
+        }
+        // The FromText policy fallback re-parses the chunk text; the certified stamped column
+        // does not (#530), so only the fallback pays the fetch.
+        if !scan.stamped_policy {
+            candidate.ensure_text()?;
+        }
+        if job_policy(&candidate.chunk, scan.max_embedding_chars, scan.stamped_policy).eligible {
+            count = count.saturating_add(1);
+        }
+        Ok(())
+    })?;
     Ok(count)
 }
 

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/reconcile_embeddings.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/reconcile_embeddings.rs
@@ -1487,3 +1487,94 @@ fn reconcile_heals_an_op_log_ghost_in_an_idle_repo() {
 
     let _ = fs::remove_dir_all(root);
 }
+
+#[test]
+fn candidate_count_stream_is_unordered_and_sorts_only_under_a_limit() {
+    // #816: the count-only callers (`pending_embedding_jobs`, `reconcile_plan`) walk EVERY
+    // candidate, so the old need-first ORDER BY — whose CASE reads LEFT-JOINed `chunk_embeddings`
+    // columns no index can serve — external-sorted the whole candidate set into a temp b-tree on
+    // every watcher backlog probe and reconcile preflight. An exhaustive walk feeds
+    // order-independent counts; only a LIMITed walk keeps the order, because it then decides
+    // WHICH rows are counted.
+    let (root, config) = markdown_config(
+        "# One\nalpha token with enough surrounding detail for embedding eligibility and useful \
+         semantic context\n",
+    );
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let conn = db.storage.connection();
+    let plan_details = |sql: &str| -> String {
+        let mut stmt = conn.prepare(&format!("EXPLAIN QUERY PLAN {sql}")).unwrap();
+        // The stream's ?1 (model_id) / ?2 (limit) slots survive into the EXPLAIN statement.
+        let details =
+            stmt.query_map(rusqlite::params!["", i64::MAX], |row| row.get::<_, String>(3)).unwrap();
+        details.collect::<Result<Vec<_>, _>>().unwrap().join("\n")
+    };
+
+    let unordered = plan_details(&crate::index::ai::embedding_candidate_stream_sql(None, false));
+    assert!(
+        !unordered.contains("USE TEMP B-TREE FOR ORDER BY"),
+        "the exhaustive count walk must not external-sort the candidate set:\n{unordered}"
+    );
+    let limited = plan_details(&crate::index::ai::embedding_candidate_stream_sql(Some(5), false));
+    assert!(
+        limited.contains("USE TEMP B-TREE FOR ORDER BY"),
+        "a LIMITed walk keeps the need-first order — it decides which rows are counted:\n{limited}"
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn count_paths_fetch_text_only_for_rows_that_reach_a_text_gate() {
+    // #816 twin of the temp-sort test: the streamed count no longer carries `chunk_text.blob`
+    // through every row. Poisoning every blob makes ANY text decompression error, so this test
+    // DISAGREES with the old eager path (which resolved every row's text before classifying)
+    // instead of passing through identical behavior.
+    let (root, mut config) = markdown_config(
+        "# One\nalpha token with enough surrounding detail for embedding eligibility and useful \
+         semantic context\n\n# Two\nbeta token with enough surrounding detail for embedding \
+         eligibility and useful semantic context\n",
+    );
+    config.llm.embedding.backend = HASH_MODEL_ID.parse().unwrap();
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    db.install_model(HASH_MODEL_ID, None).unwrap();
+    let poison_blobs = |db: &IndexDatabase| {
+        db.storage.connection().execute("UPDATE chunk_text SET blob = x'DEADBEEF'", []).unwrap();
+    };
+
+    let pending_before = db.pending_embedding_jobs().unwrap();
+    assert!(pending_before > 0, "fixture starts with un-embedded chunks");
+
+    // Missing chunks are decided by `is_stale_without_text` + the certified stamped policy
+    // column alone, so the watcher backlog probe and the plan both survive a poisoned text store
+    // untouched.
+    poison_blobs(&db);
+    assert_eq!(
+        db.pending_embedding_jobs().unwrap(),
+        pending_before,
+        "the missing-chunk backlog count must not read chunk text"
+    );
+    assert_eq!(
+        db.reconcile_plan().unwrap().embeddings.missing,
+        pending_before,
+        "the plan classifies missing chunks without reading chunk text"
+    );
+    drop(db);
+
+    // Restore real text (rebuild rewrites `chunk_text` from source), embed everything, THEN
+    // poison again: a metadata-fresh chunk still reaches the input-hash recompute — the one
+    // staleness clause that reads the text — so the lazy fetch must fail loudly, not skip the
+    // gate.
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    db.install_model(HASH_MODEL_ID, None).unwrap();
+    let report = db.reconcile(None, None).unwrap();
+    assert!(report.embeddings_written > 0, "the hash model embedded the fixture: {report:?}");
+    assert_eq!(db.pending_embedding_jobs().unwrap(), 0, "fixture is fully current");
+    poison_blobs(&db);
+    assert!(
+        db.pending_embedding_jobs().is_err(),
+        "a metadata-fresh chunk still fetches text for the input-hash clause"
+    );
+
+    let _ = fs::remove_dir_all(root);
+}


### PR DESCRIPTION
## Problem

`for_each_embedding_candidate` serves only two callers, and both are count-only: `estimated_reconcile_jobs` (the watcher backlog probe / reconcile preflight) and `embedding_reconcile_plan`. Yet the stream applied the need-first `ORDER BY CASE WHEN chunk_embeddings.chunk_id IS NULL …` — the CASE reads LEFT-JOINed `chunk_embeddings` columns, which no index can serve, so SQLite external-sorted the **entire** candidate set, `chunk_text.blob` included, into a temp b-tree before yielding row 1. Both count callers run with `limit = None` on every watcher pass; profiling a kernel-scale index showed ~210 MB of temp b-tree writes per 27 minutes in the reconcile stage, all spent producing an order that a count cannot observe.

## Change

- **Sort only when it means something.** The stream is now unordered on exhaustive walks: order cannot change the multiset an exhaustive count sees. Under a `LIMIT` the need-first order stays, because it then decides *which* rows are counted (`estimated_reconcile_jobs` honors `options.limit`). The gate lives in one place, `embedding_candidate_stream_sql(limit, changed_first)`.
- **Stop carrying text through the count.** The stream is metadata-only (`chunk_text` stays INNER JOINed for exact row-set parity, but its payload columns are no longer selected). Each row arrives as an `EmbeddingCandidate`; `ensure_text()` point-fetches and decompresses the text only when a row reaches a text gate:
  - the input-hash recompute on a metadata-fresh chunk (`needs_embedding` past its cheap clauses, and the plan's `current_artifact` check), and
  - the FromText policy fallback when the stamped policy column isn't certified.

  Under a certified stamp, missing and policy-skipped rows — the bulk of an idle-gate walk on a backlogged or skip-heavy index — never touch text at all. `needs_embedding`'s cheap clauses are extracted as `is_stale_without_text` so the streamed path and the classifier share one source of truth; the full `needs_embedding` still runs when text is loaded, so the boolean is byte-identical.
- The real embed ordering (`embedding_candidate_ids`) and the per-batch text loader (`current_chunks_by_ids`) are untouched.

## Verification

EXPLAIN QUERY PLAN + timing against a `VACUUM INTO` copy of a real consolidated index store (largest repo scope: 27,634 chunks, 6.7 MB compressed chunk text, production scope view recreated; warm cache, identical 27,634-row result in all runs):

| query | plan | time |
|---|---|---|
| before (ordered, blob carried) | `USE TEMP B-TREE FOR ORDER BY` | 79 ms |
| after (unordered, metadata-only) | no temp b-tree | 15 ms |
| after, worst case (text point-lookup on **every** row) | no temp b-tree | 26 ms |

The worst-case row is the steady-state bound (every chunk fresh → every row reaches the input-hash gate); real passes sit between the last two rows. The ~210 MB/27 min temp-write stream disappears entirely with the sort.

New regression tests (`schema_bootstrap_tests/reconcile_embeddings.rs`):

- `candidate_count_stream_is_unordered_and_sorts_only_under_a_limit` — EXPLAIN-based: the exhaustive stream plan contains no `USE TEMP B-TREE FOR ORDER BY`; the LIMITed variant still does.
- `count_paths_fetch_text_only_for_rows_that_reach_a_text_gate` — poisons every `chunk_text.blob`: the backlog count and the plan still classify missing chunks (the old eager path failed here, decompressing every row), and a fully-current index errors, pinning that the input-hash gate genuinely still reads text.

Statuses:

- `cargo nextest run -p rag-rat-core` — 1469 passed (default features) and 1467 passed (`--no-default-features`, the CI set)
- `cargo test -p rag-rat-core --no-default-features --locked` — 1467 passed (shared-process coverage runner)
- clippy, all four CI legs at `-D warnings`, exit 0: workspace `--no-default-features`, workspace `--all-features`, `-p rag-rat-core -p rag-rat --features eval` with and without default features
- `cargo +nightly fmt` clean

Fixes #816
