### PR TITLE
fix(query): scope-filter surfaced logical variant_count/group_reason + overlay branch-support test gaps (#897, #898, #899)

### DIFF
--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_overlay.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_overlay.rs
@@ -3023,3 +3023,229 @@ fn the_scoped_rederive_drops_a_removed_symbols_group() {
 
     let _ = fs::remove_dir_all(&main);
 }
+
+fn rust_symbol_selector(name: &str) -> rag_rat_query::symbol::SymbolSelector {
+    rag_rat_query::symbol::SymbolSelector {
+        logical_symbol_id: None,
+        symbol_id: None,
+        symbol_path: None,
+        symbol: Some(name.to_string()),
+        language: Some(Language::Rust),
+        allow_ambiguous: true,
+        limit: 10,
+    }
+}
+
+/// #897: a symbol present in BOTH the base commit and a linked worktree's overlay (same key) has a
+/// STORED `variant_count` of 2 (`scope_replica`), but under the linked worktree's scope only ONE
+/// member is visible. `symbol_lookup` must report the SCOPE-VISIBLE count (1) / `single` — matching
+/// the member list it returns — not the corpus-level stored total.
+#[test]
+fn overlay_scope_symbol_lookup_reports_scope_visible_variant_count() {
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(main.join("src/a.rs"), "pub fn foo() -> i32 {\n    1\n}\n").unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let config = source_config(main.clone(), Language::Rust);
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    // Body-only edit keeps foo's key line, so foo is a 2-member scope_replica group (base +
+    // overlay).
+    fs::write(linked.join("src/a.rs"), "pub fn foo() -> i32 {\n    2\n}\n").unwrap();
+    run_git(&linked, &["add", "."]);
+    run_git(&linked, &["commit", "-q", "-m", "branch body edit"]);
+    db.index_worktree_overlay(&config, &linked, &mut |_| {}).unwrap();
+
+    // index_worktree_overlay leaves the connection in the overlay scope — symbol_lookup sees ONE
+    // foo.
+    let hit = db.symbol_candidates(&rust_symbol_selector("foo"), false).unwrap();
+    assert!(!hit.candidates.is_empty(), "foo resolves in the overlay scope");
+    assert_eq!(
+        hit.candidates[0].logical_variant_count,
+        Some(1),
+        "overlay scope sees ONE foo — variant_count must be the scope-visible count, not the \
+         corpus total (2)"
+    );
+    assert_eq!(hit.candidates[0].logical_group_reason.as_deref(), Some("single"));
+
+    // The graph/impact variant LIST must be scoped too, or it would disagree with the count and
+    // leak the hidden base member (#897 review): one visible member in the overlay scope, not two.
+    let logical_id = hit.candidates[0].logical_symbol_id.expect("logical id");
+    let members =
+        rag_rat_query::symbol::logical_members(db.storage.connection(), logical_id).unwrap();
+    assert_eq!(members.len(), 1, "the scoped variant list matches the scope-visible count (1)");
+
+    // The STORED corpus-level count is still 2: the fix is at surfacing time, not in the table.
+    let stored: i64 = db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT variant_count FROM main.logical_symbols WHERE repo_id = ?1 AND logical_name = \
+             ?2",
+            rusqlite::params![db.active_repo_id, "foo"],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(stored, 2, "the stored corpus-level variant_count remains 2");
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}
+
+/// #897 (rename half): under the overlay scope, `symbol_lookup` reflects the BRANCH's renamed symbol
+/// and NOT the pre-rename name; the base scope is the reverse — per-branch symbol visibility.
+#[test]
+fn overlay_scope_symbol_lookup_reflects_a_branch_rename() {
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(main.join("src/a.rs"), "pub fn target_fn() {}\n").unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let config = source_config(main.clone(), Language::Rust);
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    fs::write(linked.join("src/a.rs"), "pub fn renamed_fn() {}\n").unwrap();
+    run_git(&linked, &["add", "."]);
+    run_git(&linked, &["commit", "-q", "-m", "rename"]);
+    db.index_worktree_overlay(&config, &linked, &mut |_| {}).unwrap();
+
+    let resolves = |db: &IndexDatabase, name: &str| {
+        !db.symbol_candidates(&rust_symbol_selector(name), false).unwrap().candidates.is_empty()
+    };
+    // Overlay scope (left installed by index_worktree_overlay):
+    assert!(resolves(&db, "renamed_fn"), "overlay scope sees the branch rename");
+    assert!(!resolves(&db, "target_fn"), "overlay scope does not see the pre-rename name");
+    // Base scope:
+    set_base_scope(&mut db, &main);
+    assert!(resolves(&db, "target_fn"), "base scope keeps the original name");
+    assert!(!resolves(&db, "renamed_fn"), "base scope does not see the branch rename");
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}
+
+/// #898: with TWO simultaneously-live worktree overlays holding divergent branch-only content,
+/// removing exactly ONE worktree and running gc prunes only that worktree's `files` rows — the
+/// other live worktree's overlay rows remain intact.
+#[test]
+fn gc_prunes_only_the_removed_worktrees_overlay_with_two_live_overlays() {
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(main.join("src/base.rs"), "pub fn base_fn() {}\n").unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let config = source_config(main.clone(), Language::Rust);
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+
+    let wt_a = unique_temp_root();
+    let _ = fs::remove_dir_all(&wt_a);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat-a", wt_a.to_str().unwrap()]);
+    fs::write(wt_a.join("src/a_only.rs"), "pub fn a_only() {}\n").unwrap();
+    run_git(&wt_a, &["add", "."]);
+    run_git(&wt_a, &["commit", "-q", "-m", "branch a"]);
+    let wt_b = unique_temp_root();
+    let _ = fs::remove_dir_all(&wt_b);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat-b", wt_b.to_str().unwrap()]);
+    fs::write(wt_b.join("src/b_only.rs"), "pub fn b_only() {}\n").unwrap();
+    run_git(&wt_b, &["add", "."]);
+    run_git(&wt_b, &["commit", "-q", "-m", "branch b"]);
+
+    db.index_worktree_overlay(&config, &wt_a, &mut |_| {}).unwrap();
+    db.index_worktree_overlay(&config, &wt_b, &mut |_| {}).unwrap();
+    let a_id = worktree_id_of(&wt_a);
+    let b_id = worktree_id_of(&wt_b);
+    assert!(
+        overlay_rows(&db, &a_id).iter().any(|(path, _)| path == "src/a_only.rs"),
+        "worktree A's branch-only file is in its overlay"
+    );
+    assert!(
+        overlay_rows(&db, &b_id).iter().any(|(path, _)| path == "src/b_only.rs"),
+        "worktree B's branch-only file is in its overlay"
+    );
+
+    // Remove ONLY worktree B, then gc.
+    run_git(&main, &["worktree", "remove", "--force", wt_b.to_str().unwrap()]);
+    set_base_scope(&mut db, &main);
+    db.garbage_collect().unwrap();
+    assert!(overlay_rows(&db, &b_id).is_empty(), "gc pruned the removed worktree B's overlay rows");
+    assert!(
+        overlay_rows(&db, &a_id).iter().any(|(path, _)| path == "src/a_only.rs"),
+        "the still-live worktree A's overlay rows are untouched"
+    );
+    crate::index::poison_sibling::assert_sibling_intact(db.storage.connection());
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&wt_a);
+}
+
+/// #899: a linked worktree that DROPS a symbol via `index_worktree_overlay` (the Inline #826 route,
+/// NOT the Deferred batch fallback): the dropped symbol's group is removed by the scoped re-derive,
+/// the surviving symbol is kept, ZERO whole-repo rebuilds, and the result is the full rebuild's
+/// fixed point. Covers the #826 scoped path for a linked-worktree rename/removal (previously only
+/// the addition case exercised the Inline route).
+#[test]
+fn a_linked_worktree_symbol_drop_scopes_the_logical_rederive() {
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(main.join("src/a.rs"), "pub fn base_fn() {}\n").unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let config = source_config(main.clone(), Language::Rust);
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    fs::write(linked.join("src/one.rs"), "pub fn one_fn() {}\n").unwrap();
+    run_git(&linked, &["add", "."]);
+    run_git(&linked, &["commit", "-q", "-m", "branch adds one_fn"]);
+    db.index_worktree_overlay(&config, &linked, &mut |_| {}).unwrap();
+
+    // Dirty-add two_fn — it exists ONLY in the overlay (never committed).
+    fs::write(linked.join("src/one.rs"), "pub fn one_fn() {}\npub fn two_fn() {}\n").unwrap();
+    db.index_worktree_overlay(&config, &linked, &mut |_| {}).unwrap();
+    assert!(logical_symbol_named(&db, "two_fn"), "the dirty-added overlay symbol is grouped");
+
+    // Dirty-remove two_fn (the `// edited` line keeps one.rs dirty vs the feat commit, so this
+    // stays the Inline scoped route, not a stale-overlay heal). two_fn is now gone from EVERY
+    // live scope.
+    fs::write(linked.join("src/one.rs"), "// edited\npub fn one_fn() {}\n").unwrap();
+    let before = db.logical_symbol_rebuilds.load(std::sync::atomic::Ordering::Relaxed);
+    db.index_worktree_overlay(&config, &linked, &mut |_| {}).unwrap();
+    assert_eq!(
+        db.logical_symbol_rebuilds.load(std::sync::atomic::Ordering::Relaxed) - before,
+        0,
+        "the drop is served by the Inline scoped re-derive, not a whole-repo rebuild"
+    );
+    assert!(
+        !logical_symbol_named(&db, "two_fn"),
+        "the removed overlay symbol's group is dropped via the scoped path"
+    );
+    assert!(logical_symbol_named(&db, "one_fn"), "the surviving symbol's group is intact");
+
+    let scoped = logical_grouping_snapshot(&db);
+    db.rebuild_logical_symbols(crate::index::graph_index::KeyVersionStamp::Defer).unwrap();
+    assert_eq!(
+        logical_grouping_snapshot(&db),
+        scoped,
+        "the scoped drop equals the whole-repo rebuild"
+    );
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}

