### PR TITLE
feat(oplog): read-time verification of a snapshot's coverage claim (#609)

### DIFF
--- a/crates/rag-rat-oplog/src/account/fold.rs
+++ b/crates/rag-rat-oplog/src/account/fold.rs
@@ -2529,6 +2529,166 @@ mod tests {
         }
     }
 
+    // ---- C6b-ii: read-time verification (#609) ----
+
+    /// Build the manifest target a HONEST author would publish for this fixture: every device's
+    /// control-chain head, and the hash its own fold produces.
+    fn honest_target(f: &Fixture) -> snapshot::ops::SnapshotTarget {
+        let history = f.fold();
+        let mut heads: HashMap<DeviceFingerprint, (u64, [u8; 32])> = HashMap::new();
+        for entry in &f.entries {
+            let h = &entry.header;
+            let slot = heads.entry(h.device_fingerprint).or_insert((h.seq, entry.entry_hash));
+            if h.seq >= slot.0 {
+                *slot = (h.seq, entry.entry_hash);
+            }
+        }
+        snapshot::ops::SnapshotTarget {
+            log_id: 0,
+            stream_id: None,
+            subject_account_id: None,
+            folded_state_hash: snapshot::projection::folded_state_hash(&history),
+            covered: heads
+                .into_iter()
+                .map(|(device_fingerprint, (seq, entry_hash))| snapshot::ops::CoveredWatermark {
+                    device_fingerprint,
+                    seq,
+                    entry_hash,
+                })
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn an_honest_snapshot_verifies_against_a_local_refold() {
+        let f = projection_fixture();
+        assert_eq!(
+            snapshot::verify::verify_snapshot(&f.entries, &[honest_target(&f)]),
+            snapshot::verify::SnapshotVerdict::Verified,
+        );
+    }
+
+    #[test]
+    fn a_false_coverage_claim_is_a_mismatch() {
+        // The point of the hash: a claim that does not match the covered prefix is detectable.
+        let f = projection_fixture();
+        let mut lying = honest_target(&f);
+        lying.folded_state_hash = [0xff; 32];
+        assert_eq!(
+            snapshot::verify::verify_snapshot(&f.entries, &[lying]),
+            snapshot::verify::SnapshotVerdict::Mismatch,
+        );
+    }
+
+    /// THE FIREWALL PROPERTY. Verification is device-dependent by nature, so it must be advisory:
+    /// a device that lacks the covered history reports `Unverifiable`, NEVER a judgement. If this
+    /// ever returned `Mismatch` for missing history, two peers at different sync progress would
+    /// disagree about the same signed entry.
+    #[test]
+    fn a_device_lacking_the_covered_history_reports_unverifiable_not_a_judgement() {
+        let f = projection_fixture();
+        let target = honest_target(&f);
+
+        // Hold nothing at all: the heads themselves are absent.
+        assert_eq!(
+            snapshot::verify::verify_snapshot(&[], std::slice::from_ref(&target)),
+            snapshot::verify::SnapshotVerdict::Unverifiable(
+                snapshot::verify::Unverifiable::WatermarkNotHeld
+            ),
+        );
+
+        // Hold the heads but not a link beneath them: a claim this device cannot reconstruct.
+        let heads: Vec<_> = f
+            .entries
+            .iter()
+            .filter(|e| target.covered.iter().any(|w| w.entry_hash == e.entry_hash))
+            .cloned()
+            .collect();
+        assert!(heads.len() < f.entries.len(), "the fixture must have interior entries");
+        assert_eq!(
+            snapshot::verify::verify_snapshot(&heads, &[target]),
+            snapshot::verify::SnapshotVerdict::Unverifiable(
+                snapshot::verify::Unverifiable::IncompleteChain
+            ),
+        );
+    }
+
+    /// The attack the branch restriction would otherwise enable. Verification folds only the chain
+    /// a watermark names — that is what makes the hash deterministic between honest peers — but it
+    /// also means the AUTHOR picks which branch gets hashed. An author who equivocates and then
+    /// snapshots the clean side produces a claim that is perfectly true about that branch.
+    ///
+    /// So a device that HOLDS the sibling must refuse it. Without this, checking `Live` over the
+    /// covered input would be inspecting the author's own selection: that fold is `Live` by
+    /// construction, because the evidence contradicting it was left out.
+    #[test]
+    fn a_snapshot_of_one_branch_is_refused_by_a_device_holding_the_equivocation() {
+        let founder = Dev::new(1);
+        let sibling_target = Dev::new(8);
+        let mut f = projection_fixture();
+        let target = honest_target(&f);
+
+        // Without the sibling, the claim verifies — the branch it names is real.
+        assert_eq!(
+            snapshot::verify::verify_snapshot(&f.entries, std::slice::from_ref(&target)),
+            snapshot::verify::SnapshotVerdict::Verified,
+        );
+
+        // Now equivocate at a covered coordinate: a second entry at a `(device, seq)` the claim's
+        // chain already occupies. The claim is unchanged and still true about its own branch.
+        let covered = target.covered.iter().find(|w| w.device_fingerprint == founder.fp).cloned();
+        let covered = covered.expect("the founder's chain is covered");
+        let held_entry = f
+            .entries
+            .iter()
+            .find(|e| e.entry_hash == covered.entry_hash)
+            .expect("the covered head is held");
+        let (seq, prev) = (held_entry.header.seq, held_entry.header.prev_hash);
+        let g = f.genesis_hash;
+        f.author_forked(
+            &founder,
+            Some(g),
+            &device_add(&sibling_target, DeviceRole::Member),
+            seq,
+            prev,
+        );
+
+        assert_eq!(
+            snapshot::verify::verify_snapshot(&f.entries, &[target]),
+            snapshot::verify::SnapshotVerdict::IgnoresHeldEvidence,
+            "a device holding the sibling must not trust a snapshot that folded only one branch",
+        );
+    }
+
+    #[test]
+    fn a_target_naming_an_unsupported_log_is_unverifiable_not_failed() {
+        // The wire admits secrets/content targets so #406 needs no bump; this binary has no
+        // projection for them and must say so rather than call the snapshot wrong.
+        let f = projection_fixture();
+        let secrets_target = snapshot::ops::SnapshotTarget { log_id: 1, ..honest_target(&f) };
+        assert_eq!(
+            snapshot::verify::verify_snapshot(&f.entries, &[secrets_target]),
+            snapshot::verify::SnapshotVerdict::Unverifiable(
+                snapshot::verify::Unverifiable::UnsupportedTargets
+            ),
+        );
+    }
+
+    #[test]
+    fn a_forged_chain_link_is_not_walkable_into_the_verification_input() {
+        // A signed header pins `prev_hash` NULLITY, not that its parent is a contiguous link on the
+        // same coordinate. A watermark whose seq disagrees with the entry it names must not fold.
+        let f = projection_fixture();
+        let mut forged = honest_target(&f);
+        forged.covered[0].seq = forged.covered[0].seq.wrapping_add(7);
+        assert_eq!(
+            snapshot::verify::verify_snapshot(&f.entries, &[forged]),
+            snapshot::verify::SnapshotVerdict::Unverifiable(
+                snapshot::verify::Unverifiable::IncompleteChain
+            ),
+        );
+    }
+
     /// The projection must be ONE complete, canonical CBOR item — not a well-formed prefix followed
     /// by trailing values. A golden hash alone cannot catch that: it freezes whatever bytes the
     /// encoder produces, malformed or not, which is exactly how a short top-level array survived

--- a/crates/rag-rat-oplog/src/account/snapshot/mod.rs
+++ b/crates/rag-rat-oplog/src/account/snapshot/mod.rs
@@ -21,3 +21,4 @@
 
 pub(in crate::account) mod ops;
 pub(in crate::account) mod projection;
+pub(in crate::account) mod verify;

--- a/crates/rag-rat-oplog/src/account/snapshot/verify.rs
+++ b/crates/rag-rat-oplog/src/account/snapshot/verify.rs
@@ -1,0 +1,198 @@
+//! Read-time verification of a snapshot's coverage claim (C6b, #609).
+//!
+//! A manifest asserts "I folded exactly this prefix and got this state". Checking that requires
+//! HOLDING the covered history and re-folding it, which is a device-dependent capability — so it
+//! happens here, at read, and never at acceptance.
+//!
+//! # The invariant this module exists to protect
+//!
+//! **Acceptance may read only frozen structural facts of the entry plus the control projection. It
+//! may never read the local candidate inventory of the logs a manifest covers.** A structurally
+//! valid manifest whose watermarks exist nowhere on this device must still be STORED — it simply
+//! never verifies here. The moment acceptance asks "do I hold the covered entries?", two peers with
+//! different sync progress reach different verdicts on the same signed entry and the fold firewall
+//! is gone. Everything in this module is therefore advisory: it decides whether a snapshot may be
+//! TRUSTED, never whether it may be stored.
+//!
+//! That is the same line C4.3b's sealing-key cross-check sits on, for the same reason.
+//!
+//! # Why the input is the on-branch prefix
+//!
+//! The fold is a pure function of the candidate SET, and the candidate DAG deliberately retains
+//! both sides of an equivocation. A watermark vector names one branch head per `(log, device)` and
+//! says nothing about off-branch siblings, so "everything at or below seq N" would leave the input
+//! under-determined: two honest devices holding different fork evidence would compute different
+//! hashes for the same claim. The verification input is therefore exactly the chains reachable by
+//! walking `prev_hash` from each named watermark — the same link discipline
+//! [`super::super::candidate::ancestry`] enforces (same `(account, log, device)` coordinate,
+//! stepping down exactly one seq slot).
+//!
+//! The counterpart to that restriction: an author could otherwise omit fork evidence and publish a
+//! "clean" snapshot of an account whose full fold is contested. So a snapshot whose covered input
+//! does not fold `Live` is not usable, however well its hash matches.
+
+use std::collections::HashMap;
+
+use super::super::envelope::VerifiedAccountEntry;
+use super::super::fold::{self, AccountClassification};
+use super::ops::{CoveredWatermark, SnapshotTarget};
+use super::projection;
+use crate::op::DeviceFingerprint;
+
+/// The account control log — the only target this binary has a projection for. A manifest may name
+/// the secrets or content logs (the wire allows it so #406 needs no bump), but nothing here can
+/// check those claims yet.
+const CONTROL_LOG_ID: u8 = 0;
+
+/// Why a claim could not be checked. Never a judgement about the snapshot — always a statement
+/// about what this device currently holds or implements.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::account) enum Unverifiable {
+    /// A named watermark entry is not held here.
+    WatermarkNotHeld,
+    /// A link on the walk from a watermark toward seq 0 is missing, or the chain is malformed.
+    IncompleteChain,
+    /// Every target names a log this binary has no canonical projection for.
+    UnsupportedTargets,
+}
+
+/// The result of checking one snapshot against local history.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::account) enum SnapshotVerdict {
+    /// Every supported target's hash matched a local re-fold of its covered prefix.
+    Verified,
+    /// A supported target's hash disagreed with the local re-fold: the claim is FALSE. The entry
+    /// remains stored — it is simply never trusted.
+    Mismatch,
+    /// The account does not fold `Live` over everything this device holds. Refused even on a hash
+    /// match: a contested account's snapshot would let peers that trust it proceed while full peers
+    /// halt.
+    NotLive,
+    /// The device HOLDS an entry at a covered coordinate that the claim's chain does not include —
+    /// an equivocation the author either did not see or chose not to fold. The claim may be
+    /// perfectly true about the branch it names and still be an incomplete view of what is known
+    /// here, so it is not trusted. This is the counterpart to restricting the input to one branch:
+    /// without it, an author picks the branch that suits them and the `Live` check above inspects
+    /// the attacker's own selection rather than reality.
+    IgnoresHeldEvidence,
+    /// Undecidable here and now.
+    Unverifiable(Unverifiable),
+}
+
+/// Check one snapshot's targets against the entries this device holds for the account.
+///
+/// A pure function of `(held, targets)` — deliberately not a storage call, so it is impossible to
+/// reach from acceptance by accident and trivial to test against a fold fixture. Advisory only: a
+/// `Mismatch` means "do not trust this", never "reject this entry".
+pub(in crate::account) fn verify_snapshot(
+    held: &[VerifiedAccountEntry],
+    targets: &[SnapshotTarget],
+) -> SnapshotVerdict {
+    let by_hash: HashMap<[u8; 32], &VerifiedAccountEntry> =
+        held.iter().map(|entry| (entry.entry_hash, entry)).collect();
+
+    // Classification duty runs over EVERYTHING this device holds, never over the claimed branch
+    // alone. Restricting the fold input to one branch is what makes the hash deterministic between
+    // honest peers — but it also means a branch chosen by the author folds `Live` by construction,
+    // so checking `Live` over that input would be checking the author's own selection.
+    if fold::fold_account(held).classification() != AccountClassification::Live {
+        return SnapshotVerdict::NotLive;
+    }
+
+    let mut supported = 0usize;
+    for target in targets {
+        if target.log_id != CONTROL_LOG_ID {
+            // A target this binary has no projection for is not a failure — a newer binary (or
+            // #406, for content) will check it.
+            continue;
+        }
+        supported += 1;
+        let prefix = match on_branch_prefix(&target.covered, &by_hash) {
+            Ok(prefix) => prefix,
+            Err(reason) => return SnapshotVerdict::Unverifiable(reason),
+        };
+        if ignores_held_evidence(&prefix, held) {
+            return SnapshotVerdict::IgnoresHeldEvidence;
+        }
+        let history = fold::fold_account(&prefix);
+        if projection::folded_state_hash(&history) != target.folded_state_hash {
+            return SnapshotVerdict::Mismatch;
+        }
+    }
+    if supported == 0 {
+        return SnapshotVerdict::Unverifiable(Unverifiable::UnsupportedTargets);
+    }
+    SnapshotVerdict::Verified
+}
+
+/// Whether this device holds an entry at a coordinate the claim's chain covers, that the chain does
+/// not include — i.e. an equivocation the author did not fold.
+///
+/// The claim can be entirely true about the branch it names and still be an incomplete view of what
+/// is known here. Since the author chooses which branch to hash, this is the check that stops that
+/// choice from being the only thing verification inspects.
+fn ignores_held_evidence(prefix: &[VerifiedAccountEntry], held: &[VerifiedAccountEntry]) -> bool {
+    let covered_slots: HashMap<(u8, DeviceFingerprint, u64), [u8; 32]> = prefix
+        .iter()
+        .map(|entry| {
+            let h = &entry.header;
+            ((h.log_id, h.device_fingerprint, h.seq), entry.entry_hash)
+        })
+        .collect();
+    held.iter().any(|entry| {
+        let h = &entry.header;
+        covered_slots
+            .get(&(h.log_id, h.device_fingerprint, h.seq))
+            .is_some_and(|chosen| *chosen != entry.entry_hash)
+    })
+}
+
+/// Collect the union of the chains reachable by walking `prev_hash` from each covered watermark.
+///
+/// The walk mirrors [`super::super::candidate::ancestry`]'s link rules exactly: every step stays on
+/// the watermark's own `(log, device)` coordinate and steps down precisely one seq slot, ending at
+/// seq 0 with no parent. A signed header pins only `prev_hash` NULLITY — not that its parent is a
+/// valid contiguous link — so a forged chain must not be walkable into the verification input.
+fn on_branch_prefix(
+    covered: &[CoveredWatermark],
+    by_hash: &HashMap<[u8; 32], &VerifiedAccountEntry>,
+) -> Result<Vec<VerifiedAccountEntry>, Unverifiable> {
+    let mut collected: Vec<&VerifiedAccountEntry> = Vec::new();
+    for watermark in covered {
+        let mut cursor = Some(watermark.entry_hash);
+        let mut expected_seq = watermark.seq;
+        let mut at_head = true;
+        while let Some(hash) = cursor {
+            let Some(entry) = by_hash.get(&hash).copied() else {
+                // A missing HEAD is "not synced yet"; a hole further down is a claim naming a chain
+                // this device cannot reconstruct. Different diagnoses, both undecidable.
+                return Err(if at_head {
+                    Unverifiable::WatermarkNotHeld
+                } else {
+                    Unverifiable::IncompleteChain
+                });
+            };
+            let header = &entry.header;
+            if header.log_id != CONTROL_LOG_ID
+                || header.device_fingerprint != watermark.device_fingerprint
+                || header.seq != expected_seq
+            {
+                return Err(Unverifiable::IncompleteChain);
+            }
+            collected.push(entry);
+            at_head = false;
+            match (header.prev_hash, header.seq) {
+                // Root of the chain: seq 0 with no parent is the only valid terminus.
+                (None, 0) => cursor = None,
+                (None, _) | (Some(_), 0) => return Err(Unverifiable::IncompleteChain),
+                (Some(prev), seq) => {
+                    cursor = Some(prev);
+                    expected_seq = seq - 1;
+                },
+            }
+        }
+    }
+    collected.sort_unstable_by_key(|entry| entry.entry_hash);
+    collected.dedup_by_key(|entry| entry.entry_hash);
+    Ok(collected.into_iter().cloned().collect())
+}

