### PR TITLE
distill: attach drive-by decision records on semantic_search hits

### DIFF
--- a/crates/rag-rat-core/src/index/query_api/graph.rs
+++ b/crates/rag-rat-core/src/index/query_api/graph.rs
@@ -704,6 +704,7 @@ impl IndexDatabase {
                         graph: None,
                         score_components: None,
                         importance: None,
+                        distilled_records: Vec::new(),
                     },
                     rag_rat_db::text_compression::ChunkTextRow {
                         blob: row.get(7)?,

--- a/crates/rag-rat-core/src/index/query_api/memory.rs
+++ b/crates/rag-rat-core/src/index/query_api/memory.rs
@@ -154,12 +154,58 @@ impl IndexDatabase {
         symbol_path: Option<&str>,
         limit: usize,
     ) -> anyhow::Result<Vec<rag_rat_papertrail::DriveByRecord>> {
-        let logical_symbol_id = rag_rat_query::memory::logical_symbol_id_for_chunk_symbol(
-            self.storage.connection(),
-            path,
-            symbol_path,
-        )?;
-        self.drive_by_records_for_logical_id(logical_symbol_id, limit)
+        let conn = self.storage.connection();
+        let repo_id = rag_rat_db::schema::active_repo_id(conn)?;
+        let logical_symbol_id =
+            rag_rat_query::memory::logical_symbol_id_for_chunk_symbol(conn, path, symbol_path)?;
+        Self::drive_by_records_scoped(conn, &repo_id, logical_symbol_id, limit)
+    }
+
+    /// Attach distilled decision records (#705 drive-by) to each search hit's symbol — the same
+    /// facet-gated, capped lane as `read_chunk`, resolved from each hit's `(path, symbol_path)`.
+    /// Skips a result set with no symbol-bearing hits so a doc/config-only result pays nothing.
+    /// `pub`: the `semantic_search` MCP handler calls it directly (the shared
+    /// `search_with_graph_meta` deliberately does NOT, so records stay off docs_for_symbol and
+    /// other search consumers).
+    pub fn attach_distilled_records_to_search_hits(
+        &self,
+        hits: &mut [rag_rat_query::SearchHit],
+    ) -> anyhow::Result<()> {
+        if hits.iter().all(|hit| hit.symbol_path.is_none()) {
+            return Ok(());
+        }
+        let conn = self.storage.connection();
+        // The distill store is optional (V077). When it is absent — a repo that never distilled —
+        // skip the WHOLE batch: `records_for_symbol` would bail at the same guard, but only after
+        // per-hit symbol resolution, so checking once here avoids that resolution work entirely on
+        // the search hot path.
+        if !rag_rat_db::schema::table_exists(conn, "papertrail_distill")? {
+            return Ok(());
+        }
+        // Resolve the repo scope ONCE for the batch, and memoize records by (path, symbol_path) so
+        // the many chunks of one symbol (e.g. its continuation parts) resolve + fetch a single time
+        // rather than re-querying per hit.
+        let repo_id = rag_rat_db::schema::active_repo_id(conn)?;
+        let mut by_symbol: std::collections::HashMap<
+            (String, Option<String>),
+            Vec<rag_rat_papertrail::DriveByRecord>,
+        > = std::collections::HashMap::new();
+        for hit in hits.iter_mut() {
+            let key = (hit.path.clone(), hit.symbol_path.clone());
+            if let Some(cached) = by_symbol.get(&key) {
+                hit.distilled_records = cached.clone();
+                continue;
+            }
+            let logical_symbol_id = rag_rat_query::memory::logical_symbol_id_for_chunk_symbol(
+                conn,
+                &hit.path,
+                hit.symbol_path.as_deref(),
+            )?;
+            let records = Self::drive_by_records_scoped(conn, &repo_id, logical_symbol_id, 2)?;
+            by_symbol.insert(key, records.clone());
+            hit.distilled_records = records;
+        }
+        Ok(())
     }
 
     /// Shared drive-by fetch: the repo-scoped, facet-gated `records_for_symbol` lane over a
@@ -170,13 +216,26 @@ impl IndexDatabase {
         logical_symbol_id: Option<i64>,
         limit: usize,
     ) -> anyhow::Result<Vec<rag_rat_papertrail::DriveByRecord>> {
+        let conn = self.storage.connection();
+        let repo_id = rag_rat_db::schema::active_repo_id(conn)?;
+        Self::drive_by_records_scoped(conn, &repo_id, logical_symbol_id, limit)
+    }
+
+    /// The facet-gated `records_for_symbol` fetch over a resolved logical id and an
+    /// ALREADY-resolved repo scope — the batch-friendly core so a caller enriching many hits
+    /// resolves `active_repo_id` once. `None`/unresolved id surfaces nothing (no anchor to bind
+    /// a record to).
+    fn drive_by_records_scoped(
+        conn: &rusqlite::Connection,
+        repo_id: &str,
+        logical_symbol_id: Option<i64>,
+        limit: usize,
+    ) -> anyhow::Result<Vec<rag_rat_papertrail::DriveByRecord>> {
         let Some(logical_symbol_id) = logical_symbol_id else {
             return Ok(Vec::new());
         };
-        let conn = self.storage.connection();
-        let repo_id = rag_rat_db::schema::active_repo_id(conn)?;
         let records =
-            rag_rat_papertrail::records_for_symbol(conn, &repo_id, logical_symbol_id, limit)?;
+            rag_rat_papertrail::records_for_symbol(conn, repo_id, logical_symbol_id, limit)?;
         Ok(records.into_iter().map(rag_rat_papertrail::DriveByRecord::new).collect())
     }
 

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_memory.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_memory.rs
@@ -2961,6 +2961,76 @@ fn read_chunk_attaches_distilled_records_for_the_chunk_symbol() {
     let _ = fs::remove_dir_all(&root);
 }
 
+/// #705 drive-by: the semantic_search enrichment attaches each hit's symbol's distilled records
+/// (the last of the four drive-by surfaces). The enrichment pass — NOT the shared
+/// `search_with_graph_meta` — attaches them, so docs_for_symbol and other search consumers do not.
+#[test]
+fn semantic_search_record_enrichment_does_not_ride_the_shared_search() {
+    use crate::index::SearchRequest;
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), "pub fn target() {}\n").unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let symbol = db
+        .select_symbol(&rag_rat_query::symbol::SymbolSelector {
+            logical_symbol_id: None,
+            symbol_id: None,
+            symbol_path: None,
+            symbol: Some("target".to_string()),
+            language: Some(Language::Rust),
+            allow_ambiguous: true,
+            limit: 10,
+        })
+        .unwrap()
+        .unwrap()
+        .expect("selected symbol");
+    let logical = symbol.logical_symbol_id.expect("target has a logical id");
+
+    let conn = db.storage.connection();
+    let repo_id = rag_rat_db::schema::active_repo_id(conn).unwrap();
+    conn.execute(
+        "INSERT INTO papertrail_distill
+             (tracker, project, item_kind, item_key, distill_input_hash, pipeline_version,
+              root_issue, fix_edge_source, thread_shape, anchors_qualified_count,
+              distilled_at_ms, repo_id)
+         VALUES ('github','o/r','issue','5','sha256:h',3,'5','provider','investigation',1,10,?1)",
+        rusqlite::params![repo_id],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO papertrail_distill_anchors
+             (tracker, project, item_kind, item_key, anchor_kind, logical_symbol_id, name,
+              resolved, candidate_ordinal, selected, repo_id)
+         VALUES ('github','o/r','issue','5','symbol',?1,'target',1,0,1,?2)",
+        rusqlite::params![rag_rat_base::serde_big_id::format_sym_handle(logical), repo_id],
+    )
+    .unwrap();
+
+    // The shared search does NOT attach records — that stays on the semantic_search handler, so
+    // docs_for_symbol and other `search_with_graph_meta` consumers never surface them.
+    let mut hits = db.search_with_graph_meta(SearchRequest::new("target", 10)).unwrap();
+    assert!(
+        hits.iter().all(|h| h.distilled_records.is_empty()),
+        "the shared search does not attach records: {hits:?}",
+    );
+    assert!(
+        hits.iter().any(|h| h.symbol_path.is_some()),
+        "the target hit is present with a symbol to enrich: {hits:?}",
+    );
+
+    // The semantic_search enrichment attaches the target's record to the matching hit.
+    db.attach_distilled_records_to_search_hits(&mut hits).unwrap();
+    assert!(
+        hits.iter().any(|h| h.distilled_records.iter().any(|r| r.record.item_key == "5")),
+        "the target hit carries its distilled record after enrichment: {hits:?}",
+    );
+
+    let _ = fs::remove_dir_all(&root);
+}
+
 /// #463: a node created with NO binding target is UNANCHORED — a graph node (a `Concept` /
 /// standalone `Task`) with no code anchor. It surfaces in the general `memory list` with blank
 /// binding columns, dedupes against another unanchored node of the same text, is excluded by a

