### PR TITLE
eval(dream): reject intent context for verification

### DIFF
--- a/crates/rag-rat-cli/src/cli.rs
+++ b/crates/rag-rat-cli/src/cli.rs
@@ -132,6 +132,11 @@ pub(crate) enum Command {
     #[command(hide = true)]
     DumpVerifyPacks(DumpVerifyPacksArgs),
 
+    /// Recompute production verifier-input hashes for existing memories. Eval fixture helper.
+    #[cfg(feature = "eval")]
+    #[command(hide = true)]
+    DumpMemoryInputHashes(DumpMemoryInputHashesArgs),
+
     /// SCIP-oracle pass: compiler-grade edge resolution from a language indexer.
     Oracle(OracleArgs),
 
@@ -507,6 +512,23 @@ pub(crate) struct DumpVerifyPacksArgs {
     #[arg(long)]
     pub root_label: String,
     /// Output JSON path: `{ "<eval_id>|<root_label>": "<pack text>" }`.
+    #[arg(long)]
+    pub out: PathBuf,
+}
+
+#[cfg(feature = "eval")]
+#[derive(Debug, Args)]
+pub(crate) struct DumpMemoryInputHashesArgs {
+    /// Existing index database whose memories should be resolved.
+    #[arg(long)]
+    pub db: PathBuf,
+    /// Repository scope containing the memories.
+    #[arg(long)]
+    pub repo_id: String,
+    /// Input JSON array of existing memory ids.
+    #[arg(long)]
+    pub memory_ids: PathBuf,
+    /// Output JSON object mapping each memory id to its current production input hash.
     #[arg(long)]
     pub out: PathBuf,
 }

--- a/crates/rag-rat-cli/src/commands/dump_verify_packs.rs
+++ b/crates/rag-rat-cli/src/commands/dump_verify_packs.rs
@@ -16,7 +16,7 @@ use rag_rat_query::memory::{RepoMemoryBindTarget, RepoMemoryCreate};
 use rag_rat_query::symbol::SymbolSelector;
 use serde::Deserialize;
 
-use crate::cli::DumpVerifyPacksArgs;
+use crate::cli::{DumpMemoryInputHashesArgs, DumpVerifyPacksArgs};
 use crate::open_index;
 
 /// The regeneration spec: the eval memories to insert, plus which of them to dump packs for.
@@ -142,5 +142,37 @@ pub(crate) fn dump_verify_packs(config: &Config, args: &DumpVerifyPacksArgs) -> 
 
     std::fs::write(&args.out, serde_json::to_string_pretty(&packs)?)?;
     eprintln!("wrote {} packs (root {}) to {}", packs.len(), args.root_label, args.out.display());
+    Ok(())
+}
+
+/// Recompute the exact production verifier-input hash for existing memories. Unlike
+/// [`dump_verify_packs`], this is read-only and operates on the configured live index; it exists so
+/// offline fixture exporters cannot mistake a merely non-null stored hash for a fresh verdict.
+pub(crate) fn dump_memory_input_hashes(
+    config: &Config,
+    args: &DumpMemoryInputHashesArgs,
+) -> anyhow::Result<()> {
+    let memory_ids: Vec<String> =
+        serde_json::from_str(&std::fs::read_to_string(&args.memory_ids)?)?;
+    let storage = rag_rat_db::storage::IndexConnection::open_read_only_blocking(&args.db)?;
+    rag_rat_core::index::install_worktree_scope_view(
+        storage.connection(),
+        &args.repo_id,
+        &config.root,
+        &config.root,
+    )?;
+    let scope = Some(args.repo_id.clone());
+    let mut hashes = BTreeMap::new();
+    for memory_id in memory_ids {
+        let hash = rag_rat_query::memory::evidence::checked_inputs_hash(
+            storage.connection(),
+            &memory_id,
+            &scope,
+        )
+        .map_err(|error| anyhow::anyhow!("hashing verifier inputs for `{memory_id}`: {error}"))?;
+        hashes.insert(memory_id, hash);
+    }
+    std::fs::write(&args.out, serde_json::to_string_pretty(&hashes)?)?;
+    eprintln!("wrote {} verifier-input hashes to {}", hashes.len(), args.out.display());
     Ok(())
 }

--- a/crates/rag-rat-cli/src/commands/mod.rs
+++ b/crates/rag-rat-cli/src/commands/mod.rs
@@ -27,7 +27,7 @@ pub(crate) use config_info::{dump_config, version_check};
 pub(crate) use consolidate::consolidate;
 pub(crate) use distill::distill;
 #[cfg(feature = "eval")]
-pub(crate) use dump_verify_packs::dump_verify_packs;
+pub(crate) use dump_verify_packs::{dump_memory_input_hashes, dump_verify_packs};
 pub(crate) use format::{output_format, set_output_format};
 pub(crate) use hooks::{hooks, papertrail};
 pub(crate) use index_ops::{doctor, doctor_global_store, index, maintenance, reconcile};

