### PR TITLE
perf(index): scope incremental edge re-resolution to changed files (#827)

### DIFF
--- a/crates/rag-rat-core/src/index/edges/resolve/mod.rs
+++ b/crates/rag-rat-core/src/index/edges/resolve/mod.rs
@@ -172,32 +172,71 @@ fn scope_context_value(conn: &Connection, key: &str) -> String {
 ///
 /// READS always span the full active-checkout `files` scope view (so a target in a shadowed/base
 /// file still resolves); this only narrows the SET of source files whose `edges_data` rows the pass
-/// mutates. A LINKED-WORKTREE OVERLAY pass must NOT rewrite a SHARED committed (base-scoped) caller
-/// file's edges: the base row's `files.id` is the same row the base scope reads, so re-resolving it
-/// against the overlay's (shadowed) symbol set would corrupt base `find_callers`/impact until a
-/// base pass resolved it back — graph results flipping by whichever worktree refreshed last (#219
-/// P1).
+/// mutates. Two orthogonal narrowings COMPOSE via `files_write_predicate` (AND-ed together):
+///
+/// - `overlay`: a LINKED-WORKTREE OVERLAY pass must NOT rewrite a SHARED committed (base-scoped)
+///   caller file's edges: the base row's `files.id` is the same row the base scope reads, so
+///   re-resolving it against the overlay's (shadowed) symbol set would corrupt base
+///   `find_callers`/impact until a base pass resolved it back — graph results flipping by whichever
+///   worktree refreshed last (#219 P1). `Some(id)` restricts writes to `files.worktree_id = id`.
+///
+/// - `changed_only`: an incremental content-changed pass restricts writes to the source files
+///   staged in `temp.edge_rewrite_files` — the files it (re)wrote this pass, plus the source files
+///   of the in-edges its removals NULLed (#827). Re-resolving every edge in the active scope on a
+///   1-file delta is the cost this narrows; the full symbol pool stays available as resolution
+///   TARGETS (only the write set shrinks). The staged set re-points every EXISTING edge that
+///   pointed into a changed file; a purely NEW binding from an UNCHANGED source (define-after-use
+///   across files) is not chased here — the same eventual-consistency recall trade-off `overlay`
+///   accepts, settled on the next full rebuild or when that caller file is next touched.
 #[derive(Clone, Copy)]
-pub(crate) enum EdgeWriteScope<'a> {
-    /// Every in-view source file (the base/incremental/full-rebuild path: the active scope OWNS its
-    /// committed rows, so rewriting them is correct).
-    ActiveScope,
-    /// Only the linked worktree's OVERLAY rows (`files.worktree_id = id`). Shared committed rows in
-    /// the view are read for resolution targets but never written.
-    OverlayOnly(&'a str),
+pub(crate) struct EdgeWriteScope<'a> {
+    /// `Some(worktree_id)` restricts writes to that worktree's overlay rows; `None` writes every
+    /// in-view source row (the active scope OWNS its committed rows, so rewriting them is
+    /// correct).
+    overlay: Option<&'a str>,
+    /// When `true`, narrow the write set to `temp.edge_rewrite_files` (#827); when `false`,
+    /// rewrite every source file the `overlay` restriction admits.
+    changed_only: bool,
 }
 
-impl EdgeWriteScope<'_> {
+impl<'a> EdgeWriteScope<'a> {
+    /// The base / incremental-when-not-narrowed / full-rebuild path: rewrite every in-view source
+    /// file's edges.
+    pub(crate) fn active_scope() -> Self {
+        Self { overlay: None, changed_only: false }
+    }
+
+    /// A linked-worktree overlay pass: rewrite ONLY that worktree's overlay source rows (#219 P1).
+    pub(crate) fn overlay_only(worktree_id: &'a str) -> Self {
+        Self { overlay: Some(worktree_id), changed_only: false }
+    }
+
+    /// An incremental content-changed BASE pass: rewrite ONLY the source files staged in
+    /// `temp.edge_rewrite_files` (#827). Composes with `overlay` (both restrictions AND together)
+    /// so a future overlay pass can narrow the same way.
+    pub(crate) fn changed_active() -> Self {
+        Self { overlay: None, changed_only: true }
+    }
+
     /// `AND`-able predicate (with a leading space) restricting `files` to the writable source rows,
-    /// or empty for `ActiveScope`. Inlined (not bound) because it is appended to several different
-    /// SELECTs; the embedded value is a git-derived worktree id, single-quote-escaped defensively.
+    /// or empty for the full active scope. Inlined (not bound) because it is appended to several
+    /// different SELECTs; the overlay value is a git-derived worktree id, single-quote-escaped
+    /// defensively. The `changed_only` term references the pass's `temp.edge_rewrite_files` staging
+    /// (created by `begin_scoped_edge_rewrite`); it AND-composes with the overlay term so an
+    /// overlay row that also changed is written while a base row that changed under an overlay
+    /// pass is not.
     fn files_write_predicate(&self) -> String {
-        match self {
-            EdgeWriteScope::ActiveScope => String::new(),
-            EdgeWriteScope::OverlayOnly(worktree_id) => {
-                format!(" AND files.worktree_id = '{}'", worktree_id.replace('\'', "''"))
-            },
+        let mut predicate = String::new();
+        if let Some(worktree_id) = self.overlay {
+            predicate.push_str(&format!(
+                " AND files.worktree_id = '{}'",
+                worktree_id.replace('\'', "''")
+            ));
         }
+        if self.changed_only {
+            predicate.push_str(" AND files.id IN (SELECT file_id FROM temp.edge_rewrite_files)");
+        }
+        predicate
     }
 }
 
@@ -219,7 +258,20 @@ impl EdgeWriteScope<'_> {
 /// scope's edges stay self-consistent until gc prunes them or their own worktree's pass rewrites
 /// them.
 pub(crate) fn resolve_all_edges(conn: &Connection) -> anyhow::Result<()> {
-    resolve_edges_with_scope(conn, EdgeWriteScope::ActiveScope)
+    resolve_edges_with_scope(conn, EdgeWriteScope::active_scope())
+}
+
+/// Re-resolve ONLY the source files staged in `temp.edge_rewrite_files` (#827) — the incremental
+/// content-changed BASE pass's narrowed twin of [`resolve_all_edges`]. Resolution TARGETS still
+/// span the full active scope (an edge in a changed file into an unchanged symbol resolves), but
+/// the WRITE set is the pass's changed files plus the source files of the in-edges its removals
+/// NULLed, so a 1-file delta rewrites a handful of files' edges instead of every edge in the scope.
+/// The caller stages the set via `begin_scoped_edge_rewrite` + the capture seams and must only
+/// reach here when the pass's mutations are purely per-file symbol/edge changes (no package-map /
+/// carry / heal visibility shift, which a narrowed write set would under-resolve) — see the
+/// incremental pass gate.
+pub(crate) fn resolve_changed_edges(conn: &Connection) -> anyhow::Result<()> {
+    resolve_edges_with_scope(conn, EdgeWriteScope::changed_active())
 }
 
 /// Re-resolve ONLY a linked worktree's OVERLAY edges (#219 P1). Resolution targets still span the
@@ -230,7 +282,7 @@ pub(crate) fn resolve_all_edges(conn: &Connection) -> anyhow::Result<()> {
 /// row is read-only here); the overlay still serves its own files' edges, and the base resolves its
 /// own on its next pass.
 pub(crate) fn resolve_overlay_edges(conn: &Connection, worktree_id: &str) -> anyhow::Result<()> {
-    resolve_edges_with_scope(conn, EdgeWriteScope::OverlayOnly(worktree_id))
+    resolve_edges_with_scope(conn, EdgeWriteScope::overlay_only(worktree_id))
 }
 
 fn resolve_edges_with_scope(conn: &Connection, write: EdgeWriteScope<'_>) -> anyhow::Result<()> {
@@ -705,7 +757,7 @@ pub(crate) fn resolve_and_insert_edges(
     // #200: synthesize construct→handler `dispatches` edges from the resolved fact rows. Runs after
     // the index rebuild — the few extra inserts maintain the (now rebuilt) indexes incrementally.
     // A full rebuild owns its whole scope, so it synthesizes over the active scope.
-    synthesize_dispatch_edges(conn, EdgeWriteScope::ActiveScope)?;
+    synthesize_dispatch_edges(conn, EdgeWriteScope::active_scope())?;
     Ok(())
 }
 

--- a/crates/rag-rat-core/src/index/edges/resolve/tests.rs
+++ b/crates/rag-rat-core/src/index/edges/resolve/tests.rs
@@ -1823,3 +1823,100 @@ fn add_py_symbol_at(
     .unwrap();
     conn.last_insert_rowid()
 }
+
+/// Stage `file_ids` into `temp.edge_rewrite_files` the way `begin_scoped_edge_rewrite` + the
+/// capture seams do, so a connection-level test can drive [`resolve_changed_edges`] directly
+/// (#827).
+fn stage_edge_rewrite_files(conn: &Connection, file_ids: &[i64]) {
+    conn.execute_batch(
+        "CREATE TEMP TABLE IF NOT EXISTS edge_rewrite_files(file_id INTEGER PRIMARY KEY);
+         DELETE FROM temp.edge_rewrite_files;",
+    )
+    .unwrap();
+    for &file_id in file_ids {
+        conn.execute(
+            "INSERT OR IGNORE INTO temp.edge_rewrite_files(file_id) VALUES (?1)",
+            params![file_id],
+        )
+        .unwrap();
+    }
+}
+
+/// #827: a scoped re-resolve rewrites ONLY the source files staged in `temp.edge_rewrite_files`,
+/// leaving every other file's edges untouched — even one a FULL re-resolve WOULD bind. The unstaged
+/// caller's edge is left `unresolved` with its target present in the corpus: if
+/// `resolve_changed_edges` fell back to a full pass it would bind it, so the surviving `unresolved`
+/// state is what proves the narrowing is real (the fast path disagrees with the fallback — not the
+/// full path in disguise).
+#[test]
+fn scoped_resolve_rewrites_only_staged_source_files() {
+    let conn = seeded_conn();
+    let caller_staged = add_file(&conn, "a.rs", NEW);
+    let caller_unstaged = add_file(&conn, "b.rs", NEW);
+    let defs = add_file(&conn, "d.rs", NEW);
+    let target = add_symbol(&conn, defs, "target", "crate::d::target");
+    add_symbol(&conn, caller_staged, "caller_a", "crate::a::caller_a");
+    add_symbol(&conn, caller_unstaged, "caller_b", "crate::b::caller_b");
+    let edge_staged = add_edge(&conn, caller_staged, "d::target", "d::target");
+    let edge_unstaged = add_edge(&conn, caller_unstaged, "d::target", "d::target");
+
+    crate::index::install_scope_view(&conn, NEW, "").unwrap();
+    // Both edges arrive `unresolved`. Stage ONLY a.rs; b.rs is the poison a full pass would bind.
+    stage_edge_rewrite_files(&conn, &[caller_staged]);
+    resolve_changed_edges(&conn).unwrap();
+
+    let (to, confidence, resolution) = edge_state(&conn, edge_staged);
+    assert_eq!(to, Some(target), "the staged file's edge is re-resolved against the full pool");
+    assert_eq!(confidence, "Syntactic");
+    assert_eq!(resolution, "qualified_suffix");
+
+    let (to, _, resolution) = edge_state(&conn, edge_unstaged);
+    assert_eq!(to, None, "the UNSTAGED file's edge is left untouched by the scoped pass");
+    assert_eq!(
+        resolution, "unresolved",
+        "a full re-resolve would bind this identical edge — its surviving unresolved state proves \
+         the scoped pass did NOT fall back to a full pass"
+    );
+}
+
+/// #827: staging the SOURCE FILE of an in-edge (what `remove_file_in_scope` captures at file
+/// granularity) re-points that in-edge onto the changed file's NEW symbol id — so a caller in an
+/// UNCHANGED file survives a change to its target's file (the `find_callers` recall floor).
+#[test]
+fn scoped_resolve_repoints_staged_inedge_onto_moved_target() {
+    let conn = seeded_conn();
+    let caller = add_file(&conn, "a.rs", NEW);
+    let defs = add_file(&conn, "d.rs", NEW);
+    add_symbol(&conn, caller, "caller", "crate::a::caller");
+    let old_target = add_symbol(&conn, defs, "target", "crate::d::target");
+    let edge = add_edge(&conn, caller, "d::target", "d::target");
+    // The caller's edge starts resolved to the target's ORIGINAL id.
+    conn.execute(
+        "UPDATE edges SET to_symbol_id = ?2, confidence = 'Syntactic', resolution = \
+         'qualified_suffix' WHERE id = ?1",
+        params![edge, old_target],
+    )
+    .unwrap();
+
+    // Simulate the target file changing: its symbol is deleted and re-inserted with a NEW id, and
+    // the in-edge is NULLed exactly as `remove_file_in_scope` does. Stage BOTH files, as the
+    // capture seams would (the changed file d.rs plus the source file a.rs of the NULLed
+    // in-edge).
+    conn.execute("DELETE FROM symbols WHERE id = ?1", params![old_target]).unwrap();
+    conn.execute(
+        "UPDATE edges SET to_symbol_id = NULL, confidence = 'NameOnly', resolution = 'unresolved' \
+         WHERE id = ?1",
+        params![edge],
+    )
+    .unwrap();
+    let new_target = add_symbol(&conn, defs, "target", "crate::d::target");
+    assert_ne!(new_target, old_target, "the re-inserted target must carry a fresh id");
+
+    crate::index::install_scope_view(&conn, NEW, "").unwrap();
+    stage_edge_rewrite_files(&conn, &[caller, defs]);
+    resolve_changed_edges(&conn).unwrap();
+
+    let (to, _, resolution) = edge_state(&conn, edge);
+    assert_eq!(to, Some(new_target), "the staged in-edge re-points onto the target's NEW id");
+    assert_eq!(resolution, "qualified_suffix");
+}

--- a/crates/rag-rat-core/src/index/file_index.rs
+++ b/crates/rag-rat-core/src/index/file_index.rs
@@ -266,14 +266,22 @@ impl IndexDatabase {
                 }
             },
             // Incremental: insert unresolved edges per file; resolve_edges resolves them afterward.
-            None =>
+            None => {
+                // #827: register this (re)written file as set (a) of the scoped re-resolve write
+                // set (no-op unless a scoped incremental pass armed capture).
+                // Staged unconditionally — even an edge-less changed file may host
+                // symbols a `resolve_changed_edges` pass will re-point in-edges
+                // toward — so the write set matches what a full re-resolve touches
+                // for the changed files.
+                self.stage_edge_rewrite_file(file_id)?;
                 if !prepared.edge_candidates.is_empty() {
                     let mut candidates = prepared.edge_candidates.clone();
                     for candidate in &mut candidates {
                         candidate.remap_from_symbol_id(&symbol_db_ids);
                     }
                     edges::insert_candidates(self.storage.connection(), file_id, candidates)?;
-                },
+                }
+            },
         }
         self.mark_fts_dirty()?;
         Ok(())

--- a/crates/rag-rat-core/src/index/file_rows.rs
+++ b/crates/rag-rat-core/src/index/file_rows.rs
@@ -7,6 +7,77 @@ use rag_rat_base::time::now_ms;
 use super::*;
 
 impl IndexDatabase {
+    /// #827: arm scoped-edge-rewrite capture for the duration of an incremental content-changed
+    /// pass. Creates (idempotently) and clears `temp.edge_rewrite_files`; while armed, the write
+    /// seams (`remove_file_in_scope`, the incremental file insert) stage the source files a scoped
+    /// re-resolve must rewrite into it. The temp table lives in the `temp` schema (no main-DB
+    /// write), so arming does not violate the idle-pass no-write invariant (#63). Paired with
+    /// [`Self::finish_scoped_edge_rewrite`].
+    pub(super) fn begin_scoped_edge_rewrite(&self) -> anyhow::Result<()> {
+        self.storage.connection().execute_batch(
+            "CREATE TEMP TABLE IF NOT EXISTS edge_rewrite_files(file_id INTEGER PRIMARY KEY);
+             DELETE FROM temp.edge_rewrite_files;",
+        )?;
+        self.edge_rewrite_capture.store(true, std::sync::atomic::Ordering::Relaxed);
+        Ok(())
+    }
+
+    /// #827: disarm scoped-edge-rewrite capture. Leaves the staged rows in place for the pass's
+    /// `resolve_changed_edges` to read; the next [`Self::begin_scoped_edge_rewrite`] clears them.
+    pub(super) fn finish_scoped_edge_rewrite(&self) {
+        self.edge_rewrite_capture.store(false, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    fn edge_rewrite_capture_active(&self) -> bool {
+        self.edge_rewrite_capture.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// #827: stage a (re)written source file's id into the scoped re-resolve write set (set (a) — the
+    /// changed files themselves). No-op unless capture is armed.
+    pub(super) fn stage_edge_rewrite_file(&self, file_id: i64) -> anyhow::Result<()> {
+        if self.edge_rewrite_capture_active() {
+            self.storage.connection().execute(
+                "INSERT OR IGNORE INTO temp.edge_rewrite_files(file_id) VALUES (?1)",
+                params![file_id],
+            )?;
+        }
+        Ok(())
+    }
+
+    /// #827: stage the SOURCE FILES of the in-edges pointing at the changed PATH's symbols (set (b)).
+    /// Called from [`Self::remove_file_in_scope`] BEFORE the NULLing UPDATE, so the in-edges are
+    /// still bound. Keyed on `path` (+ repo + generation), NOT the removed `(commit_sha,
+    /// worktree_id)` scope: a FIRST dirty edit of a committed file removes only the (empty)
+    /// overlay scope, yet the in-edge `caller → committed target` must still be re-pointed onto
+    /// the new overlay target that now WINS the active view (a full re-resolve does exactly
+    /// this). Path-keying captures the in-edge whichever scope of the path it currently binds.
+    /// Over-capturing an in-edge from a sibling worktree is harmless — the scoped resolve's
+    /// `files` view excludes non-active rows, so only the active checkout's captured sources
+    /// are actually rewritten. No-op unless capture is armed.
+    fn stage_edge_rewrite_inedge_sources(
+        &self,
+        path: &str,
+        repo_id: &str,
+        generation: i64,
+    ) -> anyhow::Result<()> {
+        if !self.edge_rewrite_capture_active() {
+            return Ok(());
+        }
+        self.storage.connection().execute(
+            "INSERT OR IGNORE INTO temp.edge_rewrite_files(file_id)
+             SELECT DISTINCT edges_data.source_file_id FROM edges_data
+             WHERE edges_data.to_symbol_id IN (
+                 SELECT symbols.id FROM symbols
+                 JOIN main.files ON main.files.id = symbols.file_id
+                 WHERE main.files.path = ?1
+                   AND main.files.repo_id = ?2
+                   AND main.files.generation = ?3
+             )",
+            params![path, repo_id, generation],
+        )?;
+        Ok(())
+    }
+
     pub(super) fn mark_file_deleted(&self, path: &Path) -> anyhow::Result<()> {
         self.write_tombstone_in_scope(path, &self.active_worktree_id)
     }
@@ -68,6 +139,13 @@ impl IndexDatabase {
         // the staging target on the rebuild connection, so each writer removes only its own
         // generation's rows.
         let generation = self.active_generation;
+        // #827: BEFORE the UPDATE NULLs them, stage the SOURCE FILES of the in-edges pointing at
+        // this PATH's symbols into the scoped re-resolve write set. A scoped incremental pass must
+        // re-resolve those files' edges (else a caller in an UNCHANGED file — NULLed here, or
+        // flipped onto a new overlay winner — would drop out of `find_callers`). Captured
+        // at FILE granularity (round up in-edge → its source file), so the whole write set
+        // stays one file-id set. No-op unless armed by `begin_scoped_edge_rewrite`.
+        self.stage_edge_rewrite_inedge_sources(&path, repo_id, generation)?;
         self.storage.connection().execute(
             "UPDATE edges_data
              SET to_symbol_id = NULL,

--- a/crates/rag-rat-core/src/index/graph_index.rs
+++ b/crates/rag-rat-core/src/index/graph_index.rs
@@ -631,6 +631,17 @@ impl IndexDatabase {
         edges::resolve_all_edges(self.storage.connection())
     }
 
+    /// Re-resolve ONLY the source files staged in `temp.edge_rewrite_files` (#827) — the
+    /// incremental content-changed pass's narrowed twin of [`Self::resolve_edges`]. The caller
+    /// must have armed capture (`begin_scoped_edge_rewrite`) so the staging holds this pass's
+    /// changed files plus the source files of the in-edges its removals NULLed, and must only
+    /// reach here when the pass's mutations are purely per-file symbol/edge changes (the
+    /// incremental resolve gate). Resolution TARGETS still span the full active scope, so an
+    /// edge in a changed file into an unchanged symbol resolves.
+    pub(super) fn resolve_changed_edges(&self) -> anyhow::Result<()> {
+        edges::resolve_changed_edges(self.storage.connection())
+    }
+
     /// Resolve edges for a LINKED-WORKTREE OVERLAY pass (#219 P1): re-resolve / re-synthesize ONLY
     /// the worktree's own overlay source files, never the SHARED committed (base) rows that are
     /// merely visible in the overlay scope view. Resolution targets still span the full overlay

--- a/crates/rag-rat-core/src/index/incremental.rs
+++ b/crates/rag-rat-core/src/index/incremental.rs
@@ -310,6 +310,14 @@ impl IndexDatabase {
             // BEGIN IMMEDIATE: take the write lock up front so a racing writer waits out
             // busy_timeout instead of failing a deferred read→write upgrade with SQLITE_BUSY.
             db.storage.execute_batch("BEGIN IMMEDIATE")?;
+            // #827: arm scoped-edge-rewrite capture for the whole pass — BEFORE the file removals /
+            // inserts below, so `remove_file_in_scope` can stage the source files of the in-edges
+            // it NULLs and the incremental file insert can stage the changed files.
+            // Whether the pass actually narrows (vs a full re-resolve) is decided AFTER
+            // apply, once the row counts are known (see the resolve gate below); arming
+            // unconditionally only writes the `temp` schema, so it costs an idle pass
+            // nothing on the main DB (#63).
+            db.begin_scoped_edge_rewrite()?;
             // Write meta only when it actually changed, and track whether this pass mutated
             // anything at all. A periodic sweep or a spurious event over an unchanged
             // tree must NOT churn the WAL with a timestamp-only write + COMMIT (issue
@@ -412,11 +420,31 @@ impl IndexDatabase {
                     },
                 }
                 progress(IndexProgress::ResolvingGraph);
-                db.resolve_edges()?;
+                // #827: narrow the re-resolve to this pass's staged changed files + the source
+                // files of the in-edges its removals NULLed
+                // (`temp.edge_rewrite_files`) — but ONLY when the pass's mutations
+                // are purely per-file symbol/edge changes. A package-map change
+                // (`roots_changed`), a carried scope (`carried`), or an overlay heal (`healed`) can
+                // shift how edges in UNCHANGED files resolve (import scope / row visibility), which
+                // a narrowed write set would silently under-resolve — those keep
+                // the full active-scope pass. The narrowed set re-points every
+                // existing edge (no `find_callers` loss); only a purely NEW binding
+                // from an unchanged source is deferred to the next full pass.
+                let scoped_resolve = indexed > 0 && healed == 0 && carried == 0 && !roots_changed;
+                if scoped_resolve {
+                    db.resolve_changed_edges()?;
+                } else {
+                    db.resolve_edges()?;
+                }
                 db.mark_graph_index_current()?;
                 progress(IndexProgress::SyncingFts);
                 db.sync_fts()?;
             }
+            // #827: disarm capture for this connection (the staged rows are consumed by the resolve
+            // above; the next pass's `begin_scoped_edge_rewrite` clears them). Runs whether or not
+            // the resolve branch was entered, so an idle or non-narrowed pass leaves
+            // the flag clean.
+            db.finish_scoped_edge_rewrite();
             if mutated {
                 db.set_repo_meta("indexed_at_ms", &now_ms().to_string())?;
                 db.storage.execute_batch("COMMIT")?;

--- a/crates/rag-rat-core/src/index/lifecycle.rs
+++ b/crates/rag-rat-core/src/index/lifecycle.rs
@@ -178,6 +178,7 @@ impl IndexDatabase {
             config: None,
             _identity_lock: None,
             drift_snapshot: std::sync::Mutex::new(None),
+            edge_rewrite_capture: std::sync::atomic::AtomicBool::new(false),
             #[cfg(test)]
             logical_symbol_rebuilds: std::sync::atomic::AtomicUsize::new(0),
         };
@@ -203,6 +204,7 @@ impl IndexDatabase {
             config: Some(config.clone()),
             _identity_lock: None,
             drift_snapshot: std::sync::Mutex::new(None),
+            edge_rewrite_capture: std::sync::atomic::AtomicBool::new(false),
             #[cfg(test)]
             logical_symbol_rebuilds: std::sync::atomic::AtomicUsize::new(0),
         };
@@ -382,6 +384,7 @@ impl IndexDatabase {
             config: Some(config.clone()),
             _identity_lock: None,
             drift_snapshot: std::sync::Mutex::new(None),
+            edge_rewrite_capture: std::sync::atomic::AtomicBool::new(false),
             #[cfg(test)]
             logical_symbol_rebuilds: std::sync::atomic::AtomicUsize::new(0),
         };
@@ -544,6 +547,7 @@ impl IndexDatabase {
             config: None,
             _identity_lock: None,
             drift_snapshot: std::sync::Mutex::new(None),
+            edge_rewrite_capture: std::sync::atomic::AtomicBool::new(false),
             #[cfg(test)]
             logical_symbol_rebuilds: std::sync::atomic::AtomicUsize::new(0),
         })

--- a/crates/rag-rat-core/src/index/mod.rs
+++ b/crates/rag-rat-core/src/index/mod.rs
@@ -100,7 +100,7 @@ mod parser_tests;
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::mpsc;
 use std::thread::JoinHandle;
 use std::time::UNIX_EPOCH;
@@ -178,6 +178,15 @@ pub struct IndexDatabase {
     /// never pay the snapshot scan. Interior mutability because the deleters take `&self`.
     drift_snapshot:
         std::sync::Mutex<Option<(String, Option<Vec<graph_index::LogicalKeyDriftRow>>)>>,
+    /// #827: when armed, the pass captures the source files whose edges a scoped re-resolve must
+    /// rewrite — the changed files it (re)writes plus the source files of the in-edges its
+    /// removals NULL — into `temp.edge_rewrite_files`, so `resolve_changed_edges` narrows the
+    /// write set to those instead of every edge in the active scope. Armed for the duration of
+    /// an incremental content-changed pass by `begin_scoped_edge_rewrite`; the capture seams
+    /// (`remove_file_in_scope`, the incremental file insert) take `&self`, hence interior
+    /// mutability. `Relaxed` is sufficient: capture and resolve run on one connection/thread
+    /// within the pass, never a cross-thread handoff.
+    edge_rewrite_capture: AtomicBool,
     /// Test-only #819 observability: how many times [`Self::rebuild_logical_symbols`] ran on this
     /// connection, so batch tests can assert the once-per-pass rebuild cardinality.
     #[cfg(test)]

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/graph_edges.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/graph_edges.rs
@@ -228,3 +228,76 @@ fn find_callers_sees_calls_in_let_bindings() {
 
     let _ = fs::remove_dir_all(root);
 }
+
+/// #827: an incremental content-changed pass narrows the edge re-resolve to the changed files plus
+/// the source files of the in-edges its removals touch — but must preserve `find_callers` parity
+/// for BOTH the touched file's own out-edges AND untouched files' in-edges into it. Editing `a.rs`
+/// (which defines `target`, called from the UNCHANGED `b.rs`) must NOT drop `b_caller` from
+/// `find_callers(target)`: the scoped pass re-points that in-edge onto the changed file's new
+/// symbol id even though the first dirty edit only shadows (never removes) the committed `target`.
+/// The reverse leg — the touched file's own call into `b.rs` — must resolve too. This is the exact
+/// verification the issue calls for: find_callers parity for touched and untouched files after a
+/// scoped pass.
+#[test]
+fn scoped_incremental_pass_preserves_find_callers_both_directions() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), "mod a;\nmod b;\n").unwrap();
+    fs::write(
+        root.join("src/a.rs"),
+        "use crate::b::b_helper;\npub fn target() {}\npub fn a_caller() {\n    b_helper();\n}\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("src/b.rs"),
+        "use crate::a::target;\npub fn b_helper() {}\npub fn b_caller() {\n    target();\n}\n",
+    )
+    .unwrap();
+    init_git_repo(&root);
+    run_git(&root, &["add", "."]);
+    run_git(&root, &["commit", "-q", "-m", "seed"]);
+    let config = source_config(root.clone(), Language::Rust);
+
+    let caller_names = |db: &IndexDatabase, of: &str| -> Vec<String> {
+        db.find_callers(of, 50).unwrap().iter().filter_map(|hop| hop.from_symbol.clone()).collect()
+    };
+    let calls = |db: &IndexDatabase, callee: &str, caller: &str| {
+        caller_names(db, callee).iter().any(|name| name.ends_with(caller))
+    };
+
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    // Baseline: both cross-file callers resolve after the full rebuild.
+    assert!(calls(&db, "target", "b_caller"), "baseline: b_caller must call target");
+    assert!(calls(&db, "b_helper", "a_caller"), "baseline: a_caller must call b_helper");
+    drop(db);
+
+    // Edit a.rs (dirty, uncommitted) — prepend a comment so its `target` / `a_caller` symbols get
+    // fresh ids while b.rs is untouched. This is the pure per-file change the scoped resolve
+    // narrows to (indexed > 0, nothing healed / carried / manifest-changed).
+    fs::write(
+        root.join("src/a.rs"),
+        "// touched\nuse crate::b::b_helper;\npub fn target() {}\npub fn a_caller() {\n    \
+         b_helper();\n}\n",
+    )
+    .unwrap();
+    let db = IndexDatabase::index_changed(&config).unwrap();
+
+    // The in-edge from the UNCHANGED b.rs must survive the scoped pass — the `find_callers` recall
+    // floor. A naive source-file-only write scope would leave it pointing at the shadowed committed
+    // `target` and drop b_caller here.
+    assert!(
+        calls(&db, "target", "b_caller"),
+        "after a scoped incremental edit of a.rs, b_caller must still call target (in-edge \
+         re-pointed onto the new symbol), got {:?}",
+        caller_names(&db, "target"),
+    );
+    // The touched file's own out-edge into b.rs must resolve too (set (a)).
+    assert!(
+        calls(&db, "b_helper", "a_caller"),
+        "after a scoped incremental edit of a.rs, a_caller must still call b_helper, got {:?}",
+        caller_names(&db, "b_helper"),
+    );
+
+    let _ = fs::remove_dir_all(root);
+}


### PR DESCRIPTION
## Problem
The incremental content-changed pass re-resolved **every** edge in the active scope on each pass (`resolve_all_edges` / `EdgeWriteScope::ActiveScope`) — a whole-corpus symbol sort plus a per-edge UPDATE — even for a one-file delta.

## Change
Narrow the write set to the source files staged in `temp.edge_rewrite_files`:
- **(a)** the files the pass (re)wrote — staged in the incremental arm of `insert_prepared_file`;
- **(b)** the source files of the in-edges the pass's removals touch — staged in `remove_file_in_scope` *before* the NULLing UPDATE, at file granularity and keyed on the changed **path** (not the removed commit/worktree scope), so a first dirty edit that only *shadows* a committed file still re-points the callers that must flip onto the new overlay winner.

Resolution *targets* still span the full symbol pool — an edge in a changed file into an unchanged symbol resolves — only the *write* set shrinks.

`EdgeWriteScope` becomes a struct composing the overlay restriction (#219) with the changed-files narrowing, so the single `files_write_predicate` — already shared by the resolve loop and dispatch synthesis — carries both, and the overlay path can narrow the same way in a follow-up.

## Safety
- Gated to the pure per-file-change case: `indexed>0 && healed==0 && carried==0 && !roots_changed`. Anything that can shift how *unchanged* files resolve (package map, #502 carry, overlay heal) keeps the full re-resolve.
- The narrowed write set is a strict **subset** of the full one, so a miss is an eventually-consistent recall gap (settled on the next full pass), never corruption.
- A purely *new* binding from an unchanged source (define-after-use across files) is not chased — the same recall trade-off the overlay path already documents.

## Measured (dogfood index: 196k edges, 473 files)
Edges rewritten per one-file edit — scoped vs full:

| Edited file | Full | Scoped | Reduction |
|---|---|---|---|
| a typical file | 196,151 | 1,879 | ~100× |
| a schema module | 196,151 | 16,562 | ~12× |
| a widely-referenced core type | 196,151 | 81,728 | ~2.4× |

The write set scales with the changed file's reverse-dependency neighborhood; even a god-module edit halves the work, its residual being the callers that must be re-pointed.

## Verification
- `find_callers` parity across a real `index_changed` edit, both directions (an in-edge from an unchanged file survives; the touched file's own out-edge resolves) — the issue's stated check.
- A poison test proving the scoped pass leaves unstaged files' edges untouched even when a full re-resolve would bind them (the fast path genuinely differs from the fallback).
- Full `rag-rat-core` suite green (every existing incremental-edit test now routes through the scoped path); clippy (no-default-features and all-features, `-D warnings`) and nightly rustfmt clean.

Fixes #827.