--- a/crates/rag-rat-oplog/src/account/storage.rs
+++ b/crates/rag-rat-oplog/src/account/storage.rs
@@ -557,6 +557,48 @@ fn owner_chain_authority_in_snapshot(
     }))
 }
 
+/// Verify every snapshot this device holds for `account_id` against the account history it holds.
+///
+/// The read/query surface for [`snapshot::verify`], and deliberately READ-ONLY: it returns verdicts
+/// and changes nothing. A `Mismatch` here does not delete, condemn, or unaccept the entry — a
+/// snapshot whose claim is false stays stored and is simply never trusted. Nothing may feed a
+/// verdict back into acceptance, because verifying consults the local candidate inventory and an
+/// acceptance rule that did so would make the verdict device-dependent.
+///
+/// Entries that are not current-version plaintext snapshots on the annex log are skipped, and a
+/// manifest this binary cannot interpret (a future state format) simply yields no verdict rather
+/// than a failure.
+pub(in crate::account) fn verify_stored_snapshots(
+    conn: &Connection,
+    account_id: AccountId,
+) -> anyhow::Result<Vec<(EntryHash, snapshot::verify::SnapshotVerdict)>> {
+    let rows = load_candidates(conn, account_id)?;
+    let held: Vec<envelope::VerifiedAccountEntry> =
+        rows.iter().map(|row| row.verified.clone()).collect();
+    let mut verdicts = Vec::new();
+    for row in &rows {
+        let header = &row.verified.header;
+        if header.log_id != fold::ANNEX_LOG
+            || header.crypto_suite != 0
+            || header.op_version != fold::SUPPORTED_OP_VERSION
+        {
+            continue;
+        }
+        let Ok(snapshot::ops::DecodedSnapshotOp::Known(snapshot::ops::SnapshotOp::Snapshot {
+            targets,
+            ..
+        })) = snapshot::ops::decode(header.entry_type, &row.verified.payload)
+        else {
+            // An unknown tag or a future state format is retained and uninterpretable here — not a
+            // verdict, and not an error.
+            continue;
+        };
+        verdicts.push((row.entry_hash, snapshot::verify::verify_snapshot(&held, &targets)));
+    }
+    verdicts.sort_unstable_by_key(|(hash, _)| *hash);
+    Ok(verdicts)
+}
+
 pub fn owner_incarnation_effective(
     conn: &Connection,
     account_id: AccountId,
@@ -3329,6 +3371,120 @@ mod tests {
             account_ingest(&conn, &other_tag.signed_bytes, NOW + 3).unwrap(),
             IngestOutcome::Ingested { status: "retained_unfolded".into() },
             "a sealed NON-snapshot annex entry is still retained",
+        );
+    }
+
+    /// END-TO-END through storage: author a real snapshot over the account's own history, ingest
+    /// it, and verify it back out. The algorithm has unit coverage against a fold fixture; this is
+    /// the path — stored bytes, manifest decode, covered walk over real rows — actually working.
+    fn author_snapshot_over(
+        conn: &Connection,
+        account_id: AccountId,
+        founder: &Dev,
+        genesis_hash: [u8; 32],
+        mangle: impl FnOnce(&mut snapshot::ops::SnapshotTarget),
+    ) -> [u8; 32] {
+        // The honest claim: every device's control-chain head, and the hash of folding exactly
+        // that.
+        let rows = load_candidates(conn, account_id).unwrap();
+        let held: Vec<_> = rows.iter().map(|r| r.verified.clone()).collect();
+        let mut heads: std::collections::HashMap<DeviceFingerprint, (u64, [u8; 32])> =
+            std::collections::HashMap::new();
+        for entry in &held {
+            if entry.header.log_id != fold::CONTROL_LOG {
+                continue;
+            }
+            let slot = heads
+                .entry(entry.header.device_fingerprint)
+                .or_insert((entry.header.seq, entry.entry_hash));
+            if entry.header.seq >= slot.0 {
+                *slot = (entry.header.seq, entry.entry_hash);
+            }
+        }
+        let control_only: Vec<_> =
+            held.iter().filter(|e| e.header.log_id == fold::CONTROL_LOG).cloned().collect();
+        let mut target =
+            snapshot::ops::SnapshotTarget {
+                log_id: fold::CONTROL_LOG,
+                stream_id: None,
+                subject_account_id: None,
+                folded_state_hash: snapshot::projection::folded_state_hash(&fold::fold_account(
+                    &control_only,
+                )),
+                covered: heads
+                    .into_iter()
+                    .map(|(device_fingerprint, (seq, entry_hash))| {
+                        snapshot::ops::CoveredWatermark { device_fingerprint, seq, entry_hash }
+                    })
+                    .collect(),
+            };
+        mangle(&mut target);
+
+        let payload = snapshot::ops::encode(&snapshot::ops::SnapshotOp::Snapshot {
+            state_format_version: snapshot::ops::SNAPSHOT_STATE_FORMAT_V1,
+            moderation_epoch: 0,
+            targets: vec![target],
+        })
+        .unwrap();
+        let header = AccountEntryHeader {
+            account_id,
+            log_id: fold::ANNEX_LOG,
+            device_fingerprint: founder.fp,
+            seq: 0,
+            prev_hash: None,
+            parent_ref: None,
+            entry_type: snapshot::ops::entry_type::SNAPSHOT,
+            op_version: 1,
+            crypto_suite: 0,
+            auth_len: 1,
+            key_id: None,
+            authority_ref: Some(genesis_hash),
+        };
+        let signed = sign_account_entry(&founder.secret, &header, &payload).unwrap();
+        account_ingest(conn, &signed.signed_bytes, NOW + 9).unwrap();
+        signed.entry_hash
+    }
+
+    #[test]
+    fn a_stored_snapshot_verifies_end_to_end_and_a_forged_one_does_not() {
+        let conn = db();
+        let founder = Dev::new(0x91);
+        let member = Dev::new(0x92);
+        let (account_id, genesis_bytes, genesis_hash) = genesis(&founder);
+        account_ingest(&conn, &genesis_bytes, NOW).unwrap();
+        let (add_bytes, _) = op(
+            account_id,
+            &founder,
+            1,
+            Some(genesis_hash),
+            Some(genesis_hash),
+            &device_add(&member, DeviceRole::Member),
+        );
+        account_ingest(&conn, &add_bytes, NOW + 1).unwrap();
+
+        let honest = author_snapshot_over(&conn, account_id, &founder, genesis_hash, |_| {});
+        assert_eq!(
+            verify_stored_snapshots(&conn, account_id).unwrap(),
+            vec![(honest, snapshot::verify::SnapshotVerdict::Verified)],
+            "an honest claim over stored history verifies through the real read path",
+        );
+
+        // A forged hash on an otherwise well-formed manifest is detected, and — the load-bearing
+        // half — the entry is still STORED. Verification never unaccepts anything.
+        let conn = db();
+        let (account_id, genesis_bytes, genesis_hash) = genesis(&founder);
+        account_ingest(&conn, &genesis_bytes, NOW).unwrap();
+        let forged = author_snapshot_over(&conn, account_id, &founder, genesis_hash, |target| {
+            target.folded_state_hash = [0xff; 32];
+        });
+        assert_eq!(verify_stored_snapshots(&conn, account_id).unwrap(), vec![(
+            forged,
+            snapshot::verify::SnapshotVerdict::Mismatch
+        )],);
+        assert_eq!(
+            status(&conn, &forged).as_deref(),
+            Some("retained_unfolded"),
+            "a false claim is still stored — verification decides trust, never storage",
         );
     }
 


