### PR TITLE
feat(sync): replicate /3 content over a second ALPN

### DIFF
--- a/crates/rag-rat-cli/src/commands/sync.rs
+++ b/crates/rag-rat-cli/src/commands/sync.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 use anyhow::{Context, anyhow, bail};
 use rag_rat_base::config::Config;
 use rag_rat_base::{hash, locks, time};
-use rag_rat_sync::{AuthPolicy, NodeAuth, OplogSyncStore};
+use rag_rat_sync::{AuthPolicy, NodeAuth, OplogContentSyncStore, OplogSyncStore};
 use rusqlite::{Connection, params};
 use zeroize::Zeroizing;
 
@@ -70,9 +70,10 @@ fn effective_relay_url(config: &Config) -> String {
 }
 
 /// Run a headless store-and-forward peer for this account's op log: bind the sync endpoint over the
-/// configured relay and replicate the account log with peers the roster authorizes. Serves the
-/// account log only — the wire is scoped to one stream per session, so content replication is a
-/// separate stream a later slice adds. Runs until interrupted; `once` serves a single connection.
+/// configured relay and replicate with peers the roster authorizes. Serves BOTH streams a peer may
+/// negotiate — the account log (`SYNC_ALPN`) and `/3` content (`CONTENT_SYNC_ALPN`) — routing
+/// each connection by its ALPN. Runs until interrupted; `once` serves a single connection (one
+/// stream), so a full account+content sync a device drives needs two connections.
 fn serve(config: &Config, once: bool) -> anyhow::Result<()> {
     let relay = effective_relay_url(config);
     // Hold a database-scoped session lock for the SERVER'S WHOLE LIFETIME. `sync_node_secret` is
@@ -150,12 +151,21 @@ fn serve(config: &Config, once: bool) -> anyhow::Result<()> {
         // delivered between iterations be swallowed by tokio's driver and missed.
         let mut shutdown = std::pin::pin!(tokio::signal::ctrl_c());
         loop {
-            let mut store = OplogSyncStore::new(conn, account_id, time::now_ms);
+            // One endpoint, one accept loop: a connection carries the ACCOUNT-LOG ALPN or the
+            // CONTENT ALPN, and `accept_and_dispatch` routes it to the matching store after the
+            // (account-level) auth phase. Both stores are cheap handles reconstructed per accept.
+            let mut account_store = OplogSyncStore::new(conn, account_id, time::now_ms);
+            let mut content_store = OplogContentSyncStore::new(conn, account_id, time::now_ms);
             let outcome = tokio::select! {
-                // `accept_and_sync` reads `now_ms` once a peer connects — the server may wait here
-                // arbitrarily long, so the auth timestamp must not predate the connection.
-                report = rag_rat_sync::accept_and_sync(&endpoint, &mut store, policy, time::now_ms)
-                    => Some(report),
+                // `accept_and_dispatch` reads `now_ms` once a peer connects — the server may wait
+                // here arbitrarily long, so the auth timestamp must not predate the connection.
+                result = rag_rat_sync::accept_and_dispatch(
+                    &endpoint,
+                    &mut account_store,
+                    &mut content_store,
+                    policy,
+                    time::now_ms,
+                ) => Some(result),
                 _ = &mut shutdown => None,
             };
             match outcome {
@@ -163,7 +173,8 @@ fn serve(config: &Config, once: bool) -> anyhow::Result<()> {
                     tracing::info!("interrupted; shutting down");
                     break;
                 },
-                Some(Ok(report)) => tracing::info!(
+                Some(Ok((alpn, report))) => tracing::info!(
+                    stream = %String::from_utf8_lossy(&alpn),
                     sent = report.entries_sent,
                     received = report.entries_received,
                     stored = report.entries_newly_stored,
@@ -280,29 +291,63 @@ pub(crate) fn device_sync_run(
                     continue;
                 },
             };
-            let mut store = OplogSyncStore::new(conn, account_id, time::now_ms);
-            match rag_rat_sync::connect_and_sync(
-                &endpoint,
-                addr,
-                &mut store,
-                AuthPolicy::Closed,
-                time::now_ms(),
-            )
-            .await
-            {
-                Ok(report) => {
-                    ok += 1;
-                    tracing::info!(
+            // Account log FIRST — it carries the roster + stream ownership that AUTHORIZE content, so
+            // leading with it minimizes parking on the peer. The account-log result IS the peer's
+            // outcome, so `ok + errors` stays equal to the number of configured peers. `/3` content
+            // rides on top: best-effort, attempted only once the account log reached the peer, and a
+            // content hiccup is logged — never a peer failure.
+            let account_ok = {
+                let mut store = OplogSyncStore::new(conn, account_id, time::now_ms);
+                match rag_rat_sync::connect_and_sync(
+                    &endpoint,
+                    addr.clone(),
+                    rag_rat_sync::SYNC_ALPN,
+                    &mut store,
+                    AuthPolicy::Closed,
+                    time::now_ms(),
+                )
+                .await
+                {
+                    Ok(report) => {
+                        tracing::info!(
+                            peer,
+                            sent = report.entries_sent,
+                            stored = report.entries_newly_stored,
+                            "device sync (account log) complete"
+                        );
+                        true
+                    },
+                    Err(e) => {
+                        tracing::warn!(peer, error = %e, "device sync (account log) failed");
+                        false
+                    },
+                }
+            };
+            if account_ok {
+                let mut store = OplogContentSyncStore::new(conn, account_id, time::now_ms);
+                match rag_rat_sync::connect_and_sync(
+                    &endpoint,
+                    addr,
+                    rag_rat_sync::CONTENT_SYNC_ALPN,
+                    &mut store,
+                    AuthPolicy::Closed,
+                    time::now_ms(),
+                )
+                .await
+                {
+                    Ok(report) => tracing::info!(
                         peer,
                         sent = report.entries_sent,
                         stored = report.entries_newly_stored,
-                        "device sync with a server peer complete"
-                    );
-                },
-                Err(e) => {
-                    errors += 1;
-                    tracing::warn!(peer, error = %e, "device sync to a server peer failed");
-                },
+                        "device sync (content) complete"
+                    ),
+                    Err(e) => tracing::warn!(peer, error = %e, "device sync (content) failed"),
+                }
+            }
+            if account_ok {
+                ok += 1;
+            } else {
+                errors += 1;
             }
         }
         anyhow::Ok((ok, errors))

--- a/crates/rag-rat-sync/src/endpoint.rs
+++ b/crates/rag-rat-sync/src/endpoint.rs
@@ -30,7 +30,7 @@ use crate::auth::{
     AuthConfig, AuthPolicy, AuthRole, DEFAULT_PRE_AUTH_TIMEOUT, NodeAuth, run_auth_phase,
 };
 use crate::session::{DEFAULT_IDLE_TIMEOUT, SessionError, SessionReport, SyncStore, run_session};
-use crate::wire::SYNC_ALPN;
+use crate::wire::{CONTENT_SYNC_ALPN, SYNC_ALPN};
 
 /// Endpoint construction or connection setup failed, before a session could run.
 #[derive(Debug)]
@@ -58,6 +58,12 @@ impl std::fmt::Display for EndpointError {
 
 impl std::error::Error for EndpointError {}
 
+/// How long an ACCEPTOR waits for the dialer to close the connection before closing from its own
+/// side. A QUIC `close()` discards in-flight stream data, so the side that STREAMED a response must
+/// not close until the dialer has read it — the dialer closes once its `run_session` finished
+/// reading, and this bounds the wait so a vanished dialer can never wedge the acceptor.
+const GRACEFUL_CLOSE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
 /// Bind a sync endpoint pinned to `relay_url`, with a stable node id derived from `secret_key` (the
 /// 32-byte ed25519 seed of the transport identity — its own key, distinct from any account device
 /// key). The same seed yields the same node id across launches, so a peer's ticket stays valid.
@@ -68,7 +74,7 @@ pub async fn build_endpoint(
     let relay_url =
         RelayUrl::from_str(relay_url.trim()).map_err(|e| EndpointError::RelayUrl(e.to_string()))?;
     Endpoint::builder(presets::Minimal)
-        .alpns(vec![SYNC_ALPN.to_vec()])
+        .alpns(vec![SYNC_ALPN.to_vec(), CONTENT_SYNC_ALPN.to_vec()])
         .relay_mode(RelayMode::custom([relay_url]))
         .secret_key(SecretKey::from_bytes(&secret_key))
         .bind()
@@ -107,16 +113,21 @@ pub fn endpoint_addr(endpoint: &Endpoint) -> EndpointAddr {
 pub async fn connect_and_sync<S: SyncStore + NodeAuth>(
     endpoint: &Endpoint,
     peer: impl Into<EndpointAddr>,
+    alpn: &[u8],
     store: &mut S,
     policy: AuthPolicy,
     now_ms: i64,
 ) -> Result<SessionReport, SyncFailure> {
     let local_node = *endpoint.id().as_bytes();
+    // The `alpn` selects the STREAM the dialer wants — [`SYNC_ALPN`] for the account log,
+    // [`CONTENT_SYNC_ALPN`] for `/3` content — and must match `store`'s type. The acceptor routes
+    // to the matching store by the negotiated ALPN.
+    //
     // Bound every peer-controlled wait explicitly (mirroring `accept_and_sync`), rather than
     // inheriting a transport dependency's idle default: a dead or unreachable configured peer must
     // fail this dial promptly — a device-side sync holds the per-database session lock while it
     // runs.
-    let conn = timeout(DEFAULT_IDLE_TIMEOUT, endpoint.connect(peer, SYNC_ALPN))
+    let conn = timeout(DEFAULT_IDLE_TIMEOUT, endpoint.connect(peer, alpn))
         .await
         .map_err(|_| SyncFailure::Endpoint(EndpointError::Connect("dial timed out".into())))?
         .map_err(|e| SyncFailure::Endpoint(EndpointError::Connect(e.to_string())))?;
@@ -139,7 +150,11 @@ pub async fn connect_and_sync<S: SyncStore + NodeAuth>(
     .await
     .map_err(SyncFailure::Auth)?;
     let report = run_session(store, send, recv).await.map_err(SyncFailure::Session)?;
-    // Best-effort graceful close; the session already exchanged an explicit Done both ways.
+    // The DIALER drives the close: our `run_session` returned only after reading the acceptor's
+    // finished streams, so closing now can't truncate our own read. The acceptor waits for this
+    // close (bounded) before closing its side, so any entries it streamed reach us first. The
+    // reverse (entries WE pushed that the acceptor is still reading) can still truncate on this
+    // close — bounded and self-healing (next cadence re-sends the diff); see issue #926.
     conn.close(0u32.into(), b"done");
     Ok(report)
 }
@@ -171,6 +186,16 @@ pub async fn accept_and_sync<S: SyncStore + NodeAuth>(
         .map_err(|_| SyncFailure::Endpoint(EndpointError::Connect("handshake timed out".into())))?
         .map_err(|e| SyncFailure::Endpoint(EndpointError::Connect(e.to_string())))?;
     let remote_node = *conn.remote_id().as_bytes();
+    // This single-stream acceptor serves ONLY the account-log ALPN. The endpoint binds the content
+    // ALPN too (for `accept_and_dispatch`), so a content client could negotiate it and land here —
+    // reject it rather than run a content connection against the account-log store.
+    if conn.alpn() != SYNC_ALPN {
+        conn.close(0u32.into(), b"wrong-alpn");
+        return Err(SyncFailure::Endpoint(EndpointError::Connect(format!(
+            "this acceptor serves only the account-log ALPN, got {:?}",
+            conn.alpn()
+        ))));
+    }
     let (mut send, mut recv) = timeout(DEFAULT_IDLE_TIMEOUT, conn.accept_bi())
         .await
         .map_err(|_| SyncFailure::Endpoint(EndpointError::Connect("peer opened no stream".into())))?
@@ -193,8 +218,94 @@ pub async fn accept_and_sync<S: SyncStore + NodeAuth>(
     .await
     .map_err(SyncFailure::Auth)?;
     let report = run_session(store, send, recv).await.map_err(SyncFailure::Session)?;
+    // As the ACCEPTOR we may have STREAMED entries the dialer is still reading; wait for the dialer
+    // to close first so those frames are delivered, then close (see `GRACEFUL_CLOSE_TIMEOUT`).
+    let _ = timeout(GRACEFUL_CLOSE_TIMEOUT, conn.closed()).await;
     conn.close(0u32.into(), b"done");
     Ok(report)
+}
+
+/// Accept ONE inbound connection and run the session for the STREAM the peer negotiated: the
+/// account log ([`SYNC_ALPN`] → `account_store`) or `/3` content ([`CONTENT_SYNC_ALPN`] →
+/// `content_store`). The auth phase is account-level — `account_store` provides the account id and
+/// the node binding for both — so only the post-auth session store differs by ALPN. `sync serve`
+/// loops this; the returned ALPN lets the caller log which stream ran. Shares the accept + auth
+/// shape with [`accept_and_sync`], which stays as the single-stream (account-log) form for callers
+/// that never serve content.
+pub async fn accept_and_dispatch<A, C>(
+    endpoint: &Endpoint,
+    account_store: &mut A,
+    content_store: &mut C,
+    policy: AuthPolicy,
+    now_ms: impl Fn() -> i64,
+) -> Result<(Vec<u8>, SessionReport), SyncFailure>
+where
+    A: SyncStore + NodeAuth,
+    C: SyncStore,
+{
+    // The two stores MUST be for the same account: the auth phase authorizes the peer against the
+    // account store's account, and a content connection then runs the content store — which would
+    // serve the WRONG account's content if they differed. Our callers always pass same-account
+    // stores; enforce it for the public generic API before any connection is accepted.
+    if account_store.account_id() != content_store.account_id() {
+        return Err(SyncFailure::Endpoint(EndpointError::Connect(
+            "account and content stores are for different accounts".into(),
+        )));
+    }
+    let local_node = *endpoint.id().as_bytes();
+    let incoming = endpoint
+        .accept()
+        .await
+        .ok_or_else(|| SyncFailure::Endpoint(EndpointError::Connect("endpoint closed".into())))?;
+    let conn = timeout(DEFAULT_IDLE_TIMEOUT, incoming)
+        .await
+        .map_err(|_| SyncFailure::Endpoint(EndpointError::Connect("handshake timed out".into())))?
+        .map_err(|e| SyncFailure::Endpoint(EndpointError::Connect(e.to_string())))?;
+    let remote_node = *conn.remote_id().as_bytes();
+    let alpn = conn.alpn().to_vec();
+    // Reject an unroutable ALPN BEFORE opening a stream or running auth — there is no reason to
+    // complete a mutual handshake for a stream we can't serve. Unreachable today (iroh's TLS
+    // refuses any ALPN `build_endpoint` didn't bind, and it binds exactly the two routed ones),
+    // but keeping the check ahead of auth means adding a third bound ALPN without a route here
+    // fails cleanly here instead of after the peer has completed authorization.
+    if alpn.as_slice() != SYNC_ALPN && alpn.as_slice() != CONTENT_SYNC_ALPN {
+        conn.close(0u32.into(), b"unknown-alpn");
+        return Err(SyncFailure::Endpoint(EndpointError::Connect(format!(
+            "peer negotiated an unknown ALPN {alpn:?}"
+        ))));
+    }
+    let (mut send, mut recv) = timeout(DEFAULT_IDLE_TIMEOUT, conn.accept_bi())
+        .await
+        .map_err(|_| SyncFailure::Endpoint(EndpointError::Connect("peer opened no stream".into())))?
+        .map_err(|e| SyncFailure::Endpoint(EndpointError::Connect(e.to_string())))?;
+    // Read the clock only now that a peer has connected (see `accept_and_sync`).
+    let now_ms = now_ms();
+    // The auth phase is store-agnostic (the binding is account-level), so authorize with the
+    // account store BEFORE any inventory — no stream leaves this peer until it passes the policy.
+    run_auth_phase(&mut send, &mut recv, &*account_store, AuthConfig {
+        role: AuthRole::Acceptor,
+        account_id: account_store.account_id(),
+        local_node,
+        remote_node,
+        policy,
+        now_ms,
+        pre_auth_timeout: DEFAULT_PRE_AUTH_TIMEOUT,
+    })
+    .await
+    .map_err(SyncFailure::Auth)?;
+    // Route the session to the store the negotiated ALPN names (validated to be one of the two
+    // routed ALPNs above, so the `else` is the content stream, not an unknown-ALPN fallthrough).
+    let report = if alpn.as_slice() == SYNC_ALPN {
+        run_session(account_store, send, recv).await
+    } else {
+        run_session(content_store, send, recv).await
+    }
+    .map_err(SyncFailure::Session)?;
+    // As the ACCEPTOR we may have STREAMED entries the dialer is still reading; wait for the dialer
+    // to close first so those frames are delivered, then close (see `GRACEFUL_CLOSE_TIMEOUT`).
+    let _ = timeout(GRACEFUL_CLOSE_TIMEOUT, conn.closed()).await;
+    conn.close(0u32.into(), b"done");
+    Ok((alpn, report))
 }
 
 /// A sync attempt that failed setting up the connection, authorizing the peer, or running the

--- a/crates/rag-rat-sync/src/lib.rs
+++ b/crates/rag-rat-sync/src/lib.rs
@@ -24,12 +24,12 @@ pub mod wire;
 
 pub use auth::{AuthConfig, AuthError, AuthPolicy, AuthRole, NodeAuth, run_auth_phase};
 pub use endpoint::{
-    EndpointError, SyncFailure, accept_and_sync, build_endpoint, connect_and_sync, endpoint_addr,
-    node_id_from_secret, peer_addr,
+    EndpointError, SyncFailure, accept_and_dispatch, accept_and_sync, build_endpoint,
+    connect_and_sync, endpoint_addr, node_id_from_secret, peer_addr,
 };
 pub use session::{
     DEFAULT_IDLE_TIMEOUT, Ingested, MAX_SESSION_ENTRIES, SessionError, SessionReport, SyncStore,
     run_session, run_session_with_idle_timeout,
 };
 pub use store::{OplogContentSyncStore, OplogSyncStore};
-pub use wire::{Frame, SYNC_ALPN, WireError};
+pub use wire::{CONTENT_SYNC_ALPN, Frame, SYNC_ALPN, WireError};

--- a/crates/rag-rat-sync/src/wire.rs
+++ b/crates/rag-rat-sync/src/wire.rs
@@ -13,11 +13,19 @@
 
 use minicbor::{Decoder, Encoder};
 
-/// The ALPN this protocol speaks. Versioned: a breaking wire change bumps the suffix so an old peer
-/// declines the handshake instead of misreading frames. Bumped to `/2` for the #881 auth phase (the
-/// `Auth` frame exchanged before any inventory) — a `/1` peer, which would stream its inventory
-/// without authenticating, must not interoperate.
+/// The ALPN for the ACCOUNT-LOG stream. Versioned: a breaking wire change bumps the suffix so an
+/// old peer declines the handshake instead of misreading frames. Bumped to `/2` for the #881 auth
+/// phase (the `Auth` frame exchanged before any inventory) — a `/1` peer, which would stream its
+/// inventory without authenticating, must not interoperate.
 pub const SYNC_ALPN: &[u8] = b"rag-rat/sync/2";
+
+/// The ALPN for the `/3` CONTENT stream — the memories themselves (#907). Same frame protocol and
+/// same account-level auth phase as [`SYNC_ALPN`]; only the STORE differs (`OplogContentSyncStore`
+/// vs `OplogSyncStore`). The stream is discriminated by the ALPN, not a frame field, so the
+/// acceptor picks the store from `conn.alpn()` and the account-log wire stays byte-identical. A
+/// peer that does not speak this ALPN simply never exchanges content — account-log sync is
+/// unaffected.
+pub const CONTENT_SYNC_ALPN: &[u8] = b"rag-rat/content/1";
 
 /// Domain tag committed into every frame's leading array element, so a frame from another protocol
 /// (or a truncated one) cannot be mistaken for a valid frame.
@@ -240,6 +248,16 @@ mod tests {
     fn roundtrip(frame: &Frame) {
         let bytes = frame.encode();
         assert_eq!(&Frame::decode(&bytes).unwrap(), frame, "encode∘decode is identity");
+    }
+
+    /// The ALPN identifiers are a frozen wire contract — an accidental rename would silently split
+    /// peers (an old peer declines the handshake). Pin both, and that they are distinct so the
+    /// acceptor can route account-log vs content by ALPN.
+    #[test]
+    fn alpn_identifiers_are_frozen() {
+        assert_eq!(SYNC_ALPN, b"rag-rat/sync/2");
+        assert_eq!(CONTENT_SYNC_ALPN, b"rag-rat/content/1");
+        assert_ne!(SYNC_ALPN, CONTENT_SYNC_ALPN);
     }
 
     #[test]

--- a/crates/rag-rat-sync/tests/oplog_sync.rs
+++ b/crates/rag-rat-sync/tests/oplog_sync.rs
@@ -363,7 +363,15 @@ async fn a_real_iroh_round_trip_restores_an_account() {
     let server =
         async { rag_rat_sync::accept_and_sync(&listener, &mut source_store, policy, || NOW).await };
     let client = async {
-        rag_rat_sync::connect_and_sync(&dialer, listener_addr, &mut dest_store, policy, NOW).await
+        rag_rat_sync::connect_and_sync(
+            &dialer,
+            listener_addr,
+            rag_rat_sync::SYNC_ALPN,
+            &mut dest_store,
+            policy,
+            NOW,
+        )
+        .await
     };
     let (server_r, client_r) = tokio::join!(server, client);
     server_r.unwrap();
@@ -371,6 +379,131 @@ async fn a_real_iroh_round_trip_restores_an_account() {
 
     let got = account_entries_for_sync(&dest, account_id).unwrap();
     assert_eq!(got.len(), want.len(), "the account restored over real iroh transport");
+}
+
+/// LIVE: content (`/3`) restores over the real iroh transport via ALPN dispatch (#907). One
+/// endpoint binds both ALPNs; the dialer syncs the account log (`SYNC_ALPN`) then content
+/// (`CONTENT_SYNC_ALPN`), and `accept_and_dispatch` routes each connection to the matching store.
+#[tokio::test]
+#[ignore = "live: binds iroh endpoints and dials over the relay"]
+async fn a_real_iroh_round_trip_restores_content_via_alpn_dispatch() {
+    use rag_rat_oplog::{
+        MemoryOp, NodeContent, NodeId, SealPolicy, author_content_batch, content_entries_for_sync,
+        ensure_owned_stream_v2_in_tx,
+    };
+    use rag_rat_sync::{CONTENT_SYNC_ALPN, OplogContentSyncStore, SYNC_ALPN};
+    use rusqlite::{Transaction, TransactionBehavior};
+
+    let relay = std::env::var("RAG_RAT_SYNC_RELAY").expect("set RAG_RAT_SYNC_RELAY to run this");
+
+    // Source: an account, an owned stream, two authored content entries.
+    let source = fresh_db();
+    let account_id = local_account(&source, NOW).unwrap();
+    let stream = {
+        let tx = Transaction::new_unchecked(&source, TransactionBehavior::Immediate).unwrap();
+        let s = ensure_owned_stream_v2_in_tx(&tx, "repo-a", NOW).unwrap();
+        tx.commit().unwrap();
+        s
+    };
+    let node = |id: &str, title: &str| MemoryOp::NodeCreate {
+        node_id: NodeId::from(id),
+        content: NodeContent {
+            kind: "Invariant".into(),
+            title: title.into(),
+            body: "body".into(),
+            confidence: "high".into(),
+            source: "agent".into(),
+            tags: Vec::new(),
+            payload: None,
+        },
+    };
+    author_content_batch(
+        &source,
+        stream,
+        &[node("n1", "first"), node("n2", "second")],
+        SealPolicy::Plaintext,
+        NOW,
+    )
+    .unwrap();
+    let want = content_entries_for_sync(&source, account_id).unwrap();
+    assert_eq!(want.len(), 2, "the source authored two content entries to move");
+
+    let dest = fresh_db();
+    let listener = rag_rat_sync::build_endpoint([3u8; 32], &relay).await.unwrap();
+    let dialer = rag_rat_sync::build_endpoint([4u8; 32], &relay).await.unwrap();
+    let listener_addr = rag_rat_sync::endpoint_addr(&listener);
+    let policy = rag_rat_sync::AuthPolicy::Open;
+
+    // Account log FIRST — carries the roster + stream ownership that authorize content acceptance.
+    {
+        let mut src_account = OplogSyncStore::new(&source, account_id, || NOW);
+        let mut src_content = OplogContentSyncStore::new(&source, account_id, || NOW);
+        let mut dst_account = OplogSyncStore::new(&dest, account_id, || NOW);
+        let server = async {
+            rag_rat_sync::accept_and_dispatch(
+                &listener,
+                &mut src_account,
+                &mut src_content,
+                policy,
+                || NOW,
+            )
+            .await
+        };
+        let client = async {
+            rag_rat_sync::connect_and_sync(
+                &dialer,
+                listener_addr.clone(),
+                SYNC_ALPN,
+                &mut dst_account,
+                policy,
+                NOW,
+            )
+            .await
+        };
+        let (server_r, client_r) = tokio::join!(server, client);
+        let (alpn, _) = server_r.unwrap();
+        assert_eq!(alpn, SYNC_ALPN, "the account-log connection routes to the account store");
+        client_r.unwrap();
+    }
+
+    // Content next — accepted now that its authority is present on the dest.
+    {
+        let mut src_account = OplogSyncStore::new(&source, account_id, || NOW);
+        let mut src_content = OplogContentSyncStore::new(&source, account_id, || NOW);
+        let mut dst_content = OplogContentSyncStore::new(&dest, account_id, || NOW);
+        let server = async {
+            rag_rat_sync::accept_and_dispatch(
+                &listener,
+                &mut src_account,
+                &mut src_content,
+                policy,
+                || NOW,
+            )
+            .await
+        };
+        let client = async {
+            rag_rat_sync::connect_and_sync(
+                &dialer,
+                listener_addr,
+                CONTENT_SYNC_ALPN,
+                &mut dst_content,
+                policy,
+                NOW,
+            )
+            .await
+        };
+        let (server_r, client_r) = tokio::join!(server, client);
+        let (alpn, _) = server_r.unwrap();
+        assert_eq!(alpn, CONTENT_SYNC_ALPN, "the content connection routes to the content store");
+        client_r.unwrap();
+    }
+
+    let got = content_entries_for_sync(&dest, account_id).unwrap();
+    assert_eq!(
+        got.len(),
+        want.len(),
+        "content restored over real iroh transport via ALPN dispatch"
+    );
 }
 
 /// A peer that offers a valid entry for a DIFFERENT account than the session is scoped to must not


### PR DESCRIPTION
Closes #907.

## What

A sync peer now replicates both the account op log **and** `/3` content. The two streams are distinguished by ALPN — one stream per connection — rather than an in-band frame discriminator:

- `SYNC_ALPN` (`rag-rat/sync/2`) → the account op log
- `CONTENT_SYNC_ALPN` (`rag-rat/content/1`) → `/3` content

`build_endpoint` now binds both. On accept, `conn.alpn()` (TLS-negotiated) selects the store: `accept_and_dispatch` routes the account-level auth phase against the account store, then runs the session against the account or content store per ALPN. `accept_and_sync` stays as the single-stream (account-log) acceptor and rejects any other ALPN. `connect_and_sync` takes the ALPN so the dialer picks the stream.

`sync serve` loops `accept_and_dispatch` and logs which stream ran. The device-side driver dials the account log first and, only on success, dials content — per-peer accounting stays `ok + errors == peers`.

## Why ALPN, not a frame type

- Account-log golden frames stay byte-identical.
- iroh dispatches natively on the negotiated ALPN.
- Auth is shared: the node binding is account-scoped and independent of which stream runs, so a connection authorizes once and then routes. Both stores impl `NodeAuth` via the same signing/authorization helpers. Content stays authority-inert on the receiver (parks, then settles) and re-verifies the roster key from the cited account entry on ingest, so foreign/forged content is rejected exactly like the local path.

## Connection teardown

A QUIC `close()` discards stream data not yet acknowledged, so a peer that just streamed entries must not close before the reader has drained them. Teardown is now asymmetric: the dialer drives the close (its session returned only after reading the acceptor's finished streams), and each acceptor waits — bounded — for the dialer to close first, so streamed frames are delivered before it closes its side. This removes an intermittent `ConnectionLost` on restore. The reverse (push) direction has a narrower, self-healing residual tracked in #926.

## Verification

- fmt; clippy `--no-default-features`, `--all-features`, and the eval feature combo, all `-D warnings`
- full workspace tests green; new frozen-ALPN golden test pins both identifiers and asserts they differ
- two live iroh round-trip tests (account restore, content-via-ALPN-dispatch) pass repeatedly over the relay