### PR TITLE
fix(tests): retain satellite-crate scratch cleanup guards

### DIFF
--- a/crates/rag-rat-base/src/locks.rs
+++ b/crates/rag-rat-base/src/locks.rs
@@ -642,17 +642,11 @@ fn socket_path_with_runtime_base(
 
 #[cfg(test)]
 mod tests {
-    use std::sync::atomic::{AtomicU64, Ordering};
 
     use super::*;
 
-    static LOCK_TEMP: AtomicU64 = AtomicU64::new(0);
-
-    fn temp_dir() -> PathBuf {
-        let id = LOCK_TEMP.fetch_add(1, Ordering::Relaxed);
-        let dir = std::env::temp_dir().join(format!("ragrat-lock-{}-{id}", std::process::id()));
-        fs::create_dir_all(&dir).unwrap();
-        dir
+    fn temp_dir() -> crate::test_scratch::ScratchDir {
+        crate::test_scratch::ScratchDir::new("lock")
     }
 
     #[test]
@@ -673,8 +667,6 @@ mod tests {
         drop(first);
         let reacquired = FileLock::try_acquire(&path).unwrap();
         assert!(reacquired.is_some(), "should acquire after the holder drops");
-
-        let _ = fs::remove_dir_all(&dir);
     }
 
     /// #409: flock ownership belongs to the open-file-description, not the fd. A child forked
@@ -726,8 +718,6 @@ mod tests {
             reacquired.is_some(),
             "drop must release the flock immediately despite the fork-inherited fd (#409)"
         );
-
-        let _ = fs::remove_dir_all(&dir);
     }
 
     #[test]
@@ -780,8 +770,6 @@ mod tests {
         .join()
         .unwrap();
         assert!(reacquired, "the lock is free after the outermost guard drops");
-
-        let _ = fs::remove_dir_all(&dir);
     }
 
     #[test]
@@ -842,12 +830,10 @@ mod tests {
         // `/tmp`->`/private/tmp` aliasing on Linux with an explicit symlink so the raw and
         // canonical forms diverge.
         let real = temp_dir();
-        let link = real.parent().unwrap().join(format!(
-            "ragrat-lock-link-{}-{}",
-            std::process::id(),
-            LOCK_TEMP.fetch_add(1, Ordering::Relaxed)
-        ));
-        let _ = fs::remove_file(&link);
+        // The symlink lives inside its own guard, so a failing assert can't strand it in the
+        // shared temp root.
+        let link_parent = temp_dir();
+        let link = link_parent.join("link");
         std::os::unix::fs::symlink(&real, &link).unwrap();
 
         // A DB whose `.rag-rat/` parent does NOT exist yet, reached through the symlink.
@@ -862,9 +848,6 @@ mod tests {
         // The aliased path and the real path resolve to ONE lock file (the alias is collapsed).
         let via_real = write_lock_path(&real.join(".rag-rat").join("index.sqlite"), "abcd12345678");
         assert_eq!(after, via_real, "aliased and canonical paths share one lock file");
-
-        let _ = fs::remove_file(&link);
-        let _ = fs::remove_dir_all(&real);
     }
 
     #[test]
@@ -930,8 +913,6 @@ mod tests {
         .join()
         .unwrap();
         assert!(reacquired, "the lock is free after the outermost session guard drops");
-
-        let _ = fs::remove_dir_all(&dir);
     }
 
     #[test]
@@ -973,21 +954,22 @@ mod tests {
     }
 
     /// Build a base dir long enough that `<base>/sockets/<hash>.sock` exceeds
-    /// `MAX_SOCKET_PATH_LEN`.
-    fn long_base_dir() -> PathBuf {
-        let mut base = temp_dir();
+    /// `MAX_SOCKET_PATH_LEN`, returned with the guard that removes it on drop.
+    fn long_base_dir() -> (crate::test_scratch::ScratchDir, PathBuf) {
+        let guard = temp_dir();
+        let mut base = guard.path().to_path_buf();
         // Each push appends ~28 bytes; 12 × 28 = 336, well over the 100-byte budget.
         for _ in 0..12 {
             base.push("very-long-directory-segment");
         }
-        base
+        (guard, base)
     }
 
     #[test]
     fn hook_socket_path_falls_back_when_base_path_is_too_long() {
         // When the preferred path is over budget and XDG_RUNTIME_DIR is a short /tmp path, the
         // XDG candidate fits within budget and is returned.
-        let long_base = long_base_dir();
+        let (_long_guard, long_base) = long_base_dir();
         let root = temp_dir();
         // Use a known-short runtime_base so the test is independent of the runner environment.
         let short_runtime_base = std::env::temp_dir(); // e.g. /tmp — always short
@@ -1005,8 +987,8 @@ mod tests {
     fn hook_socket_path_falls_back_to_temp_when_xdg_also_too_long() {
         // When both the preferred path and the XDG candidate are over budget, the function falls
         // through to the OS temp dir (best-effort; callers fail open).
-        let long_base = long_base_dir();
-        let long_runtime_base = long_base_dir();
+        let (_long_guard, long_base) = long_base_dir();
+        let (_long_rt_guard, long_runtime_base) = long_base_dir();
         let root = temp_dir();
         let socket = socket_path_with_runtime_base(&long_base, &root, &long_runtime_base);
         // Must not be under either long base.

--- a/crates/rag-rat-base/src/single_flight.rs
+++ b/crates/rag-rat-base/src/single_flight.rs
@@ -263,7 +263,6 @@ impl<P: FlightPayload> MarkerGuard<'_, P> {
 mod tests {
     use std::cell::{Cell, RefCell};
     use std::collections::BTreeSet;
-    use std::sync::atomic::{AtomicU64, Ordering};
 
     use super::*;
 
@@ -298,22 +297,16 @@ mod tests {
 
     /// A fresh flight coordinator over a unique temp key (unique across threads AND processes — the
     /// coverage runner shares one process, so pid+millis alone collides).
-    fn flight<P: FlightPayload>() -> (SingleFlight<P>, PathBuf) {
-        static NEXT: AtomicU64 = AtomicU64::new(0);
-        let dir = std::env::temp_dir().join(format!(
-            "rag-rat-single-flight-{}-{}",
-            std::process::id(),
-            NEXT.fetch_add(1, Ordering::Relaxed),
-        ));
-        std::fs::create_dir_all(&dir).unwrap();
+    fn flight<P: FlightPayload>() -> (crate::test_scratch::ScratchDir, SingleFlight<P>) {
+        let dir = crate::test_scratch::ScratchDir::new("single-flight");
         let sf =
             SingleFlight::new(dir.join("flight.lock"), dir.join("marker"), dir.join("marker.lock"));
-        (sf, dir)
+        (dir, sf)
     }
 
     #[test]
     fn a_lone_trigger_runs_once() {
-        let (sf, dir) = flight::<Ids>();
+        let (_dir, sf) = flight::<Ids>();
         let passes = RefCell::new(Vec::new());
         let outcome = sf
             .run(Ids::of([1]), |p| {
@@ -323,7 +316,6 @@ mod tests {
             .unwrap();
         assert!(matches!(outcome, FlightOutcome::Ran(Some(()))));
         assert_eq!(*passes.borrow(), vec![Ids::of([1])]);
-        let _ = std::fs::remove_dir_all(dir);
     }
 
     #[test]
@@ -332,7 +324,7 @@ mod tests {
         // the union — never a lost payload. Simulated inline: the first pass queues a
         // second payload (as a concurrent trigger's `merge` would), and the drain must
         // rerun with it.
-        let (sf, dir) = flight::<Ids>();
+        let (_dir, sf) = flight::<Ids>();
         let passes = RefCell::new(Vec::new());
         let first = Cell::new(true);
         let outcome = sf
@@ -346,14 +338,13 @@ mod tests {
             .unwrap();
         assert!(matches!(outcome, FlightOutcome::Ran(Some(()))));
         assert_eq!(*passes.borrow(), vec![Ids::of([1]), Ids::of([2, 3])]);
-        let _ = std::fs::remove_dir_all(dir);
     }
 
     #[test]
     fn a_trigger_coalesces_when_a_runner_holds_the_flight_lock() {
         // Holding the flight lock stands in for an in-flight runner: a fresh trigger must merge
         // into the marker and return Coalesced, not run.
-        let (sf, dir) = flight::<Ids>();
+        let (dir, sf) = flight::<Ids>();
         let _held = FileLock::acquire_blocking(sf.flight_lock_path()).unwrap();
         let outcome = sf
             .run(Ids::of([7]), |_| -> anyhow::Result<Step<()>> {
@@ -366,14 +357,13 @@ mod tests {
             std::fs::read(dir.join("marker")).map(|b| Ids::decode(&b)).unwrap(),
             Ids::of([7])
         );
-        let _ = std::fs::remove_dir_all(dir);
     }
 
     #[test]
     fn a_stale_marker_is_drained_not_wedged() {
         // A marker left by a killed runner must be absorbed by the next runner's first pass, never
         // strand it. Written directly, as a crashed process would leave it.
-        let (sf, dir) = flight::<Ids>();
+        let (dir, sf) = flight::<Ids>();
         std::fs::write(dir.join("marker"), Ids::of([4]).encode()).unwrap();
         let passes = RefCell::new(Vec::new());
         sf.run(Ids::of([5]), |p| {
@@ -383,12 +373,11 @@ mod tests {
         .unwrap();
         assert_eq!(*passes.borrow(), vec![Ids::of([4, 5])], "the stale marker is folded in, once");
         assert!(!dir.join("marker").exists(), "and the marker is drained, not left wedged");
-        let _ = std::fs::remove_dir_all(dir);
     }
 
     #[test]
     fn stop_requeue_leaves_the_marker_set() {
-        let (sf, dir) = flight::<Ids>();
+        let (dir, sf) = flight::<Ids>();
         let outcome = sf
             .run(Ids::of([9]), |_| -> anyhow::Result<Step<()>> { Ok(Step::StopRequeue) })
             .unwrap();
@@ -398,12 +387,11 @@ mod tests {
             Ids::of([9]),
             "the payload is left for a future runner",
         );
-        let _ = std::fs::remove_dir_all(dir);
     }
 
     #[test]
     fn stop_carry_hands_the_payload_back_and_clears_the_marker() {
-        let (sf, dir) = flight::<Ids>();
+        let (dir, sf) = flight::<Ids>();
         // A payload also queued mid-marker must be absorbed into the carried value.
         sf.queue(Ids::of([2])).unwrap();
         let outcome =
@@ -414,14 +402,13 @@ mod tests {
                 panic!("expected Stopped(Some), got {:?}", matches!(other, FlightOutcome::Ran(_))),
         }
         assert!(!dir.join("marker").exists(), "the marker is consumed into the carried payload");
-        let _ = std::fs::remove_dir_all(dir);
     }
 
     #[test]
     fn the_unit_payload_reruns_on_a_bare_marker() {
         // The maintenance (#267) case: `()` carries nothing; the marker's mere existence is the
         // rerun signal.
-        let (sf, dir) = flight::<()>();
+        let (_dir, sf) = flight::<()>();
         let count = Cell::new(0u32);
         let first = Cell::new(true);
         sf.run((), |()| {
@@ -433,6 +420,5 @@ mod tests {
         })
         .unwrap();
         assert_eq!(count.get(), 2, "a bare marker set mid-pass earns exactly one rerun");
-        let _ = std::fs::remove_dir_all(dir);
     }
 }

--- a/crates/rag-rat-clones/src/refine/cache.rs
+++ b/crates/rag-rat-clones/src/refine/cache.rs
@@ -736,8 +736,8 @@ mod tests {
         use rusqlite::OpenFlags;
 
         // Build a writable in-memory DB and apply the schema.
-        let rw_path =
-            std::env::temp_dir().join(format!("ragrat-refine-ro-probe-{}.db", std::process::id()));
+        let scratch = rag_rat_base::test_scratch::ScratchDir::new("refine-ro-probe");
+        let rw_path = scratch.join("probe.db");
         {
             let rw = rusqlite::Connection::open(&rw_path).unwrap();
             rag_rat_db::schema::apply(&rw, &rag_rat_db::MigrationHooks::noop()).unwrap();
@@ -759,8 +759,6 @@ mod tests {
             rag_rat_db::storage::is_readonly_violation(&anyhow_err),
             "the DELETE probe on a RO connection must produce SQLITE_READONLY: {anyhow_err}"
         );
-
-        let _ = std::fs::remove_file(&rw_path);
     }
 
     // ── Plan 4b Task 7: full content cache round-trip + version invalidation

--- a/crates/rag-rat-core/benches/clone_time.rs
+++ b/crates/rag-rat-core/benches/clone_time.rs
@@ -19,9 +19,8 @@
 
 mod shared;
 
-use std::path::PathBuf;
+use std::hint;
 use std::time::Duration;
-use std::{fs, hint};
 
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
 use rag_rat_core::index::{CloneSymbolSelector, FindClonesOptions};
@@ -36,29 +35,13 @@ fn default_opts() -> FindClonesOptions {
     FindClonesOptions { min_similarity: None, min_copies: None, limit: None }
 }
 
-/// Best-effort removal of a bench DB's on-disk files (`.sqlite` + `-wal`/`-shm`) when dropped, so a
-/// long run doesn't leak a corpus-sized DB per build — the same discipline as `index_time`'s
-/// `TempIndexDb` (#251). Declared so it drops AFTER the `IndexDatabase` handle it pairs with (the
-/// handle closes the connection first, then the files are unlinked).
-struct DbFiles(PathBuf);
-
-impl Drop for DbFiles {
-    fn drop(&mut self) {
-        let db = self.0.display().to_string();
-        for suffix in ["", "-wal", "-shm"] {
-            let _ = fs::remove_file(format!("{db}{suffix}"));
-        }
-    }
-}
-
 fn clone_queries(c: &mut Criterion) {
     // Clone the corpus once, before timing.
     let _ = corpus_dir();
 
     // One shared index for the cache-free / warm benches and to resolve a real subject. Declared
-    // before `db` so `db` (the open handle) drops first and `DbFiles` unlinks afterwards.
-    let config = built_config(SUBDIR);
-    let _shared_cleanup = DbFiles(config.database.clone());
+    // before `db` so `db` (the open handle) drops first and the guard removes the DB afterwards.
+    let (config, _shared_scratch) = built_config(SUBDIR);
     let db = open_like_production(&config);
 
     let components = db.candidate_clone_components().expect("candidate components");
@@ -107,11 +90,10 @@ fn clone_queries(c: &mut Criterion) {
     cold.bench_function("find_clones_cold", |b| {
         b.iter_batched_ref(
             || {
-                let config = built_config(SUBDIR);
-                let cleanup = DbFiles(config.database.clone());
+                let (config, scratch) = built_config(SUBDIR);
                 let db = open_like_production(&config);
-                // (db, cleanup): db drops first (closes the connection), then cleanup unlinks.
-                (db, cleanup)
+                // (db, scratch): db drops first (closes the connection), then the guard unlinks.
+                (db, scratch)
             },
             |(db, _cleanup)| {
                 hint::black_box(db.find_clones(default_opts()).expect("find_clones"));

--- a/crates/rag-rat-core/benches/index_time.rs
+++ b/crates/rag-rat-core/benches/index_time.rs
@@ -28,15 +28,7 @@ const SUBDIR: &str = ".";
 /// box (#251).
 struct TempIndexDb {
     config: Config,
-}
-
-impl Drop for TempIndexDb {
-    fn drop(&mut self) {
-        let db = self.config.database.display().to_string();
-        for suffix in ["", "-wal", "-shm"] {
-            let _ = std::fs::remove_file(format!("{db}{suffix}"));
-        }
-    }
+    _scratch: rag_rat_base::test_scratch::ScratchDir,
 }
 
 fn full_index(c: &mut Criterion) {
@@ -45,7 +37,7 @@ fn full_index(c: &mut Criterion) {
 
     // Build one index up front to report the real scale being measured (and to size throughput).
     // This is the headline number a user cares about: how big a repo are we actually indexing?
-    let probe = bench_config(SUBDIR);
+    let (probe, _scratch) = bench_config(SUBDIR);
     let db = IndexDatabase::rebuild(&probe).expect("probe rebuild");
     let status = db.status(&probe.database).expect("index status");
     let files: u64 = status.file_count_by_language.values().sum();
@@ -68,7 +60,10 @@ fn full_index(c: &mut Criterion) {
         // on disk rather than leaking one per iteration (#251). The deletion is outside the
         // measured section.
         b.iter_batched_ref(
-            || TempIndexDb { config: bench_config(SUBDIR) },
+            || {
+                let (config, scratch) = bench_config(SUBDIR);
+                TempIndexDb { config, _scratch: scratch }
+            },
             |bench_db| {
                 let db = IndexDatabase::rebuild(&bench_db.config).expect("rebuild corpus index");
                 std::hint::black_box(db);

--- a/crates/rag-rat-core/benches/rag_pipeline.rs
+++ b/crates/rag-rat-core/benches/rag_pipeline.rs
@@ -19,21 +19,21 @@ use shared::{bench_config, built_config, built_index, open_like_production};
 const SUBDIR: &str = "src/cargo/core/resolver";
 const QUERY: &str = "resolve dependency version conflict";
 
-fn resolver_config() -> rag_rat_base::config::Config {
+fn resolver_config() -> (Config, rag_rat_base::test_scratch::ScratchDir) {
     bench_config(SUBDIR)
 }
-fn resolver_index() -> IndexDatabase {
+fn resolver_index() -> (IndexDatabase, rag_rat_base::test_scratch::ScratchDir) {
     built_index(SUBDIR)
 }
-fn resolver_built_config() -> Config {
+fn resolver_built_config() -> (Config, rag_rat_base::test_scratch::ScratchDir) {
     built_config(SUBDIR)
 }
 
 // Index cost: full rebuild of the subtree. Setup (clone + Config) is not measured; only `rebuild`.
 #[library_benchmark]
 #[bench::cargo_resolver(setup = resolver_config)]
-fn index(config: rag_rat_base::config::Config) -> IndexDatabase {
-    IndexDatabase::rebuild(&config).expect("rebuild corpus index")
+fn index(setup: (Config, rag_rat_base::test_scratch::ScratchDir)) -> IndexDatabase {
+    IndexDatabase::rebuild(&setup.0).expect("rebuild corpus index")
 }
 
 // Cold query: open a freshly-built index from disk (cold page cache) the way production `search`
@@ -41,16 +41,16 @@ fn index(config: rag_rat_base::config::Config) -> IndexDatabase {
 // measured body, so this captures the realistic cold-open cost. Setup (rebuild) is not measured.
 #[library_benchmark]
 #[bench::cargo_resolver(setup = resolver_built_config)]
-fn query_cold(config: Config) -> usize {
-    let db = open_like_production(&config);
+fn query_cold(setup: (Config, rag_rat_base::test_scratch::ScratchDir)) -> usize {
+    let db = open_like_production(&setup.0);
     db.search(QUERY, 10, false).expect("search").len()
 }
 
 // Warm query: search against an already-open index (the build is in setup, not measured).
 #[library_benchmark]
 #[bench::cargo_resolver(setup = resolver_index)]
-fn query_warm(db: IndexDatabase) -> usize {
-    db.search(QUERY, 10, false).expect("search").len()
+fn query_warm(setup: (IndexDatabase, rag_rat_base::test_scratch::ScratchDir)) -> usize {
+    setup.0.search(QUERY, 10, false).expect("search").len()
 }
 
 library_benchmark_group!(

--- a/crates/rag-rat-core/benches/rag_pipeline.rs
+++ b/crates/rag-rat-core/benches/rag_pipeline.rs
@@ -30,27 +30,42 @@ fn resolver_built_config() -> (Config, rag_rat_base::test_scratch::ScratchDir) {
 }
 
 // Index cost: full rebuild of the subtree. Setup (clone + Config) is not measured; only `rebuild`.
+// The scratch guard is RETURNED, so its `remove_dir_all` drops in the (unmeasured) harness rather
+// than inside the instrumented function — an in-body drop would attribute the traversal to the
+// benchmark and, for the query benches, dominate the instruction count.
 #[library_benchmark]
 #[bench::cargo_resolver(setup = resolver_config)]
-fn index(setup: (Config, rag_rat_base::test_scratch::ScratchDir)) -> IndexDatabase {
-    IndexDatabase::rebuild(&setup.0).expect("rebuild corpus index")
+fn index(
+    setup: (Config, rag_rat_base::test_scratch::ScratchDir),
+) -> (IndexDatabase, rag_rat_base::test_scratch::ScratchDir) {
+    let db = IndexDatabase::rebuild(&setup.0).expect("rebuild corpus index");
+    (db, setup.1)
 }
 
 // Cold query: open a freshly-built index from disk (cold page cache) the way production `search`
 // does (open + active-checkout context, offline), then run one search — the open is INSIDE the
 // measured body, so this captures the realistic cold-open cost. Setup (rebuild) is not measured.
+// The guard rides back out for harness-side cleanup (see `index`).
 #[library_benchmark]
 #[bench::cargo_resolver(setup = resolver_built_config)]
-fn query_cold(setup: (Config, rag_rat_base::test_scratch::ScratchDir)) -> usize {
+fn query_cold(
+    setup: (Config, rag_rat_base::test_scratch::ScratchDir),
+) -> rag_rat_base::test_scratch::ScratchDir {
     let db = open_like_production(&setup.0);
-    db.search(QUERY, 10, false).expect("search").len()
+    std::hint::black_box(db.search(QUERY, 10, false).expect("search"));
+    setup.1
 }
 
-// Warm query: search against an already-open index (the build is in setup, not measured).
+// Warm query: search against an already-open index (the build is in setup, not measured). The
+// guard is returned unmeasured; the index handle itself drops in the measured body exactly as it
+// did when it was the sole parameter.
 #[library_benchmark]
 #[bench::cargo_resolver(setup = resolver_index)]
-fn query_warm(setup: (IndexDatabase, rag_rat_base::test_scratch::ScratchDir)) -> usize {
-    setup.0.search(QUERY, 10, false).expect("search").len()
+fn query_warm(
+    setup: (IndexDatabase, rag_rat_base::test_scratch::ScratchDir),
+) -> rag_rat_base::test_scratch::ScratchDir {
+    std::hint::black_box(setup.0.search(QUERY, 10, false).expect("search"));
+    setup.1
 }
 
 library_benchmark_group!(

--- a/crates/rag-rat-core/benches/shared/mod.rs
+++ b/crates/rag-rat-core/benches/shared/mod.rs
@@ -5,7 +5,6 @@
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::{env, fs};
 
 use rag_rat_base::config::{Config, ResolvedTarget, TargetKind};
@@ -43,34 +42,27 @@ pub fn corpus_dir() -> PathBuf {
     dir
 }
 
-static DB_COUNTER: AtomicU64 = AtomicU64::new(0);
-
-pub fn temp_db_path() -> PathBuf {
-    let n = DB_COUNTER.fetch_add(1, Ordering::Relaxed);
-    let path = env::temp_dir().join(format!("rag-rat-bench-{}-{n}.sqlite", std::process::id()));
-    // Pids recycle (containers, long-lived hosts), and bench DBs are never cleaned up — a name
-    // collision would REBUILD INTO the stale DB, leaving a multi-generation index whose query cost
-    // silently differs from a fresh one (measured swings of ±25% on query_warm). Delete any
-    // leftover (plus WAL/SHM siblings) so every bench run indexes into a truly fresh database.
-    for suffix in ["", "-wal", "-shm"] {
-        let _ = fs::remove_file(path.with_file_name(format!(
-            "{}{suffix}",
-            path.file_name().unwrap_or_default().to_string_lossy()
-        )));
-    }
-    path
+/// A guarded scratch dir (removed when the bench's value drops) holding the bench database.
+/// Every call is a fresh dir, so every bench run indexes into a truly fresh database — a stale
+/// DB would silently change measured query cost (the old pid+counter name reuse, ±25% on
+/// query_warm).
+fn temp_db() -> rag_rat_base::test_scratch::ScratchDir {
+    rag_rat_base::test_scratch::ScratchDir::new("bench")
 }
 
-/// A Config indexing `subdir` of the corpus into a fresh temp DB.
-pub fn bench_config(subdir: &str) -> Config {
-    Config {
+/// A Config indexing `subdir` of the corpus into a fresh temp DB, plus the guard that removes
+/// it on drop. The guard is the LAST tuple field: tuple fields drop in declaration order, so the
+/// Config — and any handle built from it — drops before the directory is removed.
+pub fn bench_config(subdir: &str) -> (Config, rag_rat_base::test_scratch::ScratchDir) {
+    let scratch = temp_db();
+    let config = Config {
         trackers: Vec::new(),
         papertrail: Default::default(),
         sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
         root: corpus_dir(),
-        database: temp_db_path(),
+        database: scratch.join("bench.sqlite"),
         targets: vec![ResolvedTarget {
             name: "rust".to_string(),
             language: Language::Rust,
@@ -88,22 +80,25 @@ pub fn bench_config(subdir: &str) -> Config {
         log: Default::default(),
         source_root_reanchored_from: None,
         allow_empty: false,
-    }
+    };
+    (config, scratch)
 }
 
-/// Build a fresh index of `subdir` and return the open handle.
-pub fn built_index(subdir: &str) -> IndexDatabase {
-    IndexDatabase::rebuild(&bench_config(subdir)).expect("rebuild corpus index")
+/// Build a fresh index of `subdir` and return the open handle (the guard drops after it).
+pub fn built_index(subdir: &str) -> (IndexDatabase, rag_rat_base::test_scratch::ScratchDir) {
+    let (config, scratch) = bench_config(subdir);
+    let db = IndexDatabase::rebuild(&config).expect("rebuild corpus index");
+    (db, scratch)
 }
 
 /// Build a fresh index of `subdir` and return its `Config`, so a cold-open bench can reopen the DB
 /// the way production `open_config` does — see [`open_like_production`]. (Returns the Config, not
 /// just the path, because the realistic reopen needs `config.root` to resolve the active-checkout
 /// git context.)
-pub fn built_config(subdir: &str) -> Config {
-    let config = bench_config(subdir);
+pub fn built_config(subdir: &str) -> (Config, rag_rat_base::test_scratch::ScratchDir) {
+    let (config, scratch) = bench_config(subdir);
     IndexDatabase::rebuild(&config).expect("rebuild corpus index");
-    config
+    (config, scratch)
 }
 
 /// Open an already-built index from disk the way the production `search` path does

--- a/crates/rag-rat-db/src/storage.rs
+++ b/crates/rag-rat-db/src/storage.rs
@@ -306,8 +306,7 @@ mod tests {
 
     #[test]
     fn open_read_only_reads_but_rejects_writes() {
-        let dir = std::env::temp_dir().join(format!("ragrat-ro-{}", std::process::id()));
-        std::fs::create_dir_all(&dir).unwrap();
+        let dir = rag_rat_base::test_scratch::ScratchDir::new("ro");
         let db = dir.join("index.db");
         {
             let rw = IndexConnection::open(&db).unwrap();
@@ -319,17 +318,11 @@ mod tests {
         assert_eq!(n, 0);
         let err = ro.connection().execute("INSERT INTO index_meta(key, value) VALUES('x','y')", []);
         assert!(err.is_err(), "read-only connection must reject writes");
-        std::fs::remove_dir_all(&dir).ok();
     }
 
     #[test]
     fn setup_pins_the_write_path_pragmas() {
-        let dir = std::env::temp_dir().join(format!(
-            "ragrat-setup-pragmas-{}-{:?}",
-            std::process::id(),
-            std::thread::current().id()
-        ));
-        std::fs::create_dir_all(&dir).unwrap();
+        let dir = rag_rat_base::test_scratch::ScratchDir::new("setup-pragmas");
         let db = dir.join("index.db");
         let rw = IndexConnection::open(&db).unwrap();
         let pragma = |name: &str| -> i64 {
@@ -349,8 +342,6 @@ mod tests {
             rw.connection().query_row("PRAGMA journal_mode", [], |row| row.get(0)).unwrap();
         assert_eq!(mode, "wal");
         assert_eq!(pragma("synchronous"), 1, "synchronous must stay NORMAL");
-
-        std::fs::remove_dir_all(&dir).ok();
     }
 
     /// Grow the `-wal` past the fold threshold with zeroblob pages (cheap to generate).
@@ -371,12 +362,7 @@ mod tests {
 
     #[test]
     fn dropping_a_write_connection_folds_an_oversized_wal() {
-        let dir = std::env::temp_dir().join(format!(
-            "ragrat-drop-fold-{}-{:?}",
-            std::process::id(),
-            std::thread::current().id()
-        ));
-        std::fs::create_dir_all(&dir).unwrap();
+        let dir = rag_rat_base::test_scratch::ScratchDir::new("drop-fold");
         let db = dir.join("index.db");
         let rw = IndexConnection::open(&db).unwrap();
         // A second live connection defeats SQLite's last-connection-close checkpoint — the drop
@@ -392,17 +378,11 @@ mod tests {
             "dropping the write connection must fold the oversized WAL (#818)"
         );
         drop(holder);
-        std::fs::remove_dir_all(&dir).ok();
     }
 
     #[test]
     fn dropping_the_nowait_connection_never_folds() {
-        let dir = std::env::temp_dir().join(format!(
-            "ragrat-drop-nowait-{}-{:?}",
-            std::process::id(),
-            std::thread::current().id()
-        ));
-        std::fs::create_dir_all(&dir).unwrap();
+        let dir = rag_rat_base::test_scratch::ScratchDir::new("drop-nowait");
         let db = dir.join("index.db");
         let holder = IndexConnection::open(&db).unwrap();
         grow_wal_past_threshold(&db);
@@ -417,23 +397,18 @@ mod tests {
             "the nowait event-loop connection must leave WAL folding to the pass worker"
         );
         drop(holder);
-        std::fs::remove_dir_all(&dir).ok();
     }
 
     #[test]
     fn open_read_only_fails_cleanly_when_database_missing() {
-        let missing = std::env::temp_dir().join("ragrat-ro-missing/never-created.db");
+        let scratch = rag_rat_base::test_scratch::ScratchDir::new("ro-missing");
+        let missing = scratch.join("never-created.db");
         assert!(IndexConnection::open_read_only(&missing).is_err());
     }
 
     #[test]
     fn open_read_only_blocking_does_not_persist_wal_mode_or_create_sidecars() {
-        let dir = std::env::temp_dir().join(format!(
-            "ragrat-ro-journal-{}-{:?}",
-            std::process::id(),
-            std::thread::current().id()
-        ));
-        std::fs::create_dir_all(&dir).unwrap();
+        let dir = rag_rat_base::test_scratch::ScratchDir::new("ro-journal");
         let db = dir.join("index.db");
         {
             let conn = Connection::open(&db).unwrap();
@@ -453,12 +428,11 @@ mod tests {
         assert_eq!(mode, "delete", "journal mode must remain DELETE after the RO open");
         assert!(!db.with_extension("db-wal").exists(), "RO planning must not create a WAL file");
         assert!(!db.with_extension("db-shm").exists(), "RO planning must not create a SHM file");
-        std::fs::remove_dir_all(&dir).ok();
     }
 
     #[test]
     fn is_readonly_violation_flags_only_sqlite_readonly_errors() {
-        let dir = std::env::temp_dir().join(format!("ragrat-roviol-{}", std::process::id()));
+        let dir = rag_rat_base::test_scratch::ScratchDir::new("roviol");
         std::fs::create_dir_all(&dir).unwrap();
         let db = dir.join("index.db");
         {
@@ -481,8 +455,6 @@ mod tests {
         let syntax_err: anyhow::Error =
             ro.connection().execute("THIS IS NOT SQL", []).unwrap_err().into();
         assert!(!is_readonly_violation(&syntax_err), "a non-readonly error must not be flagged");
-
-        std::fs::remove_dir_all(&dir).ok();
     }
 
     fn sqlite_failure(result_code: i32) -> anyhow::Error {

--- a/crates/rag-rat-llm/src/cookbook.rs
+++ b/crates/rag-rat-llm/src/cookbook.rs
@@ -1221,11 +1221,9 @@ extern "C" fn handle_terminating_signal(signo: libc::c_int) {
 mod tests {
     use std::os::unix::process::ExitStatusExt;
     use std::path::PathBuf;
-    use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     use super::*;
-
-    static N: AtomicU64 = AtomicU64::new(0);
 
     fn fixture(name: &str) -> PathBuf {
         PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/cookbook").join(name)
@@ -1346,9 +1344,11 @@ mod tests {
         assert!(err.to_string().contains("cancelled before start"), "{err:#}");
     }
 
-    fn tmp(name: &str) -> PathBuf {
-        let id = N.fetch_add(1, Ordering::Relaxed);
-        std::env::temp_dir().join(format!("ragrat-cookbook-{}-{id}-{name}", std::process::id()))
+    /// A scratch dir (removed on drop) plus the path a fixture script writes inside it.
+    fn tmp(name: &str) -> (rag_rat_base::test_scratch::ScratchDir, PathBuf) {
+        let scratch = rag_rat_base::test_scratch::ScratchDir::new("cookbook");
+        let path = scratch.join(name);
+        (scratch, path)
     }
 
     #[test]
@@ -1438,7 +1438,7 @@ mod tests {
         // only a process-GROUP kill reaches it. If `Drop` killed just `child.id()` (the old bug),
         // the grandchild would survive (the leaked paid box). We provision, read the grandchild's
         // pid, drop the box, and assert the grandchild is GONE.
-        let pidfile = tmp("grandchild-pid");
+        let (_scratch, pidfile) = tmp("grandchild-pid");
         let _ = std::fs::remove_file(&pidfile);
         let cmd = stub_command("stub_grandchild.sh", &[
             ("STUB_ENDPOINT", "http://127.0.0.1:1"),
@@ -1484,7 +1484,7 @@ mod tests {
         // the instant the leader's `waitpid` succeeded → it skipped the SIGKILL backstop and `Drop`
         // returned with the grandchild (the paid box) still alive — a leak. The fix polls the whole
         // GROUP (`killpg(pgid, 0)`), so `Drop` must NOT return until the grandchild is gone too.
-        let pidfile = tmp("lingering-grandchild-pid");
+        let (_scratch, pidfile) = tmp("lingering-grandchild-pid");
         let _ = std::fs::remove_file(&pidfile);
         let cmd = stub_command("stub_grandchild_lingers.sh", &[
             ("STUB_ENDPOINT", "http://127.0.0.1:1"),
@@ -1876,7 +1876,7 @@ mod tests {
         // group probe / NO killpg → the grandchild (the paid box) is orphaned. This case
         // FAILS before the Part-1 fix and PASSES after it: the fix always probes the GROUP
         // and runs the full SIGTERM→grace→SIGKILL teardown.
-        let pidfile = tmp("wrapper-early-gc-pid");
+        let (_scratch, pidfile) = tmp("wrapper-early-gc-pid");
         let _ = std::fs::remove_file(&pidfile);
         let cmd = stub_command("stub_wrapper_exits_early.sh", &[
             ("STUB_ENDPOINT", "http://127.0.0.1:1"),
@@ -1904,7 +1904,7 @@ mod tests {
         // `waitpid` — it polls the GROUP and (for a long-enough hang) SIGKILLs at the grace
         // deadline. `stub_grandchild`'s grandchild ignores TERM and sleeps long, so only
         // the group SIGKILL backstop reaps it.
-        let pidfile = tmp("hung-gc-pid");
+        let (_scratch, pidfile) = tmp("hung-gc-pid");
         let _ = std::fs::remove_file(&pidfile);
         let cmd = stub_command("stub_grandchild.sh", &[
             ("STUB_ENDPOINT", "http://127.0.0.1:1"),
@@ -1932,7 +1932,7 @@ mod tests {
         // up. The timeout path must run the full `teardown_group` (R1: grace, not a hard
         // SIGKILL-only) and reap the group — NOT return the timeout error while leaking the
         // grandchild.
-        let pidfile = tmp("timeout-live-gc-pid");
+        let (_scratch, pidfile) = tmp("timeout-live-gc-pid");
         let _ = std::fs::remove_file(&pidfile);
         // The box is never returned (it never serves), so the grandchild's pidfile is our handle on
         // the group. Run provisioning on a thread so we can read the pidfile while it blocks on the
@@ -2005,8 +2005,8 @@ mod tests {
         }
 
         let exe = std::env::current_exe().expect("test binary path");
-        let gc_pidfile = tmp("case6-grandchild-pid");
-        let ready_file = tmp("case6-ready");
+        let (_scratch, gc_pidfile) = tmp("case6-grandchild-pid");
+        let (_scratch2, ready_file) = tmp("case6-ready");
         let _ = std::fs::remove_file(&gc_pidfile);
         let _ = std::fs::remove_file(&ready_file);
 

--- a/crates/rag-rat-mcp/src/agent_hook.rs
+++ b/crates/rag-rat-mcp/src/agent_hook.rs
@@ -407,13 +407,8 @@ mod listener_tests {
     /// mirrors `mcp_hot_upgrade.rs`'s `TestEnv::setup`, minus targets (the listener never
     /// indexes). The DB is created at `config.database` *after* `Config::load` so root
     /// canonicalization can't desync the two paths.
-    fn test_config() -> Config {
-        let root = std::env::temp_dir().join(format!(
-            "ragrat-hooksock-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()
-        ));
-        std::fs::create_dir_all(&root).unwrap();
+    fn test_config() -> (rag_rat_base::test_scratch::ScratchDir, Config) {
+        let root = rag_rat_base::test_scratch::ScratchDir::new("hooksock");
         let config_path = root.join("rag-rat.toml");
         std::fs::write(&config_path, "[index]\nroot = \".\"\ndatabase = \".rag-rat/index.db\"\n")
             .unwrap();
@@ -461,7 +456,7 @@ mod listener_tests {
             .unwrap();
         // No rebuild_fts here: external-content FTS5 rebuilds corrupt when out of sync with
         // direct seeding, and the symbol lane needs no FTS rows.
-        config
+        (root, config)
     }
 
     async fn request(socket: &std::path::Path, body: serde_json::Value) -> serde_json::Value {
@@ -476,7 +471,7 @@ mod listener_tests {
 
     #[tokio::test]
     async fn listener_serves_context_then_dedupes_per_session() {
-        let config = test_config();
+        let (_scratch, config) = test_config();
         let _listener = spawn_listener(config.clone());
         let socket = socket_path_for(&config);
         // Election + bind are async; poll for the socket.
@@ -510,7 +505,7 @@ mod listener_tests {
     /// `frobnicate`, which has a caller), and dedups per session like grep-augment does.
     #[tokio::test]
     async fn listener_serves_read_augment_and_dedupes_per_session() {
-        let config = test_config();
+        let (_scratch, config) = test_config();
         let _listener = spawn_listener(config.clone());
         let socket = socket_path_for(&config);
         let deadline = std::time::Instant::now() + Duration::from_secs(10);
@@ -548,7 +543,7 @@ mod listener_tests {
     async fn second_listener_takes_over_when_winner_dies() {
         use super::listener::{ListenerHooks, spawn_listener_with_hooks};
 
-        let config = test_config();
+        let (_scratch, config) = test_config();
         let winner_hooks = ListenerHooks::default();
         let winner = spawn_listener_with_hooks(config.clone(), winner_hooks.clone());
         // Wait for the winner to have bound the socket instead of polling socket.exists().

--- a/crates/rag-rat-mcp/src/server/tests.rs
+++ b/crates/rag-rat-mcp/src/server/tests.rs
@@ -1,5 +1,4 @@
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
 use rag_rat_base::config::{Config, ResolvedTarget, TargetKind};
@@ -12,14 +11,8 @@ use serde_json::{Value, json};
 use super::*;
 use crate::blocking::{self, ToolTimeoutPolicy};
 
-static N: AtomicU64 = AtomicU64::new(0);
-
-fn config_over_temp_repo() -> (PathBuf, Config) {
-    let root = std::env::temp_dir().join(format!(
-        "rag-rat-server-test-{}-{}",
-        std::process::id(),
-        N.fetch_add(1, Ordering::Relaxed)
-    ));
+fn config_over_temp_repo() -> (rag_rat_base::test_scratch::ScratchDir, Config) {
+    let root = rag_rat_base::test_scratch::ScratchDir::new("server-test");
     std::fs::create_dir_all(root.join("src")).unwrap();
     std::fs::write(root.join("src/lib.rs"), "pub fn open_database() {}\n").unwrap();
     let config = Config {
@@ -28,7 +21,7 @@ fn config_over_temp_repo() -> (PathBuf, Config) {
         sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
-        root: root.clone(),
+        root: root.to_path_buf(),
         database: root.join(".rag-rat/index.sqlite"),
         targets: vec![ResolvedTarget {
             name: "rust".to_string(),
@@ -52,7 +45,7 @@ fn config_over_temp_repo() -> (PathBuf, Config) {
     (root, config)
 }
 
-fn service_over_temp_repo() -> (PathBuf, RagRatService) {
+fn service_over_temp_repo() -> (rag_rat_base::test_scratch::ScratchDir, RagRatService) {
     let (root, config) = config_over_temp_repo();
     (root, RagRatService::new(config, OutputFormat::Toon))
 }
@@ -81,7 +74,7 @@ fn timeout_and_worker_env_ignore_blank_zero_and_invalid_values() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn call_async_dispatches_through_blocking_chokepoint() {
-    let (root, svc) = service_over_temp_repo();
+    let (_root, svc) = service_over_temp_repo();
     let result = svc.call_async("index_status".to_string(), json!({})).await.unwrap();
 
     assert!(!result.content.is_empty(), "async tool dispatch returned no content");
@@ -94,14 +87,12 @@ async fn call_async_dispatches_through_blocking_chokepoint() {
         "unknown-tool error should preserve the dispatcher message, got: {}",
         err.message
     );
-
-    let _ = std::fs::remove_dir_all(root);
 }
 
 #[cfg(unix)]
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn call_async_counts_queued_blocking_work_as_inflight() {
-    let (root, mut svc) = service_over_temp_repo();
+    let (_root, mut svc) = service_over_temp_repo();
     svc.tool_workers = test_tool_workers(1);
     let held_worker = Arc::clone(&svc.tool_workers).acquire_owned().await.unwrap();
     let inflight = svc.inflight();
@@ -121,8 +112,6 @@ async fn call_async_counts_queued_blocking_work_as_inflight() {
     drop(held_worker);
     pending.await.unwrap().unwrap();
     assert_eq!(inflight.count(), 0, "in-flight guard must drop after the worker exits");
-
-    let _ = std::fs::remove_dir_all(root);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -280,7 +269,7 @@ async fn blocking_tool_work_reports_panics_as_mcp_errors() {
 /// the fleet — except a `memory_create`/`memory_update` forces it (and resets the window).
 #[test]
 fn stale_memory_nudge_throttles_forces_and_suppresses_json() {
-    let (root, config) = config_over_temp_repo();
+    let (_root, config) = config_over_temp_repo();
     // A memory bound to an unindexed/absent path resolves `gone` → drift the nudge reports.
     let toon = RagRatService::new(config.clone(), OutputFormat::Toon);
     toon.call(
@@ -320,8 +309,6 @@ fn stale_memory_nudge_throttles_forces_and_suppresses_json() {
     // Immediately after — within the window — a plain read tool is THROTTLED (nudge
     // suppressed).
     assert!(toon.stale_memory_nudge("semantic_search").is_none(), "throttled inside the window",);
-
-    let _ = std::fs::remove_dir_all(root);
 }
 
 /// #752 end-to-end: in TOON (LLM-facing) mode a repo memory riding a DRIVE-BY result
@@ -337,7 +324,7 @@ fn drive_by_memories_dedup_in_toon_but_json_mode_is_untrimmed() {
         serde_json::from_str(&text_of(&svc.call(tool, args).unwrap())).unwrap()
     }
 
-    let (root, config) = config_over_temp_repo(); // indexes `open_database`
+    let (_root, config) = config_over_temp_repo(); // indexes `open_database`
     let lookup_args = json!({"symbol": "open_database", "allow_ambiguous": true});
     const ELIDED: &str = "already surfaced this session";
 
@@ -384,8 +371,6 @@ fn drive_by_memories_dedup_in_toon_but_json_mode_is_untrimmed() {
         assert_eq!(m["memory_id"].as_str(), Some(mem_id.as_str()));
         assert!(m["elided"].is_null(), "JSON mode never stubs a drive-by memory");
     }
-
-    let _ = std::fs::remove_dir_all(root);
 }
 
 #[test]

--- a/crates/rag-rat-mcp/src/tools/tests.rs
+++ b/crates/rag-rat-mcp/src/tools/tests.rs
@@ -1,6 +1,5 @@
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicU64, Ordering};
 
 use rag_rat_base::config::{Config, ResolvedTarget, TargetKind};
 use rag_rat_base::language::Language;
@@ -8,8 +7,6 @@ use rag_rat_core::IndexDatabase;
 use serde_json::json;
 
 use super::*;
-
-static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 #[test]
 fn degraded_coverage_escalates_low_completeness_risk() {
@@ -358,7 +355,7 @@ fn enum_like_tool_args_reject_unknown_values_during_decoding() {
 
 #[test]
 fn index_status_surfaces_version_when_cached_and_enabled() {
-    let (root, config) = mixed_config();
+    let (_root, config) = mixed_config();
     IndexDatabase::rebuild(&config).unwrap();
     // Seed a clearly-newer cached crates.io result into the combined sidecar store (the network
     // refresh that normally writes this is out of band).
@@ -376,13 +373,11 @@ fn index_status_surfaces_version_when_cached_and_enabled() {
     assert_eq!(version["latest_version"], "99.0.0");
     assert_eq!(version["update_available"], true);
     assert_eq!(version["update_command"], "cargo install rag-rat --force");
-
-    let _ = std::fs::remove_dir_all(root);
 }
 
 #[test]
 fn mcp_tool_calls_preserve_compatibility_shapes() {
-    let (root, config) = mixed_config();
+    let (_root, config) = mixed_config();
     let db = IndexDatabase::rebuild(&config).unwrap();
     drop(db);
 
@@ -424,13 +419,11 @@ fn mcp_tool_calls_preserve_compatibility_shapes() {
 
     let llm = call_tool(&config.database, "llm_status", json!({})).unwrap();
     assert_eq!(llm["embedding"]["state"], "MissingModel");
-
-    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
 fn mcp_edge_tools_add_traverse_and_remove() {
-    let (root, config) = mixed_config();
+    let (_root, config) = mixed_config();
     IndexDatabase::rebuild(&config).unwrap();
 
     let create = |title: &str| -> String {
@@ -485,8 +478,6 @@ fn mcp_edge_tools_add_traverse_and_remove() {
         call_tool_for_config(&config, "memory_edge_remove", json!({"edge_key": key})).unwrap(),
         json!(true)
     );
-
-    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -498,7 +489,7 @@ fn mcp_memory_tools_create_surface_validate_and_obsolete_symbol_memory() {
         "#[cfg(unix)]\npub fn cfg_helper() {}\n#[cfg(windows)]\npub fn cfg_helper() {}\n",
     )
     .unwrap();
-    let config = rust_config(root.clone());
+    let config = rust_config(root.to_path_buf());
     let db = IndexDatabase::rebuild(&config).unwrap();
     drop(db);
 
@@ -579,8 +570,6 @@ fn mcp_memory_tools_create_surface_validate_and_obsolete_symbol_memory() {
         call_tool(&config.database, "memory_mark_obsolete", json!({"memory_id": memory_id}))
             .unwrap();
     assert_eq!(obsolete["status"], "obsolete");
-
-    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -593,7 +582,7 @@ fn mcp_dream_surfaces_a_finding_and_review_applies_a_verdict() {
     let root = unique_temp_root();
     fs::create_dir_all(root.join("src")).unwrap();
     fs::write(root.join("src/lib.rs"), "pub fn anchor() {}\n").unwrap();
-    let config = rust_config(root.clone());
+    let config = rust_config(root.to_path_buf());
     let db = IndexDatabase::rebuild(&config).unwrap();
     drop(db);
 
@@ -660,8 +649,6 @@ fn mcp_dream_surfaces_a_finding_and_review_applies_a_verdict() {
     )
     .unwrap();
     assert_eq!(reset["status"], "open");
-
-    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -672,7 +659,7 @@ fn mcp_dream_defaults_when_arguments_are_omitted() {
     let root = unique_temp_root();
     fs::create_dir_all(root.join("src")).unwrap();
     fs::write(root.join("src/lib.rs"), "pub fn anchor() {}\n").unwrap();
-    let config = rust_config(root.clone());
+    let config = rust_config(root.to_path_buf());
     let db = IndexDatabase::rebuild(&config).unwrap();
     drop(db);
 
@@ -681,8 +668,6 @@ fn mcp_dream_defaults_when_arguments_are_omitted() {
         report["findings"].is_array(),
         "a bare `dream` call (omitted arguments) returns a worklist: {report}"
     );
-
-    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -709,8 +694,6 @@ fn mcp_read_chunk_and_heal_index_do_not_return_stale_text() {
     assert!(stale.as_array().unwrap().is_empty());
     let fresh = call_tool_for_config(&config, "semantic_search", json!({"query": "beta"})).unwrap();
     assert_eq!(fresh.as_array().unwrap().len(), 1);
-
-    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -728,7 +711,7 @@ fn mcp_handle_selection_disambiguates_graph_tools() {
         "pub fn shared() {}\npub fn caller_two() {\n    shared();\n}\n",
     )
     .unwrap();
-    let config = rust_config(root.clone());
+    let config = rust_config(root.to_path_buf());
     let db = IndexDatabase::rebuild(&config).unwrap();
     drop(db);
 
@@ -880,8 +863,6 @@ fn mcp_handle_selection_disambiguates_graph_tools() {
     )
     .unwrap();
     assert!(papertrail["current_source"]["symbol"].as_str().unwrap().contains("shared"));
-
-    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -897,7 +878,7 @@ fn find_callers_zero_callers_is_not_low_completeness() {
         "pub fn orphan() {}\npub fn callee() {}\npub fn caller() {\n    callee();\n}\n",
     )
     .unwrap();
-    let config = rust_config(root.clone());
+    let config = rust_config(root.to_path_buf());
     IndexDatabase::rebuild(&config).unwrap();
 
     let orphan = call_tool(&config.database, "find_callers", json!({"symbol": "orphan"})).unwrap();
@@ -916,8 +897,6 @@ fn find_callers_zero_callers_is_not_low_completeness() {
     assert_eq!(callee["summary"]["returned_count"], 1);
     assert_eq!(callee["summary"]["completeness_risk"], "low");
     assert!(callee["summary"]["completeness_note"].is_null());
-
-    let _ = fs::remove_dir_all(root);
 }
 
 fn assert_schema_requires(tools: &[Value], name: &str, field: &str) {
@@ -1023,7 +1002,7 @@ fn mcp_rewrites_ranking_hint_when_auto_run_enabled() {
     // must say compiler ranking refreshes in the background — not tell the agent to run `oracle
     // run` by hand. The core query is config-unaware, so call_tool_for_config applies the
     // rewrite.
-    let (root, mut config) = mixed_config();
+    let (_root, mut config) = mixed_config();
     IndexDatabase::rebuild(&config).unwrap();
 
     config.oracle.auto_run = true;
@@ -1041,8 +1020,6 @@ fn mcp_rewrites_ranking_hint_when_auto_run_enabled() {
         manual["ranking_hint"].as_str(),
         Some(rag_rat_query::pagerank::RANKING_HINT_RUN_ORACLE),
     );
-
-    let _ = std::fs::remove_dir_all(root);
 }
 
 fn tool_schema<'a>(tools: &'a [Value], name: &str) -> &'a Value {
@@ -1053,19 +1030,19 @@ fn tool_schema<'a>(tools: &'a [Value], name: &str) -> &'a Value {
         .expect("tool schema")
 }
 
-fn mixed_config() -> (PathBuf, Config) {
+fn mixed_config() -> (rag_rat_base::test_scratch::ScratchDir, Config) {
     let root = unique_temp_root();
     fs::create_dir_all(root.join("docs")).unwrap();
     fs::create_dir_all(root.join("src")).unwrap();
     fs::write(root.join("docs/search.md"), "# Title\nalpha token\n").unwrap();
     fs::write(root.join("src/lib.rs"), "pub fn alpha_symbol() {}\n").unwrap();
-    (root.clone(), Config {
+    let config = Config {
         trackers: Vec::new(),
         papertrail: Default::default(),
         sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
-        root: root.clone(),
+        root: root.to_path_buf(),
         database: root.join(".rag-rat/index.sqlite"),
         targets: vec![
             ResolvedTarget {
@@ -1094,20 +1071,21 @@ fn mixed_config() -> (PathBuf, Config) {
         log: Default::default(),
         source_root_reanchored_from: None,
         allow_empty: false,
-    })
+    };
+    (root, config)
 }
 
-fn markdown_config(text: &str) -> (PathBuf, Config) {
+fn markdown_config(text: &str) -> (rag_rat_base::test_scratch::ScratchDir, Config) {
     let root = unique_temp_root();
     fs::create_dir_all(root.join("docs")).unwrap();
     fs::write(root.join("docs/search.md"), text).unwrap();
-    (root.clone(), Config {
+    let config = Config {
         trackers: Vec::new(),
         papertrail: Default::default(),
         sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
-        root: root.clone(),
+        root: root.to_path_buf(),
         database: root.join(".rag-rat/index.sqlite"),
         targets: vec![ResolvedTarget {
             name: "markdown".to_string(),
@@ -1126,7 +1104,8 @@ fn markdown_config(text: &str) -> (PathBuf, Config) {
         log: Default::default(),
         source_root_reanchored_from: None,
         allow_empty: false,
-    })
+    };
+    (root, config)
 }
 
 fn rust_config(root: PathBuf) -> Config {
@@ -1136,7 +1115,7 @@ fn rust_config(root: PathBuf) -> Config {
         sync: Default::default(),
         repo_id_override: None,
         database_key_pinned: true,
-        root: root.clone(),
+        root: root.to_path_buf(),
         database: root.join(".rag-rat/index.sqlite"),
         targets: vec![ResolvedTarget {
             name: "rust".to_string(),
@@ -1158,9 +1137,8 @@ fn rust_config(root: PathBuf) -> Config {
     }
 }
 
-fn unique_temp_root() -> PathBuf {
-    let id = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
-    std::env::temp_dir().join(format!("rag-rat-mcp-test-{}-{id}", std::process::id()))
+fn unique_temp_root() -> rag_rat_base::test_scratch::ScratchDir {
+    rag_rat_base::test_scratch::ScratchDir::new("mcp-test")
 }
 
 fn git(root: &Path, args: &[&str]) {
@@ -1198,7 +1176,6 @@ fn worktree_arg_prefers_request_then_falls_back_to_cwd() {
 #[test]
 fn worktree_param_routes_query_to_branch_overlay() {
     let root = unique_temp_root();
-    let _ = fs::remove_dir_all(&root);
     fs::create_dir_all(root.join("src")).unwrap();
     fs::write(root.join("src/a.rs"), "pub fn base_fn() {}\n").unwrap();
     git(&root, &["init", "-q", "-b", "main"]);
@@ -1206,11 +1183,10 @@ fn worktree_param_routes_query_to_branch_overlay() {
     git(&root, &["config", "user.name", "t"]);
     git(&root, &["add", "."]);
     git(&root, &["commit", "-q", "-m", "base"]);
-    let config = rust_config(root.clone());
+    let config = rust_config(root.to_path_buf());
     let mut db = IndexDatabase::rebuild(&config).unwrap();
 
     let linked = unique_temp_root();
-    let _ = fs::remove_dir_all(&linked);
     git(&root, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
     fs::write(linked.join("src/a.rs"), "pub fn linked_fn() {}\n").unwrap();
     git(&linked, &["add", "."]);
@@ -1245,9 +1221,6 @@ fn worktree_param_routes_query_to_branch_overlay() {
         0,
         "the overlay shadows the base symbol in the worktree scope"
     );
-
-    let _ = fs::remove_dir_all(&root);
-    let _ = fs::remove_dir_all(&linked);
 }
 
 #[test]
@@ -1257,7 +1230,6 @@ fn compare_graph_to_text_stays_base_scoped_under_a_worktree_param() {
     // overlay while its TEXT side stayed main — mismatched. It must stay BASE-scoped even with a
     // `worktree` arg, so a `worktree`-passed call matches the base call exactly.
     let root = unique_temp_root();
-    let _ = fs::remove_dir_all(&root);
     fs::create_dir_all(root.join("src")).unwrap();
     // Base: `caller` calls `target`.
     fs::write(root.join("src/a.rs"), "pub fn target() {}\npub fn caller() {\n    target();\n}\n")
@@ -1267,13 +1239,12 @@ fn compare_graph_to_text_stays_base_scoped_under_a_worktree_param() {
     git(&root, &["config", "user.name", "t"]);
     git(&root, &["add", "."]);
     git(&root, &["commit", "-q", "-m", "base"]);
-    let config = rust_config(root.clone());
+    let config = rust_config(root.to_path_buf());
     let mut db = IndexDatabase::rebuild(&config).unwrap();
 
     // Branch: `caller` no longer calls `target` (the callsite is gone on the branch). An
     // overlay-scoped compare would see 0 graph edges; the base sees 1.
     let linked = unique_temp_root();
-    let _ = fs::remove_dir_all(&linked);
     git(&root, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
     fs::write(linked.join("src/a.rs"), "pub fn target() {}\npub fn caller() {\n}\n").unwrap();
     git(&linked, &["add", "."]);
@@ -1310,9 +1281,6 @@ fn compare_graph_to_text_stays_base_scoped_under_a_worktree_param() {
         base["summary"]["graph_edges"].as_u64().unwrap() >= 1,
         "the base call sees the committed callsite edge: {base:?}",
     );
-
-    let _ = fs::remove_dir_all(&root);
-    let _ = fs::remove_dir_all(&linked);
 }
 
 #[test]
@@ -1324,7 +1292,6 @@ fn heal_index_from_a_linked_worktree_does_not_corrupt_the_overlay() {
     // makes the heal paths refuse to write under a linked overlay scope, so the overlay
     // survives a `heal_index` invoked from the worktree cwd.
     let root = unique_temp_root();
-    let _ = fs::remove_dir_all(&root);
     fs::create_dir_all(root.join("src")).unwrap();
     fs::write(root.join("src/a.rs"), "pub fn base_fn() {}\n").unwrap();
     git(&root, &["init", "-q", "-b", "main"]);
@@ -1332,11 +1299,10 @@ fn heal_index_from_a_linked_worktree_does_not_corrupt_the_overlay() {
     git(&root, &["config", "user.name", "t"]);
     git(&root, &["add", "."]);
     git(&root, &["commit", "-q", "-m", "base"]);
-    let config = rust_config(root.clone());
+    let config = rust_config(root.to_path_buf());
     let mut db = IndexDatabase::rebuild(&config).unwrap();
 
     let linked = unique_temp_root();
-    let _ = fs::remove_dir_all(&linked);
     git(&root, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
     // Branch modifies one file AND adds a branch-only file (the file absent from main is the strong
     // corruption vector: a worktree-scoped heal can't read it from `source_root`, so it
@@ -1376,9 +1342,6 @@ fn heal_index_from_a_linked_worktree_does_not_corrupt_the_overlay() {
         candidate_count(&only) > 0,
         "heal_index must NOT tombstone the branch-only overlay file",
     );
-
-    let _ = fs::remove_dir_all(&root);
-    let _ = fs::remove_dir_all(&linked);
 }
 
 #[test]
@@ -1406,8 +1369,6 @@ fn read_tool_lazy_write_retries_read_write_not_readonly_error() {
         !rag_rat_db::storage::is_readonly_violation(&err),
         "the lazy write must be retried read-write, never surfaced as SQLITE_READONLY: {err:?}"
     );
-
-    let _ = std::fs::remove_dir_all(root);
 }
 
 #[test]

--- a/crates/rag-rat-oracle/src/manifest.rs
+++ b/crates/rag-rat-oracle/src/manifest.rs
@@ -473,11 +473,9 @@ mod tests {
         // `--infer-tsconfig` writing one into the tree — the read-only-on-source contract.
         let manifest = ToolManifest::for_tool(OracleTool::ScipTypescript);
         assert!(manifest.prerequisite_blocked(Path::new("/no/such/repo/xyzzy")).is_some());
-        let dir = std::env::temp_dir().join("rag_rat_ts_prereq_test");
-        std::fs::create_dir_all(&dir).unwrap();
+        let dir = rag_rat_base::test_scratch::ScratchDir::new("ts-prereq");
         std::fs::write(dir.join("tsconfig.json"), "{}").unwrap();
         assert!(manifest.prerequisite_blocked(&dir).is_none());
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
@@ -504,9 +502,7 @@ mod tests {
         // `pom.xml` Kotlin project would fail rather than index (Codex on #193).
         let manifest = ToolManifest::for_tool(OracleTool::ScipJava);
         assert!(manifest.prerequisite_blocked(Path::new("/no/such/repo/xyzzy")).is_some());
-        let dir = std::env::temp_dir().join("rag_rat_java_prereq_test");
-        let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir_all(&dir).unwrap();
+        let dir = rag_rat_base::test_scratch::ScratchDir::new("java-prereq");
         assert!(manifest.prerequisite_blocked(&dir).is_some(), "empty dir has no build → Blocked");
         std::fs::write(dir.join("pom.xml"), "").unwrap();
         assert!(
@@ -526,6 +522,5 @@ mod tests {
             manifest.prerequisite_blocked(&dir).is_none(),
             "a gradlew wrapper is a scip-java Gradle sentinel → satisfied"
         );
-        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/crates/rag-rat-papertrail/src/trackers.rs
+++ b/crates/rag-rat-papertrail/src/trackers.rs
@@ -285,8 +285,6 @@ fn git_remote_url(root: &Path, remote: &str) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
-    use std::sync::atomic::{AtomicU64, Ordering};
 
     use super::*;
 
@@ -409,19 +407,13 @@ mod tests {
         assert_eq!(parse_git_remote_url("git@github.com:"), None);
     }
 
-    static REMOTE_TEMP: AtomicU64 = AtomicU64::new(0);
-
     fn git(dir: &Path, args: &[&str]) {
         let out = std::process::Command::new("git").arg("-C").arg(dir).args(args).output().unwrap();
         assert!(out.status.success(), "git {args:?}: {}", String::from_utf8_lossy(&out.stderr));
     }
 
-    fn temp_git_repo() -> PathBuf {
-        let id = REMOTE_TEMP.fetch_add(1, Ordering::Relaxed);
-        let root =
-            std::env::temp_dir().join(format!("ragrat-trackers-{}-{id}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&root);
-        std::fs::create_dir_all(&root).unwrap();
+    fn temp_git_repo() -> rag_rat_base::test_scratch::ScratchDir {
+        let root = rag_rat_base::test_scratch::ScratchDir::new("trackers");
         git(&root, &["init", "-q"]);
         root
     }
@@ -432,7 +424,6 @@ mod tests {
         git(&root, &["remote", "add", "origin", "git@github.com:owner/repo.git"]);
         let trackers = resolve_trackers(&[], &root);
         assert_eq!(trackers, vec![github("owner/repo").unwrap()]);
-        std::fs::remove_dir_all(&root).unwrap();
     }
 
     #[test]
@@ -441,7 +432,6 @@ mod tests {
         assert_eq!(resolve_trackers(&[], &root), Vec::new(), "no remote at all");
         git(&root, &["remote", "add", "origin", "git@codeberg.org:owner/repo.git"]);
         assert_eq!(resolve_trackers(&[], &root), Vec::new(), "unknown host");
-        std::fs::remove_dir_all(&root).unwrap();
     }
 
     #[test]
@@ -511,7 +501,6 @@ mod tests {
             (Tracker::Bitbucket, "PROJ/repo", Some("https://bitbucket.example.com"))
         );
         assert_eq!((trackers[2].provider, trackers[2].project.as_str()), (Tracker::Jira, "PROJ"));
-        std::fs::remove_dir_all(&root).unwrap();
     }
 
     fn tagged(tags: &[&str]) -> ResolvedTracker {


### PR DESCRIPTION
## Summary
- migrate the remaining ownerless temp fixtures across the satellite crates to `ScratchDir` guards: `rag-rat-db` storage read-only suites, `rag-rat-mcp` (`tools/tests`, `server/tests`, the hook `test_config`), `rag-rat-papertrail` tracker fixtures, `rag-rat-oracle` prereq manifests (fixed-name dirs that could collide across processes), `rag-rat-llm` cookbook pidfile fixtures, `rag-rat-clones` refine RO probe, `rag-rat-base` `single_flight` + `locks` tests
- the mcp `test_config` / `mixed_config` / `markdown_config` and `agent_hook` hook fixtures leaked on every run — they now return the guard first, so pattern drop order (right-to-left) closes handles before the directory is removed; the `locks` symlink-aliasing test keeps its symlink inside its own guard instead of the shared temp root
- benches: `bench_config` / `built_config` / `built_index` return the guard; `TempIndexDb` and `DbFiles` hand-rolled Drop impls are replaced by it, and the pid+counter stale-delete naming (with its ±25% query_warm collision hazard) is gone

## Verification
- `cargo check --workspace --tests --benches`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo +nightly fmt --all --check`
- `cargo nextest run -p rag-rat-base -p rag-rat-db -p rag-rat-mcp -p rag-rat-papertrail -p rag-rat-oracle -p rag-rat-llm -p rag-rat-clones` (1000 passed) under an isolated `TMPDIR`; the scratch namespace contained no fixture directories after the run
- `git diff --check`

Part of #586.