### PR TITLE
feat(sync): device-side account-log sync to configured server peers

### DIFF
--- a/crates/rag-rat-base/src/config/raw.rs
+++ b/crates/rag-rat-base/src/config/raw.rs
@@ -341,6 +341,8 @@ impl From<RawSearch> for SearchConfig {
 #[serde(deny_unknown_fields)]
 pub(crate) struct RawSync {
     relay_url: Option<String>,
+    server_peers: Option<Vec<String>>,
+    push_interval_secs: Option<u64>,
 }
 
 impl From<RawSync> for SyncConfig {
@@ -353,7 +355,17 @@ impl From<RawSync> for SyncConfig {
             .map(|v| v.trim().to_string())
             .filter(|v| !v.is_empty())
             .unwrap_or(default.relay_url);
-        Self { relay_url }
+        // Trim, drop blanks, and de-duplicate the peer list; the node-id FORMAT is validated at
+        // dial time (this crate has no iroh dependency to parse an `EndpointId`).
+        let mut server_peers = Vec::new();
+        for peer in raw.server_peers.unwrap_or_default() {
+            let peer = peer.trim().to_string();
+            if !peer.is_empty() && !server_peers.contains(&peer) {
+                server_peers.push(peer);
+            }
+        }
+        let push_interval_secs = raw.push_interval_secs.unwrap_or(default.push_interval_secs);
+        Self { relay_url, server_peers, push_interval_secs }
     }
 }
 

--- a/crates/rag-rat-base/src/config/tests.rs
+++ b/crates/rag-rat-base/src/config/tests.rs
@@ -2257,6 +2257,26 @@ fn sync_relay_defaults_to_the_shipped_relay_and_parses_an_override() {
 }
 
 #[test]
+fn sync_server_peers_default_empty_and_dedupe_while_push_interval_defaults() {
+    let default: SyncConfig = RawSync::default().into();
+    assert!(default.server_peers.is_empty(), "device-side sync is off until server_peers is set");
+    assert_eq!(default.push_interval_secs, 300, "the default device-sync cadence is 300s");
+
+    let raw: RawConfig = toml::from_str(
+        "[index]\nroot = \".\"\n\n[sync]\nserver_peers = [\" node-a \", \"node-b\", \"node-a\", \
+         \"  \"]\npush_interval_secs = 60\n",
+    )
+    .unwrap();
+    let sync: SyncConfig = raw.sync.into();
+    assert_eq!(
+        sync.server_peers,
+        vec!["node-a".to_string(), "node-b".to_string()],
+        "server_peers are trimmed, de-duplicated, and blanks dropped, order preserved"
+    );
+    assert_eq!(sync.push_interval_secs, 60, "[sync] push_interval_secs overrides the default");
+}
+
+#[test]
 fn dream_absent_defaults_to_off_and_local_ollama_connect() {
     // No `[llm.dream]` at all → disabled, with a local-Ollama CONNECT serving default
     // (byte-for-byte the pre-migration `[dream.model]` default).

--- a/crates/rag-rat-base/src/config/types.rs
+++ b/crates/rag-rat-base/src/config/types.rs
@@ -243,11 +243,24 @@ pub struct SyncConfig {
     /// [`DEFAULT_SYNC_RELAY`]; set `[sync] relay_url` to point at a different relay. The
     /// `RAG_RAT_SYNC_RELAY` env var overrides this at the call site (ops/tests).
     pub relay_url: String,
+    /// Server peer node ids this device replicates its account log with on the maintenance path,
+    /// each dialed via [`relay_url`](Self::relay_url). Empty (the default) disables device-side
+    /// sync entirely. Entries are trimmed, de-duplicated, and non-empty here; the node-id FORMAT
+    /// is validated at dial time (the config layer has no iroh dependency), where an
+    /// unparseable entry is warned and skipped rather than failing the whole sync.
+    pub server_peers: Vec<String>,
+    /// Minimum seconds between device-side sync attempts on the maintenance path (default 300).
+    /// `0` attempts on every trigger. Only consulted when `server_peers` is non-empty.
+    pub push_interval_secs: u64,
 }
 
 impl Default for SyncConfig {
     fn default() -> Self {
-        Self { relay_url: DEFAULT_SYNC_RELAY.to_string() }
+        Self {
+            relay_url: DEFAULT_SYNC_RELAY.to_string(),
+            server_peers: Vec::new(),
+            push_interval_secs: 300,
+        }
     }
 }
 

--- a/crates/rag-rat-cli/src/commands/index_ops.rs
+++ b/crates/rag-rat-cli/src/commands/index_ops.rs
@@ -381,6 +381,7 @@ pub(crate) fn maintenance(config: &Config, args: &MaintenanceArgs) -> anyhow::Re
         // watcher's own worker through the flight lock). This path is only reachable for
         // hook triggers (post-checkout / post-merge).
         let papertrail = papertrail_hook_trigger(config);
+        let device_sync = sync_hook_trigger(config);
         print_output(&serde_json::json!({
             "trigger": trigger,
             "status": "skipped",
@@ -388,6 +389,7 @@ pub(crate) fn maintenance(config: &Config, args: &MaintenanceArgs) -> anyhow::Re
             "old_head": old_head,
             "new_head": new_head,
             "papertrail": papertrail,
+            "device_sync": device_sync,
         }))?;
         return Ok(());
     }
@@ -427,6 +429,7 @@ pub(crate) fn maintenance(config: &Config, args: &MaintenanceArgs) -> anyhow::Re
             // this against any flight the holder (or the watcher) does run.
             if hook_trigger {
                 skip_report["papertrail"] = papertrail_hook_trigger(config);
+                skip_report["device_sync"] = sync_hook_trigger(config);
             }
             return print_output(&skip_report);
         },
