### PR TITLE
feat(memory): sync-origin provenance + edge tombstones, the projection foundation (#691)

### DIFF
--- a/crates/rag-rat-cli/tests/consolidate.rs
+++ b/crates/rag-rat-cli/tests/consolidate.rs
@@ -663,7 +663,7 @@ fn consolidate_rebuilds_stale_content_projection_before_reconcile() {
             |row| row.get(0),
         )
         .unwrap();
-    assert_eq!(stamp, "2", "consolidate upgraded the store-global projector stamp");
+    assert_eq!(stamp, "3", "consolidate upgraded the store-global projector stamp");
 
     let _ = fs::remove_dir_all(&root);
     let _ = fs::remove_dir_all(&data_dir);

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
@@ -3704,11 +3704,10 @@ fn migration_083_relabels_logical_groups_by_evidence() {
     assert_eq!(reason(300), "single");
 }
 
-/// V084 links each chunk to the symbol it was cut from, and is the schema tip.
+/// V084 links each chunk to the symbol it was cut from. (The absolute schema-tip pin moved to
+/// `migration_085_*` — V085 is the tip now; this test keeps only a per-migration check.)
 #[test]
-fn migration_084_is_the_tip_and_links_chunks_to_symbols() {
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 84, "move this pin with the next schema migration");
-
+fn migration_084_links_chunks_to_symbols() {
     // The chunks table predates the column (it lives in the baseline). Build bare chunks + symbols
     // tables WITHOUT symbol_id, seed pre-migration rows, apply V084 in ISOLATION, and confirm the
     // column appears AND the backfill links each chunk — asserting absence against this migration's
@@ -3847,4 +3846,84 @@ fn migration_084_is_the_tip_and_links_chunks_to_symbols() {
         )
         .unwrap();
     assert_eq!(recorded, 1, "the forward migration records V084");
+}
+
+/// V085 adds sync provenance (`origin`) to the read tables + edge tombstones (`present`) to the
+/// content-edge projection, and is the schema tip.
+#[test]
+fn migration_085_is_the_tip_and_adds_origin_and_edge_present() {
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 85, "move this pin with the next schema migration");
+
+    // Bare pre-V085 tables (no origin / present), each with a pre-existing row, so the migration is
+    // asserted against its OWN precondition — not the full ladder's end state.
+    let legacy = rusqlite::Connection::open_in_memory().unwrap();
+    legacy
+        .execute_batch(
+            "CREATE TABLE repo_memories(id TEXT PRIMARY KEY, repo_id TEXT);
+             CREATE TABLE repo_node_edges(edge_key TEXT PRIMARY KEY, repo_id TEXT);
+             CREATE TABLE content_projected_edges(
+                 stream_id BLOB NOT NULL, edge_key TEXT NOT NULL,
+                 spec_json TEXT NOT NULL, resolved_json TEXT,
+                 PRIMARY KEY(stream_id, edge_key)) STRICT;
+             INSERT INTO repo_memories(id, repo_id) VALUES ('mem_1', 'r');
+             INSERT INTO repo_node_edges(edge_key, repo_id) VALUES ('e_1', 'r');
+             INSERT INTO content_projected_edges(stream_id, edge_key, spec_json)
+                 VALUES (x'00', 'e_1', '{}');",
+        )
+        .unwrap();
+    let added = [
+        ("repo_memories", "origin"),
+        ("repo_node_edges", "origin"),
+        ("content_projected_edges", "present"),
+    ];
+    for (t, c) in added {
+        assert!(!schema::column_exists(&legacy, t, c).unwrap(), "pre-V085 {t} has no {c}");
+    }
+
+    schema::apply_sync_origin_and_edge_tombstone(&legacy).unwrap();
+
+    for (t, c) in added {
+        assert!(schema::column_exists(&legacy, t, c).unwrap(), "V085 adds {t}.{c}");
+    }
+    // Pre-existing rows backfill to the correct defaults.
+    let mem_origin: String = legacy
+        .query_row("SELECT origin FROM repo_memories WHERE id = 'mem_1'", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(mem_origin, "local", "existing memories default to local origin");
+    let edge_origin: String = legacy
+        .query_row("SELECT origin FROM repo_node_edges WHERE edge_key = 'e_1'", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(edge_origin, "local");
+    let present: i64 = legacy
+        .query_row("SELECT present FROM content_projected_edges WHERE edge_key = 'e_1'", [], |r| {
+            r.get(0)
+        })
+        .unwrap();
+    assert_eq!(present, 1, "existing projected edges default to present");
+    // The CHECK rejects an out-of-domain origin.
+    assert!(
+        legacy
+            .execute(
+                "INSERT INTO repo_memories(id, repo_id, origin) VALUES ('mem_2','r','bogus')",
+                []
+            )
+            .is_err(),
+        "the origin CHECK rejects a value that is neither local nor synced",
+    );
+
+    // The full ladder ends with the columns present and records V085.
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn, &crate::index::migration_hooks()).unwrap();
+    assert_eq!(schema::status(&conn).unwrap().current_version, schema::LATEST_SCHEMA_VERSION);
+    for (t, c) in added {
+        assert!(schema::column_exists(&conn, t, c).unwrap(), "the full ladder ends with {t}.{c}");
+    }
+    let recorded: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM schema_version WHERE id = '085_sync_origin_and_edge_tombstone'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(recorded, 1, "the forward migration records V085");
 }

--- a/crates/rag-rat-core/src/memory_write/authoring.rs
+++ b/crates/rag-rat-core/src/memory_write/authoring.rs
@@ -930,9 +930,15 @@ fn read_unauthored_memory_rows(
          memory completeness"
     );
     let mut stmt = conn.prepare(
+        // `origin = 'local'` is load-bearing (#691 A-pre): a SYNCED row (projected from a
+        // sibling's /3) must never be re-authored as local /3 — even if its acceptance is
+        // later revoked and its projection row vanishes — or the local device would forge
+        // authorship of, and re-legitimize, content the account revoked. Only
+        // locally-authored rows are the reconcile's to complete.
         "SELECT m.id, m.kind, m.title, m.body, m.confidence, m.status, m.source, m.payload_json
          FROM repo_memories m
          WHERE m.repo_id = ?1
+           AND m.origin = 'local'
            AND NOT EXISTS (
                  SELECT 1 FROM content_projected_nodes p
                  WHERE p.stream_id = ?2 AND p.node_id = m.id)
@@ -1294,6 +1300,23 @@ mod tests {
         assert_eq!(missing.iter().map(|r| r.memory_id.as_str()).collect::<Vec<_>>(), ["mem_ghost"]);
     }
 
+    /// A SYNCED memory is never the reconcile's to author — even absent from the projection (its
+    /// acceptance was revoked) — or the local device would forge authorship of, and re-legitimize,
+    /// content the account revoked (#691 A-pre, Trace 2). A local ghost in the same position WOULD
+    /// be authored.
+    #[test]
+    fn a_synced_memory_is_never_re_authored() {
+        let conn = scoped_conn();
+        insert_memory(&conn, "mem_synced", "active", 100);
+        conn.execute("UPDATE repo_memories SET origin = 'synced' WHERE id = 'mem_synced'", [])
+            .unwrap();
+        let stream = StreamId::from_bytes([0x22; 32]);
+        assert!(
+            read_unauthored_memory_rows(&conn, REPO, stream).unwrap().is_empty(),
+            "a synced memory is not re-authored even when absent from the projection",
+        );
+    }
+
     // --- the per-node/edge self-healing reconcile (#541) ---
 
     #[test]
@@ -1600,8 +1623,14 @@ mod tests {
 
     // --- live write-path wiring (#532) ---
 
+    /// Count LIVE projected edges (`present = 1`). A removed edge is retained as a tombstone
+    /// (`present = 0`, #691 A-pre) rather than deleted, so "how many edges are present" filters
+    /// them.
     fn projected_edge_count(conn: &Connection) -> i64 {
-        conn.query_row("SELECT COUNT(*) FROM content_projected_edges", [], |r| r.get(0)).unwrap()
+        conn.query_row("SELECT COUNT(*) FROM content_projected_edges WHERE present = 1", [], |r| {
+            r.get(0)
+        })
+        .unwrap()
     }
 
     /// Create an unanchored `Concept` (needs no code binding) through the LIVE `create_memory`.

--- a/crates/rag-rat-core/src/memory_write/edges.rs
+++ b/crates/rag-rat-core/src/memory_write/edges.rs
@@ -181,9 +181,15 @@ pub(crate) fn unauthored_edges(
         "owner stream has a pending content refold; settle pending content refolds before reading \
          edge completeness"
     );
+    // `origin = 'local'` gates out SYNCED edges (#691 A-pre): only locally-authored edges are the
+    // reconcile's to complete. The `NOT EXISTS` also now skips a TOMBSTONED edge — a removed edge
+    // is retained in `content_projected_edges` (present=0), so it exists here and is never
+    // re-authored; dropping the tombstone let a foreign `EdgeRemove` be re-added at a fresh
+    // Lamport (a growth loop).
     let mut stmt = conn.prepare(&format!(
         "{EDGE_SELECT} e
          WHERE e.repo_id = ?1
+           AND e.origin = 'local'
            AND NOT EXISTS (
                  SELECT 1 FROM content_projected_edges p
                  WHERE p.stream_id = ?2 AND p.edge_key = e.edge_key)
@@ -304,6 +310,48 @@ mod tests {
             missing[0].target_repo_id, REPO,
             "reresolve_on_read must repair the stale stored target_repo_id to the CURRENT owner \
              before the reconcile signs it"
+        );
+    }
+
+    /// A TOMBSTONED edge (retained in the projection with `present = 0`) is NOT returned as
+    /// unauthored — so a foreign `EdgeRemove` is honored, not re-authored at a fresh Lamport (the
+    /// edge-resurrection growth loop, #691 A-pre). Before tombstones were retained, the removed
+    /// edge was absent from the projection and came back here.
+    #[test]
+    fn a_tombstoned_edge_is_not_re_authored() {
+        let conn = scoped_conn();
+        insert_memory(&conn, "mem_a", "active", 100);
+        insert_memory(&conn, "mem_b", "active", 200);
+        let key = insert_raw_node_edge(&conn, "mem_a", "relates_to", "mem_b");
+        let stream = StreamId::from_bytes([0x11; 32]);
+        conn.execute(
+            "INSERT INTO content_projected_edges(
+                 stream_id, edge_key, spec_json, resolved_json, present)
+             VALUES (?1, ?2, '{}', NULL, 0)",
+            params![stream.to_bytes().as_slice(), key],
+        )
+        .unwrap();
+        assert!(
+            unauthored_edges(&conn, REPO, stream).unwrap().is_empty(),
+            "a tombstoned edge is honored, never re-authored",
+        );
+    }
+
+    /// A SYNCED edge is never the reconcile's to author — even if its projection row is absent (its
+    /// acceptance was revoked) — or the local device would forge authorship of removed content
+    /// (#691 A-pre, Trace 2). A local edge in the same position WOULD be re-authored.
+    #[test]
+    fn a_synced_edge_is_never_re_authored() {
+        let conn = scoped_conn();
+        insert_memory(&conn, "mem_a", "active", 100);
+        insert_memory(&conn, "mem_b", "active", 200);
+        let key = insert_raw_node_edge(&conn, "mem_a", "relates_to", "mem_b");
+        conn.execute("UPDATE repo_node_edges SET origin = 'synced' WHERE edge_key = ?1", [&key])
+            .unwrap();
+        let stream = StreamId::from_bytes([0x22; 32]);
+        assert!(
+            unauthored_edges(&conn, REPO, stream).unwrap().is_empty(),
+            "a synced edge is not re-authored even when absent from the projection",
         );
     }
 }

--- a/crates/rag-rat-db/src/schema/migrations.rs
+++ b/crates/rag-rat-db/src/schema/migrations.rs
@@ -1370,6 +1370,7 @@ pub(crate) fn known_version(migrations: &[AppliedMigration]) -> u32 {
             MIGRATION_082_ID => Some(82),
             MIGRATION_083_ID => Some(83),
             MIGRATION_084_ID => Some(84),
+            MIGRATION_085_ID => Some(85),
             _ => None,
         })
         .max()
@@ -1463,6 +1464,7 @@ pub(crate) fn known_migration(id: &str) -> bool {
             | MIGRATION_082_ID
             | MIGRATION_083_ID
             | MIGRATION_084_ID
+            | MIGRATION_085_ID
             | DIRTY_MIGRATION_ID
     )
 }
