### PR TITLE
fix(index): label logical-symbol groups by member evidence, not a blanket cfg_variant (#855)

### DIFF
--- a/crates/rag-rat-core/src/index/file_index.rs
+++ b/crates/rag-rat-core/src/index/file_index.rs
@@ -508,6 +508,39 @@ impl IndexDatabase {
         Ok(symbol_ids)
     }
 
+    /// Label a logical group by what the members ACTUALLY show, not by a guess.
+    ///
+    /// This used to report `cfg_variant` for every multi-member group, which was wrong for almost
+    /// all of them. A `files` PATH can have several `files` ROWS — worktree-overlay and commit
+    /// scopes each carry one for the same source file — so the same single symbol shows up once
+    /// per scope and gets grouped. On this repo's own index that accounted for 3,686 of 3,699
+    /// multi-member groups: symbols that exist exactly once in the source were being presented
+    /// as cfg variants with `variant_count` equal to the number of indexed scopes.
+    ///
+    /// What the members can actually distinguish:
+    ///
+    /// - `single` — one member.
+    /// - `scope_replica` — several members, but no single `files` row contributes more than one.
+    ///   This is one symbol observed in several index scopes; it is not a variant of anything.
+    /// - `name_collision` — some `files` row contributes two or more members, so one file genuinely
+    ///   holds multiple symbols that share name, kind, and declaration line. `impl Default for A`
+    ///   and `impl Default for B` in one file land here.
+    ///
+    /// Deliberately NOT reported: `cfg_variant`. Genuine cfg variants are indistinguishable from a
+    /// `name_collision` at this layer — both are several symbols in one file with identical
+    /// declaration lines — and the group key carries no cfg evidence to separate them. Asserting
+    /// the friendlier label is what made the old value useless.
+    fn logical_group_reason(members: &[LogicalSymbolMemberRow]) -> &'static str {
+        if members.len() <= 1 {
+            return "single";
+        }
+        let mut per_file: std::collections::HashMap<i64, usize> = std::collections::HashMap::new();
+        for member in members {
+            *per_file.entry(member.file_id).or_default() += 1;
+        }
+        if per_file.values().any(|count| *count > 1) { "same_file_multi" } else { "scope_replica" }
+    }
+
     /// Insert one logical symbol and its members. Extracted so `rebuild_logical_symbols` can flush
     /// each group as its key changes (streaming) rather than buffering every group. Both INSERTs
     /// are `prepare_cached` — the member insert runs once per symbol, so recompiling the SQL each
@@ -518,7 +551,7 @@ impl IndexDatabase {
         key: &LogicalSymbolKey,
         members: &[LogicalSymbolMemberRow],
     ) -> anyhow::Result<()> {
-        let group_reason = if members.len() > 1 { "cfg_variant" } else { "single" };
+        let group_reason = Self::logical_group_reason(members);
         // Repo-distinct id (A3): `stable_id` folds `repo_id` into the content hash so two repos
         // with identical content don't collide on the `logical_symbols.id` PK in a
         // consolidated DB.
@@ -564,5 +597,58 @@ impl IndexDatabase {
             ])?;
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod logical_group_reason_tests {
+    use super::*;
+
+    fn member(symbol_id: i64, file_id: i64) -> LogicalSymbolMemberRow {
+        LogicalSymbolMemberRow {
+            symbol_id,
+            file_id,
+            path: "src/lib.rs".to_string(),
+            language: "rust".to_string(),
+            name: "describe".to_string(),
+            qualified_name: "src/lib.rs::describe".to_string(),
+            kind: "function".to_string(),
+            signature: Some("pub fn describe(&self) -> u32 {".to_string()),
+            start_line: 1,
+            end_line: 3,
+        }
+    }
+
+    #[test]
+    fn one_member_is_single() {
+        assert_eq!(IndexDatabase::logical_group_reason(&[member(1, 10)]), "single");
+    }
+
+    /// The case the old label got wrong for 3,686 of 3,699 multi-member groups on this repo's own
+    /// index: one symbol observed once per index scope. A path carries several `files` rows —
+    /// worktree-overlay and commit scopes each add one — so the symbol is replicated, not varied.
+    /// Reporting `cfg_variant` with `variant_count` equal to the number of indexed scopes told
+    /// every caller a symbol that exists once in the source had N definitions.
+    #[test]
+    fn one_symbol_seen_in_several_scopes_is_a_replica_not_a_variant() {
+        let members = [member(1, 10), member(2, 11), member(3, 12)];
+        assert_eq!(IndexDatabase::logical_group_reason(&members), "scope_replica");
+    }
+
+    /// Two symbols inside ONE file row: genuinely several definitions sharing an identity. Covers
+    /// both `#[cfg]`-gated pairs and unrelated collisions like two `impl Default for _` blocks —
+    /// the label stays neutral because the group key cannot tell them apart.
+    #[test]
+    fn several_members_in_one_file_row_is_reported_as_same_file_multi() {
+        let members = [member(1, 10), member(2, 10)];
+        assert_eq!(IndexDatabase::logical_group_reason(&members), "same_file_multi");
+    }
+
+    /// A collision that ALSO spans scopes must not be downgraded to a replica: the same two
+    /// same-file symbols seen in two scopes is still a genuine multi-definition group.
+    #[test]
+    fn a_same_file_collision_replicated_across_scopes_is_still_same_file_multi() {
+        let members = [member(1, 10), member(2, 10), member(3, 11), member(4, 11)];
+        assert_eq!(IndexDatabase::logical_group_reason(&members), "same_file_multi");
     }
 }

