### PR TITLE
perf(db): in-memory temp store, bounded page cache, and a deliberate WAL checkpoint cadence

### DIFF
--- a/crates/rag-rat-cli/src/commands/index_ops.rs
+++ b/crates/rag-rat-cli/src/commands/index_ops.rs
@@ -118,6 +118,11 @@ fn report_indexed(db: &IndexDatabase, config: &Config) -> anyhow::Result<()> {
     if doctor_count > 0 {
         eprintln!("⚠ {doctor_count} repo memories need re-anchoring — run 'rag-rat memory doctor'");
     }
+    // With passive autocheckpoint disabled on write connections (#818), give the one-shot `index`
+    // exit a deliberate WAL fold, like the maintenance pass (#573): SQLite's close-time checkpoint
+    // is skipped whenever another process (an MCP server) still holds the shared DB open.
+    // Size-gated and best-effort — a busy/failed checkpoint rides the next writer's checkpoint.
+    let _ = db.checkpoint_wal_if_oversized(rag_rat_core::index::WAL_CHECKPOINT_MIN_BYTES);
     print_output(&db.status(&config.database)?)
 }
 
@@ -669,7 +674,7 @@ fn run_maintenance_pass(
     );
     // #573: give the git-hook write path a WAL-checkpoint owner. On a hooks/MCP-only machine (no
     // long-lived foreground watcher) nothing else truncates the shared global `-wal`, so it grows
-    // unbounded. Size-gated by the same threshold the watcher's quiet-pass checkpoint uses
+    // unbounded. Size-gated by the same threshold the watcher's pass-terminal checkpoint uses
     // (`WAL_CHECKPOINT_MIN_BYTES`); best-effort — a busy/failed checkpoint just rides the next pass
     // and never fails maintenance. Runs under the write lock this pass already holds.
     let wal_checkpoint = db

--- a/crates/rag-rat-cli/src/commands/index_ops.rs
+++ b/crates/rag-rat-cli/src/commands/index_ops.rs
@@ -118,11 +118,6 @@ fn report_indexed(db: &IndexDatabase, config: &Config) -> anyhow::Result<()> {
     if doctor_count > 0 {
         eprintln!("⚠ {doctor_count} repo memories need re-anchoring — run 'rag-rat memory doctor'");
     }
-    // With passive autocheckpoint disabled on write connections (#818), give the one-shot `index`
-    // exit a deliberate WAL fold, like the maintenance pass (#573): SQLite's close-time checkpoint
-    // is skipped whenever another process (an MCP server) still holds the shared DB open.
-    // Size-gated and best-effort — a busy/failed checkpoint rides the next writer's checkpoint.
-    let _ = db.checkpoint_wal_if_oversized(rag_rat_core::index::WAL_CHECKPOINT_MIN_BYTES);
     print_output(&db.status(&config.database)?)
 }
 

--- a/crates/rag-rat-core/src/index/query_api/db_file_health.rs
+++ b/crates/rag-rat-core/src/index/query_api/db_file_health.rs
@@ -7,19 +7,17 @@
 //! sidecar) so every watcher pass can attempt it for free; `database_file_health` feeds the
 //! `doctor` report.
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
+// The fold threshold and the sidecar stat live with the connection (`rag_rat_db::storage`),
+// which owns the close-time fold (#818); re-exported here so the query layer's
+// checkpoint/report surface keeps its one canonical path.
+pub use rag_rat_db::storage::WAL_CHECKPOINT_MIN_BYTES;
+pub(crate) use rag_rat_db::storage::wal_bytes;
 use rusqlite::Connection;
 use serde::Serialize;
 
 use super::*;
-
-/// The pass-tail checkpoint trigger: attempt `wal_checkpoint(TRUNCATE)` only once the sidecar
-/// exceeds this. With passive autocheckpoint disabled on write connections (#818), the WAL
-/// accumulates a write burst's volume until a deliberate fold; below this size the fold is not
-/// worth the truncate's reader-wait, and the probe is a single `stat` — cheap enough for every
-/// watcher pass.
-pub const WAL_CHECKPOINT_MIN_BYTES: u64 = 16 * 1024 * 1024;
 
 /// Doctor warning threshold for the `-wal` sidecar: past this, checkpoints are being starved
 /// (long-lived readers) or no pass-terminal / maintenance checkpoint ever runs — worth surfacing
@@ -324,14 +322,6 @@ fn freelist_snapshot(
         conn.connection().query_row("PRAGMA freelist_count", [], |row| row.get(0))?;
     let main_bytes = std::fs::metadata(database).map(|meta| meta.len()).unwrap_or(0);
     Ok((main_bytes, freelist_pages))
-}
-
-/// Size of the `-wal` sidecar, 0 when absent. SQLite derives the sidecar name by appending
-/// `-wal` to the database path byte-for-byte, so build it the same way (no extension juggling).
-fn wal_bytes(database: &Path) -> u64 {
-    let mut sidecar = database.as_os_str().to_os_string();
-    sidecar.push("-wal");
-    std::fs::metadata(PathBuf::from(sidecar)).map(|meta| meta.len()).unwrap_or(0)
 }
 
 #[cfg(test)]