--- a/crates/rag-rat-query/src/symbol.rs
+++ b/crates/rag-rat-query/src/symbol.rs
@@ -396,19 +396,39 @@ fn lookup_name(
     Ok(hits)
 }
 
+/// The `variant_count` and `group_reason` columns computed from the SCOPE-VISIBLE members of a
+/// `logical_symbols` row, not the stored corpus-level totals (#897). The stored `variant_count` is
+/// `members.len()` across ALL of a repo's scopes (a symbol in a dirty-overlaid file has one member
+/// per scope), but the member LIST every consumer reads is scope-filtered through the `files` view
+/// — so a scoped (worktree-overlay) `symbol_lookup` would otherwise report a count/label that
+/// disagrees with the members it returns (e.g. `variant_count=2` / `scope_replica` for one visible
+/// member). Joining the `files` view here filters to the members whose file is visible in the
+/// active scope, matching `lookup_logical_members`; the `group_reason` CASE mirrors
+/// `logical_group_reason` (single / same-file-multi / scope-replica) over that visible set. On an
+/// UNSCOPED connection (`files` resolves to `main.files`) these equal the stored columns.
+const SCOPED_LOGICAL_STATS: &str =
+    "\
+    (SELECT COUNT(*) FROM logical_symbol_members m JOIN symbols s ON s.id = m.symbol_id JOIN files \
+     f ON f.id = s.file_id WHERE m.logical_symbol_id = logical_symbols.id), (SELECT CASE WHEN \
+     COUNT(*) <= 1 THEN 'single' WHEN COUNT(*) > COUNT(DISTINCT s.file_id) THEN 'same_file_multi' \
+     ELSE 'scope_replica' END FROM logical_symbol_members m JOIN symbols s ON s.id = m.symbol_id \
+     JOIN files f ON f.id = s.file_id WHERE m.logical_symbol_id = logical_symbols.id)";
+
 pub fn lookup_logical_by_id(
     conn: &Connection,
     logical_symbol_id: i64,
 ) -> anyhow::Result<Option<LogicalSymbolHit>> {
     conn.query_row(
-        "
+        &format!(
+            "
         SELECT logical_symbols.id, logical_symbols.language, logical_symbols.path,
                logical_symbols.logical_name, qn.value, logical_symbols.kind,
-               logical_symbols.variant_count, logical_symbols.group_reason
+               {SCOPED_LOGICAL_STATS}
         FROM logical_symbols
         LEFT JOIN name_strings qn ON qn.id = logical_symbols.qualified_name_id
         WHERE logical_symbols.id = ?1
-        ",
+        "
+        ),
         [logical_symbol_id],
         logical_symbol_hit_row,
     )
@@ -421,15 +441,17 @@ pub fn logical_for_symbol_id(
     symbol_id: i64,
 ) -> anyhow::Result<Option<LogicalSymbolHit>> {
     conn.query_row(
-        "
+        &format!(
+            "
         SELECT logical_symbols.id, logical_symbols.language, logical_symbols.path,
                logical_symbols.logical_name, qn.value, logical_symbols.kind,
-               logical_symbols.variant_count, logical_symbols.group_reason
+               {SCOPED_LOGICAL_STATS}
         FROM logical_symbol_members
         JOIN logical_symbols ON logical_symbols.id = logical_symbol_members.logical_symbol_id
         LEFT JOIN name_strings qn ON qn.id = logical_symbols.qualified_name_id
         WHERE logical_symbol_members.symbol_id = ?1
-        ",
+        "
+        ),
         [symbol_id],
         logical_symbol_hit_row,
     )
@@ -441,12 +463,20 @@ pub fn logical_members(
     conn: &Connection,
     logical_symbol_id: i64,
 ) -> anyhow::Result<Vec<LogicalSymbolMember>> {
+    // Scope-filter through the `files` view (#897): a logical symbol is scope-independent (one
+    // member per scope of a path), so an unscoped list would surface members hidden by the
+    // active worktree-overlay scope — and disagree with the scope-visible `variant_count` this
+    // same graph / impact response reports (via `SCOPED_LOGICAL_STATS`). The JOIN filters to
+    // members whose file is visible in the active scope, matching `lookup_logical_members`; on
+    // an unscoped connection (`files` → `main.files`) the list is unchanged.
     let mut stmt = conn.prepare(
         "
-        SELECT symbol_id, cfg_expr, signature_hash, start_line, end_line
-        FROM logical_symbol_members
-        WHERE logical_symbol_id = ?1
-        ORDER BY start_line, symbol_id
+        SELECT m.symbol_id, m.cfg_expr, m.signature_hash, m.start_line, m.end_line
+        FROM logical_symbol_members m
+        JOIN symbols s ON s.id = m.symbol_id
+        JOIN files f ON f.id = s.file_id
+        WHERE m.logical_symbol_id = ?1
+        ORDER BY m.start_line, m.symbol_id
         ",
     )?;
     let rows = stmt.query_map([logical_symbol_id], |row| {


### PR DESCRIPTION
## #897 — scope-filter surfaced logical `variant_count` / `group_reason` / variant list
`logical_symbols.variant_count` / `group_reason` are corpus-level: the stored count is the member total across **all** of a repo's scopes, so a symbol in a dirty-overlaid file has one member per scope (committed + overlay → count 2, `scope_replica`). But every scoped (worktree-overlay) read filters members through the `files` view — so `symbol_lookup` and the graph/impact response reported a count/label/list that disagreed with the scope-visible members: `variant_count=2` / `scope_replica` for one visible member, and the graph variant list leaked the base member hidden by the active worktree scope.

`lookup_logical_by_id` / `logical_for_symbol_id` now compute `variant_count` / `group_reason` from the scope-visible members (JOIN the `files` view, the CASE mirroring `logical_group_reason`), and `logical_members` (the graph/impact variant list) is scope-filtered to match — so count and list agree. A genuine same-file cfg pair is unaffected (both members in one scope); on an unscoped connection the values equal the stored columns.

## #898, #899 — added tests
- **#898**: gc discriminating two simultaneously-live content-bearing worktree overlays — removing one prunes only its `files` rows; the other's remain intact.
- **#899**: the #826 Inline scoped logical re-derive drops a symbol removed on a linked worktree (via `index_worktree_overlay`, not the Deferred batch fallback), with zero whole-repo rebuilds and byte-identity to a forced full rebuild.

## Verification
Full `rag-rat-core` suite green (1541 tests, both CI runners); clippy (both feature sets, `-D warnings`) and nightly rustfmt clean. The existing single-scope cfg-variant test still asserts `variant_count=2` (scope-visible == stored).

Fixes #897.
Fixes #898.
Fixes #899.
