### PR TITLE
chore: release v0.21.1

### DIFF
--- a/.agents/skills/init-rag-rat/SKILL.md
+++ b/.agents/skills/init-rag-rat/SKILL.md
@@ -32,7 +32,7 @@ hand-write a config blind, and let a real config load re-check it before indexin
    do **not** use `@latest`, and **don't blindly trust an on-`PATH` `rag-rat`**:
    - If `rag-rat` is on `PATH`, check `rag-rat --version` and use it **only if it matches** the
      plugin/MCP version — a stale global install would build the index with the wrong binary.
-   - Otherwise (or on a version mismatch) use `npx -y @rag-rat/bin@0.21.0 …` — the plugin pins
+   - Otherwise (or on a version mismatch) use `npx -y @rag-rat/bin@0.21.1 …` — the plugin pins
      `@rag-rat/bin` to its own version and caches the binary privately, so this is the
      version-matched CLI; `npx` runs it in the current directory.
 

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "rag-rat",
       "description": "Local repo-intelligence index + MCP server: semantic search, symbol/graph navigation, impact-surface preflight, git + GitHub papertrail, and a source-anchored memory graph.",
-      "version": "0.21.0",
+      "version": "0.21.1",
       "source": "./plugin",
       "category": "developer-tools",
       "license": "MIT",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.1](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.21.0...rag-rat-base-v0.21.1) - 2026-07-24
