### PR TITLE
distill: attach drive-by decision records on read_chunk

### DIFF
--- a/crates/rag-rat-core/src/index/query_api/memory.rs
+++ b/crates/rag-rat-core/src/index/query_api/memory.rs
@@ -140,7 +140,37 @@ impl IndexDatabase {
         symbol: &rag_rat_query::symbol::SymbolHit,
         limit: usize,
     ) -> anyhow::Result<Vec<rag_rat_papertrail::DriveByRecord>> {
-        let Some(logical_symbol_id) = symbol.logical_symbol_id else {
+        self.drive_by_records_for_logical_id(symbol.logical_symbol_id, limit)
+    }
+
+    /// Distilled decision records for the symbol a chunk defines (#705 drive-by on `read_chunk`).
+    /// Resolves the chunk's file `path` + qualified `symbol_path` to a logical symbol, then the
+    /// same facet-gated lane as [`records_for_symbol`]. Empty when the chunk defines no resolvable
+    /// logical symbol. `pub(crate)`: only the `read_chunk` reader calls it (unlike the sibling
+    /// `records_for_symbol`, which the MCP handler invokes directly).
+    pub(crate) fn records_for_chunk_symbol(
+        &self,
+        path: &str,
+        symbol_path: Option<&str>,
+        limit: usize,
+    ) -> anyhow::Result<Vec<rag_rat_papertrail::DriveByRecord>> {
+        let logical_symbol_id = rag_rat_query::memory::logical_symbol_id_for_chunk_symbol(
+            self.storage.connection(),
+            path,
+            symbol_path,
+        )?;
+        self.drive_by_records_for_logical_id(logical_symbol_id, limit)
+    }
+
+    /// Shared drive-by fetch: the repo-scoped, facet-gated `records_for_symbol` lane over a
+    /// resolved logical-symbol handle. `None`/unresolved id surfaces nothing (no anchor to bind
+    /// a record to).
+    fn drive_by_records_for_logical_id(
+        &self,
+        logical_symbol_id: Option<i64>,
+        limit: usize,
+    ) -> anyhow::Result<Vec<rag_rat_papertrail::DriveByRecord>> {
+        let Some(logical_symbol_id) = logical_symbol_id else {
             return Ok(Vec::new());
         };
         let conn = self.storage.connection();

--- a/crates/rag-rat-core/src/index/query_api/mod.rs
+++ b/crates/rag-rat-core/src/index/query_api/mod.rs
@@ -478,6 +478,11 @@ impl IndexDatabase {
                 },
                 || self.heal_corrupt_fts(),
             )?;
+            // Distilled decision records (#705 drive-by) for the symbol this chunk defines, capped
+            // ≤2 and labeled unreviewed. Rides the memories flag; facet-gated, so empty for almost
+            // every chunk — matches the symbol_lookup convention (a lightweight per-item surface).
+            chunk.distilled_records =
+                self.records_for_chunk_symbol(&chunk.path, chunk.symbol_path.as_deref(), 2)?;
         }
         Ok(Some(chunk))
     }

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_memory.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_memory.rs
@@ -2844,6 +2844,123 @@ fn surface_summary_defers_bodies_across_the_db_memory_renderers() {
     let _ = fs::remove_dir_all(&root);
 }
 
