### PR TITLE
fix(query): resolve a chunk's symbol by closest byte range, not an arbitrary same-named winner (#855)

### DIFF
--- a/crates/rag-rat-core/src/index/query_api/memory.rs
+++ b/crates/rag-rat-core/src/index/query_api/memory.rs
@@ -150,14 +150,14 @@ impl IndexDatabase {
     /// `records_for_symbol`, which the MCP handler invokes directly).
     pub(crate) fn records_for_chunk_symbol(
         &self,
-        path: &str,
+        chunk_id: i64,
         symbol_path: Option<&str>,
         limit: usize,
     ) -> anyhow::Result<Vec<rag_rat_papertrail::DriveByRecord>> {
         let conn = self.storage.connection();
         let repo_id = rag_rat_db::schema::active_repo_id(conn)?;
         let logical_symbol_id =
-            rag_rat_query::memory::logical_symbol_id_for_chunk_symbol(conn, path, symbol_path)?;
+            rag_rat_query::memory::logical_symbol_id_for_chunk_symbol(conn, chunk_id, symbol_path)?;
         Self::drive_by_records_scoped(conn, &repo_id, logical_symbol_id, limit)
     }
 
@@ -182,27 +182,32 @@ impl IndexDatabase {
         if !rag_rat_db::schema::table_exists(conn, "papertrail_distill")? {
             return Ok(());
         }
-        // Resolve the repo scope ONCE for the batch, and memoize records by (path, symbol_path) so
-        // the many chunks of one symbol (e.g. its continuation parts) resolve + fetch a single time
-        // rather than re-querying per hit.
+        // Resolve the repo scope ONCE for the batch, then memoize the record FETCH by the
+        // RESOLVED logical id. Keying the memo on the raw `(path, symbol_path)` would be both
+        // wrong and useless now: resolution is per-chunk (two same-named methods in one file share
+        // a symbol_path but are different symbols), and continuation chunks carry distinct
+        // `qname#<part>` strings that never collided as keys in the first place. The logical id is
+        // what the many chunks of one symbol actually share.
         let repo_id = rag_rat_db::schema::active_repo_id(conn)?;
-        let mut by_symbol: std::collections::HashMap<
-            (String, Option<String>),
-            Vec<rag_rat_papertrail::DriveByRecord>,
-        > = std::collections::HashMap::new();
+        let mut by_logical: std::collections::HashMap<i64, Vec<rag_rat_papertrail::DriveByRecord>> =
+            std::collections::HashMap::new();
         for hit in hits.iter_mut() {
-            let key = (hit.path.clone(), hit.symbol_path.clone());
-            if let Some(cached) = by_symbol.get(&key) {
+            let Some(logical_symbol_id) =
+                rag_rat_query::memory::logical_symbol_id_for_chunk_symbol(
+                    conn,
+                    hit.chunk_id,
+                    hit.symbol_path.as_deref(),
+                )?
+            else {
+                continue;
+            };
+            if let Some(cached) = by_logical.get(&logical_symbol_id) {
                 hit.distilled_records = cached.clone();
                 continue;
             }
-            let logical_symbol_id = rag_rat_query::memory::logical_symbol_id_for_chunk_symbol(
-                conn,
-                &hit.path,
-                hit.symbol_path.as_deref(),
-            )?;
-            let records = Self::drive_by_records_scoped(conn, &repo_id, logical_symbol_id, 2)?;
-            by_symbol.insert(key, records.clone());
+            let records =
+                Self::drive_by_records_scoped(conn, &repo_id, Some(logical_symbol_id), 2)?;
+            by_logical.insert(logical_symbol_id, records.clone());
             hit.distilled_records = records;
         }
         Ok(())

--- a/crates/rag-rat-core/src/index/query_api/mod.rs
+++ b/crates/rag-rat-core/src/index/query_api/mod.rs
@@ -482,7 +482,7 @@ impl IndexDatabase {
             // ≤2 and labeled unreviewed. Rides the memories flag; facet-gated, so empty for almost
             // every chunk — matches the symbol_lookup convention (a lightweight per-item surface).
             chunk.distilled_records =
-                self.records_for_chunk_symbol(&chunk.path, chunk.symbol_path.as_deref(), 2)?;
+                self.records_for_chunk_symbol(chunk_id, chunk.symbol_path.as_deref(), 2)?;
         }
         Ok(Some(chunk))
     }

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_memory.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_memory.rs
@@ -2930,7 +2930,7 @@ fn read_chunk_attaches_distilled_records_for_the_chunk_symbol() {
     let base_symbol_path = chunk.symbol_path.clone().expect("the chunk defines a symbol");
     let continuation = format!("{base_symbol_path}#1");
     assert_eq!(
-        db.records_for_chunk_symbol("src/lib.rs", Some(&continuation), 2)
+        db.records_for_chunk_symbol(chunk_id, Some(&continuation), 2)
             .unwrap()
             .iter()
             .map(|r| r.record.item_key.as_str())
@@ -2953,10 +2953,8 @@ fn read_chunk_attaches_distilled_records_for_the_chunk_symbol() {
     assert!(bare.distilled_records.is_empty(), "the drive-by rides the memories include flag");
 
     // Resolver guards: a chunk with no symbol name, and an unknown symbol, both surface nothing.
-    assert!(db.records_for_chunk_symbol("src/lib.rs", None, 2).unwrap().is_empty());
-    assert!(
-        db.records_for_chunk_symbol("src/lib.rs", Some("does_not_exist"), 2).unwrap().is_empty()
-    );
+    assert!(db.records_for_chunk_symbol(chunk_id, None, 2).unwrap().is_empty());
+    assert!(db.records_for_chunk_symbol(chunk_id, Some("does_not_exist"), 2).unwrap().is_empty());
 
     let _ = fs::remove_dir_all(&root);
 }
@@ -6826,6 +6824,286 @@ fn a_rebuild_carrying_a_committed_leftover_defers_the_stamp() {
         None,
         "a rebuild carrying an other-commit committed leftover must defer the stamp, not stamp \
          over its un-reparsed rows"
+    );
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+/// A chunk resolves to the symbol it actually covers, disambiguated by BYTE OVERLAP (#855).
+///
+/// `qualified_name` is `"{path}::{simple_name}"` — the bare identifier, not scope-qualified — so
+/// every same-simple-name symbol in a file shares one name (`describe` here; `fmt` / `new` /
+/// `default` in real code). `chunks.symbol_path` is that same ambiguous string and the chunk
+/// carries no symbol id, so resolving on the name alone with `LIMIT 1` returned an arbitrary
+/// winner that could flip between reindexes as rowids are reassigned.
+///
+/// Overlap rather than containment: a chunk begins BEFORE its symbol when it captures the leading
+/// doc comment, so `symbol.start <= chunk.start` would reject the right answer.
+///
+/// NOTE the second half of this test. These two methods have BYTE-IDENTICAL declaration lines, and
+/// `signature` — the trimmed first line — is part of `LogicalSymbolKey`, so they collapse into ONE
+/// logical symbol. Every logical-id-anchored surface therefore still applies to both, and no
+/// chunk-side resolution can change that; it is a defect in the identity key. (When the
+/// declaration lines DIFFER the two are distinct logical symbols and the leak is real and fixed —
+/// see `a_decision_record_does_not_leak_between_distinct_same_named_methods`.) This test pins the
+/// raw-`symbol_id` precision that IS fixable here, plus the collapse itself, so the day the
+/// identity key gains a scope discriminator, this test notices.
+#[test]
+fn a_chunk_binding_resolves_the_symbol_it_overlaps_not_an_arbitrary_same_named_sibling() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(
+        root.join("src/lib.rs"),
+        "pub struct Alpha;\npub struct Beta;\n\nimpl Alpha {\n    /// Alpha's describe.\n    pub fn \
+         describe(&self) -> u32 {\n        let a = 1;\n        let b = 2;\n        a + b\n    }\n}\n\nimpl \
+         Beta {\n    /// Beta's describe.\n    pub fn describe(&self) -> u32 {\n        let c = \
+         3;\n        let d = 4;\n        c + d\n    }\n}\n",
+    )
+    .unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let conn = db.storage.connection();
+
+    // The two `describe` symbols share one qualified name and differ only by byte range.
+    let mut stmt = conn
+        .prepare(
+            "SELECT s.id, s.start_byte FROM symbols s
+             JOIN name_strings ns ON ns.id = s.qualified_name_id
+             WHERE ns.value = 'src/lib.rs::describe' ORDER BY s.start_byte",
+        )
+        .unwrap();
+    let describes: Vec<(i64, i64)> =
+        stmt.query_map([], |r| Ok((r.get(0)?, r.get(1)?))).unwrap().map(|r| r.unwrap()).collect();
+    drop(stmt);
+    assert_eq!(describes.len(), 2, "the fixture must actually collide, or this proves nothing");
+    let (alpha_symbol, beta_symbol) = (describes[0].0, describes[1].0);
+
+    let chunk_at = |after: i64| -> i64 {
+        conn.query_row(
+            "SELECT c.id FROM chunks c JOIN files f ON f.id = c.file_id
+             WHERE f.path = 'src/lib.rs' AND c.symbol_path = 'src/lib.rs::describe'
+               AND c.start_byte >= ?1 ORDER BY c.start_byte LIMIT 1",
+            [after],
+            |r| r.get(0),
+        )
+        .unwrap()
+    };
+    let alpha_chunk = chunk_at(0);
+    let beta_chunk = chunk_at(describes[1].1 - 8);
+    assert_ne!(alpha_chunk, beta_chunk, "the two methods must land in distinct chunks");
+
+    let resolve = |chunk_id: i64| {
+        rag_rat_query::memory::resolve_binding(conn, &rag_rat_query::memory::RepoMemoryBindTarget {
+            chunk_id: Some(chunk_id),
+            ..Default::default()
+        })
+        .unwrap()
+        .expect("chunk binding resolves")
+    };
+    let alpha = resolve(alpha_chunk);
+    let beta = resolve(beta_chunk);
+
+    assert_eq!(
+        alpha.symbol_id,
+        Some(alpha_symbol),
+        "the first method's chunk binds the first method, not whichever rowid sorted first",
+    );
+    assert_eq!(beta.symbol_id, Some(beta_symbol), "and the second method's chunk binds the second",);
+
+    // The known remaining imprecision, pinned deliberately: logical grouping is
+    // `(repo_id, path, logical_name)`, so these two distinct methods are ONE logical symbol and
+    // anything anchored to it applies to both.
+    assert_eq!(
+        alpha.logical_symbol_id, beta.logical_symbol_id,
+        "same-named symbols in one file still share a logical id — if this ever fails, grouping \
+         gained a discriminator and the logical-id-anchored surfaces became per-method",
+    );
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+/// NESTED same-named symbols: each chunk binds its OWN nesting level (#855).
+///
+/// A `run` defined inside another `run` is the case that kills the intuitive rule. The inner
+/// chunk overlaps the ENCLOSING symbol more than its own — the enclosing range is simply larger —
+/// so "widest overlap wins" binds the inner chunk to the outer symbol. Resolution is by closest
+/// range instead, which is what makes both directions come out right.
+#[test]
+fn nested_same_named_symbols_each_bind_their_own_nesting_level() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(
+        root.join("src/lib.rs"),
+        "pub fn run() -> u32 {\n    /// inner\n    fn run() -> u32 {\n        let x = 1;\n        \
+         let y = 2;\n        x + y\n    }\n    let z = run();\n    z + 1\n}\n",
+    )
+    .unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let conn = db.storage.connection();
+
+    let mut stmt = conn
+        .prepare(
+            "SELECT s.id, s.start_byte, s.end_byte FROM symbols s
+             JOIN name_strings ns ON ns.id = s.qualified_name_id
+             WHERE ns.value = 'src/lib.rs::run' ORDER BY s.start_byte",
+        )
+        .unwrap();
+    let runs: Vec<(i64, i64, i64)> = stmt
+        .query_map([], |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)))
+        .unwrap()
+        .map(|r| r.unwrap())
+        .collect();
+    drop(stmt);
+    assert_eq!(runs.len(), 2, "the fixture must nest two same-named fns");
+    let (outer_symbol, inner_symbol) = (runs[0].0, runs[1].0);
+    assert!(
+        runs[0].1 < runs[1].1 && runs[1].2 < runs[0].2,
+        "the second symbol must be nested INSIDE the first, or this tests nothing",
+    );
+
+    let mut cstmt = conn
+        .prepare(
+            "SELECT c.id, c.start_byte FROM chunks c JOIN files f ON f.id = c.file_id
+             WHERE f.path = 'src/lib.rs' AND c.symbol_path = 'src/lib.rs::run'
+             ORDER BY c.start_byte",
+        )
+        .unwrap();
+    let chunks: Vec<(i64, i64)> =
+        cstmt.query_map([], |r| Ok((r.get(0)?, r.get(1)?))).unwrap().map(|r| r.unwrap()).collect();
+    drop(cstmt);
+    assert_eq!(chunks.len(), 2, "each nesting level gets its own chunk");
+
+    let resolve = |chunk_id: i64| {
+        rag_rat_query::memory::resolve_binding(conn, &rag_rat_query::memory::RepoMemoryBindTarget {
+            chunk_id: Some(chunk_id),
+            ..Default::default()
+        })
+        .unwrap()
+        .expect("chunk binding resolves")
+        .symbol_id
+    };
+    assert_eq!(resolve(chunks[0].0), Some(outer_symbol), "the outer chunk binds the outer fn");
+    assert_eq!(
+        resolve(chunks[1].0),
+        Some(inner_symbol),
+        "the inner chunk binds the INNER fn — it overlaps the enclosing symbol more, so a \
+         widest-overlap rule would get this backwards",
+    );
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+/// THE #855 CASE: a decision record must not leak between same-named methods that are genuinely
+/// distinct logical symbols.
+///
+/// Logical grouping keys on `LogicalSymbolKey { language, path, name, qualified_name, kind,
+/// signature }`. `qualified_name` is `"{path}::{simple_name}"` and `signature` is the trimmed
+/// FIRST LINE of the declaration, so two same-named methods split into distinct logical symbols
+/// exactly when their declaration lines differ. When they do — `describe(&self) -> u32` vs
+/// `describe(&self, extra: u8) -> u64` here — an arbitrary `LIMIT 1` winner in the chunk resolver
+/// binds one method's chunk to the OTHER's logical symbol, and a record anchored there surfaces as
+/// context on a method it was never about.
+///
+/// (Where the declaration lines are byte-identical — two trait impls of `fmt`, two `default`s —
+/// the two methods are ONE logical symbol and no chunk-side fix can separate them. That is a
+/// distinct defect in the identity key, not something this resolver can reach.)
+#[test]
+fn a_decision_record_does_not_leak_between_distinct_same_named_methods() {
+    use rag_rat_base::config::MemorySurface;
+    use rag_rat_query::graph_meta::GraphMetaMode;
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(
+        root.join("src/lib.rs"),
+        "pub struct Alpha;\npub struct Beta;\n\nimpl Alpha {\n    /// Alpha's describe.\n    pub \
+         fn describe(&self) -> u32 {\n        let a = 1;\n        let b = 2;\n        a + b\n    \
+         }\n}\n\nimpl Beta {\n    /// Beta's describe.\n    pub fn describe(&self, extra: u8) -> \
+         u64 {\n        let c = u64::from(extra);\n        let d = 4;\n        c + d\n    }\n}\n",
+    )
+    .unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let conn = db.storage.connection();
+
+    let mut stmt = conn
+        .prepare(
+            "SELECT s.id, s.start_byte, m.logical_symbol_id FROM symbols s
+             JOIN logical_symbol_members m ON m.symbol_id = s.id
+             JOIN name_strings ns ON ns.id = s.qualified_name_id
+             WHERE ns.value = 'src/lib.rs::describe' ORDER BY s.start_byte",
+        )
+        .unwrap();
+    let describes: Vec<(i64, i64, i64)> = stmt
+        .query_map([], |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)))
+        .unwrap()
+        .map(|r| r.unwrap())
+        .collect();
+    drop(stmt);
+    assert_eq!(describes.len(), 2, "the fixture must collide on name");
+    assert_ne!(
+        describes[0].2, describes[1].2,
+        "differing declaration lines must yield DISTINCT logical symbols, or this test cannot \
+         distinguish a leak from correct shared-anchor behaviour",
+    );
+    let alpha_logical = describes[0].2;
+
+    let chunk_at = |after: i64| -> i64 {
+        conn.query_row(
+            "SELECT c.id FROM chunks c JOIN files f ON f.id = c.file_id
+             WHERE f.path = 'src/lib.rs' AND c.symbol_path = 'src/lib.rs::describe'
+               AND c.start_byte >= ?1 ORDER BY c.start_byte LIMIT 1",
+            [after],
+            |r| r.get(0),
+        )
+        .unwrap()
+    };
+    let (alpha_chunk, beta_chunk) = (chunk_at(0), chunk_at(describes[1].1 - 8));
+    assert_ne!(alpha_chunk, beta_chunk);
+
+    let repo_id = rag_rat_db::schema::active_repo_id(conn).unwrap();
+    conn.execute(
+        "INSERT INTO papertrail_distill
+             (tracker, project, item_kind, item_key, distill_input_hash, pipeline_version,
+              root_issue, fix_edge_source, thread_shape, anchors_qualified_count,
+              distilled_at_ms, repo_id)
+         VALUES ('github','o/r','issue','5','sha256:h',3,'5','provider','investigation',1,10,?1)",
+        rusqlite::params![repo_id],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO papertrail_distill_anchors
+             (tracker, project, item_kind, item_key, anchor_kind, logical_symbol_id, name,
+              resolved, candidate_ordinal, selected, repo_id)
+         VALUES ('github','o/r','issue','5','symbol',?1,'describe',1,0,1,?2)",
+        rusqlite::params![rag_rat_base::serde_big_id::format_sym_handle(alpha_logical), repo_id],
+    )
+    .unwrap();
+
+    let records_on = |chunk_id: i64| -> Vec<String> {
+        db.read_chunk_with_graph_and_memories(
+            chunk_id,
+            GraphMetaMode::Full,
+            20,
+            true,
+            MemorySurface::Full,
+        )
+        .unwrap()
+        .expect("chunk")
+        .distilled_records
+        .iter()
+        .map(|r| r.record.item_key.clone())
+        .collect()
+    };
+
+    assert_eq!(records_on(alpha_chunk), vec!["5".to_string()], "attaches to the anchored method");
+    assert!(
+        records_on(beta_chunk).is_empty(),
+        "and does NOT leak onto the same-named sibling — the wrong decision record presented as \
+         context is exactly what #855 reported",
     );
 
     let _ = fs::remove_dir_all(&root);

--- a/crates/rag-rat-query/src/memory/resolve.rs
+++ b/crates/rag-rat-query/src/memory/resolve.rs
@@ -466,57 +466,119 @@ pub(crate) fn symbol_id_for_chunk(
     conn: &Connection,
     chunk: &ChunkAnchor,
 ) -> anyhow::Result<Option<i64>> {
-    symbol_id_for_path_symbol(conn, &chunk.path, chunk.symbol_path.as_deref())
+    symbol_id_for_chunk_symbol(conn, chunk.chunk_id, chunk.symbol_path.as_deref())
 }
 
-/// The `symbols` rowid for the symbol at (`path`, qualified `symbol_path`). `None` when there is no
-/// symbol name or the name is unknown to the index. The rowid is reassigned on every reindex
-/// (#149), so resolve it to a logical id before caching or crossing the wire.
-pub(crate) fn symbol_id_for_path_symbol(
+/// The `symbols` rowid for the symbol a CHUNK defines, disambiguated by BYTE OVERLAP.
+///
+/// `qualified_name` is `"{path}::{simple_name}"` — the bare identifier, not scope-qualified — so
+/// every same-simple-name symbol in a file shares one name (`fmt` across two trait impls, `new`
+/// across several inherent impls). `chunks.symbol_path` is that same ambiguous string and the
+/// chunk carries no symbol id, so resolving on the name alone with `LIMIT 1` returns an arbitrary
+/// winner that flips between reindexes as rowids are reassigned (#855).
+///
+/// The chunk is DERIVED from a symbol, so the match is the symbol whose range most closely
+/// corresponds to the chunk's: minimise `|Δstart| + |Δend|`. Overlap is only a prefilter.
+///
+/// Neither obvious alternative survives contact with real input. Containment
+/// (`symbol.start <= chunk.start`) fails because a chunk begins BEFORE its symbol whenever it
+/// captures the leading doc comment. WIDEST OVERLAP fails on NESTED same-named symbols — a `run`
+/// defined inside another `run` — where the inner chunk overlaps the enclosing symbol MORE than
+/// its own simply because the enclosing one is larger, so the inner chunk would bind the outer
+/// symbol. Closest-range handles siblings, nesting, and the doc-comment offset uniformly. The
+/// rowid remains only as a last-resort determinism guarantee.
+///
+/// This is NOT merely a raw-rowid concern. Logical grouping keys on `LogicalSymbolKey
+/// { language, path, name, qualified_name, kind, signature }`, where `signature` is the trimmed
+/// FIRST LINE of the declaration — so two same-named symbols in one file are DISTINCT logical
+/// symbols whenever their declaration lines differ. Resolving to the wrong one therefore maps
+/// through `logical_symbol_members` to the wrong logical id, and surfaces another symbol's repo
+/// memories and decision records as context. (Where the declaration lines coincide — two trait
+/// impls of `fmt`, two `default`s — the symbols are ONE logical symbol and no chunk-side
+/// resolution can separate them; that is a defect in the identity key, not here.)
+///
+/// KNOWN RESIDUAL: a symbol long enough to SPLIT that also contains a same-named NESTED symbol can
+/// still resolve a continuation part onto the nested symbol. Proximity reconstructs an association
+/// the chunker knew and did not persist, and no ordering over byte ranges recovers it in general;
+/// the root fix is to record the defining symbol on the chunk at chunk time instead of inferring
+/// it here.
+///
+/// Keying on `chunk_id` also pins the file exactly — `chunks.file_id` identifies one file even in a
+/// consolidated multi-repo database, where two repos can share a path (#852).
+///
+/// The rowid is reassigned on every reindex (#149), so resolve it to a logical id before caching or
+/// crossing the wire.
+pub(crate) fn symbol_id_for_chunk_symbol(
     conn: &Connection,
-    path: &str,
+    chunk_id: i64,
     symbol_path: Option<&str>,
 ) -> anyhow::Result<Option<i64>> {
     let Some(symbol_path) = symbol_path else {
         return Ok(None);
     };
-    conn.query_row(
-        "
+    // A symbol wider than the chunk limit is split into parts; its continuation chunks carry a
+    // `qualified_name#<part>` symbol_path while `symbols.qualified_name_id` stores only the bare
+    // qualified name. Strip the suffix so a continuation resolves to the SAME defining symbol.
+    let base = strip_chunk_continuation_suffix(symbol_path);
+    let overlapping: Option<i64> = conn
+        .query_row(
+            "
         SELECT symbols.id AS symbol_id
-        FROM symbols
-        JOIN files ON files.id = symbols.file_id
-        WHERE files.path = ?1
+        FROM chunks
+        JOIN symbols ON symbols.file_id = chunks.file_id
+        WHERE chunks.id = ?1
           AND symbols.qualified_name_id = (SELECT id FROM name_strings WHERE value = ?2)
+          AND symbols.start_byte < chunks.end_byte
+          AND chunks.start_byte < symbols.end_byte
+        ORDER BY
+          ABS(symbols.start_byte - chunks.start_byte)
+            + ABS(symbols.end_byte - chunks.end_byte) ASC,
+          symbols.id ASC
         LIMIT 1
         ",
-        params![path, symbol_path],
-        |row| row.get("symbol_id"),
-    )
-    .optional()
-    .map_err(Into::into)
+            params![chunk_id, base],
+            |row| row.get("symbol_id"),
+        )
+        .optional()?;
+    if overlapping.is_some() {
+        return Ok(overlapping);
+    }
+    // No overlap at all — stale byte ranges, or a chunk whose symbol moved. Guessing is only safe
+    // when there is nothing to guess between: one candidate is the pre-#855 answer and cannot be
+    // the wrong method, while two or more means the ambiguity this function exists to resolve, so
+    // surface nothing rather than an arbitrary winner.
+    let mut stmt = conn.prepare(
+        "
+        SELECT symbols.id AS symbol_id
+        FROM chunks
+        JOIN symbols ON symbols.file_id = chunks.file_id
+        WHERE chunks.id = ?1
+          AND symbols.qualified_name_id = (SELECT id FROM name_strings WHERE value = ?2)
+        LIMIT 2
+        ",
+    )?;
+    let candidates: Vec<i64> = stmt
+        .query_map(params![chunk_id, base], |row| row.get("symbol_id"))?
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(match candidates.as_slice() {
+        [only] => Some(*only),
+        _ => None,
+    })
 }
 
-/// The stable logical-symbol handle for the symbol a chunk defines — its file `path` + qualified
-/// `symbol_path` — for #705 drive-by records on `read_chunk`. `None` when the chunk defines no
-/// symbol or the symbol has no logical grouping.
+/// The stable logical-symbol handle for the symbol a chunk defines — for #705 drive-by records on
+/// `read_chunk` and `semantic_search`. `None` when the chunk defines no symbol, the symbol has no
+/// logical grouping, or the name is ambiguous within the file and byte ranges cannot settle it
+/// (see [`symbol_id_for_chunk_symbol`]).
+///
+/// Takes the `chunk_id` rather than a path: the chunk's own byte range is what disambiguates two
+/// same-simple-name symbols in one file, and its `file_id` pins the file exactly.
 pub fn logical_symbol_id_for_chunk_symbol(
     conn: &Connection,
-    path: &str,
+    chunk_id: i64,
     symbol_path: Option<&str>,
 ) -> anyhow::Result<Option<i64>> {
-    // A symbol wider than the chunk limit is split into parts; its continuation chunks carry a
-    // `qualified_name#<part>` symbol_path (see the chunker) while `symbols.qualified_name_id`
-    // stores only the bare qualified name. Strip the numeric continuation suffix so reading a
-    // continuation chunk resolves to the SAME defining symbol as its first part instead of
-    // silently surfacing no records.
-    //
-    // Resolution is by (path, qualified name), NOT repo-scoped — matching the codebase's other
-    // qualified-name symbol resolvers (e.g. `active_symbol_id_for_qualified_name`, which the search
-    // load-bearing enrichment uses). `files` carries no `repo_id` in the base schema, and the
-    // subsequent record fetch is itself repo-scoped, so a cross-repo mis-resolution only ever
-    // yields fewer records, never a sibling repo's.
-    let base = symbol_path.map(strip_chunk_continuation_suffix);
-    let Some(symbol_id) = symbol_id_for_path_symbol(conn, path, base)? else {
+    let Some(symbol_id) = symbol_id_for_chunk_symbol(conn, chunk_id, symbol_path)? else {
         return Ok(None);
     };
     logical_symbol_id_for_symbol(conn, symbol_id)


### PR DESCRIPTION
## The bug

`qualified_name` is `"{path}::{simple_name}"` — the bare identifier, not scope-qualified — so every same-simple-name symbol in a file shares one name (`fmt` across two trait impls, `new` across several). `chunks.symbol_path` is that same ambiguous string and the chunk carries no symbol id, so `LIMIT 1` returned an arbitrary winner that could flip between reindexes as rowids are reassigned.

**This is not cosmetic.** Logical grouping keys on `LogicalSymbolKey { language, path, name, qualified_name, kind, signature }`, and `signature` is the trimmed **first line** of the declaration. So two same-named methods are **distinct logical symbols whenever their declaration lines differ**. Binding a chunk to the wrong one maps through `logical_symbol_members` to the wrong logical id and surfaces another symbol's repo memories and decision records as context — exactly what #855 reported.

Measured on a fixture, two `describe` methods in one file:

| fixture | logical ids |
|---|---|
| identical declaration lines | `4630571078350249659` / `4630571078350249659` — one symbol |
| differing declaration lines | `4630571078350249659` / `1953153497428360986` — **two symbols** |

## The resolution rule, and why the obvious ones fail

Closest range: the symbol minimising `|Δstart| + |Δend|`, with overlap as a prefilter.

- **Containment** (`symbol.start <= chunk.start`) fails — a chunk begins *before* its symbol whenever it captures the leading doc comment (chunk `[75,169)` vs symbol `[79,168)`).
- **Widest overlap** fails on **nested** same-named symbols. For inner chunk `[36,116)`, overlap with the enclosing `run` `[0,146)` is 80 but with its own `run` `[40,115)` only 75 — the enclosing range is simply larger, so the inner chunk binds the outer symbol.

The nested test is what discriminates: the sibling case passes under either rule, so it alone would have let the wrong rule ship. Both are mutation-verified.

Keying on `chunk_id` also pins the file exactly (`chunks.file_id` identifies one file even in a consolidated multi-repo database where two repos share a path) — one of #852's three sites, for free.

## Tests

- `a_decision_record_does_not_leak_between_distinct_same_named_methods` — the #855 case: differing declaration lines, distinct logical symbols, record anchored to one must not surface on the other. Fails under the pre-existing `LIMIT 1`.
- `nested_same_named_symbols_each_bind_their_own_nesting_level` — the case that rejects widest-overlap.
- `a_chunk_binding_resolves_the_symbol_it_overlaps_not_an_arbitrary_same_named_sibling` — raw `symbol_id` precision, plus a deliberate pin on the *collapse* below.

## What this does NOT fix

Where two same-named methods have **byte-identical declaration lines** — two trait impls of `fmt`, two `default`s, `new() -> Self` — they collapse into ONE logical symbol, and anything anchored to it applies to both. No chunk-side resolution can separate them; it is a defect in the identity key. A test pins that collapse so it stays visible, and so the day the key gains a scope discriminator, the test notices.

Independent analysis measured that class on this repo's own index: ~40–45 colliding groups out of 7,074 logical symbols (~0.6%), concentrated on trait- and DB-contract methods (`as_db_str` ×3, `default` ×7 in one file, `drop` ×3, an associated `type Error` collapsing 7 impl blocks). Filed separately.

## Known residual

A symbol long enough to **split** that also contains a same-named **nested** symbol can resolve a continuation part onto the nested symbol. I tried anchoring continuations to their part-0 chunk; review found the nested symbol's own base chunk can sit between the parent's part-0 and a later continuation, defeating it. Three proximity heuristics each surfaced another case, which is the signal that the foundation is wrong rather than the tuning: **proximity reconstructs an association the chunker knew and discarded.** The root fix is to record the defining symbol on the chunk at chunk time. Filed as follow-up.

Gates: workspace nextest (3589 passed), clippy on both feature sets with `-D warnings`, nightly rustfmt.

Refs #855.