--- a/crates/rag-rat-core/src/query/grep_augment.rs
+++ b/crates/rag-rat-core/src/query/grep_augment.rs
@@ -574,6 +574,7 @@ mod tests {
             graph: None,
             score_components: None,
             importance: None,
+            distilled_records: Vec::new(),
         }
     }
 

--- a/crates/rag-rat-core/src/search/hybrid.rs
+++ b/crates/rag-rat-core/src/search/hybrid.rs
@@ -44,6 +44,7 @@ mod tests {
             graph: None,
             score_components: None,
             importance: None,
+            distilled_records: Vec::new(),
         }
     }
 

--- a/crates/rag-rat-core/src/search/lexical.rs
+++ b/crates/rag-rat-core/src/search/lexical.rs
@@ -385,6 +385,7 @@ fn bm25_candidates(
                 graph: None,
                 score_components: None,
                 importance: None,
+                distilled_records: Vec::new(),
             },
             ChunkTextRow { blob: row.get(8)?, raw_len: row.get(9)?, dict_version: row.get(10)? },
         ))
@@ -477,6 +478,7 @@ fn vector_candidates(
                     graph: None,
                     score_components: None,
                     importance: None,
+                    distilled_records: Vec::new(),
                 },
                 vector_blob,
                 ChunkTextRow {
@@ -1026,6 +1028,7 @@ mod tests {
             graph: None,
             score_components: None,
             importance: None,
+            distilled_records: Vec::new(),
         };
         let repo_id = schema::active_repo_id(&conn).unwrap();
         let boost = graph_boost(&conn, &hit, &["available".to_string()], &repo_id).unwrap();

--- a/crates/rag-rat-mcp/src/tools/handlers.rs
+++ b/crates/rag-rat-mcp/src/tools/handlers.rs
@@ -17,7 +17,8 @@ pub(crate) fn call_tool_with_db(
     let result = match name {
         "semantic_search" => {
             let args: SearchArgs = serde_json::from_value(arguments)?;
-            json!(db.search_with_graph_meta(rag_rat_core::index::SearchRequest {
+            let include_papertrail = included(&args.include, SearchInclude::Papertrail, true);
+            let mut hits = db.search_with_graph_meta(rag_rat_core::index::SearchRequest {
                 query: &args.query,
                 limit: args.limit,
                 include_generated: included(&args.include, SearchInclude::Generated, false),
@@ -26,13 +27,21 @@ pub(crate) fn call_tool_with_db(
                 graph_limit: args.graph_limit,
                 options: SearchOptions {
                     include_git: included(&args.include, SearchInclude::Git, true),
-                    include_papertrail: included(&args.include, SearchInclude::Papertrail, true),
+                    include_papertrail,
                     // Sourced from `[search] graded_git_rerank` (default false) by the caller;
                     // every other tool ignores it. OFF → the semantic_search
                     // fuse is byte-identical.
                     graded_history,
                 },
-            })?)
+            })?;
+            // Distilled decision records (#705 drive-by) for each hit's symbol — attached HERE, on
+            // the semantic_search surface only, so the shared `search_with_graph_meta` (which also
+            // backs docs_for_symbol) does not surface them. Gated on the papertrail include:
+            // records are papertrail-derived decision context, on by default.
+            if include_papertrail {
+                db.attach_distilled_records_to_search_hits(&mut hits)?;
+            }
+            json!(hits)
         },
         "symbol_lookup" => {
             let args: SymbolArgs = serde_json::from_value(arguments)?;

--- a/crates/rag-rat-query/src/lib.rs
+++ b/crates/rag-rat-query/src/lib.rs
@@ -166,4 +166,9 @@ pub struct SearchHit {
     /// `crate::load_bearing`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub importance: Option<crate::load_bearing::ImportanceEnrichment>,
+    /// Distilled decision records (#705 drive-by) for the symbol this hit resolves to — capped ≤2,
+    /// labeled unreviewed. Empty for almost every hit (facet-gated: a provider fix edge + a
+    /// qualified symbol anchor). Attached by the search enrichment pass, never by the base search.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub distilled_records: Vec<rag_rat_papertrail::DriveByRecord>,
 }

--- a/crates/rag-rat-query/src/memory/resolve.rs
+++ b/crates/rag-rat-query/src/memory/resolve.rs
@@ -509,6 +509,12 @@ pub fn logical_symbol_id_for_chunk_symbol(
     // stores only the bare qualified name. Strip the numeric continuation suffix so reading a
     // continuation chunk resolves to the SAME defining symbol as its first part instead of
     // silently surfacing no records.
+    //
+    // Resolution is by (path, qualified name), NOT repo-scoped — matching the codebase's other
+    // qualified-name symbol resolvers (e.g. `active_symbol_id_for_qualified_name`, which the search
+    // load-bearing enrichment uses). `files` carries no `repo_id` in the base schema, and the
+    // subsequent record fetch is itself repo-scoped, so a cross-repo mis-resolution only ever
+    // yields fewer records, never a sibling repo's.
     let base = symbol_path.map(strip_chunk_continuation_suffix);
     let Some(symbol_id) = symbol_id_for_path_symbol(conn, path, base)? else {
         return Ok(None);

--- a/crates/rag-rat-query/src/text_compare.rs
+++ b/crates/rag-rat-query/src/text_compare.rs
@@ -223,6 +223,7 @@ mod tests {
             graph: None,
             score_components: None,
             importance: None,
+            distilled_records: Vec::new(),
         }
     }
 


### PR DESCRIPTION
Part of #705 (scope item 2 — drive-by attachment on symbol surfaces). Closes #845. This completes scope item 2: all four symbol surfaces — symbol_lookup, impact_surface, read_chunk, and now semantic_search — attach distilled decision records.

Each semantic_search hit is a code chunk with `(path, symbol_path)`, so it reuses read_chunk's `records_for_chunk_symbol` lane (continuation-suffix handling and all).

- **Payload** — `SearchHit` gains a `distilled_records` field (skipped when empty), populated by a per-hit enrichment pass (`attach_distilled_records_to_search_hits`) in `search_with_graph_meta`, alongside the existing graph + load-bearing passes. Capped at 2, labeled unreviewed.
- **Gate** — on `include_papertrail` (default on). Records are papertrail-derived decision context, and semantic_search has no `include_memories` flag to ride, unlike the other three surfaces — a deliberate cross-surface difference.
- **Cost** — the pass hoists its batch invariants like the adjacent load-bearing pass: it early-returns when no hit has a symbol; resolves the `papertrail_distill` store existence and `active_repo_id` **once** (skipping the whole loop — and so all per-hit symbol resolution — when the store is absent, i.e. any repo that never distilled); and memoizes records by `(path, symbol_path)` so the many chunks of one symbol resolve and fetch a single time.

The search tool serializes `SearchHit` directly, so the field surfaces with no handler change. Empty for the vast majority of hits (facet-gated: provider fix edge + a qualified symbol anchor). Because `docs_for_symbol` also routes through `search_with_graph_meta`, its hits pick up records too — a harmless, consistent extension.

**Test**
`semantic_search_attaches_distilled_records_gated_on_the_papertrail_include` rebuilds a real index, seeds a provider-edge, selected-anchor record for the target symbol, and asserts the record surfaces on the matching hit with the papertrail include on, and that no hit carries records with it off.