### PR TITLE
feat(sync): table→log sync engine — whole-row LWW, transport-independent (#893)

### DIFF
--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/content_digest.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/content_digest.rs
@@ -72,11 +72,11 @@ const FOLD_TRIGGERS: [&str; 3] =
 
 // ---- schema tip + trigger contract ----
 
-/// The absolute schema-tip pin lives on the newest migration's test (moved here from V085). V086
-/// creates `content_digest_state` (seeded empty on a fresh ladder) and the three fold triggers.
+/// V086 creates `content_digest_state` (seeded empty on a fresh ladder) and the three fold
+/// triggers. The absolute schema-tip pin has moved forward to the newest migration's test
+/// (V087, `migration_087_is_the_tip_and_adds_table_sync_tables`).
 #[test]
-fn content_digest_state_is_the_tip_with_live_fold_triggers() {
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 86, "move this pin with the next schema migration");
+fn content_digest_state_has_live_fold_triggers() {
     let conn = apply_schema();
     assert_eq!(schema::status(&conn).unwrap().current_version, schema::LATEST_SCHEMA_VERSION);
 

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
@@ -3850,7 +3850,7 @@ fn migration_084_links_chunks_to_symbols() {
 
 /// V085 adds sync provenance (`origin`) to the read tables + edge tombstones (`present`) to the
 /// content-edge projection. The absolute schema-tip pin lives on the newest migration's test
-/// (V086, `content_digest_state_is_the_tip_with_live_fold_triggers`).
+/// (V087, `migration_087_is_the_tip_and_adds_table_sync_tables`).
 #[test]
 fn migration_085_adds_origin_and_edge_present() {
     // Bare pre-V085 tables (no origin / present), each with a pre-existing row, so the migration is
@@ -3925,4 +3925,61 @@ fn migration_085_adds_origin_and_edge_present() {
         )
         .unwrap();
     assert_eq!(recorded, 1, "the forward migration records V085");
+}
+
+/// V087 adds the table→log sync engine's bookkeeping tables, and is the schema tip.
+#[test]
+fn migration_087_is_the_tip_and_adds_table_sync_tables() {
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 87, "move this pin with the next schema migration");
+
+    let added =
+        ["table_sync_entries", "sync_published_rows", "sync_row_tombstones", "sync_row_clocks"];
+
+    // Absence asserted against the migration's OWN precondition (a bare connection), not the full
+    // ladder's end state — a fresh in-memory DB has none of these tables before the applier runs.
+    let bare = rusqlite::Connection::open_in_memory().unwrap();
+    for t in added {
+        assert!(!schema::table_exists(&bare, t).unwrap(), "pre-V087 has no {t}");
+    }
+
+    schema::apply_table_sync_tables(&bare).unwrap();
+
+    for t in added {
+        assert!(schema::table_exists(&bare, t).unwrap(), "V087 adds {t}");
+    }
+    // The applier is idempotent (CREATE TABLE IF NOT EXISTS) — a second run is a no-op, not an
+    // error.
+    schema::apply_table_sync_tables(&bare).unwrap();
+    // The whole-row LWW clock is keyed per row; a duplicate row key collides on the composite PK.
+    bare.execute(
+        "INSERT INTO sync_row_clocks(repo_id, table_name, row_pk, lamport, device_fingerprint) \
+         VALUES ('r', 't', 'pk', 1, 'dev')",
+        [],
+    )
+    .unwrap();
+    assert!(
+        bare.execute(
+            "INSERT INTO sync_row_clocks(repo_id, table_name, row_pk, lamport, \
+             device_fingerprint) VALUES ('r', 't', 'pk', 2, 'dev')",
+            [],
+        )
+        .is_err(),
+        "the row write clock has one row per (repo, table, row_pk)",
+    );
+
+    // The full ladder ends with the tables present and records V087.
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn, &crate::index::migration_hooks()).unwrap();
+    assert_eq!(schema::status(&conn).unwrap().current_version, schema::LATEST_SCHEMA_VERSION);
+    for t in added {
+        assert!(schema::table_exists(&conn, t).unwrap(), "the full ladder ends with {t}");
+    }
+    let recorded: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM schema_version WHERE id = '087_table_sync_bookkeeping'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(recorded, 1, "the forward migration records V087");
 }

--- a/crates/rag-rat-db/src/schema/migrations.rs
+++ b/crates/rag-rat-db/src/schema/migrations.rs
@@ -1372,6 +1372,7 @@ pub(crate) fn known_version(migrations: &[AppliedMigration]) -> u32 {
             MIGRATION_084_ID => Some(84),
             MIGRATION_085_ID => Some(85),
             MIGRATION_086_ID => Some(86),
+            MIGRATION_087_ID => Some(87),
             _ => None,
         })
         .max()
@@ -1467,6 +1468,7 @@ pub(crate) fn known_migration(id: &str) -> bool {
             | MIGRATION_084_ID
             | MIGRATION_085_ID
             | MIGRATION_086_ID
+            | MIGRATION_087_ID
             | DIRTY_MIGRATION_ID
     )
 }
@@ -1559,6 +1561,7 @@ pub(crate) fn migration_checksum_mismatch(migration: &AppliedMigration) -> bool 
         MIGRATION_084_ID => migration.checksum != MIGRATION_084_CHECKSUM,
         MIGRATION_085_ID => migration.checksum != MIGRATION_085_CHECKSUM,
         MIGRATION_086_ID => migration.checksum != MIGRATION_086_CHECKSUM,
+        MIGRATION_087_ID => migration.checksum != MIGRATION_087_CHECKSUM,
         _ => false,
     }
 }
@@ -6000,6 +6003,75 @@ pub fn apply_content_digest_state(conn: &Connection) -> rusqlite::Result<()> {
         params![new_digest, legacy_digest],
     )?;
 
+    tx.commit()
+}
+
+/// V087 — the table→log sync engine's bookkeeping tables (transport-independent).
+///
+/// The engine replicates derived/metadata rows as self-describing typed-CBOR ops on a signed
+/// per-scope stream, folded by WHOLE-ROW last-writer-wins. The side tables carry the state the fold
+/// and producer need; none holds authored content (that lives in the replicated tables themselves)
+/// — these are pure sync bookkeeping.
+///
+/// - `sync_published_rows` is the anti-echo record: the post-apply hash of a row's SYNCED columns.
+///   The producer skips a row whose current synced-hash already matches, so a remotely-applied row
+///   is never re-signed and rebroadcast (the echo-republish loop). Local re-resolution churn must
+///   never enter this hash, so it covers synced columns only.
+/// - `sync_row_tombstones` is the per-row deletion clock: a `Remove` records `(lamport,
+///   device_fingerprint)`, and a later `Upsert` older than it is suppressed (never resurrects a
+///   deleted row) while a newer one overrides it. Without it, out-of-order delivery would let a
+///   stale delete win and an even older insert resurrect.
+/// - `sync_row_clocks` is the per-row latest-write clock — the whole-row LWW authority. An `Upsert`
+///   wins the entire row, and a `Remove` deletes it, only when it beats this clock; the winner then
+///   raises it. So convergence and delete/insert ordering hold regardless of arrival order.
+/// - `table_sync_entries` is the engine's OWN signed hash-chained entry log — deliberately separate
+///   from `oplog_entries`, whose upgrade re-fold (`reproject_all_streams`) decodes every stored
+///   stream as a memory-content op and would choke on a table op. One chain per `(stream_id,
+///   device_fingerprint)`, `lamport` strictly increasing.
+///
+/// All STRICT; `CREATE TABLE IF NOT EXISTS` so the migration is idempotent; one IMMEDIATE txn.
+pub fn apply_table_sync_tables(conn: &Connection) -> rusqlite::Result<()> {
+    let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
+    tx.execute_batch(
+        "CREATE TABLE IF NOT EXISTS table_sync_entries(
+             entry_hash         BLOB    NOT NULL PRIMARY KEY,
+             stream_id          BLOB    NOT NULL,
+             device_fingerprint BLOB    NOT NULL,
+             lamport            INTEGER NOT NULL,
+             prev_hash          BLOB,
+             signed_bytes       BLOB    NOT NULL,
+             received_at_ms     INTEGER NOT NULL,
+             UNIQUE(stream_id, device_fingerprint, lamport)
+         ) STRICT;
+         -- Read the stream's Lamport tip (`MAX(lamport) WHERE stream_id = ?`, on every author and
+         -- accept) from an index tail instead of scanning the stream; the UNIQUE index above leads
+         -- with device_fingerprint, so it cannot answer a per-stream MAX.
+         CREATE INDEX IF NOT EXISTS table_sync_entries_stream_lamport
+             ON table_sync_entries(stream_id, lamport);
+         CREATE TABLE IF NOT EXISTS sync_published_rows(
+             repo_id     TEXT NOT NULL,
+             table_name  TEXT NOT NULL,
+             row_pk      TEXT NOT NULL,
+             synced_hash TEXT NOT NULL,
+             PRIMARY KEY(repo_id, table_name, row_pk)
+         ) STRICT;
+         CREATE TABLE IF NOT EXISTS sync_row_tombstones(
+             repo_id            TEXT    NOT NULL,
+             table_name         TEXT    NOT NULL,
+             row_pk             TEXT    NOT NULL,
+             lamport            INTEGER NOT NULL,
+             device_fingerprint TEXT    NOT NULL,
+             PRIMARY KEY(repo_id, table_name, row_pk)
+         ) STRICT;
+         CREATE TABLE IF NOT EXISTS sync_row_clocks(
+             repo_id            TEXT    NOT NULL,
+             table_name         TEXT    NOT NULL,
+             row_pk             TEXT    NOT NULL,
+             lamport            INTEGER NOT NULL,
+             device_fingerprint TEXT    NOT NULL,
+             PRIMARY KEY(repo_id, table_name, row_pk)
+         ) STRICT;",
+    )?;
     tx.commit()
 }
 

--- a/crates/rag-rat-db/src/schema/mod.rs
+++ b/crates/rag-rat-db/src/schema/mod.rs
@@ -24,7 +24,7 @@ pub use migrations::{
     apply_papertrail_distill_substrate, apply_papertrail_mirror_resume_state,
     apply_papertrail_provider_neutral_schema, apply_repo_id_core_scoping,
     apply_repo_id_periphery_scoping, apply_repos_registry, apply_scip_moniker_anchors,
-    apply_sync_origin_and_edge_tombstone,
+    apply_sync_origin_and_edge_tombstone, apply_table_sync_tables,
 };
 pub use migrations::{column_exists, rebuild_repo_memory_fts_with_repo_id, table_exists};
 pub use purge::{RepoRowCounts, count_repo_rows, purge_repo_rows, repo_scoped_table_names};
@@ -47,7 +47,7 @@ use serde::Serialize;
 
 use crate::hooks::MigrationHooks;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 86;
+pub const LATEST_SCHEMA_VERSION: u32 = 87;
 
 /// Every oracle-DERIVED persisted table — the outputs an `oracle run` writes that must OUTLIVE a
 /// reindex.
@@ -643,6 +643,18 @@ const MIGRATION_086_DESCRIPTION: &str =
      (index_meta fts_source_revision/content_revision, clone_graph_generations.source_revision, \
      the clone-graph quiet candidate) that equals the frozen legacy digest so no one-time \
      FTS/clone rebuild fires. Replaces the O(N) main.files scan with an O(1) state read";
+
+const MIGRATION_087_ID: &str = "087_table_sync_bookkeeping";
+const MIGRATION_087_CHECKSUM: &str = "sha256:rag-rat-table-sync-bookkeeping-v87";
+const MIGRATION_087_DESCRIPTION: &str =
+    "Add the table→log sync engine's bookkeeping tables: sync_published_rows (post-apply \
+     synced-column hash that stops a remotely-applied row being re-signed and rebroadcast — the \
+     anti-echo record), sync_row_clocks (the per-row whole-row last-writer-wins clock an upsert \
+     or delete must beat to win the row), sync_row_tombstones (a per-row deletion clock so an \
+     out-of-order stale delete cannot win and an even older insert cannot resurrect), and \
+     table_sync_entries (the engine's own signed hash-chained entry log, separate from \
+     oplog_entries so the memory-content re-fold never sees a table op). All STRICT; no authored \
+     content — pure sync bookkeeping the fold and producer read";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -1355,6 +1367,12 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         checksum: MIGRATION_086_CHECKSUM,
         description: MIGRATION_086_DESCRIPTION,
         apply: MigrationFn::Plain(apply_content_digest_state),
+    },
+    Migration {
+        id: MIGRATION_087_ID,
+        checksum: MIGRATION_087_CHECKSUM,
+        description: MIGRATION_087_DESCRIPTION,
+        apply: MigrationFn::Plain(apply_table_sync_tables),
     },
 ];
 

--- a/crates/rag-rat-oplog/src/entry.rs
+++ b/crates/rag-rat-oplog/src/entry.rs
@@ -127,11 +127,11 @@ pub(super) fn sign_entry(
     }
 }
 
