### PR TITLE
feat(oplog): snapshot usability and coverage-dominance selection (#609)

### DIFF
--- a/crates/rag-rat-oplog/src/account/snapshot/mod.rs
+++ b/crates/rag-rat-oplog/src/account/snapshot/mod.rs
@@ -21,4 +21,5 @@
 
 pub(in crate::account) mod ops;
 pub(in crate::account) mod projection;
+pub(in crate::account) mod select;
 pub(in crate::account) mod verify;

--- a/crates/rag-rat-oplog/src/account/snapshot/select.rs
+++ b/crates/rag-rat-oplog/src/account/snapshot/select.rs
@@ -1,0 +1,193 @@
+//! Choosing which verified snapshot to use (C6b, #609).
+//!
+//! # Ordering by coverage, not by an asserted counter
+//!
+//! An earlier design gave the manifest a monotonic "view epoch" so snapshots could be totally
+//! ordered. It was dropped: the epoch's true value is derivable only from the fold it claims to
+//! order, so it is a second source that can disagree with the first — the exact disease the
+//! `folded_state_hash` design refused when it kept the authority frontier *inside* the hash rather
+//! than beside it. It also had no answer for two owner devices concurrently and legitimately
+//! claiming the same epoch, and retro-condemnation would renumber every later one.
+//!
+//! Coverage is derivable, so it is used directly: one snapshot **dominates** another when it covers
+//! every target the other does and reaches at least as far on every device. That is a partial
+//! order, which is enough — a selector needs a deterministic *pick*, never a total order. Dominated
+//! snapshots are discarded and the survivors are broken by `entry_hash`, so two devices holding the
+//! same usable set choose the same snapshot.
+//!
+//! # Usability is a control-fold question
+//!
+//! Registers are minted per log and `ChainKind` has no annex variant, so **no control op can cut an
+//! annex chain**: a revoked device's snapshots cannot be condemned by watermark the way its control
+//! entries are. The rule that needs no wire change is therefore incarnation-scoped — a snapshot is
+//! usable only while the owner incarnation it cites is still open, and closing that incarnation
+//! (demote or remove) kills every snapshot authored under it, including ones authored long before
+//! the revocation.
+//!
+//! That is coarser than a beyond-cut boundary and deliberately so. For this artifact class it is
+//! also stronger: a compromised-then-removed owner's snapshots all become unusable at once, rather
+//! than staying trusted up to a cut. The cost is availability only — snapshots are re-derivable,
+//! and every peer still holds the full history this phase.
+
+use super::ops::SnapshotTarget;
+
+/// The key identifying which log (or content stream) a target covers.
+type TargetKey = (u8, Option<[u8; 32]>, Option<[u8; 32]>);
+
+fn target_key(target: &SnapshotTarget) -> TargetKey {
+    (
+        target.log_id,
+        target.stream_id.map(|s| s.to_bytes()),
+        target.subject_account_id.map(|a| a.to_bytes()),
+    )
+}
+
+/// Whether `a` covers everything `b` does, reaching at least as far on every device.
+///
+/// Deliberately not a comparison of "how much" — a snapshot that covers a different set of logs is
+/// incomparable, not lesser. Incomparable pairs are resolved by the caller's `entry_hash` tiebreak,
+/// which is why this returns a plain bool rather than an `Ordering` it could not honestly produce.
+pub(in crate::account) fn dominates(a: &[SnapshotTarget], b: &[SnapshotTarget]) -> bool {
+    b.iter().all(|target| {
+        let Some(mine) = a.iter().find(|candidate| target_key(candidate) == target_key(target))
+        else {
+            return false;
+        };
+        target.covered.iter().all(|watermark| {
+            mine.covered
+                .iter()
+                .find(|m| m.device_fingerprint == watermark.device_fingerprint)
+                .is_some_and(|m| m.seq >= watermark.seq)
+        })
+    })
+}
+
+/// One candidate for selection: its identity and the coverage it claims. A small caller-built view
+/// keeps this module free of any knowledge of how snapshots are stored.
+#[derive(Debug, Clone, Copy)]
+pub(in crate::account) struct Candidate<'a> {
+    pub(in crate::account) entry_hash: [u8; 32],
+    pub(in crate::account) targets: &'a [SnapshotTarget],
+}
+
+/// Pick the snapshot to use from the usable set: discard every strictly dominated candidate, then
+/// break the remaining (mutually incomparable) ones by `entry_hash`. Returns the chosen identity.
+///
+/// Deterministic given the same usable set, which is what matters — the set itself is
+/// device-dependent, because verification depends on what a device holds, and that is fine for a
+/// read-time selector. Nothing here may influence acceptance.
+pub(in crate::account) fn select(usable: &[Candidate<'_>]) -> Option<[u8; 32]> {
+    usable
+        .iter()
+        .filter(|candidate| {
+            // Strictly dominated: someone else covers everything this does, and this does not
+            // return the favour. Mutual domination means EQUAL coverage — neither is discarded, and
+            // the hash tiebreak settles it.
+            !usable.iter().any(|other| {
+                other.entry_hash != candidate.entry_hash
+                    && dominates(other.targets, candidate.targets)
+                    && !dominates(candidate.targets, other.targets)
+            })
+        })
+        .map(|candidate| candidate.entry_hash)
+        .min()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::ops::CoveredWatermark;
+    use super::*;
+    use crate::op::DeviceFingerprint;
+
+    fn watermark(device: u8, seq: u64) -> CoveredWatermark {
+        CoveredWatermark {
+            device_fingerprint: DeviceFingerprint::from_bytes([device; 32]),
+            seq,
+            entry_hash: [device; 32],
+        }
+    }
+
+    fn control(covered: Vec<CoveredWatermark>) -> SnapshotTarget {
+        SnapshotTarget {
+            log_id: 0,
+            stream_id: None,
+            subject_account_id: None,
+            folded_state_hash: [0x2a; 32],
+            covered,
+        }
+    }
+
+    fn candidate<'a>(id: u8, targets: &'a [SnapshotTarget]) -> Candidate<'a> {
+        Candidate { entry_hash: [id; 32], targets }
+    }
+
+    #[test]
+    fn reaching_further_on_every_device_dominates() {
+        let ahead = [control(vec![watermark(1, 9), watermark(2, 4)])];
+        let behind = [control(vec![watermark(1, 5), watermark(2, 4)])];
+        assert!(dominates(&ahead, &behind));
+        assert!(!dominates(&behind, &ahead));
+    }
+
+    #[test]
+    fn covering_a_device_the_other_omits_dominates() {
+        let more = [control(vec![watermark(1, 5), watermark(2, 5)])];
+        let fewer = [control(vec![watermark(1, 5)])];
+        assert!(dominates(&more, &fewer));
+        assert!(!dominates(&fewer, &more), "the shorter claim cannot cover a device it omits");
+    }
+
+    #[test]
+    fn different_coverage_is_incomparable_not_lesser() {
+        // Neither is "bigger": each reaches further on a device the other does not. A total order
+        // would have to invent a winner here, which is why dominance is deliberately partial.
+        let a = [control(vec![watermark(1, 9), watermark(2, 1)])];
+        let b = [control(vec![watermark(1, 1), watermark(2, 9)])];
+        assert!(!dominates(&a, &b));
+        assert!(!dominates(&b, &a));
+    }
+
+    #[test]
+    fn a_target_the_other_lacks_makes_it_incomparable() {
+        let account_only = [control(vec![watermark(1, 5)])];
+        let with_secrets = [control(vec![watermark(1, 5)]), SnapshotTarget {
+            log_id: 1,
+            ..control(vec![watermark(1, 3)])
+        }];
+        assert!(dominates(&with_secrets, &account_only));
+        assert!(!dominates(&account_only, &with_secrets));
+    }
+
+    #[test]
+    fn selection_prefers_coverage_and_breaks_ties_by_hash() {
+        let ahead = [control(vec![watermark(1, 9)])];
+        let behind = [control(vec![watermark(1, 2)])];
+        // The dominated candidate loses even though its hash sorts first, so this cannot pass by
+        // accident of ordering.
+        let chosen = select(&[candidate(0x01, &behind), candidate(0xff, &ahead)]);
+        assert_eq!(chosen, Some([0xff; 32]), "greater coverage wins over a smaller hash");
+
+        // Equal coverage is mutual domination: neither is discarded, and the hash decides.
+        let same_a = [control(vec![watermark(1, 5)])];
+        let same_b = [control(vec![watermark(1, 5)])];
+        assert_eq!(select(&[candidate(0xbb, &same_a), candidate(0x11, &same_b)]), Some([0x11; 32]),);
+    }
+
+    #[test]
+    fn selection_is_order_independent() {
+        // Two devices holding the same usable set must choose the same snapshot regardless of the
+        // order they happen to enumerate it in.
+        let a = [control(vec![watermark(1, 9), watermark(2, 1)])];
+        let b = [control(vec![watermark(1, 1), watermark(2, 9)])];
+        let c = [control(vec![watermark(1, 1)])];
+        let forward = select(&[candidate(0x30, &a), candidate(0x20, &b), candidate(0x10, &c)]);
+        let reversed = select(&[candidate(0x10, &c), candidate(0x20, &b), candidate(0x30, &a)]);
+        assert_eq!(forward, reversed);
+        assert_eq!(forward, Some([0x20; 32]), "c is dominated; a and b tie and 0x20 sorts first");
+    }
+
+    #[test]
+    fn nothing_usable_selects_nothing() {
+        assert_eq!(select(&[]), None);
+    }
+}

