### PR TITLE
perf(index): return freed heap to the OS at heavy-pass terminals

### DIFF
--- a/crates/rag-rat-base/src/heap.rs
+++ b/crates/rag-rat-base/src/heap.rs
@@ -1,0 +1,49 @@
+//! Give freed heap back to the OS after a large transient working set.
+//!
+//! The sibling of [`crate::stack`]: `stack` grows what a deep walk needs, this returns what a
+//! heavy pass no longer holds.
+
+/// Release freed heap pages back to the OS after a large transient working set has been dropped.
+///
+/// glibc malloc rarely returns freed memory to the OS on its own: freed blocks park in its
+/// arenas, so a long-lived process retains its *peak* heap as private-dirty RSS. SQLite is the
+/// dominant source of that peak here — the bundled libsqlite3 allocates through the C allocator
+/// (Rust's `#[global_allocator]` never sees it), so a maintenance pass's page cache and
+/// `temp_store = MEMORY` sorts, a full rebuild's bulk-build cache, a migration's one-time
+/// buffers, and a VACUUM's rewrite all land in glibc arenas. SQLite frees all of it at
+/// connection close, but the arenas keep the pages: a store-owning server was measured holding
+/// 745 MiB RSS with zero open connections (#906). `malloc_trim(0)` walks the arenas and hands
+/// the freed pages back.
+///
+/// Call it only at the terminal of a heavy, bounded episode — a maintenance pass that ran real
+/// work, a full rebuild, a schema migration, a VACUUM — never on a hot path: it takes the malloc
+/// locks and `madvise`s freed ranges, so it costs milliseconds after a big pass, and it can only
+/// help when a large working set was actually just freed.
+///
+/// glibc-only: `malloc_trim` is a glibc extension (musl, macOS, and Windows have no equivalent),
+/// so everywhere else this compiles to a no-op. jemalloc builds (the CLI binary) are unaffected
+/// either way — jemalloc's background purge already returns the *Rust* heap, and this call
+/// reaches only the glibc arenas that C allocations (SQLite) live in.
+pub fn release_freed_heap() {
+    #[cfg(all(target_os = "linux", target_env = "gnu"))]
+    // SAFETY: malloc_trim is a thread-safe glibc call with no preconditions; the argument is
+    // the amount of free space to leave untrimmed at the top of the heap.
+    unsafe {
+        libc::malloc_trim(0);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    /// Smoke: callable on every target — glibc trims, everywhere else it is a no-op. The RSS
+    /// effect itself is not unit-assertable (`malloc_trim`'s return value only says whether any
+    /// memory was released, which depends on allocator state); the measured evidence lives in
+    /// #906.
+    #[test]
+    fn release_freed_heap_is_a_safe_no_op_or_trim() {
+        super::release_freed_heap();
+        // A second call must also be fine: pass terminals can fire back-to-back (a startup
+        // catch-up pass followed by a scheduled pass).
+        super::release_freed_heap();
+    }
+}

--- a/crates/rag-rat-base/src/lib.rs
+++ b/crates/rag-rat-base/src/lib.rs
@@ -8,6 +8,7 @@ pub mod config;
 pub mod data_dir;
 pub mod embedding_models;
 pub mod hash;
+pub mod heap;
 pub mod language;
 pub mod locks;
 pub mod logging;

--- a/crates/rag-rat-core/src/index/lifecycle.rs
+++ b/crates/rag-rat-core/src/index/lifecycle.rs
@@ -588,6 +588,15 @@ impl IndexDatabase {
             super::migration_gate::MigrationGate::from_env()
                 .ensure_migration_permitted(path, state)?;
             schema::apply(conn, &crate::index::migration_hooks())?;
+            // A store migration can rewrite whole tables (a 0.20 → 0.21 store refolded ~GBs);
+            // those one-time buffers are freed by here but sit in glibc's arenas as retained
+            // RSS unless returned (#906). `shrink_memory` first: the migration's page-cache
+            // fill is still LIVE on this kept connection, where the trim cannot reach it —
+            // release it (`sqlite3_db_release_memory`), then trim. Best-effort: a failed
+            // shrink only leaves cached pages behind. Inside the `!Compatible` arm only — the
+            // common already-current open applies nothing and must not pay either call.
+            let _ = conn.execute_batch("PRAGMA shrink_memory;");
+            rag_rat_base::heap::release_freed_heap();
         }
         Ok(())
     }

