### PR TITLE
refactor(edges): register extraction functions

### DIFF
--- a/crates/rag-rat-core/src/index/edges/extract/mod.rs
+++ b/crates/rag-rat-core/src/index/edges/extract/mod.rs
@@ -26,7 +26,7 @@ pub(crate) fn edge_candidates(
     text: &str,
     symbols: &[IndexedSymbol],
 ) -> anyhow::Result<Vec<EdgeCandidate>> {
-    if crate::index::languages::edge_backend(language).is_none() {
+    if crate::index::languages::edge_extractor(language).is_none() {
         return Ok(Vec::new());
     }
     let mut candidates = contains_edges(symbols);
@@ -43,7 +43,7 @@ pub(crate) fn edge_candidates_from_root(
     root: Node<'_>,
     symbols: &[IndexedSymbol],
 ) -> Vec<EdgeCandidate> {
-    if crate::index::languages::edge_backend(language).is_none() {
+    if crate::index::languages::edge_extractor(language).is_none() {
         return Vec::new();
     }
     let mut candidates = contains_edges(symbols);
@@ -145,7 +145,7 @@ pub(crate) fn collect_edges(
     path: &Path,
     out: &mut Vec<EdgeCandidate>,
 ) {
-    let Some(backend) = crate::index::languages::edge_backend(language) else {
+    let Some(extract) = crate::index::languages::edge_extractor(language) else {
         return;
     };
     let context =
@@ -158,7 +158,7 @@ pub(crate) fn collect_edges(
         if node.is_error() || node.is_missing() {
             continue;
         }
-        backend.edges(context.visit(node), &mut emit);
+        extract(context.visit(node), &mut emit);
         named_children.clear();
         named_children.extend(node.named_children(&mut cursor));
         for &child in named_children.iter().rev() {

--- a/crates/rag-rat-core/src/index/languages/c_family/edges.rs
+++ b/crates/rag-rat-core/src/index/languages/c_family/edges.rs
@@ -2,7 +2,7 @@
 use crate::index::edges::extract::*;
 use crate::index::edges::*;
 
-pub(super) fn c_like_edges(
+pub(in crate::index::languages) fn c_like_edges(
     EdgeVisit { text, node, symbols: _, path, locator }: EdgeVisit<'_, '_, '_>,
     emit: &mut EdgeEmitter<'_>,
 ) {

--- a/crates/rag-rat-core/src/index/languages/c_family/mod.rs
+++ b/crates/rag-rat-core/src/index/languages/c_family/mod.rs
@@ -2,10 +2,11 @@ use std::path::Path;
 
 use tree_sitter::Node;
 
-use super::{EdgeBackend, EdgeEmitter, EdgeVisit, ParserBackend, ResolverPolicy, SymbolMatch};
+use super::{ParserBackend, ResolverPolicy, SymbolMatch};
 use crate::index::parser::{self, ParserKind};
 
 mod edges;
+pub(super) use edges::c_like_edges;
 
 pub(super) static C_SUPPORT: C = C;
 pub(super) static CPP_SUPPORT: Cpp = Cpp;
@@ -102,19 +103,6 @@ fn function_name(node: Node<'_>) -> Option<Node<'_>> {
     }
     parser::last_descendant_node(name_root, parser::NAME_KINDS)
 }
-
-macro_rules! impl_edges {
-    ($backend:ty) => {
-        impl EdgeBackend for $backend {
-            fn edges(&self, visit: EdgeVisit<'_, '_, '_>, emit: &mut EdgeEmitter<'_>) {
-                edges::c_like_edges(visit, emit);
-            }
-        }
-    };
-}
-
-impl_edges!(C);
-impl_edges!(Cpp);
 
 macro_rules! impl_resolver_policy {
     ($backend:ty) => {

--- a/crates/rag-rat-core/src/index/languages/kotlin/edges.rs
+++ b/crates/rag-rat-core/src/index/languages/kotlin/edges.rs
@@ -2,7 +2,7 @@
 use crate::index::edges::extract::*;
 use crate::index::edges::*;
 
-pub(super) fn kotlin_edges(
+pub(in crate::index::languages) fn kotlin_edges(
     EdgeVisit { text, node, symbols: _, path, locator }: EdgeVisit<'_, '_, '_>,
     emit: &mut EdgeEmitter<'_>,
 ) {

--- a/crates/rag-rat-core/src/index/languages/kotlin/mod.rs
+++ b/crates/rag-rat-core/src/index/languages/kotlin/mod.rs
@@ -2,10 +2,11 @@ use std::path::Path;
 
 use tree_sitter::Node;
 
-use super::{EdgeBackend, EdgeEmitter, EdgeVisit, ParserBackend, ResolverPolicy, SymbolMatch};
+use super::{ParserBackend, ResolverPolicy, SymbolMatch};
 use crate::index::parser::{self, ParserKind};
 
 mod edges;
+pub(super) use edges::kotlin_edges;
 
 pub(super) static SUPPORT: Kotlin = Kotlin;
 
@@ -96,12 +97,6 @@ fn variable_declaration(node: Node<'_>) -> Option<Node<'_>> {
             }
         })
     })
-}
-
-impl EdgeBackend for Kotlin {
-    fn edges(&self, visit: EdgeVisit<'_, '_, '_>, emit: &mut EdgeEmitter<'_>) {
-        edges::kotlin_edges(visit, emit);
-    }
 }
 
 impl ResolverPolicy for Kotlin {

--- a/crates/rag-rat-core/src/index/languages/mod.rs
+++ b/crates/rag-rat-core/src/index/languages/mod.rs
@@ -84,9 +84,13 @@ pub(super) trait ParserBackend: Sync {
 }
 
 /// Grammar-specific edge recognition for one node visited by the shared depth-safe edge walk.
-pub(super) trait EdgeBackend: Sync {
-    fn edges(&self, visit: EdgeVisit<'_, '_, '_>, emit: &mut EdgeEmitter<'_>);
-}
+///
+/// Extractors are registered functions rather than trait objects: they carry no state and the
+/// language implementations previously did nothing except forward these two arguments.
+pub(super) type EdgeExtractor = for<'tree, 'source, 'context, 'emit, 'out> fn(
+    EdgeVisit<'tree, 'source, 'context>,
+    &'emit mut EdgeEmitter<'out>,
+);
 
 #[derive(Clone, Copy)]
 pub(super) struct KindPreference {
@@ -196,15 +200,14 @@ pub(super) fn parser_backend(language: Language) -> &'static dyn ParserBackend {
     }
 }
 
-pub(super) fn edge_backend(language: Language) -> Option<&'static dyn EdgeBackend> {
+pub(super) fn edge_extractor(language: Language) -> Option<EdgeExtractor> {
     match language {
-        Language::Rust => Some(&rust::SUPPORT),
-        Language::TypeScript => Some(&typescript::SUPPORT),
-        Language::Kotlin => Some(&kotlin::SUPPORT),
-        Language::C => Some(&c_family::C_SUPPORT),
-        Language::Cpp => Some(&c_family::CPP_SUPPORT),
-        Language::Python => Some(&python::SUPPORT),
-        Language::Swift => Some(&swift::SUPPORT),
+        Language::Rust => Some(rust::rust_edges),
+        Language::TypeScript => Some(typescript::typescript_edges),
+        Language::Kotlin => Some(kotlin::kotlin_edges),
+        Language::C | Language::Cpp => Some(c_family::c_like_edges),
+        Language::Python => Some(python::python_edges),
+        Language::Swift => Some(swift::swift_edges),
         Language::Markdown => None,
     }
 }
@@ -266,7 +269,7 @@ mod tests {
 
     use rag_rat_base::language::Language;
 
-    use super::{edge_backend, parser_backend};
+    use super::{edge_extractor, parser_backend};
     use crate::index::parser::{self, ParserKind};
 
     #[test]
@@ -279,7 +282,7 @@ mod tests {
             let kind = parser_backend(language).parser_kind(path);
             assert_eq!(kind == ParserKind::Markdown, language == Language::Markdown);
             assert_eq!(parser::grammar_for(kind).is_some(), language != Language::Markdown);
-            assert_eq!(edge_backend(language).is_some(), language != Language::Markdown);
+            assert_eq!(edge_extractor(language).is_some(), language != Language::Markdown);
         }
     }
 }

--- a/crates/rag-rat-core/src/index/languages/python/edges.rs
+++ b/crates/rag-rat-core/src/index/languages/python/edges.rs
@@ -8,7 +8,7 @@ use tree_sitter::Node;
 use crate::index::edges::extract::*;
 use crate::index::edges::*;
 
-pub(super) fn python_edges(
+pub(in crate::index::languages) fn python_edges(
     EdgeVisit { text, node, symbols: _, path, locator }: EdgeVisit<'_, '_, '_>,
     emit: &mut EdgeEmitter<'_>,
 ) {

--- a/crates/rag-rat-core/src/index/languages/python/mod.rs
+++ b/crates/rag-rat-core/src/index/languages/python/mod.rs
@@ -3,12 +3,13 @@ use std::path::Path;
 use tree_sitter::Node;
 
 use super::{
-    EdgeBackend, EdgeEmitter, EdgeVisit, ImportAliasRebind, ImportAliasRequest, KindPreference,
-    ParserBackend, ResolverPolicy, SymbolMatch,
+    ImportAliasRebind, ImportAliasRequest, KindPreference, ParserBackend, ResolverPolicy,
+    SymbolMatch,
 };
 use crate::index::parser::{self, ParserKind};
 
 mod edges;
+pub(super) use edges::python_edges;
 
 pub(super) static SUPPORT: Python = Python;
 
@@ -118,12 +119,6 @@ fn assignment_is_const_scope(node: Node<'_>) -> bool {
         }
     }
     false
-}
-
-impl EdgeBackend for Python {
-    fn edges(&self, visit: EdgeVisit<'_, '_, '_>, emit: &mut EdgeEmitter<'_>) {
-        edges::python_edges(visit, emit);
-    }
 }
 
 impl ResolverPolicy for Python {

--- a/crates/rag-rat-core/src/index/languages/rust/edges.rs
+++ b/crates/rag-rat-core/src/index/languages/rust/edges.rs
@@ -6,7 +6,7 @@ use super::dispatch;
 use crate::index::edges::extract::*;
 use crate::index::edges::*;
 
-pub(super) fn rust_edges(
+pub(in crate::index::languages) fn rust_edges(
     EdgeVisit { text, node, symbols: _, path, locator }: EdgeVisit<'_, '_, '_>,
     emit: &mut EdgeEmitter<'_>,
 ) {

--- a/crates/rag-rat-core/src/index/languages/rust/mod.rs
+++ b/crates/rag-rat-core/src/index/languages/rust/mod.rs
@@ -2,11 +2,12 @@ use std::path::Path;
 
 use tree_sitter::Node;
 
-use super::{EdgeBackend, EdgeEmitter, EdgeVisit, ParserBackend, ResolverPolicy, SymbolMatch};
+use super::{ParserBackend, ResolverPolicy, SymbolMatch};
 use crate::index::parser::{self, ParsedSymbolFact, ParserKind};
 
 mod dispatch;
 mod edges;
+pub(super) use edges::rust_edges;
 
 pub(super) static SUPPORT: Rust = Rust;
 
@@ -129,12 +130,6 @@ fn attribute_items(text: &str, node: Node<'_>) -> Vec<String> {
     preceding.reverse();
     preceding.extend(attributes);
     preceding
-}
-
-impl EdgeBackend for Rust {
-    fn edges(&self, visit: EdgeVisit<'_, '_, '_>, emit: &mut EdgeEmitter<'_>) {
-        edges::rust_edges(visit, emit);
-    }
 }
 
 impl ResolverPolicy for Rust {

--- a/crates/rag-rat-core/src/index/languages/swift/edges.rs
+++ b/crates/rag-rat-core/src/index/languages/swift/edges.rs
@@ -6,7 +6,7 @@ use super::syntax;
 use crate::index::edges::extract::*;
 use crate::index::edges::*;
 
-pub(super) fn swift_edges(
+pub(in crate::index::languages) fn swift_edges(
     EdgeVisit { text, node, symbols, path, locator }: EdgeVisit<'_, '_, '_>,
     emit: &mut EdgeEmitter<'_>,
 ) {

--- a/crates/rag-rat-core/src/index/languages/swift/mod.rs
+++ b/crates/rag-rat-core/src/index/languages/swift/mod.rs
@@ -2,12 +2,11 @@ use std::path::Path;
 
 use tree_sitter::Node;
 
-use super::{
-    EdgeBackend, EdgeEmitter, EdgeVisit, KindPreference, ParserBackend, ResolverPolicy, SymbolMatch,
-};
+use super::{KindPreference, ParserBackend, ResolverPolicy, SymbolMatch};
 use crate::index::parser::{self, ParserKind};
 
 mod edges;
+pub(super) use edges::swift_edges;
 pub(super) mod syntax;
 
 pub(super) static SUPPORT: Swift = Swift;
@@ -269,12 +268,6 @@ fn direct_child_of_kind<'tree>(node: Node<'tree>, kind: &str) -> Option<Node<'tr
         let index = u32::try_from(index).ok()?;
         node.child(index).filter(|child| child.kind() == kind)
     })
-}
-
-impl EdgeBackend for Swift {
-    fn edges(&self, visit: EdgeVisit<'_, '_, '_>, emit: &mut EdgeEmitter<'_>) {
-        edges::swift_edges(visit, emit);
-    }
 }
 
 impl ResolverPolicy for Swift {

--- a/crates/rag-rat-core/src/index/languages/typescript/edges.rs
+++ b/crates/rag-rat-core/src/index/languages/typescript/edges.rs
@@ -2,7 +2,7 @@
 use crate::index::edges::extract::*;
 use crate::index::edges::*;
 
-pub(super) fn typescript_edges(
+pub(in crate::index::languages) fn typescript_edges(
     EdgeVisit { text, node, symbols: _, path, locator }: EdgeVisit<'_, '_, '_>,
     emit: &mut EdgeEmitter<'_>,
 ) {

--- a/crates/rag-rat-core/src/index/languages/typescript/mod.rs
+++ b/crates/rag-rat-core/src/index/languages/typescript/mod.rs
@@ -2,10 +2,11 @@ use std::path::Path;
 
 use tree_sitter::Node;
 
-use super::{EdgeBackend, EdgeEmitter, EdgeVisit, ParserBackend, SymbolMatch};
+use super::{ParserBackend, SymbolMatch};
 use crate::index::parser::{self, ParserKind};
 
 mod edges;
+pub(super) use edges::typescript_edges;
 
 pub(super) static SUPPORT: TypeScript = TypeScript;
 
@@ -51,11 +52,5 @@ impl ParserBackend for TypeScript {
 
     fn is_plumbing_node(&self, node: Node<'_>) -> bool {
         node.kind().contains("comment") || node.kind() == "import_statement"
-    }
-}
-
-impl EdgeBackend for TypeScript {
-    fn edges(&self, visit: EdgeVisit<'_, '_, '_>, emit: &mut EdgeEmitter<'_>) {
-        edges::typescript_edges(visit, emit);
     }
 }


### PR DESCRIPTION
## Summary

- replace forwarding-only `EdgeBackend` trait implementations with a typed `EdgeExtractor` function registry
- keep the shared iterative walker as the sole whole-tree traversal
- preserve the constrained `EdgeVisit` / `EdgeEmitter` boundary for manual and future query-backed extractors
- keep edge extraction optional, with Markdown explicitly registering no extractor

## Validation

- `cargo +nightly fmt --all -- --check`
- `cargo clippy -p rag-rat-core --all-targets -- -D warnings`
- `cargo nextest run -p rag-rat-core --test-threads 2` using mold to keep the test-binary link within host memory limits
- `git diff --check`

Fixes #939