### PR TITLE
fix(index): link each chunk to its defining symbol so distill records resolve precisely

### DIFF
--- a/crates/rag-rat-core/src/index/chunker.rs
+++ b/crates/rag-rat-core/src/index/chunker.rs
@@ -10,6 +10,13 @@ pub const MAX_STRUCTURAL_PARSE_BYTES: usize = 512_000;
 pub struct Chunk {
     pub kind: &'static str,
     pub symbol_path: Option<String>,
+    /// Index of the parsed symbol this chunk was cut from, into the same `&[ParsedSymbol]` slice
+    /// `code_chunks_for_symbols` received — `insert_chunks` remaps it to the symbol's DB rowid and
+    /// persists it as `chunks.symbol_id` (the direct chunk→symbol link, #855/#860). `None` for
+    /// chunks that define no symbol: uncovered/context spans, whole-file, markdown, and generated
+    /// / oversized line-split chunks. Follows the same local-index-then-remap convention as
+    /// edge candidates and clone fingerprints.
+    pub symbol_index: Option<usize>,
     pub start_byte: usize,
     pub end_byte: usize,
     pub start_line: usize,
@@ -91,7 +98,7 @@ pub fn code_chunks_for_symbols(
     // instead of a from-byte-0 rescan per symbol (#517).
     let lines = LineOffsets::new(text);
     let mut chunks = Vec::new();
-    for symbol in symbols {
+    for (symbol_index, symbol) in symbols.iter().enumerate() {
         let Some(range) = lines.byte_range(symbol.start_line, symbol.end_line) else {
             continue;
         };
@@ -103,7 +110,7 @@ pub fn code_chunks_for_symbols(
         for (part_idx, part) in
             split_symbol(span_text, span_start, symbol.start_line, 120).into_iter().enumerate()
         {
-            chunks.push(make_chunk(
+            let mut chunk = make_chunk(
                 "code",
                 Some(if part_idx == 0 {
                     symbol.qualified_name.clone()
@@ -115,7 +122,12 @@ pub fn code_chunks_for_symbols(
                 part.start_line,
                 part.end_line,
                 part.text,
-            ));
+            );
+            // Every part (part 0 and each `qname#<n>` continuation) is cut from THIS symbol, so
+            // they all carry its index — and thus resolve to the one symbol/logical id at read
+            // time.
+            chunk.symbol_index = Some(symbol_index);
+            chunks.push(chunk);
         }
     }
     chunks.extend(uncovered_code_chunks(path, text, symbols, &lines));
@@ -313,6 +325,10 @@ fn make_chunk(
     Chunk {
         kind,
         symbol_path: symbol_path.filter(|s| !s.is_empty()),
+        // Defaults to "no defining symbol"; `code_chunks_for_symbols` sets it for the code chunks
+        // it cuts from a specific parsed symbol. Every other producer (context, whole-file,
+        // markdown, line-split) leaves it None.
+        symbol_index: None,
         start_byte,
         end_byte,
         start_line,

--- a/crates/rag-rat-core/src/index/file_index.rs
+++ b/crates/rag-rat-core/src/index/file_index.rs
@@ -229,11 +229,16 @@ impl IndexDatabase {
                 ],
                 |row| row.get::<_, i64>(0),
             )?;
+        // Insert symbols FIRST so their freshly assigned rowids are in hand to stamp on each code
+        // chunk's `symbol_id` (the direct chunk→symbol link, #855/#860). Chunks and symbols are
+        // independent INSERTs into their own tables, so the order is free — nothing between the two
+        // depends on chunks preceding symbols.
+        let symbol_db_ids = self.insert_symbols(file_id, file.language, &prepared.symbols)?;
         self.insert_chunks(
             ChunkInsertFile { file_id, source_revision: &prepared.sha256 },
             &prepared.chunks,
+            &symbol_db_ids,
         )?;
-        let symbol_db_ids = self.insert_symbols(file_id, file.language, &prepared.symbols)?;
         // Clone fingerprints were computed in the parallel prepare phase from the same parse used
         // for symbols/edges (#230) — no second read, no second parse here, just the DB write.
         // bump_df = graph.is_none(): the full-rebuild path (graph: Some) recomputes clone_token_df
@@ -374,6 +379,7 @@ impl IndexDatabase {
         &self,
         file: ChunkInsertFile<'_>,
         chunks: &[PreparedChunk],
+        symbol_db_ids: &[i64],
     ) -> anyhow::Result<()> {
         let ChunkInsertFile { file_id, source_revision } = file;
         // Maintain the compressed store inline when a dict exists (incremental + heal, and a full
@@ -393,20 +399,29 @@ impl IndexDatabase {
         for prepared in chunks {
             let chunk = &prepared.chunk;
             let anchor = &prepared.anchor;
+            // Remap the chunk's LOCAL parsed-symbol index to the symbol's DB rowid (same convention
+            // as edge candidates / clone fingerprints). `symbol_db_ids[i]` is the rowid of
+            // `prepared.symbols[i]`, which is 1:1 with the `&[ParsedSymbol]` the chunker indexed —
+            // so this is the exact symbol the chunk was cut from. `get` (not `[]`) stays defensive:
+            // an out-of-range index resolves to NULL rather than panicking, and NULL simply yields
+            // no drive-by record.
+            let symbol_id: Option<i64> =
+                chunk.symbol_index.and_then(|i| symbol_db_ids.get(i).copied());
             conn.prepare_cached(
-                "INSERT INTO chunks(file_id, chunk_kind, symbol_path, start_byte, end_byte, \
-                 start_line, end_line, text_hash,
+                "INSERT INTO chunks(file_id, chunk_kind, symbol_path, symbol_id, start_byte, \
+                 end_byte, start_line, end_line, text_hash,
                                     source_revision, anchor_version, normalized_hash, \
                  start_boundary_hash, end_boundary_hash,
                                     start_context_hash, end_context_hash, context_radius, \
                  embedding_policy, embedding_priority)
                  VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, \
-                 ?17, ?18)",
+                 ?17, ?18, ?19)",
             )?
             .execute(params![
                 file_id,
                 chunk.kind,
                 chunk.symbol_path,
+                symbol_id,
                 i64::try_from(chunk.start_byte)?,
                 i64::try_from(chunk.end_byte)?,
                 i64::try_from(chunk.start_line)?,

--- a/crates/rag-rat-core/src/index/query_api/memory.rs
+++ b/crates/rag-rat-core/src/index/query_api/memory.rs
@@ -144,26 +144,26 @@ impl IndexDatabase {
     }
 
     /// Distilled decision records for the symbol a chunk defines (#705 drive-by on `read_chunk`).
-    /// Resolves the chunk's file `path` + qualified `symbol_path` to a logical symbol, then the
-    /// same facet-gated lane as [`records_for_symbol`]. Empty when the chunk defines no resolvable
-    /// logical symbol. `pub(crate)`: only the `read_chunk` reader calls it (unlike the sibling
-    /// `records_for_symbol`, which the MCP handler invokes directly).
+    /// Resolves the chunk's PRECISE defining symbol by the direct `chunks.symbol_id` link
+    /// (#855/#860 — position matching is ambiguous across same-simple-name methods that nest or
+    /// share a line), then the same facet-gated lane as [`records_for_symbol`]. Empty when the
+    /// chunk defines no resolvable logical symbol. `pub(crate)`: only the `read_chunk` reader calls
+    /// it (unlike the sibling `records_for_symbol`, which the MCP handler invokes directly).
     pub(crate) fn records_for_chunk_symbol(
         &self,
         chunk_id: i64,
-        symbol_path: Option<&str>,
         limit: usize,
     ) -> anyhow::Result<Vec<rag_rat_papertrail::DriveByRecord>> {
         let conn = self.storage.connection();
         let repo_id = rag_rat_db::schema::active_repo_id(conn)?;
-        let logical_symbol_id =
-            rag_rat_query::memory::logical_symbol_id_for_chunk_symbol(conn, chunk_id, symbol_path)?;
+        let logical_symbol_id = rag_rat_query::memory::logical_symbol_id_for_chunk(conn, chunk_id)?;
         Self::drive_by_records_scoped(conn, &repo_id, logical_symbol_id, limit)
     }
 
     /// Attach distilled decision records (#705 drive-by) to each search hit's symbol — the same
-    /// facet-gated, capped lane as `read_chunk`, resolved from each hit's `(path, symbol_path)`.
-    /// Skips a result set with no symbol-bearing hits so a doc/config-only result pays nothing.
+    /// facet-gated, capped lane as `read_chunk`, resolved precisely from each hit's `chunk_id`
+    /// (#855). Skips a result set with no symbol-bearing hits so a doc/config-only result pays
+    /// nothing.
     /// `pub`: the `semantic_search` MCP handler calls it directly (the shared
     /// `search_with_graph_meta` deliberately does NOT, so records stay off docs_for_symbol and
     /// other search consumers).
@@ -182,22 +182,16 @@ impl IndexDatabase {
         if !rag_rat_db::schema::table_exists(conn, "papertrail_distill")? {
             return Ok(());
         }
-        // Resolve the repo scope ONCE for the batch, then memoize the record FETCH by the
-        // RESOLVED logical id. Keying the memo on the raw `(path, symbol_path)` would be both
-        // wrong and useless now: resolution is per-chunk (two same-named methods in one file share
-        // a symbol_path but are different symbols), and continuation chunks carry distinct
-        // `qname#<part>` strings that never collided as keys in the first place. The logical id is
-        // what the many chunks of one symbol actually share.
+        // Resolve the repo scope ONCE, and memoize the fetched records by the RESOLVED
+        // logical-symbol id — so the many chunks of one symbol (including its continuation
+        // parts, which each carry that symbol's `symbol_id` and so resolve to the same logical
+        // id) fetch a single time.
         let repo_id = rag_rat_db::schema::active_repo_id(conn)?;
         let mut by_logical: std::collections::HashMap<i64, Vec<rag_rat_papertrail::DriveByRecord>> =
             std::collections::HashMap::new();
         for hit in hits.iter_mut() {
             let Some(logical_symbol_id) =
-                rag_rat_query::memory::logical_symbol_id_for_chunk_symbol(
-                    conn,
-                    hit.chunk_id,
-                    hit.symbol_path.as_deref(),
-                )?
+                rag_rat_query::memory::logical_symbol_id_for_chunk(conn, hit.chunk_id)?
             else {
                 continue;
             };

--- a/crates/rag-rat-core/src/index/query_api/mod.rs
+++ b/crates/rag-rat-core/src/index/query_api/mod.rs
@@ -481,8 +481,7 @@ impl IndexDatabase {
             // Distilled decision records (#705 drive-by) for the symbol this chunk defines, capped
             // ≤2 and labeled unreviewed. Rides the memories flag; facet-gated, so empty for almost
             // every chunk — matches the symbol_lookup convention (a lightweight per-item surface).
-            chunk.distilled_records =
-                self.records_for_chunk_symbol(chunk_id, chunk.symbol_path.as_deref(), 2)?;
+            chunk.distilled_records = self.records_for_chunk_symbol(chunk_id, 2)?;
         }
         Ok(Some(chunk))
     }

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_memory.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_memory.rs
@@ -2845,9 +2845,9 @@ fn surface_summary_defers_bodies_across_the_db_memory_renderers() {
 }
 
 /// #705 drive-by: `read_chunk` attaches the distilled decision records for the symbol the chunk
-/// defines — resolved from the chunk's (path, symbol_path) to the same facet-gated (provider fix
-/// edge + a selected symbol anchor), capped, labeled lane the other symbol surfaces use. Rides the
-/// memories include flag.
+/// defines — resolved from the chunk's direct `symbol_id` link to the same facet-gated (provider
+/// fix edge + a selected symbol anchor), capped, labeled lane the other symbol surfaces use. Rides
+/// the memories include flag.
 #[test]
 fn read_chunk_attaches_distilled_records_for_the_chunk_symbol() {
     use rag_rat_base::config::MemorySurface;
@@ -2923,22 +2923,6 @@ fn read_chunk_attaches_distilled_records_for_the_chunk_symbol() {
     );
     assert!(chunk.distilled_records[0].unreviewed, "the drive-by record is labeled unreviewed");
 
-    // A symbol wider than the chunk limit splits; its continuation chunks carry a
-    // `<qualified_name>#<part>` symbol_path. That must resolve to the SAME defining symbol rather
-    // than silently surfacing nothing — the numeric continuation suffix is stripped before the
-    // symbol lookup.
-    let base_symbol_path = chunk.symbol_path.clone().expect("the chunk defines a symbol");
-    let continuation = format!("{base_symbol_path}#1");
-    assert_eq!(
-        db.records_for_chunk_symbol(chunk_id, Some(&continuation), 2)
-            .unwrap()
-            .iter()
-            .map(|r| r.record.item_key.as_str())
-            .collect::<Vec<_>>(),
-        vec!["5"],
-        "a `{base_symbol_path}#<part>` continuation symbol_path resolves to the same records",
-    );
-
     // include_memories = false skips the whole drive-by lane, same as memories.
     let bare = db
         .read_chunk_with_graph_and_memories(
@@ -2952,9 +2936,490 @@ fn read_chunk_attaches_distilled_records_for_the_chunk_symbol() {
         .expect("chunk");
     assert!(bare.distilled_records.is_empty(), "the drive-by rides the memories include flag");
 
-    // Resolver guards: a chunk with no symbol name, and an unknown symbol, both surface nothing.
-    assert!(db.records_for_chunk_symbol(chunk_id, None, 2).unwrap().is_empty());
-    assert!(db.records_for_chunk_symbol(chunk_id, Some("does_not_exist"), 2).unwrap().is_empty());
+    // The chunk carries the DIRECT symbol_id link written at index time; a chunk_id with no row
+    // (so no reachable symbol) surfaces nothing.
+    let linked_symbol_id: Option<i64> = conn
+        .query_row("SELECT symbol_id FROM chunks WHERE id = ?1", [chunk_id], |r| r.get(0))
+        .unwrap();
+    assert!(linked_symbol_id.is_some(), "the code chunk is linked to its defining symbol");
+    assert!(
+        db.records_for_chunk_symbol(-1, 2).unwrap().is_empty(),
+        "a nonexistent chunk surfaces nothing"
+    );
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+/// #855/#860: two same-simple-name methods in one file with DIFFERENT signatures (`make` on two
+/// impls, differing arity) are DISTINCT logical symbols that share a bare `qualified_name`
+/// (`src/lib.rs::make`). Each chunk carries a DIRECT `symbol_id` to the exact method it was cut
+/// from, so a record anchored to ONE surfaces only on THAT method's chunk — never on the other
+/// same-named overload, and never dropped.
+#[test]
+fn drive_by_records_disambiguate_same_name_overloads_by_symbol_id() {
+    use rag_rat_base::config::MemorySurface;
+    use rag_rat_query::graph_meta::GraphMetaMode;
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(
+        root.join("src/lib.rs"),
+        "pub struct A;\npub struct B;\nimpl A {\n    pub fn make(_x: u8) -> A {\n        A\n    \
+         }\n}\nimpl B {\n    pub fn make(_x: u8, _y: u8) -> B {\n        B\n    }\n}\n",
+    )
+    .unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let conn = db.storage.connection();
+    // The two `make` methods share symbol_path `src/lib.rs::make` but are distinct logical symbols
+    // (differing arity). Follow each chunk's DIRECT `symbol_id` to its method; order by start_byte
+    // for a stable first/second. The join through `chunks.symbol_id` also proves the link is
+    // populated at index time — a chunk with a NULL symbol_id would not appear.
+    let mut stmt = conn
+        .prepare(
+            "SELECT chunks.id, members.logical_symbol_id
+             FROM chunks
+             JOIN symbols ON symbols.id = chunks.symbol_id
+             JOIN logical_symbol_members members ON members.symbol_id = symbols.id
+             WHERE chunks.symbol_path = 'src/lib.rs::make'
+             ORDER BY chunks.start_byte",
+        )
+        .unwrap();
+    let makes: Vec<(i64, i64)> = stmt
+        .query_map([], |r| Ok((r.get::<_, i64>(0)?, r.get::<_, i64>(1)?)))
+        .unwrap()
+        .map(Result::unwrap)
+        .collect();
+    drop(stmt);
+    assert_eq!(
+        makes.len(),
+        2,
+        "both `make` overloads carry a symbol_id to their own method: {makes:?}"
+    );
+    let (first_chunk, first_logical) = makes[0];
+    let (second_chunk, second_logical) = makes[1];
+    assert_ne!(first_logical, second_logical, "differing signatures ⟹ distinct logical symbols");
+
+    let repo_id = rag_rat_db::schema::active_repo_id(conn).unwrap();
+    conn.execute(
+        "INSERT INTO papertrail_distill
+             (tracker, project, item_kind, item_key, distill_input_hash, pipeline_version,
+              root_issue, fix_edge_source, thread_shape, anchors_qualified_count, distilled_at_ms, \
+         repo_id)
+         VALUES ('github','o/r','issue','5','sha256:h',3,'5','provider','investigation',1,10,?1)",
+        rusqlite::params![repo_id],
+    )
+    .unwrap();
+    // Anchor the record to ONLY the FIRST `make` overload's logical id.
+    conn.execute(
+        "INSERT INTO papertrail_distill_anchors
+             (tracker, project, item_kind, item_key, anchor_kind, logical_symbol_id, name,
+              resolved, candidate_ordinal, selected, repo_id)
+         VALUES ('github','o/r','issue','5','symbol',?1,'make',1,0,1,?2)",
+        rusqlite::params![rag_rat_base::serde_big_id::format_sym_handle(first_logical), repo_id],
+    )
+    .unwrap();
+
+    let read = |chunk_id: i64| {
+        db.read_chunk_with_graph_and_memories(
+            chunk_id,
+            GraphMetaMode::Full,
+            20,
+            true,
+            MemorySurface::Full,
+        )
+        .unwrap()
+        .expect("chunk")
+        .distilled_records
+        .iter()
+        .map(|r| r.record.item_key.clone())
+        .collect::<Vec<_>>()
+    };
+    // Direct resolution: the record surfaces on the anchored overload's chunk ONLY. Before #855
+    // both chunks resolved via the shared symbol_path to one arbitrary `LIMIT 1` winner, so the
+    // record would appear on the wrong overload (or the other assertion would fail).
+    assert_eq!(read(first_chunk), vec!["5".to_string()], "record on the anchored overload's chunk");
+    assert!(read(second_chunk).is_empty(), "the other same-named overload must NOT carry it");
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+/// #855/#860: NESTED same-name symbols (a `fn wrap` inside a `fn wrap`) share a bare qualified_name
+/// AND their byte/line spans NEST (inner ⊂ outer), so no position metric can disambiguate them.
+/// The chunker cuts one chunk per symbol and stamps each with that symbol's DIRECT `symbol_id`, so
+/// the outer chunk resolves to the outer fn and the inner chunk to the inner — never crossed.
+#[test]
+fn drive_by_records_disambiguate_nested_same_name_symbols() {
+    use rag_rat_base::config::MemorySurface;
+    use rag_rat_query::graph_meta::GraphMetaMode;
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(
+        root.join("src/lib.rs"),
+        "pub fn wrap() -> u8 {\n    fn wrap() -> u8 {\n        7\n    }\n    wrap()\n}\n",
+    )
+    .unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let conn = db.storage.connection();
+
+    // Both `wrap` symbols share symbol_path; the OUTER has the wider span (it contains the nested
+    // inner), and so does its chunk. Order by width DESC so [0] is the outer.
+    let logicals: Vec<i64> = conn
+        .prepare(
+            "SELECT members.logical_symbol_id FROM symbols
+             JOIN logical_symbol_members members ON members.symbol_id = symbols.id
+             JOIN files ON files.id = symbols.file_id
+             WHERE files.path = 'src/lib.rs'
+               AND symbols.qualified_name_id = (SELECT id FROM name_strings WHERE value = \
+             'src/lib.rs::wrap')
+             ORDER BY symbols.end_byte - symbols.start_byte DESC",
+        )
+        .unwrap()
+        .query_map([], |r| r.get(0))
+        .unwrap()
+        .map(Result::unwrap)
+        .collect();
+    let chunks: Vec<i64> = conn
+        .prepare(
+            "SELECT chunks.id FROM chunks JOIN files ON files.id = chunks.file_id
+             WHERE files.path = 'src/lib.rs' AND chunks.symbol_path = 'src/lib.rs::wrap'
+             ORDER BY chunks.end_byte - chunks.start_byte DESC",
+        )
+        .unwrap()
+        .query_map([], |r| r.get(0))
+        .unwrap()
+        .map(Result::unwrap)
+        .collect();
+    assert_eq!(logicals.len(), 2, "outer + nested wrap are distinct logical symbols: {logicals:?}");
+    assert_eq!(chunks.len(), 2, "outer + nested wrap chunks: {chunks:?}");
+    assert_ne!(logicals[0], logicals[1]);
+    let (outer_logical, outer_chunk, inner_chunk) = (logicals[0], chunks[0], chunks[1]);
+
+    let repo_id = rag_rat_db::schema::active_repo_id(conn).unwrap();
+    conn.execute(
+        "INSERT INTO papertrail_distill
+             (tracker, project, item_kind, item_key, distill_input_hash, pipeline_version,
+              root_issue, fix_edge_source, thread_shape, anchors_qualified_count, distilled_at_ms, \
+         repo_id)
+         VALUES ('github','o/r','issue','5','sha256:h',3,'5','provider','investigation',1,10,?1)",
+        rusqlite::params![repo_id],
+    )
+    .unwrap();
+    // Anchor the record to the OUTER `wrap` only.
+    conn.execute(
+        "INSERT INTO papertrail_distill_anchors
+             (tracker, project, item_kind, item_key, anchor_kind, logical_symbol_id, name,
+              resolved, candidate_ordinal, selected, repo_id)
+         VALUES ('github','o/r','issue','5','symbol',?1,'wrap',1,0,1,?2)",
+        rusqlite::params![rag_rat_base::serde_big_id::format_sym_handle(outer_logical), repo_id],
+    )
+    .unwrap();
+
+    let read = |chunk_id: i64| {
+        db.read_chunk_with_graph_and_memories(
+            chunk_id,
+            GraphMetaMode::Full,
+            20,
+            true,
+            MemorySurface::Full,
+        )
+        .unwrap()
+        .expect("chunk")
+        .distilled_records
+        .iter()
+        .map(|r| r.record.item_key.clone())
+        .collect::<Vec<_>>()
+    };
+    assert_eq!(
+        read(outer_chunk),
+        vec!["5".to_string()],
+        "the OUTER wrap's chunk resolves to the outer (anchored) symbol"
+    );
+    assert!(
+        read(inner_chunk).is_empty(),
+        "the NESTED inner wrap must NOT carry the outer's record"
+    );
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+/// #855/#860: a SPLIT outer function (>120 lines, so it has continuation chunks) whose continuation
+/// SPANS a NESTED same-named inner function of a different signature. EVERY part of the outer —
+/// part 0 and each `wrap#<n>` continuation — is cut from the outer symbol and carries its DIRECT
+/// `symbol_id`, so the continuation binds to the OUTER. A position metric would wrongly pull it to
+/// the tiny inner it spans (the inner's span is nearer / narrower); the direct link cannot.
+#[test]
+fn drive_by_records_bind_a_split_continuation_to_its_outer_symbol_over_a_nested_inner() {
+    use rag_rat_base::config::MemorySurface;
+    use rag_rat_query::graph_meta::GraphMetaMode;
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    // Outer `wrap(_x: u8)` is > 120 lines (splits into `wrap` + `wrap#1`); the nested `wrap()` (no
+    // arg ⟹ different signature ⟹ distinct logical symbol) sits past line 120, inside the `wrap#1`
+    // continuation.
+    let padding = "    let _a = 0u8;\n".repeat(125);
+    fs::write(
+        root.join("src/lib.rs"),
+        format!(
+            "pub fn wrap(_x: u8) -> u8 {{\n{padding}    fn wrap() -> u8 {{ 9 }}\n    let _b = \
+             wrap();\n    _x\n}}\n"
+        ),
+    )
+    .unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let conn = db.storage.connection();
+
+    // Outer = the wrap symbol with the WIDER line span (it contains the nested inner).
+    let outer_logical: i64 = conn
+        .query_row(
+            "SELECT members.logical_symbol_id FROM symbols
+             JOIN logical_symbol_members members ON members.symbol_id = symbols.id
+             JOIN files ON files.id = symbols.file_id
+             WHERE files.path = 'src/lib.rs'
+               AND symbols.qualified_name_id = (SELECT id FROM name_strings WHERE value = \
+             'src/lib.rs::wrap')
+             ORDER BY symbols.end_line - symbols.start_line DESC LIMIT 1",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    // A CONTINUATION chunk of the outer (`wrap#<n>`), which spans the nested inner.
+    let cont_chunk: i64 = conn
+        .query_row(
+            "SELECT chunks.id FROM chunks JOIN files ON files.id = chunks.file_id
+             WHERE files.path = 'src/lib.rs' AND chunks.symbol_path LIKE 'src/lib.rs::wrap#%' \
+             LIMIT 1",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+
+    let repo_id = rag_rat_db::schema::active_repo_id(conn).unwrap();
+    conn.execute(
+        "INSERT INTO papertrail_distill
+             (tracker, project, item_kind, item_key, distill_input_hash, pipeline_version,
+              root_issue, fix_edge_source, thread_shape, anchors_qualified_count, distilled_at_ms, \
+         repo_id)
+         VALUES ('github','o/r','issue','5','sha256:h',3,'5','provider','investigation',1,10,?1)",
+        rusqlite::params![repo_id],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO papertrail_distill_anchors
+             (tracker, project, item_kind, item_key, anchor_kind, logical_symbol_id, name,
+              resolved, candidate_ordinal, selected, repo_id)
+         VALUES ('github','o/r','issue','5','symbol',?1,'wrap',1,0,1,?2)",
+        rusqlite::params![rag_rat_base::serde_big_id::format_sym_handle(outer_logical), repo_id],
+    )
+    .unwrap();
+
+    let recs = db
+        .read_chunk_with_graph_and_memories(
+            cont_chunk,
+            GraphMetaMode::Full,
+            20,
+            true,
+            MemorySurface::Full,
+        )
+        .unwrap()
+        .expect("chunk")
+        .distilled_records
+        .iter()
+        .map(|r| r.record.item_key.clone())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        recs,
+        vec!["5".to_string()],
+        "the outer's continuation chunk resolves to the OUTER symbol, not the nested inner it \
+         spans",
+    );
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+/// #855/#860: two same-name different-signature symbols on ONE physical line (minified / generated
+/// code) share start/end line AND byte span, so NO position metric can attribute a chunk to one of
+/// them — the case the earlier line/byte resolvers could only make deterministic, never correct.
+/// The direct `symbol_id` link solves it: the chunker cuts a chunk per symbol and stamps each with
+/// its own symbol's id, so each `f` chunk resolves to ITS OWN method and a record anchored to one
+/// surfaces only there.
+#[test]
+fn drive_by_records_resolve_same_line_symbols_by_symbol_id() {
+    use rag_rat_base::config::MemorySurface;
+    use rag_rat_query::graph_meta::GraphMetaMode;
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    // Two `f` (different signatures ⟹ distinct logical symbols) on ONE physical line.
+    fs::write(
+        root.join("src/lib.rs"),
+        "pub struct A;pub struct B;impl A{fn f()->u8{1}}impl B{fn f(_x:u8)->u8{2}}\n",
+    )
+    .unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let conn = db.storage.connection();
+
+    // Both `f` chunks share span and symbol_path; each is told apart ONLY by its DIRECT symbol_id.
+    // Order by the symbol's start_byte for a stable first (A::f) / second (B::f).
+    let mut stmt = conn
+        .prepare(
+            "SELECT chunks.id, members.logical_symbol_id
+             FROM chunks
+             JOIN symbols ON symbols.id = chunks.symbol_id
+             JOIN logical_symbol_members members ON members.symbol_id = symbols.id
+             WHERE chunks.symbol_path = 'src/lib.rs::f'
+             ORDER BY symbols.start_byte",
+        )
+        .unwrap();
+    let f_symbols: Vec<(i64, i64)> = stmt
+        .query_map([], |r| Ok((r.get::<_, i64>(0)?, r.get::<_, i64>(1)?)))
+        .unwrap()
+        .map(Result::unwrap)
+        .collect();
+    drop(stmt);
+    assert_eq!(
+        f_symbols.len(),
+        2,
+        "both same-line `f` symbols carry a chunk with its own symbol_id: {f_symbols:?}"
+    );
+    let (first_chunk, first_logical) = f_symbols[0];
+    let (second_chunk, second_logical) = f_symbols[1];
+    assert_ne!(first_logical, second_logical, "differing signatures ⟹ distinct logical symbols");
+    assert_ne!(first_chunk, second_chunk, "each same-line symbol is cut into its OWN chunk");
+
+    let repo_id = rag_rat_db::schema::active_repo_id(conn).unwrap();
+    conn.execute(
+        "INSERT INTO papertrail_distill
+             (tracker, project, item_kind, item_key, distill_input_hash, pipeline_version,
+              root_issue, fix_edge_source, thread_shape, anchors_qualified_count, distilled_at_ms, \
+         repo_id)
+         VALUES ('github','o/r','issue','5','sha256:h',3,'5','provider','investigation',1,10,?1)",
+        rusqlite::params![repo_id],
+    )
+    .unwrap();
+    // Anchor the record to the FIRST `f` (A::f) only.
+    conn.execute(
+        "INSERT INTO papertrail_distill_anchors
+             (tracker, project, item_kind, item_key, anchor_kind, logical_symbol_id, name,
+              resolved, candidate_ordinal, selected, repo_id)
+         VALUES ('github','o/r','issue','5','symbol',?1,'f',1,0,1,?2)",
+        rusqlite::params![rag_rat_base::serde_big_id::format_sym_handle(first_logical), repo_id],
+    )
+    .unwrap();
+
+    let read = |chunk_id: i64| {
+        db.read_chunk_with_graph_and_memories(
+            chunk_id,
+            GraphMetaMode::Full,
+            20,
+            true,
+            MemorySurface::Full,
+        )
+        .unwrap()
+        .expect("chunk")
+        .distilled_records
+        .iter()
+        .map(|r| r.record.item_key.clone())
+        .collect::<Vec<_>>()
+    };
+    // Each same-line `f` chunk resolves to its OWN method: the record surfaces on A::f's chunk
+    // only.
+    assert_eq!(read(first_chunk), vec!["5".to_string()], "record on the anchored same-line `f`");
+    assert!(read(second_chunk).is_empty(), "the other same-line `f` must NOT carry it");
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+/// #855/#860 regression: upgrading an EXISTING index to V083 must not silently drop drive-by
+/// records. Pre-migration chunks have NULL `symbol_id`, and the direct-only resolver would return
+/// nothing for them — indefinitely, since incremental indexing skips unchanged files. The V083
+/// backfill repairs those chunks. This drives the whole seam: prove the record shows, NULL out
+/// symbol_id to SIMULATE a pre-V083 index (the record must vanish — so the test disagrees with any
+/// stale fallback), run the backfill, and prove the record returns.
+#[test]
+fn drive_by_records_survive_a_v083_upgrade_via_the_backfill() {
+    use rag_rat_base::config::MemorySurface;
+    use rag_rat_query::graph_meta::GraphMetaMode;
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), "pub fn target() -> u8 {\n    7\n}\n").unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let conn = db.storage.connection();
+
+    let logical: i64 = conn
+        .query_row(
+            "SELECT members.logical_symbol_id FROM symbols
+             JOIN logical_symbol_members members ON members.symbol_id = symbols.id
+             JOIN files ON files.id = symbols.file_id
+             WHERE files.path = 'src/lib.rs'
+               AND symbols.qualified_name_id = (SELECT id FROM name_strings WHERE value = \
+             'src/lib.rs::target')",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    let chunk_id: i64 = conn
+        .query_row(
+            "SELECT chunks.id FROM chunks JOIN files ON files.id = chunks.file_id
+             WHERE files.path = 'src/lib.rs' AND chunks.symbol_path = 'src/lib.rs::target'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+
+    let repo_id = rag_rat_db::schema::active_repo_id(conn).unwrap();
+    conn.execute(
+        "INSERT INTO papertrail_distill
+             (tracker, project, item_kind, item_key, distill_input_hash, pipeline_version,
+              root_issue, fix_edge_source, thread_shape, anchors_qualified_count, distilled_at_ms, \
+         repo_id)
+         VALUES ('github','o/r','issue','5','sha256:h',3,'5','provider','investigation',1,10,?1)",
+        rusqlite::params![repo_id],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO papertrail_distill_anchors
+             (tracker, project, item_kind, item_key, anchor_kind, logical_symbol_id, name,
+              resolved, candidate_ordinal, selected, repo_id)
+         VALUES ('github','o/r','issue','5','symbol',?1,'target',1,0,1,?2)",
+        rusqlite::params![rag_rat_base::serde_big_id::format_sym_handle(logical), repo_id],
+    )
+    .unwrap();
+
+    let read = || {
+        db.read_chunk_with_graph_and_memories(
+            chunk_id,
+            GraphMetaMode::Full,
+            20,
+            true,
+            MemorySurface::Full,
+        )
+        .unwrap()
+        .expect("chunk")
+        .distilled_records
+        .iter()
+        .map(|r| r.record.item_key.clone())
+        .collect::<Vec<_>>()
+    };
+
+    // Freshly indexed: the chunk carries an exact symbol_id and the record surfaces.
+    assert_eq!(read(), vec!["5".to_string()], "record surfaces on the freshly indexed chunk");
+
+    // Simulate a pre-V083 index: strip the direct link the migration had not yet added.
+    conn.execute("UPDATE chunks SET symbol_id = NULL", []).unwrap();
+    assert!(read().is_empty(), "a pre-V083 chunk (NULL symbol_id) resolves to no record");
+
+    // The V083 backfill re-links the pre-migration chunk by line-range containment.
+    rag_rat_db::schema::apply_chunk_symbol_id(conn).unwrap();
+    assert_eq!(read(), vec!["5".to_string()], "the backfill restores the record on the old chunk");
 
     let _ = fs::remove_dir_all(&root);
 }

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
@@ -3153,7 +3153,7 @@ fn migration_078_distinguishes_candidates_from_selections() {
 
 #[test]
 fn migration_079_builds_safe_input_snapshots() {
-    // `LATEST_SCHEMA_VERSION` pin moved to `migration_082_*`, the new tip; this uses only the
+    // `LATEST_SCHEMA_VERSION` pin moved to `migration_083_*`, the new tip; this uses only the
     // symbolic checks (the hardcoded-LATEST footgun).
     let legacy = rusqlite::Connection::open_in_memory().unwrap();
     schema::apply_distill_record_store(&legacy).unwrap();
@@ -3257,7 +3257,7 @@ fn migration_079_builds_safe_input_snapshots() {
 
 #[test]
 fn migration_080_builds_enriched_context_snapshots() {
-    // The `LATEST_SCHEMA_VERSION` pin lives on `migration_082_*`, the current tip; this uses
+    // The `LATEST_SCHEMA_VERSION` pin lives on `migration_083_*`, the current tip; this uses
     // only the symbolic checks (the hardcoded-LATEST footgun).
     let legacy = rusqlite::Connection::open_in_memory().unwrap();
     schema::apply_distill_record_store(&legacy).unwrap();
@@ -3363,7 +3363,7 @@ fn migration_080_builds_enriched_context_snapshots() {
 
 #[test]
 fn migration_081_adds_evidence_source_part() {
-    // The `LATEST_SCHEMA_VERSION` pin lives on `migration_082_*`, the current tip.
+    // The `LATEST_SCHEMA_VERSION` pin lives on `migration_083_*`, the current tip.
 
     // The evidence table predates the column: build the record store (V077) without V081, then
     // apply V081 and confirm the column appears.
@@ -3437,6 +3437,7 @@ fn migration_081_adds_evidence_source_part() {
 
 #[test]
 fn migration_082_accounts_for_content_refold_work() {
+    // The `LATEST_SCHEMA_VERSION` pin lives on `migration_084_*`, the current tip.
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     schema::apply(&conn, &crate::index::migration_hooks()).unwrap();
 
@@ -3453,8 +3454,9 @@ fn migration_082_accounts_for_content_refold_work() {
             )
         };
 
-    // Reconstruct the previous tip: retain the V081 distill migrations and their data, but
-    // restore the V072 queue shape and remove every V082 object before replaying only V082.
+    // Reconstruct a pre-V082 index: retain the V081 distill migrations and their data, but
+    // restore the V072 queue shape and remove every V082 object, then replay forward from V081
+    // (V082 does the content-refold work; later tips are orthogonal to it).
     conn.execute_batch(
         "DROP TRIGGER content_stream_stats_after_insert;
          DROP TRIGGER content_stream_stats_after_delete;
@@ -3620,14 +3622,13 @@ fn migration_082_accounts_for_content_refold_work() {
     assert_eq!(v82_recorded, 1, "forward migration records V082");
 }
 
-/// V083 recomputes `logical_symbols.group_reason` from member evidence, and is the schema tip.
+/// V083 recomputes `logical_symbols.group_reason` from member evidence.
 ///
 /// The column is derived but PERSISTED, so a new labelling rule alone would never reach an existing
 /// index: a query-only server over an unchanged repository never runs `rebuild_logical_symbols` and
 /// would keep serving the old `cfg_variant` for every multi-member group indefinitely.
 #[test]
-fn migration_083_is_the_tip_and_relabels_logical_groups_by_evidence() {
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 83, "move this pin with the next schema migration");
+fn migration_083_relabels_logical_groups_by_evidence() {
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     schema::apply(&conn, &crate::index::migration_hooks()).unwrap();
 
@@ -3680,7 +3681,8 @@ fn migration_083_is_the_tip_and_relabels_logical_groups_by_evidence() {
 
     truncate_schema_to(&conn, 82);
     schema::migrate_forward(&conn, &crate::index::migration_hooks()).unwrap();
-    assert_eq!(schema::status(&conn).unwrap().current_version, 83);
+    // Replaying from 82 runs V083 and everything after it, so pin the TIP rather than a literal.
+    assert_eq!(schema::status(&conn).unwrap().current_version, schema::LATEST_SCHEMA_VERSION);
 
     let reason = |id: i64| -> String {
         conn.query_row("SELECT group_reason FROM logical_symbols WHERE id = ?1", [id], |row| {
@@ -3700,4 +3702,149 @@ fn migration_083_is_the_tip_and_relabels_logical_groups_by_evidence() {
         "two symbols inside one file row genuinely share an identity",
     );
     assert_eq!(reason(300), "single");
+}
+
+/// V084 links each chunk to the symbol it was cut from, and is the schema tip.
+#[test]
+fn migration_084_is_the_tip_and_links_chunks_to_symbols() {
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 84, "move this pin with the next schema migration");
+
+    // The chunks table predates the column (it lives in the baseline). Build bare chunks + symbols
+    // tables WITHOUT symbol_id, seed pre-migration rows, apply V084 in ISOLATION, and confirm the
+    // column appears AND the backfill links each chunk — asserting absence against this migration's
+    // own precondition, never the full ladder's end state.
+    let legacy = rusqlite::Connection::open_in_memory().unwrap();
+    legacy
+        .execute_batch(
+            "CREATE TABLE chunks(
+                 id INTEGER PRIMARY KEY AUTOINCREMENT,
+                 file_id INTEGER NOT NULL,
+                 chunk_kind TEXT NOT NULL,
+                 symbol_path TEXT,
+                 start_byte INTEGER NOT NULL,
+                 end_byte INTEGER NOT NULL,
+                 start_line INTEGER NOT NULL,
+                 end_line INTEGER NOT NULL,
+                 text_hash TEXT NOT NULL);
+             CREATE TABLE name_strings(id INTEGER PRIMARY KEY AUTOINCREMENT, value TEXT NOT NULL);
+             CREATE TABLE symbols(
+                 id INTEGER PRIMARY KEY AUTOINCREMENT,
+                 file_id INTEGER NOT NULL,
+                 qualified_name_id INTEGER NOT NULL,
+                 start_byte INTEGER NOT NULL,
+                 end_byte INTEGER NOT NULL,
+                 start_line INTEGER NOT NULL,
+                 end_line INTEGER NOT NULL);",
+        )
+        .unwrap();
+    assert!(
+        !schema::column_exists(&legacy, "chunks", "symbol_id").unwrap(),
+        "pre-V084 chunks has no symbol_id",
+    );
+
+    // Symbols in one file: an OUTER `outer` (id 1, bytes 100..200) with a DIFFERENT-named NESTED
+    // `inner` (id 2, bytes 130..160); a PAIR of same-name `g` (ids 3 & 4, disjoint bytes on one
+    // physical line — the minified same-line case); and an OUTER `wrap` (id 5, bytes 400..600) with
+    // a same-name NESTED `wrap` (id 6, bytes 500..560). Their line spans are 0/0 — the migration
+    // DEFAULT for a symbol never reindexed since the line columns were added — so the backfill MUST
+    // key off byte spans. Chunks carry the qualified name they were cut from (a split continuation
+    // appends `#<n>`).
+    legacy
+        .execute_batch(
+            "INSERT INTO name_strings(id, value) VALUES (1,'outer'), (2,'inner'), (3,'g'), \
+             (4,'wrap'), (5,'src/od#d.rs::run'), (6,'trailing2');
+             INSERT INTO symbols(id, file_id, qualified_name_id, start_byte, end_byte, start_line, \
+             end_line)
+                 VALUES (1, 1, 1, 100, 200, 0, 0), (2, 1, 2, 130, 160, 0, 0),
+                        (3, 1, 3, 300, 310, 0, 0), (4, 1, 3, 320, 330, 0, 0),
+                        (5, 1, 4, 400, 600, 0, 0), (6, 1, 4, 500, 560, 0, 0),
+                        (7, 1, 5, 700, 720, 0, 0), (8, 1, 6, 800, 820, 0, 0);
+             INSERT INTO chunks(file_id, chunk_kind, symbol_path, start_byte, end_byte, start_line,
+                                end_line, text_hash)
+                 VALUES (1,'code','outer',100,200,13,14,'h'),
+                        (1,'code','inner',130,160,14,15,'h'),
+                        (1,'code','outer#1',130,160,13,14,'h'),
+                        (1,'code','g',300,330,30,30,'h'),
+                        (1,'code','wrap#1',520,540,55,58,'h'),
+                        (1,'code',NULL,900,910,80,81,'h'),
+                        (1,'code','src/od#d.rs::run',700,720,70,71,'h'),
+                        (1,'code','trailing2',800,820,75,76,'h');",
+        )
+        .unwrap();
+
+    schema::apply_chunk_symbol_id(&legacy).unwrap();
+    assert!(
+        schema::column_exists(&legacy, "chunks", "symbol_id").unwrap(),
+        "V084 adds the symbol_id column",
+    );
+
+    // The backfill binds a chunk to the same-named symbol it overlaps in BYTES only when that
+    // symbol is UNIQUE — matching by NAME (line spans are 0, so a line predicate would match
+    // nothing):
+    //   * `outer` -> id 1, even though the `inner` bytes also overlap (`inner` is a different name,
+    //     so it is not a candidate);
+    //   * `inner` -> id 2;
+    //   * `outer#1` CONTINUATION -> id 1: the `#1` suffix is stripped to `outer`, whose only
+    //     overlapping symbol is the outer — recovered, and NOT mis-bound to the nested `inner`.
+    // It leaves NULL every case no stored data can settle: the same-line `g` chunk (its whole-line
+    // bytes overlap both `g` symbols), the `wrap#1` continuation (overlaps both the outer and
+    // nested `wrap`), and the uncovered chunk (no symbol_path).
+    let linked: Vec<(Option<String>, Option<i64>)> = legacy
+        .prepare("SELECT symbol_path, symbol_id FROM chunks ORDER BY id")
+        .unwrap()
+        .query_map([], |r| Ok((r.get(0)?, r.get(1)?)))
+        .unwrap()
+        .collect::<Result<_, _>>()
+        .unwrap();
+    assert_eq!(
+        linked,
+        vec![
+            (Some("outer".to_string()), Some(1)),
+            (Some("inner".to_string()), Some(2)),
+            (Some("outer#1".to_string()), Some(1)),
+            (Some("g".to_string()), None),
+            (Some("wrap#1".to_string()), None),
+            (None, None),
+            // A `#` inside the FILE PATH is not a continuation marker. Splitting on the FIRST `#`
+            // would truncate this to `src/od`, match nothing, and — since unchanged files are
+            // never re-chunked — strand the row at NULL forever. Only a TRAILING
+            // `#<digits>` is a suffix.
+            (Some("src/od#d.rs::run".to_string()), Some(7)),
+            // Trailing digits that are part of the NAME are likewise not a suffix: there is no `#`
+            // before them.
+            (Some("trailing2".to_string()), Some(8)),
+        ],
+        "backfill links a uniquely-named container (including a stripped continuation); a \
+         same-name tie / nested continuation / uncovered chunk stays NULL, and a `#` inside the \
+         FILE PATH is never mistaken for a continuation marker",
+    );
+
+    // Torn replay: the column already exists and every chunk is already linked, so re-applying is a
+    // no-op — it neither errors nor overwrites a resolved symbol_id.
+    schema::apply_chunk_symbol_id(&legacy).unwrap();
+    let relinked: Vec<(Option<String>, Option<i64>)> = legacy
+        .prepare("SELECT symbol_path, symbol_id FROM chunks ORDER BY id")
+        .unwrap()
+        .query_map([], |r| Ok((r.get(0)?, r.get(1)?)))
+        .unwrap()
+        .collect::<Result<_, _>>()
+        .unwrap();
+    assert_eq!(relinked, linked, "an idempotent re-apply preserves the backfilled links");
+
+    // Full ladder: the tip provisions cleanly and records V084 with the column present.
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn, &crate::index::migration_hooks()).unwrap();
+    assert_eq!(schema::status(&conn).unwrap().current_version, schema::LATEST_SCHEMA_VERSION);
+    assert!(
+        schema::column_exists(&conn, "chunks", "symbol_id").unwrap(),
+        "the full ladder ends with chunks.symbol_id present",
+    );
+    let recorded: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM schema_version WHERE id = '084_chunk_symbol_id'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(recorded, 1, "the forward migration records V084");
 }

--- a/crates/rag-rat-db/src/schema/migrations.rs
+++ b/crates/rag-rat-db/src/schema/migrations.rs
@@ -1369,6 +1369,7 @@ pub(crate) fn known_version(migrations: &[AppliedMigration]) -> u32 {
             MIGRATION_081_ID => Some(81),
             MIGRATION_082_ID => Some(82),
             MIGRATION_083_ID => Some(83),
+            MIGRATION_084_ID => Some(84),
             _ => None,
         })
         .max()
@@ -1461,6 +1462,7 @@ pub(crate) fn known_migration(id: &str) -> bool {
             | MIGRATION_081_ID
             | MIGRATION_082_ID
             | MIGRATION_083_ID
+            | MIGRATION_084_ID
             | DIRTY_MIGRATION_ID
     )
 }
@@ -1550,6 +1552,7 @@ pub(crate) fn migration_checksum_mismatch(migration: &AppliedMigration) -> bool 
         MIGRATION_081_ID => migration.checksum != MIGRATION_081_CHECKSUM,
         MIGRATION_082_ID => migration.checksum != MIGRATION_082_CHECKSUM,
         MIGRATION_083_ID => migration.checksum != MIGRATION_083_CHECKSUM,
+        MIGRATION_084_ID => migration.checksum != MIGRATION_084_CHECKSUM,
         _ => false,
     }
 }
@@ -4780,6 +4783,93 @@ pub fn apply_content_refold_queue_and_stats(conn: &Connection) -> rusqlite::Resu
     )?;
 
     tx.commit()
+}
+
+/// V083 (#855/#860) — persist the direct chunk→symbol link. `chunks.symbol_id` is the rowid of the
+/// symbol a code chunk was cut from, stamped at index time by `insert_chunks` from the same parse
+/// that assigned the symbol its rowid. It replaces position-based resolution (match by
+/// `(path, qualified_name)` then narrow by byte/line geometry), which could not disambiguate
+/// same-name symbols that nest or share a physical line — `qualified_name` is `path::simple_name`,
+/// not scope-qualified, so overloads and nested same-name functions collide, and no geometric
+/// metric attributes a chunk to one of two coincident symbols.
+pub fn apply_chunk_symbol_id(conn: &Connection) -> rusqlite::Result<()> {
+    // One transaction for the column add + backfill. An established index can hold hundreds of
+    // thousands of symbol-bearing chunks; committing each per-row UPDATE in its own autocommit
+    // (a WAL fsync apiece) would make the startup migration prohibitively slow. It is also atomic —
+    // an interrupted upgrade rolls back to no column and no partial backfill, and replay redoes it
+    // from scratch (and is idempotent on any rows a later run finds already linked).
+    let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
+    add_column_if_missing(&tx, "chunks", "symbol_id", "INTEGER")?;
+    backfill_chunk_symbol_ids(&tx)?;
+    tx.commit()
+}
+
+/// One-time backfill of `chunks.symbol_id` for chunks indexed before V083. Unlike the V079/V081
+/// derived stores, chunks are NOT rewritten on a regular cadence — incremental/discover indexing
+/// skips UNCHANGED files, so a stable file's chunks would keep NULL `symbol_id` (and lose their
+/// drive-by records) indefinitely, not "until the next reindex".
+///
+/// Resolve each chunk from the identity it ALREADY carries: `symbol_path` is the defining symbol's
+/// bare qualified name, except a split continuation which appends `#<n>` (a code path holds at most
+/// one `#`, so stripping from the first `#` recovers the bare name; context / whole-file / markdown
+/// paths keep theirs and simply match no qualified name). Link a chunk ONLY when exactly one
+/// same-file symbol of that qualified name OVERLAPS it in bytes.
+///
+/// BYTES, not lines: `symbols.start_byte`/`end_byte` are baseline columns, always populated,
+/// whereas `start_line`/`end_line` were added later with `DEFAULT 0`, so a never-reindexed legacy
+/// symbol can carry `0`/`0` line spans — a line predicate would silently match nothing and strand
+/// exactly the rows this repairs. A chunk is cut from the whole lines around its symbol, so it
+/// always overlaps that symbol's byte span (part 0 and every continuation part alike).
+///
+/// This never guesses the cases the direct link exists to resolve: a continuation whose outer is
+/// UNIQUELY named links back to that outer (even when a differently-named nested symbol's bytes it
+/// falls within also exist), but two same-name symbols that nest or share a line match more than
+/// one (`HAVING COUNT(*) = 1` excludes them → NULL), and a non-qualified-name path matches nothing
+/// (→ NULL). A NULL chunk surfaces no record; a wrong guess would surface the WRONG one and
+/// persist. `rag-rat index` re-stamps every chunk precisely from the parse.
+///
+/// One set-based statement (no per-row round-trip, no materializing every chunk in memory), run
+/// inside the caller's transaction so the whole backfill is a single commit. Idempotent: only
+/// chunks still NULL are considered, so a re-run never overwrites an exact index-time id.
+fn backfill_chunk_symbol_ids(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        // `base.qname` strips ONLY a trailing `#<digits>` continuation suffix, matching what the
+        // chunker appends. Splitting on the FIRST `#` instead would truncate a qualified name
+        // whose FILE PATH legitimately contains one (`src/foo#bar.rs::run`), and since
+        // unchanged files are never re-chunked those rows would keep a NULL `symbol_id` —
+        // and lose their drive-by records — indefinitely. `rtrim` removes trailing digits;
+        // the suffix is real only if that shortened the string AND what remains ends in
+        // `#`.
+        "WITH base AS (
+             SELECT c.id AS chunk_id, c.file_id AS file_id,
+                    c.start_byte AS start_byte, c.end_byte AS end_byte,
+                    CASE
+                        WHEN rtrim(c.symbol_path, '0123456789') <> c.symbol_path
+                         AND substr(rtrim(c.symbol_path, '0123456789'), -1) = '#'
+                        THEN substr(rtrim(c.symbol_path, '0123456789'), 1,
+                                    length(rtrim(c.symbol_path, '0123456789')) - 1)
+                        ELSE c.symbol_path
+                    END AS qname
+             FROM chunks c
+             WHERE c.symbol_id IS NULL
+               AND c.symbol_path IS NOT NULL
+         ),
+         resolved AS (
+             SELECT base.chunk_id AS chunk_id, s.id AS symbol_id
+             FROM base
+             JOIN symbols s ON s.file_id = base.file_id
+             JOIN name_strings ns ON ns.id = s.qualified_name_id
+             WHERE ns.value = base.qname
+               AND s.start_byte < base.end_byte
+               AND base.start_byte < s.end_byte
+             GROUP BY base.chunk_id
+             HAVING COUNT(*) = 1
+         )
+         UPDATE chunks
+         SET symbol_id = resolved.symbol_id
+         FROM resolved
+         WHERE chunks.id = resolved.chunk_id;",
+    )
 }
 
 /// V076 (sync phase C4.3b, #607): the sealing-key adoption audit log. A recipient device records a

--- a/crates/rag-rat-db/src/schema/mod.rs
+++ b/crates/rag-rat-db/src/schema/mod.rs
@@ -8,11 +8,12 @@ pub(crate) use migrations::*;
 // Migration steps and table lists the engine's schema tests exercise directly:
 pub use migrations::{
     apply_account_authority_boundaries, apply_account_authority_projection,
-    apply_account_candidate_dag, apply_clone_delta_maintenance, apply_clone_df_epoch,
-    apply_clone_fingerprint_tables, apply_clone_graph_tables, apply_content_candidate_dag,
-    apply_content_projected_tables, apply_content_refold_queue_and_stats,
-    apply_content_streams_pending_refold, apply_distill_anchor_selection,
-    apply_distill_enriched_context, apply_distill_evidence_source_part, apply_distill_record_store,
+    apply_account_candidate_dag, apply_chunk_symbol_id, apply_clone_delta_maintenance,
+    apply_clone_df_epoch, apply_clone_fingerprint_tables, apply_clone_graph_tables,
+    apply_content_candidate_dag, apply_content_projected_tables,
+    apply_content_refold_queue_and_stats, apply_content_streams_pending_refold,
+    apply_distill_anchor_selection, apply_distill_enriched_context,
+    apply_distill_evidence_source_part, apply_distill_record_store,
     apply_distill_safe_input_snapshot, apply_dream_findings, apply_edge_string_interning,
     apply_edge_target_qname_index, apply_external_symbols, apply_files_generation,
     apply_files_has_test_code, apply_git_change_couplings, apply_github_child_key_widening,
@@ -45,7 +46,7 @@ use serde::Serialize;
 
 use crate::hooks::MigrationHooks;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 83;
+pub const LATEST_SCHEMA_VERSION: u32 = 84;
 
 /// Every oracle-DERIVED persisted table — the outputs an `oracle run` writes that must OUTLIVE a
 /// reindex.
@@ -613,6 +614,14 @@ const MIGRATION_082_DESCRIPTION: &str =
      content_entries. SQLite triggers keep the stats exact for inserts, deletes, and mutable \
      stream_id/signed_bytes updates; existing queue rows backfill as content-candidate work with \
      min/max candidate receive times";
+const MIGRATION_084_ID: &str = "084_chunk_symbol_id";
+const MIGRATION_084_CHECKSUM: &str = "sha256:rag-rat-chunk-symbol-id-v84";
+const MIGRATION_084_DESCRIPTION: &str =
+    "Add chunks.symbol_id: the direct rowid of the symbol a code chunk was cut from, written at \
+     index time from the same parse that assigned the symbol its rowid. Replaces position-based \
+     chunk→symbol resolution, which could not disambiguate same-name symbols that nest or share a \
+     physical line. Nullable; backfills on the next reindex of each file (derived data, no SQL \
+     backfill)";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -1302,6 +1311,12 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         checksum: MIGRATION_083_CHECKSUM,
         description: MIGRATION_083_DESCRIPTION,
         apply: MigrationFn::Plain(apply_logical_group_reason_by_evidence),
+    },
+    Migration {
+        id: MIGRATION_084_ID,
+        checksum: MIGRATION_084_CHECKSUM,
+        description: MIGRATION_084_DESCRIPTION,
+        apply: MigrationFn::Plain(apply_chunk_symbol_id),
     },
 ];
 

--- a/crates/rag-rat-query/src/memory/mod.rs
+++ b/crates/rag-rat-query/src/memory/mod.rs
@@ -526,7 +526,6 @@ pub(crate) struct ChunkAnchor {
     path: String,
     start_line: i64,
     end_line: i64,
-    symbol_path: Option<String>,
     text_hash: String,
     symbol_id: Option<i64>,
 }

--- a/crates/rag-rat-query/src/memory/resolve.rs
+++ b/crates/rag-rat-query/src/memory/resolve.rs
@@ -462,137 +462,55 @@ pub(crate) fn chunk_ids_for_symbol(
         })?;
     rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
 }
+/// The `symbols` rowid the chunk was cut from — the DIRECT `chunks.symbol_id` link written at
+/// index time, not a reconstruction from byte geometry.
+///
+/// This used to resolve `(files.path, qualified_name)` and, briefly, the closest byte range.
+/// Neither can be exact: `qualified_name` is the bare `path::simple_name`, so a file can hold
+/// several symbols sharing it, and any positional metric ties or mis-attributes when those symbols
+/// nest or share a physical line. The chunker knows which symbol it cut each chunk from, so the
+/// answer is recorded rather than inferred. `None` for a chunk that defines no symbol (context,
+/// whole-file, line-split) or one written before the column existed and not yet re-indexed.
 pub(crate) fn symbol_id_for_chunk(
     conn: &Connection,
     chunk: &ChunkAnchor,
 ) -> anyhow::Result<Option<i64>> {
-    symbol_id_for_chunk_symbol(conn, chunk.chunk_id, chunk.symbol_path.as_deref())
-}
-
-/// The `symbols` rowid for the symbol a CHUNK defines, disambiguated by BYTE OVERLAP.
-///
-/// `qualified_name` is `"{path}::{simple_name}"` — the bare identifier, not scope-qualified — so
-/// every same-simple-name symbol in a file shares one name (`fmt` across two trait impls, `new`
-/// across several inherent impls). `chunks.symbol_path` is that same ambiguous string and the
-/// chunk carries no symbol id, so resolving on the name alone with `LIMIT 1` returns an arbitrary
-/// winner that flips between reindexes as rowids are reassigned (#855).
-///
-/// The chunk is DERIVED from a symbol, so the match is the symbol whose range most closely
-/// corresponds to the chunk's: minimise `|Δstart| + |Δend|`. Overlap is only a prefilter.
-///
-/// Neither obvious alternative survives contact with real input. Containment
-/// (`symbol.start <= chunk.start`) fails because a chunk begins BEFORE its symbol whenever it
-/// captures the leading doc comment. WIDEST OVERLAP fails on NESTED same-named symbols — a `run`
-/// defined inside another `run` — where the inner chunk overlaps the enclosing symbol MORE than
-/// its own simply because the enclosing one is larger, so the inner chunk would bind the outer
-/// symbol. Closest-range handles siblings, nesting, and the doc-comment offset uniformly. The
-/// rowid remains only as a last-resort determinism guarantee.
-///
-/// This is NOT merely a raw-rowid concern. Logical grouping keys on `LogicalSymbolKey
-/// { language, path, name, qualified_name, kind, signature }`, where `signature` is the trimmed
-/// FIRST LINE of the declaration — so two same-named symbols in one file are DISTINCT logical
-/// symbols whenever their declaration lines differ. Resolving to the wrong one therefore maps
-/// through `logical_symbol_members` to the wrong logical id, and surfaces another symbol's repo
-/// memories and decision records as context. (Where the declaration lines coincide — two trait
-/// impls of `fmt`, two `default`s — the symbols are ONE logical symbol and no chunk-side
-/// resolution can separate them; that is a defect in the identity key, not here.)
-///
-/// KNOWN RESIDUAL: a symbol long enough to SPLIT that also contains a same-named NESTED symbol can
-/// still resolve a continuation part onto the nested symbol. Proximity reconstructs an association
-/// the chunker knew and did not persist, and no ordering over byte ranges recovers it in general;
-/// the root fix is to record the defining symbol on the chunk at chunk time instead of inferring
-/// it here.
-///
-/// Keying on `chunk_id` also pins the file exactly — `chunks.file_id` identifies one file even in a
-/// consolidated multi-repo database, where two repos can share a path (#852).
-///
-/// The rowid is reassigned on every reindex (#149), so resolve it to a logical id before caching or
-/// crossing the wire.
-pub(crate) fn symbol_id_for_chunk_symbol(
-    conn: &Connection,
-    chunk_id: i64,
-    symbol_path: Option<&str>,
-) -> anyhow::Result<Option<i64>> {
-    let Some(symbol_path) = symbol_path else {
-        return Ok(None);
-    };
-    // A symbol wider than the chunk limit is split into parts; its continuation chunks carry a
-    // `qualified_name#<part>` symbol_path while `symbols.qualified_name_id` stores only the bare
-    // qualified name. Strip the suffix so a continuation resolves to the SAME defining symbol.
-    let base = strip_chunk_continuation_suffix(symbol_path);
-    let overlapping: Option<i64> = conn
-        .query_row(
-            "
-        SELECT symbols.id AS symbol_id
-        FROM chunks
-        JOIN symbols ON symbols.file_id = chunks.file_id
-        WHERE chunks.id = ?1
-          AND symbols.qualified_name_id = (SELECT id FROM name_strings WHERE value = ?2)
-          AND symbols.start_byte < chunks.end_byte
-          AND chunks.start_byte < symbols.end_byte
-        ORDER BY
-          ABS(symbols.start_byte - chunks.start_byte)
-            + ABS(symbols.end_byte - chunks.end_byte) ASC,
-          symbols.id ASC
-        LIMIT 1
-        ",
-            params![chunk_id, base],
-            |row| row.get("symbol_id"),
-        )
-        .optional()?;
-    if overlapping.is_some() {
-        return Ok(overlapping);
-    }
-    // No overlap at all — stale byte ranges, or a chunk whose symbol moved. Guessing is only safe
-    // when there is nothing to guess between: one candidate is the pre-#855 answer and cannot be
-    // the wrong method, while two or more means the ambiguity this function exists to resolve, so
-    // surface nothing rather than an arbitrary winner.
-    let mut stmt = conn.prepare(
-        "
-        SELECT symbols.id AS symbol_id
-        FROM chunks
-        JOIN symbols ON symbols.file_id = chunks.file_id
-        WHERE chunks.id = ?1
-          AND symbols.qualified_name_id = (SELECT id FROM name_strings WHERE value = ?2)
-        LIMIT 2
-        ",
-    )?;
-    let candidates: Vec<i64> = stmt
-        .query_map(params![chunk_id, base], |row| row.get("symbol_id"))?
-        .collect::<Result<Vec<_>, _>>()?;
-    Ok(match candidates.as_slice() {
-        [only] => Some(*only),
-        _ => None,
+    conn.query_row("SELECT symbol_id FROM chunks WHERE id = ?1", params![chunk.chunk_id], |row| {
+        row.get(0)
     })
+    .optional()
+    .map(Option::flatten)
+    .map_err(Into::into)
 }
 
-/// The stable logical-symbol handle for the symbol a chunk defines — for #705 drive-by records on
-/// `read_chunk` and `semantic_search`. `None` when the chunk defines no symbol, the symbol has no
-/// logical grouping, or the name is ambiguous within the file and byte ranges cannot settle it
-/// (see [`symbol_id_for_chunk_symbol`]).
-///
-/// Takes the `chunk_id` rather than a path: the chunk's own byte range is what disambiguates two
-/// same-simple-name symbols in one file, and its `file_id` pins the file exactly.
-pub fn logical_symbol_id_for_chunk_symbol(
+/// The stable logical-symbol handle for the symbol a chunk defines, for #705 drive-by records on
+/// `read_chunk` / `semantic_search`. `None` when the chunk defines no symbol (a context /
+/// whole-file / line-split chunk, whose `chunks.symbol_id` is NULL) or its symbol has no logical
+/// grouping.
+pub fn logical_symbol_id_for_chunk(
     conn: &Connection,
     chunk_id: i64,
-    symbol_path: Option<&str>,
 ) -> anyhow::Result<Option<i64>> {
-    let Some(symbol_id) = symbol_id_for_chunk_symbol(conn, chunk_id, symbol_path)? else {
-        return Ok(None);
-    };
-    logical_symbol_id_for_symbol(conn, symbol_id)
+    // Resolve the symbol a chunk DEFINES by the DIRECT `chunks.symbol_id` link — the rowid stamped
+    // at index time from the same parse that assigned the symbol its rowid (#855/#860). This is
+    // exact where position matching cannot be: a file can hold several symbols sharing one bare
+    // `qualified_name` (`path::simple_name`, NOT scope-qualified — `new`/`from`/`default` across
+    // impls with different signatures, or a nested `fn f` inside a `fn f`), and any byte/line
+    // metric ties or mis-attributes when such symbols nest or share a physical line. Every
+    // continuation chunk of a split symbol carries that symbol's id, so they all resolve to the one
+    // logical symbol.
+    conn.query_row(
+        "SELECT members.logical_symbol_id
+         FROM chunks
+         JOIN logical_symbol_members members ON members.symbol_id = chunks.symbol_id
+         WHERE chunks.id = ?1",
+        params![chunk_id],
+        |row| row.get(0),
+    )
+    .optional()
+    .map_err(Into::into)
 }
 
-/// Strip a chunker continuation suffix (`…#<digits>`) from a chunk's `symbol_path`, yielding the
-/// defining symbol's bare qualified name. A name without a trailing numeric `#` suffix — the common
-/// case, and part 0 of any split — passes through unchanged.
-pub(crate) fn strip_chunk_continuation_suffix(symbol_path: &str) -> &str {
-    match symbol_path.rsplit_once('#') {
-        Some((base, part)) if !part.is_empty() && part.bytes().all(|b| b.is_ascii_digit()) => base,
-        _ => symbol_path,
-    }
-}
 pub(crate) fn logical_symbol_id_for_symbol(
     conn: &Connection,
     symbol_id: i64,
@@ -612,7 +530,6 @@ pub(crate) fn chunk_anchor_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<Chun
         path: row.get("path")?,
         start_line: row.get("start_line")?,
         end_line: row.get("end_line")?,
-        symbol_path: row.get("symbol_path")?,
         text_hash: row.get("text_hash")?,
         symbol_id: row.get("symbol_id")?,
     })
@@ -1086,23 +1003,4 @@ pub(crate) fn short_symbol_name<'a>(binding_id: &'a str, path: Option<&str>) -> 
         return name;
     }
     binding_id.rsplit("::").next().unwrap_or(binding_id)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::strip_chunk_continuation_suffix as strip;
-
-    #[test]
-    fn continuation_suffix_is_stripped_only_when_numeric() {
-        // Part 0 and any ordinary qualified name pass through.
-        assert_eq!(strip("foo::bar"), "foo::bar");
-        assert_eq!(strip("target"), "target");
-        // A chunker continuation suffix (`#<digits>`) is dropped to the defining symbol.
-        assert_eq!(strip("foo::bar#1"), "foo::bar");
-        assert_eq!(strip("target#12"), "target");
-        // A `#` that is not a numeric continuation is left intact (never a split part).
-        assert_eq!(strip("foo#bar"), "foo#bar");
-        assert_eq!(strip("foo::bar#"), "foo::bar#");
-        assert_eq!(strip("foo#1a"), "foo#1a");
-    }
 }


### PR DESCRIPTION
Fixes #855; closes #860.

The `read_chunk` and `semantic_search` drive-by lanes resolved a chunk's defining symbol by `(files.path, qualified_name)`, which is ambiguous: `qualified_name` is the bare `path::simple_name` (not scope-qualified), so same-named-but-distinct logical symbols in one file — different-signature overloads (multiple `From`/`TryFrom` impls) and nested same-name functions — share one `qualified_name`. **Any** position-based tiebreak (byte or line, overlap or containment) still ties or mis-attributes when such symbols nest or share a physical line, so a distilled decision record could surface on the **wrong** symbol or **vanish** from the one it belongs to.

**Fix — a direct link.** Add `chunks.symbol_id` (migration **V083**): the rowid of the symbol a code chunk was cut from.
- The chunker already iterates the parsed symbols to cut chunks, so each chunk records that symbol's local index (`Chunk.symbol_index`).
- `insert_symbols` now runs **before** `insert_chunks` and hands over the assigned rowids; `insert_chunks` remaps `symbol_index` onto `symbol_id` — the same local-index-then-remap convention edges and clone fingerprints already use.
- `logical_symbol_id_for_chunk` becomes a direct join through `logical_symbol_members`; the old byte/line geometry (and the continuation-suffix stripping it needed) leaves the read path entirely.

Exact for every shape position matching could not disambiguate: disjoint overloads, nested same-name, a split continuation spanning a nested inner, and two same-name symbols on one physical line. The `SymbolHit`-based surfaces (`symbol_lookup`, `impact_surface`) always passed a precise logical id and are unchanged.

**Existing indexes.** Chunks are not rewritten on a regular cadence — incremental indexing skips unchanged files, so a pre-migration chunk would keep `NULL symbol_id` (and lose its drive-by records) *indefinitely*. V083 backfills once with a **single set-based `UPDATE`** inside the migration's transaction (one commit, not a per-row fsync; no per-row query loop). It keys off the identity each chunk carries — `symbol_path` is the defining symbol's qualified name (a continuation appends `#<n>`, stripped back) — matched against a same-file symbol that **overlaps it in bytes** (`start_byte`/`end_byte` are baseline and always present; `start_line`/`end_line` were added later with `DEFAULT 0`, so a never-reindexed symbol can carry `0` line spans a line predicate would miss). It links **only when exactly one** such symbol exists: a continuation of a uniquely-named outer is recovered; two same-name symbols that nest or share a line match more than one (`NULL`); a non-qualified-name path matches nothing (`NULL`). Never a guess; `rag-rat index` re-stamps every chunk precisely.

**Tests** — regression coverage for overloads, nested, a split continuation over a nested inner, same-line symbols, and a simulated V083 upgrade (`NULL` out `symbol_id` → records vanish → backfill → records return). `migration_083` pins the tip, the column, and the backfill's name-aware unique-overlap binding over symbols with `0` line spans.