-/// Sign a body over ARBITRARY op bytes (not `op::encode` of a known op) — the storage layer's
-/// poison guard and its unknown-op retention path need entries whose `op_bytes` are undecodable or
-/// decode to `Unknown`, which the typed [`sign_entry`] can't produce. Test-only; the production
-/// wire is untouched.
-#[cfg(test)]
+/// Sign a body over ARBITRARY op bytes (not `op::encode` of a known [`MemoryOp`]). The table-sync
+/// engine ([`super::table_sync`]) signs its row ops through this — their bytes are a different op
+/// vocabulary the typed [`sign_entry`] can't produce — and the storage layer's tests use it to
+/// forge undecodable / unknown `op_bytes`. The entry layer treats `op_bytes` as opaque, so the wire
+/// is unchanged whether the payload is a memory op or a table op.
 pub(super) fn sign_entry_from_op_bytes(
     secret: &DeviceSecret,
     stream_id: StreamId,

--- a/crates/rag-rat-oplog/src/lib.rs
+++ b/crates/rag-rat-oplog/src/lib.rs
@@ -61,6 +61,7 @@ mod op;
 mod project;
 mod store;
 mod stream;
+mod table_sync;
 
 // C1's curated authority seam for the C2 `/3` content envelope and candidate DAG. The account
 // implementation stays private; only typed ingest results and snapshot-consistent point queries

--- a/crates/rag-rat-oplog/src/table_sync/apply.rs
+++ b/crates/rag-rat-oplog/src/table_sync/apply.rs
@@ -1,0 +1,1288 @@
+//! The apply pipeline: fold one decoded row op into its table under WHOLE-ROW last-writer-wins.
+//!
+//! Each row carries one write clock (`sync_row_clocks`). An upsert wins the ENTIRE row iff its
+//! `(lamport, device_fingerprint)` beats that clock (higher lamport, ties broken by the smaller
+//! fingerprint) — the winner replaces the whole row atomically; a loser is a no-op.
+//! Insert-vs-update is decided by row existence, never a blind upsert. A cell whose value disagrees
+//! with its column's declared type quarantines the whole op (a broken producer, surfaced, not
+//! silently coerced); a cell for a column this binary's registry doesn't know is skipped (a newer
+//! producer, forward compatible). After a winning apply the row's synced-column hash is recorded,
+//! which is what stops the producer re-emitting a row it just received (see [`super::produce`]).
+//! Deletes and the resurrection guard use the same row clock plus a per-row tombstone; a losing op
+//! never touches the published hash, so an unsent local edit is never silently marked as sent.
+
+use rusqlite::types::Value as SqlValue;
+use rusqlite::{OptionalExtension, Transaction, params_from_iter};
+
+use super::registry::{TableSpec, ValueType};
+use super::row_op::{self, Cell, RowOp, TypedValue};
+use crate::op::OpMeta;
+
+/// The result of applying one row op. `Quarantined` means the op was structurally storable but its
+/// content is unprojectable (a type mismatch) — the entry is retained, the row is left untouched.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum ApplyOutcome {
+    Applied,
+    Quarantined(String),
+}
+
+/// Fold `op` into `spec`'s table for `repo_id`, ordered by `meta`. See the module doc for the merge
+/// rules. Every write goes through the caller's transaction, so a partially-applied op cannot leak.
+pub(crate) fn apply_row_op(
+    tx: &Transaction<'_>,
+    spec: &TableSpec,
+    repo_id: &str,
+    op: &RowOp,
+    meta: OpMeta,
+) -> anyhow::Result<ApplyOutcome> {
+    debug_assert_eq!(op.table(), spec.name, "caller resolves the spec from the op's table");
+    let pk_vals = op.pk();
+    if pk_vals.len() != spec.pk.len() {
+        return Ok(ApplyOutcome::Quarantined(format!(
+            "pk arity {} does not match `{}`'s {} identity columns",
+            pk_vals.len(),
+            spec.name,
+            spec.pk.len()
+        )));
+    }
+    // A NULL identity value is unaddressable: `WHERE pk = NULL` never matches, so upserts would
+    // insert duplicate unreachable rows and removes could never delete them. Reject the whole op.
+    if pk_vals.iter().any(|v| matches!(v, TypedValue::Null)) {
+        return Ok(ApplyOutcome::Quarantined(format!(
+            "a null primary-key value is not addressable on `{}`",
+            spec.name
+        )));
+    }
+    // Validate each pk value against its declared type before it reaches a WHERE clause. SQLite
+    // affinity would otherwise coerce a mismatched pk (e.g. `I64(1)` matching a TEXT key `'1'`)
+    // onto a different physical row than its type-exact `row_pk` clock identity, splitting the
+    // row's bookkeeping and allowing resurrection. (Arity is checked above, so `zip` covers
+    // every pk.)
+    for (column, value) in spec.pk.iter().zip(pk_vals) {
+        if !value_matches(value, column.value_type) {
+            return Ok(ApplyOutcome::Quarantined(format!(
+                "pk column `{}` value does not match its declared type on `{}`",
+                column.name, spec.name
+            )));
+        }
+    }
+    // Repo-identity gate: for a table scoped by a pk column, an op naming a different repo than the
+    // stream being synced is rejected — a peer cannot write another project's rows through this
+    // stream. (The producer already only emits the local repo's rows.)
+    if let Some(idx) = spec.repo_pk_index()
+        && pk_vals.get(idx) != Some(&TypedValue::Text(repo_id.to_string()))
+    {
+        return Ok(ApplyOutcome::Quarantined(format!(
+            "op names a different repo than the `{}` stream being synced",
+            spec.name
+        )));
+    }
+    match op {
+        RowOp::Remove { .. } => apply_remove(tx, spec, repo_id, pk_vals, meta),
+        RowOp::Upsert { cells, .. } => apply_upsert(tx, spec, repo_id, pk_vals, cells, meta),
+    }
+}
+
+/// Apply a delete. It wins unless the row's write clock is strictly newer than the delete (a
+/// concurrent later write keeps the row); either way it raises the row's tombstone so a later
+/// Upsert older than the delete cannot resurrect the row. Order-independent: a stale delete
+/// arriving after a newer write loses, and an even older insert arriving after the delete is
+/// suppressed by the tombstone.
+fn apply_remove(
+    tx: &Transaction<'_>,
+    spec: &TableSpec,
+    repo_id: &str,
+    pk_vals: &[TypedValue],
+    meta: OpMeta,
+) -> anyhow::Result<ApplyOutcome> {
+    let row_pk = &row_op::row_pk_string(pk_vals);
+    let device_hex = &meta.device.to_string();
+    let survives = match current_row_clock(tx, repo_id, spec.name, row_pk)? {
+        // A write strictly newer than the delete keeps the row alive.
+        Some((clock_lamport, clock_device)) =>
+            beats(clock_lamport, &clock_device, meta.lamport, device_hex),
+        // No recorded write — nothing can outrank the delete.
+        None => false,
+    };
+    if !survives {
+        // Attempt the physical delete BEFORE raising the tombstone. A constraint violation — an FK
+        // RESTRICT child row, an `ON DELETE RESTRICT`, a trigger abort — means the remove cannot
+        // apply; quarantine it (leaving the tombstone/clock untouched) so the already-stored entry
+        // is retained and the chain advances, instead of erroring and rolling back the entry (which
+        // would wedge every later entry on that device's chain as a permanent MissingPredecessor).
+        if let Err(err) = delete_row(tx, spec, pk_vals) {
+            if is_constraint_violation(&err) {
+                return Ok(ApplyOutcome::Quarantined(format!(
+                    "remove violates a column constraint on `{}`",
+                    spec.name
+                )));
+            }
+            return Err(err);
+        }
+        clear_row_clock(tx, repo_id, spec.name, row_pk)?;
+        clear_published(tx, repo_id, spec.name, row_pk)?;
+    }
+    // Raise the tombstone only once the remove has actually applied (the row was deleted, or a
+    // newer write kept it): the tombstone guards against an older upsert resurrecting the row.
+    raise_tombstone(tx, repo_id, spec.name, row_pk, meta.lamport, device_hex)?;
+    Ok(ApplyOutcome::Applied)
+}
+
+fn apply_upsert(
+    tx: &Transaction<'_>,
+    spec: &TableSpec,
+    repo_id: &str,
+    pk_vals: &[TypedValue],
+    cells: &[Cell],
+    meta: OpMeta,
+) -> anyhow::Result<ApplyOutcome> {
+    let row_pk = &row_op::row_pk_string(pk_vals);
+    let device_hex = &meta.device.to_string();
+
+    // A row deleted at a clock this op cannot beat stays deleted: the delete is newer than this
+    // edit, so the edit must not resurrect the row. (Suppressed, but the entry is still stored, so
+    // redelivery stays idempotent.)
+    if let Some((t_lamport, t_device)) = current_tombstone(tx, repo_id, spec.name, row_pk)?
+        && !beats(meta.lamport, device_hex, t_lamport, &t_device)
+    {
+        return Ok(ApplyOutcome::Applied);
+    }
+
+    // Classify each cell: a known synced column (type-checked), or an unknown column (skipped —
+    // forward compatibility). A type mismatch quarantines the WHOLE op before any write.
+    let mut known: Vec<(&str, &TypedValue)> = Vec::new();
+    for cell in cells {
+        let Some(column) = spec.columns.iter().find(|c| c.name == cell.column) else {
+            continue; // a column this registry doesn't know — a newer producer; skip the cell.
+        };
+        if !value_matches(&cell.value, column.value_type) {
+            return Ok(ApplyOutcome::Quarantined(format!(
+                "cell `{}` value does not match declared type on `{}`",
+                cell.column, spec.name
+            )));
+        }
+        known.push((column.name, &cell.value));
+    }
+
+    // Whole-row LWW requires a full after-image: a winning op replaces the ENTIRE row, so an op
+    // missing a synced column would leave that column at a stale value under the winning clock —
+    // two peers with different prior values there would diverge. The producer always emits every
+    // synced column (`read_all_rows`), so a partial op is malformed or a version-skew op that
+    // cannot cleanly replace this binary's row; quarantine it rather than half-apply. (Decode
+    // rejects duplicate columns and unknown columns are skipped, so `known` holds distinct synced
+    // columns — a full count means all are present.)
+    if known.len() != spec.columns.len() {
+        return Ok(ApplyOutcome::Quarantined(format!(
+            "upsert on `{}` is not a full after-image ({} of {} synced columns present)",
+            spec.name,
+            known.len(),
+            spec.columns.len()
+        )));
+    }
+
+    // Whole-row LWW: the op wins the ENTIRE row iff it beats the row's write clock (or the row is
+    // new). A losing op is a no-op — it never partially overwrites, and it must not touch the
+    // published hash (that would mark an unsent local edit as sent and make the producer drop it).
+    let wins = match current_row_clock(tx, repo_id, spec.name, row_pk)? {
+        Some((c_lamport, c_device)) => beats(meta.lamport, device_hex, c_lamport, &c_device),
+        None => true, // no prior write — this op establishes the row.
+    };
+    if !wins {
+        return Ok(ApplyOutcome::Applied);
+    }
+
+    // The winner replaces the whole row in ONE statement (so a constraint failure can't leave a
+    // half-written row), then owns its write clock and published hash. A constraint violation — a
+    // NULL in a NOT NULL column, a failed CHECK — means the op's data doesn't fit the table
+    // (malformed producer / schema skew); it is quarantined, NOT propagated as an error, so the
+    // already-stored entry is retained and the chain advances instead of wedging.
+    let write = if row_exists(tx, spec, pk_vals)? {
+        update_row(tx, spec, &known, pk_vals)
+    } else {
+        insert_row(tx, spec, pk_vals, &known)
+    };
+    if let Err(err) = write {
+        if is_constraint_violation(&err) {
+            return Ok(ApplyOutcome::Quarantined(format!(
+                "op violates a column constraint on `{}`",
+                spec.name
+            )));
+        }
+        return Err(err);
+    }
+    raise_row_clock(tx, repo_id, spec.name, row_pk, meta.lamport, device_hex)?;
+
+    // Anti-echo: the winning op now owns the whole current row state, so record its synced hash.
+    // (A losing op returned above without touching the published hash.)
+    if let Some(hash) = synced_row_hash(tx, spec, pk_vals)? {
+        record_published(tx, repo_id, spec.name, row_pk, &hash)?;
+    }
+    Ok(ApplyOutcome::Applied)
+}
+
+/// The total order on clocks: `(lamport, device_hex)` beats `(other_lamport, other_device)` iff its
+/// lamport is higher, or equal with a lexicographically-smaller fingerprint (fixed-width lowercase
+/// hex orders exactly as the raw fingerprint bytes). The one comparison every whole-row LWW
+/// decision uses — the row write clock, the tombstone, and remove-vs-edit.
+fn beats(lamport: u64, device_hex: &str, other_lamport: u64, other_device: &str) -> bool {
+    lamport > other_lamport || (lamport == other_lamport && device_hex < other_device)
+}
+
+/// The row's latest-write clock, or `None` if it has never been written on this device. Recorded on
+/// every write (including an insert-only row, which has no per-column clock), it is what a delete
+/// and the anti-echo gate compare against.
+fn current_row_clock(
+    tx: &Transaction<'_>,
+    repo_id: &str,
+    table: &str,
+    row_pk: &str,
+) -> anyhow::Result<Option<(u64, String)>> {
+    let row = tx
+        .query_row(
+            "SELECT lamport, device_fingerprint FROM sync_row_clocks
+             WHERE repo_id = ?1 AND table_name = ?2 AND row_pk = ?3",
+            rusqlite::params![repo_id, table, row_pk],
+            |row| Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?)),
+        )
+        .optional()?;
+    row.map(|(lamport, device)| Ok((u64::try_from(lamport)?, device))).transpose()
+}
+
+/// Raise the row's write clock to `(lamport, device_hex)` under LWW — a later-arriving but older
+/// write never lowers it.
+fn raise_row_clock(
+    tx: &Transaction<'_>,
+    repo_id: &str,
+    table: &str,
+    row_pk: &str,
+    lamport: u64,
+    device_hex: &str,
+) -> anyhow::Result<()> {
+    if let Some((old_lamport, old_device)) = current_row_clock(tx, repo_id, table, row_pk)?
+        && !beats(lamport, device_hex, old_lamport, &old_device)
+    {
+        return Ok(());
+    }
+    tx.execute(
+        "INSERT INTO sync_row_clocks(repo_id, table_name, row_pk, lamport, device_fingerprint)
+         VALUES (?1, ?2, ?3, ?4, ?5)
+         ON CONFLICT(repo_id, table_name, row_pk)
+         DO UPDATE SET lamport = excluded.lamport, device_fingerprint = excluded.device_fingerprint",
+        rusqlite::params![repo_id, table, row_pk, i64::try_from(lamport)?, device_hex],
+    )?;
+    Ok(())
+}
+
+fn current_tombstone(
+    tx: &Transaction<'_>,
+    repo_id: &str,
+    table: &str,
+    row_pk: &str,
+) -> anyhow::Result<Option<(u64, String)>> {
+    let row = tx
+        .query_row(
+            "SELECT lamport, device_fingerprint FROM sync_row_tombstones
+             WHERE repo_id = ?1 AND table_name = ?2 AND row_pk = ?3",
+            rusqlite::params![repo_id, table, row_pk],
+            |row| Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?)),
+        )
+        .optional()?;
+    row.map(|(lamport, device)| Ok((u64::try_from(lamport)?, device))).transpose()
+}
+
+/// Raise the row's tombstone to `(lamport, device_hex)` under LWW — a lower clock never lowers it.
+fn raise_tombstone(
+    tx: &Transaction<'_>,
+    repo_id: &str,
+    table: &str,
+    row_pk: &str,
+    lamport: u64,
+    device_hex: &str,
+) -> anyhow::Result<()> {
+    if let Some((old_lamport, old_device)) = current_tombstone(tx, repo_id, table, row_pk)?
+        && !beats(lamport, device_hex, old_lamport, &old_device)
+    {
+        return Ok(());
+    }
+    tx.execute(
+        "INSERT INTO sync_row_tombstones(repo_id, table_name, row_pk, lamport, device_fingerprint)
+         VALUES (?1, ?2, ?3, ?4, ?5)
+         ON CONFLICT(repo_id, table_name, row_pk)
+         DO UPDATE SET lamport = excluded.lamport, device_fingerprint = excluded.device_fingerprint",
+        rusqlite::params![repo_id, table, row_pk, i64::try_from(lamport)?, device_hex],
+    )?;
+    Ok(())
+}
+
+/// The row's current synced-column hash (the anti-echo identity), or `None` if the row is absent.
+/// Shared by the applier (records it) and the producer (compares against it), so both hash the
+/// identical read-back and a received row never re-produces.
+pub(crate) fn synced_row_hash(
+    tx: &Transaction<'_>,
+    spec: &TableSpec,
+    pk_vals: &[TypedValue],
+) -> anyhow::Result<Option<String>> {
+    Ok(read_synced_cells(tx, spec, pk_vals)?.map(|cells| row_op::cells_hash(&cells)))
+}
+
+/// Read a row's synced columns as typed cells (sorted by the registry's column order), mapping each
+/// stored value back to its declared type so the hash matches what the applier wrote. `None` if the
+/// row is absent.
+pub(crate) fn read_synced_cells(
+    tx: &Transaction<'_>,
+    spec: &TableSpec,
+    pk_vals: &[TypedValue],
+) -> anyhow::Result<Option<Vec<Cell>>> {
+    let select = spec.columns.iter().map(|c| quote_ident(c.name)).collect::<Vec<_>>().join(", ");
+    let sql =
+        format!("SELECT {select} FROM {} WHERE {} LIMIT 1", quote_ident(spec.name), pk_where(spec));
+    let cells = tx
+        .query_row(&sql, params_from_iter(pk_params(pk_vals)), |row| {
+            let mut cells = Vec::with_capacity(spec.columns.len());
+            for (idx, column) in spec.columns.iter().enumerate() {
+                cells.push(Cell {
+                    column: column.name.to_string(),
+                    value: read_typed(row, idx, column.value_type)?,
+                });
+            }
+            Ok(cells)
+        })
+        .optional()?;
+    Ok(cells)
+}
+
+/// Every current row of `spec`'s table FOR `repo_id` as `(pk values, synced cells)`, the producer's
+/// scan input. A repo-scoped table is filtered by its `repo_column`, so a multi-repo store never
+/// emits one repo's rows into another repo's stream. Pk values are read by their runtime storage
+/// type (identities are text/int/blob); synced cells by their declared type so the hash matches the
+/// applier's.
+pub(crate) fn read_all_rows(
+    tx: &Transaction<'_>,
+    spec: &TableSpec,
+    repo_id: &str,
+) -> anyhow::Result<Vec<(Vec<TypedValue>, Vec<Cell>)>> {
+    let pk_select = spec.pk.iter().map(|c| quote_ident(c.name));
+    let col_select = spec.columns.iter().map(|c| quote_ident(c.name));
+    let select = pk_select.chain(col_select).collect::<Vec<_>>().join(", ");
+    let (where_sql, bind): (String, Vec<SqlValue>) = match spec.repo_column {
+        Some(col) =>
+            (format!(" WHERE {} = ?", quote_ident(col)), vec![SqlValue::Text(repo_id.to_string())]),
+        None => (String::new(), Vec::new()),
+    };
+    let sql = format!("SELECT {select} FROM {}{where_sql}", quote_ident(spec.name));
+    let mut stmt = tx.prepare(&sql)?;
+    let rows = stmt
+        .query_map(params_from_iter(bind), |row| {
+            // Read each pk value by its DECLARED type, not its storage type: a `Bool` pk is stored
+            // as INTEGER 0/1, and reading it as `I64` would emit a `TypedValue` the applier's
+            // typed- pk check rejects — the producer would then sign ops its own
+            // self-apply quarantines.
+            let mut pk = Vec::with_capacity(spec.pk.len());
+            for (idx, column) in spec.pk.iter().enumerate() {
+                pk.push(read_typed(row, idx, column.value_type)?);
+            }
+            let mut cells = Vec::with_capacity(spec.columns.len());
+            for (offset, column) in spec.columns.iter().enumerate() {
+                cells.push(Cell {
+                    column: column.name.to_string(),
+                    value: read_typed(row, spec.pk.len() + offset, column.value_type)?,
+                });
+            }
+            Ok((pk, cells))
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    Ok(rows)
+}
+
+// ── row writes ───────────────────────────────────────────────────────────────────────────────
+
+fn row_exists(
+    tx: &Transaction<'_>,
+    spec: &TableSpec,
+    pk_vals: &[TypedValue],
+) -> anyhow::Result<bool> {
+    let sql = format!("SELECT 1 FROM {} WHERE {} LIMIT 1", quote_ident(spec.name), pk_where(spec));
+    Ok(tx.query_row(&sql, params_from_iter(pk_params(pk_vals)), |_| Ok(())).optional()?.is_some())
+}
+
+fn insert_row(
+    tx: &Transaction<'_>,
+    spec: &TableSpec,
+    pk_vals: &[TypedValue],
+    winning: &[(&str, &TypedValue)],
+) -> anyhow::Result<()> {
+    let mut columns: Vec<String> = spec.pk.iter().map(|c| quote_ident(c.name)).collect();
+    let mut values: Vec<SqlValue> = pk_vals.iter().map(sql_value).collect();
+    for (name, value) in winning {
+        columns.push(quote_ident(name));
+        values.push(sql_value(value));
+    }
+    let placeholders = (0..values.len()).map(|_| "?").collect::<Vec<_>>().join(", ");
+    let sql = format!(
+        "INSERT INTO {}({}) VALUES ({placeholders})",
+        quote_ident(spec.name),
+        columns.join(", ")
+    );
+    tx.execute(&sql, params_from_iter(values))?;
+    Ok(())
+}
+
+/// Replace an existing row's synced columns in ONE statement (whole-row), so a constraint failure
+/// is atomic — never a half-written row.
+fn update_row(
+    tx: &Transaction<'_>,
+    spec: &TableSpec,
+    cells: &[(&str, &TypedValue)],
+    pk_vals: &[TypedValue],
+) -> anyhow::Result<()> {
+    let assignments = cells
+        .iter()
+        .map(|(name, _)| format!("{} = ?", quote_ident(name)))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let sql =
+        format!("UPDATE {} SET {assignments} WHERE {}", quote_ident(spec.name), pk_where(spec));
+    let mut params: Vec<SqlValue> = cells.iter().map(|(_, value)| sql_value(value)).collect();
+    params.extend(pk_vals.iter().map(sql_value));
+    tx.execute(&sql, params_from_iter(params))?;
+    Ok(())
+}
+
+/// Whether an error is a SQLite constraint violation (NOT NULL, CHECK, …) — an op whose data does
+/// not fit the table, which the applier quarantines rather than propagating as a fatal error.
+fn is_constraint_violation(err: &anyhow::Error) -> bool {
+    matches!(
+        err.downcast_ref::<rusqlite::Error>(),
+        Some(rusqlite::Error::SqliteFailure(e, _))
+            if e.code == rusqlite::ErrorCode::ConstraintViolation
+    )
+}
+
+fn delete_row(
+    tx: &Transaction<'_>,
+    spec: &TableSpec,
+    pk_vals: &[TypedValue],
+) -> anyhow::Result<()> {
+    let sql = format!("DELETE FROM {} WHERE {}", quote_ident(spec.name), pk_where(spec));
+    tx.execute(&sql, params_from_iter(pk_params(pk_vals)))?;
+    Ok(())
+}
+
+// ── row clock + published-row bookkeeping ────────────────────────────────────────────────────
+
+fn clear_row_clock(
+    tx: &Transaction<'_>,
+    repo_id: &str,
+    table: &str,
+    row_pk: &str,
+) -> anyhow::Result<()> {
+    tx.execute(
+        "DELETE FROM sync_row_clocks WHERE repo_id = ?1 AND table_name = ?2 AND row_pk = ?3",
+        rusqlite::params![repo_id, table, row_pk],
+    )?;
+    Ok(())
+}
+
+/// The row's recorded anti-echo hash, or `None` if the producer has not published it yet. Read by
+/// [`super::produce`].
+pub(crate) fn published_hash(
+    tx: &Transaction<'_>,
+    repo_id: &str,
+    table: &str,
+    row_pk: &str,
+) -> anyhow::Result<Option<String>> {
+    Ok(tx
+        .query_row(
+            "SELECT synced_hash FROM sync_published_rows
+             WHERE repo_id = ?1 AND table_name = ?2 AND row_pk = ?3",
+            rusqlite::params![repo_id, table, row_pk],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?)
+}
+
+pub(crate) fn record_published(
+    tx: &Transaction<'_>,
+    repo_id: &str,
+    table: &str,
+    row_pk: &str,
+    hash: &str,
+) -> anyhow::Result<()> {
+    tx.execute(
+        "INSERT INTO sync_published_rows(repo_id, table_name, row_pk, synced_hash)
+         VALUES (?1, ?2, ?3, ?4)
+         ON CONFLICT(repo_id, table_name, row_pk) DO UPDATE SET synced_hash = excluded.synced_hash",
+        rusqlite::params![repo_id, table, row_pk, hash],
+    )?;
+    Ok(())
+}
+
+fn clear_published(
+    tx: &Transaction<'_>,
+    repo_id: &str,
+    table: &str,
+    row_pk: &str,
+) -> anyhow::Result<()> {
+    tx.execute(
+        "DELETE FROM sync_published_rows WHERE repo_id = ?1 AND table_name = ?2 AND row_pk = ?3",
+        rusqlite::params![repo_id, table, row_pk],
+    )?;
+    Ok(())
+}
+
+// ── value / identifier plumbing ──────────────────────────────────────────────────────────────
+
+/// A `col = ?` conjunction over the pk columns, in registry order (the `pk_params` order matches).
+fn pk_where(spec: &TableSpec) -> String {
+    spec.pk.iter().map(|c| format!("{} = ?", quote_ident(c.name))).collect::<Vec<_>>().join(" AND ")
+}
+
+fn pk_params(pk_vals: &[TypedValue]) -> Vec<SqlValue> {
+    pk_vals.iter().map(sql_value).collect()
+}
+
+/// Double-quote a SQL identifier (table/column). Names come only from the `&'static` registry, so
+/// this is defense in depth, not untrusted-input escaping.
+fn quote_ident(ident: &str) -> String {
+    format!("\"{}\"", ident.replace('"', "\"\""))
+}
+
+fn sql_value(value: &TypedValue) -> SqlValue {
+    match value {
+        TypedValue::Null => SqlValue::Null,
+        TypedValue::Bool(b) => SqlValue::Integer(i64::from(*b)),
+        TypedValue::I64(n) => SqlValue::Integer(*n),
+        TypedValue::Text(s) => SqlValue::Text(s.clone()),
+        TypedValue::Blob(b) => SqlValue::Blob(b.clone()),
+    }
+}
+
+fn read_typed(row: &rusqlite::Row<'_>, idx: usize, vt: ValueType) -> rusqlite::Result<TypedValue> {
+    match vt {
+        ValueType::Text =>
+            Ok(row.get::<_, Option<String>>(idx)?.map_or(TypedValue::Null, TypedValue::Text)),
+        ValueType::I64 =>
+            Ok(row.get::<_, Option<i64>>(idx)?.map_or(TypedValue::Null, TypedValue::I64)),
+        // A Bool column must hold exactly 0 or 1. Coercing any other integer to `true` (the old
+        // `n != 0`) would silently rewrite the source value to 1 on self-apply and replicate a
+        // value that differs from the row — surface the malformed value instead of
+        // normalizing it away.
+        ValueType::Bool => match row.get::<_, Option<i64>>(idx)? {
+            None => Ok(TypedValue::Null),
+            Some(0) => Ok(TypedValue::Bool(false)),
+            Some(1) => Ok(TypedValue::Bool(true)),
+            Some(other) => Err(rusqlite::Error::FromSqlConversionFailure(
+                idx,
+                rusqlite::types::Type::Integer,
+                format!("a Bool column holds {other}, not 0 or 1").into(),
+            )),
+        },
+        ValueType::Blob =>
+            Ok(row.get::<_, Option<Vec<u8>>>(idx)?.map_or(TypedValue::Null, TypedValue::Blob)),
+    }
+}
+
+/// Whether a value is storable in a column of the declared type. `Null` fits any column
+/// (nullability is the DB's constraint); every other value must match exactly.
+fn value_matches(value: &TypedValue, vt: ValueType) -> bool {
+    matches!(
+        (value, vt),
+        (TypedValue::Null, _)
+            | (TypedValue::Bool(_), ValueType::Bool)
+            | (TypedValue::I64(_), ValueType::I64)
+            | (TypedValue::Text(_), ValueType::Text)
+            | (TypedValue::Blob(_), ValueType::Blob)
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::op::DeviceFingerprint;
+    use crate::table_sync::registry::ColumnSpec;
+
+    const SPEC: TableSpec = TableSpec {
+        name: "t_demo",
+        scope_id: "demo/1",
+        pk: &[ColumnSpec { name: "id", value_type: ValueType::Text }],
+        columns: &[ColumnSpec { name: "title", value_type: ValueType::Text }],
+        local_columns: &["resolved_rowid"],
+        repo_column: None,
+    };
+
+    fn conn() -> rusqlite::Connection {
+        let c = rusqlite::Connection::open_in_memory().unwrap();
+        rag_rat_db::schema::apply(&c, &crate::test_hooks()).unwrap();
+        c.execute_batch(
+            "CREATE TABLE t_demo(id TEXT PRIMARY KEY, title TEXT, resolved_rowid INTEGER) STRICT;",
+        )
+        .unwrap();
+        c
+    }
+
+    fn device(seed: u8) -> DeviceFingerprint {
+        DeviceFingerprint::from_bytes([seed; 32])
+    }
+
+    fn upsert(cells: &[(&str, TypedValue)]) -> RowOp {
+        RowOp::Upsert {
+            table: "t_demo".to_string(),
+            pk: vec![TypedValue::Text("r1".to_string())],
+            cells: cells
+                .iter()
+                .map(|(c, v)| Cell { column: (*c).to_string(), value: v.clone() })
+                .collect(),
+        }
+    }
+
+    fn title(conn: &rusqlite::Connection) -> Option<String> {
+        conn.query_row("SELECT title FROM t_demo WHERE id = 'r1'", [], |r| r.get(0))
+            .optional()
+            .unwrap()
+    }
+
+    #[test]
+    fn an_insert_writes_the_row_and_records_the_clock_and_hash() {
+        let mut c = conn();
+        let tx = c.transaction().unwrap();
+        let out = apply_row_op(
+            &tx,
+            &SPEC,
+            "repo",
+            &upsert(&[("title", TypedValue::Text("hi".to_string()))]),
+            OpMeta { lamport: 5, device: device(2) },
+        )
+        .unwrap();
+        assert_eq!(out, ApplyOutcome::Applied);
+        let row_pk = row_op::row_pk_string(&[TypedValue::Text("r1".to_string())]);
+        assert!(published_hash(&tx, "repo", "t_demo", &row_pk).unwrap().is_some());
+        assert_eq!(current_row_clock(&tx, "repo", "t_demo", &row_pk).unwrap().unwrap().0, 5);
+        tx.commit().unwrap();
+        assert_eq!(title(&c).as_deref(), Some("hi"));
+    }
+
+    #[test]
+    fn whole_row_lww_the_winner_takes_the_whole_row_no_per_column_merge() {
+        // The chosen semantics: a concurrent edit to a DIFFERENT column does NOT merge in — the
+        // higher-lamport op owns the entire row. Deterministic (both peers converge to the same
+        // winner) and matches the whole-row real tables. Two-column table so the merge could
+        // differ.
+        const TWO_COL: TableSpec = TableSpec {
+            name: "t_two",
+            scope_id: "demo/1",
+            pk: &[ColumnSpec { name: "id", value_type: ValueType::Text }],
+            columns: &[ColumnSpec { name: "title", value_type: ValueType::Text }, ColumnSpec {
+                name: "count",
+                value_type: ValueType::I64,
+            }],
+            local_columns: &[],
+            repo_column: None,
+        };
+        let mut c = rusqlite::Connection::open_in_memory().unwrap();
+        rag_rat_db::schema::apply(&c, &crate::test_hooks()).unwrap();
+        c.execute_batch(
+            "CREATE TABLE t_two(id TEXT PRIMARY KEY, title TEXT, count INTEGER) STRICT;",
+        )
+        .unwrap();
+        let full = |title: &str, count: i64| RowOp::Upsert {
+            table: "t_two".to_string(),
+            pk: vec![TypedValue::Text("r1".into())],
+            cells: vec![
+                Cell { column: "title".into(), value: TypedValue::Text(title.into()) },
+                Cell { column: "count".into(), value: TypedValue::I64(count) },
+            ],
+        };
+        let tx = c.transaction().unwrap();
+        // Higher lamport sets {A, 1}...
+        apply_row_op(&tx, &TWO_COL, "repo", &full("A", 1), OpMeta {
+            lamport: 6,
+            device: device(2),
+        })
+        .unwrap();
+        // ...a lower-lamport op editing a different column loses the WHOLE row, not just `title`.
+        apply_row_op(&tx, &TWO_COL, "repo", &full("B", 2), OpMeta {
+            lamport: 5,
+            device: device(1),
+        })
+        .unwrap();
+        tx.commit().unwrap();
+        let row: (String, i64) = c
+            .query_row("SELECT title, count FROM t_two WHERE id = 'r1'", [], |r| {
+                Ok((r.get(0)?, r.get(1)?))
+            })
+            .unwrap();
+        assert_eq!(
+            (row.0.as_str(), row.1),
+            ("A", 1),
+            "the whole row is the winning op's — no merge"
+        );
+    }
+
+    #[test]
+    fn a_higher_lamport_wins_and_a_lower_lamport_loses() {
+        let mut c = conn();
+        let tx = c.transaction().unwrap();
+        apply_row_op(
+            &tx,
+            &SPEC,
+            "repo",
+            &upsert(&[("title", TypedValue::Text("a".into()))]),
+            OpMeta { lamport: 5, device: device(2) },
+        )
+        .unwrap();
+        // A later lamport overwrites.
+        apply_row_op(
+            &tx,
+            &SPEC,
+            "repo",
+            &upsert(&[("title", TypedValue::Text("b".into()))]),
+            OpMeta { lamport: 6, device: device(2) },
+        )
+        .unwrap();
+        // A stale (lower-lamport) op is ignored.
+        apply_row_op(
+            &tx,
+            &SPEC,
+            "repo",
+            &upsert(&[("title", TypedValue::Text("stale".into()))]),
+            OpMeta { lamport: 4, device: device(9) },
+        )
+        .unwrap();
+        tx.commit().unwrap();
+        assert_eq!(title(&c).as_deref(), Some("b"));
+    }
+
+    #[test]
+    fn a_lamport_tie_is_broken_by_the_smaller_fingerprint() {
+        let mut c = conn();
+        let tx = c.transaction().unwrap();
+        apply_row_op(
+            &tx,
+            &SPEC,
+            "repo",
+            &upsert(&[("title", TypedValue::Text("dev5".into()))]),
+            OpMeta { lamport: 7, device: device(5) },
+        )
+        .unwrap();
+        // Same lamport, SMALLER fingerprint → wins.
+        apply_row_op(
+            &tx,
+            &SPEC,
+            "repo",
+            &upsert(&[("title", TypedValue::Text("dev1".into()))]),
+            OpMeta { lamport: 7, device: device(1) },
+        )
+        .unwrap();
+        // Same lamport, LARGER fingerprint → loses.
+        apply_row_op(
+            &tx,
+            &SPEC,
+            "repo",
+            &upsert(&[("title", TypedValue::Text("dev9".into()))]),
+            OpMeta { lamport: 7, device: device(9) },
+        )
+        .unwrap();
+        tx.commit().unwrap();
+        assert_eq!(title(&c).as_deref(), Some("dev1"), "the smaller fingerprint wins the tie");
+    }
+
+    #[test]
+    fn a_type_mismatch_quarantines_the_op_and_writes_nothing() {
+        let mut c = conn();
+        let tx = c.transaction().unwrap();
+        // `title` is declared Text; an I64 value is a broken producer.
+        let out =
+            apply_row_op(&tx, &SPEC, "repo", &upsert(&[("title", TypedValue::I64(7))]), OpMeta {
+                lamport: 1,
+                device: device(2),
+            })
+            .unwrap();
+        assert!(matches!(out, ApplyOutcome::Quarantined(_)));
+        tx.commit().unwrap();
+        assert_eq!(title(&c), None, "a quarantined op leaves the table untouched");
+    }
+
+    #[test]
+    fn a_partial_upsert_missing_a_synced_column_is_quarantined() {
+        // Whole-row LWW needs a full after-image; a two-column table given only one column can't be
+        // cleanly replaced, so the op is quarantined rather than applied as a hybrid row.
+        const TWO_COL: TableSpec = TableSpec {
+            name: "t_two",
+            scope_id: "demo/1",
+            pk: &[ColumnSpec { name: "id", value_type: ValueType::Text }],
+            columns: &[ColumnSpec { name: "title", value_type: ValueType::Text }, ColumnSpec {
+                name: "count",
+                value_type: ValueType::I64,
+            }],
+            local_columns: &[],
+            repo_column: None,
+        };
+        let mut c = rusqlite::Connection::open_in_memory().unwrap();
+        rag_rat_db::schema::apply(&c, &crate::test_hooks()).unwrap();
+        c.execute_batch(
+            "CREATE TABLE t_two(id TEXT PRIMARY KEY, title TEXT, count INTEGER) STRICT;",
+        )
+        .unwrap();
+        let tx = c.transaction().unwrap();
+        let partial = RowOp::Upsert {
+            table: "t_two".to_string(),
+            pk: vec![TypedValue::Text("r1".into())],
+            cells: vec![Cell {
+                column: "title".into(),
+                value: TypedValue::Text("only-title".into()),
+            }],
+        };
+        let out =
+            apply_row_op(&tx, &TWO_COL, "repo", &partial, OpMeta { lamport: 1, device: device(2) })
+                .unwrap();
+        assert!(
+            matches!(out, ApplyOutcome::Quarantined(_)),
+            "a partial after-image is quarantined"
+        );
+        let count: i64 = tx.query_row("SELECT COUNT(*) FROM t_two", [], |r| r.get(0)).unwrap();
+        assert_eq!(count, 0, "nothing was written");
+    }
+
+    #[test]
+    fn an_unknown_column_is_skipped_and_the_rest_applies() {
+        let mut c = conn();
+        let tx = c.transaction().unwrap();
+        apply_row_op(
+            &tx,
+            &SPEC,
+            "repo",
+            &upsert(&[
+                ("title", TypedValue::Text("kept".into())),
+                ("future_col", TypedValue::Text("dropped".into())),
+            ]),
+            OpMeta { lamport: 1, device: device(2) },
+        )
+        .unwrap();
+        tx.commit().unwrap();
+        assert_eq!(
+            title(&c).as_deref(),
+            Some("kept"),
+            "the known cell applied, the unknown skipped"
+        );
+    }
+
+    #[test]
+    fn a_remove_deletes_the_row_and_its_bookkeeping() {
+        let mut c = conn();
+        let tx = c.transaction().unwrap();
+        apply_row_op(
+            &tx,
+            &SPEC,
+            "repo",
+            &upsert(&[("title", TypedValue::Text("x".into()))]),
+            OpMeta { lamport: 1, device: device(2) },
+        )
+        .unwrap();
+        apply_row_op(
+            &tx,
+            &SPEC,
+            "repo",
+            &RowOp::Remove { table: "t_demo".into(), pk: vec![TypedValue::Text("r1".into())] },
+            OpMeta { lamport: 2, device: device(2) },
+        )
+        .unwrap();
+        let row_pk = row_op::row_pk_string(&[TypedValue::Text("r1".to_string())]);
+        assert!(published_hash(&tx, "repo", "t_demo", &row_pk).unwrap().is_none());
+        assert!(current_row_clock(&tx, "repo", "t_demo", &row_pk).unwrap().is_none());
+        tx.commit().unwrap();
+        assert_eq!(title(&c), None);
+    }
+
+    fn remove() -> RowOp {
+        RowOp::Remove { table: "t_demo".to_string(), pk: vec![TypedValue::Text("r1".to_string())] }
+    }
+
+    #[test]
+    fn a_stale_remove_after_a_newer_upsert_does_not_delete() {
+        let mut c = conn();
+        let tx = c.transaction().unwrap();
+        apply_row_op(
+            &tx,
+            &SPEC,
+            "repo",
+            &upsert(&[("title", TypedValue::Text("keep".into()))]),
+            OpMeta { lamport: 5, device: device(2) },
+        )
+        .unwrap();
+        // A delete older than the row's cell clock loses — the row survives.
+        apply_row_op(&tx, &SPEC, "repo", &remove(), OpMeta { lamport: 3, device: device(2) })
+            .unwrap();
+        tx.commit().unwrap();
+        assert_eq!(title(&c).as_deref(), Some("keep"), "a stale delete cannot remove a newer row");
+    }
+
+    #[test]
+    fn an_upsert_older_than_a_remove_cannot_resurrect() {
+        let mut c = conn();
+        let tx = c.transaction().unwrap();
+        apply_row_op(&tx, &SPEC, "repo", &remove(), OpMeta { lamport: 5, device: device(2) })
+            .unwrap();
+        // An insert older than the tombstone is suppressed.
+        apply_row_op(
+            &tx,
+            &SPEC,
+            "repo",
+            &upsert(&[("title", TypedValue::Text("ghost".into()))]),
+            OpMeta { lamport: 3, device: device(2) },
+        )
+        .unwrap();
+        tx.commit().unwrap();
+        assert_eq!(title(&c), None, "an insert older than the delete cannot resurrect the row");
+    }
+
+    #[test]
+    fn an_upsert_newer_than_a_remove_resurrects() {
+        let mut c = conn();
+        let tx = c.transaction().unwrap();
+        apply_row_op(&tx, &SPEC, "repo", &remove(), OpMeta { lamport: 3, device: device(2) })
+            .unwrap();
+        apply_row_op(
+            &tx,
+            &SPEC,
+            "repo",
+            &upsert(&[("title", TypedValue::Text("back".into()))]),
+            OpMeta { lamport: 5, device: device(2) },
+        )
+        .unwrap();
+        tx.commit().unwrap();
+        assert_eq!(
+            title(&c).as_deref(),
+            Some("back"),
+            "an insert newer than the delete resurrects"
+        );
+    }
+
+    #[test]
+    fn a_remove_and_upsert_converge_regardless_of_arrival_order() {
+        let end_state = |ops: &[(RowOp, OpMeta)]| {
+            let mut c = conn();
+            let tx = c.transaction().unwrap();
+            for (op, meta) in ops {
+                apply_row_op(&tx, &SPEC, "repo", op, *meta).unwrap();
+            }
+            tx.commit().unwrap();
+            title(&c)
+        };
+        let up = (upsert(&[("title", TypedValue::Text("v".into()))]), OpMeta {
+            lamport: 5,
+            device: device(2),
+        });
+        let rm = (remove(), OpMeta { lamport: 3, device: device(2) });
+        assert_eq!(
+            end_state(&[up.clone(), rm.clone()]),
+            end_state(&[rm, up]),
+            "the fold converges regardless of the order the delete and edit arrive",
+        );
+    }
+
+    #[test]
+    fn a_losing_upsert_does_not_publish_an_unsent_local_edit() {
+        let mut c = conn();
+        let tx = c.transaction().unwrap();
+        // Establish + publish a row at lamport 5 (as authoring would).
+        apply_row_op(
+            &tx,
+            &SPEC,
+            "repo",
+            &upsert(&[("title", TypedValue::Text("v1".into()))]),
+            OpMeta { lamport: 5, device: device(2) },
+        )
+        .unwrap();
+        let row_pk = row_op::row_pk_string(&[TypedValue::Text("r1".to_string())]);
+        let published_before = published_hash(&tx, "repo", "t_demo", &row_pk).unwrap();
+        // A local direct edit (no op authored yet): the row changes but stays unpublished.
+        tx.execute("UPDATE t_demo SET title = 'local-edit' WHERE id = 'r1'", []).unwrap();
+        // A STALE remote upsert (lower lamport) loses the LWW; it must NOT publish the local edit.
+        apply_row_op(
+            &tx,
+            &SPEC,
+            "repo",
+            &upsert(&[("title", TypedValue::Text("stale".into()))]),
+            OpMeta { lamport: 3, device: device(9) },
+        )
+        .unwrap();
+        assert_eq!(
+            published_hash(&tx, "repo", "t_demo", &row_pk).unwrap(),
+            published_before,
+            "a losing op must not advance the published hash over an unsent local edit",
+        );
+        let current = synced_row_hash(&tx, &SPEC, &[TypedValue::Text("r1".into())]).unwrap();
+        assert_ne!(
+            current, published_before,
+            "the local edit is still pending, not silently dropped"
+        );
+    }
+
+    #[test]
+    fn a_delete_races_the_row_write_clock_on_a_content_addressed_row() {
+        // A content-hash-keyed row (the shape the old insert-only flag targeted) records a row
+        // write clock like any other, so a stale delete loses and a newer one wins.
+        const HASHED: TableSpec = TableSpec {
+            name: "t_io",
+            scope_id: "demo/1",
+            pk: &[ColumnSpec { name: "id", value_type: ValueType::Text }],
+            columns: &[ColumnSpec { name: "hash", value_type: ValueType::Text }],
+            local_columns: &[],
+            repo_column: None,
+        };
+        let mut c = rusqlite::Connection::open_in_memory().unwrap();
+        rag_rat_db::schema::apply(&c, &crate::test_hooks()).unwrap();
+        c.execute_batch("CREATE TABLE t_io(id TEXT PRIMARY KEY, hash TEXT) STRICT;").unwrap();
+        let tx = c.transaction().unwrap();
+        let io_upsert = RowOp::Upsert {
+            table: "t_io".to_string(),
+            pk: vec![TypedValue::Text("r".into())],
+            cells: vec![Cell { column: "hash".into(), value: TypedValue::Text("h".into()) }],
+        };
+        let io_remove =
+            RowOp::Remove { table: "t_io".to_string(), pk: vec![TypedValue::Text("r".into())] };
+
+        apply_row_op(&tx, &HASHED, "repo", &io_upsert, OpMeta { lamport: 5, device: device(2) })
+            .unwrap();
+        // A stale remove (lamport 3) must NOT delete the newer row.
+        apply_row_op(&tx, &HASHED, "repo", &io_remove, OpMeta { lamport: 3, device: device(2) })
+            .unwrap();
+        let count: i64 =
+            tx.query_row("SELECT COUNT(*) FROM t_io WHERE id = 'r'", [], |r| r.get(0)).unwrap();
+        assert_eq!(count, 1, "a stale delete cannot drop a newer row");
+        // A newer remove (lamport 7) does delete it.
+        apply_row_op(&tx, &HASHED, "repo", &io_remove, OpMeta { lamport: 7, device: device(2) })
+            .unwrap();
+        let after: i64 =
+            tx.query_row("SELECT COUNT(*) FROM t_io WHERE id = 'r'", [], |r| r.get(0)).unwrap();
+        assert_eq!(after, 0, "a delete newer than the row's write clock removes it");
+    }
+
+    #[test]
+    fn an_op_naming_a_foreign_repo_is_quarantined() {
+        const SCOPED: TableSpec = TableSpec {
+            name: "t_scoped",
+            scope_id: "demo/1",
+            pk: &[ColumnSpec { name: "repo_id", value_type: ValueType::Text }, ColumnSpec {
+                name: "id",
+                value_type: ValueType::Text,
+            }],
+            columns: &[ColumnSpec { name: "title", value_type: ValueType::Text }],
+            local_columns: &[],
+            repo_column: Some("repo_id"),
+        };
+        let mut c = rusqlite::Connection::open_in_memory().unwrap();
+        rag_rat_db::schema::apply(&c, &crate::test_hooks()).unwrap();
+        c.execute_batch(
+            "CREATE TABLE t_scoped(
+                 repo_id TEXT NOT NULL, id TEXT NOT NULL, title TEXT, PRIMARY KEY(repo_id, id)
+             ) STRICT;",
+        )
+        .unwrap();
+        let tx = c.transaction().unwrap();
+        let foreign = RowOp::Upsert {
+            table: "t_scoped".to_string(),
+            pk: vec![TypedValue::Text("B".into()), TypedValue::Text("r1".into())],
+            cells: vec![Cell { column: "title".into(), value: TypedValue::Text("x".into()) }],
+        };
+        // Applied on repo A's stream but naming repo B → rejected, nothing written.
+        let out =
+            apply_row_op(&tx, &SCOPED, "A", &foreign, OpMeta { lamport: 1, device: device(2) })
+                .unwrap();
+        assert!(matches!(out, ApplyOutcome::Quarantined(_)), "a foreign-repo op is rejected");
+        let count: i64 = tx.query_row("SELECT COUNT(*) FROM t_scoped", [], |r| r.get(0)).unwrap();
+        assert_eq!(count, 0, "no cross-repo row was written");
+        // The matching-repo op applies.
+        let own = RowOp::Upsert {
+            table: "t_scoped".to_string(),
+            pk: vec![TypedValue::Text("A".into()), TypedValue::Text("r1".into())],
+            cells: vec![Cell { column: "title".into(), value: TypedValue::Text("x".into()) }],
+        };
+        assert_eq!(
+            apply_row_op(&tx, &SCOPED, "A", &own, OpMeta { lamport: 2, device: device(2) })
+                .unwrap(),
+            ApplyOutcome::Applied,
+        );
+    }
+
+    #[test]
+    fn a_null_primary_key_is_quarantined() {
+        let mut c = conn();
+        let tx = c.transaction().unwrap();
+        let op = RowOp::Upsert {
+            table: "t_demo".to_string(),
+            pk: vec![TypedValue::Null],
+            cells: vec![Cell { column: "title".to_string(), value: TypedValue::Text("x".into()) }],
+        };
+        let out = apply_row_op(&tx, &SPEC, "repo", &op, OpMeta { lamport: 1, device: device(2) })
+            .unwrap();
+        assert!(matches!(out, ApplyOutcome::Quarantined(_)), "a null pk is not addressable");
+        let count: i64 = tx.query_row("SELECT COUNT(*) FROM t_demo", [], |r| r.get(0)).unwrap();
+        assert_eq!(count, 0, "a quarantined null-pk op writes nothing");
+    }
+
+    #[test]
+    fn a_pk_value_of_the_wrong_type_is_quarantined() {
+        // `t_demo`'s pk `id` is declared Text. An I64 pk would take SQLite affinity onto a
+        // different physical row than its type-exact `row_pk` clock identity — quarantine
+        // before the WHERE.
+        let mut c = conn();
+        let tx = c.transaction().unwrap();
+        let op = RowOp::Upsert {
+            table: "t_demo".to_string(),
+            pk: vec![TypedValue::I64(1)],
+            cells: vec![Cell { column: "title".to_string(), value: TypedValue::Text("x".into()) }],
+        };
+        let out = apply_row_op(&tx, &SPEC, "repo", &op, OpMeta { lamport: 1, device: device(2) })
+            .unwrap();
+        assert!(
+            matches!(out, ApplyOutcome::Quarantined(_)),
+            "a pk value that disagrees with its declared type is quarantined"
+        );
+        let count: i64 = tx.query_row("SELECT COUNT(*) FROM t_demo", [], |r| r.get(0)).unwrap();
+        assert_eq!(count, 0, "a quarantined type-mismatched-pk op writes nothing");
+    }
+
+    #[test]
+    fn a_null_in_a_not_null_column_is_quarantined_not_a_fatal_error() {
+        // A NOT NULL constraint violation on a synced column must surface as a quarantine (the
+        // entry is retained, the row untouched), never a hard error that would wedge the
+        // ingest loop.
+        const NOT_NULL: TableSpec = TableSpec {
+            name: "t_nn",
+            scope_id: "demo/1",
+            pk: &[ColumnSpec { name: "id", value_type: ValueType::Text }],
+            columns: &[ColumnSpec { name: "title", value_type: ValueType::Text }],
+            local_columns: &[],
+            repo_column: None,
+        };
+        let mut c = rusqlite::Connection::open_in_memory().unwrap();
+        rag_rat_db::schema::apply(&c, &crate::test_hooks()).unwrap();
+        c.execute_batch("CREATE TABLE t_nn(id TEXT PRIMARY KEY, title TEXT NOT NULL) STRICT;")
+            .unwrap();
+        let tx = c.transaction().unwrap();
+        // A well-typed NULL cell (Text column, Null value) passes the type check but violates the
+        // table's NOT NULL constraint on insert.
+        let op = RowOp::Upsert {
+            table: "t_nn".to_string(),
+            pk: vec![TypedValue::Text("r".into())],
+            cells: vec![Cell { column: "title".to_string(), value: TypedValue::Null }],
+        };
+        let out =
+            apply_row_op(&tx, &NOT_NULL, "repo", &op, OpMeta { lamport: 1, device: device(2) })
+                .unwrap();
+        assert!(
+            matches!(out, ApplyOutcome::Quarantined(_)),
+            "a constraint violation is quarantined, not a fatal error"
+        );
+        let count: i64 = tx.query_row("SELECT COUNT(*) FROM t_nn", [], |r| r.get(0)).unwrap();
+        assert_eq!(count, 0, "a quarantined constraint-violating op writes nothing");
+    }
+
+    #[test]
+    fn the_producer_reads_a_bool_pk_as_bool_and_the_applier_accepts_it() {
+        // A `Bool` pk is stored as INTEGER 0/1. The producer must emit `TypedValue::Bool` (not
+        // `I64`), or the op it signs fails the applier's typed-pk check and self-quarantines.
+        const FLAG: TableSpec = TableSpec {
+            name: "t_flag",
+            scope_id: "demo/1",
+            pk: &[ColumnSpec { name: "active", value_type: ValueType::Bool }],
+            columns: &[ColumnSpec { name: "label", value_type: ValueType::Text }],
+            local_columns: &[],
+            repo_column: None,
+        };
+        let mut src = rusqlite::Connection::open_in_memory().unwrap();
+        rag_rat_db::schema::apply(&src, &crate::test_hooks()).unwrap();
+        src.execute_batch("CREATE TABLE t_flag(active INTEGER PRIMARY KEY, label TEXT) STRICT;")
+            .unwrap();
+        src.execute("INSERT INTO t_flag(active, label) VALUES (1, 'on')", []).unwrap();
+        let src_tx = src.transaction().unwrap();
+        let rows = read_all_rows(&src_tx, &FLAG, "repo").unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(
+            rows[0].0,
+            vec![TypedValue::Bool(true)],
+            "a Bool pk is emitted as Bool, not I64"
+        );
+
+        // The op the producer would sign applies cleanly on a peer (the typed-pk check passes).
+        let op = RowOp::Upsert {
+            table: "t_flag".to_string(),
+            pk: rows[0].0.clone(),
+            cells: rows[0].1.clone(),
+        };
+        let mut peer = rusqlite::Connection::open_in_memory().unwrap();
+        rag_rat_db::schema::apply(&peer, &crate::test_hooks()).unwrap();
+        peer.execute_batch("CREATE TABLE t_flag(active INTEGER PRIMARY KEY, label TEXT) STRICT;")
+            .unwrap();
+        let peer_tx = peer.transaction().unwrap();
+        assert_eq!(
+            apply_row_op(&peer_tx, &FLAG, "repo", &op, OpMeta { lamport: 1, device: device(2) })
+                .unwrap(),
+            ApplyOutcome::Applied,
+            "the applier accepts the Bool-pk op the producer emits",
+        );
+    }
+
+    #[test]
+    fn a_bool_column_holding_a_non_boolean_int_is_rejected_not_normalized() {
+        // A `Bool` column that somehow holds an integer other than 0/1 must be surfaced, not
+        // coerced to `true` — coercing would replicate a value (1) that differs from the
+        // stored row.
+        const FLAGGED: TableSpec = TableSpec {
+            name: "t_flagged",
+            scope_id: "demo/1",
+            pk: &[ColumnSpec { name: "id", value_type: ValueType::Text }],
+            columns: &[ColumnSpec { name: "flag", value_type: ValueType::Bool }],
+            local_columns: &[],
+            repo_column: None,
+        };
+        let mut c = rusqlite::Connection::open_in_memory().unwrap();
+        rag_rat_db::schema::apply(&c, &crate::test_hooks()).unwrap();
+        c.execute_batch("CREATE TABLE t_flagged(id TEXT PRIMARY KEY, flag INTEGER) STRICT;")
+            .unwrap();
+        c.execute("INSERT INTO t_flagged(id, flag) VALUES ('r', 2)", []).unwrap();
+        let tx = c.transaction().unwrap();
+        assert!(
+            read_all_rows(&tx, &FLAGGED, "repo").is_err(),
+            "a Bool column holding 2 is rejected, not silently normalized to true",
+        );
+    }
+
+    #[test]
+    fn a_remove_blocked_by_a_foreign_key_is_quarantined_not_wedged() {
+        // A delete that hits an FK RESTRICT (a child references the row) must quarantine — NOT
+        // return a hard error, which would roll back the already-stored entry and wedge the chain.
+        const PARENT: TableSpec = TableSpec {
+            name: "parent",
+            scope_id: "demo/1",
+            pk: &[ColumnSpec { name: "id", value_type: ValueType::Text }],
+            columns: &[ColumnSpec { name: "v", value_type: ValueType::Text }],
+            local_columns: &[],
+            repo_column: None,
+        };
+        let mut c = rusqlite::Connection::open_in_memory().unwrap();
+        rag_rat_db::schema::apply(&c, &crate::test_hooks()).unwrap();
+        c.execute_batch(
+            "PRAGMA foreign_keys = ON;
+             CREATE TABLE parent(id TEXT NOT NULL PRIMARY KEY, v TEXT) STRICT;
+             CREATE TABLE child(id TEXT NOT NULL PRIMARY KEY, p TEXT NOT NULL REFERENCES \
+             parent(id)) STRICT;
+             INSERT INTO parent(id, v) VALUES ('r', 'x');
+             INSERT INTO child(id, p) VALUES ('c', 'r');",
+        )
+        .unwrap();
+        let tx = c.transaction().unwrap();
+        let op =
+            RowOp::Remove { table: "parent".to_string(), pk: vec![TypedValue::Text("r".into())] };
+        let out = apply_row_op(&tx, &PARENT, "repo", &op, OpMeta { lamport: 1, device: device(2) })
+            .unwrap();
+        assert!(
+            matches!(out, ApplyOutcome::Quarantined(_)),
+            "an FK-blocked delete quarantines, it does not error: {out:?}"
+        );
+        let n: i64 =
+            tx.query_row("SELECT COUNT(*) FROM parent WHERE id = 'r'", [], |r| r.get(0)).unwrap();
+        assert_eq!(n, 1, "the FK-blocked parent row is left untouched");
+    }
+}

--- a/crates/rag-rat-oplog/src/table_sync/engine.rs
+++ b/crates/rag-rat-oplog/src/table_sync/engine.rs
@@ -1,0 +1,337 @@
+//! The engine's orchestration surface: turn local table changes into authored entries, and fold
+//! received entries back into tables.
+//!
+//! [`produce_and_author`] scans every registered table, authors an entry per changed row on that
+//! table's scope stream, and self-applies it so the LWW clock and published-row record capture this
+//! authorship (a later remote op competes at the authored lamport; the next producer pass sees no
+//! delta). [`ingest`] verifies, stores, and applies one received entry, routing it to the right
+//! table within its scope.
+//!
+//! This is the transport-independent seam the milestone's loopback test drives; the iroh milestone
+//! wraps a per-scope `SyncStore` around exactly these two calls.
+
+use rusqlite::Transaction;
+
+use super::apply::{self, ApplyOutcome};
+use super::produce;
+use super::registry::TableSpec;
+use super::scope_stream::scope_stream_id;
+use super::store::{self, AcceptOutcome};
+use crate::device::DevicePublic;
+use crate::op::OpMeta;
+use crate::{AccountId, LocalDevice};
+
+/// The stable dependencies of a sync pass: the project being synced, the owning account (which the
+/// scope stream ids derive from), this device, the syncable-table registry, and the injected clock.
+pub(crate) struct SyncCtx<'a> {
+    pub repo_id: &'a str,
+    pub account_id: AccountId,
+    pub device: &'a LocalDevice,
+    pub registry: &'a [TableSpec],
+    pub now_ms: i64,
+}
+
+/// What ingesting one received entry did.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum IngestOutcome {
+    Applied,
+    /// Stored and relayed, but not applied — an undecodable/unknown/out-of-scope payload. The
+    /// `&str` is the reason. Forward-compatible: the chain advanced, the payload is retained.
+    Retained(&'static str),
+    AlreadyPresent,
+    /// A chain gap or fork — the transport milestone resolves it (backfill / fork evidence).
+    Parked(&'static str),
+    /// A type mismatch — stored, unprojectable, surfaced.
+    Quarantined(String),
+}
+
+/// Author the row ops that bring peers up to this device's state, returning each as signed wire
+/// bytes. Empty when everything is already published.
+pub(crate) fn produce_and_author(
+    tx: &Transaction<'_>,
+    ctx: &SyncCtx<'_>,
+) -> anyhow::Result<Vec<Vec<u8>>> {
+    let mut authored = Vec::new();
+    for spec in ctx.registry {
+        let stream = scope_stream_id(ctx.repo_id, ctx.account_id, spec.scope_id);
+        for op in produce::produce_row_ops(tx, spec, ctx.repo_id)? {
+            let signed = store::author_row_entry(tx, stream, ctx.device.secret(), &op, ctx.now_ms)?;
+            let meta =
+                OpMeta { lamport: signed.entry.lamport, device: signed.entry.device_fingerprint };
+            // Self-apply so this authorship enters the LWW clock and published-row record: a later
+            // remote op competes at this lamport, and the producer never re-emits it (no
+            // self-echo). A locally-produced op MUST self-apply cleanly — the registry lint rejects
+            // every shape that would quarantine (nullable pk, cross-row constraint, and the
+            // producer reads well-typed values). If it quarantines anyway, the
+            // published hash is NOT recorded, so the next pass would re-author the same
+            // row forever (unbounded signed-log growth) and peers would quarantine each
+            // copy: surface it and do NOT transmit the junk op.
+            match apply::apply_row_op(tx, spec, ctx.repo_id, &op, meta)? {
+                apply::ApplyOutcome::Applied => authored.push(signed.signed_bytes),
+                apply::ApplyOutcome::Quarantined(reason) => {
+                    // A locally-produced op self-quarantining is UNREACHABLE for a registered
+                    // table: the lint rejects every shape that would quarantine
+                    // (nullable pk, cross-row constraint,
+                    // ValueType/physical-type mismatch), and the producer reads well-typed
+                    // values. If it somehow happens, FAIL the pass — `author_row_entry` has already
+                    // inserted this entry in the caller's txn, so bailing rolls it back rather than
+                    // leaving it stored-but-unpublished and re-authored (re-signed) every pass
+                    // (unbounded log growth). Assert first, so a test catches the lint/producer
+                    // gap.
+                    debug_assert!(
+                        false,
+                        "table-sync: a locally-produced op self-quarantined on `{}`: {reason}",
+                        spec.name
+                    );
+                    anyhow::bail!(
+                        "table-sync: a locally-produced op self-quarantined on `{}`: {reason}",
+                        spec.name
+                    );
+                },
+            }
+        }
+    }
+    Ok(authored)
+}
+
+/// Verify, store, and apply one received entry for `scope_id`'s stream, signed by `pubkey`. A scope
+/// may carry several tables (overlay, distill), so the target spec is resolved from the decoded
+/// op's table against every registry entry in the scope — not fixed by the caller. The op's table
+/// is validated against the scope's table set BEFORE the entry is stored, so a misrouted op never
+/// advances the chain and orphans itself.
+pub(crate) fn ingest(
+    tx: &Transaction<'_>,
+    ctx: &SyncCtx<'_>,
+    scope_id: &str,
+    signed_bytes: &[u8],
+    pubkey: &DevicePublic,
+) -> anyhow::Result<IngestOutcome> {
+    let stream = scope_stream_id(ctx.repo_id, ctx.account_id, scope_id);
+    let scope_tables: Vec<&str> =
+        ctx.registry.iter().filter(|s| s.scope_id == scope_id).map(|s| s.name).collect();
+    Ok(
+        match store::accept_row_entry(tx, stream, &scope_tables, signed_bytes, pubkey, ctx.now_ms)?
+        {
+            AcceptOutcome::Stored { op, meta } => {
+                // `accept_row_entry` already validated the op's table is in `scope_tables`, so
+                // exactly one spec matches; the fallback is defensive, never
+                // reached.
+                let Some(spec) =
+                    ctx.registry.iter().find(|s| s.scope_id == scope_id && s.name == op.table())
+                else {
+                    return Ok(IngestOutcome::Parked("table not in scope"));
+                };
+                match apply::apply_row_op(tx, spec, ctx.repo_id, &op, meta)? {
+                    ApplyOutcome::Applied => IngestOutcome::Applied,
+                    ApplyOutcome::Quarantined(why) => IngestOutcome::Quarantined(why),
+                }
+            },
+            AcceptOutcome::StoredInert(reason) => IngestOutcome::Retained(reason),
+            AcceptOutcome::AlreadyPresent => IngestOutcome::AlreadyPresent,
+            AcceptOutcome::MissingPredecessor => IngestOutcome::Parked("missing predecessor"),
+            AcceptOutcome::Fork => IngestOutcome::Parked("fork"),
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::table_sync::registry::{ColumnSpec, ValueType};
+
+    const SPEC: TableSpec = TableSpec {
+        name: "t_demo",
+        scope_id: "demo/1",
+        pk: &[ColumnSpec { name: "id", value_type: ValueType::Text }],
+        columns: &[ColumnSpec { name: "title", value_type: ValueType::Text }],
+        local_columns: &[],
+        repo_column: None,
+    };
+    const REGISTRY: &[TableSpec] = &[SPEC];
+
+    /// One account's device: a fully-migrated store with the synthetic table and a minted identity.
+    struct Device {
+        conn: rusqlite::Connection,
+        local: LocalDevice,
+    }
+
+    impl Device {
+        fn new() -> Self {
+            let conn = rusqlite::Connection::open_in_memory().unwrap();
+            rag_rat_db::schema::apply(&conn, &crate::test_hooks()).unwrap();
+            conn.execute_batch("CREATE TABLE t_demo(id TEXT PRIMARY KEY, title TEXT) STRICT;")
+                .unwrap();
+            let local = crate::local_device(&conn, 0).unwrap();
+            Self { conn, local }
+        }
+
+        fn pubkey(&self) -> DevicePublic {
+            self.local.secret().public()
+        }
+
+        fn set_title(&self, title: &str) {
+            self.conn.execute("UPDATE t_demo SET title = ?1 WHERE id = 'r1'", [title]).unwrap();
+        }
+
+        fn title(&self) -> Option<String> {
+            self.conn
+                .query_row("SELECT title FROM t_demo WHERE id = 'r1'", [], |r| {
+                    r.get::<_, String>(0)
+                })
+                .ok()
+        }
+
+        fn produce(&mut self) -> Vec<Vec<u8>> {
+            let tx = self.conn.transaction().unwrap();
+            let ctx = SyncCtx {
+                repo_id: "repo",
+                account_id: AccountId::from_bytes([42; 32]),
+                device: &self.local,
+                registry: REGISTRY,
+                now_ms: 0,
+            };
+            let out = produce_and_author(&tx, &ctx).unwrap();
+            tx.commit().unwrap();
+            out
+        }
+
+        fn ingest_all(&mut self, entries: &[Vec<u8>], from: &DevicePublic) {
+            let tx = self.conn.transaction().unwrap();
+            let ctx = SyncCtx {
+                repo_id: "repo",
+                account_id: AccountId::from_bytes([42; 32]),
+                device: &self.local,
+                registry: REGISTRY,
+                now_ms: 0,
+            };
+            for bytes in entries {
+                ingest(&tx, &ctx, "demo/1", bytes, from).unwrap();
+            }
+            tx.commit().unwrap();
+        }
+    }
+
+    #[test]
+    fn a_row_written_on_one_device_appears_on_the_other_and_never_echoes() {
+        let mut a = Device::new();
+        let mut b = Device::new();
+        a.conn.execute("INSERT INTO t_demo(id, title) VALUES ('r1', 'base')", []).unwrap();
+
+        let entries = a.produce();
+        assert_eq!(entries.len(), 1, "one changed row is authored");
+        b.ingest_all(&entries, &a.pubkey());
+        assert_eq!(b.title().as_deref(), Some("base"), "the row appears on the peer");
+
+        // The flagship: the peer does not re-emit a row it received.
+        assert!(b.produce().is_empty(), "a received row never echoes back");
+        // And the author does not re-emit its own already-published row.
+        assert!(a.produce().is_empty(), "a published row is not re-authored");
+    }
+
+    #[test]
+    fn a_later_edit_supersedes_across_devices_and_both_converge() {
+        let mut a = Device::new();
+        let mut b = Device::new();
+        a.conn.execute("INSERT INTO t_demo(id, title) VALUES ('r1', 'base')", []).unwrap();
+        b.ingest_all(&a.produce(), &a.pubkey());
+
+        // A edits, syncs to B; then B edits (its lamport is now one past A's) and syncs back. B's
+        // edit is causally later, so it wins on BOTH devices — a proper Lamport-clock supersede,
+        // not a fingerprint coin-flip.
+        a.set_title("from-A");
+        b.ingest_all(&a.produce(), &a.pubkey());
+        assert_eq!(b.title().as_deref(), Some("from-A"), "A's edit reached B");
+
+        b.set_title("from-B");
+        a.ingest_all(&b.produce(), &b.pubkey());
+
+        assert_eq!(a.title(), b.title(), "the devices converge");
+        assert_eq!(a.title().as_deref(), Some("from-B"), "the causally-later edit wins on both");
+
+        // Steady state: nothing left to produce on either side.
+        assert!(a.produce().is_empty());
+        assert!(b.produce().is_empty());
+    }
+
+    #[test]
+    fn a_scope_with_multiple_tables_routes_each_op_to_its_table() {
+        const TA: TableSpec = TableSpec {
+            name: "t_a",
+            scope_id: "multi/1",
+            pk: &[ColumnSpec { name: "id", value_type: ValueType::Text }],
+            columns: &[ColumnSpec { name: "v", value_type: ValueType::Text }],
+            local_columns: &[],
+            repo_column: None,
+        };
+        const TB: TableSpec = TableSpec {
+            name: "t_b",
+            scope_id: "multi/1",
+            pk: &[ColumnSpec { name: "id", value_type: ValueType::Text }],
+            columns: &[ColumnSpec { name: "v", value_type: ValueType::Text }],
+            local_columns: &[],
+            repo_column: None,
+        };
+        const MULTI: &[TableSpec] = &[TA, TB];
+
+        let setup = || {
+            let conn = rusqlite::Connection::open_in_memory().unwrap();
+            rag_rat_db::schema::apply(&conn, &crate::test_hooks()).unwrap();
+            conn.execute_batch(
+                "CREATE TABLE t_a(id TEXT PRIMARY KEY, v TEXT) STRICT;
+                 CREATE TABLE t_b(id TEXT PRIMARY KEY, v TEXT) STRICT;",
+            )
+            .unwrap();
+            let local = crate::local_device(&conn, 0).unwrap();
+            (conn, local)
+        };
+        let (mut a_conn, a_dev) = setup();
+        let (mut b_conn, b_dev) = setup();
+        let account = AccountId::from_bytes([42; 32]);
+
+        // A writes a row into each table (both tables share the `multi/1` scope stream).
+        a_conn.execute("INSERT INTO t_a(id, v) VALUES ('r', 'in-a')", []).unwrap();
+        a_conn.execute("INSERT INTO t_b(id, v) VALUES ('r', 'in-b')", []).unwrap();
+        let entries = {
+            let tx = a_conn.transaction().unwrap();
+            let ctx = SyncCtx {
+                repo_id: "repo",
+                account_id: account,
+                device: &a_dev,
+                registry: MULTI,
+                now_ms: 0,
+            };
+            let e = produce_and_author(&tx, &ctx).unwrap();
+            tx.commit().unwrap();
+            e
+        };
+        assert_eq!(entries.len(), 2, "one op per table in the scope");
+
+        // B ingests both over the ONE shared scope stream; each must route to its own table.
+        {
+            let tx = b_conn.transaction().unwrap();
+            let ctx = SyncCtx {
+                repo_id: "repo",
+                account_id: account,
+                device: &b_dev,
+                registry: MULTI,
+                now_ms: 0,
+            };
+            for bytes in &entries {
+                assert_eq!(
+                    ingest(&tx, &ctx, "multi/1", bytes, &a_dev.secret().public()).unwrap(),
+                    IngestOutcome::Applied,
+                );
+            }
+            tx.commit().unwrap();
+        }
+        let a_val: String =
+            b_conn.query_row("SELECT v FROM t_a WHERE id = 'r'", [], |r| r.get(0)).unwrap();
+        let b_val: String =
+            b_conn.query_row("SELECT v FROM t_b WHERE id = 'r'", [], |r| r.get(0)).unwrap();
+        assert_eq!(
+            (a_val.as_str(), b_val.as_str()),
+            ("in-a", "in-b"),
+            "each op landed in its own table"
+        );
+    }
+}

--- a/crates/rag-rat-oplog/src/table_sync/mod.rs
+++ b/crates/rag-rat-oplog/src/table_sync/mod.rs
@@ -1,0 +1,18 @@
+//! The table→log sync engine: replicate derived/metadata table rows across an account's devices as
+//! self-describing typed-CBOR row ops on a signed per-scope stream, folded by per-column
+//! last-writer-wins.
+//!
+//! Transport-independent. The wire form ([`row_op`]) and the fold/produce pipeline are exercised by
+//! driving two DB connections through an in-process loopback; the iroh transport is a later
+//! milestone that plugs a `/4` sibling stream into `rag-rat-sync` (nothing here depends on it).
+//!
+//! This `mod.rs` is the curated index; the machinery lives in job-focused siblings. The re-export
+//! surface widens as the apply/produce siblings land and force each export.
+
+mod apply;
+mod engine;
+mod produce;
+mod registry;
+mod row_op;
+mod scope_stream;
+mod store;

--- a/crates/rag-rat-oplog/src/table_sync/produce.rs
+++ b/crates/rag-rat-oplog/src/table_sync/produce.rs
@@ -1,0 +1,203 @@
+//! The producer: a full-pass scan that emits the row ops needed to bring peers up to this device's
+//! state, and NOTHING for a row already in sync.
+//!
+//! For each current row it recomputes the synced-column hash and compares it against the
+//! published-rows record. No record or a stale one means a local change → an `Upsert`. A published
+//! identity with no live row means a local delete → a `Remove`. A row whose hash already matches
+//! the published record is skipped — and because the applier records that hash when it lands a
+//! remote row, **a row this device received is never re-emitted**. That is the anti-echo invariant:
+//! without it every applied remote row would be re-signed and rebroadcast by every peer, forever.
+
+use std::collections::BTreeSet;
+
+use rusqlite::{Transaction, params};
+
+use super::apply;
+use super::registry::TableSpec;
+use super::row_op::{self, RowOp};
+
+/// The row ops that carry this device's current state of `spec`'s table for `repo_id` to peers.
+/// Empty when everything is already published (the steady state).
+pub(crate) fn produce_row_ops(
+    tx: &Transaction<'_>,
+    spec: &TableSpec,
+    repo_id: &str,
+) -> anyhow::Result<Vec<RowOp>> {
+    let mut ops = Vec::new();
+    let mut live: BTreeSet<String> = BTreeSet::new();
+
+    for (pk, cells) in apply::read_all_rows(tx, spec, repo_id)? {
+        let row_pk = row_op::row_pk_string(&pk);
+        live.insert(row_pk.clone());
+        let hash = row_op::cells_hash(&cells);
+        if apply::published_hash(tx, repo_id, spec.name, &row_pk)?.as_deref() != Some(hash.as_str())
+        {
+            ops.push(RowOp::Upsert { table: spec.name.to_string(), pk, cells });
+        }
+    }
+
+    // A published identity with no live row is a local delete.
+    for row_pk in published_row_pks(tx, repo_id, spec.name)? {
+        if !live.contains(&row_pk) {
+            ops.push(RowOp::Remove {
+                table: spec.name.to_string(),
+                pk: row_op::row_pk_values(&row_pk)?,
+            });
+        }
+    }
+    Ok(ops)
+}
+
+fn published_row_pks(
+    tx: &Transaction<'_>,
+    repo_id: &str,
+    table: &str,
+) -> anyhow::Result<Vec<String>> {
+    let mut stmt = tx
+        .prepare("SELECT row_pk FROM sync_published_rows WHERE repo_id = ?1 AND table_name = ?2")?;
+    let rows = stmt
+        .query_map(params![repo_id, table], |row| row.get::<_, String>(0))?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    Ok(rows)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::op::{DeviceFingerprint, OpMeta};
+    use crate::table_sync::apply::apply_row_op;
+    use crate::table_sync::registry::{ColumnSpec, TableSpec, ValueType};
+    use crate::table_sync::row_op::{Cell, TypedValue};
+
+    const SPEC: TableSpec = TableSpec {
+        name: "t_demo",
+        scope_id: "demo/1",
+        pk: &[ColumnSpec { name: "id", value_type: ValueType::Text }],
+        columns: &[ColumnSpec { name: "title", value_type: ValueType::Text }],
+        local_columns: &["resolved_rowid"],
+        repo_column: None,
+    };
+
+    fn conn() -> rusqlite::Connection {
+        let c = rusqlite::Connection::open_in_memory().unwrap();
+        rag_rat_db::schema::apply(&c, &crate::test_hooks()).unwrap();
+        c.execute_batch(
+            "CREATE TABLE t_demo(id TEXT PRIMARY KEY, title TEXT, resolved_rowid INTEGER) STRICT;",
+        )
+        .unwrap();
+        c
+    }
+
+    fn upsert(id: &str, title: &str) -> RowOp {
+        RowOp::Upsert {
+            table: "t_demo".to_string(),
+            pk: vec![TypedValue::Text(id.to_string())],
+            cells: vec![Cell {
+                column: "title".to_string(),
+                value: TypedValue::Text(title.to_string()),
+            }],
+        }
+    }
+
+    #[test]
+    fn a_locally_written_row_is_produced_once_then_never_again() {
+        let mut c = conn();
+        let tx = c.transaction().unwrap();
+        // A row written WITHOUT going through the published-hash record (a raw local insert).
+        tx.execute("INSERT INTO t_demo(id, title) VALUES ('r1', 'hi')", []).unwrap();
+        let ops = produce_row_ops(&tx, &SPEC, "repo").unwrap();
+        assert_eq!(ops.len(), 1, "an unpublished local row is produced");
+        assert!(matches!(&ops[0], RowOp::Upsert { .. }));
+
+        // Applying our own op records the published hash; the next pass sees no delta.
+        apply_row_op(&tx, &SPEC, "repo", &ops[0], OpMeta {
+            lamport: 1,
+            device: DeviceFingerprint::from_bytes([1; 32]),
+        })
+        .unwrap();
+        assert!(
+            produce_row_ops(&tx, &SPEC, "repo").unwrap().is_empty(),
+            "a published row is not re-produced"
+        );
+    }
+
+    #[test]
+    fn a_received_row_is_never_re_emitted() {
+        // The flagship anti-echo case: applying a REMOTE op records the published hash, so this
+        // device's producer emits nothing for it — no ping-pong.
+        let mut c = conn();
+        let tx = c.transaction().unwrap();
+        apply_row_op(&tx, &SPEC, "repo", &upsert("r1", "from-peer"), OpMeta {
+            lamport: 9,
+            device: DeviceFingerprint::from_bytes([7; 32]),
+        })
+        .unwrap();
+        assert!(
+            produce_row_ops(&tx, &SPEC, "repo").unwrap().is_empty(),
+            "a row received from a peer must not be re-signed and rebroadcast",
+        );
+    }
+
+    #[test]
+    fn a_changed_row_is_re_produced() {
+        let mut c = conn();
+        let tx = c.transaction().unwrap();
+        apply_row_op(&tx, &SPEC, "repo", &upsert("r1", "v1"), OpMeta {
+            lamport: 1,
+            device: DeviceFingerprint::from_bytes([1; 32]),
+        })
+        .unwrap();
+        // A raw local edit (not through apply) leaves the published hash stale.
+        tx.execute("UPDATE t_demo SET title = 'v2' WHERE id = 'r1'", []).unwrap();
+        let ops = produce_row_ops(&tx, &SPEC, "repo").unwrap();
+        assert_eq!(ops.len(), 1, "a changed row is produced again");
+    }
+
+    #[test]
+    fn a_repo_scoped_producer_emits_only_the_current_repo() {
+        const SCOPED: TableSpec = TableSpec {
+            name: "t_scoped",
+            scope_id: "demo/1",
+            pk: &[ColumnSpec { name: "repo_id", value_type: ValueType::Text }, ColumnSpec {
+                name: "id",
+                value_type: ValueType::Text,
+            }],
+            columns: &[ColumnSpec { name: "title", value_type: ValueType::Text }],
+            local_columns: &[],
+            repo_column: Some("repo_id"),
+        };
+        let mut c = rusqlite::Connection::open_in_memory().unwrap();
+        rag_rat_db::schema::apply(&c, &crate::test_hooks()).unwrap();
+        c.execute_batch(
+            "CREATE TABLE t_scoped(
+                 repo_id TEXT NOT NULL, id TEXT NOT NULL, title TEXT, PRIMARY KEY(repo_id, id)
+             ) STRICT;
+             INSERT INTO t_scoped(repo_id, id, title) VALUES ('A','r1','a1'), ('B','r2','b1');",
+        )
+        .unwrap();
+        let tx = c.transaction().unwrap();
+        let ops = produce_row_ops(&tx, &SCOPED, "A").unwrap();
+        assert_eq!(ops.len(), 1, "only repo A's row is produced — never repo B's");
+        assert_eq!(
+            ops[0].pk()[0],
+            TypedValue::Text("A".to_string()),
+            "the produced row belongs to the repo being synced",
+        );
+    }
+
+    #[test]
+    fn a_deleted_row_produces_a_remove() {
+        let mut c = conn();
+        let tx = c.transaction().unwrap();
+        apply_row_op(&tx, &SPEC, "repo", &upsert("r1", "v1"), OpMeta {
+            lamport: 1,
+            device: DeviceFingerprint::from_bytes([1; 32]),
+        })
+        .unwrap();
+        // Row gone but its published identity remains → a Remove is produced.
+        tx.execute("DELETE FROM t_demo WHERE id = 'r1'", []).unwrap();
+        let ops = produce_row_ops(&tx, &SPEC, "repo").unwrap();
+        assert_eq!(ops.len(), 1);
+        assert!(matches!(&ops[0], RowOp::Remove { .. }), "a deleted row produces a Remove");
+    }
+}

--- a/crates/rag-rat-oplog/src/table_sync/registry.rs
+++ b/crates/rag-rat-oplog/src/table_sync/registry.rs
@@ -1,0 +1,926 @@
+//! The declarative registry of syncable tables.
+//!
+//! A [`TableSpec`] declares, for one physical table, which columns replicate (the `pk` identity
+//! plus the synced `columns`) and which are re-derived locally and must NEVER travel
+//! (`local_columns`). The engine is generic over `&[TableSpec]`, so the mechanism is exercised
+//! against a synthetic spec in tests; [`SYNCABLE_TABLES`] stays empty until the per-scope
+//! milestones register real tables (anchors, overlay, distill).
+//!
+//! [`assert_spec_covers_schema`] is the load-bearing invariant: every physical column must be
+//! classified exactly once — as pk, synced, or local. A newly-added physical column can never be
+//! silently unclassified (neither replicated nor deliberately local), which would be an invisible
+//! correctness gap.
+
+use std::collections::BTreeSet;
+
+use rusqlite::Connection;
+
+/// The storage/wire type of a synced column. A cell whose runtime value disagrees with its column's
+/// declared type is quarantined by the applier rather than silently coerced.
+///
+/// `Bool` stores as a STRICT `INTEGER` and must hold only 0 or 1. SQLite does not enforce that
+/// domain without a `CHECK (col IN (0, 1))`, which no pragma exposes for the lint to require — so a
+/// `Bool` column SHOULD carry that CHECK, and `read_typed` fail-closes (errors, halting the pass —
+/// never silently coercing) on any other integer as the runtime backstop.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ValueType {
+    Text,
+    I64,
+    Bool,
+    Blob,
+}
+
+/// One synced, non-pk column: its name and wire type. Merge is whole-row (all synced columns move
+/// together under the row's write clock), so a column carries no per-column merge policy.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ColumnSpec {
+    pub name: &'static str,
+    pub value_type: ValueType,
+}
+
+/// One syncable table. `pk` names the identity columns (encoded as the row op's `pk`); `columns`
+/// are the non-pk synced columns (encoded as the op's cells; the whole row is folded as a unit
+/// under its write clock); `local_columns` are re-derived from the local index and never
+/// replicated. `scope_id` names the `/4` stream this table rides — the routing key that binds it to
+/// an auth tier
+/// + retention class + flood budget.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct TableSpec {
+    pub name: &'static str,
+    pub scope_id: &'static str,
+    /// The identity columns, with types — the applier validates each incoming pk value against its
+    /// declared type so SQLite affinity can't coerce a mismatched pk (e.g. `I64(1)` onto a `TEXT`
+    /// key `'1'`) and split a row's bookkeeping.
+    pub pk: &'static [ColumnSpec],
+    pub columns: &'static [ColumnSpec],
+    pub local_columns: &'static [&'static str],
+    /// The column that scopes rows to a project, if the table is repo-scoped. It MUST be a
+    /// primary-key column (the exhaustiveness lint enforces this): the producer emits only rows
+    /// whose value here matches the repo being synced (so foreign-repo rows are never signed into
+    /// the wrong repo's stream), and the applier rejects an incoming op naming a different repo.
+    /// `None` for a table with no repo dimension.
+    pub repo_column: Option<&'static str>,
+}
+
+impl TableSpec {
+    /// The position of `repo_column` within `pk`, if the repo scope is a primary-key column — the
+    /// index the applier checks against the repo being synced.
+    pub fn repo_pk_index(&self) -> Option<usize> {
+        let repo_column = self.repo_column?;
+        self.pk.iter().position(|c| c.name == repo_column)
+    }
+}
+
+/// The registry of tables the engine replicates. Empty until the per-scope milestones (anchors,
+/// overlay, distill) register their tables; the engine's apply/produce take a `&[TableSpec]`, so
+/// nothing here is load-bearing yet — the mechanism is proven against a synthetic spec in tests.
+pub(crate) const SYNCABLE_TABLES: &[TableSpec] = &[];
+
+/// Assert a spec classifies EVERY physical column of its table exactly once — as pk, a synced
+/// column, or a local column — and names no column the table doesn't have. This is the invariant
+/// that stops a new column being silently unclassified: it is either replicated or deliberately
+/// local, never neither. Returns a human-readable diff on mismatch.
+pub(crate) fn assert_spec_covers_schema(conn: &Connection, spec: &TableSpec) -> Result<(), String> {
+    let columns = physical_column_info(conn, spec.name)
+        .map_err(|err| format!("cannot read columns of `{}`: {err}", spec.name))?;
+    let physical: Vec<&str> = columns.iter().map(|c| c.name.as_str()).collect();
+
+    let mut classified: BTreeSet<&str> = BTreeSet::new();
+    let mut duplicated: Vec<&str> = Vec::new();
+    let declared = spec
+        .pk
+        .iter()
+        .map(|c| c.name)
+        .chain(spec.columns.iter().map(|c| c.name))
+        .chain(spec.local_columns.iter().copied());
+    for name in declared {
+        if !classified.insert(name) {
+            duplicated.push(name);
+        }
+    }
+    if !duplicated.is_empty() {
+        return Err(format!(
+            "`{}`: column(s) classified more than once: {duplicated:?}",
+            spec.name
+        ));
+    }
+
+    let physical_set: BTreeSet<&str> = physical.iter().copied().collect();
+    let unclassified: Vec<&str> = physical_set.difference(&classified).copied().collect();
+    let absent: Vec<&str> = classified.difference(&physical_set).copied().collect();
+    if !unclassified.is_empty() || !absent.is_empty() {
+        return Err(format!(
+            "`{}` registry/schema mismatch: physical columns not classified {unclassified:?}; \
+             classified columns absent from the table {absent:?}",
+            spec.name
+        ));
+    }
+
+    // A repo scope must be a primary-key column: only then does the applier's repo-identity gate
+    // fire on every incoming op. A non-pk repo column would filter the producer but leave ingest
+    // unguarded, so a peer could write another repo's row into the shared table.
+    if let Some(repo_column) = spec.repo_column {
+        match spec.repo_pk_index() {
+            None => {
+                return Err(format!(
+                    "`{}`: repo_column `{repo_column}` must be a primary-key column so the ingest \
+                     repo gate applies",
+                    spec.name
+                ));
+            },
+            // The applier's repo gate compares the repo pk value to `TypedValue::Text(repo_id)`, so
+            // a non-Text scope key never matches — every locally-produced row self-quarantines and
+            // the whole table can never sync.
+            Some(idx) if spec.pk[idx].value_type != ValueType::Text => {
+                return Err(format!(
+                    "`{}`: repo_column `{repo_column}` must be ValueType::Text (the repo gate \
+                     compares it to the text repo_id)",
+                    spec.name
+                ));
+            },
+            Some(_) => {},
+        }
+    }
+
+    // The whole-row apply/produce SQL builds a `SELECT`/`SET` over the synced columns; a spec with
+    // no synced non-key column would emit empty-column SQL (`SELECT  FROM …`) at apply time. A
+    // key-only (pure set-membership) table would need a deliberately designed empty-row path
+    // (existence-only hash, no-op update) that whole-row LWW does not have — reject it here rather
+    // than emit invalid SQL when its first row is applied.
+    if spec.columns.is_empty() {
+        return Err(format!(
+            "`{}`: a syncable table must declare at least one synced non-key column; a key-only \
+             table is not supported by the whole-row apply path",
+            spec.name
+        ));
+    }
+
+    // The declared `pk` must be EXACTLY the table's real primary key, in order. The classification
+    // check above only matched column NAMES, so a spec could name a non-key column as `pk` (or bury
+    // a real key column in `columns`/`local_columns`): row identity would then be non-unique — one
+    // op could update or delete several physical rows through `pk_where`, and the per-row clock /
+    // tombstone key would not identify a single row. Compare against `PRAGMA table_info`'s pk
+    // order.
+    let mut pk_cols: Vec<&PhysicalColumn> = columns.iter().filter(|c| c.pk_position > 0).collect();
+    pk_cols.sort_by_key(|c| c.pk_position);
+    let actual_pk: Vec<&str> = pk_cols.iter().map(|c| c.name.as_str()).collect();
+    let declared_pk: Vec<&str> = spec.pk.iter().map(|c| c.name).collect();
+    if actual_pk != declared_pk {
+        return Err(format!(
+            "`{}`: declared pk {declared_pk:?} does not match the table's primary key \
+             {actual_pk:?} (identical columns, identical order required)",
+            spec.name
+        ));
+    }
+
+    // Every pk column must be NOT NULL. A rowid table's bare `id TEXT PRIMARY KEY` is NULLABLE
+    // (SQLite's historic quirk) — a NULL pk is unaddressable, so `read_all_rows` emits a Null pk
+    // that self-apply quarantines, and `produce_and_author` then re-signs that ghost row on
+    // every pass. A STRICT table makes its pk NOT NULL (table_info reports it), which is the
+    // intended shape.
+    for col in &pk_cols {
+        if !col.not_null {
+            return Err(format!(
+                "`{}`: primary-key column `{}` is nullable — declare it NOT NULL (a STRICT table \
+                 does this implicitly); a NULL pk is unaddressable and self-quarantines",
+                spec.name, col.name
+            ));
+        }
+    }
+
+    // Every pk column must use BINARY equality. A non-binary collation (e.g. `COLLATE NOCASE`)
+    // makes SQLite treat values differing only by collation as ONE row in the `WHERE`
+    // predicates, but `row_op::row_pk_string` encodes them as DIFFERENT bookkeeping identities
+    // — so one physical row would carry two write clocks / published hashes and diverge (or
+    // suppress the wrong update).
+    if let Some(col) = pk_column_with_non_binary_collation(conn, spec.name)
+        .map_err(|err| format!("cannot read the pk collation of `{}`: {err}", spec.name))?
+    {
+        return Err(format!(
+            "`{}`: primary-key column `{col}` uses a non-BINARY collation — the row-clock \
+             encoding is byte-exact, so collation-equal keys would split one row's bookkeeping; \
+             use BINARY",
+            spec.name
+        ));
+    }
+
+    // Whole-row LWW converges per row INDEPENDENTLY — each row's fate is decided solely by its own
+    // write clock. A CROSS-ROW constraint breaks that: the same op set can fold to different states
+    // under different arrival orders (two rows racing for one UNIQUE value: whichever loses is
+    // quarantined, and WHICH loses depends on order), so peers diverge with no dirty-local edit. A
+    // foreign key is the same class (a delete/insert can fail against another row). Reject both
+    // until a deterministic cross-row conflict rule exists.
+    if table_has_foreign_key(conn, spec.name)
+        .map_err(|err| format!("cannot read foreign keys of `{}`: {err}", spec.name))?
+    {
+        return Err(format!(
+            "`{}`: a foreign key makes whole-row LWW order-dependent (an op can fail against \
+             another row) — not supported",
+            spec.name
+        ));
+    }
+    // The inbound direction is the same hazard: a table REFERENCED by another's FK can have a
+    // `Remove` blocked (FK RESTRICT) on a peer that holds a child row but not on one that doesn't →
+    // the delete quarantines on one side, applies on the other, and the replicas diverge.
+    if table_is_referenced_by_foreign_key(conn, spec.name)
+        .map_err(|err| format!("cannot scan foreign keys referencing `{}`: {err}", spec.name))?
+    {
+        return Err(format!(
+            "`{}`: another table has a foreign key referencing it — a delete can be blocked on \
+             one peer but not another, so whole-row LWW diverges — not supported",
+            spec.name
+        ));
+    }
+    // A trigger breaks the whole-row fold's assumption that a row write is independent and
+    // deterministic: an INSERT/UPDATE/DELETE trigger can adjust the row (or others) from local
+    // derived state, so the SAME received op folds to different physical results on two devices,
+    // and apply_upsert then publishes each divergent result — the replicas stay divergent.
+    if let Some(trigger) = table_trigger(conn, spec.name)
+        .map_err(|err| format!("cannot read triggers of `{}`: {err}", spec.name))?
+    {
+        return Err(format!(
+            "`{}`: trigger `{trigger}` can mutate a row from local/derived state, so the same op \
+             folds differently across devices — not supported",
+            spec.name
+        ));
+    }
+    if let Some(index) = non_pk_unique_index(conn, spec.name)
+        .map_err(|err| format!("cannot read indexes of `{}`: {err}", spec.name))?
+    {
+        return Err(format!(
+            "`{}`: UNIQUE index `{index}` is a cross-row constraint that makes whole-row LWW \
+             order-dependent (two rows racing for one value diverge by arrival order) — not \
+             supported",
+            spec.name
+        ));
+    }
+
+    // Every local (never-replicated) column must be nullable or carry a DB default: a remote upsert
+    // INSERTs only the pk + synced columns (a local column is re-derived here, not sent), so a NOT
+    // NULL local column with no default makes that insert fail and the applier quarantine the op —
+    // the row would then be absent on every new peer that never authored it locally.
+    for local in spec.local_columns {
+        if let Some(col) = columns.iter().find(|c| c.name == *local)
+            && col.not_null
+            && !col.has_default
+        {
+            return Err(format!(
+                "`{}`: local column `{local}` is NOT NULL without a default, so a remote insert \
+                 (pk + synced columns only) cannot materialize the row",
+                spec.name
+            ));
+        }
+    }
+
+    // The table MUST be STRICT. STRICT enforces the declared column type at write time, so a value
+    // the producer read (by its `ValueType`) can never be affinity-coerced to a different stored
+    // type — which would make the post-write `synced_row_hash` read-back throw and wedge ingest
+    // after the row was already written. It also makes pk columns NOT NULL. It is the schema
+    // convention for every new table regardless.
+    if !table_is_strict(conn, spec.name)
+        .map_err(|err| format!("cannot read the schema of `{}`: {err}", spec.name))?
+    {
+        return Err(format!(
+            "`{}`: a syncable table must be STRICT (enforced column types keep an applied value \
+             from being coerced to a type the producer did not read)",
+            spec.name
+        ));
+    }
+
+    // Each replicated column's declared `ValueType` must match its physical STRICT type, so the
+    // value the producer reads round-trips through SQLite unchanged and a peer's op passes the
+    // applier's type check. (Local columns are re-derived, never sent, so they are exempt.)
+    for spec_col in spec.pk.iter().chain(spec.columns.iter()) {
+        let Some(phys) = columns.iter().find(|c| c.name == spec_col.name) else {
+            continue; // classified/absent already checked above
+        };
+        if !value_type_matches_declared(spec_col.value_type, &phys.decl_type) {
+            return Err(format!(
+                "`{}`: column `{}` is declared {:?} in the spec but has physical type `{}` — the \
+                 two must agree so values round-trip unchanged",
+                spec.name, spec_col.name, spec_col.value_type, phys.decl_type
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Whether `table` is a STRICT table. SQLite exposes no pragma for this, so read the table options
+/// that follow the column-list's closing `)` (all column-level parens nest inside it, so the LAST
+/// `)` is always that closer) and look for the `STRICT` keyword.
+fn table_is_strict(conn: &Connection, table: &str) -> rusqlite::Result<bool> {
+    let sql: String = conn.query_row(
+        "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?1",
+        [table],
+        |row| row.get(0),
+    )?;
+    let options = sql.rsplit(')').next().unwrap_or_default();
+    Ok(options
+        .to_ascii_uppercase()
+        .split(|c: char| c == ',' || c.is_whitespace())
+        .any(|token| token == "STRICT"))
+}
+
+/// Whether a declared `ValueType` matches a physical STRICT column type. `Bool` and `I64` both
+/// store as INTEGER; `Text`/`Blob` map to their obvious types. The permissive `ANY` is rejected — a
+/// typed column must pin its type so a stored value can never be a different type than the producer
+/// reads.
+fn value_type_matches_declared(vt: ValueType, decl_type: &str) -> bool {
+    match vt {
+        ValueType::Text => decl_type == "TEXT",
+        ValueType::I64 | ValueType::Bool => decl_type == "INTEGER" || decl_type == "INT",
+        ValueType::Blob => decl_type == "BLOB",
+    }
+}
+
+/// Assert the registry is internally consistent: no physical table name registered under more than
+/// one spec. Two specs for one table would share its `(repo_id, table, row_pk)` clock / tombstone /
+/// published rows across two streams — cross-scope LWW interference (the first stream to publish a
+/// row silences the second, and received writes compete through one clock). Called over the whole
+/// [`SYNCABLE_TABLES`] set, complementing the per-spec [`assert_spec_covers_schema`].
+pub(crate) fn assert_registry_consistent(registry: &[TableSpec]) -> Result<(), String> {
+    let mut seen: BTreeSet<&str> = BTreeSet::new();
+    for spec in registry {
+        if !seen.insert(spec.name) {
+            return Err(format!(
+                "table `{}` is registered under more than one spec/scope; its per-row bookkeeping \
+                 keys on (repo_id, table, row_pk) and would be shared across streams",
+                spec.name
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// One physical column of a table, from `PRAGMA table_info` (`conn.pragma` quotes the table name,
+/// so a spec name never needs manual escaping). `pk_position` is the 1-based position within the
+/// primary key, or `0` for a non-key column. `decl_type` is the declared column type (uppercased) —
+/// on a STRICT table one of `INT`/`INTEGER`/`REAL`/`TEXT`/`BLOB`/`ANY`.
+struct PhysicalColumn {
+    name: String,
+    decl_type: String,
+    not_null: bool,
+    has_default: bool,
+    pk_position: i64,
+}
+
+/// Whether `table` declares any foreign key (`PRAGMA foreign_key_list` returns a row per FK).
+fn table_has_foreign_key(conn: &Connection, table: &str) -> rusqlite::Result<bool> {
+    let mut any = false;
+    conn.pragma(None, "foreign_key_list", table, |_row| {
+        any = true;
+        Ok(())
+    })?;
+    Ok(any)
+}
+
+/// The name of `table`'s first UNIQUE index that is NOT the primary key, if any (a cross-row
+/// constraint). `PRAGMA index_list` columns: 0 seq, 1 name, 2 unique, 3 origin, 4 partial; `origin`
+/// is `pk` for the primary key's implicit index, `u` for a UNIQUE constraint, `c` for a
+/// `CREATE UNIQUE INDEX`.
+fn non_pk_unique_index(conn: &Connection, table: &str) -> rusqlite::Result<Option<String>> {
+    let mut found = None;
+    conn.pragma(None, "index_list", table, |row| {
+        let unique: i64 = row.get(2)?;
+        let origin: String = row.get(3)?;
+        if unique != 0 && origin != "pk" && found.is_none() {
+            found = Some(row.get::<_, String>(1)?);
+        }
+        Ok(())
+    })?;
+    Ok(found)
+}
+
+/// The first pk column that uses a non-BINARY collation, if any. Reads the primary key's index
+/// (`PRAGMA index_list` origin=`pk` → `index_xinfo`, whose col 2 is the column name — NULL for the
+/// implicit rowid — and col 4 the collation). An INTEGER-rowid pk has no such index (integers have
+/// no collation), so it returns `None`.
+fn pk_column_with_non_binary_collation(
+    conn: &Connection,
+    table: &str,
+) -> rusqlite::Result<Option<String>> {
+    let mut pk_index = None;
+    conn.pragma(None, "index_list", table, |row| {
+        if row.get::<_, String>(3)? == "pk" {
+            pk_index = Some(row.get::<_, String>(1)?);
+        }
+        Ok(())
+    })?;
+    let Some(index) = pk_index else { return Ok(None) };
+    let mut offending = None;
+    conn.pragma(None, "index_xinfo", &index, |row| {
+        // index_xinfo columns: 0 seqno, 1 cid, 2 name (NULL for the rowid), 3 desc, 4 coll, 5 key.
+        let name: Option<String> = row.get(2)?;
+        let collation: String = row.get(4)?;
+        if let Some(name) = name
+            && !collation.eq_ignore_ascii_case("BINARY")
+            && offending.is_none()
+        {
+            offending = Some(name);
+        }
+        Ok(())
+    })?;
+    Ok(offending)
+}
+
+/// The name of the first trigger on `table`, if any (`sqlite_master` type='trigger'). A trigger can
+/// mutate the row (or other rows) from local/derived state, so the SAME received op could fold to
+/// different physical results on two devices — divergence the whole-row fold can't detect.
+fn table_trigger(conn: &Connection, table: &str) -> rusqlite::Result<Option<String>> {
+    let mut stmt =
+        conn.prepare("SELECT name FROM sqlite_master WHERE type = 'trigger' AND tbl_name = ?1")?;
+    let mut rows = stmt.query([table])?;
+    match rows.next()? {
+        Some(row) => Ok(Some(row.get(0)?)),
+        None => Ok(None),
+    }
+}
+
+/// Whether any OTHER table declares a foreign key REFERENCING `table` (an inbound reference). Scans
+/// every base table's `PRAGMA foreign_key_list` (col 2 is the referenced table).
+fn table_is_referenced_by_foreign_key(conn: &Connection, table: &str) -> rusqlite::Result<bool> {
+    let mut tables = Vec::new();
+    {
+        let mut stmt = conn.prepare(
+            "SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'",
+        )?;
+        let rows = stmt.query_map([], |row| row.get::<_, String>(0))?;
+        for row in rows {
+            tables.push(row?);
+        }
+    }
+    for other in tables {
+        if other == table {
+            continue;
+        }
+        let mut references = false;
+        conn.pragma(None, "foreign_key_list", &other, |row| {
+            // foreign_key_list columns: 0 id, 1 seq, 2 table (the referenced table), 3 from, 4 to.
+            if row.get::<_, String>(2)? == table {
+                references = true;
+            }
+            Ok(())
+        })?;
+        if references {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+fn physical_column_info(conn: &Connection, table: &str) -> rusqlite::Result<Vec<PhysicalColumn>> {
+    let mut cols = Vec::new();
+    conn.pragma(None, "table_info", table, |row| {
+        // PRAGMA table_info columns: 0 cid, 1 name, 2 type, 3 notnull, 4 dflt_value, 5 pk.
+        cols.push(PhysicalColumn {
+            name: row.get::<_, String>(1)?,
+            decl_type: row.get::<_, String>(2)?.to_ascii_uppercase(),
+            not_null: row.get::<_, i64>(3)? != 0,
+            has_default: row.get::<_, Option<String>>(4)?.is_some(),
+            pk_position: row.get::<_, i64>(5)?,
+        });
+        Ok(())
+    })?;
+    Ok(cols)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const DEMO_PK: &[ColumnSpec] = &[ColumnSpec { name: "id", value_type: ValueType::Text }];
+    const DEMO_COLUMNS: &[ColumnSpec] =
+        &[ColumnSpec { name: "title", value_type: ValueType::Text }, ColumnSpec {
+            name: "count",
+            value_type: ValueType::I64,
+        }];
+    const DEMO_LOCAL: &[&str] = &["resolved_rowid"];
+    const DEMO_SPEC: TableSpec = TableSpec {
+        name: "t_demo",
+        scope_id: "demo/1",
+        pk: DEMO_PK,
+        columns: DEMO_COLUMNS,
+        local_columns: DEMO_LOCAL,
+        repo_column: None,
+    };
+
+    fn demo_conn() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE t_demo(
+                 id TEXT PRIMARY KEY,
+                 title TEXT NOT NULL,
+                 count INTEGER NOT NULL,
+                 resolved_rowid INTEGER
+             ) STRICT;",
+        )
+        .unwrap();
+        conn
+    }
+
+    #[test]
+    fn a_spec_that_classifies_every_column_passes() {
+        assert!(assert_spec_covers_schema(&demo_conn(), &DEMO_SPEC).is_ok());
+    }
+
+    #[test]
+    fn a_physical_column_missing_from_the_spec_fails() {
+        // The table has an extra `note` column the spec forgot to classify.
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE t_demo(
+                 id TEXT PRIMARY KEY, title TEXT NOT NULL, count INTEGER NOT NULL,
+                 resolved_rowid INTEGER, note TEXT
+             ) STRICT;",
+        )
+        .unwrap();
+        let err = assert_spec_covers_schema(&conn, &DEMO_SPEC).unwrap_err();
+        assert!(err.contains("note"), "the unclassified column is named: {err}");
+    }
+
+    #[test]
+    fn a_spec_column_absent_from_the_table_fails() {
+        // The spec names `count` but the table doesn't have it.
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE t_demo(id TEXT PRIMARY KEY, title TEXT NOT NULL, resolved_rowid \
+             INTEGER) STRICT;",
+        )
+        .unwrap();
+        let err = assert_spec_covers_schema(&conn, &DEMO_SPEC).unwrap_err();
+        assert!(err.contains("count"), "the phantom column is named: {err}");
+    }
+
+    #[test]
+    fn a_column_classified_twice_fails() {
+        const DOUBLED: TableSpec = TableSpec {
+            name: "t_demo",
+            scope_id: "demo/1",
+            pk: DEMO_PK,
+            // `title` is both a synced column and (wrongly) a local column.
+            columns: DEMO_COLUMNS,
+            local_columns: &["resolved_rowid", "title"],
+            repo_column: None,
+        };
+        let err = assert_spec_covers_schema(&demo_conn(), &DOUBLED).unwrap_err();
+        assert!(err.contains("title"), "the doubly-classified column is named: {err}");
+    }
+
+    #[test]
+    fn a_repo_column_that_is_not_a_primary_key_fails() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("CREATE TABLE t_x(id TEXT PRIMARY KEY, repo_id TEXT NOT NULL) STRICT;")
+            .unwrap();
+        const BAD: TableSpec = TableSpec {
+            name: "t_x",
+            scope_id: "demo/1",
+            pk: &[ColumnSpec { name: "id", value_type: ValueType::Text }],
+            columns: &[ColumnSpec { name: "repo_id", value_type: ValueType::Text }],
+            local_columns: &[],
+            repo_column: Some("repo_id"), /* a synced column, not a pk — the ingest gate would
+                                           * miss it */
+        };
+        let err = assert_spec_covers_schema(&conn, &BAD).unwrap_err();
+        assert!(err.contains("primary-key"), "a non-pk repo column is rejected: {err}");
+    }
+
+    #[test]
+    fn a_key_only_table_with_no_synced_columns_fails() {
+        // A table whose entire row is its composite pk has no synced non-key column; the whole-row
+        // apply path would build empty-column SQL, so the lint rejects the shape up front.
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE t_members(group_id TEXT NOT NULL, member_id TEXT NOT NULL, PRIMARY \
+             KEY(group_id, member_id)) STRICT;",
+        )
+        .unwrap();
+        const KEY_ONLY: TableSpec = TableSpec {
+            name: "t_members",
+            scope_id: "demo/1",
+            pk: &[ColumnSpec { name: "group_id", value_type: ValueType::Text }, ColumnSpec {
+                name: "member_id",
+                value_type: ValueType::Text,
+            }],
+            columns: &[],
+            local_columns: &[],
+            repo_column: None,
+        };
+        let err = assert_spec_covers_schema(&conn, &KEY_ONLY).unwrap_err();
+        assert!(
+            err.contains("at least one synced non-key column"),
+            "a key-only table is rejected: {err}"
+        );
+    }
+
+    #[test]
+    fn a_declared_pk_that_does_not_match_the_schema_fails() {
+        // The table's real primary key is (a, b), but the spec declares only `a` as pk and buries
+        // the real key column `b` in `columns` — every name is still classified once, so only the
+        // pk-vs-schema check catches the non-unique identity.
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE t_pk(a TEXT NOT NULL, b TEXT NOT NULL, v TEXT, PRIMARY KEY(a, b)) \
+             STRICT;",
+        )
+        .unwrap();
+        const WRONG_PK: TableSpec = TableSpec {
+            name: "t_pk",
+            scope_id: "demo/1",
+            pk: &[ColumnSpec { name: "a", value_type: ValueType::Text }],
+            columns: &[ColumnSpec { name: "b", value_type: ValueType::Text }, ColumnSpec {
+                name: "v",
+                value_type: ValueType::Text,
+            }],
+            local_columns: &[],
+            repo_column: None,
+        };
+        let err = assert_spec_covers_schema(&conn, &WRONG_PK).unwrap_err();
+        assert!(
+            err.contains("does not match the table's primary key"),
+            "the pk mismatch is named: {err}"
+        );
+    }
+
+    #[test]
+    fn a_not_null_local_column_without_a_default_fails() {
+        // A remote insert supplies only pk + synced columns, so a NOT NULL local column with no
+        // default would make that insert fail — the lint rejects the shape up front.
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE t_nn_local(id TEXT PRIMARY KEY, syn TEXT, loc TEXT NOT NULL) STRICT;",
+        )
+        .unwrap();
+        const NN_LOCAL: TableSpec = TableSpec {
+            name: "t_nn_local",
+            scope_id: "demo/1",
+            pk: &[ColumnSpec { name: "id", value_type: ValueType::Text }],
+            columns: &[ColumnSpec { name: "syn", value_type: ValueType::Text }],
+            local_columns: &["loc"],
+            repo_column: None,
+        };
+        let err = assert_spec_covers_schema(&conn, &NN_LOCAL).unwrap_err();
+        assert!(
+            err.contains("NOT NULL without a default"),
+            "the required local column is named: {err}"
+        );
+    }
+
+    #[test]
+    fn a_not_null_local_column_with_a_default_passes() {
+        // The same shape but with a DB default on the local column is fine — a remote insert leaves
+        // it to the default, and the local index re-derives it.
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE t_def_local(id TEXT PRIMARY KEY, syn TEXT, loc INTEGER NOT NULL DEFAULT \
+             0) STRICT;",
+        )
+        .unwrap();
+        const DEF_LOCAL: TableSpec = TableSpec {
+            name: "t_def_local",
+            scope_id: "demo/1",
+            pk: &[ColumnSpec { name: "id", value_type: ValueType::Text }],
+            columns: &[ColumnSpec { name: "syn", value_type: ValueType::Text }],
+            local_columns: &["loc"],
+            repo_column: None,
+        };
+        assert!(assert_spec_covers_schema(&conn, &DEF_LOCAL).is_ok());
+    }
+
+    #[test]
+    fn a_nullable_primary_key_fails() {
+        // A non-STRICT rowid table's bare `id TEXT PRIMARY KEY` is NULLABLE (SQLite quirk); a NULL
+        // pk self-quarantines and gets re-signed every producer pass.
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("CREATE TABLE t_np(id TEXT PRIMARY KEY, v TEXT);").unwrap();
+        const NP: TableSpec = TableSpec {
+            name: "t_np",
+            scope_id: "demo/1",
+            pk: &[ColumnSpec { name: "id", value_type: ValueType::Text }],
+            columns: &[ColumnSpec { name: "v", value_type: ValueType::Text }],
+            local_columns: &[],
+            repo_column: None,
+        };
+        let err = assert_spec_covers_schema(&conn, &NP).unwrap_err();
+        assert!(err.contains("nullable"), "a nullable pk is rejected: {err}");
+    }
+
+    #[test]
+    fn a_foreign_key_fails() {
+        // A foreign key is a cross-row constraint: a delete/insert can fail against another row, so
+        // whole-row LWW becomes order-dependent (peers diverge).
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE parent(id TEXT NOT NULL PRIMARY KEY, v TEXT) STRICT;
+             CREATE TABLE t_fk(id TEXT NOT NULL PRIMARY KEY, v TEXT, p TEXT REFERENCES parent(id)) \
+             STRICT;",
+        )
+        .unwrap();
+        const FK: TableSpec = TableSpec {
+            name: "t_fk",
+            scope_id: "demo/1",
+            pk: &[ColumnSpec { name: "id", value_type: ValueType::Text }],
+            columns: &[ColumnSpec { name: "v", value_type: ValueType::Text }, ColumnSpec {
+                name: "p",
+                value_type: ValueType::Text,
+            }],
+            local_columns: &[],
+            repo_column: None,
+        };
+        let err = assert_spec_covers_schema(&conn, &FK).unwrap_err();
+        assert!(err.contains("foreign key"), "an FK table is rejected: {err}");
+    }
+
+    #[test]
+    fn a_non_pk_unique_index_fails() {
+        // A UNIQUE constraint on a non-pk column is a cross-row constraint: two rows racing for one
+        // value fold differently by arrival order, so peers diverge.
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE t_u(id TEXT NOT NULL PRIMARY KEY, email TEXT UNIQUE) STRICT;",
+        )
+        .unwrap();
+        const U: TableSpec = TableSpec {
+            name: "t_u",
+            scope_id: "demo/1",
+            pk: &[ColumnSpec { name: "id", value_type: ValueType::Text }],
+            columns: &[ColumnSpec { name: "email", value_type: ValueType::Text }],
+            local_columns: &[],
+            repo_column: None,
+        };
+        let err = assert_spec_covers_schema(&conn, &U).unwrap_err();
+        assert!(err.contains("UNIQUE index"), "a non-pk UNIQUE table is rejected: {err}");
+    }
+
+    #[test]
+    fn a_non_strict_table_fails() {
+        // Otherwise valid (explicit NOT NULL pk, no FK/UNIQUE, matching types) but NOT STRICT — an
+        // applied value could be affinity-coerced and wedge the post-write hash read-back.
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("CREATE TABLE t_ns(id TEXT NOT NULL PRIMARY KEY, v TEXT);").unwrap();
+        const NS: TableSpec = TableSpec {
+            name: "t_ns",
+            scope_id: "demo/1",
+            pk: &[ColumnSpec { name: "id", value_type: ValueType::Text }],
+            columns: &[ColumnSpec { name: "v", value_type: ValueType::Text }],
+            local_columns: &[],
+            repo_column: None,
+        };
+        let err = assert_spec_covers_schema(&conn, &NS).unwrap_err();
+        assert!(err.contains("must be STRICT"), "a non-STRICT table is rejected: {err}");
+    }
+
+    #[test]
+    fn a_declared_value_type_that_disagrees_with_the_physical_type_fails() {
+        // `n` is physically INTEGER but the spec declares it Text.
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("CREATE TABLE t_tm(id TEXT NOT NULL PRIMARY KEY, n INTEGER) STRICT;")
+            .unwrap();
+        const TM: TableSpec = TableSpec {
+            name: "t_tm",
+            scope_id: "demo/1",
+            pk: &[ColumnSpec { name: "id", value_type: ValueType::Text }],
+            columns: &[ColumnSpec { name: "n", value_type: ValueType::Text }],
+            local_columns: &[],
+            repo_column: None,
+        };
+        let err = assert_spec_covers_schema(&conn, &TM).unwrap_err();
+        assert!(
+            err.contains("physical type"),
+            "a ValueType/physical-type mismatch is rejected: {err}"
+        );
+    }
+
+    #[test]
+    fn a_table_registered_under_two_scopes_fails() {
+        const A: TableSpec = TableSpec {
+            name: "t_dup",
+            scope_id: "scope-a/1",
+            pk: &[ColumnSpec { name: "id", value_type: ValueType::Text }],
+            columns: &[ColumnSpec { name: "v", value_type: ValueType::Text }],
+            local_columns: &[],
+            repo_column: None,
+        };
+        const B: TableSpec = TableSpec {
+            name: "t_dup",
+            scope_id: "scope-b/1",
+            pk: &[ColumnSpec { name: "id", value_type: ValueType::Text }],
+            columns: &[ColumnSpec { name: "v", value_type: ValueType::Text }],
+            local_columns: &[],
+            repo_column: None,
+        };
+        let err = assert_registry_consistent(&[A, B]).unwrap_err();
+        assert!(err.contains("more than one spec"), "a table under two scopes is rejected: {err}");
+        assert!(assert_registry_consistent(&[A]).is_ok(), "a single registration is fine");
+    }
+
+    #[test]
+    fn a_non_text_repo_column_fails() {
+        // The applier's repo gate compares the repo pk value to a TEXT repo_id, so a non-Text repo
+        // scope key never matches → every row self-quarantines.
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE t_ri(rid INTEGER NOT NULL, id TEXT NOT NULL, v TEXT, PRIMARY KEY(rid, \
+             id)) STRICT;",
+        )
+        .unwrap();
+        const RI: TableSpec = TableSpec {
+            name: "t_ri",
+            scope_id: "demo/1",
+            pk: &[ColumnSpec { name: "rid", value_type: ValueType::I64 }, ColumnSpec {
+                name: "id",
+                value_type: ValueType::Text,
+            }],
+            columns: &[ColumnSpec { name: "v", value_type: ValueType::Text }],
+            local_columns: &[],
+            repo_column: Some("rid"),
+        };
+        let err = assert_spec_covers_schema(&conn, &RI).unwrap_err();
+        assert!(
+            err.contains("must be ValueType::Text"),
+            "a non-Text repo column is rejected: {err}"
+        );
+    }
+
+    #[test]
+    fn a_table_referenced_by_a_foreign_key_fails() {
+        // No outbound FK, but a child table references it — the same cross-row delete hazard.
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE t_ref(id TEXT NOT NULL PRIMARY KEY, v TEXT) STRICT;
+             CREATE TABLE kid(id TEXT NOT NULL PRIMARY KEY, r TEXT REFERENCES t_ref(id)) STRICT;",
+        )
+        .unwrap();
+        const REF: TableSpec = TableSpec {
+            name: "t_ref",
+            scope_id: "demo/1",
+            pk: &[ColumnSpec { name: "id", value_type: ValueType::Text }],
+            columns: &[ColumnSpec { name: "v", value_type: ValueType::Text }],
+            local_columns: &[],
+            repo_column: None,
+        };
+        let err = assert_spec_covers_schema(&conn, &REF).unwrap_err();
+        assert!(err.contains("referencing it"), "an inbound-FK table is rejected: {err}");
+    }
+
+    #[test]
+    fn a_non_binary_pk_collation_fails() {
+        // A `COLLATE NOCASE` pk: SQLite treats "a"/"A" as one row, but the row-clock encoding is
+        // byte-exact → split bookkeeping for one physical row.
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE t_ci(id TEXT COLLATE NOCASE NOT NULL PRIMARY KEY, v TEXT) STRICT;",
+        )
+        .unwrap();
+        const CI: TableSpec = TableSpec {
+            name: "t_ci",
+            scope_id: "demo/1",
+            pk: &[ColumnSpec { name: "id", value_type: ValueType::Text }],
+            columns: &[ColumnSpec { name: "v", value_type: ValueType::Text }],
+            local_columns: &[],
+            repo_column: None,
+        };
+        let err = assert_spec_covers_schema(&conn, &CI).unwrap_err();
+        assert!(err.contains("non-BINARY collation"), "a NOCASE pk is rejected: {err}");
+    }
+
+    #[test]
+    fn a_table_with_a_trigger_fails() {
+        // An AFTER INSERT trigger that mutates a synced cell makes the same received op fold to a
+        // different physical row across devices.
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE t_trig(id TEXT NOT NULL PRIMARY KEY, v TEXT, n INTEGER NOT NULL DEFAULT \
+             0) STRICT;
+             CREATE TRIGGER t_trig_ai AFTER INSERT ON t_trig
+                 BEGIN UPDATE t_trig SET n = n + 1 WHERE id = NEW.id; END;",
+        )
+        .unwrap();
+        const TRIG: TableSpec = TableSpec {
+            name: "t_trig",
+            scope_id: "demo/1",
+            pk: &[ColumnSpec { name: "id", value_type: ValueType::Text }],
+            columns: &[ColumnSpec { name: "v", value_type: ValueType::Text }, ColumnSpec {
+                name: "n",
+                value_type: ValueType::I64,
+            }],
+            local_columns: &[],
+            repo_column: None,
+        };
+        let err = assert_spec_covers_schema(&conn, &TRIG).unwrap_err();
+        assert!(err.contains("trigger"), "a table with a trigger is rejected: {err}");
+    }
+
+    #[test]
+    fn every_registered_table_is_covered_by_the_live_schema() {
+        // Empty today; the moment a per-scope milestone registers a real table, this pins that its
+        // spec classifies every physical column of the migrated schema.
+        let conn = Connection::open_in_memory().unwrap();
+        rag_rat_db::schema::apply(&conn, &crate::test_hooks()).unwrap();
+        assert_registry_consistent(SYNCABLE_TABLES).expect("the registry has a duplicate table");
+        for spec in SYNCABLE_TABLES {
+            assert_spec_covers_schema(&conn, spec).unwrap_or_else(|err| {
+                panic!("registered table `{}` is not covered: {err}", spec.name)
+            });
+        }
+    }
+}

