### PR TITLE
feat(init): add Papertrail (issue tracker) and Distillation wizard steps

### DIFF
--- a/crates/rag-rat-base/src/config/mod.rs
+++ b/crates/rag-rat-base/src/config/mod.rs
@@ -183,10 +183,10 @@ pub use discovery::{
 pub(crate) use discovery::{main_worktree_root, normalize_existing_dir, resolve_default_database};
 #[cfg(test)]
 pub(crate) use load::{anchor_root_to_main_worktree, resolve_targets};
-pub use raw::endpoint_authority_has_userinfo;
 pub(crate) use raw::{RawConfig, RawTarget, resolve_relative_cookbook_path};
 #[cfg(test)]
 pub(crate) use raw::{RawMemory, RawOracle, RawSearch, RawVersionCheck, RawWatch};
+pub use raw::{endpoint_authority_has_userinfo, valid_tracker_base_url, valid_tracker_project};
 pub use types::{
     Config, DEFAULT_QUERY_ENDPOINT, DistillLlmConfig, DreamLlmConfig, EmbeddingBackend,
     EmbeddingConfig, EmbeddingRuntimeConfig, LlmConfig, LogConfig, LogFormat, LogLevel,

--- a/crates/rag-rat-base/src/config/raw.rs
+++ b/crates/rag-rat-base/src/config/raw.rs
@@ -138,17 +138,7 @@ impl TryFrom<RawTracker> for TrackerConfig {
         let base_url = match trimmed(raw.base_url) {
             None => None,
             Some(url) => {
-                let Some((scheme, rest)) = url.split_once("://") else {
-                    return Err(ConfigError::TrackerBaseUrlNotHttp(url));
-                };
-                let authority = rest.split(['/', '?', '#']).next().unwrap_or_default();
-                let suffix = &rest[authority.len()..];
-                if !matches!(scheme, "http" | "https")
-                    || authority.is_empty()
-                    || authority.starts_with(':')
-                    || authority.chars().any(char::is_whitespace)
-                    || !suffix.chars().all(|ch| ch == '/')
-                {
+                if !valid_tracker_base_url_scheme_authority(&url) {
                     return Err(ConfigError::TrackerBaseUrlNotHttp(url));
                 }
                 if endpoint_authority_has_userinfo(&url) {
@@ -176,7 +166,11 @@ impl TryFrom<RawTracker> for TrackerConfig {
     }
 }
 
-fn valid_tracker_project(provider: Tracker, project: &str) -> bool {
+/// Whether `project` is a valid identity for `provider`: `owner/repo` for GitHub/Bitbucket, a
+/// `namespace/.../repo` path for GitLab, an uppercase-alphanumeric KEY for Jira. Exposed so the
+/// `rag-rat init` wizard rejects a malformed project before writing a config `Config::load` would
+/// reject post-write.
+pub fn valid_tracker_project(provider: Tracker, project: &str) -> bool {
     let parts = project.split('/').collect::<Vec<_>>();
     let valid_code_host_segment = |part: &&str| {
         !part.is_empty()
@@ -194,6 +188,28 @@ fn valid_tracker_project(provider: Tracker, project: &str) -> bool {
                 && project.chars().next().is_some_and(|first| first.is_ascii_uppercase())
                 && project.chars().all(|ch| ch.is_ascii_uppercase() || ch.is_ascii_digit()),
     }
+}
+
+/// A valid `base_url` scheme + authority: `http`/`https`, a non-empty host authority, and only
+/// `/`-suffix after it. Does NOT check for embedded credentials — see [`valid_tracker_base_url`].
+fn valid_tracker_base_url_scheme_authority(url: &str) -> bool {
+    let Some((scheme, rest)) = url.split_once("://") else {
+        return false;
+    };
+    let authority = rest.split(['/', '?', '#']).next().unwrap_or_default();
+    let suffix = &rest[authority.len()..];
+    matches!(scheme, "http" | "https")
+        && !authority.is_empty()
+        && !authority.starts_with(':')
+        && !authority.chars().any(char::is_whitespace)
+        && suffix.chars().all(|ch| ch == '/')
+}
+
+/// The full tracker `base_url` predicate: a valid http(s) scheme + authority AND no embedded
+/// credentials — mirrors the `[[tracker]] base_url` acceptance in `TrackerConfig::try_from`.
+/// Exposed for the `rag-rat init` wizard's pre-write validation.
+pub fn valid_tracker_base_url(url: &str) -> bool {
+    valid_tracker_base_url_scheme_authority(url) && !endpoint_authority_has_userinfo(url)
 }
 
 impl TryFrom<RawTrackerAuth> for TrackerAuth {

--- a/crates/rag-rat-cli/src/init/mod.rs
+++ b/crates/rag-rat-cli/src/init/mod.rs
@@ -68,6 +68,9 @@ pub(crate) struct InitPlan {
     /// compiler-grade (SCIP) importance ranking. Default false (matches `OracleConfig`'s
     /// default).
     oracle_auto_run: bool,
+    /// Whether to write `[llm.distill] enabled = true` — the opt-in distillation model pass.
+    /// Default false; the wizard only turns it on with a resolvable issue tracker.
+    distill_enabled: bool,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -280,6 +283,7 @@ mod tests {
             ]),
             backend: EmbeddingBackend::model2vec(),
             oracle_auto_run: false,
+            distill_enabled: false,
         };
 
         let text = render_config(&plan);
@@ -314,6 +318,7 @@ mod tests {
             bindings: BTreeMap::from([(Language::Rust, vec![PathBuf::from("src")])]),
             backend: EmbeddingBackend::fast_embed(),
             oracle_auto_run: true,
+            distill_enabled: false,
         };
         assert!(render_config(&plan).contains("auto_run = true"));
     }
@@ -330,6 +335,7 @@ mod tests {
             bindings: BTreeMap::from([(Language::Swift, vec![PathBuf::from("Sources")])]),
             backend: EmbeddingBackend::fast_embed(),
             oracle_auto_run: false,
+            distill_enabled: false,
         };
 
         let text = render_config(&plan);
@@ -361,6 +367,7 @@ mod tests {
             ])]),
             backend: EmbeddingBackend::fast_embed(),
             oracle_auto_run: false,
+            distill_enabled: false,
         };
         let text = render_config(&plan);
         assert!(text.contains("# [[target]]"), "documents the expanded target form");
@@ -413,6 +420,7 @@ mod tests {
             bindings: BTreeMap::from([(Language::Rust, vec![PathBuf::from("src")])]),
             backend: EmbeddingBackend::fast_embed(),
             oracle_auto_run: false,
+            distill_enabled: false,
         };
         std::fs::write(root.join("rag-rat.toml"), render_config(&plan)).unwrap();
 

--- a/crates/rag-rat-cli/src/init/render.rs
+++ b/crates/rag-rat-cli/src/init/render.rs
@@ -77,6 +77,21 @@ pub(crate) fn render_config(plan: &InitPlan) -> String {
          \"./recipes/my-provider.mjs\"\n# gpus = [\"small\", \"large\"]\n\n",
     );
 
+    text.push_str("[llm.distill]\n");
+    text.push_str(
+        "# Turn closed issues & PRs into typed decision records (opt-in model pass; needs an \
+         issue\n# tracker below). Run it with `rag-rat distill drain`.\n",
+    );
+    text.push_str(&format!("enabled = {}\n", plan.distill_enabled));
+    text.push_str(
+        "# Serving — the wizard writes this block when you enable distillation. Default is an \
+         ephemeral\n# 30B GPU box; a connect endpoint is the alternative.\n# \
+         [llm.distill.remote]\n# backend = \"vllm\"\n# cookbook = \"@rag-rat/cookbook modal\"\n# \
+         gpu = \"L40S\"\n# model = \"Qwen/Qwen3-30B-A3B-Instruct-2507-FP8\"\n# \
+         provision_timeout_s = 1500   # cold-pull budget, under the box's 30-min lifetime\n# \
+         request_timeout_s = 240\n\n",
+    );
+
     text.push_str(
         "# Background file watcher — keeps the index fresh as files change (defaults shown).\n# \
          [watch]\n# enabled = true\n# debounce_ms = 400           # quiet window before a reindex \
@@ -90,6 +105,21 @@ pub(crate) fn render_config(plan: &InitPlan) -> String {
     text.push_str(
         "# Check crates.io for a newer rag-rat and surface it. Best-effort, cached, never \
          blocks.\n# [version_check]\n# enabled = true\n\n",
+    );
+
+    text.push_str(
+        "# Issue tracker (optional). With NO [[tracker]] block the binding is auto-detected from \
+         the\n# git origin remote (github.com / gitlab.* / bitbucket.org). Write one to pin auth, a \
+         self-\n# hosted instance, or Jira (never auto-detected). `auth` is exactly one of env / \
+         token_command.\n# [[tracker]]\n# provider = \"github\"           # github | gitlab | \
+         bitbucket | jira\n# project = \"owner/repo\"        # optional for code hosts (derived from \
+         the remote); required for jira\n# base_url = \"https://gitlab.example.com\"  # self-hosted / \
+         enterprise only\n# auth = { token_command = \"gh auth token\" }  # or { env = \
+         \"GITHUB_TOKEN\" }\n# tags = [\"bug\", \"perf\"]        # only mirror matching issues/PRs; \
+         empty = all\n#\n# Papertrail sync cadence (defaults shown).\n# [papertrail]\n# \
+         probe_interval_secs = 900\n# sync_min_interval_secs = 900\n# full_sync_interval_secs = \
+         86400\n# rate_limit_reserve = 0.35     # fraction of the API quota kept for your own \
+         tools\n\n",
     );
 
     text.push_str(

--- a/crates/rag-rat-cli/src/init/run.rs
+++ b/crates/rag-rat-cli/src/init/run.rs
@@ -308,7 +308,14 @@ pub(crate) fn default_plan(root_value: String, scan: &RepoScan) -> InitPlan {
         languages.into_iter().filter(|language| bindings.contains_key(language)).collect();
     let backend = recommend_backend(estimated_chunks(scan.total_source_bytes));
     // Non-interactive default mirrors `OracleConfig`'s default: off until explicitly enabled.
-    InitPlan { root_value, languages, bindings, backend, oracle_auto_run: false }
+    InitPlan {
+        root_value,
+        languages,
+        bindings,
+        backend,
+        oracle_auto_run: false,
+        distill_enabled: false,
+    }
 }
 pub(crate) fn setup_index(config: &Config, config_path: &Path) -> anyhow::Result<IndexDatabase> {
     eprintln!("init: migrating SQLite schema");

--- a/crates/rag-rat-cli/src/init/wizard/draft.rs
+++ b/crates/rag-rat-cli/src/init/wizard/draft.rs
@@ -8,11 +8,11 @@ use std::path::PathBuf;
 use std::str::FromStr;
 
 use rag_rat_base::config::{
-    Config, DEFAULT_QUERY_ENDPOINT, EmbeddingBackend, OracleConfig, RemoteBackend,
-    RemoteEmbeddingConfig, VersionCheckConfig,
+    Config, DEFAULT_QUERY_ENDPOINT, DistillLlmConfig, EmbeddingBackend, OracleConfig,
+    RemoteBackend, RemoteDreamConfig, RemoteEmbeddingConfig, Tracker, VersionCheckConfig,
 };
 use rag_rat_base::language::Language;
-use toml_edit::{Array, DocumentMut, Item, Table};
+use toml_edit::{Array, ArrayOfTables, DocumentMut, InlineTable, Item, Table};
 
 use crate::init::render::{config_root_value, display_rel, render_config};
 use crate::init::scan::{candidate_dirs, estimated_chunks, recommend_backend};
@@ -53,6 +53,104 @@ pub(crate) struct RemoteDraft {
     pub max_batch_chars: usize,
     /// Name of the env-var holding the bearer token, if auth is needed.
     pub auth_env: Option<String>,
+}
+
+// ── Tracker (papertrail) draft ──────────────────────────────────────────────────
+
+/// How the wizard binds an issue tracker.
+///
+/// `AutoDetect` writes no `[[tracker]]` block — `resolve_trackers` derives the binding from the
+/// `origin` remote at index time (zero-config, the product default). `Configure` writes an explicit
+/// `[[tracker]]` block, which *replaces* auto-detection.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum TrackerMode {
+    AutoDetect,
+    Configure,
+}
+
+/// The auth source for an explicit tracker binding — exactly one of `env` / `token_command`, or
+/// none (anonymous), mirroring `TrackerAuth`.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum TrackerAuthMode {
+    Anonymous,
+    Env,
+    Command,
+}
+
+/// The issue-tracker draft — written as a `[[tracker]]` binding only in `Configure` mode.
+#[derive(Clone, Debug)]
+pub(crate) struct TrackerDraft {
+    pub mode: TrackerMode,
+    /// Provider for an explicit binding (unused in `AutoDetect`).
+    pub provider: Tracker,
+    pub auth: TrackerAuthMode,
+    /// Env-var NAME (for `Env`) or shell command (for `Command`); ignored for `Anonymous`.
+    pub auth_value: String,
+    /// Self-hosted / enterprise instance URL; empty = the provider's cloud host.
+    pub base_url: String,
+    /// `owner/repo` (code hosts) or the project KEY (Jira, required); empty = derive from remote.
+    pub project: String,
+    /// The git remote `project` is derived from; empty = the config default (`origin`). Not edited
+    /// in the UI, but round-tripped so a reconfigure never drops a non-`origin` remote.
+    pub remote: String,
+    /// Comma-separated tracked tags; empty = track all.
+    pub tags: String,
+}
+
+impl Default for TrackerDraft {
+    fn default() -> Self {
+        Self {
+            mode: TrackerMode::AutoDetect,
+            provider: Tracker::Github,
+            auth: TrackerAuthMode::Anonymous,
+            auth_value: String::new(),
+            base_url: String::new(),
+            project: String::new(),
+            remote: String::new(),
+            tags: String::new(),
+        }
+    }
+}
+
+// ── Distill draft ───────────────────────────────────────────────────────────────
+
+/// How the wizard serves the distillation model pass.
+///
+/// `Off` writes `[llm.distill] enabled = false`. `ValidatedBox` writes the validated 30B ephemeral
+/// serving block ([`RemoteDreamConfig::distill_default`]). `Connect` writes a connect
+/// `[llm.distill.remote]` pointing at an already-running server.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum DistillMode {
+    Off,
+    ValidatedBox,
+    Connect,
+}
+
+/// The distillation draft — off by default. The pass is gated in the UI on a resolvable issue
+/// tracker (nothing to distill without one); the emitted config is a plain `[llm.distill]` block.
+#[derive(Clone, Debug)]
+pub(crate) struct DistillDraft {
+    pub mode: DistillMode,
+    /// Connect-mode server URL (ignored otherwise).
+    pub endpoint: String,
+    /// Connect-mode server-side model name (ignored otherwise).
+    pub model: String,
+    /// Set when `ValidatedBox` was loaded from an EXISTING ephemeral block (reconfigure). Such a
+    /// box is preserved verbatim and already provisioned, so it doesn't re-demand the paid-box
+    /// confirmation. A deliberate switch TO `ValidatedBox` in the wizard clears this (a fresh box
+    /// needs the acknowledgement and emits the shipped default).
+    pub preserved_ephemeral: bool,
+}
+
+impl Default for DistillDraft {
+    fn default() -> Self {
+        Self {
+            mode: DistillMode::Off,
+            endpoint: String::new(),
+            model: String::new(),
+            preserved_ephemeral: false,
+        }
+    }
 }
 
 // ── Cookbook + GPU constants ────────────────────────────────────────────────────
@@ -246,6 +344,10 @@ pub(crate) struct WizardDraft {
     pub version_check: bool,
     /// Hook installation selections (Task 16 fills `git` from current hook status).
     pub hooks: HooksDraft,
+    /// `[[tracker]]` issue-tracker binding (auto-detect by default).
+    pub tracker: TrackerDraft,
+    /// `[llm.distill]` model pass (off by default; gated in the UI on a resolvable tracker).
+    pub distill: DistillDraft,
 }
 
 impl WizardDraft {
@@ -310,6 +412,8 @@ impl WizardDraft {
             oracle_min_interval_secs: oracle.auto_run_min_interval_secs,
             version_check: VersionCheckConfig::default().enabled,
             hooks: HooksDraft::default(),
+            tracker: TrackerDraft::default(),
+            distill: DistillDraft::default(),
         }
     }
 
@@ -358,6 +462,10 @@ impl WizardDraft {
             version_check: cfg.version_check.enabled,
             // Task 16 fills git from the current installed hook status.
             hooks: HooksDraft::default(),
+            // Tracker mode can't be told from the resolved `cfg.trackers` (which folds in
+            // auto-detection); `from_existing` refines it from the raw `[[tracker]]` block.
+            tracker: TrackerDraft::default(),
+            distill: distill_draft_from_config(&cfg.llm.distill),
         }
     }
 
@@ -380,6 +488,14 @@ impl WizardDraft {
         if let Some(remote) = raw_remote_draft(&doc) {
             draft.remote = Some(remote);
         }
+        // An explicit `[[tracker]]` block means the user configured a binding (not auto-detect);
+        // recover its literals so reconfigure round-trips them.
+        if let Some(tracker) = raw_tracker_draft(&doc) {
+            draft.tracker = tracker;
+        }
+        // An ephemeral distill block (even a disabled/staged one) is preserved verbatim; flag it
+        // precisely from the raw doc so a defaulted (block-less) config isn't mistaken for one.
+        draft.distill.preserved_ephemeral = distill_remote_has_key(&doc, "cookbook");
         draft
     }
 
@@ -406,6 +522,7 @@ impl WizardDraft {
             bindings: self.bindings.clone(),
             backend,
             oracle_auto_run: self.oracle_auto_run,
+            distill_enabled: !matches!(self.distill.mode, DistillMode::Off),
         }
     }
 
@@ -542,7 +659,129 @@ impl WizardDraft {
         // [version_check] enabled
         doc["version_check"]["enabled"] = toml_edit::value(self.version_check);
 
+        self.emit_distill(&mut doc);
+        self.emit_tracker(&mut doc);
+
         Ok(doc.to_string())
+    }
+
+    /// Emit `[llm.distill]` (the `enabled` flag always; the `[llm.distill.remote]` serving block
+    /// set or removed by mode). The validated-box serving values come straight from
+    /// [`RemoteDreamConfig::distill_default`], so the wizard and the shipped default never drift.
+    fn emit_distill(&self, doc: &mut DocumentMut) {
+        doc["llm"]["distill"]["enabled"] =
+            toml_edit::value(!matches!(self.distill.mode, DistillMode::Off));
+        match self.distill.mode {
+            // Off sets `enabled = false` (above) but LEAVES any existing `[llm.distill.remote]`
+            // intact — a disabled remote is inert, and a user may have staged a serving block to
+            // enable later. Removing it would silently discard that config on an unrelated
+            // reconfigure. (A fresh off config simply has no remote block to leave.)
+            DistillMode::Off => {},
+            // Reconfigure safety: if the file already has an ephemeral serving block, the user may
+            // have customized its model/gpu/cookbook/timeouts — leave it untouched rather than
+            // clobber it with the shipped default. Only synthesize the default when there is no
+            // ephemeral block to keep (a fresh init, or a switch from off/connect).
+            DistillMode::ValidatedBox
+                if self.distill.preserved_ephemeral && distill_remote_has_key(doc, "cookbook") => {
+            },
+            DistillMode::ValidatedBox => {
+                let d = RemoteDreamConfig::distill_default();
+                if let Some(t) = distill_remote_table(doc) {
+                    t.insert("backend", toml_edit::value(d.backend.as_db_str()));
+                    if let Some(cb) = &d.cookbook {
+                        t.insert("cookbook", toml_edit::value(cb.clone()));
+                    }
+                    t.remove("endpoint");
+                    if let Some(gpu) = &d.gpu {
+                        t.insert("gpu", toml_edit::value(gpu.clone()));
+                    }
+                    t.insert("model", toml_edit::value(d.model.clone()));
+                    if let Some(pt) = d.provision_timeout_s {
+                        t.insert("provision_timeout_s", toml_edit::value(clamp_i64(pt)));
+                    }
+                    t.insert("request_timeout_s", toml_edit::value(clamp_i64(d.request_timeout_s)));
+                }
+            },
+            DistillMode::Connect => {
+                // Preserve an existing connect block's serving fields (`backend`,
+                // `request_timeout_s`, `auth_env`): the wizard only edits endpoint/model, so a
+                // plain reconfigure must not reset a custom backend or timeout. A fresh connect (or
+                // a switch from box/off) omits `backend` so it defaults to ollama and uses the low
+                // distill request cap.
+                let fresh = !distill_remote_has_key(doc, "endpoint");
+                if let Some(t) = distill_remote_table(doc) {
+                    t.insert(
+                        "endpoint",
+                        toml_edit::value(self.distill.endpoint.trim().to_string()),
+                    );
+                    t.insert("model", toml_edit::value(self.distill.model.trim().to_string()));
+                    t.remove("cookbook");
+                    t.remove("gpu");
+                    t.remove("provision_timeout_s");
+                    if fresh {
+                        // A stale `backend = "vllm"` would send an ollama model name to a vLLM
+                        // server; omit it so a fresh connect defaults to ollama.
+                        t.remove("backend");
+                        t.insert("request_timeout_s", toml_edit::value(240_i64));
+                    }
+                }
+            },
+        }
+    }
+
+    /// Emit an explicit `[[tracker]]` binding in `Configure` mode. `AutoDetect` DROPS every
+    /// `[[tracker]]` block so `resolve_trackers` auto-detects from `origin` again — it auto-detects
+    /// only when the binding list is *empty*, so a partial removal would leave the remainder in
+    /// control and contradict the chosen mode. (The wizard manages the whole tracker section: a
+    /// multi-binding config isn't representable in its single-tracker UI, so auto-detect means "no
+    /// explicit bindings".)
+    fn emit_tracker(&self, doc: &mut DocumentMut) {
+        if self.tracker.mode == TrackerMode::AutoDetect {
+            doc.as_table_mut().remove("tracker");
+            return;
+        }
+        let t = &self.tracker;
+        let mut table = Table::new();
+        table.insert("provider", toml_edit::value(t.provider.as_db_str()));
+        let remote = t.remote.trim();
+        if !remote.is_empty() && remote != "origin" {
+            table.insert("remote", toml_edit::value(remote.to_string()));
+        }
+        let project = t.project.trim();
+        if !project.is_empty() {
+            table.insert("project", toml_edit::value(project.to_string()));
+        }
+        let base_url = t.base_url.trim();
+        if !base_url.is_empty() {
+            table.insert("base_url", toml_edit::value(base_url.to_string()));
+        }
+        match t.auth {
+            TrackerAuthMode::Anonymous => {},
+            TrackerAuthMode::Env => {
+                table.insert("auth", toml_edit::value(auth_inline("env", t.auth_value.trim())));
+            },
+            TrackerAuthMode::Command => {
+                table.insert(
+                    "auth",
+                    toml_edit::value(auth_inline("token_command", t.auth_value.trim())),
+                );
+            },
+        }
+        let tags: Vec<&str> =
+            t.tags.split(',').map(str::trim).filter(|tag| !tag.is_empty()).collect();
+        if !tags.is_empty() {
+            let mut arr = Array::new();
+            for tag in tags {
+                arr.push(tag);
+            }
+            table.insert("tags", toml_edit::value(arr));
+        }
+        // The wizard owns the whole tracker section (its UI represents a single binding): replace
+        // any existing array with exactly this one table, so hidden extra `[[tracker]]` entries
+        // can't keep syncing behind the user's back (AutoDetect clears the section the same way).
+        let mut aot = ArrayOfTables::new();
+        aot.push(table);
+        doc["tracker"] = Item::ArrayOfTables(aot);
     }
 }
 
