### PR TITLE
perf(index): scope incremental logical-symbol re-derive to changed paths (#826)

### DIFF
--- a/crates/rag-rat-core/src/index/file_index.rs
+++ b/crates/rag-rat-core/src/index/file_index.rs
@@ -274,6 +274,11 @@ impl IndexDatabase {
                 // toward — so the write set matches what a full re-resolve touches
                 // for the changed files.
                 self.stage_edge_rewrite_file(file_id)?;
+                // #826: register this file's PATH for the scoped logical re-derive — its symbols
+                // were just (re)written, so its `logical_symbols` groups must be
+                // re-derived. No-op unless a scoped logical re-derive pass armed
+                // capture.
+                self.stage_logical_rederive_path(&path)?;
                 if !prepared.edge_candidates.is_empty() {
                     let mut candidates = prepared.edge_candidates.clone();
                     for candidate in &mut candidates {

--- a/crates/rag-rat-core/src/index/file_rows.rs
+++ b/crates/rag-rat-core/src/index/file_rows.rs
@@ -32,6 +32,44 @@ impl IndexDatabase {
         self.edge_rewrite_capture.load(std::sync::atomic::Ordering::Relaxed)
     }
 
+    /// #826: arm scoped logical re-derive capture for a pass. Creates (idempotently) and clears
+    /// `temp.logical_rederive_paths`; while armed, `remove_file_in_scope` and the incremental file
+    /// insert stage the PATHS whose symbols changed, so `rederive_changed_logical_symbols` regroups
+    /// only those paths' `logical_symbols` instead of the whole repo. `temp` schema only (no
+    /// main-DB write → #63 idle-safe). Paired with [`Self::finish_scoped_logical_rederive`].
+    pub(super) fn begin_scoped_logical_rederive(&self) -> anyhow::Result<()> {
+        self.storage.connection().execute_batch(
+            "CREATE TEMP TABLE IF NOT EXISTS logical_rederive_paths(path TEXT PRIMARY KEY);
+             DELETE FROM temp.logical_rederive_paths;",
+        )?;
+        self.logical_rederive_capture.store(true, std::sync::atomic::Ordering::Relaxed);
+        Ok(())
+    }
+
+    /// #826: disarm scoped logical re-derive capture. Leaves the staged paths for the pass's
+    /// `rederive_changed_logical_symbols` to read; the next `begin_scoped_logical_rederive` clears.
+    pub(super) fn finish_scoped_logical_rederive(&self) {
+        self.logical_rederive_capture.store(false, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    fn logical_rederive_capture_active(&self) -> bool {
+        self.logical_rederive_capture.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// #826: stage a changed PATH (a file this pass rewrote / removed / healed) into the scoped
+    /// logical re-derive set. Called from `remove_file_in_scope` (the removed path) and the
+    /// incremental file insert (the written path); their union is every path whose logical grouping
+    /// could have moved this pass. No-op unless capture is armed.
+    pub(super) fn stage_logical_rederive_path(&self, path: &str) -> anyhow::Result<()> {
+        if self.logical_rederive_capture_active() {
+            self.storage.connection().execute(
+                "INSERT OR IGNORE INTO temp.logical_rederive_paths(path) VALUES (?1)",
+                params![path],
+            )?;
+        }
+        Ok(())
+    }
+
     /// #827: stage a (re)written source file's id into the scoped re-resolve write set (set (a) — the
     /// changed files themselves). No-op unless capture is armed.
     pub(super) fn stage_edge_rewrite_file(&self, file_id: i64) -> anyhow::Result<()> {
@@ -125,6 +163,10 @@ impl IndexDatabase {
         // most once per pass.
         self.capture_drift_snapshot_before_removal()?;
         let path = path_string(path);
+        // #826: this path's symbols are about to be deleted, so its `logical_symbols` groups must
+        // be re-derived. Stage the path (re-parse remove-half, delete, heal, tombstone all
+        // funnel here). No-op unless a scoped logical re-derive pass armed capture.
+        self.stage_logical_rederive_path(&path)?;
         // Direct edges_data writes (#79): these statements touch up to every in-edge of a file's
         // symbols, so they must not pay the view triggers' per-row dictionary probes.
         // 'NameOnly' is the EdgeConfidence demotion the resolver applies to a target-less edge.

--- a/crates/rag-rat-core/src/index/graph_index.rs
+++ b/crates/rag-rat-core/src/index/graph_index.rs
@@ -690,38 +690,78 @@ impl IndexDatabase {
             self.active_repo_id
         ])?;
 
-        // STREAM the grouping instead of materializing every symbol. The previous version built a
-        // `BTreeMap<LogicalSymbolKey, Vec<row>>` over ALL symbols — at kernel scale ~3.5M rows ×
-        // six owned `String`s each (plus a cloned key per group). That structure, allocated in the
-        // trailing rebuild phase AFTER the edge accumulator is freed, was the dominant full-rebuild
-        // peak-RSS spike (~6 GB transient at the very end of a whole-kernel index). Ordering the
-        // SELECT by the key's `Ord` (language, path, name, qualified_name, kind, signature — SQLite
-        // ASC sorts NULL first, matching Rust `None < Some`) then the within-group member order
-        // (start_byte, end_byte, which the old per-group Vec preserved) makes each group's rows
-        // arrive contiguously, so we flush a group the moment its key changes and hold only the
-        // current group's members (kilobytes). Byte-identical: same grouping, same
-        // `logical_symbols` insert order (ids are content-derived via `stable_id`, not rowids), and
-        // the same member order, verified against the golden index.
-        // Read RAW `main.files` (ALL of the active repo's scopes), NOT the per-connection `files`
-        // scope VIEW. logical_symbols is per-repo but scope-INDEPENDENT within a repo; building it
-        // must not depend on whichever commit/worktree scope happens to be active. When this runs
-        // in a worktree-overlay context (a scope view IS installed), an unqualified `files`
-        // resolves to the scoped temp view, so the DELETE + repopulate would WIPE every
-        // other scope's grouping (base + sibling worktrees) and restore only the active
-        // scope's — persistently breaking `sym_<hex>`-handle graph nav for base symbols
-        // (the #219 review finding). Filtering `main.files.repo_id` (A3) keeps every symbol
-        // in every live scope OF THIS REPO while excluding a sibling repo's rows in a
-        // consolidated DB; the content-derived `stable_id` collapses cross-scope duplicates
-        // into one logical symbol with per-scope members, and downstream reads stay
-        // scope-filtered via the `files` view.
-        // Filter `main.files.generation` to the ACTIVE generation (A6): a full rebuild leaves the
-        // superseded generation's file rows in place (swept lazily by gc), so a bare `repo_id`
-        // predicate would fold BOTH the dead and the live generation's symbols into one grouping.
-        // `self.active_generation` is the WRITE generation on the rebuild connection — which the
-        // rebuild flips to LIVE and carries forward every live overlay onto BEFORE this runs, so
-        // filtering it folds the base scope + every carried-forward overlay of the live generation
-        // and nothing dead. On an incremental pass it is the live generation, unchanged behavior.
-        let mut stmt = conn.prepare(
+        // Re-derive the WHOLE repo's grouping from its current symbols via the shared streaming
+        // grouper (no path filter). The DELETE above cleared the prior rows, so re-insert cannot
+        // collide on the content-derived `stable_id` PK.
+        self.regroup_logical_symbols(conn, "")?;
+        if let Some(snapshot) = drift_snapshot {
+            self.heal_logical_key_drift(&snapshot)?;
+            if matches!(stamp, KeyVersionStamp::FullRederive) {
+                self.set_repo_meta(LOGICAL_KEY_VERSION_KEY, LOGICAL_KEY_VERSION)?;
+            }
+        }
+        // ANY successful rebuild satisfies a pending batch-deferred obligation (#819) — the batch
+        // tail, an inline overlay refresh, a heal, an incremental or full pass — so clear the
+        // marker here, in the same transaction as the rebuild it accounts for. Left set, the next
+        // maintenance pass would pay a second wholesale rebuild for nothing (e.g. after an
+        // interrupted deferred batch whose stale grouping a standalone `index --worktree` already
+        // repaired inline). A no-op DELETE when no marker is set.
+        rag_rat_db::meta::delete_repo_meta(
+            conn,
+            &self.active_repo_id,
+            super::worktree_overlay::OVERLAY_LOGICAL_REBUILD_PENDING_META,
+        )?;
+        Ok(())
+    }
+
+    /// Stream the active repo's live-generation symbols — optionally narrowed by `extra_where`, an
+    /// `AND`-able predicate over `main.files`/`symbols` (a hardcoded literal, never user input) —
+    /// grouped by the logical key, inserting each group via [`Self::insert_logical_group`]. Shared
+    /// by the whole-repo [`Self::rebuild_logical_symbols`] (`extra_where = ""`) and the
+    /// path-scoped [`Self::rederive_changed_logical_symbols`] (#826) so both derive
+    /// BYTE-IDENTICAL groupings for the paths they cover — same key order, same member order,
+    /// same content-derived ids.
+    ///
+    /// STREAM the grouping instead of materializing every symbol. The previous version built a
+    /// `BTreeMap<LogicalSymbolKey, Vec<row>>` over ALL symbols — at kernel scale ~3.5M rows × six
+    /// owned `String`s each (plus a cloned key per group). That structure, allocated in the
+    /// trailing rebuild phase AFTER the edge accumulator is freed, was the dominant
+    /// full-rebuild peak-RSS spike (~6 GB transient at the very end of a whole-kernel index).
+    /// Ordering the SELECT by the key's `Ord` (language, path, name, qualified_name, kind,
+    /// signature — SQLite ASC sorts NULL first, matching Rust `None < Some`) then the
+    /// within-group member order (start_byte, end_byte, which the old per-group Vec preserved)
+    /// makes each group's rows arrive contiguously, so we flush a group the moment its key
+    /// changes and hold only the current group's members (kilobytes). Byte-identical: same
+    /// grouping, same `logical_symbols` insert order (ids are content-derived via `stable_id`,
+    /// not rowids), and the same member order.
+    ///
+    /// Read RAW `main.files` (ALL of the active repo's scopes), NOT the per-connection `files`
+    /// scope VIEW. logical_symbols is per-repo but scope-INDEPENDENT within a repo; building it
+    /// must not depend on whichever commit/worktree scope happens to be active. When this runs
+    /// in a worktree-overlay context (a scope view IS installed), an unqualified `files`
+    /// resolves to the scoped temp view, so the DELETE + repopulate would WIPE every other
+    /// scope's grouping (base + sibling worktrees) and restore only the active scope's —
+    /// persistently breaking `sym_<hex>`-handle graph nav for base symbols (the #219 review
+    /// finding). Filtering `main.files.repo_id` (A3) keeps every symbol in every live scope OF
+    /// THIS REPO while excluding a sibling repo's rows in a consolidated DB; the
+    /// content-derived `stable_id` collapses cross-scope duplicates into one logical symbol
+    /// with per-scope members, and downstream reads stay scope-filtered via the `files` view.
+    /// This is also why the #826 path-scoped re-derive can run under an OVERLAY scope view and
+    /// still regroup a changed path across ALL its scopes.
+    ///
+    /// Filter `main.files.generation` to the ACTIVE generation (A6): a full rebuild leaves the
+    /// superseded generation's file rows in place (swept lazily by gc), so a bare `repo_id`
+    /// predicate would fold BOTH the dead and the live generation's symbols into one grouping.
+    /// `self.active_generation` is the WRITE generation on the rebuild connection — which the
+    /// rebuild flips to LIVE and carries forward every live overlay onto BEFORE this runs, so
+    /// filtering it folds the base scope + every carried-forward overlay of the live generation
+    /// and nothing dead. On an incremental pass it is the live generation, unchanged behavior.
+    fn regroup_logical_symbols(
+        &self,
+        conn: &rusqlite::Connection,
+        extra_where: &str,
+    ) -> anyhow::Result<()> {
+        let mut stmt = conn.prepare(&format!(
             "
             SELECT symbols.id, main.files.path, symbols.language, symbols.name,
                    qn.value, symbols.kind, symbols.signature, symbols.start_line,
@@ -729,11 +769,11 @@ impl IndexDatabase {
             FROM main.symbols AS symbols
             JOIN main.files ON main.files.id = symbols.file_id
             LEFT JOIN main.name_strings qn ON qn.id = symbols.qualified_name_id
-            WHERE main.files.repo_id = ?1 AND main.files.generation = ?2
+            WHERE main.files.repo_id = ?1 AND main.files.generation = ?2{extra_where}
             ORDER BY symbols.language, main.files.path, symbols.name, qn.value,
                      symbols.kind, symbols.signature, symbols.start_byte, symbols.end_byte
-            ",
-        )?;
+            "
+        ))?;
         let mut rows = stmt.query(params![self.active_repo_id, self.active_generation])?;
         let mut current: Option<(LogicalSymbolKey, Vec<LogicalSymbolMemberRow>)> = None;
         while let Some(row) = rows.next()? {
@@ -772,24 +812,53 @@ impl IndexDatabase {
         if let Some((key, members)) = current.take() {
             Self::insert_logical_group(conn, &self.active_repo_id, &key, &members)?;
         }
-        if let Some(snapshot) = drift_snapshot {
-            self.heal_logical_key_drift(&snapshot)?;
-            if matches!(stamp, KeyVersionStamp::FullRederive) {
-                self.set_repo_meta(LOGICAL_KEY_VERSION_KEY, LOGICAL_KEY_VERSION)?;
-            }
-        }
-        // ANY successful rebuild satisfies a pending batch-deferred obligation (#819) — the batch
-        // tail, an inline overlay refresh, a heal, an incremental or full pass — so clear the
-        // marker here, in the same transaction as the rebuild it accounts for. Left set, the next
-        // maintenance pass would pay a second wholesale rebuild for nothing (e.g. after an
-        // interrupted deferred batch whose stale grouping a standalone `index --worktree` already
-        // repaired inline). A no-op DELETE when no marker is set.
-        rag_rat_db::meta::delete_repo_meta(
-            conn,
-            &self.active_repo_id,
-            super::worktree_overlay::OVERLAY_LOGICAL_REBUILD_PENDING_META,
-        )?;
         Ok(())
+    }
+
+    /// #826: re-derive ONLY the `logical_symbols` of the paths staged in `temp.logical_rederive_paths`
+    /// (the files this pass rewrote / removed / healed), instead of the whole repo. A logical
+    /// symbol is confined to ONE path (`path` is a key field, folded into `stable_id`), so a
+    /// changed file only affects its own path's groups; every other path's rows are left
+    /// byte-identical. The DELETE (members first, then their parents — mirroring
+    /// [`Self::rebuild_logical_symbols`] rather than leaning on the cascade) clears the changed
+    /// paths' rows, incl. any orphaned by the pass's symbol removals; the regroup re-derives
+    /// them from current symbols across ALL of each path's scopes (raw `main.files`). NO #493
+    /// drift heal and NO #819 marker clear — the caller gates on
+    /// [`Self::can_scope_logical_rederive`], which is false whenever either is owed.
+    pub(super) fn rederive_changed_logical_symbols(&self) -> anyhow::Result<()> {
+        let conn = self.storage.connection();
+        conn.execute(
+            "DELETE FROM main.logical_symbol_members
+             WHERE logical_symbol_id IN (
+                 SELECT id FROM main.logical_symbols
+                 WHERE repo_id = ?1 AND path IN (SELECT path FROM temp.logical_rederive_paths)
+             )",
+            params![self.active_repo_id],
+        )?;
+        conn.execute(
+            "DELETE FROM main.logical_symbols
+             WHERE repo_id = ?1 AND path IN (SELECT path FROM temp.logical_rederive_paths)",
+            params![self.active_repo_id],
+        )?;
+        self.regroup_logical_symbols(
+            conn,
+            " AND main.files.path IN (SELECT path FROM temp.logical_rederive_paths)",
+        )
+    }
+
+    /// #826: whether the pass may replace the whole-repo [`Self::rebuild_logical_symbols`] with the
+    /// path-scoped [`Self::rederive_changed_logical_symbols`]. False when a #493 drift heal is owed
+    /// (the logical-key version stamp lags — the heal is a cross-file reference remap the scoped
+    /// path does NOT perform) or a #819 deferred whole-repo rebuild is pending (a scoped
+    /// re-derive would not satisfy it, and `rebuild_logical_symbols` is the sole clearer of
+    /// that marker). Two `repo_meta` reads.
+    pub(super) fn can_scope_logical_rederive(&self) -> anyhow::Result<bool> {
+        let version_current =
+            self.repo_meta(LOGICAL_KEY_VERSION_KEY)?.as_deref() == Some(LOGICAL_KEY_VERSION);
+        let rebuild_pending = self
+            .repo_meta(super::worktree_overlay::OVERLAY_LOGICAL_REBUILD_PENDING_META)?
+            .is_some();
+        Ok(version_current && !rebuild_pending)
     }
 
     /// Open the per-batch logical-grouping verdict (#820). Starts on the relink path unless the

--- a/crates/rag-rat-core/src/index/incremental.rs
+++ b/crates/rag-rat-core/src/index/incremental.rs
@@ -318,6 +318,10 @@ impl IndexDatabase {
             // unconditionally only writes the `temp` schema, so it costs an idle pass
             // nothing on the main DB (#63).
             db.begin_scoped_edge_rewrite()?;
+            // #826: likewise arm scoped LOGICAL re-derive capture — `remove_file_in_scope` and the
+            // incremental file insert stage the changed PATHS, so the logical-symbol rebuild below
+            // can re-derive only those paths' groups instead of the whole repo.
+            db.begin_scoped_logical_rederive()?;
             // Write meta only when it actually changed, and track whether this pass mutated
             // anything at all. A periodic sweep or a spurious event over an unchanged
             // tree must NOT churn the WAL with a timestamp-only write + COMMIT (issue
@@ -413,10 +417,22 @@ impl IndexDatabase {
                     Some(relinks) => db.apply_logical_member_relinks(&relinks)?,
                     None => {
                         progress(IndexProgress::RebuildingLogicalSymbols);
-                        // Defer: this pass re-parsed only the CHANGED files, so it must not
-                        // stamp the logical-key version — untouched files' drift is still in
-                        // the future (#493).
-                        db.rebuild_logical_symbols(graph_index::KeyVersionStamp::Defer)?;
+                        // #826: re-derive ONLY the changed paths' logical groups (staged in
+                        // `temp.logical_rederive_paths`) instead of the whole repo, UNLESS a #493
+                        // drift heal (key-version lag) or a #819 deferred whole-repo rebuild is
+                        // owed — both of which the scoped path cannot
+                        // serve, so they keep the full rebuild.
+                        // A carry / roots-change reaches here (their guard above excludes the
+                        // relink) but does not move any grouping, so its
+                        // captured set is empty and the scoped re-derive is
+                        // a correct no-op; a heal's removed paths ARE captured (via
+                        // `remove_file_in_scope`), so they regroup. Defer: a partial pass must not
+                        // stamp the logical-key version — untouched files' drift is still future.
+                        if db.can_scope_logical_rederive()? {
+                            db.rederive_changed_logical_symbols()?;
+                        } else {
+                            db.rebuild_logical_symbols(graph_index::KeyVersionStamp::Defer)?;
+                        }
                     },
                 }
                 progress(IndexProgress::ResolvingGraph);
@@ -445,6 +461,9 @@ impl IndexDatabase {
             // the resolve branch was entered, so an idle or non-narrowed pass leaves
             // the flag clean.
             db.finish_scoped_edge_rewrite();
+            // #826: disarm scoped logical re-derive capture (staged paths consumed above; the next
+            // pass's `begin_scoped_logical_rederive` clears them).
+            db.finish_scoped_logical_rederive();
             if mutated {
                 db.set_repo_meta("indexed_at_ms", &now_ms().to_string())?;
                 db.storage.execute_batch("COMMIT")?;

--- a/crates/rag-rat-core/src/index/lifecycle.rs
+++ b/crates/rag-rat-core/src/index/lifecycle.rs
@@ -179,6 +179,7 @@ impl IndexDatabase {
             _identity_lock: None,
             drift_snapshot: std::sync::Mutex::new(None),
             edge_rewrite_capture: std::sync::atomic::AtomicBool::new(false),
+            logical_rederive_capture: std::sync::atomic::AtomicBool::new(false),
             #[cfg(test)]
             logical_symbol_rebuilds: std::sync::atomic::AtomicUsize::new(0),
         };
@@ -205,6 +206,7 @@ impl IndexDatabase {
             _identity_lock: None,
             drift_snapshot: std::sync::Mutex::new(None),
             edge_rewrite_capture: std::sync::atomic::AtomicBool::new(false),
+            logical_rederive_capture: std::sync::atomic::AtomicBool::new(false),
             #[cfg(test)]
             logical_symbol_rebuilds: std::sync::atomic::AtomicUsize::new(0),
         };
@@ -385,6 +387,7 @@ impl IndexDatabase {
             _identity_lock: None,
             drift_snapshot: std::sync::Mutex::new(None),
             edge_rewrite_capture: std::sync::atomic::AtomicBool::new(false),
+            logical_rederive_capture: std::sync::atomic::AtomicBool::new(false),
             #[cfg(test)]
             logical_symbol_rebuilds: std::sync::atomic::AtomicUsize::new(0),
         };
@@ -548,6 +551,7 @@ impl IndexDatabase {
             _identity_lock: None,
             drift_snapshot: std::sync::Mutex::new(None),
             edge_rewrite_capture: std::sync::atomic::AtomicBool::new(false),
+            logical_rederive_capture: std::sync::atomic::AtomicBool::new(false),
             #[cfg(test)]
             logical_symbol_rebuilds: std::sync::atomic::AtomicUsize::new(0),
         })

--- a/crates/rag-rat-core/src/index/mod.rs
+++ b/crates/rag-rat-core/src/index/mod.rs
@@ -187,6 +187,16 @@ pub struct IndexDatabase {
     /// mutability. `Relaxed` is sufficient: capture and resolve run on one connection/thread
     /// within the pass, never a cross-thread handoff.
     edge_rewrite_capture: AtomicBool,
+    /// #826: when armed, the pass captures the PATHS whose symbols it rewrote / removed / healed into
+    /// `temp.logical_rederive_paths`, so `rederive_changed_logical_symbols` re-derives only those
+    /// paths' `logical_symbols` groups instead of the whole repo. Armed by
+    /// `begin_scoped_logical_rederive` for the base incremental pass AND the linked-worktree
+    /// overlay finalize; the capture seams (`remove_file_in_scope`, the incremental file
+    /// insert) take `&self`. A SEPARATE flag from `edge_rewrite_capture` (not a shared one)
+    /// because #827's edge narrowing does NOT run in the overlay pass — arming a shared flag
+    /// there would pointlessly stage `temp.edge_rewrite_files`. `Relaxed` for the same
+    /// single-thread reason as #827.
+    logical_rederive_capture: AtomicBool,
     /// Test-only #819 observability: how many times [`Self::rebuild_logical_symbols`] ran on this
     /// connection, so batch tests can assert the once-per-pass rebuild cardinality.
     #[cfg(test)]

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_overlay.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_overlay.rs
@@ -2292,8 +2292,10 @@ fn a_key_stable_relink_leaves_a_pending_obligation_for_the_tail() {
 fn a_body_only_base_edit_pass_relinks_without_a_rebuild() {
     // #820 on the BASE incremental writer: the second body-only edit of an already-dirty file
     // replaces the same scope row under an identical key multiset, so the pass's tail re-links
-    // members instead of rebuilding. (The FIRST dirty edit moves the file into the worktree
-    // scope — a key-set change for that scope — and correctly pays the rebuild.)
+    // members instead of rebuilding. (The FIRST dirty edit moves the file into the worktree scope —
+    // a key-set change for that scope — which #826 now serves with a PATH-SCOPED re-derive rather
+    // than the whole-repo rebuild; either way the second edit relinks, and both outputs are the
+    // wholesale rebuild's fixed point.)
     let main = unique_temp_root();
     let _ = fs::remove_dir_all(&main);
     fs::create_dir_all(main.join("src")).unwrap();
@@ -2305,12 +2307,21 @@ fn a_body_only_base_edit_pass_relinks_without_a_rebuild() {
     let db = IndexDatabase::rebuild(&config).unwrap();
     drop(db);
 
-    // First dirty edit: the file enters the worktree overlay scope (an ADD there) — rebuild.
+    // First dirty edit: the file enters the worktree overlay scope (an ADD there — a key-set
+    // change). #826 serves it with the path-scoped re-derive, so the pass runs ZERO whole-repo
+    // rebuilds; the resulting grouping is still correct (the relink fixed point below builds on
+    // it).
     fs::write(main.join("src/a.rs"), "pub fn base_fn() -> i32 {\n    2\n}\n").unwrap();
     let first = IndexDatabase::index_paths(&config, &[main.join("src/a.rs")]).unwrap();
+    assert_eq!(
+        first.logical_symbol_rebuilds.load(std::sync::atomic::Ordering::Relaxed),
+        0,
+        "#826: the scope move is a key-set change served by the path-scoped re-derive, not a \
+         whole-repo rebuild"
+    );
     assert!(
-        first.logical_symbol_rebuilds.load(std::sync::atomic::Ordering::Relaxed) >= 1,
-        "the scope move is a key-set change and pays the rebuild"
+        logical_symbol_named(&first, "base_fn"),
+        "the scoped re-derive grouped the overlay add"
     );
     drop(first);
 
@@ -2769,4 +2780,246 @@ fn a_dirty_gitignore_edit_forces_the_full_diff_on_matching_heads() {
 
     let _ = fs::remove_dir_all(&main);
     let _ = fs::remove_dir_all(&linked);
+}
+
+/// #826: adding a function changes a file's logical-key set (a non-#820-relink change) — which used
+/// to pay the whole-repo `rebuild_logical_symbols` on every incremental pass. It now re-derives
+/// ONLY the changed path's groups. Observable: the base incremental pass runs ZERO whole-repo
+/// logical rebuilds, yet the grouping is the wholesale rebuild's FIXED POINT (byte-identical rows,
+/// ids, variant counts, member spans and hashes).
+#[test]
+fn a_key_set_change_scopes_the_logical_rederive_to_changed_paths() {
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(main.join("src/a.rs"), "pub fn a_one() {}\n").unwrap();
+    fs::write(main.join("src/b.rs"), "pub fn b_one() {}\npub fn b_two() {}\n").unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let config = source_config(main.clone(), Language::Rust);
+    drop(IndexDatabase::rebuild(&config).unwrap());
+
+    // Add a function to a.rs (dirty, uncommitted) — a key-set change routes to the rebuild branch.
+    fs::write(main.join("src/a.rs"), "pub fn a_one() {}\npub fn a_two() {}\n").unwrap();
+    let db = IndexDatabase::index_changed(&config).unwrap();
+
+    assert_eq!(
+        db.logical_symbol_rebuilds.load(std::sync::atomic::Ordering::Relaxed),
+        0,
+        "a scoped re-derive runs ZERO whole-repo logical rebuilds"
+    );
+    assert!(logical_symbol_named(&db, "a_two"), "the added function is grouped");
+    assert!(logical_symbol_named(&db, "b_one"), "the unchanged file's grouping is intact");
+
+    // The scoped output is the wholesale rebuild's FIXED POINT — forcing the rebuild changes
+    // nothing.
+    let scoped = logical_grouping_snapshot(&db);
+    db.rebuild_logical_symbols(crate::index::graph_index::KeyVersionStamp::Defer).unwrap();
+    assert_eq!(
+        logical_grouping_snapshot(&db),
+        scoped,
+        "the scoped re-derive output must equal the whole-repo rebuild's output"
+    );
+
+    let _ = fs::remove_dir_all(&main);
+}
+
+/// #826 (the fast path must disagree with the fallback): POISON an UNCHANGED file's grouping row with
+/// a wrong `variant_count`. A scoped re-derive editing a DIFFERENT file must leave the poison
+/// intact — a whole-repo rebuild would correct it, so its survival proves the scoped pass never
+/// re-derived the unchanged path (i.e. work scales with changed files, not repo size).
+#[test]
+fn the_scoped_logical_rederive_leaves_unchanged_paths_untouched() {
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(main.join("src/a.rs"), "pub fn a_one() {}\n").unwrap();
+    fs::write(main.join("src/b.rs"), "pub fn b_one() {}\npub fn b_two() {}\n").unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let config = source_config(main.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let repo_id = db.active_repo_id.clone();
+    // Poison b.rs's grouping rows — each b_* function is its own group with variant_count 1.
+    db.storage
+        .connection()
+        .execute(
+            "UPDATE main.logical_symbols SET variant_count = 999 WHERE repo_id = ?1 AND path = ?2",
+            rusqlite::params![repo_id, "src/b.rs"],
+        )
+        .unwrap();
+    drop(db);
+
+    fs::write(main.join("src/a.rs"), "pub fn a_one() {}\npub fn a_two() {}\n").unwrap();
+    let db = IndexDatabase::index_changed(&config).unwrap();
+    assert_eq!(
+        db.logical_symbol_rebuilds.load(std::sync::atomic::Ordering::Relaxed),
+        0,
+        "the pass took the scoped re-derive, not a whole-repo rebuild"
+    );
+
+    let poisoned: i64 = db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT variant_count FROM main.logical_symbols WHERE repo_id = ?1 AND path = ?2 \
+             LIMIT 1",
+            rusqlite::params![repo_id, "src/b.rs"],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        poisoned, 999,
+        "the UNCHANGED file's poisoned grouping row survives — the scoped pass never touched b.rs"
+    );
+    assert!(logical_symbol_named(&db, "a_two"), "the edited file WAS regrouped");
+
+    // A whole-repo rebuild DOES correct the poison — proving it was live and fixable, so the scoped
+    // pass's decision to skip b.rs is what preserved it.
+    db.rebuild_logical_symbols(crate::index::graph_index::KeyVersionStamp::Defer).unwrap();
+    let corrected: i64 = db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT variant_count FROM main.logical_symbols WHERE repo_id = ?1 AND path = ?2 \
+             LIMIT 1",
+            rusqlite::params![repo_id, "src/b.rs"],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(corrected, 1, "a whole-repo rebuild corrects the poisoned variant_count");
+
+    let _ = fs::remove_dir_all(&main);
+}
+
+/// #826 over the OVERLAY finalize (Inline): a key-set change on a LINKED WORKTREE re-derives only
+/// that worktree's changed paths' groups, not the whole repo. ZERO whole-repo rebuilds, and the
+/// grouping is the wholesale rebuild's fixed point — the scoped re-derive regroups the changed path
+/// across ALL its scopes (raw `main.files`), so base + overlay members stay correct.
+#[test]
+fn a_linked_worktree_overlay_scopes_the_logical_rederive() {
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(main.join("src/a.rs"), "pub fn base_fn() {}\n").unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let config = source_config(main.clone(), Language::Rust);
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    fs::write(linked.join("src/one.rs"), "pub fn one_fn() -> i32 {\n    1\n}\n").unwrap();
+    run_git(&linked, &["add", "."]);
+    run_git(&linked, &["commit", "-q", "-m", "branch adds one_fn"]);
+    db.index_worktree_overlay(&config, &linked, &mut |_| {}).unwrap();
+    assert!(logical_symbol_named(&db, "one_fn"), "the added overlay file is grouped");
+
+    // A KEY-SET change on the linked worktree (add two_fn to one.rs, uncommitted → dirty overlay).
+    fs::write(
+        linked.join("src/one.rs"),
+        "pub fn one_fn() -> i32 {\n    1\n}\npub fn two_fn() {}\n",
+    )
+    .unwrap();
+    let before = db.logical_symbol_rebuilds.load(std::sync::atomic::Ordering::Relaxed);
+    db.index_worktree_overlay(&config, &linked, &mut |_| {}).unwrap();
+    assert_eq!(
+        db.logical_symbol_rebuilds.load(std::sync::atomic::Ordering::Relaxed) - before,
+        0,
+        "the overlay finalize's scoped re-derive runs ZERO whole-repo rebuilds"
+    );
+    assert!(logical_symbol_named(&db, "two_fn"), "the added overlay function is grouped");
+
+    let scoped = logical_grouping_snapshot(&db);
+    db.rebuild_logical_symbols(crate::index::graph_index::KeyVersionStamp::Defer).unwrap();
+    assert_eq!(
+        logical_grouping_snapshot(&db),
+        scoped,
+        "the scoped overlay re-derive output must equal the whole-repo rebuild's output"
+    );
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}
+
+/// #826 gate: a lagging `logical_key_version` owes the #493 drift heal, which ONLY the whole-repo
+/// `rebuild_logical_symbols` performs. The scoped re-derive must NOT be used — the pass keeps the
+/// full rebuild.
+#[test]
+fn a_stale_logical_key_version_keeps_the_whole_repo_rebuild() {
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(main.join("src/a.rs"), "pub fn a_one() {}\n").unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let config = source_config(main.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    // Force a version lag exactly as the #493 drift-heal tests do.
+    db.storage
+        .connection()
+        .execute("DELETE FROM repo_meta WHERE key = 'logical_key_version'", [])
+        .unwrap();
+    drop(db);
+
+    fs::write(main.join("src/a.rs"), "pub fn a_one() {}\npub fn a_two() {}\n").unwrap();
+    let db = IndexDatabase::index_changed(&config).unwrap();
+    assert!(
+        db.logical_symbol_rebuilds.load(std::sync::atomic::Ordering::Relaxed) >= 1,
+        "a lagging logical_key_version keeps the whole-repo rebuild (for the #493 drift heal), \
+         never the scoped re-derive"
+    );
+    assert!(logical_symbol_named(&db, "a_two"), "the edit is still grouped");
+
+    let _ = fs::remove_dir_all(&main);
+}
+
+/// #826: the scoped re-derive DROPS a group whose symbol is gone from every live scope. Adding a
+/// function to a dirty file then removing it leaves that function in NO scope (it was never
+/// committed), so the scoped DELETE + regroup must drop its `logical_symbols` row — with ZERO
+/// whole-repo rebuilds. (A single dirty deletion of a COMMITTED symbol is deliberately NOT tested
+/// here: `logical_symbols` is scope-independent, so the committed symbol's group correctly survives
+/// until the deletion is committed — the same for a scoped re-derive and a whole-repo rebuild.)
+#[test]
+fn the_scoped_rederive_drops_a_removed_symbols_group() {
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(main.join("src/a.rs"), "pub fn a_one() {}\n").unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let config = source_config(main.clone(), Language::Rust);
+    drop(IndexDatabase::rebuild(&config).unwrap());
+
+    // Add a_two (dirty overlay) — a_two now exists ONLY in the overlay scope.
+    fs::write(main.join("src/a.rs"), "pub fn a_one() {}\npub fn a_two() {}\n").unwrap();
+    let db = IndexDatabase::index_changed(&config).unwrap();
+    assert!(logical_symbol_named(&db, "a_two"), "the added overlay symbol is grouped");
+    drop(db);
+
+    // Remove a_two again (the `// edited` line keeps a.rs DIRTY vs the commit, so this stays a
+    // scoped dirty re-index rather than a stale-overlay heal). a_two is now gone from EVERY live
+    // scope — it was only ever in the overlay.
+    fs::write(main.join("src/a.rs"), "// edited\npub fn a_one() {}\n").unwrap();
+    let db = IndexDatabase::index_changed(&config).unwrap();
+    assert_eq!(
+        db.logical_symbol_rebuilds.load(std::sync::atomic::Ordering::Relaxed),
+        0,
+        "dropping a symbol takes the scoped re-derive, not a whole-repo rebuild"
+    );
+    assert!(!logical_symbol_named(&db, "a_two"), "the removed symbol's group is dropped");
+    assert!(logical_symbol_named(&db, "a_one"), "the surviving symbol's group is intact");
+
+    // Byte-identity: the drop leaves exactly what a whole-repo rebuild would.
+    let scoped = logical_grouping_snapshot(&db);
+    db.rebuild_logical_symbols(crate::index::graph_index::KeyVersionStamp::Defer).unwrap();
+    assert_eq!(logical_grouping_snapshot(&db), scoped, "the drop equals the whole-repo rebuild");
+
+    let _ = fs::remove_dir_all(&main);
 }

--- a/crates/rag-rat-core/src/index/worktree_overlay.rs
+++ b/crates/rag-rat-core/src/index/worktree_overlay.rs
@@ -735,6 +735,15 @@ impl IndexDatabase {
         // any error (#219 review).
         self.storage.execute_batch("BEGIN IMMEDIATE")?;
         let result = (|| -> anyhow::Result<(usize, usize, usize)> {
+            // #826: arm scoped logical re-derive capture — the overlay's file removals / inserts
+            // below stage the worktree's changed PATHS so `finalize_overlay_refresh`'s Inline case
+            // can re-derive only those paths' logical groups instead of the whole repo. Armed (and
+            // cleared) here — INSIDE the guarded closure so a temp-table create/clear failure rolls
+            // the transaction back rather than stranding it open on this reusable `&mut self` (the
+            // next refresh would then fail "cannot start a transaction within a transaction"). A
+            // batch's next worktree starts fresh; the Deferred (batch) case ignores the staged
+            // paths and settles via one whole-repo rebuild at the batch tail.
+            self.begin_scoped_logical_rederive()?;
             let applied = self.index_explicit_paths_from_root(
                 config,
                 &source_root,
@@ -777,6 +786,10 @@ impl IndexDatabase {
             self.apply_overlay_basis_tail(&worktree_id, delta.status_complete, tail.basis)?;
             Ok((indexed, tombstoned, pruned))
         })();
+        // #826: disarm scoped logical re-derive capture on BOTH Ok and Err paths — this pass's
+        // `&mut self` outlives an error return, so the flag must not leak into the caller's next
+        // use.
+        self.finish_scoped_logical_rederive();
         let (indexed, tombstoned, pruned) = match result {
             Ok(counts) => {
                 self.storage.execute_batch("COMMIT")?;
@@ -912,6 +925,15 @@ impl IndexDatabase {
         // front; ROLLBACK on any error.
         self.storage.execute_batch("BEGIN IMMEDIATE")?;
         let result = (|| -> anyhow::Result<(usize, usize, usize)> {
+            // #826: arm scoped logical re-derive capture — the overlay's file removals / inserts
+            // below stage the worktree's changed PATHS so `finalize_overlay_refresh`'s Inline case
+            // can re-derive only those paths' logical groups instead of the whole repo. Armed (and
+            // cleared) here — INSIDE the guarded closure so a temp-table create/clear failure rolls
+            // the transaction back rather than stranding it open on this reusable `&mut self` (the
+            // next refresh would then fail "cannot start a transaction within a transaction"). A
+            // batch's next worktree starts fresh; the Deferred (batch) case ignores the staged
+            // paths and settles via one whole-repo rebuild at the batch tail.
+            self.begin_scoped_logical_rederive()?;
             let applied = self.index_explicit_paths_from_root(
                 config,
                 &source_root,
@@ -961,6 +983,10 @@ impl IndexDatabase {
             )?;
             Ok((indexed, tombstoned, pruned))
         })();
+        // #826: disarm scoped logical re-derive capture on BOTH Ok and Err paths — this pass's
+        // `&mut self` outlives an error return, so the flag must not leak into the caller's next
+        // use.
+        self.finish_scoped_logical_rederive();
         let (indexed, tombstoned, pruned) = match result {
             Ok(counts) => {
                 self.storage.execute_batch("COMMIT")?;
@@ -1171,10 +1197,22 @@ impl IndexDatabase {
                 },
                 graph_index::LogicalGroupingUpkeep::RebuildRequired => match logical_rebuild {
                     OverlayLogicalRebuild::Inline => {
-                        // Defer the STAMP: an overlay refresh re-parsed only the worktree's own
-                        // files, so it must not stamp the logical-key version — the base scope's
-                        // drift is still in the future (#493).
-                        self.rebuild_logical_symbols(graph_index::KeyVersionStamp::Defer)?;
+                        // #826: re-derive ONLY this worktree's changed paths' logical groups
+                        // (staged into `temp.logical_rederive_paths` by the
+                        // overlay apply above) instead of the whole repo —
+                        // UNLESS a #493 drift heal or a #819 deferred rebuild is
+                        // owed, which the scoped path cannot serve. The re-derive reads raw
+                        // `main.files`, so under this overlay scope view it still regroups each
+                        // changed path across ALL its scopes (base + every worktree). Defer the
+                        // STAMP regardless: an overlay refresh re-parsed
+                        // only the worktree's own files, so it must not
+                        // stamp the logical-key version — the base scope's drift is still
+                        // in the future (#493).
+                        if self.can_scope_logical_rederive()? {
+                            self.rederive_changed_logical_symbols()?;
+                        } else {
+                            self.rebuild_logical_symbols(graph_index::KeyVersionStamp::Defer)?;
+                        }
                     },
                     OverlayLogicalRebuild::Deferred => {
                         // Mark the repo-global rebuild pending IN THIS transaction (#819).


### PR DESCRIPTION
## Problem
`rebuild_logical_symbols` cleared and re-derived a repo's **entire** logical-symbol table on every content-changed base pass and every changed-overlay finalize — an 8-column external sort over all symbols plus a full table rewrite — even for a one-file delta. It's the largest maintenance-pass writer.

## Change
A logical symbol is confined to **one path** (`path` is a key field, folded into the content-derived `stable_id`), so a changed file only affects its own path's groups. Re-derive only the paths this pass rewrote / removed / healed (staged in `temp.logical_rederive_paths`): delete their `logical_symbols` (members first), then regroup them via the **same** streaming grouper the whole-repo rebuild uses — extracted into a shared `regroup_logical_symbols` helper. The regroup reads raw `main.files`, so it regroups each changed path across **all** its scopes (base + every worktree overlay).

Applies to the base incremental pass **and** the linked-worktree overlay finalize (Inline). Capture rides a dedicated `logical_rederive_capture` flag, separate from #827's edge-rewrite capture.

## Safety
- Gated by `can_scope_logical_rederive`: a lagging `logical_key_version` (the #493 drift heal is a cross-file reference remap the scoped path can't do) or a pending #819 deferred-rebuild marker keeps the whole-repo rebuild.
- A carry / package-map change doesn't move any grouping → empty captured set → correct no-op; a heal's removed paths **are** captured.
- The scoped output is the wholesale rebuild's **fixed point** (byte-identical), so a miss can only be an under-scope — eventually-consistent staleness a later full pass corrects — never corruption (same posture as #827).

## Measured (dogfood index: 15,665 logical symbols, 83,127 members)
A full rebuild rewrites all of them; a scoped pass re-derives a **median of 21** groups per file (**~745× fewer**) and sorts only the changed path's symbols, not the whole corpus.

## Verification
- Byte-identity fixed-point: after a scoped key-set change (base **and** linked-worktree overlay), forcing a whole-repo rebuild changes nothing.
- Poison test: an unchanged file's deliberately-corrupted grouping row survives a scoped pass (proving work scales with changed files, not repo size) and is corrected by a forced full rebuild.
- Drop test: a symbol added to an overlay then removed is dropped from the grouping via the scoped path.
- Drift-heal gate: a stale `logical_key_version` keeps the whole-repo rebuild.
- Full `rag-rat-core` suite green (1537 default / 1535 `--no-default-features`, both CI runners) — every incremental and overlay test now routes through the scoped re-derive; clippy (both feature sets, `-D warnings`) and nightly rustfmt clean. One pre-existing #820 test that asserted the first dirty edit *rebuilds* was updated to reflect the scoped re-derive (its fixed-point + member-count checks unchanged).

Fixes #826.
