### PR TITLE
chore: release v0.21.0

### DIFF
--- a/.agents/skills/init-rag-rat/SKILL.md
+++ b/.agents/skills/init-rag-rat/SKILL.md
@@ -32,7 +32,7 @@ hand-write a config blind, and let a real config load re-check it before indexin
    do **not** use `@latest`, and **don't blindly trust an on-`PATH` `rag-rat`**:
    - If `rag-rat` is on `PATH`, check `rag-rat --version` and use it **only if it matches** the
      plugin/MCP version — a stale global install would build the index with the wrong binary.
-   - Otherwise (or on a version mismatch) use `npx -y @rag-rat/bin@0.20.0 …` — the plugin pins
+   - Otherwise (or on a version mismatch) use `npx -y @rag-rat/bin@0.21.0 …` — the plugin pins
      `@rag-rat/bin` to its own version and caches the binary privately, so this is the
      version-matched CLI; `npx` runs it in the current directory.
 

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "rag-rat",
       "description": "Local repo-intelligence index + MCP server: semantic search, symbol/graph navigation, impact-surface preflight, git + GitHub papertrail, and a source-anchored memory graph.",
-      "version": "0.20.0",
+      "version": "0.21.0",
       "source": "./plugin",
       "category": "developer-tools",
       "license": "MIT",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.20.0...rag-rat-base-v0.21.0) - 2026-07-24
