### PR TITLE
feat(distill): default the model pass to the validated 30B ephemeral box

### DIFF
--- a/crates/rag-rat-base/src/config/raw.rs
+++ b/crates/rag-rat-base/src/config/raw.rs
@@ -363,9 +363,13 @@ impl TryFrom<RawLlm> for LlmConfig {
     type Error = ConfigError;
 
     fn try_from(raw: RawLlm) -> Result<Self, Self::Error> {
-        let (dream_enabled, dream_remote) = resolve_chat_gate(raw.dream, "[llm.dream.remote]")?;
-        let (distill_enabled, distill_remote) =
-            resolve_chat_gate(raw.distill, "[llm.distill.remote]")?;
+        let (dream_enabled, dream_remote) =
+            resolve_chat_gate(raw.dream, "[llm.dream.remote]", RemoteDreamConfig::default)?;
+        let (distill_enabled, distill_remote) = resolve_chat_gate(
+            raw.distill,
+            "[llm.distill.remote]",
+            RemoteDreamConfig::distill_default,
+        )?;
         Ok(Self {
             embedding: EmbeddingConfig::try_from(raw.embedding)?,
             dream: DreamLlmConfig { enabled: dream_enabled, remote: dream_remote },
@@ -379,21 +383,25 @@ impl TryFrom<RawLlm> for LlmConfig {
 #[derive(Debug, Default, Deserialize, PartialEq)]
 pub(crate) struct RawChatLlm {
     enabled: Option<bool>,
-    /// The `.remote` chat-serving block — absent → [`RemoteDreamConfig::default`] (a local-Ollama
-    /// connect). Unlike embeddings there is no in-process fallback, so a missing block still
-    /// yields a serving config rather than `None`.
+    /// The `.remote` chat-serving block — absent → the pass's `default_remote` (dream: a
+    /// local-Ollama connect; distill: the validated 30B ephemeral box). Unlike embeddings there is
+    /// no in-process fallback, so a missing block still yields a serving config rather than
+    /// `None`.
     remote: Option<RawRemoteDream>,
 }
 
 /// Resolve a chat gate to `(enabled, remote)`. `section` names the TOML block (e.g.
 /// `"[llm.distill.remote]"`) so validation errors point at the block the operator actually wrote.
+/// `default_remote` is the pass-specific serving default used when the `.remote` block is absent —
+/// [`RemoteDreamConfig::default`] for dream, [`RemoteDreamConfig::distill_default`] for distill.
 fn resolve_chat_gate(
     raw: RawChatLlm,
     section: &'static str,
+    default_remote: fn() -> RemoteDreamConfig,
 ) -> Result<(bool, RemoteDreamConfig), ConfigError> {
     let remote = match raw.remote {
         Some(remote) => resolve_remote_dream(remote, section)?,
-        None => RemoteDreamConfig::default(),
+        None => default_remote(),
     };
     Ok((raw.enabled.unwrap_or_default(), remote))
 }

--- a/crates/rag-rat-base/src/config/tests.rs
+++ b/crates/rag-rat-base/src/config/tests.rs
@@ -5,11 +5,11 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use path_slash::PathExt;
 
 use super::{
-    self as config, Config, ConfigError, EmbeddingRuntimeConfig, LlmConfig, LogConfig, LogFormat,
-    LogLevel, MemoryConfig, MemorySurface, OracleConfig, RawConfig, RawMemory, RawOracle,
-    RawSearch, RawTarget, RawVersionCheck, RawWatch, RemoteBackend, RemoteDreamConfig,
-    RemoteEmbeddingConfig, ResolvedTarget, SearchConfig, TargetKind, TrackerAuth,
-    VersionCheckConfig, WatchConfig,
+    self as config, Config, ConfigError, DistillLlmConfig, EmbeddingRuntimeConfig, LlmConfig,
+    LogConfig, LogFormat, LogLevel, MemoryConfig, MemorySurface, OracleConfig, RawConfig,
+    RawMemory, RawOracle, RawSearch, RawTarget, RawVersionCheck, RawWatch, RemoteBackend,
+    RemoteDreamConfig, RemoteEmbeddingConfig, ResolvedTarget, SearchConfig, TargetKind,
+    TrackerAuth, VersionCheckConfig, WatchConfig,
 };
 use crate::language::Language;
 
@@ -2304,9 +2304,11 @@ fn dream_remote_connect_happy_path_applies_defaults() {
 }
 
 #[test]
-fn distill_absent_defaults_to_off_and_local_ollama_connect() {
-    // No `[llm.distill]` → disabled, with the same local-Ollama CONNECT default dream carries
-    // (the distill pass rides `RemoteDreamConfig`).
+fn distill_absent_defaults_to_off_and_the_validated_30b_ephemeral_box() {
+    // No `[llm.distill]` → disabled, but its serving default is the *validated 30B ephemeral box*,
+    // NOT dream's local-Ollama connect: distill's dense prompts need the big model, so the honest
+    // default is the config validated on the full corpus. (Enabled stays false, so nothing is
+    // provisioned until the operator opts in and the drain has work.)
     let raw: RawConfig = toml::from_str(
         r#"
             [index]
@@ -2316,8 +2318,26 @@ fn distill_absent_defaults_to_off_and_local_ollama_connect() {
     .unwrap();
     let distill = LlmConfig::try_from(raw.llm).unwrap().distill;
     assert!(!distill.enabled, "the distill model pass is OFF by default");
-    assert_eq!(distill.remote, RemoteDreamConfig::default());
-    assert!(distill.remote.is_connect() && !distill.remote.is_ephemeral());
+    assert_eq!(distill.remote, RemoteDreamConfig::distill_default());
+    assert_ne!(
+        distill.remote,
+        RemoteDreamConfig::default(),
+        "distill must diverge from dream's local-Ollama default"
+    );
+    assert!(distill.remote.is_ephemeral() && !distill.remote.is_connect());
+    assert_eq!(distill.remote.backend, RemoteBackend::Vllm);
+    assert_eq!(distill.remote.model, "Qwen/Qwen3-30B-A3B-Instruct-2507-FP8");
+    assert_eq!(distill.remote.gpu.as_deref(), Some("L40S"));
+    // Cold provisioning PLUS at least one worst-case request must fit inside the cookbook box's
+    // 30-min (1800 s) unconditional lifetime — otherwise a box that cold-starts near its budget
+    // self-destructs mid-inference on its very first request.
+    assert!(
+        distill.remote.provision_timeout_s.unwrap() + distill.remote.request_timeout_s <= 1800,
+        "provision budget + one request must fit under the 30-min box lifetime"
+    );
+    // The whole-`[llm]`-absent fallback (`DistillLlmConfig::default`) must agree with the
+    // `.remote`-absent resolution above — same validated default from both paths.
+    assert_eq!(DistillLlmConfig::default().remote, RemoteDreamConfig::distill_default());
 }
 
 #[test]

--- a/crates/rag-rat-base/src/config/types.rs
+++ b/crates/rag-rat-base/src/config/types.rs
@@ -393,16 +393,26 @@ pub struct DreamLlmConfig {
 /// a [`RemoteDreamConfig`] chat-serving block (connect XOR ephemeral), default OFF so the
 /// extraction layer stays 100% deterministic unless the operator opts in. Rides
 /// [`RemoteDreamConfig`] rather than a bespoke type — the distill pass is another single-turn chat
-/// consumer; the only difference from dream is a typically larger model (hence the
-/// `provision_timeout_s` override on the remote block, for a 30B-class weight pull).
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+/// consumer; the difference from dream is the serving default: distill defaults to the validated
+/// 30B ephemeral box ([`RemoteDreamConfig::distill_default`]), not dream's local-Ollama connect,
+/// because a local 4B produces poor records on distill's dense prompts.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DistillLlmConfig {
     /// Run the distill model pass at all (default false — opt in explicitly). When false, the
     /// deterministic extraction still runs; only the model columns stay unfilled.
     pub enabled: bool,
     /// Which chat server serves the distill turns (connect XOR ephemeral). Absent
-    /// `[llm.distill.remote]` → [`RemoteDreamConfig::default`] (a local-Ollama connect).
+    /// `[llm.distill.remote]` → [`RemoteDreamConfig::distill_default`] (the validated 30B
+    /// ephemeral box), **not** dream's local-Ollama connect.
     pub remote: RemoteDreamConfig,
+}
+
+impl Default for DistillLlmConfig {
+    /// OFF, serving the validated 30B ephemeral box — so a wholly-absent `[llm]` and a present
+    /// `[llm.distill]` with no `.remote` block resolve to the *same* distill default.
+    fn default() -> Self {
+        Self { enabled: false, remote: RemoteDreamConfig::distill_default() }
+    }
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -855,6 +865,33 @@ impl Default for RemoteDreamConfig {
 }
 
 impl RemoteDreamConfig {
+    /// The distill pass's default serving block when `[llm.distill.remote]` is omitted: the
+    /// validated 30B ephemeral box (vLLM on an L40S), **not** dream's local-Ollama connect.
+    /// Distill prompts are dense enough that a local 4B produces poor records, so the honest
+    /// default is the config that was validated on the full corpus — it provisions a paid GPU only
+    /// when the opt-in `[llm.distill] enabled = true` drain actually has pending work (a zero-work
+    /// run never cold-starts a box). `request_timeout_s` is kept low (a rare guided-decoding
+    /// whitespace loop fails fast and re-queues); `provision_timeout_s` gives the ~30 GB cold
+    /// weight pull real headroom while still **reserving serving time within the cookbook box's
+    /// 30-min unconditional lifetime** — see the constants below.
+    pub fn distill_default() -> Self {
+        Self {
+            backend: RemoteBackend::Vllm,
+            endpoint: None,
+            cookbook: Some("@rag-rat/cookbook modal".to_string()),
+            model: "Qwen/Qwen3-30B-A3B-Instruct-2507-FP8".to_string(),
+            gpu: Some("L40S".to_string()),
+            auth_env: None,
+            request_timeout_s: 240,
+            // 25 min. The cookbook box self-destructs at a hard 30-min (1800 s) lifetime, so the
+            // budget must leave room to actually *serve* after a slow cold start: even if
+            // provisioning eats this whole 1500 s, the box still has 300 s left — more than one
+            // full `request_timeout_s` (240 s) request. A larger budget lets provisioning consume
+            // the lifetime, and the first inference dies mid-flight when the box vanishes.
+            provision_timeout_s: Some(1500),
+        }
+    }
+
     /// CONNECT mode: an already-running server at `endpoint`. Exactly one of connect/ephemeral
     /// holds (config validation guarantees it), so `is_connect() == !is_ephemeral()`.
     pub fn is_connect(&self) -> bool {


### PR DESCRIPTION
Distill inherited dream's serving default — a local Ollama `qwen3:4b-instruct` connect — whenever `[llm.distill.remote]` was omitted. Distill's prompts are dense (full commit bodies + the fix diff + coalesced partners), and a local 4B produces poor records; the full-corpus verification ran on `Qwen/Qwen3-30B-A3B-Instruct-2507-FP8` (L40S, vLLM), which beat the 4B on every content metric.

## What changes

- `RemoteDreamConfig::distill_default()` — a distill-specific serving default: ephemeral vLLM on an `L40S`, provisioned via `@rag-rat/cookbook modal`. `resolve_chat_gate` now takes a pass-specific default, so **dream keeps its local-Ollama connect default** and only distill diverges. `DistillLlmConfig::default()` is made explicit so the wholly-absent-`[llm]` fallback and the absent-`.remote` resolution land on the *same* default.
- Safe by construction: the pass stays opt-in (`enabled = false`) and zero-work-guarded — nothing is provisioned until an operator sets `enabled = true` **and** the drain has pending work.
- `provision_timeout_s = 1500`: headroom for the ~30 GB cold weight pull while reserving serving time inside the cookbook box's hard 30-min (1800 s) lifetime. A box that cold-starts near budget still fits at least one full `request_timeout_s` request before it self-destructs; a config test pins that `provision_timeout_s + request_timeout_s <= 1800`.

## Tests

- The absent-config test now asserts the validated 30B ephemeral default, its divergence from dream's default, agreement between both default paths, and the box-lifetime invariant.
- Dream's default and all existing remote-parsing/validation tests are unchanged and green.

Docs describing the new default land alongside in the distillation docs PR.

Fixes #879