### PR TITLE
perf(watch): scope overlay refreshes to event paths

### DIFF
--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_overlay/lifecycle.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_overlay/lifecycle.rs
@@ -905,6 +905,100 @@ fn scoped_overlay_refresh_skips_an_unlisted_worktree_with_unchanged_basis() {
 }
 
 #[test]
+fn path_scoped_overlay_refresh_indexes_only_event_paths_and_clears_the_basis() {
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(main.join("src/a.rs"), "pub fn base_a() {}\n").unwrap();
+    fs::write(main.join("src/b.rs"), "pub fn base_b() {}\n").unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let mut config = source_config(main.clone(), Language::Rust);
+    config.watch.overlay_quiet_secs = 0;
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat-paths", linked.to_str().unwrap()]);
+    crate::watch::refresh_worktree_overlays(
+        &mut db,
+        &config,
+        None,
+        &crate::watch::OverlayScope::All,
+    );
+    let worktree_id = crate::index::worktree_id_of(&linked);
+    assert!(db.worktree_overlay_basis(&worktree_id).unwrap().is_some());
+
+    fs::write(linked.join("src/a.rs"), "pub fn event_edit() {}\n").unwrap();
+    fs::write(linked.join("src/b.rs"), "pub fn unrelated_edit() {}\n").unwrap();
+    let scope = crate::watch::OverlayScope::Paths(std::collections::BTreeMap::from([(
+        linked.clone(),
+        std::collections::BTreeSet::from([linked.join("src/a.rs")]),
+    )]));
+    assert!(crate::watch::refresh_worktree_overlays(&mut db, &config, None, &scope));
+
+    db.use_worktree_scope(&main, Some(&linked)).unwrap();
+    assert_eq!(names_in_scope(&db, "src/a.rs"), vec!["event_edit".to_string()]);
+    assert_eq!(
+        names_in_scope(&db, "src/b.rs"),
+        vec!["base_b".to_string()],
+        "the event pass must not discover an unrelated dirty path"
+    );
+    assert_eq!(
+        db.worktree_overlay_basis(&worktree_id).unwrap(),
+        None,
+        "a partial refresh cannot retain the complete-overlay skip proof"
+    );
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}
+
+#[test]
+fn widened_directory_removal_prunes_descendants_without_a_periodic_sweep() {
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(main.join("src/base.rs"), "pub fn base() {}\n").unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let mut config = source_config(main.clone(), Language::Rust);
+    config.watch.periodic_sweep_secs = 0;
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat-remove-dir", linked.to_str().unwrap()]);
+    fs::create_dir_all(linked.join("src/removed")).unwrap();
+    fs::write(linked.join("src/removed/stale.rs"), "pub fn stale_descendant() {}\n").unwrap();
+    crate::watch::refresh_worktree_overlays(
+        &mut db,
+        &config,
+        None,
+        &crate::watch::OverlayScope::All,
+    );
+    db.use_worktree_scope(&main, Some(&linked)).unwrap();
+    assert_eq!(names_in_scope(&db, "src/removed/stale.rs"), vec!["stale_descendant".to_string()]);
+
+    fs::remove_dir_all(linked.join("src/removed")).unwrap();
+    let widened = crate::watch::OverlayScope::Paths(std::collections::BTreeMap::from([(
+        linked.clone(),
+        std::collections::BTreeSet::new(),
+    )]));
+    assert!(crate::watch::refresh_worktree_overlays(&mut db, &config, None, &widened));
+    db.use_worktree_scope(&main, Some(&linked)).unwrap();
+    assert!(
+        names_in_scope(&db, "src/removed/stale.rs").is_empty(),
+        "the widened event pass must prune stale descendants even with periodic sweeps disabled"
+    );
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}
+
+#[test]
 fn scoped_overlay_refresh_refreshes_an_unlisted_worktree_whose_head_moved() {
     // #577: a commit in a linked worktree (a hook-driven pass, or a commit made without the
     // watcher observing file events) moves its HEAD. The recorded basis catches that: the pass

--- a/crates/rag-rat-core/src/watch/overlay.rs
+++ b/crates/rag-rat-core/src/watch/overlay.rs
@@ -1,3 +1,4 @@
+use std::collections::btree_map::Entry;
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 use std::time::Instant;
@@ -36,6 +37,10 @@ pub enum OverlayScope {
     /// base or linked commit is never missed just because no file event named the checkout. An
     /// empty set is a base-only pass: discovery covers the base scope regardless of this value.
     Linked(BTreeSet<PathBuf>),
+    /// Refresh exactly the event paths grouped by linked checkout. This avoids a full status walk
+    /// and base↔linked tree diff for ordinary file events. An empty path set means the checkout
+    /// was widened to a whole-delta refresh while scopes were merged.
+    Paths(BTreeMap<PathBuf, BTreeSet<PathBuf>>),
 }
 
 impl OverlayScope {
@@ -47,6 +52,8 @@ impl OverlayScope {
             Self::All => true,
             Self::Linked(roots) =>
                 roots.iter().any(|root| crate::index::worktree_id_of(root) == worktree_id),
+            Self::Paths(paths) =>
+                paths.keys().any(|root| crate::index::worktree_id_of(root) == worktree_id),
         }
     }
 
@@ -59,7 +66,41 @@ impl OverlayScope {
                 roots.extend(more);
                 Self::Linked(roots)
             },
+            (Self::Paths(mut paths), Self::Paths(more)) => {
+                for (root, more_paths) in more {
+                    match paths.entry(root) {
+                        Entry::Vacant(entry) => {
+                            entry.insert(more_paths);
+                        },
+                        Entry::Occupied(mut entry) => {
+                            let current = entry.get_mut();
+                            if more_paths.is_empty() {
+                                current.clear();
+                            } else if !current.is_empty() {
+                                current.extend(more_paths);
+                            }
+                        },
+                    }
+                }
+                Self::Paths(paths)
+            },
+            (Self::Linked(roots), Self::Paths(mut paths))
+            | (Self::Paths(mut paths), Self::Linked(roots)) => {
+                for root in roots {
+                    paths.insert(root, BTreeSet::new());
+                }
+                Self::Paths(paths)
+            },
         }