@@ -1553,6 +1555,7 @@ pub(crate) fn migration_checksum_mismatch(migration: &AppliedMigration) -> bool 
         MIGRATION_082_ID => migration.checksum != MIGRATION_082_CHECKSUM,
         MIGRATION_083_ID => migration.checksum != MIGRATION_083_CHECKSUM,
         MIGRATION_084_ID => migration.checksum != MIGRATION_084_CHECKSUM,
+        MIGRATION_085_ID => migration.checksum != MIGRATION_085_CHECKSUM,
         _ => false,
     }
 }
@@ -5873,6 +5876,42 @@ pub fn apply_distill_evidence_source_part(conn: &Connection) -> rusqlite::Result
         "ALTER TABLE papertrail_distill_evidence
              ADD COLUMN source_part TEXT CHECK(source_part IN ('title', 'body', 'comment'));",
     )
+}
+
+/// V085 (#691 A-pre): memory-sync provenance + edge tombstones — the write-path foundation for
+/// projecting synced content into the read tables without corrupting the local reconcile.
+///
+/// - `origin` on `repo_memories` / `repo_node_edges` distinguishes a locally-authored row from one
+///   projected from a synced sibling's `/3` content. It is LOAD-BEARING on the WRITE path: the
+///   memory reconcile authors every read-table row MISSING from the accepted-`/3` projection, so a
+///   synced row whose acceptance is later revoked must NOT be re-authored as local `/3` (that
+///   forges local authorship and re-legitimizes revoked content). The reconcile gates on `origin =
+///   'local'`. Every existing row is locally authored, so the `'local'` default is a correct
+///   backfill.
+/// - `present` on `content_projected_edges` retains edge TOMBSTONES (`present = 0`) rather than
+///   dropping removed edges. Without it a foreign `EdgeRemove` leaves the local `repo_node_edges`
+///   row a ghost, the reconcile re-authors it at a fresh Lamport, and the remove loses LWW forever
+///   — a cross-device op-log growth loop. Live edges default `present = 1`; the projector-version
+///   bump rebuilds the projection to write tombstones going forward.
+///
+/// Additive columns with correct defaults; atomic under one immediate txn; idempotent via
+/// `add_column_if_missing`.
+pub fn apply_sync_origin_and_edge_tombstone(conn: &Connection) -> rusqlite::Result<()> {
+    let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
+    add_column_if_missing(
+        &tx,
+        "repo_memories",
+        "origin",
+        "TEXT NOT NULL DEFAULT 'local' CHECK (origin IN ('local', 'synced'))",
+    )?;
+    add_column_if_missing(
+        &tx,
+        "repo_node_edges",
+        "origin",
+        "TEXT NOT NULL DEFAULT 'local' CHECK (origin IN ('local', 'synced'))",
+    )?;
+    add_column_if_missing(&tx, "content_projected_edges", "present", "INTEGER NOT NULL DEFAULT 1")?;
+    tx.commit()
 }
 
 #[cfg(test)]