@@ -571,6 +810,106 @@ fn remote_draft_from_config(r: &RemoteEmbeddingConfig) -> RemoteDraft {
         max_batch_chars: r.max_batch_chars,
         auth_env: r.auth_env.clone(),
     }
+}
+
+/// Map the resolved `[llm.distill]` config back to the wizard's mode. The resolved config can't
+/// tell "the validated box" from any other ephemeral block, so an enabled ephemeral binding maps
+/// to `ValidatedBox` (the only ephemeral serving the wizard offers).
+fn distill_draft_from_config(cfg: &DistillLlmConfig) -> DistillDraft {
+    let connect = cfg.remote.is_connect();
+    // Populate the serving fields from the remote REGARDLESS of `enabled`, so a staged (disabled)
+    // remote's values are visible when the user enables it — only the initial MODE reflects
+    // `enabled`. `from_existing` refines `preserved_ephemeral` precisely from the raw doc.
+    let mode = if !cfg.enabled {
+        DistillMode::Off
+    } else if connect {
+        DistillMode::Connect
+    } else {
+        DistillMode::ValidatedBox
+    };
+    DistillDraft {
+        mode,
+        endpoint: cfg.remote.endpoint.clone().unwrap_or_default(),
+        model: if connect { cfg.remote.model.clone() } else { String::new() },
+        preserved_ephemeral: !connect,
+    }
+}
+
+/// Recover a `Configure`-mode [`TrackerDraft`] from the first raw `[[tracker]]` block, if any.
+/// Returns `None` when there is no explicit binding (the auto-detect default stands).
+fn raw_tracker_draft(doc: &DocumentMut) -> Option<TrackerDraft> {
+    let t = doc.get("tracker")?.as_array_of_tables()?.get(0)?;
+    let provider = t
+        .get("provider")
+        .and_then(Item::as_str)
+        .and_then(|s| Tracker::from_db_str(s).ok())
+        .unwrap_or(Tracker::Github);
+    // `as_table_like` recovers BOTH the inline `auth = { env = ... }` and the standard
+    // `[tracker.auth]` table forms — `as_inline_table` would miss the latter and silently drop the
+    // credential source on reconfigure.
+    let (auth, auth_value) = match t.get("auth").and_then(Item::as_table_like) {
+        Some(auth) =>
+            if let Some(env) = auth.get("env").and_then(Item::as_str) {
+                (TrackerAuthMode::Env, env.to_string())
+            } else if let Some(cmd) = auth.get("token_command").and_then(Item::as_str) {
+                (TrackerAuthMode::Command, cmd.to_string())
+            } else {
+                (TrackerAuthMode::Anonymous, String::new())
+            },
+        None => (TrackerAuthMode::Anonymous, String::new()),
+    };
+    let str_field =
+        |key: &str| t.get(key).and_then(Item::as_str).map(str::to_string).unwrap_or_default();
+    let tags = t
+        .get("tags")
+        .and_then(Item::as_array)
+        .map(|arr| arr.iter().filter_map(|v| v.as_str()).collect::<Vec<_>>().join(", "))
+        .unwrap_or_default();
+    Some(TrackerDraft {
+        mode: TrackerMode::Configure,
+        provider,
+        auth,
+        auth_value,
+        base_url: str_field("base_url"),
+        project: str_field("project"),
+        remote: str_field("remote"),
+        tags,
+    })
+}
+
+/// Whether the existing `[llm.distill.remote]` block carries `key`. Used to tell a reconfigure of
+/// an ephemeral (`cookbook`) or connect (`endpoint`) block from a fresh one, so the wizard can
+/// preserve a user's custom serving fields instead of overwriting them.
+fn distill_remote_has_key(doc: &DocumentMut, key: &str) -> bool {
+    doc.get("llm")
+        .and_then(Item::as_table_like)
+        .and_then(|t| t.get("distill"))
+        .and_then(Item::as_table_like)
+        .and_then(|t| t.get("remote"))
+        .and_then(Item::as_table_like)
+        .and_then(|t| t.get(key))
+        .is_some()
+}
+
+/// `doc["llm"]["distill"]["remote"]` as a mutable table, creating it if absent.
+fn distill_remote_table(doc: &mut DocumentMut) -> Option<&mut dyn toml_edit::TableLike> {
+    let item = doc["llm"]["distill"]["remote"].or_insert(Item::Table(Table::new()));
+    if item.as_table_like_mut().is_none() {
+        *item = Item::Table(Table::new());
+    }
+    item.as_table_like_mut()
+}
+
+/// A `{ <key> = <value> }` inline auth table (`env` or `token_command`).
+fn auth_inline(key: &str, value: &str) -> InlineTable {
+    let mut inline = InlineTable::new();
+    inline.insert(key, value.into());
+    inline
+}
+
+/// Clamp a `u64` timeout to `i64` for TOML emission (TOML integers are i64).
+fn clamp_i64(v: u64) -> i64 {
+    i64::try_from(v).unwrap_or(i64::MAX)
 }
 
 fn raw_target_bindings(doc: &DocumentMut) -> Option<BTreeMap<Language, Vec<PathBuf>>> {
@@ -1266,5 +1605,293 @@ mod tests {
         assert!(!d.hooks.git);
         // root_abs must be the absolute path passed in.
         assert_eq!(d.root_abs, root_abs);
+    }
+
+    // ── Distill + tracker emission ──────────────────────────────────────────────
+
+    fn fresh_draft() -> WizardDraft {
+        let mut d = WizardDraft::from_scan(&RepoScan::default(), ".".into(), PathBuf::from("."));
+        d.bindings.insert(Language::Rust, vec!["src".into()]);
+        d
+    }
+
+    #[test]
+    fn distill_off_by_default_writes_disabled_and_no_remote() {
+        let doc: DocumentMut = fresh_draft().write_fresh().parse().unwrap();
+        assert_eq!(doc["llm"]["distill"]["enabled"].as_bool(), Some(false));
+        let has_remote = doc["llm"]["distill"]
+            .as_table_like()
+            .and_then(|t| t.get("remote"))
+            .and_then(Item::as_table_like)
+            .is_some();
+        assert!(!has_remote, "distill-off must not emit a remote serving table");
+    }
+
+    #[test]
+    fn distill_validated_box_emits_the_shipped_default_serving_block() {
+        let mut d = fresh_draft();
+        d.distill.mode = DistillMode::ValidatedBox;
+        let doc: DocumentMut = d.write_fresh().parse().unwrap();
+        assert_eq!(doc["llm"]["distill"]["enabled"].as_bool(), Some(true));
+        let remote = doc["llm"]["distill"]["remote"].as_table_like().unwrap();
+        // The emitted values come from the shipped default, so they can't drift from it.
+        let default = RemoteDreamConfig::distill_default();
+        assert_eq!(remote.get("backend").and_then(Item::as_str), Some(default.backend.as_db_str()));
+        assert_eq!(remote.get("model").and_then(Item::as_str), Some(default.model.as_str()));
+        assert_eq!(remote.get("gpu").and_then(Item::as_str), default.gpu.as_deref());
+        assert_eq!(
+            remote.get("provision_timeout_s").and_then(Item::as_integer),
+            default.provision_timeout_s.map(clamp_i64),
+        );
+        assert!(remote.get("endpoint").is_none(), "the validated box is ephemeral, not connect");
+    }
+
+    #[test]
+    fn a_disabled_connect_distill_still_populates_the_draft_fields() {
+        // Loaded Off (disabled) but the endpoint/model are visible so enabling it doesn't require
+        // re-entering values already in the config.
+        let cfg = DistillLlmConfig {
+            enabled: false,
+            remote: RemoteDreamConfig {
+                backend: RemoteBackend::Ollama,
+                endpoint: Some("http://localhost:11434".to_string()),
+                cookbook: None,
+                model: "staged-model".to_string(),
+                gpu: None,
+                auth_env: None,
+                request_timeout_s: 240,
+                provision_timeout_s: None,
+            },
+        };
+        let draft = distill_draft_from_config(&cfg);
+        assert_eq!(draft.mode, DistillMode::Off);
+        assert_eq!(draft.endpoint, "http://localhost:11434");
+        assert_eq!(draft.model, "staged-model");
+    }
+
+    #[test]
+    fn a_disabled_distill_keeps_its_staged_remote_block() {
+        // A config that stages a distill remote while enabled = false must not lose it on an
+        // unrelated reconfigure: `from_config` loads Off, and emit must LEAVE the inert remote.
+        let original = "[index]\nroot = \".\"\n[llm.embedding]\nmodel = \"m\"\n\
+                        [llm.distill]\nenabled = false\n[llm.distill.remote]\nbackend = \"ollama\"\n\
+                        endpoint = \"http://localhost:11434\"\nmodel = \"staged\"\n";
+        let mut d = fresh_draft();
+        d.distill.mode = DistillMode::Off;
+        let doc: DocumentMut = d.patch_existing(original).unwrap().parse().unwrap();
+        assert_eq!(doc["llm"]["distill"]["enabled"].as_bool(), Some(false));
+        let remote = doc["llm"]["distill"]["remote"].as_table_like().unwrap();
+        assert_eq!(remote.get("endpoint").and_then(Item::as_str), Some("http://localhost:11434"));
+        assert_eq!(remote.get("model").and_then(Item::as_str), Some("staged"));
+    }
+
+    #[test]
+    fn distill_connect_emits_endpoint_and_model() {
+        let mut d = fresh_draft();
+        d.distill.mode = DistillMode::Connect;
+        d.distill.endpoint = "http://localhost:11434".to_string();
+        d.distill.model = "qwen3:4b-instruct".to_string();
+        let doc: DocumentMut = d.write_fresh().parse().unwrap();
+        assert_eq!(doc["llm"]["distill"]["enabled"].as_bool(), Some(true));
+        let remote = doc["llm"]["distill"]["remote"].as_table_like().unwrap();
+        assert_eq!(remote.get("endpoint").and_then(Item::as_str), Some("http://localhost:11434"));
+        assert_eq!(remote.get("model").and_then(Item::as_str), Some("qwen3:4b-instruct"));
+        assert!(remote.get("cookbook").is_none());
+    }
+
+    #[test]
+    fn tracker_auto_detect_writes_no_binding() {
+        let doc: DocumentMut = fresh_draft().write_fresh().parse().unwrap();
+        assert!(doc.get("tracker").is_none(), "auto-detect must not emit a [[tracker]] block");
+    }
+
+    #[test]
+    fn tracker_configure_emits_a_binding_with_auth_and_tags() {
+        let mut d = fresh_draft();
+        d.tracker.mode = TrackerMode::Configure;
+        d.tracker.provider = Tracker::Gitlab;
+        d.tracker.auth = TrackerAuthMode::Command;
+        d.tracker.auth_value = "glab auth token".to_string();
+        d.tracker.base_url = "https://gitlab.example.com".to_string();
+        d.tracker.project = "group/sub/repo".to_string();
+        d.tracker.tags = "bug, perf".to_string();
+        let doc: DocumentMut = d.write_fresh().parse().unwrap();
+        let t = doc["tracker"].as_array_of_tables().unwrap().get(0).unwrap().clone();
+        assert_eq!(t.get("provider").and_then(Item::as_str), Some("gitlab"));
+        assert_eq!(t.get("base_url").and_then(Item::as_str), Some("https://gitlab.example.com"));
+        assert_eq!(t.get("project").and_then(Item::as_str), Some("group/sub/repo"));
+        let auth = t.get("auth").and_then(Item::as_inline_table).unwrap();
+        assert_eq!(auth.get("token_command").and_then(|v| v.as_str()), Some("glab auth token"));
+        let tags: Vec<&str> = t
+            .get("tags")
+            .and_then(Item::as_array)
+            .unwrap()
+            .iter()
+            .filter_map(|v| v.as_str())
+            .collect();
+        assert_eq!(tags, vec!["bug", "perf"]);
+    }
+
+    #[test]
+    fn configured_tracker_round_trips_through_raw_recovery() {
+        let mut d = fresh_draft();
+        d.tracker.mode = TrackerMode::Configure;
+        d.tracker.provider = Tracker::Github;
+        d.tracker.auth = TrackerAuthMode::Env;
+        d.tracker.auth_value = "GH_TOKEN".to_string();
+        let doc: DocumentMut = d.write_fresh().parse().unwrap();
+        let recovered = raw_tracker_draft(&doc).expect("configured tracker must round-trip");
+        assert_eq!(recovered.mode, TrackerMode::Configure);
+        assert_eq!(recovered.provider, Tracker::Github);
+        assert_eq!(recovered.auth, TrackerAuthMode::Env);
+        assert_eq!(recovered.auth_value, "GH_TOKEN");
+    }
+
+    #[test]
+    fn auto_detect_on_reconfigure_removes_all_explicit_trackers() {
+        // Two bindings: auto-detect must drop BOTH, since resolve_trackers only auto-detects when
+        // the binding list is empty — a partial removal would leave the remainder in control.
+        let original = "[index]\nroot = \".\"\n[target_bindings]\nrust = \
+                        [\"src\"]\n[llm.embedding]\nmodel = \"m\"\n[[tracker]]\nprovider = \
+                        \"github\"\nauth = { token_command = \"gh auth token\" \
+                        }\n[[tracker]]\nprovider = \"jira\"\nproject = \"PROJ\"\n";
+        let mut d = fresh_draft();
+        d.tracker.mode = TrackerMode::AutoDetect;
+        let doc: DocumentMut = d.patch_existing(original).unwrap().parse().unwrap();
+        assert!(
+            doc.get("tracker").is_none(),
+            "auto-detect must drop every [[tracker]] so origin detection runs again"
+        );
+    }
+
+    #[test]
+    fn validated_box_preserves_a_custom_ephemeral_distill_on_reconfigure() {
+        let original = "[index]\nroot = \".\"\n[llm.embedding]\nmodel = \
+                        \"m\"\n[llm.distill]\nenabled = true\n[llm.distill.remote]\nbackend = \
+                        \"vllm\"\ncookbook = \"@me/cookbook custom\"\ngpu = \"H100\"\nmodel = \
+                        \"my/custom-model\"\nprovision_timeout_s = 1700\n";
+        let mut d = fresh_draft();
+        d.distill.mode = DistillMode::ValidatedBox;
+        d.distill.preserved_ephemeral = true; // as `from_config` flags a loaded ephemeral box
+        let doc: DocumentMut = d.patch_existing(original).unwrap().parse().unwrap();
+        let remote = doc["llm"]["distill"]["remote"].as_table_like().unwrap();
+        // The user's custom ephemeral serving survives an unrelated reconfigure.
+        assert_eq!(remote.get("model").and_then(Item::as_str), Some("my/custom-model"));
+        assert_eq!(remote.get("gpu").and_then(Item::as_str), Some("H100"));
+        assert_eq!(remote.get("cookbook").and_then(Item::as_str), Some("@me/cookbook custom"));
+        assert_eq!(doc["llm"]["distill"]["enabled"].as_bool(), Some(true));
+    }
+
+    #[test]
+    fn configured_tracker_round_trips_a_non_origin_remote() {
+        let mut d = fresh_draft();
+        d.tracker.mode = TrackerMode::Configure;
+        d.tracker.provider = Tracker::Github;
+        d.tracker.remote = "upstream".to_string();
+        let doc: DocumentMut = d.write_fresh().parse().unwrap();
+        let t = doc["tracker"].as_array_of_tables().unwrap().get(0).unwrap().clone();
+        assert_eq!(t.get("remote").and_then(Item::as_str), Some("upstream"));
+        assert_eq!(raw_tracker_draft(&doc).unwrap().remote, "upstream");
+    }
+
+    #[test]
+    fn switching_a_box_to_connect_on_reconfigure_drops_the_vllm_backend() {
+        // A reconfigure from the ephemeral box to a connect endpoint must not leave `backend =
+        // "vllm"` behind — that would send an ollama model name to a vLLM server.
+        let original = "[index]\nroot = \".\"\n[llm.embedding]\nmodel = \
+                        \"m\"\n[llm.distill]\nenabled = true\n[llm.distill.remote]\nbackend = \
+                        \"vllm\"\ncookbook = \"@rag-rat/cookbook modal\"\ngpu = \"L40S\"\nmodel = \
+                        \"big\"\n";
+        let mut d = fresh_draft();
+        d.distill.mode = DistillMode::Connect;
+        d.distill.endpoint = "http://localhost:11434".to_string();
+        d.distill.model = "qwen3:4b-instruct".to_string();
+        let doc: DocumentMut = d.patch_existing(original).unwrap().parse().unwrap();
+        let remote = doc["llm"]["distill"]["remote"].as_table_like().unwrap();
+        assert!(remote.get("backend").is_none(), "stale vllm backend must be dropped");
+        assert!(remote.get("cookbook").is_none());
+        assert_eq!(remote.get("endpoint").and_then(Item::as_str), Some("http://localhost:11434"));
+    }
+
+    #[test]
+    fn configure_replaces_all_existing_trackers_with_the_single_binding() {
+        // Two existing bindings; Configure must leave exactly the one the wizard manages, else the
+        // hidden extra keeps syncing.
+        let original = "[index]\nroot = \".\"\n[llm.embedding]\nmodel = \
+                        \"m\"\n[[tracker]]\nprovider = \"github\"\nproject = \
+                        \"a/b\"\n[[tracker]]\nprovider = \"jira\"\nproject = \"OLD\"\n";
+        let mut d = fresh_draft();
+        d.tracker.mode = TrackerMode::Configure;
+        d.tracker.provider = Tracker::Github;
+        d.tracker.project = "owner/repo".to_string();
+        let doc: DocumentMut = d.patch_existing(original).unwrap().parse().unwrap();
+        let aot = doc["tracker"].as_array_of_tables().unwrap();
+        assert_eq!(aot.len(), 1, "the wizard owns the whole tracker section");
+        assert_eq!(aot.get(0).unwrap().get("project").and_then(Item::as_str), Some("owner/repo"));
+    }
+
+    #[test]
+    fn an_existing_ephemeral_distill_loads_as_a_preserved_box() {
+        let cfg = DistillLlmConfig { enabled: true, remote: RemoteDreamConfig::distill_default() };
+        let draft = distill_draft_from_config(&cfg);
+        assert_eq!(draft.mode, DistillMode::ValidatedBox);
+        assert!(
+            draft.preserved_ephemeral,
+            "an existing ephemeral box is preserved, not re-confirmed"
+        );
+    }
+
+    #[test]
+    fn a_fresh_validated_box_replaces_an_existing_custom_cookbook() {
+        // preserved_ephemeral=false (a deliberate box choice in the wizard) → the shipped default
+        // is written even though the original still carries a custom cookbook.
+        let original = "[index]\nroot = \".\"\n[llm.embedding]\nmodel = \
+                        \"m\"\n[llm.distill]\nenabled = true\n[llm.distill.remote]\nbackend = \
+                        \"vllm\"\ncookbook = \"@me/custom modal\"\ngpu = \"H100\"\nmodel = \
+                        \"custom\"\n";
+        let mut d = fresh_draft();
+        d.distill.mode = DistillMode::ValidatedBox;
+        d.distill.preserved_ephemeral = false;
+        let doc: DocumentMut = d.patch_existing(original).unwrap().parse().unwrap();
+        let remote = doc["llm"]["distill"]["remote"].as_table_like().unwrap();
+        let default = RemoteDreamConfig::distill_default();
+        assert_eq!(remote.get("model").and_then(Item::as_str), Some(default.model.as_str()));
+        assert_eq!(remote.get("cookbook").and_then(Item::as_str), default.cookbook.as_deref());
+    }
+
+    #[test]
+    fn connect_reconfigure_preserves_a_custom_backend_and_timeout() {
+        // A plain reconfigure of an existing connect block must keep its backend + request timeout;
+        // the wizard only edits endpoint/model.
+        let original = "[index]\nroot = \".\"\n[llm.embedding]\nmodel = \"m\"\n\
+                        [llm.distill]\nenabled = true\n[llm.distill.remote]\nbackend = \"vllm\"\n\
+                        endpoint = \"http://gpu:8000\"\nmodel = \"old\"\nrequest_timeout_s = 600\n";
+        let mut d = fresh_draft();
+        d.distill.mode = DistillMode::Connect;
+        d.distill.endpoint = "http://gpu:8000".to_string();
+        d.distill.model = "new-model".to_string();
+        let doc: DocumentMut = d.patch_existing(original).unwrap().parse().unwrap();
+        let remote = doc["llm"]["distill"]["remote"].as_table_like().unwrap();
+        assert_eq!(remote.get("model").and_then(Item::as_str), Some("new-model"));
+        assert_eq!(remote.get("backend").and_then(Item::as_str), Some("vllm"));
+        assert_eq!(remote.get("request_timeout_s").and_then(Item::as_integer), Some(600));
+    }
+
+    #[test]
+    fn table_form_tracker_auth_is_recovered() {
+        // Auth expressed as a STANDARD table (not the inline `{ ... }`): `as_inline_table` would
+        // miss it and load anonymous, dropping the credential on reconfigure.
+        let mut doc = DocumentMut::new();
+        let mut auth = Table::new();
+        auth.insert("env", toml_edit::value("GH_TOKEN"));
+        let mut tracker = Table::new();
+        tracker.insert("provider", toml_edit::value("github"));
+        tracker.insert("auth", Item::Table(auth));
+        let mut aot = ArrayOfTables::new();
+        aot.push(tracker);
+        doc["tracker"] = Item::ArrayOfTables(aot);
+        let recovered = raw_tracker_draft(&doc).expect("tracker present");
+        assert_eq!(recovered.auth, TrackerAuthMode::Env);
+        assert_eq!(recovered.auth_value, "GH_TOKEN");
     }
 }

