### PR TITLE
refactor(edges): capture identifier paths once

### DIFF
--- a/crates/rag-rat-core/src/index/edges/helpers.rs
+++ b/crates/rag-rat-core/src/index/edges/helpers.rs
@@ -39,12 +39,6 @@ pub(crate) fn target_qualified_name(node: Node<'_>, text: &str) -> Option<String
     let value = strip_generics(&node_text(function, text));
     (value.contains("::") || value.contains('.')).then(|| value.replace('.', "::"))
 }
-pub(crate) fn dotted_qualified_name(identifiers: &[String]) -> Option<String> {
-    (identifiers.len() > 1).then(|| identifiers.join("::"))
-}
-pub(crate) fn c_like_qualified_name(identifiers: &[String]) -> Option<String> {
-    (identifiers.len() > 1).then(|| identifiers.join("::"))
-}
 /// The smallest-span symbol whose byte range covers `byte` (a call/reference site's owner). When
 /// that smallest is a `const`/`property`/`static` — a value binding whose initializer is where the
 /// call actually lives, so the enclosing definition is the better owner — the smallest-span
@@ -145,28 +139,109 @@ pub(crate) fn first_identifier_text(node: Node<'_>, text: &str) -> Option<String
 pub(crate) fn last_identifier_text(node: Node<'_>, text: &str) -> Option<String> {
     identifiers_under(node, text).into_iter().last()
 }
-pub(crate) fn identifiers_under(node: Node<'_>, text: &str) -> Vec<String> {
-    let mut out = Vec::new();
-    collect_identifiers(node, text, &mut out);
-    out
+
+/// An identifier token captured together with the source text at that exact node.
+///
+/// Keeping both representations in one segment prevents callers from walking a subtree twice and
+/// relying on two parallel vectors to stay positionally aligned.
+pub(crate) struct IdentifierSegment<'tree> {
+    node: Node<'tree>,
+    text: String,
 }
-pub(crate) fn collect_identifiers(node: Node<'_>, text: &str, out: &mut Vec<String>) {
+
+/// The identifier tokens below one syntax node, in document order.
+pub(crate) struct IdentifierPath<'tree> {
+    segments: Vec<IdentifierSegment<'tree>>,
+}
+
+impl<'tree> IdentifierPath<'tree> {
+    pub(crate) fn under(node: Node<'tree>, text: &str) -> Self {
+        let mut segments = Vec::new();
+        collect_identifier_segments(node, text, &mut segments);
+        Self { segments }
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.segments.len()
+    }
+
+    pub(crate) fn first_text(&self) -> Option<&str> {
+        self.segments.first().map(|segment| segment.text.as_str())
+    }
+
+    pub(crate) fn last_text(&self) -> Option<&str> {
+        self.segments.last().map(|segment| segment.text.as_str())
+    }
+
+    pub(crate) fn first_node(&self) -> Option<Node<'tree>> {
+        self.segments.first().map(|segment| segment.node)
+    }
+
+    pub(crate) fn last_node(&self) -> Option<Node<'tree>> {
+        self.segments.last().map(|segment| segment.node)
+    }
+
+    pub(crate) fn qualified_name(&self) -> Option<String> {
+        (self.segments.len() > 1).then(|| {
+            self.segments.iter().map(|segment| segment.text.as_str()).collect::<Vec<_>>().join("::")
+        })
+    }
+
+    fn into_texts(self) -> Vec<String> {
+        self.segments.into_iter().map(|segment| segment.text).collect()
+    }
+}
+
+fn collect_identifier_segments<'tree>(
+    node: Node<'tree>,
+    text: &str,
+    out: &mut Vec<IdentifierSegment<'tree>>,
+) {
     if is_identifier_kind(node.kind()) {
         if let Ok(value) = node.utf8_text(text.as_bytes())
             && !value.is_empty()
         {
-            out.push(value.to_string());
+            out.push(IdentifierSegment { node, text: value.to_string() });
         }
         return;
     }
-    // grow_stack: full-subtree recursion; grow rather than overflow on a hostile deep subtree
-    // (#543).
+    // grow_stack: full-subtree recursion; keep the same hostile-input guard as the legacy
+    // text-only and node-only collectors.
     rag_rat_base::stack::grow_stack(|| {
         let mut cursor = node.walk();
         for child in node.named_children(&mut cursor) {
-            collect_identifiers(child, text, out);
+            collect_identifier_segments(child, text, out);
         }
     });
+}
+
+#[cfg(test)]
+mod identifier_path_tests {
+    use super::*;
+
+    #[test]
+    fn captures_text_and_nodes_in_one_ordered_path() {
+        let source = "client.api.run();";
+        let mut parser = tree_sitter::Parser::new();
+        parser.set_language(&tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into()).unwrap();
+        let tree = parser.parse(source, None).unwrap();
+        let statement = tree.root_node().named_child(0).unwrap();
+        let call = statement.named_child(0).unwrap();
+        let callee = call.child_by_field_name("function").unwrap();
+
+        let path = IdentifierPath::under(callee, source);
+
+        assert_eq!(path.len(), 3);
+        assert_eq!(path.first_text(), Some("client"));
+        assert_eq!(path.last_text(), Some("run"));
+        assert_eq!(path.qualified_name().as_deref(), Some("client::api::run"));
+        let last = path.last_node().unwrap();
+        assert_eq!(&source[last.byte_range()], "run");
+    }
+}
+
+pub(crate) fn identifiers_under(node: Node<'_>, text: &str) -> Vec<String> {
+    IdentifierPath::under(node, text).into_texts()
 }
 /// Node-returning twin of [`first_identifier_text`]: the first identifier-kind node in document
 /// order, so its byte range can be recorded for the SCIP join (#67). Same traversal, so the node it

