### PR TITLE
ci: fire release-tier workflows on tag push (GITHUB_TOKEN releases suppress release events)

### DIFF
--- a/.github/workflows/bench-release.yml
+++ b/.github/workflows/bench-release.yml
@@ -8,8 +8,16 @@ name: bench-release
 # See docs/bencher.md and tools/bench-kernel.sh.
 
 on:
-  release:
-    types: [published]
+  # Ride the release tag push, NOT `release: published`. Since v0.16.0 the GitHub release is created by
+  # cargo-dist with GITHUB_TOKEN, and GitHub suppresses downstream workflow runs for GITHUB_TOKEN-created
+  # release events (recursive-workflow prevention), so `release: published` fired into a void and this
+  # bench silently skipped v0.16.0–v0.19.0 (#712). release-plz pushes the vX.Y.Z tag with a PAT, which
+  # DOES fire tag-push workflows — the same pattern release-android.yml / release-npm.yml already use.
+  # This job only needs the source at the tag (it checks out and indexes the kernel; it downloads no
+  # release assets), so it needs no wait-for-release poll.
+  push:
+    tags:
+      - "**[0-9]+.[0-9]+.[0-9]+*"
   workflow_dispatch:
     inputs:
       kernel_subdirs:

--- a/.github/workflows/ci-cross-platform.yml
+++ b/.github/workflows/ci-cross-platform.yml
@@ -2,10 +2,12 @@ name: CI (cross-platform)
 
 # macOS + Windows coverage for the test/clippy/build-full legs. These platforms are NOT exercised on
 # every PR/push (that would multiply CI minutes for the rare platform regression); the per-PR + main
-# matrix in ci.yml stays Linux-only. Instead this runs only when a release is published — the same
-# `release: published` trigger oracle.yml and bench-release.yml already key off (release-plz cuts the
-# GitHub release, authored with RELEASE_PLZ_TOKEN so downstream workflows fire, once the Release PR's
-# version commit lands on main). workflow_dispatch is kept so the matrix can be validated manually.
+# matrix in ci.yml stays Linux-only. Instead this runs on the release tag push — the same `push: tags`
+# trigger oracle.yml and bench-release.yml key off, matching release-android.yml / release-npm.yml.
+# release-plz pushes the vX.Y.Z tag with a PAT, which fires tag-push workflows; cargo-dist then cuts the
+# GitHub release with GITHUB_TOKEN, whose `release: published` event GitHub suppresses for downstream
+# workflows (recursive-workflow prevention, #712) — so keying off the tag push is what actually fires.
+# workflow_dispatch is kept so the matrix can be validated manually.
 #
 # Jobs mirror ci.yml's Linux legs exactly (toolchain, rust-cache, feature flags) so a real mac/win
 # break surfaces the same way it would on Linux:
@@ -17,8 +19,9 @@ name: CI (cross-platform)
 # SQLite). With that landed, windows-latest links the vendored SQLite amalgamation via cc.
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - "**[0-9]+.[0-9]+.[0-9]+*"
   workflow_dispatch:
 
 # Least privilege: CI only reads the repo.

--- a/.github/workflows/oracle.yml
+++ b/.github/workflows/oracle.yml
@@ -43,6 +43,14 @@ on:
       - '.github/workflows/oracle.yml'
   push:
     branches: [main]
+    # A release tag push runs the heavy tier (see the tier select below), replacing the dead
+    # `release: published` trigger: cargo-dist creates the GitHub release with GITHUB_TOKEN, whose event
+    # GitHub suppresses for downstream workflows, but release-plz's PAT-pushed vX.Y.Z tag fires this —
+    # the release-android.yml / release-npm.yml pattern (#712). GitHub does NOT evaluate path filters
+    # for pushes of tags, so the `paths:` list below scopes only main-branch pushes; a release tag
+    # always fires regardless of which files the release commit touched.
+    tags:
+      - "**[0-9]+.[0-9]+.[0-9]+*"
     paths:
       # oracle runs the `rag-rat` binary (`index --full` + `oracle report`, see tools/oracle-run.sh)
       # over external corpora, so it gates core's parser/resolution AND the cli entry points that
@@ -67,8 +75,6 @@ on:
       - 'tools/oracle-report-bmf.py'
       - 'tools/oracle-report-md.py'
       - '.github/workflows/oracle.yml'
-  release:
-    types: [published]
   workflow_dispatch:
     inputs:
       tier:
@@ -109,7 +115,12 @@ jobs:
         run: |
           set -euo pipefail
           case "${{ github.event_name }}" in
-            release)           tier=heavy ;;
+            # A release tag push (release-plz pushes vX.Y.Z with a PAT) selects the heavy tier — this
+            # replaces the old `release` event_name, since the GITHUB_TOKEN-created release's
+            # `release: published` event is suppressed downstream (#712). A branch (main) push and a PR
+            # stay on the small tier.
+            push)
+              if [ "${{ github.ref_type }}" = tag ]; then tier=heavy; else tier=small; fi ;;
             workflow_dispatch) tier="${{ github.event.inputs.tier }}" ;;
             *)                 tier=small ;;
           esac


### PR DESCRIPTION
Fixes #712

cargo-dist publishes releases with GITHUB_TOKEN, and GitHub suppresses `release: published` events from GITHUB_TOKEN-created releases (recursive-workflow prevention) — so `bench-release.yml`, `ci-cross-platform.yml`, and `oracle.yml` never fired on a release. This applies the same tag-push pattern the repo already uses in `release-android.yml` / `release-npm.yml`, honoring the issue's caveats:

- All three: `release: {types:[published]}` **removed** (not added-alongside — no double runs), replaced with `push: {tags: ["**[0-9]+.[0-9]+.[0-9]+*"]}` matching stable and prerelease tags — equivalent to the old behavior, since `release: published` fired for prereleases too.
- `oracle.yml`: the tag trigger joins the existing `push` block; the tier selector now routes `github.ref_type == 'tag'` → heavy, main-branch push → small. Load-bearing semantic verified against GitHub docs ("Path filters are not evaluated for pushes of tags"), so the shared `paths:` list still scopes only branch pushes and a release tag always fires the heavy tier. The report job's `refs/heads/main` baseline guard correctly excludes tag refs.
- `github.ref_name` substitution turned out unnecessary — none of the three consume the tag value (checkout-at-tag only), verified per step. The asset-download wait/poll caveat also doesn't apply: no job downloads release assets (unlike release-npm, which polls).
- Prerelease guard deliberately omitted to preserve strict equivalence — but if you'd rather not spend `bigmem` minutes on prerelease tags, `if: ${{ !contains(github.ref_name, '-') }}` on the kernel/heavy jobs is a one-liner; say the word and I'll add it.

Verification (YAML-only change, honestly bounded): actionlint v1.7.7 — zero new findings vs main (the one pre-existing `runner-label` warning on the untouched `bigmem` lines remains); PyYAML structural parse clean; per-file old→new trigger mapping above. One stale line ref in the issue (`oracle.yml:53`) — the `release:` block actually sits at 70-71 on current main; fixed from the file, not the citation.

Generated by Claude Fable 5 (brief, review), Claude Opus 4.8 (implementation)