### PR TITLE
perf(edges): prepare source owner lookup

### DIFF
--- a/crates/rag-rat-core/src/index/edges/extract/mod.rs
+++ b/crates/rag-rat-core/src/index/edges/extract/mod.rs
@@ -148,7 +148,8 @@ pub(crate) fn collect_edges(
     let Some(backend) = crate::index::languages::edge_backend(language) else {
         return;
     };
-    let context = EdgeExtractionContext { text, symbols, path };
+    let context =
+        EdgeExtractionContext { text, symbols, path, locator: SymbolLocator::new(symbols) };
     let mut emit = EdgeEmitter { out };
     let mut stack = vec![root];
     let mut cursor = root.walk();
@@ -166,25 +167,32 @@ pub(crate) fn collect_edges(
     }
 }
 
-#[derive(Clone, Copy)]
 pub(crate) struct EdgeExtractionContext<'source> {
     text: &'source str,
     symbols: &'source [IndexedSymbol],
     path: &'source Path,
+    locator: SymbolLocator<'source>,
 }
 
 impl<'source> EdgeExtractionContext<'source> {
-    fn visit<'tree>(&self, node: Node<'tree>) -> EdgeVisit<'tree, 'source> {
-        EdgeVisit { text: self.text, node, symbols: self.symbols, path: self.path }
+    fn visit<'tree>(&self, node: Node<'tree>) -> EdgeVisit<'tree, 'source, '_> {
+        EdgeVisit {
+            text: self.text,
+            node,
+            symbols: self.symbols,
+            path: self.path,
+            locator: &self.locator,
+        }
     }
 }
 
 #[derive(Clone, Copy)]
-pub(crate) struct EdgeVisit<'tree, 'source> {
+pub(crate) struct EdgeVisit<'tree, 'source, 'context> {
     pub(crate) text: &'source str,
     pub(crate) node: Node<'tree>,
     pub(crate) symbols: &'source [IndexedSymbol],
     pub(crate) path: &'source Path,
+    pub(crate) locator: &'context SymbolLocator<'source>,
 }
 
 pub(crate) struct EdgeEmitter<'out> {
