### PR TITLE
perf(index): rebuild logical symbols once per overlay batch; basis writes ride the refresh transaction

### DIFF
--- a/crates/rag-rat-cli/src/commands/index_ops.rs
+++ b/crates/rag-rat-cli/src/commands/index_ops.rs
@@ -49,6 +49,9 @@ pub(crate) fn index(config: &Config, args: &IndexArgs) -> anyhow::Result<()> {
         // not the launching process's base targets — a branch that adds/narrows targets must be
         // indexed by its own config or its overlay rows are filtered/pruned (#219 review).
         let overlay_config = config.for_linked_worktree_overlay(worktree);
+        // The standalone shape: a single-checkout command has no batch to deduplicate the
+        // logical-symbol rebuild across, so it stays INLINE — atomic with the overlay
+        // transaction (the watcher/`--paths` batch routes defer it to one run per pass).
         let report = db.index_worktree_overlay(&overlay_config, worktree, &mut progress)?;
         if report.worktree_id.is_empty() {
             anyhow::bail!(

--- a/crates/rag-rat-core/src/index/graph_index.rs
+++ b/crates/rag-rat-core/src/index/graph_index.rs
@@ -504,6 +504,8 @@ impl IndexDatabase {
     /// is captured fresh here. A leftover memo for a DIFFERENT repo (a consolidated-DB context
     /// switch) is discarded, not consumed.
     pub(super) fn rebuild_logical_symbols(&self, stamp: KeyVersionStamp) -> anyhow::Result<()> {
+        #[cfg(test)]
+        self.logical_symbol_rebuilds.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         let memoized = self.drift_snapshot.lock().expect("drift snapshot lock").take();
         let drift_snapshot = match memoized {
             Some((repo, snapshot)) if repo == self.active_repo_id => snapshot,
@@ -617,6 +619,17 @@ impl IndexDatabase {
                 self.set_repo_meta(LOGICAL_KEY_VERSION_KEY, LOGICAL_KEY_VERSION)?;
             }
         }
+        // ANY successful rebuild satisfies a pending batch-deferred obligation (#819) — the batch
+        // tail, an inline overlay refresh, a heal, an incremental or full pass — so clear the
+        // marker here, in the same transaction as the rebuild it accounts for. Left set, the next
+        // maintenance pass would pay a second wholesale rebuild for nothing (e.g. after an
+        // interrupted deferred batch whose stale grouping a standalone `index --worktree` already
+        // repaired inline). A no-op DELETE when no marker is set.
+        rag_rat_db::meta::delete_repo_meta(
+            conn,
+            &self.active_repo_id,
+            super::worktree_overlay::OVERLAY_LOGICAL_REBUILD_PENDING_META,
+        )?;
         Ok(())
     }
 

--- a/crates/rag-rat-core/src/index/incremental.rs
+++ b/crates/rag-rat-core/src/index/incremental.rs
@@ -417,6 +417,14 @@ impl IndexDatabase {
             healed,
             "incremental pass (reads hoisted out of the write transaction)"
         );
+        // Settle any pending overlay-batch logical rebuild before returning (#819 review): an
+        // interrupted Deferred overlay batch leaves its obligation committed, and this pass's
+        // own rebuild is gated on its row changes — an IDLE pass closes its empty transaction
+        // above and would otherwise exit past the marker, leaving branch-only symbols
+        // unresolvable until an unrelated pass rebuilt. Its own `BEGIN IMMEDIATE` (the pass's
+        // transaction is closed by now); write-free when nothing is pending (one meta read),
+        // so the #63 idle-pass posture holds. On failure the marker survives for the next pass.
+        db.apply_pending_logical_rebuild()?;
         Ok((db, content_changed))
     }
 

--- a/crates/rag-rat-core/src/index/lifecycle.rs
+++ b/crates/rag-rat-core/src/index/lifecycle.rs
@@ -178,6 +178,8 @@ impl IndexDatabase {
             config: None,
             _identity_lock: None,
             drift_snapshot: std::sync::Mutex::new(None),
+            #[cfg(test)]
+            logical_symbol_rebuilds: std::sync::atomic::AtomicUsize::new(0),
         };
         if matches!(mode, BareOpenMode::ConfigLess) {
             db.ensure_graph_index_current()?;
@@ -201,6 +203,8 @@ impl IndexDatabase {
             config: Some(config.clone()),
             _identity_lock: None,
             drift_snapshot: std::sync::Mutex::new(None),
+            #[cfg(test)]
+            logical_symbol_rebuilds: std::sync::atomic::AtomicUsize::new(0),
         };
         db.storage.set_source_root(config.root.clone());
         // Register/adopt BEFORE anything repo-scoped runs, then install the scope context so the
@@ -378,6 +382,8 @@ impl IndexDatabase {
             config: Some(config.clone()),
             _identity_lock: None,
             drift_snapshot: std::sync::Mutex::new(None),
+            #[cfg(test)]
+            logical_symbol_rebuilds: std::sync::atomic::AtomicUsize::new(0),
         };
         // Install the scope context BEFORE the heal-owed gates: `set_context` mirrors the resolved
         // `repo_id` into `temp.connection_context` (writable even on a read-only main DB), so the
@@ -538,6 +544,8 @@ impl IndexDatabase {
             config: None,
             _identity_lock: None,
             drift_snapshot: std::sync::Mutex::new(None),
+            #[cfg(test)]
+            logical_symbol_rebuilds: std::sync::atomic::AtomicUsize::new(0),
         })
     }
 

--- a/crates/rag-rat-core/src/index/mod.rs
+++ b/crates/rag-rat-core/src/index/mod.rs
@@ -84,7 +84,9 @@ pub use query_api::{
 };
 pub use schema::RegisteredRepo;
 pub(crate) use util::*;
-pub use worktree_overlay::WorktreeOverlayReport;
+pub use worktree_overlay::{
+    OverlayBasisUpdate, OverlayLogicalRebuild, OverlayRefreshTail, WorktreeOverlayReport,
+};
 
 #[cfg(test)]
 mod anchor_tests;
@@ -173,6 +175,10 @@ pub struct IndexDatabase {
     /// never pay the snapshot scan. Interior mutability because the deleters take `&self`.
     drift_snapshot:
         std::sync::Mutex<Option<(String, Option<Vec<graph_index::LogicalKeyDriftRow>>)>>,
+    /// Test-only #819 observability: how many times [`Self::rebuild_logical_symbols`] ran on this
+    /// connection, so batch tests can assert the once-per-pass rebuild cardinality.
+    #[cfg(test)]
+    pub(crate) logical_symbol_rebuilds: AtomicUsize,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_overlay.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_overlay.rs
@@ -1723,6 +1723,172 @@ fn inline_rebuild_satisfies_a_pending_deferred_obligation() {
 }
 
 #[test]
+fn standalone_unchanged_refresh_settles_a_pending_deferred_obligation() {
+    // #819 review P2: an interrupted Deferred batch leaves the pending marker committed. A
+    // standalone `index --worktree` (Inline) over the UNCHANGED checkout then has an EMPTY
+    // delta — `finalize_overlay_refresh` (and with it the inline rebuild, the sole marker
+    // clearer) is skipped entirely — so without the entry-point tail settle the run would
+    // exit leaving BOTH the marker and the stale `logical_symbols` in place: branch-only
+    // symbols invisible to symbol/graph queries until some unrelated pass consumed the
+    // marker. The invariant: EVERY indexing entry point settles a pending obligation before
+    // exiting, even when its own delta is empty.
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(main.join("src/a.rs"), "pub fn base_fn() {}\n").unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let config = source_config(main.clone(), Language::Rust);
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    fs::write(linked.join("src/new.rs"), "pub fn branch_only_fn() {}\n").unwrap();
+    run_git(&linked, &["add", "."]);
+    run_git(&linked, &["commit", "-q", "-m", "branch adds file"]);
+
+    // Interrupted deferred batch: rows + marker committed, the batch tail never runs.
+    let tail = crate::index::OverlayRefreshTail {
+        logical_rebuild: crate::index::OverlayLogicalRebuild::Deferred,
+        basis: None,
+    };
+    db.index_worktree_overlay_with_tail(&config, &linked, tail, &mut |_| {}).unwrap();
+    assert!(logical_rebuild_pending(&db), "the interrupted batch left its obligation");
+    assert!(!logical_symbol_named(&db, "branch_only_fn"), "the grouping is stale");
+
+    // The standalone (Inline) refresh over the SAME, unchanged worktree: zero row changes.
+    let before = db.logical_symbol_rebuilds.load(std::sync::atomic::Ordering::Relaxed);
+    let report = db.index_worktree_overlay(&config, &linked, &mut |_| {}).unwrap();
+    assert_eq!(report.indexed, 0, "unchanged checkout: the refresh itself writes no rows");
+    assert_eq!(
+        db.logical_symbol_rebuilds.load(std::sync::atomic::Ordering::Relaxed) - before,
+        1,
+        "the entry-point tail ran the ONE owed rebuild"
+    );
+    assert!(!logical_rebuild_pending(&db), "the standalone exit consumed the obligation");
+    assert!(logical_symbol_named(&db, "branch_only_fn"), "branch symbols are grouped again");
+
+    // Settled means settled: a second unchanged standalone run owes (and pays) nothing.
+    let idle = db.logical_symbol_rebuilds.load(std::sync::atomic::Ordering::Relaxed);
+    db.index_worktree_overlay(&config, &linked, &mut |_| {}).unwrap();
+    assert_eq!(
+        db.logical_symbol_rebuilds.load(std::sync::atomic::Ordering::Relaxed),
+        idle,
+        "no obligation pending: the tail settle is a single meta read"
+    );
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}
+
+#[test]
+fn idle_base_incremental_pass_settles_a_pending_deferred_obligation() {
+    // Same class as the standalone-worktree exit (#819 review): the base incremental writer's
+    // logical rebuild is gated on its OWN row changes (indexed/healed/carried/roots_changed),
+    // so an IDLE `rag-rat index` pass over an unchanged base tree closes its empty transaction
+    // and would exit past a committed obligation. The pass settles at its tail instead — one
+    // meta read when nothing is pending.
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(main.join("src/a.rs"), "pub fn base_fn() {}\n").unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let config = source_config(main.clone(), Language::Rust);
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    fs::write(linked.join("src/new.rs"), "pub fn branch_only_fn() {}\n").unwrap();
+    run_git(&linked, &["add", "."]);
+    run_git(&linked, &["commit", "-q", "-m", "branch adds file"]);
+
+    // Interrupted deferred batch: rows + marker committed, the batch tail never runs.
+    let tail = crate::index::OverlayRefreshTail {
+        logical_rebuild: crate::index::OverlayLogicalRebuild::Deferred,
+        basis: None,
+    };
+    db.index_worktree_overlay_with_tail(&config, &linked, tail, &mut |_| {}).unwrap();
+    assert!(logical_rebuild_pending(&db), "the interrupted batch left its obligation");
+
+    // An idle base incremental pass (its own connection, like the CLI `index`): the base tree
+    // is unchanged, so the pass's gated rebuild never fires — only the tail settle can.
+    let refreshed = IndexDatabase::index_changed(&config).unwrap();
+    drop(refreshed);
+    assert!(!logical_rebuild_pending(&db), "the idle incremental pass settled the obligation");
+    assert!(logical_symbol_named(&db, "branch_only_fn"), "branch symbols are grouped again");
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}
+
+#[test]
+fn path_scoped_inline_refresh_settles_a_pending_deferred_obligation() {
+    // The path-scoped overlay twin (#679) has the same empty-delta exit as the whole-delta
+    // route: an unchanged supplied path identity-skips, `finalize_overlay_refresh` never runs,
+    // and a stale pending obligation (#819 review) must still be settled at the entry point's
+    // tail. The non-sibling no-op exit is an entry-point exit too.
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(main.join("src/a.rs"), "pub fn base_fn() {}\n").unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let config = source_config(main.clone(), Language::Rust);
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    fs::write(linked.join("src/new.rs"), "pub fn branch_only_fn() {}\n").unwrap();
+    run_git(&linked, &["add", "."]);
+    run_git(&linked, &["commit", "-q", "-m", "branch adds file"]);
+
+    // Interrupted deferred batch: rows + marker committed, the batch tail never runs.
+    let tail = crate::index::OverlayRefreshTail {
+        logical_rebuild: crate::index::OverlayLogicalRebuild::Deferred,
+        basis: None,
+    };
+    db.index_worktree_overlay_with_tail(&config, &linked, tail, &mut |_| {}).unwrap();
+    assert!(logical_rebuild_pending(&db), "the interrupted batch left its obligation");
+
+    // Path-scoped INLINE refresh of the UNCHANGED path: identity-skip, zero row changes.
+    let report = db
+        .index_worktree_overlay_paths(
+            &config,
+            &linked,
+            &[linked.join("src/new.rs")],
+            crate::index::OverlayLogicalRebuild::Inline,
+            &mut |_| {},
+        )
+        .unwrap();
+    assert_eq!(report.indexed, 0, "unchanged path: the refresh itself writes no rows");
+    assert!(!logical_rebuild_pending(&db), "the path-scoped exit consumed the obligation");
+    assert!(logical_symbol_named(&db, "branch_only_fn"), "branch symbols are grouped again");
+
+    // Re-arm the obligation with a second interrupted Deferred refresh...
+    fs::write(linked.join("src/more.rs"), "pub fn second_branch_fn() {}\n").unwrap();
+    run_git(&linked, &["add", "."]);
+    run_git(&linked, &["commit", "-q", "-m", "second branch file"]);
+    db.index_worktree_overlay_with_tail(&config, &linked, tail, &mut |_| {}).unwrap();
+    assert!(logical_rebuild_pending(&db), "the second interrupted batch re-armed it");
+    // ...then exit through the NON-SIBLING no-op arm (the base root is not a linked sibling):
+    // still an Inline entry-point exit, so it settles too.
+    let report = db.index_worktree_overlay(&config, &main, &mut |_| {}).unwrap();
+    assert!(report.worktree_id.is_empty(), "base root refresh is the no-op arm");
+    assert!(!logical_rebuild_pending(&db), "every Inline entry-point exit settles");
+    assert!(logical_symbol_named(&db, "second_branch_fn"), "the settle grouped the new symbol");
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}
+
+#[test]
 fn overlay_basis_writes_ride_the_refresh_transaction() {
     // #824 (#577 semantics preserved): the skip-proof basis is maintained INSIDE the overlay's
     // own BEGIN IMMEDIATE — record the caller's pair on a COMPLETE refresh (even a no-change

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_overlay.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_overlay.rs
@@ -1518,3 +1518,285 @@ fn worktree_overlay_gc_prunes_a_removed_worktrees_refresh_basis() {
     let _ = fs::remove_dir_all(&removed);
     let _ = fs::remove_dir_all(&kept);
 }
+
+/// Whether the repo's `logical_symbols` grouping has a row named `name` — the table
+/// symbol_lookup / graph nav resolve through, i.e. the direct observable for "the repo-global
+/// rebuild ran (or didn't) since these symbols were indexed".
+fn logical_symbol_named(db: &IndexDatabase, name: &str) -> bool {
+    db.storage
+        .connection()
+        .query_row(
+            "SELECT EXISTS(SELECT 1 FROM main.logical_symbols WHERE repo_id = ?1 AND logical_name \
+             = ?2)",
+            rusqlite::params![db.active_repo_id, name],
+            |row| row.get(0),
+        )
+        .unwrap()
+}
+
+/// The #819 pending-rebuild marker, so tests can assert a batch commits it with the overlay rows
+/// and the batch tail consumes it.
+fn logical_rebuild_pending(db: &IndexDatabase) -> bool {
+    db.repo_meta("overlay_logical_rebuild_pending").unwrap().is_some()
+}
+
+#[test]
+fn overlay_batch_pass_rebuilds_logical_symbols_once() {
+    // #819: `logical_symbols` is repo-scoped but scope-INDEPENDENT, so a pass refreshing K
+    // changed worktrees needs exactly ONE repo-global rebuild — per-worktree inline rebuilds
+    // are K−1 redundant DELETE-all + re-derive passes (only the last one's output survives).
+    // The counter is the cardinality observable: the old inline behavior paid one rebuild per
+    // changed worktree and fails this assertion.
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(main.join("src/a.rs"), "pub fn base_fn() {}\n").unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let config = source_config(main.clone(), Language::Rust);
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+
+    let wt_one = unique_temp_root();
+    let _ = fs::remove_dir_all(&wt_one);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat-one", wt_one.to_str().unwrap()]);
+    fs::write(wt_one.join("src/one.rs"), "pub fn one_fn() {}\n").unwrap();
+    run_git(&wt_one, &["add", "."]);
+    run_git(&wt_one, &["commit", "-q", "-m", "one"]);
+    let wt_two = unique_temp_root();
+    let _ = fs::remove_dir_all(&wt_two);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat-two", wt_two.to_str().unwrap()]);
+    fs::write(wt_two.join("src/two.rs"), "pub fn two_fn() {}\n").unwrap();
+    run_git(&wt_two, &["add", "."]);
+    run_git(&wt_two, &["commit", "-q", "-m", "two"]);
+
+    let before = db.logical_symbol_rebuilds.load(std::sync::atomic::Ordering::Relaxed);
+    crate::watch::refresh_worktree_overlays(
+        &mut db,
+        &config,
+        None,
+        &crate::watch::OverlayScope::All,
+    );
+    let after = db.logical_symbol_rebuilds.load(std::sync::atomic::Ordering::Relaxed);
+    assert_eq!(after - before, 1, "two changed worktrees, ONE repo-global rebuild");
+    assert!(!logical_rebuild_pending(&db), "the batch tail consumed the pending marker");
+    // The deferred rebuild still lands every branch's new symbols in the grouping — the #219
+    // field bug (a newly added overlay file's symbols unresolvable) stays fixed.
+    assert!(logical_symbol_named(&db, "one_fn"), "first worktree's new symbol is grouped");
+    assert!(logical_symbol_named(&db, "two_fn"), "second worktree's new symbol is grouped");
+
+    // An idle follow-up sweep neither rebuilds nor marks anything pending (#63 idle backstop).
+    let idle_before = db.logical_symbol_rebuilds.load(std::sync::atomic::Ordering::Relaxed);
+    crate::watch::refresh_worktree_overlays(
+        &mut db,
+        &config,
+        None,
+        &crate::watch::OverlayScope::All,
+    );
+    assert_eq!(
+        db.logical_symbol_rebuilds.load(std::sync::atomic::Ordering::Relaxed),
+        idle_before,
+        "an unchanged fleet rebuilds nothing"
+    );
+    assert!(!logical_rebuild_pending(&db));
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&wt_one);
+    let _ = fs::remove_dir_all(&wt_two);
+}
+
+#[test]
+fn pending_logical_rebuild_marker_heals_an_interrupted_batch() {
+    // #819 crash-window backstop: a Deferred overlay refresh commits its rows and the pending
+    // marker in ONE transaction; if the process dies before the batch tail, the next pass
+    // idle-skips the (now unchanged) overlay rows — only the persisted marker can force the
+    // owed rebuild then. Without it, a newly added branch file's symbols would stay
+    // unresolvable until an unrelated change triggered a rebuild.
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(main.join("src/a.rs"), "pub fn base_fn() {}\n").unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let config = source_config(main.clone(), Language::Rust);
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    fs::write(linked.join("src/new.rs"), "pub fn branch_only_fn() {}\n").unwrap();
+    run_git(&linked, &["add", "."]);
+    run_git(&linked, &["commit", "-q", "-m", "branch adds file"]);
+
+    // Simulate the interrupted batch: the refresh commits (rows + marker); the tail never runs.
+    let tail = crate::index::OverlayRefreshTail {
+        logical_rebuild: crate::index::OverlayLogicalRebuild::Deferred,
+        basis: None,
+    };
+    let report = db.index_worktree_overlay_with_tail(&config, &linked, tail, &mut |_| {}).unwrap();
+    assert!(report.indexed >= 1, "the branch file landed as an overlay row");
+    assert!(logical_rebuild_pending(&db), "the obligation is committed with the rows");
+    assert!(
+        !logical_symbol_named(&db, "branch_only_fn"),
+        "committed rows without the batch tail leave the grouping stale — the state the persisted \
+         marker exists to heal"
+    );
+
+    // The next maintenance pass finds every overlay row unchanged (identity-skip) but still
+    // runs the owed rebuild off the marker.
+    let before = db.logical_symbol_rebuilds.load(std::sync::atomic::Ordering::Relaxed);
+    crate::watch::refresh_worktree_overlays(
+        &mut db,
+        &config,
+        None,
+        &crate::watch::OverlayScope::All,
+    );
+    assert_eq!(
+        db.logical_symbol_rebuilds.load(std::sync::atomic::Ordering::Relaxed) - before,
+        1,
+        "the write-idle pass still runs the owed rebuild"
+    );
+    assert!(!logical_rebuild_pending(&db), "the healing pass consumed the marker");
+    assert!(logical_symbol_named(&db, "branch_only_fn"), "the branch symbol is now grouped");
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}
+
+#[test]
+fn inline_rebuild_satisfies_a_pending_deferred_obligation() {
+    // #819 review: a stale pending marker (left by an interrupted deferred batch) must be
+    // consumed by ANY successful rebuild — here a standalone INLINE overlay refresh — not only
+    // by the batch tail. Left set, the next maintenance pass would pay a second wholesale
+    // rebuild the inline one already performed.
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(main.join("src/a.rs"), "pub fn base_fn() {}\n").unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let config = source_config(main.clone(), Language::Rust);
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    fs::write(linked.join("src/new.rs"), "pub fn branch_only_fn() {}\n").unwrap();
+    run_git(&linked, &["add", "."]);
+    run_git(&linked, &["commit", "-q", "-m", "branch adds file"]);
+
+    // Interrupted deferred batch: rows + marker committed, the tail never runs.
+    let tail = crate::index::OverlayRefreshTail {
+        logical_rebuild: crate::index::OverlayLogicalRebuild::Deferred,
+        basis: None,
+    };
+    db.index_worktree_overlay_with_tail(&config, &linked, tail, &mut |_| {}).unwrap();
+    assert!(logical_rebuild_pending(&db), "the interrupted batch left its obligation");
+
+    // A later dirty edit in the same worktree, refreshed via the STANDALONE (inline) route.
+    fs::write(linked.join("src/more.rs"), "pub fn later_fn() {}\n").unwrap();
+    let report = db.index_worktree_overlay(&config, &linked, &mut |_| {}).unwrap();
+    assert!(report.indexed >= 1, "the dirty edit landed as an overlay row");
+    assert!(!logical_rebuild_pending(&db), "the inline rebuild consumed the stale obligation");
+    // The rebuild is repo-global, so it grouped the interrupted batch's earlier symbols too.
+    assert!(logical_symbol_named(&db, "branch_only_fn"));
+    assert!(logical_symbol_named(&db, "later_fn"));
+
+    // The next sweep owes nothing — no second wholesale rebuild.
+    let before = db.logical_symbol_rebuilds.load(std::sync::atomic::Ordering::Relaxed);
+    crate::watch::refresh_worktree_overlays(
+        &mut db,
+        &config,
+        None,
+        &crate::watch::OverlayScope::All,
+    );
+    assert_eq!(
+        db.logical_symbol_rebuilds.load(std::sync::atomic::Ordering::Relaxed),
+        before,
+        "an already-satisfied obligation triggers nothing"
+    );
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}
+
+#[test]
+fn overlay_basis_writes_ride_the_refresh_transaction() {
+    // #824 (#577 semantics preserved): the skip-proof basis is maintained INSIDE the overlay's
+    // own BEGIN IMMEDIATE — record the caller's pair on a COMPLETE refresh (even a no-change
+    // one: the proof "this pair is current" is the point), clear it on a PARTIAL one, leave it
+    // untouched when no basis is maintained — instead of a separate autocommit per worktree
+    // per pass.
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(main.join("src/a.rs"), "pub fn base_fn() {}\n").unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let config = source_config(main.clone(), Language::Rust);
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+
+    // COMPLETE refresh with a maintained basis: the CALLER's pair (read around the refresh,
+    // like the watcher's) is recorded in the refresh transaction.
+    let tail = crate::index::OverlayRefreshTail {
+        logical_rebuild: crate::index::OverlayLogicalRebuild::Deferred,
+        basis: Some(crate::index::OverlayBasisUpdate {
+            base_sha: "base-head-1",
+            linked_head_sha: "linked-head-1",
+        }),
+    };
+    let report = db.index_worktree_overlay_with_tail(&config, &linked, tail, &mut |_| {}).unwrap();
+    assert!(report.status_complete, "an undisturbed delta walk completes");
+    assert_eq!(
+        db.worktree_overlay_basis(&report.worktree_id).unwrap(),
+        Some(("base-head-1".to_string(), "linked-head-1".to_string())),
+        "a complete refresh records the maintained basis"
+    );
+    assert!(!logical_rebuild_pending(&db), "a no-change refresh defers no rebuild");
+
+    // PARTIAL refresh clears the recorded proof: a dirty edit moves no HEAD, so a stale pair
+    // would keep matching and scoped passes would skip the stale overlay until an `All` sweep
+    // (#577 review). Exercised at the tail seam — a real mid-walk gix status failure can't be
+    // provoked deterministically.
+    db.apply_overlay_basis_tail(
+        &report.worktree_id,
+        false,
+        Some(crate::index::OverlayBasisUpdate {
+            base_sha: "base-head-2",
+            linked_head_sha: "linked-head-2",
+        }),
+    )
+    .unwrap();
+    assert_eq!(
+        db.worktree_overlay_basis(&report.worktree_id).unwrap(),
+        None,
+        "a partial refresh drops the stale skip proof"
+    );
+
+    // The standalone shape maintains no basis: whatever is recorded stays untouched.
+    db.apply_overlay_basis_tail(
+        &report.worktree_id,
+        true,
+        Some(crate::index::OverlayBasisUpdate {
+            base_sha: "base-head-3",
+            linked_head_sha: "linked-head-3",
+        }),
+    )
+    .unwrap();
+    let standalone = db.index_worktree_overlay(&config, &linked, &mut |_| {}).unwrap();
+    assert_eq!(
+        db.worktree_overlay_basis(&standalone.worktree_id).unwrap(),
+        Some(("base-head-3".to_string(), "linked-head-3".to_string())),
+        "a refresh that maintains no basis leaves the recorded pair alone"
+    );
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}

--- a/crates/rag-rat-core/src/index/worktree_overlay.rs
+++ b/crates/rag-rat-core/src/index/worktree_overlay.rs
@@ -574,7 +574,9 @@ impl IndexDatabase {
         let Some((base_sha, worktree_id, source_root)) =
             resolve_overlay_scope(config, linked_path)?
         else {
-            // Fell back to base → not a valid linked sibling; nothing to overlay.
+            // Fell back to base → not a valid linked sibling; nothing to overlay. Still an
+            // entry-point exit, so it settles a pending batch obligation like every other one.
+            self.settle_pending_logical_rebuild_inline(tail.logical_rebuild)?;
             return Ok(WorktreeOverlayReport::default());
         };
         // Scope the connection to the overlay (base commit + linked worktree id) so context-
@@ -661,6 +663,11 @@ impl IndexDatabase {
                 return Err(err);
             },
         };
+        // AFTER the commit (its own transaction): an Inline refresh whose delta was EMPTY
+        // skipped the finalize above, so this is the exit that consumes a stale pending
+        // obligation instead of returning past it (#819 review). A failed refresh skips it —
+        // the obligation survives for the next pass, like the batch callers' error arms.
+        self.settle_pending_logical_rebuild_inline(tail.logical_rebuild)?;
 
         Ok(WorktreeOverlayReport {
             worktree_id,
@@ -710,6 +717,9 @@ impl IndexDatabase {
         let Some((base_sha, worktree_id, source_root)) =
             resolve_overlay_scope(config, linked_path)?
         else {
+            // Not a valid linked sibling — still an entry-point exit (#819 review): settle a
+            // pending batch obligation like the whole-delta route's no-op arm does.
+            self.settle_pending_logical_rebuild_inline(logical_rebuild)?;
             return Ok(WorktreeOverlayReport::default());
         };
         self.set_context(&base_sha, &worktree_id)?;
@@ -835,6 +845,10 @@ impl IndexDatabase {
                 return Err(err);
             },
         };
+        // The Inline entry-point exit settle (#819 review), AFTER the commit: an unchanged
+        // supplied path identity-skips (the finalize above never ran), and a stale pending
+        // obligation must not survive this exit.
+        self.settle_pending_logical_rebuild_inline(logical_rebuild)?;
         Ok(WorktreeOverlayReport {
             worktree_id,
             indexed,
@@ -1022,8 +1036,12 @@ impl IndexDatabase {
     /// This is also the mid-batch-error / crash backstop: the pending marker committed with each
     /// worktree's rows, so earlier worktrees' committed refreshes get their rebuild even when a
     /// later worktree failed, or when the process died between the overlay transactions and this
-    /// tail (the next pass finds the marker and heals). Returns whether a rebuild ran;
-    /// `Ok(false)` = nothing pending, write-free (the #63 idle backstop).
+    /// tail (the next pass finds the marker and heals). Beyond the batch callers, EVERY indexing
+    /// entry point runs this before returning — the Inline overlay exits (via
+    /// [`Self::settle_pending_logical_rebuild_inline`]) and the base incremental writer's tail —
+    /// so no entry point exits past a committed obligation just because its own delta was empty.
+    /// Returns whether a rebuild ran; `Ok(false)` = nothing pending, write-free (the #63 idle
+    /// backstop).
     pub fn apply_pending_logical_rebuild(&self) -> anyhow::Result<bool> {
         // Lockless fast path: the common idle pass never opens a write transaction at all.
         if self.repo_meta(OVERLAY_LOGICAL_REBUILD_PENDING_META)?.is_none() {
@@ -1055,6 +1073,27 @@ impl IndexDatabase {
                 Err(err)
             },
         }
+    }
+
+    /// The Inline entry-point exit settle (#819 review): every overlay indexing entry point
+    /// consumes a pending batch obligation before returning — even when its OWN delta was
+    /// empty. An interrupted [`OverlayLogicalRebuild::Deferred`] batch leaves the marker
+    /// committed, and an Inline refresh with no row changes skips `finalize_overlay_refresh`
+    /// (and with it the inline rebuild, the marker's sole clearer) entirely — without this,
+    /// `index --worktree` over an unchanged checkout would exit leaving BOTH the marker and the
+    /// stale `logical_symbols` in place, branch-only symbols unresolvable until an unrelated
+    /// pass happened to rebuild. Inline-only: `Deferred` callers own their batch tail
+    /// ([`Self::apply_pending_logical_rebuild`] after their loop) — settling per worktree here
+    /// would undo the #819 batching. Runs OUTSIDE the refresh transaction (its own
+    /// `BEGIN IMMEDIATE`); write-free when nothing is pending (one meta read).
+    fn settle_pending_logical_rebuild_inline(
+        &self,
+        logical_rebuild: OverlayLogicalRebuild,
+    ) -> anyhow::Result<()> {
+        if logical_rebuild == OverlayLogicalRebuild::Inline {
+            self.apply_pending_logical_rebuild()?;
+        }
+        Ok(())
     }
 
     /// Index an EXPLICIT set of repo-relative `paths`, reading bytes from `source_root` (which may

--- a/crates/rag-rat-core/src/index/worktree_overlay.rs
+++ b/crates/rag-rat-core/src/index/worktree_overlay.rs
@@ -388,6 +388,77 @@ fn change_location_path(change: &gix::object::tree::diff::Change<'_, '_, '_>) ->
 /// `watch_shutdown_reconcile_pending` marker set the pattern.
 const WORKTREE_OVERLAY_BASIS_META_PREFIX: &str = "worktree_overlay_basis:";
 
+/// `repo_meta` key marking that a committed overlay refresh deferred the repo-global
+/// `logical_symbols` rebuild to its batch's tail (#819). Set INSIDE each overlay transaction that
+/// changes source rows under [`OverlayLogicalRebuild::Deferred`]; consumed by the batch tail
+/// ([`IndexDatabase::apply_pending_logical_rebuild`]). Persisted rather
+/// than tracked in memory so a crash between a committed overlay transaction and the batch tail
+/// leaves the obligation visible: the next pass must run the rebuild even though every overlay
+/// row is unchanged (idle-skipped) by then — otherwise a newly added overlay file's symbols would
+/// stay unresolvable until an unrelated change triggered a rebuild. `rebuild_logical_symbols` is
+/// the sole CLEARER: any successful rebuild — the batch tail, an inline overlay refresh, a heal,
+/// an incremental or full pass — satisfies the obligation in the same transaction.
+pub(super) const OVERLAY_LOGICAL_REBUILD_PENDING_META: &str = "overlay_logical_rebuild_pending";
+
+/// Whether an overlay refresh runs the repo-global logical-symbol rebuild inside its own
+/// transaction, or defers it to one batch-tail rebuild (#819). `logical_symbols` is repo-scoped
+/// but scope-INDEPENDENT (see `rebuild_logical_symbols`), so when one pass refreshes K worktrees
+/// only the LAST rebuild's output survives — K inline rebuilds are K−1 wholesale
+/// DELETE-all + re-derive passes of pure write amplification.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OverlayLogicalRebuild {
+    /// Rebuild inside this refresh's transaction — atomic with the overlay rows. The standalone
+    /// single-checkout shape (CLI `index --worktree`, tests): nothing to deduplicate.
+    Inline,
+    /// Skip the rebuild and mark it pending in the same transaction. The batch caller MUST follow
+    /// up with [`IndexDatabase::apply_pending_logical_rebuild`] after its loop.
+    Deferred,
+}
+
+/// The `(base HEAD, linked HEAD)` pair a watcher pass wants recorded as the worktree's #577
+/// skip-proof refresh basis. Both heads are read by the CALLER around the refresh (base once per
+/// pass, linked before the delta) so a commit racing the refresh records the pre-refresh head —
+/// mismatching (and re-refreshing) next pass rather than skipping a stale overlay.
+#[derive(Debug, Clone, Copy)]
+pub struct OverlayBasisUpdate<'a> {
+    pub base_sha: &'a str,
+    pub linked_head_sha: &'a str,
+}
+
+/// Caller-owned handling of an overlay refresh's repo-global tail (#819/#824): how the
+/// logical-symbol rebuild runs, and whether the refresh maintains the worktree's #577 refresh
+/// basis inside its own transaction.
+#[derive(Debug, Clone, Copy)]
+pub struct OverlayRefreshTail<'a> {
+    pub logical_rebuild: OverlayLogicalRebuild,
+    /// `Some` = maintain the #577 skip-proof basis in the refresh transaction (#824): record the
+    /// pair on a COMPLETE refresh, clear the worktree's recorded basis on a PARTIAL one. (A
+    /// FAILED refresh rolls the transaction back — the caller clears after the rollback, where a
+    /// transactional clear cannot survive.) `None` = leave any recorded basis untouched.
+    pub basis: Option<OverlayBasisUpdate<'a>>,
+}
+
+impl OverlayRefreshTail<'_> {
+    /// The standalone, self-contained refresh: rebuild logical symbols inline (atomic with the
+    /// overlay transaction) and leave any recorded refresh basis untouched.
+    pub const STANDALONE: OverlayRefreshTail<'static> =
+        OverlayRefreshTail { logical_rebuild: OverlayLogicalRebuild::Inline, basis: None };
+}
+
+/// One overlay refresh's row-change counts — the gate for its finalize tail (any change means the
+/// logical-symbol/package/edge/FTS refresh runs; none means the pass stays write-free).
+struct OverlayChangeCounts {
+    indexed: usize,
+    tombstoned: usize,
+    pruned: usize,
+}
+
+impl OverlayChangeCounts {
+    fn any_changed(&self) -> bool {
+        self.indexed > 0 || self.tombstoned > 0 || self.pruned > 0
+    }
+}
+
 impl IndexDatabase {
     /// The recorded refresh basis for `worktree_id`: `(base_sha, linked_head_sha)` at the last
     /// successful overlay refresh, or `None` when never refreshed (or written by a pre-#577
@@ -460,10 +531,38 @@ impl IndexDatabase {
     /// scope, and tombstone the files it removed (#219 stage 2). No-op (empty `worktree_id` in the
     /// report) when `linked_path` is not a valid linked sibling of `config.root`'s repo. Leaves the
     /// connection scope set to the overlay; callers re-`set_context` if they need another scope.
+    ///
+    /// The standalone shape ([`OverlayRefreshTail::STANDALONE`]): the repo-global logical-symbol
+    /// rebuild runs inline, atomic with the overlay transaction, and no #577 basis is maintained.
+    /// Callers refreshing SEVERAL worktrees in one pass use
+    /// [`Self::index_worktree_overlay_with_tail`] instead, so the batch pays the rebuild once
+    /// (#819).
     pub fn index_worktree_overlay<F>(
         &mut self,
         config: &Config,
         linked_path: &Path,
+        progress: &mut F,
+    ) -> anyhow::Result<WorktreeOverlayReport>
+    where
+        F: FnMut(IndexProgress),
+    {
+        self.index_worktree_overlay_with_tail(
+            config,
+            linked_path,
+            OverlayRefreshTail::STANDALONE,
+            progress,
+        )
+    }
+
+    /// [`Self::index_worktree_overlay`] with caller-owned tail handling (#819/#824): the batch
+    /// shape. `tail` decides whether the repo-global logical-symbol rebuild runs inline or is
+    /// deferred to one [`Self::apply_pending_logical_rebuild`] per batch, and whether the
+    /// worktree's #577 refresh basis is maintained inside this refresh's own transaction.
+    pub fn index_worktree_overlay_with_tail<F>(
+        &mut self,
+        config: &Config,
+        linked_path: &Path,
+        tail: OverlayRefreshTail<'_>,
         progress: &mut F,
     ) -> anyhow::Result<WorktreeOverlayReport>
     where
@@ -541,11 +640,15 @@ impl IndexDatabase {
             self.finalize_overlay_refresh(
                 &source_root,
                 &worktree_id,
-                indexed,
-                tombstoned,
-                pruned,
+                OverlayChangeCounts { indexed, tombstoned, pruned },
                 delta.manifest_changed,
+                tail.logical_rebuild,
             )?;
+            // #824: the basis write rides the SAME transaction as the rows it proves current —
+            // previously a separate autocommit per worktree per pass (an extra WAL-dirtying
+            // commit each). Un-gated on the counts: a COMPLETE no-change refresh must still
+            // record its basis (that skip proof is the whole point of #577).
+            self.apply_overlay_basis_tail(&worktree_id, delta.status_complete, tail.basis)?;
             Ok((indexed, tombstoned, pruned))
         })();
         let (indexed, tombstoned, pruned) = match result {
@@ -588,11 +691,17 @@ impl IndexDatabase {
     /// package-map refresh stays the caller's job (via `refresh_worktree_overlay_packages`),
     /// exactly as on the whole-delta route. No-op (empty `worktree_id`) when `linked_path` is
     /// not a valid linked sibling. Leaves the connection scoped to the overlay.
+    ///
+    /// `logical_rebuild` (#819): `Deferred` skips the repo-global logical-symbol rebuild and
+    /// marks it pending, for callers batching several overlay refreshes — the batch then runs
+    /// [`Self::apply_pending_logical_rebuild`] once. Basis maintenance stays caller-side here
+    /// (this refresh is never complete, so there is never a pair to record).
     pub fn index_worktree_overlay_paths<F>(
         &mut self,
         config: &Config,
         linked_path: &Path,
         paths: &[PathBuf],
+        logical_rebuild: OverlayLogicalRebuild,
         progress: &mut F,
     ) -> anyhow::Result<WorktreeOverlayReport>
     where
@@ -710,10 +819,9 @@ impl IndexDatabase {
             self.finalize_overlay_refresh(
                 &source_root,
                 &worktree_id,
-                indexed,
-                tombstoned,
-                pruned,
+                OverlayChangeCounts { indexed, tombstoned, pruned },
                 false,
+                logical_rebuild,
             )?;
             Ok((indexed, tombstoned, pruned))
         })();
@@ -820,7 +928,9 @@ impl IndexDatabase {
     /// - rebuild_logical_symbols: symbol_lookup / graph nav resolve through `logical_symbols`, so a
     ///   NEWLY-ADDED overlay file's symbols are invisible until regrouped (a modified file's
     ///   unchanged symbols resolve via the base's logical rows — which is why only added files were
-    ///   missing). This is the field-reported bug.
+    ///   missing). This is the field-reported bug. `Deferred` (#819) replaces the rebuild with a
+    ///   persisted pending marker in this same transaction; the batch caller runs ONE rebuild for
+    ///   all its worktrees via `apply_pending_logical_rebuild`.
     /// - refresh_packages: write the overlay scope's `packages` rows from the LINKED checkout's
     ///   manifests BEFORE resolving, so the per-package import scope (#61) is correct for the
     ///   branch. The resolver's `load_package_roots_into_scope` reads `packages` at the active
@@ -843,16 +953,28 @@ impl IndexDatabase {
         &self,
         source_root: &Path,
         worktree_id: &str,
-        indexed: usize,
-        tombstoned: usize,
-        pruned: usize,
+        counts: OverlayChangeCounts,
         manifest_changed: bool,
+        logical_rebuild: OverlayLogicalRebuild,
     ) -> anyhow::Result<()> {
-        if indexed > 0 || tombstoned > 0 || pruned > 0 {
-            // Defer: an overlay refresh re-parsed only the worktree's own files, so it must not
-            // stamp the logical-key version — the base scope's drift is still in the future
-            // (#493).
-            self.rebuild_logical_symbols(graph_index::KeyVersionStamp::Defer)?;
+        if counts.any_changed() {
+            match logical_rebuild {
+                OverlayLogicalRebuild::Inline => {
+                    // Defer the STAMP: an overlay refresh re-parsed only the worktree's own
+                    // files, so it must not stamp the logical-key version — the base scope's
+                    // drift is still in the future (#493).
+                    self.rebuild_logical_symbols(graph_index::KeyVersionStamp::Defer)?;
+                },
+                OverlayLogicalRebuild::Deferred => {
+                    // Mark the repo-global rebuild pending IN THIS transaction (#819).
+                    // Committed overlay rows without a follow-up rebuild would leave a newly
+                    // added file's symbols unresolvable, and a later pass would idle-skip the
+                    // then-unchanged rows — the persisted marker survives a crash between this
+                    // commit and the batch tail, so `apply_pending_logical_rebuild` still runs.
+                    // `if_changed`: the second changed worktree of a batch finds it already set.
+                    self.set_repo_meta_if_changed(OVERLAY_LOGICAL_REBUILD_PENDING_META, "1")?;
+                },
+            }
             self.refresh_packages(source_root)?;
             self.resolve_overlay_edges(worktree_id)?;
             self.sync_fts()?;
@@ -870,6 +992,69 @@ impl IndexDatabase {
             self.resolve_overlay_edges(worktree_id)?;
         }
         Ok(())
+    }
+
+    /// Apply the #577 basis leg of an overlay refresh's tail, INSIDE the refresh transaction
+    /// (#824): record the caller's pair on a COMPLETE refresh; clear the worktree's recorded
+    /// basis on a PARTIAL one (a dirty edit moves no HEAD, so a stale pair would keep matching
+    /// and scoped passes would skip the stale overlay until an `All` sweep — #577 review); no-op
+    /// when the caller maintains no basis. FAILED refreshes never reach this: the transaction
+    /// rolls back, and the caller clears the basis outside it.
+    pub(super) fn apply_overlay_basis_tail(
+        &self,
+        worktree_id: &str,
+        status_complete: bool,
+        basis: Option<OverlayBasisUpdate<'_>>,
+    ) -> anyhow::Result<()> {
+        let Some(basis) = basis else { return Ok(()) };
+        if status_complete {
+            self.record_worktree_overlay_basis(worktree_id, basis.base_sha, basis.linked_head_sha)
+        } else {
+            self.clear_worktree_overlay_basis(worktree_id)
+        }
+    }
+
+    /// Run the batch-deferred repo-global logical-symbol rebuild if one is pending (#819) — the
+    /// REQUIRED tail of any batch of [`OverlayLogicalRebuild::Deferred`] refreshes, in its own
+    /// `BEGIN IMMEDIATE` (the caller must not hold an open transaction). One rebuild serves the
+    /// whole batch: `logical_symbols` is repo-scoped but scope-independent, so per-worktree
+    /// rebuilds are redundant — with K changed worktrees only the last one's output survives.
+    /// This is also the mid-batch-error / crash backstop: the pending marker committed with each
+    /// worktree's rows, so earlier worktrees' committed refreshes get their rebuild even when a
+    /// later worktree failed, or when the process died between the overlay transactions and this
+    /// tail (the next pass finds the marker and heals). Returns whether a rebuild ran;
+    /// `Ok(false)` = nothing pending, write-free (the #63 idle backstop).
+    pub fn apply_pending_logical_rebuild(&self) -> anyhow::Result<bool> {
+        // Lockless fast path: the common idle pass never opens a write transaction at all.
+        if self.repo_meta(OVERLAY_LOGICAL_REBUILD_PENDING_META)?.is_none() {
+            return Ok(false);
+        }
+        self.storage.execute_batch("BEGIN IMMEDIATE")?;
+        let result = (|| -> anyhow::Result<bool> {
+            // RE-CHECK under the write transaction: a concurrent tail (another watcher/hook
+            // process) may have rebuilt and cleared the marker between the read above and
+            // BEGIN IMMEDIATE — proceeding blind would pay a second wholesale rebuild for
+            // nothing.
+            if self.repo_meta(OVERLAY_LOGICAL_REBUILD_PENDING_META)?.is_none() {
+                return Ok(false);
+            }
+            // Defer the #493 stamp for the same reason each deferred refresh would have: the
+            // batch re-parsed only worktree deltas, never the full corpus. The rebuild clears
+            // the pending marker itself, in this same transaction — on failure both roll back,
+            // so the obligation survives for the next pass to retry.
+            self.rebuild_logical_symbols(graph_index::KeyVersionStamp::Defer)?;
+            Ok(true)
+        })();
+        match result {
+            Ok(ran) => {
+                self.storage.execute_batch("COMMIT")?;
+                Ok(ran)
+            },
+            Err(err) => {
+                let _ = self.storage.execute_batch("ROLLBACK");
+                Err(err)
+            },
+        }
     }
 
     /// Index an EXPLICIT set of repo-relative `paths`, reading bytes from `source_root` (which may

--- a/crates/rag-rat-core/src/watch/mod.rs
+++ b/crates/rag-rat-core/src/watch/mod.rs
@@ -29,13 +29,11 @@ mod placement;
 pub use event_loop::Watcher;
 #[cfg(test)]
 pub(crate) use event_loop::{EventLoop, flush_watch_placement_failures, shutdown_discover};
-#[cfg(test)]
-pub(crate) use overlay::{
-    OverlayBasisAction, overlay_basis_action, overlay_needs_embed, partition_paths_by_worktree,
-};
 pub use overlay::{
     OverlayScope, ReconcileBudget, is_manifest_path, refresh_worktree_overlays, reindex_paths,
 };
+#[cfg(test)]
+pub(crate) use overlay::{overlay_needs_embed, partition_paths_by_worktree};
 #[cfg(test)]
 pub(crate) use papertrail::{PapertrailClock, PapertrailScheduler, papertrail_tick_interval};
 pub use pass::{CLONE_GRAPH_QUIET_MS, maintenance_pass, maintenance_pass_or_skip};

--- a/crates/rag-rat-core/src/watch/overlay.rs
+++ b/crates/rag-rat-core/src/watch/overlay.rs
@@ -5,7 +5,9 @@ use std::time::Instant;
 use rag_rat_base::config::Config;
 
 use crate::index::ai::ReconcileOptions;
-use crate::index::{IndexDatabase, IndexProgress};
+use crate::index::{
+    IndexDatabase, IndexProgress, OverlayBasisUpdate, OverlayLogicalRebuild, OverlayRefreshTail,
+};
 
 /// The canonical worktree id string [`crate::index::live_worktree_contexts`] reports. When `root`
 /// is a repo SUBDIR (`<repo>/crate`), the enclosing worktree root is `<repo>` — which is the
@@ -127,23 +129,23 @@ pub fn refresh_worktree_overlays(
         // keeps the shared base `root`/`database` but swaps in the branch's target set
         // (#219 review).
         let overlay_config = config.for_linked_worktree_overlay(Path::new(&worktree));
-        match db.index_worktree_overlay(&overlay_config, Path::new(&worktree), &mut |_| {}) {
+        // The tail (#819/#824): defer the repo-global logical-symbol rebuild to ONE run after
+        // this loop, and let the refresh maintain the #577 basis INSIDE its own transaction —
+        // record on complete, clear on partial — instead of a separate autocommit per worktree.
+        // (A non-sibling refresh never opens the transaction and leaves any basis untouched.)
+        let tail = OverlayRefreshTail {
+            logical_rebuild: OverlayLogicalRebuild::Deferred,
+            basis: Some(OverlayBasisUpdate { base_sha: &base_sha, linked_head_sha: &linked_head }),
+        };
+        match db.index_worktree_overlay_with_tail(
+            &overlay_config,
+            Path::new(&worktree),
+            tail,
+            &mut |_| {},
+        ) {
             Ok(report) => {
                 let this_changed = report.indexed > 0 || report.tombstoned > 0 || report.pruned > 0;
                 changed |= this_changed;
-                match overlay_basis_action(&report) {
-                    // Record the refresh basis so later scoped passes can prove "unchanged" from
-                    // two head reads instead of re-computing the delta (#577). Best-effort: a
-                    // failed write just means the next pass refreshes again.
-                    OverlayBasisAction::Record => {
-                        let _ =
-                            db.record_worktree_overlay_basis(&worktree, &base_sha, &linked_head);
-                    },
-                    OverlayBasisAction::Clear => {
-                        let _ = db.clear_worktree_overlay_basis(&worktree);
-                    },
-                    OverlayBasisAction::Keep => {},
-                }
                 // Embed the overlay's chunks NOW, while the connection is still scoped to this
                 // overlay (index_worktree_overlay left it there) — the trailing base reconcile
                 // won't see them (#219 review). Run when the overlay CHANGED, OR — on an `All`
@@ -180,37 +182,19 @@ pub fn refresh_worktree_overlays(
             },
         }
     }
+    // ONE repo-global logical-symbol rebuild for the whole batch (#819): each changed overlay
+    // transaction above marked it pending instead of paying the full DELETE-all + re-derive per
+    // worktree (only the last rebuild's output would survive anyway). Runs even when a worktree
+    // errored mid-loop — the marker rode the transactions that DID commit. Best-effort like the
+    // per-worktree refresh: on failure the marker survives its rollback and the next pass
+    // retries.
+    if let Err(err) = db.apply_pending_logical_rebuild() {
+        eprintln!("watch: batch logical-symbol rebuild failed: {err}");
+    }
     // Restore the base scope for the rest of the pass (index_worktree_overlay leaves the connection
     // scoped to the last worktree it touched).
     let _ = db.use_worktree_scope(&config.root, None);
     changed
-}
-
-/// What a refresh outcome does to the worktree's skip-proof basis (#577).
-#[derive(Debug, PartialEq, Eq)]
-pub(crate) enum OverlayBasisAction {
-    /// A COMPLETE refresh of a real linked sibling: the heads captured around it prove the
-    /// overlay current.
-    Record,
-    /// A PARTIAL refresh (the working-tree status read failed midway): dirty/untracked/deleted
-    /// paths may be missing while neither HEAD moved, so a previously recorded basis would keep
-    /// matching and scoped passes would skip the stale overlay until an `All` pass. Drop it so
-    /// they keep refreshing until a complete pass lands.
-    Clear,
-    /// Not a linked sibling — there is no overlay to prove anything about.
-    Keep,
-}
-
-pub(crate) fn overlay_basis_action(
-    report: &crate::index::WorktreeOverlayReport,
-) -> OverlayBasisAction {
-    if report.worktree_id.is_empty() {
-        OverlayBasisAction::Keep
-    } else if report.status_complete {
-        OverlayBasisAction::Record
-    } else {
-        OverlayBasisAction::Clear
-    }
 }
 
 pub(crate) fn overlay_needs_embed(
@@ -309,52 +293,77 @@ where
     // Always run the base pass: it opens the db (returned for status + the overlay refresh) and
     // enforces #427. With no base paths it is a no-op scoped pass over an empty change set.
     let mut db = IndexDatabase::index_paths_with_progress(config, &base_paths, &mut progress)?;
-    for (checkout, checkout_paths) in &linked {
-        // Index EXACTLY the supplied paths of each touched checkout's overlay (#679), with the
-        // LINKED branch's OWN targets (a branch that adds/narrows targets must be indexed
-        // by its own config). Path-scoped, not the whole base↔branch delta: a single-file
-        // linked edit no longer pulls in unrelated in-flight changes in the same worktree —
-        // the base `Paths` exact-path semantics on the linked route. `?` PROPAGATES a
-        // failure — the caller (an edit hook) must be able to tell the reindex did not land
-        // and retry.
-        //
-        // EXCEPT a branch `rag-rat.toml` or `.gitignore` edit: both change the indexable set across
-        // the WHOLE overlay — a config edit re-languages / adds / drops targets; a `.gitignore`
-        // edit flips OTHER files' ignore status — and neither is itself a source target, so
-        // the path-scoped route would no-op on them and leave the drift for a later sweep.
-        // Run the whole-delta pass, which reconciles both
-        // (`overlay_target_config_reconcile` for target
-        // drift, `expand_candidates_for_ignore_only_flips` for ignore flips) (#679 review). Such
-        // edits are rare, so paying the full tree-diff there is fine.
-        let overlay_config = config.for_linked_worktree_overlay(checkout);
-        let overlay_wide_edit = checkout_paths
-            .iter()
-            .any(|path| is_config_path(path) || super::placement::is_gitignore_path(path));
-        let report = if overlay_wide_edit {
-            db.index_worktree_overlay(&overlay_config, checkout, &mut progress)?
-        } else {
-            db.index_worktree_overlay_paths(
-                &overlay_config,
-                checkout,
-                checkout_paths,
-                &mut progress,
-            )?
-        };
-        // A path-scoped pass is never a complete overlay refresh (`status_complete = false`), so —
-        // like the watcher on a partial read — CLEAR this worktree's overlay basis so the next full
-        // sweep re-refreshes anything else in the branch instead of skipping on a still-matching
-        // basis (#659/#679).
-        if !report.status_complete && !report.worktree_id.is_empty() {
-            let _ = db.clear_worktree_overlay_basis(&report.worktree_id);
+    let overlay_result = (|| -> anyhow::Result<()> {
+        for (checkout, checkout_paths) in &linked {
+            // Index EXACTLY the supplied paths of each touched checkout's overlay (#679), with the
+            // LINKED branch's OWN targets (a branch that adds/narrows targets must be indexed
+            // by its own config). Path-scoped, not the whole base↔branch delta: a single-file
+            // linked edit no longer pulls in unrelated in-flight changes in the same worktree —
+            // the base `Paths` exact-path semantics on the linked route. `?` PROPAGATES a
+            // failure — the caller (an edit hook) must be able to tell the reindex did not land
+            // and retry.
+            //
+            // EXCEPT a branch `rag-rat.toml` or `.gitignore` edit: both change the indexable set
+            // across the WHOLE overlay — a config edit re-languages / adds / drops
+            // targets; a `.gitignore` edit flips OTHER files' ignore status — and
+            // neither is itself a source target, so the path-scoped route would no-op
+            // on them and leave the drift for a later sweep. Run the whole-delta pass,
+            // which reconciles both (`overlay_target_config_reconcile` for target
+            // drift, `expand_candidates_for_ignore_only_flips` for ignore flips) (#679 review).
+            // Such edits are rare, so paying the full tree-diff there is fine.
+            let overlay_config = config.for_linked_worktree_overlay(checkout);
+            let overlay_wide_edit = checkout_paths
+                .iter()
+                .any(|path| is_config_path(path) || super::placement::is_gitignore_path(path));
+            // Defer the repo-global logical-symbol rebuild to ONE run after this loop (#819) — an
+            // `index --paths` batch spanning several checkouts would otherwise pay one full
+            // DELETE-all + re-derive per checkout. The basis pair is not maintained in-txn here:
+            // this flow never RECORDS a basis (it captures no head pair), it only clears below.
+            let report = if overlay_wide_edit {
+                db.index_worktree_overlay_with_tail(
+                    &overlay_config,
+                    checkout,
+                    OverlayRefreshTail {
+                        logical_rebuild: OverlayLogicalRebuild::Deferred,
+                        basis: None,
+                    },
+                    &mut progress,
+                )?
+            } else {
+                db.index_worktree_overlay_paths(
+                    &overlay_config,
+                    checkout,
+                    checkout_paths,
+                    OverlayLogicalRebuild::Deferred,
+                    &mut progress,
+                )?
+            };
+            // A path-scoped pass is never a complete overlay refresh (`status_complete = false`),
+            // so — like the watcher on a partial read — CLEAR this worktree's overlay
+            // basis so the next full sweep re-refreshes anything else in the branch
+            // instead of skipping on a still-matching basis (#659/#679).
+            if !report.status_complete && !report.worktree_id.is_empty() {
+                let _ = db.clear_worktree_overlay_basis(&report.worktree_id);
+            }
+            // A SUPPLIED `Cargo.toml` must refresh the overlay's package map even when it is CLEAN/
+            // committed (so it produced no source rows and the overlay's status-derived signal
+            // missed it) — the base flow refreshes on a named manifest regardless of
+            // dirtiness, and the linked route must honor the same "also sees committed
+            // changes" contract (#659 review).
+            if manifest_roots.contains(checkout) {
+                db.refresh_worktree_overlay_packages(&overlay_config, checkout)?;
+            }
         }
-        // A SUPPLIED `Cargo.toml` must refresh the overlay's package map even when it is CLEAN/
-        // committed (so it produced no source rows and the overlay's status-derived signal missed
-        // it) — the base flow refreshes on a named manifest regardless of dirtiness, and the linked
-        // route must honor the same "also sees committed changes" contract (#659 review).
-        if manifest_roots.contains(checkout) {
-            db.refresh_worktree_overlay_packages(&overlay_config, checkout)?;
-        }
-    }
+        Ok(())
+    })();
+    // Run the batch's ONE deferred logical-symbol rebuild (#819) BEFORE propagating a mid-loop
+    // error: the checkouts that already committed marked it pending, and skipping it would leave
+    // their newly indexed symbols unresolvable until another pass. When the loop failed, the loop
+    // error wins; a rebuild failure here leaves the pending marker committed, so the next
+    // maintenance pass retries it.
+    let rebuild_result = db.apply_pending_logical_rebuild();
+    overlay_result?;
+    rebuild_result?;
     // The overlay passes / the manifest refresh leave the connection scoped to the LAST overlay;
     // restore the base scope so the returned db reads base-scoped status.
     if !linked.is_empty() {

--- a/crates/rag-rat-core/src/watch/tests.rs
+++ b/crates/rag-rat-core/src/watch/tests.rs
@@ -596,33 +596,6 @@ fn overlay_changes_do_not_force_the_base_tail() {
 }
 
 #[test]
-fn basis_records_on_complete_clears_on_partial_keeps_on_non_sibling() {
-    // #577 review: a PARTIAL refresh (the gix status read failed midway, so
-    // `status_complete=false` and dirty/untracked paths may be missing) must CLEAR any
-    // recorded basis, not merely skip recording — a dirty edit moves no HEAD, so a prior
-    // basis would keep matching and later scoped passes would skip the stale overlay until
-    // an `All` pass. A non-sibling skip touches nothing.
-    let complete = crate::index::WorktreeOverlayReport {
-        worktree_id: "/wt/a".to_string(),
-        status_complete: true,
-        ..Default::default()
-    };
-    assert_eq!(overlay_basis_action(&complete), OverlayBasisAction::Record);
-    let partial = crate::index::WorktreeOverlayReport {
-        worktree_id: "/wt/a".to_string(),
-        status_complete: false,
-        ..Default::default()
-    };
-    assert_eq!(
-        overlay_basis_action(&partial),
-        OverlayBasisAction::Clear,
-        "a partial status scan drops the stale skip proof"
-    );
-    let not_a_sibling = crate::index::WorktreeOverlayReport::default();
-    assert_eq!(overlay_basis_action(&not_a_sibling), OverlayBasisAction::Keep);
-}
-
-#[test]
 fn overlay_scope_merge_unions_roots_and_all_absorbs() {
     // #577: hints accumulated while the debounce is armed must union attributable roots, and
     // an unattributable hint (rescan, registry change) must widen the whole pass to All.


### PR DESCRIPTION
## Problem

A maintenance pass over K changed linked worktrees paid K identical repo-global logical-symbol rebuilds: each per-worktree overlay refresh ran the wholesale DELETE-all + re-derive of `logical_symbols` (~15k rows through an 8-column external sort) inside its own transaction. `logical_symbols` is repo-scoped and scope-independent, so only the last rebuild's output survives — the first K−1 are pure write amplification. Measured at ~70 MB of WAL per watcher pass with 5 active worktrees (the overlays stage dominates the watcher's write profile).

Separately, the #577 refresh basis was recorded in a standalone autocommit after each overlay transaction closed — one more WAL-dirtying commit per worktree per pass.

## Change

The overlay refresh takes a caller-owned tail (`OverlayRefreshTail`); the plain `index_worktree_overlay` keeps its exact old contract (inline rebuild, atomic with the overlay transaction, no basis) as the standalone shape.

- **One rebuild per batch (#819).** `OverlayLogicalRebuild::Deferred` skips the inline rebuild and commits a persisted `overlay_logical_rebuild_pending` `repo_meta` marker in the same transaction as the row changes. The batch callers — the watcher pass and `index --paths` — run `apply_pending_logical_rebuild` once after their worktree loop: one `BEGIN IMMEDIATE`, one rebuild. The persisted marker doubles as the mid-batch-error and crash backstop: a worktree failing mid-loop, or the process dying between transactions, leaves the obligation committed, so the rebuild still runs at the batch tail or on the next pass (a later pass idle-skips the unchanged rows, so nothing else would trigger it). Any successful rebuild — batch tail, inline, heal, incremental, full — clears the marker inside its own transaction, and the batch tail re-checks the marker under `BEGIN IMMEDIATE`, so no path pays a redundant second rebuild.
- **Basis writes ride the refresh transaction (#824).** The watcher passes its (base HEAD, linked HEAD) pair into the refresh; the transaction records it on a complete refresh and clears it on a partial one — #577 semantics unchanged bit for bit. A failed refresh rolls the transaction back, so the watcher still clears the basis in its error arm, outside the dead transaction. Non-sibling refreshes never open the transaction and leave any basis untouched.

All scope-local finalize steps (package refresh, overlay edge resolution, FTS sync) stay inside each per-worktree transaction, unchanged. The CLI `index --worktree` single-checkout path keeps the inline rebuild (nothing to deduplicate; stays atomic). The base incremental path keeps its own rebuild unchanged.

## Verification

- New test: a pass over two changed worktrees performs exactly ONE logical-symbol rebuild (per-connection rebuild counter). Verified to fail against the old per-worktree behavior (3 rebuilds) by temporarily restoring the inline call, then reverted.
- New tests: the pending marker heals an interrupted batch on the next (write-idle) pass; an inline rebuild consumes a stale pending obligation so the next sweep rebuilds nothing; the basis record-on-complete / clear-on-partial / untouched matrix now runs against a real database with the write inside the refresh transaction.
- Existing #577 scoped-refresh, basis-gc, golden logical-grouping, and overlay symbol-navigation tests pass unchanged.
- `cargo nextest run -p rag-rat-core` (1481 passed), `cargo nextest run --workspace --no-default-features --locked` (3555 passed), `cargo test -p rag-rat-core --no-default-features --locked` (1479 passed), all four CI clippy legs with `-D warnings`, nightly `cargo fmt --all --check` — all green on top of current main.

Fixes #819
Fixes #824