### PR TITLE
perf(watch): quiet-window overlay skip; reuse repo handles and the recorded delta in the probe

### DIFF
--- a/crates/rag-rat-base/src/config/raw.rs
+++ b/crates/rag-rat-base/src/config/raw.rs
@@ -215,6 +215,7 @@ pub(crate) struct RawWatch {
     max_latency_ms: Option<u64>,
     periodic_sweep_secs: Option<u64>,
     pass_cooldown_secs: Option<u64>,
+    overlay_quiet_secs: Option<u64>,
 }
 
 impl From<RawWatch> for WatchConfig {
@@ -226,6 +227,7 @@ impl From<RawWatch> for WatchConfig {
             max_latency_ms: raw.max_latency_ms.unwrap_or(default.max_latency_ms),
             periodic_sweep_secs: raw.periodic_sweep_secs.unwrap_or(default.periodic_sweep_secs),
             pass_cooldown_secs: raw.pass_cooldown_secs.unwrap_or(default.pass_cooldown_secs),
+            overlay_quiet_secs: raw.overlay_quiet_secs.unwrap_or(default.overlay_quiet_secs),
         }
     }
 }

--- a/crates/rag-rat-base/src/config/tests.rs
+++ b/crates/rag-rat-base/src/config/tests.rs
@@ -2175,6 +2175,7 @@ fn watch_config_defaults_on_and_parses_overrides() {
     assert_eq!(default.max_latency_ms, 2500);
     assert_eq!(default.periodic_sweep_secs, 300);
     assert_eq!(default.pass_cooldown_secs, 60);
+    assert_eq!(default.overlay_quiet_secs, 300);
 
     let raw: RawConfig = toml::from_str(
         r#"
@@ -2187,6 +2188,7 @@ fn watch_config_defaults_on_and_parses_overrides() {
             max_latency_ms = 4000
             periodic_sweep_secs = 0
             pass_cooldown_secs = 5
+            overlay_quiet_secs = 0
             "#,
     )
     .unwrap();
@@ -2197,6 +2199,7 @@ fn watch_config_defaults_on_and_parses_overrides() {
         max_latency_ms: 4000,
         periodic_sweep_secs: 0,
         pass_cooldown_secs: 5,
+        overlay_quiet_secs: 0,
     });
 }
 

--- a/crates/rag-rat-base/src/config/types.rs
+++ b/crates/rag-rat-base/src/config/types.rs
@@ -252,6 +252,18 @@ pub struct WatchConfig {
     /// `periodic_sweep_secs` remains the staleness bound, and the periodic sweep is never held
     /// back by the cooldown.
     pub pass_cooldown_secs: u64,
+    /// Quiet window (seconds) for a linked worktree's overlay refresh on EVENT-scoped watcher
+    /// passes (0 disables): while both the base and the linked HEAD still equal the worktree's
+    /// recorded refresh basis (dirty-only working-tree churn — no commit, no checkout) and the
+    /// last complete refresh is younger than this, the pass skips that worktree's overlay refresh
+    /// (its base↔branch tree diff, status walk, and ignore compile). Either HEAD moving always
+    /// refreshes immediately. Only uncommitted-edit visibility is deferred: a skipped edit
+    /// surfaces on the first event-driven pass after the window elapses, or at latest on the
+    /// periodic sweep — sweep-style (`All`-scoped) passes (startup catch-up, the periodic sweep,
+    /// gc, the CLI/hook `maintenance` command) are never held back. The window is ignored when
+    /// `periodic_sweep_secs` is 0: without the sweep, a one-off edit deferred here could have no
+    /// later pass to surface it.
+    pub overlay_quiet_secs: u64,
 }
 
 impl Default for WatchConfig {
@@ -262,6 +274,7 @@ impl Default for WatchConfig {
             max_latency_ms: 2500,
             periodic_sweep_secs: 300,
             pass_cooldown_secs: 60,
+            overlay_quiet_secs: 300,
         }
     }
 }

--- a/crates/rag-rat-cli/src/init/render.rs
+++ b/crates/rag-rat-cli/src/init/render.rs
@@ -82,7 +82,9 @@ pub(crate) fn render_config(plan: &InitPlan) -> String {
          [watch]\n# enabled = true\n# debounce_ms = 400           # quiet window before a reindex \
          pass\n# max_latency_ms = 2500       # force a pass after this much continuous \
          activity\n# periodic_sweep_secs = 300   # backstop pass interval, 0 disables\n# \
-         pass_cooldown_secs = 60     # minimum gap between event-driven passes, 0 disables\n\n",
+         pass_cooldown_secs = 60     # minimum gap between event-driven passes, 0 disables\n# \
+         overlay_quiet_secs = 300    # linked-worktree quiet window for uncommitted edits, 0 \
+         disables\n\n",
     );
 
     text.push_str(

--- a/crates/rag-rat-core/src/index/git_context.rs
+++ b/crates/rag-rat-core/src/index/git_context.rs
@@ -93,10 +93,14 @@ pub(crate) fn matches_simple_pattern(path: &str, pattern: &str) -> bool {
 /// HEAD commit sha for `root` via gix, or empty if unborn / not a repo (matching the old
 /// `rev-parse HEAD` failure behavior).
 pub(crate) fn head_sha(root: &Path) -> String {
-    discover_repo(root)
-        .ok()
-        .and_then(|repo| repo.head_id().ok().map(|id| id.to_hex().to_string()))
-        .unwrap_or_default()
+    discover_repo(root).ok().map(|repo| repo_head_sha(&repo)).unwrap_or_default()
+}
+
+/// [`head_sha`] for an ALREADY-OPENED repository — byte-identical formatting (empty when unborn),
+/// for callers holding a handle that must not pay a re-discover. Comparisons against a recorded
+/// refresh basis (whose shas came from `head_sha`) rely on the two never diverging.
+pub(crate) fn repo_head_sha(repo: &gix::Repository) -> String {
+    repo.head_id().ok().map(|id| id.to_hex().to_string()).unwrap_or_default()
 }
 
 /// Whether the worktree has any uncommitted change (tracked modifications + untracked files), the

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/mod.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/mod.rs
@@ -371,7 +371,11 @@ fn source_config_dirs(root: PathBuf, language: Language, dirs: &[&str]) -> Confi
             kind: TargetKind::Source,
         }],
         llm: Default::default(),
-        watch: Default::default(),
+        // The #822 overlay quiet window is OFF in this shared fixture: the overlay/watch tests
+        // built on it assert per-pass refresh semantics (the #577 scope matrix, delta
+        // categorization, prune safety), which the window would time-gate. Tests exercising the
+        // window itself opt in by setting `overlay_quiet_secs` explicitly.
+        watch: rag_rat_base::config::WatchConfig { overlay_quiet_secs: 0, ..Default::default() },
         version_check: Default::default(),
         oracle: Default::default(),
         search: Default::default(),

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_overlay.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_overlay.rs
@@ -2335,3 +2335,438 @@ fn a_body_only_base_edit_pass_relinks_without_a_rebuild() {
 
     let _ = fs::remove_dir_all(&main);
 }
