### PR TITLE
perf(index): skip the logical-symbol rebuild when a batch's key multiset is unchanged

### DIFF
--- a/crates/rag-rat-core/src/index/graph_index.rs
+++ b/crates/rag-rat-core/src/index/graph_index.rs
@@ -1,6 +1,8 @@
 //! Graph/edge/logical-symbol index lifecycle: resolve edges, (re)build logical symbols, graph
 //! coverage, and graph-index freshness.
 
+use std::collections::BTreeMap;
+
 use super::*;
 
 /// Grouping key that collapses cfg variants / overloads of one symbol into a single logical symbol.
@@ -378,6 +380,88 @@ pub(super) enum KeyVersionStamp {
     Defer,
 }
 
+/// One replacement symbol's owed membership row (#820): produced when a file rewrite kept its
+/// logical-key multiset, so the grouped table needs no rebuild — only the member pointers, which
+/// died with the replaced symbol rows (`logical_symbol_members` cascades on `symbols` deletes).
+/// Field-for-field what [`IndexDatabase::insert_logical_group`]'s member INSERT writes.
+#[derive(Debug)]
+pub(super) struct LogicalMemberRelink {
+    logical_symbol_id: i64,
+    symbol_id: i64,
+    signature_hash: Option<String>,
+    start_line: i64,
+    end_line: i64,
+}
+
+/// Whether one write batch's logical-symbol tail can be served by a targeted member re-link
+/// instead of the whole-repo rebuild (#820). A body-only edit re-inserts a file's symbols under
+/// new row ids, but when the logical KEY multiset (language, path, name, qualified name, kind,
+/// signature) is unchanged, the rebuilt `logical_symbols` table would be identical — only the
+/// members' `symbol_id` pointers moved. Accumulated per batch while applying the per-file
+/// incremental plan; ANY non-key-stable change downgrades the whole batch to today's
+/// rebuild/marker behavior.
+#[derive(Debug)]
+pub(super) enum LogicalGroupingUpkeep {
+    /// Every change so far replaced a file's symbols under an IDENTICAL logical-key multiset:
+    /// the grouped table already matches what a rebuild would produce; only these member rows
+    /// are owed. NEVER a clearer of the #819 pending marker — an outstanding obligation must
+    /// survive to its settle point (`rebuild_logical_symbols` is the sole clearer).
+    RelinkMembers(Vec<LogicalMemberRelink>),
+    /// Some change altered a file's key set (an added/removed/tombstoned file, a rename, a
+    /// signature or kind change, or a mutation outside the per-file plan) — the batch owes the
+    /// full rebuild, exactly the pre-#820 behavior.
+    RebuildRequired,
+}
+
+impl LogicalGroupingUpkeep {
+    /// Whether the batch is still on the relink path — the guard for paying the per-file key
+    /// capture at all.
+    pub(super) fn is_relinkable(&self) -> bool {
+        matches!(self, Self::RelinkMembers(_))
+    }
+
+    /// Downgrade the batch to the full rebuild. Relinks gathered so far are dropped — the
+    /// rebuild re-derives every membership anyway.
+    pub(super) fn require_rebuild(&mut self) {
+        *self = Self::RebuildRequired;
+    }
+
+    /// Fold one replaced file's verdict in: `None` (the key multiset changed, or the old
+    /// grouping was unavailable) downgrades the whole batch; owed relinks accumulate.
+    pub(super) fn absorb_replaced_file(&mut self, relinks: Option<Vec<LogicalMemberRelink>>) {
+        let Some(owed) = relinks else {
+            self.require_rebuild();
+            return;
+        };
+        if let Self::RelinkMembers(pending) = self {
+            pending.extend(owed);
+        }
+    }
+}
+
+/// The six logical-key columns of one symbol row in the scope being rewritten — exactly the
+/// identity [`IndexDatabase::rebuild_logical_symbols`] groups by. `Ord` so the multiset
+/// comparison is a `BTreeMap` walk; `Option` fields compare `None`-first, and `None` never
+/// equals `Some` (an absent qualified name or signature is no wildcard).
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub(super) struct ReplacedSymbolKey {
+    language: String,
+    path: String,
+    name: String,
+    qualified_name: Option<String>,
+    kind: String,
+    signature: Option<String>,
+}
+
+/// One logical key's grouped claim in the scope row being replaced: the logical row the old
+/// members point at, and how many of THIS file's symbols it held. Per-key member counts are part
+/// of the stability bar — a count change would stale the logical row's `variant_count` /
+/// `group_reason`, which only the rebuild recomputes.
+pub(super) struct GroupedKeyClaim {
+    logical_symbol_id: i64,
+    members: usize,
+}
+
 /// A re-derived logical row competing to inherit a drifted reference — see
 /// [`IndexDatabase::heal_logical_key_drift`]. Carries `kind` so the strict (kind-agreeing)
 /// subset is split in memory from one kind-relaxed fetch, keeping cross-kind contenders visible
@@ -630,6 +714,204 @@ impl IndexDatabase {
             &self.active_repo_id,
             super::worktree_overlay::OVERLAY_LOGICAL_REBUILD_PENDING_META,
         )?;
