### PR TITLE
ci: bounded nextest retries for environmental flakes under full-workspace parallelism

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,7 +1,24 @@
 # nextest profiles. The `ci` profile emits a JUnit report for Codecov Test Analytics.
 # Tests are parallel-safe (each uses its own temp DB; the library no longer shells out to `gh`),
 # so this runs at nextest's default per-core parallelism.
+
+[profile.default]
+# Bounded retries for environmental flakes under maximum parallelism (#867, the same failure class
+# as #672). Several individually-deterministic, process-isolated tests fail ~1/run ONLY under the
+# full-workspace `--test-threads 4` load and pass alone and on a clean re-run — the signature of
+# memory / open-fd / sqlite contention, not a logic bug (#672 reached the same conclusion). The
+# affected tests carry no shared mutable state and no wall-clock dependence to fix at the source:
+# the papertrail `schedule::tests::*` cases are pure functions of literal arguments (they can only
+# "fail" if a starved process is terminated by the `slow-timeout` below), and the oracle/core cases
+# run against a private in-memory sqlite DB, where a transient allocation failure surfaces as a
+# spurious result or panic rather than a reproducible assertion. A genuine regression still fails:
+# it reproduces on every attempt, so a bounded retry never masks it, while a one-off contention blip
+# no longer reds an unrelated PR's run. The short backoff lets the resource spike drain before the
+# retry.
+retries = { backoff = "exponential", count = 2, delay = "1s", max-delay = "5s", jitter = true }
+
 [profile.ci]
+# Inherits `retries` from `[profile.default]` above.
 # A wedged test should fail with its test name instead of leaving the whole CI job running.
 slow-timeout = { period = "60s", terminate-after = 2 }
 


### PR DESCRIPTION
Fixes #867

Adds bounded, backed-off `retries` to `[profile.default]` in `.config/nextest.toml` (inherited by `[profile.ci]`): `{ backoff = "exponential", count = 2, delay = "1s", max-delay = "5s", jitter = true }`. This is remedy 1 from #672's suggested-fixes list, applied class-wide.

**Why retries and not clock injection** — I went in intending to inject a clock per the #867 thread, and the source contradicted it:
- The papertrail `schedule::tests::minimum_interval_suppresses_*` cases are pure functions of literal arguments — `decide_schedule(20_000, …)` / `decide_schedule(910_000, …)` against a literal `last_attempt_ms`. There is no `Instant`/`SystemTime`/`now()` anywhere in `schedule.rs`; nothing to inject. Under load they can only fail by starvation/termination, not timing skew.
- `oracle tests::surfacing::current_verdict_is_surfaced_for_edge` and `validate_prefers_active_root_over_persisted_meta` run against a private in-memory sqlite DB with a unique temp root (pid+atomic counter) and an explicitly-passed `active_root` — no process-global state to serialize.

So the class is what #672 concluded: resource contention under maximum parallelism, not a logic bug. A genuine regression reproduces on every attempt, so a bounded retry never masks it; a one-off contention blip stops redding an unrelated PR's run.

**A/B repro** (the named tests wouldn't reproduce on this 11-core box — more headroom than CI runners; the *class* reproduced on the timing-bounded `coherence_split_pathological_dense_minus_matching_returns_fast` under two oversubscribed full-workspace runs at once):
- without retries (`--retries 0 --test-threads 16`): 2 hard failures in 7 iterations (rc=100, would red CI)
- with this config, same contention: same flake occurred but the run stayed green — `3668 tests run: 3668 passed (1 flaky), 1 skipped` (`FLAKY 2/3`)

One honest caveat: the coverage job uses `cargo llvm-cov` (libtest, not nextest), so retries don't cover that runner — all the #867/#672 evidence is from nextest runs, but worth knowing the boundary.

If you'd still like per-test hardening on top (e.g. a nextest test-group concurrency cap for the heavy suites), happy to add it — kept this diff to the 17-line config change so the shared fix lands cleanly.

Gates: `cargo +nightly fmt --all --check` ✓, `clippy --workspace --all-targets --no-default-features --locked -- -D warnings` ✓, `cargo nextest run --workspace --no-default-features --locked --profile ci` → 3668 passed (1 flaky), 1 skipped; the 4 named tests pass in isolation (also proves the config parses).

Generated by Claude Fable 5 (brief, review), Claude Opus 4.8 (implementation)