--- a/crates/rag-rat-core/src/index/query_api/db_file_health.rs
+++ b/crates/rag-rat-core/src/index/query_api/db_file_health.rs
@@ -303,6 +303,10 @@ pub fn reclaim_freelist_at(database: &Path) -> anyhow::Result<FreelistReclaim> {
             .query_row("PRAGMA wal_checkpoint(TRUNCATE)", [], |row| row.get::<_, i64>(0))?;
     let (main_bytes_after, freelist_pages_after) = freelist_snapshot(&vacuum_conn, database)?;
     drop(vacuum_conn);
+    // VACUUM rewrote the file through this connection's page cache, all freed by the drop above
+    // — but SQLite allocates through the C allocator, so without a trim glibc's arenas retain
+    // that rewrite peak as RSS for as long as the calling process lives (#906).
+    rag_rat_base::heap::release_freed_heap();
     Ok(FreelistReclaim::Reclaimed(FreelistReclaimReport {
         main_bytes_before,
         main_bytes_after,

--- a/crates/rag-rat-core/src/index/rebuild.rs
+++ b/crates/rag-rat-core/src/index/rebuild.rs
@@ -337,13 +337,27 @@ impl IndexDatabase {
             // gc-swept).
             let _ = db.storage.execute_batch("ROLLBACK");
         }
-        // cache_size is left bumped — harmless for the short remaining lifetime of the connection.
-        // The coarse bulk-build autocheckpoint is NOT left in place: watcher heals and startup
-        // catch-up KEEP the returned connection for later passes, and a lingering autocheckpoint
-        // would fire passive checkpoints mid-pass — exactly what `wal_autocheckpoint = 0` at open
-        // exists to prevent (#818). Restore it on success AND failure; best-effort, since a failed
-        // restore only leaves the coarser cadence behind.
-        let _ = db.storage.execute_batch("PRAGMA wal_autocheckpoint = 0;");
+        // Neither bulk-build pragma is left in place: watcher heals and startup catch-up KEEP
+        // the returned connection for later passes, so a lingering autocheckpoint would fire
+        // passive checkpoints mid-pass — exactly what `wal_autocheckpoint = 0` at open exists
+        // to prevent (#818) — and the lingering 256 MiB cache_size would keep that many LIVE
+        // pages on the kept connection (and let later passes refill to it) where the heap trim
+        // below cannot reach them (#906). Restore both to their open-time values on success
+        // AND failure; best-effort, since a failed restore only leaves the coarser/bigger
+        // setting behind. `shrink_memory` then drops the connection's now-over-cap cached
+        // pages immediately (`sqlite3_db_release_memory`) instead of waiting for lazy
+        // eviction, so they are actually FREE when the trim runs.
+        let _ = db.storage.execute_batch(
+            "PRAGMA wal_autocheckpoint = 0;
+             PRAGMA cache_size = -65536;
+             PRAGMA shrink_memory;",
+        );
+        // The rebuild's transient working set — the bulk-build page cache released above, the
+        // staged waves' prepared files, the accumulated base-edge graph — was just dropped (or
+        // rolled back). Return it to the OS on success AND failure, before the early `?` below:
+        // SQLite's share lives in glibc's arenas (the C allocator, not Rust's), which otherwise
+        // retain the rebuild peak as RSS for the life of the process (#906).
+        rag_rat_base::heap::release_freed_heap();
         result?;
         // #828 §9.1: the sanctioned full rebuild is a reseed by definition — the
         // `files_content_digest_*` triggers maintained `content_digest_state` through every staged

--- a/crates/rag-rat-core/src/watch/pass.rs
+++ b/crates/rag-rat-core/src/watch/pass.rs
@@ -427,6 +427,9 @@ fn run_pass(
     if !run_base_tail && !overlays_changed {
         timings.stage("wal", || maybe_checkpoint_wal(&db, crate::index::WAL_CHECKPOINT_MIN_BYTES));
         timings.emit(false, content_changed, overlays_changed);
+        // No heap trim on the idle exit: a discover-only sweep allocates nothing worth
+        // returning, and any earlier heavy pass already trimmed at its own terminal — trimming
+        // here would just take the malloc locks every 60 s for nothing.
         return Ok(());
     }
     let mut base_reconcile_status = None;
@@ -508,6 +511,16 @@ fn run_pass(
         db.clear_watch_shutdown_reconcile_pending()?;
     }
     timings.stage("wal", || maybe_checkpoint_wal(&db, crate::index::WAL_CHECKPOINT_MIN_BYTES));
+    // This exit is only reached when the pass did real work (a base tail ran or an overlay
+    // refresh wrote), so the transient working set — SQLite's page cache and
+    // `temp_store = MEMORY` sorts (#815) plus the pass's own buffers — is what the pass peak
+    // is made of. Close the pass connection FIRST (the drop below is the same close that
+    // otherwise happens at return, moved before the trim) so SQLite actually frees its cache,
+    // then hand the freed heap back to the OS — or glibc's arenas retain the pass peak as RSS
+    // for the life of the server (#906). Timed as a stage so a pathological trim shows up in
+    // the pass summary.
+    drop(db);
+    timings.stage("trim", rag_rat_base::heap::release_freed_heap);
     timings.emit(true, content_changed, overlays_changed);
     Ok(())
 }

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -205,6 +205,10 @@ MEM_TRACE probes miss).
   trade speed for peak RSS on a memory-constrained box.
 - `RAG_RAT_MEM_TRACE=1` — emit the per-phase rebuild RSS + sqlite-memory curve to stderr. (Note: it
   does not instrument the post-COMMIT phases — use the sampler CSV for those.)
+- `MALLOC_ARENA_MAX` (glibc env var, e.g. `MALLOC_ARENA_MAX=2`) — cap glibc's per-thread malloc
+  arenas on a memory-constrained host. rag-rat already returns freed heap at pass/rebuild/
+  migration/VACUUM terminals (`malloc_trim`), but fewer arenas also lower the *peak* between
+  those points, at some allocation-contention cost.
 - `RAG_RAT_KERNEL_SUBDIRS` (bench only) — bound the indexed subtree (e.g. `"kernel mm fs net lib"`)
   to go faster while iterating; `.` is the whole tree (the headline).
 - `RAG_RAT_KERNEL_VECTORS=1` (bench only) — add the opt-in `+vectors` pass to the run, reporting


### PR DESCRIPTION
## Problem

After heavy maintenance activity against a ~2 GB store (a store migration/refold, a freelist compaction, several overlay refreshes), the store-owning server retains ~745 MiB RSS (peak 842 MiB) indefinitely — with **zero** open SQLite connections. Anatomy (`smaps_rollup` + maps): ~724 MB anonymous private-dirty heap in a stack of ~64/128 MiB anon regions — glibc malloc arenas (~21 threads). Siblings on the same binary idle at 4–31 MiB.

The peak itself is the deliberate #815 write-path trade-offs (`temp_store = MEMORY` sorts + the bounded 64 MiB per-connection page cache while passes run) plus one-time migration/refold buffers. The *retention* is pure allocator behavior — but it is worth being precise about **which** allocator, because this binary runs two:

- **jemalloc** is the Rust `#[global_allocator]` (the earlier idle-RSS fix), with background purge threads and `dirty/muzzy_decay_ms = 1000` retuned across all arenas at startup. It does **not** retain: freed Rust heap returns to the OS within seconds (that is why sibling servers idle at 4–31 MiB). Its symbols are prefixed (`_rjem_*`), so it never intercepts C `malloc`.
- **glibc** still serves every C allocation: `malloc`/`free`/`malloc_trim` are dynamic imports bound to `GLIBC_2.2.5` in the shipped binary, and bundled libsqlite3 allocates through plain C `malloc`. SQLite's page cache and `temp_store = MEMORY` sorts are exactly the transient bulk — freed at connection close, then parked forever in glibc's per-thread arenas (non-main arenas are never returned by `free()`).

`malloc_trim(0)` walks the glibc arenas and hands the freed pages back to the OS. It has no effect on (and no interaction with) the jemalloc side — including the jemalloc startup-tuning path touched by #908; this change adds no `mallctl` calls and is compiled only on linux-gnu.

## Fix

A tiny helper, `rag_rat_base::heap::release_freed_heap()` — `libc::malloc_trim(0)` behind `cfg(all(target_os = "linux", target_env = "gnu"))`, a no-op elsewhere (`malloc_trim` is a glibc extension; musl/macOS/Windows compile clean). `libc` was already a dependency of rag-rat-base.

Called at the terminals where a large transient working set has just been freed — never on a hot path:

- **Maintenance pass** (`watch/pass.rs::run_pass`): on the worked exit, after the wal fold, with the pass connection dropped *first* so SQLite's cache is actually free when the trim runs. Timed as a `trim` stage so a pathological trim shows up in the pass summary. The idle (discover-only) exit deliberately does not trim — it allocates nothing worth returning, and any earlier heavy pass already trimmed at its own terminal.
- **Full rebuild** (`index/rebuild.rs`): on success and failure alike. The bulk-build `cache_size` is now restored to the open-time 64 MiB bound and the connection's cached pages are dropped (`PRAGMA shrink_memory`) before the trim — the returned connection is *kept* by watcher heals/startup catch-up, so without that restore up to 256 MiB stayed live where a trim cannot reach it (and later passes could refill to the bulk cap).
- **Schema migration** (`lifecycle.rs::apply_schema_under_lock`): inside the `!Compatible` arm only — a store migration can rewrite whole tables (the 0.20 → 0.21 refold moved ~GBs). `shrink_memory` first (the connection is kept), then trim. The common already-current open pays nothing.
- **Freelist compaction** (`db_file_health.rs::reclaim_freelist_at`): after the VACUUM connection drops, covering both `doctor --vacuum` and the repo-removal purge.

Also: one `MALLOC_ARENA_MAX` line in the docs/benchmarks.md knobs section as the environment-level *peak* lever for constrained hosts.

## Measured before/after

A/B on a scratch watcher (private scratch DB, never the live store): identical corpus clones pinned to the merge base, empty stores, so each watcher's startup catch-up builds the whole ~91 MiB store in-process on the pass worker thread (the heavy-refresh case), then one mass edit of 300 base files drives a second heavy reindex pass. Both release builds, run simultaneously, sampled at 1 Hz from `/proc/<pid>/status`; control = merge base (1a85094a) without this change.

| | control (no trim) | fixed (this PR) |
|---|---|---|
| peak VmHWM | 443.1 MiB | 404.8 MiB |
| settled RSS after the bootstrap build (+280 s) | 222.1 MiB | **50.8 MiB** |
| settled RSS after the 300-file reindex pass (+220 s) | 246.7 MiB | **58.7 MiB** |
| final private-dirty (`smaps`) | 242.9 MiB | **35.2 MiB** |
| trim cost per worked pass (`trim` stage) | — | 3–13 ms |

The control plateaus at its pass peak and stays there flat for minutes — with jemalloc decaying at 1 s, that plateau cannot be jemalloc-held memory, confirming the glibc-arena attribution. The fixed build falls back to near-baseline at every worked-pass terminal. Peaks are comparable by design: the trim removes the residue, not the peak.

## Deliberately left out

The issue's remaining option — extending the rebuild path's soft-heap-limit posture to watcher maintenance connections to bound the *peak* — is not included: `sqlite3_soft_heap_limit64` is process-wide, not per-connection, so capping it for maintenance passes would also cap the serving read path of the same store-owning server (the existing `RAG_RAT_SQLITE_SOFT_HEAP_LIMIT_MB` diagnostic already covers investigation). An explicit jemalloc purge at the same seams was also considered and rejected as redundant: startup tuning already sets 1 s decay + background purge, so the Rust-side share reclaims itself. The peak remains governed by the #815 knobs; this PR removes the retention.

Fixes #906