--- a/crates/rag-rat-db/src/schema/mod.rs
+++ b/crates/rag-rat-db/src/schema/mod.rs
@@ -24,6 +24,7 @@ pub use migrations::{
     apply_papertrail_distill_substrate, apply_papertrail_mirror_resume_state,
     apply_papertrail_provider_neutral_schema, apply_repo_id_core_scoping,
     apply_repo_id_periphery_scoping, apply_repos_registry, apply_scip_moniker_anchors,
+    apply_sync_origin_and_edge_tombstone,
 };
 pub use migrations::{column_exists, rebuild_repo_memory_fts_with_repo_id, table_exists};
 pub use purge::{RepoRowCounts, count_repo_rows, purge_repo_rows, repo_scoped_table_names};
@@ -46,7 +47,7 @@ use serde::Serialize;
 
 use crate::hooks::MigrationHooks;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 84;
+pub const LATEST_SCHEMA_VERSION: u32 = 85;
 
 /// Every oracle-DERIVED persisted table — the outputs an `oracle run` writes that must OUTLIVE a
 /// reindex.
@@ -622,6 +623,16 @@ const MIGRATION_084_DESCRIPTION: &str =
      chunk→symbol resolution, which could not disambiguate same-name symbols that nest or share a \
      physical line. Nullable; backfills on the next reindex of each file (derived data, no SQL \
      backfill)";