### PR DESCRIPTION
Second slice of C6b, part of #609. Checks a manifest's claim by re-folding the covered prefix and comparing the canonical projection hash from #838.

## Advisory by construction

Verifying requires **holding** the covered history, which is device-dependent. An acceptance rule that consulted it would let two peers at different sync progress reach different verdicts on the same signed entry — the fold firewall gone. So this decides whether a snapshot may be **trusted**, never whether it may be **stored**.

`verify_snapshot` is a pure function of `(held entries, targets)` rather than a storage call. That is deliberate: it makes the function awkward to reach from acceptance by accident, and trivial to test against the fold fixture. Same line C4.3b's sealing-key cross-check sits on.

## The branch restriction, and the hole it opens

The verification input is the **on-branch prefix** — the chains reachable by walking `prev_hash` from each named watermark, with the same link discipline `candidate::ancestry` enforces (same coordinate, one seq slot per step, terminating at seq 0 with no parent). "Everything at or below seq N" would leave the input under-determined: the candidate DAG retains both sides of an equivocation, so two honest peers holding different fork evidence would compute different hashes for the same claim.

But restricting the input means **the author chooses which branch gets hashed**, and a branch chosen by the author folds `Live` by construction. Two checks close that:

- **Classification duty runs over everything the device holds**, not the covered branch. Checking `Live` over the covered input alone would be inspecting the attacker's own selection.
- **`IgnoresHeldEvidence`** — a claim whose chain omits an entry this device holds at a covered coordinate is refused. The claim can be perfectly true about the branch it names and still be an incomplete view of what is known here.

The test proves both directions: the same claim verifies before an equivocation is introduced at a covered coordinate, and is refused after.

Codex caught the missing second check as a P1 on the first pass — I had implemented two of the three parts the design called for, and the `Live` check was toothless without the third.

## Unverifiable is a diagnosis, not a judgement

A missing head is "not synced yet"; a hole beneath one is a chain this device cannot reconstruct; a target naming the secrets or content log is simply not something this binary has a projection for. None of them say anything about the snapshot.

## Still unwired

Nothing authors a snapshot yet, so **there is no read path to call this from** — selection over verified snapshots is the first consumer, in the next slice. Codex raised the absence of production callers as a second P1; I have not acted on it, because wiring it would mean inventing a caller rather than finding one. Flagging the disagreement rather than burying it.

## Verification

- `cargo nextest run --workspace`: 3,535 passed.
- Both CI clippy invocations with `-D warnings`: exit 0 (the first run caught a `cloned_ref_to_slice_refs` lint that the test suite passed straight through — worth checking exit codes, not just test output).
- Nightly rustfmt `--check`: clean.