### PR TITLE
ci(release-plz): bring rag-rat-sync into the lockstep group and defer its first publish

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,9 +1,11 @@
 # release-plz: automates version bumps, changelog, crates.io publish, and the GitHub release for
-# this three-crate workspace. https://release-plz.dev/docs/config
+# this workspace. https://release-plz.dev/docs/config
 #
-# Lockstep is the contract: all three crates share one version (see `[workspace.package].version`
+# Lockstep is the contract: every crate shares one version (see `[workspace.package].version`
 # in Cargo.toml). `version_group` below makes release-plz assign the SAME next version to every
-# member (the highest bump required across the group), so they never drift.
+# member (the highest bump required across the group), so they never drift. A new crate MUST be
+# added here with `version_group = "rag-rat"`, or release-plz treats it as its own group and tries
+# to publish it at the current (already-taken) workspace version.
 
 [workspace]
 # One git tag + one GitHub release per bump, not one per crate. The libraries stay tag/release-
@@ -85,3 +87,22 @@ changelog_path = "./CHANGELOG.md"
 name = "rag-rat-oplog"
 version_group = "rag-rat"
 changelog_path = "./CHANGELOG.md"
+
+# rag-rat-sync joined the workspace in #406. It versions in lockstep with the group, but its FIRST
+# crates.io publish is deferred to a manual bootstrap (`publish = false`), for two reasons that both
+# apply only to a brand-new crate:
+#   1. The CI registry token can publish new VERSIONS of crates it already owns, but not RESERVE a
+#      new crate name. The first publish must come from a maintainer's token, which then `cargo
+#      owner --add`s the CI token so later releases publish it automatically.
+#   2. `cargo publish --verify` builds the packaged crate against the crates.io copies of its path
+#      deps. A new crate that uses APIs added to a sibling (rag-rat-oplog) in the same PR cannot
+#      verify until that sibling's new version is on the registry — which only happens at the next
+#      lockstep release.
+# Bootstrap once the next release has published the siblings: `cargo publish -p rag-rat-sync`, then
+# `cargo owner --add <ci-token-user> rag-rat-sync`, then delete this line so releases publish it in
+# lockstep like every other crate. Until then nothing depends on it downstream, so deferring is safe.
+[[package]]
+name = "rag-rat-sync"
+version_group = "rag-rat"
+changelog_path = "./CHANGELOG.md"
+publish = false


### PR DESCRIPTION
## Problem

The **Release-plz release** job has been failing on every push to main since #406 (`rag-rat-sync`) merged. The new crate was never added to `release-plz.toml`, so release-plz treated it as its own version group and tried to publish it at the current workspace version (`0.20.0`). That fails at the `cargo publish --verify` step:

```
error[E0432]: unresolved imports `rag_rat_oplog::account_entries_for_sync`,
  `rag_rat_oplog::account_entry_ref`, `rag_rat_oplog::account_signed_entry_exists`,
  `rag_rat_oplog::account_signed_hash`
error: failed to verify package tarball
```

`cargo publish --verify` builds the packaged crate against the **crates.io** copies of its path deps. The published `rag-rat-oplog 0.20.0` predates the sync ingest helpers that `rag-rat-sync` imports (they landed in the same PR), so the verify build cannot resolve them.

## Fix

- Add `rag-rat-sync` to `release-plz.toml` with `version_group = "rag-rat"` so it bumps in lockstep with the rest of the workspace.
- Set `publish = false` to defer its **first** crates.io publish to a manual bootstrap.

Two things make a brand-new crate's first publish special, and both are resolved by a one-time manual step:

1. The CI registry token can publish new *versions* of crates it already owns, but cannot *reserve* a new crate name. The first publish must come from a maintainer token, which then `cargo owner --add`s the CI token so later releases publish it automatically.
2. The verify build needs `rag-rat-oplog`'s new APIs on the registry first — which only happens at the next lockstep release.

Nothing depends on `rag-rat-sync` downstream yet (the CLI doesn't wire it in until the pairing slice), so deferring the publish is safe. The bootstrap procedure is documented inline next to the entry.

## Effect on main

On the next push to main, `release-plz-release` skips `rag-rat-sync` and finds nothing else to publish (every other crate is already at `0.20.0` on crates.io), so the job goes green.

Also fixes the stale "three-crate workspace" comment (the workspace is now 13 crates) and the missing-changelog warning for the crate (points it at the combined root `CHANGELOG.md` like every other member).