+
+### Other
+
+- *(index)* return freed heap to the OS at heavy-pass terminals ([#910](https://github.com/cq27-dev/rag-rat/pull/910))
+
 ## [0.21.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.20.0...rag-rat-base-v0.21.0) - 2026-07-24
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4848,7 +4848,7 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rag-rat"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -4882,7 +4882,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-base"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "anyhow",
  "filetime",
@@ -4906,7 +4906,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-clones"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "anyhow",
  "rag-rat-base",
@@ -4922,7 +4922,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-core"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "anyhow",
  "chacha20poly1305",
@@ -4987,7 +4987,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-db"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "anyhow",
  "rag-rat-base",
@@ -5001,7 +5001,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-dream"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "anyhow",
  "rag-rat-base",
@@ -5020,7 +5020,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-llm"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "anyhow",
  "fastembed",
@@ -5041,7 +5041,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-mcp"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "anyhow",
  "libc",
@@ -5063,7 +5063,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-oplog"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "anyhow",
  "chacha20poly1305",
@@ -5085,7 +5085,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-oracle"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "anyhow",
  "protobuf",
@@ -5103,7 +5103,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-papertrail"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -5123,7 +5123,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-query"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "anyhow",
  "minicbor",
@@ -5142,7 +5142,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-sync"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "anyhow",
  "iroh",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ resolver = "3"
 # and the internal path deps below pin the same literal, so the three crates always publish in
 # lockstep. Bump this one line (and the two internal-dep `version`s under workspace.dependencies)
 # to release.
-version = "0.21.0"
+version = "0.21.1"
 authors = ["Kristaps Karlsons"]
 edition = "2024"
 # Bundled SQLite (rusqlite `bundled` -> libsqlite3-sys 0.38.1) compiles a build script that uses the
@@ -38,18 +38,18 @@ categories = ["command-line-utilities", "development-tools"]
 # Internal crates — declared once here so the version requirement is set in lockstep with
 # [workspace.package].version above. Members reference these via `{ workspace = true }` and add
 # their own feature toggles at the use site.
-rag-rat-base = { version = "0.21.0", path = "crates/rag-rat-base", default-features = false }
-rag-rat-clones = { version = "0.21.0", path = "crates/rag-rat-clones", default-features = false }
-rag-rat-db = { version = "0.21.0", path = "crates/rag-rat-db", default-features = false }
-rag-rat-dream = { version = "0.21.0", path = "crates/rag-rat-dream", default-features = false }
-rag-rat-llm = { version = "0.21.0", path = "crates/rag-rat-llm", default-features = false }
-rag-rat-oracle = { version = "0.21.0", path = "crates/rag-rat-oracle", default-features = false }
-rag-rat-oplog = { version = "0.21.0", path = "crates/rag-rat-oplog", default-features = false }
-rag-rat-papertrail = { version = "0.21.0", path = "crates/rag-rat-papertrail", default-features = false }
-rag-rat-query = { version = "0.21.0", path = "crates/rag-rat-query", default-features = false }
-rag-rat-core = { version = "0.21.0", path = "crates/rag-rat-core", default-features = false }
-rag-rat-mcp = { version = "0.21.0", path = "crates/rag-rat-mcp", default-features = false }
-rag-rat-sync = { version = "0.21.0", path = "crates/rag-rat-sync", default-features = false }
+rag-rat-base = { version = "0.21.1", path = "crates/rag-rat-base", default-features = false }
+rag-rat-clones = { version = "0.21.1", path = "crates/rag-rat-clones", default-features = false }
+rag-rat-db = { version = "0.21.1", path = "crates/rag-rat-db", default-features = false }
+rag-rat-dream = { version = "0.21.1", path = "crates/rag-rat-dream", default-features = false }
+rag-rat-llm = { version = "0.21.1", path = "crates/rag-rat-llm", default-features = false }
+rag-rat-oracle = { version = "0.21.1", path = "crates/rag-rat-oracle", default-features = false }
+rag-rat-oplog = { version = "0.21.1", path = "crates/rag-rat-oplog", default-features = false }
+rag-rat-papertrail = { version = "0.21.1", path = "crates/rag-rat-papertrail", default-features = false }
+rag-rat-query = { version = "0.21.1", path = "crates/rag-rat-query", default-features = false }
+rag-rat-core = { version = "0.21.1", path = "crates/rag-rat-core", default-features = false }
+rag-rat-mcp = { version = "0.21.1", path = "crates/rag-rat-mcp", default-features = false }
+rag-rat-sync = { version = "0.21.1", path = "crates/rag-rat-sync", default-features = false }
 anyhow = "1.0"
 # ed25519 device-identity signing for the op-log's signed entry envelope (§C4 layer-1). Default
 # features (incl. `zeroize`, which zeroizes a `SigningKey`'s seed on drop) are kept; the `rand_core`

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "rag-rat",
   "displayName": "rag-rat",
   "description": "Local repo-intelligence index + MCP server: semantic search, symbol/graph navigation, impact-surface preflight, git + GitHub papertrail, and a source-anchored memory graph.",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "author": { "name": "Kristaps Karlsons" },
   "homepage": "https://github.com/cq27-dev/rag-rat",
   "repository": "https://github.com/cq27-dev/rag-rat",
@@ -11,7 +11,7 @@
   "mcpServers": {
     "rag-rat": {
       "command": "npx",
-      "args": ["-y", "@rag-rat/bin@0.21.0", "mcp"]
+      "args": ["-y", "@rag-rat/bin@0.21.1", "mcp"]
     }
   }
 }

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rag-rat",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "description": "Local repo-intelligence index + MCP server: semantic search, symbol/graph navigation, impact-surface preflight, git + GitHub papertrail, and a source-anchored memory graph.",
   "author": { "name": "Kristaps Karlsons", "url": "https://github.com/cq27-dev/rag-rat" },
   "homepage": "https://github.com/cq27-dev/rag-rat",

--- a/plugin/.mcp.json
+++ b/plugin/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "rag-rat": {
       "command": "npx",
-      "args": ["-y", "@rag-rat/bin@0.21.0", "mcp"]
+      "args": ["-y", "@rag-rat/bin@0.21.1", "mcp"]
     }
   }
 }