--- a/crates/rag-rat-cli/src/main.rs
+++ b/crates/rag-rat-cli/src/main.rs
@@ -159,6 +159,8 @@ fn main() -> anyhow::Result<()> {
         Cmd::BenchmarkEmbedding(args) => benchmark_embedding(&config, &args)?,
         #[cfg(feature = "eval")]
         Cmd::DumpVerifyPacks(args) => dump_verify_packs(&config, &args)?,
+        #[cfg(feature = "eval")]
+        Cmd::DumpMemoryInputHashes(args) => dump_memory_input_hashes(&config, &args)?,
         Cmd::Oracle(args) => oracle(&config, &args)?,
         Cmd::Consolidate => {
             let config_path = cli

--- a/evals/memory-compaction/README.md
+++ b/evals/memory-compaction/README.md
@@ -81,6 +81,48 @@ MoE activation size is not the deployment memory floor: Coder-Next activates 3B 
 token but its 80B FP8 checkpoint still requires an H200-class box in this harness. Keep model
 selection tied to the reviewed replay rather than general coding benchmarks.
 
+### Intent-context ablation (#957)
+
+`reviewed_verify_intent_context` keeps three epistemic layers separate while replaying the same 36
+reviewed cases and the same source packs:
+
+1. **NOTE** is the historical claim being classified.
+2. **INTENT CONTEXT** is bounded, non-citable interpretation help from freshness-stamped `current`
+   neighboring memories and distilled-papertrail records linked through current bound paths.
+3. **EVIDENCE PACK** remains the only proof of current checkout state and the only admissible source
+   of `EVIDENCE:` lines.
+
+The entrypoint runs four temperature-zero arms in one model load: `source-only`, `verified-memory`,
+`papertrail`, and `combined`. Intent rows use `INTENT MEMORY` / `INTENT PAPERTRAIL` labels rather
+than identifier-table or `path:line:` syntax, and the offline production guard still receives only
+the frozen source pack. `harness/test_intent_context.py` pins both boundaries.
+
+The context fixture records provenance explicitly. The source packs are frozen at `c5303848`; the
+available dogfood context snapshot is `f9ae8f7f` and its neighboring-memory verdicts use
+`verify-pack-v3`. Only rows stamped `current` against that exact indexed commit, with matching note
+content hashes, non-null checked-input hashes, and no binding recreated after the verdict check are
+eligible. The exporter also recomputes each candidate's input hash through the shipped Rust
+resolver and requires an exact match with the stored stamp; an unchanged HEAD alone is not treated
+as freshness because an index may contain uncommitted source changes. This makes the arm an offline
+historical experiment, not evidence that the two snapshots are identical. Re-exporting records the
+new context commit/version rather than silently changing that claim.
+
+The Qwen3-4B temperature-zero ablation (Modal run `ap-TrGVrolU345ouPggx1c3eX`) rejected the
+proposal for production use:
+
+| arm | accepted false positives | true positives | discarded |
+|---|---:|---:|---:|
+| source-only | 1 / 33 | 3 / 3 | 17 / 36 |
+| verified-memory | 1 / 33 | 3 / 3 | 17 / 36 |
+| papertrail | 1 / 33 | 3 / 3 | 17 / 36 |
+| combined | 1 / 33 | 3 / 3 | 17 / 36 |
+
+The aggregate counts hide a per-case regression: every intent arm repaired the source-only false
+positive on `reviewed_26` but introduced a new false positive on `reviewed_29`. Context therefore
+failed the no-new-false-positive acceptance condition and provided no net precision, recall, or
+discard-rate improvement. Keep verification source-only; any future intent-aware attempt needs a
+different decision boundary rather than adding interpretive text to this prompt.
+
 The two **`unverifiable`** synthetics (`syn_0,syn_2`) are **not** in this manifest: they are decided
 deterministically in **pass 0** (`verify.rs` `unverifiable_findings`) and never reach the model, and
 the shipped 2-way prompt never emits `unverifiable`. They live in `PASS0_UNVERIFIABLE` in the
@@ -100,10 +142,15 @@ evals/memory-compaction/
                           REGENERATE with harness/regen-verify-packs.py after any render_pack change
     reviewed-verify-replay.json  36 manually reviewed production findings (33 current, 3 diverged)
     reviewed-verify-packs.json   frozen evidence packs for that reviewed production batch
+    reviewed-verify-intent-context.json  deterministic non-citable context for the #957 ablations
   harness/
     eval_app.py          Modal app: candidates, judge, HHEM, the v2 variants, verify + drift
     regen-verify-packs.py  rebuilds verify-packs.json against the current + doctored trees (#695)
     export-reviewed-verify-replay.py  one-time freezer for the #954 reviewed production batch
+    export-reviewed-intent-context.py  read-only context freezer with snapshot/freshness provenance
+    intent_context.py   pure bounded context/prompt renderer
+    test_intent_context.py  fixture and non-citable-boundary regressions
+    compare-reviewed-intent.py  per-arm production-guard scoreboard and changed-case report
     score.py             folds judge verdicts + HHEM + format checks into the round-1 scoreboard
     score_v2.py          scores the v2 variants; carries the offline ref-leakage metric
     make-drift-tree.py   regenerates the doctored crates/ copy the manifest's two cases need
@@ -139,6 +186,14 @@ modal run harness/eval_app.py::drift_test
 modal run harness/eval_app.py::verify_pack_test   # evidence-pack method (the live design)
 modal run harness/eval_app.py::reviewed_verify_replay
 python3 harness/score-reviewed-verify.py           # precision/recall on 33 current + 3 diverged
+cargo build -p rag-rat --features eval
+python3 harness/export-reviewed-intent-context.py --db ~/.local/share/rag-rat/rag-rat.sqlite
+modal run harness/eval_app.py::reviewed_verify_intent_context
+python3 harness/score-reviewed-verify.py --results results/reviewed-verify-intent-source-only-results.json
+python3 harness/score-reviewed-verify.py --results results/reviewed-verify-intent-verified-memory-results.json
+python3 harness/score-reviewed-verify.py --results results/reviewed-verify-intent-papertrail-results.json
+python3 harness/score-reviewed-verify.py --results results/reviewed-verify-intent-combined-results.json
+python3 harness/compare-reviewed-intent.py
 modal run harness/eval_app.py::reviewed_verify_candidates
 python3 harness/score-reviewed-verify.py --results results/reviewed-verify-candidate-results.json
 python3 harness/make-drift-tree.py                # needed for the agentic comparison arm

--- a/evals/memory-compaction/corpus/reviewed-verify-intent-context.json
+++ b/evals/memory-compaction/corpus/reviewed-verify-intent-context.json
@@ -1,0 +1,1027 @@
+{
+ "cases": {
+  "reviewed_00": {
+   "current_bound_paths": [
+    "crates/rag-rat-sync/src/auth.rs"
+   ],
+   "papertrail": [],
+   "verified_memories": []
+  },
+  "reviewed_01": {
+   "current_bound_paths": [
+    "crates/rag-rat-oplog/src/account/content/storage.rs"
+   ],
+   "papertrail": [
+    {
+     "decision_chosen": null,
+     "distilled_at_ms": 1784979288831,
+     "item_key": "773",
+     "item_kind": "change_request",
+     "outcome_summary": null,
+     "project": "cq27-dev/rag-rat",
+     "rejected_alternatives": [],
+     "root_cause": null,
+     "root_issue": null,
+     "selected_anchor": false,
+     "shared_anchor": "crates/rag-rat-oplog/src/account/content/storage.rs",
+     "thread_title": "fix(oplog): condemn beyond-cut content on a withheld watermark (I11 parity with the account fold)",
+     "tracker": "github",
+     "unreviewed": true
+    },
+    {
+     "decision_chosen": null,
+     "distilled_at_ms": 1784979288831,
+     "item_key": "780",
+     "item_kind": "change_request",
+     "outcome_summary": null,
+     "project": "cq27-dev/rag-rat",
+     "rejected_alternatives": [],
+     "root_cause": null,
+     "root_issue": null,
+     "selected_anchor": false,
+     "shared_anchor": "crates/rag-rat-oplog/src/account/content/storage.rs",
+     "thread_title": "test(oplog): tripwires for AEAD nonce freshness, sealing-selection convergence, and pre-verify per-origin isolation",
+     "tracker": "github",
+     "unreviewed": true
+    },
+    {
+     "decision_chosen": null,
+     "distilled_at_ms": 1784979288831,
+     "item_key": "885",
+     "item_kind": "change_request",
+     "outcome_summary": null,
+     "project": "cq27-dev/rag-rat",
+     "rejected_alternatives": [],
+     "root_cause": null,
+     "root_issue": null,
+     "selected_anchor": false,
+     "shared_anchor": "crates/rag-rat-oplog/src/account/content/storage.rs",
+     "thread_title": "feat(sync): extend the transport to /3 content \u2014 the memories themselves (#406)",
+     "tracker": "github",
+     "unreviewed": true
+    }
+   ],
+   "verified_memories": [
+    {
+     "freshness": {
+      "checked_against_commit": "f9ae8f7f00a5109cb71a9e71b6fbe371f47ebf91",
+      "checked_at_ms": 1785029427785,
+      "checked_inputs_hash": "73aac22d473c55a2836511a4434dd875adbe4d4c52a3740b71ee7d42be5fe4ae",
+      "content_hash": "3757464aba74841fc197948bd30ea132a512ce3ab911ec5a803d89723b425041",
+      "prompt_version": "verify-pack-v3",
+      "verdict": "current"
+     },
+     "kind": "Invariant",
+     "memory_id": "mem_19f7c2526d5_19a8b784fd07",
+     "shared_binding": "crates/rag-rat-oplog/src/account/content/storage.rs",
+     "summary": null,
+     "title": "Refold\u2192reproject coupling (#683/#698): shared refold_and_project_stream_in_tx seam; remote path queues future atomic acceptance+projection"
+    },
+    {
+     "freshness": {
+      "checked_against_commit": "f9ae8f7f00a5109cb71a9e71b6fbe371f47ebf91",
+      "checked_at_ms": 1785029427785,
+      "checked_inputs_hash": "eb14c08cc9e1d5bdc93c0ca9c536d77d23ce07b5bce530b60e6e05fc7afedc2d",
+      "content_hash": "d5b3d1e4cb1e30d1ba8b3df2306362ad136d958cb5c308a83ad052112d33a02f",
+      "prompt_version": "verify-pack-v3",
+      "verdict": "current"
+     },
+     "kind": "Invariant",
+     "memory_id": "mem_19f85f6005c_6f9995125332",
+     "shared_binding": "crates/rag-rat-oplog/src/account/content/storage.rs",
+     "summary": null,
+     "title": "Oversize settle maintenance gates on \"eligible work DRAINED\", never on \"discovery listed nothing\" \u2014 the latter starves forever"
+    }
+   ]
+  },
+  "reviewed_02": {
+   "current_bound_paths": [
+    "crates/rag-rat-papertrail/src/lib.rs"
+   ],
+   "papertrail": [
+    {
+     "decision_chosen": null,
+     "distilled_at_ms": 1784979288831,
+     "item_key": "808",
+     "item_kind": "issue",
+     "outcome_summary": null,
+     "project": "cq27-dev/rag-rat",
+     "rejected_alternatives": [],
+     "root_cause": null,
+     "root_issue": null,
+     "selected_anchor": false,
+     "shared_anchor": "crates/rag-rat-papertrail/src/lib.rs",
+     "thread_title": "distill: records_for_symbol \u2014 facet-gated symbol\u2192record read for the drive-by lane",
+     "tracker": "github",
+     "unreviewed": true
+    }
+   ],
+   "verified_memories": []
+  },
+  "reviewed_03": {
+   "current_bound_paths": [
+    "crates/rag-rat-core/src/index/ai/reconcile/model_lifecycle.rs"
+   ],
+   "papertrail": [
+    {
+     "decision_chosen": null,
+     "distilled_at_ms": 1784979288831,
+     "item_key": "371",
+     "item_kind": "issue",
+     "outcome_summary": null,
+     "project": "cq27-dev/rag-rat",
+     "rejected_alternatives": [],
+     "root_cause": null,
+     "root_issue": null,
+     "selected_anchor": false,
+     "shared_anchor": "crates/rag-rat-core/src/index/ai/reconcile/model_lifecycle.rs",
+     "thread_title": "Split index/ai/reconcile.rs god-module (2.5k lines / 84 fns, mixed concerns)",
+     "tracker": "github",
+     "unreviewed": true
+    }
+   ],
+   "verified_memories": []
+  },
+  "reviewed_04": {
+   "current_bound_paths": [
+    "crates/rag-rat-core/src/index/ai/reconcile/embed_loop.rs"
+   ],
+   "papertrail": [
+    {
+     "decision_chosen": null,
+     "distilled_at_ms": 1784979288831,
+     "item_key": "572",
+     "item_kind": "change_request",
+     "outcome_summary": null,
+     "project": "cq27-dev/rag-rat",
+     "rejected_alternatives": [],
+     "root_cause": null,
+     "root_issue": null,
+     "selected_anchor": false,
+     "shared_anchor": "crates/rag-rat-core/src/index/ai/reconcile/embed_loop.rs",
+     "thread_title": "perf(reconcile): classify skip-summary low-signal from one shared parse per file",
+     "tracker": "github",
+     "unreviewed": true
+    },
+    {
+     "decision_chosen": null,
+     "distilled_at_ms": 1784979288831,
+     "item_key": "630",
+     "item_kind": "change_request",
+     "outcome_summary": null,
+     "project": "cq27-dev/rag-rat",
+     "rejected_alternatives": [],
+     "root_cause": null,
+     "root_issue": null,
+     "selected_anchor": false,
+     "shared_anchor": "crates/rag-rat-core/src/index/ai/reconcile/embed_loop.rs",
+     "thread_title": "refactor: tiered god-module sweep (watch, config, mcp, embed_loop)",
+     "tracker": "github",
+     "unreviewed": true
+    },
+    {
+     "decision_chosen": null,
+     "distilled_at_ms": 1784979288831,
+     "item_key": "371",
+     "item_kind": "issue",
+     "outcome_summary": null,
+     "project": "cq27-dev/rag-rat",
+     "rejected_alternatives": [],
+     "root_cause": null,
+     "root_issue": null,
+     "selected_anchor": false,
+     "shared_anchor": "crates/rag-rat-core/src/index/ai/reconcile/embed_loop.rs",
+     "thread_title": "Split index/ai/reconcile.rs god-module (2.5k lines / 84 fns, mixed concerns)",
+     "tracker": "github",
+     "unreviewed": true
+    }
+   ],
+   "verified_memories": []
+  },
+  "reviewed_05": {
+   "current_bound_paths": [
+    "crates/rag-rat-cli/src/commands/index_ops.rs"
+   ],
+   "papertrail": [
+    {
+     "decision_chosen": null,
+     "distilled_at_ms": 1784979288831,
+     "item_key": "496",
+     "item_kind": "change_request",
+     "outcome_summary": null,
+     "project": "cq27-dev/rag-rat",
+     "rejected_alternatives": [],
+     "root_cause": null,
+     "root_issue": null,
+     "selected_anchor": false,
+     "shared_anchor": "crates/rag-rat-cli/src/commands/index_ops.rs",
+     "thread_title": "feat(memory): pending anchor status for in-flight worktree branches",
+     "tracker": "github",
+     "unreviewed": true
+    },
+    {
+     "decision_chosen": null,
+     "distilled_at_ms": 1784979288831,
+     "item_key": "575",
+     "item_kind": "change_request",
+     "outcome_summary": null,
+     "project": "cq27-dev/rag-rat",
+     "rejected_alternatives": [],
+     "root_cause": null,
+     "root_issue": null,
+     "selected_anchor": false,
+     "shared_anchor": "crates/rag-rat-cli/src/commands/index_ops.rs",
+     "thread_title": "perf(reconcile): serve the skip-summary from a version-stamped column",
+     "tracker": "github",
+     "unreviewed": true
+    },
+    {
+     "decision_chosen": null,
+     "distilled_at_ms": 1784979288831,
+     "item_key": "631",
+     "item_kind": "change_request",
+     "outcome_summary": null,
+     "project": "cq27-dev/rag-rat",
+     "rejected_alternatives": [],
+     "root_cause": null,
+     "root_issue": null,
+     "selected_anchor": false,
+     "shared_anchor": "crates/rag-rat-cli/src/commands/index_ops.rs",
+     "thread_title": "feat(papertrail): add tracker config and provider ref grammar",
+     "tracker": "github",
+     "unreviewed": true
+    }
+   ],
+   "verified_memories": [
+    {
+     "freshness": {
+      "checked_against_commit": "f9ae8f7f00a5109cb71a9e71b6fbe371f47ebf91",
+      "checked_at_ms": 1785029427785,
+      "checked_inputs_hash": "6db0af620475b46d6f70f5e51b3bd47e87c4f8b296358be27a755e709ae8dc79",
+      "content_hash": "b69e161f482087e480d256f6fcffcd85dd34468d13f295dcb02824637cd6aa1b",
+      "prompt_version": "verify-pack-v3",
+      "verdict": "current"
+     },
+     "kind": "PlatformQuirk",
+     "memory_id": "mem_19f88dc34a8_a4bc9a257800",
+     "shared_binding": "crates/rag-rat-cli/src/commands/index_ops.rs",
+     "summary": null,
+     "title": "index --watch exits on SIGINT via DEFAULT disposition only \u2014 launchers that inherit SIG_IGN (shell `&` in non-interactive scripts) make it un-Ctrl-C-able"
+    }
+   ]
+  },
+  "reviewed_06": {
+   "current_bound_paths": [],
+   "papertrail": [],
+   "verified_memories": []
+  },
+  "reviewed_07": {
+   "current_bound_paths": [
+    "crates/rag-rat-core/src/index/ai/policy.rs"
+   ],
+   "papertrail": [
+    {
+     "decision_chosen": null,
+     "distilled_at_ms": 1784979288831,
+     "item_key": "572",
+     "item_kind": "change_request",
+     "outcome_summary": null,
+     "project": "cq27-dev/rag-rat",
+     "rejected_alternatives": [],
+     "root_cause": null,
+     "root_issue": null,
+     "selected_anchor": false,
+     "shared_anchor": "crates/rag-rat-core/src/index/ai/policy.rs",
+     "thread_title": "perf(reconcile): classify skip-summary low-signal from one shared parse per file",
+     "tracker": "github",
+     "unreviewed": true
+    },
+    {
+     "decision_chosen": null,
+     "distilled_at_ms": 1784979288831,
+     "item_key": "575",
+     "item_kind": "change_request",
+     "outcome_summary": null,
+     "project": "cq27-dev/rag-rat",
+     "rejected_alternatives": [],
+     "root_cause": null,
+     "root_issue": null,
+     "selected_anchor": false,
+     "shared_anchor": "crates/rag-rat-core/src/index/ai/policy.rs",
+     "thread_title": "perf(reconcile): serve the skip-summary from a version-stamped column",
+     "tracker": "github",
+     "unreviewed": true
+    },
+    {
+     "decision_chosen": null,
+     "distilled_at_ms": 1784979288831,
+     "item_key": "516",
+     "item_kind": "issue",
+     "outcome_summary": null,
+     "project": "cq27-dev/rag-rat",
+     "rejected_alternatives": [],
+     "root_cause": null,
+     "root_issue": null,
+     "selected_anchor": false,
+     "shared_anchor": "crates/rag-rat-core/src/index/ai/policy.rs",
+     "thread_title": "perf(index): embedding policy re-parses every chunk \u2014 classify low-signal from the shared file parse",
+     "tracker": "github",
+     "unreviewed": true
+    }
+   ],
+   "verified_memories": [
+    {
+     "freshness": {
+      "checked_against_commit": "f9ae8f7f00a5109cb71a9e71b6fbe371f47ebf91",
+      "checked_at_ms": 1785029427785,
+      "checked_inputs_hash": "6276a8ef415519366cc38057b12a650bf5e3b9e1f6b16c4db1499ebed198d249",
+      "content_hash": "438adf7dd0e19c7d14ba851824ee3744c6a8553a611e124ea153f904b6d05022",
+      "prompt_version": "verify-pack-v3",
+      "verdict": "current"
+     },
+     "kind": "Decision",
+     "memory_id": "mem_19f7133eb05_12965327c378",
+     "shared_binding": "crates/rag-rat-core/src/index/ai/policy.rs",
+     "summary": null,
+     "title": "#725: embed path reads the certified stamped policy column (job_policy) \u2014 FromText re-parse is the fallback, not the default"
+    }
+   ]
+  },
+  "reviewed_08": {
+   "current_bound_paths": [],
+   "papertrail": [],
+   "verified_memories": []
+  },
+  "reviewed_09": {
+   "current_bound_paths": [
+    "crates/rag-rat-core/src/index/edges/resolve/mod.rs"
+   ],
+   "papertrail": [
+    {
+     "decision_chosen": null,
+     "distilled_at_ms": 1784979288831,
+     "item_key": "192",
+     "item_kind": "change_request",
+     "outcome_summary": null,
+     "project": "cq27-dev/rag-rat",
+     "rejected_alternatives": [],
+     "root_cause": null,
+     "root_issue": null,
+     "selected_anchor": false,
+     "shared_anchor": "crates/rag-rat-core/src/index/edges/resolve/mod.rs",
+     "thread_title": "fix(resolve): stop asserting high confidence on guessed Rust type references",
+     "tracker": "github",
+     "unreviewed": true
+    },
+    {
+     "decision_chosen": null,
+     "distilled_at_ms": 1784979288831,
+     "item_key": "206",
+     "item_kind": "change_request",
+     "outcome_summary": null,
+     "project": "cq27-dev/rag-rat",
+     "rejected_alternatives": [],
+     "root_cause": null,
+     "root_issue": null,
+     "selected_anchor": false,
+     "shared_anchor": "crates/rag-rat-core/src/index/edges/resolve/mod.rs",
+     "thread_title": "feat(graph): synthesize message-dispatch (actor-channel / enum) edges (#200)",
+     "tracker": "github",
+     "unreviewed": true
+    },
+    {
+     "decision_chosen": null,
+     "distilled_at_ms": 1784979288831,
+     "item_key": "1",
+     "item_kind": "issue",
+     "outcome_summary": null,
+     "project": "cq27-dev/rag-rat",
+     "rejected_alternatives": [],
+     "root_cause": null,
+     "root_issue": null,
+     "selected_anchor": false,
+     "shared_anchor": "crates/rag-rat-core/src/index/edges/resolve/mod.rs",
+     "thread_title": "M1: Keep SQLite/rusqlite storage facade and default config",
+     "tracker": "github",
+     "unreviewed": true
+    }
+   ],
+   "verified_memories": []
+  },
+  "reviewed_10": {
+   "current_bound_paths": [
+    "crates/rag-rat-db/src/content_digest.rs"
+   ],
+   "papertrail": [],
+   "verified_memories": []
+  },
+  "reviewed_11": {
+   "current_bound_paths": [],
+   "papertrail": [],
+   "verified_memories": []
+  },
+  "reviewed_12": {
+   "current_bound_paths": [
+    "tools/oracle-toolchain/package.json"
+   ],
+   "papertrail": [],
+   "verified_memories": []
+  },
+  "reviewed_13": {
+   "current_bound_paths": [
+    "crates/rag-rat-oplog/src/account/fold.rs"
+   ],
+   "papertrail": [
+    {
+     "decision_chosen": null,
+     "distilled_at_ms": 1784979288831,
+     "item_key": "737",
+     "item_kind": "change_request",
+     "outcome_summary": null,
+     "project": "cq27-dev/rag-rat",
+     "rejected_alternatives": [],
+     "root_cause": null,
+     "root_issue": null,
+     "selected_anchor": false,
+     "shared_anchor": "crates/rag-rat-oplog/src/account/fold.rs",
+     "thread_title": "feat(oplog): wire secrets-chain cut registers into the account fold (C4.2a)",
+     "tracker": "github",
+     "unreviewed": true
+    },
+    {
+     "decision_chosen": null,
+     "distilled_at_ms": 1784979288831,
+     "item_key": "774",
+     "item_kind": "change_request",
+     "outcome_summary": null,
+     "project": "cq27-dev/rag-rat",
+     "rejected_alternatives": [],
+     "root_cause": null,
+     "root_issue": null,
+     "selected_anchor": false,
+     "shared_anchor": "crates/rag-rat-oplog/src/account/fold.rs",
+     "thread_title": "test(oplog): behavioral coverage for last-owner protection and no-cascade",
+     "tracker": "github",
+     "unreviewed": true
+    },
+    {
+     "decision_chosen": null,
+     "distilled_at_ms": 1784979288831,
+     "item_key": "813",
+     "item_kind": "change_request",
+     "outcome_summary": null,
+     "project": "cq27-dev/rag-rat",
+     "rejected_alternatives": [],
+     "root_cause": null,
+     "root_issue": null,
+     "selected_anchor": false,
+     "shared_anchor": "crates/rag-rat-oplog/src/account/fold.rs",
+     "thread_title": "feat(oplog): annex log and the snapshot coverage-manifest wire (#609)",
+     "tracker": "github",
+     "unreviewed": true
+    }
+   ],
+   "verified_memories": [
+    {
+     "freshness": {
+      "checked_against_commit": "f9ae8f7f00a5109cb71a9e71b6fbe371f47ebf91",
+      "checked_at_ms": 1785029427785,
+      "checked_inputs_hash": "db3601a5ed38071b550fb9a6661195c8dce24fbae81ed8c02de86e2aacf0750d",
+      "content_hash": "baa9531e1e0d5126cd760bd489292e99c8007e69a9d8f8a8ee63cfb156fa1d05",
+      "prompt_version": "verify-pack-v3",
+      "verdict": "current"
+     },
+     "kind": "Invariant",
+     "memory_id": "mem_19f755d18e0_347e5099b1f4",
+     "shared_binding": "crates/rag-rat-oplog/src/account/fold.rs",
+     "summary": null,
+     "title": "C4.2a: secrets-chain cut registers fold via log-generic machinery (atomic per-op, whole-depth staging, intrinsic-LastOwner prefilter)"
+    },
+    {
+     "freshness": {
+      "checked_against_commit": "f9ae8f7f00a5109cb71a9e71b6fbe371f47ebf91",
+      "checked_at_ms": 1785029427785,
+      "checked_inputs_hash": "74d5e9bcaf9ca1b5644691fd7082339236a38d8a3f37e11db3c6b84cf6745985",
+      "content_hash": "af0f6966ecb6fca2e05d01acaa7626b5273f7c7b4d8f28a11c72cce2ee52b442",
+      "prompt_version": "verify-pack-v3",
+      "verdict": "current"
+     },
+     "kind": "Risk",
+     "memory_id": "mem_19f76df2f5e_8c4dc6284156",
+     "shared_binding": "crates/rag-rat-oplog/src/account/fold.rs",
+     "summary": null,
+     "title": "Intrinsic last-owner prefilter is skipped at stratum 0: sole-founder self-remove equivocation folds contested, not Live"
+    },
+    {
+     "freshness": {
+      "checked_against_commit": "f9ae8f7f00a5109cb71a9e71b6fbe371f47ebf91",
+      "checked_at_ms": 1785029427785,
+      "checked_inputs_hash": "e141bc148f678be1749d05d4efb945fc7525daa7e1a38bf16485a8ac85be83a2",
+      "content_hash": "578b2ddd9518eac945b82d23377c626752a8a573396c0fc901c88306b17eb466",
+      "prompt_version": "verify-pack-v3",
+      "verdict": "current"
+     },
+     "kind": "TestExpectation",
+     "memory_id": "mem_19f77246ae7_80f708fe55ce",
+     "shared_binding": "crates/rag-rat-oplog/src/account/fold.rs",
+     "summary": null,
+     "title": "Both LastOwner paths (intrinsic prefilter + I2 sim) are reachable in a Live fold only via a DEMOTED-but-still-live owner"
+    }
+   ]
+  },
+  "reviewed_14": {
+   "current_bound_paths": [
+    "crates/rag-rat-core/src/index/edges/extract/mod.rs"
+   ],
+   "papertrail": [
+    {
+     "decision_chosen": null,
+     "distilled_at_ms": 1784979288831,
+     "item_key": "519",
+     "item_kind": "issue",
+     "outcome_summary": null,
+     "project": "cq27-dev/rag-rat",
+     "rejected_alternatives": [],
+     "root_cause": null,
+     "root_issue": null,
+     "selected_anchor": false,
+     "shared_anchor": "crates/rag-rat-core/src/index/edges/extract/mod.rs",
+     "thread_title": "perf(edges): contains_edges is O(S\u00b2), containing_symbol allocates + sorts per edge",
+     "tracker": "github",
+     "unreviewed": true
+    },
+    {
+     "decision_chosen": null,
+     "distilled_at_ms": 1784979288831,
+     "item_key": "520",
+     "item_kind": "issue",
+     "outcome_summary": null,
+     "project": "cq27-dev/rag-rat",
+     "rejected_alternatives": [],
+     "root_cause": null,
+     "root_issue": null,
+     "selected_anchor": false,
+     "shared_anchor": "crates/rag-rat-core/src/index/edges/extract/mod.rs",
+     "thread_title": "refactor(parser): iterative single-cursor tree walks; depth-safe traversal",
+     "tracker": "github",
+     "unreviewed": true
+    },
+    {
+     "decision_chosen": null,
+     "distilled_at_ms": 1784979288831,
+     "item_key": "543",
+     "item_kind": "issue",
+     "outcome_summary": null,
+     "project": "cq27-dev/rag-rat",
+     "rejected_alternatives": [],
+     "root_cause": null,
+     "root_issue": null,
+     "selected_anchor": false,
+     "shared_anchor": "crates/rag-rat-core/src/index/edges/extract/mod.rs",
+     "thread_title": "perf(parser): depth-safe the recursive name-finding helpers (subtree-depth stack overflow)",
+     "tracker": "github",
+     "unreviewed": true
+    }
+   ],
+   "verified_memories": []
+  },
+  "reviewed_15": {
+   "current_bound_paths": [],
+   "papertrail": [],
+   "verified_memories": []
+  },
+  "reviewed_16": {
+   "current_bound_paths": [
+    "crates/rag-rat-sync/src/session.rs"
+   ],
+   "papertrail": [],
+   "verified_memories": []
+  },
+  "reviewed_17": {
+   "current_bound_paths": [
+    "crates/rag-rat-oplog/src/table_sync/apply.rs"
+   ],
+   "papertrail": [],
+   "verified_memories": []
+  },
+  "reviewed_18": {
+   "current_bound_paths": [
+    "release-plz.toml"
+   ],
+   "papertrail": [],
+   "verified_memories": []
+  },
+  "reviewed_19": {
+   "current_bound_paths": [
+    "dist-workspace.toml"
+   ],
+   "papertrail": [],
+   "verified_memories": []
+  },
+  "reviewed_20": {
+   "current_bound_paths": [
+    "cookbook/recipes/modal.mts"
+   ],
+   "papertrail": [],
+   "verified_memories": []
+  },
+  "reviewed_21": {
+   "current_bound_paths": [],
+   "papertrail": [],
+   "verified_memories": []
+  },
+  "reviewed_22": {
+   "current_bound_paths": [
+    "crates/rag-rat-papertrail/src/mirror.rs"
+   ],
+   "papertrail": [],
+   "verified_memories": []
+  },
+  "reviewed_23": {
+   "current_bound_paths": [
+    "crates/rag-rat-oplog/src/account/keywrap.rs"
+   ],
+   "papertrail": [
+    {
+     "decision_chosen": null,
+     "distilled_at_ms": 1784979288831,
+     "item_key": "780",
+     "item_kind": "change_request",
+     "outcome_summary": null,
+     "project": "cq27-dev/rag-rat",
+     "rejected_alternatives": [],
+     "root_cause": null,
+     "root_issue": null,
+     "selected_anchor": false,
+     "shared_anchor": "crates/rag-rat-oplog/src/account/keywrap.rs",
+     "thread_title": "test(oplog): tripwires for AEAD nonce freshness, sealing-selection convergence, and pre-verify per-origin isolation",
+     "tracker": "github",
+     "unreviewed": true
+    }
+   ],
+   "verified_memories": []
+  },
+  "reviewed_24": {
+   "current_bound_paths": [
+    "crates/rag-rat-core/src/index/util.rs"
+   ],
+   "papertrail": [],
+   "verified_memories": []
+  },
+  "reviewed_25": {
+   "current_bound_paths": [
+    "crates/rag-rat-oplog/src/account"
+   ],
+   "papertrail": [],
+   "verified_memories": []
+  },
+  "reviewed_26": {
+   "current_bound_paths": [
+    "crates/rag-rat-core/src/memory_write/authoring.rs"
+   ],
+   "papertrail": [
+    {
+     "decision_chosen": null,
+     "distilled_at_ms": 1784979288831,
+     "item_key": "891",
+     "item_kind": "change_request",
+     "outcome_summary": null,
+     "project": "cq27-dev/rag-rat",
+     "rejected_alternatives": [],
+     "root_cause": null,
+     "root_issue": null,
+     "selected_anchor": false,
+     "shared_anchor": "crates/rag-rat-core/src/memory_write/authoring.rs",
+     "thread_title": "feat(memory): sync-origin provenance + edge tombstones, the projection foundation (#691)",
+     "tracker": "github",
+     "unreviewed": true
+    },
+    {
+     "decision_chosen": null,
+     "distilled_at_ms": 1784979288831,
+     "item_key": "680",
+     "item_kind": "issue",
+     "outcome_summary": null,
+     "project": "cq27-dev/rag-rat",
+     "rejected_alternatives": [],
+     "root_cause": null,
+     "root_issue": null,
+     "selected_anchor": false,
+     "shared_anchor": "crates/rag-rat-core/src/memory_write/authoring.rs",
+     "thread_title": "Oversized pre-existing memory body wedges all writes for a repo",
+     "tracker": "github",
+     "unreviewed": true
+    },
+    {
+     "decision_chosen": null,
+     "distilled_at_ms": 1784979288831,
+     "item_key": "683",
+     "item_kind": "issue",
+     "outcome_summary": null,
+     "project": "cq27-dev/rag-rat",
+     "rejected_alternatives": [],
+     "root_cause": null,
+     "root_issue": null,
+     "selected_anchor": false,
+     "shared_anchor": "crates/rag-rat-core/src/memory_write/authoring.rs",
+     "thread_title": "Refresh the accepted-/3 memory projection when an account refold changes acceptance",
+     "tracker": "github",
+     "unreviewed": true
+    }
+   ],
+   "verified_memories": [
+    {
+     "freshness": {
+      "checked_against_commit": "f9ae8f7f00a5109cb71a9e71b6fbe371f47ebf91",
+      "checked_at_ms": 1785029427785,
+      "checked_inputs_hash": "a7cf39193f024f7a71661173923a803ed319599b1ce50b13bfb538412d5cb188",
+      "content_hash": "999f7f980bc3ff0e8248846c6da9cf19782bacd538f68e8a3b080c22ddc7c090",
+      "prompt_version": "verify-pack-v3",
+      "verdict": "current"
+     },
+     "kind": "Invariant",
+     "memory_id": "mem_19f796e67c2_898471e7dbea",
+     "shared_binding": "crates/rag-rat-core/src/memory_write/authoring.rs",
+     "summary": null,
+     "title": "#680 P2: whole-op write-boundary guard lives at author_in_owner_stream \u2014 the one seam all live memory mutations funnel through"
+    },
+    {
+     "freshness": {
+      "checked_against_commit": "f9ae8f7f00a5109cb71a9e71b6fbe371f47ebf91",
+      "checked_at_ms": 1785029427785,
+      "checked_inputs_hash": "5fd13e5d1cd17c5175dfc0e9ba93a638c0dc813f9cbe1d765ce3e6c3b16c97be",
+      "content_hash": "f32e3370920bb75331805ac155843a68ce1de5cc72797be719787e0944c0e7ea",
+      "prompt_version": "verify-pack-v3",
+      "verdict": "current"
+     },
+     "kind": "Invariant",
+     "memory_id": "mem_19f7f789868_b6b6febd9f01",
+     "shared_binding": "crates/rag-rat-core/src/memory_write/authoring.rs",
+     "summary": null,
+     "title": "#763 core catch-up owns durability/scope; future pairing calls it only after enrollment"
+    },
+    {
+     "freshness": {
+      "checked_against_commit": "f9ae8f7f00a5109cb71a9e71b6fbe371f47ebf91",
+      "checked_at_ms": 1785029427785,
+      "checked_inputs_hash": "ffed32941c1d9c9830720e634c3126cef17615fbd0c206eb6c8789d8fc8da154",
+      "content_hash": "1948ca0627cc828b9c7756aae12f5f41ce55b4267ba59cc3695d93487f7adb26",
+      "prompt_version": "verify-pack-v3",
+      "verdict": "current"
+     },
+     "kind": "Invariant",
+     "memory_id": "mem_19f85f6484a_ee0e681d5998",
+     "shared_binding": "crates/rag-rat-core/src/memory_write/authoring.rs",
+     "summary": null,
+     "title": "The pending-fold barrier settles the owner stream INSIDE the write's transaction \u2014 never as an unbudgeted autocommit pre-drain"
+    }
+   ]
+  },
+  "reviewed_27": {
+   "current_bound_paths": [
+    "deny.toml"
+   ],
+   "papertrail": [],
+   "verified_memories": []
+  },
+  "reviewed_28": {
+   "current_bound_paths": [
+    "crates/rag-rat-core/src/index/papertrail_autosync.rs"
+   ],
+   "papertrail": [],
+   "verified_memories": []
+  },
+  "reviewed_29": {
+   "current_bound_paths": [
+    "crates/rag-rat-oplog/src/account/storage.rs"
+   ],
+   "papertrail": [
+    {
+     "decision_chosen": null,
+     "distilled_at_ms": 1784979288831,
+     "item_key": "842",
+     "item_kind": "change_request",
+     "outcome_summary": null,
+     "project": "cq27-dev/rag-rat",
+     "rejected_alternatives": [],
+     "root_cause": null,
+     "root_issue": null,
+     "selected_anchor": false,
+     "shared_anchor": "crates/rag-rat-oplog/src/account/storage.rs",
+     "thread_title": "feat(oplog): read-time verification of a snapshot's coverage claim (#609)",
+     "tracker": "github",
+     "unreviewed": true
+    },
+    {
+     "decision_chosen": null,
+     "distilled_at_ms": 1784979288831,
+     "item_key": "846",
+     "item_kind": "change_request",
+     "outcome_summary": null,
+     "project": "cq27-dev/rag-rat",
+     "rejected_alternatives": [],
+     "root_cause": null,
+     "root_issue": null,
+     "selected_anchor": false,
+     "shared_anchor": "crates/rag-rat-oplog/src/account/storage.rs",
+     "thread_title": "feat(oplog): snapshot usability and coverage-dominance selection (#609)",
+     "tracker": "github",
+     "unreviewed": true
+    },
+    {
+     "decision_chosen": null,
+     "distilled_at_ms": 1784979288831,
+     "item_key": "861",
+     "item_kind": "change_request",
+     "outcome_summary": null,
+     "project": "cq27-dev/rag-rat",
+     "rejected_alternatives": [],
+     "root_cause": null,
+     "root_issue": null,
+     "selected_anchor": false,
+     "shared_anchor": "crates/rag-rat-oplog/src/account/storage.rs",
+     "thread_title": "test(oplog): pin the total tombstone set a snapshot binds (#609)",
+     "tracker": "github",
+     "unreviewed": true
+    }
+   ],
+   "verified_memories": [
+    {
+     "freshness": {
+      "checked_against_commit": "f9ae8f7f00a5109cb71a9e71b6fbe371f47ebf91",
+      "checked_at_ms": 1785029427785,
+      "checked_inputs_hash": "d190d976a6fef19d901a9ac28767fc0c2419984059be083906b3ca021bda4654",
+      "content_hash": "d9689b26916bfacd771feaae6c0a002ac09d21c3da799dd48d9b5e02a49a0ddf",
+      "prompt_version": "verify-pack-v3",
+      "verdict": "current"
+     },
+     "kind": "Decision",
+     "memory_id": "mem_19f756a8073_a5875921fb9c",
+     "shared_binding": "crates/rag-rat-oplog/src/account/storage.rs",
+     "summary": null,
+     "title": "Frozen convergence rule: a non-evaluable log-1 (secrets) entry is SLOT-ELIGIBLE but never accepted"
+    },
+    {
+     "freshness": {
+      "checked_against_commit": "f9ae8f7f00a5109cb71a9e71b6fbe371f47ebf91",
+      "checked_at_ms": 1785029427785,
+      "checked_inputs_hash": "49e34377e7260cc15aec507274c69dc9f77e17bbfc0e6876e3518468d982f5e9",
+      "content_hash": "53f6fa3312336a2a2f111e36919fc303771079308de6c4f5b78a6f6d1808f595",
+      "prompt_version": "verify-pack-v3",
+      "verdict": "current"
+     },
+     "kind": "Risk",
+     "memory_id": "mem_19f756ad8de_cc4edaea9959",
+     "shared_binding": "crates/rag-rat-oplog/src/account/storage.rs",
+     "summary": null,
+     "title": "Account-side branch selection has NO watermark pins; a log-1/secrets acceptance loop needs a pin-aware analog"
+    },
+    {
+     "freshness": {
+      "checked_against_commit": "f9ae8f7f00a5109cb71a9e71b6fbe371f47ebf91",
+      "checked_at_ms": 1785029427785,
+      "checked_inputs_hash": "a190a96882daed397d51a8d0d2b1a97baab22da539245dd9ec45a02e7979512b",
+      "content_hash": "28f2a366acbd4340b7dedd79e52908b151b7a77944a32a23f02ff855f026818d",
+      "prompt_version": "verify-pack-v3",
+      "verdict": "current"
+     },
+     "kind": "Risk",
+     "memory_id": "mem_19f75cc7180_be3b8d356394",
+     "shared_binding": "crates/rag-rat-oplog/src/account/storage.rs",
+     "summary": null,
+     "title": "C4.3a wrap recipient set must be roster-EFFECTIVE; stored_device_pubkeys is fold-independent and includes removed devices"
+    }
+   ]
+  },
+  "reviewed_30": {
+   "current_bound_paths": [
+    "crates/rag-rat-core/src/index/query_api/global_status.rs"
+   ],
+   "papertrail": [],
+   "verified_memories": []
+  },
+  "reviewed_31": {
+   "current_bound_paths": [],
+   "papertrail": [],
+   "verified_memories": []
+  },
+  "reviewed_32": {
+   "current_bound_paths": [
+    "crates/rag-rat-core/src/index/rebuild.rs"
+   ],
+   "papertrail": [
+    {
+     "decision_chosen": null,
+     "distilled_at_ms": 1784979288831,
+     "item_key": "231",
+     "item_kind": "issue",
+     "outcome_summary": null,
+     "project": "cq27-dev/rag-rat",
+     "rejected_alternatives": [],
+     "root_cause": null,
+     "root_issue": null,
+     "selected_anchor": false,
+     "shared_anchor": "crates/rag-rat-core/src/index/rebuild.rs",
+     "thread_title": "perf(clones): investigate BLOB-packing the token bag (vs per-token symbol_token_postings rows)",
+     "tracker": "github",
+     "unreviewed": true
+    },
+    {
+     "decision_chosen": null,
+     "distilled_at_ms": 1784979288831,
+     "item_key": "79",
+     "item_kind": "issue",
+     "outcome_summary": null,
+     "project": "cq27-dev/rag-rat",
+     "rejected_alternatives": [],
+     "root_cause": null,
+     "root_issue": null,
+     "selected_anchor": false,
+     "shared_anchor": "crates/rag-rat-core/src/index/rebuild.rs",
+     "thread_title": "Normalize repeated edge strings into an interned ids table (on-disk) \u2014 11.2M kernel edges repeat names relentlessly",
+     "tracker": "github",
+     "unreviewed": true
+    },
+    {
+     "decision_chosen": null,
+     "distilled_at_ms": 1784979288831,
+     "item_key": "87",
+     "item_kind": "issue",
+     "outcome_summary": null,
+     "project": "cq27-dev/rag-rat",
+     "rejected_alternatives": [],
+     "root_cause": null,
+     "root_issue": null,
+     "selected_anchor": false,
+     "shared_anchor": "crates/rag-rat-core/src/index/rebuild.rs",
+     "thread_title": "index --full fails with UNIQUE(files.path, commit_sha, worktree_id) when stale worktree-overlay rows linger after the tree goes clean",
+     "tracker": "github",
+     "unreviewed": true
+    }
+   ],
+   "verified_memories": [
+    {
+     "freshness": {
+      "checked_against_commit": "f9ae8f7f00a5109cb71a9e71b6fbe371f47ebf91",
+      "checked_at_ms": 1785029427785,
+      "checked_inputs_hash": "a48d23c8ee0fede5eecd57b47b947bc587cc942ec0fe1aaf21958d781ad05fd1",
+      "content_hash": "e2b9b92f708abace6e55b3f74070d89f68ff949accbdb72429e8d0d3dea4241a",
+      "prompt_version": "verify-pack-v3",
+      "verdict": "current"
+     },
+     "kind": "Decision",
+     "memory_id": "mem_19f2ab8bbf5_9804ab7e8a0d",
+     "shared_binding": "crates/rag-rat-core/src/index/rebuild.rs",
+     "summary": "GIT ROWS RIDE THE FLIP: `orientation::recent_commit_subjects` now reads `git_commits/git_file_changes` DIRECTLY, NOT via deferred cursors; `apply_prepared_git_history_deferring_cursors` and `finalize_full_rebuild_fts` move INSIDE terminal txn; `a_tail_failure_leaves_git_meta_and_history_cursors_on_the_old_state` asserts h2_row==0 and H2 subject absent. FLOCK BY CONSTRUCTION: `rebuild_with_progress` acquires `WriteLock::acquire_blocking(&config.database, &write_lock_repo_id(config))` at top; `spawn_paused_rebuild` manual acquire REMOVED; `gc/maintenance` now safe under `generation != live`. PACKAGES + BASE-EDGE: `index_targets_with_progress` returns `(usize, FullRebuildGraph)` and drops tail; `finalize_base_edges` runs INSIDE terminal txn; `refresh_clone_token_df` runs AFTER `carry_forward_live_overlays`; `carry_forward_overlay_packages` re-keys overlay packages to new base HEAD. COUNT-SCOPING: `traversal_summary`, `unique_symbol_name`, `count_callers`, `count_edges_for_symbol` now JOIN files view; `graph_traversal_summary_counts_match_the_live_rows_during_a_dead_generation_window` asserts summary == rows == 1.",
+     "title": "A6 batch 6 test probe"
+    }
+   ]
+  },
+  "reviewed_33": {
+   "current_bound_paths": [
+    ".github/workflows/release-android.yml"
+   ],
+   "papertrail": [],
+   "verified_memories": []
+  },
+  "reviewed_34": {
+   "current_bound_paths": [
+    "crates/rag-rat-dream/src/findings.rs"
+   ],
+   "papertrail": [
+    {
+     "decision_chosen": null,
+     "distilled_at_ms": 1784979288831,
+     "item_key": "769",
+     "item_kind": "issue",
+     "outcome_summary": null,
+     "project": "cq27-dev/rag-rat",
+     "rejected_alternatives": [],
+     "root_cause": null,
+     "root_issue": null,
+     "selected_anchor": false,
+     "shared_anchor": "crates/rag-rat-dream/src/findings.rs",
+     "thread_title": "Generalize the chat client into rag-rat-llm and add guided decoding",
+     "tracker": "github",
+     "unreviewed": true
+    }
+   ],
+   "verified_memories": []
+  },
+  "reviewed_35": {
+   "current_bound_paths": [],
+   "papertrail": [],
+   "verified_memories": []
+  }
+ },
+ "context_index_commit": "f9ae8f7f00a5109cb71a9e71b6fbe371f47ebf91",
+ "context_repo_id": "6f7d51904146ba48b450292ee1c2da2eedc8f9e8",
+ "limits": {
+  "papertrail": 3,
+  "rendered_context_bytes": 6000,
+  "verified_memories": 3
+ },
+ "selection_version": "intent-context-v1",
+ "source_pack_commit": "c5303848",
+ "verdict_prompt_version": "verify-pack-v3"
+}

--- a/evals/memory-compaction/harness/compare-reviewed-intent.py
+++ b/evals/memory-compaction/harness/compare-reviewed-intent.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Compare the four #957 intent-context arms through the production acceptance guard."""
+
+from __future__ import annotations
+
+import collections
+import importlib.util
+import json
+import pathlib
+
+HARNESS = pathlib.Path(__file__).resolve().parent
+EVAL_DIR = HARNESS.parent
+CORPUS = EVAL_DIR / "corpus"
+RESULTS = EVAL_DIR / "results"
+ARMS = ("source-only", "verified-memory", "papertrail", "combined")
+
+_score_spec = importlib.util.spec_from_file_location(
+    "score_reviewed_verify", HARNESS / "score-reviewed-verify.py"
+)
+score = importlib.util.module_from_spec(_score_spec)
+_score_spec.loader.exec_module(score)
+
+
+def score_arm(arm: str, cases: dict, packs: dict) -> dict:
+    path = RESULTS / f"reviewed-verify-intent-{arm}-results.json"
+    rows = json.loads(path.read_text())
+    items = [row["item"] for row in rows]
+    if sorted(items) != sorted(cases) or len(items) != len(set(items)):
+        raise SystemExit(f"{arm}: results are not one complete 36-case replay")
+    outcomes = {}
+    counts = collections.Counter()
+    for row in rows:
+        case = cases[row["item"]]
+        actual = score.production_accepts(
+            case,
+            packs[f"{row['item']}|/repo"],
+            row["answer"],
+        )
+        outcomes[row["item"]] = actual
+        counts[(case["expected_verdict"], actual)] += 1
+    false_positive_items = sorted(
+        item
+        for item, actual in outcomes.items()
+        if cases[item]["expected_verdict"] == "current" and actual == "diverged"
+    )
+    true_positive_items = sorted(
+        item
+        for item, actual in outcomes.items()
+        if cases[item]["expected_verdict"] == "diverged" and actual == "diverged"
+    )
+    return {
+        "false_positives": counts[("current", "diverged")],
+        "true_positives": counts[("diverged", "diverged")],
+        "discarded": sum(count for (_, actual), count in counts.items() if actual == "discarded"),
+        "false_positive_items": false_positive_items,
+        "true_positive_items": true_positive_items,
+        "outcomes": outcomes,
+    }
+
+
+def main() -> None:
+    cases = {
+        case["id"]: case
+        for case in json.loads((CORPUS / "reviewed-verify-replay.json").read_text())
+    }
+    packs = json.loads((CORPUS / "reviewed-verify-packs.json").read_text())
+    arms = {arm: score_arm(arm, cases, packs) for arm in ARMS}
+    control = arms["source-only"]["outcomes"]
+    for arm in ARMS:
+        result = arms[arm]
+        changed = sorted(
+            item for item, outcome in result["outcomes"].items() if outcome != control[item]
+        )
+        result["changed_from_source_only"] = changed
+        print(
+            f"{arm:16} fp={result['false_positives']}/33 "
+            f"tp={result['true_positives']}/3 discarded={result['discarded']}/36 "
+            f"fp_items={','.join(result['false_positive_items']) or '-'} "
+            f"tp_items={','.join(result['true_positive_items']) or '-'} "
+            f"changed={','.join(changed) or '-'}"
+        )
+    (RESULTS / "reviewed-verify-intent-scoreboard.json").write_text(
+        json.dumps(arms, indent=1, sort_keys=True) + "\n"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/evals/memory-compaction/harness/eval_app.py
+++ b/evals/memory-compaction/harness/eval_app.py
@@ -240,7 +240,7 @@ def _tool_read(path: str, start: int, end: int, root: str = "/repo") -> str:
     lines = p.read_text(errors="replace").splitlines()
     end = min(end, start + 99, len(lines))
     seg = lines[max(0, start - 1):end]
-    return "\n".join(f"{i}: {l}" for i, l in enumerate(seg, start))
+    return "\n".join(f"{i}: {line}" for i, line in enumerate(seg, start))
 
 
 def _parse_call(text: str):
@@ -579,6 +579,71 @@ def reviewed_verify_replay():
         print(f"{model}: ok gen={result['gen_s']}s")
     RESULTS.mkdir(exist_ok=True)
     (RESULTS / "reviewed-verify-results.json").write_text(json.dumps(out, indent=1))
+
+
+@app.local_entrypoint()
+def reviewed_verify_intent_context():
+    """Run the #957 source-only control plus verified-memory/papertrail context ablations."""
+    from intent_context import ARMS, load_context_fixture, render_reviewed_prompt
+
+    cases = json.loads((DATA_DIR / "corpus" / "reviewed-verify-replay.json").read_text())
+    packs = json.loads((DATA_DIR / "corpus" / "reviewed-verify-packs.json").read_text())
+    fixture = load_context_fixture(
+        DATA_DIR / "corpus" / "reviewed-verify-intent-context.json",
+        {case["id"] for case in cases},
+    )
+    keyed_prompts = [
+        (
+            arm,
+            case,
+            render_reviewed_prompt(
+                VERIFY_PACK_PROMPT,
+                case,
+                packs[f"{case['id']}|/repo"],
+                fixture["cases"][case["id"]],
+                arm,
+            ),
+        )
+        for arm in ARMS
+        for case in cases
+    ]
+
+    configured = _configured_dream_model()
+    model, chat_kwargs, system_prefix = V2_MODELS[0]
+    if model != configured:
+        raise SystemExit(
+            f"intent-context replay mismatch: configured model is {configured!r}, "
+            f"V2_MODELS[0] is {model!r}"
+        )
+    result = run_model.remote(
+        model,
+        chat_kwargs,
+        system_prefix,
+        [prompt for _, _, prompt in keyed_prompts],
+        450,
+        max_model_len=16384,
+    )
+    if "error" in result:
+        raise SystemExit(f"{model}: intent-context replay failed: {result['error'][:200]}")
+
+    by_arm = {arm: [] for arm in ARMS}
+    for (arm, case, _), answer in zip(keyed_prompts, result["outputs"]):
+        by_arm[arm].append(
+            {
+                "model": model,
+                "arm": arm,
+                "item": case["id"],
+                "expected": case["expected_verdict"],
+                "expected_direction": case["expected_direction"],
+                "answer": answer,
+            }
+        )
+    RESULTS.mkdir(exist_ok=True)
+    for arm, rows in by_arm.items():
+        path = RESULTS / f"reviewed-verify-intent-{arm}-results.json"
+        path.write_text(json.dumps(rows, indent=1))
+        print(f"{arm}: wrote {len(rows)} results to {path.name}")
+    print(f"{model}: ok gen={result['gen_s']}s ({len(keyed_prompts)} prompts)")
 
 
 @app.local_entrypoint()

--- a/evals/memory-compaction/harness/export-reviewed-intent-context.py
+++ b/evals/memory-compaction/harness/export-reviewed-intent-context.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+"""Freeze bounded #957 intent context for the fixed #954 reviewed replay.
+
+The exporter is read-only. It records the source-pack commit separately from the live index commit
+that supplied context so an experiment cannot silently present a same-snapshot causal claim when
+the context was selected later.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import pathlib
+import sqlite3
+import subprocess
+import tempfile
+
+HARNESS = pathlib.Path(__file__).resolve().parent
+EVAL_DIR = HARNESS.parent
+REPO_ROOT = EVAL_DIR.parents[1]
+CORPUS = EVAL_DIR / "corpus"
+CASES_PATH = CORPUS / "reviewed-verify-replay.json"
+OUTPUT_PATH = CORPUS / "reviewed-verify-intent-context.json"
+VERIFIED_MEMORY_LIMIT = 3
+PAPERTRAIL_LIMIT = 3
+TARGET_LEAKAGE_ITEMS = {"954", "957", "959"}
+
+
+def note_content_hash(title: str, body: str) -> str:
+    text = f"{title.strip()}\n{body.strip()}"
+    return hashlib.sha256(text.encode()).hexdigest()
+
+
+def repo_and_index_commit(conn: sqlite3.Connection, memory_id: str) -> tuple[str, str]:
+    rows = conn.execute(
+        "SELECT DISTINCT repo_id FROM repo_memories WHERE id = ?1", (memory_id,)
+    ).fetchall()
+    if len(rows) != 1:
+        raise SystemExit(f"{memory_id}: expected one repo, found {len(rows)}")
+    repo_id = rows[0][0]
+    row = conn.execute(
+        "SELECT value FROM repo_meta WHERE repo_id = ?1 AND key = 'git_commit'",
+        (repo_id,),
+    ).fetchone()
+    if row is None:
+        raise SystemExit(f"{memory_id}: repo {repo_id} has no indexed git_commit")
+    return repo_id, row[0]
+
+
+def current_bound_paths(
+    conn: sqlite3.Connection, memory_id: str, repo_id: str
+) -> list[str]:
+    return [
+        row[0]
+        for row in conn.execute(
+            """
+            SELECT DISTINCT path
+            FROM repo_memory_bindings
+            WHERE repo_id = ?1 AND memory_id = ?2 AND path IS NOT NULL
+              AND anchor_status IN ('current', 'relocated')
+            ORDER BY path
+            """,
+            (repo_id, memory_id),
+        ).fetchall()
+    ]
+
+
+def current_input_hashes(
+    bin_path: pathlib.Path,
+    db_path: pathlib.Path,
+    repo_id: str,
+    memory_ids: list[str],
+) -> dict[str, str]:
+    with tempfile.TemporaryDirectory(prefix="reviewed-intent-hashes-") as temp:
+        temp_path = pathlib.Path(temp)
+        ids_path = temp_path / "memory-ids.json"
+        out_path = temp_path / "hashes.json"
+        ids_path.write_text(json.dumps(memory_ids))
+        subprocess.run(
+            [
+                str(bin_path),
+                "dump-memory-input-hashes",
+                "--db",
+                str(db_path.resolve()),
+                "--repo-id",
+                repo_id,
+                "--memory-ids",
+                str(ids_path),
+                "--out",
+                str(out_path),
+            ],
+            cwd=REPO_ROOT,
+            check=True,
+        )
+        return json.loads(out_path.read_text())
+
+
+def candidate_memory_ids(
+    conn: sqlite3.Connection,
+    repo_id: str,
+    index_commit: str,
+    prompt_version: str,
+) -> list[str]:
+    return [
+        row[0]
+        for row in conn.execute(
+            """
+            SELECT memory_id
+            FROM memory_reality
+            WHERE repo_id = ?1 AND verdict = 'current' AND prompt_version = ?2
+              AND checked_against_commit = ?3 AND checked_inputs_hash IS NOT NULL
+            ORDER BY memory_id
+            """,
+            (repo_id, prompt_version, index_commit),
+        ).fetchall()
+    ]
+
+
+def verified_memories(
+    conn: sqlite3.Connection,
+    case: dict,
+    repo_id: str,
+    index_commit: str,
+    prompt_version: str,
+    bound_paths: list[str],
+    input_hashes: dict[str, str],
+) -> list[dict]:
+    if not bound_paths:
+        return []
+    path_params = ", ".join("?" for _ in bound_paths)
+    rows = conn.execute(
+        f"""
+        SELECT DISTINCT
+            m.id, m.kind, m.title, m.body, mr.content_hash, mr.checked_inputs_hash,
+            mr.prompt_version, mr.checked_against_commit, ms.summary, mr.checked_at_ms, rb.path
+        FROM repo_memory_bindings AS rb
+        JOIN repo_memories AS m
+          ON m.repo_id = rb.repo_id AND m.id = rb.memory_id
+        JOIN memory_reality AS mr
+          ON mr.repo_id = m.repo_id AND mr.memory_id = m.id
+        LEFT JOIN memory_summaries AS ms
+          ON ms.repo_id = m.repo_id AND ms.memory_id = m.id
+         AND ms.content_hash = mr.content_hash AND ms.prompt_version = 'compact-v1'
+        WHERE rb.repo_id = ?
+          AND rb.path IN ({path_params})
+          AND rb.anchor_status IN ('current', 'relocated')
+          AND m.id != ?
+          AND m.status = 'active'
+          AND mr.verdict = 'current'
+          AND mr.prompt_version = ?
+          AND mr.checked_against_commit = ?
+          AND mr.checked_inputs_hash IS NOT NULL
+          AND NOT EXISTS (
+              SELECT 1 FROM repo_memory_bindings AS changed
+              WHERE changed.repo_id = m.repo_id AND changed.memory_id = m.id
+                AND changed.created_at_ms > mr.checked_at_ms
+          )
+        ORDER BY m.id, rb.path
+        """,
+        (repo_id, *bound_paths, case["memory_id"], prompt_version, index_commit),
+    ).fetchall()
+    selected = []
+    seen = set()
+    for row in rows:
+        if row[4] != note_content_hash(row[2], row[3]):
+            continue
+        if input_hashes.get(row[0]) != row[5]:
+            continue
+        if row[0] in seen:
+            continue
+        seen.add(row[0])
+        selected.append(
+            {
+                "memory_id": row[0],
+                "kind": row[1],
+                "title": row[2],
+                "summary": row[8],
+                "shared_binding": row[10],
+                "freshness": {
+                    "verdict": "current",
+                    "content_hash": row[4],
+                    "checked_inputs_hash": row[5],
+                    "prompt_version": row[6],
+                    "checked_against_commit": row[7],
+                    "checked_at_ms": row[9],
+                },
+            }
+        )
+        if len(selected) == VERIFIED_MEMORY_LIMIT:
+            break
+    return selected
+
+
+def rejected_alternatives(conn: sqlite3.Connection, repo_id: str, row: sqlite3.Row) -> list[dict]:
+    alternatives = conn.execute(
+        """
+        SELECT alternative, reason
+        FROM papertrail_distill_alternatives
+        WHERE repo_id = ?1 AND tracker = ?2 AND project = ?3
+          AND item_kind = ?4 AND item_key = ?5
+        ORDER BY ordinal
+        """,
+        (repo_id, row["tracker"], row["project"], row["item_kind"], row["item_key"]),
+    ).fetchall()
+    return [
+        {"alternative": alternative, "reason": reason}
+        for alternative, reason in alternatives
+    ]
+
+
+def papertrail_records(
+    conn: sqlite3.Connection, repo_id: str, bound_paths: list[str]
+) -> list[dict]:
+    if not bound_paths:
+        return []
+    path_params = ", ".join("?" for _ in bound_paths)
+    rows = conn.execute(
+        f"""
+        SELECT DISTINCT
+            d.tracker, d.project, d.item_kind, d.item_key, d.root_issue, d.root_cause,
+            d.decision_chosen, d.outcome_summary, d.distilled_at_ms, a.selected, a.file_path,
+            pi.title AS thread_title
+        FROM papertrail_distill_anchors AS a
+        JOIN papertrail_distill AS d
+          ON d.repo_id = a.repo_id AND d.tracker = a.tracker AND d.project = a.project
+         AND d.item_kind = a.item_kind AND d.item_key = a.item_key
+        JOIN papertrail_items AS pi
+          ON pi.repo_id = d.repo_id AND pi.tracker = d.tracker AND pi.project = d.project
+         AND pi.item_kind = d.item_kind AND pi.item_key = d.item_key
+        WHERE a.repo_id = ? AND a.file_path IN ({path_params}) AND a.resolved = 1
+        ORDER BY a.selected DESC, d.distilled_at_ms DESC,
+                 d.tracker, d.project, d.item_kind, d.item_key
+        """,
+        (repo_id, *bound_paths),
+    ).fetchall()
+    selected = []
+    seen = set()
+    for row in rows:
+        key = (row["tracker"], row["project"], row["item_kind"], row["item_key"])
+        if key in seen or row["item_key"] in TARGET_LEAKAGE_ITEMS:
+            continue
+        alternatives = rejected_alternatives(conn, repo_id, row)
+        if not any(
+            (
+                row["root_issue"],
+                row["root_cause"],
+                row["decision_chosen"],
+                row["outcome_summary"],
+                row["thread_title"],
+                alternatives,
+            )
+        ):
+            continue
+        seen.add(key)
+        selected.append(
+            {
+                "tracker": row["tracker"],
+                "project": row["project"],
+                "item_kind": row["item_kind"],
+                "item_key": row["item_key"],
+                "thread_title": row["thread_title"],
+                "root_issue": row["root_issue"],
+                "root_cause": row["root_cause"],
+                "decision_chosen": row["decision_chosen"],
+                "outcome_summary": row["outcome_summary"],
+                "rejected_alternatives": alternatives,
+                "shared_anchor": row["file_path"],
+                "selected_anchor": bool(row["selected"]),
+                "distilled_at_ms": row["distilled_at_ms"],
+                "unreviewed": True,
+            }
+        )
+        if len(selected) == PAPERTRAIL_LIMIT:
+            break
+    return selected
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--db", type=pathlib.Path, required=True)
+    parser.add_argument("--verdict-prompt-version", default="verify-pack-v3")
+    parser.add_argument(
+        "--bin",
+        type=pathlib.Path,
+        default=REPO_ROOT / "target" / "debug" / "rag-rat",
+        help="rag-rat binary built with --features eval",
+    )
+    args = parser.parse_args()
+
+    cases = json.loads(CASES_PATH.read_text())
+    uri = f"file:{args.db.resolve()}?mode=ro"
+    with sqlite3.connect(uri, uri=True) as conn:
+        conn.row_factory = sqlite3.Row
+        repo_commits = {repo_and_index_commit(conn, case["memory_id"]) for case in cases}
+        if len(repo_commits) != 1:
+            raise SystemExit(f"reviewed cases crossed context snapshots: {sorted(repo_commits)}")
+        repo_id, index_commit = next(iter(repo_commits))
+        candidate_ids = candidate_memory_ids(
+            conn, repo_id, index_commit, args.verdict_prompt_version
+        )
+        input_hashes = current_input_hashes(args.bin, args.db, repo_id, candidate_ids)
+        contexts = {}
+        for case in cases:
+            bound_paths = current_bound_paths(conn, case["memory_id"], repo_id)
+            contexts[case["id"]] = {
+                "current_bound_paths": bound_paths,
+                "verified_memories": verified_memories(
+                    conn,
+                    case,
+                    repo_id,
+                    index_commit,
+                    args.verdict_prompt_version,
+                    bound_paths,
+                    input_hashes,
+                ),
+                "papertrail": papertrail_records(conn, repo_id, bound_paths),
+            }
+    fixture = {
+        "selection_version": "intent-context-v1",
+        "source_pack_commit": cases[0]["source_commit"],
+        "context_index_commit": index_commit,
+        "context_repo_id": repo_id,
+        "verdict_prompt_version": args.verdict_prompt_version,
+        "limits": {
+            "verified_memories": VERIFIED_MEMORY_LIMIT,
+            "papertrail": PAPERTRAIL_LIMIT,
+            "rendered_context_bytes": 6000,
+        },
+        "cases": contexts,
+    }
+    OUTPUT_PATH.write_text(json.dumps(fixture, indent=1, sort_keys=True) + "\n")
+    memory_cases = sum(bool(context["verified_memories"]) for context in contexts.values())
+    papertrail_cases = sum(bool(context["papertrail"]) for context in contexts.values())
+    print(
+        f"wrote {len(contexts)} cases to {OUTPUT_PATH.relative_to(EVAL_DIR.parents[1])}: "
+        f"verified-memory context for {memory_cases}, papertrail context for {papertrail_cases}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/evals/memory-compaction/harness/intent_context.py
+++ b/evals/memory-compaction/harness/intent_context.py
@@ -1,0 +1,102 @@
+"""Pure rendering helpers for the #957 reviewed-verifier intent-context experiment."""
+
+from __future__ import annotations
+
+import json
+import pathlib
+
+ARMS = ("source-only", "verified-memory", "papertrail", "combined")
+MAX_CONTEXT_BYTES = 6000
+
+CONTEXT_PREAMBLE = """INTENT CONTEXT (NON-CITABLE):
+These rows may help interpret whether names in the NOTE are historical, transitional, rejected, or load-bearing. They are not proof of current checkout state. Never cite an INTENT row in EVIDENCE; only complete lines from the EVIDENCE PACK are admissible citations."""
+
+
+def _one_line(value: object | None) -> str:
+    return " ".join(str(value or "").split())
+
+
+def _memory_row(row: dict) -> str:
+    lines = [
+        f"INTENT MEMORY {row['memory_id']}",
+        f"KIND: {_one_line(row['kind'])}",
+        f"TITLE: {_one_line(row['title'])}",
+    ]
+    if row.get("summary"):
+        lines.append(f"SUMMARY: {_one_line(row['summary'])}")
+    return "\n".join(lines)
+
+
+def _papertrail_row(row: dict) -> str:
+    lines = [
+        "INTENT PAPERTRAIL "
+        f"{row['tracker']}:{row['project']}#{row['item_key']} ({row['item_kind']})"
+    ]
+    for label, key in (
+        ("THREAD TITLE", "thread_title"),
+        ("ROOT ISSUE", "root_issue"),
+        ("ROOT CAUSE", "root_cause"),
+        ("DECISION", "decision_chosen"),
+        ("OUTCOME", "outcome_summary"),
+    ):
+        if row.get(key):
+            lines.append(f"{label}: {_one_line(row[key])}")
+    for alternative in row.get("rejected_alternatives", []):
+        text = _one_line(alternative["alternative"])
+        reason = _one_line(alternative.get("reason"))
+        lines.append(f"REJECTED: {text}" + (f" BECAUSE: {reason}" if reason else ""))
+    return "\n".join(lines)
+
+
+def render_intent_context(context: dict, arm: str) -> str:
+    if arm not in ARMS:
+        raise ValueError(f"unknown intent-context arm: {arm}")
+    if arm == "source-only":
+        return ""
+    rows = []
+    if arm in {"verified-memory", "combined"}:
+        rows.extend(_memory_row(row) for row in context["verified_memories"])
+    if arm in {"papertrail", "combined"}:
+        rows.extend(_papertrail_row(row) for row in context["papertrail"])
+    if not rows:
+        return ""
+
+    rendered = CONTEXT_PREAMBLE
+    for row in rows:
+        candidate = f"{rendered}\n\n{row}"
+        if len(candidate.encode()) > MAX_CONTEXT_BYTES:
+            break
+        rendered = candidate
+    return rendered
+
+
+def render_reviewed_prompt(
+    prompt_template: str,
+    case: dict,
+    pack: str,
+    context: dict,
+    arm: str,
+) -> str:
+    prompt = prompt_template.format(
+        binding=case["binding"]["value"],
+        title=case["title"],
+        body=case["body"],
+        pack=pack,
+    )
+    rendered_context = render_intent_context(context, arm)
+    if not rendered_context:
+        return prompt
+    marker = "\nEVIDENCE PACK:\n"
+    if marker not in prompt:
+        raise ValueError("reviewed verifier prompt has no EVIDENCE PACK marker")
+    return prompt.replace(marker, f"\n{rendered_context}\n{marker}", 1)
+
+
+def load_context_fixture(path: pathlib.Path, case_ids: set[str]) -> dict:
+    fixture = json.loads(path.read_text())
+    contexts = fixture["cases"]
+    if set(contexts) != case_ids:
+        missing = sorted(case_ids - set(contexts))
+        extra = sorted(set(contexts) - case_ids)
+        raise ValueError(f"intent-context fixture mismatch: missing={missing} extra={extra}")
+    return fixture

--- a/evals/memory-compaction/harness/test_intent_context.py
+++ b/evals/memory-compaction/harness/test_intent_context.py
@@ -1,0 +1,136 @@
+import importlib.util
+import json
+import pathlib
+import unittest
+
+import intent_context
+
+HARNESS = pathlib.Path(__file__).resolve().parent
+EVAL_DIR = HARNESS.parent
+
+_score_spec = importlib.util.spec_from_file_location(
+    "score_reviewed_verify", HARNESS / "score-reviewed-verify.py"
+)
+score = importlib.util.module_from_spec(_score_spec)
+_score_spec.loader.exec_module(score)
+
+
+class IntentContextTests(unittest.TestCase):
+    def setUp(self):
+        self.case = {
+            "id": "reviewed_00",
+            "memory_id": "subject",
+            "binding": {"value": "src/lib.rs"},
+            "title": "The `ghost_symbol` helper exists",
+            "body": "The `ghost_symbol` helper exists in the current writer path.",
+        }
+        self.context = {
+            "verified_memories": [
+                {
+                    "memory_id": "neighbor",
+                    "kind": "Decision",
+                    "title": "Legacy writer history",
+                    "summary": "The old writer was intentionally removed.",
+                }
+            ],
+            "papertrail": [
+                {
+                    "tracker": "github",
+                    "project": "owner/repo",
+                    "item_kind": "issue",
+                    "item_key": "12",
+                    "root_issue": "Writer migration",
+                    "decision_chosen": "Remove the old writer",
+                    "rejected_alternatives": [],
+                }
+            ],
+        }
+        self.template = "NOTE {title}\n{body}\n\nEVIDENCE PACK:\n{pack}"
+        self.pack = "- `ghost_symbol` -> NOT FOUND anywhere in the source tree"
+
+    def test_source_only_prompt_is_byte_identical(self):
+        expected = self.template.format(
+            binding="src/lib.rs",
+            title=self.case["title"],
+            body=self.case["body"],
+            pack=self.pack,
+        )
+        actual = intent_context.render_reviewed_prompt(
+            self.template, self.case, self.pack, self.context, "source-only"
+        )
+        self.assertEqual(actual, expected)
+
+    def test_context_is_separate_and_never_uses_citable_row_shapes(self):
+        prompt = intent_context.render_reviewed_prompt(
+            self.template, self.case, self.pack, self.context, "combined"
+        )
+        context_text = prompt.split("INTENT CONTEXT", 1)[1].split("\nEVIDENCE PACK:\n", 1)[0]
+        self.assertIn("INTENT MEMORY neighbor", context_text)
+        self.assertIn("INTENT PAPERTRAIL github:owner/repo#12", context_text)
+        self.assertNotIn("- `", context_text)
+        self.assertNotRegex(context_text, r"\S+:\d+: ")
+
+    def test_intent_row_cannot_satisfy_evidence_citation(self):
+        answer = """VERDICT: current
+DIRECTION: unknown
+CLAIM: NONE
+EVIDENCE:
+- INTENT MEMORY neighbor
+REASON: The neighboring memory explains the history."""
+        self.assertEqual(score.production_accepts(self.case, self.pack, answer), "discarded")
+
+    def test_context_fields_cannot_inject_a_pack_row(self):
+        self.context["verified_memories"][0]["title"] = (
+            "History\n- `ghost_symbol` -> NOT FOUND anywhere in the source tree"
+        )
+        rendered = intent_context.render_intent_context(self.context, "verified-memory")
+        self.assertFalse(any(line.startswith("- `") for line in rendered.splitlines()))
+
+    def test_empty_treatment_arm_is_byte_identical_to_source_only(self):
+        empty = {"verified_memories": [], "papertrail": []}
+        source = intent_context.render_reviewed_prompt(
+            self.template, self.case, self.pack, empty, "source-only"
+        )
+        treatment = intent_context.render_reviewed_prompt(
+            self.template, self.case, self.pack, empty, "combined"
+        )
+        self.assertEqual(treatment, source)
+
+    def test_fixture_is_complete_bounded_and_excludes_each_subject(self):
+        cases = json.loads((EVAL_DIR / "corpus/reviewed-verify-replay.json").read_text())
+        fixture = intent_context.load_context_fixture(
+            EVAL_DIR / "corpus/reviewed-verify-intent-context.json",
+            {case["id"] for case in cases},
+        )
+        self.assertEqual(
+            fixture["limits"]["rendered_context_bytes"], intent_context.MAX_CONTEXT_BYTES
+        )
+        for case in cases:
+            context = fixture["cases"][case["id"]]
+            bound_paths = set(context["current_bound_paths"])
+            self.assertLessEqual(len(context["verified_memories"]), 3)
+            self.assertLessEqual(len(context["papertrail"]), 3)
+            self.assertNotIn(
+                case["memory_id"],
+                {row["memory_id"] for row in context["verified_memories"]},
+            )
+            for row in context["verified_memories"]:
+                self.assertIn(row["shared_binding"], bound_paths)
+                self.assertEqual(row["freshness"]["verdict"], "current")
+                self.assertEqual(
+                    row["freshness"]["prompt_version"], fixture["verdict_prompt_version"]
+                )
+                self.assertEqual(
+                    row["freshness"]["checked_against_commit"],
+                    fixture["context_index_commit"],
+                )
+            for row in context["papertrail"]:
+                self.assertIn(row["shared_anchor"], bound_paths)
+                self.assertTrue(row["unreviewed"])
+                self.assertNotIn(row["item_key"], {"954", "957", "959"})
+            rendered = intent_context.render_intent_context(context, "combined")
+            self.assertLessEqual(len(rendered.encode()), intent_context.MAX_CONTEXT_BYTES)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a reproducible four-arm replay for source-only, verified-memory, papertrail, and combined verifier prompts
- freeze bounded non-citable context with exact production-input-hash freshness checks through a read-only database path
- document the negative result: context trades the source-only false positive on `reviewed_26` for a new false positive on `reviewed_29`, with no aggregate precision, recall, or discard-rate gain
- keep production dream verification source-only

## Verification
- `cargo build -p rag-rat --features eval`
- `cargo clippy -p rag-rat --all-targets --features eval -- -D warnings`
- `cargo nextest run -p rag-rat-core dream --features eval`
- `python3 -m unittest discover -s harness -p 'test_*.py'`\n- `ruff check harness/eval_app.py harness/intent_context.py harness/export-reviewed-intent-context.py harness/compare-reviewed-intent.py harness/test_intent_context.py`\n- Modal run `ap-TrGVrolU345ouPggx1c3eX`\n\nCloses #957