### PR TITLE
test(index): isolate adoption_hints git helper from ambient environment

### DIFF
--- a/crates/rag-rat-core/src/index/adoption_hints.rs
+++ b/crates/rag-rat-core/src/index/adoption_hints.rs
@@ -253,6 +253,12 @@ mod tests {
             .env("GIT_AUTHOR_EMAIL", "t@t")
             .env("GIT_COMMITTER_NAME", "t")
             .env("GIT_COMMITTER_EMAIL", "t@t")
+            // Isolate from the ambient environment (#581): no user/system gitconfig leaks in
+            // (a hostile global `core.hooksPath` fails every commit here), and HOME is pinned
+            // to the temp root so nothing resolves to the developer's/CI runner's real home.
+            .env("GIT_CONFIG_GLOBAL", "/dev/null")
+            .env("GIT_CONFIG_SYSTEM", "/dev/null")
+            .env("HOME", root)
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::null())
             .status()
@@ -272,7 +278,7 @@ mod tests {
         let root_a = unique_temp_root();
         std::fs::create_dir_all(root_a.join("src")).unwrap();
         std::fs::write(root_a.join("src/a.rs"), "fn a() {}\n").unwrap();
-        git(&root_a, &["init", "-q"]);
+        git(&root_a, &["init", "-q", "-b", "main"]);
         git(&root_a, &["add", "-A"]);
         git(&root_a, &["commit", "-q", "-m", "init"]);
         let config_a = source_config(root_a.clone(), Language::Rust);
@@ -337,7 +343,7 @@ mod tests {
         let root_a = unique_temp_root();
         std::fs::create_dir_all(root_a.join("src")).unwrap();
         std::fs::write(root_a.join("src/a.rs"), "fn a() {}\n").unwrap();
-        git(&root_a, &["init", "-q"]);
+        git(&root_a, &["init", "-q", "-b", "main"]);
         git(&root_a, &["add", "-A"]);
         git(&root_a, &["commit", "-q", "-m", "init"]);
         let config_a = source_config(root_a.clone(), Language::Rust);
@@ -412,7 +418,7 @@ mod tests {
         let root_a = unique_temp_root();
         std::fs::create_dir_all(root_a.join("src")).unwrap();
         std::fs::write(root_a.join("src/a.rs"), "fn a() {}\n").unwrap();
-        git(&root_a, &["init", "-q"]);
+        git(&root_a, &["init", "-q", "-b", "main"]);
         git(&root_a, &["add", "-A"]);
         git(&root_a, &["commit", "-q", "-m", "init"]);
         let config_a = source_config(root_a.clone(), Language::Rust);
@@ -424,7 +430,7 @@ mod tests {
         let root_b = unique_temp_root();
         std::fs::create_dir_all(root_b.join("src")).unwrap();
         std::fs::write(root_b.join("keep.txt"), "not a rust file\n").unwrap();
-        git(&root_b, &["init", "-q"]);
+        git(&root_b, &["init", "-q", "-b", "main"]);
         git(&root_b, &["add", "-A"]);
         git(&root_b, &["commit", "-q", "-m", "init"]);
         let mut config_b = source_config(root_b.clone(), Language::Rust);
@@ -506,7 +512,7 @@ mod tests {
 
         // Now give the root a git identity the DB has NOT adopted (still under the placeholder), so
         // `resolve_config_repo_id` returns None and only the sole-repo fallback can recognize it.
-        git(&root, &["init", "-q"]);
+        git(&root, &["init", "-q", "-b", "main"]);
         git(&root, &["add", "-A"]);
         git(&root, &["commit", "-q", "-m", "init"]);
 
@@ -534,7 +540,7 @@ mod tests {
         let root_a = unique_temp_root();
         std::fs::create_dir_all(root_a.join("src")).unwrap();
         std::fs::write(root_a.join("src/a.rs"), "fn a() {}\n").unwrap();
-        git(&root_a, &["init", "-q"]);
+        git(&root_a, &["init", "-q", "-b", "main"]);
         git(&root_a, &["add", "-A"]);
         git(&root_a, &["commit", "-q", "-m", "init"]);
         let config_a = source_config(root_a.clone(), Language::Rust);
@@ -577,7 +583,7 @@ mod tests {
         let root_a = unique_temp_root();
         std::fs::create_dir_all(root_a.join("src")).unwrap();
         std::fs::write(root_a.join("src/a.rs"), "fn a() {}\n").unwrap();
-        git(&root_a, &["init", "-q"]);
+        git(&root_a, &["init", "-q", "-b", "main"]);
         git(&root_a, &["add", "-A"]);
         git(&root_a, &["commit", "-q", "-m", "init"]);
         let config_a = source_config(root_a.clone(), Language::Rust);


### PR DESCRIPTION
The `git` helper in `adoption_hints.rs` shelled out without isolating the environment, so tests inherited whatever git config the developer or runner happened to have.

Fixed in the helper itself, so every test using it benefits rather than just the one that happened to fail:
- `GIT_CONFIG_GLOBAL=/dev/null` and `GIT_CONFIG_SYSTEM=/dev/null`
- `HOME` pinned to the test's own temp root
- all 7 `git init -q` call sites now pass `-b main` explicitly instead of relying on the ambient `init.defaultBranch`

**Reproducing it deterministically.** With a benign ambient config the tests pass either way, which matches the issue describing this as environment-dependent. To get a real repro I pointed `HOME` at a directory whose `.gitconfig` sets `core.hooksPath` to a hooks dir containing an `exit 1` `pre-commit` hook. Before the fix that gives 6 of 11 failures, all with the issue's exact signature:

```
panicked at adoption_hints.rs:260: git ["commit", "-q", "-m", "init"] failed
```

After the fix the same hostile-`HOME` run is `ok. 11 passed; 0 failed`. Plain runs pass both parallel and with `--test-threads=1`.

**Gates** (from `.github/workflows/ci.yml`), all exit 0:
- `cargo +nightly fmt --all --check`
- `cargo clippy --workspace --all-targets --no-default-features --locked -- -D warnings`
- `cargo test --workspace --no-default-features --locked` — 3908 passed, 0 failed across 37 suites
- `cargo build --workspace --locked`

**One thing worth flagging:** the issue says this hardening mirrors existing helpers, but as far as I can tell only `cli/src/commands/remove.rs` is actually hardened today. The same un-isolated pattern is still in `oracle_surfacing_tests.rs`, `git_context.rs`, `repo_identity.rs`, `trackers.rs`, `mcp/tests.rs`, and `cli/tests/common/mod.rs`. I left them alone to keep this PR to the issue's scope and filed #970 to track them.

Fixes #581

---
Generated by Claude Opus 4.8 (brief, review), Kimi K3 (implementation)
