### PR TITLE
perf(clones): derive the clone-delta changed set from a hint + cache the postings count

### DIFF
--- a/crates/rag-rat-core/src/index/incremental.rs
+++ b/crates/rag-rat-core/src/index/incremental.rs
@@ -40,6 +40,38 @@ struct PreparedIncrementalPass {
     deleted: BTreeSet<PathBuf>,
 }
 
+impl PreparedIncrementalPass {
+    /// The repo-relative base paths this pass will reindex or delete — the clone-delta changed-set
+    /// hint (#830). Uses the SAME `path_string` normalization the file writes use, so the strings
+    /// match `files.path` / `clone_subblock_postings.path` byte-for-byte. A superset of the paths
+    /// whose `(path, sha256)` actually changes (an unchanged prepared file writes nothing but is
+    /// still listed) — which is exactly what the delta hint requires (see `delta.rs`).
+    fn touched_base_paths(&self) -> BTreeSet<String> {
+        let mut set: BTreeSet<String> = BTreeSet::new();
+        for prepared in &self.prepared_files {
+            set.insert(rag_rat_base::paths::path_string(&prepared.file.relative_path));
+        }
+        for deleted in &self.deleted {
+            set.insert(rag_rat_base::paths::path_string(deleted));
+        }
+        set
+    }
+}
+
+/// The outcome of one incremental/discover pass the watcher tail consumes: whether index *content*
+/// changed (gates the reconcile / memory-validate tail on an idle sweep, #63) and the clone-delta
+/// changed-set hint (#830).
+pub(crate) struct IncrementalPassReport {
+    pub(crate) content_changed: bool,
+    /// The base paths this pass reindexed ∪ deleted, as the clone-delta changed-set hint. `Some`
+    /// only when the pass's content change is FULLY captured by this set; `None` forces the
+    /// delta's full DB scan — a stale-overlay heal changes `files` rows the set does not name,
+    /// and a bootstrap full rebuild reindexed the whole corpus. An empty `Some` is valid (the
+    /// revision moved but no base file was touched), letting the delta re-pin freshness
+    /// without a scan.
+    pub(crate) clone_delta_hint: Option<BTreeSet<String>>,
+}
+
 impl IndexDatabase {
     pub fn index_changed(config: &Config) -> anyhow::Result<Self> {
         Self::index_changed_with_progress(config, |_| {})
@@ -92,7 +124,9 @@ impl IndexDatabase {
     /// Like [`Self::index_discover`], but also reports whether the pass changed index *content*
     /// (a file was added / edited / removed). The watch loop uses this to skip the
     /// reconcile / memory-validate tail on an idle no-change sweep (issue #63).
-    pub fn index_discover_reporting(config: &Config) -> anyhow::Result<(Self, bool)> {
+    pub(crate) fn index_discover_reporting(
+        config: &Config,
+    ) -> anyhow::Result<(Self, IncrementalPassReport)> {
         Self::index_incremental_with_progress(config, IndexMode::Discover, None, &mut |_| {})
     }
 
@@ -101,7 +135,7 @@ impl IndexDatabase {
         mode: IndexMode,
         explicit_paths: Option<&[PathBuf]>,
         progress: &mut F,
-    ) -> anyhow::Result<(Self, bool)>
+    ) -> anyhow::Result<(Self, IncrementalPassReport)>
     where
         F: FnMut(IndexProgress),
     {
@@ -120,7 +154,12 @@ impl IndexDatabase {
                 }
                 .into());
             }
-            return Self::rebuild_with_progress(config, progress).map(|db| (db, true));
+            // A bootstrap full rebuild reindexed the whole corpus and rebuilt the clone graph from
+            // scratch, so there is no incremental changed-set to hint — `None` forces the delta's
+            // self-healing full scan next pass (#830).
+            return Self::rebuild_with_progress(config, progress).map(|db| {
+                (db, IncrementalPassReport { content_changed: true, clone_delta_hint: None })
+            });
         }
 
         // Acquire the per-repo write flock BEFORE opening + scoping the connection (#560/#561). It
@@ -227,7 +266,12 @@ impl IndexDatabase {
                 }
                 .into());
             }
-            return Self::rebuild_with_progress(config, progress).map(|db| (db, true));
+            // A bootstrap full rebuild reindexed the whole corpus and rebuilt the clone graph from
+            // scratch, so there is no incremental changed-set to hint — `None` forces the delta's
+            // self-healing full scan next pass (#830).
+            return Self::rebuild_with_progress(config, progress).map(|db| {
+                (db, IncrementalPassReport { content_changed: true, clone_delta_hint: None })
+            });
         }
         // A commit advances HEAD before committed-scope rows have been stamped for it. Likewise, a
         // target-set change can make the active scope marker stale even when the old rows still
@@ -296,6 +340,12 @@ impl IndexDatabase {
             None => None,
         };
         let prepare_ms = prepare_started.elapsed().as_millis() as u64;
+        // #830: the clone-delta changed-set hint — the base paths this pass reindexes or deletes —
+        // captured from the prepared plan before the write txn (a pure read of `prepared`). Whether
+        // it is offered to the delta is decided after apply, once `healed` is known: a
+        // stale-overlay heal touches `files` rows NOT in this set, so a healed pass falls
+        // back to the full scan.
+        let touched_base_paths = prepared.touched_base_paths();
 
         // WRITE — ONE `BEGIN IMMEDIATE` .. COMMIT (#560). The incremental path writes the LIVE
         // generation directly (no staging, no pointer flip — unlike the full rebuild), so every
@@ -502,7 +552,12 @@ impl IndexDatabase {
         // transaction is closed by now); write-free when nothing is pending (one meta read),
         // so the #63 idle-pass posture holds. On failure the marker survives for the next pass.
         db.apply_pending_logical_rebuild()?;
-        Ok((db, content_changed))
+        // #830: offer the changed-set hint ONLY when the pass's content change is fully captured by
+        // the reindexed/deleted set. A stale-overlay heal (`healed > 0`) mutates `files` rows that
+        // are NOT in `touched_base_paths`, so a healed pass yields `None` and the delta self-heals
+        // via its full DB scan.
+        let clone_delta_hint = (healed == 0).then_some(touched_base_paths);
+        Ok((db, IncrementalPassReport { content_changed, clone_delta_hint }))
     }
 
     /// Standalone full-corpus indexing into the CURRENT context — no generation staging, no