--- a/crates/rag-rat-core/src/index/graph_index.rs
+++ b/crates/rag-rat-core/src/index/graph_index.rs
@@ -553,6 +553,11 @@ fn conflicting_drift_evidence(
 #[derive(Debug, Clone)]
 pub(super) struct LogicalSymbolMemberRow {
     pub(super) symbol_id: i64,
+    /// Which `files` ROW this member came from. A path can have several: worktree-overlay and
+    /// commit scopes each carry their own row for the same source file. That distinction is what
+    /// separates "one symbol seen in N scopes" from "N symbols in one file" when labelling a
+    /// group — see [`insert_logical_group`].
+    pub(super) file_id: i64,
     pub(super) path: String,
     pub(super) language: String,
     pub(super) name: String,
@@ -651,7 +656,7 @@ impl IndexDatabase {
             "
             SELECT symbols.id, main.files.path, symbols.language, symbols.name,
                    qn.value, symbols.kind, symbols.signature, symbols.start_line,
-                   symbols.end_line
+                   symbols.end_line, symbols.file_id
             FROM main.symbols AS symbols
             JOIN main.files ON main.files.id = symbols.file_id
             LEFT JOIN main.name_strings qn ON qn.id = symbols.qualified_name_id
@@ -673,6 +678,7 @@ impl IndexDatabase {
                 signature: row.get(6)?,
                 start_line: row.get(7)?,
                 end_line: row.get(8)?,
+                file_id: row.get(9)?,
             };
             // Compare the member's key fields against the current group WITHOUT allocating a key
             // per row (only per group, on a boundary).

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
@@ -3436,8 +3436,7 @@ fn migration_081_adds_evidence_source_part() {
 }
 
 #[test]
-fn migration_082_is_the_tip_and_accounts_for_content_refold_work() {
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 82, "move this pin with the next schema migration");
+fn migration_082_accounts_for_content_refold_work() {
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     schema::apply(&conn, &crate::index::migration_hooks()).unwrap();
 
@@ -3479,7 +3478,9 @@ fn migration_082_is_the_tip_and_accounts_for_content_refold_work() {
     truncate_schema_to(&conn, 81);
 
     schema::migrate_forward(&conn, &crate::index::migration_hooks()).unwrap();
-    assert_eq!(schema::status(&conn).unwrap().current_version, 82);
+    // Replaying from 81 runs V082 and everything after it, so pin the TIP rather than a literal —
+    // this assertion is about the forward path completing, not about which migration is last.
+    assert_eq!(schema::status(&conn).unwrap().current_version, schema::LATEST_SCHEMA_VERSION);
 
     let queued: Vec<(Vec<u8>, i64, i64, i64)> = conn
         .prepare(
@@ -3617,4 +3618,86 @@ fn migration_082_is_the_tip_and_accounts_for_content_refold_work() {
         )
         .unwrap();
     assert_eq!(v82_recorded, 1, "forward migration records V082");
+}
+
+/// V083 recomputes `logical_symbols.group_reason` from member evidence, and is the schema tip.
+///
+/// The column is derived but PERSISTED, so a new labelling rule alone would never reach an existing
+/// index: a query-only server over an unchanged repository never runs `rebuild_logical_symbols` and
+/// would keep serving the old `cfg_variant` for every multi-member group indefinitely.
+#[test]
+fn migration_083_is_the_tip_and_relabels_logical_groups_by_evidence() {
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 83, "move this pin with the next schema migration");
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn, &crate::index::migration_hooks()).unwrap();
+
+    // Two `files` ROWS for one path — what a worktree-overlay or commit scope produces.
+    for (id, worktree) in [(1_i64, "base"), (2_i64, "wt")] {
+        conn.execute(
+            "INSERT INTO files(id, path, language, kind, sha256, modified_at_ms, indexed_at_ms,
+                               commit_sha, worktree_id)
+             VALUES (?1, 'src/lib.rs', 'rust', 'source', 'sha', 0, 0, 'head', ?2)",
+            rusqlite::params![id, worktree],
+        )
+        .unwrap();
+    }
+    let symbol = |id: i64, file_id: i64, name: &str| {
+        conn.execute(
+            "INSERT INTO symbols(id, file_id, language, name, kind, start_byte, end_byte)
+             VALUES (?1, ?2, 'rust', ?3, 'function', 0, 1)",
+            rusqlite::params![id, file_id, name],
+        )
+        .unwrap();
+    };
+    // `replicated` is ONE symbol seen in both scopes; `collided` is TWO symbols in one file.
+    symbol(1, 1, "replicated");
+    symbol(2, 2, "replicated");
+    symbol(3, 1, "collided");
+    symbol(4, 1, "collided");
+    symbol(5, 2, "solo");
+
+    let group = |id: i64, name: &str, members: &[i64]| {
+        conn.execute(
+            "INSERT INTO logical_symbols(id, language, path, logical_name, kind, variant_count,
+                                         group_reason)
+             VALUES (?1, 'rust', 'src/lib.rs', ?2, 'function', ?3, 'cfg_variant')",
+            rusqlite::params![id, name, members.len() as i64],
+        )
+        .unwrap();
+        for symbol_id in members {
+            conn.execute(
+                "INSERT INTO logical_symbol_members(logical_symbol_id, symbol_id, start_line,
+                                                    end_line)
+                 VALUES (?1, ?2, 1, 2)",
+                rusqlite::params![id, symbol_id],
+            )
+            .unwrap();
+        }
+    };
+    group(100, "replicated", &[1, 2]);
+    group(200, "collided", &[3, 4]);
+    group(300, "solo", &[5]);
+
+    truncate_schema_to(&conn, 82);
+    schema::migrate_forward(&conn, &crate::index::migration_hooks()).unwrap();
+    assert_eq!(schema::status(&conn).unwrap().current_version, 83);
+
+    let reason = |id: i64| -> String {
+        conn.query_row("SELECT group_reason FROM logical_symbols WHERE id = ?1", [id], |row| {
+            row.get(0)
+        })
+        .unwrap()
+    };
+    assert_eq!(
+        reason(100),
+        "scope_replica",
+        "one symbol indexed in two scopes is a replica, not a cfg variant — this is the case the \
+         old label got wrong for the overwhelming majority of groups",
+    );
+    assert_eq!(
+        reason(200),
+        "same_file_multi",
+        "two symbols inside one file row genuinely share an identity",
+    );
+    assert_eq!(reason(300), "single");
 }

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/symbol_search_lookup.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/symbol_search_lookup.rs
@@ -336,7 +336,11 @@ pub fn caller() {
         .unwrap();
     let logical_symbol_id = lookup.candidates[0].logical_symbol_id.expect("logical id");
     assert_eq!(lookup.candidates[0].logical_variant_count, Some(2));
-    assert_eq!(lookup.candidates[0].logical_group_reason.as_deref(), Some("cfg_variant"));
+    // This fixture IS a genuine cfg pair, but the label deliberately does not claim so: two
+    // `#[cfg]` definitions and two unrelated same-signature symbols in one file are
+    // indistinguishable from the group key alone, so the reported reason states only what the
+    // members show — several members inside one `files` row.
+    assert_eq!(lookup.candidates[0].logical_group_reason.as_deref(), Some("same_file_multi"));
 
     let exact_variant_callers = db
         .find_callers_with_options(

--- a/crates/rag-rat-db/src/schema/migrations.rs
+++ b/crates/rag-rat-db/src/schema/migrations.rs
@@ -1245,6 +1245,43 @@ pub(crate) fn applied_migrations(conn: &Connection) -> anyhow::Result<Vec<Applie
     Ok(migrations)
 }
 
+/// Recompute `logical_symbols.group_reason` from what the members actually show (#855).
+///
+/// The previous writer labelled EVERY multi-member group `cfg_variant`. On a representative index
+/// that was wrong for 3,686 of 3,699 such groups: a source path carries one `files` row per index
+/// scope (worktree-overlay and commit scopes), so a symbol defined once shows up once per scope and
+/// gets grouped. Callers were told a symbol with a single definition had N cfg variants.
+///
+/// This runs as a migration rather than waiting for the next `rebuild_logical_symbols` because the
+/// column is derived but PERSISTED: a query-only server over an unchanged repository never
+/// rebuilds, and would keep serving the old label indefinitely.
+///
+/// The three outcomes match [`logical_group_reason`](../../../rag-rat-core) exactly — one member is
+/// `single`; members spread one-per-`files`-row are a `scope_replica`; any `files` row holding two
+/// or more members makes the group `same_file_multi`. A group whose members have all been deleted
+/// falls back to `single` so the NOT NULL column always gets a value.
+pub(crate) fn apply_logical_group_reason_by_evidence(conn: &Connection) -> rusqlite::Result<()> {
+    // Both tables are in the baseline, so no existence guard is needed.
+    conn.execute_batch(
+        "
+        UPDATE logical_symbols SET group_reason = COALESCE((
+            SELECT CASE
+                     WHEN SUM(per_file.members) <= 1 THEN 'single'
+                     WHEN MAX(per_file.members) > 1 THEN 'same_file_multi'
+                     ELSE 'scope_replica'
+                   END
+            FROM (
+                SELECT COUNT(*) AS members
+                FROM logical_symbol_members
+                JOIN symbols ON symbols.id = logical_symbol_members.symbol_id
+                WHERE logical_symbol_members.logical_symbol_id = logical_symbols.id
+                GROUP BY symbols.file_id
+            ) AS per_file
+        ), 'single');
+        ",
+    )
+}
+
 pub(crate) fn known_version(migrations: &[AppliedMigration]) -> u32 {
     migrations
         .iter()
@@ -1331,6 +1368,7 @@ pub(crate) fn known_version(migrations: &[AppliedMigration]) -> u32 {
             MIGRATION_080_ID => Some(80),
             MIGRATION_081_ID => Some(81),
             MIGRATION_082_ID => Some(82),
+            MIGRATION_083_ID => Some(83),
             _ => None,
         })
         .max()
@@ -1422,6 +1460,7 @@ pub(crate) fn known_migration(id: &str) -> bool {
             | MIGRATION_080_ID
             | MIGRATION_081_ID
             | MIGRATION_082_ID
+            | MIGRATION_083_ID
             | DIRTY_MIGRATION_ID
     )
 }
