### PR TITLE
fix(tests): retain core unit-test scratch cleanup guards

### DIFF
--- a/crates/rag-rat-base/src/test_scratch.rs
+++ b/crates/rag-rat-base/src/test_scratch.rs
@@ -348,6 +348,16 @@ impl AsRef<Path> for ScratchDir {
     }
 }
 
+/// Path ergonomics for fixtures: `scratch.join(...)`, `scratch.canonicalize()`, and `&scratch`
+/// where a `&Path` is expected all work directly on the guarded directory.
+impl std::ops::Deref for ScratchDir {
+    type Target = Path;
+
+    fn deref(&self) -> &Self::Target {
+        self.path()
+    }
+}
+
 impl Drop for ScratchDir {
     fn drop(&mut self) {
         let _ = std::fs::remove_dir_all(&self.path);

--- a/crates/rag-rat-core/src/distill/extract.rs
+++ b/crates/rag-rat-core/src/distill/extract.rs
@@ -2257,13 +2257,8 @@ mod tests {
     /// changed_path)`. The merge's first-parent diff touches `changed_path` (added on the merged
     /// branch), while a real merge carries NO per-file numstat — exactly the shape the history
     /// index stores no `git_file_changes` rows for.
-    fn build_merge_repo() -> (std::path::PathBuf, String, String) {
-        use std::sync::atomic::{AtomicU64, Ordering};
-        static COUNTER: AtomicU64 = AtomicU64::new(0);
-        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
-        let root =
-            std::env::temp_dir().join(format!("ragrat-distill-merge-{}-{id}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&root);
+    fn build_merge_repo() -> (rag_rat_base::test_scratch::ScratchDir, String, String) {
+        let root = rag_rat_base::test_scratch::ScratchDir::new("distill-merge");
         std::fs::create_dir_all(root.join("src")).unwrap();
         let git = |args: &[&str]| {
             let status =
@@ -2356,8 +2351,6 @@ mod tests {
             0,
             "no repo handle → no fallback → no anchors from a merge with no git_file_changes rows"
         );
-
-        let _ = std::fs::remove_dir_all(root);
     }
 
     #[test]
@@ -2415,8 +2408,6 @@ mod tests {
             0,
             "no repo handle → best-effort empty diff snapshot"
         );
-
-        let _ = std::fs::remove_dir_all(root);
     }
 
     #[test]
@@ -2484,8 +2475,6 @@ mod tests {
             1,
             "a later repo-backed pass heals the missing diff rows"
         );
-
-        let _ = std::fs::remove_dir_all(root);
     }
 
     #[test]
@@ -2493,9 +2482,8 @@ mod tests {
         // At a shallow boundary the parent id is recorded but the object is absent; that is NOT a
         // root commit. Diffing against the empty tree would snapshot every repo file as added.
         let (root, merge_sha, path) = build_merge_repo();
-        let shallow =
-            std::env::temp_dir().join(format!("ragrat-distill-shallow-{}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&shallow);
+        // `git clone` into the guard's fresh, empty directory.
+        let shallow = rag_rat_base::test_scratch::ScratchDir::new("distill-shallow");
         let status = std::process::Command::new("git")
             .args([
                 "clone",
@@ -2530,20 +2518,12 @@ mod tests {
             0,
             "a missing parent skips the commit — never a full-tree 'everything added' patch"
         );
-
-        let _ = std::fs::remove_dir_all(root);
-        let _ = std::fs::remove_dir_all(shallow);
     }
 
     /// Build a throwaway repo whose HEAD fix commit modifies `src/widget.rs` and adds a >1MiB
     /// `src/big.rs`, returning `(root, fix_sha)`.
-    fn build_big_blob_repo() -> (std::path::PathBuf, String) {
-        use std::sync::atomic::{AtomicU64, Ordering};
-        static COUNTER: AtomicU64 = AtomicU64::new(0);
-        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
-        let root =
-            std::env::temp_dir().join(format!("ragrat-distill-big-{}-{id}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&root);
+    fn build_big_blob_repo() -> (rag_rat_base::test_scratch::ScratchDir, String) {
+        let root = rag_rat_base::test_scratch::ScratchDir::new("distill-big");
         std::fs::create_dir_all(root.join("src")).unwrap();
         let git = |args: &[&str]| {
             let status =
@@ -2591,8 +2571,6 @@ mod tests {
             vec!["src/widget.rs".to_string()],
             "the small patch renders; the >1MiB blob is skipped before any full diff"
         );
-
-        let _ = std::fs::remove_dir_all(root);
     }
 
     /// Seed one outbound ref row the mirror sync would have mined from `source_text`'s item body.
@@ -2777,13 +2755,8 @@ mod tests {
 
     /// Build a throwaway repo whose HEAD fix commit DELETES `src/gone.rs` (added in the base
     /// commit), returning `(root, fix_sha, path)`.
-    fn build_delete_repo() -> (std::path::PathBuf, String, String) {
-        use std::sync::atomic::{AtomicU64, Ordering};
-        static COUNTER: AtomicU64 = AtomicU64::new(0);
-        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
-        let root =
-            std::env::temp_dir().join(format!("ragrat-distill-del-{}-{id}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&root);
+    fn build_delete_repo() -> (rag_rat_base::test_scratch::ScratchDir, String, String) {
+        let root = rag_rat_base::test_scratch::ScratchDir::new("distill-del");
         std::fs::create_dir_all(root.join("src")).unwrap();
         let git = |args: &[&str]| {
             let status =
@@ -2833,8 +2806,6 @@ mod tests {
         );
         assert!(patch.contains("+++ /dev/null"), "a deleted file diffs TO /dev/null: {patch}");
         assert!(patch.contains("-fn gone() {}"), "the removed line renders: {patch}");
-
-        let _ = std::fs::remove_dir_all(root);
     }
 
     #[test]

--- a/crates/rag-rat-core/src/index/ai/reconcile/manifest.rs
+++ b/crates/rag-rat-core/src/index/ai/reconcile/manifest.rs
@@ -188,9 +188,7 @@ mod manifest_idempotence_tests {
     // write lock) once the manifest is current, or every read tool serializes on the SQLite writer.
     #[test]
     fn ensure_model_manifest_does_not_write_when_already_current() {
-        let dir = std::env::temp_dir().join(format!("ragrat-manifest-{}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir_all(&dir).unwrap();
+        let dir = rag_rat_base::test_scratch::ScratchDir::new("manifest");
         let db = dir.join("index.db");
 
         // First open establishes the manifest (a write); afterward the read-only check sees it.
@@ -230,7 +228,5 @@ mod manifest_idempotence_tests {
                 "a lingering legacy model must require a manifest write"
             );
         }
-
-        std::fs::remove_dir_all(&dir).ok();
     }
 }

--- a/crates/rag-rat-core/src/index/consolidate.rs
+++ b/crates/rag-rat-core/src/index/consolidate.rs
@@ -2287,10 +2287,7 @@ mod tests {
     /// the pinned BUSY posture.
     #[test]
     fn wal_sidecars_travel_with_the_imported_archive() {
-        let dir =
-            std::env::temp_dir().join(format!("ragrat-sidecars-{}-{:p}", std::process::id(), &()));
-        let _ = fs::remove_dir_all(&dir);
-        fs::create_dir_all(&dir).unwrap();
+        let dir = rag_rat_base::test_scratch::ScratchDir::new("sidecars");
         let source = dir.join("index.sqlite");
         let imported = imported_marker(&source);
         // Simulate the post-rename state with LEFTOVER sidecars (incl. an un-checkpointed wal).
@@ -2311,7 +2308,6 @@ mod tests {
                 "the {suffix} sidecar travelled with the archive"
             );
         }
-        let _ = fs::remove_dir_all(&dir);
     }
 
     /// The pinned-`database` refusal is PATH-AWARE: a pin at the default legacy path needs only

--- a/crates/rag-rat-core/src/index/discovery.rs
+++ b/crates/rag-rat-core/src/index/discovery.rs
@@ -248,8 +248,6 @@ pub(crate) fn target_for_path(
 
 #[cfg(test)]
 mod tests {
-    use std::sync::atomic::{AtomicU64, Ordering};
-
     use rag_rat_base::language::Language;
 
     use super::*;
@@ -258,10 +256,7 @@ mod tests {
     fn h_resolves_to_cpp_when_both_c_and_cpp_bindings_cover_it() {
         // Both bindings claim `.h`; the `cpp` upgrade must win it (the deliberate intent), while a
         // `.c` stays C and a `.cpp` stays C++.
-        static N: AtomicU64 = AtomicU64::new(0);
-        let id = N.fetch_add(1, Ordering::Relaxed);
-        let root = std::env::temp_dir().join(format!("ragrat-disc-{}-{id}", std::process::id()));
-        std::fs::create_dir_all(&root).unwrap();
+        let root = rag_rat_base::test_scratch::ScratchDir::new("disc");
         std::fs::write(
             root.join("rag-rat.toml"),
             "[index]\nroot = \".\"\n[target_bindings]\nc = [\".\"]\ncpp = [\".\"]\n",
@@ -277,7 +272,5 @@ mod tests {
         );
         // A non-code file resolves to nothing.
         assert_eq!(target_for_path(&config, Path::new("README")), None);
-
-        let _ = std::fs::remove_dir_all(&root);
     }
 }

--- a/crates/rag-rat-core/src/index/edges/imports.rs
+++ b/crates/rag-rat-core/src/index/edges/imports.rs
@@ -852,8 +852,7 @@ mod tests {
 
     #[test]
     fn local_crate_roots_scans_workspace_manifests() {
-        let dir = std::env::temp_dir().join(format!("rr-crate-roots-{}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&dir);
+        let dir = rag_rat_base::test_scratch::ScratchDir::new("rr-crate-roots");
         std::fs::create_dir_all(dir.join("crates/foo-bar/src")).unwrap();
         std::fs::write(
             dir.join("Cargo.toml"),
@@ -866,7 +865,6 @@ mod tests {
             .unwrap();
         std::fs::write(dir.join("crates/foo-bar/src/lib.rs"), "").unwrap();
         let roots = scan_packages(&dir).0;
-        let _ = std::fs::remove_dir_all(&dir);
         assert!(roots.contains("cargo"), "top package; got {roots:?}");
         assert!(roots.contains("foo_bar"), "hyphen→underscore normalized; got {roots:?}");
     }
@@ -876,8 +874,7 @@ mod tests {
     /// treated as local. A LIBRARY member (autodiscovered `src/lib.rs` or explicit `[lib]`) does.
     #[test]
     fn local_crate_roots_skips_bin_only_packages() {
-        let dir = std::env::temp_dir().join(format!("rr-bin-only-{}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&dir);
+        let dir = rag_rat_base::test_scratch::ScratchDir::new("rr-bin-only");
         std::fs::create_dir_all(dir.join("tool/src")).unwrap();
         std::fs::write(dir.join("tool/Cargo.toml"), "[package]\nname=\"clap\"\n").unwrap();
         std::fs::write(dir.join("tool/src/main.rs"), "fn main() {}").unwrap();
@@ -892,7 +889,6 @@ mod tests {
         )
         .unwrap();
         let roots = scan_packages(&dir).0;
-        let _ = std::fs::remove_dir_all(&dir);
         assert!(
             !roots.contains("clap"),
             "a bin-only package name is not a local root; got {roots:?}"
@@ -911,8 +907,7 @@ mod tests {
     /// this index, so localizing its alias would let a same-named in-corpus symbol wrongly bind.
     #[test]
     fn local_crate_roots_excludes_out_of_corpus_path_deps() {
-        let base = std::env::temp_dir().join(format!("rr-corpus-scope-{}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&base);
+        let base = rag_rat_base::test_scratch::ScratchDir::new("rr-corpus-scope");
         let root = base.join("indexed");
         std::fs::create_dir_all(base.join("sibling/src")).unwrap();
         std::fs::write(base.join("sibling/src/lib.rs"), "").unwrap();
@@ -926,7 +921,6 @@ mod tests {
         )
         .unwrap();
         let roots = scan_packages(&root).0;
-        let _ = std::fs::remove_dir_all(&base);
         assert!(
             !roots.contains("outside_alias"),
             "a path dep outside the indexed root is NOT a local root; got {roots:?}"
@@ -946,8 +940,7 @@ mod tests {
     /// source).
     #[test]
     fn scan_packages_keeps_path_dep_aliases_package_local() {
-        let root = std::env::temp_dir().join(format!("rr-scan-pkg-{}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&root);
+        let root = rag_rat_base::test_scratch::ScratchDir::new("rr-scan-pkg");
         std::fs::create_dir_all(root.join("shared/src")).unwrap();
         std::fs::write(root.join("shared/Cargo.toml"), "[package]\nname=\"shared\"\n").unwrap();
         std::fs::write(root.join("shared/src/lib.rs"), "").unwrap();
@@ -962,7 +955,6 @@ mod tests {
         std::fs::write(root.join("b/Cargo.toml"), "[package]\nname=\"b\"\n").unwrap();
         std::fs::write(root.join("b/src/lib.rs"), "").unwrap();
         let (global, packages) = scan_packages(&root);
-        let _ = std::fs::remove_dir_all(&root);
         assert!(
             global.contains("a_only"),
             "the global union includes every alias key; got {global:?}"
@@ -987,8 +979,7 @@ mod tests {
     /// resolution it was dropped as external.
     #[test]
     fn scan_packages_resolves_inherited_workspace_path_dep() {
-        let root = std::env::temp_dir().join(format!("rr-ws-inherit-{}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&root);
+        let root = rag_rat_base::test_scratch::ScratchDir::new("rr-ws-inherit");
         // Workspace root declares the path dep in [workspace.dependencies]; path is relative to the
         // workspace root dir.
         std::fs::create_dir_all(root.join("src")).unwrap();
@@ -1012,7 +1003,6 @@ mod tests {
         .unwrap();
         std::fs::write(root.join("member/src/lib.rs"), "").unwrap();
         let (global, packages) = scan_packages(&root);
-        let _ = std::fs::remove_dir_all(&root);
         assert!(
             global.contains("local"),
             "the inherited workspace path-dep alias is in the global union; got {global:?}"

--- a/crates/rag-rat-core/src/index/git_context.rs
+++ b/crates/rag-rat-core/src/index/git_context.rs
@@ -274,25 +274,26 @@ mod worktree_scope_tests {
         assert!(out.status.success(), "git {args:?}: {}", String::from_utf8_lossy(&out.stderr));
     }
 
-    fn temp_dir(tag: &str) -> PathBuf {
-        // Shared, self-healing scratch root with a startup sweep, so a panicking/killed test can't
-        // strand this dir in the system temp (#726). See `rag_rat_base::test_scratch`.
-        rag_rat_base::test_scratch::scratch_dir(&format!("ragrat-wtscope-{tag}"))
+    /// An owned scratch dir (removed on drop) plus its canonical path, which is what the git
+    /// resolution under test reports. Worktree-add destinations are also guards: the fresh empty
+    /// dir satisfies `git worktree add`, and cleanup never depends on reaching the end of the test.
+    fn temp_dir(tag: &str) -> rag_rat_base::test_scratch::ScratchDir {
+        rag_rat_base::test_scratch::ScratchDir::new(&format!("ragrat-wtscope-{tag}"))
     }
 
-    fn init_repo(tag: &str) -> PathBuf {
+    fn init_repo(tag: &str) -> (rag_rat_base::test_scratch::ScratchDir, PathBuf) {
         let dir = temp_dir(tag);
-        std::fs::create_dir_all(&dir).unwrap();
         git(&dir, &["init", "-q"]);
         std::fs::write(dir.join("a.txt"), "hello").unwrap();
         git(&dir, &["add", "."]);
         git(&dir, &["commit", "-q", "-m", "init"]);
-        dir.canonicalize().unwrap()
+        let canonical = dir.canonicalize().unwrap();
+        (dir, canonical)
     }
 
     #[test]
     fn none_is_the_base_scope() {
-        let main = init_repo("none");
+        let (_scratch, main) = init_repo("none");
         assert_eq!(resolve_worktree_scope(&main, None), resolve_git_context(&main));
     }
 
@@ -306,7 +307,7 @@ mod worktree_scope_tests {
     #[test]
     fn git_changed_paths_does_not_descend_into_ignored_directories() {
         use notify::Watcher as _;
-        let dir = init_repo("ignored-prune");
+        let (_scratch, dir) = init_repo("ignored-prune");
         std::fs::write(dir.join(".gitignore"), "vendor/\n").unwrap();
         git(&dir, &["add", ".gitignore"]);
         git(&dir, &["commit", "-q", "-m", "ignore vendor"]);
@@ -352,7 +353,7 @@ mod worktree_scope_tests {
     #[test]
     fn git_changed_paths_prunes_ignored_directories_outside_a_subdir_root() {
         use notify::Watcher as _;
-        let dir = init_repo("subdir-prune");
+        let (_scratch, dir) = init_repo("subdir-prune");
         std::fs::write(dir.join(".gitignore"), "vendor/\n").unwrap();
         std::fs::create_dir_all(dir.join("crates")).unwrap();
         std::fs::write(dir.join("crates/lib.rs"), "pub fn a() {}\n").unwrap();
@@ -390,7 +391,7 @@ mod worktree_scope_tests {
 
     #[test]
     fn linked_worktree_selects_its_overlay_on_the_base_commit() {
-        let main = init_repo("linked-main");
+        let (_scratch, main) = init_repo("linked-main");
         let linked = temp_dir("linked-wt");
         git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
         // A commit on the branch so the linked HEAD diverges from the base.
@@ -409,15 +410,15 @@ mod worktree_scope_tests {
 
     #[test]
     fn main_worktree_path_falls_back_to_base() {
-        let main = init_repo("main-fallback");
+        let (_scratch, main) = init_repo("main-fallback");
         // Passing the MAIN checkout (git_dir == common_dir) is not a linked worktree → base scope.
         assert_eq!(resolve_worktree_scope(&main, Some(&main)), resolve_git_context(&main));
     }
 
     #[test]
     fn foreign_repo_worktree_falls_back_to_base() {
-        let main = init_repo("foreign-main");
-        let other = init_repo("foreign-other");
+        let (_scratch, main) = init_repo("foreign-main");
+        let (_scratch2, other) = init_repo("foreign-other");
         let other_linked = temp_dir("foreign-linked");
         git(&other, &["worktree", "add", "-q", other_linked.to_str().unwrap()]);
         // A genuine linked worktree, but of a DIFFERENT repo (common dir differs) → base scope,
@@ -427,7 +428,7 @@ mod worktree_scope_tests {
 
     #[test]
     fn unreadable_path_falls_back_to_base() {
-        let main = init_repo("unreadable");
+        let (_scratch, main) = init_repo("unreadable");
         // The macOS bogus cwd `/` and a nonexistent path both resolve to base — no panic, no wrong
         // repo (untrusted-input guard).
         assert_eq!(resolve_worktree_scope(&main, Some(Path::new("/"))), resolve_git_context(&main));

--- a/crates/rag-rat-core/src/index/git_history/tests.rs
+++ b/crates/rag-rat-core/src/index/git_history/tests.rs
@@ -1,16 +1,12 @@
 use std::fs;
 use std::process::Command;
-use std::sync::atomic::{AtomicU64, Ordering};
 
 use super::apply::current_history_cursors_at_or_after_prepared;
 use super::read::read_history_excluding;
 use super::*;
 
-static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
-
-fn temp_root(label: &str) -> PathBuf {
-    let id = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
-    std::env::temp_dir().join(format!("ragrat-git-history-{label}-{}-{id}", std::process::id()))
+fn temp_root(label: &str) -> rag_rat_base::test_scratch::ScratchDir {
+    rag_rat_base::test_scratch::ScratchDir::new(&format!("git-history-{label}"))
 }
 
 fn run_git(root: &Path, args: &[&str]) {
@@ -37,8 +33,6 @@ fn insert_commit_row(conn: &Connection, repo_id: &str, hash: &str) {
 #[test]
 fn current_history_cursor_guard_rejects_empty_incomplete_or_wrong_scope() {
     let root = temp_root("cursor-guard");
-    let _ = fs::remove_dir_all(&root);
-    fs::create_dir_all(&root).unwrap();
     let conn = Connection::open_in_memory().unwrap();
     schema::apply(&conn, &crate::index::migration_hooks()).unwrap();
     let repo_id = "repo";
@@ -47,8 +41,11 @@ fn current_history_cursor_guard_rejects_empty_incomplete_or_wrong_scope() {
         params![repo_id],
     )
     .unwrap();
-    let repo =
-        GitRepo { worktree_root: root.clone(), head: "prepared-head".to_string(), shallow: false };
+    let repo = GitRepo {
+        worktree_root: root.to_path_buf(),
+        head: "prepared-head".to_string(),
+        shallow: false,
+    };
 
     assert!(
         current_history_cursors_at_or_after_prepared(&conn, repo_id, &root, &repo)
@@ -75,15 +72,11 @@ fn current_history_cursor_guard_rejects_empty_incomplete_or_wrong_scope() {
             .is_none(),
         "a cursor from another root cannot satisfy a stale prepared append"
     );
-
-    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
 fn read_history_excluding_reports_invalid_hidden_head() {
     let root = temp_root("invalid-hidden-head");
-    let _ = fs::remove_dir_all(&root);
-    fs::create_dir_all(&root).unwrap();
     run_git(&root, &["init"]);
     run_git(&root, &["config", "user.name", "Rag Rat"]);
     run_git(&root, &["config", "user.email", "rag@example.com"]);
@@ -95,6 +88,4 @@ fn read_history_excluding_reports_invalid_hidden_head() {
     let err = read_history_excluding(&root, &root, &head, "not-a-git-object")
         .expect_err("invalid hidden head must be reported");
     assert!(!err.to_string().is_empty());
-
-    let _ = fs::remove_dir_all(root);
 }

--- a/crates/rag-rat-core/src/index/ignore_rules.rs
+++ b/crates/rag-rat-core/src/index/ignore_rules.rs
@@ -442,7 +442,7 @@ mod tests {
 
     #[test]
     fn floor_dirs_ignored_without_any_gitignore() {
-        let tmp = tempdir();
+        let (_scratch, tmp) = tempdir();
         let m = compile(&tmp);
         assert!(m.is_ignored(&tmp.join("target"), true));
         assert!(m.is_ignored(&tmp.join("target/debug/foo.rs"), false));
@@ -452,12 +452,11 @@ mod tests {
         assert!(m.is_ignored(&tmp.join("node_modules/pkg/index.ts"), false));
         assert!(m.is_ignored(&tmp.join(".build/checkouts/Dep/Sources/Dep.swift"), false));
         assert!(!m.is_ignored(&tmp.join("src/lib.rs"), false));
-        fs::remove_dir_all(&tmp).ok();
     }
 
     #[test]
     fn python_venv_floor_dirs_ignored_but_generic_env_indexed() {
-        let tmp = tempdir();
+        let (_scratch, tmp) = tempdir();
         let m = compile(&tmp);
         // Dotted tooling trees can never be first-party import packages, so they're floored even
         // with no .gitignore (#181).
@@ -471,12 +470,11 @@ mod tests {
         assert!(!m.is_ignored(&tmp.join("src/virtualenv/__init__.py"), false));
         assert!(!m.is_ignored(&tmp.join("env/settings.py"), false));
         assert!(!m.is_ignored(&tmp.join(".env/config.py"), false));
-        fs::remove_dir_all(&tmp).ok();
     }
 
     #[test]
     fn root_gitignore_is_honored() {
-        let tmp = tempdir();
+        let (_scratch, tmp) = tempdir();
         write(&tmp.join(".gitignore"), "generated/\n*.bak\n");
         write(&tmp.join("src/lib.rs"), "fn a() {}\n");
         write(&tmp.join("generated/out.rs"), "fn b() {}\n");
@@ -486,12 +484,11 @@ mod tests {
         assert!(m.is_ignored(&tmp.join("generated/out.rs"), false), "file under gitignored dir");
         assert!(m.is_ignored(&tmp.join("src/old.bak"), false), "gitignored glob");
         assert!(!m.is_ignored(&tmp.join("src/lib.rs"), false), "non-ignored source");
-        fs::remove_dir_all(&tmp).ok();
     }
 
     #[test]
     fn nested_gitignore_scopes_to_its_subtree() {
-        let tmp = tempdir();
+        let (_scratch, tmp) = tempdir();
         // A nested gitignore ignores `vendor.rs` only under `sub/`, not at the root.
         write(&tmp.join("sub/.gitignore"), "vendor.rs\n");
         write(&tmp.join("sub/vendor.rs"), "x\n");
@@ -502,12 +499,11 @@ mod tests {
             !m.is_ignored(&tmp.join("vendor.rs"), false),
             "nested rule does NOT leak to the root",
         );
-        fs::remove_dir_all(&tmp).ok();
     }
 
     #[test]
     fn whitelist_negation_unignores() {
-        let tmp = tempdir();
+        let (_scratch, tmp) = tempdir();
         write(&tmp.join(".gitignore"), "build/\n!build/keep.rs\n");
         write(&tmp.join("build/keep.rs"), "x\n");
         write(&tmp.join("build/drop.rs"), "x\n");
@@ -518,7 +514,6 @@ mod tests {
             m.is_ignored(&tmp.join("build/keep.rs"), false),
             "floor dir beats gitignore negation"
         );
-        fs::remove_dir_all(&tmp).ok();
     }
 
     #[test]
@@ -526,14 +521,13 @@ mod tests {
         // git can re-include a file under a directory ONLY if the directory itself is whitelisted.
         // `gen/` ignored + `!gen/` re-included + `gen/skip/` re-ignored: `gen/a.rs` is back,
         // `gen/skip/b.rs` is out.
-        let tmp = tempdir();
+        let (_scratch, tmp) = tempdir();
         write(&tmp.join(".gitignore"), "gen/\n!gen/\ngen/skip/\n");
         write(&tmp.join("gen/a.rs"), "x\n");
         write(&tmp.join("gen/skip/b.rs"), "x\n");
         let m = compile(&tmp);
         assert!(!m.is_ignored(&tmp.join("gen/a.rs"), false), "re-included dir's file un-ignored");
         assert!(m.is_ignored(&tmp.join("gen/skip/b.rs"), false), "re-ignored subdir still out");
-        fs::remove_dir_all(&tmp).ok();
     }
 
     #[test]
@@ -541,7 +535,7 @@ mod tests {
         // FINDING 2: a nested `.gitignore` inside a directory ignored by an OUTER rule must NOT
         // re-include files. Git stops descending at the excluded `gen/`, so `gen/.gitignore`'s
         // `!keep.rs` is never consulted — `gen/keep.rs` stays ignored.
-        let tmp = tempdir();
+        let (_scratch, tmp) = tempdir();
         write(&tmp.join(".gitignore"), "gen/\n");
         write(&tmp.join("gen/.gitignore"), "!keep.rs\n");
         write(&tmp.join("gen/keep.rs"), "x\n");
@@ -552,7 +546,6 @@ mod tests {
             "nested negation under an ignored parent must NOT re-include",
         );
         assert!(m.is_ignored(&tmp.join("gen/drop.rs"), false), "sibling under ignored parent out");
-        fs::remove_dir_all(&tmp).ok();
     }
 
     #[test]
@@ -560,14 +553,13 @@ mod tests {
         // Distinct from the nested case: a SINGLE gitignore with `gen/` + `!gen/keep.rs` does NOT
         // re-include either, because git can't reach inside an excluded directory even from the
         // same file. Both stay ignored. (This is the git-correct behavior.)
-        let tmp = tempdir();
+        let (_scratch, tmp) = tempdir();
         write(&tmp.join(".gitignore"), "gen/\n!gen/keep.rs\n");
         write(&tmp.join("gen/keep.rs"), "x\n");
         write(&tmp.join("gen/drop.rs"), "x\n");
         let m = compile(&tmp);
         assert!(m.is_ignored(&tmp.join("gen/keep.rs"), false), "no reinclude under excluded dir");
         assert!(m.is_ignored(&tmp.join("gen/drop.rs"), false), "sibling still ignored");
-        fs::remove_dir_all(&tmp).ok();
     }
 
     #[test]
@@ -575,7 +567,8 @@ mod tests {
         // FINDING 1: the repo lives under a directory named like a floor entry (`build`). The floor
         // check must run on the path RELATIVE to the root, never on the absolute ancestors — so the
         // repo's own files are still indexed.
-        let outer = tempdir().join("build");
+        let (_scratch, outer_base) = tempdir();
+        let outer = outer_base.join("build");
         let root = outer.join("my-repo");
         write(&root.join("src/lib.rs"), "fn a() {}\n");
         write(&root.join("target/debug/built.rs"), "fn b() {}\n");
@@ -588,7 +581,6 @@ mod tests {
         assert!(m.is_ignored(&root.join("target/debug/built.rs"), false), "in-repo floor skipped");
         // A path outside the repo root is simply not governed (not ignored) by our rules.
         assert!(!m.is_ignored(&outer.join("sibling.rs"), false), "outside-root path not governed");
-        fs::remove_dir_all(outer.parent().unwrap()).ok();
     }
 
     #[test]
@@ -596,7 +588,7 @@ mod tests {
         // FINDING 3 (round 3): `config.root` is a subdirectory (`crates`) of a larger Git worktree.
         // The worktree-root `.gitignore` rules Git would apply to paths under that subdirectory
         // must be honored — files Git ignores must not be indexed.
-        let wt = tempdir();
+        let (_scratch, wt) = tempdir();
         git_init(&wt);
         // Worktree-root .gitignore ignores every `*.gen.rs` and the `vendored/` dir, repo-wide.
         write(&wt.join(".gitignore"), "*.gen.rs\nvendored/\n");
@@ -617,7 +609,6 @@ mod tests {
             m.is_ignored(&sub.join("vendored/dep.rs"), false),
             "worktree-root dir rule applies under the subdir config.root (finding 3)",
         );
-        fs::remove_dir_all(&wt).ok();
     }
 
     #[test]
@@ -626,7 +617,7 @@ mod tests {
         // not be scanned for nested `.gitignore`s. We assert by behavior: a nested `.gitignore` in
         // the sibling is never compiled, so it has no effect on classification — and, conversely, a
         // nested `.gitignore` INSIDE the target tree IS picked up.
-        let root = tempdir();
+        let (_scratch, root) = tempdir();
         // Target tree: `src`. Sibling tree: `huge` (not a target).
         write(&root.join("src/.gitignore"), "skip.rs\n");
         write(&root.join("src/skip.rs"), "x\n");
@@ -646,12 +637,11 @@ mod tests {
             !m.is_ignored(&root.join("huge/marker.rs"), false),
             "sibling outside target trees is not scanned for nested gitignores (scoping)",
         );
-        fs::remove_dir_all(&root).ok();
     }
 
     #[test]
     fn target_ancestor_gitignore_governs_nested_target_without_scanning_siblings() {
-        let root = tempdir();
+        let (_scratch, root) = tempdir();
         write(&root.join("src/.gitignore"), "generated/\n");
         write(&root.join("src/generated/lib.rs"), "x\n");
         write(&root.join("src/sibling/.gitignore"), "marker.rs\n");
@@ -666,18 +656,15 @@ mod tests {
             !m.is_ignored(&root.join("src/sibling/marker.rs"), false),
             "target ancestor compilation must not recursively scan unindexed siblings",
         );
-        fs::remove_dir_all(&root).ok();
     }
 
-    fn tempdir() -> std::path::PathBuf {
-        use std::sync::atomic::{AtomicU64, Ordering};
-        static N: AtomicU64 = AtomicU64::new(0);
-        let id = N.fetch_add(1, Ordering::Relaxed);
-        let dir = std::env::temp_dir().join(format!("ragrat-ignore-{}-{id}", std::process::id()));
-        fs::create_dir_all(&dir).unwrap();
+    fn tempdir() -> (rag_rat_base::test_scratch::ScratchDir, std::path::PathBuf) {
+        let guard = rag_rat_base::test_scratch::ScratchDir::new("ignore");
         // Canonicalize so the absolute paths we build match what worktree-root resolution returns
-        // (macOS /tmp is a symlink to /private/tmp; git reports the canonical form).
-        dir.canonicalize().unwrap_or(dir)
+        // (macOS /tmp is a symlink to /private/tmp; git reports the canonical form). The guard
+        // still removes the directory: the canonical form is the same inode.
+        let root = guard.path().canonicalize().unwrap_or_else(|_| guard.path().to_path_buf());
+        (guard, root)
     }
 
     // base_under_worktree must return the worktree root in `root`'s OWN representation even when a
@@ -688,7 +675,7 @@ mod tests {
     #[test]
     fn base_under_worktree_handles_symlinked_root_segment() {
         use std::os::unix::fs::symlink;
-        let wt = tempdir(); // canonical worktree root
+        let (_scratch, wt) = tempdir(); // canonical worktree root
         fs::create_dir_all(wt.join("a/b")).unwrap();
         // `<wt>/link` (1 component) resolves to `<wt>/a/b` (2 components) — counts differ.
         let link = wt.join("link");
@@ -701,6 +688,5 @@ mod tests {
             link.strip_prefix(base.unwrap()).is_ok(),
             "base must stay a textual prefix of root"
         );
-        let _ = fs::remove_dir_all(&wt);
     }
 }

--- a/crates/rag-rat-core/src/index/papertrail_autosync.rs
+++ b/crates/rag-rat-core/src/index/papertrail_autosync.rs
@@ -647,13 +647,15 @@ mod tests {
         assert!(FileLock::try_acquire(&stale_lock_path).unwrap().is_some());
     }
 
-    fn temp_git_repo(tag: &str) -> std::path::PathBuf {
-        let root = std::env::temp_dir().join(format!("ragrat-{tag}-{}", std::process::id()));
-        let _ = fs::remove_dir_all(&root);
-        fs::create_dir_all(&root).unwrap();
+    fn temp_git_repo(tag: &str) -> rag_rat_base::test_scratch::ScratchDir {
+        let root = rag_rat_base::test_scratch::ScratchDir::new(tag);
         let git = |args: &[&str]| {
-            let out =
-                std::process::Command::new("git").arg("-C").arg(&root).args(args).output().unwrap();
+            let out = std::process::Command::new("git")
+                .arg("-C")
+                .arg(&*root)
+                .args(args)
+                .output()
+                .unwrap();
             assert!(out.status.success(), "git {args:?}: {}", String::from_utf8_lossy(&out.stderr));
         };
         git(&["init", "-q"]);

--- a/crates/rag-rat-core/src/index/query_api/clones/of_text.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/of_text.rs
@@ -659,7 +659,9 @@ fn resolve_refs(conn: &Connection, ids: &BTreeSet<i64>) -> anyhow::Result<HashMa
 mod tests {
     use super::CloneCheckInput;
 
-    fn fixture_db(tag: &str) -> (crate::IndexDatabase, rag_rat_base::test_scratch::ScratchDir) {
+    // The guard is FIRST: pattern bindings drop right-to-left, so `let (_scratch, db)` closes the
+    // database before the directory is removed (required for cleanup on Windows).
+    fn fixture_db(tag: &str) -> (rag_rat_base::test_scratch::ScratchDir, crate::IndexDatabase) {
         let scratch = rag_rat_base::test_scratch::ScratchDir::new(&format!("of-text-{tag}"));
         let root = scratch.path();
         std::fs::create_dir_all(root.join("src")).unwrap();
@@ -695,12 +697,12 @@ mod tests {
             allow_empty: false,
         };
         let db = crate::IndexDatabase::rebuild(&config).unwrap();
-        (db, scratch)
+        (scratch, db)
     }
 
     #[test]
     fn finds_exact_clone_of_new_text() {
-        let (db, _scratch) = fixture_db("hit");
+        let (_scratch, db) = fixture_db("hit");
         let exact_text = "pub fn fetch_account(store: Db) -> i32 { let a = store.get(20); \
                           validate(a); a + 1 }\n";
         let hits = db
@@ -719,7 +721,7 @@ mod tests {
 
     #[test]
     fn batch_checks_multiple_files_and_tags_in_file() {
-        let (db, _scratch) = fixture_db("batch");
+        let (_scratch, db) = fixture_db("batch");
         let inputs = vec![
             CloneCheckInput {
                 text: "pub fn a_clone(s: Db) -> i32 { let x = s.get(1); validate(x); x + 1 }\n"
@@ -742,7 +744,7 @@ mod tests {
 
     #[test]
     fn excludes_self_file_so_in_place_edits_dont_self_flag() {
-        let (db, _scratch) = fixture_db("self");
+        let (_scratch, db) = fixture_db("self");
         // Re-write load_user IN its own file: it must NOT be reported as a clone of its indexed
         // self.
         let edited = "pub fn load_user(db: Db) -> i32 { let u = db.get(10); validate(u); u + 1 }\n";
@@ -759,7 +761,7 @@ mod tests {
 
     #[test]
     fn no_op_on_unparseable_text() {
-        let (db, _scratch) = fixture_db("noop");
+        let (_scratch, db) = fixture_db("noop");
         let none = db
             .clones_of_text(
                 "not real code !!!",
@@ -918,7 +920,7 @@ mod tests {
     /// the 2nd-connection mutations the eligibility / staleness tests need).
     fn parity_fixture(
         tag: &str,
-    ) -> (crate::IndexDatabase, rag_rat_base::test_scratch::ScratchDir, std::path::PathBuf) {
+    ) -> (rag_rat_base::test_scratch::ScratchDir, crate::IndexDatabase, std::path::PathBuf) {
         let scratch = rag_rat_base::test_scratch::ScratchDir::new(&format!("of-text-parity-{tag}"));
         let root = scratch.path();
         std::fs::create_dir_all(root.join("src")).unwrap();
@@ -975,7 +977,7 @@ mod tests {
         let db = crate::IndexDatabase::rebuild(&config).unwrap();
         assert_eq!(db.precompute_clone_graph(None).unwrap().status, "Complete");
         let db_path = root.join(".rag-rat/index.sqlite");
-        (db, scratch, db_path)
+        (scratch, db, db_path)
     }
 
     /// Run the SAME text through the postings fast path (`IndexedCorpus`) and the RAM fallback
@@ -1032,7 +1034,7 @@ mod tests {
     /// makes the fast path a pure optimization rather than a behavior change.
     #[test]
     fn fast_postings_path_equals_ram_fallback() {
-        let (db, _scratch, _path) = parity_fixture("equiv");
+        let (_scratch, db, _path) = parity_fixture("equiv");
 
         // A clone of load_user written to a NEW file → matches load_user + load_order, never the
         // #[cfg(test)] helper or the cross-language python load_user.
@@ -1080,7 +1082,7 @@ mod tests {
     #[test]
     fn indexed_fast_path_drops_stale_postings() {
         use super::CloneCorpus; // the `near_candidate_bags` trait method
-        let (db, _scratch, db_path) = parity_fixture("stale");
+        let (_scratch, db, db_path) = parity_fixture("stale");
         let conn = db.storage.connection();
         let generation = db.clone_check_indexed_generation().unwrap().unwrap();
         let corpus = super::IndexedCorpus::load(conn, generation).unwrap();
@@ -1112,7 +1114,7 @@ mod tests {
     #[test]
     fn clone_check_fast_path_eligibility_gate() {
         // Fresh + postings-complete + exactly current → eligible.
-        let (db, _scratch, db_path) = parity_fixture("elig-fresh");
+        let (_scratch, db, db_path) = parity_fixture("elig-fresh");
         assert!(
             db.clone_check_indexed_generation().unwrap().is_some(),
             "a current postings-complete generation is fast-path eligible"
@@ -1130,7 +1132,7 @@ mod tests {
         );
 
         // A postings-less (pre-feature) live generation → NOT eligible (review R2).
-        let (db2, _scratch2, db_path2) = parity_fixture("elig-pw");
+        let (_scratch2, db2, db_path2) = parity_fixture("elig-pw");
         {
             let c = rusqlite::Connection::open(&db_path2).unwrap();
             c.execute("UPDATE clone_graph_generations SET postings_written = 0", []).unwrap();
@@ -1147,7 +1149,7 @@ mod tests {
     /// would find. Overlays fall back to RAM.
     #[test]
     fn clone_check_fast_path_disabled_under_worktree_overlay() {
-        let (mut db, _scratch, _path) = parity_fixture("overlay-scope");
+        let (_scratch, mut db, _path) = parity_fixture("overlay-scope");
         assert!(
             db.clone_check_indexed_generation().unwrap().is_some(),
             "base scope (empty worktree id) is fast-path eligible"

--- a/crates/rag-rat-core/src/index/query_api/clones/of_text.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/of_text.rs
@@ -659,13 +659,9 @@ fn resolve_refs(conn: &Connection, ids: &BTreeSet<i64>) -> anyhow::Result<HashMa
 mod tests {
     use super::CloneCheckInput;
 
-    fn fixture_db(tag: &str) -> crate::IndexDatabase {
-        let root = std::env::temp_dir().join(format!(
-            "rag-rat-of-text-{tag}-{}-{}",
-            std::process::id(),
-            rag_rat_base::time::now_ms()
-        ));
-        let _ = std::fs::remove_dir_all(&root);
+    fn fixture_db(tag: &str) -> (crate::IndexDatabase, rag_rat_base::test_scratch::ScratchDir) {
+        let scratch = rag_rat_base::test_scratch::ScratchDir::new(&format!("of-text-{tag}"));
+        let root = scratch.path();
         std::fs::create_dir_all(root.join("src")).unwrap();
         std::fs::write(
             root.join("src/lib.rs"),
@@ -678,7 +674,7 @@ mod tests {
             sync: Default::default(),
             repo_id_override: None,
             database_key_pinned: true,
-            root: root.clone(),
+            root: root.to_path_buf(),
             database: root.join(".rag-rat/index.sqlite"),
             targets: vec![rag_rat_base::config::ResolvedTarget {
                 name: "rust".to_string(),
@@ -698,12 +694,13 @@ mod tests {
             source_root_reanchored_from: None,
             allow_empty: false,
         };
-        crate::IndexDatabase::rebuild(&config).unwrap()
+        let db = crate::IndexDatabase::rebuild(&config).unwrap();
+        (db, scratch)
     }
 
     #[test]
     fn finds_exact_clone_of_new_text() {
-        let db = fixture_db("hit");
+        let (db, _scratch) = fixture_db("hit");
         let exact_text = "pub fn fetch_account(store: Db) -> i32 { let a = store.get(20); \
                           validate(a); a + 1 }\n";
         let hits = db
@@ -722,7 +719,7 @@ mod tests {
 
     #[test]
     fn batch_checks_multiple_files_and_tags_in_file() {
-        let db = fixture_db("batch");
+        let (db, _scratch) = fixture_db("batch");
         let inputs = vec![
             CloneCheckInput {
                 text: "pub fn a_clone(s: Db) -> i32 { let x = s.get(1); validate(x); x + 1 }\n"
@@ -745,7 +742,7 @@ mod tests {
 
     #[test]
     fn excludes_self_file_so_in_place_edits_dont_self_flag() {
-        let db = fixture_db("self");
+        let (db, _scratch) = fixture_db("self");
         // Re-write load_user IN its own file: it must NOT be reported as a clone of its indexed
         // self.
         let edited = "pub fn load_user(db: Db) -> i32 { let u = db.get(10); validate(u); u + 1 }\n";
@@ -762,7 +759,7 @@ mod tests {
 
     #[test]
     fn no_op_on_unparseable_text() {
-        let db = fixture_db("noop");
+        let (db, _scratch) = fixture_db("noop");
         let none = db
             .clones_of_text(
                 "not real code !!!",
@@ -777,12 +774,7 @@ mod tests {
     #[test]
     fn clone_fingerprint_health_flags_stale_normalizer_version_for_reindex() {
         // Self-contained build (not `fixture_db`) so we keep the db path for the downgrade step.
-        let root = std::env::temp_dir().join(format!(
-            "rag-rat-of-text-health-{}-{}",
-            std::process::id(),
-            rag_rat_base::time::now_ms()
-        ));
-        let _ = std::fs::remove_dir_all(&root);
+        let root = rag_rat_base::test_scratch::ScratchDir::new("of-text-health");
         std::fs::create_dir_all(root.join("src")).unwrap();
         std::fs::write(
             root.join("src/lib.rs"),
@@ -796,7 +788,7 @@ mod tests {
             sync: Default::default(),
             repo_id_override: None,
             database_key_pinned: true,
-            root: root.clone(),
+            root: root.to_path_buf(),
             database: db_path.clone(),
             targets: vec![rag_rat_base::config::ResolvedTarget {
                 name: "rust".to_string(),
@@ -847,12 +839,7 @@ mod tests {
     fn excludes_indexed_tests_from_corpus_and_skips_new_test_code() {
         // #292: a real function PLUS a structurally identical helper inside a `#[cfg(test)]` module
         // (so the helper is `is_test` though it shares the real fn's body).
-        let root = std::env::temp_dir().join(format!(
-            "rag-rat-of-text-exclude-{}-{}",
-            std::process::id(),
-            rag_rat_base::time::now_ms()
-        ));
-        let _ = std::fs::remove_dir_all(&root);
+        let root = rag_rat_base::test_scratch::ScratchDir::new("of-text-exclude");
         std::fs::create_dir_all(root.join("src")).unwrap();
         std::fs::write(
             root.join("src/scoring.rs"),
@@ -868,7 +855,7 @@ mod tests {
             sync: Default::default(),
             repo_id_override: None,
             database_key_pinned: true,
-            root: root.clone(),
+            root: root.to_path_buf(),
             database: root.join(".rag-rat/index.sqlite"),
             targets: vec![rag_rat_base::config::ResolvedTarget {
                 name: "rust".to_string(),
@@ -929,13 +916,11 @@ mod tests {
     /// cross-language Python `load_user` (py/p.py, must never match a Rust check). Rebuilt AND
     /// precomputed, so a live postings-complete generation exists. Returns the db + its path (for
     /// the 2nd-connection mutations the eligibility / staleness tests need).
-    fn parity_fixture(tag: &str) -> (crate::IndexDatabase, std::path::PathBuf) {
-        let root = std::env::temp_dir().join(format!(
-            "rag-rat-of-text-parity-{tag}-{}-{}",
-            std::process::id(),
-            rag_rat_base::time::now_ms()
-        ));
-        let _ = std::fs::remove_dir_all(&root);
+    fn parity_fixture(
+        tag: &str,
+    ) -> (crate::IndexDatabase, rag_rat_base::test_scratch::ScratchDir, std::path::PathBuf) {
+        let scratch = rag_rat_base::test_scratch::ScratchDir::new(&format!("of-text-parity-{tag}"));
+        let root = scratch.path();
         std::fs::create_dir_all(root.join("src")).unwrap();
         std::fs::create_dir_all(root.join("py")).unwrap();
         std::fs::write(
@@ -971,7 +956,7 @@ mod tests {
             sync: Default::default(),
             repo_id_override: None,
             database_key_pinned: true,
-            root: root.clone(),
+            root: root.to_path_buf(),
             database: root.join(".rag-rat/index.sqlite"),
             targets: vec![
                 target("rust", rag_rat_base::language::Language::Rust, "src"),
@@ -990,7 +975,7 @@ mod tests {
         let db = crate::IndexDatabase::rebuild(&config).unwrap();
         assert_eq!(db.precompute_clone_graph(None).unwrap().status, "Complete");
         let db_path = root.join(".rag-rat/index.sqlite");
-        (db, db_path)
+        (db, scratch, db_path)
     }
 
     /// Run the SAME text through the postings fast path (`IndexedCorpus`) and the RAM fallback
@@ -1047,7 +1032,7 @@ mod tests {
     /// makes the fast path a pure optimization rather than a behavior change.
     #[test]
     fn fast_postings_path_equals_ram_fallback() {
-        let (db, _path) = parity_fixture("equiv");
+        let (db, _scratch, _path) = parity_fixture("equiv");
 
         // A clone of load_user written to a NEW file → matches load_user + load_order, never the
         // #[cfg(test)] helper or the cross-language python load_user.
@@ -1095,7 +1080,7 @@ mod tests {
     #[test]
     fn indexed_fast_path_drops_stale_postings() {
         use super::CloneCorpus; // the `near_candidate_bags` trait method
-        let (db, db_path) = parity_fixture("stale");
+        let (db, _scratch, db_path) = parity_fixture("stale");
         let conn = db.storage.connection();
         let generation = db.clone_check_indexed_generation().unwrap().unwrap();
         let corpus = super::IndexedCorpus::load(conn, generation).unwrap();
@@ -1127,7 +1112,7 @@ mod tests {
     #[test]
     fn clone_check_fast_path_eligibility_gate() {
         // Fresh + postings-complete + exactly current → eligible.
-        let (db, db_path) = parity_fixture("elig-fresh");
+        let (db, _scratch, db_path) = parity_fixture("elig-fresh");
         assert!(
             db.clone_check_indexed_generation().unwrap().is_some(),
             "a current postings-complete generation is fast-path eligible"
@@ -1145,7 +1130,7 @@ mod tests {
         );
 
         // A postings-less (pre-feature) live generation → NOT eligible (review R2).
-        let (db2, db_path2) = parity_fixture("elig-pw");
+        let (db2, _scratch2, db_path2) = parity_fixture("elig-pw");
         {
             let c = rusqlite::Connection::open(&db_path2).unwrap();
             c.execute("UPDATE clone_graph_generations SET postings_written = 0", []).unwrap();
@@ -1162,7 +1147,7 @@ mod tests {
     /// would find. Overlays fall back to RAM.
     #[test]
     fn clone_check_fast_path_disabled_under_worktree_overlay() {
-        let (mut db, _path) = parity_fixture("overlay-scope");
+        let (mut db, _scratch, _path) = parity_fixture("overlay-scope");
         assert!(
             db.clone_check_indexed_generation().unwrap().is_some(),
             "base scope (empty worktree id) is fast-path eligible"

--- a/crates/rag-rat-core/src/index/query_api/clones/tests.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/tests.rs
@@ -182,15 +182,7 @@ fn find_clones_rejects_nan_and_non_finite_min_similarity() {
     // bail!() runs in the same function before the DB is touched.
     // Instead, test the validation logic directly via the public API by setting up a
     // temporary empty database and calling find_clones with the bad values.
-    let root = std::env::temp_dir().join(format!(
-        "rag-rat-nan-test-{}-{}",
-        std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.subsec_nanos())
-            .unwrap_or(0)
-    ));
-    let _ = std::fs::remove_dir_all(&root);
+    let root = rag_rat_base::test_scratch::ScratchDir::new("rag-rat-nan-test");
     std::fs::create_dir_all(root.join("src")).unwrap();
     std::fs::write(root.join("src/lib.rs"), "pub fn f() {}\n").unwrap();
     let config = rag_rat_base::config::Config {
@@ -199,7 +191,7 @@ fn find_clones_rejects_nan_and_non_finite_min_similarity() {
         sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
-        root: root.clone(),
+        root: root.to_path_buf(),
         database: root.join(".rag-rat/index.sqlite"),
         targets: vec![rag_rat_base::config::ResolvedTarget {
             name: "rust".to_string(),
@@ -280,8 +272,6 @@ fn find_clones_rejects_nan_and_non_finite_min_similarity() {
         })
         .is_ok()
     );
-
-    let _ = std::fs::remove_dir_all(&root);
 }
 
 // ── Fix B: allocation-free two-pointer overlap ────────────────────────────────────────────
@@ -757,15 +747,7 @@ fn refine_metrics_sampled_at_value_cap() {
 fn recall_candidates_identical_blob_vs_postings_grouping() {
     use std::collections::HashMap;
 
-    let root = std::env::temp_dir().join(format!(
-        "rag-rat-recall-parity-{}-{}",
-        std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.subsec_nanos())
-            .unwrap_or(0)
-    ));
-    let _ = std::fs::remove_dir_all(&root);
+    let root = rag_rat_base::test_scratch::ScratchDir::new("rag-rat-recall-parity");
     std::fs::create_dir_all(root.join("src")).unwrap();
     // Two renamed-clone groups + one unrelated function, across files.
     std::fs::write(
@@ -788,7 +770,7 @@ fn recall_candidates_identical_blob_vs_postings_grouping() {
         sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
-        root: root.clone(),
+        root: root.to_path_buf(),
         database: root.join(".rag-rat/index.sqlite"),
         targets: vec![rag_rat_base::config::ResolvedTarget {
             name: "rust".to_string(),
@@ -892,8 +874,6 @@ fn recall_candidates_identical_blob_vs_postings_grouping() {
         !has(lu, ct) && !has(lu, ta) && !has(lo, ct) && !has(lo, ta),
         "the two clone GROUPS do not cross-pair"
     );
-
-    let _ = std::fs::remove_dir_all(&root);
 }
 
 /// #235 item 12: a focused unit test for `load_source_discriminators`, the production

--- a/crates/rag-rat-core/src/index/query_api/oracle_surfacing_tests.rs
+++ b/crates/rag-rat-core/src/index/query_api/oracle_surfacing_tests.rs
@@ -858,7 +858,7 @@ fn global_ranking(db: &IndexDatabase) -> Vec<rag_rat_query::pagerank::SymbolImpo
 /// ranking (an isolated changed symbol now correctly falls back to global; see
 /// `seed_resolving_only_to_isolated_symbols_is_labeled_global`). Returns the db; `touched.rs`
 /// is the changed file.
-fn checkout_with_dirty_indexed_symbol() -> (IndexDatabase, rag_rat_base::test_scratch::ScratchDir) {
+fn checkout_with_dirty_indexed_symbol() -> (rag_rat_base::test_scratch::ScratchDir, IndexDatabase) {
     let root = temp_root();
     fs::write(root.join("src/lib.rs"), "fn caller() { target(); } fn target() {}\n").unwrap();
     fs::write(root.join("src/touched.rs"), "pub fn placeholder() {}\n").unwrap();
@@ -874,7 +874,7 @@ fn checkout_with_dirty_indexed_symbol() -> (IndexDatabase, rag_rat_base::test_sc
     .unwrap();
     let config = rust_config(root.to_path_buf());
     let db = IndexDatabase::rebuild(&config).unwrap();
-    (db, root)
+    (root, db)
 }
 
 /// Name/path/id seed resolution: a valid name resolves to a personalized ranking; a missing
@@ -1048,7 +1048,7 @@ fn auto_seed_from_diff_picks_changed_symbols() {
     if std::process::Command::new("git").arg("--version").output().is_err() {
         return;
     }
-    let (db, _root) = checkout_with_dirty_indexed_symbol();
+    let (_root, db) = checkout_with_dirty_indexed_symbol();
     let result = db
         .important_symbols(ImportantSymbolsRequest {
             limit: 20,
@@ -1173,7 +1173,7 @@ fn mcp_auto_seeds_but_cli_stays_global_on_a_nonempty_diff() {
     if std::process::Command::new("git").arg("--version").output().is_err() {
         return;
     }
-    let (db, _root) = checkout_with_dirty_indexed_symbol();
+    let (_root, db) = checkout_with_dirty_indexed_symbol();
 
     // MCP default: auto_seed_from_diff = true → personalized.
     let mcp = db

--- a/crates/rag-rat-core/src/index/query_api/oracle_surfacing_tests.rs
+++ b/crates/rag-rat-core/src/index/query_api/oracle_surfacing_tests.rs
@@ -5,7 +5,6 @@
 //! `compare_graph_to_scip` / gc behaviours. Models `eval::tests::eval_suite_runs_oracle_*`.
 
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicU64, Ordering};
 
 use ::protobuf::{EnumOrUnknown, Message};
 use ::scip::types::{Document, Index, Occurrence, PositionEncoding, SymbolRole};
@@ -14,15 +13,8 @@ use rag_rat_oracle::OracleTool;
 
 use super::*;
 
-static N: AtomicU64 = AtomicU64::new(0);
-
-fn temp_root() -> PathBuf {
-    let root = std::env::temp_dir().join(format!(
-        "rag-rat-q-oracle-{}-{}",
-        std::process::id(),
-        N.fetch_add(1, Ordering::Relaxed)
-    ));
-    let _ = fs::remove_dir_all(&root);
+fn temp_root() -> rag_rat_base::test_scratch::ScratchDir {
+    let root = rag_rat_base::test_scratch::ScratchDir::new("q-oracle");
     fs::create_dir_all(root.join("src")).unwrap();
     root
 }
@@ -34,7 +26,7 @@ fn rust_config(root: PathBuf) -> Config {
         sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
-        root: root.clone(),
+        root: root.to_path_buf(),
         database: root.join(".rag-rat/index.sqlite"),
         targets: vec![ResolvedTarget {
             name: "rust".to_string(),
@@ -134,7 +126,7 @@ fn oracle_run_from_scip_surfaces_compiler_tier() {
     let root = temp_root();
     // Single line so byte offsets == char offsets (ASCII): `target` is the callee.
     fs::write(root.join("src/lib.rs"), "fn caller() { target(); } fn target() {}\n").unwrap();
-    let config = rust_config(root.clone());
+    let config = rust_config(root.to_path_buf());
     let db = IndexDatabase::rebuild(&config).unwrap();
 
     let (edge_id, callee_start, callee_end, path) = call_edge(&db);
@@ -175,8 +167,6 @@ fn oracle_run_from_scip_surfaces_compiler_tier() {
     let compare = db.compare_graph_to_scip().unwrap();
     assert!(!compare.summary.no_oracle_data);
     assert_eq!(compare.summary.contradictions, 0);
-
-    let _ = fs::remove_dir_all(&root);
 }
 
 /// `oracle_pre_spawn_snapshot` returns the active checkout's indexed `(path -> sha256)` map;
@@ -186,7 +176,7 @@ fn oracle_run_from_scip_surfaces_compiler_tier() {
 fn pre_spawn_snapshot_round_trips_through_run_oracle() {
     let root = temp_root();
     fs::write(root.join("src/lib.rs"), "fn caller() { target(); } fn target() {}\n").unwrap();
-    let config = rust_config(root.clone());
+    let config = rust_config(root.to_path_buf());
     let db = IndexDatabase::rebuild(&config).unwrap();
 
     let (_edge_id, cs, ce, path) = call_edge(&db);
@@ -223,8 +213,6 @@ fn pre_spawn_snapshot_round_trips_through_run_oracle() {
         .unwrap();
     assert_eq!(report.rows_written, 0, "a mid-subprocess reindex must skip the candidate");
     assert!(report.skipped_drifted >= 1);
-
-    let _ = fs::remove_dir_all(&root);
 }
 
 /// Staleness revert: after a current run surfaces `compiler`, drifting the source file (so its
@@ -234,7 +222,7 @@ fn pre_spawn_snapshot_round_trips_through_run_oracle() {
 fn drifted_file_reverts_to_heuristic_display() {
     let root = temp_root();
     fs::write(root.join("src/lib.rs"), "fn caller() { target(); } fn target() {}\n").unwrap();
-    let config = rust_config(root.clone());
+    let config = rust_config(root.to_path_buf());
     let db = IndexDatabase::rebuild(&config).unwrap();
 
     let (edge_id, cs, ce, path) = call_edge(&db);
@@ -259,8 +247,6 @@ fn drifted_file_reverts_to_heuristic_display() {
     let hop = callers.iter().find(|h| h.edge_id == edge_id).expect("call edge present");
     assert_ne!(hop.confidence, "compiler", "drifted file must revert to heuristic display");
     assert!(hop.resolution_reason.is_none());
-
-    let _ = fs::remove_dir_all(&root);
 }
 
 /// `resolved-external`: a `.scip` resolving the callee to a packaged dependency symbol with no
@@ -273,7 +259,7 @@ fn external_resolution_surfaces_resolved_external_label() {
     // unresolved), so SCIP's external resolution is a clean `resolved-external`, not a
     // contradiction of an in-corpus claim.
     fs::write(root.join("src/lib.rs"), "fn caller() { external_fn(); }\n").unwrap();
-    let config = rust_config(root.clone());
+    let config = rust_config(root.to_path_buf());
     let db = IndexDatabase::rebuild(&config).unwrap();
 
     let (edge_id, cs, ce, path) = call_edge(&db);
@@ -294,8 +280,6 @@ fn external_resolution_surfaces_resolved_external_label() {
     assert_eq!(hop.resolved_external.as_deref(), Some("resolved-external(tokio)"));
     // External placement is not an in-corpus upgrade → confidence stays heuristic.
     assert_ne!(hop.confidence, "compiler");
-
-    let _ = fs::remove_dir_all(&root);
 }
 
 /// `compare_graph_to_scip` reports a contradiction when the heuristic resolved an edge
@@ -304,7 +288,7 @@ fn external_resolution_surfaces_resolved_external_label() {
 fn compare_graph_to_scip_reports_contradiction() {
     let root = temp_root();
     fs::write(root.join("src/lib.rs"), "fn caller() { target(); } fn target() {}\n").unwrap();
-    let config = rust_config(root.clone());
+    let config = rust_config(root.to_path_buf());
     let db = IndexDatabase::rebuild(&config).unwrap();
 
     let (edge_id, cs, ce, path) = call_edge(&db);
@@ -335,8 +319,6 @@ fn compare_graph_to_scip_reports_contradiction() {
     assert_eq!(c.edge_id, edge_id);
     assert_eq!(c.heuristic_confidence, "exact");
     assert_eq!(c.resolved_external.as_deref(), Some("resolved-external(other)"));
-
-    let _ = fs::remove_dir_all(&root);
 }
 
 /// #176: surfacing must NOT be hardcoded to rust-analyzer. A verdict written under another backend
@@ -347,7 +329,7 @@ fn compare_graph_to_scip_reports_contradiction() {
 fn compare_graph_to_scip_surfaces_non_rust_analyzer_tools() {
     let root = temp_root();
     fs::write(root.join("src/lib.rs"), "fn caller() { target(); } fn target() {}\n").unwrap();
-    let config = rust_config(root.clone());
+    let config = rust_config(root.to_path_buf());
     let db = IndexDatabase::rebuild(&config).unwrap();
 
     let (edge_id, cs, ce, path) = call_edge(&db);
@@ -379,8 +361,6 @@ fn compare_graph_to_scip_surfaces_non_rust_analyzer_tools() {
         "the report must name the contributing backend, got `{}`",
         compare.query.tool
     );
-
-    let _ = fs::remove_dir_all(&root);
 }
 
 /// #82 P0: when a run EXISTS but examined 0 in-scope verdicts, `compare_graph_to_scip` must WARN
@@ -391,7 +371,7 @@ fn compare_graph_to_scip_surfaces_non_rust_analyzer_tools() {
 fn compare_warns_when_run_exists_but_no_verdicts_in_scope() {
     let root = temp_root();
     fs::write(root.join("src/lib.rs"), "fn caller() { target(); } fn target() {}\n").unwrap();
-    let config = rust_config(root.clone());
+    let config = rust_config(root.to_path_buf());
     let db = IndexDatabase::rebuild(&config).unwrap();
 
     let (_edge_id, cs, ce, path) = call_edge(&db);
@@ -414,7 +394,6 @@ fn compare_warns_when_run_exists_but_no_verdicts_in_scope() {
         "run-but-empty must warn, not silently read as compiler-agrees: {:?}",
         compare.summary.warnings
     );
-    let _ = fs::remove_dir_all(&root);
 }
 
 /// #82 finding 1: an IN-CORPUS contradiction (the compiler resolved the callee to a DIFFERENT
@@ -428,7 +407,7 @@ fn in_corpus_contradiction_is_not_labeled_resolved_external() {
     // the same callsite to the OTHER in-corpus def `other` → in-corpus Contradict.
     fs::write(root.join("src/lib.rs"), "fn caller() { target(); } fn target() {} fn other() {}\n")
         .unwrap();
-    let config = rust_config(root.clone());
+    let config = rust_config(root.to_path_buf());
     let db = IndexDatabase::rebuild(&config).unwrap();
 
     let (edge_id, cs, ce, path) = call_edge(&db);
@@ -471,8 +450,6 @@ fn in_corpus_contradiction_is_not_labeled_resolved_external() {
         c.resolved_external, None,
         "an in-corpus contradiction must not be labeled resolved-external"
     );
-
-    let _ = fs::remove_dir_all(&root);
 }
 
 /// End-to-end #108 SCIP-aware ranking: an in-corpus Contradict RETARGETS importance to the
@@ -486,7 +463,7 @@ fn important_symbols_retargets_an_in_corpus_contradiction() {
     let root = temp_root();
     fs::write(root.join("src/lib.rs"), "fn caller() { target(); } fn target() {} fn other() {}\n")
         .unwrap();
-    let config = rust_config(root.clone());
+    let config = rust_config(root.to_path_buf());
     let db = IndexDatabase::rebuild(&config).unwrap();
     let conn = db.storage.connection();
 
@@ -547,8 +524,6 @@ fn important_symbols_retargets_an_in_corpus_contradiction() {
         score_of(&after, &other_qn) > score_of(&before, &other_qn),
         "the retargeted callee gains rank it did not have heuristically: {after:?}"
     );
-
-    let _ = fs::remove_dir_all(&root);
 }
 
 /// #82 finding 2: an `Upgrade` on a heuristic-unresolved edge must surface the SCIP-RESOLVED
@@ -560,7 +535,7 @@ fn important_symbols_retargets_an_in_corpus_contradiction() {
 fn upgrade_hydrates_target_from_compiler_resolution() {
     let root = temp_root();
     fs::write(root.join("src/lib.rs"), "fn caller() { target(); } fn target() {}\n").unwrap();
-    let config = rust_config(root.clone());
+    let config = rust_config(root.to_path_buf());
     let db = IndexDatabase::rebuild(&config).unwrap();
 
     let (edge_id, cs, ce, path) = call_edge(&db);
@@ -611,8 +586,6 @@ fn upgrade_hydrates_target_from_compiler_resolution() {
     assert_eq!(hop.to_symbol.as_deref(), Some(target_qualified.as_str()));
     assert_eq!(hop.target_qualified_name.as_deref(), Some(target_qualified.as_str()));
     assert!(hop.verified_target_symbol, "the compiler-resolved target is verified");
-
-    let _ = fs::remove_dir_all(&root);
 }
 
 /// #82 finding 4: a compiler-`Upgrade`d low-confidence neighbor must appear within `limit` even
@@ -630,7 +603,7 @@ fn compiler_upgrade_survives_heuristic_limit() {
         "fn pull() {} fn a() { pull(); } fn b() { pull(); } fn c() { pull(); }\n",
     )
     .unwrap();
-    let config = rust_config(root.clone());
+    let config = rust_config(root.to_path_buf());
     let db = IndexDatabase::rebuild(&config).unwrap();
 
     // Find the three call edges to `pull`. Make two of them Exact (high heuristic rank) and the
@@ -706,8 +679,6 @@ fn compiler_upgrade_survives_heuristic_limit() {
         "the compiler-upgraded neighbor must rank into the limit ahead of Exact neighbors"
     );
     assert_eq!(callers[0].confidence, "compiler");
-
-    let _ = fs::remove_dir_all(&root);
 }
 
 /// gc prunes `oracle_runs` for dead checkout contexts: an oracle run recorded under a sibling
@@ -719,7 +690,7 @@ fn gc_prunes_oracle_runs_for_dead_contexts() {
     let _poison = crate::index::poison_sibling::disable_poison_sibling();
     let root = temp_root();
     fs::write(root.join("src/lib.rs"), "fn caller() { target(); } fn target() {}\n").unwrap();
-    let config = rust_config(root.clone());
+    let config = rust_config(root.to_path_buf());
     let db = IndexDatabase::rebuild(&config).unwrap();
 
     // Record a run for THIS (active) checkout + a run for a dead sibling context.
@@ -770,8 +741,6 @@ fn gc_prunes_oracle_runs_for_dead_contexts() {
         !remaining.iter().any(|c| c == "dead-commit"),
         "dead-context oracle_runs row must be pruned: {remaining:?}"
     );
-
-    let _ = fs::remove_dir_all(&root);
 }
 
 #[test]
@@ -847,11 +816,10 @@ fn oracle_run_without_tool_is_blocked_not_error() {
     }
     let root = temp_root();
     fs::write(root.join("src/lib.rs"), "pub fn f() {}\n").unwrap();
-    let config = rust_config(root.clone());
+    let config = rust_config(root.to_path_buf());
     let db = IndexDatabase::rebuild(&config).unwrap();
     let outcome = db.run_oracle_with_tool(OracleTool::RustAnalyzer, &root.join("o.scip")).unwrap();
     assert!(matches!(outcome, rag_rat_oracle::OracleRunOutcome::Blocked { .. }));
-    let _ = fs::remove_dir_all(&root);
 }
 
 /// Run a git command in `root`, panicking on failure — used to make a real committed checkout
@@ -890,7 +858,7 @@ fn global_ranking(db: &IndexDatabase) -> Vec<rag_rat_query::pagerank::SymbolImpo
 /// ranking (an isolated changed symbol now correctly falls back to global; see
 /// `seed_resolving_only_to_isolated_symbols_is_labeled_global`). Returns the db; `touched.rs`
 /// is the changed file.
-fn checkout_with_dirty_indexed_symbol() -> (IndexDatabase, PathBuf) {
+fn checkout_with_dirty_indexed_symbol() -> (IndexDatabase, rag_rat_base::test_scratch::ScratchDir) {
     let root = temp_root();
     fs::write(root.join("src/lib.rs"), "fn caller() { target(); } fn target() {}\n").unwrap();
     fs::write(root.join("src/touched.rs"), "pub fn placeholder() {}\n").unwrap();
@@ -904,7 +872,7 @@ fn checkout_with_dirty_indexed_symbol() -> (IndexDatabase, PathBuf) {
         "pub fn placeholder() {} pub fn touched() { placeholder(); }\n",
     )
     .unwrap();
-    let config = rust_config(root.clone());
+    let config = rust_config(root.to_path_buf());
     let db = IndexDatabase::rebuild(&config).unwrap();
     (db, root)
 }
@@ -916,7 +884,7 @@ fn checkout_with_dirty_indexed_symbol() -> (IndexDatabase, PathBuf) {
 fn explicit_seed_resolves_names_and_skips_misses() {
     let root = temp_root();
     fs::write(root.join("src/lib.rs"), "fn caller() { target(); } fn target() {}\n").unwrap();
-    let config = rust_config(root.clone());
+    let config = rust_config(root.to_path_buf());
     let db = IndexDatabase::rebuild(&config).unwrap();
 
     // A real name + a bogus one: the bogus is skipped (no_symbols += 1), the real one seeds.
@@ -966,8 +934,6 @@ fn explicit_seed_resolves_names_and_skips_misses() {
     assert_eq!(all_missing.mode, rag_rat_query::pagerank::ImportanceMode::Global);
     assert!(all_missing.reason.is_some(), "all-missing explicit seed reports why it's global");
     assert_eq!(all_missing.seed_source.unwrap().skipped.no_symbols, 2);
-
-    let _ = fs::remove_dir_all(&root);
 }
 
 /// #142 review: a seed that RESOLVES to real symbols which are not endpoints of any resolved
@@ -981,7 +947,7 @@ fn seed_resolving_only_to_isolated_symbols_is_labeled_global() {
     // enters the PageRank graph.
     fs::write(root.join("src/lib.rs"), "fn caller() { target(); } fn target() {} fn island() {}\n")
         .unwrap();
-    let config = rust_config(root.clone());
+    let config = rust_config(root.to_path_buf());
     let db = IndexDatabase::rebuild(&config).unwrap();
 
     let result = db
@@ -1011,8 +977,6 @@ fn seed_resolving_only_to_isolated_symbols_is_labeled_global() {
         .unwrap();
     assert_eq!(connected.mode, rag_rat_query::pagerank::ImportanceMode::PersonalizedToChanges);
     assert_eq!(connected.seed_source.unwrap().effective_seed_count, 1);
-
-    let _ = fs::remove_dir_all(&root);
 }
 
 /// #142 review: auto-seed-from-diff in a source root that is NOT a git worktree must not fail
@@ -1022,7 +986,7 @@ fn seed_resolving_only_to_isolated_symbols_is_labeled_global() {
 fn auto_seed_outside_a_git_worktree_falls_back_to_global() {
     let root = temp_root();
     fs::write(root.join("src/lib.rs"), "fn caller() { target(); } fn target() {}\n").unwrap();
-    let config = rust_config(root.clone());
+    let config = rust_config(root.to_path_buf());
     let db = IndexDatabase::rebuild(&config).unwrap();
 
     let result = db
@@ -1034,8 +998,6 @@ fn auto_seed_outside_a_git_worktree_falls_back_to_global() {
         .unwrap();
     assert_eq!(result.mode, rag_rat_query::pagerank::ImportanceMode::Global);
     assert!(!result.symbols.is_empty(), "the global ranking is still computed");
-
-    let _ = fs::remove_dir_all(&root);
 }
 
 /// A name that matches MULTIPLE in-scope symbols seeds ALL of them — personalization is a
@@ -1053,7 +1015,7 @@ fn multi_match_name_seeds_all_in_scope_symbols() {
         "pub struct Thing;\nimpl Thing { pub fn a(&self) {} }\nimpl Thing { pub fn b(&self) {} }\n",
     )
     .unwrap();
-    let config = rust_config(root.clone());
+    let config = rust_config(root.to_path_buf());
     let db = IndexDatabase::rebuild(&config).unwrap();
 
     // Sanity: the bare name really does match more than one symbol.
@@ -1077,7 +1039,6 @@ fn multi_match_name_seeds_all_in_scope_symbols() {
     assert_eq!(seed.kind, rag_rat_query::pagerank::SeedKind::Explicit);
     assert!(seed.symbol_seed_count >= 2, "all of the name's in-scope symbols are seeded: {seed:?}");
     assert_eq!(seed.skipped.no_symbols, 0, "a matched name is never counted as a miss");
-    let _ = fs::remove_dir_all(&root);
 }
 
 /// Auto-seed maps the git diff to symbols THROUGH the scoped `files` view: a dirty indexed file
@@ -1087,7 +1048,7 @@ fn auto_seed_from_diff_picks_changed_symbols() {
     if std::process::Command::new("git").arg("--version").output().is_err() {
         return;
     }
-    let (db, root) = checkout_with_dirty_indexed_symbol();
+    let (db, _root) = checkout_with_dirty_indexed_symbol();
     let result = db
         .important_symbols(ImportantSymbolsRequest {
             limit: 20,
@@ -1100,7 +1061,6 @@ fn auto_seed_from_diff_picks_changed_symbols() {
     assert_eq!(seed.kind, rag_rat_query::pagerank::SeedKind::GitDiff);
     assert!(seed.indexed_paths >= 1, "the dirty indexed file counted: {seed:?}");
     assert!(seed.symbol_seed_count >= 1, "the changed file's symbol seeded: {seed:?}");
-    let _ = fs::remove_dir_all(&root);
 }
 
 /// Diff with NO indexed symbols (a changed markdown file only) → global mode, a reason, and the
@@ -1117,7 +1077,7 @@ fn diff_without_symbols_falls_back_to_global_with_reason() {
     git(&root, &["commit", "-q", "-m", "init"]);
     // The only working-tree change is a markdown file — never indexed as a Rust symbol.
     fs::write(root.join("NOTES.md"), "# notes\n").unwrap();
-    let config = rust_config(root.clone());
+    let config = rust_config(root.to_path_buf());
     let db = IndexDatabase::rebuild(&config).unwrap();
 
     let result = db
@@ -1134,7 +1094,6 @@ fn diff_without_symbols_falls_back_to_global_with_reason() {
     assert!(seed.changed_paths >= 1, "the markdown change was considered: {seed:?}");
     assert_eq!(seed.symbol_seed_count, 0);
     assert!(!result.symbols.is_empty(), "global ranking still returns the spine");
-    let _ = fs::remove_dir_all(&root);
 }
 
 /// Deleted and generated changed paths are counted in `skipped`, not seeded.
@@ -1155,7 +1114,7 @@ fn deleted_and_generated_paths_counted_in_skipped() {
         sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
-        root: root.clone(),
+        root: root.to_path_buf(),
         database: root.join(".rag-rat/index.sqlite"),
         targets: vec![
             ResolvedTarget {
@@ -1204,7 +1163,6 @@ fn deleted_and_generated_paths_counted_in_skipped() {
     let seed = result.seed_source.expect("reports provenance");
     assert_eq!(seed.skipped.deleted, 1, "the removed file is counted deleted: {seed:?}");
     assert_eq!(seed.skipped.generated, 1, "the generated file is counted generated: {seed:?}");
-    let _ = fs::remove_dir_all(&root);
 }
 
 /// Acceptance invariant #1: with a non-empty diff carrying an indexed symbol, MCP defaults
@@ -1215,7 +1173,7 @@ fn mcp_auto_seeds_but_cli_stays_global_on_a_nonempty_diff() {
     if std::process::Command::new("git").arg("--version").output().is_err() {
         return;
     }
-    let (db, root) = checkout_with_dirty_indexed_symbol();
+    let (db, _root) = checkout_with_dirty_indexed_symbol();
 
     // MCP default: auto_seed_from_diff = true → personalized.
     let mcp = db
@@ -1245,7 +1203,6 @@ fn mcp_auto_seeds_but_cli_stays_global_on_a_nonempty_diff() {
         "CLI no-personalize ⇒ global, even with a non-empty diff"
     );
     assert!(cli.seed_source.is_none(), "CLI global carries no seed provenance");
-    let _ = fs::remove_dir_all(&root);
 }
 
 /// #82 P2 regression: `find_callers` with NO oracle data must return the IDENTICAL membership
@@ -1266,7 +1223,7 @@ fn find_callers_without_oracle_matches_heuristic_order() {
     }
     src.push_str("fn target() {}\n");
     fs::write(root.join("src/lib.rs"), src).unwrap();
-    let config = rust_config(root.clone());
+    let config = rust_config(root.to_path_buf());
     let db = IndexDatabase::rebuild(&config).unwrap();
 
     // No oracle run at all: enrichment early-returns false, so no re-sort fires.
@@ -1297,7 +1254,6 @@ fn find_callers_without_oracle_matches_heuristic_order() {
         ids(&heuristic),
         "with no oracle data, find_callers must match the plain heuristic membership + order"
     );
-    let _ = fs::remove_dir_all(&root);
 }
 
 /// #82 P0 regression: on a REAL committed git checkout the active context is
@@ -1320,7 +1276,7 @@ fn oracle_surfaces_compiler_tier_on_a_real_git_checkout() {
     git(&root, &["add", "-A"]);
     git(&root, &["commit", "-q", "-m", "init"]);
 
-    let config = rust_config(root.clone());
+    let config = rust_config(root.to_path_buf());
     let db = IndexDatabase::rebuild(&config).unwrap();
 
     // Sanity: the active context carries BOTH a real commit_sha and a worktree_id, and the file
@@ -1356,6 +1312,4 @@ fn oracle_surfaces_compiler_tier_on_a_real_git_checkout() {
     let hop = callees.iter().find(|h| h.edge_id == edge_id).expect("call edge present");
     assert_eq!(hop.confidence, "compiler", "Compiler tier must surface on a real git checkout");
     assert_eq!(hop.resolution_reason.as_deref(), Some("scip:rust-analyzer@v-test"));
-
-    let _ = fs::remove_dir_all(&root);
 }

--- a/crates/rag-rat-core/src/index/walker.rs
+++ b/crates/rag-rat-core/src/index/walker.rs
@@ -114,13 +114,8 @@ mod tests {
         fs::write(path, contents).unwrap();
     }
 
-    fn tempdir() -> PathBuf {
-        use std::sync::atomic::{AtomicU64, Ordering};
-        static N: AtomicU64 = AtomicU64::new(0);
-        let id = N.fetch_add(1, Ordering::Relaxed);
-        let dir = std::env::temp_dir().join(format!("ragrat-walk-{}-{id}", std::process::id()));
-        fs::create_dir_all(&dir).unwrap();
-        dir
+    fn tempdir() -> rag_rat_base::test_scratch::ScratchDir {
+        rag_rat_base::test_scratch::ScratchDir::new("walk")
     }
 
     fn cpp_target() -> ResolvedTarget {
@@ -154,8 +149,6 @@ mod tests {
         assert!(rel.contains(&"src/lib.cpp".to_string()), "{rel:?}");
         // ...but a plain `.c` file is NOT a C++ source.
         assert!(!rel.contains(&"legacy.c".to_string()), "cpp must not claim .c: {rel:?}");
-
-        fs::remove_dir_all(&root).ok();
     }
 
     #[test]
@@ -186,8 +179,6 @@ mod tests {
         assert!(!rel.contains(&"crates/app/skip.rs".to_string()), "nested gitignore: {rel:?}");
         assert!(!rel.contains(&"generated/out.rs".to_string()), "root gitignore: {rel:?}");
         assert!(!rel.iter().any(|p| p.starts_with("target/")), "floor dir: {rel:?}");
-
-        fs::remove_dir_all(&root).ok();
     }
 
     #[test]
@@ -213,7 +204,5 @@ mod tests {
             .map(|p| p.strip_prefix(&root).unwrap().to_string_lossy().replace('\\', "/"))
             .collect();
         assert_eq!(rel, vec!["present/lib.rs".to_string()], "present dir indexed, missing skipped");
-
-        fs::remove_dir_all(&root).ok();
     }
 }

--- a/crates/rag-rat-core/src/memory_write/authoring.rs
+++ b/crates/rag-rat-core/src/memory_write/authoring.rs
@@ -1140,8 +1140,7 @@ mod tests {
     /// in-memory database ignores the `synchronous` setting and would not report the change.
     #[test]
     fn authored_durability_raises_full_then_restores_normal() {
-        let dir = std::env::temp_dir().join(format!("ragrat-authdur-{}", std::process::id()));
-        std::fs::create_dir_all(&dir).unwrap();
+        let dir = rag_rat_base::test_scratch::ScratchDir::new("authdur");
         let storage = rag_rat_db::storage::IndexConnection::open(&dir.join("index.db")).unwrap();
         let conn = storage.connection();
         let synchronous = |c: &Connection| -> i64 {
@@ -1162,8 +1161,6 @@ mod tests {
             1,
             "the authored-durability guard must restore synchronous=NORMAL (=1) on drop"
         );
-
-        std::fs::remove_dir_all(&dir).ok();
     }
 
     /// A `MemoryRow` with the given status, no payload, one tag — the fixture the ported op-split

--- a/crates/rag-rat-core/src/memory_write/oracle_relocation_tests.rs
+++ b/crates/rag-rat-core/src/memory_write/oracle_relocation_tests.rs
@@ -923,9 +923,7 @@ fn doctor_attention_count_counts_active_gone_and_stale_bindings() {
 /// a bare read-only open and fails open to 0 on a missing DB — it must never block a tool call.
 #[test]
 fn memory_attention_count_reads_file_db_and_fails_open() {
-    let dir = std::env::temp_dir().join(format!("ragrat-attn-{}", std::process::id()));
-    let _ = std::fs::remove_dir_all(&dir);
-    std::fs::create_dir_all(&dir).unwrap();
+    let dir = rag_rat_base::test_scratch::ScratchDir::new("attn");
     let db_path = dir.join("index.sqlite");
 
     // Missing DB → 0 (fail-open).
@@ -955,6 +953,4 @@ fn memory_attention_count_reads_file_db_and_fails_open() {
             .unwrap();
     }
     assert_eq!(crate::memory_attention_count(&db_path), 1, "counts the gone binding from disk");
-
-    let _ = std::fs::remove_dir_all(&dir);
 }

--- a/crates/rag-rat-core/src/sidecar_state.rs
+++ b/crates/rag-rat-core/src/sidecar_state.rs
@@ -137,11 +137,11 @@ pub fn take_memory_nudge_slot(
 mod tests {
     use super::*;
 
-    fn temp_db(tag: &str) -> PathBuf {
-        let dir = std::env::temp_dir().join(format!("rr-sidecar-{tag}-{}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&dir);
+    fn temp_db(tag: &str) -> (rag_rat_base::test_scratch::ScratchDir, PathBuf) {
+        let dir = rag_rat_base::test_scratch::ScratchDir::new(&format!("sidecar-{tag}"));
         std::fs::create_dir_all(dir.join(".rag-rat")).unwrap();
-        dir.join(".rag-rat").join("index.sqlite")
+        let db = dir.join(".rag-rat").join("index.sqlite");
+        (dir, db)
     }
 
     const TTL: i64 = 30 * 60 * 1000;
@@ -149,7 +149,7 @@ mod tests {
 
     #[test]
     fn nudge_slot_throttles_to_the_window_but_forces_on_demand() {
-        let db = temp_db("nudge");
+        let (_scratch, db) = temp_db("nudge");
         // First ever show: nothing recorded → the window has "elapsed", so it shows and records.
         assert!(take_memory_nudge_slot(&db, REPO, 1_000, TTL, false), "first show");
         // Within the window, non-forced: throttled.
@@ -174,7 +174,7 @@ mod tests {
 
     #[test]
     fn repos_sharing_one_db_throttle_independently() {
-        let db = temp_db("multi-repo");
+        let (_scratch, db) = temp_db("multi-repo");
         // repoA claims its slot and is then throttled inside the window.
         assert!(take_memory_nudge_slot(&db, "repoA", 1_000, TTL, false), "repoA first show");
         assert!(
@@ -191,7 +191,7 @@ mod tests {
 
     #[test]
     fn nudge_and_version_cache_coexist_in_one_file() {
-        let db = temp_db("coexist");
+        let (_scratch, db) = temp_db("coexist");
         write_version_cache(&db, &CachedVersion {
             latest_version: "9.9.9".into(),
             checked_at_ms: 7,

--- a/crates/rag-rat-core/src/version_check.rs
+++ b/crates/rag-rat-core/src/version_check.rs
@@ -215,8 +215,7 @@ mod tests {
 
     #[test]
     fn cached_status_enabled_reflects_the_cache() {
-        let dir = std::env::temp_dir().join(format!("rr-vcheck-status-{}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&dir);
+        let dir = rag_rat_base::test_scratch::ScratchDir::new("rr-vcheck-status");
         std::fs::create_dir_all(dir.join(".rag-rat")).unwrap();
         let database = dir.join(".rag-rat").join("index.sqlite");
 
@@ -235,7 +234,6 @@ mod tests {
         assert_eq!(s.latest_version.as_deref(), Some("99.0.0"));
         assert!(s.update_available, "99.0.0 is newer than the running {}", current_version());
         assert_eq!(s.update_command, "cargo install rag-rat --force");
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
@@ -265,8 +263,7 @@ mod tests {
 
     #[test]
     fn cache_round_trips_through_disk() {
-        let dir = std::env::temp_dir().join(format!("rr-vcheck-{}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&dir);
+        let dir = rag_rat_base::test_scratch::ScratchDir::new("rr-vcheck");
         std::fs::create_dir_all(dir.join(".rag-rat")).unwrap();
         let database = dir.join(".rag-rat").join("index.sqlite");
         assert_eq!(read_cache(&database), None, "absent cache reads None");
@@ -282,6 +279,5 @@ mod tests {
             crate::sidecar_state::state_path(&database),
             dir.join(".rag-rat").join("mcp-state.json")
         );
-        let _ = std::fs::remove_dir_all(&dir);
     }
 }


### PR DESCRIPTION
## Summary
- migrate every ownerless `temp_dir().join` fixture in `rag-rat-core` unit-test modules to `ScratchDir` guards: `edges/imports`, `clones/of_text`, `clones/tests`, `distill/extract`, `version_check`, `walker`, `sidecar_state`, `memory_write/{authoring,oracle_relocation_tests}`, `oracle_surfacing_tests`, `papertrail_autosync`, `ignore_rules`, `git_history/tests`, `discovery`, `index/consolidate`, `ai/reconcile/manifest`
- `ScratchDir` gains `Deref<Target = Path>`, so fixtures use it like the bare path it replaces with no per-file wrapper
- fixture helpers now return the guard (`fixture_db` / `parity_fixture` / `temp_db` / `temp_git_repo` / `init_repo` / `tempdir`), fixing unconditional leaks: `of_text` clone fixtures, `sidecar_state`’s three nudge tests, the `autosync-unindexed` repo, and `git_context`’s `worktree_scope_tests` (`ragrat-wtscope-*`, found via the empty-namespace check — it used bare `scratch_dir()`, invisible to the `temp_dir().join` audit)
- `ignore_rules::tempdir` returns the guard plus the canonical path (macOS `/tmp` symlink); `git clone` and `git worktree add` destinations use the guard’s fresh empty dir

## Verification
- `cargo check -p rag-rat-core -p rag-rat-base --tests`
- `cargo clippy -p rag-rat-core -p rag-rat-base --tests -- -D warnings`
- `cargo +nightly fmt --all --check`
- `cargo nextest run -p rag-rat-base -p rag-rat-core` (1772 passed, 2 skipped) under an isolated `TMPDIR`; the scratch namespace contained no fixture directories after the run
- `git diff --check`

Part of #586.