+
+const MIGRATION_085_ID: &str = "085_sync_origin_and_edge_tombstone";
+const MIGRATION_085_CHECKSUM: &str = "sha256:rag-rat-sync-origin-and-edge-tombstone-v85";
+const MIGRATION_085_DESCRIPTION: &str =
+    "Add repo_memories.origin and repo_node_edges.origin ('local'|'synced') and \
+     content_projected_edges.present. The origin column gates the memory reconcile so a synced \
+     row is never re-authored as local /3 content (forging local authorship / re-legitimizing \
+     revoked content); the present column retains edge tombstones so a foreign EdgeRemove is \
+     honored instead of resurrected in an op-log growth loop. Additive; existing rows default to \
+     local/present";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -1317,6 +1328,12 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         checksum: MIGRATION_084_CHECKSUM,
         description: MIGRATION_084_DESCRIPTION,
         apply: MigrationFn::Plain(apply_chunk_symbol_id),
+    },
+    Migration {
+        id: MIGRATION_085_ID,
+        checksum: MIGRATION_085_CHECKSUM,
+        description: MIGRATION_085_DESCRIPTION,
+        apply: MigrationFn::Plain(apply_sync_origin_and_edge_tombstone),
     },
 ];
 

--- a/crates/rag-rat-oplog/src/account/content/author.rs
+++ b/crates/rag-rat-oplog/src/account/content/author.rs
@@ -1276,7 +1276,7 @@ mod tests {
             )
             .unwrap();
         assert_eq!(ghost, 0, "the wholesale clear dropped the row with no accepted content");