--- a/crates/rag-rat-oplog/src/table_sync/row_op.rs
+++ b/crates/rag-rat-oplog/src/table_sync/row_op.rs
@@ -1,0 +1,481 @@
+//! The table→log sync engine's row op + its canonical CBOR wire form.
+//!
+//! A [`RowOp`] is one replicated row mutation on a syncable table: an `Upsert` (a row identity plus
+//! its synced cells) or a `Remove` (a row identity). It mirrors [`super::super::op`]'s discipline —
+//! a domain-tagged, definite-length, deterministic envelope `[domain, op-kind, payload]`, versioned
+//! (`"rag-rat/table-op/1"`) so a future format can never collide — but its vocabulary is
+//! **self-describing**: the op carries the table name, the column names, and each value's type
+//! (through CBOR's own type system), because the applier's registry lives only in code and never
+//! travels. That is what lets a peer store-and-relay an op for a table it doesn't know.
+//!
+//! [`decode`] returns a [`DecodedRowOp`]: a recognized op-kind is `Known`; a future op-kind this
+//! binary doesn't recognize decodes to `Unknown` with its raw bytes retained (never applied) so a
+//! later binary can re-fold it — the same forward-compat seam `op` uses. A known op has exactly one
+//! accepted encoding (`encode(decode(bytes)) == bytes`); an unknown op must still be exactly one
+//! canonical CBOR item. Structurally-corrupt bytes are a hard error, distinct from the seam.
+
+use minicbor::Encoder;
+use minicbor::data::Type;
+use minicbor::decode::{Decoder, Error as CborError};
+
+use crate::cbor;
+
+/// Domain tag + version, the envelope's first element. Bump the version to evolve the wire format
+/// deliberately (an old binary then rejects the new domain rather than misreading it).
+const DOMAIN: &str = "rag-rat/table-op/1";
+
+/// Writing CBOR into a `Vec` cannot fail (its `Write` impl is infallible), so every encode step
+/// `.expect`s this — mirrors `op`/`content_hash`.
+const INFALLIBLE: &str = "encoding CBOR to a Vec is infallible";
+
+/// One replicated cell: a column name and its typed value. Cells within an op are ordered by column
+/// name and unique — the canonical form the wire pins.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Cell {
+    pub column: String,
+    pub value: TypedValue,
+}
+
+/// A self-describing cell value. The variant IS the wire type (through CBOR's own type system), so
+/// the applier can check it against the column's registry-declared type and quarantine a mismatch.
+/// `I64` covers every SQLite `INTEGER`; `Text`/`Blob`/`Bool`/`Null` map to `TEXT`/`BLOB`/a 0/1
+/// integer flag / SQL `NULL`.
+#[derive(Debug, Clone, PartialEq)]
+pub enum TypedValue {
+    Null,
+    Bool(bool),
+    I64(i64),
+    Text(String),
+    Blob(Vec<u8>),
+}
+
+/// A row mutation on a syncable table. The op-log entry that carries it supplies the ordering
+/// metadata (lamport + device); these bytes freeze only the mutation itself, as `op` does.
+#[derive(Debug, Clone, PartialEq)]
+pub enum RowOp {
+    /// Insert-or-update the row identified by `pk` with `cells` (the synced columns). The applier
+    /// resolves insert-vs-update by row existence and merges each cell under per-column LWW.
+    Upsert { table: String, pk: Vec<TypedValue>, cells: Vec<Cell> },
+    /// Delete the row identified by `pk` (and its LWW clock rows).
+    Remove { table: String, pk: Vec<TypedValue> },
+}
+
+impl RowOp {
+    /// The table this op mutates.
+    pub fn table(&self) -> &str {
+        match self {
+            Self::Upsert { table, .. } | Self::Remove { table, .. } => table,
+        }
+    }
+
+    /// The op's `pk` cells.
+    pub fn pk(&self) -> &[TypedValue] {
+        match self {
+            Self::Upsert { pk, .. } | Self::Remove { pk, .. } => pk,
+        }
+    }
+
+    /// The envelope's op-kind tag (element 1). Stable wire tokens — a rename is a format change.
+    fn kind_tag(&self) -> &'static str {
+        match self {
+            Self::Upsert { .. } => "upsert",
+            Self::Remove { .. } => "remove",
+        }
+    }
+}
+
+/// The outcome of decoding one row-op envelope. `Unknown` is the forward-compat seam: an op-kind
+/// this binary doesn't recognize is kept opaque (raw bytes RETAINED) rather than dropped or
+/// applied, so a later binary can re-fold the stream.
+#[derive(Debug, Clone, PartialEq)]
+pub enum DecodedRowOp {
+    Known(RowOp),
+    Unknown { tag: String, raw: Vec<u8> },
+}
+
+type VecEncoder<'a> = Encoder<&'a mut Vec<u8>>;
+
+/// Encode one row op to canonical CBOR: `[domain, op-kind, payload]`, definite lengths throughout,
+/// deterministic. Cells are emitted sorted by column name so the bytes are stable regardless of the
+/// producer's in-memory order.
+pub fn encode(op: &RowOp) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(64);
+    {
+        let mut enc = Encoder::new(&mut buf);
+        enc.array(3).expect(INFALLIBLE);
+        enc.str(DOMAIN).expect(INFALLIBLE);
+        enc.str(op.kind_tag()).expect(INFALLIBLE);
+        encode_payload(&mut enc, op);
+    }
+    buf
+}
+
+/// Write the op-specific payload as exactly ONE CBOR item (the envelope's element 2).
+fn encode_payload(enc: &mut VecEncoder<'_>, op: &RowOp) {
+    match op {
+        RowOp::Upsert { table, pk, cells } => {
+            enc.array(3).expect(INFALLIBLE);
+            enc.str(table).expect(INFALLIBLE);
+            encode_values(enc, pk);
+            encode_cells(enc, cells);
+        },
+        RowOp::Remove { table, pk } => {
+            enc.array(2).expect(INFALLIBLE);
+            enc.str(table).expect(INFALLIBLE);
+            encode_values(enc, pk);
+        },
+    }
+}
+
+fn encode_values(enc: &mut VecEncoder<'_>, values: &[TypedValue]) {
+    enc.array(values.len() as u64).expect(INFALLIBLE);
+    for value in values {
+        encode_value(enc, value);
+    }
+}
+
+/// Encode cells sorted by column name (the canonical order), each as a `[column, value]` pair.
+fn encode_cells(enc: &mut VecEncoder<'_>, cells: &[Cell]) {
+    let mut sorted: Vec<&Cell> = cells.iter().collect();
+    sorted.sort_by(|a, b| a.column.cmp(&b.column));
+    enc.array(sorted.len() as u64).expect(INFALLIBLE);
+    for cell in sorted {
+        enc.array(2).expect(INFALLIBLE);
+        enc.str(&cell.column).expect(INFALLIBLE);
+        encode_value(enc, &cell.value);
+    }
+}
+
+/// Encode one typed value as its natural CBOR type — the value's type is self-describing on the
+/// wire.
+fn encode_value(enc: &mut VecEncoder<'_>, value: &TypedValue) {
+    match value {
+        TypedValue::Null => {
+            enc.null().expect(INFALLIBLE);
+        },
+        TypedValue::Bool(b) => {
+            enc.bool(*b).expect(INFALLIBLE);
+        },
+        TypedValue::I64(n) => {
+            enc.i64(*n).expect(INFALLIBLE);
+        },
+        TypedValue::Text(s) => {
+            enc.str(s).expect(INFALLIBLE);
+        },
+        TypedValue::Blob(b) => {
+            enc.bytes(b).expect(INFALLIBLE);
+        },
+    }
+}
+
+/// Decode one row-op envelope. A recognized op → `Known`; a future op-kind → `Unknown` (raw bytes
+/// retained); structurally-invalid CBOR or a wrong/absent domain tag → `Err`.
+pub fn decode(bytes: &[u8]) -> anyhow::Result<DecodedRowOp> {
+    decode_envelope(bytes).map_err(|err| anyhow::anyhow!("row-op decode failed: {err}"))
+}
+
+fn decode_envelope(bytes: &[u8]) -> Result<DecodedRowOp, CborError> {
+    let mut d = Decoder::new(bytes);
+    cbor::expect_array(&mut d, 3)?;
+    cbor::expect_domain(&mut d, DOMAIN)?;
+    let kind = d.str()?.to_string();
+    let known = match kind.as_str() {
+        "upsert" => {
+            cbor::expect_array(&mut d, 3)?;
+            let table = d.str()?.to_string();
+            let pk = decode_values(&mut d)?;
+            let cells = decode_cells(&mut d)?;
+            Some(RowOp::Upsert { table, pk, cells })
+        },
+        "remove" => {
+            cbor::expect_array(&mut d, 2)?;
+            let table = d.str()?.to_string();
+            let pk = decode_values(&mut d)?;
+            Some(RowOp::Remove { table, pk })
+        },
+        // A future op-kind this binary doesn't know — retained opaque, canonicity checked below.
+        _ => None,
+    };
+    match known {
+        Some(op) => {
+            // Byte-canonical identity: a known op has exactly ONE accepted encoding (sorted cells,
+            // minimal headers, definite lengths, no trailing). Re-encoding and demanding equality
+            // rejects every alternate representation, so a later signature over these bytes is
+            // unambiguous — the same rule `op::decode` enforces.
+            if encode(&op) != bytes {
+                return Err(CborError::message("non-canonical row-op encoding"));
+            }
+            Ok(DecodedRowOp::Known(op))
+        },
+        None => {
+            // An unknown op is retained opaque (we can't re-encode it), but must still be exactly
+            // one canonical CBOR item with no trailing bytes, or a future binary that
+            // learns the kind could see two wire forms of one op.
+            cbor::require_canonical_cbor(bytes)?;
+            Ok(DecodedRowOp::Unknown { tag: kind, raw: bytes.to_vec() })
+        },
+    }
+}
+
+/// Upper bound on a row op's pk-value / cell count. A real row identity is a handful of columns and
+/// a real row is dozens; a larger declared count is malformed or hostile. Enforced BEFORE any
+/// capacity allocation so a tiny signed payload with an enormous CBOR array header cannot OOM the
+/// process (the length header is attacker-controlled and pre-sizing on it is the vector).
+const MAX_ROW_OP_ELEMENTS: u64 = 4096;
+
+/// Read a definite array length, rejecting one above the protocol cap before it is used to size an
+/// allocation.
+fn capped_len(d: &mut Decoder<'_>) -> Result<usize, CborError> {
+    let len = cbor::expect_definite_len(d)?;
+    if len > MAX_ROW_OP_ELEMENTS {
+        return Err(CborError::message("row-op array length exceeds the protocol cap"));
+    }
+    Ok(len as usize)
+}
+
+fn decode_values(d: &mut Decoder<'_>) -> Result<Vec<TypedValue>, CborError> {
+    let len = capped_len(d)?;
+    let mut values = Vec::with_capacity(len);
+    for _ in 0..len {
+        values.push(decode_value(d)?);
+    }
+    Ok(values)
+}
+
+/// Decode cells, enforcing strictly-ascending unique column names (the canonical order). Rejecting
+/// `<=` the previous column catches both unsorted input and a duplicate column in one check.
+fn decode_cells(d: &mut Decoder<'_>) -> Result<Vec<Cell>, CborError> {
+    let len = capped_len(d)?;
+    let mut cells = Vec::with_capacity(len);
+    let mut prev: Option<String> = None;
+    for _ in 0..len {
+        cbor::expect_array(d, 2)?;
+        let column = d.str()?.to_string();
+        if prev.as_ref().is_some_and(|p| &column <= p) {
+            return Err(CborError::message("row-op cells not sorted or duplicated"));
+        }
+        let value = decode_value(d)?;
+        prev = Some(column.clone());
+        cells.push(Cell { column, value });
+    }
+    Ok(cells)
+}
+
+fn decode_value(d: &mut Decoder<'_>) -> Result<TypedValue, CborError> {
+    match d.datatype()? {
+        Type::Null => {
+            d.null()?;
+            Ok(TypedValue::Null)
+        },
+        Type::Bool => Ok(TypedValue::Bool(d.bool()?)),
+        Type::U8
+        | Type::U16
+        | Type::U32
+        | Type::U64
+        | Type::I8
+        | Type::I16
+        | Type::I32
+        | Type::I64 => Ok(TypedValue::I64(d.i64()?)),
+        Type::Bytes => Ok(TypedValue::Blob(d.bytes()?.to_vec())),
+        Type::String => Ok(TypedValue::Text(d.str()?.to_string())),
+        other =>
+            Err(CborError::message(format!("unexpected CBOR type for a row-op value: {other:?}"))),
+    }
+}
+
+/// A stable, opaque string identity for a row's PK tuple — the hex of the canonical CBOR encoding
+/// of the `pk` values. Used as the `row_pk` TEXT key in the LWW clock and published-row tables, so
+/// two devices agree on a row's identity without sharing local rowids.
+pub fn row_pk_string(pk: &[TypedValue]) -> String {
+    let mut buf = Vec::with_capacity(32);
+    {
+        let mut enc = Encoder::new(&mut buf);
+        encode_values(&mut enc, pk);
+    }
+    hex_lower(&buf)
+}
+
+/// The anti-echo identity of a row: the hex `sha256` of the canonical CBOR of its synced cells
+/// (sorted by column). The applier records this after writing a row and the producer recomputes it
+/// from the current row — an equal hash means the row already carries the synced state, so it is
+/// not re-emitted (the echo-republish guard). Covers ONLY the passed cells (synced columns), so
+/// local re-resolution of other columns can never perturb it.
+pub(crate) fn cells_hash(cells: &[Cell]) -> String {
+    let mut buf = Vec::with_capacity(64);
+    {
+        let mut enc = Encoder::new(&mut buf);
+        encode_cells(&mut enc, cells);
+    }
+    hex_lower(&cbor::sha256(&buf))
+}
+
+/// Recover the pk values from a `row_pk` produced by [`row_pk_string`] — the inverse, so the
+/// producer can reconstruct a deleted row's identity (present in the published-rows table, absent
+/// from the table) to emit a `Remove`.
+pub(crate) fn row_pk_values(row_pk: &str) -> anyhow::Result<Vec<TypedValue>> {
+    let bytes = hex_decode(row_pk)?;
+    let mut d = Decoder::new(&bytes);
+    let values =
+        decode_values(&mut d).map_err(|err| anyhow::anyhow!("row_pk decode failed: {err}"))?;
+    anyhow::ensure!(d.position() == bytes.len(), "trailing bytes in row_pk");
+    Ok(values)
+}
+
+fn hex_decode(text: &str) -> anyhow::Result<Vec<u8>> {
+    anyhow::ensure!(text.len().is_multiple_of(2), "hex string has an odd length");
+    (0..text.len())
+        .step_by(2)
+        .map(|i| {
+            u8::from_str_radix(&text[i..i + 2], 16).map_err(|err| anyhow::anyhow!("bad hex: {err}"))
+        })
+        .collect()
+}
+
+fn hex_lower(bytes: &[u8]) -> String {
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        out.push(char::from_digit((byte >> 4) as u32, 16).expect("nibble is 0..=15"));
+        out.push(char::from_digit((byte & 0x0f) as u32, 16).expect("nibble is 0..=15"));
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_upsert() -> RowOp {
+        RowOp::Upsert {
+            table: "t_demo".to_string(),
+            pk: vec![TypedValue::Text("r".to_string()), TypedValue::I64(7)],
+            // Deliberately out of column order — encode must canonicalize.
+            cells: vec![
+                Cell { column: "title".to_string(), value: TypedValue::Text("hi".to_string()) },
+                Cell { column: "count".to_string(), value: TypedValue::I64(3) },
+                Cell { column: "done".to_string(), value: TypedValue::Bool(true) },
+                Cell { column: "note".to_string(), value: TypedValue::Null },
+            ],
+        }
+    }
+
+    #[test]
+    fn upsert_round_trips_and_sorts_cells() {
+        let op = sample_upsert();
+        let bytes = encode(&op);
+        let DecodedRowOp::Known(decoded) = decode(&bytes).unwrap() else {
+            panic!("known op");
+        };
+        // Decoded cells are in canonical (sorted) order.
+        let RowOp::Upsert { cells, .. } = &decoded else { panic!("upsert") };
+        let columns: Vec<&str> = cells.iter().map(|c| c.column.as_str()).collect();
+        assert_eq!(columns, ["count", "done", "note", "title"], "cells decode sorted");
+        // Re-encoding the decoded op reproduces the exact bytes (canonical identity).
+        assert_eq!(encode(&decoded), bytes);
+    }
+
+    #[test]
+    fn remove_round_trips() {
+        let op = RowOp::Remove {
+            table: "t_demo".to_string(),
+            pk: vec![TypedValue::Text("r".to_string()), TypedValue::I64(7)],
+        };
+        let bytes = encode(&op);
+        assert_eq!(decode(&bytes).unwrap(), DecodedRowOp::Known(op));
+    }
+
+    #[test]
+    fn a_duplicate_or_unsorted_column_is_rejected() {
+        // Two cells with the same column name — hand-encode past the encoder's sort so the bytes
+        // reach the decoder unsorted/duplicated.
+        let mut buf = Vec::new();
+        {
+            let mut enc = Encoder::new(&mut buf);
+            enc.array(3).unwrap();
+            enc.str(DOMAIN).unwrap();
+            enc.str("upsert").unwrap();
+            enc.array(3).unwrap();
+            enc.str("t_demo").unwrap();
+            enc.array(0).unwrap(); // empty pk
+            enc.array(2).unwrap();
+            enc.array(2).unwrap();
+            enc.str("a").unwrap();
+            enc.i64(1).unwrap();
+            enc.array(2).unwrap();
+            enc.str("a").unwrap(); // duplicate column
+            enc.i64(2).unwrap();
+        }
+        assert!(decode(&buf).is_err(), "a duplicate column is not canonical");
+    }
+
+    #[test]
+    fn an_unknown_kind_is_retained_opaque() {
+        // A canonical envelope with a future op-kind decodes to Unknown, bytes retained.
+        let mut buf = Vec::new();
+        {
+            let mut enc = Encoder::new(&mut buf);
+            enc.array(3).unwrap();
+            enc.str(DOMAIN).unwrap();
+            enc.str("wholeset").unwrap(); // a future kind this binary doesn't know
+            enc.array(0).unwrap();
+        }
+        assert_eq!(decode(&buf).unwrap(), DecodedRowOp::Unknown {
+            tag: "wholeset".to_string(),
+            raw: buf.clone()
+        },);
+    }
+
+    #[test]
+    fn a_wrong_domain_is_a_hard_error() {
+        let mut buf = Vec::new();
+        {
+            let mut enc = Encoder::new(&mut buf);
+            enc.array(3).unwrap();
+            enc.str("rag-rat/op/1").unwrap(); // the memory-content domain, not ours
+            enc.str("upsert").unwrap();
+            enc.array(0).unwrap();
+        }
+        assert!(decode(&buf).is_err(), "a foreign domain tag is rejected, never misread");
+    }
+
+    #[test]
+    fn trailing_bytes_are_rejected() {
+        let mut bytes = encode(&sample_upsert());
+        bytes.push(0x00);
+        assert!(decode(&bytes).is_err(), "trailing bytes break canonical identity");
+    }
+
+    #[test]
+    fn row_pk_string_is_stable_and_distinguishes() {
+        let a = row_pk_string(&[TypedValue::Text("r".to_string()), TypedValue::I64(7)]);
+        let b = row_pk_string(&[TypedValue::Text("r".to_string()), TypedValue::I64(8)]);
+        assert_eq!(a, row_pk_string(&[TypedValue::Text("r".to_string()), TypedValue::I64(7)]));
+        assert_ne!(a, b, "a different pk yields a different identity");
+    }
+
+    #[test]
+    fn an_oversized_array_header_is_rejected_without_allocating() {
+        // A pk array header claiming a billion elements with no payload must be rejected by the
+        // cap, never pre-sized into an allocation.
+        let mut buf = Vec::new();
+        {
+            let mut enc = Encoder::new(&mut buf);
+            enc.array(3).unwrap();
+            enc.str(DOMAIN).unwrap();
+            enc.str("upsert").unwrap();
+            enc.array(3).unwrap();
+            enc.str("t").unwrap();
+            enc.array(1_000_000_000).unwrap(); // absurd declared pk length, no elements follow
+        }
+        assert!(decode(&buf).is_err(), "an oversized array length is capped, not allocated");
+    }
+
+    /// Golden vector: the exact canonical bytes of `sample_upsert`. A change here is a wire-format
+    /// change — bump `DOMAIN` deliberately, never edit this hex to make the test pass.
+    #[test]
+    fn upsert_golden_vector() {
+        let bytes = encode(&sample_upsert());
+        assert_eq!(hex_lower(&bytes), GOLDEN_UPSERT_HEX);
+    }
+
+    const GOLDEN_UPSERT_HEX: &str = "83727261672d7261742f7461626c652d6f702f31667570736572748366745f64656d6f82617207848265636f756e74038264646f6e65f582646e6f7465f682657469746c65626869";
+}