--- a/crates/rag-rat-core/src/index/mod.rs
+++ b/crates/rag-rat-core/src/index/mod.rs
@@ -71,6 +71,7 @@ pub use lifecycle::{
 pub(crate) use mem_diag::{maybe_set_sqlite_soft_heap_limit, mem_trace};
 pub use parser_failures::ParserFailure;
 pub(crate) use prep::*;
+pub(crate) use query_api::CloneDeltaHint;
 pub use query_api::{
     CLONE_DELTA_MAX_FILES, CandidateCloneClass, CloneCheckInput, CloneCompleteness,
     CloneDeltaReport, CloneEdgeReport, CloneEligibility, CloneFingerprintHealth,

--- a/crates/rag-rat-core/src/index/query_api/clones/delta.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/delta.rs
@@ -26,6 +26,31 @@
 //!   every sub-block token uncapped, so the delta does too, or a stable-hot shared token would
 //!   silently drop edges a full rebuild keeps (pinned by
 //!   `delta_keeps_hot_token_edges_the_build_would_emit`).
+//!
+//! CHANGED-SET HINT + SELF-HEAL (#830): the delta's file set is derived either from a full DB scan
+//! ([`delta_paths`], the [`CloneDeltaHint::FullScan`]/[`CloneDeltaHint::SelfHeal`] paths) or from a
+//! reconcile-supplied set of the base paths a pass reindexed or deleted ([`delta_paths_from_hint`],
+//! the [`CloneDeltaHint::Paths`] path). The hint replaces the two per-pass corpus scans with
+//! indexed point-lookups; it is sound ONLY because it is a SUPERSET of the truly-changed
+//! clone-relevant paths: post-#828 `content_revision()` moves iff the `(path, sha256)` multiset of
+//! non-deleted files changes, so a revision-moving edit reaches the changed-set derivation, and the
+//! reconcile hint (reindexed ∪ deleted) names every file whose `(path, sha256)` it moved.
+//!
+//! Two things the hint cannot see, both closed by the gc-cadence [`CloneDeltaHint::SelfHeal`]
+//! sweep: (1) a stale-overlay heal changes `files` rows the reindexed/deleted set does not name —
+//! the reconcile withholds the hint for a healed pass, so it falls to a scan anyway; (2) a
+//! `generated`-flag flip changes `files.generated` (not `path`/`sha256`), so it moves NO revision
+//! and every `Paths`/`FullScan` delta returns `Noop` before the derivation — only `SelfHeal`, which
+//! bypasses that revision-equality early return, scans and repairs it. The watcher runs `SelfHeal`
+//! on the gc cadence (`GC_EVERY_PASSES`), so drift the digest cannot reflect is bounded to that
+//! window. When `SelfHeal` finds MORE such drift than the delta cap (`CLONE_DELTA_MAX_FILES`, e.g.
+//! a mass generated-reclassification) it `Escalate`s; because that drift is revision-neutral the
+//! quiet gate never arms (the graph looks fresh against the revision), so the watcher forces a full
+//! rebuild past the gate for exactly that fresh-graph Escalate (see `watch::pass`) rather than
+//! leaving it to the `delta_files_applied >= CLONE_GRAPH_DRIFT_REBUILD_FILES` drift rebuild, which
+//! a revision-neutral Escalate never advances. The `SelfHeal` scan is load-bearing, NOT redundant —
+//! do not "optimize" it into a plain `FullScan`, whose early `Noop` would leave generated-flip
+//! drift for the full rebuild alone.
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::time::Instant;
@@ -87,14 +112,61 @@ pub struct CloneDeltaReport {
 /// token sharing is cheap in absolute terms — never flap a healthy delta to Escalate.
 const CLONE_DELTA_MIN_POSTING_ROW_BUDGET: u64 = 100_000;
 
+/// How a delta derives its changed-file set (#830). `Paths` and `FullScan` produce the SAME set
+/// when the hint is a superset of the truly-changed clone-relevant paths (see the module doc's
+/// soundness note); `SelfHeal` is the gc-cadence sweep that also repairs drift the content digest
+/// cannot see.
+#[derive(Clone, Copy)]
+pub(crate) enum CloneDeltaHint<'a> {
+    /// Derive the changed set from the full DB scan ([`delta_paths`]), but honor the
+    /// revision-equality fast path: the default for callers with no reconcile hint (the CLI
+    /// one-shot) and the fallback when a pass cannot offer a hint yet the revision moved
+    /// (a stale-overlay heal / bootstrap rebuild).
+    FullScan,
+    /// Restrict the changed set to the pass's touched base paths ([`delta_paths_from_hint`]), using
+    /// indexed point-lookups instead of the two corpus scans.
+    Paths(&'a BTreeSet<String>),
+    /// A full DB scan that runs EVEN when `content_revision()` is unchanged — the gc-cadence
+    /// self-heal. It is the only path that repairs drift the digest does not reflect: a
+    /// `generated`-flag flip changes `files.generated` (not `path`/`sha256`), so it never moves the
+    /// revision, and a `Paths`/`FullScan` delta returns `Noop` before the changed-set derivation.
+    /// Bypassing that early return here is what makes the self-heal on `run_gc` genuinely
+    /// load-bearing rather than defeated by the fast path.
+    SelfHeal,
+}
+
+impl CloneDeltaHint<'_> {
+    /// Whether this hint scans regardless of revision movement — only [`Self::SelfHeal`] does.
+    fn scans_when_revision_unchanged(&self) -> bool {
+        matches!(self, CloneDeltaHint::SelfHeal)
+    }
+}
+
 impl IndexDatabase {
     /// Apply one clone-graph delta toward the current `content_revision()`, bounded to
     /// `max_files` changed files (larger deltas escalate — a branch switch is cheaper to rebuild).
     /// MUST run under the caller's write lock (like `reconcile_clone_edges_pass`); the read phase
     /// runs lock-stable outside a transaction, and all writes commit in ONE transaction, so a
     /// reader sees either the old graph or the fully-applied delta.
+    ///
+    /// Derives the changed set from the full DB scan ([`CloneDeltaHint::FullScan`]) — the
+    /// self-healing default for callers with no reconcile-supplied changed-set (the CLI one-shot,
+    /// the differential parity pin). The watcher uses [`Self::apply_clone_graph_delta_hinted`] to
+    /// pass the pass's touched paths (#830).
     pub fn apply_clone_graph_delta(&self, max_files: usize) -> anyhow::Result<CloneDeltaReport> {
-        self.apply_clone_graph_delta_inner(max_files, None)
+        self.apply_clone_graph_delta_inner(max_files, CloneDeltaHint::FullScan, None)
+    }
+
+    /// [`Self::apply_clone_graph_delta`] with an explicit changed-set `hint` (#830): the watcher
+    /// passes [`CloneDeltaHint::Paths`] with the base paths the reconcile just reindexed/deleted so
+    /// the read phase skips the two corpus scans, and [`CloneDeltaHint::FullScan`] on a cadence so
+    /// any hint/DB drift self-heals.
+    pub(crate) fn apply_clone_graph_delta_hinted(
+        &self,
+        max_files: usize,
+        hint: CloneDeltaHint,
+    ) -> anyhow::Result<CloneDeltaReport> {
+        self.apply_clone_graph_delta_inner(max_files, hint, None)
     }
 
     /// [`Self::apply_clone_graph_delta`] with an explicit posting-row work budget — the test seam
@@ -107,12 +179,17 @@ impl IndexDatabase {
         max_files: usize,
         posting_row_budget: u64,
     ) -> anyhow::Result<CloneDeltaReport> {
-        self.apply_clone_graph_delta_inner(max_files, Some(posting_row_budget))
+        self.apply_clone_graph_delta_inner(
+            max_files,
+            CloneDeltaHint::FullScan,
+            Some(posting_row_budget),
+        )
     }
 
     fn apply_clone_graph_delta_inner(
         &self,
         max_files: usize,
+        hint: CloneDeltaHint,
         posting_row_budget: Option<u64>,
     ) -> anyhow::Result<CloneDeltaReport> {
         let started = Instant::now();
@@ -167,7 +244,12 @@ impl IndexDatabase {
         // trigger-maintained digest (#828), so it always reflects the `files` rows as committed —
         // there is no scan to pin or reuse.
         let revision = self.content_revision()?;
-        if live.source_revision == revision {
+        // Revision-equality fast path: nothing content-addressable changed, so skip the changed-set
+        // derivation — EXCEPT for a `SelfHeal` sweep (#830), which scans anyway to repair drift the
+        // content digest cannot see (a `generated`-flag flip moves no `(path, sha256)`, so it never
+        // moves the revision). Without this exception the gc-cadence self-heal would always return
+        // here and never reach `delta_paths`, leaving that drift for the full rebuild alone.
+        if live.source_revision == revision && !hint.scans_when_revision_unchanged() {
             return Ok(CloneDeltaReport {
                 full_rebuild_owed: live.delta_files_applied >= CLONE_GRAPH_DRIFT_REBUILD_FILES,
                 ..report("Noop", None, 0, 0, 0, started)
@@ -180,7 +262,13 @@ impl IndexDatabase {
 
         // ---- Read phase (write lock held; no transaction needed for consistency) ----
 
-        let paths = delta_paths(conn, generation)?;
+        // #830: FullScan / SelfHeal derive the changed set from the whole postings/fingerprint
+        // corpus (the self-heal); Paths restricts it to the reconcile's touched base paths via
+        // indexed point-lookups. Everything after keys off this `paths` Vec identically.
+        let paths = match hint {
+            CloneDeltaHint::FullScan | CloneDeltaHint::SelfHeal => delta_paths(conn, generation)?,
+            CloneDeltaHint::Paths(touched) => delta_paths_from_hint(conn, generation, touched)?,
+        };
         if paths.len() > max_files {
             return Ok(report(
                 "Escalate",
@@ -192,15 +280,22 @@ impl IndexDatabase {
             ));
         }
         if paths.is_empty() {
-            // The revision moved but no clone-relevant file changed (e.g. a docs-target edit):
-            // the graph is semantically current — just re-pin the freshness key.
-            conn.execute(
-                "UPDATE clone_graph_generations SET source_revision = ?1 WHERE generation = ?2",
-                params![revision, generation],
-            )?;
+            // Nothing clone-relevant changed. Two ways here: the revision MOVED but only a
+            // clone-irrelevant file did (e.g. a docs-target edit) — re-pin the freshness key; or a
+            // `SelfHeal` sweep ran with the revision UNCHANGED and found no drift — leave the stamp
+            // alone so an idle gc pass stays write-free (#63). The `revision != source_revision`
+            // guard collapses to "always re-pin" on every non-`SelfHeal` path (they only reach here
+            // past the moved-revision check above).
+            let repinned = revision != live.source_revision;
+            if repinned {
+                conn.execute(
+                    "UPDATE clone_graph_generations SET source_revision = ?1 WHERE generation = ?2",
+                    params![revision, generation],
+                )?;
+            }
             return Ok(CloneDeltaReport {
                 full_rebuild_owed: drift_after(0),
-                ..report("Applied", None, 0, 0, 0, started)
+                ..report(if repinned { "Applied" } else { "Noop" }, None, 0, 0, 0, started)
             });
         }
 
@@ -370,6 +465,7 @@ impl IndexDatabase {
         conn.execute_batch("BEGIN IMMEDIATE")?;
         let result = (|| -> anyhow::Result<(u64, u64)> {
             let mut edges_removed = 0u64;
+            let mut postings_removed = 0u64;
             for chunk in paths.chunks(DELTA_SQL_CHUNK) {
                 let placeholders: Vec<String> =
                     (0..chunk.len()).map(|i| format!("?{}", i + 2)).collect();
@@ -391,27 +487,35 @@ impl IndexDatabase {
                     ),
                     params_from_iter(values.clone()),
                 )? as u64;
-                // Indexed by V049's idx_clone_subblock_postings_path.
-                conn.execute(
+                // Indexed by V049's idx_clone_subblock_postings_path. Capture the deleted row
+                // count to maintain the cached `postings_row_count` (#830) below.
+                postings_removed += conn.execute(
                     &format!(
                         "DELETE FROM clone_subblock_postings WHERE build_generation = ?1 AND path \
                          IN ({in_list})"
                     ),
                     params_from_iter(values),
-                )?;
+                )? as u64;
             }
             let edges_added = insert_edge_rows(conn, generation, &edge_batch)?;
-            insert_posting_groups(conn, generation, &posting_groups)?;
+            let postings_added = insert_posting_groups(conn, generation, &posting_groups)?;
             conn.execute(
+                // #830: `postings_row_count` is maintained by the net (added − removed) delta in
+                // the SAME transaction as the postings writes, so it always equals
+                // `COUNT(*)` for this generation. `MAX(…, 0)` guards it exactly
+                // like `edges_written` — a defensive floor against a torn prior
+                // state, never expected to bind.
                 "UPDATE clone_graph_generations
                     SET source_revision = ?1,
                         delta_files_applied = delta_files_applied + ?2,
-                        edges_written = MAX(edges_written + ?3, 0)
-                  WHERE generation = ?4",
+                        edges_written = MAX(edges_written + ?3, 0),
+                        postings_row_count = MAX(postings_row_count + ?4, 0)
+                  WHERE generation = ?5",
                 params![
                     revision,
                     paths.len() as i64,
                     edges_added as i64 - edges_removed as i64,
+                    postings_added as i64 - postings_removed as i64,
                     generation
                 ],
             )?;
@@ -509,6 +613,71 @@ fn delta_paths(conn: &Connection, generation: i64) -> anyhow::Result<Vec<String>
     Ok(set.into_iter().collect())
 }
 
+/// [`delta_paths`] RESTRICTED to a reconcile-supplied changed-set `hint` (#830): keep only the
+/// hinted paths that are actually clone-relevant under this generation, decided by INDEXED
+/// point-lookups per path — never a corpus scan (avoiding that scan is the entire point). The
+/// result equals `delta_paths()` ∩ `hint`, which is `delta_paths()` itself when the hint is a
+/// superset of the truly-changed clone-relevant paths (the module doc's soundness note).
+///
+/// A hinted path is included iff EITHER predicate from `delta_paths`, narrowed to that one path:
+/// - STALE: it has postings under this generation whose `(path, file_sha)` no longer matches an
+///   eligible current file (edited / deleted / generated-flipped); or
+/// - FRESH: it is an eligible fingerprinted file (`generated = 0`, baseline + `NORM_VERSION`,
+///   non-NULL bag) with NO postings under this generation yet.
+///
+/// The STALE lookup and the FRESH `NOT EXISTS` both key `clone_subblock_postings` on
+/// `(build_generation, path)` — served by V050's `idx_clone_subblock_postings_path` — and the
+/// file lookups key `files.path`, so no full postings scan runs (verified via EXPLAIN QUERY PLAN).
+fn delta_paths_from_hint(
+    conn: &Connection,
+    generation: i64,
+    hint: &BTreeSet<String>,
+) -> anyhow::Result<Vec<String>> {
+    // STALE: postings under this generation for `?2` with no eligible matching current file. The
+    // `p.path = ?2` seek matches `delta_paths`' STALE predicate narrowed to one path.
+    let mut stale = conn.prepare(
+        "SELECT EXISTS(
+            SELECT 1 FROM clone_subblock_postings p
+             WHERE p.build_generation = ?1 AND p.path = ?2
+               AND NOT EXISTS (SELECT 1 FROM files f
+                                WHERE f.path = p.path AND f.sha256 = p.file_sha
+                                  AND f.generated = 0))",
+    )?;
+    // FRESH: `?2` is an eligible fingerprinted file with no postings under this generation yet.
+    // Semantically `delta_paths`' FRESH predicate narrowed to one path, but written with `files f`
+    // as the SOLE outer table so the planner drives from the `f.path = ?2` seek (indexed via the
+    // scoped `files` view) instead of scanning every baseline fingerprint — the eligible-symbol
+    // check and the postings check are correlated EXISTS keyed by `s.file_id` / the postings path
+    // index.
+    let mut fresh = conn.prepare(
+        "SELECT EXISTS(
+            SELECT 1 FROM files f
+             WHERE f.path = ?2 AND f.generated = 0
+               AND EXISTS (SELECT 1 FROM symbols s
+                             JOIN symbol_fingerprints sf ON sf.symbol_id = s.id
+                            WHERE s.file_id = f.id
+                              AND sf.normalizer_kind = 'baseline'
+                              AND sf.normalizer_version = ?3
+                              AND sf.token_bag IS NOT NULL)
+               AND NOT EXISTS (SELECT 1 FROM clone_subblock_postings p
+                                WHERE p.build_generation = ?1 AND p.path = f.path))",
+    )?;
+    let mut set: BTreeSet<String> = BTreeSet::new();
+    for path in hint {
+        let is_stale: i64 = stale.query_row(params![generation, path], |r| r.get(0))?;
+        if is_stale != 0 {
+            set.insert(path.clone());
+            continue;
+        }
+        let is_fresh: i64 =
+            fresh.query_row(params![generation, path, NORM_VERSION], |r| r.get(0))?;
+        if is_fresh != 0 {
+            set.insert(path.clone());
+        }
+    }
+    Ok(set.into_iter().collect())
+}
+
 /// `(path, start_byte, file_sha)` anchors for every scoped, non-generated symbol in `paths` —
 /// `resolve_symbol_anchors` narrowed to the delta files.
 fn anchors_for_paths(conn: &Connection, paths: &[String]) -> anyhow::Result<BTreeMap<i64, Anchor>> {
@@ -576,12 +745,15 @@ fn old_struct_partners(
     Ok(partners)
 }
 
-/// The generation's persisted posting-row count — sizes the default #598 work budget.
-/// (`clone_subblock_postings` is generation-keyed, not `repo_id`-scoped: the generation id —
-/// itself resolved repo-scoped — is the scope.)
+/// The generation's cached posting-row count — sizes the default #598 work budget. Read from the
+/// maintained `clone_graph_generations.postings_row_count` column (#830) rather than a full
+/// `COUNT(*)` of the postings table: the column is seeded at build (`complete_generation`) and kept
+/// exact by each delta write-back, so it equals `COUNT(*)` for the generation on every read. (The
+/// generation id — itself resolved repo-scoped — is the scope; `clone_subblock_postings` is
+/// generation-keyed, not `repo_id`-scoped.)
 fn postings_row_count(conn: &Connection, generation: i64) -> anyhow::Result<u64> {
     let count: i64 = conn.query_row(
-        "SELECT COUNT(*) FROM clone_subblock_postings WHERE build_generation = ?1",
+        "SELECT postings_row_count FROM clone_graph_generations WHERE generation = ?1",
         [generation],
         |r| r.get(0),
     )?;
@@ -836,8 +1008,8 @@ impl<'a> CandidateHydrator<'a> {
 mod tests {
     use super::super::precompute::tests::{clone_fixture_config, edge_keys};
     use super::{
-        BTreeSet, CLONE_PRECOMPUTE_THETA, load_scoped_baseline_bags_for_paths, params,
-        sub_block_tokens,
+        BTreeSet, CLONE_PRECOMPUTE_THETA, CloneDeltaHint, load_scoped_baseline_bags_for_paths,
+        params, sub_block_tokens,
     };
     use crate::index::query_api::clones::precompute::CloneEdgeOptions;
 
@@ -1454,6 +1626,344 @@ mod tests {
         assert!(
             report.posting_rows_fetched < report.posting_rows_requested,
             "shared tokens are served from the per-application cache: {report:?}"
+        );
+    }
+
+    /// #830: the hinted changed-set derivation must NEVER full-scan the (large) postings table —
+    /// that scan is exactly what the hint exists to avoid. Pin the query plans: both the STALE
+    /// point-lookup and the FRESH `NOT EXISTS` reach `clone_subblock_postings` through
+    /// `idx_clone_subblock_postings_path` (a SEARCH), and neither plan contains a full
+    /// `SCAN clone_subblock_postings`.
+    #[test]
+    fn hinted_changed_set_lookups_never_full_scan_the_postings_table() {
+        let _poison = crate::index::poison_sibling::disable_poison_sibling();
+        let config = clone_fixture_config("delta-hint-qplan");
+        let db = crate::IndexDatabase::rebuild(&config).unwrap();
+        assert_eq!(db.precompute_clone_graph(None).unwrap().status, "Complete");
+        let conn = db.storage.connection();
+
+        let plan = |sql: &str, binds: &[super::Value]| -> String {
+            let mut stmt = conn.prepare(&format!("EXPLAIN QUERY PLAN {sql}")).unwrap();
+            stmt.query_map(super::params_from_iter(binds.iter().cloned()), |r| {
+                r.get::<_, String>(3)
+            })
+            .unwrap()
+            .map(Result::unwrap)
+            .collect::<Vec<_>>()
+            .join(" | ")
+        };
+        let generation = super::Value::Integer(1);
+        let path = super::Value::Text("src/a.rs".to_string());
+        let norm = super::Value::Integer(rag_rat_clones::NORM_VERSION);
+
+        let stale_plan = plan(
+            "SELECT EXISTS(SELECT 1 FROM clone_subblock_postings p WHERE p.build_generation = ?1 \
+             AND p.path = ?2 AND NOT EXISTS (SELECT 1 FROM files f WHERE f.path = p.path AND \
+             f.sha256 = p.file_sha AND f.generated = 0))",
+            &[generation.clone(), path.clone()],
+        );
+        assert!(
+            stale_plan.contains("idx_clone_subblock_postings_path"),
+            "STALE lookup must seek the postings path index: {stale_plan}"
+        );
+        assert!(
+            !stale_plan.contains("SCAN clone_subblock_postings"),
+            "STALE lookup must not full-scan the postings table: {stale_plan}"
+        );
+
+        let fresh_plan = plan(
+            "SELECT EXISTS(SELECT 1 FROM files f WHERE f.path = ?2 AND f.generated = 0 AND EXISTS \
+             (SELECT 1 FROM symbols s JOIN symbol_fingerprints sf ON sf.symbol_id = s.id WHERE \
+             s.file_id = f.id AND sf.normalizer_kind = 'baseline' AND sf.normalizer_version = ?3 \
+             AND sf.token_bag IS NOT NULL) AND NOT EXISTS (SELECT 1 FROM clone_subblock_postings \
+             p WHERE p.build_generation = ?1 AND p.path = f.path))",
+            &[generation, path, norm],
+        );
+        assert!(
+            !fresh_plan.contains("SCAN clone_subblock_postings"),
+            "FRESH NOT EXISTS must not full-scan the postings table: {fresh_plan}"
+        );
+        assert!(
+            fresh_plan.contains("idx_clone_subblock_postings_path"),
+            "FRESH NOT EXISTS must seek the postings path index: {fresh_plan}"
+        );
+        // The FRESH check must drive from the `files.path` seek (via the scoped view's composite
+        // indexes), NOT scan every baseline fingerprint — otherwise the per-path cost grows with
+        // the corpus and the hint stops being a win.
+        assert!(
+            !fresh_plan.contains("SCAN sf") && !fresh_plan.contains("SCAN symbol_fingerprints"),
+            "FRESH check must not scan the fingerprint table: {fresh_plan}"
+        );
+    }
+
+    /// #830: the cached `clone_graph_generations.postings_row_count` is maintained transactionally
+    /// by each delta write-back (net inserted − deleted), so it stays EQUAL to a live `COUNT(*)` of
+    /// the generation's postings across an edit sequence — that equality is what makes the cheap
+    /// column read a sound substitute for the per-pass table scan the work budget used to pay.
+    #[test]
+    fn delta_maintains_the_cached_postings_row_count() {
+        let _poison = crate::index::poison_sibling::disable_poison_sibling();
+        let config = clone_fixture_config("delta-postings-count");
+        let db = crate::IndexDatabase::rebuild(&config).unwrap();
+        let built = db.precompute_clone_graph(None).unwrap();
+        assert_eq!(built.status, "Complete");
+        let generation = built.generation;
+
+        // The build's COUNT seed already matches the postings it just wrote.
+        let cached_matches_scan = |db: &crate::IndexDatabase| {
+            let conn = db.storage.connection();
+            let cached: i64 = conn
+                .query_row(
+                    "SELECT postings_row_count FROM clone_graph_generations WHERE generation = ?1",
+                    [generation],
+                    |r| r.get(0),
+                )
+                .unwrap();
+            let scanned: i64 = conn
+                .query_row(
+                    "SELECT COUNT(*) FROM clone_subblock_postings WHERE build_generation = ?1",
+                    [generation],
+                    |r| r.get(0),
+                )
+                .unwrap();
+            assert_eq!(cached, scanned, "cached postings_row_count must equal COUNT(*)");
+        };
+        cached_matches_scan(&db);
+        drop(db);
+
+        // An edit sequence that both REMOVES postings (edited/deleted files) and ADDS them (a new
+        // near-clone member), each applied in place — the net-delta maintenance must track both.
+        let steps: &[(&str, Option<&str>)] = &[
+            (
+                "src/c.rs",
+                Some(
+                    "pub fn load_invoice(db: Db) -> i32 { let v = db.get(30); validate(v); v + 1 \
+                     }\n",
+                ),
+            ),
+            (
+                "src/a.rs",
+                Some(
+                    "pub fn load_user(db: Db) -> i32 { let u = db.get(10); validate(u); u + 1 \
+                     }\npub fn compute_totals(items: Vec<i64>) -> i64 { let mut s = 0; for it in \
+                     items { s += it * 2; } s + 1 }\npub fn sum_figures(rows: Vec<i64>) -> i64 { \
+                     let mut f = 0; for r in rows { f += r * 2; } f + 1 }\n",
+                ),
+            ),
+            ("src/b.rs", None),
+        ];
+        for (path, content) in steps {
+            let target = config.root.join(path);
+            match content {
+                Some(text) => std::fs::write(&target, text).unwrap(),
+                None => std::fs::remove_file(&target).unwrap(),
+            }
+            let db = reindex(&config);
+            assert_eq!(
+                db.apply_clone_graph_delta(64).unwrap().status,
+                "Applied",
+                "delta for {path}"
+            );
+            cached_matches_scan(&db);
+        }
+    }
+
+    /// THE #830 correctness pin: a delta driven by a `Paths` hint produces the IDENTICAL result as
+    /// one driven by the `FullScan` DB derivation — same `CloneDeltaReport` (files_changed,
+    /// edges_added/removed, full_rebuild_owed) AND the same resulting edge set. The hint is
+    /// exercised with a set that COULD disagree: it names an UNCHANGED base file alongside the
+    /// changed/new ones, so `delta_paths_from_hint` must filter the unchanged one back out to match
+    /// the scan (a hint that blindly trusted its paths would emit different edges). Run on two
+    /// identical DBs — the delta mutates, so the two derivations can't share one.
+    #[test]
+    fn a_hinted_delta_equals_the_full_scan_delta() {
+        let _poison = crate::index::poison_sibling::disable_poison_sibling();
+
+        // Two byte-identical fixtures, taken through the SAME rebuild + precompute + edit +
+        // reindex, so only the delta's changed-set derivation differs between them.
+        let prepare = |tag: &str| -> (rag_rat_base::config::Config, crate::IndexDatabase) {
+            let config = clone_fixture_config(tag);
+            let db = crate::IndexDatabase::rebuild(&config).unwrap();
+            assert_eq!(db.precompute_clone_graph(None).unwrap().status, "Complete");
+            drop(db);
+            // Edit an existing clone-family file AND add a new near-clone member; src/b.rs is left
+            // untouched (the "could disagree" element the hint names but the scan excludes).
+            std::fs::write(
+                config.root.join("src/a.rs"),
+                "pub fn load_user(db: Db) -> i32 { let u = db.get(10); validate(u); u + 1 }\npub \
+                 fn compute_totals(items: Vec<i64>) -> i64 { let mut s = 0; for it in items { s \
+                 += it * 2; } s + 1 }\npub fn sum_figures(rows: Vec<i64>) -> i64 { let mut f = 0; \
+                 for r in rows { f += r * 2; } f + 1 }\n",
+            )
+            .unwrap();
+            std::fs::write(
+                config.root.join("src/c.rs"),
+                "pub fn load_invoice(db: Db) -> i32 { let v = db.get(30); validate(v); v + 1 }\n",
+            )
+            .unwrap();
+            let db = reindex(&config);
+            (config, db)
+        };
+
+        let (_scan_config, scan_db) = prepare("delta-hint-scan");
+        let scan_report =
+            scan_db.apply_clone_graph_delta_hinted(64, CloneDeltaHint::FullScan).unwrap();
+        let scan_edges = edge_keys(&scan_db);
+
+        let (_hint_config, hint_db) = prepare("delta-hint-paths");
+        // The hint the reconcile would supply: the reindexed/new paths PLUS an unchanged base file.
+        let touched: BTreeSet<String> =
+            ["src/a.rs", "src/b.rs", "src/c.rs"].iter().map(|s| s.to_string()).collect();
+        let hint_report =
+            hint_db.apply_clone_graph_delta_hinted(64, CloneDeltaHint::Paths(&touched)).unwrap();
+        let hint_edges = edge_keys(&hint_db);
+
+        assert_eq!(scan_report.status, "Applied", "scan applied: {scan_report:?}");
+        assert_eq!(hint_report.status, "Applied", "hint applied: {hint_report:?}");
+        assert_eq!(
+            (hint_report.files_changed, hint_report.edges_added, hint_report.edges_removed),
+            (scan_report.files_changed, scan_report.edges_added, scan_report.edges_removed),
+            "hinted counts must equal the scan's: hint={hint_report:?} scan={scan_report:?}"
+        );
+        assert_eq!(
+            hint_report.full_rebuild_owed, scan_report.full_rebuild_owed,
+            "hinted drift bookkeeping must equal the scan's"
+        );
+        assert_eq!(
+            hint_edges, scan_edges,
+            "the hinted delta's resulting edge set must equal the full-scan delta's"
+        );
+    }
+
+    /// #830: a `Paths` hint whose every path is clone-IRRELEVANT (a docs / fingerprint-less edit)
+    /// makes `delta_paths_from_hint` return empty, so the delta takes the same re-pin branch as an
+    /// empty `delta_paths` — `Applied` with zero files, no edge churn, freshness key re-pinned —
+    /// and never touches the postings corpus.
+    #[test]
+    fn a_clone_irrelevant_hint_repins_without_scanning() {
+        let _poison = crate::index::poison_sibling::disable_poison_sibling();
+        let config = clone_fixture_config("delta-hint-irrelevant");
+        let db = crate::IndexDatabase::rebuild(&config).unwrap();
+        assert_eq!(db.precompute_clone_graph(None).unwrap().status, "Complete");
+        let edges_before = edge_keys(&db);
+        drop(db);
+
+        // A type-only file: indexed (revision moves) but no function fingerprints →
+        // clone-irrelevant.
+        std::fs::write(config.root.join("src/j.rs"), "pub struct MarkerOnly;\n").unwrap();
+        let db = reindex(&config);
+        let touched: BTreeSet<String> = ["src/j.rs"].iter().map(|s| s.to_string()).collect();
+        let report =
+            db.apply_clone_graph_delta_hinted(64, CloneDeltaHint::Paths(&touched)).unwrap();
+        assert_eq!(report.status, "Applied", "{report:?}");
+        assert_eq!(report.files_changed, 0, "no clone-relevant path in the hint");
+        assert_eq!(report.edges_added + report.edges_removed, 0);
+        assert_eq!(edge_keys(&db), edges_before, "the graph itself is untouched");
+        assert!(!db.pending_clone_graph().unwrap(), "the freshness key is re-pinned");
+    }
+
+    /// #830 SelfHeal: a `generated`-flag flip changes `files.generated`, not `(path, sha256)`, so
+    /// `content_revision()` does NOT move and a `FullScan`/`Paths` delta returns `Noop` before the
+    /// changed-set derivation — the flipped file's now-ineligible postings linger. `SelfHeal`
+    /// bypasses that revision-equality early return, scans, and removes them. This pins the exact
+    /// gap the gc-cadence self-heal closes: a plain `FullScan` on the SAME drift `Noop`s past it,
+    /// so the two derivations must DISAGREE here or the self-heal would be dead code.
+    #[test]
+    fn self_heal_repairs_generated_flip_drift_a_full_scan_noops_past() {
+        let _poison = crate::index::poison_sibling::disable_poison_sibling();
+        let config = clone_fixture_config("delta-selfheal-genflip");
+        let db = crate::IndexDatabase::rebuild(&config).unwrap();
+        assert_eq!(db.precompute_clone_graph(None).unwrap().status, "Complete");
+
+        let flipped: String = db
+            .storage
+            .connection()
+            .query_row(
+                "SELECT DISTINCT path FROM clone_subblock_postings ORDER BY path LIMIT 1",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        let postings_for = |db: &crate::IndexDatabase| -> i64 {
+            db.storage
+                .connection()
+                .query_row(
+                    "SELECT COUNT(*) FROM clone_subblock_postings WHERE path = ?1",
+                    [&flipped],
+                    |r| r.get(0),
+                )
+                .unwrap()
+        };
+        assert!(postings_for(&db) > 0, "the flipped file starts with postings");
+
+        // Flip it to generated = 1 directly (the `rederive_generated_flags` mechanism); the #828
+        // content-digest trigger keys on path/sha256/kind, so the revision is unmoved.
+        let revision_before = db.content_revision().unwrap();
+        db.storage
+            .connection()
+            .execute("UPDATE main.files SET generated = 1 WHERE path = ?1", [&flipped])
+            .unwrap();
+        assert_eq!(
+            db.content_revision().unwrap(),
+            revision_before,
+            "a generated-flag flip does not move content_revision"
+        );
+
+        // A plain FullScan honors the revision-equality fast path: Noop, drift left in place.
+        let full = db.apply_clone_graph_delta_hinted(64, CloneDeltaHint::FullScan).unwrap();
+        assert_eq!(full.status, "Noop", "FullScan Noops when the revision is unchanged: {full:?}");
+        assert!(
+            postings_for(&db) > 0,
+            "FullScan left the stale postings — the gap SelfHeal closes"
+        );
+
+        // SelfHeal scans past the early return and drops the now-ineligible file's postings.
+        let heal = db.apply_clone_graph_delta_hinted(64, CloneDeltaHint::SelfHeal).unwrap();
+        assert_eq!(heal.status, "Applied", "SelfHeal applies the drift repair: {heal:?}");
+        assert_eq!(postings_for(&db), 0, "SelfHeal removed the generated file's stale postings");
+    }
+
+    /// #830: when `SelfHeal` finds MORE revision-neutral drift than the delta cap it `Escalate`s
+    /// WHILE `clone_graph_stale_against` still reports the graph fresh (the revision never moved).
+    /// That is the exact `(Escalate, !stale)` state the watcher keys its forced full rebuild on —
+    /// the quiet gate keys on revision movement and would otherwise suppress the rebuild forever.
+    /// Uses a tiny `max_files` so two generated-flipped files exceed the cap.
+    #[test]
+    fn self_heal_escalates_while_fresh_when_revision_neutral_drift_exceeds_the_cap() {
+        let _poison = crate::index::poison_sibling::disable_poison_sibling();
+        let config = clone_fixture_config("delta-selfheal-escalate");
+        let db = crate::IndexDatabase::rebuild(&config).unwrap();
+        assert_eq!(db.precompute_clone_graph(None).unwrap().status, "Complete");
+
+        let conn = db.storage.connection();
+        let flip: Vec<String> = conn
+            .prepare("SELECT DISTINCT path FROM clone_subblock_postings ORDER BY path LIMIT 2")
+            .unwrap()
+            .query_map([], |r| r.get::<_, String>(0))
+            .unwrap()
+            .map(Result::unwrap)
+            .collect();
+        assert_eq!(flip.len(), 2, "fixture has at least two files with postings");
+        let revision_before = db.content_revision().unwrap();
+        for path in &flip {
+            conn.execute("UPDATE main.files SET generated = 1 WHERE path = ?1", [path]).unwrap();
+        }
+        assert_eq!(
+            db.content_revision().unwrap(),
+            revision_before,
+            "flipping generated flags does not move the revision"
+        );
+
+        // Cap of 1 < 2 drifted paths → Escalate; and the graph still reads fresh against the
+        // (unmoved) revision — the watcher's `force_revision_neutral_rebuild` condition.
+        let report = db.apply_clone_graph_delta_hinted(1, CloneDeltaHint::SelfHeal).unwrap();
+        assert_eq!(
+            report.status, "Escalate",
+            "oversized revision-neutral drift escalates: {report:?}"
+        );
+        assert!(
+            !db.clone_graph_stale().unwrap(),
+            "the graph is fresh against the revision, so the quiet gate would suppress the rebuild"
         );
     }
 }

--- a/crates/rag-rat-core/src/index/query_api/clones/precompute.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/precompute.rs
@@ -169,6 +169,15 @@ impl IndexDatabase {
 
     /// The staleness core of [`Self::pending_clone_graph`], against an already-computed
     /// `content_revision()` so the quiet gate pays the digest once per probe.
+    /// Whether the live clone generation is stale against the CURRENT `content_revision()` — the
+    /// revision-keyed staleness the quiet gate reads. `false` for a graph that looks fresh, which
+    /// is why a revision-neutral `SelfHeal` Escalate needs a forced rebuild (#830,
+    /// `watch::pass`): the drift is real but the revision — hence this check — cannot see it.
+    pub(crate) fn clone_graph_stale(&self) -> anyhow::Result<bool> {
+        let revision = self.content_revision()?;
+        self.clone_graph_stale_against(&revision)
+    }
+
     fn clone_graph_stale_against(&self, content_revision: &str) -> anyhow::Result<bool> {
         let conn = self.storage.connection();
         let Some(live) = live_generation_row(conn)? else {
@@ -548,9 +557,14 @@ impl IndexDatabase {
     fn complete_generation(&self, generation: i64, edges_written: u64) -> anyhow::Result<()> {
         let conn = self.storage.connection();
         conn.execute(
+            // Seed the cached posting-row count (#830) from one COUNT at publish time — the
+            // generation's postings are fully written by now, and the delta pass maintains this
+            // incrementally thereafter, so this is the only full COUNT the graph ever pays.
             "UPDATE clone_graph_generations
                 SET status = 'Complete', finished_at_ms = ?1, edges_written = ?2,
-                    postings_written = 1
+                    postings_written = 1,
+                    postings_row_count = (SELECT COUNT(*) FROM clone_subblock_postings
+                                           WHERE build_generation = ?3)
               WHERE generation = ?3",
             params![now_ms(), edges_written as i64, generation],
         )?;
@@ -846,12 +860,16 @@ pub(super) fn insert_edge_rows(
 }
 
 /// Insert every posting group's per-token rows for `generation` (idempotent, content-key PK).
-/// Shared by `flush_batch` and the delta pass; runs inside the CALLER's transaction.
+/// Shared by `flush_batch` and the delta pass; runs inside the CALLER's transaction. Returns the
+/// number of rows ACTUALLY inserted (the `INSERT OR IGNORE` row-change sum, so a content-key
+/// collision is not counted) — the exact delta the delta pass adds to the cached
+/// `postings_row_count` (#830).
 pub(super) fn insert_posting_groups(
     conn: &Connection,
     generation: i64,
     postings: &[PostingGroup],
-) -> anyhow::Result<()> {
+) -> anyhow::Result<u64> {
+    let mut inserted = 0u64;
     let mut stmt = conn.prepare_cached(
         "INSERT OR IGNORE INTO clone_subblock_postings
             (build_generation, token_hash, path, start_byte, file_sha)
@@ -860,10 +878,11 @@ pub(super) fn insert_posting_groups(
     for g in postings {
         let (path, start_byte, file_sha) = &g.anchor;
         for &token_hash in &g.tokens {
-            stmt.execute(params![generation, token_hash, path, start_byte, file_sha])?;
+            inserted +=
+                stmt.execute(params![generation, token_hash, path, start_byte, file_sha])? as u64;
         }
     }
-    Ok(())
+    Ok(inserted)
 }
 
 /// Whether `generation`'s postings can be ORDERED for serving (#479): its pinned df epoch

--- a/crates/rag-rat-core/src/index/query_api/mod.rs
+++ b/crates/rag-rat-core/src/index/query_api/mod.rs
@@ -26,6 +26,7 @@ mod search;
 // the capped-class semantics by name (instead of hardcoding 50). Keeps the `clones` module
 // private so `build_class`'s reachability stays narrow (no `private_interfaces` widening of
 // `SymbolBag`).
+pub(crate) use clones::delta::CloneDeltaHint;
 pub use clones::delta::{CLONE_DELTA_MAX_FILES, CloneDeltaReport};
 pub use clones::of_text::{CloneCheckInput, CloneFingerprintHealth, TextCloneMatch};
 pub use clones::precompute::CloneEdgeReport;

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/content_digest.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/content_digest.rs
@@ -74,7 +74,8 @@ const FOLD_TRIGGERS: [&str; 3] =
 
 /// V086 creates `content_digest_state` (seeded empty on a fresh ladder) and the three fold
 /// triggers. The absolute schema-tip pin has moved forward to the newest migration's test
-/// (V087, `migration_087_is_the_tip_and_adds_table_sync_tables`).
+/// (V088, `migration_088_caches_the_generation_posting_row_count`); this keeps only the symbolic
+/// "schema at LATEST after apply" check per the ladder convention.
 #[test]
 fn content_digest_state_has_live_fold_triggers() {
     let conn = apply_schema();

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/git_history_reload.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/git_history_reload.rs
@@ -992,13 +992,16 @@ fn index_discover_reporting_flags_content_changes() {
     IndexDatabase::rebuild(&config).unwrap();
 
     // No change → reports false, so the watch loop skips the reconcile / memory-validate tail.
-    let (_db, changed) = IndexDatabase::index_discover_reporting(&config).unwrap();
-    assert!(!changed, "an unchanged discover sweep must report no content change");
+    let (_db, pass) = IndexDatabase::index_discover_reporting(&config).unwrap();
+    assert!(!pass.content_changed, "an unchanged discover sweep must report no content change");
 
     // A new file on disk → reports true.
     fs::write(root.join("docs/extra.md"), "# Extra\nbody text\n").unwrap();
-    let (_db, changed) = IndexDatabase::index_discover_reporting(&config).unwrap();
-    assert!(changed, "a discover sweep that indexes a new file must report a content change");
+    let (_db, pass) = IndexDatabase::index_discover_reporting(&config).unwrap();
+    assert!(
+        pass.content_changed,
+        "a discover sweep that indexes a new file must report a content change"
+    );
 
     let _ = fs::remove_dir_all(root);
 }
@@ -1023,10 +1026,10 @@ fn discover_relanguages_h_when_binding_changes_c_to_cpp() {
     assert_eq!(lang, "c", "indexed as C under the c binding");
     drop(db);
 
-    let (db, changed) =
+    let (db, pass) =
         IndexDatabase::index_discover_reporting(&source_config(root.clone(), Language::Cpp))
             .unwrap();
-    assert!(changed, "re-languaging a .h with unchanged content must report a change");
+    assert!(pass.content_changed, "re-languaging a .h with unchanged content must report a change");
     let lang: String = db
         .storage
         .connection()

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/head_move_carry.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/head_move_carry.rs
@@ -132,8 +132,8 @@ fn a_head_move_carries_unchanged_rows_and_rederives_only_the_diff() {
     let new_head = head_sha(&root);
     assert_ne!(old_head, new_head);
 
-    let (db, content_changed) = IndexDatabase::index_discover_reporting(&config).unwrap();
-    assert!(content_changed, "the edited file is a real content change");
+    let (db, pass) = IndexDatabase::index_discover_reporting(&config).unwrap();
+    assert!(pass.content_changed, "the edited file is a real content change");
 
     // keep.rs: the SAME row (and its chunks) re-stamped to the new commit — no re-derive.
     let keep_rows = committed_rows(&db, "src/keep.rs");
@@ -205,8 +205,8 @@ fn a_branch_switch_back_carries_everything_with_no_rederive() {
     // old row — left behind at the main head with main's content — matches disk again. Nothing
     // re-derives, so the pass reports no content change.
     run_git(&root, &["checkout", "-q", "main"]);
-    let (db, content_changed) = IndexDatabase::index_discover_reporting(&config).unwrap();
-    assert!(!content_changed, "a switch back to already-derived content re-derives nothing");
+    let (db, pass) = IndexDatabase::index_discover_reporting(&config).unwrap();
+    assert!(!pass.content_changed, "a switch back to already-derived content re-derives nothing");
     assert_eq!(active_row_id(&db, "src/keep.rs"), Some(keep_id));
     assert_eq!(
         active_row_id(&db, "src/edit.rs"),
@@ -555,8 +555,8 @@ fn a_carry_only_pass_still_refreshes_package_roots() {
     run_git(&root, &["commit", "-q", "-m", "docs only"]);
     let new_head = head_sha(&root);
 
-    let (db, content_changed) = IndexDatabase::index_discover_reporting(&config).unwrap();
-    assert!(!content_changed, "no indexed content changed across the move");
+    let (db, pass) = IndexDatabase::index_discover_reporting(&config).unwrap();
+    assert!(!pass.content_changed, "no indexed content changed across the move");
     let package_rows: Vec<(String, String)> = {
         let conn = db.storage.connection();
         let mut stmt =

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
@@ -3850,7 +3850,7 @@ fn migration_084_links_chunks_to_symbols() {
 
 /// V085 adds sync provenance (`origin`) to the read tables + edge tombstones (`present`) to the
 /// content-edge projection. The absolute schema-tip pin lives on the newest migration's test
-/// (V087, `migration_087_is_the_tip_and_adds_table_sync_tables`).
+/// (V088, `migration_088_caches_the_generation_posting_row_count`).
 #[test]
 fn migration_085_adds_origin_and_edge_present() {
     // Bare pre-V085 tables (no origin / present), each with a pre-existing row, so the migration is
@@ -3927,11 +3927,10 @@ fn migration_085_adds_origin_and_edge_present() {
     assert_eq!(recorded, 1, "the forward migration records V085");
 }
 
-/// V087 adds the table→log sync engine's bookkeeping tables, and is the schema tip.
+/// V087 adds the table→log sync engine's bookkeeping tables. (No longer the schema tip — the
+/// absolute pin moved to `migration_088_caches_the_generation_posting_row_count`.)
 #[test]
-fn migration_087_is_the_tip_and_adds_table_sync_tables() {
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 87, "move this pin with the next schema migration");
-
+fn migration_087_adds_table_sync_tables() {
     let added =
         ["table_sync_entries", "sync_published_rows", "sync_row_tombstones", "sync_row_clocks"];
 
@@ -3982,4 +3981,68 @@ fn migration_087_is_the_tip_and_adds_table_sync_tables() {
         )
         .unwrap();
     assert_eq!(recorded, 1, "the forward migration records V087");
+}
+
+/// V088 (#830) caches each clone generation's posting-row count on its generation row so the #598
+/// delta work budget reads one column instead of a full `COUNT(*)` scan of the postings table.
+/// Carries the absolute schema-tip pin now that V088 is newest. Verifies the column exists on a
+/// fresh ladder and that the applier backfills an existing generation from its actual postings.
+#[test]
+fn migration_088_caches_the_generation_posting_row_count() {
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 88, "move this pin with the next schema migration");
+
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn, &crate::index::migration_hooks()).unwrap();
+    assert_eq!(
+        schema::status(&conn).unwrap().current_version,
+        schema::LATEST_SCHEMA_VERSION,
+        "schema at LATEST after apply"
+    );
+    assert!(
+        conn_table_columns(&conn, "clone_graph_generations")
+            .contains(&"postings_row_count".to_string()),
+        "generations carry the cached posting-row count that sizes the #598 work budget (#830)"
+    );
+
+    // Seed a generation with three postings, then DROP the column and re-run the applier in
+    // isolation: the backfill must recompute the count from the actual postings, not leave it 0.
+    conn.execute(
+        "INSERT INTO clone_graph_generations
+            (generation, status, theta_floor, normalizer_kind, normalizer_version,
+             source_revision, started_at_ms, postings_written)
+         VALUES (7, 'Complete', 0.7, 'baseline', 3, 'rev', 0, 1)",
+        [],
+    )
+    .unwrap();
+    for token in [10, 20, 30] {
+        conn.execute(
+            "INSERT INTO clone_subblock_postings
+                (build_generation, token_hash, path, start_byte, file_sha)
+             VALUES (7, ?1, 'src/a.rs', ?1, 'sha')",
+            [token],
+        )
+        .unwrap();
+    }
+    conn.execute_batch("ALTER TABLE clone_graph_generations DROP COLUMN postings_row_count;")
+        .unwrap();
+    schema::apply_clone_postings_row_count(&conn).unwrap();
+    let backfilled: i64 = conn
+        .query_row(
+            "SELECT postings_row_count FROM clone_graph_generations WHERE generation = 7",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(backfilled, 3, "the backfill counts the generation's actual postings");
+
+    // Additive + idempotent: a re-apply keeps the column and its value.
+    schema::apply_clone_postings_row_count(&conn).unwrap();
+    let after_reapply: i64 = conn
+        .query_row(
+            "SELECT postings_row_count FROM clone_graph_generations WHERE generation = 7",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(after_reapply, 3, "a re-apply recomputes the same exact count");
 }

--- a/crates/rag-rat-core/src/watch/event_loop.rs
+++ b/crates/rag-rat-core/src/watch/event_loop.rs
@@ -624,8 +624,8 @@ pub(crate) fn shutdown_discover(config: &Config) -> anyhow::Result<bool> {
             // it preserves #460's shutdown-reconcile debt: a content change on the way out marks
             // the base reconcile owed so the next startup pays it down.
             match IndexDatabase::index_discover_reporting(config) {
-                Ok((db, content_changed)) => {
-                    if content_changed {
+                Ok((db, pass)) => {
+                    if pass.content_changed {
                         db.mark_watch_shutdown_reconcile_pending()?;
                         return Ok(true);
                     }

--- a/crates/rag-rat-core/src/watch/pass.rs
+++ b/crates/rag-rat-core/src/watch/pass.rs
@@ -325,13 +325,17 @@ fn run_pass(
     // appears. A recorded root going empty still prunes (not first-time → not refused). The
     // one-shot `index` command instead surfaces the same error to the operator.
     let discover = timings.stage("discover", || IndexDatabase::index_discover_reporting(config));
-    let (mut db, content_changed) = match discover {
+    let (mut db, pass) = match discover {
         Ok(result) => result,
         Err(err) if err.downcast_ref::<crate::index::EmptyIndexRefused>().is_some() => {
             return Ok(());
         },
         Err(err) => return Err(err),
     };
+    let content_changed = pass.content_changed;
+    // #830: the clone-delta changed-set hint this pass produced (the base paths it reindexed or
+    // deleted, or `None` when the pass can't offer a reliable superset — a heal / bootstrap).
+    let clone_delta_hint = pass.clone_delta_hint;
     // Persist the resident watcher's watch-placement failure count (as a high-water mark) so
     // `index_status` can surface silently-dropped watches — a directory whose watch failed (ENOSPC
     // on Linux) falls back to this very sweep, but without this the degradation is invisible. This
@@ -446,15 +450,43 @@ fn run_pass(
         // the next pass. `content_revision()` is an O(1) state read (#828), so the delta recomputes
         // it directly against the `files` rows as committed — no pinned digest is threaded from the
         // probe.
-        let clone_full_rebuild_owed = match timings.stage("clone_delta", || {
-            db.apply_clone_graph_delta(crate::index::CLONE_DELTA_MAX_FILES)
-        }) {
-            Ok(delta) if delta.status == "Applied" || delta.status == "Noop" =>
-                delta.full_rebuild_owed,
+        // #830: normally derive the delta's changed set from this pass's reindexed/deleted paths
+        // (`Paths`) — indexed point-lookups instead of two corpus scans. On the gc cadence run the
+        // `SelfHeal` sweep instead: a full scan that runs EVEN when the revision is unchanged, so
+        // it repairs drift the content digest cannot see (a generated-flag flip, which
+        // moves no revision and would otherwise sit until the full rebuild). Reusing
+        // `run_gc` — the same periodic full-reconcile cadence gc already runs (prune + the
+        // #828 parity scan) — bounds that drift window. When a non-gc pass cannot offer a
+        // reliable hint (a stale-overlay heal / bootstrap left `clone_delta_hint = None`)
+        // the revision has still moved, so a plain `FullScan` derives the set. Load-bearing
+        // — do not collapse `SelfHeal` into `FullScan`.
+        let hint = if run_gc {
+            crate::index::CloneDeltaHint::SelfHeal
+        } else {
+            match &clone_delta_hint {
+                Some(touched) => crate::index::CloneDeltaHint::Paths(touched),
+                None => crate::index::CloneDeltaHint::FullScan,
+            }
+        };
+        let delta = timings.stage("clone_delta", || {
+            db.apply_clone_graph_delta_hinted(crate::index::CLONE_DELTA_MAX_FILES, hint)
+        });
+        let clone_full_rebuild_owed = match &delta {
+            Ok(d) if d.status == "Applied" || d.status == "Noop" => d.full_rebuild_owed,
             _ => true,
         };
+        // #830: a gc-cadence `SelfHeal` that ESCALATED while the graph is still FRESH against the
+        // revision found more revision-neutral drift (a mass generated-reclassification) than the
+        // delta cap. The quiet gate (`clone_graph_due`) keys on revision movement, so it never arms
+        // for a fresh-looking graph — that drift would sit unrepaired across every gc pass. Force
+        // the rebuild past the gate for exactly that case. A revision-MOVED Escalate leaves
+        // `source_revision != content_revision` (stale), so the quiet gate handles it as usual and
+        // this bypass does not weaken that thrash-prevention; a `Paths` delta only escalates on a
+        // moved revision, so it is never fresh here.
+        let force_revision_neutral_rebuild =
+            matches!(&delta, Ok(d) if d.status == "Escalate") && !db.clone_graph_stale()?;
         if clone_full_rebuild_owed
-            && clone_graph_due
+            && (clone_graph_due || force_revision_neutral_rebuild)
             && let Some(options) = budget.next_options()
         {
             let _ = timings.stage("clone_rebuild", || {

--- a/crates/rag-rat-db/src/schema/migrations.rs
+++ b/crates/rag-rat-db/src/schema/migrations.rs
@@ -1373,6 +1373,7 @@ pub(crate) fn known_version(migrations: &[AppliedMigration]) -> u32 {
             MIGRATION_085_ID => Some(85),
             MIGRATION_086_ID => Some(86),
             MIGRATION_087_ID => Some(87),
+            MIGRATION_088_ID => Some(88),
             _ => None,
         })
         .max()
@@ -1469,6 +1470,7 @@ pub(crate) fn known_migration(id: &str) -> bool {
             | MIGRATION_085_ID
             | MIGRATION_086_ID
             | MIGRATION_087_ID
+            | MIGRATION_088_ID
             | DIRTY_MIGRATION_ID
     )
 }
@@ -1562,6 +1564,7 @@ pub(crate) fn migration_checksum_mismatch(migration: &AppliedMigration) -> bool 
         MIGRATION_085_ID => migration.checksum != MIGRATION_085_CHECKSUM,
         MIGRATION_086_ID => migration.checksum != MIGRATION_086_CHECKSUM,
         MIGRATION_087_ID => migration.checksum != MIGRATION_087_CHECKSUM,
+        MIGRATION_088_ID => migration.checksum != MIGRATION_088_CHECKSUM,
         _ => false,
     }
 }
@@ -6073,6 +6076,39 @@ pub fn apply_table_sync_tables(conn: &Connection) -> rusqlite::Result<()> {
          ) STRICT;",
     )?;
     tx.commit()
+}
+
+/// V088 (#830): cache each clone generation's posting-row count on its generation row.
+///
+/// The #598 delta work budget is `max(100_000, 2 * postings_row_count(generation))`; deriving that
+/// with `COUNT(*) FROM clone_subblock_postings WHERE build_generation = ?` scanned the whole
+/// (generation-keyed) postings table on every delta pass. This adds a maintained
+/// `postings_row_count` column so the budget reads one generation row instead. The count is kept
+/// exact going forward — seeded at build (`complete_generation`) and adjusted by
+/// (inserted − deleted) in each delta write-back, both inside the same transaction as the postings
+/// change — so the column always equals `COUNT(*)` for that generation.
+///
+/// Additive + idempotent. The column type is STRICT-valid and defaulted so a row the backfill does
+/// not reach reads back 0. The backfill is UNCONDITIONAL (not gated on the column being freshly
+/// added): it recomputes the exact `COUNT(*)` the column is maintained to hold, so on a maintained
+/// DB a re-apply is a value no-op, and a torn add-then-crash retry (which re-enters with the column
+/// already present) still backfills instead of stranding an all-zero column. Re-scanning on the
+/// rare `index --full` re-apply is the acceptable cost of that robustness — the per-delta scan this
+/// migration removes is the hot one.
+pub fn apply_clone_postings_row_count(conn: &Connection) -> rusqlite::Result<()> {
+    add_column_if_missing(
+        conn,
+        "clone_graph_generations",
+        "postings_row_count",
+        "INTEGER NOT NULL DEFAULT 0",
+    )?;
+    conn.execute_batch(
+        "UPDATE clone_graph_generations
+            SET postings_row_count = (
+                SELECT COUNT(*) FROM clone_subblock_postings
+                 WHERE build_generation = clone_graph_generations.generation);",
+    )?;
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/rag-rat-db/src/schema/mod.rs
+++ b/crates/rag-rat-db/src/schema/mod.rs
@@ -10,10 +10,10 @@ pub use migrations::{
     apply_account_authority_boundaries, apply_account_authority_projection,
     apply_account_candidate_dag, apply_chunk_symbol_id, apply_clone_delta_maintenance,
     apply_clone_df_epoch, apply_clone_fingerprint_tables, apply_clone_graph_tables,
-    apply_content_candidate_dag, apply_content_digest_state, apply_content_projected_tables,
-    apply_content_refold_queue_and_stats, apply_content_streams_pending_refold,
-    apply_distill_anchor_selection, apply_distill_enriched_context,
-    apply_distill_evidence_source_part, apply_distill_record_store,
+    apply_clone_postings_row_count, apply_content_candidate_dag, apply_content_digest_state,
+    apply_content_projected_tables, apply_content_refold_queue_and_stats,
+    apply_content_streams_pending_refold, apply_distill_anchor_selection,
+    apply_distill_enriched_context, apply_distill_evidence_source_part, apply_distill_record_store,
     apply_distill_safe_input_snapshot, apply_dream_findings, apply_edge_string_interning,
     apply_edge_target_qname_index, apply_external_symbols, apply_files_generation,
     apply_files_has_test_code, apply_git_change_couplings, apply_github_child_key_widening,
@@ -47,7 +47,7 @@ use serde::Serialize;
 
 use crate::hooks::MigrationHooks;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 87;
+pub const LATEST_SCHEMA_VERSION: u32 = 88;
 
 /// Every oracle-DERIVED persisted table — the outputs an `oracle run` writes that must OUTLIVE a
 /// reindex.
@@ -643,7 +643,6 @@ const MIGRATION_086_DESCRIPTION: &str =
      (index_meta fts_source_revision/content_revision, clone_graph_generations.source_revision, \
      the clone-graph quiet candidate) that equals the frozen legacy digest so no one-time \
      FTS/clone rebuild fires. Replaces the O(N) main.files scan with an O(1) state read";
-
 const MIGRATION_087_ID: &str = "087_table_sync_bookkeeping";
 const MIGRATION_087_CHECKSUM: &str = "sha256:rag-rat-table-sync-bookkeeping-v87";
 const MIGRATION_087_DESCRIPTION: &str =
@@ -655,6 +654,15 @@ const MIGRATION_087_DESCRIPTION: &str =
      table_sync_entries (the engine's own signed hash-chained entry log, separate from \
      oplog_entries so the memory-content re-fold never sees a table op). All STRICT; no authored \
      content — pure sync bookkeeping the fold and producer read";
+const MIGRATION_088_ID: &str = "088_clone_postings_row_count";
+const MIGRATION_088_CHECKSUM: &str = "sha256:rag-rat-clone-postings-row-count-v88";
+const MIGRATION_088_DESCRIPTION: &str =
+    "Cache each clone generation's posting-row count on the generation row (#830): add \
+     clone_graph_generations.postings_row_count and backfill it from COUNT(*) of \
+     clone_subblock_postings per generation. The #598 delta work budget sizes off this count; \
+     reading a maintained column replaces a full COUNT(*) scan of the postings table on every \
+     delta pass. Additive; existing rows backfill from the current postings, and the count is \
+     then maintained transactionally at build (complete_generation) and in each delta write-back";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -1373,6 +1381,12 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         checksum: MIGRATION_087_CHECKSUM,
         description: MIGRATION_087_DESCRIPTION,
         apply: MigrationFn::Plain(apply_table_sync_tables),
+    },
+    Migration {
+        id: MIGRATION_088_ID,
+        checksum: MIGRATION_088_CHECKSUM,
+        description: MIGRATION_088_DESCRIPTION,
+        apply: MigrationFn::Plain(apply_clone_postings_row_count),
     },
 ];
 


### PR DESCRIPTION
## What

The incremental clone-graph delta re-derived its changed-file set from two corpus-scale scans **every pass**: `delta_paths` ran correlated `NOT EXISTS` seeks over the whole `clone_subblock_postings` table (~121k–220k rows) plus every baseline fingerprint, and the #598 work budget scanned the postings table again with `COUNT(*)`. Under watcher churn these repeated every pass with no cross-pass memo.

This replaces both with a reconcile-supplied changed-set hint and a maintained postings count.

## Changed-set hint

The reconcile already knows the base paths it reindexed or deleted this pass. `apply_clone_graph_delta` gains a `CloneDeltaHint`:

- **`Paths(touched)`** — the watcher's normal path: restrict the changed set to the hinted paths via indexed point-lookups (`delta_paths_from_hint`) instead of the two corpus scans. It returns `delta_paths() ∩ hint`, which equals `delta_paths()` whenever the hint is a **superset** of the truly-changed clone-relevant paths.
- **`FullScan`** — the DB-derived scan for callers without a hint (the CLI one-shot).
- **`SelfHeal`** — the gc-cadence sweep (see below).

**Soundness** rests on that superset property. Post-#828 `content_revision()` moves iff the `(path, sha256)` multiset of non-deleted files changes, so the delta reaches the changed-set derivation only when file content/set moved — exactly what the hint (reindexed ∪ deleted) reports. Two blind spots the digest can't see fall back to a scan so drift can't accumulate:

1. A **stale-overlay heal** mutates `files` rows the reindexed/deleted set doesn't name, so a healed pass withholds the hint (`clone_delta_hint = (healed == 0).then_some(…)`).
2. A **`generated`-flag flip** changes `files.generated`, not `(path, sha256)`, so it moves no revision and a `Paths`/`FullScan` delta returns `Noop` before the derivation. `SelfHeal` bypasses that revision-equality early return and scans anyway; the watcher runs it on the gc cadence (already an O(corpus) maintenance pass), so such drift is repaired within `GC_EVERY_PASSES`. When it exceeds the delta cap, `SelfHeal` escalates while the graph still reads *fresh* against the revision — a state the revision-keyed quiet gate would never rebuild — so the watcher forces the full rebuild past the gate for exactly that fresh-graph escalate, leaving the quiet gate's thrash-prevention intact for the revision-moved case.

## Cached postings count

New `clone_graph_generations.postings_row_count` column (**V087**), backfilled from `COUNT(*)`, seeded at build (`complete_generation`), and maintained by the net `(inserted − deleted)` delta in each write-back inside the same transaction as the postings change — so it always equals `COUNT(*)` for the generation. `postings_row_count()` reads the column instead of scanning.

## Measured (real index, gen 186, 140k postings)

| Operation | before | after |
|---|--:|--:|
| changed-set derivation (`delta_paths`) | ~14 s/pass (corpus scan) | O(edit): ~0.3 ms per changed path |
| budget sizing (`COUNT(*)` → column read) | 5664 µs | 5.1 µs (~1116×) |

The old derivation cost is O(corpus); the hinted derivation is O(changed files).

## Tests

Parity is preserved — `clone_graph_delta_matches_a_full_rebuild_over_an_edit_sequence` still drives the DB-derived path unchanged. New tests pin: the hinted delta equal to the full-scan delta (with a hint that names an unchanged file the scan filters out); `SelfHeal` repairing a generated-flip drift a `FullScan` `Noop`s past; `SelfHeal` escalating while fresh when the drift exceeds the cap; the empty-relevant-hint re-pin; the cached count equal to `COUNT(*)` across an edit sequence; the V087 backfill from real postings; and `EXPLAIN QUERY PLAN` that the hint lookups never full-scan the postings or fingerprint tables.

Fixes #830
