### PR TITLE
perf(index): incrementally maintain content_revision as an O(1) read

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4993,6 +4993,7 @@ dependencies = [
  "rag-rat-base",
  "rusqlite",
  "serde",
+ "sha2",
  "tempfile",
  "tracing",
  "zstd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,7 +103,7 @@ pulldown-cmark = { version = "0.13", default-features = false }
 # driven on the papertrail module's private runtime at the sync boundary.
 reqwest = { version = "0.13", default-features = false, features = ["rustls"] }
 rmcp = { version = "2.2.0", features = ["transport-io"] }
-rusqlite = { version = "0.40", features = ["bundled"] }
+rusqlite = { version = "0.40", features = ["bundled", "functions"] }
 rayon = "1.12"
 regex = "1.12"
 schemars = { version = "1.2.1", features = ["derive"] }

--- a/crates/rag-rat-core/src/index/meta.rs
+++ b/crates/rag-rat-core/src/index/meta.rs
@@ -7,21 +7,6 @@ use rag_rat_db::meta::*;
 
 use super::*;
 
-/// A [`IndexDatabase::content_revision`] digest pinned to the connection state it was computed
-/// under (#821), so a LATER stage of the same pass can reuse the digest instead of paying the
-/// full `main.files` scan again — but only when nothing can have moved it in between. Consumed
-/// through [`IndexDatabase::content_revision_reusing`], which enforces the reuse rule.
-#[derive(Debug)]
-pub(crate) struct ContentRevisionSnapshot {
-    revision: String,
-    /// `PRAGMA data_version` at capture — moves iff ANOTHER connection committed to this
-    /// database since. The database is shared cross-process (and, consolidated, cross-repo:
-    /// a sibling repo's writer moves the GLOBAL digest without touching this repo's rows).
-    data_version: i64,
-    /// SQL `total_changes()` at capture — moves iff THIS connection wrote any row since.
-    total_changes: i64,
-}
-
 impl IndexDatabase {
     pub(super) fn record_content_revision(&self) -> anyhow::Result<String> {
         let revision = self.content_revision()?;
@@ -40,77 +25,6 @@ impl IndexDatabase {
         // the global `index_meta`. (V040's `move_repo_meta_keys_to_global` migrates any stale
         // per-repo copy back; the shared relocate helper no longer re-relocates it.)
         self.set_meta("content_revision", revision)
-    }
-
-    /// The connection's `PRAGMA data_version` — differs between two reads on THIS connection iff
-    /// ANOTHER connection committed to the database in between.
-    pub(super) fn connection_data_version(&self) -> anyhow::Result<i64> {
-        Ok(self.storage.connection().query_row("PRAGMA data_version", [], |row| row.get(0))?)
-    }
-
-    /// The connection's SQL `total_changes()` — moves iff THIS connection wrote any row.
-    fn connection_total_changes(&self) -> anyhow::Result<i64> {
-        Ok(self.storage.connection().query_row("SELECT total_changes()", [], |row| row.get(0))?)
-    }
-
-    /// Pin `revision` — a digest [`Self::content_revision`] just computed on this connection —
-    /// to the connection's current write state, for [`Self::content_revision_reusing`] (#821).
-    ///
-    /// `data_version_before_digest` is [`Self::connection_data_version`] captured BEFORE the
-    /// digest was computed: it brackets the digest against the cross-connection TOCTOU. Without
-    /// it, another connection committing between the digest read and this capture would bake the
-    /// NEW `data_version` into a pin whose digest describes the OLD rows — a later no-write
-    /// window would then validate the mismatched pin. When the bracket detects such a commit the
-    /// pin is refused (`None`) and the consumer recomputes.
-    pub(super) fn pin_content_revision(
-        &self,
-        revision: String,
-        data_version_before_digest: i64,
-    ) -> anyhow::Result<Option<ContentRevisionSnapshot>> {
-        let data_version = self.connection_data_version()?;
-        if data_version != data_version_before_digest {
-            return Ok(None);
-        }
-        Ok(Some(ContentRevisionSnapshot {
-            revision,
-            data_version,
-            total_changes: self.connection_total_changes()?,
-        }))
-    }
-
-    /// The pinned digest when it is PROVABLY still current, else a fresh recompute (#821).
-    ///
-    /// REUSE RULE: a pinned digest describes `main.files` only while nothing has written to the
-    /// database, and stages run between the pin and its consumer — in the watcher pass, the base
-    /// reconcile runs between the clone quiet-gate probe and the clone delta. No stage report
-    /// distinguishes "wrote `files` rows" (the reconcile's `"Current"` covers both a no-op and a
-    /// completed embedding run), and other processes share the database file. So the gate is the
-    /// connection's own counters: reuse ONLY when `PRAGMA data_version` (other connections) AND
-    /// `total_changes()` (this connection) both still match the capture — ANY intervening write,
-    /// `files` or not, forces the recompute. Conservative by design: a false negative costs one
-    /// redundant digest; a false positive would let the consumer stamp or compare a digest that
-    /// does not describe the rows it actually read.
-    pub(super) fn content_revision_reusing(
-        &self,
-        pinned: Option<&ContentRevisionSnapshot>,
-    ) -> anyhow::Result<String> {
-        // Validation order matters: own-connection `total_changes()` FIRST, the cross-connection
-        // `data_version` LAST — read last, it covers every sibling commit up to this moment, so
-        // the validation itself has no internal race window. What remains is the gap between
-        // this check and the consumer's own reads — the SAME gap the recompute path always had
-        // (a digest is computed, then consumed outside a transaction) — and it is benign: the
-        // consumer holds the per-repo write lock, so the rows it reads cannot move; only ANOTHER
-        // repo's rows in a consolidated DB can, which lags the GLOBAL freshness stamp by one
-        // pass (the next probe recomputes and the delta re-pins) and fails safe wherever the
-        // stamp is compared for exact freshness (an older-than-content stamp disables the
-        // postings fast path, never enables it).
-        if let Some(pinned) = pinned
-            && self.connection_total_changes()? == pinned.total_changes
-            && self.connection_data_version()? == pinned.data_version
-        {
-            return Ok(pinned.revision.clone());
-        }
-        self.content_revision()
     }
 
     /// Read a per-repo meta value (`repo_meta`) for the repo owning this connection — the ergonomic
@@ -254,29 +168,104 @@ impl IndexDatabase {
         read_meta(self.storage.connection(), key)
     }
 
-    /// The content digest over EVERY indexed file row — read from the GLOBAL `main.files`, NOT the
-    /// scoped `temp.files` view. The FTS mirror (`chunk_fts`), the `content_revision` meta, and the
-    /// `fts_dirty` flag are all GLOBAL (one FTS5 index over the whole `chunks` table), so their
-    /// freshness must track global content. Reading the scoped view here made `fts_source_revision`
-    /// ALTERNATE: `sync_fts` under a linked-overlay scope recorded the overlay-view digest, then a
-    /// base read recomputed the base-view digest, saw a mismatch, and rebuilt FTS — and the next
-    /// overlay read rebuilt it back, so interleaved base/overlay reads rebuilt the global FTS every
-    /// time even though the per-row FTS entries were already in sync (#219 review). The global
-    /// digest is scope-invariant, so the freshness check is stable regardless of the active
-    /// connection scope.
+    /// The content digest over EVERY indexed file row — an O(1) read of the incrementally
+    /// maintained `content_digest_state` (#828), rendered `ms1-<64 hex>`. GLOBAL (no repo/scope
+    /// filter): the FTS mirror (`chunk_fts`), the `content_revision` meta, and the clone-graph
+    /// stamps are all global, so their freshness must track global content — reading a scoped view
+    /// here once made `fts_source_revision` ALTERNATE between base/overlay digests and rebuild FTS
+    /// every interleaved read (#219). The digest is a pure function of the current multiset
+    /// `{(path, sha256) : main.files, kind != 'deleted'}`, so it is content-stable across rebuilds,
+    /// generation flips, gc, and row-order/rowid churn — see the `rag_rat_db::content_digest`
+    /// module doc for the multiset-hash invariant.
+    ///
+    /// Maintained by the `files_content_digest_*` triggers on every write, so this is a single-row
+    /// SELECT. If the row is ABSENT (pathological — hand-deleted, or a future migration bug), fall
+    /// back to the from-scratch scan fold, WARN, and do NOT write from this read path (read-only
+    /// opens exist). A write-lock-holding context reseeds via
+    /// [`Self::verify_content_digest_parity`].
     pub(super) fn content_revision(&self) -> anyhow::Result<String> {
-        // group_concat over an ORDER BY subquery, not `string_agg(... ORDER BY path)`: string_agg()
-        // and aggregate ORDER BY are SQLite 3.44+, and this portable idiom (works on any SQLite)
-        // avoids tying the query to a SQLite version. The subquery's ORDER BY feeds rows to
-        // group_concat in path order, so the digest input is the same deterministic string. Order
-        // only has to be stable per-machine (this digest is compared against a previously-stored
-        // value on the same DB), which this idiom guarantees.
-        let value = self.storage.connection().query_row(
-            "SELECT COALESCE(group_concat(pv, ','), '') FROM (SELECT path || ':' || sha256 AS pv \
-             FROM main.files WHERE kind != 'deleted' ORDER BY path)",
-            [],
-            |row| row.get::<_, String>(0),
+        let stored: Option<String> = self
+            .storage
+            .connection()
+            .query_row("SELECT state FROM content_digest_state WHERE id = 1", [], |row| row.get(0))
+            .optional()?;
+        match stored {
+            Some(state) =>
+                Ok(format!("{}{state}", rag_rat_db::content_digest::CONTENT_REVISION_PREFIX)),
+            None => {
+                tracing::warn!(
+                    "content_digest_state row absent; falling back to a from-scratch \
+                     content_revision scan (reseed via gc or `heal_index`)"
+                );
+                self.content_revision_from_scan()
+            },
+        }
+    }
+
+    /// The from-scratch, order-free content digest over the current non-deleted `main.files`,
+    /// rendered `ms1-…` — using the SAME per-row hash the trigger fold and the migration seed use,
+    /// so a recompute can never disagree with the trigger-maintained state. Shared by the read
+    /// fallback above and the parity self-check. Read-only.
+    pub(super) fn content_revision_from_scan(&self) -> anyhow::Result<String> {
+        let (state, _rows_folded) = self.content_digest_from_scan()?;
+        Ok(rag_rat_db::content_digest::render_revision(&state))
+    }
+
+    /// `(state, rows_folded)` recomputed from a full `main.files` scan — the raw form the parity
+    /// self-check and reseed compare and write. Ordering is irrelevant (the fold is commutative).
+    fn content_digest_from_scan(
+        &self,
+    ) -> anyhow::Result<(rag_rat_db::content_digest::DigestState, i64)> {
+        let conn = self.storage.connection();
+        let mut state = [0u64; 4];
+        let mut rows_folded = 0i64;
+        let mut stmt =
+            conn.prepare("SELECT path, sha256 FROM main.files WHERE kind != 'deleted'")?;
+        let mut rows = stmt.query([])?;
+        while let Some(row) = rows.next()? {
+            let path: String = row.get(0)?;
+            let sha256: String = row.get(1)?;
+            let hash = rag_rat_db::content_digest::content_row_hash(&path, &sha256);
+            rag_rat_db::content_digest::fold_row(&mut state, &hash, true);
+            rows_folded += 1;
+        }
+        Ok((state, rows_folded))
+    }
+
+    /// Belt-and-suspenders parity self-check (#828 §9.1): recompute the digest from a full scan and
+    /// compare it (state + `rows_folded`) with the maintained `content_digest_state`. On a
+    /// mismatch — which no KNOWN path can cause (the triggers are fail-closed), so it means a
+    /// migration bug or corruption — `tracing::error!` both values and RESEED the state row in
+    /// place. MUST run only under a write lock (gc cadence, `heal_index`, full-index finalize).
+    /// Deliberately does NOT re-stamp `fts_source_revision`/clone stamps: a drift has unknown
+    /// provenance, so letting the mismatch drive the normal freshness rebuilds is the safe
+    /// direction. Also reseeds when the row is absent.
+    pub(super) fn verify_content_digest_parity(&self) -> anyhow::Result<()> {
+        let (state, rows_folded) = self.content_digest_from_scan()?;
+        let expected_state = rag_rat_db::content_digest::encode_state(&state);
+        let conn = self.storage.connection();
+        let stored: Option<(String, i64)> = conn
+            .query_row(
+                "SELECT state, rows_folded FROM content_digest_state WHERE id = 1",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .optional()?;
+        if stored.as_ref() == Some(&(expected_state.clone(), rows_folded)) {
+            return Ok(());
+        }
+        tracing::error!(
+            ?stored,
+            expected_state,
+            expected_rows_folded = rows_folded,
+            "content_digest_state parity mismatch — reseeding from scan (a trigger/migration \
+             regression drifted the incrementally maintained content_revision)"
+        );
+        conn.execute(
+            "INSERT OR REPLACE INTO content_digest_state(id, state, rows_folded) VALUES (1, ?1, \
+             ?2)",
+            params![expected_state, rows_folded],
         )?;
-        Ok(hex_sha256(value.as_bytes()))
+        Ok(())
     }
 }

--- a/crates/rag-rat-core/src/index/mod.rs
+++ b/crates/rag-rat-core/src/index/mod.rs
@@ -29,9 +29,6 @@ mod incremental;
 mod lifecycle;
 mod mem_diag;
 mod meta;
-// Crate-internal: a `content_revision()` digest pinned to its connection write-state, threaded
-// probe → clone delta by the watcher pass (#821).
-pub(crate) use meta::ContentRevisionSnapshot;
 mod migration_gate;
 mod packages;
 mod parser_failures;

--- a/crates/rag-rat-core/src/index/query_api/clones/delta.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/delta.rs
@@ -44,7 +44,7 @@ use super::substrate::{
     SymbolBag, add_struct_hash_pairs, load_scoped_baseline_bags_for_paths, overlap,
     sub_block_tokens, verified_clone,
 };
-use crate::index::{ContentRevisionSnapshot, IndexDatabase};
+use crate::index::IndexDatabase;
 
 /// SQLite bind-variable safety chunk for `IN (…)` lists (mirrors `of_text::HYDRATION_CHUNK`).
 const DELTA_SQL_CHUNK: usize = 400;
@@ -94,22 +94,7 @@ impl IndexDatabase {
     /// runs lock-stable outside a transaction, and all writes commit in ONE transaction, so a
     /// reader sees either the old graph or the fully-applied delta.
     pub fn apply_clone_graph_delta(&self, max_files: usize) -> anyhow::Result<CloneDeltaReport> {
-        self.apply_clone_graph_delta_inner(max_files, None, None)
-    }
-
-    /// [`Self::apply_clone_graph_delta`] reusing the digest the same pass's quiet-gate probe
-    /// already computed (#821): the probe and this delta run moments apart on the same
-    /// connection, and `content_revision()` is a full `main.files` scan. The pin is a HINT, not
-    /// an authority — [`Self::content_revision_reusing`] serves it only when the connection
-    /// counters prove no write (this connection's or another's) has intervened since capture,
-    /// and recomputes otherwise, so the base reconcile between probe and delta can never leave
-    /// this delta acting on a digest that no longer describes the `files` rows it reads.
-    pub(crate) fn apply_clone_graph_delta_reusing_revision(
-        &self,
-        max_files: usize,
-        pinned_revision: Option<&ContentRevisionSnapshot>,
-    ) -> anyhow::Result<CloneDeltaReport> {
-        self.apply_clone_graph_delta_inner(max_files, None, pinned_revision)
+        self.apply_clone_graph_delta_inner(max_files, None)
     }
 
     /// [`Self::apply_clone_graph_delta`] with an explicit posting-row work budget — the test seam
@@ -122,14 +107,13 @@ impl IndexDatabase {
         max_files: usize,
         posting_row_budget: u64,
     ) -> anyhow::Result<CloneDeltaReport> {
-        self.apply_clone_graph_delta_inner(max_files, Some(posting_row_budget), None)
+        self.apply_clone_graph_delta_inner(max_files, Some(posting_row_budget))
     }
 
     fn apply_clone_graph_delta_inner(
         &self,
         max_files: usize,
         posting_row_budget: Option<u64>,
-        pinned_revision: Option<&ContentRevisionSnapshot>,
     ) -> anyhow::Result<CloneDeltaReport> {
         let started = Instant::now();
         let conn = self.storage.connection();
@@ -179,12 +163,10 @@ impl IndexDatabase {
         }
         // The digest this delta settles freshness TOWARD — compared against the live
         // generation's stamp above and written back as the new stamp below, so it MUST describe
-        // the `files` rows this delta reads. `content_revision_reusing` serves the probe's
-        // pinned digest only while the connection counters prove nothing wrote in between
-        // (see the reuse rule on that method); a stale stamp here would let a later content
-        // state that happens to equal it serve the postings fast path against edges built from
-        // different content.
-        let revision = self.content_revision_reusing(pinned_revision)?;
+        // the `files` rows this delta reads. `content_revision()` is an O(1) read of the
+        // trigger-maintained digest (#828), so it always reflects the `files` rows as committed —
+        // there is no scan to pin or reuse.
+        let revision = self.content_revision()?;
         if live.source_revision == revision {
             return Ok(CloneDeltaReport {
                 full_rebuild_owed: live.delta_files_applied >= CLONE_GRAPH_DRIFT_REBUILD_FILES,
@@ -854,7 +836,7 @@ impl<'a> CandidateHydrator<'a> {
 mod tests {
     use super::super::precompute::tests::{clone_fixture_config, edge_keys};
     use super::{
-        BTreeSet, CLONE_PRECOMPUTE_THETA, Connection, load_scoped_baseline_bags_for_paths, params,
+        BTreeSet, CLONE_PRECOMPUTE_THETA, load_scoped_baseline_bags_for_paths, params,
         sub_block_tokens,
     };
     use crate::index::query_api::clones::precompute::CloneEdgeOptions;
@@ -1472,155 +1454,6 @@ mod tests {
         assert!(
             report.posting_rows_fetched < report.posting_rows_requested,
             "shared tokens are served from the per-application cache: {report:?}"
-        );
-    }
-
-    /// The stamped `source_revision` of the live generation — what the delta compares and
-    /// re-pins, so it is the observable for whether a pinned digest was served or recomputed.
-    fn stamped_source_revision(db: &crate::IndexDatabase, generation: i64) -> String {
-        db.storage
-            .connection()
-            .query_row(
-                "SELECT source_revision FROM clone_graph_generations WHERE generation = ?1",
-                params![generation],
-                |row| row.get(0),
-            )
-            .unwrap()
-    }
-
-    /// #821 reuse leg: when NOTHING writes between the pin and the delta, the delta must serve
-    /// the pinned digest instead of recomputing. The pin carries a FABRICATED revision (the
-    /// fast path must disagree with the recompute fallback, or this test would pass through the
-    /// fallback): the only way the generation ends up stamped with it is the reuse actually
-    /// firing — a recomputing delta would see the real digest, find the generation current, and
-    /// Noop without stamping anything.
-    #[test]
-    fn clone_delta_reuses_the_probes_pinned_digest_when_nothing_wrote_in_between() {
-        let _poison = crate::index::poison_sibling::disable_poison_sibling();
-        let config = clone_fixture_config("delta-revision-reuse");
-        let db = crate::IndexDatabase::rebuild(&config).unwrap();
-        let built = db.precompute_clone_graph(None).unwrap();
-        assert_eq!(built.status, "Complete");
-
-        let before_digest = db.connection_data_version().unwrap();
-        let pinned = db
-            .pin_content_revision("fabricated-pinned-digest".to_string(), before_digest)
-            .unwrap()
-            .expect("no cross-connection commit intervened, so the pin is granted");
-        let report = db.apply_clone_graph_delta_reusing_revision(64, Some(&pinned)).unwrap();
-        // The fabricated digest reads as "revision moved, no clone-relevant path changed", so
-        // the delta re-pins the generation to it — proof the reuse path served the pin.
-        assert_eq!(report.status, "Applied", "{report:?}");
-        assert_eq!(
-            stamped_source_revision(&db, built.generation),
-            "fabricated-pinned-digest",
-            "an intact pin is served verbatim"
-        );
-    }
-
-    /// #821 invalidation leg, own connection: a `files` write AFTER the pin (in the watcher
-    /// pass, the base reconcile runs between the quiet-gate probe and this delta) voids the pin
-    /// — the delta must recompute rather than compare/stamp a digest that no longer describes
-    /// the rows it reads. The pin again carries a fabricated revision so unconditional reuse
-    /// cannot hide behind a correct answer: if the stale pin were served, the generation would
-    /// be stamped `fabricated-stale-digest`.
-    #[test]
-    fn clone_delta_recomputes_when_this_connection_writes_after_the_pin() {
-        let _poison = crate::index::poison_sibling::disable_poison_sibling();
-        let config = clone_fixture_config("delta-revision-stale-own");
-        let db = crate::IndexDatabase::rebuild(&config).unwrap();
-        let built = db.precompute_clone_graph(None).unwrap();
-        assert_eq!(built.status, "Complete");
-
-        let before_digest = db.connection_data_version().unwrap();
-        let pinned = db
-            .pin_content_revision("fabricated-stale-digest".to_string(), before_digest)
-            .unwrap()
-            .expect("no cross-connection commit intervened, so the pin is granted");
-        // The simulated mid-pass mutation: a files-row write on the SAME connection.
-        db.storage
-            .connection()
-            .execute("UPDATE main.files SET sha256 = sha256 || '-moved' WHERE path = 'src/a.rs'", [
-            ])
-            .unwrap();
-
-        let report = db.apply_clone_graph_delta_reusing_revision(64, Some(&pinned)).unwrap();
-        assert_eq!(report.status, "Applied", "{report:?}");
-        let stamped = stamped_source_revision(&db, built.generation);
-        assert_ne!(stamped, "fabricated-stale-digest", "a stale pin must not be served");
-        assert_eq!(
-            stamped,
-            db.content_revision().unwrap(),
-            "the delta recomputed the digest for the mutated files table"
-        );
-    }
-
-    /// #821 invalidation leg, cross-connection: the database file is shared across processes
-    /// (and, consolidated, across repos — `content_revision()` is GLOBAL), so a commit by
-    /// ANOTHER connection after the pin must also void it, even though this connection wrote
-    /// nothing.
-    #[test]
-    fn clone_delta_recomputes_when_another_connection_writes_after_the_pin() {
-        let _poison = crate::index::poison_sibling::disable_poison_sibling();
-        let config = clone_fixture_config("delta-revision-stale-other");
-        let db = crate::IndexDatabase::rebuild(&config).unwrap();
-        let built = db.precompute_clone_graph(None).unwrap();
-        assert_eq!(built.status, "Complete");
-
-        let before_digest = db.connection_data_version().unwrap();
-        let pinned = db
-            .pin_content_revision("fabricated-stale-digest".to_string(), before_digest)
-            .unwrap()
-            .expect("no cross-connection commit intervened, so the pin is granted");
-        // The simulated concurrent writer: a files-row write through a SECOND connection.
-        let other = Connection::open(&config.database).unwrap();
-        other.busy_timeout(std::time::Duration::from_secs(5)).unwrap();
-        other
-            .execute("UPDATE files SET sha256 = sha256 || '-moved' WHERE path = 'src/a.rs'", [])
-            .unwrap();
-        drop(other);
-
-        let report = db.apply_clone_graph_delta_reusing_revision(64, Some(&pinned)).unwrap();
-        assert_eq!(report.status, "Applied", "{report:?}");
-        let stamped = stamped_source_revision(&db, built.generation);
-        assert_ne!(stamped, "fabricated-stale-digest", "a stale pin must not be served");
-        assert_eq!(
-            stamped,
-            db.content_revision().unwrap(),
-            "the delta recomputed the digest after the cross-connection write"
-        );
-    }
-
-    /// #821 TOCTOU bracket: a cross-connection commit landing BETWEEN the digest computation and
-    /// the pin capture must refuse the pin outright. Without the pre-digest `data_version`
-    /// bracket, the pin would carry the NEW data_version with a digest of the OLD rows — and a
-    /// later no-write window would validate the mismatch and serve the stale digest.
-    #[test]
-    fn pin_is_refused_when_another_connection_commits_during_the_digest() {
-        let _poison = crate::index::poison_sibling::disable_poison_sibling();
-        let config = clone_fixture_config("delta-pin-toctou");
-        let db = crate::IndexDatabase::rebuild(&config).unwrap();
-
-        // The interleaving: guard captured, then another connection commits before the pin.
-        let before_digest = db.connection_data_version().unwrap();
-        let other = Connection::open(&config.database).unwrap();
-        other.busy_timeout(std::time::Duration::from_secs(5)).unwrap();
-        other
-            .execute("UPDATE files SET sha256 = sha256 || '-moved' WHERE path = 'src/a.rs'", [])
-            .unwrap();
-        drop(other);
-        assert!(
-            db.pin_content_revision("digest-of-the-old-rows".to_string(), before_digest)
-                .unwrap()
-                .is_none(),
-            "a commit inside the digest window refuses the pin"
-        );
-
-        // Control: with no interleaved commit the same bracket grants the pin.
-        let before_digest = db.connection_data_version().unwrap();
-        assert!(
-            db.pin_content_revision("digest".to_string(), before_digest).unwrap().is_some(),
-            "an undisturbed window grants the pin"
         );
     }
 }

--- a/crates/rag-rat-core/src/index/query_api/clones/of_text.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/of_text.rs
@@ -1107,6 +1107,10 @@ mod tests {
         // matches the postings' anchor sha (2nd WAL connection; the index handle is idle).
         {
             let c = rusqlite::Connection::open(&db_path).unwrap();
+            // A `files` writer must carry the #828 content-digest fold (a real external writer
+            // registers it via `IndexConnection::setup`); this bare 2nd connection registers it
+            // explicitly so the triggers resolve.
+            rag_rat_db::content_digest::register_content_digest_fold(&c).unwrap();
             c.execute("UPDATE files SET sha256 = 'stale-not-matching-any-posting'", []).unwrap();
         }
         let stale = corpus.near_candidate_bags(conn, &probe, "rust").unwrap();
@@ -1127,6 +1131,8 @@ mod tests {
         // A content edit since the build → source_revision drift → NOT eligible (review R1).
         {
             let c = rusqlite::Connection::open(&db_path).unwrap();
+            // A 2nd-connection `files` writer must carry the #828 fold (see the note above).
+            rag_rat_db::content_digest::register_content_digest_fold(&c).unwrap();
             c.execute("UPDATE files SET sha256 = 'drift-' || sha256", []).unwrap();
         }
         assert!(

--- a/crates/rag-rat-core/src/index/query_api/clones/precompute.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/precompute.rs
@@ -30,7 +30,7 @@ use super::substrate::{
     SymbolBag, load_clone_df_epoch, load_scoped_baseline_bags_with_df, overlap, sub_block_tokens,
     verified_clone,
 };
-use crate::index::{ContentRevisionSnapshot, IndexDatabase};
+use crate::index::IndexDatabase;
 
 /// θ the graph is precomputed at — the default `find_clones` threshold. Queries at θ ≥ this read
 /// the stored edges (filtering the exact gate inputs); θ below falls back to the live path.
@@ -42,17 +42,6 @@ const DEFAULT_BATCH_SIZE: usize = 512;
 /// observation and when it was first observed (epoch ms).
 const CLONE_GRAPH_QUIET_REVISION_META: &str = "clone_graph_quiet_candidate_revision";
 const CLONE_GRAPH_QUIET_SINCE_META: &str = "clone_graph_quiet_candidate_since_ms";
-
-/// One #472 quiet-gate probe outcome (#821): whether the deferred FULL rebuild is due, plus the
-/// content digest the probe computed — pinned to the connection state — so the SAME pass's clone
-/// delta can reuse it instead of paying the `main.files` digest scan again. `revision` is `None`
-/// when the gate short-circuited without probing (nothing armed, no probe permission) or the
-/// probe errored ([`Default`] is the caller's error fallback).
-#[derive(Debug, Default)]
-pub(crate) struct CloneGraphRebuildProbe {
-    pub(crate) due: bool,
-    pub(crate) revision: Option<ContentRevisionSnapshot>,
-}
 
 /// Soft per-pass budget + checkpoint granularity for one
 /// [`IndexDatabase::reconcile_clone_edges_pass`].
@@ -218,52 +207,28 @@ impl IndexDatabase {
         quiet_ms: i64,
         probe_without_candidate: bool,
     ) -> anyhow::Result<bool> {
-        Ok(self.clone_graph_rebuild_probe(quiet_ms, probe_without_candidate)?.due)
+        self.clone_graph_rebuild_due_at(now_ms(), quiet_ms, probe_without_candidate)
     }
 
-    /// [`Self::clone_graph_rebuild_due`] returning the probe's full outcome (#821): the due
-    /// verdict PLUS the content digest the probe computed, pinned to the connection state, so
-    /// the same pass's clone delta can reuse the digest instead of re-scanning `main.files` —
-    /// see [`Self::apply_clone_graph_delta_reusing_revision`].
-    pub(crate) fn clone_graph_rebuild_probe(
-        &self,
-        quiet_ms: i64,
-        probe_without_candidate: bool,
-    ) -> anyhow::Result<CloneGraphRebuildProbe> {
-        self.clone_graph_rebuild_probe_at(now_ms(), quiet_ms, probe_without_candidate)
-    }
-
-    /// [`Self::clone_graph_rebuild_due`] with the clock injected (tests).
-    #[cfg(test)]
+    /// [`Self::clone_graph_rebuild_due`] with the clock injected.
+    ///
+    /// "Owed" here means a FULL rebuild: the graph is stale in a way the #473 delta can't settle
+    /// (absent / normalizer bump / postings gap), OR the live generation has absorbed enough
+    /// delta files ([`CLONE_GRAPH_DRIFT_REBUILD_FILES`]) that its frozen df epoch owes a refresh.
+    /// A merely revision-stale-but-delta-eligible graph also arms here — if the delta settles it
+    /// first, the next probe sees it current and disarms. `content_revision()` is now an O(1) read
+    /// (#828), so the probe and the same pass's clone delta each recompute it freely — no pinned
+    /// digest is threaded between them.
     pub(crate) fn clone_graph_rebuild_due_at(
         &self,
         now_ms: i64,
         quiet_ms: i64,
         probe_without_candidate: bool,
     ) -> anyhow::Result<bool> {
-        Ok(self.clone_graph_rebuild_probe_at(now_ms, quiet_ms, probe_without_candidate)?.due)
-    }
-
-    /// [`Self::clone_graph_rebuild_probe`] with the clock injected.
-    ///
-    /// "Owed" here means a FULL rebuild: the graph is stale in a way the #473 delta can't settle
-    /// (absent / normalizer bump / postings gap), OR the live generation has absorbed enough
-    /// delta files ([`CLONE_GRAPH_DRIFT_REBUILD_FILES`]) that its frozen df epoch owes a refresh.
-    /// A merely revision-stale-but-delta-eligible graph also arms here — if the delta settles it
-    /// first, the next probe sees it current and disarms.
-    fn clone_graph_rebuild_probe_at(
-        &self,
-        now_ms: i64,
-        quiet_ms: i64,
-        probe_without_candidate: bool,
-    ) -> anyhow::Result<CloneGraphRebuildProbe> {
         let candidate = self.clone_graph_quiet_candidate()?;
         if candidate.is_none() && !probe_without_candidate {
-            return Ok(CloneGraphRebuildProbe::default());
+            return Ok(false);
         }
-        // Captured BEFORE the digest: brackets it against a cross-connection commit landing
-        // between the digest read and the pin capture (see `pin_content_revision`).
-        let data_version_before_digest = self.connection_data_version()?;
         let revision = self.content_revision()?;
         let drifted = {
             let conn = self.storage.connection();
@@ -288,13 +253,7 @@ impl IndexDatabase {
                 },
             }
         };
-        // Pin AFTER the gate's own bookkeeping writes (arming or clearing the quiet candidate):
-        // those touch repo_meta only, never `files`, but they bump `total_changes()` — pinning
-        // before them would make the reuse check read the probe's own writes as an intervening
-        // mutation and never fire. The pre-digest `data_version` bracket still guards the whole
-        // window against other connections.
-        let revision = self.pin_content_revision(revision, data_version_before_digest)?;
-        Ok(CloneGraphRebuildProbe { due, revision })
+        Ok(due)
     }
 
     /// Whether the #472 quiet gate holds an armed candidate. Watch-level tests assert the #817

--- a/crates/rag-rat-core/src/index/query_api/gc.rs
+++ b/crates/rag-rat-core/src/index/query_api/gc.rs
@@ -41,7 +41,13 @@ impl IndexDatabase {
         live_commits.dedup();
         live_worktrees.sort();
         live_worktrees.dedup();
-        self.prune_to_live(&live_commits, &live_worktrees)
+        let report = self.prune_to_live(&live_commits, &live_worktrees)?;
+        // #828 §9.1: gc runs under the write flock every GC_EVERY_PASSES passes — the low-cadence
+        // home for the content-digest parity self-check. It recomputes the digest from scan and, on
+        // the (fail-closed-so-unexpected) mismatch a trigger/migration regression would cause,
+        // reseeds `content_digest_state` in place. Deliberately does NOT re-stamp fts/clone stamps.
+        self.verify_content_digest_parity()?;
+        Ok(report)
     }
 
     /// Prune file rows (and their derived rows) whose `commit_sha` and `worktree_id` are both

--- a/crates/rag-rat-core/src/index/query_api/mod.rs
+++ b/crates/rag-rat-core/src/index/query_api/mod.rs
@@ -646,6 +646,11 @@ impl IndexDatabase {
             report.healed_files += 1;
         }
 
+        // #828 §9.1: heal is the explicit operator remedy — verify the content-digest parity and
+        // reseed `content_digest_state` on drift BEFORE the FTS freshness pass below, so
+        // `ensure_fts_fresh` compares against a healed digest rather than a drifted one.
+        self.verify_content_digest_parity()?;
+
         // Probe for FTS shadow corruption BEFORE the freshness pass (#582): a dirty-flagged
         // index would otherwise be incidentally repaired by `ensure_fts_fresh`'s rebuild and the
         // report would under-attribute what was actually corrupt.

--- a/crates/rag-rat-core/src/index/rebuild.rs
+++ b/crates/rag-rat-core/src/index/rebuild.rs
@@ -345,6 +345,12 @@ impl IndexDatabase {
         // restore only leaves the coarser cadence behind.
         let _ = db.storage.execute_batch("PRAGMA wal_autocheckpoint = 0;");
         result?;
+        // #828 §9.1: the sanctioned full rebuild is a reseed by definition — the
+        // `files_content_digest_*` triggers maintained `content_digest_state` through every staged
+        // wave and the terminal flip, so verify parity here and reseed in place if a trigger/seam
+        // regression drifted it. Unconditional (unlike gc's cadence) because a full rebuild is the
+        // authoritative freshness baseline.
+        db.verify_content_digest_parity()?;
         // Poison-sibling test harness (compiled out of production): after the rebuild flips,
         // register a second `poison-sibling` repo with tripwire rows in every repo-scoped
         // table, so any unscoped read/count/delete downstream trips an EXISTING test.

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/content_digest.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/content_digest.rs
@@ -1,0 +1,418 @@
+//! #828 — the incrementally-maintained `content_revision` digest: schema tip, trigger contract,
+//! seam parity, multiset semantics, the fast-path-disagrees poison pin, fail-closed skew, and the
+//! migration re-stamp. The raw-schema tests drive `main.files` directly (fast, isolates the
+//! trigger mechanics against the full ladder's `files` shape); the real-`IndexDatabase` tests drive
+//! the production seams (rebuild, gc) end to end.
+
+use rag_rat_db::content_digest::{content_row_hash, encode_state, fold_row};
+
+use super::*;
+
+// ---- raw-schema helpers (in-memory, full ladder) ----
+
+fn apply_schema() -> rusqlite::Connection {
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    rag_rat_db::schema::apply(&conn, &crate::index::migration_hooks()).unwrap();
+    conn
+}
+
+fn insert_file(conn: &rusqlite::Connection, path: &str, sha: &str, kind: &str, generation: i64) {
+    conn.execute(
+        "INSERT INTO main.files(path, language, kind, sha256, modified_at_ms, indexed_at_ms, \
+         commit_sha, worktree_id, repo_id, generation)
+         VALUES (?1, 'rust', ?2, ?3, 0, 0, '', '', 'r', ?4)",
+        rusqlite::params![path, kind, sha, generation],
+    )
+    .unwrap();
+}
+
+/// The independent from-scratch fold the triggers must always agree with.
+fn digest_scan(conn: &rusqlite::Connection) -> (String, i64) {
+    let mut state = [0u64; 4];
+    let mut count = 0i64;
+    let mut stmt =
+        conn.prepare("SELECT path, sha256 FROM main.files WHERE kind != 'deleted'").unwrap();
+    let mut rows = stmt.query([]).unwrap();
+    while let Some(row) = rows.next().unwrap() {
+        let path: String = row.get(0).unwrap();
+        let sha256: String = row.get(1).unwrap();
+        fold_row(&mut state, &content_row_hash(&path, &sha256), true);
+        count += 1;
+    }
+    (encode_state(&state), count)
+}
+
+fn digest_stored(conn: &rusqlite::Connection) -> (String, i64) {
+    conn.query_row("SELECT state, rows_folded FROM content_digest_state WHERE id = 1", [], |r| {
+        Ok((r.get(0)?, r.get(1)?))
+    })
+    .unwrap()
+}
+
+fn assert_trigger_parity(conn: &rusqlite::Connection) {
+    assert_eq!(
+        digest_stored(conn),
+        digest_scan(conn),
+        "trigger-maintained content_digest_state must equal a from-scratch scan fold"
+    );
+}
+
+fn object_exists(conn: &rusqlite::Connection, kind: &str, name: &str) -> bool {
+    conn.query_row(
+        "SELECT COUNT(*) FROM sqlite_master WHERE type = ?1 AND name = ?2",
+        rusqlite::params![kind, name],
+        |r| r.get::<_, i64>(0),
+    )
+    .unwrap()
+        > 0
+}
+
+const FOLD_TRIGGERS: [&str; 3] =
+    ["files_content_digest_ai", "files_content_digest_ad", "files_content_digest_au"];
+
+// ---- schema tip + trigger contract ----
+
+/// The absolute schema-tip pin lives on the newest migration's test (moved here from V085). V086
+/// creates `content_digest_state` (seeded empty on a fresh ladder) and the three fold triggers.
+#[test]
+fn content_digest_state_is_the_tip_with_live_fold_triggers() {
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 86, "move this pin with the next schema migration");
+    let conn = apply_schema();
+    assert_eq!(schema::status(&conn).unwrap().current_version, schema::LATEST_SCHEMA_VERSION);
+
+    let (state, rows) = digest_stored(&conn);
+    assert_eq!(state, "0".repeat(64), "a fresh empty corpus seeds the all-zero state");
+    assert_eq!(rows, 0);
+    for trigger in FOLD_TRIGGERS {
+        assert!(object_exists(&conn, "trigger", trigger), "{trigger} exists after the full ladder");
+    }
+}
+
+/// §8/§9.2(4) recreation contract: a `files`-table REBUILD (the V040/V043 create/copy/drop/rename
+/// pattern) silently drops the row triggers — the tripwire that pins why a future rebuild migration
+/// MUST call `ensure_content_digest` again.
+#[test]
+fn a_files_table_rebuild_drops_the_fold_triggers_and_ensure_recreates_them() {
+    let conn = apply_schema();
+    insert_file(&conn, "a.rs", "aa", "source", 1);
+    for trigger in FOLD_TRIGGERS {
+        assert!(object_exists(&conn, "trigger", trigger));
+    }
+
+    // V040-style rebuild. `DROP TABLE files` fires no row triggers but drops the triggers ON it.
+    conn.execute_batch(
+        "PRAGMA foreign_keys = OFF;
+         CREATE TABLE files_new AS SELECT * FROM files;
+         DROP TABLE files;
+         ALTER TABLE files_new RENAME TO files;",
+    )
+    .unwrap();
+    for trigger in FOLD_TRIGGERS {
+        assert!(
+            !object_exists(&conn, "trigger", trigger),
+            "{trigger} is dropped by a files-table rebuild — the hazard the contract addresses"
+        );
+    }
+
+    // The shared helper a rebuild migration must call restores them.
+    rag_rat_db::content_digest::ensure_content_digest(&conn).unwrap();
+    for trigger in FOLD_TRIGGERS {
+        assert!(object_exists(&conn, "trigger", trigger), "{trigger} recreated by ensure");
+    }
+}
+
+// ---- seam parity + multiset semantics (raw schema) ----
+
+#[test]
+fn triggers_hold_parity_through_insert_tombstone_flip_delete_and_purge() {
+    let conn = apply_schema();
+    insert_file(&conn, "a.rs", "aa", "source", 1);
+    insert_file(&conn, "b.rs", "bb", "docs", 1);
+    assert_trigger_parity(&conn);
+    assert_eq!(digest_stored(&conn).1, 2);
+
+    // Tombstone insert (seam #2 insert arm) is excluded.
+    insert_file(&conn, "c.rs", "", "deleted", 1);
+    assert_trigger_parity(&conn);
+    assert_eq!(digest_stored(&conn).1, 2);
+
+    // sha change (incremental reindex ≈ delete+reinsert).
+    conn.execute("UPDATE main.files SET sha256 = 'aa2' WHERE path = 'a.rs'", []).unwrap();
+    assert_trigger_parity(&conn);
+
+    // Tombstone flip both arms (seam #2 upsert DO UPDATE): source -> deleted -> source.
+    conn.execute("UPDATE main.files SET kind = 'deleted', sha256 = '' WHERE path = 'b.rs'", [])
+        .unwrap();
+    assert_trigger_parity(&conn);
+    assert_eq!(digest_stored(&conn).1, 1);
+    conn.execute("UPDATE main.files SET kind = 'docs', sha256 = 'bb3' WHERE path = 'b.rs'", [])
+        .unwrap();
+    assert_trigger_parity(&conn);
+    assert_eq!(digest_stored(&conn).1, 2);
+
+    // generated-flag flip (seam #5) is digest-neutral (UPDATE OF path,sha256,kind skips it).
+    let before = digest_stored(&conn);
+    conn.execute("UPDATE main.files SET generated = 1 WHERE path = 'a.rs'", []).unwrap();
+    assert_eq!(digest_stored(&conn), before, "a generated-flag flip does not touch the digest");
+    assert_trigger_parity(&conn);
+
+    // Delete a real row (seam #3), then delete a tombstone (digest-neutral).
+    conn.execute("DELETE FROM main.files WHERE path = 'a.rs'", []).unwrap();
+    assert_trigger_parity(&conn);
+    conn.execute("DELETE FROM main.files WHERE path = 'c.rs'", []).unwrap();
+    assert_trigger_parity(&conn);
+
+    // The rag-rat-db dynamic purge sweep (seam #9) — the seam a Rust-seam design would miss.
+    rag_rat_db::schema::purge_repo_rows(&conn, "r").unwrap();
+    assert_trigger_parity(&conn);
+    assert_eq!(digest_stored(&conn).1, 0, "purging the repo removes every member");
+    assert_eq!(digest_stored(&conn).0, "0".repeat(64));
+}
+
+/// Multiset pins: two identical `(path, sha256)` rows at different generations do NOT cancel (the
+/// XOR-regression pin) and add+remove of the same pair returns exactly to the prior value (the
+/// counter/content-stability pin). Digest is invariant under insert order / rowid.
+#[test]
+fn digest_is_a_multiset_not_a_set_and_is_order_invariant() {
+    let conn = apply_schema();
+    insert_file(&conn, "dup.rs", "same", "source", 1);
+    let one = digest_stored(&conn);
+
+    // A second identical (path, sha256) row at a different generation (the staged-rebuild shape).
+    insert_file(&conn, "dup.rs", "same", "source", 2);
+    let two = digest_stored(&conn);
+    assert_ne!(two, one, "a duplicate pair moves the digest (XOR would cancel it to the prior)");
+    assert_ne!(two.0, "0".repeat(64), "two identical rows are NOT the empty state (XOR pin)");
+    assert_trigger_parity(&conn);
+
+    // Remove the duplicate: back to the single-copy digest exactly.
+    conn.execute("DELETE FROM main.files WHERE path = 'dup.rs' AND generation = 2", []).unwrap();
+    assert_eq!(digest_stored(&conn), one, "add+remove of the same pair is a no-op on the digest");
+
+    // Order / rowid invariance: a second DB inserting the same multiset in the opposite order and
+    // at different rowids lands on the identical digest.
+    let other = apply_schema();
+    insert_file(&other, "z.rs", "zz", "source", 7);
+    insert_file(&other, "a.rs", "aa", "source", 3);
+    let reverse = apply_schema();
+    insert_file(&reverse, "a.rs", "aa", "source", 9);
+    insert_file(&reverse, "z.rs", "zz", "source", 4);
+    assert_eq!(
+        digest_stored(&other).0,
+        digest_stored(&reverse).0,
+        "identical row multisets give identical digests regardless of order/rowid/generation"
+    );
+}
+
+/// §9.2(5) fail-closed skew: a `files` write on a connection WITHOUT the fold registered errors
+/// loudly and rolls back, so version skew cannot silently drift the digest. (The db-level test
+/// covers this against the minimal table; this one is against the full ladder.)
+#[test]
+fn a_files_write_without_the_fold_function_fails_closed() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("skew.sqlite");
+    {
+        let setup = rag_rat_db::storage::IndexConnection::open(&path).unwrap();
+        rag_rat_db::schema::apply(setup.connection(), &crate::index::migration_hooks()).unwrap();
+    }
+    // A bare connection that never registered the fold: the delete/insert trigger's function
+    // reference is unresolved.
+    let unregistered = rusqlite::Connection::open(&path).unwrap();
+    // Full column set, so the only thing that can fail is the trigger's unresolved function (the
+    // trigger program is compiled at statement-prepare, before NOT NULL checks).
+    let err = unregistered
+        .execute(
+            "INSERT INTO files(path, language, kind, sha256, modified_at_ms, indexed_at_ms, \
+             commit_sha, worktree_id, repo_id, generation)
+             VALUES ('a.rs', 'rust', 'source', 'aa', 0, 0, '', '', 'r', 1)",
+            [],
+        )
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("no such function"),
+        "an unregistered writer must fail closed, got: {err}"
+    );
+    let count: i64 = unregistered
+        .query_row("SELECT rows_folded FROM content_digest_state WHERE id = 1", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(count, 0, "the rolled-back INSERT left the digest untouched");
+}
+
+// ---- real IndexDatabase seams (rebuild / gc / poison / migration re-stamp) ----
+
+/// Build a tiny committed git repo and return its config (the base for the real-DB seam tests).
+fn digest_repo_config(tag: &str) -> (PathBuf, Config) {
+    let root = unique_temp_root().join(tag);
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), "pub fn a() {}\n").unwrap();
+    init_git_repo(&root);
+    run_git(&root, &["add", "."]);
+    run_git(&root, &["commit", "-q", "-m", "init"]);
+    let config = source_config(root.clone(), Language::Rust);
+    (root, config)
+}
+
+#[test]
+fn content_revision_is_content_stable_across_rebuilds_and_moves_on_edits() {
+    let _poison = crate::index::poison_sibling::disable_poison_sibling();
+    let (root, config) = digest_repo_config("digest-stable");
+
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let d1 = db.content_revision().unwrap();
+    assert!(d1.starts_with("ms1-"), "rendered digest is ms1-prefixed: {d1}");
+    assert_eq!(d1, db.content_revision_from_scan().unwrap(), "O(1) read == from-scratch scan");
+    drop(db);
+
+    // Content-identical rebuild: mid-window the staged generation and the still-live old one
+    // double the multiset (the digest correctly reflects that — a full-table scan does too), so
+    // the stability property is asserted AFTER gc sweeps the dead generation. Once swept, the
+    // byte-identical corpus lands back on the exact prior digest (the counter-regression pin — a
+    // version counter would bump on every rebuild and spuriously invalidate FTS/clone stamps).
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    // gc runs the DeadGeneration + DeadContext sweeps and the parity self-check; parity holds
+    // throughout.
+    assert_eq!(db.content_revision().unwrap(), db.content_revision_from_scan().unwrap());
+    db.garbage_collect().unwrap();
+    assert_eq!(db.content_revision().unwrap(), db.content_revision_from_scan().unwrap());
+    assert_eq!(
+        db.content_revision().unwrap(),
+        d1,
+        "after gc sweeps the dead generation, a content-identical rebuild is digest-stable"
+    );
+    drop(db);
+
+    // A content edit moves the digest.
+    fs::write(root.join("src/lib.rs"), "pub fn a() -> u8 { 1 }\n").unwrap();
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let d2 = db.content_revision().unwrap();
+    assert_ne!(d2, d1, "a content edit moves the digest");
+    assert_eq!(d2, db.content_revision_from_scan().unwrap());
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+/// The repo's fast-path-disagrees-with-fallback pin (§9.2(3)): poison the O(1) state and assert
+/// `content_revision()` returns the POISON (proving it reads the state, not the scan), then the
+/// parity self-check heals it in place.
+#[test]
+fn poisoned_state_is_read_verbatim_then_parity_heals() {
+    let _poison = crate::index::poison_sibling::disable_poison_sibling();
+    let (root, config) = digest_repo_config("digest-poison");
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let real = db.content_revision().unwrap();
+
+    // A valid-format but WRONG state (a scan would never produce it).
+    let poison = "1".repeat(64);
+    db.storage
+        .connection()
+        .execute("UPDATE content_digest_state SET state = ?1 WHERE id = 1", [&poison])
+        .unwrap();
+    assert_eq!(
+        db.content_revision().unwrap(),
+        format!("ms1-{poison}"),
+        "content_revision() returns the poisoned state — proving the O(1) read, not the scan"
+    );
+    assert_ne!(db.content_revision().unwrap(), real);
+
+    db.verify_content_digest_parity().unwrap();
+    assert_eq!(db.content_revision().unwrap(), real, "parity reseeded the drifted state");
+    assert_eq!(db.content_revision().unwrap(), db.content_revision_from_scan().unwrap());
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+/// §9.2(6) migration re-stamp: a stamp equal to the FROZEN legacy digest is pointed at the new
+/// rendered digest (no first-use FTS/clone rebuild); a stamp that was already stale is left for the
+/// normal freshness machinery. Driven on a raw connection (no scoped temp `files` view — the shape
+/// the migration actually runs under) by re-running the idempotent applier.
+#[test]
+fn migration_restamps_fresh_legacy_stamps_but_leaves_stale_ones() {
+    let conn = apply_schema();
+    // repo_meta.repo_id REFERENCES repos (files.repo_id does not), so register the repo before
+    // arming a quiet candidate for it.
+    conn.execute(
+        "INSERT OR IGNORE INTO repos(repo_id, display_name, registered_at_ms) VALUES ('r', '', 0)",
+        [],
+    )
+    .unwrap();
+    insert_file(&conn, "a.rs", "aa", "source", 1);
+    insert_file(&conn, "b.rs", "bb", "source", 1);
+
+    // The frozen pre-#828 legacy digest over the current corpus.
+    let legacy_concat: String = conn
+        .query_row(
+            "SELECT COALESCE(group_concat(pv, ','), '') FROM (SELECT path || ':' || sha256 AS pv \
+             FROM main.files WHERE kind != 'deleted' ORDER BY path)",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    let legacy = rag_rat_base::hash::hex_sha256(legacy_concat.as_bytes());
+    // The new rendered digest the applier seeds/stamps: "ms1-" + the from-scratch scan state.
+    let new_digest = format!("ms1-{}", digest_scan(&conn).0);
+
+    // Simulate a pre-#828 store: FRESH stamps sit at the legacy digest (a clone generation and an
+    // armed quiet candidate too); plus deliberately STALE controls that must NOT be re-stamped.
+    conn.execute(
+        "INSERT OR REPLACE INTO index_meta(key, value) VALUES ('fts_source_revision', ?1)",
+        [&legacy],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT OR REPLACE INTO index_meta(key, value) VALUES ('content_revision', ?1)",
+        [&legacy],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO clone_graph_generations(generation, status, theta_floor, normalizer_kind, \
+         normalizer_version, source_revision, started_at_ms)
+         VALUES (990, 'Complete', 0.7, 'baseline', 1, ?1, 0)",
+        [&legacy],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO clone_graph_generations(generation, status, theta_floor, normalizer_kind, \
+         normalizer_version, source_revision, started_at_ms)
+         VALUES (991, 'Complete', 0.7, 'baseline', 1, 'already-stale-rev', 0)",
+        [],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT OR REPLACE INTO repo_meta(repo_id, key, value)
+         VALUES ('r', 'clone_graph_quiet_candidate_revision', ?1)",
+        [&legacy],
+    )
+    .unwrap();
+
+    // Re-run the applier (idempotent): re-seeds (files unchanged) and re-stamps legacy -> new.
+    rag_rat_db::schema::apply_content_digest_state(&conn).unwrap();
+
+    let meta = |key: &str| -> String {
+        conn.query_row("SELECT value FROM index_meta WHERE key = ?1", [key], |r| r.get(0)).unwrap()
+    };
+    assert_eq!(meta("fts_source_revision"), new_digest, "a fresh legacy FTS stamp is re-stamped");
+    assert_eq!(meta("content_revision"), new_digest, "the stored content_revision is re-stamped");
+    let gen_rev = |g: i64| -> String {
+        conn.query_row(
+            "SELECT source_revision FROM clone_graph_generations WHERE generation = ?1",
+            [g],
+            |r| r.get(0),
+        )
+        .unwrap()
+    };
+    assert_eq!(gen_rev(990), new_digest, "a clone generation at the legacy digest is re-stamped");
+    assert_eq!(
+        gen_rev(991),
+        "already-stale-rev",
+        "an already-stale stamp is left for the freshness machinery"
+    );
+    let quiet: String = conn
+        .query_row(
+            "SELECT value FROM repo_meta WHERE key = 'clone_graph_quiet_candidate_revision'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(quiet, new_digest, "the armed quiet-window candidate survives the upgrade");
+}

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/mod.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/mod.rs
@@ -935,6 +935,7 @@ fn fingerprinted_symbol_id_for_ref(db: &IndexDatabase, qualified_name: &str) -> 
 mod change_coupling;
 mod chunk_store_migrations;
 mod clones;
+mod content_digest;
 mod dir_memory_tree;
 mod dispatch;
 mod embedding_policy_fast_path;

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_memory.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_memory.rs
@@ -7219,6 +7219,9 @@ fn a_rebuild_carrying_overlays_defers_the_key_version_stamp() {
     // Once the overlay rows are gone, the next rebuild's corpus is exactly what it re-parses.
     {
         let conn = rusqlite::Connection::open(&config.database).unwrap();
+        // A bare `files` writer must carry the #828 content-digest fold so the delete trigger
+        // resolves (a real writer registers it via `IndexConnection::setup`).
+        rag_rat_db::content_digest::register_content_digest_fold(&conn).unwrap();
         conn.execute_batch("PRAGMA foreign_keys = OFF;").unwrap();
         conn.execute("DELETE FROM files WHERE commit_sha = ''", []).unwrap();
     }

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
@@ -3849,11 +3849,10 @@ fn migration_084_links_chunks_to_symbols() {
 }
 
 /// V085 adds sync provenance (`origin`) to the read tables + edge tombstones (`present`) to the
-/// content-edge projection, and is the schema tip.
+/// content-edge projection. The absolute schema-tip pin lives on the newest migration's test
+/// (V086, `content_digest_state_is_the_tip_with_live_fold_triggers`).
 #[test]
-fn migration_085_is_the_tip_and_adds_origin_and_edge_present() {
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 85, "move this pin with the next schema migration");
-
+fn migration_085_adds_origin_and_edge_present() {
     // Bare pre-V085 tables (no origin / present), each with a pre-existing row, so the migration is
     // asserted against its OWN precondition — not the full ladder's end state.
     let legacy = rusqlite::Connection::open_in_memory().unwrap();

--- a/crates/rag-rat-core/src/watch/pass.rs
+++ b/crates/rag-rat-core/src/watch/pass.rs
@@ -384,19 +384,19 @@ fn run_pass(
     // for a gc pass. Probe permission is "the base tail already runs" — including a startup
     // embedding-backlog tail, which doesn't flip `base_tail_forced` — so every base-tail pass can
     // at least ARM an unarmed pending graph. Overlay-only passes deliberately carry NO permission
-    // (#817): overlay churn never moves `content_revision()` (it digests base files only), so an
-    // unarmed probe there could only re-observe the same base staleness while paying the
-    // corpus-scale revision digest every pass. An unarmed pending graph therefore rides overlay
-    // churn until a content, gc, or backlog pass arms it; an ALREADY-ARMED candidate still probes
-    // on every pass — candidate presence bypasses the permission — so a quiet-elapsed owed
-    // rebuild lands even mid-churn. When nothing is armed and nothing grants permission the gate
-    // costs one meta read. When it DOES probe, the probe hands back the content digest it
-    // computed (pinned to the connection state) so the clone delta below can reuse it instead of
-    // paying the corpus-scale `main.files` digest a second time this pass (#821).
-    let clone_probe = db
-        .clone_graph_rebuild_probe(CLONE_GRAPH_QUIET_MS, base_tail_forced || base_embedding_backlog)
-        .unwrap_or_default();
-    let clone_graph_due = clone_probe.due;
+    // (#817): overlay file rows ARE ordinary `main.files` rows, so an overlay edit that changes a
+    // row's sha256 DOES move the GLOBAL `content_revision()` (correctly — overlay chunks live in
+    // the one global `chunk_fts`). But an overlay-only pass skips the whole base tail
+    // (`run_base_tail` below), so arming a quiet candidate there would only queue a base rebuild
+    // this pass will not run; an unarmed pending graph therefore rides overlay churn until a
+    // content, gc, or backlog pass arms it. An ALREADY-ARMED candidate still probes on every pass —
+    // candidate presence bypasses the permission — so a quiet-elapsed owed rebuild lands even
+    // mid-churn. `content_revision()` is now an O(1) state read (#828), so the probe here and the
+    // clone delta below each recompute it freely; when nothing is armed and nothing grants
+    // permission the gate costs one meta read.
+    let clone_graph_due = db
+        .clone_graph_rebuild_due(CLONE_GRAPH_QUIET_MS, base_tail_forced || base_embedding_backlog)
+        .unwrap_or(false);
     // Idle backstop (issue #63, facet 2): when the sweep changed nothing, skip everything past
     // discovery — an idle server should do no work. `run_gc` (every GC_EVERY_PASSES) still forces
     // a full tail, so the cases that DON'T flip content_changed are still caught within that
@@ -406,12 +406,13 @@ fn run_pass(
     // discover that marked base reconcile owed, and an already-indexed base embedding backlog
     // left by a time-capped or blocked prior pass.
     // Overlay changes do NOT force the base tail (#817): the overlay stage above already
-    // reconciled a changed overlay's embeddings inline, and every base stage keys off
-    // `content_revision()` (base files only) — on an overlay-only pass the base reconcile is
-    // already Current and the clone delta is a guaranteed no-op that still pays two revision
-    // scans plus a corpus-scale `delta_paths` sweep (measured 66–94 s per pass under worktree
-    // churn). Such a pass runs only `memory_validate` below — cheap next to the base stages, and
-    // overlay edits can move memory anchors.
+    // reconciled a changed overlay's embeddings inline, so running the full base tail on every
+    // overlay keystroke would treadmill the base reconcile, the clone delta (whose corpus-scale
+    // `delta_paths` sweep was measured at 66–94 s per pass under worktree churn), and gc. An
+    // overlay edit does move the GLOBAL `content_revision()` (overlay rows are `main.files` rows),
+    // so that digest move — and any base work it implies — is picked up on the next content, gc,
+    // or backlog pass instead. Such a pass runs only `memory_validate` below — cheap next to the
+    // base stages, and overlay edits can move memory anchors.
     let run_base_tail = should_run_base_tail(
         content_changed,
         run_gc,
@@ -442,15 +443,11 @@ fn run_pass(
         // quiet window (`clone_graph_due`) so sustained editing defers it instead of
         // treadmilling. Best-effort + resumable, with whatever budget the embedding reconcile
         // left (shared PASS_RECONCILE_MAX_SECONDS so a pass can't overrun); `None` budget → rides
-        // the next pass. The quiet-gate probe's pinned digest is threaded in (#821); the base
-        // reconcile above ran in between, so the delta reuses it only when the connection
-        // counters prove no write intervened — see `content_revision_reusing` — and recomputes
-        // otherwise.
+        // the next pass. `content_revision()` is an O(1) state read (#828), so the delta recomputes
+        // it directly against the `files` rows as committed — no pinned digest is threaded from the
+        // probe.
         let clone_full_rebuild_owed = match timings.stage("clone_delta", || {
-            db.apply_clone_graph_delta_reusing_revision(
-                crate::index::CLONE_DELTA_MAX_FILES,
-                clone_probe.revision.as_ref(),
-            )
+            db.apply_clone_graph_delta(crate::index::CLONE_DELTA_MAX_FILES)
         }) {
             Ok(delta) if delta.status == "Applied" || delta.status == "Noop" =>
                 delta.full_rebuild_owed,

--- a/crates/rag-rat-core/src/watch/tests.rs
+++ b/crates/rag-rat-core/src/watch/tests.rs
@@ -575,11 +575,13 @@ fn startup_catchup_does_not_force_the_expensive_tail() {
 
 #[test]
 fn overlay_changes_do_not_force_the_base_tail() {
-    // #817: a changed overlay's embeddings are reconciled inline by the overlay stage, and every
-    // base-tail stage keys off `content_revision()` (base files only) — so overlay churn must not
-    // buy the corpus-scale reconcile/clone scans that are guaranteed no-ops there. The base tail
-    // is forced by base-side state only; `run_pass` still runs memory_validate on overlay-changed
-    // passes (covered by `overlay_only_pass_skips_base_tail_but_still_validates_memories`).
+    // #817: a changed overlay's embeddings are reconciled inline by the overlay stage, so running
+    // the corpus-scale base reconcile/clone stages on every overlay keystroke would treadmill.
+    // Overlay rows DO move the GLOBAL `content_revision()` (they are `main.files` rows), but that
+    // digest move and any base work it implies are picked up on the next content/gc/backlog pass,
+    // not forced here. The base tail is forced by base-side state only; `run_pass` still runs
+    // memory_validate on overlay-changed passes (covered by
+    // `overlay_only_pass_skips_base_tail_but_still_validates_memories`).
     assert!(
         !base_tail_forced_by_state(false, false, false),
         "no base-side state forces the base tail — overlay changes are not in the force set",

--- a/crates/rag-rat-db/Cargo.toml
+++ b/crates/rag-rat-db/Cargo.toml
@@ -16,6 +16,7 @@ anyhow.workspace = true
 rag-rat-base.workspace = true
 rusqlite.workspace = true
 serde.workspace = true
+sha2.workspace = true
 tracing.workspace = true
 zstd = "0.13"
 

--- a/crates/rag-rat-db/src/content_digest.rs
+++ b/crates/rag-rat-db/src/content_digest.rs
@@ -1,0 +1,465 @@
+//! The incrementally-maintained `content_revision` digest (#828).
+//!
+//! `content_revision` must be a pure function of the current multiset
+//! `{(path, sha256) : row ∈ main.files, kind != 'deleted'}` — identical content ⇒ identical
+//! digest, across rebuilds, generation flips, gc, row-order/rowid changes, and
+//! delete-then-reinsert-same-content cycles — so every freshness consumer (FTS, the clone graph,
+//! `status`) can compare it for equality. This module maintains that digest as a 256-bit additive
+//! multiset hash (AdHash-style): each contributing row hashes to four little-endian `u64` lanes,
+//! folded into a one-row `content_digest_state` table by component-wise wrapping addition. Removal
+//! subtracts the same lanes, so the group `(Z/2^64)^4` preserves multiplicity (duplicates during a
+//! generation-staged rebuild do NOT cancel, unlike XOR) and is independent of operation order.
+//!
+//! The fold is driven by three `AFTER INSERT/UPDATE/DELETE` triggers on `files` (see
+//! [`ensure_content_digest`]) that call the registered scalar function `rr_content_digest_fold`
+//! (see [`register_content_digest_fold`]). Attaching maintenance to the table — not to call sites
+//! — is what makes it complete: every writer, including the dynamic-SQL repo purge and any future
+//! seam, maintains the digest automatically. A connection that has NOT registered the function
+//! fails a `files` write loudly (`no such function`) and rolls back, so version skew can never
+//! silently drift the digest.
+//!
+//! The per-row hash, the lane fold, and the state codec here are shared by BOTH the trigger fold
+//! (via the scalar function) and the from-scratch Rust fold the migration seed, the parity
+//! self-check, and the `content_revision()` read fallback use — one implementation, so the two can
+//! never disagree.
+
+use std::fmt;
+
+use rusqlite::Connection;
+use rusqlite::functions::FunctionFlags;
+use sha2::{Digest, Sha256};
+
+/// Domain tag versioning the per-row hash function itself. Bumping it is a digest-algorithm change
+/// (a new migration that reseeds and re-stamps), which is exactly what the rendered `ms1-` prefix
+/// announces in stored stamps.
+const ROW_HASH_DOMAIN: &[u8] = b"rag-rat/content-revision/1";
+
+/// Rendered-digest prefix (algorithm generation). Self-describing in stored freshness stamps and
+/// guaranteed disjoint from the legacy 64-hex SHA digest, so a stale legacy stamp never
+/// accidentally equals a new one.
+pub const CONTENT_REVISION_PREFIX: &str = "ms1-";
+
+/// The `files.kind` value excluded from the multiset (a tombstone). The trigger fold no-ops each
+/// side whose kind is this, matching the current digest's `kind != 'deleted'` inclusion predicate.
+const TOMBSTONE_KIND: &str = "deleted";
+
+/// Four little-endian `u64` lanes — the 256-bit additive multiset-hash state. All-zero is the
+/// empty multiset.
+pub type DigestState = [u64; 4];
+
+/// A `content_digest_state.state` value that is not 64 lowercase hex chars. The scalar fold raises
+/// this (aborting the statement + transaction) rather than fold garbage into garbage — fail-closed.
+#[derive(Debug)]
+pub struct MalformedDigestState(String);
+
+impl fmt::Display for MalformedDigestState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "malformed content_digest_state.state: {}", self.0)
+    }
+}
+
+impl std::error::Error for MalformedDigestState {}
+
+/// The §6.1 per-row contribution: an injective, length-framed SHA-256 over `(path, sha256)` split
+/// into four little-endian `u64` lanes. Length framing makes the encoding injective for any byte
+/// content — a `:`- or NUL-bearing path cannot alias another row. `kind` is deliberately NOT hashed
+/// (it is the inclusion predicate only, matching the legacy digest exactly).
+pub fn content_row_hash(path: &str, sha256: &str) -> DigestState {
+    let mut hasher = Sha256::new();
+    hasher.update(ROW_HASH_DOMAIN);
+    hasher.update([0u8]);
+    hasher.update((path.len() as u64).to_le_bytes());
+    hasher.update(path.as_bytes());
+    hasher.update((sha256.len() as u64).to_le_bytes());
+    hasher.update(sha256.as_bytes());
+    let digest = hasher.finalize();
+    let mut lanes = [0u64; 4];
+    for (i, lane) in lanes.iter_mut().enumerate() {
+        let mut bytes = [0u8; 8];
+        bytes.copy_from_slice(&digest[i * 8..i * 8 + 8]);
+        *lane = u64::from_le_bytes(bytes);
+    }
+    lanes
+}
+
+/// Fold a contributing row's hash into `state`: wrapping add (`add = true`, an insert) or subtract
+/// (`add = false`, a removal), lane-wise. Every element is invertible, so the state is a pure
+/// function of the current multiset.
+pub fn fold_row(state: &mut DigestState, hash: &DigestState, add: bool) {
+    for (lane, contribution) in state.iter_mut().zip(hash.iter()) {
+        *lane =
+            if add { lane.wrapping_add(*contribution) } else { lane.wrapping_sub(*contribution) };
+    }
+}
+
+/// Encode the state as 64 lowercase hex chars (4 LE `u64` lanes = 32 bytes) — the opaque TEXT the
+/// `content_digest_state.state` column stores. SQL never does arithmetic on this, sidestepping
+/// SQLite's i64-overflow-to-REAL promotion; all wrapping happens in Rust.
+pub fn encode_state(state: &DigestState) -> String {
+    let mut out = String::with_capacity(64);
+    for lane in state {
+        for byte in lane.to_le_bytes() {
+            use fmt::Write as _;
+            let _ = write!(out, "{byte:02x}");
+        }
+    }
+    out
+}
+
+fn hex_digit(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        b'A'..=b'F' => Some(byte - b'A' + 10),
+        _ => None,
+    }
+}
+
+/// Decode a 64-hex `state` back to four LE `u64` lanes. Errs (fail-closed) on any length other than
+/// 64 or any non-hex byte — the malformed-state case the scalar fold raises.
+pub fn decode_state(hex: &str) -> Result<DigestState, MalformedDigestState> {
+    let bytes = hex.as_bytes();
+    if bytes.len() != 64 {
+        return Err(MalformedDigestState(format!("expected 64 hex chars, got {}", bytes.len())));
+    }
+    let mut raw = [0u8; 32];
+    for (out, chunk) in raw.iter_mut().zip(bytes.chunks_exact(2)) {
+        let hi = hex_digit(chunk[0])
+            .ok_or_else(|| MalformedDigestState(format!("non-hex byte {:#04x}", chunk[0])))?;
+        let lo = hex_digit(chunk[1])
+            .ok_or_else(|| MalformedDigestState(format!("non-hex byte {:#04x}", chunk[1])))?;
+        *out = (hi << 4) | lo;
+    }
+    let mut lanes = [0u64; 4];
+    for (i, lane) in lanes.iter_mut().enumerate() {
+        let mut b = [0u8; 8];
+        b.copy_from_slice(&raw[i * 8..i * 8 + 8]);
+        *lane = u64::from_le_bytes(b);
+    }
+    Ok(lanes)
+}
+
+/// The rendered digest a `content_revision()` read returns: `"ms1-" || encode_state(state)`. The
+/// raw state (not a hash of it) is rendered so a parity check can compare states directly.
+pub fn render_revision(state: &DigestState) -> String {
+    format!("{CONTENT_REVISION_PREFIX}{}", encode_state(state))
+}
+
+/// Register the deterministic scalar `rr_content_digest_fold(state, path, sha256, kind, sign)` on
+/// `conn` (§7.2). Idempotent (a re-register replaces the identical definition), cheap, and required
+/// on EVERY connection that can write `files` — the three triggers call it. The flags:
+/// `DETERMINISTIC` (required for use inside triggers under SQLite strictness) and `INNOCUOUS` (the
+/// function is pure, so it stays callable from the schema even under `trusted_schema = OFF`; NOT
+/// `DIRECTONLY`, which would forbid trigger use).
+pub fn register_content_digest_fold(conn: &Connection) -> rusqlite::Result<()> {
+    conn.create_scalar_function(
+        "rr_content_digest_fold",
+        5,
+        FunctionFlags::SQLITE_UTF8
+            | FunctionFlags::SQLITE_DETERMINISTIC
+            | FunctionFlags::SQLITE_INNOCUOUS,
+        |ctx| {
+            let state_hex: String = ctx.get(0)?;
+            // 'deleted' rows are not multiset members: return the state unchanged so the inclusion
+            // predicate lives in ONE place and the triggers stay simple (the UPDATE trigger folds
+            // both OLD and NEW unconditionally, and this no-ops each tombstone side).
+            let kind: String = ctx.get(3)?;
+            if kind == TOMBSTONE_KIND {
+                return Ok(state_hex);
+            }
+            // Decode AFTER the tombstone check would still be correct, but decoding first keeps the
+            // fail-closed guarantee uniform: a malformed state aborts the statement whatever the
+            // kind.
+            let mut state = decode_state(&state_hex)
+                .map_err(|err| rusqlite::Error::UserFunctionError(Box::new(err)))?;
+            let path: String = ctx.get(1)?;
+            let sha256: String = ctx.get(2)?;
+            let sign: i64 = ctx.get(4)?;
+            let hash = content_row_hash(&path, &sha256);
+            fold_row(&mut state, &hash, sign >= 0);
+            Ok(encode_state(&state))
+        },
+    )
+}
+
+/// Create the `content_digest_state` table and the three `files` fold triggers (§7.1 + §7.3),
+/// idempotently. Shared by the seeding migration and any FUTURE `files`-rebuild migration, which
+/// MUST call this (a `DROP TABLE files` silently drops the triggers) and then reseed. Does NOT
+/// insert the state row — the caller seeds it with a from-scratch fold, so no write can slip
+/// between trigger creation and the seed inside the migration transaction.
+pub fn ensure_content_digest(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(CONTENT_DIGEST_SCHEMA_SQL)
+}
+
+/// The state table + fold triggers. Kept as one const so trigger bodies and the invariant comment
+/// travel together; every statement is `IF NOT EXISTS`, so re-running is a no-op.
+const CONTENT_DIGEST_SCHEMA_SQL: &str = "
+-- Invariant: state == fold over {(path, sha256) : main.files, kind != 'deleted'} at every
+-- transaction boundary, maintained exclusively by the files_content_digest_* triggers below.
+-- Exactly one row (id = 1), seeded by the migration; rows_folded is the multiset cardinality
+-- (diagnostic only — never part of the rendered digest).
+CREATE TABLE IF NOT EXISTS content_digest_state(
+    id          INTEGER PRIMARY KEY CHECK (id = 1),
+    state       TEXT    NOT NULL,   -- 64 lowercase hex chars: 4 LE u64 lanes
+    rows_folded INTEGER NOT NULL
+) STRICT;
+
+-- Inserted rows join the multiset unless they are tombstones.
+CREATE TRIGGER IF NOT EXISTS files_content_digest_ai
+AFTER INSERT ON files WHEN NEW.kind != 'deleted'
+BEGIN
+    UPDATE content_digest_state
+       SET state = rr_content_digest_fold(state, NEW.path, NEW.sha256, NEW.kind, 1),
+           rows_folded = rows_folded + 1
+     WHERE id = 1;
+END;
+
+-- Deleted rows leave the multiset unless they were tombstones.
+CREATE TRIGGER IF NOT EXISTS files_content_digest_ad
+AFTER DELETE ON files WHEN OLD.kind != 'deleted'
+BEGIN
+    UPDATE content_digest_state
+       SET state = rr_content_digest_fold(state, OLD.path, OLD.sha256, OLD.kind, -1),
+           rows_folded = rows_folded - 1
+     WHERE id = 1;
+END;
+
+-- Digest-relevant column updates swap the old contribution for the new one; the fold function
+-- no-ops each side whose kind is 'deleted', which handles tombstone flips in both directions.
+-- UPDATE OF path, sha256, kind: digest-neutral writers (commit_sha, worktree_id, generation,
+-- generated, indexed_* re-stamps) never enter this trigger at all.
+CREATE TRIGGER IF NOT EXISTS files_content_digest_au
+AFTER UPDATE OF path, sha256, kind ON files
+BEGIN
+    UPDATE content_digest_state
+       SET state = rr_content_digest_fold(
+                       rr_content_digest_fold(state, OLD.path, OLD.sha256, OLD.kind, -1),
+                       NEW.path, NEW.sha256, NEW.kind, 1),
+           rows_folded = rows_folded
+                         + (NEW.kind != 'deleted') - (OLD.kind != 'deleted')
+     WHERE id = 1;
+END;
+";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_multiset_is_all_zero() {
+        let state = [0u64; 4];
+        assert_eq!(encode_state(&state), "0".repeat(64));
+        assert_eq!(render_revision(&state), format!("{CONTENT_REVISION_PREFIX}{}", "0".repeat(64)));
+    }
+
+    #[test]
+    fn encode_decode_round_trips() {
+        let mut state = [0u64; 4];
+        fold_row(&mut state, &content_row_hash("src/a.rs", "aa"), true);
+        fold_row(&mut state, &content_row_hash("src/b.rs", "bb"), true);
+        let hex = encode_state(&state);
+        assert_eq!(hex.len(), 64);
+        assert_eq!(decode_state(&hex).unwrap(), state);
+    }
+
+    #[test]
+    fn fold_is_order_independent_and_invertible() {
+        let a = content_row_hash("src/a.rs", "aa");
+        let b = content_row_hash("src/b.rs", "bb");
+        let mut ab = [0u64; 4];
+        fold_row(&mut ab, &a, true);
+        fold_row(&mut ab, &b, true);
+        let mut ba = [0u64; 4];
+        fold_row(&mut ba, &b, true);
+        fold_row(&mut ba, &a, true);
+        assert_eq!(ab, ba, "insertion order must not matter");
+        // Removing b returns to the a-only state.
+        let mut only_a = [0u64; 4];
+        fold_row(&mut only_a, &a, true);
+        fold_row(&mut ab, &b, false);
+        assert_eq!(ab, only_a, "removal is exact");
+    }
+
+    #[test]
+    fn multiset_keeps_multiplicity() {
+        // Two identical (path, sha256) contributions do NOT cancel (the XOR-regression pin).
+        let h = content_row_hash("src/a.rs", "aa");
+        let mut once = [0u64; 4];
+        fold_row(&mut once, &h, true);
+        let mut twice = [0u64; 4];
+        fold_row(&mut twice, &h, true);
+        fold_row(&mut twice, &h, true);
+        assert_ne!(once, twice, "a duplicate row must change the digest");
+    }
+
+    #[test]
+    fn length_framing_is_injective() {
+        // Without length framing, ("a:b", "c") and ("a", "b:c") could alias via a ':' join.
+        assert_ne!(content_row_hash("a:b", "c"), content_row_hash("a", "b:c"));
+        assert_ne!(content_row_hash("a", "bc"), content_row_hash("ab", "c"));
+    }
+
+    #[test]
+    fn decode_rejects_malformed_state() {
+        assert!(decode_state("").is_err());
+        assert!(decode_state("zz").is_err());
+        assert!(decode_state(&"0".repeat(63)).is_err());
+        assert!(decode_state(&"g".repeat(64)).is_err());
+    }
+
+    /// Drive the triggers against a MINIMAL `files` table (only the three columns the triggers
+    /// touch) so the trigger SQL + scalar fold are exercised in isolation from the full schema.
+    /// The full-schema seam sweep lives in rag-rat-core.
+    mod triggers {
+        use rusqlite::Connection;
+
+        use super::*;
+
+        fn open() -> Connection {
+            let conn = Connection::open_in_memory().unwrap();
+            register_content_digest_fold(&conn).unwrap();
+            conn.execute_batch("CREATE TABLE files(path TEXT, sha256 TEXT, kind TEXT);").unwrap();
+            ensure_content_digest(&conn).unwrap();
+            conn.execute(
+                "INSERT INTO content_digest_state(id, state, rows_folded) VALUES (1, ?1, 0)",
+                [encode_state(&[0u64; 4])],
+            )
+            .unwrap();
+            conn
+        }
+
+        /// The independent from-scratch fold the triggers must always agree with.
+        fn scan(conn: &Connection) -> (String, i64) {
+            let mut state = [0u64; 4];
+            let mut count = 0i64;
+            let mut stmt =
+                conn.prepare("SELECT path, sha256 FROM files WHERE kind != 'deleted'").unwrap();
+            let mut rows = stmt.query([]).unwrap();
+            while let Some(row) = rows.next().unwrap() {
+                let path: String = row.get(0).unwrap();
+                let sha256: String = row.get(1).unwrap();
+                fold_row(&mut state, &content_row_hash(&path, &sha256), true);
+                count += 1;
+            }
+            (encode_state(&state), count)
+        }
+
+        fn stored(conn: &Connection) -> (String, i64) {
+            conn.query_row(
+                "SELECT state, rows_folded FROM content_digest_state WHERE id = 1",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap()
+        }
+
+        fn assert_parity(conn: &Connection) {
+            assert_eq!(stored(conn), scan(conn), "trigger-maintained state must equal a scan fold");
+        }
+
+        #[test]
+        fn insert_update_delete_and_tombstone_flips_stay_in_parity() {
+            let conn = open();
+            // Insert two real files.
+            conn.execute("INSERT INTO files VALUES ('a.rs', 'aa', 'source')", []).unwrap();
+            conn.execute("INSERT INTO files VALUES ('b.rs', 'bb', 'docs')", []).unwrap();
+            assert_parity(&conn);
+            assert_eq!(stored(&conn).1, 2);
+
+            // A tombstone insert is excluded (WHEN NEW.kind != 'deleted').
+            conn.execute("INSERT INTO files VALUES ('c.rs', '', 'deleted')", []).unwrap();
+            assert_parity(&conn);
+            assert_eq!(stored(&conn).1, 2, "a tombstone does not join the multiset");
+
+            // sha change (delete+reinsert equivalent): swap old for new.
+            conn.execute("UPDATE files SET sha256 = 'aa2' WHERE path = 'a.rs'", []).unwrap();
+            assert_parity(&conn);
+
+            // Tombstone flip via UPDATE OF kind: 'source' -> 'deleted' removes the contribution.
+            conn.execute("UPDATE files SET kind = 'deleted', sha256 = '' WHERE path = 'b.rs'", [])
+                .unwrap();
+            assert_parity(&conn);
+            assert_eq!(stored(&conn).1, 1);
+
+            // Flip back: 'deleted' -> 'source' re-adds it.
+            conn.execute("UPDATE files SET kind = 'source', sha256 = 'bb3' WHERE path = 'b.rs'", [
+            ])
+            .unwrap();
+            assert_parity(&conn);
+            assert_eq!(stored(&conn).1, 2);
+
+            // Delete a real row.
+            conn.execute("DELETE FROM files WHERE path = 'a.rs'", []).unwrap();
+            assert_parity(&conn);
+            assert_eq!(stored(&conn).1, 1);
+
+            // Deleting a tombstone is digest-neutral (WHEN OLD.kind != 'deleted' skips it).
+            conn.execute("DELETE FROM files WHERE path = 'c.rs'", []).unwrap();
+            assert_parity(&conn);
+            assert_eq!(stored(&conn).1, 1);
+        }
+
+        #[test]
+        fn add_then_remove_same_pair_returns_to_prior_state() {
+            let conn = open();
+            conn.execute("INSERT INTO files VALUES ('x.rs', 'xx', 'source')", []).unwrap();
+            let before = stored(&conn);
+            conn.execute("INSERT INTO files VALUES ('y.rs', 'yy', 'source')", []).unwrap();
+            conn.execute("DELETE FROM files WHERE path = 'y.rs'", []).unwrap();
+            assert_eq!(
+                stored(&conn),
+                before,
+                "add+remove of the same pair is a no-op on the digest"
+            );
+        }
+
+        #[test]
+        fn a_write_without_the_registered_function_fails_closed() {
+            // A connection that never registered the fold: the trigger's function reference is
+            // unresolved, so the `files` INSERT fails loudly and the state never drifts.
+            let conn = Connection::open_in_memory().unwrap();
+            register_content_digest_fold(&conn).unwrap();
+            conn.execute_batch("CREATE TABLE files(path TEXT, sha256 TEXT, kind TEXT);").unwrap();
+            ensure_content_digest(&conn).unwrap();
+            conn.execute(
+                "INSERT INTO content_digest_state(id, state, rows_folded) VALUES (1, ?1, 0)",
+                [encode_state(&[0u64; 4])],
+            )
+            .unwrap();
+            // Now open a SECOND connection to the same in-memory DB is not possible; instead drop
+            // the function by removing it. rusqlite has no de-register, so simulate skew by writing
+            // through a fresh connection that shares nothing — use a file-backed DB.
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join("skew.sqlite");
+            {
+                let setup = Connection::open(&path).unwrap();
+                register_content_digest_fold(&setup).unwrap();
+                setup
+                    .execute_batch("CREATE TABLE files(path TEXT, sha256 TEXT, kind TEXT);")
+                    .unwrap();
+                ensure_content_digest(&setup).unwrap();
+                setup
+                    .execute(
+                        "INSERT INTO content_digest_state(id, state, rows_folded) VALUES (1, ?1, \
+                         0)",
+                        [encode_state(&[0u64; 4])],
+                    )
+                    .unwrap();
+            }
+            let unregistered = Connection::open(&path).unwrap();
+            let err = unregistered
+                .execute("INSERT INTO files VALUES ('a.rs', 'aa', 'source')", [])
+                .unwrap_err();
+            assert!(
+                err.to_string().contains("no such function"),
+                "an unregistered writer must fail closed, got: {err}"
+            );
+            let count: i64 = unregistered
+                .query_row("SELECT rows_folded FROM content_digest_state WHERE id = 1", [], |r| {
+                    r.get(0)
+                })
+                .unwrap();
+            assert_eq!(count, 0, "the rolled-back INSERT left the digest untouched");
+        }
+    }
+}

--- a/crates/rag-rat-db/src/lib.rs
+++ b/crates/rag-rat-db/src/lib.rs
@@ -5,6 +5,7 @@
 //! never link domain code downward.
 
 pub mod chunk_text_store;
+pub mod content_digest;
 pub mod hooks;
 pub mod meta;
 pub mod schema;

--- a/crates/rag-rat-db/src/schema/migrations.rs
+++ b/crates/rag-rat-db/src/schema/migrations.rs
@@ -1371,6 +1371,7 @@ pub(crate) fn known_version(migrations: &[AppliedMigration]) -> u32 {
             MIGRATION_083_ID => Some(83),
             MIGRATION_084_ID => Some(84),
             MIGRATION_085_ID => Some(85),
+            MIGRATION_086_ID => Some(86),
             _ => None,
         })
         .max()
@@ -1465,6 +1466,7 @@ pub(crate) fn known_migration(id: &str) -> bool {
             | MIGRATION_083_ID
             | MIGRATION_084_ID
             | MIGRATION_085_ID
+            | MIGRATION_086_ID
             | DIRTY_MIGRATION_ID
     )
 }
@@ -1556,6 +1558,7 @@ pub(crate) fn migration_checksum_mismatch(migration: &AppliedMigration) -> bool 
         MIGRATION_083_ID => migration.checksum != MIGRATION_083_CHECKSUM,
         MIGRATION_084_ID => migration.checksum != MIGRATION_084_CHECKSUM,
         MIGRATION_085_ID => migration.checksum != MIGRATION_085_CHECKSUM,
+        MIGRATION_086_ID => migration.checksum != MIGRATION_086_CHECKSUM,
         _ => false,
     }
 }
@@ -5911,6 +5914,92 @@ pub fn apply_sync_origin_and_edge_tombstone(conn: &Connection) -> rusqlite::Resu
         "TEXT NOT NULL DEFAULT 'local' CHECK (origin IN ('local', 'synced'))",
     )?;
     add_column_if_missing(&tx, "content_projected_edges", "present", "INTEGER NOT NULL DEFAULT 1")?;
+    tx.commit()
+}
+
+/// V086 (#828): stand up the incrementally-maintained `content_revision` digest.
+///
+/// Invariant established here: `content_digest_state.state` (one row, id = 1) is the 256-bit
+/// additive multiset hash of `{(path, sha256) : main.files, kind != 'deleted'}` at every
+/// transaction boundary, maintained by the three `files_content_digest_*` triggers
+/// [`crate::content_digest::ensure_content_digest`] creates. `content_revision()` becomes an O(1)
+/// read of that row (rendered `ms1-…`) instead of the O(N) `main.files` scan-sort-concat-hash.
+///
+/// The body runs in ONE immediate transaction, in order:
+///  1. Create the state table + triggers (idempotent; a future `files`-rebuild migration MUST call
+///     the same helper and reseed, because `DROP TABLE files` silently drops the triggers).
+///  2. Seed the state row with a from-scratch Rust fold over the current non-deleted `files` — the
+///     SAME per-row hash the trigger fold uses, so the trigger-maintained state and a recompute can
+///     never disagree. Atomic with trigger creation, so no write slips between.
+///  3. Re-stamp every freshness stamp that equals the FROZEN legacy digest (the pre-#828
+///     `hex_sha256(group_concat(path||':'||sha256 ORDER BY path))`, inlined because migrations are
+///     snapshots) to the new rendered digest. This is the ONLY place the digest value change is
+///     absorbed: a stamp equal to the legacy value was fresh, so pointing it at the new value
+///     avoids a one-time full FTS re-tokenize (`fts_source_revision`), a ~1 GB clone-graph rebuild
+///     (`clone_graph_generations.source_revision`), and a reset of the clone quiet window
+///     (`clone_graph_quiet_candidate_revision`). A stamp that did NOT equal the legacy digest was
+///     already stale and is left for the normal freshness machinery — exactly as it would have
+///     been.
+///
+/// If step 3 were dropped everything still self-heals (one FTS rebuild, one quiet-gated clone
+/// rebuild); the re-stamp is one cheap legacy scan that avoids that first-use rebuild storm.
+pub fn apply_content_digest_state(conn: &Connection) -> rusqlite::Result<()> {
+    let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
+
+    // 1. Table + triggers.
+    crate::content_digest::ensure_content_digest(&tx)?;
+
+    // 2. From-scratch seed fold over the current non-deleted rows (order-free — the fold is
+    //    commutative, so no ORDER BY is needed).
+    let mut state = [0u64; 4];
+    let mut rows_folded: i64 = 0;
+    {
+        let mut stmt = tx.prepare("SELECT path, sha256 FROM main.files WHERE kind != 'deleted'")?;
+        let mut rows = stmt.query([])?;
+        while let Some(row) = rows.next()? {
+            let path: String = row.get(0)?;
+            let sha256: String = row.get(1)?;
+            let hash = crate::content_digest::content_row_hash(&path, &sha256);
+            crate::content_digest::fold_row(&mut state, &hash, true);
+            rows_folded += 1;
+        }
+    }
+    tx.execute(
+        "INSERT OR REPLACE INTO content_digest_state(id, state, rows_folded) VALUES (1, ?1, ?2)",
+        params![crate::content_digest::encode_state(&state), rows_folded],
+    )?;
+
+    // 3. Re-stamp the frozen legacy digest -> the new rendered digest wherever it was still
+    //    current.
+    let legacy_concat: String = tx.query_row(
+        "SELECT COALESCE(group_concat(pv, ','), '') FROM (SELECT path || ':' || sha256 AS pv FROM \
+         main.files WHERE kind != 'deleted' ORDER BY path)",
+        [],
+        |row| row.get(0),
+    )?;
+    let legacy_digest = rag_rat_base::hash::hex_sha256(legacy_concat.as_bytes());
+    let new_digest = crate::content_digest::render_revision(&state);
+    // The GLOBAL freshness stamps (`content_revision` keeps `global_status`'s rollup consistent;
+    // `fts_source_revision` prevents a full chunk-text re-tokenize on first `ensure_fts_fresh`).
+    tx.execute(
+        "UPDATE index_meta SET value = ?1
+         WHERE key IN ('fts_source_revision', 'content_revision') AND value = ?2",
+        params![new_digest, legacy_digest],
+    )?;
+    // Every clone-graph generation stamped at the legacy digest keeps the postings fast path
+    // serving and skips a one-time full rebuild.
+    tx.execute(
+        "UPDATE clone_graph_generations SET source_revision = ?1 WHERE source_revision = ?2",
+        params![new_digest, legacy_digest],
+    )?;
+    // A per-repo armed quiet-window candidate survives the upgrade instead of resetting its
+    // stability clock (the key literal matches CLONE_GRAPH_QUIET_REVISION_META in rag-rat-core).
+    tx.execute(
+        "UPDATE repo_meta SET value = ?1
+         WHERE key = 'clone_graph_quiet_candidate_revision' AND value = ?2",
+        params![new_digest, legacy_digest],
+    )?;
+
     tx.commit()
 }
 

--- a/crates/rag-rat-db/src/schema/mod.rs
+++ b/crates/rag-rat-db/src/schema/mod.rs
@@ -10,7 +10,7 @@ pub use migrations::{
     apply_account_authority_boundaries, apply_account_authority_projection,
     apply_account_candidate_dag, apply_chunk_symbol_id, apply_clone_delta_maintenance,
     apply_clone_df_epoch, apply_clone_fingerprint_tables, apply_clone_graph_tables,
-    apply_content_candidate_dag, apply_content_projected_tables,
+    apply_content_candidate_dag, apply_content_digest_state, apply_content_projected_tables,
     apply_content_refold_queue_and_stats, apply_content_streams_pending_refold,
     apply_distill_anchor_selection, apply_distill_enriched_context,
     apply_distill_evidence_source_part, apply_distill_record_store,
@@ -47,7 +47,7 @@ use serde::Serialize;
 
 use crate::hooks::MigrationHooks;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 85;
+pub const LATEST_SCHEMA_VERSION: u32 = 86;
 
 /// Every oracle-DERIVED persisted table — the outputs an `oracle run` writes that must OUTLIVE a
 /// reindex.
@@ -633,6 +633,16 @@ const MIGRATION_085_DESCRIPTION: &str =
      revoked content); the present column retains edge tombstones so a foreign EdgeRemove is \
      honored instead of resurrected in an op-log growth loop. Additive; existing rows default to \
      local/present";
+const MIGRATION_086_ID: &str = "086_content_digest_state";
+const MIGRATION_086_CHECKSUM: &str = "sha256:rag-rat-content-digest-state-v86";
+const MIGRATION_086_DESCRIPTION: &str =
+    "Incrementally maintain content_revision (#828): add the one-row content_digest_state table \
+     and the three files_content_digest_* triggers that fold a 256-bit additive multiset hash of \
+     {(path, sha256) : main.files, kind != 'deleted'} via the registered rr_content_digest_fold \
+     scalar, seed the state from a from-scratch Rust fold, and re-stamp every freshness stamp \
+     (index_meta fts_source_revision/content_revision, clone_graph_generations.source_revision, \
+     the clone-graph quiet candidate) that equals the frozen legacy digest so no one-time \
+     FTS/clone rebuild fires. Replaces the O(N) main.files scan with an O(1) state read";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -759,6 +769,11 @@ fn provision_baseline(conn: &Connection) -> rusqlite::Result<()> {
 }
 
 pub fn apply(conn: &Connection, hooks: &MigrationHooks) -> rusqlite::Result<()> {
+    // The V086 content-digest triggers call `rr_content_digest_fold`, and the migration seeds the
+    // state via the shared Rust fold; a raw `rusqlite::Connection` that applies the real schema
+    // (many tests do, then write `files` rows) needs the function registered before any `files`
+    // write. Idempotent and connection-local (no DB write), so it is safe ahead of the baseline.
+    crate::content_digest::register_content_digest_fold(conn)?;
     provision_baseline(conn)?;
     // Every additive migration in order. A fresh DB runs them all; data backfills on empty tables
     // are no-ops. (An EXISTING DB takes the forward-only path via `migrate_forward`, not this.)
@@ -1335,6 +1350,12 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         description: MIGRATION_085_DESCRIPTION,
         apply: MigrationFn::Plain(apply_sync_origin_and_edge_tombstone),
     },
+    Migration {
+        id: MIGRATION_086_ID,
+        checksum: MIGRATION_086_CHECKSUM,
+        description: MIGRATION_086_DESCRIPTION,
+        apply: MigrationFn::Plain(apply_content_digest_state),
+    },
 ];
 
 /// Apply ONLY the additive migrations not already recorded, in order — the forward-only path for an
@@ -1352,6 +1373,10 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
 /// autocommit write is one fewer `SQLITE_BUSY` hazard against ordinary per-repo writers, which
 /// the schema lock deliberately does not serialize against.
 pub fn migrate_forward(conn: &Connection, hooks: &MigrationHooks) -> anyhow::Result<()> {
+    // Same rationale as `apply`: a raw connection that forward-migrates the real schema then writes
+    // `files` needs the V086 fold function. Connection-local, so it does not count as a DB write
+    // and never breaks the loser-discipline "nothing owed ⇒ write nothing" guarantee below.
+    crate::content_digest::register_content_digest_fold(conn)?;
     let applied: std::collections::HashSet<String> =
         applied_migrations(conn)?.into_iter().map(|migration| migration.id).collect();
     if applied.contains(MIGRATION_001_ID)

--- a/crates/rag-rat-db/src/storage.rs
+++ b/crates/rag-rat-db/src/storage.rs
@@ -220,6 +220,12 @@ impl IndexConnection {
             PRAGMA wal_autocheckpoint = 0;
             ",
         )?;
+        // Register the content-revision fold on every production open (#828). The three
+        // `files_content_digest_*` triggers call it, so a write connection MUST carry it — an
+        // unregistered writer fails a `files` write with `no such function` and rolls back
+        // (fail-closed) rather than silently drifting the incrementally-maintained digest.
+        // Idempotent and pure, so registering it on read-only-ish opens too is harmless.
+        crate::content_digest::register_content_digest_fold(&self.conn)?;
         // The delete→WAL transition needs an EXCLUSIVE lock, and SQLite deliberately does NOT run
         // the busy handler on parts of that upgrade path (it returns SQLITE_BUSY immediately to
         // break potential deadlocks among racing upgraders) — so busy_timeout alone does NOT save


### PR DESCRIPTION
## What

`content_revision()` is the corpus-wide content-freshness digest that gates FTS re-tokenization (`fts_source_revision`), the clone-graph quiet gate + delta, the watcher stability check, and `status`. It was an O(N) scan-sort-concat-hash over every non-deleted `main.files` row on **every** call — so hot paths recomputed it repeatedly, and a connection-state pin/reuse cache (#821) existed only to avoid paying the scan twice in a single watcher pass.

This makes it an incrementally-maintained O(1) read.

## How

`content_revision` becomes the 256-bit **additive multiset hash** of `{(path, sha256) : main.files WHERE kind != 'deleted'}`:

- Each row hashes a length-framed message (`"rag-rat/content-revision/1"` ‖ `path` ‖ `sha256`) with SHA-256 into four little-endian `u64` lanes, folded across rows by **wrapping SUM**, rendered `ms1-<64 hex>`.
- **Sum, not XOR, not a counter** — `main.files` is a *multiset*: generation-staged rebuilds transiently hold duplicate `(path, sha256)` pairs. XOR cancels duplicate pairs to the empty state; a monotonic counter would bump on content-identical rebuilds and spuriously invalidate every freshness stamp. The sum-fold is a pure function of the current multiset, so the digest is stable across rebuilds, generation flips, gc, and row-order churn, and moves **iff** content moves.
- Maintained by three `AFTER INSERT/UPDATE/DELETE` triggers on `files` (new **V086** migration) calling a registered deterministic scalar, held in a one-row `content_digest_state` table. Doing it at the SQL layer covers every write seam — including the dynamic per-repo purge sweep a Rust-seam fold would miss — and **fails closed**: a connection without the fold function registered errors a `files` write and rolls back rather than silently drifting the digest.

V086 seeds the state from a from-scratch fold and re-stamps every freshness stamp still equal to the frozen legacy digest (`index_meta` `fts_source_revision`/`content_revision`, `clone_graph_generations.source_revision`, the clone-graph quiet candidate) to the new rendered value, so **the upgrade fires no one-time FTS re-tokenize or clone-graph rebuild**. A parity self-check recomputes from scan and reseeds on mismatch under the write lock (gc cadence, `heal_index`, full-rebuild finalize) as a backstop. The #821 pin/reuse machinery is removed — with an O(1) read there is no scan to amortize.

## Measured (real indexes, read-only, warm)

| Corpus | live files | before | after | speedup |
|---|--:|--:|--:|--:|
| consolidated index | 3085 | 3095.5 µs/call | 2.3 µs/call | ~1368× |
| self-index | 473 | 305.7 µs/call | 2.8 µs/call | ~110× |

Old cost was linear in N; the new read is constant. Added write cost is one SHA-256 (~150 bytes) + function dispatch per `files` write (~1 µs/row, ~3 ms for a 3085-file full index).

## Tests

New `schema_bootstrap_tests/content_digest.rs` + `rag-rat-db/content_digest.rs` unit tests pin: schema-tip at V086 with live triggers; full seam-sweep parity (insert / tombstone-flip / delete / repo-purge); multiset-not-a-set and order/rowid invariance (the XOR- and counter-regression pins); the poisoned-state read (fast path proven to disagree with the scan fallback, then healed by parity); fail-closed skew; the files-table-rebuild trigger-drop tripwire (a future rebuild migration must call `ensure_content_digest` + reseed); and the V086 legacy-stamp re-stamp. Full workspace suite green; clippy clean under `--no-default-features`, `--all-features`, and the eval feature (lexical + hybrid).

Fixes #828
