### PR TITLE
fix(deps): override vulnerable brace-expansion

### DIFF
--- a/tools/oracle-toolchain/package-lock.json
+++ b/tools/oracle-toolchain/package-lock.json
@@ -176,19 +176,24 @@
       "license": "MIT"
     },
     "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "license": "MIT"
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/command-exists": {
@@ -205,12 +210,6 @@
       "engines": {
         "node": "^12.20.0 || >=14"
       }
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "license": "MIT"
     },
     "node_modules/create-require": {
       "version": "1.1.1",

--- a/tools/oracle-toolchain/package.json
+++ b/tools/oracle-toolchain/package.json
@@ -6,5 +6,8 @@
   "dependencies": {
     "@sourcegraph/scip-typescript": "0.4.0",
     "@sourcegraph/scip-python": "0.6.6"
+  },
+  "overrides": {
+    "brace-expansion": "5.0.8"
   }
 }


### PR DESCRIPTION
## Summary

- override the `@sourcegraph/scip-python` transitive dependency chain to use `brace-expansion` 5.0.8
- refresh `balanced-match` to the compatible 4.x line and remove the obsolete `concat-map` dependency
- clear GHSA-mh99-v99m-4gvg from the oracle toolchain audit

## Verification

- `npm ci --ignore-scripts`
- `npm audit` (0 vulnerabilities)
- `scip-python --version` (0.6.6)
- `scip-python --help`
- indexed `tests/fixtures/held-mini/src/Main.py` into a non-empty SCIP file with the overridden dependency tree