### PR TITLE
fix(index): carry distill anchors and node-edge targets through a logical-id remap (#810)

### DIFF
--- a/crates/rag-rat-core/src/index/graph_index.rs
+++ b/crates/rag-rat-core/src/index/graph_index.rs
@@ -232,7 +232,45 @@ fn rewrite_logical_symbol_references(
           WHERE end_logical_symbol_id = ?2",
         params![to, from],
     )?;
+    // The two tables below are guarded on existence because this runs DURING migrations:
+    // `realign_logical_symbol_ids` is a `MigrationHooks` entry, so an index forward-migrating from
+    // an old version reaches here at a schema state that predates them.
+    if table_present(conn, "repo_node_edges")? {
+        conn.execute(
+            "UPDATE repo_node_edges SET target_logical_symbol_id = ?1
+              WHERE target_logical_symbol_id = ?2",
+            params![to, from],
+        )?;
+    }
+    // Distill anchors store the logical id as the OPAQUE `sym_<hex>` TEXT handle, not an INTEGER,
+    // which is exactly why they were missed: every other reference column is an i64, so a remap
+    // that updated "the id columns" silently skipped this one (#810). A stale token then points at
+    // whatever now occupies that id — surfacing the previous occupant's decision record on an
+    // unrelated symbol, the failure mode that matters most here.
+    if table_present(conn, "papertrail_distill_anchors")? {
+        conn.execute(
+            "UPDATE papertrail_distill_anchors SET logical_symbol_id = ?1
+              WHERE logical_symbol_id = ?2",
+            params![
+                rag_rat_base::serde_big_id::format_sym_handle(to),
+                rag_rat_base::serde_big_id::format_sym_handle(from)
+            ],
+        )?;
+    }
     Ok(())
+}
+
+/// Does `table` exist in this connection? Kept rusqlite-native (rather than the `rag_rat_db`
+/// helper, which returns `anyhow`) so it composes with the `rusqlite::Result` remap seam.
+fn table_present(conn: &rusqlite::Connection, table: &str) -> rusqlite::Result<bool> {
+    Ok(conn
+        .query_row(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?1",
+            params![table],
+            |_| Ok(()),
+        )
+        .optional()?
+        .is_some())
 }
 
 /// NULL every CALL-PATH reference to a drifted id the heal could not realign (#493 review).
@@ -262,6 +300,26 @@ fn null_call_path_references(conn: &rusqlite::Connection, from: i64) -> rusqlite
           WHERE end_logical_symbol_id = ?1",
         params![from],
     )?;
+    // Distill anchors and node-edge targets are cleared for EVERY no-winner id, not just occupied
+    // ones, because both carry a STATUS alongside the reference. Left alone on a vanished id they
+    // keep asserting `resolved = 1` / `anchor_status = 'current'` for a target that resolves to
+    // nothing — a claim their readers act on. Memory bindings differ and stay occupied-only: a
+    // vanished binding is unresolvable, which is exactly what lets the validate-time relocation
+    // ladder find it a new home later.
+    if table_present(conn, "repo_node_edges")? {
+        conn.execute(
+            "UPDATE repo_node_edges SET target_logical_symbol_id = NULL, anchor_status = 'gone'
+              WHERE target_logical_symbol_id = ?1",
+            params![from],
+        )?;
+    }
+    if table_present(conn, "papertrail_distill_anchors")? {
+        conn.execute(
+            "UPDATE papertrail_distill_anchors SET logical_symbol_id = NULL, resolved = 0
+              WHERE logical_symbol_id = ?1",
+            params![rag_rat_base::serde_big_id::format_sym_handle(from)],
+        )?;
+    }
     Ok(())
 }
 
@@ -955,15 +1013,12 @@ impl IndexDatabase {
             return Ok(None);
         }
         let conn = self.storage.connection();