@@ -1510,6 +1549,7 @@ pub(crate) fn migration_checksum_mismatch(migration: &AppliedMigration) -> bool 
         MIGRATION_080_ID => migration.checksum != MIGRATION_080_CHECKSUM,
         MIGRATION_081_ID => migration.checksum != MIGRATION_081_CHECKSUM,
         MIGRATION_082_ID => migration.checksum != MIGRATION_082_CHECKSUM,
+        MIGRATION_083_ID => migration.checksum != MIGRATION_083_CHECKSUM,
         _ => false,
     }
 }

--- a/crates/rag-rat-db/src/schema/mod.rs
+++ b/crates/rag-rat-db/src/schema/mod.rs
@@ -45,7 +45,7 @@ use serde::Serialize;
 
 use crate::hooks::MigrationHooks;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 82;
+pub const LATEST_SCHEMA_VERSION: u32 = 83;
 
 /// Every oracle-DERIVED persisted table — the outputs an `oracle run` writes that must OUTLIVE a
 /// reindex.
@@ -600,6 +600,11 @@ const MIGRATION_081_DESCRIPTION: &str =
      key as source_id). Nullable and additive: existing rows keep NULL, the drain populates new \
      rows from its snapshot, and no SQL backfill is performed (a re-drain rewrites evidence)";
 
