### PR TITLE
fix(tests): retain CLI integration scratch cleanup guards

### DIFF
--- a/crates/rag-rat-cli/tests/agent_hook_e2e.rs
+++ b/crates/rag-rat-cli/tests/agent_hook_e2e.rs
@@ -9,9 +9,14 @@ use std::{
     io::{BufRead, BufReader},
     path::{Path, PathBuf},
     process::Child,
-    sync::atomic::{AtomicU64, Ordering},
     time::{Duration, Instant},
 };
+
+mod common;
+
+#[cfg(unix)]
+use common::ScratchRoot;
+use common::unique_dir;
 
 fn run_hook(stdin_body: &str, cwd: &std::path::Path) -> (String, std::process::ExitStatus) {
     let mut child = Command::new(env!("CARGO_BIN_EXE_rag-rat"))
@@ -40,10 +45,10 @@ fn run_hook(stdin_body: &str, cwd: &std::path::Path) -> (String, std::process::E
 
 #[test]
 fn no_rag_rat_toml_means_silent_exit_zero() {
-    let dir = std::env::temp_dir().join(format!("ragrat-hook-noindex-{}", std::process::id()));
+    let dir = unique_dir("hook-noindex");
     std::fs::create_dir_all(&dir).unwrap();
     let input = serde_json::json!({
-        "session_id": "s1", "cwd": dir, "hook_event_name": "PreToolUse",
+        "session_id": "s1", "cwd": dir.as_path(), "hook_event_name": "PreToolUse",
         "tool_name": "Grep", "tool_input": {"pattern": "anything"}
     });
     let (stdout, status) = run_hook(&input.to_string(), &dir);
@@ -53,7 +58,7 @@ fn no_rag_rat_toml_means_silent_exit_zero() {
 
 #[test]
 fn garbage_stdin_means_silent_exit_zero() {
-    let dir = std::env::temp_dir().join(format!("ragrat-hook-garbage-{}", std::process::id()));
+    let dir = unique_dir("hook-garbage");
     std::fs::create_dir_all(&dir).unwrap();
     let (stdout, status) = run_hook("this is not json", &dir);
     assert!(status.success());
@@ -62,10 +67,10 @@ fn garbage_stdin_means_silent_exit_zero() {
 
 #[test]
 fn non_search_tool_means_silent_exit_zero() {
-    let dir = std::env::temp_dir().join(format!("ragrat-hook-read-{}", std::process::id()));
+    let dir = unique_dir("hook-read");
     std::fs::create_dir_all(&dir).unwrap();
     let input = serde_json::json!({
-        "session_id": "s1", "cwd": dir, "hook_event_name": "PreToolUse",
+        "session_id": "s1", "cwd": dir.as_path(), "hook_event_name": "PreToolUse",
         "tool_name": "Read", "tool_input": {"path": "/x"}
     });
     let (stdout, status) = run_hook(&input.to_string(), &dir);
@@ -78,8 +83,7 @@ fn non_search_tool_means_silent_exit_zero() {
 /// `database.exists()` hints).
 #[test]
 fn posttooluse_without_an_index_is_silent_and_non_creating() {
-    let dir = std::env::temp_dir().join(format!("ragrat-hook-post-noindex-{}", std::process::id()));
-    let _ = std::fs::remove_dir_all(&dir);
+    let dir = unique_dir("hook-post-noindex");
     std::fs::create_dir_all(dir.join("src")).unwrap();
     std::fs::write(
         dir.join("rag-rat.toml"),
@@ -88,14 +92,13 @@ fn posttooluse_without_an_index_is_silent_and_non_creating() {
     )
     .unwrap();
     let input = serde_json::json!({
-        "session_id": "s1", "cwd": dir, "hook_event_name": "PostToolUse",
+        "session_id": "s1", "cwd": dir.as_path(), "hook_event_name": "PostToolUse",
         "tool_name": "Write", "tool_input": {"file_path": dir.join("src/new.rs")}
     });
     let (stdout, status) = run_hook(&input.to_string(), &dir);
     assert!(status.success(), "PostToolUse must exit 0 even with no index");
     assert!(stdout.is_empty(), "PostToolUse prints nothing, got: {stdout}");
     assert!(!dir.join(".rag-rat/index.sqlite").is_file(), "the hook must not create the index");
-    let _ = std::fs::remove_dir_all(&dir);
 }
 
 /// Full path: a live `rag-rat mcp` elects the hook listener, the `agent-hook` client reaches it
@@ -153,16 +156,11 @@ fn socket_path_serves_dedupes_and_falls_back() {
         fallback_context.contains("frobnicate_xyz") && fallback_context.contains("src/lib.rs"),
         "fallback must compose from SQLite directly, got: {fallback_context}"
     );
-
-    repo.cleanup();
 }
 
 #[cfg(unix)]
-static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
-
-#[cfg(unix)]
 struct TestRepo {
-    root: PathBuf,
+    root: ScratchRoot,
     config_path: PathBuf,
     config: rag_rat_base::config::Config,
 }
@@ -173,9 +171,7 @@ impl TestRepo {
     /// `IndexDatabase::rebuild` (the same path `mcp_stdio`/`mcp_hot_upgrade` use to populate a real
     /// index). Unique per run so parallel tests never collide on the socket election lock.
     fn indexed_with_symbol() -> Self {
-        let id = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
-        let root =
-            std::env::temp_dir().join(format!("ragrat-hook-e2e-{}-{id}", std::process::id()));
+        let root = unique_dir("hook-e2e");
         fs::create_dir_all(root.join("src")).unwrap();
         fs::write(root.join("src/lib.rs"), "pub fn frobnicate_xyz() {}\n").unwrap();
         let config_path = root.join("rag-rat.toml");
@@ -243,16 +239,12 @@ impl TestRepo {
     /// cwd = repo root (so `find_config` walks up to our `rag-rat.toml`).
     fn run_hook_session(&self, session_id: &str) -> String {
         let input = serde_json::json!({
-            "session_id": session_id, "cwd": self.root, "hook_event_name": "PreToolUse",
+            "session_id": session_id, "cwd": self.root.as_path(), "hook_event_name": "PreToolUse",
             "tool_name": "Grep", "tool_input": {"pattern": "frobnicate_xyz"}
         });
         let (stdout, status) = run_hook(&input.to_string(), &self.root);
         assert!(status.success(), "agent-hook must exit zero on every path");
         stdout
-    }
-
-    fn cleanup(&self) {
-        let _ = fs::remove_dir_all(&self.root);
     }
 }
 
@@ -341,7 +333,7 @@ fn edit_reindex_reconciles_the_edited_file() {
     let status = Command::new(env!("CARGO_BIN_EXE_rag-rat"))
         .arg("edit-reindex")
         .arg("--cwd")
-        .arg(&repo.root)
+        .arg(&*repo.root)
         .arg("--paths")
         .arg(repo.root.join("src/lib.rs"))
         .current_dir(&repo.root)
@@ -355,7 +347,6 @@ fn edit_reindex_reconciles_the_edited_file() {
         "the edit's new symbol is indexed"
     );
     assert!(!symbol_indexed(&repo.config, "frobnicate_xyz"), "the replaced symbol is gone");
-    repo.cleanup();
 }
 
 /// #661 end-to-end: a PostToolUse edit hook returns immediately (exit 0, silent) and backgrounds a
@@ -367,7 +358,7 @@ fn posttooluse_backgrounds_a_scoped_reindex() {
     let repo = TestRepo::indexed_with_symbol();
     fs::write(repo.root.join("src/lib.rs"), "pub fn added_via_hook_tuv() {}\n").unwrap();
     let input = serde_json::json!({
-        "session_id": "s-post", "cwd": repo.root, "hook_event_name": "PostToolUse",
+        "session_id": "s-post", "cwd": repo.root.as_path(), "hook_event_name": "PostToolUse",
         "tool_name": "Edit", "tool_input": {"file_path": repo.root.join("src/lib.rs")}
     });
     let (stdout, status) = run_hook(&input.to_string(), &repo.root);
@@ -375,7 +366,6 @@ fn posttooluse_backgrounds_a_scoped_reindex() {
     assert!(stdout.is_empty(), "PostToolUse prints nothing, got: {stdout}");
     // The reindex runs in a detached child; poll until the edit lands.
     wait_for_symbol(&repo.config, "added_via_hook_tuv", Duration::from_secs(30));
-    repo.cleanup();
 }
 
 #[cfg(unix)]
@@ -410,8 +400,7 @@ fn wait_until_gone(path: &Path, timeout: Duration) {
 /// session-start digest must become an actionable version-skew notice instead of going silent.
 #[test]
 fn session_start_warns_when_the_index_schema_is_newer() {
-    let dir = std::env::temp_dir().join(format!("ragrat-hook-newer-schema-{}", std::process::id()));
-    let _ = std::fs::remove_dir_all(&dir);
+    let dir = unique_dir("hook-newer-schema");
     std::fs::create_dir_all(dir.join("src")).unwrap();
     std::fs::write(dir.join("src/lib.rs"), "pub fn skew_probe() {}\n").unwrap();
     std::fs::write(
@@ -433,7 +422,7 @@ fn session_start_warns_when_the_index_schema_is_newer() {
     drop(conn);
 
     let input = serde_json::json!({
-        "session_id": "s-skew", "cwd": dir, "hook_event_name": "SessionStart",
+        "session_id": "s-skew", "cwd": dir.as_path(), "hook_event_name": "SessionStart",
         "source": "startup"
     });
     let (stdout, status) = run_hook(&input.to_string(), &dir);
@@ -442,6 +431,4 @@ fn session_start_warns_when_the_index_schema_is_newer() {
         stdout.contains("newer rag-rat") && stdout.contains("upgrade rag-rat"),
         "expected an actionable version-skew notice, got: {stdout:?}"
     );
-
-    let _ = std::fs::remove_dir_all(&dir);
 }

--- a/crates/rag-rat-cli/tests/common/mod.rs
+++ b/crates/rag-rat-cli/tests/common/mod.rs
@@ -30,12 +30,48 @@ fn next_seq() -> u64 {
     SEQ.fetch_add(1, Ordering::Relaxed)
 }
 
+/// One uniquely owned scratch directory, removed on drop — panics and early returns included.
+///
+/// Wraps [`rag_rat_base::test_scratch::ScratchDir`] (tag + PID + process-wide sequence naming, the
+/// #726 stale sweep as backstop) and derefs to `PathBuf`, so call sites use it exactly like the
+/// bare path this replaces. The path itself is left ABSENT (any stale dir removed, nothing
+/// created): fixtures create it — or, for `git worktree add` destinations, keep it absent —
+/// exactly as before. The guard is deliberately not cloneable: exactly one owner removes each
+/// path. Bind it for the whole test (never `unique_dir(..).join(..)` in one expression, which
+/// drops the guard at the statement boundary), and declare it before any DB connection, watcher,
+/// or child process using the path so those drop first (required for cleanup on Windows).
+#[derive(Debug)]
+pub struct ScratchRoot {
+    path: PathBuf,
+    _scratch: rag_rat_base::test_scratch::ScratchDir,
+}
+
+impl std::ops::Deref for ScratchRoot {
+    type Target = PathBuf;
+
+    fn deref(&self) -> &Self::Target {
+        &self.path
+    }
+}
+
+impl AsRef<Path> for &ScratchRoot {
+    fn as_ref(&self) -> &Path {
+        &self.path
+    }
+}
+
 /// A throwaway scratch dir under the shared, self-healing test-scratch root
-/// (see [`rag_rat_base::test_scratch`]), keyed by `tag`, the process id, and a unique counter. Any
-/// stale dir at the path is removed first, and the shared helper sweeps dirs stranded by a
-/// killed/panicking run so they can't accumulate in the system temp (#726).
-pub fn unique_dir(tag: &str) -> PathBuf {
-    rag_rat_base::test_scratch::scratch_dir(tag)
+/// (see [`rag_rat_base::test_scratch`]), keyed by `tag`, the process id, and a unique counter,
+/// returned as its owning [`ScratchRoot`] guard. The path is ABSENT on return (any stale dir at
+/// the path is removed first); the guard removes whatever the test leaves there on drop, and the
+/// shared helper sweeps dirs stranded by a killed run so they can't accumulate in the system
+/// temp (#586, #726).
+pub fn unique_dir(tag: &str) -> ScratchRoot {
+    let scratch = rag_rat_base::test_scratch::ScratchDir::new(tag);
+    let path = scratch.path().to_path_buf();
+    // Fixtures historically allocate an absent path, including Git worktree destinations.
+    let _ = std::fs::remove_dir_all(&path);
+    ScratchRoot { path, _scratch: scratch }
 }
 
 /// A filesystem path formatted for embedding inside a double-quoted TOML string value. On Windows a

--- a/crates/rag-rat-cli/tests/consolidate.rs
+++ b/crates/rag-rat-cli/tests/consolidate.rs
@@ -9,12 +9,12 @@
 //! never touches a developer's real `~/.local/share/rag-rat`.
 
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::process::{Command, Output};
 
 mod common;
 
-use common::{git, git_commit, unique_dir};
+use common::{ScratchRoot, git, git_commit, unique_dir};
 
 /// A git fixture repo with one rust file and an EXPLICIT `database` key — the pre-flip `init`
 /// shape — so the initial index builds the LEGACY per-repo `.rag-rat/index.sqlite`.
@@ -26,7 +26,7 @@ use common::{git, git_commit, unique_dir};
 /// environment-flaky. The seeded heal-owed witness (a legacy model id set directly in the DB) still
 /// mismatches this `none` config, so the "consolidate must not heal a sibling's meta" assertion is
 /// unchanged — just deterministic offline.
-fn fixture_repo() -> PathBuf {
+fn fixture_repo() -> ScratchRoot {
     let root = unique_dir("repo");
     fs::create_dir_all(root.join("src")).unwrap();
     fs::write(root.join("src/lib.rs"), "pub fn consolidate_anchor() {}\n").unwrap();
@@ -128,10 +128,6 @@ fn consolidate_refuses_a_pinned_config_then_completes_after_key_removal() {
     assert!(out.status.success(), "re-run failed: {}", String::from_utf8_lossy(&out.stderr));
     let stdout = String::from_utf8_lossy(&out.stdout);
     assert!(stdout.contains("already_global"), "re-run is a no-op via the latch: {stdout}");
-
-    let _ = fs::remove_dir_all(&root);
-    let _ = fs::remove_dir_all(&data_dir);
-    let _ = fs::remove_dir_all(&model_cache);
 }
 
 /// A CUSTOM pinned `database` path gets the path-aware remedy: the refusal prints the literal move
@@ -201,10 +197,6 @@ fn consolidate_custom_pin_remedy_moves_then_imports() {
     assert!(global.exists(), "the global store now exists");
     assert!(!default_legacy.exists(), "the moved file was renamed to the marker");
     assert!(root.join(".rag-rat/index.sqlite.imported").exists(), "marker in place");
-
-    let _ = fs::remove_dir_all(&root);
-    let _ = fs::remove_dir_all(&data_dir);
-    let _ = fs::remove_dir_all(&model_cache);
 }
 
 /// Consolidating a SECOND repo into a one-repo global DB must not heal/mutate the FIRST repo's
@@ -277,11 +269,6 @@ fn consolidating_a_second_repo_leaves_the_first_repos_heal_owed_meta() {
         Some("fastembed-all-minilm-l6-v2"),
         "consolidating repo 2 healed (cleared) repo 1's model meta through the sibling witness",
     );
-
-    let _ = fs::remove_dir_all(&repo1);
-    let _ = fs::remove_dir_all(&repo2);
-    let _ = fs::remove_dir_all(&data_dir);
-    let _ = fs::remove_dir_all(&model_cache);
 }
 
 /// Guard ordering: a config still PINNED at a missing/renamed path must be REFUSED with the
@@ -317,10 +304,6 @@ fn consolidate_refuses_a_pin_at_a_missing_path_and_accepts_a_pin_at_global() {
     assert!(out.status.success(), "a pin at the global target is already_global");
     let stdout = String::from_utf8_lossy(&out.stdout);
     assert!(stdout.contains("already_global"), "pin-at-global reports already_global: {stdout}");
-
-    let _ = fs::remove_dir_all(&root);
-    let _ = fs::remove_dir_all(&data_dir);
-    let _ = fs::remove_dir_all(&model_cache);
 }
 
 /// The legacy-side lock drain covers the source DB's OWN registered ids, not just the current
@@ -369,8 +352,8 @@ fn consolidate_drains_a_pre_deepen_writers_legacy_lock() {
     let binary = env!("CARGO_BIN_EXE_rag-rat");
     let mut child = Command::new(binary)
         .current_dir(&root)
-        .env("RAG_RAT_DATA_DIR", &data_dir)
-        .env("RAG_RAT_MODEL_CACHE", &model_cache)
+        .env("RAG_RAT_DATA_DIR", &*data_dir)
+        .env("RAG_RAT_MODEL_CACHE", &*model_cache)
         .env("RAG_RAT_NO_WATCH", "1")
         .arg("consolidate")
         .spawn()
@@ -389,10 +372,6 @@ fn consolidate_drains_a_pre_deepen_writers_legacy_lock() {
         root.join(".rag-rat/index.sqlite.imported").exists(),
         "the import + rename completed after the drain"
     );
-
-    let _ = fs::remove_dir_all(&root);
-    let _ = fs::remove_dir_all(&data_dir);
-    let _ = fs::remove_dir_all(&model_cache);
 }
 
 /// OLD-VINTAGE sources (Codex batch 6): a legacy DB this binary never opened keeps its model meta
@@ -453,10 +432,6 @@ fn consolidate_migrates_an_old_vintage_source_so_model_meta_arrives() {
         Some("vintage-model"),
         "an old-vintage source's model meta must arrive with the import (ladder-relocated)",
     );
-
-    let _ = fs::remove_dir_all(&root);
-    let _ = fs::remove_dir_all(&data_dir);
-    let _ = fs::remove_dir_all(&model_cache);
 }
 
 /// Batch-7 finding 3: a config explicitly PINNED AT the global path can coexist with a lingering,
@@ -507,10 +482,6 @@ fn consolidate_imports_a_lingering_legacy_under_a_pin_at_global() {
     assert!(out.status.success(), "re-run failed: {}", String::from_utf8_lossy(&out.stderr));
     let stdout = String::from_utf8_lossy(&out.stdout);
     assert!(stdout.contains("already_global"), "the marker latches the re-run: {stdout}");
-
-    let _ = fs::remove_dir_all(&root);
-    let _ = fs::remove_dir_all(&data_dir);
-    let _ = fs::remove_dir_all(&model_cache);
 }
 
 /// The worktree dimension of consolidate (batch-7 directive): run FROM a LINKED worktree whose
@@ -569,11 +540,6 @@ fn consolidate_from_a_linked_worktree_uses_the_main_config_and_legacy() {
     let out = run(&root, &data_dir, &model_cache, &["consolidate"]);
     assert!(out.status.success());
     assert!(String::from_utf8_lossy(&out.stdout).contains("already_global"));
-
-    let _ = fs::remove_dir_all(&root);
-    let _ = fs::remove_dir_all(&linked);
-    let _ = fs::remove_dir_all(&data_dir);
-    let _ = fs::remove_dir_all(&model_cache);
 }
 
 /// Consolidation opens its target through the schema-only path, so it must explicitly run the
@@ -664,8 +630,4 @@ fn consolidate_rebuilds_stale_content_projection_before_reconcile() {
         )
         .unwrap();
     assert_eq!(stamp, "3", "consolidate upgraded the store-global projector stamp");
-
-    let _ = fs::remove_dir_all(&root);
-    let _ = fs::remove_dir_all(&data_dir);
-    let _ = fs::remove_dir_all(&model_cache);
 }

--- a/crates/rag-rat-cli/tests/doctor_file_health.rs
+++ b/crates/rag-rat-cli/tests/doctor_file_health.rs
@@ -5,20 +5,16 @@
 use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
-use std::sync::atomic::{AtomicU64, Ordering};
 
 use rag_rat_base::config::Config;
 
-static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+mod common;
 
-/// Build a throwaway index over one Rust file and return (root, config path).
-fn build_index() -> (PathBuf, PathBuf) {
-    let root = std::env::temp_dir().join(format!(
-        "rag-rat-cli-doctor-health-{}-{}",
-        std::process::id(),
-        TEMP_COUNTER.fetch_add(1, Ordering::Relaxed)
-    ));
-    let _ = fs::remove_dir_all(&root);
+use common::{ScratchRoot, unique_dir};
+
+/// Build a throwaway index over one Rust file and return (scratch guard, config path).
+fn build_index() -> (ScratchRoot, PathBuf) {
+    let root = unique_dir("doctor-health");
     fs::create_dir_all(root.join("src")).unwrap();
     fs::write(root.join("src/lib.rs"), "pub fn doctor_probe() {}\n").unwrap();
     fs::write(
@@ -35,7 +31,7 @@ fn build_index() -> (PathBuf, PathBuf) {
 
 #[test]
 fn doctor_reports_database_file_health() {
-    let (root, config_path) = build_index();
+    let (_root, config_path) = build_index();
 
     let out = Command::new(env!("CARGO_BIN_EXE_rag-rat"))
         .arg("--config")
@@ -56,6 +52,4 @@ fn doctor_reports_database_file_health() {
     assert_eq!(health["wal_oversized"], serde_json::Value::Bool(false));
     assert_eq!(health["freelist_excessive"], serde_json::Value::Bool(false));
     assert!(health["note"].is_null(), "no advisory on a healthy file: {health}");
-
-    let _ = fs::remove_dir_all(&root);
 }

--- a/crates/rag-rat-cli/tests/init_dir_selection.rs
+++ b/crates/rag-rat-cli/tests/init_dir_selection.rs
@@ -9,16 +9,11 @@
 //! shells out to `claude`/`codex` (the real `init` install flow does all of those).
 
 use std::fs;
-use std::path::PathBuf;
 use std::process::Command;
-use std::sync::atomic::{AtomicU32, Ordering};
 
-static TEMP_COUNTER: AtomicU32 = AtomicU32::new(0);
+mod common;
 
-fn unique_temp_root() -> PathBuf {
-    let id = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
-    std::env::temp_dir().join(format!("rag-rat-init-dirsel-{}-{id}", std::process::id()))
-}
+use common::unique_dir;
 
 fn write(root: &std::path::Path, rel: &str, contents: &str) {
     let path = root.join(rel);
@@ -38,7 +33,7 @@ fn init_dry_run(root: &std::path::Path) -> std::process::Output {
 
 #[test]
 fn gitignored_root_venv_does_not_drop_the_root_entrypoint() {
-    let root = unique_temp_root();
+    let root = unique_dir("init-dirsel");
     fs::create_dir_all(&root).unwrap();
     // A Django-style layout: a root `manage.py`, a real package, and a GITIGNORED virtualenv.
     write(&root, "manage.py", "def main():\n    pass\n");
@@ -57,13 +52,11 @@ fn gitignored_root_venv_does_not_drop_the_root_entrypoint() {
         "expected `.` + package binding, got:\n{rendered}"
     );
     assert!(!root.join("rag-rat.toml").exists(), "dry-run must not write a config");
-
-    fs::remove_dir_all(&root).ok();
 }
 
 #[test]
 fn non_gitignored_env_only_repo_fails_instead_of_empty_config() {
-    let root = unique_temp_root();
+    let root = unique_dir("init-dirsel");
     fs::create_dir_all(&root).unwrap();
     // The only Python lives under a NON-gitignored, unfloored `env/` virtualenv — there is no safe
     // binding, so init must fail rather than emit an empty `[target_bindings]`.
@@ -71,13 +64,11 @@ fn non_gitignored_env_only_repo_fails_instead_of_empty_config() {
 
     let output = init_dry_run(&root);
     assert!(!output.status.success(), "init should fail with no indexable source: {output:?}");
-
-    fs::remove_dir_all(&root).ok();
 }
 
 #[test]
 fn first_party_virtualenv_package_is_bindable() {
-    let root = unique_temp_root();
+    let root = unique_dir("init-dirsel");
     fs::create_dir_all(&root).unwrap();
     // The `virtualenv` PyPI package's own layout: `src/virtualenv/` is FIRST-PARTY source (no
     // `pyvenv.cfg`). It must not be treated as a dependency tree — Python stays bound.
@@ -92,13 +83,11 @@ fn first_party_virtualenv_package_is_bindable() {
         rendered.contains("python = [\"src\"]"),
         "the virtualenv package must remain a Python binding, got:\n{rendered}"
     );
-
-    fs::remove_dir_all(&root).ok();
 }
 
 #[test]
 fn nested_real_venv_does_not_promote_its_ancestor() {
-    let root = unique_temp_root();
+    let root = unique_dir("init-dirsel");
     fs::create_dir_all(&root).unwrap();
     // A real venv (has `pyvenv.cfg`) nested under `tools/`, plus a genuine package. The venv's
     // files must not count, so `tools` is never promoted and `.` is blocked; only `myapp`
@@ -117,6 +106,4 @@ fn nested_real_venv_does_not_promote_its_ancestor() {
         rendered.contains("python = [\"myapp\"]"),
         "only the real package should bind (not `.` or `tools`), got:\n{rendered}"
     );
-
-    fs::remove_dir_all(&root).ok();
 }

--- a/crates/rag-rat-cli/tests/init_yes_writes_valid_config.rs
+++ b/crates/rag-rat-cli/tests/init_yes_writes_valid_config.rs
@@ -9,14 +9,13 @@
 //! an online run resolves from cache) so the test never leaks into the developer's model cache and
 //! never depends on a specific model being present.
 
-use std::path::PathBuf;
 use std::process::Command;
 
 use rag_rat_base::config::Config;
 
 mod common;
 
-fn unique_temp_root() -> PathBuf {
+fn unique_temp_root() -> common::ScratchRoot {
     common::unique_dir("init-yes")
 }
 
@@ -64,7 +63,7 @@ fn init_yes_writes_a_config_that_config_load_accepts() {
         .env("RAG_RAT_NO_WATCH", "1")
         .env("RAG_RAT_MODEL_CACHE", &cache)
         .env("RAG_RAT_DATA_DIR", &data_dir)
-        .env("HOME", &root)
+        .env("HOME", &*root)
         .env("XDG_CACHE_HOME", &cache)
         .output()
         .expect("run rag-rat init --yes");
@@ -114,8 +113,6 @@ fn init_yes_writes_a_config_that_config_load_accepts() {
         "the SwiftPM source tree must bind a Swift target with default globs, got: {:?}",
         config.targets
     );
-
-    std::fs::remove_dir_all(&root).ok();
 }
 
 /// `init` in a NEW repo must not heal/mutate an EXISTING repo's meta in the shared global DB
@@ -147,7 +144,7 @@ fn init_in_a_new_repo_leaves_an_existing_repos_heal_owed_meta() {
             .env("RAG_RAT_NO_WATCH", "1")
             .env("RAG_RAT_MODEL_CACHE", &cache)
             .env("RAG_RAT_DATA_DIR", &data_dir)
-            .env("HOME", &base)
+            .env("HOME", &*base)
             .env("XDG_CACHE_HOME", &cache)
             .output()
             .unwrap()
@@ -201,8 +198,6 @@ fn init_in_a_new_repo_leaves_an_existing_repos_heal_owed_meta() {
         Some("fastembed-all-minilm-l6-v2"),
         "init of a new repo healed (cleared) the existing repo's model meta",
     );
-
-    std::fs::remove_dir_all(&base).ok();
 }
 
 /// Init from a SUBDIRECTORY of the normal MAIN worktree proceeds (Codex batch 8, finding 1): the
@@ -222,7 +217,7 @@ fn init_proceeds_from_a_subdirectory_of_the_main_worktree() {
         .env("RAG_RAT_HOOK_DISABLE", "1")
         .env("RAG_RAT_NO_WATCH", "1")
         .env("RAG_RAT_DATA_DIR", root.join("data"))
-        .env("HOME", &root)
+        .env("HOME", &*root)
         .output()
         .unwrap();
     let stderr = String::from_utf8_lossy(&output.stderr);
@@ -234,8 +229,6 @@ fn init_proceeds_from_a_subdirectory_of_the_main_worktree() {
         !stderr.contains("linked git worktree"),
         "no linked-worktree refusal from a main subdir: {stderr}"
     );
-
-    let _ = std::fs::remove_dir_all(&root);
 }
 
 /// Init REFUSES to run in a LINKED git worktree (batch-7 worktree audit): the governing seam in
@@ -249,13 +242,12 @@ fn init_refuses_to_run_in_a_linked_worktree() {
     std::fs::write(root.join("src/lib.rs"), "pub fn alpha() {}\n").unwrap();
     git_init(&root);
 
-    let linked =
-        root.parent().unwrap().join(format!("{}-wt", root.file_name().unwrap().to_string_lossy()));
+    let linked = common::unique_dir("init-yes-linked");
     let out = std::process::Command::new("git")
         .arg("-C")
-        .arg(&root)
+        .arg(&*root)
         .args(["worktree", "add", "--detach", "-q"])
-        .arg(&linked)
+        .arg(&*linked)
         .output()
         .unwrap();
     assert!(out.status.success(), "worktree add: {}", String::from_utf8_lossy(&out.stderr));
@@ -274,7 +266,4 @@ fn init_refuses_to_run_in_a_linked_worktree() {
         "the refusal names the main worktree path: {stderr}"
     );
     assert!(!linked.join("rag-rat.toml").exists(), "no branch-local config was written");
-
-    let _ = std::fs::remove_dir_all(&linked);
-    let _ = std::fs::remove_dir_all(&root);
 }

--- a/crates/rag-rat-cli/tests/mcp_hot_upgrade.rs
+++ b/crates/rag-rat-cli/tests/mcp_hot_upgrade.rs
@@ -13,13 +13,14 @@ use std::os::unix::fs::PermissionsExt;
 use std::os::unix::net::UnixStream;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
 use rag_rat_base::config::Config;
 use serde_json::{Value, json};
 
-static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+mod common;
+
+use common::{ScratchRoot, unique_dir};
 
 /// SIGUSR1: drain at a boundary, hand off, `exec` the new binary in place, and resume serving the
 /// same session — the next tool call succeeds with no intervening `initialize`.
@@ -54,7 +55,6 @@ fn sigusr1_hot_upgrade_resumes_session_in_place() {
     assert_eq!(reply["v"], 1, "hook socket re-binds and speaks the protocol after hot-upgrade");
 
     session.stop();
-    env.cleanup();
 }
 
 /// When the configured upgrade binary can't be `exec`'d, the process tears down and exits non-zero
@@ -71,19 +71,17 @@ fn sigusr1_exec_failure_exits_nonzero() {
     session.send_sigusr1();
     let status = session.wait_for_exit(Duration::from_secs(20));
     assert!(!status.success(), "exec failure must exit non-zero, got {status:?}");
-
-    env.cleanup();
 }
 
 struct TestEnv {
-    root: PathBuf,
+    root: ScratchRoot,
     config_path: PathBuf,
     config: Config,
 }
 
 impl TestEnv {
     fn setup() -> Self {
-        let root = unique_temp_root();
+        let root = unique_dir("hot-upgrade");
         fs::create_dir_all(root.join("docs")).unwrap();
         fs::write(root.join("docs/search.md"), "# Search\n\nSemantic recall uses sqlite.\n")
             .unwrap();
@@ -140,10 +138,6 @@ impl TestEnv {
         let stdin = child.stdin.take().unwrap();
         let reader = BufReader::new(child.stdout.take().unwrap());
         Session { child, stdin, reader, next_id: 1 }
-    }
-
-    fn cleanup(&self) {
-        let _ = fs::remove_dir_all(&self.root);
     }
 }
 
@@ -270,9 +264,4 @@ fn wait_for(path: &Path, timeout: Duration) {
         std::thread::sleep(Duration::from_millis(50));
     }
     panic!("expected {} within {timeout:?}", path.display());
-}
-
-fn unique_temp_root() -> PathBuf {
-    let id = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
-    std::env::temp_dir().join(format!("rag-rat-hot-upgrade-{}-{id}", std::process::id()))
 }

--- a/crates/rag-rat-cli/tests/mcp_stdio.rs
+++ b/crates/rag-rat-cli/tests/mcp_stdio.rs
@@ -1,17 +1,17 @@
 use std::fs;
 use std::io::{BufRead, BufReader, Write};
-use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
-use std::sync::atomic::{AtomicU64, Ordering};
 
 use rag_rat_base::config::Config;
 use serde_json::{Value, json};
 
-static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+mod common;
+
+use common::unique_dir;
 
 #[test]
 fn mcp_stdio_smoke_lists_and_calls_core_tools() {
-    let root = unique_temp_root();
+    let root = unique_dir("mcp-stdio");
     fs::create_dir_all(root.join("docs")).unwrap();
     fs::create_dir_all(root.join("src")).unwrap();
     fs::write(root.join("docs/search.md"), "# Search\n\nSemantic recall uses sqlite.\n").unwrap();
@@ -116,7 +116,6 @@ fn mcp_stdio_smoke_lists_and_calls_core_tools() {
     assert!(papertrail["evidence"].is_array());
 
     stop(child);
-    fs::remove_dir_all(root).unwrap();
 }
 
 /// A `rag-rat mcp` launched OUTSIDE any rag-rat repo (no `rag-rat.toml` at or above cwd) must NOT
@@ -126,7 +125,7 @@ fn mcp_stdio_smoke_lists_and_calls_core_tools() {
 /// dormant notice as a NON-error result, and the process stays alive across calls.
 #[test]
 fn mcp_stdio_serves_dormant_without_a_config() {
-    let root = unique_temp_root();
+    let root = unique_dir("mcp-stdio");
     // A bare directory — deliberately NO rag-rat.toml here or (temp roots have none) above it.
     fs::create_dir_all(&root).unwrap();
 
@@ -222,7 +221,6 @@ fn mcp_stdio_serves_dormant_without_a_config() {
     assert_eq!(recv(&mut reader)["id"], 5, "the dormant server stays alive across calls");
 
     stop(child);
-    fs::remove_dir_all(root).unwrap();
 }
 
 /// The dormant tool result honors `--json` mode: its text block must be directly parseable as JSON
@@ -230,7 +228,7 @@ fn mcp_stdio_serves_dormant_without_a_config() {
 /// MCP client would otherwise fail ONLY in dormant mode.
 #[test]
 fn mcp_stdio_dormant_result_is_valid_json_in_json_mode() {
-    let root = unique_temp_root();
+    let root = unique_dir("mcp-stdio");
     fs::create_dir_all(&root).unwrap();
 
     let binary = env!("CARGO_BIN_EXE_rag-rat");
@@ -272,7 +270,6 @@ fn mcp_stdio_dormant_result_is_valid_json_in_json_mode() {
     assert_eq!(parsed["status"], "no_index", "dormant JSON payload carries the no-index status");
 
     stop(child);
-    fs::remove_dir_all(root).unwrap();
 }
 
 /// Self-healing (#603): a server that started DORMANT activates its tools as soon as the directory
@@ -286,7 +283,7 @@ fn mcp_stdio_dormant_result_is_valid_json_in_json_mode() {
 /// (#603). Activation requires a restart; the smoke test covers the launched-with-config path.
 #[test]
 fn mcp_stdio_dormant_server_stays_dormant_until_restart() {
-    let root = unique_temp_root();
+    let root = unique_dir("mcp-stdio");
     fs::create_dir_all(root.join("src")).unwrap();
     fs::write(root.join("src/lib.rs"), "pub fn healed_symbol_marker() {}\n").unwrap();
 
@@ -349,7 +346,6 @@ fn mcp_stdio_dormant_server_stays_dormant_until_restart() {
     );
 
     stop(child);
-    fs::remove_dir_all(root).unwrap();
 }
 
 /// Regression guard: every tool advertised by `tools/list` (built from `TOOL_NAMES`) must be
@@ -361,7 +357,7 @@ fn mcp_stdio_dormant_server_stays_dormant_until_restart() {
 /// an argument/validation error — only an unroutable one yields "tool not found".
 #[test]
 fn mcp_stdio_every_advertised_tool_is_routable() {
-    let root = unique_temp_root();
+    let root = unique_dir("mcp-stdio");
     fs::create_dir_all(root.join("src")).unwrap();
     fs::write(root.join("src/lib.rs"), "pub fn open_database() {}\n").unwrap();
     fs::write(
@@ -430,7 +426,6 @@ fn mcp_stdio_every_advertised_tool_is_routable() {
         }
     }
     stop(child);
-    fs::remove_dir_all(root).unwrap();
 
     assert!(
         unroutable.is_empty(),
@@ -443,7 +438,7 @@ fn mcp_stdio_json_flag_emits_json_not_toon() {
     // `rag-rat mcp --json` is the MCP-side escape hatch: MCP has no per-call flag, so the output
     // format is chosen once at launch. With it, tool results are JSON (parseable directly), not the
     // default TOON (which `serde_json::from_str` would reject).
-    let root = unique_temp_root();
+    let root = unique_dir("mcp-stdio");
     fs::create_dir_all(root.join("src")).unwrap();
     fs::write(root.join("src/lib.rs"), "pub fn open_database() {}\n").unwrap();
     fs::write(
@@ -499,7 +494,6 @@ fn mcp_stdio_json_flag_emits_json_not_toon() {
     assert!(parsed.is_array() || parsed.is_object(), "expected a JSON array/object, got: {text}");
 
     stop(child);
-    fs::remove_dir_all(root).unwrap();
 }
 
 fn send(stdin: &mut impl Write, value: Value) {
@@ -527,14 +521,9 @@ fn stop(mut child: Child) {
     let _ = child.wait();
 }
 
-fn unique_temp_root() -> PathBuf {
-    let id = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
-    std::env::temp_dir().join(format!("rag-rat-mcp-stdio-test-{}-{id}", std::process::id()))
-}
-
 #[test]
 fn mcp_stdio_find_clones_returns_class_for_planted_pair() {
-    let root = unique_temp_root();
+    let root = unique_dir("mcp-stdio");
     fs::create_dir_all(root.join("src")).unwrap();
     // Two identical functions → struct_hash fast path produces a clone pair.
     let clone_body = "pub fn cloned_helper(x: i32, y: i32) -> i32 {\n    x + y + 42\n}\n";
@@ -598,7 +587,6 @@ fn mcp_stdio_find_clones_returns_class_for_planted_pair() {
     );
 
     stop(child);
-    fs::remove_dir_all(root).unwrap();
 }
 
 /// End-to-end (#215 Plan 4b Task 8): a Type-2 clone pair — two functions whose ONLY difference is
@@ -610,7 +598,7 @@ fn mcp_stdio_find_clones_returns_class_for_planted_pair() {
 /// candidate pair that refines to a `value_param` variation point. Uses `--json` for plain JSON.
 #[test]
 fn mcp_stdio_find_clones_returns_refined_payload_for_type2_clone() {
-    let root = unique_temp_root();
+    let root = unique_dir("mcp-stdio");
     fs::create_dir_all(root.join("src")).unwrap();
     // Two functions differing ONLY in the literal KIND (int 10 vs float 2.5). Baseline
     // normalization buckets literals by kind (`LIT_INTEGER_LITERAL` vs `LIT_FLOAT_LITERAL`), so the
@@ -712,7 +700,6 @@ fn mcp_stdio_find_clones_returns_refined_payload_for_type2_clone() {
     );
 
     stop(child);
-    fs::remove_dir_all(root).unwrap();
 }
 
 /// CLI surface (#215 Plan 4b Task 8): `rag-rat clones --explain <CLASS_KEY>` prints the refined
@@ -721,7 +708,7 @@ fn mcp_stdio_find_clones_returns_refined_payload_for_type2_clone() {
 /// `--explain <key>` and assert the human output names a metavar (`m0`) and the value_param role.
 #[test]
 fn cli_clones_explain_prints_template_and_metavar_for_type2_clone() {
-    let root = unique_temp_root();
+    let root = unique_dir("mcp-stdio");
     fs::create_dir_all(root.join("src")).unwrap();
     // Same Type-2 fixture as the MCP refined-payload test: bodies identical except a differing
     // literal KIND (int 10 vs float 2.5), which is what forces a value_param variation point.
@@ -827,6 +814,4 @@ fn cli_clones_explain_prints_template_and_metavar_for_type2_clone() {
         "explain output must zip per-member values with member identity (identity=value | \
          identity=value):\n{out}"
     );
-
-    fs::remove_dir_all(root).unwrap();
 }

--- a/crates/rag-rat-cli/tests/multi_repo_e2e.rs
+++ b/crates/rag-rat-cli/tests/multi_repo_e2e.rs
@@ -45,7 +45,7 @@ mod common;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 
-use common::{git, git_commit, unique_dir};
+use common::{ScratchRoot, git, git_commit, unique_dir};
 use rag_rat_base::config::Config;
 use rag_rat_base::language::Language;
 use rag_rat_core::IndexDatabase;
@@ -66,13 +66,13 @@ fn chunky_fn(name: &str) -> String {
 /// global store) plus the given `src/<name>` files. `.rag-rat/`, `rag-rat-lib.toml`, and
 /// `target/` are gitignored so the working tree stays clean (untracked helper files must not flip
 /// the indexer's dirty accounting).
-fn keyless_repo(tag: &str, files: &[(&str, String)]) -> PathBuf {
+fn keyless_repo(tag: &str, files: &[(&str, String)]) -> ScratchRoot {
     build_repo(tag, files, "[index]\nroot = \".\"\n\n[target_bindings]\nrust = [\"src\"]\n")
 }
 
 /// A committed git repo whose `rag-rat.toml` PINS the legacy per-repo `.rag-rat/index.sqlite` — the
 /// pre-flip shape `consolidate` imports from.
-fn legacy_pinned_repo(tag: &str, files: &[(&str, String)]) -> PathBuf {
+fn legacy_pinned_repo(tag: &str, files: &[(&str, String)]) -> ScratchRoot {
     build_repo(
         tag,
         files,
@@ -81,7 +81,7 @@ fn legacy_pinned_repo(tag: &str, files: &[(&str, String)]) -> PathBuf {
     )
 }
 
-fn build_repo(tag: &str, files: &[(&str, String)], config: &str) -> PathBuf {
+fn build_repo(tag: &str, files: &[(&str, String)], config: &str) -> ScratchRoot {
     let root = unique_dir(tag);
     std::fs::create_dir_all(root.join("src")).unwrap();
     for (name, body) in files {
@@ -352,12 +352,6 @@ fn ref_memory(title: &str, gone_path: &str, bind_path: &str) -> RepoMemoryCreate
     }
 }
 
-fn cleanup(dirs: &[&Path]) {
-    for d in dirs {
-        let _ = std::fs::remove_dir_all(d);
-    }
-}
-
 // ---------------------------------------------------------------------------------------------
 // Case 0: the fixture-identity guarantee the whole matrix rests on — two BYTE-IDENTICAL repos
 // still register as two DISTINCT repo_ids in one global DB (the #435 helper closes #434).
@@ -394,8 +388,6 @@ fn identical_content_fixtures_get_distinct_repo_ids() {
         2,
         "two identical-content repos register as TWO distinct repo_ids in one global DB"
     );
-
-    cleanup(&[&repo_a, &repo_b, &data_dir, &cache]);
 }
 
 // ---------------------------------------------------------------------------------------------
@@ -489,8 +481,6 @@ fn search_symbol_and_impact_are_repo_scoped() {
     );
     let b_impact = open_scoped(&repo_b, &data_dir).impact_surface("alpha_target", 30).unwrap();
     assert!(b_impact.is_empty(), "impact for A's symbol, scoped to B, sees nothing: {b_impact:?}");
-
-    cleanup(&[&repo_a, &repo_b, &data_dir, &cache]);
 }
 
 // ---------------------------------------------------------------------------------------------
@@ -606,8 +596,6 @@ fn memories_are_isolated_across_repos() {
         b_doc.iter().all(|e| e.anchor_status != "gone"),
         "doctor B never touches or flags A's gone anchor: {b_doc:?}"
     );
-
-    cleanup(&[&repo_a, &repo_b, &data_dir, &cache]);
 }
 
 // ---------------------------------------------------------------------------------------------
@@ -680,8 +668,6 @@ fn clones_are_repo_scoped() {
         !b_recall.contains("dup_a1.rs") && !b_recall.contains("clone_alpha"),
         "B's clone listing never contains A's members:\n{b_recall}"
     );
-
-    cleanup(&[&repo_a, &repo_b, &data_dir, &cache]);
 }
 
 // ---------------------------------------------------------------------------------------------
@@ -746,8 +732,6 @@ fn gc_of_one_repo_leaves_the_other_intact_and_reports_per_repo() {
     // Repo B is byte-identical — parents AND children (row-count parity across every scoped table).
     let b_after = repo_snapshot(&data_dir, &b_id);
     assert_eq!(b_before, b_after, "gc of A left every one of B's scoped tables untouched");
-
-    cleanup(&[&repo_a, &repo_b, &data_dir, &cache]);
 }
 
 // ---------------------------------------------------------------------------------------------
@@ -839,8 +823,6 @@ fn consolidate_lands_a_third_legacy_repos_memories_fts_searchable() {
             .is_empty(),
         "repo B cannot see C's imported memory"
     );
-
-    cleanup(&[&repo_a, &repo_b, &repo_c, &data_dir, &cache]);
 }
 
 // ---------------------------------------------------------------------------------------------
@@ -876,8 +858,8 @@ fn concurrent_index_of_a_and_write_on_b_are_lock_disjoint() {
     // With B's lock held, run a full rebuild of A as a subprocess. A takes A's OWN flock.
     let mut child = Command::new(env!("CARGO_BIN_EXE_rag-rat"))
         .current_dir(&repo_a)
-        .env("RAG_RAT_DATA_DIR", &data_dir)
-        .env("RAG_RAT_MODEL_CACHE", &cache)
+        .env("RAG_RAT_DATA_DIR", &*data_dir)
+        .env("RAG_RAT_MODEL_CACHE", &*cache)
         .env("RAG_RAT_NO_WATCH", "1")
         .env("RAG_RAT_HOOK_DISABLE", "1")
         .args(["index", "--full"])
@@ -926,8 +908,6 @@ fn concurrent_index_of_a_and_write_on_b_are_lock_disjoint() {
         .unwrap();
     assert_eq!(b_mems, 6, "all of B's concurrent memory writes completed");
     assert_eq!(live_file_count(&data_dir, &a_id), 8, "A's rebuild republished all its files");
-
-    cleanup(&[&repo_a, &repo_b, &data_dir, &cache]);
 }
 
 // ---------------------------------------------------------------------------------------------
@@ -1048,8 +1028,6 @@ fn linked_worktree_resolves_through_main_config() {
         init_err.to_lowercase().contains("linked") || init_err.contains("main"),
         "init's refusal points at the main worktree: {init_err}"
     );
-
-    cleanup(&[&main, &linked, &data_dir, &cache]);
 }
 
 // ---------------------------------------------------------------------------------------------
@@ -1155,8 +1133,6 @@ fn dream_worklist_is_repo_scoped_end_to_end() {
         a_ids.iter().all(|id| !b_ids.contains(id)),
         "no dream finding id is shared across repos"
     );
-
-    cleanup(&[&repo_a, &repo_b, &data_dir, &cache]);
 }
 
 #[test]
@@ -1194,6 +1170,4 @@ fn dream_ephemeral_zero_work_guard_skips_cli_provisioning() {
         stderr.contains("skipping the ephemeral `[llm.dream.remote]` GPU box"),
         "expected the CLI zero-work guard note, got stderr:\n{stderr}"
     );
-
-    cleanup(&[&repo, &data_dir, &cache]);
 }

--- a/crates/rag-rat-cli/tests/output_format.rs
+++ b/crates/rag-rat-cli/tests/output_format.rs
@@ -6,25 +6,17 @@
 use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
-use std::sync::atomic::{AtomicU64, Ordering};
 
 use rag_rat_base::config::Config;
 
-static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+mod common;
 
-fn unique_temp_root() -> PathBuf {
-    let root = std::env::temp_dir().join(format!(
-        "rag-rat-cli-output-{}-{}",
-        std::process::id(),
-        TEMP_COUNTER.fetch_add(1, Ordering::Relaxed)
-    ));
-    let _ = fs::remove_dir_all(&root);
-    root
-}
+use common::{ScratchRoot, unique_dir};
 
-/// Build a throwaway index over one Rust file and return the config path the CLI should use.
-fn build_index() -> (PathBuf, PathBuf) {
-    let root = unique_temp_root();
+/// Build a throwaway index over one Rust file and return the scratch guard + the config path the
+/// CLI should use.
+fn build_index() -> (ScratchRoot, PathBuf) {
+    let root = unique_dir("cli-output");
     fs::create_dir_all(root.join("src")).unwrap();
     fs::write(root.join("src/lib.rs"), "pub fn open_database() {}\npub fn close_database() {}\n")
         .unwrap();
@@ -56,7 +48,7 @@ fn run(config_path: &PathBuf, json: bool, args: &[&str]) -> String {
 
 #[test]
 fn cli_defaults_to_toon_and_json_flag_flips_to_json() {
-    let (root, config_path) = build_index();
+    let (_root, config_path) = build_index();
 
     // Default: TOON. The hit list renders as a TOON object — and is NOT parseable as JSON (TOON's
     // bare-key / tabular form is not a JSON document), which is the strongest single signal that
@@ -72,8 +64,6 @@ fn cli_defaults_to_toon_and_json_flag_flips_to_json() {
     let parsed: serde_json::Value = serde_json::from_str(&json)
         .unwrap_or_else(|err| panic!("--json output is not valid JSON ({err}):\n{json}"));
     assert!(parsed.is_object() || parsed.is_array(), "unexpected JSON shape:\n{json}");
-
-    let _ = fs::remove_dir_all(&root);
 }
 
 /// Every read command that prints structured output through `print_output` must honor the global
@@ -81,7 +71,7 @@ fn cli_defaults_to_toon_and_json_flag_flips_to_json() {
 /// per-handler output branches (`doctor`/`brief`/`clusters`) the format flag threads through.
 #[test]
 fn read_commands_honor_global_format() {
-    let (root, config_path) = build_index();
+    let (_root, config_path) = build_index();
     for args in [&["doctor"][..], &["brief"][..], &["clusters"][..]] {
         let toon = run(&config_path, false, args);
         assert!(
@@ -92,17 +82,15 @@ fn read_commands_honor_global_format() {
         serde_json::from_str::<serde_json::Value>(&json)
             .unwrap_or_else(|err| panic!("`{args:?} --json` is not valid JSON ({err}):\n{json}"));
     }
-    let _ = fs::remove_dir_all(&root);
 }
 
 /// `memory list` println'd human text and ignored `--json` before this change; under `--json` it
 /// must emit the structured list (here an empty index → a JSON array).
 #[test]
 fn memory_list_json_flag_emits_json() {
-    let (root, config_path) = build_index();
+    let (_root, config_path) = build_index();
     let json = run(&config_path, true, &["memory", "list"]);
     let parsed: serde_json::Value = serde_json::from_str(&json)
         .unwrap_or_else(|err| panic!("`memory list --json` is not valid JSON ({err}):\n{json}"));
     assert!(parsed.is_array(), "expected a JSON array of memory summaries, got:\n{json}");
-    let _ = fs::remove_dir_all(&root);
 }

--- a/crates/rag-rat-cli/tests/worktree_git_env.rs
+++ b/crates/rag-rat-cli/tests/worktree_git_env.rs
@@ -84,8 +84,6 @@ fn worktree_overlay_ignores_inherited_git_dir_env() {
         "an inherited worktree GIT_DIR hijacked resolution and pruned the overlay (reinf.rs \
          missing)"
     );
-
-    let _ = fs::remove_dir_all(&base);
 }
 
 /// The DISCOVERY side of the governing seam (Codex batch 9): a linked worktree with no
@@ -154,6 +152,4 @@ fn default_config_discovery_reaches_the_main_worktree_from_a_linked_checkout() {
         "a read command from the linked checkout works too: {}",
         String::from_utf8_lossy(&out.stderr)
     );
-
-    let _ = fs::remove_dir_all(&base);
 }


### PR DESCRIPTION
## Summary
- `tests/common::unique_dir()` now returns a non-cloneable `ScratchRoot` guard (wrapping `ScratchDir`, deref to `PathBuf`, absent-path contract preserved for `git worktree add` destinations), so all 51 call sites across `consolidate`, `multi_repo_e2e`, `worktree_git_env`, and `init_yes_writes_valid_config` clean up on panic and early return
- migrate the local `unique_temp_root()` helpers in `mcp_stdio`, `mcp_hot_upgrade`, `output_format`, `doctor_file_health`, and `init_dir_selection` plus the direct `temp_dir().join` fixtures in `agent_hook_e2e` (three of which never cleaned up at all)
- `TestRepo`/`TestEnv` fixtures hold the guard instead of hand-rolled `cleanup()`; the unguarded sibling worktree path in the init linked-worktree refusal test gets its own guard
- delete the trailing `remove_dir_all` lines; drop covers every exit path

## Verification
- `cargo check -p rag-rat --tests`
- `cargo clippy -p rag-rat --tests -- -D warnings`
- `cargo +nightly fmt --all --check`
- `cargo nextest run -p rag-rat` over all 10 affected integration binaries (54 passed) under an isolated `TMPDIR`; the scratch namespace contained no fixture directories after the run
- `git diff --check`

Part of #586.