--- a/crates/rag-rat-oplog/src/table_sync/scope_stream.rs
+++ b/crates/rag-rat-oplog/src/table_sync/scope_stream.rs
@@ -1,0 +1,67 @@
+//! The `/4` table-sync stream identity.
+//!
+//! Each `(repo_id, account_id, scope_id)` names one signed hash-chained stream — a sibling of the
+//! `/3` content stream, on the same signed-entry layer. Committing the owning `account_id` inside
+//! the hash makes ownership self-certifying (as `/2` does for content); committing `scope_id`
+//! separates the anchors/overlay/distill logs so their per-column LWW clocks never compare across
+//! scopes. A row op rides its table's scope stream and no other.
+
+use minicbor::Encoder;
+
+use crate::{AccountId, StreamId, cbor};
+
+/// Domain tag + version for the table-sync stream identity. `/4` is a sibling of the content `/2`
+/// derivation; bump the version only if the canonical rule itself changes.
+const TABLE_STREAM_DOMAIN: &str = "rag-rat/stream/4";
+
+/// Writing CBOR into a `Vec` cannot fail — mirrors `super::row_op` / `super::super::stream`.
+const INFALLIBLE: &str = "encoding CBOR to a Vec is infallible";
+
+/// Derive the immutable `stream_id` for a scope's table-sync log:
+/// `sha256(cbor(["rag-rat/stream/4", account_id (b32), repo_id, scope_id]))`. Deterministic and
+/// checkout-independent, so every device of one account derives the SAME id for a repo+scope — that
+/// is what lets a peer's row ops land on the stream this device reads.
+pub(crate) fn scope_stream_id(repo_id: &str, account_id: AccountId, scope_id: &str) -> StreamId {
+    let mut buf = Vec::with_capacity(96);
+    {
+        let mut enc = Encoder::new(&mut buf);
+        enc.array(4).expect(INFALLIBLE);
+        enc.str(TABLE_STREAM_DOMAIN).expect(INFALLIBLE);
+        enc.bytes(&account_id.to_bytes()).expect(INFALLIBLE);
+        enc.str(repo_id).expect(INFALLIBLE);
+        enc.str(scope_id).expect(INFALLIBLE);
+    }
+    StreamId::from_bytes(cbor::sha256(&buf))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn account(seed: u8) -> AccountId {
+        AccountId::from_bytes([seed; 32])
+    }
+
+    #[test]
+    fn same_inputs_derive_the_same_stream() {
+        let a = scope_stream_id("repo-a", account(1), "anchors/1");
+        let b = scope_stream_id("repo-a", account(1), "anchors/1");
+        assert_eq!(a, b, "the id is a pure function of (repo, account, scope)");
+    }
+
+    #[test]
+    fn a_different_scope_repo_or_account_derives_a_different_stream() {
+        let base = scope_stream_id("repo-a", account(1), "anchors/1");
+        assert_ne!(
+            base,
+            scope_stream_id("repo-a", account(1), "overlay/1"),
+            "scope separates logs"
+        );
+        assert_ne!(base, scope_stream_id("repo-b", account(1), "anchors/1"), "repo separates logs");
+        assert_ne!(
+            base,
+            scope_stream_id("repo-a", account(2), "anchors/1"),
+            "account separates logs"
+        );
+    }
+}

