### PR TITLE
feat(mcp): publish rag-rat to the MCP Registry

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -28,6 +28,7 @@ on:
 
 permissions:
   contents: read # read the release assets (publishing goes to npm via NPM_TOKEN)
+  id-token: write # authenticate to the MCP Registry with GitHub OIDC
 
 jobs:
   publish:
@@ -113,6 +114,41 @@ jobs:
           else
             npm publish --access public
           fi
+
+      - name: Publish MCP server metadata
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          version="${TAG#v}"
+          jq --arg version "$version" \
+            '.version = $version | .packages[0].version = $version' \
+            server.json > server.release.json
+          server_name="$(jq -r '.name | @uri' server.release.json)"
+          encoded_version="$(jq -rn --arg value "$version" '$value | @uri')"
+          registry_url="https://registry.modelcontextprotocol.io/v0.1/servers/${server_name}/versions/${encoded_version}"
+          status="$(
+            curl --silent --show-error --retry 3 --retry-all-errors \
+              --output registry-response.json --write-out '%{http_code}' "$registry_url"
+          )"
+          case "$status" in
+            200)
+              echo "MCP server metadata for $version is already published — skipping"
+              exit 0
+              ;;
+            404)
+              ;;
+            *)
+              cat registry-response.json >&2
+              echo "MCP Registry version lookup failed with HTTP $status" >&2
+              exit 1
+              ;;
+          esac
+          curl -L \
+            "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" \
+            | tar xz mcp-publisher
+          ./mcp-publisher login github-oidc
+          ./mcp-publisher publish server.release.json
 
       # ── @rag-rat/skills + @rag-rat/cookbook: publish only when their version is new ───────────────
       - name: Publish @rag-rat/plugin-opencode (only if this version is new)

--- a/dist-android/patch-npm-package.mjs
+++ b/dist-android/patch-npm-package.mjs
@@ -8,8 +8,9 @@
 // attach to the GitHub release separately (release-android.yml).
 //
 // This runs on the freshly generated package BEFORE publish and:
-//   1. adds an `aarch64-linux-android` entry to package.json `supportedPlatforms`, and
-//   2. inserts a `process.platform === "android"` short-circuit at the top of binary.js
+//   1. adds the MCP Registry ownership marker and public homepage to package.json,
+//   2. adds an `aarch64-linux-android` entry to package.json `supportedPlatforms`, and
+//   3. inserts a `process.platform === "android"` short-circuit at the top of binary.js
 //      getPlatform() — os.type() reports "Linux" on Termux, so the stock glibc/musl detection would
 //      mis-resolve to a triple that either errors or downloads a non-bionic binary.
 //
@@ -20,6 +21,8 @@ import { readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 const ANDROID_TRIPLE = "aarch64-linux-android";
+const MCP_NAME = "io.github.cq27-dev/rag-rat";
+const HOMEPAGE = "https://rag-rat.cq27.dev/";
 
 // `.tar.gz`, not cargo-dist's default `.tar.xz`: Termux always ships gzip, but `xz-utils` is an
 // extra package the installer's `tar xf` would otherwise silently need.
@@ -69,6 +72,8 @@ if (!pkg.supportedPlatforms || typeof pkg.supportedPlatforms !== "object") {
 if (pkg.supportedPlatforms[ANDROID_TRIPLE]) {
   fail(`${pkgPath}: ${ANDROID_TRIPLE} already present — double patch?`);
 }
+pkg.mcpName = MCP_NAME;
+pkg.homepage = HOMEPAGE;
 pkg.supportedPlatforms[ANDROID_TRIPLE] = ANDROID_ENTRY;
 writeFileSync(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`);
 

--- a/dist-android/test-npm-package.cjs
+++ b/dist-android/test-npm-package.cjs
@@ -12,6 +12,18 @@ const assert = require("assert");
 const pkgDir = path.resolve(process.argv[2] || "target/distrib/rag-rat-npm-package");
 const binaryPath = path.join(pkgDir, "binary.js");
 const pkgJsonPath = path.join(pkgDir, "package.json");
+const pkg = require(pkgJsonPath);
+
+assert.strictEqual(
+  pkg.mcpName,
+  "io.github.cq27-dev/rag-rat",
+  "npm package must carry the MCP Registry ownership marker",
+);
+assert.strictEqual(
+  pkg.homepage,
+  "https://rag-rat.cq27.dev/",
+  "npm package should direct users to the public homepage",
+);
 
 // Load a fresh binary.js under a faked os.type()/os.arch()/process.platform, and return the
 // download URL getPackage() would fetch. Cache-busts so each case re-evaluates getPlatform().
@@ -47,6 +59,6 @@ assert.ok(
   `desktop (darwin/arm64) should still resolve to apple-darwin, got: ${darwinUrl}`,
 );
 
-console.error("test-npm-package: android + desktop resolution OK");
+console.error("test-npm-package: registry metadata + android + desktop resolution OK");
 console.error(`  android: ${androidUrl}`);
 console.error(`  darwin:  ${darwinUrl}`);

--- a/server.json
+++ b/server.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.cq27-dev/rag-rat",
+  "title": "rag-rat",
+  "description": "Repository intelligence, code graph, history, papertrail, and cross-agent memory for coding agents.",
+  "version": "0.21.1",
+  "websiteUrl": "https://rag-rat.cq27.dev/",
+  "repository": {
+    "url": "https://github.com/cq27-dev/rag-rat",
+    "source": "github"
+  },
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "@rag-rat/bin",
+      "version": "0.21.1",
+      "runtimeHint": "npx",
+      "runtimeArguments": [
+        {
+          "type": "positional",
+          "value": "-y"
+        }
+      ],
+      "packageArguments": [
+        {
+          "type": "positional",
+          "value": "mcp"
+        }
+      ],
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- add the official MCP Registry `server.json` metadata for `io.github.cq27-dev/rag-rat`
- inject the required npm ownership marker and public homepage into the generated `@rag-rat/bin` package
- publish version-matched registry metadata from stable release tags using GitHub OIDC
- cover the generated package metadata in the existing installer regression test

## Why

The MCP Registry verifies npm ownership through the package's `mcpName` field. `@rag-rat/bin` is generated by cargo-dist during a release, so the marker must be added to that generated artifact before npm publication. Registry metadata must then use the same version as the release tag and published npm package.

The current npm version remains unchanged; the first registry publication will occur with the next stable release containing the ownership marker.

## Validation

- `mcp-publisher validate server.json`
- patched and tested the cargo-dist npm artifact from release `v0.21.1`
- `node --check dist-android/patch-npm-package.mjs`
- `node --check dist-android/test-npm-package.cjs`
- `git diff --check origin/main...HEAD`