+        Ok(())
+    }
+
+    /// Open the per-batch logical-grouping verdict (#820). Starts on the relink path unless the
+    /// repo's logical-key version stamp lags [`LOGICAL_KEY_VERSION`]: a lagging stamp schedules
+    /// the #493 drift heal, which only [`Self::rebuild_logical_symbols`] performs — the relink
+    /// shortcut must not defer it (and must not leave the memoized drift snapshot unconsumed),
+    /// so a lagging repo keeps today's rebuild on every mutating pass. One `repo_meta` read.
+    pub(super) fn begin_logical_grouping_upkeep(&self) -> anyhow::Result<LogicalGroupingUpkeep> {
+        let key_version_current =
+            self.repo_meta(LOGICAL_KEY_VERSION_KEY)?.as_deref() == Some(LOGICAL_KEY_VERSION);
+        Ok(if key_version_current {
+            LogicalGroupingUpkeep::RelinkMembers(Vec::new())
+        } else {
+            LogicalGroupingUpkeep::RebuildRequired
+        })
+    }
+
+    /// The grouped logical-key claims of the scope row at `(path, commit_sha, worktree_id)` —
+    /// captured BEFORE [`Self::remove_file_in_scope`] cascades the member rows away with the
+    /// symbols. `None` when the grouping cannot vouch for the file: a symbol with NO member row
+    /// (the scope row was committed by an interrupted #819 batch and never regrouped — its keys
+    /// are not in the grouped table, so a relink would fabricate members against missing or
+    /// stale logical rows) or two same-key symbols pointing at different logical rows. The
+    /// caller then falls back to the rebuild, which is always correct.
+    pub(super) fn load_grouped_key_claims(
+        &self,
+        path: &Path,
+        commit_sha: &str,
+        worktree_id: &str,
+    ) -> anyhow::Result<Option<BTreeMap<ReplacedSymbolKey, GroupedKeyClaim>>> {
+        let conn = self.storage.connection();
+        // Same joins as the rebuild's grouping SELECT (raw `main.*`, repo + generation scoped),
+        // narrowed to the one scope row being replaced.
+        let mut stmt = conn.prepare_cached(
+            "
+            SELECT s.language, f.path, s.name, qn.value, s.kind, s.signature,
+                   m.logical_symbol_id
+            FROM main.symbols s
+            JOIN main.files f ON f.id = s.file_id
+            LEFT JOIN main.name_strings qn ON qn.id = s.qualified_name_id
+            LEFT JOIN main.logical_symbol_members m ON m.symbol_id = s.id
+            WHERE f.repo_id = ?1 AND f.path = ?2 AND f.commit_sha = ?3 AND f.worktree_id = ?4
+              AND f.generation = ?5
+            ",
+        )?;
+        let mut rows = stmt.query(params![
+            self.active_repo_id,
+            rag_rat_base::paths::path_string(path),
+            commit_sha,
+            worktree_id,
+            self.active_generation,
+        ])?;
+        let mut claims: BTreeMap<ReplacedSymbolKey, GroupedKeyClaim> = BTreeMap::new();
+        while let Some(row) = rows.next()? {
+            let key = ReplacedSymbolKey {
+                language: row.get(0)?,
+                path: row.get(1)?,
+                name: row.get(2)?,
+                qualified_name: row.get(3)?,
+                kind: row.get(4)?,
+                signature: row.get(5)?,
+            };
+            let Some(logical_symbol_id) = row.get::<_, Option<i64>>(6)? else {
+                return Ok(None); // ungrouped symbol — the grouping cannot vouch for this file
+            };
+            match claims.entry(key) {
+                std::collections::btree_map::Entry::Occupied(mut entry) => {
+                    let claim = entry.get_mut();
+                    if claim.logical_symbol_id != logical_symbol_id {
+                        return Ok(None); // same key split across logical rows — inconsistent
+                    }
+                    claim.members += 1;
+                },
+                std::collections::btree_map::Entry::Vacant(entry) => {
+                    entry.insert(GroupedKeyClaim { logical_symbol_id, members: 1 });
+                },
+            }
+        }
+        Ok(Some(claims))
+    }
+
+    /// The member rows owed to the JUST-INSERTED replacement symbols at the same scope, or
+    /// `None` when the rewrite changed the file's logical-key multiset — any added, removed,
+    /// renamed, re-kinded or re-signatured symbol, including a count change of one key's cfg
+    /// variants (which would stale `variant_count`/`group_reason`). Exactness is the
+    /// correctness bar: a false key-stable verdict would leave `logical_symbol_members` missing
+    /// rows for live symbols and break graph navigation, so all six key columns are compared as
+    /// an exact per-file multiset. Owed rows reuse the OLD members' `logical_symbol_id` (the
+    /// deterministic `stable_id` a rebuild would re-derive for the same key) and carry the
+    /// replacement symbols' fresh line spans — a body edit shifts lines even when keys hold.
+    pub(super) fn derive_key_stable_relinks(
+        &self,
+        path: &Path,
+        commit_sha: &str,
+        worktree_id: &str,
+        replaced: &BTreeMap<ReplacedSymbolKey, GroupedKeyClaim>,
+    ) -> anyhow::Result<Option<Vec<LogicalMemberRelink>>> {
+        struct ReplacementSymbolSpan {
+            symbol_id: i64,
+            start_line: i64,
+            end_line: i64,
+        }
+        let conn = self.storage.connection();
+        let mut stmt = conn.prepare_cached(
+            "
+            SELECT s.language, f.path, s.name, qn.value, s.kind, s.signature,
+                   s.id, s.start_line, s.end_line
+            FROM main.symbols s
+            JOIN main.files f ON f.id = s.file_id
+            LEFT JOIN main.name_strings qn ON qn.id = s.qualified_name_id
+            WHERE f.repo_id = ?1 AND f.path = ?2 AND f.commit_sha = ?3 AND f.worktree_id = ?4
+              AND f.generation = ?5
+            ",
+        )?;
+        let mut rows = stmt.query(params![
+            self.active_repo_id,
+            rag_rat_base::paths::path_string(path),
+            commit_sha,
+            worktree_id,
+            self.active_generation,
+        ])?;
+        let mut inserted: BTreeMap<ReplacedSymbolKey, Vec<ReplacementSymbolSpan>> = BTreeMap::new();
+        while let Some(row) = rows.next()? {
+            let key = ReplacedSymbolKey {
+                language: row.get(0)?,
+                path: row.get(1)?,
+                name: row.get(2)?,
+                qualified_name: row.get(3)?,
+                kind: row.get(4)?,
+                signature: row.get(5)?,
+            };
+            inserted.entry(key).or_default().push(ReplacementSymbolSpan {
+                symbol_id: row.get(6)?,
+                start_line: row.get(7)?,
+                end_line: row.get(8)?,
+            });
+        }
+        // Every inserted key must exist in the replaced set with the SAME member count, and the
+        // key-set cardinalities must match — together that is exact multiset equality.
+        if inserted.len() != replaced.len() {
+            return Ok(None);
+        }
+        let mut relinks = Vec::new();
+        for (key, members) in inserted {
+            let Some(claim) = replaced.get(&key) else {
+                return Ok(None);
+            };
+            if claim.members != members.len() {
+                return Ok(None);
+            }
+            // Hash exactly as `insert_logical_group` does (untrimmed bytes), so the relinked
+            // member row is byte-identical to what the rebuild would write.
+            let signature_hash = key
+                .signature
+                .as_deref()
+                .map(|signature| rag_rat_base::hash::hex_sha256(signature.as_bytes()));
+            for member in members {
+                relinks.push(LogicalMemberRelink {
+                    logical_symbol_id: claim.logical_symbol_id,
+                    symbol_id: member.symbol_id,
+                    signature_hash: signature_hash.clone(),
+                    start_line: member.start_line,
+                    end_line: member.end_line,
+                });
+            }
+        }
+        Ok(Some(relinks))
+    }
+
+    /// Write the owed member rows of a key-stable batch (#820) — the exact shape
+    /// [`Self::insert_logical_group`]'s member INSERT writes (`cfg_expr` NULL, sha256 signature
+    /// hash) — pointing the surviving logical rows at the replacement symbol ids. Runs inside
+    /// the caller's write transaction, alongside the symbol rewrite it repairs. Deliberately
+    /// NOT a clearer of the #819 pending marker: a relink is not a rebuild, and an outstanding
+    /// obligation must survive to its settle point.
+    pub(super) fn apply_logical_member_relinks(
+        &self,
+        relinks: &[LogicalMemberRelink],
+    ) -> anyhow::Result<()> {
+        let conn = self.storage.connection();
+        for relink in relinks {
+            conn.prepare_cached(
+                "
+                INSERT INTO logical_symbol_members(
+                    logical_symbol_id, symbol_id, cfg_expr, signature_hash, start_line, end_line
+                )
+                VALUES (?1, ?2, NULL, ?3, ?4, ?5)
+                ",
+            )?
+            .execute(params![
+                relink.logical_symbol_id,
+                relink.symbol_id,
+                relink.signature_hash,
+                relink.start_line,
+                relink.end_line,
+            ])?;
+        }
         Ok(())
     }
 

