### PR TITLE
feat(sync): authorize connecting nodes against the account roster before syncing (#881)

### DIFF
--- a/crates/rag-rat-oplog/src/account/mod.rs
+++ b/crates/rag-rat-oplog/src/account/mod.rs
@@ -29,6 +29,7 @@ mod id;
 #[allow(dead_code, reason = "some C4.1 primitives still precede their C5 consumers (#607)")]
 mod keywrap;
 mod limits;
+mod node_binding;
 mod ops;
 mod registers;
 // C4.2b: the account secrets log (`log_id = 1`) — the `StreamKeyWrap` op + owner-gated acceptance
@@ -85,6 +86,9 @@ pub use id::AccountId;
 // C4.1 content-key primitives the C4.3b sealing surface exposes: `ContentKey` is the `Ready`
 // payload C5's seal path consumes; `KeyId` is the selection identity (#607).
 pub use keywrap::{ContentKey, KeyId};
+// The phase-D (#881) node-authorization seam: mint + verify a signed transport-node ↔
+// account-device binding. Consumed by the transport crate's auth handshake.
+pub use node_binding::{NodeAuthError, sign_local_node_binding, verify_node_binding};
 pub use ops::{DeviceCut, DeviceRole, GrantRole};
 // The in-tx content-key mint + owner-gated `StreamKeyWrap` author seam (C4.3a), the C4.3b READ
 // side (derive-on-read sealing-key selection + the key_id adoption cross-check), and the C4.4

--- a/crates/rag-rat-oplog/src/account/node_binding.rs
+++ b/crates/rag-rat-oplog/src/account/node_binding.rs
@@ -1,0 +1,376 @@
+//! Signed transport-node ↔ account-device binding for peer sync authorization (phase D, #881).
+//!
+//! The iroh transport key is a per-install identity deliberately distinct from any account device
+//! signing key (key hygiene — the long-term device key never doubles as a TLS key). So proving that
+//! a connecting node belongs to the account needs an explicit, signed statement: a roster device
+//! vouches "transport node N may sync account A". This module mints and verifies that statement.
+//!
+//! The verifier's guarantee rests on THREE independent facts, all required:
+//! 1. the statement is signed by a device whose fingerprint is **roster-effective** in the current
+//!    fold — proves a real account device authored it;
+//! 2. the bound `node_pubkey` equals the connection's **iroh-authenticated** remote node id —
+//!    proves the *connector* actually holds that transport key, so a captured/leaked binding is
+//!    inert to anyone who does not also hold node N's transport secret (this is what defeats
+//!    replay);
+//! 3. the statement is fresh (`issued_at_ms` within a bounded window) — bounds the one residual, a
+//!    transport seed stolen without the device key, to that window rather than forever.
+//!
+//! The signed bytes are DOMAIN-TAGGED (`NODE_BINDING_DOMAIN`), separate from the account/content
+//! entry domains and the sync frame domain, so a binding signature can never collide with an op or
+//! frame preimage (a cross-protocol forgery the node-id check would not catch).
+
+use minicbor::{Decoder, Encoder};
+
+use super::storage;
+use crate::account::AccountId;
+use crate::device::DevicePublic;
+use crate::op::DeviceFingerprint;
+use crate::{cbor, identity};
+
+/// The signature domain for a node binding. Distinct from `FRAME_DOMAIN`, the account/content entry
+/// domains, and every other signed preimage in the system — a binding signature and an op signature
+/// can never be confused.
+const NODE_BINDING_DOMAIN: &str = "rag-rat/node-binding/1";
+
+/// A binding older than this (relative to the verifier's clock) is rejected. The honest client
+/// mints a fresh binding per dial — it holds both keys locally — so a tight window costs nothing
+/// and bounds the stolen-transport-seed residual to a day rather than forever.
+pub const MAX_BINDING_AGE_MS: i64 = 24 * 60 * 60 * 1000;
+
+/// A binding whose `issued_at_ms` is more than this far in the FUTURE is rejected — tolerates
+/// modest clock skew between peers without opening a meaningful pre-dating window.
+pub const MAX_BINDING_FUTURE_SKEW_MS: i64 = 60 * 60 * 1000;
+
+const INFALLIBLE: &str = "encoding into an owned Vec cannot fail";
+
+/// Why a node binding failed authorization. Typed for the caller's logging and future retry logic
+/// (a `NotRosterDevice` can be retried after more of the account log syncs; a `BadSignature` never
+/// can) — but the transport MUST collapse every variant to ONE uniform wire refusal, so a peer
+/// cannot use the distinction as an oracle ("does this server host account A / know device D").
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum NodeAuthError {
+    /// The binding bytes are not a well-formed, domain-tagged node binding.
+    Malformed,
+    /// The signature does not verify under the embedded device pubkey.
+    BadSignature,
+    /// The signing device is not roster-effective in the current fold (removed, or not yet synced).
+    NotRosterDevice,
+    /// The bound `node_pubkey` is not the connection's authenticated remote node id.
+    NodeMismatch,
+    /// The binding names a different account than the session is scoped to.
+    WrongAccount,
+    /// The binding is stale, or dated implausibly far in the future.
+    Expired,
+    /// No local device exists to sign a binding (this store has no account yet).
+    NoLocalDevice,
+}
+
+/// The canonical, domain-tagged bytes a device signs to vouch for a node. Kept identical between
+/// the mint and verify paths (and stable for a future persisted `NodeBind` op to embed), so the
+/// signature covers exactly `[domain, account_id, node_pubkey, device_pubkey, issued_at_ms]`.
+fn signing_bytes(
+    account_id: AccountId,
+    node_pubkey: &[u8; 32],
+    device_pubkey: &[u8; 32],
+    issued_at_ms: i64,
+) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(160);
+    let mut enc = Encoder::new(&mut buf);
+    enc.array(5).expect(INFALLIBLE);
+    enc.str(NODE_BINDING_DOMAIN).expect(INFALLIBLE);
+    enc.bytes(&account_id.to_bytes()).expect(INFALLIBLE);
+    enc.bytes(node_pubkey).expect(INFALLIBLE);
+    enc.bytes(device_pubkey).expect(INFALLIBLE);
+    enc.i64(issued_at_ms).expect(INFALLIBLE);
+    buf
+}
+
+/// Mint a signed binding vouching that THIS install's transport `node_pubkey` belongs to the local
+/// account device, for `account_id`. Loads the local device WITHOUT minting (a store with no
+/// account cannot authorize a sync); returns [`NodeAuthError::NoLocalDevice`] if absent. The
+/// returned bytes are what the transport puts on the wire in its `Auth` frame.
+pub fn sign_local_node_binding(
+    conn: &rusqlite::Connection,
+    account_id: AccountId,
+    node_pubkey: &[u8; 32],
+    now_ms: i64,
+) -> anyhow::Result<Result<Vec<u8>, NodeAuthError>> {
+    let Some(local) = identity::load_local_device(conn)? else {
+        return Ok(Err(NodeAuthError::NoLocalDevice));
+    };
+    let device_pubkey = local.public().to_bytes();
+    let signature =
+        local.secret().sign(&signing_bytes(account_id, node_pubkey, &device_pubkey, now_ms));
+
+    let mut buf = Vec::with_capacity(224);
+    let mut enc = Encoder::new(&mut buf);
+    enc.array(6).expect(INFALLIBLE);
+    enc.str(NODE_BINDING_DOMAIN).expect(INFALLIBLE);
+    enc.bytes(&account_id.to_bytes()).expect(INFALLIBLE);
+    enc.bytes(node_pubkey).expect(INFALLIBLE);
+    enc.bytes(&device_pubkey).expect(INFALLIBLE);
+    enc.i64(now_ms).expect(INFALLIBLE);
+    enc.bytes(&signature).expect(INFALLIBLE);
+    Ok(Ok(buf))
+}
+
+struct DecodedBinding {
+    account_id: [u8; 32],
+    node_pubkey: [u8; 32],
+    device_pubkey: [u8; 32],
+    issued_at_ms: i64,
+    signature: [u8; 64],
+}
+
+fn decode(bytes: &[u8]) -> Result<DecodedBinding, NodeAuthError> {
+    let mut dec = Decoder::new(bytes);
+    let outer = dec.array().map_err(|_| NodeAuthError::Malformed)?;
+    if outer != Some(6) {
+        return Err(NodeAuthError::Malformed);
+    }
+    let domain = dec.str().map_err(|_| NodeAuthError::Malformed)?;
+    if domain != NODE_BINDING_DOMAIN {
+        return Err(NodeAuthError::Malformed);
+    }
+    let account_id = fixed32(&mut dec)?;
+    let node_pubkey = fixed32(&mut dec)?;
+    let device_pubkey = fixed32(&mut dec)?;
+    let issued_at_ms = dec.i64().map_err(|_| NodeAuthError::Malformed)?;
+    let signature = fixed64(&mut dec)?;
+    // A canonical binding consumes ALL its bytes — trailing CBOR is malformed, never ignored.
+    if dec.position() != bytes.len() {
+        return Err(NodeAuthError::Malformed);
+    }
+    Ok(DecodedBinding { account_id, node_pubkey, device_pubkey, issued_at_ms, signature })
+}
+
+/// Verify a peer's node binding for `account_id` against the current fold and the connection's
+/// authenticated `remote_node_pubkey`. Returns `Ok(())` iff every check passes — see the module doc
+/// for why all three (roster, node match, freshness) are required. The caller re-runs this PER
+/// connection (never caches) so a device removed since a prior session is refused, and collapses
+/// any `Err` to a single uniform wire refusal.
+pub fn verify_node_binding(
+    conn: &rusqlite::Connection,
+    account_id: AccountId,
+    binding_bytes: &[u8],
+    remote_node_pubkey: &[u8; 32],
+    now_ms: i64,
+) -> anyhow::Result<Result<(), NodeAuthError>> {
+    let b = match decode(binding_bytes) {
+        Ok(b) => b,
+        Err(e) => return Ok(Err(e)),
+    };
+    // Scope: the binding must name the session's account.
+    if b.account_id != account_id.to_bytes() {
+        return Ok(Err(NodeAuthError::WrongAccount));
+    }
+    // Node match: the binding must name the connector's AUTHENTICATED transport key. This is what
+    // makes a stolen binding useless — iroh will not let anyone but node N present remote id N.
+    if &b.node_pubkey != remote_node_pubkey {
+        return Ok(Err(NodeAuthError::NodeMismatch));
+    }
+    // Signature: verify over the exact canonical preimage, under the embedded (self-certifying)
+    // device pubkey.
+    let Ok(pubkey) = DevicePublic::from_bytes(&b.device_pubkey) else {
+        return Ok(Err(NodeAuthError::BadSignature));
+    };
+    let preimage = signing_bytes(account_id, &b.node_pubkey, &b.device_pubkey, b.issued_at_ms);
+    if pubkey.verify(&preimage, &b.signature).is_err() {
+        return Ok(Err(NodeAuthError::BadSignature));
+    }
+    // Roster membership: the signer's fingerprint (self-certified as `sha256(device_pubkey)`, never
+    // resolved from a fold-independent key store) must be effective in the CURRENT fold. Any role
+    // is allowed — the roster gate is read access, not authoring authority; gating on Owner
+    // would break a member device restoring its own account.
+    let fingerprint = DeviceFingerprint::from_bytes(cbor::sha256(&b.device_pubkey));
+    let effective = storage::list_effective_roster_fingerprints(conn, account_id)?;
+    if !effective.contains(&fingerprint) {
+        return Ok(Err(NodeAuthError::NotRosterDevice));
+    }
+    // Freshness: bounds the stolen-transport-seed residual. The binding may not be older than
+    // MAX_BINDING_AGE_MS nor dated more than MAX_BINDING_FUTURE_SKEW_MS ahead of the verifier.
+    if b.issued_at_ms < now_ms.saturating_sub(MAX_BINDING_AGE_MS)
+        || b.issued_at_ms > now_ms.saturating_add(MAX_BINDING_FUTURE_SKEW_MS)
+    {
+        return Ok(Err(NodeAuthError::Expired));
+    }
+    Ok(Ok(()))
+}
+
+fn fixed32(dec: &mut Decoder<'_>) -> Result<[u8; 32], NodeAuthError> {
+    dec.bytes()
+        .map_err(|_| NodeAuthError::Malformed)?
+        .try_into()
+        .map_err(|_| NodeAuthError::Malformed)
+}
+
+fn fixed64(dec: &mut Decoder<'_>) -> Result<[u8; 64], NodeAuthError> {
+    dec.bytes()
+        .map_err(|_| NodeAuthError::Malformed)?
+        .try_into()
+        .map_err(|_| NodeAuthError::Malformed)
+}
+
+#[cfg(test)]
+mod tests {
+    use rusqlite::Connection;
+
+    use super::*;
+    use crate::account::local_account;
+    use crate::device::DeviceSecret;
+
+    const NOW: i64 = 1_700_000_000_000;
+    const NODE: [u8; 32] = [7u8; 32];
+
+    fn db_with_account() -> (Connection, AccountId) {
+        let conn = Connection::open_in_memory().unwrap();
+        rag_rat_db::schema::apply(&conn, &crate::test_hooks()).unwrap();
+        let account = local_account(&conn, NOW).unwrap();
+        (conn, account)
+    }
+
+    fn sign_local(conn: &Connection, account: AccountId, node: &[u8; 32], now: i64) -> Vec<u8> {
+        sign_local_node_binding(conn, account, node, now).unwrap().unwrap()
+    }
+
+    /// Assemble a binding signed by an ARBITRARY device (not necessarily on the roster), for the
+    /// non-roster-device test — the production mint only ever uses the local device.
+    fn sign_with(secret: &DeviceSecret, account: AccountId, node: &[u8; 32], now: i64) -> Vec<u8> {
+        let device_pubkey = secret.public().to_bytes();
+        let signature = secret.sign(&signing_bytes(account, node, &device_pubkey, now));
+        let mut buf = Vec::new();
+        let mut enc = Encoder::new(&mut buf);
+        enc.array(6).unwrap();
+        enc.str(NODE_BINDING_DOMAIN).unwrap();
+        enc.bytes(&account.to_bytes()).unwrap();
+        enc.bytes(node).unwrap();
+        enc.bytes(&device_pubkey).unwrap();
+        enc.i64(now).unwrap();
+        enc.bytes(&signature).unwrap();
+        buf
+    }
+
+    #[test]
+    fn a_valid_binding_from_a_roster_device_verifies() {
+        let (conn, account) = db_with_account();
+        let binding = sign_local(&conn, account, &NODE, NOW);
+        assert_eq!(verify_node_binding(&conn, account, &binding, &NODE, NOW).unwrap(), Ok(()));
+    }
+
+    #[test]
+    fn a_binding_for_a_different_node_is_refused() {
+        // A captured binding is inert when presented from a different transport key — the crux of
+        // the replay defense.
+        let (conn, account) = db_with_account();
+        let binding = sign_local(&conn, account, &NODE, NOW);
+        assert_eq!(
+            verify_node_binding(&conn, account, &binding, &[8u8; 32], NOW).unwrap(),
+            Err(NodeAuthError::NodeMismatch),
+        );
+    }
+
+    #[test]
+    fn a_binding_naming_a_different_account_is_refused() {
+        let (conn, account) = db_with_account();
+        let binding = sign_local(&conn, account, &NODE, NOW);
+        let other = AccountId::from_bytes([9u8; 32]);
+        assert_eq!(
+            verify_node_binding(&conn, other, &binding, &NODE, NOW).unwrap(),
+            Err(NodeAuthError::WrongAccount),
+        );
+    }
+
+    #[test]
+    fn a_binding_from_a_non_roster_device_is_refused() {
+        // Correct account + node + a valid signature, but the signer is not a roster device.
+        let (conn, account) = db_with_account();
+        let stranger = DeviceSecret::from_seed(&[0x5a; 32]);
+        let binding = sign_with(&stranger, account, &NODE, NOW);
+        assert_eq!(
+            verify_node_binding(&conn, account, &binding, &NODE, NOW).unwrap(),
+            Err(NodeAuthError::NotRosterDevice),
+        );
+    }
+
+    #[test]
+    fn a_stale_or_future_binding_is_refused() {
+        let (conn, account) = db_with_account();
+        let binding = sign_local(&conn, account, &NODE, NOW);
+        assert_eq!(
+            verify_node_binding(&conn, account, &binding, &NODE, NOW + MAX_BINDING_AGE_MS + 1)
+                .unwrap(),
+            Err(NodeAuthError::Expired),
+            "older than the max age",
+        );
+        let future = sign_local(&conn, account, &NODE, NOW + MAX_BINDING_FUTURE_SKEW_MS + 10_000);
+        assert_eq!(
+            verify_node_binding(&conn, account, &future, &NODE, NOW).unwrap(),
+            Err(NodeAuthError::Expired),
+            "dated too far in the future",
+        );
+    }
+
+    #[test]
+    fn a_tampered_signature_is_refused() {
+        let (conn, account) = db_with_account();
+        let mut binding = sign_local(&conn, account, &NODE, NOW);
+        *binding.last_mut().unwrap() ^= 0x01; // flip a bit in the trailing signature
+        assert_eq!(
+            verify_node_binding(&conn, account, &binding, &NODE, NOW).unwrap(),
+            Err(NodeAuthError::BadSignature),
+        );
+    }
+
+    #[test]
+    fn malformed_bytes_are_refused_not_panicked() {
+        let (conn, account) = db_with_account();
+        for bad in [vec![], vec![0xff; 4], vec![0u8; 200]] {
+            assert_eq!(
+                verify_node_binding(&conn, account, &bad, &NODE, NOW).unwrap(),
+                Err(NodeAuthError::Malformed),
+            );
+        }
+    }
+
+    #[test]
+    fn a_wrong_domain_binding_is_malformed() {
+        // A structurally valid 6-array whose domain tag is not ours — the cross-protocol guard.
+        let (conn, account) = db_with_account();
+        let mut buf = Vec::new();
+        let mut enc = Encoder::new(&mut buf);
+        enc.array(6).unwrap();
+        enc.str("some/other-protocol/1").unwrap();
+        enc.bytes(&account.to_bytes()).unwrap();
+        enc.bytes(&NODE).unwrap();
+        enc.bytes(&[0u8; 32]).unwrap();
+        enc.i64(NOW).unwrap();
+        enc.bytes(&[0u8; 64]).unwrap();
+        assert_eq!(
+            verify_node_binding(&conn, account, &buf, &NODE, NOW).unwrap(),
+            Err(NodeAuthError::Malformed),
+        );
+    }
+
+    #[test]
+    fn trailing_bytes_after_a_binding_are_malformed() {
+        let (conn, account) = db_with_account();
+        let mut binding = sign_local(&conn, account, &NODE, NOW);
+        binding.push(0xff); // one byte past a valid binding
+        assert_eq!(
+            verify_node_binding(&conn, account, &binding, &NODE, NOW).unwrap(),
+            Err(NodeAuthError::Malformed),
+        );
+    }
+
+    #[test]
+    fn signing_without_a_local_device_reports_no_local_device() {
+        // A store with schema but no account has no device to sign with.
+        let conn = Connection::open_in_memory().unwrap();
+        rag_rat_db::schema::apply(&conn, &crate::test_hooks()).unwrap();
+        let account = AccountId::from_bytes([1u8; 32]);
+        assert_eq!(
+            sign_local_node_binding(&conn, account, &NODE, NOW).unwrap(),
+            Err(NodeAuthError::NoLocalDevice),
+        );
+    }
+}

