### PR TITLE
chore: release v0.22.0

### DIFF
--- a/.agents/skills/init-rag-rat/SKILL.md
+++ b/.agents/skills/init-rag-rat/SKILL.md
@@ -32,7 +32,7 @@ hand-write a config blind, and let a real config load re-check it before indexin
    do **not** use `@latest`, and **don't blindly trust an on-`PATH` `rag-rat`**:
    - If `rag-rat` is on `PATH`, check `rag-rat --version` and use it **only if it matches** the
      plugin/MCP version — a stale global install would build the index with the wrong binary.
-   - Otherwise (or on a version mismatch) use `npx -y @rag-rat/bin@0.21.1 …` — the plugin pins
+   - Otherwise (or on a version mismatch) use `npx -y @rag-rat/bin@0.22.0 …` — the plugin pins
      `@rag-rat/bin` to its own version and caches the binary privately, so this is the
      version-matched CLI; `npx` runs it in the current directory.
 

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "rag-rat",
       "description": "Local repo-intelligence index + MCP server: semantic search, symbol/graph navigation, impact-surface preflight, git + GitHub papertrail, and a source-anchored memory graph.",
-      "version": "0.21.1",
+      "version": "0.22.0",
       "source": "./plugin",
       "category": "developer-tools",
       "license": "MIT",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.22.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.21.1...rag-rat-base-v0.22.0) - 2026-07-28
+## [0.22.0](https://github.com/cq27-dev/rag-rat/compare/v0.21.1...v0.22.0) - 2026-07-28
 
 ### Added
 