+
+### Added
+
+- *(init)* add Papertrail (issue tracker) and Distillation wizard steps ([#887](https://github.com/cq27-dev/rag-rat/pull/887))
+- *(distill)* default to the validated 30B ephemeral box, with distillation docs ([#876](https://github.com/cq27-dev/rag-rat/pull/876))
+- *(distill)* drain prepared snapshots through the configured chat model ([#704](https://github.com/cq27-dev/rag-rat/pull/704)) ([#799](https://github.com/cq27-dev/rag-rat/pull/799))
+
+### Other
+
+- *(watch)* quiet-window overlay skip; reuse repo handles and the recorded delta in the probe ([#857](https://github.com/cq27-dev/rag-rat/pull/857))
+- *(watch)* add a minimum inter-pass cooldown to the watcher event loop ([#847](https://github.com/cq27-dev/rag-rat/pull/847))
+
 ## [0.20.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.19.0...rag-rat-base-v0.20.0) - 2026-07-20
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4848,7 +4848,7 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rag-rat"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -4882,7 +4882,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-base"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "filetime",
@@ -4906,7 +4906,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-clones"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "rag-rat-base",
@@ -4922,7 +4922,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-core"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "chacha20poly1305",
@@ -4987,7 +4987,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-db"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "rag-rat-base",
@@ -5001,7 +5001,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-dream"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "rag-rat-base",
@@ -5020,7 +5020,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-llm"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "fastembed",
@@ -5041,7 +5041,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-mcp"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "libc",
@@ -5063,7 +5063,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-oplog"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "chacha20poly1305",
@@ -5085,7 +5085,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-oracle"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "protobuf",
@@ -5103,7 +5103,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-papertrail"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -5123,7 +5123,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-query"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "minicbor",
@@ -5142,7 +5142,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-sync"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "iroh",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ resolver = "3"
 # and the internal path deps below pin the same literal, so the three crates always publish in
 # lockstep. Bump this one line (and the two internal-dep `version`s under workspace.dependencies)
 # to release.
-version = "0.20.0"
+version = "0.21.0"
 authors = ["Kristaps Karlsons"]
 edition = "2024"
 # Bundled SQLite (rusqlite `bundled` -> libsqlite3-sys 0.38.1) compiles a build script that uses the
@@ -38,18 +38,18 @@ categories = ["command-line-utilities", "development-tools"]
 # Internal crates — declared once here so the version requirement is set in lockstep with
 # [workspace.package].version above. Members reference these via `{ workspace = true }` and add
 # their own feature toggles at the use site.
-rag-rat-base = { version = "0.20.0", path = "crates/rag-rat-base", default-features = false }
-rag-rat-clones = { version = "0.20.0", path = "crates/rag-rat-clones", default-features = false }
-rag-rat-db = { version = "0.20.0", path = "crates/rag-rat-db", default-features = false }
-rag-rat-dream = { version = "0.20.0", path = "crates/rag-rat-dream", default-features = false }
-rag-rat-llm = { version = "0.20.0", path = "crates/rag-rat-llm", default-features = false }
-rag-rat-oracle = { version = "0.20.0", path = "crates/rag-rat-oracle", default-features = false }
-rag-rat-oplog = { version = "0.20.0", path = "crates/rag-rat-oplog", default-features = false }
-rag-rat-papertrail = { version = "0.20.0", path = "crates/rag-rat-papertrail", default-features = false }
-rag-rat-query = { version = "0.20.0", path = "crates/rag-rat-query", default-features = false }
-rag-rat-core = { version = "0.20.0", path = "crates/rag-rat-core", default-features = false }
-rag-rat-mcp = { version = "0.20.0", path = "crates/rag-rat-mcp", default-features = false }
-rag-rat-sync = { version = "0.20.0", path = "crates/rag-rat-sync", default-features = false }
+rag-rat-base = { version = "0.21.0", path = "crates/rag-rat-base", default-features = false }
+rag-rat-clones = { version = "0.21.0", path = "crates/rag-rat-clones", default-features = false }
+rag-rat-db = { version = "0.21.0", path = "crates/rag-rat-db", default-features = false }
+rag-rat-dream = { version = "0.21.0", path = "crates/rag-rat-dream", default-features = false }
+rag-rat-llm = { version = "0.21.0", path = "crates/rag-rat-llm", default-features = false }
+rag-rat-oracle = { version = "0.21.0", path = "crates/rag-rat-oracle", default-features = false }
+rag-rat-oplog = { version = "0.21.0", path = "crates/rag-rat-oplog", default-features = false }
+rag-rat-papertrail = { version = "0.21.0", path = "crates/rag-rat-papertrail", default-features = false }
+rag-rat-query = { version = "0.21.0", path = "crates/rag-rat-query", default-features = false }
+rag-rat-core = { version = "0.21.0", path = "crates/rag-rat-core", default-features = false }
+rag-rat-mcp = { version = "0.21.0", path = "crates/rag-rat-mcp", default-features = false }
+rag-rat-sync = { version = "0.21.0", path = "crates/rag-rat-sync", default-features = false }
 anyhow = "1.0"
 # ed25519 device-identity signing for the op-log's signed entry envelope (§C4 layer-1). Default
 # features (incl. `zeroize`, which zeroizes a `SigningKey`'s seed on drop) are kept; the `rand_core`

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "rag-rat",
   "displayName": "rag-rat",
   "description": "Local repo-intelligence index + MCP server: semantic search, symbol/graph navigation, impact-surface preflight, git + GitHub papertrail, and a source-anchored memory graph.",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "author": { "name": "Kristaps Karlsons" },
   "homepage": "https://github.com/cq27-dev/rag-rat",
   "repository": "https://github.com/cq27-dev/rag-rat",
@@ -11,7 +11,7 @@
   "mcpServers": {
     "rag-rat": {
       "command": "npx",
-      "args": ["-y", "@rag-rat/bin@0.20.0", "mcp"]
+      "args": ["-y", "@rag-rat/bin@0.21.0", "mcp"]
     }
   }
 }

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rag-rat",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "Local repo-intelligence index + MCP server: semantic search, symbol/graph navigation, impact-surface preflight, git + GitHub papertrail, and a source-anchored memory graph.",
   "author": { "name": "Kristaps Karlsons", "url": "https://github.com/cq27-dev/rag-rat" },
   "homepage": "https://github.com/cq27-dev/rag-rat",

--- a/plugin/.mcp.json
+++ b/plugin/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "rag-rat": {
       "command": "npx",
-      "args": ["-y", "@rag-rat/bin@0.20.0", "mcp"]
+      "args": ["-y", "@rag-rat/bin@0.21.0", "mcp"]
     }
   }
 }

--- a/plugin/opencode/package.json
+++ b/plugin/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rag-rat/plugin-opencode",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "opencode plugin for rag-rat: self-registers the rag-rat MCP server (semantic search, symbol/graph navigation, impact-surface preflight, repo memory) and wires session/grep/edit hooks through the shared agent-hook.",
   "license": "MIT",
   "type": "module",

--- a/plugin/opencode/rag-rat.ts
+++ b/plugin/opencode/rag-rat.ts
@@ -3,7 +3,7 @@
 // opencode's plugin shape differs from Claude Code / Codex (no hooks.json manifest, no
 // additionalContext channel on tool.execute.before), so this module is a thin shim over the same
 // shared pieces the other harnesses use:
-//   - MCP: registered via the `config` hook as `npx -y @rag-rat/bin@0.20.0<version> mcp` (pinned; kept
+//   - MCP: registered via the `config` hook as `npx -y @rag-rat/bin@0.21.0<version> mcp` (pinned; kept
 //     in lockstep with the release by tools/sync-plugin-version.mjs).
 //   - Hooks: routed through the shared launcher (`../scripts/launch.js --no-install agent-hook`)
 //     when this file lives in the repo's plugin bundle, or — for a standalone single-file install
@@ -35,7 +35,7 @@ const BUNDLED_LAUNCHER = path.join(PLUGIN_DIR, "..", "scripts", "launch.js");
 
 // Single source of truth for the version: the pinned npm package (kept in lockstep with the
 // release by tools/sync-plugin-version.mjs — do not hand-edit the pin).
-const MCP_PACKAGE = "@rag-rat/bin@0.20.0";
+const MCP_PACKAGE = "@rag-rat/bin@0.21.0";
 const VERSION = MCP_PACKAGE.split("@").pop()!;
 
 const TOOL_TIMEOUT_MS = 10_000;

--- a/plugin/skills/init-rag-rat/SKILL.md
+++ b/plugin/skills/init-rag-rat/SKILL.md
@@ -32,7 +32,7 @@ hand-write a config blind, and let a real config load re-check it before indexin
    do **not** use `@latest`, and **don't blindly trust an on-`PATH` `rag-rat`**:
    - If `rag-rat` is on `PATH`, check `rag-rat --version` and use it **only if it matches** the
      plugin/MCP version — a stale global install would build the index with the wrong binary.
-   - Otherwise (or on a version mismatch) use `npx -y @rag-rat/bin@0.20.0 …` — the plugin pins
+   - Otherwise (or on a version mismatch) use `npx -y @rag-rat/bin@0.21.0 …` — the plugin pins
      `@rag-rat/bin` to its own version and caches the binary privately, so this is the
      version-matched CLI; `npx` runs it in the current directory.
 


### PR DESCRIPTION



## 🤖 New release

* `rag-rat-base`: 0.20.0 -> 0.21.0 (⚠ API breaking changes)
* `rag-rat-db`: 0.20.0 -> 0.21.0 (✓ API compatible changes)
* `rag-rat-clones`: 0.20.0 -> 0.21.0 (✓ API compatible changes)
* `rag-rat-llm`: 0.20.0 -> 0.21.0 (✓ API compatible changes)
* `rag-rat-papertrail`: 0.20.0 -> 0.21.0 (⚠ API breaking changes)
* `rag-rat-query`: 0.20.0 -> 0.21.0 (⚠ API breaking changes)
* `rag-rat-dream`: 0.20.0 -> 0.21.0 (✓ API compatible changes)
* `rag-rat-oplog`: 0.20.0 -> 0.21.0 (⚠ API breaking changes)
* `rag-rat-oracle`: 0.20.0 -> 0.21.0 (✓ API compatible changes)
* `rag-rat-core`: 0.20.0 -> 0.21.0 (⚠ API breaking changes)
* `rag-rat-mcp`: 0.20.0 -> 0.21.0 (✓ API compatible changes)
* `rag-rat`: 0.20.0 -> 0.21.0
* `rag-rat-sync`: 0.20.0 -> 0.21.0

### ⚠ `rag-rat-base` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field WatchConfig.pass_cooldown_secs in /tmp/.tmp4DoDNf/rag-rat/crates/rag-rat-base/src/config/types.rs:254
  field WatchConfig.overlay_quiet_secs in /tmp/.tmp4DoDNf/rag-rat/crates/rag-rat-base/src/config/types.rs:266
```

### ⚠ `rag-rat-papertrail` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field PapertrailEvidence.record in /tmp/.tmp4DoDNf/rag-rat/crates/rag-rat-papertrail/src/lib.rs:275
```

### ⚠ `rag-rat-query` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field ImpactSurfaceReport.distilled_records in /tmp/.tmp4DoDNf/rag-rat/crates/rag-rat-query/src/impact/mod.rs:117
  field SearchHit.distilled_records in /tmp/.tmp4DoDNf/rag-rat/crates/rag-rat-query/src/lib.rs:173
  field ReadChunk.distilled_records in /tmp/.tmp4DoDNf/rag-rat/crates/rag-rat-query/src/lib.rs:42
```

### ⚠ `rag-rat-oplog` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field ProjectedState.removed_edges in /tmp/.tmp4DoDNf/rag-rat/crates/rag-rat-oplog/src/project.rs:40
```

### ⚠ `rag-rat-core` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Chunk.symbol_index in /tmp/.tmp4DoDNf/rag-rat/crates/rag-rat-core/src/index/chunker.rs:19

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/inherent_method_missing.ron

Failed in:
  IndexDatabase::index_discover_reporting, previously in file /tmp/.tmpvdJAXQ/rag-rat-core/src/index/incremental.rs:84
  IndexDatabase::index_discover_reporting, previously in file /tmp/.tmpvdJAXQ/rag-rat-core/src/index/incremental.rs:84

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/method_parameter_count_changed.ron

Failed in:
  rag_rat_core::index::IndexDatabase::index_worktree_overlay_paths takes 4 parameters in /tmp/.tmpvdJAXQ/rag-rat-core/src/index/worktree_overlay.rs:591, but now takes 5 parameters in /tmp/.tmp4DoDNf/rag-rat/crates/rag-rat-core/src/index/worktree_overlay.rs:843
  rag_rat_core::IndexDatabase::index_worktree_overlay_paths takes 4 parameters in /tmp/.tmpvdJAXQ/rag-rat-core/src/index/worktree_overlay.rs:591, but now takes 5 parameters in /tmp/.tmp4DoDNf/rag-rat/crates/rag-rat-core/src/index/worktree_overlay.rs:843

--- failure pub_module_level_const_missing: pub module-level const is missing ---

Description:
A public const is missing or renamed
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/pub_module_level_const_missing.ron

Failed in:
  WAL_CHECKPOINT_MIN_BYTES in file /tmp/.tmpvdJAXQ/rag-rat-core/src/index/query_api/db_file_health.rs:19
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `rag-rat-base`

<blockquote>

## [0.21.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.20.0...rag-rat-base-v0.21.0) - 2026-07-24

### Added

- *(init)* add Papertrail (issue tracker) and Distillation wizard steps ([#887](https://github.com/cq27-dev/rag-rat/pull/887))
- *(distill)* default to the validated 30B ephemeral box, with distillation docs ([#876](https://github.com/cq27-dev/rag-rat/pull/876))
- *(distill)* drain prepared snapshots through the configured chat model ([#704](https://github.com/cq27-dev/rag-rat/pull/704)) ([#799](https://github.com/cq27-dev/rag-rat/pull/799))

### Other

- *(watch)* quiet-window overlay skip; reuse repo handles and the recorded delta in the probe ([#857](https://github.com/cq27-dev/rag-rat/pull/857))
- *(watch)* add a minimum inter-pass cooldown to the watcher event loop ([#847](https://github.com/cq27-dev/rag-rat/pull/847))
</blockquote>

## `rag-rat-db`

<blockquote>

## [0.21.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.20.0...rag-rat-base-v0.21.0) - 2026-07-24

### Added

- *(init)* add Papertrail (issue tracker) and Distillation wizard steps ([#887](https://github.com/cq27-dev/rag-rat/pull/887))
- *(distill)* default to the validated 30B ephemeral box, with distillation docs ([#876](https://github.com/cq27-dev/rag-rat/pull/876))
- *(distill)* drain prepared snapshots through the configured chat model ([#704](https://github.com/cq27-dev/rag-rat/pull/704)) ([#799](https://github.com/cq27-dev/rag-rat/pull/799))

### Other

- *(watch)* quiet-window overlay skip; reuse repo handles and the recorded delta in the probe ([#857](https://github.com/cq27-dev/rag-rat/pull/857))
- *(watch)* add a minimum inter-pass cooldown to the watcher event loop ([#847](https://github.com/cq27-dev/rag-rat/pull/847))
</blockquote>

## `rag-rat-clones`

<blockquote>

## [0.21.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.20.0...rag-rat-base-v0.21.0) - 2026-07-24

### Added

- *(init)* add Papertrail (issue tracker) and Distillation wizard steps ([#887](https://github.com/cq27-dev/rag-rat/pull/887))
- *(distill)* default to the validated 30B ephemeral box, with distillation docs ([#876](https://github.com/cq27-dev/rag-rat/pull/876))
- *(distill)* drain prepared snapshots through the configured chat model ([#704](https://github.com/cq27-dev/rag-rat/pull/704)) ([#799](https://github.com/cq27-dev/rag-rat/pull/799))

### Other

- *(watch)* quiet-window overlay skip; reuse repo handles and the recorded delta in the probe ([#857](https://github.com/cq27-dev/rag-rat/pull/857))
- *(watch)* add a minimum inter-pass cooldown to the watcher event loop ([#847](https://github.com/cq27-dev/rag-rat/pull/847))
</blockquote>

## `rag-rat-llm`

<blockquote>

## [0.21.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.20.0...rag-rat-base-v0.21.0) - 2026-07-24

### Added

- *(init)* add Papertrail (issue tracker) and Distillation wizard steps ([#887](https://github.com/cq27-dev/rag-rat/pull/887))
- *(distill)* default to the validated 30B ephemeral box, with distillation docs ([#876](https://github.com/cq27-dev/rag-rat/pull/876))
- *(distill)* drain prepared snapshots through the configured chat model ([#704](https://github.com/cq27-dev/rag-rat/pull/704)) ([#799](https://github.com/cq27-dev/rag-rat/pull/799))

### Other

- *(watch)* quiet-window overlay skip; reuse repo handles and the recorded delta in the probe ([#857](https://github.com/cq27-dev/rag-rat/pull/857))
- *(watch)* add a minimum inter-pass cooldown to the watcher event loop ([#847](https://github.com/cq27-dev/rag-rat/pull/847))
</blockquote>

## `rag-rat-papertrail`

<blockquote>

## [0.21.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.20.0...rag-rat-base-v0.21.0) - 2026-07-24

### Added

- *(init)* add Papertrail (issue tracker) and Distillation wizard steps ([#887](https://github.com/cq27-dev/rag-rat/pull/887))
- *(distill)* default to the validated 30B ephemeral box, with distillation docs ([#876](https://github.com/cq27-dev/rag-rat/pull/876))
- *(distill)* drain prepared snapshots through the configured chat model ([#704](https://github.com/cq27-dev/rag-rat/pull/704)) ([#799](https://github.com/cq27-dev/rag-rat/pull/799))

### Other

- *(watch)* quiet-window overlay skip; reuse repo handles and the recorded delta in the probe ([#857](https://github.com/cq27-dev/rag-rat/pull/857))
- *(watch)* add a minimum inter-pass cooldown to the watcher event loop ([#847](https://github.com/cq27-dev/rag-rat/pull/847))
</blockquote>

## `rag-rat-query`

<blockquote>

## [0.21.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.20.0...rag-rat-base-v0.21.0) - 2026-07-24

### Added

- *(init)* add Papertrail (issue tracker) and Distillation wizard steps ([#887](https://github.com/cq27-dev/rag-rat/pull/887))
- *(distill)* default to the validated 30B ephemeral box, with distillation docs ([#876](https://github.com/cq27-dev/rag-rat/pull/876))
- *(distill)* drain prepared snapshots through the configured chat model ([#704](https://github.com/cq27-dev/rag-rat/pull/704)) ([#799](https://github.com/cq27-dev/rag-rat/pull/799))

### Other

- *(watch)* quiet-window overlay skip; reuse repo handles and the recorded delta in the probe ([#857](https://github.com/cq27-dev/rag-rat/pull/857))
- *(watch)* add a minimum inter-pass cooldown to the watcher event loop ([#847](https://github.com/cq27-dev/rag-rat/pull/847))
</blockquote>

## `rag-rat-dream`

<blockquote>

## [0.21.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.20.0...rag-rat-base-v0.21.0) - 2026-07-24

### Added

- *(init)* add Papertrail (issue tracker) and Distillation wizard steps ([#887](https://github.com/cq27-dev/rag-rat/pull/887))
- *(distill)* default to the validated 30B ephemeral box, with distillation docs ([#876](https://github.com/cq27-dev/rag-rat/pull/876))
- *(distill)* drain prepared snapshots through the configured chat model ([#704](https://github.com/cq27-dev/rag-rat/pull/704)) ([#799](https://github.com/cq27-dev/rag-rat/pull/799))

### Other

- *(watch)* quiet-window overlay skip; reuse repo handles and the recorded delta in the probe ([#857](https://github.com/cq27-dev/rag-rat/pull/857))
- *(watch)* add a minimum inter-pass cooldown to the watcher event loop ([#847](https://github.com/cq27-dev/rag-rat/pull/847))
</blockquote>

## `rag-rat-oplog`

<blockquote>

## [0.21.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.20.0...rag-rat-base-v0.21.0) - 2026-07-24

### Added

- *(init)* add Papertrail (issue tracker) and Distillation wizard steps ([#887](https://github.com/cq27-dev/rag-rat/pull/887))
- *(distill)* default to the validated 30B ephemeral box, with distillation docs ([#876](https://github.com/cq27-dev/rag-rat/pull/876))
- *(distill)* drain prepared snapshots through the configured chat model ([#704](https://github.com/cq27-dev/rag-rat/pull/704)) ([#799](https://github.com/cq27-dev/rag-rat/pull/799))

### Other

- *(watch)* quiet-window overlay skip; reuse repo handles and the recorded delta in the probe ([#857](https://github.com/cq27-dev/rag-rat/pull/857))
- *(watch)* add a minimum inter-pass cooldown to the watcher event loop ([#847](https://github.com/cq27-dev/rag-rat/pull/847))
</blockquote>

## `rag-rat-oracle`

<blockquote>

## [0.21.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.20.0...rag-rat-base-v0.21.0) - 2026-07-24

### Added

- *(init)* add Papertrail (issue tracker) and Distillation wizard steps ([#887](https://github.com/cq27-dev/rag-rat/pull/887))
- *(distill)* default to the validated 30B ephemeral box, with distillation docs ([#876](https://github.com/cq27-dev/rag-rat/pull/876))
- *(distill)* drain prepared snapshots through the configured chat model ([#704](https://github.com/cq27-dev/rag-rat/pull/704)) ([#799](https://github.com/cq27-dev/rag-rat/pull/799))

### Other

- *(watch)* quiet-window overlay skip; reuse repo handles and the recorded delta in the probe ([#857](https://github.com/cq27-dev/rag-rat/pull/857))
- *(watch)* add a minimum inter-pass cooldown to the watcher event loop ([#847](https://github.com/cq27-dev/rag-rat/pull/847))
</blockquote>

## `rag-rat-core`

<blockquote>

## [0.21.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.20.0...rag-rat-base-v0.21.0) - 2026-07-24

### Added

- *(init)* add Papertrail (issue tracker) and Distillation wizard steps ([#887](https://github.com/cq27-dev/rag-rat/pull/887))
- *(distill)* default to the validated 30B ephemeral box, with distillation docs ([#876](https://github.com/cq27-dev/rag-rat/pull/876))
- *(distill)* drain prepared snapshots through the configured chat model ([#704](https://github.com/cq27-dev/rag-rat/pull/704)) ([#799](https://github.com/cq27-dev/rag-rat/pull/799))

### Other

- *(watch)* quiet-window overlay skip; reuse repo handles and the recorded delta in the probe ([#857](https://github.com/cq27-dev/rag-rat/pull/857))
- *(watch)* add a minimum inter-pass cooldown to the watcher event loop ([#847](https://github.com/cq27-dev/rag-rat/pull/847))
</blockquote>

## `rag-rat-mcp`

<blockquote>

## [0.21.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.20.0...rag-rat-base-v0.21.0) - 2026-07-24

### Added

- *(init)* add Papertrail (issue tracker) and Distillation wizard steps ([#887](https://github.com/cq27-dev/rag-rat/pull/887))
- *(distill)* default to the validated 30B ephemeral box, with distillation docs ([#876](https://github.com/cq27-dev/rag-rat/pull/876))
- *(distill)* drain prepared snapshots through the configured chat model ([#704](https://github.com/cq27-dev/rag-rat/pull/704)) ([#799](https://github.com/cq27-dev/rag-rat/pull/799))

### Other

- *(watch)* quiet-window overlay skip; reuse repo handles and the recorded delta in the probe ([#857](https://github.com/cq27-dev/rag-rat/pull/857))
- *(watch)* add a minimum inter-pass cooldown to the watcher event loop ([#847](https://github.com/cq27-dev/rag-rat/pull/847))
</blockquote>

## `rag-rat`

<blockquote>

## [0.21.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.20.0...rag-rat-base-v0.21.0) - 2026-07-24

### Added

- *(init)* add Papertrail (issue tracker) and Distillation wizard steps ([#887](https://github.com/cq27-dev/rag-rat/pull/887))
- *(distill)* default to the validated 30B ephemeral box, with distillation docs ([#876](https://github.com/cq27-dev/rag-rat/pull/876))
- *(distill)* drain prepared snapshots through the configured chat model ([#704](https://github.com/cq27-dev/rag-rat/pull/704)) ([#799](https://github.com/cq27-dev/rag-rat/pull/799))

### Other

- *(watch)* quiet-window overlay skip; reuse repo handles and the recorded delta in the probe ([#857](https://github.com/cq27-dev/rag-rat/pull/857))
- *(watch)* add a minimum inter-pass cooldown to the watcher event loop ([#847](https://github.com/cq27-dev/rag-rat/pull/847))
</blockquote>

## `rag-rat-sync`

<blockquote>

## [0.21.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.20.0...rag-rat-base-v0.21.0) - 2026-07-24

### Added

- *(init)* add Papertrail (issue tracker) and Distillation wizard steps ([#887](https://github.com/cq27-dev/rag-rat/pull/887))
- *(distill)* default to the validated 30B ephemeral box, with distillation docs ([#876](https://github.com/cq27-dev/rag-rat/pull/876))
- *(distill)* drain prepared snapshots through the configured chat model ([#704](https://github.com/cq27-dev/rag-rat/pull/704)) ([#799](https://github.com/cq27-dev/rag-rat/pull/799))

### Other

- *(watch)* quiet-window overlay skip; reuse repo handles and the recorded delta in the probe ([#857](https://github.com/cq27-dev/rag-rat/pull/857))
- *(watch)* add a minimum inter-pass cooldown to the watcher event loop ([#847](https://github.com/cq27-dev/rag-rat/pull/847))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).