+    }
+
+    fn paths_for(&self, worktree_id: &str) -> Option<&BTreeSet<PathBuf>> {
+        let Self::Paths(paths) = self else {
+            return None;
+        };
+        paths.iter().find_map(|(root, paths)| {
+            (crate::index::worktree_id_of(root) == worktree_id).then_some(paths)
+        })
     }
 }
 
@@ -174,13 +215,36 @@ pub fn refresh_worktree_overlays(
             logical_rebuild: OverlayLogicalRebuild::Deferred,
             basis: Some(OverlayBasisUpdate { base_sha: &base_sha, linked_head_sha: &linked_head }),
         };
-        match db.index_worktree_overlay_with_tail(
-            &overlay_config,
-            Path::new(&worktree),
-            tail,
-            &mut |_| {},
-        ) {
+        let event_paths = scope.paths_for(&worktree);
+        let overlay_wide_edit = event_paths.is_some_and(|paths| {
+            paths.is_empty()
+                || paths
+                    .iter()
+                    .any(|path| is_config_path(path) || super::placement::is_gitignore_path(path))
+        });
+        let report = match event_paths.filter(|_| basis_unchanged && !overlay_wide_edit) {
+            Some(event_paths) => {
+                let event_paths = event_paths.iter().cloned().collect::<Vec<_>>();
+                db.index_worktree_overlay_paths(
+                    &overlay_config,
+                    Path::new(&worktree),
+                    &event_paths,
+                    OverlayLogicalRebuild::Deferred,
+                    &mut |_| {},
+                )
+            },
+            None => db.index_worktree_overlay_with_tail(
+                &overlay_config,
+                Path::new(&worktree),
+                tail,
+                &mut |_| {},
+            ),
+        };
+        match report {
             Ok(report) => {
+                if !report.status_complete && !report.worktree_id.is_empty() {
+                    let _ = db.clear_worktree_overlay_basis(&report.worktree_id);
+                }
                 let this_changed = report.indexed > 0 || report.tombstoned > 0 || report.pruned > 0;
                 changed |= this_changed;
                 // Embed the overlay's chunks NOW, while the connection is still scoped to this
@@ -319,11 +383,10 @@ impl ReconcileBudget {
 /// - a path under a LINKED worktree goes through that checkout's OVERLAY instead. This is
 ///   load-bearing: `find_config` re-anchors `config.root` to the MAIN checkout, so a linked edit is
 ///   not in the base tree — a base pass would `strip_prefix` it away and silently drop it. NOTE the
-///   overlay pass is per-CHECKOUT, not per-path: [`IndexDatabase::index_worktree_overlay`]
-///   reindexes the worktree's whole base↔branch delta (there is no path-scoped overlay primitive
-///   today — see #679), so a linked `index --paths` also refreshes any OTHER pending change in that
-///   checkout. A failure PROPAGATES (unlike the best-effort watcher/maintenance sweep), so an edit
-///   hook can retry instead of exiting 0 on a drop.
+///   overlay pass is path-scoped through [`IndexDatabase::index_worktree_overlay_paths`], so a
+///   linked edit does not pull in unrelated in-flight changes in the same checkout. A failure
+///   PROPAGATES (unlike the best-effort watcher/maintenance sweep), so an edit hook can retry
+///   instead of exiting 0 on a drop.
 ///
 /// The per-repo `WriteLock` is held across BOTH halves (the base pass re-acquires it reentrantly),
 /// mirroring the maintenance path. Returns the base db so the caller can read base-scoped status.

--- a/crates/rag-rat-core/src/watch/placement.rs
+++ b/crates/rag-rat-core/src/watch/placement.rs
@@ -1,8 +1,9 @@
-use std::collections::BTreeSet;
+use std::collections::btree_map::Entry;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Component, Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use notify::event::{AccessKind, AccessMode, EventKind, ModifyKind, RenameMode};
+use notify::event::{AccessKind, AccessMode, EventKind, ModifyKind, RemoveKind, RenameMode};
 use notify::{Event, RecursiveMode};
 use rag_rat_base::config::Config;
 
@@ -265,6 +266,15 @@ impl LinkedWorktreeWatch {
             .ok()
             .is_some_and(|rel| target_for_path(&self.config, rel).is_some())
     }
+
+    fn touches_tree_event(&self, path: &Path) -> bool {
+        self.touches_event(path)
+            || path.strip_prefix(&self.config.root).ok().is_some_and(|relative| {
+                self.target_dirs
+                    .iter()
+                    .any(|target| relative.starts_with(target) || target.starts_with(relative))
+            })
+    }
 }
 
 #[derive(Debug, Default)]
@@ -329,17 +339,51 @@ impl LinkedWorktreeWatches {
         if !kind_is_mutation(&event.kind) {
             return WorktreeEventHint::None;
         }
-        let mut roots = BTreeSet::new();
+        // The path primitive can tombstone an explicit file, but it cannot enumerate stale
+        // descendants after a directory disappears. Widen removal-side directory/ambiguous rename
+        // events to a whole-checkout refresh; paired renames stay path-scoped only when the
+        // surviving destination proves this was a regular file.
+        let whole_checkout = match event.kind {
+            EventKind::Remove(RemoveKind::File) => false,
+            EventKind::Remove(_) => true,
+            EventKind::Modify(ModifyKind::Name(RenameMode::To)) =>
+                event.paths.iter().any(|path| path.is_dir()),
+            EventKind::Modify(ModifyKind::Name(RenameMode::Both)) =>
+                event.paths.last().is_none_or(|path| !path.is_file()),
+            EventKind::Modify(ModifyKind::Name(
+                RenameMode::From | RenameMode::Any | RenameMode::Other,
+            )) => true,
+            _ => false,
+        };
+        let mut paths = BTreeMap::<PathBuf, BTreeSet<PathBuf>>::new();
         for path in &event.paths {
             if registry.is_some_and(|reg| path.starts_with(reg)) {
                 // A worktree add/remove: the live set itself changed — unattributable.
                 return WorktreeEventHint::AllWorktrees;
             }
-            for state in self.states.iter().filter(|state| state.touches_event(path)) {
-                roots.insert(state.checkout_root.clone());
+            for state in self.states.iter().filter(|state| {
+                if whole_checkout {
+                    state.touches_tree_event(path)
+                } else {
+                    state.touches_event(path)
+                }
+            }) {
+                if whole_checkout {
+                    paths.entry(state.checkout_root.clone()).or_default().clear();
+                } else {
+                    match paths.entry(state.checkout_root.clone()) {
+                        Entry::Vacant(entry) => {
+                            entry.insert(BTreeSet::from([path.clone()]));
+                        },
+                        Entry::Occupied(mut entry) if !entry.get().is_empty() => {
+                            entry.get_mut().insert(path.clone());
+                        },
+                        Entry::Occupied(_) => {},
+                    }
+                }
             }
         }
-        if roots.is_empty() { WorktreeEventHint::None } else { WorktreeEventHint::Roots(roots) }
+        if paths.is_empty() { WorktreeEventHint::None } else { WorktreeEventHint::Paths(paths) }
     }
 }
 
@@ -350,8 +394,8 @@ impl LinkedWorktreeWatches {
 pub(crate) enum WorktreeEventHint {
     /// No linked checkout is touched.
     None,
-    /// The event touches these linked checkout roots.
-    Roots(BTreeSet<PathBuf>),
+    /// The event touches these paths, grouped by linked checkout root.
+    Paths(BTreeMap<PathBuf, BTreeSet<PathBuf>>),
     /// Unattributable — refresh every overlay.
     AllWorktrees,
 }
@@ -641,7 +685,7 @@ pub(crate) fn event_requests_maintenance(
     }
     let scope = match worktree_hint {
         WorktreeEventHint::AllWorktrees => OverlayScope::All,
-        WorktreeEventHint::Roots(roots) => OverlayScope::Linked(roots),
+        WorktreeEventHint::Paths(paths) => OverlayScope::Paths(paths),
         WorktreeEventHint::None => OverlayScope::Linked(BTreeSet::new()),
     };
     Some(scope.merge(OverlayScope::Linked(linked_created_dir_roots)))

--- a/crates/rag-rat-core/src/watch/tests.rs
+++ b/crates/rag-rat-core/src/watch/tests.rs
@@ -1,11 +1,13 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::RecvTimeoutError;
 use std::time::{Duration, Instant};
 
-use notify::event::{AccessKind, AccessMode, CreateKind, EventKind, Flag, ModifyKind};
+use notify::event::{
+    AccessKind, AccessMode, CreateKind, EventKind, Flag, ModifyKind, RemoveKind, RenameMode,
+};
 use notify::{Event, RecursiveMode, Watcher as _, recommended_watcher};
 use rag_rat_base::config::{
     Config, LlmConfig, RemoteBackend, RemoteEmbeddingConfig, ResolvedTarget, TargetKind,
@@ -615,6 +617,36 @@ fn overlay_scope_merge_unions_roots_and_all_absorbs() {
         a.clone().merge(OverlayScope::Linked(BTreeSet::new())),
         a,
         "a base-only contribution adds no roots"
+    );
+
+    let paths = OverlayScope::Paths(BTreeMap::from([
+        (PathBuf::from("/wt/a"), BTreeSet::from([PathBuf::from("/wt/a/src/a.rs")])),
+        (PathBuf::from("/wt/b"), BTreeSet::from([PathBuf::from("/wt/b/src/b.rs")])),
+    ]));
+    assert_eq!(
+        paths.merge(OverlayScope::Linked(BTreeSet::from([PathBuf::from("/wt/a")]))),
+        OverlayScope::Paths(BTreeMap::from([
+            (PathBuf::from("/wt/a"), BTreeSet::new()),
+            (PathBuf::from("/wt/b"), BTreeSet::from([PathBuf::from("/wt/b/src/b.rs")]),),
+        ])),
+        "a whole-checkout contribution widens only that checkout"
+    );
+
+    let a_paths = OverlayScope::Paths(BTreeMap::from([(
+        PathBuf::from("/wt/a"),
+        BTreeSet::from([PathBuf::from("/wt/a/src/a.rs")]),
+    )]));
+    let b_paths = OverlayScope::Paths(BTreeMap::from([(
+        PathBuf::from("/wt/b"),
+        BTreeSet::from([PathBuf::from("/wt/b/src/b.rs")]),
+    )]));
+    assert_eq!(
+        a_paths.merge(b_paths),
+        OverlayScope::Paths(BTreeMap::from([
+            (PathBuf::from("/wt/a"), BTreeSet::from([PathBuf::from("/wt/a/src/a.rs")])),
+            (PathBuf::from("/wt/b"), BTreeSet::from([PathBuf::from("/wt/b/src/b.rs")])),
+        ])),
+        "a newly-seen checkout retains its event paths"
     );
 }
 
@@ -1515,17 +1547,43 @@ fn event_touches_worktree_attributes_the_touched_checkout_roots() {
 
     assert_eq!(
         event_touches_worktree(&mutation_event(wt_a.join("src/a.rs")), &worktrees, None),
-        WorktreeEventHint::Roots(BTreeSet::from([wt_a.clone()])),
+        WorktreeEventHint::Paths(BTreeMap::from([(
+            wt_a.clone(),
+            BTreeSet::from([wt_a.join("src/a.rs")]),
+        )])),
         "a target edit is attributed to its own checkout only"
     );
     assert_eq!(
         event_touches_worktree(&mutation_event(wt_b.join("src/b.rs")), &worktrees, None),
-        WorktreeEventHint::Roots(BTreeSet::from([wt_b.clone()])),
+        WorktreeEventHint::Paths(BTreeMap::from([(
+            wt_b.clone(),
+            BTreeSet::from([wt_b.join("src/b.rs")]),
+        )])),
     );
     assert_eq!(
         event_touches_worktree(&mutation_event(wt_a.join("README.md")), &worktrees, None),
         WorktreeEventHint::None,
         "a non-target path implicates nothing"
+    );
+    assert_eq!(
+        event_touches_worktree(
+            &Event::new(EventKind::Remove(RemoveKind::Folder)).add_path(wt_a.join("src/removed")),
+            &worktrees,
+            None,
+        ),
+        WorktreeEventHint::Paths(BTreeMap::from([(wt_a.clone(), BTreeSet::new())])),
+        "a removed directory widens its checkout because explicit-path indexing cannot tombstone \
+         descendants"
+    );
+    assert_eq!(
+        event_touches_worktree(
+            &Event::new(EventKind::Modify(ModifyKind::Name(RenameMode::From)))
+                .add_path(wt_b.join("src/moved")),
+            &worktrees,
+            None,
+        ),
+        WorktreeEventHint::Paths(BTreeMap::from([(wt_b.clone(), BTreeSet::new())])),
+        "a removal-side rename is directory-ambiguous and must widen its checkout"
     );
     assert_eq!(
         event_touches_worktree(
@@ -1547,7 +1605,10 @@ fn event_touches_worktree_attributes_the_touched_checkout_roots() {
     // its checkout so the overlay is refreshed with the new branch config.
     assert_eq!(
         event_touches_worktree(&mutation_event(wt_b.join("rag-rat.toml")), &worktrees, None),
-        WorktreeEventHint::Roots(BTreeSet::from([wt_b.clone()])),
+        WorktreeEventHint::Paths(BTreeMap::from([(
+            wt_b.clone(),
+            BTreeSet::from([wt_b.join("rag-rat.toml")]),
+        )])),
         "a linked checkout's config edit fires for that checkout"
     );
     assert_eq!(


### PR DESCRIPTION
## Summary

- preserve exact changed paths from linked-worktree watcher events through debounce scheduling
- use the path-scoped overlay refresh when the recorded base and linked HEAD basis still matches
- retain whole-delta refreshes for rescans, registry changes, created directories, config and ignore-rule edits, and HEAD-basis changes
- clear the complete-refresh basis after partial event-path refreshes so periodic sweeps remain the missed-event backstop

## Verification

- `cargo +nightly fmt --check`
- `cargo clippy -p rag-rat-core --all-targets -- -D warnings`
- `cargo nextest run -p rag-rat-core`
- `cargo test -p rag-rat-core path_scoped_overlay_refresh_indexes_only_event_paths_and_clears_the_basis -- --nocapture`

Fixes #829