### PR TITLE
fix: green the cross-platform CI gate — macOS jemalloc startup crash, Windows clippy/tests

### DIFF
--- a/crates/rag-rat-cli/src/commands/remove.rs
+++ b/crates/rag-rat-cli/src/commands/remove.rs
@@ -425,11 +425,18 @@ mod tests {
         git(&main, &["worktree", "add", linked_b.to_str().unwrap(), "-b", "linked-b"]);
 
         let worktrees = worktree_dirs_for(&linked_a).unwrap();
-        let dirs = worktrees.dirs;
         assert!(worktrees.warnings.is_empty());
-        assert!(dirs.contains(&main));
-        assert!(dirs.contains(&linked_a));
-        assert!(dirs.contains(&linked_b));
+        // gix returns canonical worktree paths; the raw temp paths do not match on macOS (TempDir
+        // under /var → /private/var symlink) or Windows (canonicalize adds a \\?\-verbatim
+        // long-name form, and the temp dir uses an 8.3 short name). Canonicalize BOTH sides
+        // — the worktrees exist — so the compare is separator/prefix/symlink agnostic (and
+        // the set dedups too).
+        let canon = |p: &std::path::Path| std::fs::canonicalize(p).unwrap();
+        let dirs: std::collections::BTreeSet<std::path::PathBuf> =
+            worktrees.dirs.iter().map(|p| canon(p)).collect();
+        assert!(dirs.contains(&canon(&main)));
+        assert!(dirs.contains(&canon(&linked_a)));
+        assert!(dirs.contains(&canon(&linked_b)));
         assert_eq!(dirs.len(), 3, "overlapping root/current/proxy paths are deduplicated");
     }
 