--- a/crates/rag-rat-cli/src/init/wizard/mod.rs
+++ b/crates/rag-rat-cli/src/init/wizard/mod.rs
@@ -46,6 +46,17 @@ pub(crate) struct WizardResult {
     pub hook_conflicts: HashMap<&'static str, HookConflict>,
 }
 
+/// The draft as it will be WRITTEN: distillation is forced off when no tracker resolves (the pass
+/// depends on one). Both `build_result` and the review diff go through this, so the previewed diff
+/// always matches the file saved on confirmation.
+pub(super) fn normalized_write_draft(state: &WizardState) -> WizardDraft {
+    let mut result = state.draft.clone();
+    if !steps::tracker_is_set_up(state) {
+        result.distill.mode = draft::DistillMode::Off;
+    }
+    result
+}
+
 struct TerminalGuard(Terminal<CrosstermBackend<Stdout>>);
 impl Drop for TerminalGuard {
     fn drop(&mut self) {
@@ -363,7 +374,10 @@ impl Wizard {
     }
 
     fn build_result(&self) -> anyhow::Result<WizardResult> {
-        let draft = &self.state.draft;
+        // The write goes through `normalized_write_draft` (distill forced off without a resolvable
+        // tracker), the single authoritative normalization — the user can reach review/save without
+        // the Distill handler ever running (Ctrl-navigation, a tab click, `w` from Papertrail).
+        let draft = normalized_write_draft(&self.state);
         let toml = match &self.original {
             Some(orig) => draft.patch_existing(orig)?,
             None => draft.write_fresh(),
@@ -983,6 +997,24 @@ mod tests {
 
     fn ctrl_right() -> KeyEvent {
         KeyEvent::new(KeyCode::Right, KeyModifiers::CONTROL)
+    }
+
+    #[test]
+    fn build_result_forces_distill_off_without_a_resolvable_tracker() {
+        // Distillation enabled in the draft, but no tracker resolves: the write path must normalize
+        // it off regardless of how review was reached (no Distill handler ever runs here).
+        let mut w = headless(test_scan(), None);
+        w.state.draft.tracker.mode = super::draft::TrackerMode::AutoDetect;
+        w.state.detected_origin = None;
+        w.state.detected_configured = None;
+        w.state.draft.distill.mode = super::draft::DistillMode::ValidatedBox;
+        let result = w.build_result().unwrap();
+        let doc: toml_edit::DocumentMut = result.toml.parse().unwrap();
+        assert_eq!(
+            doc["llm"]["distill"]["enabled"].as_bool(),
+            Some(false),
+            "no tracker → the written config must not enable distillation"
+        );
     }
 
     fn focus_embedding(w: &mut Wizard) {

--- a/crates/rag-rat-cli/src/init/wizard/review.rs
+++ b/crates/rag-rat-cli/src/init/wizard/review.rs
@@ -18,7 +18,7 @@ use ratatui::style::Modifier;
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Paragraph, Wrap};
 
-use super::draft::RemoteMode;
+use super::draft::{DistillMode, RemoteMode, TrackerAuthMode, TrackerMode};
 use super::probe::{ProbeKind, ProbeStatus};
 use super::state::WizardState;
 use super::steps::{CheckResult, Sev as CheckSeverity, StepId, can_write};
@@ -84,6 +84,49 @@ impl ReviewModel {
             },
         }
 
+        // Papertrail / tracker
+        match draft.tracker.mode {
+            TrackerMode::AutoDetect => {
+                let detected = state
+                    .detected_origin
+                    .as_ref()
+                    .map(|d| format!("{}: {}", d.provider.as_db_str(), d.project))
+                    .unwrap_or_else(|| "none detected".to_string());
+                summary.push(format!("  tracker:    auto-detect  ({detected})"));
+            },
+            TrackerMode::Configure => {
+                let auth = match draft.tracker.auth {
+                    TrackerAuthMode::Anonymous => "anonymous".to_string(),
+                    TrackerAuthMode::Env => format!("env {}", draft.tracker.auth_value.trim()),
+                    TrackerAuthMode::Command =>
+                        format!("command {}", draft.tracker.auth_value.trim()),
+                };
+                summary.push(format!(
+                    "  tracker:    {}  auth={}",
+                    draft.tracker.provider.as_db_str(),
+                    auth
+                ));
+            },
+        }
+
+        // Distillation — shown as the EFFECTIVE state: off whenever the tracker gate isn't
+        // satisfied (matching what `build_result` writes), regardless of the draft's mode.
+        let distill = if !super::steps::tracker_is_set_up(state) {
+            "off (needs a tracker)".to_string()
+        } else {
+            match draft.distill.mode {
+                DistillMode::Off => "off".to_string(),
+                DistillMode::ValidatedBox =>
+                    if draft.distill.preserved_ephemeral {
+                        "GPU box (existing config)".to_string()
+                    } else {
+                        "validated 30B GPU box".to_string()
+                    },
+                DistillMode::Connect => format!("connect  {}", draft.distill.endpoint.trim()),
+            }
+        };
+        summary.push(format!("  distill:    {distill}"));
+
         // Oracle auto_run
         summary.push(format!(
             "  oracle:     auto_run={}",
@@ -118,8 +161,10 @@ impl ReviewModel {
             .collect();
 
         // ── diff ─────────────────────────────────────────────────────────────────
+        // Diff the NORMALIZED draft (the same one `build_result` writes) so the preview matches the
+        // saved file — e.g. distillation forced off when no tracker resolves.
         let diff = original.and_then(|orig| {
-            let patched = draft.patch_existing(orig).ok()?;
+            let patched = super::normalized_write_draft(state).patch_existing(orig).ok()?;
             Some(line_diff(orig, &patched))
         });
 

--- a/crates/rag-rat-cli/src/init/wizard/state.rs
+++ b/crates/rag-rat-cli/src/init/wizard/state.rs
@@ -3,8 +3,10 @@
 use std::collections::HashMap;
 use std::sync::mpsc::{Receiver, TryRecvError};
 
+use rag_rat_papertrail::ResolvedTracker;
+
 use super::catalog::CookbookCatalog;
-use super::draft::WizardDraft;
+use super::draft::{TrackerMode, WizardDraft};
 use super::probe::ProbeRegistry;
 use super::steps::hooks::HookConflict;
 use super::steps::{CheckResult, StepId, StepState};
@@ -77,9 +79,35 @@ pub(crate) fn provision_confirm_satisfied(ui: &WizardUiState) -> bool {
     ui.provision_confirm.trim() == PROVISION_CONFIRM_WORD
 }
 
+/// Seed the explicit-binding defaults from auto-detection — but ONLY for a still-auto-detect draft.
+/// A reconfigure draft that already recovered an explicit `[[tracker]]` (mode `Configure`) keeps
+/// its own provider/base_url; overwriting them with the origin-derived values would silently
+/// corrupt a binding (e.g. a Jira tracker in a GitHub-hosted repo becomes GitHub while keeping the
+/// Jira project/auth). For a fresh draft it just pre-selects the detected provider so switching to
+/// Configure starts from the right place.
+fn seed_tracker_from_detection(draft: &mut WizardDraft, detected: Option<&ResolvedTracker>) {
+    if draft.tracker.mode != TrackerMode::AutoDetect {
+        return;
+    }
+    if let Some(det) = detected {
+        draft.tracker.provider = det.provider;
+        if let Some(base) = &det.base_url {
+            draft.tracker.base_url = base.clone();
+        }
+    }
+}
+
 pub(crate) struct WizardState {
     pub draft: WizardDraft,
     pub cookbooks: CookbookCatalog,
+    /// What auto-detection resolves from the `origin` remote — the AutoDetect gate + panel
+    /// (runtime auto-detection always uses `origin`, regardless of a binding's configured
+    /// remote).
+    pub detected_origin: Option<ResolvedTracker>,
+    /// What the binding's CONFIGURED remote resolves to (`origin` by default) — the Configure
+    /// gate. Distinct from `detected_origin` only for an explicit non-`origin` remote. Both
+    /// are computed once at construction (git-remote reads), never re-run per frame.
+    pub detected_configured: Option<ResolvedTracker>,
     pub ui: WizardUiState,
     pub scan: RepoScan,
     pub probes: ProbeRegistry,
@@ -98,14 +126,27 @@ impl WizardState {
     }
 
     pub(crate) fn with_cookbooks(
-        draft: WizardDraft,
+        mut draft: WizardDraft,
         scan: RepoScan,
         cookbooks: CookbookCatalog,
     ) -> Self {
         let n = StepId::COUNT;
+        // Detect against BOTH origin (what AutoDetect binds at runtime) and the binding's
+        // configured remote (what a Configure binding derives from) — they differ only for an
+        // explicit non-`origin` remote, and conflating them makes the gate use the wrong one.
+        let detected_origin = rag_rat_papertrail::auto_detect_tracker(&draft.root_abs);
+        let configured_remote = match draft.tracker.remote.trim() {
+            "" => "origin",
+            other => other,
+        };
+        let detected_configured =
+            rag_rat_papertrail::detect_tracker_for_remote(&draft.root_abs, configured_remote);
+        seed_tracker_from_detection(&mut draft, detected_configured.as_ref());
         Self {
             draft,
             cookbooks,
+            detected_origin,
+            detected_configured,
             ui: WizardUiState::new(),
             scan,
             probes: ProbeRegistry::new(),
@@ -174,5 +215,37 @@ impl WizardState {
         if disconnected {
             self.provision_log_rx = None;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rag_rat_base::config::Tracker;
+
+    use super::*;
+    use crate::init::RepoScan;
+    use crate::init::wizard::draft::WizardDraft;
+
+    fn draft() -> WizardDraft {
+        WizardDraft::from_scan(&RepoScan::default(), ".".into(), std::path::PathBuf::from("."))
+    }
+
+    #[test]
+    fn detection_seeds_an_auto_detect_draft_but_never_a_configured_one() {
+        let github = rag_rat_papertrail::detect_tracker_from_remote_url("https://github.com/o/r");
+
+        // Fresh auto-detect draft: the detected provider is seeded.
+        let mut d = draft();
+        d.tracker.provider = Tracker::Bitbucket; // a stale placeholder
+        seed_tracker_from_detection(&mut d, github.as_ref());
+        assert_eq!(d.tracker.provider, Tracker::Github);
+
+        // Reconfigure draft (already Configure): detection must NOT overwrite the recovered
+        // provider — a Jira binding in a GitHub-hosted repo must stay Jira.
+        let mut d = draft();
+        d.tracker.mode = TrackerMode::Configure;
+        d.tracker.provider = Tracker::Jira;
+        seed_tracker_from_detection(&mut d, github.as_ref());
+        assert_eq!(d.tracker.provider, Tracker::Jira, "a configured binding must be preserved");
     }
 }

--- a/crates/rag-rat-cli/src/init/wizard/steps/dispatch.rs
+++ b/crates/rag-rat-cli/src/init/wizard/steps/dispatch.rs
@@ -9,6 +9,7 @@ use ratatui::layout::Rect;
 use tui_tree_widget::TreeState;
 
 use super::super::state::WizardState;
+use super::distillation::{handle_distillation, render_distillation, validate_distillation};
 use super::embedding::{
     handle_embedding, init_embedding_step, render_embedding, scroll_embedding, validate_embedding,
 };
@@ -18,6 +19,7 @@ use super::indexing::{
 };
 use super::integration::{handle_integration, render_integration, validate_hooks};
 use super::oracle::{handle_oracle, render_oracle};
+use super::tracker::{handle_papertrail, render_papertrail, validate_papertrail};
 use super::types::{CheckResult, IndexZone, Outcome, StepId, StepState};
 
 pub(crate) fn step_title(id: StepId) -> &'static str {
@@ -25,6 +27,8 @@ pub(crate) fn step_title(id: StepId) -> &'static str {
         StepId::Indexing => "Indexing",
         StepId::Oracle => "Oracle",
         StepId::Embedding => "Embedding",
+        StepId::Papertrail => "Papertrail",
+        StepId::Distill => "Distill",
         StepId::Integration => "Integration",
     }
 }
@@ -37,6 +41,8 @@ pub(crate) fn step_footer(id: StepId) -> &'static str {
         StepId::Embedding =>
             "Tab/Shift-Tab field  ↑↓/j/k move  PgUp/PgDn scroll  Space select  type edit  d \
              download  t/p test  l log",
+        StepId::Papertrail => "↑↓ move  ←→ change  type edit  Enter next",
+        StepId::Distill => "↑↓ move  ←→ change  type edit  Enter next",
         StepId::Integration => "↑↓ navigate  Space toggle  t version check  g git  Enter next",
     }
 }
@@ -47,6 +53,8 @@ fn step_matches(id: StepId, step: &Option<StepState>) -> bool {
         (StepId::Indexing, Some(StepState::Indexing { .. }))
             | (StepId::Oracle, Some(StepState::Oracle))
             | (StepId::Embedding, Some(StepState::Embedding { .. }))
+            | (StepId::Papertrail, Some(StepState::Papertrail { .. }))
+            | (StepId::Distill, Some(StepState::Distill { .. }))
             | (StepId::Integration, Some(StepState::Integration { .. }))
     )
 }
@@ -74,6 +82,8 @@ pub(crate) fn init_step(id: StepId, state: &WizardState) -> StepState {
         },
         StepId::Embedding => init_embedding_step(state),
         StepId::Oracle => StepState::Oracle,
+        StepId::Papertrail => StepState::Papertrail { focus: 0 },
+        StepId::Distill => StepState::Distill { focus: 0 },
         StepId::Integration => StepState::Integration { focus: 0 },
     }
 }
@@ -83,6 +93,8 @@ pub(crate) fn render_step(id: StepId, f: &mut Frame, area: Rect, state: &mut Wiz
         StepId::Indexing => render_indexing(f, area, state),
         StepId::Oracle => render_oracle(f, area, state),
         StepId::Embedding => render_embedding(f, area, state),
+        StepId::Papertrail => render_papertrail(f, area, state),
+        StepId::Distill => render_distillation(f, area, state),
         StepId::Integration => render_integration(f, area, state),
     }
 }
@@ -96,6 +108,8 @@ pub(crate) fn step_handle_key(id: StepId, key: KeyEvent, state: &mut WizardState
         StepId::Indexing => handle_indexing(key, state),
         StepId::Oracle => handle_oracle(key, state),
         StepId::Embedding => handle_embedding(key, state),
+        StepId::Papertrail => handle_papertrail(key, state),
+        StepId::Distill => handle_distillation(key, state),
         StepId::Integration => handle_integration(key, state),
     }
 }
@@ -105,6 +119,8 @@ pub(crate) fn validate_step(id: StepId, state: &WizardState) -> CheckResult {
         StepId::Indexing => validate_indexing(state),
         StepId::Oracle => CheckResult::ok(),
         StepId::Embedding => validate_embedding(state),
+        StepId::Papertrail => validate_papertrail(state),
+        StepId::Distill => validate_distillation(state),
         StepId::Integration => validate_hooks(state),
     }
 }

--- a/crates/rag-rat-cli/src/init/wizard/steps/distillation.rs
+++ b/crates/rag-rat-cli/src/init/wizard/steps/distillation.rs
@@ -1,0 +1,411 @@
+//! Distill step — the opt-in issue-distillation model pass. Gated on a resolvable issue tracker
+//! (nothing to distill without one) and off by default; the validated-box choice reuses the typed
+//! `provision` confirm because it provisions a paid GPU.
+
+use rag_rat_base::config::valid_tracker_base_url;
+use ratatui::Frame;
+use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use ratatui::layout::{Constraint, Layout, Rect};
+use ratatui::style::Style;
+use ratatui::text::{Line, Span};
+
+use super::super::draft::DistillMode;
+use super::super::state::{PROVISION_CONFIRM_WORD, WizardState, provision_confirm_satisfied};
+use super::super::theme;
+use super::embedding::one_line_field;
+use super::tracker::tracker_is_set_up;
+use super::types::{CheckResult, DistillZone, Outcome, StepState};
+use super::widgets::{help_panel, option_list};
+
+/// Focusable zones for the current mode. Empty when no tracker is set up (the step is inactive).
+fn distill_zones(state: &WizardState) -> Vec<DistillZone> {
+    if !tracker_is_set_up(state) {
+        return Vec::new();
+    }
+    let mut zones = vec![DistillZone::Mode];
+    match state.draft.distill.mode {
+        DistillMode::Off => {},
+        // A preserved existing box needs no confirmation (it's already provisioned).
+        DistillMode::ValidatedBox =>
+            if !state.draft.distill.preserved_ephemeral {
+                zones.push(DistillZone::ProvisionConfirm);
+            },
+        DistillMode::Connect => {
+            zones.push(DistillZone::Endpoint);
+            zones.push(DistillZone::Model);
+        },
+    }
+    zones
+}
+
+fn border(focused: bool) -> Style {
+    if focused { theme::focused_border() } else { theme::border() }
+}
+
+fn is_editable(zone: DistillZone) -> bool {
+    matches!(zone, DistillZone::Endpoint | DistillZone::Model | DistillZone::ProvisionConfirm)
+}
+
+pub(super) fn render_distillation(f: &mut Frame, area: Rect, state: &WizardState) {
+    let Some(StepState::Distill { focus }) = state.step else { return };
+    if !tracker_is_set_up(state) {
+        render_inactive(f, area);
+        return;
+    }
+    let d = &state.draft.distill;
+    let zones = distill_zones(state);
+    let focused = |z: DistillZone| zones.get(focus).copied() == Some(z);
+
+    let outer = Layout::vertical([Constraint::Length(5), Constraint::Min(0)]).split(area);
+
+    let mode_opts = vec![
+        ("off".to_string(), theme::base()),
+        ("validated 30B GPU box".to_string(), theme::base()),
+        ("connect to a server".to_string(), theme::base()),
+    ];
+    let mode_sel = match d.mode {
+        DistillMode::Off => 0,
+        DistillMode::ValidatedBox => 1,
+        DistillMode::Connect => 2,
+    };
+    option_list(
+        f,
+        outer[0],
+        "Distillation  ↑↓ move  ←→ change",
+        &mode_opts,
+        mode_sel,
+        focused(DistillZone::Mode),
+    );
+
+    match d.mode {
+        DistillMode::Off => help_panel(f, outer[1], "Off", vec![Line::from(Span::styled(
+            " Distillation off. Closed issues and PRs stay as raw papertrail.",
+            theme::muted(),
+        ))]),
+        DistillMode::ValidatedBox => render_validated_box(f, outer[1], state, focused),
+        DistillMode::Connect => render_connect(f, outer[1], state, &zones, focus),
+    }
+}
+
+fn render_inactive(f: &mut Frame, area: Rect) {
+    help_panel(f, area, "Distillation", vec![
+        Line::from(Span::styled(
+            " Distillation needs an issue tracker — none is set up.",
+            theme::warning(),
+        )),
+        Line::from(""),
+        Line::from(Span::styled(
+            "It turns closed issues and PRs into typed decision records, so it needs a tracker \
+             feeding it threads. Configure or auto-detect one on the Papertrail step first.",
+            theme::muted(),
+        )),
+    ]);
+}
+
+fn render_validated_box(
+    f: &mut Frame,
+    area: Rect,
+    state: &WizardState,
+    focused: impl Fn(DistillZone) -> bool,
+) {
+    if state.draft.distill.preserved_ephemeral {
+        help_panel(f, area, "GPU box (from your config)", vec![Line::from(Span::styled(
+            "An existing ephemeral GPU box from your config, preserved as-is. Pick another mode \
+             to replace it with the validated box or a connect endpoint.",
+            theme::muted(),
+        ))]);
+        return;
+    }
+    let rows = Layout::vertical([Constraint::Length(3), Constraint::Min(0)]).split(area);
+    f.render_widget(
+        one_line_field(
+            &state.ui.provision_confirm,
+            "confirm the paid box",
+            border(focused(DistillZone::ProvisionConfirm)),
+        ),
+        rows[0],
+    );
+    help_panel(f, rows[1], "Validated 30B box", vec![
+        Line::from(Span::styled(
+            "Ephemeral Modal L40S running the validated 30B model, provisioned per run and billed \
+             while it runs. Nothing else to configure.",
+            theme::muted(),
+        )),
+        Line::from(Span::styled(
+            format!("Type '{PROVISION_CONFIRM_WORD}' above to acknowledge the paid GPU."),
+            theme::muted(),
+        )),
+    ]);
+}
+
+fn render_connect(
+    f: &mut Frame,
+    area: Rect,
+    state: &WizardState,
+    zones: &[DistillZone],
+    focus: usize,
+) {
+    let d = &state.draft.distill;
+    let focused = |z: DistillZone| zones.get(focus).copied() == Some(z);
+    let rows = Layout::vertical([Constraint::Length(3), Constraint::Length(3), Constraint::Min(0)])
+        .split(area);
+    f.render_widget(
+        one_line_field(&d.endpoint, "endpoint", border(focused(DistillZone::Endpoint))),
+        rows[0],
+    );
+    f.render_widget(
+        one_line_field(&d.model, "model", border(focused(DistillZone::Model))),
+        rows[1],
+    );
+    help_panel(f, rows[2], "Connect", vec![
+        Line::from(Span::styled(
+            "Use your own running OpenAI-compatible server; nothing is provisioned.",
+            theme::muted(),
+        )),
+        Line::from(Span::styled(
+            "endpoint: base URL of the server. model: the server-side model name.",
+            theme::muted(),
+        )),
+    ]);
+}
+
+pub(super) fn handle_distillation(key: KeyEvent, state: &mut WizardState) -> Outcome {
+    // Inactive without a tracker: keep the pass off; only tab navigation works.
+    if !tracker_is_set_up(state) {
+        state.draft.distill.mode = DistillMode::Off;
+        return match key.code {
+            KeyCode::Enter => Outcome::Advance,
+            KeyCode::Esc => Outcome::Back,
+            _ => Outcome::Pass,
+        };
+    }
+    let zones = distill_zones(state);
+    let mut focus = match &state.step {
+        Some(StepState::Distill { focus }) => (*focus).min(zones.len().saturating_sub(1)),
+        _ => return Outcome::Pass,
+    };
+    let zone = zones.get(focus).copied().unwrap_or(DistillZone::Mode);
+    let outcome = match key.code {
+        KeyCode::Enter => return Outcome::Advance,
+        KeyCode::Esc => return Outcome::Back,
+        KeyCode::Up => {
+            focus = focus.saturating_sub(1);
+            Outcome::Consumed
+        },
+        KeyCode::Down => {
+            if focus + 1 < zones.len() {
+                focus += 1;
+            }
+            Outcome::Consumed
+        },
+        KeyCode::Left if zone == DistillZone::Mode => {
+            cycle_mode(state, false);
+            Outcome::Consumed
+        },
+        KeyCode::Right if zone == DistillZone::Mode => {
+            cycle_mode(state, true);
+            Outcome::Consumed
+        },
+        KeyCode::Char(' ') if zone == DistillZone::Mode => {
+            cycle_mode(state, true);
+            Outcome::Consumed
+        },
+        KeyCode::Backspace if is_editable(zone) => {
+            if let Some(field) = field_mut(zone, state) {
+                field.pop();
+            }
+            Outcome::Consumed
+        },
+        KeyCode::Char(c)
+            if is_editable(zone)
+                && !key.modifiers.intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) =>
+        {
+            if let Some(field) = field_mut(zone, state) {
+                field.push(c);
+            }
+            Outcome::Consumed
+        },
+        _ => Outcome::Pass,
+    };
+    if let Some(StepState::Distill { focus: f }) = &mut state.step {
+        *f = focus;
+    }
+    outcome
+}
+
+fn cycle_mode(state: &mut WizardState, forward: bool) {
+    const MODES: [DistillMode; 3] =
+        [DistillMode::Off, DistillMode::ValidatedBox, DistillMode::Connect];
+    let cur = MODES.iter().position(|m| *m == state.draft.distill.mode).unwrap_or(0);
+    let next =
+        if forward { (cur + 1) % MODES.len() } else { (cur + MODES.len() - 1) % MODES.len() };
+    state.draft.distill.mode = MODES[next];
+    // ANY deliberate mode change means the user is actively choosing — drop the preserved-existing
+    // flag so the box requires confirmation and emits the shipped default, never silently restoring
+    // a loaded custom block (whatever path the cycles take). An UNTOUCHED distill keeps its loaded
+    // state because this only fires on a cycle.
+    state.draft.distill.preserved_ephemeral = false;
+}
+
+/// The mutable field behind an editable zone. `ProvisionConfirm` edits the shared UI confirm word
+/// (not the draft) — the same one the Embedding ephemeral gate uses.
+fn field_mut(zone: DistillZone, state: &mut WizardState) -> Option<&mut String> {
+    match zone {
+        DistillZone::Endpoint => Some(&mut state.draft.distill.endpoint),
+        DistillZone::Model => Some(&mut state.draft.distill.model),
+        DistillZone::ProvisionConfirm => Some(&mut state.ui.provision_confirm),
+        DistillZone::Mode => None,
+    }
+}
+
+pub(super) fn validate_distillation(state: &WizardState) -> CheckResult {
+    if !tracker_is_set_up(state) {
+        return CheckResult::ok();
+    }
+    match state.draft.distill.mode {
+        DistillMode::Off => CheckResult::ok(),
+        // A preserved existing box is already provisioned/acknowledged — only a FRESH box choice
+        // needs the paid-GPU confirmation.
+        DistillMode::ValidatedBox =>
+            if state.draft.distill.preserved_ephemeral || provision_confirm_satisfied(&state.ui) {
+                CheckResult::ok()
+            } else {
+                CheckResult::block(format!(
+                    "type '{PROVISION_CONFIRM_WORD}' on the Distill step to confirm the paid GPU \
+                     box"
+                ))
+            },
+        DistillMode::Connect => {
+            let endpoint = state.draft.distill.endpoint.trim();
+            if endpoint.is_empty() || state.draft.distill.model.trim().is_empty() {
+                CheckResult::block("distill connect needs an endpoint and a model")
+            } else if !valid_tracker_base_url(endpoint) {
+                // Same generic http(s)-URL-without-credentials check the tracker base_url uses — a
+                // malformed endpoint (`gpu:8000`, `not-a-url`) or a credential-bearing one
+                // otherwise passes `Config::load` and only fails when the HTTP
+                // client builds a request.
+                CheckResult::block(
+                    "distill endpoint must be a valid http(s) URL with no credentials",
+                )
+            } else {
+                CheckResult::ok()
+            }
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::init::RepoScan;
+    use crate::init::wizard::draft::{TrackerMode, WizardDraft};
+    use crate::init::wizard::state::{PROVISION_CONFIRM_WORD, WizardState};
+
+    /// A wizard state whose tracker resolution is deterministic: a temp-dir root has no `origin`,
+    /// so nothing is auto-detected and the gate is driven purely by the test.
+    fn state(tracker_mode: TrackerMode, detected: bool) -> WizardState {
+        let dir = tempfile::tempdir().unwrap();
+        let mut d =
+            WizardDraft::from_scan(&RepoScan::default(), ".".into(), dir.path().to_path_buf());
+        d.tracker.mode = tracker_mode;
+        let mut s = WizardState::new(d, RepoScan::default());
+        let make = || {
+            detected
+                .then(|| {
+                    rag_rat_papertrail::detect_tracker_from_remote_url("https://github.com/o/r")
+                })
+                .flatten()
+        };
+        s.detected_origin = make();
+        s.detected_configured = make();
+        s
+    }
+
+    #[test]
+    fn distill_is_gated_on_a_resolvable_tracker() {
+        // Auto-detect: gated on the origin resolving to something.
+        assert!(!tracker_is_set_up(&state(TrackerMode::AutoDetect, false)));
+        assert!(tracker_is_set_up(&state(TrackerMode::AutoDetect, true)));
+
+        // Configure with an explicit project resolves regardless of detection.
+        let mut resolved = state(TrackerMode::Configure, false);
+        resolved.draft.tracker.project = "owner/repo".into();
+        assert!(tracker_is_set_up(&resolved));
+        assert!(!distill_zones(&resolved).is_empty());
+
+        // Configure with no project and nothing detected can't resolve → inactive.
+        let bare = state(TrackerMode::Configure, false);
+        assert!(!tracker_is_set_up(&bare));
+        assert!(distill_zones(&bare).is_empty());
+    }
+
+    #[test]
+    fn validate_blocks_connect_without_fields_and_box_without_confirm() {
+        let mut s = state(TrackerMode::Configure, false);
+        s.draft.tracker.project = "owner/repo".into(); // a resolvable tracker → distill is active
+
+        s.draft.distill.mode = DistillMode::Connect;
+        assert!(validate_distillation(&s).message.is_some(), "empty connect must block");
+        s.draft.distill.endpoint = "http://x".into();
+        s.draft.distill.model = "m".into();
+        assert!(validate_distillation(&s).message.is_none(), "filled connect is ok");
+
+        s.draft.distill.mode = DistillMode::ValidatedBox;
+        assert!(validate_distillation(&s).message.is_some(), "paid box needs the typed confirm");
+        s.ui.provision_confirm = PROVISION_CONFIRM_WORD.to_string();
+        assert!(validate_distillation(&s).message.is_none(), "confirmed box is ok");
+    }
+
+    #[test]
+    fn any_mode_cycle_clears_preservation() {
+        // preserved_ephemeral holds only while the user leaves distill UNTOUCHED. The first
+        // deliberate mode change (from any starting mode) clears it, so a box then needs
+        // confirmation + the shipped default — never a silently-restored loaded custom block.
+        for start in [DistillMode::ValidatedBox, DistillMode::Off, DistillMode::Connect] {
+            let mut s = state(TrackerMode::Configure, false);
+            s.draft.tracker.project = "owner/repo".into();
+            s.draft.distill.mode = start;
+            s.draft.distill.preserved_ephemeral = true;
+            cycle_mode(&mut s, true);
+            assert!(!s.draft.distill.preserved_ephemeral, "cycling from {start:?} clears it");
+        }
+    }
+
+    #[test]
+    fn an_inactive_step_validates_ok_regardless_of_mode() {
+        let mut s = state(TrackerMode::AutoDetect, false);
+        s.draft.distill.mode = DistillMode::ValidatedBox;
+        assert!(validate_distillation(&s).message.is_none());
+    }
+
+    #[test]
+    fn a_preserved_ephemeral_box_needs_no_confirmation() {
+        let mut s = state(TrackerMode::Configure, false);
+        s.draft.tracker.project = "owner/repo".into(); // resolvable → distill active
+        s.draft.distill.mode = DistillMode::ValidatedBox;
+        s.draft.distill.preserved_ephemeral = true;
+        // No typed confirm, yet valid — an existing box is already provisioned.
+        assert!(validate_distillation(&s).message.is_none());
+        // ...and it exposes no confirm zone.
+        assert!(!distill_zones(&s).contains(&DistillZone::ProvisionConfirm));
+
+        // A fresh box (not preserved) still requires the confirm.
+        s.draft.distill.preserved_ephemeral = false;
+        assert!(validate_distillation(&s).message.is_some());
+        assert!(distill_zones(&s).contains(&DistillZone::ProvisionConfirm));
+    }
+
+    #[test]
+    fn connect_endpoint_with_credentials_is_rejected() {
+        let mut s = state(TrackerMode::Configure, false);
+        s.draft.tracker.project = "owner/repo".into(); // resolvable → distill active
+        s.draft.distill.mode = DistillMode::Connect;
+        s.draft.distill.model = "m".into();
+        s.draft.distill.endpoint = "https://user:pass@host".into();
+        assert!(validate_distillation(&s).message.is_some(), "credential endpoint must block");
+        s.draft.distill.endpoint = "gpu:8000".into();
+        assert!(validate_distillation(&s).message.is_some(), "malformed endpoint must block");
+        s.draft.distill.endpoint = "https://host".into();
+        assert!(validate_distillation(&s).message.is_none());
+    }
+}

--- a/crates/rag-rat-cli/src/init/wizard/steps/embedding.rs
+++ b/crates/rag-rat-cli/src/init/wizard/steps/embedding.rs
@@ -445,7 +445,7 @@ pub(super) fn render_embedding(f: &mut Frame, area: Rect, state: &WizardState) {
     }
 }
 
-fn one_line_field<'a>(value: &'a str, title: &'a str, border: Style) -> Paragraph<'a> {
+pub(super) fn one_line_field<'a>(value: &'a str, title: &'a str, border: Style) -> Paragraph<'a> {
     Paragraph::new(Line::from(Span::raw(value)))
         .style(theme::base())
         .block(theme::block(title).border_style(border))

--- a/crates/rag-rat-cli/src/init/wizard/steps/mod.rs
+++ b/crates/rag-rat-cli/src/init/wizard/steps/mod.rs
@@ -4,17 +4,22 @@
 //! - [`types`] — step-state enums + shared result/state types ([`StepId`], [`Outcome`], [`Sev`],
 //!   [`CheckResult`], [`StepState`], [`EmbedFocus`], [`IndexZone`]).
 //! - [`dispatch`] — step titles/footers, state init, and the render/handle_key/validate fan-out.
-//! - [`indexing`] / [`oracle`] / [`embedding`] / [`integration`] — the per-step logic.
+//! - [`indexing`] / [`oracle`] / [`embedding`] / [`tracker`] / [`distillation`] / [`integration`] —
+//!   the per-step logic.
+//! - [`widgets`] — small shared step widgets (option list, help panel).
 //! - [`hooks`] — git-hook conflict choices + the chained-hook renderer.
 
 pub(crate) mod hooks;
 
 mod dispatch;
+mod distillation;
 mod embedding;
 mod indexing;
 mod integration;
 mod oracle;
+mod tracker;
 mod types;
+mod widgets;
 
 #[cfg(test)]
 mod tests;
@@ -22,4 +27,5 @@ mod tests;
 pub(crate) use dispatch::{
     init_step, render_step, scroll_step, step_footer, step_handle_key, step_title, validate_step,
 };
+pub(crate) use tracker::tracker_is_set_up;
 pub(crate) use types::{CheckResult, Outcome, Sev, StepId, StepState, can_write};

--- a/crates/rag-rat-cli/src/init/wizard/steps/tracker.rs
+++ b/crates/rag-rat-cli/src/init/wizard/steps/tracker.rs
@@ -1,0 +1,482 @@
+//! Papertrail step — bind an issue tracker: auto-detect from the `origin` remote (the zero-config
+//! default) or configure an explicit `[[tracker]]` binding.
+
+use rag_rat_base::config::{Tracker, valid_tracker_base_url, valid_tracker_project};
+use rag_rat_papertrail::ResolvedTracker;
+use ratatui::Frame;
+use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use ratatui::layout::{Constraint, Layout, Rect};
+use ratatui::style::Style;
+use ratatui::text::{Line, Span};
+
+use super::super::draft::{TrackerAuthMode, TrackerDraft, TrackerMode};
+use super::super::state::WizardState;
+use super::super::theme;
+use super::embedding::one_line_field;
+use super::types::{CheckResult, Outcome, PapertrailZone, StepState};
+use super::widgets::{help_panel, option_list};
+
+const PROVIDERS: [Tracker; 4] =
+    [Tracker::Github, Tracker::Gitlab, Tracker::Bitbucket, Tracker::Jira];
+
+/// Whether an issue tracker will actually be bound — the gate the Distill step keys on.
+/// `AutoDetect` binds only when the `origin` remote resolved to a tracker; `Configure` binds only
+/// when the explicit binding will actually resolve (see [`configured_tracker_resolves`]).
+pub(crate) fn tracker_is_set_up(state: &WizardState) -> bool {
+    let t = &state.draft.tracker;
+    match t.mode {
+        // AutoDetect binds `origin` at runtime, regardless of the binding's configured remote.
+        TrackerMode::AutoDetect => state.detected_origin.is_some(),
+        TrackerMode::Configure =>
+            configured_tracker_resolves(t, state.detected_configured.as_ref()),
+    }
+}
+
+/// Whether a `Configure` binding will actually resolve to a tracker. An explicit project always
+/// resolves; Jira without one never does. A code host with no project must derive it from its git
+/// remote — and `detected` is the resolution of the binding's CONFIGURED remote (origin by
+/// default; see `WizardState::with_cookbooks`), so this verifies any named remote rather than
+/// trusting it: it resolves only when that remote is a recognized host for the SAME provider.
+fn configured_tracker_resolves(t: &TrackerDraft, detected: Option<&ResolvedTracker>) -> bool {
+    if !t.project.trim().is_empty() {
+        return true;
+    }
+    if t.provider == Tracker::Jira {
+        return false; // Jira never auto-derives a project.
+    }
+    // A self-hosted `base_url` targets a specific host, but the configured remote may point at a
+    // DIFFERENT host (e.g. base_url = github.example.com, origin = github.com). Deriving the
+    // project from that remote would resolve the wrong repository, so require an explicit project.
+    if !t.base_url.trim().is_empty() {
+        return false;
+    }
+    // No explicit project → it must derive from the git remote, which we can only VERIFY for the
+    // remote `detected` covers (the binding's configured remote, origin by default): it resolves
+    // when that remote is a recognized host for the SAME provider. A self-hosted host, or a remote
+    // we can't recognize, needs an explicit project — the wizard asks for one rather than save a
+    // binding the runtime resolver might silently drop. (The config file still derives a project
+    // from a self-hosted remote for a hand-written binding; this is a wizard-level nudge toward
+    // being explicit, not a config constraint — precise verification would need a git read on every
+    // keystroke.)
+    detected.map(|d| d.provider) == Some(t.provider)
+}
+
+/// The focusable zones in render order for the current mode: auto-detect shows only the mode
+/// selector; configure reveals the form, with the auth-value field present only for non-anonymous
+/// auth. The step's `focus: usize` indexes into this list.
+fn papertrail_zones(t: &TrackerDraft) -> Vec<PapertrailZone> {
+    let mut zones = vec![PapertrailZone::Mode];
+    if t.mode == TrackerMode::Configure {
+        zones.push(PapertrailZone::Provider);
+        zones.push(PapertrailZone::Auth);
+        if t.auth != TrackerAuthMode::Anonymous {
+            zones.push(PapertrailZone::AuthValue);
+        }
+        zones.push(PapertrailZone::BaseUrl);
+        zones.push(PapertrailZone::Project);
+        zones.push(PapertrailZone::Tags);
+    }
+    zones
+}
+
+fn border(focused: bool) -> Style {
+    if focused { theme::focused_border() } else { theme::border() }
+}
+
+fn is_editable(zone: PapertrailZone) -> bool {
+    matches!(
+        zone,
+        PapertrailZone::AuthValue
+            | PapertrailZone::BaseUrl
+            | PapertrailZone::Project
+            | PapertrailZone::Tags
+    )
+}
+
+pub(super) fn render_papertrail(f: &mut Frame, area: Rect, state: &WizardState) {
+    let Some(StepState::Papertrail { focus }) = state.step else { return };
+    let t = &state.draft.tracker;
+    let zones = papertrail_zones(t);
+    let focused = |z: PapertrailZone| zones.get(focus).copied() == Some(z);
+
+    let outer = Layout::vertical([Constraint::Length(4), Constraint::Min(0)]).split(area);
+
+    let mode_opts = vec![
+        ("auto-detect from origin".to_string(), theme::base()),
+        ("configure explicitly".to_string(), theme::base()),
+    ];
+    let mode_sel = match t.mode {
+        TrackerMode::AutoDetect => 0,
+        TrackerMode::Configure => 1,
+    };
+    option_list(
+        f,
+        outer[0],
+        "Tracker  ↑↓ move  ←→ change",
+        &mode_opts,
+        mode_sel,
+        focused(PapertrailZone::Mode),
+    );
+
+    match t.mode {
+        TrackerMode::AutoDetect => render_autodetect_body(f, outer[1], state),
+        TrackerMode::Configure => render_configure_body(f, outer[1], state, focus, &zones),
+    }
+}
+
+fn render_autodetect_body(f: &mut Frame, area: Rect, state: &WizardState) {
+    let mut lines = match &state.detected_origin {
+        Some(det) => vec![Line::from(Span::styled(
+            format!(" origin → {}: {}", det.provider.as_db_str(), det.project),
+            theme::success(),
+        ))],
+        None => vec![Line::from(Span::styled(
+            " No tracker detected from the origin remote — nothing will be mirrored.",
+            theme::warning(),
+        ))],
+    };
+    lines.push(Line::from(""));
+    lines.push(Line::from(Span::styled(
+        "Derives the tracker from the git origin remote. Writes nothing; re-detected on every run.",
+        theme::muted(),
+    )));
+    lines.push(Line::from(Span::styled(
+        "Choose 'configure' to pin auth, a self-hosted instance, or Jira (never auto-detected).",
+        theme::muted(),
+    )));
+    help_panel(f, area, "Auto-detect", lines);
+}
+
+fn render_configure_body(
+    f: &mut Frame,
+    area: Rect,
+    state: &WizardState,
+    focus: usize,
+    zones: &[PapertrailZone],
+) {
+    let t = &state.draft.tracker;
+    let focused = |z: PapertrailZone| zones.get(focus).copied() == Some(z);
+    let rows = Layout::vertical([
+        Constraint::Length(6),
+        Constraint::Length(3),
+        Constraint::Length(3),
+        Constraint::Length(3),
+        Constraint::Min(0),
+    ])
+    .split(area);
+
+    let cols =
+        Layout::horizontal([Constraint::Percentage(50), Constraint::Percentage(50)]).split(rows[0]);
+    let detected = state.detected_configured.as_ref().map(|d| d.provider);
+    let provider_opts: Vec<(String, Style)> = PROVIDERS
+        .iter()
+        .map(|p| {
+            let style = if detected == Some(*p) { theme::accent() } else { theme::base() };
+            (p.as_db_str().to_string(), style)
+        })
+        .collect();
+    let provider_sel = PROVIDERS.iter().position(|p| *p == t.provider).unwrap_or(0);
+    option_list(
+        f,
+        cols[0],
+        "provider",
+        &provider_opts,
+        provider_sel,
+        focused(PapertrailZone::Provider),
+    );
+
+    let auth_opts = vec![
+        ("anonymous".to_string(), theme::base()),
+        ("env var".to_string(), theme::base()),
+        ("command".to_string(), theme::base()),
+    ];
+    let auth_sel = match t.auth {
+        TrackerAuthMode::Anonymous => 0,
+        TrackerAuthMode::Env => 1,
+        TrackerAuthMode::Command => 2,
+    };
+    option_list(f, cols[1], "auth", &auth_opts, auth_sel, focused(PapertrailZone::Auth));
+
+    if t.auth != TrackerAuthMode::Anonymous {
+        let title = if t.auth == TrackerAuthMode::Env { "env var name" } else { "token command" };
+        f.render_widget(
+            one_line_field(&t.auth_value, title, border(focused(PapertrailZone::AuthValue))),
+            rows[1],
+        );
+    }
+
+    let br =
+        Layout::horizontal([Constraint::Percentage(50), Constraint::Percentage(50)]).split(rows[2]);
+    f.render_widget(
+        one_line_field(&t.base_url, "base url", border(focused(PapertrailZone::BaseUrl))),
+        br[0],
+    );
+    f.render_widget(
+        one_line_field(&t.project, "project", border(focused(PapertrailZone::Project))),
+        br[1],
+    );
+    f.render_widget(
+        one_line_field(&t.tags, "tags", border(focused(PapertrailZone::Tags))),
+        rows[3],
+    );
+
+    help_panel(f, rows[4], "help", configure_help(zones.get(focus).copied()));
+}
+
+fn configure_help(zone: Option<PapertrailZone>) -> Vec<Line<'static>> {
+    let text = match zone {
+        Some(PapertrailZone::Provider) =>
+            "The issue tracker to bind. Jira and self-hosted instances must be configured here.",
+        Some(PapertrailZone::Auth) =>
+            "anonymous rate-limits quickly on public repos. A token command like 'gh auth token' \
+             keeps no secret in the file.",
+        Some(PapertrailZone::AuthValue) =>
+            "env var: the NAME of a variable holding the token. command: a shell command printing \
+             the token to stdout.",
+        Some(PapertrailZone::BaseUrl) =>
+            "Self-hosted / enterprise instances only (https://…). Leave empty for the cloud host.",
+        Some(PapertrailZone::Project) =>
+            "Required for Jira (the project KEY, e.g. PROJ). Elsewhere derived from the remote — \
+             owner/repo.",
+        Some(PapertrailZone::Tags) =>
+            "Optional comma-separated labels; only matching issues and PRs are mirrored. Empty = \
+             all.",
+        _ => "An explicit [[tracker]] binding replaces auto-detection entirely.",
+    };
+    vec![Line::from(Span::styled(text, theme::muted()))]
+}
+
+pub(super) fn handle_papertrail(key: KeyEvent, state: &mut WizardState) -> Outcome {
+    let zones = papertrail_zones(&state.draft.tracker);
+    // Copy focus out so the helpers below can take `&mut state` freely (a held `&mut state.step`
+    // would conflict). Clamp it in case a prior mode/auth change shrank the zone list.
+    let mut focus = match &state.step {
+        Some(StepState::Papertrail { focus }) => (*focus).min(zones.len().saturating_sub(1)),
+        _ => return Outcome::Pass,
+    };
+    let zone = zones.get(focus).copied().unwrap_or(PapertrailZone::Mode);
+    let outcome = match key.code {
+        KeyCode::Enter => return Outcome::Advance,
+        KeyCode::Esc => return Outcome::Back,
+        KeyCode::Up => {
+            focus = focus.saturating_sub(1);
+            Outcome::Consumed
+        },
+        KeyCode::Down => {
+            if focus + 1 < zones.len() {
+                focus += 1;
+            }
+            Outcome::Consumed
+        },
+        KeyCode::Left => {
+            cycle_zone(zone, state, false);
+            Outcome::Consumed
+        },
+        KeyCode::Right => {
+            cycle_zone(zone, state, true);
+            Outcome::Consumed
+        },
+        KeyCode::Char(' ') if !is_editable(zone) => {
+            cycle_zone(zone, state, true);
+            Outcome::Consumed
+        },
+        KeyCode::Backspace if is_editable(zone) => {
+            if let Some(field) = field_mut(zone, state) {
+                field.pop();
+            }
+            Outcome::Consumed
+        },
+        KeyCode::Char(c)
+            if is_editable(zone)
+                && !key.modifiers.intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) =>
+        {
+            if let Some(field) = field_mut(zone, state) {
+                field.push(c);
+            }
+            Outcome::Consumed
+        },
+        _ => Outcome::Pass,
+    };
+    if let Some(StepState::Papertrail { focus: f }) = &mut state.step {
+        *f = focus;
+    }
+    outcome
+}
+
+/// Cycle the selection of a list zone (`forward` = next option, else previous). Field zones ignore
+/// this.
+fn cycle_zone(zone: PapertrailZone, state: &mut WizardState, forward: bool) {
+    let t = &mut state.draft.tracker;
+    match zone {
+        PapertrailZone::Mode => {
+            t.mode = match t.mode {
+                TrackerMode::AutoDetect => TrackerMode::Configure,
+                TrackerMode::Configure => TrackerMode::AutoDetect,
+            };
+        },
+        PapertrailZone::Provider => {
+            let cur = PROVIDERS.iter().position(|p| *p == t.provider).unwrap_or(0);
+            t.provider = PROVIDERS[step_index(cur, PROVIDERS.len(), forward)];
+        },
+        PapertrailZone::Auth => {
+            const AUTH: [TrackerAuthMode; 3] =
+                [TrackerAuthMode::Anonymous, TrackerAuthMode::Env, TrackerAuthMode::Command];
+            let cur = AUTH.iter().position(|a| *a == t.auth).unwrap_or(0);
+            t.auth = AUTH[step_index(cur, AUTH.len(), forward)];
+        },
+        _ => {},
+    }
+}
+
+/// Wrap-around index step for the option lists.
+fn step_index(cur: usize, len: usize, forward: bool) -> usize {
+    if forward { (cur + 1) % len } else { (cur + len - 1) % len }
+}
+
+fn field_mut(zone: PapertrailZone, state: &mut WizardState) -> Option<&mut String> {
+    let t = &mut state.draft.tracker;
+    match zone {
+        PapertrailZone::AuthValue => Some(&mut t.auth_value),
+        PapertrailZone::BaseUrl => Some(&mut t.base_url),
+        PapertrailZone::Project => Some(&mut t.project),
+        PapertrailZone::Tags => Some(&mut t.tags),
+        _ => None,
+    }
+}
+
+pub(super) fn validate_papertrail(state: &WizardState) -> CheckResult {
+    let t = &state.draft.tracker;
+    if t.mode == TrackerMode::AutoDetect {
+        return CheckResult::ok();
+    }
+    // A non-anonymous auth mode needs a value.
+    if t.auth != TrackerAuthMode::Anonymous && t.auth_value.trim().is_empty() {
+        return CheckResult::block("tracker auth needs a value (env var name or token command)");
+    }
+    // Mirror the config's own constraints so init never writes a file `Config::load` then rejects,
+    // aborting after the write. A base_url must be a valid credential-free http(s) origin.
+    let base_url = t.base_url.trim();
+    if !base_url.is_empty() && !valid_tracker_base_url(base_url) {
+        return CheckResult::block("tracker base url must be an https URL with no credentials");
+    }
+    // An explicit project must match the provider's identity format.
+    let project = t.project.trim();
+    if !project.is_empty() && !valid_tracker_project(t.provider, project) {
+        return CheckResult::block(match t.provider {
+            Tracker::Jira => "Jira project must be an uppercase key (e.g. PROJ)",
+            Tracker::Gitlab => "GitLab project must be a namespace path (e.g. group/repo)",
+            _ => "project must be owner/repo",
+        });
+    }
+    // The binding must actually resolve — otherwise there is no tracker (and distillation, which
+    // depends on one, would have no threads). A code host with no project needs the origin to
+    // derive one; Jira always needs an explicit key.
+    if !configured_tracker_resolves(t, state.detected_configured.as_ref()) {
+        return CheckResult::block(match t.provider {
+            Tracker::Jira => "Jira has no auto-detected remote — set a project key",
+            _ => "set a project (owner/repo) — it can't be derived from this remote",
+        });
+    }
+    CheckResult::ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::init::RepoScan;
+    use crate::init::wizard::draft::WizardDraft;
+    use crate::init::wizard::state::WizardState;
+
+    fn state() -> WizardState {
+        let dir = tempfile::tempdir().unwrap();
+        let d = WizardDraft::from_scan(&RepoScan::default(), ".".into(), dir.path().to_path_buf());
+        WizardState::new(d, RepoScan::default())
+    }
+
+    #[test]
+    fn auto_detect_never_blocks() {
+        assert!(validate_papertrail(&state()).message.is_none());
+    }
+
+    #[test]
+    fn configure_validation_blocks_bad_and_incomplete_bindings() {
+        let mut s = state(); // temp-dir root → nothing auto-detected
+        s.draft.tracker.mode = TrackerMode::Configure;
+        s.draft.tracker.provider = Tracker::Github;
+
+        // Non-anonymous auth needs a value.
+        s.draft.tracker.auth = TrackerAuthMode::Env;
+        assert!(validate_papertrail(&s).message.is_some(), "env auth needs a value");
+        s.draft.tracker.auth_value = "GH_TOKEN".into();
+
+        // A code host with no project and no detectable origin can't resolve → block.
+        assert!(validate_papertrail(&s).message.is_some(), "no project + no origin → block");
+
+        // A malformed project → block; a valid one → ok.
+        s.draft.tracker.project = "owner".into();
+        assert!(validate_papertrail(&s).message.is_some(), "owner is not owner/repo");
+        s.draft.tracker.project = "owner/repo".into();
+        assert!(validate_papertrail(&s).message.is_none());
+
+        // A malformed base_url → block; https → ok.
+        s.draft.tracker.base_url = "gitlab.example.com".into();
+        assert!(validate_papertrail(&s).message.is_some(), "base_url needs a scheme");
+        s.draft.tracker.base_url = "https://gitlab.example.com".into();
+        assert!(validate_papertrail(&s).message.is_none());
+
+        // Jira needs an uppercase key.
+        s.draft.tracker.provider = Tracker::Jira;
+        s.draft.tracker.project = "proj".into();
+        assert!(validate_papertrail(&s).message.is_some(), "jira key must be uppercase");
+        s.draft.tracker.project = "PROJ".into();
+        assert!(validate_papertrail(&s).message.is_none());
+    }
+
+    #[test]
+    fn a_configured_binding_needs_its_remote_to_detect_a_matching_provider() {
+        // A custom remote with no project must be verified via detection (state resolves it). In a
+        // temp-dir root the remote resolves to nothing → not set up → blocked.
+        let mut s = state();
+        s.draft.tracker.mode = TrackerMode::Configure;
+        s.draft.tracker.provider = Tracker::Github;
+        s.draft.tracker.remote = "upstream".into();
+        assert!(!tracker_is_set_up(&s));
+        assert!(validate_papertrail(&s).message.is_some());
+        // Once the remote resolves to a matching provider → set up.
+        s.detected_configured =
+            rag_rat_papertrail::detect_tracker_from_remote_url("https://github.com/o/r");
+        assert!(tracker_is_set_up(&s));
+        assert!(validate_papertrail(&s).message.is_none());
+    }
+
+    #[test]
+    fn autodetect_gates_on_origin_not_the_configured_remote() {
+        // A binding whose configured (non-origin) remote resolves, but origin does not: AutoDetect
+        // binds origin at runtime, so it must NOT be considered set up.
+        let mut s = state();
+        s.draft.tracker.mode = TrackerMode::AutoDetect;
+        s.detected_configured =
+            rag_rat_papertrail::detect_tracker_from_remote_url("https://github.com/o/r");
+        s.detected_origin = None;
+        assert!(!tracker_is_set_up(&s), "AutoDetect gates on origin detection only");
+    }
+
+    #[test]
+    fn a_self_hosted_binding_without_a_project_asks_for_one() {
+        // A self-hosted base_url must not derive the project from the configured remote — that
+        // remote may be a DIFFERENT (cloud) host, resolving the wrong repository. Require a project
+        // even when origin detection succeeds.
+        let mut s = state();
+        s.draft.tracker.mode = TrackerMode::Configure;
+        s.draft.tracker.provider = Tracker::Github;
+        s.draft.tracker.base_url = "https://github.example.com".into();
+        s.detected_configured =
+            rag_rat_papertrail::detect_tracker_from_remote_url("https://github.com/o/r");
+        assert!(!tracker_is_set_up(&s), "self-hosted base_url + cloud origin needs a project");
+        assert!(validate_papertrail(&s).message.is_some());
+        // With an explicit project it resolves.
+        s.draft.tracker.project = "owner/repo".into();
+        assert!(tracker_is_set_up(&s));
+        assert!(validate_papertrail(&s).message.is_none());
+    }
+}

--- a/crates/rag-rat-cli/src/init/wizard/steps/types.rs
+++ b/crates/rag-rat-cli/src/init/wizard/steps/types.rs
@@ -17,11 +17,20 @@ pub(crate) enum StepId {
     Indexing    = 0,
     Oracle      = 1,
     Embedding   = 2,
-    Integration = 3,
+    Papertrail  = 3,
+    Distill     = 4,
+    Integration = 5,
 }
 impl StepId {
-    pub const COUNT: usize = 4;
-    pub const ALL: [StepId; 4] = [Self::Indexing, Self::Oracle, Self::Embedding, Self::Integration];
+    pub const COUNT: usize = 6;
+    pub const ALL: [StepId; 6] = [
+        Self::Indexing,
+        Self::Oracle,
+        Self::Embedding,
+        Self::Papertrail,
+        Self::Distill,
+        Self::Integration,
+    ];
     pub fn index(self) -> usize {
         self as usize
     }
@@ -110,6 +119,12 @@ pub(crate) enum StepState {
         focus: EmbedFocus,
     },
     Oracle,
+    Papertrail {
+        focus: usize,
+    },
+    Distill {
+        focus: usize,
+    },
     Integration {
         focus: usize,
     },
@@ -119,4 +134,29 @@ pub(crate) enum StepState {
 pub(crate) enum IndexZone {
     Toggles,
     Tree,
+}
+
+/// Focusable zones on the Papertrail step, in render order. Which zones are actually present
+/// depends on the tracker mode — `papertrail_zones` returns only the visible ones, and the step's
+/// `focus: usize` indexes into that list (the same variable-length-focus shape the Embedding step
+/// uses).
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum PapertrailZone {
+    Mode,
+    Provider,
+    Auth,
+    AuthValue,
+    BaseUrl,
+    Project,
+    Tags,
+}
+
+/// Focusable zones on the Distill step, in render order — mode-gated like Papertrail, and empty
+/// entirely when no tracker is set up (the step is inactive then).
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum DistillZone {
+    Mode,
+    Endpoint,
+    Model,
+    ProvisionConfirm,
 }

--- a/crates/rag-rat-cli/src/init/wizard/steps/widgets.rs
+++ b/crates/rag-rat-cli/src/init/wizard/steps/widgets.rs
@@ -1,0 +1,50 @@
+//! Small shared step widgets — a single-select option list and a help/info paragraph — used by the
+//! Papertrail and Distill steps, whose mode-gated forms share the same look.
+
+use ratatui::Frame;
+use ratatui::layout::Rect;
+use ratatui::style::Style;
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{List, ListItem, Paragraph, Wrap};
+
+use super::super::theme;
+
+/// A bordered single-select list: `*` marks the selected row; when the zone is focused the selected
+/// row is highlighted and the border brightens. `options` carries a per-row base style so callers
+/// can accent the relevant/detected row (the Oracle tool-list convention).
+pub(super) fn option_list(
+    f: &mut Frame,
+    area: Rect,
+    title: &str,
+    options: &[(String, Style)],
+    selected: usize,
+    focused: bool,
+) {
+    let items: Vec<ListItem> = options
+        .iter()
+        .enumerate()
+        .map(|(i, (label, base))| {
+            let marker = if i == selected { "*" } else { " " };
+            let style = if i == selected && focused {
+                theme::selected()
+            } else if i == selected {
+                theme::accent()
+            } else {
+                *base
+            };
+            ListItem::new(Line::from(Span::styled(format!(" {marker} {label}"), style)))
+        })
+        .collect();
+    f.render_widget(List::new(items).block(theme::focused_block(title, focused)), area);
+}
+
+/// A wrapped help/info paragraph inside a titled block.
+pub(super) fn help_panel(f: &mut Frame, area: Rect, title: &str, lines: Vec<Line<'_>>) {
+    f.render_widget(
+        Paragraph::new(lines)
+            .style(theme::base())
+            .wrap(Wrap { trim: false })
+            .block(theme::block(title)),
+        area,
+    );
+}

--- a/crates/rag-rat-papertrail/src/lib.rs
+++ b/crates/rag-rat-papertrail/src/lib.rs
@@ -50,7 +50,10 @@ use serde::{Deserialize, Serialize};
 pub use store::{rebuild_fts, *};
 pub use sync::*;
 pub(crate) use trackers::resolve_trackers;
-pub use trackers::{ResolvedTracker, detect_tracker_from_remote_url, normalized_tags};
+pub use trackers::{
+    ResolvedTracker, auto_detect_tracker, detect_tracker_for_remote,
+    detect_tracker_from_remote_url, normalized_tags,
+};
 
 /// Resolved tracker context, injected into the sync/query paths instead of being resolved inside
 /// the library. Resolution runs ONLY at the real-usage boundary (`IndexDatabase::open_config`)

--- a/crates/rag-rat-papertrail/src/trackers.rs
+++ b/crates/rag-rat-papertrail/src/trackers.rs
@@ -131,9 +131,19 @@ fn resolve_binding(binding: &TrackerConfig, root: &Path) -> Option<ResolvedTrack
     })
 }
 
