### PR TITLE
feat(oracle): live LSP watcher wiring — phase 6 slice 2 (#534)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5102,6 +5102,7 @@ name = "rag-rat-oracle"
 version = "0.21.1"
 dependencies = [
  "anyhow",
+ "path-slash",
  "protobuf",
  "rag-rat-base",
  "rag-rat-clones",
@@ -5113,6 +5114,7 @@ dependencies = [
  "sha2",
  "strum",
  "toml",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,6 +139,9 @@ ureq = { version = "3", default-features = false, features = ["rustls"] }
 tempfile = "3"
 toon-format = { version = "0.5.0", default-features = false }
 toml = "1.1"
+# Standards-compliant file URL conversion for the live LSP oracle: native disk/UNC/verbatim path
+# prefixes plus percent encoding/decoding. Already present transitively through HTTP dependencies.
+url = "2.5"
 # Structured debug logging (config-gated `[log]`; off by default). Native-only crate, so the
 # thread/file-based appender is unrestricted. See rag-rat-core/src/logging.
 tracing = "0.1"

--- a/crates/rag-rat-base/src/config/load.rs
+++ b/crates/rag-rat-base/src/config/load.rs
@@ -369,6 +369,9 @@ fn validate_raw(raw: RawConfig) -> Result<RawConfig, ConfigError> {
     if raw.dream.is_some() {
         return Err(ConfigError::DreamTableMoved);
     }
+    if raw.oracle.live.max_requests_per_pass == Some(0) {
+        return Err(ConfigError::OracleLiveRequestBudgetZero);
+    }
     Ok(raw)
 }
 

--- a/crates/rag-rat-base/src/config/mod.rs
+++ b/crates/rag-rat-base/src/config/mod.rs
@@ -174,6 +174,11 @@ pub enum ConfigError {
          sync"
     )]
     PapertrailIntervalZero(&'static str),
+    #[error(
+        "[oracle.live] `max_requests_per_pass` must be positive — zero leaves every live path \
+         permanently backlogged"
+    )]
+    OracleLiveRequestBudgetZero,
 }
 
 pub use discovery::{

--- a/crates/rag-rat-base/src/config/mod.rs
+++ b/crates/rag-rat-base/src/config/mod.rs
@@ -191,9 +191,9 @@ pub use types::{
     Config, DEFAULT_QUERY_ENDPOINT, DEFAULT_SYNC_RELAY, DistillLlmConfig, DreamLlmConfig,
     EmbeddingBackend, EmbeddingConfig, EmbeddingRuntimeConfig, LlmConfig, LogConfig, LogFormat,
     LogLevel, MAX_REMOTE_EMBEDDING_CONCURRENCY, MemoryConfig, MemorySurface, OracleConfig,
-    PapertrailConfig, RemoteBackend, RemoteDreamConfig, RemoteEmbeddingConfig, ResolvedTarget,
-    SearchConfig, SyncConfig, TargetKind, Tracker, TrackerAuth, TrackerConfig, VersionCheckConfig,
-    WatchConfig,
+    OracleLiveConfig, PapertrailConfig, RemoteBackend, RemoteDreamConfig, RemoteEmbeddingConfig,
+    ResolvedTarget, SearchConfig, SyncConfig, TargetKind, Tracker, TrackerAuth, TrackerConfig,
+    VersionCheckConfig, WatchConfig,
 };
 
 #[cfg(test)]

--- a/crates/rag-rat-base/src/config/raw.rs
+++ b/crates/rag-rat-base/src/config/raw.rs
@@ -306,7 +306,7 @@ pub(crate) struct RawOracle {
     auto_run_quiet_period_secs: Option<u64>,
     auto_run_min_interval_secs: Option<u64>,
     #[serde(default)]
-    live: RawOracleLive,
+    pub(crate) live: RawOracleLive,
 }
 
 impl From<RawOracle> for OracleConfig {
@@ -329,7 +329,7 @@ impl From<RawOracle> for OracleConfig {
 pub(crate) struct RawOracleLive {
     enabled: Option<bool>,
     idle_shutdown_secs: Option<u64>,
-    max_requests_per_pass: Option<u64>,
+    pub(crate) max_requests_per_pass: Option<u64>,
 }
 
 impl From<RawOracleLive> for OracleLiveConfig {

--- a/crates/rag-rat-base/src/config/raw.rs
+++ b/crates/rag-rat-base/src/config/raw.rs
@@ -6,9 +6,9 @@ use serde::Deserialize;
 use super::{
     ConfigError, DEFAULT_QUERY_ENDPOINT, DistillLlmConfig, DreamLlmConfig, EmbeddingBackend,
     EmbeddingConfig, EmbeddingRuntimeConfig, LlmConfig, LogConfig, LogFormat, LogLevel,
-    MAX_REMOTE_EMBEDDING_CONCURRENCY, MemoryConfig, MemorySurface, OracleConfig, PapertrailConfig,
-    RemoteBackend, RemoteDreamConfig, RemoteEmbeddingConfig, SearchConfig, SyncConfig, Tracker,
-    TrackerAuth, TrackerConfig, VersionCheckConfig, WatchConfig,
+    MAX_REMOTE_EMBEDDING_CONCURRENCY, MemoryConfig, MemorySurface, OracleConfig, OracleLiveConfig,
+    PapertrailConfig, RemoteBackend, RemoteDreamConfig, RemoteEmbeddingConfig, SearchConfig,
+    SyncConfig, Tracker, TrackerAuth, TrackerConfig, VersionCheckConfig, WatchConfig,
 };
 use crate::embedding_models::Backend;
 
@@ -305,6 +305,8 @@ pub(crate) struct RawOracle {
     auto_run: Option<bool>,
     auto_run_quiet_period_secs: Option<u64>,
     auto_run_min_interval_secs: Option<u64>,
+    #[serde(default)]
+    live: RawOracleLive,
 }
 
 impl From<RawOracle> for OracleConfig {
@@ -318,6 +320,27 @@ impl From<RawOracle> for OracleConfig {
             auto_run_min_interval_secs: raw
                 .auto_run_min_interval_secs
                 .unwrap_or(default.auto_run_min_interval_secs),
+            live: raw.live.into(),
+        }
+    }
+}
+
+#[derive(Debug, Default, Deserialize, PartialEq)]
+pub(crate) struct RawOracleLive {
+    enabled: Option<bool>,
+    idle_shutdown_secs: Option<u64>,
+    max_requests_per_pass: Option<u64>,
+}
+
+impl From<RawOracleLive> for OracleLiveConfig {
+    fn from(raw: RawOracleLive) -> Self {
+        let default = OracleLiveConfig::default();
+        Self {
+            enabled: raw.enabled.unwrap_or(default.enabled),
+            idle_shutdown_secs: raw.idle_shutdown_secs.unwrap_or(default.idle_shutdown_secs),
+            max_requests_per_pass: raw
+                .max_requests_per_pass
+                .unwrap_or(default.max_requests_per_pass),
         }
     }
 }

--- a/crates/rag-rat-base/src/config/tests.rs
+++ b/crates/rag-rat-base/src/config/tests.rs
@@ -6,9 +6,10 @@ use path_slash::PathExt;
 use super::{
     self as config, Config, ConfigError, DEFAULT_SYNC_RELAY, DistillLlmConfig,
     EmbeddingRuntimeConfig, LlmConfig, LogConfig, LogFormat, LogLevel, MemoryConfig, MemorySurface,
-    OracleConfig, RawConfig, RawMemory, RawOracle, RawSearch, RawSync, RawTarget, RawVersionCheck,
-    RawWatch, RemoteBackend, RemoteDreamConfig, RemoteEmbeddingConfig, ResolvedTarget,
-    SearchConfig, SyncConfig, TargetKind, TrackerAuth, VersionCheckConfig, WatchConfig,
+    OracleConfig, OracleLiveConfig, RawConfig, RawMemory, RawOracle, RawSearch, RawSync, RawTarget,
+    RawVersionCheck, RawWatch, RemoteBackend, RemoteDreamConfig, RemoteEmbeddingConfig,
+    ResolvedTarget, SearchConfig, SyncConfig, TargetKind, TrackerAuth, VersionCheckConfig,
+    WatchConfig,
 };
 use crate::language::Language;
 
@@ -2759,6 +2760,9 @@ fn oracle_defaults_off_and_parses_overrides() {
     assert!(!default.auto_run, "background oracle is OFF by default");
     assert_eq!(default.auto_run_quiet_period_secs, 900);
     assert_eq!(default.auto_run_min_interval_secs, 21_600);
+    assert!(!default.live.enabled, "live oracle is OFF by default (#534)");
+    assert_eq!(default.live.idle_shutdown_secs, 900);
+    assert_eq!(default.live.max_requests_per_pass, 200);
 
     let raw: RawConfig = toml::from_str(
         r#"
@@ -2769,6 +2773,11 @@ fn oracle_defaults_off_and_parses_overrides() {
             auto_run = true
             auto_run_quiet_period_secs = 60
             auto_run_min_interval_secs = 3600
+
+            [oracle.live]
+            enabled = true
+            idle_shutdown_secs = 120
+            max_requests_per_pass = 50
             "#,
     )
     .unwrap();
@@ -2777,7 +2786,27 @@ fn oracle_defaults_off_and_parses_overrides() {
         auto_run: true,
         auto_run_quiet_period_secs: 60,
         auto_run_min_interval_secs: 3600,
+        live: OracleLiveConfig {
+            enabled: true,
+            idle_shutdown_secs: 120,
+            max_requests_per_pass: 50,
+        },
     });
+
+    // `[oracle.live]` stands alone: it neither implies nor requires `[oracle] auto_run` (#534).
+    let raw: RawConfig = toml::from_str(
+        r#"
+            [index]
+            root = "."
+
+            [oracle.live]
+            enabled = true
+            "#,
+    )
+    .unwrap();
+    let oracle: OracleConfig = raw.oracle.into();
+    assert!(oracle.live.enabled);
+    assert!(!oracle.auto_run, "live must not imply the batch auto-run");
 }
 
 #[test]

--- a/crates/rag-rat-base/src/config/tests.rs
+++ b/crates/rag-rat-base/src/config/tests.rs
@@ -2810,6 +2810,14 @@ fn oracle_defaults_off_and_parses_overrides() {
 }
 
 #[test]
+fn oracle_live_rejects_a_zero_request_budget() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("rag-rat.toml");
+    std::fs::write(&path, "[oracle.live]\nenabled = true\nmax_requests_per_pass = 0\n").unwrap();
+    assert!(matches!(Config::load(path), Err(ConfigError::OracleLiveRequestBudgetZero)));
+}
+
+#[test]
 fn rejects_unknown_language() {
     let root = std::env::current_dir().unwrap();
     let simple = BTreeMap::from([("cobol".to_string(), vec![".".to_string()])]);

--- a/crates/rag-rat-base/src/config/types.rs
+++ b/crates/rag-rat-base/src/config/types.rs
@@ -196,6 +196,8 @@ impl MemorySurface {
 /// minimum-interval floor) — see `oracle::auto_run_decision`. SCIP production takes
 /// minutes while edits arrive in seconds, so edge-collapsing alone would thrash; both gates are
 /// required. Fail-open and detached: it never blocks a request and dies with the server process.
+/// The nested `[oracle.live]` table ([`OracleLiveConfig`]) is the separate live-LSP freshness
+/// path — standalone, and NOT implied by `auto_run` (#534).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OracleConfig {
     /// Run the oracle in the background on the MCP server (default false — opt in explicitly).
@@ -206,6 +208,8 @@ pub struct OracleConfig {
     pub auto_run_quiet_period_secs: u64,
     /// And at most once this often, regardless of churn. The minimum-interval floor.
     pub auto_run_min_interval_secs: u64,
+    /// The live LSP oracle (`[oracle.live]`) — per-pass resolution for just-changed files (#534).
+    pub live: OracleLiveConfig,
 }
 
 impl Default for OracleConfig {
@@ -214,7 +218,39 @@ impl Default for OracleConfig {
             auto_run: false,
             auto_run_quiet_period_secs: 900,
             auto_run_min_interval_secs: 21_600,
+            live: OracleLiveConfig::default(),
         }
+    }
+}
+
+/// Live LSP oracle (`[oracle.live]`, #74 slice 2 / #534). Opt-in; default OFF. When `enabled`,
+/// the resident watcher's maintenance pass resolves the callees of JUST-CHANGED Rust files
+/// through a resident `rust-analyzer` language server, writing `edge_oracle` verdicts under the
+/// distinct `ra-lsp` tool id — a freshness patch for files being edited, while the batch pass
+/// (`auto_run` / `oracle run`) stays the canonical whole-checkout writer.
+///
+/// Standalone: it does NOT imply or require `[oracle] auto_run`. Without a batch baseline the
+/// live pass is moniker-blind (it synthesizes `local ra-lsp-<n>` sentinel monikers), so it
+/// upgrades edge confidence tiers but contributes nothing to clone-collapse (#275) or
+/// moniker-anchored memory relocation until a batch run completes — `oracle status` surfaces
+/// that state.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OracleLiveConfig {
+    /// Resolve changed files through the resident LSP client on maintenance passes (default
+    /// false — opt in explicitly).
+    pub enabled: bool,
+    /// Shut the resident language server down after this long without a live pass (default
+    /// 900s). Bounds an idle server's resident memory; the next eligible pass respawns lazily.
+    pub idle_shutdown_secs: u64,
+    /// Cap on LSP requests a single pass may issue (default 200) — the budget that keeps a
+    /// big change set from monopolizing the maintenance pass. Unfinished files ride the next
+    /// pass via the watcher's backlog.
+    pub max_requests_per_pass: u64,
+}
+
+impl Default for OracleLiveConfig {
+    fn default() -> Self {
+        Self { enabled: false, idle_shutdown_secs: 900, max_requests_per_pass: 200 }
     }
 }
 

--- a/crates/rag-rat-base/src/config/types.rs
+++ b/crates/rag-rat-base/src/config/types.rs
@@ -244,7 +244,7 @@ pub struct OracleLiveConfig {
     pub idle_shutdown_secs: u64,
     /// Cap on LSP requests a single pass may issue (default 200) — the budget that keeps a
     /// big change set from monopolizing the maintenance pass. Unfinished files ride the next
-    /// pass via the watcher's backlog.
+    /// pass via the watcher's backlog. Must be positive; zero is rejected at config load.
     pub max_requests_per_pass: u64,
 }
 

--- a/crates/rag-rat-cli/src/cli.rs
+++ b/crates/rag-rat-cli/src/cli.rs
@@ -684,6 +684,10 @@ pub(crate) enum OracleToolArg {
     ScipTypescript,
     #[value(name = "scip-java")]
     ScipJava,
+    /// The live watcher oracle (#534). Selectable for `oracle status`; `oracle run --tool
+    /// ra-lsp` degrades to the documented `Blocked` hint (live tools never produce a `.scip`).
+    #[value(name = "ra-lsp")]
+    RaLsp,
 }
 
 impl OracleToolArg {
@@ -694,6 +698,7 @@ impl OracleToolArg {
             OracleToolArg::ScipPython => rag_rat_oracle::OracleTool::ScipPython,
             OracleToolArg::ScipTypescript => rag_rat_oracle::OracleTool::ScipTypescript,
             OracleToolArg::ScipJava => rag_rat_oracle::OracleTool::ScipJava,
+            OracleToolArg::RaLsp => rag_rat_oracle::OracleTool::RaLsp,
         }
     }
 }
@@ -1131,6 +1136,20 @@ mod tests {
             cli.command,
             Command::Oracle(OracleArgs { command: OracleCommand::Status(_) })
         ));
+    }
+
+    #[test]
+    fn oracle_status_accepts_the_live_tool_selector() {
+        // `oracle status --tool ra-lsp` must parse (#534): the status selector includes the
+        // live backend; `oracle run --tool ra-lsp` is gated to Blocked downstream instead.
+        let cli = Cli::try_parse_from(["rag-rat", "oracle", "status", "--tool", "ra-lsp"])
+            .expect("parse");
+        match cli.command {
+            Command::Oracle(OracleArgs { command: OracleCommand::Status(args) }) => {
+                assert_eq!(args.tool, Some(OracleToolArg::RaLsp));
+            },
+            other => panic!("expected oracle status, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/rag-rat-cli/src/commands/oracle.rs
+++ b/crates/rag-rat-cli/src/commands/oracle.rs
@@ -170,10 +170,29 @@ fn oracle_status(db: &IndexDatabase, args: &OracleStatusArgs) -> anyhow::Result<
             Some(version) => Some(db.oracle_status(tool, &version)?),
             None => None,
         };
+        // The live oracle without a batch baseline is moniker-blind (#534): it upgrades edge
+        // tiers under `local ra-lsp-<n>` sentinels, but clone-collapse (#275) and
+        // moniker-anchored memory relocation get nothing until a batch run completes. Surface
+        // that honestly when live verdicts exist but the batch counterpart has never run.
+        let note = if status.is_some()
+            && let Some(source) = tool.batch_moniker_source()
+            && db.latest_oracle_run_version(source)?.is_none()
+        {
+            Some(format!(
+                "live-only: no {} batch run in this checkout — edge tiers upgrade, but \
+                 clone-collapse + moniker anchoring are blind until `oracle run --tool {}` \
+                 completes",
+                source.as_db_str(),
+                source.as_db_str()
+            ))
+        } else {
+            None
+        };
         entries.push(serde_json::json!({
             "tool": tool.as_db_str(),
             "tool_available": availability,
             "verdicts": status,
+            "note": note,
         }));
     }
     print_output(&entries)

--- a/crates/rag-rat-cli/src/commands/oracle.rs
+++ b/crates/rag-rat-cli/src/commands/oracle.rs
@@ -232,6 +232,17 @@ fn oracle_report(config: &Config, args: &OracleReportArgs) -> anyhow::Result<()>
             profile.tool
         )
     })?;
+    // A live-only tool (`ra-lsp`) is driven by the watcher, never by a whole-checkout report:
+    // the `--scip` branch bypasses `produce_scip_with_tool`'s batch-capability gate, so reject
+    // here or a corpus declaring it would persist batch-shaped runs under the live identity and
+    // hide genuine session verdicts from the currency gate (#534 review).
+    anyhow::ensure!(
+        tool.batch_capable(),
+        "corpus `{}` names live-only oracle tool `{}` — it has no whole-checkout `.scip` to \
+         report over (live verdicts come from the watcher under `[oracle.live]`)",
+        profile.corpus_id,
+        profile.tool
+    );
 
     // Fail closed if the active checkout's target bindings don't match the corpus profile (Codex on
     // #175). The report stamps this profile's `corpus_profile_hash`, asserting "these numbers are

