### PR TITLE
fix(tests): retain CLI unit-test scratch cleanup guards

### DIFF
--- a/crates/rag-rat-cli/src/commands/clones.rs
+++ b/crates/rag-rat-cli/src/commands/clones.rs
@@ -212,15 +212,12 @@ pub(crate) fn clones_for(config: &Config, args: &ClonesForArgs) -> anyhow::Resul
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
-    use std::sync::atomic::{AtomicU64, Ordering};
 
     use rag_rat_base::config::{Config, ResolvedTarget, TargetKind};
     use rag_rat_base::language::Language;
     use rag_rat_core::IndexDatabase;
 
     use crate::cli::ClonesArgs;
-
-    static N: AtomicU64 = AtomicU64::new(0);
 
     /// Fix E: a qualified name like `sym_utils.rs::load_user` (a file literally named `sym_*`)
     /// must route to `Ref`, not `Id`. The old `starts_with("sym_")` guard misrouted it to `Id`,
@@ -262,12 +259,7 @@ mod tests {
         // Plant two identical functions in separate files → struct_hash fast path produces a clone
         // class. Validates that the `clones` command handler wires find_clones and prints output
         // without panicking.
-        let root = std::env::temp_dir().join(format!(
-            "rag-rat-cli-clones-{}-{}",
-            std::process::id(),
-            N.fetch_add(1, Ordering::Relaxed)
-        ));
-        let _ = std::fs::remove_dir_all(&root);
+        let root = rag_rat_base::test_scratch::ScratchDir::new("cli-clones");
         std::fs::create_dir_all(root.join("src")).unwrap();
         let clone_body =
             "pub fn cloned_helper(x: i32, y: i32) -> i32 {\n    x + y + 42\n}\n".to_string();
@@ -282,7 +274,7 @@ mod tests {
             sync: Default::default(),
             repo_id_override: None,
             database_key_pinned: true,
-            root: root.clone(),
+            root: root.to_path_buf(),
             database: root.join(".rag-rat/index.sqlite"),
             targets: vec![ResolvedTarget {
                 name: "rust".to_string(),
@@ -364,7 +356,5 @@ mod tests {
             );
         }
         assert!(syms.windows(2).all(|w| w[0] < w[1]), "clone_symbol_refs must be sorted+unique");
-
-        let _ = std::fs::remove_dir_all(&root);
     }
 }

--- a/crates/rag-rat-cli/src/commands/index_ops.rs
+++ b/crates/rag-rat-cli/src/commands/index_ops.rs
@@ -777,25 +777,17 @@ fn run_maintenance_pass(
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
-    use std::sync::atomic::{AtomicU64, Ordering};
 
     use rag_rat_base::config::{Config, ResolvedTarget, TargetKind};
     use rag_rat_base::language::Language;
     use rag_rat_core::IndexDatabase;
-
-    static N: AtomicU64 = AtomicU64::new(0);
 
     /// #574: `doctor --vacuum` opens the store, reclaims dead space under the schema lock, and
     /// leaves the freelist empty. (Reclamation-under-load correctness is unit-tested in
     /// `db_file_health`; this pins the CLI wiring — dispatch → open_config → VACUUM → report.)
     #[test]
     fn doctor_vacuum_runs_and_leaves_no_freelist() {
-        let root = std::env::temp_dir().join(format!(
-            "rag-rat-cli-vacuum-{}-{}",
-            std::process::id(),
-            N.fetch_add(1, Ordering::Relaxed)
-        ));
-        let _ = std::fs::remove_dir_all(&root);
+        let root = rag_rat_base::test_scratch::ScratchDir::new("cli-vacuum");
         std::fs::create_dir_all(root.join("docs")).unwrap();
         std::fs::write(root.join("docs/a.md"), "# Title\nalpha token\n").unwrap();
         let config = Config {
@@ -804,7 +796,7 @@ mod tests {
             sync: Default::default(),
             repo_id_override: None,
             database_key_pinned: true,
-            root: root.clone(),
+            root: root.to_path_buf(),
             database: root.join(".rag-rat/index.sqlite"),
             targets: vec![ResolvedTarget {
                 name: "markdown".to_string(),
@@ -834,7 +826,6 @@ mod tests {
             0,
             "a vacuum leaves no reclaimable freelist"
         );
-        let _ = std::fs::remove_dir_all(&root);
     }
 
     #[test]
@@ -846,12 +837,7 @@ mod tests {
         let git = |dir: &std::path::Path, args: &[&str]| {
             std::process::Command::new("git").arg("-C").arg(dir).args(args).output().unwrap()
         };
-        let root = std::env::temp_dir().join(format!(
-            "rag-rat-cli-maint-overlay-{}-{}",
-            std::process::id(),
-            N.fetch_add(1, Ordering::Relaxed)
-        ));
-        let _ = std::fs::remove_dir_all(&root);
+        let root = rag_rat_base::test_scratch::ScratchDir::new("cli-maint-overlay");
         let main = root.join("main");
         std::fs::create_dir_all(main.join("src")).unwrap();
         std::fs::write(main.join("src/a.rs"), "pub fn base_fn() {}\n").unwrap();
@@ -915,7 +901,6 @@ mod tests {
         );
 
         drop(db);
-        let _ = std::fs::remove_dir_all(&root);
     }
 
     #[test]
@@ -930,12 +915,7 @@ mod tests {
         let git = |dir: &std::path::Path, args: &[&str]| {
             std::process::Command::new("git").arg("-C").arg(dir).args(args).output().unwrap()
         };
-        let root = std::env::temp_dir().join(format!(
-            "rag-rat-cli-scope360-{}-{}",
-            std::process::id(),
-            N.fetch_add(1, Ordering::Relaxed)
-        ));
-        let _ = std::fs::remove_dir_all(&root);
+        let root = rag_rat_base::test_scratch::ScratchDir::new("cli-scope360");
         let main = root.join("main");
         std::fs::create_dir_all(main.join("src")).unwrap();
         std::fs::write(main.join("src/a.rs"), "pub fn base_fn() {}\n").unwrap();
@@ -999,8 +979,6 @@ mod tests {
             "open_config must base-scope embedding counts (open does not): scoped={scoped} \
              unscoped={unscoped}"
         );
-
-        let _ = std::fs::remove_dir_all(&root);
     }
 
     /// #573: the hook write path (`run_maintenance_pass`) checkpoints the shared global `-wal`, so a
@@ -1013,12 +991,7 @@ mod tests {
         let git = |dir: &std::path::Path, args: &[&str]| {
             std::process::Command::new("git").arg("-C").arg(dir).args(args).output().unwrap()
         };
-        let root = std::env::temp_dir().join(format!(
-            "rag-rat-cli-maint-wal-{}-{}",
-            std::process::id(),
-            N.fetch_add(1, Ordering::Relaxed)
-        ));
-        let _ = std::fs::remove_dir_all(&root);
+        let root = rag_rat_base::test_scratch::ScratchDir::new("cli-maint-wal");
         std::fs::create_dir_all(root.join("src")).unwrap();
         std::fs::write(root.join("src/a.rs"), "pub fn base_fn() {}\n").unwrap();
         git(&root, &["init", "-q", "-b", "main"]);
@@ -1032,7 +1005,7 @@ mod tests {
             sync: Default::default(),
             repo_id_override: None,
             database_key_pinned: true,
-            root: root.clone(),
+            root: root.to_path_buf(),
             database: root.join(".rag-rat/index.sqlite"),
             targets: vec![ResolvedTarget {
                 name: "rust".to_string(),
@@ -1073,7 +1046,6 @@ mod tests {
             serde_json::json!(false),
             "a fresh fixture's -wal is under the threshold, so the checkpoint is size-gated off"
         );
-        let _ = std::fs::remove_dir_all(&root);
     }
 
     #[test]
@@ -1086,12 +1058,7 @@ mod tests {
         let git = |dir: &std::path::Path, args: &[&str]| {
             std::process::Command::new("git").arg("-C").arg(dir).args(args).output().unwrap()
         };
-        let root = std::env::temp_dir().join(format!(
-            "rag-rat-cli-maint-backlog-{}-{}",
-            std::process::id(),
-            N.fetch_add(1, Ordering::Relaxed)
-        ));
-        let _ = std::fs::remove_dir_all(&root);
+        let root = rag_rat_base::test_scratch::ScratchDir::new("cli-maint-backlog");
         std::fs::create_dir_all(root.join("src")).unwrap();
         std::fs::write(root.join("src/a.rs"), "pub fn base_fn() {}\n").unwrap();
         git(&root, &["init", "-q", "-b", "main"]);
@@ -1105,7 +1072,7 @@ mod tests {
             sync: Default::default(),
             repo_id_override: None,
             database_key_pinned: true,
-            root: root.clone(),
+            root: root.to_path_buf(),
             database: root.join(".rag-rat/index.sqlite"),
             targets: vec![ResolvedTarget {
                 name: "rust".to_string(),
@@ -1155,8 +1122,6 @@ mod tests {
         ] {
             assert!(backlog.get(key).is_none(), "`{key}` must be omitted from the cheap backlog");
         }
-
-        let _ = std::fs::remove_dir_all(&root);
     }
 
     #[test]
@@ -1168,12 +1133,7 @@ mod tests {
         // #267: a single amend/merge/rebase fires several git hooks, each backgrounding
         // `rag-rat maintenance`. A concurrent trigger must coalesce — skip its pass and set the
         // rerun marker — rather than queue a redundant discover that widens the SQLITE_BUSY window.
-        let root = std::env::temp_dir().join(format!(
-            "rag-rat-cli-maint-coalesce-{}-{}",
-            std::process::id(),
-            N.fetch_add(1, Ordering::Relaxed)
-        ));
-        let _ = std::fs::remove_dir_all(&root);
+        let root = rag_rat_base::test_scratch::ScratchDir::new("cli-maint-coalesce");
         std::fs::create_dir_all(root.join("src")).unwrap();
         std::fs::write(root.join("src/lib.rs"), "pub fn f() {}\n").unwrap();
         let config = Config {
@@ -1182,7 +1142,7 @@ mod tests {
             sync: Default::default(),
             repo_id_override: None,
             database_key_pinned: true,
-            root: root.clone(),
+            root: root.to_path_buf(),
             database: root.join(".rag-rat/index.sqlite"),
             targets: vec![ResolvedTarget {
                 name: "rust".to_string(),
@@ -1228,8 +1188,6 @@ mod tests {
         // change the coalesced trigger requested).
         super::maintenance(&config, &args).unwrap();
         assert!(!pending.exists(), "the runner clears the rerun marker after its pass");
-
-        let _ = std::fs::remove_dir_all(&root);
     }
 
     /// The hook-driven maintenance tail shares the #472 quiet-window gate with the watcher: a
@@ -1237,12 +1195,7 @@ mod tests {
     /// rebuild; once the armed candidate has sat past the window, the next pass completes it.
     #[test]
     fn maintenance_defers_the_clone_graph_rebuild_inside_the_quiet_window() {
-        let root = std::env::temp_dir().join(format!(
-            "rag-rat-cli-clone-quiet-{}-{}",
-            std::process::id(),
-            N.fetch_add(1, Ordering::Relaxed)
-        ));
-        let _ = std::fs::remove_dir_all(&root);
+        let root = rag_rat_base::test_scratch::ScratchDir::new("cli-clone-quiet");
         std::fs::create_dir_all(root.join("src")).unwrap();
         std::fs::write(
             root.join("src/a.rs"),
@@ -1260,7 +1213,7 @@ mod tests {
             sync: Default::default(),
             repo_id_override: None,
             database_key_pinned: true,
-            root: root.clone(),
+            root: root.to_path_buf(),
             database: root.join(".rag-rat/index.sqlite"),
             targets: vec![ResolvedTarget {
                 name: "rust".to_string(),
@@ -1320,21 +1273,16 @@ mod tests {
             )
             .unwrap();
         assert_eq!(complete, 1, "the quiet-elapsed hook pass builds the graph to completion");
-
-        let _ = std::fs::remove_dir_all(&root);
     }
 }
 
 #[cfg(test)]
 mod papertrail_hook_tests {
     use std::path::PathBuf;
-    use std::sync::atomic::{AtomicU64, Ordering};
 
     use rag_rat_base::config::{Config, ResolvedTarget, TargetKind, Tracker, TrackerConfig};
     use rag_rat_base::language::Language;
     use rag_rat_core::IndexDatabase;
-
-    static N: AtomicU64 = AtomicU64::new(0);
 
     fn config_with_unreachable_tracker(root: &std::path::Path) -> Config {
         Config {
@@ -1376,12 +1324,7 @@ mod papertrail_hook_tests {
 
     #[test]
     fn maintenance_triggers_papertrail_after_the_pass_and_a_broken_mirror_never_fails_the_hook() {
-        let root = std::env::temp_dir().join(format!(
-            "rag-rat-cli-papertrail-hook-{}-{}",
-            std::process::id(),
-            N.fetch_add(1, Ordering::Relaxed)
-        ));
-        let _ = std::fs::remove_dir_all(&root);
+        let root = rag_rat_base::test_scratch::ScratchDir::new("cli-papertrail-hook");
         std::fs::create_dir_all(root.join("src")).unwrap();
         std::fs::write(root.join("src/lib.rs"), "pub fn f() {}\n").unwrap();
         let config = config_with_unreachable_tracker(&root);
@@ -1415,18 +1358,11 @@ mod papertrail_hook_tests {
         assert!(
             !rag_rat_base::locks::papertrail_pending_path(&config.database, &lock_repo).exists()
         );
-
-        let _ = std::fs::remove_dir_all(&root);
     }
 
     #[test]
     fn maintenance_runs_device_sync_on_a_hook_trigger_without_failing_the_hook() {
-        let root = std::env::temp_dir().join(format!(
-            "rag-rat-cli-device-sync-hook-{}-{}",
-            std::process::id(),
-            N.fetch_add(1, Ordering::Relaxed)
-        ));
-        let _ = std::fs::remove_dir_all(&root);
+        let root = rag_rat_base::test_scratch::ScratchDir::new("cli-device-sync-hook");
         std::fs::create_dir_all(root.join("src")).unwrap();
         std::fs::write(root.join("src/lib.rs"), "pub fn f() {}\n").unwrap();
         let mut config = config_with_unreachable_tracker(&root);
@@ -1457,8 +1393,6 @@ mod papertrail_hook_tests {
             )
             .unwrap();
         assert_eq!(stamped, 0, "device sync stayed disabled (no account) — no watermark stamped");
-
-        let _ = std::fs::remove_dir_all(&root);
     }
 
     /// A hook trigger that coalesces behind an in-flight maintenance run still fires its own
@@ -1469,12 +1403,7 @@ mod papertrail_hook_tests {
     fn coalesced_hook_trigger_still_fires_papertrail() {
         use rag_rat_base::locks::{FileLock, maintenance_lock_path, write_lock_repo_id};
 
-        let root = std::env::temp_dir().join(format!(
-            "rag-rat-cli-papertrail-coalesced-{}-{}",
-            std::process::id(),
-            N.fetch_add(1, Ordering::Relaxed)
-        ));
-        let _ = std::fs::remove_dir_all(&root);
+        let root = rag_rat_base::test_scratch::ScratchDir::new("cli-papertrail-coalesced");
         std::fs::create_dir_all(root.join("src")).unwrap();
         std::fs::write(root.join("src/lib.rs"), "pub fn f() {}\n").unwrap();
         let config = config_with_unreachable_tracker(&root);
@@ -1509,20 +1438,13 @@ mod papertrail_hook_tests {
         super::maintenance(&config, &args("post-commit")).unwrap();
         assert_eq!(mirror_attempts(), 1, "the hook's change signal must not be dropped");
         drop(held);
-
-        let _ = std::fs::remove_dir_all(&root);
     }
 
     /// Papertrail auto-sync rides GIT-HOOK triggers only: a manual / foreground `maintenance`
     /// run must stay bounded by its index budget and never start a network mirror flight.
     #[test]
     fn manual_maintenance_never_triggers_papertrail() {
-        let root = std::env::temp_dir().join(format!(
-            "rag-rat-cli-papertrail-manual-{}-{}",
-            std::process::id(),
-            N.fetch_add(1, Ordering::Relaxed)
-        ));
-        let _ = std::fs::remove_dir_all(&root);
+        let root = rag_rat_base::test_scratch::ScratchDir::new("cli-papertrail-manual");
         std::fs::create_dir_all(root.join("src")).unwrap();
         std::fs::write(root.join("src/lib.rs"), "pub fn f() {}\n").unwrap();
         let config = config_with_unreachable_tracker(&root);
@@ -1545,7 +1467,5 @@ mod papertrail_hook_tests {
             .query_row("SELECT COUNT(*) FROM papertrail_sync_cursor", [], |row| row.get(0))
             .unwrap();
         assert_eq!(cursor_rows, 0, "a non-hook trigger must not start a mirror flight");
-
-        let _ = std::fs::remove_dir_all(&root);
     }
 }

--- a/crates/rag-rat-cli/src/commands/models.rs
+++ b/crates/rag-rat-cli/src/commands/models.rs
@@ -332,22 +332,16 @@ fn warn_if_short_context(model_id: &str) {
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
-    use std::sync::atomic::{AtomicU64, Ordering};
 
     use rag_rat_base::config::Config;
 
-    static N: AtomicU64 = AtomicU64::new(0);
-
     /// Build a `Config` from a written rag-rat.toml with the given embedding-model selector and an
     /// optional connect `[remote]` block (a closed-port endpoint — never connected in these tests).
-    fn config_with_remote(model: &str, with_remote: bool) -> (PathBuf, Config) {
-        let root = std::env::temp_dir().join(format!(
-            "rag-rat-cli-remote-{}-{}",
-            std::process::id(),
-            N.fetch_add(1, Ordering::Relaxed)
-        ));
-        let _ = std::fs::remove_dir_all(&root);
+    fn config_with_remote(
+        model: &str,
+        with_remote: bool,
+    ) -> (rag_rat_base::test_scratch::ScratchDir, Config) {
+        let root = rag_rat_base::test_scratch::ScratchDir::new("cli-remote");
         std::fs::create_dir_all(root.join("src")).unwrap();
         std::fs::write(root.join("src/a.rs"), "pub fn a() {}\n").unwrap();
         let remote = if with_remote {
@@ -370,7 +364,7 @@ mod tests {
     #[test]
     fn remote_for_install_only_applies_the_remote_block_to_the_configured_model() {
         // Configured for the MiniLM transformer over a [remote] block.
-        let (root, config) = config_with_remote("sentence-transformers/all-MiniLM-L6-v2", true);
+        let (_root, config) = config_with_remote("sentence-transformers/all-MiniLM-L6-v2", true);
 
         // Installing the CONFIGURED model → uses the remote block.
         assert!(
@@ -389,16 +383,13 @@ mod tests {
         assert!(msg.contains("remote embedding is configured for"), "{msg}");
         assert!(msg.contains("sentence-transformers/all-MiniLM-L6-v2"), "names configured: {msg}");
         assert!(msg.contains("BAAI/bge-small-en-v1.5"), "names requested: {msg}");
-
-        let _ = std::fs::remove_dir_all(&root);
     }
 
     #[test]
     fn remote_for_install_returns_none_without_a_remote_block() {
         // No [remote] block → any install is local (None) regardless of the requested id.
-        let (root, config) = config_with_remote("sentence-transformers/all-MiniLM-L6-v2", false);
+        let (_root, config) = config_with_remote("sentence-transformers/all-MiniLM-L6-v2", false);
         assert!(super::remote_for_install(&config, "BAAI/bge-small-en-v1.5").unwrap().is_none());
         assert!(super::remote_for_install(&config, "embedding-hash").unwrap().is_none());
-        let _ = std::fs::remove_dir_all(&root);
     }
 }

--- a/crates/rag-rat-cli/src/commands/oracle.rs
+++ b/crates/rag-rat-cli/src/commands/oracle.rs
@@ -431,7 +431,6 @@ fn join_tool_version_suffix(version: String, suffix: Option<String>) -> String {
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
-    use std::sync::atomic::{AtomicU64, Ordering};
     use std::sync::mpsc;
     use std::time::Duration;
 
@@ -442,15 +441,8 @@ mod tests {
 
     use crate::cli::{OracleArgs, OracleCommand, OracleRunArgs, OracleToolArg};
 
-    static N: AtomicU64 = AtomicU64::new(0);
-
-    fn temp_config() -> (PathBuf, Config) {
-        let root = std::env::temp_dir().join(format!(
-            "rag-rat-cli-oracle-lock-{}-{}",
-            std::process::id(),
-            N.fetch_add(1, Ordering::Relaxed)
-        ));
-        let _ = std::fs::remove_dir_all(&root);
+    fn temp_config() -> (rag_rat_base::test_scratch::ScratchDir, Config) {
+        let root = rag_rat_base::test_scratch::ScratchDir::new("cli-oracle-lock");
         std::fs::create_dir_all(root.join("src")).unwrap();
         std::fs::write(root.join("src/lib.rs"), "fn caller() { target(); } fn target() {}\n")
             .unwrap();
@@ -460,7 +452,7 @@ mod tests {
             sync: Default::default(),
             repo_id_override: None,
             database_key_pinned: true,
-            root: root.clone(),
+            root: root.to_path_buf(),
             database: root.join(".rag-rat/index.sqlite"),
             targets: vec![ResolvedTarget {
                 name: "rust".to_string(),
@@ -626,8 +618,6 @@ mod tests {
             rx.recv_timeout(Duration::from_secs(20)).expect("oracle run completes after unlock");
         assert!(ok, "oracle run should succeed once the lock is free");
         handle.join().unwrap();
-
-        let _ = std::fs::remove_dir_all(&root);
     }
 
     /// The lock is RELEASED after `oracle run` returns — a subsequent acquire succeeds immediately,
@@ -650,7 +640,5 @@ mod tests {
             FileLock::try_acquire(&write_lock_path(&config.database, &write_lock_repo_id(&config)))
                 .unwrap();
         assert!(lock.is_some(), "oracle run must release the write lock when it returns");
-
-        let _ = std::fs::remove_dir_all(&root);
     }
 }

--- a/crates/rag-rat-cli/src/commands/remove.rs
+++ b/crates/rag-rat-cli/src/commands/remove.rs
@@ -447,11 +447,7 @@ mod tests {
     /// config, so this test fails on a regression.
     #[test]
     fn cleanup_of_a_gone_tree_does_not_climb_into_a_parent_repos_config() {
-        let base = std::env::temp_dir().join(format!(
-            "ragrat-rm-guard-{}-{:?}",
-            std::process::id(),
-            std::thread::current().id()
-        ));
+        let base = rag_rat_base::test_scratch::ScratchDir::new("rm-guard");
         let parent = base.join("parent");
         std::fs::create_dir_all(&parent).unwrap();
         let parent_config = parent.join("rag-rat.toml");
@@ -476,6 +472,5 @@ mod tests {
             result.warnings.iter().any(|warning| warning.contains("falling back")),
             "enumeration failure must be surfaced while cleanup falls back to the root"
         );
-        let _ = std::fs::remove_dir_all(&base);
     }
 }

--- a/crates/rag-rat-cli/src/fs_atomic.rs
+++ b/crates/rag-rat-cli/src/fs_atomic.rs
@@ -42,18 +42,10 @@ pub(crate) fn write_atomic(path: &Path, contents: &[u8]) -> anyhow::Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::atomic::{AtomicU64, Ordering};
-
     use super::*;
 
-    static COUNTER: AtomicU64 = AtomicU64::new(0);
-
-    fn temp_dir() -> std::path::PathBuf {
-        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
-        let dir = std::env::temp_dir().join(format!("rag-rat-atomic-{}-{n}", std::process::id()));
-        let _ = fs::remove_dir_all(&dir);
-        fs::create_dir_all(&dir).unwrap();
-        dir
+    fn temp_dir() -> rag_rat_base::test_scratch::ScratchDir {
+        rag_rat_base::test_scratch::ScratchDir::new("atomic")
     }
 
     #[test]
@@ -62,7 +54,6 @@ mod tests {
         let path = dir.join("settings.json");
         write_atomic(&path, b"hello\n").unwrap();
         assert_eq!(fs::read_to_string(&path).unwrap(), "hello\n");
-        let _ = fs::remove_dir_all(&dir);
     }
 
     #[test]
@@ -72,7 +63,6 @@ mod tests {
         fs::write(&path, b"old contents").unwrap();
         write_atomic(&path, b"new contents").unwrap();
         assert_eq!(fs::read_to_string(&path).unwrap(), "new contents");
-        let _ = fs::remove_dir_all(&dir);
     }
 
     #[test]
@@ -87,7 +77,6 @@ mod tests {
             .filter(|name| name != "hook")
             .collect();
         assert!(leftovers.is_empty(), "unexpected temp files left behind: {leftovers:?}");
-        let _ = fs::remove_dir_all(&dir);
     }
 
     #[test]
@@ -96,6 +85,5 @@ mod tests {
         let path = dir.join("nested").join(".claude").join("settings.json");
         write_atomic(&path, b"{}").unwrap();
         assert_eq!(fs::read_to_string(&path).unwrap(), "{}");
-        let _ = fs::remove_dir_all(&dir);
     }
 }

--- a/crates/rag-rat-cli/src/init/mod.rs
+++ b/crates/rag-rat-cli/src/init/mod.rs
@@ -325,8 +325,7 @@ mod tests {
 
     #[test]
     fn rendered_swift_binding_round_trips_with_default_glob() {
-        let root = std::env::temp_dir().join(format!("ragrat-render-swift-{}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&root);
+        let root = rag_rat_base::test_scratch::ScratchDir::new("render-swift");
         std::fs::create_dir_all(root.join("Sources/App")).unwrap();
         std::fs::write(root.join("Sources/App/App.swift"), "struct App {}\n").unwrap();
         let plan = InitPlan {
@@ -346,7 +345,6 @@ mod tests {
         assert_eq!(config.targets[0].language, Language::Swift);
         assert_eq!(config.targets[0].directories, vec![PathBuf::from("Sources")]);
         assert_eq!(config.targets[0].include, vec!["**/*.swift"]);
-        let _ = std::fs::remove_dir_all(root);
     }
 
     #[test]
@@ -354,8 +352,7 @@ mod tests {
         // The generated config documents the full surface (commented), still parses via
         // Config::load, and the example [[target]] / [watch] / [version_check] tables stay
         // COMMENTED — only the active bindings + model take effect.
-        let root = std::env::temp_dir().join(format!("ragrat-render-{}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&root);
+        let root = rag_rat_base::test_scratch::ScratchDir::new("render");
         std::fs::create_dir_all(root.join("include")).unwrap();
         std::fs::create_dir_all(root.join("src")).unwrap();
         let plan = InitPlan {
@@ -388,7 +385,6 @@ mod tests {
         assert!(config.watch.enabled);
         // Commented [log] falls back to its default (disabled).
         assert!(!config.log.enabled);
-        let _ = std::fs::remove_dir_all(&root);
     }
 
     /// A7: the freshly rendered config has NO `database` key, so `Config::load` resolves it to the
@@ -396,9 +392,7 @@ mod tests {
     /// hand-written configs. Path resolution only; nothing is created at the global path.
     #[test]
     fn rendered_config_is_keyless_and_resolves_to_the_global_database() {
-        let root =
-            std::env::temp_dir().join(format!("ragrat-render-globaldb-{}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&root);
+        let root = rag_rat_base::test_scratch::ScratchDir::new("render-globaldb");
         std::fs::create_dir_all(root.join("src")).unwrap();
         std::fs::write(root.join("src/lib.rs"), "pub fn a() {}\n").unwrap();
         // Identity-bearing root: the global default requires a derivable repo identity (a
@@ -410,8 +404,12 @@ mod tests {
             &["add", "-A"],
             &["commit", "-qm", "seed"],
         ] {
-            let out =
-                std::process::Command::new("git").arg("-C").arg(&root).args(args).output().unwrap();
+            let out = std::process::Command::new("git")
+                .arg("-C")
+                .arg(&*root)
+                .args(args)
+                .output()
+                .unwrap();
             assert!(out.status.success());
         }
         let plan = InitPlan {
@@ -431,13 +429,11 @@ mod tests {
                 .expect("a data dir resolves in the test environment"),
             "a fresh init's keyless config lands on the machine-global store",
         );
-        let _ = std::fs::remove_dir_all(&root);
     }
 
     #[test]
     fn config_load_ignores_active_init_cookbook_catalog() {
-        let root = std::env::temp_dir().join(format!("ragrat-init-catalog-{}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&root);
+        let root = rag_rat_base::test_scratch::ScratchDir::new("init-catalog");
         std::fs::create_dir_all(root.join("src")).unwrap();
         std::fs::write(
             root.join("rag-rat.toml"),
@@ -466,7 +462,6 @@ mod tests {
 
         assert_eq!(config.targets.len(), 1);
         assert_eq!(config.llm.embedding.backend.as_str(), "sentence-transformers/all-MiniLM-L6-v2");
-        let _ = std::fs::remove_dir_all(&root);
     }
 
     #[test]

--- a/crates/rag-rat-cli/src/init/run.rs
+++ b/crates/rag-rat-cli/src/init/run.rs
@@ -718,10 +718,7 @@ mod default_plan_tests {
         // endpoint) must PROPAGATE — the user asked for remote GPU embedding, so init must NOT
         // silently degrade to hash. (Contrast a LOCAL feature-missing install, which still falls
         // back.) `assume_yes=true` skips the prompt.
-        let n = std::sync::atomic::AtomicU64::new(0);
-        let id = n.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        let root = std::env::temp_dir().join(format!("ragrat-r4-{}-{id}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&root);
+        let root = rag_rat_base::test_scratch::ScratchDir::new("r4");
         std::fs::create_dir_all(root.join("src")).unwrap();
         std::fs::write(root.join("src/a.rs"), "pub fn alpha() {}\n").unwrap();
         // A closed port: bind then drop so the connect is refused at probe time.
@@ -754,7 +751,5 @@ mod default_plan_tests {
             .find(|m| m.model_id == rag_rat_base::embedding_models::HASH_MODEL_ID)
             .unwrap();
         assert!(!active.installed, "hash must NOT have been installed as a silent fallback");
-
-        let _ = std::fs::remove_dir_all(&root);
     }
 }

--- a/crates/rag-rat-cli/src/init/scan.rs
+++ b/crates/rag-rat-cli/src/init/scan.rs
@@ -288,18 +288,11 @@ pub(crate) fn path_depth(path: &Path) -> usize {
 
 #[cfg(test)]
 mod header_assignment_tests {
-    use std::sync::atomic::{AtomicU64, Ordering};
-
     use super::*;
     use crate::init::run::default_plan;
 
-    fn temp_root(tag: &str) -> PathBuf {
-        static N: AtomicU64 = AtomicU64::new(0);
-        let id = N.fetch_add(1, Ordering::Relaxed);
-        let root =
-            std::env::temp_dir().join(format!("ragrat-hdr-{tag}-{}-{id}", std::process::id()));
-        fs::remove_dir_all(&root).ok();
-        root
+    fn temp_root(tag: &str) -> rag_rat_base::test_scratch::ScratchDir {
+        rag_rat_base::test_scratch::ScratchDir::new(&format!("hdr-{tag}"))
     }
 
     #[test]
@@ -326,8 +319,6 @@ mod header_assignment_tests {
         let cpp = &plan.bindings[&Language::Cpp];
         assert!(cpp.contains(&PathBuf::from("include")), "cpp must bind the header dir: {cpp:?}");
         assert!(!plan.bindings.contains_key(&Language::C), "no C binding for a C++-only repo");
-
-        fs::remove_dir_all(&root).ok();
     }
 
     #[test]
@@ -341,8 +332,6 @@ mod header_assignment_tests {
         let scan = scan_repo(&root).unwrap();
         assert_eq!(scan.language_counts.get(&Language::C).copied().unwrap_or(0), 2, ".c + .h");
         assert_eq!(scan.language_counts.get(&Language::Cpp).copied().unwrap_or(0), 0, "no C++");
-
-        fs::remove_dir_all(&root).ok();
     }
 }
 
@@ -429,8 +418,7 @@ mod python_dir_tests {
 
     #[test]
     fn virtualenv_detected_by_content_not_name() {
-        let tmp = std::env::temp_dir().join(format!("rag-rat-venv-detect-{}", std::process::id()));
-        fs::remove_dir_all(&tmp).ok();
+        let tmp = rag_rat_base::test_scratch::ScratchDir::new("venv-detect");
         // A real venv (any name) has a `pyvenv.cfg` → detected.
         fs::create_dir_all(tmp.join("env")).unwrap();
         fs::write(tmp.join("env/pyvenv.cfg"), "home = /usr\n").unwrap();
@@ -442,7 +430,6 @@ mod python_dir_tests {
             !is_virtualenv_dir(&tmp.join("src/virtualenv")),
             "the virtualenv package dir has no pyvenv.cfg"
         );
-        fs::remove_dir_all(&tmp).ok();
     }
 
     #[test]

--- a/crates/rag-rat-cli/src/main.rs
+++ b/crates/rag-rat-cli/src/main.rs
@@ -652,11 +652,8 @@ pub(crate) struct GitPaths {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::atomic::{AtomicU64, Ordering};
 
     use super::{discover_target_config_optional, load_config_or_hint, progress_percent};
-
-    static TMP: AtomicU64 = AtomicU64::new(0);
 
     #[test]
     fn progress_percent_is_capped() {
@@ -667,10 +664,8 @@ mod tests {
 
     #[test]
     fn missing_config_yields_friendly_init_hint() {
-        let n = TMP.fetch_add(1, Ordering::Relaxed);
-        let missing =
-            std::env::temp_dir().join(format!("rag-rat-no-config-{}-{n}.toml", std::process::id()));
-        let _ = std::fs::remove_file(&missing);
+        let scratch = rag_rat_base::test_scratch::ScratchDir::new("no-config");
+        let missing = scratch.join("missing.toml");
         let err = load_config_or_hint(Some(missing.to_str().unwrap())).unwrap_err();
         let message = err.to_string();
         assert!(message.contains("rag-rat init"), "expected init hint, got: {message}");
@@ -678,9 +673,7 @@ mod tests {
 
     #[test]
     fn rm_target_config_discovery_honors_its_custom_database() {
-        let n = TMP.fetch_add(1, Ordering::Relaxed);
-        let root = std::env::temp_dir()
-            .join(format!("rag-rat-rm-target-config-{}-{n}", std::process::id()));
+        let root = rag_rat_base::test_scratch::ScratchDir::new("rm-target-config");
         std::fs::create_dir_all(root.join("src")).unwrap();
         std::fs::write(
             root.join("rag-rat.toml"),
@@ -698,6 +691,5 @@ mod tests {
         // natively.
         let root = root.canonicalize().unwrap();
         assert_eq!(config.database, root.join("custom").join("index.sqlite"));
-        let _ = std::fs::remove_dir_all(root);
     }
 }


### PR DESCRIPTION
## Summary
- migrate every ownerless `temp_dir().join` fixture in the `rag-rat` binary’s unit-test modules to `ScratchDir` guards: `commands/index_ops` (11), `init/mod` (4), `init/scan` (2 + the `temp_root` helper), `main` (2), `init/run`, `fs_atomic`, `commands/{remove,oracle,models,clones}`
- `temp_config` / `config_with_remote` return the guard first, so pattern drop order (right-to-left) closes configs before the directory is removed
- `main.rs`’s missing-config test no longer builds a bare temp file path — the missing `rag-rat.toml` lives inside a guarded scratch dir
- delete the per-module `AtomicU64` naming counters and trailing `remove_dir_all` lines; drop covers panic and early-return paths

## Verification
- `cargo check -p rag-rat --tests`
- `cargo clippy -p rag-rat --tests -- -D warnings`
- `cargo +nightly fmt --all --check`
- `cargo nextest run -p rag-rat` (349 passed) under an isolated `TMPDIR`; the scratch namespace contained no fixture directories after the run
- `git diff --check`

Part of #586.