### PR TITLE
perf(index): compute the content digest once per FTS sync and reuse the quiet-gate probe's digest in the clone delta

### DIFF
--- a/crates/rag-rat-core/src/index/fts.rs
+++ b/crates/rag-rat-core/src/index/fts.rs
@@ -92,16 +92,29 @@ impl IndexDatabase {
     }
 
     pub fn sync_fts(&self) -> anyhow::Result<()> {
-        self.record_content_revision()?;
-        self.record_fts_current()?;
+        // ONE `main.files` digest per sync (#821): the recomputing `record_content_revision` +
+        // `record_fts_current` pair paid the identical full-table scan twice back-to-back on the
+        // same connection (and this runs on every incremental index and overlay refresh). Compute
+        // it once and stamp both freshness keys from the same value — byte-identical to the
+        // recomputing forms (same path-ordered `main.files` input), so `ensure_fts_fresh`'s
+        // digest comparison never churns on which path stamped last.
+        let revision = self.content_revision()?;
+        self.record_content_revision_value(&revision)?;
+        self.record_fts_current_value(&revision)?;
         self.set_meta("fts_dirty", "false")?;
         Ok(())
     }
 
     fn record_fts_current(&self) -> anyhow::Result<()> {
-        self.set_meta("fts_synced_at_ms", &now_ms().to_string())?;
         let revision = self.content_revision()?;
-        self.set_meta("fts_source_revision", &revision)?;
+        self.record_fts_current_value(&revision)
+    }
+
+    /// [`Self::record_fts_current`] with the digest already in hand (#821) — for `sync_fts`,
+    /// which stamps both freshness keys from one computed `content_revision()`.
+    fn record_fts_current_value(&self, revision: &str) -> anyhow::Result<()> {
+        self.set_meta("fts_synced_at_ms", &now_ms().to_string())?;
+        self.set_meta("fts_source_revision", revision)?;
         Ok(())
     }
 

--- a/crates/rag-rat-core/src/index/meta.rs
+++ b/crates/rag-rat-core/src/index/meta.rs
@@ -7,17 +7,110 @@ use rag_rat_db::meta::*;
 
 use super::*;
 
