### PR TITLE
refactor(edges): add typed extraction context

### DIFF
--- a/crates/rag-rat-core/src/index/edges/extract/mod.rs
+++ b/crates/rag-rat-core/src/index/edges/extract/mod.rs
@@ -148,6 +148,8 @@ pub(crate) fn collect_edges(
     let Some(backend) = crate::index::languages::edge_backend(language) else {
         return;
     };
+    let context = EdgeExtractionContext { text, symbols, path };
+    let mut emit = EdgeEmitter { out };
     let mut stack = vec![root];
     let mut cursor = root.walk();
     let mut named_children = Vec::new();
@@ -155,12 +157,47 @@ pub(crate) fn collect_edges(
         if node.is_error() || node.is_missing() {
             continue;
         }
-        backend.edges(text, node, symbols, path, out);
+        backend.edges(context.visit(node), &mut emit);
         named_children.clear();
         named_children.extend(node.named_children(&mut cursor));
         for &child in named_children.iter().rev() {
             stack.push(child);
         }
+    }
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct EdgeExtractionContext<'source> {
+    text: &'source str,
+    symbols: &'source [IndexedSymbol],
+    path: &'source Path,
+}
+
+impl<'source> EdgeExtractionContext<'source> {
+    fn visit<'tree>(&self, node: Node<'tree>) -> EdgeVisit<'tree, 'source> {
+        EdgeVisit { text: self.text, node, symbols: self.symbols, path: self.path }
+    }
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct EdgeVisit<'tree, 'source> {
+    pub(crate) text: &'source str,
+    pub(crate) node: Node<'tree>,
+    pub(crate) symbols: &'source [IndexedSymbol],
+    pub(crate) path: &'source Path,
+}
+
+pub(crate) struct EdgeEmitter<'out> {
+    out: &'out mut Vec<EdgeCandidate>,
+}
+
+impl EdgeEmitter<'_> {
+    pub(crate) fn push(&mut self, candidate: EdgeCandidate) {
+        self.out.push(candidate);
+    }
+
+    pub(crate) fn iter(&self) -> impl Iterator<Item = &EdgeCandidate> {
+        self.out.iter()
     }
 }
 

--- a/crates/rag-rat-core/src/index/languages/c_family/edges.rs
+++ b/crates/rag-rat-core/src/index/languages/c_family/edges.rs
@@ -1,18 +1,12 @@
 //! C and C++ graph-edge extraction for the shared structural edge walk.