+
+/// One committed base repo + one linked worktree, the shared #822/#825 shape: `(main, linked,
+/// config, db)` with `src/a.rs` committed on both sides and every overlay basis unrecorded.
+fn quiet_window_fixture() -> (PathBuf, PathBuf, Config, IndexDatabase) {
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(main.join("src/a.rs"), "pub fn base_a() {}\n").unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let config = source_config(main.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    (main, linked, config, db)
+}
+
+#[test]
+fn overlay_quiet_window_skips_a_dirty_only_listed_worktree_inside_the_window() {
+    // #822: dirty working-tree churn fires events that LIST the worktree, and pre-#822 every such
+    // pass re-paid the full per-worktree probe (tree diff + status walk + ignore compile). While
+    // both heads still equal the recorded basis AND the last complete refresh is younger than the
+    // quiet window, the scoped pass skips the worktree outright; the window elapsing re-arms the
+    // refresh.
+    let (main, linked, mut config, mut db) = quiet_window_fixture();
+    config.watch.overlay_quiet_secs = 300;
+
+    // The All pass records the basis WITH its fresh timestamp (the window anchor).
+    crate::watch::refresh_worktree_overlays(
+        &mut db,
+        &config,
+        None,
+        &crate::watch::OverlayScope::All,
+    );
+
+    // Dirty-only churn: no HEAD moves, the event scope lists the worktree.
+    fs::write(linked.join("src/a.rs"), "pub fn dirty_fn() {}\n").unwrap();
+    let scope =
+        crate::watch::OverlayScope::Linked(std::collections::BTreeSet::from([linked.clone()]));
+    assert!(
+        !crate::watch::refresh_worktree_overlays(&mut db, &config, None, &scope),
+        "inside the window a dirty-only listed worktree is skipped"
+    );
+    db.use_worktree_scope(&main, Some(&linked)).unwrap();
+    assert_eq!(
+        names_in_scope(&db, "src/a.rs"),
+        vec!["base_a".to_string()],
+        "the dirty edit stays un-overlaid while the quiet window holds"
+    );
+
+    // The window elapsing re-arms the refresh: backdate the recorded timestamp past the window.
+    set_base_scope(&mut db, &main);
+    let worktree_id = crate::index::worktree_id_of(&linked);
+    let (base_sha, linked_head) = db.worktree_overlay_basis(&worktree_id).unwrap().unwrap();
+    db.record_worktree_overlay_basis(
+        &worktree_id,
+        &base_sha,
+        &linked_head,
+        rag_rat_base::time::now_ms() - 301_000,
+    )
+    .unwrap();
+    assert!(
+        crate::watch::refresh_worktree_overlays(&mut db, &config, None, &scope),
+        "an elapsed window refreshes the dirty-only worktree"
+    );
+    db.use_worktree_scope(&main, Some(&linked)).unwrap();
+    assert_eq!(
+        names_in_scope(&db, "src/a.rs"),
+        vec!["dirty_fn".to_string()],
+        "the deferred dirty edit lands once the window elapses"
+    );
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}
+
+#[test]
+fn overlay_quiet_window_never_defers_a_head_move() {
+    // #822: committed freshness stays immediate — a commit moves a HEAD, the recorded basis
+    // mismatches, and the refresh runs no matter how young the window is. Both directions: a
+    // linked commit, then a base commit.
+    let (main, linked, mut config, mut db) = quiet_window_fixture();
+    config.watch.overlay_quiet_secs = 300;
+    crate::watch::refresh_worktree_overlays(
+        &mut db,
+        &config,
+        None,
+        &crate::watch::OverlayScope::All,
+    );
+
+    // Linked commit, seconds into the window, on a pass that lists the worktree.
+    fs::write(linked.join("src/new.rs"), "pub fn committed_fn() {}\n").unwrap();
+    run_git(&linked, &["add", "."]);
+    run_git(&linked, &["commit", "-q", "-m", "branch adds file"]);
+    let scope =
+        crate::watch::OverlayScope::Linked(std::collections::BTreeSet::from([linked.clone()]));
+    assert!(
+        crate::watch::refresh_worktree_overlays(&mut db, &config, None, &scope),
+        "a linked HEAD move refreshes immediately inside the window"
+    );
+    db.use_worktree_scope(&main, Some(&linked)).unwrap();
+    assert_eq!(names_in_scope(&db, "src/new.rs"), vec!["committed_fn".to_string()]);
+
+    // Base commit: every worktree's diff basis moves; even an EMPTY event scope refreshes.
+    fs::write(main.join("src/a.rs"), "pub fn base_v2() {}\n").unwrap();
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base v2"]);
+    set_base_scope(&mut db, &main);
+    let empty = crate::watch::OverlayScope::Linked(std::collections::BTreeSet::new());
+    assert!(
+        crate::watch::refresh_worktree_overlays(&mut db, &config, None, &empty),
+        "a base HEAD move refreshes immediately inside the window"
+    );
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}
+
+#[test]
+fn overlay_quiet_window_zero_disables_and_sweeps_ignore_it() {
+    // #822: `overlay_quiet_secs = 0` restores per-pass refresh for listed worktrees, and an `All`
+    // sweep never consults the window even when it is armed — the sweep is one of the backstops
+    // the window's staleness bound leans on.
+    let (main, linked, mut config, mut db) = quiet_window_fixture();
+    config.watch.overlay_quiet_secs = 0;
+    crate::watch::refresh_worktree_overlays(
+        &mut db,
+        &config,
+        None,
+        &crate::watch::OverlayScope::All,
+    );
+    fs::write(linked.join("src/a.rs"), "pub fn dirty_v1() {}\n").unwrap();
+    let scope =
+        crate::watch::OverlayScope::Linked(std::collections::BTreeSet::from([linked.clone()]));
+    assert!(
+        crate::watch::refresh_worktree_overlays(&mut db, &config, None, &scope),
+        "0 disables the window: a dirty-only listed worktree refreshes every pass"
+    );
+    db.use_worktree_scope(&main, Some(&linked)).unwrap();
+    assert_eq!(names_in_scope(&db, "src/a.rs"), vec!["dirty_v1".to_string()]);
+
+    // Arm the window; the All sweep refreshes the fresh dirty edit regardless.
+    set_base_scope(&mut db, &main);
+    config.watch.overlay_quiet_secs = 300;
+    crate::watch::refresh_worktree_overlays(
+        &mut db,
+        &config,
+        None,
+        &crate::watch::OverlayScope::All,
+    );
+    fs::write(linked.join("src/a.rs"), "pub fn dirty_v2() {}\n").unwrap();
+    crate::watch::refresh_worktree_overlays(
+        &mut db,
+        &config,
+        None,
+        &crate::watch::OverlayScope::All,
+    );
+    db.use_worktree_scope(&main, Some(&linked)).unwrap();
+    assert_eq!(
+        names_in_scope(&db, "src/a.rs"),
+        vec!["dirty_v2".to_string()],
+        "an All sweep is never held back by the quiet window"
+    );
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}
+
+#[test]
+fn overlay_quiet_window_is_ignored_when_the_periodic_sweep_is_disabled() {
+    // #822: the window defers work it never schedules — a deferred edit is delivered by the next
+    // post-window event pass or by the periodic sweep. With `periodic_sweep_secs = 0` a one-off
+    // dirty edit skipped inside the window could have neither (no follow-up event, no sweep) and
+    // stay invisible indefinitely, so the gate must disable itself.
+    let (main, linked, mut config, mut db) = quiet_window_fixture();
+    config.watch.overlay_quiet_secs = 300;
+    config.watch.periodic_sweep_secs = 0;
+    crate::watch::refresh_worktree_overlays(
+        &mut db,
+        &config,
+        None,
+        &crate::watch::OverlayScope::All,
+    );
+    fs::write(linked.join("src/a.rs"), "pub fn dirty_fn() {}\n").unwrap();
+    let scope =
+        crate::watch::OverlayScope::Linked(std::collections::BTreeSet::from([linked.clone()]));
+    assert!(
+        crate::watch::refresh_worktree_overlays(&mut db, &config, None, &scope),
+        "no sweep backstop → the window is ignored and the pass refreshes"
+    );
+    db.use_worktree_scope(&main, Some(&linked)).unwrap();
+    assert_eq!(names_in_scope(&db, "src/a.rs"), vec!["dirty_fn".to_string()]);
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}
+
+#[test]
+fn a_cleared_basis_never_quiet_skips() {
+    // #822: the timestamp rides the basis value, so the #577 clear paths (partial refresh in-txn,
+    // failed refresh caller-side) drop the window anchor with the pair — after a clear, a scoped
+    // pass must refresh even though the window would otherwise still hold.
+    let (main, linked, mut config, mut db) = quiet_window_fixture();
+    config.watch.overlay_quiet_secs = 300;
+    crate::watch::refresh_worktree_overlays(
+        &mut db,
+        &config,
+        None,
+        &crate::watch::OverlayScope::All,
+    );
+    fs::write(linked.join("src/a.rs"), "pub fn dirty_fn() {}\n").unwrap();
+    // The failure path's clear (the watcher's Err arm calls exactly this).
+    let worktree_id = crate::index::worktree_id_of(&linked);
+    db.clear_worktree_overlay_basis(&worktree_id).unwrap();
+    let scope =
+        crate::watch::OverlayScope::Linked(std::collections::BTreeSet::from([linked.clone()]));
+    assert!(
+        crate::watch::refresh_worktree_overlays(&mut db, &config, None, &scope),
+        "no recorded basis, no quiet skip — the pass refreshes"
+    );
+    db.use_worktree_scope(&main, Some(&linked)).unwrap();
+    assert_eq!(names_in_scope(&db, "src/a.rs"), vec!["dirty_fn".to_string()]);
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}
+
+#[test]
+fn overlay_basis_value_parses_stamped_and_legacy_shapes() {
+    // #822: the basis meta value grew a third line (the last-complete-refresh timestamp). A
+    // pre-#822 two-line value must still yield the #577 pair — only the quiet window stays
+    // disarmed — and a malformed timestamp degrades the same way instead of poisoning the pair.
+    let (main, linked, _config, db) = quiet_window_fixture();
+
+    db.record_worktree_overlay_basis("wt-stamped", "base-1", "linked-1", 42).unwrap();
+    assert_eq!(
+        db.worktree_overlay_basis("wt-stamped").unwrap(),
+        Some(("base-1".to_string(), "linked-1".to_string()))
+    );
+    assert_eq!(db.worktree_overlay_basis_refreshed_at_ms("wt-stamped").unwrap(), Some(42));
+
+    // A legacy value written by a pre-#822 build.
+    db.set_repo_meta_if_changed("worktree_overlay_basis:wt-legacy", "base-2\nlinked-2").unwrap();
+    assert_eq!(
+        db.worktree_overlay_basis("wt-legacy").unwrap(),
+        Some(("base-2".to_string(), "linked-2".to_string())),
+        "the pair survives a pre-#822 value"
+    );
+    assert_eq!(
+        db.worktree_overlay_basis_refreshed_at_ms("wt-legacy").unwrap(),
+        None,
+        "no timestamp on a legacy value — the quiet window never holds"
+    );
+
+    db.set_repo_meta_if_changed("worktree_overlay_basis:wt-garbage", "base-3\nlinked-3\nnot-ms")
+        .unwrap();
+    assert_eq!(
+        db.worktree_overlay_basis("wt-garbage").unwrap(),
+        Some(("base-3".to_string(), "linked-3".to_string()))
+    );
+    assert_eq!(db.worktree_overlay_basis_refreshed_at_ms("wt-garbage").unwrap(), None);
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}
+
+/// The overlay's `(path, is_tombstone)` rows for `worktree_id` at the live scope — the observable
+/// the #825 tree-diff-skip equivalence is asserted on (tombstones included: pruning one would
+/// un-shadow a branch-deleted base file).
+fn overlay_rows(db: &IndexDatabase, worktree_id: &str) -> Vec<(String, bool)> {
+    let conn = db.storage.connection();
+    let mut stmt = conn
+        .prepare(
+            "SELECT path, kind = 'deleted' FROM main.files WHERE worktree_id = ?1 AND commit_sha \
+             = '' ORDER BY path",
+        )
+        .unwrap();
+    let rows = stmt
+        .query_map([worktree_id], |row| Ok((row.get::<_, String>(0)?, row.get::<_, bool>(1)?)))
+        .unwrap();
+    rows.filter_map(Result::ok).collect()
+}
+
+#[test]
+fn heads_unchanged_refresh_reuses_the_committed_delta_and_still_sees_dirty_edits() {
+    // #825: when both heads equal the recorded basis, the refresh seeds its committed candidates
+    // from the current overlay rows instead of walking the base↔linked tree diff; the status walk
+    // still runs. Equivalence on a heads-unchanged fixture: the committed rows (a modified file's
+    // overlay row, a deleted file's tombstone) come out identical, and a fresh dirty edit is
+    // still picked up. The PROOF the tree walk was actually skipped is the seed path's one
+    // accepted divergence: a previously-dirty file REVERTED to base content keeps its
+    // (content-identical) overlay row — the full diff would have pruned it — until the next
+    // HEAD move runs the full diff and does.
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(main.join("src/a.rs"), "pub fn base_a() {}\n").unwrap();
+    fs::write(main.join("src/b.rs"), "pub fn base_b() {}\n").unwrap();
+    fs::write(main.join("src/c.rs"), "pub fn base_c() {}\n").unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let config = source_config(main.clone(), Language::Rust);
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    // Committed branch delta: modify a.rs, delete b.rs (→ tombstone).
+    fs::write(linked.join("src/a.rs"), "pub fn branch_a() {}\n").unwrap();
+    fs::remove_file(linked.join("src/b.rs")).unwrap();
+    run_git(&linked, &["add", "."]);
+    run_git(&linked, &["commit", "-q", "-m", "branch delta"]);
+    // Dirty edit that will be REVERTED before the seeded pass.
+    fs::write(linked.join("src/c.rs"), "pub fn dirty_c() {}\n").unwrap();
+
+    // Refresh maintaining the basis with REAL heads, exactly as the watcher does.
+    let refresh = |db: &mut IndexDatabase| {
+        let base_sha = crate::index::head_sha(&main);
+        let linked_head = crate::index::head_sha(&linked);
+        let tail = crate::index::OverlayRefreshTail {
+            logical_rebuild: crate::index::OverlayLogicalRebuild::Inline,
+            basis: Some(crate::index::OverlayBasisUpdate {
+                base_sha: &base_sha,
+                linked_head_sha: &linked_head,
+            }),
+        };
+        db.index_worktree_overlay_with_tail(&config, &linked, tail, &mut |_| {}).unwrap()
+    };
+    // Pass 1: no recorded basis → the full tree diff.
+    let first = refresh(&mut db);
+    assert!(first.status_complete);
+    assert_eq!(first.indexed, 2, "branch a.rs + dirty c.rs");
+    assert_eq!(first.tombstoned, 1, "deleted b.rs shadows its base row");
+    let worktree_id = first.worktree_id.clone();
+    let committed_rows = overlay_rows(&db, &worktree_id);
+
+    // Heads unchanged; revert c.rs to base content and add a NEW dirty file d.rs.
+    fs::write(linked.join("src/c.rs"), "pub fn base_c() {}\n").unwrap();
+    fs::write(linked.join("src/d.rs"), "pub fn dirty_d() {}\n").unwrap();
+    let second = refresh(&mut db);
+    assert!(second.status_complete);
+    let expected = {
+        let mut expected = committed_rows.clone();
+        expected.push(("src/d.rs".to_string(), false));
+        expected.sort();
+        expected
+    };
+    assert_eq!(
+        overlay_rows(&db, &worktree_id),
+        expected,
+        "the seeded pass reproduces the committed delta exactly (a.rs row, b.rs tombstone), still \
+         catches the new dirty d.rs via the status walk, and keeps the reverted c.rs row — the \
+         divergence that proves the tree diff was skipped (a full diff prunes it)"
+    );
+    db.use_worktree_scope(&main, Some(&linked)).unwrap();
+    assert_eq!(names_in_scope(&db, "src/a.rs"), vec!["branch_a".to_string()]);
+    assert!(!path_in_scope(&db, "src/b.rs"), "the tombstone still shadows the base row");
+    assert_eq!(names_in_scope(&db, "src/d.rs"), vec!["dirty_d".to_string()]);
+
+    // A HEAD move runs the full diff again, which prunes the lingering reverted row.
+    set_base_scope(&mut db, &main);
+    run_git(&linked, &["add", "."]);
+    run_git(&linked, &["commit", "-q", "-m", "commit the dirty work"]);
+    let third = refresh(&mut db);
+    assert!(third.status_complete);
+    assert!(
+        !overlay_rows(&db, &worktree_id).iter().any(|(path, _)| path == "src/c.rs"),
+        "the next tree-diff refresh prunes the content-identical reverted row"
+    );
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}
+
+#[test]
+fn a_dirty_gitignore_edit_forces_the_full_diff_on_matching_heads() {
+    // #825: the one committed-side case the row seed provably cannot see — an ignore flip making
+    // a committed branch-only file indexable for the FIRST time (it produced no row, and it is
+    // tracked + clean so it is not in status). A dirty `.gitignore` among the status candidates
+    // must force the full tree diff even though the heads match the basis.
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(main.join("src/a.rs"), "pub fn base_a() {}\n").unwrap();
+    fs::write(main.join("src/.gitignore"), "gen.rs\n").unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let config = source_config(main.clone(), Language::Rust);
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    // The branch COMMITS an ignored file (forced add): a tree-diff candidate on the first pass,
+    // but not indexable → no overlay row.
+    fs::write(linked.join("src/gen.rs"), "pub fn generated_fn() {}\n").unwrap();
+    run_git(&linked, &["add", "-f", "."]);
+    run_git(&linked, &["commit", "-q", "-m", "branch adds ignored file"]);
+
+    let refresh = |db: &mut IndexDatabase| {
+        let base_sha = crate::index::head_sha(&main);
+        let linked_head = crate::index::head_sha(&linked);
+        let tail = crate::index::OverlayRefreshTail {
+            logical_rebuild: crate::index::OverlayLogicalRebuild::Inline,
+            basis: Some(crate::index::OverlayBasisUpdate {
+                base_sha: &base_sha,
+                linked_head_sha: &linked_head,
+            }),
+        };
+        db.index_worktree_overlay_with_tail(&config, &linked, tail, &mut |_| {}).unwrap()
+    };
+    let first = refresh(&mut db);
+    assert!(first.status_complete);
+    assert_eq!(first.indexed, 0, "the committed file is ignored — no overlay row yet");
+
+    // Heads unchanged; a DIRTY `.gitignore` edit unignores it. Without the forced full diff the
+    // seeded pass could never surface gen.rs: it has no row and is absent from status.
+    fs::write(linked.join("src/.gitignore"), "").unwrap();
+    let second = refresh(&mut db);
+    assert!(second.status_complete);
+    db.use_worktree_scope(&main, Some(&linked)).unwrap();
+    assert_eq!(
+        names_in_scope(&db, "src/gen.rs"),
+        vec!["generated_fn".to_string()],
+        "the dirty .gitignore edit forced the tree diff, surfacing the newly-unignored file"
+    );
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}

--- a/crates/rag-rat-core/src/index/worktree_overlay.rs
+++ b/crates/rag-rat-core/src/index/worktree_overlay.rs
@@ -98,15 +98,30 @@ fn linked_config_subdir_and_root(
     (config_subdir, linked_config_root)
 }
 
-/// Resolve the `(base_sha, worktree_id, source_root)` for a linked-worktree overlay, or `None` when
-/// `linked_path` is not a valid linked sibling of `config.root`'s repo (its scope fell back to
-/// base). Shared by [`IndexDatabase::index_worktree_overlay`] and
+/// A linked-worktree overlay's resolved identity plus the opened repositories it was resolved
+/// against. The repo handles are part of the resolution on purpose (#825): the delta computation
+/// used to re-discover both repos after this had already opened them — four `discover_repo`
+/// walks per refresh instead of two — so the handles are threaded through instead.
+pub(crate) struct ResolvedOverlayScope {
+    pub(crate) base_sha: String,
+    pub(crate) worktree_id: String,
+    /// `config.root`'s prefix relative to the repo workdir (both checkouts share the layout).
+    pub(crate) config_subdir: PathBuf,
+    /// The LINKED checkout's equivalent of `config.root` — overlay bytes are read from here.
+    pub(crate) source_root: PathBuf,
+    pub(crate) base_repo: gix::Repository,
+    pub(crate) linked_repo: gix::Repository,
+}
+
+/// Resolve a linked-worktree overlay's scope, or `None` when `linked_path` is not a valid linked
+/// sibling of `config.root`'s repo (its scope fell back to base). Shared by
+/// [`IndexDatabase::index_worktree_overlay`] and
 /// [`IndexDatabase::refresh_worktree_overlay_packages`] so both derive the SAME scope + source
 /// root.
 fn resolve_overlay_scope(
     config: &Config,
     linked_path: &Path,
-) -> anyhow::Result<Option<(String, String, PathBuf)>> {
+) -> anyhow::Result<Option<ResolvedOverlayScope>> {
     let (base_sha, worktree_id) =
         git_context::resolve_worktree_scope(&config.root, Some(linked_path));
     if worktree_id == git_context::worktree_id_of(&config.root) {
@@ -114,65 +129,65 @@ fn resolve_overlay_scope(
     }
     let base_repo = rag_rat_base::repo_discover::discover_repo(&config.root)?;
     let linked_repo = rag_rat_base::repo_discover::discover_repo(linked_path)?;
-    let (_, source_root) =
+    let (config_subdir, source_root) =
         linked_config_subdir_and_root(config, &base_repo, &linked_repo, linked_path);
-    Ok(Some((base_sha, worktree_id, source_root)))
+    Ok(Some(ResolvedOverlayScope {
+        base_sha,
+        worktree_id,
+        config_subdir,
+        source_root,
+        base_repo,
+        linked_repo,
+    }))
 }
 
-/// Compute the overlay delta of `linked_path` (a linked worktree of `config.root`'s repo) against
-/// the base scope. Candidate paths = the committed branch diff (base HEAD tree ↔ linked HEAD tree)
-/// UNION the linked worktree's working-tree status (dirty + untracked + deleted). Each candidate's
-/// FINAL category is decided by its on-disk state in the LINKED checkout — present → read it
-/// (readable); absent but present in the base tree → tombstone — which correctly merges committed
-/// and working-tree changes (and maps a rename to delete-old + add-new). Only target-matching paths
-/// are kept: the base wouldn't index the rest, so there is nothing to shadow.
+/// How an overlay refresh sources the COMMITTED half of its candidate set (#825) — the base↔linked
+/// tree diff, or (when provably identical) the recorded outcome of the last complete refresh.
+pub(crate) enum CommittedDeltaSource {
+    /// Walk the base HEAD tree ↔ linked HEAD tree diff. The default: a head moved, or there is no
+    /// complete-refresh proof to reuse.
+    TreeDiff,
+    /// Both HEADs still equal the recorded #577 basis: the committed diff is a pure function of
+    /// that pair, so its candidate outcome is already materialized as the worktree's current
+    /// overlay rows — source rows AND tombstones, config-root-relative
+    /// ([`IndexDatabase::list_overlay_shadowed_paths`]). Seed those instead of paying the tree
+    /// walk; the working-tree status walk still runs, since dirty edits are the only thing that
+    /// can differ while both heads hold still.
+    ///
+    /// Accepted (self-healing) divergence from [`Self::TreeDiff`]: a previously-dirty file
+    /// reverted to content the base already has keeps its (now content-identical, query-invisible)
+    /// overlay row until the next tree-diff refresh prunes it — the row seed can't distinguish
+    /// "row because committed diff" from "row because then-dirty".
+    UnchangedSinceBasis { shadowed_paths: Vec<PathBuf> },
+}
+
+/// Compute the overlay delta of `scope`'s linked worktree against the base scope. Candidate paths
+/// = the committed branch diff (per `committed` — the tree diff, or the recorded rows when the
+/// heads are unchanged, #825) UNION the linked worktree's working-tree status (dirty + untracked +
+/// deleted). Each candidate's FINAL category is decided by its on-disk state in the LINKED
+/// checkout — present → read it (readable); absent but present in the base tree → tombstone —
+/// which correctly merges committed and working-tree changes (and maps a rename to delete-old +
+/// add-new). Only target-matching paths are kept: the base wouldn't index the rest, so there is
+/// nothing to shadow.
 pub(crate) fn compute_linked_worktree_delta(
     config: &Config,
-    linked_path: &Path,
+    scope: &ResolvedOverlayScope,
+    committed: CommittedDeltaSource,
 ) -> anyhow::Result<WorktreeOverlayDelta> {
-    let base_repo = rag_rat_base::repo_discover::discover_repo(&config.root)?;
-    let linked_repo = rag_rat_base::repo_discover::discover_repo(linked_path)?;
     // `config.root` may be a SUBDIR of the repo. Tree-diff and status entries are repo-relative
     // (e.g. `crate/src/lib.rs`), but `target_for_path` / the overlay path keys are config-root-
     // relative (e.g. `src/lib.rs`), and the readable files are read from the LINKED checkout's
     // equivalent of `config.root`. `config_subdir` is the prefix to strip; `linked_config_root` is
-    // the source root overlay bytes are read from (#219 review).
-    let (config_subdir, linked_config_root) =
-        linked_config_subdir_and_root(config, &base_repo, &linked_repo, linked_path);
+    // the source root overlay bytes are read from (#219 review). Both were derived when the scope
+    // was resolved (the same repos this delta reads — #825 threads the opened handles through
+    // instead of re-discovering them here).
+    let config_subdir = &scope.config_subdir;
+    let linked_config_root = &scope.source_root;
 
     let mut candidates: BTreeSet<PathBuf> = BTreeSet::new();
 
-    // Resolve BOTH trees through `base_repo` so the cross-tree diff shares one object store (the
-    // worktrees share the same `.git`). Each is OPTIONAL: an unborn HEAD (a fresh `git worktree add
-    // --orphan`, zero commits) has no tree. Without tolerating that, `head_id()?` errored the whole
-    // pass, so the watcher logged a failure for an orphan worktree every pass (#219 review). The
-    // committed branch diff is computed only when both trees exist; the working-tree status below
-    // still captures an orphan worktree's files.
-    let base_tree = base_repo
-        .head_id()
-        .ok()
-        .and_then(|id| id.object().ok())
-        .and_then(|o| o.peel_to_tree().ok());
-    let linked_tree = linked_repo
-        .head_id()
-        .ok()
-        .and_then(|id| base_repo.find_object(id.detach()).ok())
-        .and_then(|o| o.peel_to_tree().ok());
-    if let (Some(base_tree), Some(linked_tree)) = (base_tree.as_ref(), linked_tree.as_ref()) {
-        // Rename detection OFF: a rename becomes delete(old)+add(new), which the on-disk
-        // categorization below resolves to tombstone(old) + readable(new).
-        base_tree
-            .changes()?
-            .options(|opts| {
-                opts.track_path().track_rewrites(None);
-            })
-            .for_each_to_obtain_tree(linked_tree, |change| {
-                candidates.insert(change_location_path(&change));
-                Ok::<_, std::convert::Infallible>(gix::object::tree::diff::Action::Continue(()))
-            })?;
-    }
-
-    // Linked working-tree status (vs the linked HEAD): dirty edits, untracked files, deletes. Track
+    // Linked working-tree status (vs the linked HEAD): dirty edits, untracked files, deletes —
+    // read FIRST so the committed-source decision below can see a dirty `.gitignore` edit. Track
     // whether it was read in FULL — a silently-dropped status read yields a PARTIAL delta (missing
     // untracked / working-tree-deleted paths), and the caller must skip the prune on a partial
     // delta or it would delete valid overlay rows (#219 review).
@@ -182,17 +197,78 @@ pub(crate) fn compute_linked_worktree_delta(
     // readable set). Detect it DURING the fold — status is a one-shot iterator. `Cell` because
     // `fold_status_candidates` takes an `Fn` locator, not `FnMut`.
     let manifest_in_status = std::cell::Cell::new(false);
-    if let Ok(platform) = linked_repo.status(gix::progress::Discard)
+    if let Ok(platform) = scope.linked_repo.status(gix::progress::Discard)
         && let Ok(items) =
             platform.untracked_files(UntrackedFiles::Files).into_iter(None::<gix::bstr::BString>)
     {
         status_complete = fold_status_candidates(&mut candidates, items, |item| {
             let path = PathBuf::from(item.location().to_str_lossy().as_ref());
-            if path_is_manifest_under_subdir(&path, &config_subdir) {
+            if path_is_manifest_under_subdir(&path, config_subdir) {
                 manifest_in_status.set(true);
             }
             path
         });
+    }
+
+    // The base tree is needed by BOTH committed sources: `shadows_base_file()` below and the
+    // ignore-flip expansion read it. OPTIONAL, like the linked tree: an unborn HEAD (a fresh
+    // `git worktree add --orphan`, zero commits) has no tree. Without tolerating that,
+    // `head_id()?` errored the whole pass, so the watcher logged a failure for an orphan worktree
+    // every pass (#219 review).
+    let base_tree = scope
+        .base_repo
+        .head_id()
+        .ok()
+        .and_then(|id| id.object().ok())
+        .and_then(|o| o.peel_to_tree().ok());
+
+    // A DIRTY `.gitignore` edit forces the full diff even when the heads are unchanged: an
+    // ignore flip can make a committed branch-only file indexable for the first time — such a
+    // file produced NO row on the last refresh (not indexable then) and is not in status (it is
+    // tracked and clean), so the row seed provably cannot surface it. Ignore edits are rare;
+    // paying the tree walk for them keeps the skip equivalence exact. (The caller already forces
+    // the full diff for the analogous branch-config/target-drift case.)
+    let dirty_ignore_edit =
+        candidates.iter().any(|path| path.file_name() == Some(std::ffi::OsStr::new(".gitignore")));
+    let committed = match committed {
+        CommittedDeltaSource::UnchangedSinceBasis { .. } if dirty_ignore_edit =>
+            CommittedDeltaSource::TreeDiff,
+        other => other,
+    };
+    match committed {
+        CommittedDeltaSource::TreeDiff => {
+            // Resolve the linked tree through `base_repo` so the cross-tree diff shares one
+            // object store (the worktrees share the same `.git`). The committed branch diff is
+            // computed only when both trees exist; the working-tree status above still captures
+            // an orphan worktree's files.
+            let linked_tree = scope
+                .linked_repo
+                .head_id()
+                .ok()
+                .and_then(|id| scope.base_repo.find_object(id.detach()).ok())
+                .and_then(|o| o.peel_to_tree().ok());
+            if let (Some(base_tree), Some(linked_tree)) = (base_tree.as_ref(), linked_tree.as_ref())
+            {
+                // Rename detection OFF: a rename becomes delete(old)+add(new), which the on-disk
+                // categorization below resolves to tombstone(old) + readable(new).
+                base_tree
+                    .changes()?
+                    .options(|opts| {
+                        opts.track_path().track_rewrites(None);
+                    })
+                    .for_each_to_obtain_tree(linked_tree, |change| {
+                        candidates.insert(change_location_path(&change));
+                        Ok::<_, std::convert::Infallible>(
+                            gix::object::tree::diff::Action::Continue(()),
+                        )
+                    })?;
+            }
+        },
+        CommittedDeltaSource::UnchangedSinceBasis { shadowed_paths } => {
+            // Overlay rows are keyed config-root-relative; candidates are repo-relative until the
+            // categorization loop strips the subdir back off.
+            candidates.extend(shadowed_paths.iter().map(|rel| config_subdir.join(rel)));
+        },
     }
 
     // Honor the worktree's `.gitignore` for files PRESENT in the worktree, so the overlay indexes
@@ -203,7 +279,7 @@ pub(crate) fn compute_linked_worktree_delta(
     // Tombstones are NOT ignore-filtered: a branch-deleted file must shadow its base row
     // regardless of ignore rules.
     let ignore =
-        ignore_rules::IgnoreMatcher::compile(&linked_config_root, &config.target_directories());
+        ignore_rules::IgnoreMatcher::compile(linked_config_root, &config.target_directories());
 
     // Ignore-ONLY change expansion. When the branch's only change under a directory is a
     // `.gitignore` edit, the tree-diff/status candidates contain just `.gitignore` itself — the
@@ -219,8 +295,8 @@ pub(crate) fn compute_linked_worktree_delta(
     expand_candidates_for_ignore_only_flips(
         &mut candidates,
         base_tree.as_ref(),
-        &config_subdir,
-        &linked_config_root,
+        config_subdir,
+        linked_config_root,
         &ignore,
         config,
     );
@@ -234,7 +310,7 @@ pub(crate) fn compute_linked_worktree_delta(
         // Candidates are repo-relative; the overlay keys rows config-root-relative (matching the
         // base rows + `target_for_path`). A candidate OUTSIDE the config subdir has no base row to
         // shadow, so it can't strip the prefix → skip it.
-        let Ok(rel) = repo_rel.strip_prefix(&config_subdir) else {
+        let Ok(rel) = repo_rel.strip_prefix(config_subdir) else {
             continue;
         };
         let rel = rel.to_path_buf();
@@ -380,13 +456,25 @@ fn change_location_path(change: &gix::object::tree::diff::Change<'_, '_, '_>) ->
 }
 
 /// `repo_meta` key prefix for a linked worktree's overlay refresh basis (#577): one key per
-/// `worktree_id`, value `"<base_sha>\n<linked_head_sha>"` — the (base HEAD, linked HEAD) pair the
-/// overlay delta was last computed against. A scoped watcher pass skips a worktree not implicated
-/// by events ONLY while this pair still matches; either head moving (a base commit re-basing every
-/// overlay, a linked commit with no file event) forces the refresh. Kept per worktree in the
-/// per-repo kv rather than a dedicated table: it is a marker, not queried relationally, and the
+/// `worktree_id`, value `"<base_sha>\n<linked_head_sha>\n<refreshed_at_ms>"` — the (base HEAD,
+/// linked HEAD) pair the overlay delta was last computed against, plus when that COMPLETE refresh
+/// recorded it (epoch ms, the #822 quiet-window anchor). A scoped watcher pass skips a worktree
+/// not implicated by events ONLY while this pair still matches; either head moving (a base commit
+/// re-basing every overlay, a linked commit with no file event) forces the refresh. A pre-#822
+/// two-line value still yields the pair — its missing timestamp just disarms the quiet window
+/// (never the safe-direction refresh). Kept per worktree in the per-repo kv rather than a
+/// dedicated table: it is a marker, not queried relationally, and the
 /// `watch_shutdown_reconcile_pending` marker set the pattern.
 const WORKTREE_OVERLAY_BASIS_META_PREFIX: &str = "worktree_overlay_basis:";
+
+/// A parsed refresh-basis value: the #577 skip-proof pair plus, when recorded by a #822-aware
+/// build, the recording refresh's timestamp. Internal to the two projection readers so the meta
+/// value is parsed in exactly one place.
+struct RecordedOverlayBasis {
+    base_sha: String,
+    linked_head_sha: String,
+    refreshed_at_ms: Option<i64>,
+}
 
 /// `repo_meta` key marking that a committed overlay refresh deferred the repo-global
 /// `logical_symbols` rebuild to its batch's tail (#819). Set INSIDE each overlay transaction that
@@ -460,30 +548,64 @@ impl OverlayChangeCounts {
 }
 
 impl IndexDatabase {
+    /// The parsed refresh-basis value for `worktree_id`, or `None` when never refreshed (or
+    /// written by a pre-#577 build). The single parse under both projection readers below.
+    fn read_worktree_overlay_basis(
+        &self,
+        worktree_id: &str,
+    ) -> anyhow::Result<Option<RecordedOverlayBasis>> {
+        let key = format!("{WORKTREE_OVERLAY_BASIS_META_PREFIX}{worktree_id}");
+        Ok(self.repo_meta(&key)?.and_then(|value| {
+            let mut lines = value.splitn(3, '\n');
+            let base_sha = lines.next()?.to_string();
+            let linked_head_sha = lines.next()?.to_string();
+            // Absent on a pre-#822 two-line value; an unparsable third line degrades the same
+            // way (no quiet skip) rather than invalidating the still-meaningful pair.
+            let refreshed_at_ms = lines.next().and_then(|at_ms| at_ms.parse().ok());
+            Some(RecordedOverlayBasis { base_sha, linked_head_sha, refreshed_at_ms })
+        }))
+    }
+
     /// The recorded refresh basis for `worktree_id`: `(base_sha, linked_head_sha)` at the last
-    /// successful overlay refresh, or `None` when never refreshed (or written by a pre-#577
+    /// COMPLETE overlay refresh, or `None` when never refreshed (or written by a pre-#577
     /// build) — the caller then refreshes unconditionally.
     pub(crate) fn worktree_overlay_basis(
         &self,
         worktree_id: &str,
     ) -> anyhow::Result<Option<(String, String)>> {
-        let key = format!("{WORKTREE_OVERLAY_BASIS_META_PREFIX}{worktree_id}");
-        Ok(self.repo_meta(&key)?.and_then(|value| {
-            let (base_sha, linked_head) = value.split_once('\n')?;
-            Some((base_sha.to_string(), linked_head.to_string()))
-        }))
+        Ok(self
+            .read_worktree_overlay_basis(worktree_id)?
+            .map(|basis| (basis.base_sha, basis.linked_head_sha)))
     }
 
-    /// Upsert the refresh basis after a successful overlay refresh. `set_repo_meta_if_changed` so
-    /// an unchanged-basis `All` sweep stays write-free (#63 idle backstop).
+    /// When `worktree_id`'s last COMPLETE refresh recorded its basis (epoch ms) — the #822
+    /// quiet-window anchor — or `None` when no basis is recorded or it predates the timestamp
+    /// (either way the quiet window never holds; the refresh side of that coin is always safe).
+    pub(crate) fn worktree_overlay_basis_refreshed_at_ms(
+        &self,
+        worktree_id: &str,
+    ) -> anyhow::Result<Option<i64>> {
+        Ok(self.read_worktree_overlay_basis(worktree_id)?.and_then(|basis| basis.refreshed_at_ms))
+    }
+
+    /// Upsert the refresh basis after a COMPLETE overlay refresh, stamped with `refreshed_at_ms`
+    /// (injected by the caller — the quiet-window anchor, #822). The timestamp advances on every
+    /// complete refresh, so unlike the pre-#822 pair-only value this writes one `repo_meta` row
+    /// per recording refresh — bounded by the #822 gate itself (a scoped pass inside the window
+    /// skips the whole refresh, and with it this write) and negligible next to the tree diff /
+    /// status walk the recording refresh just paid.
     pub(crate) fn record_worktree_overlay_basis(
         &self,
         worktree_id: &str,
         base_sha: &str,
         linked_head_sha: &str,
+        refreshed_at_ms: i64,
     ) -> anyhow::Result<()> {
         let key = format!("{WORKTREE_OVERLAY_BASIS_META_PREFIX}{worktree_id}");
-        self.set_repo_meta_if_changed(&key, &format!("{base_sha}\n{linked_head_sha}"))?;
+        self.set_repo_meta_if_changed(
+            &key,
+            &format!("{base_sha}\n{linked_head_sha}\n{refreshed_at_ms}"),
+        )?;
         Ok(())
     }
 
@@ -571,9 +693,7 @@ impl IndexDatabase {
         // `source_root` is the LINKED checkout's equivalent of `config.root` — bytes are read from
         // there, not the raw `linked_path` (which may be a subdir of the checkout, e.g. `--worktree
         // .` from `/wt/src`, or the git dir from a hook) (#219 review).
-        let Some((base_sha, worktree_id, source_root)) =
-            resolve_overlay_scope(config, linked_path)?
-        else {
+        let Some(overlay) = resolve_overlay_scope(config, linked_path)? else {
             // Fell back to base → not a valid linked sibling; nothing to overlay. Still an
             // entry-point exit, so it settles a pending batch obligation like every other one.
             self.settle_pending_logical_rebuild_inline(tail.logical_rebuild)?;
@@ -581,9 +701,11 @@ impl IndexDatabase {
         };
         // Scope the connection to the overlay (base commit + linked worktree id) so context-
         // dependent steps (tombstones, FTS, edge resolution) operate in the linked scope.
-        self.set_context(&base_sha, &worktree_id)?;
+        self.set_context(&overlay.base_sha, &overlay.worktree_id)?;
 
-        let mut delta = compute_linked_worktree_delta(config, linked_path)?;
+        let committed = self.resolve_committed_delta_source(&overlay, config)?;
+        let mut delta = compute_linked_worktree_delta(config, &overlay, committed)?;
+        let ResolvedOverlayScope { base_sha, worktree_id, source_root, .. } = overlay;
         // Fold in TARGET-IDENTITY drift: a branch config change that re-languages or drops a
         // byte-identical file is invisible to the content delta, but the overlay's (language, kind)
         // must still track the branch config, like discovery's staleness (#659 review). This also
@@ -716,7 +838,7 @@ impl IndexDatabase {
     where
         F: FnMut(IndexProgress),
     {
-        let Some((base_sha, worktree_id, source_root)) =
+        let Some(ResolvedOverlayScope { base_sha, worktree_id, source_root, .. }) =
             resolve_overlay_scope(config, linked_path)?
         else {
             // Not a valid linked sibling — still an entry-point exit (#819 review): settle a
@@ -901,6 +1023,58 @@ impl IndexDatabase {
         )?)
     }
 
+    /// Decide how a whole-delta refresh sources the COMMITTED half of its candidate set (#825).
+    /// When both CURRENT heads (re-read here, from the already-opened repos) still equal the
+    /// recorded #577 basis, the base↔linked tree diff would reproduce exactly the last complete
+    /// refresh's candidate outcome — materialized as the worktree's current overlay rows — so the
+    /// walk is skipped and those rows seed the candidates instead. Only complete refreshes record
+    /// the basis, only refreshes (or basis-clearing path-scoped passes) mutate overlay rows, and
+    /// a commit racing this read lands the safe way (the stored pair mismatches → full diff).
+    ///
+    /// Forced to the full diff when the branch config's targets may drift against the base
+    /// fingerprint: a re-target/re-language changes categorization without moving a HEAD and can
+    /// surface committed branch-only files that never produced a row, which the row seed provably
+    /// cannot see. (`compute_linked_worktree_delta` itself falls back on a dirty `.gitignore`
+    /// edit, the other row-blind case.)
+    fn resolve_committed_delta_source(
+        &self,
+        overlay: &ResolvedOverlayScope,
+        config: &Config,
+    ) -> anyhow::Result<CommittedDeltaSource> {
+        let heads_unchanged = self.worktree_overlay_basis(&overlay.worktree_id)?.is_some_and(
+            |(recorded_base, recorded_linked)| {
+                recorded_base == overlay.base_sha
+                    && recorded_linked == git_context::repo_head_sha(&overlay.linked_repo)
+            },
+        );
+        if !heads_unchanged || self.overlay_targets_may_drift(&config.targets)? {
+            return Ok(CommittedDeltaSource::TreeDiff);
+        }
+        Ok(CommittedDeltaSource::UnchangedSinceBasis {
+            shadowed_paths: self.list_overlay_shadowed_paths(&overlay.worktree_id)?,
+        })
+    }
+
+    /// Every path `worktree_id`'s overlay claims at the live generation — source rows AND
+    /// tombstones (`kind = 'deleted'`), config-root-relative: the materialized `shadowing_paths`
+    /// outcome of the last complete refresh, i.e. the committed-candidate seed when both HEADs
+    /// still match the recorded basis (#825). Tombstones MUST be included, or the seeded pass's
+    /// prune would drop them and un-shadow branch-deleted base files.
+    fn list_overlay_shadowed_paths(&self, worktree_id: &str) -> anyhow::Result<Vec<PathBuf>> {
+        let conn = self.storage.connection();
+        let mut stmt = conn.prepare(
+            "SELECT path FROM main.files WHERE repo_id = ?1 AND commit_sha = '' AND worktree_id = \
+             ?2 AND generation = ?3",
+        )?;
+        let paths = stmt
+            .query_map(params![self.active_repo_id, worktree_id, self.active_generation], |row| {
+                row.get::<_, String>(0)
+            })?
+            .map(|row| row.map(PathBuf::from))
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(paths)
+    }
+
     /// Refresh JUST the linked overlay's package/import scope (and re-resolve its edges against the
     /// new map) — the `index --paths <linked>/Cargo.toml` entry point when the supplied manifest is
     /// CLEAN/committed. `index_worktree_overlay` derives its manifest signal from the WORKING-TREE
@@ -915,7 +1089,7 @@ impl IndexDatabase {
         config: &Config,
         linked_path: &Path,
     ) -> anyhow::Result<()> {
-        let Some((base_sha, worktree_id, source_root)) =
+        let Some(ResolvedOverlayScope { base_sha, worktree_id, source_root, .. }) =
             resolve_overlay_scope(config, linked_path)?
         else {
             return Ok(());
@@ -1047,7 +1221,17 @@ impl IndexDatabase {
     ) -> anyhow::Result<()> {
         let Some(basis) = basis else { return Ok(()) };
         if status_complete {
-            self.record_worktree_overlay_basis(worktree_id, basis.base_sha, basis.linked_head_sha)
+            // The quiet-window anchor (#822) is stamped here, at the one seam every recording
+            // refresh passes through; `now_ms` is the codebase's single sanctioned wall-clock
+            // read. Riding the same value as the pair means clear-on-partial (below) and the
+            // caller-side clear-on-failure drop the timestamp with it — a cleared basis can
+            // never leave a stale quiet-skip behind.
+            self.record_worktree_overlay_basis(
+                worktree_id,
+                basis.base_sha,
+                basis.linked_head_sha,
+                rag_rat_base::time::now_ms(),
+            )
         } else {
             self.clear_worktree_overlay_basis(worktree_id)
         }

--- a/crates/rag-rat-core/src/watch/overlay.rs
+++ b/crates/rag-rat-core/src/watch/overlay.rs
@@ -88,6 +88,19 @@ impl OverlayScope {
 /// events, or at latest via the next `All` sweep (`periodic_sweep_secs`) — the same missed-event
 /// backstop the watcher already relies on.
 ///
+/// The quiet window (#822, `overlay_quiet_secs`): a worktree the scope DOES list is still skipped
+/// when both heads equal its recorded basis (dirty-only churn — file events with no commit or
+/// checkout) AND the recording COMPLETE refresh is younger than the window. Sustained editing in
+/// a worktree otherwise re-pays the full per-worktree probe every pass for a delta only the
+/// status walk can extend; the window batches that to once per `overlay_quiet_secs`. A HEAD move
+/// mismatches the basis and always refreshes immediately. Only uncommitted-edit visibility is
+/// deferred, and a skipped edit surfaces on the next pass that reaches the worktree: the first
+/// event-driven pass after the window elapses (sustained churn), or the periodic `All` sweep (a
+/// one-off edit with no follow-up event) — `All` passes never consult the window, so every
+/// existing backstop (startup catch-up, periodic sweep, gc, CLI/hook `maintenance`) is never
+/// held back. With the sweep disabled the gate turns itself off (see the clamp below): deferring
+/// an edit that no later event or sweep would deliver would leave the overlay stale forever.
+///
 /// `pub` so the hook-driven CLI `maintenance` command shares this exact path: the git hooks invoke
 /// `rag-rat maintenance` (not the foreground watcher), so without calling this a commit/checkout/
 /// merge in a linked worktree would index the base `config.root` but leave that worktree's overlay
@@ -108,6 +121,16 @@ pub fn refresh_worktree_overlays(
     // on the next pass and re-refreshes (the safe direction).
     let base_sha = crate::index::head_sha(&config.root);
     let sweep = matches!(scope, OverlayScope::All);
+    // One clock read serves every quiet-window decision of the pass (#822); the window compares
+    // against the persisted last-complete-refresh timestamp, so it survives watcher restarts.
+    let now_ms = rag_rat_base::time::now_ms();
+    // The window defers work it never schedules: a skipped edit surfaces on the NEXT pass that
+    // reaches the worktree — another event after the window elapses, or the periodic `All`
+    // sweep. With the sweep disabled (`periodic_sweep_secs = 0`) a one-off edit skipped here
+    // could have neither (no follow-up event, no sweep) and stay invisible indefinitely, so the
+    // gate disables itself rather than break the watcher's freshness contract.
+    let overlay_quiet_secs =
+        if config.watch.periodic_sweep_secs == 0 { 0 } else { config.watch.overlay_quiet_secs };
     let mut changed = false;
     for worktree in worktrees {
         if worktree == base_id {
@@ -116,11 +139,25 @@ pub fn refresh_worktree_overlays(
         // The linked HEAD is read BEFORE the refresh, so a commit racing the refresh records the
         // pre-commit head — mismatching (and re-refreshing) next pass rather than skipping.
         let linked_head = crate::index::head_sha(Path::new(&worktree));
-        if !scope.lists(&worktree)
-            && db.worktree_overlay_basis(&worktree).ok().flatten()
-                == Some((base_sha.clone(), linked_head.clone()))
-        {
+        let basis_unchanged = db.worktree_overlay_basis(&worktree).ok().flatten()
+            == Some((base_sha.clone(), linked_head.clone()));
+        if basis_unchanged && !scope.lists(&worktree) {
             continue; // not implicated by events and the diff basis is unchanged (#577)
+        }
+        // The quiet window (#822): dirty-only churn (matching basis) in a LISTED worktree defers
+        // the refresh until the window since the last COMPLETE refresh elapses. Event-scoped
+        // passes only — an `All` pass is one of the backstops the window's staleness bound
+        // relies on, so it must never be held back. A partial or failed refresh cleared the
+        // basis (timestamp included), so a stale overlay can never quiet-skip.
+        if basis_unchanged
+            && !sweep
+            && overlay_quiet_window_holds(
+                db.worktree_overlay_basis_refreshed_at_ms(&worktree).ok().flatten(),
+                overlay_quiet_secs,
+                now_ms,
+            )
+        {
+            continue;
         }
         // Refresh the overlay with the LINKED worktree's OWN config targets, not the sweeping
         // process's. A branch whose `rag-rat.toml` ADDS a target (e.g. `extra/`) would otherwise be
@@ -195,6 +232,22 @@ pub fn refresh_worktree_overlays(
     // scoped to the last worktree it touched).
     let _ = db.use_worktree_scope(&config.root, None);
     changed
+}
+
+/// Whether the #822 quiet window still holds for a heads-unchanged worktree: the last COMPLETE
+/// refresh recorded its timestamp less than `quiet_secs` ago. `0` disables the window; a missing
+/// timestamp (no recorded basis, or one written before the timestamp existed) never holds; a
+/// FUTURE timestamp (the wall clock stepped back) is a suspect proof, so it refreshes rather than
+/// skips. Pure — the caller injects `now_ms` — so the boundary cases are unit-testable.
+fn overlay_quiet_window_holds(refreshed_at_ms: Option<i64>, quiet_secs: u64, now_ms: i64) -> bool {
+    if quiet_secs == 0 {
+        return false;
+    }
+    let Some(refreshed_at_ms) = refreshed_at_ms else {
+        return false;
+    };
+    let window_ms = i64::try_from(quiet_secs.saturating_mul(1000)).unwrap_or(i64::MAX);
+    (0..window_ms).contains(&now_ms.saturating_sub(refreshed_at_ms))
 }
 
 pub(crate) fn overlay_needs_embed(
@@ -524,5 +577,34 @@ mod tests {
         let options = ReconcileOptions { max_seconds: Some(5), ..ReconcileOptions::default() };
         let spent = ReconcileBudget::new(options, Instant::now() - Duration::from_secs(10));
         assert!(spent.next_options().is_none());
+    }
+
+    #[test]
+    fn overlay_quiet_window_boundaries() {
+        let now_ms = 1_000_000;
+        assert!(
+            overlay_quiet_window_holds(Some(now_ms - 299_000), 300, now_ms),
+            "a fresh complete refresh holds the window"
+        );
+        assert!(
+            !overlay_quiet_window_holds(Some(now_ms - 300_000), 300, now_ms),
+            "the window is half-open: exactly `quiet_secs` old no longer holds"
+        );
+        assert!(
+            !overlay_quiet_window_holds(Some(now_ms - 1), 0, now_ms),
+            "0 disables the window entirely"
+        );
+        assert!(
+            !overlay_quiet_window_holds(None, 300, now_ms),
+            "no recorded timestamp (pre-#822 basis, or none) never holds"
+        );
+        assert!(
+            !overlay_quiet_window_holds(Some(now_ms + 60_000), 300, now_ms),
+            "a future timestamp (clock stepped back) refreshes rather than skips"
+        );
+        assert!(
+            overlay_quiet_window_holds(Some(0), u64::MAX, now_ms),
+            "an enormous window saturates instead of overflowing"
+        );
     }
 }

--- a/docs/config/freshness.md
+++ b/docs/config/freshness.md
@@ -12,6 +12,7 @@ debounce_ms = 400     # quiet window before a reindex pass
 max_latency_ms = 2500 # force a pass after this much continuous activity (starvation cap)
 periodic_sweep_secs = 300 # backstop pass at least this often (0 disables) — set for NFS/WSL
 pass_cooldown_secs = 60   # minimum gap between event-driven passes (0 disables)
+overlay_quiet_secs = 300  # linked-worktree quiet window for uncommitted edits (0 disables)
 ```
 
 `pass_cooldown_secs` paces the watcher under sustained editing: the next event-driven pass starts
@@ -19,6 +20,18 @@ no sooner than this long after the previous pass completed, so long agent sessio
 minutes-long passes back-to-back. The trade-off is up to that much added indexing latency after a
 pass completes; `periodic_sweep_secs` remains the staleness bound, and the periodic sweep is never
 held back by the cooldown.
+
+`overlay_quiet_secs` paces the per-worktree overlay refresh the same way, per linked worktree:
+when a pass's events for a checkout are dirty-only (neither its HEAD nor the base HEAD has moved
+since the last complete refresh), the refresh — a base↔branch tree diff plus a working-tree status
+walk — is skipped until the window since that refresh elapses. A commit or checkout in any
+worktree refreshes immediately; only uncommitted-edit visibility in worktree-scoped queries is
+deferred. A deferred edit surfaces on the first event-driven pass after the window elapses (under
+sustained editing), or at latest on the next periodic sweep (a one-off edit with no follow-up
+event) — sweep-style passes (startup catch-up, the periodic sweep, gc, the hook-driven
+`maintenance` command) ignore the window, so `periodic_sweep_secs` stays a staleness bound here
+too. When the sweep is disabled (`periodic_sweep_secs = 0`) the window is ignored entirely: a
+deferred one-off edit would otherwise have no later pass to surface it.
 
 The watcher runs inside `rag-rat mcp` automatically, and on demand via `rag-rat index --watch`. It
 watches the configured target directories recursively and runs the discover → reconcile → gc →


### PR DESCRIPTION
## Problem

Under sustained editing in a linked worktree, every event-driven watcher pass re-runs that worktree's **full overlay refresh** even when nothing but dirty working-tree churn happened (no commit, no checkout). Each refresh pays a base↔branch tree diff, a full working-tree status walk, and an `IgnoreMatcher` compile — and with the #847 cooldown flooring passes at 60 s, an agent editing for an hour still buys ~60 refreshes per worktree for content only the status walk can extend (#822).

The per-refresh probe itself is also more expensive than it needs to be: `resolve_overlay_scope` opens the base and linked repos, then `compute_linked_worktree_delta` re-discovers both — four `discover_repo` walks per refresh — and the committed base↔linked tree diff runs unconditionally even though it is a pure function of the (base HEAD, linked HEAD) pair that the #577 refresh basis already proves unchanged (#825).

## Design

**Quiet window (#822).** The per-worktree loop in `refresh_worktree_overlays` now skips a scope-listed worktree when **both** heads still equal its recorded refresh basis (dirty-only churn) **and** the recording complete refresh is younger than the new `[watch] overlay_quiet_secs` window. Semantics:

- **A HEAD move always refreshes immediately.** The gate is only ever consulted when the basis pair matches; a commit or checkout on either side mismatches it. Committed freshness is never deferred.
- **`All`-scoped passes never consult the window** — startup catch-up, the periodic sweep, gc, and the hook-driven `maintenance` command keep their existing unconditional behavior, so every backstop the watcher relies on is intact and the #577 scope matrix is unchanged.
- **The window anchor rides the basis value** as a third line (`"<base_sha>\n<linked_head>\n<refreshed_at_ms>"`), written inside the refresh transaction by the same record-on-complete path #849 established. Clear-on-partial (in-txn) and clear-on-failure (caller-side) therefore drop the timestamp with the pair — a stale quiet-skip is structurally impossible. Pre-upgrade two-line values still parse to the pair; their missing timestamp just disarms the window.
- **The gate self-disables when `periodic_sweep_secs = 0`.** The window defers work it never schedules — a skipped edit surfaces on the first event pass after the window, or at latest on the next sweep. With the sweep disabled, a one-off edit could have neither, so the gate turns itself off rather than leave an overlay stale indefinitely.

**Default 300 s, 0 disables.** The #847 cooldown already floors event-driven passes at 60 s, so a window has to be much larger than that to batch anything: 300 s collapses ~5 dirty-churn refreshes into one, matches the clone-graph quiet gate's 5-minute setting (the precedent for "defer derived work while the input is hot"), and equals the default sweep period, so it doesn't move the worst-case staleness bound for a one-off edit.

**Probe cost (#825).**
- `resolve_overlay_scope` now returns the two `gix::Repository` handles it opened (plus the config subdir it derived from them), and `compute_linked_worktree_delta` consumes that resolution instead of re-discovering — 4 repo-discovery walks per refresh down to 2, structurally: the rediscovery code path no longer exists in the signature. Orphan-HEAD tolerance (`head_id().ok()`) is unchanged.
- When the current heads (re-read from the threaded handles, same sha formatting as the basis writer) equal the recorded basis, the refresh **skips the committed tree diff**: the committed candidate outcome of the last complete refresh is already materialized as the worktree's current overlay rows (source rows *and* tombstones), so those seed the candidate set and only the working-tree status walk runs. This is what makes the `All` sweeps cheap for the (common) heads-unchanged worktrees the #822 window doesn't cover.

**Equivalence argument for the tree-diff skip.** The seed is sound because (a) only complete refreshes record the basis, and every other row-mutating path (path-scoped passes, failed refreshes) clears it, so "heads match basis" implies the rows are exactly the last complete refresh's shadowing set; (b) categorization is a pure function of (path, disk state, base tree, ignore rules, targets), and the base tree is still resolved (only the linked tree and the diff walk are skipped), so `shadows_base_file` and the ignore-flip expansion behave identically; (c) tombstones are included in the seed, so the prune cannot un-shadow branch-deleted base files. Two committed-side cases are **provably invisible to the row seed** — a committed branch-only file that produced no row can become indexable via a branch-config re-target or via a dirty `.gitignore` edit, and neither appears in status — so both force the full diff (the existing `overlay_targets_may_drift` gate caller-side; a dirty `.gitignore` detected by the status walk, which now runs before the committed-source decision). One accepted, self-healing divergence: a previously-dirty file reverted to base content keeps its content-identical (query-invisible) overlay row until the next tree-diff refresh prunes it.

## Freshness trade-offs

- Committed changes: no change — a HEAD move on either side refreshes on the next pass, exactly as before.
- Uncommitted edits in a linked worktree: visibility deferred by at most the quiet window under sustained churn (the first post-window event pass refreshes), and by at most one sweep period for a one-off edit — the sweep never consults the window. `overlay_quiet_secs = 0` restores today's per-pass behavior, and the gate disables itself when the sweep is off.
- The basis meta row is now rewritten once per recording refresh (the timestamp advances) instead of being write-free-if-unchanged; bounded by the gate itself and negligible next to the probe work the recording refresh just paid.

## Verification

- New tests: dirty-only listed worktree skipped inside the window and refreshed after it elapses (backdated anchor); linked and base HEAD moves refresh immediately inside the window; `0` disables; armed window ignored by `All` sweeps; gate self-disables with the sweep off; cleared basis never quiet-skips; basis value parse (stamped / legacy two-line / garbage timestamp); pure boundary tests for the window predicate. For #825: a heads-unchanged refresh reproduces the identical committed rows with the diff skipped, still catches new dirty edits via the status walk, and keeps a reverted-dirty row that a full diff would prune — the divergence that proves the fast path engaged, pruned again after the next HEAD move; a dirty `.gitignore` edit on matching heads still surfaces a newly-unignored committed branch-only file (forced full diff).
- Fails-on-current-main proof: the skip test's scenario (minus the not-yet-existing knob) run against the main tip fails at `inside the window a dirty-only listed worktree is skipped` — main refreshes a listed dirty worktree on every scoped pass.
- The #577 scope-matrix tests and the #849 basis-settlement test are untouched and green (the shared fixture pins `overlay_quiet_secs = 0`, so they still assert per-pass semantics; window tests opt in explicitly).
- `cargo nextest run --workspace --no-default-features --locked`: 3571 passed. `cargo test -p rag-rat-core -p rag-rat-base --no-default-features --locked`: green under the shared-process runner too. All four CI clippy legs (`--workspace --all-targets` with `--no-default-features` and `--all-features`; `-p rag-rat-core -p rag-rat` with `--features eval`, both flavors) clean with `-D warnings`; nightly rustfmt applied.

Fixes #822
Fixes #825