--- a/crates/rag-rat-cli/src/init/run.rs
+++ b/crates/rag-rat-cli/src/init/run.rs
@@ -666,12 +666,15 @@ mod default_plan_tests {
         std::fs::create_dir_all(root.path().join("src")).unwrap();
         let db_path = root.path().join("index.sqlite");
         let config_path = root.path().join("rag-rat.toml");
+        // A Windows path (C:\...) in a TOML BASIC (double-quoted) string parses its backslashes as
+        // escape sequences (\U, \r, …) → a load error. Forward slashes are valid TOML and stay
+        // absolute on Windows, so `database` resolves to the same path.
+        let db_literal = db_path.display().to_string().replace('\\', "/");
         std::fs::write(
             &config_path,
             format!(
                 "[index]\nroot = \".\"\nrepo_id = \"rm-victim\"\ndatabase = \
-                 \"{}\"\n[target_bindings]\nrust = [\"src\"]\n",
-                db_path.display()
+                 \"{db_literal}\"\n[target_bindings]\nrust = [\"src\"]\n",
             ),
         )
         .unwrap();

--- a/crates/rag-rat-cli/src/main.rs
+++ b/crates/rag-rat-cli/src/main.rs
@@ -39,7 +39,12 @@ static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 /// decayed pages are only reclaimed on later alloc calls, which a quiet server rarely makes) and
 /// tighten the decay window from the 10s default so an idle server releases memory within ~1s.
 /// Best-effort — a server that holds slightly more RAM is better than one that won't boot.
-#[cfg(all(not(target_env = "msvc"), not(target_os = "android")))]
+///
+/// Skipped on macOS: jemalloc there rejects `background_thread` ("currently supports pthread only")
+/// and the subsequent `MALLCTL_ARENAS_ALL` (`arena.4096.*`) decay writes SEGFAULT the process at
+/// startup — crashing every `rag-rat` invocation before the command even runs. macOS keeps
+/// jemalloc as the allocator, just untuned (per the same boot-over-RAM priority above).
+#[cfg(all(not(target_env = "msvc"), not(target_os = "android"), not(target_os = "macos")))]
 fn configure_jemalloc() {
     use tikv_jemalloc_ctl::{background_thread, raw};
     // Purge decayed pages on a background thread; a quiet server makes few alloc calls, which is
@@ -63,7 +68,7 @@ fn main() -> anyhow::Result<()> {
     // Record this binary's git-stamped version (#585) so migration provenance and the stranded-
     // binary refusal name a dev build (`0.16.0+g<hash>`) distinctly from a release (`0.16.0`).
     rag_rat_base::version::set_binary_version(env!("RAG_RAT_VERSION"));
-    #[cfg(all(not(target_env = "msvc"), not(target_os = "android")))]
+    #[cfg(all(not(target_env = "msvc"), not(target_os = "android"), not(target_os = "macos")))]
     configure_jemalloc();
     let cli = Cli::parse();
 

--- a/crates/rag-rat-cli/src/main.rs
+++ b/crates/rag-rat-cli/src/main.rs
@@ -690,7 +690,12 @@ mod tests {
         let config = discover_target_config_optional(&root)
             .unwrap()
             .expect("the existing target checkout's governing config should load");
-        assert_eq!(config.database, root.join("custom/index.sqlite"));
+        // Config::load resolves the relative `database` against the CANONICALIZED config dir
+        // (normalize_existing_dir → fs::canonicalize): /var→/private/var on macOS, \\?\ + long name
+        // on Windows. Canonicalize the base and join components so the expectation matches
+        // natively.
+        let root = root.canonicalize().unwrap();
+        assert_eq!(config.database, root.join("custom").join("index.sqlite"));
         let _ = std::fs::remove_dir_all(root);
     }
 }

--- a/crates/rag-rat-cli/tests/agent_hook_e2e.rs
+++ b/crates/rag-rat-cli/tests/agent_hook_e2e.rs
@@ -19,11 +19,22 @@ fn run_hook(stdin_body: &str, cwd: &std::path::Path) -> (String, std::process::E
         .current_dir(cwd)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
-        .stderr(Stdio::null())
+        // Capture (do not discard) stderr so a non-zero exit — e.g. a startup abort before the
+        // hook's own always-Ok handler runs — surfaces its reason in the failing test's output
+        // instead of a bare `status.success()` assertion.
+        .stderr(Stdio::piped())
         .spawn()
         .unwrap();
     let _ = child.stdin.as_mut().unwrap().write_all(stdin_body.as_bytes());
     let out = child.wait_with_output().unwrap();
+    if !out.status.success() {
+        eprintln!(
+            "run_hook: `rag-rat agent-hook` exited unsuccessfully: {:?}\n--- captured stderr \
+             ---\n{}\n--- end stderr ---",
+            out.status,
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
     (String::from_utf8_lossy(&out.stdout).into_owned(), out.status)
 }
 

--- a/crates/rag-rat-core/src/index/ai/policy.rs
+++ b/crates/rag-rat-core/src/index/ai/policy.rs
@@ -32,7 +32,7 @@ pub(crate) fn policy_fromtext_calls() -> usize {
 /// stale-but-matching stamp would let the fast path serve mixed-code counts). A version mismatch
 /// instead correctly forces the slow recompute. See the freshness-model Risk memory bound to this
 /// file.
-pub(crate) const EMBEDDING_POLICY_VERSION: &str = "c426172dd063e4c0";
+pub(crate) const EMBEDDING_POLICY_VERSION: &str = "cc6a08883bce0a23";
 
 /// `repo_meta` keys carrying the embedding-policy freshness stamp a full rebuild writes
 /// (`mark_embedding_policy_current`). PER-REPO, not the DB-global `index_meta`: one database can
@@ -121,7 +121,12 @@ pub(crate) fn cheap_skip_policy(
     trimmed: &str,
     max_embedding_chars: usize,
 ) -> Option<EmbeddingPolicyDecision> {
-    let path_text = path.to_string_lossy();
+    // Use the SAME normalization the stored `files.path` uses (`paths::path_string`), so this
+    // index-time stamp classifies generated/fixture paths byte-identically to the reconcile
+    // recompute — which reads `files.path`. The raw `relative_path` is OS-native (`\` on Windows),
+    // so without this the stamp disagrees with the recompute there; going through `path_string`
+    // keeps it in lockstep with storage on every platform.
+    let path_text = rag_rat_base::paths::path_string(path);
     if trimmed.chars().count() > max_embedding_chars.saturating_mul(4)
         && (file_kind == "generated" || chunk_kind == "generated" || symbol_path.is_none())
     {
@@ -171,7 +176,9 @@ pub(crate) fn embedding_policy_for_chunk(
     if low_signal.is_low_signal(language, chunk_kind, symbol_path, trimmed) {
         return policy("SkipLowSignal", 9, false);
     }
-    let path_text = path.to_string_lossy();
+    // Normalize via `paths::path_string` as `cheap_skip_policy` does, so `embedding_priority`'s
+    // path heuristics see the same form the stored `files.path` uses on every platform.
+    let path_text = rag_rat_base::paths::path_string(path);
     policy("Embed", embedding_priority(&path_text, language, chunk_kind, symbol_path), true)
 }
 
@@ -612,6 +619,31 @@ mod policy_version_tests {
             (
                 "test_fixture_path",
                 "pkg/fixtures/a.rs",
+                "rust",
+                "source",
+                "code",
+                Some("s"),
+                "fn a() { let value = compute(); process(value); }",
+                4000,
+            ),
+            // Backslash paths (Windows `relative_path`): these classify as SkipGenerated /
+            // SkipTestFixture ONLY because the policy `/`-normalizes via `paths::path_string` — so
+            // they pin that normalization AND bump the version, which forces existing Windows
+            // indexes (stamped before the normalization) to re-stamp their
+            // `chunks.embedding_policy`.
+            (
+                "backslash_generated_path",
+                "pkg\\target\\a.rs",
+                "rust",
+                "source",
+                "code",
+                Some("s"),
+                "fn a() { let value = compute(); process(value); }",
+                4000,
+            ),
+            (
+                "backslash_test_fixture_path",
+                "pkg\\fixtures\\a.rs",
                 "rust",
                 "source",
                 "code",

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/mod.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/mod.rs
@@ -95,6 +95,10 @@ fn rag_rat_config(root: &Path) -> Config {
 fn git_history_test_config(root: &Path) -> Config {
     fs::create_dir_all(root.join("docs")).unwrap();
     fs::create_dir_all(root.join("src")).unwrap();
+    // Keep the live index out of the tree: a later `git add .` in this test would otherwise commit
+    // .rag-rat/index.sqlite, and the checkout/squash round-trip then removes/restores (and under
+    // Windows autocrlf can corrupt) that committed db, failing the subsequent index open.
+    fs::write(root.join(".gitignore"), ".rag-rat/\n").unwrap();
     run_git(root, &["init"]);
     run_git(root, &["config", "user.name", "Rag Rat"]);
     run_git(root, &["config", "user.email", "rag@example.com"]);
@@ -543,8 +547,23 @@ fn first_chunk_id(db: &IndexDatabase) -> i64 {
         .unwrap()
 }
 
+/// A `git` invocation with line-ending conversion forced OFF for this child process only. GitHub's
+/// windows-latest runner sets `core.autocrlf=true` globally, which rewrites the LF fixtures these
+/// tests write+index as CRLF on checkout — changing file bytes and thus the content sha256, which
+/// defeats the HEAD-move carry (#502) sha match and corrupts the committed index db. `GIT_CONFIG_*`
+/// overrides global config without touching the user's config.
+fn git_command(root: &Path, args: &[&str]) -> Command {
+    let mut cmd = Command::new("git");
+    cmd.args(args)
+        .current_dir(root)
+        .env("GIT_CONFIG_COUNT", "1")
+        .env("GIT_CONFIG_KEY_0", "core.autocrlf")
+        .env("GIT_CONFIG_VALUE_0", "false");
+    cmd
+}
+
 fn run_git(root: &Path, args: &[&str]) {
-    let output = Command::new("git").args(args).current_dir(root).output().unwrap();
+    let output = git_command(root, args).output().unwrap();
     assert!(
         output.status.success(),
         "git {:?} failed\nstdout:\n{}\nstderr:\n{}",
@@ -555,17 +574,12 @@ fn run_git(root: &Path, args: &[&str]) {
 }
 
 fn run_git_with_env(root: &Path, args: &[&str], env: &[(&str, &str)]) {
-    let output = Command::new("git")
-        .args(args)
-        .envs(env.iter().copied())
-        .current_dir(root)
-        .output()
-        .unwrap();
+    let output = git_command(root, args).envs(env.iter().copied()).output().unwrap();
     assert!(output.status.success(), "git {:?} failed", args);
 }
 
 fn git_output(root: &Path, args: &[&str]) -> String {
-    let output = Command::new("git").args(args).current_dir(root).output().unwrap();
+    let output = git_command(root, args).output().unwrap();
     assert!(output.status.success(), "git {:?} failed", args);
     String::from_utf8(output.stdout).unwrap().trim().to_string()
 }

--- a/crates/rag-rat-mcp/src/agent_hook.rs
+++ b/crates/rag-rat-mcp/src/agent_hook.rs
@@ -597,6 +597,10 @@ mod listener_tests {
 /// A read-only hook connection cannot heal FTS corruption, and the hook is latency-critical —
 /// degrade to the hook's designed null-context reply and let `on_corrupt` kick recovery. Every
 /// other error propagates unchanged.
+// The FTS-corruption degrade/heal pair is reached only from the `#[cfg(unix)]` listener path
+// (and the test module); on non-unix targets the listener is compiled out, leaving these unused
+// under `--all-targets` clippy. They compile everywhere, so allow rather than cfg them out.
+#[cfg_attr(not(unix), allow(dead_code))]
 fn degrade_when_fts_corrupt<T>(
     result: anyhow::Result<Option<T>>,
     on_corrupt: impl FnOnce(),
@@ -614,6 +618,7 @@ fn degrade_when_fts_corrupt<T>(
 /// listener's read-only connection cannot rebuild. Without this, a grep-hook-only session
 /// (no MCP queries to trigger the query-layer self-heal) would serve null context indefinitely
 /// after a torn write, even though the repair is one lossless rebuild away.
+#[cfg_attr(not(unix), allow(dead_code))]
 fn spawn_background_fts_heal(config: rag_rat_base::config::Config) {
     use std::sync::atomic::{AtomicBool, Ordering};
     static HEAL_IN_FLIGHT: AtomicBool = AtomicBool::new(false);

--- a/crates/rag-rat-mcp/src/server.rs
+++ b/crates/rag-rat-mcp/src/server.rs
@@ -639,7 +639,11 @@ mod tests {
     async fn blocking_tool_work_reports_panics_as_mcp_errors() {
         let err = blocking::run_blocking_tool(
             "panic_test_tool".to_string(),
-            Duration::from_secs(1),
+            // Generous budget: the tool panics immediately, but a 1 s timeout races cold
+            // Windows-CI worker-pool startup (measured >1 s), turning the expected
+            // panic error into a spurious timeout error. This test exercises panic
+            // REPORTING, not the timeout.
+            Duration::from_secs(30),
             ToolTimeoutPolicy::ReturnTimeout,
             test_tool_workers(1),
             || panic!("intentional panic from blocking tool"),

--- a/crates/rag-rat-oplog/src/account/fold.rs
+++ b/crates/rag-rat-oplog/src/account/fold.rs
@@ -4248,7 +4248,7 @@ mod tests {
         // a deep chain must fold to a classification, never recurse to a stack overflow.
         // Delivered DEEPEST-FIRST (the crash-inducing order) and folded on a SMALL stack,
         // so a recursive regression would abort loudly here.
-        const N: u32 = 800;
+        const N: u32 = 2500;
         let founder = Dev::seeded(0);
         let mut f = Fixture::genesis(&founder);
         let genesis_hash = f.genesis_hash;
@@ -4262,10 +4262,15 @@ mod tests {
         let mut entries = f.entries.clone();
         entries.reverse(); // deepest-first — memoization can't keep the recursion shallow
 
-        // A 64 KiB stack fits the iterative fold's constant call depth but would overflow an
-        // N-deep recursion many times over.
+        // A 256 KiB stack comfortably fits the iterative fold's constant call depth (a few frames)
+        // yet is overflowed several times over by an N-deep recursion (2500 frames). 64 KiB was too
+        // small for Windows, whose per-thread overhead and wider (shadow-space) frames need more
+        // headroom to run even the iterative fold — so the stack is sized above that floor, and N
+        // keeps the recursion-vs-iterative margin (a regression aborts here) while staying under
+        // the 60 s slow-test budget (the fold is O(N²): deepest-first delivery defeats
+        // memoization).
         let effective = std::thread::Builder::new()
-            .stack_size(64 * 1024)
+            .stack_size(256 * 1024)
             .spawn(move || fold_account(&entries).is_effective(&genesis_hash))
             .unwrap()
             .join()


### PR DESCRIPTION
## What

Makes the cross-platform CI gate (`ci-cross-platform.yml`, macOS + Windows) fully green. It had been red on the release tag; the notable part is that one failure was a **shipped-binary crash on macOS**, not just a test issue.

## macOS binary crashed at startup (user-facing)

`configure_jemalloc()` runs before command dispatch. On macOS, jemalloc rejects `background_thread` (`<jemalloc>: option background_thread currently supports pthread only`) and the subsequent `MALLCTL_ARENAS_ALL` (`arena.4096.*`) decay writes then **SIGSEGV** the process — so every `rag-rat` invocation crashed before doing anything. This affects the shipped `aarch64-apple-darwin` binary (the jemalloc tuning has been there since #305, so prior releases shipped the same crash). Fix: skip the jemalloc tuning on macOS (keep jemalloc as the allocator, just untuned) alongside the existing msvc/android exclusions.

The agent-hook e2e harness was discarding the spawned binary's stderr, which is why the crash was opaque — it now captures and prints stderr + exit status on failure.

## Windows clippy

`degrade_when_fts_corrupt` / `spawn_background_fts_heal` are reached only from the `#[cfg(unix)]` listener path, so `--all-targets` clippy on non-unix flagged them as dead code. Allowed the lint on non-unix (they compile everywhere and the test module keeps using them).

## Cross-platform test fixes

One is a **real production bug**, the rest are test-hygiene:

- **Production**: the index-time embedding-policy stamp fed the OS-native `relative_path` into the generated/fixture path heuristics, so on Windows (`\` separators) it misclassified `src\generated\…`/fixtures and the stamped `chunks.embedding_policy` column disagreed with the reconcile recompute (which reads the `/`-normalized `files.path`). Normalized to `/` at both policy seams.
- **Path equality**: canonicalize both sides so macOS TempDir (`/var`→`/private/var` symlink) and Windows (`\\?\`-verbatim long-name vs 8.3 short-name, separators) forms compare equal.
- **git autocrlf**: the schema-bootstrap git helpers force `core.autocrlf=false` for the child process, so windows-latest's global `autocrlf=true` no longer rewrites the LF fixtures as CRLF on checkout (which changed file bytes/sha and broke the HEAD-move carry match and the committed-index squash round-trip; the latter also now `.gitignore`s `.rag-rat/`).
- **TOML path**: a Windows path in a basic string is written with forward slashes so its backslashes aren't parsed as escapes.
- **Timeout race**: the panic-reporting test gets a generous budget so a cold Windows-CI worker start doesn't turn the expected panic into a spurious timeout.
- **Thread stack**: the deep-chain fold test's explicit 64 KiB stack is raised above the Windows per-thread floor (it overflowed even the iterative fold there), with the chain length recalibrated to keep the recursion-vs-iterative overflow margin under the slow-test budget.

## Verification

`ci-cross-platform.yml` (via `workflow_dispatch` on this branch) green on all six jobs — `clippy`, `test`, and the fastembed build on both `macos-latest` and `windows-latest`. Linux `clippy` (both feature sets) + the affected tests verified locally.

The v0.21.0 release binaries already built, so this doesn't block that release; it makes the shipped macOS binary run and turns the cross-platform gate green (ready for a v0.21.1 patch — the macOS crash warrants shipping a working binary).
