### PR TITLE
feat(memory): drain accepted /3 content into repo_memories (#691)

### DIFF
--- a/crates/rag-rat-core/src/index/consolidate.rs
+++ b/crates/rag-rat-core/src/index/consolidate.rs
@@ -349,6 +349,16 @@ fn run_inner(config: &Config, config_path: Option<&Path>) -> anyhow::Result<Cons
         rag_rat_base::time::now_ms(),
     )?;
 
+    // The REVERSE direction (#691 A1): mirror any accepted SYNCED /3 content on this repo's owner
+    // stream back into the local memory tables as `origin='synced'` rows. Paired with the reconcile
+    // above so the consolidated store's synced rows are materialized, not just its local ones. A
+    // legacy import usually carries no synced content, so this is a near-no-op there.
+    crate::memory_write::drain_synced_stream_for_repo(
+        target_conn,
+        &repo_id,
+        rag_rat_base::time::now_ms(),
+    )?;
+
     // Rename the legacy file so a keyless config now resolves to the global store (via the
     // `.imported` latch), and a re-run is a no-op. AFTER the import commits, so a failure leaves
     // the legacy file in place to retry. The WAL sidecars travel WITH the archive: a bare

--- a/crates/rag-rat-core/src/index/lifecycle.rs
+++ b/crates/rag-rat-core/src/index/lifecycle.rs
@@ -119,6 +119,15 @@ impl IndexDatabase {
         // V070-tables guard inside skips cleanly); idempotent and serialized by its own
         // IMMEDIATE txn, so racing openers converge.
         rag_rat_oplog::rebuild_all_content_projections_if_stale(storage.connection())?;
+        // #691 A1: mirror any accepted SYNCED /3 content into the local memory tables now that the
+        // projection is current above — the reverse of the authoring reconcile. Store-global (one
+        // pass per real repo). A repo with no minted account or no synced content is a cheap no-op,
+        // so a single-device store's open is unaffected; a store that has pulled a peer's content
+        // materializes it as `origin='synced'` rows here, so it is a real local row on next read.
+        crate::memory_write::drain_synced_streams_for_all_repos(
+            storage.connection(),
+            rag_rat_base::time::now_ms(),
+        )?;
         Ok(storage)
     }
 

--- a/crates/rag-rat-core/src/index/query_api/memory.rs
+++ b/crates/rag-rat-core/src/index/query_api/memory.rs
@@ -345,6 +345,21 @@ impl IndexDatabase {
         )
     }
 
+    /// Materialize any accepted SYNCED `/3` content into the local memory tables — the reverse of
+    /// the memory reconcile (#691 A1). Store-global (one pass per registered real repo); a repo
+    /// with no minted account or no synced content is a cheap no-op. Called from the watcher's
+    /// maintenance pass so a long-running process picks up content pulled AFTER open without a
+    /// reopen (open and consolidate drain at their own seams). The eventual live sync-session
+    /// driver should call `drain_synced_stream_for_repo` per session for immediacy; this pass
+    /// is the backstop.
+    pub fn drain_synced_memory(&self) -> anyhow::Result<()> {
+        crate::memory_write::drain_synced_streams_for_all_repos(
+            self.storage.connection(),
+            rag_rat_base::time::now_ms(),
+        )?;
+        Ok(())
+    }
+
     pub fn memory_doctor(&self) -> anyhow::Result<Vec<rag_rat_query::memory::MemoryDoctorEntry>> {
         rag_rat_query::memory::doctor_report(self.storage.connection())
     }

--- a/crates/rag-rat-core/src/memory_write/drain.rs
+++ b/crates/rag-rat-core/src/memory_write/drain.rs
@@ -120,6 +120,15 @@ pub(crate) fn drain_synced_stream_for_repo(
     }
 
     let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
+    // Re-check the removal tombstone INSIDE the write txn (#767).
+    // `drain_synced_streams_for_all_repos` snapshots `real_repo_ids` outside any txn, so a
+    // concurrent `rag-rat rm` can purge this repo and commit its removal marker between that
+    // snapshot and here. Both are IMMEDIATE txns and serialize: if `rm` took the lock first,
+    // its tombstone is visible now — materializing would RESURRECT the synced rows `rm` just
+    // purged and reported gone. Skip a removed repo before any write.
+    if rag_rat_db::schema::is_repo_removed(&tx, repo_id)? {
+        return Ok(DrainOutcome::default());
+    }
     // Settle the owner stream's deferred refold HERE, inside the write's own transaction and before
     // the projection read, so the drain mirrors a CURRENT accepted set. A settle failure propagates
     // and rolls the drain back, so the barrier stays fail-closed (same discipline as the
@@ -1735,6 +1744,28 @@ mod tests {
             params![stream.to_bytes().as_slice()],
         )
         .unwrap();
+    }
+
+    /// A concurrent `rag-rat rm` that commits its removal tombstone after the store-global drain
+    /// has snapshotted the repo list must NOT re-materialize the removed repo's synced content.
+    /// The in-transaction tombstone recheck skips it — without the guard, the projected peer
+    /// node would be resurrected into `repo_memories` after `rm` reported it gone.
+    #[test]
+    fn a_drain_skips_a_repo_with_a_removal_tombstone() {
+        let conn = scoped_conn();
+        create_concept(&conn, "seed");
+        let stream = rag_rat_oplog::owned_stream_v2_id(&conn, REPO).unwrap().unwrap();
+        // A peer node in the projection that a drain WOULD materialize.
+        seed_projected_node(&conn, stream, "mem_peer", "Invariant", "peer", "b", "active", &[]);
+        // `rm` tombstones the repo (its purge cleared the rows; the drain must not put them back).
+        rag_rat_db::schema::mark_repo_removed(&conn, REPO, 1).unwrap();
+
+        let outcome = drain_synced_stream_for_repo(&conn, REPO, 2_000).unwrap();
+        assert_eq!(outcome, DrainOutcome::default(), "a tombstoned repo's drain is a no-op");
+        assert!(
+            memory_by_id(&conn, "mem_peer").unwrap().is_none(),
+            "the removed repo's synced content is not resurrected by the drain",
+        );
     }
 
     /// The drain gate must SKIP its scan when the projection is unchanged since the last drain —

--- a/crates/rag-rat-core/src/memory_write/drain.rs
+++ b/crates/rag-rat-core/src/memory_write/drain.rs
@@ -108,6 +108,17 @@ pub(crate) fn drain_synced_stream_for_repo(
         return Ok(DrainOutcome::default());
     };
 
+    // Cheap read-only gate: skip the write txn + O(projection) scan entirely when the projection is
+    // unchanged since this stream was last drained and nothing is pending. Every drain seam routes
+    // through here (open, consolidate, and the long-running watcher pass), so all three go O(1)
+    // when idle instead of O(projection); the first-ever drain has no watermark and always runs
+    // (the backfill). Read-only and outside the txn, so a concurrent author that advances the
+    // epoch right after this check is simply picked up by the next drain — delayed one pass,
+    // never lost.
+    if !rag_rat_oplog::content_drain_needed(conn, stream)? {
+        return Ok(DrainOutcome::default());
+    }
+
     let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
     // Settle the owner stream's deferred refold HERE, inside the write's own transaction and before
     // the projection read, so the drain mirrors a CURRENT accepted set. A settle failure propagates
@@ -115,6 +126,10 @@ pub(crate) fn drain_synced_stream_for_repo(
     // reconcile).
     rag_rat_oplog::settle_pending_content_refold_for_stream_in_tx(&tx, stream)?;
     let outcome = drain_synced_stream_in_tx(&tx, repo_id, stream, now_ms)?;
+    // Stamp the watermark to the epoch AFTER the settle above (which may have advanced it), so the
+    // next `content_drain_needed` short-circuits until the projection changes again. In the same
+    // txn as the scan, so a rolled-back drain never records progress it did not make.
+    rag_rat_oplog::record_content_drained(&tx, stream)?;
     tx.commit()?;
     Ok(outcome)
 }
@@ -1707,6 +1722,66 @@ mod tests {
         assert_eq!(origin_of(&conn, "mem_peer"), "synced");
         assert!(memory_by_id(&conn, "mem_peer").unwrap().is_some(), "readable as a local row");
         assert_eq!(origin_of(&conn, &local_id), "local", "the local row is left untouched");
+    }
+
+    /// Advance a stream's projection epoch WITHOUT rewriting the projection — the way to simulate
+    /// "the projection changed" while keeping directly-seeded poison rows in place (a real
+    /// reproject would rebuild them away). Mutates the internal `oplog_meta` epoch key by hand
+    /// on purpose.
+    fn bump_projection_epoch(conn: &Connection, stream: StreamId) {
+        conn.execute(
+            "UPDATE oplog_meta SET value = CAST(value AS INTEGER) + 1 WHERE key = \
+             'content:proj-epoch:' || hex(?1)",
+            params![stream.to_bytes().as_slice()],
+        )
+        .unwrap();
+    }
+
+    /// The drain gate must SKIP its scan when the projection is unchanged since the last drain —
+    /// and the skip must be load-bearing, not luck. Poison the projection with a node the scan
+    /// WOULD materialize but WITHOUT advancing the epoch (a direct insert bypasses the
+    /// reproject that bumps it); a gated re-drain must not pick it up. Then advance the epoch
+    /// and confirm the SAME drain now does — proving the gate, not an empty projection, is what
+    /// suppressed the first pass.
+    #[test]
+    fn the_drain_gate_skips_an_unchanged_projection_then_runs_when_the_epoch_advances() {
+        let conn = scoped_conn();
+        // Mints the account + owner stream and reprojects the local seed (epoch -> 1).
+        create_concept(&conn, "seed");
+        let stream = rag_rat_oplog::owned_stream_v2_id(&conn, REPO).unwrap().unwrap();
+
+        // First drain records the watermark at the current epoch → nothing owed afterwards.
+        drain_synced_streams_for_all_repos(&conn, 1_000).unwrap();
+        assert!(
+            !rag_rat_oplog::content_drain_needed(&conn, stream).unwrap(),
+            "nothing is owed immediately after a drain",
+        );
+
+        // Poison: a projected node the scan WOULD materialize, inserted directly so the epoch does
+        // NOT move (a real peer op would reproject and bump it).
+        seed_projected_node(&conn, stream, "mem_poison", "Invariant", "p", "b", "active", &[]);
+
+        // Gated re-drain: the epoch equals the watermark and nothing is pending, so the gate skips
+        // the scan — the poison stays unseen.
+        let skipped = drain_synced_streams_for_all_repos(&conn, 2_000).unwrap();
+        assert_eq!(skipped, DrainOutcome::default(), "the gate skipped the scan");
+        assert!(
+            memory_by_id(&conn, "mem_poison").unwrap().is_none(),
+            "a gated skip does not materialize a projected row the scan would have",
+        );
+
+        // Advance the epoch as a real reproject would; the SAME drain now runs and materializes it.
+        bump_projection_epoch(&conn, stream);
+        assert!(
+            rag_rat_oplog::content_drain_needed(&conn, stream).unwrap(),
+            "an epoch past the watermark is owed",
+        );
+        let ran = drain_synced_streams_for_all_repos(&conn, 3_000).unwrap();
+        assert_eq!(ran.nodes_written, 1, "the drain runs once the epoch advances");
+        assert!(
+            memory_by_id(&conn, "mem_poison").unwrap().is_some(),
+            "and materializes the row the earlier gated pass skipped",
+        );
     }
 
     /// The public entry no-ops on an unstable repo id (legacy / local-only) — such an id can never