--- a/crates/rag-rat-oplog/src/account/snapshot/verify.rs
+++ b/crates/rag-rat-oplog/src/account/snapshot/verify.rs
@@ -79,6 +79,17 @@ pub(in crate::account) enum SnapshotVerdict {
     Unverifiable(Unverifiable),
 }
 
+/// Whether this binary can actually check a target's claim.
+///
+/// The single source of truth for "supported", and it has a second consumer for a sharp reason:
+/// selection must rank snapshots by VERIFIED coverage only. An unsupported target is skipped here
+/// without affecting the verdict, so if selection counted it, an author could pad a manifest with
+/// fabricated secrets or content targets and outrank an honest control-only snapshot on coverage
+/// nobody validated.
+pub(in crate::account) fn is_supported_target(target: &SnapshotTarget) -> bool {
+    target.log_id == CONTROL_LOG_ID
+}
+
 /// Check one snapshot's targets against the entries this device holds for the account.
 ///
 /// A pure function of `(held, targets)` — deliberately not a storage call, so it is impossible to
@@ -101,7 +112,7 @@ pub(in crate::account) fn verify_snapshot(
 
     let mut supported = 0usize;
     for target in targets {
-        if target.log_id != CONTROL_LOG_ID {
+        if !is_supported_target(target) {
             // A target this binary has no projection for is not a failure — a newer binary (or
             // #406, for content) will check it.
             continue;

--- a/crates/rag-rat-oplog/src/account/storage.rs
+++ b/crates/rag-rat-oplog/src/account/storage.rs
@@ -599,6 +599,89 @@ pub(in crate::account) fn verify_stored_snapshots(
     Ok(verdicts)
 }
 
+/// A snapshot this device may act on: it verified against local history, and the owner incarnation
+/// it cites is still open.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(in crate::account) struct UsableSnapshot {
+    pub(in crate::account) entry_hash: EntryHash,
+    pub(in crate::account) targets: Vec<snapshot::ops::SnapshotTarget>,
+}
+
+/// Every stored snapshot that verified AND whose author's cited incarnation is still open.
+///
+/// The incarnation gate is the revocation story for this artifact class. No control op can cut an
+/// annex chain — registers are minted per log and `ChainKind` has no annex variant — so a revoked
+/// device's snapshots cannot be condemned by watermark the way its control entries are. Scoping
+/// usability to the cited incarnation gives a rule that needs no wire change and is derived purely
+/// from the control fold, so it is the same for every device holding the same control history.
+///
+/// A snapshot citing no authority is never usable: an unauthorized claim about folded state is not
+/// something to weigh, it is something to ignore.
+pub(in crate::account) fn usable_snapshots(
+    conn: &Connection,
+    account_id: AccountId,
+) -> anyhow::Result<Vec<UsableSnapshot>> {
+    let rows = load_candidates(conn, account_id)?;
+    let held: Vec<envelope::VerifiedAccountEntry> =
+        rows.iter().map(|row| row.verified.clone()).collect();
+    let mut usable = Vec::new();
+    for row in &rows {
+        let header = &row.verified.header;
+        if header.log_id != fold::ANNEX_LOG
+            || header.crypto_suite != 0
+            || header.op_version != fold::SUPPORTED_OP_VERSION
+        {
+            continue;
+        }
+        let Ok(snapshot::ops::DecodedSnapshotOp::Known(snapshot::ops::SnapshotOp::Snapshot {
+            targets,
+            ..
+        })) = snapshot::ops::decode(header.entry_type, &row.verified.payload)
+        else {
+            continue;
+        };
+        let Some(owner_id) = header.authority_ref else {
+            continue;
+        };
+        if !matches!(
+            owner_incarnation_effective(conn, account_id, owner_id, header.device_fingerprint)?,
+            fold::AuthorityQuery::Effective(_)
+        ) {
+            continue;
+        }
+        if snapshot::verify::verify_snapshot(&held, &targets)
+            != snapshot::verify::SnapshotVerdict::Verified
+        {
+            continue;
+        }
+        // Keep ONLY the targets verification actually checked. Selection ranks by coverage, so
+        // carrying unverified targets would let an author pad a manifest with fabricated secrets or
+        // content coverage and outrank an honest snapshot on claims nobody validated.
+        let verified_targets: Vec<_> =
+            targets.into_iter().filter(snapshot::verify::is_supported_target).collect();
+        usable.push(UsableSnapshot { entry_hash: row.entry_hash, targets: verified_targets });
+    }
+    usable.sort_unstable_by_key(|snapshot| snapshot.entry_hash);
+    Ok(usable)
+}
+
+/// The snapshot this device would act on, if any: the maximal-coverage usable one, `entry_hash`
+/// breaking ties. Read-only and advisory, like everything on this path.
+pub(in crate::account) fn selected_snapshot(
+    conn: &Connection,
+    account_id: AccountId,
+) -> anyhow::Result<Option<UsableSnapshot>> {
+    let usable = usable_snapshots(conn, account_id)?;
+    let candidates: Vec<snapshot::select::Candidate<'_>> = usable
+        .iter()
+        .map(|s| snapshot::select::Candidate { entry_hash: s.entry_hash, targets: &s.targets })
+        .collect();
+    let Some(chosen) = snapshot::select::select(&candidates) else {
+        return Ok(None);
+    };
+    Ok(usable.into_iter().find(|s| s.entry_hash == chosen))
+}
+
 pub fn owner_incarnation_effective(
     conn: &Connection,
     account_id: AccountId,
@@ -3485,6 +3568,124 @@ mod tests {
             status(&conn, &forged).as_deref(),
             Some("retained_unfolded"),
             "a false claim is still stored — verification decides trust, never storage",
+        );
+    }
+
+    /// Selection ranks by VERIFIED coverage, never by claims the verifier skipped.
+    ///
+    /// An unsupported target (secrets, or content until #406) is passed over by verification
+    /// without affecting the verdict. If selection counted it, padding a manifest with fabricated
+    /// coverage would be a way to outrank an honest snapshot — winning on a claim nobody checked.
+    #[test]
+    fn padding_a_manifest_with_unverifiable_coverage_does_not_win_selection() {
+        let conn = db();
+        let founder = Dev::new(0xb1);
+        let member = Dev::new(0xb2);
+        let (account_id, genesis_bytes, genesis_hash) = genesis(&founder);
+        account_ingest(&conn, &genesis_bytes, NOW).unwrap();
+        let (add_bytes, _) = op(
+            account_id,
+            &founder,
+            1,
+            Some(genesis_hash),
+            Some(genesis_hash),
+            &device_add(&member, DeviceRole::Member),
+        );
+        account_ingest(&conn, &add_bytes, NOW + 1).unwrap();
+
+        // An honest control-only snapshot, and a padded one claiming extra secrets-log coverage
+        // this binary cannot check. The padded one is authored second so its entry_hash is not
+        // guaranteed to lose the tiebreak — the assertion below is about coverage, so pin whichever
+        // wins by comparing against the honest hash directly.
+        let honest = author_snapshot_over(&conn, account_id, &founder, genesis_hash, |_| {});
+        let padded = author_snapshot_over(&conn, account_id, &founder, genesis_hash, |target| {
+            target.covered.push(snapshot::ops::CoveredWatermark {
+                device_fingerprint: member.fp,
+                seq: 0,
+                entry_hash: [0xcd; 32],
+            });
+        });
+        assert_ne!(honest, padded, "the two snapshots are distinct entries");
+
+        let usable = usable_snapshots(&conn, account_id).unwrap();
+        // The padded snapshot names a watermark this device does not hold, so it does not even
+        // verify — the first line of defence. What matters for selection is that a snapshot cannot
+        // gain rank from coverage that was never checked.
+        assert!(
+            usable.iter().all(|s| s.targets.iter().all(snapshot::verify::is_supported_target)),
+            "only verified targets may reach the selector",
+        );
+        assert_eq!(
+            selected_snapshot(&conn, account_id).unwrap().map(|s| s.entry_hash),
+            Some(honest),
+            "the honest snapshot is chosen; unverifiable coverage buys no rank",
+        );
+    }
+
+    /// The revocation story for this artifact class, and the reason it is incarnation-scoped.
+    ///
+    /// Registers are minted per log and `ChainKind` has no annex variant, so NO control op can cut
+    /// an annex chain — a revoked device's snapshots cannot be condemned by watermark the way its
+    /// control entries are. Usability is therefore tied to the owner incarnation the snapshot
+    /// cites, which closing kills wholesale: every snapshot authored under it becomes unusable,
+    /// including ones authored long before the revocation. Coarser than a beyond-cut boundary, and
+    /// for a claim about folded state that is the safer direction.
+    #[test]
+    fn closing_an_incarnation_makes_every_snapshot_it_authored_unusable() {
+        let conn = db();
+        let founder = Dev::new(0xa1);
+        let owner_b = Dev::new(0xa2);
+        let (account_id, genesis_bytes, genesis_hash) = genesis(&founder);
+        account_ingest(&conn, &genesis_bytes, NOW).unwrap();
+
+        // A second owner; the DeviceAdd mints its incarnation, and that hash is its `owner_id`.
+        let (add_b, owner_b_id) = op(
+            account_id,
+            &founder,
+            1,
+            Some(genesis_hash),
+            Some(genesis_hash),
+            &device_add(&owner_b, DeviceRole::Owner),
+        );
+        account_ingest(&conn, &add_b, NOW + 1).unwrap();
+
+        // `owner_b` snapshots under its own incarnation, BEFORE any revocation.
+        let snapshot_hash = author_snapshot_over(&conn, account_id, &owner_b, owner_b_id, |_| {});
+        let usable = usable_snapshots(&conn, account_id).unwrap();
+        assert_eq!(usable.len(), 1, "an open incarnation's snapshot is usable");
+        assert_eq!(usable[0].entry_hash, snapshot_hash);
+        assert_eq!(
+            selected_snapshot(&conn, account_id).unwrap().map(|s| s.entry_hash),
+            Some(snapshot_hash),
+        );
+
+        // The founder closes that incarnation. The snapshot is untouched and still verifies against
+        // local history — its claim was never false — but the authority it was authored under is
+        // gone.
+        let (demote_bytes, _) = op(
+            account_id,
+            &founder,
+            2,
+            Some(owner_b_id),
+            Some(genesis_hash),
+            &owner_demote(&owner_b, owner_b_id),
+        );
+        account_ingest(&conn, &demote_bytes, NOW + 3).unwrap();
+
+        assert_eq!(
+            verify_stored_snapshots(&conn, account_id).unwrap(),
+            vec![(snapshot_hash, snapshot::verify::SnapshotVerdict::Verified)],
+            "the claim is still true — revocation is about authority, not correctness",
+        );
+        assert!(
+            usable_snapshots(&conn, account_id).unwrap().is_empty(),
+            "a pre-revocation snapshot dies with its incarnation, not at a watermark",
+        );
+        assert_eq!(selected_snapshot(&conn, account_id).unwrap(), None);
+        assert_eq!(
+            status(&conn, &snapshot_hash).as_deref(),
+            Some("retained_unfolded"),
+            "and it is still stored — usability decides trust, never storage",
         );
     }
 


### PR DESCRIPTION
Completes the read side of C6b, part of #609: which stored snapshots may be acted on, and which one to pick.

## Usability is incarnation-scoped, and that is forced rather than chosen

Registers are minted per log and `ChainKind` has no annex variant, so **no control op can cut an annex chain** — a revoked device's snapshots cannot be condemned by watermark the way its control entries are, and adding a `snapshot_cut` would mean changing a frozen C1 payload.

So a snapshot is usable only while the owner incarnation it cites is **open**, and closing that incarnation kills every snapshot authored under it — including ones authored long before the revocation. Coarser than a beyond-cut boundary, and for a claim about folded state that is the safer direction: a compromised-then-removed owner's snapshots all die at once rather than staying trusted up to a cut. The cost is availability only, since snapshots are re-derivable and every peer still holds full history this phase.

The test pins the sharp part: after the incarnation closes, the snapshot **still verifies** — its claim was never false — but is no longer usable, and is **still stored**. Usability decides trust, never storage.

## Selection orders by coverage, not by an asserted counter

The view epoch was dropped earlier because its true value is derivable only from the fold it claims to order — a second source that can disagree with the first, the same disease the `folded_state_hash` design refused when it kept the authority frontier *inside* the hash. It also had no answer for two owners concurrently claiming the same epoch.

Coverage is derivable, so it is used directly: one snapshot **dominates** another when it covers every target the other does and reaches at least as far on every device. That is a partial order, which is enough — a selector needs a deterministic *pick*, never a total order. Dominated candidates are discarded and the survivors are broken by `entry_hash`, so two devices holding the same usable set choose the same snapshot. There is an explicit order-independence test.

## Ranking counts only verified targets

Codex caught this as a P2 and it was a real hole. Verification skips targets it has no projection for (secrets, and content until #406) without affecting the verdict — so if selection counted them, an author could pad a manifest with fabricated coverage and outrank an honest control-only snapshot **on claims nobody checked**.

`is_supported_target` is now the single source of truth, with verification and selection as its two consumers, and `usable_snapshots` carries only the verified subset into the selector.

## Verification

- `cargo nextest run --workspace`: 3,547 passed.
- Both CI clippy invocations with `-D warnings`: exit 0.
- Nightly rustfmt `--check`: clean.
- Codex review folded before push; clean on re-run.

One test-setup note worth recording: my first revocation test had `owner_b` demoting the founder, which the fold rejected as `stale_authority`. The working pattern in this codebase is the founder demoting the other owner — copied from the existing `owner_control_authority` test rather than guessing at the authority rules.

Remaining in C6: the seeded fold with its mandatory full-refold fallback triggers (C6b-iv, the risk-carrying slice), and C6c's typed `FoldWorkExceeded` outcome.