-        assert_eq!(stored_stamp(&conn).as_deref(), Some("2"), "the store-global stamp upgraded");
+        assert_eq!(stored_stamp(&conn).as_deref(), Some("3"), "the store-global stamp upgraded");
 
         assert!(
             !content_projection::rebuild_all_content_projections_if_stale(&conn).unwrap(),
@@ -1319,9 +1319,9 @@ mod tests {
         // The upgrade re-fold makes the store current; from then on per-stream reprojects
         // maintain the stamp.
         assert!(content_projection::rebuild_all_content_projections_if_stale(&conn).unwrap());
-        assert_eq!(stored_stamp(&conn).as_deref(), Some("2"));
+        assert_eq!(stored_stamp(&conn).as_deref(), Some("3"));
         author_committed(&conn, stream, &[node_create("n2", "second")]);
-        assert_eq!(stored_stamp(&conn).as_deref(), Some("2"), "a current store stays current");
+        assert_eq!(stored_stamp(&conn).as_deref(), Some("3"), "a current store stays current");
         assert_eq!(projected_node_count(&conn, stream), 2);
     }
 

--- a/crates/rag-rat-oplog/src/content_projection.rs
+++ b/crates/rag-rat-oplog/src/content_projection.rs
@@ -41,7 +41,11 @@ use super::stream::StreamId;
 /// the open/migrate seam and re-folds every stream before stamping — never trusted incrementally;
 /// a NEWER stamp blocks this binary from reprojecting at all (see
 /// [`assert_content_projector_not_newer`]).
-const CONTENT_PROJECTOR_VERSION: i64 = 2;
+// v3 (#691 A-pre): `content_projected_edges` now retains edge TOMBSTONES (present=0) instead of
+// dropping removed edges. The bump forces a rebuild so existing stores materialize tombstones for
+// already-removed edges (else a foreign EdgeRemove folded before the upgrade would never
+// tombstone).
+const CONTENT_PROJECTOR_VERSION: i64 = 3;
 
 /// The `oplog_meta` key holding the `/3` projector version the content projection was last folded
 /// by. DISTINCT from the `/1` `projector_version` (they evolve independently and share one meta
@@ -224,20 +228,34 @@ fn write_projection(
             ],
         )?;
     }