--- a/crates/rag-rat-oplog/src/lib.rs
+++ b/crates/rag-rat-oplog/src/lib.rs
@@ -94,7 +94,7 @@ pub use account::{
     CapacityScope, CatchUpReport, ContentIngestOutcome, ContentKey, ContentKeyring,
     ContentRefoldBudget, ContentSettleReport, DeviceCut, DeviceRole, GrantAuthority,
     GrantDeviceAuthority, GrantDeviceBoundary, GrantRole, IngestOutcome, KeyId, LiveKeyEpoch,
-    LiveKeyTargets, OwnerAuthority, OwnerChainAuthority, PreparedContentAuthoring,
+    LiveKeyTargets, NodeAuthError, OwnerAuthority, OwnerChainAuthority, PreparedContentAuthoring,
     RosterContentAuthority, RotationOutcome, SealPolicy, SealingKeyOutcome, SelectedWrap,
     SnapshotAuthorOutcome, SyncAccountEntry, SyncContentEntry, account_entries_for_sync,
     account_entry_ref, account_ingest, account_signed_entry_exists, account_signed_hash,
@@ -110,7 +110,8 @@ pub use account::{
     owned_stream_v2_id, owner_control_authority, owner_secrets_authority,
     prepare_content_authoring, roster_content_authority, rotate_stream_key_in_tx,
     select_current_sealing_wrap, settle_pending_content_refold_for_stream_in_tx,
-    settle_pending_content_refolds, stream_key_rotation_needed, stream_owner_effective,
+    settle_pending_content_refolds, sign_local_node_binding, stream_key_rotation_needed,
+    stream_owner_effective, verify_node_binding,
 };
 // The `/3` content projection's store-global upgrade re-fold (#688): wired into the index
 // open/migrate seam by rag-rat-core, so a stale store is rebuilt (every stream, then the one

--- a/crates/rag-rat-sync/src/auth.rs
+++ b/crates/rag-rat-sync/src/auth.rs
@@ -1,0 +1,414 @@
+//! The node-authorization handshake that gates a session (phase D, #881).
+//!
+//! Runs BEFORE [`crate::session::run_session`], over the same bidirectional stream, and reveals
+//! nothing about the account (not even confirmation that this peer hosts it) until the remote is
+//! authorized. Each side presents a signed transport-node ↔ account-device binding and verifies the
+//! other's under its OWN admission policy — authorization is **mutual**, so a peer handed a
+//! poisoned address never streams its inventory to an impostor.
+//!
+//! Ordering is asymmetric to close the metadata gap without deadlocking (the transfer phase that
+//! follows stays concurrent):
+//! - the **acceptor** reads the dialer's binding and verifies it BEFORE sending its own — an
+//!   unauthorized dialer learns nothing, not even the acceptor's binding;
+//! - the **dialer** sends its binding (to the node iroh already authenticated it dialed) then
+//!   verifies the acceptor's before proceeding to the data phase.
+//!
+//! A failure closes with one UNIFORM error regardless of cause (wrong account / not on roster / bad
+//! signature / stale) so a peer cannot probe "does this server host account A / know device D".
+
+use std::time::Duration;
+
+use tokio::io::{AsyncRead, AsyncWrite};
+
+use crate::codec::{self, CodecError};
+use crate::wire::Frame;
+
+/// How long a peer may take to send its auth frame before the handshake aborts. Deliberately much
+/// shorter than the data-phase idle timeout: an unauthorized peer that connects and stalls must not
+/// occupy the single-session accept slot for long.
+pub const DEFAULT_PRE_AUTH_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// The largest frame accepted during the auth phase, checked against the length prefix BEFORE any
+/// allocation. A valid auth frame is a ~600-byte cap (domain + tag + account id + a
+/// [`crate::wire::MAX_AUTH_BINDING_BYTES`] binding); 1 KiB leaves headroom while keeping the
+/// pre-auth allocation an unauthenticated peer can force to ~1 KiB, not the data-phase
+/// [`crate::codec::MAX_FRAME_BYTES`].
+const MAX_AUTH_FRAME_BYTES: u32 = 1024;
+
+/// How a peer decides whether to admit a connection. Local policy, never negotiated on the wire —
+/// an impostor cannot assert `Open` to exempt itself from the other side's `Closed`. Per-ACCOUNT,
+/// not per-endpoint: one transport node may legitimately serve several accounts, so a public
+/// account being `Open` must not open a private one on the same endpoint.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AuthPolicy {
+    /// Admit any peer. For a public, read-only knowledge base (a later slice) or a trusted LAN.
+    Open,
+    /// Admit only a peer whose binding verifies against this account's roster and the connection's
+    /// authenticated remote node id. The default for a private account.
+    Closed,
+    /// Admit a not-yet-roster peer via a one-time invite token — the onboarding/pairing flow. Not
+    /// implemented in this slice (it needs the token issue/redeem exchange); a session configured
+    /// with it fails closed rather than silently admitting.
+    InviteToken,
+}
+
+/// Which end of the connection this peer is — determines the send/verify order above.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AuthRole {
+    Dialer,
+    Acceptor,
+}
+
+/// The non-stream inputs to one auth handshake, bundled so [`run_auth_phase`] takes the stream
+/// pair, the authorizer, and this — rather than a long argument train.
+#[derive(Debug, Clone, Copy)]
+pub struct AuthConfig {
+    /// Which end this peer is (sets the send/verify order).
+    pub role: AuthRole,
+    /// The account this session is scoped to (named in our own auth frame).
+    pub account_id: [u8; 32],
+    /// Our own transport node id (bound into the binding we present).
+    pub local_node: [u8; 32],
+    /// The peer's iroh-authenticated transport node id (checked against the binding it presents).
+    pub remote_node: [u8; 32],
+    /// How we admit the peer.
+    pub policy: AuthPolicy,
+    /// The CURRENT wall-clock (ms) for this handshake — used to stamp the binding we mint and to
+    /// check the peer's binding freshness. Per-handshake, NOT a store-construction timestamp: a
+    /// reused store would otherwise mint stale bindings and never advance the replay window.
+    pub now_ms: i64,
+    /// How long we wait for the peer's auth frame before aborting.
+    pub pre_auth_timeout: Duration,
+}
+
+/// The account-authorization capability the transport needs from the store: mint our own binding,
+/// and verify a peer's. Both resolve against the store's account + live fold; kept separate from
+/// [`crate::session::SyncStore`] so the auth phase is testable without the data-phase machinery.
+pub trait NodeAuth {
+    /// Our signed binding vouching that `local_node` is this account's local device, stamped
+    /// `now_ms`. `Err` if this store cannot authorize (e.g. no local account/device yet — the
+    /// onboarding case).
+    fn local_binding(&self, local_node: &[u8; 32], now_ms: i64) -> anyhow::Result<Vec<u8>>;
+
+    /// Whether `binding` authorizes a peer whose iroh-authenticated node key is `remote_node`,
+    /// judged fresh against `now_ms`. Returns a plain bool — the store collapses the internal
+    /// failure taxonomy so the wire stays uniform. `Err` is reserved for a real fault (e.g. the
+    /// DB read failed), not a rejected peer.
+    fn authorize(
+        &self,
+        binding: &[u8],
+        remote_node: &[u8; 32],
+        now_ms: i64,
+    ) -> anyhow::Result<bool>;
+}
+
+/// A node-authorization handshake that did not admit the connection.
+#[derive(Debug)]
+pub enum AuthError {
+    /// The transport failed or the peer sent an unreadable frame.
+    Codec(CodecError),
+    /// The peer's binding did not satisfy our admission policy — the UNIFORM refusal (cause
+    /// hidden).
+    Unauthorized,
+    /// The peer sent no auth frame within the pre-auth deadline.
+    Timeout,
+    /// The peer sent something other than an auth frame to open, or a policy we cannot serve.
+    Protocol(String),
+}
+
+impl std::fmt::Display for AuthError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AuthError::Codec(e) => write!(f, "sync auth transport: {e}"),
+            AuthError::Unauthorized => write!(f, "peer is not authorized for this account"),
+            AuthError::Timeout => write!(f, "peer sent no auth frame before the deadline"),
+            AuthError::Protocol(m) => write!(f, "sync auth protocol violation: {m}"),
+        }
+    }
+}
+
+impl std::error::Error for AuthError {}
+
+/// Run the mutual auth handshake. On `Ok(())` both sides have verified each other under their own
+/// policies and the caller may proceed to [`crate::session::run_session`] over the same stream; on
+/// `Err` the caller drops the connection without revealing any inventory.
+pub async fn run_auth_phase<W, R, A>(
+    send: &mut W,
+    recv: &mut R,
+    auth: &A,
+    cfg: AuthConfig,
+) -> Result<(), AuthError>
+where
+    W: AsyncWrite + Unpin,
+    R: AsyncRead + Unpin,
+    A: NodeAuth,
+{
+    match cfg.role {
+        // Acceptor verifies the dialer BEFORE revealing its own binding.
+        AuthRole::Acceptor => {
+            verify_peer(recv, auth, &cfg).await?;
+            send_ours(send, auth, &cfg).await?;
+        },
+        // Dialer presents first (to the node it already authenticated), then verifies the acceptor
+        // before proceeding to the data phase.
+        AuthRole::Dialer => {
+            send_ours(send, auth, &cfg).await?;
+            verify_peer(recv, auth, &cfg).await?;
+        },
+    }
+    Ok(())
+}
+
+async fn send_ours<W: AsyncWrite + Unpin>(
+    send: &mut W,
+    auth: &dyn NodeAuth,
+    cfg: &AuthConfig,
+) -> Result<(), AuthError> {
+    // A store that cannot mint a binding (no local account/device) cannot authorize — fail closed.
+    let binding =
+        auth.local_binding(&cfg.local_node, cfg.now_ms).map_err(|_| AuthError::Unauthorized)?;
+    // Bound the WRITE by the same pre-auth deadline as the read: a peer that opens the stream but
+    // never grants receive credit would otherwise hang this write forever, blocking the acceptor's
+    // single-session accept slot — a pre-auth DoS.
+    let frame = Frame::Auth { account_id: cfg.account_id, binding };
+    match tokio::time::timeout(cfg.pre_auth_timeout, codec::write_frame(send, &frame)).await {
+        Ok(Ok(())) => Ok(()),
+        Ok(Err(e)) => Err(AuthError::Codec(e)),
+        Err(_elapsed) => Err(AuthError::Timeout),
+    }
+}
+
+async fn verify_peer<R: AsyncRead + Unpin>(
+    recv: &mut R,
+    auth: &dyn NodeAuth,
+    cfg: &AuthConfig,
+) -> Result<(), AuthError> {
+    let read = codec::read_frame_within(recv, MAX_AUTH_FRAME_BYTES);
+    let frame = match tokio::time::timeout(cfg.pre_auth_timeout, read).await {
+        Ok(Ok(frame)) => frame,
+        Ok(Err(e)) => return Err(AuthError::Codec(e)),
+        Err(_elapsed) => return Err(AuthError::Timeout),
+    };
+    let Frame::Auth { account_id: peer_account, binding } = frame else {
+        return Err(AuthError::Protocol("peer did not open with an auth frame".into()));
+    };
+    // Account scope is enforced regardless of policy — even an Open endpoint must not proceed to
+    // the data phase (whose Hello reveals the hosted account id + inventory) for a peer that
+    // named a DIFFERENT account. Open relaxes the BINDING check, never the scope. Uniform error
+    // either way.
+    if peer_account != cfg.account_id {
+        return Err(AuthError::Unauthorized);
+    }
+    // Every rejection below is the SAME uniform error — no not-on-roster / bad-sig distinction on
+    // the wire.
+    match cfg.policy {
+        AuthPolicy::Open => Ok(()),
+        AuthPolicy::Closed => {
+            match auth.authorize(&binding, &cfg.remote_node, cfg.now_ms) {
+                Ok(true) => Ok(()),
+                Ok(false) => Err(AuthError::Unauthorized),
+                // A real fault (DB read failed) is not the same as a rejected peer, but it still
+                // means we cannot admit — surface it uniformly rather than admitting on error.
+                Err(_) => Err(AuthError::Unauthorized),
+            }
+        },
+        AuthPolicy::InviteToken =>
+            Err(AuthError::Protocol("invite-token admission is not supported yet".into())),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ACCT: [u8; 32] = [1u8; 32];
+    const D_NODE: [u8; 32] = [2u8; 32];
+    const A_NODE: [u8; 32] = [3u8; 32];
+
+    /// A fake authorizer that tests the PROTOCOL (ordering, mutual verification, uniform refusal)
+    /// independently of the binding crypto (covered by the oplog `node_binding` tests).
+    struct FakeAuth {
+        binding: Vec<u8>,
+        authorize_ok: bool,
+    }
+
+    impl NodeAuth for FakeAuth {
+        fn local_binding(&self, _local_node: &[u8; 32], _now_ms: i64) -> anyhow::Result<Vec<u8>> {
+            Ok(self.binding.clone())
+        }
+
+        fn authorize(
+            &self,
+            _binding: &[u8],
+            _remote_node: &[u8; 32],
+            _now_ms: i64,
+        ) -> anyhow::Result<bool> {
+            Ok(self.authorize_ok)
+        }
+    }
+
+    async fn run_pair(
+        dialer: FakeAuth,
+        dialer_account: [u8; 32],
+        dialer_policy: AuthPolicy,
+        acceptor: FakeAuth,
+        acceptor_policy: AuthPolicy,
+    ) -> (Result<(), AuthError>, Result<(), AuthError>) {
+        let (mut d_send, mut a_recv) = tokio::io::duplex(1 << 16);
+        let (mut a_send, mut d_recv) = tokio::io::duplex(1 << 16);
+        // Short: the happy path never waits, and a refusal leaves the peer's read pending (the
+        // duplex send half is not dropped until this fn returns, unlike a real connection
+        // that closes on abort), so a tight timeout keeps the failure-path tests fast.
+        let timeout = Duration::from_millis(300);
+        let dialer_side = run_auth_phase(&mut d_send, &mut d_recv, &dialer, AuthConfig {
+            role: AuthRole::Dialer,
+            account_id: dialer_account,
+            local_node: D_NODE,
+            remote_node: A_NODE,
+            policy: dialer_policy,
+            now_ms: 1,
+            pre_auth_timeout: timeout,
+        });
+        let acceptor_side = run_auth_phase(&mut a_send, &mut a_recv, &acceptor, AuthConfig {
+            role: AuthRole::Acceptor,
+            account_id: ACCT,
+            local_node: A_NODE,
+            remote_node: D_NODE,
+            policy: acceptor_policy,
+            now_ms: 1,
+            pre_auth_timeout: timeout,
+        });
+        tokio::join!(dialer_side, acceptor_side)
+    }
+
+    fn ok_auth() -> FakeAuth {
+        FakeAuth { binding: vec![1, 2, 3], authorize_ok: true }
+    }
+
+    #[tokio::test]
+    async fn mutual_closed_authorization_admits_both() {
+        let (d, a) =
+            run_pair(ok_auth(), ACCT, AuthPolicy::Closed, ok_auth(), AuthPolicy::Closed).await;
+        assert!(d.is_ok() && a.is_ok(), "both sides authorized each other: {d:?} {a:?}");
+    }
+
+    #[tokio::test]
+    async fn an_unauthorized_dialer_is_refused_before_the_acceptor_reveals_its_binding() {
+        // The acceptor rejects the dialer. Because the acceptor verifies BEFORE sending its own
+        // binding, it aborts without revealing anything — the dialer's read then fails (no Auth
+        // frame arrives). This is the mutual-auth ordering that stops inventory (and here even the
+        // acceptor's binding) leaking to an unauthorized peer.
+        let acceptor = FakeAuth { binding: vec![9, 9, 9], authorize_ok: false };
+        let (dialer, accept) =
+            run_pair(ok_auth(), ACCT, AuthPolicy::Closed, acceptor, AuthPolicy::Closed).await;
+        assert!(matches!(accept, Err(AuthError::Unauthorized)), "acceptor refused: {accept:?}");
+        assert!(dialer.is_err(), "dialer got no acceptor binding — nothing leaked: {dialer:?}");
+    }
+
+    #[tokio::test]
+    async fn open_policy_admits_a_peer_that_would_fail_closed() {
+        // A peer whose binding would never verify is admitted under Open (no verification), so both
+        // sides complete.
+        let anon_dialer = FakeAuth { binding: vec![], authorize_ok: false };
+        let (d, a) =
+            run_pair(anon_dialer, ACCT, AuthPolicy::Open, ok_auth(), AuthPolicy::Open).await;
+        assert!(d.is_ok() && a.is_ok(), "open admits anyone: {d:?} {a:?}");
+    }
+
+    #[tokio::test]
+    async fn a_dialer_naming_a_different_account_is_refused_under_closed() {
+        // The dialer presents a binding scoped to a different account than the acceptor serves.
+        let (_dialer, accept) = run_pair(
+            ok_auth(),
+            [0xee; 32], // dialer names a different account
+            AuthPolicy::Closed,
+            ok_auth(),
+            AuthPolicy::Closed,
+        )
+        .await;
+        assert!(
+            matches!(accept, Err(AuthError::Unauthorized)),
+            "the acceptor refuses a cross-account dialer: {accept:?}",
+        );
+    }
+
+    #[tokio::test]
+    async fn even_an_open_endpoint_refuses_a_cross_account_dialer() {
+        // Open relaxes the binding check, NOT the account scope: a peer naming a different account
+        // than the endpoint serves must be refused before run_session could leak the hosted
+        // account's Hello + inventory.
+        let (_dialer, accept) = run_pair(
+            ok_auth(),
+            [0xee; 32], // dialer names a different account
+            AuthPolicy::Open,
+            ok_auth(),
+            AuthPolicy::Open,
+        )
+        .await;
+        assert!(
+            matches!(accept, Err(AuthError::Unauthorized)),
+            "an open endpoint still enforces the account scope: {accept:?}",
+        );
+    }
+
+    #[tokio::test]
+    async fn invite_token_policy_fails_closed_until_implemented() {
+        let (_d, a) =
+            run_pair(ok_auth(), ACCT, AuthPolicy::Closed, ok_auth(), AuthPolicy::InviteToken).await;
+        assert!(
+            matches!(a, Err(AuthError::Protocol(_))),
+            "invite-token is not admitted yet: {a:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_peer_that_sends_nothing_times_out() {
+        // The write end stays alive but silent, so the acceptor's read pends and hits the deadline
+        // (rather than seeing EOF).
+        let (_silent_writer, mut recv) = tokio::io::duplex(1 << 10);
+        let (mut send, _sink) = tokio::io::duplex(1 << 10);
+        let r = run_auth_phase(&mut send, &mut recv, &ok_auth(), AuthConfig {
+            role: AuthRole::Acceptor,
+            account_id: ACCT,
+            local_node: A_NODE,
+            remote_node: D_NODE,
+            policy: AuthPolicy::Closed,
+            now_ms: 1,
+            pre_auth_timeout: Duration::from_millis(100),
+        })
+        .await;
+        assert!(matches!(r, Err(AuthError::Timeout)), "a silent peer times out: {r:?}");
+    }
+
+    #[tokio::test]
+    async fn a_non_auth_first_frame_is_a_protocol_violation() {
+        // The peer opens with a data-phase frame instead of an Auth frame.
+        let (mut peer_send, mut recv) = tokio::io::duplex(1 << 12);
+        let (mut send, _sink) = tokio::io::duplex(1 << 12);
+        codec::write_frame(&mut peer_send, &Frame::Done).await.unwrap();
+        let r = run_auth_phase(&mut send, &mut recv, &ok_auth(), AuthConfig {
+            role: AuthRole::Acceptor,
+            account_id: ACCT,
+            local_node: A_NODE,
+            remote_node: D_NODE,
+            policy: AuthPolicy::Open,
+            now_ms: 1,
+            pre_auth_timeout: Duration::from_millis(200),
+        })
+        .await;
+        assert!(matches!(r, Err(AuthError::Protocol(_))), "a non-auth opener is refused: {r:?}");
+    }
+
+    #[test]
+    fn auth_errors_render() {
+        // Every Display arm is reachable and non-empty.
+        for e in [
+            AuthError::Unauthorized,
+            AuthError::Timeout,
+            AuthError::Protocol("x".into()),
+            AuthError::Codec(CodecError::Eof),
+        ] {
+            assert!(!format!("{e}").is_empty());
+        }
+    }
+}

--- a/crates/rag-rat-sync/src/codec.rs
+++ b/crates/rag-rat-sync/src/codec.rs
@@ -66,6 +66,17 @@ pub async fn write_frame<W: AsyncWrite + Unpin>(
 
 /// Read one frame, or [`CodecError::Eof`] if the stream ends cleanly before the next length prefix.
 pub async fn read_frame<R: AsyncRead + Unpin>(r: &mut R) -> Result<Frame, CodecError> {
+    read_frame_within(r, MAX_FRAME_BYTES).await
+}
+
+/// [`read_frame`] with a caller-supplied maximum, checked against the length prefix BEFORE any
+/// allocation. The auth phase passes a tight bound so an unauthenticated peer cannot force the full
+/// [`MAX_FRAME_BYTES`] allocation with its first frame (#881) — the frame-level cap is what
+/// actually bounds the pre-auth allocation, since the body is sized from the length prefix.
+pub async fn read_frame_within<R: AsyncRead + Unpin>(
+    r: &mut R,
+    max_bytes: u32,
+) -> Result<Frame, CodecError> {
     let mut len_buf = [0u8; 4];
     match r.read_exact(&mut len_buf).await {
         Ok(_) => {},
@@ -73,7 +84,7 @@ pub async fn read_frame<R: AsyncRead + Unpin>(r: &mut R) -> Result<Frame, CodecE
         Err(e) => return Err(CodecError::Io(e)),
     }
     let len = u32::from_be_bytes(len_buf);
-    if len > MAX_FRAME_BYTES {
+    if len > max_bytes {
         return Err(CodecError::FrameTooLarge(len));
     }
     let mut body = vec![0u8; len as usize];
@@ -118,5 +129,19 @@ mod tests {
         a.write_all(&(MAX_FRAME_BYTES + 1).to_be_bytes()).await.unwrap();
         drop(a);
         assert!(matches!(read_frame(&mut b).await, Err(CodecError::FrameTooLarge(_))));
+    }
+
+    #[tokio::test]
+    async fn a_capped_read_refuses_a_prefix_over_its_smaller_limit() {
+        // The auth phase reads with a tight cap so an unauthenticated peer cannot force the full
+        // MAX_FRAME_BYTES allocation. A 2 KiB prefix under a 1 KiB cap is refused from the prefix
+        // alone — the 2 KiB body is never allocated.
+        let (mut a, mut b) = tokio::io::duplex(64);
+        a.write_all(&2048u32.to_be_bytes()).await.unwrap();
+        drop(a);
+        assert!(matches!(
+            read_frame_within(&mut b, 1024).await,
+            Err(CodecError::FrameTooLarge(2048)),
+        ));
     }
 }

--- a/crates/rag-rat-sync/src/endpoint.rs
+++ b/crates/rag-rat-sync/src/endpoint.rs
@@ -9,16 +9,16 @@
 //! directory, so discovery happens ONLY through the relay this deployment pins — a peer is
 //! reachable iff it shares the configured relay, never via a third-party lookup.
 //!
-//! # Authorization is NOT enforced here (see #881)
+//! # Authorization (#881)
 //!
-//! iroh authenticates the transport KEY, but this slice does not check that the connecting node
-//! belongs to a device in the account. Any node that holds the endpoint address can complete the
-//! handshake and pull the account's inventory and signed entries. That is bounded — account entries
-//! are signed (a peer cannot forge one) and content is sealed (it needs keys this transport never
-//! carries), so an unauthorized peer learns the roster shape but cannot decrypt content or inject a
-//! valid entry — and no production path calls [`accept_and_sync`] yet. The node↔device binding and
-//! admission control are the pairing slice (D4); until then, treat a shared address as out-of-band
-//! trust between peers that already know each other.
+//! iroh authenticates the transport KEY; on top of that, both [`connect_and_sync`] and
+//! [`accept_and_sync`] run the mutual node-authorization handshake ([`run_auth_phase`]) BEFORE any
+//! inventory is exchanged. Under [`AuthPolicy::Closed`] a peer is admitted only if it presents a
+//! signed binding proving its authenticated node id belongs to a roster device of the account;
+//! under [`AuthPolicy::Open`] any peer is admitted (for a future public read-only knowledge base).
+//! The ONBOARDING case — admitting a not-yet-roster device via a one-time invite token
+//! ([`AuthPolicy::InviteToken`]) — is not implemented in this slice and fails closed; it is the
+//! pairing flow (`sync init` / `sync pair` / `sync join`) that the CLI slice wires up.
 
 use std::str::FromStr;
 
@@ -26,6 +26,9 @@ use iroh::endpoint::presets;
 use iroh::{Endpoint, EndpointAddr, RelayMode, RelayUrl, SecretKey};
 use tokio::time::timeout;
 
+use crate::auth::{
+    AuthConfig, AuthPolicy, AuthRole, DEFAULT_PRE_AUTH_TIMEOUT, NodeAuth, run_auth_phase,
+};
 use crate::session::{DEFAULT_IDLE_TIMEOUT, SessionError, SessionReport, SyncStore, run_session};
 use crate::wire::SYNC_ALPN;
 
@@ -76,20 +79,38 @@ pub fn endpoint_addr(endpoint: &Endpoint) -> EndpointAddr {
     endpoint.addr()
 }
 
-/// Dial `peer` and run one sync session against it, returning what moved.
-pub async fn connect_and_sync<S: SyncStore>(
+/// Dial `peer`, authorize each other under `policy`, then run one sync session, returning what
+/// moved. The auth handshake (#881) runs BEFORE any inventory: the dialer presents its binding,
+/// then verifies the acceptor's before revealing anything, so a poisoned address never leaks the
+/// account log to an impostor.
+pub async fn connect_and_sync<S: SyncStore + NodeAuth>(
     endpoint: &Endpoint,
     peer: impl Into<EndpointAddr>,
     store: &mut S,
+    policy: AuthPolicy,
+    now_ms: i64,
 ) -> Result<SessionReport, SyncFailure> {
+    let local_node = *endpoint.id().as_bytes();
     let conn = endpoint
         .connect(peer, SYNC_ALPN)
         .await
         .map_err(|e| SyncFailure::Endpoint(EndpointError::Connect(e.to_string())))?;
-    let (send, recv) = conn
+    let remote_node = *conn.remote_id().as_bytes();
+    let (mut send, mut recv) = conn
         .open_bi()
         .await
         .map_err(|e| SyncFailure::Endpoint(EndpointError::Connect(e.to_string())))?;
+    run_auth_phase(&mut send, &mut recv, &*store, AuthConfig {
+        role: AuthRole::Dialer,
+        account_id: store.account_id(),
+        local_node,
+        remote_node,
+        policy,
+        now_ms,
+        pre_auth_timeout: DEFAULT_PRE_AUTH_TIMEOUT,
+    })
+    .await
+    .map_err(SyncFailure::Auth)?;
     let report = run_session(store, send, recv).await.map_err(SyncFailure::Session)?;
     // Best-effort graceful close; the session already exchanged an explicit Done both ways.
     conn.close(0u32.into(), b"done");
@@ -103,10 +124,13 @@ pub async fn connect_and_sync<S: SyncStore>(
 /// bounded by [`DEFAULT_IDLE_TIMEOUT`]. `run_session`'s own idle timeout only starts once the
 /// stream is open, so without these a peer that connects and then stalls (never opening a stream)
 /// would hold this single-session server forever, blocking every later peer.
-pub async fn accept_and_sync<S: SyncStore>(
+pub async fn accept_and_sync<S: SyncStore + NodeAuth>(
     endpoint: &Endpoint,
     store: &mut S,
+    policy: AuthPolicy,
+    now_ms: i64,
 ) -> Result<SessionReport, SyncFailure> {
+    let local_node = *endpoint.id().as_bytes();
     let incoming = endpoint
         .accept()
         .await
@@ -115,19 +139,36 @@ pub async fn accept_and_sync<S: SyncStore>(
         .await
         .map_err(|_| SyncFailure::Endpoint(EndpointError::Connect("handshake timed out".into())))?
         .map_err(|e| SyncFailure::Endpoint(EndpointError::Connect(e.to_string())))?;
-    let (send, recv) = timeout(DEFAULT_IDLE_TIMEOUT, conn.accept_bi())
+    let remote_node = *conn.remote_id().as_bytes();
+    let (mut send, mut recv) = timeout(DEFAULT_IDLE_TIMEOUT, conn.accept_bi())
         .await
         .map_err(|_| SyncFailure::Endpoint(EndpointError::Connect("peer opened no stream".into())))?
         .map_err(|e| SyncFailure::Endpoint(EndpointError::Connect(e.to_string())))?;
+    // Authorize the dialer BEFORE run_session so no inventory (not even account confirmation)
+    // leaves this peer until the remote passes our policy (#881).
+    run_auth_phase(&mut send, &mut recv, &*store, AuthConfig {
+        role: AuthRole::Acceptor,
+        account_id: store.account_id(),
+        local_node,
+        remote_node,
+        policy,
+        now_ms,
+        pre_auth_timeout: DEFAULT_PRE_AUTH_TIMEOUT,
+    })
+    .await
+    .map_err(SyncFailure::Auth)?;
     let report = run_session(store, send, recv).await.map_err(SyncFailure::Session)?;
     conn.close(0u32.into(), b"done");
     Ok(report)
 }
 
-/// A sync attempt that failed either setting up the connection or running the session.
+/// A sync attempt that failed setting up the connection, authorizing the peer, or running the
+/// session.
 #[derive(Debug)]
 pub enum SyncFailure {
     Endpoint(EndpointError),
+    /// The node-authorization handshake refused the peer (or we could not authorize to it).
+    Auth(crate::auth::AuthError),
     Session(SessionError),
 }
 
@@ -135,6 +176,7 @@ impl std::fmt::Display for SyncFailure {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             SyncFailure::Endpoint(e) => write!(f, "{e}"),
+            SyncFailure::Auth(e) => write!(f, "{e}"),
             SyncFailure::Session(e) => write!(f, "{e}"),
         }
     }

--- a/crates/rag-rat-sync/src/lib.rs
+++ b/crates/rag-rat-sync/src/lib.rs
@@ -15,12 +15,14 @@
 //! - [`endpoint`] — the iroh endpoint that binds the ALPN over a pinned relay and runs a session
 //!   per connection.
 
+pub mod auth;
 pub mod codec;
 pub mod endpoint;
 pub mod session;
 pub mod store;
 pub mod wire;
 
+pub use auth::{AuthConfig, AuthError, AuthPolicy, AuthRole, NodeAuth, run_auth_phase};
 pub use endpoint::{
     EndpointError, SyncFailure, accept_and_sync, build_endpoint, connect_and_sync, endpoint_addr,
 };

--- a/crates/rag-rat-sync/src/session.rs
+++ b/crates/rag-rat-sync/src/session.rs
@@ -247,6 +247,11 @@ where
                 Ok(Frame::Hello { .. }) => {
                     return Err(SessionError::Protocol("a second hello mid-session".into()));
                 },
+                Ok(Frame::Auth { .. }) => {
+                    // Auth belongs to the handshake the endpoint runs BEFORE `run_session`; an Auth
+                    // frame in the data phase is out of sequence.
+                    return Err(SessionError::Protocol("an auth frame mid-session".into()));
+                },
                 // `read_frame_before` has already mapped EOF (truncated transfer) and idle timeout
                 // into a `SessionError`, so any error here just propagates.
                 Err(e) => return Err(e),

--- a/crates/rag-rat-sync/src/store.rs
+++ b/crates/rag-rat-sync/src/store.rs
@@ -9,10 +9,45 @@ use rag_rat_oplog::{
     AccountId, ContentIngestOutcome, IngestOutcome, account_entries_for_sync, account_entry_ref,
     account_ingest, account_signed_entry_exists, account_signed_hash, content_entries_for_sync,
     content_entry_ref, content_ingest, content_signed_entry_exists, content_signed_hash,
+    sign_local_node_binding, verify_node_binding,
 };
 use rusqlite::Connection;
 
+use crate::auth::NodeAuth;
 use crate::session::{Ingested, SyncStore};
+
+/// Mint this account's signed node binding for `local_node`. A store with no local device yet (a
+/// fresh peer being onboarded) has nothing to prove, so it returns an EMPTY binding rather than
+/// failing: an `Open` peer ignores it, while a `Closed` peer fails to verify it (an empty binding
+/// decodes to nothing) and correctly refuses — onboarding a not-yet-roster device is the deferred
+/// invite-token flow, not something `Closed` admits. Shared by both op-log stores — the binding is
+/// account-level, identical whether the session moves account entries or content.
+fn sign_binding(
+    conn: &Connection,
+    account_id: AccountId,
+    local_node: &[u8; 32],
+    now_ms: i64,
+) -> anyhow::Result<Vec<u8>> {
+    match sign_local_node_binding(conn, account_id, local_node, now_ms)? {
+        Ok(bytes) => Ok(bytes),
+        // No local device to sign with — send an anonymous (empty) binding. Never authorizes under
+        // `Closed`; harmless under `Open`.
+        Err(_no_local_device) => Ok(Vec::new()),
+    }
+}
+
+/// Whether a peer's binding authorizes it for `account_id`, given its authenticated `remote_node`.
+/// Collapses the internal failure taxonomy to a bool so the transport's wire refusal stays uniform;
+/// a `?`-propagated error here is a real DB fault, not a rejected peer.
+fn authorize_binding(
+    conn: &Connection,
+    account_id: AccountId,
+    binding: &[u8],
+    remote_node: &[u8; 32],
+    now_ms: i64,
+) -> anyhow::Result<bool> {
+    Ok(verify_node_binding(conn, account_id, binding, remote_node, now_ms)?.is_ok())
+}
 
 /// A [`SyncStore`] over one account's op log on a live connection. Scoped to a single account: a
 /// session syncs one account, and the hello handshake refuses a peer naming a different one.
@@ -165,5 +200,41 @@ impl SyncStore for OplogContentSyncStore<'_> {
             ContentIngestOutcome::Rejected(_) | ContentIngestOutcome::CapacityReached { .. } =>
                 Ok(Ingested::NoChange),
         }
+    }
+}
+
+// Both op-log stores carry the same account-level node-authorization capability (the binding is
+// about the account + transport node, independent of whether the session moves account entries or
+// content), so both delegate to the shared helpers above.
+// Both auth methods take `now_ms` per HANDSHAKE (not the store's construction-time `now_ms`, which
+// stays the ingest timestamp for received entries): binding freshness must track the live clock, or
+// a reused store would mint stale bindings and never advance the replay window.
+impl NodeAuth for OplogSyncStore<'_> {
+    fn local_binding(&self, local_node: &[u8; 32], now_ms: i64) -> anyhow::Result<Vec<u8>> {
+        sign_binding(self.conn, self.account_id, local_node, now_ms)
+    }
+
+    fn authorize(
+        &self,
+        binding: &[u8],
+        remote_node: &[u8; 32],
+        now_ms: i64,
+    ) -> anyhow::Result<bool> {
+        authorize_binding(self.conn, self.account_id, binding, remote_node, now_ms)
+    }
+}
+
+impl NodeAuth for OplogContentSyncStore<'_> {
+    fn local_binding(&self, local_node: &[u8; 32], now_ms: i64) -> anyhow::Result<Vec<u8>> {
+        sign_binding(self.conn, self.account_id, local_node, now_ms)
+    }
+
+    fn authorize(
+        &self,
+        binding: &[u8],
+        remote_node: &[u8; 32],
+        now_ms: i64,
+    ) -> anyhow::Result<bool> {
+        authorize_binding(self.conn, self.account_id, binding, remote_node, now_ms)
     }
 }

--- a/crates/rag-rat-sync/src/wire.rs
+++ b/crates/rag-rat-sync/src/wire.rs
@@ -13,9 +13,11 @@
 
 use minicbor::{Decoder, Encoder};
 
-/// The ALPN this protocol speaks (#406). Versioned: a breaking wire change bumps the suffix so an
-/// old peer declines the handshake instead of misreading frames.
-pub const SYNC_ALPN: &[u8] = b"rag-rat/sync/1";
+/// The ALPN this protocol speaks. Versioned: a breaking wire change bumps the suffix so an old peer
+/// declines the handshake instead of misreading frames. Bumped to `/2` for the #881 auth phase (the
+/// `Auth` frame exchanged before any inventory) — a `/1` peer, which would stream its inventory
+/// without authenticating, must not interoperate.
+pub const SYNC_ALPN: &[u8] = b"rag-rat/sync/2";
 
 /// Domain tag committed into every frame's leading array element, so a frame from another protocol
 /// (or a truncated one) cannot be mistaken for a valid frame.
@@ -32,13 +34,26 @@ pub const MAX_ENTRIES_PER_PAGE: usize = 256;
 /// accounts D targets the cap is never reached.
 pub const MAX_HELLO_HASHES: usize = 65_536;
 
+/// The maximum bytes an [`Frame::Auth`] binding carries. A node binding is a small fixed shape
+/// (~224 bytes: domain + three 32-byte keys + a timestamp + a 64-byte signature); this is a
+/// decode-time sanity bound on that field. The actual PRE-ALLOCATION bound for an unauthenticated
+/// peer is the auth phase's frame-level cap, enforced from the length prefix before the body is
+/// allocated (`auth::MAX_AUTH_FRAME_BYTES` via `codec::read_frame_within`) — not this, which is
+/// checked only after the frame is read.
+pub const MAX_AUTH_BINDING_BYTES: usize = 512;
+
 type Hash = [u8; 32];
 
 /// One protocol frame. The discriminant is the second array element (after the domain tag).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Frame {
-    /// Opens a session: the account being synced and every account-log entry hash the sender holds.
-    /// The peer replies with the entries in ITS store that are not in this set.
+    /// Authorizes the sender to the peer BEFORE any inventory is revealed (#881): names the account
+    /// and carries the sender's signed transport-node ↔ account-device binding. The peer verifies
+    /// it against its roster and the connection's authenticated remote node id under its own
+    /// admission policy, and reveals nothing (not even account confirmation) until it passes.
+    Auth { account_id: Hash, binding: Vec<u8> },
+    /// Opens the data phase: the account being synced and every account-log entry hash the sender
+    /// holds. The peer replies with the entries in ITS store that are not in this set.
     Hello { account_id: Hash, have: Vec<Hash> },
     /// A page of `signed_bytes` the peer lacked. `more` is true when further pages follow.
     Entries { entries: Vec<Vec<u8>>, more: bool },
@@ -51,6 +66,7 @@ mod tag {
     pub const HELLO: u8 = 0;
     pub const ENTRIES: u8 = 1;
     pub const DONE: u8 = 2;
+    pub const AUTH: u8 = 3;
 }
 
 /// A frame that failed to decode. Kept distinct from an I/O error so the session can treat a
@@ -83,6 +99,13 @@ impl Frame {
         let mut enc = Encoder::new(&mut buf);
         // `[domain, tag, ..variant fields]`.
         match self {
+            Frame::Auth { account_id, binding } => {
+                enc.array(4).expect(INFALLIBLE);
+                enc.str(FRAME_DOMAIN).expect(INFALLIBLE);
+                enc.u8(tag::AUTH).expect(INFALLIBLE);
+                enc.bytes(account_id).expect(INFALLIBLE);
+                enc.bytes(binding).expect(INFALLIBLE);
+            },
             Frame::Hello { account_id, have } => {
                 enc.array(3).expect(INFALLIBLE);
                 enc.str(FRAME_DOMAIN).expect(INFALLIBLE);
@@ -129,6 +152,7 @@ impl Frame {
             tag::HELLO => 3,
             tag::ENTRIES => 4,
             tag::DONE => 2,
+            tag::AUTH => 4,
             other => return Err(WireError::Malformed(format!("unknown frame tag {other}"))),
         };
         if outer != expected_outer {
@@ -147,6 +171,17 @@ impl Frame {
 
     fn decode_body(tag: u8, dec: &mut Decoder<'_>) -> Result<Frame, WireError> {
         match tag {
+            tag::AUTH => {
+                let account_id = fixed_hash(dec.bytes().map_err(m)?)?;
+                let binding = dec.bytes().map_err(m)?;
+                if binding.len() > MAX_AUTH_BINDING_BYTES {
+                    return Err(WireError::OverCap(format!(
+                        "auth binding {} > {MAX_AUTH_BINDING_BYTES}",
+                        binding.len()
+                    )));
+                }
+                Ok(Frame::Auth { account_id, binding: binding.to_vec() })
+            },
             tag::HELLO => {
                 let inner = dec.array().map_err(m)?;
                 if inner != Some(2) {
@@ -209,11 +244,22 @@ mod tests {
 
     #[test]
     fn every_frame_roundtrips() {
+        roundtrip(&Frame::Auth { account_id: [0xbb; 32], binding: vec![1, 2, 3, 4] });
+        roundtrip(&Frame::Auth { account_id: [0; 32], binding: vec![] });
         roundtrip(&Frame::Hello { account_id: [0xaa; 32], have: vec![[1; 32], [2; 32]] });
         roundtrip(&Frame::Hello { account_id: [0; 32], have: vec![] });
         roundtrip(&Frame::Entries { entries: vec![vec![1, 2, 3], vec![]], more: true });
         roundtrip(&Frame::Entries { entries: vec![], more: false });
         roundtrip(&Frame::Done);
+    }
+
+    #[test]
+    fn an_over_cap_auth_binding_is_rejected() {
+        // An Auth frame whose binding exceeds the cap is hostile — bounds the first-frame
+        // allocation an unauthenticated peer can force.
+        let frame =
+            Frame::Auth { account_id: [3; 32], binding: vec![0u8; MAX_AUTH_BINDING_BYTES + 1] };
+        assert!(matches!(Frame::decode(&frame.encode()), Err(WireError::OverCap(_))));
     }
 
     #[test]

--- a/crates/rag-rat-sync/tests/oplog_sync.rs
+++ b/crates/rag-rat-sync/tests/oplog_sync.rs
@@ -260,6 +260,83 @@ async fn foreign_account_content_is_not_stored() {
     );
 }
 
+/// The op-log store's [`NodeAuth`] wiring works end to end (#881): a store authorizes a binding it
+/// minted for a transport node, and refuses the same binding presented from any other node — the
+/// replay defense, verified through the real oplog sign/verify seams (not the fake used by the
+/// protocol tests).
+#[test]
+fn a_store_authorizes_its_own_binding_but_not_from_another_node() {
+    use rag_rat_sync::NodeAuth;
+
+    let db = fresh_db();
+    let account = local_account(&db, NOW).unwrap();
+    let store = OplogSyncStore::new(&db, account, NOW);
+
+    let node = [4u8; 32];
+    let binding = store.local_binding(&node, NOW).unwrap();
+    assert!(!binding.is_empty(), "a store with a local device mints a real binding");
+    assert!(store.authorize(&binding, &node, NOW).unwrap(), "its own node id is authorized");
+    assert!(
+        !store.authorize(&binding, &[5u8; 32], NOW).unwrap(),
+        "the same binding from a different node id is refused",
+    );
+}
+
+/// Auth freshness tracks the per-handshake clock, not the store's construction time (#881): a
+/// long-lived store constructed long ago still mints and verifies a binding at the current
+/// handshake time. Were the construction time reused, a binding minted "now" would read as
+/// implausibly far in the future and be refused.
+#[test]
+fn a_store_authorizes_against_the_handshake_clock_not_its_construction_time() {
+    use rag_rat_sync::NodeAuth;
+
+    let db = fresh_db();
+    let account = local_account(&db, NOW).unwrap();
+    let stale = OplogSyncStore::new(&db, account, NOW); // constructed with an old clock
+    let node = [4u8; 32];
+
+    let much_later = NOW + 10 * 24 * 60 * 60 * 1000; // ten days after construction
+    let binding = stale.local_binding(&node, much_later).unwrap();
+    assert!(
+        stale.authorize(&binding, &node, much_later).unwrap(),
+        "a long-lived store still authorizes using the current handshake time",
+    );
+}
+
+/// A store with no local account (a fresh onboarding peer) presents an empty, anonymous binding and
+/// authorizes nothing — so it can complete an `Open` handshake but never passes `Closed`.
+#[test]
+fn a_store_without_an_account_presents_an_empty_binding_and_authorizes_nothing() {
+    use rag_rat_sync::NodeAuth;
+
+    let db = fresh_db(); // schema only, no account
+    let account = AccountId::from_bytes([7u8; 32]);
+    let store = OplogSyncStore::new(&db, account, NOW);
+    assert!(
+        store.local_binding(&[1u8; 32], NOW).unwrap().is_empty(),
+        "no local device => an anonymous (empty) binding",
+    );
+    assert!(
+        !store.authorize(&[0u8; 10], &[1u8; 32], NOW).unwrap(),
+        "an accountless store authorizes no peer",
+    );
+}
+
+/// The content store carries the same account-level node authorization as the account-log store —
+/// the binding is about the account + transport node, not the payload.
+#[test]
+fn the_content_store_carries_the_same_node_auth() {
+    use rag_rat_sync::{NodeAuth, OplogContentSyncStore};
+
+    let db = fresh_db();
+    let account = local_account(&db, NOW).unwrap();
+    let store = OplogContentSyncStore::new(&db, account, NOW);
+    let node = [4u8; 32];
+    let binding = store.local_binding(&node, NOW).unwrap();
+    assert!(store.authorize(&binding, &node, NOW).unwrap(), "own node authorized");
+    assert!(!store.authorize(&binding, &[5u8; 32], NOW).unwrap(), "other node refused");
+}
+
 /// LIVE: the real iroh endpoint, dialed peer-to-peer over the configured relay. Ignored by default
 /// (needs network + the relay); run with `--ignored` to exercise the actual transport rather than
 /// the in-process duplex the other tests use.
@@ -279,9 +356,15 @@ async fn a_real_iroh_round_trip_restores_an_account() {
 
     let mut source_store = OplogSyncStore::new(&source, account_id, NOW);
     let mut dest_store = OplogSyncStore::new(&dest, account_id, NOW);
-    let server = async { rag_rat_sync::accept_and_sync(&listener, &mut source_store).await };
-    let client =
-        async { rag_rat_sync::connect_and_sync(&dialer, listener_addr, &mut dest_store).await };
+    // The dest is a fresh peer with no local device (onboarding), so this round-trip uses `Open`;
+    // the node-authorization path is covered directly by the auth-phase tests below and the oplog
+    // node_binding unit tests.
+    let policy = rag_rat_sync::AuthPolicy::Open;
+    let server =
+        async { rag_rat_sync::accept_and_sync(&listener, &mut source_store, policy, NOW).await };
+    let client = async {
+        rag_rat_sync::connect_and_sync(&dialer, listener_addr, &mut dest_store, policy, NOW).await
+    };
     let (server_r, client_r) = tokio::join!(server, client);
     server_r.unwrap();
     client_r.unwrap();


### PR DESCRIPTION
## What

Closes the metadata-privacy gap left open by the phase-D transport: iroh authenticates the transport key, but nothing checked that a connecting node belongs to the account being synced. This adds a **mutual node-authorization handshake** that runs BEFORE any inventory is exchanged, so a peer learns nothing — not even which account an endpoint serves — until it is authorized.

### The binding (`rag-rat-oplog`, new `account/node_binding`)
A roster device signs a domain-tagged statement `{account_id, node_pubkey, device_pubkey, issued_at_ms}` vouching that a transport node is one of the account's devices. Verification rests on three independent facts, **all required**:
- the signer is **roster-effective** in the current fold (self-certifying: `sha256(device_pubkey)` must be an effective fingerprint — never resolved from a fold-independent key store);
- the bound `node_pubkey` equals the connection's **iroh-authenticated** `remote_id` — so a captured/leaked binding is inert to anyone who doesn't also hold that transport secret (the replay defense);
- the binding is **fresh** (`issued_at_ms` within a bounded window), which bounds the one residual (a transport seed stolen without the device key).

The signed bytes are **domain-tagged**, distinct from every op/frame preimage, so a binding signature can never be confused with an op signature.

### The handshake (`rag-rat-sync`, new `auth`)
A new `Auth` frame carries the binding. Ordering is asymmetric to close the gap without deadlocking (the transfer phase stays concurrent):
- the **acceptor** verifies the dialer BEFORE revealing its own binding — an unauthorized dialer learns nothing;
- the **dialer** presents first (to the node iroh already authenticated), then verifies the acceptor before proceeding.

`AuthPolicy::{Open, Closed}` is **local per-account policy**, never negotiated on the wire (an impostor can't assert `Open` to dodge the other side's `Closed`). `InviteToken` — onboarding a not-yet-roster device — fails closed until the pairing flow lands. Every refusal is **uniform**, so a peer can't probe which account or device an endpoint knows.

## Hardening (each caught in review, fixed + tested)
- **Account scope enforced regardless of policy** — an `Open` endpoint still refuses a peer naming a different account (otherwise `run_session`'s Hello would leak the hosted account + inventory).
- **Per-handshake clock** — freshness uses the handshake time, not the store's construction time, so a long-lived store still authorizes and the replay window advances.
- **Pre-auth read + write bounded** by a short timeout — an unauthenticated peer that stalls (reading or via zero receive credit) can't hold the single-session accept slot.
- **Pre-auth allocation capped** from the length prefix (`read_frame_within`) before the body is allocated — the first frame can't force the 24 MiB data-phase allocation.
- **ALPN bumps to `/2`** — a `/1` peer, which would stream inventory without authenticating, must not interoperate.

## Scope
This is the transport-layer authorization core. **Deferred**: `InviteToken` redemption (the `sync init`/`pair`/`join` pairing flow, which the CLI slice wires up), a persisted node↔account map (only when dial-by-roster needs it — reuses the same canonical bytes), and a channel-binding upgrade that would retire the clock.

## Tests
655 pass (oplog + sync). New: node-binding crypto (roster check, node match, expiry/future, tampered signature, malformed); the handshake protocol (mutual admit, unauthorized-dropped-before-leak, Open admits, Open still enforces scope, cross-account refused, invite-token fails closed); the per-handshake clock; and the pre-auth allocation cap. Both workspace clippy legs and nightly fmt are green.