-- *(oracle)* live LSP watcher wiring — phase 6 slice 2 ([#534](https://github.com/cq27-dev/rag-rat/pull/534)) ([#972](https://github.com/cq27-dev/rag-rat/pull/972))
+- *(oracle)* live `rust-analyzer` resolution for changed Rust call edges in watch mode ([#534](https://github.com/cq27-dev/rag-rat/pull/534)) ([#972](https://github.com/cq27-dev/rag-rat/pull/972))
 - *(sync)* device-side account-log sync to configured server peers ([#922](https://github.com/cq27-dev/rag-rat/pull/922))
 - *(sync)* [sync] config + `rag-rat sync serve` headless peer ([#909](https://github.com/cq27-dev/rag-rat/pull/909))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.21.1...rag-rat-base-v0.22.0) - 2026-07-28
+
+### Added
+
+- *(oracle)* live LSP watcher wiring — phase 6 slice 2 ([#534](https://github.com/cq27-dev/rag-rat/pull/534)) ([#972](https://github.com/cq27-dev/rag-rat/pull/972))
+- *(sync)* device-side account-log sync to configured server peers ([#922](https://github.com/cq27-dev/rag-rat/pull/922))
+- *(sync)* [sync] config + `rag-rat sync serve` headless peer ([#909](https://github.com/cq27-dev/rag-rat/pull/909))
+
+### Fixed
+
+- *(tests)* isolate fixture git invocations from the ambient environment ([#975](https://github.com/cq27-dev/rag-rat/pull/975))
+- *(tests)* retain satellite-crate scratch cleanup guards ([#973](https://github.com/cq27-dev/rag-rat/pull/973))
+- *(tests)* retain core unit-test scratch cleanup guards ([#968](https://github.com/cq27-dev/rag-rat/pull/968))
+- *(tests)* retain config scratch cleanup guards ([#967](https://github.com/cq27-dev/rag-rat/pull/967))
+- *(tests)* clean high-volume scratch fixtures ([#963](https://github.com/cq27-dev/rag-rat/pull/963))
+
+### Other
+
+- *(deps)* upgrade Rust dependencies ([#933](https://github.com/cq27-dev/rag-rat/pull/933))
+
 ## [0.21.1](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.21.0...rag-rat-base-v0.21.1) - 2026-07-24
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4859,7 +4859,7 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rag-rat"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -4896,7 +4896,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-base"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "filetime",
@@ -4920,7 +4920,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-clones"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "rag-rat-base",
@@ -4936,7 +4936,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-core"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "chacha20poly1305",
@@ -5001,7 +5001,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-db"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "rag-rat-base",
@@ -5015,7 +5015,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-dream"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "rag-rat-base",
@@ -5034,7 +5034,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-llm"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "fastembed",
@@ -5055,7 +5055,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-mcp"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "libc",
@@ -5077,7 +5077,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-oplog"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "chacha20poly1305",
@@ -5099,7 +5099,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-oracle"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "path-slash",
@@ -5119,7 +5119,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-papertrail"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -5139,7 +5139,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-query"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "minicbor",
@@ -5158,7 +5158,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-sync"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "getrandom 0.4.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ resolver = "3"
 # and the internal path deps below pin the same literal, so the three crates always publish in
 # lockstep. Bump this one line (and the two internal-dep `version`s under workspace.dependencies)
 # to release.
-version = "0.21.1"
+version = "0.22.0"
 authors = ["Kristaps Karlsons"]
 edition = "2024"
 # Bundled SQLite (rusqlite `bundled` -> libsqlite3-sys 0.38.1) compiles a build script that uses the
@@ -38,18 +38,18 @@ categories = ["command-line-utilities", "development-tools"]
 # Internal crates — declared once here so the version requirement is set in lockstep with
 # [workspace.package].version above. Members reference these via `{ workspace = true }` and add
 # their own feature toggles at the use site.
-rag-rat-base = { version = "0.21.1", path = "crates/rag-rat-base", default-features = false }
-rag-rat-clones = { version = "0.21.1", path = "crates/rag-rat-clones", default-features = false }
-rag-rat-db = { version = "0.21.1", path = "crates/rag-rat-db", default-features = false }
-rag-rat-dream = { version = "0.21.1", path = "crates/rag-rat-dream", default-features = false }
-rag-rat-llm = { version = "0.21.1", path = "crates/rag-rat-llm", default-features = false }
-rag-rat-oracle = { version = "0.21.1", path = "crates/rag-rat-oracle", default-features = false }
-rag-rat-oplog = { version = "0.21.1", path = "crates/rag-rat-oplog", default-features = false }
-rag-rat-papertrail = { version = "0.21.1", path = "crates/rag-rat-papertrail", default-features = false }
-rag-rat-query = { version = "0.21.1", path = "crates/rag-rat-query", default-features = false }
-rag-rat-core = { version = "0.21.1", path = "crates/rag-rat-core", default-features = false }
-rag-rat-mcp = { version = "0.21.1", path = "crates/rag-rat-mcp", default-features = false }
-rag-rat-sync = { version = "0.21.1", path = "crates/rag-rat-sync", default-features = false }
+rag-rat-base = { version = "0.22.0", path = "crates/rag-rat-base", default-features = false }
+rag-rat-clones = { version = "0.22.0", path = "crates/rag-rat-clones", default-features = false }
+rag-rat-db = { version = "0.22.0", path = "crates/rag-rat-db", default-features = false }
+rag-rat-dream = { version = "0.22.0", path = "crates/rag-rat-dream", default-features = false }
+rag-rat-llm = { version = "0.22.0", path = "crates/rag-rat-llm", default-features = false }
+rag-rat-oracle = { version = "0.22.0", path = "crates/rag-rat-oracle", default-features = false }
+rag-rat-oplog = { version = "0.22.0", path = "crates/rag-rat-oplog", default-features = false }
+rag-rat-papertrail = { version = "0.22.0", path = "crates/rag-rat-papertrail", default-features = false }
+rag-rat-query = { version = "0.22.0", path = "crates/rag-rat-query", default-features = false }
+rag-rat-core = { version = "0.22.0", path = "crates/rag-rat-core", default-features = false }
+rag-rat-mcp = { version = "0.22.0", path = "crates/rag-rat-mcp", default-features = false }
+rag-rat-sync = { version = "0.22.0", path = "crates/rag-rat-sync", default-features = false }
 anyhow = "1.0"
 # ed25519 device-identity signing for the op-log's signed entry envelope (§C4 layer-1). Default
 # features (incl. `zeroize`, which zeroizes a `SigningKey`'s seed on drop) are kept; the `rand_core`

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "rag-rat",
   "displayName": "rag-rat",
   "description": "Local repo-intelligence index + MCP server: semantic search, symbol/graph navigation, impact-surface preflight, git + GitHub papertrail, and a source-anchored memory graph.",
-  "version": "0.21.1",
+  "version": "0.22.0",
   "author": { "name": "Kristaps Karlsons" },
   "homepage": "https://github.com/cq27-dev/rag-rat",
   "repository": "https://github.com/cq27-dev/rag-rat",
@@ -11,7 +11,7 @@
   "mcpServers": {
     "rag-rat": {
       "command": "npx",
-      "args": ["-y", "@rag-rat/bin@0.21.1", "mcp"]
+      "args": ["-y", "@rag-rat/bin@0.22.0", "mcp"]
     }
   }
 }

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rag-rat",
-  "version": "0.21.1",
+  "version": "0.22.0",
   "description": "Local repo-intelligence index + MCP server: semantic search, symbol/graph navigation, impact-surface preflight, git + GitHub papertrail, and a source-anchored memory graph.",
   "author": { "name": "Kristaps Karlsons", "url": "https://github.com/cq27-dev/rag-rat" },
   "homepage": "https://github.com/cq27-dev/rag-rat",

--- a/plugin/.mcp.json
+++ b/plugin/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "rag-rat": {
       "command": "npx",
-      "args": ["-y", "@rag-rat/bin@0.21.1", "mcp"]
+      "args": ["-y", "@rag-rat/bin@0.22.0", "mcp"]
     }
   }
 }

--- a/plugin/opencode/package.json
+++ b/plugin/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rag-rat/plugin-opencode",
-  "version": "0.21.1",
+  "version": "0.22.0",
   "description": "opencode plugin for rag-rat: self-registers the rag-rat MCP server (semantic search, symbol/graph navigation, impact-surface preflight, repo memory) and wires session/grep/edit hooks through the shared agent-hook.",
   "license": "MIT",
   "type": "module",

--- a/plugin/opencode/rag-rat.ts
+++ b/plugin/opencode/rag-rat.ts
@@ -3,7 +3,7 @@
 // opencode's plugin shape differs from Claude Code / Codex (no hooks.json manifest, no
 // additionalContext channel on tool.execute.before), so this module is a thin shim over the same
 // shared pieces the other harnesses use:
-//   - MCP: registered via the `config` hook as `npx -y @rag-rat/bin@0.21.1<version> mcp` (pinned; kept
+//   - MCP: registered via the `config` hook as `npx -y @rag-rat/bin@0.22.0<version> mcp` (pinned; kept
 //     in lockstep with the release by tools/sync-plugin-version.mjs).
 //   - Hooks: routed through the shared launcher (`../scripts/launch.js --no-install agent-hook`)
 //     when this file lives in the repo's plugin bundle, or — for a standalone single-file install
@@ -35,7 +35,7 @@ const BUNDLED_LAUNCHER = path.join(PLUGIN_DIR, "..", "scripts", "launch.js");
 
 // Single source of truth for the version: the pinned npm package (kept in lockstep with the
 // release by tools/sync-plugin-version.mjs — do not hand-edit the pin).
-const MCP_PACKAGE = "@rag-rat/bin@0.21.1";
+const MCP_PACKAGE = "@rag-rat/bin@0.22.0";
 const VERSION = MCP_PACKAGE.split("@").pop()!;
 
 const TOOL_TIMEOUT_MS = 10_000;

--- a/plugin/skills/init-rag-rat/SKILL.md
+++ b/plugin/skills/init-rag-rat/SKILL.md
@@ -32,7 +32,7 @@ hand-write a config blind, and let a real config load re-check it before indexin
    do **not** use `@latest`, and **don't blindly trust an on-`PATH` `rag-rat`**:
    - If `rag-rat` is on `PATH`, check `rag-rat --version` and use it **only if it matches** the
      plugin/MCP version — a stale global install would build the index with the wrong binary.
-   - Otherwise (or on a version mismatch) use `npx -y @rag-rat/bin@0.21.1 …` — the plugin pins
+   - Otherwise (or on a version mismatch) use `npx -y @rag-rat/bin@0.22.0 …` — the plugin pins
      `@rag-rat/bin` to its own version and caches the binary privately, so this is the
      version-matched CLI; `npx` runs it in the current directory.
 

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.cq27-dev/rag-rat",
   "title": "rag-rat",
   "description": "Repository intelligence, code graph, history, papertrail, and cross-agent memory for coding agents.",
-  "version": "0.21.1",
+  "version": "0.22.0",
   "websiteUrl": "https://rag-rat.cq27.dev/",
   "repository": {
     "url": "https://github.com/cq27-dev/rag-rat",
@@ -13,7 +13,7 @@
     {
       "registryType": "npm",
       "identifier": "@rag-rat/bin",
-      "version": "0.21.1",
+      "version": "0.22.0",
       "runtimeHint": "npx",
       "runtimeArguments": [
         {

--- a/tools/sync-plugin-version.mjs
+++ b/tools/sync-plugin-version.mjs
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
-// Sync the plugin manifests' version to the workspace crate version.
+// Sync non-Cargo manifests' versions to the workspace crate version.
 //
 // release-plz bumps only Cargo.toml ([workspace.package].version) — it has no support for non-Cargo
-// files. The plugin launcher fetches releases/download/v<plugin-version>, so the manifests MUST match
-// the released crate version or it downloads the wrong release. `.github/workflows/release-plz.yml`
-// runs this on the Release PR branch so the manifest bump rides in the same PR that cuts the tag.
+// files. The plugin launcher and MCP Registry metadata MUST match the released crate version or they
+// point at the wrong release. `.github/workflows/release-plz.yml` runs this on the Release PR branch
+// so the manifest bumps ride in the same PR that cuts the tag.
 //
 // Idempotent; run from the repo root. Exits non-zero only on a structural mismatch (so a cargo-dist /
 // release-plz change that moves the version can't silently ship a stale manifest).
@@ -32,18 +32,22 @@ function fail(msg) {
 const VERSION = workspaceVersion();
 let changed = 0;
 
-// 1) The manifests' `"version"` field — each has exactly one; rewrite it surgically to preserve
-// formatting.
+// 1) Manifest `"version"` fields. Most have one; server.json has both server and package versions.
+// Require the exact count so a schema change cannot silently leave one stale.
 const VERSION_FILES = [
-  ".claude-plugin/marketplace.json",
-  "plugin/.claude-plugin/plugin.json",
-  "plugin/.codex-plugin/plugin.json",
-  "plugin/opencode/package.json",
+  [".claude-plugin/marketplace.json", 1],
+  ["plugin/.claude-plugin/plugin.json", 1],
+  ["plugin/.codex-plugin/plugin.json", 1],
+  ["plugin/opencode/package.json", 1],
+  ["server.json", 2],
 ];
-const versionRe = /("version"\s*:\s*)"[^"]*"/;
-for (const file of VERSION_FILES) {
+const versionRe = /("version"\s*:\s*)"[^"]*"/g;
+for (const [file, expectedFields] of VERSION_FILES) {
   const src = readFileSync(file, "utf8");
-  if (!versionRe.test(src)) fail(`no "version" field in ${file}`);
+  const fields = src.match(versionRe)?.length ?? 0;
+  if (fields !== expectedFields) {
+    fail(`expected ${expectedFields} "version" field(s) in ${file}, found ${fields}`);
+  }
   const out = src.replace(versionRe, `$1"${VERSION}"`);
   if (out !== src) {
     writeFileSync(file, out);


### PR DESCRIPTION



## 🤖 New release

* `rag-rat-base`: 0.21.1 -> 0.22.0 (⚠ API breaking changes)
* `rag-rat-db`: 0.21.1 -> 0.22.0 (✓ API compatible changes)
* `rag-rat-clones`: 0.21.1 -> 0.22.0 (✓ API compatible changes)
* `rag-rat-llm`: 0.21.1 -> 0.22.0 (✓ API compatible changes)
* `rag-rat-papertrail`: 0.21.1 -> 0.22.0 (✓ API compatible changes)
* `rag-rat-query`: 0.21.1 -> 0.22.0 (✓ API compatible changes)
* `rag-rat-dream`: 0.21.1 -> 0.22.0 (✓ API compatible changes)
* `rag-rat-oplog`: 0.21.1 -> 0.22.0 (⚠ API breaking changes)
* `rag-rat-oracle`: 0.21.1 -> 0.22.0 (⚠ API breaking changes)
* `rag-rat-core`: 0.21.1 -> 0.22.0 (⚠ API breaking changes)
* `rag-rat-mcp`: 0.21.1 -> 0.22.0 (✓ API compatible changes)
* `rag-rat-sync`: 0.21.1 -> 0.22.0 (⚠ API breaking changes)
* `rag-rat`: 0.21.1 -> 0.22.0

### ⚠ `rag-rat-base` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field OracleConfig.live in /tmp/.tmp0N09vB/rag-rat/crates/rag-rat-base/src/config/types.rs:212
  field Config.sync in /tmp/.tmp0N09vB/rag-rat/crates/rag-rat-base/src/config/types.rs:27

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_added.ron

Failed in:
  variant ConfigError:OracleLiveRequestBudgetZero in /tmp/.tmp0N09vB/rag-rat/crates/rag-rat-base/src/config/mod.rs:181
```

### ⚠ `rag-rat-oplog` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field RosterContentAuthority.role in /tmp/.tmp0N09vB/rag-rat/crates/rag-rat-oplog/src/account/fold.rs:283

--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant DeviceRole::Member 0 -> 1 in /tmp/.tmp0N09vB/rag-rat/crates/rag-rat-oplog/src/account/ops.rs:57
  variant DeviceRole::Owner 1 -> 2 in /tmp/.tmp0N09vB/rag-rat/crates/rag-rat-oplog/src/account/ops.rs:58

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_added.ron

Failed in:
  variant DeviceRole:ReadOnly in /tmp/.tmp0N09vB/rag-rat/crates/rag-rat-oplog/src/account/ops.rs:56

--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/function_parameter_count_changed.ron

Failed in:
  rag_rat_oplog::settle_pending_content_refold_for_stream_in_tx now takes 3 parameters instead of 2, in /tmp/.tmp0N09vB/rag-rat/crates/rag-rat-oplog/src/account/content/storage.rs:1586
  rag_rat_oplog::settle_pending_content_refolds now takes 3 parameters instead of 2, in /tmp/.tmp0N09vB/rag-rat/crates/rag-rat-oplog/src/account/content/storage.rs:1459
```

### ⚠ `rag-rat-oracle` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_added.ron

Failed in:
  variant OracleTool:RaLsp in /tmp/.tmp0N09vB/rag-rat/crates/rag-rat-oracle/src/lib.rs:727
```

### ⚠ `rag-rat-core` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_added.ron

Failed in:
  variant OverlayScope:Paths in /tmp/.tmp0N09vB/rag-rat/crates/rag-rat-core/src/watch/overlay.rs:43
```

### ⚠ `rag-rat-sync` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_added.ron

Failed in:
  variant EndpointError:PeerId in /tmp/.tmp0N09vB/rag-rat/crates/rag-rat-sync/src/endpoint.rs:53
  variant EndpointError:PeerId in /tmp/.tmp0N09vB/rag-rat/crates/rag-rat-sync/src/endpoint.rs:53
  variant SyncFailure:Enrollment in /tmp/.tmp0N09vB/rag-rat/crates/rag-rat-sync/src/endpoint.rs:517
  variant SyncFailure:Enrollment in /tmp/.tmp0N09vB/rag-rat/crates/rag-rat-sync/src/endpoint.rs:517
  variant Frame:Ack in /tmp/.tmp0N09vB/rag-rat/crates/rag-rat-sync/src/wire.rs:76
  variant Frame:Ack in /tmp/.tmp0N09vB/rag-rat/crates/rag-rat-sync/src/wire.rs:76

--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/function_parameter_count_changed.ron

Failed in:
  rag_rat_sync::session::run_session now takes 4 parameters instead of 3, in /tmp/.tmp0N09vB/rag-rat/crates/rag-rat-sync/src/session.rs:119
  rag_rat_sync::run_session now takes 4 parameters instead of 3, in /tmp/.tmp0N09vB/rag-rat/crates/rag-rat-sync/src/session.rs:119
  rag_rat_sync::endpoint::connect_and_sync now takes 6 parameters instead of 5, in /tmp/.tmp0N09vB/rag-rat/crates/rag-rat-sync/src/endpoint.rs:276
  rag_rat_sync::connect_and_sync now takes 6 parameters instead of 5, in /tmp/.tmp0N09vB/rag-rat/crates/rag-rat-sync/src/endpoint.rs:276
  rag_rat_sync::session::run_session_with_idle_timeout now takes 5 parameters instead of 4, in /tmp/.tmp0N09vB/rag-rat/crates/rag-rat-sync/src/session.rs:135
  rag_rat_sync::run_session_with_idle_timeout now takes 5 parameters instead of 4, in /tmp/.tmp0N09vB/rag-rat/crates/rag-rat-sync/src/session.rs:135
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `rag-rat-base`

<blockquote>

## [0.22.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.21.1...rag-rat-base-v0.22.0) - 2026-07-28

### Added

- *(oracle)* live LSP watcher wiring — phase 6 slice 2 ([#534](https://github.com/cq27-dev/rag-rat/pull/534)) ([#972](https://github.com/cq27-dev/rag-rat/pull/972))
- *(sync)* device-side account-log sync to configured server peers ([#922](https://github.com/cq27-dev/rag-rat/pull/922))
- *(sync)* [sync] config + `rag-rat sync serve` headless peer ([#909](https://github.com/cq27-dev/rag-rat/pull/909))

### Fixed

- *(tests)* isolate fixture git invocations from the ambient environment ([#975](https://github.com/cq27-dev/rag-rat/pull/975))
- *(tests)* retain satellite-crate scratch cleanup guards ([#973](https://github.com/cq27-dev/rag-rat/pull/973))
- *(tests)* retain core unit-test scratch cleanup guards ([#968](https://github.com/cq27-dev/rag-rat/pull/968))
- *(tests)* retain config scratch cleanup guards ([#967](https://github.com/cq27-dev/rag-rat/pull/967))
- *(tests)* clean high-volume scratch fixtures ([#963](https://github.com/cq27-dev/rag-rat/pull/963))

### Other

- *(deps)* upgrade Rust dependencies ([#933](https://github.com/cq27-dev/rag-rat/pull/933))
</blockquote>

## `rag-rat-db`

<blockquote>

## [0.22.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.21.1...rag-rat-base-v0.22.0) - 2026-07-28

### Added

- *(oracle)* live LSP watcher wiring — phase 6 slice 2 ([#534](https://github.com/cq27-dev/rag-rat/pull/534)) ([#972](https://github.com/cq27-dev/rag-rat/pull/972))
- *(sync)* device-side account-log sync to configured server peers ([#922](https://github.com/cq27-dev/rag-rat/pull/922))
- *(sync)* [sync] config + `rag-rat sync serve` headless peer ([#909](https://github.com/cq27-dev/rag-rat/pull/909))

### Fixed

- *(tests)* isolate fixture git invocations from the ambient environment ([#975](https://github.com/cq27-dev/rag-rat/pull/975))
- *(tests)* retain satellite-crate scratch cleanup guards ([#973](https://github.com/cq27-dev/rag-rat/pull/973))
- *(tests)* retain core unit-test scratch cleanup guards ([#968](https://github.com/cq27-dev/rag-rat/pull/968))
- *(tests)* retain config scratch cleanup guards ([#967](https://github.com/cq27-dev/rag-rat/pull/967))
- *(tests)* clean high-volume scratch fixtures ([#963](https://github.com/cq27-dev/rag-rat/pull/963))

### Other

- *(deps)* upgrade Rust dependencies ([#933](https://github.com/cq27-dev/rag-rat/pull/933))
</blockquote>

## `rag-rat-clones`

<blockquote>

## [0.22.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.21.1...rag-rat-base-v0.22.0) - 2026-07-28

### Added

- *(oracle)* live LSP watcher wiring — phase 6 slice 2 ([#534](https://github.com/cq27-dev/rag-rat/pull/534)) ([#972](https://github.com/cq27-dev/rag-rat/pull/972))
- *(sync)* device-side account-log sync to configured server peers ([#922](https://github.com/cq27-dev/rag-rat/pull/922))
- *(sync)* [sync] config + `rag-rat sync serve` headless peer ([#909](https://github.com/cq27-dev/rag-rat/pull/909))

### Fixed

- *(tests)* isolate fixture git invocations from the ambient environment ([#975](https://github.com/cq27-dev/rag-rat/pull/975))
- *(tests)* retain satellite-crate scratch cleanup guards ([#973](https://github.com/cq27-dev/rag-rat/pull/973))
- *(tests)* retain core unit-test scratch cleanup guards ([#968](https://github.com/cq27-dev/rag-rat/pull/968))
- *(tests)* retain config scratch cleanup guards ([#967](https://github.com/cq27-dev/rag-rat/pull/967))
- *(tests)* clean high-volume scratch fixtures ([#963](https://github.com/cq27-dev/rag-rat/pull/963))

### Other

- *(deps)* upgrade Rust dependencies ([#933](https://github.com/cq27-dev/rag-rat/pull/933))
</blockquote>

## `rag-rat-llm`

<blockquote>

## [0.22.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.21.1...rag-rat-base-v0.22.0) - 2026-07-28

### Added

- *(oracle)* live LSP watcher wiring — phase 6 slice 2 ([#534](https://github.com/cq27-dev/rag-rat/pull/534)) ([#972](https://github.com/cq27-dev/rag-rat/pull/972))
- *(sync)* device-side account-log sync to configured server peers ([#922](https://github.com/cq27-dev/rag-rat/pull/922))
- *(sync)* [sync] config + `rag-rat sync serve` headless peer ([#909](https://github.com/cq27-dev/rag-rat/pull/909))

### Fixed

- *(tests)* isolate fixture git invocations from the ambient environment ([#975](https://github.com/cq27-dev/rag-rat/pull/975))
- *(tests)* retain satellite-crate scratch cleanup guards ([#973](https://github.com/cq27-dev/rag-rat/pull/973))
- *(tests)* retain core unit-test scratch cleanup guards ([#968](https://github.com/cq27-dev/rag-rat/pull/968))
- *(tests)* retain config scratch cleanup guards ([#967](https://github.com/cq27-dev/rag-rat/pull/967))
- *(tests)* clean high-volume scratch fixtures ([#963](https://github.com/cq27-dev/rag-rat/pull/963))

### Other

- *(deps)* upgrade Rust dependencies ([#933](https://github.com/cq27-dev/rag-rat/pull/933))
</blockquote>

## `rag-rat-papertrail`

<blockquote>

## [0.22.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.21.1...rag-rat-base-v0.22.0) - 2026-07-28

### Added

- *(oracle)* live LSP watcher wiring — phase 6 slice 2 ([#534](https://github.com/cq27-dev/rag-rat/pull/534)) ([#972](https://github.com/cq27-dev/rag-rat/pull/972))
- *(sync)* device-side account-log sync to configured server peers ([#922](https://github.com/cq27-dev/rag-rat/pull/922))
- *(sync)* [sync] config + `rag-rat sync serve` headless peer ([#909](https://github.com/cq27-dev/rag-rat/pull/909))

### Fixed

- *(tests)* isolate fixture git invocations from the ambient environment ([#975](https://github.com/cq27-dev/rag-rat/pull/975))
- *(tests)* retain satellite-crate scratch cleanup guards ([#973](https://github.com/cq27-dev/rag-rat/pull/973))
- *(tests)* retain core unit-test scratch cleanup guards ([#968](https://github.com/cq27-dev/rag-rat/pull/968))
- *(tests)* retain config scratch cleanup guards ([#967](https://github.com/cq27-dev/rag-rat/pull/967))
- *(tests)* clean high-volume scratch fixtures ([#963](https://github.com/cq27-dev/rag-rat/pull/963))

### Other

- *(deps)* upgrade Rust dependencies ([#933](https://github.com/cq27-dev/rag-rat/pull/933))
</blockquote>

## `rag-rat-query`

<blockquote>

## [0.22.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.21.1...rag-rat-base-v0.22.0) - 2026-07-28

### Added

- *(oracle)* live LSP watcher wiring — phase 6 slice 2 ([#534](https://github.com/cq27-dev/rag-rat/pull/534)) ([#972](https://github.com/cq27-dev/rag-rat/pull/972))
- *(sync)* device-side account-log sync to configured server peers ([#922](https://github.com/cq27-dev/rag-rat/pull/922))
- *(sync)* [sync] config + `rag-rat sync serve` headless peer ([#909](https://github.com/cq27-dev/rag-rat/pull/909))

### Fixed

- *(tests)* isolate fixture git invocations from the ambient environment ([#975](https://github.com/cq27-dev/rag-rat/pull/975))
- *(tests)* retain satellite-crate scratch cleanup guards ([#973](https://github.com/cq27-dev/rag-rat/pull/973))
- *(tests)* retain core unit-test scratch cleanup guards ([#968](https://github.com/cq27-dev/rag-rat/pull/968))
- *(tests)* retain config scratch cleanup guards ([#967](https://github.com/cq27-dev/rag-rat/pull/967))
- *(tests)* clean high-volume scratch fixtures ([#963](https://github.com/cq27-dev/rag-rat/pull/963))

### Other

- *(deps)* upgrade Rust dependencies ([#933](https://github.com/cq27-dev/rag-rat/pull/933))
</blockquote>

## `rag-rat-dream`

<blockquote>

## [0.22.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.21.1...rag-rat-base-v0.22.0) - 2026-07-28

### Added

- *(oracle)* live LSP watcher wiring — phase 6 slice 2 ([#534](https://github.com/cq27-dev/rag-rat/pull/534)) ([#972](https://github.com/cq27-dev/rag-rat/pull/972))
- *(sync)* device-side account-log sync to configured server peers ([#922](https://github.com/cq27-dev/rag-rat/pull/922))
- *(sync)* [sync] config + `rag-rat sync serve` headless peer ([#909](https://github.com/cq27-dev/rag-rat/pull/909))

### Fixed

- *(tests)* isolate fixture git invocations from the ambient environment ([#975](https://github.com/cq27-dev/rag-rat/pull/975))
- *(tests)* retain satellite-crate scratch cleanup guards ([#973](https://github.com/cq27-dev/rag-rat/pull/973))
- *(tests)* retain core unit-test scratch cleanup guards ([#968](https://github.com/cq27-dev/rag-rat/pull/968))
- *(tests)* retain config scratch cleanup guards ([#967](https://github.com/cq27-dev/rag-rat/pull/967))
- *(tests)* clean high-volume scratch fixtures ([#963](https://github.com/cq27-dev/rag-rat/pull/963))

### Other

- *(deps)* upgrade Rust dependencies ([#933](https://github.com/cq27-dev/rag-rat/pull/933))
</blockquote>

## `rag-rat-oplog`

<blockquote>

## [0.22.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.21.1...rag-rat-base-v0.22.0) - 2026-07-28

### Added

- *(oracle)* live LSP watcher wiring — phase 6 slice 2 ([#534](https://github.com/cq27-dev/rag-rat/pull/534)) ([#972](https://github.com/cq27-dev/rag-rat/pull/972))
- *(sync)* device-side account-log sync to configured server peers ([#922](https://github.com/cq27-dev/rag-rat/pull/922))
- *(sync)* [sync] config + `rag-rat sync serve` headless peer ([#909](https://github.com/cq27-dev/rag-rat/pull/909))

### Fixed

- *(tests)* isolate fixture git invocations from the ambient environment ([#975](https://github.com/cq27-dev/rag-rat/pull/975))
- *(tests)* retain satellite-crate scratch cleanup guards ([#973](https://github.com/cq27-dev/rag-rat/pull/973))
- *(tests)* retain core unit-test scratch cleanup guards ([#968](https://github.com/cq27-dev/rag-rat/pull/968))
- *(tests)* retain config scratch cleanup guards ([#967](https://github.com/cq27-dev/rag-rat/pull/967))
- *(tests)* clean high-volume scratch fixtures ([#963](https://github.com/cq27-dev/rag-rat/pull/963))

### Other

- *(deps)* upgrade Rust dependencies ([#933](https://github.com/cq27-dev/rag-rat/pull/933))
</blockquote>

## `rag-rat-oracle`

<blockquote>

## [0.22.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.21.1...rag-rat-base-v0.22.0) - 2026-07-28

### Added

- *(oracle)* live LSP watcher wiring — phase 6 slice 2 ([#534](https://github.com/cq27-dev/rag-rat/pull/534)) ([#972](https://github.com/cq27-dev/rag-rat/pull/972))
- *(sync)* device-side account-log sync to configured server peers ([#922](https://github.com/cq27-dev/rag-rat/pull/922))
- *(sync)* [sync] config + `rag-rat sync serve` headless peer ([#909](https://github.com/cq27-dev/rag-rat/pull/909))

### Fixed

- *(tests)* isolate fixture git invocations from the ambient environment ([#975](https://github.com/cq27-dev/rag-rat/pull/975))
- *(tests)* retain satellite-crate scratch cleanup guards ([#973](https://github.com/cq27-dev/rag-rat/pull/973))
- *(tests)* retain core unit-test scratch cleanup guards ([#968](https://github.com/cq27-dev/rag-rat/pull/968))
- *(tests)* retain config scratch cleanup guards ([#967](https://github.com/cq27-dev/rag-rat/pull/967))
- *(tests)* clean high-volume scratch fixtures ([#963](https://github.com/cq27-dev/rag-rat/pull/963))

### Other

- *(deps)* upgrade Rust dependencies ([#933](https://github.com/cq27-dev/rag-rat/pull/933))
</blockquote>

## `rag-rat-core`

<blockquote>

## [0.22.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.21.1...rag-rat-base-v0.22.0) - 2026-07-28

### Added

- *(oracle)* live LSP watcher wiring — phase 6 slice 2 ([#534](https://github.com/cq27-dev/rag-rat/pull/534)) ([#972](https://github.com/cq27-dev/rag-rat/pull/972))
- *(sync)* device-side account-log sync to configured server peers ([#922](https://github.com/cq27-dev/rag-rat/pull/922))
- *(sync)* [sync] config + `rag-rat sync serve` headless peer ([#909](https://github.com/cq27-dev/rag-rat/pull/909))

### Fixed

- *(tests)* isolate fixture git invocations from the ambient environment ([#975](https://github.com/cq27-dev/rag-rat/pull/975))
- *(tests)* retain satellite-crate scratch cleanup guards ([#973](https://github.com/cq27-dev/rag-rat/pull/973))
- *(tests)* retain core unit-test scratch cleanup guards ([#968](https://github.com/cq27-dev/rag-rat/pull/968))
- *(tests)* retain config scratch cleanup guards ([#967](https://github.com/cq27-dev/rag-rat/pull/967))
- *(tests)* clean high-volume scratch fixtures ([#963](https://github.com/cq27-dev/rag-rat/pull/963))

### Other

- *(deps)* upgrade Rust dependencies ([#933](https://github.com/cq27-dev/rag-rat/pull/933))
</blockquote>

## `rag-rat-mcp`

<blockquote>

## [0.22.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.21.1...rag-rat-base-v0.22.0) - 2026-07-28

### Added

- *(oracle)* live LSP watcher wiring — phase 6 slice 2 ([#534](https://github.com/cq27-dev/rag-rat/pull/534)) ([#972](https://github.com/cq27-dev/rag-rat/pull/972))
- *(sync)* device-side account-log sync to configured server peers ([#922](https://github.com/cq27-dev/rag-rat/pull/922))
- *(sync)* [sync] config + `rag-rat sync serve` headless peer ([#909](https://github.com/cq27-dev/rag-rat/pull/909))

### Fixed

- *(tests)* isolate fixture git invocations from the ambient environment ([#975](https://github.com/cq27-dev/rag-rat/pull/975))
- *(tests)* retain satellite-crate scratch cleanup guards ([#973](https://github.com/cq27-dev/rag-rat/pull/973))
- *(tests)* retain core unit-test scratch cleanup guards ([#968](https://github.com/cq27-dev/rag-rat/pull/968))
- *(tests)* retain config scratch cleanup guards ([#967](https://github.com/cq27-dev/rag-rat/pull/967))
- *(tests)* clean high-volume scratch fixtures ([#963](https://github.com/cq27-dev/rag-rat/pull/963))

### Other

- *(deps)* upgrade Rust dependencies ([#933](https://github.com/cq27-dev/rag-rat/pull/933))
</blockquote>

## `rag-rat-sync`

<blockquote>

## [0.22.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.21.1...rag-rat-base-v0.22.0) - 2026-07-28

### Added

- *(oracle)* live LSP watcher wiring — phase 6 slice 2 ([#534](https://github.com/cq27-dev/rag-rat/pull/534)) ([#972](https://github.com/cq27-dev/rag-rat/pull/972))
- *(sync)* device-side account-log sync to configured server peers ([#922](https://github.com/cq27-dev/rag-rat/pull/922))
- *(sync)* [sync] config + `rag-rat sync serve` headless peer ([#909](https://github.com/cq27-dev/rag-rat/pull/909))

### Fixed

- *(tests)* isolate fixture git invocations from the ambient environment ([#975](https://github.com/cq27-dev/rag-rat/pull/975))
- *(tests)* retain satellite-crate scratch cleanup guards ([#973](https://github.com/cq27-dev/rag-rat/pull/973))
- *(tests)* retain core unit-test scratch cleanup guards ([#968](https://github.com/cq27-dev/rag-rat/pull/968))
- *(tests)* retain config scratch cleanup guards ([#967](https://github.com/cq27-dev/rag-rat/pull/967))
- *(tests)* clean high-volume scratch fixtures ([#963](https://github.com/cq27-dev/rag-rat/pull/963))

### Other

- *(deps)* upgrade Rust dependencies ([#933](https://github.com/cq27-dev/rag-rat/pull/933))
</blockquote>

## `rag-rat`

<blockquote>

## [0.22.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-base-v0.21.1...rag-rat-base-v0.22.0) - 2026-07-28

### Added

- *(oracle)* live LSP watcher wiring — phase 6 slice 2 ([#534](https://github.com/cq27-dev/rag-rat/pull/534)) ([#972](https://github.com/cq27-dev/rag-rat/pull/972))
- *(sync)* device-side account-log sync to configured server peers ([#922](https://github.com/cq27-dev/rag-rat/pull/922))
- *(sync)* [sync] config + `rag-rat sync serve` headless peer ([#909](https://github.com/cq27-dev/rag-rat/pull/909))

### Fixed

- *(tests)* isolate fixture git invocations from the ambient environment ([#975](https://github.com/cq27-dev/rag-rat/pull/975))
- *(tests)* retain satellite-crate scratch cleanup guards ([#973](https://github.com/cq27-dev/rag-rat/pull/973))
- *(tests)* retain core unit-test scratch cleanup guards ([#968](https://github.com/cq27-dev/rag-rat/pull/968))
- *(tests)* retain config scratch cleanup guards ([#967](https://github.com/cq27-dev/rag-rat/pull/967))
- *(tests)* clean high-volume scratch fixtures ([#963](https://github.com/cq27-dev/rag-rat/pull/963))

### Other

- *(deps)* upgrade Rust dependencies ([#933](https://github.com/cq27-dev/rag-rat/pull/933))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).