### PR TITLE
perf(watch): add a minimum inter-pass cooldown to the watcher event loop

### DIFF
--- a/crates/rag-rat-base/src/config/raw.rs
+++ b/crates/rag-rat-base/src/config/raw.rs
@@ -214,6 +214,7 @@ pub(crate) struct RawWatch {
     debounce_ms: Option<u64>,
     max_latency_ms: Option<u64>,
     periodic_sweep_secs: Option<u64>,
+    pass_cooldown_secs: Option<u64>,
 }
 
 impl From<RawWatch> for WatchConfig {
@@ -224,6 +225,7 @@ impl From<RawWatch> for WatchConfig {
             debounce_ms: raw.debounce_ms.unwrap_or(default.debounce_ms),
             max_latency_ms: raw.max_latency_ms.unwrap_or(default.max_latency_ms),
             periodic_sweep_secs: raw.periodic_sweep_secs.unwrap_or(default.periodic_sweep_secs),
+            pass_cooldown_secs: raw.pass_cooldown_secs.unwrap_or(default.pass_cooldown_secs),
         }
     }
 }

--- a/crates/rag-rat-base/src/config/tests.rs
+++ b/crates/rag-rat-base/src/config/tests.rs
@@ -2174,6 +2174,7 @@ fn watch_config_defaults_on_and_parses_overrides() {
     assert_eq!(default.debounce_ms, 400);
     assert_eq!(default.max_latency_ms, 2500);
     assert_eq!(default.periodic_sweep_secs, 300);
+    assert_eq!(default.pass_cooldown_secs, 60);
 
     let raw: RawConfig = toml::from_str(
         r#"
@@ -2185,6 +2186,7 @@ fn watch_config_defaults_on_and_parses_overrides() {
             debounce_ms = 750
             max_latency_ms = 4000
             periodic_sweep_secs = 0
+            pass_cooldown_secs = 5
             "#,
     )
     .unwrap();
@@ -2194,6 +2196,7 @@ fn watch_config_defaults_on_and_parses_overrides() {
         debounce_ms: 750,
         max_latency_ms: 4000,
         periodic_sweep_secs: 0,
+        pass_cooldown_secs: 5,
     });
 }
 

--- a/crates/rag-rat-base/src/config/types.rs
+++ b/crates/rag-rat-base/src/config/types.rs
@@ -245,11 +245,24 @@ pub struct WatchConfig {
     /// event-blind filesystems (NFS, WSL2 `/mnt`) and a watcher that missed events, and bounds how
     /// long a wedged peer can leave the index stale.
     pub periodic_sweep_secs: u64,
+    /// Minimum seconds between watcher passes (0 disables): the next event-driven pass dispatches
+    /// no sooner than this long after the previous pass completed, so sustained editing (an agent
+    /// rewriting files for hours) can't run minutes-long passes back-to-back. Trade-off: edits
+    /// landing right after a pass wait up to the cooldown before indexing starts;
+    /// `periodic_sweep_secs` remains the staleness bound, and the periodic sweep is never held
+    /// back by the cooldown.
+    pub pass_cooldown_secs: u64,
 }
 
 impl Default for WatchConfig {
     fn default() -> Self {
-        Self { enabled: true, debounce_ms: 400, max_latency_ms: 2500, periodic_sweep_secs: 300 }
+        Self {
+            enabled: true,
+            debounce_ms: 400,
+            max_latency_ms: 2500,
+            periodic_sweep_secs: 300,
+            pass_cooldown_secs: 60,
+        }
     }
 }
 

