### PR TITLE
fix(tests): retain schema scratch cleanup guards

### DIFF
--- a/crates/rag-rat-core/src/index/remove.rs
+++ b/crates/rag-rat-core/src/index/remove.rs
@@ -425,7 +425,7 @@ mod tests {
             "an exact recorded config root remains a valid destructive target"
         );
         drop(storage);
-        let _ = std::fs::remove_dir_all(root);
+        let _ = std::fs::remove_dir_all(&root);
     }
 
     /// The one REAL fixture repo (neither the `__unassigned__` placeholder nor the poison sibling).
@@ -935,7 +935,7 @@ mod tests {
             "the newly re-added repo must survive the stale removal attempt"
         );
         drop(storage);
-        let _ = std::fs::remove_dir_all(root);
+        let _ = std::fs::remove_dir_all(&root);
     }
 
     /// The removal tombstone gates re-registration: once a repo is marked removed, the indexing

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/change_coupling.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/change_coupling.rs
@@ -760,7 +760,7 @@ fn impact_report_surfaces_and_gates_coupling_section() {
         capped.completeness_and_caveats.truncated_sections
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// Codex #566 finding 2: a co-changed file that is dirty-since-index must count toward
@@ -815,5 +815,5 @@ fn dirty_co_changed_file_counts_toward_stale_files() {
         report.completeness_and_caveats.stale_files
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/chunk_store_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/chunk_store_migrations.rs
@@ -112,7 +112,7 @@ fn rebuild_fts_repopulates_contentless_chunk_fts_from_the_store() {
         "rebuild_fts repopulates contentless chunk_fts from chunk_text"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -912,7 +912,7 @@ fn full_rebuild_applies_per_package_import_scope() {
         "a `Display` use'd from external std must not bind to the local `Display` struct"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 // ─── Phase C1: orientation composer ──────────────────────────────────────────
@@ -1034,5 +1034,5 @@ fn orientation_composes_read_only() {
     );
     assert_eq!(o2.total_files, o1.total_files, "second call: total_files changed");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/clones/eligibility.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/clones/eligibility.rs
@@ -50,7 +50,7 @@ fn clones_for_symbol_reports_eligibility() {
     let class = clone.class.expect("load_user is in a clone class");
     assert_eq!(class.member_count, 2, "the clone class has both rename-clones");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// #274 item 3a: `clones_for_symbol` reports a RICHER eligibility reason than the bare
@@ -239,5 +239,5 @@ fn clones_for_symbol_distinguishes_ineligibility_reasons() {
     }
     assert_eq!(crate::index::CloneIneligibilityReason::from_db_str("bogus"), None);
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/clones/fingerprints.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/clones/fingerprints.rs
@@ -84,7 +84,7 @@ fn indexing_writes_baseline_fingerprints_for_functions() {
         conn.query_row("SELECT count(*) FROM symbol_fingerprints", [], |r| r.get(0)).unwrap();
     assert_eq!(after_fps, 0, "fingerprints (and their token_bag BLOBs) cascade on symbol delete");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// T4 (#231): `refresh_clone_token_df` recomputed from the token-bag BLOBs equals the postings-era
@@ -147,7 +147,7 @@ fn clone_token_df_recomputed_from_blobs_matches_postings_era() {
         "the two renamed clones share at least one token (df == 2)"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -179,7 +179,7 @@ fn candidate_components_group_renamed_clones_and_exclude_unrelated() {
     assert_eq!(components.len(), 1, "exactly one clone component: {components:?}");
     assert_eq!(components[0].len(), 2, "the component is the two renamed clones: {components:?}");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// Adversarial containment (design rev-4 §8): a small function A whose entire token bag is
@@ -243,7 +243,7 @@ fn candidate_components_reject_small_function_contained_in_large_one() {
         "a small function contained in a large one is NOT a whole-symbol clone: {components:?}"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// df is a selectivity hint only (design rev-4 §2, §8): emptying `clone_token_df` must NOT change
@@ -278,7 +278,7 @@ fn candidate_components_unchanged_when_clone_token_df_is_empty() {
         "df is selectivity-only: emptying clone_token_df must not change components"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// The `files.generated = 0` predicate is a READ-SIDE filter: generated files are still
@@ -342,7 +342,7 @@ fn candidate_components_exclude_generated_files_via_read_filter() {
         "generated b.rs must be excluded from clone components by the read filter: {after:?}"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// #232 #6: a PATH-heuristic-generated file under a SOURCE target (`src/generated/*.rs`,
@@ -418,7 +418,7 @@ fn generated_files_are_not_fingerprinted_at_index_time() {
         "generated file must NOT be fingerprinted after a single-file heal"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// #232 multi-language integration: a Rust + TS + Python repo with WITHIN-language planted clones
@@ -556,7 +556,7 @@ fn multi_language_clone_integration_finds_within_language_no_cross() {
         );
     }
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// Max-denominator overlap gate regression: two structurally different functions whose
@@ -622,7 +622,7 @@ fn candidate_components_reject_partial_overlap_below_max_denominator_theta() {
          containment): min_len={min_len} max_len={max_len} threshold={threshold} {comps:?}"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// normalizer_version filter: after a NORM_VERSION bump the old rows are stale and the read
@@ -657,5 +657,5 @@ fn candidate_read_ignores_stale_normalizer_version_rows() {
         "stale-version fingerprints must be ignored by the read"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/clones/ranking.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/clones/ranking.rs
@@ -88,7 +88,7 @@ fn find_clones_ranks_a_clean_clone_class_with_metrics() {
     assert_eq!(res.completeness.normalizer_version, NORM_VERSION);
     assert!(!res.completeness.truncated);
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// `clones_for_symbol` integration test: two rename-clone functions (a.rs / b.rs) form one
@@ -152,7 +152,7 @@ fn clones_for_symbol_returns_the_class_by_ref_and_by_path_line() {
 
     // Post-condition: the clone rebuild/precompute must not touch a sibling repo (round-6 harness).
     crate::index::poison_sibling::assert_sibling_intact(db2.storage.connection());
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// Fix 1 (#215): `min_similarity` is honored ALL the way through candidate generation, not merely
@@ -214,7 +214,7 @@ fn find_clones_min_similarity_below_theta_widens_and_is_reported() {
     );
     assert_eq!(default.completeness.min_similarity, 0.7, "default completeness θ is 0.7");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// `min_similarity` is a similarity ratio θ = overlap/max_len and must lie in [0.5, 1.0]. Values
@@ -276,7 +276,7 @@ fn find_clones_rejects_out_of_range_min_similarity() {
     db.find_clones(FindClonesOptions { min_similarity: Some(0.5), min_copies: None, limit: None })
         .expect("min_similarity = 0.5 is the inclusive lower bound and must be accepted");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// Fix 2 (#215): `completeness.truncated` reflects whole CLASSES dropped by `limit`, not only
@@ -330,7 +330,7 @@ fn find_clones_truncated_reflects_class_limit() {
         "dropping a whole class via the limit must set completeness.truncated"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// Plan 4 coherence-splits over-merged components; the A~B~C chain becomes coherent sub-classes.
@@ -398,7 +398,7 @@ fn coherence_split_applied_in_find_clones() {
             })
             .unwrap();
         let sim = res.classes.first().map(|c| c.similarity_min).unwrap_or(0.0);
-        let _ = fs::remove_dir_all(r);
+        let _ = fs::remove_dir_all(&r);
         sim
     };
     let ab = edge_sim(("a", a), ("b", b));
@@ -471,7 +471,7 @@ fn coherence_split_applied_in_find_clones() {
     );
     assert!(c_class.refined, "the {{B,C}} sub-class is refined");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// #256 (R5c): the full clone path is DETERMINISTic on a synthetic transitive chain. The
@@ -513,7 +513,7 @@ fn clone_split_full_path_is_deterministic() {
         // clones_for_symbol on the chained subject B (which is in BOTH {A,B} and {B,C}).
         let by_b = db.clones_for_symbol(CloneSymbolSelector::Ref("src/b.rs::fb".into())).unwrap();
         let b_key = by_b.class.as_ref().map(|cl| cl.class_key.clone());
-        let _ = fs::remove_dir_all(root);
+        let _ = fs::remove_dir_all(&root);
         (keys, b_key)
     };
 
@@ -565,7 +565,7 @@ fn clones_for_chained_symbol_serves_tight_neighborhood() {
         "the served class must be internally coherent (≥ θ): got {}",
         b_class.cohesion_min_pairwise
     );
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// #256 (R7) recall pin: a 7-copy structurally-identical clone family (the `collect_rows`-style
@@ -624,7 +624,7 @@ fn find_clones_recall_pin_seven_copy_clone_still_found() {
     );
     assert!(seven.roi > 0.0, "a genuine clone keeps a positive ROI");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// Plan 4a: four renamed clones (same structure, different names) form ONE class that the refine
@@ -662,7 +662,7 @@ fn find_clones_refines_a_clean_class() {
         c.roi
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// Plan 4a: `clones_for_symbol` always refines the subject's class (when refine inputs are
@@ -686,5 +686,5 @@ fn clones_for_symbol_returns_refined_class() {
         class.members.iter().map(|m| &m.r#ref).collect::<Vec<_>>()
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/clones/refinement.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/clones/refinement.rs
@@ -39,7 +39,7 @@ fn refinement_key_is_content_addressed_and_distinct_from_read_key() {
         "the content-addressed refinement key must differ from the location-derived read key"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// Plan 4a: the refinement cache is read-through — the first `find_clones` populates a
@@ -78,7 +78,7 @@ fn refine_cache_is_read_through() {
     assert!(r2.classes[0].refined, "run 2 still refined (served from cache)");
     assert_eq!(count_rows(&db), after_run1, "run 2 is a cache hit — the row count must not grow");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// Fix A (#215 Plan 4a codex2): the warm path (cache hit) must NOT re-parse any source file.
@@ -118,7 +118,7 @@ fn find_clones_warm_cache_serves_refined_without_reparse() {
         "warm-path lcs_ratio must match the cold-path value"
     );
 
-    fs::remove_dir_all(root).unwrap_or(());
+    fs::remove_dir_all(&root).unwrap_or(());
 }
 
 /// Fix B (#215 Plan 4a codex2): the member-count sampling dimension must be reported consistently
@@ -155,7 +155,7 @@ fn find_clones_warm_cache_metrics_sampled_consistent() {
          ({sampled_warm}) paths"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// Plan 4a: only the top-N (by provisional ROI) classes are refined, where N == the caller's limit.
@@ -235,8 +235,8 @@ fn unrefined_class_outside_top_n_keeps_plan2_shape() {
         "limit=1 refines only the top-1 class — the out-of-budget class is never refined"
     );
 
-    let _ = fs::remove_dir_all(root);
-    let _ = fs::remove_dir_all(root2);
+    let _ = fs::remove_dir_all(&root);
+    let _ = fs::remove_dir_all(&root2);
 }
 
 /// Fix 2 (Codex P2 #215 Plan 4a): find_clones with limit=Some(N) must never return an unrefined
@@ -322,8 +322,8 @@ fn find_clones_limited_result_contains_only_refined_classes() {
         );
     }
 
-    let _ = fs::remove_dir_all(root);
-    let _ = fs::remove_dir_all(root2);
+    let _ = fs::remove_dir_all(&root);
+    let _ = fs::remove_dir_all(&root2);
 }
 
 /// I2 (#215 Plan 4a adversary): find_clones with a huge limit must clamp effective returned classes
@@ -414,7 +414,7 @@ fn find_clones_huge_limit_clamps_to_refine_budget() {
         "a limit above the budget that drops classes must set refine_budget_clamped"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// Plan 4b Task 5b: `load_refine_members` caps the re-parse to `MEMBER_VALUE_CAP` (50, previously
@@ -487,7 +487,7 @@ fn load_refine_members_returns_up_to_value_cap() {
     // live handle (`os error 32`), whereas Unix unlinks it lazily. Dropping `db` first makes the
     // strict teardown pass on both.
     drop(db);
-    fs::remove_dir_all(root).unwrap();
+    fs::remove_dir_all(&root).unwrap();
 }
 
 /// Plan 4b Task 5b: every `RefineMember` returned by `load_refine_members` must carry
@@ -555,7 +555,7 @@ fn refine_member_carries_spans_len_eq_seq() {
     // live handle (`os error 32`), whereas Unix unlinks it lazily. Dropping `db` first makes the
     // strict teardown pass on both.
     drop(db);
-    fs::remove_dir_all(root).unwrap();
+    fs::remove_dir_all(&root).unwrap();
 }
 
 /// Plan 4b Task 5b: the faithfulness pin still drops drifted members. A member whose on-disk
@@ -604,7 +604,7 @@ fn faithfulness_pin_still_drops_drifted_member() {
         "a drifted member (struct_hash mismatch) must cause load_refine_members to return Ok(None)"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// #259 (Adversary C) — END-TO-END through the real `find_clones` driver: a refine-FAILED class (a
@@ -705,5 +705,5 @@ fn refine_failed_class_member_count_dampened_end_to_end() {
         raw_roi
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/clones/resolution.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/clones/resolution.rs
@@ -69,7 +69,7 @@ fn build_class_surfaces_medoid_symbol_id() {
     // live handle (`os error 32`), whereas Unix unlinks it lazily. Dropping `db` first makes the
     // strict teardown pass on both.
     drop(db);
-    fs::remove_dir_all(root).unwrap();
+    fs::remove_dir_all(&root).unwrap();
 }
 
 /// Worktree-overlay scope: `find_clones` returns the BRANCH-ONLY clone class under the overlay
@@ -194,7 +194,7 @@ fn find_clones_falls_back_to_unrefined_when_source_unavailable() {
     assert!(c.refine_mode.is_none(), "no refine_mode on an un-refined class");
 
     // a/ and b/ are already gone; only `.rag-rat/` remains under root.
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// Fix 1 + Fix 2 (#215): a clone class with more than MAX_MEMBERS members exercises two paths that
@@ -285,7 +285,7 @@ fn find_clones_caps_large_class_and_pins_late_subject() {
         pinned.members.iter().map(|m| &m.r#ref).collect::<Vec<_>>()
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// Fix 5 (#215): the clone surface stays empty (and errors NOT) when no fingerprint rows survive —
@@ -324,7 +324,7 @@ fn find_clones_returns_no_class_when_fingerprints_vanish() {
         .unwrap();
     assert!(after.classes.is_empty(), "no fingerprints ⇒ no clone classes (no error): {after:?}");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// Fix 4 (#215): the `Ref` and `PathLine` resolution arms now LEFT JOIN symbol_fingerprints and
@@ -365,7 +365,7 @@ fn clones_for_symbol_prefers_fingerprinted_row_on_resolution() {
         "Ref and PathLine must resolve to the same fingerprinted class"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 // ── Fix 1 regression guard (PathLine tightest-span PRIMARY) ──────────────────────────────────
@@ -438,7 +438,7 @@ fn pathline_tightest_span_wins_over_fingerprinted_enclosing() {
         .unwrap();
     if lu_fp_count == 0 {
         // load_user not fingerprinted — can't run this test; skip gracefully.
-        let _ = fs::remove_dir_all(root);
+        let _ = fs::remove_dir_all(&root);
         return;
     }
 
@@ -600,7 +600,7 @@ fn pathline_tightest_span_wins_over_fingerprinted_enclosing() {
          (span=19)"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 // ── Fix 2: Ref ambiguity rejection ───────────────────────────────────────────────────────────
@@ -646,7 +646,7 @@ fn clones_for_symbol_ref_single_fingerprinted_resolves_unfingerprinted_falls_bac
     assert!(!tiny_res.symbol_fingerprinted, "tiny is below MIN_TOKENS");
     assert!(tiny_res.class.is_none());
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// Fix 2 (#215): injecting TWO distinct fingerprinted `symbols` rows that share the SAME
@@ -715,7 +715,7 @@ fn clones_for_symbol_ref_ambiguous_fingerprinted_returns_err() {
 
     let Some((nk, nv, tl, sh)) = fp else {
         // If there's no fingerprint yet the ambiguity path can't be reached; skip gracefully.
-        let _ = fs::remove_dir_all(root);
+        let _ = fs::remove_dir_all(&root);
         return;
     };
 
@@ -740,7 +740,7 @@ fn clones_for_symbol_ref_ambiguous_fingerprinted_returns_err() {
         .unwrap();
     if dup_fp_count == 0 {
         // fp INSERT was silently ignored (shouldn't happen) — skip the test.
-        let _ = fs::remove_dir_all(root);
+        let _ = fs::remove_dir_all(&root);
         return;
     }
 
@@ -755,7 +755,7 @@ fn clones_for_symbol_ref_ambiguous_fingerprinted_returns_err() {
         "error message must name the ambiguous ref, got: {msg}"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 // ── Fix 3: stale_members in completeness ────────────────────────────────────────────────────
@@ -813,7 +813,7 @@ fn find_clones_stale_members_zero_on_clean_index_and_nonzero_after_disk_edit() {
         stale.completeness.stale_members
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// Faithfulness pin (#215 Plan 4a Task 2): `load_refine_members` re-parses each member's scoped
@@ -899,7 +899,7 @@ fn load_refine_members_reparse_is_faithful_to_persisted_struct_hash() {
          refine_member_order_is_reindex_stable"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// Empty input is a valid (empty) refine set — not a failure.
@@ -915,7 +915,7 @@ fn load_refine_members_empty_input_returns_empty() {
         db.load_refine_members(&[], false).unwrap().expect("empty input is a valid empty set");
     assert!(members.is_empty(), "empty member_ids → empty members");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// Missing source: a member whose source file is deleted from disk (but whose fingerprint row is
@@ -950,7 +950,7 @@ fn load_refine_members_returns_none_when_source_missing() {
         "a member with a deleted source file must yield Ok(None) for the whole class"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// Overlay fallback (#215 Plan 4a Task 2): under a LINKED-WORKTREE OVERLAY scope, `source_root` is
@@ -1135,5 +1135,5 @@ fn scip_moniker_collapse_lifts_a_same_symbol_callee_class() {
     };
     assert_eq!(modes, vec!["baseline".to_string(), "scip".to_string()]);
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/content_digest.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/content_digest.rs
@@ -242,8 +242,8 @@ fn a_files_write_without_the_fold_function_fails_closed() {
 // ---- real IndexDatabase seams (rebuild / gc / poison / migration re-stamp) ----
 
 /// Build a tiny committed git repo and return its config (the base for the real-DB seam tests).
-fn digest_repo_config(tag: &str) -> (PathBuf, Config) {
-    let root = unique_temp_root().join(tag);
+fn digest_repo_config(tag: &str) -> (ScratchRoot, Config) {
+    let root = ScratchRoot::new(tag);
     let _ = fs::remove_dir_all(&root);
     fs::create_dir_all(root.join("src")).unwrap();
     fs::write(root.join("src/lib.rs"), "pub fn a() {}\n").unwrap();

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/dir_memory_tree.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/dir_memory_tree.rs
@@ -48,7 +48,7 @@ fn dir_memory_binds_to_a_directory() {
     assert_eq!(binding.binding_id, "src");
     assert_eq!(binding.anchor_status, "current");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -129,7 +129,7 @@ fn dir_memory_validation_current_and_gone() {
     assert_eq!(report.current, 2, "expected 2 current dir bindings");
     assert_eq!(report.gone, 1, "expected 1 gone dir binding");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -241,7 +241,7 @@ fn list_memories_returns_summaries_and_filters_by_binding_kind() {
     assert_eq!(path_only.len(), 1, "expected 1 path-kind summary, got: {path_only:?}");
     assert_eq!(path_only[0].binding_kind, "path");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 // ─── Fix 1: label/depth contract ─────────────────────────────────────────────
@@ -291,7 +291,7 @@ fn dir_tree_label_depth_flat_siblings() {
     assert_eq!(b.label, "b", "src/b label");
 
     assert_eq!(tree.truncated, 0);
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -368,7 +368,7 @@ fn dir_tree_label_depth_collapse_single_child_chain() {
         tree.nodes.iter().map(|n| &n.path).collect::<Vec<_>>()
     );
     assert_eq!(tree.truncated, 0);
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 // ─── Fix 1 + memory-only inclusion ───────────────────────────────────────────
@@ -409,7 +409,7 @@ fn dir_tree_memory_only_dir_appears_without_min_files() {
     assert_eq!(node_a.depth, 1, "src/a depth");
     assert_eq!(node_a.label, "a", "src/a label");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 // ─── Fix 2: generated exclusion ──────────────────────────────────────────────
@@ -470,7 +470,7 @@ fn dir_tree_excludes_generated_files_from_count() {
     });
     assert_eq!(real_node.file_count, 3, "src/real file_count must be 3 (non-generated only)");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 // ─── Fix 3: real multi-context scoping ───────────────────────────────────────
@@ -525,7 +525,7 @@ fn dir_tree_scope_excludes_other_worktree_files() {
         node_a.file_count
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 // ─── Fix 3: max_nodes cap ────────────────────────────────────────────────────
@@ -577,7 +577,7 @@ fn dir_tree_truncates_at_max_nodes() {
     assert!(tree.nodes.len() <= 3, "nodes.len()={} must be <= max_nodes=3", tree.nodes.len());
     assert!(tree.truncated > 0, "truncated must be >0 when nodes were dropped");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 // ─── original integration test (extended) ────────────────────────────────────
@@ -668,7 +668,7 @@ fn dir_tree_builds_annotated_layout() {
     let node_a2 = tree2.nodes.iter().find(|n| n.path == "src/a").unwrap();
     assert_eq!(node_a2.file_count, 3, "file_count changed after scope reinstall");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 // ─── Bug fix: children of collapsed node must use leaf labels ─────────────────
@@ -764,7 +764,7 @@ fn dir_tree_children_of_collapsed_node_use_leaf_labels() {
     );
 
     assert_eq!(tree.truncated, 0);
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// V022 bootstrap (fresh-applies-all): a brand-new index applies every migration through V022 and

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/dispatch.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/dispatch.rs
@@ -81,7 +81,7 @@ pub fn upsert_journal_embedding(_id: i64) {}
         "an arm side-effect call must not become a dispatch target: {log_callers:?}"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -138,7 +138,7 @@ pub fn upsert(_id: i64) {}
     // visibility predicate the view enforces.
     crate::index::edges::assert_hidden_agrees_with_visibility(conn);
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -205,7 +205,7 @@ pub fn run_stop() {}
         "a guard/predicate call must not become a dispatch handler"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -270,7 +270,7 @@ pub fn banana_handler() {}
         "Self::Variant must not cross-link distinct enums: apple={apple:?} banana={banana:?}"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -321,7 +321,7 @@ pub fn deliver() {}
     // External/aliased head (`Status` has no local enum definition) is admitted.
     assert!(dispatch_from("deliver", "emit"), "external enum-head dispatch missing");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -381,7 +381,7 @@ fn embed_text(_text: String) -> Result<i32, ()> { Ok(0) }
         "a wrapper constructor must not be a dispatch handler"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -459,7 +459,7 @@ fn run_setup() -> Result<Resp, ()> { Ok(Resp::Blank) }
         );
     }
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -536,7 +536,7 @@ fn start_span() {}
         );
     }
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -638,7 +638,7 @@ fn finish_response() -> Result<u8, ()> { Ok(0) }
         );
     }
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -723,7 +723,7 @@ fn finish_b() -> Result<u8, ()> { Ok(0) }
         );
     }
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -837,7 +837,7 @@ fn start_span() -> u8 { 0 }
         "const-generic call must resolve to the callee name"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -920,7 +920,7 @@ fn e() -> E { E::Ready(0) }
         );
     }
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -1007,7 +1007,7 @@ fn finish_c() -> Result<u8, ()> { Ok(0) }
         );
     }
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -1122,7 +1122,7 @@ fn build_deref() -> Result<u8, ()> { Ok(0) }
         );
     }
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -1194,7 +1194,7 @@ fn handler_c() -> Result<u8, ()> { Ok(0) }
         );
     }
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -1287,7 +1287,7 @@ fn finish_fp() -> Result<u8, ()> { Ok(0) }
         );
     }
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -1351,7 +1351,7 @@ fn make_worker() -> W { W }
         );
     }
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -1401,7 +1401,7 @@ pub fn run() {}
         "a nested-payload variant must not be treated as the handled variant: {senders:?}"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -1455,7 +1455,7 @@ pub mod b {
         );
     }
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -1518,5 +1518,5 @@ fn symbol_search_excludes_generated_bindings_unless_opted_in() {
     assert_eq!(id_hits.candidates.len(), 1, "explicit id must resolve the generated symbol");
     assert!(id_hits.candidates[0].path.contains("/generated/"));
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/embedding_policy_fast_path.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/embedding_policy_fast_path.rs
@@ -52,7 +52,7 @@ fn rebuild_stamps_the_policy_version_current() {
         Some(ai::DEFAULT_MAX_EMBEDDING_CHARS.to_string().as_str()),
         "the stamp records the DEFAULT cap the column was derived at"
     );
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -77,7 +77,7 @@ fn rebuild_carrying_overlay_rows_does_not_certify() {
         Some(ai::EMBEDDING_POLICY_VERSION),
         "a rebuild that carried un-reparsed overlay rows must not certify the version current"
     );
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -105,7 +105,7 @@ fn fast_path_refused_at_non_default_cap() {
         "default-cap fast path reads the poisoned column; a non-default cap recomputes from \
          source: {fast:?} vs {recomputed:?}"
     );
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -131,7 +131,7 @@ fn self_heal_skipped_at_non_default_cap() {
         Some("pre-upgrade"),
         "a non-default-cap reconcile must not certify the DEFAULT-cap column"
     );
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -167,7 +167,7 @@ fn reconcile_plan_classifies_at_the_requested_cap() {
         "cap=1000: the same chunk is now SkipTooLarge: {:?}",
         small_plan.embeddings.skipped_by_policy
     );
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -230,7 +230,7 @@ fn incremental_edit_keeps_the_certified_column_fresh() {
         Some(ai::EMBEDDING_POLICY_VERSION),
         "incremental indexing must not invalidate the stamp"
     );
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// Shared setup for the embed-path policy-source tests (#725): a rebuild whose fn chunk classifies
@@ -283,7 +283,7 @@ fn reconcile_embed_path_reads_the_stamped_policy_column() {
         0,
         "a certified-stamp embed path must not re-classify any candidate FromText"
     );
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -312,7 +312,7 @@ fn stale_stamp_reconcile_heals_then_takes_the_fast_path() {
         "the stale-stamp reconcile heals and re-certifies"
     );
     assert!(report.embeddings_written >= 1, "the healed Embed chunk still embeds: {report:?}");
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -338,7 +338,7 @@ fn reconcile_plan_classifies_from_the_stamped_column_like_the_embed_path() {
          the embed path: {:?}",
         plan.embeddings
     );
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -377,7 +377,7 @@ fn self_heal_refreshes_stale_priorities_under_an_unchanged_policy() {
         Some(ai::EMBEDDING_POLICY_VERSION),
         "the heal re-certifies after writing BOTH columns"
     );
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -409,7 +409,7 @@ fn reconcile_embed_path_recomputes_at_a_non_default_cap() {
         "the uncertified embed path must re-derive policy FromText (the fallback the fast path \
          avoids)"
     );
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -437,5 +437,5 @@ fn absent_stamp_takes_the_recompute_path() {
         0,
         "an absent stamp forces a recompute that ignores the poisoned column: {summary:?}"
     );
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/fts_corruption.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/fts_corruption.rs
@@ -278,8 +278,12 @@ fn commit_fts_heals_even_while_chunk_staging_exists() {
     fs::write(root.join("src/lib.rs"), "pub fn staged_commit_witness() {}\n").unwrap();
     // commit_fts indexes git history — the corruption probe needs a non-empty mirror.
     let git = |args: &[&str]| {
-        let out =
-            std::process::Command::new("git").arg("-C").arg(&root).args(args).output().unwrap();
+        let out = std::process::Command::new("git")
+            .arg("-C")
+            .arg(root.as_os_str())
+            .args(args)
+            .output()
+            .unwrap();
         assert!(out.status.success(), "git {args:?}: {}", String::from_utf8_lossy(&out.stderr));
     };
     git(&["init", "-q"]);

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/generation_rebuild.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/generation_rebuild.rs
@@ -19,7 +19,7 @@ use super::*;
 /// A git fixture repo with the named source files under `src/`, plus its source `Config` (absolute
 /// DB path, like production). A REAL git checkout so `adopt_repo_from_config` registers a portable
 /// repo id.
-fn generation_fixture(files: &[(&str, &str)]) -> (PathBuf, Config) {
+fn generation_fixture(files: &[(&str, &str)]) -> (ScratchRoot, Config) {
     let root = unique_temp_root();
     let _ = fs::remove_dir_all(&root);
     fs::create_dir_all(root.join("src")).unwrap();
@@ -257,7 +257,7 @@ fn a_reader_sees_the_complete_old_generation_until_the_rebuild_flips() {
     );
 
     drop(db);
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// STEP 2 (bounded writer holds): while a full rebuild is PAUSED between committed waves — holding
@@ -313,7 +313,7 @@ fn a_paused_rebuild_does_not_block_a_write_to_another_repo() {
     resume_tx.send(()).unwrap();
     handle.join().unwrap();
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// The poison-sibling harness survives a full rebuild of the PRIMARY repo: the generation-staged
@@ -330,7 +330,7 @@ fn the_poison_sibling_survives_a_full_rebuild_of_the_primary_repo() {
     let db = IndexDatabase::rebuild(&config).unwrap();
     crate::index::poison_sibling::assert_sibling_intact(db.storage.connection());
     drop(db);
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// This repo's `parser_failures` count for a path, from a fresh connection.
@@ -404,7 +404,7 @@ fn dead_generation_sweep_keeps_a_live_paths_parser_failure() {
         "a path removed from the tree loses its stale record in the rebuild tail"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// P2 #2: the pointer flip is the TERMINAL write of a rebuild. A failure anywhere in the tail
@@ -481,7 +481,7 @@ fn a_tail_failure_leaves_the_old_generation_live_and_a_retry_flips() {
         "the successful retry publishes the staged clear"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// P2 #3: dead-generation reclamation needs NO git context, so it runs even on the "no live
@@ -539,7 +539,7 @@ fn non_git_indexes_sweep_dead_generations_despite_the_context_prune_refusal() {
     );
     crate::index::poison_sibling::assert_sibling_intact(db.storage.connection());
     drop(db);
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// P2 #4: a carried-forward overlay's edges are re-resolved against the freshly staged base inside
@@ -616,7 +616,7 @@ fn carried_overlay_edges_re_resolve_onto_the_new_base_generation() {
 
     drop(db);
     let _ = fs::remove_dir_all(&linked);
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// P2 (parser_failures.rs): a previously-indexed path that freshly fails PREPARATION (invalid
@@ -645,7 +645,7 @@ fn a_fresh_prepare_failure_for_a_previously_indexed_path_survives_the_tail_sweep
         "a fresh PREPARE failure for a previously-indexed path survives the tail orphan sweep"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// P2 (rebuild.rs FTS race): during a FIRST index (no `chunk_text_dict` yet — chunk text only
@@ -706,7 +706,7 @@ fn a_concurrent_fts_refresh_during_first_index_does_not_lose_staged_rows() {
         .unwrap();
     assert!(!missing_fts, "every published chunk has a BM25 row after the first index");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// P2 (incremental.rs interleaved writers) — the PROOF's regression test: a memory written
@@ -798,7 +798,7 @@ fn a_memory_written_mid_rebuild_survives_the_flip_intact() {
     crate::index::poison_sibling::assert_sibling_intact(db.storage.connection());
 
     drop(db);
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// P2 (incremental.rs / repo_brief): `summary_counts.graph_edges` is an EXACTNESS counter — it
@@ -847,7 +847,7 @@ fn repo_brief_edge_count_is_generation_scoped() {
     );
 
     drop(db);
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// Install the keyed pause barrier for `config`'s database and spawn a full rebuild on a thread,
@@ -946,7 +946,7 @@ fn gc_serializes_on_the_flock_while_a_rebuild_is_mid_flight() {
     );
     assert_eq!(reader_scoped_file_count(&db_path, &root), 2);
     drop(db);
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// P2 (file_rows.rs, generation-bounded deletes): a LOCKLESS heal replacing a path mid-rebuild
@@ -1009,7 +1009,7 @@ fn a_lockless_heal_mid_rebuild_does_not_remove_the_staged_row() {
     );
     assert_eq!(reader_scoped_file_count(&db_path, &root), 2);
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// P2 (lifecycle.rs, bare-open scope view): the bare `IndexDatabase::open` (the MCP
@@ -1077,7 +1077,7 @@ fn a_bare_open_reader_is_generation_scoped() {
     );
     drop(bare);
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// P2 batch 4 (schema-apply race): every path that can APPLY schema serializes on the GLOBAL
@@ -1111,7 +1111,7 @@ fn concurrent_create_or_migrate_applies_the_schema_exactly_once() {
         "exactly one schema_version row per migration"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// P2 batch 6 #1 (git history rides the flip): a tail failure must leave the WHOLE git-history
@@ -1210,7 +1210,7 @@ fn a_tail_failure_leaves_git_meta_and_history_cursors_on_the_old_state() {
     assert_eq!(git_commit_meta(&db_path, &repo_id).as_deref(), Some(h2.as_str()));
     assert!(history_current(&db_path, &root), "cursors advanced with the successful flip");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// P2 batch 5 (abandoned staging): failed rebuilds leave committed-but-never-flipped generations
@@ -1270,7 +1270,7 @@ fn gc_reclaims_abandoned_staged_generations_from_failed_rebuilds() {
     assert!(live_generation(&db_path, &repo_id) > live);
     assert_eq!(reader_scoped_file_count(&db_path, &root), 2);
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// P2 batch 5 (source_root joins cursors-last): a rebuild from a NEW checkout root that fails
@@ -1324,12 +1324,12 @@ fn a_tail_failure_leaves_source_root_on_the_old_checkout() {
     );
 
     let _ = fs::remove_dir_all(&root2);
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// A git fixture that is also a Cargo crate (`[package] name = crate_name` + `src/lib.rs`), so
 /// `refresh_packages` records a real `packages` row + `repo_meta.local_crate_roots`.
-fn cargo_generation_fixture(crate_name: &str) -> (PathBuf, Config) {
+fn cargo_generation_fixture(crate_name: &str) -> (ScratchRoot, Config) {
     let root = unique_temp_root();
     let _ = fs::remove_dir_all(&root);
     fs::create_dir_all(root.join("src")).unwrap();
@@ -1395,7 +1395,7 @@ fn a_tail_failure_leaves_package_roots_on_the_old_state() {
         "the retry publishes the new crate root together with the flip"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// Batch 6 #3 (overlay package roots carried across a base HEAD advance): a full rebuild that
@@ -1456,7 +1456,7 @@ fn a_head_advancing_rebuild_carries_overlay_package_roots_onto_the_new_base_comm
     );
 
     let _ = fs::remove_dir_all(&linked);
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// Batch 6 (count-scoping class, the adversary's repro): during a DEAD-GENERATION window (two
@@ -1510,7 +1510,7 @@ fn graph_traversal_summary_counts_match_the_live_rows_during_a_dead_generation_w
     );
 
     drop(db);
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// Batch 7 P2 (incremental.rs, standalone finalize): the public `index_targets()` entry shares
@@ -1580,7 +1580,7 @@ fn standalone_index_targets_publishes_staged_parser_failures_immediately() {
     assert_eq!(logical_fine, 1, "the standalone finalize folds logical symbols (batch 7 twin)");
 
     drop(db);
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// Batch 7 P2 (rebuild.rs, overlay package carry vs a fresh refresh): an overlay that ALREADY
@@ -1650,7 +1650,7 @@ fn a_rebuild_after_an_overlay_already_refreshed_at_the_new_head_does_not_collide
     assert!(rows > 0, "the overlay package map survived the carry");
 
     let _ = fs::remove_dir_all(&linked);
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// Batch 7 (the re-key's second collision shape): overlay rows at TWO different STALE commits
@@ -1717,7 +1717,7 @@ fn a_rebuild_dedupes_multi_stale_overlay_package_rows_before_the_re_key() {
     );
 
     let _ = fs::remove_dir_all(&linked);
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// Batch 6 (concurrency HIGH): `rag-rat init`'s `setup_index` reaches the rebuild through
@@ -1782,5 +1782,5 @@ fn a_lockless_init_rebuild_serializes_a_concurrent_flock_gc() {
         2,
         "the init-path rebuild published a non-empty generation despite the racing collector"
     );
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/git_history_reload.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/git_history_reload.rs
@@ -33,7 +33,7 @@ fn git_history_appends_after_a_new_commit() {
     assert_eq!(db.commit_search("gamma", 10).unwrap().len(), 1, "new commit is indexed");
     assert_eq!(db.commit_search("beta", 10).unwrap().len(), 1, "old commit FTS rows remain live");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -73,7 +73,7 @@ fn git_history_append_rebuilds_desynced_commit_fts() {
         "fast-forward append rebuilds commit_fts and repairs pre-existing desync"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -113,7 +113,7 @@ fn git_history_falls_back_when_append_rows_are_already_present() {
     assert_eq!(sentinel_commit_count(&db), 0, "a torn append state must force full replacement");
     assert_eq!(db.commit_search("torn", 10).unwrap().len(), 1, "commit FTS is rebuilt");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -150,9 +150,9 @@ fn git_history_append_plan_falls_back_for_non_git_or_other_root() {
     let other_head = git_output(&other, &["rev-parse", "HEAD"]);
     assert_eq!(status.indexed_head.as_deref(), Some(other_head.as_str()));
 
-    let _ = fs::remove_dir_all(root);
-    let _ = fs::remove_dir_all(non_git);
-    let _ = fs::remove_dir_all(other);
+    let _ = fs::remove_dir_all(&root);
+    let _ = fs::remove_dir_all(&non_git);
+    let _ = fs::remove_dir_all(&other);
 }
 
 #[test]
@@ -270,7 +270,7 @@ fn git_history_prepare_plan_fails_closed_on_incomplete_or_shallow_cursors() {
             "corrupt cursor metadata must fail closed to a full reload plan"
         );
         drop(db);
-        let _ = fs::remove_dir_all(root);
+        let _ = fs::remove_dir_all(&root);
     }
 }
 
@@ -312,7 +312,7 @@ fn incomplete_git_history_cursor_forces_full_reload_before_fast_forward_append()
         "a complete full reload restores the append-safe cursor marker"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -345,7 +345,7 @@ fn stale_prepared_append_is_noop_after_another_pass_catches_up() {
     assert_eq!(status.indexed_head.as_deref(), Some(new_head.as_str()));
     assert_eq!(sentinel_commit_count(&db), 1, "stale prepared append must not rewrite rows");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -383,7 +383,7 @@ fn stale_prepared_append_clears_when_root_loses_git_dir() {
     assert!(!status.available, "status reports the lost git repository");
     assert_eq!(status.commit_count, 0, "the stale git-history rows were cleared");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -429,7 +429,7 @@ fn stale_prepared_append_is_noop_when_db_cursor_is_ahead() {
     assert_eq!(db.commit_search("middle", 10).unwrap().len(), 1);
     assert_eq!(db.commit_search("newer", 10).unwrap().len(), 1);
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -485,7 +485,7 @@ fn git_history_append_records_new_head_for_out_of_scope_fast_forward_commit() {
         "empty append still rebuilds commit_fts and repairs pre-existing desync"
     );
 
-    let _ = fs::remove_dir_all(worktree);
+    let _ = fs::remove_dir_all(&worktree);
 }
 
 #[test]
@@ -512,7 +512,7 @@ fn git_history_append_reports_commit_fts_prepare_errors() {
     .expect_err("missing commit_fts must surface an append failure");
     assert!(err.to_string().contains("commit_fts"));
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -525,7 +525,7 @@ fn repo_generation_file_count_reports_sql_errors() {
     let err = db.repo_generation_file_count(true).expect_err("missing files table must error");
     assert!(err.to_string().contains("files"));
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -586,7 +586,7 @@ fn repo_generation_file_count_ignores_foreign_worktree_overlays() {
         "active tombstones shadow committed rows and should not inflate the expected scope count"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -631,7 +631,7 @@ fn discovered_empty_active_commit_does_not_promote_changed_mode() {
         "after an empty active scope is discover-checked, changed-mode must not promote forever"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -686,7 +686,7 @@ fn changed_mode_discovers_when_target_fingerprint_is_stale() {
     );
     assert!(db.active_base_scope_discovered(&expanded_config.targets).unwrap());
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -707,7 +707,7 @@ fn base_scope_marker_is_absent_without_commit_or_worktree_scope() {
         "an unscoped connection has no stable marker to write"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -730,7 +730,7 @@ fn watch_shutdown_marker_clear_is_idempotent() {
         "a second clear remains write-free"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -764,7 +764,7 @@ fn git_history_appends_after_a_merge_commit() {
         "topic commit must be searchable after merge append"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -799,7 +799,7 @@ fn git_history_appends_after_a_squash_commit() {
     assert_eq!(sentinel_commit_count(&db), 1, "a squash append must not wipe old rows");
     assert_eq!(db.commit_search("theta", 10).unwrap().len(), 1, "squash commit is indexed");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -824,7 +824,7 @@ fn git_history_reloads_after_a_history_rewrite() {
     assert_eq!(db.commit_search("delta", 10).unwrap().len(), 1, "rewritten subject is indexed");
     assert_eq!(db.commit_search("beta", 10).unwrap().len(), 0, "old subject is gone after rewrite");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -847,7 +847,7 @@ fn git_history_reloads_after_a_non_fast_forward_branch_switch() {
     assert_eq!(db.commit_search("branch", 10).unwrap().len(), 1, "new branch history is indexed");
     assert_eq!(db.commit_search("beta", 10).unwrap().len(), 0, "old branch history is gone");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -895,7 +895,7 @@ fn git_history_reloads_after_squashing_indexed_commits() {
         "old commit FTS row is gone"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -936,8 +936,8 @@ fn git_history_reload_is_not_skipped_on_a_shallow_clone() {
     let db = IndexDatabase::index_changed(&config).unwrap();
     assert_eq!(sentinel_commit_count(&db), 0, "a shallow clone must never skip the reload");
 
-    let _ = fs::remove_dir_all(origin);
-    let _ = fs::remove_dir_all(shallow);
+    let _ = fs::remove_dir_all(&origin);
+    let _ = fs::remove_dir_all(&shallow);
 }
 
 #[test]
@@ -981,7 +981,7 @@ fn idle_discover_sweep_does_not_rewrite_indexed_at_ms() {
         "a sweep that indexes a new file must update indexed_at_ms"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -1003,7 +1003,7 @@ fn index_discover_reporting_flags_content_changes() {
         "a discover sweep that indexes a new file must report a content change"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -1037,7 +1037,7 @@ fn discover_relanguages_h_when_binding_changes_c_to_cpp() {
         .unwrap();
     assert_eq!(lang, "cpp", "the .h must be reindexed as C++ after the binding change");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -1085,7 +1085,7 @@ fn changed_mode_ignores_gitignored_target_files_under_root_target() {
     assert_eq!(before, after, "ignored target/ writes must not index new files");
     assert_eq!(target_rows, 0, "target/ artifacts must not enter the index");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -1135,5 +1135,5 @@ fn caller() {
         "helper callers: {callers:?}"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/graph_edges.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/graph_edges.rs
@@ -64,7 +64,7 @@ fn driver() {
     let contains = callee_byte_range(&db, "Obj", "method", "contains");
     assert_eq!(contains, None, "contains edges must have a NULL callee range");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -82,7 +82,7 @@ fn imports_edge_has_null_callee_byte_range() {
     let import = callee_byte_range(&db, "src/lib.rs", "worker", "imports");
     assert_eq!(import, None, "imports edges must have a NULL callee range");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -116,7 +116,7 @@ int runtime_open(Runtime *runtime) {
     let (start, end) = (start as usize, end as usize);
     assert_eq!(&source[start..end], "helper", "C callee range must span exactly `helper`");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -198,7 +198,7 @@ pub fn exported_fn() {}
         "comment-only UniFFI mentions must not create FFI surface rows: {surface:?}"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -226,7 +226,7 @@ fn find_callers_sees_calls_in_let_bindings() {
     assert!(has("via_let"), "missing `let x = target()` caller; got {names:?}");
     assert!(has("via_let_else"), "missing `let-else` caller; got {names:?}");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// #827: an incremental content-changed pass narrows the edge re-resolve to the changed files plus
@@ -299,5 +299,5 @@ fn scoped_incremental_pass_preserves_find_callers_both_directions() {
         caller_names(&db, "b_helper"),
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/head_move_carry.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/head_move_carry.rs
@@ -10,7 +10,7 @@ use super::*;
 
 /// A repo with two committed rust files, returning `(root, config)`. `keep.rs` stays unchanged
 /// across every HEAD move in these tests; `edit.rs` is the file the moves modify.
-fn head_move_repo(tag: &str) -> (PathBuf, Config) {
+fn head_move_repo(tag: &str) -> (ScratchRoot, Config) {
     let root = unique_temp_root();
     let _ = fs::remove_dir_all(&root);
     fs::create_dir_all(root.join("src")).unwrap();
@@ -112,7 +112,7 @@ fn scope_row_modified_at_ms_reads_the_scoped_disk_mtime() {
         "a different path is a different scope key"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -176,7 +176,7 @@ fn a_head_move_carries_unchanged_rows_and_rederives_only_the_diff() {
 
     // A carried pass must never touch a sibling repo's rows (round-6 harness).
     crate::index::poison_sibling::assert_sibling_intact(db.storage.connection());
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -216,7 +216,7 @@ fn a_branch_switch_back_carries_everything_with_no_rederive() {
     let keep_rows = committed_rows(&db, "src/keep.rs");
     assert_eq!(keep_rows.len(), 1);
     assert_eq!(keep_rows[0].1, main_head);
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -266,7 +266,7 @@ fn carry_requires_matching_language_and_kind() {
         .query_row("SELECT language FROM files WHERE path = 'src/new.rs'", [], |row| row.get(0))
         .unwrap();
     assert_eq!(language, "rust");
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -311,7 +311,7 @@ fn dirty_paths_keep_their_overlay_and_are_not_carried() {
     let committed = committed_rows(&db, "src/keep.rs");
     assert_eq!(committed.len(), 1, "no duplicate committed row is derived for a dirty path");
     assert_eq!(committed[0].1, old_head, "the shadowed committed row is left in place");
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -359,7 +359,7 @@ fn a_pull_after_a_branch_round_trip_still_carries_despite_stale_higher_id_rows()
         Some(keep_id),
         "the genuinely changed file is re-derived"
     );
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -387,7 +387,7 @@ fn discovery_status_surfaces_a_pending_carry_instead_of_reporting_clean() {
     let status = db.discovery_status(&config).unwrap();
     assert_eq!(status.carryable_files, 0, "the applied carry clears the pending count");
     assert_eq!(status.warning, None, "a carried-and-derived scope is clean");
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -429,7 +429,7 @@ fn an_untracked_recreation_of_old_content_is_not_carried_into_the_committed_scop
         new_head,
         "the genuinely committed unchanged file is still carried"
     );
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -471,7 +471,7 @@ fn a_dirty_revert_to_old_content_is_not_carried_into_the_committed_scope() {
         hex_sha256(&old_bytes),
         "the reverted bytes are served from this worktree's overlay"
     );
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -527,7 +527,7 @@ fn a_carried_callers_edge_reresolves_to_the_rederived_callee() {
         Some(fresh_target),
         "the carried caller's edge re-resolves to the re-derived callee symbol"
     );
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -570,5 +570,5 @@ fn a_carry_only_pass_still_refreshes_package_roots() {
         package_rows.iter().any(|(_, sha)| sha == &new_head),
         "package roots follow the carried scope to the new HEAD {new_head}: {package_rows:?}"
     );
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/index_paths.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/index_paths.rs
@@ -48,7 +48,7 @@ fn index_paths_reconciles_only_the_supplied_path() {
         "a new file that was NOT supplied is not indexed — only the supplied path is touched",
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -81,7 +81,7 @@ fn index_paths_is_a_noop_for_ignored_out_of_target_and_unchanged_paths() {
     );
     assert!(symbol_present(&db, "alpha_v1"), "the unchanged target file is intact");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -102,7 +102,7 @@ fn index_paths_tombstones_a_supplied_path_that_no_longer_exists() {
     assert_eq!(db.indexed_file_count().unwrap(), 1, "the deleted supplied path is tombstoned");
     assert!(symbol_present(&db, "alpha_v1"), "the un-supplied file is untouched by the tombstone");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -553,7 +553,7 @@ fn index_paths_completes_the_base_scope_after_a_commit_advances_head() {
     );
     assert!(symbol_present(&db, "alpha_v2"), "the committed edit is indexed at the new HEAD");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -589,7 +589,7 @@ fn index_paths_keeps_a_clean_committed_file_in_the_committed_scope() {
         "the clean file stays committed-scoped",
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -662,7 +662,7 @@ fn index_paths_does_not_churn_an_unchanged_files_row() {
         "an unchanged supplied file keeps its row id — no remove+reinsert churn",
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -699,7 +699,7 @@ fn index_paths_normalizes_internal_parent_dir_components() {
         "the out-of-target `outside.rs` (via `src/../`) is not indexed",
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -723,7 +723,7 @@ fn index_paths_does_not_tombstone_a_never_indexed_missing_path() {
         "a never-indexed missing path gets no tombstone row",
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -762,7 +762,7 @@ fn index_paths_signals_a_package_refresh_for_a_supplied_cargo_toml() {
             .unwrap();
     assert!(deleted_signal, "a supplied but DELETED Cargo.toml still signals a package refresh");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -783,7 +783,7 @@ fn index_paths_defers_on_a_first_time_empty_repo() {
          {result:?}",
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -809,7 +809,7 @@ fn index_paths_defers_instead_of_rebuilding_an_uninitialized_non_empty_repo() {
     );
     assert!(!config.database.exists(), "deferring must not build any index");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -873,7 +873,7 @@ fn index_paths_skips_a_supplied_symlink_to_an_in_repo_file() {
         "a supplied symlink is skipped — no duplicate index row under the symlink path",
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -904,7 +904,7 @@ fn index_paths_skips_a_path_through_a_symlinked_ancestor_dir() {
         "a path crossing a symlinked ANCESTOR dir is skipped — no row under the symlink spelling",
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -1052,7 +1052,7 @@ fn index_paths_tombstones_a_deleted_indexed_file_under_a_now_ignored_dir() {
     );
     assert!(symbol_present(&db, "alpha_v1"), "the un-supplied file is untouched");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -1103,7 +1103,7 @@ fn index_paths_reindexes_on_stored_target_identity_drift_with_unchanged_bytes() 
         "a stored target-identity drift is reindexed, not sha-skipped",
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -1178,7 +1178,7 @@ fn overlay_target_drift_scan_is_gated_on_the_config_fingerprint() {
         "a divergent branch config (C→C++) → the drift scan runs",
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -1210,7 +1210,7 @@ fn index_paths_tombstones_a_regular_file_replaced_by_a_symlink() {
     );
     assert!(symbol_present(&db, "beta_v1"), "the un-supplied file is untouched");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/migration_gate_wiring.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/migration_gate_wiring.rs
@@ -31,7 +31,7 @@ fn with_global_store(allow_migrate: bool, body: impl FnOnce(&Path)) {
     let saved_allow = std::env::var_os("RAG_RAT_ALLOW_MIGRATE");
     // SAFETY: env access is serialized by ENV_LOCK for the duration of this call.
     unsafe {
-        std::env::set_var("RAG_RAT_DATA_DIR", &data_dir);
+        std::env::set_var("RAG_RAT_DATA_DIR", data_dir.as_os_str());
         if allow_migrate {
             std::env::set_var("RAG_RAT_ALLOW_MIGRATE", "1");
         } else {

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/mod.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/mod.rs
@@ -162,13 +162,40 @@ fn hot_module_text(revision: usize) -> String {
     text
 }
 
-fn unique_temp_root() -> PathBuf {
-    // Shared, self-healing scratch root with a startup sweep, so a panicking/killed test can't
-    // strand this dir in the system temp (#726). See `rag_rat_base::test_scratch`.
-    rag_rat_base::test_scratch::scratch_dir("rag-rat-schema-test")
+pub(crate) struct ScratchRoot {
+    path: PathBuf,
+    _scratch: rag_rat_base::test_scratch::ScratchDir,
 }
 
-fn fixture_temp_root(fixture: &str) -> PathBuf {
+impl ScratchRoot {
+    fn new(tag: &str) -> Self {
+        let scratch = rag_rat_base::test_scratch::ScratchDir::new(tag);
+        let path = scratch.path().to_path_buf();
+        // Preserve the old helper's allocated-but-absent path contract for worktree destinations.
+        let _ = fs::remove_dir_all(&path);
+        Self { path, _scratch: scratch }
+    }
+}
+
+impl std::ops::Deref for ScratchRoot {
+    type Target = PathBuf;
+
+    fn deref(&self) -> &Self::Target {
+        &self.path
+    }
+}
+
+impl AsRef<Path> for &ScratchRoot {
+    fn as_ref(&self) -> &Path {
+        &self.path
+    }
+}
+
+fn unique_temp_root() -> ScratchRoot {
+    ScratchRoot::new("rag-rat-schema-test")
+}
+
+fn fixture_temp_root(fixture: &str) -> ScratchRoot {
     let root = unique_temp_root();
     let _ = fs::remove_dir_all(&root);
     let fixture_root =
@@ -191,7 +218,7 @@ fn copy_fixture_dir(from: &Path, to: &Path) {
     }
 }
 
-fn markdown_config(text: &str) -> (PathBuf, Config) {
+fn markdown_config(text: &str) -> (ScratchRoot, Config) {
     let root = unique_temp_root();
     let _ = fs::remove_dir_all(&root);
     let docs = root.join("docs");
@@ -340,7 +367,7 @@ fn overlay_row_count(db: &IndexDatabase) -> i64 {
 /// poison-sibling harness self-tests against. A REAL git root (not a bare temp dir) so
 /// `adopt_repo_from_config` registers a portable repo id (a non-git root is `Absent` and stays
 /// under the placeholder, which would leave `real_repos == 0` and defeat the opt-out self-check).
-pub(crate) fn poison_test_config(tag: &str) -> (PathBuf, Config) {
+pub(crate) fn poison_test_config(tag: &str) -> (ScratchRoot, Config) {
     let root = unique_temp_root();
     let _ = fs::remove_dir_all(&root);
     fs::create_dir_all(root.join("src")).unwrap();
@@ -756,7 +783,7 @@ impl papertrail::PapertrailClient for PartiallyFailingGitHubClient {
 }
 
 /// A git fixture with one committed source file, configured like production (absolute DB path).
-fn git_fixture_for_overlay_tests() -> (PathBuf, Config) {
+fn git_fixture_for_overlay_tests() -> (ScratchRoot, Config) {
     let root = unique_temp_root();
     let _ = fs::remove_dir_all(&root);
     fs::create_dir_all(root.join("src")).unwrap();

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/multi_repo_scope.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/multi_repo_scope.rs
@@ -13,7 +13,8 @@ use super::*;
 /// A shared DB holding repo A (really indexed) plus repo B (seeded rows at repo A's SAME commit).
 struct TwoRepoFixture {
     db: IndexDatabase,
-    root_a: PathBuf,
+    root_a: ScratchRoot,
+    _shared_root: ScratchRoot,
     repo_a_id: String,
     /// The commit both repos' rows sit at — proves the isolation is by `repo_id`, not commit sha.
     shared_commit: String,
@@ -47,7 +48,8 @@ fn two_repo_fixture() -> TwoRepoFixture {
     run_git(&root_a, &["add", "."]);
     run_git(&root_a, &["commit", "-q", "-m", "init"]);
 
-    let shared_db = unique_temp_root().join("shared.sqlite");
+    let shared_root = unique_temp_root();
+    let shared_db = shared_root.join("shared.sqlite");
     let mut config_a = source_config(root_a.clone(), Language::Rust);
     config_a.database = shared_db;
     let db = IndexDatabase::rebuild(&config_a).unwrap();
@@ -77,7 +79,7 @@ fn two_repo_fixture() -> TwoRepoFixture {
         .unwrap();
     }
 
-    TwoRepoFixture { db, root_a, repo_a_id, shared_commit }
+    TwoRepoFixture { db, root_a, _shared_root: shared_root, repo_a_id, shared_commit }
 }
 
 /// Paths visible through the per-connection scope VIEW (`temp.files`) at the active scope.
@@ -118,7 +120,7 @@ fn scope_view_isolates_repos_sharing_a_commit() {
         "repo B's view must NOT leak repo A's file: {view_b:?}"
     );
 
-    let _ = fs::remove_dir_all(fx.root_a);
+    let _ = fs::remove_dir_all(&fx.root_a);
 }
 
 /// `garbage_collect` is repo-sliced: sweeping repo A prunes ONLY repo A's dead-context rows and
@@ -212,7 +214,7 @@ fn gc_of_one_repo_leaves_the_other_intact() {
         "gc reports repo A's chunk slice, not the whole-store union",
     );
 
-    let _ = fs::remove_dir_all(fx.root_a);
+    let _ = fs::remove_dir_all(&fx.root_a);
 }
 
 /// The all-zeros id: the lexicographically SMALLEST 40-hex string, so a real commit-hash repo id
@@ -286,7 +288,7 @@ fn graph_refresh_of_one_repo_leaves_the_other_repos_edges() {
         repo_b_before,
         "repo A's graph refresh must not wipe repo B's edges"
     );
-    let _ = fs::remove_dir_all(fx.root_a);
+    let _ = fs::remove_dir_all(&fx.root_a);
 }
 
 /// #413 finding #4: the config-bearing incremental path (`index --changed`/`--discover`) must
@@ -338,7 +340,7 @@ fn incremental_adopts_the_config_repo_over_a_smaller_sibling() {
         .query_row("SELECT COUNT(*) FROM main.files WHERE repo_id = ?1", [&repo_id], |r| r.get(0))
         .unwrap();
     assert!(under_config > 0, "rows are stamped under the config's repo");
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// #413 round-4 finding #1: the read-only MCP open (`try_open_config_read_only`) must scope to the
@@ -389,7 +391,7 @@ fn read_only_open_binds_the_config_repo_over_a_smaller_sibling() {
         !ro.symbols("ro_sibling_anchor", Some(Language::Rust), 10).unwrap().is_empty(),
         "the read-only connection answers queries scoped to the config repo",
     );
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// All `repo_meta` rows as a sorted `(repo_id, key, value)` list — the snapshot the full-ladder
@@ -456,7 +458,7 @@ fn full_ladder_replay_on_a_two_repo_db_is_idempotent() {
         .query_row("SELECT COUNT(*) FROM main.files WHERE repo_id = ?1", [REPO_B], |r| r.get(0))
         .unwrap();
     assert_eq!(repo_b_files, 2, "repo B's rows are intact after the replay");
-    let _ = fs::remove_dir_all(fx.root_a);
+    let _ = fs::remove_dir_all(&fx.root_a);
 }
 
 /// #413 finding #5 (now V042): `oracle_runs.repo_id` scopes the prune to the ACTIVE repo, so GC for
@@ -491,7 +493,7 @@ fn gc_skips_the_global_oracle_prune_on_a_multi_repo_db() {
         })
         .unwrap();
     assert_eq!(surviving, 1, "repo A's repo-scoped oracle prune spares repo B's run");
-    let _ = fs::remove_dir_all(fx.root_a);
+    let _ = fs::remove_dir_all(&fx.root_a);
 }
 
 /// The complement: the ACTIVE repo's OWN dead-context run IS pruned. The dead run is stamped the
@@ -530,7 +532,7 @@ fn gc_prunes_a_dead_oracle_run_on_a_single_repo_db() {
         })
         .unwrap();
     assert_eq!(surviving, 0, "single-repo gc prunes the dead-context oracle run as before");
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// `LogicalSymbolKey::stable_id` folds the OWNING repo into the content hash: two repos with
@@ -603,7 +605,7 @@ fn repo_brief_edges_are_scoped_to_the_active_repo() {
         summary.graph_edges < u64::try_from(global_edges).unwrap(),
         "and is strictly below the global union (repo B's edge is excluded)",
     );
-    let _ = fs::remove_dir_all(fx.root_a);
+    let _ = fs::remove_dir_all(&fx.root_a);
 }
 
 /// #413 round-5: an INSTALLED-but-EMPTY scope context (`""`, the sibling-safe "match nothing" scope
@@ -638,7 +640,7 @@ fn active_repo_id_honors_an_installed_empty_scope() {
         None,
         "installed-empty scope yields empty direct-scoped reads, never a sibling's rows",
     );
-    let _ = fs::remove_dir_all(fx.root_a);
+    let _ = fs::remove_dir_all(&fx.root_a);
 }
 
 /// #413 round-5: `query::orientation` threads the config's `[index] repo_id` override into its
@@ -697,7 +699,7 @@ fn orientation_pins_the_fork_repo_over_a_shared_root_sibling() {
         "",
         "no pin at a fork-owned root → the owner mirror declines rather than bind the sibling",
     );
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 // --- Cross-repo FTS / papertrail leak matrix (spec §9, memory-sync phase A4) ---
@@ -840,7 +842,7 @@ fn lexical_and_hybrid_search_never_surface_the_other_repo() {
         "repo A must still see its own chunk: {own:?}"
     );
 
-    let _ = fs::remove_dir_all(fx.root_a);
+    let _ = fs::remove_dir_all(&fx.root_a);
 }
 
 /// Git-history queries are repo-scoped: repo B's commit (commit_fts MATCH) and its path history are
@@ -868,7 +870,7 @@ fn git_history_queries_never_surface_the_other_repo() {
     let status = crate::index::git_history::status(conn, &fx.root_a).unwrap();
     assert_eq!(status.commit_count, 1, "status counts only repo A's git_commits, not repo B's");
 
-    let _ = fs::remove_dir_all(fx.root_a);
+    let _ = fs::remove_dir_all(&fx.root_a);
 }
 
 /// Papertrail queries are repo-scoped: repo B's issue (papertrail_fts MATCH) and its
@@ -892,7 +894,7 @@ fn papertrail_queries_never_surface_the_other_repo() {
     let own_refs = rag_rat_papertrail::refs_for_path(conn, "src/a_only.rs", 10).unwrap();
     assert!(!own_refs.is_empty(), "repo A must still see its own papertrail ref");
 
-    let _ = fs::remove_dir_all(fx.root_a);
+    let _ = fs::remove_dir_all(&fx.root_a);
 }
 
 // ================================================================================================
@@ -1120,7 +1122,7 @@ fn clone_precompute_leaves_sibling_repo_generation_untouched() {
         .unwrap();
     assert!(repo_a_complete >= 1, "repo A published its own fresh Complete generation");
 
-    let _ = fs::remove_dir_all(fx.root_a);
+    let _ = fs::remove_dir_all(&fx.root_a);
 }
 
 /// A5 finding 2: `refresh_clone_token_df` reads `symbol_fingerprints` scoped to the active repo
@@ -1180,7 +1182,7 @@ fn clone_token_df_recompute_excludes_a_sibling_repos_fingerprints() {
         "a sibling repo's fingerprint token leaked into the active repo's clone_token_df",
     );
 
-    let _ = fs::remove_dir_all(fx.root_a);
+    let _ = fs::remove_dir_all(&fx.root_a);
 }
 
 /// A5 finding: `memory_by_id` is the guard for `memory_get` / `update_memory` / `mark_obsolete` /
@@ -1733,7 +1735,7 @@ fn reconcile_status_ignores_a_sibling_repos_attempt() {
         fx.db.llm_status().unwrap().last_reconcile.expect("repo A has a reconcile attempt");
     assert_eq!(status.status, "Ok", "the status must be repo A's, not repo B's newer attempt");
     assert_eq!(status.started_at_ms, 100);
-    let _ = fs::remove_dir_all(fx.root_a);
+    let _ = fs::remove_dir_all(&fx.root_a);
 }
 
 /// A5 finding: the raw memory-summary readers (`repo_brief::memory_counts` /
@@ -1811,7 +1813,7 @@ fn memory_summary_readers_exclude_a_sibling_repos_memory() {
         "orientation leaked a sibling repo's active memory title",
     );
 
-    let _ = fs::remove_dir_all(fx.root_a);
+    let _ = fs::remove_dir_all(&fx.root_a);
 }
 
 /// A7 (batch 2): the open-time model-manifest heal must never mutate a SIBLING repo's
@@ -1862,7 +1864,7 @@ fn incremental_open_heal_leaves_a_sibling_repos_model_meta_alone() {
         "the open-time manifest heal mutated a sibling repo's repo_meta (pre-adoption sole pick)",
     );
 
-    let _ = fs::remove_dir_all(fx.root_a);
+    let _ = fs::remove_dir_all(&fx.root_a);
 }
 
 /// A7 (batch 3, same class as the incremental finding — the CALLEE now enforces it): a
@@ -1951,7 +1953,7 @@ fn incremental_open_resets_source_root_from_the_config_before_heals() {
          sibling root would refresh the target's graph from the wrong checkout",
     );
 
-    let _ = fs::remove_dir_all(fx.root_a);
+    let _ = fs::remove_dir_all(&fx.root_a);
 }
 
 /// #275: `current_callee_monikers` — the clone-refine collapse's `edge_oracle` read — must scope
@@ -2172,5 +2174,5 @@ fn qualified_name_resolution_is_repo_scoped_in_a_consolidated_db() {
         "symbol_lookup must surface the active repo's symbol and never the sibling's: {ids:?}",
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/orientation_healing.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/orientation_healing.rs
@@ -31,7 +31,7 @@ fn orientation_composes_through_read_only_connection() {
     assert!(!o.tree.nodes.is_empty(), "tree.nodes empty through read-only conn");
     assert_eq!(o.total_files, 6, "total_files mismatch through read-only conn");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// #87: a full rebuild must be authoritative for the whole checkout. A stale overlay row shadows
@@ -71,7 +71,7 @@ fn full_rebuild_survives_stale_overlay_rows() {
     assert_eq!(rows.len(), 1, "exactly one row per path after an authoritative rebuild: {rows:?}");
     assert_eq!(rows[0], (commit, String::new()), "the clean tree indexes at the commit scope");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// #59: a FOREIGN file row — a path the real tree never produces — leaked into the index at the
@@ -117,7 +117,7 @@ fn full_rebuild_clears_foreign_leaked_rows_at_the_active_scope() {
         .unwrap();
     assert_eq!(leaked, 0, "the authoritative full rebuild clears foreign rows at the active scope");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// #1 / #106: in a REAL git checkout the active context is `(commit_sha=HEAD, worktree_id=<root
@@ -228,7 +228,7 @@ fn clean_checkout_file_resolves_against_its_own_package_roots() {
          symbol"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// #87 (self-heal half): an incremental pass drops a stale overlay row whose path is clean.
@@ -293,7 +293,7 @@ fn incremental_pass_heals_stale_overlay_rows() {
         "re-stamp is in place — the row id (and ids hanging off it) survive"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// #459 review: if the watcher indexes a dirty file and that file is then committed, a changed-mode
@@ -358,7 +358,7 @@ fn changed_pass_after_dirty_commit_restamps_unchanged_files() {
         .unwrap();
     assert_eq!(overlays, 0, "the stale dirty overlay row is healed after the commit");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// The dirty-commit fallback must still discover/restamp the clean tree when another target file
@@ -422,7 +422,7 @@ fn changed_pass_after_dirty_commit_restamps_with_another_dirty_target() {
          overlay"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// Phase 3: the LOCAL structural-load enrichment (`scoped weighted fan-in`) rides along on BOTH the
@@ -512,7 +512,7 @@ pub fn caller_three() -> i32 { load_bearing_hub() }
         assert_eq!(importance.label, "local structural load", "search hit labeled correctly");
     }
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// Phase 3 regression: a CALLEE neighbor whose call was written with a `::` path carries a
@@ -592,7 +592,7 @@ pub fn qualified_caller_two() -> i32 { crate::helper::deep_helper() }
     assert_eq!(importance.signal, "scoped weighted fan-in");
     assert!(importance.score > 0.0, "two callers give the callee positive fan-in");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -635,7 +635,7 @@ fn read_only_open_serves_current_index_and_declines_when_heal_is_owed() {
         "a stale graph index owes a heal write → the read-only path must decline"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -709,7 +709,7 @@ fn impact_report_flags_a_section_truncated_at_limit() {
         full.completeness_and_caveats.truncated_sections
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -748,7 +748,7 @@ fn symbol_lookup_heals_stale_line_numbers_after_an_edit() {
         after.candidates[0].start_byte
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -798,7 +798,7 @@ fn symbol_lookup_heals_a_just_added_symbol_without_waiting_for_the_watcher() {
         "a genuine miss must stay empty"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -828,7 +828,7 @@ fn impact_completeness_flags_dirty_result_files() {
         dirty.completeness_and_caveats
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -867,7 +867,7 @@ fn symbol_lookup_does_not_resurrect_a_deleted_symbol_after_heal() {
         after.candidates
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -898,7 +898,7 @@ fn symbol_lookup_by_id_keeps_pre_heal_candidate_flagged_stale() {
     assert!(!res.candidates.is_empty(), "symbol_id selector keeps the pre-heal candidate");
     assert!(!res.stale_files.is_empty(), "and flags the file stale: {:?}", res.stale_files);
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -938,7 +938,7 @@ fn impact_completeness_flags_a_dirty_callee_definition_file() {
         dirty.completeness_and_caveats
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/papertrail_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/papertrail_tests.rs
@@ -35,7 +35,7 @@ fn configless_discovery_keeps_self_contained_github_refs_from_files_and_commits(
         }));
     }
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -140,7 +140,7 @@ fn manual_sync_validates_client_and_routes_only_the_requested_github_identity() 
         .unwrap();
     assert_eq!(gitlab_cached, 0, "manual GitHub sync must not dispatch the same-key GitLab ref");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -174,7 +174,7 @@ fn rationale_lookup_keeps_self_contained_github_refs_without_a_binding() {
         evidence.iter().any(|item| item.project == "cq27-dev/rag-rat" && item.item_key == "42")
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -240,7 +240,7 @@ fn production_discovery_persists_refs_for_every_configured_tracker() {
             && reference.item_key == "PROJ-42"
     }));
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -277,7 +277,7 @@ fn papertrail_for_commit_prefers_commit_sourced_tracker_refs() {
         "structured commit refs should suppress noisy fallback evidence: {papertrail:?}"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -310,7 +310,7 @@ fn papertrail_for_symbol_dedupes_duplicate_file_refs() {
         "duplicate #42 refs in one file should collapse to one item evidence row: {papertrail:?}"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -346,7 +346,7 @@ fn papertrail_sync_keeps_the_synced_item_and_retries_a_404_ref() {
     assert_eq!(second.skipped_refs, 1);
     assert_eq!(second.failed_refs, 1);
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -366,7 +366,7 @@ fn search_recovers_when_fts_is_marked_dirty() {
     assert!(!fresh.fts_dirty);
     assert!(fresh.fts_fresh);
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -381,7 +381,7 @@ fn read_chunk_relocates_small_line_drift_to_current_text() {
     assert_eq!(chunk.end_line, 3);
     assert_eq!(chunk.text, "# Title\nalpha token\n");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -397,7 +397,7 @@ fn read_chunk_large_drift_reindexes_and_reports_stale_chunk() {
     assert_eq!(hits.len(), 1);
     assert!(db.search("alpha", 10, false).unwrap().is_empty());
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -412,7 +412,7 @@ fn search_retries_after_healing_stale_hit() {
     assert_eq!(beta_hits.len(), 1);
     assert!(beta_hits[0].summary.contains("beta"));
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -427,7 +427,7 @@ fn search_heals_relocated_hits_before_returning_line_spans() {
     assert_eq!(hits[0].end_line, 3);
     assert!(hits[0].summary.contains("alpha"));
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -441,7 +441,7 @@ fn read_chunk_deleted_source_reports_gone() {
     assert!(err.contains("Gone"), "{err}");
     assert!(db.search("alpha", 10, false).unwrap().is_empty());
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -462,7 +462,7 @@ fn search_returns_needs_reindex_when_heal_cap_is_exceeded() {
     let err = db.search("common", 20, false).unwrap_err().to_string();
     assert!(err.contains("needs_reindex"), "{err}");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -489,7 +489,7 @@ fn search_drops_deleted_file_instead_of_erroring() {
     assert!(hits.iter().all(|hit| !hit.path.ends_with("drop.md")), "{hits:?}");
     assert!(hits.iter().any(|hit| hit.path.ends_with("keep.md")), "{hits:?}");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -510,7 +510,7 @@ fn heal_index_limit_does_not_warn_when_only_fresh_files_are_skipped() {
     assert_eq!(report.skipped_files, 2);
     assert_eq!(report.message, None);
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -531,7 +531,7 @@ fn search_recovers_when_fts_revision_is_stale() {
     assert_eq!(fresh.fts_source_revision.as_deref(), Some(fresh.content_revision.as_str()));
     assert!(fresh.fts_fresh);
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -573,7 +573,7 @@ fn parser_failures_report_paths() {
     assert_eq!(status.parser_failures, 1);
     assert_eq!(status.parser_failure_paths[0].path, "src/broken.rs");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 // --- V060: provider-neutral papertrail schema ---
@@ -1072,7 +1072,7 @@ fn papertrail_sync_retries_a_failed_ref_instead_of_caching_a_partial_item() {
     assert_eq!(third.skipped_refs, 1);
     assert_eq!(third.synced_items, 0);
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -1103,7 +1103,7 @@ fn papertrail_sync_rolls_back_the_item_when_a_comment_store_fails() {
     assert_eq!(retried.status.change_requests, 1);
     assert_eq!(retried.status.comments, 4);
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/reconcile_embeddings.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/reconcile_embeddings.rs
@@ -16,7 +16,7 @@ fn indexing_skips_symlink_loops() {
 
     assert_eq!(db.symbols("loop_safe_symbol", Some(Language::Rust), 10).unwrap().len(), 1);
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -71,7 +71,7 @@ fn dirty_git_files_are_indexed_as_worktree_overlay() {
     assert_eq!(overlay_hits.len(), 1);
     assert!(overlay_hits[0].summary.contains("overlay token"));
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -114,7 +114,7 @@ fn rebuild_populates_revision_metadata_and_fresh_fts_state() {
     assert_eq!(indexed_revision_count(&db), 1);
     assert_eq!(chunk_source_revision_count(&db), 1);
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[cfg(not(feature = "fastembed"))]
@@ -135,7 +135,7 @@ fn fastembed_missing_feature_reports_rebuild_command() {
     );
     assert_eq!(status.fastembed.next.as_deref(), Some("cargo install rag-rat"));
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -228,7 +228,7 @@ fn reconcile_requires_explicit_model_install_and_ignores_stale_artifacts() {
     let stale_embedding_hits = db.search("alpha", 10, false).unwrap();
     assert_eq!(stale_embedding_hits.len(), 1);
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -271,7 +271,7 @@ fn reconcile_confirms_a_provisional_model_against_a_config_change() {
         "a reconcile-confirmed model is not switched by a config change"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -299,7 +299,7 @@ fn an_incremental_pass_heals_a_missing_active_model_atomically() {
         "the incremental pass healed the active model and committed it"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[cfg(feature = "fastembed")]
@@ -340,7 +340,7 @@ fn cached_fastembed_model_recovers_ready_state() {
         "recovery stamps the recovered model's version (R3b)",
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[cfg(feature = "fastembed")]
@@ -371,7 +371,7 @@ fn compatible_migrate_recovers_cached_fastembed_model() {
     assert_eq!(status.fastembed.status, "Ready");
     assert!(status.fastembed.active);
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -393,7 +393,7 @@ fn reconcile_without_limit_processes_all_chunks() {
     let second = db.reconcile(None, Some(2)).unwrap();
     assert_eq!(second.processed_chunks, 0);
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -416,7 +416,7 @@ fn force_reconcile_processes_each_chunk_once_and_terminates() {
     assert_eq!(report.embeddings_written, 2, "force re-embedded chunks: {report:?}");
     assert_eq!(report.processed_chunks, 2, "force re-processed chunks: {report:?}");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -463,7 +463,7 @@ fn force_reconcile_progress_is_honest_and_terminates_without_limit() {
         }
     }
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -487,7 +487,7 @@ fn status_counts_only_active_context_chunks() {
     assert_eq!(scoped.total_chunks, 0, "status ignored active context scope");
     assert_eq!(scoped.current, 0);
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -508,7 +508,7 @@ fn watch_maintenance_pass_indexes_new_files() {
     let hits = db.symbols("newly_added_symbol", Some(Language::Rust), 10).unwrap();
     assert!(!hits.is_empty(), "watcher pass did not index the new file");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -535,7 +535,7 @@ fn watch_maintenance_pass_defers_a_first_time_empty_config() {
     let hits = db.symbols("appeared", Some(Language::Rust), 10).unwrap();
     assert!(!hits.is_empty(), "a pass after content appears must register + index it");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -592,7 +592,7 @@ fn discover_deletion_is_worktree_scoped() {
     // Post-condition: a worktree-scoped discover-deletion must not delete a sibling repo's rows
     // (round-6 harness) — the same "delete only my scope" invariant, widened to the repo axis.
     crate::index::poison_sibling::assert_sibling_intact(conn);
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -640,7 +640,7 @@ fn gc_prunes_dead_context_rows_and_keeps_live_ones() {
         "live chunks were pruned",
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -658,7 +658,7 @@ fn gc_refuses_to_prune_with_no_live_context() {
 
     // Post-condition: the refused prune must leave the poison sibling untouched (round-6 harness).
     crate::index::poison_sibling::assert_sibling_intact(db.storage.connection());
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -695,7 +695,7 @@ int main(void)
     let report = db.reconcile(None, Some(8)).unwrap();
     assert!(report.embeddings_written > 0, "report: {report:?}");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -713,7 +713,7 @@ fn reconcile_policy_skips_tiny_chunks_before_embedding() {
     assert_eq!(report.skipped_by_policy.get("SkipTooSmall"), Some(&1));
     assert_eq!(db.current_embedding_count(HASH_MODEL_ID).unwrap(), 0);
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -796,7 +796,7 @@ fn policy_skip_summary_recomputes_exactly_for_a_non_default_char_cap() {
         small_cap_run.skipped_by_policy
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -845,7 +845,7 @@ fn policy_skip_summary_buckets_ineligible_chunks_across_categories() {
     // Rust is a supported embedding language.
     assert_eq!(skipped.get("SkipLanguageUnsupported"), None, "summary: {skipped:?}");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -877,7 +877,7 @@ fn reconcile_plan_reports_policy_skips_for_fastembed_model() {
     assert_eq!(plan.embeddings.missing, 0);
     assert_eq!(plan.embeddings.skipped_by_policy.get("SkipTooSmall"), Some(&1));
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[cfg(not(feature = "fastembed"))]
@@ -900,7 +900,7 @@ fn blocked_fastembed_reconcile_still_reports_policy_skips() {
     assert_eq!(report.status, "Blocked");
     assert_eq!(report.skipped_by_policy.get("SkipTooSmall"), Some(&1));
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -936,7 +936,7 @@ fn search_explain_reports_weighted_score_components() {
     assert!(components.papertrail <= 0.02);
     assert!(db.search("runtime shutdown", 10, false).unwrap()[0].score_components.is_none());
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -958,7 +958,7 @@ fn search_explain_labels_missing_vector_runtime() {
         Some("vector search unavailable: no current embedding model")
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -1065,7 +1065,7 @@ fn git_history_indexes_commits_paths_queries_and_blame() {
     let cached = db.git_blame_chunk(chunk_id).unwrap().unwrap();
     assert_eq!(cached.source_text_hash, blame.source_text_hash);
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -1084,7 +1084,7 @@ fn git_history_reload_is_skipped_when_head_is_unchanged() {
     // Real history is left intact (the 2 real commits are untouched by the skip).
     assert_eq!(db.status(&config.database).unwrap().git_history.commit_count, 2);
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -1215,7 +1215,7 @@ fn skip_summary_shared_parse_matches_per_chunk_text() {
          {span:?}"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -1280,7 +1280,7 @@ fn skip_summary_fast_path_reads_certified_column_and_falls_back_when_stale() {
          {fast:?}"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -1352,7 +1352,7 @@ fn reconcile_self_heals_stale_policy_column_and_restamps() {
         "after self-heal the summary reads the certified column (fast path): {after:?}"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -1399,7 +1399,7 @@ fn self_heal_does_not_certify_a_repo_with_another_live_scope() {
         "self-heal must NOT certify a repo whose active scope is not its whole live set"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -1487,7 +1487,7 @@ fn reconcile_heals_an_op_log_ghost_in_an_idle_repo() {
         "the reconcile pass authored the idle-repo ghost into the signed log"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -1523,7 +1523,7 @@ fn candidate_count_stream_is_unordered_and_sorts_only_under_a_limit() {
         "a LIMITed walk keeps the need-first order — it decides which rows are counted:\n{limited}"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -1578,7 +1578,7 @@ fn count_paths_fetch_text_only_for_rows_that_reach_a_text_gate() {
         "a metadata-fresh chunk still fetches text for the input-hash clause"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// #821 digest parity: `sync_fts` computes ONE `main.files` digest and stamps BOTH freshness
@@ -1608,5 +1608,5 @@ fn sync_fts_threaded_digest_matches_the_recomputing_form_byte_for_byte() {
         "the value-threaded stamp is byte-identical to a recompute over the same table state"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_memory/diagnostics.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_memory/diagnostics.rs
@@ -84,7 +84,7 @@ fn anchor_health_counts_tallies_persisted_statuses() {
     assert_eq!(health.gone, 0, "expected no gone bindings, got {health:?}");
     assert_eq!(health.stale, 0, "expected no stale bindings, got {health:?}");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -180,7 +180,7 @@ fn memory_doctor_lists_gone_and_suggests_candidates() {
         entry.candidates
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// A memory stranded under the `'__unassigned__'` placeholder on an ADOPTED DB — the V042
@@ -284,7 +284,7 @@ fn memory_doctor_dedupes_cfg_split_candidates() {
         entry.candidates.iter().filter(|c| c.ends_with("cfg_helper")).collect();
     assert_eq!(cfg_candidates.len(), 1, "cfg twins collapse to one suggestion: {cfg_candidates:?}");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -319,7 +319,7 @@ fn symbol_path_selector_is_exact_not_substring() {
         .expect("one hit");
     assert_eq!(hit.name, "spawn_blocking");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -397,7 +397,7 @@ fn select_symbol_for_bind_collapses_cfg_split_group() {
         .expect("one member returned");
     assert_eq!(hit.logical_symbol_id, Some(logical_id));
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -476,7 +476,7 @@ fn repo_brief_ranks_churn_and_god_module_candidates() {
     assert!(!god_modules.candidates[0].split_hints.is_empty());
     assert!(god_modules.candidates[0].next_tools.iter().any(|tool| tool.tool == "impact_surface"));
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -553,5 +553,5 @@ fn repo_clusters_groups_cotouched_files() {
     assert!(sync_cluster.representative_paths.contains(&"src/sync/msg.rs".to_string()));
     assert!(sync_cluster.metrics.co_touch_edges >= 2);
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_memory/relocation.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_memory/relocation.rs
@@ -99,7 +99,7 @@ fn memory_relocates_when_symbol_moves_to_another_file() {
     // Post-condition: memory validation/relocation (which rewrites bindings) must not rebind onto,
     // or delete, a SIBLING repo's rows (round-6 harness; guards the P2 #2 relocation scoping).
     crate::index::poison_sibling::assert_sibling_intact(db.storage.connection());
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -194,7 +194,7 @@ fn memory_relocation_is_durable_across_a_second_reindex() {
     );
     assert!(!binding.contains("a.rs"), "binding_id must not still reference a.rs: {binding}");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -301,7 +301,7 @@ fn relocation_persists_refreshed_symbol_and_logical_ids() {
         "persisted symbol_id must resolve to a live symbol row"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -346,7 +346,7 @@ fn full_rebuild_leaves_no_orphan_symbol_rows_for_a_path() {
         "repeated full rebuilds must not accumulate orphan symbol rows for the same path"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -415,7 +415,7 @@ fn memory_stays_gone_when_moved_symbol_body_changed() {
     assert_eq!(report.gone, 1, "changed body must not trigger relocate, expected gone: {report:?}");
     assert_eq!(report.relocated, 0, "must not relocate when body changed: {report:?}");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -530,7 +530,7 @@ fn memory_stays_gone_when_two_files_define_the_same_name() {
         "must not relocate when two identical bodies exist: {report:?}"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -653,7 +653,7 @@ fn memory_logical_binding_relocates_across_files() {
         "logical binding path should be b.rs after relocation, got: {path}"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -787,7 +787,7 @@ fn memory_chunk_binding_relocates_by_hash() {
         "binding path must reference target.rs: {binding_path:?}"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -945,5 +945,5 @@ fn memory_rebind_reanchors_and_refreshes_hash() {
         "binding must be current or relocated after validate: {post_rebind_report:?}"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_memory/surfacing.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_memory/surfacing.rs
@@ -83,7 +83,7 @@ fn repo_memory_bound_to_logical_symbol_surfaces_in_symbol_chunk_and_impact() {
     assert_eq!(impact.completeness_and_caveats.memory_status.active, 1);
     assert_eq!(impact.completeness_and_caveats.memory_status.stale, 0);
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -169,7 +169,7 @@ fn compact_repo_memory_view_projects_primary_binding_then_full_mode_round_trips(
     assert_eq!(full.direct[0].body, full_body);
     assert_eq!(full.direct[0].bindings[0].binding_kind, "logical_symbol");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -259,7 +259,7 @@ fn compact_repo_memory_view_separates_the_stale_lane() {
     assert_eq!(after.stale[0].memory_id, created.memory.memory_id);
     assert_eq!(after.stale[0].anchor_status.as_deref(), Some("stale"));
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -338,7 +338,7 @@ fn repo_memory_survives_reindex_and_relocates_when_symbol_moves() {
     assert_eq!(anchored.len(), 1, "memory did not re-anchor to moved symbol");
     assert_ne!(anchored[0].bindings[0].anchor_status, "gone");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -430,7 +430,7 @@ fn repo_memory_validate_marks_changed_or_missing_anchors_non_current() {
         db.memory_for_symbol(&symbol, 10, rag_rat_base::config::MemorySurface::Full).unwrap();
     assert_eq!(gone[0].bindings[0].anchor_status, "gone");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// #491: one qualified name, two logical twins (a `struct` and its `impl` block). The impl's
@@ -529,7 +529,7 @@ fn relocation_lands_on_the_kind_matching_twin_not_plan_order() {
          happens to return first"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// #492: the path probe took the newest `files` row with no `kind != 'deleted'` filter, and a
@@ -592,7 +592,7 @@ fn a_deleted_at_head_file_makes_a_bare_path_binding_gone() {
     assert_eq!(status(&db), "gone", "the deleted marker must not shadow the file's absence");
     assert_eq!(report.gone, 1);
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// #492: a path that is absent at THIS context's HEAD but alive in another indexed scope (a
@@ -713,7 +713,7 @@ fn a_path_alive_only_in_another_scope_validates_pending_not_gone() {
     assert_eq!(report.pending, 0);
     assert_eq!(report.gone, 1);
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -846,7 +846,7 @@ fn repo_memory_bound_to_edge_surfaces_when_impact_crosses_call_path() {
     assert_eq!(call_path[0].memory_id, call_path_memory.memory.memory_id);
     assert_eq!(call_path[0].call_paths[0].path_summary, "caller_edge -> target_edge");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -907,7 +907,7 @@ fn memory_search_defers_the_body_under_the_summary_surface() {
          yet)"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -1037,7 +1037,7 @@ fn server_derived_call_path_hash_is_stable_and_validates_through_edge_churn() {
     db.memory_validate().unwrap();
     assert_eq!(call_path_status(&db), "gone", "deleting the call site makes the path gone");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -1133,5 +1133,5 @@ fn impact_surface_surfaces_call_path_memory_when_path_crossed() {
         compact.call_path_crossed.iter().map(|m| &m.title).collect::<Vec<_>>()
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_registry.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_registry.rs
@@ -1756,7 +1756,7 @@ fn a_writer_whose_identity_upgrades_mid_run_extends_its_lock_to_the_resolved_id(
 
 /// A real git repo (two empty commits) for the upgrade-proof tests — its HEAD is a commit a genuine
 /// deepened clone would reach.
-fn real_git_repo(tag: &str) -> PathBuf {
+fn real_git_repo(tag: &str) -> ScratchRoot {
     let root = unique_temp_root();
     let _ = fs::remove_dir_all(&root);
     fs::create_dir_all(&root).unwrap();
@@ -2450,7 +2450,7 @@ fn unshallow_upgrades_a_shallow_clone_index_from_local_to_portable_in_place() {
         )
         .expect("the memory binding still resolves after the in-place upgrade");
     assert_eq!(resolved_name, symbol_name, "the memory resolves to the same symbol post-upgrade");
-    let _ = fs::remove_dir_all(base);
+    let _ = fs::remove_dir_all(&base);
 }
 
 // --- Read-path repo resolution without registering (#413 round-4 findings #1 + #2) ---
@@ -2533,7 +2533,7 @@ fn resolve_config_repo_id_returns_none_for_a_rejected_pin() {
         None,
         "a reserved-id pin does not resolve on the read path — it surfaces via the read-write open",
     );
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// #413 round-5: a NEW, unregistered `[index] repo_id` pin resolves to `None` on the read path —
@@ -2569,7 +2569,7 @@ fn resolve_config_repo_id_returns_none_for_a_new_unregistered_pin() {
         "a new unregistered pin declines on the read path — it does not bind the old (repo-a) \
          scope",
     );
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// #413 round-5, the shallow-upgrade sibling case: a repo registered under a `local:` id whose
@@ -2614,7 +2614,7 @@ fn resolve_config_repo_id_returns_none_for_a_newly_portable_local_incumbent() {
         None,
         "a newly-portable identity declines on the read path — upgrade happens on the write path",
     );
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// Test-local probe: is `repo_id` a registered real repo? (mirrors the private
@@ -2643,7 +2643,7 @@ fn open_config_surfaces_a_reserved_repo_id_pin() {
     let err = IndexDatabase::open_config(&config)
         .expect_err("a reserved-id pin is a rejection, never a silent placeholder fallback");
     assert!(err.to_string().contains("reserved"), "error names the rejection: {err}");
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// A cut shallow clone (its root commit unreachable, so a derived id would be depth-dependent) does
@@ -2684,7 +2684,7 @@ fn open_config_adopts_a_shallow_clone_under_a_local_only_id() {
         1,
         "LocalOnly repo row"
     );
-    let _ = fs::remove_dir_all(base);
+    let _ = fs::remove_dir_all(&base);
 }
 
 /// A NON-git root (no identity to derive at all) is the EXPECTED-absence class: `open_config`
@@ -2704,7 +2704,7 @@ fn open_config_falls_back_to_the_sole_repo_on_a_non_git_root() {
         db.active_repo_id, LEGACY_REPO_ID,
         "the un-adopted single-repo DB scopes to the placeholder"
     );
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// The STRUCTURAL BACKSTOP for the identity gate's second entrance (Codex batch 8, finding 5): an
@@ -2749,7 +2749,7 @@ fn an_identity_less_open_refuses_to_sole_pick_on_a_multi_repo_db() {
     assert_eq!(repos, 2, "both siblings still registered, nothing adopted");
     let roots: i64 = conn.query_row("SELECT COUNT(*) FROM repo_roots", [], |r| r.get(0)).unwrap();
     assert_eq!(roots, 0, "no root was recorded for the refused open");
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 // --- V041: repo_id scoping on the GitHub papertrail tables (memory-sync phase A4) ---

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations/bootstrap.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations/bootstrap.rs
@@ -103,7 +103,7 @@ fn rebuild_bootstraps_sqlite_schema_for_empty_target_root() {
         schema::LATEST_SCHEMA_VERSION
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -134,7 +134,7 @@ fn symbols_store_true_source_line_spans() {
     assert_eq!(line_span("alpha"), (2, 2));
     assert_eq!(line_span("beta"), (4, 6));
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -157,7 +157,7 @@ fn rebuild_reports_file_preparation_progress() {
         "missing indexing progress event: {events:?}"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -188,7 +188,7 @@ fn open_refuses_a_legacy_schema_without_version_table() {
     let err = IndexDatabase::open(&database).unwrap_err().to_string();
     assert!(err.contains("rebuild"), "{err}");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -228,7 +228,7 @@ fn forward_migration_does_not_rerun_already_applied_migrations() {
         schema::SchemaState::Compatible
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -273,7 +273,7 @@ fn forward_migration_reprovisions_missing_baseline_tables() {
     drop(conn);
     assert_eq!(edge_strings_exists, 1, "baseline did not reprovision name_strings before replay");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -305,7 +305,7 @@ fn open_auto_migrates_a_forward_older_schema_to_latest() {
     assert_eq!(after.state, schema::SchemaState::Compatible);
     assert_eq!(after.current_version, after.latest_version);
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -381,7 +381,7 @@ fn migrate_adds_edge_name_columns_before_indexing_them() {
     assert_eq!(table_count(&db, "idx_edges_from_name"), 1);
     assert_eq!(table_count(&db, "idx_edges_to_name"), 1);
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -425,7 +425,7 @@ fn migrate_preserves_the_papertrail_cache() {
     assert_eq!(hits.len(), 1);
     assert_eq!(hits[0].item_key, "42");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -460,7 +460,7 @@ fn full_rebuild_preserves_the_papertrail_cache() {
     assert_eq!(hits.len(), 1);
     assert_eq!(hits[0].item_key, "42");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -483,7 +483,7 @@ fn full_rebuild_preserves_installed_model_manifest() {
     assert!(after.embedding.installed);
     assert_eq!(after.embedding.state, "Ready");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -612,7 +612,7 @@ fn full_rebuild_preserves_other_worktree_contexts() {
         1
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -672,7 +672,7 @@ fn compatible_open_refuses_dirty_and_newer_schema() {
         assert!(err.contains("do not hot-upgrade"), "{err}");
     }
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// #498: the forward-migrate REPLAY path (an existing versioned ledger — every open-time
@@ -982,7 +982,7 @@ fn concurrent_forward_migrate_applies_the_pending_step_exactly_once() {
         "exactly one schema_version row per migration and no stranded dirty marker"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -1025,5 +1025,5 @@ fn discover_mode_indexes_new_files_and_removes_deleted_files() {
     );
     assert_eq!(db.symbols("new_symbol", Some(Language::Rust), 10).unwrap().len(), 1);
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/swift_corpus.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/swift_corpus.rs
@@ -19,7 +19,7 @@ use super::*;
 
 /// Index the corpus. SwiftPM puts first-party code under `Sources/` and its test targets under
 /// `Tests/`; both are bound so the fixture exercises test detection as well as source extraction.
-fn corpus() -> (PathBuf, IndexDatabase) {
+fn corpus() -> (ScratchRoot, IndexDatabase) {
     let root = fixture_temp_root("swift-corpus");
     let config = source_config_dirs(root.clone(), Language::Swift, &["Sources", "Tests"]);
     let db = IndexDatabase::rebuild(&config).unwrap();
@@ -119,7 +119,7 @@ fn swift_corpus_extracts_declarations_and_containment() {
         ("function".into(), "Store::load".into()),
     ]);
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// Test-target symbols are marked `is_test` and production symbols in the same index are not — the
@@ -149,7 +149,7 @@ fn swift_corpus_marks_test_target_symbols_and_leaves_production_alone() {
     assert!(!is_test_symbol(&db, "Renderer"));
     assert!(!is_test_symbol(&db, "mapped"));
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// What the baseline resolves, and — the load-bearing half — what it refuses to.
@@ -196,7 +196,7 @@ fn swift_corpus_pins_the_resolution_baseline_for_the_oracle() {
         "an overloaded call cannot be resolved by name: {fetches:?}"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// The call on the right of a binary operator reaches the graph at all.
@@ -216,7 +216,7 @@ fn swift_corpus_keeps_calls_on_the_right_of_an_operator() {
     // The method call at the end of a `+` chain, through a receiver.
     assert_eq!(call_states(&db, "described", "describe").len(), 1);
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// UTF-16 ↔ byte position conversion over real non-ASCII source — the semantic-readiness check for
@@ -268,7 +268,7 @@ fn swift_corpus_converts_utf16_positions_over_non_ascii_source() {
         }
     }
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// Coverage floors. Deliberately floors, not exact counts: they catch a broken parse or a collapsed
@@ -300,7 +300,7 @@ fn swift_corpus_meets_its_coverage_floors() {
     );
     assert_eq!(symbolless, 0, "every indexed Swift file must parse into symbols");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// The corpus is a REAL package, so it must actually build — the SourceKit-LSP oracle (#637)
@@ -349,5 +349,5 @@ fn swift_corpus_builds_with_swiftpm() {
         String::from_utf8_lossy(&build.stderr)
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/symbol_search_lookup.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/symbol_search_lookup.rs
@@ -50,7 +50,7 @@ fn stale_generated_flags_are_rederived_on_open() {
         after.candidates.iter().map(|c| &c.path).collect::<Vec<_>>()
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -142,7 +142,7 @@ fn search_and_read_chunk_attach_bounded_graph_evidence() {
     );
     assert!(full_graph.notes.iter().any(|note| note.contains("tree-sitter/syntactic")));
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -199,7 +199,7 @@ fn graph_exact_mode_requires_verified_symbol_identity() {
     );
     assert!(exact_callees.iter().all(|edge| edge.verified_target_symbol));
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -230,7 +230,7 @@ pub struct Database;
         "impl Database should still be available after the struct: {hits:?}"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -295,7 +295,7 @@ impl B {
         .collect();
     assert_eq!(reindexed_ids, logical_ids, "logical ids must be stable across reindex");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -418,7 +418,7 @@ pub fn caller() {
         "a handle in the ref slot is not ambiguous: {by_ref_handle:?}"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -459,7 +459,7 @@ fn indexes_real_world_rust_graph_patterns() {
         "serve callers: {callers:?}"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -502,7 +502,7 @@ export const callRun = () => run();
         "callRun callees: {callees:?}"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -721,7 +721,7 @@ struct Runner: Worker<Service> {
         assert_eq!(&source[start as usize..end as usize], callee);
     }
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -753,7 +753,7 @@ int runtime_open(Runtime *runtime) {
 
     assert_edge(&db, "runtime_open", "helper", "calls_name", "Syntactic");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -817,7 +817,7 @@ DEVICE_DT_INST_DEFINE(0, entropy_init, NULL, NULL, NULL,
         "DEVICE_API hits: {hits:?}"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -848,7 +848,7 @@ void Runtime::open() {
 
     assert_edge(&db, "open", "helper", "calls_name", "Syntactic");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -883,7 +883,7 @@ fn indexes_real_world_typescript_graph_patterns() {
         "Shell callees: {callees:?}"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -936,7 +936,7 @@ fn execute_one() {
     assert_eq!(edge.4, "unresolved");
     assert!(edge.5.as_deref().is_some_and(|value| value.contains("format!")));
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -1008,7 +1008,7 @@ fn execute_one() {
     assert_eq!(edge.3, "unresolved");
     assert!(edge.4.as_deref().is_some_and(|value| value.contains("format!")));
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -1065,7 +1065,7 @@ pub fn caller() {
     assert_eq!(edge.3, "NameOnly");
     assert_eq!(edge.4, "unresolved");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -1124,7 +1124,7 @@ fn rust_entry() {
     assert_eq!(edge.4, "unresolved");
     assert!(edge.5.as_deref().is_some_and(|value| value.contains("json!")));
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -1169,7 +1169,7 @@ pub fn second() {
         "spawn_blocking callers: {callers:?}"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -1266,7 +1266,7 @@ pub fn related_spawn_with_text() {
         "qualified caller lookup leaked related names or chain evidence: {qualified_callers:?}"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -1316,7 +1316,7 @@ pub fn caller() {{
         "impact: {impact:?}"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -1378,7 +1378,7 @@ pub fn caller() {
         "type references should not appear as direct impact: {impact:?}"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -1432,7 +1432,7 @@ pub fn hub() {
         "an uncapped result must NOT carry a sentinel: {full:?}"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -1465,7 +1465,7 @@ fn impact_surface_flat_signals_truncation_from_a_capped_textual_fallback() {
     let real_items = impact.iter().filter(|item| item.category != "completeness").count();
     assert_eq!(real_items, limit as usize, "exactly `limit` real items, plus the sentinel");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -1529,7 +1529,7 @@ fn impact_surface_collapses_file_matches_to_one_row_per_file() {
         .count();
     assert_eq!(store_rows, 1, "a file with four symbols collapses to one fallback row");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -1608,7 +1608,7 @@ where
         "path-local task_spawn docs should outrank unrelated phrase docs: {hits:?}"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -1636,7 +1636,7 @@ fn broken( {
     assert!(symbols.iter().any(|symbol| symbol.name == "caller"), "caller symbols: {symbols:?}");
     assert_edge(&db, "caller", "helper", "calls_name", "Syntactic");
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -1692,7 +1692,7 @@ pub struct JoinSet;
     assert_eq!(edge.4, "unresolved");
     assert_eq!(edge.5.as_deref(), Some("joinset"));
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -1781,7 +1781,7 @@ where
         "unresolved-enabled callees: {with_unresolved:?}"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -1841,7 +1841,7 @@ pub fn caller(input: Result<String, String>) -> String {
         "common-method-enabled callees: {expanded:?}"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -1883,7 +1883,7 @@ fun helper() {}
         "impact: {impact:?}"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -1915,7 +1915,7 @@ fn indexes_real_world_kotlin_graph_patterns() {
         "cleaned callers: {callers:?}"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -1981,7 +1981,7 @@ fun unrelatedBuilderCalls(dialog: AndroidDialogBuilder) {
         "unrelated builder calls should not resolve to WatchProposalBuilder.build: {callers:?}"
     );
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -2048,5 +2048,5 @@ fn papertrail_sync_caches_rationale_without_query_time_crawling() {
         matches!(item.evidence_kind, "historical_tracker" | "literal_tracker_ref")
     }));
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/watch_placement.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/watch_placement.rs
@@ -34,5 +34,5 @@ fn index_status_surfaces_watch_placement_failures() {
     assert!(db.record_watch_placement_failures(5).unwrap(), "a higher count is a change");
     assert_eq!(db.status(&config.database).unwrap().watch_placement_failures, 5);
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_overlay/lifecycle.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_overlay/lifecycle.rs
@@ -825,7 +825,7 @@ fn rebuild_restores_durable_wal_after_bulk_build() {
     // The index is intact and queryable after the bulk build.
     assert!(!db.symbols("alpha", Some(Language::Rust), 10).unwrap().is_empty());
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_overlay/quiet_window.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_overlay/quiet_window.rs
@@ -2,7 +2,7 @@ use super::*;
 
 /// One committed base repo + one linked worktree, the shared #822/#825 shape: `(main, linked,
 /// config, db)` with `src/a.rs` committed on both sides and every overlay basis unrecorded.
-fn quiet_window_fixture() -> (PathBuf, PathBuf, Config, IndexDatabase) {
+fn quiet_window_fixture() -> (ScratchRoot, ScratchRoot, Config, IndexDatabase) {
     let main = unique_temp_root();
     let _ = fs::remove_dir_all(&main);
     fs::create_dir_all(main.join("src")).unwrap();


### PR DESCRIPTION
## Summary
- retain non-cloneable `ScratchDir` ownership across all schema-bootstrap scratch roots
- propagate guard ownership through fixture helpers and shared-database fixtures
- borrow explicit cleanup paths so RAII remains available for panic and early-return cleanup

## Verification
- `cargo check -p rag-rat-core --tests`
- `cargo nextest run -p rag-rat-core schema_bootstrap_tests` (696 passed)
- isolated `TMPDIR` scratch namespace contained no fixture directories after the run
- `cargo +nightly fmt --all --check`
- `cargo clippy -p rag-rat-core --tests -- -D warnings`
- `git diff --check`
- `codex review --base origin/main` (no actionable findings)

Part of #586.