### PR TITLE
fix(cookbook): gate Modal readiness on the serve-probe, not the hang-prone waitUntilReady

### DIFF
--- a/cookbook/package.json
+++ b/cookbook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rag-rat/cookbook",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Ephemeral remote-runtime provisioning recipes for rag-rat. rag-rat (Rust) spawns a recipe as a subprocess, reads a typed JSONL event stream from its stdout (status/log/ready/error), embeds against the endpoint, then signals teardown.",
   "license": "MIT",
   "repository": {

--- a/cookbook/package.json
+++ b/cookbook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rag-rat/cookbook",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Ephemeral remote-runtime provisioning recipes for rag-rat. rag-rat (Rust) spawns a recipe as a subprocess, reads a typed JSONL event stream from its stdout (status/log/ready/error), embeds against the endpoint, then signals teardown.",
   "license": "MIT",
   "repository": {

--- a/cookbook/recipes/modal.mts
+++ b/cookbook/recipes/modal.mts
@@ -37,7 +37,7 @@
  */
 
 import { randomUUID } from "node:crypto";
-import { AlreadyExistsError, ModalClient, NotFoundError, Probe } from "modal";
+import { AlreadyExistsError, ModalClient, NotFoundError } from "modal";
 import type { Logger as ModalLogger, Sandbox } from "modal";
 
 import {
@@ -250,7 +250,10 @@ async function provision(ctx: ProvisionContext<ModalHandle>): Promise<Provisione
         },
         ...(cacheVolume !== null ? { volumes: { [HF_CACHE_MOUNT_PATH]: cacheVolume } } : {}),
         encryptedPorts: [port],
-        readinessProbe: Probe.withTcp(port, { intervalMs: 1000 }),
+        // No SDK `readinessProbe`/`waitUntilReady`: its TCP-probe RPC has hung indefinitely on a cold
+        // vLLM boot even after the port was bound and the tunnel already served HTTP 200 (the box
+        // billed the whole time, no `ready` ever emitted). Readiness is instead the endpoint
+        // serve-probe below (`verifyChat`/`verifyEmbed`) — the authoritative, backend-agnostic signal.
         timeoutMs: BOX_MAX_LIFETIME_MS,
         idleTimeoutMs: idleWindowMs(provisionTimeoutMs),
         ...(gpu !== null ? { gpu } : {}),
@@ -294,14 +297,43 @@ async function provision(ctx: ProvisionContext<ModalHandle>): Promise<Provisione
   ctx.onBox(handle);
   log("info", `sandbox created: ${sb.sandboxId ?? "(id unavailable)"}`);
 
-  ctx.status("provisioning", `waiting for ${spec.backend} to listen on port ${port}`);
-  const readinessTimeoutMs = assertBudgetRemaining(deadline, "sandbox readiness");
+  // Resolve the public tunnel URL. The tunnel is allocated at creation and returns independent of
+  // whether the in-box server is listening yet — the serving wait is the endpoint poll below.
+  ctx.status("provisioning", `resolving the tunnel for ${spec.backend} on port ${port}`);
+  const tunnels = await withBudget(deadline, "sb.tunnels", () => sb.tunnels());
+  const tunnel = tunnels[port];
+  if (tunnel === undefined) {
+    throw new Error(`no tunnel for port ${port}; got ports [${Object.keys(tunnels).join(", ")}]`);
+  }
+  const endpoint = tunnel.url;
+  log("info", `tunnel up: ${endpoint}`);
+
+  // Load the model. infinity/vLLM auto-download on boot (nothing to do); ollama boots empty, so pull
+  // the model into the running server via an in-box exec. `sb.exec` rides the command router (attached
+  // at creation), not the served port, so it does not need the serve-probe to have passed first.
+  if (spec.modelLoad === "ollama-pull") {
+    await pullOllamaModel(sb, input.model, deadline, ctx);
+  }
+
+  // THE readiness gate: poll the tunnel until the server actually SERVES (or the budget elapses).
+  // Replaces `sb.waitUntilReady()` (see the create call) — a box can be reachable while the model is
+  // still loading, so this retries until a real completion/vector, tolerating connection-refused
+  // during boot. Budget = the time REMAINING until the shared deadline. The probe matches the
+  // capability: a chat box gets a chat-completions ping, an embed box an embeddings one. On failure,
+  // surface the sandbox's own output tail + exit code so a boot crash (OOM, bad model id) is
+  // debuggable, not just an opaque "probe timed out".
+  const servePath = spec.servePath(capability);
+  ctx.status(
+    "verifying",
+    `probing ${servePath} for a real ${capability === "chat" ? "completion" : "vector"}`,
+  );
+  const verifyBudgetMs = assertBudgetRemaining(deadline, `${capability} verification`);
   try {
-    await raceWithTimeout(
-      () => sb.waitUntilReady(readinessTimeoutMs),
-      readinessTimeoutMs,
-      "sandbox.waitUntilReady",
-    );
+    if (capability === "chat") {
+      await verifyChat(endpoint, { model: input.model, chatPath: servePath, budgetMs: verifyBudgetMs });
+    } else {
+      await verifyEmbed(endpoint, { model: input.model, embedPath: servePath, budgetMs: verifyBudgetMs });
+    }
   } catch (cause) {
     const diagnosticMs = Math.min(FAILURE_LOG_SETTLE_MS, Math.max(0, deadline - Date.now()));
     const [, exitCode] = await Promise.all([
@@ -321,36 +353,7 @@ async function provision(ctx: ProvisionContext<ModalHandle>): Promise<Provisione
       { cause },
     );
   }
-  log("info", `${spec.backend} is listening`);
-
-  // Load the model. infinity/vLLM auto-download on boot (nothing to do); ollama boots empty, so pull
-  // the model into the running server via an in-box exec.
-  if (spec.modelLoad === "ollama-pull") {
-    await pullOllamaModel(sb, input.model, deadline, ctx);
-  }
-
-  // Resolve the public tunnel URL for the served port.
-  const tunnels = await withBudget(deadline, "sb.tunnels", () => sb.tunnels());
-  const tunnel = tunnels[port];
-  if (tunnel === undefined) {
-    throw new Error(`no tunnel for port ${port}; got ports [${Object.keys(tunnels).join(", ")}]`);
-  }
-  const endpoint = tunnel.url;
-  log("info", `tunnel up: ${endpoint}`);
-
-  // Verify the server actually serves before we emit `ready`. This catches a box that booted but
-  // isn't serving (the whole point of waiting before the ready event). Budget = the time REMAINING
-  // until the shared deadline (create + pull already consumed some); throws if it's spent. The probe
-  // matches the capability: a chat box gets a chat-completions ping, an embed box an embeddings one.
-  const servePath = spec.servePath(capability);
-  ctx.status("verifying", `probing ${servePath} for a real ${capability === "chat" ? "completion" : "vector"}`);
-  const verifyBudgetMs = assertBudgetRemaining(deadline, `${capability} verification`);
-  if (capability === "chat") {
-    await verifyChat(endpoint, { model: input.model, chatPath: servePath, budgetMs: verifyBudgetMs });
-  } else {
-    await verifyEmbed(endpoint, { model: input.model, embedPath: servePath, budgetMs: verifyBudgetMs });
-  }
-  log("info", `${capability} verification passed; box is serving`);
+  log("info", `${spec.backend} is serving`);
   if (cachePublication !== null) cachePublication.verified = true;
 
   // Open tunnel via encryptedPorts → no per-request token needed. auth_token stays null.

--- a/cookbook/recipes/modal.mts
+++ b/cookbook/recipes/modal.mts
@@ -52,6 +52,7 @@ import {
   runRecipe,
   verifyChat,
   verifyEmbed,
+  waitForServerListening,
   withBudget,
 } from "../src/contract.js";
 import { assertCapabilitySupported, selectBackendSpec } from "./backends.mjs";
@@ -309,9 +310,15 @@ async function provision(ctx: ProvisionContext<ModalHandle>): Promise<Provisione
   log("info", `tunnel up: ${endpoint}`);
 
   // Load the model. infinity/vLLM auto-download on boot (nothing to do); ollama boots empty, so pull
-  // the model into the running server via an in-box exec. `sb.exec` rides the command router (attached
-  // at creation), not the served port, so it does not need the serve-probe to have passed first.
+  // the model into the running server via an in-box exec. The pull connects to the local ollama
+  // server and does NOT retry on connection refusal, so gate it on an HTTP liveness poll first — the
+  // SDK readiness wait that used to gate this is gone (it hung on cold vLLM boots). vLLM/infinity load
+  // on boot and are gated by the serve-probe below instead, so they skip both steps.
   if (spec.modelLoad === "ollama-pull") {
+    ctx.status("provisioning", `waiting for ${spec.backend} to listen on ${endpoint}`);
+    await waitForServerListening(endpoint, {
+      budgetMs: assertBudgetRemaining(deadline, "server listening"),
+    });
     await pullOllamaModel(sb, input.model, deadline, ctx);
   }
 

--- a/cookbook/src/contract.ts
+++ b/cookbook/src/contract.ts
@@ -553,6 +553,44 @@ export async function pollUntil<T>(url: string, options: PollUntilOptions<T>): P
   );
 }
 
+/**
+ * Poll `endpoint` with a bare GET until the in-box server is LISTENING (it answers with a non-5xx
+ * status), or the budget elapses. A lightweight liveness gate that — unlike {@link verifyChat} /
+ * {@link verifyEmbed} — does NOT require the model to be loaded, so it fits BEFORE the ollama model
+ * pull: `ollama pull` connects to the local server and exits on connection refusal with no retry of
+ * its own, so it must not run until the server is up. Connection-refused (server still booting) and a
+ * gateway 5xx (the tunnel proxying to a not-yet-listening port) are both retried; any status < 500
+ * means the server itself answered. Throws if the budget runs out.
+ */
+export async function waitForServerListening(
+  endpoint: string,
+  options: { budgetMs: number; pollIntervalMs?: number; perAttemptTimeoutMs?: number },
+): Promise<void> {
+  const pollIntervalMs = options.pollIntervalMs ?? 1000;
+  const perAttemptTimeoutMs = options.perAttemptTimeoutMs ?? 5000;
+  const deadline = Date.now() + options.budgetMs;
+  let lastError = "(no attempt made)";
+  let attempt = 0;
+  while (Date.now() < deadline) {
+    const attemptTimeout = Math.min(perAttemptTimeoutMs, remainingBudgetMs(deadline));
+    if (attemptTimeout < 250) break;
+    attempt += 1;
+    try {
+      const res = await fetchWithTimeout(endpoint, { method: "GET" }, attemptTimeout);
+      if (res.status < 500) return;
+      lastError = `HTTP ${res.status} ${res.statusText}`;
+    } catch (cause) {
+      lastError = errorMessage(cause);
+    }
+    if (Date.now() + pollIntervalMs >= deadline) break;
+    log("info", `server-listening probe attempt ${attempt} not ready (${lastError}); retrying…`);
+    await sleep(pollIntervalMs);
+  }
+  throw new Error(
+    `server did not start listening within ${options.budgetMs}ms; last error: ${lastError}`,
+  );
+}
+
 /** Default delay between embed-readiness probes (ms). */
 const VERIFY_EMBED_POLL_INTERVAL_MS = 3_000;
 /**

--- a/cookbook/test/modal-support.test.mts
+++ b/cookbook/test/modal-support.test.mts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import type { LogLevel } from "../src/contract.js";
+import { waitForServerListening } from "../src/contract.js";
 import { selectBackendSpec } from "../recipes/backends.mjs";
 import {
   HF_CACHE_MOUNT_PATH,
@@ -166,4 +167,38 @@ test("a locked stream cannot create an unhandled pump rejection", async () => {
   await owner.cancel();
   owner.releaseLock();
   assert.equal(capture.failureTail(), "");
+});
+
+test("waitForServerListening retries connection-refused and gateway 5xx, then returns on a server answer", async () => {
+  const original = globalThis.fetch;
+  const responses: Array<() => Promise<Response>> = [
+    () => Promise.reject(new Error("ECONNREFUSED")), // server still booting
+    () => Promise.resolve(new Response("bad gateway", { status: 502 })), // tunnel up, port not yet
+    () => Promise.resolve(new Response("Ollama is running", { status: 200 })), // listening
+  ];
+  let calls = 0;
+  globalThis.fetch = (() => {
+    const next = responses[Math.min(calls, responses.length - 1)]!;
+    calls += 1;
+    return next();
+  }) as typeof fetch;
+  try {
+    await waitForServerListening("https://box.example", { budgetMs: 5_000, pollIntervalMs: 1 });
+    assert.equal(calls, 3);
+  } finally {
+    globalThis.fetch = original;
+  }
+});
+
+test("waitForServerListening throws when the server never listens within the budget", async () => {
+  const original = globalThis.fetch;
+  globalThis.fetch = (() => Promise.reject(new Error("ECONNREFUSED"))) as typeof fetch;
+  try {
+    await assert.rejects(
+      () => waitForServerListening("https://box.example", { budgetMs: 30, pollIntervalMs: 1 }),
+      /did not start listening/,
+    );
+  } finally {
+    globalThis.fetch = original;
+  }
 });


### PR DESCRIPTION
The Modal recipe waited on `sb.waitUntilReady()` (a TCP `readinessProbe` RPC) before resolving the tunnel and verifying serving. On a cold vLLM boot that RPC hangs indefinitely even after uvicorn has bound the port and the tunnel already serves HTTP 200 — the box bills the whole time and never emits `ready`, so provisioning stalls to the budget deadline and tears the box down with zero work done. (Confirmed on a 30B-FP8/L40S box: the tunnel served `curl` 200 and the Python SDK's `tunnels()` resolved instantly while the JS `waitUntilReady` was stuck 20+ min.)

## Changes
- **Readiness = the endpoint serve-probe.** Resolve the tunnel first (it is allocated at creation, independent of the in-box server) and make `verifyChat`/`verifyEmbed` the sole readiness gate — they hit the exact route the caller uses and already tolerate connection-refused while the box boots, so the SDK readiness wait was redundant as well as unreliable. Drop the now-dead `readinessProbe` + `Probe` import; boot-failure diagnostics (sandbox output tail + exit code) move onto the verify path.
- **Gate the ollama pull on a liveness poll.** `ollama pull` connects to the local server and exits on connection refusal with no retry, so it must not race ahead of the server binding (which `waitUntilReady` used to gate). New `waitForServerListening` (a bare-GET poll that retries connection-refused and gateway 5xx, returning on any status < 500) runs before the pull; vLLM/infinity load on boot and are gated by the serve-probe, so they skip it.

Published as `@rag-rat/cookbook@0.8.2`. Typecheck + tests green, including new liveness-poll coverage.