--- a/crates/rag-rat-core/src/memory_write/drain.rs
+++ b/crates/rag-rat-core/src/memory_write/drain.rs
@@ -1,0 +1,1728 @@
+//! Draining accepted `/3` content into `repo_memories` / `repo_node_edges` — the REVERSE of the
+//! local reconcile (`authoring::reconcile_owner_stream_for_repo`, which authors local rows INTO the
+//! signed `/3` log). Here, a stream's accepted projection is mirrored back OUT into the local
+//! memory tables as `origin='synced'` rows, so a memory authored on one device becomes a real,
+//! searchable local row on another device of the same account.
+//!
+//! REPO ATTRIBUTION BY FORWARD DERIVATION. Content `/3` is one stream per `(repo_id, account_id)`,
+//! and every device of one account shares the account id, so the owner stream id is identical on
+//! every device. Given a local `repo_id` the drain therefore FORWARD-derives the stream
+//! (`owned_stream_v2_id`) and mirrors exactly that stream's projection — the same input the local
+//! reconcile takes. Cross-*account* sibling streams for the same repo (the public-subscription
+//! case) are out of scope here.
+//!
+//! CONVERGE, DON'T FREEZE. The accepted `/3` projection is the LWW-merged content across ALL of the
+//! account's devices, INCLUDING this one — so when another device updates or removes a memory/edge
+//! this device originally created, the projection holds the winning value and the drain must
+//! CONVERGE the local row to it, preserving the row's `origin` (a row created here stays `'local'`,
+//! a row received from a peer stays `'synced'`). Skipping a projected `origin='local'` row would
+//! freeze this device on stale content forever. The one thing the drain must NOT touch is a local
+//! row that is ABSENT from the projection — that is a pending local edit not yet reconciled into
+//! the log, so it is left alone (and, being `origin='local'`, is spared by the synced-only removal
+//! anti-joins). New `origin` on WRITE: an absent row is INSERTed `'synced'` (received from a peer);
+//! an existing row keeps its own origin.
+//!
+//! NO ECHO. Convergence never re-authors: the authoring-side anti-join
+//! (`read_unauthored_memory_rows` / `unauthored_edges`, `WHERE origin='local' AND NOT EXISTS
+//! (…projection…)`) re-authors only a local row MISSING from the projection. A converged local row
+//! IS in the projection, so it is never in the unauthored set — the round-trip cannot loop.
+//!
+//! CROSS-REPO BOUNDARY + ROBUSTNESS. Projected content is peer-authored and only shape-validated,
+//! so the drain treats it as untrusted at the repo boundary: a node id already owned by ANOTHER
+//! repo is left untouched (node id is a global PK — a peer must never overwrite a sibling's row),
+//! an edge whose self-declared `owner_repo_id` is not this repo is skipped (never injected into /
+//! removed from a sibling), and an edge only materializes when its source node is a row THIS repo
+//! owns — an absent source (retro-condemned away) would abort the whole drain on its
+//! `source_node_id` FK (wedging every open), and a source id colliding with a sibling's node would
+//! attach a this-repo edge to that sibling's row.
+//!
+//! PER-DEVICE STATE IS NOT CONVERGED. An edge's resolution triple (`target_repo_id resolution`,
+//! `target_node_id`, `anchor_status`) is per-device derived state recomputed on read
+//! (`reresolve_on_read`), never converged: the drain writes the DURABLE spec (owner + signed
+//! `target_repo_id`) but stores the resolution `unresolved` on INSERT and never imports a peer's
+//! projected `Rebind` anchor (that would splice one device's resolution into another's edge), and
+//! it never rewrites the resolution on a converge (that would wipe a resolved local edge every
+//! pass). The read path recomputes the whole triple locally.
+//!
+//! ATOMICITY. The projection read + the table writes run inside ONE `IMMEDIATE` transaction, after
+//! settling any pending refold for the stream (the same fail-closed barrier the reconcile uses) so
+//! the projection is current. The synced rows are fully reconstructable from the durable `/3` log,
+//! so — unlike an authored write — the drain does NOT raise `synchronous = FULL`; a lost drain
+//! simply re-materializes on the next pass.
+
+use rag_rat_oplog::{self, ProjectedContentEdge, ProjectedContentNode, StreamId};
+use rag_rat_query::memory;
+use rusqlite::{Connection, OptionalExtension, Transaction, TransactionBehavior, params};
+
+/// The `repo_memories.memory_version` a synced row is stamped with — the author-side constant the
+/// live create path mints (`'v1'`), so a drained row is indistinguishable from a locally-authored
+/// one in everything but `origin`. Kept in lock-step with `api::create_memory`.
+const SYNCED_MEMORY_VERSION: &str = "v1";
+
+/// What one drain pass changed. Owned + flat counts; a re-drain over an unchanged projection
+/// reports all-zero (the idempotence contract).
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct DrainOutcome {
+    /// Nodes inserted (synced) or converged (content/status/tags updated to the projection).
+    pub nodes_written: u32,
+    /// Synced nodes removed because their projection row vanished (retro-condemn / revocation). A
+    /// local row absent from the projection is a pending edit and is NOT counted or removed.
+    pub nodes_removed: u32,
+    /// Edges inserted (synced) or converged (durable spec updated to the projection).
+    pub edges_written: u32,
+    /// Edges removed — a `present=0` tombstone (regardless of origin: a peer's remove wins), or a
+    /// synced edge whose projection row vanished entirely (retro-condemn).
+    pub edges_removed: u32,
+}
+
+impl DrainOutcome {
+    fn add(&mut self, other: DrainOutcome) {
+        self.nodes_written += other.nodes_written;
+        self.nodes_removed += other.nodes_removed;
+        self.edges_written += other.edges_written;
+        self.edges_removed += other.edges_removed;
+    }
+}
+
+/// Mirror a repo's accepted synced `/3` content into its local memory tables. Scope-EXPLICIT (the
+/// `repo_id` is passed) and scope-gated the same way the reconcile is — a LEGACY placeholder or a
+/// `local:` shallow-clone id can never root an owner stream, so it no-ops. Opens its own
+/// `IMMEDIATE` transaction, settles the owner stream's pending refold inside it (fail-closed), then
+/// drains.
+pub(crate) fn drain_synced_stream_for_repo(
+    conn: &Connection,
+    repo_id: &str,
+    now_ms: i64,
+) -> anyhow::Result<DrainOutcome> {
+    // Only a STABLE id derives an immutable owner stream (mirrors `sync_owner_stream`): the legacy
+    // `__unassigned__` placeholder and a `local:` shallow-clone id both get re-pointed later, so a
+    // stream derived under them would strand. No synced content can exist for such an id anyway.
+    if repo_id == rag_rat_base::repo_identity::LEGACY_REPO_ID
+        || repo_id.starts_with(rag_rat_base::repo_identity::LOCAL_ONLY_ID_PREFIX)
+    {
+        return Ok(DrainOutcome::default());
+    }
+    // Forward-derive the owner stream. `None` = no local account minted yet ⇒ nothing could have
+    // been authored/ingested onto this stream ⇒ nothing to drain (the analog of an unstable scope).
+    let Some(stream) = rag_rat_oplog::owned_stream_v2_id(conn, repo_id)? else {
+        return Ok(DrainOutcome::default());
+    };
+
+    let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
+    // Settle the owner stream's deferred refold HERE, inside the write's own transaction and before
+    // the projection read, so the drain mirrors a CURRENT accepted set. A settle failure propagates
+    // and rolls the drain back, so the barrier stays fail-closed (same discipline as the
+    // reconcile).
+    rag_rat_oplog::settle_pending_content_refold_for_stream_in_tx(&tx, stream)?;
+    let outcome = drain_synced_stream_in_tx(&tx, repo_id, stream, now_ms)?;
+    tx.commit()?;
+    Ok(outcome)
+}
+
+/// Drain every registered real repo's synced stream — the store-global counterpart wired into the
+/// open/migrate seam, after the projection is rebuilt current. Per-repo derivation means a repo
+/// with no minted account (or no synced content) is a cheap no-op, so this stays light on a plain
+/// open.
+pub(crate) fn drain_synced_streams_for_all_repos(
+    conn: &Connection,
+    now_ms: i64,
+) -> anyhow::Result<DrainOutcome> {
+    let mut total = DrainOutcome::default();
+    for repo_id in rag_rat_db::schema::real_repo_ids(conn)? {
+        total.add(drain_synced_stream_for_repo(conn, &repo_id, now_ms)?);
+    }
+    Ok(total)
+}
+
+/// The in-transaction drain worker: NODES first (so an edge's `source_node_id` FK target exists),
+/// then edges, then the two retro-condemn removals. Reads the projection through the oplog decode
+/// helpers; CONVERGES each projected row into the local tables (INSERT synced if absent, else
+/// update preserving origin) and removes rows the projection dropped. Assumes the caller settled
+/// any pending refold so the projection is current.
+fn drain_synced_stream_in_tx(
+    tx: &Transaction<'_>,
+    repo_id: &str,
+    stream: StreamId,
+    now_ms: i64,
+) -> anyhow::Result<DrainOutcome> {
+    let mut outcome = DrainOutcome::default();
+
+    // (1) Nodes: converge every projected node into the local tables (INSERT synced if absent,
+    // else update content/status/tags preserving origin), so every edge's source node exists
+    // before the edge pass.
+    for node in rag_rat_oplog::list_projected_content_nodes(tx, stream)? {
+        match drain_node(tx, repo_id, &node, now_ms)? {
+            NodeEffect::Written => outcome.nodes_written += 1,
+            NodeEffect::Removed => outcome.nodes_removed += 1,
+            NodeEffect::Unchanged => {},
+        }
+    }
+
+    // (2) Edges: a present edge converges (INSERT synced / update durable spec), a `present=0`
+    // tombstone removes the edge regardless of origin (a peer's remove wins).
+    for edge in rag_rat_oplog::list_projected_content_edges(tx, stream)? {
+        match drain_edge(tx, repo_id, &edge, now_ms)? {
+            EdgeEffect::Written => outcome.edges_written += 1,
+            EdgeEffect::Removed => outcome.edges_removed += 1,
+            EdgeEffect::Unchanged => {},
+        }
+    }
+
+    // (3) Retro-condemn: a synced edge whose projection row VANISHED entirely (not a present=0
+    // tombstone, which is still IN the projection) is removed — only `origin='synced'` rows.
+    outcome.edges_removed += remove_vanished_synced_edges(tx, repo_id, stream)?;
+
+    // (4) Retro-condemn: a synced NODE whose projection row vanished is removed. An
+    // `origin='local'` row of the same id (a genuine local ghost the reconcile will author) is
+    // left intact by the origin gate. Runs last so the edge passes above still saw their FK
+    // targets.
+    outcome.nodes_removed += remove_vanished_synced_nodes(tx, repo_id, stream)?;
+
+    Ok(outcome)
+}
+
+/// One existing `repo_memories` row's convergence-relevant columns. `repo_id` gates the converge to
+/// OUR repo (node id is a global PK, so a peer stream naming an id another repo already owns must
+/// NOT be allowed to overwrite that sibling); `origin` is deliberately NOT read — a converge
+/// preserves whatever it is, it is never a gate.
+struct ExistingNode {
+    repo_id: String,
+    kind: String,
+    title: String,
+    body: String,
+    confidence: String,
+    source: String,
+    payload_json: Option<String>,
+    status: String,
+}
+
+fn read_existing_node(conn: &Connection, node_id: &str) -> anyhow::Result<Option<ExistingNode>> {
+    conn.query_row(
+        "SELECT repo_id, kind, title, body, confidence, source, payload_json, status
+         FROM repo_memories WHERE id = ?1",
+        [node_id],
+        |row| {
+            Ok(ExistingNode {
+                repo_id: row.get(0)?,
+                kind: row.get(1)?,
+                title: row.get(2)?,
+                body: row.get(3)?,
+                confidence: row.get(4)?,
+                source: row.get(5)?,
+                payload_json: row.get(6)?,
+                status: row.get(7)?,
+            })
+        },
+    )
+    .optional()
+    .map_err(Into::into)
+}
+
+/// Whether a projected node's content passes the SAME validity gates the local create/update path
+/// enforces — kind / confidence closed sets, title / body length caps, source, and the kind↔payload
+/// rule (`validate_payload`). Peer content crosses the wire only SHAPE-validated, and an older or
+/// compromised account device could author content that clears the §18a envelope cap yet violates
+/// these tighter local rules; such a node must not be persisted into the searchable tables.
+fn projected_node_content_is_valid(node: &ProjectedContentNode) -> anyhow::Result<()> {
+    memory::validate_kind(&node.content.kind)?;
+    memory::validate_confidence(&node.content.confidence)?;
+    memory::validate_source(&node.content.source)?;
+    memory::validate_len("title", &node.content.title, memory::MAX_MEMORY_TITLE_LEN)?;
+    memory::validate_len("body", &node.content.body, memory::MAX_MEMORY_BODY_LEN)?;
+    memory::validate_payload(&node.content.kind, node.content.payload.as_deref())?;
+    // Tags cross the same untrusted boundary. The local write path (`replace_tags`) caps each
+    // NORMALIZED tag at 64 bytes; an over-cap tag would otherwise error inside
+    // `write_node_children` and roll back the WHOLE drain (wedging every subsequent open on the
+    // same accepted projection). Validate the normalized tags here so an oversized tag is
+    // quarantined like any other field.
+    for tag in memory::normalize_tags(&node.content.tags) {
+        memory::validate_len("tag", &tag, 64)?;
+    }
+    Ok(())
+}
+
+/// What a node converge did — mirrors [`EdgeEffect`] so the outcome counters stay honest (a
+/// quarantine that drops a stale synced mirror is a removal, not a write).
+enum NodeEffect {
+    Written,
+    Removed,
+    Unchanged,
+}
+
+/// Converge one projected node into `repo_memories`. Absent locally → INSERT `origin='synced'` (a
+/// row received from a peer). Present under OUR repo → UPDATE its content/status/tags to the
+/// projection value, PRESERVING the existing `origin` (a locally-authored row stays `'local'`) —
+/// the projection is the account-wide LWW winner, so a projected local row carries another device's
+/// accepted edit and must converge, not freeze. Present under a DIFFERENT repo → skip (node id is a
+/// global PK; a peer stream must never overwrite a sibling repo's row). A local row ABSENT from the
+/// projection is never seen here (the loop iterates projected rows) and is left untouched as a
+/// pending local edit. Content that fails the local validity gates is QUARANTINED (skipped +
+/// warned, never persisted and never wedging the drain — symmetric to the authoring-side #680
+/// quarantine) — and if a prior synced mirror of that id exists, the stale row is REMOVED so it
+/// stops being searchable. Returns the [`NodeEffect`]: a converge INSERT/UPDATE is `Written`, a
+/// quarantine that drops a stale synced mirror is `Removed`, and a no-op (a row already equal to
+/// the projection, a sibling-owned id, or invalid content with nothing to remove) is `Unchanged` —
+/// the idempotence contract.
+fn drain_node(
+    tx: &Transaction<'_>,
+    repo_id: &str,
+    node: &ProjectedContentNode,
+    now_ms: i64,
+) -> anyhow::Result<NodeEffect> {
+    // Quarantine invalid peer content rather than persist a malformed row or wedge the whole drain.
+    if let Err(err) = projected_node_content_is_valid(node) {
+        tracing::warn!(
+            repo_id,
+            node_id = %node.node_id,
+            error = %err,
+            "quarantining an invalid synced memory node: its content violates a local rule the \
+             create/update path enforces (kind/confidence/length/payload); skipped, not persisted",
+        );
+        // If this id already has a materialized synced mirror, the accepted (now-invalid) value
+        // supersedes it: we cannot persist the invalid content, but leaving the STALE prior row
+        // searchable would expose a value the projection no longer holds. Drop the synced mirror (a
+        // local row of the same id survives).
+        let removed = remove_quarantined_synced_node(tx, repo_id, &node.node_id)?;
+        return Ok(if removed { NodeEffect::Removed } else { NodeEffect::Unchanged });
+    }
+    let projected_status = node.status.as_db_str();
+    match read_existing_node(tx, &node.node_id)? {
+        // A row with this id already belongs to ANOTHER repo — never touch a sibling's content.
+        Some(existing) if existing.repo_id != repo_id => Ok(NodeEffect::Unchanged),
+        Some(existing) => {
+            let current_tags = memory::tags_for_memory(tx, &node.node_id)?;
+            let want_tags = memory::normalize_tags(&node.content.tags);
+            let unchanged = existing.kind == node.content.kind
+                && existing.title == node.content.title
+                && existing.body == node.content.body
+                && existing.confidence == node.content.confidence
+                && existing.source == node.content.source
+                && existing.payload_json.as_deref() == node.content.payload.as_deref()
+                && existing.status == projected_status
+                && current_tags == want_tags;
+            if unchanged {
+                return Ok(NodeEffect::Unchanged);
+            }
+            // Converge to the account-wide LWW value; `origin` is intentionally NOT in the SET, so
+            // whatever the row was (local or synced) is preserved — a projected local row carries a
+            // peer's accepted edit, not an echo to ignore.
+            tx.execute(
+                "UPDATE repo_memories
+                 SET kind = ?2, title = ?3, body = ?4, confidence = ?5, source = ?6,
+                     payload_json = ?7, status = ?8, updated_at_ms = ?9
+                 WHERE id = ?1",
+                params![
+                    node.node_id,
+                    node.content.kind,
+                    node.content.title,
+                    node.content.body,
+                    node.content.confidence,
+                    node.content.source,
+                    node.content.payload,
+                    projected_status,
+                    now_ms,
+                ],
+            )?;
+            write_node_children(tx, &node.node_id, &node.content.tags)?;
+            Ok(NodeEffect::Written)
+        },
+        None => {
+            // First sight of this node — received from a peer. `created_by` / `source_text_hash` /
+            // `input_hash` have no op home and are nullable; `memory_version` is the author-side
+            // constant; the clock is bookkeeping only. `origin='synced'` is what the authoring gate
+            // keys off.
+            tx.execute(
+                "INSERT INTO repo_memories(
+                     id, kind, title, body, confidence, status, created_by, created_at_ms,
+                     updated_at_ms, source, payload_json, source_text_hash, input_hash,
+                     memory_version, repo_id, origin)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, NULL, ?7, ?7, ?8, ?9, NULL, NULL, ?10, ?11,
+                     'synced')",
+                params![
+                    node.node_id,
+                    node.content.kind,
+                    node.content.title,
+                    node.content.body,
+                    node.content.confidence,
+                    projected_status,
+                    now_ms,
+                    node.content.source,
+                    node.content.payload,
+                    SYNCED_MEMORY_VERSION,
+                    repo_id,
+                ],
+            )?;
+            write_node_children(tx, &node.node_id, &node.content.tags)?;
+            Ok(NodeEffect::Written)
+        },
+    }
+}
+
+/// Whether a `repo_memories` row with this id exists UNDER `repo_id`. The edge-drain source guard
+/// requires this (not a bare existence check) for two reasons: node id is a GLOBAL PK, so a bare
+/// check would let a peer edge (with a forged `owner_repo_id = repo_id`) reference a SIBLING repo's
+/// colliding node id — attaching a this-repo edge to that repo's node, a boundary violation; and an
+/// entirely ABSENT source (its node retro-condemned away) would abort the drain on the
+/// `source_node_id` FK. Requiring the source to belong to THIS repo covers both.
+fn node_in_repo(conn: &Connection, node_id: &str, repo_id: &str) -> anyhow::Result<bool> {
+    conn.query_row(
+        "SELECT EXISTS(SELECT 1 FROM repo_memories WHERE id = ?1 AND repo_id = ?2)",
+        params![node_id, repo_id],
+        |row| row.get::<_, i64>(0),
+    )
+    .map(|exists| exists != 0)
+    .map_err(Into::into)
+}
+
+/// Fan the node's tag SET out to `repo_memory_tags` (whole-set replace) and refresh its FTS row —
+/// the same two side tables the live create/update maintain, so a synced row reads back
+/// identically.
+fn write_node_children(tx: &Transaction<'_>, node_id: &str, tags: &[String]) -> anyhow::Result<()> {
+    memory::replace_tags(tx, node_id, tags)?;
+    memory::upsert_memory_fts(tx, node_id)?;
+    Ok(())
+}
+
+/// Remove every `origin='synced'` node for this repo whose id is absent from the CURRENT projection
+/// (a retro-condemn / revocation vacated it). The `origin='synced'` gate leaves a genuine local
+/// ghost of the same id untouched. Returns the removal count.
+///
+/// The tag / binding / call-path / edge children cascade via their `ON DELETE CASCADE` FK, but the
+/// contentless `repo_memory_fts` shadow has NO foreign key, so its rows must be deleted EXPLICITLY
+/// (in this same txn, before the parent rows go) or a revoked memory leaks permanent FTS index
+/// data.
+fn remove_vanished_synced_nodes(
+    tx: &Transaction<'_>,
+    repo_id: &str,
+    stream: StreamId,
+) -> anyhow::Result<u32> {
+    // The condemned set: this repo's synced rows absent from the current projection.
+    const CONDEMNED: &str = "SELECT id FROM repo_memories
+         WHERE repo_id = ?1 AND origin = 'synced'
+           AND id NOT IN (SELECT node_id FROM content_projected_nodes WHERE stream_id = ?2)";
+    // FTS first, while the parent rows still exist to name them (no FK to cascade this shadow).
+    tx.execute(&format!("DELETE FROM repo_memory_fts WHERE memory_id IN ({CONDEMNED})"), params![
+        repo_id,
+        stream.to_bytes().as_slice()
+    ])?;
+    let removed = tx.execute(
+        "DELETE FROM repo_memories
+         WHERE repo_id = ?1 AND origin = 'synced'
+           AND id NOT IN (SELECT node_id FROM content_projected_nodes WHERE stream_id = ?2)",
+        params![repo_id, stream.to_bytes().as_slice()],
+    )?;
+    Ok(removed as u32)
+}
+
+/// Drop an existing `origin='synced'` mirror of `node_id` under `repo_id` (FTS shadow first — it
+/// has no FK to cascade; the tag / binding / call-path / edge children cascade via their FK). Used
+/// when a projected UPDATE to an already-materialized synced row fails the local validity gates:
+/// the accepted value cannot be persisted, but the STALE prior value must not stay searchable
+/// either (it is no longer the projection, so [`remove_vanished_synced_nodes`] — which only fires
+/// when the node VANISHES from the projection — would never reach it). The `origin='synced'` +
+/// `repo_id` gate leaves a genuine local row of the same id untouched: a peer's invalid edit never
+/// destroys local content. Returns whether a row was removed.
+fn remove_quarantined_synced_node(
+    tx: &Transaction<'_>,
+    repo_id: &str,
+    node_id: &str,
+) -> anyhow::Result<bool> {
+    // FTS first, while the parent row still exists to name it (no FK cascades this shadow). The
+    // subquery applies the same `origin='synced'` + repo gate as the row delete, so a local row's
+    // FTS is never dropped.
+    tx.execute(
+        "DELETE FROM repo_memory_fts WHERE memory_id IN (
+             SELECT id FROM repo_memories WHERE id = ?1 AND repo_id = ?2 AND origin = 'synced')",
+        params![node_id, repo_id],
+    )?;
+    let removed = tx.execute(
+        "DELETE FROM repo_memories WHERE id = ?1 AND repo_id = ?2 AND origin = 'synced'",
+        params![node_id, repo_id],
+    )?;
+    Ok(removed > 0)
+}
+
+/// Whether a projected edge's DURABLE spec passes the SAME length caps the local `add_edge` write
+/// path enforces (`target_anchor` / `target_repo_id` ≤ `MAX_EDGE_ANCHOR_LEN`). Peer content crosses
+/// the wire only SHAPE-validated, so an older or compromised account device could author an
+/// over-cap value that clears the envelope but bypasses this local boundary; such an edge must not
+/// be persisted into `repo_node_edges`.
+fn projected_edge_spec_is_valid(edge: &ProjectedContentEdge) -> anyhow::Result<()> {
+    memory::validate_edge_len("target_anchor", &edge.spec.target_anchor)?;
+    memory::validate_edge_len("target_repo_id", &edge.spec.target_repo_id)?;
+    Ok(())
+}
+
+/// Drop an existing `origin='synced'` mirror of `edge_key` under `repo_id` (its children cascade
+/// via FK; an edge has no FTS shadow). Symmetric to [`remove_quarantined_synced_node`]: used when a
+/// projected edge fails the local length caps, so a now-invalid update never leaves a stale durable
+/// spec searchable. The `origin='synced'` + `repo_id` gate spares a genuine local edge of the same
+/// key. Returns whether a row was removed.
+fn remove_quarantined_synced_edge(
+    tx: &Transaction<'_>,
+    repo_id: &str,
+    edge_key: &str,
+) -> anyhow::Result<bool> {
+    let removed = tx.execute(
+        "DELETE FROM repo_node_edges WHERE edge_key = ?1 AND repo_id = ?2 AND origin = 'synced'",
+        params![edge_key, repo_id],
+    )?;
+    Ok(removed > 0)
+}
+
+/// One existing `repo_node_edges` row's DURABLE-spec columns — the only ones a converge compares or
+/// updates. The content-addressed key fields (`source_node_id` / `relation` / `target_kind` /
+/// `target_anchor`) are fixed by the `edge_key` and never change; the resolution triple
+/// (`target_node_id` / `anchor_status`) is per-device and is deliberately NOT read here.
+struct ExistingEdge {
+    repo_id: String,
+    target_repo_id: String,
+}
+
+fn read_existing_edge(conn: &Connection, edge_key: &str) -> anyhow::Result<Option<ExistingEdge>> {
+    conn.query_row(
+        "SELECT repo_id, target_repo_id FROM repo_node_edges WHERE edge_key = ?1",
+        [edge_key],
+        |row| Ok(ExistingEdge { repo_id: row.get(0)?, target_repo_id: row.get(1)? }),
+    )
+    .optional()
+    .map_err(Into::into)
+}
+
+enum EdgeEffect {
+    Written,
+    Removed,
+    Unchanged,
+}
+
+/// The `repo_node_edges` column values a projected edge maps to — the DURABLE spec only
+/// (`owner_repo_id → repo_id`, `target_repo_id`, and the content-addressed key fields). The
+/// resolution triple (`target_node_id` / `anchor_status`) is NEVER taken from the projection (see
+/// [`EdgeColumns::from_projection`]): it is stored `unresolved` on INSERT and left untouched on a
+/// converge, so the local read path owns resolution.
+struct EdgeColumns {
+    repo_id: String,
+    source_node_id: String,
+    relation: String,
+    target_repo_id: String,
+    target_kind: String,
+    target_anchor: String,
+    target_node_id: Option<String>,
+    anchor_status: String,
+}
+
+impl EdgeColumns {
+    fn from_projection(edge: &ProjectedContentEdge) -> Self {
+        // The DURABLE spec ONLY — the projected `resolved` anchor is deliberately ignored. A
+        // `ResolvedAnchor` is a PEER's per-device resolution (from a historical `Rebind`); splicing
+        // its `target_repo_id` / `target_node_id` / `anchor_status` into this device's edge would
+        // mint an inconsistent triple and overwrite local resolution with another device's view.
+        // Store the target UNRESOLVED and let `reresolve_on_read` recompute the whole triple here.
+        Self {
+            repo_id: edge.spec.owner_repo_id.clone(),
+            source_node_id: edge.spec.source_node_id.as_str().to_string(),
+            relation: edge.spec.relation.as_db_str().to_string(),
+            target_repo_id: edge.spec.target_repo_id.clone(),
+            target_kind: edge.spec.target_kind.clone(),
+            target_anchor: edge.spec.target_anchor.clone(),
+            target_node_id: None,
+            anchor_status: "unresolved".to_string(),
+        }
+    }
+
+    /// Whether the existing row's DURABLE spec already equals the projection — comparing ONLY the
+    /// owner + target repo (the key fields are identical by construction, the resolution triple is
+    /// per-device and never converged). Comparing the resolution triple here would make a resolved
+    /// local edge (`anchor_status='current'`) look "changed" against every projection (which
+    /// carries no anchor) and re-converge to `unresolved` on every pass — churn, and a lost
+    /// resolution.
+    fn matches_durable(&self, existing: &ExistingEdge) -> bool {
+        existing.repo_id == self.repo_id && existing.target_repo_id == self.target_repo_id
+    }
+}
+
+/// Apply one projected edge to `repo_node_edges`, scoped to OUR repo. The owner is self-declared in
+/// the (peer-signed) spec, so an edge in this repo's stream claiming a DIFFERENT `owner_repo_id` is
+/// a malformed / hostile injection attempt and is skipped — never written into, nor removed from, a
+/// sibling repo. A `present=0` tombstone REMOVES the edge (regardless of origin — a peer's remove
+/// is the account-wide winner), scoped to this repo. A present edge converges: INSERT
+/// `origin='synced'` if absent, else UPDATE the durable spec preserving origin and the per-device
+/// resolution triple.
+fn drain_edge(
+    tx: &Transaction<'_>,
+    repo_id: &str,
+    edge: &ProjectedContentEdge,
+    now_ms: i64,
+) -> anyhow::Result<EdgeEffect> {
+    // Repo boundary: only materialize/remove edges THIS repo owns. `owner_repo_id` is self-declared
+    // in the signed spec; a foreign claim in our stream must not cross into a sibling repo.
+    if edge.spec.owner_repo_id != repo_id {
+        return Ok(EdgeEffect::Unchanged);
+    }
+    if !edge.present {
+        // Tombstone: converge the removal for BOTH origins (a local edge a peer removed goes too),
+        // scoped to this repo so a stray key can't delete a sibling's edge. The synced-only removal
+        // is the retro-condemn anti-join, not this path.
+        let removed = tx.execute(
+            "DELETE FROM repo_node_edges WHERE edge_key = ?1 AND repo_id = ?2",
+            params![edge.edge_key, repo_id],
+        )?;
+        return Ok(if removed > 0 { EdgeEffect::Removed } else { EdgeEffect::Unchanged });
+    }
+    // Untrusted-boundary length caps: apply the SAME limits `add_edge` enforces so a peer cannot
+    // materialize an over-cap `target_anchor` / `target_repo_id`. An invalid edge is quarantined
+    // (skipped + warned, never wedging the drain); a prior synced mirror of this key is removed so
+    // a now-invalid update never leaves a stale durable spec behind.
+    if let Err(err) = projected_edge_spec_is_valid(edge) {
+        tracing::warn!(
+            repo_id,
+            edge_key = %edge.edge_key,
+            error = %err,
+            "quarantining an invalid synced edge: its durable spec violates a local length cap \
+             (target_anchor/target_repo_id); skipped, not persisted",
+        );
+        let removed = remove_quarantined_synced_edge(tx, repo_id, &edge.edge_key)?;
+        return Ok(if removed { EdgeEffect::Removed } else { EdgeEffect::Unchanged });
+    }
+    // Source guard: the source node must be a row THIS repo owns. The node and edge projection
+    // registers are INDEPENDENT, so a retro-condemn can vacate the source while an accepted edge
+    // still references it — its `source_node_id` FK would then abort the WHOLE drain (and every
+    // subsequent open). And node id is a global PK, so a forged edge could name a SIBLING repo's
+    // colliding id as its source; a bare existence check would attach a this-repo edge to that
+    // repo's node. Requiring `repo_id` ownership covers both; skip the edge otherwise.
+    if !node_in_repo(tx, edge.spec.source_node_id.as_str(), repo_id)? {
+        return Ok(EdgeEffect::Unchanged);
+    }
+    let columns = EdgeColumns::from_projection(edge);
+    match read_existing_edge(tx, &edge.edge_key)? {
+        // `edge_key` is a global PK. A row already owned by ANOTHER repo must never be stolen /
+        // rewritten into ours (symmetric to the node convergence guard). The source guard above
+        // normally makes this unreachable — `edge_key` encodes the source, whose repo is the edge's
+        // owner — but keep it explicit so a future invariant slip can't leak a converge across
+        // repos.
+        Some(existing) if existing.repo_id != repo_id => Ok(EdgeEffect::Unchanged),
+        Some(existing) if columns.matches_durable(&existing) => Ok(EdgeEffect::Unchanged),
+        Some(_) => {
+            // Converge the durable spec (owner + target repo); `origin` and the per-device
+            // resolution triple (`target_node_id` / `anchor_status`) are intentionally NOT in the
+            // SET, so a locally-resolved edge keeps its resolution and its origin.
+            tx.execute(
+                "UPDATE repo_node_edges
+                 SET repo_id = ?2, target_repo_id = ?3
+                 WHERE edge_key = ?1",
+                params![edge.edge_key, columns.repo_id, columns.target_repo_id],
+            )?;
+            Ok(EdgeEffect::Written)
+        },
+        None => {
+            // First sight of this edge — received from a peer. The resolution triple is stored
+            // `unresolved` (the projection carries none; the read path resolves it).
+            tx.execute(
+                "INSERT INTO repo_node_edges(
+                     edge_key, repo_id, source_node_id, relation, target_repo_id, target_kind,
+                     target_anchor, target_node_id, anchor_status, created_at_ms, origin)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, 'synced')",
+                params![
+                    edge.edge_key,
+                    columns.repo_id,
+                    columns.source_node_id,
+                    columns.relation,
+                    columns.target_repo_id,
+                    columns.target_kind,
+                    columns.target_anchor,
+                    columns.target_node_id,
+                    columns.anchor_status,
+                    now_ms,
+                ],
+            )?;
+            Ok(EdgeEffect::Written)
+        },
+    }
+}
+
+/// Remove every `origin='synced'` edge for this repo whose `edge_key` is absent from the projection
+/// ENTIRELY — a retro-condemn vacated it. A `present=0` tombstone is still IN the projection, so it
+/// is honored by `drain_edge`, not here. The origin gate leaves a local edge of the same key
+/// intact.
+fn remove_vanished_synced_edges(
+    tx: &Transaction<'_>,
+    repo_id: &str,
+    stream: StreamId,
+) -> anyhow::Result<u32> {
+    let removed = tx.execute(
+        "DELETE FROM repo_node_edges
+         WHERE repo_id = ?1 AND origin = 'synced'
+           AND edge_key NOT IN (SELECT edge_key FROM content_projected_edges WHERE stream_id = ?2)",
+        params![repo_id, stream.to_bytes().as_slice()],
+    )?;
+    Ok(removed as u32)
+}
+
+#[cfg(test)]
+mod tests {
+    use rag_rat_query::memory::{
+        self, RepoMemoryBindTarget, RepoMemoryCreate, edge_key, memory_by_id,
+    };
+    use rusqlite::Connection;
+
+    use super::*;
+
+    const REPO: &str = "repo-a";
+
+    /// A DB with the memory schema, one registered repo, and the connection scoped to it.
+    fn scoped_conn() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("PRAGMA foreign_keys = ON;").unwrap();
+        rag_rat_db::schema::apply(&conn, &crate::index::migration_hooks()).unwrap();
+        conn.execute(
+            "INSERT INTO repos(repo_id, display_name, registered_at_ms) VALUES (?1, ?1, 0)",
+            [REPO],
+        )
+        .unwrap();
+        conn.execute_batch(
+            "CREATE TEMP TABLE IF NOT EXISTS connection_context(key TEXT PRIMARY KEY, value TEXT);",
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT OR REPLACE INTO temp.connection_context(key, value) VALUES ('repo_id', ?1)",
+            [REPO],
+        )
+        .unwrap();
+        conn
+    }
+
+    /// Create an unanchored `Concept` through the LIVE create path (mints the account + owner
+    /// stream and projects the node) — the fixture the real-path tests build on.
+    fn create_concept(conn: &Connection, title: &str) -> String {
+        crate::memory_write::create_memory(conn, RepoMemoryCreate {
+            kind: "Concept".to_string(),
+            title: title.to_string(),
+            body: "body".to_string(),
+            confidence: "high".to_string(),
+            created_by: None,
+            source: None,
+            tags: Vec::new(),
+            payload_json: None,
+            bind: RepoMemoryBindTarget::default(),
+        })
+        .unwrap()
+        .memory
+        .memory_id
+    }
+
+    /// Seed one row into `content_projected_nodes` with the exact `NodeContentRow` JSON shape the
+    /// projector writes — the "a peer authored this and it folded accepted" fixture.
+    #[allow(clippy::too_many_arguments)]
+    fn seed_projected_node(
+        conn: &Connection,
+        stream: StreamId,
+        node_id: &str,
+        kind: &str,
+        title: &str,
+        body: &str,
+        status: &str,
+        tags: &[&str],
+    ) {
+        let content_json = serde_json::json!({
+            "kind": kind,
+            "title": title,
+            "body": body,
+            "confidence": "high",
+            "source": "agent",
+            "tags": tags,
+            "payload": null,
+        })
+        .to_string();
+        conn.execute(
+            "INSERT INTO content_projected_nodes(stream_id, node_id, content_json, status)
+             VALUES (?1, ?2, ?3, ?4)",
+            params![stream.to_bytes().as_slice(), node_id, content_json, status],
+        )
+        .unwrap();
+    }
+
+    /// Seed one row into `content_projected_edges`. `resolved` is `(target_repo, target_node,
+    /// anchor_status)` when the projection carries a resolved anchor.
+    #[allow(clippy::too_many_arguments)]
+    fn seed_projected_edge(
+        conn: &Connection,
+        stream: StreamId,
+        edge_key: &str,
+        source: &str,
+        relation: &str,
+        target_kind: &str,
+        target_anchor: &str,
+        present: bool,
+    ) {
+        let spec_json = serde_json::json!({
+            "source_node_id": source,
+            "relation": relation,
+            "target_repo_id": REPO,
+            "target_kind": target_kind,
+            "target_anchor": target_anchor,
+            "owner_repo_id": REPO,
+        })
+        .to_string();
+        conn.execute(
+            "INSERT INTO content_projected_edges(
+                 stream_id, edge_key, spec_json, resolved_json, present)
+             VALUES (?1, ?2, ?3, NULL, ?4)",
+            params![stream.to_bytes().as_slice(), edge_key, spec_json, present as i64],
+        )
+        .unwrap();
+    }
+
+    /// Insert a locally-authored `repo_memories` row directly (origin defaults to `local`).
+    fn insert_local_memory(conn: &Connection, id: &str, title: &str, body: &str, status: &str) {
+        insert_local_memory_in_repo(conn, id, title, body, status, REPO);
+    }
+
+    /// As [`insert_local_memory`] but stamped with an explicit `repo_id` — used to plant a SIBLING
+    /// repo's row for the cross-repo boundary tests.
+    fn insert_local_memory_in_repo(
+        conn: &Connection,
+        id: &str,
+        title: &str,
+        body: &str,
+        status: &str,
+        repo: &str,
+    ) {
+        conn.execute(
+            "INSERT INTO repo_memories(
+                 id, kind, title, body, confidence, status, created_by, created_at_ms,
+                 updated_at_ms, source, input_hash, memory_version, repo_id)
+             VALUES (?1, 'Invariant', ?2, ?3, 'high', ?4, 'agent', 100, 100, 'agent', 'h', 'v1',
+                 ?5)",
+            params![id, title, body, status, repo],
+        )
+        .unwrap();
+    }
+
+    /// Insert a locally-authored edge directly (origin defaults to `local`); returns its key.
+    fn insert_local_edge(conn: &Connection, source: &str, relation: &str, target: &str) -> String {
+        let key = edge_key(source, relation, "node", target);
+        conn.execute(
+            "INSERT INTO repo_node_edges(
+                 edge_key, repo_id, source_node_id, relation, target_repo_id, target_kind,
+                 target_anchor, target_node_id, anchor_status, created_at_ms)
+             VALUES (?1, ?2, ?3, ?4, ?2, 'node', ?5, ?5, 'current', 100)",
+            params![key, REPO, source, relation, target],
+        )
+        .unwrap();
+        key
+    }
+
+    /// Run the in-tx drain worker over `stream` and return its outcome.
+    fn drain_worker(conn: &Connection, stream: StreamId, now_ms: i64) -> DrainOutcome {
+        let tx = conn.unchecked_transaction().unwrap();
+        let outcome = drain_synced_stream_in_tx(&tx, REPO, stream, now_ms).unwrap();
+        tx.commit().unwrap();
+        outcome
+    }
+
+    fn origin_of(conn: &Connection, id: &str) -> String {
+        conn.query_row("SELECT origin FROM repo_memories WHERE id = ?1", [id], |r| r.get(0))
+            .unwrap()
+    }
+
+    fn status_of(conn: &Connection, id: &str) -> String {
+        conn.query_row("SELECT status FROM repo_memories WHERE id = ?1", [id], |r| r.get(0))
+            .unwrap()
+    }
+
+    fn updated_at_of(conn: &Connection, id: &str) -> i64 {
+        conn.query_row("SELECT updated_at_ms FROM repo_memories WHERE id = ?1", [id], |r| r.get(0))
+            .unwrap()
+    }
+
+    fn edge_exists(conn: &Connection, key: &str) -> bool {
+        conn.query_row(
+            "SELECT EXISTS(SELECT 1 FROM repo_node_edges WHERE edge_key = ?1)",
+            [key],
+            |r| r.get::<_, i64>(0),
+        )
+        .unwrap()
+            != 0
+    }
+
+    fn origin_of_edge(conn: &Connection, key: &str) -> String {
+        conn.query_row("SELECT origin FROM repo_node_edges WHERE edge_key = ?1", [key], |r| {
+            r.get(0)
+        })
+        .unwrap()
+    }
+
+    fn fts_row_exists(conn: &Connection, id: &str) -> bool {
+        conn.query_row(
+            "SELECT EXISTS(SELECT 1 FROM repo_memory_fts WHERE memory_id = ?1)",
+            [id],
+            |r| r.get::<_, i64>(0),
+        )
+        .unwrap()
+            != 0
+    }
+
+    fn content_entry_count(conn: &Connection) -> i64 {
+        conn.query_row("SELECT COUNT(*) FROM content_entries", [], |r| r.get(0)).unwrap()
+    }
+
+    // --- Task 1: repo attribution by forward derivation (repo-identity-skew pin) ---
+
+    /// The drain derives the owner stream FORWARD from `(repo_id, account_id)` and must land on the
+    /// EXACT stream the authoring path projected into — the guard against repo-identity skew. The
+    /// derivation is a pure function of the account + repo (no device/checkout input), so it is
+    /// stable across calls.
+    #[test]
+    fn the_drain_derives_the_same_owner_stream_authoring_projected_into() {
+        let conn = scoped_conn();
+        let id = create_concept(&conn, "seed");
+        let stream = rag_rat_oplog::owned_stream_v2_id(&conn, REPO).unwrap().unwrap();
+        let projected: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM content_projected_nodes WHERE stream_id = ?1 AND node_id = \
+                 ?2",
+                params![stream.to_bytes().as_slice(), id],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(projected, 1, "the authored node is projected under the forward-derived stream");
+        assert_eq!(
+            rag_rat_oplog::owned_stream_v2_id(&conn, REPO).unwrap().unwrap(),
+            stream,
+            "the derivation is stable (a pure function of account + repo)",
+        );
+    }
+
+    // --- Task 2: node drain, happy path ---
+
+    #[test]
+    fn a_projected_node_materializes_as_a_synced_memory_with_tags() {
+        let conn = scoped_conn();
+        let stream = StreamId::from_bytes([0x33; 32]);
+        seed_projected_node(&conn, stream, "mem_x", "Invariant", "title x", "body x", "active", &[
+            "beta", "alpha",
+        ]);
+
+        let outcome = drain_worker(&conn, stream, 1_000);
+        assert_eq!(outcome.nodes_written, 1);
+
+        let memory = memory_by_id(&conn, "mem_x").unwrap().expect("materialized as a real row");
+        assert_eq!(memory.title, "title x");
+        assert_eq!(memory.body, "body x");
+        assert_eq!(memory.tags, vec!["alpha".to_string(), "beta".to_string()], "tags fanned out");
+        assert_eq!(origin_of(&conn, "mem_x"), "synced", "the drain writes an origin='synced' row");
+        let repo: String = conn
+            .query_row("SELECT repo_id FROM repo_memories WHERE id = 'mem_x'", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(repo, REPO, "the synced row is stamped with the drained repo");
+    }
+
+    // --- Task 3: converge a projected local row; leave an UNPROJECTED local row untouched ---
+
+    /// A local row that ANOTHER device changed appears in the projection (the account-wide LWW
+    /// winner) with the new value: the drain CONVERGES the local row to it, preserving
+    /// `origin='local'` (it is NOT frozen). A local row with NO projection entry is a pending,
+    /// not-yet-reconciled edit and is left untouched.
+    #[test]
+    fn a_projected_local_row_converges_and_an_unprojected_local_row_is_untouched() {
+        let conn = scoped_conn();
+        // A local row the peer updated + obsoleted: the projection holds the winning value.
+        insert_local_memory(&conn, "mem_shared", "OLD title", "old body", "active");
+        memory::replace_tags(&conn, "mem_shared", &["oldtag".to_string()]).unwrap();
+        // A local row with NO projection entry: a pending local edit not yet reconciled.
+        insert_local_memory(&conn, "mem_pending", "pending title", "pending body", "active");
+        memory::replace_tags(&conn, "mem_pending", &["pendingtag".to_string()]).unwrap();
+
+        let stream = StreamId::from_bytes([0x33; 32]);
+        seed_projected_node(
+            &conn,
+            stream,
+            "mem_shared",
+            "Decision",
+            "NEW title",
+            "new body",
+            "obsolete",
+            &["newtag"],
+        );
+
+        let outcome = drain_worker(&conn, stream, 2_000);
+        assert_eq!(outcome.nodes_written, 1, "the projected local row converges");
+        assert_eq!(outcome.nodes_removed, 0, "the unprojected local row is not removed");
+
+        // Converged to the projection value, `origin` preserved as local.
+        let (kind, title, body, status, origin): (String, String, String, String, String) = conn
+            .query_row(
+                "SELECT kind, title, body, status, origin FROM repo_memories WHERE id = \
+                 'mem_shared'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?, r.get(4)?)),
+            )
+            .unwrap();
+        assert_eq!(
+            (kind.as_str(), title.as_str(), body.as_str(), status.as_str(), origin.as_str()),
+            ("Decision", "NEW title", "new body", "obsolete", "local"),
+            "a projected local row converges to the account-wide value, origin preserved",
+        );
+        assert_eq!(memory::tags_for_memory(&conn, "mem_shared").unwrap(), vec![
+            "newtag".to_string()
+        ]);
+
+        // The unprojected local row is byte-for-byte untouched.
+        let (title2, origin2): (String, String) = conn
+            .query_row(
+                "SELECT title, origin FROM repo_memories WHERE id = 'mem_pending'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(
+            (title2.as_str(), origin2.as_str()),
+            ("pending title", "local"),
+            "a local row absent from the projection is a pending edit, left untouched",
+        );
+        assert_eq!(memory::tags_for_memory(&conn, "mem_pending").unwrap(), vec![
+            "pendingtag".to_string()
+        ],);
+    }
+
+    /// A memory created on device A, then updated (content) and — separately — obsoleted (status)
+    /// by device B: A's drain converges its local row to B's value each time, and `origin`
+    /// stays `'local'` throughout (A remains the author; convergence is not an ownership
+    /// change).
+    #[test]
+    fn a_remote_update_then_obsolete_converges_the_local_row_preserving_origin() {
+        let conn = scoped_conn();
+        insert_local_memory(&conn, "mem_a", "v1 title", "v1 body", "active");
+        let stream = StreamId::from_bytes([0x44; 32]);
+
+        // Device B updated the content.
+        seed_projected_node(
+            &conn,
+            stream,
+            "mem_a",
+            "Invariant",
+            "v2 title",
+            "v2 body",
+            "active",
+            &[],
+        );
+        let out = drain_worker(&conn, stream, 1_000);
+        assert_eq!(out.nodes_written, 1);
+        assert_eq!(
+            memory_by_id(&conn, "mem_a").unwrap().unwrap().body,
+            "v2 body",
+            "A converges to B's content",
+        );
+        assert_eq!(origin_of(&conn, "mem_a"), "local", "convergence preserves A's authorship");
+
+        // Device B then obsoleted it.
+        conn.execute(
+            "UPDATE content_projected_nodes SET status = 'obsolete' WHERE node_id = 'mem_a'",
+            [],
+        )
+        .unwrap();
+        let out = drain_worker(&conn, stream, 2_000);
+        assert_eq!(out.nodes_written, 1);
+        assert_eq!(status_of(&conn, "mem_a"), "obsolete", "A converges to B's status");
+        assert_eq!(origin_of(&conn, "mem_a"), "local", "still A's row, still local");
+    }
+
+    // --- Task 4: status flip is an UPDATE, never a DELETE ---
+
+    #[test]
+    fn a_projected_obsolete_status_updates_the_synced_row_and_does_not_delete_it() {
+        let conn = scoped_conn();
+        let stream = StreamId::from_bytes([0x33; 32]);
+        seed_projected_node(&conn, stream, "mem_x", "Invariant", "t", "b", "active", &[]);
+        drain_worker(&conn, stream, 1_000);
+        assert_eq!(status_of(&conn, "mem_x"), "active");
+
+        conn.execute(
+            "UPDATE content_projected_nodes SET status = 'obsolete' WHERE node_id = 'mem_x'",
+            [],
+        )
+        .unwrap();
+        let outcome = drain_worker(&conn, stream, 2_000);
+        assert_eq!(outcome.nodes_written, 1, "the status change is a write");
+        assert_eq!(outcome.nodes_removed, 0, "an obsolete status flip is never a delete");
+        assert_eq!(status_of(&conn, "mem_x"), "obsolete");
+        assert!(memory_by_id(&conn, "mem_x").unwrap().is_some(), "the row still exists");
+    }
+
+    // --- Task 5: edge drain + FK order ---
+
+    #[test]
+    fn a_present_edge_upserts_a_synced_edge_and_a_tombstone_removes_it() {
+        let conn = scoped_conn();
+        let stream = StreamId::from_bytes([0x33; 32]);
+        seed_projected_node(&conn, stream, "mem_a", "Invariant", "a", "b", "active", &[]);
+        seed_projected_node(&conn, stream, "mem_b", "Invariant", "b", "b", "active", &[]);
+        let key = edge_key("mem_a", "relates_to", "node", "mem_b");
+        seed_projected_edge(&conn, stream, &key, "mem_a", "relates_to", "node", "mem_b", true);
+
+        let outcome = drain_worker(&conn, stream, 1_000);
+        assert_eq!(outcome.nodes_written, 2, "both source and target nodes materialize first");
+        assert_eq!(outcome.edges_written, 1);
+        let (origin, source): (String, String) = conn
+            .query_row(
+                "SELECT origin, source_node_id FROM repo_node_edges WHERE edge_key = ?1",
+                [&key],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!((origin.as_str(), source.as_str()), ("synced", "mem_a"));
+
+        conn.execute("UPDATE content_projected_edges SET present = 0 WHERE edge_key = ?1", [&key])
+            .unwrap();
+        let outcome = drain_worker(&conn, stream, 2_000);
+        assert_eq!(outcome.edges_removed, 1, "the tombstone removes the synced edge");
+        assert!(!edge_exists(&conn, &key));
+    }
+
+    /// A local edge that ANOTHER device removed appears in the projection as a `present=0`
+    /// tombstone; the drain must remove it here too — a peer's remove is the account-wide
+    /// winner, so the tombstone path is NOT origin-gated (the P1 convergence bug: freezing it
+    /// left the edge forever).
+    #[test]
+    fn a_tombstone_removes_a_local_edge_of_the_same_key() {
+        let conn = scoped_conn();
+        let stream = StreamId::from_bytes([0x33; 32]);
+        insert_local_memory(&conn, "mem_a", "a", "b", "active");
+        let key = insert_local_edge(&conn, "mem_a", "relates_to", "mem_b");
+        assert_eq!(origin_of_edge(&conn, &key), "local");
+        // The projection carries a present=0 tombstone for the SAME key.
+        seed_projected_edge(&conn, stream, &key, "mem_a", "relates_to", "node", "mem_b", false);
+
+        let outcome = drain_worker(&conn, stream, 1_000);
+        assert_eq!(outcome.edges_removed, 1, "a peer's remove converges regardless of origin");
+        assert!(!edge_exists(&conn, &key), "the local edge a peer removed is removed here too");
+    }
+
+    /// A local edge whose durable spec (`target_repo_id`) another device changed converges to the
+    /// projection value, preserving `origin='local'` AND the per-device resolution triple
+    /// (`target_node_id` / `anchor_status`) — the read path owns resolution, the drain must not
+    /// wipe it.
+    #[test]
+    fn a_remote_spec_change_converges_a_local_edge_preserving_origin_and_resolution() {
+        let conn = scoped_conn();
+        let stream = StreamId::from_bytes([0x33; 32]);
+        insert_local_memory(&conn, "mem_a", "a", "b", "active");
+        // A local, resolved edge whose stored target repo is stale (add-time snapshot).
+        let key = edge_key("mem_a", "relates_to", "node", "mem_b");
+        conn.execute(
+            "INSERT INTO repo_node_edges(
+                 edge_key, repo_id, source_node_id, relation, target_repo_id, target_kind,
+                 target_anchor, target_node_id, anchor_status, created_at_ms)
+             VALUES (?1, ?2, 'mem_a', 'relates_to', 'stale-target-repo', 'node', 'mem_b', 'mem_b',
+                 'current', 100)",
+            params![key, REPO],
+        )
+        .unwrap();
+        // The projection carries the peer's current target repo for the same key.
+        conn.execute(
+            "INSERT INTO content_projected_edges(stream_id, edge_key, spec_json, resolved_json, \
+             present)
+             VALUES (?1, ?2, ?3, NULL, 1)",
+            params![
+                stream.to_bytes().as_slice(),
+                key,
+                serde_json::json!({
+                    "source_node_id": "mem_a",
+                    "relation": "relates_to",
+                    "target_repo_id": "current-target-repo",
+                    "target_kind": "node",
+                    "target_anchor": "mem_b",
+                    "owner_repo_id": REPO,
+                })
+                .to_string(),
+            ],
+        )
+        .unwrap();
+
+        let outcome = drain_worker(&conn, stream, 1_000);
+        assert_eq!(outcome.edges_written, 1, "the durable spec converges");
+        let (repo_id, target_repo, target_node, anchor, origin): (
+            String,
+            String,
+            Option<String>,
+            String,
+            String,
+        ) = conn
+            .query_row(
+                "SELECT repo_id, target_repo_id, target_node_id, anchor_status, origin
+                 FROM repo_node_edges WHERE edge_key = ?1",
+                [&key],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?, r.get(4)?)),
+            )
+            .unwrap();
+        assert_eq!(
+            target_repo, "current-target-repo",
+            "target_repo_id converges to the peer value"
+        );
+        assert_eq!(repo_id, REPO, "owner repo unchanged");
+        assert_eq!(origin, "local", "convergence preserves the local origin");
+        assert_eq!(
+            (target_node.as_deref(), anchor.as_str()),
+            (Some("mem_b"), "current"),
+            "the per-device resolution triple is preserved, not wiped to unresolved",
+        );
+
+        // Idempotent: a re-drain now matches the durable spec and writes nothing.
+        let again = drain_worker(&conn, stream, 2_000);
+        assert_eq!(again, DrainOutcome::default(), "converged edge is a no-op on re-drain");
+    }
+
+    // --- Task 6: retro-condemn removal ---
+
+    #[test]
+    fn a_condemned_synced_node_is_removed_on_re_drain_and_a_local_row_survives() {
+        let conn = scoped_conn();
+        let stream = StreamId::from_bytes([0x33; 32]);
+        seed_projected_node(&conn, stream, "mem_synced", "Invariant", "s", "b", "active", &[]);
+        drain_worker(&conn, stream, 1_000);
+        assert!(memory_by_id(&conn, "mem_synced").unwrap().is_some());
+
+        // A local row absent from the projection is a genuine local ghost, NOT a condemned synced
+        // row — the origin gate must spare it.
+        insert_local_memory(&conn, "mem_local", "l", "b", "active");
+        // Retro-condemn: the synced node's projection row vanishes entirely.
+        conn.execute("DELETE FROM content_projected_nodes WHERE node_id = 'mem_synced'", [])
+            .unwrap();
+
+        assert!(fts_row_exists(&conn, "mem_synced"), "the materialized synced row has an FTS row");
+
+        let outcome = drain_worker(&conn, stream, 2_000);
+        assert_eq!(outcome.nodes_removed, 1);
+        assert!(
+            memory_by_id(&conn, "mem_synced").unwrap().is_none(),
+            "the condemned synced row is removed",
+        );
+        assert!(
+            !fts_row_exists(&conn, "mem_synced"),
+            "the contentless FTS shadow (no FK) is cleaned up in the same txn, not orphaned",
+        );
+        assert!(
+            memory_by_id(&conn, "mem_local").unwrap().is_some(),
+            "a local row of an absent id survives the origin gate",
+        );
+    }
+
+    /// A projected edge carrying a PEER's `Rebind` resolution must NOT import it: the durable
+    /// target repo comes from the signed spec, and the per-device resolution triple is stored
+    /// `unresolved` for the local read path to recompute (not spliced from another device's
+    /// view).
+    #[test]
+    fn a_projected_rebind_anchor_is_ignored_when_materializing_an_edge() {
+        let conn = scoped_conn();
+        let stream = StreamId::from_bytes([0x33; 32]);
+        seed_projected_node(&conn, stream, "mem_a", "Invariant", "a", "b", "active", &[]);
+        seed_projected_node(&conn, stream, "mem_b", "Invariant", "b", "b", "active", &[]);
+        let key = edge_key("mem_a", "relates_to", "node", "mem_b");
+        conn.execute(
+            "INSERT INTO content_projected_edges(stream_id, edge_key, spec_json, resolved_json, \
+             present)
+             VALUES (?1, ?2, ?3, ?4, 1)",
+            params![
+                stream.to_bytes().as_slice(),
+                key,
+                serde_json::json!({
+                    "source_node_id": "mem_a",
+                    "relation": "relates_to",
+                    "target_repo_id": "spec-repo",
+                    "target_kind": "node",
+                    "target_anchor": "mem_b",
+                    "owner_repo_id": REPO,
+                })
+                .to_string(),
+                serde_json::json!({
+                    "target_repo_id": "peer-resolved-repo",
+                    "target_node_id": "peer-node",
+                    "anchor_status": "gone",
+                })
+                .to_string(),
+            ],
+        )
+        .unwrap();
+
+        drain_worker(&conn, stream, 1_000);
+        let (target_repo, target_node, anchor): (String, Option<String>, String) = conn
+            .query_row(
+                "SELECT target_repo_id, target_node_id, anchor_status FROM repo_node_edges
+                 WHERE edge_key = ?1",
+                [&key],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(
+            target_repo, "spec-repo",
+            "the durable signed target repo is materialized, not the peer's Rebind resolution",
+        );
+        assert_eq!(
+            (target_node.as_deref(), anchor.as_str()),
+            (None, "unresolved"),
+            "the peer's per-device resolution triple is not imported",
+        );
+    }
+
+    #[test]
+    fn a_condemned_synced_edge_is_removed_on_re_drain() {
+        let conn = scoped_conn();
+        let stream = StreamId::from_bytes([0x33; 32]);
+        seed_projected_node(&conn, stream, "mem_a", "Invariant", "a", "b", "active", &[]);
+        seed_projected_node(&conn, stream, "mem_b", "Invariant", "b", "b", "active", &[]);
+        let key = edge_key("mem_a", "relates_to", "node", "mem_b");
+        seed_projected_edge(&conn, stream, &key, "mem_a", "relates_to", "node", "mem_b", true);
+        drain_worker(&conn, stream, 1_000);
+        assert!(edge_exists(&conn, &key));
+
+        // The whole edge row (not a present=0 tombstone) vanishes from the projection.
+        conn.execute("DELETE FROM content_projected_edges WHERE edge_key = ?1", [&key]).unwrap();
+        let outcome = drain_worker(&conn, stream, 2_000);
+        assert_eq!(outcome.edges_removed, 1, "a vanished synced edge is removed on re-drain");
+        assert!(!edge_exists(&conn, &key));
+    }
+
+    // --- Hardening: robustness + cross-repo boundary against malformed peer content ---
+
+    /// The node and edge projection registers are independent, so an accepted edge can legitimately
+    /// reference a source node that was retro-condemned away. Its FK would abort the whole drain
+    /// (and every open) — the drain must SKIP it and still materialize the rest.
+    #[test]
+    fn a_projected_edge_with_a_missing_source_node_is_skipped_not_fatal() {
+        let conn = scoped_conn();
+        let stream = StreamId::from_bytes([0x33; 32]);
+        // A valid node + edge, plus a dangling edge whose source node is not in the projection.
+        seed_projected_node(&conn, stream, "mem_a", "Invariant", "a", "b", "active", &[]);
+        seed_projected_node(&conn, stream, "mem_b", "Invariant", "b", "b", "active", &[]);
+        let good = edge_key("mem_a", "relates_to", "node", "mem_b");
+        seed_projected_edge(&conn, stream, &good, "mem_a", "relates_to", "node", "mem_b", true);
+        let dangling = edge_key("ghost", "relates_to", "node", "mem_b");
+        seed_projected_edge(&conn, stream, &dangling, "ghost", "relates_to", "node", "mem_b", true);
+
+        // The drain succeeds (no FK abort), materializes the good edge, and skips the dangling one.
+        let outcome = drain_worker(&conn, stream, 1_000);
+        assert_eq!(outcome.nodes_written, 2);
+        assert_eq!(outcome.edges_written, 1, "only the edge with a materialized source is written");
+        assert!(edge_exists(&conn, &good));
+        assert!(!edge_exists(&conn, &dangling), "the dangling edge is skipped, not fatal");
+    }
+
+    /// Node id is a global PK. A peer stream naming an id another repo already owns must NOT
+    /// overwrite that sibling's row.
+    #[test]
+    fn a_projected_node_owned_by_a_sibling_repo_is_not_overwritten() {
+        let conn = scoped_conn();
+        let stream = StreamId::from_bytes([0x33; 32]);
+        // A sibling repo already owns `mem_shared`.
+        insert_local_memory_in_repo(
+            &conn,
+            "mem_shared",
+            "SIBLING title",
+            "sibling body",
+            "active",
+            "repo-b",
+        );
+        // Our stream projects a node with the same id, different content.
+        seed_projected_node(
+            &conn,
+            stream,
+            "mem_shared",
+            "Decision",
+            "HOSTILE title",
+            "hostile body",
+            "obsolete",
+            &[],
+        );
+
+        let outcome = drain_worker(&conn, stream, 1_000);
+        assert_eq!(outcome.nodes_written, 0, "a sibling repo's row is never converged");
+        let (title, repo_id): (String, String) = conn
+            .query_row(
+                "SELECT title, repo_id FROM repo_memories WHERE id = 'mem_shared'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(
+            (title.as_str(), repo_id.as_str()),
+            ("SIBLING title", "repo-b"),
+            "the sibling row is byte-for-byte unchanged",
+        );
+    }
+
+    /// An edge's `owner_repo_id` is self-declared in the peer-signed spec. An edge in OUR stream
+    /// claiming a foreign owner must not be injected into that sibling repo.
+    #[test]
+    fn a_projected_edge_claiming_a_foreign_owner_repo_is_not_injected() {
+        let conn = scoped_conn();
+        let stream = StreamId::from_bytes([0x33; 32]);
+        seed_projected_node(&conn, stream, "mem_a", "Invariant", "a", "b", "active", &[]);
+        let key = edge_key("mem_a", "relates_to", "node", "mem_b");
+        // A hostile edge in our stream claiming owner_repo_id = a sibling repo.
+        conn.execute(
+            "INSERT INTO content_projected_edges(stream_id, edge_key, spec_json, resolved_json, \
+             present)
+             VALUES (?1, ?2, ?3, NULL, 1)",
+            params![
+                stream.to_bytes().as_slice(),
+                key,
+                serde_json::json!({
+                    "source_node_id": "mem_a",
+                    "relation": "relates_to",
+                    "target_repo_id": "repo-b",
+                    "target_kind": "node",
+                    "target_anchor": "mem_b",
+                    "owner_repo_id": "repo-b",
+                })
+                .to_string(),
+            ],
+        )
+        .unwrap();
+
+        let outcome = drain_worker(&conn, stream, 1_000);
+        assert_eq!(outcome.edges_written, 0, "an edge claiming a foreign owner is not written");
+        assert!(!edge_exists(&conn, &key), "nothing is injected into the sibling repo");
+    }
+
+    /// Even with a truthful `owner_repo_id = repo_id`, an edge whose SOURCE node id collides with a
+    /// sibling repo's node must not materialize — it would attach a this-repo edge to the sibling's
+    /// node (node id is a global PK). The source guard requires the source to belong to this repo.
+    #[test]
+    fn a_projected_edge_whose_source_belongs_to_a_sibling_repo_is_skipped() {
+        let conn = scoped_conn();
+        let stream = StreamId::from_bytes([0x33; 32]);
+        // A node id owned by a SIBLING repo (not ours).
+        insert_local_memory_in_repo(&conn, "mem_sibling", "sib", "b", "active", "repo-b");
+        // Our stream projects an edge (owner = us) whose source is that sibling id.
+        let key = edge_key("mem_sibling", "relates_to", "node", "mem_b");
+        seed_projected_edge(
+            &conn,
+            stream,
+            &key,
+            "mem_sibling",
+            "relates_to",
+            "node",
+            "mem_b",
+            true,
+        );
+
+        let outcome = drain_worker(&conn, stream, 1_000);
+        assert_eq!(
+            outcome.edges_written, 0,
+            "an edge whose source is a sibling repo's node is not materialized",
+        );
+        assert!(!edge_exists(&conn, &key));
+    }
+
+    /// The store-global drain runs at open BEFORE the connection scope is installed, so on a
+    /// multi-repo store the active-repo scope is unresolvable. The synced row's FTS shadow must
+    /// still carry `repo_id` (copied from the row the drain stamped) — otherwise
+    /// `memory_search`'s repo filter never matches it and the primary "searchable now" behavior
+    /// fails until some later scoped write repairs it.
+    #[test]
+    fn a_drained_synced_node_is_repo_stamped_in_fts_even_when_scope_is_unresolvable() {
+        let conn = scoped_conn();
+        // Reproduce the open-time, multi-repo condition: a second registered repo (so
+        // `sole_repo_id` can't pick one) and no `connection_context` scope.
+        conn.execute(
+            "INSERT INTO repos(repo_id, display_name, registered_at_ms) VALUES \
+             ('repo-b','repo-b',0)",
+            [],
+        )
+        .unwrap();
+        conn.execute("DELETE FROM temp.connection_context WHERE key = 'repo_id'", []).unwrap();
+        let stream = StreamId::from_bytes([0x33; 32]);
+        seed_projected_node(&conn, stream, "mem_x", "Invariant", "findable", "b", "active", &[]);
+
+        drain_worker(&conn, stream, 1_000);
+
+        let fts_repo: Option<String> = conn
+            .query_row("SELECT repo_id FROM repo_memory_fts WHERE memory_id = 'mem_x'", [], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        assert_eq!(
+            fts_repo.as_deref(),
+            Some(REPO),
+            "the drained row's FTS carries repo_id even when the connection scope is unresolvable",
+        );
+    }
+
+    /// Peer content is only wire-shape-validated, so an older / compromised device could project a
+    /// node that violates a local content rule (here: an unknown `kind`). It must be QUARANTINED
+    /// (skipped, not persisted) without wedging the drain — the valid siblings still materialize.
+    #[test]
+    fn an_invalid_synced_node_is_quarantined_and_does_not_wedge_the_drain() {
+        let conn = scoped_conn();
+        let stream = StreamId::from_bytes([0x33; 32]);
+        seed_projected_node(&conn, stream, "mem_ok", "Invariant", "ok", "b", "active", &[]);
+        // An unknown kind — rejected by `validate_kind`, which the create path enforces.
+        seed_projected_node(&conn, stream, "mem_bad", "NotAValidKind", "bad", "b", "active", &[]);
+        // An oversized body — beyond `MAX_MEMORY_BODY_LEN`, which the create path caps.
+        seed_projected_node(
+            &conn,
+            stream,
+            "mem_big",
+            "Invariant",
+            "big",
+            &"x".repeat(1_000_000),
+            "active",
+            &[],
+        );
+
+        let outcome = drain_worker(&conn, stream, 1_000);
+        assert_eq!(outcome.nodes_written, 1, "only the valid node is materialized");
+        assert!(memory_by_id(&conn, "mem_ok").unwrap().is_some());
+        assert!(
+            memory_by_id(&conn, "mem_bad").unwrap().is_none(),
+            "the unknown-kind node is quarantined, not persisted",
+        );
+        assert!(
+            memory_by_id(&conn, "mem_big").unwrap().is_none(),
+            "the oversized-body node is quarantined, not persisted",
+        );
+    }
+
+    /// A peer edits an already-materialized synced memory to content that fails LOCAL validation.
+    /// The accepted value cannot be persisted, but the STALE prior synced row (still in the
+    /// projection, so retro-condemn never reaches it) must be removed — not left searchable
+    /// forever.
+    #[test]
+    fn a_projected_update_to_invalid_content_removes_the_stale_synced_row() {
+        let conn = scoped_conn();
+        let stream = StreamId::from_bytes([0x33; 32]);
+        // First drain: the node is valid and materializes as a searchable synced row.
+        seed_projected_node(&conn, stream, "mem_x", "Invariant", "ok", "b", "active", &[]);
+        drain_worker(&conn, stream, 1_000);
+        assert!(memory_by_id(&conn, "mem_x").unwrap().is_some());
+        assert!(fts_row_exists(&conn, "mem_x"), "the materialized synced row has an FTS row");
+
+        // A peer's accepted edit changes the projected content to an unknown kind (invalid
+        // locally).
+        conn.execute(
+            "UPDATE content_projected_nodes
+             SET content_json = json_set(content_json, '$.kind', 'NotAValidKind')
+             WHERE node_id = 'mem_x'",
+            [],
+        )
+        .unwrap();
+
+        let outcome = drain_worker(&conn, stream, 2_000);
+        assert_eq!(
+            outcome.nodes_removed, 1,
+            "the stale synced mirror is removed, counted as removed"
+        );
+        assert_eq!(outcome.nodes_written, 0, "the invalid value is never persisted");
+        assert!(
+            memory_by_id(&conn, "mem_x").unwrap().is_none(),
+            "the stale prior synced row is not left searchable under an invalidated projection",
+        );
+        assert!(
+            !fts_row_exists(&conn, "mem_x"),
+            "the contentless FTS shadow is cleaned up in the same txn, not orphaned",
+        );
+
+        // Idempotent: a re-drain still sees the invalid projection but has nothing left to remove.
+        let again = drain_worker(&conn, stream, 3_000);
+        assert_eq!(again, DrainOutcome::default(), "no row to remove twice — a no-op re-drain");
+    }
+
+    /// The quarantine-removal is gated to `origin='synced'`: a peer's invalid edit must never
+    /// destroy a genuine local row of the same id (the user's own authored content).
+    #[test]
+    fn a_projected_update_to_invalid_content_spares_a_local_row() {
+        let conn = scoped_conn();
+        let stream = StreamId::from_bytes([0x33; 32]);
+        // A locally-authored row (origin='local'), and a projection that would converge it but is
+        // invalid.
+        insert_local_memory(&conn, "mem_local", "mine", "b", "active");
+        seed_projected_node(&conn, stream, "mem_local", "NotAValidKind", "peer", "b", "active", &[
+        ]);
+
+        let outcome = drain_worker(&conn, stream, 1_000);
+        assert_eq!(
+            outcome.nodes_removed, 0,
+            "a local row is never removed by an invalid peer edit"
+        );
+        assert!(
+            memory_by_id(&conn, "mem_local").unwrap().is_some(),
+            "the user's local content survives an invalid projected edit",
+        );
+    }
+
+    /// A projected node whose tag exceeds the local 64-byte cap must be quarantined here, not left
+    /// to error inside `write_node_children`/`replace_tags` and roll back (and wedge) the whole
+    /// drain.
+    #[test]
+    fn an_oversized_tag_on_a_synced_node_is_quarantined_not_fatal() {
+        let conn = scoped_conn();
+        let stream = StreamId::from_bytes([0x33; 32]);
+        seed_projected_node(&conn, stream, "mem_ok", "Invariant", "ok", "b", "active", &["fine"]);
+        let big_tag = "x".repeat(65);
+        seed_projected_node(&conn, stream, "mem_tag", "Invariant", "t", "b", "active", &[&big_tag]);
+
+        let outcome = drain_worker(&conn, stream, 1_000);
+        assert_eq!(outcome.nodes_written, 1, "only the valid node materializes");
+        assert!(memory_by_id(&conn, "mem_ok").unwrap().is_some());
+        assert!(
+            memory_by_id(&conn, "mem_tag").unwrap().is_none(),
+            "an oversized tag quarantines the node rather than wedging the whole drain",
+        );
+    }
+
+    /// A projected edge whose `target_anchor` exceeds `MAX_EDGE_ANCHOR_LEN` must be quarantined at
+    /// the untrusted boundary — the same cap the local `add_edge` write path enforces.
+    #[test]
+    fn an_oversized_edge_anchor_on_a_synced_edge_is_quarantined_not_persisted() {
+        let conn = scoped_conn();
+        let stream = StreamId::from_bytes([0x33; 32]);
+        seed_projected_node(&conn, stream, "mem_a", "Invariant", "a", "b", "active", &[]);
+        let big_anchor = "x".repeat(memory::MAX_EDGE_ANCHOR_LEN + 1);
+        let key = edge_key("mem_a", "relates_to", "node", &big_anchor);
+        seed_projected_edge(&conn, stream, &key, "mem_a", "relates_to", "node", &big_anchor, true);
+
+        let outcome = drain_worker(&conn, stream, 1_000);
+        assert_eq!(outcome.edges_written, 0, "the over-cap edge is not persisted");
+        assert!(
+            !edge_exists(&conn, &key),
+            "an oversized edge anchor is quarantined at the boundary"
+        );
+    }
+
+    /// An existing edge row owned by a SIBLING repo (a global-PK `edge_key` collision) must not be
+    /// stolen or rewritten into this repo by a converge — symmetric to the node guard.
+    #[test]
+    fn a_converge_never_steals_a_sibling_repos_edge_row() {
+        let conn = scoped_conn();
+        let stream = StreamId::from_bytes([0x33; 32]);
+        insert_local_memory(&conn, "mem_a", "a", "b", "active");
+        let key = edge_key("mem_a", "relates_to", "node", "mem_b");
+        // An existing edge row on this key owned by a sibling repo (the collision codex describes).
+        conn.execute(
+            "INSERT INTO repo_node_edges(
+                 edge_key, repo_id, source_node_id, relation, target_repo_id, target_kind,
+                 target_anchor, target_node_id, anchor_status, created_at_ms)
+             VALUES (?1, 'repo-b', 'mem_a', 'relates_to', 'repo-b', 'node', 'mem_b', 'mem_b',
+                 'current', 100)",
+            [&key],
+        )
+        .unwrap();
+        // Our stream projects the same key (owner = us, different target repo).
+        seed_projected_edge(&conn, stream, &key, "mem_a", "relates_to", "node", "mem_b", true);
+
+        let outcome = drain_worker(&conn, stream, 1_000);
+        assert_eq!(outcome.edges_written, 0, "the sibling's edge is not converged");
+        let (repo_id, target_repo): (String, String) = conn
+            .query_row(
+                "SELECT repo_id, target_repo_id FROM repo_node_edges WHERE edge_key = ?1",
+                [&key],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(
+            (repo_id.as_str(), target_repo.as_str()),
+            ("repo-b", "repo-b"),
+            "the sibling repo's edge is left byte-for-byte unchanged, not stolen",
+        );
+    }
+
+    // --- Task 7: idempotence ---
+
+    #[test]
+    fn re_running_the_drain_over_an_unchanged_projection_is_a_no_op() {
+        let conn = scoped_conn();
+        let stream = StreamId::from_bytes([0x33; 32]);
+        seed_projected_node(&conn, stream, "mem_x", "Invariant", "t", "b", "active", &["a", "b"]);
+        seed_projected_node(&conn, stream, "mem_y", "Invariant", "y", "b", "active", &[]);
+        let key = edge_key("mem_x", "relates_to", "node", "mem_y");
+        seed_projected_edge(&conn, stream, &key, "mem_x", "relates_to", "node", "mem_y", true);
+
+        let first = drain_worker(&conn, stream, 1_000);
+        assert_eq!(first.nodes_written, 2);
+        assert_eq!(first.edges_written, 1);
+        let updated_before = updated_at_of(&conn, "mem_x");
+
+        let second = drain_worker(&conn, stream, 9_999);
+        assert_eq!(
+            second,
+            DrainOutcome::default(),
+            "a re-drain over an unchanged projection writes and removes nothing",
+        );
+        assert_eq!(
+            updated_at_of(&conn, "mem_x"),
+            updated_before,
+            "updated_at_ms is not bumped on a no-op re-drain",
+        );
+    }
+
+    // --- Task 8: no echo — the round-trip is proven end-to-end ---
+
+    /// A drained `origin='synced'` row must NOT be re-authored back into the signed `/3` log by the
+    /// next reconcile — the authoring-side `origin='local'` gate plus the projection anti-join make
+    /// the round-trip non-echoing. Exercised on the REAL path (real owner stream + public entry).
+    #[test]
+    fn a_drained_synced_row_is_not_re_authored_by_the_next_reconcile() {
+        let conn = scoped_conn();
+        create_concept(&conn, "seed"); // mints the account + establishes the owner stream
+        let stream = rag_rat_oplog::owned_stream_v2_id(&conn, REPO).unwrap().unwrap();
+        // A peer's node: present in the accepted-/3 projection, not yet materialized locally.
+        seed_projected_node(&conn, stream, "mem_peer", "Invariant", "peer", "body", "active", &[]);
+        let entries_before = content_entry_count(&conn);
+
+        let outcome = drain_synced_stream_for_repo(&conn, REPO, 5_000).unwrap();
+        assert_eq!(outcome.nodes_written, 1, "the peer node materializes");
+        assert_eq!(origin_of(&conn, "mem_peer"), "synced");
+        assert!(
+            memory_by_id(&conn, "mem_peer").unwrap().is_some(),
+            "searchable as a local row now"
+        );
+
+        // The reconcile runs: the synced row is excluded from re-authoring (origin gate), and it is
+        // also already in the projection, so nothing is appended to the immutable /3 log.
+        crate::memory_write::backfill_memory_oplog(&conn, 6_000).unwrap();
+        assert_eq!(
+            content_entry_count(&conn),
+            entries_before,
+            "a synced row is never re-authored into the signed /3 log",
+        );
+        assert_eq!(origin_of(&conn, "mem_peer"), "synced", "and it is never flipped to local");
+    }
+
+    // --- Task 9: the store-global drain the open/migrate seam calls ---
+
+    /// The store-global entry (wired into the open/migrate seam) iterates every registered real
+    /// repo and materializes its synced content, while leaving locally-authored rows untouched
+    /// — proving the exact call the lifecycle open makes.
+    #[test]
+    fn the_store_global_drain_materializes_synced_content_and_spares_local_rows() {
+        let conn = scoped_conn();
+        // A real local memory mints the account + owner stream and projects itself origin='local'.
+        let local_id = create_concept(&conn, "local seed");
+        let stream = rag_rat_oplog::owned_stream_v2_id(&conn, REPO).unwrap().unwrap();
+        // A peer's node in the projection, not yet materialized locally.
+        seed_projected_node(&conn, stream, "mem_peer", "Invariant", "peer", "body", "active", &[]);
+
+        let outcome = drain_synced_streams_for_all_repos(&conn, 7_000).unwrap();
+        assert_eq!(outcome.nodes_written, 1, "the peer node materializes for the registered repo");
+        assert_eq!(origin_of(&conn, "mem_peer"), "synced");
+        assert!(memory_by_id(&conn, "mem_peer").unwrap().is_some(), "readable as a local row");
+        assert_eq!(origin_of(&conn, &local_id), "local", "the local row is left untouched");
+    }
+
+    /// The public entry no-ops on an unstable repo id (legacy / local-only) — such an id can never
+    /// root an owner stream, so there is nothing to drain and it must not touch the tables.
+    #[test]
+    fn the_public_entry_no_ops_on_an_unstable_repo_id() {
+        let conn = scoped_conn();
+        let legacy = rag_rat_base::repo_identity::LEGACY_REPO_ID;
+        assert_eq!(
+            drain_synced_stream_for_repo(&conn, legacy, 1_000).unwrap(),
+            DrainOutcome::default(),
+        );
+        let local = format!("{}deadbeef", rag_rat_base::repo_identity::LOCAL_ONLY_ID_PREFIX);
+        assert_eq!(
+            drain_synced_stream_for_repo(&conn, &local, 1_000).unwrap(),
+            DrainOutcome::default(),
+        );
+    }
+}

--- a/crates/rag-rat-core/src/memory_write/mod.rs
+++ b/crates/rag-rat-core/src/memory_write/mod.rs
@@ -9,6 +9,9 @@ mod api;
 // The op-log authoring seam: row→op translation, the one-time full backfill, and the live
 // `author_*` helpers the memory mutations call in-transaction (#532).
 mod authoring;
+// The REVERSE of the authoring reconcile (#691 A1): mirror a stream's accepted synced `/3` content
+// back into `repo_memories` / `repo_node_edges` as `origin='synced'` rows.
+mod drain;
 mod edges;
 #[cfg(test)]
 mod oracle_relocation_tests;
@@ -23,6 +26,10 @@ pub(crate) use authoring::backfill_memory_oplog;
 // `index::consolidate` names this through this re-export (Task 5 of #541).
 pub(crate) use authoring::reconcile_owner_stream_for_repo;
 pub(crate) use authoring::{catch_up_enrolled_device_keys, enable_sealed_authoring};
+// The synced-content drain entries (#691 A1): the per-repo drain (consolidate) and the
+// store-global drain (open/migrate) that materialize accepted synced `/3` content into the
+// local memory tables.
+pub(crate) use drain::{drain_synced_stream_for_repo, drain_synced_streams_for_all_repos};
 pub(crate) use edges::{add_edge, remove_edge};
 
 // The `rag-rat rm` removal-tombstone guard (#767 review) the memory mutations call inside

--- a/crates/rag-rat-core/src/watch/pass.rs
+++ b/crates/rag-rat-core/src/watch/pass.rs
@@ -469,6 +469,12 @@ fn run_pass(
         }
     }
     let _ = timings.stage("memory_validate", || db.memory_validate());
