### PR TITLE
test(oplog): pin control-log quarantine as spec and correct the retention comment (#809)

### DIFF
--- a/crates/rag-rat-oplog/src/account/fold.rs
+++ b/crates/rag-rat-oplog/src/account/fold.rs
@@ -1066,8 +1066,18 @@ fn fold_account_pass(
         // Fold only a KNOWN op on the control log (§11), at the supported version, with a PLAINTEXT
         // payload (`crypto_suite == 0`). A NON-foldable entry (unknown type / other log / future
         // version / sealed `crypto_suite != 0` ciphertext that could spuriously parse) is always
-        // retained header-only — never folded, never HARD-rejected — so a forward-compatible entry
-        // stays a valid watermark/ancestry target and its own layer (C2/C4/newer) folds it.
+        // retained header-only — never folded, never HARD-rejected — so it stays a valid
+        // watermark/ancestry target and its own layer (C2/C4/newer) folds it.
+        //
+        // What retention does NOT buy: forward compatibility WITHIN log 0. Branch selection accepts
+        // one contiguous chain per (log, device) over EFFECTIVE entries, so a retained entry
+        // mid-chain truncates its author's accepted chain — every later entry from that device
+        // forks. That is deliberate quarantine, not an oversight (#809): no binary folds such an
+        // entry, so every binary truncates at the same slot and peers still converge, and a third
+        // party cannot place an entry on someone else's chain. It is load-bearing only because
+        // log 0's tag set is CLOSED — a new artifact class gets its own log (C6 →
+        // `ANNEX_LOG`), never a new tag here. `retained_entry_on_the_control_log_quarantines_the_
+        // rest_of_its_own_chain` pins this.
         let foldable = entry.header.log_id == CONTROL_LOG
             && entry.header.op_version == SUPPORTED_OP_VERSION
             && entry.header.crypto_suite == 0;

--- a/crates/rag-rat-oplog/src/account/storage.rs
+++ b/crates/rag-rat-oplog/src/account/storage.rs
@@ -3461,6 +3461,105 @@ mod tests {
         );
     }
 
+    /// TRIPWIRE (#809): a retained entry on the CONTROL log quarantines the rest of its own chain.
+    ///
+    /// This is SPEC, not a defect, and this test exists so it cannot drift into one silently.
+    /// Branch selection accepts one contiguous chain per `(log, device)` built from EFFECTIVE
+    /// entries, so an entry the fold retains rather than folds breaks the `seq` walk at its slot
+    /// and every later entry from that device forks.
+    ///
+    /// Why that is safe rather than a convergence bug: NO binary folds such an entry, so every
+    /// binary truncates at the same slot and honest peers still agree; and a third party cannot
+    /// place an entry on a device's chain (ingest verifies the signature), so the quarantine is
+    /// self-inflicted by the signer. The property is load-bearing only because **log 0's tag set is
+    /// closed** — a new artifact class gets its own log, as C6 did with `ANNEX_LOG`, never a new
+    /// tag, a bumped `op_version`, or a sealed payload here.
+    ///
+    /// If this test fails, someone changed one of those two things: either branch selection now
+    /// walks through retained entries, or log 0 grew a class it cannot fold. Both are decisions to
+    /// make deliberately (see #809), not to absorb by editing the expectation.
+    ///
+    /// Revisit only when an op is proposed that (a) must occupy a slot in log 0's per-device chain
+    /// with a cross-log hash anchor demonstrably insufficient, (b) is authority-inert — otherwise
+    /// `auth_len`/`AuthLenAhead` divergence kills it across versions regardless of chain walking —
+    /// and (c) cannot be expressed as an annex artifact keyed on a control-fold-derivable
+    /// condition. That change must land BEFORE transport ships (#406) or behind a protocol version
+    /// fence: once peers are live, accepting entries a peer forks is a mesh-splitting change.
+    #[test]
+    fn a_retained_entry_on_the_control_log_quarantines_the_rest_of_its_own_chain() {
+        // Every class `fold_account` retains rather than folds, ON the control log. A new retained
+        // class added here without a decision on #809 fails this test.
+        enum Retained {
+            UnknownTag,
+            FutureVersion,
+            SealedPayload,
+        }
+        let cases = [
+            ("unknown entry_type", Retained::UnknownTag),
+            ("future op_version", Retained::FutureVersion),
+            ("sealed payload", Retained::SealedPayload),
+        ];
+
+        for (label, retained_class) in cases {
+            let conn = db();
+            let founder = Dev::new(0x91);
+            let (account_id, genesis_bytes, genesis_hash) = genesis(&founder);
+            account_ingest(&conn, &genesis_bytes, NOW).unwrap();
+
+            let base = AccountEntryHeader {
+                account_id,
+                log_id: fold::CONTROL_LOG,
+                device_fingerprint: founder.fp,
+                seq: 1,
+                prev_hash: Some(genesis_hash),
+                parent_ref: Some(genesis_hash),
+                entry_type: ops::entry_type::DEVICE_ADD,
+                op_version: fold::SUPPORTED_OP_VERSION,
+                crypto_suite: 0,
+                key_id: None,
+                auth_len: 1,
+                authority_ref: Some(genesis_hash),
+            };
+            let header = match retained_class {
+                Retained::UnknownTag => AccountEntryHeader { entry_type: 250, ..base },
+                Retained::FutureVersion =>
+                    AccountEntryHeader { op_version: fold::SUPPORTED_OP_VERSION + 1, ..base },
+                Retained::SealedPayload =>
+                    AccountEntryHeader { crypto_suite: 1, key_id: Some([0x77; 32]), ..base },
+            };
+            let retained = sign_account_entry(&founder.secret, &header, &[0x81, 0x01]).unwrap();
+            assert_eq!(
+                account_ingest(&conn, &retained.signed_bytes, NOW + 1).unwrap(),
+                IngestOutcome::Ingested { status: "retained_unfolded".into() },
+                "{label}: the entry is retained, never rejected — that half is the forward-compat \
+                 promise and must not regress either",
+            );
+
+            // An ordinary, perfectly valid op by the same device, chaining from it.
+            let (add_bytes, add_hash) = op(
+                account_id,
+                &founder,
+                2,
+                Some(retained.entry_hash),
+                Some(genesis_hash),
+                &device_add(&Dev::new(0x92), DeviceRole::Owner),
+            );
+            account_ingest(&conn, &add_bytes, NOW + 2).unwrap();
+
+            assert_eq!(
+                status(&conn, &genesis_hash).as_deref(),
+                Some("accepted"),
+                "{label}: the chain up to the retained entry is unaffected",
+            );
+            assert_eq!(
+                status(&conn, &add_hash).as_deref(),
+                Some("forked"),
+                "{label}: everything after a retained entry is quarantined — SPEC, see the doc \
+                 comment before changing this",
+            );
+        }
+    }
+
     #[test]
     fn a_sealed_snapshot_is_refused_rather_than_retained() {
         // A sealed manifest can never serve its purpose (§4.7's whole value is that a peer verifies


### PR DESCRIPTION
Closes #809 by deciding it rather than changing it.

## The behaviour

An entry `fold_account` retains rather than folds — unknown `entry_type`, future `op_version`, or sealed `crypto_suite != 0` payload — is absent from the `effective` set that branch selection builds its `children` map from. The contiguous `seq` walk therefore breaks at that slot, and **every later entry from that device forks**.

| entry | status |
|---|---|
| genesis (seq 0) | `accepted` |
| retained entry (seq 1) | `retained_unfolded` |
| ordinary `DeviceAdd` (seq 2, chains from it) | `forked` |

## Why it stays

It is not a convergence defect. **No** binary folds such an entry, so every binary truncates at the same slot and honest peers still agree; and a third party cannot place an entry on someone else's chain, since ingest verifies the signature. The quarantine is self-inflicted by the signer.

The cost is real and worth stating plainly: **log 0's tag set is closed.** No new `entry_type`, no `op_version` bump on an existing type, no sealed payload. Protocol evolution happens by adding logs. That is already the de-facto state — C6 put snapshots on `ANNEX_LOG = 3` for exactly this reason, and C4.2b gave the secrets log its own pin-aware selector.

## Why the fix was rejected

The obvious change — walk the chain over all structurally-valid entries so retained entries become transparent links — was designed in full and adversarially reviewed. It has three independent kill-class defects:

1. **Snapshot authoring becomes impossible.** `author_snapshot_in_tx` bails and rolls back unless the authored entry folds exactly `retained_unfolded`; under the change every snapshot folds `accepted`.
2. **It aborts the refold.** Log 1 already has `secrets::candidate::select_accepted_branch` (pin-aware), wired via `refold_secrets_log`. A widened main-loop walk would also set `accepted = 1` on log-1 rows; when the pin-aware and min-hash winners disagree — precisely what pins exist for — both rows hit the `account_accepted_slot` partial UNIQUE index, poisoning every later refold of that account.
3. **`accepted ⊆ effective` is load-bearing.** "All structurally valid" also admits `Condemned`/`Rejected`/`Parked` rows. The status writer checks `accepted` before the taxonomy, so a revoked device's post-cut entries would report `accepted` and be named as snapshot coverage heads, defeating condemnation. `bootstrap.rs` also uses `Some("accepted")` as its never-return-a-wedged-account gate.

The decisive point is that fixing chain walkability opens only **one of two doors**. Authority-bearing evolution on log 0 is foreclosed regardless by `effective_count`/`auth_len`: an old binary folds the new op retained, its effective count diverges, and later entries park `AuthLenAhead` un-healably. So the change would buy option value only for authority-*inert* ops that must interleave in log 0's per-device order — and those are strictly better on their own log, with `parent_ref`/`authority_ref` as a causal anchor.

## What ships

No production behaviour changes.

- A **tripwire test** covering all three retained classes, so a newly added one fails here rather than silently quarantining its author's chain. Both halves are mutation-verified: making branch selection walk through retained entries fails it, and making a retained class foldable fails it.
- The fold's retention comment no longer implies a forward compatibility it does not provide — it was accurate about watermarks and ancestry but silent about the author's own chain.
- The decision, its rejected alternative, and the revisit signal recorded as a repo memory.

## When to revisit

Build the alternative when an op is proposed that satisfies **all three**: it must occupy a slot in log 0's per-device chain with a cross-log hash anchor demonstrably insufficient; it is authority-inert; and it cannot be expressed as an annex artifact keyed on a control-fold-derivable condition.

**Timing constraint:** such a change must land **before transport ships (#406)** or behind a protocol version fence. Once peers are live, accepting entries a peer forks splits the mesh on honest entries downstream of one retained entry.

Gates: workspace nextest (3585 passed), clippy on both feature sets with `-D warnings`, nightly rustfmt.

Closes #809.