--- a/crates/rag-rat-cli/src/init/render.rs
+++ b/crates/rag-rat-cli/src/init/render.rs
@@ -81,7 +81,8 @@ pub(crate) fn render_config(plan: &InitPlan) -> String {
         "# Background file watcher — keeps the index fresh as files change (defaults shown).\n# \
          [watch]\n# enabled = true\n# debounce_ms = 400           # quiet window before a reindex \
          pass\n# max_latency_ms = 2500       # force a pass after this much continuous \
-         activity\n# periodic_sweep_secs = 300   # backstop pass interval, 0 disables\n\n",
+         activity\n# periodic_sweep_secs = 300   # backstop pass interval, 0 disables\n# \
+         pass_cooldown_secs = 60     # minimum gap between event-driven passes, 0 disables\n\n",
     );
 
     text.push_str(

--- a/crates/rag-rat-core/src/watch/event_loop.rs
+++ b/crates/rag-rat-core/src/watch/event_loop.rs
@@ -14,7 +14,7 @@ use rag_rat_papertrail::AutosyncRequest;
 use super::overlay::OverlayScope;
 use super::papertrail::{self, PapertrailClock, PapertrailScheduler};
 use super::pass::{
-    Debounce, LoopMsg, PassRequest, PassScheduler, SKIP_TIMEOUT, SweepClock,
+    Debounce, LoopMsg, PassCooldown, PassRequest, PassScheduler, SKIP_TIMEOUT, SweepClock,
     maintenance_pass_scoped, spawn_pass_worker, startup_catchup_pass,
 };
 use super::placement::{
@@ -360,6 +360,15 @@ impl<W: notify::Watcher> EventLoop<'_, W> {
         let periodic = (self.config.watch.periodic_sweep_secs > 0)
             .then(|| Duration::from_secs(self.config.watch.periodic_sweep_secs));
         let mut sweep = SweepClock::new(periodic, Instant::now());
+        // Minimum inter-pass cooldown (#823): the next event-driven pass dispatches no sooner
+        // than this long after the previous pass completed, so sustained editing can't run
+        // passes back-to-back off a debounce that elapsed mid-pass. Watcher-event-loop-only:
+        // the startup catch-up (dispatched before this loop) and the hook/CLI
+        // `maintenance_pass*` entry points are not rate-limited.
+        let mut cooldown = PassCooldown::new(
+            (self.config.watch.pass_cooldown_secs > 0)
+                .then(|| Duration::from_secs(self.config.watch.pass_cooldown_secs)),
+        );
         // The papertrail evaluation deadline (#592): fires even on a filesystem-idle watcher, so
         // the freshness probe and the daily full-walk backstop run on time without any events.
         let mut papertrail_clock =
@@ -395,7 +404,13 @@ impl<W: notify::Watcher> EventLoop<'_, W> {
                     .unwrap_or(IDLE_WAIT)
             } else {
                 [
-                    debounce.due_in(now),
+                    // The debounce deadline is floored by the cooldown's remaining time (#823):
+                    // a debounce that elapsed during the pass stays fireable while dispatch is
+                    // held back, so an unfloored deadline would wake the loop every iteration —
+                    // the same spin the in-flight branch above avoids. The sweep deadline is
+                    // deliberately NOT floored: the periodic backstop overrides the cooldown, so
+                    // its wake must arrive on time.
+                    cooldown.gate_debounce_wait(&debounce, now),
                     fleet_debounce.due_in(now),
                     sweep.due_in(now),
                     papertrail_clock.due_in(now),
@@ -469,7 +484,12 @@ impl<W: notify::Watcher> EventLoop<'_, W> {
                 Ok(LoopMsg::Fs(Err(_))) => {},
                 Ok(LoopMsg::PassDone) => {
                     self.scheduler.on_done();
-                    sweep.on_pass_done(Instant::now());
+                    let done_at = Instant::now();
+                    sweep.on_pass_done(done_at);
+                    // The cooldown counts from pass COMPLETION (#823) — the armed debounce below
+                    // is typically long-elapsed by now, and without this the next iteration
+                    // would dispatch the follow-up immediately, back-to-back.
+                    cooldown.on_pass_done(done_at);
                     // Refresh the live linked-worktree set after every pass. Existing checkout
                     // paths can switch branches and therefore branch-local target sets; rebuilding
                     // the state keeps classification, ignore matchers, and watch placement in one
@@ -513,7 +533,10 @@ impl<W: notify::Watcher> EventLoop<'_, W> {
                 }
             }
             let periodic_due = sweep.due(now);
-            if debounce.should_fire(now) || periodic_due {
+            // The cooldown (#823) holds back only the DEBOUNCE-driven dispatch; a due periodic
+            // sweep dispatches regardless — the missed-event backstop is never starved by the
+            // cooldown.
+            if periodic_due || (debounce.should_fire(now) && cooldown.ready(now)) {
                 // The periodic sweep is the missed-event backstop, so it refreshes every overlay;
                 // an event-driven pass carries the roots accumulated above (#577). When both are
                 // due at once, `All` is the superset — and because the sweep clock counts from

--- a/crates/rag-rat-core/src/watch/mod.rs
+++ b/crates/rag-rat-core/src/watch/mod.rs
@@ -41,9 +41,10 @@ pub(crate) use papertrail::{PapertrailClock, PapertrailScheduler, papertrail_tic
 pub use pass::{CLONE_GRAPH_QUIET_MS, maintenance_pass, maintenance_pass_or_skip};
 #[cfg(test)]
 pub(crate) use pass::{
-    Debounce, GC_EVERY_PASSES, LoopMsg, PassRequest, PassScheduler, STARTUP_CATCHUP_RUN_GC,
-    SweepClock, base_embedding_backlog_needs_tail, base_tail_forced_by_state, maybe_checkpoint_wal,
-    should_run_base_tail, spawn_pass_worker, startup_catchup_pass,
+    Debounce, GC_EVERY_PASSES, LoopMsg, PassCooldown, PassRequest, PassScheduler,
+    STARTUP_CATCHUP_RUN_GC, SweepClock, base_embedding_backlog_needs_tail,
+    base_tail_forced_by_state, maybe_checkpoint_wal, should_run_base_tail, spawn_pass_worker,
+    startup_catchup_pass,
 };
 #[cfg(test)]
 pub(crate) use placement::{

--- a/crates/rag-rat-core/src/watch/pass.rs
+++ b/crates/rag-rat-core/src/watch/pass.rs
@@ -110,6 +110,64 @@ impl SweepClock {
     }
 }
 
+/// Minimum inter-pass cooldown (#823), pure like [`SweepClock`] (clock injected). A debounce armed
+/// by mid-pass events survives the whole (minutes-long) pass — it resets only on dispatch — so on
+/// `PassDone` the loop would otherwise find it long-elapsed and dispatch the coalesced follow-up
+/// immediately, running passes back-to-back for as long as editing continues (107 passes in ~5 h
+/// measured under continuous agent editing). This clock holds the next EVENT-driven dispatch until
+/// the cooldown has elapsed since the previous pass COMPLETED.
+///
+/// Only the watcher event loop consults it: the periodic sweep bypasses it (the missed-event
+/// backstop must never be starved by the cooldown), and the startup catch-up pass and the
+/// hook/CLI `maintenance_pass*` entry points are not rate-limited.
+#[derive(Debug)]
+pub(crate) struct PassCooldown {
+    /// `None` disables the cooldown (`pass_cooldown_secs = 0`) — dispatch is never held back.
+    cooldown: Option<Duration>,
+    /// When the most recent pass completed; `None` until the first completion (nothing to cool
+    /// down from).
+    last_pass_done: Option<Instant>,
+}
+
+impl PassCooldown {
+    pub(crate) fn new(cooldown: Option<Duration>) -> Self {
+        Self { cooldown, last_pass_done: None }
+    }
+
+    /// A pass completed; event-driven dispatch is held back until the cooldown elapses from here.
+    pub(crate) fn on_pass_done(&mut self, now: Instant) {
+        self.last_pass_done = Some(now);
+    }
+
+    /// `None` when no cooldown is pending — disabled, no pass completed yet, or a configured
+    /// duration so large the deadline overflows `Instant` arithmetic (degrades to "not held
+    /// back", never a panic in the watcher's wait computation).
+    fn ready_at(&self) -> Option<Instant> {
+        self.last_pass_done?.checked_add(self.cooldown?)
+    }
+
+    /// Whether an event-driven dispatch may go ahead (`now >= last completion + cooldown`). The
+    /// periodic sweep must NOT consult this — the caller ORs its due-ness in front.
+    pub(crate) fn ready(&self, now: Instant) -> bool {
+        self.ready_at().is_none_or(|at| now >= at)
+    }
+
+    /// Time left until [`Self::ready`]; `Duration::ZERO` when already ready.
+    fn remaining(&self, now: Instant) -> Duration {
+        self.ready_at().map_or(Duration::ZERO, |at| at.saturating_duration_since(now))
+    }
+
+    /// The event-debounce slot of the loop's recv-wait: the debounce deadline floored by this
+    /// cooldown's remaining time. While the cooldown holds dispatch back, an already-elapsed
+    /// debounce stays fireable (it resets only on dispatch), so its raw `due_in` of zero would
+    /// wake the loop every iteration — the same spin the in-flight branch avoids by dropping the
+    /// debounce deadline entirely. Flooring makes the loop SLEEP until dispatch is allowed. An
+    /// idle debounce yields `None`: the cooldown alone never wakes the loop.
+    pub(crate) fn gate_debounce_wait(&self, debounce: &Debounce, now: Instant) -> Option<Duration> {
+        debounce.due_in(now).map(|due| due.max(self.remaining(now)))
+    }
+}
+
 /// What the event loop asks the pass worker to run (#506).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum PassRequest {

--- a/crates/rag-rat-core/src/watch/tests.rs
+++ b/crates/rag-rat-core/src/watch/tests.rs
@@ -2536,6 +2536,80 @@ fn scheduler_coalesces_fire_requests_while_a_pass_is_in_flight() {
 }
 
 #[test]
+fn the_pass_cooldown_holds_the_coalesced_follow_up_until_it_elapses() {
+    // #823: a debounce armed by mid-pass events survives the whole (minutes-long) pass — it
+    // resets only on dispatch — so at PassDone it is long past due and, unchecked, the coalesced
+    // follow-up dispatches back-to-back (107 passes in ~5 h measured). The cooldown gates that
+    // dispatch until it has elapsed since the pass COMPLETED.
+    let t0 = Instant::now();
+    let mut debounce = Debounce::new(Duration::from_millis(400), Duration::from_millis(2500));
+    let mut cooldown = PassCooldown::new(Some(Duration::from_secs(60)));
+
+    // Before any pass completes there is nothing to cool down from.
+    assert!(cooldown.ready(t0), "no completed pass yet — dispatch is not held back");
+
+    // An event lands while a pass is in flight; the debounce stays armed across the pass.
+    debounce.on_event(t0);
+    let pass_done = t0 + Duration::from_secs(120);
+    cooldown.on_pass_done(pass_done);
+
+    // Immediately after PassDone the debounce is long past due — the #823 precondition...
+    assert!(debounce.should_fire(pass_done), "the armed debounce elapsed during the pass");
+    // ...but the cooldown holds the dispatch until it elapses from the COMPLETION instant.
+    assert!(!cooldown.ready(pass_done), "no immediate back-to-back redispatch");
+    assert!(!cooldown.ready(pass_done + Duration::from_secs(59)));
+    assert!(cooldown.ready(pass_done + Duration::from_secs(60)), "ready once elapsed");
+}
+
+#[test]
+fn a_zero_pass_cooldown_preserves_immediate_redispatch() {
+    // `pass_cooldown_secs = 0` disables the gate entirely: the follow-up may dispatch at the
+    // very instant the pass completes — exactly the pre-#823 behavior (the loop-level pin is
+    // `a_pass_in_flight_does_not_starve_events_or_the_fleet_trigger`, which runs cooldown-free).
+    let mut cooldown = PassCooldown::new(None);
+    let t0 = Instant::now();
+    cooldown.on_pass_done(t0);
+    assert!(cooldown.ready(t0), "a disabled cooldown never holds dispatch back");
+    let mut armed = Debounce::new(Duration::from_millis(400), Duration::from_millis(2500));
+    armed.on_event(t0);
+    assert_eq!(
+        cooldown.gate_debounce_wait(&armed, t0),
+        Some(Duration::from_millis(400)),
+        "a disabled cooldown is transparent to the recv-wait — the raw debounce deadline stands",
+    );
+}
+
+#[test]
+fn a_held_back_debounce_sleeps_out_the_cooldown_instead_of_spinning() {
+    // #823 spin-avoidance: after PassDone the armed debounce is already past due while dispatch
+    // is held back, so the raw debounce deadline of zero would wake the loop every iteration.
+    // The recv-wait slot must be the cooldown's REMAINING time — the loop sleeps until dispatch
+    // is actually allowed (the injected-clock analogue of counting loop iterations).
+    let t0 = Instant::now();
+    let mut debounce = Debounce::new(Duration::from_millis(400), Duration::from_millis(2500));
+    let mut cooldown = PassCooldown::new(Some(Duration::from_secs(60)));
+    debounce.on_event(t0);
+    cooldown.on_pass_done(t0 + Duration::from_secs(120));
+
+    let mid_cooldown = t0 + Duration::from_secs(130);
+    assert_eq!(debounce.due_in(mid_cooldown), Some(Duration::ZERO), "debounce is past due");
+    assert_eq!(
+        cooldown.gate_debounce_wait(&debounce, mid_cooldown),
+        Some(Duration::from_secs(50)),
+        "the wait is the cooldown remainder, not a zero-length spin",
+    );
+    assert_eq!(
+        cooldown.gate_debounce_wait(&debounce, t0 + Duration::from_secs(180)),
+        Some(Duration::ZERO),
+        "once the cooldown elapses the past-due debounce fires without further delay",
+    );
+    // An idle debounce has no deadline: the cooldown alone never wakes the loop (there is
+    // nothing to dispatch when it elapses).
+    let idle = Debounce::new(Duration::from_millis(400), Duration::from_millis(2500));
+    assert_eq!(cooldown.gate_debounce_wait(&idle, mid_cooldown), None);
+}
+
+#[test]
 fn scheduler_gc_cadence_counts_maintenance_passes_only() {
     let mut scheduler = PassScheduler::new();
     assert_eq!(scheduler.dispatch_startup(), PassRequest::StartupCatchup);
@@ -2602,6 +2676,9 @@ fn a_pass_in_flight_does_not_starve_events_or_the_fleet_trigger() {
     config.watch.debounce_ms = 10;
     config.watch.max_latency_ms = 50;
     config.watch.periodic_sweep_secs = 0;
+    // This test pins #506 coalescing, not pacing: with the cooldown DISABLED the coalesced
+    // follow-up must dispatch immediately on PassDone — exactly the pre-#823 behavior.
+    config.watch.pass_cooldown_secs = 0;
     let target_dirs = config.target_directories();
     let mut ignore = IgnoreMatcher::compile(&config.root, &target_dirs);
     let mut linked_worktrees = LinkedWorktreeWatches::default();
@@ -2681,6 +2758,175 @@ fn a_pass_in_flight_does_not_starve_events_or_the_fleet_trigger() {
         let _ = tx.send(LoopMsg::Wake);
         let final_refresh_owed = loop_thread.join().unwrap();
         assert!(!final_refresh_owed, "every observed edit was consumed by a dispatched pass",);
+    });
+}
+
+/// The #823 regression, end-to-end: events arriving during a pass leave the debounce armed and
+/// long-elapsed at `PassDone`, and the loop used to dispatch the coalesced follow-up immediately —
+/// back-to-back passes for as long as editing continued. With a cooldown configured, the follow-up
+/// must wait it out (counted from pass COMPLETION) and then dispatch.
+#[test]
+fn events_during_a_pass_do_not_redispatch_until_the_cooldown_elapses() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let root = tmp.path();
+    std::fs::create_dir_all(root.join("src")).unwrap();
+    std::fs::write(root.join("src/lib.rs"), "pub fn f() {}\n").unwrap();
+
+    let mut config = whole_root_config(root, &[PathBuf::from("src")]);
+    config.watch.debounce_ms = 10;
+    config.watch.max_latency_ms = 50;
+    config.watch.periodic_sweep_secs = 0;
+    config.watch.pass_cooldown_secs = 2;
+    let target_dirs = config.target_directories();
+    let mut ignore = IgnoreMatcher::compile(&config.root, &target_dirs);
+    let mut linked_worktrees = LinkedWorktreeWatches::default();
+    let mut notify_watcher =
+        <RecordingWatcher as notify::Watcher>::new(|_| {}, notify::Config::default()).unwrap();
+    let (tx, rx) = std::sync::mpsc::channel();
+    let (pass_tx, pass_rx) = std::sync::mpsc::channel();
+    let pass_tx_for_loop = pass_tx.clone();
+    let mut scheduler = PassScheduler::new();
+    let stop = AtomicBool::new(false);
+    let mut fleet_trigger = |_: &Path| {};
+
+    let counters = placement_counters();
+    let event_loop = EventLoop {
+        config: &config,
+        target_dirs: &target_dirs,
+        fleet_bin: None,
+        notify_watcher: &mut notify_watcher,
+        counters: &counters,
+        ignore: &mut ignore,
+        linked_worktrees: &mut linked_worktrees,
+        worktree_registry: None,
+        rx,
+        pass_tx: &pass_tx_for_loop,
+        scheduler: &mut scheduler,
+        papertrail_tx: None,
+        papertrail_interval: None,
+        stop: &stop,
+        fleet_trigger: &mut fleet_trigger,
+    };
+    std::thread::scope(|scope| {
+        let loop_thread = scope.spawn(move || event_loop.run());
+
+        // A relevant edit dispatches the first pass (this test plays the worker).
+        tx.send(LoopMsg::Fs(Ok(mutation_event(root.join("src/lib.rs"))))).unwrap();
+        assert_eq!(
+            pass_rx.recv_timeout(Duration::from_secs(5)),
+            Ok(PassRequest::Maintenance {
+                run_gc: false,
+                overlay_scope: OverlayScope::Linked(BTreeSet::new())
+            }),
+        );
+
+        // More edits land while the pass is in flight — they coalesce into the armed debounce.
+        tx.send(LoopMsg::Fs(Ok(mutation_event(root.join("src/lib.rs"))))).unwrap();
+        // Let the debounce (10 ms) and even the max-latency cap (50 ms) elapse BEFORE the pass
+        // completes — the production shape: the pass runs minutes, so at PassDone the armed
+        // debounce is already past due and the loop's own PassDone iteration is where the
+        // back-to-back redispatch used to happen.
+        std::thread::sleep(Duration::from_millis(100));
+        tx.send(LoopMsg::PassDone).unwrap();
+
+        // The pre-#823 behavior was an immediate redispatch here. The follow-up must instead
+        // wait out the cooldown (2 s; the 700 ms probe leaves ample CI-jitter margin)...
+        assert_eq!(
+            pass_rx.recv_timeout(Duration::from_millis(700)),
+            Err(RecvTimeoutError::Timeout),
+            "the coalesced follow-up must not dispatch before the cooldown elapses",
+        );
+        // ...and then dispatch, carrying the coalesced scope.
+        assert_eq!(
+            pass_rx.recv_timeout(Duration::from_secs(10)),
+            Ok(PassRequest::Maintenance {
+                run_gc: false,
+                overlay_scope: OverlayScope::Linked(BTreeSet::new())
+            }),
+            "the follow-up dispatches once the cooldown elapses",
+        );
+
+        stop.store(true, Ordering::Relaxed);
+        // Best-effort wake: a timeout tick may have already observed `stop` and exited the loop,
+        // in which case `rx` is gone and this send fails — that is success, not an error.
+        let _ = tx.send(LoopMsg::Wake);
+        let final_refresh_owed = loop_thread.join().unwrap();
+        assert!(!final_refresh_owed, "the held-back edit was consumed by the delayed follow-up");
+    });
+}
+
+/// #823: the periodic sweep is the missed-event backstop and must never be starved by the
+/// cooldown. With an absurdly long cooldown armed by a completed pass, a due sweep still
+/// dispatches on time.
+#[test]
+fn a_due_periodic_sweep_overrides_the_pass_cooldown() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let root = tmp.path();
+    std::fs::create_dir_all(root.join("src")).unwrap();
+    std::fs::write(root.join("src/lib.rs"), "pub fn f() {}\n").unwrap();
+
+    let mut config = whole_root_config(root, &[PathBuf::from("src")]);
+    // No debounce fires (nothing event-driven); the sweep is due every second while the
+    // cooldown would hold event-driven dispatch for an hour.
+    config.watch.debounce_ms = 60_000;
+    config.watch.max_latency_ms = 60_000;
+    config.watch.periodic_sweep_secs = 1;
+    config.watch.pass_cooldown_secs = 3_600;
+    let target_dirs = config.target_directories();
+    let mut ignore = IgnoreMatcher::compile(&config.root, &target_dirs);
+    let mut linked_worktrees = LinkedWorktreeWatches::default();
+    let mut notify_watcher =
+        <RecordingWatcher as notify::Watcher>::new(|_| {}, notify::Config::default()).unwrap();
+    let (tx, rx) = std::sync::mpsc::channel();
+    let (pass_tx, pass_rx) = std::sync::mpsc::channel();
+    let pass_tx_for_loop = pass_tx.clone();
+    let mut scheduler = PassScheduler::new();
+    let stop = AtomicBool::new(false);
+    let mut fleet_trigger = |_: &Path| {};
+
+    let counters = placement_counters();
+    let event_loop = EventLoop {
+        config: &config,
+        target_dirs: &target_dirs,
+        fleet_bin: None,
+        notify_watcher: &mut notify_watcher,
+        counters: &counters,
+        ignore: &mut ignore,
+        linked_worktrees: &mut linked_worktrees,
+        worktree_registry: None,
+        rx,
+        pass_tx: &pass_tx_for_loop,
+        scheduler: &mut scheduler,
+        papertrail_tx: None,
+        papertrail_interval: None,
+        stop: &stop,
+        fleet_trigger: &mut fleet_trigger,
+    };
+    std::thread::scope(|scope| {
+        let handle = scope.spawn(move || event_loop.run());
+
+        // The first periodic sweep dispatches; completing it arms the hour-long cooldown.
+        assert_eq!(
+            pass_rx.recv_timeout(Duration::from_secs(5)),
+            Ok(PassRequest::Maintenance { run_gc: false, overlay_scope: OverlayScope::All }),
+        );
+        tx.send(LoopMsg::PassDone).unwrap();
+
+        // The next sweep falls due one second later — deep inside the cooldown — and must
+        // dispatch anyway: the backstop bypasses the cooldown.
+        assert_eq!(
+            pass_rx.recv_timeout(Duration::from_secs(5)),
+            Ok(PassRequest::Maintenance { run_gc: false, overlay_scope: OverlayScope::All }),
+            "a due periodic sweep must never be starved by the pass cooldown",
+        );
+
+        stop.store(true, Ordering::Relaxed);
+        // Best-effort wake: a timeout tick may have already observed `stop` and exited the loop,
+        // in which case `rx` is gone and this send fails — that is success, not an error.
+        let _ = tx.send(LoopMsg::Wake);
+        drop(tx);
+        drop(pass_tx);
+        let _ = handle.join();
     });
 }
 

--- a/docs/config/freshness.md
+++ b/docs/config/freshness.md
@@ -11,7 +11,14 @@ enabled = true        # on by default; false (or RAG_RAT_NO_WATCH=1) disables it
 debounce_ms = 400     # quiet window before a reindex pass
 max_latency_ms = 2500 # force a pass after this much continuous activity (starvation cap)
 periodic_sweep_secs = 300 # backstop pass at least this often (0 disables) — set for NFS/WSL
+pass_cooldown_secs = 60   # minimum gap between event-driven passes (0 disables)
 ```
+
+`pass_cooldown_secs` paces the watcher under sustained editing: the next event-driven pass starts
+no sooner than this long after the previous pass completed, so long agent sessions can't run
+minutes-long passes back-to-back. The trade-off is up to that much added indexing latency after a
+pass completes; `periodic_sweep_secs` remains the staleness bound, and the periodic sweep is never
+held back by the cooldown.
 
 The watcher runs inside `rag-rat mcp` automatically, and on demand via `rag-rat index --watch`. It
 watches the configured target directories recursively and runs the discover → reconcile → gc →


### PR DESCRIPTION
## Problem

A relevant fs event arms the debounce, and the arm survives the whole (minutes-long) maintenance pass — the debounce resets only on dispatch. When `PassDone` clears the in-flight slot, the next loop iteration finds the debounce long-elapsed and dispatches the coalesced follow-up immediately. Under continuous agent editing this runs passes back-to-back indefinitely: 107 consecutive passes in ~5 h measured in production.

## Change

- **`PassCooldown`** (`watch/pass.rs`): a pure, injected-clock cooldown mirroring `SweepClock`. It records the pass-completion instant in the `PassDone` handler and holds the next **event-driven** dispatch until `now >= last_pass_done + cooldown`.
- **Backstop exempt:** a due periodic sweep dispatches regardless of the cooldown — the missed-event backstop is never starved.
- **No busy-spin:** `gate_debounce_wait` floors the debounce's recv-wait slot with the cooldown's remaining time, so a still-fireable debounce sleeps until dispatch is allowed instead of waking the loop every iteration (the same spin-avoidance the in-flight branch already documents). The sweep deadline is deliberately not floored.
- **Scope:** watcher-event-loop-only. The startup catch-up pass and the hook/CLI `maintenance_pass*` entry points are not rate-limited (stated in code comments).
- **Config:** `[watch] pass_cooldown_secs` (default 60, 0 disables) with raw/serde plumbing, doc comments, the init template line, and `docs/config/freshness.md`.

## Trade-off

After a pass completes, fresh edits can wait up to the cooldown before indexing starts. `periodic_sweep_secs` remains the staleness bound, and the periodic sweep itself is never held back.

## Verification

- New tests: cooldown holds the coalesced follow-up until it elapses (pure + end-to-end through `EventLoop::run`), a due periodic sweep overrides the cooldown end-to-end, cooldown 0 preserves immediate redispatch (pure, plus the #506 coalescing test now pins the cooldown-free loop behavior), and the recv-wait floor returns the cooldown remainder — not zero — for a past-due debounce (the injected-clock no-spin proof).
- Fails-without-fix: with the fire-condition gate bypassed, `events_during_a_pass_do_not_redispatch_until_the_cooldown_elapses` fails — `assertion failed: the coalesced follow-up must not dispatch before the cooldown elapses; left: Ok(Maintenance {..}), right: Err(Timeout)` — and passes with the gate restored.
- `cargo nextest run -p rag-rat-core -p rag-rat-base`: 1653 passed; with `--no-default-features --locked`: 1651 passed; plain `cargo test --no-default-features --locked`: core 1475 + base 176 passed.
- CI-exact clippy, both legs (`--no-default-features` / `--all-features`, `--locked -- -D warnings`): clean. `cargo +nightly fmt --all --check`: clean.

Fixes #823