+    // Materialize any accepted synced `/3` content pulled since the last pass into the local memory
+    // tables (#691 A1) — the reverse of the reconcile. Best-effort like `memory_validate` above (a
+    // failure rides the next pass); a store with no synced content or no minted account is a cheap
+    // no-op. This is the long-running-process backstop so a pull after open surfaces without a
+    // reopen; open + consolidate drain at their own seams.
+    let _ = timings.stage("memory_drain", || db.drain_synced_memory());
     if shutdown_reconcile_pending && base_reconcile_status.as_deref() == Some("Current") {
         db.clear_watch_shutdown_reconcile_pending()?;
     }

--- a/crates/rag-rat-db/src/schema/mod.rs
+++ b/crates/rag-rat-db/src/schema/mod.rs
@@ -38,8 +38,8 @@ pub use registry::{
     RegisteredRepo, active_generation, active_repo_id, clear_repo_removed,
     connection_context_value, earliest_recorded_root, is_repo_removed,
     is_root_already_indexed_conn, live_files_generation, mark_repo_removed, periphery_repo_scope,
-    periphery_repo_scope_clause, register_repo, register_repo_read_only, registered_repos,
-    repo_has_recorded_root, repo_id_is_registered, repo_indexed_at_this_root,
+    periphery_repo_scope_clause, real_repo_ids, register_repo, register_repo_read_only,
+    registered_repos, repo_has_recorded_root, repo_id_is_registered, repo_indexed_at_this_root,
     repo_removal_generation, resolve_config_repo_id, scope_context_repo_id, sole_repo_id,
 };
 use rusqlite::{Connection, OptionalExtension, Transaction, TransactionBehavior, params};

