### PR TITLE
feat(sync): add one-time device enrollment wire protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5159,12 +5159,15 @@ name = "rag-rat-sync"
 version = "0.21.1"
 dependencies = [
  "anyhow",
+ "getrandom 0.4.3",
  "iroh",
  "minicbor",
  "rag-rat-base",
  "rag-rat-db",
  "rag-rat-oplog",
  "rusqlite",
+ "sha2",
+ "tempfile",
  "tokio",
  "tracing",
 ]

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
@@ -1266,12 +1266,10 @@ fn migration_087_adds_table_sync_tables() {
 
 /// V088 (#830) caches each clone generation's posting-row count on its generation row so the #598
 /// delta work budget reads one column instead of a full `COUNT(*)` scan of the postings table.
-/// Carries the absolute schema-tip pin now that V088 is newest. Verifies the column exists on a
-/// fresh ladder and that the applier backfills an existing generation from its actual postings.
+/// Verifies the column exists on a fresh ladder and that the applier backfills an existing
+/// generation from its actual postings.
 #[test]
 fn migration_088_caches_the_generation_posting_row_count() {
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 88, "move this pin with the next schema migration");
-
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     schema::apply(&conn, &crate::index::migration_hooks()).unwrap();
     assert_eq!(
@@ -1326,4 +1324,190 @@ fn migration_088_caches_the_generation_posting_row_count() {
         )
         .unwrap();
     assert_eq!(after_reapply, 3, "a re-apply recomputes the same exact count");
+}
+
+/// V089 (#945) adds the durable one-time invite row redeemed by the enrollment ALPN.
+#[test]
+fn migration_089_adds_sync_invites() {
+    let bare = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply_sync_invites(&bare).unwrap();
+    schema::apply_sync_invites(&bare).expect("replay is a no-op");
+    assert!(conn_table_exists(&bare, "sync_invites"));
+    assert!(
+        !conn_table_exists(&bare, "account_candidate_reservations"),
+        "V089 stays frozen; the reservation table is V090",
+    );
+    assert!(
+        bare.execute(
+            "INSERT INTO sync_invites(
+                 nonce, account_id, role, label, expires_at_ms, created_at_ms, used_at_ms
+             ) VALUES (zeroblob(32), zeroblob(32), 'administrator', NULL, 2, 1, NULL)",
+            [],
+        )
+        .is_err(),
+        "the store rejects roles outside the frozen three-level vocabulary",
+    );
+    assert!(
+        bare.execute(
+            "INSERT INTO sync_invites(
+                 nonce, account_id, role, label, expires_at_ms, created_at_ms, used_at_ms
+             ) VALUES (zeroblob(32), zeroblob(32), 'member', NULL, 2, 1, 2)",
+            [],
+        )
+        .is_err(),
+        "a consumed invite must persist its complete replay identity and receipt",
+    );
+
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn, &crate::index::migration_hooks()).unwrap();
+    assert_eq!(schema::status(&conn).unwrap().current_version, schema::LATEST_SCHEMA_VERSION);
+    let recorded: i64 = conn
+        .query_row("SELECT COUNT(*) FROM schema_version WHERE id = '089_sync_invites'", [], |row| {
+            row.get(0)
+        })
+        .unwrap();
+    assert_eq!(recorded, 1, "the forward migration records V089");
+}
+
+/// V090 (#949) adds durable candidate-capacity reservations for outstanding enrollment invites.
+#[test]
+fn migration_090_adds_account_candidate_reservations() {
+    let bare = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply_account_candidate_reservations(&bare).unwrap();
+    schema::apply_account_candidate_reservations(&bare).expect("replay is a no-op");
+    assert!(conn_table_exists(&bare, "account_candidate_reservations"));
+    assert!(
+        bare.execute(
+            "INSERT INTO account_candidate_reservations(
+                 reservation_id, account_id, reserved_entries, reserved_bytes, expires_at_ms
+             ) VALUES (zeroblob(32), zeroblob(32), -1, 0, 2)",
+            [],
+        )
+        .is_err(),
+        "a reservation cannot hold a negative entry count",
+    );
+
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn, &crate::index::migration_hooks()).unwrap();
+    assert_eq!(schema::status(&conn).unwrap().current_version, schema::LATEST_SCHEMA_VERSION);
+    let recorded: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM schema_version WHERE id = '090_account_candidate_reservations'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(recorded, 1, "the forward migration records V090");
+}
+
+/// V092 (#949) drops the duplicated per-invite receipt copy; replay reconstructs the bootstrap
+/// from the grow-only candidate DAG.
+#[test]
+fn migration_092_normalizes_invite_receipts() {
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 92, "move this pin with the next schema migration");
+
+    let bare = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply_sync_invites(&bare).unwrap();
+    bare.execute(
+        "INSERT INTO sync_invites(
+             nonce, account_id, role, label, expires_at_ms, created_at_ms, used_at_ms,
+             used_transport_node, used_ed25519_pubkey, used_x25519_pubkey,
+             receipt_hash, receipt_signed, receipt_bytes
+         ) VALUES (zeroblob(32), zeroblob(32), 'member', NULL, 10, 1, 2,
+                   zeroblob(32), zeroblob(32), zeroblob(32),
+                   zeroblob(32), X'01', X'01020304')",
+        [],
+    )
+    .unwrap();
+    schema::apply_sync_invites_normalized_receipts(&bare).unwrap();
+    schema::apply_sync_invites_normalized_receipts(&bare).expect("replay is a no-op");
+    let (role, receipt, legacy): (String, Vec<u8>, Vec<u8>) = bare
+        .query_row(
+            "SELECT role, receipt_signed, receipt_bytes FROM sync_invites
+              WHERE nonce = zeroblob(32)",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .unwrap();
+    assert_eq!(
+        (role.as_str(), receipt.as_slice(), legacy.as_slice()),
+        ("member", &[1][..], &[1, 2, 3, 4][..]),
+        "a consumed invite keeps replaying through its window"
+    );
+
+    // Replaying V092 over a POST-V092 row (the `index --full` recovery path) preserves the
+    // normalized manifest rather than nulling it into the consumed-row CHECK.
+    bare.execute(
+        "INSERT INTO sync_invites(
+             nonce, account_id, role, label, expires_at_ms, created_at_ms, used_at_ms,
+             used_transport_node, used_ed25519_pubkey, used_x25519_pubkey,
+             receipt_hash, receipt_signed, receipt_entries, receipt_bytes
+         ) VALUES (X'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', zeroblob(32), 'member', NULL, 10, 1, 2,
+                   zeroblob(32), zeroblob(32), zeroblob(32),
+                   zeroblob(32), X'01', X'02020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202', NULL)",
+        [],
+    )
+    .unwrap();
+    schema::apply_sync_invites_normalized_receipts(&bare).unwrap();
+    let manifest: Vec<u8> = bare
+        .query_row(
+            "SELECT receipt_entries FROM sync_invites
+              WHERE nonce = X'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(manifest.len(), 64, "the re-applied migration preserves stored manifests");
+
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn, &crate::index::migration_hooks()).unwrap();
+    assert_eq!(schema::status(&conn).unwrap().current_version, 92);
+    let recorded: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM schema_version
+              WHERE id = '092_sync_invites_normalized_receipts'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(recorded, 1, "the forward migration records V092");
+}
+
+/// V091 (#949) tracks the live key-target count each invite reservation covers, so fold-time
+/// growth — local or synced — can top reservations up to the current mandatory cost.
+#[test]
+fn migration_091_adds_account_candidate_reservation_targets() {
+    let bare = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply_account_candidate_reservations(&bare).unwrap();
+    bare.execute(
+        "INSERT INTO account_candidate_reservations(
+             reservation_id, account_id, reserved_entries, reserved_bytes, expires_at_ms
+         ) VALUES (zeroblob(32), zeroblob(32), 4, 900, 10)",
+        [],
+    )
+    .unwrap();
+    schema::apply_account_candidate_reservation_targets(&bare).unwrap();
+    schema::apply_account_candidate_reservation_targets(&bare).expect("replay is a no-op");
+    let targets: i64 = bare
+        .query_row(
+            "SELECT reserved_targets FROM account_candidate_reservations
+              WHERE reservation_id = zeroblob(32)",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(targets, 3, "the backfill recovers reserved_entries - 1 covered targets");
+
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn, &crate::index::migration_hooks()).unwrap();
+    assert_eq!(schema::status(&conn).unwrap().current_version, schema::LATEST_SCHEMA_VERSION);
+    let recorded: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM schema_version
+              WHERE id = '091_account_candidate_reservation_targets'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(recorded, 1, "the forward migration records V091");
 }

--- a/crates/rag-rat-core/src/memory_write/authoring.rs
+++ b/crates/rag-rat-core/src/memory_write/authoring.rs
@@ -356,8 +356,12 @@ impl ReconcileWork {
 /// Settling in-transaction bounds the cost to ONE fold per local write — work the write's own
 /// authoring performs anyway — and lets a mid-write enqueue self-heal. A fold failure propagates
 /// and rolls the write back, so the barrier stays fail-closed.
-fn settle_owner_stream_in_tx(tx: &Transaction<'_>, stream: StreamId) -> anyhow::Result<()> {
-    rag_rat_oplog::settle_pending_content_refold_for_stream_in_tx(tx, stream)
+fn settle_owner_stream_in_tx(
+    tx: &Transaction<'_>,
+    stream: StreamId,
+    now_ms: i64,
+) -> anyhow::Result<()> {
+    rag_rat_oplog::settle_pending_content_refold_for_stream_in_tx(tx, stream, now_ms)
         .context("settling the owner stream's pending content refold before reading completeness")
 }
 
@@ -457,7 +461,7 @@ fn sync_owner_stream(conn: &Connection, repo_id: &str, now_ms: i64) -> anyhow::R
     let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
     // Settle the owner stream's deferred refold debt HERE, inside the write's own transaction and
     // before the authoritative re-read, so completeness is read against a current projection.
-    settle_owner_stream_in_tx(&tx, stream)?;
+    settle_owner_stream_in_tx(&tx, stream, now_ms)?;
     anyhow::ensure!(
         stream_seal_policy(&tx, repo_id, stream)? == policy,
         "memory stream seal policy changed while preparing reconcile; retry"
@@ -606,7 +610,7 @@ pub(crate) fn enable_sealed_authoring(conn: &Connection, now_ms: i64) -> anyhow:
     rag_rat_db::meta::set_repo_meta(&tx, &repo_id, STREAM_SEAL_POLICY_META_KEY, "sealed")?;
     // Same barrier discipline as the reconcile path: settle inside this transaction so the sealed
     // re-authoring below reads completeness against a current accepted-`/3` projection.
-    settle_owner_stream_in_tx(&tx, stream)?;
+    settle_owner_stream_in_tx(&tx, stream, now_ms)?;
     let work = read_reconcile_work(&tx, &repo_id, stream, StreamSealPolicy::Sealed)?;
     work.warn_quarantined(&repo_id);
     let ops = build_reconcile_ops(

--- a/crates/rag-rat-core/src/memory_write/drain.rs
+++ b/crates/rag-rat-core/src/memory_write/drain.rs
@@ -133,7 +133,7 @@ pub(crate) fn drain_synced_stream_for_repo(
     // the projection read, so the drain mirrors a CURRENT accepted set. A settle failure propagates
     // and rolls the drain back, so the barrier stays fail-closed (same discipline as the
     // reconcile).
-    rag_rat_oplog::settle_pending_content_refold_for_stream_in_tx(&tx, stream)?;
+    rag_rat_oplog::settle_pending_content_refold_for_stream_in_tx(&tx, stream, now_ms)?;
     let outcome = drain_synced_stream_in_tx(&tx, repo_id, stream, now_ms)?;
     // Stamp the watermark to the epoch AFTER the settle above (which may have advanced it), so the
     // next `content_drain_needed` short-circuits until the projection changes again. In the same

--- a/crates/rag-rat-db/src/schema/migrations.rs
+++ b/crates/rag-rat-db/src/schema/migrations.rs
@@ -1374,6 +1374,10 @@ pub(crate) fn known_version(migrations: &[AppliedMigration]) -> u32 {
             MIGRATION_086_ID => Some(86),
             MIGRATION_087_ID => Some(87),
             MIGRATION_088_ID => Some(88),
+            MIGRATION_089_ID => Some(89),
+            MIGRATION_090_ID => Some(90),
+            MIGRATION_091_ID => Some(91),
+            MIGRATION_092_ID => Some(92),
             _ => None,
         })
         .max()
@@ -1471,6 +1475,10 @@ pub(crate) fn known_migration(id: &str) -> bool {
             | MIGRATION_086_ID
             | MIGRATION_087_ID
             | MIGRATION_088_ID
+            | MIGRATION_089_ID
+            | MIGRATION_090_ID
+            | MIGRATION_091_ID
+            | MIGRATION_092_ID
             | DIRTY_MIGRATION_ID
     )
 }
@@ -1565,6 +1573,10 @@ pub(crate) fn migration_checksum_mismatch(migration: &AppliedMigration) -> bool 
         MIGRATION_086_ID => migration.checksum != MIGRATION_086_CHECKSUM,
         MIGRATION_087_ID => migration.checksum != MIGRATION_087_CHECKSUM,
         MIGRATION_088_ID => migration.checksum != MIGRATION_088_CHECKSUM,
+        MIGRATION_089_ID => migration.checksum != MIGRATION_089_CHECKSUM,
+        MIGRATION_090_ID => migration.checksum != MIGRATION_090_CHECKSUM,
+        MIGRATION_091_ID => migration.checksum != MIGRATION_091_CHECKSUM,
+        MIGRATION_092_ID => migration.checksum != MIGRATION_092_CHECKSUM,
         _ => false,
     }
 }
@@ -6109,6 +6121,165 @@ pub fn apply_clone_postings_row_count(conn: &Connection) -> rusqlite::Result<()>
                  WHERE build_generation = clone_graph_generations.generation);",
     )?;
     Ok(())
+}
+
+/// V089 (#945): durable, single-use enrollment invites.
+pub fn apply_sync_invites(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS sync_invites(
+             nonce         BLOB    NOT NULL PRIMARY KEY CHECK(length(nonce) = 32),
+             account_id    BLOB    NOT NULL CHECK(length(account_id) = 32),
+             role          TEXT    NOT NULL CHECK(role IN ('read_only', 'member', 'owner')),
+             label         TEXT,
+             expires_at_ms INTEGER NOT NULL,
+             created_at_ms INTEGER NOT NULL,
+             used_at_ms    INTEGER,
+             used_transport_node BLOB CHECK(
+                 used_transport_node IS NULL OR length(used_transport_node) = 32
+             ),
+             used_ed25519_pubkey BLOB CHECK(
+                 used_ed25519_pubkey IS NULL OR length(used_ed25519_pubkey) = 32
+             ),
+             used_x25519_pubkey BLOB CHECK(
+                 used_x25519_pubkey IS NULL OR length(used_x25519_pubkey) = 32
+             ),
+             receipt_hash BLOB CHECK(receipt_hash IS NULL OR length(receipt_hash) = 32),
+             receipt_signed BLOB,
+             receipt_bytes BLOB,
+             CHECK(
+                 (used_at_ms IS NULL
+                  AND used_transport_node IS NULL
+                  AND used_ed25519_pubkey IS NULL
+                  AND used_x25519_pubkey IS NULL
+                  AND receipt_hash IS NULL
+                  AND receipt_signed IS NULL
+                  AND receipt_bytes IS NULL)
+                 OR
+                 (used_at_ms IS NOT NULL
+                  AND used_transport_node IS NOT NULL
+                  AND used_ed25519_pubkey IS NOT NULL
+                  AND used_x25519_pubkey IS NOT NULL
+                  AND receipt_hash IS NOT NULL
+                  AND receipt_signed IS NOT NULL
+                  AND receipt_bytes IS NOT NULL)
+             )
+         ) STRICT;
+         CREATE INDEX IF NOT EXISTS sync_invites_account_expiry
+             ON sync_invites(account_id, expires_at_ms);",
+    )
+}
+
+/// V090 (#949): durable candidate-capacity reservations for outstanding enrollment invites.
+pub fn apply_account_candidate_reservations(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS account_candidate_reservations(
+             reservation_id BLOB    NOT NULL PRIMARY KEY CHECK(length(reservation_id) = 32),
+             account_id     BLOB    NOT NULL CHECK(length(account_id) = 32),
+             reserved_entries INTEGER NOT NULL CHECK(reserved_entries >= 0),
+             reserved_bytes   INTEGER NOT NULL CHECK(reserved_bytes >= 0),
+             expires_at_ms    INTEGER NOT NULL
+         ) STRICT;
+         CREATE INDEX IF NOT EXISTS account_candidate_reservations_account_expiry
+             ON account_candidate_reservations(account_id, expires_at_ms);",
+    )
+}
+
+/// V091 (#949): track the live key-target count each invite reservation covers, so any fold that
+/// grows the target set — local authoring or REMOTELY synced `StreamOwn`/wrap entries — can top
+/// the reservation up to the current mandatory redemption cost.
+///
+/// Additive + idempotent. The backfill is exact for every reservation written since V090: those
+/// rows hold `reserved_entries = 1 (DeviceAdd) + covered_targets`, so `reserved_entries - 1`
+/// recovers the covered target count.
+pub fn apply_account_candidate_reservation_targets(conn: &Connection) -> rusqlite::Result<()> {
+    add_column_if_missing(
+        conn,
+        "account_candidate_reservations",
+        "reserved_targets",
+        "INTEGER NOT NULL DEFAULT 0",
+    )?;
+    conn.execute_batch(
+        "UPDATE account_candidate_reservations
+            SET reserved_targets = MAX(0, reserved_entries - 1);",
+    )?;
+    Ok(())
+}
+
+/// V092 (#949): stop duplicating every enrollment receipt in the invite row.
+///
+/// Each consumed invite used to store the complete signed account bootstrap (`receipt_bytes`),
+/// so a fleet enrolling within the replay window kept one full history copy PER invite —
+/// quadratic growth in a grow-only store. New redemptions persist only the joiner-specific
+/// `DeviceAdd` envelope plus the manifest of receipt entry hashes (`receipt_entries`, 32 bytes
+/// each in receipt order), and replay reconstructs the EXACT acknowledged receipt from the
+/// grow-only candidate DAG. The legacy `receipt_bytes` column is RETAINED (never written again)
+/// so invites consumed before this migration keep replaying through their 24h window; pruning
+/// drops both forms. Rebuilds the table, preserving every row.
+pub fn apply_sync_invites_normalized_receipts(conn: &Connection) -> rusqlite::Result<()> {
+    // A re-apply (the sanctioned `index --full` recovery) sees the V092 shape: preserve its
+    // `receipt_entries` manifests rather than nulling them into the consumed-row CHECK.
+    let already_normalized = column_exists(conn, "sync_invites", "receipt_entries")?;
+    let entries_expr = if already_normalized { "receipt_entries" } else { "NULL" };
+    let tx = conn.unchecked_transaction()?;
+    tx.execute_batch(
+        "CREATE TABLE sync_invites_v092(
+             nonce         BLOB    NOT NULL PRIMARY KEY CHECK(length(nonce) = 32),
+             account_id    BLOB    NOT NULL CHECK(length(account_id) = 32),
+             role          TEXT    NOT NULL CHECK(role IN ('read_only', 'member', 'owner')),
+             label         TEXT,
+             expires_at_ms INTEGER NOT NULL,
+             created_at_ms INTEGER NOT NULL,
+             used_at_ms    INTEGER,
+             used_transport_node BLOB CHECK(
+                 used_transport_node IS NULL OR length(used_transport_node) = 32
+             ),
+             used_ed25519_pubkey BLOB CHECK(
+                 used_ed25519_pubkey IS NULL OR length(used_ed25519_pubkey) = 32
+             ),
+             used_x25519_pubkey BLOB CHECK(
+                 used_x25519_pubkey IS NULL OR length(used_x25519_pubkey) = 32
+             ),
+             receipt_hash BLOB CHECK(receipt_hash IS NULL OR length(receipt_hash) = 32),
+             receipt_signed BLOB,
+             receipt_entries BLOB CHECK(
+                 receipt_entries IS NULL OR length(receipt_entries) % 32 = 0
+             ),
+             receipt_bytes BLOB,
+             CHECK(
+                 (used_at_ms IS NULL
+                  AND used_transport_node IS NULL
+                  AND used_ed25519_pubkey IS NULL
+                  AND used_x25519_pubkey IS NULL
+                  AND receipt_hash IS NULL
+                  AND receipt_signed IS NULL
+                  AND receipt_entries IS NULL
+                  AND receipt_bytes IS NULL)
+                 OR
+                 (used_at_ms IS NOT NULL
+                  AND used_transport_node IS NOT NULL
+                  AND used_ed25519_pubkey IS NOT NULL
+                  AND used_x25519_pubkey IS NOT NULL
+                  AND receipt_hash IS NOT NULL
+                  AND receipt_signed IS NOT NULL
+                  AND (receipt_entries IS NOT NULL OR receipt_bytes IS NOT NULL))
+              )
+         ) STRICT;",
+    )?;
+    tx.execute_batch(&format!(
+        "INSERT INTO sync_invites_v092(
+             nonce, account_id, role, label, expires_at_ms, created_at_ms, used_at_ms,
+             used_transport_node, used_ed25519_pubkey, used_x25519_pubkey,
+             receipt_hash, receipt_signed, receipt_entries, receipt_bytes)
+          SELECT nonce, account_id, role, label, expires_at_ms, created_at_ms, used_at_ms,
+             used_transport_node, used_ed25519_pubkey, used_x25519_pubkey,
+             receipt_hash, receipt_signed, {entries_expr}, receipt_bytes
+            FROM sync_invites;
+         DROP TABLE sync_invites;
+         ALTER TABLE sync_invites_v092 RENAME TO sync_invites;
+         CREATE INDEX IF NOT EXISTS sync_invites_account_expiry
+             ON sync_invites(account_id, expires_at_ms);"
+    ))?;
+    tx.commit()
 }
 
 #[cfg(test)]

--- a/crates/rag-rat-db/src/schema/mod.rs
+++ b/crates/rag-rat-db/src/schema/mod.rs
@@ -8,7 +8,8 @@ pub(crate) use migrations::*;
 // Migration steps and table lists the engine's schema tests exercise directly:
 pub use migrations::{
     apply_account_authority_boundaries, apply_account_authority_projection,
-    apply_account_candidate_dag, apply_chunk_symbol_id, apply_clone_delta_maintenance,
+    apply_account_candidate_dag, apply_account_candidate_reservation_targets,
+    apply_account_candidate_reservations, apply_chunk_symbol_id, apply_clone_delta_maintenance,
     apply_clone_df_epoch, apply_clone_fingerprint_tables, apply_clone_graph_tables,
     apply_clone_postings_row_count, apply_content_candidate_dag, apply_content_digest_state,
     apply_content_projected_tables, apply_content_refold_queue_and_stats,
@@ -24,6 +25,7 @@ pub use migrations::{
     apply_papertrail_distill_substrate, apply_papertrail_mirror_resume_state,
     apply_papertrail_provider_neutral_schema, apply_repo_id_core_scoping,
     apply_repo_id_periphery_scoping, apply_repos_registry, apply_scip_moniker_anchors,
+    apply_sync_invites, apply_sync_invites_normalized_receipts,
     apply_sync_origin_and_edge_tombstone, apply_table_sync_tables,
 };
 pub use migrations::{column_exists, rebuild_repo_memory_fts_with_repo_id, table_exists};
@@ -47,7 +49,7 @@ use serde::Serialize;
 
 use crate::hooks::MigrationHooks;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 88;
+pub const LATEST_SCHEMA_VERSION: u32 = 92;
 
 /// Every oracle-DERIVED persisted table — the outputs an `oracle run` writes that must OUTLIVE a
 /// reindex.
@@ -663,6 +665,37 @@ const MIGRATION_088_DESCRIPTION: &str =
      reading a maintained column replaces a full COUNT(*) scan of the postings table on every \
      delta pass. Additive; existing rows backfill from the current postings, and the count is \
      then maintained transactionally at build (complete_generation) and in each delta write-back";
+const MIGRATION_089_ID: &str = "089_sync_invites";
+const MIGRATION_089_CHECKSUM: &str = "sha256:rag-rat-sync-invites-bootstrap-replay-v89";
+const MIGRATION_089_DESCRIPTION: &str =
+    "Add the durable one-time enrollment invite store: a random nonce binds one account, granted \
+     device role, optional label, and expiry; successful redemption stores the exact request \
+     identity, signed DeviceAdd, and exact account-log bootstrap receipt in the same transaction \
+     as invite consumption and key catch-up, so delivery failures can replay the acknowledged \
+     enrollment idempotently and a fresh joiner can authorize its first closed sync";
+const MIGRATION_090_ID: &str = "090_account_candidate_reservations";
+const MIGRATION_090_CHECKSUM: &str = "sha256:rag-rat-account-candidate-reservations-v90";
+const MIGRATION_090_DESCRIPTION: &str =
+    "Add durable candidate-capacity reservations for outstanding enrollment invites (#949): a \
+     minted invite reserves the exact entries/bytes its mandatory DeviceAdd plus stream-key wraps \
+     will consume, and candidate admission charges active reservations against the same grow-only \
+     counters, so ordinary ingest or a second mint cannot strand an already-minted ticket. \
+     Redemption releases its reservation under the writer lock; expiry frees it";
+const MIGRATION_091_ID: &str = "091_account_candidate_reservation_targets";
+const MIGRATION_091_CHECKSUM: &str = "sha256:rag-rat-account-candidate-reservation-targets-v91";
+const MIGRATION_091_DESCRIPTION: &str =
+    "Track the live key-target count each outstanding invite reservation covers \
+     (account_candidate_reservations.reserved_targets, #949): any fold that grows the target set \
+     — local key mints or remotely synced StreamOwn/wrap entries — tops reservations up to the \
+     current mandatory redemption cost, so a minted ticket cannot be stranded by later growth. \
+     Backfilled from reserved_entries - 1, exact for every V090-era row";
+const MIGRATION_092_ID: &str = "092_sync_invites_normalized_receipts";
+const MIGRATION_092_CHECKSUM: &str = "sha256:rag-rat-sync-invites-normalized-receipts-v92";
+const MIGRATION_092_DESCRIPTION: &str =
+    "Drop sync_invites.receipt_bytes (#949): consumed invites keep only the joiner-specific \
+     DeviceAdd envelope; the account bootstrap is already durable in the grow-only candidate DAG, \
+     and receipt replay reconstructs the snapshot from it instead of storing one full copy per \
+     invite (quadratic growth across a fleet). Table rebuild preserving every row";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -1387,6 +1420,30 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         checksum: MIGRATION_088_CHECKSUM,
         description: MIGRATION_088_DESCRIPTION,
         apply: MigrationFn::Plain(apply_clone_postings_row_count),
+    },
+    Migration {
+        id: MIGRATION_089_ID,
+        checksum: MIGRATION_089_CHECKSUM,
+        description: MIGRATION_089_DESCRIPTION,
+        apply: MigrationFn::Plain(apply_sync_invites),
+    },
+    Migration {
+        id: MIGRATION_090_ID,
+        checksum: MIGRATION_090_CHECKSUM,
+        description: MIGRATION_090_DESCRIPTION,
+        apply: MigrationFn::Plain(apply_account_candidate_reservations),
+    },
+    Migration {
+        id: MIGRATION_091_ID,
+        checksum: MIGRATION_091_CHECKSUM,
+        description: MIGRATION_091_DESCRIPTION,
+        apply: MigrationFn::Plain(apply_account_candidate_reservation_targets),
+    },
+    Migration {
+        id: MIGRATION_092_ID,
+        checksum: MIGRATION_092_CHECKSUM,
+        description: MIGRATION_092_DESCRIPTION,
+        apply: MigrationFn::Plain(apply_sync_invites_normalized_receipts),
     },
 ];
 

--- a/crates/rag-rat-oplog/src/account/authoring.rs
+++ b/crates/rag-rat-oplog/src/account/authoring.rs
@@ -17,14 +17,18 @@
 //! gate serializes racers, so a duplicate `StreamOwn` is never authored at all.
 
 use anyhow::Context;
-use rusqlite::{Connection, OptionalExtension, Transaction, params};
+use rusqlite::{Connection, OptionalExtension, Transaction, TransactionBehavior, params};
 
 use super::bootstrap::{self, LocalAccountRef};
-use super::envelope::{AccountEntryHeader, VerifiedAccountEntry, sign_account_entry};
+use super::envelope::{
+    AccountEntryHeader, VerifiedAccountEntry, sign_account_entry, signed_entry_len,
+};
 use super::id::AccountId;
+use super::limits::ACCOUNT_ENVELOPE_MAX_BYTES;
 use super::ops::{self, AccountOp};
 use super::storage::{self, CandidateInsert};
 use super::{AuthorityQuery, fold};
+use crate::device::{DeviceSecret, DeviceX25519Secret};
 use crate::identity::LocalDevice;
 use crate::local_device;
 use crate::op::DeviceFingerprint;
@@ -206,6 +210,125 @@ pub struct EnrollingDevice {
     pub label: Option<String>,
 }
 
+/// The exact mandatory candidate cost of redeeming an enrollment invite: one `DeviceAdd` plus one
+/// stream-key wrap per live key target across `streams`, measured from the real encoders at the
+/// maximum header width (the `DeviceAdd` at its actual role/label via
+/// [`device_add_envelope_bytes`], a one-recipient wrap via
+/// [`super::secrets::single_recipient_wrap_envelope_bytes`]). Mint persists this as the invite's
+/// candidate-capacity reservation; redemption releases the reservation and consumes exactly it.
+pub fn enrollment_authoring_requirements(
+    conn: &Connection,
+    account_id: AccountId,
+    streams: &[StreamId],
+    role: ops::DeviceRole,
+    label: Option<&str>,
+) -> anyhow::Result<(u64, u64)> {
+    let targets =
+        super::secrets::recoverable_live_stream_key_target_count(conn, account_id, streams)?;
+    let required_entries = 1u64.saturating_add(u64::try_from(targets)?);
+    let wrap_bytes = super::secrets::single_recipient_wrap_envelope_bytes();
+    let required_bytes = u64::try_from(
+        device_add_envelope_bytes(role, label)?.saturating_add(wrap_bytes.saturating_mul(targets)),
+    )?;
+    Ok((required_entries, required_bytes))
+}
+
+/// Refuse when the grow-only account candidate store cannot fit the mandatory entries redeeming an
+/// enrollment invite authors: the `DeviceAdd` and one stream-key wrap per live key target across
+/// `streams`. Latent pre-verify promotion is best-effort maintenance after enrollment commits and
+/// never consumes this reservation. Headroom is net of every outstanding invite's reservation at
+/// `now_ms`, so two invites cannot be minted against the same capacity. Read in the caller's
+/// snapshot; the mint transaction re-reads it under the writer lock.
+pub fn enrollment_authoring_fits(
+    conn: &Connection,
+    account_id: AccountId,
+    streams: &[StreamId],
+    role: ops::DeviceRole,
+    label: Option<&str>,
+    now_ms: i64,
+) -> anyhow::Result<()> {
+    let (required_entries, required_bytes) =
+        enrollment_authoring_requirements(conn, account_id, streams, role, label)?;
+    let required_entries = i64::try_from(required_entries)?;
+    let required_bytes = i64::try_from(required_bytes)?;
+    let headroom = storage::candidate_capacity_headroom(conn, account_id, now_ms)?;
+    anyhow::ensure!(
+        headroom.account_entries_remaining >= required_entries
+            && headroom.global_entries_remaining >= required_entries
+            && headroom.account_bytes_remaining >= required_bytes
+            && headroom.global_bytes_remaining >= required_bytes,
+        "the account candidate store cannot fit this enrollment's DeviceAdd and stream-key wraps; \
+         an invite minted now would be unredeemable (candidate capacity is grow-only)",
+    );
+    Ok(())
+}
+
+/// The exact signed-envelope byte length of the `DeviceAdd` [`author_device_add_in_tx`] authors
+/// for `role`/`label`, at the maximum header width. Shared by [`validate_device_add_label`]
+/// (which signs the shape) and [`enrollment_authoring_fits`] (which charges it).
+fn device_add_envelope(
+    role: ops::DeviceRole,
+    label: Option<&str>,
+) -> (AccountEntryHeader, Vec<u8>) {
+    let author = DeviceSecret::from_seed(&[0x41; 32]);
+    let joiner = DeviceSecret::from_seed(&[0x42; 32]);
+    let joiner_x25519 = DeviceX25519Secret::from_seed(&[0x43; 32]);
+    let op = AccountOp::DeviceAdd {
+        device_fingerprint: joiner.public().fingerprint(),
+        ed25519_pubkey: joiner.public().to_bytes(),
+        x25519_pubkey: joiner_x25519.public().to_bytes(),
+        role,
+        label: label.map(str::to_owned),
+    };
+    let payload = ops::encode(&op).expect("a locally-built DeviceAdd encodes");
+    let header = AccountEntryHeader {
+        account_id: AccountId::from_bytes([u8::MAX; 32]),
+        log_id: 0,
+        device_fingerprint: author.public().fingerprint(),
+        seq: u64::MAX,
+        prev_hash: Some([u8::MAX; 32]),
+        parent_ref: Some([u8::MAX; 32]),
+        entry_type: ops::entry_type_of(&op),
+        op_version: 1,
+        crypto_suite: 0,
+        auth_len: u64::MAX,
+        key_id: None,
+        authority_ref: Some([u8::MAX; 32]),
+    };
+    (header, payload)
+}
+
+pub(in crate::account) fn device_add_envelope_bytes(
+    role: ops::DeviceRole,
+    label: Option<&str>,
+) -> anyhow::Result<usize> {
+    if label.is_some_and(|label| label.len() > ACCOUNT_ENVELOPE_MAX_BYTES) {
+        anyhow::bail!(
+            "device label exceeds the {ACCOUNT_ENVELOPE_MAX_BYTES}-byte account envelope limit"
+        );
+    }
+    let (header, payload) = device_add_envelope(role, label);
+    Ok(signed_entry_len(&header, &payload))
+}
+
+/// Validate that `label` can fit in every authorable `DeviceAdd` signed envelope.
+///
+/// This is the shared preflight for invite minting and actual authoring. It deliberately builds
+/// the largest possible header shape used by [`author_device_add_in_tx`] and routes the candidate
+/// through the real op encoder + account-envelope signer, so transport code never duplicates the
+/// account wire's size arithmetic.
+pub fn validate_device_add_label(label: Option<&str>) -> anyhow::Result<()> {
+    if label.is_some_and(|label| label.len() > ACCOUNT_ENVELOPE_MAX_BYTES) {
+        anyhow::bail!(
+            "device label exceeds the {ACCOUNT_ENVELOPE_MAX_BYTES}-byte account envelope limit"
+        );
+    }
+    let (header, payload) = device_add_envelope(ops::DeviceRole::Owner, label);
+    sign_account_entry(&DeviceSecret::from_seed(&[0x41; 32]), &header, &payload)
+        .context("device label cannot fit in an authorable DeviceAdd")?;
+    Ok(())
+}
+
 /// Author a `DeviceAdd` enrolling `joiner` onto the local account's roster at `role`, signed by the
 /// local owner device, and refold WITHIN the caller's transaction. Returns the authored entry hash
 /// (which, for `role == Owner`, IS the added device's owner-incarnation id). Neither opens nor
@@ -223,6 +346,34 @@ pub fn author_device_add_in_tx(
     role: ops::DeviceRole,
     now_ms: i64,
 ) -> anyhow::Result<EntryHash> {
+    author_device_add_with_promotion_in_tx(tx, joiner, role, now_ms, DeviceAddPromotion::Retry)
+}
+
+/// Enrollment-specific DeviceAdd authoring. Mandatory wraps and the durable receipt are committed
+/// before latent pre-verify work is retried, so opaque queue state cannot consume their capacity.
+pub fn author_enrollment_device_add_in_tx(
+    tx: &Transaction<'_>,
+    joiner: EnrollingDevice,
+    role: ops::DeviceRole,
+    now_ms: i64,
+) -> anyhow::Result<EntryHash> {
+    author_device_add_with_promotion_in_tx(tx, joiner, role, now_ms, DeviceAddPromotion::Defer)
+}
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+enum DeviceAddPromotion {
+    Retry,
+    Defer,
+}
+
+fn author_device_add_with_promotion_in_tx(
+    tx: &Transaction<'_>,
+    joiner: EnrollingDevice,
+    role: ops::DeviceRole,
+    now_ms: i64,
+    promotion: DeviceAddPromotion,
+) -> anyhow::Result<EntryHash> {
+    validate_device_add_label(joiner.label.as_deref())?;
     let LocalAccountRef { account_id, genesis_hash } = bootstrap::local_account_ref(tx)?.context(
         "cannot enroll a device before the store's local account is minted (call local_account \
          first)",
@@ -253,6 +404,9 @@ pub fn author_device_add_in_tx(
         label: joiner.label,
     };
     let entry_hash = author_account_op_in_tx(tx, &device, account_id, genesis_hash, &op, now_ms)?;
+    if promotion == DeviceAddPromotion::Retry {
+        storage::promote_after_local_device_add_in_tx(tx, account_id, now_ms)?;
+    }
 
     // Verify the FACT, and the SPECIFIC fact — the joiner's effective roster row is THIS DeviceAdd
     // (`roster_ref == entry_hash`) at the REQUESTED role — never the authored entry's status. Bare
@@ -275,6 +429,18 @@ pub fn author_device_add_in_tx(
         ),
     }
     Ok(entry_hash)
+}
+
+/// Retry pre-verify rows unlocked by a committed enrollment in a separate maintenance transaction.
+pub fn retry_enrollment_pre_verify(
+    conn: &Connection,
+    account_id: AccountId,
+    now_ms: i64,
+) -> anyhow::Result<()> {
+    let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
+    storage::promote_after_local_device_add_in_tx(&tx, account_id, now_ms)?;
+    tx.commit()?;
+    Ok(())
 }
 
 /// One `(account, log_id, device)` chain's tail: its highest-`seq` entry as `(seq, entry_hash)`, or
@@ -408,6 +574,72 @@ mod tests {
             1,
             "the check-fact-first gate authors no second StreamOwn on re-ensure",
         );
+    }
+
+    #[test]
+    fn locally_authored_device_add_promotes_rows_signed_by_the_joiner() {
+        let conn = db();
+        let account = bootstrap::local_account(&conn, NOW).expect("mint local account");
+        let joiner = DeviceSecret::from_seed(&[0x71; 32]);
+        let joiner_x = DeviceX25519Secret::from_seed(&[0x72; 32]);
+        let payload = ops::encode(&AccountOp::AccountGenesis {
+            ed25519_pubkey: joiner.public().to_bytes(),
+            x25519_pubkey: joiner_x.public().to_bytes(),
+            nonce16: [8; 16],
+            created_at_ms: NOW as u64,
+            label: None,
+        })
+        .unwrap();
+        let header = AccountEntryHeader {
+            account_id: account,
+            log_id: fold::CONTROL_LOG,
+            device_fingerprint: joiner.public().fingerprint(),
+            seq: 0,
+            prev_hash: None,
+            parent_ref: None,
+            entry_type: ops::entry_type::ACCOUNT_GENESIS,
+            op_version: fold::SUPPORTED_OP_VERSION + 1,
+            crypto_suite: 0,
+            auth_len: 0,
+            key_id: None,
+            authority_ref: None,
+        };
+        let parked = sign_account_entry(&joiner, &header, &payload).unwrap();
+        assert_eq!(
+            storage::account_ingest(&conn, &parked.signed_bytes, NOW).unwrap(),
+            storage::IngestOutcome::PreVerify,
+        );
+
+        let tx = Transaction::new_unchecked(&conn, TransactionBehavior::Immediate).unwrap();
+        author_device_add_in_tx(
+            &tx,
+            EnrollingDevice {
+                ed25519_pubkey: joiner.public().to_bytes(),
+                x25519_pubkey: joiner_x.public().to_bytes(),
+                label: None,
+            },
+            ops::DeviceRole::ReadOnly,
+            NOW,
+        )
+        .unwrap();
+        tx.commit().unwrap();
+
+        let parked_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM account_pre_verify WHERE signed_hash = ?1",
+                [crate::cbor::sha256(&parked.signed_bytes).as_slice()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let candidate_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM account_entries WHERE entry_hash = ?1",
+                [parked.entry_hash.as_slice()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(parked_count, 0, "the newly resolvable queue row is drained");
+        assert_eq!(candidate_count, 1, "the joiner-signed row is promoted to the candidate DAG");
     }
 
     #[test]

--- a/crates/rag-rat-oplog/src/account/bootstrap.rs
+++ b/crates/rag-rat-oplog/src/account/bootstrap.rs
@@ -32,11 +32,14 @@ use anyhow::Context;
 use rusqlite::{Connection, OptionalExtension, Transaction, TransactionBehavior, params};
 
 use super::AccountId;
-use super::envelope::{AccountEntryHeader, VerifiedAccountEntry, sign_account_entry};
+use super::envelope::{
+    self, AccountEntryHeader, SignedAccountEntry, VerifiedAccountEntry, sign_account_entry,
+};
 use super::id::account_id_from_genesis_payload;
 use super::ops::{self, AccountOp};
 use super::storage::{self, CandidateInsert};
 use crate::local_device;
+use crate::op::DeviceFingerprint;
 
 /// Return this store's persisted local account, minting its self-authorizing genesis on the first
 /// call and returning the SAME account stably thereafter. `now_ms` stamps a freshly-minted genesis
@@ -65,6 +68,306 @@ pub fn local_account(conn: &Connection, now_ms: i64) -> anyhow::Result<AccountId
     // if we won, the incumbent's if we lost.
     read_local_account(conn)?
         .context("local account pointer missing immediately after mint (single-row insert lost?)")
+}
+
+/// Adopt an already-ingested, accepted account genesis as this store's local account. Enrollment
+/// uses this after cryptographically verifying and ingesting the inviter's bootstrap; unlike
+/// [`local_account`], it never mints a competing genesis.
+pub fn adopt_local_account(
+    conn: &Connection,
+    account_id: AccountId,
+    genesis_hash: [u8; 32],
+    now_ms: i64,
+) -> anyhow::Result<()> {
+    if let Some(existing) = read_local_account(conn)? {
+        anyhow::ensure!(existing == account_id, "store already belongs to another local account");
+        return Ok(());
+    }
+    let _durability = AuthoredDurability::begin(conn)?;
+    let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
+    adopt_local_account_in_tx(&tx, account_id, genesis_hash, now_ms)?;
+    tx.commit()?;
+    Ok(())
+}
+
+/// Atomically ingest a verified enrollment bootstrap, confirm the acknowledged device is
+/// effective, and adopt its genesis as this store's local account. No bootstrap row can become
+/// durable without the matching pointer, so a crash or rejected later entry cannot strand the
+/// one-time enrollment between identities.
+pub struct EnrollmentBootstrap<'a> {
+    pub account_entries: &'a [Vec<u8>],
+    pub account_id: AccountId,
+    pub genesis_hash: [u8; 32],
+    pub device_fingerprint: DeviceFingerprint,
+    pub device_add_hash: [u8; 32],
+    pub now_ms: i64,
+}
+
+/// The joiner-side admission budget this store can offer an enrollment redemption, clamped at
+/// zero (headroom goes negative past the grow-only caps). Sent in the enrollment request so the
+/// owner can measure its exact receipt against it BEFORE consuming the one-time nonce (#945).
+///
+/// Already-held candidates are NOT credited here — the request carries their hashes separately
+/// ([`held_account_entry_hashes`]), so the owner credits exactly the confirmed intersection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EnrollmentBudget {
+    pub account_entries_remaining: u64,
+    pub account_bytes_remaining: u64,
+    pub global_entries_remaining: u64,
+    pub global_bytes_remaining: u64,
+}
+
+/// Complete candidate inventory bound for one enrollment request.
+pub const ENROLLMENT_HELD_ENTRY_HASHES_MAX: usize = storage::CANDIDATES_PER_ACCOUNT_MAX;
+
+pub fn enrollment_budget(
+    conn: &Connection,
+    account_id: AccountId,
+    now_ms: i64,
+) -> anyhow::Result<EnrollmentBudget> {
+    let headroom = storage::candidate_capacity_headroom(conn, account_id, now_ms)?;
+    let clamp = |value: i64| u64::try_from(value).unwrap_or(0);
+    Ok(EnrollmentBudget {
+        account_entries_remaining: clamp(headroom.account_entries_remaining),
+        account_bytes_remaining: clamp(headroom.account_bytes_remaining),
+        global_entries_remaining: clamp(headroom.global_entries_remaining),
+        global_bytes_remaining: clamp(headroom.global_bytes_remaining),
+    })
+}
+
+/// Durable candidate-capacity reservations for outstanding enrollment invites (#945). A minted
+/// invite reserves the exact entries/bytes its mandatory `DeviceAdd` plus stream-key wraps will
+/// consume, and [`storage::insert_candidate`] charges active reservations against the same
+/// grow-only counters — so ordinary ingest or another mint cannot consume headroom an outstanding
+/// ticket was measured against and strand it permanently. Redemption releases its own reservation
+/// under the writer lock; expiry frees it (`expires_at_ms` is the invite's own expiry).
+pub fn upsert_account_candidate_reservation_in_tx(
+    tx: &Transaction<'_>,
+    account_id: AccountId,
+    reservation_id: [u8; 32],
+    reserved_entries: u64,
+    reserved_bytes: u64,
+    reserved_targets: u64,
+    expires_at_ms: i64,
+) -> anyhow::Result<()> {
+    tx.execute(
+        "INSERT INTO account_candidate_reservations(
+             reservation_id, account_id, reserved_entries, reserved_bytes, reserved_targets,
+             expires_at_ms)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+         ON CONFLICT(reservation_id) DO UPDATE SET
+             account_id = excluded.account_id,
+             reserved_entries = excluded.reserved_entries,
+             reserved_bytes = excluded.reserved_bytes,
+             reserved_targets = excluded.reserved_targets,
+             expires_at_ms = excluded.expires_at_ms",
+        params![
+            reservation_id.as_slice(),
+            account_id.to_bytes().as_slice(),
+            i64::try_from(reserved_entries)?,
+            i64::try_from(reserved_bytes)?,
+            i64::try_from(reserved_targets)?,
+            expires_at_ms,
+        ],
+    )?;
+    Ok(())
+}
+
+/// Release one invite's reservation. Called inside the redemption transaction immediately before
+/// the mandatory entries are authored, so the freed capacity is consumed by exactly the writes it
+/// was measured for; a rollback restores the reservation with everything else.
+pub fn release_account_candidate_reservation_in_tx(
+    tx: &Transaction<'_>,
+    reservation_id: [u8; 32],
+) -> anyhow::Result<()> {
+    tx.execute("DELETE FROM account_candidate_reservations WHERE reservation_id = ?1", [
+        reservation_id.as_slice(),
+    ])?;
+    Ok(())
+}
+
+/// Delete expired reservations. Correctness never depends on this — the counters filter on
+/// `expires_at_ms` — it only keeps the table bounded.
+pub fn prune_account_candidate_reservations_in_tx(
+    conn: &Connection,
+    now_ms: i64,
+) -> anyhow::Result<()> {
+    conn.execute("DELETE FROM account_candidate_reservations WHERE expires_at_ms <= ?1", [now_ms])?;
+    Ok(())
+}
+
+/// Every authenticated candidate hash this store holds for `account_id`, sorted for canonical
+/// enrollment encoding. Parked unauthenticated envelopes are normal-sync work, not bootstrap data.
+pub fn held_account_entry_hashes(
+    conn: &Connection,
+    account_id: AccountId,
+) -> anyhow::Result<Vec<[u8; 32]>> {
+    let mut stmt = conn.prepare(
+        "SELECT entry_hash FROM account_entries WHERE account_id = ?1 ORDER BY entry_hash",
+    )?;
+    let hashes = stmt
+        .query_map([account_id.to_bytes().as_slice()], |row| row.get::<_, Vec<u8>>(0))?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    anyhow::ensure!(
+        hashes.len() <= ENROLLMENT_HELD_ENTRY_HASHES_MAX,
+        "account held-proof inventory exceeds the enrollment wire bound"
+    );
+    hashes
+        .into_iter()
+        .map(|hash| {
+            <[u8; 32]>::try_from(hash.as_slice())
+                .map_err(|_| anyhow::anyhow!("stored entry_hash is not exactly 32 bytes"))
+        })
+        .collect()
+}
+
+/// One bootstrap entry staged for causal ingestion: its raw bytes plus the structural decode (the
+/// full signature verify still happens in `account_ingest_in_tx`). Undecodable entries sort last
+/// so they reach ingest — and their rejection rolls the adoption back — after every decodable
+/// entry had its chance.
+struct BootstrapEntry<'a> {
+    bytes: &'a [u8],
+    decoded: Option<SignedAccountEntry>,
+}
+
+impl BootstrapEntry<'_> {
+    /// The canonical deterministic pre-order the causal worklist scans: `(log_id, seq,
+    /// entry_hash, signed_bytes)` — the same key `account_entries_for_sync` emits, with
+    /// `signed_bytes` as the tie-break because two envelopes can share an `entry_hash` yet carry
+    /// different signatures.
+    fn causal_pre_order(&self, other: &Self) -> std::cmp::Ordering {
+        match (&self.decoded, &other.decoded) {
+            (Some(a), Some(b)) => (a.header.log_id, a.header.seq, a.entry_hash, &a.signed_bytes)
+                .cmp(&(b.header.log_id, b.header.seq, b.entry_hash, &b.signed_bytes)),
+            (None, Some(_)) => std::cmp::Ordering::Greater,
+            (Some(_), None) => std::cmp::Ordering::Less,
+            (None, None) => self.bytes.cmp(other.bytes),
+        }
+    }
+}
+
+pub fn adopt_enrollment_bootstrap(
+    conn: &Connection,
+    bootstrap: EnrollmentBootstrap<'_>,
+) -> anyhow::Result<()> {
+    let _durability = AuthoredDurability::begin(conn)?;
+    let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
+    // Ingest in CAUSAL order — an entry only after the entry introducing its signer's key. The
+    // receipt's raw `(log_id, seq, entry_hash)` order puts EVERY promoted device's seq-0 control
+    // entry before the founder-chain DeviceAdd introducing its key, so raw-order ingestion parks
+    // them all simultaneously and can trip the pre-verify eviction budget — a deterministic
+    // adoption failure replayed for 24h against a committed enrollment (#945). The fold is
+    // order-free (I8), so reordering changes only transient parking, never the final accepted
+    // set; receipt bytes and their canonical-CBOR identity are untouched.
+    let mut pending: Vec<BootstrapEntry<'_>> = bootstrap
+        .account_entries
+        .iter()
+        .map(|bytes| BootstrapEntry { bytes, decoded: envelope::decode_account_signed(bytes).ok() })
+        .collect();
+    pending.sort_by(BootstrapEntry::causal_pre_order);
+    // Seed resolvability from what this store ALREADY holds (a prior sync session may have
+    // delivered some candidates), then drain the worklist: ingest every entry whose signer
+    // resolves, growing the map with the keys each ingested entry itself certifies — the exact
+    // `stored_device_pubkeys` + `add_self_pubkey` semantics ingest applies.
+    let mut resolved = storage::stored_device_pubkeys(&tx, bootstrap.account_id)?;
+    loop {
+        let mut progressed = false;
+        let mut still_pending = Vec::with_capacity(pending.len());
+        for entry in pending {
+            let ready = entry.decoded.as_ref().is_some_and(|signed| {
+                resolved.contains_key(&signed.header.device_fingerprint)
+                    || storage::self_certifies_signer(&signed.header, &signed.payload)
+            });
+            if ready {
+                let signed = entry.decoded.as_ref().expect("ready implies decoded");
+                let resolved_signer = resolved.get(&signed.header.device_fingerprint).copied();
+                storage::stage_enrollment_bootstrap_entry_in_tx(
+                    &tx,
+                    entry.bytes,
+                    resolved_signer,
+                    bootstrap.now_ms,
+                )?;
+                storage::add_self_pubkey(&mut resolved, &signed.header, &signed.payload);
+                progressed = true;
+            } else {
+                still_pending.push(entry);
+            }
+        }
+        pending = still_pending;
+        if !progressed {
+            break;
+        }
+    }
+    anyhow::ensure!(
+        pending.is_empty(),
+        "enrollment bootstrap contains an entry whose signer is not certified by the candidate \
+         snapshot"
+    );
+    // The one-time adoption fold contains ONLY receipt candidates and already-authenticated local
+    // candidates; the acknowledged DeviceAdd must win THAT fold before the local-account pointer
+    // commits. Pre-existing parked rows are retried only after the adoption is durable — a newly
+    // resolvable parked sibling can no longer roll the one-time bootstrap back, and its later
+    // promotion is ordinary best-effort queue work.
+    storage::finish_enrollment_bootstrap_in_tx(&tx, bootstrap.account_id, bootstrap.now_ms)?;
+    let enrolled: bool = tx.query_row(
+        "SELECT EXISTS(
+             SELECT 1 FROM account_roster_history
+              WHERE account_id = ?1
+                AND device_fingerprint = ?2
+                AND roster_ref = ?3
+                AND closed_at IS NULL
+        )",
+        params![
+            bootstrap.account_id.to_bytes().as_slice(),
+            bootstrap.device_fingerprint.to_bytes().as_slice(),
+            bootstrap.device_add_hash.as_slice(),
+        ],
+        |row| row.get(0),
+    )?;
+    anyhow::ensure!(
+        enrolled,
+        "account bootstrap did not make the acknowledged DeviceAdd effective"
+    );
+    adopt_local_account_in_tx(&tx, bootstrap.account_id, bootstrap.genesis_hash, bootstrap.now_ms)?;
+    tx.commit()?;
+    // The caller retries parked rows the receipt's keys may now resolve in a SEPARATE
+    // best-effort maintenance pass (`retry_enrollment_pre_verify`): the enrollment and
+    // local-account pointer are durable at this point, so queue maintenance must never
+    // invalidate the completed enrollment or re-enter its one-time fold.
+    Ok(())
+}
+
+fn adopt_local_account_in_tx(
+    tx: &Transaction<'_>,
+    account_id: AccountId,
+    genesis_hash: [u8; 32],
+    now_ms: i64,
+) -> anyhow::Result<()> {
+    if let Some(existing) = read_local_account(tx)? {
+        anyhow::ensure!(existing == account_id, "store already belongs to another local account");
+        return Ok(());
+    }
+    let accepted: bool = tx.query_row(
+        "SELECT EXISTS(
+             SELECT 1
+               FROM account_entries e
+               JOIN account_entry_status s ON s.entry_hash = e.entry_hash
+              WHERE e.entry_hash = ?1
+                AND e.account_id = ?2
+                AND e.log_id = 0
+                AND e.seq = 0
+                AND s.status = 'accepted'
+         )",
+        params![genesis_hash.as_slice(), account_id.to_bytes().as_slice()],
+        |row| row.get(0),
+    )?;
+    anyhow::ensure!(accepted, "enrollment genesis is not accepted for the expected account");
+    tx.execute(
+        "INSERT INTO oplog_local_account(id, genesis_entry_hash, created_at_ms)
+         VALUES (0, ?1, ?2)",
+        params![genesis_hash.as_slice(), now_ms],
+    )?;
+    Ok(())
 }
 
 /// Mint the local account inside the caller's IMMEDIATE transaction, or adopt an incumbent and
@@ -240,12 +543,12 @@ fn read_pointer_hash(conn: &Connection) -> anyhow::Result<Option<[u8; 32]>> {
 /// path (including error/panic), so a shared connection is never stranded at FULL. Mirrors
 /// `query::memory::authoring::AuthoredDurability`, which the account layer cannot reach up into
 /// (the dependency is one-way).
-struct AuthoredDurability<'a> {
+pub struct AuthoredDurability<'a> {
     conn: &'a Connection,
 }
 
 impl<'a> AuthoredDurability<'a> {
-    fn begin(conn: &'a Connection) -> anyhow::Result<Self> {
+    pub fn begin(conn: &'a Connection) -> anyhow::Result<Self> {
         conn.execute_batch("PRAGMA synchronous = FULL;")?;
         Ok(Self { conn })
     }
@@ -359,6 +662,53 @@ mod tests {
             account_id,
             "the resolved account_id is the genesis commitment",
         );
+    }
+
+    #[test]
+    fn enrollment_inventory_returns_every_candidate_beyond_the_old_prefix() {
+        let conn = db();
+        let account = local_account(&conn, NOW).unwrap();
+        for ordinal in 1u64..=120 {
+            let mut hash = [0u8; 32];
+            hash[24..].copy_from_slice(&ordinal.to_be_bytes());
+            conn.execute(
+                "INSERT INTO account_entries(
+                     entry_hash, account_id, log_id, device_fingerprint, seq, prev_hash,
+                     parent_ref, authority_ref, entry_type, accepted, signed_bytes, received_at_ms)
+                 VALUES (?1, ?2, 3, ?3, ?4, NULL, NULL, NULL, 255, 0, X'00', ?5)",
+                params![
+                    hash.as_slice(),
+                    account.to_bytes().as_slice(),
+                    [9u8; 32].as_slice(),
+                    i64::try_from(ordinal).unwrap(),
+                    NOW,
+                ],
+            )
+            .unwrap();
+        }
+
+        let parked_entry_hash = [0xf0; 32];
+        let parked_signed_hash = [0xf1; 32];
+        conn.execute(
+            "INSERT INTO account_pre_verify(
+                 signed_hash, entry_hash, claimed_account_id, claimed_fingerprint, raw_bytes,
+                 received_at_ms)
+             VALUES (?1, ?2, ?3, ?4, X'00', ?5)",
+            params![
+                parked_signed_hash.as_slice(),
+                parked_entry_hash.as_slice(),
+                account.to_bytes().as_slice(),
+                [0xf2u8; 32].as_slice(),
+                NOW,
+            ],
+        )
+        .unwrap();
+
+        let hashes = held_account_entry_hashes(&conn, account).unwrap();
+        assert_eq!(hashes.len(), 121, "genesis and every authenticated candidate are advertised");
+        assert!(!hashes.contains(&parked_signed_hash));
+        assert!(!hashes.contains(&parked_entry_hash));
+        assert!(hashes.windows(2).all(|pair| pair[0] < pair[1]));
     }
 
     #[test]

--- a/crates/rag-rat-oplog/src/account/content/author.rs
+++ b/crates/rag-rat-oplog/src/account/content/author.rs
@@ -2047,6 +2047,7 @@ mod tests {
         content_storage::settle_pending_content_refolds(
             &peer,
             &content_storage::ContentRefoldBudget::unbounded(),
+            NOW,
         )
         .expect("settle the refold");
 

--- a/crates/rag-rat-oplog/src/account/content/mod.rs
+++ b/crates/rag-rat-oplog/src/account/content/mod.rs
@@ -29,7 +29,6 @@ pub use author::{author_content_batch_in_tx, content_op_is_authorable, content_s
 pub(crate) use envelope::open_sealed_payload;
 pub use envelope::{
     ContentEntryHeader, SignedContentEntry, VerifiedContentEntry, decode_content_signed,
-    sign_content_entry, verify_content_signed,
 };
 // The C5a envelope-layer seal + sign (#608): the injected-nonce core (goldens) and the
 // OS-nonce production wrapper. The sealed author seam and projection tests consume these; no
@@ -39,6 +38,11 @@ pub use envelope::{
     reason = "sealed envelope authoring remains unwired from the live memory path (#608)"
 )]
 pub use envelope::{seal_and_sign_content_entry, sign_sealed_content_entry};
+// `sign_content_entry` / `verify_content_signed` stay in `envelope` at the crate root (they
+// take `pub(crate)` device-key types and must not reach the root glob); test consumers use
+// them through `content`.
+#[allow(unused_imports, reason = "test consumers use these signing seams through `content`")]
+pub use envelope::{sign_content_entry, verify_content_signed};
 // The V070 `content_projected_*` table-existence guard: shared crate-wide with the `/3`
 // projection's open-path upgrade re-fold (#688) so there is ONE guard, reused per the #683
 // doctrine.

--- a/crates/rag-rat-oplog/src/account/content/storage.rs
+++ b/crates/rag-rat-oplog/src/account/content/storage.rs
@@ -667,6 +667,7 @@ pub(in crate::account) fn affected_streams_for_account(
 pub(super) fn refold_and_project_stream_in_tx(
     tx: &Transaction<'_>,
     stream_id: StreamId,
+    now_ms: i64,
 ) -> anyhow::Result<()> {
     refold_content_stream(tx, stream_id)?;
     if content_projected_tables_exist(tx)? {
@@ -675,15 +676,20 @@ pub(super) fn refold_and_project_stream_in_tx(
     if pending_refold_table_exists(tx)? {
         clear_pending_content_refold(tx, stream_id)?;
     }
+    // Accepted suite-1 content pins its sealing key as a live enrollment catch-up target, so
+    // settling content can grow an outstanding invite's mandatory redemption cost without any
+    // account fold — refresh reservations here, at the content-acceptance choke point (#945).
+    super::super::storage::refresh_enrollment_reservations_for_stream_in_tx(tx, stream_id, now_ms)?;
     Ok(())
 }
 
 pub(in crate::account) fn finalize_affected_streams(
     tx: &Transaction<'_>,
     streams: &[StreamId],
+    now_ms: i64,
 ) -> anyhow::Result<()> {
     for &stream_id in streams {
-        refold_and_project_stream_in_tx(tx, stream_id)?;
+        refold_and_project_stream_in_tx(tx, stream_id, now_ms)?;
     }
     Ok(())
 }
@@ -1207,6 +1213,7 @@ fn settle_one_pending_refold(
     stream_id: StreamId,
     budget: &ContentRefoldBudget,
     consumed: ContentSettleConsumption,
+    now_ms: i64,
 ) -> PendingRefoldOutcome {
     #[cfg(test)]
     SETTLE_ADMISSION_PROBES.with(|c| c.set(c.get() + 1));
@@ -1237,7 +1244,7 @@ fn settle_one_pending_refold(
         return PendingRefoldOutcome::Deferred { oversize: false };
     };
 
-    if let Err(error) = refold_and_project_stream_in_tx(&tx, stream_id) {
+    if let Err(error) = refold_and_project_stream_in_tx(&tx, stream_id, now_ms) {
         return PendingRefoldOutcome::Failed { admitted: Some((work, oversize)), error };
     }
     match tx.commit() {
@@ -1452,13 +1459,15 @@ pub struct ContentSettleReport {
 pub fn settle_pending_content_refolds(
     conn: &Connection,
     budget: &ContentRefoldBudget,
+    now_ms: i64,
 ) -> anyhow::Result<ContentSettleReport> {
-    settle_pending_content_refolds_inner(conn, budget, || {})
+    settle_pending_content_refolds_inner(conn, budget, now_ms, || {})
 }
 
 fn settle_pending_content_refolds_inner(
     conn: &Connection,
     budget: &ContentRefoldBudget,
+    now_ms: i64,
     after_first_listing: impl FnOnce(),
 ) -> anyhow::Result<ContentSettleReport> {
     let batch = settle_candidate_batch_size(budget);
@@ -1507,7 +1516,7 @@ fn settle_pending_content_refolds_inner(
                 report.deferred_budget += 1;
                 continue;
             }
-            let outcome = settle_one_pending_refold(conn, stream_id, budget, consumed);
+            let outcome = settle_one_pending_refold(conn, stream_id, budget, consumed, now_ms);
             let (admitted, vanished, demote) =
                 record_settle_outcome(&mut report, &mut consumed, stream_id, outcome);
             if demote {
@@ -1546,7 +1555,7 @@ fn settle_pending_content_refolds_inner(
         && consumed.attempted_streams < budget.max_streams
         && let Some(stream_id) = oldest_oversize_pending_refold(conn, budget)?
     {
-        let outcome = settle_one_pending_refold(conn, stream_id, budget, consumed);
+        let outcome = settle_one_pending_refold(conn, stream_id, budget, consumed, now_ms);
         let (_, _, demote) = record_settle_outcome(&mut report, &mut consumed, stream_id, outcome);
         if demote {
             deferred_demotions.push(stream_id);
@@ -1577,11 +1586,12 @@ fn settle_pending_content_refolds_inner(
 pub fn settle_pending_content_refold_for_stream_in_tx(
     tx: &Transaction<'_>,
     stream_id: StreamId,
+    now_ms: i64,
 ) -> anyhow::Result<()> {
     if !content_stream_has_pending_refold(tx, stream_id)? {
         return Ok(());
     }
-    refold_and_project_stream_in_tx(tx, stream_id)
+    refold_and_project_stream_in_tx(tx, stream_id, now_ms)
 }
 
 /// Narrow the branch-selected winners to a contiguous accepted prefix per coordinate.
@@ -2248,6 +2258,8 @@ fn fixed<const N: usize>(bytes: &[u8]) -> anyhow::Result<[u8; N]> {
 mod tests {
     use rag_rat_db::schema;
 
+    const NOW: i64 = 1_700_000_000_000;
+
     use super::super::super::envelope::{AccountEntryHeader, sign_account_entry};
     use super::super::super::id::account_id_from_genesis_payload;
     use super::super::ContentEntryHeader;
@@ -2428,6 +2440,45 @@ mod tests {
     /// A device fingerprint distinct from any real local device — the pre-#652 default seed used
     /// for candidates that stand in for FOREIGN, remotely-signed rows in the capacity tests.
     const FOREIGN_FP: [u8; 32] = [2_u8; 32];
+
+    #[test]
+    fn enrollment_mint_ignores_non_fatal_content_promotions() {
+        let conn = db();
+        let account = super::super::super::bootstrap::local_account(&conn, 1).unwrap();
+        seed_content_candidates(
+            &conn,
+            account,
+            FOREIGN_FP,
+            0x945,
+            CANDIDATES_PER_AUTHOR_MAX as usize,
+            1,
+        );
+        conn.execute(
+            "INSERT INTO content_pre_verify(
+                 signed_hash, entry_hash, claimed_stream_id, claimed_author_account_id,
+                 claimed_fingerprint, roster_ref, raw_bytes, received_at_ms)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, X'00', 1)",
+            params![
+                [0xd1u8; 32].as_slice(),
+                [0xd2u8; 32].as_slice(),
+                [0xd3u8; 32].as_slice(),
+                account.to_bytes().as_slice(),
+                [0xd4u8; 32].as_slice(),
+                [0xd5u8; 32].as_slice(),
+            ],
+        )
+        .unwrap();
+
+        super::super::super::authoring::enrollment_authoring_fits(
+            &conn,
+            account,
+            &[],
+            crate::account::DeviceRole::Member,
+            None,
+            1,
+        )
+        .expect("opaque parked content is not part of mandatory enrollment authoring");
+    }
 
     #[test]
     fn exact_roster_ref_verifies_and_full_u64_counters_persist() {
@@ -3561,7 +3612,7 @@ mod tests {
     ) {
         let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate).unwrap();
         let streams = affected_streams_for_account(&tx, account, previously_owned).unwrap();
-        finalize_affected_streams(&tx, &streams).unwrap();
+        finalize_affected_streams(&tx, &streams, NOW).unwrap();
         tx.commit().unwrap();
     }
 
@@ -3817,7 +3868,7 @@ mod tests {
         let owner = signed_roster(&DeviceSecret::from_seed(&[0xe2; 32])).0;
         let tx = Transaction::new_unchecked(&conn, TransactionBehavior::Immediate).unwrap();
         let streams = affected_streams_for_account(&tx, owner, &[]).unwrap();
-        finalize_affected_streams(&tx, &streams).unwrap();
+        finalize_affected_streams(&tx, &streams, NOW).unwrap();
         tx.commit().unwrap();
     }
 
@@ -4025,7 +4076,7 @@ mod tests {
     /// (drain the whole queue in one call). Tests written against that contract use this helper;
     /// the budgeted tests pass an explicit [`ContentRefoldBudget`] instead.
     fn settle_all(conn: &Connection) -> ContentSettleReport {
-        settle_pending_content_refolds(conn, &ContentRefoldBudget::unbounded()).unwrap()
+        settle_pending_content_refolds(conn, &ContentRefoldBudget::unbounded(), NOW).unwrap()
     }
 
     fn pending_refold_state(conn: &Connection) -> (i64, i64, i64) {
@@ -4573,7 +4624,7 @@ mod tests {
         }
         let one_stream = budget(1, u64::MAX, u64::MAX, false);
 
-        let first = settle_pending_content_refolds(&conn, &one_stream).unwrap();
+        let first = settle_pending_content_refolds(&conn, &one_stream, NOW).unwrap();
         assert_eq!(first.settled_streams, 1);
         assert_eq!(first.consumed_candidates, 1);
         assert_eq!(first.consumed_candidate_bytes, SYNTHETIC_ROW_BYTES);
@@ -4585,16 +4636,16 @@ mod tests {
         assert!(queue_contains(&conn, middle));
         assert!(queue_contains(&conn, newest));
 
-        let second = settle_pending_content_refolds(&conn, &one_stream).unwrap();
+        let second = settle_pending_content_refolds(&conn, &one_stream, NOW).unwrap();
         assert_eq!(second.settled_streams, 1);
         assert!(!second.queue_empty, "the resume continues where the budget stopped");
         assert!(!queue_contains(&conn, middle));
         assert!(queue_contains(&conn, newest));
 
-        let third = settle_pending_content_refolds(&conn, &one_stream).unwrap();
+        let third = settle_pending_content_refolds(&conn, &one_stream, NOW).unwrap();
         assert_eq!(third.settled_streams, 1);
         assert!(third.queue_empty);
-        let drained = settle_pending_content_refolds(&conn, &one_stream).unwrap();
+        let drained = settle_pending_content_refolds(&conn, &one_stream, NOW).unwrap();
         assert_eq!(drained.settled_streams, 0, "a drained queue is a no-op");
         assert!(drained.queue_empty);
     }
@@ -4611,7 +4662,8 @@ mod tests {
 
         // Candidate limit: `big` exactly fills it, so `small` no longer fits the remainder.
         let report =
-            settle_pending_content_refolds(&conn, &budget(u64::MAX, 3, u64::MAX, false)).unwrap();
+            settle_pending_content_refolds(&conn, &budget(u64::MAX, 3, u64::MAX, false), NOW)
+                .unwrap();
         assert_eq!(report.settled_streams, 1);
         assert_eq!(report.consumed_candidates, 3);
         assert_eq!(report.deferred_budget, 1);
@@ -4625,13 +4677,13 @@ mod tests {
         enqueue_refold(&conn, big, 1);
         enqueue_refold(&conn, small, 2);
         let byte_budget = budget(u64::MAX, u64::MAX, 2 * SYNTHETIC_ROW_BYTES, false);
-        let report = settle_pending_content_refolds(&conn, &byte_budget).unwrap();
+        let report = settle_pending_content_refolds(&conn, &byte_budget, NOW).unwrap();
         assert_eq!(report.settled_streams, 1);
         assert_eq!(report.consumed_candidate_bytes, 2 * SYNTHETIC_ROW_BYTES);
         assert_eq!(report.deferred_budget, 1);
         assert!(queue_contains(&conn, small));
         // The resume settles the remainder with a fresh budget.
-        let report = settle_pending_content_refolds(&conn, &byte_budget).unwrap();
+        let report = settle_pending_content_refolds(&conn, &byte_budget, NOW).unwrap();
         assert_eq!(report.settled_streams, 1);
         assert!(report.queue_empty);
     }
@@ -4657,7 +4709,8 @@ mod tests {
         )
         .unwrap();
         let report =
-            settle_pending_content_refolds(&conn, &budget(u64::MAX, 5, u64::MAX, false)).unwrap();
+            settle_pending_content_refolds(&conn, &budget(u64::MAX, 5, u64::MAX, false), NOW)
+                .unwrap();
         assert_eq!(report.settled_streams, 0);
         assert_eq!(
             report.deferred_oversize, 0,
@@ -4672,7 +4725,8 @@ mod tests {
         ])
         .unwrap();
         let report =
-            settle_pending_content_refolds(&conn, &budget(u64::MAX, 5, u64::MAX, false)).unwrap();
+            settle_pending_content_refolds(&conn, &budget(u64::MAX, 5, u64::MAX, false), NOW)
+                .unwrap();
         assert_eq!(report.settled_streams, 1);
         assert_eq!(report.consumed_candidates, 3);
         assert!(report.queue_empty);
@@ -4692,6 +4746,7 @@ mod tests {
         let report = settle_pending_content_refolds_inner(
             &conn,
             &budget(u64::MAX, 2, u64::MAX, false),
+            NOW,
             || seed_synthetic_candidates(&concurrent, stream, 2),
         )
         .unwrap();
@@ -4725,12 +4780,16 @@ mod tests {
         seed_synthetic_candidates(&conn, listed, 1);
         enqueue_refold(&conn, listed, 1);
 
-        let report =
-            settle_pending_content_refolds_inner(&conn, &ContentRefoldBudget::unbounded(), || {
+        let report = settle_pending_content_refolds_inner(
+            &conn,
+            &ContentRefoldBudget::unbounded(),
+            NOW,
+            || {
                 seed_synthetic_candidates(&concurrent, newly_enqueued, 1);
                 enqueue_refold(&concurrent, newly_enqueued, 2);
-            })
-            .unwrap();
+            },
+        )
+        .unwrap();
 
         assert_eq!(report.settled_streams, 1);
         assert!(!report.queue_empty, "the final queue-empty probe sees the committed enqueue");
@@ -4752,6 +4811,7 @@ mod tests {
         let report = settle_pending_content_refolds_inner(
             &conn,
             &budget(1, 1, SYNTHETIC_ROW_BYTES, false),
+            NOW,
             || {
                 concurrent
                     .execute("DELETE FROM content_streams_pending_refold WHERE stream_id = ?1", [
@@ -4781,7 +4841,8 @@ mod tests {
         enqueue_refold(&conn, small, 2);
 
         let report =
-            settle_pending_content_refolds(&conn, &budget(u64::MAX, 2, u64::MAX, false)).unwrap();
+            settle_pending_content_refolds(&conn, &budget(u64::MAX, 2, u64::MAX, false), NOW)
+                .unwrap();
         assert_eq!(report.settled_streams, 1, "the smaller stream still settles");
         assert_eq!(report.consumed_candidates, 1);
         assert_eq!(report.deferred_budget, 0);
@@ -4796,7 +4857,8 @@ mod tests {
         // Normal mode NEVER starts it: repeated calls converge nothing further and never re-list
         // it.
         let stuck =
-            settle_pending_content_refolds(&conn, &budget(u64::MAX, 2, u64::MAX, false)).unwrap();
+            settle_pending_content_refolds(&conn, &budget(u64::MAX, 2, u64::MAX, false), NOW)
+                .unwrap();
         assert_eq!(stuck.settled_streams, 0);
         assert_eq!(stuck.deferred_oversize, 0);
         assert!(!stuck.queue_empty);
@@ -4820,7 +4882,7 @@ mod tests {
         // queue for this budget — so the oversize slot then fires for the OLDEST oversize stream,
         // an intentional exceedance visible in the charged counters. Exactly ONE oversize row is
         // admitted per call.
-        let first = settle_pending_content_refolds(&conn, &maintenance).unwrap();
+        let first = settle_pending_content_refolds(&conn, &maintenance, NOW).unwrap();
         assert_eq!(
             first.settled_streams, 2,
             "the eligible small stream settles, then the drained queue releases the oversize slot",
@@ -4838,7 +4900,7 @@ mod tests {
 
         // Call 2: the scheduled maintenance loop converges — the second big stream claims this
         // call's oversize slot.
-        let second = settle_pending_content_refolds(&conn, &maintenance).unwrap();
+        let second = settle_pending_content_refolds(&conn, &maintenance, NOW).unwrap();
         assert_eq!(second.settled_streams, 1);
         assert_eq!(second.consumed_candidates, 3);
         assert!(!queue_contains(&conn, other_big));
@@ -4904,9 +4966,12 @@ mod tests {
         )
         .unwrap();
 
-        let report =
-            settle_pending_content_refolds(&conn, &budget(1, 2, 2 * SYNTHETIC_ROW_BYTES, false))
-                .unwrap();
+        let report = settle_pending_content_refolds(
+            &conn,
+            &budget(1, 2, 2 * SYNTHETIC_ROW_BYTES, false),
+            NOW,
+        )
+        .unwrap();
 
         assert_eq!(report.settled_streams, 0);
         assert_eq!(report.failures.len(), 1, "the stream budget permits one attempt");
@@ -4927,7 +4992,7 @@ mod tests {
         enqueue_refold(&conn, oversize, 1);
 
         let zero_streams =
-            settle_pending_content_refolds(&conn, &budget(0, 2, u64::MAX, true)).unwrap();
+            settle_pending_content_refolds(&conn, &budget(0, 2, u64::MAX, true), NOW).unwrap();
         assert_eq!(zero_streams.settled_streams, 0);
         assert_eq!(zero_streams.consumed_candidates, 0);
         assert!(zero_streams.failures.is_empty());
@@ -4943,7 +5008,7 @@ mod tests {
         enqueue_refold(&conn, oversize, 2);
 
         let one_stream =
-            settle_pending_content_refolds(&conn, &budget(1, 2, u64::MAX, true)).unwrap();
+            settle_pending_content_refolds(&conn, &budget(1, 2, u64::MAX, true), NOW).unwrap();
         assert_eq!(one_stream.settled_streams, 1);
         assert_eq!(one_stream.consumed_candidates, 1);
         assert_eq!(
@@ -4975,7 +5040,7 @@ mod tests {
         let one_stream = budget(1, u64::MAX, u64::MAX, false);
         let mut settled_order = Vec::new();
         for expected in [older, tie_low, tie_mid, tie_high] {
-            let report = settle_pending_content_refolds(&conn, &one_stream).unwrap();
+            let report = settle_pending_content_refolds(&conn, &one_stream, NOW).unwrap();
             assert_eq!(report.settled_streams, 1);
             assert!(!queue_contains(&conn, expected), "expected {expected:?} to settle next");
             settled_order.push(expected);
@@ -5026,7 +5091,7 @@ mod tests {
         let one_stream = budget(1, u64::MAX, u64::MAX, false);
 
         reset_settle_work_counters();
-        let first = settle_pending_content_refolds(&conn, &one_stream).unwrap();
+        let first = settle_pending_content_refolds(&conn, &one_stream, NOW).unwrap();
         let (listings, probes) = settle_work_counters();
         assert_eq!(first.settled_streams, 1);
         assert!(
@@ -5054,7 +5119,7 @@ mod tests {
         // A repeated call keeps the SAME per-call bound: draining stays linear in total, with no
         // per-call full scan.
         reset_settle_work_counters();
-        let second = settle_pending_content_refolds(&conn, &one_stream).unwrap();
+        let second = settle_pending_content_refolds(&conn, &one_stream, NOW).unwrap();
         let (listings, probes) = settle_work_counters();
         assert_eq!(second.settled_streams, 1);
         assert!(!second.queue_empty);
@@ -5092,7 +5157,7 @@ mod tests {
         // vanished rows, so discovery must page onward — without ever listing the rest of the
         // queue — to reach the first eligible stream.
         reset_settle_work_counters();
-        let report = settle_pending_content_refolds_inner(&conn, &one_stream, || {
+        let report = settle_pending_content_refolds_inner(&conn, &one_stream, NOW, || {
             for ordinal in 0..VANISHED {
                 concurrent
                     .execute("DELETE FROM content_streams_pending_refold WHERE stream_id = ?1", [
@@ -5144,7 +5209,7 @@ mod tests {
         let one_stream = budget(1, 2, u64::MAX, false);
 
         reset_settle_work_counters();
-        let report = settle_pending_content_refolds(&conn, &one_stream).unwrap();
+        let report = settle_pending_content_refolds(&conn, &one_stream, NOW).unwrap();
         let (listings, probes) = settle_work_counters();
 
         assert_eq!(report.settled_streams, 1, "the smaller later stream settles");
@@ -5184,7 +5249,7 @@ mod tests {
         let one_stream = budget(1, 2, 2 * SYNTHETIC_ROW_BYTES, false);
 
         reset_settle_work_counters();
-        let first = settle_pending_content_refolds(&conn, &one_stream).unwrap();
+        let first = settle_pending_content_refolds(&conn, &one_stream, NOW).unwrap();
         let (listings, probes) = settle_work_counters();
         assert_eq!(first.settled_streams, 1, "the small stream settles on the FIRST call");
         assert!(!queue_contains(&conn, small));
@@ -5197,7 +5262,7 @@ mod tests {
 
         // A follow-up call over the pure-oversize queue discovers nothing and probes nothing.
         reset_settle_work_counters();
-        let second = settle_pending_content_refolds(&conn, &one_stream).unwrap();
+        let second = settle_pending_content_refolds(&conn, &one_stream, NOW).unwrap();
         let (listings, probes) = settle_work_counters();
         assert_eq!(second.settled_streams, 0);
         assert!(!second.queue_empty);
@@ -5220,7 +5285,7 @@ mod tests {
         let maintenance = budget(1, 2, u64::MAX, true);
 
         reset_settle_work_counters();
-        let report = settle_pending_content_refolds(&conn, &maintenance).unwrap();
+        let report = settle_pending_content_refolds(&conn, &maintenance, NOW).unwrap();
         let (listings, probes) = settle_work_counters();
         assert_eq!(report.settled_streams, 1);
         assert_eq!(report.consumed_candidates, 3, "the intentional exceedance is charged");
@@ -5230,7 +5295,7 @@ mod tests {
         assert_eq!(listings, 2, "one filtered page plus the single targeted oversize query");
         assert_eq!(probes, 1, "only the admitted oversize row pays for a transaction");
 
-        let report = settle_pending_content_refolds(&conn, &maintenance).unwrap();
+        let report = settle_pending_content_refolds(&conn, &maintenance, NOW).unwrap();
         assert_eq!(report.settled_streams, 1);
         assert!(report.queue_empty);
     }
@@ -5253,7 +5318,7 @@ mod tests {
         // Two stream slots for four eligible rows: the budget runs out with eligible work queued.
         let maintenance = budget(2, 2, u64::MAX, true);
 
-        let report = settle_pending_content_refolds(&conn, &maintenance).unwrap();
+        let report = settle_pending_content_refolds(&conn, &maintenance, NOW).unwrap();
         assert_eq!(report.settled_streams, 2, "only the two budgeted eligible rows settle");
         assert!(
             queue_contains(&conn, oversize),
@@ -5286,7 +5351,7 @@ mod tests {
         .unwrap();
         let maintenance = budget(4, 5, u64::MAX, true);
 
-        let report = settle_pending_content_refolds(&conn, &maintenance).unwrap();
+        let report = settle_pending_content_refolds(&conn, &maintenance, NOW).unwrap();
         assert_eq!(report.failures.len(), 1, "the poisoned row is attempted and fails");
         assert!(
             !queue_contains(&conn, oversize),
@@ -5310,7 +5375,7 @@ mod tests {
         seed_synthetic_candidates(&conn, arrival, 1);
         enqueue_refold(&conn, arrival, 2);
 
-        let report = settle_pending_content_refolds(&conn, &maintenance).unwrap();
+        let report = settle_pending_content_refolds(&conn, &maintenance, NOW).unwrap();
         assert!(
             !queue_contains(&conn, oversize),
             "a steady trickle of eligible rows no longer starves oversize maintenance",
@@ -5328,7 +5393,8 @@ mod tests {
         seed_synthetic_candidates(&conn, oversize, 50);
         enqueue_refold(&conn, oversize, 1);
 
-        let report = settle_pending_content_refolds(&conn, &budget(4, 5, u64::MAX, false)).unwrap();
+        let report =
+            settle_pending_content_refolds(&conn, &budget(4, 5, u64::MAX, false), NOW).unwrap();
         assert_eq!(report.settled_streams, 0);
         assert_eq!(report.deferred_oversize, 0, "a listing-filtered row is never counted here");
         assert!(report.failures.is_empty());
@@ -5365,7 +5431,7 @@ mod tests {
         // Call 1: the poisoned stream is oldest, admitted first, and fails; its one stream slot is
         // spent so the healthy stream is deferred. The failed row is demoted behind the healthy
         // row.
-        let first = settle_pending_content_refolds(&conn, &one_stream).unwrap();
+        let first = settle_pending_content_refolds(&conn, &one_stream, NOW).unwrap();
         assert_eq!(first.settled_streams, 0, "the poisoned stream took the only stream slot");
         assert_eq!(first.failures.len(), 1);
         assert_eq!(first.failures[0].stream_id, StreamId::from_bytes(poisoned));
@@ -5379,7 +5445,7 @@ mod tests {
         // Call 2: because the poisoned row was demoted, the healthy stream is now oldest and
         // settles — without demotion the poisoned oldest row would head-of-line block it
         // forever.
-        let second = settle_pending_content_refolds(&conn, &one_stream).unwrap();
+        let second = settle_pending_content_refolds(&conn, &one_stream, NOW).unwrap();
         assert_eq!(second.settled_streams, 1, "the healthy stream settles once the poison demoted");
         assert!(!queue_contains(&conn, healthy));
         assert!(queue_contains(&conn, poisoned), "the poisoned stream is still queued for retry");
@@ -5429,7 +5495,7 @@ mod tests {
         );
 
         reset_settle_work_counters();
-        let report = settle_pending_content_refolds(&conn, &unbounded).unwrap();
+        let report = settle_pending_content_refolds(&conn, &unbounded, NOW).unwrap();
         let (listings, probes) = settle_work_counters();
 
         // Fairness: every healthy row settles despite the failing oldest row on page 1.

--- a/crates/rag-rat-oplog/src/account/mod.rs
+++ b/crates/rag-rat-oplog/src/account/mod.rs
@@ -43,18 +43,28 @@ mod storage;
 // `established_owned_stream_v2` (derivation + effective-ownership fact — the reconcile's fast-path
 // probe). #664 wires all three into `query::memory`, so they are plain re-exports.
 pub use authoring::{
-    EnrollingDevice, author_device_add_in_tx, ensure_owned_stream_v2_in_tx,
-    established_owned_stream_v2, owned_stream_v2_id,
+    EnrollingDevice, author_device_add_in_tx, author_enrollment_device_add_in_tx,
+    enrollment_authoring_fits, enrollment_authoring_requirements, ensure_owned_stream_v2_in_tx,
+    established_owned_stream_v2, owned_stream_v2_id, retry_enrollment_pre_verify,
+    validate_device_add_label,
 };
-pub use bootstrap::{local_account, read_local_account};
+pub use bootstrap::{
+    AuthoredDurability, ENROLLMENT_HELD_ENTRY_HASHES_MAX, EnrollmentBootstrap, EnrollmentBudget,
+    adopt_enrollment_bootstrap, adopt_local_account, enrollment_budget, held_account_entry_hashes,
+    local_account, prune_account_candidate_reservations_in_tx, read_local_account,
+    release_account_candidate_reservation_in_tx, upsert_account_candidate_reservation_in_tx,
+};
 #[allow(unused_imports, reason = "C2 contract is frozen before transport wiring lands")]
 pub use content::{
     ContentCapacityScope, ContentEntryHeader, ContentIngestOutcome, ContentRefoldBudget,
     ContentSettleReport, ContentStreamSettleFailure, SignedContentEntry, VerifiedContentEntry,
     content_ingest, content_stream_has_pending_refold, decode_content_signed,
     settle_pending_content_refold_for_stream_in_tx, settle_pending_content_refolds,
-    sign_content_entry, verify_content_signed,
 };
+// The envelope sign/verify primitives take `&DeviceSecret`/`&DevicePublic` (`pub(crate)`
+// types), so they stay off the crate-root glob — account-internal consumers reach them through
+// `content`.
+
 // The C5a sealed-authoring surface (#608): the envelope-layer seal
 // (`sign_sealed_content_entry` + its OS-nonce wrapper `seal_and_sign_content_entry`), the
 // policy-aware prepared authoring surface, sealed-op size predicate, and downgrade-ratchet
@@ -77,7 +87,7 @@ pub use content::{author_content_batch_in_tx, content_op_is_authorable, content_
 // re-fold (#688).
 pub(crate) use content::{content_projected_tables_exist, open_sealed_payload};
 #[allow(unused_imports, reason = "envelope tests consume these crate-internal signing seams")]
-pub use content::{seal_and_sign_content_entry, sign_sealed_content_entry};
+pub(in crate::account) use content::{seal_and_sign_content_entry, sign_sealed_content_entry};
 pub use fold::{
     AuthorityBoundary, AuthorityFreshness, AuthorityInvalidReason, AuthorityQuery, GrantAuthority,
     GrantDeviceAuthority, GrantDeviceBoundary, OwnerAuthority, OwnerChainAuthority,
@@ -97,9 +107,10 @@ pub use ops::{DeviceCut, DeviceRole, GrantRole};
 pub use secrets::{
     CatchUpReport, ContentKeyring, LiveKeyEpoch, LiveKeyTargets, RotationOutcome,
     SealingKeyOutcome, SelectedWrap, catch_up_stream_keys_for_device_in_tx, current_sealing_key,
-    ensure_stream_key_current_in_tx, historical_content_keyring,
-    live_stream_key_targets_for_device, mint_and_author_stream_key_wrap_in_tx,
-    rotate_stream_key_in_tx, select_current_sealing_wrap, stream_key_rotation_needed,
+    enroll_stream_keys_for_device_in_tx, ensure_stream_key_current_in_tx,
+    historical_content_keyring, live_stream_key_targets_for_device,
+    mint_and_author_stream_key_wrap_in_tx, rotate_stream_key_in_tx, select_current_sealing_wrap,
+    stream_key_rotation_needed,
 };
 // The C6 snapshot-authoring seam (#609). No caller fires it yet, and that is deliberate rather
 // than an oversight: a snapshot is only worth minting once something reads one. #406 owns both
@@ -111,8 +122,10 @@ pub use secrets::{
 pub use snapshot::author::{SnapshotAuthorOutcome, author_snapshot_in_tx};
 pub(crate) use storage::stream_owner_account;
 pub use storage::{
-    CapacityScope, IngestOutcome, SyncAccountEntry, account_entries_for_sync, account_entry_ref,
-    account_ingest, account_signed_entry_exists, account_signed_hash, auth_len_freshness,
-    backfill_authority_projection, grant_effective_for_device, owner_control_authority,
-    owner_secrets_authority, roster_content_authority, stream_owner_effective,
+    CapacityScope, IngestOutcome, SyncAccountEntry, account_entries_for_enrollment,
+    account_entries_for_sync, account_entry_ref, account_ingest, account_signed_entry_exists,
+    account_signed_hash, auth_len_freshness, backfill_authority_projection,
+    grant_effective_for_device, owned_streams_for_account, owner_control_authority,
+    owner_control_authority_in_snapshot, owner_secrets_authority, roster_content_authority,
+    stream_owner_effective, verify_enrollment_device_add,
 };

--- a/crates/rag-rat-oplog/src/account/ops.rs
+++ b/crates/rag-rat-oplog/src/account/ops.rs
@@ -65,7 +65,7 @@ impl DeviceRole {
         matches!(self, DeviceRole::Member | DeviceRole::Owner)
     }
 
-    pub(super) fn as_db_str(self) -> &'static str {
+    pub fn as_db_str(self) -> &'static str {
         match self {
             DeviceRole::ReadOnly => "read_only",
             DeviceRole::Member => "member",
@@ -73,7 +73,7 @@ impl DeviceRole {
         }
     }
 
-    pub(super) fn from_db_str(value: &str) -> anyhow::Result<Self> {
+    pub fn from_db_str(value: &str) -> anyhow::Result<Self> {
         match value {
             "read_only" => Ok(DeviceRole::ReadOnly),
             "member" => Ok(DeviceRole::Member),

--- a/crates/rag-rat-oplog/src/account/secrets/author.rs
+++ b/crates/rag-rat-oplog/src/account/secrets/author.rs
@@ -41,9 +41,11 @@ use anyhow::Context;
 use rusqlite::Transaction;
 
 use super::super::bootstrap::{self, LocalAccountRef};
-use super::super::envelope::{AccountEntryHeader, VerifiedAccountEntry, sign_account_entry};
+use super::super::envelope::{
+    AccountEntryHeader, VerifiedAccountEntry, sign_account_entry, signed_entry_len,
+};
 use super::super::fold::{SECRETS_LOG, SUPPORTED_OP_VERSION};
-use super::super::keywrap::{self, ContentKey, WrapContext};
+use super::super::keywrap::{self, ContentKey, SealedKeyWrap, WrapContext};
 use super::super::storage::{self, CandidateInsert};
 use super::super::{AccountId, authoring, limits};
 use super::ops::{self, StreamKeyWrap, WrapEntry};
@@ -206,6 +208,35 @@ pub fn catch_up_stream_keys_for_device_in_tx(
     streams: &[StreamId],
     now_ms: i64,
 ) -> anyhow::Result<CatchUpReport> {
+    rewrap_live_stream_keys_for_device_in_tx(tx, target, streams, now_ms, ExistingCoverage::Credit)
+}
+
+/// Re-wrap every live content key to the key certified by a newly authored `DeviceAdd`, even when
+/// an older accepted wrap names the same fingerprint. Enrollment cannot credit fingerprint-only
+/// coverage: that ciphertext may have been sealed to a different X25519 key before the roster
+/// certificate existed.
+pub fn enroll_stream_keys_for_device_in_tx(
+    tx: &Transaction<'_>,
+    target: DeviceFingerprint,
+    streams: &[StreamId],
+    now_ms: i64,
+) -> anyhow::Result<CatchUpReport> {
+    rewrap_live_stream_keys_for_device_in_tx(tx, target, streams, now_ms, ExistingCoverage::Ignore)
+}
+
+#[derive(Clone, Copy)]
+enum ExistingCoverage {
+    Credit,
+    Ignore,
+}
+
+fn rewrap_live_stream_keys_for_device_in_tx(
+    tx: &Transaction<'_>,
+    target: DeviceFingerprint,
+    streams: &[StreamId],
+    now_ms: i64,
+    existing_coverage: ExistingCoverage,
+) -> anyhow::Result<CatchUpReport> {
     let LocalAccountRef { account_id, .. } = bootstrap::local_account_ref(tx)?
         .context("cannot catch up stream keys before the store's local account is minted")?;
     let device = local_device(tx, now_ms)?;
@@ -217,7 +248,14 @@ pub fn catch_up_stream_keys_for_device_in_tx(
     let target_public = storage::effective_roster_x25519_pubkey(tx, account_id, target)?.context(
         "stream-key catch-up target is not currently roster-effective in the local account",
     )?;
-    let targets = super::sealing::live_stream_key_targets_for_device(tx, target, streams)?;
+    let targets = match existing_coverage {
+        ExistingCoverage::Credit =>
+            super::sealing::live_stream_key_targets_for_device(tx, target, streams)?,
+        ExistingCoverage::Ignore => super::sealing::LiveKeyTargets {
+            required: super::sealing::live_stream_key_epochs(tx, account_id, streams)?,
+            already_covered: Vec::new(),
+        },
+    };
 
     let mut authored_wraps = Vec::with_capacity(targets.required.len());
     for live in &targets.required {
@@ -369,6 +407,39 @@ fn pack_wraps_into_ops(
 /// Sign, store, refold, and verify one batch of already-sealed wraps. The secrets chain is shared
 /// across streams, so the tail is read once and advanced in memory; one refold classifies the whole
 /// batch.
+/// The exact signed-envelope byte length of a one-recipient `StreamKeyWrap` entry at the maximum
+/// header width — what enrollment's mint preflight charges per live key target (#945). Measured
+/// from the real encoder + [`signed_entry_len`] (never a hand-computed sum): a wrap is a small
+/// fixed-size payload, so charging the §18a envelope maximum per entry would put an artificial
+/// enrollment ceiling on accounts with many streams or many retained live historical keys.
+pub(in crate::account) fn single_recipient_wrap_envelope_bytes() -> usize {
+    let wrap = StreamKeyWrap {
+        stream_id: StreamId::from_bytes([u8::MAX; 32]),
+        key_id: [u8::MAX; 32],
+        key_epoch: u64::MAX,
+        wraps: vec![WrapEntry {
+            recipient_fp: DeviceFingerprint::from_bytes([u8::MAX; 32]),
+            sealed: SealedKeyWrap { ephemeral_pubkey: [u8::MAX; 32], ciphertext: [u8::MAX; 48] },
+        }],
+    };
+    let payload = ops::encode(&wrap).expect("a single canonical recipient encodes");
+    let header = AccountEntryHeader {
+        account_id: AccountId::from_bytes([u8::MAX; 32]),
+        log_id: SECRETS_LOG,
+        device_fingerprint: DeviceFingerprint::from_bytes([u8::MAX; 32]),
+        seq: u64::MAX,
+        prev_hash: Some([u8::MAX; 32]),
+        parent_ref: Some([u8::MAX; 32]),
+        entry_type: ops::entry_type_of(&wrap),
+        op_version: SUPPORTED_OP_VERSION,
+        crypto_suite: 0,
+        auth_len: u64::MAX,
+        key_id: None,
+        authority_ref: Some([u8::MAX; 32]),
+    };
+    signed_entry_len(&header, &payload)
+}
+
 fn author_stream_key_wrap_batch_in_tx(
     tx: &Transaction<'_>,
     wraps: &[StreamKeyWrap],
@@ -1027,6 +1098,81 @@ mod tests {
             )
             .unwrap();
         assert_eq!(after, before, "accepted remote coverage is an idempotent no-op");
+    }
+
+    #[test]
+    fn enrollment_rewraps_coverage_sealed_before_the_device_certificate() {
+        use crate::device::DeviceSecret;
+
+        let conn = db();
+        let (account, stream) = account_with_owned_stream(&conn, "repo-x");
+        let key = ContentKey::from_seed(&[0x7b; 32]);
+        {
+            let tx = Transaction::new_unchecked(&conn, TransactionBehavior::Immediate).unwrap();
+            author_stream_key_wrap_in_tx(&tx, stream, &key, 0, NOW).unwrap();
+            tx.commit().unwrap();
+        }
+
+        let remote_owner = DeviceSecret::from_seed(&[0x7c; 32]);
+        let remote_owner_x = DeviceX25519Secret::from_seed(&[0x7d; 32]);
+        let remote_authority = author_control_op(&conn, account, &AccountOp::DeviceAdd {
+            device_fingerprint: remote_owner.public().fingerprint(),
+            ed25519_pubkey: remote_owner.public().to_bytes(),
+            x25519_pubkey: remote_owner_x.public().to_bytes(),
+            role: DeviceRole::Owner,
+            label: None,
+        });
+        let target_ed = DeviceSecret::from_seed(&[0x7e; 32]);
+        let target = target_ed.public().fingerprint();
+        let wrong_x = DeviceX25519Secret::from_seed(&[0x7f; 32]);
+        let wrong_ctx = WrapContext {
+            account_id: account.to_bytes(),
+            stream_id: stream.to_bytes(),
+            key_epoch: 0,
+            recipient_pub: wrong_x.public().to_bytes(),
+        };
+        let remote_wrap = StreamKeyWrap {
+            stream_id: stream,
+            key_id: key.key_id().to_bytes(),
+            key_epoch: 0,
+            wraps: vec![WrapEntry {
+                recipient_fp: target,
+                sealed: keywrap::seal_content_key(&key, &wrong_ctx, &wrong_x.public()).unwrap(),
+            }],
+        };
+        author_remote_stream_key_wrap(
+            &conn,
+            account,
+            &remote_owner,
+            remote_authority,
+            &remote_wrap,
+        );
+
+        let target_x = DeviceX25519Secret::from_seed(&[0x80; 32]);
+        assert_eq!(add_member_device_with_seed(&conn, account, &target_x, 0x7e), target);
+        let ordinary =
+            super::super::sealing::live_stream_key_targets_for_device(&conn, target, &[stream])
+                .unwrap();
+        assert!(ordinary.required.is_empty(), "fingerprint-only coverage looks complete");
+
+        let tx = Transaction::new_unchecked(&conn, TransactionBehavior::Immediate).unwrap();
+        let report = enroll_stream_keys_for_device_in_tx(&tx, target, &[stream], NOW).unwrap();
+        tx.commit().unwrap();
+        assert_eq!(report.authored.len(), 1, "enrollment always authors fresh coverage");
+        assert!(report.already_covered.is_empty());
+
+        let ctx = WrapContext {
+            account_id: account.to_bytes(),
+            stream_id: stream.to_bytes(),
+            key_epoch: 0,
+            recipient_pub: target_x.public().to_bytes(),
+        };
+        let decryptable = accepted_wraps_for_target(&conn, target)
+            .iter()
+            .flat_map(|wrap| &wrap.wraps)
+            .filter(|wrap| unwrap_content_key(&wrap.sealed, &target_x, &ctx).is_ok())
+            .count();
+        assert_eq!(decryptable, 1, "the certified X25519 key receives a fresh decryptable wrap");
     }
 
     #[test]

--- a/crates/rag-rat-oplog/src/account/secrets/mod.rs
+++ b/crates/rag-rat-oplog/src/account/secrets/mod.rs
@@ -21,15 +21,15 @@ mod storage;
 // points (`rotate_stream_key_in_tx` / `ensure_stream_key_current_in_tx` / `RotationOutcome`):
 // re-exported up through `account` and the crate root for the seal path (C5) to reach (`pub` here
 // so `account::mod` can re-export it — the private `mod secrets` keeps it crate-scoped regardless).
-pub use author::{
-    CatchUpReport, RotationOutcome, catch_up_stream_keys_for_device_in_tx,
-    ensure_stream_key_current_in_tx, mint_and_author_stream_key_wrap_in_tx,
-    rotate_stream_key_in_tx,
-};
 // The ingest-time structural validation twin (mirrors the control-plaintext arm) and the
 // refold pass wired into `refold_in_tx`.
+pub(in crate::account) use author::single_recipient_wrap_envelope_bytes;
+pub use author::{
+    CatchUpReport, RotationOutcome, catch_up_stream_keys_for_device_in_tx,
+    enroll_stream_keys_for_device_in_tx, ensure_stream_key_current_in_tx,
+    mint_and_author_stream_key_wrap_in_tx, rotate_stream_key_in_tx,
+};
 pub(in crate::account) use ops::validate_storable_secrets_payload;
-pub(in crate::account) use sealing::accepted_stream_key_wrap_exists_strict;
 // The C4.3b READ side: derive-on-read sealing-key selection + the key_id adoption cross-check.
 // `current_sealing_key` is what C5's seal path calls; `select_current_sealing_wrap` is also
 // the CLI "what key is current" surface. Nothing calls them in C4.3b (machinery ships one
@@ -38,5 +38,8 @@ pub use sealing::{
     ContentKeyring, LiveKeyEpoch, LiveKeyTargets, SealingKeyOutcome, SelectedWrap,
     current_sealing_key, historical_content_keyring, live_stream_key_targets_for_device,
     select_current_sealing_wrap, stream_key_rotation_needed,
+};
+pub(in crate::account) use sealing::{
+    accepted_stream_key_wrap_exists_strict, recoverable_live_stream_key_target_count,
 };
 pub(in crate::account) use storage::refold_secrets_log;

--- a/crates/rag-rat-oplog/src/account/secrets/sealing.rs
+++ b/crates/rag-rat-oplog/src/account/secrets/sealing.rs
@@ -20,7 +20,7 @@ use super::super::keywrap::{self, ContentKey, KeyId, WrapContext};
 use super::super::{AccountId, bootstrap, content, envelope, fold, storage};
 use super::ops::{self, DecodedSecretsOp, StreamKeyWrap};
 use super::security_event::{self, SyncSecurityEvent, SyncSecurityEventKind};
-use crate::identity::LocalDevice;
+use crate::identity::{LocalDevice, load_local_device};
 use crate::stream::StreamId;
 
 /// The current sealing selection for a stream — the winning `(epoch, key_id)` over the accepted
@@ -139,7 +139,59 @@ pub fn live_stream_key_targets_for_device(
     storage::effective_roster_x25519_pubkey(conn, account_id, target)?.context(
         "stream-key catch-up target is not currently roster-effective in the local account",
     )?;
+    let live = live_stream_key_epochs(conn, account_id, streams)?;
 
+    let mut required = Vec::new();
+    let mut already_covered = Vec::new();
+    for key in live {
+        let covered = list_accepted_stream_key_wraps(conn, account_id, key.stream_id)?
+            .iter()
+            .filter(|accepted| {
+                accepted.wrap.key_epoch == key.key_epoch
+                    && KeyId::from_bytes(accepted.wrap.key_id) == key.key_id
+            })
+            .flat_map(|accepted| &accepted.wrap.wraps)
+            .any(|wrap| wrap.recipient_fp == target);
+        if covered {
+            already_covered.push(key);
+        } else {
+            required.push(key);
+        }
+    }
+    Ok(LiveKeyTargets { required, already_covered })
+}
+
+/// Verify the local founder can recover every live exact key a new device needs, then return the
+/// catch-up workload. Enrollment minting calls this before issuing a ticket; counting alone would
+/// allow a permanently unusable invite when an accepted wrap omitted or cannot decrypt locally.
+pub(crate) fn recoverable_live_stream_key_target_count(
+    conn: &Connection,
+    account_id: AccountId,
+    streams: &[StreamId],
+) -> anyhow::Result<usize> {
+    let live = live_stream_key_epochs(conn, account_id, streams)?;
+    let device = load_local_device(conn)?
+        .context("cannot preflight enrollment key recovery without a local device")?;
+    for target in &live {
+        anyhow::ensure!(
+            recover_exact_historical_content_key(conn, account_id, *target, &device)?.is_some(),
+            "live content key is not recoverable for enrollment catch-up (stream {:?}, epoch {}, \
+             key {:?})",
+            target.stream_id,
+            target.key_epoch,
+            target.key_id,
+        );
+    }
+    Ok(live.len())
+}
+
+/// Every live exact key group in `streams` (see [`live_stream_key_targets_for_device`] for what
+/// "live" means). Each requested stream must currently be owned by `account_id`.
+pub(super) fn live_stream_key_epochs(
+    conn: &Connection,
+    account_id: AccountId,
+    streams: &[StreamId],
+) -> anyhow::Result<Vec<LiveKeyEpoch>> {
     let mut stmt = conn.prepare(
         "SELECT stream_id FROM account_stream_ownership
          WHERE account_id = ?1 ORDER BY stream_id",
@@ -203,25 +255,7 @@ pub fn live_stream_key_targets_for_device(
 
     live.sort_by_key(|key| (key.stream_id.to_bytes(), key.key_epoch, key.key_id.to_bytes()));
     live.dedup();
-
-    let mut required = Vec::new();
-    let mut already_covered = Vec::new();
-    for key in live {
-        let covered = list_accepted_stream_key_wraps(conn, account_id, key.stream_id)?
-            .iter()
-            .filter(|accepted| {
-                accepted.wrap.key_epoch == key.key_epoch
-                    && KeyId::from_bytes(accepted.wrap.key_id) == key.key_id
-            })
-            .flat_map(|accepted| &accepted.wrap.wraps)
-            .any(|wrap| wrap.recipient_fp == target);
-        if covered {
-            already_covered.push(key);
-        } else {
-            required.push(key);
-        }
-    }
-    Ok(LiveKeyTargets { required, already_covered })
+    Ok(live)
 }
 
 fn fixed<const N: usize>(bytes: &[u8]) -> anyhow::Result<[u8; N]> {

--- a/crates/rag-rat-oplog/src/account/storage.rs
+++ b/crates/rag-rat-oplog/src/account/storage.rs
@@ -32,9 +32,9 @@ type BranchChildren = HashMap<BranchKey, Vec<BranchChild>>;
 // count and aggregate-byte limits: refolding materializes every candidate, so a count-only ceiling
 // would still permit hundreds of MiB in one writer transaction. Admission rejects rather than
 // evicts: deleting grow-only history would break replica convergence.
-const PRE_VERIFY_PER_ACCOUNT_MAX: usize = 64;
+pub(super) const PRE_VERIFY_PER_ACCOUNT_MAX: usize = 64;
 const PRE_VERIFY_GLOBAL_MAX: usize = 256;
-const CANDIDATES_PER_ACCOUNT_MAX: usize = 4_096;
+pub(super) const CANDIDATES_PER_ACCOUNT_MAX: usize = 4_096;
 const CANDIDATES_GLOBAL_MAX: usize = 16_384;
 const CANDIDATE_BYTES_PER_ACCOUNT_MAX: usize = 16 * 1024 * 1024;
 const CANDIDATE_BYTES_GLOBAL_MAX: usize = 64 * 1024 * 1024;
@@ -168,21 +168,103 @@ pub fn account_ingest(
     // One IMMEDIATE transaction spans the race-sensitive resolution → park-or-store decision,
     // promotion, and refold. Count/byte checks and insertion are therefore one serialized unit.
     let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
+    let outcome =
+        account_ingest_decoded_in_tx(&tx, signed, signed_bytes, now_ms, optimistic_verified)?;
+    tx.commit()?;
+    Ok(outcome)
+}
+
+/// Ingest one signed account entry inside the caller's transaction. Enrollment uses this to make
+/// its complete bootstrap and local-account pointer one atomic state transition.
+pub(super) fn account_ingest_in_tx(
+    tx: &Transaction<'_>,
+    signed_bytes: &[u8],
+    now_ms: i64,
+) -> anyhow::Result<IngestOutcome> {
+    let signed = match envelope::decode_account_signed(signed_bytes) {
+        Ok(signed) => signed,
+        Err(err) => return Ok(IngestOutcome::Rejected(err.to_string())),
+    };
+    if let Err(err) = validate_storable_header_payload(&signed.header, &signed.payload) {
+        return Ok(IngestOutcome::Rejected(err));
+    }
+    account_ingest_decoded_in_tx(tx, signed, signed_bytes, now_ms, None)
+}
+
+/// Authenticate and stage one enrollment receipt entry without refolding projections or retrying
+/// pre-existing parked work. The caller stages the complete receipt before one final
+/// reconciliation, so adoption remains linear in the account-history size and receipt rows win
+/// candidate admission.
+pub(super) fn stage_enrollment_bootstrap_entry_in_tx(
+    tx: &Transaction<'_>,
+    signed_bytes: &[u8],
+    resolved_signer: Option<[u8; 32]>,
+    now_ms: i64,
+) -> anyhow::Result<()> {
+    let signed = envelope::decode_account_signed(signed_bytes)
+        .map_err(|err| anyhow::anyhow!("enrollment bootstrap entry is malformed: {err}"))?;
+    validate_storable_header_payload(&signed.header, &signed.payload)
+        .map_err(|err| anyhow::anyhow!("enrollment bootstrap entry is invalid: {err}"))?;
+
+    let device_fp = signed.header.device_fingerprint;
+    let self_certified_signer = || {
+        let mut pubkeys = HashMap::new();
+        add_self_pubkey(&mut pubkeys, &signed.header, &signed.payload);
+        pubkeys.get(&device_fp).copied()
+    };
+    let pubkey_bytes = resolved_signer.or_else(self_certified_signer).ok_or_else(|| {
+        anyhow::anyhow!("enrollment bootstrap entry has no candidate-certified signer")
+    })?;
+    let verified = authenticate_entry(signed_bytes, &pubkey_bytes).map_err(|err| {
+        anyhow::anyhow!("enrollment bootstrap entry failed authentication: {err}")
+    })?;
+    match insert_candidate(tx, &verified, signed_bytes, now_ms)? {
+        CandidateInsert::Inserted | CandidateInsert::AlreadyPresent => Ok(()),
+        CandidateInsert::AtCapacity(scope) => {
+            anyhow::bail!("enrollment bootstrap entry reached candidate capacity at {scope:?}")
+        },
+    }
+}
+
+/// Project the staged enrollment receipt in the caller's transaction — receipt candidates and
+/// already-authenticated local candidates ONLY. Pre-existing parked rows are deliberately NOT
+/// retried here: a newly resolvable parked sibling (say, a competing `DeviceAdd` for the joining
+/// fingerprint, signed by a key the receipt certifies) would enter the same one-time fold and
+/// could make the acknowledged `DeviceAdd` lose deterministic branch selection, rolling the
+/// adoption back after the owner already consumed the nonce — and every exact replay would fail
+/// identically. The parked queues are retried in a separate transaction after adoption commits.
+pub(super) fn finish_enrollment_bootstrap_in_tx(
+    tx: &Transaction<'_>,
+    account_id: AccountId,
+    now_ms: i64,
+) -> anyhow::Result<()> {
+    let _state = refold_untrusted_ingest_in_tx(tx, account_id, now_ms, PreVerifyPromotion::Skip)?;
+    Ok(())
+}
+
+fn account_ingest_decoded_in_tx(
+    tx: &Transaction<'_>,
+    signed: envelope::SignedAccountEntry,
+    signed_bytes: &[u8],
+    now_ms: i64,
+    optimistic_verified: Option<VerifiedAccountEntry>,
+) -> anyhow::Result<IngestOutcome> {
+    let account_id = signed.header.account_id;
+    let device_fp = signed.header.device_fingerprint;
     let verified = if let Some(verified) = optimistic_verified {
         verified
     } else {
-        let mut pubkeys = stored_device_pubkeys(&tx, account_id)?;
+        let mut pubkeys = stored_device_pubkeys(tx, account_id)?;
         add_self_pubkey(&mut pubkeys, &signed.header, &signed.payload);
         let Some(pubkey_bytes) = pubkeys.get(&device_fp).copied() else {
             let parked = insert_pre_verify(
-                &tx,
+                tx,
                 &signed.entry_hash,
                 account_id,
                 device_fp,
                 signed_bytes,
                 now_ms,
             )?;
-            tx.commit()?;
             return Ok(match parked {
                 PreVerifyInsert::Parked { evicted } if evicted.is_empty() =>
                     IngestOutcome::PreVerify,
@@ -197,31 +279,27 @@ pub fn account_ingest(
         }
     };
 
-    match insert_candidate(&tx, &verified, signed_bytes, now_ms)? {
+    match insert_candidate(tx, &verified, signed_bytes, now_ms)? {
         CandidateInsert::AtCapacity(scope) => {
             return Ok(IngestOutcome::CapacityReached { scope });
         },
         CandidateInsert::AlreadyPresent => {
-            if let Some((status, _)) = entry_status(&tx, &verified.entry_hash)? {
-                tx.commit()?;
+            if let Some((status, _)) = entry_status(tx, &verified.entry_hash)? {
                 return Ok(IngestOutcome::Ingested { status });
             }
         },
         CandidateInsert::Inserted => {},
     }
     // A DeviceAdd/genesis may resolve devices that were parked — retry their pre-verify rows.
-    let rejected_promotions = if is_genesis(&verified.header) || is_device_add(&verified) {
-        promote_pre_verify(&tx, account_id, now_ms)?
+    let introduces_device = is_genesis(&verified.header) || is_device_add(&verified);
+    let rejected_promotions = if introduces_device {
+        promote_pre_verify(tx, account_id, now_ms)?
     } else {
         PromotionOutcome::default()
     };
-    let promotion = if is_genesis(&verified.header) || is_device_add(&verified) {
-        PreVerifyPromotion::Retry
-    } else {
-        PreVerifyPromotion::Skip
-    };
-    let state = refold_untrusted_ingest_in_tx(&tx, account_id, now_ms, promotion)?;
-    tx.commit()?;
+    let promotion =
+        if introduces_device { PreVerifyPromotion::Retry } else { PreVerifyPromotion::Skip };
+    let state = refold_untrusted_ingest_in_tx(tx, account_id, now_ms, promotion)?;
     let status =
         state.statuses.get(&verified.entry_hash).cloned().unwrap_or_else(|| "unknown".into());
     Ok(match (rejected_promotions.scope, state.rejected_content_promotions.scope) {
@@ -429,6 +507,18 @@ pub fn owner_control_authority(
     device_fingerprint: DeviceFingerprint,
 ) -> anyhow::Result<fold::AuthorityQuery<fold::OwnerChainAuthority>> {
     owner_chain_authority(conn, account_id, owner_id, device_fingerprint, "control")
+}
+
+/// Snapshot-safe counterpart of [`owner_control_authority`]. Callers that already own a
+/// transaction use this to keep an authority check and the authored mutation in one snapshot
+/// without attempting to open a nested read transaction.
+pub fn owner_control_authority_in_snapshot(
+    conn: &Connection,
+    account_id: AccountId,
+    owner_id: EntryHash,
+    device_fingerprint: DeviceFingerprint,
+) -> anyhow::Result<fold::AuthorityQuery<fold::OwnerChainAuthority>> {
+    owner_chain_authority_in_snapshot(conn, account_id, owner_id, device_fingerprint, "control")
 }
 
 pub fn owner_secrets_authority(
@@ -1088,12 +1178,27 @@ pub(super) fn refold_in_tx(
     now_ms: i64,
 ) -> anyhow::Result<HashMap<[u8; 32], String>> {
     let state = fold_account_state_in_tx(tx, account_id, now_ms, PreVerifyPromotion::Skip)?;
-    super::content::finalize_affected_streams(tx, &state.affected_streams)?;
+    super::content::finalize_affected_streams(tx, &state.affected_streams, now_ms)?;
     // `state.rejected_content_promotions` is deliberately DISCARDED here: this trusted/local path
     // has no remote caller to signal evicted promotions to (the ingest outcome variants carry it
     // only on the untrusted remote path), and the evicted set is bounded by the per-author
     // pre-verify cap, so it can never grow into unbounded silent loss.
     Ok(state.statuses)
+}
+
+/// Retry rows unlocked by a locally authored `DeviceAdd`, then immediately finalize content in the
+/// same trusted transaction. The ordinary local refold skips these sweeps because no other local
+/// account op introduces a signing key.
+pub(super) fn promote_after_local_device_add_in_tx(
+    tx: &Transaction<'_>,
+    account_id: AccountId,
+    now_ms: i64,
+) -> anyhow::Result<()> {
+    let _rejected_account_promotions = promote_pre_verify(tx, account_id, now_ms)?;
+    let state = fold_account_state_in_tx(tx, account_id, now_ms, PreVerifyPromotion::Retry)?;
+    let _rejected_content_promotions = state.rejected_content_promotions;
+    super::content::finalize_affected_streams(tx, &state.affected_streams, now_ms)?;
+    Ok(())
 }
 
 /// Remote account ingest commits account/authority/secrets state and durable content wakeups, but
@@ -1137,7 +1242,7 @@ fn fold_account_state_in_tx(
     // Streams this account owns BEFORE the projection rewrite: a fold that drops a `StreamOwn` fact
     // must still refold that stream so its content is declassified, but the ownership row is gone
     // after the rewrite — so capture it now and hand it to the content trigger below.
-    let previously_owned = owned_streams(tx, account_id)?;
+    let previously_owned = owned_stream_bytes(tx, account_id)?;
 
     // Rewrite atomically so the partial unique index never observes two accepted rows at a slot.
     tx.execute("UPDATE account_entries SET accepted = 0 WHERE account_id = ?1", params![
@@ -1191,14 +1296,29 @@ fn fold_account_state_in_tx(
     };
     let affected_streams =
         super::content::affected_streams_for_account(tx, account_id, &previously_owned)?;
+    // Every fold path — trusted, untrusted, and the DeviceAdd promotion sweep — can grow the
+    // live key-target set (a locally minted key, a remotely synced `StreamOwn`/wrap, or a parked
+    // wrap a promoted DeviceAdd just certified). Top outstanding invite reservations up to the
+    // new mandatory redemption cost inside the same transaction (#945).
+    top_up_account_candidate_reservations_in_tx(tx, account_id, now_ms)?;
     Ok(AccountStateFold { statuses, affected_streams, rejected_content_promotions })
 }
 
 /// The streams this account currently owns, per the projection — captured before a refold rewrites
 /// it so a dropped `StreamOwn` still triggers its stream's content declassification.
-fn owned_streams(tx: &Transaction<'_>, account_id: AccountId) -> anyhow::Result<Vec<[u8; 32]>> {
-    let mut stmt =
-        tx.prepare("SELECT stream_id FROM account_stream_ownership WHERE account_id = ?1")?;
+pub fn owned_streams_for_account(
+    conn: &Connection,
+    account_id: AccountId,
+) -> anyhow::Result<Vec<StreamId>> {
+    owned_stream_bytes(conn, account_id)
+        .map(|streams| streams.into_iter().map(StreamId::from_bytes).collect())
+}
+
+fn owned_stream_bytes(conn: &Connection, account_id: AccountId) -> anyhow::Result<Vec<[u8; 32]>> {
+    let mut stmt = conn.prepare(
+        "SELECT stream_id FROM account_stream_ownership
+          WHERE account_id = ?1 ORDER BY stream_id",
+    )?;
     let rows = stmt
         .query_map([account_id.to_bytes().as_slice()], |row| row.get::<_, Vec<u8>>(0))?
         .collect::<rusqlite::Result<Vec<_>>>()?;
@@ -1605,6 +1725,99 @@ pub fn account_entry_ref(signed_bytes: &[u8]) -> anyhow::Result<(AccountId, [u8;
     Ok((signed.header.account_id, signed.entry_hash))
 }
 
+/// Verify that an enrollment bootstrap contains a founder-signed `DeviceAdd` for the exact
+/// account, entry hash, and joiner keys the caller requested. This is deliberately independent of
+/// transport identity: the inviter's QUIC key routes the exchange, while the account founder key
+/// carried by the self-certifying genesis authorizes enrollment.
+pub fn verify_enrollment_device_add(
+    account_entries: &[Vec<u8>],
+    expected_account: AccountId,
+    expected_hash: [u8; 32],
+    expected_signed: &[u8],
+    expected_ed25519_pubkey: [u8; 32],
+    expected_x25519_pubkey: [u8; 32],
+) -> anyhow::Result<[u8; 32]> {
+    let mut entries = Vec::with_capacity(account_entries.len());
+    let mut device_add = None;
+    for bytes in account_entries {
+        let signed = envelope::decode_account_signed(bytes)?;
+        anyhow::ensure!(
+            signed.header.account_id == expected_account,
+            "enrollment bootstrap contains an entry for another account"
+        );
+        if signed.entry_hash == expected_hash {
+            anyhow::ensure!(
+                bytes.as_slice() == expected_signed,
+                "bootstrap DeviceAdd bytes differ from the receipt"
+            );
+            anyhow::ensure!(
+                device_add.replace(signed.clone()).is_none(),
+                "duplicate enrollment DeviceAdd entry"
+            );
+        }
+        entries.push(signed);
+    }
+    // Select the same canonical, current-version root the account fold accepts. A parked opaque
+    // future-version row may preserve genesis-looking header coordinates, but it is not an
+    // authoritative root and must not poison an otherwise valid durable receipt.
+    let candidates = entries
+        .iter()
+        .map(|signed| VerifiedAccountEntry {
+            header: signed.header.clone(),
+            payload: signed.payload.clone(),
+            entry_hash: signed.entry_hash,
+        })
+        .collect::<Vec<_>>();
+    let genesis_hash = fold::fold_account(&candidates)
+        .genesis_hash()
+        .ok_or_else(|| anyhow::anyhow!("enrollment bootstrap has no accepted account genesis"))?;
+    let genesis = entries
+        .into_iter()
+        .find(|signed| signed.entry_hash == genesis_hash)
+        .expect("the fold's genesis hash names an entry in its input");
+    // The per-entry check above compares ATTACKER-CONTROLLED header bytes; bind the genesis to
+    // the expected account the way ingest does (§4): its payload must self-hash to
+    // `expected_account`, or an impostor's own founder-signed genesis + DeviceAdd (stamped with
+    // the victim's account_id in their headers) would pass every signature check below.
+    anyhow::ensure!(
+        account_id_from_genesis_payload(&genesis.payload) == expected_account,
+        "enrollment genesis payload does not hash to the expected account"
+    );
+    let DecodedAccountOp::Known(AccountOp::AccountGenesis { ed25519_pubkey: founder_key, .. }) =
+        ops::decode(genesis.header.entry_type, &genesis.payload)?
+    else {
+        anyhow::bail!("enrollment bootstrap genesis payload is not AccountGenesis");
+    };
+    authenticate_entry(&genesis.signed_bytes, &founder_key).map_err(anyhow::Error::msg)?;
+
+    let device_add = device_add
+        .ok_or_else(|| anyhow::anyhow!("enrollment bootstrap has no acknowledged DeviceAdd"))?;
+    anyhow::ensure!(
+        device_add.header.authority_ref == Some(genesis.entry_hash),
+        "enrollment DeviceAdd does not cite the founder incarnation"
+    );
+    let verified =
+        authenticate_entry(&device_add.signed_bytes, &founder_key).map_err(anyhow::Error::msg)?;
+    anyhow::ensure!(
+        verified.entry_hash == expected_hash,
+        "enrollment DeviceAdd hash does not match the receipt"
+    );
+    let DecodedAccountOp::Known(AccountOp::DeviceAdd { ed25519_pubkey, x25519_pubkey, .. }) =
+        ops::decode(verified.header.entry_type, &verified.payload)?
+    else {
+        anyhow::bail!("acknowledged enrollment entry is not a DeviceAdd");
+    };
+    anyhow::ensure!(
+        ed25519_pubkey == expected_ed25519_pubkey,
+        "enrollment DeviceAdd names a different ed25519 key"
+    );
+    anyhow::ensure!(
+        x25519_pubkey == expected_x25519_pubkey,
+        "enrollment DeviceAdd names a different x25519 key"
+    );
+    Ok(genesis.entry_hash)
+}
+
 /// The wire dedup key for a signed account entry: `sha256(signed_bytes)`, the SAME hash
 /// `account_pre_verify` keys its rows by. This distinguishes competing SIGNATURES of one entry —
 /// two envelopes can share an `entry_hash` (same body) yet differ in signature, and the sync layer
@@ -1638,26 +1851,14 @@ pub fn account_signed_entry_exists(
     Ok(found.is_some())
 }
 
-/// Every account-log entry for `account_id` that a peer may need — the held entries AND the ones
-/// durably PARKED in `account_pre_verify` awaiting their signer's introduction.
-///
-/// Parked entries must be offered too: a valid entry whose signing device is not yet known here is
-/// still real, and a peer that holds the authorizing `DeviceAdd` can promote it. Omitting them
-/// would let a session complete with one peer holding a dependent entry the other never receives —
-/// a silent divergence.
-///
-/// Held entries come first, ordered `(log_id, seq, entry_hash)` — a causal-leaning order (the
-/// account genesis at seq 0, then the `DeviceAdd`s that introduce signers, then later ops) so a
-/// cooperative receiver folds authorizers before dependents and avoids parking-then-eviction. It is
-/// NOT a full topological guarantee against an adversarial sender (that needs a reconciliation pass
-/// at the caller); it makes the honest restore converge in one session. Parked entries follow,
-/// since they depend on authorizers in the held set.
-pub fn account_entries_for_sync(
+/// Every authenticated account candidate for an enrollment bootstrap. Unlike normal sync, this
+/// excludes unauthenticated pre-verify rows: enrollment is an authority bootstrap, not a vehicle
+/// for speculative queue work.
+pub fn account_entries_for_enrollment(
     conn: &Connection,
     account_id: AccountId,
 ) -> anyhow::Result<Vec<SyncAccountEntry>> {
     let mut out = Vec::new();
-
     let mut held = conn.prepare(
         "SELECT entry_hash, device_fingerprint, seq, log_id, signed_bytes
          FROM account_entries WHERE account_id = ?1
@@ -1684,6 +1885,28 @@ pub fn account_entries_for_sync(
             signed_bytes,
         });
     }
+    Ok(out)
+}
+
+/// Every account-log entry for `account_id` that a peer may need — the held entries AND the ones
+/// durably PARKED in `account_pre_verify` awaiting their signer's introduction.
+///
+/// Parked entries must be offered too: a valid entry whose signing device is not yet known here is
+/// still real, and a peer that holds the authorizing `DeviceAdd` can promote it. Omitting them
+/// would let a session complete with one peer holding a dependent entry the other never receives —
+/// a silent divergence.
+///
+/// Held entries come first, ordered `(log_id, seq, entry_hash)` — a causal-leaning order (the
+/// account genesis at seq 0, then the `DeviceAdd`s that introduce signers, then later ops) so a
+/// cooperative receiver folds authorizers before dependents and avoids parking-then-eviction. It is
+/// NOT a full topological guarantee against an adversarial sender (that needs a reconciliation pass
+/// at the caller); it makes the honest restore converge in one session. Parked entries follow,
+/// since they depend on authorizers in the held set.
+pub fn account_entries_for_sync(
+    conn: &Connection,
+    account_id: AccountId,
+) -> anyhow::Result<Vec<SyncAccountEntry>> {
+    let mut out = account_entries_for_enrollment(conn, account_id)?;
 
     // Parked rows carry the raw signed bytes but not decoded coordinates; decode the header for the
     // log/seq the wire records (informational — the session diffs on entry_hash). A parked row that
@@ -1733,18 +1956,28 @@ pub(super) fn insert_candidate(
     if already_present {
         return Ok(CandidateInsert::AlreadyPresent);
     }
+    // Outstanding enrollment invites reserve their mandatory DeviceAdd + wraps in these SAME
+    // counters until they are consumed or expire (#945): candidate capacity is grow-only, so
+    // without charging reservations here, ordinary ingest or a second invite could consume
+    // headroom an already-minted ticket was measured against and strand it permanently.
     let candidate_count: i64 = tx.query_row(
-        "SELECT COUNT(*) FROM account_entries WHERE account_id = ?1",
-        params![h.account_id.to_bytes().as_slice()],
+        "SELECT (SELECT COUNT(*) FROM account_entries WHERE account_id = ?1)
+              + (SELECT COALESCE(SUM(reserved_entries), 0)
+                   FROM account_candidate_reservations
+                  WHERE account_id = ?1 AND expires_at_ms > ?2)",
+        params![h.account_id.to_bytes().as_slice(), now_ms],
         |row| row.get(0),
     )?;
     if candidate_count >= CANDIDATES_PER_ACCOUNT_MAX as i64 {
         return Ok(CandidateInsert::AtCapacity(CapacityScope::CandidateAccount));
     }
     let candidate_bytes: i64 = tx.query_row(
-        "SELECT COALESCE(SUM(length(signed_bytes)), 0)
-         FROM account_entries WHERE account_id = ?1",
-        params![h.account_id.to_bytes().as_slice()],
+        "SELECT (SELECT COALESCE(SUM(length(signed_bytes)), 0)
+                   FROM account_entries WHERE account_id = ?1)
+              + (SELECT COALESCE(SUM(reserved_bytes), 0)
+                   FROM account_candidate_reservations
+                  WHERE account_id = ?1 AND expires_at_ms > ?2)",
+        params![h.account_id.to_bytes().as_slice(), now_ms],
         |row| row.get(0),
     )?;
     if candidate_bytes.saturating_add(signed_bytes.len() as i64)
@@ -1752,14 +1985,23 @@ pub(super) fn insert_candidate(
     {
         return Ok(CandidateInsert::AtCapacity(CapacityScope::CandidateAccountBytes));
     }
-    let global_candidate_count: i64 =
-        tx.query_row("SELECT COUNT(*) FROM account_entries", [], |row| row.get(0))?;
+    let global_candidate_count: i64 = tx.query_row(
+        "SELECT (SELECT COUNT(*) FROM account_entries)
+              + (SELECT COALESCE(SUM(reserved_entries), 0)
+                   FROM account_candidate_reservations
+                  WHERE expires_at_ms > ?1)",
+        [now_ms],
+        |row| row.get(0),
+    )?;
     if global_candidate_count >= CANDIDATES_GLOBAL_MAX as i64 {
         return Ok(CandidateInsert::AtCapacity(CapacityScope::CandidateGlobal));
     }
     let global_candidate_bytes: i64 = tx.query_row(
-        "SELECT COALESCE(SUM(length(signed_bytes)), 0) FROM account_entries",
-        [],
+        "SELECT (SELECT COALESCE(SUM(length(signed_bytes)), 0) FROM account_entries)
+              + (SELECT COALESCE(SUM(reserved_bytes), 0)
+                   FROM account_candidate_reservations
+                  WHERE expires_at_ms > ?1)",
+        [now_ms],
         |row| row.get(0),
     )?;
     if global_candidate_bytes.saturating_add(signed_bytes.len() as i64)
@@ -1791,10 +2033,175 @@ pub(super) fn insert_candidate(
     Ok(if inserted == 1 { CandidateInsert::Inserted } else { CandidateInsert::AlreadyPresent })
 }
 
+/// The grow-only candidate-admission budget still available to `account_id` and to the store
+/// globally — the exact counters [`insert_candidate`] enforces, exposed so an authoring PREFLIGHT
+/// (enrollment invite minting, #945) can refuse a write that redemption could never recover:
+/// candidate capacity never drains on its own.
+pub(crate) struct CandidateCapacityHeadroom {
+    pub(crate) account_entries_remaining: i64,
+    pub(crate) account_bytes_remaining: i64,
+    pub(crate) global_entries_remaining: i64,
+    pub(crate) global_bytes_remaining: i64,
+}
+
+pub(crate) fn candidate_capacity_headroom(
+    conn: &Connection,
+    account_id: AccountId,
+    now_ms: i64,
+) -> rusqlite::Result<CandidateCapacityHeadroom> {
+    let account_count: i64 = conn.query_row(
+        "SELECT (SELECT COUNT(*) FROM account_entries WHERE account_id = ?1)
+              + (SELECT COALESCE(SUM(reserved_entries), 0)
+                   FROM account_candidate_reservations
+                  WHERE account_id = ?1 AND expires_at_ms > ?2)",
+        params![account_id.to_bytes().as_slice(), now_ms],
+        |row| row.get(0),
+    )?;
+    let account_bytes: i64 = conn.query_row(
+        "SELECT (SELECT COALESCE(SUM(length(signed_bytes)), 0)
+                   FROM account_entries WHERE account_id = ?1)
+              + (SELECT COALESCE(SUM(reserved_bytes), 0)
+                   FROM account_candidate_reservations
+                  WHERE account_id = ?1 AND expires_at_ms > ?2)",
+        params![account_id.to_bytes().as_slice(), now_ms],
+        |row| row.get(0),
+    )?;
+    let global_count: i64 = conn.query_row(
+        "SELECT (SELECT COUNT(*) FROM account_entries)
+              + (SELECT COALESCE(SUM(reserved_entries), 0)
+                   FROM account_candidate_reservations
+                  WHERE expires_at_ms > ?1)",
+        [now_ms],
+        |row| row.get(0),
+    )?;
+    let global_bytes: i64 = conn.query_row(
+        "SELECT (SELECT COALESCE(SUM(length(signed_bytes)), 0) FROM account_entries)
+              + (SELECT COALESCE(SUM(reserved_bytes), 0)
+                   FROM account_candidate_reservations
+                  WHERE expires_at_ms > ?1)",
+        [now_ms],
+        |row| row.get(0),
+    )?;
+    Ok(CandidateCapacityHeadroom {
+        account_entries_remaining: (CANDIDATES_PER_ACCOUNT_MAX as i64) - account_count,
+        account_bytes_remaining: (CANDIDATE_BYTES_PER_ACCOUNT_MAX as i64) - account_bytes,
+        global_entries_remaining: (CANDIDATES_GLOBAL_MAX as i64) - global_count,
+        global_bytes_remaining: (CANDIDATE_BYTES_GLOBAL_MAX as i64) - global_bytes,
+    })
+}
+
+/// Top outstanding enrollment invite reservations up to the CURRENT live key-target count after
+/// a fold (#945). Every mandatory redemption wraps every live target to its joiner, so when a
+/// fold grows the target set — a local key mint, or a REMOTELY synced `StreamOwn`/wrap the local
+/// authoring hooks never see — each outstanding invite's reservation must grow by the same delta,
+/// or ordinary candidate writes could consume headroom a minted ticket needs and strand it.
+/// Called from both refold wrappers; costs one indexed EXISTS in the common no-invites case.
+/// A bump that would exceed the grow-only caps fails the fold that caused the growth instead of
+/// silently stranding the ticket.
+pub(super) fn top_up_account_candidate_reservations_in_tx(
+    tx: &Transaction<'_>,
+    account_id: AccountId,
+    now_ms: i64,
+) -> anyhow::Result<()> {
+    // Migration replays (e.g. V064's authority backfill) refold before V090 exists.
+    let table_exists: bool = tx.query_row(
+        "SELECT EXISTS(
+             SELECT 1 FROM sqlite_master
+              WHERE type = 'table' AND name = 'account_candidate_reservations')",
+        [],
+        |row| row.get(0),
+    )?;
+    if !table_exists {
+        return Ok(());
+    }
+    let any_outstanding: bool = tx.query_row(
+        "SELECT EXISTS(
+             SELECT 1 FROM account_candidate_reservations
+              WHERE account_id = ?1 AND expires_at_ms > ?2)",
+        params![account_id.to_bytes().as_slice(), now_ms],
+        |row| row.get(0),
+    )?;
+    if !any_outstanding {
+        return Ok(());
+    }
+    let streams = owned_streams_for_account(tx, account_id)?;
+    let targets =
+        super::secrets::recoverable_live_stream_key_target_count(tx, account_id, &streams)?;
+    let targets = i64::try_from(targets)?;
+    let wrap_bytes = i64::try_from(super::secrets::single_recipient_wrap_envelope_bytes())?;
+    // Bidirectional: a fold that SHRINKS the live target set (say, a competing control branch
+    // makes a previously owned stream ineffective) reclaims the obsolete reservation in the same
+    // update, so a long-lived invite near a cap cannot keep capacity it no longer needs.
+    let grew: bool = tx.query_row(
+        "SELECT EXISTS(
+             SELECT 1 FROM account_candidate_reservations
+              WHERE account_id = ?1 AND expires_at_ms > ?2 AND reserved_targets < ?3)",
+        params![account_id.to_bytes().as_slice(), now_ms, targets],
+        |row| row.get(0),
+    )?;
+    tx.execute(
+        "UPDATE account_candidate_reservations
+            SET reserved_entries = reserved_entries + (?3 - reserved_targets),
+                reserved_bytes   = reserved_bytes + (?3 - reserved_targets) * ?4,
+                reserved_targets = ?3
+          WHERE account_id = ?1 AND expires_at_ms > ?2 AND reserved_targets != ?3",
+        params![account_id.to_bytes().as_slice(), now_ms, targets, wrap_bytes],
+    )?;
+    if !grew {
+        return Ok(());
+    }
+    let headroom = candidate_capacity_headroom(tx, account_id, now_ms)?;
+    anyhow::ensure!(
+        headroom.account_entries_remaining >= 0
+            && headroom.account_bytes_remaining >= 0
+            && headroom.global_entries_remaining >= 0
+            && headroom.global_bytes_remaining >= 0,
+        "the new mandatory enrollment key targets do not fit the candidate store alongside the \
+         outstanding invite reservations",
+    );
+    Ok(())
+}
+
+/// Refresh outstanding invite reservations after a `/3` content stream's acceptance settles
+/// (#945). Accepted suite-1 content pins its sealing key as a live enrollment catch-up target
+/// (`live_stream_key_epochs` reads `content_entries.accepted`), so content finalization can grow
+/// the mandatory redemption cost without any account fold. Derives the stream's owner account
+/// (if any) and runs the same bidirectional top-up the account fold uses.
+pub(in crate::account) fn refresh_enrollment_reservations_for_stream_in_tx(
+    tx: &Transaction<'_>,
+    stream_id: StreamId,
+    now_ms: i64,
+) -> anyhow::Result<()> {
+    // Content refolds can replay during migrations that predate the authority/reservation tables.
+    let tables_ready: bool = tx.query_row(
+        "SELECT EXISTS(
+             SELECT 1 FROM sqlite_master
+              WHERE type = 'table' AND name = 'account_stream_ownership')
+           AND EXISTS(
+             SELECT 1 FROM sqlite_master
+              WHERE type = 'table' AND name = 'account_candidate_reservations')",
+        [],
+        |row| row.get(0),
+    )?;
+    if !tables_ready {
+        return Ok(());
+    }
+    let owner: Option<Vec<u8>> = tx
+        .query_row(
+            "SELECT account_id FROM account_stream_ownership WHERE stream_id = ?1 LIMIT 1",
+            [stream_id.to_bytes().as_slice()],
+            |row| row.get(0),
+        )
+        .optional()?;
+    let Some(owner) = owner else { return Ok(()) };
+    let account_id = AccountId::from_bytes(fixed(&owner)?);
+    top_up_account_candidate_reservations_in_tx(tx, account_id, now_ms)
+}
+
 /// The `(fingerprint → ed25519_pubkey)` map from every stored genesis / DeviceAdd for the account —
 /// the only ops that carry a device's key. Fold-status-independent (§16.2): a key resolves from ANY
 /// stored candidate carrying it, whether or not it is currently accepted.
-fn stored_device_pubkeys(
+pub(super) fn stored_device_pubkeys(
     conn: &Connection,
     account_id: AccountId,
 ) -> anyhow::Result<HashMap<DeviceFingerprint, [u8; 32]>> {
@@ -1825,11 +2232,20 @@ fn stored_device_pubkeys(
     Ok(out)
 }
 
+/// Whether the entry certifies its OWN signer key with no prior state — the genesis arm of
+/// [`add_self_pubkey`]. The enrollment bootstrap's causal ingest order treats exactly these as
+/// worklist roots (a DeviceAdd certifies the ADDED key, never its signer, so it is not a root).
+pub(super) fn self_certifies_signer(header: &AccountEntryHeader, payload: &[u8]) -> bool {
+    let mut map = HashMap::new();
+    add_self_pubkey(&mut map, header, payload);
+    map.contains_key(&header.device_fingerprint)
+}
+
 /// Add the `(fingerprint → pubkey)` an entry itself certifies: a genesis certifies its founder key
 /// (the SIGNER); a DeviceAdd certifies the ADDED device's key. Both bind `sha256(pk) ==
 /// fingerprint` (genesis: the header device; DeviceAdd: the op's `device_fingerprint`, enforced at
 /// decode).
-fn add_self_pubkey(
+pub(super) fn add_self_pubkey(
     map: &mut HashMap<DeviceFingerprint, [u8; 32]>,
     header: &AccountEntryHeader,
     payload: &[u8],
@@ -2346,6 +2762,33 @@ mod tests {
     }
 
     #[test]
+    fn owned_stream_reader_returns_every_stream_for_the_account() {
+        let conn = db();
+        let account = AccountId::from_bytes([0xa1; 32]);
+        for (stream, own) in [([1u8; 32], [11u8; 32]), ([2u8; 32], [22u8; 32])] {
+            conn.execute(
+                "INSERT INTO account_stream_ownership(
+                     stream_id, account_id, own_id, effective_at
+                 ) VALUES (?1, ?2, ?3, 1)",
+                params![stream.as_slice(), account.to_bytes().as_slice(), own.as_slice(),],
+            )
+            .unwrap();
+        }
+        conn.execute(
+            "INSERT INTO account_stream_ownership(
+                 stream_id, account_id, own_id, effective_at
+             ) VALUES (?1, ?2, ?3, 1)",
+            params![[3u8; 32].as_slice(), [0xb2u8; 32].as_slice(), [33u8; 32].as_slice()],
+        )
+        .unwrap();
+
+        assert_eq!(owned_streams_for_account(&conn, account).unwrap(), vec![
+            StreamId::from_bytes([1; 32]),
+            StreamId::from_bytes([2; 32])
+        ]);
+    }
+
+    #[test]
     fn effective_owner_incarnation_resolves_the_open_incarnation_not_a_closed_one() {
         // Reverse lookup by device: a device can hold a CLOSED prior incarnation and an OPEN
         // current one (demote-then-repromote). The StreamKeyWrap author cites the OPEN
@@ -2510,6 +2953,945 @@ mod tests {
             role,
             label: None,
         }
+    }
+
+    #[test]
+    fn enrollment_verification_requires_the_genesis_to_commit_to_the_account() {
+        let founder = Dev::new(0x51);
+        let joiner = Dev::new(0x52);
+        let (account, genesis_bytes, genesis_hash) = genesis(&founder);
+        let (device_add_bytes, device_add_hash) = op(
+            account,
+            &founder,
+            1,
+            Some(genesis_hash),
+            Some(genesis_hash),
+            &device_add(&joiner, DeviceRole::ReadOnly),
+        );
+        let bootstrap = vec![genesis_bytes, device_add_bytes.clone()];
+        verify_enrollment_device_add(
+            &bootstrap,
+            account,
+            device_add_hash,
+            &device_add_bytes,
+            joiner.ed,
+            joiner.x,
+        )
+        .unwrap();
+
+        // An impostor signs its OWN genesis + DeviceAdd but stamps the VICTIM's account_id into
+        // both headers: every signature verifies under the impostor's founder key, so canonical
+        // genesis selection must reject the root whose payload does not self-hash to the account.
+        let impostor = Dev::new(0x53);
+        let victim = AccountId::from_bytes([0xaa; 32]);
+        let impostor_genesis_op = AccountOp::AccountGenesis {
+            ed25519_pubkey: impostor.ed,
+            x25519_pubkey: impostor.x,
+            nonce16: [0u8; 16],
+            created_at_ms: NOW as u64,
+            label: None,
+        };
+        let impostor_genesis_payload = ops::encode(&impostor_genesis_op).unwrap();
+        assert_ne!(account_id_from_genesis_payload(&impostor_genesis_payload), victim);
+        let impostor_genesis_header = AccountEntryHeader {
+            account_id: victim,
+            log_id: 0,
+            device_fingerprint: impostor.fp,
+            seq: 0,
+            prev_hash: None,
+            parent_ref: None,
+            entry_type: ops::entry_type::ACCOUNT_GENESIS,
+            op_version: 1,
+            crypto_suite: 0,
+            auth_len: 0,
+            key_id: None,
+            authority_ref: None,
+        };
+        let impostor_genesis = sign_account_entry(
+            &impostor.secret,
+            &impostor_genesis_header,
+            &impostor_genesis_payload,
+        )
+        .unwrap();
+        let (impostor_add_bytes, impostor_add_hash) = op(
+            victim,
+            &impostor,
+            1,
+            Some(impostor_genesis.entry_hash),
+            Some(impostor_genesis.entry_hash),
+            &device_add(&joiner, DeviceRole::ReadOnly),
+        );
+        let forged = vec![impostor_genesis.signed_bytes, impostor_add_bytes.clone()];
+        let error = verify_enrollment_device_add(
+            &forged,
+            victim,
+            impostor_add_hash,
+            &impostor_add_bytes,
+            joiner.ed,
+            joiner.x,
+        )
+        .expect_err("a genesis that does not self-hash to the expected account is rejected");
+        assert!(
+            error.to_string().contains("no accepted account genesis"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn enrollment_verification_ignores_a_parked_future_genesis_lookalike() {
+        let conn = db();
+        let founder = Dev::new(0x54);
+        let joiner = Dev::new(0x55);
+        let stranger = Dev::new(0x56);
+        let (account, genesis_bytes, genesis_hash) = genesis(&founder);
+        let (device_add_bytes, device_add_hash) = op(
+            account,
+            &founder,
+            1,
+            Some(genesis_hash),
+            Some(genesis_hash),
+            &device_add(&joiner, DeviceRole::ReadOnly),
+        );
+        assert!(matches!(
+            account_ingest(&conn, &genesis_bytes, NOW).unwrap(),
+            IngestOutcome::Ingested { .. }
+        ));
+        assert!(matches!(
+            account_ingest(&conn, &device_add_bytes, NOW).unwrap(),
+            IngestOutcome::Ingested { .. }
+        ));
+
+        let lookalike_payload = ops::encode(&AccountOp::AccountGenesis {
+            ed25519_pubkey: stranger.ed,
+            x25519_pubkey: stranger.x,
+            nonce16: [7; 16],
+            created_at_ms: NOW as u64,
+            label: None,
+        })
+        .unwrap();
+        let lookalike_header = AccountEntryHeader {
+            account_id: account,
+            log_id: fold::CONTROL_LOG,
+            device_fingerprint: stranger.fp,
+            seq: 0,
+            prev_hash: None,
+            parent_ref: None,
+            entry_type: ops::entry_type::ACCOUNT_GENESIS,
+            op_version: fold::SUPPORTED_OP_VERSION + 1,
+            crypto_suite: 0,
+            auth_len: 0,
+            key_id: None,
+            authority_ref: None,
+        };
+        let lookalike =
+            sign_account_entry(&stranger.secret, &lookalike_header, &lookalike_payload).unwrap();
+        assert_eq!(
+            account_ingest(&conn, &lookalike.signed_bytes, NOW).unwrap(),
+            IngestOutcome::PreVerify,
+            "an unresolved future-version row follows the normal durable parking path",
+        );
+
+        let receipt = account_entries_for_sync(&conn, account)
+            .unwrap()
+            .into_iter()
+            .map(|entry| entry.signed_bytes)
+            .collect::<Vec<_>>();
+        assert!(receipt.iter().any(|bytes| bytes == &lookalike.signed_bytes));
+        assert_eq!(
+            verify_enrollment_device_add(
+                &receipt,
+                account,
+                device_add_hash,
+                &device_add_bytes,
+                joiner.ed,
+                joiner.x,
+            )
+            .unwrap(),
+            genesis_hash,
+            "the fold's accepted current-version genesis wins over an opaque parked lookalike",
+        );
+    }
+
+    struct InterleavedBootstrap {
+        account: AccountId,
+        genesis_hash: [u8; 32],
+        device_b: Dev,
+        b0_hash: [u8; 32],
+        joiner: Dev,
+        add_joiner_hash: [u8; 32],
+        account_entries: Vec<Vec<u8>>,
+    }
+
+    /// A bootstrap whose raw `(log_id, seq, entry_hash)` receipt order interleaves seq-0 control
+    /// entries from two promoted devices BEFORE the founder-chain DeviceAdds introducing their
+    /// keys — the ordering that forces simultaneous pre-verify parking when ingested raw (#945).
+    fn interleaved_promoted_device_bootstrap() -> InterleavedBootstrap {
+        let founder = Dev::new(0x61);
+        let device_b = Dev::new(0x62);
+        let device_c = Dev::new(0x63);
+        let joiner = Dev::new(0x64);
+        let (account, genesis_bytes, genesis_hash) = genesis(&founder);
+        let (add_b_bytes, add_b_hash) = op(
+            account,
+            &founder,
+            1,
+            Some(genesis_hash),
+            Some(genesis_hash),
+            &device_add(&device_b, DeviceRole::Member),
+        );
+        let (add_c_bytes, add_c_hash) = op(
+            account,
+            &founder,
+            2,
+            Some(add_b_hash),
+            Some(genesis_hash),
+            &device_add(&device_c, DeviceRole::Member),
+        );
+        let (add_joiner_bytes, add_joiner_hash) = op(
+            account,
+            &founder,
+            3,
+            Some(add_c_hash),
+            Some(genesis_hash),
+            &device_add(&joiner, DeviceRole::Member),
+        );
+        let (_stream, own_op) = stream_own(account);
+        let (b0_bytes, b0_hash) = op(account, &device_b, 0, None, None, &own_op);
+        let (c0_bytes, c0_hash) = op(account, &device_c, 0, None, None, &own_op);
+        // The receipt order, exactly as `account_entries_for_sync` emits it.
+        let mut ordered = vec![
+            (0u64, genesis_hash, genesis_bytes),
+            (0, b0_hash, b0_bytes),
+            (0, c0_hash, c0_bytes),
+            (1, add_b_hash, add_b_bytes),
+            (2, add_c_hash, add_c_bytes),
+            (3, add_joiner_hash, add_joiner_bytes),
+        ];
+        ordered.sort_by_key(|(seq, hash, _)| (*seq, *hash));
+        InterleavedBootstrap {
+            account,
+            genesis_hash,
+            device_b,
+            b0_hash,
+            joiner,
+            add_joiner_hash,
+            account_entries: ordered.into_iter().map(|(_, _, bytes)| bytes).collect(),
+        }
+    }
+
+    fn park_fillers(conn: &Connection, account: AccountId, count: i64) {
+        park_fillers_for_device(conn, account, Dev::new(9).fp, 0, count);
+    }
+
+    fn park_fillers_for_device(
+        conn: &Connection,
+        account: AccountId,
+        fingerprint: DeviceFingerprint,
+        first_ordinal: i64,
+        count: i64,
+    ) {
+        for ordinal in 0..count {
+            let ordinal = first_ordinal + ordinal;
+            let hash = cbor::sha256(&ordinal.to_be_bytes());
+            conn.execute(
+                "INSERT INTO account_pre_verify(
+                     signed_hash, entry_hash, claimed_account_id, claimed_fingerprint, raw_bytes,
+                     received_at_ms)
+                 VALUES (?1, ?2, ?3, ?4, X'00', ?5)",
+                params![
+                    hash.as_slice(),
+                    hash.as_slice(),
+                    account.to_bytes().as_slice(),
+                    fingerprint.to_bytes().as_slice(),
+                    NOW,
+                ],
+            )
+            .unwrap();
+        }
+    }
+
+    #[test]
+    fn raw_order_bootstrap_ingestion_parks_promoted_device_entries_simultaneously() {
+        // Witness for the failure the causal ingest order fixes: with one free pre-verify slot,
+        // the receipt's raw order evicts on the second promoted-device entry.
+        let fixture = interleaved_promoted_device_bootstrap();
+        let joiner_db = db();
+        park_fillers(&joiner_db, fixture.account, PRE_VERIFY_PER_ACCOUNT_MAX as i64 - 1);
+        let tx = Transaction::new_unchecked(&joiner_db, TransactionBehavior::Immediate).unwrap();
+        let mut evicted = false;
+        for bytes in &fixture.account_entries {
+            if matches!(
+                account_ingest_in_tx(&tx, bytes, NOW + 1).unwrap(),
+                IngestOutcome::PreVerifyWithEviction { .. }
+            ) {
+                evicted = true;
+                break;
+            }
+        }
+        tx.rollback().unwrap();
+        assert!(evicted, "raw order needs two simultaneous pre-verify slots for this bootstrap");
+    }
+
+    #[test]
+    fn a_bootstrap_interleaving_promoted_device_entries_adopts_in_causal_order() {
+        use super::super::bootstrap::{EnrollmentBootstrap, adopt_enrollment_bootstrap};
+
+        let fixture = interleaved_promoted_device_bootstrap();
+        let joiner_db = db();
+        park_fillers(&joiner_db, fixture.account, PRE_VERIFY_PER_ACCOUNT_MAX as i64 - 1);
+        adopt_enrollment_bootstrap(&joiner_db, EnrollmentBootstrap {
+            account_entries: &fixture.account_entries,
+            account_id: fixture.account,
+            genesis_hash: fixture.genesis_hash,
+            device_fingerprint: fixture.joiner.fp,
+            device_add_hash: fixture.add_joiner_hash,
+            now_ms: NOW + 1,
+        })
+        .expect("causal-order ingestion adopts without simultaneous parking");
+        assert_eq!(
+            super::super::bootstrap::read_local_account(&joiner_db).unwrap(),
+            Some(fixture.account),
+        );
+        let effective: bool = joiner_db
+            .query_row(
+                "SELECT EXISTS(
+                     SELECT 1 FROM account_roster_history
+                      WHERE account_id = ?1 AND roster_ref = ?2 AND closed_at IS NULL
+                 )",
+                params![fixture.account.to_bytes().as_slice(), fixture.add_joiner_hash.as_slice()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(effective, "the acknowledged DeviceAdd is roster-effective after adoption");
+    }
+
+    #[test]
+    fn enrollment_bootstrap_staging_defers_projection_until_finish() {
+        let fixture = interleaved_promoted_device_bootstrap();
+        let joiner_db = db();
+        let tx = Transaction::new_unchecked(&joiner_db, TransactionBehavior::Immediate).unwrap();
+
+        let mut pending: Vec<&Vec<u8>> = fixture.account_entries.iter().collect();
+        let mut resolved = HashMap::new();
+        while !pending.is_empty() {
+            let index = pending
+                .iter()
+                .position(|bytes| {
+                    let signed = envelope::decode_account_signed(bytes).unwrap();
+                    resolved.contains_key(&signed.header.device_fingerprint)
+                        || self_certifies_signer(&signed.header, &signed.payload)
+                })
+                .expect("candidate snapshot has a causal authentication root");
+            let bytes = pending.remove(index);
+            let signed = envelope::decode_account_signed(bytes).unwrap();
+            let signer = resolved.get(&signed.header.device_fingerprint).copied();
+            stage_enrollment_bootstrap_entry_in_tx(&tx, bytes, signer, NOW + 1).unwrap();
+            add_self_pubkey(&mut resolved, &signed.header, &signed.payload);
+        }
+        let projected_before_finish: i64 = tx
+            .query_row(
+                "SELECT COUNT(*)
+                   FROM account_entry_status s
+                   JOIN account_entries e ON e.entry_hash = s.entry_hash
+                  WHERE e.account_id = ?1",
+                [fixture.account.to_bytes().as_slice()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(projected_before_finish, 0, "staging must not refold partial receipts");
+
+        finish_enrollment_bootstrap_in_tx(&tx, fixture.account, NOW + 1).unwrap();
+        let projected_after_finish: i64 = tx
+            .query_row(
+                "SELECT COUNT(*)
+                   FROM account_entry_status s
+                   JOIN account_entries e ON e.entry_hash = s.entry_hash
+                  WHERE e.account_id = ?1",
+                [fixture.account.to_bytes().as_slice()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            projected_after_finish as usize,
+            fixture.account_entries.len(),
+            "one final reconciliation projects the complete receipt"
+        );
+        tx.rollback().unwrap();
+    }
+
+    #[test]
+    fn enrollment_receipt_wins_capacity_over_rows_unlocked_by_the_receipt() {
+        use super::super::bootstrap::{EnrollmentBootstrap, adopt_enrollment_bootstrap};
+
+        let fixture = interleaved_promoted_device_bootstrap();
+        let joiner_db = db();
+        let (_, own_op) = stream_own(fixture.account);
+        let (latent_bytes, latent_hash) =
+            op(fixture.account, &fixture.device_b, 1, Some(fixture.b0_hash), None, &own_op);
+        let latent_signed_hash = cbor::sha256(&latent_bytes);
+        joiner_db
+            .execute(
+                "INSERT INTO account_pre_verify(
+                     signed_hash, entry_hash, claimed_account_id, claimed_fingerprint, raw_bytes,
+                     received_at_ms)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                params![
+                    latent_signed_hash.as_slice(),
+                    latent_hash.as_slice(),
+                    fixture.account.to_bytes().as_slice(),
+                    fixture.device_b.fp.to_bytes().as_slice(),
+                    latent_bytes,
+                    NOW,
+                ],
+            )
+            .unwrap();
+        seed_global_candidate_rows(
+            &joiner_db,
+            CANDIDATES_GLOBAL_MAX - fixture.account_entries.len(),
+            10_000,
+        );
+
+        adopt_enrollment_bootstrap(&joiner_db, EnrollmentBootstrap {
+            account_entries: &fixture.account_entries,
+            account_id: fixture.account,
+            genesis_hash: fixture.genesis_hash,
+            device_fingerprint: fixture.joiner.fp,
+            device_add_hash: fixture.add_joiner_hash,
+            now_ms: NOW + 1,
+        })
+        .expect("pre-existing parked work must not displace the one-time receipt");
+        // The production caller runs this best-effort maintenance after adoption; here it is the
+        // behavior under test.
+        super::super::authoring::retry_enrollment_pre_verify(&joiner_db, fixture.account, NOW + 1)
+            .unwrap();
+
+        for bytes in &fixture.account_entries {
+            let (_, entry_hash) = account_entry_ref(bytes).unwrap();
+            let held: bool = joiner_db
+                .query_row(
+                    "SELECT EXISTS(SELECT 1 FROM account_entries WHERE entry_hash = ?1)",
+                    [entry_hash.as_slice()],
+                    |row| row.get(0),
+                )
+                .unwrap();
+            assert!(held, "every receipt entry wins admission");
+        }
+        let latent_held: bool = joiner_db
+            .query_row(
+                "SELECT EXISTS(SELECT 1 FROM account_entries WHERE entry_hash = ?1)",
+                [latent_hash.as_slice()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(!latent_held, "the later latent promotion cannot exceed the terminal cap");
+        let latent_parked: bool = joiner_db
+            .query_row(
+                "SELECT EXISTS(SELECT 1 FROM account_pre_verify WHERE signed_hash = ?1)",
+                [latent_signed_hash.as_slice()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(!latent_parked, "terminally capacity-blocked queue work is removed");
+    }
+
+    #[test]
+    fn enrollment_budget_reports_raw_headroom_and_clamps_at_zero() {
+        let conn = db();
+        let account = AccountId::from_bytes([7; 32]);
+        let local_fp = crate::local_device(&conn, NOW).unwrap().fingerprint();
+        let budget = super::super::bootstrap::enrollment_budget(&conn, account, NOW).unwrap();
+        assert_eq!(budget.account_entries_remaining as usize, CANDIDATES_PER_ACCOUNT_MAX);
+        assert_eq!(budget.global_entries_remaining as usize, CANDIDATES_GLOBAL_MAX);
+
+        // 100 one-byte held candidates plus parked rows that are malformed or claim an unrelated
+        // signer. None can promote after the local DeviceAdd, so they consume no candidate
+        // headroom. Held candidates are not credited; the request proves their hashes separately.
+        seed_candidate_rows(&conn, account, Dev::new(9).fp, 42, 100);
+        park_fillers_for_device(&conn, account, local_fp, 0, 5);
+        park_fillers_for_device(&conn, account, Dev::new(9).fp, 100, 5);
+        for (ordinal, fingerprint) in [(0u8, local_fp), (1, Dev::new(9).fp)] {
+            conn.execute(
+                "INSERT INTO content_pre_verify(
+                     signed_hash, entry_hash, claimed_stream_id, claimed_author_account_id,
+                     claimed_fingerprint, roster_ref, raw_bytes, received_at_ms)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, X'00', ?7)",
+                params![
+                    [0xa0 + ordinal; 32].as_slice(),
+                    [0xb0 + ordinal; 32].as_slice(),
+                    [0xc0 + ordinal; 32].as_slice(),
+                    account.to_bytes().as_slice(),
+                    fingerprint.to_bytes().as_slice(),
+                    [0xd0 + ordinal; 32].as_slice(),
+                    NOW,
+                ],
+            )
+            .unwrap();
+        }
+        let budget = super::super::bootstrap::enrollment_budget(&conn, account, NOW).unwrap();
+        assert_eq!(budget.account_entries_remaining as usize, CANDIDATES_PER_ACCOUNT_MAX - 100);
+        assert_eq!(budget.global_entries_remaining as usize, CANDIDATES_GLOBAL_MAX - 100);
+        assert_eq!(budget.account_bytes_remaining as usize, CANDIDATE_BYTES_PER_ACCOUNT_MAX - 100);
+        assert_eq!(budget.global_bytes_remaining as usize, CANDIDATE_BYTES_GLOBAL_MAX - 100);
+
+        // Past the grow-only caps the budget clamps at zero rather than wrapping.
+        let clamped = db();
+        seed_global_candidate_rows(&clamped, CANDIDATES_GLOBAL_MAX + 10, 1_000);
+        let budget = super::super::bootstrap::enrollment_budget(&clamped, account, NOW).unwrap();
+        assert_eq!(budget.global_entries_remaining, 0, "past-cap headroom clamps to zero");
+    }
+
+    #[test]
+    fn enrollment_budget_does_not_reserve_non_fatal_pre_verify_promotions() {
+        let conn = db();
+        let local = Dev::new(0x31);
+        let child = Dev::new(0x32);
+        conn.execute(
+            "INSERT INTO oplog_device_identity(id, seed, public_key, fingerprint, created_at_ms)
+             VALUES (0, ?1, ?2, ?3, ?4)",
+            params![
+                [0x31u8; 32].as_slice(),
+                local.ed.as_slice(),
+                local.fp.to_bytes().as_slice(),
+                NOW,
+            ],
+        )
+        .unwrap();
+        let (account, _, genesis_hash) = genesis(&local);
+        let (add_child_bytes, add_child_hash) = op(
+            account,
+            &local,
+            1,
+            Some(genesis_hash),
+            Some(genesis_hash),
+            &device_add(&child, DeviceRole::Member),
+        );
+        let (_, own_op) = stream_own(account);
+        let (child_bytes, child_hash) = op(account, &child, 0, None, None, &own_op);
+        for (raw, entry_hash, fingerprint) in
+            [(add_child_bytes, add_child_hash, local.fp), (child_bytes, child_hash, child.fp)]
+        {
+            let signed_hash = cbor::sha256(&raw);
+            conn.execute(
+                "INSERT INTO account_pre_verify(
+                     signed_hash, entry_hash, claimed_account_id, claimed_fingerprint, raw_bytes,
+                     received_at_ms)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                params![
+                    signed_hash.as_slice(),
+                    entry_hash.as_slice(),
+                    account.to_bytes().as_slice(),
+                    fingerprint.to_bytes().as_slice(),
+                    raw,
+                    NOW,
+                ],
+            )
+            .unwrap();
+        }
+        conn.execute(
+            "INSERT INTO content_pre_verify(
+                 signed_hash, entry_hash, claimed_stream_id, claimed_author_account_id,
+                 claimed_fingerprint, roster_ref, raw_bytes, received_at_ms)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, X'00', ?7)",
+            params![
+                [0xe1u8; 32].as_slice(),
+                [0xe2u8; 32].as_slice(),
+                [0xe3u8; 32].as_slice(),
+                account.to_bytes().as_slice(),
+                child.fp.to_bytes().as_slice(),
+                add_child_hash.as_slice(),
+                NOW,
+            ],
+        )
+        .unwrap();
+
+        let budget = super::super::bootstrap::enrollment_budget(&conn, account, NOW).unwrap();
+        // Account and content retries happen only after every receipt entry wins admission, so
+        // they cannot roll one-time adoption back even when they form a valid transitive closure.
+        assert_eq!(budget.account_entries_remaining as usize, CANDIDATES_PER_ACCOUNT_MAX);
+        assert_eq!(budget.global_entries_remaining as usize, CANDIDATES_GLOBAL_MAX);
+    }
+
+    #[test]
+    fn a_real_wrap_entry_fits_the_enrollment_preflight_bound() {
+        let conn = db();
+        let _account = super::super::bootstrap::local_account(&conn, NOW).unwrap();
+        let tx = Transaction::new_unchecked(&conn, TransactionBehavior::Immediate).unwrap();
+        let stream =
+            super::super::authoring::ensure_owned_stream_v2_in_tx(&tx, "repo-a", NOW).unwrap();
+        super::super::secrets::mint_and_author_stream_key_wrap_in_tx(&tx, stream, NOW).unwrap();
+        tx.commit().unwrap();
+        let wrap_len: i64 = conn
+            .query_row(
+                "SELECT length(signed_bytes) FROM account_entries WHERE log_id = 1",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let bound = super::super::secrets::single_recipient_wrap_envelope_bytes();
+        assert!(
+            wrap_len as usize <= bound,
+            "a real wrap entry ({wrap_len} bytes) exceeds the charged bound ({bound})"
+        );
+        // The bound is TIGHT: an account with 256 live key targets must fit the per-account
+        // byte budget — the old per-entry §18a-maximum charge refused this outright.
+        let device_add =
+            super::super::authoring::device_add_envelope_bytes(DeviceRole::Member, None).unwrap();
+        assert!(
+            256 * bound + device_add <= CANDIDATE_BYTES_PER_ACCOUNT_MAX,
+            "256 live targets fit the per-account byte budget"
+        );
+    }
+
+    #[test]
+    fn enrollment_authoring_fits_gates_the_invite_boundary_on_candidate_headroom() {
+        // A fresh store with no owned streams fits the lone DeviceAdd redemption authors.
+        let conn = db();
+        let account = super::super::bootstrap::local_account(&conn, NOW).unwrap();
+        super::super::authoring::enrollment_authoring_fits(
+            &conn,
+            account,
+            &[],
+            DeviceRole::Member,
+            Some("laptop"),
+            NOW,
+        )
+        .unwrap();
+
+        // Saturate the account's grow-only candidate budget so not even the DeviceAdd fits:
+        // minting here would distribute a permanently unredeemable ticket.
+        seed_candidate_rows(&conn, account, Dev::new(9).fp, 42, CANDIDATES_PER_ACCOUNT_MAX - 1);
+        let error = super::super::authoring::enrollment_authoring_fits(
+            &conn,
+            account,
+            &[],
+            DeviceRole::Member,
+            Some("laptop"),
+            NOW,
+        )
+        .expect_err("a store without headroom for the DeviceAdd itself must refuse");
+        assert!(error.to_string().contains("unredeemable"), "unexpected error: {error}");
+
+        // Leave exactly one slot for the mandatory DeviceAdd. Opaque parked work is retried only
+        // after enrollment commits and therefore cannot make this exact preflight refuse.
+        let conn = db();
+        let account = super::super::bootstrap::local_account(&conn, NOW).unwrap();
+        seed_candidate_rows(&conn, account, Dev::new(8).fp, 43, CANDIDATES_PER_ACCOUNT_MAX - 2);
+        conn.execute(
+            "INSERT INTO account_pre_verify(
+                 signed_hash, entry_hash, claimed_account_id, claimed_fingerprint, raw_bytes,
+                 received_at_ms)
+             VALUES (?1, ?2, ?3, ?4, X'00', ?5)",
+            params![
+                [0xe1u8; 32].as_slice(),
+                [0xe2u8; 32].as_slice(),
+                account.to_bytes().as_slice(),
+                [0xe3u8; 32].as_slice(),
+                NOW,
+            ],
+        )
+        .unwrap();
+        super::super::authoring::enrollment_authoring_fits(
+            &conn,
+            account,
+            &[],
+            DeviceRole::Member,
+            None,
+            NOW,
+        )
+        .expect("latent pre-verify work is not part of mandatory enrollment capacity");
+    }
+
+    #[test]
+    fn enrollment_bootstrap_finish_leaves_parked_rows_for_post_commit_retry() {
+        let fixture = interleaved_promoted_device_bootstrap();
+        let joiner_db = db();
+        let tx = Transaction::new_unchecked(&joiner_db, TransactionBehavior::Immediate).unwrap();
+        let mut pending: Vec<&Vec<u8>> = fixture.account_entries.iter().collect();
+        let mut resolved = HashMap::new();
+        while !pending.is_empty() {
+            let index = pending
+                .iter()
+                .position(|bytes| {
+                    let signed = envelope::decode_account_signed(bytes).unwrap();
+                    resolved.contains_key(&signed.header.device_fingerprint)
+                        || self_certifies_signer(&signed.header, &signed.payload)
+                })
+                .expect("candidate snapshot has a causal authentication root");
+            let bytes = pending.remove(index);
+            let signed = envelope::decode_account_signed(bytes).unwrap();
+            let signer = resolved.get(&signed.header.device_fingerprint).copied();
+            stage_enrollment_bootstrap_entry_in_tx(&tx, bytes, signer, NOW + 1).unwrap();
+            add_self_pubkey(&mut resolved, &signed.header, &signed.payload);
+        }
+
+        // A valid parked row whose signer the receipt certifies (the founder) must NOT enter the
+        // one-time adoption fold: a parked sibling DeviceAdd for the joining fingerprint could
+        // otherwise win branch selection and roll the acknowledged enrollment back after the
+        // owner already consumed the nonce.
+        let founder = Dev::new(0x61);
+        let (sibling_bytes, sibling_hash) = op(
+            fixture.account,
+            &founder,
+            1,
+            Some(fixture.genesis_hash),
+            Some(fixture.genesis_hash),
+            &device_add(&fixture.joiner, DeviceRole::Owner),
+        );
+        let sibling_signed_hash = cbor::sha256(&sibling_bytes);
+        tx.execute(
+            "INSERT INTO account_pre_verify(
+                 signed_hash, entry_hash, claimed_account_id, claimed_fingerprint, raw_bytes,
+                 received_at_ms)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            params![
+                sibling_signed_hash.as_slice(),
+                sibling_hash.as_slice(),
+                fixture.account.to_bytes().as_slice(),
+                founder.fp.to_bytes().as_slice(),
+                sibling_bytes,
+                NOW,
+            ],
+        )
+        .unwrap();
+
+        finish_enrollment_bootstrap_in_tx(&tx, fixture.account, NOW + 1).unwrap();
+        let still_parked: bool = tx
+            .query_row(
+                "SELECT EXISTS(SELECT 1 FROM account_pre_verify WHERE signed_hash = ?1)",
+                [sibling_signed_hash.as_slice()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(still_parked, "the one-time adoption fold must not promote parked rows");
+        let promoted: bool = tx
+            .query_row(
+                "SELECT EXISTS(SELECT 1 FROM account_entries WHERE entry_hash = ?1)",
+                [sibling_hash.as_slice()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(!promoted, "parked siblings enter the fold only after adoption commits");
+    }
+
+    #[test]
+    fn adopt_local_account_adopts_an_accepted_genesis_and_refuses_conflicts() {
+        let fixture = interleaved_promoted_device_bootstrap();
+        let conn = db();
+        // Ingest the genesis as an ordinary accepted candidate, then adopt it directly.
+        account_ingest(&conn, &fixture.account_entries[0], NOW).unwrap();
+        super::super::bootstrap::adopt_local_account(
+            &conn,
+            fixture.account,
+            fixture.genesis_hash,
+            NOW + 1,
+        )
+        .unwrap();
+        assert_eq!(
+            super::super::bootstrap::read_local_account(&conn).unwrap(),
+            Some(fixture.account)
+        );
+        // Idempotent for the same account…
+        super::super::bootstrap::adopt_local_account(
+            &conn,
+            fixture.account,
+            fixture.genesis_hash,
+            NOW + 2,
+        )
+        .unwrap();
+        // …but a store can never change identity.
+        let (other_account, _, other_genesis_hash) = genesis(&Dev::new(0x77));
+        let error = super::super::bootstrap::adopt_local_account(
+            &conn,
+            other_account,
+            other_genesis_hash,
+            NOW + 3,
+        )
+        .expect_err("a second account identity must be refused");
+        assert!(error.to_string().contains("another local account"), "unexpected error: {error}");
+        // An unaccepted genesis hash cannot be adopted either.
+        let stranger = db();
+        let error = super::super::bootstrap::adopt_local_account(
+            &stranger,
+            fixture.account,
+            [0xfe; 32],
+            NOW,
+        )
+        .expect_err("adopting an unknown genesis must fail");
+        assert!(error.to_string().contains("not accepted"), "unexpected error: {error}");
+    }
+
+    #[test]
+    fn enrollment_bootstrap_rejects_an_entry_whose_signer_the_snapshot_never_certifies() {
+        let fixture = interleaved_promoted_device_bootstrap();
+        let stranger = Dev::new(0x7f);
+        let (_stream, own_op) = stream_own(fixture.account);
+        let (stranger_bytes, _) = op(fixture.account, &stranger, 0, None, None, &own_op);
+        let mut entries: Vec<Vec<u8>> = fixture.account_entries.iter().take(2).cloned().collect();
+        entries.push(stranger_bytes);
+
+        let joiner_db = db();
+        let error = super::super::bootstrap::adopt_enrollment_bootstrap(
+            &joiner_db,
+            super::super::bootstrap::EnrollmentBootstrap {
+                account_entries: &entries,
+                account_id: fixture.account,
+                genesis_hash: fixture.genesis_hash,
+                device_fingerprint: fixture.joiner.fp,
+                device_add_hash: fixture.add_joiner_hash,
+                now_ms: NOW + 1,
+            },
+        )
+        .expect_err("an entry no snapshot key certifies must refuse the bootstrap");
+        assert!(error.to_string().contains("not certified"), "unexpected error: {error}");
+        let stored: i64 = joiner_db
+            .query_row("SELECT COUNT(*) FROM account_entries", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(stored, 0, "the failed adoption rolls every staged entry back");
+    }
+
+    #[test]
+    fn enrollment_bootstrap_refuses_to_replace_a_conflicting_local_account() {
+        let fixture = interleaved_promoted_device_bootstrap();
+        let joiner_db = db();
+        let _other_account = super::super::bootstrap::local_account(&joiner_db, NOW).unwrap();
+        let error = super::super::bootstrap::adopt_enrollment_bootstrap(
+            &joiner_db,
+            super::super::bootstrap::EnrollmentBootstrap {
+                account_entries: &fixture.account_entries,
+                account_id: fixture.account,
+                genesis_hash: fixture.genesis_hash,
+                device_fingerprint: fixture.joiner.fp,
+                device_add_hash: fixture.add_joiner_hash,
+                now_ms: NOW + 1,
+            },
+        )
+        .expect_err("adopting a second account identity must refuse");
+        assert!(error.to_string().contains("another local account"), "unexpected error: {error}");
+    }
+
+    #[test]
+    fn reservation_upsert_updates_and_release_is_idempotent() {
+        let conn = db();
+        let account = super::super::bootstrap::local_account(&conn, NOW).unwrap();
+        let tx = Transaction::new_unchecked(&conn, TransactionBehavior::Immediate).unwrap();
+        super::super::bootstrap::upsert_account_candidate_reservation_in_tx(
+            &tx,
+            account,
+            [0x53; 32],
+            1,
+            100,
+            0,
+            NOW + 100,
+        )
+        .unwrap();
+        super::super::bootstrap::upsert_account_candidate_reservation_in_tx(
+            &tx,
+            account,
+            [0x53; 32],
+            5,
+            500,
+            4,
+            NOW + 200,
+        )
+        .unwrap();
+        let (entries, bytes, targets, expiry): (i64, i64, i64, i64) = tx
+            .query_row(
+                "SELECT reserved_entries, reserved_bytes, reserved_targets, expires_at_ms
+                   FROM account_candidate_reservations WHERE reservation_id = ?1",
+                [[0x53; 32].as_slice()],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .unwrap();
+        assert_eq!((entries, bytes, targets, expiry), (5, 500, 4, NOW + 200));
+        super::super::bootstrap::release_account_candidate_reservation_in_tx(&tx, [0x53; 32])
+            .unwrap();
+        super::super::bootstrap::release_account_candidate_reservation_in_tx(&tx, [0x53; 32])
+            .unwrap();
+        tx.commit().unwrap();
+        let rows: i64 = conn
+            .query_row("SELECT COUNT(*) FROM account_candidate_reservations", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(rows, 0, "releasing twice is a no-op, not an error");
+    }
+
+    #[test]
+    fn invite_reservations_shrink_when_the_live_target_set_shrinks() {
+        let conn = db();
+        let account = super::super::bootstrap::local_account(&conn, NOW).unwrap();
+        // A reservation recorded when two key targets were live must not keep their capacity
+        // after a fold reduces the live set: the top-up is bidirectional.
+        let tx = Transaction::new_unchecked(&conn, TransactionBehavior::Immediate).unwrap();
+        super::super::bootstrap::upsert_account_candidate_reservation_in_tx(
+            &tx,
+            account,
+            [0x52; 32],
+            3,
+            100_000,
+            2,
+            NOW + 1_000,
+        )
+        .unwrap();
+        tx.commit().unwrap();
+
+        refold_account(&conn, account).unwrap();
+        let (entries, bytes, targets): (i64, i64, i64) = conn
+            .query_row(
+                "SELECT reserved_entries, reserved_bytes, reserved_targets
+                   FROM account_candidate_reservations WHERE reservation_id = ?1",
+                [[0x52; 32].as_slice()],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(targets, 0, "no live key targets remain");
+        assert_eq!(entries, 1, "only the mandatory DeviceAdd stays reserved");
+        assert!(bytes < 100_000, "the reclaimed wrap bytes return to the shared headroom");
+    }
+
+    #[test]
+    fn enrollment_reservations_reserve_candidate_capacity_until_consumed_or_expired() {
+        let conn = db();
+        let account = super::super::bootstrap::local_account(&conn, NOW).unwrap();
+        let fits = |now_ms| {
+            super::super::authoring::enrollment_authoring_fits(
+                &conn,
+                account,
+                &[],
+                DeviceRole::Member,
+                Some("laptop"),
+                now_ms,
+            )
+        };
+        fits(NOW).unwrap();
+
+        // An outstanding invite's reservation consumes the same grow-only counters ordinary
+        // ingest enforces, so the remaining headroom no longer fits another redemption.
+        let tx = Transaction::new_unchecked(&conn, TransactionBehavior::Immediate).unwrap();
+        super::super::bootstrap::upsert_account_candidate_reservation_in_tx(
+            &tx,
+            account,
+            [0x51; 32],
+            (CANDIDATES_PER_ACCOUNT_MAX - 1) as u64,
+            0,
+            0,
+            NOW + 100,
+        )
+        .unwrap();
+        tx.commit().unwrap();
+        let error = fits(NOW + 1).expect_err("reserved headroom is not available to a new mint");
+        assert!(error.to_string().contains("unredeemable"), "unexpected error: {error}");
+
+        // Expiry frees the reservation (the counters filter on `expires_at_ms > now`; pruning only
+        // keeps the table bounded), and redemption's release removes the row outright.
+        fits(NOW + 99).expect_err("the reservation is still active before its expiry instant");
+        fits(NOW + 100).expect("an expired reservation frees its capacity");
+        let tx = Transaction::new_unchecked(&conn, TransactionBehavior::Immediate).unwrap();
+        super::super::bootstrap::prune_account_candidate_reservations_in_tx(&tx, NOW + 101)
+            .unwrap();
+        tx.commit().unwrap();
+        let rows: i64 = conn
+            .query_row("SELECT COUNT(*) FROM account_candidate_reservations", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(rows, 0, "pruning removes expired reservation rows");
     }
 
     fn stream_own(account_id: AccountId) -> (crate::stream::StreamId, AccountOp) {
@@ -3060,7 +4442,7 @@ mod tests {
         let content = signed_member_content(&member, account_id, stream_id, add_hash, 3);
         content_ingest(&conn, &content.signed_bytes, NOW + 3).unwrap();
         assert_eq!(
-            settle_pending_content_refolds(&conn, &ContentRefoldBudget::unbounded())
+            settle_pending_content_refolds(&conn, &ContentRefoldBudget::unbounded(), NOW)
                 .unwrap()
                 .settled_streams,
             1
@@ -3093,7 +4475,7 @@ mod tests {
         assert_eq!(reason, 2, "the revoke queues ACCOUNT_CHANGE");
 
         assert_eq!(
-            settle_pending_content_refolds(&conn, &ContentRefoldBudget::unbounded())
+            settle_pending_content_refolds(&conn, &ContentRefoldBudget::unbounded(), NOW)
                 .unwrap()
                 .settled_streams,
             1
@@ -3126,7 +4508,7 @@ mod tests {
         account_ingest(&conn, &add_bytes, NOW + 2).unwrap();
         let content = signed_member_content(&member, account_id, stream_id, add_hash, 3);
         content_ingest(&conn, &content.signed_bytes, NOW + 3).unwrap();
-        settle_pending_content_refolds(&conn, &ContentRefoldBudget::unbounded()).unwrap();
+        settle_pending_content_refolds(&conn, &ContentRefoldBudget::unbounded(), NOW).unwrap();
 
         conn.execute_batch(
             "CREATE TRIGGER fail_content_reproject

--- a/crates/rag-rat-oplog/src/identity.rs
+++ b/crates/rag-rat-oplog/src/identity.rs
@@ -38,6 +38,19 @@ pub struct LocalDevice {
 }
 
 impl LocalDevice {
+    /// The persisted ed25519 public key used to identify this store during device enrollment.
+    /// Exposes only public material; the signing secret remains oplog-internal.
+    pub fn ed25519_public_key(&self) -> [u8; 32] {
+        self.public.to_bytes()
+    }
+
+    /// The persisted X25519 public key to which this store's content-key wraps are sealed during
+    /// device enrollment. Exposes only public material; the decryption secret remains
+    /// oplog-internal.
+    pub fn x25519_public_key(&self) -> [u8; 32] {
+        self.x25519_public.to_bytes()
+    }
+
     /// The signing capability — the authoring seam signs entry bodies with this. `pub(super)`: the
     /// secret (and `DeviceSecret` itself) stay oplog-internal; the store's authoring path is the
     /// only caller. Cross-module callers author under a whole `&LocalDevice`, never the raw secret.

--- a/crates/rag-rat-oplog/src/lib.rs
+++ b/crates/rag-rat-oplog/src/lib.rs
@@ -86,34 +86,42 @@ mod table_sync;
 // `prepare_content_authoring` / `author_prepared_content_batch_in_tx` / `SealPolicy` (C5, #608):
 // policy-aware `/3` authoring prepared before, then executed inside, a caller-owned transaction;
 // `author_content_batch` is the self-transacting convenience composition. The
-// envelope-layer seal
-// primitives (`sign_sealed_content_entry` / `seal_and_sign_content_entry`) take a `&DeviceSecret`,
-// so — like `sign_content_entry` — they stay account-crate-internal (never re-exported at the crate
-// root, or they would leak the `pub(crate)` `DeviceSecret` past its visibility).
+// envelope-layer seal primitives (`sign_sealed_content_entry` / `seal_and_sign_content_entry`)
+// take a `&DeviceSecret`, so — like `sign_content_entry` — they stay account-crate-internal. Keep
+// this crate-root API explicit: adding an account implementation seam must not silently make it a
+// public semver commitment.
 pub use account::{
-    AccountId, AuthorityBoundary, AuthorityFreshness, AuthorityInvalidReason, AuthorityQuery,
-    CapacityScope, CatchUpReport, ContentIngestOutcome, ContentKey, ContentKeyring,
-    ContentRefoldBudget, ContentSettleReport, DeviceCut, DeviceRole, EnrollingDevice,
-    GrantAuthority, GrantDeviceAuthority, GrantDeviceBoundary, GrantRole, IngestOutcome, KeyId,
-    LiveKeyEpoch, LiveKeyTargets, NodeAuthError, OwnerAuthority, OwnerChainAuthority,
-    PreparedContentAuthoring, RosterContentAuthority, RotationOutcome, SealPolicy,
-    SealingKeyOutcome, SelectedWrap, SnapshotAuthorOutcome, SyncAccountEntry, SyncContentEntry,
-    account_entries_for_sync, account_entry_ref, account_ingest, account_signed_entry_exists,
-    account_signed_hash, auth_len_freshness, author_content_batch, author_content_batch_in_tx,
-    author_device_add_in_tx, author_prepared_content_batch_in_tx, author_snapshot_in_tx,
-    backfill_authority_projection, catch_up_stream_keys_for_device_in_tx, content_entries_for_sync,
-    content_entry_ref, content_ingest, content_op_is_authorable, content_op_is_sealed_authorable,
+    AccountId, AuthoredDurability, AuthorityBoundary, AuthorityFreshness, AuthorityInvalidReason,
+    AuthorityQuery, CapacityScope, CatchUpReport, ContentCapacityScope, ContentEntryHeader,
+    ContentIngestOutcome, ContentKey, ContentKeyring, ContentRefoldBudget, ContentSettleReport,
+    ContentStreamSettleFailure, DeviceCut, DeviceRole, ENROLLMENT_HELD_ENTRY_HASHES_MAX,
+    EnrollingDevice, EnrollmentBootstrap, EnrollmentBudget, GrantAuthority, GrantDeviceAuthority,
+    GrantDeviceBoundary, GrantRole, IngestOutcome, KeyId, LiveKeyEpoch, LiveKeyTargets,
+    NodeAuthError, OwnerAuthority, OwnerChainAuthority, PreparedContentAuthoring,
+    RosterContentAuthority, RotationOutcome, SealPolicy, SealingKeyOutcome, SelectedWrap,
+    SignedContentEntry, SnapshotAuthorOutcome, SyncAccountEntry, SyncContentEntry,
+    VerifiedContentEntry, account_entries_for_enrollment, account_entries_for_sync,
+    account_entry_ref, account_ingest, account_signed_entry_exists, account_signed_hash,
+    adopt_enrollment_bootstrap, adopt_local_account, auth_len_freshness, author_content_batch,
+    author_content_batch_in_tx, author_device_add_in_tx, author_enrollment_device_add_in_tx,
+    author_prepared_content_batch_in_tx, author_snapshot_in_tx, backfill_authority_projection,
+    catch_up_stream_keys_for_device_in_tx, content_entries_for_sync, content_entry_ref,
+    content_ingest, content_op_is_authorable, content_op_is_sealed_authorable,
     content_signed_entry_exists, content_signed_hash, content_stream_has_pending_refold,
     content_stream_has_sealed_ratchet, content_stream_is_empty, current_sealing_key,
-    decode_content_signed, ensure_owned_stream_v2_in_tx, ensure_stream_key_current_in_tx,
-    established_owned_stream_v2, grant_effective_for_device, historical_content_keyring,
-    live_stream_key_targets_for_device, local_account, mint_and_author_stream_key_wrap_in_tx,
-    owned_stream_v2_id, owner_control_authority, owner_secrets_authority,
-    prepare_content_authoring, read_local_account, roster_content_authority,
-    rotate_stream_key_in_tx, select_current_sealing_wrap,
+    decode_content_signed, enroll_stream_keys_for_device_in_tx, enrollment_authoring_fits,
+    enrollment_authoring_requirements, enrollment_budget, ensure_owned_stream_v2_in_tx,
+    ensure_stream_key_current_in_tx, established_owned_stream_v2, grant_effective_for_device,
+    held_account_entry_hashes, historical_content_keyring, live_stream_key_targets_for_device,
+    local_account, mint_and_author_stream_key_wrap_in_tx, owned_stream_v2_id,
+    owned_streams_for_account, owner_control_authority, owner_control_authority_in_snapshot,
+    owner_secrets_authority, prepare_content_authoring, prune_account_candidate_reservations_in_tx,
+    read_local_account, release_account_candidate_reservation_in_tx, retry_enrollment_pre_verify,
+    roster_content_authority, rotate_stream_key_in_tx, select_current_sealing_wrap,
     settle_pending_content_refold_for_stream_in_tx, settle_pending_content_refolds,
     sign_local_node_binding, stream_key_rotation_needed, stream_owner_effective,
-    verify_node_binding,
+    upsert_account_candidate_reservation_in_tx, validate_device_add_label,
+    verify_enrollment_device_add, verify_node_binding,
 };
 // The `/3` content projection's store-global upgrade re-fold (#688): wired into the index
 // open/migrate seam by rag-rat-core, so a stale store is rebuilt (every stream, then the one

--- a/crates/rag-rat-sync/Cargo.toml
+++ b/crates/rag-rat-sync/Cargo.toml
@@ -16,7 +16,10 @@ minicbor.workspace = true
 tokio = { workspace = true, features = ["sync", "io-util", "time"] }
 iroh.workspace = true
 tracing.workspace = true
+getrandom.workspace = true
+sha2.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time", "sync"] }
 rag-rat-db.workspace = true
+tempfile.workspace = true

--- a/crates/rag-rat-sync/src/endpoint.rs
+++ b/crates/rag-rat-sync/src/endpoint.rs
@@ -16,20 +16,28 @@
 //! inventory is exchanged. Under [`AuthPolicy::Closed`] a peer is admitted only if it presents a
 //! signed binding proving its authenticated node id belongs to a roster device of the account;
 //! under [`AuthPolicy::Open`] any peer is admitted (for a future public read-only knowledge base).
-//! The ONBOARDING case — admitting a not-yet-roster device via a one-time invite token
-//! ([`AuthPolicy::InviteToken`]) — is not implemented in this slice and fails closed; it is the
-//! pairing flow (`sync init` / `sync pair` / `sync join`) that the CLI slice wires up.
+//! The ONBOARDING case uses the separate [`ENROLL_ALPN`] exchange: an owner atomically redeems a
+//! one-time invite into a roster `DeviceAdd` before normal sync authentication can admit the new
+//! device.
 
 use std::str::FromStr;
 
 use iroh::endpoint::presets;
 use iroh::{Endpoint, EndpointAddr, EndpointId, RelayMode, RelayUrl, SecretKey};
+use rag_rat_oplog::{self, AccountId, DeviceFingerprint};
+use rusqlite::Connection;
+use sha2::{Digest, Sha256};
 use tokio::time::timeout;
 
 use crate::auth::{
     AuthConfig, AuthPolicy, AuthRole, DEFAULT_PRE_AUTH_TIMEOUT, NodeAuth, run_auth_phase,
 };
+use crate::enrollment::{
+    ENROLL_ALPN, EnrollmentAcceptorOutcome, EnrollmentReceipt, EnrollmentRequest, InviteError,
+    RESPONSE_ACK, RESPONSE_ACK_TIMEOUT, run_enrollment_acceptor, run_enrollment_dialer,
+};
 use crate::session::{DEFAULT_IDLE_TIMEOUT, SessionError, SessionReport, SyncStore, run_session};
+use crate::store::OplogSyncStore;
 use crate::wire::{CONTENT_SYNC_ALPN, SYNC_ALPN};
 
 /// Endpoint construction or connection setup failed, before a session could run.
@@ -74,7 +82,7 @@ pub async fn build_endpoint(
     let relay_url =
         RelayUrl::from_str(relay_url.trim()).map_err(|e| EndpointError::RelayUrl(e.to_string()))?;
     Endpoint::builder(presets::Minimal)
-        .alpns(vec![SYNC_ALPN.to_vec(), CONTENT_SYNC_ALPN.to_vec()])
+        .alpns(vec![SYNC_ALPN.to_vec(), CONTENT_SYNC_ALPN.to_vec(), ENROLL_ALPN.to_vec()])
         .relay_mode(RelayMode::custom([relay_url]))
         .secret_key(SecretKey::from_bytes(&secret_key))
         .bind()
@@ -104,6 +112,161 @@ pub fn peer_addr(node_id: &str, relay_url: &str) -> Result<EndpointAddr, Endpoin
 /// [`connect_and_sync`] back.
 pub fn endpoint_addr(endpoint: &Endpoint) -> EndpointAddr {
     endpoint.addr()
+}
+
+/// Dial an owner over the dedicated enrollment ALPN, verify the founder-signed receipt, ingest its
+/// account bootstrap, and adopt that accepted genesis locally before returning. The next Closed
+/// account-log session can therefore mutually authorize without a fresh-device bootstrap deadlock.
+pub async fn connect_and_enroll(
+    endpoint: &Endpoint,
+    peer: impl Into<EndpointAddr>,
+    database: &Connection,
+    expected_account: AccountId,
+    request: &EnrollmentRequest,
+    now_ms: i64,
+) -> Result<EnrollmentReceipt, InviteError> {
+    // The budget and held-entry inventory are always recomputed from the local store — the
+    // acceptor measures its exact receipt against them before consuming the nonce — so the
+    // values the caller set are irrelevant.
+    //
+    // The declaration is a point-in-time read: a competing LOCAL write that shrinks capacity
+    // before adoption could still burn the nonce. Do NOT fix that by holding the database's
+    // writer reservation across the network exchange — a slow or malicious owner can stretch
+    // the transfer (per-chunk progress windows) and starve every local writer past its busy
+    // timeout. The caller MUST instead serialize capacity-consuming local writes across this
+    // call — the same per-database sync-session lock `sync serve` and device sync already
+    // respect — which the enrollment CLI flow holds for the whole enrollment.
+    let mut request = request.clone();
+    request.expected_account = expected_account;
+    // The QUIC connection authenticates as THIS endpoint's transport identity, so the request
+    // must name it — a caller-supplied value is either redundant or a guaranteed WrongNode.
+    request.transport_node_id = *endpoint.id().as_bytes();
+    request.budget = rag_rat_oplog::enrollment_budget(database, expected_account, now_ms)?;
+    request.held_entry_hashes =
+        rag_rat_oplog::held_account_entry_hashes(database, expected_account)?;
+    validate_enrollment_request_identity(database, expected_account, &request, now_ms)?;
+    let conn = timeout(DEFAULT_IDLE_TIMEOUT, endpoint.connect(peer, ENROLL_ALPN))
+        .await
+        .map_err(|_| InviteError::Storage(anyhow::anyhow!("enrollment dial timed out")))?
+        .map_err(|error| InviteError::Storage(error.into()))?;
+    let (mut send, mut recv) = timeout(DEFAULT_IDLE_TIMEOUT, conn.open_bi())
+        .await
+        .map_err(|_| InviteError::Storage(anyhow::anyhow!("opening enrollment stream timed out")))?
+        .map_err(|error| InviteError::Storage(error.into()))?;
+    let receipt = run_enrollment_dialer(&mut recv, &mut send, expected_account, &request).await?;
+    let genesis_hash = rag_rat_oplog::verify_enrollment_device_add(
+        &receipt.account_entries,
+        expected_account,
+        receipt.device_add_hash,
+        &receipt.device_add_signed,
+        request.ed25519_pubkey,
+        request.x25519_pubkey,
+    )
+    .map_err(|error| InviteError::Malformed(format!("invalid enrollment receipt: {error}")))?;
+    let fingerprint = DeviceFingerprint::from_bytes(Sha256::digest(request.ed25519_pubkey).into());
+    rag_rat_oplog::adopt_enrollment_bootstrap(database, rag_rat_oplog::EnrollmentBootstrap {
+        account_entries: &receipt.account_entries,
+        account_id: expected_account,
+        genesis_hash,
+        device_fingerprint: fingerprint,
+        device_add_hash: receipt.device_add_hash,
+        now_ms,
+    })?;
+    // Best-effort maintenance AFTER the durable adoption: retry parked rows the receipt's keys
+    // may now resolve. Kept out of the one-time adoption transaction so a newly resolvable
+    // parked sibling can never enter its fold, and a maintenance failure cannot invalidate the
+    // completed enrollment (normal sync retries the same queues later).
+    if let Err(error) =
+        rag_rat_oplog::retry_enrollment_pre_verify(database, expected_account, now_ms)
+    {
+        tracing::warn!(%error, "post-enrollment pre-verify retry failed");
+    }
+    conn.close(0u32.into(), b"done");
+    Ok(receipt)
+}
+
+/// Refuse a request assembled for a different store before making network contact: redemption is
+/// one-shot, and adopting a receipt whose device keys are not locally held would leave Closed sync
+/// unable to authenticate or decrypt the delivered stream-key wraps.
+fn validate_enrollment_request_identity(
+    database: &Connection,
+    expected_account: AccountId,
+    request: &EnrollmentRequest,
+    now_ms: i64,
+) -> Result<(), InviteError> {
+    if let Some(existing_account) = rag_rat_oplog::read_local_account(database)?
+        && existing_account != expected_account
+    {
+        return Err(InviteError::Malformed(
+            "enrollment account does not match the store's existing local account".into(),
+        ));
+    }
+    let local = rag_rat_oplog::local_device(database, now_ms)?;
+    if request.ed25519_pubkey != local.ed25519_public_key() {
+        return Err(InviteError::Malformed(
+            "enrollment request ed25519 key does not match the local device identity".into(),
+        ));
+    }
+    if request.x25519_pubkey != local.x25519_public_key() {
+        return Err(InviteError::Malformed(
+            "enrollment request X25519 key does not match the local device identity".into(),
+        ));
+    }
+    Ok(())
+}
+
+/// Close an enrollment connection after the exchange. The dialer acks the response the moment it
+/// is DECODED, so the ack byte is the delivery signal for both outcomes: once it lands, close
+/// immediately — an enrolled receipt needs no graceful-close wait, and a refused peer
+/// (unauthenticated; any random nonce reaches a refusal) is bounded by [`RESPONSE_ACK_TIMEOUT`]
+/// instead of holding the serial accept loop for [`GRACEFUL_CLOSE_TIMEOUT`]. An invite-holding
+/// peer that never acks still gets the graceful-close fallback so its streamed receipt lands.
+async fn close_enrollment_connection(
+    conn: iroh::endpoint::Connection,
+    recv: &mut iroh::endpoint::RecvStream,
+    enrolled: bool,
+) {
+    let mut ack = [0u8; 1];
+    let delivered =
+        matches!(timeout(RESPONSE_ACK_TIMEOUT, recv.read_exact(&mut ack)).await, Ok(Ok(_)))
+            && ack == [RESPONSE_ACK];
+    if enrolled && !delivered {
+        let _ = timeout(GRACEFUL_CLOSE_TIMEOUT, conn.closed()).await;
+    }
+    conn.close(0u32.into(), b"done");
+}
+
+/// Accept one owner-side enrollment connection and atomically redeem its invite.
+pub async fn accept_enrollment(
+    endpoint: &Endpoint,
+    database: &Connection,
+    now_ms: impl Fn() -> i64,
+) -> Result<EnrollmentReceipt, InviteError> {
+    let incoming = endpoint
+        .accept()
+        .await
+        .ok_or_else(|| InviteError::Storage(anyhow::anyhow!("endpoint closed")))?;
+    let conn = timeout(DEFAULT_IDLE_TIMEOUT, incoming)
+        .await
+        .map_err(|_| InviteError::Storage(anyhow::anyhow!("enrollment handshake timed out")))?
+        .map_err(|error| InviteError::Storage(error.into()))?;
+    if conn.alpn() != ENROLL_ALPN {
+        conn.close(0u32.into(), b"wrong-alpn");
+        return Err(InviteError::Malformed("connection did not negotiate enrollment ALPN".into()));
+    }
+    let remote_node = *conn.remote_id().as_bytes();
+    let (mut send, mut recv) = timeout(DEFAULT_IDLE_TIMEOUT, conn.accept_bi())
+        .await
+        .map_err(|_| InviteError::Storage(anyhow::anyhow!("peer opened no enrollment stream")))?
+        .map_err(|error| InviteError::Storage(error.into()))?;
+    let outcome =
+        run_enrollment_acceptor(&mut recv, &mut send, database, remote_node, now_ms).await?;
+    let enrolled = matches!(outcome, EnrollmentAcceptorOutcome::Enrolled(..));
+    close_enrollment_connection(conn, &mut recv, enrolled).await;
+    match outcome {
+        EnrollmentAcceptorOutcome::Enrolled(receipt, _) => Ok(receipt),
+        EnrollmentAcceptorOutcome::Refused(error) => Err(error),
+    }
 }
 
 /// Dial `peer`, authorize each other under `policy`, then run one sync session, returning what
@@ -226,21 +389,19 @@ pub async fn accept_and_sync<S: SyncStore + NodeAuth>(
 }
 
 /// Accept ONE inbound connection and run the session for the STREAM the peer negotiated: the
-/// account log ([`SYNC_ALPN`] → `account_store`) or `/3` content ([`CONTENT_SYNC_ALPN`] →
-/// `content_store`). The auth phase is account-level — `account_store` provides the account id and
-/// the node binding for both — so only the post-auth session store differs by ALPN. `sync serve`
-/// loops this; the returned ALPN lets the caller log which stream ran. Shares the accept + auth
-/// shape with [`accept_and_sync`], which stays as the single-stream (account-log) form for callers
-/// that never serve content.
-pub async fn accept_and_dispatch<A, C>(
+/// account log ([`SYNC_ALPN`] → `account_store`), `/3` content ([`CONTENT_SYNC_ALPN`] →
+/// `content_store`), or owner-side enrollment ([`ENROLL_ALPN`] → the account store's database).
+/// The auth phase is account-level for normal sync; enrollment instead authenticates the requested
+/// node by the QUIC transport identity and atomically adds it to the roster before normal auth can
+/// admit it.
+pub async fn accept_and_dispatch<C>(
     endpoint: &Endpoint,
-    account_store: &mut A,
+    account_store: &mut OplogSyncStore<'_>,
     content_store: &mut C,
     policy: AuthPolicy,
-    now_ms: impl Fn() -> i64,
+    now_ms: impl Fn() -> i64 + Copy,
 ) -> Result<(Vec<u8>, SessionReport), SyncFailure>
 where
-    A: SyncStore + NodeAuth,
     C: SyncStore,
 {
     // The two stores MUST be for the same account: the auth phase authorizes the peer against the
@@ -268,7 +429,10 @@ where
     // refuses any ALPN `build_endpoint` didn't bind, and it binds exactly the two routed ones),
     // but keeping the check ahead of auth means adding a third bound ALPN without a route here
     // fails cleanly here instead of after the peer has completed authorization.
-    if alpn.as_slice() != SYNC_ALPN && alpn.as_slice() != CONTENT_SYNC_ALPN {
+    if alpn.as_slice() != SYNC_ALPN
+        && alpn.as_slice() != CONTENT_SYNC_ALPN
+        && alpn.as_slice() != ENROLL_ALPN
+    {
         conn.close(0u32.into(), b"unknown-alpn");
         return Err(SyncFailure::Endpoint(EndpointError::Connect(format!(
             "peer negotiated an unknown ALPN {alpn:?}"
@@ -278,6 +442,32 @@ where
         .await
         .map_err(|_| SyncFailure::Endpoint(EndpointError::Connect("peer opened no stream".into())))?
         .map_err(|e| SyncFailure::Endpoint(EndpointError::Connect(e.to_string())))?;
+    if alpn.as_slice() == ENROLL_ALPN {
+        let enrollment_database = account_store.connection();
+        // The acceptor consumes one of the enrollment database's OWN invites and authors the
+        // DeviceAdd into ITS account, so unless that database's local account is exactly the one
+        // the sync stores serve, a miswired dispatcher would enroll the device into an unrelated
+        // account — and report that as a successful enrollment — while sync connections keep
+        // serving the stores' account. Refuse BEFORE redemption (the irreversible boundary).
+        let matches = enrollment_database_matches(enrollment_database, account_store.account_id())
+            .map_err(|error| SyncFailure::Endpoint(EndpointError::Connect(error.to_string())))?;
+        if !matches {
+            conn.close(0u32.into(), b"enrollment-account-mismatch");
+            return Err(SyncFailure::Endpoint(EndpointError::Connect(
+                "enrollment database belongs to a different account than the sync stores".into(),
+            )));
+        }
+        let outcome =
+            run_enrollment_acceptor(&mut recv, &mut send, enrollment_database, remote_node, now_ms)
+                .await
+                .map_err(SyncFailure::Enrollment)?;
+        let enrolled = matches!(outcome, EnrollmentAcceptorOutcome::Enrolled(..));
+        close_enrollment_connection(conn, &mut recv, enrolled).await;
+        return match outcome {
+            EnrollmentAcceptorOutcome::Enrolled(_, _) => Ok((alpn, SessionReport::default())),
+            EnrollmentAcceptorOutcome::Refused(error) => Err(SyncFailure::Enrollment(error)),
+        };
+    }
     // Read the clock only now that a peer has connected (see `accept_and_sync`).
     let now_ms = now_ms();
     // The auth phase is store-agnostic (the binding is account-level), so authorize with the
@@ -308,11 +498,24 @@ where
     Ok((alpn, report))
 }
 
+/// Whether `enrollment_database`'s local account is exactly `account_id` — see the ENROLL_ALPN
+/// branch of [`accept_and_dispatch`]. A database with no minted account cannot redeem anything,
+/// so it does not match either.
+fn enrollment_database_matches(
+    enrollment_database: &Connection,
+    account_id: [u8; 32],
+) -> anyhow::Result<bool> {
+    Ok(rag_rat_oplog::read_local_account(enrollment_database)?
+        == Some(AccountId::from_bytes(account_id)))
+}
+
 /// A sync attempt that failed setting up the connection, authorizing the peer, or running the
 /// session.
 #[derive(Debug)]
 pub enum SyncFailure {
     Endpoint(EndpointError),
+    /// The dedicated owner-side enrollment exchange failed.
+    Enrollment(InviteError),
     /// The node-authorization handshake refused the peer (or we could not authorize to it).
     Auth(crate::auth::AuthError),
     Session(SessionError),
@@ -322,6 +525,7 @@ impl std::fmt::Display for SyncFailure {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             SyncFailure::Endpoint(e) => write!(f, "{e}"),
+            SyncFailure::Enrollment(e) => write!(f, "{e}"),
             SyncFailure::Auth(e) => write!(f, "{e}"),
             SyncFailure::Session(e) => write!(f, "{e}"),
         }
@@ -329,3 +533,271 @@ impl std::fmt::Display for SyncFailure {
 }
 
 impl std::error::Error for SyncFailure {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const NOW: i64 = 1_700_000_000_000;
+
+    fn database() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        rag_rat_db::schema::apply(&conn, &rag_rat_db::MigrationHooks::noop()).unwrap();
+        conn
+    }
+
+    fn local_request(database: &Connection) -> EnrollmentRequest {
+        let local = rag_rat_oplog::local_device(database, NOW).unwrap();
+        EnrollmentRequest {
+            nonce: [1; 32],
+            expected_account: AccountId::from_bytes([5; 32]),
+            ed25519_pubkey: local.ed25519_public_key(),
+            x25519_pubkey: local.x25519_public_key(),
+            transport_node_id: [2; 32],
+            budget: rag_rat_oplog::EnrollmentBudget {
+                account_entries_remaining: u64::MAX,
+                account_bytes_remaining: u64::MAX,
+                global_entries_remaining: u64::MAX,
+                global_bytes_remaining: u64::MAX,
+            },
+            held_entry_hashes: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn enrollment_request_must_use_the_database_device_keys() {
+        let database = database();
+        let request = local_request(&database);
+        let expected_account = AccountId::from_bytes([5; 32]);
+        validate_enrollment_request_identity(&database, expected_account, &request, NOW).unwrap();
+
+        let mut wrong_signing_key = request.clone();
+        wrong_signing_key.ed25519_pubkey = [3; 32];
+        assert!(matches!(
+            validate_enrollment_request_identity(
+                &database,
+                expected_account,
+                &wrong_signing_key,
+                NOW,
+            ),
+            Err(InviteError::Malformed(message)) if message.contains("ed25519")
+        ));
+
+        let mut wrong_encryption_key = request;
+        wrong_encryption_key.x25519_pubkey = [4; 32];
+        assert!(matches!(
+            validate_enrollment_request_identity(
+                &database,
+                expected_account,
+                &wrong_encryption_key,
+                NOW,
+            ),
+            Err(InviteError::Malformed(message)) if message.contains("X25519")
+        ));
+    }
+
+    #[test]
+    fn enrollment_database_must_belong_to_the_served_account() {
+        let served_db = database();
+        let served = rag_rat_oplog::local_account(&served_db, NOW).unwrap().to_bytes();
+        assert!(enrollment_database_matches(&served_db, served).unwrap());
+
+        let other_db = database();
+        let other = rag_rat_oplog::local_account(&other_db, NOW).unwrap().to_bytes();
+        assert_ne!(served, other);
+        assert!(
+            !enrollment_database_matches(&other_db, served).unwrap(),
+            "an enrollment database for another account is not accepted"
+        );
+
+        let unminted = database();
+        assert!(
+            !enrollment_database_matches(&unminted, served).unwrap(),
+            "an enrollment database with no local account cannot redeem anything"
+        );
+    }
+
+    /// Two iroh endpoints on loopback UDP with the relay disabled — no network, no relay, just a
+    /// real QUIC transport between in-process endpoints.
+    async fn loopback_endpoints() -> (Endpoint, Endpoint) {
+        let bind = |seed: [u8; 32]| async move {
+            Endpoint::builder(presets::Minimal)
+                .alpns(vec![SYNC_ALPN.to_vec(), CONTENT_SYNC_ALPN.to_vec(), ENROLL_ALPN.to_vec()])
+                .relay_mode(RelayMode::Disabled)
+                .secret_key(SecretKey::from_bytes(&seed))
+                .bind()
+                .await
+                .unwrap()
+        };
+        (bind([0x11; 32]).await, bind([0x12; 32]).await)
+    }
+
+    fn direct_addr(endpoint: &Endpoint) -> EndpointAddr {
+        let port = endpoint
+            .addr()
+            .ip_addrs()
+            .next()
+            .expect("a bound endpoint advertises at least one socket address")
+            .port();
+        EndpointAddr::new(endpoint.id())
+            .with_ip_addr(std::net::SocketAddr::from(([127, 0, 0, 1], port)))
+    }
+
+    #[tokio::test]
+    async fn enrollment_round_trips_over_loopback_endpoints() {
+        let owner_db = database();
+        let account = rag_rat_oplog::local_account(&owner_db, NOW).unwrap();
+        let (listener, dialer) = loopback_endpoints().await;
+        let joiner_db = database();
+        let local = rag_rat_oplog::local_device(&joiner_db, NOW).unwrap();
+        let ticket = crate::enrollment::mint_invite(&owner_db, crate::enrollment::InviteSpec {
+            account_id: account,
+            inviter_node_id: *listener.id().as_bytes(),
+            relay_url: "https://relay.example".into(),
+            role: rag_rat_oplog::DeviceRole::Member,
+            label: None,
+            now_ms: &|| NOW,
+            ttl: std::time::Duration::from_secs(60),
+        })
+        .unwrap();
+        // A stale caller-supplied transport identity is overwritten from the dialing endpoint;
+        // without that, the acceptor would deterministically return WrongNode.
+        let request = EnrollmentRequest {
+            nonce: ticket.nonce,
+            expected_account: account,
+            ed25519_pubkey: local.ed25519_public_key(),
+            x25519_pubkey: local.x25519_public_key(),
+            transport_node_id: [0xaa; 32],
+            budget: rag_rat_oplog::EnrollmentBudget {
+                account_entries_remaining: 0,
+                account_bytes_remaining: 0,
+                global_entries_remaining: 0,
+                global_bytes_remaining: 0,
+            },
+            held_entry_hashes: Vec::new(),
+        };
+        let peer = direct_addr(&listener);
+        let server = accept_enrollment(&listener, &owner_db, || NOW);
+        let client = connect_and_enroll(&dialer, peer, &joiner_db, account, &request, NOW);
+        let (server_r, client_r) = tokio::join!(server, client);
+        let accepted = server_r.unwrap();
+        let received = client_r.unwrap();
+        assert_eq!(received, accepted, "dialer and acceptor agree on the receipt");
+        assert_eq!(rag_rat_oplog::read_local_account(&joiner_db).unwrap(), Some(account));
+    }
+
+    #[tokio::test]
+    async fn dispatch_routes_enrollment_over_loopback() {
+        let owner_db = database();
+        let account = rag_rat_oplog::local_account(&owner_db, NOW).unwrap();
+        let (listener, dialer) = loopback_endpoints().await;
+        let joiner_db = database();
+        let local = rag_rat_oplog::local_device(&joiner_db, NOW).unwrap();
+        let ticket = crate::enrollment::mint_invite(&owner_db, crate::enrollment::InviteSpec {
+            account_id: account,
+            inviter_node_id: *listener.id().as_bytes(),
+            relay_url: "https://relay.example".into(),
+            role: rag_rat_oplog::DeviceRole::Member,
+            label: None,
+            now_ms: &|| NOW,
+            ttl: std::time::Duration::from_secs(60),
+        })
+        .unwrap();
+        let request = EnrollmentRequest {
+            nonce: ticket.nonce,
+            expected_account: account,
+            ed25519_pubkey: local.ed25519_public_key(),
+            x25519_pubkey: local.x25519_public_key(),
+            transport_node_id: [0xbb; 32],
+            budget: rag_rat_oplog::EnrollmentBudget {
+                account_entries_remaining: 0,
+                account_bytes_remaining: 0,
+                global_entries_remaining: 0,
+                global_bytes_remaining: 0,
+            },
+            held_entry_hashes: Vec::new(),
+        };
+        let mut account_store = crate::store::OplogSyncStore::new(&owner_db, account, || NOW);
+        let mut content_store =
+            crate::store::OplogContentSyncStore::new(&owner_db, account, || NOW);
+        let peer = direct_addr(&listener);
+        let server = accept_and_dispatch(
+            &listener,
+            &mut account_store,
+            &mut content_store,
+            crate::auth::AuthPolicy::Open,
+            || NOW,
+        );
+        let client = connect_and_enroll(&dialer, peer, &joiner_db, account, &request, NOW);
+        let (server_r, client_r) = tokio::join!(server, client);
+        let (alpn, _) = server_r.unwrap();
+        assert_eq!(alpn, ENROLL_ALPN, "the dispatcher routed the enrollment stream");
+        client_r.unwrap();
+    }
+
+    #[tokio::test]
+    async fn enrollment_refusal_and_wrong_alpn_close_over_loopback() {
+        let owner_db = database();
+        let _ = rag_rat_oplog::local_account(&owner_db, NOW).unwrap();
+        let (listener, dialer) = loopback_endpoints().await;
+        let joiner_db = database();
+        let local = rag_rat_oplog::local_device(&joiner_db, NOW).unwrap();
+        // An unknown nonce redeems nothing: the acceptor answers a semantic refusal and closes
+        // without the enrolled wait.
+        let request = EnrollmentRequest {
+            nonce: [0x99; 32],
+            expected_account: rag_rat_oplog::read_local_account(&owner_db).unwrap().unwrap(),
+            ed25519_pubkey: local.ed25519_public_key(),
+            x25519_pubkey: local.x25519_public_key(),
+            transport_node_id: [0; 32],
+            budget: rag_rat_oplog::EnrollmentBudget {
+                account_entries_remaining: 0,
+                account_bytes_remaining: 0,
+                global_entries_remaining: 0,
+                global_bytes_remaining: 0,
+            },
+            held_entry_hashes: Vec::new(),
+        };
+        let peer = direct_addr(&listener);
+        let server = accept_enrollment(&listener, &owner_db, || NOW);
+        let client =
+            connect_and_enroll(&dialer, peer, &joiner_db, request.expected_account, &request, NOW);
+        let (server_r, client_r) = tokio::join!(server, client);
+        assert!(matches!(server_r, Err(InviteError::Unknown)), "server: {server_r:?}");
+        assert!(matches!(client_r, Err(InviteError::Unknown)), "client: {client_r:?}");
+
+        // A connection negotiating the wrong ALPN is refused before any enrollment frame.
+        let server = accept_enrollment(&listener, &joiner_db, || NOW);
+        let client = async {
+            let conn = dialer
+                .connect(direct_addr(&listener), SYNC_ALPN)
+                .await
+                .map_err(|e| InviteError::Storage(e.into()))?;
+            let (send, _recv) = conn.open_bi().await.map_err(|e| InviteError::Storage(e.into()))?;
+            drop(send);
+            conn.closed().await;
+            Ok::<(), InviteError>(())
+        };
+        let (server_r, client_r) = tokio::join!(server, client);
+        assert!(matches!(server_r, Err(InviteError::Malformed(_))), "server: {server_r:?}");
+        client_r.unwrap();
+    }
+
+    #[test]
+    fn enrollment_refuses_a_conflicting_local_account_before_dialing() {
+        let database = database();
+        let request = local_request(&database);
+        let existing_account = rag_rat_oplog::local_account(&database, NOW).unwrap();
+        let expected_account = AccountId::from_bytes([7; 32]);
+        assert_ne!(existing_account, expected_account);
+        assert!(matches!(
+            validate_enrollment_request_identity(
+                &database,
+                expected_account,
+                &request,
+                NOW,
+            ),
+            Err(InviteError::Malformed(message)) if message.contains("existing local account")
+        ));
+    }
+}

--- a/crates/rag-rat-sync/src/enrollment.rs
+++ b/crates/rag-rat-sync/src/enrollment.rs
@@ -1,0 +1,2931 @@
+//! One-time owner↔joiner enrollment protocol (#945).
+//!
+//! The ticket is routing data plus an opaque nonce; the granted role and label stay in the
+//! inviter's durable row, so a joiner cannot escalate by editing the ticket. Redemption consumes
+//! the nonce, authors the exact `DeviceAdd`, and catches up stream keys in one IMMEDIATE
+//! transaction. Any failure rolls all three effects back.
+
+use std::mem::MaybeUninit;
+use std::str::FromStr;
+use std::time::Duration;
+
+use iroh::{EndpointId, RelayUrl};
+use minicbor::{Decoder, Encoder};
+use rag_rat_oplog::{
+    AccountId, AuthoredDurability, AuthorityBoundary, AuthorityQuery, CatchUpReport,
+    DeviceFingerprint, DeviceRole, ENROLLMENT_HELD_ENTRY_HASHES_MAX, EnrollingDevice,
+    EnrollmentBudget, account_entries_for_enrollment, author_enrollment_device_add_in_tx,
+    enroll_stream_keys_for_device_in_tx, enrollment_authoring_fits, load_local_device,
+    owned_streams_for_account, owner_control_authority_in_snapshot, read_local_account,
+    retry_enrollment_pre_verify, validate_device_add_label, verify_enrollment_device_add,
+};
+use rusqlite::{Connection, OptionalExtension, Transaction, TransactionBehavior, params};
+use sha2::{Digest, Sha256};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+
+pub const ENROLL_ALPN: &[u8] = b"rag-rat/enroll/1";
+const TICKET_DOMAIN: &str = "rag-rat/enrollment-ticket/1";
+const REQUEST_DOMAIN: &str = "rag-rat/enrollment-request/1";
+const RECEIPT_DOMAIN: &str = "rag-rat/enrollment-receipt/1";
+const RESPONSE_DOMAIN: &str = "rag-rat/enrollment-response/1";
+const MAX_ENROLL_REQUEST_FRAME: u32 = 144 * 1024;
+const MAX_ENROLL_RESPONSE_FRAME: u32 = crate::codec::MAX_FRAME_BYTES;
+const MAX_ENROLL_BOOTSTRAP_ENTRIES: u64 = 4_096;
+const MAX_RELAY_URL_BYTES: usize = 2048;
+const RECEIPT_REPLAY_RETENTION_MS: i64 = 24 * 60 * 60 * 1000;
+/// Per-chunk progress window for enrollment frame IO: every 64 KiB slice of a frame body must
+/// arrive (or drain) within this window. Mirrors the session's per-frame idle reset
+/// (`read_frame_before`), so a slow but progressing multi-megabyte receipt never times out while
+/// a stalled peer dies within one window.
+pub const ENROLL_PROGRESS_TIMEOUT: Duration = Duration::from_secs(60);
+/// Chunk size for progress-tracked frame IO: 64 KiB per window tolerates ~1 KiB/s links, and a
+/// byte-at-a-time trickle can never complete a chunk, so the slow-loris floor is one window.
+const ENROLL_PROGRESS_CHUNK_BYTES: usize = 64 * 1024;
+/// The tighter window applied to frames any UNAUTHENTICATED peer can reach — the request and a
+/// refusal response (a random nonce gets that far). Both are at most a couple of chunks, so a
+/// bogus peer's hold on the serial accept loop stays in seconds, not minutes; the full
+/// [`ENROLL_PROGRESS_TIMEOUT`] applies only once a valid nonce has authorized the receipt.
+const ENROLL_UNAUTH_PROGRESS_TIMEOUT: Duration = Duration::from_secs(10);
+/// One byte the dialer sends the moment it has DECODED the response — the acceptor's delivery
+/// signal, letting it close without a peer-controlled graceful-close wait (#945). Not a
+/// length-prefixed blob: it is the terminal byte of the exchange, written after the response
+/// frame and read raw by the acceptor.
+pub(crate) const RESPONSE_ACK: u8 = 0x01;
+/// Shared bound for sending or receiving the terminal response acknowledgement. Ack delivery is
+/// best-effort after the response is decoded, so a stalled reverse stream cannot mask the result.
+pub(crate) const RESPONSE_ACK_TIMEOUT: Duration = Duration::from_secs(2);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EnrollmentTicket {
+    pub account_id: AccountId,
+    pub inviter_node_id: [u8; 32],
+    pub relay_url: String,
+    pub nonce: [u8; 32],
+    pub expires_at_ms: i64,
+}
+
+impl EnrollmentTicket {
+    pub fn encode(&self) -> Vec<u8> {
+        let mut out = Vec::new();
+        let mut enc = Encoder::new(&mut out);
+        enc.array(6).expect("owned Vec");
+        enc.str(TICKET_DOMAIN).expect("owned Vec");
+        enc.bytes(&self.account_id.to_bytes()).expect("owned Vec");
+        enc.bytes(&self.inviter_node_id).expect("owned Vec");
+        enc.str(&self.relay_url).expect("owned Vec");
+        enc.bytes(&self.nonce).expect("owned Vec");
+        enc.i64(self.expires_at_ms).expect("owned Vec");
+        out
+    }
+
+    pub fn decode(bytes: &[u8]) -> Result<Self, InviteError> {
+        let mut dec = Decoder::new(bytes);
+        exact_array(&mut dec, 6, "ticket")?;
+        exact_str(&mut dec, TICKET_DOMAIN, "ticket domain")?;
+        let account_id = AccountId::from_bytes(fixed32(dec.bytes().map_err(decode)?, "account")?);
+        let inviter_node_id = fixed32(dec.bytes().map_err(decode)?, "node id")?;
+        let relay_url = dec.str().map_err(decode)?.to_owned();
+        validate_enrollment_route(&inviter_node_id, &relay_url)?;
+        let nonce = fixed32(dec.bytes().map_err(decode)?, "nonce")?;
+        let expires_at_ms = dec.i64().map_err(decode)?;
+        ensure_consumed(&dec, bytes)?;
+        let ticket = Self { account_id, inviter_node_id, relay_url, nonce, expires_at_ms };
+        if ticket.encode() != bytes {
+            return Err(InviteError::Malformed("ticket is not canonical CBOR".into()));
+        }
+        Ok(ticket)
+    }
+}
+
+fn validate_enrollment_route(
+    inviter_node_id: &[u8; 32],
+    relay_url: &str,
+) -> Result<(), InviteError> {
+    EndpointId::from_bytes(inviter_node_id)
+        .map_err(|error| InviteError::Malformed(format!("invalid inviter node id: {error}")))?;
+    if relay_url.len() > MAX_RELAY_URL_BYTES {
+        return Err(InviteError::Malformed("relay URL exceeds 2048 bytes".into()));
+    }
+    RelayUrl::from_str(relay_url.trim())
+        .map_err(|error| InviteError::Malformed(format!("invalid relay URL: {error}")))?;
+    Ok(())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EnrollmentRequest {
+    pub nonce: [u8; 32],
+    /// Account the joiner intends to adopt. The acceptor compares this with the nonce's persisted
+    /// account before authoring or consuming the one-time invite.
+    pub expected_account: AccountId,
+    pub ed25519_pubkey: [u8; 32],
+    pub x25519_pubkey: [u8; 32],
+    pub transport_node_id: [u8; 32],
+    /// The joiner store's remaining admission budget, so the owner can measure its exact receipt
+    /// against it BEFORE consuming the one-time nonce (#945). [`connect_and_enroll`] always
+    /// recomputes this from the local store; the value a caller sets here is overwritten.
+    pub budget: EnrollmentBudget,
+    /// Candidate `entry_hash` values the joiner already holds. Enrollment never transfers
+    /// unauthenticated parked rows; those remain normal-sync work.
+    pub held_entry_hashes: Vec<[u8; 32]>,
+}
+
+impl EnrollmentRequest {
+    fn encode(&self) -> Vec<u8> {
+        let mut out = Vec::new();
+        let mut enc = Encoder::new(&mut out);
+        enc.array(8).expect("owned Vec");
+        enc.str(REQUEST_DOMAIN).expect("owned Vec");
+        enc.bytes(&self.nonce).expect("owned Vec");
+        enc.bytes(&self.expected_account.to_bytes()).expect("owned Vec");
+        enc.bytes(&self.ed25519_pubkey).expect("owned Vec");
+        enc.bytes(&self.x25519_pubkey).expect("owned Vec");
+        enc.bytes(&self.transport_node_id).expect("owned Vec");
+        enc.array(4).expect("owned Vec");
+        enc.u64(self.budget.account_entries_remaining).expect("owned Vec");
+        enc.u64(self.budget.account_bytes_remaining).expect("owned Vec");
+        enc.u64(self.budget.global_entries_remaining).expect("owned Vec");
+        enc.u64(self.budget.global_bytes_remaining).expect("owned Vec");
+        enc.array(self.held_entry_hashes.len() as u64).expect("owned Vec");
+        for hash in &self.held_entry_hashes {
+            enc.bytes(hash).expect("owned Vec");
+        }
+        out
+    }
+
+    fn decode(bytes: &[u8]) -> Result<Self, InviteError> {
+        let mut dec = Decoder::new(bytes);
+        exact_array(&mut dec, 8, "request")?;
+        exact_str(&mut dec, REQUEST_DOMAIN, "request domain")?;
+        let budget_u64 =
+            |dec: &mut Decoder<'_>| -> Result<u64, InviteError> { dec.u64().map_err(decode) };
+        let request = Self {
+            nonce: fixed32(dec.bytes().map_err(decode)?, "nonce")?,
+            expected_account: AccountId::from_bytes(fixed32(
+                dec.bytes().map_err(decode)?,
+                "expected account",
+            )?),
+            ed25519_pubkey: fixed32(dec.bytes().map_err(decode)?, "ed25519 key")?,
+            x25519_pubkey: fixed32(dec.bytes().map_err(decode)?, "x25519 key")?,
+            transport_node_id: fixed32(dec.bytes().map_err(decode)?, "transport node id")?,
+            budget: {
+                exact_array(&mut dec, 4, "request budget")?;
+                EnrollmentBudget {
+                    account_entries_remaining: budget_u64(&mut dec)?,
+                    account_bytes_remaining: budget_u64(&mut dec)?,
+                    global_entries_remaining: budget_u64(&mut dec)?,
+                    global_bytes_remaining: budget_u64(&mut dec)?,
+                }
+            },
+            held_entry_hashes: {
+                let count = dec.array().map_err(decode)?.ok_or_else(|| {
+                    InviteError::Malformed("held entry hashes must be a definite array".into())
+                })?;
+                if count > ENROLLMENT_HELD_ENTRY_HASHES_MAX as u64 {
+                    return Err(InviteError::Malformed(format!(
+                        "held entry hashes {count} over {ENROLLMENT_HELD_ENTRY_HASHES_MAX}"
+                    )));
+                }
+                let mut hashes = Vec::with_capacity(count as usize);
+                for _ in 0..count {
+                    hashes.push(fixed32(dec.bytes().map_err(decode)?, "held entry hash")?);
+                }
+                if hashes.windows(2).any(|pair| pair[0] >= pair[1]) {
+                    return Err(InviteError::Malformed(
+                        "held entry hashes must be strictly sorted and unique".into(),
+                    ));
+                }
+                hashes
+            },
+        };
+        ensure_consumed(&dec, bytes)?;
+        if request.encode() != bytes {
+            return Err(InviteError::Malformed("request is not canonical CBOR".into()));
+        }
+        Ok(request)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EnrollmentReceipt {
+    pub device_add_hash: [u8; 32],
+    pub device_add_signed: Vec<u8>,
+    /// Exact signed account-log bootstrap, ordered as normal account sync would offer it. A fresh
+    /// joiner ingests these entries before its first Closed session so it can verify the inviter's
+    /// account binding and fold its own DeviceAdd effective.
+    pub account_entries: Vec<Vec<u8>>,
+}
+
+pub struct InviteSpec<'a> {
+    pub account_id: AccountId,
+    pub inviter_node_id: [u8; 32],
+    pub relay_url: String,
+    pub role: DeviceRole,
+    pub label: Option<&'a str>,
+    /// Mint clock. Read ONCE after the writer transaction is acquired — a pre-lock timestamp can
+    /// go stale behind SQLite's busy timeout and would mint an already-expired ticket.
+    pub now_ms: &'a dyn Fn() -> i64,
+    pub ttl: Duration,
+}
+
+struct StoredInvite {
+    account_bytes: Vec<u8>,
+    role: String,
+    label: Option<String>,
+    expires_at_ms: i64,
+    used_at_ms: Option<i64>,
+    used_transport_node: Option<Vec<u8>>,
+    used_ed25519_pubkey: Option<Vec<u8>>,
+    used_x25519_pubkey: Option<Vec<u8>>,
+    receipt_hash: Option<Vec<u8>>,
+    receipt_signed: Option<Vec<u8>>,
+    receipt_entries: Option<Vec<u8>>,
+    /// Legacy full-receipt copy (pre-V092). Never written anymore; retained so invites consumed
+    /// before V092 keep replaying through their 24h window. The manifest form is preferred.
+    receipt_bytes: Option<Vec<u8>>,
+}
+
+/// Owner-side result after a complete enrollment request. Refusals are sent over the wire before
+/// being returned, so the caller may gracefully close the QUIC connection without hiding the
+/// semantic error from the joiner.
+pub enum EnrollmentAcceptorOutcome {
+    Enrolled(EnrollmentReceipt, CatchUpReport),
+    Refused(InviteError),
+}
+
+enum EnrollmentResponse {
+    Enrolled(EnrollmentReceipt),
+    Refused(RefusalCode),
+}
+
+#[derive(Clone, Copy)]
+enum RefusalCode {
+    Expired,
+    Used,
+    Unknown,
+    WrongNode,
+    AccountMismatch,
+    Revoked,
+    JoinerCapacity,
+    HeldStateConflict,
+}
+
+impl EnrollmentReceipt {
+    fn encode(&self) -> Vec<u8> {
+        let mut out = Vec::new();
+        let mut enc = Encoder::new(&mut out);
+        enc.array(4).expect("owned Vec");
+        enc.str(RECEIPT_DOMAIN).expect("owned Vec");
+        enc.bytes(&self.device_add_hash).expect("owned Vec");
+        enc.bytes(&self.device_add_signed).expect("owned Vec");
+        enc.array(self.account_entries.len() as u64).expect("owned Vec");
+        for entry in &self.account_entries {
+            enc.bytes(entry).expect("owned Vec");
+        }
+        out
+    }
+
+    fn decode(bytes: &[u8]) -> Result<Self, InviteError> {
+        let mut dec = Decoder::new(bytes);
+        exact_array(&mut dec, 4, "receipt")?;
+        exact_str(&mut dec, RECEIPT_DOMAIN, "receipt domain")?;
+        let device_add_hash = fixed32(dec.bytes().map_err(decode)?, "DeviceAdd hash")?;
+        let device_add_signed = dec.bytes().map_err(decode)?.to_vec();
+        let entry_count = dec.array().map_err(decode)?.ok_or_else(|| {
+            InviteError::Malformed("bootstrap entries must be a definite array".into())
+        })?;
+        if entry_count > MAX_ENROLL_BOOTSTRAP_ENTRIES {
+            return Err(InviteError::Malformed(format!(
+                "bootstrap has {entry_count} entries, over {MAX_ENROLL_BOOTSTRAP_ENTRIES}"
+            )));
+        }
+        let mut account_entries = Vec::with_capacity(entry_count as usize);
+        for _ in 0..entry_count {
+            account_entries.push(dec.bytes().map_err(decode)?.to_vec());
+        }
+        let receipt = Self { device_add_hash, device_add_signed, account_entries };
+        ensure_consumed(&dec, bytes)?;
+        if receipt.encode() != bytes {
+            return Err(InviteError::Malformed("receipt is not canonical CBOR".into()));
+        }
+        Ok(receipt)
+    }
+}
+
+impl EnrollmentResponse {
+    fn encode(&self) -> Vec<u8> {
+        let mut out = Vec::new();
+        let mut enc = Encoder::new(&mut out);
+        enc.array(3).expect("owned Vec");
+        enc.str(RESPONSE_DOMAIN).expect("owned Vec");
+        match self {
+            Self::Enrolled(receipt) => {
+                enc.str("enrolled").expect("owned Vec");
+                enc.bytes(&receipt.encode()).expect("owned Vec");
+            },
+            Self::Refused(code) => {
+                enc.str("refused").expect("owned Vec");
+                enc.str(code.as_str()).expect("owned Vec");
+            },
+        }
+        out
+    }
+
+    fn decode(bytes: &[u8]) -> Result<Self, InviteError> {
+        let mut dec = Decoder::new(bytes);
+        exact_array(&mut dec, 3, "response")?;
+        exact_str(&mut dec, RESPONSE_DOMAIN, "response domain")?;
+        let response = match dec.str().map_err(decode)? {
+            "enrolled" => Self::Enrolled(EnrollmentReceipt::decode(dec.bytes().map_err(decode)?)?),
+            "refused" => Self::Refused(RefusalCode::from_str(dec.str().map_err(decode)?)?),
+            value =>
+                return Err(InviteError::Malformed(format!("unknown enrollment response {value}"))),
+        };
+        ensure_consumed(&dec, bytes)?;
+        if response.encode() != bytes {
+            return Err(InviteError::Malformed("response is not canonical CBOR".into()));
+        }
+        Ok(response)
+    }
+}
+
+impl RefusalCode {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Expired => "expired",
+            Self::Used => "used",
+            Self::Unknown => "unknown",
+            Self::WrongNode => "wrong_node",
+            Self::AccountMismatch => "account_mismatch",
+            Self::Revoked => "revoked",
+            Self::JoinerCapacity => "joiner_capacity",
+            Self::HeldStateConflict => "held_state_conflict",
+        }
+    }
+
+    fn from_str(value: &str) -> Result<Self, InviteError> {
+        match value {
+            "expired" => Ok(Self::Expired),
+            "used" => Ok(Self::Used),
+            "unknown" => Ok(Self::Unknown),
+            "wrong_node" => Ok(Self::WrongNode),
+            "account_mismatch" => Ok(Self::AccountMismatch),
+            "revoked" => Ok(Self::Revoked),
+            "joiner_capacity" => Ok(Self::JoinerCapacity),
+            "held_state_conflict" => Ok(Self::HeldStateConflict),
+            _ => Err(InviteError::Malformed(format!("unknown enrollment refusal {value}"))),
+        }
+    }
+
+    fn into_error(self) -> InviteError {
+        match self {
+            Self::Expired => InviteError::Expired,
+            Self::Used => InviteError::Used,
+            Self::Unknown => InviteError::Unknown,
+            Self::WrongNode => InviteError::WrongNode,
+            Self::AccountMismatch => InviteError::AccountMismatch,
+            Self::Revoked => InviteError::Revoked,
+            Self::JoinerCapacity => InviteError::JoinerCapacity,
+            Self::HeldStateConflict => InviteError::HeldStateConflict,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum InviteError {
+    Malformed(String),
+    Expired,
+    Used,
+    Unknown,
+    WrongNode,
+    /// The request's expected account differs from the account bound to its one-time nonce.
+    AccountMismatch,
+    /// The exact-request replay found the acknowledged DeviceAdd no longer roster-effective —
+    /// the owner removed the device inside the replay window, so the stored receipt (and its
+    /// stream-key wraps) must not be released again.
+    Revoked,
+    /// The exact receipt does not fit the admission budget the joiner declared. Refused BEFORE
+    /// the nonce is consumed: candidate capacity is grow-only, so committing the redemption
+    /// would burn the enrollment on a receipt the joiner can never hold.
+    JoinerCapacity,
+    /// The joiner claims a candidate the owner's authenticated snapshot does not hold. Refused
+    /// BEFORE the nonce is consumed: adopting the receipt into the union with that unreconciled
+    /// history could make the acknowledged DeviceAdd ineffective, and every exact replay would
+    /// fail identically.
+    HeldStateConflict,
+    Storage(anyhow::Error),
+    Io(std::io::Error),
+}
+
+impl std::fmt::Display for InviteError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Malformed(message) => write!(f, "malformed enrollment data: {message}"),
+            Self::Expired => write!(f, "enrollment invite expired"),
+            Self::Used => write!(f, "enrollment invite was already used"),
+            Self::Unknown => write!(f, "enrollment invite is unknown"),
+            Self::WrongNode =>
+                write!(f, "join request transport node does not match the connection"),
+            Self::AccountMismatch => write!(f, "enrollment invite belongs to a different account"),
+            Self::Revoked => write!(f, "the enrolled device was removed from the roster"),
+            Self::JoinerCapacity =>
+                write!(f, "the enrollment receipt does not fit the joiner's declared capacity"),
+            Self::HeldStateConflict => write!(
+                f,
+                "the joiner holds account candidates the inviter's snapshot cannot reconcile"
+            ),
+            Self::Storage(error) => write!(f, "enrollment storage: {error}"),
+            Self::Io(error) => write!(f, "enrollment stream: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for InviteError {}
+
+impl From<anyhow::Error> for InviteError {
+    fn from(value: anyhow::Error) -> Self {
+        Self::Storage(value)
+    }
+}
+
+impl From<std::io::Error> for InviteError {
+    fn from(value: std::io::Error) -> Self {
+        Self::Io(value)
+    }
+}
+
+pub fn mint_invite(
+    conn: &Connection,
+    spec: InviteSpec<'_>,
+) -> Result<EnrollmentTicket, InviteError> {
+    let InviteSpec { account_id, inviter_node_id, relay_url, role, label, now_ms, ttl } = spec;
+    validate_enrollment_route(&inviter_node_id, &relay_url)?;
+    validate_device_add_label(label).map_err(|error| InviteError::Malformed(error.to_string()))?;
+    let ttl_ms = i64::try_from(ttl.as_millis())
+        .map_err(|_| InviteError::Malformed("invite TTL is too large".into()))?;
+    // A zero or sub-millisecond TTL mints a ticket that is already expired — redemption treats
+    // `now_ms >= expires_at_ms` as expired, so this is a deterministic failure that must not
+    // cross the invite-issuance boundary.
+    if ttl_ms == 0 {
+        return Err(InviteError::Malformed("invite TTL must be at least one millisecond".into()));
+    }
+    let mut nonce_bytes = [MaybeUninit::uninit(); 32];
+    let nonce = getrandom::fill_uninit(&mut nonce_bytes)
+        .map_err(|error| InviteError::Storage(anyhow::anyhow!("invite entropy: {error}")))?
+        .try_into()
+        .map(|nonce: &mut [u8; 32]| *nonce)
+        .expect("the fixed-size destination preserves its length");
+    let _durability = AuthoredDurability::begin(conn)?;
+    let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)
+        .map_err(|error| InviteError::Storage(error.into()))?;
+    // BEGIN IMMEDIATE can wait out the busy timeout behind another writer: read the mint clock
+    // ONLY NOW, or a ticket minted after a long lock wait would carry a pre-wait expiry and be
+    // born already unusable (mirrors redemption's post-lock clock, #945).
+    let now_ms = now_ms();
+    let expires_at_ms = now_ms
+        .checked_add(ttl_ms)
+        .ok_or_else(|| InviteError::Malformed("invite expiry overflows i64".into()))?;
+    require_founder_enrollment_authority(&tx, account_id)?;
+    // The candidate store is grow-only — capacity never drains — so if it cannot fit THIS
+    // redemption's DeviceAdd plus its stream-key wraps, the ticket would be permanently
+    // unusable: a deterministic failure that must gate the invite-issuance boundary (#945),
+    // checked in the same commit snapshot as the authority preflight. Minting then RESERVES
+    // that exact requirement against the shared candidate counters, so ordinary ingest or a
+    // second mint cannot consume the headroom this ticket was measured against; the reservation
+    // is released only by redemption (under the writer lock) or expiry.
+    let streams = owned_streams_for_account(&tx, account_id)?;
+    enrollment_authoring_fits(&tx, account_id, &streams, role, label, now_ms)?;
+    let (reserved_entries, reserved_bytes) =
+        rag_rat_oplog::enrollment_authoring_requirements(&tx, account_id, &streams, role, label)?;
+    rag_rat_oplog::upsert_account_candidate_reservation_in_tx(
+        &tx,
+        account_id,
+        nonce,
+        reserved_entries,
+        reserved_bytes,
+        reserved_entries.saturating_sub(1),
+        expires_at_ms,
+    )?;
+    prune_expired_invites_in_tx(&tx, now_ms)?;
+    tx.execute(
+        "INSERT INTO sync_invites(
+             nonce, account_id, role, label, expires_at_ms, created_at_ms, used_at_ms
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, NULL)",
+        params![
+            nonce.as_slice(),
+            account_id.to_bytes().as_slice(),
+            role.as_db_str(),
+            label,
+            expires_at_ms,
+            now_ms,
+        ],
+    )
+    .map_err(|error| InviteError::Storage(error.into()))?;
+    tx.commit().map_err(|error| InviteError::Storage(error.into()))?;
+    Ok(EnrollmentTicket { account_id, inviter_node_id, relay_url, nonce, expires_at_ms })
+}
+
+fn require_founder_enrollment_authority(
+    conn: &Connection,
+    account_id: AccountId,
+) -> Result<(), InviteError> {
+    if read_local_account(conn)
+        .map_err(InviteError::from)?
+        .filter(|local| *local == account_id)
+        .is_none()
+    {
+        return Err(InviteError::Storage(anyhow::anyhow!(
+            "invite account is not the local account"
+        )));
+    }
+    let local_device = load_local_device(conn)
+        .map_err(InviteError::from)?
+        .ok_or_else(|| InviteError::Storage(anyhow::anyhow!("local device identity is missing")))?;
+    let genesis_bytes: Vec<u8> = conn
+        .query_row("SELECT genesis_entry_hash FROM oplog_local_account WHERE id = 0", [], |row| {
+            row.get(0)
+        })
+        .map_err(|error| InviteError::Storage(error.into()))?;
+    let genesis_hash = genesis_bytes.try_into().map_err(|_| {
+        InviteError::Storage(anyhow::anyhow!("local account genesis hash is not 32 bytes"))
+    })?;
+    let authority = owner_control_authority_in_snapshot(
+        conn,
+        account_id,
+        genesis_hash,
+        local_device.fingerprint(),
+    )
+    .map_err(InviteError::from)?;
+    if !matches!(
+        authority,
+        AuthorityQuery::Effective(authority)
+            if authority.device_boundary == AuthorityBoundary::Open
+                && authority.incarnation_boundary == AuthorityBoundary::Open
+    ) {
+        return Err(InviteError::Storage(anyhow::anyhow!(
+            "local device lacks open founder authority to enroll devices"
+        )));
+    }
+    Ok(())
+}
+
+pub fn redeem_invite(
+    conn: &Connection,
+    request: EnrollmentRequest,
+    authenticated_remote_node: [u8; 32],
+    now_ms: &dyn Fn() -> i64,
+) -> Result<(EnrollmentReceipt, CatchUpReport), InviteError> {
+    if request.transport_node_id != authenticated_remote_node {
+        return Err(InviteError::WrongNode);
+    }
+    // Reject random unauthenticated nonces without taking SQLite's database-wide writer
+    // reservation. A valid candidate is re-read after BEGIN IMMEDIATE below.
+    let Some(invite) = stored_invite(conn, request.nonce)? else {
+        return Err(InviteError::Unknown);
+    };
+    let account_id = stored_invite_account(&invite)?;
+    if request.expected_account != account_id {
+        return Err(InviteError::AccountMismatch);
+    }
+    let arrival_ms = now_ms();
+    if receipt_replay_expired(&invite, arrival_ms) {
+        prune_expired_invites(conn, arrival_ms)?;
+        return Err(InviteError::Used);
+    }
+    if let Some(receipt) = replay_receipt(conn, &invite, &request)? {
+        return Ok((receipt, empty_catch_up(&request)));
+    }
+    if arrival_ms >= invite.expires_at_ms {
+        return Err(InviteError::Expired);
+    }
+    let _durability = AuthoredDurability::begin(conn)?;
+    let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)
+        .map_err(|error| InviteError::Storage(error.into()))?;
+    // BEGIN IMMEDIATE can wait out the busy timeout behind another writer: re-read the clock
+    // NOW that the writer lock is held, or an invite that expired during the wait would be
+    // consumed against the stale pre-wait timestamp.
+    let commit_ms = now_ms();
+    let Some(invite) = stored_invite(&tx, request.nonce)? else {
+        return Err(InviteError::Unknown);
+    };
+    let account_id = stored_invite_account(&invite)?;
+    if request.expected_account != account_id {
+        return Err(InviteError::AccountMismatch);
+    }
+    if receipt_replay_expired(&invite, commit_ms) {
+        prune_expired_invites_in_tx(&tx, commit_ms)?;
+        tx.commit().map_err(|error| InviteError::Storage(error.into()))?;
+        return Err(InviteError::Used);
+    }
+    if let Some(receipt) = replay_receipt(&tx, &invite, &request)? {
+        return Ok((receipt, empty_catch_up(&request)));
+    }
+    if commit_ms >= invite.expires_at_ms {
+        return Err(InviteError::Expired);
+    }
+    prune_expired_invites_in_tx(&tx, commit_ms)?;
+    if read_local_account(&tx)
+        .map_err(InviteError::from)?
+        .filter(|local| *local == account_id)
+        .is_none()
+    {
+        return Err(InviteError::Storage(anyhow::anyhow!(
+            "invite account is not the local account"
+        )));
+    }
+    let role = DeviceRole::from_db_str(&invite.role).map_err(InviteError::from)?;
+    let fingerprint = DeviceFingerprint::from_bytes(Sha256::digest(request.ed25519_pubkey).into());
+    // Release THIS invite's reservation under the writer lock, then RE-MEASURE the mandatory
+    // requirement against current state: key targets may have grown since minting, and the
+    // reservation covered only the mint-time set. The fits check runs with our reservation
+    // released (other outstanding invites' reservations still count), so it passes only if the
+    // DeviceAdd plus the CURRENT wraps genuinely fit — a shortfall rolls back, preserving the
+    // nonce and restoring the reservation instead of stranding the ticket mid-redemption.
+    rag_rat_oplog::release_account_candidate_reservation_in_tx(&tx, request.nonce)?;
+    // Resolve ownership in this same redemption snapshot. A long-running server can ingest
+    // StreamOwn/StreamRevoke entries after startup; caching this set would either omit a newly
+    // owned stream's key wrap or make a stale, no-longer-owned stream abort the whole enrollment.
+    let streams = owned_streams_for_account(&tx, account_id)?;
+    enrollment_authoring_fits(&tx, account_id, &streams, role, invite.label.as_deref(), commit_ms)?;
+    let device_add = author_enrollment_device_add_in_tx(
+        &tx,
+        EnrollingDevice {
+            ed25519_pubkey: request.ed25519_pubkey,
+            x25519_pubkey: request.x25519_pubkey,
+            label: invite.label,
+        },
+        role,
+        commit_ms,
+    )?;
+    let device_add_signed = tx
+        .query_row(
+            "SELECT signed_bytes FROM account_entries WHERE entry_hash = ?1",
+            [device_add.as_slice()],
+            |row| row.get(0),
+        )
+        .map_err(|error| InviteError::Storage(error.into()))?;
+    let catch_up = enroll_stream_keys_for_device_in_tx(&tx, fingerprint, &streams, commit_ms)?;
+    let bootstrap_entries = account_entries_for_enrollment(&tx, account_id)?;
+    // Every candidate the joiner claims to hold MUST be one the owner's authenticated snapshot
+    // also holds. An unrepresented hash means the joiner carries history this receipt cannot
+    // reconcile (a competing control branch, or a false claim); adoption would refold the union
+    // of the receipt and those grow-only extras and could leave the acknowledged DeviceAdd
+    // ineffective — burning the nonce on a bootstrap that can never succeed. Refuse BEFORE the
+    // consume boundary, rolling back the authored entries and restoring the reservation.
+    let receipt_hashes: std::collections::HashSet<&[u8; 32]> =
+        bootstrap_entries.iter().map(|entry| &entry.entry_hash).collect();
+    if request.held_entry_hashes.iter().any(|hash| !receipt_hashes.contains(hash)) {
+        return Err(InviteError::HeldStateConflict);
+    }
+    let account_entries =
+        bootstrap_entries.iter().map(|entry| entry.signed_bytes.clone()).collect();
+    let receipt =
+        EnrollmentReceipt { device_add_hash: device_add, device_add_signed, account_entries };
+    // The receipt must FIT the state the joiner declared: candidate capacity is grow-only, so
+    // consuming the one-time nonce for a receipt the joiner can never hold would burn the
+    // enrollment — a deterministic failure checked BEFORE the consume boundary (#945).
+    //
+    // The charge is the joiner's ACTUAL adoption cost, not the receipt's raw size:
+    // - entries whose hash the joiner already holds are FREE (`insert_candidate` returns
+    //   `AlreadyPresent`) — only the confirmed intersection the joiner proved is credited;
+    // - every NEW authenticated candidate is charged against the declared candidate budgets.
+    let held: std::collections::HashSet<&[u8; 32]> = request.held_entry_hashes.iter().collect();
+    let mut new_entries = 0u64;
+    let mut new_bytes = 0u64;
+    for entry in &bootstrap_entries {
+        if held.contains(&entry.entry_hash) {
+            continue;
+        }
+        new_entries += 1;
+        new_bytes += entry.signed_bytes.len() as u64;
+    }
+    let budget = &request.budget;
+    if new_entries > budget.account_entries_remaining
+        || new_entries > budget.global_entries_remaining
+        || new_bytes > budget.account_bytes_remaining
+        || new_bytes > budget.global_bytes_remaining
+    {
+        return Err(InviteError::JoinerCapacity);
+    }
+    ensure_frame_len(
+        EnrollmentResponse::Enrolled(receipt.clone()).encode().len(),
+        MAX_ENROLL_RESPONSE_FRAME,
+        "response",
+    )?;
+    // Only the joiner-specific DeviceAdd plus the manifest of receipt entry hashes is persisted:
+    // the bootstrap is already durable in the grow-only candidate DAG, and replay reconstructs
+    // the EXACT acknowledged receipt from it rather than storing one full copy per invite
+    // (quadratic across a fleet, #945).
+    let mut receipt_manifest = Vec::with_capacity(32 * bootstrap_entries.len());
+    for entry in &bootstrap_entries {
+        receipt_manifest.extend_from_slice(&entry.entry_hash);
+    }
+    let changed = tx
+        .execute(
+            "UPDATE sync_invites
+                SET used_at_ms = ?2,
+                    used_transport_node = ?3,
+                    used_ed25519_pubkey = ?4,
+                    used_x25519_pubkey = ?5,
+                    receipt_hash = ?6,
+                    receipt_signed = ?7,
+                    receipt_entries = ?8
+              WHERE nonce = ?1 AND used_at_ms IS NULL AND expires_at_ms > ?2",
+            params![
+                request.nonce.as_slice(),
+                commit_ms,
+                request.transport_node_id.as_slice(),
+                request.ed25519_pubkey.as_slice(),
+                request.x25519_pubkey.as_slice(),
+                receipt.device_add_hash.as_slice(),
+                receipt.device_add_signed,
+                receipt_manifest,
+            ],
+        )
+        .map_err(|error| InviteError::Storage(error.into()))?;
+    if changed != 1 {
+        return Err(InviteError::Used);
+    }
+    tx.commit().map_err(|error| InviteError::Storage(error.into()))?;
+    if let Err(error) = retry_enrollment_pre_verify(conn, account_id, commit_ms) {
+        tracing::warn!(%error, "post-enrollment pre-verify retry failed");
+    }
+    Ok((receipt, catch_up))
+}
+
+fn stored_invite(conn: &Connection, nonce: [u8; 32]) -> Result<Option<StoredInvite>, InviteError> {
+    conn.query_row(
+        "SELECT account_id, role, label, expires_at_ms, used_at_ms,
+                used_transport_node, used_ed25519_pubkey, used_x25519_pubkey,
+                receipt_hash, receipt_signed, receipt_entries, receipt_bytes
+           FROM sync_invites WHERE nonce = ?1",
+        [nonce.as_slice()],
+        |row| {
+            Ok(StoredInvite {
+                account_bytes: row.get(0)?,
+                role: row.get(1)?,
+                label: row.get(2)?,
+                expires_at_ms: row.get(3)?,
+                used_at_ms: row.get(4)?,
+                used_transport_node: row.get(5)?,
+                used_ed25519_pubkey: row.get(6)?,
+                used_x25519_pubkey: row.get(7)?,
+                receipt_hash: row.get(8)?,
+                receipt_signed: row.get(9)?,
+                receipt_entries: row.get(10)?,
+                receipt_bytes: row.get(11)?,
+            })
+        },
+    )
+    .optional()
+    .map_err(|error| InviteError::Storage(error.into()))
+}
+
+fn stored_invite_account(invite: &StoredInvite) -> Result<AccountId, InviteError> {
+    Ok(AccountId::from_bytes(invite.account_bytes.as_slice().try_into().map_err(|_| {
+        InviteError::Storage(anyhow::anyhow!("sync_invites account_id is not 32 bytes"))
+    })?))
+}
+
+fn replay_receipt(
+    conn: &Connection,
+    invite: &StoredInvite,
+    request: &EnrollmentRequest,
+) -> Result<Option<EnrollmentReceipt>, InviteError> {
+    if invite.used_at_ms.is_none() {
+        return Ok(None);
+    }
+    let same_request = invite.used_transport_node.as_deref()
+        == Some(request.transport_node_id.as_slice())
+        && invite.used_ed25519_pubkey.as_deref() == Some(request.ed25519_pubkey.as_slice())
+        && invite.used_x25519_pubkey.as_deref() == Some(request.x25519_pubkey.as_slice());
+    if !same_request {
+        return Err(InviteError::Used);
+    }
+    let device_add_hash: [u8; 32] = invite
+        .receipt_hash
+        .as_deref()
+        .ok_or_else(|| InviteError::Storage(anyhow::anyhow!("used invite has no receipt hash")))?
+        .try_into()
+        .map_err(|_| {
+            InviteError::Storage(anyhow::anyhow!("stored receipt hash is not 32 bytes"))
+        })?;
+    let device_add_signed = invite
+        .receipt_signed
+        .clone()
+        .ok_or_else(|| InviteError::Storage(anyhow::anyhow!("used invite has no DeviceAdd")))?;
+    let account_id = stored_invite_account(invite)?;
+    let receipt = if let Some(manifest) = invite.receipt_entries.as_deref() {
+        if manifest.len() % 32 != 0 || manifest.len() / 32 > MAX_ENROLL_BOOTSTRAP_ENTRIES as usize {
+            return Err(InviteError::Storage(anyhow::anyhow!(
+                "stored receipt manifest is not a bounded hash list"
+            )));
+        }
+        // Reconstruct the EXACT acknowledged receipt from the grow-only candidate DAG: the
+        // manifest pins the original entry set and order, so the capacity and frame checks the
+        // original redemption measured stay valid no matter how much history arrived since —
+        // the replay never ships an unadoptable or oversized response.
+        let mut signed_by_hash: std::collections::HashMap<[u8; 32], Vec<u8>> =
+            account_entries_for_enrollment(conn, account_id)?
+                .into_iter()
+                .map(|entry| (entry.entry_hash, entry.signed_bytes))
+                .collect();
+        let mut account_entries = Vec::with_capacity(manifest.len() / 32);
+        for hash in manifest.chunks_exact(32) {
+            let hash: [u8; 32] = hash.try_into().expect("chunked by 32");
+            let bytes = signed_by_hash.remove(&hash).ok_or_else(|| {
+                InviteError::Storage(anyhow::anyhow!(
+                    "receipt entry missing from the candidate DAG"
+                ))
+            })?;
+            account_entries.push(bytes);
+        }
+        EnrollmentReceipt { device_add_hash, device_add_signed, account_entries }
+    } else {
+        // Pre-V092 legacy form: the exact receipt was stored whole and replays as-is through the
+        // remainder of its 24h window.
+        let receipt_bytes = invite
+            .receipt_bytes
+            .as_deref()
+            .ok_or_else(|| InviteError::Storage(anyhow::anyhow!("used invite has no receipt")))?;
+        let receipt = EnrollmentReceipt::decode(receipt_bytes)?;
+        if receipt.device_add_hash != device_add_hash
+            || receipt.device_add_signed != device_add_signed
+        {
+            return Err(InviteError::Storage(anyhow::anyhow!(
+                "stored receipt replay columns disagree"
+            )));
+        }
+        receipt
+    };
+    // A replay must not outlive the enrollment it replays: if the owner removed the device
+    // after redemption, re-releasing the stored bootstrap and its stream-key wraps would arm a
+    // revoked device and report success for an enrollment Closed sync can no longer authorize.
+    let fingerprint = DeviceFingerprint::from_bytes(Sha256::digest(request.ed25519_pubkey).into());
+    let still_effective: bool = conn
+        .query_row(
+            "SELECT EXISTS(
+                 SELECT 1 FROM account_roster_history
+                  WHERE account_id = ?1
+                    AND device_fingerprint = ?2
+                    AND roster_ref = ?3
+                    AND closed_at IS NULL
+            )",
+            params![
+                account_id.to_bytes().as_slice(),
+                fingerprint.to_bytes().as_slice(),
+                receipt.device_add_hash.as_slice(),
+            ],
+            |row| row.get(0),
+        )
+        .map_err(|error| InviteError::Storage(error.into()))?;
+    if !still_effective {
+        return Err(InviteError::Revoked);
+    }
+    Ok(Some(receipt))
+}
+
+fn receipt_replay_expired(invite: &StoredInvite, now_ms: i64) -> bool {
+    invite
+        .used_at_ms
+        .is_some_and(|used_at_ms| now_ms >= used_at_ms.saturating_add(RECEIPT_REPLAY_RETENTION_MS))
+}
+
+fn prune_expired_invites(conn: &Connection, now_ms: i64) -> Result<(), InviteError> {
+    let _durability = AuthoredDurability::begin(conn)?;
+    let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)
+        .map_err(|error| InviteError::Storage(error.into()))?;
+    prune_expired_invites_in_tx(&tx, now_ms)?;
+    tx.commit().map_err(|error| InviteError::Storage(error.into()))
+}
+
+fn prune_expired_invites_in_tx(conn: &Connection, now_ms: i64) -> Result<(), InviteError> {
+    let replay_cutoff_ms = now_ms.saturating_sub(RECEIPT_REPLAY_RETENTION_MS);
+    conn.execute(
+        "DELETE FROM sync_invites
+          WHERE (used_at_ms IS NULL AND expires_at_ms <= ?1)
+             OR (used_at_ms IS NOT NULL AND used_at_ms <= ?2)",
+        params![now_ms, replay_cutoff_ms],
+    )
+    .map_err(|error| InviteError::Storage(error.into()))?;
+    rag_rat_oplog::prune_account_candidate_reservations_in_tx(conn, now_ms)?;
+    Ok(())
+}
+
+fn empty_catch_up(request: &EnrollmentRequest) -> CatchUpReport {
+    CatchUpReport {
+        target: DeviceFingerprint::from_bytes(Sha256::digest(request.ed25519_pubkey).into()),
+        authored: Vec::new(),
+        already_covered: Vec::new(),
+    }
+}
+
+pub async fn run_enrollment_acceptor<R, W, F>(
+    recv: &mut R,
+    send: &mut W,
+    conn: &Connection,
+    authenticated_remote_node: [u8; 32],
+    now_ms: F,
+) -> Result<EnrollmentAcceptorOutcome, InviteError>
+where
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+    F: Fn() -> i64,
+{
+    run_enrollment_acceptor_with_progress(
+        recv,
+        send,
+        conn,
+        authenticated_remote_node,
+        now_ms,
+        ENROLL_PROGRESS_TIMEOUT,
+    )
+    .await
+}
+
+pub async fn run_enrollment_acceptor_with_progress<R, W, F>(
+    recv: &mut R,
+    send: &mut W,
+    conn: &Connection,
+    authenticated_remote_node: [u8; 32],
+    now_ms: F,
+    progress: Duration,
+) -> Result<EnrollmentAcceptorOutcome, InviteError>
+where
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+    F: Fn() -> i64,
+{
+    // The request and a refusal are reachable by ANY peer (a random nonce gets both): read and
+    // write them under the tighter unauthenticated window so a bogus peer's hold on the serial
+    // accept loop stays in seconds. The enrolled receipt — gated on a valid nonce — gets the
+    // full progress window.
+    let unauth = progress.min(ENROLL_UNAUTH_PROGRESS_TIMEOUT);
+    let request = EnrollmentRequest::decode(
+        &read_blob(recv, MAX_ENROLL_REQUEST_FRAME, "request", unauth).await?,
+    )?;
+    // Evaluate expiry only after the complete peer-controlled request arrives. A timestamp read
+    // before this await would let a peer hold the stream open past expiry and still redeem.
+    match redeem_invite(conn, request, authenticated_remote_node, &now_ms) {
+        Ok((receipt, catch_up)) => {
+            write_blob(
+                send,
+                &EnrollmentResponse::Enrolled(receipt.clone()).encode(),
+                MAX_ENROLL_RESPONSE_FRAME,
+                "response",
+                progress,
+            )
+            .await?;
+            Ok(EnrollmentAcceptorOutcome::Enrolled(receipt, catch_up))
+        },
+        Err(error) if refusal_code(&error).is_some() => {
+            let code = refusal_code(&error).expect("guarded above");
+            write_blob(
+                send,
+                &EnrollmentResponse::Refused(code).encode(),
+                MAX_ENROLL_RESPONSE_FRAME,
+                "response",
+                unauth,
+            )
+            .await?;
+            Ok(EnrollmentAcceptorOutcome::Refused(error))
+        },
+        Err(error) => Err(error),
+    }
+}
+
+pub async fn run_enrollment_dialer<R, W>(
+    recv: &mut R,
+    send: &mut W,
+    expected_account: AccountId,
+    request: &EnrollmentRequest,
+) -> Result<EnrollmentReceipt, InviteError>
+where
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    run_enrollment_dialer_with_progress(
+        recv,
+        send,
+        expected_account,
+        request,
+        ENROLL_PROGRESS_TIMEOUT,
+    )
+    .await
+}
+
+pub async fn run_enrollment_dialer_with_progress<R, W>(
+    recv: &mut R,
+    send: &mut W,
+    expected_account: AccountId,
+    request: &EnrollmentRequest,
+    progress: Duration,
+) -> Result<EnrollmentReceipt, InviteError>
+where
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    if request.expected_account != expected_account {
+        return Err(InviteError::AccountMismatch);
+    }
+    write_blob(send, &request.encode(), MAX_ENROLL_REQUEST_FRAME, "request", progress).await?;
+    let response = EnrollmentResponse::decode(
+        &read_blob(recv, MAX_ENROLL_RESPONSE_FRAME, "response", progress).await?,
+    )?;
+    // Ack the response BEFORE any post-processing (verification, adoption): the byte tells the
+    // acceptor the response reached the application, so it can close immediately instead of
+    // waiting on us to finish local work and tear down.
+    let ack_window = progress.min(RESPONSE_ACK_TIMEOUT);
+    if write_within(send, &[RESPONSE_ACK], ack_window).await.is_ok() {
+        let _ = flush_within(send, ack_window).await;
+    }
+    match response {
+        EnrollmentResponse::Enrolled(receipt) => {
+            verify_enrollment_device_add(
+                &receipt.account_entries,
+                expected_account,
+                receipt.device_add_hash,
+                &receipt.device_add_signed,
+                request.ed25519_pubkey,
+                request.x25519_pubkey,
+            )
+            .map_err(|error| {
+                InviteError::Malformed(format!("invalid enrollment receipt: {error}"))
+            })?;
+            Ok(receipt)
+        },
+        EnrollmentResponse::Refused(code) => Err(code.into_error()),
+    }
+}
+
+fn refusal_code(error: &InviteError) -> Option<RefusalCode> {
+    match error {
+        InviteError::Expired => Some(RefusalCode::Expired),
+        InviteError::Used => Some(RefusalCode::Used),
+        InviteError::Unknown => Some(RefusalCode::Unknown),
+        InviteError::WrongNode => Some(RefusalCode::WrongNode),
+        InviteError::AccountMismatch => Some(RefusalCode::AccountMismatch),
+        InviteError::Revoked => Some(RefusalCode::Revoked),
+        InviteError::JoinerCapacity => Some(RefusalCode::JoinerCapacity),
+        InviteError::HeldStateConflict => Some(RefusalCode::HeldStateConflict),
+        InviteError::Malformed(_) | InviteError::Storage(_) | InviteError::Io(_) => None,
+    }
+}
+
+async fn write_blob<W: AsyncWrite + Unpin>(
+    send: &mut W,
+    body: &[u8],
+    max_len: u32,
+    frame_name: &str,
+    progress: Duration,
+) -> Result<(), InviteError> {
+    let len = ensure_frame_len(body.len(), max_len, frame_name)?;
+    write_within(send, &len.to_be_bytes(), progress).await?;
+    // Chunked so each slice gets its own progress window: a slow-reading peer back-pressures
+    // `write_all`, and a monolithic write would turn the whole-exchange deadline into a
+    // total-transfer deadline the peer controls.
+    for chunk in body.chunks(ENROLL_PROGRESS_CHUNK_BYTES) {
+        write_within(send, chunk, progress).await?;
+    }
+    flush_within(send, progress).await?;
+    Ok(())
+}
+
+async fn flush_within<W: AsyncWrite + Unpin>(
+    send: &mut W,
+    window: Duration,
+) -> Result<(), InviteError> {
+    tokio::time::timeout(window, send.flush()).await.map_err(|_| {
+        InviteError::Io(std::io::Error::new(
+            std::io::ErrorKind::TimedOut,
+            "enrollment frame flush stalled",
+        ))
+    })??;
+    Ok(())
+}
+
+async fn write_within<W: AsyncWrite + Unpin>(
+    send: &mut W,
+    bytes: &[u8],
+    window: Duration,
+) -> Result<(), InviteError> {
+    tokio::time::timeout(window, send.write_all(bytes)).await.map_err(|_| {
+        InviteError::Io(std::io::Error::new(
+            std::io::ErrorKind::TimedOut,
+            "enrollment frame write stalled",
+        ))
+    })??;
+    Ok(())
+}
+
+fn ensure_frame_len(len: usize, max_len: u32, frame_name: &str) -> Result<u32, InviteError> {
+    let len = u32::try_from(len)
+        .map_err(|_| InviteError::Malformed("enrollment frame length overflows u32".into()))?;
+    if len > max_len {
+        return Err(InviteError::Malformed(format!(
+            "enrollment {frame_name} frame exceeds {max_len} bytes"
+        )));
+    }
+    Ok(len)
+}
+
+async fn read_blob<R: AsyncRead + Unpin>(
+    recv: &mut R,
+    max_len: u32,
+    frame_name: &str,
+    progress: Duration,
+) -> Result<Vec<u8>, InviteError> {
+    let mut prefix = [0u8; 4];
+    read_within(recv, &mut prefix, progress).await?;
+    let len = u32::from_be_bytes(prefix);
+    if len > max_len {
+        return Err(InviteError::Malformed(format!(
+            "enrollment {frame_name} frame exceeds {max_len} bytes"
+        )));
+    }
+    let mut body = vec![0; len as usize];
+    for chunk in body.chunks_mut(ENROLL_PROGRESS_CHUNK_BYTES) {
+        read_within(recv, chunk, progress).await?;
+    }
+    Ok(body)
+}
+
+async fn read_within<R: AsyncRead + Unpin>(
+    recv: &mut R,
+    buf: &mut [u8],
+    window: Duration,
+) -> Result<(), InviteError> {
+    tokio::time::timeout(window, recv.read_exact(buf)).await.map_err(|_| {
+        InviteError::Io(std::io::Error::new(
+            std::io::ErrorKind::TimedOut,
+            "enrollment frame read stalled",
+        ))
+    })??;
+    Ok(())
+}
+
+fn exact_array(dec: &mut Decoder<'_>, expected: u64, name: &str) -> Result<(), InviteError> {
+    if dec.array().map_err(decode)? != Some(expected) {
+        return Err(InviteError::Malformed(format!("{name} arity")));
+    }
+    Ok(())
+}
+
+fn exact_str(dec: &mut Decoder<'_>, expected: &str, name: &str) -> Result<(), InviteError> {
+    if dec.str().map_err(decode)? != expected {
+        return Err(InviteError::Malformed(format!("{name} mismatch")));
+    }
+    Ok(())
+}
+
+fn fixed32(bytes: &[u8], name: &str) -> Result<[u8; 32], InviteError> {
+    bytes.try_into().map_err(|_| InviteError::Malformed(format!("{name} must be 32 bytes")))
+}
+
+fn ensure_consumed(dec: &Decoder<'_>, bytes: &[u8]) -> Result<(), InviteError> {
+    if dec.position() != bytes.len() {
+        return Err(InviteError::Malformed("trailing bytes".into()));
+    }
+    Ok(())
+}
+
+fn decode(error: minicbor::decode::Error) -> InviteError {
+    InviteError::Malformed(error.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::pin::Pin;
+    use std::sync::atomic::{AtomicI64, Ordering};
+    use std::sync::{Arc, Barrier};
+    use std::task::{Context, Poll};
+
+    use super::*;
+
+    const NOW: i64 = 1_700_000_000_000;
+
+    struct StallAfterBytes {
+        remaining: usize,
+    }
+
+    impl AsyncWrite for StallAfterBytes {
+        fn poll_write(
+            mut self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            bytes: &[u8],
+        ) -> Poll<std::io::Result<usize>> {
+            if self.remaining == 0 {
+                return Poll::Pending;
+            }
+            let written = self.remaining.min(bytes.len());
+            self.remaining -= written;
+            Poll::Ready(Ok(written))
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    fn db() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        rag_rat_db::schema::apply(&conn, &rag_rat_db::MigrationHooks::noop()).unwrap();
+        conn
+    }
+
+    fn joiner_keys() -> ([u8; 32], [u8; 32]) {
+        let conn = db();
+        rag_rat_oplog::local_account(&conn, NOW).unwrap();
+        conn.query_row(
+            "SELECT public_key, x25519_public FROM oplog_device_identity WHERE id = 0",
+            [],
+            |row| {
+                let ed: Vec<u8> = row.get(0)?;
+                let x: Vec<u8> = row.get(1)?;
+                Ok((ed.try_into().unwrap(), x.try_into().unwrap()))
+            },
+        )
+        .unwrap()
+    }
+
+    fn ticket(conn: &Connection, account: AccountId, role: DeviceRole) -> EnrollmentTicket {
+        mint_invite(conn, InviteSpec {
+            account_id: account,
+            inviter_node_id: crate::endpoint::node_id_from_secret([2; 32]),
+            relay_url: "https://relay.example".into(),
+            role,
+            label: Some("laptop"),
+            now_ms: &|| NOW,
+            ttl: Duration::from_secs(60),
+        })
+        .unwrap()
+    }
+
+    fn invalid_endpoint_id() -> [u8; 32] {
+        (0u64..1_000)
+            .map(|ordinal| Sha256::digest(ordinal.to_be_bytes()).into())
+            .find(|bytes| EndpointId::from_bytes(bytes).is_err())
+            .expect("random-looking bytes include an invalid compressed Edwards point")
+    }
+
+    /// A budget no honest redemption can exceed, for tests that are not exercising the capacity
+    /// check.
+    fn generous_budget() -> EnrollmentBudget {
+        EnrollmentBudget {
+            account_entries_remaining: u64::MAX,
+            account_bytes_remaining: u64::MAX,
+            global_entries_remaining: u64::MAX,
+            global_bytes_remaining: u64::MAX,
+        }
+    }
+
+    #[test]
+    fn request_is_canonical_and_exactly_bound() {
+        let (ed25519_pubkey, x25519_pubkey) = joiner_keys();
+        let request = EnrollmentRequest {
+            nonce: [7; 32],
+            expected_account: AccountId::from_bytes([8; 32]),
+            ed25519_pubkey,
+            x25519_pubkey,
+            transport_node_id: [9; 32],
+            budget: EnrollmentBudget {
+                account_entries_remaining: 10,
+                account_bytes_remaining: 20,
+                global_entries_remaining: 30,
+                global_bytes_remaining: 40,
+            },
+            held_entry_hashes: vec![[3; 32], [4; 32]],
+        };
+        let bytes = request.encode();
+        assert!(
+            bytes.len() <= MAX_ENROLL_REQUEST_FRAME as usize,
+            "the request still fits the unauthenticated frame cap"
+        );
+        assert_eq!(EnrollmentRequest::decode(&bytes).unwrap(), request);
+
+        let mut trailing = bytes.clone();
+        trailing.push(0);
+        assert!(matches!(EnrollmentRequest::decode(&trailing), Err(InviteError::Malformed(_))));
+        // A non-minimal u64 in the budget fails the canonical re-encode check.
+        let mut non_minimal = bytes.clone();
+        non_minimal.truncate(bytes.len() - 2); // drop the final u8-form u64 (0x18 60)
+        non_minimal.push(0x1b); // and re-encode the same value in the 8-byte form
+        non_minimal.extend_from_slice(&60u64.to_be_bytes());
+        assert!(matches!(EnrollmentRequest::decode(&non_minimal), Err(InviteError::Malformed(_))));
+
+        let hashes = (0..ENROLLMENT_HELD_ENTRY_HASHES_MAX)
+            .map(|ordinal| {
+                let mut hash = [0u8; 32];
+                hash[24..].copy_from_slice(&(ordinal as u64).to_be_bytes());
+                hash
+            })
+            .collect::<Vec<_>>();
+        let maximal = EnrollmentRequest { held_entry_hashes: hashes, ..request.clone() };
+        let maximal_bytes = maximal.encode();
+        assert!(maximal_bytes.len() <= MAX_ENROLL_REQUEST_FRAME as usize);
+        assert_eq!(EnrollmentRequest::decode(&maximal_bytes).unwrap(), maximal);
+
+        let mut unsorted = request.clone();
+        unsorted.held_entry_hashes = vec![[2; 32], [1; 32]];
+        assert!(matches!(
+            EnrollmentRequest::decode(&unsorted.encode()),
+            Err(InviteError::Malformed(_))
+        ));
+        let mut duplicate = request;
+        duplicate.held_entry_hashes = vec![[2; 32], [2; 32]];
+        assert!(matches!(
+            EnrollmentRequest::decode(&duplicate.encode()),
+            Err(InviteError::Malformed(_))
+        ));
+    }
+
+    #[test]
+    fn ticket_is_canonical_and_exactly_bound() {
+        let conn = db();
+        let account = rag_rat_oplog::local_account(&conn, NOW).unwrap();
+        let ticket = ticket(&conn, account, DeviceRole::ReadOnly);
+        let bytes = ticket.encode();
+        assert_eq!(EnrollmentTicket::decode(&bytes).unwrap(), ticket);
+
+        let mut trailing = bytes;
+        trailing.push(0);
+        assert!(matches!(EnrollmentTicket::decode(&trailing), Err(InviteError::Malformed(_))));
+
+        let invalid_node =
+            EnrollmentTicket { inviter_node_id: invalid_endpoint_id(), ..ticket.clone() };
+        assert!(matches!(
+            EnrollmentTicket::decode(&invalid_node.encode()),
+            Err(InviteError::Malformed(message)) if message.contains("node id")
+        ));
+        let invalid_relay = EnrollmentTicket { relay_url: "not a relay URL".into(), ..ticket };
+        assert!(matches!(
+            EnrollmentTicket::decode(&invalid_relay.encode()),
+            Err(InviteError::Malformed(message)) if message.contains("relay URL")
+        ));
+    }
+
+    #[test]
+    fn mint_requires_live_founder_authority_and_leaves_no_invite_on_failure() {
+        let conn = db();
+        let account = rag_rat_oplog::local_account(&conn, NOW).unwrap();
+        conn.execute(
+            "UPDATE account_owner_incarnations
+                SET closed_at = ?2,
+                    control_boundary = 'closed',
+                    control_seq = NULL,
+                    control_hash = NULL
+              WHERE account_id = ?1",
+            params![account.to_bytes().as_slice(), NOW + 1],
+        )
+        .unwrap();
+        conn.execute(
+            "UPDATE account_roster_history
+                SET closed_at = ?2,
+                    control_boundary = 'closed',
+                    control_seq = NULL,
+                    control_hash = NULL
+              WHERE account_id = ?1",
+            params![account.to_bytes().as_slice(), NOW + 1],
+        )
+        .unwrap();
+
+        let result = mint_invite(&conn, InviteSpec {
+            account_id: account,
+            inviter_node_id: crate::endpoint::node_id_from_secret([2; 32]),
+            relay_url: "https://relay.example".into(),
+            role: DeviceRole::Member,
+            label: Some("laptop"),
+            now_ms: &|| NOW + 2,
+            ttl: Duration::from_secs(60),
+        });
+
+        assert!(matches!(result, Err(InviteError::Storage(_))));
+        let invites: i64 =
+            conn.query_row("SELECT COUNT(*) FROM sync_invites", [], |row| row.get(0)).unwrap();
+        assert_eq!(invites, 0, "a device unable to redeem must not distribute an invite");
+        let synchronous: i64 =
+            conn.pragma_query_value(None, "synchronous", |row| row.get(0)).unwrap();
+        assert_eq!(synchronous, 1, "the authored-durability guard restores NORMAL");
+    }
+
+    #[test]
+    fn mint_rejects_founder_authority_bounded_by_a_cut() {
+        let conn = db();
+        let account = rag_rat_oplog::local_account(&conn, NOW).unwrap();
+        let genesis_hash: Vec<u8> = conn
+            .query_row(
+                "SELECT genesis_entry_hash FROM oplog_local_account WHERE id = 0",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        conn.execute(
+            "UPDATE account_roster_history
+                SET control_boundary = 'cut',
+                    control_seq = ?2,
+                    control_hash = ?3
+              WHERE account_id = ?1",
+            params![account.to_bytes().as_slice(), 0_u64.to_be_bytes().as_slice(), genesis_hash,],
+        )
+        .unwrap();
+
+        let result = mint_invite(&conn, InviteSpec {
+            account_id: account,
+            inviter_node_id: crate::endpoint::node_id_from_secret([2; 32]),
+            relay_url: "https://relay.example".into(),
+            role: DeviceRole::Member,
+            label: Some("laptop"),
+            now_ms: &|| NOW + 1,
+            ttl: Duration::from_secs(60),
+        });
+
+        assert!(matches!(result, Err(InviteError::Storage(_))));
+        let invites: i64 =
+            conn.query_row("SELECT COUNT(*) FROM sync_invites", [], |row| row.get(0)).unwrap();
+        assert_eq!(invites, 0, "bounded founder authority must not mint an invite");
+    }
+
+    #[test]
+    fn mint_rejects_an_unauthorable_label_before_persisting_the_nonce() {
+        let conn = db();
+        let account = rag_rat_oplog::local_account(&conn, NOW).unwrap();
+        let label = "x".repeat(64 * 1024);
+
+        let result = mint_invite(&conn, InviteSpec {
+            account_id: account,
+            inviter_node_id: crate::endpoint::node_id_from_secret([2; 32]),
+            relay_url: "https://relay.example".into(),
+            role: DeviceRole::Member,
+            label: Some(&label),
+            now_ms: &|| NOW,
+            ttl: Duration::from_secs(60),
+        });
+
+        assert!(matches!(result, Err(InviteError::Malformed(_))));
+        let invites: i64 =
+            conn.query_row("SELECT COUNT(*) FROM sync_invites", [], |row| row.get(0)).unwrap();
+        assert_eq!(invites, 0, "an unusable invite must never cross the mint boundary");
+    }
+
+    #[test]
+    fn mint_rejects_an_unparseable_relay_url_before_persisting_the_nonce() {
+        let conn = db();
+        let account = rag_rat_oplog::local_account(&conn, NOW).unwrap();
+        let result = mint_invite(&conn, InviteSpec {
+            account_id: account,
+            inviter_node_id: crate::endpoint::node_id_from_secret([2; 32]),
+            relay_url: "not a relay URL".into(),
+            role: DeviceRole::Member,
+            label: None,
+            now_ms: &|| NOW,
+            ttl: Duration::from_secs(60),
+        });
+        assert!(matches!(result, Err(InviteError::Malformed(_))));
+        let invites: i64 =
+            conn.query_row("SELECT COUNT(*) FROM sync_invites", [], |row| row.get(0)).unwrap();
+        assert_eq!(invites, 0);
+    }
+
+    #[test]
+    fn mint_rejects_an_invalid_inviter_node_before_persisting_the_nonce() {
+        let conn = db();
+        let account = rag_rat_oplog::local_account(&conn, NOW).unwrap();
+        let result = mint_invite(&conn, InviteSpec {
+            account_id: account,
+            inviter_node_id: invalid_endpoint_id(),
+            relay_url: "https://relay.example".into(),
+            role: DeviceRole::Member,
+            label: None,
+            now_ms: &|| NOW,
+            ttl: Duration::from_secs(60),
+        });
+        assert!(matches!(result, Err(InviteError::Malformed(_))));
+        let invites: i64 =
+            conn.query_row("SELECT COUNT(*) FROM sync_invites", [], |row| row.get(0)).unwrap();
+        assert_eq!(invites, 0, "an undialable node id must fail before invite persistence");
+    }
+
+    #[test]
+    fn mint_rejects_a_live_key_the_founder_cannot_recover() {
+        let conn = db();
+        let account = rag_rat_oplog::local_account(&conn, NOW).unwrap();
+        let tx = Transaction::new_unchecked(&conn, TransactionBehavior::Immediate).unwrap();
+        let stream =
+            rag_rat_oplog::ensure_owned_stream_v2_in_tx(&tx, "recovery-test", NOW).unwrap();
+        rag_rat_oplog::mint_and_author_stream_key_wrap_in_tx(&tx, stream, NOW).unwrap();
+        tx.commit().unwrap();
+
+        let other = db();
+        rag_rat_oplog::local_account(&other, NOW).unwrap();
+        let (secret, public): (Vec<u8>, Vec<u8>) = other
+            .query_row(
+                "SELECT x25519_secret, x25519_public FROM oplog_device_identity WHERE id = 0",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        conn.execute(
+            "UPDATE oplog_device_identity SET x25519_secret = ?1, x25519_public = ?2 WHERE id = 0",
+            params![secret, public],
+        )
+        .unwrap();
+
+        let result = mint_invite(&conn, InviteSpec {
+            account_id: account,
+            inviter_node_id: crate::endpoint::node_id_from_secret([2; 32]),
+            relay_url: "https://relay.example".into(),
+            role: DeviceRole::Member,
+            label: None,
+            now_ms: &|| NOW + 1,
+            ttl: Duration::from_secs(60),
+        });
+        assert!(matches!(result, Err(InviteError::Storage(_))));
+        let invites: i64 =
+            conn.query_row("SELECT COUNT(*) FROM sync_invites", [], |row| row.get(0)).unwrap();
+        assert_eq!(invites, 0, "an unrecoverable live key must gate invite issuance");
+    }
+
+    #[test]
+    fn mint_refuses_a_ttl_that_is_already_expired() {
+        let conn = db();
+        let account = rag_rat_oplog::local_account(&conn, NOW).unwrap();
+        for ttl in [Duration::ZERO, Duration::from_nanos(999_999)] {
+            let result = mint_invite(&conn, InviteSpec {
+                account_id: account,
+                inviter_node_id: crate::endpoint::node_id_from_secret([2; 32]),
+                relay_url: "https://relay.example".into(),
+                role: DeviceRole::Member,
+                label: None,
+                now_ms: &|| NOW,
+                ttl,
+            });
+            assert!(
+                matches!(result, Err(InviteError::Malformed(_))),
+                "a {ttl:?} TTL mints a ticket redemption always rejects as expired"
+            );
+        }
+        let invites: i64 =
+            conn.query_row("SELECT COUNT(*) FROM sync_invites", [], |row| row.get(0)).unwrap();
+        assert_eq!(invites, 0, "an unusable invite must never cross the mint boundary");
+    }
+
+    #[test]
+    fn every_budget_scope_gates_the_consume() {
+        let conn = db();
+        let account = rag_rat_oplog::local_account(&conn, NOW).unwrap();
+        type BudgetScope = (&'static str, fn(&mut EnrollmentBudget));
+        let scopes: [BudgetScope; 4] = [
+            ("account_entries_remaining", |budget| budget.account_entries_remaining = 0),
+            ("account_bytes_remaining", |budget| budget.account_bytes_remaining = 0),
+            ("global_entries_remaining", |budget| budget.global_entries_remaining = 0),
+            ("global_bytes_remaining", |budget| budget.global_bytes_remaining = 0),
+        ];
+        for (name, zero) in scopes {
+            let ticket = ticket(&conn, account, DeviceRole::Member);
+            let (ed25519_pubkey, x25519_pubkey) = joiner_keys();
+            let mut budget = generous_budget();
+            zero(&mut budget);
+            let request = EnrollmentRequest {
+                nonce: ticket.nonce,
+                expected_account: account,
+                ed25519_pubkey,
+                x25519_pubkey,
+                transport_node_id: [9; 32],
+                budget,
+                held_entry_hashes: Vec::new(),
+            };
+            assert!(
+                matches!(
+                    redeem_invite(&conn, request, [9; 32], &|| NOW + 1),
+                    Err(InviteError::JoinerCapacity)
+                ),
+                "zeroing {name} must refuse"
+            );
+            let used: Option<i64> = conn
+                .query_row(
+                    "SELECT used_at_ms FROM sync_invites WHERE nonce = ?1",
+                    [ticket.nonce.as_slice()],
+                    |row| row.get(0),
+                )
+                .unwrap();
+            assert_eq!(used, None, "the {name} refusal must not consume the nonce");
+        }
+    }
+
+    #[test]
+    fn redemption_charges_only_receipt_entries_the_joiner_does_not_hold() {
+        let conn = db();
+        let account = rag_rat_oplog::local_account(&conn, NOW).unwrap();
+        // Enroll one device so the next receipt carries genesis + AddB + AddJoiner.
+        let first_ticket = ticket(&conn, account, DeviceRole::Member);
+        let (first_ed, first_x) = joiner_keys();
+        let first = EnrollmentRequest {
+            nonce: first_ticket.nonce,
+            expected_account: account,
+            ed25519_pubkey: first_ed,
+            x25519_pubkey: first_x,
+            transport_node_id: [8; 32],
+            budget: generous_budget(),
+            held_entry_hashes: Vec::new(),
+        };
+        let _ = redeem_invite(&conn, first, [8; 32], &|| NOW + 1).unwrap();
+
+        // The joiner proves it already holds every prior entry (genesis + AddB): only the new
+        // DeviceAdd is charged, so a one-entry budget fits.
+        let prior = rag_rat_oplog::account_entries_for_sync(&conn, account).unwrap();
+        assert_eq!(prior.len(), 2, "genesis plus the first DeviceAdd");
+        let mut held = vec![prior[0].entry_hash, prior[1].entry_hash];
+        held.sort_unstable();
+        let second_ticket = ticket(&conn, account, DeviceRole::Member);
+        let (ed25519_pubkey, x25519_pubkey) = joiner_keys();
+        let request = EnrollmentRequest {
+            nonce: second_ticket.nonce,
+            expected_account: account,
+            ed25519_pubkey,
+            x25519_pubkey,
+            transport_node_id: [9; 32],
+            budget: EnrollmentBudget { account_entries_remaining: 1, ..generous_budget() },
+            held_entry_hashes: held.clone(),
+        };
+        let _ = redeem_invite(&conn, request.clone(), [9; 32], &|| NOW + 2).unwrap();
+    }
+
+    #[test]
+    fn redemption_preserves_the_nonce_when_the_receipt_exceeds_the_declared_budget() {
+        let conn = db();
+        let account = rag_rat_oplog::local_account(&conn, NOW).unwrap();
+        // Enroll one device so the next receipt carries history beyond genesis + its DeviceAdd.
+        let first_ticket = ticket(&conn, account, DeviceRole::Member);
+        let (first_ed, first_x) = joiner_keys();
+        let first = EnrollmentRequest {
+            nonce: first_ticket.nonce,
+            expected_account: account,
+            ed25519_pubkey: first_ed,
+            x25519_pubkey: first_x,
+            transport_node_id: [8; 32],
+            budget: generous_budget(),
+            held_entry_hashes: Vec::new(),
+        };
+        let _ = redeem_invite(&conn, first, [8; 32], &|| NOW + 1).unwrap();
+
+        let second_ticket = ticket(&conn, account, DeviceRole::Member);
+        let (ed25519_pubkey, x25519_pubkey) = joiner_keys();
+        let mut request = EnrollmentRequest {
+            nonce: second_ticket.nonce,
+            expected_account: account,
+            ed25519_pubkey,
+            x25519_pubkey,
+            transport_node_id: [9; 32],
+            budget: generous_budget(),
+            held_entry_hashes: Vec::new(),
+        };
+        // The receipt is genesis + two DeviceAdds; a budget for only two entries cannot hold it.
+        request.budget.account_entries_remaining = 2;
+        assert!(matches!(
+            redeem_invite(&conn, request.clone(), [9; 32], &|| NOW + 2),
+            Err(InviteError::JoinerCapacity)
+        ));
+        let used: Option<i64> = conn
+            .query_row(
+                "SELECT used_at_ms FROM sync_invites WHERE nonce = ?1",
+                [second_ticket.nonce.as_slice()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(used, None, "a capacity refusal must not consume the nonce");
+        // The same invite redeems once the joiner declares honest headroom.
+        request.budget = generous_budget();
+        let _ = redeem_invite(&conn, request, [9; 32], &|| NOW + 3).unwrap();
+    }
+
+    #[test]
+    fn mint_reserves_and_redemption_releases_the_mandatory_candidate_capacity() {
+        let conn = db();
+        let account = rag_rat_oplog::local_account(&conn, NOW).unwrap();
+        let ticket = ticket(&conn, account, DeviceRole::Member);
+        let (reserved_entries, reserved_bytes): (i64, i64) = conn
+            .query_row(
+                "SELECT reserved_entries, reserved_bytes
+                   FROM account_candidate_reservations WHERE reservation_id = ?1",
+                [ticket.nonce.as_slice()],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .expect("minting persists a reservation for the mandatory redemption entries");
+        assert!(reserved_entries >= 1, "the DeviceAdd itself must be reserved");
+        assert!(reserved_bytes > 0, "the reserved entries must carry their byte cost");
+
+        let (ed25519_pubkey, x25519_pubkey) = joiner_keys();
+        let request = EnrollmentRequest {
+            nonce: ticket.nonce,
+            expected_account: account,
+            ed25519_pubkey,
+            x25519_pubkey,
+            transport_node_id: [9; 32],
+            budget: generous_budget(),
+            held_entry_hashes: Vec::new(),
+        };
+        let _ = redeem_invite(&conn, request, [9; 32], &|| NOW + 1).unwrap();
+        let rows: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM account_candidate_reservations WHERE reservation_id = ?1",
+                [ticket.nonce.as_slice()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(rows, 0, "redemption releases its own reservation under the writer lock");
+    }
+
+    #[test]
+    fn an_outstanding_invite_reservation_gates_the_next_mint_until_expiry() {
+        let conn = db();
+        let account = rag_rat_oplog::local_account(&conn, NOW).unwrap();
+        // Simulate an already-minted invite whose reservation consumes the whole per-account
+        // candidate budget: the next mint must refuse rather than distribute a ticket the first
+        // redemption would strand.
+        let tx = Transaction::new_unchecked(&conn, TransactionBehavior::Immediate).unwrap();
+        rag_rat_oplog::upsert_account_candidate_reservation_in_tx(
+            &tx,
+            account,
+            [0x77; 32],
+            4_096,
+            0,
+            0,
+            NOW + 1_000,
+        )
+        .unwrap();
+        tx.commit().unwrap();
+
+        let spec = |now_ms: &'static dyn Fn() -> i64| InviteSpec {
+            account_id: account,
+            inviter_node_id: crate::endpoint::node_id_from_secret([2; 32]),
+            relay_url: "https://relay.example".into(),
+            role: DeviceRole::Member,
+            label: None,
+            now_ms,
+            ttl: Duration::from_secs(60),
+        };
+        assert!(matches!(mint_invite(&conn, spec(&|| NOW)), Err(InviteError::Storage(_))));
+        let invites: i64 =
+            conn.query_row("SELECT COUNT(*) FROM sync_invites", [], |row| row.get(0)).unwrap();
+        assert_eq!(invites, 0, "no second invite may be minted against reserved capacity");
+        // After the outstanding reservation expires, minting prunes it and succeeds.
+        let _ = mint_invite(&conn, spec(&|| NOW + 1_001)).expect("expiry frees the reservation");
+    }
+
+    #[test]
+    fn mint_reads_the_clock_once_after_acquiring_the_writer_lock() {
+        let conn = db();
+        let account = rag_rat_oplog::local_account(&conn, NOW).unwrap();
+        let clock_reads = AtomicI64::new(0);
+        let ticket = mint_invite(&conn, InviteSpec {
+            account_id: account,
+            inviter_node_id: crate::endpoint::node_id_from_secret([2; 32]),
+            relay_url: "https://relay.example".into(),
+            role: DeviceRole::Member,
+            label: None,
+            now_ms: &|| NOW + clock_reads.fetch_add(1, Ordering::SeqCst),
+            ttl: Duration::from_secs(60),
+        })
+        .unwrap();
+        assert_eq!(
+            clock_reads.load(Ordering::SeqCst),
+            1,
+            "one post-lock read: a pre-lock timestamp cannot mint an already-expired ticket"
+        );
+        let created_at_ms: i64 = conn
+            .query_row(
+                "SELECT created_at_ms FROM sync_invites WHERE nonce = ?1",
+                [ticket.nonce.as_slice()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(ticket.expires_at_ms, created_at_ms + 60_000);
+    }
+
+    #[test]
+    fn new_mandatory_key_targets_grow_an_outstanding_invites_reservation() {
+        let conn = db();
+        let account = rag_rat_oplog::local_account(&conn, NOW).unwrap();
+        let ticket = ticket(&conn, account, DeviceRole::Member);
+        let reservation_of = |nonce: [u8; 32]| {
+            conn.query_row(
+                "SELECT reserved_entries, reserved_bytes
+                   FROM account_candidate_reservations WHERE reservation_id = ?1",
+                [nonce.as_slice()],
+                |row| Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?)),
+            )
+            .unwrap()
+        };
+        let (entries0, bytes0) = reservation_of(ticket.nonce);
+        assert_eq!(entries0, 1, "no live keys yet: only the DeviceAdd is reserved");
+
+        // Authoring a new live key target grows the outstanding invite's reservation in the same
+        // transaction, so ordinary candidate writes cannot consume the headroom redemption will
+        // need for the catch-up wrap.
+        let tx = Transaction::new_unchecked(&conn, TransactionBehavior::Immediate).unwrap();
+        let stream = rag_rat_oplog::ensure_owned_stream_v2_in_tx(&tx, "repo-a", NOW + 1).unwrap();
+        rag_rat_oplog::mint_and_author_stream_key_wrap_in_tx(&tx, stream, NOW + 1).unwrap();
+        tx.commit().unwrap();
+        let (entries1, bytes1) = reservation_of(ticket.nonce);
+        assert_eq!(entries1, entries0 + 1, "one new live key target is one reserved wrap");
+        assert!(bytes1 > bytes0, "the reserved wrap carries its byte cost");
+
+        // Redemption re-measures the CURRENT requirement and succeeds against the grown
+        // reservation, delivering the post-mint key's wrap to the joiner.
+        let (ed25519_pubkey, x25519_pubkey) = joiner_keys();
+        let request = EnrollmentRequest {
+            nonce: ticket.nonce,
+            expected_account: account,
+            ed25519_pubkey,
+            x25519_pubkey,
+            transport_node_id: [9; 32],
+            budget: generous_budget(),
+            held_entry_hashes: Vec::new(),
+        };
+        let (_, catch_up) = redeem_invite(&conn, request, [9; 32], &|| NOW + 2).unwrap();
+        assert_eq!(catch_up.authored.len(), 1, "the post-mint key is wrapped for the joiner");
+    }
+
+    #[test]
+    fn synced_key_target_growth_tops_up_the_outstanding_reservation() {
+        // Another device of the same account authors a StreamOwn + key; the entries arrive here
+        // through ordinary (untrusted) account sync. The fold-time top-up must grow the
+        // outstanding invite's reservation to cover the new mandatory catch-up wrap — the local
+        // authoring hooks never see this transition.
+        // Enroll this store's device so it holds a roster wrap recipient: key recovery targets
+        // are measured for the local device, exactly as they are on a real inviter.
+        let inviter = db();
+        let account = rag_rat_oplog::local_account(&inviter, NOW).unwrap();
+        let conn = db();
+        let _ = rag_rat_oplog::local_device(&conn, NOW).unwrap();
+        let (ed25519_pubkey, x25519_pubkey): ([u8; 32], [u8; 32]) = conn
+            .query_row(
+                "SELECT public_key, x25519_public FROM oplog_device_identity WHERE id = 0",
+                [],
+                |row| Ok((row.get::<_, Vec<u8>>(0)?, row.get::<_, Vec<u8>>(1)?)),
+            )
+            .map(|(ed, x)| (ed.try_into().unwrap(), x.try_into().unwrap()))
+            .unwrap();
+        let ticket = ticket(&inviter, account, DeviceRole::Member);
+        let request = EnrollmentRequest {
+            nonce: ticket.nonce,
+            expected_account: account,
+            ed25519_pubkey,
+            x25519_pubkey,
+            transport_node_id: [9; 32],
+            budget: generous_budget(),
+            held_entry_hashes: Vec::new(),
+        };
+        let (receipt, _) = redeem_invite(&inviter, request, [9; 32], &|| NOW + 1).unwrap();
+        let genesis_hash = rag_rat_oplog::verify_enrollment_device_add(
+            &receipt.account_entries,
+            account,
+            receipt.device_add_hash,
+            &receipt.device_add_signed,
+            ed25519_pubkey,
+            x25519_pubkey,
+        )
+        .unwrap();
+        let fingerprint = DeviceFingerprint::from_bytes(Sha256::digest(ed25519_pubkey).into());
+        rag_rat_oplog::adopt_enrollment_bootstrap(&conn, rag_rat_oplog::EnrollmentBootstrap {
+            account_entries: &receipt.account_entries,
+            account_id: account,
+            genesis_hash,
+            device_fingerprint: fingerprint,
+            device_add_hash: receipt.device_add_hash,
+            now_ms: NOW + 1,
+        })
+        .unwrap();
+
+        // The founder authors the new stream + key AFTER this device enrolled; the wrap names it.
+        let tx = Transaction::new_unchecked(&inviter, TransactionBehavior::Immediate).unwrap();
+        let stream = rag_rat_oplog::ensure_owned_stream_v2_in_tx(&tx, "repo-a", NOW + 2).unwrap();
+        rag_rat_oplog::mint_and_author_stream_key_wrap_in_tx(&tx, stream, NOW + 2).unwrap();
+        tx.commit().unwrap();
+        let entries = rag_rat_oplog::account_entries_for_sync(&inviter, account).unwrap();
+
+        // An outstanding invite on this store reserved only the DeviceAdd (no targets yet).
+        let tx = Transaction::new_unchecked(&conn, TransactionBehavior::Immediate).unwrap();
+        rag_rat_oplog::upsert_account_candidate_reservation_in_tx(
+            &tx,
+            account,
+            [0x88; 32],
+            1,
+            200,
+            0,
+            NOW + 10_000,
+        )
+        .unwrap();
+        tx.commit().unwrap();
+        // The StreamOwn + wrap arrive through ordinary untrusted account sync.
+        for entry in &entries {
+            let _ = rag_rat_oplog::account_ingest(&conn, &entry.signed_bytes, NOW + 2).unwrap();
+        }
+        let (reserved_entries, reserved_targets): (i64, i64) = conn
+            .query_row(
+                "SELECT reserved_entries, reserved_targets
+                   FROM account_candidate_reservations WHERE reservation_id = ?1",
+                [[0x88; 32].as_slice()],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(reserved_targets, 1, "the synced key target is now covered");
+        assert_eq!(reserved_entries, 2, "DeviceAdd plus the new mandatory wrap");
+
+        // A sealed /3 entry authored under the FIRST key, then a rotation to a second key: the
+        // accepted content pins the historical key as a live catch-up target only when the
+        // CONTENT settles — a path no account fold traverses (#949).
+        rag_rat_oplog::author_content_batch(
+            &inviter,
+            stream,
+            &[rag_rat_oplog::MemoryOp::NodeCreate {
+                node_id: rag_rat_oplog::NodeId::from("n1"),
+                content: rag_rat_oplog::NodeContent {
+                    kind: "Invariant".into(),
+                    title: "t".into(),
+                    body: "body".into(),
+                    confidence: "high".into(),
+                    source: "agent".into(),
+                    tags: Vec::new(),
+                    payload: None,
+                },
+            }],
+            rag_rat_oplog::SealPolicy::Sealed,
+            NOW + 3,
+        )
+        .unwrap();
+        let sealed = rag_rat_oplog::content_entries_for_sync(&inviter, account).unwrap();
+        let sealed = sealed.last().expect("one sealed content entry").signed_bytes.clone();
+        let tx = Transaction::new_unchecked(&inviter, TransactionBehavior::Immediate).unwrap();
+        rag_rat_oplog::rotate_stream_key_in_tx(&tx, stream, NOW + 4).unwrap();
+        tx.commit().unwrap();
+        // The rotation's wrap arrives by account sync; with no accepted content yet, the live
+        // set is still only the selected key.
+        for entry in rag_rat_oplog::account_entries_for_sync(&inviter, account).unwrap() {
+            let _ = rag_rat_oplog::account_ingest(&conn, &entry.signed_bytes, NOW + 4).unwrap();
+        }
+        let (_, targets_after_rotation): (i64, i64) = conn
+            .query_row(
+                "SELECT reserved_entries, reserved_targets
+                   FROM account_candidate_reservations WHERE reservation_id = ?1",
+                [[0x88; 32].as_slice()],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(targets_after_rotation, 1, "rotation alone does not pin the historical key");
+        // The sealed entry settles through content sync — acceptance pins the historical key and
+        // the reservation grows without any account fold.
+        rag_rat_oplog::content_ingest(&conn, &sealed, NOW + 5).unwrap();
+        rag_rat_oplog::settle_pending_content_refolds(
+            &conn,
+            &rag_rat_oplog::ContentRefoldBudget::unbounded(),
+            NOW + 5,
+        )
+        .unwrap();
+        let (entries_after_content, targets_after_content): (i64, i64) = conn
+            .query_row(
+                "SELECT reserved_entries, reserved_targets
+                   FROM account_candidate_reservations WHERE reservation_id = ?1",
+                [[0x88; 32].as_slice()],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(targets_after_content, 2, "settled content pins its sealing key as a target");
+        assert_eq!(entries_after_content, 3, "both live wraps are now reserved");
+    }
+
+    #[test]
+    fn replay_reconstructs_the_exact_acknowledged_receipt_from_the_manifest() {
+        let conn = db();
+        let account = rag_rat_oplog::local_account(&conn, NOW).unwrap();
+        let first_ticket = ticket(&conn, account, DeviceRole::Member);
+        let (first_ed, first_x) = joiner_keys();
+        let first = EnrollmentRequest {
+            nonce: first_ticket.nonce,
+            expected_account: account,
+            ed25519_pubkey: first_ed,
+            x25519_pubkey: first_x,
+            transport_node_id: [8; 32],
+            budget: generous_budget(),
+            held_entry_hashes: Vec::new(),
+        };
+        let (original, _) = redeem_invite(&conn, first.clone(), [8; 32], &|| NOW + 1).unwrap();
+
+        // A second enrollment advances the account snapshot AFTER the first receipt was stored.
+        let second_ticket = ticket(&conn, account, DeviceRole::Member);
+        let (second_ed, second_x) = joiner_keys();
+        let second = EnrollmentRequest {
+            nonce: second_ticket.nonce,
+            expected_account: account,
+            ed25519_pubkey: second_ed,
+            x25519_pubkey: second_x,
+            transport_node_id: [9; 32],
+            budget: generous_budget(),
+            held_entry_hashes: Vec::new(),
+        };
+        let _ = redeem_invite(&conn, second, [9; 32], &|| NOW + 2).unwrap();
+
+        // Replaying the first request reconstructs the EXACT acknowledged receipt from the hash
+        // manifest — never a superset the joiner's measured capacity might not fit, and never a
+        // second stored copy of the bootstrap bytes.
+        let (replayed, _) = redeem_invite(&conn, first, [8; 32], &|| NOW + 3).unwrap();
+        assert_eq!(replayed, original);
+        let duplicated: bool = conn
+            .query_row(
+                "SELECT receipt_bytes IS NOT NULL FROM sync_invites WHERE nonce = ?1",
+                [first_ticket.nonce.as_slice()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(!duplicated, "new redemptions persist only the DeviceAdd plus the hash manifest");
+
+        // The reconstructed receipt adopts cleanly on the original joiner.
+        let joiner_db = db();
+        let _ = rag_rat_oplog::local_device(&joiner_db, NOW).unwrap();
+        let genesis_hash = rag_rat_oplog::verify_enrollment_device_add(
+            &replayed.account_entries,
+            account,
+            replayed.device_add_hash,
+            &replayed.device_add_signed,
+            first_ed,
+            first_x,
+        )
+        .unwrap();
+        let fingerprint = DeviceFingerprint::from_bytes(Sha256::digest(first_ed).into());
+        rag_rat_oplog::adopt_enrollment_bootstrap(&joiner_db, rag_rat_oplog::EnrollmentBootstrap {
+            account_entries: &replayed.account_entries,
+            account_id: account,
+            genesis_hash,
+            device_fingerprint: fingerprint,
+            device_add_hash: replayed.device_add_hash,
+            now_ms: NOW + 3,
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn redemption_rejects_joiner_candidates_absent_from_the_owner_snapshot() {
+        let conn = db();
+        let account = rag_rat_oplog::local_account(&conn, NOW).unwrap();
+        let ticket = ticket(&conn, account, DeviceRole::Member);
+        let (ed25519_pubkey, x25519_pubkey) = joiner_keys();
+        // The joiner claims a candidate the owner's authenticated snapshot does not hold — a
+        // competing branch or a false claim. Adoption would refold the union, so redemption
+        // refuses BEFORE consuming the nonce (and before releasing the reservation).
+        let request = EnrollmentRequest {
+            nonce: ticket.nonce,
+            expected_account: account,
+            ed25519_pubkey,
+            x25519_pubkey,
+            transport_node_id: [9; 32],
+            budget: generous_budget(),
+            held_entry_hashes: vec![[0xee; 32]],
+        };
+        assert!(matches!(
+            redeem_invite(&conn, request, [9; 32], &|| NOW + 1),
+            Err(InviteError::HeldStateConflict)
+        ));
+        let unused: bool = conn
+            .query_row(
+                "SELECT used_at_ms IS NULL FROM sync_invites WHERE nonce = ?1",
+                [ticket.nonce.as_slice()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(unused, "an unreconciled held-state claim must not consume the nonce");
+        let reservation: bool = conn
+            .query_row(
+                "SELECT EXISTS(
+                     SELECT 1 FROM account_candidate_reservations WHERE reservation_id = ?1)",
+                [ticket.nonce.as_slice()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(reservation, "the rolled-back redemption restores the invite's reservation");
+    }
+
+    #[test]
+    fn a_replayed_receipt_ignores_the_declared_budget() {
+        let conn = db();
+        let account = rag_rat_oplog::local_account(&conn, NOW).unwrap();
+        let ticket = ticket(&conn, account, DeviceRole::Member);
+        let (ed25519_pubkey, x25519_pubkey) = joiner_keys();
+        let mut request = EnrollmentRequest {
+            nonce: ticket.nonce,
+            expected_account: account,
+            ed25519_pubkey,
+            x25519_pubkey,
+            transport_node_id: [9; 32],
+            budget: generous_budget(),
+            held_entry_hashes: Vec::new(),
+        };
+        let (receipt, _) = redeem_invite(&conn, request.clone(), [9; 32], &|| NOW + 1).unwrap();
+        // The retry declares zero headroom: replay returns the stored receipt regardless — the
+        // capacity check gates only the one-time consume.
+        request.budget = EnrollmentBudget {
+            account_entries_remaining: 0,
+            account_bytes_remaining: 0,
+            global_entries_remaining: 0,
+            global_bytes_remaining: 0,
+        };
+        let (replayed, _) = redeem_invite(&conn, request, [9; 32], &|| NOW + 2).unwrap();
+        assert_eq!(replayed, receipt);
+    }
+
+    #[tokio::test]
+    async fn joiner_capacity_refusal_travels_the_wire() {
+        let conn = db();
+        let account = rag_rat_oplog::local_account(&conn, NOW).unwrap();
+        let ticket = ticket(&conn, account, DeviceRole::Member);
+        let (ed25519_pubkey, x25519_pubkey) = joiner_keys();
+        let request = EnrollmentRequest {
+            nonce: ticket.nonce,
+            expected_account: account,
+            ed25519_pubkey,
+            x25519_pubkey,
+            transport_node_id: [9; 32],
+            budget: EnrollmentBudget { account_entries_remaining: 0, ..generous_budget() },
+            held_entry_hashes: Vec::new(),
+        };
+        let (mut dial_send, mut accept_recv) = tokio::io::duplex(4096);
+        let (mut accept_send, mut dial_recv) = tokio::io::duplex(4096);
+        let (dial, accept) = tokio::join!(
+            run_enrollment_dialer(&mut dial_recv, &mut dial_send, account, &request),
+            run_enrollment_acceptor(&mut accept_recv, &mut accept_send, &conn, [9; 32], || NOW + 1,),
+        );
+        assert!(matches!(dial, Err(InviteError::JoinerCapacity)));
+        assert!(matches!(
+            accept,
+            Ok(EnrollmentAcceptorOutcome::Refused(InviteError::JoinerCapacity))
+        ));
+    }
+
+    #[test]
+    fn replay_is_refused_once_the_enrolled_device_is_removed() {
+        let conn = db();
+        let account = rag_rat_oplog::local_account(&conn, NOW).unwrap();
+        let ticket = ticket(&conn, account, DeviceRole::ReadOnly);
+        let (ed25519_pubkey, x25519_pubkey) = joiner_keys();
+        let request = EnrollmentRequest {
+            nonce: ticket.nonce,
+            expected_account: account,
+            ed25519_pubkey,
+            x25519_pubkey,
+            transport_node_id: [9; 32],
+            budget: generous_budget(),
+            held_entry_hashes: Vec::new(),
+        };
+        let (receipt, _) = redeem_invite(&conn, request.clone(), [9; 32], &|| NOW + 1).unwrap();
+        // While the acknowledged DeviceAdd is roster-effective, the exact request replays.
+        let (replayed, _) = redeem_invite(&conn, request.clone(), [9; 32], &|| NOW + 2).unwrap();
+        assert_eq!(replayed, receipt);
+        // The owner removes the device inside the replay window: the stored bootstrap and its
+        // stream-key wraps must not be released again.
+        conn.execute(
+            "UPDATE account_roster_history SET closed_at = ?2 WHERE roster_ref = ?1",
+            params![receipt.device_add_hash.as_slice(), NOW + 3],
+        )
+        .unwrap();
+        assert!(matches!(
+            redeem_invite(&conn, request, [9; 32], &|| NOW + 3),
+            Err(InviteError::Revoked)
+        ));
+    }
+
+    #[test]
+    fn redemption_replays_only_the_same_request_and_uses_the_server_side_role() {
+        let conn = db();
+        let account = rag_rat_oplog::local_account(&conn, NOW).unwrap();
+        let ticket = ticket(&conn, account, DeviceRole::ReadOnly);
+        let (ed25519_pubkey, x25519_pubkey) = joiner_keys();
+        let request = EnrollmentRequest {
+            nonce: ticket.nonce,
+            expected_account: account,
+            ed25519_pubkey,
+            x25519_pubkey,
+            transport_node_id: [9; 32],
+            budget: generous_budget(),
+            held_entry_hashes: Vec::new(),
+        };
+        let (receipt, catch_up) =
+            redeem_invite(&conn, request.clone(), [9; 32], &|| NOW + 1).unwrap();
+        assert_eq!(catch_up.authored.len(), 0);
+        let role: String = conn
+            .query_row(
+                "SELECT role FROM account_roster_history
+                 WHERE account_id = ?1 AND roster_ref = ?2",
+                params![account.to_bytes().as_slice(), receipt.device_add_hash.as_slice()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(role, "read_only");
+        let (response_account, response_hash) =
+            rag_rat_oplog::account_entry_ref(&receipt.device_add_signed).unwrap();
+        assert_eq!(response_account, account);
+        assert_eq!(response_hash, receipt.device_add_hash);
+        assert!(
+            receipt.account_entries.len() >= 2,
+            "the receipt bootstraps genesis plus the DeviceAdd"
+        );
+        verify_enrollment_device_add(
+            &receipt.account_entries,
+            account,
+            receipt.device_add_hash,
+            &receipt.device_add_signed,
+            ed25519_pubkey,
+            x25519_pubkey,
+        )
+        .unwrap();
+        assert!(
+            verify_enrollment_device_add(
+                &receipt.account_entries,
+                AccountId::from_bytes([0xff; 32]),
+                receipt.device_add_hash,
+                &receipt.device_add_signed,
+                ed25519_pubkey,
+                x25519_pubkey,
+            )
+            .is_err(),
+            "a receipt for another account is not trusted"
+        );
+        assert!(
+            verify_enrollment_device_add(
+                &receipt.account_entries,
+                account,
+                receipt.device_add_hash,
+                &receipt.device_add_signed,
+                [0xee; 32],
+                x25519_pubkey,
+            )
+            .is_err(),
+            "a receipt enrolling different request keys is not trusted"
+        );
+        let mut forged_signed = receipt.device_add_signed.clone();
+        forged_signed[0] ^= 1;
+        assert!(
+            verify_enrollment_device_add(
+                &receipt.account_entries,
+                account,
+                receipt.device_add_hash,
+                &forged_signed,
+                ed25519_pubkey,
+                x25519_pubkey,
+            )
+            .is_err(),
+            "the acknowledged signed bytes must be the verified bootstrap entry"
+        );
+
+        let joiner = db();
+        let genesis_hash = verify_enrollment_device_add(
+            &receipt.account_entries,
+            account,
+            receipt.device_add_hash,
+            &receipt.device_add_signed,
+            ed25519_pubkey,
+            x25519_pubkey,
+        )
+        .unwrap();
+        let joiner_fingerprint =
+            DeviceFingerprint::from_bytes(Sha256::digest(ed25519_pubkey).into());
+        rag_rat_oplog::adopt_enrollment_bootstrap(&joiner, rag_rat_oplog::EnrollmentBootstrap {
+            account_entries: &receipt.account_entries,
+            account_id: account,
+            genesis_hash,
+            device_fingerprint: joiner_fingerprint,
+            device_add_hash: receipt.device_add_hash,
+            now_ms: NOW + 2,
+        })
+        .unwrap();
+        assert_eq!(rag_rat_oplog::read_local_account(&joiner).unwrap(), Some(account));
+        let folded_role: String = joiner
+            .query_row(
+                "SELECT role FROM account_roster_history
+                 WHERE account_id = ?1 AND roster_ref = ?2 AND closed_at IS NULL",
+                params![account.to_bytes().as_slice(), receipt.device_add_hash.as_slice()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            folded_role, "read_only",
+            "bootstrap ingestion makes the joiner roster-effective before closed sync"
+        );
+
+        let interrupted_joiner = db();
+        let mut invalid_bootstrap = receipt.account_entries.clone();
+        invalid_bootstrap.push(vec![0xff]);
+        assert!(
+            rag_rat_oplog::adopt_enrollment_bootstrap(
+                &interrupted_joiner,
+                rag_rat_oplog::EnrollmentBootstrap {
+                    account_entries: &invalid_bootstrap,
+                    account_id: account,
+                    genesis_hash,
+                    device_fingerprint: joiner_fingerprint,
+                    device_add_hash: receipt.device_add_hash,
+                    now_ms: NOW + 2,
+                },
+            )
+            .is_err()
+        );
+        let retained_entries: i64 = interrupted_joiner
+            .query_row("SELECT COUNT(*) FROM account_entries", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(retained_entries, 0, "a later bootstrap failure rolls back earlier entries");
+        assert_eq!(
+            rag_rat_oplog::read_local_account(&interrupted_joiner).unwrap(),
+            None,
+            "a failed bootstrap cannot publish the local-account pointer"
+        );
+        let (replayed, replay_catch_up) =
+            redeem_invite(&conn, request.clone(), [9; 32], &|| NOW + 2).unwrap();
+        assert_eq!(replayed, receipt);
+        assert!(replay_catch_up.authored.is_empty());
+        assert!(replay_catch_up.already_covered.is_empty());
+
+        let mut different = request;
+        different.x25519_pubkey = [7; 32];
+        assert!(matches!(
+            redeem_invite(&conn, different, [9; 32], &|| NOW + 2),
+            Err(InviteError::Used)
+        ));
+    }
+
+    #[test]
+    fn redemption_rechecks_expiry_with_the_post_lock_clock() {
+        let conn = db();
+        let account = rag_rat_oplog::local_account(&conn, NOW).unwrap();
+        let ticket = ticket(&conn, account, DeviceRole::Member);
+        let (ed25519_pubkey, x25519_pubkey) = joiner_keys();
+        let request = EnrollmentRequest {
+            nonce: ticket.nonce,
+            expected_account: account,
+            ed25519_pubkey,
+            x25519_pubkey,
+            transport_node_id: [9; 32],
+            budget: generous_budget(),
+            held_entry_hashes: Vec::new(),
+        };
+        // The optimistic pre-lock read sees the invite still valid; the writer-lock wait then
+        // crosses the TTL, so the in-tx check must refuse with the refreshed clock instead of
+        // consuming against the stale pre-wait one.
+        let reads = AtomicI64::new(0);
+        let clock = || {
+            if reads.fetch_add(1, Ordering::SeqCst) == 0 { NOW + 1 } else { ticket.expires_at_ms }
+        };
+        assert!(matches!(
+            redeem_invite(&conn, request.clone(), [9; 32], &clock),
+            Err(InviteError::Expired)
+        ));
+        let used: Option<i64> = conn
+            .query_row(
+                "SELECT used_at_ms FROM sync_invites WHERE nonce = ?1",
+                [ticket.nonce.as_slice()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(used, None, "an expiry-crossing redemption must not consume the nonce");
+        // The still-valid invite redeems normally afterwards.
+        let _ = redeem_invite(&conn, request, [9; 32], &|| NOW + 2).unwrap();
+    }
+
+    #[test]
+    fn replay_within_the_retention_window_survives_the_post_lock_clock() {
+        let conn = db();
+        let account = rag_rat_oplog::local_account(&conn, NOW).unwrap();
+        let ticket = ticket(&conn, account, DeviceRole::Member);
+        let (ed25519_pubkey, x25519_pubkey) = joiner_keys();
+        let request = EnrollmentRequest {
+            nonce: ticket.nonce,
+            expected_account: account,
+            ed25519_pubkey,
+            x25519_pubkey,
+            transport_node_id: [9; 32],
+            budget: generous_budget(),
+            held_entry_hashes: Vec::new(),
+        };
+        let (receipt, _) = redeem_invite(&conn, request.clone(), [9; 32], &|| NOW + 1).unwrap();
+        // A retry arriving before expiry but checked after the TTL (and within the 24h replay
+        // window) must still replay the stored receipt: the in-tx replay check runs before the
+        // refreshed expiry check.
+        let reads = AtomicI64::new(0);
+        let clock = || {
+            if reads.fetch_add(1, Ordering::SeqCst) == 0 {
+                NOW + 2
+            } else {
+                ticket.expires_at_ms + 60_000
+            }
+        };
+        let (replayed, _) = redeem_invite(&conn, request, [9; 32], &clock).unwrap();
+        assert_eq!(replayed, receipt);
+    }
+
+    #[test]
+    fn expiry_and_node_binding_fail_before_consumption() {
+        let conn = db();
+        let account = rag_rat_oplog::local_account(&conn, NOW).unwrap();
+        let ticket = ticket(&conn, account, DeviceRole::Member);
+        let (ed25519_pubkey, x25519_pubkey) = joiner_keys();
+        let request = EnrollmentRequest {
+            nonce: ticket.nonce,
+            expected_account: account,
+            ed25519_pubkey,
+            x25519_pubkey,
+            transport_node_id: [9; 32],
+            budget: generous_budget(),
+            held_entry_hashes: Vec::new(),
+        };
+        assert!(matches!(
+            redeem_invite(&conn, request.clone(), [8; 32], &|| NOW + 1),
+            Err(InviteError::WrongNode)
+        ));
+        assert!(matches!(
+            redeem_invite(&conn, request, [9; 32], &|| ticket.expires_at_ms),
+            Err(InviteError::Expired)
+        ));
+        let used: Option<i64> = conn
+            .query_row(
+                "SELECT used_at_ms FROM sync_invites WHERE nonce = ?1",
+                [ticket.nonce.as_slice()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(used, None);
+    }
+
+    #[test]
+    fn expected_account_mismatch_fails_before_authoring_or_consumption() {
+        let conn = db();
+        let account = rag_rat_oplog::local_account(&conn, NOW).unwrap();
+        let ticket = ticket(&conn, account, DeviceRole::Member);
+        let (ed25519_pubkey, x25519_pubkey) = joiner_keys();
+        let mut request = EnrollmentRequest {
+            nonce: ticket.nonce,
+            expected_account: AccountId::from_bytes([0xa5; 32]),
+            ed25519_pubkey,
+            x25519_pubkey,
+            transport_node_id: [9; 32],
+            budget: generous_budget(),
+            held_entry_hashes: Vec::new(),
+        };
+        let roster_before: i64 = conn
+            .query_row("SELECT COUNT(*) FROM account_roster_history", [], |row| row.get(0))
+            .unwrap();
+
+        assert!(matches!(
+            redeem_invite(&conn, request.clone(), [9; 32], &|| NOW + 1),
+            Err(InviteError::AccountMismatch)
+        ));
+        let (used_at_ms, roster_after): (Option<i64>, i64) = (
+            conn.query_row(
+                "SELECT used_at_ms FROM sync_invites WHERE nonce = ?1",
+                [ticket.nonce.as_slice()],
+                |row| row.get(0),
+            )
+            .unwrap(),
+            conn.query_row("SELECT COUNT(*) FROM account_roster_history", [], |row| row.get(0))
+                .unwrap(),
+        );
+        assert_eq!(used_at_ms, None);
+        assert_eq!(roster_after, roster_before);
+
+        request.expected_account = account;
+        redeem_invite(&conn, request, [9; 32], &|| NOW + 2)
+            .expect("the account-mismatch refusal leaves the invite redeemable");
+    }
+
+    #[test]
+    fn receipt_replay_is_retained_for_one_day_then_pruned() {
+        let conn = db();
+        let account = rag_rat_oplog::local_account(&conn, NOW).unwrap();
+        let ticket = ticket(&conn, account, DeviceRole::Member);
+        let (ed25519_pubkey, x25519_pubkey) = joiner_keys();
+        let request = EnrollmentRequest {
+            nonce: ticket.nonce,
+            expected_account: account,
+            ed25519_pubkey,
+            x25519_pubkey,
+            transport_node_id: [9; 32],
+            budget: generous_budget(),
+            held_entry_hashes: Vec::new(),
+        };
+        let used_at_ms = NOW + 1;
+        let (receipt, _) = redeem_invite(&conn, request.clone(), [9; 32], &|| used_at_ms).unwrap();
+        let (replayed, _) = redeem_invite(&conn, request.clone(), [9; 32], &|| {
+            used_at_ms + RECEIPT_REPLAY_RETENTION_MS - 1
+        })
+        .unwrap();
+        assert_eq!(replayed, receipt);
+
+        assert!(matches!(
+            redeem_invite(&conn, request, [9; 32], &|| used_at_ms + RECEIPT_REPLAY_RETENTION_MS),
+            Err(InviteError::Used)
+        ));
+        let retained: bool = conn
+            .query_row(
+                "SELECT EXISTS(SELECT 1 FROM sync_invites WHERE nonce = ?1)",
+                [ticket.nonce.as_slice()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(!retained, "the expired multi-megabyte receipt row is deleted");
+    }
+
+    #[test]
+    fn failed_device_add_rolls_back_invite_consumption() {
+        let conn = db();
+        let account = rag_rat_oplog::local_account(&conn, NOW).unwrap();
+        let ticket = ticket(&conn, account, DeviceRole::Member);
+        let (ed25519_pubkey, x25519_pubkey) = joiner_keys();
+        let bad = EnrollmentRequest {
+            nonce: ticket.nonce,
+            expected_account: account,
+            ed25519_pubkey,
+            x25519_pubkey: [0; 32],
+            transport_node_id: [9; 32],
+            budget: generous_budget(),
+            held_entry_hashes: Vec::new(),
+        };
+        assert!(matches!(
+            redeem_invite(&conn, bad, [9; 32], &|| NOW + 1),
+            Err(InviteError::Storage(_))
+        ));
+        let good = EnrollmentRequest {
+            nonce: ticket.nonce,
+            expected_account: account,
+            ed25519_pubkey,
+            x25519_pubkey,
+            transport_node_id: [9; 32],
+            budget: generous_budget(),
+            held_entry_hashes: Vec::new(),
+        };
+        redeem_invite(&conn, good, [9; 32], &|| NOW + 2)
+            .expect("the failed transaction must leave the invite redeemable");
+    }
+
+    #[test]
+    fn account_entry_sized_receipt_fits_the_bootstrap_frame() {
+        let conn = db();
+        let account = rag_rat_oplog::local_account(&conn, NOW).unwrap();
+        let label = "x".repeat(8 * 1024);
+        let ticket = mint_invite(&conn, InviteSpec {
+            account_id: account,
+            inviter_node_id: crate::endpoint::node_id_from_secret([2; 32]),
+            relay_url: "https://relay.example".into(),
+            role: DeviceRole::Member,
+            label: Some(&label),
+            now_ms: &|| NOW,
+            ttl: Duration::from_secs(60),
+        })
+        .unwrap();
+        let (ed25519_pubkey, x25519_pubkey) = joiner_keys();
+        let request = EnrollmentRequest {
+            nonce: ticket.nonce,
+            expected_account: account,
+            ed25519_pubkey,
+            x25519_pubkey,
+            transport_node_id: [9; 32],
+            budget: generous_budget(),
+            held_entry_hashes: Vec::new(),
+        };
+
+        redeem_invite(&conn, request, [9; 32], &|| NOW + 1)
+            .expect("the enrollment frame cap covers account-entry-sized receipts");
+        let used: Option<i64> = conn
+            .query_row(
+                "SELECT used_at_ms FROM sync_invites WHERE nonce = ?1",
+                [ticket.nonce.as_slice()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(used, Some(NOW + 1));
+    }
+
+    #[test]
+    fn simultaneous_redemption_has_exactly_one_winner() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("enrollment.sqlite");
+        let conn = Connection::open(&path).unwrap();
+        rag_rat_db::schema::apply(&conn, &rag_rat_db::MigrationHooks::noop()).unwrap();
+        let account = rag_rat_oplog::local_account(&conn, NOW).unwrap();
+        let ticket = ticket(&conn, account, DeviceRole::Member);
+        drop(conn);
+
+        let barrier = Arc::new(Barrier::new(3));
+        let mut handles = Vec::new();
+        for transport_node_id in [[8; 32], [9; 32]] {
+            let path = path.clone();
+            let barrier = Arc::clone(&barrier);
+            let nonce = ticket.nonce;
+            handles.push(std::thread::spawn(move || {
+                let conn = Connection::open(path).unwrap();
+                conn.busy_timeout(Duration::from_secs(5)).unwrap();
+                let (ed25519_pubkey, x25519_pubkey) = joiner_keys();
+                let request = EnrollmentRequest {
+                    nonce,
+                    expected_account: account,
+                    ed25519_pubkey,
+                    x25519_pubkey,
+                    transport_node_id,
+                    budget: generous_budget(),
+                    held_entry_hashes: Vec::new(),
+                };
+                barrier.wait();
+                redeem_invite(&conn, request, transport_node_id, &|| NOW + 1)
+            }));
+        }
+        barrier.wait();
+        let results: Vec<_> = handles.into_iter().map(|handle| handle.join().unwrap()).collect();
+        assert_eq!(results.iter().filter(|result| result.is_ok()).count(), 1);
+        assert_eq!(
+            results.iter().filter(|result| matches!(result, Err(InviteError::Used))).count(),
+            1
+        );
+
+        let conn = Connection::open(path).unwrap();
+        let additions: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM account_roster_history
+                 WHERE account_id = ?1",
+                [account.to_bytes().as_slice()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        // AccountGenesis contributes the owner row; exactly one DeviceAdd may join it.
+        assert_eq!(additions, 2);
+    }
+
+    #[tokio::test]
+    async fn duplex_exchange_returns_the_authored_device_add() {
+        let conn = db();
+        let account = rag_rat_oplog::local_account(&conn, NOW).unwrap();
+        let ticket = ticket(&conn, account, DeviceRole::Member);
+        let (ed25519_pubkey, x25519_pubkey) = joiner_keys();
+        let request = EnrollmentRequest {
+            nonce: ticket.nonce,
+            expected_account: account,
+            ed25519_pubkey,
+            x25519_pubkey,
+            transport_node_id: [9; 32],
+            budget: generous_budget(),
+            held_entry_hashes: Vec::new(),
+        };
+        let (mut dial_send, mut accept_recv) = tokio::io::duplex(4096);
+        let (mut accept_send, mut dial_recv) = tokio::io::duplex(4096);
+        let (dial, accept) = tokio::join!(
+            run_enrollment_dialer(&mut dial_recv, &mut dial_send, account, &request),
+            run_enrollment_acceptor(&mut accept_recv, &mut accept_send, &conn, [9; 32], || NOW + 1,),
+        );
+        let dial = dial.unwrap();
+        let EnrollmentAcceptorOutcome::Enrolled(accept, _) = accept.unwrap() else {
+            panic!("valid enrollment must succeed");
+        };
+        assert_eq!(dial, accept);
+    }
+
+    #[tokio::test]
+    async fn a_slow_but_progressing_response_completes() {
+        let (ed25519_pubkey, x25519_pubkey) = joiner_keys();
+        let request = EnrollmentRequest {
+            nonce: [42; 32],
+            expected_account: AccountId::from_bytes([1; 32]),
+            ed25519_pubkey,
+            x25519_pubkey,
+            transport_node_id: [9; 32],
+            budget: generous_budget(),
+            held_entry_hashes: Vec::new(),
+        };
+        let (mut dial_send, mut accept_recv) = tokio::io::duplex(1024);
+        let (mut accept_send, mut dial_recv) = tokio::io::duplex(1024);
+        // Drip the refusal in small writes with gaps — comfortably inside each per-chunk window,
+        // past what a whole-exchange deadline of the same size would tolerate.
+        let server = async move {
+            let mut prefix = [0u8; 4];
+            accept_recv.read_exact(&mut prefix).await.unwrap();
+            let mut req = vec![0u8; u32::from_be_bytes(prefix) as usize];
+            accept_recv.read_exact(&mut req).await.unwrap();
+            let response = EnrollmentResponse::Refused(RefusalCode::Unknown).encode();
+            let framed = [(response.len() as u32).to_be_bytes().as_slice(), &response].concat();
+            for piece in framed.chunks(8) {
+                accept_send.write_all(piece).await.unwrap();
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        };
+        let (dial, _) = tokio::join!(
+            run_enrollment_dialer_with_progress(
+                &mut dial_recv,
+                &mut dial_send,
+                AccountId::from_bytes([1; 32]),
+                &request,
+                Duration::from_millis(500),
+            ),
+            server,
+        );
+        assert!(matches!(dial, Err(InviteError::Unknown)));
+    }
+
+    #[tokio::test]
+    async fn a_stalled_response_times_out_within_one_window() {
+        let (ed25519_pubkey, x25519_pubkey) = joiner_keys();
+        let request = EnrollmentRequest {
+            nonce: [42; 32],
+            expected_account: AccountId::from_bytes([1; 32]),
+            ed25519_pubkey,
+            x25519_pubkey,
+            transport_node_id: [9; 32],
+            budget: generous_budget(),
+            held_entry_hashes: Vec::new(),
+        };
+        let (mut dial_send, mut accept_recv) = tokio::io::duplex(1024);
+        let (mut accept_send, mut dial_recv) = tokio::io::duplex(1024);
+        let server = tokio::spawn(async move {
+            let mut prefix = [0u8; 4];
+            accept_recv.read_exact(&mut prefix).await.unwrap();
+            let mut req = vec![0u8; u32::from_be_bytes(prefix) as usize];
+            accept_recv.read_exact(&mut req).await.unwrap();
+            // A valid prefix and half the body, then silence forever.
+            accept_send.write_all(&128u32.to_be_bytes()).await.unwrap();
+            accept_send.write_all(&[0u8; 64]).await.unwrap();
+            accept_send.flush().await.unwrap();
+            std::future::pending::<()>().await;
+        });
+        let start = std::time::Instant::now();
+        let dial = run_enrollment_dialer_with_progress(
+            &mut dial_recv,
+            &mut dial_send,
+            AccountId::from_bytes([1; 32]),
+            &request,
+            Duration::from_millis(100),
+        )
+        .await;
+        server.abort();
+        assert!(
+            matches!(dial, Err(InviteError::Io(ref error)) if error.kind() == std::io::ErrorKind::TimedOut),
+            "a stalled frame must die with a timeout: {dial:?}"
+        );
+        assert!(start.elapsed() < Duration::from_secs(2), "the stall dies in one window");
+    }
+
+    #[tokio::test]
+    async fn a_stalled_reader_times_out_the_frame_write() {
+        let (mut send, _recv) = tokio::io::duplex(64);
+        let body = vec![0u8; 256 * 1024];
+        let result = write_blob(
+            &mut send,
+            &body,
+            MAX_ENROLL_RESPONSE_FRAME,
+            "response",
+            Duration::from_millis(100),
+        )
+        .await;
+        assert!(
+            matches!(result, Err(InviteError::Io(ref error)) if error.kind() == std::io::ErrorKind::TimedOut),
+            "a back-pressured write must die with a timeout: {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn dialer_acks_the_response_once_decoded() {
+        let conn = db();
+        let (ed25519_pubkey, x25519_pubkey) = joiner_keys();
+        let request = EnrollmentRequest {
+            nonce: [42; 32],
+            expected_account: AccountId::from_bytes([1; 32]),
+            ed25519_pubkey,
+            x25519_pubkey,
+            transport_node_id: [9; 32],
+            budget: generous_budget(),
+            held_entry_hashes: Vec::new(),
+        };
+        let (mut dial_send, mut accept_recv) = tokio::io::duplex(4096);
+        let (mut accept_send, mut dial_recv) = tokio::io::duplex(4096);
+        let (dial, accept) = tokio::join!(
+            run_enrollment_dialer(
+                &mut dial_recv,
+                &mut dial_send,
+                AccountId::from_bytes([1; 32]),
+                &request,
+            ),
+            run_enrollment_acceptor(&mut accept_recv, &mut accept_send, &conn, [9; 32], || NOW + 1,),
+        );
+        assert!(matches!(dial, Err(InviteError::Unknown)));
+        assert!(matches!(accept, Ok(EnrollmentAcceptorOutcome::Refused(_))));
+        let mut ack = [0u8; 1];
+        accept_recv.read_exact(&mut ack).await.unwrap();
+        assert_eq!(ack, [RESPONSE_ACK], "the dialer acks even a refused response");
+    }
+
+    #[tokio::test]
+    async fn a_stalled_response_ack_is_bounded_and_best_effort() {
+        let (ed25519_pubkey, x25519_pubkey) = joiner_keys();
+        let request = EnrollmentRequest {
+            nonce: [42; 32],
+            expected_account: AccountId::from_bytes([1; 32]),
+            ed25519_pubkey,
+            x25519_pubkey,
+            transport_node_id: [9; 32],
+            budget: generous_budget(),
+            held_entry_hashes: Vec::new(),
+        };
+        let response = EnrollmentResponse::Refused(RefusalCode::Unknown).encode();
+        let framed = [(response.len() as u32).to_be_bytes().as_slice(), &response].concat();
+        let (mut response_send, mut dial_recv) = tokio::io::duplex(4096);
+        response_send.write_all(&framed).await.unwrap();
+        let mut dial_send = StallAfterBytes { remaining: 4 + request.encode().len() };
+
+        let start = std::time::Instant::now();
+        let dial = run_enrollment_dialer_with_progress(
+            &mut dial_recv,
+            &mut dial_send,
+            AccountId::from_bytes([1; 32]),
+            &request,
+            Duration::from_millis(100),
+        )
+        .await;
+
+        assert!(matches!(dial, Err(InviteError::Unknown)));
+        assert!(start.elapsed() < Duration::from_secs(2), "the stalled ack is bounded");
+    }
+
+    #[tokio::test]
+    async fn duplex_exchange_returns_a_semantic_refusal() {
+        let conn = db();
+        let (ed25519_pubkey, x25519_pubkey) = joiner_keys();
+        let request = EnrollmentRequest {
+            nonce: [42; 32],
+            expected_account: AccountId::from_bytes([1; 32]),
+            ed25519_pubkey,
+            x25519_pubkey,
+            transport_node_id: [9; 32],
+            budget: generous_budget(),
+            held_entry_hashes: Vec::new(),
+        };
+        let (mut dial_send, mut accept_recv) = tokio::io::duplex(4096);
+        let (mut accept_send, mut dial_recv) = tokio::io::duplex(4096);
+        let (dial, accept) = tokio::join!(
+            run_enrollment_dialer(
+                &mut dial_recv,
+                &mut dial_send,
+                AccountId::from_bytes([1; 32]),
+                &request,
+            ),
+            run_enrollment_acceptor(&mut accept_recv, &mut accept_send, &conn, [9; 32], || NOW + 1,),
+        );
+        assert!(matches!(dial, Err(InviteError::Unknown)));
+        assert!(matches!(accept, Ok(EnrollmentAcceptorOutcome::Refused(InviteError::Unknown))));
+    }
+
+    #[tokio::test]
+    async fn acceptor_checks_expiry_after_receiving_the_request() {
+        let conn = db();
+        let account = rag_rat_oplog::local_account(&conn, NOW).unwrap();
+        let ticket = ticket(&conn, account, DeviceRole::Member);
+        let (ed25519_pubkey, x25519_pubkey) = joiner_keys();
+        let request = EnrollmentRequest {
+            nonce: ticket.nonce,
+            expected_account: account,
+            ed25519_pubkey,
+            x25519_pubkey,
+            transport_node_id: [9; 32],
+            budget: generous_budget(),
+            held_entry_hashes: Vec::new(),
+        };
+        let clock = AtomicI64::new(NOW + 1);
+        let (mut dial_send, mut accept_recv) = tokio::io::duplex(4096);
+        let (mut accept_send, _dial_recv) = tokio::io::duplex(4096);
+        let send_request = async {
+            write_blob(
+                &mut dial_send,
+                &request.encode(),
+                MAX_ENROLL_REQUEST_FRAME,
+                "request",
+                ENROLL_PROGRESS_TIMEOUT,
+            )
+            .await
+            .unwrap();
+            clock.store(ticket.expires_at_ms, Ordering::SeqCst);
+        };
+        let accept =
+            run_enrollment_acceptor(&mut accept_recv, &mut accept_send, &conn, [9; 32], || {
+                clock.load(Ordering::SeqCst)
+            });
+
+        let (_, result) = tokio::join!(send_request, accept);
+        assert!(matches!(result, Ok(EnrollmentAcceptorOutcome::Refused(InviteError::Expired))));
+    }
+
+    #[tokio::test]
+    async fn request_length_is_capped_before_allocating_its_body() {
+        let (mut send, mut recv) = tokio::io::duplex(16);
+        send.write_all(&(MAX_ENROLL_REQUEST_FRAME + 1).to_be_bytes()).await.unwrap();
+        let error =
+            read_blob(&mut recv, MAX_ENROLL_REQUEST_FRAME, "request", ENROLL_PROGRESS_TIMEOUT)
+                .await
+                .unwrap_err();
+        assert!(
+            matches!(error, InviteError::Malformed(message) if message.contains("request")),
+            "the unauthenticated request uses its small cap"
+        );
+    }
+}

--- a/crates/rag-rat-sync/src/lib.rs
+++ b/crates/rag-rat-sync/src/lib.rs
@@ -18,14 +18,20 @@
 pub mod auth;
 pub mod codec;
 pub mod endpoint;
+pub mod enrollment;
 pub mod session;
 pub mod store;
 pub mod wire;
 
 pub use auth::{AuthConfig, AuthError, AuthPolicy, AuthRole, NodeAuth, run_auth_phase};
 pub use endpoint::{
-    EndpointError, SyncFailure, accept_and_dispatch, accept_and_sync, build_endpoint,
-    connect_and_sync, endpoint_addr, node_id_from_secret, peer_addr,
+    EndpointError, SyncFailure, accept_and_dispatch, accept_and_sync, accept_enrollment,
+    build_endpoint, connect_and_enroll, connect_and_sync, endpoint_addr, node_id_from_secret,
+    peer_addr,
+};
+pub use enrollment::{
+    ENROLL_ALPN, EnrollmentReceipt, EnrollmentRequest, EnrollmentTicket, InviteError, InviteSpec,
+    mint_invite, redeem_invite, run_enrollment_acceptor, run_enrollment_dialer,
 };
 pub use session::{
     DEFAULT_IDLE_TIMEOUT, Ingested, MAX_SESSION_ENTRIES, SessionError, SessionReport, SyncStore,

--- a/crates/rag-rat-sync/src/store.rs
+++ b/crates/rag-rat-sync/src/store.rs
@@ -64,6 +64,10 @@ impl<'a> OplogSyncStore<'a> {
     pub fn new(conn: &'a Connection, account_id: AccountId, now_fn: fn() -> i64) -> Self {
         Self { conn, account_id, now_fn }
     }
+
+    pub(crate) fn connection(&self) -> &'a Connection {
+        self.conn
+    }
 }
 
 impl SyncStore for OplogSyncStore<'_> {

--- a/crates/rag-rat-sync/src/wire.rs
+++ b/crates/rag-rat-sync/src/wire.rs
@@ -257,7 +257,10 @@ mod tests {
     fn alpn_identifiers_are_frozen() {
         assert_eq!(SYNC_ALPN, b"rag-rat/sync/2");
         assert_eq!(CONTENT_SYNC_ALPN, b"rag-rat/content/1");
+        assert_eq!(crate::enrollment::ENROLL_ALPN, b"rag-rat/enroll/1");
         assert_ne!(SYNC_ALPN, CONTENT_SYNC_ALPN);
+        assert_ne!(SYNC_ALPN, crate::enrollment::ENROLL_ALPN);
+        assert_ne!(CONTENT_SYNC_ALPN, crate::enrollment::ENROLL_ALPN);
     }
 
     #[test]

--- a/crates/rag-rat-sync/tests/oplog_sync.rs
+++ b/crates/rag-rat-sync/tests/oplog_sync.rs
@@ -191,7 +191,7 @@ async fn a_fresh_peer_restores_the_accounts_content_after_the_account_log() {
 
     // And the moved bytes are usable: once the deferred refold settles, the peer accepts them —
     // acceptance the peer recomputes from the synced authority, never trusting the sender.
-    settle_pending_content_refolds(&dest, &ContentRefoldBudget::unbounded()).unwrap();
+    settle_pending_content_refolds(&dest, &ContentRefoldBudget::unbounded(), NOW).unwrap();
     let accepted: i64 = dest
         .query_row(
             "SELECT count(*) FROM content_entries WHERE author_account_id = ?1 AND accepted = 1",


### PR DESCRIPTION
Closes #945.

## What changed

- add canonical-CBOR enrollment tickets and join/request receipts over `rag-rat/enroll/1`
- persist role-bound, TTL-limited, single-use invite nonces in schema V089
- atomically consume the invite, author the joining device, and catch up sealed stream keys
- return the exact signed `DeviceAdd` envelope to the joiner
- bind the claimed transport node to the authenticated QUIC peer and register the enrollment ALPN

## Safety properties

The granted role and label remain owner-side and are never trusted from ticket bytes. Invite consumption, `DeviceAdd`, and key catch-up share one IMMEDIATE transaction, so failures leave the invite redeemable. Concurrent redemption admits exactly one winner.

## Validation

- `cargo +nightly fmt --check`
- `cargo build --workspace --all-targets`
- `cargo nextest run -p rag-rat-sync -p rag-rat-db` (71 passed, 2 live-relay tests skipped)
- `cargo test -p rag-rat-core migration_08` (9 passed)
- workspace clippy with no default features and all features
- eval clippy with and without default features