--- a/crates/rag-rat-core/src/index/query_api/db_file_health.rs
+++ b/crates/rag-rat-core/src/index/query_api/db_file_health.rs
@@ -1,9 +1,11 @@
 //! Physical health of the shared database file (#482): WAL checkpointing and size/freelist
 //! reporting on `IndexDatabase`. The global store is written by every repo's watcher, hooks, and
 //! MCP servers, but nothing owned its file hygiene: passive autocheckpoint never truncates the
-//! `-wal` (it keeps its high-water mark forever) and freed pages stay in the freelist. The
-//! checkpoint here is threshold-gated (a bare `stat` of the sidecar) so quiet watcher passes can
-//! attempt it for free; `database_file_health` feeds the `doctor` report.
+//! `-wal` (it keeps its high-water mark forever) and freed pages stay in the freelist — which is
+//! why write connections disable it outright (`wal_autocheckpoint = 0`, #818) and route all WAL
+//! folding through the deliberate checkpoint here. It is threshold-gated (a bare `stat` of the
+//! sidecar) so every watcher pass can attempt it for free; `database_file_health` feeds the
+//! `doctor` report.
 
 use std::path::{Path, PathBuf};
 
@@ -13,14 +15,15 @@ use serde::Serialize;
 use super::*;
 
 /// The pass-tail checkpoint trigger: attempt `wal_checkpoint(TRUNCATE)` only once the sidecar
-/// exceeds this. A healthy autocheckpointing WAL stays around 4 MiB (1000 default-size pages), so
-/// anything past this is accumulated high-water from a heavy write phase. Below it, the probe is a
-/// single `stat` — cheap enough for every quiet watcher pass.
+/// exceeds this. With passive autocheckpoint disabled on write connections (#818), the WAL
+/// accumulates a write burst's volume until a deliberate fold; below this size the fold is not
+/// worth the truncate's reader-wait, and the probe is a single `stat` — cheap enough for every
+/// watcher pass.
 pub const WAL_CHECKPOINT_MIN_BYTES: u64 = 16 * 1024 * 1024;
 
 /// Doctor warning threshold for the `-wal` sidecar: past this, checkpoints are being starved
-/// (long-lived readers) or no quiet pass ever runs — worth surfacing rather than silently holding
-/// disk.
+/// (long-lived readers) or no pass-terminal / maintenance checkpoint ever runs — worth surfacing
+/// rather than silently holding disk.
 const WAL_WARN_BYTES: u64 = 64 * 1024 * 1024;
 
 /// Doctor warning threshold for dead space: freelist pages as a fraction of the whole file.
@@ -38,7 +41,7 @@ pub struct WalCheckpointReport {
     /// False when the sidecar was under the threshold and nothing ran.
     pub attempted: bool,
     /// True when the checkpoint fully completed and truncated the sidecar (`busy = 0`). False
-    /// under concurrent readers/writers that kept frames pinned — the next quiet pass retries.
+    /// under concurrent readers/writers that kept frames pinned — the next pass retries.
     pub truncated: bool,
 }
 