--- a/crates/rag-rat-db/src/schema/registry.rs
+++ b/crates/rag-rat-db/src/schema/registry.rs
@@ -1291,8 +1291,9 @@ fn resolve_by_root_or_sole(conn: &Connection, root: &Path) -> rusqlite::Result<O
 }
 
 /// Every registered `repo_id` that is a real (adopted) id — i.e. excluding the [`LEGACY_REPO_ID`]
-/// placeholder. A single-repo DB returns at most one.
-fn real_repo_ids(conn: &Connection) -> rusqlite::Result<Vec<String>> {
+/// placeholder. A single-repo DB returns at most one. The store-global memory drain iterates these
+/// to mirror each repo's synced `/3` content at open.
+pub fn real_repo_ids(conn: &Connection) -> rusqlite::Result<Vec<String>> {
     let mut stmt =
         conn.prepare("SELECT repo_id FROM repos WHERE repo_id != ?1 ORDER BY repo_id")?;
     let ids = stmt.query_map([LEGACY_REPO_ID], |row| row.get::<_, String>(0))?;

--- a/crates/rag-rat-oplog/src/content_projection.rs
+++ b/crates/rag-rat-oplog/src/content_projection.rs
@@ -25,8 +25,8 @@ use anyhow::Context;
 use rusqlite::{Connection, OptionalExtension, Transaction, TransactionBehavior, params};
 
 use super::account::{
-    KeyId, content_projected_tables_exist, decode_content_signed, historical_content_keyring,
-    open_sealed_payload, stream_owner_account,
+    KeyId, content_projected_tables_exist, content_stream_has_pending_refold,
+    decode_content_signed, historical_content_keyring, open_sealed_payload, stream_owner_account,
 };
 use super::identity::load_local_device;
 use super::op::{
@@ -127,20 +127,39 @@ pub fn rebuild_all_content_projections_if_stale(conn: &Connection) -> anyhow::Re
 /// first so a row whose stream's accepted set emptied since its last reproject (a full
 /// retro-condemn) cannot linger, then fold each stream (mirrors [`crate::store`]'s
 /// `reproject_all_streams`). Runs inside the caller's txn; the caller stamps after.
+///
+/// The rebuild set is captured BEFORE the clear and includes streams that currently have projection
+/// ROWS but no accepted content (an emptied acceptance set). Reprojecting such a stream to empty
+/// still advances its projection epoch, so the memory drain re-runs and retro-condemns its
+/// now-unbacked `origin='synced'` rows — otherwise the wholesale clear would drop the projection
+/// rows while leaving the drain watermark matched, and the stale synced memories would stay
+/// searchable.
 fn reproject_all_accepted_content_streams(tx: &Transaction<'_>) -> anyhow::Result<()> {
+    let streams = accepted_or_projected_content_streams(tx)?;
     tx.execute("DELETE FROM content_projected_nodes", [])?;
     tx.execute("DELETE FROM content_projected_edges", [])?;
-    for stream_id in accepted_content_streams(tx)? {
+    for stream_id in streams {
         reproject_stream_projection(tx, stream_id)?;
     }
     Ok(())
 }
 
-/// Every distinct `/2` stream the log currently holds ACCEPTED `/3` content for — the rebuild set
-/// for a projector upgrade (mirrors [`crate::store`]'s `streams_present`).
-fn accepted_content_streams(conn: &Connection) -> anyhow::Result<Vec<StreamId>> {
-    let mut stmt =
-        conn.prepare("SELECT DISTINCT stream_id FROM content_entries WHERE accepted = 1")?;
+/// Every distinct `/2` stream that holds ACCEPTED `/3` content OR currently has projection rows —
+/// the rebuild set for a projector upgrade (mirrors [`crate::store`]'s `streams_present`). Read
+/// BEFORE the wholesale clear so a stream whose accepted set emptied is still reprojected (to
+/// empty), which advances its epoch for the memory drain (see the caller). The projection selects
+/// are gated to a well-formed 32-byte `stream_id`: a projection row can carry a malformed/ghost
+/// stream id that is never a real owner stream (the wholesale clear drops it and there is nothing
+/// to reproject or drain for it), while a non-32-byte id from `content_entries` is genuine
+/// corruption and still trips the length check below.
+fn accepted_or_projected_content_streams(conn: &Connection) -> anyhow::Result<Vec<StreamId>> {
+    let mut stmt = conn.prepare(
+        "SELECT stream_id FROM content_entries WHERE accepted = 1
+         UNION
+         SELECT stream_id FROM content_projected_nodes WHERE length(stream_id) = 32
+         UNION
+         SELECT stream_id FROM content_projected_edges WHERE length(stream_id) = 32",
+    )?;
     let rows = stmt.query_map([], |row| row.get::<_, Vec<u8>>(0))?;
     let mut streams = Vec::new();
     for row in rows {
@@ -158,7 +177,16 @@ fn accepted_content_streams(conn: &Connection) -> anyhow::Result<Vec<StreamId>> 
 fn reproject_stream_projection(tx: &Transaction<'_>, stream_id: StreamId) -> anyhow::Result<()> {
     let entries = load_accepted_entries(tx, stream_id)?;
     let state = project::project(&entries);
-    write_projection(tx, stream_id, &state)
+    write_projection(tx, stream_id, &state)?;
+    // Advance this stream's projection epoch. A consumer that MATERIALIZES the projection (the
+    // memory drain, `memory_write::drain`) gates its O(projection) scan on this epoch, so it must
+    // move whenever the projection is rewritten — through EITHER path that reaches here (the local
+    // author's inline reproject and the ingest settle's deferred reproject). Bumping on every
+    // rewrite, even an idempotent one, is deliberately conservative: it can only cause an extra
+    // no-op drain, never a missed one. Distinct from the store-global projector VERSION stamp,
+    // which tracks the binary's projector, not per-stream content change.
+    bump_content_projection_epoch(tx, stream_id)?;
+    Ok(())
 }
 
 /// Error if a NEWER `/3` projector already folded this store's content projection — an older binary
@@ -200,6 +228,88 @@ fn stored_content_projector_version(conn: &Connection) -> anyhow::Result<Option<
     .optional()?
     .map(|value| value.parse::<i64>().context("oplog content_projector_version is not an integer"))
     .transpose()
+}
+
+// ── per-stream projection epoch + memory-drain watermark ───────────────────────────────────────
+//
+// A monotonic per-stream counter (`content:proj-epoch:<hex>` in `oplog_meta`) bumped on every
+// projection rewrite, plus the epoch a consumer last materialized (`content:drain-wm:<hex>`). This
+// lets the memory drain (`memory_write::drain`) skip its O(projection) scan when the projection is
+// unchanged since it last ran — the store-global watcher pass would otherwise re-scan every stream
+// every pass. `oplog_meta` (a KV table) is reused so this needs no schema migration; the stream is
+// keyed via SQLite's own `hex()` (no Rust hex dependency).
+
+/// Advance `stream`'s projection epoch by one (creating it at 1). Called from the single reproject
+/// choke point, so it moves on every rewrite regardless of which path triggered it. `hex(?1)` keys
+/// the row by the stream without a Rust hex dependency (UPPERCASE, matched by the reads below).
+fn bump_content_projection_epoch(
+    tx: &Transaction<'_>,
+    stream_id: StreamId,
+) -> rusqlite::Result<()> {
+    tx.execute(
+        "INSERT INTO oplog_meta(key, value) VALUES ('content:proj-epoch:' || hex(?1), '1')
+         ON CONFLICT(key) DO UPDATE SET value = CAST(value AS INTEGER) + 1",
+        params![stream_id.to_bytes().as_slice()],
+    )?;
+    Ok(())
+}
+
+/// `stream`'s current projection epoch — `0` if it has never been projected. Accepts a
+/// `&Connection` or (via deref) a `&Transaction`, so the drain can read it both in its read-only
+/// pre-check and inside its write txn.
+pub fn content_projection_epoch(conn: &Connection, stream_id: StreamId) -> anyhow::Result<u64> {
+    let value: Option<i64> = conn
+        .query_row(
+            "SELECT CAST(value AS INTEGER) FROM oplog_meta WHERE key = 'content:proj-epoch:' || \
+             hex(?1)",
+            params![stream_id.to_bytes().as_slice()],
+            |row| row.get(0),
+        )
+        .optional()?;
+    Ok(value.unwrap_or(0).max(0) as u64)
+}
+
+/// The epoch the memory drain last materialized for `stream`, or `None` if it has never drained it.
+fn content_drain_watermark(conn: &Connection, stream_id: StreamId) -> anyhow::Result<Option<u64>> {
+    let value: Option<i64> = conn
+        .query_row(
+            "SELECT CAST(value AS INTEGER) FROM oplog_meta WHERE key = 'content:drain-wm:' || \
+             hex(?1)",
+            params![stream_id.to_bytes().as_slice()],
+            |row| row.get(0),
+        )
+        .optional()?;
+    Ok(value.map(|v| v.max(0) as u64))
+}
+
+/// Whether the memory drain needs to run for `stream`: it has never drained it (backfill), a refold
+/// is pending (un-projected content whose settle has not folded it into the projection yet, so the
+/// epoch has not moved), or the projection changed since the last drain (epoch moved past the
+/// watermark). A cheap READ-ONLY pre-check (indexed lookups, no write txn) so an idle watcher pass
+/// skips opening a transaction and scanning the whole projection. CONSERVATIVE — any doubt is
+/// `true`, so a drain is never wrongly skipped; the worst case is one redundant no-op scan.
+pub fn content_drain_needed(conn: &Connection, stream_id: StreamId) -> anyhow::Result<bool> {
+    if content_stream_has_pending_refold(conn, stream_id)? {
+        return Ok(true);
+    }
+    match content_drain_watermark(conn, stream_id)? {
+        None => Ok(true),
+        Some(watermark) => Ok(content_projection_epoch(conn, stream_id)? != watermark),
+    }
+}
+
+/// Record that the drain has materialized `stream` up to its CURRENT projection epoch. Called
+/// inside the drain's write txn AFTER its settle (which may have advanced the epoch), so the
+/// watermark reflects exactly what was scanned. The next [`content_drain_needed`] returns `false`
+/// until the projection changes again.
+pub fn record_content_drained(tx: &Transaction<'_>, stream_id: StreamId) -> anyhow::Result<()> {
+    let epoch = content_projection_epoch(tx, stream_id)?;
+    tx.execute(
+        "INSERT INTO oplog_meta(key, value) VALUES ('content:drain-wm:' || hex(?1), ?2)
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+        params![stream_id.to_bytes().as_slice(), epoch.to_string()],
+    )?;
+    Ok(())
 }
 
 /// Rewrite one stream's rows in `content_projected_nodes` / `content_projected_edges` — clear the
@@ -435,4 +545,143 @@ pub fn list_projected_content_edges(
         });
     }
     Ok(edges)
+}
+
+#[cfg(test)]
+mod drain_gate_tests {
+    use rag_rat_db::schema;
+
+    use super::*;
+
+    fn conn() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        schema::apply(&conn, &crate::test_hooks()).unwrap();
+        conn
+    }
+
+    /// The drain gate tracks the three conditions it must run under — never drained (backfill), a
+    /// pending refold, and an epoch advanced past the recorded watermark — and short-circuits only
+    /// when the projection is provably unchanged since the last drain.
+    #[test]
+    fn content_drain_needed_tracks_epoch_watermark_and_pending() {
+        let mut conn = conn();
+        let stream = StreamId::from_bytes([7; 32]);
+
+        // Never projected, never drained → backfill owed; epoch starts at 0.
+        assert!(content_drain_needed(&conn, stream).unwrap(), "a never-drained stream is owed");
+        assert_eq!(content_projection_epoch(&conn, stream).unwrap(), 0);
+
+        // A projection rewrite advances the epoch; still owed (no watermark yet).
+        {
+            let tx = conn.transaction().unwrap();
+            bump_content_projection_epoch(&tx, stream).unwrap();
+            tx.commit().unwrap();
+        }
+        assert_eq!(content_projection_epoch(&conn, stream).unwrap(), 1);
+        assert!(content_drain_needed(&conn, stream).unwrap(), "no watermark yet, still owed");
+
+        // The drain records the watermark at the current epoch → no longer owed.
+        {
+            let tx = conn.transaction().unwrap();
+            record_content_drained(&tx, stream).unwrap();
+            tx.commit().unwrap();
+        }
+        assert!(!content_drain_needed(&conn, stream).unwrap(), "caught up: not owed");
+
+        // A pending refold (un-projected content) makes it owed even at the same epoch.
+        conn.execute("INSERT INTO content_streams_pending_refold(stream_id) VALUES (?1)", params![
+            stream.to_bytes().as_slice()
+        ])
+        .unwrap();
+        assert!(content_drain_needed(&conn, stream).unwrap(), "a pending refold is owed");
+        conn.execute("DELETE FROM content_streams_pending_refold WHERE stream_id = ?1", params![
+            stream.to_bytes().as_slice()
+        ])
+        .unwrap();
+        assert!(!content_drain_needed(&conn, stream).unwrap(), "cleared pending: not owed");
+
+        // Another rewrite advances the epoch past the watermark → owed again.
+        {
+            let tx = conn.transaction().unwrap();
+            bump_content_projection_epoch(&tx, stream).unwrap();
+            tx.commit().unwrap();
+        }
+        assert_eq!(content_projection_epoch(&conn, stream).unwrap(), 2);
+        assert!(content_drain_needed(&conn, stream).unwrap(), "epoch past watermark is owed");
+    }
+
+    /// A projector-version rebuild clears a stream whose accepted set emptied. Its epoch MUST still
+    /// advance (via a reproject-to-empty), or a drain that already watermarked the old epoch would
+    /// skip and leave the stream's now-unbacked `origin='synced'` rows searchable forever.
+    #[test]
+    fn a_projector_rebuild_bumps_the_epoch_of_a_stream_whose_projection_emptied() {
+        let mut conn = conn();
+        let stream = StreamId::from_bytes([9; 32]);
+        // A stale projection row with NO backing accepted content entry (an emptied acceptance
+        // set), plus a drain watermark recorded at the current (0) epoch → nothing owed
+        // yet.
+        conn.execute(
+            "INSERT INTO content_projected_nodes(stream_id, node_id, content_json, status)
+             VALUES (?1, 'n', '{}', 'active')",
+            params![stream.to_bytes().as_slice()],
+        )
+        .unwrap();
+        {
+            let tx = conn.transaction().unwrap();
+            record_content_drained(&tx, stream).unwrap();
+            tx.commit().unwrap();
+        }
+        assert!(
+            !content_drain_needed(&conn, stream).unwrap(),
+            "watermark matches epoch 0: not owed"
+        );
+
+        // Age the stored projector stamp so the next open triggers a store-global rebuild.
+        conn.execute(
+            "INSERT INTO oplog_meta(key, value) VALUES (?1, ?2)
+             ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            params![CONTENT_PROJECTOR_VERSION_KEY, (CONTENT_PROJECTOR_VERSION - 1).to_string()],
+        )
+        .unwrap();
+        assert!(
+            rebuild_all_content_projections_if_stale(&conn).unwrap(),
+            "the stale stamp triggers a rebuild",
+        );
+
+        // The emptied stream was reprojected (to empty), advancing its epoch past the watermark.
+        assert_eq!(
+            content_projection_epoch(&conn, stream).unwrap(),
+            1,
+            "an emptied stream's epoch is bumped by the rebuild",
+        );
+        assert!(
+            content_drain_needed(&conn, stream).unwrap(),
+            "the emptied projection is owed a drain"
+        );
+        let rows: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM content_projected_nodes WHERE stream_id = ?1",
+                params![stream.to_bytes().as_slice()],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(rows, 0, "the stale projection row was cleared by the rebuild");
+    }
+
+    /// Epochs and watermarks are per-stream: draining one stream never clears another's.
+    #[test]
+    fn the_epoch_and_watermark_are_per_stream() {
+        let mut conn = conn();
+        let a = StreamId::from_bytes([1; 32]);
+        let b = StreamId::from_bytes([2; 32]);
+        {
+            let tx = conn.transaction().unwrap();
+            bump_content_projection_epoch(&tx, a).unwrap();
+            bump_content_projection_epoch(&tx, b).unwrap();
+            record_content_drained(&tx, a).unwrap();
+            tx.commit().unwrap();
+        }
+        assert!(!content_drain_needed(&conn, a).unwrap(), "a is caught up");
+        assert!(content_drain_needed(&conn, b).unwrap(), "b was never drained, still owed");
+    }
 }

--- a/crates/rag-rat-oplog/src/content_projection.rs
+++ b/crates/rag-rat-oplog/src/content_projection.rs
@@ -29,7 +29,9 @@ use super::account::{
     open_sealed_payload, stream_owner_account,
 };
 use super::identity::load_local_device;
-use super::op::{self, DecodedOp, Entry, OpMeta};
+use super::op::{
+    self, DecodedOp, EdgeSpec, Entry, NodeContent, NodeStatus, OpMeta, ResolvedAnchor,
+};
 use super::project;
 use super::project::ProjectedState;
 use super::store::{EdgeSpecRow, NodeContentRow, ResolvedAnchorRow};
@@ -346,4 +348,91 @@ fn load_accepted_entries(tx: &Transaction<'_>, stream_id: StreamId) -> anyhow::R
         }
     }
     Ok(entries)
+}
+
+/// One projected `/3` node, decoded for a projection consumer: the stable node id, the folded
+/// content register, and the folded status. The memory drain (rag-rat-core) reads these to mirror
+/// a stream's accepted nodes into `repo_memories` as `origin='synced'` rows — the reverse direction
+/// of the local reconcile. Owned + flat: the private row DTOs stay inside this crate.
+pub struct ProjectedContentNode {
+    pub node_id: String,
+    pub content: NodeContent,
+    pub status: NodeStatus,
+}
+
+/// One projected `/3` edge, decoded for a projection consumer: the stable key, the folded spec (the
+/// edge is self-describing — it carries its own `owner_repo_id`), the last resolved anchor if any,
+/// and `present` (a `false` row is a RETAINED tombstone the consumer honors, not a live edge).
+pub struct ProjectedContentEdge {
+    pub edge_key: String,
+    pub spec: EdgeSpec,
+    pub resolved: Option<ResolvedAnchor>,
+    pub present: bool,
+}
+
+/// Read one `/2` stream's projected nodes, decoded from the stored `content_json` back into the op
+/// model. Deterministic `node_id` order. An unknown status token FAILS (a newer binary folded it),
+/// mirroring the reconcile's authoring guard rather than silently coercing it.
+pub fn list_projected_content_nodes(
+    conn: &Connection,
+    stream_id: StreamId,
+) -> anyhow::Result<Vec<ProjectedContentNode>> {
+    let mut stmt = conn.prepare(
+        "SELECT node_id, content_json, status FROM content_projected_nodes
+         WHERE stream_id = ?1 ORDER BY node_id",
+    )?;
+    let rows = stmt.query_map(params![stream_id.to_bytes().as_slice()], |row| {
+        Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?, row.get::<_, String>(2)?))
+    })?;
+    let mut nodes = Vec::new();
+    for row in rows {
+        let (node_id, content_json, status) = row?;
+        let content: NodeContentRow = serde_json::from_str(&content_json)
+            .with_context(|| format!("decode projected /3 node content for `{node_id}`"))?;
+        let status = NodeStatus::from_db_str(&status).with_context(|| {
+            format!("projected /3 node `{node_id}` carries unknown status `{status}`")
+        })?;
+        nodes.push(ProjectedContentNode { node_id, content: NodeContent::from(content), status });
+    }
+    Ok(nodes)
+}
+
+/// Read one `/2` stream's projected edges (live AND tombstoned), decoded from the stored
+/// `spec_json` / `resolved_json` back into the op model. Deterministic `edge_key` order.
+pub fn list_projected_content_edges(
+    conn: &Connection,
+    stream_id: StreamId,
+) -> anyhow::Result<Vec<ProjectedContentEdge>> {
+    let mut stmt = conn.prepare(
+        "SELECT edge_key, spec_json, resolved_json, present FROM content_projected_edges
+         WHERE stream_id = ?1 ORDER BY edge_key",
+    )?;
+    let rows = stmt.query_map(params![stream_id.to_bytes().as_slice()], |row| {
+        Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, String>(1)?,
+            row.get::<_, Option<String>>(2)?,
+            row.get::<_, i64>(3)?,
+        ))
+    })?;
+    let mut edges = Vec::new();
+    for row in rows {
+        let (edge_key, spec_json, resolved_json, present) = row?;
+        let spec_row: EdgeSpecRow = serde_json::from_str(&spec_json)
+            .with_context(|| format!("decode projected /3 edge spec for `{edge_key}`"))?;
+        let resolved = resolved_json
+            .map(|json| {
+                serde_json::from_str::<ResolvedAnchorRow>(&json)
+                    .with_context(|| format!("decode projected /3 edge anchor for `{edge_key}`"))
+                    .map(ResolvedAnchor::from)
+            })
+            .transpose()?;
+        edges.push(ProjectedContentEdge {
+            edge_key,
+            spec: EdgeSpec::try_from(spec_row)?,
+            resolved,
+            present: present != 0,
+        });
+    }
+    Ok(edges)
 }