-    for (edge_key, edge) in &state.edges {
-        let spec_json = serde_json::to_string(&EdgeSpecRow::from(&edge.spec))
-            .context("serialize projected /3 edge spec")?;
-        let resolved_json = edge
-            .resolved
-            .as_ref()
-            .map(|resolved| serde_json::to_string(&ResolvedAnchorRow::from(resolved)))
-            .transpose()
-            .context("serialize projected /3 edge resolved anchor")?;
-        tx.execute(
-            "INSERT INTO content_projected_edges(stream_id, edge_key, spec_json, resolved_json)
-             VALUES (?1, ?2, ?3, ?4)",
-            params![stream_bytes.as_slice(), edge_key.as_str(), spec_json, resolved_json],
-        )?;
+    // Live edges (present=1) AND tombstones (present=0). The tombstones are RETAINED, not dropped,
+    // so a projection consumer honors a foreign `EdgeRemove`: the memory reconcile treats a
+    // tombstoned edge as authored (never re-adds it) and the projection deletes the read-table
+    // row. Dropping them lets a foreign remove be re-authored at a fresh Lamport — a
+    // cross-device growth loop (#691 A-pre).
+    for (present, edges) in [(1, &state.edges), (0, &state.removed_edges)] {
+        for (edge_key, edge) in edges {
+            let spec_json = serde_json::to_string(&EdgeSpecRow::from(&edge.spec))
+                .context("serialize projected /3 edge spec")?;
+            let resolved_json = edge
+                .resolved
+                .as_ref()
+                .map(|resolved| serde_json::to_string(&ResolvedAnchorRow::from(resolved)))
+                .transpose()
+                .context("serialize projected /3 edge resolved anchor")?;
+            tx.execute(
+                "INSERT INTO content_projected_edges(stream_id, edge_key, spec_json, \
+                 resolved_json,
+                 present) VALUES (?1, ?2, ?3, ?4, ?5)",
+                params![
+                    stream_bytes.as_slice(),
+                    edge_key.as_str(),
+                    spec_json,
+                    resolved_json,
+                    present
+                ],
+            )?;
+        }
     }
     Ok(())
 }

--- a/crates/rag-rat-oplog/src/project.rs
+++ b/crates/rag-rat-oplog/src/project.rs
@@ -30,6 +30,14 @@ use super::op::{
 pub struct ProjectedState {
     pub nodes: BTreeMap<NodeId, ProjectedNode>,
     pub edges: BTreeMap<EdgeKey, ProjectedEdge>,
+    /// Edges that were ADDED and then REMOVED — the tombstones. Retained (not dropped like the
+    /// fold used to) so a projection consumer honors the remove instead of re-authoring the
+    /// edge as a ghost: the reconcile treats a tombstoned edge as authored (never re-adds it),
+    /// and the memory projection deletes the corresponding read-table row. An edge that was
+    /// never added (a remove-only or rebind-only key) is absent from BOTH maps. The
+    /// spec/resolved carried here are the last-known values, kept only so the projection row's
+    /// non-null columns can be written.
+    pub removed_edges: BTreeMap<EdgeKey, ProjectedEdge>,
 }
 
 /// A projected node: its winning content and status. Presence in `ProjectedState::nodes` IS its
@@ -126,6 +134,23 @@ pub fn project(entries: &[Entry]) -> ProjectedState {
         }
     }
 
+    // Split edges into live and tombstoned. `spec` is set only by an `EdgeAdd`, so `spec.is_some()`
+    // means the edge was added at some point: `(present, added)` → live, `(removed, added)` →
+    // tombstone, `(_, never-added)` → no row at all.
+    let mut live_edges = BTreeMap::new();
+    let mut removed_edges = BTreeMap::new();
+    for (key, acc) in edges {
+        match acc.spec {
+            Some(spec) if acc.present => {
+                live_edges.insert(key, ProjectedEdge { spec, resolved: acc.resolved });
+            },
+            Some(spec) => {
+                removed_edges.insert(key, ProjectedEdge { spec, resolved: acc.resolved });
+            },
+            None => {},
+        }
+    }
+
     ProjectedState {
         nodes: nodes
             .into_iter()
@@ -135,14 +160,8 @@ pub fn project(entries: &[Entry]) -> ProjectedState {
                 Some((id, ProjectedNode { content, status: acc.status.unwrap_or_default() }))
             })
             .collect(),
-        edges: edges
-            .into_iter()
-            .filter_map(|(key, acc)| {
-                // Present iff the last presence op was an add; the resolved anchor rides along.
-                let spec = acc.present.then_some(acc.spec).flatten()?;
-                Some((key, ProjectedEdge { spec, resolved: acc.resolved }))
-            })
-            .collect(),
+        edges: live_edges,
+        removed_edges,
     }
 }
 