+/// #705 drive-by: `read_chunk` attaches the distilled decision records for the symbol the chunk
+/// defines — resolved from the chunk's (path, symbol_path) to the same facet-gated (provider fix
+/// edge + a selected symbol anchor), capped, labeled lane the other symbol surfaces use. Rides the
+/// memories include flag.
+#[test]
+fn read_chunk_attaches_distilled_records_for_the_chunk_symbol() {
+    use rag_rat_base::config::MemorySurface;
+    use rag_rat_query::graph_meta::GraphMetaMode;
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), "pub fn target() {}\n").unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let symbol = db
+        .select_symbol(&rag_rat_query::symbol::SymbolSelector {
+            logical_symbol_id: None,
+            symbol_id: None,
+            symbol_path: None,
+            symbol: Some("target".to_string()),
+            language: Some(Language::Rust),
+            allow_ambiguous: true,
+            limit: 10,
+        })
+        .unwrap()
+        .unwrap()
+        .expect("selected symbol");
+    let logical = symbol.logical_symbol_id.expect("target has a logical id");
+
+    let conn = db.storage.connection();
+    let repo_id = rag_rat_db::schema::active_repo_id(conn).unwrap();
+    // A distilled record for issue #5: a PROVIDER fix edge, anchored to `target`'s logical symbol
+    // and SELECTED — the two facets `records_for_symbol` gates the drive-by on.
+    conn.execute(
+        "INSERT INTO papertrail_distill
+             (tracker, project, item_kind, item_key, distill_input_hash, pipeline_version,
+              root_issue, fix_edge_source, thread_shape, anchors_qualified_count,
+              distilled_at_ms, repo_id)
+         VALUES ('github','o/r','issue','5','sha256:h',3,'5','provider','investigation',1,10,?1)",
+        rusqlite::params![repo_id],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO papertrail_distill_anchors
+             (tracker, project, item_kind, item_key, anchor_kind, logical_symbol_id, name,
+              resolved, candidate_ordinal, selected, repo_id)
+         VALUES ('github','o/r','issue','5','symbol',?1,'target',1,0,1,?2)",
+        rusqlite::params![rag_rat_base::serde_big_id::format_sym_handle(logical), repo_id],
+    )
+    .unwrap();
+
+    let chunk_id: i64 = conn
+        .query_row(
+            "SELECT chunks.id FROM chunks JOIN files ON files.id = chunks.file_id WHERE \
+             files.path = 'src/lib.rs' AND chunks.symbol_path IS NOT NULL LIMIT 1",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+
+    // Happy path: the record surfaces on read_chunk, labeled unreviewed.
+    let chunk = db
+        .read_chunk_with_graph_and_memories(
+            chunk_id,
+            GraphMetaMode::Full,
+            20,
+            true,
+            MemorySurface::Full,
+        )
+        .unwrap()
+        .expect("chunk");
+    assert_eq!(
+        chunk.distilled_records.iter().map(|r| r.record.item_key.as_str()).collect::<Vec<_>>(),
+        vec!["5"],
+        "the provider-edge, selected-anchor record for this chunk's symbol attaches",
+    );
+    assert!(chunk.distilled_records[0].unreviewed, "the drive-by record is labeled unreviewed");
+
+    // A symbol wider than the chunk limit splits; its continuation chunks carry a
+    // `<qualified_name>#<part>` symbol_path. That must resolve to the SAME defining symbol rather
+    // than silently surfacing nothing — the numeric continuation suffix is stripped before the
+    // symbol lookup.
+    let base_symbol_path = chunk.symbol_path.clone().expect("the chunk defines a symbol");
+    let continuation = format!("{base_symbol_path}#1");
+    assert_eq!(
+        db.records_for_chunk_symbol("src/lib.rs", Some(&continuation), 2)
+            .unwrap()
+            .iter()
+            .map(|r| r.record.item_key.as_str())
+            .collect::<Vec<_>>(),
+        vec!["5"],
+        "a `{base_symbol_path}#<part>` continuation symbol_path resolves to the same records",
+    );
+
+    // include_memories = false skips the whole drive-by lane, same as memories.
+    let bare = db
+        .read_chunk_with_graph_and_memories(
+            chunk_id,
+            GraphMetaMode::Full,
+            20,
+            false,
+            MemorySurface::Full,
+        )
+        .unwrap()
+        .expect("chunk");
+    assert!(bare.distilled_records.is_empty(), "the drive-by rides the memories include flag");
+
+    // Resolver guards: a chunk with no symbol name, and an unknown symbol, both surface nothing.
+    assert!(db.records_for_chunk_symbol("src/lib.rs", None, 2).unwrap().is_empty());
+    assert!(
+        db.records_for_chunk_symbol("src/lib.rs", Some("does_not_exist"), 2).unwrap().is_empty()
+    );
+
+    let _ = fs::remove_dir_all(&root);
+}
+
 /// #463: a node created with NO binding target is UNANCHORED — a graph node (a `Concept` /
 /// standalone `Task`) with no code anchor. It surfaces in the general `memory list` with blank
 /// binding columns, dedupes against another unanchored node of the same text, is excluded by a