--- a/plugin/opencode/package.json
+++ b/plugin/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rag-rat/plugin-opencode",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "description": "opencode plugin for rag-rat: self-registers the rag-rat MCP server (semantic search, symbol/graph navigation, impact-surface preflight, repo memory) and wires session/grep/edit hooks through the shared agent-hook.",
   "license": "MIT",
   "type": "module",

--- a/plugin/opencode/rag-rat.ts
+++ b/plugin/opencode/rag-rat.ts
@@ -3,7 +3,7 @@
 // opencode's plugin shape differs from Claude Code / Codex (no hooks.json manifest, no
 // additionalContext channel on tool.execute.before), so this module is a thin shim over the same
 // shared pieces the other harnesses use:
-//   - MCP: registered via the `config` hook as `npx -y @rag-rat/bin@0.21.0<version> mcp` (pinned; kept
+//   - MCP: registered via the `config` hook as `npx -y @rag-rat/bin@0.21.1<version> mcp` (pinned; kept
 //     in lockstep with the release by tools/sync-plugin-version.mjs).
 //   - Hooks: routed through the shared launcher (`../scripts/launch.js --no-install agent-hook`)
 //     when this file lives in the repo's plugin bundle, or — for a standalone single-file install
@@ -35,7 +35,7 @@ const BUNDLED_LAUNCHER = path.join(PLUGIN_DIR, "..", "scripts", "launch.js");
 
 // Single source of truth for the version: the pinned npm package (kept in lockstep with the
 // release by tools/sync-plugin-version.mjs — do not hand-edit the pin).
-const MCP_PACKAGE = "@rag-rat/bin@0.21.0";
+const MCP_PACKAGE = "@rag-rat/bin@0.21.1";
 const VERSION = MCP_PACKAGE.split("@").pop()!;
 
 const TOOL_TIMEOUT_MS = 10_000;

--- a/plugin/skills/init-rag-rat/SKILL.md
+++ b/plugin/skills/init-rag-rat/SKILL.md
@@ -32,7 +32,7 @@ hand-write a config blind, and let a real config load re-check it before indexin
    do **not** use `@latest`, and **don't blindly trust an on-`PATH` `rag-rat`**:
    - If `rag-rat` is on `PATH`, check `rag-rat --version` and use it **only if it matches** the
      plugin/MCP version — a stale global install would build the index with the wrong binary.
-   - Otherwise (or on a version mismatch) use `npx -y @rag-rat/bin@0.21.0 …` — the plugin pins
+   - Otherwise (or on a version mismatch) use `npx -y @rag-rat/bin@0.21.1 …` — the plugin pins
      `@rag-rat/bin` to its own version and caches the binary privately, so this is the
      version-matched CLI; `npx` runs it in the current directory.
 


### PR DESCRIPTION



## 🤖 New release

* `rag-rat-base`: 0.21.0 -> 0.21.1 (✓ API compatible changes)
* `rag-rat-db`: 0.21.0 -> 0.21.1
* `rag-rat-clones`: 0.21.0 -> 0.21.1
* `rag-rat-llm`: 0.21.0 -> 0.21.1
* `rag-rat-papertrail`: 0.21.0 -> 0.21.1
* `rag-rat-query`: 0.21.0 -> 0.21.1
* `rag-rat-dream`: 0.21.0 -> 0.21.1
* `rag-rat-oplog`: 0.21.0 -> 0.21.1 (✓ API compatible changes)
* `rag-rat-oracle`: 0.21.0 -> 0.21.1
* `rag-rat-core`: 0.21.0 -> 0.21.1 (✓ API compatible changes)
* `rag-rat-mcp`: 0.21.0 -> 0.21.1 (✓ API compatible changes)
* `rag-rat`: 0.21.0 -> 0.21.1
* `rag-rat-sync`: 0.21.0 -> 0.21.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `rag-rat-base`

<blockquote>

## [0.21.1](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.21.0...rag-rat-base-v0.21.1) - 2026-07-24