+const MIGRATION_083_ID: &str = "083_logical_group_reason_by_evidence";
+const MIGRATION_083_CHECKSUM: &str = "sha256:rag-rat-logical-group-reason-by-evidence-v83";
+const MIGRATION_083_DESCRIPTION: &str = "Recompute logical_symbols.group_reason from member \
+                                         evidence — the old value asserted cfg_variant for every \
+                                         multi-member group (#855)";
 const MIGRATION_082_ID: &str = "082_content_refold_queue_and_stats";
 const MIGRATION_082_CHECKSUM: &str = "sha256:rag-rat-content-refold-queue-and-stats-v82";
 const MIGRATION_082_DESCRIPTION: &str =
@@ -1291,6 +1296,12 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         checksum: MIGRATION_082_CHECKSUM,
         description: MIGRATION_082_DESCRIPTION,
         apply: MigrationFn::Plain(apply_content_refold_queue_and_stats),
+    },
+    Migration {
+        id: MIGRATION_083_ID,
+        checksum: MIGRATION_083_CHECKSUM,
+        description: MIGRATION_083_DESCRIPTION,
+        apply: MigrationFn::Plain(apply_logical_group_reason_by_evidence),
     },
 ];
 


### PR DESCRIPTION
`insert_logical_group` labelled **every** multi-member group `cfg_variant`. On this repo's own index that was wrong for **3,655 of 3,699** such groups.