--- a/crates/rag-rat-cli/src/commands/oracle.rs
+++ b/crates/rag-rat-cli/src/commands/oracle.rs
@@ -53,6 +53,17 @@ pub(crate) fn with_oracle_write_lock<T>(
 /// error. Prints the `OracleReport` (or the `Blocked` outcome) as JSON.
 fn oracle_run(config: &Config, args: &OracleRunArgs) -> anyhow::Result<()> {
     let tool = args.tool.core();
+    // A live-only tool (`ra-lsp`) has no whole-checkout `.scip` — reject BOTH the tool-driven and
+    // the `--scip` prebuilt branches here (the prebuilt branch never reaches
+    // `produce_scip_with_tool`'s batch gate). Otherwise a `--scip` run would persist batch-shaped
+    // verdicts + a run row under the live identity and supersede genuine watcher-session verdicts
+    // in the currency gate (#534 review).
+    anyhow::ensure!(
+        tool.batch_capable(),
+        "`oracle run` cannot drive the live tool `{}` — it resolves from the watcher under \
+         `[oracle.live] enabled`, not a whole-checkout `.scip`",
+        tool.as_db_str()
+    );
     if let Some(scip_path) = &args.scip {
         // Pre-built index: reading a file is fast, so this whole path runs under the lock.
         let scip_bytes = fs::read(scip_path).map_err(|err| {
@@ -657,6 +668,26 @@ mod tests {
         assert!(ok, "oracle run should succeed once the lock is free");
         handle.join().unwrap();
 
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// #534: a live-only tool has no whole-checkout `.scip`, so `oracle run --tool ra-lsp` (even
+    /// with a prebuilt `--scip`, the branch that skips `produce_scip_with_tool`'s gate) is
+    /// rejected before touching the index — never persist a batch-shaped run under the live id.
+    #[test]
+    fn oracle_run_rejects_the_live_only_tool() {
+        let (root, config) = temp_config();
+        IndexDatabase::rebuild(&config).unwrap();
+        let scip_path = root.join("empty.scip");
+        std::fs::write(&scip_path, []).unwrap();
+        let args = OracleArgs {
+            command: OracleCommand::Run(OracleRunArgs {
+                tool: OracleToolArg::RaLsp,
+                scip: Some(scip_path),
+            }),
+        };
+        let err = super::oracle(&config, &args).unwrap_err();
+        assert!(err.to_string().contains("live tool"), "{err}");
         let _ = std::fs::remove_dir_all(&root);
     }
 

--- a/crates/rag-rat-cli/src/init/wizard/steps/oracle.rs
+++ b/crates/rag-rat-cli/src/init/wizard/steps/oracle.rs
@@ -55,6 +55,12 @@ pub(super) fn render_oracle(f: &mut Frame, area: Rect, state: &WizardState) {
         _ => {},
     }
     for tool in OracleTool::ALL {
+        // The wizard lists BATCH (`.scip`-producing) tools only — a live backend (`ra-lsp`) is a
+        // watcher feature toggled via `[oracle.live]`, not a tool the user installs separately
+        // (#534).
+        if !tool.batch_capable() {
+            continue;
+        }
         let m = ToolManifest::for_tool(*tool);
         let relevant = m.languages.iter().any(|l| detected.contains(l));
         let style = if relevant { theme::accent() } else { theme::muted() };
@@ -108,6 +114,7 @@ fn tools_for_scan(state: &WizardState) -> Vec<OracleTool> {
     OracleTool::ALL
         .iter()
         .copied()
+        .filter(|t| t.batch_capable())
         .filter(|&t| ToolManifest::for_tool(t).languages.iter().any(|l| detected.contains(l)))
         .collect()
 }

--- a/crates/rag-rat-cli/src/main.rs
+++ b/crates/rag-rat-cli/src/main.rs
@@ -279,6 +279,11 @@ fn spawn_detached_oracle_auto_run(config: &rag_rat_base::config::Config) {
         let configured_languages: std::collections::HashSet<&str> =
             config.targets.iter().map(|target| target.language.as_str()).collect();
         for &tool in OracleTool::ALL {
+            // Live-only backends (`ra-lsp`) are driven by the watcher, never by the batch
+            // auto-run loop (#534).
+            if !tool.batch_capable() {
+                continue;
+            }
             // Skip a backend whose language this checkout doesn't index — never auto-run it here
             // (the status registry stays broad; only background runs are gated).
             let manifest = rag_rat_oracle::ToolManifest::for_tool(tool);

--- a/crates/rag-rat-core/src/index/query_api/graph.rs
+++ b/crates/rag-rat-core/src/index/query_api/graph.rs
@@ -86,11 +86,15 @@ impl IndexDatabase {
         }
         // Merge verdicts from EVERY oracle backend that has a run in this checkout, not just
         // rust-analyzer (#176): a mixed-language repo has rust-analyzer/scip-clang/scip-python
-        // runs, and a Python (or C) edge's `compiler` tier lives under that tool's verdicts. An
-        // edge belongs to one language, so the per-tool verdict sets are disjoint — merging can't
-        // collide.
+        // runs, and a Python (or C) edge's `compiler` tier lives under that tool's verdicts.
+        // BATCH tools merge FIRST and WIN ties: batch verdict sets are disjoint across languages,
+        // but a LIVE tool (`ra-lsp`, #534) covers the SAME Rust edges its batch counterpart does,
+        // so overlap is real. The batch pass is the canonical writer (whole-checkout,
+        // authoritative clear, moniker-minting); a live verdict for the same edge is a freshness
+        // patch that must not displace it. Batch-first order + first-writer-wins per edge_id
+        // gives exactly that, deterministically (never relying on ALL's declaration order).
         let conn = self.storage.connection();
-        let runs = rag_rat_oracle::latest_runs_in_scope(
+        let mut runs = rag_rat_oracle::latest_runs_in_scope(
             conn,
             &self.active_commit_sha,
             &self.active_worktree_id,
@@ -99,17 +103,21 @@ impl IndexDatabase {
             // No oracle run for this checkout — nothing to surface, all hops stay heuristic.
             return Ok(false);
         }
+        // Stable sort: batch tools (`batch_capable`) first, preserving their ALL order.
+        runs.sort_by_key(|(tool, _)| !tool.batch_capable());
         let edge_ids = hops.iter().map(|hop| hop.edge_id).collect::<Vec<_>>();
         let mut verdicts = std::collections::HashMap::new();
         for (tool, tool_version) in &runs {
-            verdicts.extend(rag_rat_oracle::current_oracle_verdicts_for_edges(
+            for (edge_id, verdict) in rag_rat_oracle::current_oracle_verdicts_for_edges(
                 conn,
                 *tool,
                 tool_version,
                 &self.active_commit_sha,
                 &self.active_worktree_id,
                 &edge_ids,
-            )?);
+            )? {
+                verdicts.entry(edge_id).or_insert(verdict);
+            }
         }
         if verdicts.is_empty() {
             return Ok(false);
@@ -473,15 +481,21 @@ impl IndexDatabase {
         let conn = self.storage.connection();
         // Compare against EVERY backend with a run in this checkout, not just rust-analyzer (#176):
         // a mixed-language repo's contradictions span tools (a C edge under scip-clang, a Python
-        // edge under scip-python). Verdict sets are disjoint by edge language, so aggregating is a
-        // plain concatenation.
-        let runs = rag_rat_oracle::latest_runs_in_scope(
+        // edge under scip-python). Batch tools report FIRST and win per-edge ties (#534): batch
+        // verdict sets are disjoint across languages, but a live tool (`ra-lsp`) overlaps its
+        // batch counterpart on the same Rust edges — without the dedupe one edge would appear
+        // once per tool, and the batch (canonical) verdict is the one to show.
+        let mut runs = rag_rat_oracle::latest_runs_in_scope(
             conn,
             &self.active_commit_sha,
             &self.active_worktree_id,
         )?;
+        // Stable sort: batch tools (`batch_capable`) first, preserving their ALL order.
+        runs.sort_by_key(|(tool, _)| !tool.batch_capable());
         let mut summary = rag_rat_query::graph::CompareGraphScipSummary::default();
         let mut contradictions = Vec::new();
+        // Edge ids already reported as contradicted (batch-first dedupe, #534).
+        let mut contradicted_edge_ids = std::collections::HashSet::new();
         if runs.is_empty() {
             summary.no_oracle_data = true;
             summary.warnings.push(
@@ -511,6 +525,11 @@ impl IndexDatabase {
             summary.verdicts_examined += u64::try_from(comparisons.len()).unwrap_or(u64::MAX);
             for comparison in comparisons {
                 if comparison.kind != rag_rat_oracle::OracleResolutionKind::Contradict {
+                    continue;
+                }
+                // One row per edge: the batch tool's contradiction (merged first) stands over a
+                // live duplicate — same batch-wins-on-overlap precedence as the tier surfacing.
+                if !contradicted_edge_ids.insert(comparison.edge_id) {
                     continue;
                 }
                 contradictions.push(rag_rat_query::graph::GraphScipContradiction {

--- a/crates/rag-rat-core/src/index/query_api/graph.rs
+++ b/crates/rag-rat-core/src/index/query_api/graph.rs
@@ -514,6 +514,13 @@ impl IndexDatabase {
                 contradictions,
             });
         }
+        // Batch-wins precedence (#534): reserve EVERY edge a batch tool has a verdict on (any
+        // kind — Confirm/Upgrade/ResolvedExternal/Contradict) BEFORE emitting any live
+        // contradiction. `runs` is sorted batch-first, so by the time a live tool is examined
+        // `batch_covered` holds all batch-covered edges. A live `Contradict` on a batch-covered
+        // edge is suppressed: the batch pass is canonical, so surfacing a live disagreement the
+        // authoritative tool doesn't share would be a false "compiler disagrees with the graph".
+        let mut batch_covered = std::collections::HashSet::new();
         for (tool, version) in &runs {
             let comparisons = rag_rat_oracle::current_oracle_comparisons(
                 conn,
@@ -523,7 +530,14 @@ impl IndexDatabase {
                 &self.active_worktree_id,
             )?;
             summary.verdicts_examined += u64::try_from(comparisons.len()).unwrap_or(u64::MAX);
+            let is_batch = tool.batch_capable();
             for comparison in comparisons {
+                if is_batch {
+                    batch_covered.insert(comparison.edge_id);
+                } else if batch_covered.contains(&comparison.edge_id) {
+                    // A batch tool already spoke for this edge — its verdict wins.
+                    continue;
+                }
                 if comparison.kind != rag_rat_oracle::OracleResolutionKind::Contradict {
                     continue;
                 }

--- a/crates/rag-rat-core/src/index/query_api/importance.rs
+++ b/crates/rag-rat-core/src/index/query_api/importance.rs
@@ -418,7 +418,13 @@ impl IndexDatabase {
             return Ok(None);
         }
         let mut effects: Option<std::collections::HashMap<i64, EdgeOracleEffect>> = None;
-        for &tool in rag_rat_oracle::OracleTool::ALL {
+        // BATCH tools first (#534): batch verdict sets are disjoint across languages, but a live
+        // tool (`ra-lsp`) overlaps its batch counterpart on the same Rust edges. The batch pass
+        // is canonical, so first-writer-wins per edge_id gives batch-wins-on-overlap —
+        // deterministically, not via ALL's declaration order.
+        let mut tools = rag_rat_oracle::OracleTool::ALL.to_vec();
+        tools.sort_by_key(|tool| !tool.batch_capable());
+        for tool in tools {
             let Some(version) = self.latest_oracle_run_version(tool)? else {
                 continue;
             };
@@ -441,9 +447,10 @@ impl IndexDatabase {
                     // Upgrade we can't name a target for: leave the edge heuristic.
                     (Kind::Upgrade, None) => continue,
                 };
-                // An edge belongs to one file → one language → at most one tool's verdict, so this
-                // never overwrites a different tool's effect for the same edge.
-                map.insert(edge_id, effect);
+                // First writer wins: the batch tool's effect stands over a live duplicate for
+                // the same edge (batch is canonical); disjoint-language batch tools never
+                // collide with each other.
+                map.entry(edge_id).or_insert(effect);
             }
         }
         Ok(effects)

--- a/crates/rag-rat-core/src/index/query_api/oracle_runs.rs
+++ b/crates/rag-rat-core/src/index/query_api/oracle_runs.rs
@@ -89,6 +89,40 @@ impl IndexDatabase {
         )
     }
 
+    /// Run the live oracle's per-pass resolution (#534) over `worklist` (repo-relative Rust
+    /// paths the maintenance pass just reindexed, plus any backlog): resolve their callees
+    /// through the resident LSP `session` and write `ra-lsp` verdicts + a backing run row in one
+    /// transaction. The batch pass stays the canonical writer — live rows are a per-pass
+    /// freshness patch, and there is NO authoritative clear. Best-effort for LSP-side failures
+    /// (a dead server aborts the remaining worklist into `unfinished_paths`, never fails);
+    /// `Err` is DB-only.
+    pub fn run_live_oracle_pass(
+        &self,
+        session: &mut rag_rat_oracle::LiveOracleSession,
+        worklist: &[String],
+        max_requests: u64,
+        started_at_ms: i64,
+    ) -> anyhow::Result<rag_rat_oracle::LivePassReport> {
+        let Some(root) = self.storage.source_root() else {
+            anyhow::bail!(
+                "index has no source_root metadata; rebuild required for the live oracle pass"
+            );
+        };
+        let root = root.to_path_buf();
+        rag_rat_oracle::live_oracle_pass(
+            self.storage.connection(),
+            session,
+            &rag_rat_oracle::LivePassInput {
+                commit_sha: &self.active_commit_sha,
+                worktree_id: &self.active_worktree_id,
+                checkout_root: &root,
+                worklist,
+                max_requests,
+                started_at_ms,
+            },
+        )
+    }
+
     /// Heuristic-vs-oracle eval metrics (precision/recall/recovery) for a tool/version, diffing the
     /// persisted `edge_oracle` rows against the `edges` heuristic. [`RecallCalls`] is the
     /// `(covered_calls, oracle_only_calls)` pair reported by the most recent [`run_oracle`] — both

--- a/crates/rag-rat-core/src/index/query_api/oracle_runs.rs
+++ b/crates/rag-rat-core/src/index/query_api/oracle_runs.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 
 use rag_rat_base::time::now_ms;
 use rag_rat_oracle::{
-    self, OracleEvalMetrics, OracleReport, OracleStatus, OracleTool, RecallCalls,
+    self, OracleEvalMetrics, OracleReport, OracleStatus, OracleTool, RecallCalls, ToolManifest,
 };
 
 use super::*;
@@ -262,10 +262,15 @@ impl IndexDatabase {
         self.run_oracle(tool, tool_version, scip_bytes, OracleShaSnapshots::default())
     }
 
-    /// Probe whether an oracle tool is installed, for `oracle status`. A `Blocked` probe is
-    /// informational (the tool isn't installed), never an error.
+    /// Probe whether an oracle tool is installed, for `oracle status`. Config-backed opens probe
+    /// from the checkout root so rustup directory overrides select the same rust-analyzer as the
+    /// watcher. A `Blocked` probe is informational (the tool isn't installed), never an error.
     pub fn probe_oracle_tool(&self, tool: OracleTool) -> rag_rat_oracle::ToolAvailability {
-        rag_rat_oracle::probe_oracle_tool(tool)
+        let manifest = ToolManifest::for_tool(tool);
+        match &self.config {
+            Some(config) => manifest.probe_in(&config.root),
+            None => manifest.probe(),
+        }
     }
 
     /// The `tool_version` of the most recent oracle run for `tool` in this checkout, or `None` when

--- a/crates/rag-rat-core/src/index/query_api/oracle_surfacing_tests.rs
+++ b/crates/rag-rat-core/src/index/query_api/oracle_surfacing_tests.rs
@@ -363,6 +363,123 @@ fn compare_graph_to_scip_surfaces_non_rust_analyzer_tools() {
     );
 }
 
+/// #534 batch-wins-on-overlap: a clean Rust edge can carry BOTH the batch `rust-analyzer` and
+/// the live `ra-lsp` tool's current verdicts (live covers the same edges at pass cadence). The
+/// batch pass is canonical, so the hop must surface the BATCH verdict — never displaced by the
+/// live one, regardless of `OracleTool::ALL` declaration order. Here the batch Confirms
+/// (compiler tier) while the live Contradicts (would NOT promote): if the merge order let the
+/// live row win, the edge would silently drop out of the compiler tier.
+#[test]
+fn batch_verdict_wins_over_live_for_the_same_edge() {
+    let root = temp_root();
+    fs::write(root.join("src/lib.rs"), "fn caller() { target(); } fn target() {}\n").unwrap();
+    let config = rust_config(root.to_path_buf());
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let (edge_id, cs, ce, path) = call_edge(&db);
+    // Force the heuristic edge in-corpus-resolved so the live external resolution below is a
+    // Contradict (not a resolved-external label).
+    let target_sym: i64 = db
+        .storage
+        .connection()
+        .query_row("SELECT id FROM symbols WHERE name = 'target' LIMIT 1", [], |r| r.get(0))
+        .unwrap();
+    db.storage
+        .connection()
+        .execute(
+            "UPDATE edges SET confidence = 'Exact', resolution = 'exact', to_symbol_id = ?2 WHERE \
+             id = ?1",
+            params![edge_id, target_sym],
+        )
+        .unwrap();
+
+    // Batch (canonical): resolve in-corpus → Confirm → compiler tier.
+    let symbol = "scip-rust crate held-mini `target`().";
+    let scip = scip_with(&path, cs, ce, symbol, Some(&path), Some((29, 35)));
+    db.run_oracle_from_scip(OracleTool::RustAnalyzer, "v-batch", &scip).unwrap();
+
+    // Live (`ra-lsp`): a DIFFERENT verdict on the SAME edge — an external placement, which
+    // against the in-corpus heuristic classifies as a Contradict. (Written through the batch
+    // consumption path under the ra-lsp tool id: the read-side merge can't tell the difference,
+    // which is exactly what makes this a valid precedence fixture.)
+    let live_symbol = "scip-rust cargo other 1.0 `target`().";
+    let live_scip = scip_with(&path, cs, ce, live_symbol, None, None);
+    db.run_oracle_from_scip(OracleTool::RaLsp, "v-live", &live_scip).unwrap();
+
+    // The batch verdict must survive the merge: still compiler, still the batch's reason.
+    let callers = db
+        .find_callers_with_options("target", 50, &rag_rat_query::graph::GraphTraversalOptions {
+            include_unresolved: true,
+            ..Default::default()
+        })
+        .unwrap();
+    let hop = callers.iter().find(|h| h.edge_id == edge_id).expect("call edge present");
+    assert_eq!(
+        hop.confidence, "compiler",
+        "the batch verdict must win over the live one for the same edge"
+    );
+    assert_eq!(hop.resolution_reason.as_deref(), Some("scip:rust-analyzer@v-batch"));
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+/// #534: when BOTH the batch and the live tool contradict the same edge, `compare_graph_to_scip`
+/// reports the edge ONCE, carrying the batch (canonical) tool's evidence — never two rows for
+/// one edge, and never the live tool's version of the disagreement.
+#[test]
+fn compare_graph_to_scip_dedupes_cross_tool_contradictions_batch_first() {
+    let root = temp_root();
+    fs::write(root.join("src/lib.rs"), "fn caller() { target(); } fn target() {}\n").unwrap();
+    let config = rust_config(root.to_path_buf());
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let (edge_id, cs, ce, path) = call_edge(&db);
+    let target_sym: i64 = db
+        .storage
+        .connection()
+        .query_row("SELECT id FROM symbols WHERE name = 'target' LIMIT 1", [], |r| r.get(0))
+        .unwrap();
+    db.storage
+        .connection()
+        .execute(
+            "UPDATE edges SET confidence = 'Exact', resolution = 'exact', to_symbol_id = ?2 WHERE \
+             id = ?1",
+            params![edge_id, target_sym],
+        )
+        .unwrap();
+
+    // Both tools contradict the same in-corpus edge, with DIFFERENT external targets.
+    let batch_symbol = "scip-rust cargo batchdep 1.0 `target`().";
+    db.run_oracle_from_scip(
+        OracleTool::RustAnalyzer,
+        "v-batch",
+        &scip_with(&path, cs, ce, batch_symbol, None, None),
+    )
+    .unwrap();
+    let live_symbol = "scip-rust cargo livedep 1.0 `target`().";
+    db.run_oracle_from_scip(
+        OracleTool::RaLsp,
+        "v-live",
+        &scip_with(&path, cs, ce, live_symbol, None, None),
+    )
+    .unwrap();
+
+    let compare = db.compare_graph_to_scip().unwrap();
+    assert_eq!(
+        compare.summary.contradictions, 1,
+        "one edge, one contradiction row (deduped): {compare:?}"
+    );
+    let c = &compare.contradictions[0];
+    assert_eq!(c.edge_id, edge_id);
+    assert_eq!(
+        c.resolved_external.as_deref(),
+        Some("resolved-external(batchdep)"),
+        "the batch tool's evidence wins the dedupe"
+    );
+
+    let _ = fs::remove_dir_all(&root);
+}
+
 /// #82 P0: when a run EXISTS but examined 0 in-scope verdicts, `compare_graph_to_scip` must WARN
 /// — that is "run-but-empty" (the silent symptom of the scope bug), not "compiler agrees". Here
 /// a run writes a verdict, then the callsite file drifts so the current-content gate

--- a/crates/rag-rat-core/src/index/query_api/oracle_surfacing_tests.rs
+++ b/crates/rag-rat-core/src/index/query_api/oracle_surfacing_tests.rs
@@ -480,6 +480,63 @@ fn compare_graph_to_scip_dedupes_cross_tool_contradictions_batch_first() {
     let _ = fs::remove_dir_all(&root);
 }
 
+/// #534: when the canonical batch tool has ANY verdict on an edge (here a `Confirm`) but the
+/// live tool `Contradict`s the same edge, `compare_graph_to_scip` suppresses the live
+/// contradiction — a batch-covered edge never surfaces a live-only disagreement (the batch is
+/// authoritative; showing it would be a false "compiler disagrees with the graph").
+#[test]
+fn compare_graph_to_scip_suppresses_a_live_contradiction_on_a_batch_covered_edge() {
+    let root = temp_root();
+    fs::write(root.join("src/lib.rs"), "fn caller() { target(); } fn target() {}\n").unwrap();
+    let config = rust_config(root.to_path_buf());
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let (edge_id, cs, ce, path) = call_edge(&db);
+    // Batch (rust-analyzer): resolve in-corpus → Confirm (agreement-shaped, no contradiction).
+    db.run_oracle_from_scip(
+        OracleTool::RustAnalyzer,
+        "v-batch",
+        &scip_with(
+            &path,
+            cs,
+            ce,
+            "scip-rust crate held-mini `target`().",
+            Some(&path),
+            Some((29, 35)),
+        ),
+    )
+    .unwrap();
+    // Force the heuristic edge in-corpus-resolved so the live external resolution is a
+    // Contradict, then write it under the live tool for the SAME edge.
+    let target_sym: i64 = db
+        .storage
+        .connection()
+        .query_row("SELECT id FROM symbols WHERE name = 'target' LIMIT 1", [], |r| r.get(0))
+        .unwrap();
+    db.storage
+        .connection()
+        .execute(
+            "UPDATE edges SET confidence = 'Exact', resolution = 'exact', to_symbol_id = ?2 WHERE \
+             id = ?1",
+            params![edge_id, target_sym],
+        )
+        .unwrap();
+    db.run_oracle_from_scip(
+        OracleTool::RaLsp,
+        "v-live",
+        &scip_with(&path, cs, ce, "scip-rust cargo other 1.0 `target`().", None, None),
+    )
+    .unwrap();
+
+    let compare = db.compare_graph_to_scip().unwrap();
+    assert_eq!(
+        compare.summary.contradictions, 0,
+        "the batch Confirm covers the edge, so the live Contradict is suppressed: {compare:?}"
+    );
+
+    let _ = fs::remove_dir_all(&root);
+}
+
 /// #82 P0: when a run EXISTS but examined 0 in-scope verdicts, `compare_graph_to_scip` must WARN
 /// — that is "run-but-empty" (the silent symptom of the scope bug), not "compiler agrees". Here
 /// a run writes a verdict, then the callsite file drifts so the current-content gate

--- a/crates/rag-rat-core/src/watch/event_loop.rs
+++ b/crates/rag-rat-core/src/watch/event_loop.rs
@@ -11,6 +11,7 @@ use rag_rat_base::config::Config;
 use rag_rat_base::locks::{self, FileLock};
 use rag_rat_papertrail::AutosyncRequest;
 
+use super::live_oracle::LiveOracleTail;
 use super::overlay::OverlayScope;
 use super::papertrail::{self, PapertrailClock, PapertrailScheduler};
 use super::pass::{
@@ -197,22 +198,29 @@ fn watcher_main(
         }
     }
 
-    // Maintenance passes run on the worker thread (#506); see `spawn_pass_worker` for why.
+    // Maintenance passes run on the worker thread (#506); see `spawn_pass_worker` for why. The
+    // live oracle's resident session + backlog (#534) lives here too — owned by the pass-worker
+    // closure, so it survives across passes but dies with the watcher.
     let (pass_tx, pass_rx) = std::sync::mpsc::channel();
     let Some(pass_worker) = spawn_pass_worker(pass_rx, tx, {
         let config = config.clone();
         // This watcher's counters, shared with the event-loop thread that records into them; the
         // pass reads them to persist the placement-failure high-water mark for `index_status`.
         let watch_counters = Arc::clone(&watch_counters);
+        let mut live_oracle = LiveOracleTail::new();
         move |request| {
             let _ = match request {
-                PassRequest::StartupCatchup =>
-                    startup_catchup_pass(&config, Some(watch_counters.as_ref())),
+                PassRequest::StartupCatchup => startup_catchup_pass(
+                    &config,
+                    Some(watch_counters.as_ref()),
+                    Some(&mut live_oracle),
+                ),
                 PassRequest::Maintenance { run_gc, overlay_scope } => maintenance_pass_scoped(
                     &config,
                     *run_gc,
                     overlay_scope,
                     Some(watch_counters.as_ref()),
+                    Some(&mut live_oracle),
                 ),
             };
         }

--- a/crates/rag-rat-core/src/watch/live_oracle.rs
+++ b/crates/rag-rat-core/src/watch/live_oracle.rs
@@ -1,0 +1,169 @@
+//! The live oracle's maintenance-pass tail (#74 slice 2 / #534): the watcher-owned state that
+//! drives [`rag_rat_oracle::live_oracle_pass`] — the resident LSP session (lazily spawned,
+//! idle-shutdown) and the backlog of changed paths a prior pass's request budget didn't reach.
+//!
+//! Gating (all cheap, in order): `[oracle.live] enabled` (standalone — it does NOT imply or
+//! require `[oracle] auto_run`), Rust among the checkout's indexed languages, and a non-empty
+//! worklist (backlog ∪ this pass's changed `.rs` paths). A pass with no reliable changed set
+//! (a heal/bootstrap leaves `clone_delta_hint = None`) contributes no paths: live's scope is
+//! exactly "files the pass reindexed", and a whole-checkout sweep is the BATCH pass's job.
+//!
+//! Everything here is best-effort: a missing `rust-analyzer`, a failed spawn, or a dead server
+//! mid-pass never fails the maintenance pass — the worklist rides to the next pass via the
+//! backlog, and the session is dropped so a later pass respawns (crash tolerance/warm-up
+//! hardening is slice 3, #535).
+
+use std::collections::{BTreeSet, HashSet};
+
+use rag_rat_base::config::Config;
+use rag_rat_base::language::Language;
+use rag_rat_base::time::now_ms;
+use rag_rat_oracle::LiveOracleSession;
+
+use crate::index::IndexDatabase;
+
+/// Resident live-oracle state for one watcher: the LSP session + the deferred-path backlog.
+/// Owned by the pass-worker closure (it must outlive individual passes); the hook/CLI
+/// `maintenance_pass*` entry points pass no state, so the live stage only ever runs from the
+/// resident watcher — a one-shot CLI pass must not spawn a minutes-warming language server.
+pub(crate) struct LiveOracleTail {
+    session: Option<LiveOracleSession>,
+    backlog: Vec<String>,
+}
+
+impl LiveOracleTail {
+    pub(crate) fn new() -> Self {
+        Self { session: None, backlog: Vec::new() }
+    }
+
+    /// One pass's live stage: the idle-shutdown sweep, then (when enabled and there is work)
+    /// resolve the changed Rust files through the resident client. Never returns an error — a
+    /// failure is logged and the work rides the next pass.
+    pub(crate) fn on_pass(
+        &mut self,
+        db: &IndexDatabase,
+        config: &Config,
+        changed_paths: Option<&BTreeSet<String>>,
+    ) {
+        let live_cfg = &config.oracle.live;
+        if !live_cfg.enabled {
+            return;
+        }
+        let now = now_ms();
+        // Idle-shutdown sweep: an idle server shouldn't hold rust-analyzer's resident memory.
+        // Runs even on a workless (quiet) pass — that is exactly when idleness accrues.
+        if self.session.as_ref().is_some_and(|session| {
+            session.idle_for(now, live_cfg.idle_shutdown_secs.saturating_mul(1000))
+        }) && let Some(session) = self.session.take()
+        {
+            tracing::debug!(target: "rag_rat_core::watch", "live oracle: idle shutdown");
+            session.shutdown();
+        }
+
+        // The worklist: backlog first (older edits wait longest), then this pass's changed Rust
+        // paths, deduped. `changed_paths` is `None` on a heal/bootstrap — no reliable superset,
+        // so only the backlog rides.
+        let worklist = assemble_worklist(std::mem::take(&mut self.backlog), changed_paths);
+        if worklist.is_empty() {
+            return;
+        }
+        // Rust must be an indexed language of this checkout (ra-lsp's language).
+        if !config.targets.iter().any(|target| target.language == Language::Rust) {
+            return;
+        }
+
+        // Spawn the session lazily on the first eligible pass. `None` (rust-analyzer absent /
+        // unw spawnable) leaves the work in the backlog for a later pass — the same
+        // degrade-quietly UX as a missing embedding model.
+        if self.session.is_none() {
+            self.session = LiveOracleSession::spawn(&config.root, now);
+        }
+        let Some(session) = &mut self.session else {
+            self.backlog = worklist;
+            return;
+        };
+
+        match db.run_live_oracle_pass(session, &worklist, live_cfg.max_requests_per_pass, now) {
+            Ok(report) => {
+                self.backlog = report.unfinished_paths.clone();
+                if report.rows_written > 0 || !report.unfinished_paths.is_empty() {
+                    tracing::info!(
+                        target: "rag_rat_core::watch",
+                        rows_written = report.rows_written,
+                        upgraded = report.upgraded,
+                        confirmed = report.confirmed,
+                        contradicted = report.contradicted,
+                        requests = report.requests_used,
+                        deferred = report.unfinished_paths.len(),
+                        refinements_invalidated = report.refinements_invalidated,
+                        status = %report.status,
+                        "live oracle pass"
+                    );
+                }
+            },
+            Err(err) => {
+                // A DB-side failure (the only `Err`): drop the session so the next pass
+                // respawns fresh, keep the whole worklist riding, and never fail the pass.
+                if let Some(session) = self.session.take() {
+                    session.shutdown();
+                }
+                self.backlog = worklist;
+                tracing::warn!(
+                    target: "rag_rat_core::watch",
+                    error = %err,
+                    "live oracle pass failed; worklist deferred to the next pass"
+                );
+            },
+        }
+    }
+}
+
+/// The pass's worklist: backlog paths first (oldest edits wait longest), then the changed
+/// `.rs` paths (ra-lsp's language), deduped, order-preserving. `None` changed paths (a
+/// heal/bootstrap pass) contributes nothing — only the backlog rides.
+fn assemble_worklist(
+    backlog: Vec<String>,
+    changed_paths: Option<&BTreeSet<String>>,
+) -> Vec<String> {
+    let mut seen = HashSet::new();
+    let mut worklist = Vec::new();
+    for path in backlog {
+        if seen.insert(path.clone()) {
+            worklist.push(path);
+        }
+    }
+    if let Some(paths) = changed_paths {
+        for path in paths.iter().filter(|p| p.ends_with(".rs")) {
+            if seen.insert(path.clone()) {
+                worklist.push(path.clone());
+            }
+        }
+    }
+    worklist
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn worklist_dedupes_backlog_against_changed_and_filters_non_rust() {
+        let backlog = vec!["src/a.rs".to_string(), "src/b.rs".to_string()];
+        let changed = BTreeSet::from([
+            "src/b.rs".to_string(),
+            "src/c.rs".to_string(),
+            "Cargo.toml".to_string(),
+        ]);
+        let worklist = assemble_worklist(backlog, Some(&changed));
+        // Backlog order first, then new changed paths; duplicates collapse; non-Rust dropped.
+        assert_eq!(worklist, vec!["src/a.rs", "src/b.rs", "src/c.rs"]);
+    }
+
+    #[test]
+    fn worklist_without_changed_set_rides_backlog_only() {
+        let backlog = vec!["src/a.rs".to_string()];
+        // A heal/bootstrap pass (None) contributes no paths.
+        assert_eq!(assemble_worklist(backlog, None), vec!["src/a.rs"]);
+        assert!(assemble_worklist(Vec::new(), None).is_empty());
+    }
+}

--- a/crates/rag-rat-core/src/watch/live_oracle.rs
+++ b/crates/rag-rat-core/src/watch/live_oracle.rs
@@ -86,6 +86,19 @@ impl LiveOracleTail {
         match db.run_live_oracle_pass(session, &worklist, live_cfg.max_requests_per_pass, now) {
             Ok(report) => {
                 self.backlog = report.unfinished_paths.clone();
+                // An aborted pass means the server died or wedged mid-resolution: drop the
+                // session so the next pass respawns a clean one instead of reusing a broken
+                // transport (the aborted files are already requeued in `unfinished_paths`).
+                if report.status.starts_with("Aborted:")
+                    && let Some(session) = self.session.take()
+                {
+                    tracing::warn!(
+                        target: "rag_rat_core::watch",
+                        status = %report.status,
+                        "live oracle: server aborted; session dropped, respawn on next pass"
+                    );
+                    session.shutdown();
+                }
                 if report.rows_written > 0 || !report.unfinished_paths.is_empty() {
                     tracing::info!(
                         target: "rag_rat_core::watch",

--- a/crates/rag-rat-core/src/watch/mod.rs
+++ b/crates/rag-rat-core/src/watch/mod.rs
@@ -21,6 +21,7 @@
 //!   never postponed by an in-flight maintenance pass.
 
 mod event_loop;
+mod live_oracle;
 mod overlay;
 mod papertrail;
 mod pass;

--- a/crates/rag-rat-core/src/watch/pass.rs
+++ b/crates/rag-rat-core/src/watch/pass.rs
@@ -6,6 +6,7 @@ use notify::Event;
 use rag_rat_base::config::Config;
 use rag_rat_base::locks::{self};
 
+use super::live_oracle::LiveOracleTail;
 use super::overlay::{OverlayScope, ReconcileBudget, refresh_worktree_overlays};
 use super::placement::WatchPlacementCounters;
 use crate::index::IndexDatabase;
@@ -269,22 +270,25 @@ pub(crate) fn spawn_pass_worker(
 /// The hook/CLI entry point — it has no resident watcher, so there are no watch-placement counters
 /// to persist (`None`); a running watcher records its own via [`maintenance_pass_scoped`].
 pub fn maintenance_pass(config: &Config, run_gc: bool) -> anyhow::Result<()> {
-    maintenance_pass_scoped(config, run_gc, &OverlayScope::All, None)
+    maintenance_pass_scoped(config, run_gc, &OverlayScope::All, None, None)
 }
 
 /// [`maintenance_pass`] with an explicit overlay scope — the watcher's event-driven passes name
 /// the checkouts events came from instead of sweeping the whole worktree fleet (#577). The resident
 /// watcher passes `Some(counters)` so this pass persists its watch-placement failure high-water
-/// mark; the hook/CLI wrapper above passes `None`.
+/// mark; the hook/CLI wrapper above passes `None`. Only the resident watcher passes
+/// `Some(live_oracle)` (#534): the live tail owns a resident language server, and a one-shot
+/// hook/CLI pass must not spawn one (minutes of warm-up for a process about to exit).
 pub(crate) fn maintenance_pass_scoped(
     config: &Config,
     run_gc: bool,
     overlay_scope: &OverlayScope,
     watch_counters: Option<&WatchPlacementCounters>,
+    live_oracle: Option<&mut LiveOracleTail>,
 ) -> anyhow::Result<()> {
     let lock_repo = locks::write_lock_repo_id(config);
     let _lock = locks::WriteLock::acquire_blocking(&config.database, &lock_repo)?;
-    run_pass(config, run_gc, false, overlay_scope, watch_counters)
+    run_pass(config, run_gc, false, overlay_scope, watch_counters, live_oracle)
 }
 
 /// Run one maintenance pass only if the write lock is free within `SKIP_TIMEOUT`; returns whether
@@ -294,7 +298,7 @@ pub fn maintenance_pass_or_skip(config: &Config, run_gc: bool) -> anyhow::Result
     let lock_repo = locks::write_lock_repo_id(config);
     match locks::WriteLock::acquire_timeout(&config.database, &lock_repo, SKIP_TIMEOUT)? {
         Some(_lock) => {
-            run_pass(config, run_gc, false, &OverlayScope::All, None)?;
+            run_pass(config, run_gc, false, &OverlayScope::All, None, None)?;
             Ok(true)
         },
         None => Ok(false),
@@ -304,10 +308,11 @@ pub fn maintenance_pass_or_skip(config: &Config, run_gc: bool) -> anyhow::Result
 pub(crate) fn startup_catchup_pass(
     config: &Config,
     watch_counters: Option<&WatchPlacementCounters>,
+    live_oracle: Option<&mut LiveOracleTail>,
 ) -> anyhow::Result<()> {
     let lock_repo = locks::write_lock_repo_id(config);
     let _lock = locks::WriteLock::acquire_blocking(&config.database, &lock_repo)?;
-    run_pass(config, STARTUP_CATCHUP_RUN_GC, true, &OverlayScope::All, watch_counters)
+    run_pass(config, STARTUP_CATCHUP_RUN_GC, true, &OverlayScope::All, watch_counters, live_oracle)
 }
 
 fn run_pass(
@@ -316,6 +321,7 @@ fn run_pass(
     retry_base_embedding_backlog: bool,
     overlay_scope: &OverlayScope,
     watch_counters: Option<&WatchPlacementCounters>,
+    live_oracle: Option<&mut LiveOracleTail>,
 ) -> anyhow::Result<()> {
     let started = Instant::now();
     let mut timings = PassTimings::new(started);
@@ -401,6 +407,15 @@ fn run_pass(
     let clone_graph_due = db
         .clone_graph_rebuild_due(CLONE_GRAPH_QUIET_MS, base_tail_forced || base_embedding_backlog)
         .unwrap_or(false);
+    // Live oracle (#74 slice 2 / #534): resolve this pass's changed Rust files through the
+    // resident LSP client, writing `ra-lsp` verdicts as a per-pass freshness patch (the batch
+    // pass stays canonical). Runs BEFORE the tail decision on purpose: on a quiet pass the work
+    // side is a cheap no-op (no changed set, empty backlog), but the idle-shutdown sweep inside
+    // must still fire so a gone-quiet server releases the resident language server. Only the
+    // resident watcher passes the state in — hook/CLI passes skip the stage entirely.
+    if let Some(live) = live_oracle {
+        timings.stage("live_oracle", || live.on_pass(&db, config, clone_delta_hint.as_ref()));
+    }
     // Idle backstop (issue #63, facet 2): when the sweep changed nothing, skip everything past
     // discovery — an idle server should do no work. `run_gc` (every GC_EVERY_PASSES) still forces
     // a full tail, so the cases that DON'T flip content_changed are still caught within that

--- a/crates/rag-rat-core/src/watch/tests.rs
+++ b/crates/rag-rat-core/src/watch/tests.rs
@@ -809,7 +809,7 @@ fn startup_catchup_retries_existing_base_embedding_backlog() {
     );
     drop(db);
 
-    startup_catchup_pass(&config, None).unwrap();
+    startup_catchup_pass(&config, None, None).unwrap();
     let db = IndexDatabase::open_config(&config).unwrap();
     assert_eq!(
         db.pending_embedding_jobs().unwrap(),
@@ -962,7 +962,7 @@ fn startup_catchup_skips_ephemeral_backlog_scan_without_query_endpoint() {
     drop(db);
 
     crate::index::ai::reset_estimated_reconcile_job_calls();
-    startup_catchup_pass(&config, None).unwrap();
+    startup_catchup_pass(&config, None, None).unwrap();
     assert_eq!(
         crate::index::ai::estimated_reconcile_job_calls(),
         0,

--- a/crates/rag-rat-oracle/Cargo.toml
+++ b/crates/rag-rat-oracle/Cargo.toml
@@ -13,6 +13,7 @@ categories.workspace = true
 
 [dependencies]
 anyhow.workspace = true
+path-slash.workspace = true
 protobuf.workspace = true
 rag-rat-base.workspace = true
 rag-rat-clones.workspace = true
@@ -24,3 +25,4 @@ serde_json.workspace = true
 sha2.workspace = true
 strum.workspace = true
 toml.workspace = true
+url.workspace = true

--- a/crates/rag-rat-oracle/src/join.rs
+++ b/crates/rag-rat-oracle/src/join.rs
@@ -87,8 +87,26 @@ pub(crate) fn classify_edge(input: &JoinInput<'_>) -> Option<EdgeVerdict> {
 /// heuristic already resolved (Exact/Syntactic), upgrade otherwise (unresolved / NameOnly /
 /// Ambiguous).
 fn classify_resolved(input: &JoinInput<'_>, oracle_symbol_id: i64) -> OracleResolutionKind {
-    if heuristic_resolved_in_corpus(input) {
-        if heuristic_agrees_with_oracle(input, oracle_symbol_id) {
+    classify_in_corpus(
+        input.confidence,
+        input.heuristic_symbol_id,
+        oracle_symbol_id,
+        input.logical_symbol_of,
+    )
+}
+
+/// The in-corpus classification over plain values — shared with the LIVE oracle's write path
+/// (#534), which resolves a callee to an in-corpus symbol via the LSP definition rather than a
+/// SCIP occurrence but must apply the IDENTICAL confirm/contradict/upgrade taxonomy so live and
+/// batch verdicts are interchangeable downstream.
+pub(crate) fn classify_in_corpus(
+    confidence: &str,
+    heuristic_symbol_id: Option<i64>,
+    oracle_symbol_id: i64,
+    logical_symbol_of: &dyn Fn(i64) -> Option<i64>,
+) -> OracleResolutionKind {
+    if heuristic_resolved_in_corpus(confidence, heuristic_symbol_id) {
+        if heuristic_agrees_with_oracle(heuristic_symbol_id, oracle_symbol_id, logical_symbol_of) {
             OracleResolutionKind::Confirm
         } else {
             OracleResolutionKind::Contradict
@@ -108,17 +126,18 @@ fn classify_resolved(input: &JoinInput<'_>, oracle_symbol_id: i64) -> OracleReso
 /// confirm/contradict split was ~even because *which* concrete row the resolver returned first was
 /// order-dependent, not correctness-dependent). Concrete-equality stays the fast path; the logical
 /// lookup only runs when the ids differ.
-fn heuristic_agrees_with_oracle(input: &JoinInput<'_>, oracle_symbol_id: i64) -> bool {
-    let Some(heuristic_symbol_id) = input.heuristic_symbol_id else {
+fn heuristic_agrees_with_oracle(
+    heuristic_symbol_id: Option<i64>,
+    oracle_symbol_id: i64,
+    logical_symbol_of: &dyn Fn(i64) -> Option<i64>,
+) -> bool {
+    let Some(heuristic_symbol_id) = heuristic_symbol_id else {
         return false;
     };
     if heuristic_symbol_id == oracle_symbol_id {
         return true;
     }
-    match (
-        (input.logical_symbol_of)(heuristic_symbol_id),
-        (input.logical_symbol_of)(oracle_symbol_id),
-    ) {
+    match (logical_symbol_of(heuristic_symbol_id), logical_symbol_of(oracle_symbol_id)) {
         (Some(heuristic_logical), Some(oracle_logical)) => heuristic_logical == oracle_logical,
         _ => false,
     }
@@ -134,7 +153,7 @@ fn heuristic_agrees_with_oracle(input: &JoinInput<'_>, oracle_symbol_id: i64) ->
 /// heuristic did NOT resolve in-corpus (unresolved / `NameOnly` / `Ambiguous`): there is no
 /// in-corpus claim to contradict, just an external placement the heuristic missed.
 fn classify_external(input: &JoinInput<'_>) -> OracleResolutionKind {
-    if heuristic_resolved_in_corpus(input) {
+    if heuristic_resolved_in_corpus(input.confidence, input.heuristic_symbol_id) {
         OracleResolutionKind::Contradict
     } else {
         OracleResolutionKind::ResolvedExternal
@@ -144,8 +163,8 @@ fn classify_external(input: &JoinInput<'_>) -> OracleResolutionKind {
 /// Whether the heuristic already resolved this edge to an in-corpus symbol: an `Exact`/`Syntactic`
 /// confidence carrying a concrete `to_symbol_id`. This is the precondition for a confirm/contradict
 /// verdict (there is a heuristic claim to agree or disagree with).
-fn heuristic_resolved_in_corpus(input: &JoinInput<'_>) -> bool {
-    matches!(input.confidence, "Exact" | "Syntactic") && input.heuristic_symbol_id.is_some()
+fn heuristic_resolved_in_corpus(confidence: &str, heuristic_symbol_id: Option<i64>) -> bool {
+    matches!(confidence, "Exact" | "Syntactic") && heuristic_symbol_id.is_some()
 }
 
 /// The occurrence whose byte range contains the callee token. Prefers a reference occurrence (the

--- a/crates/rag-rat-oracle/src/lib.rs
+++ b/crates/rag-rat-oracle/src/lib.rs
@@ -22,6 +22,7 @@ mod auto_run;
 mod corpus;
 mod join;
 mod library_usage;
+mod live;
 pub(crate) mod lsp;
 mod manifest;
 mod report;
@@ -45,6 +46,7 @@ pub use library_usage::{
     LibraryUsageCallSite, LibraryUsageEntry, LibraryUsageOptions, LibraryUsageReport,
     LibraryUsageStatus, check_library_usage,
 };
+pub use live::{LiveOracleSession, LivePassInput, LivePassReport, live_oracle_pass};
 // LSP position conversion (line/char <-> byte under an encoding) — consumed by the engine's
 // corpus fixtures; the rest of `lsp` stays private.
 pub use lsp::position::{LineIndex, LspEncoding, LspPosition};
@@ -304,6 +306,20 @@ pub fn produce_scip_with_tool(
     scip_output: &Path,
 ) -> anyhow::Result<ScipProduction> {
     let manifest = ToolManifest::for_tool(tool);
+    // A live-only tool (`ra-lsp`) has no `scip_command` — it writes verdicts from the watcher's
+    // maintenance pass, not a whole-checkout index. Block with that explanation rather than
+    // probing/spawning anything (#534).
+    if !tool.batch_capable() {
+        return Ok(ScipProduction::Blocked {
+            tool: tool.as_db_str().to_string(),
+            program: manifest.program.to_string(),
+            hint: format!(
+                "{} is a live oracle backend: it runs from the watcher under `[oracle.live] \
+                 enabled`, not via `oracle run` — there is no `.scip` to produce.",
+                tool.as_db_str()
+            ),
+        });
+    }
     let version = match manifest.probe() {
         ToolAvailability::Available { version, .. } => version,
         ToolAvailability::Blocked { tool, program, hint } => {
@@ -700,17 +716,29 @@ pub enum OracleTool {
     /// scip-typescript; unlike scip-python/typescript it embeds no project version in local
     /// monikers (always `.` placeholders), so monikers are already commit-stable.
     ScipJava,
+    /// The LIVE rust-analyzer LSP client (#74 / #534) — a resident server resolving callees in
+    /// just-changed files at watcher cadence, writing the same `edge_oracle` shape the batch pass
+    /// writes. Deliberately a DISTINCT tool id from [`Self::RustAnalyzer`]: the
+    /// `(tool, tool_version)` axis of the `edge_oracle`/`oracle_runs` keys exists so writers of
+    /// different authority + cadence coexist, and reusing the batch id would make
+    /// `auto_run_decision` see the index as always-fresh (live run rows land every pass), silently
+    /// stopping the whole-checkout batch pass. Never batch-capable — see
+    /// [`Self::batch_capable`].
+    RaLsp,
 }
 
 impl OracleTool {
     /// Every known oracle tool, for "report on all tools" surfaces (`oracle status` with no
-    /// `--tool`). Later language backends extend this alongside the enum.
+    /// `--tool`). Later language backends extend this alongside the enum. Includes the LIVE tools
+    /// (`RaLsp`) — read surfaces merge across every writer with a run; batch-only DRIVERS must
+    /// filter through [`Self::batch_capable`].
     pub const ALL: &[OracleTool] = &[
         Self::RustAnalyzer,
         Self::ScipClang,
         Self::ScipPython,
         Self::ScipTypescript,
         Self::ScipJava,
+        Self::RaLsp,
     ];
 
     pub fn as_db_str(self) -> &'static str {
@@ -719,6 +747,26 @@ impl OracleTool {
 
     pub fn from_db_str(value: &str) -> Option<Self> {
         value.parse().ok()
+    }
+
+    /// Whether this tool produces/consumes whole-checkout `.scip` indexes — the batch paths:
+    /// `oracle run`, the background auto-run loop, the init-wizard tool listing, and
+    /// [`produce_scip_with_tool`]. `false` ONLY for the live LSP tools (`RaLsp`), which write
+    /// per-pass verdicts from the watcher and have no `scip_command`; every batch driver must skip
+    /// them rather than try to invoke them as indexers.
+    pub fn batch_capable(self) -> bool {
+        !matches!(self, Self::RaLsp)
+    }
+
+    /// The batch tool whose `logical_symbol_monikers` rows a LIVE tool copies into its own
+    /// `edge_oracle.scip_symbol` values, so live verdicts are byte-identical to what the batch
+    /// pass would write (clone-collapse + memory anchoring treat them as one evidence set, #534).
+    /// `None` for a batch tool (it mints monikers itself).
+    pub fn batch_moniker_source(self) -> Option<OracleTool> {
+        match self {
+            Self::RaLsp => Some(Self::RustAnalyzer),
+            _ => None,
+        }
     }
 
     /// Whether this backend's non-zero EXIT CODE reflects source DIAGNOSTICS rather than indexing
@@ -734,7 +782,6 @@ impl OracleTool {
     pub(crate) fn exit_code_reflects_diagnostics(self) -> bool {
         matches!(self, Self::ScipPython)
     }
-
     /// The position encoding to assume for SCIP documents this tool emits **without** an explicit
     /// `position_encoding` (the protobuf default `Unspecified`). scip-typescript reports ranges in
     /// UTF-16 code units (TypeScript's internal string offsets) but never sets the field, so
@@ -749,7 +796,9 @@ impl OracleTool {
             // UTF-16 count). Reading them as the UTF-32 fallback mis-converts past astral chars.
             Self::ScipTypescript | Self::ScipJava =>
                 PositionEncoding::UTF16CodeUnitOffsetFromLineStart,
-            Self::RustAnalyzer | Self::ScipClang | Self::ScipPython =>
+            // RaLsp never parses a `.scip` (the live client negotiates its own LSP encoding);
+            // the arm exists only for exhaustiveness.
+            Self::RustAnalyzer | Self::ScipClang | Self::ScipPython | Self::RaLsp =>
                 PositionEncoding::UnspecifiedPositionEncoding,
         }
     }

--- a/crates/rag-rat-oracle/src/live.rs
+++ b/crates/rag-rat-oracle/src/live.rs
@@ -249,17 +249,24 @@ pub fn live_oracle_pass(
             continue;
         };
 
-        let uri = format!("{}/{}", session.root_uri, path);
+        let uri = format!("{}/{}", session.root_uri, encode_uri_path(path));
         let starts: Vec<usize> =
             callees.iter().filter_map(|c| usize::try_from(c.callee_start_byte).ok()).collect();
         report.requests_used += starts.len() as u64;
         let resolved = match session.client.resolve_definitions(&uri, "rust", &text, &starts) {
             Ok(resolved) => resolved,
             Err(err) => {
-                // A dead/wedged server: keep what earlier files produced, abort the rest, and
-                // let the watcher drop the session (a later pass respawns). Never fail the
-                // maintenance pass over it (#535 hardens this further).
+                // A dead/wedged server: keep what earlier files produced, REQUEUE this file and
+                // every candidate-bearing path after it (the watcher rides them into the next
+                // pass and replaces the session), and never fail the maintenance pass over it
+                // (#535 hardens this further).
                 aborted = Some(err.to_string());
+                report.unfinished_paths.extend(
+                    input.worklist[position..]
+                        .iter()
+                        .filter(|p| by_path.contains_key(p.as_str()))
+                        .cloned(),
+                );
                 break 'files;
             },
         };
@@ -378,6 +385,12 @@ pub fn live_oracle_pass(
             None if report.unfinished_paths.is_empty() => "Completed".to_string(),
             None => "BudgetExhausted".to_string(),
         };
+        if refinements_stale {
+            rag_rat_clones::refine::cache::invalidate_scip_refinements(conn)?;
+            report.refinements_invalidated = true;
+        }
+        // Serialize AFTER every report field is final (the invalidation flag above rides the
+        // same stats_json the status surface reads).
         store::record_oracle_run_at(
             conn,
             tool,
@@ -388,10 +401,6 @@ pub fn live_oracle_pass(
             &report.status,
             &serde_json::to_string(&report).unwrap_or_else(|_| "{}".to_string()),
         )?;
-        if refinements_stale {
-            rag_rat_clones::refine::cache::invalidate_scip_refinements(conn)?;
-            report.refinements_invalidated = true;
-        }
     } else {
         report.status = match &aborted {
             Some(err) => format!("Aborted: {err}"),
@@ -400,7 +409,9 @@ pub fn live_oracle_pass(
         };
     }
     tx.commit()?;
-    session.touch(input.started_at_ms);
+    // Stamp usage at COMPLETION, not the pass's start: a pass longer than the idle window must
+    // not read as idle on the next pass (that would force a needless respawn + warm-up).
+    session.touch(rag_rat_base::time::now_ms());
     Ok(report)
 }
 
@@ -479,6 +490,21 @@ mod tests {
             Some("src/a file.rs".to_string())
         );
         assert_eq!(path_from_uri(root, "file:///elsewhere/src/lib.rs"), None);
+    }
+
+    #[test]
+    fn document_uri_encodes_the_relative_path() {
+        // A repo path carrying URI-reserved bytes (`#`, `%`, spaces, non-ASCII) must be encoded
+        // BEFORE joining the root URI, or the server parses `b.rs` as a fragment and the opened
+        // document never associates with the indexed file (#534 review).
+        assert_eq!(encode_uri_path("src/a b#c%.rs"), "src/a%20b%23c%25.rs");
+        let root = root_uri_for(Path::new("/repo"));
+        let uri = format!("{}/{}", root, encode_uri_path("src/доки/a b.rs"));
+        assert_eq!(
+            path_from_uri(&root, &uri),
+            Some("src/доки/a b.rs".to_string()),
+            "encode → open → decode round-trips the reserved-byte path"
+        );
     }
 
     #[test]

--- a/crates/rag-rat-oracle/src/live.rs
+++ b/crates/rag-rat-oracle/src/live.rs
@@ -162,8 +162,12 @@ pub struct LivePassReport {
     /// Whether the scip-mode refine cache was invalidated (a row's `scip_symbol` changed under
     /// an unchanged `file_sha`).
     pub refinements_invalidated: bool,
-    /// Whether an `oracle_runs` row backs this pass (only when `rows_written > 0`).
+    /// Whether an `oracle_runs` row backs this pass (when `rows_written > 0` or a version
+    /// migration made the new `tool_version` current).
     pub run_recorded: bool,
+    /// Whether prior-version live verdicts were migrated to the session's `tool_version` (a
+    /// `rust-analyzer` upgrade detected at spawn).
+    pub version_migrated: bool,
     /// Worklist paths the request budget didn't reach — the caller's backlog into the next pass.
     #[serde(skip)]
     pub unfinished_paths: Vec<String>,
@@ -199,16 +203,36 @@ pub fn live_oracle_pass(
     }
     report.files_with_candidates = by_path.len() as u64;
 
-    // The indexed shas the definition-side drift gate compares against (the callsite side uses
-    // each candidate's own `file_sha`, which IS the indexed sha of the just-reindexed file).
-    let indexed_shas =
-        store::indexed_file_shas_in_scope(conn, input.commit_sha, input.worktree_id)?;
-
     let tx = conn.unchecked_transaction()?;
     let mut refinements_stale = false;
+    // Version transition: a respawn probing a NEW `rust-analyzer --version` must not strand the
+    // prior version's still-current verdicts — the first partial pass's run row would become the
+    // latest for the whole checkout and gate every prior-version verdict out of currency,
+    // collapsing live coverage to the handful of files this pass revisits. Migrate the rows
+    // (content-addressed, so `file_sha` still gates drift) and invalidate the scip refinements
+    // whose evidence just changed hands.
+    let mut version_migrated = false;
+    if let Some(old_version) =
+        store::latest_run_tool_version(conn, tool, input.commit_sha, input.worktree_id)?
+        && old_version != session.tool_version()
+    {
+        let moved = store::migrate_live_verdicts_to_version(
+            conn,
+            tool,
+            &old_version,
+            session.tool_version(),
+        )?;
+        if moved > 0 {
+            version_migrated = true;
+            refinements_stale = true;
+        }
+    }
     let mut aborted: Option<String> = None;
-    // Per-pass caches: definition-file disk bytes and symbol spans, keyed by repo-relative path.
+    // Per-pass caches: definition-file disk bytes / indexed sha / symbol spans, keyed by
+    // repo-relative path (the LSP returns a bounded set of def paths, so these stay small — the
+    // whole-checkout sha map is deliberately NOT loaded).
     let mut def_bytes: HashMap<String, Option<Vec<u8>>> = HashMap::new();
+    let mut def_indexed_sha: HashMap<String, Option<String>> = HashMap::new();
     let mut def_spans: HashMap<String, Vec<store::SymbolSpan>> = HashMap::new();
     let logical_cache: std::cell::RefCell<HashMap<i64, Option<i64>>> =
         std::cell::RefCell::new(HashMap::new());
@@ -218,12 +242,9 @@ pub fn live_oracle_pass(
         let Some(callees) = by_path.get(path.as_str()) else {
             continue;
         };
-        // The request budget caps whole files (a file resolves fully or rides the next pass),
-        // except the FIRST candidate-bearing file, which always resolves even over budget so a
-        // huge file can never wedge the pass at zero progress.
-        if report.files_resolved > 0
-            && report.requests_used + callees.len() as u64 > input.max_requests
-        {
+        // Budget gate: nothing left → every candidate-bearing path from here rides the backlog.
+        let remaining = input.max_requests.saturating_sub(report.requests_used) as usize;
+        if remaining == 0 {
             report.unfinished_paths.extend(
                 input.worklist[position..]
                     .iter()
@@ -249,9 +270,32 @@ pub fn live_oracle_pass(
             continue;
         };
 
+        // Covered-skip continuation: a callee with a CURRENT live verdict (same tool_version +
+        // file_sha) is NEVER re-resolved for the same content — the budget only ever spends on
+        // unverdicted callees. A file a prior pass truncated therefore resumes exactly where it
+        // stopped, and a fully-covered file costs nothing (the first-file exemption this
+        // replaces let a huge generated file blow the budget). Re-resolution happens naturally
+        // on content change (a new `file_sha` un-covers the callee) — e.g. upgrading a sentinel
+        // to a batch moniker — or on a version migration, so a stale sentinel costs only
+        // cosmetics: the batch row carries the real evidence for any span both tools cover.
+        let covered = store::live_covered_callees_for_path(
+            conn,
+            tool,
+            session.tool_version(),
+            path,
+            &callees[0].file_sha,
+        )?;
+        let unverdicted: Vec<&store::EdgeJoinCandidate> =
+            callees.iter().copied().filter(|c| !covered.contains(&c.callee_start_byte)).collect();
+        if unverdicted.is_empty() {
+            continue;
+        }
+        let (to_resolve, deferred) = unverdicted.split_at(remaining.min(unverdicted.len()));
+        let deferred_count = deferred.len();
+
         let uri = format!("{}/{}", session.root_uri, encode_uri_path(path));
         let starts: Vec<usize> =
-            callees.iter().filter_map(|c| usize::try_from(c.callee_start_byte).ok()).collect();
+            to_resolve.iter().filter_map(|c| usize::try_from(c.callee_start_byte).ok()).collect();
         report.requests_used += starts.len() as u64;
         let resolved = match session.client.resolve_definitions(&uri, "rust", &text, &starts) {
             Ok(resolved) => resolved,
@@ -271,8 +315,13 @@ pub fn live_oracle_pass(
             },
         };
         report.files_resolved += 1;
+        if deferred_count > 0 {
+            // The budget cut this file short; it rides the backlog and resumes at the deferred
+            // callees (the covered-skip above makes that resume exact).
+            report.unfinished_paths.push(path.clone());
+        }
 
-        for (candidate, definition) in callees.iter().zip(resolved.iter()) {
+        for (candidate, definition) in to_resolve.iter().zip(resolved.iter()) {
             let Some((target_uri, target_range)) = definition else {
                 report.unresolved += 1;
                 continue;
@@ -294,11 +343,29 @@ pub fn live_oracle_pass(
                 report.skipped_drifted += 1;
                 continue;
             };
-            if indexed_shas.get(&def_path).map(String::as_str)
-                != Some(hex_sha256(&def_disk).as_str())
-            {
-                report.skipped_drifted += 1;
-                continue;
+            let indexed_sha = def_indexed_sha
+                .entry(def_path.clone())
+                .or_insert_with(|| {
+                    store::indexed_file_sha_for_path(
+                        conn,
+                        &def_path,
+                        input.commit_sha,
+                        input.worktree_id,
+                    )
+                    .unwrap_or(None)
+                })
+                .clone();
+            match indexed_sha {
+                // Not indexed in this checkout — nothing live can map to it.
+                None => {
+                    report.skipped_external += 1;
+                    continue;
+                },
+                Some(sha) if sha == hex_sha256(&def_disk) => {},
+                Some(_) => {
+                    report.skipped_drifted += 1;
+                    continue;
+                },
             }
             let index = LineIndex::new(&def_disk, session.client.encoding());
             let (Some(def_start), Some(def_end)) = (
@@ -378,10 +445,15 @@ pub fn live_oracle_pass(
         }
     }
 
-    if report.rows_written > 0 {
+    // A run row is recorded for a pass that WROTE verdicts OR migrated the tool version: the
+    // migration is what makes the new `tool_version` current for the currency gate, and without
+    // a backing run row the migrated rows stay invisible (the gate keys on the LATEST run).
+    report.version_migrated = version_migrated;
+    if report.rows_written > 0 || version_migrated {
         report.run_recorded = true;
         report.status = match &aborted {
             Some(err) => format!("Aborted: {err}"),
+            None if report.rows_written == 0 => "VersionMigrated".to_string(),
             None if report.unfinished_paths.is_empty() => "Completed".to_string(),
             None => "BudgetExhausted".to_string(),
         };

--- a/crates/rag-rat-oracle/src/live.rs
+++ b/crates/rag-rat-oracle/src/live.rs
@@ -22,9 +22,9 @@
 //!   only READS the moniker table.
 //! - **Currency.** The verdict rows + the backing `oracle_runs` row commit in ONE transaction — the
 //!   per-tool currency gate (`callee_moniker_current_clause`) must never see live rows without a
-//!   backing run. A run row is recorded only for a pass that wrote ≥1 row. There is NO
-//!   authoritative clear: live's scope is only this pass's changed files (the batch pass owns
-//!   whole-checkout authority).
+//!   backing run. A run row is recorded for a pass that wrote ≥1 row or migrated tool-version
+//!   currency. There is NO authoritative clear: live's scope is only this pass's changed files (the
+//!   batch pass owns whole-checkout authority).
 //! - **Refine cache.** When a live write CHANGES an existing row's `scip_symbol` for an UNCHANGED
 //!   `file_sha`, the scip-mode clone refinements that consulted the old evidence are invalidated
 //!   (nothing in the refinement key folds oracle content — the same reasoning as the batch hook in
@@ -72,11 +72,11 @@ impl LiveOracleSession {
     /// session's verdicts came from.
     pub fn spawn(checkout_root: &Path, now_ms: i64) -> Option<Self> {
         let manifest = ToolManifest::for_tool(OracleTool::RaLsp);
-        let ToolAvailability::Available { version, .. } = manifest.probe() else {
+        let ToolAvailability::Available { version, .. } = manifest.probe_in(checkout_root) else {
             return None;
         };
         let root_uri = root_uri_for(checkout_root)?;
-        let mut client = LspClient::spawn(manifest.program, &[]).ok()?;
+        let mut client = LspClient::spawn(manifest.program, &[], checkout_root).ok()?;
         client.initialize(&root_uri).ok()?;
         Some(Self { client, tool_version: version, root_uri, last_used_ms: now_ms })
     }
@@ -125,7 +125,7 @@ pub struct LivePassInput<'a> {
     /// The active checkout the just-reindexed files (and their edge candidates) are scoped to.
     pub commit_sha: &'a str,
     pub worktree_id: &'a str,
-    /// The checkout root: document URIs are `root_uri/path`, and target bytes are read from
+    /// The checkout root: `url::Url` converts each document path, and target bytes are read from
     /// `checkout_root/path`.
     pub checkout_root: &'a Path,
     /// Repo-relative paths the pass may resolve (the maintenance pass's changed set plus any
@@ -156,6 +156,9 @@ pub struct LivePassReport {
     pub contradicted: u64,
     /// Candidates/definitions skipped for content drift (callsite or definition document).
     pub skipped_drifted: u64,
+    /// Writes skipped because a sibling checkout still owns the same content key + tool version
+    /// for different file bytes (the schema cannot represent both because SHA is outside the PK).
+    pub skipped_content_collisions: u64,
     /// Definitions skipped as out-of-corpus for live purposes: target outside the checkout root,
     /// in an unindexed file, or mapping to no indexed symbol. Live writes no `resolved-external`
     /// rows (see the module docs).
@@ -163,7 +166,7 @@ pub struct LivePassReport {
     /// Callees the server left unresolved (a `null` definition — e.g. still indexing).
     pub unresolved: u64,
     /// Whether the scip-mode refine cache was invalidated (a row's `scip_symbol` changed under
-    /// an unchanged `file_sha`).
+    /// unchanged bytes, or newly inserted non-local evidence became visible).
     pub refinements_invalidated: bool,
     /// Whether an `oracle_runs` row backs this pass (when `rows_written > 0` or a version
     /// migration made the new `tool_version` current).
@@ -283,14 +286,17 @@ pub fn live_oracle_pass(
         // makes the indexed callee ranges point at the wrong content. Skip, never mis-resolve.
         let Ok(bytes) = std::fs::read(input.checkout_root.join(path)) else {
             report.skipped_drifted += callees.len() as u64;
+            report.unfinished_paths.push(path.clone());
             continue;
         };
         if hex_sha256(&bytes) != callees[0].file_sha {
             report.skipped_drifted += callees.len() as u64;
+            report.unfinished_paths.push(path.clone());
             continue;
         }
         let Ok(text) = String::from_utf8(bytes) else {
             report.skipped_drifted += callees.len() as u64;
+            report.unfinished_paths.push(path.clone());
             continue;
         };
 
@@ -355,16 +361,19 @@ pub fn live_oracle_pass(
                 break 'files;
             },
         };
-        // Fully sent only when nothing was budget-deferred: `files_resolved` documents "every
-        // callee of this file was sent", so a truncated file must not inflate it (the field
-        // rides `oracle_runs.stats_json` into status consumers).
-        if deferred_count == 0 {
-            report.files_resolved += 1;
-        } else {
-            // The budget cut this file short; it rides the backlog and resumes at the deferred
-            // callees (the covered-skip above makes that resume exact).
+        // The caller may change while synchronous requests are in flight. Re-read AFTER the batch:
+        // the server resolved the didOpen snapshot, and writing it against an already-changed disk
+        // file would look current until the queued reindex catches up (or forever if its event was
+        // missed).
+        if std::fs::read(input.checkout_root.join(path))
+            .ok()
+            .is_none_or(|current| hex_sha256(&current) != callees[0].file_sha)
+        {
+            report.skipped_drifted += to_resolve.len() as u64;
             report.unfinished_paths.push(path.clone());
+            continue;
         }
+        let mut retry_file = deferred_count > 0;
         // Definition bytes are cached ONLY within this file's batch: a def file edited between
         // two source files' LSP requests would otherwise be hashed + position-converted from a
         // stale snapshot, defeating the definition-side drift gate. (The indexed sha + symbol
@@ -391,6 +400,7 @@ pub fn live_oracle_pass(
                 .clone();
             let Some(def_disk) = def_disk else {
                 report.skipped_drifted += 1;
+                retry_file = true;
                 continue;
             };
             let indexed_sha = match def_indexed_sha.entry(def_path.clone()) {
@@ -413,6 +423,7 @@ pub fn live_oracle_pass(
                 Some(sha) if sha == hex_sha256(&def_disk) => {},
                 Some(_) => {
                     report.skipped_drifted += 1;
+                    retry_file = true;
                     continue;
                 },
             }
@@ -422,6 +433,7 @@ pub fn live_oracle_pass(
                 index.byte_at_position(target_range.end),
             ) else {
                 report.skipped_drifted += 1;
+                retry_file = true;
                 continue;
             };
             let spans = match def_spans.entry(def_path.clone()) {
@@ -487,13 +499,23 @@ pub fn live_oracle_pass(
                 scip_symbol: &scip_symbol,
                 kind,
             };
-            // Refine-cache interplay: a CHANGED scip_symbol under an UNCHANGED file_sha moves
-            // oracle evidence nothing in the refinement key folds — invalidate (same-value
-            // upserts deliberately skip).
-            if let Some((old_sha, old_symbol)) =
-                store::existing_verdict_scip_symbol(conn, tool, session.tool_version(), &row)?
-                && old_sha == candidate.file_sha
-                && old_symbol != scip_symbol
+            let existing =
+                store::existing_verdict_scip_symbol(conn, tool, session.tool_version(), &row)?;
+            // The content-key PK excludes file_sha. Preserve a different-SHA row while any sibling
+            // checkout still joins to it; overwriting would make that sibling lose live evidence.
+            if let Some((old_sha, _)) = &existing
+                && old_sha != &candidate.file_sha
+                && store::verdict_content_is_current_anywhere(conn, &row, old_sha)?
+            {
+                report.skipped_content_collisions += 1;
+                continue;
+            }
+            // Refine-cache interplay: CHANGED evidence under the same bytes, OR newly inserted
+            // NON-LOCAL moniker evidence, moves data absent from the refinement key. Local
+            // sentinels are filtered by the consumer and are refine-neutral.
+            if existing.as_ref().is_some_and(|(old_sha, old_symbol)| {
+                old_sha == &candidate.file_sha && old_symbol != &scip_symbol
+            }) || (existing.is_none() && !super::scip::is_local_symbol(&scip_symbol))
             {
                 refinements_stale = true;
             }
@@ -506,6 +528,16 @@ pub fn live_oracle_pass(
                 // Live never emits ResolvedExternal (out-of-corpus defs are skipped above).
                 OracleResolutionKind::ResolvedExternal => {},
             }
+        }
+        // Fully resolved only when nothing was budget- or drift-deferred. A definition that changed
+        // during this caller's batch requeues the CALLER because the definition's own watcher event
+        // does not enumerate every caller that resolved into it.
+        if retry_file {
+            if !report.unfinished_paths.contains(path) {
+                report.unfinished_paths.push(path.clone());
+            }
+        } else {
+            report.files_resolved += 1;
         }
     }
 

--- a/crates/rag-rat-oracle/src/live.rs
+++ b/crates/rag-rat-oracle/src/live.rs
@@ -1,0 +1,506 @@
+//! The live oracle pass (#74 slice 2 / #534): wire the resident LSP client (slice 1's `lsp`
+//! substrate) to the watcher's maintenance pass and WRITE its per-callee verdicts into the
+//! `edge_oracle` seam, under the distinct [`OracleTool::RaLsp`] tool id.
+//!
+//! Invariants this module upholds (settled on #74):
+//!
+//! - **Tool identity.** Live rows carry `ra-lsp` + the session's probed `rust-analyzer --version`
+//!   (re-probed at every spawn). Reusing the batch `rust-analyzer` id is rejected: a live
+//!   `oracle_runs` row under the batch id would make `auto_run_decision` see the index as
+//!   always-fresh and silently stop the whole-checkout batch pass.
+//! - **Moniker source.** A live verdict's `scip_symbol` is the resolved target's BATCH moniker from
+//!   `logical_symbol_monikers` — byte-identical to what the batch pass writes, so clone-collapse
+//!   (#275) and moniker-anchored memory relocation treat live and batch rows as one evidence set
+//!   with zero consumer changes. When the target has no batch moniker (batch never ran, or the def
+//!   is outside its definitions) the fallback is a `local ra-lsp-<hash>` SCIP-local sentinel:
+//!   `is_local_symbol` skips it before the conflict logic, so it can never poison a batch moniker,
+//!   while the row's `resolved_symbol_id` still upgrades the edge tier. The sentinel's hash is
+//!   content-derived (callsite path + callee span), so it is STABLE across reindexes — a no-op
+//!   re-pass is a same-value upsert and does not churn the refine cache. The LSP
+//!   `textDocument/moniker` string is NEVER persisted: it never equals the SCIP moniker, and the
+//!   cross-tool conflict-drop would destroy batch collapse coverage on any co-covered span. Live
+//!   only READS the moniker table.
+//! - **Currency.** The verdict rows + the backing `oracle_runs` row commit in ONE transaction — the
+//!   per-tool currency gate (`callee_moniker_current_clause`) must never see live rows without a
+//!   backing run. A run row is recorded only for a pass that wrote ≥1 row. There is NO
+//!   authoritative clear: live's scope is only this pass's changed files (the batch pass owns
+//!   whole-checkout authority).
+//! - **Refine cache.** When a live write CHANGES an existing row's `scip_symbol` for an UNCHANGED
+//!   `file_sha`, the scip-mode clone refinements that consulted the old evidence are invalidated
+//!   (nothing in the refinement key folds oracle content — the same reasoning as the batch hook in
+//!   `run_in_tx`). Same-value upserts skip the invalidation.
+//! - **Drift.** A verdict is written only when the callsite's disk bytes still hash to the indexed
+//!   `file_sha`, and the definition document's disk bytes still hash to its indexed `files.sha256`
+//!   — the live analog of the batch join's index-vs-disk content gate. Anything else is skipped,
+//!   never mis-joined.
+//!
+//! Out of scope (later slices): crash/version/warm-up hardening and server→client request
+//! handlers (#535), non-Rust backends (#536), `resolved-external` verdicts (a live def outside
+//! the checkout has no batch-interchangeable SCIP symbol string, so it is skipped, not written).
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use rag_rat_base::hash::hex_sha256;
+use rusqlite::Connection;
+use serde::Serialize;
+
+use super::lsp::client::LspClient;
+use super::lsp::position::LineIndex;
+use super::store::{self, EdgeOracleRow};
+use super::{OracleResolutionKind, OracleTool, ToolAvailability, ToolManifest, join};
+
+/// A resident live-oracle language-server session: the spawned client, the `tool_version` its
+/// rows are stamped with, and the checkout root URI documents are opened under. Owned by the
+/// watcher's pass worker across passes; spawned lazily on the first eligible pass and shut down
+/// after an idle window (both driven by the watcher).
+pub struct LiveOracleSession {
+    client: LspClient,
+    tool_version: String,
+    root_uri: String,
+    last_used_ms: i64,
+}
+
+impl LiveOracleSession {
+    /// Probe `rust-analyzer` and spawn the resident client for `checkout_root`, or `None` when
+    /// the tool is unavailable / the session can't be established — the same degrade-quietly UX
+    /// as a missing embedding model or batch tool (never an error, never a failed pass). The
+    /// version is RE-probed at every spawn so `tool_version` always names the binary this
+    /// session's verdicts came from.
+    pub fn spawn(checkout_root: &Path, now_ms: i64) -> Option<Self> {
+        let manifest = ToolManifest::for_tool(OracleTool::RaLsp);
+        let ToolAvailability::Available { version, .. } = manifest.probe() else {
+            return None;
+        };
+        let root_uri = root_uri_for(checkout_root);
+        let mut client = LspClient::spawn(manifest.program, &[]).ok()?;
+        client.initialize(&root_uri).ok()?;
+        Some(Self { client, tool_version: version, root_uri, last_used_ms: now_ms })
+    }
+
+    /// Test seam: a session over an injected (fake-server) client transport. Runs the
+    /// `initialize` handshake exactly like [`Self::spawn`] so the negotiated encoding is real.
+    #[cfg(test)]
+    pub(crate) fn from_client(mut client: LspClient, tool_version: &str, root_uri: &str) -> Self {
+        client.initialize(root_uri).expect("test server completes the handshake");
+        Self {
+            client,
+            tool_version: tool_version.to_string(),
+            root_uri: root_uri.to_string(),
+            last_used_ms: 0,
+        }
+    }
+
+    pub fn tool_version(&self) -> &str {
+        &self.tool_version
+    }
+
+    pub fn last_used_ms(&self) -> i64 {
+        self.last_used_ms
+    }
+
+    /// Whether the session has gone `idle_ms` without a pass — the watcher's cue to shut it
+    /// down (an idle server shouldn't hold rust-analyzer's resident memory).
+    pub fn idle_for(&self, now_ms: i64, idle_ms: u64) -> bool {
+        now_ms.saturating_sub(self.last_used_ms) > idle_ms as i64
+    }
+
+    /// Graceful LSP teardown (`shutdown` + `exit`); the client's Drop hard-kills as the
+    /// fallback. Consumes the session.
+    pub fn shutdown(self) {
+        let mut this = self;
+        let _ = this.client.shutdown();
+    }
+
+    fn touch(&mut self, now_ms: i64) {
+        self.last_used_ms = now_ms;
+    }
+}
+
+/// Inputs for one live oracle pass.
+pub struct LivePassInput<'a> {
+    /// The active checkout the just-reindexed files (and their edge candidates) are scoped to.
+    pub commit_sha: &'a str,
+    pub worktree_id: &'a str,
+    /// The checkout root: document URIs are `root_uri/path`, and target bytes are read from
+    /// `checkout_root/path`.
+    pub checkout_root: &'a Path,
+    /// Repo-relative paths the pass may resolve (the maintenance pass's changed set plus any
+    /// backlog), RUST files only — the ra-lsp backend's language. Processed in order; whatever
+    /// the request budget doesn't cover rides `LivePassReport::unfinished_paths`.
+    pub worklist: &'a [String],
+    /// Cap on `textDocument/definition` requests this pass may issue.
+    pub max_requests: u64,
+    /// Unix-epoch ms the maintenance pass began — stamped as the run's `started_at`.
+    pub started_at_ms: i64,
+}
+
+/// Outcome of one live pass, mirroring `OracleReport`'s shape. Persisted opaquely as the run
+/// row's `stats_json` (when a run is recorded).
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct LivePassReport {
+    /// Worklist files carrying at least one edge candidate (the population the pass works over).
+    pub files_with_candidates: u64,
+    /// Files whose callees were all sent to the server (not deferred by the budget, not skipped
+    /// for drift).
+    pub files_resolved: u64,
+    /// `textDocument/definition` requests issued.
+    pub requests_used: u64,
+    /// `edge_oracle` rows written this pass.
+    pub rows_written: u64,
+    pub upgraded: u64,
+    pub confirmed: u64,
+    pub contradicted: u64,
+    /// Candidates/definitions skipped for content drift (callsite or definition document).
+    pub skipped_drifted: u64,
+    /// Definitions skipped as out-of-corpus for live purposes: target outside the checkout root,
+    /// in an unindexed file, or mapping to no indexed symbol. Live writes no `resolved-external`
+    /// rows (see the module docs).
+    pub skipped_external: u64,
+    /// Callees the server left unresolved (a `null` definition — e.g. still indexing).
+    pub unresolved: u64,
+    /// Whether the scip-mode refine cache was invalidated (a row's `scip_symbol` changed under
+    /// an unchanged `file_sha`).
+    pub refinements_invalidated: bool,
+    /// Whether an `oracle_runs` row backs this pass (only when `rows_written > 0`).
+    pub run_recorded: bool,
+    /// Worklist paths the request budget didn't reach — the caller's backlog into the next pass.
+    #[serde(skip)]
+    pub unfinished_paths: Vec<String>,
+    pub status: String,
+}
+
+/// Run one live oracle pass: resolve the worklist's callees through the resident client and
+/// write the verdicts + a backing run row in ONE transaction. Never fails the maintenance pass
+/// for an LSP-side problem — a dead/wedged server aborts the remaining worklist (reported in
+/// `status`) while the verdicts already gathered still commit; DB failures are the only `Err`.
+pub fn live_oracle_pass(
+    conn: &Connection,
+    session: &mut LiveOracleSession,
+    input: &LivePassInput<'_>,
+) -> anyhow::Result<LivePassReport> {
+    let mut report = LivePassReport::default();
+    let tool = OracleTool::RaLsp;
+    // The batch tool whose monikers live copies (rust-analyzer for ra-lsp) — always `Some` for a
+    // live tool; the join is vacuous without it.
+    let Some(moniker_source) = tool.batch_moniker_source() else {
+        anyhow::bail!("live_oracle_pass requires a live (non-batch) tool");
+    };
+
+    let candidates = store::edge_join_candidates_for_paths(
+        conn,
+        input.commit_sha,
+        input.worktree_id,
+        input.worklist,
+    )?;
+    let mut by_path: HashMap<&str, Vec<&store::EdgeJoinCandidate>> = HashMap::new();
+    for candidate in &candidates {
+        by_path.entry(candidate.source_path.as_str()).or_default().push(candidate);
+    }
+    report.files_with_candidates = by_path.len() as u64;
+
+    // The indexed shas the definition-side drift gate compares against (the callsite side uses
+    // each candidate's own `file_sha`, which IS the indexed sha of the just-reindexed file).
+    let indexed_shas =
+        store::indexed_file_shas_in_scope(conn, input.commit_sha, input.worktree_id)?;
+
+    let tx = conn.unchecked_transaction()?;
+    let mut refinements_stale = false;
+    let mut aborted: Option<String> = None;
+    // Per-pass caches: definition-file disk bytes and symbol spans, keyed by repo-relative path.
+    let mut def_bytes: HashMap<String, Option<Vec<u8>>> = HashMap::new();
+    let mut def_spans: HashMap<String, Vec<store::SymbolSpan>> = HashMap::new();
+    let logical_cache: std::cell::RefCell<HashMap<i64, Option<i64>>> =
+        std::cell::RefCell::new(HashMap::new());
+    let mut moniker_cache: HashMap<i64, Option<String>> = HashMap::new();
+
+    'files: for (position, path) in input.worklist.iter().enumerate() {
+        let Some(callees) = by_path.get(path.as_str()) else {
+            continue;
+        };
+        // The request budget caps whole files (a file resolves fully or rides the next pass),
+        // except the FIRST candidate-bearing file, which always resolves even over budget so a
+        // huge file can never wedge the pass at zero progress.
+        if report.files_resolved > 0
+            && report.requests_used + callees.len() as u64 > input.max_requests
+        {
+            report.unfinished_paths.extend(
+                input.worklist[position..]
+                    .iter()
+                    .filter(|p| by_path.contains_key(p.as_str()))
+                    .cloned(),
+            );
+            break 'files;
+        }
+
+        // Callsite drift gate: the server resolves the DIRTY disk bytes, so those bytes must
+        // still hash to the indexed `file_sha` the candidates were built from — a mid-pass edit
+        // makes the indexed callee ranges point at the wrong content. Skip, never mis-resolve.
+        let Ok(bytes) = std::fs::read(input.checkout_root.join(path)) else {
+            report.skipped_drifted += callees.len() as u64;
+            continue;
+        };
+        if hex_sha256(&bytes) != callees[0].file_sha {
+            report.skipped_drifted += callees.len() as u64;
+            continue;
+        }
+        let Ok(text) = String::from_utf8(bytes) else {
+            report.skipped_drifted += callees.len() as u64;
+            continue;
+        };
+
+        let uri = format!("{}/{}", session.root_uri, path);
+        let starts: Vec<usize> =
+            callees.iter().filter_map(|c| usize::try_from(c.callee_start_byte).ok()).collect();
+        report.requests_used += starts.len() as u64;
+        let resolved = match session.client.resolve_definitions(&uri, "rust", &text, &starts) {
+            Ok(resolved) => resolved,
+            Err(err) => {
+                // A dead/wedged server: keep what earlier files produced, abort the rest, and
+                // let the watcher drop the session (a later pass respawns). Never fail the
+                // maintenance pass over it (#535 hardens this further).
+                aborted = Some(err.to_string());
+                break 'files;
+            },
+        };
+        report.files_resolved += 1;
+
+        for (candidate, definition) in callees.iter().zip(resolved.iter()) {
+            let Some((target_uri, target_range)) = definition else {
+                report.unresolved += 1;
+                continue;
+            };
+            // The definition must land inside this checkout: an external target (a dependency
+            // source outside the root) has no indexed symbol and no batch-interchangeable
+            // moniker, so live writes nothing for it.
+            let Some(def_path) = path_from_uri(&session.root_uri, target_uri) else {
+                report.skipped_external += 1;
+                continue;
+            };
+            // Definition-side drift gate: the LSP range converts against the def file's CURRENT
+            // disk bytes, so those must still be the indexed bytes the symbol spans came from.
+            let def_disk = def_bytes
+                .entry(def_path.clone())
+                .or_insert_with(|| std::fs::read(input.checkout_root.join(&def_path)).ok())
+                .clone();
+            let Some(def_disk) = def_disk else {
+                report.skipped_drifted += 1;
+                continue;
+            };
+            if indexed_shas.get(&def_path).map(String::as_str)
+                != Some(hex_sha256(&def_disk).as_str())
+            {
+                report.skipped_drifted += 1;
+                continue;
+            }
+            let index = LineIndex::new(&def_disk, session.client.encoding());
+            let (Some(def_start), Some(def_end)) = (
+                index.byte_at_position(target_range.start),
+                index.byte_at_position(target_range.end),
+            ) else {
+                report.skipped_drifted += 1;
+                continue;
+            };
+            let spans = def_spans.entry(def_path.clone()).or_insert_with(|| {
+                store::symbol_spans_for_path(conn, &def_path, input.commit_sha, input.worktree_id)
+                    .unwrap_or_default()
+            });
+            let Some(symbol_id) = join::map_definition_to_symbol(spans, def_start, def_end) else {
+                // The def is in an indexed file but under no indexed symbol (macro-generated
+                // code, a symbol kind without a row): nothing trustworthy to write.
+                report.skipped_external += 1;
+                continue;
+            };
+
+            let logical_symbol_of = |symbol_id: i64| -> Option<i64> {
+                if let Some(cached) = logical_cache.borrow().get(&symbol_id) {
+                    return *cached;
+                }
+                let logical = store::logical_symbol_id_for_member(conn, symbol_id).unwrap_or(None);
+                logical_cache.borrow_mut().insert(symbol_id, logical);
+                logical
+            };
+            let kind = join::classify_in_corpus(
+                &candidate.confidence,
+                candidate.to_symbol_id,
+                symbol_id,
+                &logical_symbol_of,
+            );
+
+            // Moniker: the target's batch moniker verbatim, else the content-stable local
+            // sentinel (module docs — NEVER the LSP moniker string).
+            let scip_symbol = moniker_cache
+                .entry(symbol_id)
+                .or_insert_with(|| {
+                    store::batch_moniker_for_symbol(conn, symbol_id, moniker_source).unwrap_or(None)
+                })
+                .clone()
+                .unwrap_or_else(|| live_local_sentinel(&candidate.source_path, candidate));
+
+            let row = EdgeOracleRow {
+                source_path: &candidate.source_path,
+                source_start_byte: candidate.source_start_byte,
+                source_end_byte: candidate.source_end_byte,
+                callee_start_byte: candidate.callee_start_byte,
+                callee_end_byte: candidate.callee_end_byte,
+                edge_kind: &candidate.edge_kind,
+                file_sha: &candidate.file_sha,
+                resolved_symbol_id: Some(symbol_id),
+                scip_symbol: &scip_symbol,
+                kind,
+            };
+            // Refine-cache interplay: a CHANGED scip_symbol under an UNCHANGED file_sha moves
+            // oracle evidence nothing in the refinement key folds — invalidate (same-value
+            // upserts deliberately skip).
+            if let Some((old_sha, old_symbol)) =
+                store::existing_verdict_scip_symbol(conn, tool, session.tool_version(), &row)?
+                && old_sha == candidate.file_sha
+                && old_symbol != scip_symbol
+            {
+                refinements_stale = true;
+            }
+            store::write_edge_oracle(conn, tool, session.tool_version(), &row)?;
+            report.rows_written += 1;
+            match kind {
+                OracleResolutionKind::Upgrade => report.upgraded += 1,
+                OracleResolutionKind::Confirm => report.confirmed += 1,
+                OracleResolutionKind::Contradict => report.contradicted += 1,
+                // Live never emits ResolvedExternal (out-of-corpus defs are skipped above).
+                OracleResolutionKind::ResolvedExternal => {},
+            }
+        }
+    }
+
+    if report.rows_written > 0 {
+        report.run_recorded = true;
+        report.status = match &aborted {
+            Some(err) => format!("Aborted: {err}"),
+            None if report.unfinished_paths.is_empty() => "Completed".to_string(),
+            None => "BudgetExhausted".to_string(),
+        };
+        store::record_oracle_run_at(
+            conn,
+            tool,
+            session.tool_version(),
+            input.commit_sha,
+            input.worktree_id,
+            input.started_at_ms,
+            &report.status,
+            &serde_json::to_string(&report).unwrap_or_else(|_| "{}".to_string()),
+        )?;
+        if refinements_stale {
+            rag_rat_clones::refine::cache::invalidate_scip_refinements(conn)?;
+            report.refinements_invalidated = true;
+        }
+    } else {
+        report.status = match &aborted {
+            Some(err) => format!("Aborted: {err}"),
+            None if report.unfinished_paths.is_empty() => "NoVerdicts".to_string(),
+            None => "BudgetExhausted".to_string(),
+        };
+    }
+    tx.commit()?;
+    session.touch(input.started_at_ms);
+    Ok(report)
+}
+
+/// The content-stable SCIP-local sentinel a live verdict carries when the resolved symbol has no
+/// batch moniker: `local ra-lsp-<hash>` keyed by the callsite (path + callee span), so a no-op
+/// re-pass reproduces the SAME string (a same-value upsert — no refine-cache churn). Parses as a
+/// SCIP local symbol, so `is_local_symbol` drops it before `current_callee_monikers`' conflict
+/// logic and it can never poison a batch moniker.
+fn live_local_sentinel(source_path: &str, candidate: &store::EdgeJoinCandidate) -> String {
+    let hash = hex_sha256(
+        format!("{}:{}:{}", source_path, candidate.callee_start_byte, candidate.callee_end_byte)
+            .as_bytes(),
+    );
+    format!("local ra-lsp-{}", &hash[..16])
+}
+
+/// The `file://` URI of a checkout root — the base every document URI hangs off. Encodes any
+/// non-URI-path byte as %XX (spaces, non-ASCII); `/` is preserved.
+fn root_uri_for(checkout_root: &Path) -> String {
+    let lossy = checkout_root.to_string_lossy().replace('\\', "/");
+    let with_lead = if lossy.starts_with('/') { lossy } else { format!("/{lossy}") };
+    format!("file://{}", encode_uri_path(&with_lead))
+}
+
+/// Percent-encode a URI path: keep the RFC 3986 unreserved set plus `/`; %XX-encode the rest.
+fn encode_uri_path(path: &str) -> String {
+    let mut out = String::with_capacity(path.len());
+    for byte in path.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' | b'/' =>
+                out.push(byte as char),
+            _ => {
+                use std::fmt::Write as _;
+                let _ = write!(out, "%{byte:02X}");
+            },
+        }
+    }
+    out
+}
+
+/// The repo-relative path of a `file://` document URI under `root_uri`, percent-decoded; `None`
+/// when the URI points outside the checkout (an external dependency — nothing live can write).
+fn path_from_uri(root_uri: &str, uri: &str) -> Option<String> {
+    let rest = uri.strip_prefix(root_uri)?.strip_prefix('/')?;
+    let mut bytes = Vec::with_capacity(rest.len());
+    let raw = rest.as_bytes();
+    let mut i = 0;
+    while i < raw.len() {
+        if raw[i] == b'%' && i + 2 < raw.len() {
+            let hex = std::str::from_utf8(&raw[i + 1..i + 3]).ok()?;
+            bytes.push(u8::from_str_radix(hex, 16).ok()?);
+            i += 3;
+        } else {
+            bytes.push(raw[i]);
+            i += 1;
+        }
+    }
+    String::from_utf8(bytes).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn root_uri_encodes_spaces_and_preserves_slashes() {
+        assert_eq!(root_uri_for(Path::new("/tmp/my repo")), "file:///tmp/my%20repo");
+        assert_eq!(root_uri_for(Path::new("/plain/path")), "file:///plain/path");
+    }
+
+    #[test]
+    fn path_from_uri_decodes_and_rejects_external() {
+        let root = "file:///tmp/my%20repo";
+        assert_eq!(
+            path_from_uri(root, "file:///tmp/my%20repo/src/a file.rs"),
+            Some("src/a file.rs".to_string())
+        );
+        assert_eq!(path_from_uri(root, "file:///elsewhere/src/lib.rs"), None);
+    }
+
+    #[test]
+    fn sentinel_is_content_stable_and_local() {
+        let candidate = store::EdgeJoinCandidate {
+            edge_id: 1,
+            source_path: "src/lib.rs".to_string(),
+            file_sha: "sha".to_string(),
+            source_start_byte: 0,
+            source_end_byte: 10,
+            callee_start_byte: 4,
+            callee_end_byte: 9,
+            confidence: "NameOnly".to_string(),
+            edge_kind: "calls_name".to_string(),
+            to_symbol_id: None,
+        };
+        let a = live_local_sentinel("src/lib.rs", &candidate);
+        let b = live_local_sentinel("src/lib.rs", &candidate);
+        assert_eq!(a, b, "same callsite reproduces the same sentinel (no refine churn)");
+        assert!(super::super::scip::is_local_symbol(&a), "parses as a SCIP local: {a}");
+        assert!(a.starts_with("local ra-lsp-"));
+        let other = store::EdgeJoinCandidate { callee_start_byte: 5, ..candidate };
+        assert_ne!(a, live_local_sentinel("src/lib.rs", &other), "span-keyed");
+    }
+}

--- a/crates/rag-rat-oracle/src/live.rs
+++ b/crates/rag-rat-oracle/src/live.rs
@@ -42,9 +42,11 @@ use std::collections::HashMap;
 use std::collections::hash_map::Entry;
 use std::path::Path;
 
+use path_slash::PathExt as _;
 use rag_rat_base::hash::hex_sha256;
 use rusqlite::Connection;
 use serde::Serialize;
+use url::Url;
 
 use super::lsp::client::LspClient;
 use super::lsp::position::LineIndex;
@@ -73,7 +75,7 @@ impl LiveOracleSession {
         let ToolAvailability::Available { version, .. } = manifest.probe() else {
             return None;
         };
-        let root_uri = root_uri_for(checkout_root);
+        let root_uri = root_uri_for(checkout_root)?;
         let mut client = LspClient::spawn(manifest.program, &[]).ok()?;
         client.initialize(&root_uri).ok()?;
         Some(Self { client, tool_version: version, root_uri, last_used_ms: now_ms })
@@ -328,13 +330,11 @@ pub fn live_oracle_pass(
         let (to_resolve, deferred) = unverdicted.split_at(remaining.min(unverdicted.len()));
         let deferred_count = deferred.len();
 
-        // Join on exactly one separator: a root URI already ending in `/` (a filesystem-root `/`
-        // or a drive root `C:\`) would otherwise produce `file:////…` / `file:///C://…`, which
-        // rust-analyzer's canonical single-slash form then fails to prefix-match (#534 review).
-        // `strip_suffix` drops at most ONE slash — `trim_end_matches('/')` would eat `file:///`
-        // down to `file:`.
-        let root = session.root_uri.strip_suffix('/').unwrap_or(&session.root_uri);
-        let uri = format!("{root}/{}", encode_uri_path(path));
+        // Platform-aware file URL conversion handles drive/UNC/verbatim prefixes and percent
+        // encoding; hand-joining the root and DB path repeatedly produced malformed URIs.
+        let uri: String = Url::from_file_path(input.checkout_root.join(path))
+            .map_err(|()| anyhow::anyhow!("cannot convert live-oracle document path to file URL"))?
+            .into();
         let starts: Vec<usize> =
             to_resolve.iter().filter_map(|c| usize::try_from(c.callee_start_byte).ok()).collect();
         report.requests_used += starts.len() as u64;
@@ -564,150 +564,80 @@ fn live_local_sentinel(source_path: &str, candidate: &store::EdgeJoinCandidate) 
     format!("local ra-lsp-{}", &hash[..16])
 }
 
-/// The `file://` URI of a checkout root — the base every document URI hangs off. Encodes any
-/// non-URI-path byte as %XX (spaces, non-ASCII); `/` is preserved. Two Windows forms keep the
-/// shape rust-analyzer returns canonically (so `path_from_uri`'s literal prefix match agrees,
-/// #534 review): a drive prefix (`C:`) keeps its colon unencoded (`file:///C:/repo`), and a UNC
-/// path (`\\server\share`) becomes an authority URI (`file://server/share/…`, no extra slash).
-fn root_uri_for(checkout_root: &Path) -> String {
-    let lossy = checkout_root.to_string_lossy().replace('\\', "/");
-    // `Path::canonicalize` on Windows returns verbatim paths. Normalize those BEFORE the UNC
-    // branch: `\\?\C:\repo` becomes `//?/C:/repo` after separator replacement and would otherwise
-    // be mistaken for an authority named `?`; verbatim UNC uses the `\\?\UNC\server\share` form.
-    let lossy = if let Some(unc) = lossy.strip_prefix("//?/UNC/") {
-        format!("//{unc}")
-    } else if let Some(drive) = lossy.strip_prefix("//?/") {
-        drive.to_string()
-    } else {
-        lossy
-    };
-    // UNC: `//server/share/…` → `file://server/share/…` (the server is the URI authority, not a
-    // path segment). Encode each segment but keep the `/` separators.
-    if let Some(unc) = lossy.strip_prefix("//") {
-        return format!("file://{}", encode_uri_path(unc));
-    }
-    let with_lead = if lossy.starts_with('/') { lossy } else { format!("/{lossy}") };
-    let bytes = with_lead.as_bytes();
-    // Drive prefix: `/C:/…` after the leading-slash normalization.
-    let drive_len =
-        if bytes.len() >= 4 && bytes[1].is_ascii_alphabetic() && bytes[2] == b':' { 3 } else { 0 };
-    format!("file://{}{}", &with_lead[..drive_len], encode_uri_path(&with_lead[drive_len..]))
+/// The canonical `file://` URL of a checkout directory. `url` handles native disk,
+/// verbatim-disk, UNC, and verbatim-UNC prefixes on Windows and percent-encodes path bytes.
+fn root_uri_for(checkout_root: &Path) -> Option<String> {
+    Url::from_directory_path(checkout_root).ok().map(Into::into)
 }
 
-/// Percent-encode a URI path: keep the RFC 3986 unreserved set plus `/`; %XX-encode the rest.
-fn encode_uri_path(path: &str) -> String {
-    let mut out = String::with_capacity(path.len());
-    for byte in path.bytes() {
-        match byte {
-            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' | b'/' =>
-                out.push(byte as char),
-            _ => {
-                use std::fmt::Write as _;
-                let _ = write!(out, "%{byte:02X}");
-            },
-        }
-    }
-    out
-}
-
-/// The repo-relative path of a `file://` document URI under `root_uri`, percent-decoded; `None`
-/// when the URI points outside the checkout (an external dependency — nothing live can write).
+/// The repo-relative slash path of a `file://` document URI under `root_uri`; `None` when either
+/// URL is not a native file path or the target is outside the checkout.
 fn path_from_uri(root_uri: &str, uri: &str) -> Option<String> {
-    let rest = uri.strip_prefix(root_uri)?;
-    // Require a path boundary after a non-root checkout URI. A lexical prefix such as
-    // `file:///work/repo` must not accept `file:///work/repository/x.rs` as `sitory/x.rs`.
-    // Slash-terminated roots (`file:///`, `file:///C:/`) already supply that boundary.
-    let rest = if root_uri.ends_with('/') { rest } else { rest.strip_prefix('/')? };
-    let mut bytes = Vec::with_capacity(rest.len());
-    let raw = rest.as_bytes();
-    let mut i = 0;
-    while i < raw.len() {
-        if raw[i] == b'%' && i + 2 < raw.len() {
-            let hex = std::str::from_utf8(&raw[i + 1..i + 3]).ok()?;
-            bytes.push(u8::from_str_radix(hex, 16).ok()?);
-            i += 3;
-        } else {
-            bytes.push(raw[i]);
-            i += 1;
-        }
-    }
-    String::from_utf8(bytes).ok()
+    let root = Url::parse(root_uri).ok()?.to_file_path().ok()?;
+    let target = Url::parse(uri).ok()?.to_file_path().ok()?;
+    let relative = target.strip_prefix(root).ok()?;
+    Some(relative.to_slash_lossy().into_owned())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    #[cfg(unix)]
     #[test]
     fn root_uri_encodes_spaces_and_preserves_slashes() {
-        assert_eq!(root_uri_for(Path::new("/tmp/my repo")), "file:///tmp/my%20repo");
-        assert_eq!(root_uri_for(Path::new("/plain/path")), "file:///plain/path");
+        assert_eq!(
+            root_uri_for(Path::new("/tmp/my repo")).as_deref(),
+            Some("file:///tmp/my%20repo/")
+        );
+        assert_eq!(root_uri_for(Path::new("/plain/path")).as_deref(), Some("file:///plain/path/"));
     }
 
+    #[cfg(windows)]
     #[test]
     fn root_uri_keeps_a_windows_drive_colon_verbatim() {
         // rust-analyzer returns `file:///C:/repo/…` canonically; encoding the drive colon
         // (`file:///C%3A/repo`) would break `path_from_uri`'s prefix match and class every
         // in-repo definition as external (#534 review).
-        let root = root_uri_for(Path::new(r"C:\repo"));
-        assert_eq!(root, "file:///C:/repo");
+        let root = root_uri_for(Path::new(r"C:\repo")).unwrap();
+        assert_eq!(root, "file:///C:/repo/");
         assert_eq!(path_from_uri(&root, "file:///C:/repo/src/lib.rs"), Some("src/lib.rs".into()));
         // A drive root with a space still encodes the non-drive part.
-        assert_eq!(root_uri_for(Path::new(r"D:\my repo")), "file:///D:/my%20repo");
-    }
-
-    #[test]
-    fn root_uri_strips_windows_verbatim_prefixes() {
-        // Canonical Windows paths carry `\\?\`; rust-analyzer emits ordinary canonical file URLs.
-        assert_eq!(root_uri_for(Path::new(r"\\?\C:\repo")), "file:///C:/repo");
         assert_eq!(
-            root_uri_for(Path::new(r"\\?\UNC\server\share\repo")),
-            "file://server/share/repo"
+            root_uri_for(Path::new(r"D:\my repo")).as_deref(),
+            Some("file:///D:/my%20repo/")
         );
     }
 
+    #[cfg(windows)]
+    #[test]
+    fn root_uri_strips_windows_verbatim_prefixes() {
+        // `url` maps canonical Windows verbatim prefixes to ordinary canonical file URLs.
+        assert_eq!(root_uri_for(Path::new(r"\\?\C:\repo")).as_deref(), Some("file:///C:/repo/"));
+        assert_eq!(
+            root_uri_for(Path::new(r"\\?\UNC\server\share\repo")).as_deref(),
+            Some("file://server/share/repo/")
+        );
+    }
+
+    #[cfg(windows)]
     #[test]
     fn root_uri_maps_a_unc_path_to_an_authority_url() {
         // `\\server\share\repo` → `file://server/share/repo` (authority form), matching the
         // canonical URI rust-analyzer returns; a naive join would emit `file:////server/...`
         // and misclass every in-repo definition as external (#534 review).
-        let root = root_uri_for(Path::new(r"\\server\share\repo"));
-        assert_eq!(root, "file://server/share/repo");
+        let root = root_uri_for(Path::new(r"\\server\share\repo")).unwrap();
+        assert_eq!(root, "file://server/share/repo/");
         assert_eq!(
             path_from_uri(&root, "file://server/share/repo/src/a.rs"),
             Some("src/a.rs".into())
         );
     }
 
-    #[test]
-    fn document_join_uses_one_separator_at_a_slash_terminated_root() {
-        // A checkout AT the filesystem root (`/`) or a drive root (`C:\`) yields a root URI
-        // ending in `/`; joining a document must not double the separator or the server's
-        // canonical URI won't prefix-match (#534 review).
-        let root = root_uri_for(Path::new("/"));
-        assert_eq!(root, "file:///");
-        let doc = format!(
-            "{}/{}",
-            root.strip_suffix('/').unwrap_or(&root),
-            encode_uri_path("src/lib.rs")
-        );
-        assert_eq!(doc, "file:///src/lib.rs");
-        assert_eq!(path_from_uri(&root, &doc), Some("src/lib.rs".into()));
-
-        let drive = root_uri_for(Path::new(r"C:\"));
-        assert_eq!(drive, "file:///C:/");
-        let doc = format!(
-            "{}/{}",
-            drive.strip_suffix('/').unwrap_or(&drive),
-            encode_uri_path("src/lib.rs")
-        );
-        assert_eq!(doc, "file:///C:/src/lib.rs");
-        assert_eq!(path_from_uri(&drive, &doc), Some("src/lib.rs".into()));
-    }
-
+    #[cfg(unix)]
     #[test]
     fn path_from_uri_decodes_and_rejects_external() {
-        let root = "file:///tmp/my%20repo";
+        let root = "file:///tmp/my%20repo/";
         assert_eq!(
             path_from_uri(root, "file:///tmp/my%20repo/src/a file.rs"),
             Some("src/a file.rs".to_string())
@@ -716,17 +646,15 @@ mod tests {
         assert_eq!(path_from_uri(root, "file:///tmp/my%20repository/src/lib.rs"), None);
     }
 
+    #[cfg(unix)]
     #[test]
     fn document_uri_encodes_the_relative_path() {
-        // A repo path carrying URI-reserved bytes (`#`, `%`, spaces, non-ASCII) must be encoded
-        // BEFORE joining the root URI, or the server parses `b.rs` as a fragment and the opened
-        // document never associates with the indexed file (#534 review).
-        assert_eq!(encode_uri_path("src/a b#c%.rs"), "src/a%20b%23c%25.rs");
-        let root = root_uri_for(Path::new("/repo"));
-        let uri = format!("{}/{}", root, encode_uri_path("src/доки/a b.rs"));
+        let root = root_uri_for(Path::new("/repo")).unwrap();
+        let uri: String = Url::from_file_path("/repo/src/доки/a b#c%.rs").unwrap().into();
+        assert!(uri.contains("a%20b%23c%25.rs"));
         assert_eq!(
             path_from_uri(&root, &uri),
-            Some("src/доки/a b.rs".to_string()),
+            Some("src/доки/a b#c%.rs".to_string()),
             "encode → open → decode round-trips the reserved-byte path"
         );
     }

--- a/crates/rag-rat-oracle/src/live.rs
+++ b/crates/rag-rat-oracle/src/live.rs
@@ -292,6 +292,8 @@ pub fn live_oracle_pass(
             session.tool_version(),
             path,
             &callees[0].file_sha,
+            input.commit_sha,
+            input.worktree_id,
         )?;
         let is_covered = |c: &store::EdgeJoinCandidate| {
             covered.contains(&(
@@ -412,14 +414,23 @@ pub fn live_oracle_pass(
                 continue;
             };
 
-            let logical_symbol_of = |symbol_id: i64| -> Option<i64> {
-                if let Some(cached) = logical_cache.borrow().get(&symbol_id) {
-                    return *cached;
+            // Resolve the logical ids of the heuristic + compiler targets up front, propagating
+            // a DB failure instead of swallowing it to `None` — a swallowed error would degrade
+            // a real Confirm (same logical symbol) into a Contradict and corrupt precision while
+            // later writes still succeed (#534 review). The closure then reads the warmed cache.
+            let warm_logical = |id: i64| -> anyhow::Result<()> {
+                if !logical_cache.borrow().contains_key(&id) {
+                    let logical = store::logical_symbol_id_for_member(conn, id)?;
+                    logical_cache.borrow_mut().insert(id, logical);
                 }
-                let logical = store::logical_symbol_id_for_member(conn, symbol_id).unwrap_or(None);
-                logical_cache.borrow_mut().insert(symbol_id, logical);
-                logical
+                Ok(())
             };
+            warm_logical(symbol_id)?;
+            if let Some(heuristic_id) = candidate.to_symbol_id {
+                warm_logical(heuristic_id)?;
+            }
+            let logical_symbol_of =
+                |id: i64| -> Option<i64> { logical_cache.borrow().get(&id).copied().flatten() };
             let kind = join::classify_in_corpus(
                 &candidate.confidence,
                 candidate.to_symbol_id,
@@ -428,13 +439,14 @@ pub fn live_oracle_pass(
             );
 
             // Moniker: the target's batch moniker verbatim, else the content-stable local
-            // sentinel (module docs — NEVER the LSP moniker string).
+            // sentinel (module docs — NEVER the LSP moniker string). A DB failure propagates.
+            if let std::collections::hash_map::Entry::Vacant(slot) = moniker_cache.entry(symbol_id)
+            {
+                slot.insert(store::batch_moniker_for_symbol(conn, symbol_id, moniker_source)?);
+            }
             let scip_symbol = moniker_cache
-                .entry(symbol_id)
-                .or_insert_with(|| {
-                    store::batch_moniker_for_symbol(conn, symbol_id, moniker_source).unwrap_or(None)
-                })
-                .clone()
+                .get(&symbol_id)
+                .and_then(Clone::clone)
                 .unwrap_or_else(|| live_local_sentinel(&candidate.source_path, candidate));
 
             let row = EdgeOracleRow {
@@ -527,12 +539,17 @@ fn live_local_sentinel(source_path: &str, candidate: &store::EdgeJoinCandidate) 
 }
 
 /// The `file://` URI of a checkout root — the base every document URI hangs off. Encodes any
-/// non-URI-path byte as %XX (spaces, non-ASCII); `/` is preserved. A Windows drive prefix
-/// (`C:`) keeps its colon UNENCODED — `file:///C:/repo`, not `file:///C%3A/repo` — because
-/// that is the canonical form rust-analyzer returns for definition URIs, and `path_from_uri`'s
-/// literal prefix match must agree with it (#534 review).
+/// non-URI-path byte as %XX (spaces, non-ASCII); `/` is preserved. Two Windows forms keep the
+/// shape rust-analyzer returns canonically (so `path_from_uri`'s literal prefix match agrees,
+/// #534 review): a drive prefix (`C:`) keeps its colon unencoded (`file:///C:/repo`), and a UNC
+/// path (`\\server\share`) becomes an authority URI (`file://server/share/…`, no extra slash).
 fn root_uri_for(checkout_root: &Path) -> String {
     let lossy = checkout_root.to_string_lossy().replace('\\', "/");
+    // UNC: `//server/share/…` → `file://server/share/…` (the server is the URI authority, not a
+    // path segment). Encode each segment but keep the `/` separators.
+    if let Some(unc) = lossy.strip_prefix("//") {
+        return format!("file://{}", encode_uri_path(unc));
+    }
     let with_lead = if lossy.starts_with('/') { lossy } else { format!("/{lossy}") };
     let bytes = with_lead.as_bytes();
     // Drive prefix: `/C:/…` after the leading-slash normalization.
@@ -597,6 +614,19 @@ mod tests {
         assert_eq!(path_from_uri(&root, "file:///C:/repo/src/lib.rs"), Some("src/lib.rs".into()));
         // A drive root with a space still encodes the non-drive part.
         assert_eq!(root_uri_for(Path::new(r"D:\my repo")), "file:///D:/my%20repo");
+    }
+
+    #[test]
+    fn root_uri_maps_a_unc_path_to_an_authority_url() {
+        // `\\server\share\repo` → `file://server/share/repo` (authority form), matching the
+        // canonical URI rust-analyzer returns; a naive join would emit `file:////server/...`
+        // and misclass every in-repo definition as external (#534 review).
+        let root = root_uri_for(Path::new(r"\\server\share\repo"));
+        assert_eq!(root, "file://server/share/repo");
+        assert_eq!(
+            path_from_uri(&root, "file://server/share/repo/src/a.rs"),
+            Some("src/a.rs".into())
+        );
     }
 
     #[test]

--- a/crates/rag-rat-oracle/src/live.rs
+++ b/crates/rag-rat-oracle/src/live.rs
@@ -209,21 +209,27 @@ pub fn live_oracle_pass(
     // prior version's still-current verdicts — the first partial pass's run row would become the
     // latest for the whole checkout and gate every prior-version verdict out of currency,
     // collapsing live coverage to the handful of files this pass revisits. Migrate the rows
-    // (content-addressed, so `file_sha` still gates drift) and invalidate the scip refinements
-    // whose evidence just changed hands.
+    // (content-addressed, so `file_sha` still gates drift; SCOPED to this checkout so a sibling
+    // worktree's rows and currency stay untouched) and invalidate the scip refinements whose
+    // evidence just changed hands. The transition run is recorded whenever the version moved —
+    // even with zero rows moved — because the session's binary IS the new version and the
+    // currency gate must start selecting it (a sibling's migration may already have moved the
+    // shared rows).
     let mut version_migrated = false;
     if let Some(old_version) =
         store::latest_run_tool_version(conn, tool, input.commit_sha, input.worktree_id)?
         && old_version != session.tool_version()
     {
+        version_migrated = true;
         let moved = store::migrate_live_verdicts_to_version(
             conn,
             tool,
             &old_version,
             session.tool_version(),
+            input.commit_sha,
+            input.worktree_id,
         )?;
         if moved > 0 {
-            version_migrated = true;
             refinements_stale = true;
         }
     }
@@ -270,23 +276,34 @@ pub fn live_oracle_pass(
             continue;
         };
 
-        // Covered-skip continuation: a callee with a CURRENT live verdict (same tool_version +
-        // file_sha) is NEVER re-resolved for the same content — the budget only ever spends on
-        // unverdicted callees. A file a prior pass truncated therefore resumes exactly where it
-        // stopped, and a fully-covered file costs nothing (the first-file exemption this
-        // replaces let a huge generated file blow the budget). Re-resolution happens naturally
-        // on content change (a new `file_sha` un-covers the callee) — e.g. upgrading a sentinel
-        // to a batch moniker — or on a version migration, so a stale sentinel costs only
-        // cosmetics: the batch row carries the real evidence for any span both tools cover.
-        let covered = store::live_covered_callees_for_path(
+        // Covered-skip continuation: an edge with a CURRENT live verdict (same tool_version +
+        // file_sha, FULL content key — two edges may share a callee token, and a start-byte key
+        // would let one written row starve the other) is NEVER re-resolved for the same
+        // content — the budget only ever spends on unverdicted edges. A file a prior pass
+        // truncated therefore resumes exactly where it stopped, and a fully-covered file costs
+        // nothing (the first-file exemption this replaces let a huge generated file blow the
+        // budget). Re-resolution happens naturally on content change (a new `file_sha`
+        // un-covers the edge) — e.g. upgrading a sentinel to a batch moniker — or on a version
+        // migration, so a stale sentinel costs only cosmetics: the batch row carries the real
+        // evidence for any span both tools cover.
+        let covered = store::live_covered_edges_for_path(
             conn,
             tool,
             session.tool_version(),
             path,
             &callees[0].file_sha,
         )?;
+        let is_covered = |c: &store::EdgeJoinCandidate| {
+            covered.contains(&(
+                c.source_start_byte,
+                c.source_end_byte,
+                c.callee_start_byte,
+                c.callee_end_byte,
+                c.edge_kind.clone(),
+            ))
+        };
         let unverdicted: Vec<&store::EdgeJoinCandidate> =
-            callees.iter().copied().filter(|c| !covered.contains(&c.callee_start_byte)).collect();
+            callees.iter().copied().filter(|c| !is_covered(c)).collect();
         if unverdicted.is_empty() {
             continue;
         }
@@ -314,12 +331,21 @@ pub fn live_oracle_pass(
                 break 'files;
             },
         };
-        report.files_resolved += 1;
-        if deferred_count > 0 {
+        // Fully sent only when nothing was budget-deferred: `files_resolved` documents "every
+        // callee of this file was sent", so a truncated file must not inflate it (the field
+        // rides `oracle_runs.stats_json` into status consumers).
+        if deferred_count == 0 {
+            report.files_resolved += 1;
+        } else {
             // The budget cut this file short; it rides the backlog and resumes at the deferred
             // callees (the covered-skip above makes that resume exact).
             report.unfinished_paths.push(path.clone());
         }
+        // Definition bytes are cached ONLY within this file's batch: a def file edited between
+        // two source files' LSP requests would otherwise be hashed + position-converted from a
+        // stale snapshot, defeating the definition-side drift gate. (The indexed sha + symbol
+        // spans stay cached: the write lock pins the index for the whole pass.)
+        def_bytes.clear();
 
         for (candidate, definition) in to_resolve.iter().zip(resolved.iter()) {
             let Some((target_uri, target_range)) = definition else {
@@ -501,11 +527,18 @@ fn live_local_sentinel(source_path: &str, candidate: &store::EdgeJoinCandidate) 
 }
 
 /// The `file://` URI of a checkout root — the base every document URI hangs off. Encodes any
-/// non-URI-path byte as %XX (spaces, non-ASCII); `/` is preserved.
+/// non-URI-path byte as %XX (spaces, non-ASCII); `/` is preserved. A Windows drive prefix
+/// (`C:`) keeps its colon UNENCODED — `file:///C:/repo`, not `file:///C%3A/repo` — because
+/// that is the canonical form rust-analyzer returns for definition URIs, and `path_from_uri`'s
+/// literal prefix match must agree with it (#534 review).
 fn root_uri_for(checkout_root: &Path) -> String {
     let lossy = checkout_root.to_string_lossy().replace('\\', "/");
     let with_lead = if lossy.starts_with('/') { lossy } else { format!("/{lossy}") };
-    format!("file://{}", encode_uri_path(&with_lead))
+    let bytes = with_lead.as_bytes();
+    // Drive prefix: `/C:/…` after the leading-slash normalization.
+    let drive_len =
+        if bytes.len() >= 4 && bytes[1].is_ascii_alphabetic() && bytes[2] == b':' { 3 } else { 0 };
+    format!("file://{}{}", &with_lead[..drive_len], encode_uri_path(&with_lead[drive_len..]))
 }
 
 /// Percent-encode a URI path: keep the RFC 3986 unreserved set plus `/`; %XX-encode the rest.
@@ -552,6 +585,18 @@ mod tests {
     fn root_uri_encodes_spaces_and_preserves_slashes() {
         assert_eq!(root_uri_for(Path::new("/tmp/my repo")), "file:///tmp/my%20repo");
         assert_eq!(root_uri_for(Path::new("/plain/path")), "file:///plain/path");
+    }
+
+    #[test]
+    fn root_uri_keeps_a_windows_drive_colon_verbatim() {
+        // rust-analyzer returns `file:///C:/repo/…` canonically; encoding the drive colon
+        // (`file:///C%3A/repo`) would break `path_from_uri`'s prefix match and class every
+        // in-repo definition as external (#534 review).
+        let root = root_uri_for(Path::new(r"C:\repo"));
+        assert_eq!(root, "file:///C:/repo");
+        assert_eq!(path_from_uri(&root, "file:///C:/repo/src/lib.rs"), Some("src/lib.rs".into()));
+        // A drive root with a space still encodes the non-drive part.
+        assert_eq!(root_uri_for(Path::new(r"D:\my repo")), "file:///D:/my%20repo");
     }
 
     #[test]

--- a/crates/rag-rat-oracle/src/live.rs
+++ b/crates/rag-rat-oracle/src/live.rs
@@ -221,8 +221,7 @@ pub fn live_oracle_pass(
         store::latest_run_tool_version(conn, tool, input.commit_sha, input.worktree_id)?
         && old_version != session.tool_version()
     {
-        version_migrated = true;
-        let moved = store::migrate_live_verdicts_to_version(
+        let migration = store::migrate_live_verdicts_to_version(
             conn,
             tool,
             &old_version,
@@ -230,8 +229,23 @@ pub fn live_oracle_pass(
             input.commit_sha,
             input.worktree_id,
         )?;
-        if moved > 0 {
-            refinements_stale = true;
+        match migration {
+            store::LiveVersionMigration::Copied(moved) => {
+                version_migrated = true;
+                if moved > 0 {
+                    refinements_stale = true;
+                }
+            },
+            store::LiveVersionMigration::BlockedByContentCollision => {
+                // The content-key PK cannot hold both checkouts' different bytes under the new
+                // version. Do NOT process/write with that version or record its currency: preserve
+                // the active checkout's old-version coverage and retry after the collision clears.
+                report.unfinished_paths = input.worklist.to_vec();
+                report.status = "VersionMigrationBlocked".to_string();
+                tx.commit()?;
+                session.touch(rag_rat_base::time::now_ms());
+                return Ok(report);
+            },
         }
     }
     let mut aborted: Option<String> = None;

--- a/crates/rag-rat-oracle/src/live.rs
+++ b/crates/rag-rat-oracle/src/live.rs
@@ -39,6 +39,7 @@
 //! the checkout has no batch-interchangeable SCIP symbol string, so it is skipped, not written).
 
 use std::collections::HashMap;
+use std::collections::hash_map::Entry;
 use std::path::Path;
 
 use rag_rat_base::hash::hex_sha256;
@@ -392,18 +393,17 @@ pub fn live_oracle_pass(
                 report.skipped_drifted += 1;
                 continue;
             };
-            let indexed_sha = def_indexed_sha
-                .entry(def_path.clone())
-                .or_insert_with(|| {
-                    store::indexed_file_sha_for_path(
+            let indexed_sha = match def_indexed_sha.entry(def_path.clone()) {
+                Entry::Occupied(entry) => entry.get().clone(),
+                Entry::Vacant(entry) => entry
+                    .insert(store::indexed_file_sha_for_path(
                         conn,
                         &def_path,
                         input.commit_sha,
                         input.worktree_id,
-                    )
-                    .unwrap_or(None)
-                })
-                .clone();
+                    )?)
+                    .clone(),
+            };
             match indexed_sha {
                 // Not indexed in this checkout — nothing live can map to it.
                 None => {
@@ -424,10 +424,15 @@ pub fn live_oracle_pass(
                 report.skipped_drifted += 1;
                 continue;
             };
-            let spans = def_spans.entry(def_path.clone()).or_insert_with(|| {
-                store::symbol_spans_for_path(conn, &def_path, input.commit_sha, input.worktree_id)
-                    .unwrap_or_default()
-            });
+            let spans = match def_spans.entry(def_path.clone()) {
+                Entry::Occupied(entry) => entry.into_mut(),
+                Entry::Vacant(entry) => entry.insert(store::symbol_spans_for_path(
+                    conn,
+                    &def_path,
+                    input.commit_sha,
+                    input.worktree_id,
+                )?),
+            };
             let Some(symbol_id) = join::map_definition_to_symbol(spans, def_start, def_end) else {
                 // The def is in an indexed file but under no indexed symbol (macro-generated
                 // code, a symbol kind without a row): nothing trustworthy to write.
@@ -566,6 +571,16 @@ fn live_local_sentinel(source_path: &str, candidate: &store::EdgeJoinCandidate) 
 /// path (`\\server\share`) becomes an authority URI (`file://server/share/…`, no extra slash).
 fn root_uri_for(checkout_root: &Path) -> String {
     let lossy = checkout_root.to_string_lossy().replace('\\', "/");
+    // `Path::canonicalize` on Windows returns verbatim paths. Normalize those BEFORE the UNC
+    // branch: `\\?\C:\repo` becomes `//?/C:/repo` after separator replacement and would otherwise
+    // be mistaken for an authority named `?`; verbatim UNC uses the `\\?\UNC\server\share` form.
+    let lossy = if let Some(unc) = lossy.strip_prefix("//?/UNC/") {
+        format!("//{unc}")
+    } else if let Some(drive) = lossy.strip_prefix("//?/") {
+        drive.to_string()
+    } else {
+        lossy
+    };
     // UNC: `//server/share/…` → `file://server/share/…` (the server is the URI authority, not a
     // path segment). Encode each segment but keep the `/` separators.
     if let Some(unc) = lossy.strip_prefix("//") {
@@ -639,6 +654,16 @@ mod tests {
         assert_eq!(path_from_uri(&root, "file:///C:/repo/src/lib.rs"), Some("src/lib.rs".into()));
         // A drive root with a space still encodes the non-drive part.
         assert_eq!(root_uri_for(Path::new(r"D:\my repo")), "file:///D:/my%20repo");
+    }
+
+    #[test]
+    fn root_uri_strips_windows_verbatim_prefixes() {
+        // Canonical Windows paths carry `\\?\`; rust-analyzer emits ordinary canonical file URLs.
+        assert_eq!(root_uri_for(Path::new(r"\\?\C:\repo")), "file:///C:/repo");
+        assert_eq!(
+            root_uri_for(Path::new(r"\\?\UNC\server\share\repo")),
+            "file://server/share/repo"
+        );
     }
 
     #[test]

--- a/crates/rag-rat-oracle/src/live.rs
+++ b/crates/rag-rat-oracle/src/live.rs
@@ -214,7 +214,8 @@ pub fn live_oracle_pass(
     // evidence just changed hands. The transition run is recorded whenever the version moved —
     // even with zero rows moved — because the session's binary IS the new version and the
     // currency gate must start selecting it (a sibling's migration may already have moved the
-    // shared rows).
+    // shared rows). Migration COPIES rather than relabels: identical-content siblings share the
+    // old row and still need it under their old-version currency.
     let mut version_migrated = false;
     if let Some(old_version) =
         store::latest_run_tool_version(conn, tool, input.commit_sha, input.worktree_id)?
@@ -583,10 +584,11 @@ fn encode_uri_path(path: &str) -> String {
 /// The repo-relative path of a `file://` document URI under `root_uri`, percent-decoded; `None`
 /// when the URI points outside the checkout (an external dependency — nothing live can write).
 fn path_from_uri(root_uri: &str, uri: &str) -> Option<String> {
-    // The separator between root and document is OPTIONAL here because the root itself may end
-    // in `/` (a filesystem-root `/` or a drive root `C:\`) — strip it only when present.
     let rest = uri.strip_prefix(root_uri)?;
-    let rest = rest.strip_prefix('/').unwrap_or(rest);
+    // Require a path boundary after a non-root checkout URI. A lexical prefix such as
+    // `file:///work/repo` must not accept `file:///work/repository/x.rs` as `sitory/x.rs`.
+    // Slash-terminated roots (`file:///`, `file:///C:/`) already supply that boundary.
+    let rest = if root_uri.ends_with('/') { rest } else { rest.strip_prefix('/')? };
     let mut bytes = Vec::with_capacity(rest.len());
     let raw = rest.as_bytes();
     let mut i = 0;
@@ -672,6 +674,7 @@ mod tests {
             Some("src/a file.rs".to_string())
         );
         assert_eq!(path_from_uri(root, "file:///elsewhere/src/lib.rs"), None);
+        assert_eq!(path_from_uri(root, "file:///tmp/my%20repository/src/lib.rs"), None);
     }
 
     #[test]

--- a/crates/rag-rat-oracle/src/live.rs
+++ b/crates/rag-rat-oracle/src/live.rs
@@ -312,7 +312,13 @@ pub fn live_oracle_pass(
         let (to_resolve, deferred) = unverdicted.split_at(remaining.min(unverdicted.len()));
         let deferred_count = deferred.len();
 
-        let uri = format!("{}/{}", session.root_uri, encode_uri_path(path));
+        // Join on exactly one separator: a root URI already ending in `/` (a filesystem-root `/`
+        // or a drive root `C:\`) would otherwise produce `file:////…` / `file:///C://…`, which
+        // rust-analyzer's canonical single-slash form then fails to prefix-match (#534 review).
+        // `strip_suffix` drops at most ONE slash — `trim_end_matches('/')` would eat `file:///`
+        // down to `file:`.
+        let root = session.root_uri.strip_suffix('/').unwrap_or(&session.root_uri);
+        let uri = format!("{root}/{}", encode_uri_path(path));
         let starts: Vec<usize> =
             to_resolve.iter().filter_map(|c| usize::try_from(c.callee_start_byte).ok()).collect();
         report.requests_used += starts.len() as u64;
@@ -577,7 +583,10 @@ fn encode_uri_path(path: &str) -> String {
 /// The repo-relative path of a `file://` document URI under `root_uri`, percent-decoded; `None`
 /// when the URI points outside the checkout (an external dependency — nothing live can write).
 fn path_from_uri(root_uri: &str, uri: &str) -> Option<String> {
-    let rest = uri.strip_prefix(root_uri)?.strip_prefix('/')?;
+    // The separator between root and document is OPTIONAL here because the root itself may end
+    // in `/` (a filesystem-root `/` or a drive root `C:\`) — strip it only when present.
+    let rest = uri.strip_prefix(root_uri)?;
+    let rest = rest.strip_prefix('/').unwrap_or(rest);
     let mut bytes = Vec::with_capacity(rest.len());
     let raw = rest.as_bytes();
     let mut i = 0;
@@ -627,6 +636,32 @@ mod tests {
             path_from_uri(&root, "file://server/share/repo/src/a.rs"),
             Some("src/a.rs".into())
         );
+    }
+
+    #[test]
+    fn document_join_uses_one_separator_at_a_slash_terminated_root() {
+        // A checkout AT the filesystem root (`/`) or a drive root (`C:\`) yields a root URI
+        // ending in `/`; joining a document must not double the separator or the server's
+        // canonical URI won't prefix-match (#534 review).
+        let root = root_uri_for(Path::new("/"));
+        assert_eq!(root, "file:///");
+        let doc = format!(
+            "{}/{}",
+            root.strip_suffix('/').unwrap_or(&root),
+            encode_uri_path("src/lib.rs")
+        );
+        assert_eq!(doc, "file:///src/lib.rs");
+        assert_eq!(path_from_uri(&root, &doc), Some("src/lib.rs".into()));
+
+        let drive = root_uri_for(Path::new(r"C:\"));
+        assert_eq!(drive, "file:///C:/");
+        let doc = format!(
+            "{}/{}",
+            drive.strip_suffix('/').unwrap_or(&drive),
+            encode_uri_path("src/lib.rs")
+        );
+        assert_eq!(doc, "file:///C:/src/lib.rs");
+        assert_eq!(path_from_uri(&drive, &doc), Some("src/lib.rs".into()));
     }
 
     #[test]

--- a/crates/rag-rat-oracle/src/lsp/client.rs
+++ b/crates/rag-rat-oracle/src/lsp/client.rs
@@ -10,6 +10,7 @@
 //! whole client unit-testable without a real `rust-analyzer`.
 
 use std::io::{self, BufRead, BufReader, Write};
+use std::path::Path;
 use std::process::{Child, Command, Stdio};
 
 use serde_json::{Value, json};
@@ -42,12 +43,14 @@ pub(crate) struct LspClient {
 }
 
 impl LspClient {
-    /// Spawn `program args…` as a language server, piping its stdio into the JSON-RPC transport.
-    /// stderr is discarded (server diagnostics are not part of the protocol). The session starts at
-    /// the LSP default encoding (UTF-16) until [`initialize`](Self::initialize) negotiates one.
-    pub(crate) fn spawn(program: &str, args: &[&str]) -> io::Result<Self> {
+    /// Spawn `program args…` from `cwd` as a language server, piping stdio into the JSON-RPC
+    /// transport. stderr is discarded (server diagnostics are not part of the protocol). The
+    /// session starts at the LSP default encoding (UTF-16) until
+    /// [`initialize`](Self::initialize) negotiates one.
+    pub(crate) fn spawn(program: &str, args: &[&str], cwd: &Path) -> io::Result<Self> {
         let mut child = Command::new(program)
             .args(args)
+            .current_dir(cwd)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::null())
@@ -383,6 +386,15 @@ mod tests {
 
     #[test]
     fn spawn_of_a_missing_program_errors() {
-        assert!(LspClient::spawn("rag-rat-no-such-lsp-xyzzy", &[]).is_err());
+        assert!(LspClient::spawn("rag-rat-no-such-lsp-xyzzy", &[], Path::new(".")).is_err());
+    }
+
+    #[test]
+    fn spawn_applies_the_checkout_cwd() {
+        let root = rag_rat_base::test_scratch::ScratchDir::new("lsp-spawn-cwd");
+        assert!(
+            LspClient::spawn("cargo", &["--version"], &root.path().join("missing")).is_err(),
+            "a missing cwd must prevent spawn"
+        );
     }
 }

--- a/crates/rag-rat-oracle/src/lsp/mod.rs
+++ b/crates/rag-rat-oracle/src/lsp/mod.rs
@@ -2,22 +2,24 @@
 //! resolution shape the batch SCIP pass produces, but for dirty/overlay files at watcher cadence
 //! rather than a whole-checkout SCIP build.
 //!
-//! Slice 1 (this module) is the CLIENT SUBSTRATE only — process lifecycle + JSON-RPC framing +
+//! Slice 1 (this module) is the CLIENT SUBSTRATE — process lifecycle + JSON-RPC framing +
 //! per-document `textDocument/definition` resolution + the position-encoding conversion the LSP
-//! spec demands — with NO watcher wiring, NO DB access, and NO persistence. It is exercised end to
-//! end against a fake in-process LSP server (a thread over `std::io::pipe`), so it is fully
-//! unit-testable without a real `rust-analyzer`. The DB mapping (definition → symbol id via
-//! `join::map_definition_to_symbol`, moniker synthesis, `EdgeOracleRow` assembly + write) and the
-//! maintenance-pass wiring land in slice 2.
+//! spec demands — exercised end to end against a fake in-process LSP server (a thread over
+//! `std::io::pipe`), so it is fully unit-testable without a real `rust-analyzer`. Slice 2 (#534)
+//! wired it to the watcher: `crate::live` owns the DB mapping (definition → symbol id via
+//! `join::map_definition_to_symbol`, batch-moniker synthesis, `EdgeOracleRow` assembly + write)
+//! and the maintenance-pass tail drives it. `resolve_callees` (the variant WITH the moniker
+//! fan-out) has no production caller yet — the live write path never persists LSP monikers, so it
+//! resolves definitions only (`resolve_definitions`).
 //!
 //! Layout mirrors the batch reader's split (`scip.rs` / `join.rs`):
 //! - `position.rs` — LSP `(line, character)` ↔ absolute byte conversion, per the negotiated
 //!   position encoding. The batch analog is `scip::LineColumnToByte`; LSP defaults to UTF-16 and
 //!   negotiates via `initialize`, and unlike SCIP we need BOTH directions (byte → position to ASK
 //!   for a definition, position → byte to READ one back).
-#![allow(dead_code)] // Slice-1 substrate: the maintenance pass wires this in slice 2 (#74).
+#![allow(dead_code)] // `resolve_callees`'s moniker fan-out is unused until a consumer needs it.
 
-mod client;
+pub(crate) mod client;
 pub(crate) mod position;
 mod protocol;
-mod resolve;
+pub(crate) mod resolve;

--- a/crates/rag-rat-oracle/src/lsp/resolve.rs
+++ b/crates/rag-rat-oracle/src/lsp/resolve.rs
@@ -168,11 +168,17 @@ impl LspClient {
 }
 
 /// Parse a `textDocument/definition` result: `Location`, `Location[]`, `LocationLink`,
-/// `LocationLink[]`, or `null`. Returns the FIRST target's `(uri, range)`.
+/// `LocationLink[]`, or `null`. A multi-target response is authoritative only when every entry
+/// names the same target; choosing the first distinct target would turn unordered alternatives
+/// into a false Confirm/Upgrade/Contradict verdict.
 fn parse_definition(value: &Value) -> Option<(String, LspRange)> {
     match value {
         Value::Null => None,
-        Value::Array(items) => items.first().and_then(parse_one_location),
+        Value::Array(items) => {
+            let mut parsed = items.iter().map(parse_one_location);
+            let first = parsed.next()??;
+            parsed.all(|target| target.as_ref() == Some(&first)).then_some(first)
+        },
         object => parse_one_location(object),
     }
 }
@@ -444,6 +450,25 @@ mod tests {
                 end: LspPosition { line: 2, character: 9 },
             }))
         );
+    }
+
+    #[test]
+    fn parse_definition_rejects_distinct_multi_target_responses() {
+        let range = |line| {
+            json!({"start": {"line": line, "character": 0},
+                   "end": {"line": line, "character": 1}})
+        };
+        let ambiguous = json!([
+            {"uri": "file:///a.rs", "range": range(0)},
+            {"uri": "file:///b.rs", "range": range(1)}
+        ]);
+        assert_eq!(parse_definition(&ambiguous), None);
+
+        let duplicate = json!([
+            {"uri": "file:///a.rs", "range": range(0)},
+            {"uri": "file:///a.rs", "range": range(0)}
+        ]);
+        assert!(parse_definition(&duplicate).is_some(), "duplicate targets are unambiguous");
     }
 
     #[test]

--- a/crates/rag-rat-oracle/src/lsp/resolve.rs
+++ b/crates/rag-rat-oracle/src/lsp/resolve.rs
@@ -116,6 +116,32 @@ impl LspClient {
         resolved
     }
 
+    /// [`resolve_callees`] without the per-callee `textDocument/moniker` fan-out — the slice-2
+    /// write path's shape (#534). Live verdicts NEVER persist an LSP moniker (it is not
+    /// interchangeable with the batch SCIP moniker string, so persisting one would trip the
+    /// cross-tool conflict-drop), so the request would be pure waste against the pass's request
+    /// budget. Returns `(target_uri, target_range)` per callee, aligned with `callee_starts`.
+    pub(crate) fn resolve_definitions(
+        &mut self,
+        uri: &str,
+        language_id: &str,
+        text: &str,
+        callee_starts: &[usize],
+    ) -> io::Result<Vec<Option<(String, LspRange)>>> {
+        self.did_open(uri, language_id, text)?;
+        let resolved = (|| {
+            let index = LineIndex::new(text.as_bytes(), self.encoding());
+            let mut out = Vec::with_capacity(callee_starts.len());
+            for &start in callee_starts {
+                let position = index.position_at_byte(start);
+                out.push(self.definition_at(uri, position)?);
+            }
+            Ok(out)
+        })();
+        let _ = self.did_close(uri);
+        resolved
+    }
+
     /// The resolution loop over an ALREADY-OPEN document (the interior of [`resolve_callees`],
     /// split out so the enclosing `didOpen`/`didClose` always pair even when a request errors).
     fn resolve_open_callees(
@@ -417,6 +443,34 @@ mod tests {
                 start: LspPosition { line: 2, character: 3 },
                 end: LspPosition { line: 2, character: 9 },
             }))
+        );
+    }
+
+    #[test]
+    fn resolve_definitions_skips_the_moniker_fan_out() {
+        // The slice-2 write path never persists an LSP moniker, so the definitions-only variant
+        // must not spend a moniker request per callee — assert none leaves the client.
+        let captured = Arc::new(Mutex::new(Vec::new()));
+        let mut client = client_with_server(responder(
+            "utf-16",
+            Some(("file:///defs.rs", (5, 3), (5, 9))),
+            Some("cargo std foo"),
+            Arc::clone(&captured),
+        ));
+        client.initialize("file:///repo").unwrap();
+        let src = "fn caller() { foo(); }\n";
+        let foo = src.find("foo").unwrap();
+        let out = client.resolve_definitions("file:///src.rs", "rust", src, &[foo]).unwrap();
+        assert_eq!(out, vec![Some(("file:///defs.rs".to_string(), LspRange {
+            start: LspPosition { line: 5, character: 3 },
+            end: LspPosition { line: 5, character: 9 },
+        },))]);
+        let requests = captured.lock().unwrap();
+        assert!(
+            !requests
+                .iter()
+                .any(|m| m.get("method").and_then(Value::as_str) == Some("textDocument/moniker")),
+            "no moniker request may be issued: {requests:?}"
         );
     }
 

--- a/crates/rag-rat-oracle/src/manifest.rs
+++ b/crates/rag-rat-oracle/src/manifest.rs
@@ -123,7 +123,17 @@ impl ToolManifest {
     /// `scip` subcommand as `Available`, then fail the actual run. `Blocked` must mean "can't
     /// produce SCIP."
     pub fn probe(&self) -> ToolAvailability {
-        match detect_version(self.program) {
+        self.probe_with_cwd(None)
+    }
+
+    /// Probe from `cwd`. The live rust-analyzer backend uses this so rustup directory overrides in
+    /// the indexed checkout select the same toolchain for `--version` and the later LSP process.
+    pub fn probe_in(&self, cwd: &Path) -> ToolAvailability {
+        self.probe_with_cwd(Some(cwd))
+    }
+
+    fn probe_with_cwd(&self, cwd: Option<&Path>) -> ToolAvailability {
+        match detect_version_in(self.program, cwd) {
             Some(version) if self.can_emit_scip() => ToolAvailability::Available {
                 tool: self.tool.as_db_str().to_string(),
                 program: self.program.to_string(),
@@ -333,8 +343,13 @@ fn has_gradle_build(root: &Path) -> bool {
 /// program is absent / not executable / exits non-zero. The version string is opaque (recorded as
 /// `tool_version` for content-addressed staleness — a different version invalidates prior
 /// verdicts).
-fn detect_version(program: &str) -> Option<String> {
-    let output = Command::new(program).arg("--version").output().ok()?;
+fn detect_version_in(program: &str, cwd: Option<&Path>) -> Option<String> {
+    let mut command = Command::new(program);
+    command.arg("--version");
+    if let Some(cwd) = cwd {
+        command.current_dir(cwd);
+    }
+    let output = command.output().ok()?;
     if !output.status.success() {
         return None;
     }
@@ -386,8 +401,18 @@ mod tests {
     fn detect_version_reads_a_known_program() {
         // `cargo --version` is reliably present in the test environment (we're building with it).
         // Proves the version-detection path returns a non-empty line for a real program.
-        let version = detect_version("cargo");
+        let version = detect_version_in("cargo", None);
         assert!(version.is_some_and(|v| v.starts_with("cargo")));
+    }
+
+    #[test]
+    fn detect_version_in_applies_the_checkout_cwd() {
+        let root = rag_rat_base::test_scratch::ScratchDir::new("oracle-probe-cwd");
+        assert!(detect_version_in("cargo", Some(root.path())).is_some());
+        assert!(
+            detect_version_in("cargo", Some(&root.path().join("missing"))).is_none(),
+            "a missing cwd must prevent spawn, proving current_dir is applied"
+        );
     }
 
     #[test]
@@ -402,7 +427,7 @@ mod tests {
             languages: &["rust"],
             install_hint: "hint",
         };
-        assert!(detect_version("cargo").is_some(), "cargo reports a version");
+        assert!(detect_version_in("cargo", None).is_some(), "cargo reports a version");
         assert!(!manifest.can_emit_scip(), "cargo has no `scip` subcommand");
         assert!(
             !manifest.probe().is_available(),

--- a/crates/rag-rat-oracle/src/manifest.rs
+++ b/crates/rag-rat-oracle/src/manifest.rs
@@ -98,6 +98,17 @@ impl ToolManifest {
                                project's Gradle build (Maven Kotlin is unsupported), so the build \
                                must succeed; or pass a pre-built index with `--scip <path>`.",
             },
+            // The live rust-analyzer LSP client (#534): same binary as the batch Rust backend,
+            // driven as a resident language server by the watcher (`[oracle.live]`), never as a
+            // `.scip` producer — `batch_capable` gates it out of every batch driver.
+            OracleTool::RaLsp => ToolManifest {
+                tool,
+                program: "rust-analyzer",
+                languages: &["rust"],
+                install_hint: "rust-analyzer not found on PATH. Install it (e.g. `rustup \
+                               component add rust-analyzer`) so the live oracle (`[oracle.live] \
+                               enabled`) can spawn it as a language server.",
+            },
         }
     }
 
@@ -147,6 +158,9 @@ impl ToolManifest {
                     .arg("--help")
                     .output()
                     .is_ok_and(|output| output.status.success()),
+            // The live client drives rust-analyzer as an LSP server (no `scip` subcommand needed);
+            // a successful `--version` (already detected by `probe`) is the capability signal.
+            OracleTool::RaLsp => true,
         }
     }
 
@@ -204,6 +218,8 @@ impl ToolManifest {
                     root.display()
                 )
             }),
+            // The live client has no checkout prerequisite beyond the binary itself.
+            OracleTool::RaLsp => None,
         }
     }
 
@@ -287,6 +303,13 @@ impl ToolManifest {
                     .arg(output);
                 cmd
             },
+            // Unreachable: every batch driver gates live-only tools out BEFORE building a command
+            // (`produce_scip_with_tool` returns `Blocked`, the auto-run loop and the wizard filter
+            // on `batch_capable`). A live tool has no whole-checkout index invocation.
+            OracleTool::RaLsp => unreachable!(
+                "ra-lsp is a live oracle backend with no scip_command — the caller must gate on \
+                 OracleTool::batch_capable()"
+            ),
         }
     }
 }

--- a/crates/rag-rat-oracle/src/store.rs
+++ b/crates/rag-rat-oracle/src/store.rs
@@ -673,6 +673,41 @@ pub(crate) fn existing_verdict_scip_symbol(
     .map_err(Into::into)
 }
 
+/// Whether `row`'s content key is still a live edge for `file_sha` in ANY checkout of the active
+/// repo. Live rows are content-keyed without `file_sha` in the PK, so an ordinary same-version
+/// upsert must not replace a different-SHA row while a sibling checkout still joins to it.
+pub(crate) fn verdict_content_is_current_anywhere(
+    conn: &Connection,
+    row: &EdgeOracleRow<'_>,
+    file_sha: &str,
+) -> anyhow::Result<bool> {
+    conn.query_row(
+        "SELECT EXISTS (
+             SELECT 1
+             FROM edges_data
+             JOIN files ON files.id = edges_data.source_file_id
+             JOIN name_strings ek ON ek.id = edges_data.edge_kind_id
+             WHERE files.path = ?1 AND files.sha256 = ?2
+               AND edges_data.source_start_byte = ?3
+               AND edges_data.source_end_byte = ?4
+               AND edges_data.callee_start_byte = ?5
+               AND edges_data.callee_end_byte = ?6
+               AND ek.value = ?7
+               AND edges_data.hidden = 0)",
+        params![
+            row.source_path,
+            file_sha,
+            row.source_start_byte,
+            row.source_end_byte,
+            row.callee_start_byte,
+            row.callee_end_byte,
+            row.edge_kind,
+        ],
+        |db_row| db_row.get(0),
+    )
+    .map_err(Into::into)
+}
+
 /// All symbols defined in a file (by path, scoped to commit/worktree), with their byte spans, so a
 /// SCIP definition range can be mapped to the enclosing symbol by overlap.
 pub(crate) fn symbol_spans_for_path(

--- a/crates/rag-rat-oracle/src/store.rs
+++ b/crates/rag-rat-oracle/src/store.rs
@@ -368,21 +368,31 @@ pub(crate) type LiveEdgeKey = (i64, i64, i64, i64, String);
 /// (source span + callee span + edge kind), never the callee start alone: two edges can share
 /// one token (`calls_name` + `references_type`), and a start-byte key would let the first
 /// written row mark BOTH covered and starve the other forever.
+///
+/// A verdict whose resolved DEFINITION no longer exists in the active checkout (the def file was
+/// edited + reindexed between passes while THIS file's bytes held) is NOT counted covered — it
+/// applies the same definition-current predicate the surfacing reads use, so continuation
+/// re-resolves the edge instead of skipping it forever behind evidence the read path rejects.
 pub(crate) fn live_covered_edges_for_path(
     conn: &Connection,
     tool: OracleTool,
     tool_version: &str,
     source_path: &str,
     file_sha: &str,
+    commit_sha: &str,
+    worktree_id: &str,
 ) -> anyhow::Result<std::collections::HashSet<LiveEdgeKey>> {
     let repo_clause = oracle_repo_scope_clause(conn, "edge_oracle")?;
+    let def_current = edge_oracle_def_current_predicate("?5", "?6");
     let mut stmt = conn.prepare(&format!(
         "SELECT source_start_byte, source_end_byte, callee_start_byte, callee_end_byte, edge_kind
          FROM edge_oracle
-         WHERE tool = ?1 AND tool_version = ?2 AND source_path = ?3 AND file_sha = ?4{repo_clause}"
+         WHERE tool = ?1 AND tool_version = ?2 AND source_path = ?3 AND file_sha = \
+         ?4{repo_clause}{def_current}"
     ))?;
-    let rows =
-        stmt.query_map(params![tool.as_db_str(), tool_version, source_path, file_sha], |row| {
+    let rows = stmt.query_map(
+        params![tool.as_db_str(), tool_version, source_path, file_sha, commit_sha, worktree_id],
+        |row| {
             Ok((
                 row.get::<_, i64>(0)?,
                 row.get::<_, i64>(1)?,
@@ -390,7 +400,8 @@ pub(crate) fn live_covered_edges_for_path(
                 row.get::<_, i64>(3)?,
                 row.get::<_, String>(4)?,
             ))
-        })?;
+        },
+    )?;
     let mut out = std::collections::HashSet::new();
     for row in rows {
         out.insert(row?);
@@ -422,8 +433,31 @@ pub(crate) fn migrate_live_verdicts_to_version(
 ) -> anyhow::Result<u64> {
     let repo_clause = oracle_repo_scope_clause(conn, "edge_oracle")?;
     let scope = active_checkout_file_predicate("?4", "?5");
-    // Drop old-version rows whose content key the new version already covers in THIS checkout
-    // (PK is (repo_id?, tool, tool_version, source_path, spans…, edge_kind)).
+    // The active-checkout, current-CONTENT live-edge predicate: the row's `file_sha` must equal
+    // the checkout's CURRENT `files.sha256`, so a sibling worktree's row (same path + spans, but
+    // its own content sha) is NOT treated as this checkout's — without the sha correlation a
+    // repo-wide relabel would move the sibling's row while only this checkout records the
+    // new-version run, hiding the sibling's verdicts behind its still-old currency gate.
+    let active_current = format!(
+        "EXISTS (
+             SELECT 1
+             FROM edges_data
+             JOIN files ON files.id = edges_data.source_file_id
+             JOIN name_strings ek ON ek.id = edges_data.edge_kind_id
+             WHERE files.path = edge_oracle.source_path
+               AND files.sha256 = edge_oracle.file_sha
+               AND edges_data.source_start_byte = edge_oracle.source_start_byte
+               AND edges_data.source_end_byte = edge_oracle.source_end_byte
+               AND edges_data.callee_start_byte = edge_oracle.callee_start_byte
+               AND edges_data.callee_end_byte = edge_oracle.callee_end_byte
+               AND ek.value = edge_oracle.edge_kind
+               AND edges_data.hidden = 0
+               AND {scope})"
+    );
+    // Drop old-version rows whose content key the new version already occupies (the PK is
+    // (repo_id?, tool, tool_version, source_path, spans…, edge_kind) — file_sha is NOT in it, so
+    // the UPDATE below would otherwise hit a PK collision), restricted to rows current in THIS
+    // checkout.
     conn.execute(
         &format!(
             "DELETE FROM edge_oracle
@@ -434,19 +468,7 @@ pub(crate) fn migrate_live_verdicts_to_version(
                            callee_start_byte, callee_end_byte, edge_kind
                     FROM edge_oracle
                     WHERE tool = ?1 AND tool_version = ?3{repo_clause})
-               AND EXISTS (
-                    SELECT 1
-                    FROM edges_data
-                    JOIN files ON files.id = edges_data.source_file_id
-                    JOIN name_strings ek ON ek.id = edges_data.edge_kind_id
-                    WHERE files.path = edge_oracle.source_path
-                      AND edges_data.source_start_byte = edge_oracle.source_start_byte
-                      AND edges_data.source_end_byte = edge_oracle.source_end_byte
-                      AND edges_data.callee_start_byte = edge_oracle.callee_start_byte
-                      AND edges_data.callee_end_byte = edge_oracle.callee_end_byte
-                      AND ek.value = edge_oracle.edge_kind
-                      AND edges_data.hidden = 0
-                      AND {scope})"
+               AND {active_current}"
         ),
         params![tool.as_db_str(), from_version, to_version, commit_sha, worktree_id],
     )?;
@@ -454,19 +476,7 @@ pub(crate) fn migrate_live_verdicts_to_version(
         &format!(
             "UPDATE edge_oracle SET tool_version = ?3
              WHERE tool = ?1 AND tool_version = ?2{repo_clause}
-               AND EXISTS (
-                    SELECT 1
-                    FROM edges_data
-                    JOIN files ON files.id = edges_data.source_file_id
-                    JOIN name_strings ek ON ek.id = edges_data.edge_kind_id
-                    WHERE files.path = edge_oracle.source_path
-                      AND edges_data.source_start_byte = edge_oracle.source_start_byte
-                      AND edges_data.source_end_byte = edge_oracle.source_end_byte
-                      AND edges_data.callee_start_byte = edge_oracle.callee_start_byte
-                      AND edges_data.callee_end_byte = edge_oracle.callee_end_byte
-                      AND ek.value = edge_oracle.edge_kind
-                      AND edges_data.hidden = 0
-                      AND {scope})"
+               AND {active_current}"
         ),
         params![tool.as_db_str(), from_version, to_version, commit_sha, worktree_id],
     )?;

--- a/crates/rag-rat-oracle/src/store.rs
+++ b/crates/rag-rat-oracle/src/store.rs
@@ -355,27 +355,36 @@ pub(crate) fn indexed_file_sha_for_path(
     .map_err(Into::into)
 }
 
-/// The callee start bytes of a file already covered by a CURRENT live verdict for
+/// The full content keys of a file's edges already covered by a CURRENT live verdict for
 /// `(tool, tool_version)` — current meaning the row's `file_sha` matches the file's indexed
 /// content NOW (the content-addressed currency the live pass keys on, #534). The budget
 /// continuation mechanism: a file a prior pass truncated resumes where it stopped, because
-/// already-verdicted callees are re-resolved LAST (and skipped entirely while the budget is
-/// exhausted).
-pub(crate) fn live_covered_callees_for_path(
+/// already-verdicted callees are skipped by the live pass. The key is the FULL edge identity
+/// (source span + callee span + edge kind), never the callee start alone: two edges can share
+/// one token (`calls_name` + `references_type`), and a start-byte key would let the first
+/// written row mark BOTH covered and starve the other forever.
+pub(crate) fn live_covered_edges_for_path(
     conn: &Connection,
     tool: OracleTool,
     tool_version: &str,
     source_path: &str,
     file_sha: &str,
-) -> anyhow::Result<std::collections::HashSet<i64>> {
+) -> anyhow::Result<std::collections::HashSet<(i64, i64, i64, i64, String)>> {
     let repo_clause = oracle_repo_scope_clause(conn, "edge_oracle")?;
     let mut stmt = conn.prepare(&format!(
-        "SELECT callee_start_byte FROM edge_oracle
+        "SELECT source_start_byte, source_end_byte, callee_start_byte, callee_end_byte, edge_kind
+         FROM edge_oracle
          WHERE tool = ?1 AND tool_version = ?2 AND source_path = ?3 AND file_sha = ?4{repo_clause}"
     ))?;
-    let rows = stmt
-        .query_map(params![tool.as_db_str(), tool_version, source_path, file_sha], |row| {
-            row.get::<_, i64>(0)
+    let rows =
+        stmt.query_map(params![tool.as_db_str(), tool_version, source_path, file_sha], |row| {
+            Ok((
+                row.get::<_, i64>(0)?,
+                row.get::<_, i64>(1)?,
+                row.get::<_, i64>(2)?,
+                row.get::<_, i64>(3)?,
+                row.get::<_, String>(4)?,
+            ))
         })?;
     let mut out = std::collections::HashSet::new();
     for row in rows {
@@ -391,15 +400,25 @@ pub(crate) fn live_covered_callees_for_path(
 /// coverage to the handful of files the new session revisited. The rows are content-addressed
 /// (`file_sha` still gates drift), so moving them under the new version preserves coverage; a
 /// row the new version already wrote (same content key) is dropped first to keep the PK.
+///
+/// SCOPE (load-bearing): restricted to rows whose LIVE EDGE belongs to the active
+/// `(commit_sha, worktree_id)` checkout — the SAME content join [`clear_edge_oracle_for_tool`]
+/// uses. `edge_oracle` rows carry no commit/worktree columns (their scope is the live-edge
+/// join), so a repo-wide UPDATE would relabel a SIBLING worktree's rows too while only THIS
+/// checkout gets the new-version run row — and the sibling's currency gate, still selecting the
+/// old version, would then hide all of its own verdicts.
 pub(crate) fn migrate_live_verdicts_to_version(
     conn: &Connection,
     tool: OracleTool,
     from_version: &str,
     to_version: &str,
+    commit_sha: &str,
+    worktree_id: &str,
 ) -> anyhow::Result<u64> {
     let repo_clause = oracle_repo_scope_clause(conn, "edge_oracle")?;
-    // Drop old-version rows whose content key the new version already covers (PK is
-    // (repo_id?, tool, tool_version, source_path, spans…, edge_kind)).
+    let scope = active_checkout_file_predicate("?4", "?5");
+    // Drop old-version rows whose content key the new version already covers in THIS checkout
+    // (PK is (repo_id?, tool, tool_version, source_path, spans…, edge_kind)).
     conn.execute(
         &format!(
             "DELETE FROM edge_oracle
@@ -409,16 +428,42 @@ pub(crate) fn migrate_live_verdicts_to_version(
                     SELECT source_path, source_start_byte, source_end_byte,
                            callee_start_byte, callee_end_byte, edge_kind
                     FROM edge_oracle
-                    WHERE tool = ?1 AND tool_version = ?3{repo_clause})"
+                    WHERE tool = ?1 AND tool_version = ?3{repo_clause})
+               AND EXISTS (
+                    SELECT 1
+                    FROM edges_data
+                    JOIN files ON files.id = edges_data.source_file_id
+                    JOIN name_strings ek ON ek.id = edges_data.edge_kind_id
+                    WHERE files.path = edge_oracle.source_path
+                      AND edges_data.source_start_byte = edge_oracle.source_start_byte
+                      AND edges_data.source_end_byte = edge_oracle.source_end_byte
+                      AND edges_data.callee_start_byte = edge_oracle.callee_start_byte
+                      AND edges_data.callee_end_byte = edge_oracle.callee_end_byte
+                      AND ek.value = edge_oracle.edge_kind
+                      AND edges_data.hidden = 0
+                      AND {scope})"
         ),
-        params![tool.as_db_str(), from_version, to_version],
+        params![tool.as_db_str(), from_version, to_version, commit_sha, worktree_id],
     )?;
     let moved = conn.execute(
         &format!(
             "UPDATE edge_oracle SET tool_version = ?3
-             WHERE tool = ?1 AND tool_version = ?2{repo_clause}"
+             WHERE tool = ?1 AND tool_version = ?2{repo_clause}
+               AND EXISTS (
+                    SELECT 1
+                    FROM edges_data
+                    JOIN files ON files.id = edges_data.source_file_id
+                    JOIN name_strings ek ON ek.id = edges_data.edge_kind_id
+                    WHERE files.path = edge_oracle.source_path
+                      AND edges_data.source_start_byte = edge_oracle.source_start_byte
+                      AND edges_data.source_end_byte = edge_oracle.source_end_byte
+                      AND edges_data.callee_start_byte = edge_oracle.callee_start_byte
+                      AND edges_data.callee_end_byte = edge_oracle.callee_end_byte
+                      AND ek.value = edge_oracle.edge_kind
+                      AND edges_data.hidden = 0
+                      AND {scope})"
         ),
-        params![tool.as_db_str(), from_version, to_version],
+        params![tool.as_db_str(), from_version, to_version, commit_sha, worktree_id],
     )?;
     Ok(moved as u64)
 }

--- a/crates/rag-rat-oracle/src/store.rs
+++ b/crates/rag-rat-oracle/src/store.rs
@@ -361,8 +361,9 @@ pub(crate) fn indexed_file_sha_for_path(
 pub(crate) type LiveEdgeKey = (i64, i64, i64, i64, String);
 
 /// The full content keys of a file's edges already covered by a CURRENT live verdict for
-/// `(tool, tool_version)` — current meaning the row's `file_sha` matches the file's indexed
-/// content NOW (the content-addressed currency the live pass keys on, #534). The budget
+/// `(tool, tool_version)` — current meaning this checkout's latest run selects `tool_version` and
+/// the row's `file_sha` matches the file's indexed content NOW (the content-addressed currency the
+/// live pass keys on, #534). The budget
 /// continuation mechanism: a file a prior pass truncated resumes where it stopped, because
 /// already-verdicted callees are skipped by the live pass. The key is the FULL edge identity
 /// (source span + callee span + edge kind), never the callee start alone: two edges can share
@@ -382,6 +383,14 @@ pub(crate) fn live_covered_edges_for_path(
     commit_sha: &str,
     worktree_id: &str,
 ) -> anyhow::Result<std::collections::HashSet<LiveEdgeKey>> {
+    // Shared content-key rows are NOT usable continuation coverage until this checkout has a run
+    // establishing the same tool version as current. Without this gate, a sibling's rows can make
+    // a fresh checkout skip every request while surfacing rejects them for missing currency.
+    if latest_run_tool_version(conn, tool, commit_sha, worktree_id)?.as_deref()
+        != Some(tool_version)
+    {
+        return Ok(std::collections::HashSet::new());
+    }
     let repo_clause = oracle_repo_scope_clause(conn, "edge_oracle")?;
     let def_current = edge_oracle_def_current_predicate("?5", "?6");
     let mut stmt = conn.prepare(&format!(
@@ -468,6 +477,22 @@ pub(crate) fn migrate_live_verdicts_to_version(
     );
     let (repo_col, repo_value) =
         if oracle_repo_scope(conn)?.is_some() { ("repo_id, ", "repo_id, ") } else { ("", "") };
+    let repo_id = rag_rat_db::schema::active_repo_id(conn)?;
+    let generation = rag_rat_db::schema::active_generation(conn)?;
+    // Unlike the active-source predicate above, destination currency must look across EVERY
+    // checkout. Bypass temp.files and pin the raw tables to this repo's live generation.
+    let dest_current = "EXISTS (
+         SELECT 1
+         FROM main.edges_data all_edges
+         JOIN main.files all_files ON all_files.id = all_edges.source_file_id
+         JOIN main.name_strings all_kinds ON all_kinds.id = all_edges.edge_kind_id
+         WHERE all_files.repo_id = ?6 AND all_files.generation = ?7
+           AND all_files.path = dest.source_path AND all_files.sha256 = dest.file_sha
+           AND all_edges.source_start_byte = dest.source_start_byte
+           AND all_edges.source_end_byte = dest.source_end_byte
+           AND all_edges.callee_start_byte = dest.callee_start_byte
+           AND all_edges.callee_end_byte = dest.callee_end_byte
+           AND all_kinds.value = dest.edge_kind AND all_edges.hidden = 0)";
     let collision = conn.query_row(
         &format!(
             "SELECT EXISTS (
@@ -484,14 +509,53 @@ pub(crate) fn migrate_live_verdicts_to_version(
                   AND dest.edge_kind = old.edge_kind{dest_repo_clause}
                  WHERE old.tool = ?1 AND old.tool_version = ?2{repo_clause}
                    AND dest.file_sha != old.file_sha
-                   AND {active_current})"
+                   AND {active_current}
+                   AND {dest_current})"
         ),
-        params![tool.as_db_str(), from_version, to_version, commit_sha, worktree_id],
+        params![
+            tool.as_db_str(),
+            from_version,
+            to_version,
+            commit_sha,
+            worktree_id,
+            repo_id,
+            generation,
+        ],
         |row| row.get::<_, bool>(0),
     )?;
     if collision {
         return Ok(LiveVersionMigration::BlockedByContentCollision);
     }
+    // A destination collision that is NOT current anywhere is stale retained history (for example
+    // v1→v2→v1 after content changed). Remove it so INSERT below can copy current evidence instead
+    // of being silently ignored by the content-key PK.
+    conn.execute(
+        &format!(
+            "DELETE FROM edge_oracle AS dest
+             WHERE dest.tool = ?1 AND dest.tool_version = ?3{dest_repo_clause}
+               AND NOT {dest_current}
+               AND EXISTS (
+                   SELECT 1 FROM edge_oracle old
+                   WHERE old.tool = ?1 AND old.tool_version = ?2{repo_clause}
+                     AND old.source_path = dest.source_path
+                     AND old.source_start_byte = dest.source_start_byte
+                     AND old.source_end_byte = dest.source_end_byte
+                     AND old.callee_start_byte = dest.callee_start_byte
+                     AND old.callee_end_byte = dest.callee_end_byte
+                     AND old.edge_kind = dest.edge_kind
+                     AND old.file_sha != dest.file_sha
+                     AND {active_current})"
+        ),
+        params![
+            tool.as_db_str(),
+            from_version,
+            to_version,
+            commit_sha,
+            worktree_id,
+            repo_id,
+            generation,
+        ],
+    )?;
     // COPY, never relabel: two checkouts with identical bytes + spans intentionally share the old
     // row. Keeping it lets a sibling's old-version currency continue surfacing the verdict while
     // this checkout switches to the copied new-version row.
@@ -681,19 +745,22 @@ pub(crate) fn verdict_content_is_current_anywhere(
     row: &EdgeOracleRow<'_>,
     file_sha: &str,
 ) -> anyhow::Result<bool> {
+    let repo_id = rag_rat_db::schema::active_repo_id(conn)?;
+    let generation = rag_rat_db::schema::active_generation(conn)?;
     conn.query_row(
         "SELECT EXISTS (
              SELECT 1
-             FROM edges_data
-             JOIN files ON files.id = edges_data.source_file_id
-             JOIN name_strings ek ON ek.id = edges_data.edge_kind_id
-             WHERE files.path = ?1 AND files.sha256 = ?2
-               AND edges_data.source_start_byte = ?3
-               AND edges_data.source_end_byte = ?4
-               AND edges_data.callee_start_byte = ?5
-               AND edges_data.callee_end_byte = ?6
+             FROM main.edges_data all_edges
+             JOIN main.files all_files ON all_files.id = all_edges.source_file_id
+             JOIN main.name_strings ek ON ek.id = all_edges.edge_kind_id
+             WHERE all_files.repo_id = ?8 AND all_files.generation = ?9
+               AND all_files.path = ?1 AND all_files.sha256 = ?2
+               AND all_edges.source_start_byte = ?3
+               AND all_edges.source_end_byte = ?4
+               AND all_edges.callee_start_byte = ?5
+               AND all_edges.callee_end_byte = ?6
                AND ek.value = ?7
-               AND edges_data.hidden = 0)",
+               AND all_edges.hidden = 0)",
         params![
             row.source_path,
             file_sha,
@@ -702,6 +769,8 @@ pub(crate) fn verdict_content_is_current_anywhere(
             row.callee_start_byte,
             row.callee_end_byte,
             row.edge_kind,
+            repo_id,
+            generation,
         ],
         |db_row| db_row.get(0),
     )

--- a/crates/rag-rat-oracle/src/store.rs
+++ b/crates/rag-rat-oracle/src/store.rs
@@ -355,6 +355,11 @@ pub(crate) fn indexed_file_sha_for_path(
     .map_err(Into::into)
 }
 
+/// An `edge_oracle` row's full content key: `(source_start_byte, source_end_byte,
+/// callee_start_byte, callee_end_byte, edge_kind)` — the identity the live pass's covered-skip
+/// tracks (never the callee start alone; two edges can share one token).
+pub(crate) type LiveEdgeKey = (i64, i64, i64, i64, String);
+
 /// The full content keys of a file's edges already covered by a CURRENT live verdict for
 /// `(tool, tool_version)` — current meaning the row's `file_sha` matches the file's indexed
 /// content NOW (the content-addressed currency the live pass keys on, #534). The budget
@@ -369,7 +374,7 @@ pub(crate) fn live_covered_edges_for_path(
     tool_version: &str,
     source_path: &str,
     file_sha: &str,
-) -> anyhow::Result<std::collections::HashSet<(i64, i64, i64, i64, String)>> {
+) -> anyhow::Result<std::collections::HashSet<LiveEdgeKey>> {
     let repo_clause = oracle_repo_scope_clause(conn, "edge_oracle")?;
     let mut stmt = conn.prepare(&format!(
         "SELECT source_start_byte, source_end_byte, callee_start_byte, callee_end_byte, edge_kind

--- a/crates/rag-rat-oracle/src/store.rs
+++ b/crates/rag-rat-oracle/src/store.rs
@@ -333,9 +333,26 @@ pub(crate) fn edge_join_candidates(
 
 /// [`edge_join_candidates`] restricted to a set of source paths — the live oracle's per-pass
 /// worklist (#534): only the files the maintenance pass just reindexed. Same scope + ordering
-/// discipline as the whole-checkout variant. `paths` is caller-capped (the pass budget), so the
-/// `IN` list stays bounded.
+/// discipline as the whole-checkout variant. Paths are queried in bounded chunks (one `IN` list
+/// per chunk), so an accumulated backlog larger than SQLite's bound-variable limit can't fail
+/// the prepare and wedge the backlog forever.
 pub(crate) fn edge_join_candidates_for_paths(
+    conn: &Connection,
+    commit_sha: &str,
+    worktree_id: &str,
+    paths: &[String],
+) -> anyhow::Result<Vec<EdgeJoinCandidate>> {
+    const PATH_CHUNK: usize = 500;
+    let mut out = Vec::new();
+    for chunk in paths.chunks(PATH_CHUNK) {
+        out.extend(edge_join_candidates_in_paths(conn, commit_sha, worktree_id, chunk)?);
+    }
+    // Chunks concatenate in worklist order; the per-chunk ORDER BY keeps candidates grouped by
+    // path, which is all the live pass's per-file grouping requires.
+    Ok(out)
+}
+
+fn edge_join_candidates_in_paths(
     conn: &Connection,
     commit_sha: &str,
     worktree_id: &str,

--- a/crates/rag-rat-oracle/src/store.rs
+++ b/crates/rag-rat-oracle/src/store.rs
@@ -409,14 +409,24 @@ pub(crate) fn live_covered_edges_for_path(
     Ok(out)
 }
 
-/// Copy every current-checkout `edge_oracle` row of `tool` from one `tool_version` to another,
-/// returning the inserted row count. The live oracle's version-transition path (#534): a respawn
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum LiveVersionMigration {
+    Copied(u64),
+    /// The destination version already owns the same content key for different file bytes. Because
+    /// `file_sha` is not in the PK, both checkout-scoped verdicts cannot coexist under that
+    /// version.
+    BlockedByContentCollision,
+}
+
+/// Copy every current-checkout `edge_oracle` row of `tool` from one `tool_version` to another.
+/// The live oracle's version-transition path (#534): a respawn
 /// probing a NEW `rust-analyzer --version` would otherwise make the first partial pass's run row
 /// the latest for the whole checkout and gate every prior-version verdict out of currency —
 /// collapsing live coverage to the handful of files the new session revisited. The rows are
 /// content-addressed (`file_sha` still gates drift), so copying them under the new version
-/// preserves coverage; a row the new version already wrote (same content key) wins via `INSERT OR
-/// IGNORE`.
+/// preserves coverage. An identical destination row wins via `INSERT OR IGNORE`; a destination
+/// row for DIFFERENT bytes blocks the whole transition before any copy, because the content-key PK
+/// cannot represent both and advancing currency would hide one checkout's valid verdict.
 ///
 /// SCOPE (load-bearing): the copied set is restricted to rows whose LIVE EDGE belongs to the active
 /// `(commit_sha, worktree_id)` checkout — the SAME content join [`clear_edge_oracle_for_tool`]
@@ -432,8 +442,9 @@ pub(crate) fn migrate_live_verdicts_to_version(
     to_version: &str,
     commit_sha: &str,
     worktree_id: &str,
-) -> anyhow::Result<u64> {
-    let repo_clause = oracle_repo_scope_clause(conn, "edge_oracle")?;
+) -> anyhow::Result<LiveVersionMigration> {
+    let repo_clause = oracle_repo_scope_clause(conn, "old")?;
+    let dest_repo_clause = oracle_repo_scope_clause(conn, "dest")?;
     let scope = active_checkout_file_predicate("?4", "?5");
     // The active-checkout, current-CONTENT live-edge predicate: the row's `file_sha` must equal
     // the checkout's CURRENT `files.sha256`, so a sibling worktree's row (same path + spans, but
@@ -445,18 +456,42 @@ pub(crate) fn migrate_live_verdicts_to_version(
              FROM edges_data
              JOIN files ON files.id = edges_data.source_file_id
              JOIN name_strings ek ON ek.id = edges_data.edge_kind_id
-             WHERE files.path = edge_oracle.source_path
-               AND files.sha256 = edge_oracle.file_sha
-               AND edges_data.source_start_byte = edge_oracle.source_start_byte
-               AND edges_data.source_end_byte = edge_oracle.source_end_byte
-               AND edges_data.callee_start_byte = edge_oracle.callee_start_byte
-               AND edges_data.callee_end_byte = edge_oracle.callee_end_byte
-               AND ek.value = edge_oracle.edge_kind
+             WHERE files.path = old.source_path
+               AND files.sha256 = old.file_sha
+               AND edges_data.source_start_byte = old.source_start_byte
+               AND edges_data.source_end_byte = old.source_end_byte
+               AND edges_data.callee_start_byte = old.callee_start_byte
+               AND edges_data.callee_end_byte = old.callee_end_byte
+               AND ek.value = old.edge_kind
                AND edges_data.hidden = 0
                AND {scope})"
     );
     let (repo_col, repo_value) =
         if oracle_repo_scope(conn)?.is_some() { ("repo_id, ", "repo_id, ") } else { ("", "") };
+    let collision = conn.query_row(
+        &format!(
+            "SELECT EXISTS (
+                 SELECT 1
+                 FROM edge_oracle old
+                 JOIN edge_oracle dest
+                   ON dest.tool = old.tool
+                  AND dest.tool_version = ?3
+                  AND dest.source_path = old.source_path
+                  AND dest.source_start_byte = old.source_start_byte
+                  AND dest.source_end_byte = old.source_end_byte
+                  AND dest.callee_start_byte = old.callee_start_byte
+                  AND dest.callee_end_byte = old.callee_end_byte
+                  AND dest.edge_kind = old.edge_kind{dest_repo_clause}
+                 WHERE old.tool = ?1 AND old.tool_version = ?2{repo_clause}
+                   AND dest.file_sha != old.file_sha
+                   AND {active_current})"
+        ),
+        params![tool.as_db_str(), from_version, to_version, commit_sha, worktree_id],
+        |row| row.get::<_, bool>(0),
+    )?;
+    if collision {
+        return Ok(LiveVersionMigration::BlockedByContentCollision);
+    }
     // COPY, never relabel: two checkouts with identical bytes + spans intentionally share the old
     // row. Keeping it lets a sibling's old-version currency continue surfacing the verdict while
     // this checkout switches to the copied new-version row.
@@ -469,13 +504,13 @@ pub(crate) fn migrate_live_verdicts_to_version(
              SELECT {repo_value}source_path, source_start_byte, source_end_byte,
                     callee_start_byte, callee_end_byte, edge_kind, file_sha, tool, ?3,
                     resolved_symbol_id, scip_symbol, kind, computed_at
-             FROM edge_oracle
-             WHERE tool = ?1 AND tool_version = ?2{repo_clause}
+             FROM edge_oracle old
+             WHERE old.tool = ?1 AND old.tool_version = ?2{repo_clause}
                AND {active_current}"
         ),
         params![tool.as_db_str(), from_version, to_version, commit_sha, worktree_id],
     )?;
-    Ok(moved as u64)
+    Ok(LiveVersionMigration::Copied(moved as u64))
 }
 
 /// [`edge_join_candidates`] restricted to a set of source paths — the live oracle's per-pass

--- a/crates/rag-rat-oracle/src/store.rs
+++ b/crates/rag-rat-oracle/src/store.rs
@@ -331,6 +331,98 @@ pub(crate) fn edge_join_candidates(
     Ok(out)
 }
 
+/// The `files.sha256` of ONE indexed path in the active checkout, or `None` when the path isn't
+/// indexed here (tombstones excluded, as in [`indexed_file_shas_in_scope`]). The live oracle's
+/// definition-side drift probe (#534): the LSP returns a bounded set of definition paths per
+/// pass, so materializing the whole-checkout map would be O(repo files) per pass under the write
+/// lock for no benefit.
+pub(crate) fn indexed_file_sha_for_path(
+    conn: &Connection,
+    path: &str,
+    commit_sha: &str,
+    worktree_id: &str,
+) -> anyhow::Result<Option<String>> {
+    use rusqlite::OptionalExtension as _;
+    conn.query_row(
+        &format!(
+            "SELECT sha256 FROM files WHERE path = ?1 AND kind != 'deleted' AND {scope}",
+            scope = active_checkout_file_predicate("?2", "?3"),
+        ),
+        params![path, commit_sha, worktree_id],
+        |row| row.get::<_, String>(0),
+    )
+    .optional()
+    .map_err(Into::into)
+}
+
+/// The callee start bytes of a file already covered by a CURRENT live verdict for
+/// `(tool, tool_version)` — current meaning the row's `file_sha` matches the file's indexed
+/// content NOW (the content-addressed currency the live pass keys on, #534). The budget
+/// continuation mechanism: a file a prior pass truncated resumes where it stopped, because
+/// already-verdicted callees are re-resolved LAST (and skipped entirely while the budget is
+/// exhausted).
+pub(crate) fn live_covered_callees_for_path(
+    conn: &Connection,
+    tool: OracleTool,
+    tool_version: &str,
+    source_path: &str,
+    file_sha: &str,
+) -> anyhow::Result<std::collections::HashSet<i64>> {
+    let repo_clause = oracle_repo_scope_clause(conn, "edge_oracle")?;
+    let mut stmt = conn.prepare(&format!(
+        "SELECT callee_start_byte FROM edge_oracle
+         WHERE tool = ?1 AND tool_version = ?2 AND source_path = ?3 AND file_sha = ?4{repo_clause}"
+    ))?;
+    let rows = stmt
+        .query_map(params![tool.as_db_str(), tool_version, source_path, file_sha], |row| {
+            row.get::<_, i64>(0)
+        })?;
+    let mut out = std::collections::HashSet::new();
+    for row in rows {
+        out.insert(row?);
+    }
+    Ok(out)
+}
+
+/// Migrate every `edge_oracle` row of `tool` from one `tool_version` to another, returning the
+/// moved row count. The live oracle's version-transition path (#534): a respawn probing a NEW
+/// `rust-analyzer --version` would otherwise make the first partial pass's run row the latest
+/// for the whole checkout and gate every prior-version verdict out of currency — collapsing live
+/// coverage to the handful of files the new session revisited. The rows are content-addressed
+/// (`file_sha` still gates drift), so moving them under the new version preserves coverage; a
+/// row the new version already wrote (same content key) is dropped first to keep the PK.
+pub(crate) fn migrate_live_verdicts_to_version(
+    conn: &Connection,
+    tool: OracleTool,
+    from_version: &str,
+    to_version: &str,
+) -> anyhow::Result<u64> {
+    let repo_clause = oracle_repo_scope_clause(conn, "edge_oracle")?;
+    // Drop old-version rows whose content key the new version already covers (PK is
+    // (repo_id?, tool, tool_version, source_path, spans…, edge_kind)).
+    conn.execute(
+        &format!(
+            "DELETE FROM edge_oracle
+             WHERE tool = ?1 AND tool_version = ?2{repo_clause}
+               AND (source_path, source_start_byte, source_end_byte,
+                    callee_start_byte, callee_end_byte, edge_kind) IN (
+                    SELECT source_path, source_start_byte, source_end_byte,
+                           callee_start_byte, callee_end_byte, edge_kind
+                    FROM edge_oracle
+                    WHERE tool = ?1 AND tool_version = ?3{repo_clause})"
+        ),
+        params![tool.as_db_str(), from_version, to_version],
+    )?;
+    let moved = conn.execute(
+        &format!(
+            "UPDATE edge_oracle SET tool_version = ?3
+             WHERE tool = ?1 AND tool_version = ?2{repo_clause}"
+        ),
+        params![tool.as_db_str(), from_version, to_version],
+    )?;
+    Ok(moved as u64)
+}
+
 /// [`edge_join_candidates`] restricted to a set of source paths — the live oracle's per-pass
 /// worklist (#534): only the files the maintenance pass just reindexed. Same scope + ordering
 /// discipline as the whole-checkout variant. Paths are queried in bounded chunks (one `IN` list

--- a/crates/rag-rat-oracle/src/store.rs
+++ b/crates/rag-rat-oracle/src/store.rs
@@ -331,6 +331,149 @@ pub(crate) fn edge_join_candidates(
     Ok(out)
 }
 
+/// [`edge_join_candidates`] restricted to a set of source paths — the live oracle's per-pass
+/// worklist (#534): only the files the maintenance pass just reindexed. Same scope + ordering
+/// discipline as the whole-checkout variant. `paths` is caller-capped (the pass budget), so the
+/// `IN` list stays bounded.
+pub(crate) fn edge_join_candidates_for_paths(
+    conn: &Connection,
+    commit_sha: &str,
+    worktree_id: &str,
+    paths: &[String],
+) -> anyhow::Result<Vec<EdgeJoinCandidate>> {
+    if paths.is_empty() {
+        return Ok(Vec::new());
+    }
+    // Numbered params, NOT anonymous `?`: the scope predicate binds ?1/?2 (and an anonymous
+    // parameter would take slot 1, colliding with them), so the path list numbers from ?3.
+    let marks = (3..3 + paths.len()).map(|i| format!("?{i}")).collect::<Vec<_>>().join(",");
+    let sql = format!(
+        "
+        SELECT edges.id,
+               files.path,
+               files.sha256,
+               edges.source_start_byte,
+               edges.source_end_byte,
+               edges.callee_start_byte,
+               edges.callee_end_byte,
+               edges.confidence,
+               edges.edge_kind,
+               edges.to_symbol_id
+        FROM edges
+        JOIN files ON files.id = edges.source_file_id
+        WHERE edges.callee_start_byte IS NOT NULL
+          AND edges.callee_end_byte IS NOT NULL
+          AND files.path IN ({marks})
+          AND {scope}
+        ORDER BY files.path, edges.callee_start_byte
+        ",
+        scope = active_checkout_file_predicate("?1", "?2"),
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    // ?1/?2 are the checkout scope; the path list binds from ?3.
+    let mut params: Vec<&dyn rusqlite::ToSql> = vec![&commit_sha, &worktree_id];
+    for path in paths {
+        params.push(path);
+    }
+    let rows = stmt.query_map(params.as_slice(), |row| {
+        Ok(EdgeJoinCandidate {
+            edge_id: row.get(0)?,
+            source_path: row.get(1)?,
+            file_sha: row.get(2)?,
+            source_start_byte: row.get(3)?,
+            source_end_byte: row.get(4)?,
+            callee_start_byte: row.get(5)?,
+            callee_end_byte: row.get(6)?,
+            confidence: row.get(7)?,
+            edge_kind: row.get(8)?,
+            to_symbol_id: row.get(9)?,
+        })
+    })?;
+    let mut out = Vec::new();
+    for row in rows {
+        out.push(row?);
+    }
+    Ok(out)
+}
+
+/// The batch tool's persisted moniker for the logical symbol `symbol_id` belongs to — the string
+/// the LIVE writer copies verbatim into its `edge_oracle.scip_symbol` (#534). Interchangeability
+/// is literal string equality: the batch moniker is byte-identical to what the batch pass's own
+/// verdicts carry (for rust-analyzer `stabilize_moniker_version` is the identity), so
+/// clone-collapse + moniker-anchored memory relocation treat live and batch rows as one evidence
+/// set, and `current_callee_monikers`' cross-tool conflict-drop never fires on a co-covered
+/// span. `None` when the batch pass has no moniker for the symbol (never run, or the def maps
+/// outside its definitions) — the caller then falls back to a SCIP-local sentinel. Live only
+/// READS this table; only the batch pass writes it.
+pub(crate) fn batch_moniker_for_symbol(
+    conn: &Connection,
+    symbol_id: i64,
+    batch_tool: OracleTool,
+) -> anyhow::Result<Option<String>> {
+    use rusqlite::OptionalExtension as _;
+    // The qualifier is the `m` alias this query uses, so the repo clause names the alias, not the
+    // table.
+    let repo_clause = oracle_repo_scope_clause(conn, "m")?;
+    conn.query_row(
+        &format!(
+            "
+            SELECT m.moniker
+            FROM logical_symbol_monikers m
+            JOIN logical_symbol_members mem
+              ON mem.logical_symbol_id = m.logical_symbol_id
+            WHERE mem.symbol_id = ?1 AND m.tool = ?2{repo_clause}
+            LIMIT 1
+            "
+        ),
+        params![symbol_id, batch_tool.as_db_str()],
+        |row| row.get::<_, String>(0),
+    )
+    .optional()
+    .map_err(Into::into)
+}
+
+/// The persisted `(file_sha, scip_symbol)` of the `edge_oracle` row at `row`'s content key for
+/// `(tool, tool_version)`, if any. The live writer reads this before its upsert (#534): an
+/// existing row whose `scip_symbol` CHANGES while its `file_sha` stays constant means the
+/// oracle evidence a scip-mode clone refinement consulted moved under an unchanged refinement
+/// key, so the refine cache must be invalidated (mirroring the batch run's hook). A same-value
+/// upsert (or a `file_sha` change, which already re-keys everything downstream) skips it.
+pub(crate) fn existing_verdict_scip_symbol(
+    conn: &Connection,
+    tool: OracleTool,
+    tool_version: &str,
+    row: &EdgeOracleRow<'_>,
+) -> anyhow::Result<Option<(String, String)>> {
+    use rusqlite::OptionalExtension as _;
+    let repo_clause = oracle_repo_scope_clause(conn, "edge_oracle")?;
+    conn.query_row(
+        &format!(
+            "
+            SELECT file_sha, scip_symbol
+            FROM edge_oracle
+            WHERE tool = ?1 AND tool_version = ?2
+              AND source_path = ?3
+              AND source_start_byte = ?4 AND source_end_byte = ?5
+              AND callee_start_byte = ?6 AND callee_end_byte = ?7
+              AND edge_kind = ?8{repo_clause}
+            "
+        ),
+        params![
+            tool.as_db_str(),
+            tool_version,
+            row.source_path,
+            row.source_start_byte,
+            row.source_end_byte,
+            row.callee_start_byte,
+            row.callee_end_byte,
+            row.edge_kind,
+        ],
+        |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+    )
+    .optional()
+    .map_err(Into::into)
+}
+
 /// All symbols defined in a file (by path, scoped to commit/worktree), with their byte spans, so a
 /// SCIP definition range can be mapped to the enclosing symbol by overlap.
 pub(crate) fn symbol_spans_for_path(

--- a/crates/rag-rat-oracle/src/store.rs
+++ b/crates/rag-rat-oracle/src/store.rs
@@ -409,20 +409,22 @@ pub(crate) fn live_covered_edges_for_path(
     Ok(out)
 }
 
-/// Migrate every `edge_oracle` row of `tool` from one `tool_version` to another, returning the
-/// moved row count. The live oracle's version-transition path (#534): a respawn probing a NEW
-/// `rust-analyzer --version` would otherwise make the first partial pass's run row the latest
-/// for the whole checkout and gate every prior-version verdict out of currency — collapsing live
-/// coverage to the handful of files the new session revisited. The rows are content-addressed
-/// (`file_sha` still gates drift), so moving them under the new version preserves coverage; a
-/// row the new version already wrote (same content key) is dropped first to keep the PK.
+/// Copy every current-checkout `edge_oracle` row of `tool` from one `tool_version` to another,
+/// returning the inserted row count. The live oracle's version-transition path (#534): a respawn
+/// probing a NEW `rust-analyzer --version` would otherwise make the first partial pass's run row
+/// the latest for the whole checkout and gate every prior-version verdict out of currency —
+/// collapsing live coverage to the handful of files the new session revisited. The rows are
+/// content-addressed (`file_sha` still gates drift), so copying them under the new version
+/// preserves coverage; a row the new version already wrote (same content key) wins via `INSERT OR
+/// IGNORE`.
 ///
-/// SCOPE (load-bearing): restricted to rows whose LIVE EDGE belongs to the active
+/// SCOPE (load-bearing): the copied set is restricted to rows whose LIVE EDGE belongs to the active
 /// `(commit_sha, worktree_id)` checkout — the SAME content join [`clear_edge_oracle_for_tool`]
 /// uses. `edge_oracle` rows carry no commit/worktree columns (their scope is the live-edge
 /// join), so a repo-wide UPDATE would relabel a SIBLING worktree's rows too while only THIS
-/// checkout gets the new-version run row — and the sibling's currency gate, still selecting the
-/// old version, would then hide all of its own verdicts.
+/// checkout gets the new-version run row. The old row MUST remain: identical-content sibling
+/// checkouts share one `edge_oracle` row, so destructively relabeling it would hide that verdict
+/// from every sibling whose currency still selects the old version.
 pub(crate) fn migrate_live_verdicts_to_version(
     conn: &Connection,
     tool: OracleTool,
@@ -436,8 +438,7 @@ pub(crate) fn migrate_live_verdicts_to_version(
     // The active-checkout, current-CONTENT live-edge predicate: the row's `file_sha` must equal
     // the checkout's CURRENT `files.sha256`, so a sibling worktree's row (same path + spans, but
     // its own content sha) is NOT treated as this checkout's — without the sha correlation a
-    // repo-wide relabel would move the sibling's row while only this checkout records the
-    // new-version run, hiding the sibling's verdicts behind its still-old currency gate.
+    // a sibling worktree's row while only this checkout records the new-version run.
     let active_current = format!(
         "EXISTS (
              SELECT 1
@@ -454,27 +455,21 @@ pub(crate) fn migrate_live_verdicts_to_version(
                AND edges_data.hidden = 0
                AND {scope})"
     );
-    // Drop old-version rows whose content key the new version already occupies (the PK is
-    // (repo_id?, tool, tool_version, source_path, spans…, edge_kind) — file_sha is NOT in it, so
-    // the UPDATE below would otherwise hit a PK collision), restricted to rows current in THIS
-    // checkout.
-    conn.execute(
-        &format!(
-            "DELETE FROM edge_oracle
-             WHERE tool = ?1 AND tool_version = ?2{repo_clause}
-               AND (source_path, source_start_byte, source_end_byte,
-                    callee_start_byte, callee_end_byte, edge_kind) IN (
-                    SELECT source_path, source_start_byte, source_end_byte,
-                           callee_start_byte, callee_end_byte, edge_kind
-                    FROM edge_oracle
-                    WHERE tool = ?1 AND tool_version = ?3{repo_clause})
-               AND {active_current}"
-        ),
-        params![tool.as_db_str(), from_version, to_version, commit_sha, worktree_id],
-    )?;
+    let (repo_col, repo_value) =
+        if oracle_repo_scope(conn)?.is_some() { ("repo_id, ", "repo_id, ") } else { ("", "") };
+    // COPY, never relabel: two checkouts with identical bytes + spans intentionally share the old
+    // row. Keeping it lets a sibling's old-version currency continue surfacing the verdict while
+    // this checkout switches to the copied new-version row.
     let moved = conn.execute(
         &format!(
-            "UPDATE edge_oracle SET tool_version = ?3
+            "INSERT OR IGNORE INTO edge_oracle(
+                 {repo_col}source_path, source_start_byte, source_end_byte,
+                 callee_start_byte, callee_end_byte, edge_kind, file_sha, tool, tool_version,
+                 resolved_symbol_id, scip_symbol, kind, computed_at)
+             SELECT {repo_value}source_path, source_start_byte, source_end_byte,
+                    callee_start_byte, callee_end_byte, edge_kind, file_sha, tool, ?3,
+                    resolved_symbol_id, scip_symbol, kind, computed_at
+             FROM edge_oracle
              WHERE tool = ?1 AND tool_version = ?2{repo_clause}
                AND {active_current}"
         ),

--- a/crates/rag-rat-oracle/src/tests/live.rs
+++ b/crates/rag-rat-oracle/src/tests/live.rs
@@ -134,8 +134,9 @@ fn live_verdict_copies_the_batch_moniker_verbatim() {
     let mut session = fake_session(&uri, Some((def.clone(), (0, 3), (0, 9))));
     let worklist = vec!["src.rs".to_string()];
 
-    live_oracle_pass(&h.conn, &mut session, &pass_input(&h, &worklist, 100)).unwrap();
+    let report = live_oracle_pass(&h.conn, &mut session, &pass_input(&h, &worklist, 100)).unwrap();
 
+    assert!(report.refinements_invalidated, "new non-local evidence invalidates cached refinement");
     assert_eq!(
         scip_symbol_of(&h, edge),
         TARGET_MONIKER,
@@ -239,6 +240,79 @@ fn live_pass_skips_a_drifted_callsite_and_records_no_run() {
     assert_eq!(report.rows_written, 0);
     assert!(!report.run_recorded);
     assert_eq!(live_run_count(&h.conn), 0, "a pass that wrote nothing records no run row");
+    assert_eq!(report.unfinished_paths, ["src.rs"], "drifted caller is retried after reindex");
+}
+
+#[test]
+fn live_pass_revalidates_the_caller_after_lsp_requests() {
+    let h = Harness::new();
+    let (_src, _target, _edge) = seed_corpus(&h);
+    let uri = root_uri(&h);
+    let def = def_uri(&h, "defs.rs");
+    let root = h.root().to_path_buf();
+    let client = client_with_server(move |msg: &Value| {
+        let id = msg.get("id").cloned();
+        match msg.get("method").and_then(Value::as_str) {
+            Some("initialize") => Some(vec![json!({
+                "jsonrpc": "2.0", "id": id,
+                "result": {"capabilities": {"positionEncoding": "utf-16"}}
+            })]),
+            Some("textDocument/definition") => {
+                std::fs::write(root.join("src.rs"), "fn changed() { target(); }\n").unwrap();
+                Some(vec![json!({
+                    "jsonrpc": "2.0", "id": id,
+                    "result": {"uri": def,
+                               "range": {"start": {"line": 0, "character": 3},
+                                         "end": {"line": 0, "character": 9}}}
+                })])
+            },
+            _ if id.is_none() => Some(vec![]),
+            _ => Some(vec![json!({"jsonrpc": "2.0", "id": id, "result": null})]),
+        }
+    });
+    let mut session = LiveOracleSession::from_client(client, LIVE_VERSION, &uri);
+    let worklist = vec!["src.rs".to_string()];
+
+    let report = live_oracle_pass(&h.conn, &mut session, &pass_input(&h, &worklist, 100)).unwrap();
+    assert_eq!(report.rows_written, 0);
+    assert_eq!(report.skipped_drifted, 1);
+    assert_eq!(report.unfinished_paths, ["src.rs"]);
+}
+
+#[test]
+fn live_pass_requeues_a_caller_when_its_definition_drifts() {
+    let h = Harness::new();
+    let (_src, _target, _edge) = seed_corpus(&h);
+    let uri = root_uri(&h);
+    let def = def_uri(&h, "defs.rs");
+    let root = h.root().to_path_buf();
+    let client = client_with_server(move |msg: &Value| {
+        let id = msg.get("id").cloned();
+        match msg.get("method").and_then(Value::as_str) {
+            Some("initialize") => Some(vec![json!({
+                "jsonrpc": "2.0", "id": id,
+                "result": {"capabilities": {"positionEncoding": "utf-16"}}
+            })]),
+            Some("textDocument/definition") => {
+                std::fs::write(root.join("defs.rs"), "fn changed_target() {}\n").unwrap();
+                Some(vec![json!({
+                    "jsonrpc": "2.0", "id": id,
+                    "result": {"uri": def,
+                               "range": {"start": {"line": 0, "character": 3},
+                                         "end": {"line": 0, "character": 9}}}
+                })])
+            },
+            _ if id.is_none() => Some(vec![]),
+            _ => Some(vec![json!({"jsonrpc": "2.0", "id": id, "result": null})]),
+        }
+    });
+    let mut session = LiveOracleSession::from_client(client, LIVE_VERSION, &uri);
+    let worklist = vec!["src.rs".to_string()];
+
+    let report = live_oracle_pass(&h.conn, &mut session, &pass_input(&h, &worklist, 100)).unwrap();
+    assert_eq!(report.rows_written, 0);
+    assert_eq!(report.skipped_drifted, 1);
+    assert_eq!(report.unfinished_paths, ["src.rs"]);
 }
 
 #[test]
@@ -666,6 +740,53 @@ fn live_version_migration_blocks_a_different_content_destination_collision() {
         "active currency stays on its still-valid old row"
     );
     assert_eq!(scip_symbol_of(&h, edge), "local ra-lsp-active");
+}
+
+#[test]
+fn live_same_version_write_preserves_a_current_sibling_content_row() {
+    let h = Harness::new();
+    let (_src, _target, edge) = seed_corpus(&h);
+    let key = h.edge_content_key(edge);
+    let sibling_file = h.add_file_in_scope("src.rs", OTHER_COMMIT, OTHER_WORKTREE);
+    let sibling_sha = h.file_sha_for_commit("src.rs", OTHER_COMMIT);
+    h.add_edge(sibling_file, "target", 14, 20, "NameOnly", None);
+    crate::store::write_edge_oracle(
+        &h.conn,
+        OracleTool::RaLsp,
+        LIVE_VERSION,
+        &crate::store::EdgeOracleRow {
+            source_path: &key.source_path,
+            source_start_byte: key.source_start_byte,
+            source_end_byte: key.source_end_byte,
+            callee_start_byte: key.callee_start_byte,
+            callee_end_byte: key.callee_end_byte,
+            edge_kind: &key.edge_kind,
+            file_sha: &sibling_sha,
+            resolved_symbol_id: None,
+            scip_symbol: "local ra-lsp-sibling",
+            kind: OracleResolutionKind::Upgrade,
+        },
+    )
+    .unwrap();
+
+    let uri = root_uri(&h);
+    let def = def_uri(&h, "defs.rs");
+    let mut session = fake_session(&uri, Some((def, (0, 3), (0, 9))));
+    let worklist = vec!["src.rs".to_string()];
+    let report = live_oracle_pass(&h.conn, &mut session, &pass_input(&h, &worklist, 100)).unwrap();
+
+    assert_eq!(report.rows_written, 0);
+    assert_eq!(report.skipped_content_collisions, 1);
+    let (stored_sha, stored_symbol): (String, String) = h
+        .conn
+        .query_row(
+            "SELECT file_sha, scip_symbol FROM edge_oracle
+             WHERE tool = 'ra-lsp' AND tool_version = ?1",
+            [LIVE_VERSION],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!((stored_sha, stored_symbol), (sibling_sha, "local ra-lsp-sibling".into()));
 }
 
 #[test]

--- a/crates/rag-rat-oracle/src/tests/live.rs
+++ b/crates/rag-rat-oracle/src/tests/live.rs
@@ -742,6 +742,73 @@ fn live_version_migration_blocks_a_different_content_destination_collision() {
     assert_eq!(scip_symbol_of(&h, edge), "local ra-lsp-active");
 }
 
+/// A destination row for bytes no live checkout still owns is retained history, not a collision.
+/// Version migration must replace it with the active checkout's current evidence.
+#[test]
+fn live_version_migration_replaces_a_stale_destination_collision() {
+    let h = Harness::new();
+    let (_src, _target, edge) = seed_corpus(&h);
+    let key = h.edge_content_key(edge);
+    let active_sha = h.file_sha("src.rs");
+    crate::store::write_edge_oracle(
+        &h.conn,
+        OracleTool::RaLsp,
+        "old-v",
+        &crate::store::EdgeOracleRow {
+            source_path: &key.source_path,
+            source_start_byte: key.source_start_byte,
+            source_end_byte: key.source_end_byte,
+            callee_start_byte: key.callee_start_byte,
+            callee_end_byte: key.callee_end_byte,
+            edge_kind: &key.edge_kind,
+            file_sha: &active_sha,
+            resolved_symbol_id: None,
+            scip_symbol: "local ra-lsp-current",
+            kind: OracleResolutionKind::Upgrade,
+        },
+    )
+    .unwrap();
+    crate::store::write_edge_oracle(
+        &h.conn,
+        OracleTool::RaLsp,
+        "new-v",
+        &crate::store::EdgeOracleRow {
+            source_path: &key.source_path,
+            source_start_byte: key.source_start_byte,
+            source_end_byte: key.source_end_byte,
+            callee_start_byte: key.callee_start_byte,
+            callee_end_byte: key.callee_end_byte,
+            edge_kind: &key.edge_kind,
+            file_sha: "stale-unowned-sha",
+            resolved_symbol_id: None,
+            scip_symbol: "local ra-lsp-stale",
+            kind: OracleResolutionKind::Upgrade,
+        },
+    )
+    .unwrap();
+
+    let copied = crate::store::migrate_live_verdicts_to_version(
+        &h.conn,
+        OracleTool::RaLsp,
+        "old-v",
+        "new-v",
+        COMMIT,
+        WORKTREE,
+    )
+    .unwrap();
+    assert_eq!(copied, crate::store::LiveVersionMigration::Copied(1));
+    let (sha, symbol): (String, String) = h
+        .conn
+        .query_row(
+            "SELECT file_sha, scip_symbol FROM edge_oracle
+             WHERE tool = 'ra-lsp' AND tool_version = 'new-v'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!((sha, symbol), (active_sha, "local ra-lsp-current".into()));
+}
+
 #[test]
 fn live_same_version_write_preserves_a_current_sibling_content_row() {
     let h = Harness::new();

--- a/crates/rag-rat-oracle/src/tests/live.rs
+++ b/crates/rag-rat-oracle/src/tests/live.rs
@@ -334,7 +334,7 @@ fn live_pass_budget_continuation_resumes_within_a_file() {
 }
 
 /// A `rust-analyzer` upgrade between sessions must not strand prior verdicts: the first pass
-/// under the new `tool_version` migrates them (content-addressed, still `file_sha`-gated) and
+/// under the new `tool_version` copies them (content-addressed, still `file_sha`-gated) and
 /// records the run that makes the new version current — otherwise the currency gate collapses
 /// live coverage to the few files the new session revisited (#534 review).
 #[test]
@@ -378,8 +378,8 @@ fn live_pass_migrates_prior_verdicts_across_a_version_change() {
     assert!(report.version_migrated);
     assert!(report.refinements_invalidated, "the evidence changed hands");
     assert_eq!(report.status, "VersionMigrated");
-    assert_eq!(version_of(LIVE_VERSION), 0, "old-version rows moved");
-    assert_eq!(version_of("ra-test-2"), 1, "rows now carried by the new version");
+    assert_eq!(version_of(LIVE_VERSION), 1, "old-version rows remain for sibling currency");
+    assert_eq!(version_of("ra-test-2"), 1, "rows are copied under the new version");
     // The migrated verdict survives with its content + symbol intact.
     let (kind, resolved, symbol) = h.verdict(edge).expect("migrated verdict persists");
     assert_eq!(kind, "upgrade");
@@ -496,6 +496,63 @@ fn live_version_migration_leaves_a_sibling_checkouts_rows_alone() {
         .unwrap();
     assert_eq!(sibling_version, "old-v", "the sibling checkout's row keeps its version");
     let _ = edge;
+}
+
+/// Identical-content sibling checkouts SHARE the same content-keyed verdict row. A version
+/// transition must copy that row, not relabel it: the active checkout selects the new version while
+/// the sibling's still-old currency needs the old row to remain visible.
+#[test]
+fn live_version_migration_preserves_a_shared_old_version_row() {
+    let h = Harness::new();
+    let (_src, _target, edge) = seed_corpus(&h);
+    let key = h.edge_content_key(edge);
+    let active_sha = h.file_sha("src.rs");
+    crate::store::write_edge_oracle(
+        &h.conn,
+        OracleTool::RaLsp,
+        "old-v",
+        &crate::store::EdgeOracleRow {
+            source_path: &key.source_path,
+            source_start_byte: key.source_start_byte,
+            source_end_byte: key.source_end_byte,
+            callee_start_byte: key.callee_start_byte,
+            callee_end_byte: key.callee_end_byte,
+            edge_kind: &key.edge_kind,
+            file_sha: &active_sha,
+            resolved_symbol_id: None,
+            scip_symbol: "local ra-lsp-shared",
+            kind: OracleResolutionKind::Upgrade,
+        },
+    )
+    .unwrap();
+
+    // Model another checkout with the SAME path, bytes, and edge spans: both scopes join to the
+    // one old-version edge_oracle row.
+    let sibling_file = h.add_file_in_scope("src.rs", OTHER_COMMIT, OTHER_WORKTREE);
+    h.set_file_sha(sibling_file, &active_sha);
+    h.add_edge(sibling_file, "target", 14, 20, "NameOnly", None);
+
+    let copied = crate::store::migrate_live_verdicts_to_version(
+        &h.conn,
+        OracleTool::RaLsp,
+        "old-v",
+        "new-v",
+        COMMIT,
+        WORKTREE,
+    )
+    .unwrap();
+    assert_eq!(copied, 1);
+
+    let mut versions = h
+        .conn
+        .prepare("SELECT tool_version FROM edge_oracle WHERE tool = 'ra-lsp' ORDER BY tool_version")
+        .unwrap()
+        .query_map([], |row| row.get::<_, String>(0))
+        .unwrap()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+    versions.dedup();
+    assert_eq!(versions, ["new-v", "old-v"], "both checkout currencies retain coverage");
 }
 
 #[test]

--- a/crates/rag-rat-oracle/src/tests/live.rs
+++ b/crates/rag-rat-oracle/src/tests/live.rs
@@ -485,7 +485,11 @@ fn live_version_migration_leaves_a_sibling_checkouts_rows_alone() {
     )
     .unwrap();
 
-    assert_eq!(moved, 1, "only the active checkout's row moves");
+    assert_eq!(
+        moved,
+        crate::store::LiveVersionMigration::Copied(1),
+        "only the active checkout's row copies"
+    );
     let sibling_version: String = h
         .conn
         .query_row(
@@ -541,7 +545,7 @@ fn live_version_migration_preserves_a_shared_old_version_row() {
         WORKTREE,
     )
     .unwrap();
-    assert_eq!(copied, 1);
+    assert_eq!(copied, crate::store::LiveVersionMigration::Copied(1));
 
     let mut versions = h
         .conn
@@ -553,6 +557,93 @@ fn live_version_migration_preserves_a_shared_old_version_row() {
         .unwrap();
     versions.dedup();
     assert_eq!(versions, ["new-v", "old-v"], "both checkout currencies retain coverage");
+}
+
+/// The content-key PK excludes `file_sha`, so two different file versions cannot both occupy the
+/// same edge key + tool version. The transition must remain on the old currency instead of letting
+/// a sibling's destination row make active evidence disappear.
+#[test]
+fn live_version_migration_blocks_a_different_content_destination_collision() {
+    let h = Harness::new();
+    let (_src, _target, edge) = seed_corpus(&h);
+    let key = h.edge_content_key(edge);
+    let active_sha = h.file_sha("src.rs");
+    crate::store::write_edge_oracle(
+        &h.conn,
+        OracleTool::RaLsp,
+        LIVE_VERSION,
+        &crate::store::EdgeOracleRow {
+            source_path: &key.source_path,
+            source_start_byte: key.source_start_byte,
+            source_end_byte: key.source_end_byte,
+            callee_start_byte: key.callee_start_byte,
+            callee_end_byte: key.callee_end_byte,
+            edge_kind: &key.edge_kind,
+            file_sha: &active_sha,
+            resolved_symbol_id: None,
+            scip_symbol: "local ra-lsp-active",
+            kind: OracleResolutionKind::Upgrade,
+        },
+    )
+    .unwrap();
+    crate::store::record_oracle_run(
+        &h.conn,
+        OracleTool::RaLsp,
+        LIVE_VERSION,
+        COMMIT,
+        WORKTREE,
+        "Completed",
+        "{}",
+    )
+    .unwrap();
+
+    let sibling_file = h.add_file_in_scope("src.rs", OTHER_COMMIT, OTHER_WORKTREE);
+    let sibling_sha = h.file_sha_for_commit("src.rs", OTHER_COMMIT);
+    h.add_edge(sibling_file, "target", 14, 20, "NameOnly", None);
+    crate::store::write_edge_oracle(
+        &h.conn,
+        OracleTool::RaLsp,
+        "ra-test-2",
+        &crate::store::EdgeOracleRow {
+            source_path: &key.source_path,
+            source_start_byte: key.source_start_byte,
+            source_end_byte: key.source_end_byte,
+            callee_start_byte: key.callee_start_byte,
+            callee_end_byte: key.callee_end_byte,
+            edge_kind: &key.edge_kind,
+            file_sha: &sibling_sha,
+            resolved_symbol_id: None,
+            scip_symbol: "local ra-lsp-sibling",
+            kind: OracleResolutionKind::Upgrade,
+        },
+    )
+    .unwrap();
+
+    let client = client_with_server(move |msg: &Value| {
+        let id = msg.get("id").cloned();
+        match msg.get("method").and_then(Value::as_str) {
+            Some("initialize") => Some(vec![json!({
+                "jsonrpc": "2.0", "id": id,
+                "result": {"capabilities": {"positionEncoding": "utf-16"}}
+            })]),
+            _ if id.is_none() => Some(vec![]),
+            _ => Some(vec![json!({"jsonrpc": "2.0", "id": id, "result": null})]),
+        }
+    });
+    let uri = root_uri(&h);
+    let mut session = LiveOracleSession::from_client(client, "ra-test-2", &uri);
+    let report = live_oracle_pass(&h.conn, &mut session, &pass_input(&h, &[], 100)).unwrap();
+
+    assert_eq!(report.status, "VersionMigrationBlocked");
+    assert!(!report.version_migrated);
+    assert_eq!(
+        crate::store::latest_run_tool_version(&h.conn, OracleTool::RaLsp, COMMIT, WORKTREE)
+            .unwrap()
+            .as_deref(),
+        Some(LIVE_VERSION),
+        "active currency stays on its still-valid old row"
+    );
+    assert_eq!(scip_symbol_of(&h, edge), "local ra-lsp-active");
 }
 
 #[test]

--- a/crates/rag-rat-oracle/src/tests/live.rs
+++ b/crates/rag-rat-oracle/src/tests/live.rs
@@ -397,6 +397,107 @@ fn live_pass_migrates_prior_verdicts_across_a_version_change() {
     assert_eq!(latest, "ra-test-2");
 }
 
+/// Two edges sharing ONE callee token (`calls_name` + `references_type`) must not starve each
+/// other: coverage is keyed by the FULL content key, so a budget split between them resumes the
+/// deferred edge instead of treating the shared start byte as covered (#534 review).
+#[test]
+fn live_pass_continuation_keys_coverage_by_the_full_edge_identity() {
+    let h = Harness::new();
+    let defs = h.add_file("defs.rs", DEFS_SRC);
+    h.add_symbol(defs, "target", 0, 13);
+    let src = h.add_file("src.rs", CALLER_SRC);
+    // Two edge kinds on the SAME token (14..20).
+    let call = h.add_edge(src, "target", 14, 20, "NameOnly", None);
+    let refty = h.add_edge_with_kind(src, "target", 14, 20, "references_type", "NameOnly", None);
+    let uri = root_uri(&h);
+    let def = def_uri(&h, "defs.rs");
+
+    // Pass 1, budget 1: ONE of the two edges resolves; the other is deferred.
+    let mut session = fake_session(&uri, Some((def.clone(), (0, 3), (0, 9))));
+    let worklist = vec!["src.rs".to_string()];
+    let report = live_oracle_pass(&h.conn, &mut session, &pass_input(&h, &worklist, 1)).unwrap();
+    assert_eq!(report.rows_written, 1);
+    assert_eq!(report.unfinished_paths, vec!["src.rs".to_string()]);
+
+    // Pass 2: the deferred edge must NOT read as covered by the shared start byte — it resolves
+    // (one more request) and both verdicts persist.
+    let mut session = fake_session(&uri, Some((def.clone(), (0, 3), (0, 9))));
+    let report = live_oracle_pass(&h.conn, &mut session, &pass_input(&h, &worklist, 1)).unwrap();
+    assert_eq!(report.requests_used, 1);
+    assert_eq!(report.rows_written, 1);
+    assert!(report.unfinished_paths.is_empty());
+    assert!(h.verdict(call).is_some() || h.verdict(refty).is_some());
+    let both = h
+        .conn
+        .query_row("SELECT COUNT(*) FROM edge_oracle WHERE tool = 'ra-lsp'", [], |r| {
+            r.get::<_, i64>(0)
+        })
+        .unwrap();
+    assert_eq!(both, 2, "both token-sharing edges have verdicts");
+}
+
+/// The version migration is SCOPED to the active checkout (#534 review): a sibling worktree's
+/// `ra-lsp` rows must not be relabeled — only the migrating checkout's currency advances.
+#[test]
+fn live_version_migration_leaves_a_sibling_checkouts_rows_alone() {
+    let h = Harness::new();
+    let (_src, _target, edge) = seed_corpus(&h);
+    // A sibling checkout with its own file + edge + ra-lsp verdict under the OLD version.
+    let sib_file = h.add_file_in_scope("sibling.rs", OTHER_COMMIT, OTHER_WORKTREE);
+    let sib_edge = h.add_edge(sib_file, "t", 9, 10, "NameOnly", None);
+    let sib_key = h.edge_content_key(sib_edge);
+    crate::store::write_edge_oracle(
+        &h.conn,
+        OracleTool::RaLsp,
+        "old-v",
+        &crate::store::EdgeOracleRow {
+            source_path: &sib_key.source_path,
+            source_start_byte: sib_key.source_start_byte,
+            source_end_byte: sib_key.source_end_byte,
+            callee_start_byte: sib_key.callee_start_byte,
+            callee_end_byte: sib_key.callee_end_byte,
+            edge_kind: &sib_key.edge_kind,
+            file_sha: "sib-sha",
+            resolved_symbol_id: None,
+            scip_symbol: "local ra-lsp-sib",
+            kind: OracleResolutionKind::Upgrade,
+        },
+    )
+    .unwrap();
+    // The active checkout's ra-lsp verdict under the OLD version (from a prior pass).
+    let uri = root_uri(&h);
+    let def = def_uri(&h, "defs.rs");
+    let worklist = vec!["src.rs".to_string()];
+    let mut session = fake_session(&uri, Some((def.clone(), (0, 3), (0, 9))));
+    live_oracle_pass(&h.conn, &mut session, &pass_input(&h, &worklist, 100)).unwrap();
+    // Relabel the active checkout's row to the old version too (both start at old-v).
+    h.conn
+        .execute("UPDATE edge_oracle SET tool_version = 'old-v' WHERE tool = 'ra-lsp'", [])
+        .unwrap();
+
+    let moved = crate::store::migrate_live_verdicts_to_version(
+        &h.conn,
+        OracleTool::RaLsp,
+        "old-v",
+        "new-v",
+        COMMIT,
+        WORKTREE,
+    )
+    .unwrap();
+
+    assert_eq!(moved, 1, "only the active checkout's row moves");
+    let sibling_version: String = h
+        .conn
+        .query_row(
+            "SELECT tool_version FROM edge_oracle WHERE source_path = 'sibling.rs'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(sibling_version, "old-v", "the sibling checkout's row keeps its version");
+    let _ = edge;
+}
+
 #[test]
 fn live_pass_aborts_best_effort_when_the_server_dies_mid_pass() {
     let h = Harness::new();

--- a/crates/rag-rat-oracle/src/tests/live.rs
+++ b/crates/rag-rat-oracle/src/tests/live.rs
@@ -1,0 +1,318 @@
+//! End-to-end tests for the LIVE oracle pass (#534): a fake in-process LSP server (the slice-1
+//! test seam) answers `textDocument/definition`; the real `live_oracle_pass` write path maps the
+//! definitions to symbols + batch monikers and persists `ra-lsp` verdicts + a backing run row.
+//! No real rust-analyzer, no network.
+
+use serde_json::{Value, json};
+
+use super::*;
+use crate::live::{LiveOracleSession, LivePassInput, live_oracle_pass};
+use crate::lsp::client::test_support::client_with_server;
+
+const LIVE_VERSION: &str = "ra-test-1";
+
+/// The callsite file: `caller` calls `target`; the callee identifier `target` sits at byte 14.
+const CALLER_SRC: &str = "fn caller() { target(); }\n";
+const CALLER_CALLEE_START: usize = 14;
+const CALLER_CALLEE_END: usize = 20;
+/// The definition file: `target` declared at the top; its identifier span is (0,3)–(0,9).
+const DEFS_SRC: &str = "fn target() {}\n";
+
+/// A canned definition the fake server returns: `(target_uri, start (line, char), end)`.
+type FakeDefTarget = (String, (u32, u32), (u32, u32));
+
+/// A fake LSP session whose server answers every definition request with `def_target`
+/// `(uri, (start_line, start_char), (end_line, end_char))` — or `None` for an unresolved `null`.
+fn fake_session(root_uri: &str, def_target: Option<FakeDefTarget>) -> LiveOracleSession {
+    let client = client_with_server(move |msg: &Value| {
+        let id = msg.get("id").cloned();
+        match msg.get("method").and_then(Value::as_str) {
+            Some("initialize") => Some(vec![json!({
+                "jsonrpc": "2.0", "id": id,
+                "result": {"capabilities": {"positionEncoding": "utf-16"}}
+            })]),
+            Some("textDocument/definition") => {
+                let result = match &def_target {
+                    Some((uri, (sl, sc), (el, ec))) => json!({
+                        "uri": uri,
+                        "range": {"start": {"line": sl, "character": sc},
+                                  "end": {"line": el, "character": ec}}
+                    }),
+                    None => Value::Null,
+                };
+                Some(vec![json!({"jsonrpc": "2.0", "id": id, "result": result})])
+            },
+            // Notifications (initialized / didOpen / didClose) need no reply.
+            _ if id.is_none() => Some(vec![]),
+            _ => Some(vec![json!({"jsonrpc": "2.0", "id": id, "result": null})]),
+        }
+    });
+    // `from_client` runs the `initialize` handshake, exactly like a spawned session.
+    LiveOracleSession::from_client(client, LIVE_VERSION, root_uri)
+}
+
+/// Seed the standard two-file corpus: `defs.rs` with `target`, `src.rs` with a `NameOnly` call
+/// edge onto `target`. Returns `(src_file_id, target_symbol_id, edge_id)`.
+fn seed_corpus(h: &Harness) -> (i64, i64, i64) {
+    let defs = h.add_file("defs.rs", DEFS_SRC);
+    let target = h.add_symbol(defs, "target", 0, 13);
+    let src = h.add_file("src.rs", CALLER_SRC);
+    let edge = h.add_edge(src, "target", CALLER_CALLEE_START, CALLER_CALLEE_END, "NameOnly", None);
+    (src, target, edge)
+}
+
+fn pass_input<'a>(h: &'a Harness, worklist: &'a [String], max_requests: u64) -> LivePassInput<'a> {
+    LivePassInput {
+        commit_sha: COMMIT,
+        worktree_id: WORKTREE,
+        checkout_root: h.root(),
+        worklist,
+        max_requests,
+        started_at_ms: 1_000,
+    }
+}
+
+fn root_uri(h: &Harness) -> String {
+    format!("file://{}", h.root().display())
+}
+
+fn def_uri(h: &Harness, path: &str) -> String {
+    format!("{}/{path}", root_uri(h))
+}
+
+fn live_run_count(conn: &Connection) -> i64 {
+    conn.query_row("SELECT COUNT(*) FROM oracle_runs WHERE tool = 'ra-lsp'", [], |row| row.get(0))
+        .unwrap()
+}
+
+fn scip_symbol_of(h: &Harness, edge_id: i64) -> String {
+    h.verdict(edge_id).map(|(_, _, symbol)| symbol).expect("a persisted verdict")
+}
+
+#[test]
+fn live_pass_upgrades_a_name_only_edge_and_records_the_run() {
+    let h = Harness::new();
+    let (_src, target, edge) = seed_corpus(&h);
+    let uri = root_uri(&h);
+    let def = def_uri(&h, "defs.rs");
+    let mut session = fake_session(&uri, Some((def.clone(), (0, 3), (0, 9))));
+    let worklist = vec!["src.rs".to_string()];
+
+    let report = live_oracle_pass(&h.conn, &mut session, &pass_input(&h, &worklist, 100)).unwrap();
+
+    assert_eq!(report.rows_written, 1);
+    assert_eq!(report.upgraded, 1);
+    assert_eq!(report.requests_used, 1);
+    assert_eq!(report.status, "Completed");
+    assert!(report.run_recorded);
+    assert!(!report.refinements_invalidated);
+    let (kind, resolved, symbol) = h.verdict(edge).expect("verdict persisted");
+    assert_eq!(kind, "upgrade");
+    assert_eq!(resolved, Some(target));
+    assert!(
+        symbol.starts_with("local ra-lsp-"),
+        "no batch baseline ⇒ the content-stable sentinel: {symbol}"
+    );
+    assert_eq!(live_run_count(&h.conn), 1, "one backing run row for the writing pass");
+}
+
+#[test]
+fn live_verdict_copies_the_batch_moniker_verbatim() {
+    let h = Harness::new();
+    let (_src, target, edge) = seed_corpus(&h);
+    h.add_logical_symbol(1001, "defs.rs", "target", "defs.rs::target", target);
+    crate::store::write_logical_symbol_moniker(
+        &h.conn,
+        OracleTool::RustAnalyzer,
+        "batch-v",
+        1001,
+        TARGET_MONIKER,
+    )
+    .unwrap();
+    let uri = root_uri(&h);
+    let def = def_uri(&h, "defs.rs");
+    let mut session = fake_session(&uri, Some((def.clone(), (0, 3), (0, 9))));
+    let worklist = vec!["src.rs".to_string()];
+
+    live_oracle_pass(&h.conn, &mut session, &pass_input(&h, &worklist, 100)).unwrap();
+
+    assert_eq!(
+        scip_symbol_of(&h, edge),
+        TARGET_MONIKER,
+        "the live row carries the batch moniker byte-identically — clone-collapse and memory \
+         anchoring treat live and batch evidence as one set"
+    );
+}
+
+#[test]
+fn live_sentinel_is_stable_then_a_batch_moniker_arrival_invalidates_refinements() {
+    let h = Harness::new();
+    let (_src, target, edge) = seed_corpus(&h);
+    let uri = root_uri(&h);
+    let def = def_uri(&h, "defs.rs");
+    let worklist = vec!["src.rs".to_string()];
+
+    // Pass 1 (no batch baseline): the sentinel.
+    let mut session = fake_session(&uri, Some((def.clone(), (0, 3), (0, 9))));
+    let report = live_oracle_pass(&h.conn, &mut session, &pass_input(&h, &worklist, 100)).unwrap();
+    assert!(!report.refinements_invalidated, "no prior row — nothing to invalidate");
+    let sentinel = scip_symbol_of(&h, edge);
+    assert!(sentinel.starts_with("local ra-lsp-"));
+
+    // Pass 2, same content: the SAME sentinel → a same-value upsert, no refine churn.
+    let mut session = fake_session(&uri, Some((def.clone(), (0, 3), (0, 9))));
+    let report = live_oracle_pass(&h.conn, &mut session, &pass_input(&h, &worklist, 100)).unwrap();
+    assert_eq!(scip_symbol_of(&h, edge), sentinel, "sentinel is content-stable");
+    assert!(!report.refinements_invalidated, "same-value upsert skips the invalidation");
+
+    // A batch run then lands a moniker; the next live pass copies it — the scip_symbol CHANGES
+    // under an unchanged file_sha, so the scip-mode refinements that consulted the sentinel must
+    // be invalidated.
+    h.add_logical_symbol(1001, "defs.rs", "target", "defs.rs::target", target);
+    crate::store::write_logical_symbol_moniker(
+        &h.conn,
+        OracleTool::RustAnalyzer,
+        "batch-v",
+        1001,
+        TARGET_MONIKER,
+    )
+    .unwrap();
+    let mut session = fake_session(&uri, Some((def.clone(), (0, 3), (0, 9))));
+    let report = live_oracle_pass(&h.conn, &mut session, &pass_input(&h, &worklist, 100)).unwrap();
+    assert_eq!(scip_symbol_of(&h, edge), TARGET_MONIKER);
+    assert!(report.refinements_invalidated, "changed evidence under an unchanged file_sha");
+}
+
+#[test]
+fn live_pass_confirms_and_contradicts_exact_edges() {
+    let h = Harness::new();
+    let defs = h.add_file("defs.rs", DEFS_SRC);
+    let target = h.add_symbol(defs, "target", 0, 13);
+    let other = h.add_symbol(defs, "other", 0, 13);
+    // Two DISTINCT call sites (the verdict's content key spans the callee token): one the
+    // heuristic already resolved to `target` (the oracle agrees → confirm), one resolved to
+    // `other` (the oracle disagrees → contradict).
+    let src = h.add_file("src.rs", "fn caller() { target(); target(); }\n");
+    let agree = h.add_edge(src, "target", 14, 20, "Exact", Some(target));
+    let disagree = h.add_edge(src, "target", 24, 30, "Exact", Some(other));
+    let uri = root_uri(&h);
+    let def = def_uri(&h, "defs.rs");
+    let mut session = fake_session(&uri, Some((def.clone(), (0, 3), (0, 9))));
+    let worklist = vec!["src.rs".to_string()];
+
+    let report = live_oracle_pass(&h.conn, &mut session, &pass_input(&h, &worklist, 100)).unwrap();
+
+    assert_eq!(report.confirmed, 1);
+    assert_eq!(report.contradicted, 1);
+    assert_eq!(h.verdict(agree).unwrap().0, "confirm");
+    assert_eq!(h.verdict(disagree).unwrap().0, "contradict");
+    // The heuristic edge row is NEVER touched (the side-table invariant).
+    assert_eq!(h.heuristic_resolution(disagree), ("exact".to_string(), Some(other)));
+}
+
+#[test]
+fn live_pass_skips_a_drifted_callsite_and_records_no_run() {
+    let h = Harness::new();
+    let (src, _target, _edge) = seed_corpus(&h);
+    // Model a mid-pass edit: the indexed sha no longer matches the disk bytes.
+    h.set_file_sha(src, "not-the-disk-sha");
+    let uri = root_uri(&h);
+    let def = def_uri(&h, "defs.rs");
+    let mut session = fake_session(&uri, Some((def.clone(), (0, 3), (0, 9))));
+    let worklist = vec!["src.rs".to_string()];
+
+    let report = live_oracle_pass(&h.conn, &mut session, &pass_input(&h, &worklist, 100)).unwrap();
+
+    assert_eq!(report.skipped_drifted, 1);
+    assert_eq!(report.rows_written, 0);
+    assert!(!report.run_recorded);
+    assert_eq!(live_run_count(&h.conn), 0, "a pass that wrote nothing records no run row");
+}
+
+#[test]
+fn live_pass_skips_an_external_definition_without_a_row() {
+    let h = Harness::new();
+    let (_src, _target, _edge) = seed_corpus(&h);
+    let uri = root_uri(&h);
+    // The definition lands OUTSIDE the checkout root — a dependency source live can't write
+    // about (no indexed symbol, no batch-interchangeable moniker).
+    let mut session = fake_session(
+        &uri,
+        Some(("file:///cargo/registry/src/serde/lib.rs".to_string(), (0, 3), (0, 9))),
+    );
+    let worklist = vec!["src.rs".to_string()];
+
+    let report = live_oracle_pass(&h.conn, &mut session, &pass_input(&h, &worklist, 100)).unwrap();
+
+    assert_eq!(report.skipped_external, 1);
+    assert_eq!(report.rows_written, 0);
+    assert_eq!(live_run_count(&h.conn), 0);
+}
+
+#[test]
+fn live_pass_records_no_run_when_the_server_resolves_nothing() {
+    let h = Harness::new();
+    let (_src, _target, _edge) = seed_corpus(&h);
+    let uri = root_uri(&h);
+    let mut session = fake_session(&uri, None); // every definition is `null`
+    let worklist = vec!["src.rs".to_string()];
+
+    let report = live_oracle_pass(&h.conn, &mut session, &pass_input(&h, &worklist, 100)).unwrap();
+
+    assert_eq!(report.unresolved, 1);
+    assert_eq!(report.rows_written, 0);
+    assert_eq!(report.status, "NoVerdicts");
+    assert_eq!(live_run_count(&h.conn), 0);
+}
+
+#[test]
+fn live_pass_budget_defers_whole_files_to_the_next_pass() {
+    let h = Harness::new();
+    let defs = h.add_file("defs.rs", DEFS_SRC);
+    h.add_symbol(defs, "target", 0, 13);
+    let a = h.add_file("a.rs", CALLER_SRC);
+    let b = h.add_file("b.rs", CALLER_SRC);
+    h.add_edge(a, "target", 14, 20, "NameOnly", None);
+    h.add_edge(b, "target", 14, 20, "NameOnly", None);
+    let uri = root_uri(&h);
+    let def = def_uri(&h, "defs.rs");
+    let mut session = fake_session(&uri, Some((def.clone(), (0, 3), (0, 9))));
+    // One request of budget: the first file resolves, the second rides.
+    let worklist = vec!["a.rs".to_string(), "b.rs".to_string()];
+
+    let report = live_oracle_pass(&h.conn, &mut session, &pass_input(&h, &worklist, 1)).unwrap();
+
+    assert_eq!(report.files_resolved, 1);
+    assert_eq!(report.rows_written, 1);
+    assert_eq!(report.unfinished_paths, vec!["b.rs".to_string()]);
+    assert_eq!(report.status, "BudgetExhausted");
+}
+
+#[test]
+fn live_pass_aborts_best_effort_when_the_server_dies_mid_pass() {
+    let h = Harness::new();
+    let (_src, _target, _edge) = seed_corpus(&h);
+    let uri = root_uri(&h);
+    // The server answers initialize, then CLOSES on the first definition request (a crash).
+    let client = client_with_server(move |msg: &Value| {
+        let id = msg.get("id").cloned();
+        match msg.get("method").and_then(Value::as_str) {
+            Some("initialize") => Some(vec![json!({
+                "jsonrpc": "2.0", "id": id,
+                "result": {"capabilities": {"positionEncoding": "utf-16"}}
+            })]),
+            Some("textDocument/definition") => None,
+            _ if id.is_none() => Some(vec![]),
+            _ => Some(vec![json!({"jsonrpc": "2.0", "id": id, "result": null})]),
+        }
+    });
+    let mut session = LiveOracleSession::from_client(client, LIVE_VERSION, &uri);
+    let worklist = vec!["src.rs".to_string()];
+
+    // Never an `Err` — the maintenance pass must survive a dead server (#535 hardens further).
+    let report = live_oracle_pass(&h.conn, &mut session, &pass_input(&h, &worklist, 100)).unwrap();
+
+    assert!(report.status.starts_with("Aborted:"), "{}", report.status);
+    assert_eq!(report.rows_written, 0);
+    assert_eq!(live_run_count(&h.conn), 0);
+}

--- a/crates/rag-rat-oracle/src/tests/live.rs
+++ b/crates/rag-rat-oracle/src/tests/live.rs
@@ -242,6 +242,28 @@ fn live_pass_skips_a_drifted_callsite_and_records_no_run() {
 }
 
 #[test]
+fn live_pass_propagates_definition_metadata_query_failures() {
+    // SQLite's dynamic typing models a malformed symbol metadata row. The cache fill must return
+    // the DB error, not reinterpret it as "no symbols" and record a deceptively successful run.
+    let h = Harness::new();
+    let (_src, _target, _edge) = seed_corpus(&h);
+    h.conn
+        .execute(
+            "UPDATE symbols SET start_byte = 'bad' WHERE file_id =
+                 (SELECT id FROM files WHERE path = 'defs.rs')",
+            [],
+        )
+        .unwrap();
+    let uri = root_uri(&h);
+    let def = def_uri(&h, "defs.rs");
+    let mut session = fake_session(&uri, Some((def, (0, 3), (0, 9))));
+    let worklist = vec!["src.rs".to_string()];
+
+    assert!(live_oracle_pass(&h.conn, &mut session, &pass_input(&h, &worklist, 100)).is_err());
+    assert_eq!(live_run_count(&h.conn), 0);
+}
+
+#[test]
 fn live_pass_skips_an_external_definition_without_a_row() {
     let h = Harness::new();
     let (_src, _target, _edge) = seed_corpus(&h);

--- a/crates/rag-rat-oracle/src/tests/live.rs
+++ b/crates/rag-rat-oracle/src/tests/live.rs
@@ -308,11 +308,13 @@ fn live_pass_aborts_best_effort_when_the_server_dies_mid_pass() {
     });
     let mut session = LiveOracleSession::from_client(client, LIVE_VERSION, &uri);
     let worklist = vec!["src.rs".to_string()];
-
     // Never an `Err` — the maintenance pass must survive a dead server (#535 hardens further).
     let report = live_oracle_pass(&h.conn, &mut session, &pass_input(&h, &worklist, 100)).unwrap();
 
     assert!(report.status.starts_with("Aborted:"), "{}", report.status);
     assert_eq!(report.rows_written, 0);
+    // The failed file is REQUEUED (not dropped): the watcher rides it into the next pass with a
+    // freshly spawned session.
+    assert_eq!(report.unfinished_paths, vec!["src.rs".to_string()]);
     assert_eq!(live_run_count(&h.conn), 0);
 }

--- a/crates/rag-rat-oracle/src/tests/live.rs
+++ b/crates/rag-rat-oracle/src/tests/live.rs
@@ -145,9 +145,9 @@ fn live_verdict_copies_the_batch_moniker_verbatim() {
 }
 
 #[test]
-fn live_sentinel_is_stable_then_a_batch_moniker_arrival_invalidates_refinements() {
+fn live_sentinel_is_stable_then_a_content_change_upgrades_to_the_batch_moniker() {
     let h = Harness::new();
-    let (_src, target, edge) = seed_corpus(&h);
+    let (src_file, target, edge) = seed_corpus(&h);
     let uri = root_uri(&h);
     let def = def_uri(&h, "defs.rs");
     let worklist = vec!["src.rs".to_string()];
@@ -159,15 +159,17 @@ fn live_sentinel_is_stable_then_a_batch_moniker_arrival_invalidates_refinements(
     let sentinel = scip_symbol_of(&h, edge);
     assert!(sentinel.starts_with("local ra-lsp-"));
 
-    // Pass 2, same content: the SAME sentinel → a same-value upsert, no refine churn.
+    // Pass 2, same content: the callee is COVERED (same tool_version + file_sha) and the
+    // covered-skip never re-resolves it — zero requests, the row untouched.
     let mut session = fake_session(&uri, Some((def.clone(), (0, 3), (0, 9))));
     let report = live_oracle_pass(&h.conn, &mut session, &pass_input(&h, &worklist, 100)).unwrap();
-    assert_eq!(scip_symbol_of(&h, edge), sentinel, "sentinel is content-stable");
-    assert!(!report.refinements_invalidated, "same-value upsert skips the invalidation");
+    assert_eq!(report.requests_used, 0, "a fully-covered file costs no requests");
+    assert_eq!(report.rows_written, 0);
+    assert_eq!(scip_symbol_of(&h, edge), sentinel, "sentinel is stable by construction");
+    assert!(!report.refinements_invalidated);
 
-    // A batch run then lands a moniker; the next live pass copies it — the scip_symbol CHANGES
-    // under an unchanged file_sha, so the scip-mode refinements that consulted the sentinel must
-    // be invalidated.
+    // A batch run then lands a moniker. Same content → the covered-skip still declines to
+    // re-resolve (the batch row carries the real evidence for the span meanwhile).
     h.add_logical_symbol(1001, "defs.rs", "target", "defs.rs::target", target);
     crate::store::write_logical_symbol_moniker(
         &h.conn,
@@ -178,9 +180,19 @@ fn live_sentinel_is_stable_then_a_batch_moniker_arrival_invalidates_refinements(
     )
     .unwrap();
     let mut session = fake_session(&uri, Some((def.clone(), (0, 3), (0, 9))));
+    live_oracle_pass(&h.conn, &mut session, &pass_input(&h, &worklist, 100)).unwrap();
+    assert_eq!(scip_symbol_of(&h, edge), sentinel, "unchanged content stays covered");
+
+    // A content change un-covers the callee (new file_sha), so the pass re-resolves it — now
+    // copying the batch moniker. No refine invalidation: the content change already re-keys
+    // every refinement that consulted the file.
+    let edited = "fn callXr() { target(); }\n";
+    std::fs::write(h.root().join("src.rs"), edited).unwrap();
+    h.set_file_sha(src_file, &sha256_hex(edited.as_bytes()));
+    let mut session = fake_session(&uri, Some((def.clone(), (0, 3), (0, 9))));
     let report = live_oracle_pass(&h.conn, &mut session, &pass_input(&h, &worklist, 100)).unwrap();
-    assert_eq!(scip_symbol_of(&h, edge), TARGET_MONIKER);
-    assert!(report.refinements_invalidated, "changed evidence under an unchanged file_sha");
+    assert_eq!(scip_symbol_of(&h, edge), TARGET_MONIKER, "content change re-resolves");
+    assert!(!report.refinements_invalidated, "the sha changed — refinements re-key anyway");
 }
 
 #[test]
@@ -286,6 +298,103 @@ fn live_pass_budget_defers_whole_files_to_the_next_pass() {
     assert_eq!(report.rows_written, 1);
     assert_eq!(report.unfinished_paths, vec!["b.rs".to_string()]);
     assert_eq!(report.status, "BudgetExhausted");
+}
+
+/// The budget binds WITHIN a file too: a file with more callees than the budget is truncated,
+/// rides the backlog, and the NEXT pass resumes at the unverdicted callees (the covered-skip
+/// continuation) instead of re-requesting from the top (#534 review).
+#[test]
+fn live_pass_budget_continuation_resumes_within_a_file() {
+    let h = Harness::new();
+    let defs = h.add_file("defs.rs", DEFS_SRC);
+    h.add_symbol(defs, "target", 0, 13);
+    // Three calls in one file: callees at 14, 24, 34.
+    let src = h.add_file("src.rs", "fn caller() { target(); target(); target(); }\n");
+    h.add_edge(src, "target", 14, 20, "NameOnly", None);
+    h.add_edge(src, "target", 24, 30, "NameOnly", None);
+    h.add_edge(src, "target", 34, 40, "NameOnly", None);
+    let uri = root_uri(&h);
+    let def = def_uri(&h, "defs.rs");
+
+    // Pass 1, budget 2: two callees resolve, the file rides with one deferred.
+    let mut session = fake_session(&uri, Some((def.clone(), (0, 3), (0, 9))));
+    let worklist = vec!["src.rs".to_string()];
+    let report = live_oracle_pass(&h.conn, &mut session, &pass_input(&h, &worklist, 2)).unwrap();
+    assert_eq!(report.rows_written, 2);
+    assert_eq!(report.unfinished_paths, vec!["src.rs".to_string()]);
+
+    // Pass 2 (same session + version): the two covered callees are skipped, so the whole
+    // remaining budget goes to the ONE unverdicted callee — exactly one request.
+    let mut session = fake_session(&uri, Some((def.clone(), (0, 3), (0, 9))));
+    let report = live_oracle_pass(&h.conn, &mut session, &pass_input(&h, &worklist, 2)).unwrap();
+    assert_eq!(report.requests_used, 1, "covered callees don't spend the budget");
+    assert_eq!(report.rows_written, 1);
+    assert!(report.unfinished_paths.is_empty(), "the file drains this pass");
+    assert_eq!(report.status, "Completed");
+}
+
+/// A `rust-analyzer` upgrade between sessions must not strand prior verdicts: the first pass
+/// under the new `tool_version` migrates them (content-addressed, still `file_sha`-gated) and
+/// records the run that makes the new version current — otherwise the currency gate collapses
+/// live coverage to the few files the new session revisited (#534 review).
+#[test]
+fn live_pass_migrates_prior_verdicts_across_a_version_change() {
+    let h = Harness::new();
+    let (_src, _target, edge) = seed_corpus(&h);
+    let uri = root_uri(&h);
+    let def = def_uri(&h, "defs.rs");
+    let worklist = vec!["src.rs".to_string()];
+
+    // Pass 1 under version LIVE_VERSION.
+    let mut session = fake_session(&uri, Some((def.clone(), (0, 3), (0, 9))));
+    live_oracle_pass(&h.conn, &mut session, &pass_input(&h, &worklist, 100)).unwrap();
+    let sentinel = scip_symbol_of(&h, edge);
+    let version_of = |v: &str| {
+        h.conn
+            .query_row(
+                "SELECT COUNT(*) FROM edge_oracle WHERE tool = 'ra-lsp' AND tool_version = ?1",
+                params![v],
+                |row| row.get::<_, i64>(0),
+            )
+            .unwrap()
+    };
+    assert_eq!(version_of(LIVE_VERSION), 1);
+
+    // A NEW session probing a NEW rust-analyzer version; an EMPTY worklist (a quiet pass).
+    let client = client_with_server(move |msg: &Value| {
+        let id = msg.get("id").cloned();
+        match msg.get("method").and_then(Value::as_str) {
+            Some("initialize") => Some(vec![json!({
+                "jsonrpc": "2.0", "id": id,
+                "result": {"capabilities": {"positionEncoding": "utf-16"}}
+            })]),
+            _ if id.is_none() => Some(vec![]),
+            _ => Some(vec![json!({"jsonrpc": "2.0", "id": id, "result": null})]),
+        }
+    });
+    let mut session = LiveOracleSession::from_client(client, "ra-test-2", &uri);
+    let report = live_oracle_pass(&h.conn, &mut session, &pass_input(&h, &[], 100)).unwrap();
+
+    assert!(report.version_migrated);
+    assert!(report.refinements_invalidated, "the evidence changed hands");
+    assert_eq!(report.status, "VersionMigrated");
+    assert_eq!(version_of(LIVE_VERSION), 0, "old-version rows moved");
+    assert_eq!(version_of("ra-test-2"), 1, "rows now carried by the new version");
+    // The migrated verdict survives with its content + symbol intact.
+    let (kind, resolved, symbol) = h.verdict(edge).expect("migrated verdict persists");
+    assert_eq!(kind, "upgrade");
+    assert!(resolved.is_some());
+    assert_eq!(symbol, sentinel);
+    // And the new run row makes the new version the currency gate's latest.
+    let latest: String = h
+        .conn
+        .query_row(
+            "SELECT tool_version FROM oracle_runs WHERE tool = 'ra-lsp' ORDER BY id DESC LIMIT 1",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(latest, "ra-test-2");
 }
 
 #[test]

--- a/crates/rag-rat-oracle/src/tests/mod.rs
+++ b/crates/rag-rat-oracle/src/tests/mod.rs
@@ -15,6 +15,7 @@ use crate::test_support::*;
 mod edge_view;
 mod join_tests;
 mod library_usage;
+mod live;
 mod monikers;
 mod persisted_enums;
 mod pre_spawn;

--- a/crates/rag-rat-oracle/src/tests/persisted_enums.rs
+++ b/crates/rag-rat-oracle/src/tests/persisted_enums.rs
@@ -14,6 +14,7 @@ fn persisted_enums_round_trip_through_db_strings() {
         (OracleTool::ScipPython, "scip-python"),
         (OracleTool::ScipTypescript, "scip-typescript"),
         (OracleTool::ScipJava, "scip-java"),
+        (OracleTool::RaLsp, "ra-lsp"),
     ] {
         assert_eq!(tool.as_db_str(), token);
         assert_eq!(OracleTool::from_db_str(tool.as_db_str()), Some(tool));

--- a/crates/rag-rat-oracle/src/tests/store_io.rs
+++ b/crates/rag-rat-oracle/src/tests/store_io.rs
@@ -599,6 +599,8 @@ fn live_covered_edges_excludes_a_stale_definition_verdict() {
         kind: OracleResolutionKind::Upgrade,
     })
     .unwrap();
+    store::record_oracle_run(&h.conn, OracleTool::RaLsp, "v", COMMIT, WORKTREE, "Completed", "{}")
+        .unwrap();
     let covered = store::live_covered_edges_for_path(
         &h.conn,
         OracleTool::RaLsp,
@@ -610,4 +612,56 @@ fn live_covered_edges_excludes_a_stale_definition_verdict() {
     )
     .unwrap();
     assert_eq!(covered.len(), 1, "the live-definition verdict is coverage; the stale one is not");
+}
+
+/// Content-keyed verdict rows can be shared by identical checkout content, but continuation
+/// currency cannot: a sibling checkout's run must not make a fresh checkout skip LSP requests.
+#[test]
+fn live_covered_edges_requires_this_checkouts_current_run() {
+    let h = Harness::new();
+    let src = h.add_file("src.rs", "fn caller() { target(); }\n");
+    let edge = h.add_edge(src, "target", 14, 20, "NameOnly", None);
+    let key = h.edge_content_key(edge);
+    let sha = h.file_sha("src.rs");
+    store::write_edge_oracle(&h.conn, OracleTool::RaLsp, "v", &EdgeOracleRow {
+        source_path: &key.source_path,
+        source_start_byte: key.source_start_byte,
+        source_end_byte: key.source_end_byte,
+        callee_start_byte: key.callee_start_byte,
+        callee_end_byte: key.callee_end_byte,
+        edge_kind: &key.edge_kind,
+        file_sha: &sha,
+        resolved_symbol_id: None,
+        scip_symbol: "local ra-lsp-shared",
+        kind: OracleResolutionKind::Upgrade,
+    })
+    .unwrap();
+    store::record_oracle_run(
+        &h.conn,
+        OracleTool::RaLsp,
+        "v",
+        OTHER_COMMIT,
+        OTHER_WORKTREE,
+        "Completed",
+        "{}",
+    )
+    .unwrap();
+
+    let covered = || {
+        store::live_covered_edges_for_path(
+            &h.conn,
+            OracleTool::RaLsp,
+            "v",
+            "src.rs",
+            &sha,
+            COMMIT,
+            WORKTREE,
+        )
+        .unwrap()
+    };
+    assert!(covered().is_empty(), "a sibling's run does not establish this checkout's currency");
+
+    store::record_oracle_run(&h.conn, OracleTool::RaLsp, "v", COMMIT, WORKTREE, "Completed", "{}")
+        .unwrap();
+    assert_eq!(covered().len(), 1, "this checkout's matching run activates shared coverage");
 }

--- a/crates/rag-rat-oracle/src/tests/store_io.rs
+++ b/crates/rag-rat-oracle/src/tests/store_io.rs
@@ -542,3 +542,72 @@ fn edge_join_candidates_for_paths_scopes_and_chunks() {
         store::edge_join_candidates_for_paths(&h.conn, COMMIT, WORKTREE, &[]).unwrap().is_empty()
     );
 }
+
+/// `live_covered_edges_for_path` (the budget-continuation coverage read, #534) must NOT count a
+/// verdict whose resolved DEFINITION no longer exists in the active checkout — the surfacing
+/// read rejects such a row, so continuation would otherwise skip re-resolving the edge forever
+/// behind evidence the read path never shows.
+#[test]
+fn live_covered_edges_excludes_a_stale_definition_verdict() {
+    let h = Harness::new();
+    let src = h.add_file("src.rs", "fn caller() { target(); }\n");
+    let sha = h.file_sha("src.rs");
+    // A live verdict resolving to a symbol that does NOT exist (id 9999) — a def that was
+    // deleted/reindexed away.
+    let stale = h.add_edge(src, "target", 14, 20, "NameOnly", None);
+    let key = h.edge_content_key(stale);
+    store::write_edge_oracle(&h.conn, OracleTool::RaLsp, "v", &EdgeOracleRow {
+        source_path: &key.source_path,
+        source_start_byte: key.source_start_byte,
+        source_end_byte: key.source_end_byte,
+        callee_start_byte: key.callee_start_byte,
+        callee_end_byte: key.callee_end_byte,
+        edge_kind: &key.edge_kind,
+        file_sha: &sha,
+        resolved_symbol_id: Some(9999),
+        scip_symbol: "local ra-lsp-stale",
+        kind: OracleResolutionKind::Upgrade,
+    })
+    .unwrap();
+
+    let covered = store::live_covered_edges_for_path(
+        &h.conn,
+        OracleTool::RaLsp,
+        "v",
+        "src.rs",
+        &sha,
+        COMMIT,
+        WORKTREE,
+    )
+    .unwrap();
+    assert!(covered.is_empty(), "a verdict with a vanished definition is not coverage");
+
+    // A verdict with NULL resolved_symbol_id (external-ish) or a live definition IS coverage.
+    let real_target = h.add_symbol(src, "target", 0, 25);
+    let live = h.add_edge_with_kind(src, "target", 14, 20, "references_type", "NameOnly", None);
+    let live_key = h.edge_content_key(live);
+    store::write_edge_oracle(&h.conn, OracleTool::RaLsp, "v", &EdgeOracleRow {
+        source_path: &live_key.source_path,
+        source_start_byte: live_key.source_start_byte,
+        source_end_byte: live_key.source_end_byte,
+        callee_start_byte: live_key.callee_start_byte,
+        callee_end_byte: live_key.callee_end_byte,
+        edge_kind: &live_key.edge_kind,
+        file_sha: &sha,
+        resolved_symbol_id: Some(real_target),
+        scip_symbol: "local ra-lsp-live",
+        kind: OracleResolutionKind::Upgrade,
+    })
+    .unwrap();
+    let covered = store::live_covered_edges_for_path(
+        &h.conn,
+        OracleTool::RaLsp,
+        "v",
+        "src.rs",
+        &sha,
+        COMMIT,
+        WORKTREE,
+    )
+    .unwrap();
+    assert_eq!(covered.len(), 1, "the live-definition verdict is coverage; the stale one is not");
+}

--- a/crates/rag-rat-oracle/src/tests/store_io.rs
+++ b/crates/rag-rat-oracle/src/tests/store_io.rs
@@ -502,3 +502,43 @@ fn current_callee_monikers_drops_verdicts_without_a_live_edge() {
         "a verdict with no live edge is dropped; the live-edge-backed one is returned"
     );
 }
+
+/// `edge_join_candidates_for_paths` (the live oracle's worklist read, #534) scopes candidates to
+/// the named paths AND survives a worklist larger than one `IN`-list chunk — an accumulated
+/// watcher backlog must never fail the prepare with a bound-variable overflow and wedge the
+/// backlog.
+#[test]
+fn edge_join_candidates_for_paths_scopes_and_chunks() {
+    let h = Harness::new();
+    let a = h.add_file("a.rs", "fn a() { t(); }\n");
+    let edge_a = h.add_edge(a, "t", 9, 10, "NameOnly", None);
+    let b = h.add_file("b.rs", "fn b() { t(); }\n");
+    h.add_edge(b, "t", 9, 10, "NameOnly", None);
+    // c.rs exists but is NOT in the worklist.
+    let c = h.add_file("c.rs", "fn c() { t(); }\n");
+    h.add_edge(c, "t", 9, 10, "NameOnly", None);
+
+    // Scoped: only the named paths come back.
+    let candidates = store::edge_join_candidates_for_paths(&h.conn, COMMIT, WORKTREE, &[
+        "a.rs".to_string(),
+        "b.rs".to_string(),
+    ])
+    .unwrap();
+    assert_eq!(candidates.len(), 2);
+    assert_eq!(candidates[0].edge_id, edge_a);
+    assert!(candidates.iter().all(|c| c.source_path != "c.rs"));
+
+    // Chunked: > 500 paths (499 fillers + the real one) crosses one chunk boundary and still
+    // resolves — the query is issued in bounded `IN` lists.
+    let mut big: Vec<String> = (0..600).map(|i| format!("src/filler-{i}.rs")).collect();
+    big.push("a.rs".to_string());
+    let candidates =
+        store::edge_join_candidates_for_paths(&h.conn, COMMIT, WORKTREE, &big).unwrap();
+    assert_eq!(candidates.len(), 1);
+    assert_eq!(candidates[0].edge_id, edge_a);
+
+    // Empty worklist → no query, no candidates.
+    assert!(
+        store::edge_join_candidates_for_paths(&h.conn, COMMIT, WORKTREE, &[]).unwrap().is_empty()
+    );
+}

--- a/crates/rag-rat-oracle/src/tests/tool_defaults.rs
+++ b/crates/rag-rat-oracle/src/tests/tool_defaults.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use super::*;
 
 /// `scip::stabilize_moniker_version` pins a scip-typescript local moniker's version to `_` so a
@@ -40,4 +42,33 @@ fn default_position_encoding_is_utf16_for_typescript_and_java() {
     assert_eq!(OracleTool::RustAnalyzer.default_position_encoding(), UNSPEC);
     assert_eq!(OracleTool::ScipClang.default_position_encoding(), UNSPEC);
     assert_eq!(OracleTool::ScipPython.default_position_encoding(), UNSPEC);
+    assert_eq!(OracleTool::RaLsp.default_position_encoding(), UNSPEC);
+}
+
+/// #534: the live `ra-lsp` tool is NEVER batch-capable — every batch driver (the auto-run loop,
+/// the init wizard, `produce_scip_with_tool`) must gate it out via the discriminator, and
+/// `batch_moniker_source` names the batch tool whose monikers the live writer copies.
+#[test]
+fn ra_lsp_is_gated_out_of_the_batch_paths() {
+    for &tool in OracleTool::ALL {
+        assert_eq!(tool.batch_capable(), tool != OracleTool::RaLsp, "{tool:?}");
+    }
+    assert_eq!(OracleTool::RaLsp.batch_moniker_source(), Some(OracleTool::RustAnalyzer));
+    for tool in OracleTool::ALL.iter().filter(|t| t.batch_capable()) {
+        assert_eq!(tool.batch_moniker_source(), None, "{tool:?}");
+    }
+
+    // `produce_scip_with_tool` on the live tool returns the documented Blocked hint and never
+    // builds a `scip_command` (which would be an unreachable! panic).
+    let outcome =
+        produce_scip_with_tool(OracleTool::RaLsp, Path::new("/tmp"), Path::new("/tmp/x.scip"))
+            .unwrap();
+    match outcome {
+        ScipProduction::Blocked { tool, program, hint } => {
+            assert_eq!(tool, "ra-lsp");
+            assert_eq!(program, "rust-analyzer");
+            assert!(hint.contains("[oracle.live]"), "{hint}");
+        },
+        ScipProduction::Produced { .. } => panic!("a live tool must never produce a .scip"),
+    }
 }

--- a/docs/config/oracle.md
+++ b/docs/config/oracle.md
@@ -37,7 +37,7 @@ the batch verdict wins.
 [oracle.live]
 enabled = false               # off by default — opt in explicitly
 idle_shutdown_secs = 900      # shut the language server down after 15 min idle
-max_requests_per_pass = 200   # cap on LSP requests per maintenance pass; the rest rides the next pass
+max_requests_per_pass = 200   # positive cap per maintenance pass; zero is rejected
 ```
 
 **Standalone:** `[oracle.live]` does NOT imply or require `[oracle] auto_run`. Without a batch
@@ -47,4 +47,5 @@ moniker-anchored memory relocation get nothing until a batch `oracle run` comple
 status` says so when that's the case). Each completed batch run auto-upgrades subsequent live
 passes to the real monikers. Live runs only from the resident watcher (never one-shot hook/CLI
 maintenance passes, which would pay a language-server warm-up per invocation), and needs
-`rust-analyzer` on `PATH`; a missing tool degrades quietly like a missing embedding model.
+`rust-analyzer` on `PATH`; probe and launch run from the checkout root so rustup directory overrides
+apply. A missing tool degrades quietly like a missing embedding model.

--- a/docs/config/oracle.md
+++ b/docs/config/oracle.md
@@ -23,3 +23,28 @@ the brief join/write serializes), and is **fail-open** — any error, or a missi
 silent no-op, and the thread dies with the server process. While auto-fresh is on, `important-symbols`
 reports `heuristic ranking — compiler ranking refreshes in the background` instead of nudging you to
 run the oracle by hand.
+
+## Live LSP oracle (`[oracle.live]`)
+
+The **live** oracle is the per-pass freshness path (#534): the resident watcher's maintenance pass
+resolves the callees of **just-changed Rust files** through a resident `rust-analyzer` language
+server and writes the same `edge_oracle` verdicts the batch pass writes, under a distinct `ra-lsp`
+tool id. The batch pass (`auto_run` / `oracle run`) stays the canonical whole-checkout writer —
+live rows are a freshness patch for files being edited, and where both tools cover the same edge
+the batch verdict wins.
+
+```toml
+[oracle.live]
+enabled = false               # off by default — opt in explicitly
+idle_shutdown_secs = 900      # shut the language server down after 15 min idle
+max_requests_per_pass = 200   # cap on LSP requests per maintenance pass; the rest rides the next pass
+```
+
+**Standalone:** `[oracle.live]` does NOT imply or require `[oracle] auto_run`. Without a batch
+baseline the live pass is *moniker-blind* — it upgrades edge confidence tiers under `local
+ra-lsp-<n>` sentinel monikers, but clone-collapse (`find_clones` scip refine mode) and
+moniker-anchored memory relocation get nothing until a batch `oracle run` completes (`oracle
+status` says so when that's the case). Each completed batch run auto-upgrades subsequent live
+passes to the real monikers. Live runs only from the resident watcher (never one-shot hook/CLI
+maintenance passes, which would pay a language-server warm-up per invocation), and needs
+`rust-analyzer` on `PATH`; a missing tool degrades quietly like a missing embedding model.

--- a/docs/oracle.md
+++ b/docs/oracle.md
@@ -81,6 +81,18 @@ It needs a SCIP tool (e.g. `rust-analyzer`) on `PATH`, runs only inside the MCP 
 the `.scip` outside the index write lock so the file watcher is never starved. See
 [`config.md`](config.md) for all knobs.
 
+### Live freshness (`[oracle.live]`)
+
+The batch pass covers the whole checkout on a slow cadence; the **live** oracle (#534) patches the
+gap for files being edited right now. With `[oracle.live] enabled`, the watcher's maintenance pass
+resolves the callees of just-changed Rust files through a resident `rust-analyzer` language server
+and writes the same verdict shape under the `ra-lsp` tool id — so a dirty file's edges reach the
+`Compiler` tier within a pass instead of the next batch run. Batch stays canonical: where both
+tools cover an edge, the batch verdict wins. `[oracle.live]` stands alone (it does not imply
+`auto_run`), but it is *moniker-blind* without a batch baseline — run `oracle run` occasionally so
+clone-collapse and moniker-anchored memories see the live edges too. See
+[`config/oracle.md`](config/oracle.md).
+
 ## Resolution-quality CI (the corpus runner)
 
 `tools/oracle-corpora.toml` declares real-repo corpora (a small per-PR tier + a heavy


### PR DESCRIPTION
## Summary

Slice 2 of #74 (phase 6 of the #61 SCIP oracle epic). The resident LSP client substrate (slice 1, #531) is now wired to the watcher: each maintenance pass resolves the callees of just-changed Rust files through a resident `rust-analyzer` language server and writes the same `edge_oracle` verdict shape the batch pass writes, under the distinct `ra-lsp` tool id. The batch pass stays the canonical whole-checkout writer; live rows are a per-pass freshness patch for files being edited.

## Design (settled on #74)

- **Tool identity.** `OracleTool::RaLsp` (`"ra-lsp"`) + a `batch_capable()` discriminator gates the live tool out of every batch driver — the auto-run loop, the init-wizard listing, and `produce_scip_with_tool` (→ `Blocked` hint, never a `scip_command`). Reusing the batch `rust-analyzer` id was rejected: live run rows would make `auto_run_decision` see the index as always-fresh, silently stopping the batch pass. `tool_version` is the probed `rust-analyzer --version`, re-probed per session.
- **Moniker source.** A live verdict's `scip_symbol` is the resolved target's **batch** moniker from `logical_symbol_monikers` — byte-identical to what batch writes, so clone-collapse (#275) and moniker-anchored memory relocation treat live and batch rows as one evidence set. Fallback is a content-stable `local ra-lsp-<hash>` sentinel (a same-value upsert across reindexes, skipped by `is_local_symbol` before the conflict logic). LSP `textDocument/moniker` output is **never** persisted; live only READS the moniker table.
- **Write path.** Definition location → byte span (target file content, negotiated encoding) → `join::map_definition_to_symbol` containment → symbol. Verdict upserts + the backing `oracle_runs` row commit in **one transaction** (the currency gate never sees rows without a run); a run row is recorded only when a pass wrote ≥1 row; **no authoritative clear**. Callsite and definition-document drift gates mirror the batch join's index-vs-disk discipline.
- **Verdict merge precedence.** A clean Rust edge can now carry both tools' current verdicts, so all three multi-tool merge sites apply deterministic **batch-wins-on-overlap**: `enrich_hops_with_oracle` and `symbol_importance_oracle_effects` (batch-first + first-writer-wins per edge id) and `compare_graph_to_scip` (one contradiction row per edge, batch's evidence).
- **Refine-cache interplay.** A live write that changes an existing row's `scip_symbol` for an unchanged `file_sha` calls `invalidate_scip_refinements` (same reasoning as the batch hook); same-value upserts skip it.
- **Config.** `[oracle.live] enabled` (default off) is **standalone** — it does not imply or require `[oracle] auto_run`. Without a batch baseline live is moniker-blind (upgrades tiers only); `oracle status` surfaces exactly that. `idle_shutdown_secs` bounds the resident server's memory; `max_requests_per_pass` budgets the pass, with whole-file deferral riding a watcher-held backlog into the next pass.
- **Watcher.** `LiveOracleTail` (session + backlog) is owned by the resident watcher's pass-worker closure; hook/CLI maintenance passes pass no state, so a one-shot pass never spawns a language server. The stage runs before the tail decision so the idle-shutdown sweep fires on quiet passes. Everything is best-effort: a missing/wedged server never fails the maintenance pass (hardening continues in #535).

## Scope notes

- Rust only; TS / clangd / Kotlin live backends are #536 (separate PR).
- Live is in-corpus only: a definition outside the checkout root / unindexed / unmapped is skipped — no `resolved-external` rows (no batch-interchangeable symbol string exists for them).
- Warm-up / crash / server→client request handling is #535; a dead server aborts the pass's remaining worklist without failing it.

## Verification

- 9 end-to-end live-pass tests over the slice-1 fake-server seam (`oracle/tests/live.rs`): upgrade/confirm/contradict, batch-moniker verbatim copy, sentinel stability + refine invalidation on moniker arrival, callsite drift, external skip, no-run-when-empty, budget deferral, dead-server abort.
- 2 precedence integration tests (`oracle_surfacing_tests.rs`): batch verdict survives a live duplicate on the same edge; cross-tool contradiction dedupe.
- Config parse / manifest gating / persisted-enum token tests; worklist assembly unit tests.
- `cargo nextest run --workspace` — 3928 passed, 4 skipped. `cargo clippy --all-targets` clean. `cargo +nightly fmt`.
- Docs: `docs/oracle.md` + `docs/config/oracle.md` live sections.

Closes #534. Part of #74 / #61.