### PR TITLE
feat(oplog): canonical account projection and folded_state_hash (#609)

### DIFF
--- a/crates/rag-rat-oplog/src/account/fold.rs
+++ b/crates/rag-rat-oplog/src/account/fold.rs
@@ -210,6 +210,9 @@ pub(super) struct AccountAuthHistory {
     stream_ownership: HashMap<StreamId, StreamOwnershipFact>,
     grants: HashMap<[u8; 32], GrantFact>,
     grant_cuts: HashMap<[u8; 32], Vec<DeviceCut>>,
+    /// Removed devices (I4: never re-enroll). Exported because the C6 canonical projection binds
+    /// it: a snapshot that omitted tombstones would let a bootstrap re-admit a removed device.
+    tombstoned: HashSet<DeviceFingerprint>,
 }
 
 /// One authority fact resolved against the CURRENT fold. There is exactly one snapshot to resolve
@@ -375,6 +378,20 @@ impl AccountAuthHistory {
 
     pub(super) fn grant_facts(&self) -> impl Iterator<Item = (&[u8; 32], &GrantFact)> {
         self.grants.iter()
+    }
+
+    /// Every EFFECTIVE entry with the `auth_epoch` it took, in arbitrary order. The C6 canonical
+    /// projection sorts this; callers must not depend on iteration order (it is a `HashMap`).
+    pub(super) fn effective_entries(&self) -> impl Iterator<Item = ([u8; 32], u64)> + '_ {
+        self.outcomes.iter().filter_map(|(hash, outcome)| match outcome {
+            Outcome::Effective { auth_epoch } => Some((*hash, *auth_epoch)),
+            _ => None,
+        })
+    }
+
+    /// Removed devices (I4). Arbitrary order — see [`Self::effective_entries`].
+    pub(super) fn tombstoned(&self) -> impl Iterator<Item = &DeviceFingerprint> {
+        self.tombstoned.iter()
     }
 
     pub(super) fn grant_cuts(&self) -> impl Iterator<Item = (&[u8; 32], &[DeviceCut])> {
@@ -1083,6 +1100,7 @@ fn fold_account_pass(
                 stream_ownership: HashMap::new(),
                 grants: HashMap::new(),
                 grant_cuts: HashMap::new(),
+                tombstoned: HashSet::new(),
             },
             HashMap::new(),
         );
@@ -1592,6 +1610,7 @@ fn fold_account_pass(
             stream_ownership: facts.stream_ownership,
             grants: facts.grants,
             grant_cuts: facts.grant_cuts,
+            tombstoned: state.tombstoned,
         },
         discovered,
     )
