### PR TITLE
fix(distill): count repaired replies per serde rung so the clean-guided rate is exact

### DIFF
--- a/crates/rag-rat-core/src/distill/drain.rs
+++ b/crates/rag-rat-core/src/distill/drain.rs
@@ -32,10 +32,10 @@ pub struct DistillDrainReport {
     pub rung_serde: u64,
     pub rung_unguided: u64,
     pub rung_tolerant: u64,
-    /// Of the accepted replies, how many passed only after `RecordOutput::normalize` repaired the
-    /// model's formatting (a demoted backtick phrase or a deduped id). Orthogonal to the rungs, so
-    /// the genuinely-clean guided rate is `rung_serde` minus the serde-rung share of this.
-    pub repaired: u64,
+    /// Of the replies accepted on the SERDE rung, how many passed only because
+    /// `RecordOutput::normalize` repaired the model's formatting (a demoted backtick phrase or a
+    /// deduped id), so the genuinely-clean guided rate is exactly `rung_serde - repaired_serde`.
+    pub repaired_serde: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -165,7 +165,7 @@ pub(crate) fn drain(
     report.rung_serde = aggregate_stats.rung_serde;
     report.rung_unguided = aggregate_stats.rung_unguided;
     report.rung_tolerant = aggregate_stats.rung_tolerant;
-    report.repaired = aggregate_stats.repaired;
+    report.repaired_serde = aggregate_stats.repaired_serde;
     let _write_lock = WriteLock::acquire_blocking(database_path, repo_id)?;
     in_transaction(conn, "IMMEDIATE", || {
         run_stats::record_distill_run(

--- a/crates/rag-rat-core/src/distill/output.rs
+++ b/crates/rag-rat-core/src/distill/output.rs
@@ -196,13 +196,14 @@ pub(crate) struct LadderStats {
     pub rung_unguided: u64,
     pub rung_tolerant: u64,
     pub failed: u64,
-    /// Of the accepted replies (any rung), how many passed only after `RecordOutput::normalize`
-    /// changed the model's output (a demoted backtick phrase or a deduped id). Orthogonal to the
-    /// rungs — a repaired reply is still counted in whichever rung accepted it — so
-    /// `rung_serde - repaired-on-serde` is the genuinely-clean guided rate. Without this, a
-    /// repaired reply is indistinguishable from clean guided output in the run-stats, hiding
-    /// the very formatting-failure rate the normalization exists to absorb.
-    pub repaired: u64,
+    /// Of the replies accepted on the SERDE rung (the clean-guided path), how many passed only
+    /// because `RecordOutput::normalize` repaired the model's output (a demoted backtick phrase or
+    /// a deduped id). So the genuinely-clean guided rate is exactly `rung_serde - repaired_serde`
+    /// — without it, a repaired reply is indistinguishable from clean guided output, hiding
+    /// the formatting-failure rate the normalization exists to absorb. Repairs on the
+    /// unguided/tolerant recovery rungs are not tracked separately: those rungs already denote
+    /// non-clean output.
+    pub repaired_serde: u64,
 }
 
 impl LadderStats {
@@ -221,7 +222,7 @@ impl LadderStats {
         self.rung_unguided += other.rung_unguided;
         self.rung_tolerant += other.rung_tolerant;
         self.failed += other.failed;
-        self.repaired += other.repaired;
+        self.repaired_serde += other.repaired_serde;
     }
 
     pub(crate) fn terminal_count(self) -> u64 {
@@ -272,7 +273,7 @@ pub(crate) fn run_output_ladder(
                 Ok((output, value, repaired)) => {
                     stats.record(OutputRung::Serde);
                     if repaired {
-                        stats.repaired += 1;
+                        stats.repaired_serde += 1;
                     }
                     return Ok(LadderResult {
                         output,
@@ -301,11 +302,10 @@ pub(crate) fn run_output_ladder(
     };
 
     match parse_and_validate(&retry_raw, input, budget) {
-        Ok((output, value, repaired)) => {
+        // A repair on the unguided/tolerant recovery rung is not tracked separately (`_repaired`):
+        // those rungs already denote non-clean output, so only serde-rung repairs carry signal.
+        Ok((output, value, _repaired)) => {
             stats.record(OutputRung::Unguided);
-            if repaired {
-                stats.repaired += 1;
-            }
             return Ok(LadderResult {
                 output,
                 value,
@@ -319,11 +319,8 @@ pub(crate) fn run_output_ladder(
 
     if let Some(stripped) = strip_whole_json_fence(&retry_raw) {
         match parse_and_validate(stripped, input, budget) {
-            Ok((output, value, repaired)) => {
+            Ok((output, value, _repaired)) => {
                 stats.record(OutputRung::Tolerant);
-                if repaired {
-                    stats.repaired += 1;
-                }
                 return Ok(LadderResult {
                     output,
                     value,
@@ -538,7 +535,7 @@ mod tests {
         assert_eq!(result.output.decision.chosen.as_deref(), Some("Adopt the retry loop approach"));
         assert_eq!(result.value["decision"]["chosen"], "Adopt the retry loop approach");
         // The reply needed repair, so it is counted apart from clean guided output.
-        assert_eq!(result.stats.repaired, 1);
+        assert_eq!(result.stats.repaired_serde, 1);
     }
 
     #[test]
@@ -552,7 +549,7 @@ mod tests {
         assert_eq!(result.output.root_cause_units.len(), 1);
         assert_eq!(result.output.decision_units.len(), 1);
         assert_eq!(result.output.anchor_indices, vec![3]);
-        assert_eq!(result.stats.repaired, 1);
+        assert_eq!(result.stats.repaired_serde, 1);
     }
 
     #[test]

--- a/crates/rag-rat-core/src/distill/run_stats.rs
+++ b/crates/rag-rat-core/src/distill/run_stats.rs
@@ -88,7 +88,7 @@ mod tests {
             rung_unguided: 1,
             rung_tolerant: 1,
             failed: 1,
-            repaired: 2,
+            repaired_serde: 2,
         };
         record_distill_run(&conn, "repo", 42, 4, stats).unwrap();
         let row: (i64, i64, i64, i64, i64, i64, String) = conn
@@ -113,9 +113,9 @@ mod tests {
         assert_eq!((row.0, row.1, row.2, row.3, row.4, row.5), (4, 4, 1, 1, 1, 1));
         let stats_json = serde_json::from_str::<serde_json::Value>(&row.6).unwrap();
         assert_eq!(stats_json["failed"], 1);
-        // `repaired` has no dedicated column; it rides in stats_json so a repaired reply is
-        // distinguishable from clean guided output.
-        assert_eq!(stats_json["repaired"], 2);
+        // `repaired_serde` has no dedicated column; it rides in stats_json so a serde reply that
+        // needed repair stays distinguishable from clean guided output.
+        assert_eq!(stats_json["repaired_serde"], 2);
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to #872 (review). The run-stats added there recorded a single cross-rung `repaired` counter, which cannot tell how many of the SERDE-rung replies were repaired — so the genuinely-clean guided rate it documented is not actually computable from the drain report or `stats_json`.

Rename it to `repaired_serde` and increment it only when a reply accepted on the serde rung needed `RecordOutput::normalize` — so the clean-guided rate is exactly `rung_serde - repaired_serde`. Repairs on the unguided/tolerant recovery rungs are not counted separately: those rungs already denote non-clean output. Surfaced in the drain report and the per-run `stats_json`; no schema change.

Tests updated to assert `repaired_serde` (the two rescue tests accept on serde) and its `stats_json` round-trip. `cargo test -p rag-rat-core --lib distill` 116/0; clippy clean on both CI configs.