### PR TITLE
feat(sync): `[sync]` config + `rag-rat sync serve` headless peer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4853,6 +4853,7 @@ dependencies = [
  "anyhow",
  "clap",
  "dialoguer",
+ "getrandom 0.4.3",
  "gix",
  "libc",
  "path-slash",
@@ -4866,6 +4867,7 @@ dependencies = [
  "rag-rat-oracle",
  "rag-rat-papertrail",
  "rag-rat-query",
+ "rag-rat-sync",
  "ratatui",
  "rusqlite",
  "serde",
@@ -4878,6 +4880,7 @@ dependencies = [
  "toon-format",
  "tracing",
  "tui-tree-widget",
+ "zeroize",
 ]
 
 [[package]]

--- a/crates/rag-rat-base/src/config/load.rs
+++ b/crates/rag-rat-base/src/config/load.rs
@@ -6,7 +6,8 @@ use std::str::FromStr;
 use super::{
     self as config, Config, ConfigError, DistillLlmConfig, DreamLlmConfig, EmbeddingConfig,
     LlmConfig, LogConfig, MemoryConfig, OracleConfig, PapertrailConfig, RawConfig, RawTarget,
-    ResolvedTarget, SearchConfig, TargetKind, TrackerConfig, VersionCheckConfig, WatchConfig,
+    ResolvedTarget, SearchConfig, SyncConfig, TargetKind, TrackerConfig, VersionCheckConfig,
+    WatchConfig,
 };
 use crate::language::Language;
 
@@ -271,6 +272,7 @@ impl Config {
         let version_check = raw.version_check.into();
         let oracle = raw.oracle.into();
         let search = raw.search.into();
+        let sync = raw.sync.into();
         let memory = MemoryConfig::try_from(raw.memory)?;
         let trackers =
             raw.tracker.into_iter().map(TrackerConfig::try_from).collect::<Result<Vec<_>, _>>()?;
@@ -299,6 +301,7 @@ impl Config {
             memory,
             trackers,
             papertrail,
+            sync,
             log,
             repo_id_override,
             database_key_pinned,
@@ -329,6 +332,7 @@ impl Config {
             memory: MemoryConfig::default(),
             trackers: Vec::new(),
             papertrail: PapertrailConfig::default(),
+            sync: SyncConfig::default(),
             repo_id_override: None,
             database_key_pinned: false,
             source_root_reanchored_from: None,

--- a/crates/rag-rat-base/src/config/mod.rs
+++ b/crates/rag-rat-base/src/config/mod.rs
@@ -185,14 +185,15 @@ pub(crate) use discovery::{main_worktree_root, normalize_existing_dir, resolve_d
 pub(crate) use load::{anchor_root_to_main_worktree, resolve_targets};
 pub(crate) use raw::{RawConfig, RawTarget, resolve_relative_cookbook_path};
 #[cfg(test)]
-pub(crate) use raw::{RawMemory, RawOracle, RawSearch, RawVersionCheck, RawWatch};
+pub(crate) use raw::{RawMemory, RawOracle, RawSearch, RawSync, RawVersionCheck, RawWatch};
 pub use raw::{endpoint_authority_has_userinfo, valid_tracker_base_url, valid_tracker_project};
 pub use types::{
-    Config, DEFAULT_QUERY_ENDPOINT, DistillLlmConfig, DreamLlmConfig, EmbeddingBackend,
-    EmbeddingConfig, EmbeddingRuntimeConfig, LlmConfig, LogConfig, LogFormat, LogLevel,
-    MAX_REMOTE_EMBEDDING_CONCURRENCY, MemoryConfig, MemorySurface, OracleConfig, PapertrailConfig,
-    RemoteBackend, RemoteDreamConfig, RemoteEmbeddingConfig, ResolvedTarget, SearchConfig,
-    TargetKind, Tracker, TrackerAuth, TrackerConfig, VersionCheckConfig, WatchConfig,
+    Config, DEFAULT_QUERY_ENDPOINT, DEFAULT_SYNC_RELAY, DistillLlmConfig, DreamLlmConfig,
+    EmbeddingBackend, EmbeddingConfig, EmbeddingRuntimeConfig, LlmConfig, LogConfig, LogFormat,
+    LogLevel, MAX_REMOTE_EMBEDDING_CONCURRENCY, MemoryConfig, MemorySurface, OracleConfig,
+    PapertrailConfig, RemoteBackend, RemoteDreamConfig, RemoteEmbeddingConfig, ResolvedTarget,
+    SearchConfig, SyncConfig, TargetKind, Tracker, TrackerAuth, TrackerConfig, VersionCheckConfig,
+    WatchConfig,
 };
 
 #[cfg(test)]

--- a/crates/rag-rat-base/src/config/raw.rs
+++ b/crates/rag-rat-base/src/config/raw.rs
@@ -7,8 +7,8 @@ use super::{
     ConfigError, DEFAULT_QUERY_ENDPOINT, DistillLlmConfig, DreamLlmConfig, EmbeddingBackend,
     EmbeddingConfig, EmbeddingRuntimeConfig, LlmConfig, LogConfig, LogFormat, LogLevel,
     MAX_REMOTE_EMBEDDING_CONCURRENCY, MemoryConfig, MemorySurface, OracleConfig, PapertrailConfig,
-    RemoteBackend, RemoteDreamConfig, RemoteEmbeddingConfig, SearchConfig, Tracker, TrackerAuth,
-    TrackerConfig, VersionCheckConfig, WatchConfig,
+    RemoteBackend, RemoteDreamConfig, RemoteEmbeddingConfig, SearchConfig, SyncConfig, Tracker,
+    TrackerAuth, TrackerConfig, VersionCheckConfig, WatchConfig,
 };
 use crate::embedding_models::Backend;
 
@@ -42,6 +42,8 @@ pub(crate) struct RawConfig {
     pub(crate) oracle: RawOracle,
     #[serde(default)]
     pub(crate) search: RawSearch,
+    #[serde(default)]
+    pub(crate) sync: RawSync,
     #[serde(default)]
     pub(crate) memory: RawMemory,
     #[serde(default, rename = "tracker")]
@@ -332,6 +334,26 @@ impl From<RawSearch> for SearchConfig {
                 .graded_git_rerank
                 .unwrap_or(SearchConfig::default().graded_git_rerank),
         }
+    }
+}
+
+#[derive(Debug, Default, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct RawSync {
+    relay_url: Option<String>,
+}
+
+impl From<RawSync> for SyncConfig {
+    fn from(raw: RawSync) -> Self {
+        let default = SyncConfig::default();
+        // A blank/whitespace value falls back to the shipped default rather than binding an empty
+        // relay URL that would fail at endpoint construction with a less obvious error.
+        let relay_url = raw
+            .relay_url
+            .map(|v| v.trim().to_string())
+            .filter(|v| !v.is_empty())
+            .unwrap_or(default.relay_url);
+        Self { relay_url }
     }
 }
 

--- a/crates/rag-rat-base/src/config/tests.rs
+++ b/crates/rag-rat-base/src/config/tests.rs
@@ -5,11 +5,11 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use path_slash::PathExt;
 
 use super::{
-    self as config, Config, ConfigError, DistillLlmConfig, EmbeddingRuntimeConfig, LlmConfig,
-    LogConfig, LogFormat, LogLevel, MemoryConfig, MemorySurface, OracleConfig, RawConfig,
-    RawMemory, RawOracle, RawSearch, RawTarget, RawVersionCheck, RawWatch, RemoteBackend,
-    RemoteDreamConfig, RemoteEmbeddingConfig, ResolvedTarget, SearchConfig, TargetKind,
-    TrackerAuth, VersionCheckConfig, WatchConfig,
+    self as config, Config, ConfigError, DEFAULT_SYNC_RELAY, DistillLlmConfig,
+    EmbeddingRuntimeConfig, LlmConfig, LogConfig, LogFormat, LogLevel, MemoryConfig, MemorySurface,
+    OracleConfig, RawConfig, RawMemory, RawOracle, RawSearch, RawSync, RawTarget, RawVersionCheck,
+    RawWatch, RemoteBackend, RemoteDreamConfig, RemoteEmbeddingConfig, ResolvedTarget,
+    SearchConfig, SyncConfig, TargetKind, TrackerAuth, VersionCheckConfig, WatchConfig,
 };
 use crate::language::Language;
 
@@ -2226,6 +2226,37 @@ fn search_defaults_off_and_parses_opt_in() {
 }
 
 #[test]
+fn sync_relay_defaults_to_the_shipped_relay_and_parses_an_override() {
+    let default: SyncConfig = RawSync::default().into();
+    assert_eq!(
+        default.relay_url, DEFAULT_SYNC_RELAY,
+        "an absent [sync] block uses the shipped default relay"
+    );
+
+    let raw: RawConfig = toml::from_str(
+        "[index]\nroot = \".\"\n\n[sync]\nrelay_url = \"https://relay.example.test\"\n",
+    )
+    .unwrap();
+    let sync: SyncConfig = raw.sync.into();
+    assert_eq!(
+        sync.relay_url, "https://relay.example.test",
+        "[sync] relay_url overrides the default"
+    );
+
+    // A blank value falls back to the default rather than binding an empty relay URL.
+    let raw: RawConfig =
+        toml::from_str("[index]\nroot = \".\"\n\n[sync]\nrelay_url = \"   \"\n").unwrap();
+    let sync: SyncConfig = raw.sync.into();
+    assert_eq!(sync.relay_url, DEFAULT_SYNC_RELAY, "a blank relay_url falls back to the default");
+
+    // An unknown key under [sync] is rejected, not silently dropped.
+    assert!(
+        toml::from_str::<RawConfig>("[index]\nroot = \".\"\n\n[sync]\nrelay = \"x\"\n").is_err(),
+        "[sync] rejects unknown keys (deny_unknown_fields)"
+    );
+}
+
+#[test]
 fn dream_absent_defaults_to_off_and_local_ollama_connect() {
     // No `[llm.dream]` at all → disabled, with a local-Ollama CONNECT serving default
     // (byte-for-byte the pre-migration `[dream.model]` default).
@@ -2955,6 +2986,7 @@ fn target_directories_deduplicates_across_targets() {
     let cfg = Config {
         trackers: Vec::new(),
         papertrail: Default::default(),
+        sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
         root: dir.path().to_path_buf(),

--- a/crates/rag-rat-base/src/config/types.rs
+++ b/crates/rag-rat-base/src/config/types.rs
@@ -24,6 +24,7 @@ pub struct Config {
     pub memory: MemoryConfig,
     pub trackers: Vec<TrackerConfig>,
     pub papertrail: PapertrailConfig,
+    pub sync: SyncConfig,
     /// Optional `[index] repo_id` override for the consolidated global store — pins the repo's
     /// identity instead of deriving it from the root-commit hash. `None` = derive. Consumed by
     /// `crate::repo_identity::resolve_repo_identity`. An EXPLICIT `database` path never depends on
@@ -228,6 +229,25 @@ pub struct VersionCheckConfig {
 impl Default for VersionCheckConfig {
     fn default() -> Self {
         Self { enabled: true }
+    }
+}
+
+/// The project's shipped default sync relay. iroh discovery is pinned to a single relay (no
+/// third-party node directory), so a peer is reachable iff it shares this relay. Overridable via
+/// `[sync] relay_url`, and per-invocation via the `RAG_RAT_SYNC_RELAY` env var at the call site.
+pub const DEFAULT_SYNC_RELAY: &str = "https://relay.cq27.dev";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SyncConfig {
+    /// The iroh relay URL peers pin for discovery and relay fallback. Defaults to
+    /// [`DEFAULT_SYNC_RELAY`]; set `[sync] relay_url` to point at a different relay. The
+    /// `RAG_RAT_SYNC_RELAY` env var overrides this at the call site (ops/tests).
+    pub relay_url: String,
+}
+
+impl Default for SyncConfig {
+    fn default() -> Self {
+        Self { relay_url: DEFAULT_SYNC_RELAY.to_string() }
     }
 }
 

--- a/crates/rag-rat-base/src/hash.rs
+++ b/crates/rag-rat-base/src/hash.rs
@@ -2,16 +2,23 @@
 
 use sha2::{Digest, Sha256};
 
+/// Lower-hex encode a byte slice (two chars per byte, `0`-padded). The one hex encoder for the
+/// workspace — there is no `hex` crate dependency, so every caller that needs raw-bytes→hex (digest
+/// rendering, a hex-encoded meta value, the table-sync golden vectors) routes through here rather
+/// than hand-rolling the loop.
+pub fn hex_lower(bytes: &[u8]) -> String {
+    use std::fmt::Write as _;
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        let _ = write!(out, "{byte:02x}");
+    }
+    out
+}
+
 /// Hex SHA-256 of a byte slice. This is the hash space of `files.sha256` (the indexer writes
 /// `hex_sha256(fs::read(file))`), so every consumer that compares against stored file hashes —
 /// the content-integrity check, the oracle's scip-vs-disk gate (#82 TOCTOU) — MUST hash through
 /// this function to stay in the same space.
 pub fn hex_sha256(bytes: &[u8]) -> String {
-    let hash = Sha256::digest(bytes);
-    let mut out = String::with_capacity(hash.len() * 2);
-    for byte in hash {
-        use std::fmt::Write as _;
-        let _ = write!(out, "{byte:02x}");
-    }
-    out
+    hex_lower(&Sha256::digest(bytes))
 }

--- a/crates/rag-rat-base/src/logging/mod.rs
+++ b/crates/rag-rat-base/src/logging/mod.rs
@@ -131,6 +131,7 @@ mod tests {
         Config {
             trackers: Vec::new(),
             papertrail: Default::default(),
+            sync: Default::default(),
             repo_id_override: None,
             database_key_pinned: true,
             root: dir.to_path_buf(),

--- a/crates/rag-rat-cli/Cargo.toml
+++ b/crates/rag-rat-cli/Cargo.toml
@@ -31,12 +31,17 @@ gix.workspace = true
 rag-rat-core = { workspace = true }
 rag-rat-oracle.workspace = true
 rag-rat-oplog.workspace = true
+rag-rat-sync.workspace = true
 rag-rat-query.workspace = true
 rag-rat-mcp = { workspace = true }
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
 tracing.workspace = true
+rusqlite.workspace = true
+# Minting the persisted sync node key (OS CSPRNG) and scrubbing the in-memory copy.
+getrandom.workspace = true
+zeroize.workspace = true
 
 # Consumed only by the unix-gated terminal-reset guard (`init/mod.rs`) — dead on non-unix targets,
 # so gate it there to match rag-rat-core / rag-rat-mcp (#240).
@@ -58,8 +63,6 @@ tikv-jemalloc-ctl = "0.7"
 # MCP tool results render as TOON; integration tests decode them back to JSON Values to assert.
 toon-format.workspace = true
 tempfile.workspace = true
-# The consolidate integration tests assert sibling-repo repo_meta state directly in the global DB.
-rusqlite.workspace = true
 # Test helpers embed a temp path into a TOML value; path-slash makes it TOML-safe cross-platform.
 path-slash.workspace = true
 

--- a/crates/rag-rat-cli/src/cli.rs
+++ b/crates/rag-rat-cli/src/cli.rs
@@ -202,6 +202,18 @@ pub(crate) enum SyncCommand {
         #[arg(value_name = "DEVICE_FINGERPRINT")]
         target: rag_rat_oplog::DeviceFingerprint,
     },
+    /// Run a headless store-and-forward peer: bind the sync endpoint over the configured relay and
+    /// exchange this account's op-log with authorized peers.
+    #[command(long_about = "Binds an iroh endpoint pinned to the configured relay ([sync] \
+                            relay_url, default relay.cq27.dev; RAG_RAT_SYNC_RELAY overrides), \
+                            then accepts connections and replicates this account's op log with \
+                            peers authorized against the account roster. Runs until interrupted; \
+                            --once serves a single connection and exits.")]
+    Serve {
+        /// Serve exactly one connection, then exit (useful for scripted checks).
+        #[arg(long)]
+        once: bool,
+    },
 }
 
 #[derive(Debug, Args)]

--- a/crates/rag-rat-cli/src/commands/clones.rs
+++ b/crates/rag-rat-cli/src/commands/clones.rs
@@ -279,6 +279,7 @@ mod tests {
         let config = Config {
             trackers: Vec::new(),
             papertrail: Default::default(),
+            sync: Default::default(),
             repo_id_override: None,
             database_key_pinned: true,
             root: root.clone(),

--- a/crates/rag-rat-cli/src/commands/index_ops.rs
+++ b/crates/rag-rat-cli/src/commands/index_ops.rs
@@ -743,6 +743,7 @@ mod tests {
         let config = Config {
             trackers: Vec::new(),
             papertrail: Default::default(),
+            sync: Default::default(),
             repo_id_override: None,
             database_key_pinned: true,
             root: root.clone(),
@@ -804,6 +805,7 @@ mod tests {
         let config = Config {
             trackers: Vec::new(),
             papertrail: Default::default(),
+            sync: Default::default(),
             repo_id_override: None,
             database_key_pinned: true,
             root: main.clone(),
@@ -887,6 +889,7 @@ mod tests {
         let config = Config {
             trackers: Vec::new(),
             papertrail: Default::default(),
+            sync: Default::default(),
             repo_id_override: None,
             database_key_pinned: true,
             root: main.clone(),
@@ -968,6 +971,7 @@ mod tests {
         let config = Config {
             trackers: Vec::new(),
             papertrail: Default::default(),
+            sync: Default::default(),
             repo_id_override: None,
             database_key_pinned: true,
             root: root.clone(),
@@ -1040,6 +1044,7 @@ mod tests {
         let config = Config {
             trackers: Vec::new(),
             papertrail: Default::default(),
+            sync: Default::default(),
             repo_id_override: None,
             database_key_pinned: true,
             root: root.clone(),
@@ -1116,6 +1121,7 @@ mod tests {
         let config = Config {
             trackers: Vec::new(),
             papertrail: Default::default(),
+            sync: Default::default(),
             repo_id_override: None,
             database_key_pinned: true,
             root: root.clone(),
@@ -1193,6 +1199,7 @@ mod tests {
         let config = Config {
             trackers: Vec::new(),
             papertrail: Default::default(),
+            sync: Default::default(),
             repo_id_override: None,
             database_key_pinned: true,
             root: root.clone(),
@@ -1284,6 +1291,7 @@ mod papertrail_hook_tests {
                 tags: Vec::new(),
             }],
             papertrail: Default::default(),
+            sync: Default::default(),
             repo_id_override: None,
             database_key_pinned: true,
             root: root.to_path_buf(),

--- a/crates/rag-rat-cli/src/commands/oracle.rs
+++ b/crates/rag-rat-cli/src/commands/oracle.rs
@@ -457,6 +457,7 @@ mod tests {
         let config = Config {
             trackers: Vec::new(),
             papertrail: Default::default(),
+            sync: Default::default(),
             repo_id_override: None,
             database_key_pinned: true,
             root: root.clone(),
@@ -510,6 +511,7 @@ mod tests {
         let config_with = |include: Vec<String>, exclude: Vec<String>| Config {
             trackers: Vec::new(),
             papertrail: Default::default(),
+            sync: Default::default(),
             repo_id_override: None,
             database_key_pinned: true,
             root: PathBuf::from("/x"),

--- a/crates/rag-rat-cli/src/commands/sync.rs
+++ b/crates/rag-rat-cli/src/commands/sync.rs
@@ -1,13 +1,34 @@
-//! Local memory-stream authoring configuration. No transport surface lives here.
+//! The `rag-rat sync` command: local memory-stream authoring configuration plus the peer transport
+//! driver (a persisted node identity today; `serve`/pairing land on top).
 
+use std::time::Duration;
+
+use anyhow::{Context, anyhow, bail};
 use rag_rat_base::config::Config;
+use rag_rat_base::{hash, locks, time};
+use rag_rat_sync::{AuthPolicy, NodeAuth, OplogSyncStore};
+use rusqlite::{Connection, params};
+use zeroize::Zeroizing;
 
 use crate::cli::{SyncArgs, SyncCommand};
 use crate::{open_index, print_output};
 
+/// How long `serve` waits for the database-scoped session lock before refusing to start — kept
+/// short so a second `serve` (or a running device sync) fails fast rather than hanging.
+const SERVE_SESSION_LOCK_TIMEOUT: Duration = Duration::from_secs(5);
+/// How long `serve`'s one-time startup writes wait for the per-repo write lock (e.g. behind a
+/// watcher pass) before giving up; the operator retries.
+const SERVE_INIT_LOCK_TIMEOUT: Duration = Duration::from_secs(60);
+
 pub(crate) fn sync(config: &Config, args: &SyncArgs) -> anyhow::Result<()> {
-    let lock_repo = rag_rat_base::locks::write_lock_repo_id(config);
-    let _lock = rag_rat_base::locks::WriteLock::acquire_blocking(&config.database, &lock_repo)?;
+    // `serve` is a long-running server that manages its own connection; it must run OUTSIDE the
+    // command-wide repo write lock, which would otherwise block indexing, the watcher, and GC for
+    // the entire life of the server.
+    if let SyncCommand::Serve { once } = &args.command {
+        return serve(config, *once);
+    }
+    let lock_repo = locks::write_lock_repo_id(config);
+    let _lock = locks::WriteLock::acquire_blocking(&config.database, &lock_repo)?;
     let db = open_index(config)?;
     match &args.command {
         SyncCommand::Enable => {
@@ -35,5 +56,247 @@ pub(crate) fn sync(config: &Config, args: &SyncArgs) -> anyhow::Result<()> {
                 "note": "existing live keys were re-wrapped without rotation; no enrollment, pairing, or transport occurred",
             }))
         },
+        SyncCommand::Serve { .. } => unreachable!("serve is dispatched before the write lock"),
+    }
+}
+
+/// The relay this invocation binds: `RAG_RAT_SYNC_RELAY` (ops/tests) overrides the configured
+/// `[sync] relay_url`, which itself defaults to the shipped relay.
+fn effective_relay_url(config: &Config) -> String {
+    match std::env::var("RAG_RAT_SYNC_RELAY") {
+        Ok(v) if !v.trim().is_empty() => v.trim().to_string(),
+        _ => config.sync.relay_url.clone(),
+    }
+}
+
+/// Run a headless store-and-forward peer for this account's op log: bind the sync endpoint over the
+/// configured relay and replicate the account log with peers the roster authorizes. Serves the
+/// account log only — the wire is scoped to one stream per session, so content replication is a
+/// separate stream a later slice adds. Runs until interrupted; `once` serves a single connection.
+fn serve(config: &Config, once: bool) -> anyhow::Result<()> {
+    let relay = effective_relay_url(config);
+    // Hold a database-scoped session lock for the SERVER'S WHOLE LIFETIME. `sync_node_secret` is
+    // store-global, so a second `serve` (or a colocated device-side sync) on the same database
+    // would bind a SECOND endpoint advertising the same iroh node id — the two would race relay
+    // registration and inbound connections. This rejects that. Crucially it does NOT block the
+    // watcher / indexing / GC (they take the per-repo write lock, not this one), so only other sync
+    // ENDPOINTS are excluded — exactly the collision to prevent.
+    let _serve_lock = locks::WriteLock::acquire_sync_session_timeout(
+        &config.database,
+        SERVE_SESSION_LOCK_TIMEOUT,
+    )?
+    .ok_or_else(|| {
+        anyhow!(
+            "another sync session already holds this database's node identity (a `serve` peer or \
+             a device sync is running); only one endpoint may run at a time"
+        )
+    })?;
+    // Startup WRITES — the schema migration, the account read, and the first-run node-key mint —
+    // under the per-repo write lock, BOUNDED here because the global session lock is already held
+    // (the per-repo-while-global lock-ordering rule). `open_index` is the SANCTIONED open: it
+    // refuses a missing index and migrates FORWARD-ONLY under the schema lock + gate; a bare
+    // `schema::apply` would replay data migrations and skip the gate. The repo lock is RELEASED
+    // before the accept loop so the watcher / GC aren't blocked for the server's life; the loop's
+    // own ingests rely on SQLite's writer serialization instead.
+    let lock_repo = locks::write_lock_repo_id(config);
+    let repo_lock =
+        locks::WriteLock::acquire_timeout(&config.database, &lock_repo, SERVE_INIT_LOCK_TIMEOUT)?
+            .ok_or_else(|| {
+            anyhow!("the index write lock is busy (another writer is mid-pass); retry `sync serve`")
+        })?;
+    let db = crate::open_index(config)?;
+    let (account_id, node_key) = {
+        let conn = db.connection();
+        (existing_account_or_hint(conn)?, node_secret(conn)?)
+    };
+    drop(repo_lock);
+
+    let runtime =
+        tokio::runtime::Builder::new_multi_thread().worker_threads(2).enable_all().build()?;
+    runtime.block_on(async move {
+        // `db` moved in; re-borrow the connection here so the loop can hold it for the run.
+        let conn = db.connection();
+        let endpoint = rag_rat_sync::build_endpoint(*node_key, &relay)
+            .await
+            .with_context(|| format!("binding the sync endpoint over relay {relay}"))?;
+        // A private account admits only peers whose binding verifies against the roster (mutual),
+        // so the serve peer must itself hold an EFFECTIVE (roster-current) device. Fail fast by
+        // running its own binding through the roster authorization path — not just an is-empty
+        // check: a device REMOVED from the roster still holds its local key and mints a nonempty
+        // binding, but every `Closed` peer would reject it as `NotRosterDevice`. Self-authorization
+        // fails closed for both "no local device" and "revoked", so the server never starts only to
+        // silently reject every session.
+        let local_node = *endpoint.id().as_bytes();
+        let probe = OplogSyncStore::new(conn, account_id, time::now_ms);
+        let probe_now = time::now_ms();
+        let binding = probe.local_binding(&local_node, probe_now)?;
+        if !probe.authorize(&binding, &local_node, probe_now)? {
+            bail!(
+                "this peer's device is not an effective member of the account (no enrolled \
+                 device, or removed from the roster) — it cannot serve a private account; run \
+                 `rag-rat sync enable` and enroll this peer"
+            );
+        }
+        let policy = AuthPolicy::Closed;
+
+        tracing::info!(node_id = %endpoint.id(), relay = %relay, "sync serve listening");
+        // The dialable node identity must reach the operator on stdout: repository logging is off
+        // by default, and a peer cannot connect without the node id (the relay is shared config).
+        crate::print_output(&serde_json::json!({
+            "status": "listening",
+            "node_id": endpoint.id().to_string(),
+            "relay": relay,
+        }))?;
+
+        // The database-scoped session lock taken at startup is still held for this whole loop
+        // (released only when serve exits), keeping this database's node identity singular. A
+        // per-connection ingest needs no further lock — SQLite serializes it against any watcher
+        // write.
+        //
+        // ONE ctrl_c future for the whole loop: a fresh `ctrl_c()` per iteration would let a signal
+        // delivered between iterations be swallowed by tokio's driver and missed.
+        let mut shutdown = std::pin::pin!(tokio::signal::ctrl_c());
+        loop {
+            let mut store = OplogSyncStore::new(conn, account_id, time::now_ms);
+            let outcome = tokio::select! {
+                // `accept_and_sync` reads `now_ms` once a peer connects — the server may wait here
+                // arbitrarily long, so the auth timestamp must not predate the connection.
+                report = rag_rat_sync::accept_and_sync(&endpoint, &mut store, policy, time::now_ms)
+                    => Some(report),
+                _ = &mut shutdown => None,
+            };
+            match outcome {
+                None => {
+                    tracing::info!("interrupted; shutting down");
+                    break;
+                },
+                Some(Ok(report)) => tracing::info!(
+                    sent = report.entries_sent,
+                    received = report.entries_received,
+                    stored = report.entries_newly_stored,
+                    "sync session complete"
+                ),
+                // In one-shot mode the session IS the command's result, so a failed session is a
+                // failed command (scripted checks must see the non-zero exit). The long-running
+                // server logs and moves on to the next peer instead.
+                Some(Err(e)) if once => return Err(anyhow!("sync session failed: {e}")),
+                Some(Err(e)) => {
+                    tracing::warn!(error = %e, "sync session failed");
+                    // A closed endpoint makes `accept` fail immediately and forever, so continuing
+                    // would spin the loop at 100% CPU logging the same error — exit non-zero.
+                    if endpoint.is_closed() {
+                        return Err(anyhow!("sync endpoint closed: {e}"));
+                    }
+                },
+            }
+            // Cadence WAL fold (#818): a long-lived writer must checkpoint mid-lifetime or its
+            // `-wal` sidecar grows unbounded (passive autocheckpoint is pinned off). Size-gated and
+            // best-effort, mirroring the watcher's per-pass fold.
+            db.fold_wal();
+            if once {
+                break;
+            }
+        }
+        anyhow::Ok(())
+    })
+}
+
+/// Resolve this store's EXISTING local account WITHOUT minting one. A serve peer must already be
+/// enrolled; merely starting the server must never create account or device identity state as a
+/// side effect (that is `sync enable`'s job). The "no account yet" case becomes an actionable
+/// enrollment hint.
+fn existing_account_or_hint(conn: &Connection) -> anyhow::Result<rag_rat_oplog::AccountId> {
+    rag_rat_oplog::read_local_account(conn)?.context(
+        "no local sync account — run `rag-rat sync enable` and enroll this peer before serving",
+    )
+}
+
+/// Meta key for this index's persisted iroh node secret (the transport identity).
+const NODE_SECRET_META_KEY: &str = "sync_node_secret";
+
+/// This index's stable iroh node secret — the transport identity, minted once and persisted so the
+/// node id stays the same across launches. It is deliberately distinct from the account device
+/// signing key: rotating or losing one must not touch the other. Stored hex in the global
+/// `index_meta`, plaintext like every other row in the unencrypted index; the in-memory copy is
+/// returned in a `Zeroizing` wrapper so it is scrubbed when the caller drops it. `INSERT OR IGNORE`
+/// plus a mandatory re-read makes a concurrent first-open adopt whichever key actually landed, so
+/// two processes never end up with different node ids.
+fn node_secret(conn: &Connection) -> anyhow::Result<Zeroizing<[u8; 32]>> {
+    // The hex forms of the secret are held in `Zeroizing` too, so the only lingering plaintext copy
+    // is the one at rest in `index_meta` (the DB is unencrypted by design).
+    if let Some(stored) = rag_rat_db::meta::read_meta(conn, NODE_SECRET_META_KEY)? {
+        return decode_node_secret(&Zeroizing::new(stored));
+    }
+    let mut fresh = Zeroizing::new([0u8; 32]);
+    // `getrandom::Error` implements `std::error::Error` only behind getrandom's `std` feature,
+    // which is off here — format it directly rather than through `Context`.
+    getrandom::fill(fresh.as_mut_slice())
+        .map_err(|e| anyhow!("OS CSPRNG unavailable to mint the sync node key: {e}"))?;
+    let hex = Zeroizing::new(hash::hex_lower(fresh.as_slice()));
+    conn.execute("INSERT OR IGNORE INTO index_meta(key, value) VALUES (?1, ?2)", params![
+        NODE_SECRET_META_KEY,
+        hex.as_str()
+    ])?;
+    let stored = Zeroizing::new(
+        rag_rat_db::meta::read_meta(conn, NODE_SECRET_META_KEY)?
+            .context("sync node secret missing from index_meta immediately after mint")?,
+    );
+    decode_node_secret(&stored)
+}
+
+/// Decode a persisted node secret: exactly 64 hex chars → 32 bytes. A wrong length or a non-hex
+/// character is a corrupt persisted key, surfaced rather than silently coerced.
+fn decode_node_secret(hex: &str) -> anyhow::Result<Zeroizing<[u8; 32]>> {
+    let hex = hex.trim();
+    if hex.len() != 64 {
+        bail!("persisted sync node secret is {} hex chars, expected 64", hex.len());
+    }
+    let mut out = Zeroizing::new([0u8; 32]);
+    for (i, pair) in hex.as_bytes().chunks_exact(2).enumerate() {
+        match ((pair[0] as char).to_digit(16), (pair[1] as char).to_digit(16)) {
+            (Some(hi), Some(lo)) => out[i] = ((hi << 4) | lo) as u8,
+            _ => bail!("persisted sync node secret is not valid hex"),
+        }
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use rag_rat_base::hash;
+    use rusqlite::Connection;
+
+    use super::{decode_node_secret, node_secret};
+
+    fn schema_conn() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        rag_rat_db::schema::apply(&conn, &rag_rat_db::MigrationHooks::noop()).unwrap();
+        conn
+    }
+
+    #[test]
+    fn node_secret_is_minted_once_and_stable_across_calls() {
+        let conn = schema_conn();
+        let first = node_secret(&conn).unwrap();
+        assert_ne!(*first, [0u8; 32], "a real key is minted, not left zeroed");
+        let second = node_secret(&conn).unwrap();
+        assert_eq!(*first, *second, "the persisted node secret is stable across calls");
+    }
+
+    #[test]
+    fn node_secret_hex_round_trips_every_byte() {
+        let mut bytes = [0u8; 32];
+        for (i, b) in bytes.iter_mut().enumerate() {
+            *b = (i as u8).wrapping_mul(7).wrapping_add(3);
+        }
+        let hex = hash::hex_lower(&bytes);
+        assert_eq!(hex.len(), 64);
+        assert_eq!(*decode_node_secret(&hex).unwrap(), bytes);
+    }
+
+    #[test]
+    fn decode_node_secret_rejects_wrong_length_and_non_hex() {
+        assert!(decode_node_secret("abcd").is_err(), "too short is rejected");
+        assert!(decode_node_secret(&"zz".repeat(32)).is_err(), "non-hex chars are rejected");
     }
 }

--- a/crates/rag-rat-core/benches/shared/mod.rs
+++ b/crates/rag-rat-core/benches/shared/mod.rs
@@ -66,6 +66,7 @@ pub fn bench_config(subdir: &str) -> Config {
     Config {
         trackers: Vec::new(),
         papertrail: Default::default(),
+        sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
         root: corpus_dir(),

--- a/crates/rag-rat-core/src/index/adoption_hints.rs
+++ b/crates/rag-rat-core/src/index/adoption_hints.rs
@@ -197,6 +197,7 @@ mod tests {
         Config {
             trackers: Vec::new(),
             papertrail: Default::default(),
+            sync: Default::default(),
             repo_id_override: None,
             database_key_pinned: true,
             root: root.clone(),

--- a/crates/rag-rat-core/src/index/lifecycle.rs
+++ b/crates/rag-rat-core/src/index/lifecycle.rs
@@ -59,6 +59,22 @@ impl IndexDatabase {
         self.storage.database_path()
     }
 
+    /// The raw SQLite connection this index opened, already MIGRATED through the sanctioned gate.
+    /// Exposed for store-global (op-log) operations that are not repo-scoped — `rag-rat sync serve`
+    /// reads the account/node identity and ingests received entries through it. Repo-scoped
+    /// readers/writers use the scoped helpers, never this.
+    pub fn connection(&self) -> &rusqlite::Connection {
+        self.storage.connection()
+    }
+
+    /// A cadence WAL fold for a long-lived holder (#818): `setup()` pins `wal_autocheckpoint = 0`,
+    /// so a connection that never closes would strand its writes in the `-wal` sidecar. Size-gated
+    /// and best-effort, same as the Drop fold; `sync serve` calls it between sessions, as the
+    /// watcher folds per pass.
+    pub fn fold_wal(&self) {
+        self.storage.fold_wal();
+    }
+
     /// Open the DB at `path` and bring its schema current, migrating FORWARD under the index write
     /// lock when it lags this binary. Shared by every open path; resolves NO repo scope (the caller
     /// does — a bare open via [`sole_repo_id`](schema::sole_repo_id), a config-bearing open via

--- a/crates/rag-rat-core/src/index/papertrail_autosync.rs
+++ b/crates/rag-rat-core/src/index/papertrail_autosync.rs
@@ -675,6 +675,7 @@ mod tests {
         Config {
             trackers: Vec::new(),
             papertrail: Default::default(),
+            sync: Default::default(),
             repo_id_override: None,
             database_key_pinned: true,
             root: root.to_path_buf(),

--- a/crates/rag-rat-core/src/index/query_api/clones/of_text.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/of_text.rs
@@ -675,6 +675,7 @@ mod tests {
         let config = rag_rat_base::config::Config {
             trackers: Vec::new(),
             papertrail: Default::default(),
+            sync: Default::default(),
             repo_id_override: None,
             database_key_pinned: true,
             root: root.clone(),
@@ -792,6 +793,7 @@ mod tests {
         let config = rag_rat_base::config::Config {
             trackers: Vec::new(),
             papertrail: Default::default(),
+            sync: Default::default(),
             repo_id_override: None,
             database_key_pinned: true,
             root: root.clone(),
@@ -863,6 +865,7 @@ mod tests {
         let config = rag_rat_base::config::Config {
             trackers: Vec::new(),
             papertrail: Default::default(),
+            sync: Default::default(),
             repo_id_override: None,
             database_key_pinned: true,
             root: root.clone(),
@@ -965,6 +968,7 @@ mod tests {
         let config = rag_rat_base::config::Config {
             trackers: Vec::new(),
             papertrail: Default::default(),
+            sync: Default::default(),
             repo_id_override: None,
             database_key_pinned: true,
             root: root.clone(),

--- a/crates/rag-rat-core/src/index/query_api/clones/precompute.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/precompute.rs
@@ -1095,6 +1095,7 @@ pub(super) mod tests {
         rag_rat_base::config::Config {
             trackers: Vec::new(),
             papertrail: Default::default(),
+            sync: Default::default(),
             repo_id_override: None,
             database_key_pinned: true,
             root: root.clone(),

--- a/crates/rag-rat-core/src/index/query_api/clones/tests.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/tests.rs
@@ -196,6 +196,7 @@ fn find_clones_rejects_nan_and_non_finite_min_similarity() {
     let config = rag_rat_base::config::Config {
         trackers: Vec::new(),
         papertrail: Default::default(),
+        sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
         root: root.clone(),
@@ -784,6 +785,7 @@ fn recall_candidates_identical_blob_vs_postings_grouping() {
     let config = rag_rat_base::config::Config {
         trackers: Vec::new(),
         papertrail: Default::default(),
+        sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
         root: root.clone(),

--- a/crates/rag-rat-core/src/index/query_api/db_file_health.rs
+++ b/crates/rag-rat-core/src/index/query_api/db_file_health.rs
@@ -344,6 +344,7 @@ mod tests {
         rag_rat_base::config::Config {
             trackers: Vec::new(),
             papertrail: Default::default(),
+            sync: Default::default(),
             repo_id_override: None,
             database_key_pinned: true,
             root: root.clone(),

--- a/crates/rag-rat-core/src/index/query_api/oracle_surfacing_tests.rs
+++ b/crates/rag-rat-core/src/index/query_api/oracle_surfacing_tests.rs
@@ -31,6 +31,7 @@ fn rust_config(root: PathBuf) -> Config {
     Config {
         trackers: Vec::new(),
         papertrail: Default::default(),
+        sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
         root: root.clone(),
@@ -1151,6 +1152,7 @@ fn deleted_and_generated_paths_counted_in_skipped() {
     let config = Config {
         trackers: Vec::new(),
         papertrail: Default::default(),
+        sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
         root: root.clone(),

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/clones.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/clones.rs
@@ -1081,6 +1081,7 @@ fn multi_language_clone_integration_finds_within_language_no_cross() {
     let config = Config {
         trackers: Vec::new(),
         papertrail: Default::default(),
+        sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
         root: root.clone(),
@@ -1298,6 +1299,7 @@ fn find_clones_ranks_a_clean_clone_class_with_metrics() {
     let config = Config {
         trackers: Vec::new(),
         papertrail: Default::default(),
+        sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
         root: root.clone(),

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/dir_memory_tree.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/dir_memory_tree.rs
@@ -309,6 +309,7 @@ fn dir_tree_label_depth_collapse_single_child_chain() {
     let config = Config {
         trackers: Vec::new(),
         papertrail: Default::default(),
+        sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
         root: root.clone(),
@@ -543,6 +544,7 @@ fn dir_tree_truncates_at_max_nodes() {
     let config = Config {
         trackers: Vec::new(),
         papertrail: Default::default(),
+        sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
         root: root.clone(),
@@ -694,6 +696,7 @@ fn dir_tree_children_of_collapsed_node_use_leaf_labels() {
     let config = Config {
         trackers: Vec::new(),
         papertrail: Default::default(),
+        sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
         root: root.clone(),

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/mod.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/mod.rs
@@ -74,6 +74,7 @@ fn rag_rat_config(root: &Path) -> Config {
     Config {
         trackers: Vec::new(),
         papertrail: Default::default(),
+        sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
         root: root.to_path_buf(),
@@ -200,6 +201,7 @@ fn markdown_config_for_root(root: PathBuf) -> Config {
     Config {
         trackers: Vec::new(),
         papertrail: Default::default(),
+        sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
         root: root.clone(),
@@ -358,6 +360,7 @@ fn source_config_dirs(root: PathBuf, language: Language, dirs: &[&str]) -> Confi
     Config {
         trackers: Vec::new(),
         papertrail: Default::default(),
+        sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
         root: root.clone(),
@@ -753,6 +756,7 @@ fn git_fixture_for_overlay_tests() -> (PathBuf, Config) {
     let config = Config {
         trackers: Vec::new(),
         papertrail: Default::default(),
+        sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
         root: root.clone(),
@@ -886,6 +890,7 @@ fn four_clone_config(root: &Path) -> Config {
     Config {
         trackers: Vec::new(),
         papertrail: Default::default(),
+        sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
         root: root.to_path_buf(),

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/orientation_healing.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/orientation_healing.rs
@@ -166,6 +166,7 @@ fn clean_checkout_file_resolves_against_its_own_package_roots() {
     let config = Config {
         trackers: Vec::new(),
         papertrail: Default::default(),
+        sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
         root: root.clone(),

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/papertrail_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/papertrail_tests.rs
@@ -544,6 +544,7 @@ fn parser_failures_report_paths() {
     let config = Config {
         trackers: Vec::new(),
         papertrail: Default::default(),
+        sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
         root: root.clone(),

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/reconcile_embeddings.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/reconcile_embeddings.rs
@@ -733,6 +733,7 @@ fn policy_skip_summary_recomputes_exactly_for_a_non_default_char_cap() {
     let config = Config {
         trackers: Vec::new(),
         papertrail: Default::default(),
+        sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
         root: root.clone(),
@@ -982,6 +983,7 @@ fn git_history_indexes_commits_paths_queries_and_blame() {
     let config = Config {
         trackers: Vec::new(),
         papertrail: Default::default(),
+        sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
         root: root.clone(),

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_memory.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_memory.rs
@@ -2507,6 +2507,7 @@ fn repo_brief_ranks_churn_and_god_module_candidates() {
     let config = Config {
         trackers: Vec::new(),
         papertrail: Default::default(),
+        sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
         root: root.clone(),
@@ -2596,6 +2597,7 @@ fn repo_clusters_groups_cotouched_files() {
     let config = Config {
         trackers: Vec::new(),
         papertrail: Default::default(),
+        sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
         root: root.clone(),

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
@@ -10,6 +10,7 @@ fn rebuild_bootstraps_sqlite_schema_for_empty_target_root() {
     let config = Config {
         trackers: Vec::new(),
         papertrail: Default::default(),
+        sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
         root: root.clone(),

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/symbol_search_lookup.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/symbol_search_lookup.rs
@@ -784,6 +784,7 @@ DEVICE_DT_INST_DEFINE(0, entropy_init, NULL, NULL, NULL,
     let config = Config {
         trackers: Vec::new(),
         papertrail: Default::default(),
+        sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
         root: root.clone(),
@@ -1563,6 +1564,7 @@ where
     let config = Config {
         trackers: Vec::new(),
         papertrail: Default::default(),
+        sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
         root: root.clone(),

--- a/crates/rag-rat-core/src/watch/tests.rs
+++ b/crates/rag-rat-core/src/watch/tests.rs
@@ -37,6 +37,7 @@ fn whole_root_config(root: &Path, target_dirs: &[PathBuf]) -> Config {
     Config {
         trackers: Vec::new(),
         papertrail: Default::default(),
+        sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
         root: root.to_path_buf(),
@@ -1398,6 +1399,7 @@ fn event_touches_worktree_matches_checkout_targets_and_registry() {
     let config = Config {
         trackers: Vec::new(),
         papertrail: Default::default(),
+        sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
         root: PathBuf::from("/main"),
@@ -2157,6 +2159,7 @@ fn event_touches_worktree_rebases_subdir_rooted_config() {
     let config = Config {
         trackers: Vec::new(),
         papertrail: Default::default(),
+        sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
         root: config_root,
@@ -2207,6 +2210,7 @@ fn event_is_relevant_skips_gitignored_paths_consistently_with_walker() {
     let config = Config {
         trackers: Vec::new(),
         papertrail: Default::default(),
+        sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
         root: root.clone(),
@@ -2273,6 +2277,7 @@ fn gitignore_edit_is_relevant_and_recompile_reflects_new_rules() {
     let config = Config {
         trackers: Vec::new(),
         papertrail: Default::default(),
+        sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
         root: root.clone(),
@@ -2350,6 +2355,7 @@ fn worktree_root_gitignore_edit_recompiles_for_subdir_config_root() {
     let config = Config {
         trackers: Vec::new(),
         papertrail: Default::default(),
+        sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
         root: sub.clone(),
@@ -2958,6 +2964,7 @@ fn worktree_watch_targets_excludes_the_main_checkout_for_a_subdir_config_root() 
     let config = Config {
         trackers: Vec::new(),
         papertrail: Default::default(),
+        sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
         root: sub.clone(),
@@ -3309,6 +3316,7 @@ fn a_bare_directory_create_is_not_relevant_so_placement_must_be_unconditional() 
     let config = Config {
         trackers: Vec::new(),
         papertrail: Default::default(),
+        sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
         root: root.clone(),

--- a/crates/rag-rat-db/src/storage.rs
+++ b/crates/rag-rat-db/src/storage.rs
@@ -164,6 +164,18 @@ impl IndexConnection {
         &self.conn
     }
 
+    /// Size-gated ([`WAL_CHECKPOINT_MIN_BYTES`]), best-effort `wal_checkpoint(TRUNCATE)`. The
+    /// Drop-time fold and any long-lived holder's cadence fold (the watcher per pass, `sync serve`
+    /// between sessions) share this so the gate and best-effort semantics live in one place — a
+    /// busy or failed truncate simply rides the next fold.
+    pub fn fold_wal(&self) {
+        if wal_bytes(&self.database_path) < WAL_CHECKPOINT_MIN_BYTES {
+            return;
+        }
+        let _ =
+            self.conn.query_row("PRAGMA wal_checkpoint(TRUNCATE)", [], |row| row.get::<_, i64>(0));
+    }
+
     pub fn source_root(&self) -> Option<&Path> {
         self.source_root.as_deref()
     }
@@ -284,11 +296,7 @@ impl Drop for IndexConnection {
         if !self.fold_wal_on_close || std::thread::panicking() {
             return;
         }
-        if wal_bytes(&self.database_path) < WAL_CHECKPOINT_MIN_BYTES {
-            return;
-        }
-        let _ =
-            self.conn.query_row("PRAGMA wal_checkpoint(TRUNCATE)", [], |row| row.get::<_, i64>(0));
+        self.fold_wal();
     }
 }
 

--- a/crates/rag-rat-mcp/src/server.rs
+++ b/crates/rag-rat-mcp/src/server.rs
@@ -409,6 +409,7 @@ mod tests {
         let config = Config {
             trackers: Vec::new(),
             papertrail: Default::default(),
+            sync: Default::default(),
             repo_id_override: None,
             database_key_pinned: true,
             root: root.clone(),

--- a/crates/rag-rat-mcp/src/tools/tests.rs
+++ b/crates/rag-rat-mcp/src/tools/tests.rs
@@ -1062,6 +1062,7 @@ fn mixed_config() -> (PathBuf, Config) {
     (root.clone(), Config {
         trackers: Vec::new(),
         papertrail: Default::default(),
+        sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
         root: root.clone(),
@@ -1103,6 +1104,7 @@ fn markdown_config(text: &str) -> (PathBuf, Config) {
     (root.clone(), Config {
         trackers: Vec::new(),
         papertrail: Default::default(),
+        sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
         root: root.clone(),
@@ -1131,6 +1133,7 @@ fn rust_config(root: PathBuf) -> Config {
     Config {
         trackers: Vec::new(),
         papertrail: Default::default(),
+        sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
         root: root.clone(),

--- a/crates/rag-rat-oplog/src/account/bootstrap.rs
+++ b/crates/rag-rat-oplog/src/account/bootstrap.rs
@@ -179,11 +179,13 @@ pub(super) fn local_account_ref(conn: &Connection) -> anyhow::Result<Option<Loca
     Ok(Some(LocalAccountRef { account_id, genesis_hash }))
 }
 
-/// Resolve this store's local account from the pointer, or `None` if none is minted yet. The
-/// pointer is a content address; the account_id is recovered by looking the genesis up in the
-/// candidate DAG (§4 commits the account_id inside the genesis payload, so this is the one true
-/// id).
-fn read_local_account(conn: &Connection) -> anyhow::Result<Option<AccountId>> {
+/// Resolve this store's local account from the pointer, or `None` if none is minted yet — the
+/// read-only, non-minting twin of [`local_account`] (which mints a genesis on first call). Callers
+/// that must NOT create identity state (e.g. a server that requires an already-enrolled account)
+/// use this. The pointer is a content address; the account_id is recovered by looking the genesis
+/// up in the candidate DAG (§4 commits the account_id inside the genesis payload, so this is the
+/// one true id).
+pub fn read_local_account(conn: &Connection) -> anyhow::Result<Option<AccountId>> {
     let Some(genesis_hash) = read_pointer_hash(conn)? else {
         return Ok(None);
     };

--- a/crates/rag-rat-oplog/src/account/mod.rs
+++ b/crates/rag-rat-oplog/src/account/mod.rs
@@ -45,7 +45,7 @@ mod storage;
 pub use authoring::{
     ensure_owned_stream_v2_in_tx, established_owned_stream_v2, owned_stream_v2_id,
 };
-pub use bootstrap::local_account;
+pub use bootstrap::{local_account, read_local_account};
 #[allow(unused_imports, reason = "C2 contract is frozen before transport wiring lands")]
 pub use content::{
     ContentCapacityScope, ContentEntryHeader, ContentIngestOutcome, ContentRefoldBudget,

--- a/crates/rag-rat-oplog/src/lib.rs
+++ b/crates/rag-rat-oplog/src/lib.rs
@@ -109,10 +109,11 @@ pub use account::{
     established_owned_stream_v2, grant_effective_for_device, historical_content_keyring,
     live_stream_key_targets_for_device, local_account, mint_and_author_stream_key_wrap_in_tx,
     owned_stream_v2_id, owner_control_authority, owner_secrets_authority,
-    prepare_content_authoring, roster_content_authority, rotate_stream_key_in_tx,
-    select_current_sealing_wrap, settle_pending_content_refold_for_stream_in_tx,
-    settle_pending_content_refolds, sign_local_node_binding, stream_key_rotation_needed,
-    stream_owner_effective, verify_node_binding,
+    prepare_content_authoring, read_local_account, roster_content_authority,
+    rotate_stream_key_in_tx, select_current_sealing_wrap,
+    settle_pending_content_refold_for_stream_in_tx, settle_pending_content_refolds,
+    sign_local_node_binding, stream_key_rotation_needed, stream_owner_effective,
+    verify_node_binding,
 };
 // The `/3` content projection's store-global upgrade re-fold (#688): wired into the index
 // open/migrate seam by rag-rat-core, so a stale store is rebuilt (every stream, then the one

--- a/crates/rag-rat-oplog/src/table_sync/row_op.rs
+++ b/crates/rag-rat-oplog/src/table_sync/row_op.rs
@@ -292,7 +292,7 @@ pub fn row_pk_string(pk: &[TypedValue]) -> String {
         let mut enc = Encoder::new(&mut buf);
         encode_values(&mut enc, pk);
     }
-    hex_lower(&buf)
+    rag_rat_base::hash::hex_lower(&buf)
 }
 
 /// The anti-echo identity of a row: the hex `sha256` of the canonical CBOR of its synced cells
@@ -306,7 +306,7 @@ pub(crate) fn cells_hash(cells: &[Cell]) -> String {
         let mut enc = Encoder::new(&mut buf);
         encode_cells(&mut enc, cells);
     }
-    hex_lower(&cbor::sha256(&buf))
+    rag_rat_base::hash::hex_lower(&cbor::sha256(&buf))
 }
 
 /// Recover the pk values from a `row_pk` produced by [`row_pk_string`] — the inverse, so the
@@ -329,15 +329,6 @@ fn hex_decode(text: &str) -> anyhow::Result<Vec<u8>> {
             u8::from_str_radix(&text[i..i + 2], 16).map_err(|err| anyhow::anyhow!("bad hex: {err}"))
         })
         .collect()
-}
-
-fn hex_lower(bytes: &[u8]) -> String {
-    let mut out = String::with_capacity(bytes.len() * 2);
-    for byte in bytes {
-        out.push(char::from_digit((byte >> 4) as u32, 16).expect("nibble is 0..=15"));
-        out.push(char::from_digit((byte & 0x0f) as u32, 16).expect("nibble is 0..=15"));
-    }
-    out
 }
 
 #[cfg(test)]
@@ -474,7 +465,7 @@ mod tests {
     #[test]
     fn upsert_golden_vector() {
         let bytes = encode(&sample_upsert());
-        assert_eq!(hex_lower(&bytes), GOLDEN_UPSERT_HEX);
+        assert_eq!(rag_rat_base::hash::hex_lower(&bytes), GOLDEN_UPSERT_HEX);
     }
 
     const GOLDEN_UPSERT_HEX: &str = "83727261672d7261742f7461626c652d6f702f31667570736572748366745f64656d6f82617207848265636f756e74038264646f6e65f582646e6f7465f682657469746c65626869";

--- a/crates/rag-rat-oracle/src/report.rs
+++ b/crates/rag-rat-oracle/src/report.rs
@@ -94,7 +94,7 @@ impl CorpusProfile {
         // order, so this byte stream is stable for a given profile value.
         let canonical = serde_json::to_vec(self).expect("CorpusProfile is always serializable");
         let digest = Sha256::digest(&canonical);
-        hex_lower(&digest)
+        rag_rat_base::hash::hex_lower(&digest)
     }
 }
 
@@ -249,15 +249,6 @@ pub struct ResolutionBefore {
 
 fn ratio(numerator: u64, denominator: u64) -> f64 {
     if denominator == 0 { 1.0 } else { numerator as f64 / denominator as f64 }
-}
-
-fn hex_lower(bytes: &[u8]) -> String {
-    use std::fmt::Write as _;
-    let mut out = String::with_capacity(bytes.len() * 2);
-    for b in bytes {
-        let _ = write!(out, "{b:02x}");
-    }
-    out
 }
 
 #[cfg(test)]

--- a/crates/rag-rat-sync/src/endpoint.rs
+++ b/crates/rag-rat-sync/src/endpoint.rs
@@ -124,11 +124,15 @@ pub async fn connect_and_sync<S: SyncStore + NodeAuth>(
 /// bounded by [`DEFAULT_IDLE_TIMEOUT`]. `run_session`'s own idle timeout only starts once the
 /// stream is open, so without these a peer that connects and then stalls (never opening a stream)
 /// would hold this single-session server forever, blocking every later peer.
+///
+/// `now_ms` is a CLOCK, read once a peer has connected — never a timestamp captured before the
+/// accept wait. A server may idle arbitrarily long between connections, so the auth phase must
+/// stamp and verify bindings against the time the connection actually arrived (see the read below).
 pub async fn accept_and_sync<S: SyncStore + NodeAuth>(
     endpoint: &Endpoint,
     store: &mut S,
     policy: AuthPolicy,
-    now_ms: i64,
+    now_ms: impl Fn() -> i64,
 ) -> Result<SessionReport, SyncFailure> {
     let local_node = *endpoint.id().as_bytes();
     let incoming = endpoint
@@ -144,6 +148,10 @@ pub async fn accept_and_sync<S: SyncStore + NodeAuth>(
         .await
         .map_err(|_| SyncFailure::Endpoint(EndpointError::Connect("peer opened no stream".into())))?
         .map_err(|e| SyncFailure::Endpoint(EndpointError::Connect(e.to_string())))?;
+    // Read the clock only now that a peer has connected — NOT before the accept wait above. A
+    // long-idle server whose stamp/verify time predated the wait would treat a peer's freshly
+    // minted binding (and its own) as future-skewed and reject the session.
+    let now_ms = now_ms();
     // Authorize the dialer BEFORE run_session so no inventory (not even account confirmation)
     // leaves this peer until the remote passes our policy (#881).
     run_auth_phase(&mut send, &mut recv, &*store, AuthConfig {

--- a/crates/rag-rat-sync/src/store.rs
+++ b/crates/rag-rat-sync/src/store.rs
@@ -54,12 +54,15 @@ fn authorize_binding(
 pub struct OplogSyncStore<'a> {
     conn: &'a Connection,
     account_id: AccountId,
-    now_ms: i64,
+    /// A CLOCK, not a captured instant: `ingest` reads it when an entry actually arrives, so a
+    /// long-idle acceptor stamps `received_at_ms` (and drives pre-verify eviction ordering) with
+    /// the receipt time, not a stale construction time.
+    now_fn: fn() -> i64,
 }
 
 impl<'a> OplogSyncStore<'a> {
-    pub fn new(conn: &'a Connection, account_id: AccountId, now_ms: i64) -> Self {
-        Self { conn, account_id, now_ms }
+    pub fn new(conn: &'a Connection, account_id: AccountId, now_fn: fn() -> i64) -> Self {
+        Self { conn, account_id, now_fn }
     }
 }
 
@@ -102,7 +105,7 @@ impl SyncStore for OplogSyncStore<'_> {
         // A structurally rejected entry is NOT an error — a peer may legitimately offer something
         // this binary refuses (e.g. over a future cap) — so map it to NoChange, not a failure that
         // would abort the whole session.
-        match account_ingest(self.conn, signed_bytes, self.now_ms)? {
+        match account_ingest(self.conn, signed_bytes, (self.now_fn)())? {
             // Newly durable: stored, or durably parked pending its signer. Every `Ingested*`
             // variant added state (the `RejectedPromotions` suffixes report collateral pre-verify
             // eviction of OTHER parked rows, not a failure of THIS entry).
@@ -137,12 +140,14 @@ impl SyncStore for OplogSyncStore<'_> {
 pub struct OplogContentSyncStore<'a> {
     conn: &'a Connection,
     account_id: AccountId,
-    now_ms: i64,
+    /// A CLOCK read at ingest time (see [`OplogSyncStore::now_fn`]), not a captured instant, so a
+    /// long-idle acceptor stamps received content with its receipt time.
+    now_fn: fn() -> i64,
 }
 
 impl<'a> OplogContentSyncStore<'a> {
-    pub fn new(conn: &'a Connection, account_id: AccountId, now_ms: i64) -> Self {
-        Self { conn, account_id, now_ms }
+    pub fn new(conn: &'a Connection, account_id: AccountId, now_fn: fn() -> i64) -> Self {
+        Self { conn, account_id, now_fn }
     }
 }
 
@@ -189,7 +194,7 @@ impl SyncStore for OplogContentSyncStore<'_> {
         // budgets. A structural refusal (Rejected) or a capacity block is NOT a session error — a
         // peer may legitimately offer what this binary declines (e.g. content over the remote-flood
         // cap) — so map both to NoChange rather than aborting the whole session.
-        match content_ingest(self.conn, signed_bytes, self.now_ms)? {
+        match content_ingest(self.conn, signed_bytes, (self.now_fn)())? {
             // Newly durable: stored as a candidate, or durably parked pending its roster key. The
             // `Eviction` suffix reports collateral pre-verify eviction of OTHER parked rows, not a
             // failure of THIS entry.
@@ -206,9 +211,9 @@ impl SyncStore for OplogContentSyncStore<'_> {
 // Both op-log stores carry the same account-level node-authorization capability (the binding is
 // about the account + transport node, independent of whether the session moves account entries or
 // content), so both delegate to the shared helpers above.
-// Both auth methods take `now_ms` per HANDSHAKE (not the store's construction-time `now_ms`, which
-// stays the ingest timestamp for received entries): binding freshness must track the live clock, or
-// a reused store would mint stale bindings and never advance the replay window.
+// Both auth methods take `now_ms` per HANDSHAKE (distinct from the store's `now_fn` ingest clock):
+// binding freshness must track the live clock, or a reused store would mint stale bindings and
+// never advance the replay window.
 impl NodeAuth for OplogSyncStore<'_> {
     fn local_binding(&self, local_node: &[u8; 32], now_ms: i64) -> anyhow::Result<Vec<u8>> {
         sign_binding(self.conn, self.account_id, local_node, now_ms)

--- a/crates/rag-rat-sync/tests/oplog_sync.rs
+++ b/crates/rag-rat-sync/tests/oplog_sync.rs
@@ -33,8 +33,8 @@ async fn a_fresh_peer_restores_an_account_over_the_session() {
         "the destination starts empty for this account",
     );
 
-    let mut source_store = OplogSyncStore::new(&source, account_id, NOW);
-    let mut dest_store = OplogSyncStore::new(&dest, account_id, NOW);
+    let mut source_store = OplogSyncStore::new(&source, account_id, || NOW);
+    let mut dest_store = OplogSyncStore::new(&dest, account_id, || NOW);
 
     let (a_send, b_recv) = tokio::io::duplex(1 << 20);
     let (b_send, a_recv) = tokio::io::duplex(1 << 20);
@@ -70,7 +70,7 @@ async fn two_peers_in_sync_transfer_nothing() {
     // Seed b with the same entries by ingesting a's, so both hold the identical set.
     let b = fresh_db();
     {
-        let mut b_store = OplogSyncStore::new(&b, account_id, NOW);
+        let mut b_store = OplogSyncStore::new(&b, account_id, || NOW);
         for e in &entries {
             use rag_rat_sync::SyncStore;
             b_store.ingest(&e.signed_bytes).unwrap();
@@ -78,8 +78,8 @@ async fn two_peers_in_sync_transfer_nothing() {
     }
     assert_eq!(account_entries_for_sync(&b, account_id).unwrap().len(), entries.len());
 
-    let mut a_store = OplogSyncStore::new(&a, account_id, NOW);
-    let mut b_store = OplogSyncStore::new(&b, account_id, NOW);
+    let mut a_store = OplogSyncStore::new(&a, account_id, || NOW);
+    let mut b_store = OplogSyncStore::new(&b, account_id, || NOW);
     let (a_send, b_recv) = tokio::io::duplex(1 << 16);
     let (b_send, a_recv) = tokio::io::duplex(1 << 16);
     let (ra, rb) = tokio::join!(
@@ -145,8 +145,8 @@ async fn a_fresh_peer_restores_the_accounts_content_after_the_account_log() {
     //    content session run before this would still transfer the bytes, but they would park until
     //    authority arrived; restore runs the logs in dependency order.
     {
-        let mut src = OplogSyncStore::new(&source, account_id, NOW);
-        let mut dst = OplogSyncStore::new(&dest, account_id, NOW);
+        let mut src = OplogSyncStore::new(&source, account_id, || NOW);
+        let mut dst = OplogSyncStore::new(&dest, account_id, || NOW);
         let (a_send, b_recv) = tokio::io::duplex(1 << 20);
         let (b_send, a_recv) = tokio::io::duplex(1 << 20);
         let (ra, rb) = tokio::join!(
@@ -159,8 +159,8 @@ async fn a_fresh_peer_restores_the_accounts_content_after_the_account_log() {
 
     // 2) Content — the memories.
     let dest_report = {
-        let mut src = OplogContentSyncStore::new(&source, account_id, NOW);
-        let mut dst = OplogContentSyncStore::new(&dest, account_id, NOW);
+        let mut src = OplogContentSyncStore::new(&source, account_id, || NOW);
+        let mut dst = OplogContentSyncStore::new(&dest, account_id, || NOW);
         let (a_send, b_recv) = tokio::io::duplex(1 << 20);
         let (b_send, a_recv) = tokio::io::duplex(1 << 20);
         let (ra, rb) = tokio::join!(
@@ -248,7 +248,7 @@ async fn foreign_account_content_is_not_stored() {
     let mine = fresh_db();
     let my_account = local_account(&mine, NOW).unwrap();
     assert_ne!(my_account.to_bytes(), other_account.to_bytes());
-    let mut store = OplogContentSyncStore::new(&mine, my_account, NOW);
+    let mut store = OplogContentSyncStore::new(&mine, my_account, || NOW);
     assert_eq!(
         store.ingest(&foreign).unwrap(),
         rag_rat_sync::Ingested::NoChange,
@@ -270,7 +270,7 @@ fn a_store_authorizes_its_own_binding_but_not_from_another_node() {
 
     let db = fresh_db();
     let account = local_account(&db, NOW).unwrap();
-    let store = OplogSyncStore::new(&db, account, NOW);
+    let store = OplogSyncStore::new(&db, account, || NOW);
 
     let node = [4u8; 32];
     let binding = store.local_binding(&node, NOW).unwrap();
@@ -292,7 +292,7 @@ fn a_store_authorizes_against_the_handshake_clock_not_its_construction_time() {
 
     let db = fresh_db();
     let account = local_account(&db, NOW).unwrap();
-    let stale = OplogSyncStore::new(&db, account, NOW); // constructed with an old clock
+    let stale = OplogSyncStore::new(&db, account, || NOW); // constructed with an old clock
     let node = [4u8; 32];
 
     let much_later = NOW + 10 * 24 * 60 * 60 * 1000; // ten days after construction
@@ -311,7 +311,7 @@ fn a_store_without_an_account_presents_an_empty_binding_and_authorizes_nothing()
 
     let db = fresh_db(); // schema only, no account
     let account = AccountId::from_bytes([7u8; 32]);
-    let store = OplogSyncStore::new(&db, account, NOW);
+    let store = OplogSyncStore::new(&db, account, || NOW);
     assert!(
         store.local_binding(&[1u8; 32], NOW).unwrap().is_empty(),
         "no local device => an anonymous (empty) binding",
@@ -330,7 +330,7 @@ fn the_content_store_carries_the_same_node_auth() {
 
     let db = fresh_db();
     let account = local_account(&db, NOW).unwrap();
-    let store = OplogContentSyncStore::new(&db, account, NOW);
+    let store = OplogContentSyncStore::new(&db, account, || NOW);
     let node = [4u8; 32];
     let binding = store.local_binding(&node, NOW).unwrap();
     assert!(store.authorize(&binding, &node, NOW).unwrap(), "own node authorized");
@@ -354,14 +354,14 @@ async fn a_real_iroh_round_trip_restores_an_account() {
     let dialer = rag_rat_sync::build_endpoint([2u8; 32], &relay).await.unwrap();
     let listener_addr = rag_rat_sync::endpoint_addr(&listener);
 
-    let mut source_store = OplogSyncStore::new(&source, account_id, NOW);
-    let mut dest_store = OplogSyncStore::new(&dest, account_id, NOW);
+    let mut source_store = OplogSyncStore::new(&source, account_id, || NOW);
+    let mut dest_store = OplogSyncStore::new(&dest, account_id, || NOW);
     // The dest is a fresh peer with no local device (onboarding), so this round-trip uses `Open`;
     // the node-authorization path is covered directly by the auth-phase tests below and the oplog
     // node_binding unit tests.
     let policy = rag_rat_sync::AuthPolicy::Open;
     let server =
-        async { rag_rat_sync::accept_and_sync(&listener, &mut source_store, policy, NOW).await };
+        async { rag_rat_sync::accept_and_sync(&listener, &mut source_store, policy, || NOW).await };
     let client = async {
         rag_rat_sync::connect_and_sync(&dialer, listener_addr, &mut dest_store, policy, NOW).await
     };
@@ -390,7 +390,7 @@ async fn an_entry_for_another_account_is_not_stored() {
     assert_ne!(my_account.to_bytes(), other_account.to_bytes());
 
     // A store scoped to MY account is handed the OTHER account's (perfectly valid) entry.
-    let mut store = OplogSyncStore::new(&mine, my_account, NOW);
+    let mut store = OplogSyncStore::new(&mine, my_account, || NOW);
     let outcome = store.ingest(&other_entry).unwrap();
     assert_eq!(outcome, rag_rat_sync::Ingested::NoChange, "a foreign-account entry is refused");
     // And it did not land: my account holds only its own genesis, the other account holds nothing.


### PR DESCRIPTION
Turns the transport-independent sync primitives (endpoint, hello/pull/push, node auth) into a runnable driver: a config home for the relay, a persisted node identity, and a headless store-and-forward peer.

## What it adds

- **`[sync]` config.** A `relay_url` field defaulting to the project relay (`https://relay.cq27.dev`) and overridable in config; `RAG_RAT_SYNC_RELAY` overrides it at the call site for ops/tests.
- **Stable node key.** A 32-byte iroh node secret, minted once and persisted in `index_meta` so the node id survives restarts. It is deliberately distinct from the account device signing key, and held in a `Zeroizing` wrapper in memory.
- **`rag-rat sync serve`.** A headless peer that binds the endpoint over the configured relay and replicates this account's op log with peers the roster authorizes (mutual verification, private-account default). Startup (schema migration, account read, node-key mint) runs under the repo write lock like the other `sync` subcommands and releases it before the long-running accept loop, so it never blocks indexing/watcher/GC. It refuses to start without an already-enrolled account (it never mints identity as a side effect), prints its dialable node id to stdout, and `--once` serves a single connection for scripted checks.
- Consolidates three hand-rolled lower-hex encoders into `rag_rat_base::hash::hex_lower`.

## Behavior notes

- The session wire carries one stream per session, so serve replicates the **account log** — the identity/roster substrate a fresh device restores first. Content replication needs a wire stream discriminator; tracked in #907.
- The authentication and ingest clocks are read once a peer connects, not when the server starts: a server can idle arbitrarily long between connections, and a pre-wait timestamp would reject a peer's freshly minted binding as future-skewed and stamp received entries stale.

## Tests

`[sync]` config round-trip + env/default resolution, node-key mint-once + hex round-trip, and the existing two-endpoint session/loopback coverage (the live relay path stays behind `--ignored`). Full workspace green under both CI runners; all clippy feature gates clean.

Part of #406. Fixes #905.