+/// A [`IndexDatabase::content_revision`] digest pinned to the connection state it was computed
+/// under (#821), so a LATER stage of the same pass can reuse the digest instead of paying the
+/// full `main.files` scan again — but only when nothing can have moved it in between. Consumed
+/// through [`IndexDatabase::content_revision_reusing`], which enforces the reuse rule.
+#[derive(Debug)]
+pub(crate) struct ContentRevisionSnapshot {
+    revision: String,
+    /// `PRAGMA data_version` at capture — moves iff ANOTHER connection committed to this
+    /// database since. The database is shared cross-process (and, consolidated, cross-repo:
+    /// a sibling repo's writer moves the GLOBAL digest without touching this repo's rows).
+    data_version: i64,
+    /// SQL `total_changes()` at capture — moves iff THIS connection wrote any row since.
+    total_changes: i64,
+}
+
 impl IndexDatabase {
     pub(super) fn record_content_revision(&self) -> anyhow::Result<String> {
         let revision = self.content_revision()?;
+        self.record_content_revision_value(&revision)?;
+        Ok(revision)
+    }
+
+    /// [`Self::record_content_revision`] with the digest already in hand (#821): `sync_fts`
+    /// computes ONE `main.files` digest and stamps both `content_revision` and
+    /// `fts_source_revision` from it instead of paying the full-table scan twice.
+    pub(super) fn record_content_revision_value(&self, revision: &str) -> anyhow::Result<()> {
         // GLOBAL, not per-repo (V040 reclassification): `content_revision()` digests the WHOLE
         // `main.files` (no repo filter — see the method below), so its stored value is scope- and
         // repo-invariant. V039 relocated it to `repo_meta` under the one-DB-per-repo assumption;
         // per-repo copies would make a consolidated DB's FTS freshness alternate. `set_meta` writes
         // the global `index_meta`. (V040's `move_repo_meta_keys_to_global` migrates any stale
         // per-repo copy back; the shared relocate helper no longer re-relocates it.)
-        self.set_meta("content_revision", &revision)?;
-        Ok(revision)
+        self.set_meta("content_revision", revision)
+    }
+
+    /// The connection's `PRAGMA data_version` — differs between two reads on THIS connection iff
+    /// ANOTHER connection committed to the database in between.
+    pub(super) fn connection_data_version(&self) -> anyhow::Result<i64> {
+        Ok(self.storage.connection().query_row("PRAGMA data_version", [], |row| row.get(0))?)
+    }
+
+    /// The connection's SQL `total_changes()` — moves iff THIS connection wrote any row.
+    fn connection_total_changes(&self) -> anyhow::Result<i64> {
+        Ok(self.storage.connection().query_row("SELECT total_changes()", [], |row| row.get(0))?)
+    }
+
+    /// Pin `revision` — a digest [`Self::content_revision`] just computed on this connection —
+    /// to the connection's current write state, for [`Self::content_revision_reusing`] (#821).
+    ///
+    /// `data_version_before_digest` is [`Self::connection_data_version`] captured BEFORE the
+    /// digest was computed: it brackets the digest against the cross-connection TOCTOU. Without
+    /// it, another connection committing between the digest read and this capture would bake the
+    /// NEW `data_version` into a pin whose digest describes the OLD rows — a later no-write
+    /// window would then validate the mismatched pin. When the bracket detects such a commit the
+    /// pin is refused (`None`) and the consumer recomputes.
+    pub(super) fn pin_content_revision(
+        &self,
+        revision: String,
+        data_version_before_digest: i64,
+    ) -> anyhow::Result<Option<ContentRevisionSnapshot>> {
+        let data_version = self.connection_data_version()?;
+        if data_version != data_version_before_digest {
+            return Ok(None);
+        }
+        Ok(Some(ContentRevisionSnapshot {
+            revision,
+            data_version,
+            total_changes: self.connection_total_changes()?,
+        }))
+    }
+
+    /// The pinned digest when it is PROVABLY still current, else a fresh recompute (#821).
+    ///
+    /// REUSE RULE: a pinned digest describes `main.files` only while nothing has written to the
+    /// database, and stages run between the pin and its consumer — in the watcher pass, the base
+    /// reconcile runs between the clone quiet-gate probe and the clone delta. No stage report
+    /// distinguishes "wrote `files` rows" (the reconcile's `"Current"` covers both a no-op and a
+    /// completed embedding run), and other processes share the database file. So the gate is the
+    /// connection's own counters: reuse ONLY when `PRAGMA data_version` (other connections) AND
+    /// `total_changes()` (this connection) both still match the capture — ANY intervening write,
+    /// `files` or not, forces the recompute. Conservative by design: a false negative costs one
+    /// redundant digest; a false positive would let the consumer stamp or compare a digest that
+    /// does not describe the rows it actually read.
+    pub(super) fn content_revision_reusing(
+        &self,
+        pinned: Option<&ContentRevisionSnapshot>,
+    ) -> anyhow::Result<String> {
+        // Validation order matters: own-connection `total_changes()` FIRST, the cross-connection
+        // `data_version` LAST — read last, it covers every sibling commit up to this moment, so
+        // the validation itself has no internal race window. What remains is the gap between
+        // this check and the consumer's own reads — the SAME gap the recompute path always had
+        // (a digest is computed, then consumed outside a transaction) — and it is benign: the
+        // consumer holds the per-repo write lock, so the rows it reads cannot move; only ANOTHER
+        // repo's rows in a consolidated DB can, which lags the GLOBAL freshness stamp by one
+        // pass (the next probe recomputes and the delta re-pins) and fails safe wherever the
+        // stamp is compared for exact freshness (an older-than-content stamp disables the
+        // postings fast path, never enables it).
+        if let Some(pinned) = pinned
+            && self.connection_total_changes()? == pinned.total_changes
+            && self.connection_data_version()? == pinned.data_version
+        {
+            return Ok(pinned.revision.clone());
+        }
+        self.content_revision()
     }
 
     /// Read a per-repo meta value (`repo_meta`) for the repo owning this connection — the ergonomic

--- a/crates/rag-rat-core/src/index/mod.rs
+++ b/crates/rag-rat-core/src/index/mod.rs
@@ -29,6 +29,9 @@ mod incremental;
 mod lifecycle;
 mod mem_diag;
 mod meta;
+// Crate-internal: a `content_revision()` digest pinned to its connection write-state, threaded
+// probe → clone delta by the watcher pass (#821).
+pub(crate) use meta::ContentRevisionSnapshot;
 mod migration_gate;
 mod packages;
 mod parser_failures;

--- a/crates/rag-rat-core/src/index/query_api/clones/delta.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/delta.rs
@@ -44,7 +44,7 @@ use super::substrate::{
     SymbolBag, add_struct_hash_pairs, load_scoped_baseline_bags_for_paths, overlap,
     sub_block_tokens, verified_clone,
 };
-use crate::index::IndexDatabase;
+use crate::index::{ContentRevisionSnapshot, IndexDatabase};
 
 /// SQLite bind-variable safety chunk for `IN (…)` lists (mirrors `of_text::HYDRATION_CHUNK`).
 const DELTA_SQL_CHUNK: usize = 400;
@@ -94,7 +94,22 @@ impl IndexDatabase {
     /// runs lock-stable outside a transaction, and all writes commit in ONE transaction, so a
     /// reader sees either the old graph or the fully-applied delta.
     pub fn apply_clone_graph_delta(&self, max_files: usize) -> anyhow::Result<CloneDeltaReport> {
-        self.apply_clone_graph_delta_inner(max_files, None)
+        self.apply_clone_graph_delta_inner(max_files, None, None)
+    }
+
+    /// [`Self::apply_clone_graph_delta`] reusing the digest the same pass's quiet-gate probe
+    /// already computed (#821): the probe and this delta run moments apart on the same
+    /// connection, and `content_revision()` is a full `main.files` scan. The pin is a HINT, not
+    /// an authority — [`Self::content_revision_reusing`] serves it only when the connection
+    /// counters prove no write (this connection's or another's) has intervened since capture,
+    /// and recomputes otherwise, so the base reconcile between probe and delta can never leave
+    /// this delta acting on a digest that no longer describes the `files` rows it reads.
+    pub(crate) fn apply_clone_graph_delta_reusing_revision(
+        &self,
+        max_files: usize,
+        pinned_revision: Option<&ContentRevisionSnapshot>,
+    ) -> anyhow::Result<CloneDeltaReport> {
+        self.apply_clone_graph_delta_inner(max_files, None, pinned_revision)
     }
 
     /// [`Self::apply_clone_graph_delta`] with an explicit posting-row work budget — the test seam
@@ -107,13 +122,14 @@ impl IndexDatabase {
         max_files: usize,
         posting_row_budget: u64,
     ) -> anyhow::Result<CloneDeltaReport> {
-        self.apply_clone_graph_delta_inner(max_files, Some(posting_row_budget))
+        self.apply_clone_graph_delta_inner(max_files, Some(posting_row_budget), None)
     }
 
     fn apply_clone_graph_delta_inner(
         &self,
         max_files: usize,
         posting_row_budget: Option<u64>,
+        pinned_revision: Option<&ContentRevisionSnapshot>,
     ) -> anyhow::Result<CloneDeltaReport> {
         let started = Instant::now();
         let conn = self.storage.connection();
@@ -161,7 +177,14 @@ impl IndexDatabase {
                 started,
             ));
         }
-        let revision = self.content_revision()?;
+        // The digest this delta settles freshness TOWARD — compared against the live
+        // generation's stamp above and written back as the new stamp below, so it MUST describe
+        // the `files` rows this delta reads. `content_revision_reusing` serves the probe's
+        // pinned digest only while the connection counters prove nothing wrote in between
+        // (see the reuse rule on that method); a stale stamp here would let a later content
+        // state that happens to equal it serve the postings fast path against edges built from
+        // different content.
+        let revision = self.content_revision_reusing(pinned_revision)?;
         if live.source_revision == revision {
             return Ok(CloneDeltaReport {
                 full_rebuild_owed: live.delta_files_applied >= CLONE_GRAPH_DRIFT_REBUILD_FILES,
@@ -831,7 +854,7 @@ impl<'a> CandidateHydrator<'a> {
 mod tests {
     use super::super::precompute::tests::{clone_fixture_config, edge_keys};
     use super::{
-        BTreeSet, CLONE_PRECOMPUTE_THETA, load_scoped_baseline_bags_for_paths, params,
+        BTreeSet, CLONE_PRECOMPUTE_THETA, Connection, load_scoped_baseline_bags_for_paths, params,
         sub_block_tokens,
     };
     use crate::index::query_api::clones::precompute::CloneEdgeOptions;
@@ -1449,6 +1472,155 @@ mod tests {
         assert!(
             report.posting_rows_fetched < report.posting_rows_requested,
             "shared tokens are served from the per-application cache: {report:?}"
+        );
+    }
+
+    /// The stamped `source_revision` of the live generation — what the delta compares and
+    /// re-pins, so it is the observable for whether a pinned digest was served or recomputed.
+    fn stamped_source_revision(db: &crate::IndexDatabase, generation: i64) -> String {
+        db.storage
+            .connection()
+            .query_row(
+                "SELECT source_revision FROM clone_graph_generations WHERE generation = ?1",
+                params![generation],
+                |row| row.get(0),
+            )
+            .unwrap()
+    }
+
+    /// #821 reuse leg: when NOTHING writes between the pin and the delta, the delta must serve
+    /// the pinned digest instead of recomputing. The pin carries a FABRICATED revision (the
+    /// fast path must disagree with the recompute fallback, or this test would pass through the
+    /// fallback): the only way the generation ends up stamped with it is the reuse actually
+    /// firing — a recomputing delta would see the real digest, find the generation current, and
+    /// Noop without stamping anything.
+    #[test]
+    fn clone_delta_reuses_the_probes_pinned_digest_when_nothing_wrote_in_between() {
+        let _poison = crate::index::poison_sibling::disable_poison_sibling();
+        let config = clone_fixture_config("delta-revision-reuse");
+        let db = crate::IndexDatabase::rebuild(&config).unwrap();
+        let built = db.precompute_clone_graph(None).unwrap();
+        assert_eq!(built.status, "Complete");
+
+        let before_digest = db.connection_data_version().unwrap();
+        let pinned = db
+            .pin_content_revision("fabricated-pinned-digest".to_string(), before_digest)
+            .unwrap()
+            .expect("no cross-connection commit intervened, so the pin is granted");
+        let report = db.apply_clone_graph_delta_reusing_revision(64, Some(&pinned)).unwrap();
+        // The fabricated digest reads as "revision moved, no clone-relevant path changed", so
+        // the delta re-pins the generation to it — proof the reuse path served the pin.
+        assert_eq!(report.status, "Applied", "{report:?}");
+        assert_eq!(
+            stamped_source_revision(&db, built.generation),
+            "fabricated-pinned-digest",
+            "an intact pin is served verbatim"
+        );
+    }
+
+    /// #821 invalidation leg, own connection: a `files` write AFTER the pin (in the watcher
+    /// pass, the base reconcile runs between the quiet-gate probe and this delta) voids the pin
+    /// — the delta must recompute rather than compare/stamp a digest that no longer describes
+    /// the rows it reads. The pin again carries a fabricated revision so unconditional reuse
+    /// cannot hide behind a correct answer: if the stale pin were served, the generation would
+    /// be stamped `fabricated-stale-digest`.
+    #[test]
+    fn clone_delta_recomputes_when_this_connection_writes_after_the_pin() {
+        let _poison = crate::index::poison_sibling::disable_poison_sibling();
+        let config = clone_fixture_config("delta-revision-stale-own");
+        let db = crate::IndexDatabase::rebuild(&config).unwrap();
+        let built = db.precompute_clone_graph(None).unwrap();
+        assert_eq!(built.status, "Complete");
+
+        let before_digest = db.connection_data_version().unwrap();
+        let pinned = db
+            .pin_content_revision("fabricated-stale-digest".to_string(), before_digest)
+            .unwrap()
+            .expect("no cross-connection commit intervened, so the pin is granted");
+        // The simulated mid-pass mutation: a files-row write on the SAME connection.
+        db.storage
+            .connection()
+            .execute("UPDATE main.files SET sha256 = sha256 || '-moved' WHERE path = 'src/a.rs'", [
+            ])
+            .unwrap();
+
+        let report = db.apply_clone_graph_delta_reusing_revision(64, Some(&pinned)).unwrap();
+        assert_eq!(report.status, "Applied", "{report:?}");
+        let stamped = stamped_source_revision(&db, built.generation);
+        assert_ne!(stamped, "fabricated-stale-digest", "a stale pin must not be served");
+        assert_eq!(
+            stamped,
+            db.content_revision().unwrap(),
+            "the delta recomputed the digest for the mutated files table"
+        );
+    }
+
+    /// #821 invalidation leg, cross-connection: the database file is shared across processes
+    /// (and, consolidated, across repos — `content_revision()` is GLOBAL), so a commit by
+    /// ANOTHER connection after the pin must also void it, even though this connection wrote
+    /// nothing.
+    #[test]
+    fn clone_delta_recomputes_when_another_connection_writes_after_the_pin() {
+        let _poison = crate::index::poison_sibling::disable_poison_sibling();
+        let config = clone_fixture_config("delta-revision-stale-other");
+        let db = crate::IndexDatabase::rebuild(&config).unwrap();
+        let built = db.precompute_clone_graph(None).unwrap();
+        assert_eq!(built.status, "Complete");
+
+        let before_digest = db.connection_data_version().unwrap();
+        let pinned = db
+            .pin_content_revision("fabricated-stale-digest".to_string(), before_digest)
+            .unwrap()
+            .expect("no cross-connection commit intervened, so the pin is granted");
+        // The simulated concurrent writer: a files-row write through a SECOND connection.
+        let other = Connection::open(&config.database).unwrap();
+        other.busy_timeout(std::time::Duration::from_secs(5)).unwrap();
+        other
+            .execute("UPDATE files SET sha256 = sha256 || '-moved' WHERE path = 'src/a.rs'", [])
+            .unwrap();
+        drop(other);
+
+        let report = db.apply_clone_graph_delta_reusing_revision(64, Some(&pinned)).unwrap();
+        assert_eq!(report.status, "Applied", "{report:?}");
+        let stamped = stamped_source_revision(&db, built.generation);
+        assert_ne!(stamped, "fabricated-stale-digest", "a stale pin must not be served");
+        assert_eq!(
+            stamped,
+            db.content_revision().unwrap(),
+            "the delta recomputed the digest after the cross-connection write"
+        );
+    }
+
+    /// #821 TOCTOU bracket: a cross-connection commit landing BETWEEN the digest computation and
+    /// the pin capture must refuse the pin outright. Without the pre-digest `data_version`
+    /// bracket, the pin would carry the NEW data_version with a digest of the OLD rows — and a
+    /// later no-write window would validate the mismatch and serve the stale digest.
+    #[test]
+    fn pin_is_refused_when_another_connection_commits_during_the_digest() {
+        let _poison = crate::index::poison_sibling::disable_poison_sibling();
+        let config = clone_fixture_config("delta-pin-toctou");
+        let db = crate::IndexDatabase::rebuild(&config).unwrap();
+
+        // The interleaving: guard captured, then another connection commits before the pin.
+        let before_digest = db.connection_data_version().unwrap();
+        let other = Connection::open(&config.database).unwrap();
+        other.busy_timeout(std::time::Duration::from_secs(5)).unwrap();
+        other
+            .execute("UPDATE files SET sha256 = sha256 || '-moved' WHERE path = 'src/a.rs'", [])
+            .unwrap();
+        drop(other);
+        assert!(
+            db.pin_content_revision("digest-of-the-old-rows".to_string(), before_digest)
+                .unwrap()
+                .is_none(),
+            "a commit inside the digest window refuses the pin"
+        );
+
+        // Control: with no interleaved commit the same bracket grants the pin.
+        let before_digest = db.connection_data_version().unwrap();
+        assert!(
+            db.pin_content_revision("digest".to_string(), before_digest).unwrap().is_some(),
+            "an undisturbed window grants the pin"
         );
     }
 }

--- a/crates/rag-rat-core/src/index/query_api/clones/precompute.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/precompute.rs
@@ -30,7 +30,7 @@ use super::substrate::{
     SymbolBag, load_clone_df_epoch, load_scoped_baseline_bags_with_df, overlap, sub_block_tokens,
     verified_clone,
 };
-use crate::index::IndexDatabase;
+use crate::index::{ContentRevisionSnapshot, IndexDatabase};
 
 /// θ the graph is precomputed at — the default `find_clones` threshold. Queries at θ ≥ this read
 /// the stored edges (filtering the exact gate inputs); θ below falls back to the live path.
@@ -42,6 +42,17 @@ const DEFAULT_BATCH_SIZE: usize = 512;
 /// observation and when it was first observed (epoch ms).
 const CLONE_GRAPH_QUIET_REVISION_META: &str = "clone_graph_quiet_candidate_revision";
 const CLONE_GRAPH_QUIET_SINCE_META: &str = "clone_graph_quiet_candidate_since_ms";
+
+/// One #472 quiet-gate probe outcome (#821): whether the deferred FULL rebuild is due, plus the
+/// content digest the probe computed — pinned to the connection state — so the SAME pass's clone
+/// delta can reuse it instead of paying the `main.files` digest scan again. `revision` is `None`
+/// when the gate short-circuited without probing (nothing armed, no probe permission) or the
+/// probe errored ([`Default`] is the caller's error fallback).
+#[derive(Debug, Default)]
+pub(crate) struct CloneGraphRebuildProbe {
+    pub(crate) due: bool,
+    pub(crate) revision: Option<ContentRevisionSnapshot>,
+}
 
 /// Soft per-pass budget + checkpoint granularity for one
 /// [`IndexDatabase::reconcile_clone_edges_pass`].
@@ -207,50 +218,83 @@ impl IndexDatabase {
         quiet_ms: i64,
         probe_without_candidate: bool,
     ) -> anyhow::Result<bool> {
-        self.clone_graph_rebuild_due_at(now_ms(), quiet_ms, probe_without_candidate)
+        Ok(self.clone_graph_rebuild_probe(quiet_ms, probe_without_candidate)?.due)
+    }
+
+    /// [`Self::clone_graph_rebuild_due`] returning the probe's full outcome (#821): the due
+    /// verdict PLUS the content digest the probe computed, pinned to the connection state, so
+    /// the same pass's clone delta can reuse the digest instead of re-scanning `main.files` —
+    /// see [`Self::apply_clone_graph_delta_reusing_revision`].
+    pub(crate) fn clone_graph_rebuild_probe(
+        &self,
+        quiet_ms: i64,
+        probe_without_candidate: bool,
+    ) -> anyhow::Result<CloneGraphRebuildProbe> {
+        self.clone_graph_rebuild_probe_at(now_ms(), quiet_ms, probe_without_candidate)
     }
 
     /// [`Self::clone_graph_rebuild_due`] with the clock injected (tests).
-    ///
-    /// "Owed" here means a FULL rebuild: the graph is stale in a way the #473 delta can't settle
-    /// (absent / normalizer bump / postings gap), OR the live generation has absorbed enough
-    /// delta files ([`CLONE_GRAPH_DRIFT_REBUILD_FILES`]) that its frozen df epoch owes a refresh.
-    /// A merely revision-stale-but-delta-eligible graph also arms here — if the delta settles it
-    /// first, the next probe sees it current and disarms.
+    #[cfg(test)]
     pub(crate) fn clone_graph_rebuild_due_at(
         &self,
         now_ms: i64,
         quiet_ms: i64,
         probe_without_candidate: bool,
     ) -> anyhow::Result<bool> {
+        Ok(self.clone_graph_rebuild_probe_at(now_ms, quiet_ms, probe_without_candidate)?.due)
+    }
+
+    /// [`Self::clone_graph_rebuild_probe`] with the clock injected.
+    ///
+    /// "Owed" here means a FULL rebuild: the graph is stale in a way the #473 delta can't settle
+    /// (absent / normalizer bump / postings gap), OR the live generation has absorbed enough
+    /// delta files ([`CLONE_GRAPH_DRIFT_REBUILD_FILES`]) that its frozen df epoch owes a refresh.
+    /// A merely revision-stale-but-delta-eligible graph also arms here — if the delta settles it
+    /// first, the next probe sees it current and disarms.
+    fn clone_graph_rebuild_probe_at(
+        &self,
+        now_ms: i64,
+        quiet_ms: i64,
+        probe_without_candidate: bool,
+    ) -> anyhow::Result<CloneGraphRebuildProbe> {
         let candidate = self.clone_graph_quiet_candidate()?;
         if candidate.is_none() && !probe_without_candidate {
-            return Ok(false);
+            return Ok(CloneGraphRebuildProbe::default());
         }
+        // Captured BEFORE the digest: brackets it against a cross-connection commit landing
+        // between the digest read and the pin capture (see `pin_content_revision`).
+        let data_version_before_digest = self.connection_data_version()?;
         let revision = self.content_revision()?;
         let drifted = {
             let conn = self.storage.connection();
             live_generation_row(conn)?
                 .is_some_and(|live| live.delta_files_applied >= CLONE_GRAPH_DRIFT_REBUILD_FILES)
         };
-        if !self.clone_graph_stale_against(&revision)? && !drifted {
+        let due = if !self.clone_graph_stale_against(&revision)? && !drifted {
             if candidate.is_some() {
                 self.clear_clone_graph_quiet_candidate()?;
             }
-            return Ok(false);
-        }
-        if quiet_ms == 0 {
-            return Ok(true);
-        }
-        match candidate {
-            Some((armed_revision, since_ms)) if armed_revision == revision =>
-                Ok(now_ms.saturating_sub(since_ms) >= quiet_ms),
-            _ => {
-                self.set_repo_meta(CLONE_GRAPH_QUIET_REVISION_META, &revision)?;
-                self.set_repo_meta(CLONE_GRAPH_QUIET_SINCE_META, &now_ms.to_string())?;
-                Ok(false)
-            },
-        }
+            false
+        } else if quiet_ms == 0 {
+            true
+        } else {
+            match candidate {
+                Some((armed_revision, since_ms)) if armed_revision == revision =>
+                    now_ms.saturating_sub(since_ms) >= quiet_ms,
+                _ => {
+                    self.set_repo_meta(CLONE_GRAPH_QUIET_REVISION_META, &revision)?;
+                    self.set_repo_meta(CLONE_GRAPH_QUIET_SINCE_META, &now_ms.to_string())?;
+                    false
+                },
+            }
+        };
+        // Pin AFTER the gate's own bookkeeping writes (arming or clearing the quiet candidate):
+        // those touch repo_meta only, never `files`, but they bump `total_changes()` — pinning
+        // before them would make the reuse check read the probe's own writes as an intervening
+        // mutation and never fire. The pre-digest `data_version` bracket still guards the whole
+        // window against other connections.
+        let revision = self.pin_content_revision(revision, data_version_before_digest)?;
+        Ok(CloneGraphRebuildProbe { due, revision })
     }
 
     /// Whether the #472 quiet gate holds an armed candidate. Watch-level tests assert the #817

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/reconcile_embeddings.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/reconcile_embeddings.rs
@@ -1578,3 +1578,33 @@ fn count_paths_fetch_text_only_for_rows_that_reach_a_text_gate() {
 
     let _ = fs::remove_dir_all(root);
 }
+
+/// #821 digest parity: `sync_fts` computes ONE `main.files` digest and stamps BOTH freshness
+/// keys (`content_revision`, `fts_source_revision`) from it. The stamps must be byte-identical
+/// to what the recomputing form produces from the same table state — that identity is what keeps
+/// `ensure_fts_fresh`'s digest comparison from churning on which path stamped last.
+#[test]
+fn sync_fts_threaded_digest_matches_the_recomputing_form_byte_for_byte() {
+    // Whole-DB-digest assertions; the poison-sibling harness would legitimately move the fresh
+    // digest after rebuild. Opt out (same rationale as the revision-metadata test above).
+    let _poison = crate::index::poison_sibling::disable_poison_sibling();
+    let (root, config) = markdown_config("parity token");
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    // Poison both stamps so the assertions below can only pass if `sync_fts` rewrote them.
+    db.set_meta("content_revision", "poisoned-stale").unwrap();
+    db.set_meta("fts_source_revision", "poisoned-stale").unwrap();
+    db.sync_fts().unwrap();
+    let threaded_content = db.meta("content_revision").unwrap().unwrap();
+    let threaded_fts = db.meta("fts_source_revision").unwrap().unwrap();
+    assert_eq!(threaded_content, threaded_fts, "one digest feeds both freshness keys");
+
+    // The recomputing form re-scans `main.files` and returns the digest it stamped.
+    let recomputed = db.record_content_revision().unwrap();
+    assert_eq!(
+        threaded_content, recomputed,
+        "the value-threaded stamp is byte-identical to a recompute over the same table state"
+    );
+
+    let _ = fs::remove_dir_all(root);
+}

--- a/crates/rag-rat-core/src/watch/pass.rs
+++ b/crates/rag-rat-core/src/watch/pass.rs
@@ -390,10 +390,13 @@ fn run_pass(
     // churn until a content, gc, or backlog pass arms it; an ALREADY-ARMED candidate still probes
     // on every pass — candidate presence bypasses the permission — so a quiet-elapsed owed
     // rebuild lands even mid-churn. When nothing is armed and nothing grants permission the gate
-    // costs one meta read.
-    let clone_graph_due = db
-        .clone_graph_rebuild_due(CLONE_GRAPH_QUIET_MS, base_tail_forced || base_embedding_backlog)
-        .unwrap_or(false);
+    // costs one meta read. When it DOES probe, the probe hands back the content digest it
+    // computed (pinned to the connection state) so the clone delta below can reuse it instead of
+    // paying the corpus-scale `main.files` digest a second time this pass (#821).
+    let clone_probe = db
+        .clone_graph_rebuild_probe(CLONE_GRAPH_QUIET_MS, base_tail_forced || base_embedding_backlog)
+        .unwrap_or_default();
+    let clone_graph_due = clone_probe.due;
     // Idle backstop (issue #63, facet 2): when the sweep changed nothing, skip everything past
     // discovery — an idle server should do no work. `run_gc` (every GC_EVERY_PASSES) still forces
     // a full tail, so the cases that DON'T flip content_changed are still caught within that
@@ -439,9 +442,15 @@ fn run_pass(
         // quiet window (`clone_graph_due`) so sustained editing defers it instead of
         // treadmilling. Best-effort + resumable, with whatever budget the embedding reconcile
         // left (shared PASS_RECONCILE_MAX_SECONDS so a pass can't overrun); `None` budget → rides
-        // the next pass.
+        // the next pass. The quiet-gate probe's pinned digest is threaded in (#821); the base
+        // reconcile above ran in between, so the delta reuses it only when the connection
+        // counters prove no write intervened — see `content_revision_reusing` — and recomputes
+        // otherwise.
         let clone_full_rebuild_owed = match timings.stage("clone_delta", || {
-            db.apply_clone_graph_delta(crate::index::CLONE_DELTA_MAX_FILES)
+            db.apply_clone_graph_delta_reusing_revision(
+                crate::index::CLONE_DELTA_MAX_FILES,
+                clone_probe.revision.as_ref(),
+            )
         }) {
             Ok(delta) if delta.status == "Applied" || delta.status == "Noop" =>
                 delta.full_rebuild_owed,


### PR DESCRIPTION
## Problem

`content_revision()` is a full scan of live `main.files` rows (`group_concat(path||':'||sha256 ORDER BY path)` + SHA-256), and one watcher tail pass recomputed it up to four times on the same connection:

- twice inside `sync_fts` — `record_content_revision` computed it, then `record_fts_current` immediately recomputed it (and `sync_fts` runs on every incremental index and overlay refresh);
- once in the #472 clone quiet-gate probe (`clone_graph_rebuild_due`);
- once in `apply_clone_graph_delta`, moments after the probe.

None of them reused a value already in hand. The scan is O(files): ~10 ms warm per scan on this repo's consolidated index (~2k live file rows, 222 KB digest input), growing linearly on larger corpora.

## Change

Two independent dedups, plus the invalidation rule that makes the second one sound:

**Inside `sync_fts`** — compute the digest once and stamp both freshness keys from the same value through new value-taking forms (`record_content_revision_value`, `record_fts_current_value`). The digest input is unchanged (path-ordered `main.files`), so the stamps stay byte-identical to the recomputing forms and `ensure_fts_fresh`'s comparison cannot churn. The recomputing forms remain for `rebuild_fts` / `finalize_full_rebuild_fts` and all other callers.

**Probe → delta threading** — the quiet-gate probe now returns the digest it computed as a `ContentRevisionSnapshot`, pinned to the connection's write state, and `run_pass` threads it into a new `apply_clone_graph_delta_reusing_revision`. On the reuse path the delta skips its own full-table scan. Overlay-only passes are unaffected (they neither probe nor run the tail, per #817), and the CLI maintenance path keeps the recomputing `apply_clone_graph_delta`.

**Invalidation rule** — the pin is a hint, never an authority. The base reconcile runs between the probe and the delta, and no stage status distinguishes a `files` write (the reconcile's `"Current"` covers both a no-op and a completed embedding run); the database file is also shared across processes and, consolidated, across repos. So `content_revision_reusing` serves the pin only while the connection's own counters prove nothing wrote in between — SQL `total_changes()` for this connection, `PRAGMA data_version` for every other connection — and recomputes otherwise. Two TOCTOU hardenings on top: the probe captures `data_version` *before* computing the digest and `pin_content_revision` refuses the pin if it moved (a sibling commit inside the digest window would otherwise bake the new counter into a pin describing old rows), and validation reads `total_changes()` first / `data_version` last so the cross-connection check covers every sibling commit up to the moment of the check. Acting on a stale digest is not just a delayed refresh: a stale `source_revision` stamp could later coincide with a content state it does not describe and let the postings fast path serve edges built from different content.

## Verification

- `cargo nextest run -p rag-rat-core` — 1483 passed (rebased on `main` including #847).
- `cargo test -p rag-rat-core --no-default-features --locked` — 1481 passed (the coverage job's shared-process runner).
- CI-exact clippy, both legs (`--workspace --all-targets --no-default-features --locked` and `--all-features`, `-D warnings`) — exit 0.
- `cargo +nightly fmt --all --check` — clean.
- New tests:
  - digest parity: after `sync_fts`, both meta rows equal a fresh recompute byte-for-byte;
  - reuse detector with a poisoned pin: the pin carries a fabricated digest, so the test passes only if the reuse path actually serves it (a recompute fallback would Noop and fail the test);
  - staleness, both legs: a same-connection `files` write and a cross-connection `files` write after the pin each force a recompute — both tests were verified to **fail** against a deliberately always-reuse variant of the gate, then the variant was reverted;
  - TOCTOU bracket: a cross-connection commit between the digest computation and the pin capture refuses the pin outright.
- Existing clone-graph quiet-gate tests and FTS freshness tests are unchanged and green (`clone_graph_rebuild_due_at`'s bool signature is preserved as a test shim over the probe).
- Measured on a copy of this repo's real consolidated index: one digest scan ≈ 10 ms warm over 1978 live file rows / 222 KB of digest input; the change removes up to 3 of the 4 scans on a content-changed/gc/backlog tail pass (probe reused by the delta, one instead of two in each `sync_fts`) with O(files) scaling on bigger corpora. The incrementally-maintained digest remains #828.

Fixes #821
