### PR TITLE
refactor(resolve): use typed language policies

### DIFF
--- a/crates/rag-rat-core/src/index/edges/mod.rs
+++ b/crates/rag-rat-core/src/index/edges/mod.rs
@@ -70,6 +70,54 @@ impl EdgeKind {
             Self::DispatchHandle => "dispatch_handle",
         }
     }
+
+    pub fn from_db_str(value: &str) -> anyhow::Result<Self> {
+        match value {
+            "imports" => Ok(Self::Imports),
+            "exports" => Ok(Self::Exports),
+            "calls_name" => Ok(Self::CallsName),
+            "constructs" => Ok(Self::Constructs),
+            "uses_operator" => Ok(Self::UsesOperator),
+            "uses_precedence_group" => Ok(Self::UsesPrecedenceGroup),
+            "uses_macro" => Ok(Self::UsesMacro),
+            "references_type" => Ok(Self::ReferencesType),
+            "implements" => Ok(Self::Implements),
+            "contains" => Ok(Self::Contains),
+            "dispatches" => Ok(Self::Dispatches),
+            "dispatch_construct" => Ok(Self::DispatchConstruct),
+            "dispatch_handle" => Ok(Self::DispatchHandle),
+            _ => anyhow::bail!("unknown edge kind `{value}`"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod edge_kind_tests {
+    use super::EdgeKind;
+
+    #[test]
+    fn persisted_tokens_round_trip() {
+        let kinds = [
+            EdgeKind::Imports,
+            EdgeKind::Exports,
+            EdgeKind::CallsName,
+            EdgeKind::Constructs,
+            EdgeKind::UsesOperator,
+            EdgeKind::UsesPrecedenceGroup,
+            EdgeKind::UsesMacro,
+            EdgeKind::ReferencesType,
+            EdgeKind::Implements,
+            EdgeKind::Contains,
+            EdgeKind::Dispatches,
+            EdgeKind::DispatchConstruct,
+            EdgeKind::DispatchHandle,
+        ];
+
+        for kind in kinds {
+            assert_eq!(EdgeKind::from_db_str(kind.as_str()).unwrap(), kind);
+        }
+        assert!(EdgeKind::from_db_str("unknown").is_err());
+    }
 }
 
 /// The `edges_data.hidden` value for a row (#734): 1 exactly when the row is not a public graph
@@ -551,7 +599,7 @@ impl<'a> SymbolIndex<'a> {
 pub(crate) struct ResolveSymbolRequest<'a> {
     name: &'a str,
     target_qualified_name: Option<&'a str>,
-    edge_kind: &'a str,
+    edge_kind: EdgeKind,
     evidence: Option<&'a str>,
     receiver_hint: Option<&'a str>,
     source_file_id: i64,

--- a/crates/rag-rat-core/src/index/edges/resolve/mod.rs
+++ b/crates/rag-rat-core/src/index/edges/resolve/mod.rs
@@ -45,7 +45,7 @@ fn import_alias_rebind(
         let target = import_scope.import_alias_target(request.file_id, name, request.ref_byte)?;
         (!index.file_defines(request.file_id, short_name(target))).then(|| target.to_string())
     };
-    policy.rebind_import_alias(crate::index::languages::ImportAliasRequest {
+    (policy.rebind_import_alias)(crate::index::languages::ImportAliasRequest {
         to_name: request.to_name,
         target_qualified_name: request.target_qualified_name,
         receiver_hint: request.receiver_hint,
@@ -313,7 +313,9 @@ fn resolve_edges_with_scope(conn: &Connection, write: EdgeWriteScope<'_>) -> any
             let evidence: Option<String> = row.get(3)?;
             let scope = import_scope_from_row(row.get(4)?, row.get(5)?, row.get(6)?);
             let carries_alias = crate::index::languages::resolver_policy_for_name(Some(&language))
-                .is_some_and(|policy| policy.import_edges_carry_aliases());
+                .is_some_and(|policy| {
+                    policy.import_binding == crate::index::languages::ImportBinding::Aliases
+                });
             if carries_alias {
                 // Alias carriers encode `evidence = alias`, `to_name = target`, and a lexical
                 // scope. Non-aliased imports have no scope and are ignored by this path.
@@ -371,12 +373,13 @@ fn resolve_edges_with_scope(conn: &Connection, write: EdgeWriteScope<'_>) -> any
         source_language,
     ) in rows
     {
+        let edge_kind = EdgeKind::from_db_str(&edge_kind)?;
         // #200: a `dispatch_construct` fact's `to_name` is a synthetic `Enum::Variant` key, NOT a
         // real call target — resolving it would bind a bogus `to_symbol_id` to any same-named
         // symbol, and synthesis reads only the fact's `from_symbol_id`. Leave it
         // unresolved. (`dispatch_handle` DOES resolve — synthesis reads its handler
         // `to_symbol_id`.)
-        if edge_kind == EdgeKind::DispatchConstruct.as_str() {
+        if edge_kind == EdgeKind::DispatchConstruct {
             let confidence_id = interner.get(conn, EdgeConfidence::NameOnly.as_str())?;
             let resolution_id = interner.get(conn, "unresolved")?;
             conn.prepare_cached(
@@ -389,7 +392,7 @@ fn resolve_edges_with_scope(conn: &Connection, write: EdgeWriteScope<'_>) -> any
                 edge_id,
                 confidence_id,
                 resolution_id,
-                edge_hidden_flag(&edge_kind, "unresolved"),
+                edge_hidden_flag(edge_kind.as_str(), "unresolved"),
             ])?;
             continue;
         }
@@ -397,7 +400,7 @@ fn resolve_edges_with_scope(conn: &Connection, write: EdgeWriteScope<'_>) -> any
         let ref_byte = usize::try_from(source_start_byte).unwrap_or(0);
         // A language-owned import-alias policy may rewrite a reference to its imported target.
         // Imports edges retain their own target name.
-        let rebind = if edge_kind == EdgeKind::Imports.as_str() {
+        let rebind = if edge_kind == EdgeKind::Imports {
             Default::default()
         } else {
             import_alias_rebind(&import_scope, &index, ImportAliasResolveRequest {
@@ -417,7 +420,7 @@ fn resolve_edges_with_scope(conn: &Connection, write: EdgeWriteScope<'_>) -> any
             ResolveSymbolRequest {
                 name: resolve_name,
                 target_qualified_name: resolve_qualified,
-                edge_kind: &edge_kind,
+                edge_kind,
                 evidence: evidence.as_deref(),
                 receiver_hint: resolve_receiver,
                 source_file_id,
@@ -438,7 +441,8 @@ fn resolve_edges_with_scope(conn: &Connection, write: EdgeWriteScope<'_>) -> any
             let suppressed =
                 crate::index::languages::resolver_policy_for_name(Some(&source_language))
                     .is_some_and(|policy| {
-                        policy.suppress_unresolved_reference(&edge_kind, evidence.as_deref())
+                        (policy.unresolved_disposition)(edge_kind, evidence.as_deref())
+                            == crate::index::languages::UnresolvedDisposition::Suppress
                     });
             let confidence = if current_confidence == EdgeConfidence::Ambiguous.as_str() {
                 EdgeConfidence::Ambiguous
@@ -464,7 +468,7 @@ fn resolve_edges_with_scope(conn: &Connection, write: EdgeWriteScope<'_>) -> any
                 edge_id,
                 confidence_id,
                 resolution_id,
-                edge_hidden_flag(&edge_kind, resolution),
+                edge_hidden_flag(edge_kind.as_str(), resolution),
             ])?;
             continue;
         };
@@ -489,7 +493,7 @@ fn resolve_edges_with_scope(conn: &Connection, write: EdgeWriteScope<'_>) -> any
             resolution_id,
             // A re-resolved candidate un-hides (a previously suppressed Swift macro candidate
             // whose target appears later); a resolved dispatch_handle FACT stays hidden.
-            edge_hidden_flag(&edge_kind, reason),
+            edge_hidden_flag(edge_kind.as_str(), reason),
         ])?;
     }
     // #200: now that the dispatch FACT rows are resolved (handlers bound to symbols), synthesize
@@ -563,7 +567,9 @@ pub(crate) fn resolve_and_insert_edges(
             let evidence = arena.get_opt(candidate.evidence).unwrap_or("");
             let source_language = file_language.get(file_id).map(String::as_str);
             let carries_alias = crate::index::languages::resolver_policy_for_name(source_language)
-                .is_some_and(|policy| policy.import_edges_carry_aliases());
+                .is_some_and(|policy| {
+                    policy.import_binding == crate::index::languages::ImportBinding::Aliases
+                });
             if carries_alias {
                 let target = arena.get(candidate.to_name).trim();
                 if !evidence.is_empty() && !target.is_empty() {
@@ -643,7 +649,7 @@ pub(crate) fn resolve_and_insert_edges(
                 ResolveSymbolRequest {
                     name: resolve_name,
                     target_qualified_name: resolve_qualified,
-                    edge_kind: candidate.edge_kind.as_str(),
+                    edge_kind: candidate.edge_kind,
                     evidence,
                     receiver_hint: resolve_receiver,
                     source_file_id: *file_id,
@@ -675,7 +681,8 @@ pub(crate) fn resolve_and_insert_edges(
                         file_language.get(file_id).map(String::as_str),
                     )
                     .is_some_and(|policy| {
-                        policy.suppress_unresolved_reference(candidate.edge_kind.as_str(), evidence)
+                        (policy.unresolved_disposition)(candidate.edge_kind, evidence)
+                            == crate::index::languages::UnresolvedDisposition::Suppress
                     });
                     let confidence = if candidate.confidence == EdgeConfidence::Ambiguous {
                         EdgeConfidence::Ambiguous
@@ -766,7 +773,7 @@ pub(crate) fn resolve_symbol<'a>(
     index: &SymbolIndex<'a>,
 ) -> Option<(&'a IndexedSymbol, EdgeConfidence, &'static str)> {
     let kind_matches = |symbol: &IndexedSymbol| {
-        (request.edge_kind != EdgeKind::UsesMacro.as_str() || symbol.kind == "macro")
+        (request.edge_kind != EdgeKind::UsesMacro || symbol.kind == "macro")
             && crate::index::languages::target_matches_policy(
                 request.source_language,
                 request.edge_kind,
@@ -785,14 +792,19 @@ pub(crate) fn resolve_symbol<'a>(
     // A language-owned local qualifier overrides an external bare-leaf import.
     if request.imported_external
         && !request.target_qualified_name.and_then(|path| path.split_once("::")).is_some_and(
-            |(root, _)| policy.is_some_and(|policy| policy.is_local_qualified_root(root)),
+            |(root, _)| {
+                policy.is_some_and(|policy| {
+                    (policy.qualified_root)(root) == crate::index::languages::QualifiedRoot::Local
+                })
+            },
         )
     {
         return None;
     }
-    if policy
-        .is_some_and(|policy| policy.reference_is_unresolvable(request.edge_kind, request.name))
-    {
+    if policy.is_some_and(|policy| {
+        (policy.reference_disposition)(request.edge_kind, request.name)
+            == crate::index::languages::ReferenceDisposition::Unresolvable
+    }) {
         return None;
     }
     if let Some(qualified) = request.target_qualified_name.filter(|value| !value.is_empty()) {
@@ -889,7 +901,8 @@ pub(crate) fn resolve_symbol<'a>(
     let bare_shape_ok = |symbol: &IndexedSymbol| {
         reference_is_bare
             || !policy.is_some_and(|policy| {
-                policy.kind_requires_unqualified_reference(request.edge_kind, &symbol.kind)
+                (policy.target_shape)(request.edge_kind, &symbol.kind)
+                    == crate::index::languages::ReferenceShape::UnqualifiedOnly
             })
     };
     let matches = index
@@ -903,8 +916,10 @@ pub(crate) fn resolve_symbol<'a>(
     let preferred = preferred_matches(request.edge_kind, request.source_language, &matches);
     // Language policy decides whether a type-position reference may bind a value declaration.
     if preferred.is_empty()
-        && request.edge_kind == EdgeKind::ReferencesType.as_str()
-        && policy.is_some_and(|policy| policy.type_reference_requires_type_definition())
+        && request.edge_kind == EdgeKind::ReferencesType
+        && policy.is_some_and(|policy| {
+            policy.type_binding == crate::index::languages::TypeBinding::DefinitionsOnly
+        })
     {
         return None;
     }
@@ -963,7 +978,10 @@ pub(crate) fn same_logical_symbol(symbols: &[&IndexedSymbol]) -> bool {
         .parse::<Language>()
         .ok()
         .and_then(crate::index::languages::resolver_policy)
-        .is_some_and(|policy| !policy.collapse_same_named_declarations())
+        .is_some_and(|policy| {
+            policy.declaration_identity
+                == crate::index::languages::DeclarationIdentity::PreserveAmbiguity
+        })
     {
         return false;
     }
@@ -975,14 +993,14 @@ pub(crate) fn same_logical_symbol(symbols: &[&IndexedSymbol]) -> bool {
     })
 }
 pub(crate) fn allow_unqualified_fallback(
-    edge_kind: &str,
+    edge_kind: EdgeKind,
     qualified: &str,
     name: &str,
     evidence: Option<&str>,
     receiver_hint: Option<&str>,
     source_language: Option<&str>,
 ) -> bool {
-    if edge_kind == EdgeKind::UsesMacro.as_str() {
+    if edge_kind == EdgeKind::UsesMacro {
         return false;
     }
     let target = short_name(name);
@@ -994,22 +1012,33 @@ pub(crate) fn allow_unqualified_fallback(
         .next()
         .unwrap_or_default();
     let policy = crate::index::languages::resolver_policy_for_name(source_language);
-    if policy.is_some_and(|policy| policy.is_local_qualified_root(qualifier)) {
+    if policy.is_some_and(|policy| {
+        (policy.qualified_root)(qualifier) == crate::index::languages::QualifiedRoot::Local
+    }) {
         return true;
     }
     if receiver_hint
         .is_some_and(|receiver| looks_like_type_name(receiver) && !is_common_member_name(target))
-        && policy.is_some_and(|policy| policy.allow_type_receiver_fallback())
+        && policy.is_some_and(|policy| {
+            matches!(
+                policy.receiver_fallback,
+                crate::index::languages::ReceiverFallback::Type
+                    | crate::index::languages::ReceiverFallback::TypeAndValue
+            )
+        })
     {
         return true;
     }
     if receiver_hint.is_some_and(|receiver| !matches!(receiver, "self" | "Self"))
         && evidence.is_some_and(|value| value.contains('.'))
     {
-        return policy.is_some_and(|policy| policy.allow_value_receiver_fallback())
-            && !is_common_member_name(target);
+        return policy.is_some_and(|policy| {
+            policy.receiver_fallback == crate::index::languages::ReceiverFallback::TypeAndValue
+        }) && !is_common_member_name(target);
     }
-    if policy.is_some_and(|policy| policy.rejects_qualified_root(qualifier)) {
+    if policy.is_some_and(|policy| {
+        (policy.qualified_root)(qualifier) == crate::index::languages::QualifiedRoot::External
+    }) {
         return false;
     }
     if looks_like_type_name(qualifier) && is_common_member_name(target) {
@@ -1039,7 +1068,7 @@ pub(crate) fn is_common_member_name(value: &str) -> bool {
     )
 }
 pub(crate) fn preferred_matches<'a>(
-    edge_kind: &str,
+    edge_kind: EdgeKind,
     source_language: Option<&str>,
     matches: &[&'a IndexedSymbol],
 ) -> Vec<&'a IndexedSymbol> {
@@ -1047,17 +1076,18 @@ pub(crate) fn preferred_matches<'a>(
         // `dispatch_handle` (#200) is a call to the handler the match arm delegates to — resolve it
         // with the SAME callable preference as a direct call, so a same-named type/const never wins
         // over the handler function/method.
-        "calls_name" | "dispatch_handle" => &["function", "method"],
-        "constructs" => &["struct", "class", "object"],
-        "uses_macro" => &["macro"],
-        "implements" => &["trait", "interface"],
-        "references_type" => &["struct", "enum", "trait", "type", "class", "interface", "object"],
+        EdgeKind::CallsName | EdgeKind::DispatchHandle => &["function", "method"],
+        EdgeKind::Constructs => &["struct", "class", "object"],
+        EdgeKind::UsesMacro => &["macro"],
+        EdgeKind::Implements => &["trait", "interface"],
+        EdgeKind::ReferencesType =>
+            &["struct", "enum", "trait", "type", "class", "interface", "object"],
         _ => &[],
     };
     let source_language = source_language.and_then(|name| name.parse::<Language>().ok());
     let language_preference = source_language
         .and_then(crate::index::languages::resolver_policy)
-        .and_then(|policy| policy.preferred_kinds(edge_kind));
+        .and_then(|policy| (policy.preferred_kinds)(edge_kind));
     let preferred_kinds = language_preference
         .as_ref()
         .map_or(generic_preferred_kinds, |preference| preference.symbol_kinds);

--- a/crates/rag-rat-core/src/index/edges/resolve/tests.rs
+++ b/crates/rag-rat-core/src/index/edges/resolve/tests.rs
@@ -219,24 +219,22 @@ fn swift_type_edges_prefer_swift_protocols_and_actors_over_foreign_types() {
     let foreign_function = preferred_candidate(10, Language::Rust, "function");
     let swift_constructor = preferred_candidate(11, Language::Swift, "constructor");
 
-    let implements =
-        preferred_matches(EdgeKind::Implements.as_str(), Some(Language::Swift.as_str()), &[
-            &foreign_trait,
-            &protocol,
-        ]);
+    let implements = preferred_matches(EdgeKind::Implements, Some(Language::Swift.as_str()), &[
+        &foreign_trait,
+        &protocol,
+    ]);
     assert_eq!(implements.iter().map(|symbol| symbol.id).collect::<Vec<_>>(), vec![protocol.id]);
 
-    let inheritance =
-        preferred_matches(EdgeKind::Implements.as_str(), Some(Language::Swift.as_str()), &[
-            &foreign_trait,
-            &swift_class,
-        ]);
+    let inheritance = preferred_matches(EdgeKind::Implements, Some(Language::Swift.as_str()), &[
+        &foreign_trait,
+        &swift_class,
+    ]);
     assert_eq!(inheritance.iter().map(|symbol| symbol.id).collect::<Vec<_>>(), vec![
         swift_class.id
     ]);
 
     let protocol_reference =
-        preferred_matches(EdgeKind::ReferencesType.as_str(), Some(Language::Swift.as_str()), &[
+        preferred_matches(EdgeKind::ReferencesType, Some(Language::Swift.as_str()), &[
             &foreign_trait,
             &protocol,
         ]);
@@ -245,7 +243,7 @@ fn swift_type_edges_prefer_swift_protocols_and_actors_over_foreign_types() {
     ]);
 
     for edge_kind in [EdgeKind::Constructs, EdgeKind::ReferencesType] {
-        let preferred = preferred_matches(edge_kind.as_str(), Some(Language::Swift.as_str()), &[
+        let preferred = preferred_matches(edge_kind, Some(Language::Swift.as_str()), &[
             &foreign_struct,
             &actor,
         ]);
@@ -256,15 +254,14 @@ fn swift_type_edges_prefer_swift_protocols_and_actors_over_foreign_types() {
         );
     }
 
-    let macro_use =
-        preferred_matches(EdgeKind::UsesMacro.as_str(), Some(Language::Swift.as_str()), &[
-            &foreign_macro,
-            &swift_macro,
-        ]);
+    let macro_use = preferred_matches(EdgeKind::UsesMacro, Some(Language::Swift.as_str()), &[
+        &foreign_macro,
+        &swift_macro,
+    ]);
     assert_eq!(macro_use.iter().map(|symbol| symbol.id).collect::<Vec<_>>(), vec![swift_macro.id]);
 
     let enum_construction =
-        preferred_matches(EdgeKind::Constructs.as_str(), Some(Language::Swift.as_str()), &[
+        preferred_matches(EdgeKind::Constructs, Some(Language::Swift.as_str()), &[
             &foreign_struct,
             &swift_enum,
         ]);
@@ -272,14 +269,14 @@ fn swift_type_edges_prefer_swift_protocols_and_actors_over_foreign_types() {
         swift_enum.id
     ]);
 
-    let call = preferred_matches(EdgeKind::CallsName.as_str(), Some(Language::Swift.as_str()), &[
+    let call = preferred_matches(EdgeKind::CallsName, Some(Language::Swift.as_str()), &[
         &foreign_function,
         &swift_method,
     ]);
     assert_eq!(call.iter().map(|symbol| symbol.id).collect::<Vec<_>>(), vec![swift_method.id]);
 
     let initializer_call =
-        preferred_matches(EdgeKind::CallsName.as_str(), Some(Language::Swift.as_str()), &[
+        preferred_matches(EdgeKind::CallsName, Some(Language::Swift.as_str()), &[
             &foreign_function,
             &swift_constructor,
         ]);
@@ -288,21 +285,19 @@ fn swift_type_edges_prefer_swift_protocols_and_actors_over_foreign_types() {
     ]);
 
     assert!(
-        preferred_matches(EdgeKind::ReferencesType.as_str(), Some(Language::Swift.as_str()), &[
+        preferred_matches(EdgeKind::ReferencesType, Some(Language::Swift.as_str()), &[
             &foreign_struct
         ],)
         .is_empty(),
         "Swift type names without a Swift target must not prefer a foreign symbol"
     );
     assert!(
-        preferred_matches(EdgeKind::UsesMacro.as_str(), Some(Language::Swift.as_str()), &[
-            &foreign_macro
-        ],)
-        .is_empty(),
+        preferred_matches(EdgeKind::UsesMacro, Some(Language::Swift.as_str()), &[&foreign_macro],)
+            .is_empty(),
         "Swift macro names without a Swift target must not prefer a foreign macro"
     );
     assert!(
-        preferred_matches(EdgeKind::CallsName.as_str(), Some(Language::Swift.as_str()), &[
+        preferred_matches(EdgeKind::CallsName, Some(Language::Swift.as_str()), &[
             &foreign_function
         ],)
         .is_empty(),
@@ -318,18 +313,17 @@ fn generic_resolution_does_not_prefer_swift_only_symbol_kinds() {
     let rust_struct = preferred_candidate(4, Language::Rust, "struct");
 
     let implements =
-        preferred_matches(EdgeKind::Implements.as_str(), Some(Language::TypeScript.as_str()), &[
+        preferred_matches(EdgeKind::Implements, Some(Language::TypeScript.as_str()), &[
             &swift_protocol,
             &rust_trait,
         ]);
     assert_eq!(implements.iter().map(|symbol| symbol.id).collect::<Vec<_>>(), vec![rust_trait.id]);
 
     for edge_kind in [EdgeKind::Constructs, EdgeKind::ReferencesType] {
-        let preferred =
-            preferred_matches(edge_kind.as_str(), Some(Language::TypeScript.as_str()), &[
-                &swift_actor,
-                &rust_struct,
-            ]);
+        let preferred = preferred_matches(edge_kind, Some(Language::TypeScript.as_str()), &[
+            &swift_actor,
+            &rust_struct,
+        ]);
         assert_eq!(preferred.iter().map(|symbol| symbol.id).collect::<Vec<_>>(), vec![
             rust_struct.id
         ]);
@@ -669,7 +663,7 @@ fn swift_local_receivers_override_external_bare_name_suppression() {
             ResolveSymbolRequest {
                 name: "make",
                 target_qualified_name: Some(&qualified),
-                edge_kind: EdgeKind::CallsName.as_str(),
+                edge_kind: EdgeKind::CallsName,
                 evidence: Some("make()"),
                 receiver_hint: Some(receiver),
                 source_file_id: 1,

--- a/crates/rag-rat-core/src/index/languages/c_family/mod.rs
+++ b/crates/rag-rat-core/src/index/languages/c_family/mod.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use tree_sitter::Node;
 
-use super::{ParserBackend, ResolverPolicy, SymbolMatch};
+use super::{ParserBackend, ResolutionPolicy, SymbolMatch, TypeBinding};
 use crate::index::parser::{self, ParserKind};
 
 mod edges;
@@ -104,19 +104,5 @@ fn function_name(node: Node<'_>) -> Option<Node<'_>> {
     parser::last_descendant_node(name_root, parser::NAME_KINDS)
 }
 
-macro_rules! impl_resolver_policy {
-    ($backend:ty) => {
-        impl ResolverPolicy for $backend {
-            fn preferred_kinds(&self, _edge_kind: &str) -> Option<super::KindPreference> {
-                None
-            }
-
-            fn type_reference_requires_type_definition(&self) -> bool {
-                true
-            }
-        }
-    };
-}
-
-impl_resolver_policy!(C);
-impl_resolver_policy!(Cpp);
+pub(super) const RESOLVER_POLICY: ResolutionPolicy =
+    ResolutionPolicy { type_binding: TypeBinding::DefinitionsOnly, ..ResolutionPolicy::DEFAULT };

--- a/crates/rag-rat-core/src/index/languages/kotlin/mod.rs
+++ b/crates/rag-rat-core/src/index/languages/kotlin/mod.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use tree_sitter::Node;
 
-use super::{ParserBackend, ResolverPolicy, SymbolMatch};
+use super::{ParserBackend, ReceiverFallback, ResolutionPolicy, SymbolMatch};
 use crate::index::parser::{self, ParserKind};
 
 mod edges;
@@ -99,16 +99,7 @@ fn variable_declaration(node: Node<'_>) -> Option<Node<'_>> {
     })
 }
 
-impl ResolverPolicy for Kotlin {
-    fn preferred_kinds(&self, _edge_kind: &str) -> Option<super::KindPreference> {
-        None
-    }
-
-    fn allow_type_receiver_fallback(&self) -> bool {
-        true
-    }
-
-    fn allow_value_receiver_fallback(&self) -> bool {
-        true
-    }
-}
+pub(super) const RESOLVER_POLICY: ResolutionPolicy = ResolutionPolicy {
+    receiver_fallback: ReceiverFallback::TypeAndValue,
+    ..ResolutionPolicy::DEFAULT
+};

--- a/crates/rag-rat-core/src/index/languages/mod.rs
+++ b/crates/rag-rat-core/src/index/languages/mod.rs
@@ -11,6 +11,7 @@ use std::path::Path;
 use rag_rat_base::language::Language;
 use tree_sitter::Node;
 
+use super::edges::EdgeKind;
 pub(super) use super::edges::extract::{EdgeEmitter, EdgeVisit};
 use super::parser::ParserKind;
 
@@ -98,60 +99,84 @@ pub(super) struct KindPreference {
     pub(super) same_language_only: bool,
 }
 
-/// Language-semantic resolution rules that cannot be derived from generic symbol kinds.
-pub(super) trait ResolverPolicy: Sync {
-    fn preferred_kinds(&self, edge_kind: &str) -> Option<KindPreference>;
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum DeclarationIdentity {
+    CollapseEquivalent,
+    PreserveAmbiguity,
+}
 
-    fn collapse_same_named_declarations(&self) -> bool {
-        true
-    }
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum ImportBinding {
+    Uses,
+    Aliases,
+}
 
-    fn import_edges_carry_aliases(&self) -> bool {
-        false
-    }
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum TypeBinding {
+    AnySymbol,
+    DefinitionsOnly,
+}
 
-    fn rebind_import_alias(&self, _request: ImportAliasRequest<'_>) -> ImportAliasRebind {
-        ImportAliasRebind::default()
-    }
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum ReceiverFallback {
+    None,
+    Type,
+    TypeAndValue,
+}
 
-    fn reference_is_unresolvable(&self, _edge_kind: &str, _name: &str) -> bool {
-        false
-    }
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum QualifiedRoot {
+    Neutral,
+    Local,
+    External,
+}
 
-    /// A target kind the BARE-NAME fallback may bind only when the reference itself carried no
-    /// qualifier and no receiver — i.e. only for the syntactic shape that is actual evidence for
-    /// that kind.
-    ///
-    /// The qualified/receiver-bearing shapes are unaffected: they resolve through the qualified
-    /// path (`Status.idle` → the `Status::idle` case) and only fall back to the bare name when
-    /// that path finds nothing — which is exactly where a wrong bind would be manufactured.
-    fn kind_requires_unqualified_reference(&self, _edge_kind: &str, _target_kind: &str) -> bool {
-        false
-    }
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum ReferenceDisposition {
+    Resolve,
+    Unresolvable,
+}
 
-    fn suppress_unresolved_reference(&self, _edge_kind: &str, _evidence: Option<&str>) -> bool {
-        false
-    }
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum UnresolvedDisposition {
+    Keep,
+    Suppress,
+}
 
-    fn type_reference_requires_type_definition(&self) -> bool {
-        false
-    }
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum ReferenceShape {
+    Any,
+    UnqualifiedOnly,
+}
 
-    fn allow_type_receiver_fallback(&self) -> bool {
-        false
-    }
+/// One inspectable bundle of language-semantic resolution choices.
+#[derive(Clone, Copy)]
+pub(super) struct ResolutionPolicy {
+    pub(super) preferred_kinds: fn(EdgeKind) -> Option<KindPreference>,
+    pub(super) declaration_identity: DeclarationIdentity,
+    pub(super) import_binding: ImportBinding,
+    pub(super) rebind_import_alias: fn(ImportAliasRequest<'_>) -> ImportAliasRebind,
+    pub(super) reference_disposition: fn(EdgeKind, &str) -> ReferenceDisposition,
+    pub(super) target_shape: fn(EdgeKind, &str) -> ReferenceShape,
+    pub(super) unresolved_disposition: fn(EdgeKind, Option<&str>) -> UnresolvedDisposition,
+    pub(super) type_binding: TypeBinding,
+    pub(super) receiver_fallback: ReceiverFallback,
+    pub(super) qualified_root: fn(&str) -> QualifiedRoot,
+}
 
-    fn allow_value_receiver_fallback(&self) -> bool {
-        false
-    }
-
-    fn rejects_qualified_root(&self, _root: &str) -> bool {
-        false
-    }
-
-    fn is_local_qualified_root(&self, _root: &str) -> bool {
-        false
-    }
+impl ResolutionPolicy {
+    pub(super) const DEFAULT: Self = Self {
+        preferred_kinds: no_kind_preference,
+        declaration_identity: DeclarationIdentity::CollapseEquivalent,
+        import_binding: ImportBinding::Uses,
+        rebind_import_alias: no_alias_rebind,
+        reference_disposition: resolvable_reference,
+        target_shape: any_reference_shape,
+        unresolved_disposition: keep_unresolved,
+        type_binding: TypeBinding::AnySymbol,
+        receiver_fallback: ReceiverFallback::None,
+        qualified_root: neutral_qualified_root,
+    };
 }
 
 pub(super) struct ImportAliasRequest<'a> {
@@ -168,9 +193,33 @@ pub(super) struct ImportAliasRebind {
     pub(super) receiver_hint: Option<String>,
 }
 
+fn no_kind_preference(_edge_kind: EdgeKind) -> Option<KindPreference> {
+    None
+}
+
+fn no_alias_rebind(_request: ImportAliasRequest<'_>) -> ImportAliasRebind {
+    ImportAliasRebind::default()
+}
+
+fn resolvable_reference(_edge_kind: EdgeKind, _name: &str) -> ReferenceDisposition {
+    ReferenceDisposition::Resolve
+}
+
+fn any_reference_shape(_edge_kind: EdgeKind, _target_kind: &str) -> ReferenceShape {
+    ReferenceShape::Any
+}
+
+fn keep_unresolved(_edge_kind: EdgeKind, _evidence: Option<&str>) -> UnresolvedDisposition {
+    UnresolvedDisposition::Keep
+}
+
+fn neutral_qualified_root(_root: &str) -> QualifiedRoot {
+    QualifiedRoot::Neutral
+}
+
 pub(super) fn target_matches_policy(
     source_language: Option<&str>,
-    edge_kind: &str,
+    edge_kind: EdgeKind,
     target_language: &str,
     target_kind: &str,
 ) -> bool {
@@ -179,7 +228,7 @@ pub(super) fn target_matches_policy(
         return true;
     };
     let Some(preference) =
-        resolver_policy(source_language).and_then(|policy| policy.preferred_kinds(edge_kind))
+        resolver_policy(source_language).and_then(|policy| (policy.preferred_kinds)(edge_kind))
     else {
         return true;
     };
@@ -212,21 +261,20 @@ pub(super) fn edge_extractor(language: Language) -> Option<EdgeExtractor> {
     }
 }
 
-pub(super) fn resolver_policy(language: Language) -> Option<&'static dyn ResolverPolicy> {
+pub(super) fn resolver_policy(language: Language) -> Option<&'static ResolutionPolicy> {
     match language {
-        Language::Rust => Some(&rust::SUPPORT),
-        Language::Kotlin => Some(&kotlin::SUPPORT),
-        Language::C => Some(&c_family::C_SUPPORT),
-        Language::Cpp => Some(&c_family::CPP_SUPPORT),
-        Language::Python => Some(&python::SUPPORT),
-        Language::Swift => Some(&swift::SUPPORT),
+        Language::Rust => Some(&rust::RESOLVER_POLICY),
+        Language::Kotlin => Some(&kotlin::RESOLVER_POLICY),
+        Language::C | Language::Cpp => Some(&c_family::RESOLVER_POLICY),
+        Language::Python => Some(&python::RESOLVER_POLICY),
+        Language::Swift => Some(&swift::RESOLVER_POLICY),
         _ => None,
     }
 }
 
 pub(super) fn resolver_policy_for_name(
     language: Option<&str>,
-) -> Option<&'static dyn ResolverPolicy> {
+) -> Option<&'static ResolutionPolicy> {
     language.and_then(|name| name.parse::<Language>().ok()).and_then(resolver_policy)
 }
 
@@ -254,12 +302,12 @@ pub(crate) fn all_symbol_kinds() -> BTreeSet<&'static str> {
 
 pub(super) fn requires_same_language_target(
     source_language: Option<&str>,
-    edge_kind: &str,
+    edge_kind: EdgeKind,
 ) -> bool {
     source_language
         .and_then(|language| language.parse::<Language>().ok())
         .and_then(resolver_policy)
-        .and_then(|policy| policy.preferred_kinds(edge_kind))
+        .and_then(|policy| (policy.preferred_kinds)(edge_kind))
         .is_some_and(|preference| preference.same_language_only)
 }
 
@@ -269,7 +317,10 @@ mod tests {
 
     use rag_rat_base::language::Language;
 
-    use super::{edge_extractor, parser_backend};
+    use super::{
+        DeclarationIdentity, ImportBinding, ReceiverFallback, TypeBinding, edge_extractor,
+        parser_backend, resolver_policy,
+    };
     use crate::index::parser::{self, ParserKind};
 
     #[test]
@@ -283,6 +334,81 @@ mod tests {
             assert_eq!(kind == ParserKind::Markdown, language == Language::Markdown);
             assert_eq!(parser::grammar_for(kind).is_some(), language != Language::Markdown);
             assert_eq!(edge_extractor(language).is_some(), language != Language::Markdown);
+        }
+    }
+
+    #[test]
+    fn resolver_policies_are_complete_and_inspectable() {
+        let expected = [
+            (
+                Language::Rust,
+                Some((
+                    DeclarationIdentity::CollapseEquivalent,
+                    ImportBinding::Uses,
+                    TypeBinding::DefinitionsOnly,
+                    ReceiverFallback::Type,
+                )),
+            ),
+            (Language::TypeScript, None),
+            (
+                Language::Kotlin,
+                Some((
+                    DeclarationIdentity::CollapseEquivalent,
+                    ImportBinding::Uses,
+                    TypeBinding::AnySymbol,
+                    ReceiverFallback::TypeAndValue,
+                )),
+            ),
+            (
+                Language::C,
+                Some((
+                    DeclarationIdentity::CollapseEquivalent,
+                    ImportBinding::Uses,
+                    TypeBinding::DefinitionsOnly,
+                    ReceiverFallback::None,
+                )),
+            ),
+            (
+                Language::Cpp,
+                Some((
+                    DeclarationIdentity::CollapseEquivalent,
+                    ImportBinding::Uses,
+                    TypeBinding::DefinitionsOnly,
+                    ReceiverFallback::None,
+                )),
+            ),
+            (
+                Language::Python,
+                Some((
+                    DeclarationIdentity::CollapseEquivalent,
+                    ImportBinding::Aliases,
+                    TypeBinding::AnySymbol,
+                    ReceiverFallback::None,
+                )),
+            ),
+            (
+                Language::Swift,
+                Some((
+                    DeclarationIdentity::PreserveAmbiguity,
+                    ImportBinding::Uses,
+                    TypeBinding::AnySymbol,
+                    ReceiverFallback::None,
+                )),
+            ),
+            (Language::Markdown, None),
+        ];
+
+        assert_eq!(expected.len(), Language::all().len());
+        for (language, expected) in expected {
+            let actual = resolver_policy(language).map(|policy| {
+                (
+                    policy.declaration_identity,
+                    policy.import_binding,
+                    policy.type_binding,
+                    policy.receiver_fallback,
+                )
+            });
+            assert_eq!(actual, expected, "{language}");
         }
     }
 }

--- a/crates/rag-rat-core/src/index/languages/python/mod.rs
+++ b/crates/rag-rat-core/src/index/languages/python/mod.rs
@@ -3,9 +3,10 @@ use std::path::Path;
 use tree_sitter::Node;
 
 use super::{
-    ImportAliasRebind, ImportAliasRequest, KindPreference, ParserBackend, ResolverPolicy,
-    SymbolMatch,
+    ImportAliasRebind, ImportAliasRequest, ImportBinding, KindPreference, ParserBackend,
+    ResolutionPolicy, SymbolMatch,
 };
+use crate::index::edges::EdgeKind;
 use crate::index::parser::{self, ParserKind};
 
 mod edges;
@@ -121,37 +122,36 @@ fn assignment_is_const_scope(node: Node<'_>) -> bool {
     false
 }
 
-impl ResolverPolicy for Python {
-    fn preferred_kinds(&self, edge_kind: &str) -> Option<KindPreference> {
-        (edge_kind == "implements").then_some(KindPreference {
-            symbol_kinds: &["class", "object"],
-            same_language_only: true,
-        })
-    }
+pub(super) const RESOLVER_POLICY: ResolutionPolicy = ResolutionPolicy {
+    preferred_kinds,
+    import_binding: ImportBinding::Aliases,
+    rebind_import_alias,
+    ..ResolutionPolicy::DEFAULT
+};
 
-    fn import_edges_carry_aliases(&self) -> bool {
-        true
-    }
+fn preferred_kinds(edge_kind: EdgeKind) -> Option<KindPreference> {
+    (edge_kind == EdgeKind::Implements)
+        .then_some(KindPreference { symbol_kinds: &["class", "object"], same_language_only: true })
+}
 
-    fn rebind_import_alias(&self, request: ImportAliasRequest<'_>) -> ImportAliasRebind {
-        match request.receiver_hint {
-            Some(receiver) => {
-                let Some(target) = (request.lookup)(receiver) else {
-                    return ImportAliasRebind::default();
-                };
-                ImportAliasRebind {
-                    name: None,
-                    target_qualified_name: request
-                        .target_qualified_name
-                        .map(|qualified| replace_qualified_root(qualified, &target)),
-                    receiver_hint: Some(target),
-                }
-            },
-            None => ImportAliasRebind {
-                name: (request.lookup)(short_name(request.to_name)),
-                ..ImportAliasRebind::default()
-            },
-        }
+fn rebind_import_alias(request: ImportAliasRequest<'_>) -> ImportAliasRebind {
+    match request.receiver_hint {
+        Some(receiver) => {
+            let Some(target) = (request.lookup)(receiver) else {
+                return ImportAliasRebind::default();
+            };
+            ImportAliasRebind {
+                name: None,
+                target_qualified_name: request
+                    .target_qualified_name
+                    .map(|qualified| replace_qualified_root(qualified, &target)),
+                receiver_hint: Some(target),
+            }
+        },
+        None => ImportAliasRebind {
+            name: (request.lookup)(short_name(request.to_name)),
+            ..ImportAliasRebind::default()
+        },
     }
 }
 

--- a/crates/rag-rat-core/src/index/languages/rust/mod.rs
+++ b/crates/rag-rat-core/src/index/languages/rust/mod.rs
@@ -2,7 +2,11 @@ use std::path::Path;
 
 use tree_sitter::Node;
 
-use super::{ParserBackend, ResolverPolicy, SymbolMatch};
+use super::{
+    ParserBackend, QualifiedRoot, ReceiverFallback, ReferenceDisposition, ResolutionPolicy,
+    SymbolMatch, TypeBinding,
+};
+use crate::index::edges::EdgeKind;
 use crate::index::parser::{self, ParsedSymbolFact, ParserKind};
 
 mod dispatch;
@@ -132,30 +136,29 @@ fn attribute_items(text: &str, node: Node<'_>) -> Vec<String> {
     preceding
 }
 
-impl ResolverPolicy for Rust {
-    fn preferred_kinds(&self, _edge_kind: &str) -> Option<super::KindPreference> {
-        None
-    }
+pub(super) const RESOLVER_POLICY: ResolutionPolicy = ResolutionPolicy {
+    reference_disposition,
+    type_binding: TypeBinding::DefinitionsOnly,
+    receiver_fallback: ReceiverFallback::Type,
+    qualified_root,
+    ..ResolutionPolicy::DEFAULT
+};
 
-    fn reference_is_unresolvable(&self, edge_kind: &str, name: &str) -> bool {
-        edge_kind == crate::index::edges::EdgeKind::ReferencesType.as_str()
-            && type_ref_is_unresolvable(name)
+fn reference_disposition(edge_kind: EdgeKind, name: &str) -> ReferenceDisposition {
+    if edge_kind == EdgeKind::ReferencesType && type_ref_is_unresolvable(name) {
+        ReferenceDisposition::Unresolvable
+    } else {
+        ReferenceDisposition::Resolve
     }
+}
 
-    fn type_reference_requires_type_definition(&self) -> bool {
-        true
-    }
-
-    fn allow_type_receiver_fallback(&self) -> bool {
-        true
-    }
-
-    fn rejects_qualified_root(&self, root: &str) -> bool {
-        is_external_root(root)
-    }
-
-    fn is_local_qualified_root(&self, root: &str) -> bool {
-        matches!(root, "crate" | "self" | "super")
+fn qualified_root(root: &str) -> QualifiedRoot {
+    if matches!(root, "crate" | "self" | "super") {
+        QualifiedRoot::Local
+    } else if is_external_root(root) {
+        QualifiedRoot::External
+    } else {
+        QualifiedRoot::Neutral
     }
 }
 

--- a/crates/rag-rat-core/src/index/languages/swift/mod.rs
+++ b/crates/rag-rat-core/src/index/languages/swift/mod.rs
@@ -2,7 +2,11 @@ use std::path::Path;
 
 use tree_sitter::Node;
 
-use super::{KindPreference, ParserBackend, ResolverPolicy, SymbolMatch};
+use super::{
+    DeclarationIdentity, KindPreference, ParserBackend, QualifiedRoot, ReferenceDisposition,
+    ReferenceShape, ResolutionPolicy, SymbolMatch, UnresolvedDisposition,
+};
+use crate::index::edges::EdgeKind;
 use crate::index::parser::{self, ParserKind};
 
 mod edges;
@@ -270,53 +274,72 @@ fn direct_child_of_kind<'tree>(node: Node<'tree>, kind: &str) -> Option<Node<'tr
     })
 }
 
-impl ResolverPolicy for Swift {
-    fn preferred_kinds(&self, edge_kind: &str) -> Option<KindPreference> {
-        let symbol_kinds: &'static [&'static str] = match edge_kind {
-            "calls_name" => &["function", "method", "constructor", "enum_case"],
-            "constructs" => &["struct", "enum", "class", "object", "actor"],
-            "implements" => &["protocol", "class"],
-            "references_type" =>
-                &["struct", "enum", "type", "class", "object", "actor", "protocol"],
-            "uses_macro" => &["macro"],
-            "uses_operator" => &["operator"],
-            "uses_precedence_group" => &["precedence_group"],
-            _ => return None,
-        };
-        Some(KindPreference { symbol_kinds, same_language_only: true })
-    }
+pub(super) const RESOLVER_POLICY: ResolutionPolicy = ResolutionPolicy {
+    preferred_kinds,
+    declaration_identity: DeclarationIdentity::PreserveAmbiguity,
+    reference_disposition,
+    target_shape,
+    unresolved_disposition,
+    qualified_root,
+    ..ResolutionPolicy::DEFAULT
+};
 
-    fn collapse_same_named_declarations(&self) -> bool {
-        false
-    }
+fn preferred_kinds(edge_kind: EdgeKind) -> Option<KindPreference> {
+    let symbol_kinds: &'static [&'static str] = match edge_kind {
+        EdgeKind::CallsName => &["function", "method", "constructor", "enum_case"],
+        EdgeKind::Constructs => &["struct", "enum", "class", "object", "actor"],
+        EdgeKind::Implements => &["protocol", "class"],
+        EdgeKind::ReferencesType =>
+            &["struct", "enum", "type", "class", "object", "actor", "protocol"],
+        EdgeKind::UsesMacro => &["macro"],
+        EdgeKind::UsesOperator => &["operator"],
+        EdgeKind::UsesPrecedenceGroup => &["precedence_group"],
+        _ => return None,
+    };
+    Some(KindPreference { symbol_kinds, same_language_only: true })
+}
 
-    fn reference_is_unresolvable(&self, edge_kind: &str, name: &str) -> bool {
-        edge_kind == "imports" || (edge_kind == "calls_name" && operator_has_builtin_meaning(name))
+fn reference_disposition(edge_kind: EdgeKind, name: &str) -> ReferenceDisposition {
+    if edge_kind == EdgeKind::Imports
+        || (edge_kind == EdgeKind::CallsName && operator_has_builtin_meaning(name))
+    {
+        ReferenceDisposition::Unresolvable
+    } else {
+        ReferenceDisposition::Resolve
     }
+}
 
-    /// An enum case is reachable by BARE NAME only through Swift's shorthand `.idle` — the one
-    /// shape that is evidence of a case (the enum is inferred, so no qualifier exists to match
-    /// on).
-    ///
-    /// Everything else that lands on `calls_name` shares that AST shape without being a case: a
-    /// value-receiver method call (`client.idle()`) and a static member read (`Config.idle`) both
-    /// carry a receiver/qualifier. Those resolve through the qualified path when the member really
-    /// exists; when it does NOT, the bare-name fallback would otherwise bind them to an unrelated
-    /// `enum Status { case idle }` and report an ordinary property read or method call as a caller
-    /// of that case. Enum cases cannot be invoked through an arbitrary value receiver, so the bind
-    /// is never right — require the bare shape.
-    fn kind_requires_unqualified_reference(&self, edge_kind: &str, target_kind: &str) -> bool {
-        edge_kind == "calls_name" && target_kind == "enum_case"
+/// An enum case is reachable by BARE NAME only through Swift's shorthand `.idle` — the one
+/// shape that is evidence of a case (the enum is inferred, so no qualifier exists to match
+/// on).
+///
+/// Everything else that lands on `calls_name` shares that AST shape without being a case: a
+/// value-receiver method call (`client.idle()`) and a static member read (`Config.idle`) both
+/// carry a receiver/qualifier. Those resolve through the qualified path when the member really
+/// exists; when it does NOT, the bare-name fallback would otherwise bind them to an unrelated
+/// `enum Status { case idle }` and report an ordinary property read or method call as a caller
+/// of that case. Enum cases cannot be invoked through an arbitrary value receiver, so the bind
+/// is never right — require the bare shape.
+fn target_shape(edge_kind: EdgeKind, target_kind: &str) -> ReferenceShape {
+    if edge_kind == EdgeKind::CallsName && target_kind == "enum_case" {
+        ReferenceShape::UnqualifiedOnly
+    } else {
+        ReferenceShape::Any
     }
+}
 
-    fn suppress_unresolved_reference(&self, edge_kind: &str, evidence: Option<&str>) -> bool {
-        matches!(edge_kind, "uses_macro" | "references_type")
-            && evidence.is_some_and(|source| source.trim_start().starts_with('@'))
+fn unresolved_disposition(edge_kind: EdgeKind, evidence: Option<&str>) -> UnresolvedDisposition {
+    if matches!(edge_kind, EdgeKind::UsesMacro | EdgeKind::ReferencesType)
+        && evidence.is_some_and(|source| source.trim_start().starts_with('@'))
+    {
+        UnresolvedDisposition::Suppress
+    } else {
+        UnresolvedDisposition::Keep
     }
+}
 
-    fn is_local_qualified_root(&self, root: &str) -> bool {
-        is_local_qualified_root(root)
-    }
+fn qualified_root(root: &str) -> QualifiedRoot {
+    if is_local_qualified_root(root) { QualifiedRoot::Local } else { QualifiedRoot::Neutral }
 }
 
 fn operator_has_builtin_meaning(name: &str) -> bool {


### PR DESCRIPTION
## Summary

- replace `ResolverPolicy` boolean hooks with a single inspectable `ResolutionPolicy` value built from named enums and typed callbacks
- carry `EdgeKind` through core resolution and parse persisted edge-kind strings once at the database boundary
- express receiver fallback, type binding, declaration identity, import binding, qualified roots, reference shape, and unresolved handling as explicit policy choices
- add exact persisted-token round-trip coverage and a table covering every registered language policy

## Behavior

Per-language resolution semantics are unchanged. Existing Rust, Kotlin, C/C++, Python, and Swift behavior is represented by typed policy values; TypeScript and Markdown continue to use the generic resolver behavior without language-specific policy.

## Validation

- `cargo +nightly fmt --all`
- `cargo clippy -p rag-rat-core --all-targets -- -D warnings`
- `cargo nextest run -p rag-rat-core` — 1,585 passed
- `git diff --check`

Fixes #940