--- a/crates/rag-rat-query/src/lib.rs
+++ b/crates/rag-rat-query/src/lib.rs
@@ -35,6 +35,11 @@ pub struct ReadChunk {
     pub graph: Option<graph_meta::GraphEvidence>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub memories: Vec<memory::RepoMemory>,
+    /// Distilled decision records (#705 drive-by) for the symbol this chunk defines — capped ≤2,
+    /// labeled unreviewed. Empty for almost every chunk (facet-gated: a provider fix edge + a
+    /// qualified symbol anchor). Populated by the core reader, never by the base `read_chunk`.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub distilled_records: Vec<rag_rat_papertrail::DriveByRecord>,
 }
 
 pub fn read_chunk(conn: &Connection, chunk_id: i64) -> anyhow::Result<Option<ReadChunk>> {
@@ -82,6 +87,7 @@ pub fn read_chunk_with(
                         text: String::new(),
                         graph: None,
                         memories: Vec::new(),
+                        distilled_records: Vec::new(),
                     },
                     ChunkTextRow {
                         blob: row.get(7)?,

--- a/crates/rag-rat-query/src/memory/resolve.rs
+++ b/crates/rag-rat-query/src/memory/resolve.rs
@@ -466,7 +466,18 @@ pub(crate) fn symbol_id_for_chunk(
     conn: &Connection,
     chunk: &ChunkAnchor,
 ) -> anyhow::Result<Option<i64>> {
-    let Some(symbol_path) = chunk.symbol_path.as_deref() else {
+    symbol_id_for_path_symbol(conn, &chunk.path, chunk.symbol_path.as_deref())
+}
+
+/// The `symbols` rowid for the symbol at (`path`, qualified `symbol_path`). `None` when there is no
+/// symbol name or the name is unknown to the index. The rowid is reassigned on every reindex
+/// (#149), so resolve it to a logical id before caching or crossing the wire.
+pub(crate) fn symbol_id_for_path_symbol(
+    conn: &Connection,
+    path: &str,
+    symbol_path: Option<&str>,
+) -> anyhow::Result<Option<i64>> {
+    let Some(symbol_path) = symbol_path else {
         return Ok(None);
     };
     conn.query_row(
@@ -478,11 +489,41 @@ pub(crate) fn symbol_id_for_chunk(
           AND symbols.qualified_name_id = (SELECT id FROM name_strings WHERE value = ?2)
         LIMIT 1
         ",
-        params![chunk.path, symbol_path],
+        params![path, symbol_path],
         |row| row.get("symbol_id"),
     )
     .optional()
     .map_err(Into::into)
+}
+
+/// The stable logical-symbol handle for the symbol a chunk defines — its file `path` + qualified
+/// `symbol_path` — for #705 drive-by records on `read_chunk`. `None` when the chunk defines no
+/// symbol or the symbol has no logical grouping.
+pub fn logical_symbol_id_for_chunk_symbol(
+    conn: &Connection,
+    path: &str,
+    symbol_path: Option<&str>,
+) -> anyhow::Result<Option<i64>> {
+    // A symbol wider than the chunk limit is split into parts; its continuation chunks carry a
+    // `qualified_name#<part>` symbol_path (see the chunker) while `symbols.qualified_name_id`
+    // stores only the bare qualified name. Strip the numeric continuation suffix so reading a
+    // continuation chunk resolves to the SAME defining symbol as its first part instead of
+    // silently surfacing no records.
+    let base = symbol_path.map(strip_chunk_continuation_suffix);
+    let Some(symbol_id) = symbol_id_for_path_symbol(conn, path, base)? else {
+        return Ok(None);
+    };
+    logical_symbol_id_for_symbol(conn, symbol_id)
+}
+
+/// Strip a chunker continuation suffix (`…#<digits>`) from a chunk's `symbol_path`, yielding the
+/// defining symbol's bare qualified name. A name without a trailing numeric `#` suffix — the common
+/// case, and part 0 of any split — passes through unchanged.
+pub(crate) fn strip_chunk_continuation_suffix(symbol_path: &str) -> &str {
+    match symbol_path.rsplit_once('#') {
+        Some((base, part)) if !part.is_empty() && part.bytes().all(|b| b.is_ascii_digit()) => base,
+        _ => symbol_path,
+    }
 }
 pub(crate) fn logical_symbol_id_for_symbol(
     conn: &Connection,
@@ -977,4 +1018,23 @@ pub(crate) fn short_symbol_name<'a>(binding_id: &'a str, path: Option<&str>) -> 
         return name;
     }
     binding_id.rsplit("::").next().unwrap_or(binding_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::strip_chunk_continuation_suffix as strip;
+
+    #[test]
+    fn continuation_suffix_is_stripped_only_when_numeric() {
+        // Part 0 and any ordinary qualified name pass through.
+        assert_eq!(strip("foo::bar"), "foo::bar");
+        assert_eq!(strip("target"), "target");
+        // A chunker continuation suffix (`#<digits>`) is dropped to the defining symbol.
+        assert_eq!(strip("foo::bar#1"), "foo::bar");
+        assert_eq!(strip("target#12"), "target");
+        // A `#` that is not a numeric continuation is left intact (never a split part).
+        assert_eq!(strip("foo#bar"), "foo#bar");
+        assert_eq!(strip("foo::bar#"), "foo::bar#");
+        assert_eq!(strip("foo#1a"), "foo#1a");
+    }
 }


### PR DESCRIPTION
Part of #705 (scope item 2 — drive-by attachment on symbol surfaces). Closes #843.

`symbol_lookup` and `impact_surface` already surface distilled decision records on the symbol they resolve; `read_chunk` did not. This resolves the chunk's symbol from its `(path, symbol_path)` to a logical symbol, then reuses the same facet-gated (provider fix edge + a selected symbol anchor), repo-scoped, capped `records_for_symbol` lane the other surfaces use.

- **Resolver** — `rag-rat-query` gains `logical_symbol_id_for_chunk_symbol`, which shares its `symbols` lookup with the existing `symbol_id_for_chunk` (extracted into `symbol_id_for_path_symbol`) and then resolves the logical id via `logical_symbol_id_for_symbol`. This is the same two-step resolution the memory chunk-binding path already performs.
- **Payload** — `ReadChunk` carries a `distilled_records` field (skipped when empty), populated by the core reader inside the `include_memories` block, capped at 2 and labeled unreviewed. This matches the `symbol_lookup` convention: a lightweight per-item surface with no completeness section to signal truncation through (only `impact_surface`, which returns a report, signals truncation).
- `records_for_symbol` and the new `records_for_chunk_symbol` share a private `drive_by_records_for_logical_id`.

The `read_chunk` tool serializes `ReadChunk` directly, so the field surfaces with no handler change. Empty for the vast majority of chunks — the facet gate requires a provider fix edge and a qualified symbol anchor.

**Test**
`read_chunk_attaches_distilled_records_for_the_chunk_symbol` rebuilds a real index, seeds a provider-edge, selected-anchor record for the target symbol, and asserts it surfaces on `read_chunk`; that the lane rides the memories include flag (`include_memories=false` → empty); and that the resolver guards (no symbol, unknown symbol) return empty. The happy path cross-checks two independent resolvers agree on the logical id, so it cannot pass trivially.