-use std::path::Path;
-
-use tree_sitter::Node;
-
 use crate::index::edges::extract::*;
 use crate::index::edges::*;
 
 pub(super) fn c_like_edges(
-    text: &str,
-    node: Node<'_>,
-    symbols: &[IndexedSymbol],
-    path: &Path,
-    out: &mut Vec<EdgeCandidate>,
+    EdgeVisit { text, node, symbols, path }: EdgeVisit<'_, '_>,
+    emit: &mut EdgeEmitter<'_>,
 ) {
+    let out = emit;
     match node.kind() {
         "preproc_include" => {
             let include = node_text(node, text)

--- a/crates/rag-rat-core/src/index/languages/c_family/mod.rs
+++ b/crates/rag-rat-core/src/index/languages/c_family/mod.rs
@@ -2,8 +2,7 @@ use std::path::Path;
 
 use tree_sitter::Node;
 
-use super::{EdgeBackend, ParserBackend, ResolverPolicy, SymbolMatch};
-use crate::index::edges::{EdgeCandidate, IndexedSymbol};
+use super::{EdgeBackend, EdgeEmitter, EdgeVisit, ParserBackend, ResolverPolicy, SymbolMatch};
 use crate::index::parser::{self, ParserKind};
 
 mod edges;
@@ -107,15 +106,8 @@ fn function_name(node: Node<'_>) -> Option<Node<'_>> {
 macro_rules! impl_edges {
     ($backend:ty) => {
         impl EdgeBackend for $backend {
-            fn edges(
-                &self,
-                text: &str,
-                node: Node<'_>,
-                symbols: &[IndexedSymbol],
-                path: &Path,
-                out: &mut Vec<EdgeCandidate>,
-            ) {
-                edges::c_like_edges(text, node, symbols, path, out);
+            fn edges(&self, visit: EdgeVisit<'_, '_>, emit: &mut EdgeEmitter<'_>) {
+                edges::c_like_edges(visit, emit);
             }
         }
     };

--- a/crates/rag-rat-core/src/index/languages/kotlin/edges.rs
+++ b/crates/rag-rat-core/src/index/languages/kotlin/edges.rs
@@ -1,18 +1,12 @@
 //! Kotlin graph-edge extraction for the shared structural edge walk.
-use std::path::Path;
-
-use tree_sitter::Node;
-
 use crate::index::edges::extract::*;
 use crate::index::edges::*;
 
 pub(super) fn kotlin_edges(
-    text: &str,
-    node: Node<'_>,
-    symbols: &[IndexedSymbol],
-    path: &Path,
-    out: &mut Vec<EdgeCandidate>,
+    EdgeVisit { text, node, symbols, path }: EdgeVisit<'_, '_>,
+    emit: &mut EdgeEmitter<'_>,
 ) {
+    let out = emit;
     match node.kind() {
         "import" | "import_header" | "import_directive" => {
             for name in identifiers_under(node, text) {

--- a/crates/rag-rat-core/src/index/languages/kotlin/mod.rs
+++ b/crates/rag-rat-core/src/index/languages/kotlin/mod.rs
@@ -2,8 +2,7 @@ use std::path::Path;
 
 use tree_sitter::Node;
 
-use super::{EdgeBackend, ParserBackend, ResolverPolicy, SymbolMatch};
-use crate::index::edges::{EdgeCandidate, IndexedSymbol};
+use super::{EdgeBackend, EdgeEmitter, EdgeVisit, ParserBackend, ResolverPolicy, SymbolMatch};
 use crate::index::parser::{self, ParserKind};
 
 mod edges;
@@ -100,15 +99,8 @@ fn variable_declaration(node: Node<'_>) -> Option<Node<'_>> {
 }
 
 impl EdgeBackend for Kotlin {
-    fn edges(
-        &self,
-        text: &str,
-        node: Node<'_>,
-        symbols: &[IndexedSymbol],
-        path: &Path,
-        out: &mut Vec<EdgeCandidate>,
-    ) {
-        edges::kotlin_edges(text, node, symbols, path, out);
+    fn edges(&self, visit: EdgeVisit<'_, '_>, emit: &mut EdgeEmitter<'_>) {
+        edges::kotlin_edges(visit, emit);
     }
 }
 

--- a/crates/rag-rat-core/src/index/languages/mod.rs
+++ b/crates/rag-rat-core/src/index/languages/mod.rs
@@ -11,7 +11,7 @@ use std::path::Path;
 use rag_rat_base::language::Language;
 use tree_sitter::Node;
 
-use super::edges::{EdgeCandidate, IndexedSymbol};
+pub(super) use super::edges::extract::{EdgeEmitter, EdgeVisit};
 use super::parser::ParserKind;
 
 mod c_family;
@@ -85,14 +85,7 @@ pub(super) trait ParserBackend: Sync {
 
 /// Grammar-specific edge recognition for one node visited by the shared depth-safe edge walk.
 pub(super) trait EdgeBackend: Sync {
-    fn edges(
-        &self,
-        text: &str,
-        node: Node<'_>,
-        symbols: &[IndexedSymbol],
-        path: &Path,
-        out: &mut Vec<EdgeCandidate>,
-    );
+    fn edges(&self, visit: EdgeVisit<'_, '_>, emit: &mut EdgeEmitter<'_>);
 }
 
 #[derive(Clone, Copy)]

--- a/crates/rag-rat-core/src/index/languages/python/edges.rs
+++ b/crates/rag-rat-core/src/index/languages/python/edges.rs
@@ -9,12 +9,10 @@ use crate::index::edges::extract::*;
 use crate::index::edges::*;
 
 pub(super) fn python_edges(
-    text: &str,
-    node: Node<'_>,
-    symbols: &[IndexedSymbol],
-    path: &Path,
-    out: &mut Vec<EdgeCandidate>,
+    EdgeVisit { text, node, symbols, path }: EdgeVisit<'_, '_>,
+    emit: &mut EdgeEmitter<'_>,
 ) {
+    let out = emit;
     match node.kind() {
         // `from <module> import <name|name as alias>, ...` — emit Imports edges to the MODULE and
         // to each imported NAME, never the local alias. A relative import (`.sessions`)
@@ -221,7 +219,7 @@ fn emit_python_type_refs(
     node: Node<'_>,
     symbols: &[IndexedSymbol],
     text: &str,
-    out: &mut Vec<EdgeCandidate>,
+    out: &mut EdgeEmitter<'_>,
 ) {
     match node.kind() {
         "type" | "generic_type" | "subscript" | "binary_operator" | "list" | "tuple"
@@ -518,7 +516,7 @@ fn python_import_target(
     record_alias: bool,
     import_start: usize,
     module_root: Option<Node<'_>>,
-    out: &mut Vec<EdgeCandidate>,
+    out: &mut EdgeEmitter<'_>,
 ) {
     if child.kind() == "import_list" {
         // grow_stack: uniform depth guard for a tree descender (#543); `import_list` doesn't nest

--- a/crates/rag-rat-core/src/index/languages/python/mod.rs
+++ b/crates/rag-rat-core/src/index/languages/python/mod.rs
@@ -3,10 +3,9 @@ use std::path::Path;
 use tree_sitter::Node;
 
 use super::{
-    EdgeBackend, ImportAliasRebind, ImportAliasRequest, KindPreference, ParserBackend,
-    ResolverPolicy, SymbolMatch,
+    EdgeBackend, EdgeEmitter, EdgeVisit, ImportAliasRebind, ImportAliasRequest, KindPreference,
+    ParserBackend, ResolverPolicy, SymbolMatch,
 };
-use crate::index::edges::{EdgeCandidate, IndexedSymbol};
 use crate::index::parser::{self, ParserKind};
 
 mod edges;
@@ -122,15 +121,8 @@ fn assignment_is_const_scope(node: Node<'_>) -> bool {
 }
 
 impl EdgeBackend for Python {
-    fn edges(
-        &self,
-        text: &str,
-        node: Node<'_>,
-        symbols: &[IndexedSymbol],
-        path: &Path,
-        out: &mut Vec<EdgeCandidate>,
-    ) {
-        edges::python_edges(text, node, symbols, path, out);
+    fn edges(&self, visit: EdgeVisit<'_, '_>, emit: &mut EdgeEmitter<'_>) {
+        edges::python_edges(visit, emit);
     }
 }
 

--- a/crates/rag-rat-core/src/index/languages/rust/dispatch.rs
+++ b/crates/rag-rat-core/src/index/languages/rust/dispatch.rs
@@ -6,6 +6,7 @@
 //! false-edge-is-a-bug contract is documented in the repo memories bound here and on the parent.
 use tree_sitter::Node;
 
+use crate::index::edges::extract::EdgeEmitter;
 use crate::index::edges::*;
 
 /// PascalCase test for the enum/variant convention (#200): first char uppercase AND at least one
@@ -665,7 +666,7 @@ pub(super) fn rust_dispatch_handle_facts(
     text: &str,
     node: Node<'_>,
     symbols: &[IndexedSymbol],
-    out: &mut Vec<EdgeCandidate>,
+    out: &mut EdgeEmitter<'_>,
 ) {
     let Some(pattern) = node.child_by_field_name("pattern") else {
         return;

--- a/crates/rag-rat-core/src/index/languages/rust/edges.rs
+++ b/crates/rag-rat-core/src/index/languages/rust/edges.rs
@@ -1,7 +1,5 @@
 //! Rust graph-edge extraction for the shared structural edge walk. It recognizes calls, types,
 //! constructions, imports, impl headers, and dispatch facts.
-use std::path::Path;
-
 use tree_sitter::Node;
 
 use super::dispatch;
@@ -9,12 +7,10 @@ use crate::index::edges::extract::*;
 use crate::index::edges::*;
 
 pub(super) fn rust_edges(
-    text: &str,
-    node: Node<'_>,
-    symbols: &[IndexedSymbol],
-    path: &Path,
-    out: &mut Vec<EdgeCandidate>,
+    EdgeVisit { text, node, symbols, path }: EdgeVisit<'_, '_>,
+    emit: &mut EdgeEmitter<'_>,
 ) {
+    let out = emit;
     match node.kind() {
         "use_declaration" => {
             let names = identifiers_under(node, text);
@@ -208,7 +204,7 @@ pub(super) fn rust_impl_edges(
     text: &str,
     node: Node<'_>,
     symbols: &[IndexedSymbol],
-    out: &mut Vec<EdgeCandidate>,
+    out: &mut EdgeEmitter<'_>,
 ) {
     let node_text = node_text(node, text);
     let header = node_text.split('{').next().unwrap_or_default();

--- a/crates/rag-rat-core/src/index/languages/rust/mod.rs
+++ b/crates/rag-rat-core/src/index/languages/rust/mod.rs
@@ -2,8 +2,7 @@ use std::path::Path;
 
 use tree_sitter::Node;
 
-use super::{EdgeBackend, ParserBackend, ResolverPolicy, SymbolMatch};
-use crate::index::edges::{EdgeCandidate, IndexedSymbol};
+use super::{EdgeBackend, EdgeEmitter, EdgeVisit, ParserBackend, ResolverPolicy, SymbolMatch};
 use crate::index::parser::{self, ParsedSymbolFact, ParserKind};
 
 mod dispatch;
@@ -133,15 +132,8 @@ fn attribute_items(text: &str, node: Node<'_>) -> Vec<String> {
 }
 
 impl EdgeBackend for Rust {
-    fn edges(
-        &self,
-        text: &str,
-        node: Node<'_>,
-        symbols: &[IndexedSymbol],
-        path: &Path,
-        out: &mut Vec<EdgeCandidate>,
-    ) {
-        edges::rust_edges(text, node, symbols, path, out);
+    fn edges(&self, visit: EdgeVisit<'_, '_>, emit: &mut EdgeEmitter<'_>) {
+        edges::rust_edges(visit, emit);
     }
 }
 

--- a/crates/rag-rat-core/src/index/languages/swift/edges.rs
+++ b/crates/rag-rat-core/src/index/languages/swift/edges.rs
@@ -1,7 +1,5 @@
 //! Swift graph-edge extraction for the shared structural edge walk.
 
-use std::path::Path;
-
 use tree_sitter::Node;
 
 use super::syntax;
@@ -9,12 +7,10 @@ use crate::index::edges::extract::*;
 use crate::index::edges::*;
 
 pub(super) fn swift_edges(
-    text: &str,
-    node: Node<'_>,
-    symbols: &[IndexedSymbol],
-    path: &Path,
-    out: &mut Vec<EdgeCandidate>,
+    EdgeVisit { text, node, symbols, path }: EdgeVisit<'_, '_>,
+    emit: &mut EdgeEmitter<'_>,
 ) {
+    let out = emit;
     match node.kind() {
         "source_file"
             if text.contains(',')
@@ -135,7 +131,7 @@ fn swift_operator_or_shorthand_case_edges(
     text: &str,
     node: Node<'_>,
     symbols: &[IndexedSymbol],
-    out: &mut Vec<EdgeCandidate>,
+    out: &mut EdgeEmitter<'_>,
 ) {
     let Some(operation) =
         node.child_by_field_name("op").or_else(|| node.child_by_field_name("operation"))
@@ -186,7 +182,7 @@ fn swift_qualified_case_edges(
     text: &str,
     node: Node<'_>,
     symbols: &[IndexedSymbol],
-    out: &mut Vec<EdgeCandidate>,
+    out: &mut EdgeEmitter<'_>,
 ) {
     if node.parent().is_some_and(|parent| {
         parent.kind() == "call_expression" && swift_call_target(parent) == Some(node)
@@ -218,7 +214,7 @@ fn swift_call_edges(
     text: &str,
     node: Node<'_>,
     symbols: &[IndexedSymbol],
-    out: &mut Vec<EdgeCandidate>,
+    out: &mut EdgeEmitter<'_>,
 ) {
     if swift_subscript_suffix(node, text).is_some() {
         let Some(target) = swift_call_target(node).map(swift_callee_operand) else {
@@ -255,7 +251,7 @@ fn swift_constructor_edges(
     text: &str,
     node: Node<'_>,
     symbols: &[IndexedSymbol],
-    out: &mut Vec<EdgeCandidate>,
+    out: &mut EdgeEmitter<'_>,
 ) {
     let Some(constructed_type) = node.child_by_field_name("constructed_type") else {
         return;
@@ -275,7 +271,7 @@ fn emit_swift_call_edges(
     text: &str,
     node: Node<'_>,
     symbols: &[IndexedSymbol],
-    out: &mut Vec<EdgeCandidate>,
+    out: &mut EdgeEmitter<'_>,
     identifiers: Vec<String>,
     callee_range: Option<CalleeRange>,
     constructs: bool,
@@ -315,7 +311,7 @@ fn swift_macro_edges(
     text: &str,
     node: Node<'_>,
     symbols: &[IndexedSymbol],
-    out: &mut Vec<EdgeCandidate>,
+    out: &mut EdgeEmitter<'_>,
 ) {
     let Some(name_node) = syntax::identifier_nodes(node).first().copied() else {
         return;
@@ -350,7 +346,7 @@ fn swift_attribute_macro_edges(
     text: &str,
     node: Node<'_>,
     symbols: &[IndexedSymbol],
-    out: &mut Vec<EdgeCandidate>,
+    out: &mut EdgeEmitter<'_>,
 ) {
     let Some(attribute_name) = node.named_child(0) else {
         return;
@@ -393,7 +389,7 @@ fn swift_precedence_group_edges(
     text: &str,
     node: Node<'_>,
     symbols: &[IndexedSymbol],
-    out: &mut Vec<EdgeCandidate>,
+    out: &mut EdgeEmitter<'_>,
 ) {
     let Some(group) = syntax::identifier_nodes(node).last().copied() else {
         return;
@@ -412,7 +408,7 @@ fn swift_precedence_group_relation_edges(
     text: &str,
     node: Node<'_>,
     symbols: &[IndexedSymbol],
-    out: &mut Vec<EdgeCandidate>,
+    out: &mut EdgeEmitter<'_>,
 ) {
     let identifiers = syntax::identifier_nodes(node);
     let Some((relation, dependencies)) = identifiers.split_first() else {
@@ -454,7 +450,7 @@ fn swift_precedence_group_relation_list_edges(
     text: &str,
     node: Node<'_>,
     symbols: &[IndexedSymbol],
-    out: &mut Vec<EdgeCandidate>,
+    out: &mut EdgeEmitter<'_>,
 ) {
     let source = node_text(node, text);
     let code = swift_code_without_comments_or_strings(&source);
@@ -525,7 +521,7 @@ fn swift_recovered_precedence_relations(
     body_start: usize,
     body_end: usize,
     source_symbol: Option<&IndexedSymbol>,
-    out: &mut Vec<EdgeCandidate>,
+    out: &mut EdgeEmitter<'_>,
 ) {
     let mut cursor = body_start;
     while cursor < body_end {

--- a/crates/rag-rat-core/src/index/languages/swift/mod.rs
+++ b/crates/rag-rat-core/src/index/languages/swift/mod.rs
@@ -2,8 +2,9 @@ use std::path::Path;
 
 use tree_sitter::Node;
 
-use super::{EdgeBackend, KindPreference, ParserBackend, ResolverPolicy, SymbolMatch};
-use crate::index::edges::{EdgeCandidate, IndexedSymbol};
+use super::{
+    EdgeBackend, EdgeEmitter, EdgeVisit, KindPreference, ParserBackend, ResolverPolicy, SymbolMatch,
+};
 use crate::index::parser::{self, ParserKind};
 
 mod edges;
@@ -271,15 +272,8 @@ fn direct_child_of_kind<'tree>(node: Node<'tree>, kind: &str) -> Option<Node<'tr
 }
 
 impl EdgeBackend for Swift {
-    fn edges(
-        &self,
-        text: &str,
-        node: Node<'_>,
-        symbols: &[IndexedSymbol],
-        path: &Path,
-        out: &mut Vec<EdgeCandidate>,
-    ) {
-        edges::swift_edges(text, node, symbols, path, out);
+    fn edges(&self, visit: EdgeVisit<'_, '_>, emit: &mut EdgeEmitter<'_>) {
+        edges::swift_edges(visit, emit);
     }
 }
 

--- a/crates/rag-rat-core/src/index/languages/typescript/edges.rs
+++ b/crates/rag-rat-core/src/index/languages/typescript/edges.rs
@@ -1,18 +1,12 @@
 //! TypeScript graph-edge extraction for the shared structural edge walk.
-use std::path::Path;
-
-use tree_sitter::Node;
-
 use crate::index::edges::extract::*;
 use crate::index::edges::*;
 
 pub(super) fn typescript_edges(
-    text: &str,
-    node: Node<'_>,
-    symbols: &[IndexedSymbol],
-    path: &Path,
-    out: &mut Vec<EdgeCandidate>,
+    EdgeVisit { text, node, symbols, path }: EdgeVisit<'_, '_>,
+    emit: &mut EdgeEmitter<'_>,
 ) {
+    let out = emit;
     match node.kind() {
         "import_statement" =>
             for name in identifiers_under(node, text) {

--- a/crates/rag-rat-core/src/index/languages/typescript/mod.rs
+++ b/crates/rag-rat-core/src/index/languages/typescript/mod.rs
@@ -2,8 +2,7 @@ use std::path::Path;
 
 use tree_sitter::Node;
 
-use super::{EdgeBackend, ParserBackend, SymbolMatch};
-use crate::index::edges::{EdgeCandidate, IndexedSymbol};
+use super::{EdgeBackend, EdgeEmitter, EdgeVisit, ParserBackend, SymbolMatch};
 use crate::index::parser::{self, ParserKind};
 
 mod edges;
@@ -56,14 +55,7 @@ impl ParserBackend for TypeScript {
 }
 
 impl EdgeBackend for TypeScript {
-    fn edges(
-        &self,
-        text: &str,
-        node: Node<'_>,
-        symbols: &[IndexedSymbol],
-        path: &Path,
-        out: &mut Vec<EdgeCandidate>,
-    ) {
-        edges::typescript_edges(text, node, symbols, path, out);
+    fn edges(&self, visit: EdgeVisit<'_, '_>, emit: &mut EdgeEmitter<'_>) {
+        edges::typescript_edges(visit, emit);
     }
 }


### PR DESCRIPTION
## Summary

- create one immutable `EdgeExtractionContext` per file in the shared edge walker
- pass `EdgeVisit` and `EdgeEmitter` through every language backend instead of the loose text/node/symbols/path/output argument train
- route nested language helpers through the constrained emitter while preserving candidate order and Swift duplicate checks

## Behavior

Traversal remains iterative and keeps the existing error/missing-subtree pruning. Emitted candidate fields, ordering, source ownership lookup, and oracle join behavior are unchanged.

## Validation

- `cargo +nightly fmt --all -- --check`
- `cargo clippy -p rag-rat-core --all-targets -- -D warnings`
- `cargo nextest run -p rag-rat-core` (1,582 passed)

Fixes #937