### Other

- *(index)* return freed heap to the OS at heavy-pass terminals ([#910](https://github.com/cq27-dev/rag-rat/pull/910))
</blockquote>

## `rag-rat-db`

<blockquote>

## [0.21.1](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.21.0...rag-rat-base-v0.21.1) - 2026-07-24

### Other

- *(index)* return freed heap to the OS at heavy-pass terminals ([#910](https://github.com/cq27-dev/rag-rat/pull/910))
</blockquote>

## `rag-rat-clones`

<blockquote>

## [0.21.1](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.21.0...rag-rat-base-v0.21.1) - 2026-07-24

### Other

- *(index)* return freed heap to the OS at heavy-pass terminals ([#910](https://github.com/cq27-dev/rag-rat/pull/910))
</blockquote>

## `rag-rat-llm`

<blockquote>

## [0.21.1](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.21.0...rag-rat-base-v0.21.1) - 2026-07-24

### Other

- *(index)* return freed heap to the OS at heavy-pass terminals ([#910](https://github.com/cq27-dev/rag-rat/pull/910))
</blockquote>

## `rag-rat-papertrail`

<blockquote>

## [0.21.1](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.21.0...rag-rat-base-v0.21.1) - 2026-07-24

### Other

- *(index)* return freed heap to the OS at heavy-pass terminals ([#910](https://github.com/cq27-dev/rag-rat/pull/910))
</blockquote>

## `rag-rat-query`

<blockquote>

## [0.21.1](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.21.0...rag-rat-base-v0.21.1) - 2026-07-24

### Other

- *(index)* return freed heap to the OS at heavy-pass terminals ([#910](https://github.com/cq27-dev/rag-rat/pull/910))
</blockquote>

## `rag-rat-dream`

<blockquote>

## [0.21.1](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.21.0...rag-rat-base-v0.21.1) - 2026-07-24

### Other

- *(index)* return freed heap to the OS at heavy-pass terminals ([#910](https://github.com/cq27-dev/rag-rat/pull/910))
</blockquote>

## `rag-rat-oplog`

<blockquote>

## [0.21.1](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.21.0...rag-rat-base-v0.21.1) - 2026-07-24

### Other

- *(index)* return freed heap to the OS at heavy-pass terminals ([#910](https://github.com/cq27-dev/rag-rat/pull/910))
</blockquote>

## `rag-rat-oracle`

<blockquote>

## [0.21.1](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.21.0...rag-rat-base-v0.21.1) - 2026-07-24

### Other

- *(index)* return freed heap to the OS at heavy-pass terminals ([#910](https://github.com/cq27-dev/rag-rat/pull/910))
</blockquote>

## `rag-rat-core`

<blockquote>

## [0.21.1](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.21.0...rag-rat-base-v0.21.1) - 2026-07-24

### Other

- *(index)* return freed heap to the OS at heavy-pass terminals ([#910](https://github.com/cq27-dev/rag-rat/pull/910))
</blockquote>

## `rag-rat-mcp`

<blockquote>

## [0.21.1](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.21.0...rag-rat-base-v0.21.1) - 2026-07-24

### Other

- *(index)* return freed heap to the OS at heavy-pass terminals ([#910](https://github.com/cq27-dev/rag-rat/pull/910))
</blockquote>

## `rag-rat`

<blockquote>

## [0.21.1](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.21.0...rag-rat-base-v0.21.1) - 2026-07-24

### Other

- *(index)* return freed heap to the OS at heavy-pass terminals ([#910](https://github.com/cq27-dev/rag-rat/pull/910))
</blockquote>

## `rag-rat-sync`

<blockquote>

## [0.21.1](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.21.0...rag-rat-base-v0.21.1) - 2026-07-24

### Other

- *(index)* return freed heap to the OS at heavy-pass terminals ([#910](https://github.com/cq27-dev/rag-rat/pull/910))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).