## Why it was wrong

A source path carries one `files` row per index scope — worktree-overlay and commit scopes each add one (525 file rows for 294 distinct paths here). So a symbol defined exactly once shows up once per scope and gets grouped. `symbol_lookup` then reported `variant_count: 9, group_reason: cfg_variant` for a symbol that has a single definition in the source.

## The new labels

| label | meaning |
|---|---|
| `single` | one member |
| `scope_replica` | several members, no `files` row contributing more than one — one symbol observed in several index scopes |
| `same_file_multi` | some `files` row contributes 2+ members, so one file genuinely holds several symbols sharing name, kind and declaration line |

**`cfg_variant` is deliberately gone.** Two `#[cfg]`-gated definitions and two unrelated `impl Default for _` blocks are indistinguishable from the group key — both are several symbols in one file with identical declaration lines, and the key carries no cfg evidence to separate them. Asserting the friendlier reading in every case is what made the old value useless, so `same_file_multi` stays neutral and a caller needing the distinction has to look at the source. The existing cfg-variant test keeps its genuine `#[cfg]` fixture and now asserts the neutral label, with a comment explaining why it does not claim more.

## Migration

`group_reason` is derived but **persisted**, so a new rule alone would never reach an existing index: a query-only server over an unchanged repository never runs `rebuild_logical_symbols` and would serve the old label indefinitely. **V083** recomputes it in SQL, matching the Rust labeller exactly.

Verified against the real index rather than only fixtures:

| label | before | after |
|---|---|---|
| `cfg_variant` | 3699 | — |
| `scope_replica` | — | 3655 |
| `same_file_multi` | — | 44 |
| `single` | 3375 | 3375 |

## Why this matters beyond tidiness

The 44 `same_file_multi` groups are genuine collisions — distinct symbols merged into one logical symbol, so anything anchored to that `sym_<hex>` (repo memories, distilled decision records, monikers) applies to all of them. They concentrate on trait- and DB-contract methods (`as_db_str`, `default` ×7 in one file, `drop` ×3, an associated `type Error` spanning 7 impl blocks) — exactly the symbols invariants get bound to.

Separating them out is what makes them countable. **Fixing** them means changing the identity key so distinct same-named symbols get distinct logical ids, which churns every cached `sym_<hex>` handle and is a separate, deliberate change. This PR buys the visibility to decide that with numbers rather than guesses.

Tests: four unit tests over the labeller (including a collision that also spans scopes, which must not be downgraded to a replica), and a V083 migration test that stages both shapes, replays from 82, and asserts the recomputed values.

Gates: workspace nextest (3591 passed), clippy on both feature sets with `-D warnings`, nightly rustfmt.

Refs #855.