### PR TITLE
perf(watch): skip full discovery on safe clean scopes

### DIFF
--- a/crates/rag-rat-core/src/index/incremental.rs
+++ b/crates/rag-rat-core/src/index/incremental.rs
@@ -81,8 +81,23 @@ impl IndexDatabase {
     where
         F: FnMut(IndexProgress),
     {
-        Self::index_incremental_with_progress(config, IndexMode::Changed, None, &mut progress)
-            .map(|(db, _)| db)
+        Self::index_incremental_with_progress(
+            config,
+            IndexMode::Changed,
+            None,
+            false,
+            &mut progress,
+        )
+        .map(|(db, _)| db)
+    }
+
+    /// Watcher-safe reporting entry point. A complete, clean Git scope with no worktree-scoped
+    /// rows uses the cheap `Changed` preparation; every ambiguous case retains authoritative
+    /// discovery semantics (non-Git roots, dirty paths, and stale untracked/modified rows).
+    pub(crate) fn index_watch_reporting(
+        config: &Config,
+    ) -> anyhow::Result<(Self, IncrementalPassReport)> {
+        Self::index_incremental_with_progress(config, IndexMode::Changed, None, true, &mut |_| {})
     }
 
     /// Reconcile exactly the supplied candidate `paths` (#659) — the edit-driven-reindex substrate.
@@ -105,8 +120,14 @@ impl IndexDatabase {
     where
         F: FnMut(IndexProgress),
     {
-        Self::index_incremental_with_progress(config, IndexMode::Paths, Some(paths), &mut progress)
-            .map(|(db, _)| db)
+        Self::index_incremental_with_progress(
+            config,
+            IndexMode::Paths,
+            Some(paths),
+            false,
+            &mut progress,
+        )
+        .map(|(db, _)| db)
     }
 
     pub fn index_discover(config: &Config) -> anyhow::Result<Self> {
@@ -117,23 +138,29 @@ impl IndexDatabase {
     where
         F: FnMut(IndexProgress),
     {
-        Self::index_incremental_with_progress(config, IndexMode::Discover, None, &mut progress)
-            .map(|(db, _)| db)
+        Self::index_incremental_with_progress(
+            config,
+            IndexMode::Discover,
+            None,
+            false,
+            &mut progress,
+        )
+        .map(|(db, _)| db)
     }
 
     /// Like [`Self::index_discover`], but also reports whether the pass changed index *content*
-    /// (a file was added / edited / removed). The watch loop uses this to skip the
-    /// reconcile / memory-validate tail on an idle no-change sweep (issue #63).
+    /// (a file was added / edited / removed).
     pub(crate) fn index_discover_reporting(
         config: &Config,
     ) -> anyhow::Result<(Self, IncrementalPassReport)> {
-        Self::index_incremental_with_progress(config, IndexMode::Discover, None, &mut |_| {})
+        Self::index_incremental_with_progress(config, IndexMode::Discover, None, false, &mut |_| {})
     }
 
     fn index_incremental_with_progress<F>(
         config: &Config,
         mode: IndexMode,
         explicit_paths: Option<&[PathBuf]>,
+        watch_safe_fast_path: bool,
         progress: &mut F,
     ) -> anyhow::Result<(Self, IncrementalPassReport)>
     where
@@ -288,12 +315,14 @@ impl IndexDatabase {
         // HEAD/target fingerprint, #459) to complete the scope; the named paths are a
         // subset discovery already covers. On a COMPLETE scope, `Paths` keeps its scoped
         // behavior.
-        let effective_mode =
-            if active_scope_incomplete && matches!(mode, IndexMode::Changed | IndexMode::Paths) {
-                IndexMode::Discover
-            } else {
-                mode
-            };
+        let effective_mode = if (active_scope_incomplete
+            && matches!(mode, IndexMode::Changed | IndexMode::Paths))
+            || (watch_safe_fast_path && !db.watch_changed_fast_path_is_safe(config))
+        {
+            IndexMode::Discover
+        } else {
+            mode
+        };
         progress(IndexProgress::Started {
             database: config.database.clone(),
             mode: effective_mode,
@@ -558,6 +587,30 @@ impl IndexDatabase {
         // via its full DB scan.
         let clone_delta_hint = (healed == 0).then_some(touched_base_paths);
         Ok((db, IncrementalPassReport { content_changed, clone_delta_hint }))
+    }
+
+    /// A git-status-only pass is authoritative for the watcher only when there is no current
+    /// filesystem ambiguity. Worktree-scoped rows include untracked and modified content; if Git
+    /// now reports a clean tree, discovery must reconcile rows whose untracked file vanished or
+    /// whose tracked file was restored. Any current dirt is also discovered so ignore changes and
+    /// symlink replacements retain the authoritative walk's semantics.
+    fn watch_changed_fast_path_is_safe(&self, config: &Config) -> bool {
+        let Ok(changes) = git_changed_paths(&config.root) else {
+            return false;
+        };
+        if !changes.changed.is_empty() || !changes.deleted.is_empty() {
+            return false;
+        }
+        self.storage
+            .connection()
+            .query_row(
+                "SELECT NOT EXISTS(
+                    SELECT 1 FROM files WHERE worktree_id <> ''
+                )",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap_or(false)
     }
 
     /// Standalone full-corpus indexing into the CURRENT context — no generation staging, no

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/git_history_reload.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/git_history_reload.rs
@@ -985,22 +985,108 @@ fn idle_discover_sweep_does_not_rewrite_indexed_at_ms() {
 }
 
 #[test]
-fn index_discover_reporting_flags_content_changes() {
+fn index_watch_reporting_flags_content_changes() {
     let root = unique_temp_root();
     let _ = fs::remove_dir_all(&root);
     let config = git_history_test_config(&root);
     IndexDatabase::rebuild(&config).unwrap();
 
     // No change → reports false, so the watch loop skips the reconcile / memory-validate tail.
-    let (_db, pass) = IndexDatabase::index_discover_reporting(&config).unwrap();
-    assert!(!pass.content_changed, "an unchanged discover sweep must report no content change");
+    let (_db, pass) = IndexDatabase::index_watch_reporting(&config).unwrap();
+    assert!(!pass.content_changed, "an unchanged changed-mode pass must report no content change");
 
     // A new file on disk → reports true.
     fs::write(root.join("docs/extra.md"), "# Extra\nbody text\n").unwrap();
-    let (_db, pass) = IndexDatabase::index_discover_reporting(&config).unwrap();
+    let (_db, pass) = IndexDatabase::index_watch_reporting(&config).unwrap();
     assert!(
         pass.content_changed,
-        "a discover sweep that indexes a new file must report a content change"
+        "a changed-mode pass that indexes a new file must report a content change"
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn watch_reporting_discovers_a_vanished_untracked_file() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    let config = git_history_test_config(&root);
+    IndexDatabase::rebuild(&config).unwrap();
+
+    fs::write(root.join("docs/untracked.md"), "# Untracked\n").unwrap();
+    let (db, pass) = IndexDatabase::index_watch_reporting(&config).unwrap();
+    assert!(pass.content_changed);
+    assert_eq!(
+        db.storage
+            .connection()
+            .query_row("SELECT COUNT(*) FROM files WHERE path = 'docs/untracked.md'", [], |row| {
+                row.get::<_, i64>(0)
+            })
+            .unwrap(),
+        1
+    );
+    drop(db);
+
+    fs::remove_file(root.join("docs/untracked.md")).unwrap();
+    let (db, pass) = IndexDatabase::index_watch_reporting(&config).unwrap();
+    assert!(pass.content_changed, "the stale worktree-scoped row must force discovery");
+    assert_eq!(
+        db.storage
+            .connection()
+            .query_row("SELECT COUNT(*) FROM files WHERE path = 'docs/untracked.md'", [], |row| {
+                row.get::<_, i64>(0)
+            })
+            .unwrap(),
+        0
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn watch_reporting_discovers_ignore_rule_changes() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    let config = git_history_test_config(&root);
+    IndexDatabase::rebuild(&config).unwrap();
+
+    fs::write(root.join(".gitignore"), ".rag-rat/\ndocs/search.md\n").unwrap();
+    let (db, pass) = IndexDatabase::index_watch_reporting(&config).unwrap();
+    assert!(pass.content_changed);
+    assert_eq!(
+        db.storage
+            .connection()
+            .query_row("SELECT COUNT(*) FROM files WHERE path = 'docs/search.md'", [], |row| {
+                row.get::<_, i64>(0)
+            })
+            .unwrap(),
+        0
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[cfg(unix)]
+#[test]
+fn watch_reporting_does_not_index_a_changed_symlink() {
+    use std::os::unix::fs::symlink;
+
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    let config = git_history_test_config(&root);
+    IndexDatabase::rebuild(&config).unwrap();
+
+    symlink("guide.md", root.join("docs/link.md")).unwrap();
+    let (db, pass) = IndexDatabase::index_watch_reporting(&config).unwrap();
+    assert!(!pass.content_changed, "the authoritative walk must reject the symlink");
+    assert_eq!(
+        db.storage
+            .connection()
+            .query_row("SELECT COUNT(*) FROM files WHERE path = 'docs/link.md'", [], |row| {
+                row.get::<_, i64>(0)
+            })
+            .unwrap(),
+        0
     );
 
     let _ = fs::remove_dir_all(root);

--- a/crates/rag-rat-core/src/watch/pass.rs
+++ b/crates/rag-rat-core/src/watch/pass.rs
@@ -324,8 +324,8 @@ fn run_pass(
     // "nothing to index yet" and DEFERS silently — a later pass registers once real content
     // appears. A recorded root going empty still prunes (not first-time → not refused). The
     // one-shot `index` command instead surfaces the same error to the operator.
-    let discover = timings.stage("discover", || IndexDatabase::index_discover_reporting(config));
-    let (mut db, pass) = match discover {
+    let index = timings.stage("index", || IndexDatabase::index_watch_reporting(config));
+    let (mut db, pass) = match index {
         Ok(result) => result,
         Err(err) if err.downcast_ref::<crate::index::EmptyIndexRefused>().is_some() => {
             return Ok(());


### PR DESCRIPTION
## Summary

- enter watcher base maintenance through Changed preparation only for clean Git checkouts with a complete active scope and no worktree-scoped rows
- retain authoritative discovery for non-Git roots, dirty paths, ignore-rule changes, symlink replacements, and stale untracked or modified rows
- preserve the existing automatic discovery promotion for bootstrap, HEAD moves, and target changes
- retain content-change and clone-delta reporting for the watcher tail

Fixes #955

## Verification

- `cargo +nightly fmt --all --check`
- `cargo check -q -p rag-rat-core --tests`
- `cargo nextest run -p rag-rat-core` — 1593 passed, 2 skipped
- `cargo clippy -q -p rag-rat-core --all-targets -- -D warnings`
- `git diff --check`

Regression coverage includes non-Git maintenance, vanished untracked files, ignore-rule changes, and changed symlinks.