@@ -301,7 +309,7 @@ pub(crate) fn inline_mod_scope(node: Node<'_>) -> Option<ImportScopeRange> {
     })
 }
 pub(crate) fn symbol_edge(
-    symbols: &[IndexedSymbol],
+    locator: &SymbolLocator<'_>,
     node: Node<'_>,
     to_name: String,
     edge_kind: EdgeKind,
@@ -309,7 +317,7 @@ pub(crate) fn symbol_edge(
     callee_span: Option<CalleeRange>,
 ) -> EdgeCandidate {
     symbol_edge_with_context(
-        symbols,
+        locator,
         node,
         "",
         to_name,
@@ -321,7 +329,7 @@ pub(crate) fn symbol_edge(
 }
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn symbol_edge_with_context(
-    symbols: &[IndexedSymbol],
+    locator: &SymbolLocator<'_>,
     node: Node<'_>,
     text: &str,
     to_name: String,
@@ -335,7 +343,7 @@ pub(crate) fn symbol_edge_with_context(
     callee_span: Option<CalleeRange>,
 ) -> EdgeCandidate {
     let byte = node.start_byte();
-    let source = containing_symbol(symbols, byte);
+    let source = locator.find(byte);
     EdgeCandidate {
         from_symbol_id: source.map(|symbol| symbol.id),
         from_name: source.map(|symbol| symbol.qualified_name.clone()),

--- a/crates/rag-rat-core/src/index/edges/helpers.rs
+++ b/crates/rag-rat-core/src/index/edges/helpers.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeSet;
+
 use super::*;
 
 /// Remove balanced `<...>` generic-argument regions from a call path — and the turbofish's leading
@@ -39,6 +41,91 @@ pub(crate) fn target_qualified_name(node: Node<'_>, text: &str) -> Option<String
     let value = strip_generics(&node_text(function, text));
     (value.contains("::") || value.contains('.')).then(|| value.replace('.', "::"))
 }
+
+/// Prepared source-owner lookup for edge extraction.
+///
+/// Construction sweeps symbol interval boundaries once and records the selected owner for each
+/// run. Lookups then binary-search those runs instead of scanning every symbol for every edge.
+pub(crate) struct SymbolLocator<'symbols> {
+    symbols: &'symbols [IndexedSymbol],
+    runs: Vec<(usize, Option<usize>)>,
+}
+
+impl<'symbols> SymbolLocator<'symbols> {
+    pub(crate) fn new(symbols: &'symbols [IndexedSymbol]) -> Self {
+        let mut events = Vec::with_capacity(symbols.len().saturating_mul(2));
+        for (index, symbol) in symbols.iter().enumerate() {
+            events.push((symbol.start_byte, true, index));
+            if let Some(after_end) = symbol.end_byte.checked_add(1) {
+                events.push((after_end, false, index));
+            }
+        }
+        // `false < true`, so an interval ending immediately before a new one starts is removed
+        // before the new interval is selected at that byte.
+        events.sort_unstable_by_key(|&(byte, add, index)| (byte, add, index));
+
+        let key = |index: usize| {
+            let symbol = &symbols[index];
+            (symbol.end_byte.saturating_sub(symbol.start_byte), index)
+        };
+        let is_special =
+            |index: usize| matches!(symbols[index].kind.as_str(), "const" | "property" | "static");
+        let mut active = BTreeSet::new();
+        let mut active_non_special = BTreeSet::new();
+        let mut runs = Vec::with_capacity(events.len());
+        let mut cursor = 0;
+        while cursor < events.len() {
+            let byte = events[cursor].0;
+            while cursor < events.len() && events[cursor].0 == byte {
+                let (_, add, index) = events[cursor];
+                if add {
+                    active.insert(key(index));
+                    if !is_special(index) {
+                        active_non_special.insert(key(index));
+                    }
+                } else {
+                    active.remove(&key(index));
+                    if !is_special(index) {
+                        active_non_special.remove(&key(index));
+                    }
+                }
+                cursor += 1;
+            }
+            let selected = active.first().map(|&(_, index)| index).and_then(|smallest| {
+                if is_special(smallest) {
+                    active_non_special.first().map(|&(_, index)| index).or(Some(smallest))
+                } else {
+                    Some(smallest)
+                }
+            });
+            if runs.last().is_none_or(|&(_, previous)| previous != selected) {
+                runs.push((byte, selected));
+            }
+        }
+        Self { symbols, runs }
+    }
+
+    pub(crate) fn find(&self, byte: usize) -> Option<&'symbols IndexedSymbol> {
+        let index = self.find_index_by(byte, || {});
+        index.map(|index| &self.symbols[index])
+    }
+
+    fn find_index_by(&self, byte: usize, mut probe: impl FnMut()) -> Option<usize> {
+        let mut low = 0;
+        let mut high = self.runs.len();
+        while low < high {
+            probe();
+            let middle = low + (high - low) / 2;
+            if self.runs[middle].0 <= byte {
+                low = middle + 1;
+            } else {
+                high = middle;
+            }
+        }
+        low.checked_sub(1).and_then(|index| self.runs[index].1)
+    }
+}
+
 /// The smallest-span symbol whose byte range covers `byte` (a call/reference site's owner). When
 /// that smallest is a `const`/`property`/`static` — a value binding whose initializer is where the
 /// call actually lives, so the enclosing definition is the better owner — the smallest-span
@@ -49,7 +136,8 @@ pub(crate) fn target_qualified_name(node: Node<'_>, text: &str) -> Option<String
 /// sort-by-span ran once per edge candidate (O(E·S) plus an alloc+sort each). Tracking the two
 /// running minima gives byte-identical selection — a strict `<` update keeps the FIRST symbol of an
 /// equal-span tie, exactly as the stable sort did.
-pub(crate) fn containing_symbol(symbols: &[IndexedSymbol], byte: usize) -> Option<&IndexedSymbol> {
+#[cfg(test)]
+fn containing_symbol(symbols: &[IndexedSymbol], byte: usize) -> Option<&IndexedSymbol> {
     let span = |symbol: &IndexedSymbol| symbol.end_byte.saturating_sub(symbol.start_byte);
     let is_special =
         |symbol: &IndexedSymbol| matches!(symbol.kind.as_str(), "const" | "property" | "static");
@@ -621,6 +709,8 @@ mod containing_symbol_tests {
         let got = containing_symbol(symbols, byte).map(|symbol| symbol.id);
         let want = reference(symbols, byte).map(|symbol| symbol.id);
         assert_eq!(got, want, "byte={byte}");
+        let prepared = SymbolLocator::new(symbols).find(byte).map(|symbol| symbol.id);
+        assert_eq!(prepared, want, "prepared locator at byte={byte}");
     }
 
     #[test]
@@ -691,5 +781,18 @@ mod containing_symbol_tests {
         for byte in 0..=110 {
             assert_equiv(&symbols, byte);
         }
+    }
+
+    #[test]
+    fn prepared_lookup_is_logarithmic_in_symbol_count() {
+        let symbols = (0..4_096)
+            .map(|index| sym(index, "function", index as usize * 2, index as usize * 2))
+            .collect::<Vec<_>>();
+        let locator = SymbolLocator::new(&symbols);
+
+        let mut probes = 0;
+        let selected = locator.find_index_by(8_190, || probes += 1);
+        assert_eq!(selected.map(|index| symbols[index].id), Some(4_095));
+        assert!(probes <= 14, "{probes} probes for {} symbols", symbols.len());
     }
 }

--- a/crates/rag-rat-core/src/index/languages/c_family/edges.rs
+++ b/crates/rag-rat-core/src/index/languages/c_family/edges.rs
@@ -3,7 +3,7 @@ use crate::index::edges::extract::*;
 use crate::index::edges::*;
 
 pub(super) fn c_like_edges(
-    EdgeVisit { text, node, symbols, path }: EdgeVisit<'_, '_>,
+    EdgeVisit { text, node, symbols: _, path, locator }: EdgeVisit<'_, '_, '_>,
     emit: &mut EdgeEmitter<'_>,
 ) {
     let out = emit;
@@ -35,7 +35,7 @@ pub(super) fn c_like_edges(
                 .or_else(|| call_target_name(node, text))
             {
                 out.push(symbol_edge_with_context(
-                    symbols,
+                    locator,
                     node,
                     text,
                     name,
@@ -55,7 +55,7 @@ pub(super) fn c_like_edges(
         "type_identifier" | "qualified_identifier" | "namespace_identifier" => {
             if let Some(name) = last_identifier_text(node, text) {
                 out.push(symbol_edge(
-                    symbols,
+                    locator,
                     node,
                     name,
                     EdgeKind::ReferencesType,

--- a/crates/rag-rat-core/src/index/languages/c_family/mod.rs
+++ b/crates/rag-rat-core/src/index/languages/c_family/mod.rs
@@ -106,7 +106,7 @@ fn function_name(node: Node<'_>) -> Option<Node<'_>> {
 macro_rules! impl_edges {
     ($backend:ty) => {
         impl EdgeBackend for $backend {
-            fn edges(&self, visit: EdgeVisit<'_, '_>, emit: &mut EdgeEmitter<'_>) {
+            fn edges(&self, visit: EdgeVisit<'_, '_, '_>, emit: &mut EdgeEmitter<'_>) {
                 edges::c_like_edges(visit, emit);
             }
         }

--- a/crates/rag-rat-core/src/index/languages/kotlin/edges.rs
+++ b/crates/rag-rat-core/src/index/languages/kotlin/edges.rs
@@ -3,7 +3,7 @@ use crate::index::edges::extract::*;
 use crate::index::edges::*;
 
 pub(super) fn kotlin_edges(
-    EdgeVisit { text, node, symbols, path }: EdgeVisit<'_, '_>,
+    EdgeVisit { text, node, symbols: _, path, locator }: EdgeVisit<'_, '_, '_>,
     emit: &mut EdgeEmitter<'_>,
 ) {
     let out = emit;
@@ -28,7 +28,7 @@ pub(super) fn kotlin_edges(
                 .or_else(|| first_identifier_text(node, text))
             {
                 out.push(symbol_edge_with_context(
-                    symbols,
+                    locator,
                     node,
                     text,
                     name,
@@ -48,7 +48,7 @@ pub(super) fn kotlin_edges(
                 identifiers.first_text().filter(|_| identifiers.len() > 1).map(ToOwned::to_owned)
             {
                 out.push(symbol_edge(
-                    symbols,
+                    locator,
                     node,
                     receiver,
                     EdgeKind::ReferencesType,
@@ -68,7 +68,7 @@ pub(super) fn kotlin_edges(
                 // identifier (matching `identifiers.first()`).
                 let constructor_range = identifiers.first_node().map(CalleeRange::of_node);
                 out.push(symbol_edge(
-                    symbols,
+                    locator,
                     node,
                     constructor.clone(),
                     EdgeKind::ReferencesType,
@@ -76,7 +76,7 @@ pub(super) fn kotlin_edges(
                     constructor_range,
                 ));
                 out.push(symbol_edge_with_context(
-                    symbols,
+                    locator,
                     node,
                     text,
                     constructor,
@@ -90,7 +90,7 @@ pub(super) fn kotlin_edges(
         "user_type" | "type_identifier" =>
             if let Some(name) = last_identifier_text(node, text) {
                 out.push(symbol_edge(
-                    symbols,
+                    locator,
                     node,
                     name,
                     EdgeKind::ReferencesType,
@@ -101,7 +101,7 @@ pub(super) fn kotlin_edges(
         "delegation_specifier" | "supertype" | "super_type" => {
             if let Some(name) = last_identifier_text(node, text) {
                 out.push(symbol_edge(
-                    symbols,
+                    locator,
                     node,
                     name,
                     EdgeKind::Implements,

--- a/crates/rag-rat-core/src/index/languages/kotlin/mod.rs
+++ b/crates/rag-rat-core/src/index/languages/kotlin/mod.rs
@@ -99,7 +99,7 @@ fn variable_declaration(node: Node<'_>) -> Option<Node<'_>> {
 }
 
 impl EdgeBackend for Kotlin {
-    fn edges(&self, visit: EdgeVisit<'_, '_>, emit: &mut EdgeEmitter<'_>) {
+    fn edges(&self, visit: EdgeVisit<'_, '_, '_>, emit: &mut EdgeEmitter<'_>) {
         edges::kotlin_edges(visit, emit);
     }
 }

--- a/crates/rag-rat-core/src/index/languages/mod.rs
+++ b/crates/rag-rat-core/src/index/languages/mod.rs
@@ -85,7 +85,7 @@ pub(super) trait ParserBackend: Sync {
 
 /// Grammar-specific edge recognition for one node visited by the shared depth-safe edge walk.
 pub(super) trait EdgeBackend: Sync {
-    fn edges(&self, visit: EdgeVisit<'_, '_>, emit: &mut EdgeEmitter<'_>);
+    fn edges(&self, visit: EdgeVisit<'_, '_, '_>, emit: &mut EdgeEmitter<'_>);
 }
 
 #[derive(Clone, Copy)]

--- a/crates/rag-rat-core/src/index/languages/python/edges.rs
+++ b/crates/rag-rat-core/src/index/languages/python/edges.rs
@@ -9,7 +9,7 @@ use crate::index::edges::extract::*;
 use crate::index::edges::*;
 
 pub(super) fn python_edges(
-    EdgeVisit { text, node, symbols, path }: EdgeVisit<'_, '_>,
+    EdgeVisit { text, node, symbols: _, path, locator }: EdgeVisit<'_, '_, '_>,
     emit: &mut EdgeEmitter<'_>,
 ) {
     let out = emit;
@@ -92,7 +92,7 @@ pub(super) fn python_edges(
                 // fall through to recursion without emitting a call edge
             } else if let Some(name) = identifiers.last_text().map(ToOwned::to_owned) {
                 out.push(symbol_edge_with_context(
-                    symbols,
+                    locator,
                     node,
                     text,
                     name,
@@ -148,7 +148,7 @@ pub(super) fn python_edges(
                             .map(final_segment_node)
                             .map(CalleeRange::of_node);
                         out.push(symbol_edge(
-                            symbols,
+                            locator,
                             base,
                             name,
                             EdgeKind::Implements,
@@ -156,7 +156,7 @@ pub(super) fn python_edges(
                             callee,
                         ));
                     }
-                    emit_python_type_refs(base, symbols, text, out);
+                    emit_python_type_refs(base, locator, text, out);
                 }
             },
         // Type annotations (`x: T`, `-> T`) wrap their type in a `type` node.
@@ -166,7 +166,7 @@ pub(super) fn python_edges(
         // referenced type. The alias NAME in a `type X = …` is skipped (it's a definition,
         // not a reference). String forward refs (`-> "Api"`) carry no identifier → no edge.
         "type" if !python_is_type_alias_name(node) => {
-            emit_python_type_refs(node, symbols, text, out);
+            emit_python_type_refs(node, locator, text, out);
         },
         // A bare decorator (`@requires_auth`, `@pytest.fixture`) is an identifier/attribute, not a
         // `call` — applying it is a call-like dependency, so emit a NameOnly call edge. A
@@ -184,7 +184,7 @@ pub(super) fn python_edges(
                 // `pytest` receiver + dotted path — same context the call arm records — so the
                 // resolver doesn't fall back to a bare local `fixture` of the same name.
                 out.push(symbol_edge_with_context(
-                    symbols,
+                    locator,
                     node,
                     text,
                     name,
@@ -217,7 +217,7 @@ pub(super) fn python_edges(
 /// uniformly.
 fn emit_python_type_refs(
     node: Node<'_>,
-    symbols: &[IndexedSymbol],
+    locator: &SymbolLocator<'_>,
     text: &str,
     out: &mut EdgeEmitter<'_>,
 ) {
@@ -229,14 +229,14 @@ fn emit_python_type_refs(
             rag_rat_base::stack::grow_stack(|| {
                 let mut cursor = node.walk();
                 for child in node.named_children(&mut cursor) {
-                    emit_python_type_refs(child, symbols, text, out);
+                    emit_python_type_refs(child, locator, text, out);
                 }
             });
         },
         "identifier" =>
             if let Some(name) = last_identifier_text(node, text) {
                 out.push(symbol_edge(
-                    symbols,
+                    locator,
                     node,
                     name,
                     EdgeKind::ReferencesType,
@@ -259,7 +259,7 @@ fn emit_python_type_refs(
                     .map(|object| node_text(object, text))
                     .or_else(|| identifiers.first_text().map(ToOwned::to_owned));
                 out.push(symbol_edge_with_context(
-                    symbols,
+                    locator,
                     node,
                     "",
                     name,

--- a/crates/rag-rat-core/src/index/languages/python/mod.rs
+++ b/crates/rag-rat-core/src/index/languages/python/mod.rs
@@ -121,7 +121,7 @@ fn assignment_is_const_scope(node: Node<'_>) -> bool {
 }
 
 impl EdgeBackend for Python {
-    fn edges(&self, visit: EdgeVisit<'_, '_>, emit: &mut EdgeEmitter<'_>) {
+    fn edges(&self, visit: EdgeVisit<'_, '_, '_>, emit: &mut EdgeEmitter<'_>) {
         edges::python_edges(visit, emit);
     }
 }

--- a/crates/rag-rat-core/src/index/languages/rust/dispatch.rs
+++ b/crates/rag-rat-core/src/index/languages/rust/dispatch.rs
@@ -632,14 +632,14 @@ pub(super) fn scoped_identifier_in_value_position(node: Node<'_>) -> bool {
 /// method). `to_name` is the variant key (construct) or the handler name (handle). No callee range,
 /// so the SCIP oracle skips these rows.
 pub(super) fn dispatch_fact(
-    symbols: &[IndexedSymbol],
+    locator: &SymbolLocator<'_>,
     node: Node<'_>,
     to_name: String,
     edge_kind: EdgeKind,
     context: EdgeContext,
     evidence: Option<String>,
 ) -> EdgeCandidate {
-    let source = containing_symbol(symbols, node.start_byte());
+    let source = locator.find(node.start_byte());
     EdgeCandidate {
         from_symbol_id: source.map(|symbol| symbol.id),
         from_name: source.map(|symbol| symbol.qualified_name.clone()),
@@ -665,7 +665,7 @@ pub(super) fn dispatch_fact(
 pub(super) fn rust_dispatch_handle_facts(
     text: &str,
     node: Node<'_>,
-    symbols: &[IndexedSymbol],
+    locator: &SymbolLocator<'_>,
     out: &mut EdgeEmitter<'_>,
 ) {
     let Some(pattern) = node.child_by_field_name("pattern") else {
@@ -694,7 +694,7 @@ pub(super) fn rust_dispatch_handle_facts(
             // handler name + call context still come from the delegate call; from_symbol resolves
             // to the same dispatcher fn either way.
             out.push(dispatch_fact(
-                symbols,
+                locator,
                 *variant_node,
                 handler.clone(),
                 EdgeKind::DispatchHandle,

--- a/crates/rag-rat-core/src/index/languages/rust/edges.rs
+++ b/crates/rag-rat-core/src/index/languages/rust/edges.rs
@@ -7,7 +7,7 @@ use crate::index::edges::extract::*;
 use crate::index::edges::*;
 
 pub(super) fn rust_edges(
-    EdgeVisit { text, node, symbols, path }: EdgeVisit<'_, '_>,
+    EdgeVisit { text, node, symbols: _, path, locator }: EdgeVisit<'_, '_, '_>,
     emit: &mut EdgeEmitter<'_>,
 ) {
     let out = emit;
@@ -79,7 +79,7 @@ pub(super) fn rust_edges(
         "call_expression" => {
             if let Some(name) = call_target_name(node, text) {
                 out.push(symbol_edge_with_context(
-                    symbols,
+                    locator,
                     node,
                     text,
                     name,
@@ -101,7 +101,7 @@ pub(super) fn rust_edges(
                 && receiver.chars().next().is_some_and(char::is_uppercase)
             {
                 out.push(symbol_edge(
-                    symbols,
+                    locator,
                     node,
                     receiver,
                     EdgeKind::ReferencesType,
@@ -123,7 +123,7 @@ pub(super) fn rust_edges(
                 .and_then(|f| dispatch::enum_variant_key(f, text))
             {
                 out.push(dispatch::dispatch_fact(
-                    symbols,
+                    locator,
                     node,
                     key,
                     EdgeKind::DispatchConstruct,
@@ -139,7 +139,7 @@ pub(super) fn rust_edges(
                 node.child_by_field_name("name").and_then(|n| dispatch::enum_variant_key(n, text))
             {
                 out.push(dispatch::dispatch_fact(
-                    symbols,
+                    locator,
                     node,
                     key,
                     EdgeKind::DispatchConstruct,
@@ -161,7 +161,7 @@ pub(super) fn rust_edges(
                 && let Some(key) = dispatch::enum_variant_key(node, text)
             {
                 out.push(dispatch::dispatch_fact(
-                    symbols,
+                    locator,
                     node,
                     key,
                     EdgeKind::DispatchConstruct,
@@ -170,11 +170,11 @@ pub(super) fn rust_edges(
                 ));
             }
         },
-        "match_arm" => dispatch::rust_dispatch_handle_facts(text, node, symbols, out),
+        "match_arm" => dispatch::rust_dispatch_handle_facts(text, node, locator, out),
         "macro_invocation" =>
             if let Some(name) = first_identifier_text(node, text) {
                 out.push(symbol_edge_with_context(
-                    symbols,
+                    locator,
                     node,
                     text,
                     name,
@@ -184,11 +184,11 @@ pub(super) fn rust_edges(
                     first_identifier_node(node).map(CalleeRange::of_node),
                 ));
             },
-        "impl_item" => rust_impl_edges(text, node, symbols, out),
+        "impl_item" => rust_impl_edges(text, node, locator, out),
         "type_identifier" | "scoped_type_identifier" | "generic_type" => {
             if let Some(name) = last_identifier_text(node, text) {
                 out.push(symbol_edge(
-                    symbols,
+                    locator,
                     node,
                     name,
                     EdgeKind::ReferencesType,
@@ -203,7 +203,7 @@ pub(super) fn rust_edges(
 pub(super) fn rust_impl_edges(
     text: &str,
     node: Node<'_>,
-    symbols: &[IndexedSymbol],
+    locator: &SymbolLocator<'_>,
     out: &mut EdgeEmitter<'_>,
 ) {
     let node_text = node_text(node, text);
@@ -218,7 +218,7 @@ pub(super) fn rust_impl_edges(
         let trait_name = type_names.first().cloned().unwrap_or_default();
         let type_name = type_names.last().cloned().unwrap_or_default();
         out.push(EdgeCandidate {
-            from_symbol_id: containing_symbol(symbols, node.start_byte()).map(|symbol| symbol.id),
+            from_symbol_id: locator.find(node.start_byte()).map(|symbol| symbol.id),
             from_name: Some(type_name),
             to_name: trait_name,
             target_qualified_name: None,
@@ -234,7 +234,7 @@ pub(super) fn rust_impl_edges(
         });
     } else if let Some(type_name) = type_names.first() {
         out.push(symbol_edge(
-            symbols,
+            locator,
             node,
             type_name.clone(),
             EdgeKind::ReferencesType,

--- a/crates/rag-rat-core/src/index/languages/rust/mod.rs
+++ b/crates/rag-rat-core/src/index/languages/rust/mod.rs
@@ -132,7 +132,7 @@ fn attribute_items(text: &str, node: Node<'_>) -> Vec<String> {
 }
 
 impl EdgeBackend for Rust {
-    fn edges(&self, visit: EdgeVisit<'_, '_>, emit: &mut EdgeEmitter<'_>) {
+    fn edges(&self, visit: EdgeVisit<'_, '_, '_>, emit: &mut EdgeEmitter<'_>) {
         edges::rust_edges(visit, emit);
     }
 }

--- a/crates/rag-rat-core/src/index/languages/swift/edges.rs
+++ b/crates/rag-rat-core/src/index/languages/swift/edges.rs
@@ -7,7 +7,7 @@ use crate::index::edges::extract::*;
 use crate::index::edges::*;
 
 pub(super) fn swift_edges(
-    EdgeVisit { text, node, symbols, path }: EdgeVisit<'_, '_>,
+    EdgeVisit { text, node, symbols, path, locator }: EdgeVisit<'_, '_, '_>,
     emit: &mut EdgeEmitter<'_>,
 ) {
     let out = emit;
@@ -29,12 +29,12 @@ pub(super) fn swift_edges(
                 ));
             }
         },
-        "call_expression" => swift_call_edges(text, node, symbols, out),
-        "constructor_expression" => swift_constructor_edges(text, node, symbols, out),
-        "macro_invocation" => swift_macro_edges(text, node, symbols, out),
-        "operator_declaration" => swift_precedence_group_edges(text, node, symbols, out),
+        "call_expression" => swift_call_edges(text, node, locator, out),
+        "constructor_expression" => swift_constructor_edges(text, node, locator, out),
+        "macro_invocation" => swift_macro_edges(text, node, locator, out),
+        "operator_declaration" => swift_precedence_group_edges(text, node, locator, out),
         "precedence_group_attribute" =>
-            swift_precedence_group_relation_edges(text, node, symbols, out),
+            swift_precedence_group_relation_edges(text, node, locator, out),
         "postfix_expression"
         | "prefix_expression"
         | "multiplicative_expression"
@@ -45,10 +45,10 @@ pub(super) fn swift_edges(
         | "equality_expression"
         | "conjunction_expression"
         | "disjunction_expression"
-        | "bitwise_operation" => swift_operator_or_shorthand_case_edges(text, node, symbols, out),
-        "navigation_expression" => swift_qualified_case_edges(text, node, symbols, out),
+        | "bitwise_operation" => swift_operator_or_shorthand_case_edges(text, node, locator, out),
+        "navigation_expression" => swift_qualified_case_edges(text, node, locator, out),
         "attribute" if !swift_node_is_import_modifier(node) =>
-            swift_attribute_macro_edges(text, node, symbols, out),
+            swift_attribute_macro_edges(text, node, locator, out),
         "inheritance_specifier" => {
             let Some(type_path) = swift_inherited_type_name(node) else {
                 return;
@@ -67,7 +67,7 @@ pub(super) fn swift_edges(
                 EdgeKind::Implements
             };
             out.push(symbol_edge_with_context(
-                symbols,
+                locator,
                 node,
                 text,
                 name,
@@ -95,7 +95,7 @@ pub(super) fn swift_edges(
                 return;
             };
             out.push(symbol_edge_with_context(
-                symbols,
+                locator,
                 node,
                 text,
                 name,
@@ -115,7 +115,7 @@ pub(super) fn swift_edges(
         {
             let name = node_text(node, text);
             out.push(symbol_edge(
-                symbols,
+                locator,
                 node,
                 name,
                 EdgeKind::ReferencesType,
@@ -130,7 +130,7 @@ pub(super) fn swift_edges(
 fn swift_operator_or_shorthand_case_edges(
     text: &str,
     node: Node<'_>,
-    symbols: &[IndexedSymbol],
+    locator: &SymbolLocator<'_>,
     out: &mut EdgeEmitter<'_>,
 ) {
     let Some(operation) =
@@ -143,7 +143,7 @@ fn swift_operator_or_shorthand_case_edges(
             return;
         };
         out.push(symbol_edge(
-            symbols,
+            locator,
             node,
             node_text(case_name, text),
             EdgeKind::CallsName,
@@ -161,7 +161,7 @@ fn swift_operator_or_shorthand_case_edges(
         return;
     }
     out.push(symbol_edge(
-        symbols,
+        locator,
         node,
         node_text(operation, text),
         EdgeKind::UsesOperator,
@@ -169,7 +169,7 @@ fn swift_operator_or_shorthand_case_edges(
         Some(CalleeRange::of_node(operation)),
     ));
     out.push(symbol_edge(
-        symbols,
+        locator,
         node,
         node_text(operation, text),
         EdgeKind::CallsName,
@@ -181,7 +181,7 @@ fn swift_operator_or_shorthand_case_edges(
 fn swift_qualified_case_edges(
     text: &str,
     node: Node<'_>,
-    symbols: &[IndexedSymbol],
+    locator: &SymbolLocator<'_>,
     out: &mut EdgeEmitter<'_>,
 ) {
     if node.parent().is_some_and(|parent| {
@@ -199,7 +199,7 @@ fn swift_qualified_case_edges(
         return;
     };
     out.push(symbol_edge_with_context(
-        symbols,
+        locator,
         node,
         text,
         node_text(case_name, text),
@@ -213,7 +213,7 @@ fn swift_qualified_case_edges(
 fn swift_call_edges(
     text: &str,
     node: Node<'_>,
-    symbols: &[IndexedSymbol],
+    locator: &SymbolLocator<'_>,
     out: &mut EdgeEmitter<'_>,
 ) {
     if swift_subscript_suffix(node, text).is_some() {
@@ -229,7 +229,7 @@ fn swift_call_edges(
             return;
         }
         identifiers.push("subscript".to_string());
-        emit_swift_call_edges(text, node, symbols, out, identifiers, None, false);
+        emit_swift_call_edges(text, node, locator, out, identifiers, None, false);
         return;
     }
     let Some(target) = swift_call_target(node).map(swift_callee_operand) else {
@@ -244,13 +244,13 @@ fn swift_call_edges(
         return;
     }
     let constructs = identifiers.last().is_some_and(|name| looks_like_type_name(name));
-    emit_swift_call_edges(text, node, symbols, out, identifiers, callee_range, constructs);
+    emit_swift_call_edges(text, node, locator, out, identifiers, callee_range, constructs);
 }
 
 fn swift_constructor_edges(
     text: &str,
     node: Node<'_>,
-    symbols: &[IndexedSymbol],
+    locator: &SymbolLocator<'_>,
     out: &mut EdgeEmitter<'_>,
 ) {
     let Some(constructed_type) = node.child_by_field_name("constructed_type") else {
@@ -264,13 +264,13 @@ fn swift_constructor_edges(
     {
         return;
     }
-    emit_swift_call_edges(text, node, symbols, out, identifiers, callee_range, true);
+    emit_swift_call_edges(text, node, locator, out, identifiers, callee_range, true);
 }
 
 fn emit_swift_call_edges(
     text: &str,
     node: Node<'_>,
-    symbols: &[IndexedSymbol],
+    locator: &SymbolLocator<'_>,
     out: &mut EdgeEmitter<'_>,
     identifiers: Vec<String>,
     callee_range: Option<CalleeRange>,
@@ -280,7 +280,7 @@ fn emit_swift_call_edges(
         return;
     };
     out.push(symbol_edge_with_context(
-        symbols,
+        locator,
         node,
         text,
         name.clone(),
@@ -295,7 +295,7 @@ fn emit_swift_call_edges(
     ));
     if constructs {
         out.push(symbol_edge_with_context(
-            symbols,
+            locator,
             node,
             text,
             name,
@@ -310,7 +310,7 @@ fn emit_swift_call_edges(
 fn swift_macro_edges(
     text: &str,
     node: Node<'_>,
-    symbols: &[IndexedSymbol],
+    locator: &SymbolLocator<'_>,
     out: &mut EdgeEmitter<'_>,
 ) {
     let Some(name_node) = syntax::identifier_nodes(node).first().copied() else {
@@ -322,7 +322,7 @@ fn swift_macro_edges(
         return;
     }
     out.push(symbol_edge(
-        symbols,
+        locator,
         node,
         node_text(name_node, text),
         EdgeKind::UsesMacro,
@@ -345,7 +345,7 @@ fn swift_has_ancestor_kind(node: Node<'_>, kind: &str) -> bool {
 fn swift_attribute_macro_edges(
     text: &str,
     node: Node<'_>,
-    symbols: &[IndexedSymbol],
+    locator: &SymbolLocator<'_>,
     out: &mut EdgeEmitter<'_>,
 ) {
     let Some(attribute_name) = node.named_child(0) else {
@@ -361,7 +361,7 @@ fn swift_attribute_macro_edges(
         return;
     };
     out.push(symbol_edge_with_context(
-        symbols,
+        locator,
         node,
         text,
         name.clone(),
@@ -374,7 +374,7 @@ fn swift_attribute_macro_edges(
     // builders. Emit both semantic possibilities; language-policy resolution keeps only the one
     // whose declaration kind exists and suppresses both candidates when the attribute is external.
     out.push(symbol_edge_with_context(
-        symbols,
+        locator,
         node,
         text,
         name,
@@ -388,14 +388,14 @@ fn swift_attribute_macro_edges(
 fn swift_precedence_group_edges(
     text: &str,
     node: Node<'_>,
-    symbols: &[IndexedSymbol],
+    locator: &SymbolLocator<'_>,
     out: &mut EdgeEmitter<'_>,
 ) {
     let Some(group) = syntax::identifier_nodes(node).last().copied() else {
         return;
     };
     out.push(symbol_edge(
-        symbols,
+        locator,
         node,
         node_text(group, text),
         EdgeKind::UsesPrecedenceGroup,
@@ -407,7 +407,7 @@ fn swift_precedence_group_edges(
 fn swift_precedence_group_relation_edges(
     text: &str,
     node: Node<'_>,
-    symbols: &[IndexedSymbol],
+    locator: &SymbolLocator<'_>,
     out: &mut EdgeEmitter<'_>,
 ) {
     let identifiers = syntax::identifier_nodes(node);
@@ -421,7 +421,7 @@ fn swift_precedence_group_relation_edges(
     }
     for dependency in dependencies {
         let edge = symbol_edge(
-            symbols,
+            locator,
             node,
             node_text(*dependency, text),
             EdgeKind::UsesPrecedenceGroup,

--- a/crates/rag-rat-core/src/index/languages/swift/mod.rs
+++ b/crates/rag-rat-core/src/index/languages/swift/mod.rs
@@ -272,7 +272,7 @@ fn direct_child_of_kind<'tree>(node: Node<'tree>, kind: &str) -> Option<Node<'tr
 }
 
 impl EdgeBackend for Swift {
-    fn edges(&self, visit: EdgeVisit<'_, '_>, emit: &mut EdgeEmitter<'_>) {
+    fn edges(&self, visit: EdgeVisit<'_, '_, '_>, emit: &mut EdgeEmitter<'_>) {
         edges::swift_edges(visit, emit);
     }
 }

--- a/crates/rag-rat-core/src/index/languages/typescript/edges.rs
+++ b/crates/rag-rat-core/src/index/languages/typescript/edges.rs
@@ -3,7 +3,7 @@ use crate::index::edges::extract::*;
 use crate::index::edges::*;
 
 pub(super) fn typescript_edges(
-    EdgeVisit { text, node, symbols, path }: EdgeVisit<'_, '_>,
+    EdgeVisit { text, node, symbols: _, path, locator }: EdgeVisit<'_, '_, '_>,
     emit: &mut EdgeEmitter<'_>,
 ) {
     let out = emit;
@@ -44,7 +44,7 @@ pub(super) fn typescript_edges(
                     EdgeKind::CallsName
                 };
                 out.push(symbol_edge_with_context(
-                    symbols,
+                    locator,
                     node,
                     text,
                     name,
@@ -64,7 +64,7 @@ pub(super) fn typescript_edges(
                 identifiers.first_text().filter(|_| identifiers.len() > 1).map(ToOwned::to_owned)
             {
                 out.push(symbol_edge(
-                    symbols,
+                    locator,
                     node,
                     receiver,
                     EdgeKind::ReferencesType,
@@ -81,7 +81,7 @@ pub(super) fn typescript_edges(
         "jsx_opening_element" | "jsx_self_closing_element" => {
             if let Some(name) = first_identifier_text(node, text) {
                 out.push(symbol_edge(
-                    symbols,
+                    locator,
                     node,
                     name,
                     EdgeKind::ReferencesType,
@@ -93,7 +93,7 @@ pub(super) fn typescript_edges(
         "type_identifier" => {
             if let Some(name) = node.utf8_text(text.as_bytes()).ok().map(ToOwned::to_owned) {
                 out.push(symbol_edge(
-                    symbols,
+                    locator,
                     node,
                     name,
                     EdgeKind::ReferencesType,

--- a/crates/rag-rat-core/src/index/languages/typescript/mod.rs
+++ b/crates/rag-rat-core/src/index/languages/typescript/mod.rs
@@ -55,7 +55,7 @@ impl ParserBackend for TypeScript {
 }
 
 impl EdgeBackend for TypeScript {
-    fn edges(&self, visit: EdgeVisit<'_, '_>, emit: &mut EdgeEmitter<'_>) {
+    fn edges(&self, visit: EdgeVisit<'_, '_, '_>, emit: &mut EdgeEmitter<'_>) {
         edges::typescript_edges(visit, emit);
     }
 }


### PR DESCRIPTION
## Summary

- build one interval-based `SymbolLocator` per file in the extraction context
- resolve source ownership with binary search instead of scanning the complete symbol slice for every candidate
- route all language extractors and Rust dispatch facts through the prepared locator

## Preserved behavior

The locator keeps inclusive byte ranges, first-in-slice equal-span ties, and the existing `const`/`property`/`static` fallback to the smallest non-special container. The former linear implementation remains test-only as a differential oracle.

## Validation

- `cargo +nightly fmt --all -- --check`
- `cargo clippy -p rag-rat-core --all-targets -- -D warnings`
- `cargo nextest run -p rag-rat-core` — 1,583 passed
- operation-count regression: 4,096 symbols resolve in at most 14 lookup probes

Fixes #938