@@ -447,8 +450,20 @@ pub(crate) fn maintenance(config: &Config, args: &MaintenanceArgs) -> anyhow::Re
                        papertrail sync` for an explicit mirror pass",
         })
     };
+    // Device-side sync likewise rides git-hook triggers only (a manual/cron `maintenance` stays
+    // bounded by its index budget); the cadence watermark keeps it to at most one dial per
+    // interval.
+    let device_sync = if hook_trigger {
+        sync_hook_trigger(config)
+    } else {
+        serde_json::json!({
+            "status": "skipped",
+            "reason": "device-side sync rides git-hook triggers only",
+        })
+    };
     if let Some(report) = report.as_object_mut() {
         report.insert("papertrail".to_string(), papertrail);
+        report.insert("device_sync".to_string(), device_sync);
     }
     print_output(&report)
 }
@@ -485,6 +500,49 @@ fn papertrail_hook_trigger(config: &Config) -> serde_json::Value {
                 target: "rag_rat_core::papertrail",
                 error = %error,
                 "papertrail auto-sync failed; a later trigger retries"
+            );
+            serde_json::json!({"status": "error", "error": error.to_string()})
+        },
+    }
+}
+
+/// Best-effort device-side sync riding the git trigger: after ordinary maintenance, dial the
+/// configured `[sync] server_peers` and replicate this account's op log. Like papertrail it never
+/// holds the repo write lock (each account ingest is a short SQLite transaction) and every failure
+/// is folded into the report — a broken peer must never fail the git hook. The cadence watermark
+/// and the per-database session lock dedup the several triggers one git action fires.
+fn sync_hook_trigger(config: &Config) -> serde_json::Value {
+    use crate::commands::sync::{DeviceSyncOutcome, device_sync_run};
+    // Re-open the migrated index for the account-log sync (the pass closed its own connection). A
+    // Compatible store needs no migration, so this is cheap — the same shape autosync uses.
+    let db = match crate::open_index(config) {
+        Ok(db) => db,
+        Err(error) => return serde_json::json!({"status": "error", "error": error.to_string()}),
+    };
+    match device_sync_run(config, db.connection()) {
+        Ok(DeviceSyncOutcome::Disabled) => serde_json::json!({
+            "status": "disabled",
+            "reason": "no [sync] server_peers, no local account, or this device is not roster-effective",
+        }),
+        Ok(DeviceSyncOutcome::Skipped) => serde_json::json!({
+            "status": "skipped",
+            "reason": "within push_interval_secs since the last device sync",
+        }),
+        Ok(DeviceSyncOutcome::Deferred) => serde_json::json!({
+            "status": "deferred",
+            "reason": "this database's node identity is busy (a serve peer or another sync)",
+        }),
+        Ok(DeviceSyncOutcome::Ran { peers, ok, errors }) => serde_json::json!({
+            "status": "ran",
+            "peers": peers,
+            "ok": ok,
+            "errors": errors,
+        }),
+        Err(error) => {
+            tracing::warn!(
+                target: "rag_rat_core::sync",
+                error = %error,
+                "device sync failed; a later trigger retries"
             );
             serde_json::json!({"status": "error", "error": error.to_string()})
         },
@@ -1357,6 +1415,48 @@ mod papertrail_hook_tests {
         assert!(
             !rag_rat_base::locks::papertrail_pending_path(&config.database, &lock_repo).exists()
         );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn maintenance_runs_device_sync_on_a_hook_trigger_without_failing_the_hook() {
+        let root = std::env::temp_dir().join(format!(
+            "rag-rat-cli-device-sync-hook-{}-{}",
+            std::process::id(),
+            N.fetch_add(1, Ordering::Relaxed)
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::write(root.join("src/lib.rs"), "pub fn f() {}\n").unwrap();
+        let mut config = config_with_unreachable_tracker(&root);
+        config.trackers.clear(); // isolate the trigger tail to device sync only
+        // A configured server peer but NO enrolled sync account: `device_sync_run` returns
+        // `Disabled` BEFORE binding any endpoint, so this stays offline while still exercising the
+        // `maintenance` → `sync_hook_trigger` wire-in and proving a hook trigger cannot fail there.
+        config.sync.server_peers = vec!["some-server-node-id".to_string()];
+        IndexDatabase::rebuild(&config).unwrap();
+
+        let args = super::MaintenanceArgs {
+            trigger: Some("post-commit".to_string()),
+            max_seconds: Some(0),
+            branch_checkout: None,
+            old_head: None,
+            new_head: None,
+        };
+        // Device-side sync rides the hook after the pass; a disabled peer must never fail the hook.
+        super::maintenance(&config, &args).unwrap();
+
+        // No account was enrolled, so device sync was disabled and never stamped its watermark.
+        let conn = rusqlite::Connection::open(&config.database).unwrap();
+        let stamped: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM index_meta WHERE key = 'sync_device_last_at_ms'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(stamped, 0, "device sync stayed disabled (no account) — no watermark stamped");
 
         let _ = std::fs::remove_dir_all(&root);
     }

--- a/crates/rag-rat-cli/src/commands/sync.rs
+++ b/crates/rag-rat-cli/src/commands/sync.rs
@@ -120,17 +120,10 @@ fn serve(config: &Config, once: bool) -> anyhow::Result<()> {
             .await
             .with_context(|| format!("binding the sync endpoint over relay {relay}"))?;
         // A private account admits only peers whose binding verifies against the roster (mutual),
-        // so the serve peer must itself hold an EFFECTIVE (roster-current) device. Fail fast by
-        // running its own binding through the roster authorization path — not just an is-empty
-        // check: a device REMOVED from the roster still holds its local key and mints a nonempty
-        // binding, but every `Closed` peer would reject it as `NotRosterDevice`. Self-authorization
-        // fails closed for both "no local device" and "revoked", so the server never starts only to
-        // silently reject every session.
+        // so the serve peer must itself hold an EFFECTIVE (roster-current) device. Fail fast rather
+        // than start and silently reject every session.
         let local_node = *endpoint.id().as_bytes();
-        let probe = OplogSyncStore::new(conn, account_id, time::now_ms);
-        let probe_now = time::now_ms();
-        let binding = probe.local_binding(&local_node, probe_now)?;
-        if !probe.authorize(&binding, &local_node, probe_now)? {
+        if !device_roster_effective(conn, account_id, &local_node)? {
             bail!(
                 "this peer's device is not an effective member of the account (no enrolled \
                  device, or removed from the roster) — it cannot serve a private account; run \
@@ -201,6 +194,157 @@ fn serve(config: &Config, once: bool) -> anyhow::Result<()> {
     })
 }
 
+/// How long device-side sync waits for the per-database session lock before deferring to the next
+/// maintenance pass. Kept short: a colocated `serve` peer holds this lock for its whole life, so a
+/// long wait would just burn time on every hook before deferring; a transient overlap with another
+/// device sync resolves on the next trigger anyway (the cadence has already been satisfied).
+const DEVICE_SYNC_LOCK_TIMEOUT: Duration = Duration::from_secs(1);
+/// Meta key: the last device-side sync attempt (ms), the cadence watermark.
+const DEVICE_SYNC_LAST_META_KEY: &str = "sync_device_last_at_ms";
+
+/// What a device-side sync attempt did — folded into the maintenance hook report.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum DeviceSyncOutcome {
+    /// No server peers configured, no local account, or the device is not roster-effective.
+    Disabled,
+    /// The cadence gate suppressed this attempt (a sync ran within `push_interval_secs`).
+    Skipped,
+    /// The per-database session lock is held (a serve peer or another sync); retry next pass.
+    Deferred,
+    /// Ran against the configured peers: `ok` sessions succeeded, `errors` failed.
+    Ran { peers: usize, ok: usize, errors: usize },
+}
+
+/// Best-effort device-side account-log sync on the maintenance path: dial each configured server
+/// peer and run one bidirectional session (push the entries the peer lacks, pull the ones we lack).
+/// Reuses the migrated `conn` from the maintenance pass and never holds the repo write lock — each
+/// account ingest is a single SQLite transaction serialized against any watcher write. Every
+/// per-peer failure is counted and logged; the caller folds the outcome into the hook report and a
+/// broken peer never fails the hook.
+pub(crate) fn device_sync_run(
+    config: &Config,
+    conn: &Connection,
+) -> anyhow::Result<DeviceSyncOutcome> {
+    if config.sync.server_peers.is_empty() {
+        return Ok(DeviceSyncOutcome::Disabled);
+    }
+    // Device-side sync must NOT mint identity: an unenrolled store simply has nothing to sync.
+    let Some(account_id) = rag_rat_oplog::read_local_account(conn)? else {
+        return Ok(DeviceSyncOutcome::Disabled);
+    };
+    if !device_sync_due(conn, config.sync.push_interval_secs)? {
+        return Ok(DeviceSyncOutcome::Skipped);
+    }
+    // The per-database session lock: this device-side ephemeral session must not run while a
+    // colocated serve peer (or another device sync) holds the same node identity. On timeout,
+    // defer to the next maintenance pass rather than block the hook.
+    let Some(_session) =
+        locks::WriteLock::acquire_sync_session_timeout(&config.database, DEVICE_SYNC_LOCK_TIMEOUT)?
+    else {
+        return Ok(DeviceSyncOutcome::Deferred);
+    };
+    // Re-check the cadence UNDER the lock (double-checked locking): several git hooks fire per
+    // action and can all pass the pre-lock check on the same old watermark; without this a
+    // serialized contender would re-dial every peer right after the first run stamps the watermark.
+    if !device_sync_due(conn, config.sync.push_interval_secs)? {
+        return Ok(DeviceSyncOutcome::Skipped);
+    }
+    let node_key = node_secret(conn)?;
+    // Gate on roster-effectiveness BEFORE binding an endpoint: the node id is derivable from the
+    // secret, so this pays no socket or relay traffic. A revoked or unenrolled device could
+    // authorize to no `Closed` peer, so dialing would only fail every session. Stamp the watermark
+    // so this local-broken state is cadence-limited exactly like an unreachable peer — otherwise
+    // every hook would rebind an endpoint and hit the relay for nothing.
+    let local_node = rag_rat_sync::node_id_from_secret(*node_key);
+    if !device_roster_effective(conn, account_id, &local_node)? {
+        record_device_sync(conn)?;
+        return Ok(DeviceSyncOutcome::Disabled);
+    }
+    let relay = effective_relay_url(config);
+    let peers = &config.sync.server_peers;
+
+    let runtime =
+        tokio::runtime::Builder::new_multi_thread().worker_threads(2).enable_all().build()?;
+    let result: anyhow::Result<(usize, usize)> = runtime.block_on(async {
+        let endpoint = rag_rat_sync::build_endpoint(*node_key, &relay)
+            .await
+            .with_context(|| format!("binding the sync endpoint over relay {relay}"))?;
+        let mut ok = 0usize;
+        let mut errors = 0usize;
+        for peer in peers {
+            let addr = match rag_rat_sync::peer_addr(peer, &relay) {
+                Ok(addr) => addr,
+                Err(e) => {
+                    errors += 1;
+                    tracing::warn!(peer, error = %e, "skipping a server peer with an invalid node id");
+                    continue;
+                },
+            };
+            let mut store = OplogSyncStore::new(conn, account_id, time::now_ms);
+            match rag_rat_sync::connect_and_sync(
+                &endpoint,
+                addr,
+                &mut store,
+                AuthPolicy::Closed,
+                time::now_ms(),
+            )
+            .await
+            {
+                Ok(report) => {
+                    ok += 1;
+                    tracing::info!(
+                        peer,
+                        sent = report.entries_sent,
+                        stored = report.entries_newly_stored,
+                        "device sync with a server peer complete"
+                    );
+                },
+                Err(e) => {
+                    errors += 1;
+                    tracing::warn!(peer, error = %e, "device sync to a server peer failed");
+                },
+            }
+        }
+        anyhow::Ok((ok, errors))
+    });
+
+    // Stamp the cadence watermark on ANY completed attempt — a per-peer failure OR an endpoint-bind
+    // failure (a bad relay URL, a relay outage). Without stamping before we propagate, the bind
+    // failure would `?`-exit and every subsequent hook would rebind and hit the relay again,
+    // ignoring `push_interval_secs`. A bind failure still surfaces (the caller reports it and never
+    // fails the hook), but it is now cadence-limited exactly like an unreachable peer.
+    record_device_sync(conn)?;
+    let (ok, errors) = result?;
+    Ok(DeviceSyncOutcome::Ran { peers: peers.len(), ok, errors })
+}
+
+/// The cadence gate: whether enough time has passed since the last device-side sync attempt.
+/// `push_interval_secs == 0` always runs; a never-synced store always runs.
+fn device_sync_due(conn: &Connection, push_interval_secs: u64) -> anyhow::Result<bool> {
+    if push_interval_secs == 0 {
+        return Ok(true);
+    }
+    let Some(last) = rag_rat_db::meta::read_meta(conn, DEVICE_SYNC_LAST_META_KEY)?
+        .and_then(|s| s.trim().parse::<i64>().ok())
+    else {
+        return Ok(true);
+    };
+    let now = time::now_ms();
+    // A watermark in the FUTURE means the clock stepped backward (NTP correcting a fast RTC, a VM
+    // resume) after a stamp — never trust it, or device sync would stay silently suppressed for the
+    // whole gap until the wall clock catches up. Treat it as due and let the next run re-stamp.
+    if last > now {
+        return Ok(true);
+    }
+    let interval_ms = i64::try_from(push_interval_secs).unwrap_or(i64::MAX).saturating_mul(1000);
+    Ok(now - last >= interval_ms)
+}
+
+/// Stamp the device-side sync cadence watermark at the current time.
+fn record_device_sync(conn: &Connection) -> anyhow::Result<()> {
+    rag_rat_db::meta::set_meta(conn, DEVICE_SYNC_LAST_META_KEY, &time::now_ms().to_string())
+}
+
 /// Resolve this store's EXISTING local account WITHOUT minting one. A serve peer must already be
 /// enrolled; merely starting the server must never create account or device identity state as a
 /// side effect (that is `sync enable`'s job). The "no account yet" case becomes an actionable
@@ -209,6 +353,23 @@ fn existing_account_or_hint(conn: &Connection) -> anyhow::Result<rag_rat_oplog::
     rag_rat_oplog::read_local_account(conn)?.context(
         "no local sync account — run `rag-rat sync enable` and enroll this peer before serving",
     )
+}
+
+/// Whether this store's local device is roster-EFFECTIVE — not merely present. Mints its own
+/// binding for `local_node` and runs it through the roster `authorize` path (self-authorization).
+/// Returns `false` for both "no local device" (empty binding) and "removed from the roster" (a
+/// nonempty binding a `Closed` peer would reject as `NotRosterDevice`). Both `serve` (accept) and
+/// device-side sync (dial) gate on this: a non-effective device can neither serve nor sync a
+/// private account, so acting on it would only fail every session.
+fn device_roster_effective(
+    conn: &Connection,
+    account_id: rag_rat_oplog::AccountId,
+    local_node: &[u8; 32],
+) -> anyhow::Result<bool> {
+    let probe = OplogSyncStore::new(conn, account_id, time::now_ms);
+    let now = time::now_ms();
+    let binding = probe.local_binding(local_node, now)?;
+    probe.authorize(&binding, local_node, now)
 }
 
 /// Meta key for this index's persisted iroh node secret (the transport identity).
@@ -263,15 +424,85 @@ fn decode_node_secret(hex: &str) -> anyhow::Result<Zeroizing<[u8; 32]>> {
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+
+    use rag_rat_base::config::Config;
     use rag_rat_base::hash;
     use rusqlite::Connection;
 
-    use super::{decode_node_secret, node_secret};
+    use super::{
+        DEVICE_SYNC_LAST_META_KEY, DeviceSyncOutcome, decode_node_secret, device_sync_due,
+        device_sync_run, node_secret, record_device_sync,
+    };
 
     fn schema_conn() -> Connection {
         let conn = Connection::open_in_memory().unwrap();
         rag_rat_db::schema::apply(&conn, &rag_rat_db::MigrationHooks::noop()).unwrap();
         conn
+    }
+
+    /// A minimal config whose paths are never touched by these gate tests (they all return before
+    /// the session lock / network). `[sync]` starts at its defaults (no peers).
+    fn min_config() -> Config {
+        Config::minimal_for_database(
+            PathBuf::from("/nonexistent/db.sqlite"),
+            PathBuf::from("/nonexistent"),
+        )
+    }
+
+    #[test]
+    fn device_sync_due_respects_the_cadence() {
+        let conn = schema_conn();
+        assert!(device_sync_due(&conn, 0).unwrap(), "interval 0 always runs");
+        assert!(device_sync_due(&conn, 300).unwrap(), "a never-synced store is due");
+        record_device_sync(&conn).unwrap();
+        assert!(
+            !device_sync_due(&conn, 300).unwrap(),
+            "a just-synced store waits out the interval"
+        );
+        rag_rat_db::meta::set_meta(&conn, DEVICE_SYNC_LAST_META_KEY, "0").unwrap();
+        assert!(device_sync_due(&conn, 300).unwrap(), "an ancient watermark is due again");
+        // A watermark in the future (backward clock step) must not silently suppress sync.
+        let future = (rag_rat_base::time::now_ms() + 10_000_000).to_string();
+        rag_rat_db::meta::set_meta(&conn, DEVICE_SYNC_LAST_META_KEY, &future).unwrap();
+        assert!(device_sync_due(&conn, 300).unwrap(), "a future watermark is treated as due");
+    }
+
+    #[test]
+    fn device_sync_run_is_disabled_without_configured_peers() {
+        let conn = schema_conn();
+        assert_eq!(
+            device_sync_run(&min_config(), &conn).unwrap(),
+            DeviceSyncOutcome::Disabled,
+            "no [sync] server_peers => device-side sync is off"
+        );
+    }
+
+    #[test]
+    fn device_sync_run_is_disabled_without_a_local_account() {
+        let conn = schema_conn(); // schema only, never minted an account
+        let mut config = min_config();
+        config.sync.server_peers = vec!["some-node-id".to_string()];
+        assert_eq!(
+            device_sync_run(&config, &conn).unwrap(),
+            DeviceSyncOutcome::Disabled,
+            "configured peers but no enrolled account => nothing to sync (and never mints one)"
+        );
+    }
+
+    #[test]
+    fn device_sync_run_skips_within_the_cadence_window() {
+        let conn = schema_conn();
+        rag_rat_oplog::local_account(&conn, 1_700_000_000_000).unwrap(); // enroll a local account
+        record_device_sync(&conn).unwrap(); // just synced
+        let mut config = min_config();
+        config.sync.server_peers = vec!["some-node-id".to_string()];
+        config.sync.push_interval_secs = 300;
+        assert_eq!(
+            device_sync_run(&config, &conn).unwrap(),
+            DeviceSyncOutcome::Skipped,
+            "a recent sync suppresses the next attempt before any dial"
+        );
     }
 
     #[test]

--- a/crates/rag-rat-sync/src/endpoint.rs
+++ b/crates/rag-rat-sync/src/endpoint.rs
@@ -23,7 +23,7 @@
 use std::str::FromStr;
 
 use iroh::endpoint::presets;
-use iroh::{Endpoint, EndpointAddr, RelayMode, RelayUrl, SecretKey};
+use iroh::{Endpoint, EndpointAddr, EndpointId, RelayMode, RelayUrl, SecretKey};
 use tokio::time::timeout;
 
 use crate::auth::{
@@ -41,6 +41,8 @@ pub enum EndpointError {
     Bind(String),
     /// Dialling a peer, or accepting an inbound connection, failed.
     Connect(String),
+    /// A configured peer node id did not parse.
+    PeerId(String),
 }
 
 impl std::fmt::Display for EndpointError {
@@ -49,6 +51,7 @@ impl std::fmt::Display for EndpointError {
             EndpointError::RelayUrl(m) => write!(f, "invalid relay url: {m}"),
             EndpointError::Bind(m) => write!(f, "binding the sync endpoint failed: {m}"),
             EndpointError::Connect(m) => write!(f, "sync connection setup failed: {m}"),
+            EndpointError::PeerId(m) => write!(f, "invalid peer node id: {m}"),
         }
     }
 }
@@ -73,6 +76,24 @@ pub async fn build_endpoint(
         .map_err(|e| EndpointError::Bind(e.to_string()))
 }
 
+/// The iroh node id (public-key bytes) a `secret_key` yields — the exact id [`build_endpoint`]
+/// would bind. Lets a caller check its own transport identity WITHOUT binding an endpoint (no
+/// socket, no relay traffic), e.g. to gate on roster-effectiveness before paying for a bind.
+pub fn node_id_from_secret(secret_key: [u8; 32]) -> [u8; 32] {
+    *SecretKey::from_bytes(&secret_key).public().as_bytes()
+}
+
+/// Build a dialable [`EndpointAddr`] from a peer's node id (the z-base-32 form `endpoint.id()`
+/// prints) and the shared relay URL. The device-side sync driver configures server peers by node id
+/// and reaches each through the pinned relay — the CLI stays iroh-free by going through here.
+pub fn peer_addr(node_id: &str, relay_url: &str) -> Result<EndpointAddr, EndpointError> {
+    let id =
+        EndpointId::from_str(node_id.trim()).map_err(|e| EndpointError::PeerId(e.to_string()))?;
+    let relay =
+        RelayUrl::from_str(relay_url.trim()).map_err(|e| EndpointError::RelayUrl(e.to_string()))?;
+    Ok(EndpointAddr::new(id).with_relay_url(relay))
+}
+
 /// This endpoint's dialable address — hand it (or a ticket wrapping it) to a peer so it can
 /// [`connect_and_sync`] back.
 pub fn endpoint_addr(endpoint: &Endpoint) -> EndpointAddr {
@@ -91,14 +112,20 @@ pub async fn connect_and_sync<S: SyncStore + NodeAuth>(
     now_ms: i64,
 ) -> Result<SessionReport, SyncFailure> {
     let local_node = *endpoint.id().as_bytes();
-    let conn = endpoint
-        .connect(peer, SYNC_ALPN)
+    // Bound every peer-controlled wait explicitly (mirroring `accept_and_sync`), rather than
+    // inheriting a transport dependency's idle default: a dead or unreachable configured peer must
+    // fail this dial promptly — a device-side sync holds the per-database session lock while it
+    // runs.
+    let conn = timeout(DEFAULT_IDLE_TIMEOUT, endpoint.connect(peer, SYNC_ALPN))
         .await
+        .map_err(|_| SyncFailure::Endpoint(EndpointError::Connect("dial timed out".into())))?
         .map_err(|e| SyncFailure::Endpoint(EndpointError::Connect(e.to_string())))?;
     let remote_node = *conn.remote_id().as_bytes();
-    let (mut send, mut recv) = conn
-        .open_bi()
+    let (mut send, mut recv) = timeout(DEFAULT_IDLE_TIMEOUT, conn.open_bi())
         .await
+        .map_err(|_| {
+            SyncFailure::Endpoint(EndpointError::Connect("opening a stream timed out".into()))
+        })?
         .map_err(|e| SyncFailure::Endpoint(EndpointError::Connect(e.to_string())))?;
     run_auth_phase(&mut send, &mut recv, &*store, AuthConfig {
         role: AuthRole::Dialer,

--- a/crates/rag-rat-sync/src/lib.rs
+++ b/crates/rag-rat-sync/src/lib.rs
@@ -25,6 +25,7 @@ pub mod wire;
 pub use auth::{AuthConfig, AuthError, AuthPolicy, AuthRole, NodeAuth, run_auth_phase};
 pub use endpoint::{
     EndpointError, SyncFailure, accept_and_sync, build_endpoint, connect_and_sync, endpoint_addr,
+    node_id_from_secret, peer_addr,
 };
 pub use session::{
     DEFAULT_IDLE_TIMEOUT, Ingested, MAX_SESSION_ENTRIES, SessionError, SessionReport, SyncStore,


### PR DESCRIPTION
The dialer half of the sync transport: `rag-rat sync serve` is the accept side, and this is the device that reaches it. On the git-hook maintenance path a device replicates its account log with configured server peers.

## What it adds

- **Config.** A `[sync] server_peers` list (server node ids, dialed via the shared `relay_url`) and `push_interval_secs` — a cadence backed by a persisted watermark. Device-side sync is off until `server_peers` is set.
- **The driver.** For each configured peer it runs one bidirectional session (`connect_and_sync`) — pushing the entries the peer lacks, pulling the ones this device lacks — best-effort per peer. It reuses the persisted node key, the endpoint, and the roster-effectiveness probe; reads an existing account without ever minting one; acquires the per-database session lock (deferring while a serve peer or another sync holds the node identity); and never holds the repo write lock.
- **Maintenance seam.** Rides the git-hook maintenance trigger after the index pass, mirroring papertrail auto-sync: the outcome is folded into the report and a broken peer never fails the hook.
- **`rag_rat_sync::peer_addr` / `node_id_from_secret`** so the CLI dials a peer by node id and checks its own transport identity without an iroh dependency.

## Behavior notes

- Account log only; `/3` content replication needs the wire stream discriminator (#907).
- A persistent failure — an unreachable peer, a bad relay, a revoked local device — is cadence-limited: the watermark is stamped on every completed attempt, so a broken configuration does not rebind and redial on every hook.
- The clock is read at the right moments (a future watermark from a backward clock step is treated as due; the dial is explicitly time-bounded).

## Tests

Config round-trip, the cadence gate (including the future-watermark case), the disabled/skipped gate paths, and the maintenance wire-in (a hook trigger runs device sync without failing the hook). Full workspace green under both CI runners; all clippy feature gates clean.

Part of #406. Fixes #914.