@@ -285,6 +304,31 @@ mod tests {
             at(3, 1, MemoryOp::EdgeAdd { edge }),
         ]);
         assert!(state.edges.contains_key(&key), "the newest op is the add → edge present");
+        assert!(!state.removed_edges.contains_key(&key), "re-added → not a tombstone");
+    }
+
+    #[test]
+    fn an_added_then_removed_edge_is_a_retained_tombstone() {
+        // The tombstone is retained in `removed_edges` (not dropped), so a projection consumer can
+        // honor the remove instead of re-authoring it as a ghost (#691).
+        let edge = spec("mem_a", "mem_b");
+        let key = edge.edge_key();
+        let state = project(&[
+            at(1, 1, MemoryOp::EdgeAdd { edge }),
+            at(2, 1, MemoryOp::EdgeRemove { edge_key: key.clone() }),
+        ]);
+        assert!(!state.edges.contains_key(&key), "removed → absent from live edges");
+        assert!(state.removed_edges.contains_key(&key), "removed → retained as a tombstone");
+    }
+
+    #[test]
+    fn a_remove_only_or_rebind_only_edge_is_not_a_tombstone() {
+        // An edge that was never ADDED has no tombstone — nothing to honor.
+        let edge = spec("mem_a", "mem_b");
+        let key = edge.edge_key();
+        let state = project(&[at(1, 1, MemoryOp::EdgeRemove { edge_key: key.clone() })]);
+        assert!(!state.edges.contains_key(&key));
+        assert!(!state.removed_edges.contains_key(&key), "never added → no tombstone");
     }
 
     #[test]


### PR DESCRIPTION
## What

The write-path foundation for **#691** (projecting synced content into the memory read tables). Both changes are correctness-critical the moment content sync moves a sibling's memory ops — **independent of the projection itself** — so they land first.

### Edge tombstones (fixes a cross-device op-log growth loop)

The projection fold dropped a removed edge entirely, and the edge reconcile re-authors any `repo_node_edges` row absent from the projection. So a synced `EdgeRemove` left the local row a ghost → the reconcile re-signed it at a fresh Lamport → the remove lost LWW forever, and re-gossiped: a growth loop that fires the first time any peer syncs an `EdgeRemove`.

- The fold now **retains** removed edges as tombstones (`ProjectedState.removed_edges`) instead of dropping them (additive field — the 22 callers of `.edges` are untouched).
- `write_projection` writes them to `content_projected_edges` with `present = 0`.
- The reconcile's `NOT EXISTS` anti-join now finds the tombstone row → treats the edge as authored → never re-adds it.
- `CONTENT_PROJECTOR_VERSION` bumps (2→3) so existing stores rebuild with tombstones for already-removed edges.

### Sync-origin provenance

`repo_memories` and `repo_node_edges` gain `origin TEXT NOT NULL DEFAULT 'local' CHECK (origin IN ('local','synced'))`. The reconcile anti-joins gate on `origin = 'local'`, so a **synced** row is never re-authored as local `/3` — even if its acceptance is later revoked and its projection row vanishes, which would otherwise **forge local authorship of, and re-legitimize, content the account revoked**. Reads stay provenance-blind (that's the feature); this is purely a write-path guard. Every existing row is locally authored → the `'local'` default is a correct backfill.

## Migration

**V085** adds the two `origin` columns (with the `CHECK`) and `content_projected_edges.present`, all additive with correct defaults; the tip pin moves from the V084 test.

## Tests

The fold's tombstone split (added-then-removed → tombstone; re-added / never-added → not); the migration in isolation (its own precondition) and through the full ladder; that a **tombstoned edge** is not re-authored (the growth-loop fix); and that a **synced-origin** node and edge are never re-authored even absent from the projection. 2155 oplog+core tests pass; both clippy legs and nightly fmt green.

## Scope

This is A-pre. The next PR is **#691 proper** — the drain that projects `content_projected_*` → `repo_memories`/`repo_node_edges` (origin `'synced'`) plus the derived read surfaces (FTS, tags, embeddings, bindings) and the drive seams.