### PR TITLE
fix(tests): clean high-volume scratch fixtures

### DIFF
--- a/crates/rag-rat-base/src/test_scratch.rs
+++ b/crates/rag-rat-base/src/test_scratch.rs
@@ -22,8 +22,8 @@
 //!   2. the FIRST scratch request in each process sweeps sibling scratch dirs older than
 //!      [`SWEEP_MAX_AGE`] out of that root — self-healing after a `kill -9`, no external cron.
 //!
-//! `Drop`-based cleanup stays the fast path; the age-bounded sweep is only the backstop for the
-//! cases where `Drop` never runs.
+//! [`ScratchDir`]'s `Drop` cleanup is the fast path; the age-bounded sweep is only the backstop for
+//! the cases where `Drop` never runs.
 //!
 //! # Security: the namespace is per-user and its identity is verified before any sweep
 //!
@@ -318,6 +318,42 @@ pub fn scratch_dir(tag: &str) -> PathBuf {
     dir
 }
 
+/// One uniquely owned scratch directory, removed on drop.
+///
+/// Names retain [`scratch_dir`]'s tag + PID + atomic-sequence scheme, so parallel tests never share
+/// a directory. The guard is deliberately not cloneable: exactly one owner removes each path.
+/// Keep it alive until every file, database connection, watcher, and child process using the path
+/// has dropped; this is required for cleanup on Windows.
+#[derive(Debug)]
+pub struct ScratchDir {
+    path: PathBuf,
+}
+
+impl ScratchDir {
+    pub fn new(tag: &str) -> Self {
+        let path = scratch_dir(tag);
+        std::fs::create_dir_all(&path)
+            .unwrap_or_else(|error| panic!("failed to create scratch directory {path:?}: {error}"));
+        Self { path }
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl AsRef<Path> for ScratchDir {
+    fn as_ref(&self) -> &Path {
+        self.path()
+    }
+}
+
+impl Drop for ScratchDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::ffi::OsStr;
@@ -510,6 +546,46 @@ mod tests {
         assert_eq!(dir.parent(), Some(scratch_root().as_path()));
         let name = dir.file_name().and_then(|n| n.to_str()).unwrap_or_default();
         assert!(name.starts_with("normal-tag-"), "unexpected scratch name {name:?}");
+    }
+
+    #[test]
+    fn scratch_guard_removes_its_directory_on_drop() {
+        let path = {
+            let scratch = ScratchDir::new("drop-probe");
+            let path = scratch.path().to_path_buf();
+            std::fs::write(path.join("payload"), "test").unwrap();
+            path
+        };
+        assert!(!path.exists(), "scratch guard left its directory behind: {path:?}");
+    }
+
+    #[test]
+    fn scratch_guard_removes_its_directory_during_unwind() {
+        let scratch = ScratchDir::new("unwind-probe");
+        let path = scratch.path().to_path_buf();
+        let result = std::panic::catch_unwind(move || {
+            let _scratch = scratch;
+            panic!("fixture failure");
+        });
+        assert!(result.is_err());
+        assert!(!path.exists(), "unwinding left the scratch directory behind: {path:?}");
+    }
+
+    #[test]
+    fn parallel_scratch_guards_get_distinct_directories() {
+        let workers = (0..32)
+            .map(|_| std::thread::spawn(|| ScratchDir::new("parallel-probe")))
+            .collect::<Vec<_>>();
+        let scratch = workers.into_iter().map(|worker| worker.join().unwrap()).collect::<Vec<_>>();
+        let paths = scratch
+            .iter()
+            .map(|dir| dir.path().to_path_buf())
+            .collect::<std::collections::BTreeSet<_>>();
+        assert_eq!(paths.len(), scratch.len());
+        assert!(paths.iter().all(|path| path.is_dir()));
+
+        drop(scratch);
+        assert!(paths.iter().all(|path| !path.exists()));
     }
 
     /// The exact #732-review attack: a `..` tag aims the join+delete at a victim OUTSIDE the

--- a/crates/rag-rat-core/src/index/query_api/clones/delta.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/delta.rs
@@ -1781,7 +1781,7 @@ mod tests {
 
         // Two byte-identical fixtures, taken through the SAME rebuild + precompute + edit +
         // reindex, so only the delta's changed-set derivation differs between them.
-        let prepare = |tag: &str| -> (rag_rat_base::config::Config, crate::IndexDatabase) {
+        let prepare = |tag: &str| {
             let config = clone_fixture_config(tag);
             let db = crate::IndexDatabase::rebuild(&config).unwrap();
             assert_eq!(db.precompute_clone_graph(None).unwrap().status, "Complete");
@@ -1802,15 +1802,15 @@ mod tests {
             )
             .unwrap();
             let db = reindex(&config);
-            (config, db)
+            config.retain_for(db)
         };
 
-        let (_scan_config, scan_db) = prepare("delta-hint-scan");
+        let scan_db = prepare("delta-hint-scan");
         let scan_report =
             scan_db.apply_clone_graph_delta_hinted(64, CloneDeltaHint::FullScan).unwrap();
         let scan_edges = edge_keys(&scan_db);
 
-        let (_hint_config, hint_db) = prepare("delta-hint-paths");
+        let hint_db = prepare("delta-hint-paths");
         // The hint the reconcile would supply: the reindexed/new paths PLUS an unchanged base file.
         let touched: BTreeSet<String> =
             ["src/a.rs", "src/b.rs", "src/c.rs"].iter().map(|s| s.to_string()).collect();

--- a/crates/rag-rat-core/src/index/query_api/clones/precompute/tests.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/precompute/tests.rs
@@ -2,18 +2,53 @@ use super::build::{build_sub_block_index, resolve_symbol_anchors};
 use super::storage::open_building_generation;
 use super::*;
 
+pub(in super::super) struct CloneFixture {
+    config: rag_rat_base::config::Config,
+    scratch: rag_rat_base::test_scratch::ScratchDir,
+}
+
+impl CloneFixture {
+    pub(in super::super) fn retain_for(self, db: crate::IndexDatabase) -> CloneDatabase {
+        CloneDatabase { db, _scratch: self.scratch }
+    }
+}
+
+impl std::ops::Deref for CloneFixture {
+    type Target = rag_rat_base::config::Config;
+
+    fn deref(&self) -> &Self::Target {
+        &self.config
+    }
+}
+
+impl std::ops::DerefMut for CloneFixture {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.config
+    }
+}
+
+pub(in super::super) struct CloneDatabase {
+    // Fields drop in declaration order: close SQLite before removing its directory on Windows.
+    db: crate::IndexDatabase,
+    _scratch: rag_rat_base::test_scratch::ScratchDir,
+}
+
+impl std::ops::Deref for CloneDatabase {
+    type Target = crate::IndexDatabase;
+
+    fn deref(&self) -> &Self::Target {
+        &self.db
+    }
+}
+
 /// The config for a fixed two-file fixture with two renamed-clone groups
 /// (load_user/load_order and compute_totals/tally_amounts). Identical file CONTENT across tags
 /// → identical content-key edges, so two builds are directly comparable. Split out so a
 /// test can `rebuild` the SAME config twice (identical content) to exercise the
 /// full-rebuild df refresh.
-pub(in super::super) fn clone_fixture_config(tag: &str) -> rag_rat_base::config::Config {
-    let root = std::env::temp_dir().join(format!(
-        "rag-rat-precompute-{tag}-{}-{}",
-        std::process::id(),
-        now_ms()
-    ));
-    let _ = std::fs::remove_dir_all(&root);
+pub(in super::super) fn clone_fixture_config(tag: &str) -> CloneFixture {
+    let scratch = rag_rat_base::test_scratch::ScratchDir::new(&format!("precompute-{tag}"));
+    let root = scratch.path().to_path_buf();
     std::fs::create_dir_all(root.join("src")).unwrap();
     std::fs::write(
         root.join("src/a.rs"),
@@ -29,7 +64,7 @@ pub(in super::super) fn clone_fixture_config(tag: &str) -> rag_rat_base::config:
          } t + 1 }\n",
     )
     .unwrap();
-    rag_rat_base::config::Config {
+    let config = rag_rat_base::config::Config {
         trackers: Vec::new(),
         papertrail: Default::default(),
         sync: Default::default(),
@@ -54,12 +89,15 @@ pub(in super::super) fn clone_fixture_config(tag: &str) -> rag_rat_base::config:
         log: Default::default(),
         source_root_reanchored_from: None,
         allow_empty: false,
-    }
+    };
+    CloneFixture { config, scratch }
 }
 
 /// A fixed two-file fixture (see [`clone_fixture_config`]), rebuilt fresh.
-fn build_clone_fixture(tag: &str) -> crate::IndexDatabase {
-    crate::IndexDatabase::rebuild(&clone_fixture_config(tag)).unwrap()
+fn build_clone_fixture(tag: &str) -> CloneDatabase {
+    let fixture = clone_fixture_config(tag);
+    let db = crate::IndexDatabase::rebuild(&fixture).unwrap();
+    fixture.retain_for(db)
 }
 
 /// The content-key set of the live-or-only generation's edges, sorted — the build-stable

--- a/crates/rag-rat-core/src/index/query_api/db_file_health.rs
+++ b/crates/rag-rat-core/src/index/query_api/db_file_health.rs
@@ -330,22 +330,32 @@ fn freelist_snapshot(
 
 #[cfg(test)]
 mod tests {
-    use std::sync::atomic::{AtomicU64, Ordering};
-
     use super::*;
 
-    static FIXTURE_SEQ: AtomicU64 = AtomicU64::new(0);
+    struct TestDatabase {
+        // Fields drop in declaration order: close SQLite before removing its directory on Windows.
+        db: crate::IndexDatabase,
+        _scratch: rag_rat_base::test_scratch::ScratchDir,
+    }
+
+    impl std::ops::Deref for TestDatabase {
+        type Target = crate::IndexDatabase;
+
+        fn deref(&self) -> &Self::Target {
+            &self.db
+        }
+    }
 
     /// Minimal single-file fixture: file-health tests need a real WAL-mode database with a
     /// registered repo, not any particular indexed content.
-    fn fixture_config(tag: &str) -> rag_rat_base::config::Config {
-        let seq = FIXTURE_SEQ.fetch_add(1, Ordering::Relaxed);
-        let root = std::env::temp_dir()
-            .join(format!("rag-rat-file-health-{tag}-{}-{seq}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&root);
+    fn fixture_config(
+        tag: &str,
+    ) -> (rag_rat_base::config::Config, rag_rat_base::test_scratch::ScratchDir) {
+        let scratch = rag_rat_base::test_scratch::ScratchDir::new(&format!("file-health-{tag}"));
+        let root = scratch.path().to_path_buf();
         std::fs::create_dir_all(root.join("src")).unwrap();
         std::fs::write(root.join("src/a.rs"), "pub fn health_probe() -> i32 { 1 }\n").unwrap();
-        rag_rat_base::config::Config {
+        let config = rag_rat_base::config::Config {
             trackers: Vec::new(),
             papertrail: Default::default(),
             sync: Default::default(),
@@ -370,11 +380,14 @@ mod tests {
             log: Default::default(),
             source_root_reanchored_from: None,
             allow_empty: false,
-        }
+        };
+        (config, scratch)
     }
 
-    fn build_fixture(tag: &str) -> crate::IndexDatabase {
-        crate::IndexDatabase::rebuild(&fixture_config(tag)).unwrap()
+    fn build_fixture(tag: &str) -> TestDatabase {
+        let (config, scratch) = fixture_config(tag);
+        let db = crate::IndexDatabase::rebuild(&config).unwrap();
+        TestDatabase { db, _scratch: scratch }
     }
 
     /// Guarantee at least one un-checkpointed WAL frame (the rebuild may have autocheckpointed).

--- a/crates/rag-rat-oracle/src/test_support.rs
+++ b/crates/rag-rat-oracle/src/test_support.rs
@@ -4,45 +4,16 @@
 //! memory-relocation tests, so it is NOT `#[cfg(test)]` — the gate does not propagate cross-crate.
 //! Not part of the semver-stable API surface.
 
-use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::path::Path;
 
 use ::protobuf::{EnumOrUnknown, Message};
 use ::scip::types::{Document, Index, Occurrence, PositionEncoding};
+use rag_rat_base::test_scratch::ScratchDir;
 use rag_rat_db::schema;
 use rusqlite::{Connection, params};
 
 use crate::store::{self, EdgeOracleRow};
 use crate::{OracleResolutionKind, OracleTool};
-
-/// A unique temp directory under the system temp root (no external crate; matches the repo's
-/// `std::env::temp_dir` + atomic-counter convention). Cleaned up on `Drop`.
-struct TempRoot {
-    path: PathBuf,
-}
-
-impl TempRoot {
-    fn new() -> Self {
-        static N: AtomicU64 = AtomicU64::new(0);
-        let path = std::env::temp_dir().join(format!(
-            "rag-rat-oracle-{}-{}",
-            std::process::id(),
-            N.fetch_add(1, Ordering::Relaxed)
-        ));
-        std::fs::create_dir_all(&path).unwrap();
-        TempRoot { path }
-    }
-
-    fn path(&self) -> &Path {
-        &self.path
-    }
-}
-
-impl Drop for TempRoot {
-    fn drop(&mut self) {
-        let _ = std::fs::remove_dir_all(&self.path);
-    }
-}
 
 pub const TOOL: OracleTool = OracleTool::RustAnalyzer;
 pub const VERSION: &str = "test";
@@ -67,7 +38,8 @@ pub struct EdgeContentKey {
 /// A test corpus written to a temp checkout + an index DB seeded to match.
 pub struct Harness {
     pub conn: Connection,
-    root: TempRoot,
+    // Fields drop in declaration order: close SQLite before removing its directory on Windows.
+    root: ScratchDir,
 }
 
 impl Default for Harness {
@@ -85,7 +57,7 @@ impl Harness {
         // Fresh in-memory scratch DB: the documented-sound `MigrationHooks::noop()` case — every
         // hook-using migration runs over empty tables, so the harness stays engine-free.
         schema::apply(&conn, &rag_rat_db::MigrationHooks::noop()).unwrap();
-        let root = TempRoot::new();
+        let root = ScratchDir::new("oracle");
         Harness { conn, root }
     }
 


### PR DESCRIPTION
## Summary
- add a non-cloneable `ScratchDir` guard on top of the secure per-user scratch namespace and stale-process sweep
- preserve parallel uniqueness with tag + PID + atomic sequence names, including explicit concurrent and unwind cleanup tests
- migrate clone precompute/delta and file-health fixtures that leaked on successful runs
- route the shared oracle harness through the same namespace and ensure database handles close before directory removal

## Verification
- `cargo nextest run -p rag-rat-base test_scratch`
- `cargo nextest run -p rag-rat-core precompute`
- `cargo nextest run -p rag-rat-core db_file_health`
- `cargo nextest run -p rag-rat-core delta`
- `cargo nextest run -p rag-rat-oracle`
- `cargo nextest run -p rag-rat-core oracle`
- `cargo clippy -p rag-rat-base -p rag-rat-oracle -p rag-rat-core --all-targets -- -D warnings`
- isolated parallel TMPDIR run of the 31 migrated core tests left only the empty namespace at 0 bytes

Addresses #586. Schema, watch, and remaining ad-hoc `PathBuf` fixtures can migrate incrementally to the same guard.