-/// Zero-config detection from the `origin` remote URL.
-fn auto_detect_tracker(root: &Path) -> Option<ResolvedTracker> {
-    detect_tracker_from_remote_url(&git_remote_url(root, "origin")?)
+/// Zero-config detection from the `origin` remote URL — the same detection `resolve_trackers`
+/// applies when no `[[tracker]]` binding is configured. Exposed so callers (the `rag-rat init`
+/// wizard) can show what auto-detection would bind and gate tracker-dependent features on it.
+pub fn auto_detect_tracker(root: &Path) -> Option<ResolvedTracker> {
+    detect_tracker_for_remote(root, "origin")
+}
+
+/// Detect the tracker a specific git remote resolves to — the same host/path derivation
+/// auto-detection applies to `origin`, for any named remote. Returns `None` when the remote is
+/// missing or its host is not a recognized code host. Exposed so the `rag-rat init` wizard can
+/// verify a configured non-`origin` remote instead of trusting it.
+pub fn detect_tracker_for_remote(root: &Path, remote: &str) -> Option<ResolvedTracker> {
+    detect_tracker_from_remote_url(&git_remote_url(root, remote)?)
 }
 
 /// Detect (provider, project, base_url) from one git remote URL: `github.com` → GitHub, a


### PR DESCRIPTION
The `rag-rat init` wizard gains two mode-gated steps, following the existing Embedding step's progressive-disclosure pattern (a mode selector reveals further fields) rather than splitting into more tabs.

Tab order: **Indexing → Oracle → Embedding → Papertrail → Distill → Integration** (Papertrail before Distill — Distill consumes the tracker's threads).

## Papertrail — bind an issue tracker (`[[tracker]]`)
- **auto-detect** (default) — writes nothing; `resolve_trackers` derives the binding from the git `origin` remote.
- **configure** — provider (github/gitlab/bitbucket/jira), auth (anonymous / env var name / token command), self-hosted `base_url`, `project`, `tags`, with a live detection line and contextual help.
- Field validation mirrors the config's own constraints (project format, https base_url, exactly-one auth), so init never writes a file `Config::load` then rejects.

## Distill — the opt-in model pass (`[llm.distill]`)
- **Off by default**, and gated on a resolvable tracker (it turns closed issues/PRs into decision records — nothing to distill without one). Inactive when no tracker resolves.
- **validated 30B GPU box** writes the shipped `[llm.distill.remote]` default and reuses the typed `provision` confirm (it provisions a paid Modal L40S); **connect** points at a running server.

## Reconfigure is non-destructive
- An existing custom ephemeral/connect distill block is **preserved verbatim** (no clobber, no re-confirmation); a deliberate mode switch emits a fresh default.
- Switching to auto-detect **clears the whole `[[tracker]]` section** (auto-detection only runs on an empty list); configure replaces it.
- The write path **forces distill off whenever no tracker resolves**, so an enabled-distill-without-tracker config is never written regardless of navigation.

## Supporting
- `rag-rat-base`: expose `valid_tracker_project` / `valid_tracker_base_url` (DRY the `TryFrom<RawTracker>` base_url check).
- `rag-rat-papertrail`: expose `auto_detect_tracker` / `detect_tracker_for_remote`.

Tested: unit coverage for emission (off/box/connect, `[[tracker]]` with auth/tags/remote), reconfigure round-trips and preservation, the tracker gate, validation, and write-time normalization. Full workspace suite green.

Fixes #882