--- a/crates/rag-rat-oplog/src/lib.rs
+++ b/crates/rag-rat-oplog/src/lib.rs
@@ -126,6 +126,12 @@ pub use content_projection::{
     ProjectedContentEdge, ProjectedContentNode, list_projected_content_edges,
     list_projected_content_nodes,
 };
+// The drain-gate seam (#902): a per-stream projection epoch + last-drained watermark (both in
+// `oplog_meta`) so the memory drain skips its O(projection) scan when nothing changed since it
+// last ran — the store-global watcher pass would otherwise re-scan every stream every pass.
+pub use content_projection::{
+    content_drain_needed, content_projection_epoch, record_content_drained,
+};
 // The op-log's first crate-internal API surface (#524): the MINTING primitives + the op
 // vocabulary the memory subsystem needs to author + backfill entries. Every submodule above is
 // otherwise private, so this curated re-export is the ONE seam `query::memory` reaches through

--- a/crates/rag-rat-oplog/src/lib.rs
+++ b/crates/rag-rat-oplog/src/lib.rs
@@ -117,6 +117,15 @@ pub use account::{
 // open/migrate seam by rag-rat-core, so a stale store is rebuilt (every stream, then the one
 // stamp) before any per-stream write.
 pub use content_projection::rebuild_all_content_projections_if_stale;
+// The projection READ seam (#691 A1): decode a `/2` stream's projected nodes/edges back into
+// the op model. The memory drain reads these to mirror accepted synced content into
+// `repo_memories` / `repo_node_edges` as `origin='synced'` rows — the reverse of the local
+// reconcile. Read-only over the projection tables, keeping the private row DTOs inside this
+// crate.
+pub use content_projection::{
+    ProjectedContentEdge, ProjectedContentNode, list_projected_content_edges,
+    list_projected_content_nodes,
+};
 // The op-log's first crate-internal API surface (#524): the MINTING primitives + the op
 // vocabulary the memory subsystem needs to author + backfill entries. Every submodule above is
 // otherwise private, so this curated re-export is the ONE seam `query::memory` reaches through
@@ -124,7 +133,7 @@ pub use content_projection::rebuild_all_content_projections_if_stale;
 pub use identity::{LocalDevice, load_local_device, local_device};
 pub use op::{
     DeviceFingerprint, EdgeKey, EdgeSpec, MemoryOp, NodeContent, NodeId, NodeStatus,
-    ParseDeviceFingerprintError,
+    ParseDeviceFingerprintError, ResolvedAnchor,
 };
 // The `/1` shadow-projection read seams (`ProjectedState` / `load_projection`) and the
 // standalone (own-txn) `/1` authoring wrappers (`author_batch` / `author_op`) — test-only

--- a/crates/rag-rat-query/src/memory/hydrate.rs
+++ b/crates/rag-rat-query/src/memory/hydrate.rs
@@ -98,10 +98,14 @@ pub fn upsert_memory_fts(conn: &Connection, memory_id: &str) -> anyhow::Result<(
     conn.execute("DELETE FROM repo_memory_fts WHERE memory_id = ?1", [memory_id])?;
     let tags = tags_for_memory(conn, memory_id)?.join(" ");
     // Post-A5 the FTS carries a `repo_id UNINDEXED` mirror of the parent memory's, so
-    // `memory_search` can filter it after the MATCH. Stamp it from `repo_memories.repo_id`
-    // (already set by the time this runs). On the pre-A5 schema the column does not exist, so
-    // write the original row shape.
-    if memory_repo_scope(conn)?.is_some() {
+    // `memory_search` can filter it after the MATCH. Stamp it by COPYING `repo_memories.repo_id`
+    // (already set by the time this runs). The branch keys on the SCHEMA capability (does the
+    // column exist?), NOT on the connection's active-repo scope: a scope-less writer on the current
+    // schema (e.g. the synced-content drain at open, before `set_context`) must still stamp the
+    // repo_id it copies from the row, or `memory_search`'s repo filter would never match the row
+    // and a subsequent no-op write would never repair it. On the pre-A5 schema the column does not
+    // exist, so write the original row shape.
+    if rag_rat_db::schema::column_exists(conn, "repo_memories", "repo_id")? {
         conn.execute(
             "
             INSERT INTO repo_memory_fts(repo_id, memory_id, title, body, kind, tags)


### PR DESCRIPTION
## Summary

Drains a stream's accepted `/3` content into `repo_memories` / `repo_node_edges` — the reverse of the local reconcile, which authors local rows into the signed `/3` log. A memory authored on one device of an account becomes a real, searchable local row on another device of the same account.

Repo attribution is by **forward derivation**: `stream → repo` is a one-way hash and nodes carry no `repo_id`, but content `/3` is one stream per `(repo_id, account_id)` and every device of an account shares the account id, so `owned_stream_v2_id` derives the same stream on every device.

## Convergence, not freeze

The projection is the account-wide last-writer-wins content across all devices including this one, so the drain **converges**:

- absent locally → INSERT `origin='synced'`;
- present (local or synced) → UPDATE to the projection value **preserving origin**, so another device's accepted edit to a locally-authored memory is applied, not ignored;
- a local row **absent** from the projection is a pending local edit and is left alone;
- a `present=0` edge tombstone removes the edge regardless of origin (a peer's remove wins); a retro-condemned row (projection entry vanished) is removed, gated to `origin='synced'`.

Convergence never re-authors (a converged row is already in the projection, which the authoring-side anti-join excludes), so it does not echo.

## Untrusted-boundary validation

Projected content is peer-authored and only shape-validated on the wire, so it is treated as untrusted:

- a global-PK node id already owned by **another** repo is never overwritten; an edge materializes only when its owner and source node belong to the drained repo; an existing edge owned by another repo is never rewritten;
- a projected value that fails the **same** gates the local write path enforces is **quarantined** (skipped + warned, never wedging the drain) — a node's kind/confidence/source/title/body/payload and per-tag length caps, and an edge's `target_anchor` / `target_repo_id` length caps;
- if a prior `origin='synced'` mirror exists and the accepted update is invalid, the **stale row is removed** so it never stays searchable under a value the projection no longer holds (a local row of the same id is spared);
- a retro-condemned node's contentless `repo_memory_fts` shadow (no FK) is deleted explicitly.

## Wiring

Runs inside an IMMEDIATE transaction after settling pending refold, at three writer seams: the consolidate reconcile (per repo), the open/migrate rebuild (store-global), and the watcher maintenance pass (store-global backstop for a long-running process). No schema change — the `origin` column already exists at V085.

## Testing

- 39 drain unit tests (convergence, origin preservation, tombstones, retro-condemn, cross-repo boundary, quarantine of every invalid field class).
- Full workspace green: `nextest` (2292 tests) under both runners, `clippy` `--no-default-features` and `--all-features` (`-D warnings`), nightly `fmt`.

## Drain gate (second commit)

Every drain seam (open, consolidate, and the long-running watcher pass) opened an IMMEDIATE transaction and scanned the whole projection on every call — O(projection) under a write lock even when nothing changed, on a hot path (a minted account projects every local memory, so this hit every repo with memories on every watcher pass).

The drain now consults a cheap read-only gate before opening its transaction: a per-stream **projection epoch** (bumped at the single reproject choke point) plus the epoch a drain last materialized. It skips entirely unless it has never drained the stream (backfill), a refold is pending, or the epoch moved past the watermark. Both live in `oplog_meta` keyed by SQLite `hex(stream_id)` — no schema migration, no new dependency.

- **Measured** (N=2000 projected nodes): an idle re-drain drops from a **50.9 ms** full-scan pass to an **83.9 µs** read-only skip — ~**600×** — with no write lock held.
- **Correctness:** the gate is conservative (any doubt runs the drain, so a change is never missed). A projector-version rebuild that empties a stream's accepted set now still reprojects it (to empty) and bumps its epoch, so the drain re-runs and removes its now-unbacked `origin='synced'` rows.

## Follow-up (tracked, not blocking correctness)

- **Read-only opens do not drain — by design.** A read-only connection cannot write `repo_memories`; the transport's ingest driver (a writer) will drain what it ingests.

Fixes #691.