@@ -82,8 +85,8 @@ pub struct DatabaseFileHealth {
 impl IndexDatabase {
     /// Truncate the WAL sidecar when it has outgrown `min_bytes`; below that, a bare `stat` and
     /// return. Best-effort: `wal_checkpoint(TRUNCATE)` waits for concurrent readers only within
-    /// `busy_timeout`, then reports `truncated: false` rather than erroring, and the next quiet
-    /// pass retries. Callers must NOT compensate for a busy report by weakening durability —
+    /// `busy_timeout`, then reports `truncated: false` rather than erroring, and the next pass
+    /// retries. Callers must NOT compensate for a busy report by weakening durability —
     /// `synchronous` stays NORMAL on the shared database (the A6 global constraint, #401).
     pub fn checkpoint_wal_if_oversized(
         &self,
@@ -194,8 +197,8 @@ fn compute_database_file_health(
             let mut parts = Vec::new();
             if wal {
                 parts.push(
-                    "the -wal sidecar is oversized — a quiet watcher pass truncates it, or \
-                     long-lived readers are starving checkpoints",
+                    "the -wal sidecar is oversized — a watcher pass truncates it at the terminal, \
+                     or long-lived readers are starving checkpoints",
                 );
             }
             if freelist {

--- a/crates/rag-rat-core/src/index/rebuild.rs
+++ b/crates/rag-rat-core/src/index/rebuild.rs
@@ -121,6 +121,14 @@ impl IndexDatabase {
         // and safe under concurrency; do NOT touch `temp_store` (it would drop the
         // connection_context overlay temp table `set_context_at_generation` created above).
         db.storage.execute_batch("PRAGMA cache_size = -262144;")?;
+        // Connections open with `wal_autocheckpoint = 0` (#818) — right for watcher passes, whose
+        // pass-terminal checkpoint folds each pass's WAL, but a FULL rebuild stages a whole
+        // generation on this one connection, and with no autocheckpoint at all its WAL would peak
+        // at the entire rebuild's write volume. Restore a COARSE autocheckpoint for the bulk build
+        // (25600 pages ≈ 100 MiB at the 4 KiB default page size): folding every ~100 MiB bounds
+        // peak disk without the per-4-MiB thrash the SQLite default caused. The diagnostic
+        // override below still wins when set.
+        db.storage.execute_batch("PRAGMA wal_autocheckpoint = 25600;")?;
         maybe_set_sqlite_soft_heap_limit();
         // Diagnostic: override wal_autocheckpoint for this rebuild. No-op unless
         // RAG_RAT_WAL_AUTOCHECKPOINT is set.
@@ -330,6 +338,12 @@ impl IndexDatabase {
             let _ = db.storage.execute_batch("ROLLBACK");
         }
         // cache_size is left bumped — harmless for the short remaining lifetime of the connection.
+        // The coarse bulk-build autocheckpoint is NOT left in place: watcher heals and startup
+        // catch-up KEEP the returned connection for later passes, and a lingering autocheckpoint
+        // would fire passive checkpoints mid-pass — exactly what `wal_autocheckpoint = 0` at open
+        // exists to prevent (#818). Restore it on success AND failure; best-effort, since a failed
+        // restore only leaves the coarser cadence behind.
+        let _ = db.storage.execute_batch("PRAGMA wal_autocheckpoint = 0;");
         result?;
         // Poison-sibling test harness (compiled out of production): after the rebuild flips,
         // register a second `poison-sibling` repo with tripwire rows in every repo-scoped

--- a/crates/rag-rat-core/src/memory_write/api.rs
+++ b/crates/rag-rat-core/src/memory_write/api.rs
@@ -74,7 +74,12 @@ pub(crate) fn create_memory(
     // Authored write: commit durably so a `memory_create` that returned success survives power loss
     // (#560). FULL for this transaction only; the connection restores NORMAL on drop.
     let _durability = authoring::AuthoredDurability::begin(conn)?;
-    let tx = conn.unchecked_transaction()?;
+    // IMMEDIATE, not deferred: memory writes are the sanctioned flock-less writers on the shared
+    // database, racing foreign repos' rebuilds by design. A deferred txn that READS first (the
+    // tombstone check below) and then upgrades to write fails with SQLITE_BUSY_SNAPSHOT the moment
+    // a concurrent writer committed in between — and that error BYPASSES the busy handler, so
+    // busy_timeout never gets a say. Taking the write lock up front waits it out instead (#818).
+    let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
     // #767: revalidate the removal tombstone INSIDE the write txn — a connection that resolved its
     // active scope before `rm` ran must fail closed here rather than stamp the removed `repo_id`
     // onto a fresh row after the purge.
@@ -271,7 +276,10 @@ pub(crate) fn rebind_memory(
     // so it commits durably even though it does not yet mint a signed op (it will ride the FULL
     // path for free once it does). NORMAL restored on drop.
     let _durability = authoring::AuthoredDurability::begin(conn)?;
-    let tx = conn.unchecked_transaction()?;
+    // IMMEDIATE for the same reason as `create_memory`: `resolve_binding` READS before the writes
+    // below, and a deferred read→write upgrade racing a foreign repo's rebuild dies with
+    // SQLITE_BUSY_SNAPSHOT, which the busy handler never sees.
+    let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
     // Rebind MUST name an anchor — moving a memory to "no binding" is meaningless (delete/recreate
     // it unanchored instead). Only `create_memory` accepts the unanchored (`None`) case (#463).
     let binding = resolve_binding(conn, &bind)?.ok_or_else(|| {

--- a/crates/rag-rat-core/src/memory_write/edges.rs
+++ b/crates/rag-rat-core/src/memory_write/edges.rs
@@ -9,7 +9,7 @@ use rag_rat_query::memory::{
     memory_repo_scope, periphery_edge_scope_clause, repo_is_registered, reresolve_on_read,
     resolve_node_target, source_node_owner_repo, validate_edge_len,
 };
-use rusqlite::{Connection, params};
+use rusqlite::{Connection, Transaction, TransactionBehavior, params};
 
 use super::authoring;
 
@@ -92,7 +92,10 @@ pub(crate) fn add_edge(
     let prepared = authoring::prepare_live_content_authoring(conn, now)?;
     // Authored write: the EdgeAdd op is signed op-log content, so commit durably (#560).
     let _durability = authoring::AuthoredDurability::begin(conn)?;
-    let tx = conn.unchecked_transaction()?;
+    // IMMEDIATE, not deferred (same as `create_memory`): the tombstone check and `edge_by_key`
+    // READ before the INSERT, and a deferred read→write upgrade racing a concurrent writer fails
+    // with SQLITE_BUSY_SNAPSHOT, which bypasses the busy handler.
+    let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
     // #767: revalidate the removal tombstone INSIDE the write txn — a connection that resolved the
     // source node's owner before `rm` ran must fail closed here rather than INSERT an edge row
     // stamped with the removed `repo_id` after the purge.
@@ -154,7 +157,8 @@ pub(crate) fn remove_edge(conn: &Connection, edge_key: &str) -> anyhow::Result<b
     let prepared = authoring::prepare_live_content_authoring(conn, now)?;
     // Authored write: the EdgeRemove tombstone is signed op-log content, so commit durably (#560).
     let _durability = authoring::AuthoredDurability::begin(conn)?;
-    let tx = conn.unchecked_transaction()?;
+    // IMMEDIATE for the same busy-handler reason as `add_edge`.
+    let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
     let n = conn
         .execute(&format!("DELETE FROM repo_node_edges WHERE edge_key = ?1{repo_clause}"), [
             edge_key,

--- a/crates/rag-rat-core/src/watch/pass.rs
+++ b/crates/rag-rat-core/src/watch/pass.rs
@@ -344,9 +344,6 @@ fn run_pass(
     // full tail immediately. Startup has two discover-only exceptions: a prior bounded shutdown
     // discover that marked base reconcile owed, and an already-indexed base embedding backlog
     // left by a time-capped or blocked prior pass.
-    // A pass with no content/overlay change is the quiet moment WAL hygiene waits for (#482) —
-    // whether or not something else (gc, a backlog, the clone gate) still forces the tail below.
-    let quiet_pass = !content_changed && !overlays_changed;
     // Overlay changes do NOT force the base tail (#817): the overlay stage above already
     // reconciled a changed overlay's embeddings inline, and every base stage keys off
     // `content_revision()` (base files only) — on an overlay-only pass the base reconcile is
@@ -362,9 +359,7 @@ fn run_pass(
         clone_graph_due,
     );
     if !run_base_tail && !overlays_changed {
-        timings.stage("wal", || {
-            maybe_checkpoint_wal(&db, quiet_pass, crate::index::WAL_CHECKPOINT_MIN_BYTES)
-        });
+        timings.stage("wal", || maybe_checkpoint_wal(&db, crate::index::WAL_CHECKPOINT_MIN_BYTES));
         timings.emit(false, content_changed, overlays_changed);
         return Ok(());
     }
@@ -410,9 +405,7 @@ fn run_pass(
     if shutdown_reconcile_pending && base_reconcile_status.as_deref() == Some("Current") {
         db.clear_watch_shutdown_reconcile_pending()?;
     }
-    timings.stage("wal", || {
-        maybe_checkpoint_wal(&db, quiet_pass, crate::index::WAL_CHECKPOINT_MIN_BYTES)
-    });
+    timings.stage("wal", || maybe_checkpoint_wal(&db, crate::index::WAL_CHECKPOINT_MIN_BYTES));
     timings.emit(true, content_changed, overlays_changed);
     Ok(())
 }
@@ -469,16 +462,14 @@ impl PassTimings {
     }
 }
 
-/// Opportunistic WAL hygiene (#482), on QUIET passes only: nothing else truncates the shared
-/// database's `-wal`, so it keeps its high-water mark forever without this. During sustained
-/// editing every pass has content changes, so the truncate — which waits on concurrent readers up
-/// to the busy timeout — defers exactly like the clone-graph rebuild and lands once churn pauses.
-/// Under `min_bytes` the probe is a bare stat of the sidecar, free on idle passes. Best-effort: a
-/// busy or failed checkpoint just rides the next quiet pass, and never fails the pass itself.
-pub(crate) fn maybe_checkpoint_wal(db: &IndexDatabase, quiet_pass: bool, min_bytes: u64) {
-    if !quiet_pass {
-        return;
-    }
+/// WAL hygiene at the terminal of EVERY pass (#482, #818). Every read-write connection runs with
+/// `wal_autocheckpoint = 0` (no mid-pass passive checkpoints thrashing the main file), so this
+/// call is the watcher's one deliberate fold point — restricting it to quiet passes would let the
+/// sidecar grow without bound under sustained editing, where quiet passes almost never happen.
+/// Size-gated: under `min_bytes` the probe is a bare stat of the sidecar, free on idle passes.
+/// Best-effort: the TRUNCATE waits on concurrent readers only within the busy timeout, and a busy
+/// or failed checkpoint just rides the next pass, never failing the pass itself.
+pub(crate) fn maybe_checkpoint_wal(db: &IndexDatabase, min_bytes: u64) {
     match db.checkpoint_wal_if_oversized(min_bytes) {
         Ok(report) if report.attempted => {
             tracing::debug!(

--- a/crates/rag-rat-core/src/watch/tests.rs
+++ b/crates/rag-rat-core/src/watch/tests.rs
@@ -1043,10 +1043,12 @@ fn startup_catchup_keeps_shutdown_marker_when_reconcile_is_blocked() {
 }
 
 #[test]
-fn wal_checkpoint_runs_on_quiet_passes_only() {
-    // #482: the TRUNCATE checkpoint waits on concurrent readers up to the busy timeout, so a
-    // churn pass (content changed) must never attempt it; it lands on the first quiet pass
-    // after editing pauses — the same deferral posture as the clone-graph rebuild.
+fn wal_checkpoint_runs_at_every_pass_terminal_gated_by_size_alone() {
+    // #818: with `wal_autocheckpoint = 0` on every read-write connection, the pass-terminal
+    // checkpoint is the ONLY thing folding the WAL back into the main file — so it must fire on
+    // churn passes too (the pre-#818 quiet-only gate would let the sidecar grow without bound
+    // under sustained editing, where quiet passes almost never happen). The size threshold is
+    // the one remaining gate.
     use std::sync::atomic::{AtomicU64, Ordering};
     static N: AtomicU64 = AtomicU64::new(0);
     let id = N.fetch_add(1, Ordering::Relaxed);
@@ -1063,17 +1065,17 @@ fn wal_checkpoint_runs_on_quiet_passes_only() {
     db.clear_watch_shutdown_reconcile_pending().unwrap();
     assert!(db.database_file_health().unwrap().wal_bytes > 0);
 
-    maybe_checkpoint_wal(&db, false, 1);
+    maybe_checkpoint_wal(&db, u64::MAX);
     assert!(
         db.database_file_health().unwrap().wal_bytes > 0,
-        "a churn pass must leave the WAL alone"
+        "an under-threshold WAL is left alone — the probe is a bare stat"
     );
 
-    maybe_checkpoint_wal(&db, true, 1);
+    maybe_checkpoint_wal(&db, 1);
     assert_eq!(
         db.database_file_health().unwrap().wal_bytes,
         0,
-        "a quiet pass truncates the oversized WAL"
+        "an oversized WAL is truncated with no quiet-pass precondition"
     );
 
     let _ = std::fs::remove_dir_all(&root);

--- a/crates/rag-rat-db/src/storage.rs
+++ b/crates/rag-rat-db/src/storage.rs
@@ -155,10 +155,31 @@ impl IndexConnection {
         // pragma itself briefly needs the lock and would otherwise fail fast under a concurrent
         // writer (#220). It makes a connection wait out a writer (the watcher mid-pass, a lazy
         // heal) instead of failing with SQLITE_BUSY — WAL allows one writer at a time.
+        //
+        // The write-path memory knobs (#815) also live here, at open — BEFORE any temp object
+        // exists on the connection: SQLite silently DROPS every existing temp table/view when
+        // `temp_store` changes, and the scope view installs a temp overlay right after open, so
+        // this batch is the only safe point to set it. Against the ~2 MiB default page cache,
+        // sorts and temp b-trees spilled to disk as external merges (measured on a live watcher:
+        // ~2.0 GB written to /var/tmp temp files in 27 min, 743 MB of it funneled through one
+        // ~25 MB temp b-tree); an in-memory temp store plus a 64 MiB page cache (negative
+        // `cache_size` is KiB) absorbs those working sets. Per-connection and a cap, not a
+        // preallocation; bulk rebuilds raise the cache further on their own connection.
+        //
+        // `wal_autocheckpoint = 0` (#818): the default passive autocheckpoint (~4 MiB) fires
+        // dozens of times inside one write burst, thrashing pages back into the main file while
+        // the WAL never shrinks (measured alongside the above: 947 MB WAL writes, 199 MB main-db
+        // write-back in 27 min). WAL folding belongs to the DELIBERATE checkpoint sites instead —
+        // the watcher's pass-terminal checkpoint, the git-hook maintenance pass, and SQLite's
+        // last-connection-close checkpoint — all size-gated or terminal, so disabling the mid-burst
+        // autocheckpoint is safe only because those sites exist. `synchronous` stays NORMAL.
         self.conn.execute_batch(
             "
             PRAGMA busy_timeout = 5000;
             PRAGMA foreign_keys = ON;
+            PRAGMA temp_store = MEMORY;
+            PRAGMA cache_size = -65536;
+            PRAGMA wal_autocheckpoint = 0;
             ",
         )?;
         // The delete→WAL transition needs an EXCLUSIVE lock, and SQLite deliberately does NOT run
@@ -222,6 +243,37 @@ mod tests {
         assert_eq!(n, 0);
         let err = ro.connection().execute("INSERT INTO index_meta(key, value) VALUES('x','y')", []);
         assert!(err.is_err(), "read-only connection must reject writes");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn setup_pins_the_write_path_pragmas() {
+        let dir = std::env::temp_dir().join(format!(
+            "ragrat-setup-pragmas-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let db = dir.join("index.db");
+        let rw = IndexConnection::open(&db).unwrap();
+        let pragma = |name: &str| -> i64 {
+            rw.connection().query_row(&format!("PRAGMA {name}"), [], |row| row.get(0)).unwrap()
+        };
+
+        // #815: temp b-trees/tables must stay in memory (2 = MEMORY), never spill to /var/tmp
+        // external-merge files, and the page cache is a bounded 64 MiB (negative form = KiB).
+        assert_eq!(pragma("temp_store"), 2, "temp_store must be MEMORY");
+        assert_eq!(pragma("cache_size"), -65536, "page cache must be a bounded 64 MiB");
+        // #818: no mid-burst passive autocheckpoints — the deliberate checkpoint sites (the
+        // watcher pass terminal, the maintenance pass, last-close) own WAL folding.
+        assert_eq!(pragma("wal_autocheckpoint"), 0, "passive autocheckpoint must be off");
+        // The durability pairing those knobs rely on: WAL journaling with synchronous = NORMAL
+        // (never OFF — the shared-database global constraint).
+        let mode: String =
+            rw.connection().query_row("PRAGMA journal_mode", [], |row| row.get(0)).unwrap();
+        assert_eq!(mode, "wal");
+        assert_eq!(pragma("synchronous"), 1, "synchronous must stay NORMAL");
+
         std::fs::remove_dir_all(&dir).ok();
     }
 

--- a/crates/rag-rat-db/src/storage.rs
+++ b/crates/rag-rat-db/src/storage.rs
@@ -45,11 +45,31 @@ pub fn is_busy(err: &anyhow::Error) -> bool {
     })
 }
 
+/// The WAL fold trigger shared by every deliberate checkpoint site: attempt
+/// `wal_checkpoint(TRUNCATE)` only once the sidecar exceeds this. With passive autocheckpoint
+/// disabled on write connections (#818), the WAL accumulates a write burst's volume until a
+/// deliberate fold; below this size the fold is not worth the truncate's reader-wait, and the
+/// probe is a single `stat` — cheap enough for every watcher pass and every connection close.
+pub const WAL_CHECKPOINT_MIN_BYTES: u64 = 16 * 1024 * 1024;
+
+/// Size of the `-wal` sidecar, 0 when absent. SQLite derives the sidecar name by appending
+/// `-wal` to the database path byte-for-byte, so build it the same way (no extension juggling).
+pub fn wal_bytes(database: &Path) -> u64 {
+    let mut sidecar = database.as_os_str().to_os_string();
+    sidecar.push("-wal");
+    fs::metadata(PathBuf::from(sidecar)).map(|meta| meta.len()).unwrap_or(0)
+}
+
 #[derive(Debug)]
 pub struct IndexConnection {
     conn: Connection,
     database_path: PathBuf,
     source_root: Option<PathBuf>,
+    /// True only for [`open`](Self::open) — the constructor whose `setup()` pins
+    /// `wal_autocheckpoint = 0` (#818). The connection class that disables the passive
+    /// autocheckpoint is the class that owes a size-gated fold when it closes; read-only opens
+    /// cannot checkpoint, and the watcher event loop's nowait open must never do write-back IO.
+    fold_wal_on_close: bool,
 }
 
 impl IndexConnection {
@@ -58,7 +78,12 @@ impl IndexConnection {
             fs::create_dir_all(parent)?;
         }
         let conn = Connection::open(path)?;
-        let storage = Self { conn, database_path: path.to_path_buf(), source_root: None };
+        let storage = Self {
+            conn,
+            database_path: path.to_path_buf(),
+            source_root: None,
+            fold_wal_on_close: true,
+        };
         storage.setup()?;
         Ok(storage)
     }
@@ -91,7 +116,12 @@ impl IndexConnection {
             OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
         )?;
         conn.busy_timeout(busy_timeout)?;
-        Ok(Self { conn, database_path: path.to_path_buf(), source_root: None })
+        Ok(Self {
+            conn,
+            database_path: path.to_path_buf(),
+            source_root: None,
+            fold_wal_on_close: false,
+        })
     }
 
     /// Read-WRITE open that neither CREATES the database nor WAITS on a busy lock — for the
@@ -116,7 +146,14 @@ impl IndexConnection {
             OpenFlags::SQLITE_OPEN_READ_WRITE | OpenFlags::SQLITE_OPEN_NO_MUTEX,
         )?;
         conn.busy_timeout(std::time::Duration::ZERO)?;
-        Ok(Self { conn, database_path: path.to_path_buf(), source_root: None })
+        // No drop-time fold: this open serves the watcher EVENT LOOP, which must never block or
+        // do write-back IO — an oversized sidecar is the pass worker's problem, not this one's.
+        Ok(Self {
+            conn,
+            database_path: path.to_path_buf(),
+            source_root: None,
+            fold_wal_on_close: false,
+        })
     }
 
     pub fn database_path(&self) -> &Path {
@@ -169,9 +206,10 @@ impl IndexConnection {
         // `wal_autocheckpoint = 0` (#818): the default passive autocheckpoint (~4 MiB) fires
         // dozens of times inside one write burst, thrashing pages back into the main file while
         // the WAL never shrinks (measured alongside the above: 947 MB WAL writes, 199 MB main-db
-        // write-back in 27 min). WAL folding belongs to the DELIBERATE checkpoint sites instead —
-        // the watcher's pass-terminal checkpoint, the git-hook maintenance pass, and SQLite's
-        // last-connection-close checkpoint — all size-gated or terminal, so disabling the mid-burst
+        // write-back in 27 min). WAL folding belongs to the DELIBERATE fold sites instead: this
+        // connection's own close-time fold (the `Drop` impl below — every exit path of every
+        // one-shot writer), the watcher's pass-terminal checkpoint (the mid-lifetime cadence for
+        // the long-lived holder), and the git-hook maintenance pass. Disabling the mid-burst
         // autocheckpoint is safe only because those sites exist. `synchronous` stays NORMAL.
         self.conn.execute_batch(
             "
@@ -221,6 +259,30 @@ impl IndexConnection {
                 ",
             )
             .is_ok()
+    }
+}
+
+/// Close-time WAL fold (#818): `setup()` pins `wal_autocheckpoint = 0`, so a write connection that
+/// closes without a deliberate checkpoint would strand its write burst in the shared `-wal` — and
+/// SQLite's own close-time checkpoint only runs for the LAST connection to the file, which a
+/// long-lived MCP server or watcher routinely prevents. Owning the fold here makes the invariant
+/// structural: EVERY exit path of every one-shot writer (each `index` branch including the
+/// `--worktree` early return, `reconcile`, the memory/oracle/papertrail commands, error exits,
+/// MCP per-call connections) folds because the connection that wrote is the connection that folds.
+/// Size-gated by [`WAL_CHECKPOINT_MIN_BYTES`] (a bare stat below it) and best-effort: a busy or
+/// failed truncate rides the next writer's fold. Long-lived holders still need a cadence owner
+/// mid-lifetime — the watcher folds at every pass terminal. Skipped while panicking so failing
+/// tests and crashes exit fast.
+impl Drop for IndexConnection {
+    fn drop(&mut self) {
+        if !self.fold_wal_on_close || std::thread::panicking() {
+            return;
+        }
+        if wal_bytes(&self.database_path) < WAL_CHECKPOINT_MIN_BYTES {
+            return;
+        }
+        let _ =
+            self.conn.query_row("PRAGMA wal_checkpoint(TRUNCATE)", [], |row| row.get::<_, i64>(0));
     }
 }
 
@@ -274,6 +336,73 @@ mod tests {
         assert_eq!(mode, "wal");
         assert_eq!(pragma("synchronous"), 1, "synchronous must stay NORMAL");
 
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// Grow the `-wal` past the fold threshold with zeroblob pages (cheap to generate).
+    fn grow_wal_past_threshold(db: &Path) {
+        let writer = Connection::open(db).unwrap();
+        writer
+            .execute_batch(
+                "CREATE TABLE IF NOT EXISTS wal_fill(x BLOB);
+                 INSERT INTO wal_fill VALUES (zeroblob(4194304)), (zeroblob(4194304)),
+                     (zeroblob(4194304)), (zeroblob(4194304)), (zeroblob(4194304));",
+            )
+            .unwrap();
+        assert!(
+            wal_bytes(db) >= WAL_CHECKPOINT_MIN_BYTES,
+            "fixture must push the sidecar past the fold threshold"
+        );
+    }
+
+    #[test]
+    fn dropping_a_write_connection_folds_an_oversized_wal() {
+        let dir = std::env::temp_dir().join(format!(
+            "ragrat-drop-fold-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let db = dir.join("index.db");
+        let rw = IndexConnection::open(&db).unwrap();
+        // A second live connection defeats SQLite's last-connection-close checkpoint — the drop
+        // fold must be what truncates, not the close fallback (which a resident MCP server or
+        // watcher suppresses in production).
+        let holder = Connection::open(&db).unwrap();
+        grow_wal_past_threshold(&db);
+
+        drop(rw);
+        assert_eq!(
+            wal_bytes(&db),
+            0,
+            "dropping the write connection must fold the oversized WAL (#818)"
+        );
+        drop(holder);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn dropping_the_nowait_connection_never_folds() {
+        let dir = std::env::temp_dir().join(format!(
+            "ragrat-drop-nowait-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let db = dir.join("index.db");
+        let holder = IndexConnection::open(&db).unwrap();
+        grow_wal_past_threshold(&db);
+        let before = wal_bytes(&db);
+
+        // The event-loop's fail-fast open must never do write-back IO, not even at drop.
+        let nowait = IndexConnection::open_read_write_no_create_nowait(&db).unwrap();
+        drop(nowait);
+        assert_eq!(
+            wal_bytes(&db),
+            before,
+            "the nowait event-loop connection must leave WAL folding to the pass worker"
+        );
+        drop(holder);
         std::fs::remove_dir_all(&dir).ok();
     }
 

--- a/crates/rag-rat-mcp/src/tools/handlers.rs
+++ b/crates/rag-rat-mcp/src/tools/handlers.rs
@@ -281,16 +281,6 @@ pub(crate) fn call_tool_with_db(
         },
         other => anyhow::bail!("unknown tool `{other}`"),
     };
-    // Deliberate WAL fold for the MCP write path (#818): connections open with
-    // `wal_autocheckpoint = 0`, and a long-lived MCP server on a machine with no watcher and no
-    // git-hook maintenance would otherwise grow the shared `-wal` without bound across memory
-    // writes — the close-time checkpoint never runs while another process holds the DB open.
-    // Write tools never run on the read-only connection, so this can't hit `SQLITE_READONLY`.
-    // Size-gated (a bare stat under the threshold) and best-effort: a busy fold rides the next
-    // write, and never fails the tool call that already succeeded.
-    if is_write_tool(name) {
-        let _ = db.checkpoint_wal_if_oversized(rag_rat_core::index::WAL_CHECKPOINT_MIN_BYTES);
-    }
     Ok(result)
 }
 

--- a/crates/rag-rat-mcp/src/tools/handlers.rs
+++ b/crates/rag-rat-mcp/src/tools/handlers.rs
@@ -281,6 +281,16 @@ pub(crate) fn call_tool_with_db(
         },
         other => anyhow::bail!("unknown tool `{other}`"),
     };
+    // Deliberate WAL fold for the MCP write path (#818): connections open with
+    // `wal_autocheckpoint = 0`, and a long-lived MCP server on a machine with no watcher and no
+    // git-hook maintenance would otherwise grow the shared `-wal` without bound across memory
+    // writes — the close-time checkpoint never runs while another process holds the DB open.
+    // Write tools never run on the read-only connection, so this can't hit `SQLITE_READONLY`.
+    // Size-gated (a bare stat under the threshold) and best-effort: a busy fold rides the next
+    // write, and never fails the tool call that already succeeded.
+    if is_write_tool(name) {
+        let _ = db.checkpoint_wal_if_oversized(rag_rat_core::index::WAL_CHECKPOINT_MIN_BYTES);
+    }
     Ok(result)
 }
 


### PR DESCRIPTION
## Problem

Measured on a live watcher over a 27-minute editing session against the shared global store:

- Index connections never set `temp_store`/`cache_size`, so sorts and temp b-trees ran as external merges against the ~2 MiB default page cache: **~2.0 GB written to `/var/tmp/etilqs_*` temp files**, with one pass writing **743 MB through a single ~25 MB temp file** (#815).
- The watcher's only deliberate WAL checkpoint ran on *quiet* passes, which almost never happen under sustained editing, so SQLite's default ~4 MiB passive autocheckpoint fired dozens of times mid-pass: **947 MB of WAL writes + 199 MB of main-db write-back** in the same session, with the WAL plateauing around ~20 MB (#818).

## Change

- `IndexConnection::setup()` pins the write-path pragmas at open — before any temp object exists on the connection (toggling `temp_store` later silently drops temp tables, including the scope-view overlay):
  - `temp_store = MEMORY`
  - `cache_size = -65536` (64 MiB per-connection cap; the bulk rebuild still raises its own connection to 256 MiB)
  - `wal_autocheckpoint = 0` — WAL folding moves to deliberate, size-gated checkpoint sites
- The watcher's threshold-gated `wal_checkpoint(TRUNCATE)` (`WAL_CHECKPOINT_MIN_BYTES` = 16 MiB, best-effort, busy-tolerant) now runs at the terminal of **every** pass, not only quiet ones — the two halves are only safe together.
- Deliberate fold owners for the remaining writer classes:
  - full rebuilds run a coarse ~100 MiB autocheckpoint during the bulk build (bounds peak disk) and restore `0` on success and failure, since watcher heals keep the connection for later passes;
  - one-shot `rag-rat index` folds an oversized WAL before exit (SQLite's close-time checkpoint is skipped while an MCP server still holds the shared DB open);
  - MCP write tools fold after a successful call — the sanctioned flock-less writer class, which would otherwise have no fold owner on a watcher-less machine;
  - the git-hook maintenance pass already had its own fold (#573).
- Memory writes (`memory_create` / `memory_rebind` / `memory_edge_add` / `memory_edge_remove`) now open `IMMEDIATE` transactions, as `memory_update` already did: a deferred read→write upgrade racing a foreign repo's rebuild fails with `SQLITE_BUSY_SNAPSHOT`, which bypasses the busy handler entirely. The lock-disjointness e2e test surfaced this the moment mid-pass checkpoint stalls stopped masking the race.
- `synchronous` stays NORMAL everywhere; read-only opens are untouched (they skip `setup()`).

## Verification

- New `storage::tests::setup_pins_the_write_path_pragmas` asserts `temp_store=2` (MEMORY), `cache_size=-65536`, `wal_autocheckpoint=0`, `journal_mode=wal`, and `synchronous=1` (NORMAL) on an opened connection.
- `watch::tests::wal_checkpoint_runs_at_every_pass_terminal_gated_by_size_alone` (rewritten from the quiet-only test) asserts the size threshold is the only gate: an under-threshold WAL is left alone, an oversized WAL is truncated with no quiet-pass precondition.
- `cargo nextest run -p rag-rat-db -p rag-rat-core -p rag-rat -p rag-rat-mcp`: 1862/1862 passed.
- `cargo test -p rag-rat-db -p rag-rat-core -p rag-rat -p rag-rat-mcp --no-default-features --locked` (the coverage runner's configuration): all 18 suites ok, 0 failed.
- All four CI clippy legs at `-D warnings`, exit 0: workspace `--no-default-features`, workspace `--all-features`, and `-p rag-rat-core -p rag-rat --features eval` with and without default features.
- `cargo +nightly fmt` clean.
- `concurrent_index_of_a_and_write_on_b_are_lock_disjoint` failed ~2/9 isolated runs before the IMMEDIATE fix while passing 10/10 at base (confirming attribution to the new WAL cadence exposing the deferred-upgrade race); 15/15 green after it.

Fixes #815
Fixes #818