@@ -2235,7 +2254,7 @@ fn apply_effect(c: &Candidate, state: &mut FoldState) {
 mod tests {
     use super::*;
     use crate::account::envelope::{sign_account_entry, verify_account_signed};
-    use crate::account::{AccountId, ops as account_ops};
+    use crate::account::{AccountId, ops as account_ops, snapshot};
     use crate::device::{DeviceSecret, DeviceX25519Secret};
     use crate::stream::{StreamId, StreamSpec, StreamSpecV2};
 
@@ -2453,6 +2472,150 @@ mod tests {
         fn effective_set(history: &AccountAuthHistory) -> HashSet<[u8; 32]> {
             history.outcomes.iter().filter(|(_, o)| o.is_effective()).map(|(h, _)| *h).collect()
         }
+    }
+
+    // ---- C6b: the canonical projection (#609) ----
+
+    /// A fixture exercising every collection the projection binds: two owners, a member, a removed
+    /// device (tombstone + cuts), stream ownership, and a grant.
+    fn projection_fixture() -> Fixture {
+        let founder = Dev::new(1);
+        let owner_b = Dev::new(2);
+        let member = Dev::new(3);
+        let removed = Dev::new(4);
+        let mut f = Fixture::genesis(&founder);
+        let g = f.genesis_hash;
+        f.author(&founder, Some(g), &device_add(&owner_b, DeviceRole::Owner));
+        f.author(&founder, Some(g), &device_add(&member, DeviceRole::Member));
+        f.author(&founder, Some(g), &device_add(&removed, DeviceRole::Member));
+        let (stream_id, own) = stream_own(f.account_id);
+        f.author(&founder, Some(g), &own);
+        f.author(&founder, Some(g), &AccountOp::StreamGrant {
+            stream_id,
+            grantee_account_id: AccountId::from_bytes([0x9a; 32]),
+            grant_role: GrantRole::Writer,
+        });
+        // `Cut::Empty` because `removed` never authored an entry: a `Cut::At` would name a
+        // coordinate on its chain that does not exist, and the remove would park
+        // `unknown_cut_target` instead of taking effect — leaving the fixture with no tombstone at
+        // all, which is exactly what `a_different_covered_prefix_projects_differently` caught.
+        f.author(&founder, Some(g), &AccountOp::DeviceRemove {
+            device_fingerprint: removed.fp,
+            control_cut: Cut::Empty,
+            secrets_cut: Cut::Empty,
+            content_cuts: Vec::new(),
+            reason: "revoked".to_string(),
+        });
+        f
+    }
+
+    /// THE determinism tripwire. Every collection the projection reads is a `HashMap`/`HashSet`,
+    /// whose iteration order varies run to run and between peers. Arrival order must not change one
+    /// byte — this is what makes `folded_state_hash` a claim two honest devices can both compute.
+    ///
+    /// It fails the moment any collection is iterated straight into the encoder instead of being
+    /// sorted first.
+    #[test]
+    fn a_shuffled_fold_produces_identical_projection_bytes() {
+        let f = projection_fixture();
+        let baseline = snapshot::projection::encoded(&f.fold());
+        assert!(baseline.len() > 200, "the fixture must exercise a non-trivial projection");
+        for rot in 0..f.entries.len() {
+            assert_eq!(
+                snapshot::projection::encoded(&f.fold_rotated(rot)),
+                baseline,
+                "arrival order rotated by {rot} changed the canonical bytes",
+            );
+        }
+    }
+
+    /// The projection must be ONE complete, canonical CBOR item — not a well-formed prefix followed
+    /// by trailing values. A golden hash alone cannot catch that: it freezes whatever bytes the
+    /// encoder produces, malformed or not, which is exactly how a short top-level array survived
+    /// into a pinned vector. This checks the shape rather than the digest.
+    #[test]
+    fn the_projection_is_one_complete_canonical_cbor_item() {
+        let bytes = snapshot::projection::encoded(&projection_fixture().fold());
+        crate::cbor::require_canonical_cbor(&bytes)
+            .expect("the canonical projection must decode as exactly one canonical CBOR item");
+    }
+
+    /// The canonical encoding is a FROZEN WIRE: two honest devices must agree byte-for-byte, and a
+    /// hash computed under one encoding is meaningless under another. Determinism and sensitivity
+    /// tests both keep passing if the encoding silently changes shape, so pin the bytes.
+    ///
+    /// If this fails, you changed what `folded_state_hash` covers — that is a
+    /// `SNAPSHOT_STATE_FORMAT_V1` bump, not a refactor.
+    #[test]
+    fn golden_projection_pins_the_canonical_encoding() {
+        let hash = snapshot::projection::folded_state_hash(&projection_fixture().fold());
+        assert_eq!(
+            hash.iter().map(|b| format!("{b:02x}")).collect::<String>(),
+            "f6cace33757ebd07c34e076bc6078233321e857292c422e3b2b16940cbe7cb52",
+        );
+    }
+
+    /// The hash must actually depend on the state it claims to bind. Without this, a projection
+    /// that silently dropped a collection would still pass the determinism test above.
+    #[test]
+    fn the_projection_hash_moves_with_every_bound_collection() {
+        let base = snapshot::projection::folded_state_hash(&projection_fixture().fold());
+
+        // A roster/effective-set change.
+        let mut roster = projection_fixture();
+        let g = roster.genesis_hash;
+        roster.author(&Dev::new(1), Some(g), &device_add(&Dev::new(7), DeviceRole::Member));
+        assert_ne!(
+            snapshot::projection::folded_state_hash(&roster.fold()),
+            base,
+            "an added device must change the hash",
+        );
+
+        // A tombstone change (I4's set is bound, so a bootstrap cannot re-admit a removed device).
+        let mut tombstone = projection_fixture();
+        let g = tombstone.genesis_hash;
+        let victim = Dev::new(3);
+        tombstone.author(&Dev::new(1), Some(g), &AccountOp::DeviceRemove {
+            device_fingerprint: victim.fp,
+            control_cut: Cut::Empty,
+            secrets_cut: Cut::Empty,
+            content_cuts: Vec::new(),
+            reason: "revoked".to_string(),
+        });
+        assert_ne!(
+            snapshot::projection::folded_state_hash(&tombstone.fold()),
+            base,
+            "a tombstoned device must change the hash",
+        );
+
+        // A grant change.
+        let mut grant = projection_fixture();
+        let g = grant.genesis_hash;
+        let (stream_id, _) = stream_own(grant.account_id);
+        grant.author(&Dev::new(1), Some(g), &AccountOp::StreamGrant {
+            stream_id,
+            grantee_account_id: AccountId::from_bytes([0xbe; 32]),
+            grant_role: GrantRole::Reader,
+        });
+        assert_ne!(
+            snapshot::projection::folded_state_hash(&grant.fold()),
+            base,
+            "an added grant must change the hash",
+        );
+    }
+
+    /// A held-back entry changes the fold, so it must change the projection — this is what makes a
+    /// coverage claim meaningful rather than a constant.
+    #[test]
+    fn a_different_covered_prefix_projects_differently() {
+        let f = projection_fixture();
+        let full = snapshot::projection::folded_state_hash(&f.fold());
+        let withheld = f.entries.last().expect("fixture has entries").entry_hash;
+        assert_ne!(
+            snapshot::projection::folded_state_hash(&f.fold_without(withheld)),
+            full,
+            "folding a shorter prefix must project differently",
+        );
     }
 
     fn device_add(dev: &Dev, role: DeviceRole) -> AccountOp {

--- a/crates/rag-rat-oplog/src/account/ops.rs
+++ b/crates/rag-rat-oplog/src/account/ops.rs
@@ -69,7 +69,7 @@ impl DeviceRole {
         }
     }
 
-    fn as_u8(self) -> u8 {
+    pub(in crate::account) fn as_u8(self) -> u8 {
         match self {
             DeviceRole::Member => 1,
             DeviceRole::Owner => 2,
@@ -109,7 +109,7 @@ impl GrantRole {
         }
     }
 
-    fn as_u8(self) -> u8 {
+    pub(in crate::account) fn as_u8(self) -> u8 {
         match self {
             GrantRole::Reader => 1,
             GrantRole::Writer => 2,

--- a/crates/rag-rat-oplog/src/account/snapshot/mod.rs
+++ b/crates/rag-rat-oplog/src/account/snapshot/mod.rs
@@ -20,3 +20,4 @@
 //! local inventory would make the verdict device-dependent, breaking convergence.
 
 pub(in crate::account) mod ops;
+pub(in crate::account) mod projection;

--- a/crates/rag-rat-oplog/src/account/snapshot/projection.rs
+++ b/crates/rag-rat-oplog/src/account/snapshot/projection.rs
@@ -1,0 +1,227 @@
+//! The canonical account projection and its `folded_state_hash` (C6b, #609).
+//!
+//! A snapshot manifest claims "I folded exactly this prefix and got this state". The state itself
+//! never rides the wire — the §18a envelope could not hold it — so the claim is a 32-byte hash and
+//! a peer verifies by re-folding the covered prefix and recomputing. That makes this encoding a
+//! **frozen wire in every sense that matters**: two honest devices must produce byte-identical
+//! bytes from the same fold, or verification fails between correct implementations. It is pinned by
+//! golden vectors exactly like the manifest wire, and changing it means bumping
+//! `SNAPSHOT_STATE_FORMAT_V1`.
+//!
+//! # Determinism is the whole job
+//!
+//! Every collection in [`super::super::fold::AccountAuthHistory`] is a `HashMap`/`HashSet`, whose
+//! iteration order varies run to run. Nothing here may iterate one directly into the encoder: each
+//! collection is materialized, sorted by a total key, and only then written. `encoded` is the only
+//! place that ordering is established, and `a_shuffled_fold_produces_identical_bytes` is what keeps
+//! it honest — it builds the same logical account through different arrival orders and asserts the
+//! bytes match.
+//!
+//! # What it binds, and why that set
+//!
+//! The authority projection in full: the account classification and its recovery successor, the
+//! effective set (each entry with the `auth_epoch` it took), roster facts, owner incarnations,
+//! stream ownership, grants and their cuts, and the tombstone set. Two of those deserve a note.
+//!
+//! The **effective set** is bound explicitly rather than left implicit in the derived facts. The
+//! facts are a function of it, but not an injective one — two folds could agree on every roster and
+//! grant fact while disagreeing about which entries were effective (an entry that mints nothing
+//! moves between `parked` and `condemned` without touching a fact). Since the whole purpose is
+//! convergence cross-checking, the set that must converge is bound directly.
+//!
+//! The **tombstone set** is bound because I4 (a tombstoned fingerprint never re-enrolls) is
+//! otherwise unverifiable from a snapshot: a manifest that omitted tombstones would let a peer
+//! bootstrap into a state that re-admits a removed device. The set is total, never windowed —
+//! growth is `DeviceRemove`-rate at 32 bytes each, so a pathological account is kilobytes.
+//!
+//! What it does NOT bind: per-entry outcomes for non-effective entries. Park reasons are
+//! recoverable local state (a park heals when the missing input arrives) rather than converged
+//! verdicts, and binding them would make the hash disagree between two peers that are both correct
+//! and merely differently supplied.
+
+use minicbor::Encoder;
+
+use super::super::fold::{AccountAuthHistory, AccountClassification, AuthorityBoundary};
+use super::super::ops::DeviceCut;
+use crate::cbor;
+
+/// Writing CBOR into a `Vec` cannot fail (its `Write` impl is infallible).
+const INFALLIBLE: &str = "encoding CBOR to a Vec is infallible";
+
+/// Domain tag for the canonical projection. Changing what this encoding covers is a
+/// `SNAPSHOT_STATE_FORMAT_V1` bump, and this tag is what makes a hash from one encoding
+/// unmistakable for a hash from another.
+const PROJECTION_DOMAIN: &str = "rag-rat/account-projection/1";
+
+/// The hash a snapshot manifest claims for a covered prefix: `sha256` of [`encoded`].
+pub(in crate::account) fn folded_state_hash(history: &AccountAuthHistory) -> [u8; 32] {
+    cbor::sha256(&encoded(history))
+}
+
+/// The canonical bytes. Deterministic by construction: every collection is sorted by a total key
+/// before it is written, and no `HashMap`/`HashSet` is ever iterated straight into the encoder.
+pub(in crate::account) fn encoded(history: &AccountAuthHistory) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(512);
+    let mut enc = Encoder::new(&mut buf);
+    // ELEVEN top-level items, and the count is load-bearing: a short array makes a conforming
+    // decoder treat the tail as trailing values outside the frame, even though every byte is still
+    // hashed. Keep this in step with the writes below — domain, classification, successor,
+    // effective_count, then the seven collections.
+    enc.array(11).expect(INFALLIBLE);
+    enc.str(PROJECTION_DOMAIN).expect(INFALLIBLE);
+
+    // 1. Classification. `Contested` carries the depth its pre-contest state was frozen at, which
+    //    is part of the state a peer must agree on, not a local detail.
+    match history.classification() {
+        AccountClassification::Live => {
+            enc.array(1).expect(INFALLIBLE);
+            enc.u8(0).expect(INFALLIBLE);
+        },
+        AccountClassification::Contested { state_before_depth } => {
+            enc.array(2).expect(INFALLIBLE);
+            enc.u8(1).expect(INFALLIBLE);
+            enc.u64(state_before_depth as u64).expect(INFALLIBLE);
+        },
+    }
+
+    // 2. The deterministic recovery successor (§12), when contested.
+    match history.contested_successor() {
+        Some(account) => enc.bytes(&account.to_bytes()).expect(INFALLIBLE),
+        None => enc.null().expect(INFALLIBLE),
+    };
+
+    enc.u64(history.effective_count()).expect(INFALLIBLE);
+
+    // 3. The effective set, sorted by entry hash.
+    let mut effective: Vec<([u8; 32], u64)> = history.effective_entries().collect();
+    effective.sort_unstable();
+    enc.array(effective.len() as u64).expect(INFALLIBLE);
+    for (hash, auth_epoch) in effective {
+        enc.array(2).expect(INFALLIBLE);
+        enc.bytes(&hash).expect(INFALLIBLE);
+        enc.u64(auth_epoch).expect(INFALLIBLE);
+    }
+
+    // 4. Roster facts, sorted by the entry hash that minted them.
+    let mut roster: Vec<_> = history.roster_facts().collect();
+    roster.sort_unstable_by_key(|(hash, _)| **hash);
+    enc.array(roster.len() as u64).expect(INFALLIBLE);
+    for (hash, fact) in roster {
+        enc.array(7).expect(INFALLIBLE);
+        enc.bytes(hash).expect(INFALLIBLE);
+        enc.bytes(&fact.authority.device_fingerprint.to_bytes()).expect(INFALLIBLE);
+        enc.u8(fact.authority.current_role.as_u8()).expect(INFALLIBLE);
+        write_window(&mut enc, fact.effective_at, fact.closed_at);
+        write_boundary(&mut enc, fact.control_boundary);
+        write_boundary(&mut enc, fact.secrets_boundary);
+        let mut content: Vec<_> = fact.content_boundaries.iter().collect();
+        content.sort_unstable_by_key(|(stream, _)| stream.to_bytes());
+        enc.array(content.len() as u64).expect(INFALLIBLE);
+        for (stream, boundary) in content {
+            enc.array(2).expect(INFALLIBLE);
+            enc.bytes(&stream.to_bytes()).expect(INFALLIBLE);
+            write_boundary(&mut enc, *boundary);
+        }
+    }
+
+    // 5. Owner incarnations, sorted by mint hash.
+    let mut incarnations: Vec<_> = history.owner_incarnation_facts().collect();
+    incarnations.sort_unstable_by_key(|(hash, _)| **hash);
+    enc.array(incarnations.len() as u64).expect(INFALLIBLE);
+    for (hash, fact) in incarnations {
+        enc.array(5).expect(INFALLIBLE);
+        enc.bytes(hash).expect(INFALLIBLE);
+        enc.bytes(&fact.authority.device_fingerprint.to_bytes()).expect(INFALLIBLE);
+        write_window(&mut enc, fact.effective_at, fact.closed_at);
+        write_boundary(&mut enc, fact.control_boundary);
+        write_boundary(&mut enc, fact.secrets_boundary);
+    }
+
+    // 6. Stream ownership, sorted by stream.
+    let mut ownership: Vec<_> = history.stream_ownership_facts().collect();
+    ownership.sort_unstable_by_key(|(stream, _)| stream.to_bytes());
+    enc.array(ownership.len() as u64).expect(INFALLIBLE);
+    for (stream, fact) in ownership {
+        enc.array(3).expect(INFALLIBLE);
+        enc.bytes(&stream.to_bytes()).expect(INFALLIBLE);
+        enc.bytes(&fact.own_id).expect(INFALLIBLE);
+        enc.u64(fact.effective_at).expect(INFALLIBLE);
+    }
+
+    // 7. Grants, sorted by grant id.
+    let mut grants: Vec<_> = history.grant_facts().collect();
+    grants.sort_unstable_by_key(|(id, _)| **id);
+    enc.array(grants.len() as u64).expect(INFALLIBLE);
+    for (grant_id, fact) in grants {
+        // FIVE items: grant_id, stream, grantee, role, window — `write_window` emits ONE array, not
+        // two values. A miscounted nested arity makes the decoder consume following top-level items
+        // to fill this one, which is how a malformed frame hides behind a stable hash.
+        enc.array(5).expect(INFALLIBLE);
+        enc.bytes(grant_id).expect(INFALLIBLE);
+        enc.bytes(&fact.authority.stream_id.to_bytes()).expect(INFALLIBLE);
+        enc.bytes(&fact.authority.grantee_account_id.to_bytes()).expect(INFALLIBLE);
+        enc.u8(fact.authority.role.as_u8()).expect(INFALLIBLE);
+        write_window(&mut enc, fact.effective_at, fact.closed_at);
+    }
+
+    // 8. Grant cuts, sorted by grant id then by the device each cut names.
+    let mut grant_cuts: Vec<_> = history.grant_cuts().collect();
+    grant_cuts.sort_unstable_by_key(|(id, _)| **id);
+    enc.array(grant_cuts.len() as u64).expect(INFALLIBLE);
+    for (grant_id, cuts) in grant_cuts {
+        enc.array(2).expect(INFALLIBLE);
+        enc.bytes(grant_id).expect(INFALLIBLE);
+        let mut sorted: Vec<&DeviceCut> = cuts.iter().collect();
+        sorted.sort_unstable_by_key(|cut| (cut.device_fingerprint.to_bytes(), cut.seq, cut.hash));
+        enc.array(sorted.len() as u64).expect(INFALLIBLE);
+        for cut in sorted {
+            enc.array(3).expect(INFALLIBLE);
+            enc.bytes(&cut.device_fingerprint.to_bytes()).expect(INFALLIBLE);
+            enc.u64(cut.seq).expect(INFALLIBLE);
+            enc.bytes(&cut.hash).expect(INFALLIBLE);
+        }
+    }
+
+    // 9. Tombstones, sorted. Total, never windowed — I4 depends on exact membership.
+    let mut tombstoned: Vec<[u8; 32]> =
+        history.tombstoned().map(|fingerprint| fingerprint.to_bytes()).collect();
+    tombstoned.sort_unstable();
+    enc.array(tombstoned.len() as u64).expect(INFALLIBLE);
+    for fingerprint in tombstoned {
+        enc.bytes(&fingerprint).expect(INFALLIBLE);
+    }
+
+    buf
+}
+
+/// An `(effective_at, closed_at)` validity window. Written as a pair so a closed fact can never
+/// encode identically to an open one at the same epoch.
+fn write_window(enc: &mut Encoder<&mut Vec<u8>>, effective_at: u64, closed_at: Option<u64>) {
+    enc.array(2).expect(INFALLIBLE);
+    enc.u64(effective_at).expect(INFALLIBLE);
+    match closed_at {
+        Some(at) => enc.u64(at).expect(INFALLIBLE),
+        None => enc.null().expect(INFALLIBLE),
+    };
+}
+
+/// `Open`/`Closed` are discriminants alone; `Cut` carries its coordinate. Encoded as a tagged array
+/// rather than a bare integer so a future boundary variant cannot collide with an existing one.
+fn write_boundary(enc: &mut Encoder<&mut Vec<u8>>, boundary: AuthorityBoundary) {
+    match boundary {
+        AuthorityBoundary::Open => {
+            enc.array(1).expect(INFALLIBLE);
+            enc.u8(0).expect(INFALLIBLE);
+        },
+        AuthorityBoundary::Cut { seq, hash } => {
+            enc.array(3).expect(INFALLIBLE);
+            enc.u8(1).expect(INFALLIBLE);
+            enc.u64(seq).expect(INFALLIBLE);
+            enc.bytes(&hash).expect(INFALLIBLE);
+        },
+        AuthorityBoundary::Closed => {
+            enc.array(1).expect(INFALLIBLE);
+            enc.u8(2).expect(INFALLIBLE);
+        },
+    }
+}


### PR DESCRIPTION
First slice of C6b, part of #609. Builds the artifact a snapshot manifest's `folded_state_hash` actually refers to. Nothing authors or verifies a snapshot yet — that is the next slice.

## Why this is a frozen wire

The state a manifest claims never rides the wire (the §18a envelope could not hold it), so the claim is a 32-byte hash and a peer verifies by re-folding the covered prefix and recomputing. Two honest devices must therefore produce **byte-identical** bytes from the same fold, or verification fails between correct implementations. Changing what this covers is a `SNAPSHOT_STATE_FORMAT_V1` bump, not a refactor.

## Determinism is the whole job

Every collection on `AccountAuthHistory` is a `HashMap`/`HashSet` whose iteration order varies run to run and between peers. Nothing here iterates one into the encoder: each is materialized, sorted by a total key, and only then written.

`a_shuffled_fold_produces_identical_projection_bytes` folds the same account through every rotation of its arrival order and asserts the bytes match. Mutation-tested — dropping any single sort fails it.

## What it binds, and what it deliberately does not

The authority projection in full: classification and recovery successor, the effective set, roster facts, owner incarnations, stream ownership, grants and their cuts, and the tombstone set.

- The **effective set** is bound explicitly rather than left implicit in the derived facts. The facts are a function of it, but not an injective one — two folds can agree on every roster and grant fact while disagreeing about which entries were effective, since an entry that mints nothing can move between `parked` and `condemned` without touching a fact. The set that must converge is bound directly.
- The **tombstone set** is bound because I4 is otherwise unverifiable from a snapshot: a manifest that omitted tombstones would let a bootstrap re-admit a removed device. Total, never windowed — growth is `DeviceRemove`-rate at 32 bytes each.
- **Per-entry outcomes for non-effective entries are excluded.** Park reasons are recoverable local state, not converged verdicts; binding them would make the hash disagree between two peers that are both correct and merely differently supplied.

The fold gains two exports for this (the tombstone set and an effective-entry iterator), and the op wire's role tokens are reused rather than introducing a second encoding of the same enums.

## The three tests carry different weight

The shuffle test pins determinism. The golden pins the bytes — because determinism and sensitivity both keep passing if the encoding silently changes shape. And a **well-formedness check** requires the output to be exactly one complete canonical CBOR item.

That third one earned its place immediately: it caught a nested grant entry declaring six elements while writing five (`write_window` emits one array, not two). A decoder consumes following top-level items to fill the short entry and runs off the end. The golden had **already frozen** that malformed frame, and the determinism test passes with it — verified by mutation, so the check is doing work neither of the others can.

A fixture bug surfaced the same way: `a_different_covered_prefix_projects_differently` failed because the fixture's `DeviceRemove` cut named a coordinate on a chain its target had never written to, so the op parked instead of taking effect and the fixture produced no tombstone at all.

## Verification

- `cargo nextest run --workspace`: 3,526 passed.
- Both CI clippy invocations with `-D warnings`: exit 0.
- Nightly rustfmt `--check`: clean.
- Codex review run twice — it found the malformed frame on the first pass (diagnosing it at the top-level array; the actual defect was the nested grant arity, which the well-formedness check localized), and is clean on the second.