### PR TITLE
fix(eval): guard the replay scratch database against error paths

### DIFF
--- a/crates/rag-rat-core/src/eval.rs
+++ b/crates/rag-rat-core/src/eval.rs
@@ -428,8 +428,11 @@ fn score_case_at_parent(
         return Ok(None);
     }
     let mut case_config = Config::load(&manifest)?;
-    case_config.database = std::env::temp_dir().join(format!("rag-rat-replay-{short}.sqlite"));
-    let _ = std::fs::remove_file(&case_config.database);
+    // The replay DB lives in a guarded scratch dir, so an indexing/scoring error removes it (and
+    // its WAL/SHM sidecars) instead of stranding a per-case sqlite in the system temp (#586). The
+    // guard outlives every handle below: it is declared first and drops last.
+    let scratch = rag_rat_base::test_scratch::ScratchDir::new(&format!("replay-{short}"));
+    case_config.database = scratch.join("replay.sqlite");
     IndexDatabase::rebuild(&case_config)?;
     let report = {
         let case_db = IndexDatabase::open_config(&case_config)?;
@@ -452,7 +455,6 @@ fn score_case_at_parent(
         // default `TOP_K` candidate width (the candidate-ceiling dial is HEAD-scored).
         evaluate_query(&case_config, &case_db, &query, SearchMode::Active, false, TOP_K)?
     };
-    let _ = std::fs::remove_file(&case_config.database);
     Ok(Some(report))
 }
 

--- a/crates/rag-rat-core/src/eval.rs
+++ b/crates/rag-rat-core/src/eval.rs
@@ -428,7 +428,7 @@ fn score_case_at_parent(
         return Ok(None);
     }
     let mut case_config = Config::load(&manifest)?;
-    let scratch = ReplayDbDir::create(short);
+    let scratch = ReplayDbDir::create(short)?;
     case_config.database = scratch.path.join("replay.sqlite");
     IndexDatabase::rebuild(&case_config)?;
     let report = {
@@ -548,11 +548,13 @@ struct ReplayDbDir {
 }
 
 impl ReplayDbDir {
-    fn create(dir_key: &str) -> Self {
+    /// Errors (a full/read-only temp filesystem) propagate: the replay loop reports and skips the
+    /// case rather than aborting the whole run.
+    fn create(dir_key: &str) -> anyhow::Result<Self> {
         let path = std::env::temp_dir().join(format!("rag-rat-replay-db-{dir_key}"));
         let _ = std::fs::remove_dir_all(&path);
-        std::fs::create_dir_all(&path).expect("create replay scratch dir");
-        Self { path }
+        std::fs::create_dir_all(&path)?;
+        Ok(Self { path })
     }
 }
 

--- a/crates/rag-rat-core/src/eval.rs
+++ b/crates/rag-rat-core/src/eval.rs
@@ -428,11 +428,8 @@ fn score_case_at_parent(
         return Ok(None);
     }
     let mut case_config = Config::load(&manifest)?;
-    // The replay DB lives in a guarded scratch dir, so an indexing/scoring error removes it (and
-    // its WAL/SHM sidecars) instead of stranding a per-case sqlite in the system temp (#586). The
-    // guard outlives every handle below: it is declared first and drops last.
-    let scratch = rag_rat_base::test_scratch::ScratchDir::new(&format!("replay-{short}"));
-    case_config.database = scratch.join("replay.sqlite");
+    let scratch = ReplayDbDir::create(short);
+    case_config.database = scratch.path.join("replay.sqlite");
     IndexDatabase::rebuild(&case_config)?;
     let report = {
         let case_db = IndexDatabase::open_config(&case_config)?;
@@ -538,6 +535,30 @@ impl Drop for ParentWorktree {
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::null())
             .status();
+    }
+}
+
+/// RAII throwaway directory for one replay case's index database. Removed on drop, so an indexing
+/// or scoring error never strands the per-case sqlite (and its WAL/SHM sidecars) in the system
+/// temp; a stale dir from a crashed run is cleared on creation. Deliberately NOT the test-scratch
+/// namespace: replay indexing is a production workload with no bounded duration, and the test
+/// helper's two-hour stale sweep is only sound for short-lived test fixtures.
+struct ReplayDbDir {
+    path: PathBuf,
+}
+
+impl ReplayDbDir {
+    fn create(dir_key: &str) -> Self {
+        let path = std::env::temp_dir().join(format!("rag-rat-replay-db-{dir_key}"));
+        let _ = std::fs::remove_dir_all(&path);
+        std::fs::create_dir_all(&path).expect("create replay scratch dir");
+        Self { path }
+    }
+}
+
+impl Drop for ReplayDbDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
     }
 }
 


### PR DESCRIPTION
## Summary
- the parent-state replay's per-case database now lives in a `ScratchDir` guard instead of a bare `temp_dir().join(...).sqlite` path: any indexing or scoring error (the `?` paths in `score_case_at_parent`) removes the sqlite and its WAL/SHM sidecars instead of stranding them in the system temp, and the happy-path trailing `remove_file` goes away
- the throwaway `ParentWorktree` was already RAII with a stale-dir prune on create, so it is unchanged

## Verification
- `cargo check -p rag-rat-core --tests` (also with `--features eval`)
- `cargo clippy -p rag-rat-core --all-targets -- -D warnings`
- `cargo +nightly fmt --all --check`
- `cargo nextest run -p rag-rat-core -E 'test(eval)'` (5 passed) under an isolated `TMPDIR`; the scratch namespace contained no fixture directories after the run
- `git diff --check`

Closes the last ownerless temp path from #586.