--- a/crates/rag-rat-oplog/src/table_sync/store.rs
+++ b/crates/rag-rat-oplog/src/table_sync/store.rs
@@ -1,0 +1,566 @@
+//! The engine's signed entry log: `table_sync_entries`, one hash-chained chain per
+//! `(stream_id, device_fingerprint)`.
+//!
+//! Deliberately separate from `oplog_entries` — that table's upgrade re-fold decodes every stored
+//! stream as a memory-content op and would choke on a table op. The signing/verification/chain
+//! primitives ([`super::super::entry`]) are op-agnostic (they treat `op_bytes` as opaque), so they
+//! are reused verbatim; only the storage table and the row-op poison guard are new.
+//!
+//! [`author_row_entry`] mints a local entry (lamport = one past the highest on the stream);
+//! [`accept_row_entry`] verifies and chain-classifies a foreign entry, stores it if the chain is
+//! continuous, then decides whether its payload applies — so one bad payload never wedges the
+//! chain. Full fork evidence and out-of-order backfill are the transport milestone's job — here a
+//! gap or conflict is simply reported, not durably quarantined.
+
+use anyhow::Context;
+use rusqlite::{OptionalExtension, Transaction, params};
+
+use super::row_op::{self, DecodedRowOp, RowOp};
+use crate::device::{DevicePublic, DeviceSecret};
+use crate::entry::{self, SignedEntry, VerifiedEntry};
+use crate::op::{DeviceFingerprint, OpMeta};
+use crate::stream::StreamId;
+
+/// Upper bound on an entry's lamport, far below `i64::MAX`. A Lamport clock increments by one per
+/// op, so a legitimate value never approaches this; a larger one is malformed or a wedging attack.
+const MAX_ENTRY_LAMPORT: u64 = 1 << 62;
+
+/// The most a single accepted entry may advance the stream's Lamport clock. A Lamport clock ticks
+/// by one per op, so a legitimate entry is at most a partition's worth of ops ahead of the highest
+/// lamport already stored — never billions. This bound (far above any real causal gap, far below
+/// the ceiling) refuses a griefing entry that jumps toward `MAX_ENTRY_LAMPORT`: such an entry would
+/// dominate every row's whole-row LWW AND, once `next_stream_lamport` reaches the ceiling, halt all
+/// local authoring on the scope. With the bound, reaching the ceiling needs ~2^30 chained entries,
+/// not one. (A peer griefing WITHIN the bound is the auth/roster milestone's job — device removal.)
+const MAX_LAMPORT_ADVANCE: u64 = 1 << 32;
+
+/// The result of accepting a foreign entry. A chain-continuous entry is ALWAYS stored (so one bad
+/// payload cannot wedge the device's chain); whether its payload is APPLIED is a separate decision.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum AcceptOutcome {
+    /// Stored, and its known in-scope row op is ready to apply.
+    Stored {
+        op: RowOp,
+        meta: OpMeta,
+    },
+    /// Stored and retained, but NOT applied — an undecodable payload, a future op-kind, or a table
+    /// not in this scope. The chain still advanced; the `&str` is the reason, for reporting.
+    StoredInert(&'static str),
+    AlreadyPresent,
+    /// The lamport advances past the tail but the entry does not link to it (a gap): the
+    /// predecessor has not arrived. Routine under out-of-order delivery; the transport retries
+    /// after backfill.
+    MissingPredecessor,
+    /// The entry conflicts with the stored chain (a second genesis, or a lamport at/behind the
+    /// tail) — an equivocation the transport milestone will quarantine with evidence.
+    Fork,
+}
+
+/// Mint one local row op as a signed entry on `stream` and store it.
+///
+/// The lamport is a Lamport clock over the WHOLE stream — one past the highest lamport seen from
+/// any device — NOT this device's own chain position. That is what makes a local edit supersede a
+/// row this device just received: a per-device counter would restart at 0 and could tie (and lose)
+/// to an ingested op at the same position. The `prev_hash` still links this device's own chain, so
+/// a device's lamports are strictly increasing but need not be contiguous. Read inside the caller's
+/// transaction so the reads and the insert are one write.
+pub(crate) fn author_row_entry(
+    tx: &Transaction<'_>,
+    stream: StreamId,
+    secret: &DeviceSecret,
+    op: &RowOp,
+    now_ms: i64,
+) -> anyhow::Result<SignedEntry> {
+    let device = secret.public().fingerprint();
+    let lamport = next_stream_lamport(tx, stream)?;
+    let prev_hash = chain_tail(tx, stream, device)?.map(|(_, entry_hash)| entry_hash);
+    let signed =
+        entry::sign_entry_from_op_bytes(secret, stream, prev_hash, lamport, row_op::encode(op));
+    insert_entry(tx, &signed.entry, &signed.signed_bytes, now_ms)?;
+    Ok(signed)
+}
+
+/// One past the highest lamport on `stream` across all devices — the next Lamport-clock tick. `0`
+/// for an empty stream.
+fn next_stream_lamport(tx: &Transaction<'_>, stream: StreamId) -> anyhow::Result<u64> {
+    let stream_bytes = stream.to_bytes();
+    let highest: Option<i64> = tx.query_row(
+        "SELECT MAX(lamport) FROM table_sync_entries WHERE stream_id = ?1",
+        params![stream_bytes.as_slice()],
+        |row| row.get::<_, Option<i64>>(0),
+    )?;
+    let next = match highest {
+        Some(lamport) =>
+            u64::try_from(lamport)?.checked_add(1).context("stream lamport overflow")?,
+        None => 0,
+    };
+    // Cap at the same ceiling `accept_row_entry` enforces, so a locally-authored entry can never
+    // exceed what peers accept. Only reachable if a near-ceiling entry was ingested (impossible at
+    // legitimate op volume); refusing to author is a bounded halt, never a divergent split.
+    anyhow::ensure!(next < MAX_ENTRY_LAMPORT, "stream lamport ceiling reached");
+    Ok(next)
+}
+
+/// Verify + chain-classify + store one foreign signed entry, expected on `expected_stream` under
+/// `pubkey`. A tampered/wrong-keyed entry or one naming a different stream is an `Err`; a chain gap
+/// or conflict is a (non-storing) [`AcceptOutcome`]. A chain-continuous entry is stored REGARDLESS
+/// of whether its payload is applicable, so one undecodable / unknown / out-of-scope payload cannot
+/// wedge every later entry from that device — storage is gated on the CHAIN, application on the
+/// PAYLOAD.
+pub(crate) fn accept_row_entry(
+    tx: &Transaction<'_>,
+    expected_stream: StreamId,
+    expected_tables: &[&str],
+    signed_bytes: &[u8],
+    pubkey: &DevicePublic,
+    now_ms: i64,
+) -> anyhow::Result<AcceptOutcome> {
+    let verified = entry::verify_signed(signed_bytes, pubkey)?;
+    if verified.stream_id != expected_stream {
+        anyhow::bail!("entry names a different stream than the one being synced");
+    }
+    // Reserve the lamport ceiling (reject `>=`, not `>`). Without this, an entry AT the boundary
+    // would be accepted, then the next local `MAX(lamport)+1` would exceed it and be rejected by
+    // every peer — splitting this device's later edits from the scope. Authoring is capped at the
+    // same ceiling (`next_stream_lamport`), so no locally-authored entry can ever cross it. The
+    // ceiling sits far below i64::MAX, so it is unreachable by legitimate op volume.
+    if verified.lamport >= MAX_ENTRY_LAMPORT {
+        anyhow::bail!("entry lamport {} exceeds the protocol ceiling", verified.lamport);
+    }
+    // Bounded advance: refuse an entry that jumps the stream's Lamport clock implausibly far ahead
+    // of what is already stored (see `MAX_LAMPORT_ADVANCE`). Without it, a single griefing
+    // entry near the ceiling would dominate every row's LWW and halt local authoring once
+    // `next_stream_lamport` hits the ceiling. Read the current max BEFORE storing this entry.
+    let stream_max: u64 = {
+        let stored: i64 = tx.query_row(
+            "SELECT COALESCE(MAX(lamport), 0) FROM table_sync_entries WHERE stream_id = ?1",
+            params![expected_stream.to_bytes().as_slice()],
+            |row| row.get(0),
+        )?;
+        u64::try_from(stored).unwrap_or(0)
+    };
+    if verified.lamport > stream_max.saturating_add(MAX_LAMPORT_ADVANCE) {
+        anyhow::bail!(
+            "entry lamport {} jumps more than {MAX_LAMPORT_ADVANCE} past the stream clock \
+             {stream_max} — refusing (a near-ceiling jump would dominate LWW and halt authoring)",
+            verified.lamport
+        );
+    }
+    if entry_exists(tx, &verified.entry_hash)? {
+        return Ok(AcceptOutcome::AlreadyPresent);
+    }
+    match classify(tx, expected_stream, &verified)? {
+        ChainFit::Ok => {},
+        ChainFit::Gap => return Ok(AcceptOutcome::MissingPredecessor),
+        ChainFit::Conflict => return Ok(AcceptOutcome::Fork),
+    }
+    // Chain-continuous: store now so a bad payload can never wedge the device's chain.
+    insert_entry(tx, &verified, signed_bytes, now_ms)?;
+
+    // Classify the payload for application — the entry is already durably stored either way.
+    Ok(match row_op::decode(&verified.op_bytes) {
+        Err(_) => AcceptOutcome::StoredInert("undecodable op payload"),
+        Ok(DecodedRowOp::Unknown { .. }) => AcceptOutcome::StoredInert("unknown op-kind"),
+        Ok(DecodedRowOp::Known(op)) =>
+            if expected_tables.contains(&op.table()) {
+                AcceptOutcome::Stored {
+                    op,
+                    meta: OpMeta { lamport: verified.lamport, device: verified.device_fingerprint },
+                }
+            } else {
+                AcceptOutcome::StoredInert("table not in scope")
+            },
+    })
+}
+
+/// How a verified entry fits its `(stream, device)` chain tail.
+enum ChainFit {
+    Ok,
+    Gap,
+    Conflict,
+}
+
+fn classify(
+    tx: &Transaction<'_>,
+    stream: StreamId,
+    verified: &VerifiedEntry,
+) -> anyhow::Result<ChainFit> {
+    Ok(match (verified.prev_hash, chain_tail(tx, stream, verified.device_fingerprint)?) {
+        // A genesis (no predecessor) is the valid first entry of this device's chain; a genesis
+        // when a chain already exists is a second head — an equivocation.
+        (None, None) => ChainFit::Ok,
+        (None, Some(_)) => ChainFit::Conflict,
+        // A non-genesis whose device has no chain yet: its predecessor has not been delivered.
+        (Some(_), None) => ChainFit::Gap,
+        (Some(prev), Some((tail_lamport, tail_hash))) =>
+            if prev == tail_hash && verified.lamport > tail_lamport {
+                ChainFit::Ok
+            } else if verified.lamport <= tail_lamport {
+                ChainFit::Conflict // at/behind the tail — an equivocation.
+            } else if entry_exists(tx, &prev)? {
+                // Links PAST the tail to an ALREADY-STORED ancestor: that ancestor already has a
+                // successor (the one leading to the tail), so this is a SECOND successor — an
+                // equivocation, not a missing intermediate. Reporting Gap would make the transport
+                // backfill, get `AlreadyPresent`, and loop without ever recognizing the fork.
+                ChainFit::Conflict
+            } else {
+                ChainFit::Gap // links to an UNKNOWN predecessor — a genuine missing intermediate.
+            },
+    })
+}
+
+/// The `(stream, device)` chain's highest-lamport `(lamport, entry_hash)`, or `None` for an empty
+/// chain — the `max(seen)+1` restore point, read fresh inside the caller's transaction.
+fn chain_tail(
+    tx: &Transaction<'_>,
+    stream: StreamId,
+    device: DeviceFingerprint,
+) -> anyhow::Result<Option<(u64, [u8; 32])>> {
+    let stream_bytes = stream.to_bytes();
+    let device_bytes = device.to_bytes();
+    let row = tx
+        .query_row(
+            "SELECT lamport, entry_hash FROM table_sync_entries
+             WHERE stream_id = ?1 AND device_fingerprint = ?2 ORDER BY lamport DESC LIMIT 1",
+            params![stream_bytes.as_slice(), device_bytes.as_slice()],
+            |row| Ok((row.get::<_, i64>(0)?, row.get::<_, Vec<u8>>(1)?)),
+        )
+        .optional()?;
+    row.map(|(lamport, hash)| Ok((u64::try_from(lamport)?, fixed32(hash)?))).transpose()
+}
+
+fn entry_exists(tx: &Transaction<'_>, entry_hash: &[u8; 32]) -> anyhow::Result<bool> {
+    Ok(tx
+        .query_row(
+            "SELECT 1 FROM table_sync_entries WHERE entry_hash = ?1",
+            params![entry_hash.as_slice()],
+            |_| Ok(()),
+        )
+        .optional()?
+        .is_some())
+}
+
+fn insert_entry(
+    tx: &Transaction<'_>,
+    verified: &VerifiedEntry,
+    signed_bytes: &[u8],
+    now_ms: i64,
+) -> anyhow::Result<()> {
+    let stream_bytes = verified.stream_id.to_bytes();
+    let device_bytes = verified.device_fingerprint.to_bytes();
+    let prev_hash: Option<Vec<u8>> = verified.prev_hash.map(|h| h.to_vec());
+    tx.execute(
+        "INSERT INTO table_sync_entries(
+             entry_hash, stream_id, device_fingerprint, lamport, prev_hash, signed_bytes,
+             received_at_ms)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+        params![
+            verified.entry_hash.as_slice(),
+            stream_bytes.as_slice(),
+            device_bytes.as_slice(),
+            i64::try_from(verified.lamport)?,
+            prev_hash,
+            signed_bytes,
+            now_ms,
+        ],
+    )?;
+    Ok(())
+}
+
+fn fixed32(bytes: Vec<u8>) -> anyhow::Result<[u8; 32]> {
+    <[u8; 32]>::try_from(bytes)
+        .map_err(|got| anyhow::anyhow!("stored entry_hash must be 32 bytes, got {}", got.len()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::table_sync::row_op::TypedValue;
+
+    fn conn() -> rusqlite::Connection {
+        let c = rusqlite::Connection::open_in_memory().unwrap();
+        rag_rat_db::schema::apply(&c, &crate::test_hooks()).unwrap();
+        c
+    }
+
+    fn stream() -> StreamId {
+        StreamId::from_bytes([5; 32])
+    }
+
+    fn op(id: &str) -> RowOp {
+        RowOp::Remove { table: "t".to_string(), pk: vec![TypedValue::Text(id.to_string())] }
+    }
+
+    #[test]
+    fn author_then_accept_round_trips_a_row_op() {
+        let mut a = conn();
+        let secret = DeviceSecret::from_seed(&[1; 32]);
+        let tx = a.transaction().unwrap();
+        let signed = author_row_entry(&tx, stream(), &secret, &op("r1"), 0).unwrap();
+        tx.commit().unwrap();
+
+        // A fresh store accepts the wire and decodes the same op.
+        let mut b = conn();
+        let tx = b.transaction().unwrap();
+        let outcome =
+            accept_row_entry(&tx, stream(), &["t"], &signed.signed_bytes, &secret.public(), 0)
+                .unwrap();
+        assert_eq!(outcome, AcceptOutcome::Stored {
+            op: op("r1"),
+            meta: OpMeta { lamport: 0, device: secret.public().fingerprint() }
+        });
+    }
+
+    #[test]
+    fn lamport_advances_and_restores_from_the_stored_tail() {
+        let mut a = conn();
+        let secret = DeviceSecret::from_seed(&[1; 32]);
+        {
+            let tx = a.transaction().unwrap();
+            assert_eq!(
+                author_row_entry(&tx, stream(), &secret, &op("r1"), 0).unwrap().entry.lamport,
+                0
+            );
+            assert_eq!(
+                author_row_entry(&tx, stream(), &secret, &op("r2"), 0).unwrap().entry.lamport,
+                1
+            );
+            tx.commit().unwrap();
+        }
+        // Re-opening the transaction continues from the stored tail (max seen + 1), not from 0.
+        let tx = a.transaction().unwrap();
+        assert_eq!(
+            author_row_entry(&tx, stream(), &secret, &op("r3"), 0).unwrap().entry.lamport,
+            2
+        );
+    }
+
+    #[test]
+    fn a_redelivered_entry_is_idempotent() {
+        let mut b = conn();
+        let secret = DeviceSecret::from_seed(&[1; 32]);
+        let signed = {
+            let mut a = conn();
+            let tx = a.transaction().unwrap();
+            let s = author_row_entry(&tx, stream(), &secret, &op("r1"), 0).unwrap();
+            tx.commit().unwrap();
+            s
+        };
+        let tx = b.transaction().unwrap();
+        assert!(matches!(
+            accept_row_entry(&tx, stream(), &["t"], &signed.signed_bytes, &secret.public(), 0)
+                .unwrap(),
+            AcceptOutcome::Stored { .. }
+        ));
+        assert_eq!(
+            accept_row_entry(&tx, stream(), &["t"], &signed.signed_bytes, &secret.public(), 0)
+                .unwrap(),
+            AcceptOutcome::AlreadyPresent,
+        );
+    }
+
+    #[test]
+    fn an_entry_for_a_foreign_stream_is_rejected() {
+        let mut b = conn();
+        let secret = DeviceSecret::from_seed(&[1; 32]);
+        let signed = {
+            let mut a = conn();
+            let tx = a.transaction().unwrap();
+            let s = author_row_entry(&tx, stream(), &secret, &op("r1"), 0).unwrap();
+            tx.commit().unwrap();
+            s
+        };
+        let tx = b.transaction().unwrap();
+        let other = StreamId::from_bytes([9; 32]);
+        assert!(
+            accept_row_entry(&tx, other, &["t"], &signed.signed_bytes, &secret.public(), 0)
+                .is_err(),
+            "an entry cannot be re-homed onto a stream it was not signed for",
+        );
+    }
+
+    #[test]
+    fn a_foreign_table_op_is_stored_inert_and_does_not_wedge_the_chain() {
+        let secret = DeviceSecret::from_seed(&[1; 32]);
+        // Sender authors two chained ops for table "t".
+        let (first, second) = {
+            let mut a = conn();
+            let tx = a.transaction().unwrap();
+            let first = author_row_entry(&tx, stream(), &secret, &op("r1"), 0).unwrap();
+            let second = author_row_entry(&tx, stream(), &secret, &op("r2"), 0).unwrap();
+            tx.commit().unwrap();
+            (first, second)
+        };
+        let mut b = conn();
+        let tx = b.transaction().unwrap();
+        // The genesis routed to a scope that does NOT include "t": stored INERT (the chain still
+        // advances), not applied.
+        assert_eq!(
+            accept_row_entry(&tx, stream(), &["other"], &first.signed_bytes, &secret.public(), 0)
+                .unwrap(),
+            AcceptOutcome::StoredInert("table not in scope"),
+        );
+        // The chain is not wedged: the next entry (which links to the first) still stores +
+        // applies.
+        assert!(matches!(
+            accept_row_entry(&tx, stream(), &["t"], &second.signed_bytes, &secret.public(), 0)
+                .unwrap(),
+            AcceptOutcome::Stored { .. },
+        ));
+    }
+
+    #[test]
+    fn a_malformed_payload_is_stored_inert_and_does_not_wedge_the_chain() {
+        let secret = DeviceSecret::from_seed(&[1; 32]);
+        // Sender: a genesis entry with GARBAGE (undecodable) op-bytes, then a valid entry chained
+        // onto it.
+        let (garbage, valid) = {
+            let mut a = conn();
+            let tx = a.transaction().unwrap();
+            let garbage = entry::sign_entry_from_op_bytes(&secret, stream(), None, 0, vec![0x00]);
+            insert_entry(&tx, &garbage.entry, &garbage.signed_bytes, 0).unwrap();
+            let valid = author_row_entry(&tx, stream(), &secret, &op("r1"), 0).unwrap();
+            tx.commit().unwrap();
+            (garbage, valid)
+        };
+        let mut b = conn();
+        let tx = b.transaction().unwrap();
+        assert_eq!(
+            accept_row_entry(&tx, stream(), &["t"], &garbage.signed_bytes, &secret.public(), 0)
+                .unwrap(),
+            AcceptOutcome::StoredInert("undecodable op payload"),
+        );
+        // One bad payload does not wedge the chain: the next valid entry still applies.
+        assert!(matches!(
+            accept_row_entry(&tx, stream(), &["t"], &valid.signed_bytes, &secret.public(), 0)
+                .unwrap(),
+            AcceptOutcome::Stored { .. },
+        ));
+    }
+
+    #[test]
+    fn an_out_of_bound_lamport_is_rejected() {
+        let secret = DeviceSecret::from_seed(&[1; 32]);
+        // A signed genesis claiming a near-maximal lamport would make every peer's next
+        // MAX(lamport)+1 overflow i64 at insert — it must be refused before it is stored.
+        let poison = entry::sign_entry_from_op_bytes(
+            &secret,
+            stream(),
+            None,
+            u64::MAX,
+            row_op::encode(&op("r1")),
+        );
+        let mut b = conn();
+        let tx = b.transaction().unwrap();
+        assert!(
+            accept_row_entry(&tx, stream(), &["t"], &poison.signed_bytes, &secret.public(), 0)
+                .is_err(),
+            "an out-of-bound lamport is rejected before it can poison the stream counter",
+        );
+    }
+
+    #[test]
+    fn a_lamport_jump_beyond_the_advance_bound_is_rejected() {
+        // On an empty stream the clock is 0, so the largest acceptable lamport is exactly the
+        // advance bound; one past it is a griefing jump (it would dominate every row's LWW
+        // and, near the ceiling, halt local authoring). Two fresh streams so the accepted
+        // entry does not raise the clock the rejected one is measured against.
+        let secret = DeviceSecret::from_seed(&[1; 32]);
+        let at_bound = entry::sign_entry_from_op_bytes(
+            &secret,
+            stream(),
+            None,
+            MAX_LAMPORT_ADVANCE,
+            row_op::encode(&op("r1")),
+        );
+        let beyond = entry::sign_entry_from_op_bytes(
+            &secret,
+            stream(),
+            None,
+            MAX_LAMPORT_ADVANCE + 1,
+            row_op::encode(&op("r2")),
+        );
+
+        let mut ok = conn();
+        let tx = ok.transaction().unwrap();
+        assert!(
+            matches!(
+                accept_row_entry(
+                    &tx,
+                    stream(),
+                    &["t"],
+                    &at_bound.signed_bytes,
+                    &secret.public(),
+                    0
+                )
+                .unwrap(),
+                AcceptOutcome::Stored { .. },
+            ),
+            "a lamport exactly at the advance bound is accepted",
+        );
+
+        let mut bad = conn();
+        let tx = bad.transaction().unwrap();
+        assert!(
+            accept_row_entry(&tx, stream(), &["t"], &beyond.signed_bytes, &secret.public(), 0)
+                .is_err(),
+            "a lamport one past the advance bound is refused",
+        );
+    }
+
+    #[test]
+    fn a_gap_is_reported_not_stored() {
+        // A second-position entry (lamport 1) arriving before the genesis is a missing predecessor.
+        let mut b = conn();
+        let secret = DeviceSecret::from_seed(&[1; 32]);
+        let second = {
+            let mut a = conn();
+            let tx = a.transaction().unwrap();
+            author_row_entry(&tx, stream(), &secret, &op("r1"), 0).unwrap();
+            let s = author_row_entry(&tx, stream(), &secret, &op("r2"), 0).unwrap();
+            tx.commit().unwrap();
+            s
+        };
+        let tx = b.transaction().unwrap();
+        assert_eq!(
+            accept_row_entry(&tx, stream(), &["t"], &second.signed_bytes, &secret.public(), 0)
+                .unwrap(),
+            AcceptOutcome::MissingPredecessor,
+        );
+    }
+
+    #[test]
+    fn a_fork_linking_past_the_tail_to_a_stored_ancestor_is_a_conflict() {
+        let secret = DeviceSecret::from_seed(&[1; 32]);
+        // Device A's real chain: e1 (genesis) -> e2.
+        let (e1, e2) = {
+            let mut a = conn();
+            let tx = a.transaction().unwrap();
+            let e1 = author_row_entry(&tx, stream(), &secret, &op("r1"), 0).unwrap();
+            let e2 = author_row_entry(&tx, stream(), &secret, &op("r2"), 0).unwrap();
+            tx.commit().unwrap();
+            (e1, e2)
+        };
+        // A FORK: a SECOND successor of e1 (prev = e1's hash) with a lamport PAST the tail e2.
+        let fork = entry::sign_entry_from_op_bytes(
+            &secret,
+            stream(),
+            Some(e1.entry.entry_hash),
+            e2.entry.lamport + 1,
+            row_op::encode(&op("r_fork")),
+        );
+
+        let mut b = conn();
+        let tx = b.transaction().unwrap();
+        accept_row_entry(&tx, stream(), &["t"], &e1.signed_bytes, &secret.public(), 0).unwrap();
+        accept_row_entry(&tx, stream(), &["t"], &e2.signed_bytes, &secret.public(), 0).unwrap();
+        // Links past the tail to the STORED ancestor e1 (which already has a successor) → an
+        // equivocation, not a missing predecessor.
+        assert_eq!(
+            accept_row_entry(&tx, stream(), &["t"], &fork.signed_bytes, &secret.public(), 0)
+                .unwrap(),
+            AcceptOutcome::Fork,
+            "a fork linking to a stored ancestor is a Fork, not a MissingPredecessor",
+        );
+    }
+}


### PR DESCRIPTION
Fixes #893. Part of #892.

The transport-independent engine that replicates derived/metadata table rows across an account's devices, ready to land ahead of any wire change (driven end-to-end through an in-process loopback).

## What it does

- **Self-describing typed-CBOR row ops** (`row_op`) — a domain-tagged, canonical, definite-length `Upsert`/`Remove` carrying the table name, column names, and each value's type. The registry never travels, so a peer can store-and-relay an op for a table it doesn't know. Golden-vector pinned; a future op-kind decodes to `Unknown` and is retained; a hostile array header is bounded before it can allocate.
- **`/4` per-scope stream identity** — one signed hash-chained stream per `(repo_id, account_id, scope_id)`, a sibling of the `/3` content stream; committing the account makes ownership self-certifying, committing the scope keeps each log's clocks isolated.
- **Whole-row LWW apply** (`apply`) — one per-row write clock is the sole authority: an upsert wins the entire row, and a delete removes it, only when it beats that clock (higher lamport, ties to the smaller device fingerprint). A per-row tombstone makes deletes order-independent and blocks resurrection. Whole-row LWW converges **per row independently**, so the engine is exact only for row-independent tables — the registry gate (below) enforces that. Bad ops quarantine without wedging the chain: a type/pk mismatch, a partial after-image, a foreign-repo op, a null pk, or a constraint violation (including an FK-blocked delete) is retained-but-not-applied while the signed chain still advances.
- **Anti-echo producer** (`produce`) — a full-pass scan that emits an op only when a row's synced-column hash differs from the published record. Because a winning apply records that hash, a row received from a peer is never re-signed and rebroadcast. Pk and cell values are read by their declared type (a `Bool` pk travels as `Bool`; a non-0/1 `Bool` is rejected rather than coerced).
- **Signed entry log** (`store`) — the engine's own `table_sync_entries`, deliberately separate from `oplog_entries` so the memory-content re-fold never sees a table op. The author lamport is a stream-global Lamport clock (max seen + 1) so a local edit reliably supersedes a received row; a chain-continuous entry is always stored before its payload is classified (a bad payload can never wedge the chain); the lamport ceiling is inclusive; an entry linking past the tail to an already-stored ancestor is a fork, not a gap.
- **Orchestration** (`engine`) — `produce_and_author` (self-applying each authored op so authorship enters the clock) and a scope-based `ingest` that routes an op to the right table among a scope's tables.

## The registry gate

`TableSpec` declares one physical table's pk / synced columns / never-replicated local columns / `/4` scope / repo column. `assert_spec_covers_schema` validates a spec against the live schema before it can be registered — a table the engine cannot correctly replicate fails here (and in CI) rather than corrupting silently. It requires:

- **Complete classification** — every physical column is exactly one of pk / synced / local.
- **Exact identity** — the declared pk equals the table's real primary key (columns and order); every pk column is `NOT NULL` and uses `BINARY` collation; the table is `STRICT` and each replicated column's declared type matches its physical type.
- **Row independence** — no foreign key (outbound or inbound) and no non-pk `UNIQUE` index: a cross-row constraint makes whole-row LWW order-dependent (two devices would diverge). No key-only table.
- **Repo scoping** — a repo column must be a `Text` primary-key column; local columns must be nullable or defaulted (a remote insert supplies only pk + synced columns).
- **Registry consistency** — no table registered under two scopes (which would share one per-row clock).

`SYNCABLE_TABLES` is empty until the per-scope milestones (anchors / overlay / distill) register real tables.

## Schema

Additive V087: `table_sync_entries`, `sync_row_clocks`, `sync_row_tombstones`, `sync_published_rows`. All STRICT, pure bookkeeping (no authored content).

## Tests

~69 table-sync unit tests including a two-device loopback (convergence, no echo, causally-later-wins), order-independence of concurrent upsert/remove/re-upsert, and the registry-gate rejection matrix. Full workspace green under both CI runners; both clippy feature gates clean; migration tip test at V087.

## Deferred to the transport / real-table milestones

None can manifest while `SYNCABLE_TABLES` is empty and there is no transport:

- **Forward-compat re-fold** — an entry retained for an unknown column/kind is not replayed after a binary upgrade learns it (needs a projector version + replay, the `/3` content-log analog).
- **Retention / GC** — tombstones and entries are never pruned.
- **rm-purge** — `table_sync_entries` (crypto-stream-keyed) is retained after `rag-rat rm`, the same posture as the `oplog_*` / `content_*` substrate; the projected state (repo-keyed clocks / tombstones / published) is purged.
- **Account-global tables** — a repo-less table would need an account-scoped stream + bookkeeping.
- **Driver ordering** — the transport must author local changes before applying remote ops each cycle, so an unpublished local edit isn't clobbered.
