### PR TITLE
feat(distill): default to the validated 30B ephemeral box, with distillation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ sequenceDiagram
   symbols.
 - **History as evidence.** Git history, lazy chunk blame, and cached GitHub issue/PR/review
   rationale, all queryable.
+- **Issue distillation.** Every closed issue and merged PR **plus its fixing diff** distilled into a typed
+  [decision record](docs/distillation.md) — root cause, the approach that landed (and the rejected
+  alternatives), and the outcome — validated against the thread and surfaced as drive-by context on
+  the anchored symbols.
 - **Rides your existing grep.** A [grep-augmentation hook](docs/grep-augmentation.md) injects the
   memories and symbols behind whatever you just searched for.
 - **Flags clones as you write them.** A PreToolUse hook on Write/Edit/MultiEdit fingerprints the

--- a/crates/rag-rat-base/src/config/raw.rs
+++ b/crates/rag-rat-base/src/config/raw.rs
@@ -363,9 +363,13 @@ impl TryFrom<RawLlm> for LlmConfig {
     type Error = ConfigError;
 
     fn try_from(raw: RawLlm) -> Result<Self, Self::Error> {
-        let (dream_enabled, dream_remote) = resolve_chat_gate(raw.dream, "[llm.dream.remote]")?;
-        let (distill_enabled, distill_remote) =
-            resolve_chat_gate(raw.distill, "[llm.distill.remote]")?;
+        let (dream_enabled, dream_remote) =
+            resolve_chat_gate(raw.dream, "[llm.dream.remote]", RemoteDreamConfig::default)?;
+        let (distill_enabled, distill_remote) = resolve_chat_gate(
+            raw.distill,
+            "[llm.distill.remote]",
+            RemoteDreamConfig::distill_default,
+        )?;
         Ok(Self {
             embedding: EmbeddingConfig::try_from(raw.embedding)?,
             dream: DreamLlmConfig { enabled: dream_enabled, remote: dream_remote },
@@ -379,21 +383,25 @@ impl TryFrom<RawLlm> for LlmConfig {
 #[derive(Debug, Default, Deserialize, PartialEq)]
 pub(crate) struct RawChatLlm {
     enabled: Option<bool>,
-    /// The `.remote` chat-serving block — absent → [`RemoteDreamConfig::default`] (a local-Ollama
-    /// connect). Unlike embeddings there is no in-process fallback, so a missing block still
-    /// yields a serving config rather than `None`.
+    /// The `.remote` chat-serving block — absent → the pass's `default_remote` (dream: a
+    /// local-Ollama connect; distill: the validated 30B ephemeral box). Unlike embeddings there is
+    /// no in-process fallback, so a missing block still yields a serving config rather than
+    /// `None`.
     remote: Option<RawRemoteDream>,
 }
 
 /// Resolve a chat gate to `(enabled, remote)`. `section` names the TOML block (e.g.
 /// `"[llm.distill.remote]"`) so validation errors point at the block the operator actually wrote.
+/// `default_remote` is the pass-specific serving default used when the `.remote` block is absent —
+/// [`RemoteDreamConfig::default`] for dream, [`RemoteDreamConfig::distill_default`] for distill.
 fn resolve_chat_gate(
     raw: RawChatLlm,
     section: &'static str,
+    default_remote: fn() -> RemoteDreamConfig,
 ) -> Result<(bool, RemoteDreamConfig), ConfigError> {
     let remote = match raw.remote {
         Some(remote) => resolve_remote_dream(remote, section)?,
-        None => RemoteDreamConfig::default(),
+        None => default_remote(),
     };
     Ok((raw.enabled.unwrap_or_default(), remote))
 }

--- a/crates/rag-rat-base/src/config/tests.rs
+++ b/crates/rag-rat-base/src/config/tests.rs
@@ -5,11 +5,11 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use path_slash::PathExt;
 
 use super::{
-    self as config, Config, ConfigError, EmbeddingRuntimeConfig, LlmConfig, LogConfig, LogFormat,
-    LogLevel, MemoryConfig, MemorySurface, OracleConfig, RawConfig, RawMemory, RawOracle,
-    RawSearch, RawTarget, RawVersionCheck, RawWatch, RemoteBackend, RemoteDreamConfig,
-    RemoteEmbeddingConfig, ResolvedTarget, SearchConfig, TargetKind, TrackerAuth,
-    VersionCheckConfig, WatchConfig,
+    self as config, Config, ConfigError, DistillLlmConfig, EmbeddingRuntimeConfig, LlmConfig,
+    LogConfig, LogFormat, LogLevel, MemoryConfig, MemorySurface, OracleConfig, RawConfig,
+    RawMemory, RawOracle, RawSearch, RawTarget, RawVersionCheck, RawWatch, RemoteBackend,
+    RemoteDreamConfig, RemoteEmbeddingConfig, ResolvedTarget, SearchConfig, TargetKind,
+    TrackerAuth, VersionCheckConfig, WatchConfig,
 };
 use crate::language::Language;
 
@@ -2304,9 +2304,11 @@ fn dream_remote_connect_happy_path_applies_defaults() {
 }
 
 #[test]
-fn distill_absent_defaults_to_off_and_local_ollama_connect() {
-    // No `[llm.distill]` → disabled, with the same local-Ollama CONNECT default dream carries
-    // (the distill pass rides `RemoteDreamConfig`).
+fn distill_absent_defaults_to_off_and_the_validated_30b_ephemeral_box() {
+    // No `[llm.distill]` → disabled, but its serving default is the *validated 30B ephemeral box*,
+    // NOT dream's local-Ollama connect: distill's dense prompts need the big model, so the honest
+    // default is the config validated on the full corpus. (Enabled stays false, so nothing is
+    // provisioned until the operator opts in and the drain has work.)
     let raw: RawConfig = toml::from_str(
         r#"
             [index]
@@ -2316,8 +2318,26 @@ fn distill_absent_defaults_to_off_and_local_ollama_connect() {
     .unwrap();
     let distill = LlmConfig::try_from(raw.llm).unwrap().distill;
     assert!(!distill.enabled, "the distill model pass is OFF by default");
-    assert_eq!(distill.remote, RemoteDreamConfig::default());
-    assert!(distill.remote.is_connect() && !distill.remote.is_ephemeral());
+    assert_eq!(distill.remote, RemoteDreamConfig::distill_default());
+    assert_ne!(
+        distill.remote,
+        RemoteDreamConfig::default(),
+        "distill must diverge from dream's local-Ollama default"
+    );
+    assert!(distill.remote.is_ephemeral() && !distill.remote.is_connect());
+    assert_eq!(distill.remote.backend, RemoteBackend::Vllm);
+    assert_eq!(distill.remote.model, "Qwen/Qwen3-30B-A3B-Instruct-2507-FP8");
+    assert_eq!(distill.remote.gpu.as_deref(), Some("L40S"));
+    // Cold provisioning PLUS at least one worst-case request must fit inside the cookbook box's
+    // 30-min (1800 s) unconditional lifetime — otherwise a box that cold-starts near its budget
+    // self-destructs mid-inference on its very first request.
+    assert!(
+        distill.remote.provision_timeout_s.unwrap() + distill.remote.request_timeout_s <= 1800,
+        "provision budget + one request must fit under the 30-min box lifetime"
+    );
+    // The whole-`[llm]`-absent fallback (`DistillLlmConfig::default`) must agree with the
+    // `.remote`-absent resolution above — same validated default from both paths.
+    assert_eq!(DistillLlmConfig::default().remote, RemoteDreamConfig::distill_default());
 }
 
 #[test]

--- a/crates/rag-rat-base/src/config/types.rs
+++ b/crates/rag-rat-base/src/config/types.rs
@@ -393,16 +393,26 @@ pub struct DreamLlmConfig {
 /// a [`RemoteDreamConfig`] chat-serving block (connect XOR ephemeral), default OFF so the
 /// extraction layer stays 100% deterministic unless the operator opts in. Rides
 /// [`RemoteDreamConfig`] rather than a bespoke type — the distill pass is another single-turn chat
-/// consumer; the only difference from dream is a typically larger model (hence the
-/// `provision_timeout_s` override on the remote block, for a 30B-class weight pull).
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+/// consumer; the difference from dream is the serving default: distill defaults to the validated
+/// 30B ephemeral box ([`RemoteDreamConfig::distill_default`]), not dream's local-Ollama connect,
+/// because a local 4B produces poor records on distill's dense prompts.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DistillLlmConfig {
     /// Run the distill model pass at all (default false — opt in explicitly). When false, the
     /// deterministic extraction still runs; only the model columns stay unfilled.
     pub enabled: bool,
     /// Which chat server serves the distill turns (connect XOR ephemeral). Absent
-    /// `[llm.distill.remote]` → [`RemoteDreamConfig::default`] (a local-Ollama connect).
+    /// `[llm.distill.remote]` → [`RemoteDreamConfig::distill_default`] (the validated 30B
+    /// ephemeral box), **not** dream's local-Ollama connect.
     pub remote: RemoteDreamConfig,
+}
+
+impl Default for DistillLlmConfig {
+    /// OFF, serving the validated 30B ephemeral box — so a wholly-absent `[llm]` and a present
+    /// `[llm.distill]` with no `.remote` block resolve to the *same* distill default.
+    fn default() -> Self {
+        Self { enabled: false, remote: RemoteDreamConfig::distill_default() }
+    }
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -855,6 +865,33 @@ impl Default for RemoteDreamConfig {
 }
 
 impl RemoteDreamConfig {
+    /// The distill pass's default serving block when `[llm.distill.remote]` is omitted: the
+    /// validated 30B ephemeral box (vLLM on an L40S), **not** dream's local-Ollama connect.
+    /// Distill prompts are dense enough that a local 4B produces poor records, so the honest
+    /// default is the config that was validated on the full corpus — it provisions a paid GPU only
+    /// when the opt-in `[llm.distill] enabled = true` drain actually has pending work (a zero-work
+    /// run never cold-starts a box). `request_timeout_s` is kept low (a rare guided-decoding
+    /// whitespace loop fails fast and re-queues); `provision_timeout_s` gives the ~30 GB cold
+    /// weight pull real headroom while still **reserving serving time within the cookbook box's
+    /// 30-min unconditional lifetime** — see the constants below.
+    pub fn distill_default() -> Self {
+        Self {
+            backend: RemoteBackend::Vllm,
+            endpoint: None,
+            cookbook: Some("@rag-rat/cookbook modal".to_string()),
+            model: "Qwen/Qwen3-30B-A3B-Instruct-2507-FP8".to_string(),
+            gpu: Some("L40S".to_string()),
+            auth_env: None,
+            request_timeout_s: 240,
+            // 25 min. The cookbook box self-destructs at a hard 30-min (1800 s) lifetime, so the
+            // budget must leave room to actually *serve* after a slow cold start: even if
+            // provisioning eats this whole 1500 s, the box still has 300 s left — more than one
+            // full `request_timeout_s` (240 s) request. A larger budget lets provisioning consume
+            // the lifetime, and the first inference dies mid-flight when the box vanishes.
+            provision_timeout_s: Some(1500),
+        }
+    }
+
     /// CONNECT mode: an already-running server at `endpoint`. Exactly one of connect/ephemeral
     /// holds (config validation guarantees it), so `is_connect() == !is_ephemeral()`.
     pub fn is_connect(&self) -> bool {

--- a/docs/config.md
+++ b/docs/config.md
@@ -42,6 +42,8 @@ Each topic below has its own in-depth page under [`docs/config/`](config/):
   (`[version_check]`).
 - **[Dream memory maintenance](config/dream.md)** — the opt-in verify/compaction model
   (`[llm.dream]`), ephemeral GPU serving, nightly scheduling, and reviewing findings.
+- **[Issue distillation model](config/distill.md)** — the opt-in LLM pass that fills distilled
+  decision records (`[llm.distill]`), ephemeral GPU serving, and batching.
 - **[Memory surfacing](config/memory.md)** — summary-vs-full rendering of repo memories
   everywhere they surface (`[memory] surface`).
 - **[Issue trackers & papertrail](config/trackers.md)** — `[[tracker]]` bindings, per-provider

--- a/docs/config/distill.md
+++ b/docs/config/distill.md
@@ -1,0 +1,83 @@
+# Distill model (`[llm.distill]` / `[llm.distill.remote]`)
+
+Part of the [config reference](../config.md). For the feature itself, see
+[Issue distillation](../distillation.md).
+
+`[llm.distill]` configures the **model half** of issue distillation — the LLM pass that fills a
+distilled record's `root_cause` / `decision` / `outcome` fields. Like [`[llm.dream]`](dream.md) it is
+**out-of-process, opt-in, and gated**: `rag-rat distill extract` builds the deterministic substrate
+with no model, and `rag-rat distill drain` runs the model pass only when `enabled = true`. The
+serving config lives under `[llm.distill.remote]`, mirroring `[llm.dream.remote]` — a **connect**
+endpoint (an already-running chat server) or an **ephemeral** cookbook-provisioned GPU box.
+
+```toml
+[llm.distill]
+enabled = false             # off by default — `distill drain` refuses if work is pending and this is false
+```
+
+With no `[llm.distill.remote]` block, distill defaults to the **validated 30B ephemeral box** — an
+on-demand vLLM GPU provisioned through the cookbook (the same mechanism embeddings and dream use).
+Distillation prompts are dense (full commit bodies + the fix diff + coalesced partners + cross-refs),
+so a small local model produces poor records and CPU inference is impractical at corpus scale — the
+big model earns its place. This is the exact config the full-corpus verification ran on; the
+equivalent explicit block:
+
+```toml
+# DEFAULT when [llm.distill.remote] is omitted, shown explicitly:
+[llm.distill.remote]
+backend  = "vllm"                                   # ollama | vllm  (infinity is embed-only — rejected here)
+cookbook = "@rag-rat/cookbook modal"                # provision an ephemeral box (mutually exclusive with endpoint)
+gpu      = "L40S"                                    # provider-specific GPU class (validated at provision time)
+model    = "Qwen/Qwen3-30B-A3B-Instruct-2507-FP8"   # HF id for vllm (an ollama name for the ollama backend)
+provision_timeout_s = 1500                           # cold-pull budget; stays under the box's 30-min hard lifetime
+request_timeout_s = 240
+```
+
+On the model-comparison run this beat a 4B on every content metric (rejected-alternatives coverage,
+root-cause coverage, qualified anchors) while ~3× faster and ~20% cheaper per thread (MoE, ~3B
+active); a 4B on an `L4` is the constrained fallback. Nothing is provisioned until you set
+`enabled = true` **and** the drain has pending work — a zero-work run never cold-starts a paid box.
+
+**Connect to a running server instead.** To point distill at an already-running OpenAI-compatible
+chat server (a local Ollama, a shared vLLM, …) rather than provisioning a box, set `endpoint` in
+place of `cookbook`:
+
+```toml
+[llm.distill.remote]
+backend  = "ollama"
+endpoint = "http://localhost:11434"     # OpenAI-compatible chat server (mutually exclusive with cookbook)
+model    = "qwen3:4b-instruct"          # server-side model name
+# auth_env = "DISTILL_TOKEN"            # optional: names the env var holding the bearer token for a protected endpoint
+request_timeout_s = 240
+```
+
+A local 4B connect is cheap but low-quality on distill's dense prompts — fine for a smoke test, not a
+corpus backfill.
+
+**`provision_timeout_s`.** A 30B re-downloads ~30 GB of weights from Hugging Face on a cold box and
+can exceed the vLLM boot default (15 min). The default (1500 s / 25 min) gives that cold pull headroom
+while staying under the cookbook box's **hard 30-min lifetime** — a box that spends its whole budget
+provisioning still has room to serve at least one full `request_timeout_s` request before it
+self-destructs. Don't raise it past ~28 min: the box vanishes at 30, so a larger budget only fails the
+slow cold start it was meant to cover. The first cold box is slow; a clean teardown publishes the HF +
+compile cache markers, so every later box boots in ~2 min.
+
+**`request_timeout_s`.** Keep this **low** (≈240 s, not the 900 s dream uses). A bounded record
+generates in well under a minute, but a rare guided-decoding whitespace loop otherwise blocks the
+sequential drain for the full timeout; a low cap fails it fast and re-queues the thread. See #874.
+
+## Running the pass
+
+```bash
+rag-rat distill extract              # deterministic substrate only — no model, no cost
+rag-rat distill drain --limit 100    # extract, then drain up to 100 queued threads through the model
+```
+
+The box is provisioned only when there is pending work (a zero-work run never cold-starts a paid
+GPU), and torn down when the run ends. The client speaks the standard `/v1/chat/completions` route
+(temperature 0, no streaming, guided JSON where the backend supports it).
+
+**Batch long runs.** The cookbook caps a box's lifetime (~30 min), so a single `drain` cannot finish
+a large corpus on one box — size `--limit` to one box's serving window (~70–150 threads by thread
+size) and loop `distill drain` until the queue empties. The queue is resumable and every completed
+record is durable, so a killed box loses nothing. See #875.

--- a/docs/distillation.md
+++ b/docs/distillation.md
@@ -1,0 +1,152 @@
+# Issue distillation — typed decision records
+
+Distillation turns every **closed issue and merged pull request** **plus its fixing-commit diff**
+into one **typed decision record**: what was broken or asked for, the underlying cause, the
+approach that *landed* (and the alternatives that didn't), and what actually happened — anchored to
+the symbols and files the change touched, and validated mechanically at every step. Records are a
+**regenerable derived layer**: they are surfaced where agents already look (retrieval payloads and
+drive-by context on the anchored symbols), so the reasoning behind a piece of code arrives in one
+call instead of a git-archaeology session.
+
+Nothing shipping elsewhere combines these: existing tools mine the *discussion* without the diff, or
+the *diff* without the discussion; none anchor the extracted knowledge to validated symbols, track
+`decision → outcome`, or backfill years of closed history on day one.
+
+The model half is **out-of-process, opt-in, and gated by a deterministic layer** — the same posture
+as the [dream](config/dream.md) passes. The deterministic extraction runs model-free; the LLM pass
+only runs when you enable `[llm.distill]` and drain the queue.
+
+## The record
+
+Each eligible thread yields one record; when a merged PR closes an issue the two **coalesce into a
+single issue-owned record** (the PR is exposed as a partner, not its own record). Records are stored
+in `papertrail_distill` (with evidence and anchors in side tables) and surfaced to consumers as a
+flat `DistilledRecord`. Its content fields:
+
+| field | meaning |
+|---|---|
+| `root_issue` | what was broken or requested, from the reporter's point of view (null if none stated) |
+| `root_cause` / `root_cause_class` | the underlying technical cause + a short failure-class label — **honestly null** when the thread establishes no failure (a feature, not a bug) |
+| `decision_chosen` | the core approach that **landed** — not a reviewer's rejected proposal |
+| `rejected_alternatives[]` | alternatives explicitly considered and not taken (`{alternative, reason}`) |
+| `outcome_status` | the *effective* status: `landed` \| `descoped` \| `superseded` \| `reverted` \| `unclear` (the model's raw call is kept as `outcome_status_model`) |
+| `outcome_summary` | what actually happened — **measured results stated as results**, projections never asserted as delivered |
+| `fixing_commits` | the commit(s) that resolved the thread |
+
+During the **drain**, the model **cites** every claim to the verbatim `[U#]` thread units that
+establish it and **selects** anchors from the changed files' candidate symbols (`extract` only builds
+the candidate list, model-free); both are validated (a fabricated citation or an off-list anchor is
+rejected) and stored in side tables. The surfaced record does **not** carry the raw citations or
+anchor tuples — it exposes the **provenance facets** derived from them (not a fused confidence
+score): `fix_edge_source` (`provider` \| `text` \| `none`), `thread_shape` (`investigation` \|
+`review_stream` \| `thin`), `anchors_qualified_count`, `outcome_claim_verified`, and
+`decision_provenance_verified`. (`epistemic_status_decision` / `epistemic_status_outcome` are reserved
+— null in v1.) The *effective* `outcome_status` is computed
+in the read layer from status-floor inputs (a revert override, a closing-keyword floor, the presence
+of a fix edge) layered over the model's raw status — the model never sees the final label.
+
+## How it works
+
+Two phases, split at the model boundary:
+
+### 1. Extract (deterministic, model-free)
+
+`rag-rat distill extract` walks the papertrail mirror and, for every eligible thread — a closed
+issue or a **merged** pull request (a closed-unmerged PR is not yet distilled; see #743) — builds:
+
+- a **skeleton record** on the natural key `(repo_id, tracker, project, item_kind, item_key)`;
+- **fixing-commit edges** — provider-attested closing references + merge commits first, a
+  text-derived fallback tier where the provider has no native edges;
+- **coalesced edges** — an issue and its fixing PR answer as one work-unit (the issue side);
+- **anchor candidates** — the `(logical_symbol_id, file, name, kind)` symbols in the changed files,
+  offered to the model as an index-selection list (selecting by index removes name-normalization);
+- **immutable input snapshots** — the exact thread units, the cross-referenced item titles + opening
+  paragraphs, and every coalesced partner are folded into the record's regeneration identity, so the
+  drain never reads mutable mirror state. The capped fix diff (per-file unified patches for the paths
+  that yielded a symbol anchor) is snapshotted too, but is **best-effort and outside** that identity —
+  a shallow or bare-index run that had no diff can fill it in later without re-distilling the record;
+- the **work queue** — one row per thread awaiting the model pass.
+
+### 2. Drain (the model pass)
+
+`rag-rat distill drain` runs extraction, then drains the queue through the configured chat model.
+Each thread hydrates its snapshot into a rendered prompt + a guided-JSON schema (both hashed into
+`model_input_hash`), then runs the **output ladder** — at most two model calls, with an acceptance
+rung at each parse:
+
+```
+guided decode ──▶ strict serde + validation ──▶ accept (serde)
+      │ fail
+      ▼
+unguided retry ──▶ strict serde + validation ──▶ accept (unguided)
+      │ fail
+      ▼
+one tolerant fence-strip ──▶ accept (tolerant)  │  else fail → re-queue (raw reply persisted)
+```
+
+Before validation, the model's output is **normalized** (content-preserving, post-generation only —
+it never touches the prompt or the regeneration hash): a reject-worthy inline-code span (a multi-word
+backtick phrase, an empty span, an unclosed backtick) is demoted to plain prose while genuine
+single-identifier spans are kept, and duplicate citation / anchor ids are deduped order-preserving.
+This rescues records the model would otherwise fail on *formatting alone*, with their content intact
+— the run stats record a `repaired_serde` counter so the genuinely-clean guided rate stays
+`rung_serde − repaired_serde`. Evidence must cite real units; anchors must be visible candidates;
+outcome numbers must not assert a projection as a delivered result.
+
+Every completed record is **durable immediately** — a died box loses nothing, and re-running resumes
+the queue. The pass is idempotent: a record whose `model_input_hash` matches the current input is not
+re-distilled.
+
+## Running it
+
+```bash
+# Deterministic substrate only (no model, no cost): skeleton records, fixing edges,
+# coalesced pairs, anchor candidates, work queue.
+rag-rat distill extract
+
+# Run extraction, then drain up to N queued threads through the model.
+rag-rat distill drain --limit 100
+```
+
+The drain requires `[llm.distill] enabled = true` and a serving config — see
+[`[llm.distill]` configuration](config/distill.md). A zero-work run returns before any capability
+check or provisioning, so scheduling it generously costs nothing when the queue is empty.
+
+**Long runs must batch.** On an ephemeral GPU box the provider caps the box's lifetime (~30 min on
+the Modal cookbook), so a single drain over a large corpus cannot finish on one box. Size `--limit`
+to one box's serving window and loop `distill drain` until the queue empties — the queue is
+resumable and records are durable per thread, and a clean teardown warms the model cache so later
+boxes boot fast.
+
+## Where records surface
+
+Records ride the surfaces agents already use — there is **no new vector lane** (measurement showed
+the record payload beats every no-LLM baseline while embeddings don't beat the existing FTS on
+ranking):
+
+- **Retrieval payload** — a `rationale_search` / `papertrail_issue_search` hit that has a distilled
+  record returns the record (root issue/cause, decision incl. rejected alternatives, outcome status +
+  fixing commits, provenance facets) instead of only raw item/comment matches. Coalesced issue↔PR
+  pairs answer as one result.
+- **Drive-by attachment** on the symbol surfaces — `semantic_search`, `symbol_lookup`,
+  `impact_surface`, and `read_chunk` attach the records for the symbols they touch. This is
+  **facet-gated** (requires a provider fix edge *and* a **model-selected** qualified symbol anchor — a
+  drain can validly select none even when candidates exist, in which case the record surfaces on no
+  symbol), hard-capped (≤2 records per symbol, coalesced, newest-distilled first by `distilled_at_ms`),
+  and clearly labeled as distilled + unreviewed
+  with the thread + commit as provenance, so a hot symbol's payload never blows the budget.
+
+## Regeneration & durability
+
+Records are a derived layer keyed by `pipeline_version` (extraction shape) and `prompt_version`
+(prompt/schema). Bumping either re-queues affected records with model state cleared; a record is
+otherwise recomputed only when its input snapshot changes. Because the drain keys on
+`model_input_hash`, an unchanged thread is never re-distilled — so a full backfill is a one-time cost
+and incremental threads are sub-cent. The fix diff is the one exception: it is deliberately outside
+the identity hash, so a diff that only becomes available on a later run (a bare or shallow index had
+none) is filled in **without** re-distilling the record.
+
+## Configuration
+
+See [`[llm.distill]` configuration](config/distill.md) for the serving config (connect endpoint vs.
+ephemeral cookbook box), the recommended model, and the per-request timeout.


### PR DESCRIPTION
Ships the issue-distillation feature docs **and** makes the validated 30B the shipped default, together so they stay consistent.

## Default change (code)

Distill inherited dream's serving default — a local Ollama `qwen3:4b-instruct` connect — whenever `[llm.distill.remote]` was omitted. Distill's prompts are dense and a local 4B produces poor records; the full-corpus verification ran on `Qwen/Qwen3-30B-A3B-Instruct-2507-FP8` (L40S, vLLM), which beat the 4B on every content metric.

- `RemoteDreamConfig::distill_default()` — a distill-specific serving default: ephemeral vLLM on an `L40S` via `@rag-rat/cookbook modal`. `resolve_chat_gate` takes a pass-specific default, so **dream keeps its local-Ollama default** and only distill diverges; `DistillLlmConfig::default()` is made explicit so both default paths agree.
- Opt-in + zero-work-guarded: nothing provisions until `enabled = true` **and** the drain has pending work.
- `provision_timeout_s = 1500`: cold-pull headroom that still reserves serving time inside the cookbook box's hard 30-min lifetime (a config test pins `provision_timeout_s + request_timeout_s <= 1800`, so a box that cold-starts near budget still fits one full request before it self-destructs).

## Docs

- `docs/distillation.md` — the feature: record schema, provenance facets, extract vs drain, the output ladder, where records surface, regeneration/durability.
- `docs/config/distill.md` — `[llm.distill]` config, leading with the 30B ephemeral default and the connect override; the box-lifetime reasoning for `provision_timeout_s`.
- `docs/config.md` + `README.md` — links.

Fixes #879