--- a/crates/rag-rat-core/src/index/incremental.rs
+++ b/crates/rag-rat-core/src/index/incremental.rs
@@ -13,6 +13,17 @@ struct IncrementalFilesOutcome {
     indexed: usize,
     manifest_in_change_set: bool,
     carried: usize,
+    /// The batch's logical-grouping verdict (#820): whether the pass's tail may re-link members
+    /// instead of paying the whole-repo `rebuild_logical_symbols`.
+    logical: graph_index::LogicalGroupingUpkeep,
+}
+
+/// What the shared prepared-file WRITE step did: the rows that actually landed (per-file writes
+/// plus tombstones — the caller's `mutated`/finalize gate input, unchanged), and the batch's
+/// logical-grouping verdict (#820) accumulated while replacing files.
+pub(super) struct IncrementalWriteOutcome {
+    pub(super) written: usize,
+    pub(super) logical: graph_index::LogicalGroupingUpkeep,
 }
 
 /// Everything the incremental/discover WRITE phase needs, computed entirely OUTSIDE the write
@@ -330,7 +341,7 @@ impl IndexDatabase {
             // per-file writes are keyed by (path, commit_sha, worktree_id) scope, so they are
             // idempotent against any intervening lockless overlay heal; and the flock has excluded
             // the only writer that could flip `active_generation`.
-            let IncrementalFilesOutcome { indexed, manifest_in_change_set, carried } =
+            let IncrementalFilesOutcome { indexed, manifest_in_change_set, carried, logical } =
                 db.apply_prepared_incremental_pass(&prepared, effective_mode, progress)?;
             let base_scope_discovery_marked = if effective_mode == IndexMode::Discover {
                 db.mark_active_base_scope_discovered(&config.targets)?
@@ -377,10 +388,29 @@ impl IndexDatabase {
             // re-resolves so a carried caller's edge re-points at re-derived rowids
             // (#502).
             if indexed > 0 || healed > 0 || carried > 0 || roots_changed {
-                progress(IndexProgress::RebuildingLogicalSymbols);
-                // Defer: this pass re-parsed only the CHANGED files, so it must not stamp the
-                // logical-key version — untouched files' drift is still in the future (#493).
-                db.rebuild_logical_symbols(graph_index::KeyVersionStamp::Defer)?;
+                // #820: a batch whose EVERY change was a key-stable file replacement keeps the
+                // grouped table correct by re-linking members inside this same transaction —
+                // the wholesale rebuild is owed only when a key set changed, or when the pass
+                // mutated grouping-relevant state OUTSIDE the per-file plan (an overlay heal
+                // moves symbols across scopes; a carry re-stamps scope rows; a package-map
+                // change keeps today's rebuild coupling). A pre-existing #819 obligation is
+                // untouched either way — the pass's tail settle below still consumes it.
+                let key_stable_relinks = match logical {
+                    graph_index::LogicalGroupingUpkeep::RelinkMembers(relinks)
+                        if healed == 0 && carried == 0 && !roots_changed =>
+                        Some(relinks),
+                    _ => None,
+                };
+                match key_stable_relinks {
+                    Some(relinks) => db.apply_logical_member_relinks(&relinks)?,
+                    None => {
+                        progress(IndexProgress::RebuildingLogicalSymbols);
+                        // Defer: this pass re-parsed only the CHANGED files, so it must not
+                        // stamp the logical-key version — untouched files' drift is still in
+                        // the future (#493).
+                        db.rebuild_logical_symbols(graph_index::KeyVersionStamp::Defer)?;
+                    },
+                }
                 progress(IndexProgress::ResolvingGraph);
                 db.resolve_edges()?;
                 db.mark_graph_index_current()?;
@@ -774,16 +804,17 @@ impl IndexDatabase {
         } else {
             0
         };
-        let indexed = self.write_prepared_incremental_files(
+        let written = self.write_prepared_incremental_files(
             &prepared.prepared_files,
             &prepared.deleted,
             Some(mode),
             progress,
         )?;
         Ok(IncrementalFilesOutcome {
-            indexed,
+            indexed: written.written,
             manifest_in_change_set: prepared.manifest_in_change_set,
             carried,
+            logical: written.logical,
         })
     }
 
@@ -922,7 +953,7 @@ impl IndexDatabase {
         files: Vec<IndexFile>,
         deleted: BTreeSet<PathBuf>,
         progress: &mut F,
-    ) -> anyhow::Result<usize>
+    ) -> anyhow::Result<IncrementalWriteOutcome>
     where
         F: FnMut(IndexProgress),
     {
@@ -944,10 +975,17 @@ impl IndexDatabase {
         deleted: &BTreeSet<PathBuf>,
         mode_guard: Option<IndexMode>,
         progress: &mut F,
-    ) -> anyhow::Result<usize>
+    ) -> anyhow::Result<IncrementalWriteOutcome>
     where
         F: FnMut(IndexProgress),
     {
+        // #820: the batch's logical-grouping verdict, opened only when this call can actually
+        // mutate rows — an idle pass (nothing prepared, nothing deleted) stays at zero reads.
+        let mut logical = if prepared.is_empty() && deleted.is_empty() {
+            graph_index::LogicalGroupingUpkeep::RelinkMembers(Vec::new())
+        } else {
+            self.begin_logical_grouping_upkeep()?
+        };
         // `mode_guard` is `Some` only for the #560 hoisted path, whose plan was prepared OFF the
         // write lock; the in-txn callers (zero-hit heal, worktree-overlay pass) prepare inside
         // their own transaction — no concurrent commit is possible — so they pass `None`
@@ -984,6 +1022,11 @@ impl IndexDatabase {
             }
             self.mark_file_deleted(path)?;
             deleted_count += 1;
+        }
+        // A tombstoned path removes a whole file's keys from the grouped corpus — never
+        // key-stable (#820).
+        if deleted_count > 0 {
+            logical.require_rebuild();
         }
 
         let total = prepared.len();
@@ -1044,6 +1087,18 @@ impl IndexDatabase {
             {
                 continue;
             }
+            // #820 key-stability capture, BEFORE the removal cascades the old member rows away
+            // with the symbols. Skipped once the batch already owes a rebuild — the capture
+            // would be dead weight then.
+            let replaced_grouping = if logical.is_relinkable() {
+                self.load_grouped_key_claims(
+                    &prepared_file.file.relative_path,
+                    &prepared_file.file.commit_sha,
+                    &prepared_file.file.worktree_id,
+                )?
+            } else {
+                None
+            };
             self.remove_file_in_scope(
                 &prepared_file.file.relative_path,
                 &prepared_file.file.commit_sha,
@@ -1055,11 +1110,24 @@ impl IndexDatabase {
             // terminal tail.
             self.insert_prepared_file(prepared_file, None)?;
             written += 1;
+            // Compare the replacement's key multiset against the captured claims: identical →
+            // the file's owed member rows accumulate; anything else (including a first-time
+            // scope row, whose captured claims are empty) downgrades the batch to the rebuild.
+            let owed_relinks = match &replaced_grouping {
+                Some(replaced) => self.derive_key_stable_relinks(
+                    &prepared_file.file.relative_path,
+                    &prepared_file.file.commit_sha,
+                    &prepared_file.file.worktree_id,
+                    replaced,
+                )?,
+                None => None,
+            };
+            logical.absorb_replaced_file(owed_relinks);
         }
 
         // Count only what actually landed (skips excluded), so an all-skipped pass keeps the
         // caller's `mutated` flag honest and preserves the #63 idle no-write invariant.
-        Ok(written + deleted_count)
+        Ok(IncrementalWriteOutcome { written: written + deleted_count, logical })
     }
 }
 

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_overlay.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_overlay.rs
@@ -1966,3 +1966,372 @@ fn overlay_basis_writes_ride_the_refresh_transaction() {
     let _ = fs::remove_dir_all(&main);
     let _ = fs::remove_dir_all(&linked);
 }
+
+/// How many `logical_symbol_members` rows for `logical_name`'s logical rows resolve to a LIVE
+/// symbol row — the #820 relink observable: a member pointing at a deleted symbol id (or a
+/// replacement symbol missing its member row) shows up here as a wrong count, which is exactly
+/// the breakage a false key-stable verdict would cause.
+fn live_member_count(db: &IndexDatabase, logical_name: &str) -> i64 {
+    db.storage
+        .connection()
+        .query_row(
+            "SELECT COUNT(*) FROM main.logical_symbol_members m
+             JOIN main.logical_symbols ls ON ls.id = m.logical_symbol_id
+             JOIN main.symbols s ON s.id = m.symbol_id
+             WHERE ls.repo_id = ?1 AND ls.logical_name = ?2",
+            rusqlite::params![db.active_repo_id, logical_name],
+            |row| row.get(0),
+        )
+        .unwrap()
+}
+
+/// Every grouped row + member of the repo, rendered to comparable strings — so a test can assert
+/// the #820 relink path's output is the FIXED POINT of `rebuild_logical_symbols` (running the
+/// wholesale rebuild on top of a relinked state changes nothing, byte for byte).
+fn logical_grouping_snapshot(db: &IndexDatabase) -> Vec<String> {
+    let conn = db.storage.connection();
+    let mut snapshot = Vec::new();
+    let mut rows = conn
+        .prepare(
+            "SELECT ls.id, ls.language, ls.path, ls.logical_name,
+                    COALESCE((SELECT value FROM name_strings WHERE id = ls.qualified_name_id), ''),
+                    ls.kind, ls.variant_count, ls.group_reason
+             FROM main.logical_symbols ls WHERE ls.repo_id = ?1 ORDER BY ls.id",
+        )
+        .unwrap()
+        .query_map(rusqlite::params![db.active_repo_id], |row| {
+            Ok(format!(
+                "row {}|{}|{}|{}|{}|{}|{}|{}",
+                row.get::<_, i64>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, String>(3)?,
+                row.get::<_, String>(4)?,
+                row.get::<_, String>(5)?,
+                row.get::<_, i64>(6)?,
+                row.get::<_, String>(7)?,
+            ))
+        })
+        .unwrap()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+    snapshot.append(&mut rows);
+    let mut members = conn
+        .prepare(
+            "SELECT m.logical_symbol_id, m.symbol_id, COALESCE(m.cfg_expr, ''),
+                    COALESCE(m.signature_hash, ''), m.start_line, m.end_line
+             FROM main.logical_symbol_members m
+             JOIN main.logical_symbols ls ON ls.id = m.logical_symbol_id
+             WHERE ls.repo_id = ?1 ORDER BY m.logical_symbol_id, m.symbol_id",
+        )
+        .unwrap()
+        .query_map(rusqlite::params![db.active_repo_id], |row| {
+            Ok(format!(
+                "member {}|{}|{}|{}|{}|{}",
+                row.get::<_, i64>(0)?,
+                row.get::<_, i64>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, String>(3)?,
+                row.get::<_, i64>(4)?,
+                row.get::<_, i64>(5)?,
+            ))
+        })
+        .unwrap()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+    snapshot.append(&mut members);
+    snapshot
+}
+
+#[test]
+fn a_body_only_overlay_edit_relinks_members_without_a_rebuild() {
+    // #820: a body-only edit re-inserts the file's symbols under NEW row ids, but the logical
+    // KEY multiset (language, path, name, qualified name, kind, signature) is unchanged — the
+    // rebuilt `logical_symbols` table would be identical, so the refresh re-points the members
+    // at the replacement symbol ids instead of paying the whole-repo DELETE-all + re-derive.
+    // The counter is the observable: pre-#820 this pass rebuilt (delta 1) and fails the zero
+    // assertion below.
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(main.join("src/a.rs"), "pub fn base_fn() {}\n").unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let config = source_config(main.clone(), Language::Rust);
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    // MULTI-line fn: the stored signature is the declaration's first line, so a body edit below
+    // it keeps all six key columns. (A one-liner's body is part of its signature line — that
+    // edit is a key change and correctly keeps the rebuild.)
+    fs::write(linked.join("src/one.rs"), "pub fn one_fn() -> i32 {\n    1\n}\n").unwrap();
+    run_git(&linked, &["add", "."]);
+    run_git(&linked, &["commit", "-q", "-m", "branch adds one_fn"]);
+
+    // First refresh: the overlay file is ADDED — a key-set change, so the batch pays its one
+    // rebuild and the branch symbol becomes resolvable.
+    crate::watch::refresh_worktree_overlays(
+        &mut db,
+        &config,
+        None,
+        &crate::watch::OverlayScope::All,
+    );
+    assert!(logical_symbol_named(&db, "one_fn"), "the added overlay file is grouped");
+
+    // Body-only edit: same declaration line, different body — the key multiset holds.
+    fs::write(linked.join("src/one.rs"), "pub fn one_fn() -> i32 {\n    2\n}\n").unwrap();
+    let before = db.logical_symbol_rebuilds.load(std::sync::atomic::Ordering::Relaxed);
+    crate::watch::refresh_worktree_overlays(
+        &mut db,
+        &config,
+        None,
+        &crate::watch::OverlayScope::All,
+    );
+    assert_eq!(
+        db.logical_symbol_rebuilds.load(std::sync::atomic::Ordering::Relaxed) - before,
+        0,
+        "a key-stable batch pays ZERO repo-global rebuilds"
+    );
+    assert!(!logical_rebuild_pending(&db), "a key-stable batch creates no rebuild obligation");
+    // The replacement symbols are grouped and their members resolve to LIVE symbol rows — the
+    // exact property a false key-stable verdict would break.
+    assert!(logical_symbol_named(&db, "one_fn"));
+    assert_eq!(live_member_count(&db, "one_fn"), 1, "the member points at the live symbol");
+
+    // The relinked state is the wholesale rebuild's FIXED POINT: forcing the rebuild changes
+    // nothing, byte for byte — grouped rows, ids, variant counts, member spans and hashes.
+    let relinked = logical_grouping_snapshot(&db);
+    db.rebuild_logical_symbols(crate::index::graph_index::KeyVersionStamp::Defer).unwrap();
+    assert_eq!(
+        logical_grouping_snapshot(&db),
+        relinked,
+        "relink output must equal the rebuild's output"
+    );
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}
+
+#[test]
+fn key_altering_edits_force_the_full_rebuild() {
+    // #820 adversarial matrix: every change that alters a file's logical-key multiset must keep
+    // today's rebuild — a signature change, a rename, an added file, a tombstoned base file,
+    // and a pruned branch-only file. A false key-stable verdict on any of these would leave
+    // members pointing at deleted symbol ids or stale rows orphaned in the grouping.
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(main.join("src/a.rs"), "pub fn base_fn() {}\n").unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let config = source_config(main.clone(), Language::Rust);
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    fs::write(linked.join("src/one.rs"), "pub fn one_fn() -> i32 {\n    1\n}\n").unwrap();
+    run_git(&linked, &["add", "."]);
+    run_git(&linked, &["commit", "-q", "-m", "branch adds one_fn"]);
+    crate::watch::refresh_worktree_overlays(
+        &mut db,
+        &config,
+        None,
+        &crate::watch::OverlayScope::All,
+    );
+    assert!(logical_symbol_named(&db, "one_fn"));
+    let rebuilds =
+        |db: &IndexDatabase| db.logical_symbol_rebuilds.load(std::sync::atomic::Ordering::Relaxed);
+
+    // A SIGNATURE change (same name) alters the key.
+    fs::write(linked.join("src/one.rs"), "pub fn one_fn(bump: i32) -> i32 {\n    bump\n}\n")
+        .unwrap();
+    let before = rebuilds(&db);
+    crate::watch::refresh_worktree_overlays(
+        &mut db,
+        &config,
+        None,
+        &crate::watch::OverlayScope::All,
+    );
+    assert_eq!(rebuilds(&db) - before, 1, "a signature change pays the rebuild");
+    assert_eq!(live_member_count(&db, "one_fn"), 1, "the re-derived group is live");
+
+    // A RENAME drops one key and adds another; the stale logical row must be GONE afterwards —
+    // exactly the orphan a falsely-engaged relink would leave behind.
+    fs::write(linked.join("src/one.rs"), "pub fn one_fn_renamed() -> i32 {\n    3\n}\n").unwrap();
+    let before = rebuilds(&db);
+    crate::watch::refresh_worktree_overlays(
+        &mut db,
+        &config,
+        None,
+        &crate::watch::OverlayScope::All,
+    );
+    assert_eq!(rebuilds(&db) - before, 1, "a rename pays the rebuild");
+    assert!(logical_symbol_named(&db, "one_fn_renamed"));
+    assert!(!logical_symbol_named(&db, "one_fn"), "the old key's row is dropped, not orphaned");
+
+    // An ADDED file introduces new keys.
+    fs::write(linked.join("src/two.rs"), "pub fn two_fn() -> i32 {\n    4\n}\n").unwrap();
+    let before = rebuilds(&db);
+    crate::watch::refresh_worktree_overlays(
+        &mut db,
+        &config,
+        None,
+        &crate::watch::OverlayScope::All,
+    );
+    assert_eq!(rebuilds(&db) - before, 1, "an added file pays the rebuild");
+    assert!(logical_symbol_named(&db, "two_fn"));
+
+    // A TOMBSTONED base file (deleted in the worktree, present in the base tree) removes keys
+    // from the branch's view.
+    fs::remove_file(linked.join("src/a.rs")).unwrap();
+    let before = rebuilds(&db);
+    crate::watch::refresh_worktree_overlays(
+        &mut db,
+        &config,
+        None,
+        &crate::watch::OverlayScope::All,
+    );
+    assert_eq!(rebuilds(&db) - before, 1, "a tombstoned file pays the rebuild");
+
+    // A PRUNED branch-only file (deleted from the worktree with no base row to shadow) removes
+    // its keys entirely.
+    fs::remove_file(linked.join("src/one.rs")).unwrap();
+    let before = rebuilds(&db);
+    crate::watch::refresh_worktree_overlays(
+        &mut db,
+        &config,
+        None,
+        &crate::watch::OverlayScope::All,
+    );
+    assert_eq!(rebuilds(&db) - before, 1, "a pruned overlay row pays the rebuild");
+    assert!(!logical_symbol_named(&db, "one_fn_renamed"), "the pruned file's keys are dropped");
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}
+
+#[test]
+fn a_key_stable_relink_leaves_a_pending_obligation_for_the_tail() {
+    // #820 × #819: the relink path must NEVER clear (or mask) a pre-existing pending rebuild
+    // obligation — only `rebuild_logical_symbols` clears the marker. An interrupted Deferred
+    // batch leaves the marker committed and an UNGROUPED overlay file behind; a body-only
+    // follow-up edit then takes the relink path (its own file's grouping is intact), and the
+    // marker must survive that refresh for the batch tail to settle.
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(main.join("src/a.rs"), "pub fn base_fn() {}\n").unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let config = source_config(main.clone(), Language::Rust);
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    fs::write(linked.join("src/one.rs"), "pub fn one_fn() -> i32 {\n    1\n}\n").unwrap();
+    run_git(&linked, &["add", "."]);
+    run_git(&linked, &["commit", "-q", "-m", "branch adds one_fn"]);
+    // A complete first refresh grounds one_fn's grouping.
+    crate::watch::refresh_worktree_overlays(
+        &mut db,
+        &config,
+        None,
+        &crate::watch::OverlayScope::All,
+    );
+    assert!(logical_symbol_named(&db, "one_fn"));
+
+    // Interrupted Deferred batch (#819's scenario): a NEW branch file's rows + the marker are
+    // committed, the batch tail never runs — its symbols stay ungrouped.
+    fs::write(linked.join("src/new.rs"), "pub fn branch_only_fn() {}\n").unwrap();
+    let tail = crate::index::OverlayRefreshTail {
+        logical_rebuild: crate::index::OverlayLogicalRebuild::Deferred,
+        basis: None,
+    };
+    db.index_worktree_overlay_with_tail(&config, &linked, tail, &mut |_| {}).unwrap();
+    assert!(logical_rebuild_pending(&db), "the interrupted batch left its obligation");
+    assert!(!logical_symbol_named(&db, "branch_only_fn"), "the grouping is stale");
+
+    // Body-only follow-up edit, refreshed Deferred WITHOUT a tail (the next interrupted-batch
+    // window): the edited file is key-stable, so the refresh takes the relink path — and the
+    // outstanding obligation must be untouched.
+    fs::write(linked.join("src/one.rs"), "pub fn one_fn() -> i32 {\n    2\n}\n").unwrap();
+    let before = db.logical_symbol_rebuilds.load(std::sync::atomic::Ordering::Relaxed);
+    db.index_worktree_overlay_with_tail(&config, &linked, tail, &mut |_| {}).unwrap();
+    assert_eq!(
+        db.logical_symbol_rebuilds.load(std::sync::atomic::Ordering::Relaxed),
+        before,
+        "the key-stable refresh itself rebuilds nothing"
+    );
+    assert!(
+        logical_rebuild_pending(&db),
+        "the relink path must not clear a pre-existing obligation"
+    );
+    assert_eq!(live_member_count(&db, "one_fn"), 1, "the relink still landed in the refresh txn");
+
+    // The batch tail settles the surviving obligation: ONE rebuild, marker consumed, the
+    // interrupted file's symbols finally grouped.
+    let before = db.logical_symbol_rebuilds.load(std::sync::atomic::Ordering::Relaxed);
+    assert!(db.apply_pending_logical_rebuild().unwrap(), "the tail found the obligation");
+    assert_eq!(db.logical_symbol_rebuilds.load(std::sync::atomic::Ordering::Relaxed) - before, 1);
+    assert!(!logical_rebuild_pending(&db));
+    assert!(logical_symbol_named(&db, "branch_only_fn"), "the settle grouped the stale file");
+    assert_eq!(live_member_count(&db, "one_fn"), 1, "the rebuild agrees with the relink");
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}
+
+#[test]
+fn a_body_only_base_edit_pass_relinks_without_a_rebuild() {
+    // #820 on the BASE incremental writer: the second body-only edit of an already-dirty file
+    // replaces the same scope row under an identical key multiset, so the pass's tail re-links
+    // members instead of rebuilding. (The FIRST dirty edit moves the file into the worktree
+    // scope — a key-set change for that scope — and correctly pays the rebuild.)
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(main.join("src/a.rs"), "pub fn base_fn() -> i32 {\n    1\n}\n").unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let config = source_config(main.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    drop(db);
+
+    // First dirty edit: the file enters the worktree overlay scope (an ADD there) — rebuild.
+    fs::write(main.join("src/a.rs"), "pub fn base_fn() -> i32 {\n    2\n}\n").unwrap();
+    let first = IndexDatabase::index_paths(&config, &[main.join("src/a.rs")]).unwrap();
+    assert!(
+        first.logical_symbol_rebuilds.load(std::sync::atomic::Ordering::Relaxed) >= 1,
+        "the scope move is a key-set change and pays the rebuild"
+    );
+    drop(first);
+
+    // Second body-only edit: same scope row replaced, identical key multiset — zero rebuilds
+    // on the whole pass (pre-#820 this was 1).
+    fs::write(main.join("src/a.rs"), "pub fn base_fn() -> i32 {\n    3\n}\n").unwrap();
+    let second = IndexDatabase::index_paths(&config, &[main.join("src/a.rs")]).unwrap();
+    assert_eq!(
+        second.logical_symbol_rebuilds.load(std::sync::atomic::Ordering::Relaxed),
+        0,
+        "a key-stable base pass pays ZERO repo-global rebuilds"
+    );
+    assert!(logical_symbol_named(&second, "base_fn"));
+    // Committed row + dirty overlay row both carry the key → two live members, the overlay one
+    // pointing at the replacement symbol id.
+    assert_eq!(live_member_count(&second, "base_fn"), 2);
+
+    // Fixed-point check on the base route too.
+    let relinked = logical_grouping_snapshot(&second);
+    second.rebuild_logical_symbols(crate::index::graph_index::KeyVersionStamp::Defer).unwrap();
+    assert_eq!(logical_grouping_snapshot(&second), relinked);
+
+    let _ = fs::remove_dir_all(&main);
+}

--- a/crates/rag-rat-core/src/index/worktree_overlay.rs
+++ b/crates/rag-rat-core/src/index/worktree_overlay.rs
@@ -613,13 +613,14 @@ impl IndexDatabase {
         // any error (#219 review).
         self.storage.execute_batch("BEGIN IMMEDIATE")?;
         let result = (|| -> anyhow::Result<(usize, usize, usize)> {
-            let indexed = self.index_explicit_paths_from_root(
+            let applied = self.index_explicit_paths_from_root(
                 config,
                 &source_root,
                 &delta.readable,
                 &scope,
                 progress,
             )?;
+            let indexed = applied.written;
             // Write a tombstone only when one isn't already present, so a re-run on a static
             // worktree writes nothing (idle-safety, like the readable sha-skip).
             let mut tombstoned = 0;
@@ -645,6 +646,7 @@ impl IndexDatabase {
                 OverlayChangeCounts { indexed, tombstoned, pruned },
                 delta.manifest_changed,
                 tail.logical_rebuild,
+                applied.logical,
             )?;
             // #824: the basis write rides the SAME transaction as the rows it proves current —
             // previously a separate autocommit per worktree per pass (an extra WAL-dirtying
@@ -788,13 +790,14 @@ impl IndexDatabase {
         // front; ROLLBACK on any error.
         self.storage.execute_batch("BEGIN IMMEDIATE")?;
         let result = (|| -> anyhow::Result<(usize, usize, usize)> {
-            let indexed = self.index_explicit_paths_from_root(
+            let applied = self.index_explicit_paths_from_root(
                 config,
                 &source_root,
                 &readable,
                 &scope,
                 progress,
             )?;
+            let indexed = applied.written;
             let mut tombstoned = 0;
             for (rel, full) in &tombstones {
                 // RE-VALIDATE under the write lock (like removals): if the file was recreated /
@@ -832,6 +835,7 @@ impl IndexDatabase {
                 OverlayChangeCounts { indexed, tombstoned, pruned },
                 false,
                 logical_rebuild,
+                applied.logical,
             )?;
             Ok((indexed, tombstoned, pruned))
         })();
@@ -944,7 +948,11 @@ impl IndexDatabase {
     ///   unchanged symbols resolve via the base's logical rows — which is why only added files were
     ///   missing). This is the field-reported bug. `Deferred` (#819) replaces the rebuild with a
     ///   persisted pending marker in this same transaction; the batch caller runs ONE rebuild for
-    ///   all its worktrees via `apply_pending_logical_rebuild`.
+    ///   all its worktrees via `apply_pending_logical_rebuild`. When EVERY indexed change kept its
+    ///   file's logical-key multiset (#820 — the body-only-edit refresh), neither runs: the grouped
+    ///   table is already what a rebuild would produce, so the surviving logical rows are
+    ///   re-pointed at the replacement symbol ids instead, and no obligation is created. A
+    ///   tombstone or prune always changes the key set, so those refreshes keep the rebuild/marker.
     /// - refresh_packages: write the overlay scope's `packages` rows from the LINKED checkout's
     ///   manifests BEFORE resolving, so the per-package import scope (#61) is correct for the
     ///   branch. The resolver's `load_package_roots_into_scope` reads `packages` at the active
@@ -970,23 +978,40 @@ impl IndexDatabase {
         counts: OverlayChangeCounts,
         manifest_changed: bool,
         logical_rebuild: OverlayLogicalRebuild,
+        mut grouping: graph_index::LogicalGroupingUpkeep,
     ) -> anyhow::Result<()> {
         if counts.any_changed() {
-            match logical_rebuild {
-                OverlayLogicalRebuild::Inline => {
-                    // Defer the STAMP: an overlay refresh re-parsed only the worktree's own
-                    // files, so it must not stamp the logical-key version — the base scope's
-                    // drift is still in the future (#493).
-                    self.rebuild_logical_symbols(graph_index::KeyVersionStamp::Defer)?;
+            // #820: a tombstone or prune removes a whole file's keys from the grouped corpus —
+            // never key-stable, whatever the indexed half of the delta looked like.
+            if counts.tombstoned > 0 || counts.pruned > 0 {
+                grouping.require_rebuild();
+            }
+            match grouping {
+                graph_index::LogicalGroupingUpkeep::RelinkMembers(relinks) => {
+                    // Every indexed change was a key-stable replacement: re-link the members
+                    // inside this transaction and create NO rebuild obligation. A PRE-EXISTING
+                    // #819 marker is deliberately left in place — a relink is not a rebuild,
+                    // only `rebuild_logical_symbols` may clear the marker, and the entry-point
+                    // / batch-tail settles still consume it.
+                    self.apply_logical_member_relinks(&relinks)?;
                 },
-                OverlayLogicalRebuild::Deferred => {
-                    // Mark the repo-global rebuild pending IN THIS transaction (#819).
-                    // Committed overlay rows without a follow-up rebuild would leave a newly
-                    // added file's symbols unresolvable, and a later pass would idle-skip the
-                    // then-unchanged rows — the persisted marker survives a crash between this
-                    // commit and the batch tail, so `apply_pending_logical_rebuild` still runs.
-                    // `if_changed`: the second changed worktree of a batch finds it already set.
-                    self.set_repo_meta_if_changed(OVERLAY_LOGICAL_REBUILD_PENDING_META, "1")?;
+                graph_index::LogicalGroupingUpkeep::RebuildRequired => match logical_rebuild {
+                    OverlayLogicalRebuild::Inline => {
+                        // Defer the STAMP: an overlay refresh re-parsed only the worktree's own
+                        // files, so it must not stamp the logical-key version — the base scope's
+                        // drift is still in the future (#493).
+                        self.rebuild_logical_symbols(graph_index::KeyVersionStamp::Defer)?;
+                    },
+                    OverlayLogicalRebuild::Deferred => {
+                        // Mark the repo-global rebuild pending IN THIS transaction (#819).
+                        // Committed overlay rows without a follow-up rebuild would leave a newly
+                        // added file's symbols unresolvable, and a later pass would idle-skip the
+                        // then-unchanged rows — the persisted marker survives a crash between this
+                        // commit and the batch tail, so `apply_pending_logical_rebuild` still
+                        // runs. `if_changed`: the second changed worktree of a batch finds it
+                        // already set.
+                        self.set_repo_meta_if_changed(OVERLAY_LOGICAL_REBUILD_PENDING_META, "1")?;
+                    },
                 },
             }
             self.refresh_packages(source_root)?;
@@ -1110,7 +1135,7 @@ impl IndexDatabase {
         paths: &[PathBuf],
         scope: &FileScope,
         progress: &mut F,
-    ) -> anyhow::Result<usize>
+    ) -> anyhow::Result<incremental::IncrementalWriteOutcome>
     where
         F: FnMut(IndexProgress),
     {


### PR DESCRIPTION
## Problem

A body-only edit re-inserts a file's symbols under new row ids, but when the logical KEY multiset — `(language, path, name, qualified_name, kind, signature)` — is unchanged, the rebuilt `logical_symbols` table is identical to the one already sitting there: only the `logical_symbol_members.symbol_id` pointers moved. The pass still paid the whole-repo DELETE-all + re-INSERT + 8-column external sort (`rebuild_logical_symbols`) on every such edit, on both the overlay refresh and the base incremental writer. With #849's batching the cost is already once per batch; this removes it entirely for the dominant edit shape.

## Gate design

The gate sits where the rebuild obligation is *created*, building on #849's structure:

- **Per-file capture (`load_grouped_key_claims`)** — before `remove_file_in_scope` cascades the old member rows away, the replaced scope row's grouped state is read *through the `logical_symbol_members` join*: per key, the logical row its members point at and how many of this file's symbols it held. A symbol with no member row (e.g. a scope row committed by an interrupted deferred batch, never regrouped), or one key split across logical rows, yields no capture.
- **Per-file verdict (`derive_key_stable_relinks`)** — after `insert_prepared_file`, the replacement symbols' keys are compared against the capture as an **exact multiset over all six key columns**. Identical → the file's owed member rows (old logical id, new symbol id, fresh line spans, recomputed signature hash) accumulate; anything else → the whole batch downgrades.
- **Batch verdict (`LogicalGroupingUpkeep`)** — `RelinkMembers` only when *every* change in the batch was a key-stable replacement AND nothing else grouping-relevant happened: any tombstone/prune/fs-deletion, overlay heal, #502 carry, or package-map change forces `RebuildRequired` (exactly today's behavior). A lagging #493 logical-key version stamp forces it too, so the drift heal is never deferred.
- **Tail** — `finalize_overlay_refresh` (both the Inline and Deferred shapes) and the incremental writer's tail run `apply_logical_member_relinks` inside the same transaction as the symbol rewrite instead of rebuilding or setting the `overlay_logical_rebuild_pending` marker. The member INSERT is byte-for-byte what `insert_logical_group` writes (`cfg_expr` NULL, untrimmed-bytes sha256 signature hash).

The #819 settlement protocol is untouched: the relink path never clears (or sets) the pending marker — `rebuild_logical_symbols` stays its sole clearer — and a pre-existing obligation still settles at every entry-point exit and batch tail.

## Why a false key-stable verdict is impossible

A false verdict would leave members pointing at deleted symbol ids or missing for live ones. Every uncertainty resolves to the rebuild:

- **Exact comparison, no wildcards.** All six key columns compared per file as a multiset; `None` (absent qualified name / signature) never matches `Some`. Adds, deletes, renames, signature or kind changes, and cfg-variant count changes all mismatch. Per-key *count* equality is part of the bar because `variant_count`/`group_reason` are derived from member counts and only the rebuild recomputes them.
- **Capture goes through the members join.** An ungrouped replaced symbol (stale grouping — interrupted-batch state) fails the capture and forces the rebuild, so the relink can never fabricate members against missing logical rows. Other files' staleness is exactly what the surviving pending marker's settle heals.
- **Whole-file removals never qualify.** Tombstones, prunes, and fs-deletions bypass the per-file replace path entirely, so they downgrade the batch by count, not by comparison.
- **Fixed-point proof in tests.** After a relinked pass, forcing `rebuild_logical_symbols` must change nothing byte-for-byte — grouped rows, ids, `variant_count`, member spans and hashes. Asserted on both routes.
- **FK-safety by construction.** The relinked `logical_symbol_id` comes from live member rows in the same transaction (members cannot outlive their logical row), and the new `symbol_id` is freshly inserted — no dangling reference is expressible.

## Verification

- New tests: body-only edit on the overlay batch route and on the base incremental route each assert **zero** rebuilds via the #849 per-connection rebuild counter, plus live-member resolution and the fixed-point check; an adversarial matrix (signature change, rename, added file, tombstoned base file, pruned branch-only file) asserts each still pays the rebuild with correct grouping; the interrupted-batch scenario asserts a key-stable follow-up refresh leaves the pending obligation for the tail, which then settles it with one rebuild.
- **Proven failing before the fix:** with the three source files reverted to the previous behavior (tests kept), `a_body_only_overlay_edit_relinks_members_without_a_rebuild` and `a_body_only_base_edit_pass_relinks_without_a_rebuild` fail with `left: 1, right: 0` (the pass rebuilds), and `a_key_stable_relink_leaves_a_pending_obligation_for_the_tail` fails at the live-member assertion (the replaced file's members are missing until the batch tail — the window the relink closes).
- `cargo nextest run -p rag-rat-core`: 1493 passed. Plain `cargo test -p rag-rat-core --no-default-features --locked`: 1491 passed. Golden logical-grouping tests unchanged.
- CI-exact clippy, both legs (`--no-default-features` and `--all-features`, `--workspace --all-targets --locked -- -D warnings`): clean. `cargo +nightly fmt --check`: clean.

Fixes #820
