### PR TITLE
chore(deps): update vulnerable npm dependencies

### DIFF
--- a/cookbook/package-lock.json
+++ b/cookbook/package-lock.json
@@ -1245,9 +1245,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.6.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
-      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/tools/oracle-toolchain/package-lock.json
+++ b/tools/oracle-toolchain/package-lock.json
@@ -182,9 +182,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",


### PR DESCRIPTION
## Summary

- update `brace-expansion` from 1.1.15 to 1.1.16 in the oracle toolchain lockfile
- update `protobufjs` from 7.6.4 to 7.6.5 in the cookbook lockfile
- refresh only the affected resolved URLs and integrity hashes

## Verification

- `npm ci --ignore-scripts` (`tools/oracle-toolchain`)
- `npm ci --ignore-scripts` (`cookbook`)
- `npm run typecheck` (`cookbook`)
- `npm test` (`cookbook`, 11 passed)