-        let mut stmt = conn.prepare(&format!(
+        // The snapshot is bounded to ids holding a DURABLE reference — healing an id nothing points
+        // at would be wasted work. That makes this list the definition of "durable reference", so a
+        // reference table missing from it is never healed at all, no matter what the remap covers
+        // (#810). Both additions below are guarded because a store can predate their tables.
+        let mut reference_sources = String::from(
             "
-            SELECT ls.id, ls.path, ls.logical_name,
-                   (SELECT value FROM name_strings WHERE id = ls.qualified_name_id),
-                   ls.kind,
-                   {UNANIMOUS_MEMBER_SIGNATURE_SQL}
-            FROM main.logical_symbols ls
-            WHERE ls.repo_id = ?1
-              AND ls.id IN (
                   SELECT logical_symbol_id FROM repo_memory_bindings
                    WHERE logical_symbol_id IS NOT NULL
                   UNION
@@ -973,7 +1028,39 @@ impl IndexDatabase {
                   SELECT end_logical_symbol_id FROM repo_memory_call_paths
                    WHERE end_logical_symbol_id IS NOT NULL
                   UNION
-                  SELECT logical_symbol_id FROM logical_symbol_monikers
+                  SELECT logical_symbol_id FROM logical_symbol_monikers",
+        );
+        if table_present(conn, "repo_node_edges")? {
+            reference_sources.push_str(
+                "
+                  UNION
+                  SELECT target_logical_symbol_id FROM repo_node_edges
+                   WHERE target_logical_symbol_id IS NOT NULL",
+            );
+        }
+        if table_present(conn, "papertrail_distill_anchors")? {
+            // Anchors hold the OPAQUE `sym_<hex>` handle as TEXT, so the match runs the other way:
+            // format the candidate id and compare. SQLite's `%x` is byte-identical to the Rust
+            // `format_sym_handle` encoding, and `stable_id` is a shifted sha256 so ids are never
+            // negative — the two agree over the whole domain in play.
+            reference_sources.push_str(
+                "
+                  UNION
+                  SELECT anchored.id FROM main.logical_symbols anchored
+                   WHERE EXISTS (
+                       SELECT 1 FROM papertrail_distill_anchors a
+                        WHERE a.logical_symbol_id = 'sym_' || format('%x', anchored.id))",
+            );
+        }
+        let mut stmt = conn.prepare(&format!(
+            "
+            SELECT ls.id, ls.path, ls.logical_name,
+                   (SELECT value FROM name_strings WHERE id = ls.qualified_name_id),
+                   ls.kind,
+                   {UNANIMOUS_MEMBER_SIGNATURE_SQL}
+            FROM main.logical_symbols ls
+            WHERE ls.repo_id = ?1
+              AND ls.id IN ({reference_sources}
               )
             "
         ))?;

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_memory.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_memory.rs
@@ -7108,3 +7108,395 @@ fn a_decision_record_does_not_leak_between_distinct_same_named_methods() {
 
     let _ = fs::remove_dir_all(&root);
 }
+
+/// #810: a logical-id remap must carry the distill anchor's `sym_<hex>` TEXT token with it.
+///
+/// Every other durable reference to a logical id is an INTEGER column, so a remap written as "move
+/// the id columns" silently skipped `papertrail_distill_anchors.logical_symbol_id`, which stores
+/// the OPAQUE handle as TEXT. The anchor then still names the OLD id, and if a later re-derive
+/// hands that id to a different symbol — exactly what the drift heal exists to handle — the anchor
+/// resolves to the new occupant and surfaces one symbol's decision record on another.
+///
+/// The anchor is the ONLY reference here on purpose. Closing the remap alone would not have been
+/// enough: the drift snapshot is bounded to ids holding a durable reference, and its definition of
+/// that did not include anchors either, so this id would never have been considered for healing.
+/// Both halves are required and this fixture fails if either is missing.
+#[test]
+fn a_remap_heals_a_logical_id_referenced_only_by_a_distill_anchor() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), "pub fn drift_anchor() -> u32 { 7 }\n").unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let repo_id = rag_rat_db::schema::active_repo_id(db.storage.connection()).unwrap();
+    let real_id: i64 = db
+        .storage
+        .connection()
+        .query_row("SELECT id FROM logical_symbols WHERE logical_name = 'drift_anchor'", [], |r| {
+            r.get(0)
+        })
+        .unwrap();
+
+    let stale_id = 424242_i64;
+    {
+        let conn = rusqlite::Connection::open(&config.database).unwrap();
+        conn.execute_batch("PRAGMA foreign_keys = OFF;").unwrap();
+        conn.execute("UPDATE logical_symbols SET id = ?1 WHERE id = ?2", params![
+            stale_id, real_id
+        ])
+        .unwrap();
+        conn.execute(
+            "UPDATE logical_symbol_members SET logical_symbol_id = ?1 WHERE logical_symbol_id = ?2",
+            params![stale_id, real_id],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO papertrail_distill
+                 (tracker, project, item_kind, item_key, distill_input_hash, pipeline_version,
+                  root_issue, fix_edge_source, thread_shape, anchors_qualified_count,
+                  distilled_at_ms, repo_id)
+             VALUES \
+             ('github','o/r','issue','5','sha256:h',3,'5','provider','investigation',1,10,?1)",
+            params![repo_id],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO papertrail_distill_anchors
+                 (tracker, project, item_kind, item_key, anchor_kind, logical_symbol_id, name,
+                  resolved, candidate_ordinal, selected, repo_id)
+             VALUES ('github','o/r','issue','5','symbol',?1,'drift_anchor',1,0,1,?2)",
+            params![rag_rat_base::serde_big_id::format_sym_handle(stale_id), repo_id],
+        )
+        .unwrap();
+        conn.execute("DELETE FROM repo_meta WHERE key = 'logical_key_version'", []).unwrap();
+    }
+
+    // A content change so the next rebuild runs a full pass (unchanged content short-circuits).
+    fs::write(
+        root.join("src/lib.rs"),
+        "pub fn drift_anchor() -> u32 { 7 }\n\npub fn drift_appendix() {}\n",
+    )
+    .unwrap();
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let conn = db.storage.connection();
+
+    let fresh_id: i64 = conn
+        .query_row("SELECT id FROM logical_symbols WHERE logical_name = 'drift_anchor'", [], |r| {
+            r.get(0)
+        })
+        .unwrap();
+    assert_ne!(
+        fresh_id, stale_id,
+        "the re-derive must mint a different id, or nothing is remapped"
+    );
+    let anchor_token: String = conn
+        .query_row(
+            "SELECT logical_symbol_id FROM papertrail_distill_anchors WHERE item_key = '5'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        anchor_token,
+        rag_rat_base::serde_big_id::format_sym_handle(fresh_id),
+        "the anchor's sym_<hex> token follows the symbol; left stale it names whatever occupies \
+         the old id next",
+    );
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+/// The same gap, for `repo_node_edges.target_logical_symbol_id` — an INTEGER column that was simply
+/// never added to either the remap or the snapshot's reference set. Referenced only by that edge.
+#[test]
+fn a_remap_heals_a_logical_id_referenced_only_by_a_node_edge() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), "pub fn drift_anchor() -> u32 { 7 }\n").unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let repo_id = rag_rat_db::schema::active_repo_id(db.storage.connection()).unwrap();
+    let real_id: i64 = db
+        .storage
+        .connection()
+        .query_row("SELECT id FROM logical_symbols WHERE logical_name = 'drift_anchor'", [], |r| {
+            r.get(0)
+        })
+        .unwrap();
+
+    let stale_id = 424242_i64;
+    {
+        let conn = rusqlite::Connection::open(&config.database).unwrap();
+        conn.execute_batch("PRAGMA foreign_keys = OFF;").unwrap();
+        conn.execute("UPDATE logical_symbols SET id = ?1 WHERE id = ?2", params![
+            stale_id, real_id
+        ])
+        .unwrap();
+        conn.execute(
+            "UPDATE logical_symbol_members SET logical_symbol_id = ?1 WHERE logical_symbol_id = ?2",
+            params![stale_id, real_id],
+        )
+        .unwrap();
+        // FKs are off here, so a placeholder source node is fine — the row exists only to carry a
+        // `target_logical_symbol_id` through the remap.
+        conn.execute(
+            "INSERT INTO repo_node_edges
+                 (edge_key, repo_id, source_node_id, relation, target_repo_id, target_kind,
+                  target_anchor, target_logical_symbol_id, anchor_status, created_at_ms)
+             VALUES ('edge-810', ?1, 'node-810', 'references', ?1, 'symbol', 'drift_anchor', ?2,
+                     'current', 0)",
+            params![repo_id, stale_id],
+        )
+        .unwrap();
+        conn.execute("DELETE FROM repo_meta WHERE key = 'logical_key_version'", []).unwrap();
+    }
+
+    fs::write(
+        root.join("src/lib.rs"),
+        "pub fn drift_anchor() -> u32 { 7 }\n\npub fn drift_appendix() {}\n",
+    )
+    .unwrap();
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let conn = db.storage.connection();
+
+    let fresh_id: i64 = conn
+        .query_row("SELECT id FROM logical_symbols WHERE logical_name = 'drift_anchor'", [], |r| {
+            r.get(0)
+        })
+        .unwrap();
+    assert_ne!(fresh_id, stale_id);
+    let edge_target: i64 = conn
+        .query_row(
+            "SELECT target_logical_symbol_id FROM repo_node_edges WHERE edge_key = 'edge-810'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(edge_target, fresh_id, "the node-edge target follows the symbol");
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+/// No drift winner on an OCCUPIED id: the references must be CLEARED, never left naming it.
+///
+/// Snapshotting these tables put them in scope for the successful-remap branch. Leaving them out of
+/// the failure branch would be worse than never snapshotting them: an occupied no-winner id belongs
+/// to a DIFFERENT re-derived symbol, so a reference still naming it resolves to that unrelated
+/// symbol while reporting itself current — the false positive #810 calls the concerning case.
+///
+/// Note the cleanup is deliberately occupied-only. A VANISHED id resolves to nothing, so leaving a
+/// reference on it is a miss rather than a mis-attribution, and the validate-time ladder still gets
+/// a chance to relocate it.
+#[test]
+fn a_no_winner_drift_on_an_occupied_id_clears_the_anchor_and_the_node_edge() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(
+        root.join("src/lib.rs"),
+        "pub fn alpha_occ(a: u8) -> u8 { a }\n\npub fn beta_occ(b: u16) -> u16 { b }\n",
+    )
+    .unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let repo_id = rag_rat_db::schema::active_repo_id(db.storage.connection()).unwrap();
+    let id_of = |db: &IndexDatabase, name: &str| -> i64 {
+        db.storage
+            .connection()
+            .query_row("SELECT id FROM logical_symbols WHERE logical_name = ?1", [name], |r| {
+                r.get(0)
+            })
+            .unwrap()
+    };
+    let alpha_id = id_of(&db, "alpha_occ");
+    let beta_id = id_of(&db, "beta_occ");
+    drop(db);
+
+    {
+        let conn = rusqlite::Connection::open(&config.database).unwrap();
+        conn.execute_batch("PRAGMA foreign_keys = OFF;").unwrap();
+        // The swap: under OLD rules alpha's key hashed to what is beta's id under the NEW rules.
+        // Park alpha's row and its references there; beta will re-derive back onto that id, so it
+        // is OCCUPIED after the rebuild.
+        conn.execute("DELETE FROM logical_symbol_members WHERE logical_symbol_id = ?1", params![
+            beta_id
+        ])
+        .unwrap();
+        conn.execute("DELETE FROM logical_symbols WHERE id = ?1", params![beta_id]).unwrap();
+        conn.execute("UPDATE logical_symbols SET id = ?1 WHERE id = ?2", params![
+            beta_id, alpha_id
+        ])
+        .unwrap();
+        conn.execute(
+            "UPDATE logical_symbol_members SET logical_symbol_id = ?1 WHERE logical_symbol_id = ?2",
+            params![beta_id, alpha_id],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO papertrail_distill
+                 (tracker, project, item_kind, item_key, distill_input_hash, pipeline_version,
+                  root_issue, fix_edge_source, thread_shape, anchors_qualified_count,
+                  distilled_at_ms, repo_id)
+             VALUES \
+             ('github','o/r','issue','5','sha256:h',3,'5','provider','investigation',1,10,?1)",
+            params![repo_id],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO papertrail_distill_anchors
+                 (tracker, project, item_kind, item_key, anchor_kind, logical_symbol_id, name,
+                  resolved, candidate_ordinal, selected, repo_id)
+             VALUES ('github','o/r','issue','5','symbol',?1,'alpha_occ',1,0,1,?2)",
+            params![rag_rat_base::serde_big_id::format_sym_handle(beta_id), repo_id],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO repo_node_edges
+                 (edge_key, repo_id, source_node_id, relation, target_repo_id, target_kind,
+                  target_anchor, target_logical_symbol_id, anchor_status, created_at_ms)
+             VALUES ('edge-810', ?1, 'node-810', 'references', ?1, 'symbol', 'alpha_occ', ?2,
+                     'current', 0)",
+            params![repo_id, beta_id],
+        )
+        .unwrap();
+        conn.execute("DELETE FROM repo_meta WHERE key = 'logical_key_version'", []).unwrap();
+    }
+
+    // alpha disappears, so the parked row has no candidate to match: no winner, and the id it sits
+    // on is re-derived back to beta.
+    fs::write(root.join("src/lib.rs"), "pub fn beta_occ(b: u16) -> u16 { b }\n").unwrap();
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let conn = db.storage.connection();
+    assert_eq!(id_of(&db, "beta_occ"), beta_id, "beta re-derives onto the contested id");
+
+    let anchor: (Option<String>, i64) = conn
+        .query_row(
+            "SELECT logical_symbol_id, resolved FROM papertrail_distill_anchors WHERE item_key = \
+             '5'",
+            [],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(
+        anchor.0, None,
+        "the anchor token is cleared rather than left resolving to the symbol that now holds that \
+         id",
+    );
+    assert_eq!(anchor.1, 0, "and the anchor is marked unresolved");
+
+    let edge: (Option<i64>, String) = conn
+        .query_row(
+            "SELECT target_logical_symbol_id, anchor_status FROM repo_node_edges WHERE edge_key = \
+             'edge-810'",
+            [],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(edge.0, None, "the node-edge target is cleared");
+    assert_eq!(edge.1, "gone", "and reports itself gone rather than current");
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+/// The VANISHED no-winner case: nothing occupies the old id, and the references are still cleared.
+///
+/// Nothing mis-resolves here — a dead id resolves to nothing — but both of these carry a STATUS
+/// next to the reference, and left alone they keep asserting `resolved = 1` and
+/// `anchor_status = 'current'` for a target that no longer exists. Their readers act on those
+/// fields, so a dead-but-"current" row is a false claim rather than a harmless miss. Memory
+/// bindings deliberately behave differently and are left for the relocation ladder.
+#[test]
+fn a_no_winner_drift_on_a_vanished_id_also_clears_the_anchor_and_the_node_edge() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), "pub fn drift_anchor() -> u32 { 7 }\n").unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let repo_id = rag_rat_db::schema::active_repo_id(db.storage.connection()).unwrap();
+    let real_id: i64 = db
+        .storage
+        .connection()
+        .query_row("SELECT id FROM logical_symbols WHERE logical_name = 'drift_anchor'", [], |r| {
+            r.get(0)
+        })
+        .unwrap();
+
+    let stale_id = 424242_i64;
+    {
+        let conn = rusqlite::Connection::open(&config.database).unwrap();
+        conn.execute_batch("PRAGMA foreign_keys = OFF;").unwrap();
+        conn.execute("UPDATE logical_symbols SET id = ?1 WHERE id = ?2", params![
+            stale_id, real_id
+        ])
+        .unwrap();
+        conn.execute(
+            "UPDATE logical_symbol_members SET logical_symbol_id = ?1 WHERE logical_symbol_id = ?2",
+            params![stale_id, real_id],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO papertrail_distill
+                 (tracker, project, item_kind, item_key, distill_input_hash, pipeline_version,
+                  root_issue, fix_edge_source, thread_shape, anchors_qualified_count,
+                  distilled_at_ms, repo_id)
+             VALUES \
+             ('github','o/r','issue','5','sha256:h',3,'5','provider','investigation',1,10,?1)",
+            params![repo_id],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO papertrail_distill_anchors
+                 (tracker, project, item_kind, item_key, anchor_kind, logical_symbol_id, name,
+                  resolved, candidate_ordinal, selected, repo_id)
+             VALUES ('github','o/r','issue','5','symbol',?1,'drift_anchor',1,0,1,?2)",
+            params![rag_rat_base::serde_big_id::format_sym_handle(stale_id), repo_id],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO repo_node_edges
+                 (edge_key, repo_id, source_node_id, relation, target_repo_id, target_kind,
+                  target_anchor, target_logical_symbol_id, anchor_status, created_at_ms)
+             VALUES ('edge-810v', ?1, 'node-810v', 'references', ?1, 'symbol', 'drift_anchor', ?2,
+                     'current', 0)",
+            params![repo_id, stale_id],
+        )
+        .unwrap();
+        conn.execute("DELETE FROM repo_meta WHERE key = 'logical_key_version'", []).unwrap();
+    }
+
+    // The symbol disappears and nothing re-derives onto 424242, so the id simply vanishes.
+    fs::write(root.join("src/lib.rs"), "pub fn something_else() {}\n").unwrap();
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let conn = db.storage.connection();
+    let occupied: i64 = conn
+        .query_row("SELECT COUNT(*) FROM logical_symbols WHERE id = ?1", [stale_id], |r| r.get(0))
+        .unwrap();
+    assert_eq!(occupied, 0, "the old id must be VANISHED, not occupied, for this test to differ");
+
+    let anchor: (Option<String>, i64) = conn
+        .query_row(
+            "SELECT logical_symbol_id, resolved FROM papertrail_distill_anchors WHERE item_key = \
+             '5'",
+            [],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(anchor.0, None, "a dead token is cleared");
+    assert_eq!(anchor.1, 0, "and the anchor stops claiming to be resolved");
+
+    let edge: (Option<i64>, String) = conn
+        .query_row(
+            "SELECT target_logical_symbol_id, anchor_status FROM repo_node_edges WHERE edge_key = \
+             'edge-810v'",
+            [],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(edge.0, None, "a dead target is cleared");
+    assert_eq!(edge.1, "gone", "and stops claiming to be current");
+
+    let _ = fs::remove_dir_all(&root);
+}


### PR DESCRIPTION
Closes #810.

## The gap

`papertrail_distill_anchors.logical_symbol_id` stores the logical id as the opaque `sym_<hex>` handle in **TEXT**. Every other durable reference is an INTEGER column, so a relocation seam written as "move the id columns" skipped it silently. `repo_node_edges.target_logical_symbol_id` was missed too — an integer column simply never added.

A stale anchor still names the **old** id. If a later re-derive hands that id to a different symbol — exactly what the drift heal exists to handle — the anchor resolves to the new occupant and surfaces one symbol's decision record on another.

## Closing the remap alone was not enough

The drift snapshot is bounded to ids holding a durable reference, and its definition of "durable reference" did not include either table. So an id referenced **only** by an anchor was never considered for healing, no matter what the remap covered.

Both halves are required, and each of the four is pinned by a reference-only test that fails when just that half is reverted:

| disabled | fails |
|---|---|
| snapshot: anchors | anchor-only test |
| remap: anchors | anchor-only test |
| snapshot: node edges | node-edge-only test |
| remap: node edges | node-edge-only test |

Anchors are matched from SQL by **formatting the candidate id** rather than parsing the token — SQLite's `%x` is byte-identical to the Rust handle encoding across the whole domain, negatives included.

## The failure branch needed its own handling

Bringing these tables into the snapshot put them in scope for the successful-remap branch. Leaving them out of the failure branch would have been worse than never snapshotting them: a no-winner id is often **occupied** by a different re-derived symbol, so a reference left naming it resolves to that unrelated symbol while reporting itself current — the false positive #810 calls the concerning case.

Both are therefore cleared for **every** no-winner id, occupied and vanished alike. Memory bindings deliberately stay occupied-only: a vanished binding is unresolvable, and that is precisely what lets the validate-time relocation ladder find it a new home later.

The vanished case still matters here even though nothing mis-resolves, because both of these carry a **status** next to the reference. Left alone they keep asserting `resolved = 1` and `anchor_status = 'current'` for a target that resolves to nothing, and their readers act on those fields. `null_call_path_references` already covers occupied-and-vanished alike for the same reason.

## Migration safety

Both tables are guarded on existence: `realign_logical_symbol_ids` is a `MigrationHooks` entry, so this code runs *during* a forward migration, at a schema state that predates them.

Tests: four reference-only remap tests plus occupied and vanished no-winner tests, all mutation-verified.

Gates: workspace nextest (3598 passed), clippy on both feature sets with `-D warnings`, nightly rustfmt.