--- a/crates/rag-rat-core/src/index/languages/c_family/edges.rs
+++ b/crates/rag-rat-core/src/index/languages/c_family/edges.rs
@@ -34,10 +34,11 @@ pub(super) fn c_like_edges(
         },
         "call_expression" => {
             let function = node.child_by_field_name("function").unwrap_or(node);
-            let identifiers = identifiers_under(function, text);
-            // Parallel to `identifiers` so the callee `.last()` node matches the string pick (#67).
-            let identifier_nodes = identifier_nodes_under(function);
-            if let Some(name) = identifiers.last().cloned().or_else(|| call_target_name(node, text))
+            let identifiers = IdentifierPath::under(function, text);
+            if let Some(name) = identifiers
+                .last_text()
+                .map(ToOwned::to_owned)
+                .or_else(|| call_target_name(node, text))
             {
                 out.push(symbol_edge_with_context(
                     symbols,
@@ -47,13 +48,13 @@ pub(super) fn c_like_edges(
                     EdgeKind::CallsName,
                     EdgeConfidence::NameOnly,
                     EdgeContext {
-                        target_qualified_name: c_like_qualified_name(&identifiers),
+                        target_qualified_name: identifiers.qualified_name(),
                         receiver_hint: identifiers
-                            .first()
+                            .first_text()
                             .filter(|_| identifiers.len() > 1)
-                            .cloned(),
+                            .map(ToOwned::to_owned),
                     },
-                    identifier_nodes.last().copied().map(CalleeRange::of_node),
+                    identifiers.last_node().map(CalleeRange::of_node),
                 ));
             }
         },

--- a/crates/rag-rat-core/src/index/languages/kotlin/edges.rs
+++ b/crates/rag-rat-core/src/index/languages/kotlin/edges.rs
@@ -27,12 +27,11 @@ pub(super) fn kotlin_edges(
             }
         },
         "call_expression" => {
-            let identifiers = identifiers_under(node, text);
-            // Parallel to `identifiers` (same node, same traversal order) so the callee `.last()`
-            // and receiver/constructor `.first()` nodes line up with the string picks (#67).
-            let identifier_nodes = identifier_nodes_under(node);
-            if let Some(name) =
-                identifiers.last().cloned().or_else(|| first_identifier_text(node, text))
+            let identifiers = IdentifierPath::under(node, text);
+            if let Some(name) = identifiers
+                .last_text()
+                .map(ToOwned::to_owned)
+                .or_else(|| first_identifier_text(node, text))
             {
                 out.push(symbol_edge_with_context(
                     symbols,
@@ -42,35 +41,38 @@ pub(super) fn kotlin_edges(
                     EdgeKind::CallsName,
                     EdgeConfidence::NameOnly,
                     EdgeContext {
-                        target_qualified_name: dotted_qualified_name(&identifiers),
+                        target_qualified_name: identifiers.qualified_name(),
                         receiver_hint: identifiers
-                            .first()
+                            .first_text()
                             .filter(|_| identifiers.len() > 1)
-                            .cloned(),
+                            .map(ToOwned::to_owned),
                     },
-                    identifier_nodes.last().copied().map(CalleeRange::of_node),
+                    identifiers.last_node().map(CalleeRange::of_node),
                 ));
             }
-            if let Some(receiver) = identifiers.first().filter(|_| identifiers.len() > 1).cloned() {
+            if let Some(receiver) =
+                identifiers.first_text().filter(|_| identifiers.len() > 1).map(ToOwned::to_owned)
+            {
                 out.push(symbol_edge(
                     symbols,
                     node,
                     receiver,
                     EdgeKind::ReferencesType,
                     EdgeConfidence::NameOnly,
-                    identifier_nodes
-                        .first()
-                        .filter(|_| identifier_nodes.len() > 1)
-                        .copied()
+                    identifiers
+                        .first_node()
+                        .filter(|_| identifiers.len() > 1)
                         .map(CalleeRange::of_node),
                 ));
             }
-            if let Some(constructor) =
-                identifiers.first().filter(|name| looks_like_type_name(name)).cloned()
+            if let Some(constructor) = identifiers
+                .first_text()
+                .filter(|name| looks_like_type_name(name))
+                .map(ToOwned::to_owned)
             {
                 // Both the type reference and the construct point at the constructor — the FIRST
                 // identifier (matching `identifiers.first()`).
-                let constructor_range = identifier_nodes.first().copied().map(CalleeRange::of_node);
+                let constructor_range = identifiers.first_node().map(CalleeRange::of_node);
                 out.push(symbol_edge(
                     symbols,
                     node,

--- a/crates/rag-rat-core/src/index/languages/python/edges.rs
+++ b/crates/rag-rat-core/src/index/languages/python/edges.rs
@@ -86,14 +86,13 @@ pub(super) fn python_edges(
         // resolving it is the oracle's job, not the heuristic's).
         "call" => {
             let function = node.child_by_field_name("function").unwrap_or(node);
-            let identifiers = identifiers_under(function, text);
-            let identifier_nodes = identifier_nodes_under(function);
+            let identifiers = IdentifierPath::under(function, text);
             // `handlers[key]()` — the callee is the subscript RESULT, not the index variable
             // `last()` would pick. There's no clean callee identifier, so emit nothing (a wrong
             // `calls_name key` is worse than a missing edge).
             if function.kind() == "subscript" {
                 // fall through to recursion without emitting a call edge
-            } else if let Some(name) = identifiers.last().cloned() {
+            } else if let Some(name) = identifiers.last_text().map(ToOwned::to_owned) {
                 out.push(symbol_edge_with_context(
                     symbols,
                     node,
@@ -102,13 +101,13 @@ pub(super) fn python_edges(
                     EdgeKind::CallsName,
                     EdgeConfidence::NameOnly,
                     EdgeContext {
-                        target_qualified_name: dotted_qualified_name(&identifiers),
+                        target_qualified_name: identifiers.qualified_name(),
                         receiver_hint: identifiers
-                            .first()
+                            .first_text()
                             .filter(|_| identifiers.len() > 1)
-                            .cloned(),
+                            .map(ToOwned::to_owned),
                     },
-                    identifier_nodes.last().copied().map(CalleeRange::of_node),
+                    identifiers.last_node().map(CalleeRange::of_node),
                 ));
             }
         },
@@ -178,12 +177,14 @@ pub(super) fn python_edges(
         "decorator" => {
             if let Some(inner) = node.named_child(0)
                 && matches!(inner.kind(), "identifier" | "attribute")
-                && let Some(name) = last_identifier_text(inner, text)
             {
+                let identifiers = IdentifierPath::under(inner, text);
+                let Some(name) = identifiers.last_text().map(ToOwned::to_owned) else {
+                    return;
+                };
                 // Preserve the qualifier so a qualified decorator (`@pytest.fixture`) carries its
                 // `pytest` receiver + dotted path — same context the call arm records — so the
                 // resolver doesn't fall back to a bare local `fixture` of the same name.
-                let identifiers = identifiers_under(inner, text);
                 out.push(symbol_edge_with_context(
                     symbols,
                     node,
@@ -192,13 +193,13 @@ pub(super) fn python_edges(
                     EdgeKind::CallsName,
                     EdgeConfidence::NameOnly,
                     EdgeContext {
-                        target_qualified_name: dotted_qualified_name(&identifiers),
+                        target_qualified_name: identifiers.qualified_name(),
                         receiver_hint: identifiers
-                            .first()
+                            .first_text()
                             .filter(|_| identifiers.len() > 1)
-                            .cloned(),
+                            .map(ToOwned::to_owned),
                     },
-                    last_identifier_node(inner).map(final_segment_node).map(CalleeRange::of_node),
+                    identifiers.last_node().map(final_segment_node).map(CalleeRange::of_node),
                 ));
             }
         },
@@ -252,13 +253,13 @@ fn emit_python_type_refs(
         // for `User` resolves `User::Inner`, not bare `Inner` (#174 review). Without the
         // qualified name the rebind would have nothing to rewrite and resolution would fall
         // back to the ambiguous bare tail.
-        "attribute" | "dotted_name" =>
-            if let Some(name) = last_identifier_text(node, text) {
-                let identifiers = identifiers_under(node, text);
+        "attribute" | "dotted_name" => {
+            let identifiers = IdentifierPath::under(node, text);
+            if let Some(name) = identifiers.last_text().map(ToOwned::to_owned) {
                 let receiver = node
                     .child_by_field_name("object")
                     .map(|object| node_text(object, text))
-                    .or_else(|| identifiers.first().cloned());
+                    .or_else(|| identifiers.first_text().map(ToOwned::to_owned));
                 out.push(symbol_edge_with_context(
                     symbols,
                     node,
@@ -268,11 +269,12 @@ fn emit_python_type_refs(
                     EdgeConfidence::NameOnly,
                     EdgeContext {
                         receiver_hint: receiver,
-                        target_qualified_name: dotted_qualified_name(&identifiers),
+                        target_qualified_name: identifiers.qualified_name(),
                     },
-                    last_identifier_node(node).map(final_segment_node).map(CalleeRange::of_node),
+                    identifiers.last_node().map(final_segment_node).map(CalleeRange::of_node),
                 ));
-            },
+            }
+        },
         _ => {},
     }
 }

--- a/crates/rag-rat-core/src/index/languages/typescript/edges.rs
+++ b/crates/rag-rat-core/src/index/languages/typescript/edges.rs
@@ -38,11 +38,11 @@ pub(super) fn typescript_edges(
             },
         "call_expression" | "new_expression" => {
             let function = node.child_by_field_name("function").unwrap_or(node);
-            let identifiers = identifiers_under(function, text);
-            // Parallel to `identifiers` (same traversal order), so `.last()`/`.first()` pick the
-            // node for the same token the string Vec does (#67).
-            let identifier_nodes = identifier_nodes_under(function);
-            if let Some(name) = identifiers.last().cloned().or_else(|| call_target_name(node, text))
+            let identifiers = IdentifierPath::under(function, text);
+            if let Some(name) = identifiers
+                .last_text()
+                .map(ToOwned::to_owned)
+                .or_else(|| call_target_name(node, text))
             {
                 let edge_kind = if node.kind() == "new_expression" {
                     EdgeKind::Constructs
@@ -57,17 +57,18 @@ pub(super) fn typescript_edges(
                     edge_kind,
                     EdgeConfidence::NameOnly,
                     EdgeContext {
-                        target_qualified_name: dotted_qualified_name(&identifiers),
+                        target_qualified_name: identifiers.qualified_name(),
                         receiver_hint: identifiers
-                            .first()
+                            .first_text()
                             .filter(|_| identifiers.len() > 1)
-                            .cloned(),
+                            .map(ToOwned::to_owned),
                     },
-                    // The callee is the final segment — `.last()`, matching `identifiers.last()`.
-                    identifier_nodes.last().copied().map(CalleeRange::of_node),
+                    identifiers.last_node().map(CalleeRange::of_node),
                 ));
             }
-            if let Some(receiver) = identifiers.first().filter(|_| identifiers.len() > 1).cloned() {
+            if let Some(receiver) =
+                identifiers.first_text().filter(|_| identifiers.len() > 1).map(ToOwned::to_owned)
+            {
                 out.push(symbol_edge(
                     symbols,
                     node,
@@ -76,10 +77,9 @@ pub(super) fn typescript_edges(
                     EdgeConfidence::NameOnly,
                     // The type is the receiver — the FIRST segment, matching
                     // `identifiers.first()`.
-                    identifier_nodes
-                        .first()
-                        .filter(|_| identifier_nodes.len() > 1)
-                        .copied()
+                    identifiers
+                        .first_node()
+                        .filter(|_| identifiers.len() > 1)
                         .map(CalleeRange::of_node),
                 ));
             }


### PR DESCRIPTION
## Summary

- capture identifier text and its tree-sitter node in one ordered `IdentifierPath`
- derive qualified names, receiver hints, and SCIP callee ranges from the same segments
- migrate C/C++, Kotlin, Python, and TypeScript away from parallel subtree walks

This removes the positional-alignment invariant between separate text and node vectors while preserving emitted edge behavior.

Fixes #936.

## Validation

- `cargo +nightly fmt --check`
- `cargo check -p rag-rat-core --all-targets`
- `cargo clippy -p rag-rat-core --all-targets -- -D warnings`
- `cargo nextest run -p rag-rat-core` — 1,582 passed