### PR TITLE
distill: stop surfacing the keyword classification label on retrieval and impact

### DIFF
--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/symbol_search_lookup.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/symbol_search_lookup.rs
@@ -2013,7 +2013,7 @@ fn papertrail_sync_caches_rationale_without_query_time_crawling() {
 
     let issue_hits = db.papertrail_issue_search("sqlite", 10).unwrap();
     assert_eq!(issue_hits.len(), 1);
-    assert_eq!(issue_hits[0].classification, "decision");
+    assert_eq!(issue_hits[0].title, "Decision: keep sqlite");
     assert_eq!(issue_hits[0].evidence_kind, "historical_tracker");
 
     let refs = db.papertrail_refs_for_path("docs/search.md", 10).unwrap();
@@ -2021,7 +2021,7 @@ fn papertrail_sync_caches_rationale_without_query_time_crawling() {
     assert_eq!(refs[0].source_kind, "file");
 
     let rationale = db.rationale_search("risk", 10).unwrap();
-    assert!(rationale.iter().any(|item| item.classification == "risk"));
+    assert!(rationale.iter().any(|item| item.snippet.contains("live crawling")));
     let issue_ref_rationale = db.rationale_search("Fixes #42", 10).unwrap();
     assert_eq!(issue_ref_rationale.first().map(|item| item.item_key.as_str()), Some("42"));
     assert_eq!(

--- a/crates/rag-rat-papertrail/src/evidence.rs
+++ b/crates/rag-rat-papertrail/src/evidence.rs
@@ -504,4 +504,16 @@ mod payload_tests {
         attach_records(&conn, &mut hits).unwrap();
         assert!(hits[0].record.is_none(), "no distill store → bare hit, no error");
     }
+
+    #[test]
+    fn classification_is_never_serialized_to_a_read_surface() {
+        // #705: the coarse keyword label is internal-only (the eval harness scores against it); the
+        // distilled `record` supersedes it as the decision signal. A populated `classification`
+        // must NOT reach the JSON a retrieval consumer sees, while ordinary fields still do.
+        let mut hit = ev("issue", "5", None);
+        hit.classification = "decision".into();
+        let json = serde_json::to_string(&hit).unwrap();
+        assert!(!json.contains("classification"), "classification must not surface: {json}");
+        assert!(json.contains("\"item_key\":\"5\""), "ordinary fields still serialize: {json}");
+    }
 }

--- a/crates/rag-rat-papertrail/src/lib.rs
+++ b/crates/rag-rat-papertrail/src/lib.rs
@@ -256,6 +256,12 @@ pub struct PapertrailEvidence {
     pub url: String,
     pub title: String,
     pub snippet: String,
+    /// Coarse keyword label (`classify_text`) kept for the internal eval harness only. It is NOT a
+    /// read surface: the distilled decision record (`record`, #705) supersedes it, so it is never
+    /// serialized to a retrieval payload or drive-by. Retained (not deleted) because the eval
+    /// harness still scores against it; the `papertrail_fts.classification` column keeps
+    /// populating it. Do not resurface it — read `record` instead.
+    #[serde(skip_serializing)]
     pub classification: String,
     pub evidence_kind: &'static str,
     pub score: f64,

--- a/crates/rag-rat-query/src/impact/historical.rs
+++ b/crates/rag-rat-query/src/impact/historical.rs
@@ -177,7 +177,7 @@ pub(crate) fn papertrail_rationale_for_query(
     let repo_id = rag_rat_db::schema::active_repo_id(conn)?;
     let mut stmt = conn.prepare(
         "
-        SELECT url, title, classification
+        SELECT url, title
         FROM papertrail_fts
         WHERE papertrail_fts MATCH ?1 AND repo_id = ?3
         ORDER BY rank
@@ -186,10 +186,10 @@ pub(crate) fn papertrail_rationale_for_query(
     )?;
     let rows = stmt.query_map(
         params![fts_query, i64::try_from(limit).unwrap_or(i64::MAX), repo_id],
-        |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?, row.get::<_, String>(2)?)),
+        |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
     )?;
     for row in rows {
-        let (url, title, classification) = row?;
+        let (url, title) = row?;
         surface.push(
             ImpactCategory::HistoricalPapertrail,
             FileSymbol {
@@ -199,7 +199,7 @@ pub(crate) fn papertrail_rationale_for_query(
                 symbol: None,
             },
             "papertrail",
-            format!("{classification}: {title} ({url})"),
+            format!("{title} ({url})"),
         );
     }
     Ok(())
@@ -312,5 +312,40 @@ mod tests {
         // hot.rs's three commits collapsed into one item carrying multiple evidence lines.
         let hot = items.iter().find(|item| item.path == "hot.rs").unwrap();
         assert!(hot.evidence.len() >= 2, "collapsed commits accumulate evidence: {hot:?}");
+    }
+
+    /// #705: the historical papertrail rationale surfaces `title (url)` only — it must NOT prefix
+    /// the line with the deprecated `classify_text` keyword label, so the distilled record is the
+    /// sole decision signal on this surface.
+    #[test]
+    fn papertrail_rationale_surfaces_title_and_url_without_the_classification_prefix() {
+        let conn = Connection::open_in_memory().unwrap();
+        schema::apply(&conn, &rag_rat_core::index::migration_hooks()).unwrap();
+        conn.execute(
+            "INSERT INTO repos(repo_id, display_name, registered_at_ms) VALUES ('r', 'r', 0)",
+            [],
+        )
+        .unwrap();
+        // The `classification` column is still stored ('decision') — the assertion proves it does
+        // not reach the surfaced text.
+        conn.execute(
+            "INSERT INTO papertrail_fts(tracker, project, item_kind, item_key, doc_kind, \
+             comment_id, url, title, body, classification, repo_id) VALUES ('github', 'o/r', \
+             'issue', '7', 'item', '', 'https://x/7', 'Keep sqlite', 'We keep sqlite for size.', \
+             'decision', 'r')",
+            [],
+        )
+        .unwrap();
+
+        let mut surface = ImpactSurface::default();
+        papertrail_rationale_for_query(&conn, "sqlite", &mut surface, 10).unwrap();
+        let items = surface.into_items(10);
+        let text = items
+            .iter()
+            .flat_map(|item| item.evidence.iter())
+            .find(|line| line.contains("Keep sqlite"))
+            .expect("the matching papertrail item surfaces");
+        assert_eq!(text, "Keep sqlite (https://x/7)", "title (url) only, no prefix: {text}");
+        assert!(!text.contains("decision"), "the keyword label must not surface: {text}");
     }
 }


### PR DESCRIPTION
Part of #705. Closes #837.

The distilled decision record now surfaces on retrieval payloads and symbol drive-by, so the older `classify_text` keyword `classification` label and the distilled record are two competing decision-detectors over the same rows. The label was surfaced but never used for ranking (bm25 is), so this removes it from every read surface:

- **Retrieval payload / drive-by JSON** — `PapertrailEvidence.classification` is marked `#[serde(skip_serializing)]`, so it no longer appears in any serialized retrieval result. The field itself is retained (not deleted): the internal eval harness (`--features eval`) still scores against it, and the `papertrail_fts.classification` column keeps populating it. This mirrors how `DriveByRecord.outcome_status_model` stays internal via the same attribute.
- **Impact-surface historical rationale** — `papertrail_rationale_for_query` no longer selects or prints the label: the surfaced line is now `title (url)` instead of `classification: title (url)`. This is a display string that a serde attribute can't cover, so it's a separate fix for the same label.

The `papertrail_fts.classification` column (NOT NULL) and its write path stay in place for a later schema migration; the write path keeps populating the column harmlessly. Retrieval consumers read the distilled record instead.

**Tests**
- `classification_is_never_serialized_to_a_read_surface` — a populated `classification` is absent from the serialized `PapertrailEvidence` while ordinary fields still serialize.
- `papertrail_rationale_surfaces_title_and_url_without_the_classification_prefix` — the historical rationale surfaces `title (url)` with the stored label ('decision') absent from the text.
- Two integration assertions in the search/rationale bootstrap test move off the deprecated field onto stable content checks (item title, comment snippet).