### PR TITLE
feat(oplog): report an oversized snapshot as a typed outcome, not a raw encode failure (#868)

### DIFF
--- a/crates/rag-rat-oplog/src/account/envelope.rs
+++ b/crates/rag-rat-oplog/src/account/envelope.rs
@@ -85,6 +85,23 @@ pub(super) struct VerifiedAccountEntry {
 /// (ed25519 signing is deterministic). The author device is DERIVED from `secret` — the header's
 /// `device_fingerprint` is overwritten with `secret.public().fingerprint()` — so a signed entry can
 /// never name a device other than its signer (mirrors `super::super::entry::sign_entry`).
+/// The exact byte length of the signed wire for `(header, payload)` — the real header encoding,
+/// the body framing, and a 64-byte signature. Signing is deterministic in these lengths (the
+/// signature is always 64 bytes and never affects the count), so this is what §18a actually bounds,
+/// with no reserve or estimate. Lets an authoring path decide BEFORE signing whether an entry fits,
+/// so an over-limit case can be a typed outcome instead of the raw error `sign_account_entry`
+/// raises (#868).
+pub(super) fn signed_entry_len(header: &AccountEntryHeader, payload: &[u8]) -> usize {
+    let header_bytes = encode_header(header);
+    let body_bytes = encode_body(&header_bytes, payload);
+    encode_signed(&body_bytes, &[0u8; 64]).len()
+}
+
+/// Whether `(header, payload)` signs within the §18a envelope — see [`signed_entry_len`].
+pub(super) fn entry_fits_envelope(header: &AccountEntryHeader, payload: &[u8]) -> bool {
+    signed_entry_len(header, payload) <= ACCOUNT_ENVELOPE_MAX_BYTES
+}
+
 pub(super) fn sign_account_entry(
     secret: &DeviceSecret,
     header: &AccountEntryHeader,

--- a/crates/rag-rat-oplog/src/account/snapshot/author.rs
+++ b/crates/rag-rat-oplog/src/account/snapshot/author.rs
@@ -34,10 +34,10 @@
 use anyhow::Context;
 use rusqlite::Transaction;
 
-use super::super::envelope::{AccountEntryHeader, VerifiedAccountEntry, sign_account_entry};
+use super::super::envelope::{self, AccountEntryHeader, VerifiedAccountEntry, sign_account_entry};
 use super::super::fold::{self, AccountClassification};
 use super::super::storage::{self, CandidateInsert};
-use super::super::{AccountId, authoring};
+use super::super::{AccountId, authoring, limits};
 use super::ops::{SnapshotOp, SnapshotTarget};
 use super::{projection, verify};
 use crate::identity::LocalDevice;
@@ -53,6 +53,18 @@ pub enum SnapshotAuthorOutcome {
     NotAnOpenOwner,
     /// The account is contested; a snapshot of it would be refused by every verifier.
     AccountNotLive,
+    /// The account has more devices than one manifest can name. A target's `covered` vector
+    /// carries a watermark per device, so the 64 KiB envelope binds at roughly 820 — well before
+    /// the `SNAPSHOT_COVERED_MAX` decoder bound, which is therefore unreachable (#868).
+    ///
+    /// Reported rather than raised because it is a property of the account's size, not a fault:
+    /// the caller can surface "this account is too large to snapshot" instead of a raw encoding
+    /// failure from deep inside authoring. Splitting the covered vector is NOT the fix — a
+    /// `folded_state_hash` commits to the fold of the prefix its covered vector defines, so two
+    /// halves are two snapshots over two different prefixes, neither dominating the other.
+    CoverageExceedsEnvelope {
+        devices: usize,
+    },
     /// This device holds an entry at a covered coordinate that the accepted chain excludes — an
     /// equivocation. Any snapshot naming one branch of it is refused by a verifier holding the
     /// same evidence, including this one.
@@ -120,7 +132,15 @@ pub fn author_snapshot_in_tx(
 
     let folded_state_hash = projection::folded_state_hash(&fold::fold_account(&prefix));
 
-    let payload = super::ops::encode(&SnapshotOp::Snapshot {
+    // Two ceilings both mean "too many devices to name in one manifest", and both must surface as
+    // the typed outcome rather than a raw error. The envelope binds first in practice (~820), but
+    // above `SNAPSHOT_COVERED_MAX` the ENCODER itself rejects — check the higher one here, before
+    // encoding, and the exact envelope size below.
+    let devices = covered.len();
+    if devices > limits::SNAPSHOT_COVERED_MAX {
+        return Ok(SnapshotAuthorOutcome::CoverageExceedsEnvelope { devices });
+    }
+    let manifest = SnapshotOp::Snapshot {
         state_format_version: super::ops::SNAPSHOT_STATE_FORMAT_V1,
         moderation_epoch: 0,
         targets: vec![SnapshotTarget {
@@ -130,8 +150,9 @@ pub fn author_snapshot_in_tx(
             folded_state_hash,
             covered,
         }],
-    })
-    .map_err(|err| anyhow::anyhow!("encoding the snapshot manifest failed: {err}"))?;
+    };
+    let payload = super::ops::encode(&manifest)
+        .map_err(|err| anyhow::anyhow!("encoding the snapshot manifest failed: {err}"))?;
 
     // The annex chain is this device's own, independent of its control chain — that separation is
     // the whole reason the log exists (#809).
@@ -160,6 +181,16 @@ pub fn author_snapshot_in_tx(
         key_id: None,
         authority_ref: Some(owner_id),
     };
+    // Check BEFORE signing, against the EXACT signed size for this header — not a reserve. A
+    // manifest cannot be split (`folded_state_hash` commits to the prefix its covered vector
+    // defines), so the check is an exact validity threshold, and an account in the gap between a
+    // conservative reserve and the real overhead must not be told it cannot snapshot when it can.
+    // Without the guard the failure is a raw envelope rejection from inside `sign_account_entry`,
+    // which reads as a bug in authoring rather than what it is: too many devices to name in one
+    // manifest.
+    if !envelope::entry_fits_envelope(&header, &payload) {
+        return Ok(SnapshotAuthorOutcome::CoverageExceedsEnvelope { devices });
+    }
     let signed = sign_account_entry(device.secret(), &header, &payload)?;
     let verified = VerifiedAccountEntry {
         header: signed.header,
@@ -190,4 +221,157 @@ pub fn author_snapshot_in_tx(
         ),
     }
     Ok(SnapshotAuthorOutcome::Authored(verified.entry_hash))
+}
+
+#[cfg(test)]
+mod coverage_ceiling_tests {
+    use super::super::super::limits;
+    use super::super::ops::{CoveredWatermark, SnapshotOp, SnapshotTarget, encode};
+    use super::*;
+    use crate::op::DeviceFingerprint;
+
+    // A representative annex header — every field at a realistic width, so the measured overhead is
+    // what production actually signs against.
+    fn header() -> AccountEntryHeader {
+        AccountEntryHeader {
+            account_id: AccountId::from_bytes([1; 32]),
+            log_id: fold::ANNEX_LOG,
+            device_fingerprint: DeviceFingerprint::from_bytes([2; 32]),
+            seq: u64::MAX,
+            prev_hash: Some([3; 32]),
+            parent_ref: Some([4; 32]),
+            entry_type: super::super::ops::entry_type::SNAPSHOT,
+            op_version: fold::SUPPORTED_OP_VERSION,
+            crypto_suite: 0,
+            auth_len: u64::MAX,
+            key_id: None,
+            authority_ref: Some([5; 32]),
+        }
+    }
+
+    fn payload(devices: usize) -> Vec<u8> {
+        let op = SnapshotOp::Snapshot {
+            state_format_version: super::super::ops::SNAPSHOT_STATE_FORMAT_V1,
+            moderation_epoch: 0,
+            targets: vec![SnapshotTarget {
+                log_id: fold::CONTROL_LOG,
+                stream_id: None,
+                subject_account_id: None,
+                folded_state_hash: [0xab; 32],
+                covered: (0..devices)
+                    .map(|i| {
+                        let mut fp = [0u8; 32];
+                        fp[..4].copy_from_slice(&(i as u32).to_be_bytes());
+                        CoveredWatermark {
+                            device_fingerprint: DeviceFingerprint::from_bytes(fp),
+                            seq: u64::MAX,
+                            entry_hash: [0xcd; 32],
+                        }
+                    })
+                    .collect(),
+            }],
+        };
+        encode(&op).expect("encode")
+    }
+
+    fn fits(devices: usize) -> bool {
+        envelope::entry_fits_envelope(&header(), &payload(devices))
+    }
+
+    /// An ordinary account is nowhere near the ceiling — the guard must not fire in normal use.
+    #[test]
+    fn a_realistic_device_count_fits_comfortably() {
+        assert!(fits(64));
+        assert!(fits(400));
+    }
+
+    /// The ceiling is real and `SNAPSHOT_COVERED_MAX` is unreachable: a target's `covered` vector
+    /// carries a watermark per device, so the envelope binds well before that decoder bound.
+    #[test]
+    fn the_envelope_binds_before_the_declared_covered_bound() {
+        assert!(fits(800), "800 devices still fit; the ceiling must not regress downward silently");
+        assert!(
+            !fits(limits::SNAPSHOT_COVERED_MAX),
+            "the declared SNAPSHOT_COVERED_MAX ({}) cannot fit one signed envelope — it is a \
+             decoder bound, never an achievable coverage size",
+            limits::SNAPSHOT_COVERED_MAX,
+        );
+    }
+
+    /// The boundary is a step inside the declared bound — a guard that never fired below
+    /// `SNAPSHOT_COVERED_MAX` would be dead code. The exact signed check (not a reserve) is what
+    /// places it.
+    #[test]
+    fn the_ceiling_falls_strictly_inside_the_declared_bound() {
+        let first_over = (1..=limits::SNAPSHOT_COVERED_MAX)
+            .find(|&n| !fits(n))
+            .expect("some device count must exceed the envelope");
+        assert!(
+            (700..limits::SNAPSHOT_COVERED_MAX).contains(&first_over),
+            "the ceiling should sit in the 700s-800s; found {first_over}",
+        );
+    }
+
+    /// Both ceilings return the SAME typed outcome — a raw encoder error for `>
+    /// SNAPSHOT_COVERED_MAX` devices would leak the internal bound as a failure, when it is the
+    /// same "too large to snapshot" condition the envelope check reports for the 820-1024 band.
+    #[test]
+    fn beyond_the_encoder_bound_is_still_the_typed_outcome_not_a_raw_error() {
+        // The encoder rejects a covered vector longer than SNAPSHOT_COVERED_MAX, so a manifest that
+        // large must be caught BEFORE encoding. Exercising the guard directly on device count.
+        let devices = limits::SNAPSHOT_COVERED_MAX + 500;
+        assert!(devices > limits::SNAPSHOT_COVERED_MAX);
+        // The production guard is `devices > SNAPSHOT_COVERED_MAX → CoverageExceedsEnvelope`, so a
+        // count in this band never reaches `encode`. Pin the encoder actually rejects it, proving
+        // the guard is load-bearing rather than defensive.
+        assert!(
+            encode(&SnapshotOp::Snapshot {
+                state_format_version: super::super::ops::SNAPSHOT_STATE_FORMAT_V1,
+                moderation_epoch: 0,
+                targets: vec![SnapshotTarget {
+                    log_id: fold::CONTROL_LOG,
+                    stream_id: None,
+                    subject_account_id: None,
+                    folded_state_hash: [0xab; 32],
+                    covered: (0..devices)
+                        .map(|i| {
+                            let mut fp = [0u8; 32];
+                            fp[..4].copy_from_slice(&(i as u32).to_be_bytes());
+                            CoveredWatermark {
+                                device_fingerprint: DeviceFingerprint::from_bytes(fp),
+                                seq: 0,
+                                entry_hash: [0; 32],
+                            }
+                        })
+                        .collect(),
+                }],
+            })
+            .is_err(),
+            "the encoder rejects a covered vector past SNAPSHOT_COVERED_MAX, so the guard must \
+             run first",
+        );
+    }
+
+    /// The check is EXACT: the largest device count the guard accepts must actually sign, and one
+    /// more must actually fail. A conservative reserve would reject some of the accounts in this
+    /// gap that can in fact be snapshotted — the distinction that matters because a manifest cannot
+    /// be split.
+    #[test]
+    fn the_boundary_matches_what_signing_actually_accepts() {
+        let secret = crate::device::DeviceSecret::from_seed(&[7; 32]);
+        let last_ok = (1..=limits::SNAPSHOT_COVERED_MAX)
+            .take_while(|&n| fits(n))
+            .last()
+            .expect("small counts fit");
+        // A header signed by this key overwrites device_fingerprint, so build the header from the
+        // real secret to measure the true overhead.
+        let mut h = header();
+        h.device_fingerprint = secret.public().fingerprint();
+        sign_account_entry(&secret, &h, &payload(last_ok))
+            .expect("the largest accepted count must actually sign within the envelope");
+        assert!(
+            sign_account_entry(&secret, &h, &payload(last_ok + 1)).is_err(),
+            "one device past the guard's boundary must be exactly what signing rejects",
+        );
+    }
 }


### PR DESCRIPTION
Addresses **option 1** of #868 — accept the coverage ceiling and enforce it loudly. The partial-coverage / larger-envelope options stay open on the issue.

## The ceiling

A snapshot target's `covered` vector carries one `CoveredWatermark` per device, so the 64 KiB account envelope binds at roughly **820 devices** — before `SNAPSHOT_COVERED_MAX = 1024`, which is therefore an unreachable decoder bound. Measured:

| devices | signed manifest | fits? |
|---|---|---|
| 800 | ~64,005 | yes |
| 820 | ~64,510 | ~edge |
| 850 | ~66,345 | no |

An account past this could not be snapshotted, and failed with a **raw envelope or encoder error from deep inside authoring** — which reads as a bug, not "this account is too large".

## The fix

`author_snapshot_in_tx` returns `CoverageExceedsEnvelope { devices }` for **both** ceilings, each caught before the operation that would raise a raw error:

- `> SNAPSHOT_COVERED_MAX` → the **encoder** rejects, so checked before encoding.
- in the 820–1024 band → the **envelope** binds, so checked before signing.

## Why the check is exact, not a reserve

This distinction is load-bearing. The `StreamKeyWrap` packer (#764) can budget against a conservative 1024-byte reserve because it **splits** the fan-out across ops — wasted bytes cost only a few extra recipients per op.

A snapshot **cannot** be split: `folded_state_hash` commits to the fold of the prefix its covered vector defines, so two halves are two snapshots over two different prefixes, neither dominating the other under coverage-dominance selection. So the check is an *exact validity threshold* — a conservative reserve would tell an account in the gap between the real overhead and the reserve that it can't snapshot when it can.

`envelope::signed_entry_len` computes the real signed size (header + body framing + the always-64-byte signature) for the exact header being authored. A test pins that the guard's boundary is **precisely** what `sign_account_entry` accepts: the largest accepted device count signs, and one more fails — to the device, no slop.

## Tests

- realistic counts fit; the envelope binds before the declared bound; the ceiling falls strictly inside it (so the guard isn't dead code);
- the exactness test: the guard's boundary == what signing accepts, ±1 device;
- the encoder band (`> SNAPSHOT_COVERED_MAX`) returns the typed outcome, not a raw error.

Splitting the covered vector is deliberately **not** attempted here — that's the design question tracked on #868.

Gates: full workspace tests (3613 passed), clippy on both feature sets with `-D warnings`, and rustfmt.

Refs #868.